### PR TITLE
fix(multi-select): MultiSelect should correctly lose focus

### DIFF
--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -338,16 +338,6 @@
           if (inputRef) inputRef.focus();
         }
       }}"
-      on:blur="{({ relatedTarget }) => {
-        if (
-          relatedTarget &&
-          !['INPUT', 'SELECT', 'TEXTAREA'].includes(relatedTarget.tagName) &&
-          relatedTarget.getAttribute('role') !== 'button' &&
-          relatedTarget.getAttribute('role') !== 'searchbox'
-        ) {
-          fieldRef.focus();
-        }
-      }}"
       id="{id}"
       disabled="{disabled}"
       translateWithId="{translateWithId}"
@@ -422,18 +412,6 @@
           on:keyup
           on:focus
           on:blur
-          on:blur="{({ relatedTarget }) => {
-            if (
-              relatedTarget &&
-              !['INPUT', 'SELECT', 'TEXTAREA'].includes(
-                relatedTarget.tagName
-              ) &&
-              relatedTarget.getAttribute('role') !== 'button' &&
-              relatedTarget.getAttribute('role') !== 'searchbox'
-            ) {
-              inputRef.focus();
-            }
-          }}"
           disabled="{disabled}"
           placeholder="{placeholder}"
           id="{id}"


### PR DESCRIPTION
Fixes #848
Fixes #938
Fixes #1024

Currently, opening a MultiSelect and then clicking an interactive target will cause the MultiSelect to retain focus.

This is best illustrated by the repro provided in #848.

This removes the hacky blur logic that causes focus issues when clicking away from an open MultiSelect. PR #961 already blurs the input when tabbing.