### PR TITLE
fix(types): narrow dispatched events without detail to use `null` instead of `any`

### DIFF
--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -572,7 +572,7 @@ None.
 | mouseenter   | forwarded  | --                |
 | mouseleave   | forwarded  | --                |
 | animationend | forwarded  | --                |
-| copy         | dispatched | --                |
+| copy         | dispatched | <code>null</code> |
 
 ## `CodeSnippetSkeleton`
 
@@ -726,10 +726,10 @@ export interface ComboBoxItem {
 | mouseover             | forwarded  | --                              |
 | mouseenter            | forwarded  | --                              |
 | mouseleave            | forwarded  | --                              |
-| submit                | dispatched | --                              |
-| click:button--primary | dispatched | --                              |
-| close                 | dispatched | --                              |
-| open                  | dispatched | --                              |
+| submit                | dispatched | <code>null</code>               |
+| click:button--primary | dispatched | <code>null</code>               |
+| close                 | dispatched | <code>null</code>               |
+| open                  | dispatched | <code>null</code>               |
 
 ## `Content`
 
@@ -799,7 +799,7 @@ None.
 | open       | dispatched | <code>HTMLElement</code> |
 | click      | forwarded  | --                       |
 | keydown    | forwarded  | --                       |
-| close      | dispatched | --                       |
+| close      | dispatched | <code>null</code>        |
 
 ## `ContextMenuDivider`
 
@@ -862,12 +862,12 @@ None.
 
 ### Events
 
-| Event name | Type       | Detail |
-| :--------- | :--------- | :----- |
-| keydown    | forwarded  | --     |
-| mouseenter | forwarded  | --     |
-| mouseleave | forwarded  | --     |
-| click      | dispatched | --     |
+| Event name | Type       | Detail            |
+| :--------- | :--------- | :---------------- |
+| keydown    | forwarded  | --                |
+| mouseenter | forwarded  | --                |
+| mouseleave | forwarded  | --                |
+| click      | dispatched | <code>null</code> |
 
 ## `ContextMenuRadioGroup`
 
@@ -906,11 +906,11 @@ None.
 
 ### Events
 
-| Event name   | Type       | Detail |
-| :----------- | :--------- | :----- |
-| click        | forwarded  | --     |
-| animationend | forwarded  | --     |
-| copy         | dispatched | --     |
+| Event name   | Type       | Detail            |
+| :----------- | :--------- | :---------------- |
+| click        | forwarded  | --                |
+| animationend | forwarded  | --                |
+| copy         | dispatched | <code>null</code> |
 
 ## `DataTable`
 
@@ -1888,13 +1888,13 @@ None.
 
 ### Events
 
-| Event name | Type       | Detail |
-| :--------- | :--------- | :----- |
-| click      | forwarded  | --     |
-| mouseover  | forwarded  | --     |
-| mouseenter | forwarded  | --     |
-| mouseleave | forwarded  | --     |
-| success    | dispatched | --     |
+| Event name | Type       | Detail            |
+| :--------- | :--------- | :---------------- |
+| click      | forwarded  | --                |
+| mouseover  | forwarded  | --                |
+| mouseenter | forwarded  | --                |
+| mouseleave | forwarded  | --                |
+| success    | dispatched | <code>null</code> |
 
 ## `InlineNotification`
 
@@ -2235,10 +2235,10 @@ None.
 | mouseover               | forwarded  | --                              |
 | mouseenter              | forwarded  | --                              |
 | mouseleave              | forwarded  | --                              |
-| submit                  | dispatched | --                              |
-| click:button--primary   | dispatched | --                              |
-| close                   | dispatched | --                              |
-| open                    | dispatched | --                              |
+| submit                  | dispatched | <code>null</code>               |
+| click:button--primary   | dispatched | <code>null</code>               |
+| close                   | dispatched | <code>null</code>               |
+| open                    | dispatched | <code>null</code>               |
 
 ## `ModalBody`
 
@@ -2785,9 +2785,9 @@ None.
 
 ### Events
 
-| Event name    | Type       | Detail |
-| :------------ | :--------- | :----- |
-| click:outside | dispatched | --     |
+| Event name    | Type       | Detail            |
+| :------------ | :--------- | :---------------- |
+| click:outside | dispatched | <code>null</code> |
 
 ## `ProgressBar`
 
@@ -3101,7 +3101,7 @@ None.
 | blur       | forwarded  | --                |
 | keydown    | forwarded  | --                |
 | keyup      | forwarded  | --                |
-| clear      | dispatched | --                |
+| clear      | dispatched | <code>null</code> |
 
 ## `SearchSkeleton`
 
@@ -3966,13 +3966,13 @@ None.
 
 ### Events
 
-| Event name | Type       | Detail |
-| :--------- | :--------- | :----- |
-| click      | forwarded  | --     |
-| mouseover  | forwarded  | --     |
-| mouseenter | forwarded  | --     |
-| mouseleave | forwarded  | --     |
-| close      | dispatched | --     |
+| Event name | Type       | Detail            |
+| :--------- | :--------- | :---------------- |
+| click      | forwarded  | --                |
+| mouseover  | forwarded  | --                |
+| mouseenter | forwarded  | --                |
+| mouseleave | forwarded  | --                |
+| close      | dispatched | <code>null</code> |
 
 ## `TagSkeleton`
 

--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -1185,7 +1185,7 @@
           "name": "animationend",
           "element": "CopyButton"
         },
