### PR TITLE
fix(a11y): ignore false positive a11y warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "rollup-plugin-terser": "^7.0.2",
     "sass": "^1.49.11",
     "sveld": "^0.17.2",
-    "svelte": "^3.50.0",
+    "svelte": "^3.51.0",
     "svelte-check": "^2.8.1",
     "typescript": "^4.7.4"
   },

--- a/src/CodeSnippet/CodeSnippet.svelte
+++ b/src/CodeSnippet/CodeSnippet.svelte
@@ -215,6 +215,7 @@
     on:mouseenter
     on:mouseleave
   >
+    <!-- svelte-ignore a11y-no-noninteractive-tabindex -->
     <div
       role="{type === 'single' ? 'textbox' : undefined}"
       tabindex="{type === 'single' && !disabled ? '0' : undefined}"

--- a/src/ComposedModal/ComposedModal.svelte
+++ b/src/ComposedModal/ComposedModal.svelte
@@ -150,6 +150,7 @@
     }
   }}"
 >
+  <!-- svelte-ignore a11y-click-events-have-key-events -->
   <div
     bind:this="{innerModal}"
     role="dialog"

--- a/src/ComposedModal/ModalBody.svelte
+++ b/src/ComposedModal/ModalBody.svelte
@@ -6,6 +6,7 @@
   export let hasScrollingContent = false;
 </script>
 
+<!-- svelte-ignore a11y-no-noninteractive-tabindex -->
 <div
   tabindex="{hasScrollingContent ? '0' : undefined}"
   role="{hasScrollingContent ? 'region' : undefined}"

--- a/src/DataTable/DataTableSkeleton.svelte
+++ b/src/DataTable/DataTableSkeleton.svelte
@@ -63,6 +63,7 @@
       </div>
     </section>
   {/if}
+  <!-- svelte-ignore a11y-click-events-have-key-events -->
   <table
     class:bx--skeleton="{true}"
     class:bx--data-table="{true}"

--- a/src/FileUploader/FileUploaderButton.svelte
+++ b/src/FileUploader/FileUploaderButton.svelte
@@ -60,6 +60,7 @@
   }
 </script>
 
+<!-- svelte-ignore a11y-no-noninteractive-tabindex -->
 <label
   aria-disabled="{disabled}"
   for="{id}"

--- a/src/FileUploader/FileUploaderDropContainer.svelte
+++ b/src/FileUploader/FileUploaderDropContainer.svelte
@@ -81,6 +81,7 @@
     }
   }}"
 >
+  <!-- svelte-ignore a11y-no-noninteractive-tabindex -->
   <label
     for="{id}"
     tabindex="{tabindex}"

--- a/src/ListBox/ListBoxField.svelte
+++ b/src/ListBox/ListBoxField.svelte
@@ -43,6 +43,7 @@
   $: menuId = `menu-${id}`;
 </script>
 
+<!-- svelte-ignore a11y-no-noninteractive-tabindex -->
 <div
   bind:this="{ref}"
   role="{role}"

--- a/src/Modal/Modal.svelte
+++ b/src/Modal/Modal.svelte
@@ -243,6 +243,7 @@
         </button>
       {/if}
     </div>
+    <!-- svelte-ignore a11y-no-noninteractive-tabindex -->
     <div
       id="{modalBodyId}"
       class:bx--modal-content="{true}"

--- a/src/NumberInput/NumberInput.svelte
+++ b/src/NumberInput/NumberInput.svelte
@@ -153,6 +153,7 @@
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
+<!-- svelte-ignore a11y-click-events-have-key-events -->
 <div
   class:bx--form-item="{true}"
   on:click

--- a/src/Search/Search.svelte
+++ b/src/Search/Search.svelte
@@ -101,6 +101,7 @@
     class:bx--search--expanded="{expanded}"
     class="{searchClass}"
   >
+    <!-- svelte-ignore a11y-click-events-have-key-events -->
     <div
       bind:this="{searchRef}"
       class:bx--search-magnifier="{true}"

