### PR TITLE
fix(tag): add `type="button"` on interactive, filter tag variants

### DIFF
--- a/src/Tag/Tag.svelte
+++ b/src/Tag/Tag.svelte
@@ -77,6 +77,7 @@
       <span class:bx--tag__label="{true}">{type}</span>
     </slot>
     <button
+      type="button"
       aria-labelledby="{id}"
       class:bx--tag__close-icon="{true}"
       disabled="{disabled}"
@@ -94,6 +95,7 @@
   </div>
 {:else if interactive}
   <button
+    type="button"
     id="{id}"
     disabled="{disabled}"
     aria-disabled="{disabled}"


### PR DESCRIPTION
Fixes #1243

This adds an explicit `type="button"` attribute on interactive, filterable tags.

Otherwise, pressing "Enter" will trigger a form submission if the tag is wrapped in a `form` element.