### PR TITLE
fix(dropdown): avoid runtime error if `items` is empty

### DIFF
--- a/src/Dropdown/Dropdown.svelte
+++ b/src/Dropdown/Dropdown.svelte
@@ -121,6 +121,7 @@
   function change(dir) {
     let index = highlightedIndex + dir;
 
+    if (items.length === 0) return;
     if (index < 0) {
       index = items.length - 1;
     } else if (index >= items.length) {


### PR DESCRIPTION
Related #1545, #1577

A runtime error is thrown when focusing the input and using arrow keys of an empty `Dropdown`.

```svelte
<Dropdown items={[]} />
```