### PR TITLE
fix(ui-shell): allow `$$restProps.style` to be applied to `Content`

### DIFF
--- a/src/UIShell/Content.svelte
+++ b/src/UIShell/Content.svelte
@@ -18,7 +18,7 @@
   id="{id}"
   class:bx--content="{true}"
   {...$$restProps}
-  style="{unsetLeftMargin && 'margin-left: 0;'} {$$restProps.style}}"
+  style="{unsetLeftMargin ? 'margin-left: 0;' : ''} {$$restProps.style}"
 >
   <slot />
 </main>


### PR DESCRIPTION
Fixes #1467

This PR applies the suggestion in #1467 to address a bug where `$$restProps.style` isn't applied to `Content` if `unsetLeftMargin` is `false`. If `false`, the style value evaluates to "false [additional styles]," which is invalid and will not be evaluated by the browser.