### PR TITLE
refactor(code-snippet): pass required `text` prop to `CopyButton`

### DIFF
--- a/src/CodeSnippet/CodeSnippet.svelte
+++ b/src/CodeSnippet/CodeSnippet.svelte
@@ -110,11 +110,6 @@
     if (height > 0) showMoreLess = ref.getBoundingClientRect().height > 255;
   }
 
-  function copyCode() {
-    copy(code);
-    dispatch("copy");
-  }
-
   $: expandText = expanded ? showLessText : showMoreText;
   $: minHeight = expanded ? 16 * 15 : 48;
   $: maxHeight = expanded ? "none" : 16 * 15 + "px";
@@ -174,7 +169,8 @@
       {...$$restProps}
       on:click
       on:click="{() => {
-        copyCode();
+        copy(code);
+        dispatch('copy');
         if (animation === 'fade-in') return;
         animation = 'fade-in';
         timeout = setTimeout(() => {
@@ -229,12 +225,14 @@
     </div>
     {#if !hideCopyButton}
       <CopyButton
+        text="{code}"
+        copy="{copy}"
         disabled="{disabled}"
         feedback="{feedback}"
         feedbackTimeout="{feedbackTimeout}"
         iconDescription="{copyButtonDescription}"
         on:click
-        on:click="{copyCode}"
+        on:copy
         on:animationend
       />
     {/if}


### PR DESCRIPTION
Using the multi-line `CodeSnippet` will log a warning in development because the `text` prop in `CopyButton` is marked as required,

```
<CopyButton> was created without expected prop 'text'
```

This PR refactors `CodeSnippet` to pass the `text` prop to `CopyButton`. It also passed down the `copy` prop and forwards the dispatched `copy` event.