### PR TITLE
chore(examples):remove config.kit.target from sveltekit example

### DIFF
--- a/examples/sveltekit/svelte.config.js
+++ b/examples/sveltekit/svelte.config.js
@@ -3,9 +3,6 @@ import { optimizeImports } from "carbon-preprocess-svelte";
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
   preprocess: [optimizeImports()],
-  kit: {
-    target: "#svelte",
-  },
 };
 
 export default config;


### PR DESCRIPTION
to prevent this error that halts dev or build

> config.kit.target is no longer required, and should be removed