### PR TITLE
Fix 1556 Toggle events fire before `toggled` is changed

### DIFF
--- a/src/Toggle/Toggle.svelte
+++ b/src/Toggle/Toggle.svelte
@@ -60,17 +60,17 @@
     class:bx--toggle-input="{true}"
     class:bx--toggle-input--small="{size === 'sm'}"
     checked="{toggled}"
-    on:change
     on:change="{() => {
       toggled = !toggled;
     }}"
-    on:keyup
+    on:change
     on:keyup="{(e) => {
       if (e.key === ' ' || e.key === 'Enter') {
         e.preventDefault();
         toggled = !toggled;
       }
     }}"
+    on:keyup
     on:focus
     on:blur
     disabled="{disabled}"


### PR DESCRIPTION
`Toggle` events `change`, `keyup` and `click` will stay with the old value instead of the new when firing. By changing the order of  execution of `change` and `keyup`, it seems to fix the problem. `click` stayed the same because the user may wants to execute something before the `toggled` change status.