### PR TITLE
fix(list-box-menu-item): avoid element reference error

### DIFF
--- a/src/ListBox/ListBoxMenuItem.svelte
+++ b/src/ListBox/ListBoxMenuItem.svelte
@@ -12,7 +12,7 @@
 
   $: isTruncated = ref?.offsetWidth < ref?.scrollWidth;
   $: title = isTruncated ? ref?.innerText : undefined;
-  $: if (highlighted && !ref?.matches(":hover")) {
+  $: if (highlighted && ref && !ref.matches(":hover")) {
     // Scroll highlighted item into view if using keyboard navigation
     ref.scrollIntoView({ block: "nearest" });
   }


### PR DESCRIPTION
Fixes #1505
Fixes #1503

`ref?.matches(':hover')` will not throw if `ref` is undefined or null. However, it does not prevent the `ref.scrollIntoView` statement from being evaluated if `ref` is `null`, resulting in a runtime error.