### PR TITLE
feat(file-uploader-drop-container): rework `FileUploaderDropContainer`

### DIFF
--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -1328,18 +1328,19 @@ None.
 
 ### Props
 
-| Prop name     | Kind             | Reactive | Type                                       | Default value                                    | Description                                                                                                  |
-| :------------ | :--------------- | :------- | :----------------------------------------- | ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------ |
-| ref           | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code>  | <code>null</code>                                | Obtain a reference to the input HTML element                                                                 |
-| accept        | <code>let</code> | No       | <code>string[]</code>                      | <code>[]</code>                                  | Specify the accepted file types                                                                              |
-| multiple      | <code>let</code> | No       | <code>boolean</code>                       | <code>false</code>                               | Set to `true` to allow multiple files                                                                        |
-| validateFiles | <code>let</code> | No       | <code>(files: FileList) => FileList</code> | <code>(files) => files</code>                    | Override the default behavior of validating uploaded files<br />The default behavior does not validate files |
-| labelText     | <code>let</code> | No       | <code>string</code>                        | <code>"Add file"</code>                          | Specify the label text                                                                                       |
-| role          | <code>let</code> | No       | <code>string</code>                        | <code>"button"</code>                            | Specify the `role` attribute of the drop container                                                           |
-| disabled      | <code>let</code> | No       | <code>boolean</code>                       | <code>false</code>                               | Set to `true` to disable the input                                                                           |
-| tabindex      | <code>let</code> | No       | <code>string</code>                        | <code>"0"</code>                                 | Specify `tabindex` attribute                                                                                 |
-| id            | <code>let</code> | No       | <code>string</code>                        | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the input element                                                                              |
-| name          | <code>let</code> | No       | <code>string</code>                        | <code>""</code>                                  | Specify a name attribute for the input                                                                       |
+| Prop name     | Kind             | Reactive | Type                                      | Default value                                    | Description                                                                                                  |
+| :------------ | :--------------- | :------- | :---------------------------------------- | ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------ |
+| ref           | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code> | <code>null</code>                                | Obtain a reference to the input HTML element                                                                 |
+| files         | <code>let</code> | Yes      | <code>File[]</code>                       | <code>[]</code>                                  | Obtain a reference to the uploaded files                                                                     |
+| accept        | <code>let</code> | No       | <code>string[]</code>                     | <code>[]</code>                                  | Specify the accepted file types                                                                              |
+| multiple      | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to allow multiple files                                                                        |
+| validateFiles | <code>let</code> | No       | <code>(files: File) => File</code>        | <code>(files) => files</code>                    | Override the default behavior of validating uploaded files<br />The default behavior does not validate files |
+| labelText     | <code>let</code> | No       | <code>string</code>                       | <code>"Add file"</code>                          | Specify the label text                                                                                       |
+| role          | <code>let</code> | No       | <code>string</code>                       | <code>"button"</code>                            | Specify the `role` attribute of the drop container                                                           |
+| disabled      | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to disable the input                                                                           |
+| tabindex      | <code>let</code> | No       | <code>string</code>                       | <code>"0"</code>                                 | Specify `tabindex` attribute                                                                                 |
+| id            | <code>let</code> | No       | <code>string</code>                       | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the input element                                                                              |
+| name          | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Specify a name attribute for the input                                                                       |
 
 ### Slots
 
@@ -1349,15 +1350,15 @@ None.
 
 ### Events
 
-| Event name | Type       | Detail                |
-| :--------- | :--------- | :-------------------- |
-| add        | dispatched | <code>FileList</code> |
-| dragover   | forwarded  | --                    |
-| dragleave  | forwarded  | --                    |
-| drop       | forwarded  | --                    |
-| keydown    | forwarded  | --                    |
-| change     | forwarded  | --                    |
-| click      | forwarded  | --                    |
+| Event name | Type       | Detail              |
+| :--------- | :--------- | :------------------ |
+| add        | dispatched | <code>File[]</code> |
+| change     | dispatched | <code>File[]</code> |
+| dragover   | forwarded  | --                  |
+| dragleave  | forwarded  | --                  |
+| drop       | forwarded  | --                  |
+| keydown    | forwarded  | --                  |
+| click      | forwarded  | --                  |
 
 ## `FileUploaderItem`
 

--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -3750,6 +3750,17 @@
           "reactive": false
         },
         {
+          "name": "files",
+          "kind": "let",
+          "description": "Obtain a reference to the uploaded files",
+          "type": "File[]",
+          "value": "[]",
+          "isFunction": false,
+          "isFunctionDeclaration": false,
+          "constant": false,
+          "reactive": true
+        },
+        {
           "name": "multiple",
           "kind": "let",
           "description": "Set to `true` to allow multiple files",
@@ -3764,7 +3775,7 @@
           "name": "validateFiles",
           "kind": "let",
           "description": "Override the default behavior of validating uploaded files\nThe default behavior does not validate files",
-          "type": "(files: FileList) => FileList",
+          "type": "(files: File) => File",
           "value": "(files) => files",
           "isFunction": true,
           "isFunctionDeclaration": false,
@@ -3858,12 +3869,12 @@
         }
       ],
       "events": [
-        { "type": "dispatched", "name": "add", "detail": "FileList" },
+        { "type": "dispatched", "name": "add", "detail": "File[]" },
+        { "type": "dispatched", "name": "change", "detail": "File[]" },
         { "type": "forwarded", "name": "dragover", "element": "div" },
         { "type": "forwarded", "name": "dragleave", "element": "div" },
         { "type": "forwarded", "name": "drop", "element": "div" },
         { "type": "forwarded", "name": "keydown", "element": "label" },
-        { "type": "forwarded", "name": "change", "element": "input" },
         { "type": "forwarded", "name": "click", "element": "input" }
       ],
       "typedefs": [],

