### PR TITLE
feat!: use 1-indexing for PaginationNav

### DIFF
--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -2694,7 +2694,7 @@ None.
 
 | Prop name    | Required | Kind             | Reactive | Type                 | Default value                | Description                               |
 | :----------- | :------- | :--------------- | :------- | -------------------- | ---------------------------- | ----------------------------------------- |
-| page         | No       | <code>let</code> | Yes      | <code>number</code>  | <code>0</code>               | Specify the current page index            |
+| page         | No       | <code>let</code> | Yes      | <code>number</code>  | <code>1</code>               | Specify the current page index            |
 | total        | No       | <code>let</code> | No       | <code>number</code>  | <code>10</code>              | Specify the total number of pages         |
 | shown        | No       | <code>let</code> | No       | <code>number</code>  | <code>10</code>              | Specify the total number of pages to show |
 | loop         | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code>           | Set to `true` to loop the navigation      |

--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -8431,7 +8431,7 @@
           "kind": "let",
           "description": "Specify the current page index",
           "type": "number",
-          "value": "0",
+          "value": "1",
           "isFunction": false,
           "isFunctionDeclaration": false,
           "isRequired": false,

--- a/docs/src/pages/framed/PaginationNav/PaginationNavReactive.svelte
+++ b/docs/src/pages/framed/PaginationNav/PaginationNavReactive.svelte
@@ -7,8 +7,8 @@
 <PaginationNav bind:page />
 
 <div style="margin: var(--cds-layout-01) 0">
-  <Button on:click="{() => (page = 0)}" disabled="{page === 0}">
-    Set page to 0
+  <Button on:click="{() => (page = 1)}" disabled="{page === 0}">
+    Set page to 1
   </Button>
 </div>
 

--- a/src/PaginationNav/PaginationItem.svelte
+++ b/src/PaginationNav/PaginationItem.svelte
@@ -1,6 +1,6 @@
 <script>
   /** Specify the current page index */
-  export let page = 0;
+  export let page = 1;
 
   /** Set to `true` to use the active state */
   export let active = false;

--- a/src/PaginationNav/PaginationOverflow.svelte
+++ b/src/PaginationNav/PaginationOverflow.svelte
@@ -34,7 +34,7 @@
       >
         <option value="" hidden></option>
         {#each Array.from({ length: count }, (_, i) => i) as i}
-          <option value="{fromIndex + i}" data-page="{fromIndex + i + 1}">
+          <option value="{fromIndex + i + 1}" data-page="{fromIndex + i + 1}">
             {fromIndex + i + 1}
           </option>
         {/each}

--- a/types/PaginationNav/PaginationNav.svelte.d.ts
+++ b/types/PaginationNav/PaginationNav.svelte.d.ts
@@ -5,7 +5,7 @@ export interface PaginationNavProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["nav"]> {
   /**
    * Specify the current page index
-   * @default 0
+   * @default 1
    */
   page?: number;
 


### PR DESCRIPTION
Closes #1513 

Changes include:

- BREAKING CHANGE (PaginationNav): use 1-indexing
  closes #1513 
- fix(PaginationNav): make 'change' event emit after user interaction instead of reactive event (explanation below)

I removed the event dispatcher in `<PaginationNav>` for `change` called in `afterUpdate` since it would dispatch on mount when it should only dispatch upon a user's interaction. When adding a change handler to `<PaginationNav>`, I would have to add a mount flag as a workaround. This treatment is similar to the one I provided in #1497.

With the changes in this PR I can remove my workaround in my change handler, allowing me to trust the `change` event would fire after user input only:

```diff
<script>
  import {
    PaginationNav
  } from 'carbon-components-svelte'
- import { onMount } from 'svelte'
  import { goto } from '$app/navigation'
  import { page } from '$app/stores'

  /** @type {import('./$types').PageServerData} */
  export let data

- let mounted = false

  // ...

  /**
   * changePage via pagination dropdown or prev/next buttons
   * @param e
   */
  const changePage = async e => {
-   if (!mounted) return
    const url = new URL($page.url)
    url.searchParams.set('page', e.detail.page)

    await goto(`?${url.searchParams.toString()}`)
  }

- onMount(() => mounted = true)
</script>

<!-- ...other html -->

<PaginationNav
  page={listPage}
  total={Math.ceil(data.itemCount / pageSize)}
  shown={5}
  on:change={changePage}
/>
```