### PR TITLE
fix(modal): remove close button title attribute, add `aria-hidden` to icons

### DIFF
--- a/src/ComposedModal/ModalHeader.svelte
+++ b/src/ComposedModal/ModalHeader.svelte
@@ -50,7 +50,6 @@
   <slot />
   <button
     type="button"
-    title="{iconDescription}"
     aria-label="{iconDescription}"
     class:bx--modal-close="{true}"
     class="{closeClass}"

--- a/src/ComposedModal/ModalHeader.svelte
+++ b/src/ComposedModal/ModalHeader.svelte
@@ -56,6 +56,10 @@
     on:click
     on:click="{closeModal}"
   >
-    <Close size="{20}" class="bx--modal-close__icon {closeIconClass}" />
+    <Close
+      size="{20}"
+      class="bx--modal-close__icon {closeIconClass}"
+      aria-hidden="true"
+    />
   </button>
 </div>

--- a/src/Modal/Modal.svelte
+++ b/src/Modal/Modal.svelte
@@ -222,7 +222,6 @@
           bind:this="{buttonRef}"
           type="button"
           aria-label="{iconDescription}"
-          title="{iconDescription}"
           class:bx--modal-close="{true}"
           on:click="{() => {
             open = false;
@@ -248,7 +247,6 @@
           bind:this="{buttonRef}"
           type="button"
           aria-label="{iconDescription}"
-          title="{iconDescription}"
           class:bx--modal-close="{true}"
           on:click="{() => {
             open = false;

--- a/src/Modal/Modal.svelte
+++ b/src/Modal/Modal.svelte
@@ -227,7 +227,7 @@
             open = false;
           }}"
         >
-          <Close size="{20}" class="bx--modal-close__icon" />
+          <Close size="{20}" class="bx--modal-close__icon" aria-hidden="true" />
         </button>
       {/if}
       {#if modalLabel}
@@ -248,7 +248,7 @@
             open = false;
           }}"
         >
-          <Close size="{20}" class="bx--modal-close__icon" />
+          <Close size="{20}" class="bx--modal-close__icon" aria-hidden="true" />
         </button>
       {/if}
     </div>

--- a/src/Modal/Modal.svelte
+++ b/src/Modal/Modal.svelte
@@ -227,11 +227,7 @@
             open = false;
           }}"
         >
-          <Close
-            size="{20}"
-            aria-label="{iconDescription}"
-            class="bx--modal-close__icon"
-          />
+          <Close size="{20}" class="bx--modal-close__icon" />
         </button>
       {/if}
       {#if modalLabel}
@@ -252,11 +248,7 @@
             open = false;
           }}"
         >
-          <Close
-            size="{20}"
-            aria-label="{iconDescription}"
-            class="bx--modal-close__icon"
-          />
+          <Close size="{20}" class="bx--modal-close__icon" />
         </button>
       {/if}
     </div>


### PR DESCRIPTION
Referencing the upstream React implementation, the close button in the Modal components should not have a title attribute. In addition the SVG icons in the close buttons should not have an aria-label; instead they should have an aria-hidden attribute.

**Fixes**

- `Modal`, `ModalHeader`
  - remove `title` attribute from close button in `Modal`, `ModalHeader`
  - remove redundant `aria-label` attribute from close button icon
  - add `aria-hidden="true"` to close button icon