### PR TITLE
fix(inline-checkbox): remove `aria-checked="mixed"` if indeterminate

### DIFF
--- a/src/Checkbox/InlineCheckbox.svelte
+++ b/src/Checkbox/InlineCheckbox.svelte
@@ -27,7 +27,7 @@
     indeterminate="{indeterminate}"
     id="{id}"
     {...$$restProps}
-    aria-checked="{indeterminate ? 'mixed' : checked}"
+    aria-checked="{indeterminate ? undefined : checked}"
     on:change
   />
   <label


### PR DESCRIPTION
Ref: https://github.com/carbon-design-system/carbon/pull/11908

This implements a backported change to the `InlineCheckbox` component, which avoids setting `aria-checked="mixed"` if the checkbox is indeterminate.

Within the library itself, `InlineCheckbox` is only used in a selectable `DataTable`.