### PR TITLE
fix: use `@component` comments for deprecation notices

### DIFF
--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -4608,7 +4608,8 @@
         { "type": "dispatched", "name": "focusInputSearch" },
         { "type": "dispatched", "name": "focusOutInputSearch" }
       ],
-      "typedefs": []
+      "typedefs": [],
+      "componentComment": "\n@deprecated\nThis component is deprecated. Use `HeaderSearch` instead."
     },
     {
       "moduleName": "HeaderGlobalAction",
@@ -4991,7 +4992,8 @@
       "extends": {
         "interface": "IconSkeletonProps",
         "import": "\"./IconSkeleton.svelte\""
-      }
+      },
+      "componentComment": "\n@deprecated This component is deprecated.\nUse icons from \"carbon-icons-svelte\" instead."
     },
     {
       "moduleName": "IconSkeleton",
@@ -5017,7 +5019,8 @@
         { "type": "forwarded", "name": "mouseleave", "element": "div" }
       ],
       "typedefs": [],
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": { "type": "Element", "name": "div" },
+      "componentComment": "\n@deprecated This component is deprecated."
     },
     {
       "moduleName": "ImageLoader",
@@ -6985,7 +6988,8 @@
       ],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [],
-      "typedefs": []
+      "typedefs": [],
+      "componentComment": "\n@deprecated This component is deprecated."
     },
     {
       "moduleName": "NumberInput",
@@ -12716,7 +12720,8 @@
         { "type": "forwarded", "name": "blur", "element": "input" }
       ],
       "typedefs": [],
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": { "type": "Element", "name": "div" },
+      "componentComment": "\n@deprecated This component is deprecated.\nUse`<Toggle size=\"sm\" />` instead."
     },
     {
       "moduleName": "ToggleSmallSkeleton",
@@ -12753,7 +12758,8 @@
         { "type": "forwarded", "name": "mouseleave", "element": "div" }
       ],
       "typedefs": [],
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": { "type": "Element", "name": "div" },
+      "componentComment": "\n@deprecated This component is deprecated.\nUse`<ToggleSkeleton size=\"sm\" />` instead."
     },
     {
       "moduleName": "Toolbar",

--- a/src/Icon/Icon.svelte
+++ b/src/Icon/Icon.svelte
@@ -1,11 +1,5 @@
 <script>
   /**
-   * @deprecated
-   * This component will be removed in version 1.0.0.
-   * Use icons from "carbon-icons-svelte" instead
-   */
-
-  /**
    * @extends {"./IconSkeleton.svelte"} IconSkeletonProps
    * @restProps {svg}
    */
@@ -21,6 +15,11 @@
 
   import IconSkeleton from "./IconSkeleton.svelte";
 </script>
+
+<!-- @component
+@deprecated This component is deprecated.
+Use icons from "carbon-icons-svelte" instead.
+-->
 
 {#if skeleton}
   <IconSkeleton

--- a/src/Icon/IconSkeleton.svelte
+++ b/src/Icon/IconSkeleton.svelte
@@ -1,12 +1,11 @@
 <script>
-  /**
-   * @deprecated
-   * This component will be removed in version 1.0.0.
-   */
-
   /** Set the size of the icon */
   export let size = 16;
 </script>
+
+<!-- @component
+@deprecated This component is deprecated.
+-->
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <div

--- a/src/Notification/NotificationTextDetails.svelte
+++ b/src/Notification/NotificationTextDetails.svelte
@@ -1,10 +1,5 @@
 <script>
   /**
-   * @deprecated
-   * This component will be removed in version 1.0.0.
-   */
-
-  /**
    * Set the type of notification
    * @type {"toast" | "inline"}
    */
@@ -19,6 +14,10 @@
   /** Specify the caption text */
   export let caption = "Caption";
 </script>
+
+<!-- @component
+@deprecated This component is deprecated.
+-->
 
 {#if notificationType === "toast"}
   <div class:bx--toast-notification__details="{true}">

--- a/src/ToggleSmall/ToggleSmall.svelte
+++ b/src/ToggleSmall/ToggleSmall.svelte
@@ -1,10 +1,4 @@
 <script>
-  /**
-   * @deprecated
-   * This component will be removed in version 1.0.0.
-   * Use `<Toggle size="sm" />` instead
-   */
-
   /** Set to `true` to toggle the checkbox input */
   export let toggled = false;
 
@@ -29,6 +23,11 @@
    */
   export let name = undefined;
 </script>
+
+<!-- @component
+@deprecated This component is deprecated.
+Use`<Toggle size="sm" />` instead.
+-->
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <div

--- a/src/ToggleSmall/ToggleSmallSkeleton.svelte
+++ b/src/ToggleSmall/ToggleSmallSkeleton.svelte
@@ -1,16 +1,15 @@
 <script>
-  /**
-   * @deprecated
-   * This component will be removed in version 1.0.0.
-   * Use `<ToggleSkeleton size="sm" />` instead
-   */
-
   /** Specify the label text */
   export let labelText = "";
 
   /** Set an id for the input element */
   export let id = "ccs-" + Math.random().toString(36);
 </script>
+
+<!-- @component
+@deprecated This component is deprecated.
+Use`<ToggleSkeleton size="sm" />` instead.
+-->
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <div

--- a/src/UIShell/GlobalHeader/HeaderActionSearch.svelte
+++ b/src/UIShell/GlobalHeader/HeaderActionSearch.svelte
@@ -1,11 +1,5 @@
 <script>
   /**
-   * @deprecated
-   * This component will be removed in version 1.0.0.
-   * Use `HeaderSearch` instead
-   */
-
-  /**
    * @event {{ action: "search"; textInput: string; }} inputSearch
    */
 
@@ -64,6 +58,10 @@
   }}"
 />
 
+<!-- @component
+@deprecated
+This component is deprecated. Use `HeaderSearch` instead.
+-->
 <div
   bind:this="{elTypeSearch}"
   role="search"

--- a/types/Icon/Icon.svelte.d.ts
+++ b/types/Icon/Icon.svelte.d.ts
@@ -18,6 +18,10 @@ export interface IconProps
   skeleton?: boolean;
 }
 
