### PR TITLE
fix(tooltip): pressing "Escape" should break out of trap focus

### DIFF
--- a/src/Tooltip/Tooltip.svelte
+++ b/src/Tooltip/Tooltip.svelte
@@ -75,6 +75,7 @@
   function onKeydown(e) {
     if (e.key === "Escape" || e.key === "Tab") {
       e.stopPropagation();
+      if (e.key === "Escape") refIcon?.focus();
       open = false;
     } else if (e.key === " " || e.key === "Enter") {
       e.stopPropagation();


### PR DESCRIPTION
Fixes #924

When shift + tabbing, pressing "Escape" should close the tooltip and re-focus the icon, allowing the user to exit the trap focus.