### PR TITLE
fix(side-nav-menu): chevron icon should not be focusable

### DIFF
--- a/src/UIShell/SideNavMenu.svelte
+++ b/src/UIShell/SideNavMenu.svelte
@@ -45,7 +45,7 @@
       class:bx--side-nav__icon--small="{true}"
       class:bx--side-nav__submenu-chevron="{true}"
     >
-      <svelte:component this="{ChevronDown}" title="Open Menu" tabindex="0" />
+      <svelte:component this="{ChevronDown}" title="Open Menu" />
     </div>
   </button>
   <ul role="menu" class:bx--side-nav__menu="{true}">


### PR DESCRIPTION
The chevron icon in the `SideNavMenu` should not be focusable.

See the recording below for the current behavior:

https://user-images.githubusercontent.com/10718366/175302933-bbe4e8b0-2db6-44ba-9f2f-12d98b12d864.mov

