### PR TITLE
Align v10.52

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -12,7 +12,7 @@
     "@sveltech/routify": "^1.9.9",
     "@sveltejs/vite-plugin-svelte": "^1.0.0-next.33",
     "autoprefixer": "^10.2.3",
-    "carbon-components": "10.51.0",
+    "carbon-components": "10.52.0",
     "carbon-components-10.47": "npm:carbon-components@10.47",
     "carbon-components-svelte": "../",
     "carbon-icons-svelte": "^10.44.3",

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -467,14 +467,14 @@ caniuse-lite@^1.0.30001173, caniuse-lite@^1.0.30001178:
     warning "^3.0.0"
 
 carbon-components-svelte@../:
-  version "0.54.0"
+  version "0.57.1"
   dependencies:
     flatpickr "4.6.9"
 
-carbon-components@10.51.0:
-  version "10.51.0"
-  resolved "https://registry.yarnpkg.com/carbon-components/-/carbon-components-10.51.0.tgz#a09b259db12fa3ea7868489bbea6cb165d4f814a"
-  integrity sha512-TkcfsYdFioZBx5vasC6bMOxI4XqJPt6EM7AqWAjwOeS7HByfBREYALHbZ3pBslb9yauoSbxQFKO2JlK5l+Baag==
+carbon-components@10.52.0:
+  version "10.52.0"
+  resolved "https://registry.yarnpkg.com/carbon-components/-/carbon-components-10.52.0.tgz#07db35dddbc5f9e5042e8621a781e9cb96fce0fa"
+  integrity sha512-itiG52GdDGxGh4IyuIV7gsuQCE1LLD2FCTEp5bPGhF/Onn042QzGendjl+yE7kfUk3FVlWmHN216dh/mA2sdZg==
   dependencies:
     "@carbon/telemetry" "0.0.0-alpha.6"
     flatpickr "4.6.1"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@rollup/plugin-node-resolve": "^11.1.1",
     "@tsconfig/svelte": "^1.0.10",
     "autoprefixer": "^10.2.4",
-    "carbon-components": "10.51.0",
+    "carbon-components": "10.52.0",
     "carbon-components-10.47": "npm:carbon-components@10.47",
     "carbon-icons-svelte": "^10.38.0",
     "husky": "^4.3.8",

--- a/src/FileUploader/FileUploaderDropContainer.svelte
+++ b/src/FileUploader/FileUploaderDropContainer.svelte
@@ -93,24 +93,24 @@
         {labelText}
       </slot>
     </div>
-    <input
-      bind:this="{ref}"
-      type="file"
-      tabindex="-1"
-      id="{id}"
-      disabled="{disabled}"
-      accept="{accept}"
-      name="{name}"
-      multiple="{multiple}"
-      class:bx--file-input="{true}"
-      on:change
-      on:change="{({ target }) => {
-        dispatch('add', validateFiles(target.files));
-      }}"
-      on:click
-      on:click="{({ target }) => {
-        target.value = null;
-      }}"
-    />
   </label>
+  <input
+    bind:this="{ref}"
+    type="file"
+    tabindex="-1"
+    id="{id}"
+    disabled="{disabled}"
+    accept="{accept}"
+    name="{name}"
+    multiple="{multiple}"
+    class:bx--file-input="{true}"
+    on:change
+    on:change="{({ target }) => {
+      dispatch('add', validateFiles(target.files));
+    }}"
+    on:click
+    on:click="{({ target }) => {
+      target.value = null;
+    }}"
+  />
 </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -469,10 +469,10 @@ caniuse-lite@^1.0.30001181:
     lodash.debounce "^4.0.8"
     warning "^3.0.0"
 
-carbon-components@10.51.0:
-  version "10.51.0"
-  resolved "https://registry.yarnpkg.com/carbon-components/-/carbon-components-10.51.0.tgz#a09b259db12fa3ea7868489bbea6cb165d4f814a"
-  integrity sha512-TkcfsYdFioZBx5vasC6bMOxI4XqJPt6EM7AqWAjwOeS7HByfBREYALHbZ3pBslb9yauoSbxQFKO2JlK5l+Baag==
+carbon-components@10.52.0:
+  version "10.52.0"
+  resolved "https://registry.yarnpkg.com/carbon-components/-/carbon-components-10.52.0.tgz#07db35dddbc5f9e5042e8621a781e9cb96fce0fa"
+  integrity sha512-itiG52GdDGxGh4IyuIV7gsuQCE1LLD2FCTEp5bPGhF/Onn042QzGendjl+yE7kfUk3FVlWmHN216dh/mA2sdZg==
   dependencies:
     "@carbon/telemetry" "0.0.0-alpha.6"
     flatpickr "4.6.1"


### PR DESCRIPTION
CSS from `carbon-components` v10.52.0 fixes #993.

**Fixes**

- move `FileUploaderDropContainer` input outside of label to fix a11y error

**Housekeeping**

- upgrade `carbon-components` to v10.52.0