-        { "type": "dispatched", "name": "copy" }
+        { "type": "dispatched", "name": "copy", "detail": "null" }
       ],
       "typedefs": [],
       "rest_props": { "type": "InlineComponent", "name": "CodeSnippetSkeleton" }
@@ -1759,10 +1759,14 @@
         { "type": "forwarded", "name": "mouseover", "element": "div" },
         { "type": "forwarded", "name": "mouseenter", "element": "div" },
         { "type": "forwarded", "name": "mouseleave", "element": "div" },
-        { "type": "dispatched", "name": "submit" },
-        { "type": "dispatched", "name": "click:button--primary" },
-        { "type": "dispatched", "name": "close" },
-        { "type": "dispatched", "name": "open" }
+        { "type": "dispatched", "name": "submit", "detail": "null" },
+        {
+          "type": "dispatched",
+          "name": "click:button--primary",
+          "detail": "null"
+        },
+        { "type": "dispatched", "name": "close", "detail": "null" },
+        { "type": "dispatched", "name": "open", "detail": "null" }
       ],
       "typedefs": [],
       "rest_props": { "type": "Element", "name": "div" }
@@ -1893,7 +1897,7 @@
         { "type": "dispatched", "name": "open", "detail": "HTMLElement" },
         { "type": "forwarded", "name": "click", "element": "ul" },
         { "type": "forwarded", "name": "keydown", "element": "ul" },
-        { "type": "dispatched", "name": "close" }
+        { "type": "dispatched", "name": "close", "detail": "null" }
       ],
       "typedefs": [],
       "rest_props": { "type": "Element", "name": "ul" }
@@ -2078,7 +2082,7 @@
         { "type": "forwarded", "name": "keydown", "element": "li" },
         { "type": "forwarded", "name": "mouseenter", "element": "li" },
         { "type": "forwarded", "name": "mouseleave", "element": "li" },
-        { "type": "dispatched", "name": "click" }
+        { "type": "dispatched", "name": "click", "detail": "null" }
       ],
       "typedefs": [],
       "rest_props": { "type": "Element", "name": "li" }
@@ -2179,7 +2183,7 @@
       "events": [
         { "type": "forwarded", "name": "click", "element": "button" },
         { "type": "forwarded", "name": "animationend", "element": "button" },
-        { "type": "dispatched", "name": "copy" }
+        { "type": "dispatched", "name": "copy", "detail": "null" }
       ],
       "typedefs": [],
       "rest_props": { "type": "Element", "name": "button" }
@@ -5135,7 +5139,7 @@
         { "type": "forwarded", "name": "mouseover", "element": "div" },
         { "type": "forwarded", "name": "mouseenter", "element": "div" },
         { "type": "forwarded", "name": "mouseleave", "element": "div" },
-        { "type": "dispatched", "name": "success" }
+        { "type": "dispatched", "name": "success", "detail": "null" }
       ],
       "typedefs": [],
       "rest_props": { "type": "Element", "name": "div" }
@@ -6172,10 +6176,14 @@
         { "type": "forwarded", "name": "mouseover", "element": "div" },
         { "type": "forwarded", "name": "mouseenter", "element": "div" },
         { "type": "forwarded", "name": "mouseleave", "element": "div" },
