### PR TITLE
feat: set title attribute in `CheckBox`, `MultiSelect`, `Dropdown`, `ComboBox`  if label is truncated

### DIFF
--- a/src/Checkbox/Checkbox.svelte
+++ b/src/Checkbox/Checkbox.svelte
@@ -62,6 +62,11 @@
   $: useGroup = Array.isArray(group);
   $: checked = useGroup ? group.includes(value) : checked;
   $: dispatch("check", checked);
+
+  let refLabel = null;
+
+  $: isTruncated = refLabel?.offsetWidth < refLabel?.scrollWidth;
+  $: title = isTruncated ? refLabel?.innerText : title;
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
@@ -109,6 +114,7 @@
     />
     <label for="{id}" title="{title}" class:bx--checkbox-label="{true}">
       <span
+        bind:this="{refLabel}"
         class:bx--checkbox-label-text="{true}"
         class:bx--visually-hidden="{hideLabel}"
       >

--- a/src/ListBox/ListBoxMenuItem.svelte
+++ b/src/ListBox/ListBoxMenuItem.svelte
@@ -4,6 +4,11 @@
 
   /** Set to `true` to enable the highlighted state */
   export let highlighted = false;
+
+  let ref = null;
+
+  $: isTruncated = ref?.offsetWidth < ref?.scrollWidth;
+  $: title = isTruncated ? ref?.innerText : undefined;
 </script>
 
 <div
@@ -15,7 +20,11 @@
   on:mouseenter
   on:mouseleave
 >
-  <div class:bx--list-box__menu-item__option="{true}">
+  <div
+    bind:this="{ref}"
+    title="{title}"
+    class:bx--list-box__menu-item__option="{true}"
+  >
     <slot />
   </div>
 </div>


### PR DESCRIPTION
Closes #1205

The `title` attribute should be set if an item's label text is truncated.

This implementation using the `element.innerText` method since the text may not be provided via a prop (e.g., slots).

<img width="588" alt="Screen Shot 2022-05-28 at 10 06 18 AM" src="https://user-images.githubusercontent.com/10718366/170835518-66fa878e-0265-4252-96c6-ab0802c973d6.png">
