### PR TITLE
breaking(header-action): use `SlideParams` to type `transition` prop

### DIFF
--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -1608,26 +1608,16 @@ None.
 
 ## `HeaderAction`
 
-### Types
-
-```ts
-export interface HeaderActionSlideTransition {
-  delay?: number;
-  duration?: number;
-  easing?: (t: number) => number;
-}
-```
-
 ### Props
 
-| Prop name  | Kind             | Reactive | Type                                                  | Default value                  | Description                                                                                                   |
-| :--------- | :--------------- | :------- | :---------------------------------------------------- | ------------------------------ | ------------------------------------------------------------------------------------------------------------- |
-| ref        | <code>let</code> | Yes      | <code>null &#124; HTMLButtonElement</code>            | <code>null</code>              | Obtain a reference to the button HTML element                                                                 |
-| isOpen     | <code>let</code> | Yes      | <code>boolean</code>                                  | <code>false</code>             | Set to `true` to open the panel                                                                               |
-| icon       | <code>let</code> | No       | <code>typeof import("svelte").SvelteComponent</code>  | <code>undefined</code>         | Specify the icon to render                                                                                    |
-| closeIcon  | <code>let</code> | No       | <code>typeof import("svelte").SvelteComponent</code>  | <code>undefined</code>         | Specify the icon to render when the action panel is open                                                      |
-| text       | <code>let</code> | No       | <code>string</code>                                   | <code>undefined</code>         | Specify the text<br />Alternatively, use the named slot "text" (e.g., &lt;div slot="text"&gt;...&lt;/div&gt;) |
-| transition | <code>let</code> | No       | <code>false &#124; HeaderActionSlideTransition</code> | <code>{ duration: 200 }</code> | Customize the panel transition (i.e., `transition:slide`)<br />Set to `false` to disable the transition       |
+| Prop name  | Kind             | Reactive | Type                                                              | Default value                  | Description                                                                                                   |
+| :--------- | :--------------- | :------- | :---------------------------------------------------------------- | ------------------------------ | ------------------------------------------------------------------------------------------------------------- |
+| ref        | <code>let</code> | Yes      | <code>null &#124; HTMLButtonElement</code>                        | <code>null</code>              | Obtain a reference to the button HTML element                                                                 |
+| isOpen     | <code>let</code> | Yes      | <code>boolean</code>                                              | <code>false</code>             | Set to `true` to open the panel                                                                               |
+| icon       | <code>let</code> | No       | <code>typeof import("svelte").SvelteComponent</code>              | <code>undefined</code>         | Specify the icon to render                                                                                    |
+| closeIcon  | <code>let</code> | No       | <code>typeof import("svelte").SvelteComponent</code>              | <code>undefined</code>         | Specify the icon to render when the action panel is open                                                      |
+| text       | <code>let</code> | No       | <code>string</code>                                               | <code>undefined</code>         | Specify the text<br />Alternatively, use the named slot "text" (e.g., &lt;div slot="text"&gt;...&lt;/div&gt;) |
+| transition | <code>let</code> | No       | <code>false &#124; import("svelte/transition").SlideParams</code> | <code>{ duration: 200 }</code> | Customize the panel transition (i.e., `transition:slide`).<br />Set to `false` to disable the transition      |
 
 ### Slots
 

--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -4517,8 +4517,8 @@
         {
           "name": "transition",
           "kind": "let",
-          "description": "Customize the panel transition (i.e., `transition:slide`)\nSet to `false` to disable the transition",
-          "type": "false | HeaderActionSlideTransition",
+          "description": "Customize the panel transition (i.e., `transition:slide`).\nSet to `false` to disable the transition",
+          "type": "false | import(\"svelte/transition\").SlideParams",
           "value": "{ duration: 200 }",
           "isFunction": false,
           "isFunctionDeclaration": false,
@@ -4539,13 +4539,7 @@
         { "type": "forwarded", "name": "click", "element": "button" },
         { "type": "dispatched", "name": "close" }
       ],
-      "typedefs": [
-        {
-          "type": "{ delay?: number; duration?: number; easing?: (t: number) => number; }",
-          "name": "HeaderActionSlideTransition",
-          "ts": "interface HeaderActionSlideTransition { delay?: number; duration?: number; easing?: (t: number) => number; }"
-        }
-      ],
+      "typedefs": [],
       "rest_props": { "type": "Element", "name": "button" }
     },
     {

--- a/src/UIShell/GlobalHeader/HeaderAction.svelte
+++ b/src/UIShell/GlobalHeader/HeaderAction.svelte
@@ -1,8 +1,4 @@
 <script>
-  /**
-   * @typedef {{ delay?: number; duration?: number; easing?: (t: number) => number; }} HeaderActionSlideTransition
-   */
-
   /** Set to `true` to open the panel */
   export let isOpen = false;
 
@@ -29,9 +25,9 @@
   export let ref = null;
 
   /**
-   * Customize the panel transition (i.e., `transition:slide`)
+   * Customize the panel transition (i.e., `transition:slide`).
    * Set to `false` to disable the transition
-   * @type {false | HeaderActionSlideTransition}
+   * @type {false | import("svelte/transition").SlideParams}
    */
   export let transition = { duration: 200 };
 

--- a/types/UIShell/GlobalHeader/HeaderAction.svelte.d.ts
+++ b/types/UIShell/GlobalHeader/HeaderAction.svelte.d.ts
@@ -1,12 +1,6 @@
 /// <reference types="svelte" />
 import { SvelteComponentTyped } from "svelte";
 
-export interface HeaderActionSlideTransition {
-  delay?: number;
-  duration?: number;
-  easing?: (t: number) => number;
-}
-
 export interface HeaderActionProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["button"]> {
   /**
@@ -41,11 +35,11 @@ export interface HeaderActionProps
   ref?: null | HTMLButtonElement;
 
   /**
-   * Customize the panel transition (i.e., `transition:slide`)
+   * Customize the panel transition (i.e., `transition:slide`).
    * Set to `false` to disable the transition
    * @default { duration: 200 }
    */
-  transition?: false | HeaderActionSlideTransition;
+  transition?: false | import("svelte/transition").SlideParams;
 }
 
 export default class HeaderAction extends SvelteComponentTyped<


### PR DESCRIPTION
Instead of manually typing the Svelte slide transition prop, we can reuse `SlideParams` from `svelte/transition`.