### PR TITLE
fix(toggle): override margin top if `hideLabel` is true

### DIFF
--- a/src/Toggle/Toggle.svelte
+++ b/src/Toggle/Toggle.svelte
@@ -85,7 +85,10 @@
         {labelText}
       </slot>
     </span>
-    <span class:bx--toggle__switch="{true}">
+    <span
+      class:bx--toggle__switch="{true}"
+      style="{hideLabel && 'margin-top: 0'}"
+    >
       <span aria-hidden="true" class:bx--toggle__text--off="{true}">
         <slot name="labelA">
           {labelA}


### PR DESCRIPTION
Fixes #1413
Follow-up to #1414

Although `hideLabel` visually hides the label text, the `margin-top` property on `.bx--toggle__switch` still has to be overridden because the `@carbon/styles` are composed differently (the label has a margin-bottom instead of the switch having a margin-top).