### PR TITLE
fix(data-table): use `headers` key as id

### DIFF
--- a/src/DataTable/DataTable.svelte
+++ b/src/DataTable/DataTable.svelte
@@ -154,9 +154,6 @@
       selectedRowIds = [];
       if (refSelectAll) refSelectAll.checked = false;
     },
-    add: (id) => {
-      headerItems.update((_) => [..._, id]);
-    },
   });
 
   let expanded = false;

--- a/src/DataTable/DataTable.svelte
+++ b/src/DataTable/DataTable.svelte
@@ -136,7 +136,7 @@
   const headerItems = writable([]);
   const thKeys = derived(headerItems, () =>
     headers
-      .map(({ key }, i) => ({ key, id: $headerItems[i] }))
+      .map(({ key }, i) => ({ key, id: key }))
       .reduce((a, c) => ({ ...a, [c.key]: c.id }), {})
   );
   const resolvePath = (object, path) =>

--- a/src/DataTable/TableHeader.svelte
+++ b/src/DataTable/TableHeader.svelte
@@ -18,9 +18,7 @@
   import ArrowUp20 from "../icons/ArrowUp20.svelte";
   import ArrowsVertical20 from "../icons/ArrowsVertical20.svelte";
 
-  const { sortHeader, tableSortable, add } = getContext("DataTable");
-
-  add(id);
+  const { sortHeader, tableSortable } = getContext("DataTable");
 
   $: active = $sortHeader.id === id;
   // TODO: translate with id


### PR DESCRIPTION
Fixes #1062, closes #1063

If `headers` is dynamically updated, clicking a sortable table header will sort the incorrect column. Instead of randomly generating an id and keeping track of it through context, we can simply use the required key in `headers` as the id.

```svelte
<script>
  import { DataTable } from "carbon-components-svelte";

  let headers = [];
  let rows = [
    // ...
  ];

  setTimeout(() => {
    headers = [
      { key: "name", value: "Name" },
      { key: "protocol", value: "Protocol" },
      { key: "port", value: "Port" },
      { key: "rule", value: "Rule" },
    ];
  }, 500);
</script>

<DataTable {rows} {headers} />
```