### PR TITLE
Do not set `aria-pressed` on link buttons.

### DIFF
--- a/src/Button/Button.svelte
+++ b/src/Button/Button.svelte
@@ -97,7 +97,8 @@
     tabindex,
     disabled: disabled === true ? true : undefined,
     href,
-    "aria-pressed": hasIconOnly && kind === "ghost" ? isSelected : undefined,
+    "aria-pressed":
+      hasIconOnly && kind === "ghost" && !href ? isSelected : undefined,
     ...$$restProps,
     class: [
       "bx--btn",


### PR DESCRIPTION
Fixes #1090.