### PR TITLE
Fix filterable MultiSelect keydown behavior

### DIFF
--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -64,7 +64,7 @@
    * @type {(item: MultiSelectItem, value: string) => string}
    */
   export let filterItem = (item, value) =>
-    item.text.toLowerCase().includes(value.toLowerCase());
+    item.text.toLowerCase().includes(value.trim().toLowerCase());
 
   /** Set to `true` to open the dropdown */
   export let open = false;
@@ -419,6 +419,8 @@
               change(-1);
             } else if (key === 'Escape') {
               open = false;
+            } else if (key === ' ') {
+              if (!open) open = true;
             }
           }}"
           on:keyup

--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -417,6 +417,8 @@
               change(1);
             } else if (key === 'ArrowUp') {
               change(-1);
+            } else if (key === 'Escape') {
+              open = false;
             }
           }}"
           on:keyup

--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -412,6 +412,7 @@
               }
             } else if (key === 'Tab') {
               open = false;
+              inputRef.blur();
             } else if (key === 'ArrowDown') {
               change(1);
             } else if (key === 'ArrowUp') {


### PR DESCRIPTION
**Fixes**

- blur filterable `MultiSelect` input when pressing "Tab" (fixes #938)
- close filterable menu when pressing "Escape"
- open filterable menu when pressing [Space]