### PR TITLE
fix(header-action): stop propagation on button click event

### DIFF
--- a/src/UIShell/GlobalHeader/HeaderAction.svelte
+++ b/src/UIShell/GlobalHeader/HeaderAction.svelte
@@ -58,16 +58,16 @@
   class:action-text="{text}"
   {...$$restProps}
   on:click
-  on:click="{() => {
+  on:click|stopPropagation="{() => {
     isOpen = !isOpen;
     dispatch(isOpen ? 'open' : 'close');
   }}"
 >
-  <svelte:component this="{icon}" style="{isOpen ? 'display: none' : ''}" />
-  <svelte:component
-    this="{closeIcon}"
-    style="{!isOpen ? 'display: none' : ''}"
-  />
+  {#if isOpen}
+    <svelte:component this="{closeIcon}" />
+  {:else}
+    <svelte:component this="{icon}" />
+  {/if}
   <slot name="text">
     {#if text}<span>{text}</span>{/if}
   </slot>


### PR DESCRIPTION
Currently, both open/close icons in `HeaderAction` are rendered to avoid the behavior where clicking the icon would double trigger the `isOpen` toggle.

```svelte
<svelte:component this="{icon}" style="{isOpen ? 'display: none' : ''}" />
<svelte:component this="{closeIcon}" style="{!isOpen ? 'display: none' : ''}" />
```

This PR stops the propagation on the `click` event so that inadvertently clicking the icon `svg` element will not double trigger the panel.

As a result, we can properly render the open/close icons based on the `isOpen` condition:

```svelte
{#if isOpen}
  <svelte:component this="{closeIcon}" />
{:else}
  <svelte:component this="{icon}" />
{/if}
```