### PR TITLE
Simplify open modal tracking code

### DIFF
--- a/src/ComposedModal/ComposedModal.svelte
+++ b/src/ComposedModal/ComposedModal.svelte
@@ -96,11 +96,7 @@
       dispatch("open");
     }
 
-    if ($modalsOpen.length > 0) {
-      document.body.classList.add("bx--body--with-modal-open");
-    } else {
-      document.body.classList.remove("bx--body--with-modal-open");
-    }
+    document.body.classList.toggle("bx--body--with-modal-open", $modalsOpen.length > 0);
   });
 
   $: if (open) {

--- a/src/ComposedModal/ComposedModal.svelte
+++ b/src/ComposedModal/ComposedModal.svelte
@@ -46,7 +46,6 @@
   let buttonRef = null;
   let innerModal = null;
   let didClickInnerModal = false;
-  const id = "ccs-" + Math.random().toString(36);
 
   setContext("ComposedModal", {
     closeModal: () => {

--- a/src/ComposedModal/ComposedModal.svelte
+++ b/src/ComposedModal/ComposedModal.svelte
@@ -38,7 +38,7 @@
     afterUpdate,
   } from "svelte";
   import { writable } from "svelte/store";
-  import { modalsOpen, addModalId, removeModalId } from "../Modal/modalStore";
+  import { trackModal } from "../Modal/modalStore";
 
   const dispatch = createEventDispatcher();
   const label = writable(undefined);
@@ -74,15 +74,14 @@
   let opened = false;
   $: didOpen = open;
 
+  const openStore = writable(open);
+  $: $openStore = open;
+  trackModal(openStore);
+
   onMount(() => {
     tick().then(() => {
       focus();
     });
-
-    return () => {
-      removeModalId(id);
-      document.body.classList.remove("bx--body--with-modal-open");
-    };
   });
 
   afterUpdate(() => {
@@ -95,15 +94,7 @@
       opened = true;
       dispatch("open");
     }
-
-    document.body.classList.toggle("bx--body--with-modal-open", $modalsOpen.length > 0);
   });
-
-  $: if (open) {
-    addModalId(id);
-  } else {
-    removeModalId(id);
-  }
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->

--- a/src/ComposedModal/ComposedModal.svelte
+++ b/src/ComposedModal/ComposedModal.svelte
@@ -46,7 +46,7 @@
   let buttonRef = null;
   let innerModal = null;
   let didClickInnerModal = false;
-  let id = "ccs-" + Math.random().toString(36);
+  const id = "ccs-" + Math.random().toString(36);
 
   setContext("ComposedModal", {
     closeModal: () => {

--- a/src/Modal/Modal.svelte
+++ b/src/Modal/Modal.svelte
@@ -126,11 +126,7 @@
       dispatch("open");
     }
 
-    if ($modalsOpen.length > 0) {
-      document.body.classList.add("bx--body--with-modal-open");
-    } else {
-      document.body.classList.remove("bx--body--with-modal-open");
-    }
+    document.body.classList.toggle("bx--body--with-modal-open", $modalsOpen.length > 0);
   });
 
   $: modalLabelId = `bx--modal-header__label--modal-${id}`;

--- a/src/Modal/Modal.svelte
+++ b/src/Modal/Modal.svelte
@@ -89,10 +89,11 @@
   /** Obtain a reference to the top-level HTML element */
   export let ref = null;
 
-  import { createEventDispatcher, onMount, afterUpdate } from "svelte";
+  import { createEventDispatcher, afterUpdate } from "svelte";
   import Close from "../icons/Close.svelte";
   import Button from "../Button/Button.svelte";
-  import { modalsOpen, addModalId, removeModalId } from "./modalStore";
+  import { trackModal } from "./modalStore";
+  import { writable } from "svelte/store";
 
   const dispatch = createEventDispatcher();
 
@@ -107,12 +108,9 @@
     node.focus();
   }
 
-  onMount(() => {
-    return () => {
-      removeModalId(id);
-      document.body.classList.remove("bx--body--with-modal-open");
-    };
-  });
+  const openStore = writable(open);
+  $: $openStore = open;
+  trackModal(openStore);
 
   afterUpdate(() => {
     if (opened) {
@@ -125,8 +123,6 @@
       focus();
       dispatch("open");
     }
-
-    document.body.classList.toggle("bx--body--with-modal-open", $modalsOpen.length > 0);
   });
 
   $: modalLabelId = `bx--modal-header__label--modal-${id}`;
@@ -134,12 +130,6 @@
   $: modalBodyId = `bx--modal-body--${id}`;
   $: ariaLabel =
     modalLabel || $$props["aria-label"] || modalAriaLabel || modalHeading;
-
-  $: if (open) {
-    addModalId(id);
-  } else {
-    removeModalId(id);
-  }
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->

--- a/src/Modal/modalStore.js
+++ b/src/Modal/modalStore.js
@@ -7,6 +7,9 @@ const stores = new Set();
 /** Store for the number of open modals. */
 const modalsOpen = writable(0);
 
+const updateModalsOpen = () =>
+  modalsOpen.set([...stores].filter((open) => get(open)).length);
+
 /**
  * Adds a modal's store to the open modal tracking.
  * Has to be called during component initialization.
@@ -17,16 +20,13 @@ const modalsOpen = writable(0);
 export const trackModal = (openStore) =>
   onMount(() => {
     stores.add(openStore);
-
-    const unsubscribe = openStore.subscribe(() =>
-      modalsOpen.set([...stores].filter((open) => get(open)).length)
-    );
+    const unsubscribe = openStore.subscribe(updateModalsOpen);
 
     return () => {
       unsubscribe();
-      if (get(openStore)) modalsOpen.update((count) => count - 1);
-
       stores.delete(openStore);
+
+      updateModalsOpen();
     };
   });
 


### PR DESCRIPTION
- Class application:
  - Can be simplified using `toggle`.
  - Can be extracted, so it does not need to be duplicated across components.
- On destroy cleanup can be extracted and unified with open/close logic.
- `ComposedModal` ID can be removed again.

Addresses comments on [`22f93ee`](https://github.com/carbon-design-system/carbon-components-svelte/commit/22f93ee675c04e96a3119fdd76eaa273614891cd)