### PR TITLE
fix(ui-shell): fix `HeaderNavMenu` accessibility, undefined context

### DIFF
--- a/src/UIShell/GlobalHeader/HeaderNav.svelte
+++ b/src/UIShell/GlobalHeader/HeaderNav.svelte
@@ -13,7 +13,7 @@
 </script>
 
 <nav {...props} class:bx--header__nav="{true}" {...$$restProps}>
-  <ul {...props} class:bx--header__menu-bar="{true}">
+  <ul {...props} role="menubar" class:bx--header__menu-bar="{true}">
     <slot />
   </ul>
 </nav>

--- a/src/UIShell/GlobalHeader/HeaderNavItem.svelte
+++ b/src/UIShell/GlobalHeader/HeaderNavItem.svelte
@@ -26,7 +26,7 @@
   $: updateSelectedItems({ id, isSelected });
 </script>
 
-<li>
+<li role="none">
   <a
     bind:this="{ref}"
     role="menuitem"

--- a/src/UIShell/GlobalHeader/HeaderNavItem.svelte
+++ b/src/UIShell/GlobalHeader/HeaderNavItem.svelte
@@ -17,13 +17,24 @@
   /** Obtain a reference to the HTML anchor element */
   export let ref = null;
 
-  import { getContext } from "svelte";
+  import { getContext, onMount } from "svelte";
 
   const id = "ccs-" + Math.random().toString(36);
-  const { selectedItems, updateSelectedItems, closeMenu } =
-    getContext("HeaderNavMenu");
+  const ctx = getContext("HeaderNavMenu");
 
-  $: updateSelectedItems({ id, isSelected });
+  let selectedItemIds = [];
+
+  const unsubSelectedItems = ctx?.selectedItems.subscribe((_selectedItems) => {
+    selectedItemIds = Object.keys(_selectedItems);
+  });
+
+  $: ctx?.updateSelectedItems({ id, isSelected });
+
+  onMount(() => {
+    return () => {
+      if (unsubSelectedItems) unsubSelectedItems();
+    };
+  });
 </script>
 
 <li role="none">
@@ -45,8 +56,9 @@
     on:focus
     on:blur
     on:blur="{() => {
-      const ids = Object.keys($selectedItems);
-      if (ids.indexOf(id) === ids.length - 1) closeMenu();
+      if (selectedItemIds.indexOf(id) === selectedItemIds.length - 1) {
+        ctx?.closeMenu();
+      }
     }}"
   >
     <span class:bx--text-truncate--end="{true}">{text}</span>

--- a/src/UIShell/GlobalHeader/HeaderNavMenu.svelte
+++ b/src/UIShell/GlobalHeader/HeaderNavMenu.svelte
@@ -14,10 +14,6 @@
   /** Obtain a reference to the HTML anchor element */
   export let ref = null;
 
-  export function toggle() {
-    expanded = !expanded;
-  }
-
   import { setContext } from "svelte";
   import { writable } from "svelte/store";
   import ChevronDown16 from "../../icons/ChevronDown16.svelte";

--- a/src/UIShell/GlobalHeader/HeaderNavMenu.svelte
+++ b/src/UIShell/GlobalHeader/HeaderNavMenu.svelte
@@ -48,6 +48,7 @@
 />
 
 <li
+  role="none"
   class:bx--header__submenu="{true}"
   class:bx--header__submenu--current="{isCurrentSubmenu}"
   on:click="{(e) => {
@@ -65,6 +66,7 @@
 >
   <a
     bind:this="{ref}"
+    role="menuitem"
     tabindex="0"
     aria-haspopup="menu"
     aria-expanded="{expanded}"


### PR DESCRIPTION
**Fixes**

- [hotfix(ui-shell): remove toggle accessor from HeaderNavMenu](https://github.com/carbon-design-system/carbon-components-svelte/commit/4dae650f76663b438a9f7c07d2e5b981298608af)
- [hotfix(ui-shell): HeaderNavMenu is possibly undefined](https://github.com/carbon-design-system/carbon-components-svelte/commit/5b9b680e51c139f002a2048ebc93d37525988771)
-  [fix(ui-shell): apply a11y navigation menubar attributes](https://github.com/carbon-design-system/carbon-components-svelte/commit/995a47450f212b2074e7fcf619700664c051af8d), applies [this suggestion](https://github.com/carbon-design-system/carbon-components-svelte/pull/1073#issuecomment-1035061334)

CC @brunnerh good call, using the navigation menubar accessibility best practices results in a 100 Lighthouse score:

<img width="709" alt="Screen Shot 2022-02-10 at 7 56 59 AM" src="https://user-images.githubusercontent.com/10718366/153447794-ac55640d-558c-40c6-8feb-f6bd20738380.png">

