### PR TITLE
add an overflow menu selection variant for DataTable

### DIFF
--- a/src/DataTable/DataTable.svelte
+++ b/src/DataTable/DataTable.svelte
@@ -93,6 +93,9 @@
   /** Set to `true` for the radio selection variant */
   export let radio = false;
 
+  /** Set to `true` for the overflow menu selection variant */
+  export let overflowMenu = false;
+
   /**
    * Set to `true` for the selectable variant
    * Automatically set to `true` if `radio` or `batchSelection` are `true`
@@ -126,11 +129,15 @@
   /** Set to `number` to set current page */
   export let page = 0;
 
+  /** Obtain a reference to the trigger body element */
+  export let tRef = null;
+
   import { createEventDispatcher, setContext } from "svelte";
   import { writable } from "svelte/store";
   import ChevronRight from "../icons/ChevronRight.svelte";
   import InlineCheckbox from "../Checkbox/InlineCheckbox.svelte";
   import RadioButton from "../RadioButton/RadioButton.svelte";
+  import OverflowMenu from "../OverflowMenu/OverflowMenu.svelte";
   import Table from "./Table.svelte";
   import TableBody from "./TableBody.svelte";
   import TableCell from "./TableCell.svelte";
@@ -194,7 +201,7 @@
     expandable = true;
     expanded = expandedRowIds.length === expandableRowIds.length;
   }
-  $: if (radio || batchSelection) selectable = true;
+  $: if (radio || batchSelection || OverflowMenu) selectable = true;
   $: headerKeys = headers.map(({ key }) => key);
   $: tableCellsByRowId = rows.reduce((rows, row) => {
     rows[row.id] = headerKeys.map((key, index) => ({
@@ -258,7 +265,7 @@
   };
 </script>
 
-<TableContainer useStaticWidth="{useStaticWidth}" {...$$restProps}>
+<TableContainer bind:ref={tRef} useStaticWidth="{useStaticWidth}" {...$$restProps}>
   {#if title || $$slots.title || description || $$slots.description}
     <div class:bx--data-table-header="{true}">
       {#if title || $$slots.title}
@@ -309,7 +316,7 @@
         {#if selectable && !batchSelection}
           <th scope="col"></th>
         {/if}
-        {#if batchSelection && !radio}
+        {#if batchSelection && !radio && !overflowMenu}
           <th scope="col" class:bx--table-column-checkbox="{true}">
             <InlineCheckbox
               bind:ref="{refSelectAll}"
@@ -450,6 +457,10 @@
                       dispatch('click:row--select', { row, selected: true });
                     }}"
                   />
+                {:else if overflowMenu}
+                  <svelte:component this={OverflowMenu} bind:parentRef={tRef}>
+                    <slot name="overflowMenu" row="{row}" />
+                  </svelte:component>
                 {:else}
                   <InlineCheckbox
                     name="select-row-{row.id}"

--- a/src/DataTable/DataTable.svelte
+++ b/src/DataTable/DataTable.svelte
@@ -201,7 +201,7 @@
     expandable = true;
     expanded = expandedRowIds.length === expandableRowIds.length;
   }
-  $: if (radio || batchSelection || OverflowMenu) selectable = true;
+  $: if (radio || batchSelection || overflowMenu) selectable = true;
   $: headerKeys = headers.map(({ key }) => key);
   $: tableCellsByRowId = rows.reduce((rows, row) => {
     rows[row.id] = headerKeys.map((key, index) => ({
@@ -314,7 +314,7 @@
           </th>
         {/if}
         {#if selectable && !batchSelection}
-          <th scope="col"></th>
+          <th scope="col" style="width: var(--cds-spacing-08);"></th>
         {/if}
         {#if batchSelection && !radio && !overflowMenu}
           <th scope="col" class:bx--table-column-checkbox="{true}">
@@ -458,7 +458,7 @@
                     }}"
                   />
                 {:else if overflowMenu}
-                  <svelte:component this={OverflowMenu} bind:parentRef={tRef}>
+                  <svelte:component size="sm" this={OverflowMenu} bind:parentRef={tRef}>
                     <slot name="overflowMenu" row="{row}" />
                   </svelte:component>
                 {:else}

--- a/types/DataTable/DataTable.svelte.d.ts
+++ b/types/DataTable/DataTable.svelte.d.ts
@@ -129,6 +129,12 @@ export interface DataTableProps
   radio?: boolean;
 
   /**
+   * Set to `true` for the overflow menu selection variant
+   * @default false
+   */
+   overflowMenu?: boolean;
+
+  /**
    * Set to `true` for the selectable variant
    * Automatically set to `true` if `radio` or `batchSelection` are `true`
    * @default false
@@ -176,6 +182,12 @@ export interface DataTableProps
    * @default 0
    */
   page?: number;
+
+  /**
+   * Obtain a reference to the TableContainer Div HTML element
+   * @type {null | HTMLDivElement}
+   */
+  tref?: null | HTMLDivElement;
 }
 
 export default class DataTable extends SvelteComponentTyped<


### PR DESCRIPTION
Add an `overflowMenu` option to add overflow menu selection variant for `DataTable` (like `radio`).
This need the PR #1530.

Code:
```svelte
<script>
  import {
    DataTable,
    OverflowMenu,
    OverflowMenuItem,
  } from "carbon-components-svelte";

  const headers = [
    { key: "name", value: "Name" },
    { key: "port", value: "Port" },
    { key: "rule", value: "Rule" }
  ];

  const rows = [
    { id: "a", name: "Load Balancer 3", port: 3000, rule: "Round robin" },
    { id: "b", name: "Load Balancer 1", port: 443, rule: "Round robin" },
    { id: "c", name: "Load Balancer 2", port: 80, rule: "DNS delegation" },
    { id: "d", name: "Load Balancer 6", port: 3000, rule: "Round robin" },
    { id: "e", name: "Load Balancer 4", port: 443, rule: "Round robin" },
    { id: "f", name: "Load Balancer 5", port: 80, rule: "DNS delegation" },
  ];
</script>

<DataTable sortable {headers} {rows} overflowMenu={true}>
  <svelte:fragment slot="overflowMenu" let:row>
    <OverflowMenuItem text="Restart" />
    <OverflowMenuItem
      href="https://cloud.ibm.com/docs/loadbalancer-service"
      text="API documentation"
    />
    <OverflowMenuItem danger text="Stop" />
  </svelte:fragment>
</DataTable>
```
Screenshot:
![OverflowMenu](https://user-images.githubusercontent.com/4975967/197020514-44efc1ed-44cc-4928-aba2-9192317b8c40.png)
