### PR TITLE
Use store $ assignment to fix batch selection

### DIFF
--- a/src/DataTable/DataTable.svelte
+++ b/src/DataTable/DataTable.svelte
@@ -195,16 +195,14 @@
   $: if (radio || batchSelection) selectable = true;
   $: tableSortable.set(sortable);
   $: headerKeys = headers.map(({ key }) => key);
-  $: tableRows.set(
-    rows.map((row) => ({
-      ...row,
-      cells: headerKeys.map((key, index) => ({
-        key,
-        value: resolvePath(row, key),
-        display: headers[index].display,
-      })),
-    }))
-  );
+  $: $tableRows = rows.map((row) => ({
+    ...row,
+    cells: headerKeys.map((key, index) => ({
+      key,
+      value: resolvePath(row, key),
+      display: headers[index].display,
+    })),
+  }));
   $: sortedRows = [...$tableRows];
   $: ascending = $sortHeader.sortDirection === "ascending";
   $: sortKey = $sortHeader.key;


### PR DESCRIPTION
Without the `=` sign, the reactivity chain were broken.
Using an assignment by prefixing the store with a `$` fixes this.

https://svelte.dev/docs#component-format-script-4-prefix-stores-with-$-to-access-their-values

Fixes #1254