### PR TITLE
fix(file-uploader): `FileUploader` files should not be keyed

### DIFF
--- a/src/FileUploader/FileUploader.svelte
+++ b/src/FileUploader/FileUploader.svelte
@@ -100,7 +100,7 @@
     }}"
   />
   <div class:bx--file-container="{true}">
-    {#each files as { name }, i (name)}
+    {#each files as { name }, i}
       <span class:bx--file__selected-file="{true}">
         <p class:bx--file-filename="{true}">{name}</p>
         <span class:bx--file__state-container="{true}">


### PR DESCRIPTION
Fixes #1115