### PR TITLE
fix: `CopyButton` text prop and `Dropdown` selectedId prop should be required

### DIFF
--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -176,12 +176,12 @@
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                              | Default value          | Description                                      |
-| :-------- | :--------------- | :------- | :-------------------------------- | ---------------------- | ------------------------------------------------ |
-| align     | <code>let</code> | No       | <code>"start" &#124; "end"</code> | <code>"end"</code>     | Specify alignment of accordion item chevron icon |
-| size      | <code>let</code> | No       | <code>"sm" &#124; "xl"</code>     | <code>undefined</code> | Specify the size of the accordion                |
-| disabled  | <code>let</code> | No       | <code>boolean</code>              | <code>false</code>     | Set to `true` to disable the accordion           |
-| skeleton  | <code>let</code> | No       | <code>boolean</code>              | <code>false</code>     | Set to `true` to display the skeleton state      |
+| Prop name | Required | Kind             | Reactive | Type                              | Default value          | Description                                      |
+| :-------- | :------- | :--------------- | :------- | --------------------------------- | ---------------------- | ------------------------------------------------ |
+| align     | No       | <code>let</code> | No       | <code>"start" &#124; "end"</code> | <code>"end"</code>     | Specify alignment of accordion item chevron icon |
+| size      | No       | <code>let</code> | No       | <code>"sm" &#124; "xl"</code>     | <code>undefined</code> | Specify the size of the accordion                |
+| disabled  | No       | <code>let</code> | No       | <code>boolean</code>              | <code>false</code>     | Set to `true` to disable the accordion           |
+| skeleton  | No       | <code>let</code> | No       | <code>boolean</code>              | <code>false</code>     | Set to `true` to display the skeleton state      |
 
 ### Slots
 
@@ -202,12 +202,12 @@
 
 ### Props
 
-| Prop name       | Kind             | Reactive | Type                 | Default value                  | Description                                                                                                                              |
-| :-------------- | :--------------- | :------- | :------------------- | ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| disabled        | <code>let</code> | Yes      | <code>boolean</code> | <code>false</code>             | Set to `true` to disable the accordion item                                                                                              |
-| open            | <code>let</code> | Yes      | <code>boolean</code> | <code>false</code>             | Set to `true` to open the first accordion item                                                                                           |
-| title           | <code>let</code> | No       | <code>string</code>  | <code>"title"</code>           | Specify the title of the accordion item heading<br />Alternatively, use the "title" slot (e.g., &lt;div slot="title"&gt;...&lt;/div&gt;) |
-| iconDescription | <code>let</code> | No       | <code>string</code>  | <code>"Expand/Collapse"</code> | Specify the ARIA label for the accordion item chevron icon                                                                               |
+| Prop name       | Required | Kind             | Reactive | Type                 | Default value                  | Description                                                                                                                              |
+| :-------------- | :------- | :--------------- | :------- | -------------------- | ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| disabled        | No       | <code>let</code> | Yes      | <code>boolean</code> | <code>false</code>             | Set to `true` to disable the accordion item                                                                                              |
+| open            | No       | <code>let</code> | Yes      | <code>boolean</code> | <code>false</code>             | Set to `true` to open the first accordion item                                                                                           |
+| title           | No       | <code>let</code> | No       | <code>string</code>  | <code>"title"</code>           | Specify the title of the accordion item heading<br />Alternatively, use the "title" slot (e.g., &lt;div slot="title"&gt;...&lt;/div&gt;) |
+| iconDescription | No       | <code>let</code> | No       | <code>string</code>  | <code>"Expand/Collapse"</code> | Specify the ARIA label for the accordion item chevron icon                                                                               |
 
 ### Slots
 
@@ -231,12 +231,12 @@
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                              | Default value          | Description                                      |
-| :-------- | :--------------- | :------- | :-------------------------------- | ---------------------- | ------------------------------------------------ |
-| count     | <code>let</code> | No       | <code>number</code>               | <code>4</code>         | Specify the number of accordion items to render  |
-| align     | <code>let</code> | No       | <code>"start" &#124; "end"</code> | <code>"end"</code>     | Specify alignment of accordion item chevron icon |
-| size      | <code>let</code> | No       | <code>"sm" &#124; "xl"</code>     | <code>undefined</code> | Specify the size of the accordion                |
-| open      | <code>let</code> | No       | <code>boolean</code>              | <code>true</code>      | Set to `false` to close the first accordion item |
+| Prop name | Required | Kind             | Reactive | Type                              | Default value          | Description                                      |
+| :-------- | :------- | :--------------- | :------- | --------------------------------- | ---------------------- | ------------------------------------------------ |
+| count     | No       | <code>let</code> | No       | <code>number</code>               | <code>4</code>         | Specify the number of accordion items to render  |
+| align     | No       | <code>let</code> | No       | <code>"start" &#124; "end"</code> | <code>"end"</code>     | Specify alignment of accordion item chevron icon |
+| size      | No       | <code>let</code> | No       | <code>"sm" &#124; "xl"</code>     | <code>undefined</code> | Specify the size of the accordion                |
+| open      | No       | <code>let</code> | No       | <code>boolean</code>              | <code>true</code>      | Set to `false` to close the first accordion item |
 
 ### Slots
 
@@ -255,9 +255,9 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                                                                                                                         | Default value      | Description              |
-| :-------- | :--------------- | :------- | :--------------------------------------------------------------------------------------------------------------------------- | ------------------ | ------------------------ |
-| ratio     | <code>let</code> | No       | <code>"2x1" &#124; "2x3" &#124; "16x9" &#124; "4x3" &#124; "1x1" &#124; "3x4" &#124; "3x2" &#124; "9x16" &#124; "1x2"</code> | <code>"2x1"</code> | Specify the aspect ratio |
+| Prop name | Required | Kind             | Reactive | Type                                                                                                                         | Default value      | Description              |
+| :-------- | :------- | :--------------- | :------- | ---------------------------------------------------------------------------------------------------------------------------- | ------------------ | ------------------------ |
+| ratio     | No       | <code>let</code> | No       | <code>"2x1" &#124; "2x3" &#124; "16x9" &#124; "4x3" &#124; "1x1" &#124; "3x4" &#124; "3x2" &#124; "9x16" &#124; "1x2"</code> | <code>"2x1"</code> | Specify the aspect ratio |
 
 ### Slots
 
@@ -273,10 +273,10 @@ None.
 
 ### Props
 
-| Prop name       | Kind             | Reactive | Type                 | Default value      | Description                                         |
-| :-------------- | :--------------- | :------- | :------------------- | ------------------ | --------------------------------------------------- |
-| noTrailingSlash | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to hide the breadcrumb trailing slash |
-| skeleton        | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to display skeleton state             |
+| Prop name       | Required | Kind             | Reactive | Type                 | Default value      | Description                                         |
+| :-------------- | :------- | :--------------- | :------- | -------------------- | ------------------ | --------------------------------------------------- |
+| noTrailingSlash | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to hide the breadcrumb trailing slash |
+| skeleton        | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to display skeleton state             |
 
 ### Slots
 
@@ -297,10 +297,10 @@ None.
 
 ### Props
 
-| Prop name     | Kind             | Reactive | Type                 | Default value          | Description                                                      |
-| :------------ | :--------------- | :------- | :------------------- | ---------------------- | ---------------------------------------------------------------- |
-| href          | <code>let</code> | No       | <code>string</code>  | <code>undefined</code> | Set the `href` to use an anchor link                             |
-| isCurrentPage | <code>let</code> | No       | <code>boolean</code> | <code>false</code>     | Set to `true` if the breadcrumb item represents the current page |
+| Prop name     | Required | Kind             | Reactive | Type                 | Default value          | Description                                                      |
+| :------------ | :------- | :--------------- | :------- | -------------------- | ---------------------- | ---------------------------------------------------------------- |
+| href          | No       | <code>let</code> | No       | <code>string</code>  | <code>undefined</code> | Set the `href` to use an anchor link                             |
+| isCurrentPage | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code>     | Set to `true` if the breadcrumb item represents the current page |
 
 ### Slots
 
@@ -321,10 +321,10 @@ None.
 
 ### Props
 
-| Prop name       | Kind             | Reactive | Type                 | Default value      | Description                                         |
-| :-------------- | :--------------- | :------- | :------------------- | ------------------ | --------------------------------------------------- |
-| noTrailingSlash | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to hide the breadcrumb trailing slash |
-| count           | <code>let</code> | No       | <code>number</code>  | <code>3</code>     | Specify the number of breadcrumb items to render    |
+| Prop name       | Required | Kind             | Reactive | Type                 | Default value      | Description                                         |
+| :-------------- | :------- | :--------------- | :------- | -------------------- | ------------------ | --------------------------------------------------- |
+| noTrailingSlash | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to hide the breadcrumb trailing slash |
+| count           | No       | <code>let</code> | No       | <code>number</code>  | <code>3</code>     | Specify the number of breadcrumb items to render    |
 
 ### Slots
 
@@ -351,10 +351,10 @@ export type BreakpointValue = 320 | 672 | 1056 | 1312 | 1584;
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                                         | Default value                                                             | Description                                       |
-| :-------- | :--------------- | :------- | :------------------------------------------- | ------------------------------------------------------------------------- | ------------------------------------------------- |
-| sizes     | <code>let</code> | Yes      | <code>Record<BreakpointSize, boolean></code> | <code>{ sm: false, md: false, lg: false, xlg: false, max: false, }</code> | Carbon grid sizes as an object                    |
-| size      | <code>let</code> | Yes      | <code>BreakpointSize</code>                  | <code>undefined</code>                                                    | Determine the current Carbon grid breakpoint size |
+| Prop name | Required | Kind             | Reactive | Type                                         | Default value                                                             | Description                                       |
+| :-------- | :------- | :--------------- | :------- | -------------------------------------------- | ------------------------------------------------------------------------- | ------------------------------------------------- |
+| sizes     | No       | <code>let</code> | Yes      | <code>Record<BreakpointSize, boolean></code> | <code>{ sm: false, md: false, lg: false, xlg: false, max: false, }</code> | Carbon grid sizes as an object                    |
+| size      | No       | <code>let</code> | Yes      | <code>BreakpointSize</code>                  | <code>undefined</code>                                                    | Determine the current Carbon grid breakpoint size |
 
 ### Slots
 
@@ -372,23 +372,23 @@ export type BreakpointValue = 320 | 672 | 1056 | 1312 | 1584;
 
 ### Props
 
-| Prop name        | Kind             | Reactive | Type                                                                                                                                      | Default value          | Description                                                                                                                                                                                   |
-| :--------------- | :--------------- | :------- | :---------------------------------------------------------------------------------------------------------------------------------------- | ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| ref              | <code>let</code> | Yes      | <code>null &#124; HTMLAnchorElement &#124; HTMLButtonElement</code>                                                                       | <code>null</code>      | Obtain a reference to the HTML element                                                                                                                                                        |
-| kind             | <code>let</code> | No       | <code>"primary" &#124; "secondary" &#124; "tertiary" &#124; "ghost" &#124; "danger" &#124; "danger-tertiary" &#124; "danger-ghost"</code> | <code>"primary"</code> | Specify the kind of button                                                                                                                                                                    |
-| size             | <code>let</code> | No       | <code>"default" &#124; "field" &#124; "small" &#124; "lg" &#124; "xl"</code>                                                              | <code>"default"</code> | Specify the size of button                                                                                                                                                                    |
-| expressive       | <code>let</code> | No       | <code>boolean</code>                                                                                                                      | <code>false</code>     | Set to `true` to use Carbon's expressive typesetting                                                                                                                                          |
-| isSelected       | <code>let</code> | No       | <code>boolean</code>                                                                                                                      | <code>false</code>     | Set to `true` to enable the selected state for an icon-only, ghost button                                                                                                                     |
-| icon             | <code>let</code> | No       | <code>typeof import("svelte").SvelteComponent</code>                                                                                      | <code>undefined</code> | Specify the icon to render                                                                                                                                                                    |
-| iconDescription  | <code>let</code> | No       | <code>string</code>                                                                                                                       | <code>undefined</code> | Specify the ARIA label for the button icon                                                                                                                                                    |
-| tooltipAlignment | <code>let</code> | No       | <code>"start" &#124; "center" &#124; "end"</code>                                                                                         | <code>"center"</code>  | Set the alignment of the tooltip relative to the icon.<br />Only applies to icon-only buttons                                                                                                 |
-| tooltipPosition  | <code>let</code> | No       | <code>"top" &#124; "right" &#124; "bottom" &#124; "left"</code>                                                                           | <code>"bottom"</code>  | Set the position of the tooltip relative to the icon                                                                                                                                          |
-| as               | <code>let</code> | No       | <code>boolean</code>                                                                                                                      | <code>false</code>     | Set to `true` to render a custom HTML element<br />Props are destructured as `props` in the default slot (e.g., &lt;Button let:props&gt;&lt;div {...props}&gt;...&lt;/div&gt;&lt;/Button&gt;) |
-| skeleton         | <code>let</code> | No       | <code>boolean</code>                                                                                                                      | <code>false</code>     | Set to `true` to display the skeleton state                                                                                                                                                   |
-| disabled         | <code>let</code> | No       | <code>boolean</code>                                                                                                                      | <code>false</code>     | Set to `true` to disable the button                                                                                                                                                           |
-| href             | <code>let</code> | No       | <code>string</code>                                                                                                                       | <code>undefined</code> | Set the `href` to use an anchor link                                                                                                                                                          |
-| tabindex         | <code>let</code> | No       | <code>string</code>                                                                                                                       | <code>"0"</code>       | Specify the tabindex                                                                                                                                                                          |
-| type             | <code>let</code> | No       | <code>string</code>                                                                                                                       | <code>"button"</code>  | Specify the `type` attribute for the button element                                                                                                                                           |
+| Prop name        | Required | Kind             | Reactive | Type                                                                                                                                      | Default value          | Description                                                                                                                                                                                   |
+| :--------------- | :------- | :--------------- | :------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ref              | No       | <code>let</code> | Yes      | <code>null &#124; HTMLAnchorElement &#124; HTMLButtonElement</code>                                                                       | <code>null</code>      | Obtain a reference to the HTML element                                                                                                                                                        |
+| kind             | No       | <code>let</code> | No       | <code>"primary" &#124; "secondary" &#124; "tertiary" &#124; "ghost" &#124; "danger" &#124; "danger-tertiary" &#124; "danger-ghost"</code> | <code>"primary"</code> | Specify the kind of button                                                                                                                                                                    |
+| size             | No       | <code>let</code> | No       | <code>"default" &#124; "field" &#124; "small" &#124; "lg" &#124; "xl"</code>                                                              | <code>"default"</code> | Specify the size of button                                                                                                                                                                    |
+| expressive       | No       | <code>let</code> | No       | <code>boolean</code>                                                                                                                      | <code>false</code>     | Set to `true` to use Carbon's expressive typesetting                                                                                                                                          |
+| isSelected       | No       | <code>let</code> | No       | <code>boolean</code>                                                                                                                      | <code>false</code>     | Set to `true` to enable the selected state for an icon-only, ghost button                                                                                                                     |
+| icon             | No       | <code>let</code> | No       | <code>typeof import("svelte").SvelteComponent</code>                                                                                      | <code>undefined</code> | Specify the icon to render                                                                                                                                                                    |
+| iconDescription  | No       | <code>let</code> | No       | <code>string</code>                                                                                                                       | <code>undefined</code> | Specify the ARIA label for the button icon                                                                                                                                                    |
+| tooltipAlignment | No       | <code>let</code> | No       | <code>"start" &#124; "center" &#124; "end"</code>                                                                                         | <code>"center"</code>  | Set the alignment of the tooltip relative to the icon.<br />Only applies to icon-only buttons                                                                                                 |
+| tooltipPosition  | No       | <code>let</code> | No       | <code>"top" &#124; "right" &#124; "bottom" &#124; "left"</code>                                                                           | <code>"bottom"</code>  | Set the position of the tooltip relative to the icon                                                                                                                                          |
+| as               | No       | <code>let</code> | No       | <code>boolean</code>                                                                                                                      | <code>false</code>     | Set to `true` to render a custom HTML element<br />Props are destructured as `props` in the default slot (e.g., &lt;Button let:props&gt;&lt;div {...props}&gt;...&lt;/div&gt;&lt;/Button&gt;) |
+| skeleton         | No       | <code>let</code> | No       | <code>boolean</code>                                                                                                                      | <code>false</code>     | Set to `true` to display the skeleton state                                                                                                                                                   |
+| disabled         | No       | <code>let</code> | No       | <code>boolean</code>                                                                                                                      | <code>false</code>     | Set to `true` to disable the button                                                                                                                                                           |
+| href             | No       | <code>let</code> | No       | <code>string</code>                                                                                                                       | <code>undefined</code> | Set the `href` to use an anchor link                                                                                                                                                          |
+| tabindex         | No       | <code>let</code> | No       | <code>string</code>                                                                                                                       | <code>"0"</code>       | Specify the tabindex                                                                                                                                                                          |
+| type             | No       | <code>let</code> | No       | <code>string</code>                                                                                                                       | <code>"button"</code>  | Specify the `type` attribute for the button element                                                                                                                                           |
 
 ### Slots
 
@@ -409,9 +409,9 @@ export type BreakpointValue = 320 | 672 | 1056 | 1312 | 1584;
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                 | Default value      | Description                                   |
-| :-------- | :--------------- | :------- | :------------------- | ------------------ | --------------------------------------------- |
-| stacked   | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to stack the buttons vertically |
+| Prop name | Required | Kind             | Reactive | Type                 | Default value      | Description                                   |
+| :-------- | :------- | :--------------- | :------- | -------------------- | ------------------ | --------------------------------------------- |
+| stacked   | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to stack the buttons vertically |
 
 ### Slots
 
@@ -427,10 +427,10 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                                                                         | Default value          | Description                          |
-| :-------- | :--------------- | :------- | :--------------------------------------------------------------------------- | ---------------------- | ------------------------------------ |
-| href      | <code>let</code> | No       | <code>string</code>                                                          | <code>undefined</code> | Set the `href` to use an anchor link |
-| size      | <code>let</code> | No       | <code>"default" &#124; "field" &#124; "small" &#124; "lg" &#124; "xl"</code> | <code>"default"</code> | Specify the size of button skeleton  |
+| Prop name | Required | Kind             | Reactive | Type                                                                         | Default value          | Description                          |
+| :-------- | :------- | :--------------- | :------- | ---------------------------------------------------------------------------- | ---------------------- | ------------------------------------ |
+| href      | No       | <code>let</code> | No       | <code>string</code>                                                          | <code>undefined</code> | Set the `href` to use an anchor link |
+| size      | No       | <code>let</code> | No       | <code>"default" &#124; "field" &#124; "small" &#124; "lg" &#124; "xl"</code> | <code>"default"</code> | Specify the size of button skeleton  |
 
 ### Slots
 
@@ -449,22 +449,22 @@ None.
 
 ### Props
 
-| Prop name     | Kind             | Reactive | Type                                      | Default value                                    | Description                                       |
-| :------------ | :--------------- | :------- | :---------------------------------------- | ------------------------------------------------ | ------------------------------------------------- |
-| ref           | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code> | <code>null</code>                                | Obtain a reference to the input HTML element      |
-| group         | <code>let</code> | Yes      | <code>any[]</code>                        | <code>undefined</code>                           | Specify the bound group                           |
-| checked       | <code>let</code> | Yes      | <code>boolean</code>                      | <code>false</code>                               | Specify whether the checkbox is checked           |
-| value         | <code>let</code> | No       | <code>any</code>                          | <code>""</code>                                  | Specify the value of the checkbox                 |
-| indeterminate | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Specify whether the checkbox is indeterminate     |
-| skeleton      | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to display the skeleton state       |
-| required      | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to mark the field as required       |
-| readonly      | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` for the checkbox to be read-only    |
-| disabled      | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to disable the checkbox             |
-| labelText     | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Specify the label text                            |
-| hideLabel     | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to visually hide the label text     |
-| name          | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Set a name for the input element                  |
-| title         | <code>let</code> | No       | <code>string</code>                       | <code>undefined</code>                           | Specify the title attribute for the label element |
-| id            | <code>let</code> | No       | <code>string</code>                       | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the input label                     |
+| Prop name     | Required | Kind             | Reactive | Type                                      | Default value                                    | Description                                       |
+| :------------ | :------- | :--------------- | :------- | ----------------------------------------- | ------------------------------------------------ | ------------------------------------------------- |
+| ref           | No       | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code> | <code>null</code>                                | Obtain a reference to the input HTML element      |
+| group         | No       | <code>let</code> | Yes      | <code>any[]</code>                        | <code>undefined</code>                           | Specify the bound group                           |
+| checked       | No       | <code>let</code> | Yes      | <code>boolean</code>                      | <code>false</code>                               | Specify whether the checkbox is checked           |
+| value         | No       | <code>let</code> | No       | <code>any</code>                          | <code>""</code>                                  | Specify the value of the checkbox                 |
+| indeterminate | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Specify whether the checkbox is indeterminate     |
+| skeleton      | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to display the skeleton state       |
+| required      | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to mark the field as required       |
+| readonly      | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` for the checkbox to be read-only    |
+| disabled      | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to disable the checkbox             |
+| labelText     | No       | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Specify the label text                            |
+| hideLabel     | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to visually hide the label text     |
+| name          | No       | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Set a name for the input element                  |
+| title         | No       | <code>let</code> | No       | <code>string</code>                       | <code>undefined</code>                           | Specify the title attribute for the label element |
+| id            | No       | <code>let</code> | No       | <code>string</code>                       | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the input label                     |
 
 ### Slots
 
@@ -507,12 +507,12 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                 | Default value          | Description                               |
-| :-------- | :--------------- | :------- | :------------------- | ---------------------- | ----------------------------------------- |
-| clicked   | <code>let</code> | Yes      | <code>boolean</code> | <code>false</code>     | Set to `true` to click the tile           |
-| light     | <code>let</code> | No       | <code>boolean</code> | <code>false</code>     | Set to `true` to enable the light variant |
-| disabled  | <code>let</code> | No       | <code>boolean</code> | <code>false</code>     | Set to `true` to disable the tile         |
-| href      | <code>let</code> | No       | <code>string</code>  | <code>undefined</code> | Set the `href`                            |
+| Prop name | Required | Kind             | Reactive | Type                 | Default value          | Description                               |
+| :-------- | :------- | :--------------- | :------- | -------------------- | ---------------------- | ----------------------------------------- |
+| clicked   | No       | <code>let</code> | Yes      | <code>boolean</code> | <code>false</code>     | Set to `true` to click the tile           |
+| light     | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code>     | Set to `true` to enable the light variant |
+| disabled  | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code>     | Set to `true` to disable the tile         |
+| href      | No       | <code>let</code> | No       | <code>string</code>  | <code>undefined</code> | Set the `href`                            |
 
 ### Slots
 
@@ -534,26 +534,26 @@ None.
 
 ### Props
 
-| Prop name             | Kind             | Reactive | Type                                                 | Default value                                                                                                     | Description                                                                                                                                                                   |
-| :-------------------- | :--------------- | :------- | :--------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| ref                   | <code>let</code> | Yes      | <code>null &#124; HTMLPreElement</code>              | <code>null</code>                                                                                                 | Obtain a reference to the pre HTML element                                                                                                                                    |
-| showMoreLess          | <code>let</code> | Yes      | <code>boolean</code>                                 | <code>false</code>                                                                                                | Set to `true` to enable the show more/less button                                                                                                                             |
-| expanded              | <code>let</code> | Yes      | <code>boolean</code>                                 | <code>false</code>                                                                                                | Set to `true` to expand a multi-line code snippet (type="multi")                                                                                                              |
-| type                  | <code>let</code> | No       | <code>"single" &#124; "inline" &#124; "multi"</code> | <code>"single"</code>                                                                                             | Set the type of code snippet                                                                                                                                                  |
-| code                  | <code>let</code> | No       | <code>string</code>                                  | <code>undefined</code>                                                                                            | Set the code snippet text<br />Alternatively, use the default slot (e.g., &lt;CodeSnippet&gt;{`code`}&lt;/CodeSnippet&gt;)<br />You must use the `code` prop to copy the code |
-| copy                  | <code>let</code> | No       | <code>(code: string) => void</code>                  | <code>async (code) => { try { await navigator.clipboard.writeText(code); } catch (e) { console.log(e); } }</code> | Override the default copy behavior of using the navigator.clipboard.writeText API to copy text                                                                                |
-| hideCopyButton        | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>                                                                                                | Set to `true` to hide the copy button                                                                                                                                         |
-| disabled              | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>                                                                                                | Set to `true` for the disabled variant<br />Only applies to the "single", "multi" types                                                                                       |
-| wrapText              | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>                                                                                                | Set to `true` to wrap the text<br />Note that `type` must be "multi"                                                                                                          |
-| light                 | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>                                                                                                | Set to `true` to enable the light variant                                                                                                                                     |
-| skeleton              | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>                                                                                                | Set to `true` to display the skeleton state                                                                                                                                   |
-| copyButtonDescription | <code>let</code> | No       | <code>string</code>                                  | <code>undefined</code>                                                                                            | Specify the ARIA label for the copy button icon                                                                                                                               |
-| copyLabel             | <code>let</code> | No       | <code>string</code>                                  | <code>undefined</code>                                                                                            | Specify the ARIA label of the copy button                                                                                                                                     |
-| feedback              | <code>let</code> | No       | <code>string</code>                                  | <code>"Copied!"</code>                                                                                            | Specify the feedback text displayed when clicking the snippet                                                                                                                 |
-| feedbackTimeout       | <code>let</code> | No       | <code>number</code>                                  | <code>2000</code>                                                                                                 | Set the timeout duration (ms) to display feedback text                                                                                                                        |
-| showLessText          | <code>let</code> | No       | <code>string</code>                                  | <code>"Show less"</code>                                                                                          | Specify the show less text<br />`type` must be "multi"                                                                                                                        |
-| showMoreText          | <code>let</code> | No       | <code>string</code>                                  | <code>"Show more"</code>                                                                                          | Specify the show more text<br />`type` must be "multi"                                                                                                                        |
-| id                    | <code>let</code> | No       | <code>string</code>                                  | <code>"ccs-" + Math.random().toString(36)</code>                                                                  | Set an id for the code element                                                                                                                                                |
+| Prop name             | Required | Kind             | Reactive | Type                                                 | Default value                                                                                                     | Description                                                                                                                                                                   |
+| :-------------------- | :------- | :--------------- | :------- | ---------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ref                   | No       | <code>let</code> | Yes      | <code>null &#124; HTMLPreElement</code>              | <code>null</code>                                                                                                 | Obtain a reference to the pre HTML element                                                                                                                                    |
+| showMoreLess          | No       | <code>let</code> | Yes      | <code>boolean</code>                                 | <code>false</code>                                                                                                | Set to `true` to enable the show more/less button                                                                                                                             |
+| expanded              | No       | <code>let</code> | Yes      | <code>boolean</code>                                 | <code>false</code>                                                                                                | Set to `true` to expand a multi-line code snippet (type="multi")                                                                                                              |
+| type                  | No       | <code>let</code> | No       | <code>"single" &#124; "inline" &#124; "multi"</code> | <code>"single"</code>                                                                                             | Set the type of code snippet                                                                                                                                                  |
+| code                  | No       | <code>let</code> | No       | <code>string</code>                                  | <code>undefined</code>                                                                                            | Set the code snippet text<br />Alternatively, use the default slot (e.g., &lt;CodeSnippet&gt;{`code`}&lt;/CodeSnippet&gt;)<br />You must use the `code` prop to copy the code |
+| copy                  | No       | <code>let</code> | No       | <code>(code: string) => void</code>                  | <code>async (code) => { try { await navigator.clipboard.writeText(code); } catch (e) { console.log(e); } }</code> | Override the default copy behavior of using the navigator.clipboard.writeText API to copy text                                                                                |
+| hideCopyButton        | No       | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>                                                                                                | Set to `true` to hide the copy button                                                                                                                                         |
+| disabled              | No       | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>                                                                                                | Set to `true` for the disabled variant<br />Only applies to the "single", "multi" types                                                                                       |
+| wrapText              | No       | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>                                                                                                | Set to `true` to wrap the text<br />Note that `type` must be "multi"                                                                                                          |
+| light                 | No       | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>                                                                                                | Set to `true` to enable the light variant                                                                                                                                     |
+| skeleton              | No       | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>                                                                                                | Set to `true` to display the skeleton state                                                                                                                                   |
+| copyButtonDescription | No       | <code>let</code> | No       | <code>string</code>                                  | <code>undefined</code>                                                                                            | Specify the ARIA label for the copy button icon                                                                                                                               |
+| copyLabel             | No       | <code>let</code> | No       | <code>string</code>                                  | <code>undefined</code>                                                                                            | Specify the ARIA label of the copy button                                                                                                                                     |
+| feedback              | No       | <code>let</code> | No       | <code>string</code>                                  | <code>"Copied!"</code>                                                                                            | Specify the feedback text displayed when clicking the snippet                                                                                                                 |
+| feedbackTimeout       | No       | <code>let</code> | No       | <code>number</code>                                  | <code>2000</code>                                                                                                 | Set the timeout duration (ms) to display feedback text                                                                                                                        |
+| showLessText          | No       | <code>let</code> | No       | <code>string</code>                                  | <code>"Show less"</code>                                                                                          | Specify the show less text<br />`type` must be "multi"                                                                                                                        |
+| showMoreText          | No       | <code>let</code> | No       | <code>string</code>                                  | <code>"Show more"</code>                                                                                          | Specify the show more text<br />`type` must be "multi"                                                                                                                        |
+| id                    | No       | <code>let</code> | No       | <code>string</code>                                  | <code>"ccs-" + Math.random().toString(36)</code>                                                                  | Set an id for the code element                                                                                                                                                |
 
 ### Slots
 
@@ -578,9 +578,9 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                                 | Default value         | Description                  |
-| :-------- | :--------------- | :------- | :----------------------------------- | --------------------- | ---------------------------- |
-| type      | <code>let</code> | No       | <code>"single" &#124; "multi"</code> | <code>"single"</code> | Set the type of code snippet |
+| Prop name | Required | Kind             | Reactive | Type                                 | Default value         | Description                  |
+| :-------- | :------- | :--------------- | :------- | ------------------------------------ | --------------------- | ---------------------------- |
+| type      | No       | <code>let</code> | No       | <code>"single" &#124; "multi"</code> | <code>"single"</code> | Set the type of code snippet |
 
 ### Slots
 
@@ -612,19 +612,19 @@ export type ColumnBreakpoint = ColumnSize | ColumnSizeDescriptor;
 
 ### Props
 
-| Prop name     | Kind             | Reactive | Type                                                                                               | Default value          | Description                                                                                                                                                                                           |
-| :------------ | :--------------- | :------- | :------------------------------------------------------------------------------------------------- | ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| as            | <code>let</code> | No       | <code>boolean</code>                                                                               | <code>false</code>     | Set to `true` to render a custom HTML element<br />Props are destructured as `props` in the default slot (e.g., &lt;Column let:props&gt;&lt;article {...props}&gt;...&lt;/article&gt;&lt;/Column&gt;) |
-| noGutter      | <code>let</code> | No       | <code>boolean</code>                                                                               | <code>false</code>     | Set to `true` to remove the gutter                                                                                                                                                                    |
-| noGutterLeft  | <code>let</code> | No       | <code>boolean</code>                                                                               | <code>false</code>     | Set to `true` to remove the left gutter                                                                                                                                                               |
-| noGutterRight | <code>let</code> | No       | <code>boolean</code>                                                                               | <code>false</code>     | Set to `true` to remove the right gutter                                                                                                                                                              |
-| padding       | <code>let</code> | No       | <code>boolean</code>                                                                               | <code>false</code>     | Set to `true` to add top and bottom padding to the column                                                                                                                                             |
-| aspectRatio   | <code>let</code> | No       | <code>"2x1" &#124; "16x9" &#124; "9x16" &#124; "1x2" &#124; "4x3" &#124; "3x4" &#124; "1x1"</code> | <code>undefined</code> | Specify the aspect ratio of the column                                                                                                                                                                |
-| sm            | <code>let</code> | No       | <code>ColumnBreakpoint</code>                                                                      | <code>undefined</code> | Set the small breakpoint                                                                                                                                                                              |
-| md            | <code>let</code> | No       | <code>ColumnBreakpoint</code>                                                                      | <code>undefined</code> | Set the medium breakpoint                                                                                                                                                                             |
-| lg            | <code>let</code> | No       | <code>ColumnBreakpoint</code>                                                                      | <code>undefined</code> | Set the large breakpoint                                                                                                                                                                              |
-| xlg           | <code>let</code> | No       | <code>ColumnBreakpoint</code>                                                                      | <code>undefined</code> | Set the extra large breakpoint                                                                                                                                                                        |
-| max           | <code>let</code> | No       | <code>ColumnBreakpoint</code>                                                                      | <code>undefined</code> | Set the maximum breakpoint                                                                                                                                                                            |
+| Prop name     | Required | Kind             | Reactive | Type                                                                                               | Default value          | Description                                                                                                                                                                                           |
+| :------------ | :------- | :--------------- | :------- | -------------------------------------------------------------------------------------------------- | ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| as            | No       | <code>let</code> | No       | <code>boolean</code>                                                                               | <code>false</code>     | Set to `true` to render a custom HTML element<br />Props are destructured as `props` in the default slot (e.g., &lt;Column let:props&gt;&lt;article {...props}&gt;...&lt;/article&gt;&lt;/Column&gt;) |
+| noGutter      | No       | <code>let</code> | No       | <code>boolean</code>                                                                               | <code>false</code>     | Set to `true` to remove the gutter                                                                                                                                                                    |
+| noGutterLeft  | No       | <code>let</code> | No       | <code>boolean</code>                                                                               | <code>false</code>     | Set to `true` to remove the left gutter                                                                                                                                                               |
+| noGutterRight | No       | <code>let</code> | No       | <code>boolean</code>                                                                               | <code>false</code>     | Set to `true` to remove the right gutter                                                                                                                                                              |
+| padding       | No       | <code>let</code> | No       | <code>boolean</code>                                                                               | <code>false</code>     | Set to `true` to add top and bottom padding to the column                                                                                                                                             |
+| aspectRatio   | No       | <code>let</code> | No       | <code>"2x1" &#124; "16x9" &#124; "9x16" &#124; "1x2" &#124; "4x3" &#124; "3x4" &#124; "1x1"</code> | <code>undefined</code> | Specify the aspect ratio of the column                                                                                                                                                                |
+| sm            | No       | <code>let</code> | No       | <code>ColumnBreakpoint</code>                                                                      | <code>undefined</code> | Set the small breakpoint                                                                                                                                                                              |
+| md            | No       | <code>let</code> | No       | <code>ColumnBreakpoint</code>                                                                      | <code>undefined</code> | Set the medium breakpoint                                                                                                                                                                             |
+| lg            | No       | <code>let</code> | No       | <code>ColumnBreakpoint</code>                                                                      | <code>undefined</code> | Set the large breakpoint                                                                                                                                                                              |
+| xlg           | No       | <code>let</code> | No       | <code>ColumnBreakpoint</code>                                                                      | <code>undefined</code> | Set the extra large breakpoint                                                                                                                                                                        |
+| max           | No       | <code>let</code> | No       | <code>ColumnBreakpoint</code>                                                                      | <code>undefined</code> | Set the maximum breakpoint                                                                                                                                                                            |
 
 ### Slots
 
@@ -651,32 +651,32 @@ export interface ComboBoxItem {
 
 ### Props
 
-| Prop name                | Kind                  | Reactive | Type                                                                                                  | Default value                                                                                                                                                                                                                | Description                                                                                                                                                 |
-| :----------------------- | :-------------------- | :------- | :---------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| listRef                  | <code>let</code>      | Yes      | <code>null &#124; HTMLDivElement</code>                                                               | <code>null</code>                                                                                                                                                                                                            | Obtain a reference to the list HTML element                                                                                                                 |
-| ref                      | <code>let</code>      | Yes      | <code>null &#124; HTMLInputElement</code>                                                             | <code>null</code>                                                                                                                                                                                                            | Obtain a reference to the input HTML element                                                                                                                |
-| open                     | <code>let</code>      | Yes      | <code>boolean</code>                                                                                  | <code>false</code>                                                                                                                                                                                                           | Set to `true` to open the combobox menu dropdown                                                                                                            |
-| value                    | <code>let</code>      | Yes      | <code>string</code>                                                                                   | <code>""</code>                                                                                                                                                                                                              | Specify the selected combobox value                                                                                                                         |
-| selectedId               | <code>let</code>      | Yes      | <code>ComboBoxItemId</code>                                                                           | <code>undefined</code>                                                                                                                                                                                                       | Set the selected item by value id                                                                                                                           |
-| items                    | <code>let</code>      | No       | <code>ComboBoxItem[]</code>                                                                           | <code>[]</code>                                                                                                                                                                                                              | Set the combobox items                                                                                                                                      |
-| itemToString             | <code>let</code>      | No       | <code>(item: ComboBoxItem) => string</code>                                                           | <code>(item) => item.text &#124;&#124; item.id</code>                                                                                                                                                                        | Override the display of a combobox item                                                                                                                     |
-| direction                | <code>let</code>      | No       | <code>"bottom" &#124; "top"</code>                                                                    | <code>"bottom"</code>                                                                                                                                                                                                        | Specify the direction of the combobox dropdown menu                                                                                                         |
-| size                     | <code>let</code>      | No       | <code>"sm" &#124; "xl"</code>                                                                         | <code>undefined</code>                                                                                                                                                                                                       | Set the size of the combobox                                                                                                                                |
-| disabled                 | <code>let</code>      | No       | <code>boolean</code>                                                                                  | <code>false</code>                                                                                                                                                                                                           | Set to `true` to disable the combobox                                                                                                                       |
-| titleText                | <code>let</code>      | No       | <code>string</code>                                                                                   | <code>""</code>                                                                                                                                                                                                              | Specify the title text of the combobox                                                                                                                      |
-| placeholder              | <code>let</code>      | No       | <code>string</code>                                                                                   | <code>""</code>                                                                                                                                                                                                              | Specify the placeholder text                                                                                                                                |
-| helperText               | <code>let</code>      | No       | <code>string</code>                                                                                   | <code>""</code>                                                                                                                                                                                                              | Specify the helper text                                                                                                                                     |
-| invalidText              | <code>let</code>      | No       | <code>string</code>                                                                                   | <code>""</code>                                                                                                                                                                                                              | Specify the invalid state text                                                                                                                              |
-| invalid                  | <code>let</code>      | No       | <code>boolean</code>                                                                                  | <code>false</code>                                                                                                                                                                                                           | Set to `true` to indicate an invalid state                                                                                                                  |
-| warn                     | <code>let</code>      | No       | <code>boolean</code>                                                                                  | <code>false</code>                                                                                                                                                                                                           | Set to `true` to indicate an warning state                                                                                                                  |
-| warnText                 | <code>let</code>      | No       | <code>string</code>                                                                                   | <code>""</code>                                                                                                                                                                                                              | Specify the warning state text                                                                                                                              |
-| light                    | <code>let</code>      | No       | <code>boolean</code>                                                                                  | <code>false</code>                                                                                                                                                                                                           | Set to `true` to enable the light variant                                                                                                                   |
-| shouldFilterItem         | <code>let</code>      | No       | <code>(item: ComboBoxItem, value: string) => boolean</code>                                           | <code>() => true</code>                                                                                                                                                                                                      | Determine if an item should be filtered given the current combobox value                                                                                    |
-| translateWithId          | <code>let</code>      | No       | <code>(id: import("../ListBox/ListBoxMenuIcon.svelte").ListBoxMenuIconTranslationId) => string</code> | <code>undefined</code>                                                                                                                                                                                                       | Override the chevron icon label based on the open state.<br />Defaults to "Open menu" when closed and "Close menu" when open                                |
-| translateWithIdSelection | <code>let</code>      | No       | <code>(id: "clearSelection") => string</code>                                                         | <code>undefined</code>                                                                                                                                                                                                       | Override the label of the clear button when the input has a selection.<br />Defaults to "Clear selected item" since a combo box can only have on selection. |
-| id                       | <code>let</code>      | No       | <code>string</code>                                                                                   | <code>"ccs-" + Math.random().toString(36)</code>                                                                                                                                                                             | Set an id for the list box component                                                                                                                        |
-| name                     | <code>let</code>      | No       | <code>string</code>                                                                                   | <code>undefined</code>                                                                                                                                                                                                       | Specify a name attribute for the input                                                                                                                      |
-| clear                    | <code>function</code> | No       | <code>(options?: { focus?: boolean; }) => void</code>                                                 | <code>() => { prevSelectedId = null; highlightedIndex = -1; highlightedId = undefined; selectedId = undefined; selectedItem = undefined; open = false; inputValue = ""; if (options?.focus !== false) ref?.focus(); }</code> | Clear the combo box programmatically                                                                                                                        |
+| Prop name                | Required | Kind                  | Reactive | Type                                                                                                  | Default value                                                                                                                                                                                                                | Description                                                                                                                                                 |
+| :----------------------- | :------- | :-------------------- | :------- | ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| listRef                  | No       | <code>let</code>      | Yes      | <code>null &#124; HTMLDivElement</code>                                                               | <code>null</code>                                                                                                                                                                                                            | Obtain a reference to the list HTML element                                                                                                                 |
+| ref                      | No       | <code>let</code>      | Yes      | <code>null &#124; HTMLInputElement</code>                                                             | <code>null</code>                                                                                                                                                                                                            | Obtain a reference to the input HTML element                                                                                                                |
+| open                     | No       | <code>let</code>      | Yes      | <code>boolean</code>                                                                                  | <code>false</code>                                                                                                                                                                                                           | Set to `true` to open the combobox menu dropdown                                                                                                            |
+| value                    | No       | <code>let</code>      | Yes      | <code>string</code>                                                                                   | <code>""</code>                                                                                                                                                                                                              | Specify the selected combobox value                                                                                                                         |
+| selectedId               | No       | <code>let</code>      | Yes      | <code>ComboBoxItemId</code>                                                                           | <code>undefined</code>                                                                                                                                                                                                       | Set the selected item by value id                                                                                                                           |
+| items                    | No       | <code>let</code>      | No       | <code>ComboBoxItem[]</code>                                                                           | <code>[]</code>                                                                                                                                                                                                              | Set the combobox items                                                                                                                                      |
+| itemToString             | No       | <code>let</code>      | No       | <code>(item: ComboBoxItem) => string</code>                                                           | <code>(item) => item.text &#124;&#124; item.id</code>                                                                                                                                                                        | Override the display of a combobox item                                                                                                                     |
+| direction                | No       | <code>let</code>      | No       | <code>"bottom" &#124; "top"</code>                                                                    | <code>"bottom"</code>                                                                                                                                                                                                        | Specify the direction of the combobox dropdown menu                                                                                                         |
+| size                     | No       | <code>let</code>      | No       | <code>"sm" &#124; "xl"</code>                                                                         | <code>undefined</code>                                                                                                                                                                                                       | Set the size of the combobox                                                                                                                                |
+| disabled                 | No       | <code>let</code>      | No       | <code>boolean</code>                                                                                  | <code>false</code>                                                                                                                                                                                                           | Set to `true` to disable the combobox                                                                                                                       |
+| titleText                | No       | <code>let</code>      | No       | <code>string</code>                                                                                   | <code>""</code>                                                                                                                                                                                                              | Specify the title text of the combobox                                                                                                                      |
+| placeholder              | No       | <code>let</code>      | No       | <code>string</code>                                                                                   | <code>""</code>                                                                                                                                                                                                              | Specify the placeholder text                                                                                                                                |
+| helperText               | No       | <code>let</code>      | No       | <code>string</code>                                                                                   | <code>""</code>                                                                                                                                                                                                              | Specify the helper text                                                                                                                                     |
+| invalidText              | No       | <code>let</code>      | No       | <code>string</code>                                                                                   | <code>""</code>                                                                                                                                                                                                              | Specify the invalid state text                                                                                                                              |
+| invalid                  | No       | <code>let</code>      | No       | <code>boolean</code>                                                                                  | <code>false</code>                                                                                                                                                                                                           | Set to `true` to indicate an invalid state                                                                                                                  |
+| warn                     | No       | <code>let</code>      | No       | <code>boolean</code>                                                                                  | <code>false</code>                                                                                                                                                                                                           | Set to `true` to indicate an warning state                                                                                                                  |
+| warnText                 | No       | <code>let</code>      | No       | <code>string</code>                                                                                   | <code>""</code>                                                                                                                                                                                                              | Specify the warning state text                                                                                                                              |
+| light                    | No       | <code>let</code>      | No       | <code>boolean</code>                                                                                  | <code>false</code>                                                                                                                                                                                                           | Set to `true` to enable the light variant                                                                                                                   |
+| shouldFilterItem         | No       | <code>let</code>      | No       | <code>(item: ComboBoxItem, value: string) => boolean</code>                                           | <code>() => true</code>                                                                                                                                                                                                      | Determine if an item should be filtered given the current combobox value                                                                                    |
+| translateWithId          | No       | <code>let</code>      | No       | <code>(id: import("../ListBox/ListBoxMenuIcon.svelte").ListBoxMenuIconTranslationId) => string</code> | <code>undefined</code>                                                                                                                                                                                                       | Override the chevron icon label based on the open state.<br />Defaults to "Open menu" when closed and "Close menu" when open                                |
+| translateWithIdSelection | No       | <code>let</code>      | No       | <code>(id: "clearSelection") => string</code>                                                         | <code>undefined</code>                                                                                                                                                                                                       | Override the label of the clear button when the input has a selection.<br />Defaults to "Clear selected item" since a combo box can only have on selection. |
+| id                       | No       | <code>let</code>      | No       | <code>string</code>                                                                                   | <code>"ccs-" + Math.random().toString(36)</code>                                                                                                                                                                             | Set an id for the list box component                                                                                                                        |
+| name                     | No       | <code>let</code>      | No       | <code>string</code>                                                                                   | <code>undefined</code>                                                                                                                                                                                                       | Specify a name attribute for the input                                                                                                                      |
+| clear                    | No       | <code>function</code> | No       | <code>(options?: { focus?: boolean; }) => void</code>                                                 | <code>() => { prevSelectedId = null; highlightedIndex = -1; highlightedId = undefined; selectedId = undefined; selectedItem = undefined; open = false; inputValue = ""; if (options?.focus !== false) ref?.focus(); }</code> | Clear the combo box programmatically                                                                                                                        |
 
 ### Slots
 
@@ -700,15 +700,15 @@ export interface ComboBoxItem {
 
 ### Props
 
-| Prop name                  | Kind             | Reactive | Type                                      | Default value                             | Description                                                           |
-| :------------------------- | :--------------- | :------- | :---------------------------------------- | ----------------------------------------- | --------------------------------------------------------------------- |
-| ref                        | <code>let</code> | Yes      | <code>null &#124; HTMLDivElement</code>   | <code>null</code>                         | Obtain a reference to the top-level HTML element                      |
-| open                       | <code>let</code> | Yes      | <code>boolean</code>                      | <code>false</code>                        | Set to `true` to open the modal                                       |
-| size                       | <code>let</code> | No       | <code>"xs" &#124; "sm" &#124; "lg"</code> | <code>undefined</code>                    | Set the size of the composed modal                                    |
-| danger                     | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                        | Set to `true` to use the danger variant                               |
-| preventCloseOnClickOutside | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                        | Set to `true` to prevent the modal from closing when clicking outside |
-| containerClass             | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                           | Specify a class for the inner modal                                   |
-| selectorPrimaryFocus       | <code>let</code> | No       | <code>null &#124; string</code>           | <code>"[data-modal-primary-focus]"</code> | Specify a selector to be focused when opening the modal               |
+| Prop name                  | Required | Kind             | Reactive | Type                                      | Default value                             | Description                                                           |
+| :------------------------- | :------- | :--------------- | :------- | ----------------------------------------- | ----------------------------------------- | --------------------------------------------------------------------- |
+| ref                        | No       | <code>let</code> | Yes      | <code>null &#124; HTMLDivElement</code>   | <code>null</code>                         | Obtain a reference to the top-level HTML element                      |
+| open                       | No       | <code>let</code> | Yes      | <code>boolean</code>                      | <code>false</code>                        | Set to `true` to open the modal                                       |
+| size                       | No       | <code>let</code> | No       | <code>"xs" &#124; "sm" &#124; "lg"</code> | <code>undefined</code>                    | Set the size of the composed modal                                    |
+| danger                     | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                        | Set to `true` to use the danger variant                               |
+| preventCloseOnClickOutside | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                        | Set to `true` to prevent the modal from closing when clicking outside |
+| containerClass             | No       | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                           | Specify a class for the inner modal                                   |
+| selectorPrimaryFocus       | No       | <code>let</code> | No       | <code>null &#124; string</code>           | <code>"[data-modal-primary-focus]"</code> | Specify a selector to be focused when opening the modal               |
 
 ### Slots
 
@@ -735,9 +735,9 @@ export interface ComboBoxItem {
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                | Default value               | Description                         |
-| :-------- | :--------------- | :------- | :------------------ | --------------------------- | ----------------------------------- |
-| id        | <code>let</code> | No       | <code>string</code> | <code>"main-content"</code> | Specify the id for the main element |
+| Prop name | Required | Kind             | Reactive | Type                | Default value               | Description                         |
+| :-------- | :------- | :--------------- | :------- | ------------------- | --------------------------- | ----------------------------------- |
+| id        | No       | <code>let</code> | No       | <code>string</code> | <code>"main-content"</code> | Specify the id for the main element |
 
 ### Slots
 
@@ -753,10 +753,10 @@ None.
 
 ### Props
 
-| Prop name     | Kind             | Reactive | Type                          | Default value          | Description                               |
-| :------------ | :--------------- | :------- | :---------------------------- | ---------------------- | ----------------------------------------- |
-| selectedIndex | <code>let</code> | Yes      | <code>number</code>           | <code>0</code>         | Set the selected index of the switch item |
-| size          | <code>let</code> | No       | <code>"sm" &#124; "xl"</code> | <code>undefined</code> | Specify the size of the content switcher  |
+| Prop name     | Required | Kind             | Reactive | Type                          | Default value          | Description                               |
+| :------------ | :------- | :--------------- | :------- | ----------------------------- | ---------------------- | ----------------------------------------- |
+| selectedIndex | No       | <code>let</code> | Yes      | <code>number</code>           | <code>0</code>         | Set the selected index of the switch item |
+| size          | No       | <code>let</code> | No       | <code>"sm" &#124; "xl"</code> | <code>undefined</code> | Specify the size of the content switcher  |
 
 ### Slots
 
@@ -778,13 +778,13 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                                                      | Default value      | Description                                                                                                                                        |
-| :-------- | :--------------- | :------- | :-------------------------------------------------------- | ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| ref       | <code>let</code> | Yes      | <code>null &#124; HTMLUListElement</code>                 | <code>null</code>  | Obtain a reference to the unordered list HTML element                                                                                              |
-| y         | <code>let</code> | Yes      | <code>number</code>                                       | <code>0</code>     | Specify the vertical offset of the menu position                                                                                                   |
-| x         | <code>let</code> | Yes      | <code>number</code>                                       | <code>0</code>     | Specify the horizontal offset of the menu position                                                                                                 |
-| open      | <code>let</code> | Yes      | <code>boolean</code>                                      | <code>false</code> | Set to `true` to open the menu<br />Either `x` and `y` must be greater than zero                                                                   |
-| target    | <code>let</code> | No       | <code>null &#124; HTMLElement &#124; HTMLElement[]</code> | <code>null</code>  | Specify an element or list of elements to trigger the context menu.<br />If no element is specified, the context menu applies to the entire window |
+| Prop name | Required | Kind             | Reactive | Type                                                      | Default value      | Description                                                                                                                                        |
+| :-------- | :------- | :--------------- | :------- | --------------------------------------------------------- | ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ref       | No       | <code>let</code> | Yes      | <code>null &#124; HTMLUListElement</code>                 | <code>null</code>  | Obtain a reference to the unordered list HTML element                                                                                              |
+| y         | No       | <code>let</code> | Yes      | <code>number</code>                                       | <code>0</code>     | Specify the vertical offset of the menu position                                                                                                   |
+| x         | No       | <code>let</code> | Yes      | <code>number</code>                                       | <code>0</code>     | Specify the horizontal offset of the menu position                                                                                                 |
+| open      | No       | <code>let</code> | Yes      | <code>boolean</code>                                      | <code>false</code> | Set to `true` to open the menu<br />Either `x` and `y` must be greater than zero                                                                   |
+| target    | No       | <code>let</code> | No       | <code>null &#124; HTMLElement &#124; HTMLElement[]</code> | <code>null</code>  | Specify an element or list of elements to trigger the context menu.<br />If no element is specified, the context menu applies to the entire window |
 
 ### Slots
 
@@ -819,10 +819,10 @@ None.
 
 ### Props
 
-| Prop name   | Kind             | Reactive | Type                  | Default value   | Description            |
-| :---------- | :--------------- | :------- | :-------------------- | --------------- | ---------------------- |
-| selectedIds | <code>let</code> | Yes      | <code>string[]</code> | <code>[]</code> | --                     |
-| labelText   | <code>let</code> | No       | <code>string</code>   | <code>""</code> | Specify the label text |
+| Prop name   | Required | Kind             | Reactive | Type                  | Default value   | Description            |
+| :---------- | :------- | :--------------- | :------- | --------------------- | --------------- | ---------------------- |
+| selectedIds | No       | <code>let</code> | Yes      | <code>string[]</code> | <code>[]</code> | --                     |
+| labelText   | No       | <code>let</code> | No       | <code>string</code>   | <code>""</code> | Specify the label text |
 
 ### Slots
 
@@ -838,18 +838,18 @@ None.
 
 ### Props
 
-| Prop name    | Kind             | Reactive | Type                                                 | Default value                                    | Description                                                                                                                        |
-| :----------- | :--------------- | :------- | :--------------------------------------------------- | ------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------- |
-| ref          | <code>let</code> | Yes      | <code>null &#124; HTMLLIElement</code>               | <code>null</code>                                | Obtain a reference to the list item HTML element                                                                                   |
-| selectable   | <code>let</code> | Yes      | <code>boolean</code>                                 | <code>false</code>                               | Set to `true` to enable the selectable variant<br />Automatically set to `true` if `selected` is `true`                            |
-| selected     | <code>let</code> | Yes      | <code>boolean</code>                                 | <code>false</code>                               | Set to `true` to use the selected variant                                                                                          |
-| icon         | <code>let</code> | Yes      | <code>typeof import("svelte").SvelteComponent</code> | <code>undefined</code>                           | Specify the icon to render<br />Icon is rendered to the left of the label text                                                     |
-| indented     | <code>let</code> | Yes      | <code>boolean</code>                                 | <code>false</code>                               | Set to `true` to indent the label                                                                                                  |
-| kind         | <code>let</code> | No       | <code>"default" &#124; "danger"</code>               | <code>"default"</code>                           | Specify the kind of option                                                                                                         |
-| disabled     | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>                               | Set to `true` to enable the disabled state                                                                                         |
-| labelText    | <code>let</code> | No       | <code>string</code>                                  | <code>""</code>                                  | Specify the label text<br />Alternatively, use the "labelText" slot (e.g., &lt;span slot="labelText"&gt;...&lt;/span&gt;)          |
-| shortcutText | <code>let</code> | No       | <code>string</code>                                  | <code>""</code>                                  | Specify the shortcut text<br />Alternatively, use the "shortcutText" slot (e.g., &lt;span slot="shortcutText"&gt;...&lt;/span&gt;) |
-| id           | <code>let</code> | No       | <code>string</code>                                  | <code>"ccs-" + Math.random().toString(36)</code> | Specify the id<br />It's recommended to provide an id as a value to bind to within a selectable/radio menu group                   |
+| Prop name    | Required | Kind             | Reactive | Type                                                 | Default value                                    | Description                                                                                                                        |
+| :----------- | :------- | :--------------- | :------- | ---------------------------------------------------- | ------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------- |
+| ref          | No       | <code>let</code> | Yes      | <code>null &#124; HTMLLIElement</code>               | <code>null</code>                                | Obtain a reference to the list item HTML element                                                                                   |
+| selectable   | No       | <code>let</code> | Yes      | <code>boolean</code>                                 | <code>false</code>                               | Set to `true` to enable the selectable variant<br />Automatically set to `true` if `selected` is `true`                            |
+| selected     | No       | <code>let</code> | Yes      | <code>boolean</code>                                 | <code>false</code>                               | Set to `true` to use the selected variant                                                                                          |
+| icon         | No       | <code>let</code> | Yes      | <code>typeof import("svelte").SvelteComponent</code> | <code>undefined</code>                           | Specify the icon to render<br />Icon is rendered to the left of the label text                                                     |
+| indented     | No       | <code>let</code> | Yes      | <code>boolean</code>                                 | <code>false</code>                               | Set to `true` to indent the label                                                                                                  |
+| kind         | No       | <code>let</code> | No       | <code>"default" &#124; "danger"</code>               | <code>"default"</code>                           | Specify the kind of option                                                                                                         |
+| disabled     | No       | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>                               | Set to `true` to enable the disabled state                                                                                         |
+| labelText    | No       | <code>let</code> | No       | <code>string</code>                                  | <code>""</code>                                  | Specify the label text<br />Alternatively, use the "labelText" slot (e.g., &lt;span slot="labelText"&gt;...&lt;/span&gt;)          |
+| shortcutText | No       | <code>let</code> | No       | <code>string</code>                                  | <code>""</code>                                  | Specify the shortcut text<br />Alternatively, use the "shortcutText" slot (e.g., &lt;span slot="shortcutText"&gt;...&lt;/span&gt;) |
+| id           | No       | <code>let</code> | No       | <code>string</code>                                  | <code>"ccs-" + Math.random().toString(36)</code> | Specify the id<br />It's recommended to provide an id as a value to bind to within a selectable/radio menu group                   |
 
 ### Slots
 
@@ -873,10 +873,10 @@ None.
 
 ### Props
 
-| Prop name  | Kind             | Reactive | Type                | Default value   | Description                     |
-| :--------- | :--------------- | :------- | :------------------ | --------------- | ------------------------------- |
-| selectedId | <code>let</code> | Yes      | <code>string</code> | <code>""</code> | Set the selected radio group id |
-| labelText  | <code>let</code> | No       | <code>string</code> | <code>""</code> | Specify the label text          |
+| Prop name  | Required | Kind             | Reactive | Type                | Default value   | Description                     |
+| :--------- | :------- | :--------------- | :------- | ------------------- | --------------- | ------------------------------- |
+| selectedId | No       | <code>let</code> | Yes      | <code>string</code> | <code>""</code> | Set the selected radio group id |
+| labelText  | No       | <code>let</code> | No       | <code>string</code> | <code>""</code> | Specify the label text          |
 
 ### Slots
 
@@ -892,13 +892,13 @@ None.
 
 ### Props
 
-| Prop name       | Kind             | Reactive | Type                                | Default value                                                                                                     | Description                                                                                    |
-| :-------------- | :--------------- | :------- | :---------------------------------- | ----------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
-| feedback        | <code>let</code> | No       | <code>string</code>                 | <code>"Copied!"</code>                                                                                            | Set the feedback text shown after clicking the button                                          |
-| feedbackTimeout | <code>let</code> | No       | <code>number</code>                 | <code>2000</code>                                                                                                 | Set the timeout duration (ms) to display feedback text                                         |
-| iconDescription | <code>let</code> | No       | <code>string</code>                 | <code>"Copy to clipboard"</code>                                                                                  | Set the title and ARIA label for the copy button                                               |
-| text            | <code>let</code> | No       | <code>string</code>                 | <code>undefined</code>                                                                                            | Specify the text to copy                                                                       |
-| copy            | <code>let</code> | No       | <code>(text: string) => void</code> | <code>async (text) => { try { await navigator.clipboard.writeText(text); } catch (e) { console.log(e); } }</code> | Override the default copy behavior of using the navigator.clipboard.writeText API to copy text |
+| Prop name       | Required | Kind             | Reactive | Type                                | Default value                                                                                                     | Description                                                                                    |
+| :-------------- | :------- | :--------------- | :------- | ----------------------------------- | ----------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| feedback        | No       | <code>let</code> | No       | <code>string</code>                 | <code>"Copied!"</code>                                                                                            | Set the feedback text shown after clicking the button                                          |
+| feedbackTimeout | No       | <code>let</code> | No       | <code>number</code>                 | <code>2000</code>                                                                                                 | Set the timeout duration (ms) to display feedback text                                         |
+| iconDescription | No       | <code>let</code> | No       | <code>string</code>                 | <code>"Copy to clipboard"</code>                                                                                  | Set the title and ARIA label for the copy button                                               |
+| text            | Yes      | <code>let</code> | No       | <code>string</code>                 | <code>undefined</code>                                                                                            | Specify the text to copy                                                                       |
+| copy            | No       | <code>let</code> | No       | <code>(text: string) => void</code> | <code>async (text) => { try { await navigator.clipboard.writeText(text); } catch (e) { console.log(e); } }</code> | Override the default copy behavior of using the navigator.clipboard.writeText API to copy text |
 
 ### Slots
 
@@ -959,28 +959,28 @@ export interface DataTableCell {
 
 ### Props
 
-| Prop name           | Kind             | Reactive | Type                                                                | Default value          | Description                                                                                                         |
-| :------------------ | :--------------- | :------- | :------------------------------------------------------------------ | ---------------------- | ------------------------------------------------------------------------------------------------------------------- |
-| selectedRowIds      | <code>let</code> | Yes      | <code>DataTableRowId[]</code>                                       | <code>[]</code>        | Specify the row ids to be selected                                                                                  |
-| selectable          | <code>let</code> | Yes      | <code>boolean</code>                                                | <code>false</code>     | Set to `true` for the selectable variant<br />Automatically set to `true` if `radio` or `batchSelection` are `true` |
-| expandedRowIds      | <code>let</code> | Yes      | <code>DataTableRowId[]</code>                                       | <code>[]</code>        | Specify the row ids to be expanded                                                                                  |
-| expandable          | <code>let</code> | Yes      | <code>boolean</code>                                                | <code>false</code>     | Set to `true` for the expandable variant<br />Automatically set to `true` if `batchExpansion` is `true`             |
-| headers             | <code>let</code> | No       | <code>DataTableHeader[]</code>                                      | <code>[]</code>        | Specify the data table headers                                                                                      |
-| rows                | <code>let</code> | No       | <code>DataTableRow[]</code>                                         | <code>[]</code>        | Specify the rows the data table should render<br />keys defined in `headers` are used for the row ids               |
-| size                | <code>let</code> | No       | <code>"compact" &#124; "short" &#124; "medium" &#124; "tall"</code> | <code>undefined</code> | Set the size of the data table                                                                                      |
-| title               | <code>let</code> | No       | <code>string</code>                                                 | <code>""</code>        | Specify the title of the data table                                                                                 |
-| description         | <code>let</code> | No       | <code>string</code>                                                 | <code>""</code>        | Specify the description of the data table                                                                           |
-| zebra               | <code>let</code> | No       | <code>boolean</code>                                                | <code>false</code>     | Set to `true` to use zebra styles                                                                                   |
-| sortable            | <code>let</code> | No       | <code>boolean</code>                                                | <code>false</code>     | Set to `true` for the sortable variant                                                                              |
-| batchExpansion      | <code>let</code> | No       | <code>boolean</code>                                                | <code>false</code>     | Set to `true` to enable batch expansion                                                                             |
-| nonExpandableRowIds | <code>let</code> | No       | <code>DataTableRowId[]</code>                                       | <code>[]</code>        | Specify the ids for rows that should not be expandable                                                              |
-| radio               | <code>let</code> | No       | <code>boolean</code>                                                | <code>false</code>     | Set to `true` for the radio selection variant                                                                       |
-| batchSelection      | <code>let</code> | No       | <code>boolean</code>                                                | <code>false</code>     | Set to `true` to enable batch selection                                                                             |
-| nonSelectableRowIds | <code>let</code> | No       | <code>DataTableRowId[]</code>                                       | <code>[]</code>        | Specify the ids of rows that should not be selectable                                                               |
-| stickyHeader        | <code>let</code> | No       | <code>boolean</code>                                                | <code>false</code>     | Set to `true` to enable a sticky header                                                                             |
-| useStaticWidth      | <code>let</code> | No       | <code>boolean</code>                                                | <code>false</code>     | Set to `true` to use static width                                                                                   |
-| pageSize            | <code>let</code> | No       | <code>number</code>                                                 | <code>0</code>         | Specify the number of items to display in a page                                                                    |
-| page                | <code>let</code> | No       | <code>number</code>                                                 | <code>0</code>         | Set to `number` to set current page                                                                                 |
+| Prop name           | Required | Kind             | Reactive | Type                                                                | Default value          | Description                                                                                                         |
+| :------------------ | :------- | :--------------- | :------- | ------------------------------------------------------------------- | ---------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| selectedRowIds      | No       | <code>let</code> | Yes      | <code>DataTableRowId[]</code>                                       | <code>[]</code>        | Specify the row ids to be selected                                                                                  |
+| selectable          | No       | <code>let</code> | Yes      | <code>boolean</code>                                                | <code>false</code>     | Set to `true` for the selectable variant<br />Automatically set to `true` if `radio` or `batchSelection` are `true` |
+| expandedRowIds      | No       | <code>let</code> | Yes      | <code>DataTableRowId[]</code>                                       | <code>[]</code>        | Specify the row ids to be expanded                                                                                  |
+| expandable          | No       | <code>let</code> | Yes      | <code>boolean</code>                                                | <code>false</code>     | Set to `true` for the expandable variant<br />Automatically set to `true` if `batchExpansion` is `true`             |
+| headers             | No       | <code>let</code> | No       | <code>DataTableHeader[]</code>                                      | <code>[]</code>        | Specify the data table headers                                                                                      |
+| rows                | No       | <code>let</code> | No       | <code>DataTableRow[]</code>                                         | <code>[]</code>        | Specify the rows the data table should render<br />keys defined in `headers` are used for the row ids               |
+| size                | No       | <code>let</code> | No       | <code>"compact" &#124; "short" &#124; "medium" &#124; "tall"</code> | <code>undefined</code> | Set the size of the data table                                                                                      |
+| title               | No       | <code>let</code> | No       | <code>string</code>                                                 | <code>""</code>        | Specify the title of the data table                                                                                 |
+| description         | No       | <code>let</code> | No       | <code>string</code>                                                 | <code>""</code>        | Specify the description of the data table                                                                           |
+| zebra               | No       | <code>let</code> | No       | <code>boolean</code>                                                | <code>false</code>     | Set to `true` to use zebra styles                                                                                   |
+| sortable            | No       | <code>let</code> | No       | <code>boolean</code>                                                | <code>false</code>     | Set to `true` for the sortable variant                                                                              |
+| batchExpansion      | No       | <code>let</code> | No       | <code>boolean</code>                                                | <code>false</code>     | Set to `true` to enable batch expansion                                                                             |
+| nonExpandableRowIds | No       | <code>let</code> | No       | <code>DataTableRowId[]</code>                                       | <code>[]</code>        | Specify the ids for rows that should not be expandable                                                              |
+| radio               | No       | <code>let</code> | No       | <code>boolean</code>                                                | <code>false</code>     | Set to `true` for the radio selection variant                                                                       |
+| batchSelection      | No       | <code>let</code> | No       | <code>boolean</code>                                                | <code>false</code>     | Set to `true` to enable batch selection                                                                             |
+| nonSelectableRowIds | No       | <code>let</code> | No       | <code>DataTableRowId[]</code>                                       | <code>[]</code>        | Specify the ids of rows that should not be selectable                                                               |
+| stickyHeader        | No       | <code>let</code> | No       | <code>boolean</code>                                                | <code>false</code>     | Set to `true` to enable a sticky header                                                                             |
+| useStaticWidth      | No       | <code>let</code> | No       | <code>boolean</code>                                                | <code>false</code>     | Set to `true` to use static width                                                                                   |
+| pageSize            | No       | <code>let</code> | No       | <code>number</code>                                                 | <code>0</code>         | Specify the number of items to display in a page                                                                    |
+| page                | No       | <code>let</code> | No       | <code>number</code>                                                 | <code>0</code>         | Set to `number` to set current page                                                                                 |
 
 ### Slots
 
@@ -1010,15 +1010,15 @@ export interface DataTableCell {
 
 ### Props
 
-| Prop name   | Kind             | Reactive | Type                                                    | Default value          | Description                                                                                  |
-| :---------- | :--------------- | :------- | :------------------------------------------------------ | ---------------------- | -------------------------------------------------------------------------------------------- |
-| columns     | <code>let</code> | No       | <code>number</code>                                     | <code>5</code>         | Specify the number of columns<br />Superseded by `headers` if `headers` is a non-empty array |
-| rows        | <code>let</code> | No       | <code>number</code>                                     | <code>5</code>         | Specify the number of rows                                                                   |
-| size        | <code>let</code> | No       | <code>"compact" &#124; "short" &#124; "tall"</code>     | <code>undefined</code> | Set the size of the data table                                                               |
-| zebra       | <code>let</code> | No       | <code>boolean</code>                                    | <code>false</code>     | Set to `true` to apply zebra styles to the datatable rows                                    |
-| showHeader  | <code>let</code> | No       | <code>boolean</code>                                    | <code>true</code>      | Set to `false` to hide the header                                                            |
-| headers     | <code>let</code> | No       | <code>string[] &#124; Partial<DataTableHeader>[]</code> | <code>[]</code>        | Set the column headers<br />Supersedes `columns` if value is a non-empty array               |
-| showToolbar | <code>let</code> | No       | <code>boolean</code>                                    | <code>true</code>      | Set to `false` to hide the toolbar                                                           |
+| Prop name   | Required | Kind             | Reactive | Type                                                    | Default value          | Description                                                                                  |
+| :---------- | :------- | :--------------- | :------- | ------------------------------------------------------- | ---------------------- | -------------------------------------------------------------------------------------------- |
+| columns     | No       | <code>let</code> | No       | <code>number</code>                                     | <code>5</code>         | Specify the number of columns<br />Superseded by `headers` if `headers` is a non-empty array |
+| rows        | No       | <code>let</code> | No       | <code>number</code>                                     | <code>5</code>         | Specify the number of rows                                                                   |
+| size        | No       | <code>let</code> | No       | <code>"compact" &#124; "short" &#124; "tall"</code>     | <code>undefined</code> | Set the size of the data table                                                               |
+| zebra       | No       | <code>let</code> | No       | <code>boolean</code>                                    | <code>false</code>     | Set to `true` to apply zebra styles to the datatable rows                                    |
+| showHeader  | No       | <code>let</code> | No       | <code>boolean</code>                                    | <code>true</code>      | Set to `false` to hide the header                                                            |
+| headers     | No       | <code>let</code> | No       | <code>string[] &#124; Partial<DataTableHeader>[]</code> | <code>[]</code>        | Set the column headers<br />Supersedes `columns` if value is a non-empty array               |
+| showToolbar | No       | <code>let</code> | No       | <code>boolean</code>                                    | <code>true</code>      | Set to `false` to hide the toolbar                                                           |
 
 ### Slots
 
@@ -1037,20 +1037,20 @@ None.
 
 ### Props
 
-| Prop name      | Kind             | Reactive | Type                                                                                                             | Default value                                    | Description                                                                                       |
-| :------------- | :--------------- | :------- | :--------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ | ------------------------------------------------------------------------------------------------- |
-| valueTo        | <code>let</code> | Yes      | <code>string</code>                                                                                              | <code>""</code>                                  | Specify the date picker end date value (to)<br />Only works with the "range" date picker type     |
-| valueFrom      | <code>let</code> | Yes      | <code>string</code>                                                                                              | <code>""</code>                                  | Specify the date picker start date value (from)<br />Only works with the "range" date picker type |
-| value          | <code>let</code> | Yes      | <code>number &#124; string</code>                                                                                | <code>""</code>                                  | Specify the date picker input value                                                               |
-| datePickerType | <code>let</code> | No       | <code>"simple" &#124; "single" &#124; "range"</code>                                                             | <code>"simple"</code>                            | Specify the date picker type                                                                      |
-| dateFormat     | <code>let</code> | No       | <code>string</code>                                                                                              | <code>"m/d/Y"</code>                             | Specify the date format                                                                           |
-| maxDate        | <code>let</code> | No       | <code>null &#124; string &#124; Date</code>                                                                      | <code>null</code>                                | Specify the maximum date                                                                          |
-| minDate        | <code>let</code> | No       | <code>null &#124; string &#124; Date</code>                                                                      | <code>null</code>                                | Specify the minimum date                                                                          |
-| locale         | <code>let</code> | No       | <code>import("flatpickr/dist/types/locale").CustomLocale &#124; import("flatpickr/dist/types/locale").key</code> | <code>"en"</code>                                | Specify the locale                                                                                |
-| short          | <code>let</code> | No       | <code>boolean</code>                                                                                             | <code>false</code>                               | Set to `true` to use the short variant                                                            |
-| light          | <code>let</code> | No       | <code>boolean</code>                                                                                             | <code>false</code>                               | Set to `true` to enable the light variant                                                         |
-| id             | <code>let</code> | No       | <code>string</code>                                                                                              | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the date picker element                                                             |
-| flatpickrProps | <code>let</code> | No       | <code>import("flatpickr/dist/types/options").Options</code>                                                      | <code>{ static: true }</code>                    | Override the options passed to the Flatpickr instance.<br />@see https://flatpickr.js.org/options |
+| Prop name      | Required | Kind             | Reactive | Type                                                                                                             | Default value                                    | Description                                                                                       |
+| :------------- | :------- | :--------------- | :------- | ---------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ | ------------------------------------------------------------------------------------------------- |
+| valueTo        | No       | <code>let</code> | Yes      | <code>string</code>                                                                                              | <code>""</code>                                  | Specify the date picker end date value (to)<br />Only works with the "range" date picker type     |
+| valueFrom      | No       | <code>let</code> | Yes      | <code>string</code>                                                                                              | <code>""</code>                                  | Specify the date picker start date value (from)<br />Only works with the "range" date picker type |
+| value          | No       | <code>let</code> | Yes      | <code>number &#124; string</code>                                                                                | <code>""</code>                                  | Specify the date picker input value                                                               |
+| datePickerType | No       | <code>let</code> | No       | <code>"simple" &#124; "single" &#124; "range"</code>                                                             | <code>"simple"</code>                            | Specify the date picker type                                                                      |
+| dateFormat     | No       | <code>let</code> | No       | <code>string</code>                                                                                              | <code>"m/d/Y"</code>                             | Specify the date format                                                                           |
+| maxDate        | No       | <code>let</code> | No       | <code>null &#124; string &#124; Date</code>                                                                      | <code>null</code>                                | Specify the maximum date                                                                          |
+| minDate        | No       | <code>let</code> | No       | <code>null &#124; string &#124; Date</code>                                                                      | <code>null</code>                                | Specify the minimum date                                                                          |
+| locale         | No       | <code>let</code> | No       | <code>import("flatpickr/dist/types/locale").CustomLocale &#124; import("flatpickr/dist/types/locale").key</code> | <code>"en"</code>                                | Specify the locale                                                                                |
+| short          | No       | <code>let</code> | No       | <code>boolean</code>                                                                                             | <code>false</code>                               | Set to `true` to use the short variant                                                            |
+| light          | No       | <code>let</code> | No       | <code>boolean</code>                                                                                             | <code>false</code>                               | Set to `true` to enable the light variant                                                         |
+| id             | No       | <code>let</code> | No       | <code>string</code>                                                                                              | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the date picker element                                                             |
+| flatpickrProps | No       | <code>let</code> | No       | <code>import("flatpickr/dist/types/options").Options</code>                                                      | <code>{ static: true }</code>                    | Override the options passed to the Flatpickr instance.<br />@see https://flatpickr.js.org/options |
 
 ### Slots
 
@@ -1072,24 +1072,24 @@ None.
 
 ### Props
 
-| Prop name       | Kind             | Reactive | Type                                      | Default value                                    | Description                                        |
-| :-------------- | :--------------- | :------- | :---------------------------------------- | ------------------------------------------------ | -------------------------------------------------- |
-| ref             | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code> | <code>null</code>                                | Obtain a reference to the input HTML element       |
-| size            | <code>let</code> | No       | <code>"sm" &#124; "xl"</code>             | <code>undefined</code>                           | Set the size of the input                          |
-| type            | <code>let</code> | No       | <code>string</code>                       | <code>"text"</code>                              | Specify the input type                             |
-| placeholder     | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Specify the input placeholder text                 |
-| pattern         | <code>let</code> | No       | <code>string</code>                       | <code>"\\d{1,2}\\/\\d{1,2}\\/\\d{4}"</code>      | Specify the Regular Expression for the input value |
-| disabled        | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to disable the input                 |
-| helperText      | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Specify the helper text                            |
-| iconDescription | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Specify the ARIA label for the calendar icon       |
-| id              | <code>let</code> | No       | <code>string</code>                       | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the input element                    |
-| labelText       | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Specify the label text                             |
-| hideLabel       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to visually hide the label text      |
-| invalid         | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to indicate an invalid state         |
-| invalidText     | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Specify the invalid state text                     |
-| warn            | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to indicate an warning state         |
-| warnText        | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Specify the warning state text                     |
-| name            | <code>let</code> | No       | <code>string</code>                       | <code>undefined</code>                           | Set a name for the input element                   |
+| Prop name       | Required | Kind             | Reactive | Type                                      | Default value                                    | Description                                        |
+| :-------------- | :------- | :--------------- | :------- | ----------------------------------------- | ------------------------------------------------ | -------------------------------------------------- |
+| ref             | No       | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code> | <code>null</code>                                | Obtain a reference to the input HTML element       |
+| size            | No       | <code>let</code> | No       | <code>"sm" &#124; "xl"</code>             | <code>undefined</code>                           | Set the size of the input                          |
+| type            | No       | <code>let</code> | No       | <code>string</code>                       | <code>"text"</code>                              | Specify the input type                             |
+| placeholder     | No       | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Specify the input placeholder text                 |
+| pattern         | No       | <code>let</code> | No       | <code>string</code>                       | <code>"\\d{1,2}\\/\\d{1,2}\\/\\d{4}"</code>      | Specify the Regular Expression for the input value |
+| disabled        | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to disable the input                 |
+| helperText      | No       | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Specify the helper text                            |
+| iconDescription | No       | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Specify the ARIA label for the calendar icon       |
+| id              | No       | <code>let</code> | No       | <code>string</code>                       | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the input element                    |
+| labelText       | No       | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Specify the label text                             |
+| hideLabel       | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to visually hide the label text      |
+| invalid         | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to indicate an invalid state         |
+| invalidText     | No       | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Specify the invalid state text                     |
+| warn            | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to indicate an warning state         |
+| warnText        | No       | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Specify the warning state text                     |
+| name            | No       | <code>let</code> | No       | <code>string</code>                       | <code>undefined</code>                           | Set a name for the input element                   |
 
 ### Slots
 
@@ -1110,10 +1110,10 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                 | Default value                                    | Description                               |
-| :-------- | :--------------- | :------- | :------------------- | ------------------------------------------------ | ----------------------------------------- |
-| range     | <code>let</code> | No       | <code>boolean</code> | <code>false</code>                               | Set to `true` to use the range variant    |
-| id        | <code>let</code> | No       | <code>string</code>  | <code>"ccs-" + Math.random().toString(36)</code> | Set an id to be used by the label element |
+| Prop name | Required | Kind             | Reactive | Type                 | Default value                                    | Description                               |
+| :-------- | :------- | :--------------- | :------- | -------------------- | ------------------------------------------------ | ----------------------------------------- |
+| range     | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code>                               | Set to `true` to use the range variant    |
+| id        | No       | <code>let</code> | No       | <code>string</code>  | <code>"ccs-" + Math.random().toString(36)</code> | Set an id to be used by the label element |
 
 ### Slots
 
@@ -1145,30 +1145,30 @@ export interface DropdownItem {
 
 ### Props
 
-| Prop name       | Kind             | Reactive | Type                                                                                                  | Default value                                         | Description                                                                                                                  |
-| :-------------- | :--------------- | :------- | :---------------------------------------------------------------------------------------------------- | ----------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| ref             | <code>let</code> | Yes      | <code>null &#124; HTMLButtonElement</code>                                                            | <code>null</code>                                     | Obtain a reference to the button HTML element                                                                                |
-| inline          | <code>let</code> | Yes      | <code>boolean</code>                                                                                  | <code>false</code>                                    | Set to `true` to use the inline variant                                                                                      |
-| open            | <code>let</code> | Yes      | <code>boolean</code>                                                                                  | <code>false</code>                                    | Set to `true` to open the dropdown                                                                                           |
-| selectedId      | <code>let</code> | Yes      | <code>DropdownItemId</code>                                                                           | <code>undefined</code>                                | Specify the selected item id                                                                                                 |
-| items           | <code>let</code> | No       | <code>DropdownItem[]</code>                                                                           | <code>[]</code>                                       | Set the dropdown items                                                                                                       |
-| itemToString    | <code>let</code> | No       | <code>(item: DropdownItem) => string</code>                                                           | <code>(item) => item.text &#124;&#124; item.id</code> | Override the display of a dropdown item                                                                                      |
-| type            | <code>let</code> | No       | <code>"default" &#124; "inline"</code>                                                                | <code>"default"</code>                                | Specify the type of dropdown                                                                                                 |
-| direction       | <code>let</code> | No       | <code>"bottom" &#124; "top"</code>                                                                    | <code>"bottom"</code>                                 | Specify the direction of the dropdown menu                                                                                   |
-| size            | <code>let</code> | No       | <code>"sm" &#124; "lg" &#124; "xl"</code>                                                             | <code>undefined</code>                                | Specify the size of the dropdown field                                                                                       |
-| light           | <code>let</code> | No       | <code>boolean</code>                                                                                  | <code>false</code>                                    | Set to `true` to enable the light variant                                                                                    |
-| disabled        | <code>let</code> | No       | <code>boolean</code>                                                                                  | <code>false</code>                                    | Set to `true` to disable the dropdown                                                                                        |
-| titleText       | <code>let</code> | No       | <code>string</code>                                                                                   | <code>""</code>                                       | Specify the title text                                                                                                       |
-| invalid         | <code>let</code> | No       | <code>boolean</code>                                                                                  | <code>false</code>                                    | Set to `true` to indicate an invalid state                                                                                   |
-| invalidText     | <code>let</code> | No       | <code>string</code>                                                                                   | <code>""</code>                                       | Specify the invalid state text                                                                                               |
-| warn            | <code>let</code> | No       | <code>boolean</code>                                                                                  | <code>false</code>                                    | Set to `true` to indicate an warning state                                                                                   |
-| warnText        | <code>let</code> | No       | <code>string</code>                                                                                   | <code>""</code>                                       | Specify the warning state text                                                                                               |
-| helperText      | <code>let</code> | No       | <code>string</code>                                                                                   | <code>""</code>                                       | Specify the helper text                                                                                                      |
-| label           | <code>let</code> | No       | <code>string</code>                                                                                   | <code>undefined</code>                                | Specify the list box label                                                                                                   |
-| hideLabel       | <code>let</code> | No       | <code>boolean</code>                                                                                  | <code>false</code>                                    | Set to `true` to visually hide the label text                                                                                |
-| translateWithId | <code>let</code> | No       | <code>(id: import("../ListBox/ListBoxMenuIcon.svelte").ListBoxMenuIconTranslationId) => string</code> | <code>undefined</code>                                | Override the chevron icon label based on the open state.<br />Defaults to "Open menu" when closed and "Close menu" when open |
-| id              | <code>let</code> | No       | <code>string</code>                                                                                   | <code>"ccs-" + Math.random().toString(36)</code>      | Set an id for the list box component                                                                                         |
-| name            | <code>let</code> | No       | <code>string</code>                                                                                   | <code>undefined</code>                                | Specify a name attribute for the list box                                                                                    |
+| Prop name       | Required | Kind             | Reactive | Type                                                                                                  | Default value                                         | Description                                                                                                                  |
+| :-------------- | :------- | :--------------- | :------- | ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| ref             | No       | <code>let</code> | Yes      | <code>null &#124; HTMLButtonElement</code>                                                            | <code>null</code>                                     | Obtain a reference to the button HTML element                                                                                |
+| inline          | No       | <code>let</code> | Yes      | <code>boolean</code>                                                                                  | <code>false</code>                                    | Set to `true` to use the inline variant                                                                                      |
+| open            | No       | <code>let</code> | Yes      | <code>boolean</code>                                                                                  | <code>false</code>                                    | Set to `true` to open the dropdown                                                                                           |
+| selectedId      | Yes      | <code>let</code> | Yes      | <code>DropdownItemId</code>                                                                           | <code>undefined</code>                                | Specify the selected item id                                                                                                 |
+| items           | No       | <code>let</code> | No       | <code>DropdownItem[]</code>                                                                           | <code>[]</code>                                       | Set the dropdown items                                                                                                       |
+| itemToString    | No       | <code>let</code> | No       | <code>(item: DropdownItem) => string</code>                                                           | <code>(item) => item.text &#124;&#124; item.id</code> | Override the display of a dropdown item                                                                                      |
+| type            | No       | <code>let</code> | No       | <code>"default" &#124; "inline"</code>                                                                | <code>"default"</code>                                | Specify the type of dropdown                                                                                                 |
+| direction       | No       | <code>let</code> | No       | <code>"bottom" &#124; "top"</code>                                                                    | <code>"bottom"</code>                                 | Specify the direction of the dropdown menu                                                                                   |
+| size            | No       | <code>let</code> | No       | <code>"sm" &#124; "lg" &#124; "xl"</code>                                                             | <code>undefined</code>                                | Specify the size of the dropdown field                                                                                       |
+| light           | No       | <code>let</code> | No       | <code>boolean</code>                                                                                  | <code>false</code>                                    | Set to `true` to enable the light variant                                                                                    |
+| disabled        | No       | <code>let</code> | No       | <code>boolean</code>                                                                                  | <code>false</code>                                    | Set to `true` to disable the dropdown                                                                                        |
+| titleText       | No       | <code>let</code> | No       | <code>string</code>                                                                                   | <code>""</code>                                       | Specify the title text                                                                                                       |
+| invalid         | No       | <code>let</code> | No       | <code>boolean</code>                                                                                  | <code>false</code>                                    | Set to `true` to indicate an invalid state                                                                                   |
+| invalidText     | No       | <code>let</code> | No       | <code>string</code>                                                                                   | <code>""</code>                                       | Specify the invalid state text                                                                                               |
+| warn            | No       | <code>let</code> | No       | <code>boolean</code>                                                                                  | <code>false</code>                                    | Set to `true` to indicate an warning state                                                                                   |
+| warnText        | No       | <code>let</code> | No       | <code>string</code>                                                                                   | <code>""</code>                                       | Specify the warning state text                                                                                               |
+| helperText      | No       | <code>let</code> | No       | <code>string</code>                                                                                   | <code>""</code>                                       | Specify the helper text                                                                                                      |
+| label           | No       | <code>let</code> | No       | <code>string</code>                                                                                   | <code>undefined</code>                                | Specify the list box label                                                                                                   |
+| hideLabel       | No       | <code>let</code> | No       | <code>boolean</code>                                                                                  | <code>false</code>                                    | Set to `true` to visually hide the label text                                                                                |
+| translateWithId | No       | <code>let</code> | No       | <code>(id: import("../ListBox/ListBoxMenuIcon.svelte").ListBoxMenuIconTranslationId) => string</code> | <code>undefined</code>                                | Override the chevron icon label based on the open state.<br />Defaults to "Open menu" when closed and "Close menu" when open |
+| id              | No       | <code>let</code> | No       | <code>string</code>                                                                                   | <code>"ccs-" + Math.random().toString(36)</code>      | Set an id for the list box component                                                                                         |
+| name            | No       | <code>let</code> | No       | <code>string</code>                                                                                   | <code>undefined</code>                                | Specify a name attribute for the list box                                                                                    |
 
 ### Slots
 
@@ -1186,9 +1186,9 @@ export interface DropdownItem {
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                 | Default value      | Description                             |
-| :-------- | :--------------- | :------- | :------------------- | ------------------ | --------------------------------------- |
-| inline    | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use the inline variant |
+| Prop name | Required | Kind             | Reactive | Type                 | Default value      | Description                             |
+| :-------- | :------- | :--------------- | :------- | -------------------- | ------------------ | --------------------------------------- |
+| inline    | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use the inline variant |
 
 ### Slots
 
@@ -1207,19 +1207,19 @@ None.
 
 ### Props
 
-| Prop name             | Kind             | Reactive | Type                                       | Default value                                    | Description                                           |
-| :-------------------- | :--------------- | :------- | :----------------------------------------- | ------------------------------------------------ | ----------------------------------------------------- |
-| ref                   | <code>let</code> | Yes      | <code>null &#124; HTMLButtonElement</code> | <code>null</code>                                | Obtain a reference to the top-level element           |
-| tilePadding           | <code>let</code> | Yes      | <code>number</code>                        | <code>0</code>                                   | Specify the padding of the tile (number of pixels)    |
-| tileMaxHeight         | <code>let</code> | Yes      | <code>number</code>                        | <code>0</code>                                   | Specify the max height of the tile (number of pixels) |
-| expanded              | <code>let</code> | Yes      | <code>boolean</code>                       | <code>false</code>                               | Set to `true` to expand the tile                      |
-| light                 | <code>let</code> | No       | <code>boolean</code>                       | <code>false</code>                               | Set to `true` to enable the light variant             |
-| tileCollapsedIconText | <code>let</code> | No       | <code>string</code>                        | <code>"Interact to expand Tile"</code>           | Specify the icon text of the collapsed tile           |
-| tileExpandedIconText  | <code>let</code> | No       | <code>string</code>                        | <code>"Interact to collapse Tile"</code>         | Specify the icon text of the expanded tile            |
-| tileExpandedLabel     | <code>let</code> | No       | <code>string</code>                        | <code>""</code>                                  | Specify the icon label of the expanded tile           |
-| tileCollapsedLabel    | <code>let</code> | No       | <code>string</code>                        | <code>""</code>                                  | Specify the icon label of the collapsed tile          |
-| tabindex              | <code>let</code> | No       | <code>string</code>                        | <code>"0"</code>                                 | Specify the tabindex                                  |
-| id                    | <code>let</code> | No       | <code>string</code>                        | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the top-level div element               |
+| Prop name             | Required | Kind             | Reactive | Type                                       | Default value                                    | Description                                           |
+| :-------------------- | :------- | :--------------- | :------- | ------------------------------------------ | ------------------------------------------------ | ----------------------------------------------------- |
+| ref                   | No       | <code>let</code> | Yes      | <code>null &#124; HTMLButtonElement</code> | <code>null</code>                                | Obtain a reference to the top-level element           |
+| tilePadding           | No       | <code>let</code> | Yes      | <code>number</code>                        | <code>0</code>                                   | Specify the padding of the tile (number of pixels)    |
+| tileMaxHeight         | No       | <code>let</code> | Yes      | <code>number</code>                        | <code>0</code>                                   | Specify the max height of the tile (number of pixels) |
+| expanded              | No       | <code>let</code> | Yes      | <code>boolean</code>                       | <code>false</code>                               | Set to `true` to expand the tile                      |
+| light                 | No       | <code>let</code> | No       | <code>boolean</code>                       | <code>false</code>                               | Set to `true` to enable the light variant             |
+| tileCollapsedIconText | No       | <code>let</code> | No       | <code>string</code>                        | <code>"Interact to expand Tile"</code>           | Specify the icon text of the collapsed tile           |
+| tileExpandedIconText  | No       | <code>let</code> | No       | <code>string</code>                        | <code>"Interact to collapse Tile"</code>         | Specify the icon text of the expanded tile            |
+| tileExpandedLabel     | No       | <code>let</code> | No       | <code>string</code>                        | <code>""</code>                                  | Specify the icon label of the expanded tile           |
+| tileCollapsedLabel    | No       | <code>let</code> | No       | <code>string</code>                        | <code>""</code>                                  | Specify the icon label of the collapsed tile          |
+| tabindex              | No       | <code>let</code> | No       | <code>string</code>                        | <code>"0"</code>                                 | Specify the tabindex                                  |
+| id                    | No       | <code>let</code> | No       | <code>string</code>                        | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the top-level div element               |
 
 ### Slots
 
@@ -1242,20 +1242,20 @@ None.
 
 ### Props
 
-| Prop name        | Kind               | Reactive | Type                                                                                       | Default value                           | Description                                                 |
-| :--------------- | :----------------- | :------- | :----------------------------------------------------------------------------------------- | --------------------------------------- | ----------------------------------------------------------- |
-| files            | <code>let</code>   | Yes      | <code>File[]</code>                                                                        | <code>[]</code>                         | Obtain a reference to the uploaded files                    |
-| status           | <code>let</code>   | No       | <code>"uploading" &#124; "edit" &#124; "complete"</code>                                   | <code>"uploading"</code>                | Specify the file uploader status                            |
-| disabled         | <code>let</code>   | No       | <code>boolean</code>                                                                       | <code>false</code>                      | Set to `true` to disable the file uploader                  |
-| accept           | <code>let</code>   | No       | <code>string[]</code>                                                                      | <code>[]</code>                         | Specify the accepted file types                             |
-| multiple         | <code>let</code>   | No       | <code>boolean</code>                                                                       | <code>false</code>                      | Set to `true` to allow multiple files                       |
-| clearFiles       | <code>const</code> | No       | <code>() => void</code>                                                                    | <code>() => { files = []; }</code>      | Programmatically clear the uploaded files                   |
-| labelDescription | <code>let</code>   | No       | <code>string</code>                                                                        | <code>""</code>                         | Specify the label description                               |
-| labelTitle       | <code>let</code>   | No       | <code>string</code>                                                                        | <code>""</code>                         | Specify the label title                                     |
-| kind             | <code>let</code>   | No       | <code>"primary" &#124; "secondary" &#124; "tertiary" &#124; "ghost" &#124; "danger"</code> | <code>"primary"</code>                  | Specify the kind of file uploader button                    |
-| buttonLabel      | <code>let</code>   | No       | <code>string</code>                                                                        | <code>""</code>                         | Specify the button label                                    |
-| iconDescription  | <code>let</code>   | No       | <code>string</code>                                                                        | <code>"Provide icon description"</code> | Specify the ARIA label used for the status icons            |
-| name             | <code>let</code>   | No       | <code>string</code>                                                                        | <code>""</code>                         | Specify a name attribute for the file button uploader input |
+| Prop name        | Required | Kind               | Reactive | Type                                                                                       | Default value                           | Description                                                 |
+| :--------------- | :------- | :----------------- | :------- | ------------------------------------------------------------------------------------------ | --------------------------------------- | ----------------------------------------------------------- |
+| files            | No       | <code>let</code>   | Yes      | <code>File[]</code>                                                                        | <code>[]</code>                         | Obtain a reference to the uploaded files                    |
+| status           | No       | <code>let</code>   | No       | <code>"uploading" &#124; "edit" &#124; "complete"</code>                                   | <code>"uploading"</code>                | Specify the file uploader status                            |
+| disabled         | No       | <code>let</code>   | No       | <code>boolean</code>                                                                       | <code>false</code>                      | Set to `true` to disable the file uploader                  |
+| accept           | No       | <code>let</code>   | No       | <code>string[]</code>                                                                      | <code>[]</code>                         | Specify the accepted file types                             |
+| multiple         | No       | <code>let</code>   | No       | <code>boolean</code>                                                                       | <code>false</code>                      | Set to `true` to allow multiple files                       |
+| clearFiles       | No       | <code>const</code> | No       | <code>() => void</code>                                                                    | <code>() => { files = []; }</code>      | Programmatically clear the uploaded files                   |
+| labelDescription | No       | <code>let</code>   | No       | <code>string</code>                                                                        | <code>""</code>                         | Specify the label description                               |
+| labelTitle       | No       | <code>let</code>   | No       | <code>string</code>                                                                        | <code>""</code>                         | Specify the label title                                     |
+| kind             | No       | <code>let</code>   | No       | <code>"primary" &#124; "secondary" &#124; "tertiary" &#124; "ghost" &#124; "danger"</code> | <code>"primary"</code>                  | Specify the kind of file uploader button                    |
+| buttonLabel      | No       | <code>let</code>   | No       | <code>string</code>                                                                        | <code>""</code>                         | Specify the button label                                    |
+| iconDescription  | No       | <code>let</code>   | No       | <code>string</code>                                                                        | <code>"Provide icon description"</code> | Specify the ARIA label used for the status icons            |
+| name             | No       | <code>let</code>   | No       | <code>string</code>                                                                        | <code>""</code>                         | Specify a name attribute for the file button uploader input |
 
 ### Slots
 
@@ -1278,20 +1278,20 @@ None.
 
 ### Props
 
-| Prop name           | Kind             | Reactive | Type                                                                                       | Default value                                    | Description                                  |
-| :------------------ | :--------------- | :------- | :----------------------------------------------------------------------------------------- | ------------------------------------------------ | -------------------------------------------- |
-| ref                 | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code>                                                  | <code>null</code>                                | Obtain a reference to the input HTML element |
-| labelText           | <code>let</code> | Yes      | <code>string</code>                                                                        | <code>"Add file"</code>                          | Specify the label text                       |
-| files               | <code>let</code> | Yes      | <code>File[]</code>                                                                        | <code>[]</code>                                  | Obtain a reference to the uploaded files     |
-| accept              | <code>let</code> | No       | <code>string[]</code>                                                                      | <code>[]</code>                                  | Specify the accepted file types              |
-| multiple            | <code>let</code> | No       | <code>boolean</code>                                                                       | <code>false</code>                               | Set to `true` to allow multiple files        |
-| disabled            | <code>let</code> | No       | <code>boolean</code>                                                                       | <code>false</code>                               | Set to `true` to disable the input           |
-| disableLabelChanges | <code>let</code> | No       | <code>boolean</code>                                                                       | <code>false</code>                               | Set to `true` to disable label changes       |
-| kind                | <code>let</code> | No       | <code>"primary" &#124; "secondary" &#124; "tertiary" &#124; "ghost" &#124; "danger"</code> | <code>"primary"</code>                           | Specify the kind of file uploader button     |
-| role                | <code>let</code> | No       | <code>string</code>                                                                        | <code>"button"</code>                            | Specify the label role                       |
-| tabindex            | <code>let</code> | No       | <code>string</code>                                                                        | <code>"0"</code>                                 | Specify `tabindex` attribute                 |
-| id                  | <code>let</code> | No       | <code>string</code>                                                                        | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the input element              |
-| name                | <code>let</code> | No       | <code>string</code>                                                                        | <code>""</code>                                  | Specify a name attribute for the input       |
+| Prop name           | Required | Kind             | Reactive | Type                                                                                       | Default value                                    | Description                                  |
+| :------------------ | :------- | :--------------- | :------- | ------------------------------------------------------------------------------------------ | ------------------------------------------------ | -------------------------------------------- |
+| ref                 | No       | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code>                                                  | <code>null</code>                                | Obtain a reference to the input HTML element |
+| labelText           | No       | <code>let</code> | Yes      | <code>string</code>                                                                        | <code>"Add file"</code>                          | Specify the label text                       |
+| files               | No       | <code>let</code> | Yes      | <code>File[]</code>                                                                        | <code>[]</code>                                  | Obtain a reference to the uploaded files     |
+| accept              | No       | <code>let</code> | No       | <code>string[]</code>                                                                      | <code>[]</code>                                  | Specify the accepted file types              |
+| multiple            | No       | <code>let</code> | No       | <code>boolean</code>                                                                       | <code>false</code>                               | Set to `true` to allow multiple files        |
+| disabled            | No       | <code>let</code> | No       | <code>boolean</code>                                                                       | <code>false</code>                               | Set to `true` to disable the input           |
+| disableLabelChanges | No       | <code>let</code> | No       | <code>boolean</code>                                                                       | <code>false</code>                               | Set to `true` to disable label changes       |
+| kind                | No       | <code>let</code> | No       | <code>"primary" &#124; "secondary" &#124; "tertiary" &#124; "ghost" &#124; "danger"</code> | <code>"primary"</code>                           | Specify the kind of file uploader button     |
+| role                | No       | <code>let</code> | No       | <code>string</code>                                                                        | <code>"button"</code>                            | Specify the label role                       |
+| tabindex            | No       | <code>let</code> | No       | <code>string</code>                                                                        | <code>"0"</code>                                 | Specify `tabindex` attribute                 |
+| id                  | No       | <code>let</code> | No       | <code>string</code>                                                                        | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the input element              |
+| name                | No       | <code>let</code> | No       | <code>string</code>                                                                        | <code>""</code>                                  | Specify a name attribute for the input       |
 
 ### Slots
 
@@ -1311,19 +1311,19 @@ None.
 
 ### Props
 
-| Prop name     | Kind             | Reactive | Type                                      | Default value                                    | Description                                                                                                  |
-| :------------ | :--------------- | :------- | :---------------------------------------- | ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------ |
-| ref           | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code> | <code>null</code>                                | Obtain a reference to the input HTML element                                                                 |
-| files         | <code>let</code> | Yes      | <code>File[]</code>                       | <code>[]</code>                                  | Obtain a reference to the uploaded files                                                                     |
-| accept        | <code>let</code> | No       | <code>string[]</code>                     | <code>[]</code>                                  | Specify the accepted file types                                                                              |
-| multiple      | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to allow multiple files                                                                        |
-| validateFiles | <code>let</code> | No       | <code>(files: File[]) => File[]</code>    | <code>(files) => files</code>                    | Override the default behavior of validating uploaded files<br />The default behavior does not validate files |
-| labelText     | <code>let</code> | No       | <code>string</code>                       | <code>"Add file"</code>                          | Specify the label text                                                                                       |
-| role          | <code>let</code> | No       | <code>string</code>                       | <code>"button"</code>                            | Specify the `role` attribute of the drop container                                                           |
-| disabled      | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to disable the input                                                                           |
-| tabindex      | <code>let</code> | No       | <code>string</code>                       | <code>"0"</code>                                 | Specify `tabindex` attribute                                                                                 |
-| id            | <code>let</code> | No       | <code>string</code>                       | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the input element                                                                              |
-| name          | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Specify a name attribute for the input                                                                       |
+| Prop name     | Required | Kind             | Reactive | Type                                      | Default value                                    | Description                                                                                                  |
+| :------------ | :------- | :--------------- | :------- | ----------------------------------------- | ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------ |
+| ref           | No       | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code> | <code>null</code>                                | Obtain a reference to the input HTML element                                                                 |
+| files         | No       | <code>let</code> | Yes      | <code>File[]</code>                       | <code>[]</code>                                  | Obtain a reference to the uploaded files                                                                     |
+| accept        | No       | <code>let</code> | No       | <code>string[]</code>                     | <code>[]</code>                                  | Specify the accepted file types                                                                              |
+| multiple      | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to allow multiple files                                                                        |
+| validateFiles | No       | <code>let</code> | No       | <code>(files: File[]) => File[]</code>    | <code>(files) => files</code>                    | Override the default behavior of validating uploaded files<br />The default behavior does not validate files |
+| labelText     | No       | <code>let</code> | No       | <code>string</code>                       | <code>"Add file"</code>                          | Specify the label text                                                                                       |
+| role          | No       | <code>let</code> | No       | <code>string</code>                       | <code>"button"</code>                            | Specify the `role` attribute of the drop container                                                           |
+| disabled      | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to disable the input                                                                           |
+| tabindex      | No       | <code>let</code> | No       | <code>string</code>                       | <code>"0"</code>                                 | Specify `tabindex` attribute                                                                                 |
+| id            | No       | <code>let</code> | No       | <code>string</code>                       | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the input element                                                                              |
+| name          | No       | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Specify a name attribute for the input                                                                       |
 
 ### Slots
 
@@ -1347,16 +1347,16 @@ None.
 
 ### Props
 
-| Prop name       | Kind             | Reactive | Type                                                     | Default value                                    | Description                                      |
-| :-------------- | :--------------- | :------- | :------------------------------------------------------- | ------------------------------------------------ | ------------------------------------------------ |
-| status          | <code>let</code> | No       | <code>"uploading" &#124; "edit" &#124; "complete"</code> | <code>"uploading"</code>                         | Specify the file uploader status                 |
-| size            | <code>let</code> | No       | <code>"default" &#124; "field" &#124; "small"</code>     | <code>"default"</code>                           | Specify the size of button skeleton              |
-| iconDescription | <code>let</code> | No       | <code>string</code>                                      | <code>""</code>                                  | Specify the ARIA label used for the status icons |
-| invalid         | <code>let</code> | No       | <code>boolean</code>                                     | <code>false</code>                               | Set to `true` to indicate an invalid state       |
-| errorSubject    | <code>let</code> | No       | <code>string</code>                                      | <code>""</code>                                  | Specify the error subject text                   |
-| errorBody       | <code>let</code> | No       | <code>string</code>                                      | <code>""</code>                                  | Specify the error body text                      |
-| id              | <code>let</code> | No       | <code>string</code>                                      | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the top-level element              |
-| name            | <code>let</code> | No       | <code>string</code>                                      | <code>""</code>                                  | Specify the file uploader name                   |
+| Prop name       | Required | Kind             | Reactive | Type                                                     | Default value                                    | Description                                      |
+| :-------------- | :------- | :--------------- | :------- | -------------------------------------------------------- | ------------------------------------------------ | ------------------------------------------------ |
+| status          | No       | <code>let</code> | No       | <code>"uploading" &#124; "edit" &#124; "complete"</code> | <code>"uploading"</code>                         | Specify the file uploader status                 |
+| size            | No       | <code>let</code> | No       | <code>"default" &#124; "field" &#124; "small"</code>     | <code>"default"</code>                           | Specify the size of button skeleton              |
+| iconDescription | No       | <code>let</code> | No       | <code>string</code>                                      | <code>""</code>                                  | Specify the ARIA label used for the status icons |
+| invalid         | No       | <code>let</code> | No       | <code>boolean</code>                                     | <code>false</code>                               | Set to `true` to indicate an invalid state       |
+| errorSubject    | No       | <code>let</code> | No       | <code>string</code>                                      | <code>""</code>                                  | Specify the error subject text                   |
+| errorBody       | No       | <code>let</code> | No       | <code>string</code>                                      | <code>""</code>                                  | Specify the error body text                      |
+| id              | No       | <code>let</code> | No       | <code>string</code>                                      | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the top-level element              |
+| name            | No       | <code>let</code> | No       | <code>string</code>                                      | <code>""</code>                                  | Specify the file uploader name                   |
 
 ### Slots
 
@@ -1394,11 +1394,11 @@ None.
 
 ### Props
 
-| Prop name       | Kind             | Reactive | Type                                                     | Default value            | Description                                      |
-| :-------------- | :--------------- | :------- | :------------------------------------------------------- | ------------------------ | ------------------------------------------------ |
-| status          | <code>let</code> | No       | <code>"uploading" &#124; "edit" &#124; "complete"</code> | <code>"uploading"</code> | Specify the file name status                     |
-| iconDescription | <code>let</code> | No       | <code>string</code>                                      | <code>""</code>          | Specify the ARIA label used for the status icons |
-| invalid         | <code>let</code> | No       | <code>boolean</code>                                     | <code>false</code>       | Set to `true` to indicate an invalid state       |
+| Prop name       | Required | Kind             | Reactive | Type                                                     | Default value            | Description                                      |
+| :-------------- | :------- | :--------------- | :------- | -------------------------------------------------------- | ------------------------ | ------------------------------------------------ |
+| status          | No       | <code>let</code> | No       | <code>"uploading" &#124; "edit" &#124; "complete"</code> | <code>"uploading"</code> | Specify the file name status                     |
+| iconDescription | No       | <code>let</code> | No       | <code>string</code>                                      | <code>""</code>          | Specify the ARIA label used for the status icons |
+| invalid         | No       | <code>let</code> | No       | <code>boolean</code>                                     | <code>false</code>       | Set to `true` to indicate an invalid state       |
 
 ### Slots
 
@@ -1438,9 +1438,9 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                                     | Default value     | Description                            |
-| :-------- | :--------------- | :------- | :--------------------------------------- | ----------------- | -------------------------------------- |
-| ref       | <code>let</code> | Yes      | <code>null &#124; HTMLFormElement</code> | <code>null</code> | Obtain a reference to the form element |
+| Prop name | Required | Kind             | Reactive | Type                                     | Default value     | Description                            |
+| :-------- | :------- | :--------------- | :------- | ---------------------------------------- | ----------------- | -------------------------------------- |
+| ref       | No       | <code>let</code> | Yes      | <code>null &#124; HTMLFormElement</code> | <code>null</code> | Obtain a reference to the form element |
 
 ### Slots
 
@@ -1463,14 +1463,14 @@ None.
 
 ### Props
 
-| Prop name   | Kind             | Reactive | Type                 | Default value      | Description                                   |
-| :---------- | :--------------- | :------- | :------------------- | ------------------ | --------------------------------------------- |
-| noMargin    | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` for to remove the bottom margin |
-| invalid     | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to indicate an invalid state    |
-| message     | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to render a form requirement    |
-| messageText | <code>let</code> | No       | <code>string</code>  | <code>""</code>    | Specify the message text                      |
-| legendText  | <code>let</code> | No       | <code>string</code>  | <code>""</code>    | Specify the legend text                       |
-| legendId    | <code>let</code> | No       | <code>string</code>  | <code>""</code>    | Specify an id for the legend element          |
+| Prop name   | Required | Kind             | Reactive | Type                 | Default value      | Description                                   |
+| :---------- | :------- | :--------------- | :------- | -------------------- | ------------------ | --------------------------------------------- |
+| noMargin    | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` for to remove the bottom margin |
+| invalid     | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to indicate an invalid state    |
+| message     | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to render a form requirement    |
+| messageText | No       | <code>let</code> | No       | <code>string</code>  | <code>""</code>    | Specify the message text                      |
+| legendText  | No       | <code>let</code> | No       | <code>string</code>  | <code>""</code>    | Specify the legend text                       |
+| legendId    | No       | <code>let</code> | No       | <code>string</code>  | <code>""</code>    | Specify an id for the legend element          |
 
 ### Slots
 
@@ -1512,9 +1512,9 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                | Default value                                    | Description                               |
-| :-------- | :--------------- | :------- | :------------------ | ------------------------------------------------ | ----------------------------------------- |
-| id        | <code>let</code> | No       | <code>string</code> | <code>"ccs-" + Math.random().toString(36)</code> | Set an id to be used by the label element |
+| Prop name | Required | Kind             | Reactive | Type                | Default value                                    | Description                               |
+| :-------- | :------- | :--------------- | :------- | ------------------- | ------------------------------------------------ | ----------------------------------------- |
+| id        | No       | <code>let</code> | No       | <code>string</code> | <code>"ccs-" + Math.random().toString(36)</code> | Set an id to be used by the label element |
 
 ### Slots
 
@@ -1535,16 +1535,16 @@ None.
 
 ### Props
 
-| Prop name     | Kind             | Reactive | Type                 | Default value      | Description                                                                                                                                                                                     |
-| :------------ | :--------------- | :------- | :------------------- | ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| as            | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to render a custom HTML element<br />Props are destructured as `props` in the default slot (e.g., &lt;Grid let:props&gt;&lt;header {...props}&gt;...&lt;/header&gt;&lt;/Grid&gt;) |
-| condensed     | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use the condensed variant                                                                                                                                                      |
-| narrow        | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use the narrow variant                                                                                                                                                         |
-| fullWidth     | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use the fullWidth variant                                                                                                                                                      |
-| noGutter      | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to remove the gutter                                                                                                                                                              |
-| noGutterLeft  | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to remove the left gutter                                                                                                                                                         |
-| noGutterRight | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to remove the right gutter                                                                                                                                                        |
-| padding       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to add top and bottom padding to all columns                                                                                                                                      |
+| Prop name     | Required | Kind             | Reactive | Type                 | Default value      | Description                                                                                                                                                                                     |
+| :------------ | :------- | :--------------- | :------- | -------------------- | ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| as            | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to render a custom HTML element<br />Props are destructured as `props` in the default slot (e.g., &lt;Grid let:props&gt;&lt;header {...props}&gt;...&lt;/header&gt;&lt;/Grid&gt;) |
+| condensed     | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use the condensed variant                                                                                                                                                      |
+| narrow        | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use the narrow variant                                                                                                                                                         |
+| fullWidth     | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use the fullWidth variant                                                                                                                                                      |
+| noGutter      | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to remove the gutter                                                                                                                                                              |
+| noGutterLeft  | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to remove the left gutter                                                                                                                                                         |
+| noGutterRight | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to remove the right gutter                                                                                                                                                        |
+| padding       | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to add top and bottom padding to all columns                                                                                                                                      |
 
 ### Slots
 
@@ -1560,19 +1560,19 @@ None.
 
 ### Props
 
-| Prop name               | Kind             | Reactive | Type                                                 | Default value          | Description                                                                                                                                                                                                                                                      |
-| :---------------------- | :--------------- | :------- | :--------------------------------------------------- | ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| ref                     | <code>let</code> | Yes      | <code>null &#124; HTMLAnchorElement</code>           | <code>null</code>      | Obtain a reference to the HTML anchor element                                                                                                                                                                                                                    |
-| isSideNavOpen           | <code>let</code> | Yes      | <code>boolean</code>                                 | <code>false</code>     | Set to `true` to open the side nav                                                                                                                                                                                                                               |
-| expandedByDefault       | <code>let</code> | No       | <code>boolean</code>                                 | <code>true</code>      | Set to `false` to hide the side nav by default                                                                                                                                                                                                                   |
-| uiShellAriaLabel        | <code>let</code> | No       | <code>string</code>                                  | <code>undefined</code> | Specify the ARIA label for the header                                                                                                                                                                                                                            |
-| href                    | <code>let</code> | No       | <code>string</code>                                  | <code>undefined</code> | Specify the `href` attribute                                                                                                                                                                                                                                     |
-| company                 | <code>let</code> | No       | <code>string</code>                                  | <code>undefined</code> | Specify the company name                                                                                                                                                                                                                                         |
-| platformName            | <code>let</code> | No       | <code>string</code>                                  | <code>""</code>        | Specify the platform name<br />Alternatively, use the named slot "platform" (e.g., &lt;span slot="platform"&gt;...&lt;/span&gt;)                                                                                                                                 |
-| persistentHamburgerMenu | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>     | Set to `true` to persist the hamburger menu                                                                                                                                                                                                                      |
-| expansionBreakpoint     | <code>let</code> | No       | <code>number</code>                                  | <code>1056</code>      | The window width (px) at which the SideNav is expanded and the hamburger menu is hidden<br />1056 represents the "large" breakpoint in pixels from the Carbon Design System:<br />small: 320<br />medium: 672<br />large: 1056<br />x-large: 1312<br />max: 1584 |
-| iconMenu                | <code>let</code> | No       | <code>typeof import("svelte").SvelteComponent</code> | <code>undefined</code> | Specify the icon to render for the closed state.<br />Defaults to `&lt;Menu size={20} /&gt;`                                                                                                                                                                     |
-| iconClose               | <code>let</code> | No       | <code>typeof import("svelte").SvelteComponent</code> | <code>undefined</code> | Specify the icon to render for the opened state.<br />Defaults to `&lt;Close size={20} /&gt;`                                                                                                                                                                    |
+| Prop name               | Required | Kind             | Reactive | Type                                                 | Default value          | Description                                                                                                                                                                                                                                                      |
+| :---------------------- | :------- | :--------------- | :------- | ---------------------------------------------------- | ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ref                     | No       | <code>let</code> | Yes      | <code>null &#124; HTMLAnchorElement</code>           | <code>null</code>      | Obtain a reference to the HTML anchor element                                                                                                                                                                                                                    |
+| isSideNavOpen           | No       | <code>let</code> | Yes      | <code>boolean</code>                                 | <code>false</code>     | Set to `true` to open the side nav                                                                                                                                                                                                                               |
+| expandedByDefault       | No       | <code>let</code> | No       | <code>boolean</code>                                 | <code>true</code>      | Set to `false` to hide the side nav by default                                                                                                                                                                                                                   |
+| uiShellAriaLabel        | No       | <code>let</code> | No       | <code>string</code>                                  | <code>undefined</code> | Specify the ARIA label for the header                                                                                                                                                                                                                            |
+| href                    | No       | <code>let</code> | No       | <code>string</code>                                  | <code>undefined</code> | Specify the `href` attribute                                                                                                                                                                                                                                     |
+| company                 | No       | <code>let</code> | No       | <code>string</code>                                  | <code>undefined</code> | Specify the company name                                                                                                                                                                                                                                         |
+| platformName            | No       | <code>let</code> | No       | <code>string</code>                                  | <code>""</code>        | Specify the platform name<br />Alternatively, use the named slot "platform" (e.g., &lt;span slot="platform"&gt;...&lt;/span&gt;)                                                                                                                                 |
+| persistentHamburgerMenu | No       | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>     | Set to `true` to persist the hamburger menu                                                                                                                                                                                                                      |
+| expansionBreakpoint     | No       | <code>let</code> | No       | <code>number</code>                                  | <code>1056</code>      | The window width (px) at which the SideNav is expanded and the hamburger menu is hidden<br />1056 represents the "large" breakpoint in pixels from the Carbon Design System:<br />small: 320<br />medium: 672<br />large: 1056<br />x-large: 1312<br />max: 1584 |
+| iconMenu                | No       | <code>let</code> | No       | <code>typeof import("svelte").SvelteComponent</code> | <code>undefined</code> | Specify the icon to render for the closed state.<br />Defaults to `&lt;Menu size={20} /&gt;`                                                                                                                                                                     |
+| iconClose               | No       | <code>let</code> | No       | <code>typeof import("svelte").SvelteComponent</code> | <code>undefined</code> | Specify the icon to render for the opened state.<br />Defaults to `&lt;Close size={20} /&gt;`                                                                                                                                                                    |
 
 ### Slots
 
@@ -1592,14 +1592,14 @@ None.
 
 ### Props
 
-| Prop name  | Kind             | Reactive | Type                                                              | Default value                  | Description                                                                                                   |
-| :--------- | :--------------- | :------- | :---------------------------------------------------------------- | ------------------------------ | ------------------------------------------------------------------------------------------------------------- |
-| ref        | <code>let</code> | Yes      | <code>null &#124; HTMLButtonElement</code>                        | <code>null</code>              | Obtain a reference to the button HTML element                                                                 |
-| isOpen     | <code>let</code> | Yes      | <code>boolean</code>                                              | <code>false</code>             | Set to `true` to open the panel                                                                               |
-| icon       | <code>let</code> | No       | <code>typeof import("svelte").SvelteComponent</code>              | <code>undefined</code>         | Specify the icon to render when the action panel is closed.<br />Defaults to `&lt;Switcher size={20} /&gt;`   |
-| closeIcon  | <code>let</code> | No       | <code>typeof import("svelte").SvelteComponent</code>              | <code>undefined</code>         | Specify the icon to render when the action panel is open.<br />Defaults to `&lt;Close size={20} /&gt;`        |
-| text       | <code>let</code> | No       | <code>string</code>                                               | <code>undefined</code>         | Specify the text<br />Alternatively, use the named slot "text" (e.g., &lt;div slot="text"&gt;...&lt;/div&gt;) |
-| transition | <code>let</code> | No       | <code>false &#124; import("svelte/transition").SlideParams</code> | <code>{ duration: 200 }</code> | Customize the panel transition (i.e., `transition:slide`).<br />Set to `false` to disable the transition      |
+| Prop name  | Required | Kind             | Reactive | Type                                                              | Default value                  | Description                                                                                                   |
+| :--------- | :------- | :--------------- | :------- | ----------------------------------------------------------------- | ------------------------------ | ------------------------------------------------------------------------------------------------------------- |
+| ref        | No       | <code>let</code> | Yes      | <code>null &#124; HTMLButtonElement</code>                        | <code>null</code>              | Obtain a reference to the button HTML element                                                                 |
+| isOpen     | No       | <code>let</code> | Yes      | <code>boolean</code>                                              | <code>false</code>             | Set to `true` to open the panel                                                                               |
+| icon       | No       | <code>let</code> | No       | <code>typeof import("svelte").SvelteComponent</code>              | <code>undefined</code>         | Specify the icon to render when the action panel is closed.<br />Defaults to `&lt;Switcher size={20} /&gt;`   |
+| closeIcon  | No       | <code>let</code> | No       | <code>typeof import("svelte").SvelteComponent</code>              | <code>undefined</code>         | Specify the icon to render when the action panel is open.<br />Defaults to `&lt;Close size={20} /&gt;`        |
+| text       | No       | <code>let</code> | No       | <code>string</code>                                               | <code>undefined</code>         | Specify the text<br />Alternatively, use the named slot "text" (e.g., &lt;div slot="text"&gt;...&lt;/div&gt;) |
+| transition | No       | <code>let</code> | No       | <code>false &#124; import("svelte/transition").SlideParams</code> | <code>{ duration: 200 }</code> | Customize the panel transition (i.e., `transition:slide`).<br />Set to `false` to disable the transition      |
 
 ### Slots
 
@@ -1622,12 +1622,12 @@ None.
 
 ### Props
 
-| Prop name    | Kind             | Reactive | Type                                                 | Default value          | Description                                   |
-| :----------- | :--------------- | :------- | :--------------------------------------------------- | ---------------------- | --------------------------------------------- |
-| ref          | <code>let</code> | Yes      | <code>null &#124; HTMLAnchorElement</code>           | <code>null</code>      | Obtain a reference to the HTML anchor element |
-| linkIsActive | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>     | Set to `true` to use the active state         |
-| href         | <code>let</code> | No       | <code>string</code>                                  | <code>undefined</code> | Specify the `href` attribute                  |
-| icon         | <code>let</code> | No       | <code>typeof import("svelte").SvelteComponent</code> | <code>undefined</code> | Specify the icon to render                    |
+| Prop name    | Required | Kind             | Reactive | Type                                                 | Default value          | Description                                   |
+| :----------- | :------- | :--------------- | :------- | ---------------------------------------------------- | ---------------------- | --------------------------------------------- |
+| ref          | No       | <code>let</code> | Yes      | <code>null &#124; HTMLAnchorElement</code>           | <code>null</code>      | Obtain a reference to the HTML anchor element |
+| linkIsActive | No       | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>     | Set to `true` to use the active state         |
+| href         | No       | <code>let</code> | No       | <code>string</code>                                  | <code>undefined</code> | Specify the `href` attribute                  |
+| icon         | No       | <code>let</code> | No       | <code>typeof import("svelte").SvelteComponent</code> | <code>undefined</code> | Specify the icon to render                    |
 
 ### Slots
 
@@ -1643,11 +1643,11 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                                                 | Default value          | Description                                   |
-| :-------- | :--------------- | :------- | :--------------------------------------------------- | ---------------------- | --------------------------------------------- |
-| ref       | <code>let</code> | Yes      | <code>null &#124; HTMLButtonElement</code>           | <code>null</code>      | Obtain a reference to the HTML button element |
-| isActive  | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>     | Set to `true` to use the active variant       |
-| icon      | <code>let</code> | No       | <code>typeof import("svelte").SvelteComponent</code> | <code>undefined</code> | Specify the icon to render                    |
+| Prop name | Required | Kind             | Reactive | Type                                                 | Default value          | Description                                   |
+| :-------- | :------- | :--------------- | :------- | ---------------------------------------------------- | ---------------------- | --------------------------------------------- |
+| ref       | No       | <code>let</code> | Yes      | <code>null &#124; HTMLButtonElement</code>           | <code>null</code>      | Obtain a reference to the HTML button element |
+| isActive  | No       | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>     | Set to `true` to use the active variant       |
+| icon      | No       | <code>let</code> | No       | <code>typeof import("svelte").SvelteComponent</code> | <code>undefined</code> | Specify the icon to render                    |
 
 ### Slots
 
@@ -1681,12 +1681,12 @@ None.
 
 ### Props
 
-| Prop name  | Kind             | Reactive | Type                                       | Default value          | Description                                   |
-| :--------- | :--------------- | :------- | :----------------------------------------- | ---------------------- | --------------------------------------------- |
-| ref        | <code>let</code> | Yes      | <code>null &#124; HTMLAnchorElement</code> | <code>null</code>      | Obtain a reference to the HTML anchor element |
-| href       | <code>let</code> | No       | <code>string</code>                        | <code>undefined</code> | Specify the `href` attribute                  |
-| text       | <code>let</code> | No       | <code>string</code>                        | <code>undefined</code> | Specify the text                              |
-| isSelected | <code>let</code> | No       | <code>boolean</code>                       | <code>false</code>     | Set to `true` to select the item              |
+| Prop name  | Required | Kind             | Reactive | Type                                       | Default value          | Description                                   |
+| :--------- | :------- | :--------------- | :------- | ------------------------------------------ | ---------------------- | --------------------------------------------- |
+| ref        | No       | <code>let</code> | Yes      | <code>null &#124; HTMLAnchorElement</code> | <code>null</code>      | Obtain a reference to the HTML anchor element |
+| href       | No       | <code>let</code> | No       | <code>string</code>                        | <code>undefined</code> | Specify the `href` attribute                  |
+| text       | No       | <code>let</code> | No       | <code>string</code>                        | <code>undefined</code> | Specify the text                              |
+| isSelected | No       | <code>let</code> | No       | <code>boolean</code>                       | <code>false</code>     | Set to `true` to select the item              |
 
 ### Slots
 
@@ -1709,12 +1709,12 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                                       | Default value          | Description                                   |
-| :-------- | :--------------- | :------- | :----------------------------------------- | ---------------------- | --------------------------------------------- |
-| ref       | <code>let</code> | Yes      | <code>null &#124; HTMLAnchorElement</code> | <code>null</code>      | Obtain a reference to the HTML anchor element |
-| expanded  | <code>let</code> | Yes      | <code>boolean</code>                       | <code>false</code>     | Set to `true` to toggle the expanded state    |
-| href      | <code>let</code> | No       | <code>string</code>                        | <code>"/"</code>       | Specify the `href` attribute                  |
-| text      | <code>let</code> | No       | <code>string</code>                        | <code>undefined</code> | Specify the text                              |
+| Prop name | Required | Kind             | Reactive | Type                                       | Default value          | Description                                   |
+| :-------- | :------- | :--------------- | :------- | ------------------------------------------ | ---------------------- | --------------------------------------------- |
+| ref       | No       | <code>let</code> | Yes      | <code>null &#124; HTMLAnchorElement</code> | <code>null</code>      | Obtain a reference to the HTML anchor element |
+| expanded  | No       | <code>let</code> | Yes      | <code>boolean</code>                       | <code>false</code>     | Set to `true` to toggle the expanded state    |
+| href      | No       | <code>let</code> | No       | <code>string</code>                        | <code>"/"</code>       | Specify the `href` attribute                  |
+| text      | No       | <code>let</code> | No       | <code>string</code>                        | <code>undefined</code> | Specify the text                              |
 
 ### Slots
 
@@ -1755,10 +1755,10 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                                       | Default value          | Description                                   |
-| :-------- | :--------------- | :------- | :----------------------------------------- | ---------------------- | --------------------------------------------- |
-| ref       | <code>let</code> | Yes      | <code>null &#124; HTMLAnchorElement</code> | <code>null</code>      | Obtain a reference to the HTML anchor element |
-| href      | <code>let</code> | No       | <code>string</code>                        | <code>undefined</code> | Specify the `href` attribute                  |
+| Prop name | Required | Kind             | Reactive | Type                                       | Default value          | Description                                   |
+| :-------- | :------- | :--------------- | :------- | ------------------------------------------ | ---------------------- | --------------------------------------------- |
+| ref       | No       | <code>let</code> | Yes      | <code>null &#124; HTMLAnchorElement</code> | <code>null</code>      | Obtain a reference to the HTML anchor element |
+| href      | No       | <code>let</code> | No       | <code>string</code>                        | <code>undefined</code> | Specify the `href` attribute                  |
 
 ### Slots
 
@@ -1802,13 +1802,13 @@ export interface HeaderSearchResult {
 
 ### Props
 
-| Prop name           | Kind             | Reactive | Type                                      | Default value      | Description                                        |
-| :------------------ | :--------------- | :------- | :---------------------------------------- | ------------------ | -------------------------------------------------- |
-| selectedResultIndex | <code>let</code> | Yes      | <code>number</code>                       | <code>0</code>     | Specify the selected result index                  |
-| ref                 | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code> | <code>null</code>  | Obtain a reference to the input HTML element       |
-| active              | <code>let</code> | Yes      | <code>boolean</code>                      | <code>false</code> | Set to `true` to activate and focus the search bar |
-| value               | <code>let</code> | Yes      | <code>string</code>                       | <code>""</code>    | Specify the search input value                     |
-| results             | <code>let</code> | No       | <code>HeaderSearchResult[]</code>         | <code>[]</code>    | Render a list of search results                    |
+| Prop name           | Required | Kind             | Reactive | Type                                      | Default value      | Description                                        |
+| :------------------ | :------- | :--------------- | :------- | ----------------------------------------- | ------------------ | -------------------------------------------------- |
+| selectedResultIndex | No       | <code>let</code> | Yes      | <code>number</code>                       | <code>0</code>     | Specify the selected result index                  |
+| ref                 | No       | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code> | <code>null</code>  | Obtain a reference to the input HTML element       |
+| active              | No       | <code>let</code> | Yes      | <code>boolean</code>                      | <code>false</code> | Set to `true` to activate and focus the search bar |
+| value               | No       | <code>let</code> | Yes      | <code>string</code>                       | <code>""</code>    | Specify the search input value                     |
+| results             | No       | <code>let</code> | No       | <code>HeaderSearchResult[]</code>         | <code>[]</code>    | Render a list of search results                    |
 
 ### Slots
 
@@ -1850,16 +1850,16 @@ None.
 
 ### Props
 
-| Prop name | Kind               | Reactive | Type                                                                                                            | Default value                                                                                                                                                                                                                | Description                                                                                                                 |
-| :-------- | :----------------- | :------- | :-------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| error     | <code>let</code>   | Yes      | <code>boolean</code>                                                                                            | <code>false</code>                                                                                                                                                                                                           | Set to `true` if an error occurs when loading the image                                                                     |
-| loaded    | <code>let</code>   | Yes      | <code>boolean</code>                                                                                            | <code>false</code>                                                                                                                                                                                                           | Set to `true` when the image is loaded                                                                                      |
-| loading   | <code>let</code>   | Yes      | <code>boolean</code>                                                                                            | <code>false</code>                                                                                                                                                                                                           | Set to `true` when `loaded` is `true` and `error` is false                                                                  |
-| src       | <code>let</code>   | No       | <code>string</code>                                                                                             | <code>""</code>                                                                                                                                                                                                              | Specify the image source                                                                                                    |
-| alt       | <code>let</code>   | No       | <code>string</code>                                                                                             | <code>""</code>                                                                                                                                                                                                              | Specify the image alt text                                                                                                  |
-| ratio     | <code>let</code>   | No       | <code>"2x1" &#124; "16x9" &#124; "4x3" &#124; "1x1" &#124; "3x4" &#124; "3x2" &#124; "9x16" &#124; "1x2"</code> | <code>undefined</code>                                                                                                                                                                                                       | Specify the aspect ratio for the image wrapper                                                                              |
-| fadeIn    | <code>let</code>   | No       | <code>boolean</code>                                                                                            | <code>false</code>                                                                                                                                                                                                           | Set to `true` to fade in the image on load<br />The duration uses the `fast-02` value following Carbon guidelines on motion |
-| loadImage | <code>const</code> | No       | <code>(url?: string) => void</code>                                                                             | <code>(url) => { if (image != null) image = null; loaded = false; error = false; image = new Image(); image.src = url &#124;&#124; src; image.onload = () => (loaded = true); image.onerror = () => (error = true); }</code> | Method invoked to load the image provided a `src` value                                                                     |
+| Prop name | Required | Kind               | Reactive | Type                                                                                                            | Default value                                                                                                                                                                                                                | Description                                                                                                                 |
+| :-------- | :------- | :----------------- | :------- | --------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| error     | No       | <code>let</code>   | Yes      | <code>boolean</code>                                                                                            | <code>false</code>                                                                                                                                                                                                           | Set to `true` if an error occurs when loading the image                                                                     |
+| loaded    | No       | <code>let</code>   | Yes      | <code>boolean</code>                                                                                            | <code>false</code>                                                                                                                                                                                                           | Set to `true` when the image is loaded                                                                                      |
+| loading   | No       | <code>let</code>   | Yes      | <code>boolean</code>                                                                                            | <code>false</code>                                                                                                                                                                                                           | Set to `true` when `loaded` is `true` and `error` is false                                                                  |
+| src       | No       | <code>let</code>   | No       | <code>string</code>                                                                                             | <code>""</code>                                                                                                                                                                                                              | Specify the image source                                                                                                    |
+| alt       | No       | <code>let</code>   | No       | <code>string</code>                                                                                             | <code>""</code>                                                                                                                                                                                                              | Specify the image alt text                                                                                                  |
+| ratio     | No       | <code>let</code>   | No       | <code>"2x1" &#124; "16x9" &#124; "4x3" &#124; "1x1" &#124; "3x4" &#124; "3x2" &#124; "9x16" &#124; "1x2"</code> | <code>undefined</code>                                                                                                                                                                                                       | Specify the aspect ratio for the image wrapper                                                                              |
+| fadeIn    | No       | <code>let</code>   | No       | <code>boolean</code>                                                                                            | <code>false</code>                                                                                                                                                                                                           | Set to `true` to fade in the image on load<br />The duration uses the `fast-02` value following Carbon guidelines on motion |
+| loadImage | No       | <code>const</code> | No       | <code>(url?: string) => void</code>                                                                             | <code>(url) => { if (image != null) image = null; loaded = false; error = false; image = new Image(); image.src = url &#124;&#124; src; image.onload = () => (loaded = true); image.onerror = () => (error = true); }</code> | Method invoked to load the image provided a `src` value                                                                     |
 
 ### Slots
 
@@ -1879,12 +1879,12 @@ None.
 
 ### Props
 
-| Prop name       | Kind             | Reactive | Type                                                                     | Default value          | Description                                                       |
-| :-------------- | :--------------- | :------- | :----------------------------------------------------------------------- | ---------------------- | ----------------------------------------------------------------- |
-| status          | <code>let</code> | No       | <code>"active" &#124; "inactive" &#124; "finished" &#124; "error"</code> | <code>"active"</code>  | Set the loading status                                            |
-| description     | <code>let</code> | No       | <code>string</code>                                                      | <code>undefined</code> | Set the loading description                                       |
-| iconDescription | <code>let</code> | No       | <code>string</code>                                                      | <code>undefined</code> | Specify the ARIA label for the loading icon                       |
-| successDelay    | <code>let</code> | No       | <code>number</code>                                                      | <code>1500</code>      | Specify the timeout delay (ms) after `status` is set to "success" |
+| Prop name       | Required | Kind             | Reactive | Type                                                                     | Default value          | Description                                                       |
+| :-------------- | :------- | :--------------- | :------- | ------------------------------------------------------------------------ | ---------------------- | ----------------------------------------------------------------- |
+| status          | No       | <code>let</code> | No       | <code>"active" &#124; "inactive" &#124; "finished" &#124; "error"</code> | <code>"active"</code>  | Set the loading status                                            |
+| description     | No       | <code>let</code> | No       | <code>string</code>                                                      | <code>undefined</code> | Set the loading description                                       |
+| iconDescription | No       | <code>let</code> | No       | <code>string</code>                                                      | <code>undefined</code> | Specify the ARIA label for the loading icon                       |
+| successDelay    | No       | <code>let</code> | No       | <code>number</code>                                                      | <code>1500</code>      | Specify the timeout delay (ms) after `status` is set to "success" |
 
 ### Slots
 
@@ -1904,16 +1904,16 @@ None.
 
 ### Props
 
-| Prop name       | Kind             | Reactive | Type                                                                                                           | Default value                      | Description                                                             |
-| :-------------- | :--------------- | :------- | :------------------------------------------------------------------------------------------------------------- | ---------------------------------- | ----------------------------------------------------------------------- |
-| kind            | <code>let</code> | No       | <code>"error" &#124; "info" &#124; "info-square" &#124; "success" &#124; "warning" &#124; "warning-alt"</code> | <code>"error"</code>               | Specify the kind of notification                                        |
-| lowContrast     | <code>let</code> | No       | <code>boolean</code>                                                                                           | <code>false</code>                 | Set to `true` to use the low contrast variant                           |
-| timeout         | <code>let</code> | No       | <code>number</code>                                                                                            | <code>0</code>                     | Set the timeout duration (ms) to hide the notification after opening it |
-| role            | <code>let</code> | No       | <code>string</code>                                                                                            | <code>"alert"</code>               | Set the `role` attribute                                                |
-| title           | <code>let</code> | No       | <code>string</code>                                                                                            | <code>""</code>                    | Specify the title text                                                  |
-| subtitle        | <code>let</code> | No       | <code>string</code>                                                                                            | <code>""</code>                    | Specify the subtitle text                                               |
-| hideCloseButton | <code>let</code> | No       | <code>boolean</code>                                                                                           | <code>false</code>                 | Set to `true` to hide the close button                                  |
-| iconDescription | <code>let</code> | No       | <code>string</code>                                                                                            | <code>"Closes notification"</code> | Specify the ARIA label for the icon                                     |
+| Prop name       | Required | Kind             | Reactive | Type                                                                                                           | Default value                      | Description                                                             |
+| :-------------- | :------- | :--------------- | :------- | -------------------------------------------------------------------------------------------------------------- | ---------------------------------- | ----------------------------------------------------------------------- |
+| kind            | No       | <code>let</code> | No       | <code>"error" &#124; "info" &#124; "info-square" &#124; "success" &#124; "warning" &#124; "warning-alt"</code> | <code>"error"</code>               | Specify the kind of notification                                        |
+| lowContrast     | No       | <code>let</code> | No       | <code>boolean</code>                                                                                           | <code>false</code>                 | Set to `true` to use the low contrast variant                           |
+| timeout         | No       | <code>let</code> | No       | <code>number</code>                                                                                            | <code>0</code>                     | Set the timeout duration (ms) to hide the notification after opening it |
+| role            | No       | <code>let</code> | No       | <code>string</code>                                                                                            | <code>"alert"</code>               | Set the `role` attribute                                                |
+| title           | No       | <code>let</code> | No       | <code>string</code>                                                                                            | <code>""</code>                    | Specify the title text                                                  |
+| subtitle        | No       | <code>let</code> | No       | <code>string</code>                                                                                            | <code>""</code>                    | Specify the subtitle text                                               |
+| hideCloseButton | No       | <code>let</code> | No       | <code>boolean</code>                                                                                           | <code>false</code>                 | Set to `true` to hide the close button                                  |
+| iconDescription | No       | <code>let</code> | No       | <code>string</code>                                                                                            | <code>"Closes notification"</code> | Specify the ARIA label for the icon                                     |
 
 ### Slots
 
@@ -1938,15 +1938,15 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                                                                   | Default value          | Description                                              |
-| :-------- | :--------------- | :------- | :--------------------------------------------------------------------- | ---------------------- | -------------------------------------------------------- |
-| ref       | <code>let</code> | Yes      | <code>null &#124; HTMLAnchorElement &#124; HTMLParagraphElement</code> | <code>null</code>      | Obtain a reference to the top-level HTML element         |
-| size      | <code>let</code> | No       | <code>"sm" &#124; "lg"</code>                                          | <code>undefined</code> | Specify the size of the link                             |
-| href      | <code>let</code> | No       | <code>string</code>                                                    | <code>undefined</code> | Specify the href value                                   |
-| inline    | <code>let</code> | No       | <code>boolean</code>                                                   | <code>false</code>     | Set to `true` to use the inline variant                  |
-| icon      | <code>let</code> | No       | <code>typeof import("svelte").SvelteComponent</code>                   | <code>undefined</code> | Specify the icon to render<br />`inline` must be `false` |
-| disabled  | <code>let</code> | No       | <code>boolean</code>                                                   | <code>false</code>     | Set to `true` to disable the checkbox                    |
-| visited   | <code>let</code> | No       | <code>boolean</code>                                                   | <code>false</code>     | Set to `true` to allow visited styles                    |
+| Prop name | Required | Kind             | Reactive | Type                                                                   | Default value          | Description                                              |
+| :-------- | :------- | :--------------- | :------- | ---------------------------------------------------------------------- | ---------------------- | -------------------------------------------------------- |
+| ref       | No       | <code>let</code> | Yes      | <code>null &#124; HTMLAnchorElement &#124; HTMLParagraphElement</code> | <code>null</code>      | Obtain a reference to the top-level HTML element         |
+| size      | No       | <code>let</code> | No       | <code>"sm" &#124; "lg"</code>                                          | <code>undefined</code> | Specify the size of the link                             |
+| href      | No       | <code>let</code> | No       | <code>string</code>                                                    | <code>undefined</code> | Specify the href value                                   |
+| inline    | No       | <code>let</code> | No       | <code>boolean</code>                                                   | <code>false</code>     | Set to `true` to use the inline variant                  |
+| icon      | No       | <code>let</code> | No       | <code>typeof import("svelte").SvelteComponent</code>                   | <code>undefined</code> | Specify the icon to render<br />`inline` must be `false` |
+| disabled  | No       | <code>let</code> | No       | <code>boolean</code>                                                   | <code>false</code>     | Set to `true` to disable the checkbox                    |
+| visited   | No       | <code>let</code> | No       | <code>boolean</code>                                                   | <code>false</code>     | Set to `true` to allow visited styles                    |
 
 ### Slots
 
@@ -1968,17 +1968,17 @@ None.
 
 ### Props
 
-| Prop name   | Kind             | Reactive | Type                                   | Default value          | Description                                |
-| :---------- | :--------------- | :------- | :------------------------------------- | ---------------------- | ------------------------------------------ |
-| size        | <code>let</code> | No       | <code>"sm" &#124; "xl"</code>          | <code>undefined</code> | Set the size of the list box               |
-| type        | <code>let</code> | No       | <code>"default" &#124; "inline"</code> | <code>"default"</code> | Set the type of the list box               |
-| open        | <code>let</code> | No       | <code>boolean</code>                   | <code>false</code>     | Set to `true` to open the list box         |
-| light       | <code>let</code> | No       | <code>boolean</code>                   | <code>false</code>     | Set to `true` to enable the light variant  |
-| disabled    | <code>let</code> | No       | <code>boolean</code>                   | <code>false</code>     | Set to `true` to disable the list box      |
-| invalid     | <code>let</code> | No       | <code>boolean</code>                   | <code>false</code>     | Set to `true` to indicate an invalid state |
-| invalidText | <code>let</code> | No       | <code>string</code>                    | <code>""</code>        | Specify the invalid state text             |
-| warn        | <code>let</code> | No       | <code>boolean</code>                   | <code>false</code>     | Set to `true` to indicate an warning state |
-| warnText    | <code>let</code> | No       | <code>string</code>                    | <code>""</code>        | Specify the warning state text             |
+| Prop name   | Required | Kind             | Reactive | Type                                   | Default value          | Description                                |
+| :---------- | :------- | :--------------- | :------- | -------------------------------------- | ---------------------- | ------------------------------------------ |
+| size        | No       | <code>let</code> | No       | <code>"sm" &#124; "xl"</code>          | <code>undefined</code> | Set the size of the list box               |
+| type        | No       | <code>let</code> | No       | <code>"default" &#124; "inline"</code> | <code>"default"</code> | Set the type of the list box               |
+| open        | No       | <code>let</code> | No       | <code>boolean</code>                   | <code>false</code>     | Set to `true` to open the list box         |
+| light       | No       | <code>let</code> | No       | <code>boolean</code>                   | <code>false</code>     | Set to `true` to enable the light variant  |
+| disabled    | No       | <code>let</code> | No       | <code>boolean</code>                   | <code>false</code>     | Set to `true` to disable the list box      |
+| invalid     | No       | <code>let</code> | No       | <code>boolean</code>                   | <code>false</code>     | Set to `true` to indicate an invalid state |
+| invalidText | No       | <code>let</code> | No       | <code>string</code>                    | <code>""</code>        | Specify the invalid state text             |
+| warn        | No       | <code>let</code> | No       | <code>boolean</code>                   | <code>false</code>     | Set to `true` to indicate an warning state |
+| warnText    | No       | <code>let</code> | No       | <code>string</code>                    | <code>""</code>        | Specify the warning state text             |
 
 ### Slots
 
@@ -2003,15 +2003,15 @@ export type ListBoxFieldTranslationId = "close" | "open";
 
 ### Props
 
-| Prop name       | Kind               | Reactive | Type                                                   | Default value                                    | Description                                      |
-| :-------------- | :----------------- | :------- | :----------------------------------------------------- | ------------------------------------------------ | ------------------------------------------------ |
-| ref             | <code>let</code>   | Yes      | <code>null &#124; HTMLDivElement</code>                | <code>null</code>                                | Obtain a reference to the top-level HTML element |
-| disabled        | <code>let</code>   | No       | <code>boolean</code>                                   | <code>false</code>                               | Set to `true` to disable the list box field      |
-| role            | <code>let</code>   | No       | <code>string</code>                                    | <code>"combobox"</code>                          | Specify the role attribute                       |
-| tabindex        | <code>let</code>   | No       | <code>string</code>                                    | <code>"-1"</code>                                | Specify the tabindex                             |
-| translationIds  | <code>const</code> | No       | <code>{ close: "close", open: "open" }</code>          | <code>{ close: "close", open: "open" }</code>    | Default translation ids                          |
-| translateWithId | <code>let</code>   | No       | <code>(id: ListBoxFieldTranslationId) => string</code> | <code>(id) => defaultTranslations[id]</code>     | Override the default translation ids             |
-| id              | <code>let</code>   | No       | <code>string</code>                                    | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the top-level element              |
+| Prop name       | Required | Kind               | Reactive | Type                                                   | Default value                                    | Description                                      |
+| :-------------- | :------- | :----------------- | :------- | ------------------------------------------------------ | ------------------------------------------------ | ------------------------------------------------ |
+| ref             | No       | <code>let</code>   | Yes      | <code>null &#124; HTMLDivElement</code>                | <code>null</code>                                | Obtain a reference to the top-level HTML element |
+| disabled        | No       | <code>let</code>   | No       | <code>boolean</code>                                   | <code>false</code>                               | Set to `true` to disable the list box field      |
+| role            | No       | <code>let</code>   | No       | <code>string</code>                                    | <code>"combobox"</code>                          | Specify the role attribute                       |
+| tabindex        | No       | <code>let</code>   | No       | <code>string</code>                                    | <code>"-1"</code>                                | Specify the tabindex                             |
+| translationIds  | No       | <code>const</code> | No       | <code>{ close: "close", open: "open" }</code>          | <code>{ close: "close", open: "open" }</code>    | Default translation ids                          |
+| translateWithId | No       | <code>let</code>   | No       | <code>(id: ListBoxFieldTranslationId) => string</code> | <code>(id) => defaultTranslations[id]</code>     | Override the default translation ids             |
+| id              | No       | <code>let</code>   | No       | <code>string</code>                                    | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the top-level element              |
 
 ### Slots
 
@@ -2035,10 +2035,10 @@ export type ListBoxFieldTranslationId = "close" | "open";
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                                    | Default value                                    | Description                            |
-| :-------- | :--------------- | :------- | :-------------------------------------- | ------------------------------------------------ | -------------------------------------- |
-| ref       | <code>let</code> | Yes      | <code>null &#124; HTMLDivElement</code> | <code>null</code>                                | Obtain a reference to the HTML element |
-| id        | <code>let</code> | No       | <code>string</code>                     | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the top-level element    |
+| Prop name | Required | Kind             | Reactive | Type                                    | Default value                                    | Description                            |
+| :-------- | :------- | :--------------- | :------- | --------------------------------------- | ------------------------------------------------ | -------------------------------------- |
+| ref       | No       | <code>let</code> | Yes      | <code>null &#124; HTMLDivElement</code> | <code>null</code>                                | Obtain a reference to the HTML element |
+| id        | No       | <code>let</code> | No       | <code>string</code>                     | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the top-level element    |
 
 ### Slots
 
@@ -2062,11 +2062,11 @@ export type ListBoxMenuIconTranslationId = "close" | "open";
 
 ### Props
 
-| Prop name       | Kind               | Reactive | Type                                                      | Default value                                 | Description                                  |
-| :-------------- | :----------------- | :------- | :-------------------------------------------------------- | --------------------------------------------- | -------------------------------------------- |
-| open            | <code>let</code>   | No       | <code>boolean</code>                                      | <code>false</code>                            | Set to `true` to open the list box menu icon |
-| translationIds  | <code>const</code> | No       | <code>{ close: "close", open: "open" }</code>             | <code>{ close: "close", open: "open" }</code> | Default translation ids                      |
-| translateWithId | <code>let</code>   | No       | <code>(id: ListBoxMenuIconTranslationId) => string</code> | <code>(id) => defaultTranslations[id]</code>  | Override the default translation ids         |
+| Prop name       | Required | Kind               | Reactive | Type                                                      | Default value                                 | Description                                  |
+| :-------------- | :------- | :----------------- | :------- | --------------------------------------------------------- | --------------------------------------------- | -------------------------------------------- |
+| open            | No       | <code>let</code>   | No       | <code>boolean</code>                                      | <code>false</code>                            | Set to `true` to open the list box menu icon |
+| translationIds  | No       | <code>const</code> | No       | <code>{ close: "close", open: "open" }</code>             | <code>{ close: "close", open: "open" }</code> | Default translation ids                      |
+| translateWithId | No       | <code>let</code>   | No       | <code>(id: ListBoxMenuIconTranslationId) => string</code> | <code>(id) => defaultTranslations[id]</code>  | Override the default translation ids         |
 
 ### Slots
 
@@ -2082,10 +2082,10 @@ None.
 
 ### Props
 
-| Prop name   | Kind             | Reactive | Type                 | Default value      | Description                                   |
-| :---------- | :--------------- | :------- | :------------------- | ------------------ | --------------------------------------------- |
-| active      | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to enable the active state      |
-| highlighted | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to enable the highlighted state |
+| Prop name   | Required | Kind             | Reactive | Type                 | Default value      | Description                                   |
+| :---------- | :------- | :--------------- | :------- | -------------------- | ------------------ | --------------------------------------------- |
+| active      | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to enable the active state      |
+| highlighted | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to enable the highlighted state |
 
 ### Slots
 
@@ -2111,13 +2111,13 @@ export type ListBoxSelectionTranslationId = "clearAll" | "clearSelection";
 
 ### Props
 
-| Prop name       | Kind               | Reactive | Type                                                                     | Default value                                                            | Description                                      |
-| :-------------- | :----------------- | :------- | :----------------------------------------------------------------------- | ------------------------------------------------------------------------ | ------------------------------------------------ |
-| ref             | <code>let</code>   | Yes      | <code>null &#124; HTMLDivElement</code>                                  | <code>null</code>                                                        | Obtain a reference to the top-level HTML element |
-| selectionCount  | <code>let</code>   | No       | <code>number</code>                                                      | <code>undefined</code>                                                   | Specify the number of selected items             |
-| disabled        | <code>let</code>   | No       | <code>boolean</code>                                                     | <code>false</code>                                                       | Set to `true` to disable the list box selection  |
-| translationIds  | <code>const</code> | No       | <code>{ clearAll: "clearAll", clearSelection: "clearSelection", }</code> | <code>{ clearAll: "clearAll", clearSelection: "clearSelection", }</code> | Default translation ids                          |
-| translateWithId | <code>let</code>   | No       | <code>(id: ListBoxSelectionTranslationId) => string</code>               | <code>(id) => defaultTranslations[id]</code>                             | Override the default translation ids             |
+| Prop name       | Required | Kind               | Reactive | Type                                                                     | Default value                                                            | Description                                      |
+| :-------------- | :------- | :----------------- | :------- | ------------------------------------------------------------------------ | ------------------------------------------------------------------------ | ------------------------------------------------ |
+| ref             | No       | <code>let</code>   | Yes      | <code>null &#124; HTMLDivElement</code>                                  | <code>null</code>                                                        | Obtain a reference to the top-level HTML element |
+| selectionCount  | No       | <code>let</code>   | No       | <code>number</code>                                                      | <code>undefined</code>                                                   | Specify the number of selected items             |
+| disabled        | No       | <code>let</code>   | No       | <code>boolean</code>                                                     | <code>false</code>                                                       | Set to `true` to disable the list box selection  |
+| translationIds  | No       | <code>const</code> | No       | <code>{ clearAll: "clearAll", clearSelection: "clearSelection", }</code> | <code>{ clearAll: "clearAll", clearSelection: "clearSelection", }</code> | Default translation ids                          |
+| translateWithId | No       | <code>let</code>   | No       | <code>(id: ListBoxSelectionTranslationId) => string</code>               | <code>(id) => defaultTranslations[id]</code>                             | Override the default translation ids             |
 
 ### Slots
 
@@ -2154,13 +2154,13 @@ None.
 
 ### Props
 
-| Prop name   | Kind             | Reactive | Type                 | Default value                                    | Description                                |
-| :---------- | :--------------- | :------- | :------------------- | ------------------------------------------------ | ------------------------------------------ |
-| small       | <code>let</code> | No       | <code>boolean</code> | <code>false</code>                               | Set to `true` to use the small variant     |
-| active      | <code>let</code> | No       | <code>boolean</code> | <code>true</code>                                | Set to `false` to disable the active state |
-| withOverlay | <code>let</code> | No       | <code>boolean</code> | <code>true</code>                                | Set to `false` to disable the overlay      |
-| description | <code>let</code> | No       | <code>string</code>  | <code>"Active loading indicator"</code>          | Specify the label description              |
-| id          | <code>let</code> | No       | <code>string</code>  | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the label element            |
+| Prop name   | Required | Kind             | Reactive | Type                 | Default value                                    | Description                                |
+| :---------- | :------- | :--------------- | :------- | -------------------- | ------------------------------------------------ | ------------------------------------------ |
+| small       | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code>                               | Set to `true` to use the small variant     |
+| active      | No       | <code>let</code> | No       | <code>boolean</code> | <code>true</code>                                | Set to `false` to disable the active state |
+| withOverlay | No       | <code>let</code> | No       | <code>boolean</code> | <code>true</code>                                | Set to `false` to disable the overlay      |
+| description | No       | <code>let</code> | No       | <code>string</code>  | <code>"Active loading indicator"</code>          | Specify the label description              |
+| id          | No       | <code>let</code> | No       | <code>string</code>  | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the label element            |
 
 ### Slots
 
@@ -2174,12 +2174,12 @@ None.
 
 ### Props
 
-| Prop name | Kind                  | Reactive | Type                    | Default value                                        | Description                                                     |
-| :-------- | :-------------------- | :------- | :---------------------- | ---------------------------------------------------- | --------------------------------------------------------------- |
-| value     | <code>let</code>      | Yes      | <code>any</code>        | <code>""</code>                                      | Provide a value to persist                                      |
-| key       | <code>let</code>      | No       | <code>string</code>     | <code>"local-storage-key"</code>                     | Specify the local storage key                                   |
-| clearItem | <code>function</code> | No       | <code>() => void</code> | <code>() => { localStorage.removeItem(key); }</code> | Remove the persisted key value from the browser's local storage |
-| clearAll  | <code>function</code> | No       | <code>() => void</code> | <code>() => { localStorage.clear(); }</code>         | Clear all key values from the browser's local storage           |
+| Prop name | Required | Kind                  | Reactive | Type                    | Default value                                        | Description                                                     |
+| :-------- | :------- | :-------------------- | :------- | ----------------------- | ---------------------------------------------------- | --------------------------------------------------------------- |
+| value     | No       | <code>let</code>      | Yes      | <code>any</code>        | <code>""</code>                                      | Provide a value to persist                                      |
+| key       | No       | <code>let</code>      | No       | <code>string</code>     | <code>"local-storage-key"</code>                     | Specify the local storage key                                   |
+| clearItem | No       | <code>function</code> | No       | <code>() => void</code> | <code>() => { localStorage.removeItem(key); }</code> | Remove the persisted key value from the browser's local storage |
+| clearAll  | No       | <code>function</code> | No       | <code>() => void</code> | <code>() => { localStorage.clear(); }</code>         | Clear all key values from the browser's local storage           |
 
 ### Slots
 
@@ -2196,29 +2196,29 @@ None.
 
 ### Props
 
-| Prop name                  | Kind             | Reactive | Type                                                 | Default value                                    | Description                                                                                                   |
-| :------------------------- | :--------------- | :------- | :--------------------------------------------------- | ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------- |
-| ref                        | <code>let</code> | Yes      | <code>null &#124; HTMLDivElement</code>              | <code>null</code>                                | Obtain a reference to the top-level HTML element                                                              |
-| open                       | <code>let</code> | Yes      | <code>boolean</code>                                 | <code>false</code>                               | Set to `true` to open the modal                                                                               |
-| size                       | <code>let</code> | No       | <code>"xs" &#124; "sm" &#124; "lg"</code>            | <code>undefined</code>                           | Set the size of the modal                                                                                     |
-| danger                     | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>                               | Set to `true` to use the danger variant                                                                       |
-| alert                      | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>                               | Set to `true` to enable alert mode                                                                            |
-| passiveModal               | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>                               | Set to `true` to use the passive variant                                                                      |
-| modalHeading               | <code>let</code> | No       | <code>string</code>                                  | <code>undefined</code>                           | Specify the modal heading                                                                                     |
-| modalLabel                 | <code>let</code> | No       | <code>string</code>                                  | <code>undefined</code>                           | Specify the modal label                                                                                       |
-| modalAriaLabel             | <code>let</code> | No       | <code>string</code>                                  | <code>undefined</code>                           | Specify the ARIA label for the modal                                                                          |
-| iconDescription            | <code>let</code> | No       | <code>string</code>                                  | <code>"Close the modal"</code>                   | Specify the ARIA label for the close icon                                                                     |
-| hasForm                    | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>                               | Set to `true` if the modal contains form elements                                                             |
-| hasScrollingContent        | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>                               | Set to `true` if the modal contains scrolling content                                                         |
-| primaryButtonText          | <code>let</code> | No       | <code>string</code>                                  | <code>""</code>                                  | Specify the primary button text                                                                               |
-| primaryButtonDisabled      | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>                               | Set to `true` to disable the primary button                                                                   |
-| primaryButtonIcon          | <code>let</code> | No       | <code>typeof import("svelte").SvelteComponent</code> | <code>undefined</code>                           | Specify the primary button icon                                                                               |
-| shouldSubmitOnEnter        | <code>let</code> | No       | <code>boolean</code>                                 | <code>true</code>                                | Set to `true` for the "submit" and "click:button--primary" events<br />to be dispatched when pressing "Enter" |
-| secondaryButtonText        | <code>let</code> | No       | <code>string</code>                                  | <code>""</code>                                  | Specify the secondary button text                                                                             |
-| secondaryButtons           | <code>let</code> | No       | <code>[{ text: string; }, { text: string; }]</code>  | <code>[]</code>                                  | 2-tuple prop to render two secondary buttons for a 3 button modal<br />supersedes `secondaryButtonText`       |
-| selectorPrimaryFocus       | <code>let</code> | No       | <code>string</code>                                  | <code>"[data-modal-primary-focus]"</code>        | Specify a selector to be focused when opening the modal                                                       |
-| preventCloseOnClickOutside | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>                               | Set to `true` to prevent the modal from closing when clicking outside                                         |
-| id                         | <code>let</code> | No       | <code>string</code>                                  | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the top-level element                                                                           |
+| Prop name                  | Required | Kind             | Reactive | Type                                                 | Default value                                    | Description                                                                                                   |
+| :------------------------- | :------- | :--------------- | :------- | ---------------------------------------------------- | ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------- |
+| ref                        | No       | <code>let</code> | Yes      | <code>null &#124; HTMLDivElement</code>              | <code>null</code>                                | Obtain a reference to the top-level HTML element                                                              |
+| open                       | No       | <code>let</code> | Yes      | <code>boolean</code>                                 | <code>false</code>                               | Set to `true` to open the modal                                                                               |
+| size                       | No       | <code>let</code> | No       | <code>"xs" &#124; "sm" &#124; "lg"</code>            | <code>undefined</code>                           | Set the size of the modal                                                                                     |
+| danger                     | No       | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>                               | Set to `true` to use the danger variant                                                                       |
+| alert                      | No       | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>                               | Set to `true` to enable alert mode                                                                            |
+| passiveModal               | No       | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>                               | Set to `true` to use the passive variant                                                                      |
+| modalHeading               | No       | <code>let</code> | No       | <code>string</code>                                  | <code>undefined</code>                           | Specify the modal heading                                                                                     |
+| modalLabel                 | No       | <code>let</code> | No       | <code>string</code>                                  | <code>undefined</code>                           | Specify the modal label                                                                                       |
+| modalAriaLabel             | No       | <code>let</code> | No       | <code>string</code>                                  | <code>undefined</code>                           | Specify the ARIA label for the modal                                                                          |
+| iconDescription            | No       | <code>let</code> | No       | <code>string</code>                                  | <code>"Close the modal"</code>                   | Specify the ARIA label for the close icon                                                                     |
+| hasForm                    | No       | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>                               | Set to `true` if the modal contains form elements                                                             |
+| hasScrollingContent        | No       | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>                               | Set to `true` if the modal contains scrolling content                                                         |
+| primaryButtonText          | No       | <code>let</code> | No       | <code>string</code>                                  | <code>""</code>                                  | Specify the primary button text                                                                               |
+| primaryButtonDisabled      | No       | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>                               | Set to `true` to disable the primary button                                                                   |
+| primaryButtonIcon          | No       | <code>let</code> | No       | <code>typeof import("svelte").SvelteComponent</code> | <code>undefined</code>                           | Specify the primary button icon                                                                               |
+| shouldSubmitOnEnter        | No       | <code>let</code> | No       | <code>boolean</code>                                 | <code>true</code>                                | Set to `true` for the "submit" and "click:button--primary" events<br />to be dispatched when pressing "Enter" |
+| secondaryButtonText        | No       | <code>let</code> | No       | <code>string</code>                                  | <code>""</code>                                  | Specify the secondary button text                                                                             |
+| secondaryButtons           | No       | <code>let</code> | No       | <code>[{ text: string; }, { text: string; }]</code>  | <code>[]</code>                                  | 2-tuple prop to render two secondary buttons for a 3 button modal<br />supersedes `secondaryButtonText`       |
+| selectorPrimaryFocus       | No       | <code>let</code> | No       | <code>string</code>                                  | <code>"[data-modal-primary-focus]"</code>        | Specify a selector to be focused when opening the modal                                                       |
+| preventCloseOnClickOutside | No       | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>                               | Set to `true` to prevent the modal from closing when clicking outside                                         |
+| id                         | No       | <code>let</code> | No       | <code>string</code>                                  | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the top-level element                                                                           |
 
 ### Slots
 
@@ -2248,10 +2248,10 @@ None.
 
 ### Props
 
-| Prop name           | Kind             | Reactive | Type                 | Default value      | Description                                           |
-| :------------------ | :--------------- | :------- | :------------------- | ------------------ | ----------------------------------------------------- |
-| hasForm             | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` if the modal contains form elements     |
-| hasScrollingContent | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` if the modal contains scrolling content |
+| Prop name           | Required | Kind             | Reactive | Type                 | Default value      | Description                                           |
+| :------------------ | :------- | :--------------- | :------- | -------------------- | ------------------ | ----------------------------------------------------- |
+| hasForm             | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` if the modal contains form elements     |
+| hasScrollingContent | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` if the modal contains scrolling content |
 
 ### Slots
 
@@ -2267,16 +2267,16 @@ None.
 
 ### Props
 
-| Prop name             | Kind             | Reactive | Type                                                 | Default value          | Description                                                                                             |
-| :-------------------- | :--------------- | :------- | :--------------------------------------------------- | ---------------------- | ------------------------------------------------------------------------------------------------------- |
-| primaryButtonText     | <code>let</code> | No       | <code>string</code>                                  | <code>""</code>        | Specify the primary button text                                                                         |
-| primaryButtonIcon     | <code>let</code> | No       | <code>typeof import("svelte").SvelteComponent</code> | <code>undefined</code> | Specify the primary button icon                                                                         |
-| primaryButtonDisabled | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>     | Set to `true` to disable the primary button                                                             |
-| primaryClass          | <code>let</code> | No       | <code>string</code>                                  | <code>undefined</code> | Specify a class for the primary button                                                                  |
-| secondaryButtonText   | <code>let</code> | No       | <code>string</code>                                  | <code>""</code>        | Specify the secondary button text                                                                       |
-| secondaryButtons      | <code>let</code> | No       | <code>[{ text: string; }, { text: string; }]</code>  | <code>[]</code>        | 2-tuple prop to render two secondary buttons for a 3 button modal<br />supersedes `secondaryButtonText` |
-| secondaryClass        | <code>let</code> | No       | <code>string</code>                                  | <code>undefined</code> | Specify a class for the secondary button                                                                |
-| danger                | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>     | Set to `true` to use the danger variant                                                                 |
+| Prop name             | Required | Kind             | Reactive | Type                                                 | Default value          | Description                                                                                             |
+| :-------------------- | :------- | :--------------- | :------- | ---------------------------------------------------- | ---------------------- | ------------------------------------------------------------------------------------------------------- |
+| primaryButtonText     | No       | <code>let</code> | No       | <code>string</code>                                  | <code>""</code>        | Specify the primary button text                                                                         |
+| primaryButtonIcon     | No       | <code>let</code> | No       | <code>typeof import("svelte").SvelteComponent</code> | <code>undefined</code> | Specify the primary button icon                                                                         |
+| primaryButtonDisabled | No       | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>     | Set to `true` to disable the primary button                                                             |
+| primaryClass          | No       | <code>let</code> | No       | <code>string</code>                                  | <code>undefined</code> | Specify a class for the primary button                                                                  |
+| secondaryButtonText   | No       | <code>let</code> | No       | <code>string</code>                                  | <code>""</code>        | Specify the secondary button text                                                                       |
+| secondaryButtons      | No       | <code>let</code> | No       | <code>[{ text: string; }, { text: string; }]</code>  | <code>[]</code>        | 2-tuple prop to render two secondary buttons for a 3 button modal<br />supersedes `secondaryButtonText` |
+| secondaryClass        | No       | <code>let</code> | No       | <code>string</code>                                  | <code>undefined</code> | Specify a class for the secondary button                                                                |
+| danger                | No       | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>     | Set to `true` to use the danger variant                                                                 |
 
 ### Slots
 
@@ -2294,15 +2294,15 @@ None.
 
 ### Props
 
-| Prop name       | Kind             | Reactive | Type                | Default value        | Description                               |
-| :-------------- | :--------------- | :------- | :------------------ | -------------------- | ----------------------------------------- |
-| title           | <code>let</code> | No       | <code>string</code> | <code>""</code>      | Specify the modal title                   |
-| label           | <code>let</code> | No       | <code>string</code> | <code>""</code>      | Specify the modal label                   |
-| labelClass      | <code>let</code> | No       | <code>string</code> | <code>""</code>      | Specify the label class                   |
-| titleClass      | <code>let</code> | No       | <code>string</code> | <code>""</code>      | Specify the title class                   |
-| closeClass      | <code>let</code> | No       | <code>string</code> | <code>""</code>      | Specify the close class                   |
-| closeIconClass  | <code>let</code> | No       | <code>string</code> | <code>""</code>      | Specify the close icon class              |
-| iconDescription | <code>let</code> | No       | <code>string</code> | <code>"Close"</code> | Specify the ARIA label for the close icon |
+| Prop name       | Required | Kind             | Reactive | Type                | Default value        | Description                               |
+| :-------------- | :------- | :--------------- | :------- | ------------------- | -------------------- | ----------------------------------------- |
+| title           | No       | <code>let</code> | No       | <code>string</code> | <code>""</code>      | Specify the modal title                   |
+| label           | No       | <code>let</code> | No       | <code>string</code> | <code>""</code>      | Specify the modal label                   |
+| labelClass      | No       | <code>let</code> | No       | <code>string</code> | <code>""</code>      | Specify the label class                   |
+| titleClass      | No       | <code>let</code> | No       | <code>string</code> | <code>""</code>      | Specify the title class                   |
+| closeClass      | No       | <code>let</code> | No       | <code>string</code> | <code>""</code>      | Specify the close class                   |
+| closeIconClass  | No       | <code>let</code> | No       | <code>string</code> | <code>""</code>      | Specify the close icon class              |
+| iconDescription | No       | <code>let</code> | No       | <code>string</code> | <code>"Close"</code> | Specify the ARIA label for the close icon |
 
 ### Slots
 
@@ -2333,43 +2333,43 @@ export interface MultiSelectItem {
 
 ### Props
 
-| Prop name                | Kind             | Reactive | Type                                                                                                    | Default value                                                                              | Description                                                                                                                                                           |
-| :----------------------- | :--------------- | :------- | :------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| highlightedId            | <code>let</code> | Yes      | <code>null &#124; MultiSelectItemId</code>                                                              | <code>null</code>                                                                          | Id of the highlighted ListBoxMenuItem                                                                                                                                 |
-| selectionRef             | <code>let</code> | Yes      | <code>null &#124; HTMLDivElement</code>                                                                 | <code>null</code>                                                                          | Obtain a reference to the selection element                                                                                                                           |
-| fieldRef                 | <code>let</code> | Yes      | <code>null &#124; HTMLDivElement</code>                                                                 | <code>null</code>                                                                          | Obtain a reference to the field box element                                                                                                                           |
-| multiSelectRef           | <code>let</code> | Yes      | <code>null &#124; HTMLDivElement</code>                                                                 | <code>null</code>                                                                          | Obtain a reference to the outer div element                                                                                                                           |
-| inputRef                 | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code>                                                               | <code>null</code>                                                                          | Obtain a reference to the input HTML element                                                                                                                          |
-| open                     | <code>let</code> | Yes      | <code>boolean</code>                                                                                    | <code>false</code>                                                                         | Set to `true` to open the dropdown                                                                                                                                    |
-| value                    | <code>let</code> | Yes      | <code>string</code>                                                                                     | <code>""</code>                                                                            | Specify the multiselect value                                                                                                                                         |
-| selectedIds              | <code>let</code> | Yes      | <code>MultiSelectItemId[]</code>                                                                        | <code>[]</code>                                                                            | Set the selected ids                                                                                                                                                  |
-| items                    | <code>let</code> | Yes      | <code>MultiSelectItem[]</code>                                                                          | <code>[]</code>                                                                            | Set the multiselect items                                                                                                                                             |
-| itemToString             | <code>let</code> | No       | <code>(item: MultiSelectItem) => any</code>                                                             | <code>(item) => item.text &#124;&#124; item.id</code>                                      | Override the display of a multiselect item                                                                                                                            |
-| itemToInput              | <code>let</code> | No       | <code>(item: MultiSelectItem) => { name?: string; labelText?: any; title?: string; }</code>             | <code>(item) => {}</code>                                                                  | Override the item name, title, labelText passed to the checkbox input                                                                                                 |
-| size                     | <code>let</code> | No       | <code>"sm" &#124; "lg" &#124; "xl"</code>                                                               | <code>undefined</code>                                                                     | Set the size of the combobox                                                                                                                                          |
-| type                     | <code>let</code> | No       | <code>"default" &#124; "inline"</code>                                                                  | <code>"default"</code>                                                                     | Specify the type of multiselect                                                                                                                                       |
-| direction                | <code>let</code> | No       | <code>"bottom" &#124; "top"</code>                                                                      | <code>"bottom"</code>                                                                      | Specify the direction of the multiselect dropdown menu                                                                                                                |
-| selectionFeedback        | <code>let</code> | No       | <code>"top" &#124; "fixed" &#124; "top-after-reopen"</code>                                             | <code>"top-after-reopen"</code>                                                            | Specify the selection feedback after selecting items                                                                                                                  |
-| disabled                 | <code>let</code> | No       | <code>boolean</code>                                                                                    | <code>false</code>                                                                         | Set to `true` to disable the dropdown                                                                                                                                 |
-| filterable               | <code>let</code> | No       | <code>boolean</code>                                                                                    | <code>false</code>                                                                         | Set to `true` to filter items                                                                                                                                         |
-| filterItem               | <code>let</code> | No       | <code>(item: MultiSelectItem, value: string) => string</code>                                           | <code>(item, value) => item.text.toLowerCase().includes(value.trim().toLowerCase())</code> | Override the filtering logic<br />The default filtering is an exact string comparison                                                                                 |
-| light                    | <code>let</code> | No       | <code>boolean</code>                                                                                    | <code>false</code>                                                                         | Set to `true` to enable the light variant                                                                                                                             |
-| locale                   | <code>let</code> | No       | <code>string</code>                                                                                     | <code>"en"</code>                                                                          | Specify the locale                                                                                                                                                    |
-| placeholder              | <code>let</code> | No       | <code>string</code>                                                                                     | <code>""</code>                                                                            | Specify the placeholder text                                                                                                                                          |
-| sortItem                 | <code>let</code> | No       | <code>((a: MultiSelectItem, b: MultiSelectItem) => MultiSelectItem) &#124; (() => void)</code>          | <code>(a, b) => a.text.localeCompare(b.text, locale, { numeric: true })</code>             | Override the sorting logic<br />The default sorting compare the item text value                                                                                       |
-| translateWithId          | <code>let</code> | No       | <code>(id: import("../ListBox/ListBoxMenuIcon.svelte").ListBoxMenuIconTranslationId) => string</code>   | <code>undefined</code>                                                                     | Override the chevron icon label based on the open state.<br />Defaults to "Open menu" when closed and "Close menu" when open                                          |
-| translateWithIdSelection | <code>let</code> | No       | <code>(id: import("../ListBox/ListBoxSelection.svelte").ListBoxSelectionTranslationId) => string</code> | <code>undefined</code>                                                                     | Override the label of the clear button when the input has a selection.<br />Defaults to "Clear selected item" and "Clear all items" if more than one item is selected |
-| titleText                | <code>let</code> | No       | <code>string</code>                                                                                     | <code>""</code>                                                                            | Specify the title text                                                                                                                                                |
-| useTitleInItem           | <code>let</code> | No       | <code>boolean</code>                                                                                    | <code>false</code>                                                                         | Set to `true` to pass the item to `itemToString` in the checkbox                                                                                                      |
-| invalid                  | <code>let</code> | No       | <code>boolean</code>                                                                                    | <code>false</code>                                                                         | Set to `true` to indicate an invalid state                                                                                                                            |
-| invalidText              | <code>let</code> | No       | <code>string</code>                                                                                     | <code>""</code>                                                                            | Specify the invalid state text                                                                                                                                        |
-| warn                     | <code>let</code> | No       | <code>boolean</code>                                                                                    | <code>false</code>                                                                         | Set to `true` to indicate an warning state                                                                                                                            |
-| warnText                 | <code>let</code> | No       | <code>string</code>                                                                                     | <code>""</code>                                                                            | Specify the warning state text                                                                                                                                        |
-| helperText               | <code>let</code> | No       | <code>string</code>                                                                                     | <code>""</code>                                                                            | Specify the helper text                                                                                                                                               |
-| label                    | <code>let</code> | No       | <code>string</code>                                                                                     | <code>""</code>                                                                            | Specify the list box label                                                                                                                                            |
-| hideLabel                | <code>let</code> | No       | <code>boolean</code>                                                                                    | <code>false</code>                                                                         | Set to `true` to visually hide the label text                                                                                                                         |
-| id                       | <code>let</code> | No       | <code>string</code>                                                                                     | <code>"ccs-" + Math.random().toString(36)</code>                                           | Set an id for the list box component                                                                                                                                  |
-| name                     | <code>let</code> | No       | <code>string</code>                                                                                     | <code>undefined</code>                                                                     | Specify a name attribute for the select                                                                                                                               |
+| Prop name                | Required | Kind             | Reactive | Type                                                                                                    | Default value                                                                              | Description                                                                                                                                                           |
+| :----------------------- | :------- | :--------------- | :------- | ------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| highlightedId            | No       | <code>let</code> | Yes      | <code>null &#124; MultiSelectItemId</code>                                                              | <code>null</code>                                                                          | Id of the highlighted ListBoxMenuItem                                                                                                                                 |
+| selectionRef             | No       | <code>let</code> | Yes      | <code>null &#124; HTMLDivElement</code>                                                                 | <code>null</code>                                                                          | Obtain a reference to the selection element                                                                                                                           |
+| fieldRef                 | No       | <code>let</code> | Yes      | <code>null &#124; HTMLDivElement</code>                                                                 | <code>null</code>                                                                          | Obtain a reference to the field box element                                                                                                                           |
+| multiSelectRef           | No       | <code>let</code> | Yes      | <code>null &#124; HTMLDivElement</code>                                                                 | <code>null</code>                                                                          | Obtain a reference to the outer div element                                                                                                                           |
+| inputRef                 | No       | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code>                                                               | <code>null</code>                                                                          | Obtain a reference to the input HTML element                                                                                                                          |
+| open                     | No       | <code>let</code> | Yes      | <code>boolean</code>                                                                                    | <code>false</code>                                                                         | Set to `true` to open the dropdown                                                                                                                                    |
+| value                    | No       | <code>let</code> | Yes      | <code>string</code>                                                                                     | <code>""</code>                                                                            | Specify the multiselect value                                                                                                                                         |
+| selectedIds              | No       | <code>let</code> | Yes      | <code>MultiSelectItemId[]</code>                                                                        | <code>[]</code>                                                                            | Set the selected ids                                                                                                                                                  |
+| items                    | No       | <code>let</code> | Yes      | <code>MultiSelectItem[]</code>                                                                          | <code>[]</code>                                                                            | Set the multiselect items                                                                                                                                             |
+| itemToString             | No       | <code>let</code> | No       | <code>(item: MultiSelectItem) => any</code>                                                             | <code>(item) => item.text &#124;&#124; item.id</code>                                      | Override the display of a multiselect item                                                                                                                            |
+| itemToInput              | No       | <code>let</code> | No       | <code>(item: MultiSelectItem) => { name?: string; labelText?: any; title?: string; }</code>             | <code>(item) => {}</code>                                                                  | Override the item name, title, labelText passed to the checkbox input                                                                                                 |
+| size                     | No       | <code>let</code> | No       | <code>"sm" &#124; "lg" &#124; "xl"</code>                                                               | <code>undefined</code>                                                                     | Set the size of the combobox                                                                                                                                          |
+| type                     | No       | <code>let</code> | No       | <code>"default" &#124; "inline"</code>                                                                  | <code>"default"</code>                                                                     | Specify the type of multiselect                                                                                                                                       |
+| direction                | No       | <code>let</code> | No       | <code>"bottom" &#124; "top"</code>                                                                      | <code>"bottom"</code>                                                                      | Specify the direction of the multiselect dropdown menu                                                                                                                |
+| selectionFeedback        | No       | <code>let</code> | No       | <code>"top" &#124; "fixed" &#124; "top-after-reopen"</code>                                             | <code>"top-after-reopen"</code>                                                            | Specify the selection feedback after selecting items                                                                                                                  |
+| disabled                 | No       | <code>let</code> | No       | <code>boolean</code>                                                                                    | <code>false</code>                                                                         | Set to `true` to disable the dropdown                                                                                                                                 |
+| filterable               | No       | <code>let</code> | No       | <code>boolean</code>                                                                                    | <code>false</code>                                                                         | Set to `true` to filter items                                                                                                                                         |
+| filterItem               | No       | <code>let</code> | No       | <code>(item: MultiSelectItem, value: string) => string</code>                                           | <code>(item, value) => item.text.toLowerCase().includes(value.trim().toLowerCase())</code> | Override the filtering logic<br />The default filtering is an exact string comparison                                                                                 |
+| light                    | No       | <code>let</code> | No       | <code>boolean</code>                                                                                    | <code>false</code>                                                                         | Set to `true` to enable the light variant                                                                                                                             |
+| locale                   | No       | <code>let</code> | No       | <code>string</code>                                                                                     | <code>"en"</code>                                                                          | Specify the locale                                                                                                                                                    |
+| placeholder              | No       | <code>let</code> | No       | <code>string</code>                                                                                     | <code>""</code>                                                                            | Specify the placeholder text                                                                                                                                          |
+| sortItem                 | No       | <code>let</code> | No       | <code>((a: MultiSelectItem, b: MultiSelectItem) => MultiSelectItem) &#124; (() => void)</code>          | <code>(a, b) => a.text.localeCompare(b.text, locale, { numeric: true })</code>             | Override the sorting logic<br />The default sorting compare the item text value                                                                                       |
+| translateWithId          | No       | <code>let</code> | No       | <code>(id: import("../ListBox/ListBoxMenuIcon.svelte").ListBoxMenuIconTranslationId) => string</code>   | <code>undefined</code>                                                                     | Override the chevron icon label based on the open state.<br />Defaults to "Open menu" when closed and "Close menu" when open                                          |
+| translateWithIdSelection | No       | <code>let</code> | No       | <code>(id: import("../ListBox/ListBoxSelection.svelte").ListBoxSelectionTranslationId) => string</code> | <code>undefined</code>                                                                     | Override the label of the clear button when the input has a selection.<br />Defaults to "Clear selected item" and "Clear all items" if more than one item is selected |
+| titleText                | No       | <code>let</code> | No       | <code>string</code>                                                                                     | <code>""</code>                                                                            | Specify the title text                                                                                                                                                |
+| useTitleInItem           | No       | <code>let</code> | No       | <code>boolean</code>                                                                                    | <code>false</code>                                                                         | Set to `true` to pass the item to `itemToString` in the checkbox                                                                                                      |
+| invalid                  | No       | <code>let</code> | No       | <code>boolean</code>                                                                                    | <code>false</code>                                                                         | Set to `true` to indicate an invalid state                                                                                                                            |
+| invalidText              | No       | <code>let</code> | No       | <code>string</code>                                                                                     | <code>""</code>                                                                            | Specify the invalid state text                                                                                                                                        |
+| warn                     | No       | <code>let</code> | No       | <code>boolean</code>                                                                                    | <code>false</code>                                                                         | Set to `true` to indicate an warning state                                                                                                                            |
+| warnText                 | No       | <code>let</code> | No       | <code>string</code>                                                                                     | <code>""</code>                                                                            | Specify the warning state text                                                                                                                                        |
+| helperText               | No       | <code>let</code> | No       | <code>string</code>                                                                                     | <code>""</code>                                                                            | Specify the helper text                                                                                                                                               |
+| label                    | No       | <code>let</code> | No       | <code>string</code>                                                                                     | <code>""</code>                                                                            | Specify the list box label                                                                                                                                            |
+| hideLabel                | No       | <code>let</code> | No       | <code>boolean</code>                                                                                    | <code>false</code>                                                                         | Set to `true` to visually hide the label text                                                                                                                         |
+| id                       | No       | <code>let</code> | No       | <code>string</code>                                                                                     | <code>"ccs-" + Math.random().toString(36)</code>                                           | Set an id for the list box component                                                                                                                                  |
+| name                     | No       | <code>let</code> | No       | <code>string</code>                                                                                     | <code>undefined</code>                                                                     | Specify a name attribute for the select                                                                                                                               |
 
 ### Slots
 
@@ -2413,12 +2413,12 @@ None.
 
 ### Props
 
-| Prop name        | Kind             | Reactive | Type                                                 | Default value             | Description                         |
-| :--------------- | :--------------- | :------- | :--------------------------------------------------- | ------------------------- | ----------------------------------- |
-| notificationType | <code>let</code> | No       | <code>"toast" &#124; "inline"</code>                 | <code>"toast"</code>      | Set the type of notification        |
-| icon             | <code>let</code> | No       | <code>typeof import("svelte").SvelteComponent</code> | <code>undefined</code>    | Specify the icon to render          |
-| title            | <code>let</code> | No       | <code>string</code>                                  | <code>undefined</code>    | Specify the title of the icon       |
-| iconDescription  | <code>let</code> | No       | <code>string</code>                                  | <code>"Close icon"</code> | Specify the ARIA label for the icon |
+| Prop name        | Required | Kind             | Reactive | Type                                                 | Default value             | Description                         |
+| :--------------- | :------- | :--------------- | :------- | ---------------------------------------------------- | ------------------------- | ----------------------------------- |
+| notificationType | No       | <code>let</code> | No       | <code>"toast" &#124; "inline"</code>                 | <code>"toast"</code>      | Set the type of notification        |
+| icon             | No       | <code>let</code> | No       | <code>typeof import("svelte").SvelteComponent</code> | <code>undefined</code>    | Specify the icon to render          |
+| title            | No       | <code>let</code> | No       | <code>string</code>                                  | <code>undefined</code>    | Specify the title of the icon       |
+| iconDescription  | No       | <code>let</code> | No       | <code>string</code>                                  | <code>"Close icon"</code> | Specify the ARIA label for the icon |
 
 ### Slots
 
@@ -2437,11 +2437,11 @@ None.
 
 ### Props
 
-| Prop name        | Kind             | Reactive | Type                                                                                                           | Default value                      | Description                           |
-| :--------------- | :--------------- | :------- | :------------------------------------------------------------------------------------------------------------- | ---------------------------------- | ------------------------------------- |
-| kind             | <code>let</code> | No       | <code>"error" &#124; "info" &#124; "info-square" &#124; "success" &#124; "warning" &#124; "warning-alt"</code> | <code>"error"</code>               | Specify the kind of notification icon |
-| notificationType | <code>let</code> | No       | <code>"toast" &#124; "inline"</code>                                                                           | <code>"toast"</code>               | Set the type of notification          |
-| iconDescription  | <code>let</code> | No       | <code>string</code>                                                                                            | <code>"Closes notification"</code> | Specify the ARIA label for the icon   |
+| Prop name        | Required | Kind             | Reactive | Type                                                                                                           | Default value                      | Description                           |
+| :--------------- | :------- | :--------------- | :------- | -------------------------------------------------------------------------------------------------------------- | ---------------------------------- | ------------------------------------- |
+| kind             | No       | <code>let</code> | No       | <code>"error" &#124; "info" &#124; "info-square" &#124; "success" &#124; "warning" &#124; "warning-alt"</code> | <code>"error"</code>               | Specify the kind of notification icon |
+| notificationType | No       | <code>let</code> | No       | <code>"toast" &#124; "inline"</code>                                                                           | <code>"toast"</code>               | Set the type of notification          |
+| iconDescription  | No       | <code>let</code> | No       | <code>string</code>                                                                                            | <code>"Closes notification"</code> | Specify the ARIA label for the icon   |
 
 ### Slots
 
@@ -2461,31 +2461,31 @@ export type NumberInputTranslationId = "increment" | "decrement";
 
 ### Props
 
-| Prop name       | Kind               | Reactive | Type                                                            | Default value                                                    | Description                                                   |
-| :-------------- | :----------------- | :------- | :-------------------------------------------------------------- | ---------------------------------------------------------------- | ------------------------------------------------------------- |
-| ref             | <code>let</code>   | Yes      | <code>null &#124; HTMLInputElement</code>                       | <code>null</code>                                                | Obtain a reference to the input HTML element                  |
-| value           | <code>let</code>   | Yes      | <code>null &#124; number</code>                                 | <code>null</code>                                                | Specify the input value.<br />Use `null` to denote "no value" |
-| size            | <code>let</code>   | No       | <code>"sm" &#124; "xl"</code>                                   | <code>undefined</code>                                           | Set the size of the input                                     |
-| step            | <code>let</code>   | No       | <code>number</code>                                             | <code>1</code>                                                   | Specify the step increment                                    |
-| max             | <code>let</code>   | No       | <code>number</code>                                             | <code>undefined</code>                                           | Specify the maximum value                                     |
-| min             | <code>let</code>   | No       | <code>number</code>                                             | <code>undefined</code>                                           | Specify the minimum value                                     |
-| light           | <code>let</code>   | No       | <code>boolean</code>                                            | <code>false</code>                                               | Set to `true` to enable the light variant                     |
-| readonly        | <code>let</code>   | No       | <code>boolean</code>                                            | <code>false</code>                                               | Set to `true` for the input to be read-only                   |
-| allowEmpty      | <code>let</code>   | No       | <code>boolean</code>                                            | <code>false</code>                                               | Set to `true` to allow for an empty value                     |
-| disabled        | <code>let</code>   | No       | <code>boolean</code>                                            | <code>false</code>                                               | Set to `true` to disable the input                            |
-| hideSteppers    | <code>let</code>   | No       | <code>boolean</code>                                            | <code>false</code>                                               | Set to `true` to hide the input stepper buttons               |
-| iconDescription | <code>let</code>   | No       | <code>string</code>                                             | <code>""</code>                                                  | Specify the ARIA label for the increment icons                |
-| invalid         | <code>let</code>   | No       | <code>boolean</code>                                            | <code>false</code>                                               | Set to `true` to indicate an invalid state                    |
-| invalidText     | <code>let</code>   | No       | <code>string</code>                                             | <code>""</code>                                                  | Specify the invalid state text                                |
-| warn            | <code>let</code>   | No       | <code>boolean</code>                                            | <code>false</code>                                               | Set to `true` to indicate an warning state                    |
-| warnText        | <code>let</code>   | No       | <code>string</code>                                             | <code>""</code>                                                  | Specify the warning state text                                |
-| helperText      | <code>let</code>   | No       | <code>string</code>                                             | <code>""</code>                                                  | Specify the helper text                                       |
-| label           | <code>let</code>   | No       | <code>string</code>                                             | <code>""</code>                                                  | Specify the label text                                        |
-| hideLabel       | <code>let</code>   | No       | <code>boolean</code>                                            | <code>false</code>                                               | Set to `true` to visually hide the label text                 |
-| translateWithId | <code>let</code>   | No       | <code>(id: NumberInputTranslationId) => string</code>           | <code>(id) => defaultTranslations[id]</code>                     | Override the default translation ids                          |
-| translationIds  | <code>const</code> | No       | <code>{ increment: "increment"; decrement: "decrement" }</code> | <code>{ increment: "increment", decrement: "decrement", }</code> | Default translation ids                                       |
-| id              | <code>let</code>   | No       | <code>string</code>                                             | <code>"ccs-" + Math.random().toString(36)</code>                 | Set an id for the input element                               |
-| name            | <code>let</code>   | No       | <code>string</code>                                             | <code>undefined</code>                                           | Specify a name attribute for the input                        |
+| Prop name       | Required | Kind               | Reactive | Type                                                            | Default value                                                    | Description                                                   |
+| :-------------- | :------- | :----------------- | :------- | --------------------------------------------------------------- | ---------------------------------------------------------------- | ------------------------------------------------------------- |
+| ref             | No       | <code>let</code>   | Yes      | <code>null &#124; HTMLInputElement</code>                       | <code>null</code>                                                | Obtain a reference to the input HTML element                  |
+| value           | No       | <code>let</code>   | Yes      | <code>null &#124; number</code>                                 | <code>null</code>                                                | Specify the input value.<br />Use `null` to denote "no value" |
+| size            | No       | <code>let</code>   | No       | <code>"sm" &#124; "xl"</code>                                   | <code>undefined</code>                                           | Set the size of the input                                     |
+| step            | No       | <code>let</code>   | No       | <code>number</code>                                             | <code>1</code>                                                   | Specify the step increment                                    |
+| max             | No       | <code>let</code>   | No       | <code>number</code>                                             | <code>undefined</code>                                           | Specify the maximum value                                     |
+| min             | No       | <code>let</code>   | No       | <code>number</code>                                             | <code>undefined</code>                                           | Specify the minimum value                                     |
+| light           | No       | <code>let</code>   | No       | <code>boolean</code>                                            | <code>false</code>                                               | Set to `true` to enable the light variant                     |
+| readonly        | No       | <code>let</code>   | No       | <code>boolean</code>                                            | <code>false</code>                                               | Set to `true` for the input to be read-only                   |
+| allowEmpty      | No       | <code>let</code>   | No       | <code>boolean</code>                                            | <code>false</code>                                               | Set to `true` to allow for an empty value                     |
+| disabled        | No       | <code>let</code>   | No       | <code>boolean</code>                                            | <code>false</code>                                               | Set to `true` to disable the input                            |
+| hideSteppers    | No       | <code>let</code>   | No       | <code>boolean</code>                                            | <code>false</code>                                               | Set to `true` to hide the input stepper buttons               |
+| iconDescription | No       | <code>let</code>   | No       | <code>string</code>                                             | <code>""</code>                                                  | Specify the ARIA label for the increment icons                |
+| invalid         | No       | <code>let</code>   | No       | <code>boolean</code>                                            | <code>false</code>                                               | Set to `true` to indicate an invalid state                    |
+| invalidText     | No       | <code>let</code>   | No       | <code>string</code>                                             | <code>""</code>                                                  | Specify the invalid state text                                |
+| warn            | No       | <code>let</code>   | No       | <code>boolean</code>                                            | <code>false</code>                                               | Set to `true` to indicate an warning state                    |
+| warnText        | No       | <code>let</code>   | No       | <code>string</code>                                             | <code>""</code>                                                  | Specify the warning state text                                |
+| helperText      | No       | <code>let</code>   | No       | <code>string</code>                                             | <code>""</code>                                                  | Specify the helper text                                       |
+| label           | No       | <code>let</code>   | No       | <code>string</code>                                             | <code>""</code>                                                  | Specify the label text                                        |
+| hideLabel       | No       | <code>let</code>   | No       | <code>boolean</code>                                            | <code>false</code>                                               | Set to `true` to visually hide the label text                 |
+| translateWithId | No       | <code>let</code>   | No       | <code>(id: NumberInputTranslationId) => string</code>           | <code>(id) => defaultTranslations[id]</code>                     | Override the default translation ids                          |
+| translationIds  | No       | <code>const</code> | No       | <code>{ increment: "increment"; decrement: "decrement" }</code> | <code>{ increment: "increment", decrement: "decrement", }</code> | Default translation ids                                       |
+| id              | No       | <code>let</code>   | No       | <code>string</code>                                             | <code>"ccs-" + Math.random().toString(36)</code>                 | Set an id for the input element                               |
+| name            | No       | <code>let</code>   | No       | <code>string</code>                                             | <code>undefined</code>                                           | Specify a name attribute for the input                        |
 
 ### Slots
 
@@ -2510,9 +2510,9 @@ export type NumberInputTranslationId = "increment" | "decrement";
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                 | Default value      | Description                          |
-| :-------- | :--------------- | :------- | :------------------- | ------------------ | ------------------------------------ |
-| hideLabel | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to hide the label text |
+| Prop name | Required | Kind             | Reactive | Type                 | Default value      | Description                          |
+| :-------- | :------- | :--------------- | :------- | -------------------- | ------------------ | ------------------------------------ |
+| hideLabel | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to hide the label text |
 
 ### Slots
 
@@ -2531,11 +2531,11 @@ None.
 
 ### Props
 
-| Prop name  | Kind             | Reactive | Type                 | Default value      | Description                                          |
-| :--------- | :--------------- | :------- | :------------------- | ------------------ | ---------------------------------------------------- |
-| nested     | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use the nested variant              |
-| native     | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use native list styles              |
-| expressive | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use Carbon's expressive typesetting |
+| Prop name  | Required | Kind             | Reactive | Type                 | Default value      | Description                                          |
+| :--------- | :------- | :--------------- | :------- | -------------------- | ------------------ | ---------------------------------------------------- |
+| nested     | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use the nested variant              |
+| native     | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use native list styles              |
+| expressive | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use Carbon's expressive typesetting |
 
 ### Slots
 
@@ -2577,20 +2577,20 @@ None.
 
 ### Props
 
-| Prop name        | Kind             | Reactive | Type                                                 | Default value                                    | Description                                                                   |
-| :--------------- | :--------------- | :------- | :--------------------------------------------------- | ------------------------------------------------ | ----------------------------------------------------------------------------- |
-| menuRef          | <code>let</code> | Yes      | <code>null &#124; HTMLUListElement</code>            | <code>null</code>                                | Obtain a reference to the overflow menu element                               |
-| buttonRef        | <code>let</code> | Yes      | <code>null &#124; HTMLButtonElement</code>           | <code>null</code>                                | Obtain a reference to the trigger button element                              |
-| icon             | <code>let</code> | Yes      | <code>typeof import("svelte").SvelteComponent</code> | <code>undefined</code>                           | Specify the icon to render.<br />Defaults to `&lt;OverflowMenuVertical /&gt;` |
-| open             | <code>let</code> | Yes      | <code>boolean</code>                                 | <code>false</code>                               | Set to `true` to open the menu                                                |
-| size             | <code>let</code> | No       | <code>"sm" &#124; "xl"</code>                        | <code>undefined</code>                           | Specify the size of the overflow menu                                         |
-| direction        | <code>let</code> | No       | <code>"top" &#124; "bottom"</code>                   | <code>"bottom"</code>                            | Specify the direction of the overflow menu relative to the button             |
-| light            | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>                               | Set to `true` to enable the light variant                                     |
-| flipped          | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>                               | Set to `true` to flip the menu relative to the button                         |
-| menuOptionsClass | <code>let</code> | No       | <code>string</code>                                  | <code>undefined</code>                           | Specify the menu options class                                                |
-| iconClass        | <code>let</code> | No       | <code>string</code>                                  | <code>undefined</code>                           | Specify the icon class                                                        |
-| iconDescription  | <code>let</code> | No       | <code>string</code>                                  | <code>"Open and close list of options"</code>    | Specify the ARIA label for the icon                                           |
-| id               | <code>let</code> | No       | <code>string</code>                                  | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the button element                                              |
+| Prop name        | Required | Kind             | Reactive | Type                                                 | Default value                                    | Description                                                                   |
+| :--------------- | :------- | :--------------- | :------- | ---------------------------------------------------- | ------------------------------------------------ | ----------------------------------------------------------------------------- |
+| menuRef          | No       | <code>let</code> | Yes      | <code>null &#124; HTMLUListElement</code>            | <code>null</code>                                | Obtain a reference to the overflow menu element                               |
+| buttonRef        | No       | <code>let</code> | Yes      | <code>null &#124; HTMLButtonElement</code>           | <code>null</code>                                | Obtain a reference to the trigger button element                              |
+| icon             | No       | <code>let</code> | Yes      | <code>typeof import("svelte").SvelteComponent</code> | <code>undefined</code>                           | Specify the icon to render.<br />Defaults to `&lt;OverflowMenuVertical /&gt;` |
+| open             | No       | <code>let</code> | Yes      | <code>boolean</code>                                 | <code>false</code>                               | Set to `true` to open the menu                                                |
+| size             | No       | <code>let</code> | No       | <code>"sm" &#124; "xl"</code>                        | <code>undefined</code>                           | Specify the size of the overflow menu                                         |
+| direction        | No       | <code>let</code> | No       | <code>"top" &#124; "bottom"</code>                   | <code>"bottom"</code>                            | Specify the direction of the overflow menu relative to the button             |
+| light            | No       | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>                               | Set to `true` to enable the light variant                                     |
+| flipped          | No       | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>                               | Set to `true` to flip the menu relative to the button                         |
+| menuOptionsClass | No       | <code>let</code> | No       | <code>string</code>                                  | <code>undefined</code>                           | Specify the menu options class                                                |
+| iconClass        | No       | <code>let</code> | No       | <code>string</code>                                  | <code>undefined</code>                           | Specify the icon class                                                        |
+| iconDescription  | No       | <code>let</code> | No       | <code>string</code>                                  | <code>"Open and close list of options"</code>    | Specify the ARIA label for the icon                                           |
+| id               | No       | <code>let</code> | No       | <code>string</code>                                  | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the button element                                              |
 
 ### Slots
 
@@ -2614,17 +2614,17 @@ None.
 
 ### Props
 
-| Prop name    | Kind             | Reactive | Type                                                                | Default value                                    | Description                                                                         |
-| :----------- | :--------------- | :------- | :------------------------------------------------------------------ | ------------------------------------------------ | ----------------------------------------------------------------------------------- |
-| ref          | <code>let</code> | Yes      | <code>null &#124; HTMLAnchorElement &#124; HTMLButtonElement</code> | <code>null</code>                                | Obtain a reference to the HTML element                                              |
-| primaryFocus | <code>let</code> | Yes      | <code>boolean</code>                                                | <code>false</code>                               | Set to `true` if the item should be focused when opening the menu                   |
-| text         | <code>let</code> | No       | <code>string</code>                                                 | <code>"Provide text"</code>                      | Specify the item text<br />Alternatively, use the default slot for a custom element |
-| href         | <code>let</code> | No       | <code>string</code>                                                 | <code>""</code>                                  | Specify the `href` attribute if the item is a link                                  |
-| disabled     | <code>let</code> | No       | <code>boolean</code>                                                | <code>false</code>                               | Set to `true` to disable the item                                                   |
-| hasDivider   | <code>let</code> | No       | <code>boolean</code>                                                | <code>false</code>                               | Set to `true` to include a divider                                                  |
-| danger       | <code>let</code> | No       | <code>boolean</code>                                                | <code>false</code>                               | Set to `true` to use the danger variant                                             |
-| requireTitle | <code>let</code> | No       | <code>boolean</code>                                                | <code>true</code>                                | Set to `false` to omit the button `title` attribute                                 |
-| id           | <code>let</code> | No       | <code>string</code>                                                 | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the top-level element                                                 |
+| Prop name    | Required | Kind             | Reactive | Type                                                                | Default value                                    | Description                                                                         |
+| :----------- | :------- | :--------------- | :------- | ------------------------------------------------------------------- | ------------------------------------------------ | ----------------------------------------------------------------------------------- |
+| ref          | No       | <code>let</code> | Yes      | <code>null &#124; HTMLAnchorElement &#124; HTMLButtonElement</code> | <code>null</code>                                | Obtain a reference to the HTML element                                              |
+| primaryFocus | No       | <code>let</code> | Yes      | <code>boolean</code>                                                | <code>false</code>                               | Set to `true` if the item should be focused when opening the menu                   |
+| text         | No       | <code>let</code> | No       | <code>string</code>                                                 | <code>"Provide text"</code>                      | Specify the item text<br />Alternatively, use the default slot for a custom element |
+| href         | No       | <code>let</code> | No       | <code>string</code>                                                 | <code>""</code>                                  | Specify the `href` attribute if the item is a link                                  |
+| disabled     | No       | <code>let</code> | No       | <code>boolean</code>                                                | <code>false</code>                               | Set to `true` to disable the item                                                   |
+| hasDivider   | No       | <code>let</code> | No       | <code>boolean</code>                                                | <code>false</code>                               | Set to `true` to include a divider                                                  |
+| danger       | No       | <code>let</code> | No       | <code>boolean</code>                                                | <code>false</code>                               | Set to `true` to use the danger variant                                             |
+| requireTitle | No       | <code>let</code> | No       | <code>boolean</code>                                                | <code>true</code>                                | Set to `false` to omit the button `title` attribute                                 |
+| id           | No       | <code>let</code> | No       | <code>string</code>                                                 | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the top-level element                                                 |
 
 ### Slots
 
@@ -2643,24 +2643,24 @@ None.
 
 ### Props
 
-| Prop name             | Kind             | Reactive | Type                                                             | Default value                                                                  | Description                                      |
-| :-------------------- | :--------------- | :------- | :--------------------------------------------------------------- | ------------------------------------------------------------------------------ | ------------------------------------------------ |
-| pageSize              | <code>let</code> | Yes      | <code>number</code>                                              | <code>10</code>                                                                | Specify the number of items to display in a page |
-| page                  | <code>let</code> | Yes      | <code>number</code>                                              | <code>1</code>                                                                 | Specify the current page index                   |
-| totalItems            | <code>let</code> | No       | <code>number</code>                                              | <code>0</code>                                                                 | Specify the total number of items                |
-| disabled              | <code>let</code> | No       | <code>boolean</code>                                             | <code>false</code>                                                             | Set to `true` to disable the pagination          |
-| forwardText           | <code>let</code> | No       | <code>string</code>                                              | <code>"Next page"</code>                                                       | Specify the forward button text                  |
-| backwardText          | <code>let</code> | No       | <code>string</code>                                              | <code>"Previous page"</code>                                                   | Specify the backward button text                 |
-| itemsPerPageText      | <code>let</code> | No       | <code>string</code>                                              | <code>"Items per page:"</code>                                                 | Specify the items per page text                  |
-| itemText              | <code>let</code> | No       | <code>(min: number, max: number) => string</code>                | <code>(min, max) => \`${min}–${max} items\`</code>                             | Override the item text                           |
-| itemRangeText         | <code>let</code> | No       | <code>(min: number, max: number, total: number) => string</code> | <code>(min, max, total) => \`${min}–${max} of ${total} items\`</code>          | Override the item range text                     |
-| pageInputDisabled     | <code>let</code> | No       | <code>boolean</code>                                             | <code>false</code>                                                             | Set to `true` to disable the page input          |
-| pageSizeInputDisabled | <code>let</code> | No       | <code>boolean</code>                                             | <code>false</code>                                                             | Set to `true` to disable the page size input     |
-| pageSizes             | <code>let</code> | No       | <code>number[]</code>                                            | <code>[10]</code>                                                              | Specify the available page sizes                 |
-| pagesUnknown          | <code>let</code> | No       | <code>boolean</code>                                             | <code>false</code>                                                             | Set to `true` if the number of pages is unknown  |
-| pageText              | <code>let</code> | No       | <code>(page: number) => string</code>                            | <code>(page) => \`page ${page}\`</code>                                        | Override the page text                           |
-| pageRangeText         | <code>let</code> | No       | <code>(current: number, total: number) => string</code>          | <code>(current, total) => \`of ${total} page${total === 1 ? "" : "s"}\`</code> | Override the page range text                     |
-| id                    | <code>let</code> | No       | <code>string</code>                                              | <code>"ccs-" + Math.random().toString(36)</code>                               | Set an id for the top-level element              |
+| Prop name             | Required | Kind             | Reactive | Type                                                             | Default value                                                                  | Description                                      |
+| :-------------------- | :------- | :--------------- | :------- | ---------------------------------------------------------------- | ------------------------------------------------------------------------------ | ------------------------------------------------ |
+| pageSize              | No       | <code>let</code> | Yes      | <code>number</code>                                              | <code>10</code>                                                                | Specify the number of items to display in a page |
+| page                  | No       | <code>let</code> | Yes      | <code>number</code>                                              | <code>1</code>                                                                 | Specify the current page index                   |
+| totalItems            | No       | <code>let</code> | No       | <code>number</code>                                              | <code>0</code>                                                                 | Specify the total number of items                |
+| disabled              | No       | <code>let</code> | No       | <code>boolean</code>                                             | <code>false</code>                                                             | Set to `true` to disable the pagination          |
+| forwardText           | No       | <code>let</code> | No       | <code>string</code>                                              | <code>"Next page"</code>                                                       | Specify the forward button text                  |
+| backwardText          | No       | <code>let</code> | No       | <code>string</code>                                              | <code>"Previous page"</code>                                                   | Specify the backward button text                 |
+| itemsPerPageText      | No       | <code>let</code> | No       | <code>string</code>                                              | <code>"Items per page:"</code>                                                 | Specify the items per page text                  |
+| itemText              | No       | <code>let</code> | No       | <code>(min: number, max: number) => string</code>                | <code>(min, max) => \`${min}–${max} items\`</code>                             | Override the item text                           |
+| itemRangeText         | No       | <code>let</code> | No       | <code>(min: number, max: number, total: number) => string</code> | <code>(min, max, total) => \`${min}–${max} of ${total} items\`</code>          | Override the item range text                     |
+| pageInputDisabled     | No       | <code>let</code> | No       | <code>boolean</code>                                             | <code>false</code>                                                             | Set to `true` to disable the page input          |
+| pageSizeInputDisabled | No       | <code>let</code> | No       | <code>boolean</code>                                             | <code>false</code>                                                             | Set to `true` to disable the page size input     |
+| pageSizes             | No       | <code>let</code> | No       | <code>number[]</code>                                            | <code>[10]</code>                                                              | Specify the available page sizes                 |
+| pagesUnknown          | No       | <code>let</code> | No       | <code>boolean</code>                                             | <code>false</code>                                                             | Set to `true` if the number of pages is unknown  |
+| pageText              | No       | <code>let</code> | No       | <code>(page: number) => string</code>                            | <code>(page) => \`page ${page}\`</code>                                        | Override the page text                           |
+| pageRangeText         | No       | <code>let</code> | No       | <code>(current: number, total: number) => string</code>          | <code>(current, total) => \`of ${total} page${total === 1 ? "" : "s"}\`</code> | Override the page range text                     |
+| id                    | No       | <code>let</code> | No       | <code>string</code>                                              | <code>"ccs-" + Math.random().toString(36)</code>                               | Set an id for the top-level element              |
 
 ### Slots
 
@@ -2678,14 +2678,14 @@ None.
 
 ### Props
 
-| Prop name    | Kind             | Reactive | Type                 | Default value                | Description                               |
-| :----------- | :--------------- | :------- | :------------------- | ---------------------------- | ----------------------------------------- |
-| page         | <code>let</code> | Yes      | <code>number</code>  | <code>0</code>               | Specify the current page index            |
-| total        | <code>let</code> | No       | <code>number</code>  | <code>10</code>              | Specify the total number of pages         |
-| shown        | <code>let</code> | No       | <code>number</code>  | <code>10</code>              | Specify the total number of pages to show |
-| loop         | <code>let</code> | No       | <code>boolean</code> | <code>false</code>           | Set to `true` to loop the navigation      |
-| forwardText  | <code>let</code> | No       | <code>string</code>  | <code>"Next page"</code>     | Specify the forward button text           |
-| backwardText | <code>let</code> | No       | <code>string</code>  | <code>"Previous page"</code> | Specify the backward button text          |
+| Prop name    | Required | Kind             | Reactive | Type                 | Default value                | Description                               |
+| :----------- | :------- | :--------------- | :------- | -------------------- | ---------------------------- | ----------------------------------------- |
+| page         | No       | <code>let</code> | Yes      | <code>number</code>  | <code>0</code>               | Specify the current page index            |
+| total        | No       | <code>let</code> | No       | <code>number</code>  | <code>10</code>              | Specify the total number of pages         |
+| shown        | No       | <code>let</code> | No       | <code>number</code>  | <code>10</code>              | Specify the total number of pages to show |
+| loop         | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code>           | Set to `true` to loop the navigation      |
+| forwardText  | No       | <code>let</code> | No       | <code>string</code>  | <code>"Next page"</code>     | Specify the forward button text           |
+| backwardText | No       | <code>let</code> | No       | <code>string</code>  | <code>"Previous page"</code> | Specify the backward button text          |
 
 ### Slots
 
@@ -2722,29 +2722,29 @@ None.
 
 ### Props
 
-| Prop name         | Kind             | Reactive | Type                                                            | Default value                                    | Description                                           |
-| :---------------- | :--------------- | :------- | :-------------------------------------------------------------- | ------------------------------------------------ | ----------------------------------------------------- |
-| ref               | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code>                       | <code>null</code>                                | Obtain a reference to the input HTML element          |
-| type              | <code>let</code> | Yes      | <code>"text" &#124; "password"</code>                           | <code>"password"</code>                          | Set to `"text"` to toggle the password visibility     |
-| value             | <code>let</code> | Yes      | <code>number &#124; string</code>                               | <code>""</code>                                  | Specify the input value                               |
-| size              | <code>let</code> | No       | <code>"sm" &#124; "xl"</code>                                   | <code>undefined</code>                           | Set the size of the input                             |
-| placeholder       | <code>let</code> | No       | <code>string</code>                                             | <code>""</code>                                  | Specify the placeholder text                          |
-| hidePasswordLabel | <code>let</code> | No       | <code>string</code>                                             | <code>"Hide password"</code>                     | Specify the hide password label text                  |
-| showPasswordLabel | <code>let</code> | No       | <code>string</code>                                             | <code>"Show password"</code>                     | Specify the show password label text                  |
-| tooltipAlignment  | <code>let</code> | No       | <code>"start" &#124; "center" &#124; "end"</code>               | <code>"center"</code>                            | Set the alignment of the tooltip relative to the icon |
-| tooltipPosition   | <code>let</code> | No       | <code>"top" &#124; "right" &#124; "bottom" &#124; "left"</code> | <code>"bottom"</code>                            | Set the position of the tooltip relative to the icon  |
-| light             | <code>let</code> | No       | <code>boolean</code>                                            | <code>false</code>                               | Set to `true` to enable the light variant             |
-| disabled          | <code>let</code> | No       | <code>boolean</code>                                            | <code>false</code>                               | Set to `true` to disable the input                    |
-| helperText        | <code>let</code> | No       | <code>string</code>                                             | <code>""</code>                                  | Specify the helper text                               |
-| labelText         | <code>let</code> | No       | <code>string</code>                                             | <code>""</code>                                  | Specify the label text                                |
-| hideLabel         | <code>let</code> | No       | <code>boolean</code>                                            | <code>false</code>                               | Set to `true` to visually hide the label text         |
-| invalid           | <code>let</code> | No       | <code>boolean</code>                                            | <code>false</code>                               | Set to `true` to indicate an invalid state            |
-| invalidText       | <code>let</code> | No       | <code>string</code>                                             | <code>""</code>                                  | Specify the text for the invalid state                |
-| warn              | <code>let</code> | No       | <code>boolean</code>                                            | <code>false</code>                               | Set to `true` to indicate an warning state            |
-| warnText          | <code>let</code> | No       | <code>string</code>                                             | <code>""</code>                                  | Specify the warning state text                        |
-| inline            | <code>let</code> | No       | <code>boolean</code>                                            | <code>false</code>                               | Set to `true` to use inline version                   |
-| id                | <code>let</code> | No       | <code>string</code>                                             | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the input element                       |
-| name              | <code>let</code> | No       | <code>string</code>                                             | <code>undefined</code>                           | Specify a name attribute for the input                |
+| Prop name         | Required | Kind             | Reactive | Type                                                            | Default value                                    | Description                                           |
+| :---------------- | :------- | :--------------- | :------- | --------------------------------------------------------------- | ------------------------------------------------ | ----------------------------------------------------- |
+| ref               | No       | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code>                       | <code>null</code>                                | Obtain a reference to the input HTML element          |
+| type              | No       | <code>let</code> | Yes      | <code>"text" &#124; "password"</code>                           | <code>"password"</code>                          | Set to `"text"` to toggle the password visibility     |
+| value             | No       | <code>let</code> | Yes      | <code>number &#124; string</code>                               | <code>""</code>                                  | Specify the input value                               |
+| size              | No       | <code>let</code> | No       | <code>"sm" &#124; "xl"</code>                                   | <code>undefined</code>                           | Set the size of the input                             |
+| placeholder       | No       | <code>let</code> | No       | <code>string</code>                                             | <code>""</code>                                  | Specify the placeholder text                          |
+| hidePasswordLabel | No       | <code>let</code> | No       | <code>string</code>                                             | <code>"Hide password"</code>                     | Specify the hide password label text                  |
+| showPasswordLabel | No       | <code>let</code> | No       | <code>string</code>                                             | <code>"Show password"</code>                     | Specify the show password label text                  |
+| tooltipAlignment  | No       | <code>let</code> | No       | <code>"start" &#124; "center" &#124; "end"</code>               | <code>"center"</code>                            | Set the alignment of the tooltip relative to the icon |
+| tooltipPosition   | No       | <code>let</code> | No       | <code>"top" &#124; "right" &#124; "bottom" &#124; "left"</code> | <code>"bottom"</code>                            | Set the position of the tooltip relative to the icon  |
+| light             | No       | <code>let</code> | No       | <code>boolean</code>                                            | <code>false</code>                               | Set to `true` to enable the light variant             |
+| disabled          | No       | <code>let</code> | No       | <code>boolean</code>                                            | <code>false</code>                               | Set to `true` to disable the input                    |
+| helperText        | No       | <code>let</code> | No       | <code>string</code>                                             | <code>""</code>                                  | Specify the helper text                               |
+| labelText         | No       | <code>let</code> | No       | <code>string</code>                                             | <code>""</code>                                  | Specify the label text                                |
+| hideLabel         | No       | <code>let</code> | No       | <code>boolean</code>                                            | <code>false</code>                               | Set to `true` to visually hide the label text         |
+| invalid           | No       | <code>let</code> | No       | <code>boolean</code>                                            | <code>false</code>                               | Set to `true` to indicate an invalid state            |
+| invalidText       | No       | <code>let</code> | No       | <code>string</code>                                             | <code>""</code>                                  | Specify the text for the invalid state                |
+| warn              | No       | <code>let</code> | No       | <code>boolean</code>                                            | <code>false</code>                               | Set to `true` to indicate an warning state            |
+| warnText          | No       | <code>let</code> | No       | <code>string</code>                                             | <code>""</code>                                  | Specify the warning state text                        |
+| inline            | No       | <code>let</code> | No       | <code>boolean</code>                                            | <code>false</code>                               | Set to `true` to use inline version                   |
+| id                | No       | <code>let</code> | No       | <code>string</code>                                             | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the input element                       |
+| name              | No       | <code>let</code> | No       | <code>string</code>                                             | <code>undefined</code>                           | Specify a name attribute for the input                |
 
 ### Slots
 
@@ -2771,15 +2771,15 @@ None.
 
 ### Props
 
-| Prop name           | Kind             | Reactive | Type                                                                                                                                                                                                                            | Default value      | Description                                            |
-| :------------------ | :--------------- | :------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------ | ------------------------------------------------------ |
-| open                | <code>let</code> | Yes      | <code>boolean</code>                                                                                                                                                                                                            | <code>false</code> | Set to `true` to display the popover                   |
-| closeOnOutsideClick | <code>let</code> | No       | <code>boolean</code>                                                                                                                                                                                                            | <code>false</code> | Set to `true` to close the popover on an outside click |
-| caret               | <code>let</code> | No       | <code>boolean</code>                                                                                                                                                                                                            | <code>false</code> | Set to `true` render a caret                           |
-| align               | <code>let</code> | No       | <code>"top" &#124; "top-left" &#124; "top-right" &#124; "bottom" &#124; "bottom-left" &#124; "bottom-right" &#124; "left" &#124; "left-bottom" &#124; "left-top" &#124; "right" &#124; "right-bottom" &#124; "right-top"</code> | <code>"top"</code> | Specify the alignment of the caret                     |
-| light               | <code>let</code> | No       | <code>boolean</code>                                                                                                                                                                                                            | <code>false</code> | Set to `true` to enable the light variant              |
-| highContrast        | <code>let</code> | No       | <code>boolean</code>                                                                                                                                                                                                            | <code>false</code> | Set to `true` to enable the high contrast variant      |
-| relative            | <code>let</code> | No       | <code>boolean</code>                                                                                                                                                                                                            | <code>false</code> | Set to `true` to use a relative position               |
+| Prop name           | Required | Kind             | Reactive | Type                                                                                                                                                                                                                            | Default value      | Description                                            |
+| :------------------ | :------- | :--------------- | :------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ | ------------------------------------------------------ |
+| open                | No       | <code>let</code> | Yes      | <code>boolean</code>                                                                                                                                                                                                            | <code>false</code> | Set to `true` to display the popover                   |
+| closeOnOutsideClick | No       | <code>let</code> | No       | <code>boolean</code>                                                                                                                                                                                                            | <code>false</code> | Set to `true` to close the popover on an outside click |
+| caret               | No       | <code>let</code> | No       | <code>boolean</code>                                                                                                                                                                                                            | <code>false</code> | Set to `true` render a caret                           |
+| align               | No       | <code>let</code> | No       | <code>"top" &#124; "top-left" &#124; "top-right" &#124; "bottom" &#124; "bottom-left" &#124; "bottom-right" &#124; "left" &#124; "left-bottom" &#124; "left-top" &#124; "right" &#124; "right-bottom" &#124; "right-top"</code> | <code>"top"</code> | Specify the alignment of the caret                     |
+| light               | No       | <code>let</code> | No       | <code>boolean</code>                                                                                                                                                                                                            | <code>false</code> | Set to `true` to enable the light variant              |
+| highContrast        | No       | <code>let</code> | No       | <code>boolean</code>                                                                                                                                                                                                            | <code>false</code> | Set to `true` to enable the high contrast variant      |
+| relative            | No       | <code>let</code> | No       | <code>boolean</code>                                                                                                                                                                                                            | <code>false</code> | Set to `true` to use a relative position               |
 
 ### Slots
 
@@ -2797,16 +2797,16 @@ None.
 
 ### Props
 
-| Prop name  | Kind             | Reactive | Type                                                     | Default value                                    | Description                                   |
-| :--------- | :--------------- | :------- | :------------------------------------------------------- | ------------------------------------------------ | --------------------------------------------- |
-| value      | <code>let</code> | No       | <code>number</code>                                      | <code>undefined</code>                           | Specify the current value                     |
-| max        | <code>let</code> | No       | <code>number</code>                                      | <code>100</code>                                 | Specify the maximum value                     |
-| kind       | <code>let</code> | No       | <code>"default" &#124; "inline" &#124; "indented"</code> | <code>"default"</code>                           | Specify the kind of progress bar              |
-| size       | <code>let</code> | No       | <code>"sm" &#124; "md"</code>                            | <code>"md"</code>                                | Specify the size                              |
-| labelText  | <code>let</code> | No       | <code>string</code>                                      | <code>""</code>                                  | Specify the label text                        |
-| hideLabel  | <code>let</code> | No       | <code>boolean</code>                                     | <code>false</code>                               | Set to `true` to visually hide the label text |
-| helperText | <code>let</code> | No       | <code>string</code>                                      | <code>""</code>                                  | Specify the helper text                       |
-| id         | <code>let</code> | No       | <code>string</code>                                      | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the progress bar element        |
+| Prop name  | Required | Kind             | Reactive | Type                                                     | Default value                                    | Description                                   |
+| :--------- | :------- | :--------------- | :------- | -------------------------------------------------------- | ------------------------------------------------ | --------------------------------------------- |
+| value      | No       | <code>let</code> | No       | <code>number</code>                                      | <code>undefined</code>                           | Specify the current value                     |
+| max        | No       | <code>let</code> | No       | <code>number</code>                                      | <code>100</code>                                 | Specify the maximum value                     |
+| kind       | No       | <code>let</code> | No       | <code>"default" &#124; "inline" &#124; "indented"</code> | <code>"default"</code>                           | Specify the kind of progress bar              |
+| size       | No       | <code>let</code> | No       | <code>"sm" &#124; "md"</code>                            | <code>"md"</code>                                | Specify the size                              |
+| labelText  | No       | <code>let</code> | No       | <code>string</code>                                      | <code>""</code>                                  | Specify the label text                        |
+| hideLabel  | No       | <code>let</code> | No       | <code>boolean</code>                                     | <code>false</code>                               | Set to `true` to visually hide the label text |
+| helperText | No       | <code>let</code> | No       | <code>string</code>                                      | <code>""</code>                                  | Specify the helper text                       |
+| id         | No       | <code>let</code> | No       | <code>string</code>                                      | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the progress bar element        |
 
 ### Slots
 
@@ -2822,12 +2822,12 @@ None.
 
 ### Props
 
-| Prop name            | Kind             | Reactive | Type                 | Default value      | Description                                                                                    |
-| :------------------- | :--------------- | :------- | :------------------- | ------------------ | ---------------------------------------------------------------------------------------------- |
-| currentIndex         | <code>let</code> | Yes      | <code>number</code>  | <code>0</code>     | Specify the current step index                                                                 |
-| vertical             | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use the vertical variant                                                      |
-| spaceEqually         | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to specify whether the progress steps should be split equally in size in the div |
-| preventChangeOnClick | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to prevent `currentIndex` from updating                                          |
+| Prop name            | Required | Kind             | Reactive | Type                 | Default value      | Description                                                                                    |
+| :------------------- | :------- | :--------------- | :------- | -------------------- | ------------------ | ---------------------------------------------------------------------------------------------- |
+| currentIndex         | No       | <code>let</code> | Yes      | <code>number</code>  | <code>0</code>     | Specify the current step index                                                                 |
+| vertical             | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use the vertical variant                                                      |
+| spaceEqually         | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to specify whether the progress steps should be split equally in size in the div |
+| preventChangeOnClick | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to prevent `currentIndex` from updating                                          |
 
 ### Slots
 
@@ -2849,10 +2849,10 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                 | Default value      | Description                               |
-| :-------- | :--------------- | :------- | :------------------- | ------------------ | ----------------------------------------- |
-| vertical  | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use the vertical variant |
-| count     | <code>let</code> | No       | <code>number</code>  | <code>4</code>     | Specify the number of steps to render     |
+| Prop name | Required | Kind             | Reactive | Type                 | Default value      | Description                               |
+| :-------- | :------- | :--------------- | :------- | -------------------- | ------------------ | ----------------------------------------- |
+| vertical  | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use the vertical variant |
+| count     | No       | <code>let</code> | No       | <code>number</code>  | <code>4</code>     | Specify the number of steps to render     |
 
 ### Slots
 
@@ -2871,16 +2871,16 @@ None.
 
 ### Props
 
-| Prop name      | Kind             | Reactive | Type                 | Default value                                    | Description                                |
-| :------------- | :--------------- | :------- | :------------------- | ------------------------------------------------ | ------------------------------------------ |
-| current        | <code>let</code> | Yes      | <code>boolean</code> | <code>false</code>                               | Set to `true` to use the current variant   |
-| complete       | <code>let</code> | Yes      | <code>boolean</code> | <code>false</code>                               | Set to `true` for the complete variant     |
-| disabled       | <code>let</code> | No       | <code>boolean</code> | <code>false</code>                               | Set to `true` to disable the progress step |
-| invalid        | <code>let</code> | No       | <code>boolean</code> | <code>false</code>                               | Set to `true` to indicate an invalid state |
-| description    | <code>let</code> | No       | <code>string</code>  | <code>""</code>                                  | Specify the step description               |
-| label          | <code>let</code> | No       | <code>string</code>  | <code>""</code>                                  | Specify the step label                     |
-| secondaryLabel | <code>let</code> | No       | <code>string</code>  | <code>""</code>                                  | Specify the step secondary label           |
-| id             | <code>let</code> | No       | <code>string</code>  | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the top-level element        |
+| Prop name      | Required | Kind             | Reactive | Type                 | Default value                                    | Description                                |
+| :------------- | :------- | :--------------- | :------- | -------------------- | ------------------------------------------------ | ------------------------------------------ |
+| current        | No       | <code>let</code> | Yes      | <code>boolean</code> | <code>false</code>                               | Set to `true` to use the current variant   |
+| complete       | No       | <code>let</code> | Yes      | <code>boolean</code> | <code>false</code>                               | Set to `true` for the complete variant     |
+| disabled       | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code>                               | Set to `true` to disable the progress step |
+| invalid        | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code>                               | Set to `true` to indicate an invalid state |
+| description    | No       | <code>let</code> | No       | <code>string</code>  | <code>""</code>                                  | Specify the step description               |
+| label          | No       | <code>let</code> | No       | <code>string</code>  | <code>""</code>                                  | Specify the step label                     |
+| secondaryLabel | No       | <code>let</code> | No       | <code>string</code>  | <code>""</code>                                  | Specify the step secondary label           |
+| id             | No       | <code>let</code> | No       | <code>string</code>  | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the top-level element        |
 
 ### Slots
 
@@ -2902,18 +2902,18 @@ None.
 
 ### Props
 
-| Prop name     | Kind             | Reactive | Type                                      | Default value                                    | Description                                         |
-| :------------ | :--------------- | :------- | :---------------------------------------- | ------------------------------------------------ | --------------------------------------------------- |
-| ref           | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code> | <code>null</code>                                | Obtain a reference to the input HTML element        |
-| checked       | <code>let</code> | Yes      | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to check the radio button             |
-| value         | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Specify the value of the radio button               |
-| disabled      | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to disable the radio button           |
-| required      | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to mark the field as required         |
-| labelPosition | <code>let</code> | No       | <code>"right" &#124; "left"</code>        | <code>"right"</code>                             | Specify the label position                          |
-| labelText     | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Specify the label text                              |
-| hideLabel     | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to visually hide the label text       |
-| id            | <code>let</code> | No       | <code>string</code>                       | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the input element                     |
-| name          | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Specify a name attribute for the radio button input |
+| Prop name     | Required | Kind             | Reactive | Type                                      | Default value                                    | Description                                         |
+| :------------ | :------- | :--------------- | :------- | ----------------------------------------- | ------------------------------------------------ | --------------------------------------------------- |
+| ref           | No       | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code> | <code>null</code>                                | Obtain a reference to the input HTML element        |
+| checked       | No       | <code>let</code> | Yes      | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to check the radio button             |
+| value         | No       | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Specify the value of the radio button               |
+| disabled      | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to disable the radio button           |
+| required      | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to mark the field as required         |
+| labelPosition | No       | <code>let</code> | No       | <code>"right" &#124; "left"</code>        | <code>"right"</code>                             | Specify the label position                          |
+| labelText     | No       | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Specify the label text                              |
+| hideLabel     | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to visually hide the label text       |
+| id            | No       | <code>let</code> | No       | <code>string</code>                       | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the input element                     |
+| name          | No       | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Specify a name attribute for the radio button input |
 
 ### Slots
 
@@ -2931,15 +2931,15 @@ None.
 
 ### Props
 
-| Prop name     | Kind             | Reactive | Type                                        | Default value             | Description                                  |
-| :------------ | :--------------- | :------- | :------------------------------------------ | ------------------------- | -------------------------------------------- |
-| selected      | <code>let</code> | Yes      | <code>string</code>                         | <code>undefined</code>    | Set the selected radio button value          |
-| disabled      | <code>let</code> | No       | <code>boolean</code>                        | <code>false</code>        | Set to `true` to disable the radio buttons   |
-| legendText    | <code>let</code> | No       | <code>string</code>                         | <code>""</code>           | Specify the legend text                      |
-| hideLegend    | <code>let</code> | No       | <code>boolean</code>                        | <code>false</code>        | Set to `true` to visually hide the legend    |
-| labelPosition | <code>let</code> | No       | <code>"right" &#124; "left"</code>          | <code>"right"</code>      | Specify the label position                   |
-| orientation   | <code>let</code> | No       | <code>"horizontal" &#124; "vertical"</code> | <code>"horizontal"</code> | Specify the orientation of the radio buttons |
-| id            | <code>let</code> | No       | <code>string</code>                         | <code>undefined</code>    | Set an id for the container div element      |
+| Prop name     | Required | Kind             | Reactive | Type                                        | Default value             | Description                                  |
+| :------------ | :------- | :--------------- | :------- | ------------------------------------------- | ------------------------- | -------------------------------------------- |
+| selected      | No       | <code>let</code> | Yes      | <code>string</code>                         | <code>undefined</code>    | Set the selected radio button value          |
+| disabled      | No       | <code>let</code> | No       | <code>boolean</code>                        | <code>false</code>        | Set to `true` to disable the radio buttons   |
+| legendText    | No       | <code>let</code> | No       | <code>string</code>                         | <code>""</code>           | Specify the legend text                      |
+| hideLegend    | No       | <code>let</code> | No       | <code>boolean</code>                        | <code>false</code>        | Set to `true` to visually hide the legend    |
+| labelPosition | No       | <code>let</code> | No       | <code>"right" &#124; "left"</code>          | <code>"right"</code>      | Specify the label position                   |
+| orientation   | No       | <code>let</code> | No       | <code>"horizontal" &#124; "vertical"</code> | <code>"horizontal"</code> | Specify the orientation of the radio buttons |
+| id            | No       | <code>let</code> | No       | <code>string</code>                         | <code>undefined</code>    | Set an id for the container div element      |
 
 ### Slots
 
@@ -2981,16 +2981,16 @@ None.
 
 ### Props
 
-| Prop name       | Kind             | Reactive | Type                 | Default value                                    | Description                                              |
-| :-------------- | :--------------- | :------- | :------------------- | ------------------------------------------------ | -------------------------------------------------------- |
-| checked         | <code>let</code> | Yes      | <code>boolean</code> | <code>false</code>                               | Set to `true` to check the tile                          |
-| light           | <code>let</code> | No       | <code>boolean</code> | <code>false</code>                               | Set to `true` to enable the light variant                |
-| disabled        | <code>let</code> | No       | <code>boolean</code> | <code>false</code>                               | Set to `true` to disable the tile                        |
-| value           | <code>let</code> | No       | <code>string</code>  | <code>""</code>                                  | Specify the value of the radio input                     |
-| tabindex        | <code>let</code> | No       | <code>string</code>  | <code>"0"</code>                                 | Specify the tabindex                                     |
-| iconDescription | <code>let</code> | No       | <code>string</code>  | <code>"Tile checkmark"</code>                    | Specify the ARIA label for the radio tile checkmark icon |
-| id              | <code>let</code> | No       | <code>string</code>  | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the input element                          |
-| name            | <code>let</code> | No       | <code>string</code>  | <code>""</code>                                  | Specify a name attribute for the input                   |
+| Prop name       | Required | Kind             | Reactive | Type                 | Default value                                    | Description                                              |
+| :-------------- | :------- | :--------------- | :------- | -------------------- | ------------------------------------------------ | -------------------------------------------------------- |
+| checked         | No       | <code>let</code> | Yes      | <code>boolean</code> | <code>false</code>                               | Set to `true` to check the tile                          |
+| light           | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code>                               | Set to `true` to enable the light variant                |
+| disabled        | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code>                               | Set to `true` to disable the tile                        |
+| value           | No       | <code>let</code> | No       | <code>string</code>  | <code>""</code>                                  | Specify the value of the radio input                     |
+| tabindex        | No       | <code>let</code> | No       | <code>string</code>  | <code>"0"</code>                                 | Specify the tabindex                                     |
+| iconDescription | No       | <code>let</code> | No       | <code>string</code>  | <code>"Tile checkmark"</code>                    | Specify the ARIA label for the radio tile checkmark icon |
+| id              | No       | <code>let</code> | No       | <code>string</code>  | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the input element                          |
+| name            | No       | <code>let</code> | No       | <code>string</code>  | <code>""</code>                                  | Specify a name attribute for the input                   |
 
 ### Slots
 
@@ -3023,10 +3023,10 @@ export interface RecursiveListNode {
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                                                                        | Default value            | Description                        |
-| :-------- | :--------------- | :------- | :-------------------------------------------------------------------------- | ------------------------ | ---------------------------------- |
-| children  | <code>let</code> | No       | <code>Array<RecursiveListNode & { children?: RecursiveListNode[]; }></code> | <code>[]</code>          | Specify the children to render     |
-| type      | <code>let</code> | No       | <code>"unordered" &#124; "ordered" &#124; "ordered-native"</code>           | <code>"unordered"</code> | Specify the type of list to render |
+| Prop name | Required | Kind             | Reactive | Type                                                                        | Default value            | Description                        |
+| :-------- | :------- | :--------------- | :------- | --------------------------------------------------------------------------- | ------------------------ | ---------------------------------- |
+| children  | No       | <code>let</code> | No       | <code>Array<RecursiveListNode & { children?: RecursiveListNode[]; }></code> | <code>[]</code>          | Specify the children to render     |
+| type      | No       | <code>let</code> | No       | <code>"unordered" &#124; "ordered" &#124; "ordered-native"</code>           | <code>"unordered"</code> | Specify the type of list to render |
 
 ### Slots
 
@@ -3040,15 +3040,15 @@ None.
 
 ### Props
 
-| Prop name     | Kind             | Reactive | Type                 | Default value      | Description                                                                                                                                                                                     |
-| :------------ | :--------------- | :------- | :------------------- | ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| as            | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to render a custom HTML element<br />Props are destructured as `props` in the default slot (e.g., &lt;Row let:props&gt;&lt;section {...props}&gt;...&lt;/section&gt;&lt;/Row&gt;) |
-| condensed     | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use the condensed variant                                                                                                                                                      |
-| narrow        | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use the narrow variant                                                                                                                                                         |
-| noGutter      | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to remove the gutter                                                                                                                                                              |
-| noGutterLeft  | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to remove the left gutter                                                                                                                                                         |
-| noGutterRight | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to remove the right gutter                                                                                                                                                        |
-| padding       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to add top and bottom padding to all columns                                                                                                                                      |
+| Prop name     | Required | Kind             | Reactive | Type                 | Default value      | Description                                                                                                                                                                                     |
+| :------------ | :------- | :--------------- | :------- | -------------------- | ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| as            | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to render a custom HTML element<br />Props are destructured as `props` in the default slot (e.g., &lt;Row let:props&gt;&lt;section {...props}&gt;...&lt;/section&gt;&lt;/Row&gt;) |
+| condensed     | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use the condensed variant                                                                                                                                                      |
+| narrow        | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use the narrow variant                                                                                                                                                         |
+| noGutter      | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to remove the gutter                                                                                                                                                              |
+| noGutterLeft  | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to remove the left gutter                                                                                                                                                         |
+| noGutterRight | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to remove the right gutter                                                                                                                                                        |
+| padding       | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to add top and bottom padding to all columns                                                                                                                                      |
 
 ### Slots
 
@@ -3064,24 +3064,24 @@ None.
 
 ### Props
 
-| Prop name            | Kind             | Reactive | Type                                                 | Default value                                    | Description                                                     |
-| :------------------- | :--------------- | :------- | :--------------------------------------------------- | ------------------------------------------------ | --------------------------------------------------------------- |
-| ref                  | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code>            | <code>null</code>                                | Obtain a reference to the input HTML element                    |
-| expanded             | <code>let</code> | Yes      | <code>boolean</code>                                 | <code>false</code>                               | Set to `true to expand the search input                         |
-| value                | <code>let</code> | Yes      | <code>any</code>                                     | <code>""</code>                                  | Specify the value of the search input                           |
-| size                 | <code>let</code> | No       | <code>"sm" &#124; "lg" &#124; "xl"</code>            | <code>"xl"</code>                                | Specify the size of the search input                            |
-| searchClass          | <code>let</code> | No       | <code>string</code>                                  | <code>""</code>                                  | Specify the class name passed to the outer div element          |
-| skeleton             | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>                               | Set to `true` to display the skeleton state                     |
-| light                | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>                               | Set to `true` to enable the light variant                       |
-| disabled             | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>                               | Set to `true` to disable the search input                       |
-| expandable           | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>                               | Set to `true` to enable the expandable variant                  |
-| placeholder          | <code>let</code> | No       | <code>string</code>                                  | <code>"Search..."</code>                         | Specify the `placeholder` attribute of the search input         |
-| autocomplete         | <code>let</code> | No       | <code>"on" &#124; "off"</code>                       | <code>"off"</code>                               | Specify the `autocomplete` attribute                            |
-| autofocus            | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>                               | Set to `true` to auto focus the search element                  |
-| closeButtonLabelText | <code>let</code> | No       | <code>string</code>                                  | <code>"Clear search input"</code>                | Specify the close button label text                             |
-| labelText            | <code>let</code> | No       | <code>string</code>                                  | <code>""</code>                                  | Specify the label text                                          |
-| icon                 | <code>let</code> | No       | <code>typeof import("svelte").SvelteComponent</code> | <code>undefined</code>                           | Specify the icon to render.<br />Defaults to `&lt;Search /&gt;` |
-| id                   | <code>let</code> | No       | <code>string</code>                                  | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the input element                                 |
+| Prop name            | Required | Kind             | Reactive | Type                                                 | Default value                                    | Description                                                     |
+| :------------------- | :------- | :--------------- | :------- | ---------------------------------------------------- | ------------------------------------------------ | --------------------------------------------------------------- |
+| ref                  | No       | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code>            | <code>null</code>                                | Obtain a reference to the input HTML element                    |
+| expanded             | No       | <code>let</code> | Yes      | <code>boolean</code>                                 | <code>false</code>                               | Set to `true to expand the search input                         |
+| value                | No       | <code>let</code> | Yes      | <code>any</code>                                     | <code>""</code>                                  | Specify the value of the search input                           |
+| size                 | No       | <code>let</code> | No       | <code>"sm" &#124; "lg" &#124; "xl"</code>            | <code>"xl"</code>                                | Specify the size of the search input                            |
+| searchClass          | No       | <code>let</code> | No       | <code>string</code>                                  | <code>""</code>                                  | Specify the class name passed to the outer div element          |
+| skeleton             | No       | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>                               | Set to `true` to display the skeleton state                     |
+| light                | No       | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>                               | Set to `true` to enable the light variant                       |
+| disabled             | No       | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>                               | Set to `true` to disable the search input                       |
+| expandable           | No       | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>                               | Set to `true` to enable the expandable variant                  |
+| placeholder          | No       | <code>let</code> | No       | <code>string</code>                                  | <code>"Search..."</code>                         | Specify the `placeholder` attribute of the search input         |
+| autocomplete         | No       | <code>let</code> | No       | <code>"on" &#124; "off"</code>                       | <code>"off"</code>                               | Specify the `autocomplete` attribute                            |
+| autofocus            | No       | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>                               | Set to `true` to auto focus the search element                  |
+| closeButtonLabelText | No       | <code>let</code> | No       | <code>string</code>                                  | <code>"Clear search input"</code>                | Specify the close button label text                             |
+| labelText            | No       | <code>let</code> | No       | <code>string</code>                                  | <code>""</code>                                  | Specify the label text                                          |
+| icon                 | No       | <code>let</code> | No       | <code>typeof import("svelte").SvelteComponent</code> | <code>undefined</code>                           | Specify the icon to render.<br />Defaults to `&lt;Search /&gt;` |
+| id                   | No       | <code>let</code> | No       | <code>string</code>                                  | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the input element                                 |
 
 ### Slots
 
@@ -3111,9 +3111,9 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                                      | Default value     | Description                          |
-| :-------- | :--------------- | :------- | :---------------------------------------- | ----------------- | ------------------------------------ |
-| size      | <code>let</code> | No       | <code>"sm" &#124; "lg" &#124; "xl"</code> | <code>"xl"</code> | Specify the size of the search input |
+| Prop name | Required | Kind             | Reactive | Type                                      | Default value     | Description                          |
+| :-------- | :------- | :--------------- | :------- | ----------------------------------------- | ----------------- | ------------------------------------ |
+| size      | No       | <code>let</code> | No       | <code>"sm" &#124; "lg" &#124; "xl"</code> | <code>"xl"</code> | Specify the size of the search input |
 
 ### Slots
 
@@ -3132,25 +3132,25 @@ None.
 
 ### Props
 
-| Prop name   | Kind             | Reactive | Type                                       | Default value                                    | Description                                     |
-| :---------- | :--------------- | :------- | :----------------------------------------- | ------------------------------------------------ | ----------------------------------------------- |
-| ref         | <code>let</code> | Yes      | <code>null &#124; HTMLSelectElement</code> | <code>null</code>                                | Obtain a reference to the select HTML element   |
-| selected    | <code>let</code> | Yes      | <code>string</code>                        | <code>undefined</code>                           | Specify the selected item value                 |
-| size        | <code>let</code> | No       | <code>"sm" &#124; "xl"</code>              | <code>undefined</code>                           | Set the size of the select input                |
-| inline      | <code>let</code> | No       | <code>boolean</code>                       | <code>false</code>                               | Set to `true` to use the inline variant         |
-| light       | <code>let</code> | No       | <code>boolean</code>                       | <code>false</code>                               | Set to `true` to enable the light variant       |
-| disabled    | <code>let</code> | No       | <code>boolean</code>                       | <code>false</code>                               | Set to `true` to disable the select element     |
-| id          | <code>let</code> | No       | <code>string</code>                        | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the select element                |
-| name        | <code>let</code> | No       | <code>string</code>                        | <code>undefined</code>                           | Specify a name attribute for the select element |
-| invalid     | <code>let</code> | No       | <code>boolean</code>                       | <code>false</code>                               | Set to `true` to indicate an invalid state      |
-| invalidText | <code>let</code> | No       | <code>string</code>                        | <code>""</code>                                  | Specify the invalid state text                  |
-| warn        | <code>let</code> | No       | <code>boolean</code>                       | <code>false</code>                               | Set to `true` to indicate an warning state      |
-| warnText    | <code>let</code> | No       | <code>string</code>                        | <code>""</code>                                  | Specify the warning state text                  |
-| helperText  | <code>let</code> | No       | <code>string</code>                        | <code>""</code>                                  | Specify the helper text                         |
-| noLabel     | <code>let</code> | No       | <code>boolean</code>                       | <code>false</code>                               | Set to `true` to not render a label             |
-| labelText   | <code>let</code> | No       | <code>string</code>                        | <code>""</code>                                  | Specify the label text                          |
-| hideLabel   | <code>let</code> | No       | <code>boolean</code>                       | <code>false</code>                               | Set to `true` to visually hide the label text   |
-| required    | <code>let</code> | No       | <code>boolean</code>                       | <code>false</code>                               | Set to `true` to mark the field as required     |
+| Prop name   | Required | Kind             | Reactive | Type                                       | Default value                                    | Description                                     |
+| :---------- | :------- | :--------------- | :------- | ------------------------------------------ | ------------------------------------------------ | ----------------------------------------------- |
+| ref         | No       | <code>let</code> | Yes      | <code>null &#124; HTMLSelectElement</code> | <code>null</code>                                | Obtain a reference to the select HTML element   |
+| selected    | No       | <code>let</code> | Yes      | <code>string</code>                        | <code>undefined</code>                           | Specify the selected item value                 |
+| size        | No       | <code>let</code> | No       | <code>"sm" &#124; "xl"</code>              | <code>undefined</code>                           | Set the size of the select input                |
+| inline      | No       | <code>let</code> | No       | <code>boolean</code>                       | <code>false</code>                               | Set to `true` to use the inline variant         |
+| light       | No       | <code>let</code> | No       | <code>boolean</code>                       | <code>false</code>                               | Set to `true` to enable the light variant       |
+| disabled    | No       | <code>let</code> | No       | <code>boolean</code>                       | <code>false</code>                               | Set to `true` to disable the select element     |
+| id          | No       | <code>let</code> | No       | <code>string</code>                        | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the select element                |
+| name        | No       | <code>let</code> | No       | <code>string</code>                        | <code>undefined</code>                           | Specify a name attribute for the select element |
+| invalid     | No       | <code>let</code> | No       | <code>boolean</code>                       | <code>false</code>                               | Set to `true` to indicate an invalid state      |
+| invalidText | No       | <code>let</code> | No       | <code>string</code>                        | <code>""</code>                                  | Specify the invalid state text                  |
+| warn        | No       | <code>let</code> | No       | <code>boolean</code>                       | <code>false</code>                               | Set to `true` to indicate an warning state      |
+| warnText    | No       | <code>let</code> | No       | <code>string</code>                        | <code>""</code>                                  | Specify the warning state text                  |
+| helperText  | No       | <code>let</code> | No       | <code>string</code>                        | <code>""</code>                                  | Specify the helper text                         |
+| noLabel     | No       | <code>let</code> | No       | <code>boolean</code>                       | <code>false</code>                               | Set to `true` to not render a label             |
+| labelText   | No       | <code>let</code> | No       | <code>string</code>                        | <code>""</code>                                  | Specify the label text                          |
+| hideLabel   | No       | <code>let</code> | No       | <code>boolean</code>                       | <code>false</code>                               | Set to `true` to visually hide the label text   |
+| required    | No       | <code>let</code> | No       | <code>boolean</code>                       | <code>false</code>                               | Set to `true` to mark the field as required     |
 
 ### Slots
 
@@ -3172,12 +3172,12 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                 | Default value      | Description                         |
-| :-------- | :--------------- | :------- | :------------------- | ------------------ | ----------------------------------- |
-| value     | <code>let</code> | No       | <code>string</code>  | <code>""</code>    | Specify the option value            |
-| text      | <code>let</code> | No       | <code>string</code>  | <code>""</code>    | Specify the option text             |
-| hidden    | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to hide the option    |
-| disabled  | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to disable the option |
+| Prop name | Required | Kind             | Reactive | Type                 | Default value      | Description                         |
+| :-------- | :------- | :--------------- | :------- | -------------------- | ------------------ | ----------------------------------- |
+| value     | No       | <code>let</code> | No       | <code>string</code>  | <code>""</code>    | Specify the option value            |
+| text      | No       | <code>let</code> | No       | <code>string</code>  | <code>""</code>    | Specify the option text             |
+| hidden    | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to hide the option    |
+| disabled  | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to disable the option |
 
 ### Slots
 
@@ -3191,10 +3191,10 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                 | Default value                | Description                                         |
-| :-------- | :--------------- | :------- | :------------------- | ---------------------------- | --------------------------------------------------- |
-| disabled  | <code>let</code> | No       | <code>boolean</code> | <code>false</code>           | Set to `true` to disable the optgroup element       |
-| label     | <code>let</code> | No       | <code>string</code>  | <code>"Provide label"</code> | Specify the label attribute of the optgroup element |
+| Prop name | Required | Kind             | Reactive | Type                 | Default value                | Description                                         |
+| :-------- | :------- | :--------------- | :------- | -------------------- | ---------------------------- | --------------------------------------------------- |
+| disabled  | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code>           | Set to `true` to disable the optgroup element       |
+| label     | No       | <code>let</code> | No       | <code>string</code>  | <code>"Provide label"</code> | Specify the label attribute of the optgroup element |
 
 ### Slots
 
@@ -3210,9 +3210,9 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                 | Default value      | Description                          |
-| :-------- | :--------------- | :------- | :------------------- | ------------------ | ------------------------------------ |
-| hideLabel | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to hide the label text |
+| Prop name | Required | Kind             | Reactive | Type                 | Default value      | Description                          |
+| :-------- | :------- | :--------------- | :------- | -------------------- | ------------------ | ------------------------------------ |
+| hideLabel | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to hide the label text |
 
 ### Slots
 
@@ -3231,18 +3231,18 @@ None.
 
 ### Props
 
-| Prop name       | Kind             | Reactive | Type                                      | Default value                                    | Description                                                   |
-| :-------------- | :--------------- | :------- | :---------------------------------------- | ------------------------------------------------ | ------------------------------------------------------------- |
-| ref             | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code> | <code>null</code>                                | Obtain a reference to the input HTML element                  |
-| selected        | <code>let</code> | Yes      | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to select the tile                              |
-| light           | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to enable the light variant                     |
-| disabled        | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to disable the tile                             |
-| title           | <code>let</code> | No       | <code>string</code>                       | <code>"title"</code>                             | Specify the title of the selectable tile                      |
-| value           | <code>let</code> | No       | <code>string</code>                       | <code>"value"</code>                             | Specify the value of the selectable tile                      |
-| tabindex        | <code>let</code> | No       | <code>string</code>                       | <code>"0"</code>                                 | Specify the tabindex                                          |
-| iconDescription | <code>let</code> | No       | <code>string</code>                       | <code>"Tile checkmark"</code>                    | Specify the ARIA label for the selectable tile checkmark icon |
-| id              | <code>let</code> | No       | <code>string</code>                       | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the input element                               |
-| name            | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Specify a name attribute for the input                        |
+| Prop name       | Required | Kind             | Reactive | Type                                      | Default value                                    | Description                                                   |
+| :-------------- | :------- | :--------------- | :------- | ----------------------------------------- | ------------------------------------------------ | ------------------------------------------------------------- |
+| ref             | No       | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code> | <code>null</code>                                | Obtain a reference to the input HTML element                  |
+| selected        | No       | <code>let</code> | Yes      | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to select the tile                              |
+| light           | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to enable the light variant                     |
+| disabled        | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to disable the tile                             |
+| title           | No       | <code>let</code> | No       | <code>string</code>                       | <code>"title"</code>                             | Specify the title of the selectable tile                      |
+| value           | No       | <code>let</code> | No       | <code>string</code>                       | <code>"value"</code>                             | Specify the value of the selectable tile                      |
+| tabindex        | No       | <code>let</code> | No       | <code>string</code>                       | <code>"0"</code>                                 | Specify the tabindex                                          |
+| iconDescription | No       | <code>let</code> | No       | <code>string</code>                       | <code>"Tile checkmark"</code>                    | Specify the ARIA label for the selectable tile checkmark icon |
+| id              | No       | <code>let</code> | No       | <code>string</code>                       | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the input element                               |
+| name            | No       | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Specify a name attribute for the input                        |
 
 ### Slots
 
@@ -3264,13 +3264,13 @@ None.
 
 ### Props
 
-| Prop name           | Kind             | Reactive | Type                 | Default value          | Description                                                                                                                                                                                                                                                      |
-| :------------------ | :--------------- | :------- | :------------------- | ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| isOpen              | <code>let</code> | Yes      | <code>boolean</code> | <code>false</code>     | Set to `true` to toggle the expanded state                                                                                                                                                                                                                       |
-| fixed               | <code>let</code> | No       | <code>boolean</code> | <code>false</code>     | Set to `true` to use the fixed variant                                                                                                                                                                                                                           |
-| rail                | <code>let</code> | No       | <code>boolean</code> | <code>false</code>     | Set to `true` to use the rail variant                                                                                                                                                                                                                            |
-| ariaLabel           | <code>let</code> | No       | <code>string</code>  | <code>undefined</code> | Specify the ARIA label for the nav                                                                                                                                                                                                                               |
-| expansionBreakpoint | <code>let</code> | No       | <code>number</code>  | <code>1056</code>      | The window width (px) at which the SideNav is expanded and the hamburger menu is hidden<br />1056 represents the "large" breakpoint in pixels from the Carbon Design System:<br />small: 320<br />medium: 672<br />large: 1056<br />x-large: 1312<br />max: 1584 |
+| Prop name           | Required | Kind             | Reactive | Type                 | Default value          | Description                                                                                                                                                                                                                                                      |
+| :------------------ | :------- | :--------------- | :------- | -------------------- | ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| isOpen              | No       | <code>let</code> | Yes      | <code>boolean</code> | <code>false</code>     | Set to `true` to toggle the expanded state                                                                                                                                                                                                                       |
+| fixed               | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code>     | Set to `true` to use the fixed variant                                                                                                                                                                                                                           |
+| rail                | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code>     | Set to `true` to use the rail variant                                                                                                                                                                                                                            |
+| ariaLabel           | No       | <code>let</code> | No       | <code>string</code>  | <code>undefined</code> | Specify the ARIA label for the nav                                                                                                                                                                                                                               |
+| expansionBreakpoint | No       | <code>let</code> | No       | <code>number</code>  | <code>1056</code>      | The window width (px) at which the SideNav is expanded and the hamburger menu is hidden<br />1056 represents the "large" breakpoint in pixels from the Carbon Design System:<br />small: 320<br />medium: 672<br />large: 1056<br />x-large: 1312<br />max: 1584 |
 
 ### Slots
 
@@ -3320,13 +3320,13 @@ None.
 
 ### Props
 
-| Prop name  | Kind             | Reactive | Type                                                 | Default value          | Description                                   |
-| :--------- | :--------------- | :------- | :--------------------------------------------------- | ---------------------- | --------------------------------------------- |
-| ref        | <code>let</code> | Yes      | <code>null &#124; HTMLAnchorElement</code>           | <code>null</code>      | Obtain a reference to the HTML anchor element |
-| isSelected | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>     | Set to `true` to select the current link      |
-| href       | <code>let</code> | No       | <code>string</code>                                  | <code>undefined</code> | Specify the `href` attribute                  |
-| text       | <code>let</code> | No       | <code>string</code>                                  | <code>undefined</code> | Specify the text                              |
-| icon       | <code>let</code> | No       | <code>typeof import("svelte").SvelteComponent</code> | <code>undefined</code> | Specify the icon to render                    |
+| Prop name  | Required | Kind             | Reactive | Type                                                 | Default value          | Description                                   |
+| :--------- | :------- | :--------------- | :------- | ---------------------------------------------------- | ---------------------- | --------------------------------------------- |
+| ref        | No       | <code>let</code> | Yes      | <code>null &#124; HTMLAnchorElement</code>           | <code>null</code>      | Obtain a reference to the HTML anchor element |
+| isSelected | No       | <code>let</code> | No       | <code>boolean</code>                                 | <code>false</code>     | Set to `true` to select the current link      |
+| href       | No       | <code>let</code> | No       | <code>string</code>                                  | <code>undefined</code> | Specify the `href` attribute                  |
+| text       | No       | <code>let</code> | No       | <code>string</code>                                  | <code>undefined</code> | Specify the text                              |
+| icon       | No       | <code>let</code> | No       | <code>typeof import("svelte").SvelteComponent</code> | <code>undefined</code> | Specify the icon to render                    |
 
 ### Slots
 
@@ -3345,12 +3345,12 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                                                 | Default value          | Description                                   |
-| :-------- | :--------------- | :------- | :--------------------------------------------------- | ---------------------- | --------------------------------------------- |
-| ref       | <code>let</code> | Yes      | <code>null &#124; HTMLButtonElement</code>           | <code>null</code>      | Obtain a reference to the HTML button element |
-| expanded  | <code>let</code> | Yes      | <code>boolean</code>                                 | <code>false</code>     | Set to `true` to toggle the expanded state    |
-| text      | <code>let</code> | No       | <code>string</code>                                  | <code>undefined</code> | Specify the text                              |
-| icon      | <code>let</code> | No       | <code>typeof import("svelte").SvelteComponent</code> | <code>undefined</code> | Specify the icon to render                    |
+| Prop name | Required | Kind             | Reactive | Type                                                 | Default value          | Description                                   |
+| :-------- | :------- | :--------------- | :------- | ---------------------------------------------------- | ---------------------- | --------------------------------------------- |
+| ref       | No       | <code>let</code> | Yes      | <code>null &#124; HTMLButtonElement</code>           | <code>null</code>      | Obtain a reference to the HTML button element |
+| expanded  | No       | <code>let</code> | Yes      | <code>boolean</code>                                 | <code>false</code>     | Set to `true` to toggle the expanded state    |
+| text      | No       | <code>let</code> | No       | <code>string</code>                                  | <code>undefined</code> | Specify the text                              |
+| icon      | No       | <code>let</code> | No       | <code>typeof import("svelte").SvelteComponent</code> | <code>undefined</code> | Specify the icon to render                    |
 
 ### Slots
 
@@ -3369,12 +3369,12 @@ None.
 
 ### Props
 
-| Prop name  | Kind             | Reactive | Type                                       | Default value          | Description                                   |
-| :--------- | :--------------- | :------- | :----------------------------------------- | ---------------------- | --------------------------------------------- |
-| ref        | <code>let</code> | Yes      | <code>null &#124; HTMLAnchorElement</code> | <code>null</code>      | Obtain a reference to the HTML anchor element |
-| isSelected | <code>let</code> | No       | <code>boolean</code>                       | <code>false</code>     | Set to `true` to select the item              |
-| href       | <code>let</code> | No       | <code>string</code>                        | <code>undefined</code> | Specify the `href` attribute                  |
-| text       | <code>let</code> | No       | <code>string</code>                        | <code>undefined</code> | Specify the item text                         |
+| Prop name  | Required | Kind             | Reactive | Type                                       | Default value          | Description                                   |
+| :--------- | :------- | :--------------- | :------- | ------------------------------------------ | ---------------------- | --------------------------------------------- |
+| ref        | No       | <code>let</code> | Yes      | <code>null &#124; HTMLAnchorElement</code> | <code>null</code>      | Obtain a reference to the HTML anchor element |
+| isSelected | No       | <code>let</code> | No       | <code>boolean</code>                       | <code>false</code>     | Set to `true` to select the item              |
+| href       | No       | <code>let</code> | No       | <code>string</code>                        | <code>undefined</code> | Specify the `href` attribute                  |
+| text       | No       | <code>let</code> | No       | <code>string</code>                        | <code>undefined</code> | Specify the item text                         |
 
 ### Slots
 
@@ -3411,12 +3411,12 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                 | Default value       | Description                                     |
-| :-------- | :--------------- | :------- | :------------------- | ------------------- | ----------------------------------------------- |
-| lines     | <code>let</code> | No       | <code>number</code>  | <code>3</code>      | Specify the number of lines to render           |
-| heading   | <code>let</code> | No       | <code>boolean</code> | <code>false</code>  | Set to `true` to use the heading size variant   |
-| paragraph | <code>let</code> | No       | <code>boolean</code> | <code>false</code>  | Set to `true` to use the paragraph size variant |
-| width     | <code>let</code> | No       | <code>string</code>  | <code>"100%"</code> | Specify the width of the text (% or px)         |
+| Prop name | Required | Kind             | Reactive | Type                 | Default value       | Description                                     |
+| :-------- | :------- | :--------------- | :------- | -------------------- | ------------------- | ----------------------------------------------- |
+| lines     | No       | <code>let</code> | No       | <code>number</code>  | <code>3</code>      | Specify the number of lines to render           |
+| heading   | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code>  | Set to `true` to use the heading size variant   |
+| paragraph | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code>  | Set to `true` to use the paragraph size variant |
+| width     | No       | <code>let</code> | No       | <code>string</code>  | <code>"100%"</code> | Specify the width of the text (% or px)         |
 
 ### Slots
 
@@ -3435,10 +3435,10 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                | Default value                | Description                  |
-| :-------- | :--------------- | :------- | :------------------ | ---------------------------- | ---------------------------- |
-| href      | <code>let</code> | No       | <code>string</code> | <code>"#main-content"</code> | Specify the `href` attribute |
-| tabindex  | <code>let</code> | No       | <code>string</code> | <code>"0"</code>             | Specify the tabindex         |
+| Prop name | Required | Kind             | Reactive | Type                | Default value                | Description                  |
+| :-------- | :------- | :--------------- | :------- | ------------------- | ---------------------------- | ---------------------------- |
+| href      | No       | <code>let</code> | No       | <code>string</code> | <code>"#main-content"</code> | Specify the `href` attribute |
+| tabindex  | No       | <code>let</code> | No       | <code>string</code> | <code>"0"</code>             | Specify the tabindex         |
 
 ### Slots
 
@@ -3456,25 +3456,25 @@ None.
 
 ### Props
 
-| Prop name      | Kind             | Reactive | Type                                    | Default value                                    | Description                                |
-| :------------- | :--------------- | :------- | :-------------------------------------- | ------------------------------------------------ | ------------------------------------------ |
-| ref            | <code>let</code> | Yes      | <code>null &#124; HTMLDivElement</code> | <code>null</code>                                | Obtain a reference to the HTML element     |
-| value          | <code>let</code> | Yes      | <code>number</code>                     | <code>0</code>                                   | Specify the value of the slider            |
-| max            | <code>let</code> | No       | <code>number</code>                     | <code>100</code>                                 | Set the maximum slider value               |
-| maxLabel       | <code>let</code> | No       | <code>string</code>                     | <code>""</code>                                  | Specify the label for the max value        |
-| min            | <code>let</code> | No       | <code>number</code>                     | <code>0</code>                                   | Set the minimum slider value               |
-| minLabel       | <code>let</code> | No       | <code>string</code>                     | <code>""</code>                                  | Specify the label for the min value        |
-| step           | <code>let</code> | No       | <code>number</code>                     | <code>1</code>                                   | Set the step value                         |
-| stepMultiplier | <code>let</code> | No       | <code>number</code>                     | <code>4</code>                                   | Set the step multiplier value              |
-| required       | <code>let</code> | No       | <code>boolean</code>                    | <code>false</code>                               | Set to `true` to require a value           |
-| inputType      | <code>let</code> | No       | <code>string</code>                     | <code>"number"</code>                            | Specify the input type                     |
-| disabled       | <code>let</code> | No       | <code>boolean</code>                    | <code>false</code>                               | Set to `true` to disable the slider        |
-| light          | <code>let</code> | No       | <code>boolean</code>                    | <code>false</code>                               | Set to `true` to enable the light variant  |
-| hideTextInput  | <code>let</code> | No       | <code>boolean</code>                    | <code>false</code>                               | Set to `true` to hide the text input       |
-| id             | <code>let</code> | No       | <code>string</code>                     | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the slider div element       |
-| invalid        | <code>let</code> | No       | <code>boolean</code>                    | <code>false</code>                               | Set to `true` to indicate an invalid state |
-| labelText      | <code>let</code> | No       | <code>string</code>                     | <code>""</code>                                  | Specify the label text                     |
-| name           | <code>let</code> | No       | <code>string</code>                     | <code>""</code>                                  | Set a name for the slider element          |
+| Prop name      | Required | Kind             | Reactive | Type                                    | Default value                                    | Description                                |
+| :------------- | :------- | :--------------- | :------- | --------------------------------------- | ------------------------------------------------ | ------------------------------------------ |
+| ref            | No       | <code>let</code> | Yes      | <code>null &#124; HTMLDivElement</code> | <code>null</code>                                | Obtain a reference to the HTML element     |
+| value          | No       | <code>let</code> | Yes      | <code>number</code>                     | <code>0</code>                                   | Specify the value of the slider            |
+| max            | No       | <code>let</code> | No       | <code>number</code>                     | <code>100</code>                                 | Set the maximum slider value               |
+| maxLabel       | No       | <code>let</code> | No       | <code>string</code>                     | <code>""</code>                                  | Specify the label for the max value        |
+| min            | No       | <code>let</code> | No       | <code>number</code>                     | <code>0</code>                                   | Set the minimum slider value               |
+| minLabel       | No       | <code>let</code> | No       | <code>string</code>                     | <code>""</code>                                  | Specify the label for the min value        |
+| step           | No       | <code>let</code> | No       | <code>number</code>                     | <code>1</code>                                   | Set the step value                         |
+| stepMultiplier | No       | <code>let</code> | No       | <code>number</code>                     | <code>4</code>                                   | Set the step multiplier value              |
+| required       | No       | <code>let</code> | No       | <code>boolean</code>                    | <code>false</code>                               | Set to `true` to require a value           |
+| inputType      | No       | <code>let</code> | No       | <code>string</code>                     | <code>"number"</code>                            | Specify the input type                     |
+| disabled       | No       | <code>let</code> | No       | <code>boolean</code>                    | <code>false</code>                               | Set to `true` to disable the slider        |
+| light          | No       | <code>let</code> | No       | <code>boolean</code>                    | <code>false</code>                               | Set to `true` to enable the light variant  |
+| hideTextInput  | No       | <code>let</code> | No       | <code>boolean</code>                    | <code>false</code>                               | Set to `true` to hide the text input       |
+| id             | No       | <code>let</code> | No       | <code>string</code>                     | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the slider div element       |
+| invalid        | No       | <code>let</code> | No       | <code>boolean</code>                    | <code>false</code>                               | Set to `true` to indicate an invalid state |
+| labelText      | No       | <code>let</code> | No       | <code>string</code>                     | <code>""</code>                                  | Specify the label text                     |
+| name           | No       | <code>let</code> | No       | <code>string</code>                     | <code>""</code>                                  | Set a name for the slider element          |
 
 ### Slots
 
@@ -3496,9 +3496,9 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                 | Default value      | Description                          |
-| :-------- | :--------------- | :------- | :------------------- | ------------------ | ------------------------------------ |
-| hideLabel | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to hide the label text |
+| Prop name | Required | Kind             | Reactive | Type                 | Default value      | Description                          |
+| :-------- | :------- | :--------------- | :------- | -------------------- | ------------------ | ------------------------------------ |
+| hideLabel | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to hide the label text |
 
 ### Slots
 
@@ -3517,12 +3517,12 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                 | Default value          | Description                                    |
-| :-------- | :--------------- | :------- | :------------------- | ---------------------- | ---------------------------------------------- |
-| selected  | <code>let</code> | Yes      | <code>string</code>  | <code>undefined</code> | Specify the selected structured list row value |
-| condensed | <code>let</code> | No       | <code>boolean</code> | <code>false</code>     | Set to `true` to use the condensed variant     |
-| flush     | <code>let</code> | No       | <code>boolean</code> | <code>false</code>     | Set to `true` to flush the list                |
-| selection | <code>let</code> | No       | <code>boolean</code> | <code>false</code>     | Set to `true` to use the selection variant     |
+| Prop name | Required | Kind             | Reactive | Type                 | Default value          | Description                                    |
+| :-------- | :------- | :--------------- | :------- | -------------------- | ---------------------- | ---------------------------------------------- |
+| selected  | No       | <code>let</code> | Yes      | <code>string</code>  | <code>undefined</code> | Specify the selected structured list row value |
+| condensed | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code>     | Set to `true` to use the condensed variant     |
+| flush     | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code>     | Set to `true` to flush the list                |
+| selection | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code>     | Set to `true` to use the selection variant     |
 
 ### Slots
 
@@ -3565,10 +3565,10 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                 | Default value      | Description                       |
-| :-------- | :--------------- | :------- | :------------------- | ------------------ | --------------------------------- |
-| head      | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use as a header  |
-| noWrap    | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to prevent wrapping |
+| Prop name | Required | Kind             | Reactive | Type                 | Default value      | Description                       |
+| :-------- | :------- | :--------------- | :------- | -------------------- | ------------------ | --------------------------------- |
+| head      | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use as a header  |
+| noWrap    | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to prevent wrapping |
 
 ### Slots
 
@@ -3610,14 +3610,14 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                                      | Default value                                    | Description                                  |
-| :-------- | :--------------- | :------- | :---------------------------------------- | ------------------------------------------------ | -------------------------------------------- |
-| ref       | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code> | <code>null</code>                                | Obtain a reference to the input HTML element |
-| checked   | <code>let</code> | Yes      | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to check the input             |
-| title     | <code>let</code> | No       | <code>string</code>                       | <code>"title"</code>                             | Specify the title of the input               |
-| value     | <code>let</code> | No       | <code>string</code>                       | <code>"value"</code>                             | Specify the value of the input               |
-| id        | <code>let</code> | No       | <code>string</code>                       | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the input element              |
-| name      | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Specify a name attribute for the input       |
+| Prop name | Required | Kind             | Reactive | Type                                      | Default value                                    | Description                                  |
+| :-------- | :------- | :--------------- | :------- | ----------------------------------------- | ------------------------------------------------ | -------------------------------------------- |
+| ref       | No       | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code> | <code>null</code>                                | Obtain a reference to the input HTML element |
+| checked   | No       | <code>let</code> | Yes      | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to check the input             |
+| title     | No       | <code>let</code> | No       | <code>string</code>                       | <code>"title"</code>                             | Specify the title of the input               |
+| value     | No       | <code>let</code> | No       | <code>string</code>                       | <code>"value"</code>                             | Specify the value of the input               |
+| id        | No       | <code>let</code> | No       | <code>string</code>                       | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the input element              |
+| name      | No       | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Specify a name attribute for the input       |
 
 ### Slots
 
@@ -3631,11 +3631,11 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                 | Default value      | Description                          |
-| :-------- | :--------------- | :------- | :------------------- | ------------------ | ------------------------------------ |
-| head      | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use as a header     |
-| label     | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to render a label slot |
-| tabindex  | <code>let</code> | No       | <code>string</code>  | <code>"0"</code>   | Specify the tabindex                 |
+| Prop name | Required | Kind             | Reactive | Type                 | Default value      | Description                          |
+| :-------- | :------- | :--------------- | :------- | -------------------- | ------------------ | ------------------------------------ |
+| head      | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use as a header     |
+| label     | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to render a label slot |
+| tabindex  | No       | <code>let</code> | No       | <code>string</code>  | <code>"0"</code>   | Specify the tabindex                 |
 
 ### Slots
 
@@ -3657,9 +3657,9 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                | Default value  | Description                |
-| :-------- | :--------------- | :------- | :------------------ | -------------- | -------------------------- |
-| rows      | <code>let</code> | No       | <code>number</code> | <code>5</code> | Specify the number of rows |
+| Prop name | Required | Kind             | Reactive | Type                | Default value  | Description                |
+| :-------- | :------- | :--------------- | :------- | ------------------- | -------------- | -------------------------- |
+| rows      | No       | <code>let</code> | No       | <code>number</code> | <code>5</code> | Specify the number of rows |
 
 ### Slots
 
@@ -3678,13 +3678,13 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                                       | Default value                                    | Description                                                                                                      |
-| :-------- | :--------------- | :------- | :----------------------------------------- | ------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------- |
-| ref       | <code>let</code> | Yes      | <code>null &#124; HTMLButtonElement</code> | <code>null</code>                                | Obtain a reference to the button HTML element                                                                    |
-| selected  | <code>let</code> | Yes      | <code>boolean</code>                       | <code>false</code>                               | Set to `true` for the switch to be selected                                                                      |
-| text      | <code>let</code> | No       | <code>string</code>                        | <code>"Provide text"</code>                      | Specify the switch text<br />Alternatively, use the "text" slot (e.g., &lt;span slot="text"&gt;...&lt;/span&gt;) |
-| disabled  | <code>let</code> | No       | <code>boolean</code>                       | <code>false</code>                               | Set to `true` to disable the switch                                                                              |
-| id        | <code>let</code> | No       | <code>string</code>                        | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the button element                                                                                 |
+| Prop name | Required | Kind             | Reactive | Type                                       | Default value                                    | Description                                                                                                      |
+| :-------- | :------- | :--------------- | :------- | ------------------------------------------ | ------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------- |
+| ref       | No       | <code>let</code> | Yes      | <code>null &#124; HTMLButtonElement</code> | <code>null</code>                                | Obtain a reference to the button HTML element                                                                    |
+| selected  | No       | <code>let</code> | Yes      | <code>boolean</code>                       | <code>false</code>                               | Set to `true` for the switch to be selected                                                                      |
+| text      | No       | <code>let</code> | No       | <code>string</code>                        | <code>"Provide text"</code>                      | Specify the switch text<br />Alternatively, use the "text" slot (e.g., &lt;span slot="text"&gt;...&lt;/span&gt;) |
+| disabled  | No       | <code>let</code> | No       | <code>boolean</code>                       | <code>false</code>                               | Set to `true` to disable the switch                                                                              |
+| id        | No       | <code>let</code> | No       | <code>string</code>                        | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the button element                                                                                 |
 
 ### Slots
 
@@ -3706,14 +3706,14 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                                       | Default value                                    | Description                                                                                                                  |
-| :-------- | :--------------- | :------- | :----------------------------------------- | ------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------- |
-| ref       | <code>let</code> | Yes      | <code>null &#124; HTMLAnchorElement</code> | <code>null</code>                                | Obtain a reference to the anchor HTML element                                                                                |
-| label     | <code>let</code> | No       | <code>string</code>                        | <code>""</code>                                  | Specify the tab label<br />Alternatively, use the default slot (e.g., &lt;Tab&gt;&lt;span&gt;Label&lt;/span&gt;&lt;/Tab&gt;) |
-| href      | <code>let</code> | No       | <code>string</code>                        | <code>"#"</code>                                 | Specify the href attribute                                                                                                   |
-| disabled  | <code>let</code> | No       | <code>boolean</code>                       | <code>false</code>                               | Set to `true` to disable the tab                                                                                             |
-| tabindex  | <code>let</code> | No       | <code>string</code>                        | <code>"0"</code>                                 | Specify the tabindex                                                                                                         |
-| id        | <code>let</code> | No       | <code>string</code>                        | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the top-level element                                                                                          |
+| Prop name | Required | Kind             | Reactive | Type                                       | Default value                                    | Description                                                                                                                  |
+| :-------- | :------- | :--------------- | :------- | ------------------------------------------ | ------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------- |
+| ref       | No       | <code>let</code> | Yes      | <code>null &#124; HTMLAnchorElement</code> | <code>null</code>                                | Obtain a reference to the anchor HTML element                                                                                |
+| label     | No       | <code>let</code> | No       | <code>string</code>                        | <code>""</code>                                  | Specify the tab label<br />Alternatively, use the default slot (e.g., &lt;Tab&gt;&lt;span&gt;Label&lt;/span&gt;&lt;/Tab&gt;) |
+| href      | No       | <code>let</code> | No       | <code>string</code>                        | <code>"#"</code>                                 | Specify the href attribute                                                                                                   |
+| disabled  | No       | <code>let</code> | No       | <code>boolean</code>                       | <code>false</code>                               | Set to `true` to disable the tab                                                                                             |
+| tabindex  | No       | <code>let</code> | No       | <code>string</code>                        | <code>"0"</code>                                 | Specify the tabindex                                                                                                         |
+| id        | No       | <code>let</code> | No       | <code>string</code>                        | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the top-level element                                                                                          |
 
 ### Slots
 
@@ -3734,9 +3734,9 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                | Default value                                    | Description                         |
-| :-------- | :--------------- | :------- | :------------------ | ------------------------------------------------ | ----------------------------------- |
-| id        | <code>let</code> | No       | <code>string</code> | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the top-level element |
+| Prop name | Required | Kind             | Reactive | Type                | Default value                                    | Description                         |
+| :-------- | :------- | :--------------- | :------- | ------------------- | ------------------------------------------------ | ----------------------------------- |
+| id        | No       | <code>let</code> | No       | <code>string</code> | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the top-level element |
 
 ### Slots
 
@@ -3752,14 +3752,14 @@ None.
 
 ### Props
 
-| Prop name      | Kind             | Reactive | Type                                                                | Default value          | Description                                    |
-| :------------- | :--------------- | :------- | :------------------------------------------------------------------ | ---------------------- | ---------------------------------------------- |
-| size           | <code>let</code> | No       | <code>"compact" &#124; "short" &#124; "medium" &#124; "tall"</code> | <code>undefined</code> | Set the size of the table                      |
-| zebra          | <code>let</code> | No       | <code>boolean</code>                                                | <code>false</code>     | Set to `true` to use zebra styles              |
-| useStaticWidth | <code>let</code> | No       | <code>boolean</code>                                                | <code>false</code>     | Set to `true` to use static width              |
-| sortable       | <code>let</code> | No       | <code>boolean</code>                                                | <code>false</code>     | Set to `true` for the sortable variant         |
-| stickyHeader   | <code>let</code> | No       | <code>boolean</code>                                                | <code>false</code>     | Set to `true` to enable a sticky header        |
-| tableStyle     | <code>let</code> | No       | <code>string</code>                                                 | <code>undefined</code> | Set the style attribute on the `table` element |
+| Prop name      | Required | Kind             | Reactive | Type                                                                | Default value          | Description                                    |
+| :------------- | :------- | :--------------- | :------- | ------------------------------------------------------------------- | ---------------------- | ---------------------------------------------- |
+| size           | No       | <code>let</code> | No       | <code>"compact" &#124; "short" &#124; "medium" &#124; "tall"</code> | <code>undefined</code> | Set the size of the table                      |
+| zebra          | No       | <code>let</code> | No       | <code>boolean</code>                                                | <code>false</code>     | Set to `true` to use zebra styles              |
+| useStaticWidth | No       | <code>let</code> | No       | <code>boolean</code>                                                | <code>false</code>     | Set to `true` to use static width              |
+| sortable       | No       | <code>let</code> | No       | <code>boolean</code>                                                | <code>false</code>     | Set to `true` for the sortable variant         |
+| stickyHeader   | No       | <code>let</code> | No       | <code>boolean</code>                                                | <code>false</code>     | Set to `true` to enable a sticky header        |
+| tableStyle     | No       | <code>let</code> | No       | <code>string</code>                                                 | <code>undefined</code> | Set the style attribute on the `table` element |
 
 ### Slots
 
@@ -3812,12 +3812,12 @@ None.
 
 ### Props
 
-| Prop name      | Kind             | Reactive | Type                 | Default value      | Description                               |
-| :------------- | :--------------- | :------- | :------------------- | ------------------ | ----------------------------------------- |
-| title          | <code>let</code> | No       | <code>string</code>  | <code>""</code>    | Specify the title of the data table       |
-| description    | <code>let</code> | No       | <code>string</code>  | <code>""</code>    | Specify the description of the data table |
-| stickyHeader   | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to enable a sticky header   |
-| useStaticWidth | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use static width         |
+| Prop name      | Required | Kind             | Reactive | Type                 | Default value      | Description                               |
+| :------------- | :------- | :--------------- | :------- | -------------------- | ------------------ | ----------------------------------------- |
+| title          | No       | <code>let</code> | No       | <code>string</code>  | <code>""</code>    | Specify the title of the data table       |
+| description    | No       | <code>let</code> | No       | <code>string</code>  | <code>""</code>    | Specify the description of the data table |
+| stickyHeader   | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to enable a sticky header   |
+| useStaticWidth | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use static width         |
 
 ### Slots
 
@@ -3854,12 +3854,12 @@ None.
 
 ### Props
 
-| Prop name       | Kind             | Reactive | Type                      | Default value                                    | Description                                            |
-| :-------------- | :--------------- | :------- | :------------------------ | ------------------------------------------------ | ------------------------------------------------------ |
-| disableSorting  | <code>let</code> | No       | <code>boolean</code>      | <code>false</code>                               | Set to `true` to disable sorting on this specific cell |
-| scope           | <code>let</code> | No       | <code>string</code>       | <code>"col"</code>                               | Specify the `scope` attribute                          |
-| translateWithId | <code>let</code> | No       | <code>() => string</code> | <code>() => ""</code>                            | Override the default id translations                   |
-| id              | <code>let</code> | No       | <code>string</code>       | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the top-level element                    |
+| Prop name       | Required | Kind             | Reactive | Type                      | Default value                                    | Description                                            |
+| :-------------- | :------- | :--------------- | :------- | ------------------------- | ------------------------------------------------ | ------------------------------------------------------ |
+| disableSorting  | No       | <code>let</code> | No       | <code>boolean</code>      | <code>false</code>                               | Set to `true` to disable sorting on this specific cell |
+| scope           | No       | <code>let</code> | No       | <code>string</code>       | <code>"col"</code>                               | Specify the `scope` attribute                          |
+| translateWithId | No       | <code>let</code> | No       | <code>() => string</code> | <code>() => ""</code>                            | Override the default id translations                   |
+| id              | No       | <code>let</code> | No       | <code>string</code>       | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the top-level element                    |
 
 ### Slots
 
@@ -3901,13 +3901,13 @@ None.
 
 ### Props
 
-| Prop name       | Kind             | Reactive | Type                                      | Default value                    | Description                                  |
-| :-------------- | :--------------- | :------- | :---------------------------------------- | -------------------------------- | -------------------------------------------- |
-| selected        | <code>let</code> | Yes      | <code>number</code>                       | <code>0</code>                   | Specify the selected tab index               |
-| type            | <code>let</code> | No       | <code>"default" &#124; "container"</code> | <code>"default"</code>           | Specify the type of tabs                     |
-| autoWidth       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>               | Set to `true` for tabs to have an auto-width |
-| iconDescription | <code>let</code> | No       | <code>string</code>                       | <code>"Show menu options"</code> | Specify the ARIA label for the chevron icon  |
-| triggerHref     | <code>let</code> | No       | <code>string</code>                       | <code>"#"</code>                 | Specify the tab trigger href attribute       |
+| Prop name       | Required | Kind             | Reactive | Type                                      | Default value                    | Description                                  |
+| :-------------- | :------- | :--------------- | :------- | ----------------------------------------- | -------------------------------- | -------------------------------------------- |
+| selected        | No       | <code>let</code> | Yes      | <code>number</code>                       | <code>0</code>                   | Specify the selected tab index               |
+| type            | No       | <code>let</code> | No       | <code>"default" &#124; "container"</code> | <code>"default"</code>           | Specify the type of tabs                     |
+| autoWidth       | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>               | Set to `true` for tabs to have an auto-width |
+| iconDescription | No       | <code>let</code> | No       | <code>string</code>                       | <code>"Show menu options"</code> | Specify the ARIA label for the chevron icon  |
+| triggerHref     | No       | <code>let</code> | No       | <code>string</code>                       | <code>"#"</code>                 | Specify the tab trigger href attribute       |
 
 ### Slots
 
@@ -3928,10 +3928,10 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                                      | Default value          | Description                          |
-| :-------- | :--------------- | :------- | :---------------------------------------- | ---------------------- | ------------------------------------ |
-| count     | <code>let</code> | No       | <code>number</code>                       | <code>4</code>         | Specify the number of tabs to render |
-| type      | <code>let</code> | No       | <code>"default" &#124; "container"</code> | <code>"default"</code> | Specify the type of tabs             |
+| Prop name | Required | Kind             | Reactive | Type                                      | Default value          | Description                          |
+| :-------- | :------- | :--------------- | :------- | ----------------------------------------- | ---------------------- | ------------------------------------ |
+| count     | No       | <code>let</code> | No       | <code>number</code>                       | <code>4</code>         | Specify the number of tabs to render |
+| type      | No       | <code>let</code> | No       | <code>"default" &#124; "container"</code> | <code>"default"</code> | Specify the type of tabs             |
 
 ### Slots
 
@@ -3950,17 +3950,17 @@ None.
 
 ### Props
 
-| Prop name   | Kind             | Reactive | Type                                                                                                                                                                                                     | Default value                                    | Description                                                   |
-| :---------- | :--------------- | :------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ | ------------------------------------------------------------- |
-| type        | <code>let</code> | No       | <code>"red" &#124; "magenta" &#124; "purple" &#124; "blue" &#124; "cyan" &#124; "teal" &#124; "green" &#124; "gray" &#124; "cool-gray" &#124; "warm-gray" &#124; "high-contrast" &#124; "outline"</code> | <code>undefined</code>                           | Specify the type of tag                                       |
-| size        | <code>let</code> | No       | <code>"sm" &#124; "default"</code>                                                                                                                                                                       | <code>"default"</code>                           | --                                                            |
-| filter      | <code>let</code> | No       | <code>boolean</code>                                                                                                                                                                                     | <code>false</code>                               | Set to `true` to use filterable variant                       |
-| disabled    | <code>let</code> | No       | <code>boolean</code>                                                                                                                                                                                     | <code>false</code>                               | Set to `true` to disable a filterable tag                     |
-| interactive | <code>let</code> | No       | <code>boolean</code>                                                                                                                                                                                     | <code>false</code>                               | Set to `true` to render a `button` element instead of a `div` |
-| skeleton    | <code>let</code> | No       | <code>boolean</code>                                                                                                                                                                                     | <code>false</code>                               | Set to `true` to display the skeleton state                   |
-| title       | <code>let</code> | No       | <code>string</code>                                                                                                                                                                                      | <code>"Clear filter"</code>                      | Set the title for the close button in a filterable tag        |
-| icon        | <code>let</code> | No       | <code>typeof import("svelte").SvelteComponent</code>                                                                                                                                                     | <code>undefined</code>                           | Specify the icon to render                                    |
-| id          | <code>let</code> | No       | <code>string</code>                                                                                                                                                                                      | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the filterable tag                              |
+| Prop name   | Required | Kind             | Reactive | Type                                                                                                                                                                                                     | Default value                                    | Description                                                   |
+| :---------- | :------- | :--------------- | :------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ | ------------------------------------------------------------- |
+| type        | No       | <code>let</code> | No       | <code>"red" &#124; "magenta" &#124; "purple" &#124; "blue" &#124; "cyan" &#124; "teal" &#124; "green" &#124; "gray" &#124; "cool-gray" &#124; "warm-gray" &#124; "high-contrast" &#124; "outline"</code> | <code>undefined</code>                           | Specify the type of tag                                       |
+| size        | No       | <code>let</code> | No       | <code>"sm" &#124; "default"</code>                                                                                                                                                                       | <code>"default"</code>                           | --                                                            |
+| filter      | No       | <code>let</code> | No       | <code>boolean</code>                                                                                                                                                                                     | <code>false</code>                               | Set to `true` to use filterable variant                       |
+| disabled    | No       | <code>let</code> | No       | <code>boolean</code>                                                                                                                                                                                     | <code>false</code>                               | Set to `true` to disable a filterable tag                     |
+| interactive | No       | <code>let</code> | No       | <code>boolean</code>                                                                                                                                                                                     | <code>false</code>                               | Set to `true` to render a `button` element instead of a `div` |
+| skeleton    | No       | <code>let</code> | No       | <code>boolean</code>                                                                                                                                                                                     | <code>false</code>                               | Set to `true` to display the skeleton state                   |
+| title       | No       | <code>let</code> | No       | <code>string</code>                                                                                                                                                                                      | <code>"Clear filter"</code>                      | Set the title for the close button in a filterable tag        |
+| icon        | No       | <code>let</code> | No       | <code>typeof import("svelte").SvelteComponent</code>                                                                                                                                                     | <code>undefined</code>                           | Specify the icon to render                                    |
+| id          | No       | <code>let</code> | No       | <code>string</code>                                                                                                                                                                                      | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the filterable tag                              |
 
 ### Slots
 
@@ -3983,9 +3983,9 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                               | Default value          | Description |
-| :-------- | :--------------- | :------- | :--------------------------------- | ---------------------- | ----------- |
-| size      | <code>let</code> | No       | <code>"sm" &#124; "default"</code> | <code>"default"</code> | --          |
+| Prop name | Required | Kind             | Reactive | Type                               | Default value          | Description |
+| :-------- | :------- | :--------------- | :------- | ---------------------------------- | ---------------------- | ----------- |
+| size      | No       | <code>let</code> | No       | <code>"sm" &#124; "default"</code> | <code>"default"</code> | --          |
 
 ### Slots
 
@@ -4004,24 +4004,24 @@ None.
 
 ### Props
 
-| Prop name   | Kind             | Reactive | Type                                         | Default value                                    | Description                                     |
-| :---------- | :--------------- | :------- | :------------------------------------------- | ------------------------------------------------ | ----------------------------------------------- |
-| ref         | <code>let</code> | Yes      | <code>null &#124; HTMLTextAreaElement</code> | <code>null</code>                                | Obtain a reference to the textarea HTML element |
-| value       | <code>let</code> | Yes      | <code>string</code>                          | <code>""</code>                                  | Specify the textarea value                      |
-| placeholder | <code>let</code> | No       | <code>string</code>                          | <code>""</code>                                  | Specify the placeholder text                    |
-| cols        | <code>let</code> | No       | <code>number</code>                          | <code>50</code>                                  | Specify the number of cols                      |
-| rows        | <code>let</code> | No       | <code>number</code>                          | <code>4</code>                                   | Specify the number of rows                      |
-| maxCount    | <code>let</code> | No       | <code>number</code>                          | <code>undefined</code>                           | Specify the max character count                 |
-| light       | <code>let</code> | No       | <code>boolean</code>                         | <code>false</code>                               | Set to `true` to enable the light variant       |
-| disabled    | <code>let</code> | No       | <code>boolean</code>                         | <code>false</code>                               | Set to `true` to disable the input              |
-| readonly    | <code>let</code> | No       | <code>boolean</code>                         | <code>false</code>                               | Set to `true` to use the read-only variant      |
-| helperText  | <code>let</code> | No       | <code>string</code>                          | <code>""</code>                                  | Specify the helper text                         |
-| labelText   | <code>let</code> | No       | <code>string</code>                          | <code>""</code>                                  | Specify the label text                          |
-| hideLabel   | <code>let</code> | No       | <code>boolean</code>                         | <code>false</code>                               | Set to `true` to visually hide the label text   |
-| invalid     | <code>let</code> | No       | <code>boolean</code>                         | <code>false</code>                               | Set to `true` to indicate an invalid state      |
-| invalidText | <code>let</code> | No       | <code>string</code>                          | <code>""</code>                                  | Specify the text for the invalid state          |
-| id          | <code>let</code> | No       | <code>string</code>                          | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the textarea element              |
-| name        | <code>let</code> | No       | <code>string</code>                          | <code>undefined</code>                           | Specify a name attribute for the input          |
+| Prop name   | Required | Kind             | Reactive | Type                                         | Default value                                    | Description                                     |
+| :---------- | :------- | :--------------- | :------- | -------------------------------------------- | ------------------------------------------------ | ----------------------------------------------- |
+| ref         | No       | <code>let</code> | Yes      | <code>null &#124; HTMLTextAreaElement</code> | <code>null</code>                                | Obtain a reference to the textarea HTML element |
+| value       | No       | <code>let</code> | Yes      | <code>string</code>                          | <code>""</code>                                  | Specify the textarea value                      |
+| placeholder | No       | <code>let</code> | No       | <code>string</code>                          | <code>""</code>                                  | Specify the placeholder text                    |
+| cols        | No       | <code>let</code> | No       | <code>number</code>                          | <code>50</code>                                  | Specify the number of cols                      |
+| rows        | No       | <code>let</code> | No       | <code>number</code>                          | <code>4</code>                                   | Specify the number of rows                      |
+| maxCount    | No       | <code>let</code> | No       | <code>number</code>                          | <code>undefined</code>                           | Specify the max character count                 |
+| light       | No       | <code>let</code> | No       | <code>boolean</code>                         | <code>false</code>                               | Set to `true` to enable the light variant       |
+| disabled    | No       | <code>let</code> | No       | <code>boolean</code>                         | <code>false</code>                               | Set to `true` to disable the input              |
+| readonly    | No       | <code>let</code> | No       | <code>boolean</code>                         | <code>false</code>                               | Set to `true` to use the read-only variant      |
+| helperText  | No       | <code>let</code> | No       | <code>string</code>                          | <code>""</code>                                  | Specify the helper text                         |
+| labelText   | No       | <code>let</code> | No       | <code>string</code>                          | <code>""</code>                                  | Specify the label text                          |
+| hideLabel   | No       | <code>let</code> | No       | <code>boolean</code>                         | <code>false</code>                               | Set to `true` to visually hide the label text   |
+| invalid     | No       | <code>let</code> | No       | <code>boolean</code>                         | <code>false</code>                               | Set to `true` to indicate an invalid state      |
+| invalidText | No       | <code>let</code> | No       | <code>string</code>                          | <code>""</code>                                  | Specify the text for the invalid state          |
+| id          | No       | <code>let</code> | No       | <code>string</code>                          | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the textarea element              |
+| name        | No       | <code>let</code> | No       | <code>string</code>                          | <code>undefined</code>                           | Specify a name attribute for the input          |
 
 ### Slots
 
@@ -4048,9 +4048,9 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                 | Default value      | Description                                   |
-| :-------- | :--------------- | :------- | :------------------- | ------------------ | --------------------------------------------- |
-| hideLabel | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to visually hide the label text |
+| Prop name | Required | Kind             | Reactive | Type                 | Default value      | Description                                   |
+| :-------- | :------- | :--------------- | :------- | -------------------- | ------------------ | --------------------------------------------- |
+| hideLabel | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to visually hide the label text |
 
 ### Slots
 
@@ -4069,26 +4069,26 @@ None.
 
 ### Props
 
-| Prop name   | Kind             | Reactive | Type                                          | Default value                                    | Description                                                                                                     |
-| :---------- | :--------------- | :------- | :-------------------------------------------- | ------------------------------------------------ | --------------------------------------------------------------------------------------------------------------- |
-| ref         | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code>     | <code>null</code>                                | Obtain a reference to the input HTML element                                                                    |
-| value       | <code>let</code> | Yes      | <code>null &#124; number &#124; string</code> | <code>""</code>                                  | Specify the input value.<br /><br />`value` will be set to `null` if type="number"<br />and the value is empty. |
-| size        | <code>let</code> | No       | <code>"sm" &#124; "xl"</code>                 | <code>undefined</code>                           | Set the size of the input                                                                                       |
-| placeholder | <code>let</code> | No       | <code>string</code>                           | <code>""</code>                                  | Specify the placeholder text                                                                                    |
-| light       | <code>let</code> | No       | <code>boolean</code>                          | <code>false</code>                               | Set to `true` to enable the light variant                                                                       |
-| disabled    | <code>let</code> | No       | <code>boolean</code>                          | <code>false</code>                               | Set to `true` to disable the input                                                                              |
-| helperText  | <code>let</code> | No       | <code>string</code>                           | <code>""</code>                                  | Specify the helper text                                                                                         |
-| id          | <code>let</code> | No       | <code>string</code>                           | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the input element                                                                                 |
-| name        | <code>let</code> | No       | <code>string</code>                           | <code>undefined</code>                           | Specify a name attribute for the input                                                                          |
-| labelText   | <code>let</code> | No       | <code>string</code>                           | <code>""</code>                                  | Specify the label text                                                                                          |
-| hideLabel   | <code>let</code> | No       | <code>boolean</code>                          | <code>false</code>                               | Set to `true` to visually hide the label text                                                                   |
-| invalid     | <code>let</code> | No       | <code>boolean</code>                          | <code>false</code>                               | Set to `true` to indicate an invalid state                                                                      |
-| invalidText | <code>let</code> | No       | <code>string</code>                           | <code>""</code>                                  | Specify the invalid state text                                                                                  |
-| warn        | <code>let</code> | No       | <code>boolean</code>                          | <code>false</code>                               | Set to `true` to indicate an warning state                                                                      |
-| warnText    | <code>let</code> | No       | <code>string</code>                           | <code>""</code>                                  | Specify the warning state text                                                                                  |
-| required    | <code>let</code> | No       | <code>boolean</code>                          | <code>false</code>                               | Set to `true` to mark the field as required                                                                     |
-| inline      | <code>let</code> | No       | <code>boolean</code>                          | <code>false</code>                               | Set to `true` to use the inline variant                                                                         |
-| readonly    | <code>let</code> | No       | <code>boolean</code>                          | <code>false</code>                               | Set to `true` to use the read-only variant                                                                      |
+| Prop name   | Required | Kind             | Reactive | Type                                          | Default value                                    | Description                                                                                                     |
+| :---------- | :------- | :--------------- | :------- | --------------------------------------------- | ------------------------------------------------ | --------------------------------------------------------------------------------------------------------------- |
+| ref         | No       | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code>     | <code>null</code>                                | Obtain a reference to the input HTML element                                                                    |
+| value       | No       | <code>let</code> | Yes      | <code>null &#124; number &#124; string</code> | <code>""</code>                                  | Specify the input value.<br /><br />`value` will be set to `null` if type="number"<br />and the value is empty. |
+| size        | No       | <code>let</code> | No       | <code>"sm" &#124; "xl"</code>                 | <code>undefined</code>                           | Set the size of the input                                                                                       |
+| placeholder | No       | <code>let</code> | No       | <code>string</code>                           | <code>""</code>                                  | Specify the placeholder text                                                                                    |
+| light       | No       | <code>let</code> | No       | <code>boolean</code>                          | <code>false</code>                               | Set to `true` to enable the light variant                                                                       |
+| disabled    | No       | <code>let</code> | No       | <code>boolean</code>                          | <code>false</code>                               | Set to `true` to disable the input                                                                              |
+| helperText  | No       | <code>let</code> | No       | <code>string</code>                           | <code>""</code>                                  | Specify the helper text                                                                                         |
+| id          | No       | <code>let</code> | No       | <code>string</code>                           | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the input element                                                                                 |
+| name        | No       | <code>let</code> | No       | <code>string</code>                           | <code>undefined</code>                           | Specify a name attribute for the input                                                                          |
+| labelText   | No       | <code>let</code> | No       | <code>string</code>                           | <code>""</code>                                  | Specify the label text                                                                                          |
+| hideLabel   | No       | <code>let</code> | No       | <code>boolean</code>                          | <code>false</code>                               | Set to `true` to visually hide the label text                                                                   |
+| invalid     | No       | <code>let</code> | No       | <code>boolean</code>                          | <code>false</code>                               | Set to `true` to indicate an invalid state                                                                      |
+| invalidText | No       | <code>let</code> | No       | <code>string</code>                           | <code>""</code>                                  | Specify the invalid state text                                                                                  |
+| warn        | No       | <code>let</code> | No       | <code>boolean</code>                          | <code>false</code>                               | Set to `true` to indicate an warning state                                                                      |
+| warnText    | No       | <code>let</code> | No       | <code>string</code>                           | <code>""</code>                                  | Specify the warning state text                                                                                  |
+| required    | No       | <code>let</code> | No       | <code>boolean</code>                          | <code>false</code>                               | Set to `true` to mark the field as required                                                                     |
+| inline      | No       | <code>let</code> | No       | <code>boolean</code>                          | <code>false</code>                               | Set to `true` to use the inline variant                                                                         |
+| readonly    | No       | <code>let</code> | No       | <code>boolean</code>                          | <code>false</code>                               | Set to `true` to use the read-only variant                                                                      |
 
 ### Slots
 
@@ -4115,9 +4115,9 @@ None.
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                 | Default value      | Description                          |
-| :-------- | :--------------- | :------- | :------------------- | ------------------ | ------------------------------------ |
-| hideLabel | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to hide the label text |
+| Prop name | Required | Kind             | Reactive | Type                 | Default value      | Description                          |
+| :-------- | :------- | :--------------- | :------- | -------------------- | ------------------ | ------------------------------------ |
+| hideLabel | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to hide the label text |
 
 ### Slots
 
@@ -4142,15 +4142,15 @@ export type CarbonTheme = "white" | "g10" | "g80" | "g90" | "g100";
 
 ### Props
 
-| Prop name  | Kind             | Reactive | Type                                                                                                           | Default value                                                                                                 | Description                                                                                                                    |
-| :--------- | :--------------- | :------- | :------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| theme      | <code>let</code> | Yes      | <code>CarbonTheme</code>                                                                                       | <code>"white"</code>                                                                                          | Set the current Carbon theme                                                                                                   |
-| tokens     | <code>let</code> | No       | <code>{ [token: string]: any; }</code>                                                                         | <code>{}</code>                                                                                               | Customize a theme with your own tokens<br />@see https://carbondesignsystem.com/guidelines/themes/overview#customizing-a-theme |
-| persist    | <code>let</code> | No       | <code>boolean</code>                                                                                           | <code>false</code>                                                                                            | Set to `true` to persist the theme using window.localStorage                                                                   |
-| persistKey | <code>let</code> | No       | <code>string</code>                                                                                            | <code>"theme"</code>                                                                                          | Specify the local storage key                                                                                                  |
-| render     | <code>let</code> | No       | <code>"toggle" &#124; "select"</code>                                                                          | <code>undefined</code>                                                                                        | Render a toggle or select dropdown to control the theme                                                                        |
-| toggle     | <code>let</code> | No       | <code>import("../Toggle/Toggle").ToggleProps & { themes?: [labelA: CarbonTheme, labelB: CarbonTheme]; }</code> | <code>{ themes: ["white", "g100"], labelA: "", labelB: "", labelText: "Dark mode", hideLabel: false, }</code> | Override the default toggle props                                                                                              |
-| select     | <code>let</code> | No       | <code>import("../Select/Select").SelectProps & { themes?: CarbonTheme[]; }</code>                              | <code>{ themes: themeKeys, labelText: "Themes", hideLabel: false, }</code>                                    | Override the default select props                                                                                              |
+| Prop name  | Required | Kind             | Reactive | Type                                                                                                           | Default value                                                                                                 | Description                                                                                                                    |
+| :--------- | :------- | :--------------- | :------- | -------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| theme      | No       | <code>let</code> | Yes      | <code>CarbonTheme</code>                                                                                       | <code>"white"</code>                                                                                          | Set the current Carbon theme                                                                                                   |
+| tokens     | No       | <code>let</code> | No       | <code>{ [token: string]: any; }</code>                                                                         | <code>{}</code>                                                                                               | Customize a theme with your own tokens<br />@see https://carbondesignsystem.com/guidelines/themes/overview#customizing-a-theme |
+| persist    | No       | <code>let</code> | No       | <code>boolean</code>                                                                                           | <code>false</code>                                                                                            | Set to `true` to persist the theme using window.localStorage                                                                   |
+| persistKey | No       | <code>let</code> | No       | <code>string</code>                                                                                            | <code>"theme"</code>                                                                                          | Specify the local storage key                                                                                                  |
+| render     | No       | <code>let</code> | No       | <code>"toggle" &#124; "select"</code>                                                                          | <code>undefined</code>                                                                                        | Render a toggle or select dropdown to control the theme                                                                        |
+| toggle     | No       | <code>let</code> | No       | <code>import("../Toggle/Toggle").ToggleProps & { themes?: [labelA: CarbonTheme, labelB: CarbonTheme]; }</code> | <code>{ themes: ["white", "g100"], labelA: "", labelB: "", labelText: "Dark mode", hideLabel: false, }</code> | Override the default toggle props                                                                                              |
+| select     | No       | <code>let</code> | No       | <code>import("../Select/Select").SelectProps & { themes?: CarbonTheme[]; }</code>                              | <code>{ themes: themeKeys, labelText: "Themes", hideLabel: false, }</code>                                    | Override the default select props                                                                                              |
 
 ### Slots
 
@@ -4168,9 +4168,9 @@ export type CarbonTheme = "white" | "g10" | "g80" | "g90" | "g100";
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                 | Default value      | Description                               |
-| :-------- | :--------------- | :------- | :------------------- | ------------------ | ----------------------------------------- |
-| light     | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to enable the light variant |
+| Prop name | Required | Kind             | Reactive | Type                 | Default value      | Description                               |
+| :-------- | :------- | :--------------- | :------- | -------------------- | ------------------ | ----------------------------------------- |
+| light     | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to enable the light variant |
 
 ### Slots
 
@@ -4191,11 +4191,11 @@ export type CarbonTheme = "white" | "g10" | "g80" | "g90" | "g100";
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                 | Default value          | Description                             |
-| :-------- | :--------------- | :------- | :------------------- | ---------------------- | --------------------------------------- |
-| selected  | <code>let</code> | Yes      | <code>string</code>  | <code>undefined</code> | Specify the selected tile value         |
-| disabled  | <code>let</code> | No       | <code>boolean</code> | <code>false</code>     | Set to `true` to disable the tile group |
-| legend    | <code>let</code> | No       | <code>string</code>  | <code>""</code>        | Specify the legend text                 |
+| Prop name | Required | Kind             | Reactive | Type                 | Default value          | Description                             |
+| :-------- | :------- | :--------------- | :------- | -------------------- | ---------------------- | --------------------------------------- |
+| selected  | No       | <code>let</code> | Yes      | <code>string</code>  | <code>undefined</code> | Specify the selected tile value         |
+| disabled  | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code>     | Set to `true` to disable the tile group |
+| legend    | No       | <code>let</code> | No       | <code>string</code>  | <code>""</code>        | Specify the legend text                 |
 
 ### Slots
 
@@ -4213,23 +4213,23 @@ export type CarbonTheme = "white" | "g10" | "g80" | "g90" | "g100";
 
 ### Props
 
-| Prop name   | Kind             | Reactive | Type                                      | Default value                                       | Description                                           |
-| :---------- | :--------------- | :------- | :---------------------------------------- | --------------------------------------------------- | ----------------------------------------------------- |
-| ref         | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code> | <code>null</code>                                   | Obtain a reference to the input HTML element          |
-| value       | <code>let</code> | Yes      | <code>string</code>                       | <code>""</code>                                     | Specify the input value                               |
-| size        | <code>let</code> | No       | <code>"sm" &#124; "xl"</code>             | <code>undefined</code>                              | Specify the size of the input                         |
-| type        | <code>let</code> | No       | <code>string</code>                       | <code>"text"</code>                                 | Specify the input type                                |
-| placeholder | <code>let</code> | No       | <code>string</code>                       | <code>"hh:mm"</code>                                | Specify the input placeholder text                    |
-| pattern     | <code>let</code> | No       | <code>string</code>                       | <code>"(1[012]&#124;[1-9]):[0-5][0-9](\\s)?"</code> | Specify the `pattern` attribute for the input element |
-| maxlength   | <code>let</code> | No       | <code>number</code>                       | <code>5</code>                                      | Specify the `maxlength` input attribute               |
-| light       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                                  | Set to `true` to enable the light variant             |
-| disabled    | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                                  | Set to `true` to disable the input                    |
-| labelText   | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                     | Specify the label text                                |
-| hideLabel   | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                                  | Set to `true` to visually hide the label text         |
-| invalid     | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                                  | Set to `true` to indicate an invalid state            |
-| invalidText | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                     | Specify the invalid state text                        |
-| id          | <code>let</code> | No       | <code>string</code>                       | <code>"ccs-" + Math.random().toString(36)</code>    | Set an id for the input element                       |
-| name        | <code>let</code> | No       | <code>string</code>                       | <code>undefined</code>                              | Specify a name attribute for the input                |
+| Prop name   | Required | Kind             | Reactive | Type                                      | Default value                                       | Description                                           |
+| :---------- | :------- | :--------------- | :------- | ----------------------------------------- | --------------------------------------------------- | ----------------------------------------------------- |
+| ref         | No       | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code> | <code>null</code>                                   | Obtain a reference to the input HTML element          |
+| value       | No       | <code>let</code> | Yes      | <code>string</code>                       | <code>""</code>                                     | Specify the input value                               |
+| size        | No       | <code>let</code> | No       | <code>"sm" &#124; "xl"</code>             | <code>undefined</code>                              | Specify the size of the input                         |
+| type        | No       | <code>let</code> | No       | <code>string</code>                       | <code>"text"</code>                                 | Specify the input type                                |
+| placeholder | No       | <code>let</code> | No       | <code>string</code>                       | <code>"hh:mm"</code>                                | Specify the input placeholder text                    |
+| pattern     | No       | <code>let</code> | No       | <code>string</code>                       | <code>"(1[012]&#124;[1-9]):[0-5][0-9](\\s)?"</code> | Specify the `pattern` attribute for the input element |
+| maxlength   | No       | <code>let</code> | No       | <code>number</code>                       | <code>5</code>                                      | Specify the `maxlength` input attribute               |
+| light       | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                                  | Set to `true` to enable the light variant             |
+| disabled    | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                                  | Set to `true` to disable the input                    |
+| labelText   | No       | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                     | Specify the label text                                |
+| hideLabel   | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                                  | Set to `true` to visually hide the label text         |
+| invalid     | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                                  | Set to `true` to indicate an invalid state            |
+| invalidText | No       | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                     | Specify the invalid state text                        |
+| id          | No       | <code>let</code> | No       | <code>string</code>                       | <code>"ccs-" + Math.random().toString(36)</code>    | Set an id for the input element                       |
+| name        | No       | <code>let</code> | No       | <code>string</code>                       | <code>undefined</code>                              | Specify a name attribute for the input                |
 
 ### Slots
 
@@ -4257,15 +4257,15 @@ export type CarbonTheme = "white" | "g10" | "g80" | "g90" | "g100";
 
 ### Props
 
-| Prop name       | Kind             | Reactive | Type                                       | Default value                                    | Description                                     |
-| :-------------- | :--------------- | :------- | :----------------------------------------- | ------------------------------------------------ | ----------------------------------------------- |
-| ref             | <code>let</code> | Yes      | <code>null &#124; HTMLSelectElement</code> | <code>null</code>                                | Obtain a reference to the select HTML element   |
-| value           | <code>let</code> | Yes      | <code>number &#124; string</code>          | <code>""</code>                                  | Specify the select value                        |
-| disabled        | <code>let</code> | No       | <code>boolean</code>                       | <code>false</code>                               | Set to `true` to disable the select             |
-| iconDescription | <code>let</code> | No       | <code>string</code>                        | <code>"Open list of options"</code>              | Specify the ARIA label for the chevron icon     |
-| labelText       | <code>let</code> | No       | <code>string</code>                        | <code>""</code>                                  | Specify the label text                          |
-| id              | <code>let</code> | No       | <code>string</code>                        | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the select element                |
-| name            | <code>let</code> | No       | <code>string</code>                        | <code>undefined</code>                           | Specify a name attribute for the select element |
+| Prop name       | Required | Kind             | Reactive | Type                                       | Default value                                    | Description                                     |
+| :-------------- | :------- | :--------------- | :------- | ------------------------------------------ | ------------------------------------------------ | ----------------------------------------------- |
+| ref             | No       | <code>let</code> | Yes      | <code>null &#124; HTMLSelectElement</code> | <code>null</code>                                | Obtain a reference to the select HTML element   |
+| value           | No       | <code>let</code> | Yes      | <code>number &#124; string</code>          | <code>""</code>                                  | Specify the select value                        |
+| disabled        | No       | <code>let</code> | No       | <code>boolean</code>                       | <code>false</code>                               | Set to `true` to disable the select             |
+| iconDescription | No       | <code>let</code> | No       | <code>string</code>                        | <code>"Open list of options"</code>              | Specify the ARIA label for the chevron icon     |
+| labelText       | No       | <code>let</code> | No       | <code>string</code>                        | <code>""</code>                                  | Specify the label text                          |
+| id              | No       | <code>let</code> | No       | <code>string</code>                        | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the select element                |
+| name            | No       | <code>let</code> | No       | <code>string</code>                        | <code>undefined</code>                           | Specify a name attribute for the select element |
 
 ### Slots
 
@@ -4287,17 +4287,17 @@ export type CarbonTheme = "white" | "g10" | "g80" | "g90" | "g100";
 
 ### Props
 
-| Prop name       | Kind             | Reactive | Type                                                                                                           | Default value                      | Description                                                             |
-| :-------------- | :--------------- | :------- | :------------------------------------------------------------------------------------------------------------- | ---------------------------------- | ----------------------------------------------------------------------- |
-| kind            | <code>let</code> | No       | <code>"error" &#124; "info" &#124; "info-square" &#124; "success" &#124; "warning" &#124; "warning-alt"</code> | <code>"error"</code>               | Specify the kind of notification                                        |
-| lowContrast     | <code>let</code> | No       | <code>boolean</code>                                                                                           | <code>false</code>                 | Set to `true` to use the low contrast variant                           |
-| timeout         | <code>let</code> | No       | <code>number</code>                                                                                            | <code>0</code>                     | Set the timeout duration (ms) to hide the notification after opening it |
-| role            | <code>let</code> | No       | <code>string</code>                                                                                            | <code>"alert"</code>               | Set the `role` attribute                                                |
-| title           | <code>let</code> | No       | <code>string</code>                                                                                            | <code>""</code>                    | Specify the title text                                                  |
-| subtitle        | <code>let</code> | No       | <code>string</code>                                                                                            | <code>""</code>                    | Specify the subtitle text                                               |
-| caption         | <code>let</code> | No       | <code>string</code>                                                                                            | <code>""</code>                    | Specify the caption text                                                |
-| iconDescription | <code>let</code> | No       | <code>string</code>                                                                                            | <code>"Closes notification"</code> | Specify the ARIA label for the icon                                     |
-| hideCloseButton | <code>let</code> | No       | <code>boolean</code>                                                                                           | <code>false</code>                 | Set to `true` to hide the close button                                  |
+| Prop name       | Required | Kind             | Reactive | Type                                                                                                           | Default value                      | Description                                                             |
+| :-------------- | :------- | :--------------- | :------- | -------------------------------------------------------------------------------------------------------------- | ---------------------------------- | ----------------------------------------------------------------------- |
+| kind            | No       | <code>let</code> | No       | <code>"error" &#124; "info" &#124; "info-square" &#124; "success" &#124; "warning" &#124; "warning-alt"</code> | <code>"error"</code>               | Specify the kind of notification                                        |
+| lowContrast     | No       | <code>let</code> | No       | <code>boolean</code>                                                                                           | <code>false</code>                 | Set to `true` to use the low contrast variant                           |
+| timeout         | No       | <code>let</code> | No       | <code>number</code>                                                                                            | <code>0</code>                     | Set the timeout duration (ms) to hide the notification after opening it |
+| role            | No       | <code>let</code> | No       | <code>string</code>                                                                                            | <code>"alert"</code>               | Set the `role` attribute                                                |
+| title           | No       | <code>let</code> | No       | <code>string</code>                                                                                            | <code>""</code>                    | Specify the title text                                                  |
+| subtitle        | No       | <code>let</code> | No       | <code>string</code>                                                                                            | <code>""</code>                    | Specify the subtitle text                                               |
+| caption         | No       | <code>let</code> | No       | <code>string</code>                                                                                            | <code>""</code>                    | Specify the caption text                                                |
+| iconDescription | No       | <code>let</code> | No       | <code>string</code>                                                                                            | <code>"Closes notification"</code> | Specify the ARIA label for the icon                                     |
+| hideCloseButton | No       | <code>let</code> | No       | <code>boolean</code>                                                                                           | <code>false</code>                 | Set to `true` to hide the close button                                  |
 
 ### Slots
 
@@ -4322,16 +4322,16 @@ export type CarbonTheme = "white" | "g10" | "g80" | "g90" | "g100";
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                               | Default value                                    | Description                                     |
-| :-------- | :--------------- | :------- | :--------------------------------- | ------------------------------------------------ | ----------------------------------------------- |
-| toggled   | <code>let</code> | Yes      | <code>boolean</code>               | <code>false</code>                               | Set to `true` to toggle the checkbox input      |
-| size      | <code>let</code> | No       | <code>"default" &#124; "sm"</code> | <code>"default"</code>                           | Specify the toggle size                         |
-| disabled  | <code>let</code> | No       | <code>boolean</code>               | <code>false</code>                               | Set to `true` to disable checkbox input         |
-| labelA    | <code>let</code> | No       | <code>string</code>                | <code>"Off"</code>                               | Specify the label for the untoggled state       |
-| labelB    | <code>let</code> | No       | <code>string</code>                | <code>"On"</code>                                | Specify the label for the toggled state         |
-| labelText | <code>let</code> | No       | <code>string</code>                | <code>""</code>                                  | Specify the label text                          |
-| id        | <code>let</code> | No       | <code>string</code>                | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the input element                 |
-| name      | <code>let</code> | No       | <code>string</code>                | <code>undefined</code>                           | Specify a name attribute for the checkbox input |
+| Prop name | Required | Kind             | Reactive | Type                               | Default value                                    | Description                                     |
+| :-------- | :------- | :--------------- | :------- | ---------------------------------- | ------------------------------------------------ | ----------------------------------------------- |
+| toggled   | No       | <code>let</code> | Yes      | <code>boolean</code>               | <code>false</code>                               | Set to `true` to toggle the checkbox input      |
+| size      | No       | <code>let</code> | No       | <code>"default" &#124; "sm"</code> | <code>"default"</code>                           | Specify the toggle size                         |
+| disabled  | No       | <code>let</code> | No       | <code>boolean</code>               | <code>false</code>                               | Set to `true` to disable checkbox input         |
+| labelA    | No       | <code>let</code> | No       | <code>string</code>                | <code>"Off"</code>                               | Specify the label for the untoggled state       |
+| labelB    | No       | <code>let</code> | No       | <code>string</code>                | <code>"On"</code>                                | Specify the label for the toggled state         |
+| labelText | No       | <code>let</code> | No       | <code>string</code>                | <code>""</code>                                  | Specify the label text                          |
+| id        | No       | <code>let</code> | No       | <code>string</code>                | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the input element                 |
+| name      | No       | <code>let</code> | No       | <code>string</code>                | <code>undefined</code>                           | Specify a name attribute for the checkbox input |
 
 ### Slots
 
@@ -4359,11 +4359,11 @@ export type CarbonTheme = "white" | "g10" | "g80" | "g90" | "g100";
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                               | Default value                                    | Description                     |
-| :-------- | :--------------- | :------- | :--------------------------------- | ------------------------------------------------ | ------------------------------- |
-| size      | <code>let</code> | No       | <code>"default" &#124; "sm"</code> | <code>"default"</code>                           | Specify the toggle size         |
-| labelText | <code>let</code> | No       | <code>string</code>                | <code>""</code>                                  | Specify the label text          |
-| id        | <code>let</code> | No       | <code>string</code>                | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the input element |
+| Prop name | Required | Kind             | Reactive | Type                               | Default value                                    | Description                     |
+| :-------- | :------- | :--------------- | :------- | ---------------------------------- | ------------------------------------------------ | ------------------------------- |
+| size      | No       | <code>let</code> | No       | <code>"default" &#124; "sm"</code> | <code>"default"</code>                           | Specify the toggle size         |
+| labelText | No       | <code>let</code> | No       | <code>string</code>                | <code>""</code>                                  | Specify the label text          |
+| id        | No       | <code>let</code> | No       | <code>string</code>                | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the input element |
 
 ### Slots
 
@@ -4384,9 +4384,9 @@ export type CarbonTheme = "white" | "g10" | "g80" | "g90" | "g100";
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                               | Default value          | Description              |
-| :-------- | :--------------- | :------- | :--------------------------------- | ---------------------- | ------------------------ |
-| size      | <code>let</code> | No       | <code>"sm" &#124; "default"</code> | <code>"default"</code> | Specify the toolbar size |
+| Prop name | Required | Kind             | Reactive | Type                               | Default value          | Description              |
+| :-------- | :------- | :--------------- | :------- | ---------------------------------- | ---------------------- | ------------------------ |
+| size      | No       | <code>let</code> | No       | <code>"sm" &#124; "default"</code> | <code>"default"</code> | Specify the toolbar size |
 
 ### Slots
 
@@ -4402,9 +4402,9 @@ None.
 
 ### Props
 
-| Prop name           | Kind             | Reactive | Type                                           | Default value                                                                                       | Description                            |
-| :------------------ | :--------------- | :------- | :--------------------------------------------- | --------------------------------------------------------------------------------------------------- | -------------------------------------- |
-| formatTotalSelected | <code>let</code> | No       | <code>(totalSelected: number) => string</code> | <code>(totalSelected) => \`${totalSelected} item${totalSelected === 1 ? "" : "s"} selected\`</code> | Override the total items selected text |
+| Prop name           | Required | Kind             | Reactive | Type                                           | Default value                                                                                       | Description                            |
+| :------------------ | :------- | :--------------- | :------- | ---------------------------------------------- | --------------------------------------------------------------------------------------------------- | -------------------------------------- |
+| formatTotalSelected | No       | <code>let</code> | No       | <code>(totalSelected: number) => string</code> | <code>(totalSelected) => \`${totalSelected} item${totalSelected === 1 ? "" : "s"} selected\`</code> | Override the total items selected text |
 
 ### Slots
 
@@ -4472,15 +4472,15 @@ None.
 
 ### Props
 
-| Prop name        | Kind             | Reactive | Type                                                                                                                   | Default value      | Description                                                                                                                                                                                                                                                                                                                                     |
-| :--------------- | :--------------- | :------- | :--------------------------------------------------------------------------------------------------------------------- | ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| ref              | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code>                                                                              | <code>null</code>  | Obtain a reference to the input HTML element                                                                                                                                                                                                                                                                                                    |
-| expanded         | <code>let</code> | Yes      | <code>boolean</code>                                                                                                   | <code>false</code> | Set to `true` to expand the search bar                                                                                                                                                                                                                                                                                                          |
-| value            | <code>let</code> | Yes      | <code>number &#124; string</code>                                                                                      | <code>""</code>    | Specify the value of the search input                                                                                                                                                                                                                                                                                                           |
-| persistent       | <code>let</code> | No       | <code>boolean</code>                                                                                                   | <code>false</code> | Set to `true` to keep the search bar expanded                                                                                                                                                                                                                                                                                                   |
-| disabled         | <code>let</code> | No       | <code>boolean</code>                                                                                                   | <code>false</code> | Set to `true` to disable the search bar                                                                                                                                                                                                                                                                                                         |
-| shouldFilterRows | <code>let</code> | No       | <code>boolean &#124; ((row: import("./DataTable.svelte").DataTableRow, value: number &#124; string) => boolean)</code> | <code>false</code> | Set to `true` to filter table rows using the search value.<br /><br />If `true`, the default search excludes `id`, `cells` fields and<br />only does a basic comparison on string and number type cell values.<br /><br />To implement your own client-side filtering, pass a function<br />that accepts a row and value and returns a boolean. |
-| tabindex         | <code>let</code> | No       | <code>string</code>                                                                                                    | <code>"0"</code>   | Specify the tabindex                                                                                                                                                                                                                                                                                                                            |
+| Prop name        | Required | Kind             | Reactive | Type                                                                                                                   | Default value      | Description                                                                                                                                                                                                                                                                                                                                     |
+| :--------------- | :------- | :--------------- | :------- | ---------------------------------------------------------------------------------------------------------------------- | ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ref              | No       | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code>                                                                              | <code>null</code>  | Obtain a reference to the input HTML element                                                                                                                                                                                                                                                                                                    |
+| expanded         | No       | <code>let</code> | Yes      | <code>boolean</code>                                                                                                   | <code>false</code> | Set to `true` to expand the search bar                                                                                                                                                                                                                                                                                                          |
+| value            | No       | <code>let</code> | Yes      | <code>number &#124; string</code>                                                                                      | <code>""</code>    | Specify the value of the search input                                                                                                                                                                                                                                                                                                           |
+| persistent       | No       | <code>let</code> | No       | <code>boolean</code>                                                                                                   | <code>false</code> | Set to `true` to keep the search bar expanded                                                                                                                                                                                                                                                                                                   |
+| disabled         | No       | <code>let</code> | No       | <code>boolean</code>                                                                                                   | <code>false</code> | Set to `true` to disable the search bar                                                                                                                                                                                                                                                                                                         |
+| shouldFilterRows | No       | <code>let</code> | No       | <code>boolean &#124; ((row: import("./DataTable.svelte").DataTableRow, value: number &#124; string) => boolean)</code> | <code>false</code> | Set to `true` to filter table rows using the search value.<br /><br />If `true`, the default search excludes `id`, `cells` fields and<br />only does a basic comparison on string and number type cell values.<br /><br />To implement your own client-side filtering, pass a function<br />that accepts a row and value and returns a boolean. |
+| tabindex         | No       | <code>let</code> | No       | <code>string</code>                                                                                                    | <code>"0"</code>   | Specify the tabindex                                                                                                                                                                                                                                                                                                                            |
 
 ### Slots
 
@@ -4500,22 +4500,22 @@ None.
 
 ### Props
 
-| Prop name       | Kind             | Reactive | Type                                                            | Default value                                    | Description                                                                                |
-| :-------------- | :--------------- | :------- | :-------------------------------------------------------------- | ------------------------------------------------ | ------------------------------------------------------------------------------------------ |
-| refIcon         | <code>let</code> | Yes      | <code>null &#124; HTMLDivElement</code>                         | <code>null</code>                                | Obtain a reference to the icon HTML element                                                |
-| refTooltip      | <code>let</code> | Yes      | <code>null &#124; HTMLDivElement</code>                         | <code>null</code>                                | Obtain a reference to the tooltip HTML element                                             |
-| ref             | <code>let</code> | Yes      | <code>null &#124; HTMLDivElement</code>                         | <code>null</code>                                | Obtain a reference to the trigger text HTML element                                        |
-| open            | <code>let</code> | Yes      | <code>boolean</code>                                            | <code>false</code>                               | Set to `true` to open the tooltip                                                          |
-| align           | <code>let</code> | No       | <code>"start" &#124; "center" &#124; "end"</code>               | <code>"center"</code>                            | Set the alignment of the tooltip relative to the icon                                      |
-| direction       | <code>let</code> | No       | <code>"top" &#124; "right" &#124; "bottom" &#124; "left"</code> | <code>"bottom"</code>                            | Set the direction of the tooltip relative to the button                                    |
-| hideIcon        | <code>let</code> | No       | <code>boolean</code>                                            | <code>false</code>                               | Set to `true` to hide the tooltip icon                                                     |
-| icon            | <code>let</code> | No       | <code>typeof import("svelte").SvelteComponent</code>            | <code>undefined</code>                           | Specify the icon to render for the tooltip button.<br />Default to `&lt;Information /&gt;` |
-| iconDescription | <code>let</code> | No       | <code>string</code>                                             | <code>""</code>                                  | Specify the ARIA label for the tooltip button                                              |
-| iconName        | <code>let</code> | No       | <code>string</code>                                             | <code>""</code>                                  | Specify the icon name attribute                                                            |
-| tabindex        | <code>let</code> | No       | <code>string</code>                                             | <code>"0"</code>                                 | Set the button tabindex                                                                    |
-| tooltipId       | <code>let</code> | No       | <code>string</code>                                             | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the tooltip                                                                  |
-| triggerId       | <code>let</code> | No       | <code>string</code>                                             | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the tooltip button                                                           |
-| triggerText     | <code>let</code> | No       | <code>string</code>                                             | <code>""</code>                                  | Set the tooltip button text                                                                |
+| Prop name       | Required | Kind             | Reactive | Type                                                            | Default value                                    | Description                                                                                |
+| :-------------- | :------- | :--------------- | :------- | --------------------------------------------------------------- | ------------------------------------------------ | ------------------------------------------------------------------------------------------ |
+| refIcon         | No       | <code>let</code> | Yes      | <code>null &#124; HTMLDivElement</code>                         | <code>null</code>                                | Obtain a reference to the icon HTML element                                                |
+| refTooltip      | No       | <code>let</code> | Yes      | <code>null &#124; HTMLDivElement</code>                         | <code>null</code>                                | Obtain a reference to the tooltip HTML element                                             |
+| ref             | No       | <code>let</code> | Yes      | <code>null &#124; HTMLDivElement</code>                         | <code>null</code>                                | Obtain a reference to the trigger text HTML element                                        |
+| open            | No       | <code>let</code> | Yes      | <code>boolean</code>                                            | <code>false</code>                               | Set to `true` to open the tooltip                                                          |
+| align           | No       | <code>let</code> | No       | <code>"start" &#124; "center" &#124; "end"</code>               | <code>"center"</code>                            | Set the alignment of the tooltip relative to the icon                                      |
+| direction       | No       | <code>let</code> | No       | <code>"top" &#124; "right" &#124; "bottom" &#124; "left"</code> | <code>"bottom"</code>                            | Set the direction of the tooltip relative to the button                                    |
+| hideIcon        | No       | <code>let</code> | No       | <code>boolean</code>                                            | <code>false</code>                               | Set to `true` to hide the tooltip icon                                                     |
+| icon            | No       | <code>let</code> | No       | <code>typeof import("svelte").SvelteComponent</code>            | <code>undefined</code>                           | Specify the icon to render for the tooltip button.<br />Default to `&lt;Information /&gt;` |
+| iconDescription | No       | <code>let</code> | No       | <code>string</code>                                             | <code>""</code>                                  | Specify the ARIA label for the tooltip button                                              |
+| iconName        | No       | <code>let</code> | No       | <code>string</code>                                             | <code>""</code>                                  | Specify the icon name attribute                                                            |
+| tabindex        | No       | <code>let</code> | No       | <code>string</code>                                             | <code>"0"</code>                                 | Set the button tabindex                                                                    |
+| tooltipId       | No       | <code>let</code> | No       | <code>string</code>                                             | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the tooltip                                                                  |
+| triggerId       | No       | <code>let</code> | No       | <code>string</code>                                             | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the tooltip button                                                           |
+| triggerText     | No       | <code>let</code> | No       | <code>string</code>                                             | <code>""</code>                                  | Set the tooltip button text                                                                |
 
 ### Slots
 
@@ -4538,14 +4538,14 @@ None.
 
 ### Props
 
-| Prop name   | Kind             | Reactive | Type                                              | Default value                                    | Description                                           |
-| :---------- | :--------------- | :------- | :------------------------------------------------ | ------------------------------------------------ | ----------------------------------------------------- |
-| ref         | <code>let</code> | Yes      | <code>null &#124; HTMLButtonElement</code>        | <code>null</code>                                | Obtain a reference to the button HTML element         |
-| open        | <code>let</code> | Yes      | <code>boolean</code>                              | <code>false</code>                               | Set to `true` to open the tooltip                     |
-| tooltipText | <code>let</code> | No       | <code>string</code>                               | <code>""</code>                                  | Specify the tooltip text                              |
-| align       | <code>let</code> | No       | <code>"start" &#124; "center" &#124; "end"</code> | <code>"center"</code>                            | Set the alignment of the tooltip relative to the icon |
-| direction   | <code>let</code> | No       | <code>"top" &#124; "bottom"</code>                | <code>"bottom"</code>                            | Set the direction of the tooltip relative to the icon |
-| id          | <code>let</code> | No       | <code>string</code>                               | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the tooltip div element                 |
+| Prop name   | Required | Kind             | Reactive | Type                                              | Default value                                    | Description                                           |
+| :---------- | :------- | :--------------- | :------- | ------------------------------------------------- | ------------------------------------------------ | ----------------------------------------------------- |
+| ref         | No       | <code>let</code> | Yes      | <code>null &#124; HTMLButtonElement</code>        | <code>null</code>                                | Obtain a reference to the button HTML element         |
+| open        | No       | <code>let</code> | Yes      | <code>boolean</code>                              | <code>false</code>                               | Set to `true` to open the tooltip                     |
+| tooltipText | No       | <code>let</code> | No       | <code>string</code>                               | <code>""</code>                                  | Specify the tooltip text                              |
+| align       | No       | <code>let</code> | No       | <code>"start" &#124; "center" &#124; "end"</code> | <code>"center"</code>                            | Set the alignment of the tooltip relative to the icon |
+| direction   | No       | <code>let</code> | No       | <code>"top" &#124; "bottom"</code>                | <code>"bottom"</code>                            | Set the direction of the tooltip relative to the icon |
+| id          | No       | <code>let</code> | No       | <code>string</code>                               | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the tooltip div element                 |
 
 ### Slots
 
@@ -4570,9 +4570,9 @@ None.
 
 ### Props
 
-| Prop name            | Kind             | Reactive | Type                | Default value                                  | Description                                                                 |
-| :------------------- | :--------------- | :------- | :------------------ | ---------------------------------------------- | --------------------------------------------------------------------------- |
-| selectorPrimaryFocus | <code>let</code> | No       | <code>string</code> | <code>"a[href], button:not([disabled])"</code> | Specify a selector to be focused inside the footer when opening the tooltip |
+| Prop name            | Required | Kind             | Reactive | Type                | Default value                                  | Description                                                                 |
+| :------------------- | :------- | :--------------- | :------- | ------------------- | ---------------------------------------------- | --------------------------------------------------------------------------- |
+| selectorPrimaryFocus | No       | <code>let</code> | No       | <code>string</code> | <code>"a[href], button:not([disabled])"</code> | Specify a selector to be focused inside the footer when opening the tooltip |
 
 ### Slots
 
@@ -4588,15 +4588,15 @@ None.
 
 ### Props
 
-| Prop name   | Kind             | Reactive | Type                                                            | Default value                                    | Description                                                              |
-| :---------- | :--------------- | :------- | :-------------------------------------------------------------- | ------------------------------------------------ | ------------------------------------------------------------------------ |
-| ref         | <code>let</code> | Yes      | <code>null &#124; HTMLButtonElement</code>                      | <code>null</code>                                | Obtain a reference to the button HTML element                            |
-| tooltipText | <code>let</code> | No       | <code>string</code>                                             | <code>""</code>                                  | Specify the tooltip text.<br />Alternatively, use the "tooltipText" slot |
-| icon        | <code>let</code> | No       | <code>typeof import("svelte").SvelteComponent</code>            | <code>undefined</code>                           | Specify the icon to render                                               |
-| disabled    | <code>let</code> | No       | <code>boolean</code>                                            | <code>false</code>                               | Set to `true` to disable the tooltip icon                                |
-| align       | <code>let</code> | No       | <code>"start" &#124; "center" &#124; "end"</code>               | <code>"center"</code>                            | Set the alignment of the tooltip relative to the icon                    |
-| direction   | <code>let</code> | No       | <code>"top" &#124; "right" &#124; "bottom" &#124; "left"</code> | <code>"bottom"</code>                            | Set the direction of the tooltip relative to the icon                    |
-| id          | <code>let</code> | No       | <code>string</code>                                             | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the span element                                           |
+| Prop name   | Required | Kind             | Reactive | Type                                                            | Default value                                    | Description                                                              |
+| :---------- | :------- | :--------------- | :------- | --------------------------------------------------------------- | ------------------------------------------------ | ------------------------------------------------------------------------ |
+| ref         | No       | <code>let</code> | Yes      | <code>null &#124; HTMLButtonElement</code>                      | <code>null</code>                                | Obtain a reference to the button HTML element                            |
+| tooltipText | No       | <code>let</code> | No       | <code>string</code>                                             | <code>""</code>                                  | Specify the tooltip text.<br />Alternatively, use the "tooltipText" slot |
+| icon        | No       | <code>let</code> | No       | <code>typeof import("svelte").SvelteComponent</code>            | <code>undefined</code>                           | Specify the icon to render                                               |
+| disabled    | No       | <code>let</code> | No       | <code>boolean</code>                                            | <code>false</code>                               | Set to `true` to disable the tooltip icon                                |
+| align       | No       | <code>let</code> | No       | <code>"start" &#124; "center" &#124; "end"</code>               | <code>"center"</code>                            | Set the alignment of the tooltip relative to the icon                    |
+| direction   | No       | <code>let</code> | No       | <code>"top" &#124; "right" &#124; "bottom" &#124; "left"</code> | <code>"bottom"</code>                            | Set the direction of the tooltip relative to the icon                    |
+| id          | No       | <code>let</code> | No       | <code>string</code>                                             | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the span element                                           |
 
 ### Slots
 
@@ -4633,19 +4633,19 @@ export interface TreeNode {
 
 ### Props
 
-| Prop name     | Kind                  | Reactive | Type                                                          | Default value                                                                                                                                                                              | Description                                                                                      |
-| :------------ | :-------------------- | :------- | :------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------ |
-| expandedIds   | <code>let</code>      | Yes      | <code>TreeNodeId[]</code>                                     | <code>[]</code>                                                                                                                                                                            | Set the node ids to be expanded                                                                  |
-| selectedIds   | <code>let</code>      | Yes      | <code>TreeNodeId[]</code>                                     | <code>[]</code>                                                                                                                                                                            | Set the node ids to be selected                                                                  |
-| activeId      | <code>let</code>      | Yes      | <code>TreeNodeId</code>                                       | <code>""</code>                                                                                                                                                                            | Set the current active node id<br />Only one node can be active                                  |
-| children      | <code>let</code>      | No       | <code>Array<TreeNode & { children?: TreeNode[] }></code>      | <code>[]</code>                                                                                                                                                                            | Provide an array of children nodes to render                                                     |
-| size          | <code>let</code>      | No       | <code>"default" &#124; "compact"</code>                       | <code>"default"</code>                                                                                                                                                                     | Specify the TreeView size                                                                        |
-| labelText     | <code>let</code>      | No       | <code>string</code>                                           | <code>""</code>                                                                                                                                                                            | Specify the label text                                                                           |
-| hideLabel     | <code>let</code>      | No       | <code>boolean</code>                                          | <code>false</code>                                                                                                                                                                         | Set to `true` to visually hide the label text                                                    |
-| expandAll     | <code>function</code> | No       | <code>() => void</code>                                       | <code>() => { expandedIds = [...nodeIds]; }</code>                                                                                                                                         | Programmatically expand all nodes                                                                |
-| collapseAll   | <code>function</code> | No       | <code>() => void</code>                                       | <code>() => { expandedIds = []; }</code>                                                                                                                                                   | Programmatically collapse all nodes                                                              |
-| expandNodes   | <code>function</code> | No       | <code>(filterId?: (node: TreeNode) => boolean) => void</code> | <code>() => { expandedIds = nodes .filter( (node) => filterNode(node) &#124;&#124; node.children?.some((child) => filterNode(child) && child.children) ) .map((node) => node.id); }</code> | Programmatically expand a subset of nodes.<br />Expands all nodes if no argument is provided     |
-| collapseNodes | <code>function</code> | No       | <code>(filterId?: (node: TreeNode) => boolean) => void</code> | <code>() => { expandedIds = nodes .filter((node) => expandedIds.includes(node.id) && !filterNode(node)) .map((node) => node.id); }</code>                                                  | Programmatically collapse a subset of nodes.<br />Collapses all nodes if no argument is provided |
+| Prop name     | Required | Kind                  | Reactive | Type                                                          | Default value                                                                                                                                                                              | Description                                                                                      |
+| :------------ | :------- | :-------------------- | :------- | ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------ |
+| expandedIds   | No       | <code>let</code>      | Yes      | <code>TreeNodeId[]</code>                                     | <code>[]</code>                                                                                                                                                                            | Set the node ids to be expanded                                                                  |
+| selectedIds   | No       | <code>let</code>      | Yes      | <code>TreeNodeId[]</code>                                     | <code>[]</code>                                                                                                                                                                            | Set the node ids to be selected                                                                  |
+| activeId      | No       | <code>let</code>      | Yes      | <code>TreeNodeId</code>                                       | <code>""</code>                                                                                                                                                                            | Set the current active node id<br />Only one node can be active                                  |
+| children      | No       | <code>let</code>      | No       | <code>Array<TreeNode & { children?: TreeNode[] }></code>      | <code>[]</code>                                                                                                                                                                            | Provide an array of children nodes to render                                                     |
+| size          | No       | <code>let</code>      | No       | <code>"default" &#124; "compact"</code>                       | <code>"default"</code>                                                                                                                                                                     | Specify the TreeView size                                                                        |
+| labelText     | No       | <code>let</code>      | No       | <code>string</code>                                           | <code>""</code>                                                                                                                                                                            | Specify the label text                                                                           |
+| hideLabel     | No       | <code>let</code>      | No       | <code>boolean</code>                                          | <code>false</code>                                                                                                                                                                         | Set to `true` to visually hide the label text                                                    |
+| expandAll     | No       | <code>function</code> | No       | <code>() => void</code>                                       | <code>() => { expandedIds = [...nodeIds]; }</code>                                                                                                                                         | Programmatically expand all nodes                                                                |
+| collapseAll   | No       | <code>function</code> | No       | <code>() => void</code>                                       | <code>() => { expandedIds = []; }</code>                                                                                                                                                   | Programmatically collapse all nodes                                                              |
+| expandNodes   | No       | <code>function</code> | No       | <code>(filterId?: (node: TreeNode) => boolean) => void</code> | <code>() => { expandedIds = nodes .filter( (node) => filterNode(node) &#124;&#124; node.children?.some((child) => filterNode(child) && child.children) ) .map((node) => node.id); }</code> | Programmatically expand a subset of nodes.<br />Expands all nodes if no argument is provided     |
+| collapseNodes | No       | <code>function</code> | No       | <code>(filterId?: (node: TreeNode) => boolean) => void</code> | <code>() => { expandedIds = nodes .filter((node) => expandedIds.includes(node.id) && !filterNode(node)) .map((node) => node.id); }</code>                                                  | Programmatically collapse a subset of nodes.<br />Collapses all nodes if no argument is provided |
 
 ### Slots
 
@@ -4666,9 +4666,9 @@ export interface TreeNode {
 
 ### Props
 
-| Prop name | Kind             | Reactive | Type                              | Default value      | Description |
-| :-------- | :--------------- | :------- | :-------------------------------- | ------------------ | ----------- |
-| clamp     | <code>let</code> | No       | <code>"end" &#124; "front"</code> | <code>"end"</code> | --          |
+| Prop name | Required | Kind             | Reactive | Type                              | Default value      | Description |
+| :-------- | :------- | :--------------- | :------- | --------------------------------- | ------------------ | ----------- |
+| clamp     | No       | <code>let</code> | No       | <code>"end" &#124; "front"</code> | <code>"end"</code> | --          |
 
 ### Slots
 
@@ -4684,10 +4684,10 @@ None.
 
 ### Props
 
-| Prop name  | Kind             | Reactive | Type                 | Default value      | Description                                          |
-| :--------- | :--------------- | :------- | :------------------- | ------------------ | ---------------------------------------------------- |
-| nested     | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use the nested variant              |
-| expressive | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use Carbon's expressive typesetting |
+| Prop name  | Required | Kind             | Reactive | Type                 | Default value      | Description                                          |
+| :--------- | :------- | :--------------- | :------- | -------------------- | ------------------ | ---------------------------------------------------- |
+| nested     | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use the nested variant              |
+| expressive | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to use Carbon's expressive typesetting |
 
 ### Slots
 

--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -13,6 +13,7 @@
           "value": "\"end\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -23,6 +24,7 @@
           "type": "\"sm\" | \"xl\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -34,6 +36,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -45,6 +48,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -92,6 +96,7 @@
           "value": "\"title\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -103,6 +108,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -114,6 +120,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -125,6 +132,7 @@
           "value": "\"Expand/Collapse\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -162,6 +170,7 @@
           "value": "4",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -173,6 +182,7 @@
           "value": "\"end\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -183,6 +193,7 @@
           "type": "\"sm\" | \"xl\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -194,6 +205,7 @@
           "value": "true",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -221,6 +233,7 @@
           "value": "\"2x1\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -243,6 +256,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -254,6 +268,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -300,6 +315,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -311,6 +327,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -344,6 +361,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -355,6 +373,7 @@
           "value": "3",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -381,6 +400,7 @@
           "type": "BreakpointSize",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -392,6 +412,7 @@
           "value": "{     sm: false,     md: false,     lg: false,     xlg: false,     max: false,   }",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -436,6 +457,7 @@
           "value": "\"primary\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -447,6 +469,7 @@
           "value": "\"default\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -458,6 +481,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -469,6 +493,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -479,6 +504,7 @@
           "type": "typeof import(\"svelte\").SvelteComponent",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -489,6 +515,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -500,6 +527,7 @@
           "value": "\"center\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -511,6 +539,7 @@
           "value": "\"bottom\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -522,6 +551,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -533,6 +563,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -544,6 +575,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -554,6 +586,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -565,6 +598,7 @@
           "value": "\"0\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -576,6 +610,7 @@
           "value": "\"button\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -587,6 +622,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -636,6 +672,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -657,6 +694,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -668,6 +706,7 @@
           "value": "\"default\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -695,6 +734,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -706,6 +746,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -716,6 +757,7 @@
           "type": "any[]",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -727,6 +769,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -738,6 +781,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -749,6 +793,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -760,6 +805,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -771,6 +817,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -782,6 +829,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -793,6 +841,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -804,6 +853,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -814,6 +864,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -825,6 +876,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -836,6 +888,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -900,6 +953,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -911,6 +965,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -922,6 +977,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -932,6 +988,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -960,6 +1017,7 @@
           "value": "\"single\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -970,6 +1028,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -981,6 +1040,7 @@
           "value": "async (code) => {     try {       await navigator.clipboard.writeText(code);     } catch (e) {       console.log(e);     }   }",
           "isFunction": true,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -992,6 +1052,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -1003,6 +1064,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1014,6 +1076,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1025,6 +1088,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1036,6 +1100,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1047,6 +1112,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1057,6 +1123,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1067,6 +1134,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1078,6 +1146,7 @@
           "value": "\"Copied!\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1089,6 +1158,7 @@
           "value": "2000",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1100,6 +1170,7 @@
           "value": "\"Show less\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1111,6 +1182,7 @@
           "value": "\"Show more\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1122,6 +1194,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -1133,6 +1206,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1144,6 +1218,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -1202,6 +1277,7 @@
           "value": "\"single\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -1229,6 +1305,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1240,6 +1317,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1251,6 +1329,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1262,6 +1341,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1273,6 +1353,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1283,6 +1364,7 @@
           "type": "\"2x1\" | \"16x9\" | \"9x16\" | \"1x2\" | \"4x3\" | \"3x4\" | \"1x1\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1293,6 +1375,7 @@
           "type": "ColumnBreakpoint",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1303,6 +1386,7 @@
           "type": "ColumnBreakpoint",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1313,6 +1397,7 @@
           "type": "ColumnBreakpoint",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1323,6 +1408,7 @@
           "type": "ColumnBreakpoint",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1333,6 +1419,7 @@
           "type": "ColumnBreakpoint",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -1377,6 +1464,7 @@
           "value": "[]",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1388,6 +1476,7 @@
           "value": "(item) => item.text || item.id",
           "isFunction": true,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1398,6 +1487,7 @@
           "type": "ComboBoxItemId",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -1409,6 +1499,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -1420,6 +1511,7 @@
           "value": "\"bottom\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1430,6 +1522,7 @@
           "type": "\"sm\" | \"xl\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1441,6 +1534,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1452,6 +1546,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1463,6 +1558,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1474,6 +1570,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1485,6 +1582,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1496,6 +1594,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1507,6 +1606,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1518,6 +1618,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1529,6 +1630,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1540,6 +1642,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -1551,6 +1654,7 @@
           "value": "() => true",
           "isFunction": true,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1561,6 +1665,7 @@
           "type": "(id: import(\"../ListBox/ListBoxMenuIcon.svelte\").ListBoxMenuIconTranslationId) => string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1571,6 +1676,7 @@
           "type": "(id: \"clearSelection\") => string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1582,6 +1688,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1592,6 +1699,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1603,6 +1711,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -1614,6 +1723,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -1625,6 +1735,7 @@
           "value": "() => {     prevSelectedId = null;     highlightedIndex = -1;     highlightedId = undefined;     selectedId = undefined;     selectedItem = undefined;     open = false;     inputValue = \"\";     if (options?.focus !== false) ref?.focus();   }",
           "isFunction": true,
           "isFunctionDeclaration": true,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -1676,6 +1787,7 @@
           "type": "\"xs\" | \"sm\" | \"lg\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1687,6 +1799,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -1698,6 +1811,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1709,6 +1823,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1720,6 +1835,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1731,6 +1847,7 @@
           "value": "\"[data-modal-primary-focus]\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1742,6 +1859,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -1783,6 +1901,7 @@
           "value": "\"main-content\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -1805,6 +1924,7 @@
           "value": "0",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -1815,6 +1935,7 @@
           "type": "\"sm\" | \"xl\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -1843,6 +1964,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1854,6 +1976,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -1865,6 +1988,7 @@
           "value": "0",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -1876,6 +2000,7 @@
           "value": "0",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -1887,6 +2012,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -1922,6 +2048,7 @@
           "value": "[]",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -1933,6 +2060,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -1954,6 +2082,7 @@
           "value": "\"default\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1965,6 +2094,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -1976,6 +2106,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -1986,6 +2117,7 @@
           "type": "typeof import(\"svelte\").SvelteComponent",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -1997,6 +2129,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2008,6 +2141,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -2019,6 +2153,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -2030,6 +2165,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2041,6 +2177,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2052,6 +2189,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -2099,6 +2237,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -2110,6 +2249,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -2131,6 +2271,7 @@
           "value": "\"Copied!\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2142,6 +2283,7 @@
           "value": "2000",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2153,6 +2295,7 @@
           "value": "\"Copy to clipboard\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2163,6 +2306,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": true,
           "constant": false,
           "reactive": false
         },
@@ -2174,6 +2318,7 @@
           "value": "async (text) => {     try {       await navigator.clipboard.writeText(text);     } catch (e) {       console.log(e);     }   }",
           "isFunction": true,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -2200,6 +2345,7 @@
           "value": "[]",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2211,6 +2357,7 @@
           "value": "[]",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2221,6 +2368,7 @@
           "type": "\"compact\" | \"short\" | \"medium\" | \"tall\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2232,6 +2380,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2243,6 +2392,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2254,6 +2404,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2265,6 +2416,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2276,6 +2428,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -2287,6 +2440,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2298,6 +2452,7 @@
           "value": "[]",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -2309,6 +2464,7 @@
           "value": "[]",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2320,6 +2476,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2331,6 +2488,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -2342,6 +2500,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2353,6 +2512,7 @@
           "value": "[]",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -2364,6 +2524,7 @@
           "value": "[]",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2375,6 +2536,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2386,6 +2548,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2397,6 +2560,7 @@
           "value": "0",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2408,6 +2572,7 @@
           "value": "0",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -2539,6 +2704,7 @@
           "value": "5",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2550,6 +2716,7 @@
           "value": "5",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2560,6 +2727,7 @@
           "type": "\"compact\" | \"short\" | \"tall\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2571,6 +2739,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2582,6 +2751,7 @@
           "value": "true",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2593,6 +2763,7 @@
           "value": "[]",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2604,6 +2775,7 @@
           "value": "true",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -2635,6 +2807,7 @@
           "value": "\"simple\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2646,6 +2819,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -2657,6 +2831,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -2668,6 +2843,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -2679,6 +2855,7 @@
           "value": "\"m/d/Y\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2690,6 +2867,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2701,6 +2879,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2712,6 +2891,7 @@
           "value": "\"en\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2723,6 +2903,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2734,6 +2915,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2745,6 +2927,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2756,6 +2939,7 @@
           "value": "{ static: true }",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -2787,6 +2971,7 @@
           "type": "\"sm\" | \"xl\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2798,6 +2983,7 @@
           "value": "\"text\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2809,6 +2995,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2820,6 +3007,7 @@
           "value": "\"\\\\d{1,2}\\\\/\\\\d{1,2}\\\\/\\\\d{4}\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2831,6 +3019,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2842,6 +3031,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2853,6 +3043,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2864,6 +3055,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2875,6 +3067,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2886,6 +3079,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2897,6 +3091,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2908,6 +3103,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2919,6 +3115,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2930,6 +3127,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2940,6 +3138,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2951,6 +3150,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -2985,6 +3185,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -2996,6 +3197,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -3023,6 +3225,7 @@
           "value": "[]",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3034,6 +3237,7 @@
           "value": "(item) => item.text || item.id",
           "isFunction": true,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3044,6 +3248,7 @@
           "type": "DropdownItemId",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": true,
           "constant": false,
           "reactive": true
         },
@@ -3055,6 +3260,7 @@
           "value": "\"default\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3066,6 +3272,7 @@
           "value": "\"bottom\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3076,6 +3283,7 @@
           "type": "\"sm\" | \"lg\" | \"xl\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3087,6 +3295,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -3098,6 +3307,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -3109,6 +3319,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3120,6 +3331,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3131,6 +3343,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3142,6 +3355,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3153,6 +3367,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3164,6 +3379,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3175,6 +3391,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3186,6 +3403,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3196,6 +3414,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3207,6 +3426,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3217,6 +3437,7 @@
           "type": "(id: import(\"../ListBox/ListBoxMenuIcon.svelte\").ListBoxMenuIconTranslationId) => string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3228,6 +3449,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3238,6 +3460,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3249,6 +3472,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -3300,6 +3524,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -3327,6 +3552,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -3338,6 +3564,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3349,6 +3576,7 @@
           "value": "0",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -3360,6 +3588,7 @@
           "value": "0",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -3371,6 +3600,7 @@
           "value": "\"Interact to expand Tile\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3382,6 +3612,7 @@
           "value": "\"Interact to collapse Tile\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3393,6 +3624,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3404,6 +3636,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3415,6 +3648,7 @@
           "value": "\"0\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3426,6 +3660,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3437,6 +3672,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -3468,6 +3704,7 @@
           "value": "\"uploading\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3479,6 +3716,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3490,6 +3728,7 @@
           "value": "[]",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3501,6 +3740,7 @@
           "value": "[]",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -3512,6 +3752,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3523,6 +3764,7 @@
           "value": "() => {     files = [];   }",
           "isFunction": true,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": true,
           "reactive": false
         },
@@ -3534,6 +3776,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3545,6 +3788,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3556,6 +3800,7 @@
           "value": "\"primary\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3567,6 +3812,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3578,6 +3824,7 @@
           "value": "\"Provide icon description\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3589,6 +3836,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -3620,6 +3868,7 @@
           "value": "[]",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3631,6 +3880,7 @@
           "value": "[]",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -3642,6 +3892,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3653,6 +3904,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3664,6 +3916,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3675,6 +3928,7 @@
           "value": "\"primary\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3686,6 +3940,7 @@
           "value": "\"Add file\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -3697,6 +3952,7 @@
           "value": "\"button\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3708,6 +3964,7 @@
           "value": "\"0\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3719,6 +3976,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3730,6 +3988,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3741,6 +4000,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -3774,6 +4034,7 @@
           "value": "[]",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3785,6 +4046,7 @@
           "value": "[]",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -3796,6 +4058,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3807,6 +4070,7 @@
           "value": "(files) => files",
           "isFunction": true,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3818,6 +4082,7 @@
           "value": "\"Add file\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3829,6 +4094,7 @@
           "value": "\"button\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3840,6 +4106,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3851,6 +4118,7 @@
           "value": "\"0\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3862,6 +4130,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3873,6 +4142,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3884,6 +4154,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -3921,6 +4192,7 @@
           "value": "\"uploading\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3932,6 +4204,7 @@
           "value": "\"default\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3943,6 +4216,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3954,6 +4228,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3965,6 +4240,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3976,6 +4252,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3987,6 +4264,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -3998,6 +4276,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -4040,6 +4319,7 @@
           "value": "\"uploading\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -4051,6 +4331,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -4062,6 +4343,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -4104,6 +4386,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -4133,6 +4416,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -4144,6 +4428,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -4155,6 +4440,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -4166,6 +4452,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -4177,6 +4464,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -4188,6 +4476,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -4230,6 +4519,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -4257,6 +4547,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -4268,6 +4559,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -4279,6 +4571,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -4290,6 +4583,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -4301,6 +4595,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -4312,6 +4607,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -4323,6 +4619,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -4334,6 +4631,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -4362,6 +4660,7 @@
           "value": "true",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -4373,6 +4672,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -4383,6 +4683,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -4393,6 +4694,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -4403,6 +4705,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -4414,6 +4717,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -4425,6 +4729,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -4436,6 +4741,7 @@
           "value": "1056",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -4447,6 +4753,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -4457,6 +4764,7 @@
           "type": "typeof import(\"svelte\").SvelteComponent",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -4467,6 +4775,7 @@
           "type": "typeof import(\"svelte\").SvelteComponent",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -4498,6 +4807,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -4508,6 +4818,7 @@
           "type": "typeof import(\"svelte\").SvelteComponent",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -4518,6 +4829,7 @@
           "type": "typeof import(\"svelte\").SvelteComponent",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -4528,6 +4840,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -4539,6 +4852,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -4550,6 +4864,7 @@
           "value": "{ duration: 200 }",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -4596,6 +4911,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -4606,6 +4922,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -4616,6 +4933,7 @@
           "type": "typeof import(\"svelte\").SvelteComponent",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -4627,6 +4945,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -4656,6 +4975,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -4666,6 +4986,7 @@
           "type": "typeof import(\"svelte\").SvelteComponent",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -4677,6 +4998,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -4715,6 +5037,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -4725,6 +5048,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -4736,6 +5060,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -4747,6 +5072,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -4778,6 +5104,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -4789,6 +5116,7 @@
           "value": "\"/\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -4799,6 +5127,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -4810,6 +5139,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -4849,6 +5179,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -4860,6 +5191,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -4891,6 +5223,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -4902,6 +5235,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -4913,6 +5247,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -4924,6 +5259,7 @@
           "value": "[]",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -4935,6 +5271,7 @@
           "value": "0",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -4993,6 +5330,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5004,6 +5342,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5014,6 +5353,7 @@
           "type": "\"2x1\" | \"16x9\" | \"4x3\" | \"1x1\" | \"3x4\" | \"3x2\" | \"9x16\" | \"1x2\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5025,6 +5365,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -5036,6 +5377,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -5047,6 +5389,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -5058,6 +5401,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5069,6 +5413,7 @@
           "value": "(url) => {     if (image != null) image = null;     loaded = false;     error = false;     image = new Image();     image.src = url || src;     image.onload = () => (loaded = true);     image.onerror = () => (error = true);   }",
           "isFunction": true,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": true,
           "reactive": false
         }
@@ -5097,6 +5442,7 @@
           "value": "\"active\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5107,6 +5453,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5117,6 +5464,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5128,6 +5476,7 @@
           "value": "1500",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -5156,6 +5505,7 @@
           "value": "\"error\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5167,6 +5517,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5178,6 +5529,7 @@
           "value": "0",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5189,6 +5541,7 @@
           "value": "\"alert\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5200,6 +5553,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5211,6 +5565,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5222,6 +5577,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5233,6 +5589,7 @@
           "value": "\"Closes notification\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -5279,6 +5636,7 @@
           "type": "\"sm\" | \"lg\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5289,6 +5647,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5300,6 +5659,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5310,6 +5670,7 @@
           "type": "typeof import(\"svelte\").SvelteComponent",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5321,6 +5682,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5332,6 +5694,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5343,6 +5706,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -5377,6 +5741,7 @@
           "type": "\"sm\" | \"xl\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5388,6 +5753,7 @@
           "value": "\"default\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5399,6 +5765,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5410,6 +5777,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5421,6 +5789,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5432,6 +5801,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5443,6 +5813,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5454,6 +5825,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5465,6 +5837,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -5490,6 +5863,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5501,6 +5875,7 @@
           "value": "\"combobox\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5512,6 +5887,7 @@
           "value": "\"-1\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5523,6 +5899,7 @@
           "value": "{ close: \"close\", open: \"open\" }",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": true,
           "reactive": false
         },
@@ -5534,6 +5911,7 @@
           "value": "(id) => defaultTranslations[id]",
           "isFunction": true,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5545,6 +5923,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5556,6 +5935,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -5592,6 +5972,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5603,6 +5984,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -5625,6 +6007,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5636,6 +6019,7 @@
           "value": "{ close: \"close\", open: \"open\" }",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": true,
           "reactive": false
         },
@@ -5647,6 +6031,7 @@
           "value": "(id) => defaultTranslations[id]",
           "isFunction": true,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -5675,6 +6060,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5686,6 +6072,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -5711,6 +6098,7 @@
           "type": "number",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5722,6 +6110,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5733,6 +6122,7 @@
           "value": "{     clearAll: \"clearAll\",     clearSelection: \"clearSelection\",   }",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": true,
           "reactive": false
         },
@@ -5744,6 +6134,7 @@
           "value": "(id) => defaultTranslations[id]",
           "isFunction": true,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5755,6 +6146,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -5798,6 +6190,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5809,6 +6202,7 @@
           "value": "true",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5820,6 +6214,7 @@
           "value": "true",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5831,6 +6226,7 @@
           "value": "\"Active loading indicator\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5842,6 +6238,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -5864,6 +6261,7 @@
           "value": "\"local-storage-key\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5875,6 +6273,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -5886,6 +6285,7 @@
           "value": "() => {     localStorage.removeItem(key);   }",
           "isFunction": true,
           "isFunctionDeclaration": true,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5897,6 +6297,7 @@
           "value": "() => {     localStorage.clear();   }",
           "isFunction": true,
           "isFunctionDeclaration": true,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -5924,6 +6325,7 @@
           "type": "\"xs\" | \"sm\" | \"lg\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5935,6 +6337,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -5946,6 +6349,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5957,6 +6361,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5968,6 +6373,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5978,6 +6384,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5988,6 +6395,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -5998,6 +6406,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6009,6 +6418,7 @@
           "value": "\"Close the modal\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6020,6 +6430,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6031,6 +6442,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6042,6 +6454,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6053,6 +6466,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6063,6 +6477,7 @@
           "type": "typeof import(\"svelte\").SvelteComponent",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6074,6 +6489,7 @@
           "value": "true",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6085,6 +6501,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6096,6 +6513,7 @@
           "value": "[]",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6107,6 +6525,7 @@
           "value": "\"[data-modal-primary-focus]\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6118,6 +6537,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6129,6 +6549,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6140,6 +6561,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -6200,6 +6622,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6211,6 +6634,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -6233,6 +6657,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6243,6 +6668,7 @@
           "type": "typeof import(\"svelte\").SvelteComponent",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6254,6 +6680,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6264,6 +6691,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6275,6 +6703,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6286,6 +6715,7 @@
           "value": "[]",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6296,6 +6726,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6307,6 +6738,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -6335,6 +6767,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6346,6 +6779,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6357,6 +6791,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6368,6 +6803,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6379,6 +6815,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6390,6 +6827,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6401,6 +6839,7 @@
           "value": "\"Close\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -6423,6 +6862,7 @@
           "value": "[]",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -6434,6 +6874,7 @@
           "value": "(item) => item.text || item.id",
           "isFunction": true,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6445,6 +6886,7 @@
           "value": "(item) => {}",
           "isFunction": true,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6456,6 +6898,7 @@
           "value": "[]",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -6467,6 +6910,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -6477,6 +6921,7 @@
           "type": "\"sm\" | \"lg\" | \"xl\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6488,6 +6933,7 @@
           "value": "\"default\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6499,6 +6945,7 @@
           "value": "\"bottom\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6510,6 +6957,7 @@
           "value": "\"top-after-reopen\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6521,6 +6969,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6532,6 +6981,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6543,6 +6993,7 @@
           "value": "(item, value) =>     item.text.toLowerCase().includes(value.trim().toLowerCase())",
           "isFunction": true,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6554,6 +7005,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -6565,6 +7017,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6576,6 +7029,7 @@
           "value": "\"en\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6587,6 +7041,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6598,6 +7053,7 @@
           "value": "(a, b) =>     a.text.localeCompare(b.text, locale, { numeric: true })",
           "isFunction": true,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6608,6 +7064,7 @@
           "type": "(id: import(\"../ListBox/ListBoxMenuIcon.svelte\").ListBoxMenuIconTranslationId) => string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6618,6 +7075,7 @@
           "type": "(id: import(\"../ListBox/ListBoxSelection.svelte\").ListBoxSelectionTranslationId) => string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6629,6 +7087,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6640,6 +7099,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6651,6 +7111,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6662,6 +7123,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6673,6 +7135,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6684,6 +7147,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6695,6 +7159,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6706,6 +7171,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6717,6 +7183,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6728,6 +7195,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6738,6 +7206,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6749,6 +7218,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -6760,6 +7230,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -6771,6 +7242,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -6782,6 +7254,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -6793,6 +7266,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -6868,6 +7342,7 @@
           "value": "\"toast\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6878,6 +7353,7 @@
           "type": "typeof import(\"svelte\").SvelteComponent",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6888,6 +7364,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6899,6 +7376,7 @@
           "value": "\"Close icon\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -6926,6 +7404,7 @@
           "value": "\"error\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6937,6 +7416,7 @@
           "value": "\"toast\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6948,6 +7428,7 @@
           "value": "\"Closes notification\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -6968,6 +7449,7 @@
           "type": "\"sm\" | \"xl\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -6979,6 +7461,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -6990,6 +7473,7 @@
           "value": "1",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7000,6 +7484,7 @@
           "type": "number",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7010,6 +7495,7 @@
           "type": "number",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7021,6 +7507,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7032,6 +7519,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7043,6 +7531,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7054,6 +7543,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7065,6 +7555,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7076,6 +7567,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7087,6 +7579,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7098,6 +7591,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7109,6 +7603,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7120,6 +7615,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7131,6 +7627,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7142,6 +7639,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7153,6 +7651,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7164,6 +7663,7 @@
           "value": "(id) => defaultTranslations[id]",
           "isFunction": true,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7175,6 +7675,7 @@
           "value": "{     increment: \"increment\",     decrement: \"decrement\",   }",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": true,
           "reactive": false
         },
@@ -7186,6 +7687,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7196,6 +7698,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7207,6 +7710,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -7251,6 +7755,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -7278,6 +7783,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7289,6 +7795,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7300,6 +7807,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -7342,6 +7850,7 @@
           "type": "\"sm\" | \"xl\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7353,6 +7862,7 @@
           "value": "\"bottom\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7364,6 +7874,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -7375,6 +7886,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7386,6 +7898,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7396,6 +7909,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7406,6 +7920,7 @@
           "type": "typeof import(\"svelte\").SvelteComponent",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -7416,6 +7931,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7427,6 +7943,7 @@
           "value": "\"Open and close list of options\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7438,6 +7955,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7449,6 +7967,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -7460,6 +7979,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -7501,6 +8021,7 @@
           "value": "\"Provide text\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7512,6 +8033,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7523,6 +8045,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -7534,6 +8057,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7545,6 +8069,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7556,6 +8081,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7567,6 +8093,7 @@
           "value": "true",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7578,6 +8105,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7589,6 +8117,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -7621,6 +8150,7 @@
           "value": "1",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -7632,6 +8162,7 @@
           "value": "0",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7643,6 +8174,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7654,6 +8186,7 @@
           "value": "\"Next page\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7665,6 +8198,7 @@
           "value": "\"Previous page\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7676,6 +8210,7 @@
           "value": "\"Items per page:\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7687,6 +8222,7 @@
           "value": "(min, max) => `${min}–${max} items`",
           "isFunction": true,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7698,6 +8234,7 @@
           "value": "(min, max, total) =>     `${min}–${max} of ${total} items`",
           "isFunction": true,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7709,6 +8246,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7720,6 +8258,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7731,6 +8270,7 @@
           "value": "10",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -7742,6 +8282,7 @@
           "value": "[10]",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7753,6 +8294,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7764,6 +8306,7 @@
           "value": "(page) => `page ${page}`",
           "isFunction": true,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7775,6 +8318,7 @@
           "value": "(current, total) =>     `of ${total} page${total === 1 ? \"\" : \"s\"}`",
           "isFunction": true,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7786,6 +8330,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -7824,6 +8369,7 @@
           "value": "0",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -7835,6 +8381,7 @@
           "value": "10",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7846,6 +8393,7 @@
           "value": "10",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7857,6 +8405,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7868,6 +8417,7 @@
           "value": "\"Next page\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7879,6 +8429,7 @@
           "value": "\"Previous page\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -7931,6 +8482,7 @@
           "type": "\"sm\" | \"xl\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7942,6 +8494,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -7953,6 +8506,7 @@
           "value": "\"password\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -7964,6 +8518,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7975,6 +8530,7 @@
           "value": "\"Hide password\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7986,6 +8542,7 @@
           "value": "\"Show password\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -7997,6 +8554,7 @@
           "value": "\"center\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8008,6 +8566,7 @@
           "value": "\"bottom\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8019,6 +8578,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8030,6 +8590,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8041,6 +8602,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8052,6 +8614,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8063,6 +8626,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8074,6 +8638,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8085,6 +8650,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8096,6 +8662,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8107,6 +8674,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8118,6 +8686,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8129,6 +8698,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8139,6 +8709,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8150,6 +8721,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -8190,6 +8762,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -8201,6 +8774,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8212,6 +8786,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8223,6 +8798,7 @@
           "value": "\"top\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8234,6 +8810,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8245,6 +8822,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8256,6 +8834,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -8279,6 +8858,7 @@
           "type": "number",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8290,6 +8870,7 @@
           "value": "100",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8301,6 +8882,7 @@
           "value": "\"default\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8312,6 +8894,7 @@
           "value": "\"md\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8323,6 +8906,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8334,6 +8918,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8345,6 +8930,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8356,6 +8942,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -8385,6 +8972,7 @@
           "value": "0",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -8396,6 +8984,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8407,6 +8996,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8418,6 +9008,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -8446,6 +9037,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8457,6 +9049,7 @@
           "value": "4",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -8484,6 +9077,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -8495,6 +9089,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -8506,6 +9101,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8517,6 +9113,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8528,6 +9125,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8539,6 +9137,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8550,6 +9149,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8561,6 +9161,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -8596,6 +9197,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8607,6 +9209,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -8618,6 +9221,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8629,6 +9233,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8640,6 +9245,7 @@
           "value": "\"right\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8651,6 +9257,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8662,6 +9269,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8673,6 +9281,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8684,6 +9293,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8695,6 +9305,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -8723,6 +9334,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -8734,6 +9346,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8745,6 +9358,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8756,6 +9370,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8767,6 +9382,7 @@
           "value": "\"right\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8778,6 +9394,7 @@
           "value": "\"horizontal\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8788,6 +9405,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -8839,6 +9457,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -8850,6 +9469,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8861,6 +9481,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8872,6 +9493,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8883,6 +9505,7 @@
           "value": "\"0\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8894,6 +9517,7 @@
           "value": "\"Tile checkmark\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8905,6 +9529,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8916,6 +9541,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -8945,6 +9571,7 @@
           "value": "[]",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8956,6 +9583,7 @@
           "value": "\"unordered\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -8984,6 +9612,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -8995,6 +9624,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9006,6 +9636,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9017,6 +9648,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9028,6 +9660,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9039,6 +9672,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9050,6 +9684,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -9078,6 +9713,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -9089,6 +9725,7 @@
           "value": "\"xl\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9100,6 +9737,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9111,6 +9749,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9122,6 +9761,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9133,6 +9773,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9144,6 +9785,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9155,6 +9797,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -9166,6 +9809,7 @@
           "value": "\"Search...\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9177,6 +9821,7 @@
           "value": "\"off\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9188,6 +9833,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9199,6 +9845,7 @@
           "value": "\"Clear search input\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9210,6 +9857,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9220,6 +9868,7 @@
           "type": "typeof import(\"svelte\").SvelteComponent",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9231,6 +9880,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9242,6 +9892,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -9297,6 +9948,7 @@
           "value": "\"xl\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -9323,6 +9975,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -9333,6 +9986,7 @@
           "type": "\"sm\" | \"xl\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9344,6 +9998,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9355,6 +10010,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9366,6 +10022,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9377,6 +10034,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9387,6 +10045,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9398,6 +10057,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9409,6 +10069,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9420,6 +10081,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9431,6 +10093,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9442,6 +10105,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9453,6 +10117,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9464,6 +10129,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9475,6 +10141,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9486,6 +10153,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -9497,6 +10165,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -9532,6 +10201,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9543,6 +10213,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9554,6 +10225,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9565,6 +10237,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -9586,6 +10259,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9597,6 +10271,7 @@
           "value": "\"Provide label\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -9619,6 +10294,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -9646,6 +10322,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -9657,6 +10334,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9668,6 +10346,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9679,6 +10358,7 @@
           "value": "\"title\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9690,6 +10370,7 @@
           "value": "\"value\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9701,6 +10382,7 @@
           "value": "\"0\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9712,6 +10394,7 @@
           "value": "\"Tile checkmark\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9723,6 +10406,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9734,6 +10418,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9745,6 +10430,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -9773,6 +10459,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9784,6 +10471,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9794,6 +10482,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9805,6 +10494,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -9816,6 +10506,7 @@
           "value": "1056",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -9861,6 +10552,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9871,6 +10563,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9881,6 +10574,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9891,6 +10585,7 @@
           "type": "typeof import(\"svelte\").SvelteComponent",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9902,6 +10597,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -9937,6 +10633,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -9947,6 +10644,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9957,6 +10655,7 @@
           "type": "typeof import(\"svelte\").SvelteComponent",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -9968,6 +10667,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -9998,6 +10698,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10008,6 +10709,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10018,6 +10720,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10029,6 +10732,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -10073,6 +10777,7 @@
           "value": "3",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10084,6 +10789,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10095,6 +10801,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10106,6 +10813,7 @@
           "value": "\"100%\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -10133,6 +10841,7 @@
           "value": "\"#main-content\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10144,6 +10853,7 @@
           "value": "\"0\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -10173,6 +10883,7 @@
           "value": "0",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -10184,6 +10895,7 @@
           "value": "100",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10195,6 +10907,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10206,6 +10919,7 @@
           "value": "0",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10217,6 +10931,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10228,6 +10943,7 @@
           "value": "1",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10239,6 +10955,7 @@
           "value": "4",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10250,6 +10967,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10261,6 +10979,7 @@
           "value": "\"number\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10272,6 +10991,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10283,6 +11003,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10294,6 +11015,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10305,6 +11027,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10316,6 +11039,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10327,6 +11051,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10338,6 +11063,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10349,6 +11075,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -10384,6 +11111,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -10410,6 +11138,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -10421,6 +11150,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10432,6 +11162,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10443,6 +11174,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -10486,6 +11218,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10497,6 +11230,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -10539,6 +11273,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -10550,6 +11285,7 @@
           "value": "\"title\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10561,6 +11297,7 @@
           "value": "\"value\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10572,6 +11309,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10583,6 +11321,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10594,6 +11333,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -10616,6 +11356,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10627,6 +11368,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10638,6 +11380,7 @@
           "value": "\"0\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -10666,6 +11409,7 @@
           "value": "5",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -10693,6 +11437,7 @@
           "value": "\"Provide text\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10704,6 +11449,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -10715,6 +11461,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10726,6 +11473,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10737,6 +11485,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -10772,6 +11521,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10783,6 +11533,7 @@
           "value": "\"#\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10794,6 +11545,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10805,6 +11557,7 @@
           "value": "\"0\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10816,6 +11569,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10827,6 +11581,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -10861,6 +11616,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -10882,6 +11638,7 @@
           "type": "\"compact\" | \"short\" | \"medium\" | \"tall\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10893,6 +11650,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10904,6 +11662,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10915,6 +11674,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10926,6 +11686,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10936,6 +11697,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -10983,6 +11745,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -10994,6 +11757,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -11005,6 +11769,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -11016,6 +11781,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -11053,6 +11819,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -11064,6 +11831,7 @@
           "value": "\"col\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -11075,6 +11843,7 @@
           "value": "() => \"\"",
           "isFunction": true,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -11086,6 +11855,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -11128,6 +11898,7 @@
           "value": "0",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -11139,6 +11910,7 @@
           "value": "\"default\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -11150,6 +11922,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -11161,6 +11934,7 @@
           "value": "\"Show menu options\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -11172,6 +11946,7 @@
           "value": "\"#\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -11201,6 +11976,7 @@
           "value": "4",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -11212,6 +11988,7 @@
           "value": "\"default\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -11238,6 +12015,7 @@
           "type": "\"red\" | \"magenta\" | \"purple\" | \"blue\" | \"cyan\" | \"teal\" | \"green\" | \"gray\" | \"cool-gray\" | \"warm-gray\" | \"high-contrast\" | \"outline\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -11248,6 +12026,7 @@
           "value": "\"default\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -11259,6 +12038,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -11270,6 +12050,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -11281,6 +12062,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -11292,6 +12074,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -11303,6 +12086,7 @@
           "value": "\"Clear filter\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -11313,6 +12097,7 @@
           "type": "typeof import(\"svelte\").SvelteComponent",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -11324,6 +12109,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -11363,6 +12149,7 @@
           "value": "\"default\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -11390,6 +12177,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -11401,6 +12189,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -11412,6 +12201,7 @@
           "value": "50",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -11423,6 +12213,7 @@
           "value": "4",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -11433,6 +12224,7 @@
           "type": "number",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -11444,6 +12236,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -11455,6 +12248,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -11466,6 +12260,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -11477,6 +12272,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -11488,6 +12284,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -11499,6 +12296,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -11510,6 +12308,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -11521,6 +12320,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -11532,6 +12332,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -11542,6 +12343,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -11553,6 +12355,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -11593,6 +12396,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -11619,6 +12423,7 @@
           "type": "\"sm\" | \"xl\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -11630,6 +12435,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -11641,6 +12447,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -11652,6 +12459,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -11663,6 +12471,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -11674,6 +12483,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -11685,6 +12495,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -11695,6 +12506,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -11706,6 +12518,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -11717,6 +12530,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -11728,6 +12542,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -11739,6 +12554,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -11750,6 +12566,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -11761,6 +12578,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -11772,6 +12590,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -11783,6 +12602,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -11794,6 +12614,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -11805,6 +12626,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -11853,6 +12675,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -11880,6 +12703,7 @@
           "value": "\"white\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -11891,6 +12715,7 @@
           "value": "{}",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -11902,6 +12727,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -11913,6 +12739,7 @@
           "value": "\"theme\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -11923,6 +12750,7 @@
           "type": "\"toggle\" | \"select\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -11934,6 +12762,7 @@
           "value": "{     themes: [\"white\", \"g100\"],     labelA: \"\",     labelB: \"\",     labelText: \"Dark mode\",     hideLabel: false,   }",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -11945,6 +12774,7 @@
           "value": "{     themes: themeKeys,     labelText: \"Themes\",     hideLabel: false,   }",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -11984,6 +12814,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -12010,6 +12841,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -12021,6 +12853,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -12032,6 +12865,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -12053,6 +12887,7 @@
           "type": "\"sm\" | \"xl\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -12064,6 +12899,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -12075,6 +12911,7 @@
           "value": "\"text\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -12086,6 +12923,7 @@
           "value": "\"hh:mm\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -12097,6 +12935,7 @@
           "value": "\"(1[012]|[1-9]):[0-5][0-9](\\\\s)?\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -12108,6 +12947,7 @@
           "value": "5",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -12119,6 +12959,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -12130,6 +12971,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -12141,6 +12983,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -12152,6 +12995,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -12163,6 +13007,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -12174,6 +13019,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -12185,6 +13031,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -12195,6 +13042,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -12206,6 +13054,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -12247,6 +13096,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -12258,6 +13108,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -12269,6 +13120,7 @@
           "value": "\"Open list of options\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -12280,6 +13132,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -12291,6 +13144,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -12301,6 +13155,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -12312,6 +13167,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -12347,6 +13203,7 @@
           "value": "\"error\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -12358,6 +13215,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -12369,6 +13227,7 @@
           "value": "0",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -12380,6 +13239,7 @@
           "value": "\"alert\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -12391,6 +13251,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -12402,6 +13263,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -12413,6 +13275,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -12424,6 +13287,7 @@
           "value": "\"Closes notification\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -12435,6 +13299,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -12487,6 +13352,7 @@
           "value": "\"default\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -12498,6 +13364,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -12509,6 +13376,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -12520,6 +13388,7 @@
           "value": "\"Off\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -12531,6 +13400,7 @@
           "value": "\"On\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -12542,6 +13412,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -12553,6 +13424,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -12563,6 +13435,7 @@
           "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -12618,6 +13491,7 @@
           "value": "\"default\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -12629,6 +13503,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -12640,6 +13515,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -12674,6 +13550,7 @@
           "value": "\"default\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -12696,6 +13573,7 @@
           "value": "(totalSelected) =>     `${totalSelected} item${totalSelected === 1 ? \"\" : \"s\"} selected`",
           "isFunction": true,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -12770,6 +13648,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -12781,6 +13660,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -12792,6 +13672,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -12803,6 +13684,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -12814,6 +13696,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -12825,6 +13708,7 @@
           "value": "\"0\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -12836,6 +13720,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -12864,6 +13749,7 @@
           "value": "\"center\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -12875,6 +13761,7 @@
           "value": "\"bottom\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -12886,6 +13773,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -12897,6 +13785,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -12907,6 +13796,7 @@
           "type": "typeof import(\"svelte\").SvelteComponent",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -12918,6 +13808,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -12929,6 +13820,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -12940,6 +13832,7 @@
           "value": "\"0\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -12951,6 +13844,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -12962,6 +13856,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -12973,6 +13868,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -12984,6 +13880,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -12995,6 +13892,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -13006,6 +13904,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -13047,6 +13946,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -13058,6 +13958,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -13069,6 +13970,7 @@
           "value": "\"center\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -13080,6 +13982,7 @@
           "value": "\"bottom\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -13091,6 +13994,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -13102,6 +14006,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -13140,6 +14045,7 @@
           "value": "\"a[href], button:not([disabled])\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -13161,6 +14067,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -13171,6 +14078,7 @@
           "type": "typeof import(\"svelte\").SvelteComponent",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -13182,6 +14090,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -13193,6 +14102,7 @@
           "value": "\"center\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -13204,6 +14114,7 @@
           "value": "\"bottom\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -13215,6 +14126,7 @@
           "value": "\"ccs-\" + Math.random().toString(36)",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -13226,6 +14138,7 @@
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         }
@@ -13267,6 +14180,7 @@
           "value": "[]",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -13278,6 +14192,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -13289,6 +14204,7 @@
           "value": "[]",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -13300,6 +14216,7 @@
           "value": "[]",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": true
         },
@@ -13311,6 +14228,7 @@
           "value": "\"default\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -13322,6 +14240,7 @@
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -13333,6 +14252,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -13344,6 +14264,7 @@
           "value": "() => {     expandedIds = [...nodeIds];   }",
           "isFunction": true,
           "isFunctionDeclaration": true,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -13355,6 +14276,7 @@
           "value": "() => {     expandedIds = [];   }",
           "isFunction": true,
           "isFunctionDeclaration": true,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -13366,6 +14288,7 @@
           "value": "() => {     expandedIds = nodes       .filter(         (node) =>           filterNode(node) ||           node.children?.some((child) => filterNode(child) && child.children)       )       .map((node) => node.id);   }",
           "isFunction": true,
           "isFunctionDeclaration": true,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -13377,6 +14300,7 @@
           "value": "() => {     expandedIds = nodes       .filter((node) => expandedIds.includes(node.id) && !filterNode(node))       .map((node) => node.id);   }",
           "isFunction": true,
           "isFunctionDeclaration": true,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -13433,6 +14357,7 @@
           "value": "\"end\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }
@@ -13455,6 +14380,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         },
@@ -13466,6 +14392,7 @@
           "value": "false",
           "isFunction": false,
           "isFunctionDeclaration": false,
+          "isRequired": false,
           "constant": false,
           "reactive": false
         }

--- a/docs/src/components/ComponentApi.svelte
+++ b/docs/src/components/ComponentApi.svelte
@@ -68,12 +68,17 @@
               <InlineSnippet code="{prop.name}" />
               {#if prop.reactive}
                 <div
-                  style="white-space: nowrap; margin-top: var(--cds-spacing-03); margin-bottom: var(--cds-spacing-03)"
+                  style="white-space: nowrap; margin-top: var(--cds-spacing-03); margin-bottom: var(--cds-spacing-{prop.isRequired
+                    ? '01'
+                    : '03'})"
                 >
                   <Tag style="margin-left: 0" size="sm" type="cyan">
                     Reactive
                   </Tag>
                 </div>
+              {/if}
+              {#if prop.isRequired}
+                <Tag size="sm" type="magenta">Required</Tag>
               {/if}
             </StructuredListCell>
             <StructuredListCell>

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "rollup-plugin-svelte": "^7.1.0",
     "rollup-plugin-terser": "^7.0.2",
     "sass": "^1.49.11",
-    "sveld": "^0.15.3",
+    "sveld": "^0.17.0",
     "svelte": "^3.46.6",
     "svelte-check": "^2.4.6",
     "typescript": "^4.6.3"

--- a/src/CopyButton/CopyButton.svelte
+++ b/src/CopyButton/CopyButton.svelte
@@ -12,7 +12,7 @@
    * Specify the text to copy
    * @type {string}
    */
-  export let text = undefined;
+  export let text;
 
   /**
    * Override the default copy behavior of using the navigator.clipboard.writeText API to copy text

--- a/src/Dropdown/Dropdown.svelte
+++ b/src/Dropdown/Dropdown.svelte
@@ -23,7 +23,7 @@
    * Specify the selected item id
    * @type {DropdownItemId}
    */
-  export let selectedId = undefined;
+  export let selectedId;
 
   /**
    * Specify the type of dropdown

--- a/types/CopyButton/CopyButton.svelte.d.ts
+++ b/types/CopyButton/CopyButton.svelte.d.ts
@@ -25,7 +25,7 @@ export interface CopyButtonProps
    * Specify the text to copy
    * @default undefined
    */
-  text?: string;
+  text: string;
 
   /**
    * Override the default copy behavior of using the navigator.clipboard.writeText API to copy text

--- a/types/Dropdown/Dropdown.svelte.d.ts
+++ b/types/Dropdown/Dropdown.svelte.d.ts
@@ -28,7 +28,7 @@ export interface DropdownProps
    * Specify the selected item id
    * @default undefined
    */
-  selectedId?: DropdownItemId;
+  selectedId: DropdownItemId;
 
   /**
    * Specify the type of dropdown

--- a/yarn.lock
+++ b/yarn.lock
@@ -1330,10 +1330,10 @@ supports-color@^9.2.1:
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-9.2.2.tgz#502acaf82f2b7ee78eb7c83dcac0f89694e5a7bb"
   integrity sha512-XC6g/Kgux+rJXmwokjm9ECpD6k/smUoS5LKlUCcsYr4IY3rW0XyAympon2RmxGrlnZURMpg5T18gWDP9CsHXFA==
 
-sveld@^0.15.3:
-  version "0.15.3"
-  resolved "https://registry.yarnpkg.com/sveld/-/sveld-0.15.3.tgz#75fe72f472b9cfbe863f6f0b074612d4132dc960"
-  integrity sha512-3TYhrLpm8z8elnZ6ffQeq1SeoxzC2zsFY/9QeNHu1UcQxAZ6LqfyUufnOkNkelYJMq9uBn4bGUAYJpbpTMjnOA==
+sveld@^0.17.0:
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/sveld/-/sveld-0.17.0.tgz#af1f3d24a507d7bc84a356bf7f5c4b599ea444c2"
+  integrity sha512-OB15S0KyT033fXsZL9hnyuQDaSvpuRQs4CwIRVVnwbLy6IbBQyvNl9LG7Cu7z982qoYY3AMkZ0GzjpTtiMI4OQ==
   dependencies:
     "@rollup/plugin-node-resolve" "^13.2.1"
     acorn "^8.7.0"


### PR DESCRIPTION
Both the `CopyButton` and `Dropdown` components have a required prop (`text` and `selectedId` respectively). They will not work without a provided value.

An uninitialized prop in a Svelte component is required.

When using TypeScript, there should be an error if the prop is not provided.

<img width="745" alt="Screen Shot 2022-05-22 at 8 12 52 AM" src="https://user-images.githubusercontent.com/10718366/169702251-0f3b2b61-ecaf-4eaa-90f6-a514395b4f69.png">
