### PR TITLE
fix(number-input): fix interaction between `allowEmpty` and `min`

### DIFF
--- a/src/NumberInput/NumberInput.svelte
+++ b/src/NumberInput/NumberInput.svelte
@@ -131,7 +131,10 @@
   $: incrementLabel = translateWithId("increment");
   $: decrementLabel = translateWithId("decrement");
   $: error =
-    invalid || (!allowEmpty && value == null) || value > max || value < min;
+    invalid ||
+    (!allowEmpty && value == null) ||
+    value > max ||
+    (typeof value === "number" && value < min);
   $: errorId = `error-${id}`;
   $: ariaLabel =
     $$props["aria-label"] ||


### PR DESCRIPTION
Proposal to fix https://github.com/carbon-design-system/carbon-components-svelte/issues/1510