### PR TITLE
fix: add a value prop to Checkbox

### DIFF
--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -463,6 +463,7 @@ None.
 | :------------ | :--------------- | :------- | :---------------------------------------- | ------------------------------------------------ | ------------------------------------------------- |
 | ref           | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code> | <code>null</code>                                | Obtain a reference to the input HTML element      |
 | checked       | <code>let</code> | Yes      | <code>boolean</code>                      | <code>false</code>                               | Specify whether the checkbox is checked           |
+| value         | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Specify the value of the checkbox                 |
 | indeterminate | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Specify whether the checkbox is indeterminate     |
 | skeleton      | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to display the skeleton state       |
 | readonly      | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` for the checkbox to be read-only    |

--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -709,6 +709,17 @@
       "filePath": "src/Checkbox/Checkbox.svelte",
       "props": [
         {
+          "name": "value",
+          "kind": "let",
+          "description": "Specify the value of the checkbox",
+          "type": "string",
+          "value": "\"\"",
+          "isFunction": false,
+          "isFunctionDeclaration": false,
+          "constant": false,
+          "reactive": false
+        },
+        {
           "name": "checked",
           "kind": "let",
           "description": "Specify whether the checkbox is checked",

--- a/src/Checkbox/Checkbox.svelte
+++ b/src/Checkbox/Checkbox.svelte
@@ -3,6 +3,9 @@
    * @event {boolean} check
    */
 
+  /** Specify the value of the checkbox */
+  export let value = "";
+
   /** Specify whether the checkbox is checked */
   export let checked = false;
 
@@ -69,6 +72,7 @@
     <input
       bind:this="{ref}"
       type="checkbox"
+      value="{value}"
       checked="{checked}"
       disabled="{disabled}"
       id="{id}"

--- a/types/Checkbox/Checkbox.d.ts
+++ b/types/Checkbox/Checkbox.d.ts
@@ -3,6 +3,12 @@ import { SvelteComponentTyped } from "svelte";
 
 export interface CheckboxProps {
   /**
+   * Specify the value of the checkbox
+   * @default ""
+   */
+  value?: string;
+
+  /**
    * Specify whether the checkbox is checked
    * @default false
    */


### PR DESCRIPTION
Thanks 🎉 
I think a `value` prop is missing in Checkbox component.
cf) https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox#attr-value

