### PR TITLE
fix(tree-view): fix filter logic in expandNodes/collapseNodes

### DIFF
--- a/src/TreeView/TreeView.svelte
+++ b/src/TreeView/TreeView.svelte
@@ -67,7 +67,11 @@
    */
   export function expandNodes(filterNode = (node) => false) {
     expandedIds = nodes
-      .filter((node) => !filterNode(node))
+      .filter(
+        (node) =>
+          filterNode(node) ||
+          node.children?.some((child) => filterNode(child) && child.children)
+      )
       .map((node) => node.id);
   }
 
@@ -78,7 +82,7 @@
    */
   export function collapseNodes(filterNode = (node) => true) {
     expandedIds = nodes
-      .filter((node) => !filterNode(node))
+      .filter((node) => expandedIds.includes(node.id) && !filterNode(node))
       .map((node) => node.id);
   }
 


### PR DESCRIPTION
Fixes #1214

- `expandNodes` must expand parent nodes that include expandable child nodes
- `collapseNodes` should only filter nodes that are already expanded


https://user-images.githubusercontent.com/10718366/160252282-77ed9096-583d-40bc-a4c9-50c359142cdf.mov

