### PR TITLE
docs: rename `ComboBox` example, do not open modal in `DatePicker` by default

### DIFF
--- a/docs/src/pages/components/ComboBox.svx
+++ b/docs/src/pages/components/ComboBox.svx
@@ -24,7 +24,7 @@ Override the default slot to customize the display of each item. Access the item
 
 <FileSource src="/framed/ComboBox/ComboBoxSlot" />
 
-### Selected id
+### Initial selected id
 
 <ComboBox titleText="Contact" placeholder="Select contact method"
 selectedId="1"

--- a/docs/src/pages/framed/DatePicker/DatePickerModal.svelte
+++ b/docs/src/pages/framed/DatePicker/DatePickerModal.svelte
@@ -1,12 +1,22 @@
 <script>
-  import { Modal, DatePicker, DatePickerInput } from "carbon-components-svelte";
+  import {
+    Button,
+    Modal,
+    DatePicker,
+    DatePickerInput,
+  } from "carbon-components-svelte";
+
+  let open = false;
 </script>
 
+<Button on:click="{() => (open = true)}">Select date</Button>
+
 <Modal
-  open
+  bind:open
   modalHeading="Meeting date"
   primaryButtonText="Confirm"
   secondaryButtonText="Cancel"
+  on:click:button--secondary="{() => (open = false)}"
 >
   <DatePicker datePickerType="single" style="min-height: 420px">
     <DatePickerInput labelText="Meeting date" placeholder="mm/dd/yyyy" />


### PR DESCRIPTION
**Documentation**

- rename `ComboBox` example "Selected id" to "Initial selected id"
- revise `DatePicker` example "DatePicker in a modal" to prevent the iframe from stealing focus