### PR TITLE
feat(types): support `sveltekit:prefetch`, `sveltekit:noscroll` attributes in type definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "rollup-plugin-svelte": "^7.1.0",
     "rollup-plugin-terser": "^7.0.2",
     "sass": "^1.49.11",
-    "sveld": "^0.13.4",
+    "sveld": "^0.14.0",
     "svelte": "^3.46.6",
     "svelte-check": "^2.4.6",
     "typescript": "^4.6.3"

--- a/types/Accordion/Accordion.svelte.d.ts
+++ b/types/Accordion/Accordion.svelte.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
-import { AccordionSkeletonProps } from "./AccordionSkeleton.svelte";
+import type { SvelteComponentTyped } from "svelte";
+import type { AccordionSkeletonProps } from "./AccordionSkeleton.svelte";
 
 export interface AccordionProps extends AccordionSkeletonProps {
   /**

--- a/types/Accordion/AccordionItem.svelte.d.ts
+++ b/types/Accordion/AccordionItem.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface AccordionItemProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["li"]> {

--- a/types/Accordion/AccordionSkeleton.svelte.d.ts
+++ b/types/Accordion/AccordionSkeleton.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface AccordionSkeletonProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["ul"]> {

--- a/types/AspectRatio/AspectRatio.svelte.d.ts
+++ b/types/AspectRatio/AspectRatio.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface AspectRatioProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {

--- a/types/Breadcrumb/Breadcrumb.svelte.d.ts
+++ b/types/Breadcrumb/Breadcrumb.svelte.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
-import { BreadcrumbSkeletonProps } from "./BreadcrumbSkeleton.svelte";
+import type { SvelteComponentTyped } from "svelte";
+import type { BreadcrumbSkeletonProps } from "./BreadcrumbSkeleton.svelte";
 
 export interface BreadcrumbProps extends BreadcrumbSkeletonProps {
   /**

--- a/types/Breadcrumb/BreadcrumbItem.svelte.d.ts
+++ b/types/Breadcrumb/BreadcrumbItem.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface BreadcrumbItemProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["li"]> {

--- a/types/Breadcrumb/BreadcrumbSkeleton.svelte.d.ts
+++ b/types/Breadcrumb/BreadcrumbSkeleton.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface BreadcrumbSkeletonProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {

--- a/types/Breakpoint/Breakpoint.svelte.d.ts
+++ b/types/Breakpoint/Breakpoint.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export type BreakpointSize = "sm" | "md" | "lg" | "xlg" | "max";
 

--- a/types/Button/Button.svelte.d.ts
+++ b/types/Button/Button.svelte.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
-import { ButtonSkeletonProps } from "./ButtonSkeleton.svelte";
+import type { SvelteComponentTyped } from "svelte";
+import type { ButtonSkeletonProps } from "./ButtonSkeleton.svelte";
 
 export interface ButtonProps
   extends ButtonSkeletonProps,
@@ -105,6 +105,22 @@ export interface ButtonProps
    * @default null
    */
   ref?: null | HTMLAnchorElement | HTMLButtonElement;
+
+  /**
+   * SvelteKit attribute to enable data prefetching
+   * if a link is hovered over or touched on mobile.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @default false
+   */
+  "sveltekit:prefetch"?: boolean;
+
+  /**
+   * SvelteKit attribute to prevent scrolling
+   * after the link is clicked.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @default false
+   */
+  "sveltekit:noscroll"?: boolean;
 }
 
 export default class Button extends SvelteComponentTyped<

--- a/types/Button/ButtonSet.svelte.d.ts
+++ b/types/Button/ButtonSet.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface ButtonSetProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {

--- a/types/Button/ButtonSkeleton.svelte.d.ts
+++ b/types/Button/ButtonSkeleton.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface ButtonSkeletonProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]> {
@@ -14,6 +14,22 @@ export interface ButtonSkeletonProps
    * @default "default"
    */
   size?: "default" | "field" | "small" | "lg" | "xl";
+
+  /**
+   * SvelteKit attribute to enable data prefetching
+   * if a link is hovered over or touched on mobile.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @default false
+   */
+  "sveltekit:prefetch"?: boolean;
+
+  /**
+   * SvelteKit attribute to prevent scrolling
+   * after the link is clicked.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @default false
+   */
+  "sveltekit:noscroll"?: boolean;
 }
 
 export default class ButtonSkeleton extends SvelteComponentTyped<

