### PR TITLE
fix(slider): add `aria-labelledby` slider thumb

### DIFF
--- a/src/Slider/Slider.svelte
+++ b/src/Slider/Slider.svelte
@@ -185,6 +185,7 @@
         aria-valuemax="{max}"
         aria-valuemin="{min}"
         aria-valuenow="{value}"
+        aria-labelledby="{labelId}"
         id="{id}"
       ></div>
       <div bind:this="{trackRef}" class:bx--slider__track="{true}"></div>


### PR DESCRIPTION
Ref: https://github.com/carbon-design-system/carbon/pull/11798

This implements a backported change to the `Slider` component, which adds the `aria-labelledby` attribute to the slider thumb for accessibility.