### PR TITLE
chore(date-picker): also set `static: true` in exported prop

### DIFF
--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -1050,7 +1050,7 @@ None.
 | short          | <code>let</code> | No       | <code>boolean</code>                                                                                             | <code>false</code>                               | Set to `true` to use the short variant                                                            |
 | light          | <code>let</code> | No       | <code>boolean</code>                                                                                             | <code>false</code>                               | Set to `true` to enable the light variant                                                         |
 | id             | <code>let</code> | No       | <code>string</code>                                                                                              | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the date picker element                                                             |
-| flatpickrProps | <code>let</code> | No       | <code>import("flatpickr/dist/types/options").Options</code>                                                      | <code>{}</code>                                  | Override the options passed to the Flatpickr instance.<br />@see https://flatpickr.js.org/options |
+| flatpickrProps | <code>let</code> | No       | <code>import("flatpickr/dist/types/options").Options</code>                                                      | <code>{ static: true }</code>                    | Override the options passed to the Flatpickr instance.<br />@see https://flatpickr.js.org/options |
 
 ### Slots
 

--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -2753,7 +2753,7 @@
           "kind": "let",
           "description": "Override the options passed to the Flatpickr instance.\n@see https://flatpickr.js.org/options",
           "type": "import(\"flatpickr/dist/types/options\").Options",
-          "value": "{}",
+          "value": "{ static: true }",
           "isFunction": false,
           "isFunctionDeclaration": false,
           "constant": false,

--- a/src/DatePicker/DatePicker.svelte
+++ b/src/DatePicker/DatePicker.svelte
@@ -64,7 +64,7 @@
    * @see https://flatpickr.js.org/options
    * @type {import("flatpickr/dist/types/options").Options}
    */
-  export let flatpickrProps = {};
+  export let flatpickrProps = { static: true };
 
   import {
     createEventDispatcher,

--- a/types/DatePicker/DatePicker.svelte.d.ts
+++ b/types/DatePicker/DatePicker.svelte.d.ts
@@ -76,7 +76,7 @@ export interface DatePickerProps
   /**
    * Override the options passed to the Flatpickr instance.
    * @see https://flatpickr.js.org/options
-   * @default {}
+   * @default { static: true }
    */
   flatpickrProps?: import("flatpickr/dist/types/options").Options;
 }


### PR DESCRIPTION
Follow-up to #1298 

`static` should be set to `false` in the exported `flatpickrProps` prop for docs/types purposes.