### PR TITLE
fix(toggle): `labelText` should not be selectable

### DIFF
--- a/src/Toggle/Toggle.svelte
+++ b/src/Toggle/Toggle.svelte
@@ -44,6 +44,7 @@
 <div
   class:bx--form-item="{true}"
   {...$$restProps}
+  style="{$$restProps['style']}; user-select: none"
   on:click
   on:mouseover
   on:mouseenter


### PR DESCRIPTION
Fixes #1137

Rapidly clicking the `Toggle` label text can select it. The upstream Carbon implementation has [added a `user-select: none`](https://github.com/carbon-design-system/carbon/pull/11670) rule to the toggle. However, the rule is only available in Carbon v11 in the `@carbon/styles` package.

We can set an inline `style` attribute for the implementation.