### PR TITLE
Fixes

### DIFF
--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -4532,9 +4532,10 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props | Fallback |
-| :-------- | :------ | :---- | :------- |
-| --        | Yes     | --    | --       |
+| Slot name | Default | Props | Fallback            |
+| :-------- | :------ | :---- | :------------------ |
+| --        | Yes     | --    | --                  |
+| cancel    | No      | --    | <code>Cancel</code> |
 
 ### Events
 

--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -12541,7 +12541,15 @@
           "reactive": false
         }
       ],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        { "name": "__default__", "default": true, "slot_props": "{}" },
+        {
+          "name": "cancel",
+          "default": false,
+          "fallback": "Cancel",
+          "slot_props": "{}"
+        }
+      ],
       "events": [],
       "typedefs": [],
       "rest_props": { "type": "Element", "name": "div" }

--- a/src/ComboBox/ComboBox.svelte
+++ b/src/ComboBox/ComboBox.svelte
@@ -309,6 +309,7 @@
       {/if}
       <ListBoxMenuIcon
         on:click="{(e) => {
+          if (disabled) return;
           e.stopPropagation();
           open = !open;
         }}"

--- a/src/DataTable/ToolbarBatchActions.svelte
+++ b/src/DataTable/ToolbarBatchActions.svelte
@@ -51,7 +51,7 @@
         tabindex="{showActions ? '0' : '-1'}"
         on:click="{ctx.resetSelectedRowIds}"
       >
-        Cancel
+        <slot name="cancel">Cancel</slot>
       </Button>
     </div>
   </div>

--- a/types/DataTable/ToolbarBatchActions.d.ts
+++ b/types/DataTable/ToolbarBatchActions.d.ts
@@ -13,5 +13,5 @@ export interface ToolbarBatchActionsProps
 export default class ToolbarBatchActions extends SvelteComponentTyped<
   ToolbarBatchActionsProps,
   {},
-  { default: {} }
+  { default: {}; cancel: {} }
 > {}


### PR DESCRIPTION
**Fixes**

- if `ComboBox` is disabled, clicking the chevron icon should not toggle the dropdown #776 
- `ToolbarBatchActions` cancel button text should be slottable #782 