### PR TITLE
docs: update README, links

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ The preprocessor optimizes imports from the following packages:
 - [carbon-icons-svelte](https://github.com/carbon-design-system/carbon-icons-svelte)
 - [carbon-pictograms-svelte](https://github.com/carbon-design-system/carbon-pictograms-svelte)
 
-**Example**
+**Before & After**
 
 ```diff
 - import { Button } from "carbon-components-svelte";
@@ -219,6 +219,21 @@ import { optimizeImports } from "carbon-preprocess-svelte";
 
 export default {
   preprocess: [optimizeImports()],
+};
+```
+
+`svelte-preprocess` should be invoked before any preprocessor from `carbon-preprocess-svelte`.
+
+```diff
+// svelte.config.js
++ import sveltePreprocess from "svelte-preprocess";
+import { optimizeImports } from "carbon-preprocess-svelte";
+
+export default {
+  preprocess: [
++   sveltePreprocess(),
+    optimizeImports()
+  ],
 };
 ```
 

--- a/README.md
+++ b/README.md
@@ -31,8 +31,6 @@ Other forms of documentation are auto-generated:
 
 Install `carbon-components-svelte` as a development dependency.
 
-A minimum Svelte version of 3.48.0 is required to use this library.
-
 ```sh
 # Yarn
 yarn add -D carbon-components-svelte

--- a/docs/src/pages/index.svelte
+++ b/docs/src/pages/index.svelte
@@ -208,7 +208,7 @@
                 <OutboundLink
                   inline
                   size="lg"
-                  href="https://github.com/carbon-design-system/carbon/blob/main/docs/guides/sass.md"
+                  href="https://github.com/carbon-design-system/carbon/blob/v10/docs/guides/sass.md"
                 >
                   official Carbon guide on SASS
                 </OutboundLink>

--- a/docs/src/pages/index.svelte
+++ b/docs/src/pages/index.svelte
@@ -12,7 +12,6 @@
     OutboundLink,
     RadioButtonGroup,
     RadioButton,
-    InlineNotification,
   } from "carbon-components-svelte";
   import TileCard from "../components/TileCard.svelte";
   import { theme } from "../store";
@@ -92,13 +91,6 @@
     <Row style="margin-bottom: var(--cds-layout-02)">
       <Column max="{10}" xlg="{10}">
         <h2 style="margin-top: var(--cds-layout-02)">Installation</h2>
-        <InlineNotification
-          style="max-width: calc(48rem - 1rem);"
-          kind="info"
-          subtitle="A minimum Svelte version of 3.48.0 is required to use this library."
-          lowContrast
-          hideCloseButton
-        />
       </Column>
     </Row>
     <Row style="margin-bottom: var(--cds-layout-02)">


### PR DESCRIPTION
- add note on using `optimizeImports` with `svelte-preprocess` (closes #1500)
- point link to v10 SASS guide (#1489)
- remove note on minimum Svelte version required