--- a/types/Checkbox/Checkbox.svelte.d.ts
+++ b/types/Checkbox/Checkbox.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface CheckboxProps {
   /**

--- a/types/Checkbox/CheckboxSkeleton.svelte.d.ts
+++ b/types/Checkbox/CheckboxSkeleton.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface CheckboxSkeletonProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {}

--- a/types/CodeSnippet/CodeSnippet.svelte.d.ts
+++ b/types/CodeSnippet/CodeSnippet.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface CodeSnippetProps {
   /**

--- a/types/CodeSnippet/CodeSnippetSkeleton.svelte.d.ts
+++ b/types/CodeSnippet/CodeSnippetSkeleton.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface CodeSnippetSkeletonProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {

--- a/types/ComboBox/ComboBox.svelte.d.ts
+++ b/types/ComboBox/ComboBox.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export type ComboBoxItemId = any;
 

--- a/types/ComposedModal/ComposedModal.svelte.d.ts
+++ b/types/ComposedModal/ComposedModal.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface ComposedModalProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {

--- a/types/ComposedModal/ModalBody.svelte.d.ts
+++ b/types/ComposedModal/ModalBody.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface ModalBodyProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {

--- a/types/ComposedModal/ModalFooter.svelte.d.ts
+++ b/types/ComposedModal/ModalFooter.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface ModalFooterProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {

--- a/types/ComposedModal/ModalHeader.svelte.d.ts
+++ b/types/ComposedModal/ModalHeader.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface ModalHeaderProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {

--- a/types/ContentSwitcher/ContentSwitcher.svelte.d.ts
+++ b/types/ContentSwitcher/ContentSwitcher.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface ContentSwitcherProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {

--- a/types/ContentSwitcher/Switch.svelte.d.ts
+++ b/types/ContentSwitcher/Switch.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface SwitchProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["button"]> {

--- a/types/ContextMenu/ContextMenu.svelte.d.ts
+++ b/types/ContextMenu/ContextMenu.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface ContextMenuProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["ul"]> {

--- a/types/ContextMenu/ContextMenuDivider.svelte.d.ts
+++ b/types/ContextMenu/ContextMenuDivider.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface ContextMenuDividerProps {}
 

--- a/types/ContextMenu/ContextMenuGroup.svelte.d.ts
+++ b/types/ContextMenu/ContextMenuGroup.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface ContextMenuGroupProps {
   /**

--- a/types/ContextMenu/ContextMenuOption.svelte.d.ts
+++ b/types/ContextMenu/ContextMenuOption.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface ContextMenuOptionProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["li"]> {

--- a/types/ContextMenu/ContextMenuRadioGroup.svelte.d.ts
+++ b/types/ContextMenu/ContextMenuRadioGroup.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface ContextMenuRadioGroupProps {
   /**

--- a/types/CopyButton/CopyButton.svelte.d.ts
+++ b/types/CopyButton/CopyButton.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface CopyButtonProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["button"]> {

--- a/types/DataTable/DataTable.svelte.d.ts
+++ b/types/DataTable/DataTable.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export type DataTableKey = string;
 

--- a/types/DataTable/DataTableSkeleton.svelte.d.ts
+++ b/types/DataTable/DataTableSkeleton.svelte.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
-import { DataTableHeader } from "./DataTable.svelte";
+import type { SvelteComponentTyped } from "svelte";
+import type { DataTableHeader } from "./DataTable.svelte";
 
 export interface DataTableSkeletonProps
   extends DataTableHeader,

--- a/types/DataTable/Table.svelte.d.ts
+++ b/types/DataTable/Table.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface TableProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["section"]> {

--- a/types/DataTable/TableBody.svelte.d.ts
+++ b/types/DataTable/TableBody.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface TableBodyProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["tbody"]> {}

--- a/types/DataTable/TableCell.svelte.d.ts
+++ b/types/DataTable/TableCell.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface TableCellProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["td"]> {}

--- a/types/DataTable/TableContainer.svelte.d.ts
+++ b/types/DataTable/TableContainer.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface TableContainerProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {

--- a/types/DataTable/TableHead.svelte.d.ts
+++ b/types/DataTable/TableHead.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface TableHeadProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["thead"]> {}

--- a/types/DataTable/TableHeader.svelte.d.ts
+++ b/types/DataTable/TableHeader.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface TableHeaderProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["th"]> {

--- a/types/DataTable/TableRow.svelte.d.ts
+++ b/types/DataTable/TableRow.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface TableRowProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["tr"]> {}

--- a/types/DataTable/Toolbar.svelte.d.ts
+++ b/types/DataTable/Toolbar.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface ToolbarProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["section"]> {

--- a/types/DataTable/ToolbarBatchActions.svelte.d.ts
+++ b/types/DataTable/ToolbarBatchActions.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface ToolbarBatchActionsProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {

--- a/types/DataTable/ToolbarContent.svelte.d.ts
+++ b/types/DataTable/ToolbarContent.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface ToolbarContentProps {}
 

--- a/types/DataTable/ToolbarMenu.svelte.d.ts
+++ b/types/DataTable/ToolbarMenu.svelte.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
-import { OverflowMenuProps } from "../OverflowMenu/OverflowMenu.svelte";
+import type { SvelteComponentTyped } from "svelte";
+import type { OverflowMenuProps } from "../OverflowMenu/OverflowMenu.svelte";
 
 export interface ToolbarMenuProps extends OverflowMenuProps {}
 

--- a/types/DataTable/ToolbarMenuItem.svelte.d.ts
+++ b/types/DataTable/ToolbarMenuItem.svelte.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
-import { OverflowMenuItemProps } from "../OverflowMenu/OverflowMenuItem.svelte";
+import type { SvelteComponentTyped } from "svelte";
+import type { OverflowMenuItemProps } from "../OverflowMenu/OverflowMenuItem.svelte";
 
 export interface ToolbarMenuItemProps extends OverflowMenuItemProps {}
 

--- a/types/DataTable/ToolbarSearch.svelte.d.ts
+++ b/types/DataTable/ToolbarSearch.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface ToolbarSearchProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["input"]> {

--- a/types/DatePicker/DatePicker.svelte.d.ts
+++ b/types/DatePicker/DatePicker.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface DatePickerProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {

--- a/types/DatePicker/DatePickerInput.svelte.d.ts
+++ b/types/DatePicker/DatePickerInput.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface DatePickerInputProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["input"]> {

--- a/types/DatePicker/DatePickerSkeleton.svelte.d.ts
+++ b/types/DatePicker/DatePickerSkeleton.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface DatePickerSkeletonProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {

--- a/types/Dropdown/Dropdown.svelte.d.ts
+++ b/types/Dropdown/Dropdown.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export type DropdownItemId = any;
 

--- a/types/Dropdown/DropdownSkeleton.svelte.d.ts
+++ b/types/Dropdown/DropdownSkeleton.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface DropdownSkeletonProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {

--- a/types/FileUploader/FileUploader.svelte.d.ts
+++ b/types/FileUploader/FileUploader.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface FileUploaderProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {

--- a/types/FileUploader/FileUploaderButton.svelte.d.ts
+++ b/types/FileUploader/FileUploaderButton.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface FileUploaderButtonProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["input"]> {

--- a/types/FileUploader/FileUploaderDropContainer.svelte.d.ts
+++ b/types/FileUploader/FileUploaderDropContainer.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface FileUploaderDropContainerProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {

--- a/types/FileUploader/FileUploaderItem.svelte.d.ts
+++ b/types/FileUploader/FileUploaderItem.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface FileUploaderItemProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["span"]> {

--- a/types/FileUploader/FileUploaderSkeleton.svelte.d.ts
+++ b/types/FileUploader/FileUploaderSkeleton.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface FileUploaderSkeletonProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {}

--- a/types/FileUploader/Filename.svelte.d.ts
+++ b/types/FileUploader/Filename.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface FilenameProps {
   /**

--- a/types/FluidForm/FluidForm.svelte.d.ts
+++ b/types/FluidForm/FluidForm.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface FluidFormProps {}
 

--- a/types/Form/Form.svelte.d.ts
+++ b/types/Form/Form.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface FormProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["form"]> {

--- a/types/FormGroup/FormGroup.svelte.d.ts
+++ b/types/FormGroup/FormGroup.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface FormGroupProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["fieldset"]> {

--- a/types/FormItem/FormItem.svelte.d.ts
+++ b/types/FormItem/FormItem.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface FormItemProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {}

--- a/types/FormLabel/FormLabel.svelte.d.ts
+++ b/types/FormLabel/FormLabel.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface FormLabelProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["label"]> {

--- a/types/Grid/Column.svelte.d.ts
+++ b/types/Grid/Column.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export type ColumnSize = boolean | number;
 

--- a/types/Grid/Grid.svelte.d.ts
+++ b/types/Grid/Grid.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface GridProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {

--- a/types/Grid/Row.svelte.d.ts
+++ b/types/Grid/Row.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface RowProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {

--- a/types/ImageLoader/ImageLoader.svelte.d.ts
+++ b/types/ImageLoader/ImageLoader.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface ImageLoaderProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["img"]> {

--- a/types/InlineLoading/InlineLoading.svelte.d.ts
+++ b/types/InlineLoading/InlineLoading.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface InlineLoadingProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {

--- a/types/Link/Link.svelte.d.ts
+++ b/types/Link/Link.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface LinkProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["p"]>,
@@ -46,6 +46,22 @@ export interface LinkProps
    * @default null
    */
   ref?: null | HTMLAnchorElement | HTMLParagraphElement;
+
+  /**
+   * SvelteKit attribute to enable data prefetching
+   * if a link is hovered over or touched on mobile.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @default false
+   */
+  "sveltekit:prefetch"?: boolean;
+
+  /**
+   * SvelteKit attribute to prevent scrolling
+   * after the link is clicked.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @default false
+   */
+  "sveltekit:noscroll"?: boolean;
 }
 
 export default class Link extends SvelteComponentTyped<

