### PR TITLE
Fix checkbox two-way reactivity

### DIFF
--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -462,7 +462,7 @@ None.
 | Prop name     | Kind             | Reactive | Type                                      | Default value                                    | Description                                       |
 | :------------ | :--------------- | :------- | :---------------------------------------- | ------------------------------------------------ | ------------------------------------------------- |
 | ref           | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code> | <code>null</code>                                | Obtain a reference to the input HTML element      |
-| group         | <code>let</code> | Yes      | <code>any[]</code>                        | <code>[]</code>                                  | Specify the bound group                           |
+| group         | <code>let</code> | Yes      | <code>any[]</code>                        | <code>undefined</code>                           | Specify the bound group                           |
 | checked       | <code>let</code> | Yes      | <code>boolean</code>                      | <code>false</code>                               | Specify whether the checkbox is checked           |
 | value         | <code>let</code> | No       | <code>any</code>                          | <code>""</code>                                  | Specify the value of the checkbox                 |
 | indeterminate | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Specify whether the checkbox is indeterminate     |

--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -735,7 +735,6 @@
           "kind": "let",
           "description": "Specify the bound group",
           "type": "any[]",
-          "value": "[]",
           "isFunction": false,
           "isFunctionDeclaration": false,
           "constant": false,

--- a/src/Checkbox/Checkbox.svelte
+++ b/src/Checkbox/Checkbox.svelte
@@ -16,7 +16,7 @@
    * Specify the bound group
    * @type {any[]}
    */
-  export let group = [];
+  export let group = undefined;
 
   /** Specify whether the checkbox is indeterminate */
   export let indeterminate = false;
@@ -59,6 +59,8 @@
 
   const dispatch = createEventDispatcher();
 
+  $: useGroup = Array.isArray(group);
+  $: checked = useGroup ? group.includes(value) : checked;
   $: dispatch("check", checked);
 </script>
 
@@ -85,7 +87,7 @@
       bind:this="{ref}"
       type="checkbox"
       value="{value}"
-      checked="{checked || group.includes(value)}"
+      checked="{checked}"
       disabled="{disabled}"
       id="{id}"
       indeterminate="{indeterminate}"
@@ -94,10 +96,13 @@
       readonly="{readonly}"
       class:bx--checkbox="{true}"
       on:change="{() => {
-        checked = !checked;
-        group = group.includes(value)
-          ? group.filter((_value) => _value !== value)
-          : [...group, value];
+        if (useGroup) {
+          group = group.includes(value)
+            ? group.filter((_value) => _value !== value)
+            : [...group, value];
+        } else {
+          checked = !checked;
+        }
       }}"
       on:change
       on:blur

--- a/types/Checkbox/Checkbox.svelte.d.ts
+++ b/types/Checkbox/Checkbox.svelte.d.ts
@@ -16,7 +16,7 @@ export interface CheckboxProps {
 
   /**
    * Specify the bound group
-   * @default []
+   * @default undefined
    */
   group?: any[];
 


### PR DESCRIPTION
Fixes #967 

Currently, it is not possible to programmatically set `checked` or `group` since both props are used to determine the checkbox value.

This proposes initializing `group` as undefined instead of an empty array. If `group` is an array, the Checkbox will use it to determine the checked state; if not, it will default to the `checked` prop.

With this solution, two-way reactivity can be supported for either `checked` or `group` props, but not both. When using the `group` prop, `checked` will have one-way binding (i.e., read but not set).