### PR TITLE
docs(icons): correctly render icon imports in examples

### DIFF
--- a/docs/src/pages/components/Button.svx
+++ b/docs/src/pages/components/Button.svx
@@ -2,9 +2,6 @@
   import { InlineNotification, Button } from "carbon-components-svelte";
   import Add from "carbon-icons-svelte/lib/Add.svelte";
   import TrashCan from "carbon-icons-svelte/lib/TrashCan.svelte";
-  import TextBold from "carbon-icons-svelte/lib/TextBold.svelte";
-  import TextItalic from "carbon-icons-svelte/lib/TextItalic.svelte";
-  import TextUnderline from "carbon-icons-svelte/lib/TextUnderline.svelte";
   import Login from "carbon-icons-svelte/lib/Login.svelte";
   import Preview from "../../components/Preview.svelte";
 


### PR DESCRIPTION
Previously, icon imports would be created if the icon(s) in the example code contained [`16|20|24|32` in their names](https://github.com/carbon-design-system/carbon-components-svelte/blob/3950496b7ee88bf2637cb5b652084bd39f186961/docs/svelte.config.js#L17).

Since v11, Carbon icons no longer specify the size in their name. As a result, icon imports are not created; this causes examples with icons to be broken (copy/pasting producing an error).

This PR updates the test to determine if an inline component or expression name is a Carbon icon.