### PR TITLE
Fix vertical layout of ProgressStep.

### DIFF
--- a/src/ProgressIndicator/ProgressStep.svelte
+++ b/src/ProgressIndicator/ProgressStep.svelte
@@ -92,12 +92,14 @@
     {:else}
       <CircleDash title="{description}" />
     {/if}
-    <slot props="{{ class: 'bx--progress-label' }}">
-      <p class:bx--progress-label="{true}">{label}</p>
-    </slot>
-    {#if secondaryLabel}
-      <p class:bx--progress-optional="{true}">{secondaryLabel}</p>
-    {/if}
+    <div class:bx--progress-text="{true}">
+      <slot props="{{ class: 'bx--progress-label' }}">
+        <p class:bx--progress-label="{true}">{label}</p>
+      </slot>
+      {#if secondaryLabel}
+        <p class:bx--progress-optional="{true}">{secondaryLabel}</p>
+      {/if}
+    </div>
     <span class:bx--progress-line="{true}"></span>
   </button>
 </li>


### PR DESCRIPTION
Wraps label/secondary label in container that places the secondary label under the primary one.
(Looked up element hierarchy in React implementation.)

Fixes #1532.