### PR TITLE
chore(select): update dispatched change event type

### DIFF
--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -3173,12 +3173,12 @@ None.
 
 ### Events
 
-| Event name | Type       | Detail              |
-| :--------- | :--------- | :------------------ |
-| change     | dispatched | <code>string</code> |
-| input      | forwarded  | --                  |
-| focus      | forwarded  | --                  |
-| blur       | forwarded  | --                  |
+| Event name | Type       | Detail                            |
+| :--------- | :--------- | :-------------------------------- |
+| change     | dispatched | <code>string &#124; number</code> |
+| input      | forwarded  | --                                |
+| focus      | forwarded  | --                                |
+| blur       | forwarded  | --                                |
 
 ## `SelectItem`
 

--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -10236,7 +10236,7 @@
         }
       ],
       "events": [
-        { "type": "dispatched", "name": "change", "detail": "string" },
+        { "type": "dispatched", "name": "change", "detail": "string | number" },
         { "type": "forwarded", "name": "input", "element": "select" },
         { "type": "forwarded", "name": "focus", "element": "select" },
         { "type": "forwarded", "name": "blur", "element": "select" }

--- a/src/Select/Select.svelte
+++ b/src/Select/Select.svelte
@@ -1,6 +1,6 @@
 <script>
   /**
-   * @event {string} change
+   * @event {string | number} change
    */
 
   /**

--- a/types/Select/Select.svelte.d.ts
+++ b/types/Select/Select.svelte.d.ts
@@ -109,7 +109,7 @@ export interface SelectProps
 export default class Select extends SvelteComponentTyped<
   SelectProps,
   {
-    change: CustomEvent<string>;
+    change: CustomEvent<string | number>;
     input: WindowEventMap["input"];
     focus: WindowEventMap["focus"];
     blur: WindowEventMap["blur"];


### PR DESCRIPTION
Follow-up to #1355

This updates the "change" event type to reflect the `selected` prop type `string | number`.