### PR TITLE
fix: pressing "Escape" should close `Dropdown`, `MultiSelect` menu

### DIFF
--- a/src/Dropdown/Dropdown.svelte
+++ b/src/Dropdown/Dropdown.svelte
@@ -236,6 +236,8 @@
           change(1);
         } else if (key === 'ArrowUp') {
           change(-1);
+        } else if (key === 'Escape') {
+          open = false;
         }
       }}"
       disabled="{disabled}"

--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -368,6 +368,8 @@
               return { ...item, checked: !item.checked };
             });
           }
+        } else if (key === 'Escape') {
+          open = false;
         }
       }}"
       on:focus="{() => {


### PR DESCRIPTION
Pressing "Escape" should close the menu. `ComboBox` already implements this.