### PR TITLE
Improve docs

### DIFF
--- a/docs/src/pages/components/ClickableTile.svx
+++ b/docs/src/pages/components/ClickableTile.svx
@@ -13,6 +13,20 @@ source: Tile/ClickableTile.svelte
 Carbon Design System
 </ClickableTile>
 
+### Prevent default behavior
+
+Use the forwarded `click` event and invoke `e.preventDefault()` to prevent the native link behavior.
+
+<ClickableTile
+  href="/"
+  on:click={(e) => {
+    e.preventDefault();
+    // custom behavior
+  }}
+>
+  Carbon Design System
+</ClickableTile>
+
 ### Light variant
 
 <ClickableTile light href="https://www.carbondesignsystem.com/">

--- a/docs/src/pages/components/ComboBox.svx
+++ b/docs/src/pages/components/ComboBox.svx
@@ -9,12 +9,6 @@
   <div class="body-short-01">Every <code>items</code> object must have a unique "id" property.</div>
 </InlineNotification>
 
-<InlineNotification svx-ignore lowContrast title="Note:" kind="info" hideCloseButton>
-  <div class="body-short-01">
-    Since version 0.53, <strong>selectedIndex</strong> has been replaced with <strong>selectedId</strong>.
-  </div>
-</InlineNotification>
-
 ### Default
 
 <ComboBox titleText="Contact" placeholder="Select contact method"

--- a/docs/src/pages/components/ComboBox.svx
+++ b/docs/src/pages/components/ComboBox.svx
@@ -3,6 +3,12 @@
   import Preview from "../../components/Preview.svelte";
 </script>
 
+`ComboBox` is keyed for performance reasons.
+
+<InlineNotification svx-ignore lowContrast title="Note:" kind="info" hideCloseButton>
+  <div class="body-short-01">Every <code>items</code> object must have a unique "id" property.</div>
+</InlineNotification>
+
 <InlineNotification svx-ignore lowContrast title="Note:" kind="info" hideCloseButton>
   <div class="body-short-01">
     Since version 0.53, <strong>selectedIndex</strong> has been replaced with <strong>selectedId</strong>.

--- a/docs/src/pages/components/DataTable.svx
+++ b/docs/src/pages/components/DataTable.svx
@@ -22,6 +22,10 @@ components: ["DataTable", "Pagination","Toolbar", "ToolbarContent", "ToolbarSear
 
 ### Default
 
+The key value in `headers` corresponds to the key value defined in `rows`.
+
+For example, the header key `"name"` will use the value of `rows[index].name`.
+
 <DataTable
   headers="{[
     { key: "name", value: "Name" },

--- a/docs/src/pages/components/DataTable.svx
+++ b/docs/src/pages/components/DataTable.svx
@@ -10,7 +10,7 @@ components: ["DataTable", "Pagination","Toolbar", "ToolbarContent", "ToolbarSear
   const pagination = { pageSize: 5, page: 1}
 </script>
 
-`DataTable` is keyed for both rendering and sorting purposes.
+`DataTable` is keyed for performance reasons.
 
 <InlineNotification svx-ignore lowContrast title="Note:" kind="info" hideCloseButton>
   <div class="body-short-01">Every <code>headers</code> object must have a unique "key" property.</div>

--- a/docs/src/pages/components/Dropdown.svx
+++ b/docs/src/pages/components/Dropdown.svx
@@ -13,12 +13,6 @@ components: ["Dropdown", "DropdownSkeleton"]
   <div class="body-short-01">Every <code>items</code> object must have a unique "id" property.</div>
 </InlineNotification>
 
-<InlineNotification svx-ignore lowContrast title="Note:" kind="info" hideCloseButton>
-  <div class="body-short-01">
-    Since version 0.53, <strong>selectedIndex</strong> has been replaced with <strong>selectedId</strong>.
-  </div>
-</InlineNotification>
-
 ### Default
 
 <Dropdown titleText="Contact" selectedId="0" items="{[{id: "0", text: "Slack"},

--- a/docs/src/pages/components/Dropdown.svx
+++ b/docs/src/pages/components/Dropdown.svx
@@ -7,6 +7,12 @@ components: ["Dropdown", "DropdownSkeleton"]
   import Preview from "../../components/Preview.svelte";
 </script>
 
+`Dropdown` is keyed for performance reasons.
+
+<InlineNotification svx-ignore lowContrast title="Note:" kind="info" hideCloseButton>
+  <div class="body-short-01">Every <code>items</code> object must have a unique "id" property.</div>
+</InlineNotification>
+
 <InlineNotification svx-ignore lowContrast title="Note:" kind="info" hideCloseButton>
   <div class="body-short-01">
     Since version 0.53, <strong>selectedIndex</strong> has been replaced with <strong>selectedId</strong>.

--- a/docs/src/pages/components/MultiSelect.svx
+++ b/docs/src/pages/components/MultiSelect.svx
@@ -1,7 +1,13 @@
 <script>
-  import { MultiSelect } from "carbon-components-svelte";
+  import { MultiSelect, InlineNotification } from "carbon-components-svelte";
   import Preview from "../../components/Preview.svelte";
 </script>
+
+`MultiSelect` is keyed for performance reasons.
+
+<InlineNotification svx-ignore lowContrast title="Note:" kind="info" hideCloseButton>
+  <div class="body-short-01">Every <code>items</code> object must have a unique "id" property.</div>
+</InlineNotification>
 
 ### Default
 


### PR DESCRIPTION
- add `ClickableTile` "Prevent default behavior" example
- add note to `Dropdown`, `ComboBox`, and `MultiSelect` that `items` object requires a unique id
- remove note from `Dropdown`, `ComboBox` on `selectedId` breaking change
- explain how `DataTable` `headers` keys work