--- a/src/StructuredList/StructuredListRow.svelte
+++ b/src/StructuredList/StructuredListRow.svelte
@@ -12,6 +12,7 @@
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
 {#if label}
   <!-- svelte-ignore a11y-label-has-associated-control -->
+  <!-- svelte-ignore a11y-no-noninteractive-tabindex -->
   <label
     tabindex="{tabindex}"
     class:bx--structured-list-row="{true}"

--- a/src/TextArea/TextArea.svelte
+++ b/src/TextArea/TextArea.svelte
@@ -59,6 +59,7 @@
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
+<!-- svelte-ignore a11y-click-events-have-key-events -->
 <div
   on:click
   on:mouseover

--- a/src/TextInput/PasswordInput.svelte
+++ b/src/TextInput/PasswordInput.svelte
@@ -94,6 +94,7 @@
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
+<!-- svelte-ignore a11y-click-events-have-key-events -->
 <div
   class:bx--form-item="{true}"
   class:bx--text-input-wrapper="{true}"

--- a/src/TextInput/TextInput.svelte
+++ b/src/TextInput/TextInput.svelte
@@ -100,6 +100,7 @@
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
+<!-- svelte-ignore a11y-click-events-have-key-events -->
 <div
   class:bx--form-item="{true}"
   class:bx--text-input-wrapper="{true}"

--- a/src/Tile/SelectableTile.svelte
+++ b/src/Tile/SelectableTile.svelte
@@ -53,6 +53,7 @@
   disabled="{disabled}"
 />
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
+<!-- svelte-ignore a11y-no-noninteractive-tabindex -->
 <label
   for="{id}"
   tabindex="{disabled ? undefined : tabindex}"

--- a/src/TimePicker/TimePicker.svelte
+++ b/src/TimePicker/TimePicker.svelte
@@ -52,6 +52,7 @@
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
+<!-- svelte-ignore a11y-click-events-have-key-events -->
 <div
   class:bx--form-item="{true}"
   on:click

--- a/src/Tooltip/Tooltip.svelte
+++ b/src/Tooltip/Tooltip.svelte
@@ -249,6 +249,7 @@
       on:keydown="{onKeydown}"
     >
       <span class:bx--tooltip__caret="{true}"></span>
+      <!-- svelte-ignore a11y-click-events-have-key-events -->
       <div
         on:click|stopPropagation
         on:mousedown|stopPropagation

--- a/src/TreeView/TreeViewNodeList.svelte
+++ b/src/TreeView/TreeViewNodeList.svelte
@@ -132,6 +132,7 @@
     }}"
   >
     <div class:bx--tree-node__label="{true}" bind:this="{refLabel}">
+      <!-- svelte-ignore a11y-click-events-have-key-events -->
       <span
         class:bx--tree-parent-node__toggle="{true}"
         disabled="{disabled}"

--- a/src/UIShell/SideNav.svelte
+++ b/src/UIShell/SideNav.svelte
@@ -55,6 +55,7 @@
 <svelte:window bind:innerWidth="{winWidth}" />
 
 {#if !fixed}
+  <!-- svelte-ignore a11y-click-events-have-key-events -->
   <div
     on:click="{() => {
       dispatch('click:overlay');

--- a/yarn.lock
+++ b/yarn.lock
@@ -1419,10 +1419,10 @@ svelte@^3.47.0:
   resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.49.0.tgz#5baee3c672306de1070c3b7888fc2204e36a4029"
   integrity sha512-+lmjic1pApJWDfPCpUUTc1m8azDqYCG1JN9YEngrx/hUyIcFJo6VZhj0A1Ai0wqoHcEIuQy+e9tk+4uDgdtsFA==
 
-svelte@^3.50.0:
-  version "3.50.0"
-  resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.50.0.tgz#d11a7a6bd1e084ec051d55104a9af8bccf54461f"
-  integrity sha512-zXeOUDS7+85i+RxLN+0iB6PMbGH7OhEgjETcD1fD8ZrhuhNFxYxYEHU41xuhkHIulJavcu3PKbPyuCrBxdxskQ==
+svelte@^3.51.0:
+  version "3.51.0"
+  resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.51.0.tgz#a1a0afb25dc518217f353dd73ea6471c128ddf84"
+  integrity sha512-PBITYIrsNOuW+Dtds00gSY68raNZQn7i59Dg/fjgf6WwyawPKeBwle692coO7ILZqSO+UJe9899aDn9sMdeOHA==
 
 terser@^5.0.0:
   version "5.14.2"


### PR DESCRIPTION
Fixes #1517

Ignore a11y warnings emitted from Svelte version 3.51.