### PR TITLE
flip menu direction to top if is bigger than the parent offset

### DIFF
--- a/src/DataTable/DataTable.svelte
+++ b/src/DataTable/DataTable.svelte
@@ -126,6 +126,9 @@
   /** Set to `number` to set current page */
   export let page = 0;
 
+  /** Obtain a reference to the trigger body element */
+  export let tRef = null;
+
   import { createEventDispatcher, setContext } from "svelte";
   import { writable, derived } from "svelte/store";
   import ChevronRight from "../icons/ChevronRight.svelte";
@@ -258,7 +261,7 @@
   };
 </script>
 
-<TableContainer useStaticWidth="{useStaticWidth}" {...$$restProps}>
+<TableContainer bind:ref={tRef} useStaticWidth="{useStaticWidth}" {...$$restProps}>
   {#if title || $$slots.title || description || $$slots.description}
     <div class:bx--data-table-header="{true}">
       {#if title || $$slots.title}

--- a/src/DataTable/TableContainer.svelte
+++ b/src/DataTable/TableContainer.svelte
@@ -10,9 +10,13 @@
 
   /** Set to `true` to use static width */
   export let useStaticWidth = false;
+
+  /** Obtain a reference to the Div HTML element */
+  export let ref = null;
 </script>
 
 <div
+  bind:this={ref}
   class:bx--data-table-container="{true}"
   class:bx--data-table-container--static="{useStaticWidth}"
   class:bx--data-table--max-width="{stickyHeader}"

--- a/src/OverflowMenu/OverflowMenu.svelte
+++ b/src/OverflowMenu/OverflowMenu.svelte
@@ -49,6 +49,9 @@
   /** Set an id for the button element */
   export let id = "ccs-" + Math.random().toString(36);
 
+  /** Obtain a reference to the trigger parent element */
+  export let parentRef = null;
+
   /** Obtain a reference to the trigger button element */
   export let buttonRef = null;
 
@@ -128,9 +131,19 @@
     }
 
     if (open) {
-      const { width, height } = buttonRef.getBoundingClientRect();
+      const { width, height, bottom } = buttonRef.getBoundingClientRect();
 
       buttonWidth = width;
+
+      // if menu height is bigger than the offset then flip  the direction to top
+      if (parentRef) {
+        if (
+          menuRef.getBoundingClientRect().height >
+          parentRef.getBoundingClientRect().bottom - bottom
+        ) {
+          direction = "top";
+        }
+      }
 
       if (!onMountAfterUpdate && $currentIndex < 0) {
         menuRef.focus();

--- a/types/DataTable/DataTable.svelte.d.ts
+++ b/types/DataTable/DataTable.svelte.d.ts
@@ -176,6 +176,12 @@ export interface DataTableProps
    * @default 0
    */
   page?: number;
+
+  /**
+   * Obtain a reference to the TableContainer Div HTML element
+   * @type {null | HTMLDivElement}
+   */
+  tref?: null | HTMLDivElement;
 }
 
 export default class DataTable extends SvelteComponentTyped<

--- a/types/DataTable/TableContainer.svelte.d.ts
+++ b/types/DataTable/TableContainer.svelte.d.ts
@@ -26,6 +26,12 @@ export interface TableContainerProps
    * @default false
    */
   useStaticWidth?: boolean;
+
+  /**
+   * Obtain a reference to the Div HTML element
+   * @type {null | HTMLDivElement}
+   */
+   ref?: null | HTMLDivElement;
 }
 
 export default class TableContainer extends SvelteComponentTyped<

--- a/types/OverflowMenu/OverflowMenu.svelte.d.ts
+++ b/types/OverflowMenu/OverflowMenu.svelte.d.ts
@@ -75,6 +75,12 @@ export interface OverflowMenuProps
    * @default null
    */
   menuRef?: null | HTMLUListElement;
+
+  /**
+   * Obtain a reference to the trigger parent element
+   * @default null
+   */
+  parentRef?: null | HTMLElement;
 }
 
 export default class OverflowMenu extends SvelteComponentTyped<


### PR DESCRIPTION
Flip the menu direction to `top` if menu's height is bigger than the parent offset. The example code below with screenshots.

```svelte
<script>
  import {
    DataTable,
    OverflowMenu,
    OverflowMenuItem,
  } from "carbon-components-svelte";

  const headers = [
    { key: "name", value: "Name" },
    { key: "port", value: "Port" },
    { key: "rule", value: "Rule" },
    { key: "overflow", empty: true },
  ];

  const rows = [
    { id: "a", name: "Load Balancer 3", port: 3000, rule: "Round robin" },
    { id: "b", name: "Load Balancer 1", port: 443, rule: "Round robin" },
    { id: "c", name: "Load Balancer 2", port: 80, rule: "DNS delegation" },
    { id: "d", name: "Load Balancer 6", port: 3000, rule: "Round robin" },
    { id: "e", name: "Load Balancer 4", port: 443, rule: "Round robin" },
    { id: "f", name: "Load Balancer 5", port: 80, rule: "DNS delegation" },
  ];

  let tRef = null;
</script>

<DataTable sortable {headers} {rows} bind:tRef={tRef}>
  <svelte:fragment slot="cell" let:cell>
    {#if cell.key === "overflow"}
      <OverflowMenu flipped bind:parentRef={tRef}>
        <OverflowMenuItem text="Restart" />
        <OverflowMenuItem
          href="https://cloud.ibm.com/docs/loadbalancer-service"
          text="API documentation"
        />
        <OverflowMenuItem danger text="Stop" />
      </OverflowMenu>
    {:else}{cell.value}{/if}
  </svelte:fragment>
</DataTable>
```
![Before the PR](https://user-images.githubusercontent.com/4975967/197017288-72bad061-bf66-437e-a914-b06db39fa40e.png)
![After the PR](https://user-images.githubusercontent.com/4975967/197017295-1c41d40d-7018-4a51-9b45-88c90b9f68ab.png)


