### PR TITLE
fix(code-snippet): use "small" size for expand/collapse button

### DIFF
--- a/src/CodeSnippet/CodeSnippet.svelte
+++ b/src/CodeSnippet/CodeSnippet.svelte
@@ -235,7 +235,7 @@
     {#if showMoreLess}
       <Button
         kind="ghost"
-        size="field"
+        size="small"
         class="bx--snippet-btn--expand"
         disabled="{disabled}"
         on:click="{() => {


### PR DESCRIPTION
The expand/collapse button for multi-line code snippets should use the "small" size, not the "field" size.

Ref: https://github.com/carbon-design-system/carbon/pull/11353