### PR TITLE
fix(overflow-menu): keyboard navigation should skip disabled items

### DIFF
--- a/src/OverflowMenu/OverflowMenu.svelte
+++ b/src/OverflowMenu/OverflowMenu.svelte
@@ -80,26 +80,39 @@
 
   setContext("OverflowMenu", {
     focusedId,
-    add: ({ id, text, primaryFocus }) => {
+    add: ({ id, text, primaryFocus, disabled }) => {
       items.update((_) => {
         if (primaryFocus) {
           currentIndex.set(_.length);
         }
 
-        return [..._, { id, text, primaryFocus, index: _.length }];
+        return [..._, { id, text, primaryFocus, disabled, index: _.length }];
       });
     },
     update: (id) => {
       currentId.set(id);
     },
     change: (direction) => {
-      // TODO: skip disabled
       let index = $currentIndex + direction;
 
       if (index < 0) {
         index = $items.length - 1;
       } else if (index >= $items.length) {
         index = 0;
+      }
+
+      let disabled = $items[index].disabled;
+
+      while (disabled) {
+        index = index + direction;
+
+        if (index < 0) {
+          index = $items.length - 1;
+        } else if (index >= $items.length) {
+          index = 0;
+        }
+
+        disabled = $items[index].disabled;
       }
 
       currentIndex.set(index);

--- a/src/OverflowMenu/OverflowMenuItem.svelte
+++ b/src/OverflowMenu/OverflowMenuItem.svelte
@@ -33,7 +33,7 @@
 
   const { focusedId, add, update, change } = getContext("OverflowMenu");
 
-  add({ id, text, primaryFocus });
+  add({ id, text, primaryFocus, disabled });
 
   afterUpdate(() => {
     if (ref && primaryFocus) {


### PR DESCRIPTION
Using Up/Down arrow keys to navigate an open overflow menu should skip disabled items.

```svelte
<script>
  import { OverflowMenu, OverflowMenuItem } from "carbon-components-svelte";
</script>

<OverflowMenu>
  <OverflowMenuItem text="Create key" />
  <OverflowMenuItem text="Import key" />
  <OverflowMenuItem text="Revoke key" disabled />
  <OverflowMenuItem text="Duplicate key" disabled />
  <OverflowMenuItem
    hasDivider
    href="https://cloud.ibm.com/docs/api-gateway/"
    text="API documentation"
  />
  <OverflowMenuItem hasDivider danger text="Delete service" disabled />
</OverflowMenu>

```


https://user-images.githubusercontent.com/10718366/153732311-f9bf9a60-a90d-4a41-942e-953c1fd49259.mov

