### PR TITLE
fix(Dropdown): adjust select event and add arrow key interactions

### DIFF
--- a/src/Dropdown/Dropdown.svelte
+++ b/src/Dropdown/Dropdown.svelte
@@ -112,6 +112,12 @@
 
   let highlightedIndex = -1;
 
+  $: inline = type === "inline";
+  $: selectedItem = items.find((item) => item.id === selectedId);
+  $: if (!open) {
+    highlightedIndex = -1;
+  }
+
   function change(dir) {
     let index = highlightedIndex + dir;
 
@@ -138,14 +144,9 @@
     highlightedIndex = index;
   }
 
-  $: if (selectedId !== undefined) {
+  const dispatchSelect = () => {
     dispatch("select", { selectedId, selectedItem });
-  }
-  $: inline = type === "inline";
-  $: selectedItem = items.find((item) => item.id === selectedId);
-  $: if (!open) {
-    highlightedIndex = -1;
-  }
+  };
 </script>
 
 <svelte:window
@@ -227,16 +228,37 @@
             items[highlightedIndex].id !== selectedId
           ) {
             selectedId = items[highlightedIndex].id;
+            dispatchSelect();
             open = false;
           }
         } else if (key === 'Tab') {
           open = false;
           ref.blur();
         } else if (key === 'ArrowDown') {
+          if (!open) open = true;
           change(1);
         } else if (key === 'ArrowUp') {
+          if (!open) open = true;
           change(-1);
         } else if (key === 'Escape') {
+          open = false;
+        }
+      }}"
+      on:keyup="{(e) => {
+        const { key } = e;
+        if ([' '].includes(key)) {
+          e.preventDefault();
+        } else {
+          return;
+        }
+        open = !open;
+
+        if (
+          highlightedIndex > -1 &&
+          items[highlightedIndex].id !== selectedId
+        ) {
+          selectedId = items[highlightedIndex].id;
+          dispatchSelect();
           open = false;
         }
       }}"
@@ -271,6 +293,7 @@
                 return;
               }
               selectedId = item.id;
+              dispatchSelect();
               ref.focus();
             }}"
             on:mouseenter="{() => {


### PR DESCRIPTION
Changes:

1. Dispatch `select` event only upon user interaction
    * Currently, when using Dropdown with `on:select`, this event always dispatches on initial load, which is undesirable when I depend on that event for side-effects such as navigation.
    * With these changes, it will only dispatch upon a user interaction. It's a similar dilemma to the one I had raised in #1497.

2. Allow arrow keys to open menu and highlight items, closes #1475 
    * Matches interaction behaviours in the main [Carbon Dropdown Live Demo](https://carbondesignsystem.com/components/dropdown/usage/#live-demo) also described in [Dropdown Interactions](https://carbondesignsystem.com/components/dropdown/usage/#interactions).
    * Does not fully address #1475 since the ask was to keep the Dropdown collapsed while selecting items, like an HTML `<select>`. Perhaps a design request can be made in the main Carbon repository. I also left the "slide-down transition upon opening" out of scope.

I'm in particular need for the fix in (1). Your time is appreciated! 😃 