### PR TITLE
perf(data-table): save rows reference when reducing

### DIFF
--- a/src/DataTable/DataTable.svelte
+++ b/src/DataTable/DataTable.svelte
@@ -199,17 +199,14 @@
   }
   $: if (radio || batchSelection) selectable = true;
   $: headerKeys = headers.map(({ key }) => key);
-  $: tableCellsByRowId = rows.reduce(
-    (rows, row) => ({
-      ...rows,
-      [row.id]: headerKeys.map((key, index) => ({
-        key,
-        value: resolvePath(row, key),
-        display: headers[index].display,
-      })),
-    }),
-    {}
-  );
+  $: tableCellsByRowId = rows.reduce((rows, row) => {
+    rows[row.id] = headerKeys.map((key, index) => ({
+      key,
+      value: resolvePath(row, key),
+      display: headers[index].display,
+    }));
+    return rows;
+  }, {});
   $: $tableRows = rows;
   $: sortedRows = [...$tableRows];
   $: ascending = sortDirection === "ascending";


### PR DESCRIPTION
https://github.com/carbon-design-system/carbon-components-svelte/commit/d2cdb8eb0f5a1bdf3e7e8d01ae859542d470c9d4#r75383503

https://github.com/carbon-design-system/carbon-components-svelte/pull/1336 isn't released yet; this PR applies a suggestion to save the `rows` reference when reducing it to an object.