### PR TITLE
fix transitions delaying navigation

### DIFF
--- a/src/ImageLoader/ImageLoader.svelte
+++ b/src/ImageLoader/ImageLoader.svelte
@@ -86,7 +86,7 @@
       style="width: 100%;{$$restProps.style}"
       src="{src}"
       alt="{alt}"
-      transition:fade="{{ duration: fadeIn ? fast02 : 0 }}"
+      transition:fade|local="{{ duration: fadeIn ? fast02 : 0 }}"
     />
   {/if}
   {#if error}
@@ -103,7 +103,7 @@
         style="width: 100%;{$$restProps.style}"
         src="{src}"
         alt="{alt}"
-        transition:fade="{{ duration: fadeIn ? fast02 : 0 }}"
+        transition:fade|local="{{ duration: fadeIn ? fast02 : 0 }}"
       />
     {/if}
     {#if error}

--- a/src/UIShell/HeaderAction.svelte
+++ b/src/UIShell/HeaderAction.svelte
@@ -88,7 +88,7 @@
     bind:this="{refPanel}"
     class:bx--header-panel="{true}"
     class:bx--header-panel--expanded="{true}"
-    transition:slide="{{
+    transition:slide|local="{{
       ...transition,
       duration: transition === false ? 0 : transition.duration,
     }}"


### PR DESCRIPTION
fixes #1501

Adds `local` to transitions to prevent them from playing between page navigations.

https://svelte.dev/docs#template-syntax-element-directives-transition-fn-transition-events
> Local transitions only play when the block they belong to is created or destroyed, not when parent blocks are created or destroyed.