### PR TITLE
fix(ui-shell): prevent default behavior when pressing Space

### DIFF
--- a/src/UIShell/GlobalHeader/HeaderNavMenu.svelte
+++ b/src/UIShell/GlobalHeader/HeaderNavMenu.svelte
@@ -78,6 +78,7 @@
     style="{$$restProps.style}; z-index: 1"
     on:keydown
     on:keydown="{(e) => {
+      if (e.key === ' ') e.preventDefault();
       if (e.key === 'Enter' || e.key === ' ') {
         expanded = !expanded;
       }


### PR DESCRIPTION
Follow-up to #1079

Pressing Space without preventing the default behavior will cause a page with overflow content to scroll.