### PR TITLE
fix(header-action): type missing "open" event

### DIFF
--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -1608,10 +1608,11 @@ None.
 
 ### Events
 
-| Event name | Type       | Detail |
-| :--------- | :--------- | :----- |
-| click      | forwarded  | --     |
-| close      | dispatched | --     |
+| Event name | Type       | Detail            |
+| :--------- | :--------- | :---------------- |
+| open       | dispatched | <code>null</code> |
+| close      | dispatched | <code>null</code> |
+| click      | forwarded  | --                |
 
 ## `HeaderActionLink`
 

--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -4573,8 +4573,9 @@
         }
       ],
       "events": [
-        { "type": "forwarded", "name": "click", "element": "button" },
-        { "type": "dispatched", "name": "close" }
+        { "type": "dispatched", "name": "open", "detail": "null" },
+        { "type": "dispatched", "name": "close", "detail": "null" },
+        { "type": "forwarded", "name": "click", "element": "button" }
       ],
       "typedefs": [],
       "rest_props": { "type": "Element", "name": "button" }

--- a/src/UIShell/HeaderAction.svelte
+++ b/src/UIShell/HeaderAction.svelte
@@ -1,4 +1,9 @@
 <script>
+  /**
+   * @event {null} open
+   * @event {null} close
+   */
+
   /** Set to `true` to open the panel */
   export let isOpen = false;
 

--- a/tests/HeaderUtilities.test.svelte
+++ b/tests/HeaderUtilities.test.svelte
@@ -33,6 +33,8 @@
     <HeaderGlobalAction aria-label="Settings" icon="{SettingsAdjust}" />
     <HeaderAction
       bind:isOpen
+      on:open
+      on:close
       transition="{{ duration: 400, easing: quintOut }}"
     >
       <HeaderPanelLinks>

--- a/types/UIShell/HeaderAction.svelte.d.ts
+++ b/types/UIShell/HeaderAction.svelte.d.ts
@@ -46,6 +46,10 @@ export interface HeaderActionProps
 
 export default class HeaderAction extends SvelteComponentTyped<
   HeaderActionProps,
-  { click: WindowEventMap["click"]; close: CustomEvent<any> },
+  {
+    open: CustomEvent<null>;
+    close: CustomEvent<null>;
+    click: WindowEventMap["click"];
+  },
   { default: {}; closeIcon: {}; icon: {}; text: {} }
 > {}


### PR DESCRIPTION
`HeaderAction` typedefs should include the dispatched "open" event.