### PR TITLE
breaking(form): do not prevent default behavior on submit event

### DIFF
--- a/docs/src/pages/components/Form.svx
+++ b/docs/src/pages/components/Form.svx
@@ -60,3 +60,17 @@ components: ["Form", "FormGroup"]
   </FormGroup>
   <Button type="submit">Submit</Button>
 </Form>
+
+### Prevent default behavior
+
+The forwarded `submit` event is not modified. Use `e.preventDefault()` to prevent the native form submission behavior.
+
+```
+<Form on:submit={e => {
+  e.preventDefault();
+  console.log("submit", e);
+}}>
+   <Checkbox id="checkbox-0" labelText="Checkbox Label" checked />
+  <Button type="submit">Submit</Button>
+</Form>
+```

--- a/src/Form/Form.svelte
+++ b/src/Form/Form.svelte
@@ -13,7 +13,7 @@
   on:mouseover
   on:mouseenter
   on:mouseleave
-  on:submit|preventDefault
+  on:submit
 >
   <slot />
 </form>


### PR DESCRIPTION
Closes #1140
Closes #1134

The modifier blocks the consumer from using the native form submission behavior. The consumer still has the ability to prevent the default behavior if needed.

```svelte
<Form
  on:submit={(e) => {
    e.preventDefault();
  }}
/>
```
