### PR TITLE
Fix a11y warnings emitted by Svelte v3.45

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "rollup-plugin-terser": "^7.0.2",
     "sass": "^1.42.1",
     "sveld": "^0.11.1",
-    "svelte": "^3.44.3",
+    "svelte": "^3.45.0",
     "svelte-check": "^1.1.32",
     "typescript": "^4.1.3"
   },

--- a/src/Dropdown/Dropdown.svelte
+++ b/src/Dropdown/Dropdown.svelte
@@ -198,7 +198,6 @@
       bind:this="{ref}"
       class:bx--list-box__field="{true}"
       tabindex="0"
-      role="button"
       aria-expanded="{open}"
       on:keydown="{(e) => {
         const { key } = e;

--- a/src/UIShell/GlobalHeader/Header.svelte
+++ b/src/UIShell/GlobalHeader/Header.svelte
@@ -78,7 +78,7 @@
 
 <svelte:window bind:innerWidth="{winWidth}" />
 
-<header role="banner" aria-label="{ariaLabel}" class:bx--header="{true}">
+<header aria-label="{ariaLabel}" class:bx--header="{true}">
   <slot name="skip-to-content" />
   {#if ($shouldRenderHamburgerMenu && winWidth < expansionBreakpoint) || persistentHamburgerMenu}
     <HamburgerMenu

--- a/yarn.lock
+++ b/yarn.lock
@@ -2350,10 +2350,10 @@ svelte@^3.42.4:
   resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.43.2.tgz#217fc6059f52afa281f39200b6253ac1b83812b4"
   integrity sha512-Lj+TJfSeod8UGnoG2opysdlCy4MCck/hHQsZwtNPXdYTwLTz+WC37QwewPhZtd+h3dpfps4h9QzFxWGVI4tzQw==
 
-svelte@^3.44.3:
-  version "3.44.3"
-  resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.44.3.tgz#795b1ced6ed3da44969099e5061b850c93c95e9a"
-  integrity sha512-aGgrNCip5PQFNfq9e9tmm7EYxWLVHoFsEsmKrtOeRD8dmoGDdyTQ+21xd7qgFd8MNdKGSYvg7F9dr+Tc0yDymg==
+svelte@^3.45.0:
+  version "3.45.0"
+  resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.45.0.tgz#bcb90a72e984f809c419529f8cf9100ad9937a4b"
+  integrity sha512-6AWftH2eqqKLYH1HvKpuUWe8OfjflarhegN57P/Cqwc2Rb2F5oIdDtANU/jMscyZMzG0v6nTQox0siZR9cmRVQ==
 
 terser@^5.0.0:
   version "5.3.0"


### PR DESCRIPTION
Fixes #988 

- Upgrade svelte to version 3.45.0
- Remove redundant "button" role in `Dropdown` to fix a11y warning
- Remove redundant "banner" role in `Header` to fix a11y warning