### PR TITLE
fix(number-input): do not coerce empty input to 0

### DIFF
--- a/src/NumberInput/NumberInput.svelte
+++ b/src/NumberInput/NumberInput.svelte
@@ -131,10 +131,15 @@
 
   let inputValue = value;
 
+  const normalizeValue = (_value) => {
+    if (_value === undefined || _value === "") return _value;
+    return Number(_value);
+  };
+
   $: dispatch("change", value);
   $: incrementLabel = translateWithId("increment");
   $: decrementLabel = translateWithId("decrement");
-  $: value = Number(inputValue);
+  $: value = normalizeValue(inputValue);
   $: error =
     invalid || (!allowEmpty && value === "") || value > max || value < min;
   $: errorId = `error-${id}`;


### PR DESCRIPTION
Fixes #1031

If `allowEmpty` is enabled on a `NumberInput`, an empty value (`""`) should not be coerced to 0.

The bug stems from this line: `$: value = Number(inputValue)`.

`Number("")` will return `0`.

---

**Expected result**

In the example below, the input should not display a validate error when provided an empty input.

The initial value will be `"" string` for both `bind:value` and `on:change`.

Typing in a number should emit `[x] number` for both.

Clearing the input manually should print "" string` again.

```svelte
<script>
  import { NumberInput } from "carbon-components-svelte";

  let value = "";

  $: console.log("bind:value", value, typeof value);
</script>

<NumberInput
  allowEmpty
  bind:value
  on:change={(e) => console.log("on:change", e.detail, typeof e.detail)}
/>

```