### PR TITLE
feat(ui-shell): make `SideNavLink` text slottable

### DIFF
--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -3444,6 +3444,7 @@ None.
 
 | Slot name | Default | Props | Fallback                                              |
 | :-------- | :------ | :---- | :---------------------------------------------------- |
+| --        | Yes     | --    | <code>{text}</code>                                   |
 | icon      | No      | --    | <code>&lt;svelte:component this="{icon}" /&gt;</code> |
 
 ### Events

--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -10152,6 +10152,12 @@
       "moduleExports": [],
       "slots": [
         {
+          "name": "__default__",
+          "default": true,
+          "fallback": "{text}",
+          "slot_props": "{}"
+        },
+        {
           "name": "icon",
           "default": false,
           "fallback": "<svelte:component this=\"{icon}\" />",

--- a/src/UIShell/SideNav/SideNavLink.svelte
+++ b/src/UIShell/SideNav/SideNavLink.svelte
@@ -45,6 +45,10 @@
         </slot>
       </div>
     {/if}
-    <span class:bx--side-nav__link-text="{true}">{text}</span>
+    <span class:bx--side-nav__link-text="{true}">
+      <slot>
+        {text}
+      </slot>
+    </span>
   </a>
 </li>

--- a/types/UIShell/SideNav/SideNavLink.svelte.d.ts
+++ b/types/UIShell/SideNav/SideNavLink.svelte.d.ts
@@ -37,5 +37,5 @@ export interface SideNavLinkProps
 export default class SideNavLink extends SvelteComponentTyped<
   SideNavLinkProps,
   { click: WindowEventMap["click"] },
-  { icon: {} }
+  { default: {}; icon: {} }
 > {}


### PR DESCRIPTION
This adds a default slot to `SideNavLink` so that `text` is slottable.

```svelte
<SideNavLink href="/" text="Text" />

<SideNavLink href="/">
  <strong>Text</strong>
</SideNavLink>
```