### PR TITLE
fix(select): do not dispatch "change" event on initial load

### DIFF
--- a/src/Select/Select.svelte
+++ b/src/Select/Select.svelte
@@ -108,9 +108,16 @@
     selectedValue.set(value);
   };
 
+  let prevSelected = undefined;
+
   afterUpdate(() => {
     selected = $selectedValue;
-    dispatch("change", $selectedValue);
+
+    if (prevSelected !== undefined && selected !== prevSelected) {
+      dispatch("change", $selectedValue);
+    }
+
+    prevSelected = selected;
   });
 
   $: errorId = `error-${id}`;


### PR DESCRIPTION
Follow-up to #1353

If `selected` is `undefined` or not provided, the "change" event will be dispatched since the first `SelectItem` value will be set as the default.

The "change" event should only be dispatched when the value is actually changed.

```svelte
<script>
  import { Select, SelectItem, Button } from "carbon-components-svelte";

  let selected = undefined;
</script>

{selected}
{typeof selected}

<Select
  bind:selected
  on:change={(e) => {
    console.log("change", e.detail, typeof e.detail);
  }}
>
  <SelectItem value={initialValue}  />
  <SelectItem value={1}  />
  <SelectItem value={2} />
  <SelectItem value={3}  />
  <SelectItem value={4}  />
</Select>

<Button
  on:click={() => (initialValue = typeof initialValue === "number" ? "0" : 0)}
>
  Toggle
</Button>

<Button
  on:click={() => {
    selected = undefined;
    // selected is set to the first value; "change" should fire
  }}
>
  Set undefined
</Button>
```