+/**
+ * @deprecated This component is deprecated.
+ * Use icons from "carbon-icons-svelte" instead.
+ */
 export default class Icon extends SvelteComponentTyped<
   IconProps,
   {

--- a/types/Icon/IconSkeleton.svelte.d.ts
+++ b/types/Icon/IconSkeleton.svelte.d.ts
@@ -10,6 +10,9 @@ export interface IconSkeletonProps
   size?: number;
 }
 
+/**
+ * @deprecated This component is deprecated.
+ */
 export default class IconSkeleton extends SvelteComponentTyped<
   IconSkeletonProps,
   {

--- a/types/Notification/NotificationTextDetails.svelte.d.ts
+++ b/types/Notification/NotificationTextDetails.svelte.d.ts
@@ -27,6 +27,9 @@ export interface NotificationTextDetailsProps {
   caption?: string;
 }
 
+/**
+ * @deprecated This component is deprecated.
+ */
 export default class NotificationTextDetails extends SvelteComponentTyped<
   NotificationTextDetailsProps,
   {},

--- a/types/ToggleSmall/ToggleSmall.svelte.d.ts
+++ b/types/ToggleSmall/ToggleSmall.svelte.d.ts
@@ -46,6 +46,10 @@ export interface ToggleSmallProps
   name?: string;
 }
 
+/**
+ * @deprecated This component is deprecated.
+ * Use`<Toggle size="sm" />` instead.
+ */
 export default class ToggleSmall extends SvelteComponentTyped<
   ToggleSmallProps,
   {

--- a/types/ToggleSmall/ToggleSmallSkeleton.svelte.d.ts
+++ b/types/ToggleSmall/ToggleSmallSkeleton.svelte.d.ts
@@ -16,6 +16,10 @@ export interface ToggleSmallSkeletonProps
   id?: string;
 }
 
+/**
+ * @deprecated This component is deprecated.
+ * Use`<ToggleSkeleton size="sm" />` instead.
+ */
 export default class ToggleSmallSkeleton extends SvelteComponentTyped<
   ToggleSmallSkeletonProps,
   {

--- a/types/UIShell/GlobalHeader/HeaderActionSearch.svelte.d.ts
+++ b/types/UIShell/GlobalHeader/HeaderActionSearch.svelte.d.ts
@@ -9,6 +9,10 @@ export interface HeaderActionSearchProps {
   searchIsActive?: boolean;
 }
 
+/**
+ * @deprecated
+ * This component is deprecated. Use `HeaderSearch` instead.
+ */
 export default class HeaderActionSearch extends SvelteComponentTyped<
   HeaderActionSearchProps,
   {


### PR DESCRIPTION
The Svelte Language Server allows [component-level comments](https://svelte.dev/faq#how-do-i-document-my-components) through `<!-- @component ... -->` syntax.

This PR moves the deprecation notices for components from the script block to the markup template.

This leads to proper component-level comments:

<img width="535" alt="Screen Shot 2022-02-19 at 6 41 21 PM" src="https://user-images.githubusercontent.com/10718366/154826360-07803da9-ee6a-4850-81b9-3bce478d9c81.png">

**Fixes**

- use `@component` comments for component deprecation notices