### PR TITLE
refactor(link): make `a` precede `p` element for restProps

### DIFF
--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -5347,7 +5347,7 @@
         { "type": "forwarded", "name": "mouseleave", "element": "p" }
       ],
       "typedefs": [],
-      "rest_props": { "type": "Element", "name": "p | a" }
+      "rest_props": { "type": "Element", "name": "a | p" }
     },
     {
       "moduleName": "ListBox",

--- a/src/Link/Link.svelte
+++ b/src/Link/Link.svelte
@@ -1,5 +1,5 @@
 <script>
-  /** @restProps {p | a} */
+  /** @restProps {a | p} */
 
   /**
    * Specify the size of the link

--- a/types/Link/Link.svelte.d.ts
+++ b/types/Link/Link.svelte.d.ts
@@ -2,8 +2,8 @@
 import type { SvelteComponentTyped } from "svelte";
 
 export interface LinkProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["p"]>,
-    svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]> {
+  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]>,
+    svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["p"]> {
   /**
    * Specify the size of the link
    * @default undefined


### PR DESCRIPTION
Fast follow to #1233

Minor nit but the `a` element should precede the `p` element. Intellisense in VS Code will show the "p" attributes on hover. This can be misleading as we want a `Link` to display `a` attributes instead.

This is also consistent with how `ClickableTile` is typed.