### PR TITLE
fix(file-uploader): correctly fire add/remove events

### DIFF
--- a/src/FileUploader/FileUploader.svelte
+++ b/src/FileUploader/FileUploader.svelte
@@ -61,15 +61,28 @@
 
   const dispatch = createEventDispatcher();
 
-  $: prevFiles = [];
+  let prevFiles = [];
+
+  /** @type {(file: File) => string} */
+  const getFileId = (file) => file.lastModified + file.name;
 
   afterUpdate(() => {
-    if (files.length > prevFiles.length) {
-      dispatch("add", files);
-    } else {
+    const fileIds = files.map(getFileId);
+    const prevFileIds = prevFiles.map(getFileId);
+    const addedIds = fileIds.filter((_) => !prevFileIds.includes(_));
+    const removedIds = prevFileIds.filter((_) => !fileIds.includes(_));
+
+    if (addedIds.length > 0) {
+      dispatch(
+        "add",
+        addedIds.map((id) => files.find((file) => id === getFileId(file)))
+      );
+    }
+
+    if (removedIds.length > 0) {
       dispatch(
         "remove",
-        prevFiles.filter((_) => !files.includes(_))
+        removedIds.map((id) => prevFiles.find((file) => id === getFileId(file)))
       );
     }
 


### PR DESCRIPTION
Fixes #1119

Currently, `FileUploader` dispatches add/remove if the number of files changes.

This doesn't account for the case of adding/removing the same number of files. The comparison logic now uses `file.lastModified + file.name` as a heuristic for a file id.