### PR TITLE
fix(multi-select): resolve a11y violations

### DIFF
--- a/src/ListBox/ListBoxField.svelte
+++ b/src/ListBox/ListBoxField.svelte
@@ -45,7 +45,7 @@
 
 <div
   bind:this="{ref}"
-  role="{ariaExpanded ? 'combobox' : role}"
+  role="{role}"
   aria-expanded="{ariaExpanded}"
   aria-owns="{(ariaExpanded && menuId) || undefined}"
   aria-controls="{(ariaExpanded && menuId) || undefined}"

--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -268,8 +268,7 @@
     </label>
   {/if}
   <ListBox
-    aria-label="{ariaLabel}"
-    id="{id}"
+    role="{undefined}"
     disabled="{disabled}"
     invalid="{invalid}"
     invalidText="{invalidText}"
@@ -470,10 +469,17 @@
       {/if}
     </ListBoxField>
     {#if open}
-      <ListBoxMenu aria-label="{ariaLabel}" id="{id}">
+      <ListBoxMenu
+        aria-label="{ariaLabel}"
+        id="{id}"
+        aria-multiselectable="true"
+      >
         {#each filterable ? filteredItems : sortedItems as item, i (item.id)}
           <ListBoxMenuItem
             id="{item.id}"
+            role="option"
+            aria-labelledby="checkbox-{item.id}"
+            aria-selected="{item.checked}"
             active="{item.checked}"
             highlighted="{highlightedIndex === i}"
             on:click="{() => {


### PR DESCRIPTION
Fixes #1071

Addresses the following Lighthouse accessibility warning(s):

```
Elements with an ARIA [role] that require children to contain a specific [role] are missing some or all of those required children.
```

- role="listbox" children require the role="option" attribute
- add a "aria-multiselectable" attribute to the listbox menu
- move "aria-label" attribute from listbox to listbox menu
- listbox field should not have a "combobox" role when expanded (the non-filterable variant serves as a "button")