### PR TITLE
Revert "fix(notification): `on:close` should be cancellable (#1379)"

### DIFF
--- a/src/Notification/InlineNotification.svelte
+++ b/src/Notification/InlineNotification.svelte
@@ -40,14 +40,8 @@
   let timeoutId = undefined;
 
   function close(closeFromTimeout) {
-    const shouldContinue = dispatch(
-      "close",
-      { timeout: closeFromTimeout === true },
-      { cancelable: true }
-    );
-    if (shouldContinue) {
-      open = false;
-    }
+    open = false;
+    dispatch("close", { timeout: closeFromTimeout === true });
   }
 
   onMount(() => {

--- a/src/Notification/ToastNotification.svelte
+++ b/src/Notification/ToastNotification.svelte
@@ -43,14 +43,8 @@
   let timeoutId = undefined;
 
   function close(closeFromTimeout) {
-    const shouldContinue = dispatch(
-      "close",
-      { timeout: closeFromTimeout === true },
-      { cancelable: true }
-    );
-    if (shouldContinue) {
-      open = false;
-    }
+    open = false;
+    dispatch("close", { timeout: closeFromTimeout === true });
   }
 
   onMount(() => {


### PR DESCRIPTION
This reverts commit 924b6d352eebf5c82da63f0ead450dc59e80ca30.

v0.66.2 actually contains breaking changes. It breaks the close behavior of `ToastNotification` and `InlineNotifiation` if svelte version 3.48 or greater is not used.

I'm going to revert, publish a patch, deprecate v0.66.2, and re-revert in v0.67.0.