### PR TITLE
no need to import derived from "svelte/store"

### DIFF
--- a/src/DataTable/DataTable.svelte
+++ b/src/DataTable/DataTable.svelte
@@ -127,7 +127,7 @@
   export let page = 0;
 
   import { createEventDispatcher, setContext } from "svelte";
-  import { writable, derived } from "svelte/store";
+  import { writable } from "svelte/store";
   import ChevronRight from "../icons/ChevronRight.svelte";
   import InlineCheckbox from "../Checkbox/InlineCheckbox.svelte";
   import RadioButton from "../RadioButton/RadioButton.svelte";


### PR DESCRIPTION
remove the `derived` import from "svelte/store"