### PR TITLE
feat: support `item.disabled` key for `Dropdown`, `MultiSelect`, `ComboBox`

### DIFF
--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -646,6 +646,7 @@ export type ComboBoxItemId = any;
 export interface ComboBoxItem {
   id: ComboBoxItemId;
   text: string;
+  disabled?: boolean;
 }
 ```
 
@@ -1140,6 +1141,7 @@ export type DropdownItemText = string;
 export interface DropdownItem {
   id: DropdownItemId;
   text: DropdownItemText;
+  disabled?: boolean;
 }
 ```
 
@@ -2086,6 +2088,7 @@ None.
 | :---------- | :------- | :--------------- | :------- | -------------------- | ------------------ | --------------------------------------------- |
 | active      | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to enable the active state      |
 | highlighted | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to enable the highlighted state |
+| disabled    | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code> | Set to `true` to disable the menu item        |
 
 ### Slots
 
@@ -2328,6 +2331,7 @@ export type MultiSelectItemText = string;
 export interface MultiSelectItem {
   id: MultiSelectItemId;
   text: MultiSelectItemText;
+  disabled?: boolean;
 }
 ```
 

--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -1769,9 +1769,9 @@
           "ts": "type ComboBoxItemId = any"
         },
         {
-          "type": "{ id: ComboBoxItemId; text: string; }",
+          "type": "{ id: ComboBoxItemId; text: string; disabled?: boolean; }",
           "name": "ComboBoxItem",
-          "ts": "interface ComboBoxItem { id: ComboBoxItemId; text: string; }"
+          "ts": "interface ComboBoxItem { id: ComboBoxItemId; text: string; disabled?: boolean; }"
         }
       ],
       "rest_props": { "type": "Element", "name": "input" }
@@ -3505,9 +3505,9 @@
           "ts": "type DropdownItemText = string"
         },
         {
-          "type": "{ id: DropdownItemId; text: DropdownItemText; }",
+          "type": "{ id: DropdownItemId; text: DropdownItemText; disabled?: boolean; }",
           "name": "DropdownItem",
-          "ts": "interface DropdownItem { id: DropdownItemId; text: DropdownItemText; }"
+          "ts": "interface DropdownItem { id: DropdownItemId; text: DropdownItemText; disabled?: boolean; }"
         }
       ],
       "rest_props": { "type": "Element", "name": "div" }
@@ -6075,6 +6075,18 @@
           "isRequired": false,
           "constant": false,
           "reactive": false
+        },
+        {
+          "name": "disabled",
+          "kind": "let",
+          "description": "Set to `true` to disable the menu item",
+          "type": "boolean",
+          "value": "false",
+          "isFunction": false,
+          "isFunctionDeclaration": false,
+          "isRequired": false,
+          "constant": false,
+          "reactive": false
         }
       ],
       "moduleExports": [],
@@ -7308,9 +7320,9 @@
           "ts": "type MultiSelectItemText = string"
         },
         {
-          "type": "{ id: MultiSelectItemId; text: MultiSelectItemText; }",
+          "type": "{ id: MultiSelectItemId; text: MultiSelectItemText; disabled?: boolean; }",
           "name": "MultiSelectItem",
-          "ts": "interface MultiSelectItem { id: MultiSelectItemId; text: MultiSelectItemText; }"
+          "ts": "interface MultiSelectItem { id: MultiSelectItemId; text: MultiSelectItemText; disabled?: boolean; }"
         }
       ],
       "rest_props": { "type": "Element", "name": "input" }

--- a/docs/src/pages/components/ComboBox.svx
+++ b/docs/src/pages/components/ComboBox.svx
@@ -112,7 +112,7 @@ items={[
   {id: "2", text: "Fax"}
   ]}  />
 
-### Disabled
+### Disabled state
 
 <ComboBox disabled titleText="Contact" placeholder="Select contact method"
 items={[
@@ -120,3 +120,17 @@ items={[
   {id: "1", text: "Email"},
   {id: "2", text: "Fax"}
   ]}  />
+
+### Disabled items
+
+Use the `disabled` property in the `items` prop to disable specific items.
+
+<ComboBox
+  titleText="Contact"
+  placeholder="Select contact method"
+  items={[
+    { id: "0", text: "Slack" },
+    { id: "1", text: "Email", disabled: true },
+    { id: "2", text: "Fax" },
+  ]}
+/>

--- a/docs/src/pages/components/Dropdown.svx
+++ b/docs/src/pages/components/Dropdown.svx
@@ -95,6 +95,20 @@ Set `direction` to `"top"` for the dropdown menu to appear above the input.
   {id: "1", text: "Email"},
   {id: "2", text: "Fax"}]}" />
 
+### Disabled items
+
+Use the `disabled` property in the `items` prop to disable specific items.
+
+<Dropdown
+  selectedId="0"
+  titleText="Contact"
+  items={[
+    { id: "0", text: "Slack" },
+    { id: "1", text: "Email", disabled: true },
+    { id: "2", text: "Fax" },
+  ]}
+/>
+
 ### Skeleton
 
 <DropdownSkeleton />

--- a/docs/src/pages/components/MultiSelect.svx
+++ b/docs/src/pages/components/MultiSelect.svx
@@ -146,3 +146,17 @@ Set `direction` to `"top"` for the dropdown menu to appear above the input.
     {id: "1", text: "Email"},
     {id: "2", text: "Fax"}]}"
   />
+
+### Disabled items
+
+Use the `disabled` property in the `items` prop to disable specific items.
+
+<MultiSelect
+  titleText="Contact"
+  label="Select contact methods..."
+  items={[
+    { id: "0", text: "Slack" },
+    { id: "1", text: "Email", disabled: true },
+    { id: "2", text: "Fax" },
+  ]}
+/>

--- a/src/ComboBox/ComboBox.svelte
+++ b/src/ComboBox/ComboBox.svelte
@@ -1,7 +1,7 @@
 <script>
   /**
    * @typedef {any} ComboBoxItemId
-   * @typedef {{ id: ComboBoxItemId; text: string; }} ComboBoxItem
+   * @typedef {{ id: ComboBoxItemId; text: string; disabled?: boolean; }} ComboBoxItem
    * @event {{ selectedId: ComboBoxItemId; selectedItem: ComboBoxItem }} select
    * @slot {{ item: ComboBoxItem; index: number }}
    */
@@ -133,6 +133,20 @@
     } else if (index >= _items.length) {
       index = 0;
     }
+    let disabled = items[index].disabled;
+
+    while (disabled) {
+      index = index + dir;
+
+      if (index < 0) {
+        index = items.length - 1;
+      } else if (index >= items.length) {
+        index = 0;
+      }
+
+      disabled = items[index].disabled;
+    }
+
     highlightedIndex = index;
   }
 
@@ -360,7 +374,12 @@
             id="{item.id}"
             active="{selectedId === item.id}"
             highlighted="{highlightedIndex === i}"
-            on:click="{() => {
+            disabled="{item.disabled}"
+            on:click="{(e) => {
+              if (item.disabled) {
+                e.stopPropagation();
+                return;
+              }
               selectedId = item.id;
               open = false;
 
@@ -369,6 +388,7 @@
               }
             }}"
             on:mouseenter="{() => {
+              if (item.disabled) return;
               highlightedIndex = i;
             }}"
           >

--- a/src/Dropdown/Dropdown.svelte
+++ b/src/Dropdown/Dropdown.svelte
@@ -2,7 +2,7 @@
   /**
    * @typedef {any} DropdownItemId
    * @typedef {string} DropdownItemText
-   * @typedef {{ id: DropdownItemId; text: DropdownItemText; }} DropdownItem
+   * @typedef {{ id: DropdownItemId; text: DropdownItemText; disabled?: boolean; }} DropdownItem
    * @event {{ selectedId: DropdownItemId, selectedItem: DropdownItem }} select
    * @slot {{ item: DropdownItem; index: number; }}
    */
@@ -122,6 +122,20 @@
       index = items.length - 1;
     } else if (index >= items.length) {
       index = 0;
+    }
+
+    let disabled = items[index].disabled;
+
+    while (disabled) {
+      index = index + dir;
+
+      if (index < 0) {
+        index = items.length - 1;
+      } else if (index >= items.length) {
+        index = 0;
+      }
+
+      disabled = items[index].disabled;
     }
 
     highlightedIndex = index;
@@ -251,11 +265,17 @@
             id="{item.id}"
             active="{selectedId === item.id}"
             highlighted="{highlightedIndex === i || selectedId === item.id}"
-            on:click="{() => {
+            disabled="{item.disabled}"
+            on:click="{(e) => {
+              if (item.disabled) {
+                e.stopPropagation();
+                return;
+              }
               selectedId = item.id;
               ref.focus();
             }}"
             on:mouseenter="{() => {
+              if (item.disabled) return;
               highlightedIndex = i;
             }}"
           >

--- a/src/ListBox/ListBoxMenuItem.svelte
+++ b/src/ListBox/ListBoxMenuItem.svelte
@@ -5,6 +5,9 @@
   /** Set to `true` to enable the highlighted state */
   export let highlighted = false;
 
+  /** Set to `true` to disable the menu item */
+  export let disabled = false;
+
   let ref = null;
 
   $: isTruncated = ref?.offsetWidth < ref?.scrollWidth;
@@ -17,6 +20,7 @@
   class:bx--list-box__menu-item--active="{active}"
   class:bx--list-box__menu-item--highlighted="{highlighted}"
   aria-selected="{active}"
+  disabled="{disabled ? true : undefined}"
   {...$$restProps}
   on:click
   on:mouseenter

--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -2,7 +2,7 @@
   /**
    * @typedef {any} MultiSelectItemId
    * @typedef {string} MultiSelectItemText
-   * @typedef {{ id: MultiSelectItemId; text: MultiSelectItemText; }} MultiSelectItem
+   * @typedef {{ id: MultiSelectItemId; text: MultiSelectItemText; disabled?: boolean; }} MultiSelectItem
    * @event {{ selectedIds: MultiSelectItemId[]; selected: MultiSelectItem[]; unselected: MultiSelectItem[]; }} select
    * @event {null} clear
    * @event {FocusEvent | CustomEvent<FocusEvent>} blur
@@ -208,6 +208,20 @@
       index = length - 1;
     } else if (index >= length) {
       index = 0;
+    }
+
+    let disabled = items[index].disabled;
+
+    while (disabled) {
+      index = index + direction;
+
+      if (index < 0) {
+        index = items.length - 1;
+      } else if (index >= items.length) {
+        index = 0;
+      }
+
+      disabled = items[index].disabled;
     }
 
     highlightedIndex = index;
@@ -481,13 +495,19 @@
             aria-selected="{item.checked}"
             active="{item.checked}"
             highlighted="{highlightedIndex === i}"
-            on:click="{() => {
+            disabled="{item.disabled}"
+            on:click="{(e) => {
+              if (item.disabled) {
+                e.stopPropagation();
+                return;
+              }
               sortedItems = sortedItems.map((_) =>
                 _.id === item.id ? { ..._, checked: !_.checked } : _
               );
               fieldRef.focus();
             }}"
             on:mouseenter="{() => {
+              if (item.disabled) return;
               highlightedIndex = i;
             }}"
           >
@@ -499,7 +519,7 @@
               tabindex="-1"
               id="checkbox-{item.id}"
               checked="{item.checked}"
-              disabled="{disabled}"
+              disabled="{item.disabled}"
               on:blur="{() => {
                 if (i === filteredItems.length - 1) open = false;
               }}"

--- a/tests/ComboBox.test.svelte
+++ b/tests/ComboBox.test.svelte
@@ -5,7 +5,7 @@
   const items: ComboBoxItem[] = [
     { id: 0, text: "Slack" },
     { id: "1", text: "Email" },
-    { id: "2", text: "Fax" },
+    { id: "2", text: "Fax", disabled: true },
   ];
 
   let ref: ComboBox;

--- a/tests/Dropdown.test.svelte
+++ b/tests/Dropdown.test.svelte
@@ -9,7 +9,7 @@
   items="{[
     { id: 0, text: 'Slack' },
     { id: '1', text: 'Email' },
-    { id: '2', text: 'Fax' },
+    { id: '2', text: 'Fax', disabled: true },
   ]}"
   on:select="{(e) => {
     console.log(e.detail.selectedId);

--- a/tests/MultiSelect.test.svelte
+++ b/tests/MultiSelect.test.svelte
@@ -10,7 +10,7 @@
   items="{[
     { id: 0, text: 'Slack' },
     { id: '1', text: 'Email' },
-    { id: '2', text: 'Fax' },
+    { id: '2', text: 'Fax', disabled: true },
   ]}"
   on:select="{(e) => {
     console.log(e.detail.selectedIds);

--- a/types/ComboBox/ComboBox.svelte.d.ts
+++ b/types/ComboBox/ComboBox.svelte.d.ts
@@ -6,6 +6,7 @@ export type ComboBoxItemId = any;
 export interface ComboBoxItem {
   id: ComboBoxItemId;
   text: string;
+  disabled?: boolean;
 }
 
 export interface ComboBoxProps

--- a/types/Dropdown/Dropdown.svelte.d.ts
+++ b/types/Dropdown/Dropdown.svelte.d.ts
@@ -8,6 +8,7 @@ export type DropdownItemText = string;
 export interface DropdownItem {
   id: DropdownItemId;
   text: DropdownItemText;
+  disabled?: boolean;
 }
 
 export interface DropdownProps

--- a/types/ListBox/ListBoxMenuItem.svelte.d.ts
+++ b/types/ListBox/ListBoxMenuItem.svelte.d.ts
@@ -14,6 +14,12 @@ export interface ListBoxMenuItemProps
    * @default false
    */
   highlighted?: boolean;
+
+  /**
+   * Set to `true` to disable the menu item
+   * @default false
+   */
+  disabled?: boolean;
 }
 
 export default class ListBoxMenuItem extends SvelteComponentTyped<

--- a/types/MultiSelect/MultiSelect.svelte.d.ts
+++ b/types/MultiSelect/MultiSelect.svelte.d.ts
@@ -8,6 +8,7 @@ export type MultiSelectItemText = string;
 export interface MultiSelectItem {
   id: MultiSelectItemId;
   text: MultiSelectItemText;
+  disabled?: boolean;
 }
 
 export interface MultiSelectProps


### PR DESCRIPTION
Closes #1326 

This PR adds the option to disable individual items in a `Dropdown`, `MultiSelect`, or `ComboBox`.

Set `item.disabled` to `true` for the item to be disabled.

**Example**

```svelte
<Dropdown
  titleText="Contact"
  selectedId="0"
  items={[
    { id: "0", text: "Slack" },
    { id: "1", text: "Email", disabled: true },
    { id: "2", text: "Fax" },
  ]}
/>
```