### PR TITLE
fix(tooltip): aria-label should use iconDescription if triggerText is falsy

### DIFF
--- a/src/Tooltip/Tooltip.svelte
+++ b/src/Tooltip/Tooltip.svelte
@@ -172,7 +172,7 @@
     "aria-expanded": open,
     "aria-describedby": open ? tooltipId : undefined,
     "aria-labelledby": triggerText ? triggerId : undefined,
-    "aria-label": triggerText ? iconDescription : undefined,
+    "aria-label": triggerText ? undefined : iconDescription,
     tabindex,
     style: hideIcon ? $$restProps.style : undefined,
   };


### PR DESCRIPTION
Fixes #1094