### PR TITLE
emit select event on checkbox or radio button activity

### DIFF
--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -1008,6 +1008,7 @@ export interface DataTableCell {
 | mouseenter:row       | dispatched | <code>DataTableRow</code>                                                                               |
 | mouseleave:row       | dispatched | <code>DataTableRow</code>                                                                               |
 | click:row--expand    | dispatched | <code>{ expanded: boolean; row: DataTableRow; }</code>                                                  |
+| click:row--select    | dispatched | <code>{ selected: boolean; row: DataTableRow; }</code>                                                  |
 | click:cell           | dispatched | <code>DataTableCell</code>                                                                              |
 
 ## `DataTableSkeleton`

--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -2665,6 +2665,11 @@
         },
         {
           "type": "dispatched",
+          "name": "click:row--select",
+          "detail": "{ selected: boolean; row: DataTableRow; }"
+        },
+        {
+          "type": "dispatched",
           "name": "click:cell",
           "detail": "DataTableCell"
         }

--- a/src/DataTable/DataTable.svelte
+++ b/src/DataTable/DataTable.svelte
@@ -18,6 +18,7 @@
    * @event {DataTableRow} mouseenter:row
    * @event {DataTableRow} mouseleave:row
    * @event {{ expanded: boolean; row: DataTableRow; }} click:row--expand
+   * @event {{ selected: boolean; row: DataTableRow; }} click:row--select
    * @event {DataTableCell} click:cell
    * @restProps {div}
    */
@@ -440,6 +441,7 @@
                     checked="{selectedRowIds.includes(row.id)}"
                     on:change="{() => {
                       selectedRowIds = [row.id];
+                      dispatch('click:row--select', { row, selected: true });
                     }}"
                   />
                 {:else}
@@ -451,8 +453,10 @@
                         selectedRowIds = selectedRowIds.filter(
                           (id) => id !== row.id
                         );
+                        dispatch('click:row--select', { row, selected: false });
                       } else {
                         selectedRowIds = [...selectedRowIds, row.id];
+                        dispatch('click:row--select', { row, selected: true });
                       }
                     }}"
                   />

--- a/types/DataTable/DataTable.svelte.d.ts
+++ b/types/DataTable/DataTable.svelte.d.ts
@@ -198,6 +198,10 @@ export default class DataTable extends SvelteComponentTyped<
       expanded: boolean;
       row: DataTableRow;
     }>;
+    ["click:row--select"]: CustomEvent<{
+      selected: boolean;
+      row: DataTableRow;
+    }>;
     ["click:cell"]: CustomEvent<DataTableCell>;
   },
   {


### PR DESCRIPTION
Proposed solution to #1449

Implementation follows existing `click:row--expand ` pattern. 

No backwards-compatibility issues AFIAK. 