### PR TITLE
chore(deps-dev): upgrade sveld to v0.15.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "rollup-plugin-svelte": "^7.1.0",
     "rollup-plugin-terser": "^7.0.2",
     "sass": "^1.49.11",
-    "sveld": "^0.14.0",
+    "sveld": "^0.15.0",
     "svelte": "^3.46.6",
     "svelte-check": "^2.4.6",
     "typescript": "^4.6.3"

--- a/types/Button/Button.svelte.d.ts
+++ b/types/Button/Button.svelte.d.ts
@@ -115,9 +115,17 @@ export interface ButtonProps
   "sveltekit:prefetch"?: boolean;
 
   /**
+   * SvelteKit attribute to trigger a full page
+   * reload after the link is clicked.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-reload
+   * @default false
+   */
+  "sveltekit:reload"?: boolean;
+
+  /**
    * SvelteKit attribute to prevent scrolling
    * after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-noscroll
    * @default false
    */
   "sveltekit:noscroll"?: boolean;

--- a/types/Button/ButtonSkeleton.svelte.d.ts
+++ b/types/Button/ButtonSkeleton.svelte.d.ts
@@ -24,9 +24,17 @@ export interface ButtonSkeletonProps
   "sveltekit:prefetch"?: boolean;
 
   /**
+   * SvelteKit attribute to trigger a full page
+   * reload after the link is clicked.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-reload
+   * @default false
+   */
+  "sveltekit:reload"?: boolean;
+
+  /**
    * SvelteKit attribute to prevent scrolling
    * after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-noscroll
    * @default false
    */
   "sveltekit:noscroll"?: boolean;

--- a/types/Link/Link.svelte.d.ts
+++ b/types/Link/Link.svelte.d.ts
@@ -56,9 +56,17 @@ export interface LinkProps
   "sveltekit:prefetch"?: boolean;
 
   /**
+   * SvelteKit attribute to trigger a full page
+   * reload after the link is clicked.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-reload
+   * @default false
+   */
+  "sveltekit:reload"?: boolean;
+
+  /**
    * SvelteKit attribute to prevent scrolling
    * after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-noscroll
    * @default false
    */
   "sveltekit:noscroll"?: boolean;

--- a/types/Tile/ClickableTile.svelte.d.ts
+++ b/types/Tile/ClickableTile.svelte.d.ts
@@ -37,9 +37,17 @@ export interface ClickableTileProps
   "sveltekit:prefetch"?: boolean;
 
   /**
+   * SvelteKit attribute to trigger a full page
+   * reload after the link is clicked.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-reload
+   * @default false
+   */
+  "sveltekit:reload"?: boolean;
+
+  /**
    * SvelteKit attribute to prevent scrolling
    * after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-noscroll
    * @default false
    */
   "sveltekit:noscroll"?: boolean;

--- a/types/UIShell/Header.svelte.d.ts
+++ b/types/UIShell/Header.svelte.d.ts
@@ -87,9 +87,17 @@ export interface HeaderProps
   "sveltekit:prefetch"?: boolean;
 
   /**
+   * SvelteKit attribute to trigger a full page
+   * reload after the link is clicked.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-reload
+   * @default false
+   */
+  "sveltekit:reload"?: boolean;
+
+  /**
    * SvelteKit attribute to prevent scrolling
    * after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-noscroll
    * @default false
    */
   "sveltekit:noscroll"?: boolean;

--- a/types/UIShell/HeaderActionLink.svelte.d.ts
+++ b/types/UIShell/HeaderActionLink.svelte.d.ts
@@ -36,9 +36,17 @@ export interface HeaderActionLinkProps
   "sveltekit:prefetch"?: boolean;
 
   /**
+   * SvelteKit attribute to trigger a full page
+   * reload after the link is clicked.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-reload
+   * @default false
+   */
+  "sveltekit:reload"?: boolean;
+
+  /**
    * SvelteKit attribute to prevent scrolling
    * after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-noscroll
    * @default false
    */
   "sveltekit:noscroll"?: boolean;

--- a/types/UIShell/HeaderNavItem.svelte.d.ts
+++ b/types/UIShell/HeaderNavItem.svelte.d.ts
@@ -36,9 +36,17 @@ export interface HeaderNavItemProps
   "sveltekit:prefetch"?: boolean;
 
   /**
+   * SvelteKit attribute to trigger a full page
+   * reload after the link is clicked.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-reload
+   * @default false
+   */
+  "sveltekit:reload"?: boolean;
+
+  /**
    * SvelteKit attribute to prevent scrolling
    * after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-noscroll
    * @default false
    */
   "sveltekit:noscroll"?: boolean;

