### PR TITLE
fix(combo-box): remove redundant clear events #817

### DIFF
--- a/src/ComboBox/ComboBox.svelte
+++ b/src/ComboBox/ComboBox.svelte
@@ -152,9 +152,6 @@
   $: if (selectedIndex > -1) {
     selectedId = items[selectedIndex].id;
     dispatch("select", { selectedId, selectedIndex, selectedItem });
-  } else {
-    clear();
-    dispatch("clear");
   }
   $: ariaLabel = $$props["aria-label"] || "Choose an item";
   $: menuId = `menu-${id}`;


### PR DESCRIPTION
Fixes #817

- prevent redundant `clear` events in `ComboBox`