### PR TITLE
use 'sm' instead of 'small'

### DIFF
--- a/src/Button/Button.svelte
+++ b/src/Button/Button.svelte
@@ -13,7 +13,7 @@
 
   /**
    * Specify the size of button
-   * @type {"default" | "field" | "small" | "lg" | "xl"}
+   * @type {"default" | "field" | "sm" | "lg" | "xl"}
    */
   export let size = "default";
 
@@ -97,14 +97,10 @@
     class: [
       "bx--btn",
       expressive && "bx--btn--expressive",
-      ((size === "small" && !expressive) ||
-        (size === "sm" && !expressive) ||
-        (size === "small" && !expressive)) &&
-        "bx--btn--sm",
       (size === "field" && !expressive) ||
         (size === "md" && !expressive && "bx--btn--md"),
       size === "field" && "bx--btn--field",
-      size === "small" && "bx--btn--sm",
+      size === "sm" && "bx--btn--sm",
       size === "lg" && "bx--btn--lg",
       size === "xl" && "bx--btn--xl",
       kind && `bx--btn--${kind}`,

--- a/src/Button/ButtonSkeleton.svelte
+++ b/src/Button/ButtonSkeleton.svelte
@@ -7,7 +7,7 @@
 
   /**
    * Specify the size of button skeleton
-   * @type {"default" | "field" | "small" | "lg" | "xl"}
+   * @type {"default" | "field" | "sm" | "lg" | "xl"}
    */
   export let size = "default";
 </script>
@@ -21,7 +21,7 @@
     class:bx--skeleton="{true}"
     class:bx--btn="{true}"
     class:bx--btn--field="{size === 'field'}"
-    class:bx--btn--sm="{size === 'small'}"
+    class:bx--btn--sm="{size === 'sm'}"
     class:bx--btn--lg="{size === 'lg'}"
     class:bx--btn--xl="{size === 'xl'}"
     {...$$restProps}
@@ -37,7 +37,7 @@
     class:bx--skeleton="{true}"
     class:bx--btn="{true}"
     class:bx--btn--field="{size === 'field'}"
-    class:bx--btn--sm="{size === 'small'}"
+    class:bx--btn--sm="{size === 'sm'}"
     class:bx--btn--lg="{size === 'lg'}"
     class:bx--btn--xl="{size === 'xl'}"
     {...$$restProps}

--- a/tests/Button.test.svelte
+++ b/tests/Button.test.svelte
@@ -42,15 +42,15 @@
 
 <Button size="field" kind="danger">Danger</Button>
 
-<Button size="small">Primary</Button>
+<Button size="sm">Primary</Button>
 
-<Button size="small" kind="secondary">Secondary</Button>
+<Button size="sm" kind="secondary">Secondary</Button>
 
-<Button size="small" kind="tertiary">Tertiary</Button>
+<Button size="sm" kind="tertiary">Tertiary</Button>
 
-<Button size="small" kind="ghost">Ghost</Button>
+<Button size="sm" kind="ghost">Ghost</Button>
 
-<Button size="small" kind="danger">Danger</Button>
+<Button size="sm" kind="danger">Danger</Button>
 
 <Button disabled>Disabled button</Button>
 
@@ -58,4 +58,4 @@
 
 <Button skeleton size="field" />
 
-<Button skeleton size="small" />
+<Button skeleton size="sm" />

--- a/tests/Tooltip.test.svelte
+++ b/tests/Tooltip.test.svelte
@@ -33,13 +33,13 @@
   <p>Resources are provisioned based on your account's organization.</p>
   <div class="bx--tooltip__footer">
     <Link href="/">Learn more</Link>
-    <Button size="small">Manage</Button>
+    <Button size="sm">Manage</Button>
   </div>
 </Tooltip>
 
 <Link href="/">Learn more</Link>
 
-<Button size="small">Manage</Button>
+<Button size="sm">Manage</Button>
 
 <Tooltip triggerText="Resource list" icon="{Catalog}">
   <p>Resources are provisioned based on your account's organization.</p>

--- a/types/Button/Button.svelte.d.ts
+++ b/types/Button/Button.svelte.d.ts
@@ -24,7 +24,7 @@ export interface ButtonProps
    * Specify the size of button
    * @default "default"
    */
-  size?: "default" | "field" | "small" | "lg" | "xl";
+  size?: "default" | "field" | "sm" | "lg" | "xl";
 
   /**
    * Set to `true` to use Carbon's expressive typesetting

--- a/types/Button/ButtonSkeleton.svelte.d.ts
+++ b/types/Button/ButtonSkeleton.svelte.d.ts
@@ -13,7 +13,7 @@ export interface ButtonSkeletonProps
    * Specify the size of button skeleton
    * @default "default"
    */
-  size?: "default" | "field" | "small" | "lg" | "xl";
+  size?: "default" | "field" | "sm" | "lg" | "xl";
 
   /**
    * SvelteKit attribute to enable data prefetching


### PR DESCRIPTION
Why not use `sm` instead of `small` ?
It's better for semantics  with other components, or there is something I'm missing ?