### PR TITLE
fix(number-input): forward keydown, keyup events

### DIFF
--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -2512,6 +2512,8 @@ export type NumberInputTranslationId = "increment" | "decrement";
 | mouseover  | forwarded  | --                              |
 | mouseenter | forwarded  | --                              |
 | mouseleave | forwarded  | --                              |
+| keydown    | forwarded  | --                              |
+| keyup      | forwarded  | --                              |
 | focus      | forwarded  | --                              |
 | blur       | forwarded  | --                              |
 | paste      | forwarded  | --                              |

--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -7779,6 +7779,8 @@
         { "type": "forwarded", "name": "mouseover", "element": "div" },
         { "type": "forwarded", "name": "mouseenter", "element": "div" },
         { "type": "forwarded", "name": "mouseleave", "element": "div" },
+        { "type": "forwarded", "name": "keydown", "element": "input" },
+        { "type": "forwarded", "name": "keyup", "element": "input" },
         { "type": "forwarded", "name": "focus", "element": "input" },
         { "type": "forwarded", "name": "blur", "element": "input" },
         { "type": "forwarded", "name": "paste", "element": "input" }

--- a/src/NumberInput/NumberInput.svelte
+++ b/src/NumberInput/NumberInput.svelte
@@ -204,6 +204,8 @@
         {...$$restProps}
         on:change="{onChange}"
         on:input="{onInput}"
+        on:keydown
+        on:keyup
         on:focus
         on:blur
         on:paste

--- a/tests/NumberInput.test.svelte
+++ b/tests/NumberInput.test.svelte
@@ -19,6 +19,8 @@
   on:change="{(e) => {
     console.log(e.detail); // null | number
   }}"
+  on:keydown
+  on:keyup
   on:paste
 />
 

--- a/types/NumberInput/NumberInput.svelte.d.ts
+++ b/types/NumberInput/NumberInput.svelte.d.ts
@@ -148,6 +148,8 @@ export default class NumberInput extends SvelteComponentTyped<
     mouseover: WindowEventMap["mouseover"];
     mouseenter: WindowEventMap["mouseenter"];
     mouseleave: WindowEventMap["mouseleave"];
+    keydown: WindowEventMap["keydown"];
+    keyup: WindowEventMap["keyup"];
     focus: WindowEventMap["focus"];
     blur: WindowEventMap["blur"];
     paste: DocumentAndElementEventHandlersEventMap["paste"];


### PR DESCRIPTION
Fixes #1421

`NumberInput` should forward keydown and keyup events.

```svelte
<NumberInput
  on:keydown={(e) => {
    console.log("keydown", e);
  }}
  on:keyup={(e) => {
    console.log("keyup", e);
  }}
/>
```