### PR TITLE
fix(side-nav): Remove content left margin when side nav collapsed

### DIFF
--- a/docs/src/global.css
+++ b/docs/src/global.css
@@ -246,7 +246,6 @@ main.bx--content {
 
 @media (max-width: 1056px) {
   .bx--side-nav ~ .bx--content {
-    margin-left: 0;
     padding-left: 1rem;
     padding-right: 1rem;
   }

--- a/src/UIShell/SideNav.svelte
+++ b/src/UIShell/SideNav.svelte
@@ -74,3 +74,9 @@
 >
   <slot />
 </nav>
+
+<style>
+  :global(.bx--side-nav--collapsed ~ .bx--content) {
+    margin-left: 0;
+  }
+</style>


### PR DESCRIPTION
As described in #1145, when a SideNav is used outside a header, a 3rem margin is applied to the site Content block, even when the side navigation component is collapsed. 

![image](https://user-images.githubusercontent.com/6686319/179641286-6f98e4b5-b813-4457-9513-7177ba06f955.png)

This was manually overwritten with a CSS styling rule in the docs site. The purpose of this PR is to bring that change to the component so that it is applied by default, ensuring there is no extraneous left margin on smaller screens.

Fixes #1145