### PR TITLE
fix(modal): nested modals should correctly toggle the body class

### DIFF
--- a/src/ComposedModal/ComposedModal.svelte
+++ b/src/ComposedModal/ComposedModal.svelte
@@ -38,6 +38,7 @@
     afterUpdate,
   } from "svelte";
   import { writable } from "svelte/store";
+  import { modalsOpen, addModalId, removeModalId } from "../Modal/modalStore";
 
   const dispatch = createEventDispatcher();
   const label = writable(undefined);
@@ -45,6 +46,7 @@
   let buttonRef = null;
   let innerModal = null;
   let didClickInnerModal = false;
+  let id = "ccs-" + Math.random().toString(36);
 
   setContext("ComposedModal", {
     closeModal: () => {
@@ -78,6 +80,7 @@
     });
 
     return () => {
+      removeModalId(id);
       document.body.classList.remove("bx--body--with-modal-open");
     };
   });
@@ -87,14 +90,24 @@
       if (!open) {
         opened = false;
         dispatch("close");
-        document.body.classList.remove("bx--body--with-modal-open");
       }
     } else if (open) {
       opened = true;
       dispatch("open");
+    }
+
+    if ($modalsOpen.length > 0) {
       document.body.classList.add("bx--body--with-modal-open");
+    } else {
+      document.body.classList.remove("bx--body--with-modal-open");
     }
   });
+
+  $: if (open) {
+    addModalId(id);
+  } else {
+    removeModalId(id);
+  }
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->

--- a/src/Modal/Modal.svelte
+++ b/src/Modal/Modal.svelte
@@ -92,6 +92,7 @@
   import { createEventDispatcher, onMount, afterUpdate } from "svelte";
   import Close from "../icons/Close.svelte";
   import Button from "../Button/Button.svelte";
+  import { modalsOpen, addModalId, removeModalId } from "./modalStore";
 
   const dispatch = createEventDispatcher();
 
@@ -108,6 +109,7 @@
 
   onMount(() => {
     return () => {
+      removeModalId(id);
       document.body.classList.remove("bx--body--with-modal-open");
     };
   });
@@ -117,13 +119,17 @@
       if (!open) {
         opened = false;
         dispatch("close");
-        document.body.classList.remove("bx--body--with-modal-open");
       }
     } else if (open) {
       opened = true;
       focus();
       dispatch("open");
+    }
+
+    if ($modalsOpen.length > 0) {
       document.body.classList.add("bx--body--with-modal-open");
+    } else {
+      document.body.classList.remove("bx--body--with-modal-open");
     }
   });
 
@@ -142,6 +148,11 @@
       alertDialogProps.role = "alertdialog";
       alertDialogProps["aria-describedby"] = modalBodyId;
     }
+  }
+  $: if (open) {
+    addModalId(id);
+  } else {
+    removeModalId(id);
   }
 </script>
 

--- a/src/Modal/modalStore.js
+++ b/src/Modal/modalStore.js
@@ -1,0 +1,8 @@
+import { writable } from "svelte/store";
+
+export const modalsOpen = writable([]);
+
+export const addModalId = (id) => modalsOpen.update((ids) => [...ids, id]);
+
+export const removeModalId = (id) =>
+  modalsOpen.update((ids) => ids.filter((_id) => _id !== id));


### PR DESCRIPTION
Fixes #1324

If multiple modals are open at once, the "bx--body--with-modal-open" class may be unexpectedly removed when closing one of the modals.

The solution is to use a store to keep track of the open modals. The class should only be removed if no modal is open.