-        { "type": "dispatched", "name": "submit" },
-        { "type": "dispatched", "name": "click:button--primary" },
-        { "type": "dispatched", "name": "close" },
-        { "type": "dispatched", "name": "open" }
+        { "type": "dispatched", "name": "submit", "detail": "null" },
+        {
+          "type": "dispatched",
+          "name": "click:button--primary",
+          "detail": "null"
+        },
+        { "type": "dispatched", "name": "close", "detail": "null" },
+        { "type": "dispatched", "name": "open", "detail": "null" }
       ],
       "typedefs": [],
       "rest_props": { "type": "Element", "name": "div" }
@@ -8254,7 +8262,9 @@
       ],
       "moduleExports": [],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
-      "events": [{ "type": "dispatched", "name": "click:outside" }],
+      "events": [
+        { "type": "dispatched", "name": "click:outside", "detail": "null" }
+      ],
       "typedefs": [],
       "rest_props": { "type": "Element", "name": "div" }
     },
@@ -9270,7 +9280,7 @@
         { "type": "forwarded", "name": "blur", "element": "input" },
         { "type": "forwarded", "name": "keydown", "element": "input" },
         { "type": "forwarded", "name": "keyup", "element": "input" },
-        { "type": "dispatched", "name": "clear" }
+        { "type": "dispatched", "name": "clear", "detail": "null" }
       ],
       "typedefs": [],
       "rest_props": { "type": "InlineComponent", "name": "SearchSkeleton" }
@@ -11327,7 +11337,7 @@
         { "type": "forwarded", "name": "mouseover", "element": "TagSkeleton" },
         { "type": "forwarded", "name": "mouseenter", "element": "TagSkeleton" },
         { "type": "forwarded", "name": "mouseleave", "element": "TagSkeleton" },
-        { "type": "dispatched", "name": "close" }
+        { "type": "dispatched", "name": "close", "detail": "null" }
       ],
       "typedefs": [],
       "rest_props": { "type": "Element", "name": "div | span" }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "rollup-plugin-svelte": "^7.1.0",
     "rollup-plugin-terser": "^7.0.2",
     "sass": "^1.49.11",
-    "sveld": "^0.15.0",
+    "sveld": "^0.15.2",
     "svelte": "^3.46.6",
     "svelte-check": "^2.4.6",
     "typescript": "^4.6.3"

--- a/types/CodeSnippet/CodeSnippet.svelte.d.ts
+++ b/types/CodeSnippet/CodeSnippet.svelte.d.ts
@@ -127,7 +127,7 @@ export default class CodeSnippet extends SvelteComponentTyped<
     mouseenter: WindowEventMap["mouseenter"];
     mouseleave: WindowEventMap["mouseleave"];
     animationend: WindowEventMap["animationend"];
-    copy: CustomEvent<any>;
+    copy: CustomEvent<null>;
   },
   { default: {} }
 > {}

--- a/types/ComposedModal/ComposedModal.svelte.d.ts
+++ b/types/ComposedModal/ComposedModal.svelte.d.ts
@@ -55,10 +55,10 @@ export default class ComposedModal extends SvelteComponentTyped<
     mouseover: WindowEventMap["mouseover"];
     mouseenter: WindowEventMap["mouseenter"];
     mouseleave: WindowEventMap["mouseleave"];
-    submit: CustomEvent<any>;
-    ["click:button--primary"]: CustomEvent<any>;
-    close: CustomEvent<any>;
-    open: CustomEvent<any>;
+    submit: CustomEvent<null>;
+    ["click:button--primary"]: CustomEvent<null>;
+    close: CustomEvent<null>;
+    open: CustomEvent<null>;
   },
   { default: {} }
 > {}

--- a/types/ContextMenu/ContextMenu.svelte.d.ts
+++ b/types/ContextMenu/ContextMenu.svelte.d.ts
@@ -42,7 +42,7 @@ export default class ContextMenu extends SvelteComponentTyped<
     open: CustomEvent<HTMLElement>;
     click: WindowEventMap["click"];
     keydown: WindowEventMap["keydown"];
-    close: CustomEvent<any>;
+    close: CustomEvent<null>;
   },
   { default: {} }
 > {}

--- a/types/ContextMenu/ContextMenuOption.svelte.d.ts
+++ b/types/ContextMenu/ContextMenuOption.svelte.d.ts
@@ -75,7 +75,7 @@ export default class ContextMenuOption extends SvelteComponentTyped<
     keydown: WindowEventMap["keydown"];
     mouseenter: WindowEventMap["mouseenter"];
     mouseleave: WindowEventMap["mouseleave"];