--- a/types/UIShell/HeaderNavMenu.svelte.d.ts
+++ b/types/UIShell/HeaderNavMenu.svelte.d.ts
@@ -36,9 +36,17 @@ export interface HeaderNavMenuProps
   "sveltekit:prefetch"?: boolean;
 
   /**
+   * SvelteKit attribute to trigger a full page
+   * reload after the link is clicked.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-reload
+   * @default false
+   */
+  "sveltekit:reload"?: boolean;
+
+  /**
    * SvelteKit attribute to prevent scrolling
    * after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-noscroll
    * @default false
    */
   "sveltekit:noscroll"?: boolean;

--- a/types/UIShell/HeaderPanelLink.svelte.d.ts
+++ b/types/UIShell/HeaderPanelLink.svelte.d.ts
@@ -24,9 +24,17 @@ export interface HeaderPanelLinkProps
   "sveltekit:prefetch"?: boolean;
 
   /**
+   * SvelteKit attribute to trigger a full page
+   * reload after the link is clicked.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-reload
+   * @default false
+   */
+  "sveltekit:reload"?: boolean;
+
+  /**
    * SvelteKit attribute to prevent scrolling
    * after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-noscroll
    * @default false
    */
   "sveltekit:noscroll"?: boolean;

--- a/types/UIShell/SideNavLink.svelte.d.ts
+++ b/types/UIShell/SideNavLink.svelte.d.ts
@@ -42,9 +42,17 @@ export interface SideNavLinkProps
   "sveltekit:prefetch"?: boolean;
 
   /**
+   * SvelteKit attribute to trigger a full page
+   * reload after the link is clicked.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-reload
+   * @default false
+   */
+  "sveltekit:reload"?: boolean;
+
+  /**
    * SvelteKit attribute to prevent scrolling
    * after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-noscroll
    * @default false
    */
   "sveltekit:noscroll"?: boolean;

--- a/types/UIShell/SideNavMenuItem.svelte.d.ts
+++ b/types/UIShell/SideNavMenuItem.svelte.d.ts
@@ -36,9 +36,17 @@ export interface SideNavMenuItemProps
   "sveltekit:prefetch"?: boolean;
 
   /**
+   * SvelteKit attribute to trigger a full page
+   * reload after the link is clicked.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-reload
+   * @default false
+   */
+  "sveltekit:reload"?: boolean;
+
+  /**
    * SvelteKit attribute to prevent scrolling
    * after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-noscroll
    * @default false
    */
   "sveltekit:noscroll"?: boolean;

--- a/types/UIShell/SkipToContent.svelte.d.ts
+++ b/types/UIShell/SkipToContent.svelte.d.ts
@@ -24,9 +24,17 @@ export interface SkipToContentProps
   "sveltekit:prefetch"?: boolean;
 
   /**
+   * SvelteKit attribute to trigger a full page
+   * reload after the link is clicked.
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-reload
+   * @default false
+   */
+  "sveltekit:reload"?: boolean;
+
+  /**
    * SvelteKit attribute to prevent scrolling
    * after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
+   * @see https://kit.svelte.dev/docs/a-options#sveltekit-noscroll
    * @default false
    */
   "sveltekit:noscroll"?: boolean;

--- a/yarn.lock
+++ b/yarn.lock
@@ -62,10 +62,10 @@
     magic-string "^0.25.7"
     resolve "^1.17.0"
 
-"@rollup/plugin-node-resolve@^11.0.1":
-  version "11.2.1"
-  resolved "https://registry.yarnpkg.com/@rollup/plugin-node-resolve/-/plugin-node-resolve-11.2.1.tgz#82aa59397a29cd4e13248b106e6a4a1880362a60"
-  integrity sha512-yc2n43jcqVyGE2sqV5/YCmocy9ArjVAP/BeXyTtADTBBX6V0e5UMqwO8CdQ0kzjb6zu5P1qMzsScCMRvE9OlVg==
+"@rollup/plugin-node-resolve@^13.1.3":
+  version "13.1.3"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.1.3.tgz#2ed277fb3ad98745424c1d2ba152484508a92d79"
+  integrity sha512-BdxNk+LtmElRo5d06MGY4zoepyrXX1tkzX2hrnPEZ53k78GuOMWLqmJDGIIOPwVRIFZrLQOo+Yr6KtCuLIA0AQ==
   dependencies:
     "@rollup/pluginutils" "^3.1.0"
     "@types/resolve" "1.17.1"
