### PR TITLE
fix(data-table): expand batch expansion chevron if all rows are expanded

### DIFF
--- a/src/DataTable/DataTable.svelte
+++ b/src/DataTable/DataTable.svelte
@@ -172,10 +172,7 @@
     selectedRowIds.length > 0 && selectedRowIds.length < rows.length;
   $: if (batchExpansion) {
     expandable = true;
-
-    if (expandedRowIds.length < expandableRowIds.length) {
-      expanded = false;
-    }
+    expanded = expandedRowIds.length === expandableRowIds.length;
   }
   $: if (radio || batchSelection) selectable = true;
   $: tableSortable.set(sortable);


### PR DESCRIPTION
Fixes #867

The batch expansion chevron should be toggled if all expandable rows and expanded.