### PR TITLE
refactor(types): remove unnecessary JSDoc default type

### DIFF
--- a/src/Search/Search.svelte
+++ b/src/Search/Search.svelte
@@ -12,7 +12,7 @@
 
   /**
    * Specify the size of the search input
-   * @type {"sm" | "lg" | "xl"} [size="xl"]
+   * @type {"sm" | "lg" | "xl"}
    */
   export let size = "xl";
 


### PR DESCRIPTION
The JSDoc default type (e.g., `[size="xl"]`) can be omitted as it is already determined by sveld.

```js
/*
 * @type {"sm" | "lg" | "xl"} [size="xl"]
 */
```