### PR TITLE
fix: guard against invalid accesses

### DIFF
--- a/src/Modal/modalStore.js
+++ b/src/Modal/modalStore.js
@@ -31,6 +31,6 @@ export const trackModal = (openStore) =>
   });
 
 modalsOpen.subscribe((openCount) => {
-  if (typeof document !== "undefined")
+  if (typeof document !== "undefined" && document.body && document.body.classList && typeof document.body.classList.toggle === "function")
     document.body.classList.toggle("bx--body--with-modal-open", openCount > 0);
 });


### PR DESCRIPTION
Current check does only check for presence of document and assumes the full tree below exists but that is not always the case and can lead to exceptions.