### PR TITLE
fix(combo-box): name should be passed to input

### DIFF
--- a/src/ComboBox/ComboBox.svelte
+++ b/src/ComboBox/ComboBox.svelte
@@ -230,7 +230,6 @@
         ref.focus();
       }}"
       id="{id}"
-      name="{name}"
       disabled="{disabled}"
       translateWithId="{translateWithId}"
     >
@@ -249,6 +248,7 @@
         placeholder="{placeholder}"
         id="{id}"
         value="{inputValue}"
+        name="{name}"
         {...$$restProps}
         class:bx--text-input="{true}"
         class:bx--text-input--light="{light}"


### PR DESCRIPTION
Fixes #797

The "name" prop was mistakenly passed to the `ListBoxField` element when it should be set on the `input` element.