### PR TITLE
feat(dropdown): make `Dropdown` slottable

### DIFF
--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -1195,7 +1195,9 @@ export interface DropdownItem {
 
 ### Slots
 
-None.
+| Slot name | Default | Props                                                | Fallback                          |
+| :-------- | :------ | :--------------------------------------------------- | :-------------------------------- |
+| --        | Yes     | <code>{ item: DropdownItem; index: number; } </code> | <code>{itemToString(item)}</code> |
 
 ### Events
 

--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -3311,7 +3311,14 @@
         }
       ],
       "moduleExports": [],
-      "slots": [],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "fallback": "{itemToString(item)}",
+          "slot_props": "{ item: DropdownItem; index: number; }"
+        }
+      ],
       "events": [
         {
           "type": "dispatched",

--- a/docs/src/pages/components/Dropdown.svx
+++ b/docs/src/pages/components/Dropdown.svx
@@ -19,6 +19,12 @@ components: ["Dropdown", "DropdownSkeleton"]
   {id: "1", text: "Email"},
   {id: "2", text: "Fax"}]}" />
 
+### Custom slot
+
+Override the default slot to customize the display of each item. Access the item and index through the `let:` directive.
+
+<FileSource src="/framed/Dropdown/DropdownSlot" />
+
 ### Hidden label
 
 <Dropdown hideLabel titleText="Contact" selectedId="0" items="{[{id: "0", text: "Slack"},

--- a/docs/src/pages/framed/Dropdown/DropdownSlot.svelte
+++ b/docs/src/pages/framed/Dropdown/DropdownSlot.svelte
@@ -1,0 +1,29 @@
+<script>
+  import { Dropdown } from "carbon-components-svelte";
+</script>
+
+<Dropdown
+  titleText="Contact"
+  selectedId="0"
+  items="{[
+    { id: '0', text: 'Slack' },
+    { id: '1', text: 'Email' },
+    { id: '2', text: 'Fax' },
+  ]}"
+  let:item
+  let:index
+>
+  <div>
+    <strong>{item.text}</strong>
+  </div>
+  <div>
+    id: {item.id} - index:
+    {index}
+  </div>
+</Dropdown>
+
+<style>
+  :global(.bx--list-box__menu-item, .bx--list-box__menu-item__option) {
+    height: auto;
+  }
+</style>

--- a/src/Dropdown/Dropdown.svelte
+++ b/src/Dropdown/Dropdown.svelte
@@ -4,6 +4,7 @@
    * @typedef {string} DropdownItemText
    * @typedef {{ id: DropdownItemId; text: DropdownItemText; }} DropdownItem
    * @event {{ selectedId: DropdownItemId, selectedItem: DropdownItem }} select
+   * @slot {{ item: DropdownItem; index: number; }}
    */
 
   /**
@@ -256,7 +257,9 @@
               highlightedIndex = i;
             }}"
           >
-            {itemToString(item)}
+            <slot item="{item}" index="{i}">
+              {itemToString(item)}
+            </slot>
           </ListBoxMenuItem>
         {/each}
       </ListBoxMenu>

--- a/tests/Dropdown.test.svelte
+++ b/tests/Dropdown.test.svelte
@@ -14,7 +14,12 @@
   on:select="{(e) => {
     console.log(e.detail.selectedId);
   }}"
-/>
+  let:item
+  let:index
+>
+  {item.id}
+  {index}
+</Dropdown>
 
 <Dropdown
   itemToString="{(item) => {

--- a/types/Dropdown/Dropdown.svelte.d.ts
+++ b/types/Dropdown/Dropdown.svelte.d.ts
@@ -153,5 +153,5 @@ export default class Dropdown extends SvelteComponentTyped<
       selectedItem: DropdownItem;
     }>;
   },
-  {}
+  { default: { item: DropdownItem; index: number } }
 > {}


### PR DESCRIPTION
Related https://github.com/carbon-design-system/carbon-components-svelte/issues/1176

Similar to making the `ComboBox` slottable (#1181), this PR makes the `Dropdown` slottable.

```svelte
<Dropdown
  titleText="Contact"
  selectedId="0"
  items="{[
    { id: '0', text: 'Slack' },
    { id: '1', text: 'Email' },
    { id: '2', text: 'Fax' },
  ]}"
  let:item
  let:index
>
  {item.text} {item.id} {index}
</Dropdown>
```