### PR TITLE
export an "icon only variant" option

### DIFF
--- a/src/Button/Button.svelte
+++ b/src/Button/Button.svelte
@@ -26,6 +26,11 @@
   export let isSelected = false;
 
   /**
+   * Set to `true` for the icon-only variant
+   */
+   export let iconOnly = false;
+
+  /**
    * Specify the icon to render
    * @type {typeof import("svelte").SvelteComponent}
    */
@@ -85,7 +90,7 @@
   $: if (ctx && ref) {
     ctx.declareRef(ref);
   }
-  $: hasIconOnly = icon && !$$slots.default;
+  $: hasIconOnly = iconOnly || (icon && !$$slots.default);
   $: buttonProps = {
     type: href && !disabled ? undefined : type,
     tabindex,
@@ -152,8 +157,10 @@
   >
     {#if hasIconOnly}
       <span class:bx--assistive-text="{true}">{iconDescription}</span>
+    {:else}
+      <slot />
     {/if}
-    <slot /><svelte:component
+    <svelte:component
       this="{icon}"
       aria-hidden="true"
       class="bx--btn__icon"
@@ -171,8 +178,10 @@
   >
     {#if hasIconOnly}
       <span class:bx--assistive-text="{true}">{iconDescription}</span>
+    {:else}
+      <slot />
     {/if}
-    <slot /><svelte:component
+    <svelte:component
       this="{icon}"
       aria-hidden="true"
       class="bx--btn__icon"

--- a/types/Button/Button.svelte.d.ts
+++ b/types/Button/Button.svelte.d.ts
@@ -39,6 +39,12 @@ export interface ButtonProps
   isSelected?: boolean;
 
   /**
+   * Set to `true` for the icon-only variant
+   * @default false
+   */
+   iconOnly?: boolean;
+
+  /**
    * Specify the icon to render
    * @default undefined
    */


### PR DESCRIPTION
The `$$slots.default` will be trigged even if there is no contents.
For example the code below will cause the `!!$$slots.default` to be `true` even there is no actual contents.
The solution is to export an `iconOnly` option for the icon only variant.
```svelte
  <Button
    iconDescription="Add"
    icon={Add}
    on:click={() => handleClick('add')}>
    {#if !isMobileView}
      Add New
    {/if}
  </Button>
```

Using the `iconOnly` option fixed the problem:
```svelte
  <Button
    iconOnly={isMobileView}
    iconDescription="Add"
    icon={Add}
    on:click={() => handleClick('add')}>
    Add New
  </Button>
```
