### PR TITLE
docs(pagination-nav): add more examples

### DIFF
--- a/docs/src/pages/components/PaginationNav.svx
+++ b/docs/src/pages/components/PaginationNav.svx
@@ -5,8 +5,35 @@
 
 ## Default
 
+`PaginationNav` renders `10` items and does not loop by default.
+
 <PaginationNav />
+
+## Total
+
+Use the `total` prop to specify the number of pages.
+
+<PaginationNav total={3} />
 
 ## Loopable
 
+Set `loop` to `true` for navigation to be looped.
+
 <PaginationNav total={3} loop />
+
+## Shown
+
+If `total` is greater than `10`, the number of items shown will be truncated to `10`.
+
+Use `shown` to override the number of items shown.
+
+<PaginationNav total={100} shown={5}  />
+
+## Custom button text
+
+Use the `forwardText` and `backwardText` props to customize the button text.
+
+<PaginationNav
+  forwardText="Next"
+  backwardText="Previous"
+/>

--- a/docs/src/pages/components/PaginationNav.svx
+++ b/docs/src/pages/components/PaginationNav.svx
@@ -9,6 +9,12 @@
 
 <PaginationNav />
 
+## Reactive example
+
+Use the `page` prop to bind to the current page number.
+
+<FileSource src="/framed/PaginationNav/PaginationNavReactive" />
+
 ## Total
 
 Use the `total` prop to specify the number of pages.

--- a/docs/src/pages/framed/PaginationNav/PaginationNavReactive.svelte
+++ b/docs/src/pages/framed/PaginationNav/PaginationNavReactive.svelte
@@ -1,0 +1,16 @@
+<script>
+  import { PaginationNav, Button } from "carbon-components-svelte";
+
+  let page = 2;
+</script>
+
+<PaginationNav bind:page />
+
+<div style="margin: var(--cds-layout-01) 0">
+  <Button on:click="{() => (page = 0)}" disabled="{page === 0}">
+    Set page to 0
+  </Button>
+</div>
+
+<strong>page:</strong>
+{page}


### PR DESCRIPTION
This adds the following examples to the `PaginationNav` docs:

- Reactive example
- Total
- Shown
- Custom button text