-    click: CustomEvent<any>;
+    click: CustomEvent<null>;
   },
   { default: {}; icon: {}; labelText: {}; shortcutText: {} }
 > {}

--- a/types/CopyButton/CopyButton.svelte.d.ts
+++ b/types/CopyButton/CopyButton.svelte.d.ts
@@ -39,7 +39,7 @@ export default class CopyButton extends SvelteComponentTyped<
   {
     click: WindowEventMap["click"];
     animationend: WindowEventMap["animationend"];
-    copy: CustomEvent<any>;
+    copy: CustomEvent<null>;
   },
   {}
 > {}

--- a/types/InlineLoading/InlineLoading.svelte.d.ts
+++ b/types/InlineLoading/InlineLoading.svelte.d.ts
@@ -35,7 +35,7 @@ export default class InlineLoading extends SvelteComponentTyped<
     mouseover: WindowEventMap["mouseover"];
     mouseenter: WindowEventMap["mouseenter"];
     mouseleave: WindowEventMap["mouseleave"];
-    success: CustomEvent<any>;
+    success: CustomEvent<null>;
   },
   {}
 > {}

--- a/types/Modal/Modal.svelte.d.ts
+++ b/types/Modal/Modal.svelte.d.ts
@@ -142,10 +142,10 @@ export default class Modal extends SvelteComponentTyped<
     mouseover: WindowEventMap["mouseover"];
     mouseenter: WindowEventMap["mouseenter"];
     mouseleave: WindowEventMap["mouseleave"];
-    submit: CustomEvent<any>;
-    ["click:button--primary"]: CustomEvent<any>;
-    close: CustomEvent<any>;
-    open: CustomEvent<any>;
+    submit: CustomEvent<null>;
+    ["click:button--primary"]: CustomEvent<null>;
+    close: CustomEvent<null>;
+    open: CustomEvent<null>;
   },
   { default: {}; heading: {}; label: {} }
 > {}

--- a/types/Popover/Popover.svelte.d.ts
+++ b/types/Popover/Popover.svelte.d.ts
@@ -60,6 +60,6 @@ export interface PopoverProps
 
 export default class Popover extends SvelteComponentTyped<
   PopoverProps,
-  { ["click:outside"]: CustomEvent<any> },
+  { ["click:outside"]: CustomEvent<null> },
   { default: {} }
 > {}

--- a/types/Search/Search.svelte.d.ts
+++ b/types/Search/Search.svelte.d.ts
@@ -115,7 +115,7 @@ export default class Search extends SvelteComponentTyped<
     blur: WindowEventMap["blur"];
     keydown: WindowEventMap["keydown"];
     keyup: WindowEventMap["keyup"];
-    clear: CustomEvent<any>;
+    clear: CustomEvent<null>;
   },
   { labelText: {} }
 > {}

--- a/types/Tag/Tag.svelte.d.ts
+++ b/types/Tag/Tag.svelte.d.ts
@@ -77,7 +77,7 @@ export default class Tag extends SvelteComponentTyped<
     mouseover: WindowEventMap["mouseover"];
     mouseenter: WindowEventMap["mouseenter"];
     mouseleave: WindowEventMap["mouseleave"];
-    close: CustomEvent<any>;
+    close: CustomEvent<null>;
   },
   { default: { props: { class: "bx--tag__label" } }; icon: {} }
 > {}

--- a/yarn.lock
+++ b/yarn.lock
@@ -74,15 +74,15 @@
     is-module "^1.0.0"
     resolve "^1.19.0"
 
-"@rollup/plugin-node-resolve@^13.2.0":
-  version "13.2.0"
-  resolved "https://registry.yarnpkg.com/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.2.0.tgz#ac516c4649b7133273a944778df439d3081dc3d1"
-  integrity sha512-GuUIUyIKq7EjQxB51XSn6zPHYo+cILQQBYOGYvFFNxws2OVOqCBShAoof2hFrV8bAZzZGDBDQ8m2iUt8SLOUkg==
+"@rollup/plugin-node-resolve@^13.2.1":
+  version "13.3.0"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.3.0.tgz#da1c5c5ce8316cef96a2f823d111c1e4e498801c"
+  integrity sha512-Lus8rbUo1eEcnS4yTFKLZrVumLPY+YayBdWXgFSHYhTT2iJbMhoaaBL3xl5NCdeRytErGr8tZ0L71BMRmnlwSw==
   dependencies:
     "@rollup/pluginutils" "^3.1.0"
     "@types/resolve" "1.17.1"
