### PR TITLE
fix(text-input): coerce TextInput value to number if type is numerical

### DIFF
--- a/src/TextInput/TextInput.svelte
+++ b/src/TextInput/TextInput.svelte
@@ -175,7 +175,7 @@
         on:change
         on:input
         on:input="{({ target }) => {
-          value = target.value;
+          value = type === 'number' ? Number(target.value) : target.value;
         }}"
         on:keydown
         on:keyup


### PR DESCRIPTION
Fixes #898

Even though there is a dedicated `NumberInput` component, the `TextInput` should have a numerical value if `type` is explicitly set to `"number"`.

```svelte
<script>
  import { TextInput } from "carbon-components-svelte";

  let value;

  $: console.log(value, typeof value);
</script>

<TextInput type="number" bind:value />

```