### PR TITLE
fix(DatePicker): fixing typed value handling when Enter has pressed

### DIFF
--- a/src/DatePicker/DatePicker.svelte
+++ b/src/DatePicker/DatePicker.svelte
@@ -253,14 +253,6 @@
         e.stopPropagation();
         calendar.close();
       }
-
-      if (
-        $hasCalendar &&
-        /INPUT/.test(document.activeElement?.tagName) &&
-        e.key === 'Enter'
-      ) {
-        e.stopPropagation();
-      }
     }}"
   >
     <slot />


### PR DESCRIPTION
Bug: when press Enter with the "lenient" date, the value has been updated to wrong value (13/01/2050).
Expected: value set to 01/01/2051, and Calendar closed.
The second input finished with TAB, it works as expected.

https://user-images.githubusercontent.com/1846548/166449917-d616b4e3-abcf-44f2-a54a-81eeb8935077.mp4

Fix:

https://user-images.githubusercontent.com/1846548/166450584-7ded414f-f19a-4154-b49d-b0a6160514d7.mp4

Related specification: https://carbondesignsystem.com/components/date-picker/usage/ "Calendar behaviour" > "Opening the calendar"

Related older, closed bug: https://github.com/carbon-design-system/carbon-components-svelte/issues/876 (In my opinion, it goes against the specification.)

