### PR TITLE
feat(ToolbarBatchActions): Override cancel button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- ## Unreleased -->
 
+## [0.67.9](https://github.com/carbon-design-system/carbon-components-svelte/releases/tag/v0.67.9) - 2022-08-11
+
+**Fixes**
+
+- `NotificationActionButton` types should extend `Button` props
+
 ## [0.67.8](https://github.com/carbon-design-system/carbon-components-svelte/releases/tag/v0.67.8) - 2022-08-10
 
 **Fixes**

--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -4422,9 +4422,10 @@ None.
 
 ### Props
 
-| Prop name           | Required | Kind             | Reactive | Type                                           | Default value                                                                                       | Description                            |
-| :------------------ | :------- | :--------------- | :------- | ---------------------------------------------- | --------------------------------------------------------------------------------------------------- | -------------------------------------- |
-| formatTotalSelected | No       | <code>let</code> | No       | <code>(totalSelected: number) => string</code> | <code>(totalSelected) => \`${totalSelected} item${totalSelected === 1 ? "" : "s"} selected\`</code> | Override the total items selected text |
+| Prop name           | Required | Kind             | Reactive | Type                                           | Default value                                                                                       | Description                                                   |
+| :------------------ | :------- | :--------------- | :------- | ---------------------------------------------- | --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
+| formatTotalSelected | No       | <code>let</code> | No       | <code>(totalSelected: number) => string</code> | <code>(totalSelected) => \`${totalSelected} item${totalSelected === 1 ? "" : "s"} selected\`</code> | Override the total items selected text                        |
+| active              | No       | <code>let</code> | No       | <code>boolean</code>                           | <code>false</code>                                                                                  | Set to `true` to show the toolbar regardless of row selection |
 
 ### Slots
 

--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -1,6 +1,6 @@
 # Component Index
 
-> 165 components exported from carbon-components-svelte@0.67.8.
+> 165 components exported from carbon-components-svelte@0.67.9.
 
 ## Components
 

--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -4436,7 +4436,9 @@ None.
 
 ### Events
 
-None.
+| Event name | Type       | Detail            |
+| :--------- | :--------- | :---------------- |
+| cancel     | dispatched | <code>null</code> |
 
 ## `ToolbarContent`
 

--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -13696,7 +13696,7 @@
           "slot_props": "{}"
         }
       ],
-      "events": [],
+      "events": [{ "type": "dispatched", "name": "cancel", "detail": "null" }],
       "typedefs": [],
       "rest_props": { "type": "Element", "name": "div" }
     },

--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -13672,6 +13672,18 @@
           "isRequired": false,
           "constant": false,
           "reactive": false
+        },
+        {
+          "name": "active",
+          "kind": "let",
+          "description": "Set to `true` to show the toolbar regardless of row selection",
+          "type": "boolean",
+          "value": "false",
+          "isFunction": false,
+          "isFunctionDeclaration": false,
+          "isRequired": false,
+          "constant": false,
+          "reactive": false
         }
       ],
       "moduleExports": [],

--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -7376,7 +7376,11 @@
         { "type": "forwarded", "name": "mouseleave", "element": "Button" }
       ],
       "typedefs": [],
-      "rest_props": { "type": "InlineComponent", "name": "Button" }
+      "rest_props": { "type": "InlineComponent", "name": "Button" },
+      "extends": {
+        "interface": "ButtonProps",
+        "import": "\"../Button/Button.svelte\""
+      }
     },
     {
       "moduleName": "NotificationButton",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "carbon-components-svelte",
-  "version": "0.67.8",
+  "version": "0.67.9",
   "license": "Apache-2.0",
   "description": "Svelte implementation of the Carbon Design System",
   "svelte": "./src/index.js",

--- a/src/DataTable/ToolbarBatchActions.svelte
+++ b/src/DataTable/ToolbarBatchActions.svelte
@@ -5,13 +5,19 @@
    */
   export let formatTotalSelected = (totalSelected) =>
     `${totalSelected} item${totalSelected === 1 ? "" : "s"} selected`;
-
+  
+  /** 
+   * Set to `true` to show the toolbar regardless of row selection
+   * @type {boolean}
+   */
+  export let active = false;
+  
   import { onMount, getContext } from "svelte";
   import Button from "../Button/Button.svelte";
 
   let batchSelectedIds = [];
 
-  $: showActions = batchSelectedIds.length > 0;
+  $: showActions = batchSelectedIds.length > 0 || active;
 
   const ctx = getContext("DataTable");
   const unsubscribe = ctx.batchSelectedIds.subscribe((value) => {

--- a/src/DataTable/ToolbarBatchActions.svelte
+++ b/src/DataTable/ToolbarBatchActions.svelte
@@ -1,5 +1,9 @@
 <script>
   /**
+   * @event {null} cancel
+   */
+
+  /**
    * Override the total items selected text
    * @type {(totalSelected: number) => string}
    */
@@ -12,14 +16,26 @@
    */
   export let active = false;
   
-  import { onMount, getContext } from "svelte";
+  import { onMount, getContext, createEventDispatcher } from "svelte";
+
   import Button from "../Button/Button.svelte";
 
   let batchSelectedIds = [];
 
-  $: showActions = batchSelectedIds.length > 0 || active;
+  const dispatch = createEventDispatcher();
+
 
   const ctx = getContext("DataTable");
+
+  function cancel() {
+    const shouldContinue = dispatch("cancel", null, { cancelable: true });
+
+    if (shouldContinue) {
+      ctx.resetSelectedRowIds();
+    }
+  }
+
+  $: showActions = batchSelectedIds.length > 0 || active;
   const unsubscribe = ctx.batchSelectedIds.subscribe((value) => {
     batchSelectedIds = value;
   });
@@ -55,7 +71,7 @@
       <Button
         class="bx--batch-summary__cancel"
         tabindex="{showActions ? '0' : '-1'}"
-        on:click="{ctx.resetSelectedRowIds}"
+        on:click="{cancel}"
       >
         <slot name="cancel">Cancel</slot>
       </Button>

--- a/src/Notification/NotificationActionButton.svelte
+++ b/src/Notification/NotificationActionButton.svelte
@@ -1,4 +1,6 @@
 <script>
+  /** @extends {"../Button/Button.svelte"} ButtonProps */
+
   import Button from "../Button/Button.svelte";
 </script>
 

--- a/types/DataTable/ToolbarBatchActions.svelte.d.ts
+++ b/types/DataTable/ToolbarBatchActions.svelte.d.ts
@@ -8,6 +8,12 @@ export interface ToolbarBatchActionsProps
    * @default (totalSelected) => `${totalSelected} item${totalSelected === 1 ? "" : "s"} selected`
    */
   formatTotalSelected?: (totalSelected: number) => string;
+
+  /**
+   * Set to `true` to show the toolbar regardless of row selection
+   * @default false
+   */
+  active?: boolean;
 }
 
 export default class ToolbarBatchActions extends SvelteComponentTyped<

--- a/types/DataTable/ToolbarBatchActions.svelte.d.ts
+++ b/types/DataTable/ToolbarBatchActions.svelte.d.ts
@@ -18,6 +18,6 @@ export interface ToolbarBatchActionsProps
 
 export default class ToolbarBatchActions extends SvelteComponentTyped<
   ToolbarBatchActionsProps,
-  {},
+  { cancel: CustomEvent<null> },
   { default: {}; cancel: {} }
 > {}

--- a/types/Notification/NotificationActionButton.svelte.d.ts
+++ b/types/Notification/NotificationActionButton.svelte.d.ts
@@ -1,7 +1,8 @@
 /// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { ButtonProps } from "../Button/Button.svelte";
 
-export interface NotificationActionButtonProps {}
+export interface NotificationActionButtonProps extends ButtonProps {}
 
 export default class NotificationActionButton extends SvelteComponentTyped<
   NotificationActionButtonProps,


### PR DESCRIPTION
Fixes #1438.

Give the user the ability to override the functionality of the cancel button by passing in their own function. If no override is provided, the existing functionality of reseting selected row ids is preserved.

Example implementation:

```
<ToolbarBatchActions cancel={()=>{console.log("User clicked cancel!")}}>
 ...
</ToolbarBatchActions>
```