### PR TITLE
fix(button): resolve visual regression in `Pagination`, `PaginationNav`

### DIFF
--- a/src/Button/Button.svelte
+++ b/src/Button/Button.svelte
@@ -175,7 +175,8 @@
     <slot /><svelte:component
       this="{icon}"
       aria-hidden="true"
-      class="{hasIconOnly ? '' : 'bx--btn__icon'}"
+      class="bx--btn__icon"
+      style="{hasIconOnly ? 'margin-left: 0' : undefined}"
       aria-label="{iconDescription}"
     />
   </button>


### PR DESCRIPTION
#1477 removed the "bx--btn__icon" class for icon-only buttons to fix #1476.

However, it caused a visual regression in the next/previous buttons in `Pagination` and `PaginationNav`, which require the "bx--btn__icon" class.

The solution is to use an inline style attribute to manually unset the left margin instead of removing the class altogether. This is the simplest solution because it does not change the existing component API (like adding a prop/slot or using context).

---

### Before

<img width="982" alt="Before" src="https://user-images.githubusercontent.com/10718366/191979545-db6b2fdb-962b-4c35-b5c5-52a74d446a19.png">

### After

<img width="985" alt="After" src="https://user-images.githubusercontent.com/10718366/191979554-f6806f19-0b5d-49e2-baea-185ccc518895.png">
