### PR TITLE
Dispatch `change` event from `Pagination` and `Select`

### DIFF
--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -2682,11 +2682,12 @@ None.
 
 ### Events
 
-| Event name             | Type       | Detail                                           |
-| :--------------------- | :--------- | :----------------------------------------------- |
-| update                 | dispatched | <code>{ pageSize: number; page: number; }</code> |
-| click:button--previous | dispatched | <code>{ page: number; }</code>                   |
-| click:button--next     | dispatched | <code>{ page: number; }</code>                   |
+| Event name             | Type       | Detail                                            |
+| :--------------------- | :--------- | :------------------------------------------------ |
+| change                 | dispatched | <code>{ page?: number; pageSize?: number }</code> |
+| click:button--previous | dispatched | <code>{ page: number; }</code>                    |
+| click:button--next     | dispatched | <code>{ page: number; }</code>                    |
+| update                 | dispatched | <code>{ pageSize: number; page: number; }</code>  |
 
 ## `PaginationNav`
 

--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -3179,8 +3179,8 @@ None.
 
 | Event name | Type       | Detail                            |
 | :--------- | :--------- | :-------------------------------- |
-| change     | dispatched | <code>string &#124; number</code> |
-| input      | forwarded  | --                                |
+| input      | dispatched | <code>string &#124; number</code> |
+| change     | forwarded  | --                                |
 | focus      | forwarded  | --                                |
 | blur       | forwarded  | --                                |
 

--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -3180,8 +3180,9 @@ None.
 
 | Event name | Type       | Detail                            |
 | :--------- | :--------- | :-------------------------------- |
-| input      | dispatched | <code>string &#124; number</code> |
+| update     | dispatched | <code>string &#124; number</code> |
 | change     | forwarded  | --                                |
+| input      | forwarded  | --                                |
 | focus      | forwarded  | --                                |
 | blur       | forwarded  | --                                |
 

--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -8405,8 +8405,8 @@
       "events": [
         {
           "type": "dispatched",
-          "name": "update",
-          "detail": "{ pageSize: number; page: number; }"
+          "name": "change",
+          "detail": "{ page?: number; pageSize?: number }"
         },
         {
           "type": "dispatched",
@@ -8417,6 +8417,11 @@
           "type": "dispatched",
           "name": "click:button--next",
           "detail": "{ page: number; }"
+        },
+        {
+          "type": "dispatched",
+          "name": "update",
+          "detail": "{ pageSize: number; page: number; }"
         }
       ],
       "typedefs": [],

--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -10252,8 +10252,8 @@
         }
       ],
       "events": [
-        { "type": "dispatched", "name": "change", "detail": "string | number" },
-        { "type": "forwarded", "name": "input", "element": "select" },
+        { "type": "dispatched", "name": "input", "detail": "string | number" },
+        { "type": "forwarded", "name": "change", "element": "select" },
         { "type": "forwarded", "name": "focus", "element": "select" },
         { "type": "forwarded", "name": "blur", "element": "select" }
       ],

--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -10257,8 +10257,9 @@
         }
       ],
       "events": [
-        { "type": "dispatched", "name": "input", "detail": "string | number" },
+        { "type": "dispatched", "name": "update", "detail": "string | number" },
         { "type": "forwarded", "name": "change", "element": "select" },
+        { "type": "forwarded", "name": "input", "element": "select" },
         { "type": "forwarded", "name": "focus", "element": "select" },
         { "type": "forwarded", "name": "blur", "element": "select" }
       ],

