### PR TITLE
docs: update `Theme`, `DataTable` docs

### DIFF
--- a/docs/src/pages/components/DataTable.svx
+++ b/docs/src/pages/components/DataTable.svx
@@ -334,6 +334,10 @@ Specify a `width` or `minWidth` property in the `headers` object to customize th
 
 A [table-layout: fixed](https://developer.mozilla.org/en-US/docs/Web/CSS/table-layout#values) rule will be applied to the `table` element when using custom widths.
 
+<InlineNotification svx-ignore lowContrast kind="warning" title="Note:" hideCloseButton>
+  <div class="body-short-01">Custom column widths do not work with a <a class="bx--link" href="#sticky-header">sticky header</a>.</div>
+</InlineNotification>
+
 <FileSource src="/framed/DataTable/DataTableHeaderWidth" />
 
 ### Sticky header

--- a/docs/src/pages/components/Theme.svx
+++ b/docs/src/pages/components/Theme.svx
@@ -1,9 +1,19 @@
 <script>
-  import { Theme } from "carbon-components-svelte";
+  import { InlineNotification, CodeSnippet } from "carbon-components-svelte";
   import Preview from "../../components/Preview.svelte";
+
+  let code = `import "carbon-components-svelte/css/all.css";`;
 </script>
 
-This utility component dynamically updates the Carbon theme on the client-side using CSS variables.
+The `Theme` component can dyanmically update the Carbon theme on the client-side. It can persist the theme locally using [window.localStorage](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage).
+
+<InlineNotification svx-ignore lowContrast title="Note:" kind="info" hideCloseButton>
+  <div class="body-short-01">You must use the "all.css" StyleSheet with the <code>Theme</code> component.</div>
+</InlineNotification>
+
+The `all.css` StyleSheet uses [CSS variables](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties) for dynamic theming.
+  
+<CodeSnippet svx-ignore {code} />
 
 ### Default
 


### PR DESCRIPTION
- update `Theme` docs to note that it must be used with `all.css`
- update `DataTable` docs to note that custom column widths do not work with a sticky header