### PR TITLE
refactor: remove Icon usage

### DIFF
--- a/src/UIShell/GlobalHeader/HeaderAction.svelte
+++ b/src/UIShell/GlobalHeader/HeaderAction.svelte
@@ -39,7 +39,6 @@
   import { slide } from "svelte/transition";
   import Close20 from "../../icons/Close20.svelte";
   import AppSwitcher20 from "../../icons/AppSwitcher20.svelte";
-  import Icon from "../../Icon/Icon.svelte";
 
   const dispatch = createEventDispatcher();
 
@@ -69,8 +68,11 @@
       dispatch(isOpen ? 'open' : 'close');
     }}"
   >
-    <Icon render="{icon}" style="{isOpen ? 'display: none' : ''}" />
-    <Icon render="{closeIcon}" style="{!isOpen ? 'display: none' : ''}" />
+    <svelte:component this="{icon}" style="{isOpen ? 'display: none' : ''}" />
+    <svelte:component
+      this="{closeIcon}"
+      style="{!isOpen ? 'display: none' : ''}"
+    />
     <slot name="text">
       {#if text}<span>{text}</span>{/if}
     </slot>

--- a/src/UIShell/GlobalHeader/HeaderActionLink.svelte
+++ b/src/UIShell/GlobalHeader/HeaderActionLink.svelte
@@ -16,8 +16,6 @@
 
   /** Obtain a reference to the HTML anchor element */
   export let ref = null;
-
-  import Icon from "../../Icon/Icon.svelte";
 </script>
 
 <a
@@ -29,7 +27,7 @@
   rel="{$$restProps.target === '_blank' ? 'noopener noreferrer' : undefined}"
   {...$$restProps}
 >
-  <Icon render="{icon}" />
+  <svelte:component this="{icon}" />
 </a>
 
 <style>


### PR DESCRIPTION
The `Icon` component is deprecated.

This replaces `Icon` usage in `HeaderAction` components with the native `svelte:component`.