--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -8406,7 +8406,8 @@
         {
           "type": "dispatched",
           "name": "change",
-          "detail": "{ page?: number; pageSize?: number }"
+          "detail": "{ page?: number; pageSize?: number }",
+          "description": "Dispatched after any user interaction"
         },
         {
           "type": "dispatched",
@@ -10257,7 +10258,12 @@
         }
       ],
       "events": [
-        { "type": "dispatched", "name": "update", "detail": "string | number" },
+        {
+          "type": "dispatched",
+          "name": "update",
+          "detail": "string | number",
+          "description": "The selected value."
+        },
         { "type": "forwarded", "name": "change", "element": "select" },
         { "type": "forwarded", "name": "input", "element": "select" },
         { "type": "forwarded", "name": "focus", "element": "select" },

--- a/docs/src/components/ComponentApi.svelte
+++ b/docs/src/components/ComponentApi.svelte
@@ -168,11 +168,33 @@
 <h2 id="dispatched-events">Dispatched events</h2>
 
 {#if dispatched_events.length > 0}
-  <UnorderedList class="my-layout-01-03">
-    {#each dispatched_events as event (event.name)}
-      <ListItem>on:{event.name}</ListItem>
-    {/each}
-  </UnorderedList>
+  {@const hasDescription = dispatched_events.find((el) => el.description)}
+  <StructuredList flush>
+    <StructuredListHead>
+      <StructuredListRow>
+        <StructuredListCell>Event name</StructuredListCell>
+        <StructuredListCell><code>event.details</code> type</StructuredListCell>
+        {#if hasDescription}
+          <StructuredListCell>Description</StructuredListCell>
+        {/if}
+      </StructuredListRow>
+    </StructuredListHead>
+    <StructuredListBody>
+      {#each dispatched_events as event (event.name)}
+        <StructuredListRow>
+          <StructuredListCell>
+            <strong>on:{event.name}</strong>
+          </StructuredListCell>
+          <StructuredListCell>
+            <code>{event.detail}</code>
+          </StructuredListCell>
+          <StructuredListCell>
+            {event.description ?? ""}
+          </StructuredListCell>
+        </StructuredListRow>
+      {/each}
+    </StructuredListBody>
+  </StructuredList>
 {:else}
   <p class="my-layout-01-03">No dispatched events.</p>
 {/if}

--- a/docs/src/pages/components/Select.svx
+++ b/docs/src/pages/components/Select.svx
@@ -11,7 +11,7 @@ components: ["Select", "SelectItem", "SelectItemGroup", "SelectSkeleton"]
 
 If the `selected` prop is not set, the value of the first `SelectItem` will be used as the default value.
 
-<Select labelText="Carbon theme" on:change={e => console.log("value", e.detail)}>
+<Select labelText="Carbon theme" on:change={e => console.log("value", e.target.value)}>
   <SelectItem value="white" />
   <SelectItem value="g10" />
   <SelectItem value="g80" />
@@ -23,7 +23,7 @@ If the `selected` prop is not set, the value of the first `SelectItem` will be u
 
 Use the `text` prop on `SelectItem` to customize the display value.
 
-<Select labelText="Carbon theme" on:change={e => console.log("value", e.detail)}>
+<Select labelText="Carbon theme" on:change={e => console.log("value", e.target.value)}>
   <SelectItem value="white" text="White" />
   <SelectItem value="g10" text="Gray 10" />
   <SelectItem value="g80" text="Gray 80" />
@@ -35,7 +35,7 @@ Use the `text` prop on `SelectItem` to customize the display value.
 
 Use the `selected` prop to specify an initial value.
 
-<Select labelText="Carbon theme" selected="g10" on:change={e => console.log("value", e.detail)}>
+<Select labelText="Carbon theme" selected="g10" on:change={e => console.log("value", e.target.value)}>
   <SelectItem value="white" text="White" />
   <SelectItem value="g10" text="Gray 10" />
   <SelectItem value="g80" text="Gray 80" />

--- a/src/Pagination/Pagination.svelte
+++ b/src/Pagination/Pagination.svelte
@@ -1,8 +1,9 @@
 <script>
   /**
-   * @event {{ pageSize: number; page: number; }} update
+   * @event {{ page?: number; pageSize?: number }} change - Dispatched after any user interaction
    * @event {{ page: number; }} click:button--previous
    * @event {{ page: number; }} click:button--next
+   * @event {{ pageSize: number; page: number; }} update
    */
 
   /** Specify the current page index */
@@ -109,6 +110,9 @@
         hideLabel
         noLabel
         inline
+        on:change="{() => {
+          dispatch('change', { pageSize });
+        }}"
         bind:selected="{pageSize}"
       >
         {#each pageSizes as size, i (size)}
@@ -136,6 +140,10 @@
         labelText="Page number, of {totalPages} pages"
         inline
         hideLabel
+        on:input="{() => console.log('select input event')}"
+        on:change="{() => {
+          dispatch('change', { page });
+        }}"
         bind:selected="{page}"
       >
         {#each selectItems as size, i (size)}
@@ -161,6 +169,7 @@
       on:click="{() => {
         page--;
         dispatch('click:button--previous', { page });
+        dispatch('change', { page });
       }}"
     />
     <Button
@@ -176,6 +185,7 @@
       on:click="{() => {
         page++;
         dispatch('click:button--next', { page });
+        dispatch('change', { page });
       }}"
     />
   </div>

--- a/src/Pagination/Pagination.svelte
+++ b/src/Pagination/Pagination.svelte
@@ -140,7 +140,6 @@
         labelText="Page number, of {totalPages} pages"
         inline
         hideLabel
-        on:input="{() => console.log('select input event')}"
         on:change="{() => {
           dispatch('change', { page });
         }}"

