### PR TITLE
fix(ui-shell): remove `Content` left margin if `SideNav` is collapsed

### DIFF
--- a/docs/src/global.css
+++ b/docs/src/global.css
@@ -246,7 +246,6 @@ main.bx--content {
 
 @media (max-width: 1056px) {
   .bx--side-nav ~ .bx--content {
-    margin-left: 0;
     padding-left: 1rem;
     padding-right: 1rem;
   }

--- a/src/UIShell/Content.svelte
+++ b/src/UIShell/Content.svelte
@@ -1,8 +1,15 @@
 <script>
   /** Specify the id for the main element */
   export let id = "main-content";
+
+  import { isSideNavCollapsed } from "./navStore";
 </script>
 
-<main id="{id}" class:bx--content="{true}" {...$$restProps}>
+<main
+  id="{id}"
+  class:bx--content="{true}"
+  {...$$restProps}
+  style="{$isSideNavCollapsed && 'margin-left: 0;'} {$$restProps.style}}"
+>
   <slot />
 </main>

--- a/src/UIShell/SideNav.svelte
+++ b/src/UIShell/SideNav.svelte
@@ -32,13 +32,14 @@
   export let expansionBreakpoint = 1056;
 
   import { onMount, createEventDispatcher } from "svelte";
-  import { shouldRenderHamburgerMenu } from "./navStore";
+  import { shouldRenderHamburgerMenu, isSideNavCollapsed } from "./navStore";
 
   const dispatch = createEventDispatcher();
 
   let winWidth = undefined;
 
   $: dispatch(isOpen ? "open" : "close");
+  $: $isSideNavCollapsed = !isOpen;
 
   onMount(() => {
     shouldRenderHamburgerMenu.set(true);

--- a/src/UIShell/navStore.js
+++ b/src/UIShell/navStore.js
@@ -1,3 +1,5 @@
 import { writable } from "svelte/store";
 
 export const shouldRenderHamburgerMenu = writable(false);
+
+export const isSideNavCollapsed = writable(false);


### PR DESCRIPTION
Fixes #1145, closes #1406
Related https://github.com/carbon-design-system/carbon/issues/7909

This PR removes the left margin from the `Content` component if the `SideNav` is collapsed.

This PR is an alternative to #1406. The implementation uses a Svelte store instead of global CSS. In part, the motivation is to avoid the `:global` directive. The second reason is that the inline HTML style attribute offers a higher specificity.