### PR TITLE
breaking(data-table): use `data` attribute instead of `id` for table header/row

### DIFF
--- a/src/DataTable/DataTable.svelte
+++ b/src/DataTable/DataTable.svelte
@@ -353,7 +353,7 @@
     <TableBody>
       {#each sorting ? displayedSortedRows : displayedRows as row, i (row.id)}
         <TableRow
-          id="row-{row.id}"
+          data-row="{row.id}"
           data-parent-row="{expandable ? true : undefined}"
           class="{selectedRowIds.includes(row.id)
             ? 'bx--data-table--selected'

--- a/src/DataTable/TableHeader.svelte
+++ b/src/DataTable/TableHeader.svelte
@@ -30,7 +30,7 @@
   <th
     aria-sort="{active ? $sortHeader.sortDirection : 'none'}"
     scope="{scope}"
-    id="{id}"
+    data-header="{id}"
     {...$$restProps}
     on:mouseover
     on:mouseenter
@@ -61,7 +61,7 @@
 {:else}
   <th
     scope="{scope}"
-    id="{id}"
+    data-header="{id}"
     {...$$restProps}
     on:click
     on:mouseover


### PR DESCRIPTION
Fixes #1294

`DataTable` header cells have an `id` attribute with the header key as its value. Similarly, rows have an `id` attribute with `row-{row.id}` as its value.

These ids aren't used internally by the `DataTable`. They were initially added to make it easier to query elements through the DOM (e.g., attaching event listeners).

However, because the ids are not random, they can clash with other `DataTable` instances that use the same header keys or row ids.

The solution is to use `data` attributes to store these values.

For table headers, the data attribute is named `data-header`. For rows, the attribute is `data-row`.

**Headers**

```diff
- id={header.key}
+ data-header={header.key}
```

**Rows**

```diff
- id={row.id}
+ data-row={row.id}
```