### PR TITLE
fix(structured-list): override `overflow-y` to be `visible`

### DIFF
--- a/src/StructuredList/StructuredList.svelte
+++ b/src/StructuredList/StructuredList.svelte
@@ -46,6 +46,7 @@
   class:bx--structured-list--condensed="{condensed}"
   class:bx--structured-list--flush="{flush}"
   {...$$restProps}
+  style="overflow-y: visible; {$$restProps.style}"
   on:click
   on:mouseover
   on:mouseenter


### PR DESCRIPTION
Fixes #1106

Monkey patches the `StructuredList` component to always set `overflow-y: visible`. This allows for overflow content, like tooltips etc.