### PR TITLE
hotfix(multi-select): prevent double trigger in a filterable multiselect

### DIFF
--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -454,6 +454,7 @@
           />
         {/if}
         <ListBoxMenuIcon
+          style="pointer-events: {open ? 'auto' : 'none'}"
           on:click="{(e) => {
             e.stopPropagation();
             open = !open;


### PR DESCRIPTION
Fixes #940

Manually set `pointer-events` to "none" when a filterable multiselect menu is not open to prevent a double trigger.