### PR TITLE
fix(search): prop types should extend `input` attributes

### DIFF
--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -10001,7 +10001,7 @@
         { "type": "dispatched", "name": "clear", "detail": "null" }
       ],
       "typedefs": [],
-      "rest_props": { "type": "InlineComponent", "name": "SearchSkeleton" }
+      "rest_props": { "type": "Element", "name": "input" }
     },
     {
       "moduleName": "SearchSkeleton",

--- a/src/Search/Search.svelte
+++ b/src/Search/Search.svelte
@@ -2,6 +2,7 @@
   /**
    * @event {null} expand
    * @event {null} collapse
+   * @restProps {input}
    */
 
   /**

--- a/tests/Search.test.svelte
+++ b/tests/Search.test.svelte
@@ -6,7 +6,7 @@
 
 <Search placeholder="Search catalog..." value="Cloud functions" />
 
-<Search light />
+<Search light name="search" dirname="search" />
 
 <Search size="lg" />
 

--- a/types/Search/Search.svelte.d.ts
+++ b/types/Search/Search.svelte.d.ts
@@ -1,7 +1,8 @@
 /// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
 
-export interface SearchProps {
+export interface SearchProps
+  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["input"]> {
   /**
    * Specify the value of the search input
    * @default ""


### PR DESCRIPTION
Fixes #1520

`$$restProps` are forwarded to the `input` element. However, this is not reflected in the generated TypeScript definitions.

For example, the following would produce an error in TypeScript:

```svelte
<Search name="q" />
```