### PR TITLE
fix(types): dispatched events without a detail value should be `null`

### DIFF
--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -1863,9 +1863,9 @@ export interface HeaderSearchResult {
 
 | Event name | Type       | Detail                                                                                          |
 | :--------- | :--------- | :---------------------------------------------------------------------------------------------- |
-| active     | dispatched | <code>any</code>                                                                                |
-| inactive   | dispatched | <code>any</code>                                                                                |
-| clear      | dispatched | <code>any</code>                                                                                |
+| active     | dispatched | <code>null</code>                                                                               |
+| inactive   | dispatched | <code>null</code>                                                                               |
+| clear      | dispatched | <code>null</code>                                                                               |
 | select     | dispatched | <code>{ value: string; selectedResultIndex: number; selectedResult: HeaderSearchResult }</code> |
 | change     | forwarded  | --                                                                                              |
 | input      | forwarded  | --                                                                                              |
@@ -1956,10 +1956,10 @@ None.
 
 ### Events
 
-| Event name | Type       | Detail           |
-| :--------- | :--------- | :--------------- |
-| load       | dispatched | <code>any</code> |
-| error      | dispatched | <code>any</code> |
+| Event name | Type       | Detail            |
+| :--------- | :--------- | :---------------- |
+| load       | dispatched | <code>null</code> |
+| error      | dispatched | <code>null</code> |
 
 ## `InlineLoading`
 
@@ -2274,7 +2274,7 @@ None.
 
 | Event name | Type       | Detail                                       |
 | :--------- | :--------- | :------------------------------------------- |
-| save       | dispatched | <code>any</code>                             |
+| save       | dispatched | <code>null</code>                            |
 | update     | dispatched | <code>{ prevValue: any; value: any; }</code> |
 
 ## `Modal`
@@ -2464,7 +2464,7 @@ None.
 | :--------- | :--------- | :------------------------------------------------------------------------------------------------------------- |
 | blur       | dispatched | <code>FocusEvent &#124; CustomEvent<FocusEvent></code>                                                         |
 | select     | dispatched | <code>{ selectedIds: MultiSelectItemId[]; selected: MultiSelectItem[]; unselected: MultiSelectItem[]; }</code> |
-| clear      | dispatched | <code>any</code>                                                                                               |
+| clear      | dispatched | <code>null</code>                                                                                              |
 | keydown    | forwarded  | --                                                                                                             |
 | keyup      | forwarded  | --                                                                                                             |
 | focus      | forwarded  | --                                                                                                             |
@@ -3193,21 +3193,21 @@ None.
 
 ### Events
 
-| Event name | Type       | Detail           |
-| :--------- | :--------- | :--------------- |
-| expand     | dispatched | <code>any</code> |
-| collapse   | dispatched | <code>any</code> |
-| click      | forwarded  | --               |
-| mouseover  | forwarded  | --               |
-| mouseenter | forwarded  | --               |
-| mouseleave | forwarded  | --               |
-| change     | forwarded  | --               |
-| input      | forwarded  | --               |
-| focus      | forwarded  | --               |
-| blur       | forwarded  | --               |
-| keydown    | forwarded  | --               |
-| keyup      | forwarded  | --               |
-| clear      | dispatched | --               |
+| Event name | Type       | Detail            |
+| :--------- | :--------- | :---------------- |
+| expand     | dispatched | <code>null</code> |
+| collapse   | dispatched | <code>null</code> |
+| click      | forwarded  | --                |
+| mouseover  | forwarded  | --                |
+| mouseenter | forwarded  | --                |
+| mouseleave | forwarded  | --                |
+| change     | forwarded  | --                |
+| input      | forwarded  | --                |
+| focus      | forwarded  | --                |
+| blur       | forwarded  | --                |
+| keydown    | forwarded  | --                |
+| keyup      | forwarded  | --                |
+| clear      | dispatched | --                |
 
 ## `SearchSkeleton`
 
@@ -3383,11 +3383,11 @@ None.
 
 ### Events
 
-| Event name    | Type       | Detail           |
-| :------------ | :--------- | :--------------- |
-| open          | dispatched | <code>any</code> |
-| close         | dispatched | <code>any</code> |
-| click:overlay | dispatched | <code>any</code> |
+| Event name    | Type       | Detail            |
+| :------------ | :--------- | :---------------- |
+| open          | dispatched | <code>null</code> |
+| close         | dispatched | <code>null</code> |
+| click:overlay | dispatched | <code>null</code> |
 
 ## `SideNavDivider`
 
@@ -4679,12 +4679,12 @@ None.
 
 ### Events
 
-| Event name | Type       | Detail           |
-| :--------- | :--------- | :--------------- |
-| open       | dispatched | <code>any</code> |
-| close      | dispatched | <code>any</code> |
-| click      | forwarded  | --               |
-| mousedown  | forwarded  | --               |
+| Event name | Type       | Detail            |
+| :--------- | :--------- | :---------------- |
+| open       | dispatched | <code>null</code> |
+| close      | dispatched | <code>null</code> |
+| click      | forwarded  | --                |
+| mousedown  | forwarded  | --                |
 
 ## `TooltipDefinition`
 
@@ -4708,15 +4708,15 @@ None.
 
 ### Events
 
-| Event name | Type       | Detail           |
-| :--------- | :--------- | :--------------- |
-| open       | dispatched | <code>any</code> |
-| close      | dispatched | <code>any</code> |
-| click      | forwarded  | --               |
-| mouseover  | forwarded  | --               |
-| mouseenter | forwarded  | --               |
-| mouseleave | forwarded  | --               |
-| focus      | forwarded  | --               |
+| Event name | Type       | Detail            |
+| :--------- | :--------- | :---------------- |
+| open       | dispatched | <code>null</code> |
+| close      | dispatched | <code>null</code> |
+| click      | forwarded  | --                |
+| mouseover  | forwarded  | --                |
+| mouseenter | forwarded  | --                |
+| mouseleave | forwarded  | --                |
+| focus      | forwarded  | --                |
 
 ## `TooltipFooter`
 

--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -4915,9 +4915,9 @@
         }
       ],
       "events": [
-        { "type": "dispatched", "name": "active", "detail": "any" },
-        { "type": "dispatched", "name": "inactive", "detail": "any" },
-        { "type": "dispatched", "name": "clear", "detail": "any" },
+        { "type": "dispatched", "name": "active", "detail": "null" },
+        { "type": "dispatched", "name": "inactive", "detail": "null" },
+        { "type": "dispatched", "name": "clear", "detail": "null" },
         {
           "type": "dispatched",
           "name": "select",
@@ -5115,8 +5115,8 @@
         { "name": "loading", "default": false, "slot_props": "{}" }
       ],
       "events": [
-        { "type": "dispatched", "name": "load", "detail": "any" },
-        { "type": "dispatched", "name": "error", "detail": "any" }
+        { "type": "dispatched", "name": "load", "detail": "null" },
+        { "type": "dispatched", "name": "error", "detail": "null" }
       ],
       "typedefs": [],
       "rest_props": { "type": "Element", "name": "img" }
@@ -5920,7 +5920,7 @@
       ],
       "slots": [],
       "events": [
-        { "type": "dispatched", "name": "save", "detail": "any" },
+        { "type": "dispatched", "name": "save", "detail": "null" },
         {
           "type": "dispatched",
           "name": "update",
@@ -6796,7 +6796,7 @@
           "name": "select",
           "detail": "{ selectedIds: MultiSelectItemId[]; selected: MultiSelectItem[]; unselected: MultiSelectItem[]; }"
         },
-        { "type": "dispatched", "name": "clear", "detail": "any" },
+        { "type": "dispatched", "name": "clear", "detail": "null" },
         { "type": "forwarded", "name": "keydown", "element": "input" },
         { "type": "forwarded", "name": "keyup", "element": "input" },
         { "type": "forwarded", "name": "focus", "element": "input" }
@@ -9261,8 +9261,8 @@
         }
       ],
       "events": [
-        { "type": "dispatched", "name": "expand", "detail": "any" },
-        { "type": "dispatched", "name": "collapse", "detail": "any" },
+        { "type": "dispatched", "name": "expand", "detail": "null" },
+        { "type": "dispatched", "name": "collapse", "detail": "null" },
         { "type": "forwarded", "name": "click", "element": "SearchSkeleton" },
         {
           "type": "forwarded",
@@ -9831,9 +9831,9 @@
       ],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [
-        { "type": "dispatched", "name": "open", "detail": "any" },
-        { "type": "dispatched", "name": "close", "detail": "any" },
-        { "type": "dispatched", "name": "click:overlay", "detail": "any" }
+        { "type": "dispatched", "name": "open", "detail": "null" },
+        { "type": "dispatched", "name": "close", "detail": "null" },
+        { "type": "dispatched", "name": "click:overlay", "detail": "null" }
       ],
       "typedefs": [],
       "rest_props": { "type": "Element", "name": "nav" }
@@ -13104,8 +13104,8 @@
         }
       ],
       "events": [
-        { "type": "dispatched", "name": "open", "detail": "any" },
-        { "type": "dispatched", "name": "close", "detail": "any" },
+        { "type": "dispatched", "name": "open", "detail": "null" },
+        { "type": "dispatched", "name": "close", "detail": "null" },
         { "type": "forwarded", "name": "click", "element": "div" },
         { "type": "forwarded", "name": "mousedown", "element": "div" }
       ],
