### PR TITLE
fix(composed-modal): node to focus is possibly `null`

### DIFF
--- a/src/ComposedModal/ComposedModal.svelte
+++ b/src/ComposedModal/ComposedModal.svelte
@@ -66,7 +66,7 @@
   function focus(element) {
     if (selectorPrimaryFocus == null) return;
     const node =
-      (element || innerModal).querySelector(selectorPrimaryFocus) || buttonRef;
+      (element || innerModal)?.querySelector(selectorPrimaryFocus) || buttonRef;
     if (node != null) node.focus();
   }
 


### PR DESCRIPTION
Fixes #1360

This resolves the type error `Cannot read properties of null (reading 'querySelector')`.