### PR TITLE
fix: use default values if `translateWithId` is falsy

### DIFF
--- a/src/ListBox/ListBoxMenuIcon.svelte
+++ b/src/ListBox/ListBoxMenuIcon.svelte
@@ -22,7 +22,9 @@
     [translationIds.open]: "Open menu",
   };
 
-  $: description = open ? translateWithId("close") : translateWithId("open");
+  $: translationId = open ? translationIds.close : translationIds.open;
+  $: description =
+    translateWithId?.(translationId) ?? defaultTranslations[translationId];
 </script>
 
 <div

--- a/src/ListBox/ListBoxSelection.svelte
+++ b/src/ListBox/ListBoxSelection.svelte
@@ -41,9 +41,12 @@
     ctx.declareRef({ key: "selection", ref });
   }
 
-  $: description = selectionCount
-    ? translateWithId("clearAll")
-    : translateWithId("clearSelection");
+  $: translationId = selectionCount
+    ? translationIds.clearAll
+    : translationIds.clearSelection;
+
+  $: description =
+    translateWithId?.(translationId) ?? defaultTranslations[translationId];
 </script>
 
 {#if selectionCount !== undefined}


### PR DESCRIPTION
Fixes #1281

`translateWithId` is used to customize the labels for icons and buttons based on its state (e.g., if the menu is "open" or closed).

`Dropdown`, `ComboBox`, and `MultiSelect` default `translateWithId` to `undefined` when using transitions (#1281). This value will then be passed to `ListBoxMenuIcon` and `ListBoxSelection`, throwing a runtime error.

This PR ensures that `translateWithId` is only invoked if it's a function. It defaults to the default translations.