### PR TITLE
fix(link): `$$restProps` should extend `p`, `a` HTML attributes

### DIFF
--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -5347,7 +5347,7 @@
         { "type": "forwarded", "name": "mouseleave", "element": "p" }
       ],
       "typedefs": [],
-      "rest_props": { "type": "Element", "name": "p" }
+      "rest_props": { "type": "Element", "name": "p | a" }
     },
     {
       "moduleName": "ListBox",

--- a/src/Link/Link.svelte
+++ b/src/Link/Link.svelte
@@ -1,4 +1,6 @@
 <script>
+  /** @restProps {p | a} */
+
   /**
    * Specify the size of the link
    * @type {"sm" | "lg"}

--- a/tests/Link.test.svelte
+++ b/tests/Link.test.svelte
@@ -1,29 +1,9 @@
 <script lang="ts">
-  import { Link } from "../types";
+  import { Link, OutboundLink } from "../types";
 </script>
 
-<Link href="https://www.carbondesignsystem.com/">Carbon Design System</Link>
-
-<Link href="https://www.carbondesignsystem.com/" target="_blank">
+<Link size="sm" inline disabled download visited href="/" target="_blank">
   Carbon Design System
 </Link>
 
-<Link inline href="https://www.carbondesignsystem.com/">
-  Carbon Design System
-</Link>
-
-<Link size="lg" href="https://www.carbondesignsystem.com/">
-  Carbon Design System
-</Link>
-
-<Link size="sm" href="https://www.carbondesignsystem.com/">
-  Carbon Design System
-</Link>
-
-<Link disabled href="https://www.carbondesignsystem.com/">
-  Carbon Design System
-</Link>
-
-<Link visited href="https://www.carbondesignsystem.com/">
-  Carbon Design System
-</Link>
+<OutboundLink inline href="https://www.carbondesignsystem.com/" />

--- a/types/Link/Link.svelte.d.ts
+++ b/types/Link/Link.svelte.d.ts
@@ -2,7 +2,8 @@
 import { SvelteComponentTyped } from "svelte";
 
 export interface LinkProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["p"]> {
+  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["p"]>,
+    svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]> {
   /**
    * Specify the size of the link
    * @default undefined


### PR DESCRIPTION
While investigating #1232, I noticed that `Link` rest props do not extend `a` element attributes. It only extends `p` attributes.

The solution is to use `@restProps` to explicitly write that it should extend either `a` or `p` attributes.