### PR TITLE
hotfix(popover): manually apply relative style if `relative` is true

### DIFF
--- a/src/Popover/Popover.svelte
+++ b/src/Popover/Popover.svelte
@@ -61,6 +61,7 @@
   class:bx--popover--open="{open}"
   class:bx--popover--relative="{relative}"
   {...$$restProps}
+  style="{$$restProps.style}; {relative && 'position: relative'}"
 >
   <div class:bx--popover-contents="{true}">
     <slot />


### PR DESCRIPTION
Support for the `relative` prop in Popover was dropped upstream as early as version 10.36.

This PR manually applies a relative style if `relative` is true.