### PR TITLE
hotfix: fix remaining imports from carbon-icons-svelte

### DIFF
--- a/src/ComboBox/ComboBox.svelte
+++ b/src/ComboBox/ComboBox.svelte
@@ -95,8 +95,8 @@
   export let listRef = null;
 
   import { createEventDispatcher, afterUpdate, tick } from "svelte";
-  import Checkmark16 from "carbon-icons-svelte/lib/Checkmark16/Checkmark16.svelte";
-  import WarningFilled16 from "carbon-icons-svelte/lib/WarningFilled16/WarningFilled16.svelte";
+  import Checkmark16 from "../icons/Checkmark16.svelte";
+  import WarningFilled16 from "../icons/WarningFilled16.svelte";
   import WarningAltFilled16 from "../icons/WarningAltFilled16.svelte";
   import ListBox from "../ListBox/ListBox.svelte";
   import ListBoxField from "../ListBox/ListBoxField.svelte";

--- a/src/ContextMenu/ContextMenuOption.svelte
+++ b/src/ContextMenu/ContextMenuOption.svelte
@@ -50,7 +50,7 @@
 
   import { onMount, getContext, createEventDispatcher, tick } from "svelte";
   import ContextMenu from "./ContextMenu.svelte";
-  import Checkmark16 from "carbon-icons-svelte/lib/Checkmark16/Checkmark16.svelte";
+  import Checkmark16 from "../icons/Checkmark16.svelte";
   import CaretRight16 from "../icons/CaretRight16.svelte";
 
   const dispatch = createEventDispatcher();

--- a/src/DataTable/TableHeader.svelte
+++ b/src/DataTable/TableHeader.svelte
@@ -15,7 +15,7 @@
   export let id = "ccs-" + Math.random().toString(36);
 
   import { getContext } from "svelte";
-  import ArrowUp20 from "carbon-icons-svelte/lib/ArrowUp20/ArrowUp20.svelte";
+  import ArrowUp20 from "../icons/ArrowUp20.svelte";
   import ArrowsVertical20 from "../icons/ArrowsVertical20.svelte";
 
   const { sortHeader, tableSortable, add } = getContext("DataTable");

--- a/src/DatePicker/DatePickerInput.svelte
+++ b/src/DatePicker/DatePickerInput.svelte
@@ -54,8 +54,8 @@
   export let ref = null;
 
   import { getContext } from "svelte";
