### PR TITLE
fix(data-table): batch selection checkbox should be reactive

### DIFF
--- a/src/DataTable/DataTable.svelte
+++ b/src/DataTable/DataTable.svelte
@@ -164,7 +164,7 @@
     {}
   );
 
-  let selectAll = false;
+  $: selectAll = rows.length > 0 && selectedRowIds.length === rows.length;
   let refSelectAll = null;
 
   $: batchSelectedIds.set(selectedRowIds);


### PR DESCRIPTION
Fixes #1083

If `DataTable` selectedIds is programmatically cleared, the batch selection checkbox should be unchecked.

The issue is that `selectAll` is not reactive. The solution is that it should be `true` if the number of selected row ids equals the total rows (and if there is at least one row in the table).