### PR TITLE
docs: add breaking change notice to `ComboBox`, `Dropdown` docs

### DIFF
--- a/docs/src/pages/components/ComboBox.svx
+++ b/docs/src/pages/components/ComboBox.svx
@@ -1,7 +1,13 @@
 <script>
-  import { ComboBox } from "carbon-components-svelte";
+  import { ComboBox, InlineNotification } from "carbon-components-svelte";
   import Preview from "../../components/Preview.svelte";
 </script>
+
+<InlineNotification svx-ignore title="Note:" kind="info" hideCloseButton>
+  <div class="body-short-01">
+    Since version 0.53, <strong>selectedIndex</strong> has been replaced with <strong>selectedId</strong>.
+  </div>
+</InlineNotification>
 
 ### Default
 

--- a/docs/src/pages/components/Dropdown.svx
+++ b/docs/src/pages/components/Dropdown.svx
@@ -3,9 +3,15 @@ components: ["Dropdown", "DropdownSkeleton"]
 ---
 
 <script>
-  import { Dropdown, DropdownSkeleton } from "carbon-components-svelte";
+  import { Dropdown, DropdownSkeleton, InlineNotification } from "carbon-components-svelte";
   import Preview from "../../components/Preview.svelte";
 </script>
+
+<InlineNotification svx-ignore title="Note:" kind="info" hideCloseButton>
+  <div class="body-short-01">
+    Since version 0.53, <strong>selectedIndex</strong> has been replaced with <strong>selectedId</strong>.
+  </div>
+</InlineNotification>
 
 ### Default
 


### PR DESCRIPTION
This PR adds a breaking change notice to the `ComboBox`, `Dropdown` pages following #1004, #1016

<img width="783" alt="Screen Shot 2022-01-18 at 7 29 25 PM" src="https://user-images.githubusercontent.com/10718366/150058740-c1a88458-6f2f-4d6a-8ad2-b71922005670.png">
