### PR TITLE
docs(notification): add examples "Prevent default close behavior"

### DIFF
--- a/docs/src/pages/components/InlineNotification.svx
+++ b/docs/src/pages/components/InlineNotification.svx
@@ -11,6 +11,21 @@ source: Notification/InlineNotification.svelte
 
 <InlineNotification title="Error:" subtitle="An internal server error occurred." />
 
+### Prevent default close behavior
+
+`InlineNotification` is a controlled component. Prevent the default close behavior using the `e.preventDefault()` method in the dispatched `on:close` event.
+
+<InlineNotification svx-ignore lowContrast title="Note:" kind="info" hideCloseButton>
+  <div class="body-short-01">
+    Svelte version 3.48.0 or greater is required.
+  </div>
+</InlineNotification>
+
+<InlineNotification title="Error" subtitle="An internal server error occurred." on:close={(e) => {
+  e.preventDefault();
+  // custom close logic (e.g., transitions)
+}} />
+
 ### Slottable title, subtitle
 
 <InlineNotification>

--- a/docs/src/pages/components/ToastNotification.svx
+++ b/docs/src/pages/components/ToastNotification.svx
@@ -3,13 +3,28 @@ source: Notification/ToastNotification.svelte
 ---
 
 <script>
-  import { ToastNotification } from "carbon-components-svelte";
+  import { ToastNotification, InlineNotification } from "carbon-components-svelte";
   import Preview from "../../components/Preview.svelte";
 </script>
 
 ### Default (error)
 
 <ToastNotification title="Error" subtitle="An internal server error occurred." caption="{new Date().toLocaleString()}" />
+
+### Prevent default close behavior
+
+`ToastNotification` is a controlled component. Prevent the default close behavior using the `e.preventDefault()` method in the dispatched `on:close` event.
+
+<InlineNotification svx-ignore lowContrast title="Note:" kind="info" hideCloseButton>
+  <div class="body-short-01">
+    Svelte version 3.48.0 or greater is required.
+  </div>
+</InlineNotification>
+
+<ToastNotification title="Error" subtitle="An internal server error occurred." caption="{new Date().toLocaleString()}" on:close={(e) => {
+  e.preventDefault();
+  // custom close logic (e.g., transitions)
+}} />
 
 ### Slottable title, subtitle, caption
 


### PR DESCRIPTION
Follow-up to #1379

This adds examples "Prevent default close behavior" to `ToastNotification` and `InlineNotification`.

Svelte version 3.48.0 is required to leverage [cancellable events](https://svelte.dev/docs#run-time-svelte-createeventdispatcher).