### PR TITLE
fix(types): use `@see` tag for flatpickr options link

### DIFF
--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -1050,7 +1050,7 @@ None.
 | short          | <code>let</code> | No       | <code>boolean</code>                                                                                             | <code>false</code>                               | Set to `true` to use the short variant                                                            |
 | light          | <code>let</code> | No       | <code>boolean</code>                                                                                             | <code>false</code>                               | Set to `true` to enable the light variant                                                         |
 | id             | <code>let</code> | No       | <code>string</code>                                                                                              | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the date picker element                                                             |
-| flatpickrProps | <code>let</code> | No       | <code>import("flatpickr/dist/types/options").Options</code>                                                      | <code>{}</code>                                  | Override the options passed to the Flatpickr instance<br />https://flatpickr.js.org/options       |
+| flatpickrProps | <code>let</code> | No       | <code>import("flatpickr/dist/types/options").Options</code>                                                      | <code>{}</code>                                  | Override the options passed to the Flatpickr instance.<br />@see https://flatpickr.js.org/options |
 
 ### Slots
 

--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -2751,7 +2751,7 @@
         {
           "name": "flatpickrProps",
           "kind": "let",
-          "description": "Override the options passed to the Flatpickr instance\nhttps://flatpickr.js.org/options",
+          "description": "Override the options passed to the Flatpickr instance.\n@see https://flatpickr.js.org/options",
           "type": "import(\"flatpickr/dist/types/options\").Options",
           "value": "{}",
           "isFunction": false,

--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -10863,16 +10863,6 @@
           "isFunctionDeclaration": false,
           "constant": false,
           "reactive": false
-        },
-        {
-          "name": "tableStyle",
-          "kind": "let",
-          "description": "Set the style attribute on the `table` element",
-          "type": "string",
-          "isFunction": false,
-          "isFunctionDeclaration": false,
-          "constant": false,
-          "reactive": false
         }
       ],
       "moduleExports": [],
@@ -10934,6 +10924,16 @@
           "description": "Set to `true` to enable a sticky header",
           "type": "boolean",
           "value": "false",
+          "isFunction": false,
+          "isFunctionDeclaration": false,
+          "constant": false,
+          "reactive": false
+        },
+        {
+          "name": "tableStyle",
+          "kind": "let",
+          "description": "Set the style attribute on the `table` element",
+          "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
           "constant": false,

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "rollup-plugin-svelte": "^7.1.0",
     "rollup-plugin-terser": "^7.0.2",
     "sass": "^1.49.11",
-    "sveld": "^0.15.2",
+    "sveld": "^0.15.3",
     "svelte": "^3.46.6",
     "svelte-check": "^2.4.6",
     "typescript": "^4.6.3"

--- a/src/DatePicker/DatePicker.svelte
+++ b/src/DatePicker/DatePicker.svelte
@@ -60,8 +60,8 @@
   export let id = "ccs-" + Math.random().toString(36);
 
   /**
-   * Override the options passed to the Flatpickr instance
-   * https://flatpickr.js.org/options
+   * Override the options passed to the Flatpickr instance.
+   * @see https://flatpickr.js.org/options
    * @type {import("flatpickr/dist/types/options").Options}
    */
   export let flatpickrProps = {};

--- a/types/DatePicker/DatePicker.svelte.d.ts
+++ b/types/DatePicker/DatePicker.svelte.d.ts
@@ -74,8 +74,8 @@ export interface DatePickerProps
   id?: string;
 
   /**
-   * Override the options passed to the Flatpickr instance
-   * https://flatpickr.js.org/options
+   * Override the options passed to the Flatpickr instance.
+   * @see https://flatpickr.js.org/options
    * @default {}
    */
   flatpickrProps?: import("flatpickr/dist/types/options").Options;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1330,10 +1330,10 @@ supports-color@^9.2.1:
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-9.2.2.tgz#502acaf82f2b7ee78eb7c83dcac0f89694e5a7bb"
   integrity sha512-XC6g/Kgux+rJXmwokjm9ECpD6k/smUoS5LKlUCcsYr4IY3rW0XyAympon2RmxGrlnZURMpg5T18gWDP9CsHXFA==
 
-sveld@^0.15.2:
-  version "0.15.2"
-  resolved "https://registry.yarnpkg.com/sveld/-/sveld-0.15.2.tgz#f8a72cafa8ba5e2ff12ce5a858935b6ca72bc18f"
-  integrity sha512-Ogv8IBPJxNSIkLeGKIOLkqh6bcOjy/43Tcf8wiGMzg60ZWU1vnogkDl5aEAs4QvWZ+Mzy5t3GAAG8rpb4WO1YA==
+sveld@^0.15.3:
+  version "0.15.3"
+  resolved "https://registry.yarnpkg.com/sveld/-/sveld-0.15.3.tgz#75fe72f472b9cfbe863f6f0b074612d4132dc960"
+  integrity sha512-3TYhrLpm8z8elnZ6ffQeq1SeoxzC2zsFY/9QeNHu1UcQxAZ6LqfyUufnOkNkelYJMq9uBn4bGUAYJpbpTMjnOA==
   dependencies:
     "@rollup/plugin-node-resolve" "^13.2.1"
     acorn "^8.7.0"


### PR DESCRIPTION
Using the JSDoc `@see` tag will give better Intellisense in VSCode when hovering over the `flatpickrProps` prop.

<img width="569" alt="Screen Shot 2022-05-14 at 12 40 57 PM" src="https://user-images.githubusercontent.com/10718366/168446104-c8d64fec-800e-45a4-90e0-94aa808e0ce9.png">
