### PR TITLE
fix(toggle): add missing `hideLabel` prop 

### DIFF
--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -4347,6 +4347,7 @@ export type CarbonTheme = "white" | "g10" | "g80" | "g90" | "g100";
 | labelA    | No       | <code>let</code> | No       | <code>string</code>                | <code>"Off"</code>                               | Specify the label for the untoggled state       |
 | labelB    | No       | <code>let</code> | No       | <code>string</code>                | <code>"On"</code>                                | Specify the label for the toggled state         |
 | labelText | No       | <code>let</code> | No       | <code>string</code>                | <code>""</code>                                  | Specify the label text                          |
+| hideLabel | No       | <code>let</code> | No       | <code>boolean</code>               | <code>false</code>                               | Set to `true` to visually hide the label text   |
 | id        | No       | <code>let</code> | No       | <code>string</code>                | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the input element                 |
 | name      | No       | <code>let</code> | No       | <code>string</code>                | <code>undefined</code>                           | Specify a name attribute for the checkbox input |
 

--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -13495,6 +13495,18 @@
           "reactive": false
         },
         {
+          "name": "hideLabel",
+          "kind": "let",
+          "description": "Set to `true` to visually hide the label text",
+          "type": "boolean",
+          "value": "false",
+          "isFunction": false,
+          "isFunctionDeclaration": false,
+          "isRequired": false,
+          "constant": false,
+          "reactive": false
+        },
+        {
           "name": "id",
           "kind": "let",
           "description": "Set an id for the input element",

--- a/docs/src/pages/components/Toggle.svx
+++ b/docs/src/pages/components/Toggle.svx
@@ -23,6 +23,12 @@ components: ["Toggle", "ToggleSkeleton"]
 
 <Toggle labelText="Push notifications" on:toggle={e => console.log(e.detail)} />
 
+### Hidden label text
+
+Set `hideLabel` to `true` to visually hide the label text. It's recommended to still specify `labelText` for screen reader accessibility.
+
+<Toggle labelText="Push notifications" hideLabel />
+
 ### Custom labels
 
 <Toggle labelText="Push notifications" labelA="No" labelB="Yes" />

--- a/src/Toggle/Toggle.svelte
+++ b/src/Toggle/Toggle.svelte
@@ -24,6 +24,9 @@
   /** Specify the label text */
   export let labelText = "";
 
+  /** Set to `true` to visually hide the label text */
+  export let hideLabel = false;
+
   /** Set an id for the input element */
   export let id = "ccs-" + Math.random().toString(36);
 
@@ -76,9 +79,11 @@
     for="{id}"
     class:bx--toggle-input__label="{true}"
   >
-    <slot name="labelText">
-      {labelText}
-    </slot>
+    <span class:bx--visually-hidden="{hideLabel}">
+      <slot name="labelText">
+        {labelText}
+      </slot>
+    </span>
     <span class:bx--toggle__switch="{true}">
       <span aria-hidden="true" class:bx--toggle__text--off="{true}">
         <slot name="labelA">

--- a/tests/Toggle.test.svelte
+++ b/tests/Toggle.test.svelte
@@ -2,7 +2,7 @@
   import { Toggle, ToggleSkeleton } from "../types";
 </script>
 
-<Toggle labelText="Push notifications" />
+<Toggle labelText="Push notifications" hideLabel />
 
 <Toggle
   labelText="Push notifications"

--- a/types/Toggle/Toggle.svelte.d.ts
+++ b/types/Toggle/Toggle.svelte.d.ts
@@ -40,6 +40,12 @@ export interface ToggleProps
   labelText?: string;
 
   /**
+   * Set to `true` to visually hide the label text
+   * @default false
+   */
+  hideLabel?: boolean;
+
+  /**
    * Set an id for the input element
    * @default "ccs-" + Math.random().toString(36)
    */


### PR DESCRIPTION
Fixes #1413

Passing an empty string to `labelText` will make the `Toggle` appear to have an extra top margin. `Toggle` should expose a `hideLabel` prop that visually hides the label for accessibility.

```svelte
<Toggle labelText="Push notifications" hideLabel />
```