### PR TITLE
hotfix(popover): include missing Popover styles from carbon-components version 10.47

### DIFF
--- a/css/all.scss
+++ b/css/all.scss
@@ -22,6 +22,7 @@ $css--plex: true;
 @import "carbon-components/src/components/tag/tag";
 @import "carbon-components/src/components/notification/inline-notification";
 @import "carbon-components/src/components/notification/toast-notification";
+@import "carbon-components-10.47/src/components/popover/popover";
 
 // The default theme is "white" (White)
 :root {

--- a/css/g10.scss
+++ b/css/g10.scss
@@ -17,6 +17,7 @@ $css--plex: true;
 @import "carbon-components/src/components/tag/tag";
 @import "carbon-components/src/components/notification/inline-notification";
 @import "carbon-components/src/components/notification/toast-notification";
+@import "carbon-components-10.47/src/components/popover/popover";
 
 $carbon--theme: $carbon--theme--g10;
 @include carbon--theme();

--- a/css/g100.scss
+++ b/css/g100.scss
@@ -17,6 +17,7 @@ $css--plex: true;
 @import "carbon-components/src/components/tag/tag";
 @import "carbon-components/src/components/notification/inline-notification";
 @import "carbon-components/src/components/notification/toast-notification";
+@import "carbon-components-10.47/src/components/popover/popover";
 
 $carbon--theme: $carbon--theme--g100;
 @include carbon--theme();

--- a/css/g80.scss
+++ b/css/g80.scss
@@ -17,6 +17,7 @@ $css--plex: true;
 @import "carbon-components/src/components/tag/tag";
 @import "carbon-components/src/components/notification/inline-notification";
 @import "carbon-components/src/components/notification/toast-notification";
+@import "carbon-components-10.47/src/components/popover/popover";
 
 $carbon--theme: $carbon--theme--g80;
 @include carbon--theme();

--- a/css/g90.scss
+++ b/css/g90.scss
@@ -17,6 +17,7 @@ $css--plex: true;
 @import "carbon-components/src/components/tag/tag";
 @import "carbon-components/src/components/notification/inline-notification";
 @import "carbon-components/src/components/notification/toast-notification";
+@import "carbon-components-10.47/src/components/popover/popover";
 
 $carbon--theme: $carbon--theme--g90;
 @include carbon--theme();

--- a/css/white.scss
+++ b/css/white.scss
@@ -17,6 +17,7 @@ $css--plex: true;
 @import "carbon-components/src/components/tag/tag";
 @import "carbon-components/src/components/notification/inline-notification";
 @import "carbon-components/src/components/notification/toast-notification";
+@import "carbon-components-10.47/src/components/popover/popover";
 
 $carbon--theme: $carbon--theme--white;
 @include carbon--theme();

--- a/docs/package.json
+++ b/docs/package.json
@@ -12,6 +12,7 @@
     "@sveltech/routify": "^1.9.9",
     "autoprefixer": "^10.2.3",
     "carbon-components": "10.48.0",
+    "carbon-components-10.47": "npm:carbon-components@10.47",
     "carbon-components-svelte": "../",
     "carbon-icons-svelte": "^10.38.0",
     "clipboard-copy": "^4.0.1",

--- a/docs/src/App.svelte
+++ b/docs/src/App.svelte
@@ -30,6 +30,7 @@
   @import "carbon-components/src/components/tag/tag";
   @import "carbon-components/src/components/notification/inline-notification";
   @import "carbon-components/src/components/notification/toast-notification";
+  @import "carbon-components-10.47/src/components/popover/popover";
 
   // The default theme is "white" (White)
   :root {

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -844,8 +844,18 @@ caniuse-lite@^1.0.30001173, caniuse-lite@^1.0.30001178:
   resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001180.tgz#67abcd6d1edf48fa5e7d1e84091d1d65ab76e33b"
   integrity sha512-n8JVqXuZMVSPKiPiypjFtDTXc4jWIdjxull0f92WLo7e1MSi3uJ3NvveakSh/aCl1QKFAvIz3vIj0v+0K+FrXw==
 
+"carbon-components-10.47@npm:carbon-components@10.47":
+  version "10.47.1"
+  resolved "https://registry.yarnpkg.com/carbon-components/-/carbon-components-10.47.1.tgz#9a6c5b54d9d7dc4e75aa9ba0e8d6c60ef27ab5ff"
+  integrity sha512-1/DajErW6vUWhCSZuiqFdo7kXx3WkGOkOSCW8xcWmQ4BQyGC70fcsselQoAXPwLvUtM4fCGJuGAG/TWwliUpwQ==
+  dependencies:
+    "@carbon/telemetry" "0.0.0-alpha.6"
+    flatpickr "4.6.1"
+    lodash.debounce "^4.0.8"
+    warning "^3.0.0"
+
 carbon-components-svelte@../:
-  version "0.48.1"
+  version "0.49.0"
   dependencies:
     flatpickr "4.6.9"
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@tsconfig/svelte": "^1.0.10",
     "autoprefixer": "^10.2.4",
     "carbon-components": "10.48.0",
+    "carbon-components-10.47": "npm:carbon-components@10.47",
     "carbon-icons-svelte": "^10.38.0",
     "husky": "^4.3.8",
     "lint-staged": "^10.5.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -447,6 +447,16 @@ caniuse-lite@^1.0.30001181:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001183.tgz#7a57ba9d6584119bb5f2bc76d3cc47ba9356b3e2"
   integrity sha512-7JkwTEE1hlRKETbCFd8HDZeLiQIUcl8rC6JgNjvHCNaxOeNmQ9V4LvQXRUsKIV2CC73qKxljwVhToaA3kLRqTw==
 
+"carbon-components-10.47@npm:carbon-components@10.47":
+  version "10.47.1"
+  resolved "https://registry.yarnpkg.com/carbon-components/-/carbon-components-10.47.1.tgz#9a6c5b54d9d7dc4e75aa9ba0e8d6c60ef27ab5ff"
+  integrity sha512-1/DajErW6vUWhCSZuiqFdo7kXx3WkGOkOSCW8xcWmQ4BQyGC70fcsselQoAXPwLvUtM4fCGJuGAG/TWwliUpwQ==
+  dependencies:
+    "@carbon/telemetry" "0.0.0-alpha.6"
+    flatpickr "4.6.1"
+    lodash.debounce "^4.0.8"
+    warning "^3.0.0"
+
 carbon-components@10.48.0:
   version "10.48.0"
   resolved "https://registry.yarnpkg.com/carbon-components/-/carbon-components-10.48.0.tgz#e1c31b7b5d27cf12299fd86f6c9b8f0546bb6b43"


### PR DESCRIPTION
Fixes #912 
Related #910 

Popover styles were removed completely from `carbon-components@10.48`. This PR adds `carbon-components@10.47` as a development dependency and manually imports the popover styles in the SCSS files for generating.