### PR TITLE
fix(date-picker-input): avoid opening calendar if input is descendant of a disabled fieldset

### DIFF
--- a/src/DatePicker/DatePickerInput.svelte
+++ b/src/DatePicker/DatePickerInput.svelte
@@ -154,7 +154,10 @@
         class="bx--date-picker__icon"
         aria-label="{iconDescription}"
         title="{iconDescription}"
-        on:click="{openCalendar}"
+        on:click="{() => {
+          if (disabled || ref.matches(':disabled')) return;
+          openCalendar();
+        }}"
       />
     {/if}
   </div>


### PR DESCRIPTION
Fixes #857

This PR implements a fix suggested by @brunnerh.

**Fixes**

- Avoid opening calendar if `DatePickerInput` is descendant of a disabled fieldset