### PR TITLE
fix(tabs): dispatch "change" event only if index has changed

### DIFF
--- a/src/Tabs/Tabs.svelte
+++ b/src/Tabs/Tabs.svelte
@@ -52,7 +52,6 @@
     },
     update: (id) => {
       currentIndex = $tabsById[id].index;
-      dispatch("change", currentIndex);
     },
     change: (direction) => {
       let index = currentIndex + direction;
@@ -78,16 +77,22 @@
       }
 
       currentIndex = index;
-      dispatch("change", currentIndex);
     },
   });
 
   afterUpdate(() => {
     selected = currentIndex;
+
+    if (prevIndex > -1 && prevIndex !== currentIndex) {
+      dispatch("change", currentIndex);
+    }
+
+    prevIndex = currentIndex;
   });
 
   let dropdownHidden = true;
   let currentIndex = selected;
+  let prevIndex = -1;
 
   $: currentIndex = selected;
   $: currentTab = $tabs[currentIndex] || undefined;


### PR DESCRIPTION
Fixes #1278

Currently, `Tabs` can dispatch repeated "change" events when clicking the same tab. The solution is to use another variable to track the previous index to ensure that the event is fired only when the index has actually changed.

The following code should trigger the "change" event when:

- clicking a different tab
- using the arrow keys to change tabs
- clicking the button which programmatically updates the `selected` value

The event should not fire twice in any circumstance.

```svelte
<script>
  import { Tabs, Tab } from "carbon-components-svelte";

  let selected = 0;
</script>

<Tabs bind:selected on:change={({ detail }) => console.log("change", detail)}>
  <Tab label="Tab 1" />
  <Tab label="Tab 2" />
  <Tab label="Tab 3" />
</Tabs>

<button on:click={() => (selected = 1)}>Update index to 1</button>

{selected}

```