-  import Calendar16 from "carbon-icons-svelte/lib/Calendar16/Calendar16.svelte";
-  import WarningFilled16 from "carbon-icons-svelte/lib/WarningFilled16/WarningFilled16.svelte";
+  import Calendar16 from "../icons/Calendar16.svelte";
+  import WarningFilled16 from "../icons/WarningFilled16.svelte";
   import WarningAltFilled16 from "../icons/WarningAltFilled16.svelte";
 
   const {

--- a/src/Dropdown/Dropdown.svelte
+++ b/src/Dropdown/Dropdown.svelte
@@ -97,7 +97,7 @@
   export let ref = null;
 
   import { createEventDispatcher } from "svelte";
-  import WarningFilled16 from "carbon-icons-svelte/lib/WarningFilled16/WarningFilled16.svelte";
+  import WarningFilled16 from "../icons/WarningFilled16.svelte";
   import WarningAltFilled16 from "../icons/WarningAltFilled16.svelte";
   import {
     ListBox,

--- a/src/FileUploader/Filename.svelte
+++ b/src/FileUploader/Filename.svelte
@@ -11,8 +11,8 @@
   /** Set to `true` to indicate an invalid state */
   export let invalid = false;
 
-  import Close16 from "carbon-icons-svelte/lib/Close16";
-  import CheckmarkFilled16 from "carbon-icons-svelte/lib/CheckmarkFilled16";
+  import Close16 from "../icons/Close16.svelte";
+  import CheckmarkFilled16 from "../icons/CheckmarkFilled16.svelte";
   import WarningFilled16 from "../icons/WarningFilled16.svelte";
   import { Loading } from "../Loading";
 </script>

--- a/src/InlineLoading/InlineLoading.svelte
+++ b/src/InlineLoading/InlineLoading.svelte
@@ -21,7 +21,7 @@
   export let successDelay = 1500;
 
   import { createEventDispatcher, afterUpdate, onMount } from "svelte";
-  import CheckmarkFilled16 from "carbon-icons-svelte/lib/CheckmarkFilled16/CheckmarkFilled16.svelte";
+  import CheckmarkFilled16 from "../icons/CheckmarkFilled16.svelte";
   import ErrorFilled16 from "../icons/ErrorFilled16.svelte";
   import Loading from "../Loading/Loading.svelte";
 

--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -147,7 +147,7 @@
   export let selectionRef = null;
 
   import { afterUpdate, createEventDispatcher, setContext } from "svelte";
-  import WarningFilled16 from "carbon-icons-svelte/lib/WarningFilled16/WarningFilled16.svelte";
+  import WarningFilled16 from "../icons/WarningFilled16.svelte";
   import WarningAltFilled16 from "../icons/WarningAltFilled16.svelte";
   import Checkbox from "../Checkbox/Checkbox.svelte";
   import {

--- a/src/Notification/NotificationIcon.svelte
+++ b/src/Notification/NotificationIcon.svelte
@@ -14,11 +14,11 @@
   /** Specify the ARIA label for the icon */
   export let iconDescription = "Closes notification";
 
-  import CheckmarkFilled20 from "carbon-icons-svelte/lib/CheckmarkFilled20/CheckmarkFilled20.svelte";
-  import ErrorFilled20 from "carbon-icons-svelte/lib/ErrorFilled20/ErrorFilled20.svelte";
-  import InformationFilled20 from "carbon-icons-svelte/lib/InformationFilled20/InformationFilled20.svelte";
-  import InformationSquareFilled20 from "carbon-icons-svelte/lib/InformationSquareFilled20/InformationSquareFilled20.svelte";
-  import WarningFilled20 from "carbon-icons-svelte/lib/WarningFilled20/WarningFilled20.svelte";
+  import CheckmarkFilled20 from "../icons/CheckmarkFilled20.svelte";
+  import ErrorFilled20 from "../icons/ErrorFilled20.svelte";
+  import InformationFilled20 from "../icons/InformationFilled20.svelte";
+  import InformationSquareFilled20 from "../icons/InformationSquareFilled20.svelte";
+  import WarningFilled20 from "../icons/WarningFilled20.svelte";
   import WarningAltFilled20 from "../icons/WarningAltFilled20.svelte";
 
   const icons = {

--- a/src/NumberInput/NumberInput.svelte
+++ b/src/NumberInput/NumberInput.svelte
@@ -104,10 +104,10 @@
   export let ref = null;
 
   import { createEventDispatcher } from "svelte";
-  import Add16 from "carbon-icons-svelte/lib/Add16/Add16.svelte";
-  import Subtract16 from "carbon-icons-svelte/lib/Subtract16/Subtract16.svelte";
-  import WarningFilled16 from "carbon-icons-svelte/lib/WarningFilled16/WarningFilled16.svelte";
-  import WarningAltFilled16 from "carbon-icons-svelte/lib/WarningAltFilled16/WarningAltFilled16.svelte";
+  import Add16 from "../icons/Add16.svelte";
+  import Subtract16 from "../icons/Subtract16.svelte";
+  import WarningFilled16 from "../icons/WarningFilled16.svelte";
+  import WarningAltFilled16 from "../icons/WarningAltFilled16.svelte";
   import EditOff16 from "../icons/EditOff16.svelte";
 
   const defaultTranslations = {

--- a/src/OverflowMenu/OverflowMenu.svelte
+++ b/src/OverflowMenu/OverflowMenu.svelte
@@ -61,7 +61,7 @@
     afterUpdate,
   } from "svelte";
   import { writable } from "svelte/store";
-  import OverflowMenuVertical16 from "carbon-icons-svelte/lib/OverflowMenuVertical16/OverflowMenuVertical16.svelte";
+  import OverflowMenuVertical16 from "../icons/OverflowMenuVertical16.svelte";
   import OverflowMenuHorizontal16 from "../icons/OverflowMenuHorizontal16.svelte";
 
   const ctxBreadcrumbItem = getContext("BreadcrumbItem");

--- a/src/Pagination/Pagination.svelte
+++ b/src/Pagination/Pagination.svelte
@@ -71,7 +71,7 @@
   export let id = "ccs-" + Math.random().toString(36);
 
   import { createEventDispatcher } from "svelte";
-  import CaretLeft16 from "carbon-icons-svelte/lib/CaretLeft16/CaretLeft16.svelte";
+  import CaretLeft16 from "../icons/CaretLeft16.svelte";
   import CaretRight16 from "../icons/CaretRight16.svelte";
   import Button from "../Button/Button.svelte";
   import Select from "../Select/Select.svelte";

--- a/src/PaginationNav/PaginationNav.svelte
+++ b/src/PaginationNav/PaginationNav.svelte
@@ -24,7 +24,7 @@
   export let backwardText = "Previous page";
 
   import { afterUpdate, createEventDispatcher } from "svelte";
-  import CaretLeft16 from "carbon-icons-svelte/lib/CaretLeft16/CaretLeft16.svelte";
+  import CaretLeft16 from "../icons/CaretLeft16.svelte";
   import CaretRight16 from "../icons/CaretRight16.svelte";
   import PaginationItem from "./PaginationItem.svelte";
   import PaginationOverflow from "./PaginationOverflow.svelte";

--- a/src/ProgressIndicator/ProgressStep.svelte
+++ b/src/ProgressIndicator/ProgressStep.svelte
@@ -24,7 +24,7 @@
   export let id = "ccs-" + Math.random().toString(36);
 
   import { onMount, getContext } from "svelte";
-  import CheckmarkOutline16 from "carbon-icons-svelte/lib/CheckmarkOutline16/CheckmarkOutline16.svelte";
+  import CheckmarkOutline16 from "../icons/CheckmarkOutline16.svelte";
   import Warning16 from "../icons/Warning16.svelte";
 
   let step = {};

--- a/src/Search/Search.svelte
+++ b/src/Search/Search.svelte
@@ -71,8 +71,8 @@
   export let ref = null;
 
   import { createEventDispatcher } from "svelte";
-  import Close16 from "carbon-icons-svelte/lib/Close16/Close16.svelte";
-  import Close20 from "carbon-icons-svelte/lib/Close20/Close20.svelte";
+  import Close16 from "../icons/Close16.svelte";
+  import Close20 from "../icons/Close20.svelte";
   import Search16 from "../icons/Search16.svelte";
   import SearchSkeleton from "./SearchSkeleton.svelte";
 

--- a/src/Select/Select.svelte
+++ b/src/Select/Select.svelte
@@ -62,8 +62,8 @@
 
   import { createEventDispatcher, setContext, afterUpdate } from "svelte";
   import { writable } from "svelte/store";
-  import ChevronDown16 from "carbon-icons-svelte/lib/ChevronDown16/ChevronDown16.svelte";
-  import WarningFilled16 from "carbon-icons-svelte/lib/WarningFilled16/WarningFilled16.svelte";
+  import ChevronDown16 from "../icons/ChevronDown16.svelte";
+  import WarningFilled16 from "../icons/WarningFilled16.svelte";
   import WarningAltFilled16 from "../icons/WarningAltFilled16.svelte";
 
   const dispatch = createEventDispatcher();

--- a/src/TextInput/PasswordInput.svelte
+++ b/src/TextInput/PasswordInput.svelte
@@ -81,9 +81,9 @@
   export let ref = null;
 
   import { getContext } from "svelte";
-  import WarningFilled16 from "carbon-icons-svelte/lib/WarningFilled16/WarningFilled16.svelte";
-  import WarningAltFilled16 from "carbon-icons-svelte/lib/WarningAltFilled16/WarningAltFilled16.svelte";
-  import View16 from "carbon-icons-svelte/lib/View16/View16.svelte";
+  import WarningFilled16 from "../icons/WarningFilled16.svelte";
+  import WarningAltFilled16 from "../icons/WarningAltFilled16.svelte";
+  import View16 from "../icons/View16.svelte";
   import ViewOff16 from "../icons/ViewOff16.svelte";
 
   const ctx = getContext("Form");

--- a/src/TextInput/TextInput.svelte
+++ b/src/TextInput/TextInput.svelte
@@ -66,8 +66,8 @@
   export let readonly = false;
 
   import { getContext } from "svelte";
-  import WarningFilled16 from "carbon-icons-svelte/lib/WarningFilled16/WarningFilled16.svelte";
-  import WarningAltFilled16 from "carbon-icons-svelte/lib/WarningAltFilled16/WarningAltFilled16.svelte";
+  import WarningFilled16 from "../icons/WarningFilled16.svelte";
+  import WarningAltFilled16 from "../icons/WarningAltFilled16.svelte";
   import EditOff16 from "../icons/EditOff16.svelte";
 
   const ctx = getContext("Form");

--- a/src/UIShell/GlobalHeader/Header.svelte
+++ b/src/UIShell/GlobalHeader/Header.svelte
@@ -60,7 +60,7 @@
    */
   export let iconClose = Close20;
 
-  import Close20 from "carbon-icons-svelte/lib/Close20/Close20.svelte";
+  import Close20 from "../../icons/Close20.svelte";
   import Menu20 from "../../icons/Menu20.svelte";
   import { shouldRenderHamburgerMenu } from "../navStore";
   import HamburgerMenu from "../SideNav/HamburgerMenu.svelte";

--- a/src/UIShell/GlobalHeader/HeaderAction.svelte
+++ b/src/UIShell/GlobalHeader/HeaderAction.svelte
@@ -37,7 +37,7 @@
 
   import { createEventDispatcher } from "svelte";
   import { slide } from "svelte/transition";
-  import Close20 from "carbon-icons-svelte/lib/Close20/Close20.svelte";
+  import Close20 from "../../icons/Close20.svelte";
   import AppSwitcher20 from "../../icons/AppSwitcher20.svelte";
   import Icon from "../../Icon/Icon.svelte";
 

--- a/src/UIShell/GlobalHeader/HeaderActionSearch.svelte
+++ b/src/UIShell/GlobalHeader/HeaderActionSearch.svelte
@@ -13,7 +13,7 @@
   export let searchIsActive = false;
 
   import { createEventDispatcher } from "svelte";
-  import Close20 from "carbon-icons-svelte/lib/Close20";
+  import Close20 from "../../icons/Close20.svelte";
   import Search20 from "../../icons/Search20.svelte";
   import searchStore from "../searchStore";
 

--- a/src/UIShell/HeaderSearch.svelte
+++ b/src/UIShell/HeaderSearch.svelte
@@ -27,7 +27,7 @@
   export let selectedResultIndex = 0;
 
   import { createEventDispatcher, tick } from "svelte";
-  import Close20 from "carbon-icons-svelte/lib/Close20/Close20.svelte";
+  import Close20 from "../icons/Close20.svelte";
   import Search20 from "../icons/Search20.svelte";
 
   const dispatch = createEventDispatcher();

--- a/src/UIShell/SideNav/HamburgerMenu.svelte
+++ b/src/UIShell/SideNav/HamburgerMenu.svelte
@@ -25,7 +25,7 @@
   /** Obtain a reference to the HTML button element */
   export let ref = null;
 
-  import Close20 from "carbon-icons-svelte/lib/Close20/Close20.svelte";
+  import Close20 from "../../icons/Close20.svelte";
   import Menu20 from "../../icons/Menu20.svelte";
 </script>
 


### PR DESCRIPTION
#904 inlined icons from `carbon-icons-svelte`. Unfortunately, many references were missed in the script.

This didn't throw errors when building the library because `carbon-icons-svelte` is installed as a devDependency.