### PR TITLE
fix: duplicated SkeletonText heading removed

### DIFF
--- a/docs/src/pages/components/SkeletonText.svx
+++ b/docs/src/pages/components/SkeletonText.svx
@@ -11,10 +11,6 @@
 
 <SkeletonText heading />
 
-### Heading variant
-
-<SkeletonText heading />
-
 ### Paragraph variant
 
 <SkeletonText paragraph />


### PR DESCRIPTION
Hello,

While reading the docs, I found duplication on SkeletonText