### PR TITLE
fix(data-table): avoid triggering click:row when clicking expandable row chevron

### DIFF
--- a/src/DataTable/DataTable.svelte
+++ b/src/DataTable/DataTable.svelte
@@ -363,7 +363,7 @@
                   aria-label="{expandedRows[row.id]
                     ? 'Collapse current row'
                     : 'Expand current row'}"
-                  on:click="{() => {
+                  on:click|stopPropagation="{() => {
                     const rowExpanded = !!expandedRows[row.id];
 
                     expandedRowIds = rowExpanded


### PR DESCRIPTION
Fixes #889

Currently, the `click:row--expand` event will be dispatched along with `click:row` when clicking the chevron button in an expandable row. The solution is to stop the event from propagating from the cell to the parent row.

In the example below, both "click:row". and "click:row--expand" can be triggered together. The expected behavior is that only "click:row--expand" should fire when toggling the chevron.

```svelte
<DataTable
  on:click:row={() => {
    console.log("click:row");
  }}
  on:click:row--expand={() => {
    console.log("click:row--expand");
  }}
/>
```