### PR TITLE
fix(combo-box): prevent default when pressing Enter/ArrowUp/ArrowDown

### DIFF
--- a/src/ComboBox/ComboBox.svelte
+++ b/src/ComboBox/ComboBox.svelte
@@ -284,7 +284,11 @@
           }
         }}"
         on:keydown
-        on:keydown|stopPropagation="{({ key }) => {
+        on:keydown|stopPropagation="{(e) => {
+          const { key } = e;
+          if (['Enter', 'ArrowDown', 'ArrowUp'].includes(key)) {
+            e.preventDefault();
+          }
           if (key === 'Enter') {
             open = !open;
             if (


### PR DESCRIPTION
Without preventing the default behavior, pressing the arrow up/down keys will change the cursor position in the input box.

Like `Dropdown`, the default behavior for Enter/ArrowDown/ArrowUp should be prevented.