### PR TITLE
Fix popover click outside handler when clicking siblings

### DIFF
--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -2804,9 +2804,9 @@ None.
 
 ### Events
 
-| Event name    | Type       | Detail            |
-| :------------ | :--------- | :---------------- |
-| click:outside | dispatched | <code>null</code> |
+| Event name    | Type       | Detail                                |
+| :------------ | :--------- | :------------------------------------ |
+| click:outside | dispatched | <code>{ target: HTMLElement; }</code> |
 
 ## `ProgressBar`
 

--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -8908,7 +8908,11 @@
       "moduleExports": [],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [
-        { "type": "dispatched", "name": "click:outside", "detail": "null" }
+        {
+          "type": "dispatched",
+          "name": "click:outside",
+          "detail": "{ target: HTMLElement; }"
+        }
       ],
       "typedefs": [],
       "rest_props": { "type": "Element", "name": "div" }

--- a/docs/src/pages/components/Popover.svx
+++ b/docs/src/pages/components/Popover.svx
@@ -36,6 +36,12 @@ Set `closeOnOutsideClick` to set `open` to `false` when clicking outside of the 
     </Popover>
 </div>
 
+## Manage open state with a Button
+
+You can bind the `open` prop and manage the open state of the popover with an external button.
+
+<FileSource src="/framed/Popover/WithButton" />
+
 ## Popover alignment
 
 Customize the popover alignment using the `align` prop. Valid values include: `"top" | "top-left" | "top-right" | "bottom" | "bottom-left" | "bottom-right" | "left" | "left-bottom" | "left-top" | "right" | "right-bottom" | "right-top"`.

--- a/docs/src/pages/framed/Popover/WithButton.svelte
+++ b/docs/src/pages/framed/Popover/WithButton.svelte
@@ -1,0 +1,37 @@
+<script>
+  import { Popover, Button } from "carbon-components-svelte";
+
+  let open = true;
+  let containerRef = null;
+</script>
+
+<div data-outline>
+  <div
+    bind:this="{containerRef}"
+    style:position="relative"
+    style:display="inline-block"
+  >
+    <Button on:click="{() => (open = !open)}">Click to open</Button>
+    <Popover
+      bind:open
+      align="bottom-left"
+      on:click:outside="{({ detail }) => {
+        console.log('on:click:outside');
+        if (!containerRef.contains(detail.target)) {
+          open = false;
+        }
+      }}"
+    >
+      <div style="padding: var(--cds-spacing-05)">Content</div>
+    </Popover>
+  </div>
+  <div>
+    <br />
+    Anim eu laboris veniam in est elit ullamco enim irure id. Lorem est culpa ex
+    in enim enim. Culpa quis incididunt magna officia et aliqua. Ullamco deserunt
+    aute enim cupidatat. Culpa quis enim sint sint anim qui irure exercitation labore
+    occaecat in reprehenderit proident. Nisi laborum ut et amet commodo amet ullamco
+    commodo non aliqua magna ad eu. Ad aliquip minim nostrud id enim elit velit ullamco
+    pariatur eu excepteur pariatur cillum.
+  </div>
+</div>

--- a/src/Popover/Popover.svelte
+++ b/src/Popover/Popover.svelte
@@ -33,8 +33,8 @@
 <svelte:window
   on:click="{(e) => {
     if (!open) return;
-    if (e.target.contains(ref)) {
-      dispatch('click:outside');
+    if (!ref.contains(e.target)) {
+      dispatch('click:outside', { target: e.target });
       if (closeOnOutsideClick) open = false;
     }
   }}"

--- a/src/Popover/Popover.svelte
+++ b/src/Popover/Popover.svelte
@@ -1,4 +1,8 @@
 <script>
+  /**
+   * @event {{ target: HTMLElement; }} click:outside
+   */
+
   /** Set to `true` to display the popover */
   export let open = false;
 

--- a/types/Popover/Popover.svelte.d.ts
+++ b/types/Popover/Popover.svelte.d.ts
@@ -60,6 +60,6 @@ export interface PopoverProps
 
 export default class Popover extends SvelteComponentTyped<
   PopoverProps,
-  { ["click:outside"]: CustomEvent<null> },
+  { ["click:outside"]: CustomEvent<{ target: HTMLElement }> },
   { default: {} }
 > {}


### PR DESCRIPTION
When clicking on a sibling of the popover component, the `click:outside` event was not firing, because the sibling doesn't contain the popover's ref.

Also added a usage example with a button that binds the `open` prop, since it has a small behavior to think into account when clicking on the button.