### PR TITLE
fix(toolbar-search): clearing value should re-focus search bar

### DIFF
--- a/src/DataTable/ToolbarSearch.svelte
+++ b/src/DataTable/ToolbarSearch.svelte
@@ -68,6 +68,7 @@
   }
 
   async function expandSearch() {
+    await tick();
     if (disabled || persistent || expanded) return;
     expanded = true;
     await tick();
@@ -94,6 +95,7 @@
   bind:ref
   bind:value
   on:clear
+  on:clear="{expandSearch}"
   on:change
   on:input
   on:focus


### PR DESCRIPTION
Fixes #1258

Currently, clearing the value of a non-persistent `ToolbarSearch` will close the search bar. Clicking the button won't re-open the search bar.

This PR fixes the logic; when clearing the value, the search bar is kept open and is re-focused.

This is consistent with the [React implementation](https://react.carbondesignsystem.com/?path=/story/components-datatable-toolbar--default-toolbar) as well as the behavior of the basic `Search` component.


https://user-images.githubusercontent.com/10718366/164483650-22468dca-aaa1-4569-8143-21e7b572d9e9.mov

