### PR TITLE
perf: use direct imports where possible

### DIFF
--- a/src/DataTable/DataTable.svelte
+++ b/src/DataTable/DataTable.svelte
@@ -109,8 +109,8 @@
   import { createEventDispatcher, setContext } from "svelte";
   import { writable, derived } from "svelte/store";
   import ChevronRight16 from "../icons/ChevronRight16.svelte";
-  import { InlineCheckbox } from "../Checkbox";
-  import { RadioButton } from "../RadioButton";
+  import InlineCheckbox from "../Checkbox/InlineCheckbox.svelte";
+  import RadioButton from "../RadioButton/RadioButton.svelte";
   import Table from "./Table.svelte";
   import TableBody from "./TableBody.svelte";
   import TableCell from "./TableCell.svelte";

--- a/src/DataTable/ToolbarBatchActions.svelte
+++ b/src/DataTable/ToolbarBatchActions.svelte
@@ -7,7 +7,7 @@
     `${totalSelected} item${totalSelected === 1 ? "" : "s"} selected`;
 
   import { onMount, getContext } from "svelte";
-  import { Button } from "../Button";
+  import Button from "../Button/Button.svelte";
 
   let batchSelectedIds = [];
 

--- a/src/DataTable/ToolbarMenu.svelte
+++ b/src/DataTable/ToolbarMenu.svelte
@@ -3,7 +3,7 @@
 
   import { getContext } from "svelte";
   import Settings16 from "../icons/Settings16.svelte";
-  import { OverflowMenu } from "../OverflowMenu";
+  import OverflowMenu from "../OverflowMenu/OverflowMenu.svelte";
 
   const ctx = getContext("Toolbar");
 

--- a/src/DataTable/ToolbarMenuItem.svelte
+++ b/src/DataTable/ToolbarMenuItem.svelte
@@ -1,7 +1,7 @@
 <script>
   /** @extends {"../OverflowMenu/OverflowMenuItem.svelte"} OverflowMenuItemProps */
 
-  import { OverflowMenuItem } from "../OverflowMenu";
+  import OverflowMenuItem from "../OverflowMenu/OverflowMenuItem.svelte";
 </script>
 
 <OverflowMenuItem {...$$restProps} on:click on:keydown>

--- a/src/FileUploader/FileUploaderSkeleton.svelte
+++ b/src/FileUploader/FileUploaderSkeleton.svelte
@@ -1,6 +1,6 @@
 <script>
-  import { ButtonSkeleton } from "../Button";
-  import { SkeletonText } from "../SkeletonText";
+  import ButtonSkeleton from "../Button/ButtonSkeleton.svelte";
+  import SkeletonText from "../SkeletonText/SkeletonText.svelte";
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->

--- a/src/FileUploader/Filename.svelte
+++ b/src/FileUploader/Filename.svelte
@@ -14,7 +14,7 @@
   import Close16 from "../icons/Close16.svelte";
   import CheckmarkFilled16 from "../icons/CheckmarkFilled16.svelte";
   import WarningFilled16 from "../icons/WarningFilled16.svelte";
-  import { Loading } from "../Loading";
+  import Loading from "../Loading/Loading.svelte";
 </script>
 
 {#if status === "uploading"}


### PR DESCRIPTION
This refactors imports to use the direct path where possible.

```diff
- import { InlineCheckbox } from "../Checkbox";
+ import InlineCheckbox from "../Checkbox/InlineCheckbox.svelte";
```

This offers a small performance improvement during development (unused imports should still be tree-shaken by modern bundlers). Importing a components from the JS file will also import other, unnecessary components.

Run "yarn build:lib" to ensure the ESM/UMD bundles can be correctly generated.