### PR TITLE
fix `carbon-components` link

### DIFF
--- a/docs/src/pages/index.svelte
+++ b/docs/src/pages/index.svelte
@@ -147,7 +147,7 @@
                 <OutboundLink
                   inline
                   size="lg"
-                  href="https://github.com/carbon-design-system/carbon/tree/main/packages/components"
+                  href="https://github.com/carbon-design-system/carbon/tree/main/packages/carbon-components"
                 >
                   carbon-components
                 </OutboundLink>.


### PR DESCRIPTION
it looks like `components` was renamed to `carbon-components`