### PR TITLE
refactor: use class directive in `TextInput`, `DatePickerInput`

### DIFF
--- a/src/DatePicker/DatePickerInput.svelte
+++ b/src/DatePicker/DatePickerInput.svelte
@@ -116,7 +116,8 @@
         : $inputValue}"
       class:bx--date-picker__input="{true}"
       class:bx--date-picker__input--invalid="{invalid}"
-      class="{size && `bx--date-picker__input--${size}`}"
+      class:bx--date-picker__input--sm="{size === 'sm'}"
+      class:bx--date-picker__input--xl="{size === 'xl'}"
       on:input
       on:input="{({ target }) => {
         updateValue({ type: 'input', value: target.value });

--- a/src/TextInput/TextInput.svelte
+++ b/src/TextInput/TextInput.svelte
@@ -146,7 +146,8 @@
       class:bx--visually-hidden="{hideLabel}"
       class:bx--label--disabled="{disabled}"
       class:bx--label--inline="{inline}"
-      class="{inline && !!size && `bx--label--inline--${size}`}"
+      class:bx--label--inline-sm="{inline && size === 'sm'}"
+      class:bx--label--inline-xl="{inline && size === 'xl'}"
     >
       <slot name="labelText">
         {labelText}


### PR DESCRIPTION
Related #1425

This PR replaces dynamically-formed classes with the `class:` directive to avoid situations like https://github.com/carbon-design-system/carbon-preprocess-svelte/issues/39 where `purgecss` is unable to recognize interpolated strings.