### PR TITLE
fix(header-search): fix layout regression

### DIFF
--- a/src/UIShell/HeaderSearch.svelte
+++ b/src/UIShell/HeaderSearch.svelte
@@ -197,7 +197,7 @@
     outline-offset: -2px;
   }
 
-  [role="combobox"] {
+  [aria-haspopup="menu"] {
     display: flex;
     flex-grow: 1;
     border-bottom: 1px solid #393939;


### PR DESCRIPTION
Fixes #1504

#1480 [updated markup](https://github.com/carbon-design-system/carbon-components-svelte/commit/73385bf598740f616946e974b94c970d8b8e3825#diff-aafe2deee611782c19726e6a62ac9472b9001003bac8342afd555d42bc9b5c34R64) in `HeaderSearch`, which caused some styles to be lost.