--- a/types/Link/OutboundLink.svelte.d.ts
+++ b/types/Link/OutboundLink.svelte.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
-import { LinkProps } from "./Link.svelte";
+import type { SvelteComponentTyped } from "svelte";
+import type { LinkProps } from "./Link.svelte";
 
 export interface OutboundLinkProps extends LinkProps {}
 

--- a/types/ListBox/ListBox.svelte.d.ts
+++ b/types/ListBox/ListBox.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface ListBoxProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {

--- a/types/ListBox/ListBoxField.svelte.d.ts
+++ b/types/ListBox/ListBoxField.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export type ListBoxFieldTranslationId = "close" | "open";
 

--- a/types/ListBox/ListBoxMenu.svelte.d.ts
+++ b/types/ListBox/ListBoxMenu.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface ListBoxMenuProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {

--- a/types/ListBox/ListBoxMenuIcon.svelte.d.ts
+++ b/types/ListBox/ListBoxMenuIcon.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export type ListBoxMenuIconTranslationId = "close" | "open";
 

--- a/types/ListBox/ListBoxMenuItem.svelte.d.ts
+++ b/types/ListBox/ListBoxMenuItem.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface ListBoxMenuItemProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {

--- a/types/ListBox/ListBoxSelection.svelte.d.ts
+++ b/types/ListBox/ListBoxSelection.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export type ListBoxSelectionTranslationId = "clearAll" | "clearSelection";
 

--- a/types/ListItem/ListItem.svelte.d.ts
+++ b/types/ListItem/ListItem.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface ListItemProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["li"]> {}

--- a/types/Loading/Loading.svelte.d.ts
+++ b/types/Loading/Loading.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface LoadingProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {

--- a/types/LocalStorage/LocalStorage.svelte.d.ts
+++ b/types/LocalStorage/LocalStorage.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface LocalStorageProps {
   /**

--- a/types/Modal/Modal.svelte.d.ts
+++ b/types/Modal/Modal.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface ModalProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {

--- a/types/MultiSelect/MultiSelect.svelte.d.ts
+++ b/types/MultiSelect/MultiSelect.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export type MultiSelectItemId = any;
 

--- a/types/Notification/InlineNotification.svelte.d.ts
+++ b/types/Notification/InlineNotification.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface InlineNotificationProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {

--- a/types/Notification/NotificationActionButton.svelte.d.ts
+++ b/types/Notification/NotificationActionButton.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface NotificationActionButtonProps {}
 

--- a/types/Notification/NotificationButton.svelte.d.ts
+++ b/types/Notification/NotificationButton.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface NotificationButtonProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["button"]> {

--- a/types/Notification/NotificationIcon.svelte.d.ts
+++ b/types/Notification/NotificationIcon.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface NotificationIconProps {
   /**

--- a/types/Notification/ToastNotification.svelte.d.ts
+++ b/types/Notification/ToastNotification.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface ToastNotificationProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {

--- a/types/NumberInput/NumberInput.svelte.d.ts
+++ b/types/NumberInput/NumberInput.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export type NumberInputTranslationId = "increment" | "decrement";
 

--- a/types/NumberInput/NumberInputSkeleton.svelte.d.ts
+++ b/types/NumberInput/NumberInputSkeleton.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface NumberInputSkeletonProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {

--- a/types/OrderedList/OrderedList.svelte.d.ts
+++ b/types/OrderedList/OrderedList.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface OrderedListProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["ol"]> {

--- a/types/OverflowMenu/OverflowMenu.svelte.d.ts
+++ b/types/OverflowMenu/OverflowMenu.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface OverflowMenuProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["button"]> {

--- a/types/OverflowMenu/OverflowMenuItem.svelte.d.ts
+++ b/types/OverflowMenu/OverflowMenuItem.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface OverflowMenuItemProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["li"]> {

--- a/types/Pagination/Pagination.svelte.d.ts
+++ b/types/Pagination/Pagination.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface PaginationProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {

--- a/types/Pagination/PaginationSkeleton.svelte.d.ts
+++ b/types/Pagination/PaginationSkeleton.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface PaginationSkeletonProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {}

--- a/types/PaginationNav/PaginationNav.svelte.d.ts
+++ b/types/PaginationNav/PaginationNav.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface PaginationNavProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["nav"]> {

--- a/types/Popover/Popover.svelte.d.ts
+++ b/types/Popover/Popover.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface PopoverProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {

--- a/types/ProgressBar/ProgressBar.svelte.d.ts
+++ b/types/ProgressBar/ProgressBar.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface ProgressBarProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {

--- a/types/ProgressIndicator/ProgressIndicator.svelte.d.ts
+++ b/types/ProgressIndicator/ProgressIndicator.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface ProgressIndicatorProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["ul"]> {

--- a/types/ProgressIndicator/ProgressIndicatorSkeleton.svelte.d.ts
+++ b/types/ProgressIndicator/ProgressIndicatorSkeleton.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface ProgressIndicatorSkeletonProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["ul"]> {

--- a/types/ProgressIndicator/ProgressStep.svelte.d.ts
+++ b/types/ProgressIndicator/ProgressStep.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface ProgressStepProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["li"]> {

--- a/types/RadioButton/RadioButton.svelte.d.ts
+++ b/types/RadioButton/RadioButton.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface RadioButtonProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {

--- a/types/RadioButton/RadioButtonSkeleton.svelte.d.ts
+++ b/types/RadioButton/RadioButtonSkeleton.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface RadioButtonSkeletonProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {}

--- a/types/RadioButtonGroup/RadioButtonGroup.svelte.d.ts
+++ b/types/RadioButtonGroup/RadioButtonGroup.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface RadioButtonGroupProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {

--- a/types/RecursiveList/RecursiveList.svelte.d.ts
+++ b/types/RecursiveList/RecursiveList.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface RecursiveListNode {
   text?: string;

--- a/types/Search/Search.svelte.d.ts
+++ b/types/Search/Search.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface SearchProps {
   /**

--- a/types/Search/SearchSkeleton.svelte.d.ts
+++ b/types/Search/SearchSkeleton.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface SearchSkeletonProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {

--- a/types/Select/Select.svelte.d.ts
+++ b/types/Select/Select.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface SelectProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {

--- a/types/Select/SelectItem.svelte.d.ts
+++ b/types/Select/SelectItem.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface SelectItemProps {
   /**

--- a/types/Select/SelectItemGroup.svelte.d.ts
+++ b/types/Select/SelectItemGroup.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface SelectItemGroupProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["optgroup"]> {

--- a/types/Select/SelectSkeleton.svelte.d.ts
+++ b/types/Select/SelectSkeleton.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface SelectSkeletonProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {

--- a/types/SkeletonPlaceholder/SkeletonPlaceholder.svelte.d.ts
+++ b/types/SkeletonPlaceholder/SkeletonPlaceholder.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface SkeletonPlaceholderProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {}

--- a/types/SkeletonText/SkeletonText.svelte.d.ts
+++ b/types/SkeletonText/SkeletonText.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface SkeletonTextProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {

--- a/types/Slider/Slider.svelte.d.ts
+++ b/types/Slider/Slider.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface SliderProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {

--- a/types/Slider/SliderSkeleton.svelte.d.ts
+++ b/types/Slider/SliderSkeleton.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface SliderSkeletonProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {

--- a/types/StructuredList/StructuredList.svelte.d.ts
+++ b/types/StructuredList/StructuredList.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface StructuredListProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {

--- a/types/StructuredList/StructuredListBody.svelte.d.ts
+++ b/types/StructuredList/StructuredListBody.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface StructuredListBodyProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {}

--- a/types/StructuredList/StructuredListCell.svelte.d.ts
+++ b/types/StructuredList/StructuredListCell.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface StructuredListCellProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {

--- a/types/StructuredList/StructuredListHead.svelte.d.ts
+++ b/types/StructuredList/StructuredListHead.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface StructuredListHeadProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {}

--- a/types/StructuredList/StructuredListInput.svelte.d.ts
+++ b/types/StructuredList/StructuredListInput.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface StructuredListInputProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["input"]> {

--- a/types/StructuredList/StructuredListRow.svelte.d.ts
+++ b/types/StructuredList/StructuredListRow.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface StructuredListRowProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["label"]> {

--- a/types/StructuredList/StructuredListSkeleton.svelte.d.ts
+++ b/types/StructuredList/StructuredListSkeleton.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface StructuredListSkeletonProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {

--- a/types/Tabs/Tab.svelte.d.ts
+++ b/types/Tabs/Tab.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface TabProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["li"]> {

--- a/types/Tabs/TabContent.svelte.d.ts
+++ b/types/Tabs/TabContent.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface TabContentProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {

--- a/types/Tabs/Tabs.svelte.d.ts
+++ b/types/Tabs/Tabs.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface TabsProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {

--- a/types/Tabs/TabsSkeleton.svelte.d.ts
+++ b/types/Tabs/TabsSkeleton.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface TabsSkeletonProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {

--- a/types/Tag/Tag.svelte.d.ts
+++ b/types/Tag/Tag.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface TagProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]>,

--- a/types/Tag/TagSkeleton.svelte.d.ts
+++ b/types/Tag/TagSkeleton.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface TagSkeletonProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["span"]> {

--- a/types/TextArea/TextArea.svelte.d.ts
+++ b/types/TextArea/TextArea.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface TextAreaProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["textarea"]> {

--- a/types/TextArea/TextAreaSkeleton.svelte.d.ts
+++ b/types/TextArea/TextAreaSkeleton.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface TextAreaSkeletonProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {

--- a/types/TextInput/PasswordInput.svelte.d.ts
+++ b/types/TextInput/PasswordInput.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface PasswordInputProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["input"]> {

--- a/types/TextInput/TextInput.svelte.d.ts
+++ b/types/TextInput/TextInput.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface TextInputProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["input"]> {

--- a/types/TextInput/TextInputSkeleton.svelte.d.ts
+++ b/types/TextInput/TextInputSkeleton.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface TextInputSkeletonProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {

--- a/types/Theme/Theme.svelte.d.ts
+++ b/types/Theme/Theme.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export type CarbonTheme = "white" | "g10" | "g80" | "g90" | "g100";
 

--- a/types/Tile/ClickableTile.svelte.d.ts
+++ b/types/Tile/ClickableTile.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface ClickableTileProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]>,
@@ -27,6 +27,22 @@ export interface ClickableTileProps
    * @default undefined
    */
   href?: string;
+
+  /**
+   * SvelteKit attribute to enable data prefetching
+   * if a link is hovered over or touched on mobile.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @default false
+   */
+  "sveltekit:prefetch"?: boolean;
+
+  /**
+   * SvelteKit attribute to prevent scrolling
+   * after the link is clicked.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @default false
+   */
+  "sveltekit:noscroll"?: boolean;
 }
 
 export default class ClickableTile extends SvelteComponentTyped<

--- a/types/Tile/ExpandableTile.svelte.d.ts
+++ b/types/Tile/ExpandableTile.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface ExpandableTileProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["button"]> {

--- a/types/Tile/RadioTile.svelte.d.ts
+++ b/types/Tile/RadioTile.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface RadioTileProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["label"]> {

--- a/types/Tile/SelectableTile.svelte.d.ts
+++ b/types/Tile/SelectableTile.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface SelectableTileProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["label"]> {

--- a/types/Tile/Tile.svelte.d.ts
+++ b/types/Tile/Tile.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface TileProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {

--- a/types/Tile/TileGroup.svelte.d.ts
+++ b/types/Tile/TileGroup.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface TileGroupProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["fieldset"]> {

--- a/types/TimePicker/TimePicker.svelte.d.ts
+++ b/types/TimePicker/TimePicker.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface TimePickerProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["input"]> {

--- a/types/TimePicker/TimePickerSelect.svelte.d.ts
+++ b/types/TimePicker/TimePickerSelect.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface TimePickerSelectProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {

--- a/types/Toggle/Toggle.svelte.d.ts
+++ b/types/Toggle/Toggle.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface ToggleProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {

--- a/types/Toggle/ToggleSkeleton.svelte.d.ts
+++ b/types/Toggle/ToggleSkeleton.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface ToggleSkeletonProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {

--- a/types/Tooltip/Tooltip.svelte.d.ts
+++ b/types/Tooltip/Tooltip.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface TooltipProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {

--- a/types/Tooltip/TooltipFooter.svelte.d.ts
+++ b/types/Tooltip/TooltipFooter.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface TooltipFooterProps {
   /**

--- a/types/TooltipDefinition/TooltipDefinition.svelte.d.ts
+++ b/types/TooltipDefinition/TooltipDefinition.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface TooltipDefinitionProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["span"]> {

--- a/types/TooltipIcon/TooltipIcon.svelte.d.ts
+++ b/types/TooltipIcon/TooltipIcon.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface TooltipIconProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["button"]> {

--- a/types/TreeView/TreeView.svelte.d.ts
+++ b/types/TreeView/TreeView.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export type TreeNodeId = string | number;
 

--- a/types/Truncate/Truncate.svelte.d.ts
+++ b/types/Truncate/Truncate.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface TruncateProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["p"]> {

--- a/types/UIShell/Content.svelte.d.ts
+++ b/types/UIShell/Content.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface ContentProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["main"]> {

--- a/types/UIShell/Header.svelte.d.ts
+++ b/types/UIShell/Header.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface HeaderProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]> {
@@ -77,6 +77,22 @@ export interface HeaderProps
    * @default undefined
    */
   iconClose?: typeof import("svelte").SvelteComponent;
+
+  /**
+   * SvelteKit attribute to enable data prefetching
+   * if a link is hovered over or touched on mobile.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @default false
+   */
+  "sveltekit:prefetch"?: boolean;
+
+  /**
+   * SvelteKit attribute to prevent scrolling
+   * after the link is clicked.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @default false
+   */
+  "sveltekit:noscroll"?: boolean;
 }
 
 export default class Header extends SvelteComponentTyped<

--- a/types/UIShell/HeaderAction.svelte.d.ts
+++ b/types/UIShell/HeaderAction.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface HeaderActionProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["button"]> {

--- a/types/UIShell/HeaderActionLink.svelte.d.ts
+++ b/types/UIShell/HeaderActionLink.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface HeaderActionLinkProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]> {
@@ -26,6 +26,22 @@ export interface HeaderActionLinkProps
    * @default null
    */
   ref?: null | HTMLAnchorElement;
+
+  /**
+   * SvelteKit attribute to enable data prefetching
+   * if a link is hovered over or touched on mobile.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @default false
+   */
+  "sveltekit:prefetch"?: boolean;
+
+  /**
+   * SvelteKit attribute to prevent scrolling
+   * after the link is clicked.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @default false
+   */
+  "sveltekit:noscroll"?: boolean;
 }
 
 export default class HeaderActionLink extends SvelteComponentTyped<

--- a/types/UIShell/HeaderGlobalAction.svelte.d.ts
+++ b/types/UIShell/HeaderGlobalAction.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface HeaderGlobalActionProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["button"]> {

--- a/types/UIShell/HeaderNav.svelte.d.ts
+++ b/types/UIShell/HeaderNav.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface HeaderNavProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["nav"]> {}

--- a/types/UIShell/HeaderNavItem.svelte.d.ts
+++ b/types/UIShell/HeaderNavItem.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface HeaderNavItemProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]> {
@@ -26,6 +26,22 @@ export interface HeaderNavItemProps
    * @default null
    */
   ref?: null | HTMLAnchorElement;
+
+  /**
+   * SvelteKit attribute to enable data prefetching
+   * if a link is hovered over or touched on mobile.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @default false
+   */
+  "sveltekit:prefetch"?: boolean;
+
+  /**
+   * SvelteKit attribute to prevent scrolling
+   * after the link is clicked.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @default false
+   */
+  "sveltekit:noscroll"?: boolean;
 }
 
 export default class HeaderNavItem extends SvelteComponentTyped<

--- a/types/UIShell/HeaderNavMenu.svelte.d.ts
+++ b/types/UIShell/HeaderNavMenu.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface HeaderNavMenuProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]> {
@@ -26,6 +26,22 @@ export interface HeaderNavMenuProps
    * @default null
    */
   ref?: null | HTMLAnchorElement;
+
+  /**
+   * SvelteKit attribute to enable data prefetching
+   * if a link is hovered over or touched on mobile.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @default false
+   */
+  "sveltekit:prefetch"?: boolean;
+
+  /**
+   * SvelteKit attribute to prevent scrolling
+   * after the link is clicked.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @default false
+   */
+  "sveltekit:noscroll"?: boolean;
 }
 
 export default class HeaderNavMenu extends SvelteComponentTyped<

--- a/types/UIShell/HeaderPanelDivider.svelte.d.ts
+++ b/types/UIShell/HeaderPanelDivider.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface HeaderPanelDividerProps {}
 

--- a/types/UIShell/HeaderPanelLink.svelte.d.ts
+++ b/types/UIShell/HeaderPanelLink.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface HeaderPanelLinkProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]> {
@@ -14,6 +14,22 @@ export interface HeaderPanelLinkProps
    * @default null
    */
   ref?: null | HTMLAnchorElement;
+
+  /**
+   * SvelteKit attribute to enable data prefetching
+   * if a link is hovered over or touched on mobile.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @default false
+   */
+  "sveltekit:prefetch"?: boolean;
+
+  /**
+   * SvelteKit attribute to prevent scrolling
+   * after the link is clicked.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @default false
+   */
+  "sveltekit:noscroll"?: boolean;
 }
 
 export default class HeaderPanelLink extends SvelteComponentTyped<

--- a/types/UIShell/HeaderPanelLinks.svelte.d.ts
+++ b/types/UIShell/HeaderPanelLinks.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface HeaderPanelLinksProps {}
 

--- a/types/UIShell/HeaderSearch.svelte.d.ts
+++ b/types/UIShell/HeaderSearch.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface HeaderSearchResult {
   href: string;

--- a/types/UIShell/HeaderUtilities.svelte.d.ts
+++ b/types/UIShell/HeaderUtilities.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface HeaderUtilitiesProps {}
 

--- a/types/UIShell/SideNav.svelte.d.ts
+++ b/types/UIShell/SideNav.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface SideNavProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["nav"]> {

--- a/types/UIShell/SideNavDivider.svelte.d.ts
+++ b/types/UIShell/SideNavDivider.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface SideNavDividerProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["li"]> {}

--- a/types/UIShell/SideNavItems.svelte.d.ts
+++ b/types/UIShell/SideNavItems.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface SideNavItemsProps {}
 

--- a/types/UIShell/SideNavLink.svelte.d.ts
+++ b/types/UIShell/SideNavLink.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface SideNavLinkProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]> {
@@ -32,6 +32,22 @@ export interface SideNavLinkProps
    * @default null
    */
   ref?: null | HTMLAnchorElement;
+
+  /**
+   * SvelteKit attribute to enable data prefetching
+   * if a link is hovered over or touched on mobile.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @default false
+   */
+  "sveltekit:prefetch"?: boolean;
+
+  /**
+   * SvelteKit attribute to prevent scrolling
+   * after the link is clicked.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @default false
+   */
+  "sveltekit:noscroll"?: boolean;
 }
 
 export default class SideNavLink extends SvelteComponentTyped<

--- a/types/UIShell/SideNavMenu.svelte.d.ts
+++ b/types/UIShell/SideNavMenu.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface SideNavMenuProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["button"]> {

--- a/types/UIShell/SideNavMenuItem.svelte.d.ts
+++ b/types/UIShell/SideNavMenuItem.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface SideNavMenuItemProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]> {
@@ -26,6 +26,22 @@ export interface SideNavMenuItemProps
    * @default null
    */
   ref?: null | HTMLAnchorElement;
+
+  /**
+   * SvelteKit attribute to enable data prefetching
+   * if a link is hovered over or touched on mobile.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @default false
+   */
+  "sveltekit:prefetch"?: boolean;
+
+  /**
+   * SvelteKit attribute to prevent scrolling
+   * after the link is clicked.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @default false
+   */
+  "sveltekit:noscroll"?: boolean;
 }
 
 export default class SideNavMenuItem extends SvelteComponentTyped<

--- a/types/UIShell/SkipToContent.svelte.d.ts
+++ b/types/UIShell/SkipToContent.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface SkipToContentProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]> {
@@ -14,6 +14,22 @@ export interface SkipToContentProps
    * @default "0"
    */
   tabindex?: string;
+
+  /**
+   * SvelteKit attribute to enable data prefetching
+   * if a link is hovered over or touched on mobile.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @default false
+   */
+  "sveltekit:prefetch"?: boolean;
+
+  /**
+   * SvelteKit attribute to prevent scrolling
+   * after the link is clicked.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @default false
+   */
+  "sveltekit:noscroll"?: boolean;
 }
 
 export default class SkipToContent extends SvelteComponentTyped<

--- a/types/UnorderedList/UnorderedList.svelte.d.ts
+++ b/types/UnorderedList/UnorderedList.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface UnorderedListProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["ul"]> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -292,7 +292,7 @@
   dependencies:
     "@types/node" "*"
 
-acorn@^8.4.1:
+acorn@^8.7.0:
   version "8.7.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.7.0.tgz#90951fde0f8f09df93549481e5fc141445b791cf"
   integrity sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==
@@ -635,10 +635,10 @@ commander@^6.2.0:
   resolved "https://registry.npmjs.org/commander/-/commander-6.2.0.tgz#b990bfb8ac030aedc6d11bc04d1488ffef56db75"
   integrity sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q==
 
-comment-parser@^0.7.6:
-  version "0.7.6"
-  resolved "https://registry.yarnpkg.com/comment-parser/-/comment-parser-0.7.6.tgz#0e743a53c8e646c899a1323db31f6cd337b10f12"
-  integrity sha512-GKNxVA7/iuTnAqGADlTWX4tkhzxZKXp5fLJqKTlQLHkE65XDUKutZ3BHaJC5IGcper2tT3QRD1xr4o3jNpgXXg==
+comment-parser@^1.3.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/comment-parser/-/comment-parser-1.3.1.tgz#3d7ea3adaf9345594aedee6563f422348f165c1b"
+  integrity sha512-B52sN2VNghyq5ofvUsqZjmk6YkihBX5vMSChmSK9v4ShjKf3Vk5Xcmgpw4o+iIgtrnM/u5FiMpz9VKb8lpBveA==
 
 commondir@^1.0.1:
   version "1.0.1"
@@ -819,6 +819,17 @@ execa@^4.1.0:
     signal-exit "^3.0.2"
     strip-final-newline "^2.0.0"
 
+fast-glob@^3.2.11, fast-glob@^3.2.7:
+  version "3.2.11"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.11.tgz#a1172ad95ceb8a16e20caa5c5e56480e5129c1d9"
+  integrity sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.2"
+    merge2 "^1.3.0"
+    micromatch "^4.0.4"
+
 fast-glob@^3.2.4:
   version "3.2.5"
   resolved "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.5.tgz#7939af2a656de79a4f1901903ee8adcaa7cb9661"
@@ -830,17 +841,6 @@ fast-glob@^3.2.4:
     merge2 "^1.3.0"
     micromatch "^4.0.2"
     picomatch "^2.2.1"
-
-fast-glob@^3.2.7:
-  version "3.2.11"
-  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.11.tgz#a1172ad95ceb8a16e20caa5c5e56480e5129c1d9"
-  integrity sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==
-  dependencies:
-    "@nodelib/fs.stat" "^2.0.2"
-    "@nodelib/fs.walk" "^1.2.3"
-    glob-parent "^5.1.2"
-    merge2 "^1.3.0"
-    micromatch "^4.0.4"
 
 fast-safe-stringify@^2.0.4:
   version "2.0.7"
@@ -1785,14 +1785,7 @@ rollup-pluginutils@^2.8.2:
   dependencies:
     estree-walker "^0.6.1"
 
-rollup@^2.66.0:
-  version "2.66.0"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.66.0.tgz#ee529ea15a20485d579039637fec3050bad03bbb"
-  integrity sha512-L6mKOkdyP8HK5kKJXaiWG7KZDumPJjuo1P+cfyHOJPNNTK3Moe7zCH5+fy7v8pVmHXtlxorzaBjvkBMB23s98g==
-  optionalDependencies:
-    fsevents "~2.3.2"
-
-rollup@^2.70.1:
+rollup@^2.68.0, rollup@^2.70.1:
   version "2.70.1"
   resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.70.1.tgz#824b1f1f879ea396db30b0fc3ae8d2fead93523e"
   integrity sha512-CRYsI5EuzLbXdxC6RnYhOuRdtz4bhejPMSWjsFLfVM/7w/85n2szZv6yExqUXsBdz5KT8eoubeyDUDjhLHEslA==
@@ -2041,21 +2034,20 @@ supports-color@^7.0.0, supports-color@^7.1.0:
   dependencies:
     has-flag "^4.0.0"
 
-sveld@^0.13.4:
-  version "0.13.4"
-  resolved "https://registry.yarnpkg.com/sveld/-/sveld-0.13.4.tgz#0824e7b59b36704ef45f622c42f9268ebb3d5229"
-  integrity sha512-LY9G/4aNv+WYnybqHfRFVHN3JZzDcnJEYX5/LYpD+/Jgr+Iby5bBSwm/YMtM7D4tvV7tPchv1Z0T7P3RiJIiJA==
+sveld@^0.14.0:
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/sveld/-/sveld-0.14.0.tgz#427f77ea95bd5d3c1c347bdf303aab1129511931"
+  integrity sha512-XhBp3OjkBzuIxnKUX5zS6zNB9XjNMUvn6lCueDP/Abrx9Gt/k3elgFOdcO4mQaKMyoMk3OGNpA1a1iMfonjN2w==
   dependencies:
     "@rollup/plugin-node-resolve" "^11.0.1"
-    acorn "^8.4.1"
-    comment-parser "^0.7.6"
-    fast-glob "^3.2.7"
-    fs-extra "^9.0.1"
+    acorn "^8.7.0"
+    comment-parser "^1.3.0"
+    fast-glob "^3.2.11"
     prettier "^2.5.1"
-    rollup "^2.66.0"
+    rollup "^2.68.0"
     rollup-plugin-svelte "^7.1.0"
-    svelte "^3.46.2"
-    svelte-preprocess "^4.10.2"
+    svelte "^3.46.4"
+    svelte-preprocess "^4.10.4"
     typescript "^4.5.5"
 
 svelte-check@^2.4.6:
@@ -2083,10 +2075,10 @@ svelte-preprocess@^4.0.0:
     detect-indent "^6.0.0"
     strip-indent "^3.0.0"
 
-svelte-preprocess@^4.10.2:
-  version "4.10.2"
-  resolved "https://registry.yarnpkg.com/svelte-preprocess/-/svelte-preprocess-4.10.2.tgz#2405689e57161916947b8360679051a56eddd5c6"
-  integrity sha512-aPpkCreSo8EL/y8kJSa1trhiX0oyAtTjlNNM7BNjRAsMJ8Yy2LtqHt0zyd4pQPXt+D4PzbO3qTjjio3kwOxDlA==
+svelte-preprocess@^4.10.4:
+  version "4.10.5"
+  resolved "https://registry.yarnpkg.com/svelte-preprocess/-/svelte-preprocess-4.10.5.tgz#c4d20fd67b92559e5cac80281154c813c1c17353"
+  integrity sha512-VKXPRScCzAZqeBZOGq4LLwtNrAu++mVn7XvQox3eFDV7Ciq0Lg70Q8QWjH9iXF7J+pMlXhPsSFwpCb2E+hoeyA==
   dependencies:
     "@types/pug" "^2.0.4"
     "@types/sass" "^1.16.0"
@@ -2095,10 +2087,10 @@ svelte-preprocess@^4.10.2:
     sorcery "^0.10.0"
     strip-indent "^3.0.0"
 
-svelte@^3.46.2:
-  version "3.46.2"
-  resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.46.2.tgz#f0ffbffaea3a9a760edcbefc0902b41998a686ad"
-  integrity sha512-RXSAtYNefe01Sb1lXtZ2I+gzn3t/h/59hoaRNeRrm8IkMIu6BSiAkbpi41xb+C44x54YKnbk9+dtfs3pM4hECA==
+svelte@^3.46.4:
+  version "3.47.0"
+  resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.47.0.tgz#ba46fe4aea99fc650d6939c215cd4694f5325a19"
+  integrity sha512-4JaJp3HEoTCGARRWZQIZDUanhYv0iyoHikklVHVLH9xFE9db22g4TDv7CPeNA8HD1JgjXI1vlhR1JZvvhaTu2Q==
 
 svelte@^3.46.6:
   version "3.46.6"


### PR DESCRIPTION
Closes #1232 

This upgrades svelte to v0.14.0 so that components that pass `$$restProps` to an anchor element allow `sveltekit:prefetch` and `sveltekit:noscroll` attributes to work without throwing a TypeScript error.