### PR TITLE
feat(ToolbarBatchActions): Allow showing the toolbar via override

### DIFF
--- a/src/DataTable/ToolbarBatchActions.svelte
+++ b/src/DataTable/ToolbarBatchActions.svelte
@@ -5,13 +5,19 @@
    */
   export let formatTotalSelected = (totalSelected) =>
     `${totalSelected} item${totalSelected === 1 ? "" : "s"} selected`;
-
+  
+  /** 
+   * Set to `true` to show the ToolbarBatchActions regardless of row selection
+   * @type {boolean}
+   */
+  export let show = false;
+  
   import { onMount, getContext } from "svelte";
   import Button from "../Button/Button.svelte";
 
   let batchSelectedIds = [];
 
-  $: showActions = batchSelectedIds.length > 0;
+  $: showActions = batchSelectedIds.length > 0 || show;
 
   const ctx = getContext("DataTable");
   const unsubscribe = ctx.batchSelectedIds.subscribe((value) => {


### PR DESCRIPTION
Fixes #1438.

Show the toolbar even if there are no selected toolbars.

Maintains current behavior but allows for an over-ride to ensure the toolbarbatchactions bar does not close when the user has unselected all items.

Example Useage:
```
<Toolbar>
    <ToolbarContent>
        <ToolbarBatchActions show={true}>
         ....
        </ToolbarBatchActions>
    </ToolbarContent>
</Toolbar>
```