### PR TITLE
Fix `step` floating point issue in `NumberInput`

### DIFF
--- a/docs/src/pages/components/NumberInput.svx
+++ b/docs/src/pages/components/NumberInput.svx
@@ -23,6 +23,10 @@ See [#no-value](#no-value) to allow for an empty value.
 
 <NumberInput min="{4}" max="{20}" value="{4}" invalidText="Number must be between 4 and 20." helperText="Clusters provisioned in your region" label="Clusters (4 min, 20 max)" />
 
+## With step value
+
+<NumberInput value="{1}" helperText="Step of 0.1" step={0.1} label="Clusters" />
+
 ## No value
 
 Set `allowEmpty` to `true` to allow for no value.

--- a/src/NumberInput/NumberInput.svelte
+++ b/src/NumberInput/NumberInput.svelte
@@ -113,16 +113,13 @@
 
   const dispatch = createEventDispatcher();
 
-  function updateValue(direction) {
-    const nextValue = (value += direction * step);
-
-    if (nextValue < min) {
-      value = min;
-    } else if (nextValue > max) {
-      value = max;
+  function updateValue(isIncrementing) {
+    if (isIncrementing) {
+      ref.stepUp();
     } else {
-      value = nextValue;
+      ref.stepDown();
     }
+    value = ref.value;
 
     dispatch("input", value);
     dispatch("change", value);
@@ -235,7 +232,7 @@
             class:bx--number__control-btn="{true}"
             class:down-icon="{true}"
             on:click="{() => {
-              updateValue(-1);
+              updateValue(false);
             }}"
             disabled="{disabled}"
           >
@@ -250,7 +247,7 @@
             class:bx--number__control-btn="{true}"
             class:up-icon="{true}"
             on:click="{() => {
-              updateValue(1);
+              updateValue(true);
             }}"
             disabled="{disabled}"
           >

--- a/tests/NumberInput.test.svelte
+++ b/tests/NumberInput.test.svelte
@@ -16,6 +16,30 @@
   label="Clusters"
   helperText="Clusters provisioned in your region"
   invalidText="Number must be between 4 and 20."
+  on:input="{(e) => {
+    console.log({ input: e.detail }); // null | number
+  }}"
+  on:change="{(e) => {
+    console.log({ change: e.detail }); // null | number
+  }}"
+  on:keydown
+  on:keyup
+  on:paste
+/>
+
+<NumberInput
+  disabled
+  light
+  min="{1}"
+  max="{10}"
+  value="{4}"
+  step="{0.1}"
+  label="Clusters"
+  helperText="Clusters provisioned in your region"
+  invalidText="Number must be between 1 and 10."
+  on:input="{(e) => {
+    console.log({ input: e.detail }); // null | number
+  }}"
   on:change="{(e) => {
     console.log(e.detail); // null | number
   }}"


### PR DESCRIPTION
Fixes #233, fixes #486, fixes #1554

Use the built-in function of steppers then assign the value.

JS has a bug with floating point which result in a visual bug where input has many decimals. 
There's 2 ways to fix this : 

1. Converting `float` to an `int` (by multiplying by 10 x number of decimals) then make the equation then reconvert to a floating value.
2. Use built-in functions to step up and down.

I prefer the second approach which is simpler.

Also, with this method we don't need to test the `min` and `max` values since `stepUp` and `stepDown` built-in functions do this internally. We do need to assign `value` to the input value because Svelte won't know that the value changed.

I also added a step test and updated the docs to add the step function.

For the margin I understand that because of the error Icon we can't reduce the padding, I'll update the issue.