### PR TITLE
Add Switch Role to Toggle Component for Accessibility

### DIFF
--- a/src/Toggle/Toggle.svelte
+++ b/src/Toggle/Toggle.svelte
@@ -54,6 +54,7 @@
   on:mouseleave
 >
   <input
+    role="switch"
     type="checkbox"
     class:bx--toggle-input="{true}"
     class:bx--toggle-input--small="{size === 'sm'}"


### PR DESCRIPTION
ARIA Authoring Guide recommends adding the role "switch" to on/off components like the toggle.
- [ARIA Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/switch/)
- [Documentation For Switch Role](https://w3c.github.io/aria/#switch)
- [Example of Checkbox Switch](https://www.w3.org/WAI/ARIA/apg/example-index/switch/switch-checkbox.html)