### PR TITLE
fix(tabs): tab should not steal focus if index is programmatically updated

### DIFF
--- a/src/Tabs/Tab.svelte
+++ b/src/Tabs/Tab.svelte
@@ -20,27 +20,13 @@
   /** Obtain a reference to the anchor HTML element */
   export let ref = null;
 
-  import { onMount, afterUpdate, getContext, tick } from "svelte";
+  import { getContext } from "svelte";
 
   const { selectedTab, useAutoWidth, add, update, change } = getContext("Tabs");
 
   add({ id, label, disabled });
 
-  let didMount = false;
-
   $: selected = $selectedTab === id;
-
-  onMount(() => {
-    tick().then(() => {
-      didMount = true;
-    });
-  });
-
-  afterUpdate(() => {
-    if (didMount && selected && ref) {
-      ref.focus();
-    }
-  });
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->

--- a/src/Tabs/Tabs.svelte
+++ b/src/Tabs/Tabs.svelte
@@ -20,7 +20,7 @@
   /** Specify the tab trigger href attribute */
   export let triggerHref = "#";
 
-  import { createEventDispatcher, afterUpdate, setContext } from "svelte";
+  import { createEventDispatcher, afterUpdate, setContext, tick } from "svelte";
   import { writable, derived } from "svelte/store";
   import ChevronDown from "../icons/ChevronDown.svelte";
 
@@ -38,6 +38,8 @@
   );
   const selectedContent = writable(undefined);
 
+  let refTabList = null;
+
   setContext("Tabs", {
     tabs,
     contentById,
@@ -53,7 +55,7 @@
     update: (id) => {
       currentIndex = $tabsById[id].index;
     },
-    change: (direction) => {
+    change: async (direction) => {
       let index = currentIndex + direction;
 
       if (index < 0) {
@@ -77,6 +79,11 @@
       }
 
       currentIndex = index;
+
+      await tick();
+      const activeTab =
+        refTabList?.querySelectorAll("[role='tab']")[currentIndex];
+      activeTab?.focus();
     },
   });
 
@@ -145,6 +152,7 @@
     <ChevronDown aria-hidden="true" title="{iconDescription}" />
   </div>
   <ul
+    bind:this="{refTabList}"
     role="tablist"
     class:bx--tabs__nav="{true}"
     class:bx--tabs__nav--hidden="{dropdownHidden}"


### PR DESCRIPTION
Fixes #572

Currently, if the selected index for a `Tabs` component is programmatically updated (i.e., tab is changed not through clicking or keyboard navigation), the selected tab will "steal" the focus.

The expected behavior is that the appropriate element should retain the focus.

The solution is to only focus the tab if the consumer is using keyboard navigation. Clicking a tab will already focus the tab.

In the demo below, the selected tab is not focused if it is programmatically set.

- typing in an input retains its focus
- clicking the button retains its focus


https://user-images.githubusercontent.com/10718366/170882840-6631c784-61c3-482a-9c0e-87f6698a8e87.mov

