### PR TITLE
fix(button): avoid left margin style for icon-only buttons

### DIFF
--- a/src/Button/Button.svelte
+++ b/src/Button/Button.svelte
@@ -175,7 +175,7 @@
     <slot /><svelte:component
       this="{icon}"
       aria-hidden="true"
-      class="bx--btn__icon"
+      class="{hasIconOnly ? '' : 'bx--btn__icon'}"
       aria-label="{iconDescription}"
     />
   </button>


### PR DESCRIPTION
Fixes #1476

Icon-only buttons should omit the "bx--btn__icon" class.