### PR TITLE
fix(toolbar-search): context can be undefined

### DIFF
--- a/src/DataTable/ToolbarSearch.svelte
+++ b/src/DataTable/ToolbarSearch.svelte
@@ -40,7 +40,7 @@
   import { tick, getContext } from "svelte";
   import Search from "../Search/Search.svelte";
 
-  const { tableRows } = getContext("DataTable");
+  const { tableRows } = getContext("DataTable") ?? {};
 
   $: originalRows = tableRows ? [...$tableRows] : [];
   $: if (shouldFilterRows) {


### PR DESCRIPTION
Fixes #1189

This is a hot fix for use cases where `ToolbarSearch` is used standalone. Currently, it depends on the "DataTable" context.