### PR TITLE
fix(dropdown): remove redundant role/id

### DIFF
--- a/src/Dropdown/Dropdown.svelte
+++ b/src/Dropdown/Dropdown.svelte
@@ -164,9 +164,9 @@
     </label>
   {/if}
   <ListBox
+    role="{undefined}"
     type="{type}"
     size="{size}"
-    id="{id}"
     name="{name}"
     aria-label="{$$props['aria-label']}"
     class="bx--dropdown {direction === 'top' && 'bx--list-box--up'} {invalid &&

--- a/src/ListBox/ListBoxMenuItem.svelte
+++ b/src/ListBox/ListBoxMenuItem.svelte
@@ -12,9 +12,11 @@
 </script>
 
 <div
+  role="option"
   class:bx--list-box__menu-item="{true}"
   class:bx--list-box__menu-item--active="{active}"
   class:bx--list-box__menu-item--highlighted="{highlighted}"
+  aria-selected="{active}"
   {...$$restProps}
   on:click
   on:mouseenter


### PR DESCRIPTION
A couple of accessibility points here:

- the `ListBoxMenuItem` should have an "option" role
- if an item is selected (active), it should have an attribute `aria-selected="true"`
- remove redundant `role`, `id` from `Dropdown`