### PR TITLE
docs(tooltip): remove unnecessary `tooltipBodyId` in examples

### DIFF
--- a/docs/src/pages/components/RadioButton.svx
+++ b/docs/src/pages/components/RadioButton.svx
@@ -30,8 +30,8 @@ Use the named "legendText" slot to customize the legend text.
 <RadioButtonGroup selected="standard">
   <div slot="legendText" style="display: flex">
     Storage tier (disk)
-    <Tooltip tooltipBodyId="tooltip-body">
-      <p id="tooltip-body">
+    <Tooltip>
+      <p>
         Storage tiers may vary based on geolocation.
       </p>
     </Tooltip>

--- a/docs/src/pages/components/Tooltip.svx
+++ b/docs/src/pages/components/Tooltip.svx
@@ -12,8 +12,8 @@ components: ["Tooltip", "TooltipFooter"]
 
 By default, the tooltip is triggered by an information icon.
 
-<Tooltip tooltipBodyId="tooltip-body">
-  <p id="tooltip-body">
+<Tooltip>
+  <p>
     Resources are provisioned based on your account's organization.
   </p>
 </Tooltip>


### PR DESCRIPTION
Fixes #1270

`tooltipBodyId` should be `tooltipId`. However, it's actually not needed in the examples as the [`id` is already assigned](https://github.com/carbon-design-system/carbon-components-svelte/blob/020b2e07b60948cadecc8f9c09fd03a27bf2eef5/src/Tooltip/Tooltip.svelte#L238) to the tooltip content (by default it will be randomly generated).

In fact, it's actually incorrect to assign the tooltip id to the content element since it will create duplicate `id`s:

```svelte
<Tooltip tooltipBodyId="tooltip-body">

  <!-- this `id` is incorrectly applied -->
  <p id="tooltip-body">
    Resources are provisioned based on your account's organization.
  </p>
</Tooltip>
```