@@ -74,10 +74,10 @@
     is-module "^1.0.0"
     resolve "^1.19.0"
 
-"@rollup/plugin-node-resolve@^13.1.3":
-  version "13.1.3"
-  resolved "https://registry.yarnpkg.com/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.1.3.tgz#2ed277fb3ad98745424c1d2ba152484508a92d79"
-  integrity sha512-BdxNk+LtmElRo5d06MGY4zoepyrXX1tkzX2hrnPEZ53k78GuOMWLqmJDGIIOPwVRIFZrLQOo+Yr6KtCuLIA0AQ==
+"@rollup/plugin-node-resolve@^13.2.0":
+  version "13.2.0"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.2.0.tgz#ac516c4649b7133273a944778df439d3081dc3d1"
+  integrity sha512-GuUIUyIKq7EjQxB51XSn6zPHYo+cILQQBYOGYvFFNxws2OVOqCBShAoof2hFrV8bAZzZGDBDQ8m2iUt8SLOUkg==
   dependencies:
     "@rollup/pluginutils" "^3.1.0"
     "@types/resolve" "1.17.1"
@@ -404,7 +404,7 @@ commander@^8.3.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-8.3.0.tgz#4837ea1b2da67b9c616a67afbb0fafee567bca66"
   integrity sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==
 
-comment-parser@^1.3.0:
+comment-parser@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/comment-parser/-/comment-parser-1.3.1.tgz#3d7ea3adaf9345594aedee6563f422348f165c1b"
   integrity sha512-B52sN2VNghyq5ofvUsqZjmk6YkihBX5vMSChmSK9v4ShjKf3Vk5Xcmgpw4o+iIgtrnM/u5FiMpz9VKb8lpBveA==
@@ -999,11 +999,6 @@ prettier-plugin-svelte@^2.6.0:
   resolved "https://registry.yarnpkg.com/prettier-plugin-svelte/-/prettier-plugin-svelte-2.6.0.tgz#0e845b560b55cd1d951d6c50431b4949f8591746"
   integrity sha512-NPSRf6Y5rufRlBleok/pqg4+1FyGsL0zYhkYP6hnueeL1J/uCm3OfOZPsLX4zqD9VAdcXfyEL2PYqGv8ZoOSfA==
 
-prettier@^2.5.1:
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.5.1.tgz#fff75fa9d519c54cf0fce328c1017d94546bc56a"
-  integrity sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==
-
 prettier@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.6.2.tgz#e26d71a18a74c3d0f0597f55f01fb6c06c206032"
@@ -1105,7 +1100,7 @@ rollup-pluginutils@^2.8.2:
   dependencies:
     estree-walker "^0.6.1"
 
-rollup@^2.68.0, rollup@^2.70.1:
+rollup@^2.70.1:
   version "2.70.1"
   resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.70.1.tgz#824b1f1f879ea396db30b0fc3ae8d2fead93523e"
   integrity sha512-CRYsI5EuzLbXdxC6RnYhOuRdtz4bhejPMSWjsFLfVM/7w/85n2szZv6yExqUXsBdz5KT8eoubeyDUDjhLHEslA==
@@ -1316,21 +1311,21 @@ supports-color@^9.2.1:
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-9.2.2.tgz#502acaf82f2b7ee78eb7c83dcac0f89694e5a7bb"
   integrity sha512-XC6g/Kgux+rJXmwokjm9ECpD6k/smUoS5LKlUCcsYr4IY3rW0XyAympon2RmxGrlnZURMpg5T18gWDP9CsHXFA==
 
-sveld@^0.14.0:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/sveld/-/sveld-0.14.0.tgz#427f77ea95bd5d3c1c347bdf303aab1129511931"
-  integrity sha512-XhBp3OjkBzuIxnKUX5zS6zNB9XjNMUvn6lCueDP/Abrx9Gt/k3elgFOdcO4mQaKMyoMk3OGNpA1a1iMfonjN2w==
+sveld@^0.15.0:
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/sveld/-/sveld-0.15.0.tgz#826a1064f67f234bd415582b400b4d80b164ac8e"
+  integrity sha512-qBo/6q2QAsAkEAIvz4uTX2mSAhJ5MNtOB+ntpLVoVnKJlNGpqKQgjsMGB8mfa1vF+BDZemtf+tLDq+sPNpxxUA==
   dependencies:
