### PR TITLE
fix(css): set global theme variable first

### DIFF
--- a/css/g10.scss
+++ b/css/g10.scss
@@ -1,3 +1,9 @@
+// Use the "g10" (Gray 10) Carbon theme
+@import "carbon-components/scss/globals/scss/vendor/@carbon/themes/scss";
+
+$carbon--theme: $carbon--theme--g10;
+@include carbon--theme();
+
 $feature-flags: (
   ui-shell: true,
   grid-columns-16: true
@@ -11,16 +17,11 @@ $css--reset: true;
 $css--default-type: true;
 $css--plex: true;
 
-// Use the "g10" (Gray 10) Carbon theme
-@import "carbon-components/scss/globals/scss/vendor/@carbon/themes/scss";
 @import "carbon-components/scss/globals/scss/component-tokens";
 @import "carbon-components/src/components/tag/tag";
 @import "carbon-components/src/components/notification/inline-notification";
 @import "carbon-components/src/components/notification/toast-notification";
 @import "carbon-components-10.47/src/components/popover/popover";
-
-$carbon--theme: $carbon--theme--g10;
-@include carbon--theme();
 
 @import "carbon-components/scss/globals/scss/_css--reset";
 @import "carbon-components/scss/globals/scss/_css--font-face";

--- a/css/g100.scss
+++ b/css/g100.scss
@@ -1,3 +1,9 @@
+// Use the "g100" (Gray 100) Carbon theme
+@import "carbon-components/scss/globals/scss/vendor/@carbon/themes/scss";
+
+$carbon--theme: $carbon--theme--g100;
+@include carbon--theme();
+
 $feature-flags: (
   ui-shell: true,
   grid-columns-16: true
@@ -11,16 +17,11 @@ $css--reset: true;
 $css--default-type: true;
 $css--plex: true;
 
-// Use the "g100" (Gray 100) Carbon theme
-@import "carbon-components/scss/globals/scss/vendor/@carbon/themes/scss";
 @import "carbon-components/scss/globals/scss/component-tokens";
 @import "carbon-components/src/components/tag/tag";
 @import "carbon-components/src/components/notification/inline-notification";
 @import "carbon-components/src/components/notification/toast-notification";
 @import "carbon-components-10.47/src/components/popover/popover";
-
-$carbon--theme: $carbon--theme--g100;
-@include carbon--theme();
 
 @import "carbon-components/scss/globals/scss/_css--reset";
 @import "carbon-components/scss/globals/scss/_css--font-face";

--- a/css/g80.scss
+++ b/css/g80.scss
@@ -1,3 +1,9 @@
+// Use the "g80" (Gray 80) Carbon theme
+@import "carbon-components/scss/globals/scss/vendor/@carbon/themes/scss";
+
+$carbon--theme: $carbon--theme--g80;
+@include carbon--theme();
+
 $feature-flags: (
   ui-shell: true,
   grid-columns-16: true
@@ -11,16 +17,11 @@ $css--reset: true;
 $css--default-type: true;
 $css--plex: true;
 
-// Use the "g80" (Gray 80) Carbon theme
-@import "carbon-components/scss/globals/scss/vendor/@carbon/themes/scss";
 @import "carbon-components/scss/globals/scss/component-tokens";
 @import "carbon-components/src/components/tag/tag";
 @import "carbon-components/src/components/notification/inline-notification";
 @import "carbon-components/src/components/notification/toast-notification";
 @import "carbon-components-10.47/src/components/popover/popover";
-
-$carbon--theme: $carbon--theme--g80;
-@include carbon--theme();
 
 @import "carbon-components/scss/globals/scss/_css--reset";
 @import "carbon-components/scss/globals/scss/_css--font-face";

--- a/css/g90.scss
+++ b/css/g90.scss
@@ -1,3 +1,9 @@
+// Use the "g90" (Gray 90) Carbon theme
+@import "carbon-components/scss/globals/scss/vendor/@carbon/themes/scss";
+
+$carbon--theme: $carbon--theme--g90;
+@include carbon--theme();
+
 $feature-flags: (
   ui-shell: true,
   grid-columns-16: true
@@ -11,16 +17,11 @@ $css--reset: true;
 $css--default-type: true;
 $css--plex: true;
 
-// Use the "g90" (Gray 90) Carbon theme
-@import "carbon-components/scss/globals/scss/vendor/@carbon/themes/scss";
 @import "carbon-components/scss/globals/scss/component-tokens";
 @import "carbon-components/src/components/tag/tag";
 @import "carbon-components/src/components/notification/inline-notification";
 @import "carbon-components/src/components/notification/toast-notification";
 @import "carbon-components-10.47/src/components/popover/popover";
-
-$carbon--theme: $carbon--theme--g90;
-@include carbon--theme();
 
 @import "carbon-components/scss/globals/scss/_css--reset";
 @import "carbon-components/scss/globals/scss/_css--font-face";

--- a/css/white.scss
+++ b/css/white.scss
@@ -1,3 +1,9 @@
+// Use the "white" (White) Carbon theme
+@import "carbon-components/scss/globals/scss/vendor/@carbon/themes/scss";
+
+$carbon--theme: $carbon--theme--white;
+@include carbon--theme();
+
 $feature-flags: (
   ui-shell: true,
   grid-columns-16: true
@@ -11,16 +17,11 @@ $css--reset: true;
 $css--default-type: true;
 $css--plex: true;
 
-// Use the "white" (White) Carbon theme
-@import "carbon-components/scss/globals/scss/vendor/@carbon/themes/scss";
 @import "carbon-components/scss/globals/scss/component-tokens";
 @import "carbon-components/src/components/tag/tag";
 @import "carbon-components/src/components/notification/inline-notification";
 @import "carbon-components/src/components/notification/toast-notification";
 @import "carbon-components-10.47/src/components/popover/popover";
-
-$carbon--theme: $carbon--theme--white;
-@include carbon--theme();
 
 @import "carbon-components/scss/globals/scss/_css--reset";
 @import "carbon-components/scss/globals/scss/_css--font-face";


### PR DESCRIPTION
Fixes #966

In the theme SCSS files, the global theme variable should be set before any other imports.