### PR TITLE
fix(tree-view): fix type error when navigating an expanded node

### DIFF
--- a/src/TreeView/TreeViewNodeList.svelte
+++ b/src/TreeView/TreeViewNodeList.svelte
@@ -109,7 +109,7 @@
 
       if (parent && e.key === 'ArrowRight') {
         if (expanded) {
-          ref.lastChild.firstChild.focus();
+          ref.lastChild.firstElementChild?.focus();
         } else {
           expanded = true;
           expandNode(node, true);


### PR DESCRIPTION
Fixes #1349

Using keyboard navigation on an expanded node can produce the type error "...firstChild.focus" is not a function.

This is because the white space in the DOM can cause `lastChild.firstChild` to be a `#text` node, which does not [contain a `focus` method](https://developer.mozilla.org/en-US/docs/Web/API/Node/firstChild).

The solution is to use the [`firstElementChild`](https://developer.mozilla.org/en-US/docs/Web/API/Element/firstElementChild) API, which should return the first child element.