### PR TITLE
fix(clickable-tile): explicitly type restProps

### DIFF
--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -932,7 +932,7 @@
         { "type": "forwarded", "name": "mouseleave", "element": "Link" }
       ],
       "typedefs": [],
-      "rest_props": { "type": "InlineComponent", "name": "Link" }
+      "rest_props": { "type": "Element", "name": "a | p" }
     },
     {
       "moduleName": "CodeSnippet",

--- a/src/Tile/ClickableTile.svelte
+++ b/src/Tile/ClickableTile.svelte
@@ -1,4 +1,6 @@
 <script>
+  /** @restProps {a | p} */
+
   /** Set to `true` to click the tile */
   export let clicked = false;
 

--- a/tests/ClickableTile.test.svelte
+++ b/tests/ClickableTile.test.svelte
@@ -6,6 +6,11 @@
   Carbon Design System
 </ClickableTile>
 
-<ClickableTile light href="https://www.carbondesignsystem.com/">
+<ClickableTile
+  light
+  href="https://www.carbondesignsystem.com/"
+  title=""
+  target="_blank"
+>
   Carbon Design System
 </ClickableTile>

--- a/types/Tile/ClickableTile.d.ts
+++ b/types/Tile/ClickableTile.d.ts
@@ -1,7 +1,9 @@
 /// <reference types="svelte" />
 import { SvelteComponentTyped } from "svelte";
 
-export interface ClickableTileProps {
+export interface ClickableTileProps
+  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]>,
+    svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["p"]> {
   /**
    * Set to `true` to click the tile
    * @default false


### PR DESCRIPTION
**Fixes**

- `ClickableTile` TypeScript definition restProps should extend attributes of either `a` or `p` tags