### PR TITLE
fix(date-picker): update calendar if options change

### DIFF
--- a/src/DatePicker/DatePicker.svelte
+++ b/src/DatePicker/DatePicker.svelte
@@ -139,10 +139,24 @@
   });
 
   async function initCalendar(options) {
-    calendar?.destroy();
-    calendar = null;
+    if (calendar) {
+      calendar.set("minDate", minDate);
+      calendar.set("maxDate", maxDate);
+      calendar.set("locale", locale);
+      calendar.set("dateFormat", dateFormat);
+      Object.entries(flatpickrProps).forEach(([option, value]) => {
+        calendar.set(options, value);
+      });
+      return;
+    }
+
     calendar = await createCalendar({
-      options,
+      options: {
+        ...options,
+        appendTo: datePickerRef,
+        defaultDate: $inputValue,
+        mode: $mode,
+      },
       base: inputRef,
       input: inputRefTo,
       dispatch: (event) => {
@@ -196,17 +210,15 @@
   $: valueFrom = $inputValueFrom;
   $: inputValueTo.set(valueTo);
   $: valueTo = $inputValueTo;
-  $: if ($hasCalendar && inputRef)
+  $: if ($hasCalendar && inputRef) {
     initCalendar({
-      appendTo: datePickerRef,
       dateFormat,
-      defaultDate: $inputValue,
       locale,
       maxDate,
       minDate,
-      mode: $mode,
       ...flatpickrProps,
     });
+  }
 </script>
 
 <svelte:window

--- a/src/DatePicker/DatePicker.svelte
+++ b/src/DatePicker/DatePicker.svelte
@@ -138,18 +138,11 @@
     },
   });
 
-  async function initCalendar() {
+  async function initCalendar(options) {
+    calendar?.destroy();
+    calendar = null;
     calendar = await createCalendar({
-      options: {
-        appendTo: datePickerRef,
-        dateFormat,
-        defaultDate: $inputValue,
-        locale,
-        maxDate,
-        minDate,
-        mode: $mode,
-        ...flatpickrProps,
-      },
+      options,
       base: inputRef,
       input: inputRefTo,
       dispatch: (event) => {
@@ -203,7 +196,17 @@
   $: valueFrom = $inputValueFrom;
   $: inputValueTo.set(valueTo);
   $: valueTo = $inputValueTo;
-  $: if ($hasCalendar && !calendar && inputRef) initCalendar();
+  $: if ($hasCalendar && inputRef)
+    initCalendar({
+      appendTo: datePickerRef,
+      dateFormat,
+      defaultDate: $inputValue,
+      locale,
+      maxDate,
+      minDate,
+      mode: $mode,
+      ...flatpickrProps,
+    });
 </script>
 
 <svelte:window


### PR DESCRIPTION
Fixes #1127

Currently, the `DatePicker` calendar will only initialize once. It should be reactive and initialize if any consumer-provided options change.

Updated the implementation to use `calendar.set` API and only trigger the update logic if any option except for `appendTo`, `defaultDate`, or `mode` changes.