### PR TITLE
fix(ComboBox): adding title prop to ListBoxMenuItem

### DIFF
--- a/src/ComboBox/ComboBox.svelte
+++ b/src/ComboBox/ComboBox.svelte
@@ -350,6 +350,7 @@
         {#each filteredItems as item, i (item.id)}
           <ListBoxMenuItem
             id="{item.id}"
+            title="{itemToString(item)}"
             active="{selectedId === item.id}"
             highlighted="{highlightedIndex === i}"
             on:click="{() => {


### PR DESCRIPTION
This PR add title prop to ListBoxMenuItem.

Design documentation:
"Avoid having multiple lines of text in a dropdown. If the text is too long for one line, add an ellipsis (…) for overflow content, _**and accompany with a browser-based tooltip to show the full string of text.**_"
https://www.carbondesignsystem.com/components/dropdown/usage/#overflow-content