### PR TITLE
Stops propagation of clicks when combined with data table header.

### DIFF
--- a/src/Dropdown/Dropdown.svelte
+++ b/src/Dropdown/Dropdown.svelte
@@ -155,7 +155,9 @@
       {inline && 'bx--dropdown--inline'}
       {disabled && 'bx--dropdown--disabled'}
       {light && 'bx--dropdown--light'}"
-    on:click="{({ target }) => {
+    on:click="{(e) => {
+      e.stopImmediatePropagation();
+      const { target } = e;
       open = ref.contains(target) ? !open : false;
     }}"
     disabled="{disabled}"


### PR DESCRIPTION
When clicking on the Dropdown target button of so, and sortable=true, it seems not possible to prevent the sort function from being triggered by other means.

```
<span slot="cell-header" let:header>
  <Dropdown />
</span>
```
