### PR TITLE
fix(code-snippet): remove whitespace from `pre` tag

### DIFF
--- a/src/CodeSnippet/CodeSnippet.svelte
+++ b/src/CodeSnippet/CodeSnippet.svelte
@@ -190,9 +190,7 @@
       class:bx--snippet-container="{true}"
       style="width: 100%; min-height: {minHeight}px; max-height: {maxHeight}"
     >
-      <pre bind:this="{ref}">
-        <code><slot>{code}</slot></code>
-      </pre>
+      <pre bind:this="{ref}"><code><slot>{code}</slot></code></pre>
     </div>
     {#if !hideCopyButton}
       <CopyButton


### PR DESCRIPTION
Fixes #1087

Svelte v3.46.4 preserves whitespace inside `pre` tags by default. This PR removes the whitespace from inside the `pre` tag in `CodeSnippet`.