### PR TITLE
fix(a11y): resolve accessibility warnings in Svelte 3.50.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "rollup-plugin-terser": "^7.0.2",
     "sass": "^1.49.11",
     "sveld": "^0.17.2",
-    "svelte": "^3.46.6",
+    "svelte": "^3.50.0",
     "svelte-check": "^2.8.1",
     "typescript": "^4.7.4"
   },

--- a/src/Toggle/Toggle.svelte
+++ b/src/Toggle/Toggle.svelte
@@ -53,6 +53,7 @@
   on:mouseenter
   on:mouseleave
 >
+  <!-- svelte-ignore a11y-role-has-required-aria-props -->
   <input
     role="switch"
     type="checkbox"

--- a/src/UIShell/HeaderSearch.svelte
+++ b/src/UIShell/HeaderSearch.svelte
@@ -61,10 +61,11 @@
 
 <div bind:this="{refSearch}" role="search" class:active>
   <label for="search-input" id="search-label">Search</label>
-  <div role="combobox" aria-expanded="{active}">
+  <div aria-owns="search-menu" aria-haspopup="menu">
     <button
       type="button"
       aria-label="Search"
+      aria-expanded="{active}"
       tabindex="{active ? '-1' : '0'}"
       class:bx--header__action="{true}"
       class:disabled="{active}"
@@ -83,6 +84,8 @@
       class:active
       {...$$restProps}
       id="search-input"
+      aria-autocomplete="list"
+      aria-controls="search-menu"
       aria-activedescendant="{selectedId}"
       bind:value
       on:change
@@ -133,7 +136,7 @@
   {#if active && results.length > 0}
     <ul aria-labelledby="search-label" role="menu" id="search-menu">
       {#each results as result, i}
-        <li>
+        <li role="none">
           <a
             tabindex="-1"
             id="search-menuitem-{i}"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1414,10 +1414,15 @@ svelte-preprocess@^4.10.6:
     sorcery "^0.10.0"
     strip-indent "^3.0.0"
 
-svelte@^3.46.6, svelte@^3.47.0:
+svelte@^3.47.0:
   version "3.49.0"
   resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.49.0.tgz#5baee3c672306de1070c3b7888fc2204e36a4029"
   integrity sha512-+lmjic1pApJWDfPCpUUTc1m8azDqYCG1JN9YEngrx/hUyIcFJo6VZhj0A1Ai0wqoHcEIuQy+e9tk+4uDgdtsFA==
+
+svelte@^3.50.0:
+  version "3.50.0"
+  resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.50.0.tgz#d11a7a6bd1e084ec051d55104a9af8bccf54461f"
+  integrity sha512-zXeOUDS7+85i+RxLN+0iB6PMbGH7OhEgjETcD1fD8ZrhuhNFxYxYEHU41xuhkHIulJavcu3PKbPyuCrBxdxskQ==
 
 terser@^5.0.0:
   version "5.14.2"


### PR DESCRIPTION
Fixes #1479

Svelte [v3.50.0](https://github.com/sveltejs/svelte/blob/ed078e31fe1d3594c105a17f7fb6def769b386f6/CHANGELOG.md#3500) checks for additional a11y violations.

- For the `Toggle` component, the `a11y-role-has-required-aria-props` warning is a false positive since `input role="switch" type="checkbox"` has [built in semantics](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-checked), and does not require an additional `aria-checked` attribute.

- Aria attributes in `HeaderSearch` have been updated to reflect the upstream implementation of the search bar as seen on https://carbondesignsystem.com.