### PR TITLE
Update TileGroup on programmatic selection change.

### DIFF
--- a/src/Tile/TileGroup.svelte
+++ b/src/Tile/TileGroup.svelte
@@ -26,11 +26,12 @@
     },
     update: (value) => {
       selectedValue.set(value);
+      dispatch("select", value);
     },
   });
 
   $: selected = $selectedValue;
-  $: dispatch("select", $selectedValue);
+  $: selectedValue.set(selected);
 </script>
 
 <fieldset disabled="{disabled}" class:bx--tile-group="{true}" {...$$restProps}>


### PR DESCRIPTION
Also only fire `select` event for user interaction (from RadioTile).

Uses `set` function instead of `$` to prevent cyclic dependency error.

Fixes #859.