### PR TITLE
fix(data-table): pass header key to `TableHeader`

### DIFF
--- a/src/DataTable/DataTable.svelte
+++ b/src/DataTable/DataTable.svelte
@@ -306,6 +306,7 @@
             <th scope="col"></th>
           {:else}
             <TableHeader
+              id="{header.key}"
               disableSorting="{header.sort === false}"
               on:click="{() => {
                 dispatch('click', { header });


### PR DESCRIPTION
This fixes a regression caused by #1075

The id is needed to update the sort icon direction accordingly.

Fixes #1113