### PR TITLE
Fix zero items length bug

### DIFF
--- a/src/ComboBox/ComboBox.svelte
+++ b/src/ComboBox/ComboBox.svelte
@@ -127,6 +127,7 @@
   function change(dir) {
     let index = highlightedIndex + dir;
     let _items = !filteredItems?.length ? items : filteredItems;
+    if (_items.length === 0) return;
     if (index < 0) {
       index = _items.length - 1;
     } else if (index >= _items.length) {


### PR DESCRIPTION
Fix an error related to zero items in combobox.
The error stack trace was:
```
ComboBox.svelte:135 Uncaught TypeError: Cannot read property 'disabled' of undefined
    at change (ComboBox.svelte:135)
    at HTMLInputElement.keydown_handler_1 (ComboBox.svelte:325)
    at HTMLInputElement.<anonymous> (index.mjs:427)
```