### PR TITLE
fix(side-nav): set high `z-index` on open overlay

### DIFF
--- a/src/UIShell/SideNav.svelte
+++ b/src/UIShell/SideNav.svelte
@@ -56,6 +56,7 @@
     }}"
     class:bx--side-nav__overlay="{true}"
     class:bx--side-nav__overlay-active="{isOpen}"
+    style="{isOpen && 'z-index: 6000'}"
   ></div>
 {/if}
 <nav


### PR DESCRIPTION
Fixes #786 

See https://github.com/carbon-design-system/carbon-components-svelte/issues/786#issuecomment-1181923149 for a repro.

The `SideNav` overlay does not have a `z-index` set when active. This can cause other elements to visually supersede it. A hotfix would be to manually apply a `z-index` value when the overlay is active.

The rationale for the value `6000` is that it corresponds to the [`overlay` z-index](https://github.com/carbon-design-system/carbon/blob/5825cb460bb147bc7580bda93845b80a66a8ba51/packages/styles/scss/utilities/_z-index.scss#L18) as defined in Carbon styles.
