### PR TITLE
feat(tooltip-definition): export open prop, dispatch open/close events

### DIFF
--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -4691,6 +4691,7 @@ None.
 | Prop name   | Kind             | Reactive | Type                                              | Default value                                    | Description                                           |
 | :---------- | :--------------- | :------- | :------------------------------------------------ | ------------------------------------------------ | ----------------------------------------------------- |
 | ref         | <code>let</code> | Yes      | <code>null &#124; HTMLButtonElement</code>        | <code>null</code>                                | Obtain a reference to the button HTML element         |
+| open        | <code>let</code> | Yes      | <code>boolean</code>                              | <code>false</code>                               | Set to `true` to open the tooltip                     |
 | tooltipText | <code>let</code> | No       | <code>string</code>                               | <code>""</code>                                  | Specify the tooltip text                              |
 | align       | <code>let</code> | No       | <code>"start" &#124; "center" &#124; "end"</code> | <code>"center"</code>                            | Set the alignment of the tooltip relative to the icon |
 | direction   | <code>let</code> | No       | <code>"top" &#124; "bottom"</code>                | <code>"bottom"</code>                            | Set the direction of the tooltip relative to the icon |
@@ -4705,13 +4706,15 @@ None.
 
 ### Events
 
-| Event name | Type      | Detail |
-| :--------- | :-------- | :----- |
-| click      | forwarded | --     |
-| mouseover  | forwarded | --     |
-| mouseenter | forwarded | --     |
-| mouseleave | forwarded | --     |
-| focus      | forwarded | --     |
+| Event name | Type       | Detail           |
+| :--------- | :--------- | :--------------- |
+| open       | dispatched | <code>any</code> |
+| close      | dispatched | <code>any</code> |
+| click      | forwarded  | --               |
+| mouseover  | forwarded  | --               |
+| mouseenter | forwarded  | --               |
+| mouseleave | forwarded  | --               |
+| focus      | forwarded  | --               |
 
 ## `TooltipFooter`
 

--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -13112,6 +13112,17 @@
           "reactive": false
         },
         {
+          "name": "open",
+          "kind": "let",
+          "description": "Set to `true` to open the tooltip",
+          "type": "boolean",
+          "value": "false",
+          "isFunction": false,
+          "isFunctionDeclaration": false,
+          "constant": false,
+          "reactive": true
+        },
+        {
           "name": "align",
           "kind": "let",
           "description": "Set the alignment of the tooltip relative to the icon",
@@ -13166,6 +13177,8 @@
         }
       ],
       "events": [
+        { "type": "dispatched", "name": "open", "detail": "any" },
+        { "type": "dispatched", "name": "close", "detail": "any" },
         { "type": "forwarded", "name": "click", "element": "button" },
         { "type": "forwarded", "name": "mouseover", "element": "button" },
         { "type": "forwarded", "name": "mouseenter", "element": "button" },

--- a/src/TooltipDefinition/TooltipDefinition.svelte
+++ b/src/TooltipDefinition/TooltipDefinition.svelte
@@ -1,4 +1,9 @@
 <script>
+  /**
+   * @event {any} open
+   * @event {any} close
+   */
+
   /** Specify the tooltip text */
   export let tooltipText = "";
 

--- a/src/TooltipDefinition/TooltipDefinition.svelte
+++ b/src/TooltipDefinition/TooltipDefinition.svelte
@@ -25,9 +25,15 @@
   /** Obtain a reference to the button HTML element */
   export let ref = null;
 
+  import { createEventDispatcher } from "svelte";
+
+  const dispatch = createEventDispatcher();
+
   const hide = () => (open = false);
 
   const show = () => (open = true);
+
+  $: dispatch(open ? "open" : "close");
 </script>
 
 <svelte:window

--- a/src/TooltipDefinition/TooltipDefinition.svelte
+++ b/src/TooltipDefinition/TooltipDefinition.svelte
@@ -25,13 +25,9 @@
   /** Obtain a reference to the button HTML element */
   export let ref = null;
 
-  function hide() {
-    open = false;
-  }
+  const hide = () => (open = false);
 
-  function show() {
-    open = true;
-  }
+  const show = () => (open = true);
 </script>
 
 <svelte:window

--- a/src/TooltipDefinition/TooltipDefinition.svelte
+++ b/src/TooltipDefinition/TooltipDefinition.svelte
@@ -3,6 +3,11 @@
   export let tooltipText = "";
 
   /**
+   * Set to `true` to open the tooltip
+   */
+  export let open = false;
+
+  /**
    * Set the alignment of the tooltip relative to the icon
    * @type {"start" | "center" | "end"}
    */
@@ -20,14 +25,12 @@
   /** Obtain a reference to the button HTML element */
   export let ref = null;
 
-  let visible = false;
-
   function hide() {
-    visible = false;
+    open = false;
   }
 
   function show() {
-    visible = true;
+    open = true;
   }
 </script>
 
@@ -51,8 +54,8 @@
     class:bx--tooltip--a11y="{true}"
     class:bx--tooltip__trigger="{true}"
     class:bx--tooltip__trigger--definition="{true}"
-    class:bx--tooltip--hidden="{!visible}"
-    class:bx--tooltip--visible="{visible}"
+    class:bx--tooltip--hidden="{!open}"
+    class:bx--tooltip--visible="{open}"
     class:bx--tooltip--top="{direction === 'top'}"
     class:bx--tooltip--bottom="{direction === 'bottom'}"
     class:bx--tooltip--align-start="{align === 'start'}"

--- a/tests/TooltipDefinition.test.svelte
+++ b/tests/TooltipDefinition.test.svelte
@@ -1,8 +1,13 @@
 <script lang="ts">
   import { TooltipDefinition } from "../types";
+
+  let open = false;
 </script>
 
 <TooltipDefinition
+  bind:open
+  on:open
+  on:close
   tooltipText="IBM Corporate Headquarters is based in Armonk, New York."
 >
   Armonk

--- a/types/TooltipDefinition/TooltipDefinition.svelte.d.ts
+++ b/types/TooltipDefinition/TooltipDefinition.svelte.d.ts
@@ -10,6 +10,12 @@ export interface TooltipDefinitionProps
   tooltipText?: string;
 
   /**
+   * Set to `true` to open the tooltip
+   * @default false
+   */
+  open?: boolean;
+
+  /**
    * Set the alignment of the tooltip relative to the icon
    * @default "center"
    */
@@ -37,6 +43,8 @@ export interface TooltipDefinitionProps
 export default class TooltipDefinition extends SvelteComponentTyped<
   TooltipDefinitionProps,
   {
+    open: CustomEvent<any>;
+    close: CustomEvent<any>;
     click: WindowEventMap["click"];
     mouseover: WindowEventMap["mouseover"];
     mouseenter: WindowEventMap["mouseenter"];


### PR DESCRIPTION
TODO:

- [ ] needs docs

---

**Features**

- export `open` prop from `TooltipDefinition` for programmatic control; dispatch open, close events

```svelte
<script>
  import { TooltipDefinition } from "carbon-components-svelte";

  let open = true;
</script>

<TooltipDefinition
  bind:open
  on:open
  on:close
  tooltipText="IBM Corporate Headquarters is based in Armonk, New York."
>
  Armonk
</TooltipDefinition>

<button on:click={() => (open = !open)}> Toggle: {open} </button>
```