### PR TITLE
fix(multi-select): avoid runtime error if `items` is empty

### DIFF
--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -203,6 +203,7 @@
   function change(direction) {
     let index = highlightedIndex + direction;
     const length = filterable ? filteredItems.length : items.length;
+    if (length === 0) return;
     if (index < 0) {
       index = length - 1;
     } else if (index >= length) {


### PR DESCRIPTION
Related #1545

A runtime error is thrown when focusing the input and using arrow keys of an empty `MultiSelect`.

```svelte
<MultiSelect items={[]} />
```