### PR TITLE
fix(select): use first `SelectItem` value as default if `selected` is undefined

### DIFF
--- a/src/Select/Select.svelte
+++ b/src/Select/Select.svelte
@@ -71,8 +71,26 @@
 
   const dispatch = createEventDispatcher();
   const selectedValue = writable(selected);
+  const defaultSelectId = writable(null);
+  const defaultValue = writable(null);
 
-  setContext("Select", { selectedValue });
+  setContext("Select", {
+    selectedValue,
+    setDefaultValue: (id, value) => {
+      /**
+       * Use the first `SelectItem` value as the
+       * default value if `selected` is `undefined`.
+       */
+      if ($defaultValue === null) {
+        defaultSelectId.set(id);
+        defaultValue.set(value);
+      } else {
+        if ($defaultSelectId === id) {
+          selectedValue.set(value);
+        }
+      }
+    },
+  });
 
   afterUpdate(() => {
     selected = $selectedValue;
@@ -80,7 +98,7 @@
   });
 
   $: errorId = `error-${id}`;
-  $: selectedValue.set(selected);
+  $: selectedValue.set(selected ?? $defaultValue);
 </script>
 
 <div class:bx--form-item="{true}" {...$$restProps}>

--- a/src/Select/SelectItem.svelte
+++ b/src/Select/SelectItem.svelte
@@ -13,7 +13,10 @@
 
   import { getContext, onMount } from "svelte";
 
+  const id = "ccs-" + Math.random().toString(36);
   const ctx = getContext("Select") || getContext("TimePickerSelect");
+
+  $: ctx?.setDefaultValue?.(id, value);
 
   let selected = false;
 


### PR DESCRIPTION
Fixes #570 

If the `selected` prop is not provided to `Select`, the value of the first `SelectItem` should be used. Currently, the `SelectItem` value is shown in the UI as the default, but `selected` is not updated in turn.

This logic matches the native behavior of the `select` element.

The specific use case is that – because `selected` is an optional prop – no value may be initially provided. The consumer may either bind to `selected` or opt not to use it all. For example, they may choose to use the dispatched `change` event.

```svelte
<script>
  import { Select, SelectItem } from "carbon-components-svelte";

  let selected = undefined;
</script>

<Select
  labelText="Carbon theme"
  bind:selected
  on:change={(e) => {
    console.log("change", e.detail);
  }}
>
  <SelectItem value="white" text="White" />
  <SelectItem value="g10" text="Gray 10" />
  <SelectItem value="g80" text="Gray 80" />
  <SelectItem value="g90" text="Gray 90" />
  <SelectItem value="g100" text="Gray 100" />
</Select>
```