### PR TITLE
fix(file-uploader-item): fix "delete" event regression

### DIFF
--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -4053,8 +4053,8 @@
       "moduleExports": [],
       "slots": [],
       "events": [
-        { "type": "forwarded", "name": "click", "element": "Close" },
-        { "type": "forwarded", "name": "keydown", "element": "Close" }
+        { "type": "forwarded", "name": "click", "element": "button" },
+        { "type": "forwarded", "name": "keydown", "element": "button" }
       ],
       "typedefs": [],
       "rest_props": { "type": "InlineComponent", "name": "Loading" }

--- a/src/FileUploader/Filename.svelte
+++ b/src/FileUploader/Filename.svelte
@@ -30,14 +30,17 @@
   {#if invalid}
     <WarningFilled class="bx--file-invalid" />
   {/if}
-  <Close
+  <button
     aria-label="{iconDescription}"
-    title="{iconDescription}"
-    class="bx--file-close"
+    class:bx--file-close="{true}"
+    type="button"
+    tabindex="0"
     {...$$restProps}
     on:click
     on:keydown
-  />
+  >
+    <Close />
+  </button>
 {/if}
 
 {#if status === "complete"}


### PR DESCRIPTION
Fixes #1267

`FileUploaderItem` with an "edit" status should dispatch a "delete" event when clicking the close icon.
https://github.com/carbon-design-system/carbon-components-svelte/pull/1227 refactored icons to use Carbon icons v11 instead of v10. A breaking change is that events are not forwarded to the SVG elements.

The solution is to wrap the icon in an interactive element, which is a `button` in this case.
