### PR TITLE
fix(label-text): correctly render "labelText" slots

### DIFF
--- a/src/DatePicker/DatePickerInput.svelte
+++ b/src/DatePicker/DatePickerInput.svelte
@@ -82,7 +82,7 @@
   class:bx--date-picker-container="{true}"
   class:bx--date-picker--nolabel="{!labelText}"
 >
-  {#if labelText}
+  {#if labelText || $$slots.labelText}
     <label
       for="{id}"
       class:bx--label="{true}"

--- a/src/TextArea/TextArea.svelte
+++ b/src/TextArea/TextArea.svelte
@@ -57,7 +57,7 @@
   on:mouseleave
   class:bx--form-item="{true}"
 >
-  {#if labelText && !hideLabel}
+  {#if (labelText || $$slots.labelText) && !hideLabel}
     <label
       for="{id}"
       class:bx--label="{true}"

--- a/src/TimePicker/TimePicker.svelte
+++ b/src/TimePicker/TimePicker.svelte
@@ -74,7 +74,7 @@
     class:bx--select--light="{light}"
   >
     <div class:bx--time-picker__input="{true}">
-      {#if labelText}
+      {#if labelText || $$slots.labelText}
         <label
           for="{id}"
           class:bx--label="{true}"

--- a/src/TimePicker/TimePickerSelect.svelte
+++ b/src/TimePicker/TimePickerSelect.svelte
@@ -54,7 +54,7 @@
   on:mouseenter
   on:mouseleave
 >
-  {#if labelText}
+  {#if labelText || $$slots.labelText}
     <label
       for="{id}"
       class:bx--label="{true}"

--- a/src/Toggle/ToggleSkeleton.svelte
+++ b/src/Toggle/ToggleSkeleton.svelte
@@ -36,7 +36,7 @@
     class:bx--toggle__label="{true}"
     class:bx--skeleton="{true}"
   >
-    {#if labelText}
+    {#if labelText || $$slots.labelText}
       <span class:bx--toggle__label-text="{true}">
         <slot name="labelText">
           {labelText}


### PR DESCRIPTION
Fixes #944

The `{#if labelText}` conditional that guards a named slot should also check that `$$slots.labelText` is truthy.