### PR TITLE
fix(ui-shell): use semantic `hr` in `HeaderPanelDivider` to render dividers

### DIFF
--- a/src/UIShell/GlobalHeader/HeaderPanelDivider.svelte
+++ b/src/UIShell/GlobalHeader/HeaderPanelDivider.svelte
@@ -1,22 +1,27 @@
-<li class="subject-divider">
-  <span>
-    <slot />
-  </span>
-</li>
+{#if $$slots.default}
+  <li>
+    <span>
+      <slot />
+    </span>
+  </li>
+{/if}
+<hr class:bx--switcher__item--divider="{true}" {...$$restProps} />
 
 <style>
-  .subject-divider {
-    color: #525252;
-    padding-bottom: 4px;
-    border-bottom: 1px solid #525252;
-    margin: 32px 1rem 8px;
-  }
+  /**
+    * Carbon does not support a divider with a subject.
+    * We apply custom styles using the switcher subject divider
+    * from https://carbondesignsystem.com/ as a reference.
+    */
 
-  .subject-divider span {
+  li {
+    margin: 2rem 1rem 0;
+    color: #525252;
+  }
+  span {
     font-size: 0.75rem;
-    font-weight: 400;
-    line-height: 1rem;
-    letter-spacing: 0.32px;
+    line-height: 1.3;
+    letter-spacing: 0.02rem;
     color: #c6c6c6;
   }
 </style>

--- a/src/UIShell/GlobalHeader/HeaderPanelDivider.svelte
+++ b/src/UIShell/GlobalHeader/HeaderPanelDivider.svelte
@@ -5,7 +5,7 @@
     </span>
   </li>
 {/if}
-<hr class:bx--switcher__item--divider="{true}" {...$$restProps} />
+<hr class:bx--switcher__item--divider="{true}" />
 
 <style>
   /**


### PR DESCRIPTION
Currently, you can provide a subject using the `HeaderPanelDivider` default slot:

```svelte
<HeaderPanelDivider>Switcher subject 1</HeaderPanelDivider>

<!-- DOM output -->
<li><span>Switcher subject 1</span></li>
```

However, if you just want the divider, an empty `li` element will be rendered:

```svelte
<HeaderPanelDivider />

<!-- DOM output -->
<li><span></span></li>
```

This PR uses the semantic `hr` element for a divider without a subject:

```svelte
<HeaderPanelDivider />

<!-- DOM output -->
<hr />
```

Thus, a divider with a subject will still render a `li` tag:

```svelte
<HeaderPanelDivider>Switcher subject 1</HeaderPanelDivider>

<!-- DOM output -->
<li><span>Switcher subject 1</span></li>
<hr />
```

- conditionally render the subject if component has a default slot
- use `hr` semantic element to signify a break
- use Carbon's "bx--switcher__item--divider" class to style the divider
- simplify custom CSS
- add a comment as to why we use custom styles

There are style changes, albeit subtle:

<img width="505" alt="Screen Shot 2022-02-12 at 7 52 59 AM" src="https://user-images.githubusercontent.com/10718366/153718571-7c6766d8-10e3-4c74-bd41-9a80bddc1f88.png">
