### PR TITLE
fix(notification): avoid dynamic class names in `NotificationButton`, `NotificationIcon`

### DIFF
--- a/src/Notification/NotificationButton.svelte
+++ b/src/Notification/NotificationButton.svelte
@@ -40,6 +40,8 @@
     this="{icon}"
     size="{20}"
     title="{title}"
-    class="bx--{notificationType}-notification__close-icon"
+    class="{notificationType === 'toast' &&
+      'bx--toast-notification__close-icon'} {notificationType === 'inline' &&
+      'bx--inline-notification__close-icon'}"
   />
 </button>

--- a/src/Notification/NotificationIcon.svelte
+++ b/src/Notification/NotificationIcon.svelte
@@ -35,5 +35,7 @@
   this="{icons[kind]}"
   size="{20}"
   title="{iconDescription}"
-  class="bx--{notificationType}-notification__icon"
+  class="{notificationType === 'toast' &&
+    'bx--toast-notification__icon'} {notificationType === 'inline' &&
+    'bx--inline-notification__icon'}"
 />


### PR DESCRIPTION
Fixes https://github.com/carbon-design-system/carbon-preprocess-svelte/issues/39

The `optimizeCss` plugin from `carbon-preprocess-svelte` fails to recognize dynamic strings like `bx--{notificationType}-notification__close-icon`. This hardcodes the class name in full so that it can be statically analyzed.

Note that `svelte:component` does not support the `class:` directive so we have to hardcode the classes in the `class` attribute.