### PR TITLE
style(docs): remove UI Shell overrides

### DIFF
--- a/docs/src/global.css
+++ b/docs/src/global.css
@@ -89,6 +89,18 @@ html[theme="g90"] .code-override {
   width: auto;
 }
 
+/*
+ * Main content needs to supersede z-index of SideNav but not that of the Header.
+ * UI Shell Header shares the same z-index.
+ */
+[aria-label="Navigation"] {
+  z-index: calc(8000 + 2);
+}
+
+[aria-label="Navigation"] ~ [data-components] {
+  z-index: calc(8000 + 1);
+}
+
 .prose > p > .bx--link {
   font-size: inherit;
   text-decoration: underline;

--- a/docs/src/global.css
+++ b/docs/src/global.css
@@ -239,25 +239,3 @@ html[theme="g90"] .code-override {
 .bx--col > p {
   margin-bottom: var(--cds-layout-02);
 }
-
-main.bx--content {
-  min-height: calc(100vh - 3rem - 3rem);
-}
-
-@media (max-width: 1056px) {
-  .bx--side-nav ~ .bx--content {
-    padding-left: 1rem;
-    padding-right: 1rem;
-  }
-
-  .bx--side-nav--expanded ~ .bx--content {
-    white-space: nowrap;
-    min-width: 28rem;
-  }
-}
-
-@media (min-width: 1057px) {
-  .bx--side-nav__navigation {
-    z-index: 1;
-  }
-}


### PR DESCRIPTION
The docs site manually overrides UI Shell styles. It applies these styles globally, which affect the UI Shell standalone examples.

One solution to scope the overrides to just the docs site. However, from a philosophical standpoint, I believe overrides should be avoided where possible as they can lead to confusion (e.g., #1145) over what styles are actually correct.