### PR TITLE
fix(date-picker): stop "Escape" from closing modal

### DIFF
--- a/src/DatePicker/DatePicker.svelte
+++ b/src/DatePicker/DatePicker.svelte
@@ -234,6 +234,12 @@
       {datePickerType === 'range' &&
       $labelTextEmpty &&
       'bx--date-picker--nolabel'}"
+    on:keydown="{(e) => {
+      if (calendar?.isOpen && e.key === 'Escape') {
+        e.stopPropagation();
+        calendar.close();
+      }
+    }}"
   >
     <slot />
   </div>


### PR DESCRIPTION
Fixes #952

This PR programmatically closes the calendar when pressing "Escape" and stops the event from propagating; this addresses the use case of a date picker within a modal.