### PR TITLE
Refactor `onDestroy` to use `onMount` return function

### DIFF
--- a/src/ComposedModal/ComposedModal.svelte
+++ b/src/ComposedModal/ComposedModal.svelte
@@ -36,7 +36,6 @@
     setContext,
     onMount,
     afterUpdate,
-    onDestroy,
   } from "svelte";
   import { writable } from "svelte/store";
 
@@ -73,13 +72,14 @@
   let opened = false;
   $: didOpen = open;
 
-  onMount(async () => {
-    await tick();
-    focus();
-  });
+  onMount(() => {
+    tick().then(() => {
+      focus();
+    });
 
-  onDestroy(() => {
-    document.body.classList.remove("bx--body--with-modal-open");
+    return () => {
+      document.body.classList.remove("bx--body--with-modal-open");
+    };
   });
 
   afterUpdate(() => {

--- a/src/ContentSwitcher/Switch.svelte
+++ b/src/ContentSwitcher/Switch.svelte
@@ -17,7 +17,7 @@
   /** Obtain a reference to the button HTML element */
   export let ref = null;
 
-  import { afterUpdate, getContext, onDestroy } from "svelte";
+  import { afterUpdate, getContext, onMount } from "svelte";
 
   const ctx = getContext("ContentSwitcher");
 
@@ -33,8 +33,8 @@
     }
   });
 
-  onDestroy(() => {
-    unsubscribe();
+  onMount(() => {
+    return () => unsubscribe();
   });
 </script>
 

--- a/src/DatePicker/DatePicker.svelte
+++ b/src/DatePicker/DatePicker.svelte
@@ -70,7 +70,7 @@
     createEventDispatcher,
     setContext,
     afterUpdate,
-    onDestroy,
+    onMount,
   } from "svelte";
   import { writable, derived } from "svelte/store";
   import { createCalendar } from "./createCalendar";
@@ -175,6 +175,15 @@
     });
   }
 
+  onMount(() => {
+    return () => {
+      if (calendar) {
+        calendar.destroy();
+        calendar = null;
+      }
+    };
+  });
+
   afterUpdate(() => {
     if (calendar) {
       if ($range) {
@@ -185,13 +194,6 @@
       } else {
         calendar.setDate($inputValue);
       }
-    }
-  });
-
-  onDestroy(() => {
-    if (calendar) {
-      calendar.destroy();
-      calendar = null;
     }
   });
 

--- a/src/Select/SelectItem.svelte
+++ b/src/Select/SelectItem.svelte
@@ -11,7 +11,7 @@
   /** Set to `true` to disable the option */
   export let disabled = false;
 
-  import { getContext, onDestroy } from "svelte";
+  import { getContext, onMount } from "svelte";
 
   const ctx = getContext("Select") || getContext("TimePickerSelect");
 
@@ -21,8 +21,8 @@
     selected = currentValue === value;
   });
 
-  onDestroy(() => {
-    unsubscribe();
+  onMount(() => {
+    return () => unsubscribe();
   });
 </script>
 


### PR DESCRIPTION
Avoid running code server-side by using `onMount` instead of `onDestroy`.