### PR TITLE
fix(side-nav-menu): expanded `SideNavMenu` should not have a max-height 

### DIFF
--- a/docs/src/global.css
+++ b/docs/src/global.css
@@ -262,7 +262,3 @@ main.bx--content {
     z-index: 1;
   }
 }
-
-.bx--side-nav__submenu[aria-expanded="true"] + .bx--side-nav__menu {
-  max-height: 144rem;
-}

--- a/src/UIShell/SideNavMenu.svelte
+++ b/src/UIShell/SideNavMenu.svelte
@@ -48,7 +48,11 @@
       <svelte:component this="{ChevronDown}" title="Open Menu" tabindex="0" />
     </div>
   </button>
-  <ul role="menu" class:bx--side-nav__menu="{true}">
+  <ul
+    role="menu"
+    class:bx--side-nav__menu="{true}"
+    style="{expanded && 'max-height: none'}"
+  >
     <slot />
   </ul>
 </li>


### PR DESCRIPTION
The Carbon styles apply a max-height of `93.75rem` to the `SideNavMenu`. Although this seems to be a deliberate design choice, I don't think a cap should be set.

This overrides the max-height to be `none` if the menu is expanded.