--- a/src/FileUploader/FileUploaderDropContainer.svelte
+++ b/src/FileUploader/FileUploaderDropContainer.svelte
@@ -9,6 +9,12 @@
    */
   export let accept = [];
 
+  /**
+   * Obtain a reference to the uploaded files
+   * @type {File[]}
+   */
+  export let files = [];
+
   /** Set to `true` to allow multiple files */
   export let multiple = false;
 
@@ -68,7 +74,8 @@
   on:drop|preventDefault|stopPropagation="{({ dataTransfer }) => {
     if (!disabled) {
       over = false;
-      dispatch('add', validateFiles([...dataTransfer.files]));
+      files = validateFiles([...dataTransfer.files]);
+      dispatch('add', files);
     }
   }}"
 >
@@ -106,7 +113,8 @@
     class:bx--file-input="{true}"
     on:change
     on:change="{({ target }) => {
-      dispatch('add', validateFiles([...target.files]));
+      files = validateFiles([...target.files]);
+      dispatch('add', files);
     }}"
     on:click
     on:click="{({ target }) => {

--- a/src/FileUploader/FileUploaderDropContainer.svelte
+++ b/src/FileUploader/FileUploaderDropContainer.svelte
@@ -1,6 +1,7 @@
 <script>
   /**
-   * @event {File} add
+   * @event {File[]} add
+   * @event {File[]} change
    */
 
   /**
@@ -76,6 +77,7 @@
       over = false;
       files = validateFiles([...dataTransfer.files]);
       dispatch('add', files);
+      dispatch('change', files);
     }
   }}"
 >
@@ -111,10 +113,10 @@
     name="{name}"
     multiple="{multiple}"
     class:bx--file-input="{true}"
-    on:change
     on:change="{({ target }) => {
       files = validateFiles([...target.files]);
       dispatch('add', files);
+      dispatch('change', files);
     }}"
     on:click
     on:click="{({ target }) => {

--- a/src/FileUploader/FileUploaderDropContainer.svelte
+++ b/src/FileUploader/FileUploaderDropContainer.svelte
@@ -1,6 +1,6 @@
 <script>
   /**
-   * @event {FileList} add
+   * @event {File} add
    */
 
   /**
@@ -15,7 +15,7 @@
   /**
    * Override the default behavior of validating uploaded files
    * The default behavior does not validate files
-   * @type {(files: FileList) => FileList}
+   * @type {(files: File) => File}
    */
   export let validateFiles = (files) => files;
 
@@ -68,7 +68,7 @@
   on:drop|preventDefault|stopPropagation="{({ dataTransfer }) => {
     if (!disabled) {
       over = false;
-      dispatch('add', validateFiles(dataTransfer.files));
+      dispatch('add', validateFiles([...dataTransfer.files]));
     }
   }}"
 >
@@ -106,7 +106,7 @@
     class:bx--file-input="{true}"
     on:change
     on:change="{({ target }) => {
-      dispatch('add', validateFiles(target.files));
+      dispatch('add', validateFiles([...target.files]));
     }}"
     on:click
     on:click="{({ target }) => {

--- a/types/FileUploader/FileUploaderDropContainer.svelte.d.ts
+++ b/types/FileUploader/FileUploaderDropContainer.svelte.d.ts
@@ -10,6 +10,12 @@ export interface FileUploaderDropContainerProps
   accept?: string[];
 
   /**
+   * Obtain a reference to the uploaded files
+   * @default []
+   */
+  files?: File[];
+
+  /**
    * Set to `true` to allow multiple files
    * @default false
    */
@@ -20,7 +26,7 @@ export interface FileUploaderDropContainerProps
    * The default behavior does not validate files
    * @default (files) => files
    */
-  validateFiles?: (files: FileList) => FileList;
+  validateFiles?: (files: File) => File;
 
   /**
    * Specify the label text
@@ -68,12 +74,12 @@ export interface FileUploaderDropContainerProps
 export default class FileUploaderDropContainer extends SvelteComponentTyped<
   FileUploaderDropContainerProps,
   {
-    add: CustomEvent<FileList>;
+    add: CustomEvent<File[]>;
+    change: CustomEvent<File[]>;
     dragover: WindowEventMap["dragover"];
     dragleave: WindowEventMap["dragleave"];
     drop: WindowEventMap["drop"];
     keydown: WindowEventMap["keydown"];
-    change: WindowEventMap["change"];
     click: WindowEventMap["click"];
   },
   { labelText: {} }


### PR DESCRIPTION
**Features**

- convert `FileList` to `File[]` to be consistent with `FileUploader` and `FileUploaderButton`
- add `files` prop for two-way binding
- dispatch instead of forward the `change` event (detail signature: `File[]`)