### PR TITLE
fix(multi-select): fix keyboard behavior

### DIFF
--- a/src/ListBox/ListBoxField.svelte
+++ b/src/ListBox/ListBoxField.svelte
@@ -60,7 +60,7 @@
   on:mouseover
   on:mouseenter
   on:mouseleave
-  on:keydown|preventDefault|stopPropagation
+  on:keydown
   on:focus
   on:blur
 >

--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -315,10 +315,17 @@
           open = !open;
         }
       }}"
-      on:keydown="{({ key }) => {
+      on:keydown="{(e) => {
         if (filterable) {
           return;
         }
+
+        const key = e.key;
+
+        if ([' ', 'ArrowUp', 'ArrowDown'].includes(key)) {
+          e.preventDefault();
+        }
+
         if (key === ' ') {
           open = !open;
         } else if (key === 'Tab') {

--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -326,8 +326,15 @@
           e.preventDefault();
         }
 
-        if (key === ' ') {
-          open = !open;
+        if (key === ' ' || key === 'Enter') {
+          if (highlightedIndex > -1) {
+            sortedItems = sortedItems.map((item, i) => {
+              if (i !== highlightedIndex) return item;
+              return { ...item, checked: !item.checked };
+            });
+          } else {
+            open = !open;
+          }
         } else if (key === 'Tab') {
           if (selectionRef && checked.length > 0) {
             selectionRef.focus();
@@ -339,13 +346,6 @@
           change(1);
         } else if (key === 'ArrowUp') {
           change(-1);
-        } else if (key === 'Enter') {
-          if (highlightedIndex > -1) {
-            sortedItems = sortedItems.map((item, i) => {
-              if (i !== highlightedIndex) return item;
-              return { ...item, checked: !item.checked };
-            });
-          }
         } else if (key === 'Escape') {
           open = false;
         }

--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -339,6 +339,8 @@
               return { ...item, checked: !item.checked };
             });
           }
+        } else if (key === 'Escape') {
+          open = false;
         }
       }}"
       on:focus="{() => {


### PR DESCRIPTION
Fixes #938

- remove `preventDefault|stopPropagation` from `ListBoxField` forwarded keydown event
- pressing "Escape" should close an open menu
- pressing "Enter" should toggle the menu
- pressing "Space" should select an item