### PR TITLE
fix(list-box-menu-item): do not scroll entire page when using keyboard navigation

### DIFF
--- a/src/ListBox/ListBoxMenuItem.svelte
+++ b/src/ListBox/ListBoxMenuItem.svelte
@@ -14,7 +14,7 @@
   $: title = isTruncated ? ref?.innerText : undefined;
   $: if (highlighted && !ref?.matches(":hover")) {
     // Scroll highlighted item into view if using keyboard navigation
-    ref.scrollIntoView({ block: "end" });
+    ref.scrollIntoView({ block: "nearest" });
   }
 </script>
 


### PR DESCRIPTION
Fast-follow to #1471

#1471 added missing behavior to scroll the highlighted item into view.

However, the incorrect [`scrollIntoView` strategy](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView) was used.

Using `block: "end"` causes the entire browser page to scroll if there is overflowing content. Setting `block: "nearest"` will only scroll the item into view as necessary.

