### PR TITLE
docs: add `DataTable` example "Batch selection with controlled toolbar"

### DIFF
--- a/docs/src/pages/components/DataTable.svx
+++ b/docs/src/pages/components/DataTable.svx
@@ -1111,7 +1111,7 @@ Use the `selectedRowIds` prop to specify which rows should be selected.
 
 <FileSource src="/framed/DataTable/DataTableBatchSelectionInitial" />
 
-### Selectable with batch actions
+### Batch selection with batch actions toolbar
 
 <FileSource src="/framed/DataTable/DataTableBatchSelectionToolbar" />
 

--- a/docs/src/pages/components/DataTable.svx
+++ b/docs/src/pages/components/DataTable.svx
@@ -1115,6 +1115,16 @@ Use the `selectedRowIds` prop to specify which rows should be selected.
 
 <FileSource src="/framed/DataTable/DataTableBatchSelectionToolbar" />
 
+### Batch selection with controlled toolbar
+
+By default, `ToolbarBatchActions` is activated if one or more rows is selected. Clicking "Cancel" will deactivate it.
+
+Use the `active` prop to control the toolbar. Note that it will still activate if one or more rows are selected.
+
+You can also prevent the default "Cancel" behavior in the dispatched `on:cancel` event.
+
+<FileSource src="/framed/DataTable/DataTableBatchSelectionToolbarControlled" />
+
 ### Selectable (radio)
 
 <FileSource src="/framed/DataTable/RadioSelectableDataTable" />

--- a/docs/src/pages/components/InlineNotification.svx
+++ b/docs/src/pages/components/InlineNotification.svx
@@ -1,4 +1,5 @@
 ---
+components: ["InlineNotification", "NotificationActionButton"]
 source: Notification/InlineNotification.svelte
 ---
 

--- a/docs/src/pages/components/InlineNotification.svx
+++ b/docs/src/pages/components/InlineNotification.svx
@@ -16,12 +16,6 @@ source: Notification/InlineNotification.svelte
 
 `InlineNotification` is a controlled component. Prevent the default close behavior using the `e.preventDefault()` method in the dispatched `on:close` event.
 
-<InlineNotification svx-ignore lowContrast title="Note:" kind="info" hideCloseButton>
-  <div class="body-short-01">
-    Svelte version 3.48.0 or greater is required.
-  </div>
-</InlineNotification>
-
 <InlineNotification title="Error" subtitle="An internal server error occurred." on:close={(e) => {
   e.preventDefault();
   // custom close logic (e.g., transitions)

--- a/docs/src/pages/components/ToastNotification.svx
+++ b/docs/src/pages/components/ToastNotification.svx
@@ -3,7 +3,7 @@ source: Notification/ToastNotification.svelte
 ---
 
 <script>
-  import { ToastNotification, InlineNotification } from "carbon-components-svelte";
+  import { ToastNotification } from "carbon-components-svelte";
   import Preview from "../../components/Preview.svelte";
 </script>
 
@@ -14,12 +14,6 @@ source: Notification/ToastNotification.svelte
 ### Prevent default close behavior
 
 `ToastNotification` is a controlled component. Prevent the default close behavior using the `e.preventDefault()` method in the dispatched `on:close` event.
-
-<InlineNotification svx-ignore lowContrast title="Note:" kind="info" hideCloseButton>
-  <div class="body-short-01">
-    Svelte version 3.48.0 or greater is required.
-  </div>
-</InlineNotification>
 
 <ToastNotification title="Error" subtitle="An internal server error occurred." caption="{new Date().toLocaleString()}" on:close={(e) => {
   e.preventDefault();

--- a/docs/src/pages/framed/DataTable/DataTableBatchSelectionToolbarControlled.svelte
+++ b/docs/src/pages/framed/DataTable/DataTableBatchSelectionToolbarControlled.svelte
@@ -1,0 +1,63 @@
+<script>
+  import {
+    DataTable,
+    Toolbar,
+    ToolbarContent,
+    ToolbarBatchActions,
+    Button,
+  } from "carbon-components-svelte";
+  import TrashCan from "carbon-icons-svelte/lib/TrashCan.svelte";
+
+  const headers = [
+    { key: "name", value: "Name" },
+    { key: "port", value: "Port" },
+    { key: "rule", value: "Rule" },
+  ];
+
+  let rows = [
+    { id: "a", name: "Load Balancer 3", port: 3000, rule: "Round robin" },
+    { id: "b", name: "Load Balancer 1", port: 443, rule: "Round robin" },
+    { id: "c", name: "Load Balancer 2", port: 80, rule: "DNS delegation" },
+    { id: "d", name: "Load Balancer 6", port: 3000, rule: "Round robin" },
+    { id: "e", name: "Load Balancer 4", port: 443, rule: "Round robin" },
+    { id: "f", name: "Load Balancer 5", port: 80, rule: "DNS delegation" },
+  ];
+
+  let active = false;
+  let selectedRowIds = [];
+
+  $: console.log("active", active);
+  $: console.log("selectedRowIds", selectedRowIds);
+</script>
+
+<DataTable
+  selectable
+  batchSelection="{active}"
+  bind:selectedRowIds
+  headers="{headers}"
+  rows="{rows}"
+>
+  <Toolbar>
+    <ToolbarBatchActions
+      bind:active
+      on:cancel="{(e) => {
+        e.preventDefault();
+        active = false;
+      }}"
+    >
+      <Button
+        icon="{TrashCan}"
+        disabled="{selectedRowIds.length === 0}"
+        on:click="{() => {
+          rows = rows.filter((row) => !selectedRowIds.includes(row.id));
+          selectedRowIds = [];
+        }}"
+      >
+        Delete
+      </Button>
+    </ToolbarBatchActions>
+    <ToolbarContent>
+      <Button on:click="{() => (active = true)}">Edit rows</Button>
+    </ToolbarContent>
+  </Toolbar>
+</DataTable>


### PR DESCRIPTION
Along with other small docs updates, this PR adds an example for a `DataTable` with a controlled `ToolbarBatchActions` (#1440, #1441).

**Documentation**

- add `DataTable` example "Batch selection with controlled toolbar"