### PR TITLE
fix(data-table): prevent selectable datatable with sticky header from jumping

### DIFF
--- a/src/Checkbox/InlineCheckbox.svelte
+++ b/src/Checkbox/InlineCheckbox.svelte
@@ -18,20 +18,22 @@
   export let ref = null;
 </script>
 
-<input
-  bind:this="{ref}"
-  type="checkbox"
-  class:bx--checkbox="{true}"
-  checked="{indeterminate ? false : checked}"
-  indeterminate="{indeterminate}"
-  id="{id}"
-  {...$$restProps}
-  aria-label="{undefined}"
-  aria-checked="{indeterminate ? 'mixed' : checked}"
-  on:change
-/>
-<label
-  for="{id}"
-  title="{title}"
-  aria-label="{$$props['aria-label']}"
-  class:bx--checkbox-label="{true}"></label>
+<div class:bx--checkbox--inline="{true}">
+  <input
+    bind:this="{ref}"
+    type="checkbox"
+    class:bx--checkbox="{true}"
+    checked="{indeterminate ? false : checked}"
+    indeterminate="{indeterminate}"
+    id="{id}"
+    {...$$restProps}
+    aria-label="{undefined}"
+    aria-checked="{indeterminate ? 'mixed' : checked}"
+    on:change
+  />
+  <label
+    for="{id}"
+    title="{title}"
+    aria-label="{$$props['aria-label']}"
+    class:bx--checkbox-label="{true}"></label>
+</div>

--- a/src/Checkbox/InlineCheckbox.svelte
+++ b/src/Checkbox/InlineCheckbox.svelte
@@ -27,7 +27,6 @@
     indeterminate="{indeterminate}"
     id="{id}"
     {...$$restProps}
-    aria-label="{undefined}"
     aria-checked="{indeterminate ? 'mixed' : checked}"
     on:change
   />


### PR DESCRIPTION
This PR fixes a bug where selecting a datatable row will cause the page to scroll back to the top. It applies a fix suggested in #1230.

Sample code to repro:

1. Scroll down the page
2. Select a row
3. The page should scroll to the top

```svelte
<script>
  import { DataTable } from "carbon-components-svelte";

  const headers = [
    { key: "name", value: "Name" },
    { key: "port", value: "Port" },
    { key: "rule", value: "Rule" },
  ];

  const rows = [
    { id: "a", name: "Load Balancer 3", port: 3000, rule: "Round robin" },
    { id: "b", name: "Load Balancer 1", port: 443, rule: "Round robin" },
    { id: "c", name: "Load Balancer 2", port: 80, rule: "DNS delegation" },
    { id: "d", name: "Load Balancer 6", port: 3000, rule: "Round robin" },
    { id: "e", name: "Load Balancer 4", port: 443, rule: "Round robin" },
    { id: "f", name: "Load Balancer 5", port: 80, rule: "DNS delegation" },
  ];
</script>

<div style="min-height: 200vh">
  <DataTable stickyHeader batchSelection {headers} {rows} />
</div>

```