### PR TITLE
fix(notification): add extends to button

### DIFF
--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -7376,7 +7376,11 @@
         { "type": "forwarded", "name": "mouseleave", "element": "Button" }
       ],
       "typedefs": [],
-      "rest_props": { "type": "InlineComponent", "name": "Button" }
+      "rest_props": { "type": "InlineComponent", "name": "Button" },
+      "extends": {
+        "interface": "ButtonProps",
+        "import": "\"../Button/Button.svelte\""
+      }
     },
     {
       "moduleName": "NotificationButton",

--- a/src/Notification/NotificationActionButton.svelte
+++ b/src/Notification/NotificationActionButton.svelte
@@ -1,4 +1,6 @@
 <script>
+  /** @extends {"../Button/Button.svelte"} ButtonProps */
+
   import Button from "../Button/Button.svelte";
 </script>
 

--- a/types/Notification/NotificationActionButton.svelte.d.ts
+++ b/types/Notification/NotificationActionButton.svelte.d.ts
@@ -1,7 +1,8 @@
 /// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
+import type { ButtonProps } from "../Button/Button.svelte";
 
-export interface NotificationActionButtonProps {}
+export interface NotificationActionButtonProps extends ButtonProps {}
 
 export default class NotificationActionButton extends SvelteComponentTyped<
   NotificationActionButtonProps,


### PR DESCRIPTION
This way, props from Button can be used in NotificationActionButton and
still typecheck correctly.