### PR TITLE
fix(dropdown): set explicit `type="button` attribute on button

### DIFF
--- a/src/Dropdown/Dropdown.svelte
+++ b/src/Dropdown/Dropdown.svelte
@@ -199,6 +199,7 @@
     {/if}
     <button
       bind:this="{ref}"
+      type="button"
       class:bx--list-box__field="{true}"
       tabindex="0"
       aria-expanded="{open}"


### PR DESCRIPTION
Fixes #739

The `button` element in the `Dropdown` component requires an explicit `type="button"` value.

Buttons without an explicit type attribute will default to a "submit" behavior when used inside a form.

```svelte
<script>
  import { Form, TextInput, Button, Dropdown } from "carbon-components-svelte";
</script>

<Form
  on:submit={(e) => {
    e.preventDefault();
    alert("form submit");
  }}
>
  <TextInput
    id="username"
    labelText="User name"
    placeholder="Enter user name..."
  />
  <Dropdown
    titleText="Contact"
    selectedId={"0"}
    items={[
      { id: "0", text: "Slack" },
      { id: "1", text: "Email" },
      { id: "2", text: "Fax" },
    ]}
  />
  <Button type="submit">Submit</Button>
</Form>

```