### PR TITLE
bump svite version to resolve esbuild not working on M1

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -26,7 +26,7 @@
     "svelte": "3.29.0",
     "svelte-hmr": "0.11.1",
     "svelte-preprocess": "^4.3.2",
-    "svite": "0.7.2"
+    "svite": "0.8.1"
   },
   "routify": {
     "routifyDir": ".routify",


### PR DESCRIPTION
Fixes this error thrown during `yarn install` in the `docs` directory:
```
error /Users/pm/Code/carbon-components-svelte/docs/node_modules/esbuild: Command failed.
Exit code: 1
Command: node install.js
Arguments:
Directory: /Users/pm/Code/carbon-components-svelte/docs/node_modules/esbuild
Output:
Unsupported platform: darwin arm64 LE
```