### PR TITLE
refactor(text-area): use native binding for `value` prop

### DIFF
--- a/src/TextArea/TextArea.svelte
+++ b/src/TextArea/TextArea.svelte
@@ -94,6 +94,7 @@
     {/if}
     <textarea
       bind:this="{ref}"
+      bind:value
       aria-invalid="{invalid || undefined}"
       aria-describedby="{invalid ? errorId : undefined}"
       disabled="{disabled}"
@@ -101,7 +102,6 @@
       name="{name}"
       cols="{cols}"
       rows="{rows}"
-      value="{value ?? ''}"
       placeholder="{placeholder}"
       readonly="{readonly}"
       class:bx--text-area="{true}"
@@ -111,9 +111,6 @@
       {...$$restProps}
       on:change
       on:input
-      on:input="{({ target }) => {
-        value = target.value;
-      }}"
       on:keydown
       on:keyup
       on:focus


### PR DESCRIPTION
Tested to make sure #935 didn't regress.

As expected, setting `value` to undefined will empty the `textarea` value, not set it to be "undefined."

```svelte
<script>
  import { Button, TextArea } from "carbon-components-svelte";

  let value;
</script>

<TextArea bind:value />

<Button on:click={() => (value = undefined)}>Click</Button>
```