### PR TITLE
fix: menuOptionsClass in OverflowMenu

### DIFF
--- a/src/OverflowMenu/OverflowMenu.svelte
+++ b/src/OverflowMenu/OverflowMenu.svelte
@@ -238,7 +238,7 @@
       class:bx--overflow-menu-options--sm="{size === 'sm'}"
       class:bx--overflow-menu-options--xl="{size === 'xl'}"
       class:bx--breadcrumb-menu-options="{!!ctxBreadcrumbItem}"
-      class:menuOptionsClass
+      class="{menuOptionsClass}"
     >
       <slot />
     </ul>


### PR DESCRIPTION
Thanks.
I think that the `menuOptionsClass` prop (in OverflowMenu component) is not work correctly.

```svelte
<OverflowMenu menuOptionsClass="foo-class" open>
  <OverflowMenuItem text="foo" />
  <OverflowMenuItem text="bar" />
</OverflowMenu>
```

## before
![image](https://user-images.githubusercontent.com/40315079/135856658-e3430209-bcf9-41dd-a4c4-70534013115b.png)

## after(this PR)
![image](https://user-images.githubusercontent.com/40315079/135856566-b4447f07-50d1-418c-b0cb-dba3982e527a.png)
