### PR TITLE
fix(toolbar): elevate toolbar z-index above table

### DIFF
--- a/src/DataTable/Toolbar.svelte
+++ b/src/DataTable/Toolbar.svelte
@@ -28,6 +28,7 @@
   class:bx--table-toolbar--small="{size === 'sm'}"
   class:bx--table-toolbar--normal="{size === 'default'}"
   {...$$restProps}
+  style="z-index: 1; {$$restProps.style}"
 >
   <slot />
 </section>


### PR DESCRIPTION
Fixes #652

Carbon Svelte implements overflow menus using a relative position. As a result, the menu may be clipped by adjacent content. For example, the overflow menu in a `Toolbar` can conflict with the `DataTable` sortable header icon.

The workaround is to manually set an inline `z-index: 1` style on the `Toolbar` so that an open overflow menu is not clipped by content below it.