### PR TITLE
fix(data-table): do not overwrite `row.cells` property

### DIFF
--- a/src/DataTable/DataTable.svelte
+++ b/src/DataTable/DataTable.svelte
@@ -213,11 +213,11 @@
     } else {
       sortedRows = [...$tableRows].sort((a, b) => {
         const itemA = ascending
-          ? resolvePath(a, sortKey, "")
-          : resolvePath(b, sortKey, "");
+          ? resolvePath(a, sortKey)
+          : resolvePath(b, sortKey);
         const itemB = ascending
-          ? resolvePath(b, sortKey, "")
-          : resolvePath(a, sortKey, "");
+          ? resolvePath(b, sortKey)
+          : resolvePath(a, sortKey);
 
         if ($sortHeader.sort) return $sortHeader.sort(itemA, itemB);
 

--- a/src/DataTable/DataTable.svelte
+++ b/src/DataTable/DataTable.svelte
@@ -195,14 +195,18 @@
   $: if (radio || batchSelection) selectable = true;
   $: tableSortable.set(sortable);
   $: headerKeys = headers.map(({ key }) => key);
-  $: $tableRows = rows.map((row) => ({
-    ...row,
-    cells: headerKeys.map((key, index) => ({
-      key,
-      value: resolvePath(row, key),
-      display: headers[index].display,
-    })),
-  }));
+  $: tableCellsByRowId = rows.reduce(
+    (rows, row) => ({
+      ...rows,
+      [row.id]: headerKeys.map((key, index) => ({
+        key,
+        value: resolvePath(row, key),
+        display: headers[index].display,
+      })),
+    }),
+    {}
+  );
+  $: $tableRows = rows;
   $: sortedRows = [...$tableRows];
   $: ascending = $sortHeader.sortDirection === "ascending";
   $: sortKey = $sortHeader.key;
@@ -464,7 +468,7 @@
               {/if}
             </td>
           {/if}
-          {#each row.cells as cell, j (cell.key)}
+          {#each tableCellsByRowId[row.id] as cell, j (cell.key)}
             {#if headers[j].empty}
               <td class:bx--table-column-menu="{headers[j].columnMenu}">
                 <slot

--- a/src/DataTable/DataTable.svelte
+++ b/src/DataTable/DataTable.svelte
@@ -146,11 +146,13 @@
       .map(({ key }, i) => ({ key, id: key }))
       .reduce((a, c) => ({ ...a, [c.key]: c.id }), {})
   );
-  const resolvePath = (object, path) =>
-    path
+  const resolvePath = (object, path) => {
+    if (path in object) return object[path];
+    return path
       .split(/[\.\[\]\'\"]/)
       .filter((p) => p)
       .reduce((o, p) => (o && typeof o === "object" ? o[p] : o), object);
+  };
 
   setContext("DataTable", {
     sortHeader,

--- a/src/DataTable/ToolbarSearch.svelte
+++ b/src/DataTable/ToolbarSearch.svelte
@@ -50,7 +50,7 @@
       if (shouldFilterRows === true) {
         rows = rows.filter((row) => {
           return Object.entries(row)
-            .filter(([key]) => !["cells", "id"].includes(key))
+            .filter(([key]) => key !== "id")
             .some(([key, _value]) => {
               if (typeof _value === "string" || typeof _value === "number") {
                 return (_value + "")


### PR DESCRIPTION
Currently, `DataTable` will add a `cells` property to each row which contains computed metadata for each header (e.g., key, display value, resolved value if using nested headers).

This is undesirable as it overrides the "cells" property in a row.

Although technically a breaking change, I'm considering this a fix as no row properties should be overridden in the first place.

Additional changes:

- chore: touch up prop descriptions (use periods where needed)
- refactor: remove unneeded third argument in `resolvePath()`
- perf: when resolving path, early return `object[path]` if value exists