### PR TITLE
Update docs

### DIFF
--- a/docs/src/pages/components/Search.svx
+++ b/docs/src/pages/components/Search.svx
@@ -20,7 +20,7 @@ The `Search` component size is extra-large by default. There are [large](#large-
 
 ### on:clear
 
-The "clear" event is dispatched when clicking the "X" button in the search input element.
+The "clear" event is dispatched when clicking the "X" button or when pressing the "Escape" key.
 
 <Search value="Cloud functions" on:clear={() => console.log('clear')}/>
 

--- a/docs/src/pages/components/Search.svx
+++ b/docs/src/pages/components/Search.svx
@@ -26,7 +26,9 @@ The "clear" event is dispatched when clicking the "X" button or when pressing th
 
 ### Expandable variant
 
-<Search expandable on:expand on:collapse />
+Set `expandable` to `true` to use the expandable variant.
+
+<FileSource src="/framed/Search/SearchExpandableReactive" />
 
 ### Light variant
 

--- a/docs/src/pages/components/TreeView.svx
+++ b/docs/src/pages/components/TreeView.svx
@@ -49,7 +49,7 @@ Initial multiple selected nodes can be set using `selectedIds`.
 
 ### Expand all nodes
 
-To programmatically expand all nodes, access the component instance using the [bind:this](https://svelte.dev/docs#bind_element) directive and invoke the `TreeView.expandAll()` method to expand all nodes.
+To programmatically expand all nodes, access the component instance using the [bind:this](https://svelte.dev/docs#bind_element) directive and invoke the `TreeView.expandAll()` accessor.
 
 <FileSource src="/framed/TreeView/TreeViewExpandAll" />
 

--- a/docs/src/pages/framed/Search/SearchExpandableReactive.svelte
+++ b/docs/src/pages/framed/Search/SearchExpandableReactive.svelte
@@ -1,0 +1,12 @@
+<script>
+  import { Search } from "carbon-components-svelte";
+
+  let expanded = false;
+</script>
+
+<Search expandable bind:expanded on:expand on:collapse />
+
+<br />
+
+<strong>Expanded:</strong>
+{expanded}


### PR DESCRIPTION
**Documentation**

- avoid redundant copy in `TreeView`"Expand all nodes" example
- document that `Search` also dispatches a "clear" event when pressing "Escape"
- refactor expandable `Search` to demonstrate reactivity