### PR TITLE
fix(list-box-menu-item): scroll item into view when using keyboard navigation

### DIFF
--- a/src/Dropdown/Dropdown.svelte
+++ b/src/Dropdown/Dropdown.svelte
@@ -261,7 +261,7 @@
           <ListBoxMenuItem
             id="{item.id}"
             active="{selectedId === item.id}"
-            highlighted="{highlightedIndex === i || selectedId === item.id}"
+            highlighted="{highlightedIndex === i}"
             disabled="{item.disabled}"
             on:click="{(e) => {
               if (item.disabled) {

--- a/src/ListBox/ListBoxMenuItem.svelte
+++ b/src/ListBox/ListBoxMenuItem.svelte
@@ -12,13 +12,17 @@
 
   $: isTruncated = ref?.offsetWidth < ref?.scrollWidth;
   $: title = isTruncated ? ref?.innerText : undefined;
+  $: if (highlighted && !ref?.matches(":hover")) {
+    // Scroll highlighted item into view if using keyboard navigation
+    ref.scrollIntoView({ block: "end" });
+  }
 </script>
 
 <div
   role="option"
   class:bx--list-box__menu-item="{true}"
   class:bx--list-box__menu-item--active="{active}"
-  class:bx--list-box__menu-item--highlighted="{highlighted}"
+  class:bx--list-box__menu-item--highlighted="{highlighted || active}"
   aria-selected="{active}"
   disabled="{disabled ? true : undefined}"
   {...$$restProps}


### PR DESCRIPTION
Fixes #1470

If keyboard navigation is used to navigate the `Dropdown` menu, the highlighted item should scroll into view.

Updating `ListBoxMenuItem` should apply the same behavior to `Dropdown`, `ComboBox`, and `MultiSelect`.