### PR TITLE
fix(header-action-link): align icon with `HeaderAction`

### DIFF
--- a/src/UIShell/GlobalHeader/HeaderAction.svelte
+++ b/src/UIShell/GlobalHeader/HeaderAction.svelte
@@ -54,43 +54,41 @@
   }}"
 />
 
-<div>
-  <button
-    bind:this="{ref}"
-    type="button"
-    class:bx--header__action="{true}"
-    class:bx--header__action--active="{isOpen}"
-    class:action-text="{text}"
-    {...$$restProps}
-    on:click
-    on:click="{() => {
-      isOpen = !isOpen;
-      dispatch(isOpen ? 'open' : 'close');
+<button
+  bind:this="{ref}"
+  type="button"
+  class:bx--header__action="{true}"
+  class:bx--header__action--active="{isOpen}"
+  class:action-text="{text}"
+  {...$$restProps}
+  on:click
+  on:click="{() => {
+    isOpen = !isOpen;
+    dispatch(isOpen ? 'open' : 'close');
+  }}"
+>
+  <svelte:component this="{icon}" style="{isOpen ? 'display: none' : ''}" />
+  <svelte:component
+    this="{closeIcon}"
+    style="{!isOpen ? 'display: none' : ''}"
+  />
+  <slot name="text">
+    {#if text}<span>{text}</span>{/if}
+  </slot>
+</button>
+{#if isOpen}
+  <div
+    bind:this="{refPanel}"
+    class:bx--header-panel="{true}"
+    class:bx--header-panel--expanded="{true}"
+    transition:slide="{{
+      ...transition,
+      duration: transition === false ? 0 : transition.duration,
     }}"
   >
-    <svelte:component this="{icon}" style="{isOpen ? 'display: none' : ''}" />
-    <svelte:component
-      this="{closeIcon}"
-      style="{!isOpen ? 'display: none' : ''}"
-    />
-    <slot name="text">
-      {#if text}<span>{text}</span>{/if}
-    </slot>
-  </button>
-  {#if isOpen}
-    <div
-      bind:this="{refPanel}"
-      class:bx--header-panel="{true}"
-      class:bx--header-panel--expanded="{true}"
-      transition:slide="{{
-        ...transition,
-        duration: transition === false ? 0 : transition.duration,
-      }}"
-    >
-      <slot />
-    </div>
-  {/if}
-</div>
+    <slot />
+  </div>
+{/if}
 
 <style>
   .action-text {

--- a/src/UIShell/GlobalHeader/HeaderActionLink.svelte
+++ b/src/UIShell/GlobalHeader/HeaderActionLink.svelte
@@ -22,7 +22,6 @@
   bind:this="{ref}"
   class:bx--header__action="{true}"
   class:bx--header__action--active="{linkIsActive}"
-  class:action-link="{true}"
   href="{href}"
   rel="{$$restProps.target === '_blank' ? 'noopener noreferrer' : undefined}"
   {...$$restProps}
@@ -31,11 +30,11 @@
 </a>
 
 <style>
-  .action-link {
-    text-align: center;
+  .bx--header__action {
+    display: flex;
     align-items: center;
-    vertical-align: middle;
     justify-content: center;
-    padding-top: 10px;
+    /** Hot fix to align icon with `HeaderAction` */
+    padding-bottom: 2px;
   }
 </style>


### PR DESCRIPTION
The icon in `HeaderActionLink` is misaligned with the icon in `HeaderAction`.

This is apparent when using the same icon (in this instance, `LogoGithub20`).

<img width="258" alt="Screen Shot 2022-03-12 at 1 53 35 PM" src="https://user-images.githubusercontent.com/10718366/158036797-7665520f-718a-4694-ac5c-039725bec0f6.png">
