### PR TITLE
Modify tab click events to prevent navigation.

### DIFF
--- a/src/Tabs/Tabs.svelte
+++ b/src/Tabs/Tabs.svelte
@@ -130,8 +130,8 @@
       tabindex="-1"
       class:bx--tabs-trigger-text="{true}"
       href="{triggerHref}"
-      on:click
-      on:click="{() => {
+      on:click|preventDefault
+      on:click|preventDefault|stopPropagation="{() => {
         dropdownHidden = !dropdownHidden;
       }}"
     >


### PR DESCRIPTION
Without `preventDefault` the link will navigate the page instead of opening the dropdown when the tabs are in the compact mode.
Because the parent element also toggles on click, there is an additional `stopPropagation` to not toggle twice which would be a no-op.

Fixes #626.