### PR TITLE
fix(toolbar-batch-actions): `active` prop should be reactive

### DIFF
--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -4422,10 +4422,10 @@ None.
 
 ### Props
 
-| Prop name           | Required | Kind             | Reactive | Type                                           | Default value                                                                                       | Description                                                   |
-| :------------------ | :------- | :--------------- | :------- | ---------------------------------------------- | --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
-| formatTotalSelected | No       | <code>let</code> | No       | <code>(totalSelected: number) => string</code> | <code>(totalSelected) => \`${totalSelected} item${totalSelected === 1 ? "" : "s"} selected\`</code> | Override the total items selected text                        |
-| active              | No       | <code>let</code> | No       | <code>boolean</code>                           | <code>false</code>                                                                                  | Set to `true` to show the toolbar regardless of row selection |
+| Prop name           | Required | Kind             | Reactive | Type                                           | Default value                                                                                       | Description                               |
+| :------------------ | :------- | :--------------- | :------- | ---------------------------------------------- | --------------------------------------------------------------------------------------------------- | ----------------------------------------- |
+| active              | No       | <code>let</code> | Yes      | <code>undefined &#124; boolean</code>          | <code>undefined</code>                                                                              | Use a boolean to show or hide the toolbar |
+| formatTotalSelected | No       | <code>let</code> | No       | <code>(totalSelected: number) => string</code> | <code>(totalSelected) => \`${totalSelected} item${totalSelected === 1 ? "" : "s"} selected\`</code> | Override the total items selected text    |
 
 ### Slots
 

--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -13676,14 +13676,13 @@
         {
           "name": "active",
           "kind": "let",
-          "description": "Set to `true` to show the toolbar regardless of row selection",
-          "type": "boolean",
-          "value": "false",
+          "description": "Use a boolean to show or hide the toolbar",
+          "type": "undefined | boolean",
           "isFunction": false,
           "isFunctionDeclaration": false,
           "isRequired": false,
           "constant": false,
-          "reactive": false
+          "reactive": true
         }
       ],
       "moduleExports": [],

--- a/src/DataTable/ToolbarBatchActions.svelte
+++ b/src/DataTable/ToolbarBatchActions.svelte
@@ -9,21 +9,26 @@
    */
   export let formatTotalSelected = (totalSelected) =>
     `${totalSelected} item${totalSelected === 1 ? "" : "s"} selected`;
-  
-  /** 
-   * Set to `true` to show the toolbar regardless of row selection
-   * @type {boolean}
+
+  /**
+   * Use a boolean to show or hide the toolbar
+   * @type {undefined | boolean}
    */
-  export let active = false;
-  
-  import { onMount, getContext, createEventDispatcher } from "svelte";
+  export let active = undefined;
+
+  import {
+    onMount,
+    getContext,
+    createEventDispatcher,
+    afterUpdate,
+  } from "svelte";
 
   import Button from "../Button/Button.svelte";
 
   let batchSelectedIds = [];
+  let prevActive;
 
   const dispatch = createEventDispatcher();
-
 
   const ctx = getContext("DataTable");
 
@@ -36,6 +41,14 @@
   }
 
   $: showActions = batchSelectedIds.length > 0 || active;
+  $: {
+    if (prevActive !== active && active === false) {
+      showActions = false;
+    }
+
+    prevActive = active;
+  }
+
   const unsubscribe = ctx.batchSelectedIds.subscribe((value) => {
     batchSelectedIds = value;
   });
@@ -52,6 +65,12 @@
       unsubscribe();
       unsubscribeOverflow();
     };
+  });
+
+  afterUpdate(() => {
+    if (active === false && showActions) {
+      active = true;
+    }
   });
 </script>
 

--- a/types/DataTable/ToolbarBatchActions.svelte.d.ts
+++ b/types/DataTable/ToolbarBatchActions.svelte.d.ts
@@ -10,10 +10,10 @@ export interface ToolbarBatchActionsProps
   formatTotalSelected?: (totalSelected: number) => string;
 
   /**
-   * Set to `true` to show the toolbar regardless of row selection
-   * @default false
+   * Use a boolean to show or hide the toolbar
+   * @default undefined
    */
-  active?: boolean;
+  active?: undefined | boolean;
 }
 
 export default class ToolbarBatchActions extends SvelteComponentTyped<


### PR DESCRIPTION
Follow-up to #1440

When testing a scenario of a `DataTable` with a controlled batch actions toolbar, I noticed that setting `active` to `false` would not close it if there are selected rows.

This is because the toolbar is activated if there are one or more selected rows OR if `active` is `true`:

```ts
$: showActions = batchSelectedIds.length > 0 || active;
```

Therefore, it's possibly to programmatically activate a toolbar but not close it in the same fashion.

The solution is two-fold:

1. Set `active` to `true` if one or more rows are selected. Then, `showActive` should be set to `false` if the `active` prop is changed from `true` to `false`. As a result, the `active` prop becomes reactive.
2. Type `active` to be `undefined` by default. `showActive` should only be set to `false` if `active` is `false` to not breaking the default behavior.

The code for the controlled toolbar looks like this:

```svelte
<script>
  import {
    DataTable,
    Toolbar,
    ToolbarContent,
    ToolbarBatchActions,
    Button,
  } from "carbon-components-svelte";
  import TrashCan from "carbon-icons-svelte/lib/TrashCan.svelte";

  const headers = [
    { key: "name", value: "Name" },
    { key: "port", value: "Port" },
    { key: "rule", value: "Rule" },
  ];

  let rows = [
    { id: "a", name: "Load Balancer 3", port: 3000, rule: "Round robin" },
    { id: "b", name: "Load Balancer 1", port: 443, rule: "Round robin" },
    { id: "c", name: "Load Balancer 2", port: 80, rule: "DNS delegation" },
    { id: "d", name: "Load Balancer 6", port: 3000, rule: "Round robin" },
    { id: "e", name: "Load Balancer 4", port: 443, rule: "Round robin" },
    { id: "f", name: "Load Balancer 5", port: 80, rule: "DNS delegation" },
  ];

  let active = false;
  let selectedRowIds = [];

  $: console.log("selectedRowIds", selectedRowIds);
</script>

<DataTable
  selectable
  batchSelection={active}
  bind:selectedRowIds
  {headers}
  {rows}
>
  <Toolbar>
    <ToolbarBatchActions
      bind:active
      on:cancel={(e) => {
        e.preventDefault();
        active = false;
      }}
    >
      <Button
        icon={TrashCan}
        disabled={selectedRowIds.length === 0}
        on:click={() => {
          rows = rows.filter((row) => !selectedRowIds.includes(row.id));
          selectedRowIds = [];
        }}
      >
        Delete
      </Button>
    </ToolbarBatchActions>
    <ToolbarContent>
      <Button on:click={() => (active = true)}>Edit rows</Button>
    </ToolbarContent>
  </Toolbar>
</DataTable>

```