@@ -13193,8 +13193,8 @@
         }
       ],
       "events": [
-        { "type": "dispatched", "name": "open", "detail": "any" },
-        { "type": "dispatched", "name": "close", "detail": "any" },
+        { "type": "dispatched", "name": "open", "detail": "null" },
+        { "type": "dispatched", "name": "close", "detail": "null" },
         { "type": "forwarded", "name": "click", "element": "button" },
         { "type": "forwarded", "name": "mouseover", "element": "button" },
         { "type": "forwarded", "name": "mouseenter", "element": "button" },

--- a/src/ImageLoader/ImageLoader.svelte
+++ b/src/ImageLoader/ImageLoader.svelte
@@ -1,7 +1,7 @@
 <script>
   /**
-   * @event {any} load
-   * @event {any} error
+   * @event {null} load
+   * @event {null} error
    */
 
   /**

--- a/src/LocalStorage/LocalStorage.svelte
+++ b/src/LocalStorage/LocalStorage.svelte
@@ -1,6 +1,6 @@
 <script>
   /**
-   * @event {any} save
+   * @event {null} save
    * @event {{ prevValue: any; value: any; }} update
    */
 

--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -8,7 +8,7 @@
    * @typedef {string} MultiSelectItemText
    * @typedef {{ id: MultiSelectItemId; text: MultiSelectItemText; }} MultiSelectItem
    * @event {{ selectedIds: MultiSelectItemId[]; selected: MultiSelectItem[]; unselected: MultiSelectItem[]; }} select
-   * @event {any} clear
+   * @event {null} clear
    */
 
   /**

--- a/src/Search/Search.svelte
+++ b/src/Search/Search.svelte
@@ -1,7 +1,7 @@
 <script>
   /**
-   * @event {any} expand
-   * @event {any} collapse
+   * @event {null} expand
+   * @event {null} collapse
    */
 
   /**

--- a/src/Tooltip/Tooltip.svelte
+++ b/src/Tooltip/Tooltip.svelte
@@ -1,7 +1,7 @@
 <script>
   /**
-   * @event {any} open
-   * @event {any} close
+   * @event {null} open
+   * @event {null} close
    */
 
   /**

--- a/src/TooltipDefinition/TooltipDefinition.svelte
+++ b/src/TooltipDefinition/TooltipDefinition.svelte
@@ -1,7 +1,7 @@
 <script>
   /**
-   * @event {any} open
-   * @event {any} close
+   * @event {null} open
+   * @event {null} close
    */
 
   /** Specify the tooltip text */

--- a/src/UIShell/HeaderSearch.svelte
+++ b/src/UIShell/HeaderSearch.svelte
@@ -1,9 +1,9 @@
 <script>
   /**
    * @typedef {{ href: string; text: string; description?: string; }} HeaderSearchResult
-   * @event {any} active
-   * @event {any} inactive
-   * @event {any} clear
+   * @event {null} active
+   * @event {null} inactive
+   * @event {null} clear
    * @event {{ value: string; selectedResultIndex: number; selectedResult: HeaderSearchResult }} select
    * @slot {{ result: HeaderSearchResult; index: number }}
    */

--- a/src/UIShell/SideNav/SideNav.svelte
+++ b/src/UIShell/SideNav/SideNav.svelte
@@ -1,8 +1,8 @@
 <script>
   /**
-   * @event {any} open
-   * @event {any} close
-   * @event {any} click:overlay
+   * @event {null} open
+   * @event {null} close
+   * @event {null} click:overlay
    */
 
   /** Set to `true` to use the fixed variant */

--- a/tests/ImageLoader.test.svelte
+++ b/tests/ImageLoader.test.svelte
@@ -13,6 +13,10 @@
   fadeIn
   ratio="16x9"
   src=""
-  on:load="{() => {}}"
-  on:error="{() => {}}"
+  on:load="{(e) => {
+    console.log(e.detail); // null
+  }}"
+  on:error="{(e) => {
+    console.log(e.detail); // null
+  }}"
 />

