### PR TITLE
fix(side-nav-menu): remove title attribute from menu icon

### DIFF
--- a/src/UIShell/SideNavMenu.svelte
+++ b/src/UIShell/SideNavMenu.svelte
@@ -45,7 +45,7 @@
       class:bx--side-nav__icon--small="{true}"
       class:bx--side-nav__submenu-chevron="{true}"
     >
-      <svelte:component this="{ChevronDown}" title="Open Menu" />
+      <ChevronDown />
     </div>
   </button>
   <ul


### PR DESCRIPTION
The chevron icon in the UI Shell `SideNavMenu` icon should not have a title attribute.

Ref: https://github.com/carbon-design-system/carbon/blob/f17b8147b7e66325bbee6bcc6a6180d9aa5ec4d5/packages/react/src/components/UIShell/SideNavMenu.js#L71