### PR TITLE
Set cols for StructuredListSkeleton

### DIFF
--- a/src/StructuredList/StructuredListSkeleton.svelte
+++ b/src/StructuredList/StructuredListSkeleton.svelte
@@ -2,6 +2,9 @@
   /** Specify the number of rows */
   export let rows = 5;
 
+  /** Specify the number of cols */
+  export let cols = 3;
+
   /** Set to `true` to use the bordered variant */
   export let border = false;
 </script>
@@ -21,17 +24,17 @@
       class:bx--structured-list-row="{true}"
       class:bx--structured-list-row--header-row="{true}"
     >
-      <div class:bx--structured-list-th="{true}"><span></span></div>
-      <div class:bx--structured-list-th="{true}"><span></span></div>
-      <div class:bx--structured-list-th="{true}"><span></span></div>
+      {#each Array.from({ length: cols }, (_, i) => i) as row, i (row)}
+        <div class:bx--structured-list-th="{true}"><span></span></div>
+      {/each}
     </div>
   </div>
   <div class:bx--structured-list-tbody="{true}">
     {#each Array.from({ length: rows }, (_, i) => i) as row, i (row)}
       <div class:bx--structured-list-row="{true}">
-        <div class:bx--structured-list-td="{true}"></div>
-        <div class:bx--structured-list-td="{true}"></div>
-        <div class:bx--structured-list-td="{true}"></div>
+        {#each Array.from({ length: cols }, (_, i) => i) as row, i (row)}
+          <div class:bx--structured-list-td="{true}"></div>
+        {/each}
       </div>
     {/each}
   </div>


### PR DESCRIPTION
Currently you can not set the number of columns in the Skeleton of a StructuredList, it is fixed to 3 columns. This creates a mismatch if you use a different amount of columns.