### PR TITLE
fix: slottable labelText should render correctly

### DIFF
--- a/src/TextInput/PasswordInput.svelte
+++ b/src/TextInput/PasswordInput.svelte
@@ -129,7 +129,7 @@
       </div>
     {/if}
   {/if}
-  {#if !inline && labelText}
+  {#if !inline && (labelText || $$slots.labelText)}
     <label
       for="{id}"
       class:bx--label="{true}"

--- a/src/TextInput/TextInput.svelte
+++ b/src/TextInput/TextInput.svelte
@@ -138,7 +138,7 @@
       {/if}
     </div>
   {/if}
-  {#if !inline && labelText}
+  {#if !inline && (labelText || $$slots.labelText)}
     <label
       for="{id}"
       class:bx--label="{true}"


### PR DESCRIPTION
Currently, in `TextInput` and `PasswordInput`, the "labelText" slot will not be rendered as the condition only checks for the `labelText` prop.

```svelte
<TextInput placeholder="Enter user name...">
  <!-- doesn't render -->
  <b slot="labelText" style="color: red">Label</b>
</TextInput>
```

**Fixes**

- correctly render "labelText" slot in `TextInput` and `PasswordInput`