--- a/src/Select/Select.svelte
+++ b/src/Select/Select.svelte
@@ -1,6 +1,6 @@
 <script>
   /**
-   * @event {string | number} update
+   * @event {string | number} update The selected value.
    */
 
   /**

--- a/src/Select/Select.svelte
+++ b/src/Select/Select.svelte
@@ -1,6 +1,6 @@
 <script>
   /**
-   * @event {string | number} input
+   * @event {string | number} update
    */
 
   /**
@@ -114,7 +114,7 @@
     selected = $selectedValue;
 
     if (prevSelected !== undefined && selected !== prevSelected) {
-      dispatch("input", $selectedValue);
+      dispatch("update", $selectedValue);
     }
 
     prevSelected = selected;
@@ -207,6 +207,7 @@
           class:bx--select-input--sm="{size === 'sm'}"
           class:bx--select-input--xl="{size === 'xl'}"
           on:change="{handleChange}"
+          on:change
           on:input
           on:focus
           on:blur

--- a/src/Select/Select.svelte
+++ b/src/Select/Select.svelte
@@ -1,6 +1,6 @@
 <script>
   /**
-   * @event {string | number} change
+   * @event {string | number} input
    */
 
   /**
@@ -114,7 +114,7 @@
     selected = $selectedValue;
 
     if (prevSelected !== undefined && selected !== prevSelected) {
-      dispatch("change", $selectedValue);
+      dispatch("input", $selectedValue);
     }
 
     prevSelected = selected;
@@ -163,6 +163,7 @@
             class:bx--select-input--sm="{size === 'sm'}"
             class:bx--select-input--xl="{size === 'xl'}"
             on:change="{handleChange}"
+            on:change
             on:input
             on:focus
             on:blur

--- a/tests/Pagination.test.svelte
+++ b/tests/Pagination.test.svelte
@@ -5,6 +5,9 @@
 <Pagination
   totalItems="{102}"
   pageSizes="{[10, 15, 20]}"
+  on:change="{(e) => {
+    console.log(e.detail); // { pageSize?: number, page?: number }
+  }}"
   on:update="{(e) => {
     console.log(e.detail); // { pageSize: number; page: number; }
   }}"

--- a/types/Pagination/Pagination.svelte.d.ts
+++ b/types/Pagination/Pagination.svelte.d.ts
@@ -103,6 +103,7 @@ export interface PaginationProps
 export default class Pagination extends SvelteComponentTyped<
   PaginationProps,
   {
+    /** Dispatched after any user interaction */
     change: CustomEvent<{ page?: number; pageSize?: number }>;
     ["click:button--previous"]: CustomEvent<{ page: number }>;
     ["click:button--next"]: CustomEvent<{ page: number }>;

--- a/types/Pagination/Pagination.svelte.d.ts
+++ b/types/Pagination/Pagination.svelte.d.ts
@@ -103,9 +103,10 @@ export interface PaginationProps
 export default class Pagination extends SvelteComponentTyped<
   PaginationProps,
   {
-    update: CustomEvent<{ pageSize: number; page: number }>;
+    change: CustomEvent<{ page?: number; pageSize?: number }>;
     ["click:button--previous"]: CustomEvent<{ page: number }>;
     ["click:button--next"]: CustomEvent<{ page: number }>;
+    update: CustomEvent<{ pageSize: number; page: number }>;
   },
   {}
 > {}

--- a/types/Select/Select.svelte.d.ts
+++ b/types/Select/Select.svelte.d.ts
@@ -109,8 +109,9 @@ export interface SelectProps
 export default class Select extends SvelteComponentTyped<
   SelectProps,
   {
-    input: CustomEvent<string | number>;
+    update: CustomEvent<string | number>;
     change: WindowEventMap["change"];
+    input: WindowEventMap["input"];
     focus: WindowEventMap["focus"];
     blur: WindowEventMap["blur"];
   },

--- a/types/Select/Select.svelte.d.ts
+++ b/types/Select/Select.svelte.d.ts
@@ -109,8 +109,8 @@ export interface SelectProps
 export default class Select extends SvelteComponentTyped<
   SelectProps,
   {
-    change: CustomEvent<string | number>;
-    input: WindowEventMap["input"];
+    input: CustomEvent<string | number>;
+    change: WindowEventMap["change"];
     focus: WindowEventMap["focus"];
     blur: WindowEventMap["blur"];
   },

--- a/types/Select/Select.svelte.d.ts
+++ b/types/Select/Select.svelte.d.ts
@@ -109,7 +109,7 @@ export interface SelectProps
 export default class Select extends SvelteComponentTyped<
   SelectProps,
   {
-    update: CustomEvent<string | number>;
+    /** The selected value. */ update: CustomEvent<string | number>;
     change: WindowEventMap["change"];
     input: WindowEventMap["input"];
     focus: WindowEventMap["focus"];


### PR DESCRIPTION
Closes #1491 

Pagination

- Feature: dispatch `change` event from `<Pagination>` whenever user interacts with "previous" button, "next" button, page dropdown, or page size dropdown

Select

- Feature: forward `change` event from `<Select>`; necessary for Pagination to react to changes
- Fix (or breaking change?): dispatch `input` instead of `change`

Side note, it would be nice if the note I added to the `@event` JSDoc appeared on the rendered docs. Perhaps I can open a separate issue for that.