-    "@rollup/plugin-node-resolve" "^11.0.1"
+    "@rollup/plugin-node-resolve" "^13.2.0"
     acorn "^8.7.0"
-    comment-parser "^1.3.0"
+    comment-parser "^1.3.1"
     fast-glob "^3.2.11"
-    prettier "^2.5.1"
-    rollup "^2.68.0"
+    prettier "^2.6.2"
+    rollup "^2.70.1"
     rollup-plugin-svelte "^7.1.0"
-    svelte "^3.46.4"
-    svelte-preprocess "^4.10.4"
-    typescript "^4.5.5"
+    svelte "^3.47.0"
+    svelte-preprocess "^4.10.6"
+    typescript "^4.6.3"
 
 svelte-check@^2.4.6:
   version "2.4.6"
@@ -1357,10 +1352,10 @@ svelte-preprocess@^4.0.0:
     detect-indent "^6.0.0"
     strip-indent "^3.0.0"
 
-svelte-preprocess@^4.10.4:
-  version "4.10.5"
-  resolved "https://registry.yarnpkg.com/svelte-preprocess/-/svelte-preprocess-4.10.5.tgz#c4d20fd67b92559e5cac80281154c813c1c17353"
-  integrity sha512-VKXPRScCzAZqeBZOGq4LLwtNrAu++mVn7XvQox3eFDV7Ciq0Lg70Q8QWjH9iXF7J+pMlXhPsSFwpCb2E+hoeyA==
+svelte-preprocess@^4.10.6:
+  version "4.10.6"
+  resolved "https://registry.yarnpkg.com/svelte-preprocess/-/svelte-preprocess-4.10.6.tgz#5f9a53e7ed3b85fc7e0841120c725b76ac5a1ba8"
+  integrity sha512-I2SV1w/AveMvgIQlUF/ZOO3PYVnhxfcpNyGt8pxpUVhPfyfL/CZBkkw/KPfuFix5FJ9TnnNYMhACK3DtSaYVVQ==
   dependencies:
     "@types/pug" "^2.0.4"
     "@types/sass" "^1.16.0"
@@ -1369,15 +1364,15 @@ svelte-preprocess@^4.10.4:
     sorcery "^0.10.0"
     strip-indent "^3.0.0"
 
-svelte@^3.46.4:
-  version "3.47.0"
-  resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.47.0.tgz#ba46fe4aea99fc650d6939c215cd4694f5325a19"
-  integrity sha512-4JaJp3HEoTCGARRWZQIZDUanhYv0iyoHikklVHVLH9xFE9db22g4TDv7CPeNA8HD1JgjXI1vlhR1JZvvhaTu2Q==
-
 svelte@^3.46.6:
   version "3.46.6"
   resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.46.6.tgz#23046a361ba5f8bafcc9cf9f6fca6d011fb005a7"
   integrity sha512-o9nNft/OzCz/9kJpmWa1S52GAM+huCjPIsNWydYmgei74ZWlOA9/hN9+Z12INdklghu31seEXZMRHhS1+8DETw==
+
+svelte@^3.47.0:
+  version "3.47.0"
+  resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.47.0.tgz#ba46fe4aea99fc650d6939c215cd4694f5325a19"
+  integrity sha512-4JaJp3HEoTCGARRWZQIZDUanhYv0iyoHikklVHVLH9xFE9db22g4TDv7CPeNA8HD1JgjXI1vlhR1JZvvhaTu2Q==
 
 terser@^5.0.0:
   version "5.3.0"
@@ -1414,11 +1409,6 @@ typescript@*:
   version "4.0.5"
   resolved "https://registry.npmjs.org/typescript/-/typescript-4.0.5.tgz#ae9dddfd1069f1cb5beb3ef3b2170dd7c1332389"
   integrity sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==
-
-typescript@^4.5.5:
-  version "4.5.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.5.tgz#d8c953832d28924a9e3d37c73d729c846c5896f3"
-  integrity sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==
 
 typescript@^4.6.3:
   version "4.6.3"


### PR DESCRIPTION
Upgrades `sveld` so that type definitions for links include the optional `sveltekit:reload` attribute.