### PR TITLE
Do not dispatch "click", "click:row" events in `DataTable` if target is an `OverflowMenu`

### DIFF
--- a/src/DataTable/DataTable.svelte
+++ b/src/DataTable/DataTable.svelte
@@ -336,7 +336,15 @@
             : ''} {expandable && parentRowId === row.id
             ? 'bx--expandable-row--hover'
             : ''}"
-          on:click="{() => {
+          on:click="{({ target }) => {
+            // forgo "click", "click:row" events if target resembles an overflow menu
+            if (
+              [...target.classList].some((name) =>
+                /^bx--overflow-menu/.test(name)
+              )
+            ) {
+              return;
+            }
             dispatch('click', { row });
             dispatch('click:row', row);
           }}"


### PR DESCRIPTION
Fixes #917

```svelte
<script>
  import {
    DataTable,
    OverflowMenu,
    OverflowMenuItem,
  } from "carbon-components-svelte";

  const headers = [
    { key: "name", value: "Name" },
    { key: "port", value: "Port" },
    { key: "rule", value: "Rule" },
    { key: "overflow", empty: true },
  ];

  const rows = [
    { id: "a", name: "Load Balancer 3", port: 3000, rule: "Round robin" },
    { id: "b", name: "Load Balancer 1", port: 443, rule: "Round robin" },
    { id: "c", name: "Load Balancer 2", port: 80, rule: "DNS delegation" },
    { id: "d", name: "Load Balancer 6", port: 3000, rule: "Round robin" },
    { id: "e", name: "Load Balancer 4", port: 443, rule: "Round robin" },
    { id: "f", name: "Load Balancer 5", port: 80, rule: "DNS delegation" },
  ];
</script>

<DataTable
  {headers}
  {rows}
  on:click:row={(e) => {
    // should not trigger when opening/closing the overflow menu
    console.log("click:row", e.detail);
  }}
>
  <span slot="cell" let:cell>
    {#if cell.key === "overflow"}
      <OverflowMenu flipped>
        <OverflowMenuItem text="Restart" />
        <OverflowMenuItem
          href="https://cloud.ibm.com/docs/loadbalancer-service"
          text="API documentation"
        />
        <OverflowMenuItem danger text="Stop" />
      </OverflowMenu>
    {:else}{cell.value}{/if}
  </span>
</DataTable>

```