### PR TITLE
chore(code-snippet): preserve custom copy event type

### DIFF
--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -567,12 +567,12 @@ None.
 | :----------- | :--------- | :---------------- |
 | expand       | dispatched | <code>null</code> |
 | collapse     | dispatched | <code>null</code> |
+| copy         | dispatched | <code>null</code> |
 | click        | forwarded  | --                |
 | mouseover    | forwarded  | --                |
 | mouseenter   | forwarded  | --                |
 | mouseleave   | forwarded  | --                |
 | animationend | forwarded  | --                |
-| copy         | dispatched | <code>null</code> |
 
 ## `CodeSnippetSkeleton`
 

--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -1235,6 +1235,7 @@
       "events": [
         { "type": "dispatched", "name": "expand", "detail": "null" },
         { "type": "dispatched", "name": "collapse", "detail": "null" },
+        { "type": "dispatched", "name": "copy", "detail": "null" },
         {
           "type": "forwarded",
           "name": "click",
@@ -1255,12 +1256,7 @@
           "name": "mouseleave",
           "element": "CodeSnippetSkeleton"
         },
-        {
-          "type": "forwarded",
-          "name": "animationend",
-          "element": "CopyButton"
-        },
-        { "type": "dispatched", "name": "copy", "detail": "null" }
+        { "type": "forwarded", "name": "animationend", "element": "CopyButton" }
       ],
       "typedefs": [],
       "rest_props": { "type": "InlineComponent", "name": "CodeSnippetSkeleton" }

--- a/src/CodeSnippet/CodeSnippet.svelte
+++ b/src/CodeSnippet/CodeSnippet.svelte
@@ -2,6 +2,7 @@
   /**
    * @event {null} expand
    * @event {null} collapse
+   * @event {null} copy
    */
 
   /**

--- a/types/CodeSnippet/CodeSnippet.svelte.d.ts
+++ b/types/CodeSnippet/CodeSnippet.svelte.d.ts
@@ -122,12 +122,12 @@ export default class CodeSnippet extends SvelteComponentTyped<
   {
     expand: CustomEvent<null>;
     collapse: CustomEvent<null>;
+    copy: CustomEvent<null>;
     click: WindowEventMap["click"];
     mouseover: WindowEventMap["mouseover"];
     mouseenter: WindowEventMap["mouseenter"];
     mouseleave: WindowEventMap["mouseleave"];
     animationend: WindowEventMap["animationend"];
-    copy: CustomEvent<null>;
   },
   { default: {} }
 > {}


### PR DESCRIPTION
Follow-up to #1372

#1372 forwarded instead of dispatched a custom `copy` event. If it's not explicitly annotated, `sveld` will assume it's a native event.