### PR TITLE
fix(tooltip-definition): button should have `type="button"`

### DIFF
--- a/src/TooltipDefinition/TooltipDefinition.svelte
+++ b/src/TooltipDefinition/TooltipDefinition.svelte
@@ -46,6 +46,7 @@
 >
   <button
     bind:this="{ref}"
+    type="button"
     aria-describedby="{id}"
     class:bx--tooltip--a11y="{true}"
     class:bx--tooltip__trigger="{true}"


### PR DESCRIPTION
Fixes #1055