--- a/types/ImageLoader/ImageLoader.svelte.d.ts
+++ b/types/ImageLoader/ImageLoader.svelte.d.ts
@@ -49,7 +49,7 @@ export interface ImageLoaderProps
 
 export default class ImageLoader extends SvelteComponentTyped<
   ImageLoaderProps,
-  { load: CustomEvent<any>; error: CustomEvent<any> },
+  { load: CustomEvent<null>; error: CustomEvent<null> },
   { error: {}; loading: {} }
 > {
   /**

--- a/types/LocalStorage/LocalStorage.svelte.d.ts
+++ b/types/LocalStorage/LocalStorage.svelte.d.ts
@@ -18,7 +18,7 @@ export interface LocalStorageProps {
 export default class LocalStorage extends SvelteComponentTyped<
   LocalStorageProps,
   {
-    save: CustomEvent<any>;
+    save: CustomEvent<null>;
     update: CustomEvent<{ prevValue: any; value: any }>;
   },
   {}

--- a/types/MultiSelect/MultiSelect.svelte.d.ts
+++ b/types/MultiSelect/MultiSelect.svelte.d.ts
@@ -228,7 +228,7 @@ export default class MultiSelect extends SvelteComponentTyped<
       selected: MultiSelectItem[];
       unselected: MultiSelectItem[];
     }>;
-    clear: CustomEvent<any>;
+    clear: CustomEvent<null>;
     keydown: WindowEventMap["keydown"];
     keyup: WindowEventMap["keyup"];
     focus: WindowEventMap["focus"];

--- a/types/Search/Search.svelte.d.ts
+++ b/types/Search/Search.svelte.d.ts
@@ -113,8 +113,8 @@ export interface SearchProps {
 export default class Search extends SvelteComponentTyped<
   SearchProps,
   {
-    expand: CustomEvent<any>;
-    collapse: CustomEvent<any>;
+    expand: CustomEvent<null>;
+    collapse: CustomEvent<null>;
     click: WindowEventMap["click"];
     mouseover: WindowEventMap["mouseover"];
     mouseenter: WindowEventMap["mouseenter"];

--- a/types/Tooltip/Tooltip.svelte.d.ts
+++ b/types/Tooltip/Tooltip.svelte.d.ts
@@ -92,8 +92,8 @@ export interface TooltipProps
 export default class Tooltip extends SvelteComponentTyped<
   TooltipProps,
   {
-    open: CustomEvent<any>;
-    close: CustomEvent<any>;
+    open: CustomEvent<null>;
+    close: CustomEvent<null>;
     click: WindowEventMap["click"];
     mousedown: WindowEventMap["mousedown"];
   },

--- a/types/TooltipDefinition/TooltipDefinition.svelte.d.ts
+++ b/types/TooltipDefinition/TooltipDefinition.svelte.d.ts
@@ -43,8 +43,8 @@ export interface TooltipDefinitionProps
 export default class TooltipDefinition extends SvelteComponentTyped<
   TooltipDefinitionProps,
   {
-    open: CustomEvent<any>;
-    close: CustomEvent<any>;
+    open: CustomEvent<null>;
+    close: CustomEvent<null>;
     click: WindowEventMap["click"];
     mouseover: WindowEventMap["mouseover"];
     mouseenter: WindowEventMap["mouseenter"];

--- a/types/UIShell/HeaderSearch.svelte.d.ts
+++ b/types/UIShell/HeaderSearch.svelte.d.ts
@@ -43,9 +43,9 @@ export interface HeaderSearchProps
 export default class HeaderSearch extends SvelteComponentTyped<
   HeaderSearchProps,
   {
-    active: CustomEvent<any>;
-    inactive: CustomEvent<any>;
-    clear: CustomEvent<any>;
+    active: CustomEvent<null>;
+    inactive: CustomEvent<null>;
+    clear: CustomEvent<null>;
     select: CustomEvent<{
       value: string;
       selectedResultIndex: number;

--- a/types/UIShell/SideNav/SideNav.svelte.d.ts
+++ b/types/UIShell/SideNav/SideNav.svelte.d.ts
@@ -43,9 +43,9 @@ export interface SideNavProps
 export default class SideNav extends SvelteComponentTyped<
   SideNavProps,
   {
-    open: CustomEvent<any>;
-    close: CustomEvent<any>;
-    ["click:overlay"]: CustomEvent<any>;
+    open: CustomEvent<null>;
+    close: CustomEvent<null>;
+    ["click:overlay"]: CustomEvent<null>;
   },
   { default: {} }
 > {}


### PR DESCRIPTION
Currently, dispatched events without `e.detail` have a type of `any`.

We can be more specific as a `CustomEvent` detail value defaults to `null`.