### PR TITLE
fix(progress-indicator): prevent keyboard navigation for incomplete steps

### DIFF
--- a/src/ProgressIndicator/ProgressStep.svelte
+++ b/src/ProgressIndicator/ProgressStep.svelte
@@ -75,6 +75,7 @@
     on:mouseleave
     on:keydown
     on:keydown="{(e) => {
+      if (!step.complete) return;
       if (e.key === ' ' || e.key === 'Enter') {
         change(step.index);
       }


### PR DESCRIPTION
Fixes #851

**Fixes**

- Prevent space/enter keys from selecting incomplete `ProgressIndicator` steps