### PR TITLE
Fix filterable multiselect keyboard selection behavior

### DIFF
--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -329,9 +329,10 @@
           change(-1);
         } else if (key === 'Enter') {
           if (highlightedIndex > -1) {
-            sortedItems[highlightedIndex].checked = !sortedItems[
-              highlightedIndex
-            ].checked;
+            sortedItems = sortedItems.map((item, i) => {
+              if (i !== highlightedIndex) return item;
+              return { ...item, checked: !item.checked };
+            });
           }
         }
       }}"
@@ -403,9 +404,10 @@
                     return { ...item, checked: !item.checked };
                   });
                 } else {
-                  sortedItems[highlightedIndex].checked = !sortedItems[
-                    highlightedIndex
-                  ].checked;
+                  sortedItems = sortedItems.map((item, i) => {
+                    if (i !== highlightedIndex) return item;
+                    return { ...item, checked: !item.checked };
+                  });
                 }
               }
             } else if (key === 'Tab') {

--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -392,9 +392,21 @@
           on:keydown|stopPropagation="{({ key }) => {
             if (key === 'Enter') {
               if (highlightedIndex > -1) {
-                sortedItems[highlightedIndex].checked = !sortedItems[
-                  highlightedIndex
-                ].checked;
+                if (filterable) {
+                  const filteredItemId = filteredItems[highlightedIndex].id;
+                  const filteredItemIndex = sortedItems
+                    .map((item) => item.id)
+                    .indexOf(filteredItemId);
+
+                  sortedItems = sortedItems.map((item, i) => {
+                    if (i !== filteredItemIndex) return item;
+                    return { ...item, checked: !item.checked };
+                  });
+                } else {
+                  sortedItems[highlightedIndex].checked = !sortedItems[
+                    highlightedIndex
+                  ].checked;
+                }
               }
             } else if (key === 'Tab') {
               open = false;


### PR DESCRIPTION
**Fixes**

- select correct item in filterable `MultiSelect` using keyboard navigation
- do not mutate `sortedItems` in `MultiSelect`