### PR TITLE
fix(multi-select): ListBoxField should not prevent default keyboard behavior

### DIFF
--- a/src/ListBox/ListBoxField.svelte
+++ b/src/ListBox/ListBoxField.svelte
@@ -60,7 +60,7 @@
   on:mouseover
   on:mouseenter
   on:mouseleave
-  on:keydown|preventDefault|stopPropagation
+  on:keydown|stopPropagation
   on:focus
   on:blur
 >

--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -315,9 +315,13 @@
           open = !open;
         }
       }}"
-      on:keydown="{({ key }) => {
+      on:keydown="{(e) => {
         if (filterable) {
           return;
+        }
+        const key = e.key;
+        if ([' ', 'ArrowUp', 'ArrowDown'].includes(key)) {
+          e.preventDefault();
         }
         if (key === ' ') {
           open = !open;


### PR DESCRIPTION
Fixes #938

- only prevent `MultiSelect` default behavior when pressing Space/ArrowDown/ArrowUp