### PR TITLE
Update PasswordInput.svelte

### DIFF
--- a/src/TextInput/PasswordInput.svelte
+++ b/src/TextInput/PasswordInput.svelte
@@ -128,7 +128,8 @@
         {helperText}
       </div>
     {/if}
-  {:else}
+  {/if}
+  {#if !inline && labelText}
     <label
       for="{id}"
       class:bx--label="{true}"


### PR DESCRIPTION
If no labelText is given, label should not be rendered. This behavior is present in TextInput.svelte, but not in PasswordInput.svelte