-    builtin-modules "^3.1.0"
     deepmerge "^4.2.2"
+    is-builtin-module "^3.1.0"
     is-module "^1.0.0"
     resolve "^1.19.0"
 
@@ -267,6 +267,11 @@ buffer-from@^1.0.0:
   version "1.1.1"
   resolved "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
+
+builtin-modules@^3.0.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-3.3.0.tgz#cae62812b89801e9656336e46223e030386be7b6"
+  integrity sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==
 
 builtin-modules@^3.1.0:
   version "3.1.0"
@@ -682,6 +687,13 @@ is-binary-path@~2.1.0:
   integrity sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==
   dependencies:
     binary-extensions "^2.0.0"
+
+is-builtin-module@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/is-builtin-module/-/is-builtin-module-3.1.0.tgz#6fdb24313b1c03b75f8b9711c0feb8c30b903b00"
+  integrity sha512-OV7JjAgOTfAFJmHZLvpSTb4qi0nIILDV1gWPYDnDJUTNFM5aGlRAhk4QcT8i7TuAleeEV5Fdkqn3t4mS+Q11fg==
+  dependencies:
+    builtin-modules "^3.0.0"
 
 is-core-module@^2.1.0:
   version "2.2.0"
@@ -1107,6 +1119,13 @@ rollup@^2.70.1:
   optionalDependencies:
     fsevents "~2.3.2"
 
+rollup@^2.70.2:
+  version "2.73.0"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.73.0.tgz#128fef4b333fd92d02d6929afbb6ee38d7feb32d"
+  integrity sha512-h/UngC3S4Zt28mB3g0+2YCMegT5yoftnQplwzPqGZcKvlld5e+kT/QRmJiL+qxGyZKOYpgirWGdLyEO1b0dpLQ==
+  optionalDependencies:
+    fsevents "~2.3.2"
+
 run-parallel@^1.1.9:
   version "1.1.10"
   resolved "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.10.tgz#60a51b2ae836636c81377df16cb107351bcd13ef"
@@ -1311,17 +1330,17 @@ supports-color@^9.2.1:
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-9.2.2.tgz#502acaf82f2b7ee78eb7c83dcac0f89694e5a7bb"
   integrity sha512-XC6g/Kgux+rJXmwokjm9ECpD6k/smUoS5LKlUCcsYr4IY3rW0XyAympon2RmxGrlnZURMpg5T18gWDP9CsHXFA==
 
-sveld@^0.15.0:
-  version "0.15.0"
-  resolved "https://registry.yarnpkg.com/sveld/-/sveld-0.15.0.tgz#826a1064f67f234bd415582b400b4d80b164ac8e"
-  integrity sha512-qBo/6q2QAsAkEAIvz4uTX2mSAhJ5MNtOB+ntpLVoVnKJlNGpqKQgjsMGB8mfa1vF+BDZemtf+tLDq+sPNpxxUA==
+sveld@^0.15.2:
+  version "0.15.2"
+  resolved "https://registry.yarnpkg.com/sveld/-/sveld-0.15.2.tgz#f8a72cafa8ba5e2ff12ce5a858935b6ca72bc18f"
+  integrity sha512-Ogv8IBPJxNSIkLeGKIOLkqh6bcOjy/43Tcf8wiGMzg60ZWU1vnogkDl5aEAs4QvWZ+Mzy5t3GAAG8rpb4WO1YA==
   dependencies:
-    "@rollup/plugin-node-resolve" "^13.2.0"
+    "@rollup/plugin-node-resolve" "^13.2.1"
     acorn "^8.7.0"
     comment-parser "^1.3.1"
     fast-glob "^3.2.11"
     prettier "^2.6.2"
-    rollup "^2.70.1"
+    rollup "^2.70.2"
     rollup-plugin-svelte "^7.1.0"
     svelte "^3.47.0"
     svelte-preprocess "^4.10.6"


### PR DESCRIPTION
Currently, dispatched events without a detail type are typed as `CustomEvent<any>`. Although this isn't wrong, we can narrow the `e.detail` type to be `null`.