### PR TITLE
chore(types)!: remove `sveltekit:` attributes from types

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "rollup-plugin-svelte": "^7.1.0",
     "rollup-plugin-terser": "^7.0.2",
     "sass": "^1.49.11",
-    "sveld": "^0.17.2",
+    "sveld": "^0.18.0",
     "svelte": "^3.51.0",
     "svelte-check": "^2.8.1",
     "typescript": "^4.7.4"

--- a/types/Button/Button.svelte.d.ts
+++ b/types/Button/Button.svelte.d.ts
@@ -105,30 +105,6 @@ export interface ButtonProps
    * @default null
    */
   ref?: null | HTMLAnchorElement | HTMLButtonElement;
-
-  /**
-   * SvelteKit attribute to enable data prefetching
-   * if a link is hovered over or touched on mobile.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
-   * @default false
-   */
-  "sveltekit:prefetch"?: boolean;
-
-  /**
-   * SvelteKit attribute to trigger a full page
-   * reload after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-reload
-   * @default false
-   */
-  "sveltekit:reload"?: boolean;
-
-  /**
-   * SvelteKit attribute to prevent scrolling
-   * after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-noscroll
-   * @default false
-   */
-  "sveltekit:noscroll"?: boolean;
 }
 
 export default class Button extends SvelteComponentTyped<

--- a/types/Button/ButtonSkeleton.svelte.d.ts
+++ b/types/Button/ButtonSkeleton.svelte.d.ts
@@ -14,30 +14,6 @@ export interface ButtonSkeletonProps
    * @default "default"
    */
   size?: "default" | "field" | "small" | "lg" | "xl";
-
-  /**
-   * SvelteKit attribute to enable data prefetching
-   * if a link is hovered over or touched on mobile.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
-   * @default false
-   */
-  "sveltekit:prefetch"?: boolean;
-
-  /**
-   * SvelteKit attribute to trigger a full page
-   * reload after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-reload
-   * @default false
-   */
-  "sveltekit:reload"?: boolean;
-
-  /**
-   * SvelteKit attribute to prevent scrolling
-   * after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-noscroll
-   * @default false
-   */
-  "sveltekit:noscroll"?: boolean;
 }
 
 export default class ButtonSkeleton extends SvelteComponentTyped<

--- a/types/Link/Link.svelte.d.ts
+++ b/types/Link/Link.svelte.d.ts
@@ -46,30 +46,6 @@ export interface LinkProps
    * @default null
    */
   ref?: null | HTMLAnchorElement | HTMLParagraphElement;
-
-  /**
-   * SvelteKit attribute to enable data prefetching
-   * if a link is hovered over or touched on mobile.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
-   * @default false
-   */
-  "sveltekit:prefetch"?: boolean;
-
-  /**
-   * SvelteKit attribute to trigger a full page
-   * reload after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-reload
-   * @default false
-   */
-  "sveltekit:reload"?: boolean;
-
-  /**
-   * SvelteKit attribute to prevent scrolling
-   * after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-noscroll
-   * @default false
-   */
-  "sveltekit:noscroll"?: boolean;
 }
 
 export default class Link extends SvelteComponentTyped<

--- a/types/Tile/ClickableTile.svelte.d.ts
+++ b/types/Tile/ClickableTile.svelte.d.ts
@@ -27,30 +27,6 @@ export interface ClickableTileProps
    * @default undefined
    */
   href?: string;
-
-  /**
-   * SvelteKit attribute to enable data prefetching
-   * if a link is hovered over or touched on mobile.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
-   * @default false
-   */
-  "sveltekit:prefetch"?: boolean;
-
-  /**
-   * SvelteKit attribute to trigger a full page
-   * reload after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-reload
-   * @default false
-   */
-  "sveltekit:reload"?: boolean;
-
-  /**
-   * SvelteKit attribute to prevent scrolling
-   * after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-noscroll
-   * @default false
-   */
-  "sveltekit:noscroll"?: boolean;
 }
 
 export default class ClickableTile extends SvelteComponentTyped<

--- a/types/UIShell/Header.svelte.d.ts
+++ b/types/UIShell/Header.svelte.d.ts
@@ -77,30 +77,6 @@ export interface HeaderProps
    * @default undefined
    */
   iconClose?: typeof import("svelte").SvelteComponent;
-
-  /**
-   * SvelteKit attribute to enable data prefetching
-   * if a link is hovered over or touched on mobile.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
-   * @default false
-   */
-  "sveltekit:prefetch"?: boolean;
-
-  /**
-   * SvelteKit attribute to trigger a full page
-   * reload after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-reload
-   * @default false
-   */
-  "sveltekit:reload"?: boolean;
-
-  /**
-   * SvelteKit attribute to prevent scrolling
-   * after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-noscroll
-   * @default false
-   */
-  "sveltekit:noscroll"?: boolean;
 }
 
 export default class Header extends SvelteComponentTyped<

--- a/types/UIShell/HeaderActionLink.svelte.d.ts
+++ b/types/UIShell/HeaderActionLink.svelte.d.ts
@@ -26,30 +26,6 @@ export interface HeaderActionLinkProps
    * @default null
    */
   ref?: null | HTMLAnchorElement;
-
-  /**
-   * SvelteKit attribute to enable data prefetching
-   * if a link is hovered over or touched on mobile.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
-   * @default false
-   */
-  "sveltekit:prefetch"?: boolean;
-
-  /**
-   * SvelteKit attribute to trigger a full page
-   * reload after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-reload
-   * @default false
-   */
-  "sveltekit:reload"?: boolean;
-
-  /**
-   * SvelteKit attribute to prevent scrolling
-   * after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-noscroll
-   * @default false
-   */
-  "sveltekit:noscroll"?: boolean;
 }
 
 export default class HeaderActionLink extends SvelteComponentTyped<

--- a/types/UIShell/HeaderNavItem.svelte.d.ts
+++ b/types/UIShell/HeaderNavItem.svelte.d.ts
@@ -26,30 +26,6 @@ export interface HeaderNavItemProps
    * @default null
    */
   ref?: null | HTMLAnchorElement;
-
-  /**
-   * SvelteKit attribute to enable data prefetching
-   * if a link is hovered over or touched on mobile.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
-   * @default false
-   */
-  "sveltekit:prefetch"?: boolean;
-
-  /**
-   * SvelteKit attribute to trigger a full page
-   * reload after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-reload
-   * @default false
-   */
-  "sveltekit:reload"?: boolean;
-
-  /**
-   * SvelteKit attribute to prevent scrolling
-   * after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-noscroll
-   * @default false
-   */
-  "sveltekit:noscroll"?: boolean;
 }
 
 export default class HeaderNavItem extends SvelteComponentTyped<

--- a/types/UIShell/HeaderNavMenu.svelte.d.ts
+++ b/types/UIShell/HeaderNavMenu.svelte.d.ts
@@ -26,30 +26,6 @@ export interface HeaderNavMenuProps
    * @default null
    */
   ref?: null | HTMLAnchorElement;
-
-  /**
-   * SvelteKit attribute to enable data prefetching
-   * if a link is hovered over or touched on mobile.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
-   * @default false
-   */
-  "sveltekit:prefetch"?: boolean;
-
-  /**
-   * SvelteKit attribute to trigger a full page
-   * reload after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-reload
-   * @default false
-   */
-  "sveltekit:reload"?: boolean;
-
-  /**
-   * SvelteKit attribute to prevent scrolling
-   * after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-noscroll
-   * @default false
-   */
-  "sveltekit:noscroll"?: boolean;
 }
 
 export default class HeaderNavMenu extends SvelteComponentTyped<

--- a/types/UIShell/HeaderPanelLink.svelte.d.ts
+++ b/types/UIShell/HeaderPanelLink.svelte.d.ts
@@ -14,30 +14,6 @@ export interface HeaderPanelLinkProps
    * @default null
    */
   ref?: null | HTMLAnchorElement;
-
-  /**
-   * SvelteKit attribute to enable data prefetching
-   * if a link is hovered over or touched on mobile.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
-   * @default false
-   */
-  "sveltekit:prefetch"?: boolean;
-
-  /**
-   * SvelteKit attribute to trigger a full page
-   * reload after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-reload
-   * @default false
-   */
-  "sveltekit:reload"?: boolean;
-
-  /**
-   * SvelteKit attribute to prevent scrolling
-   * after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-noscroll
-   * @default false
-   */
-  "sveltekit:noscroll"?: boolean;
 }
 
 export default class HeaderPanelLink extends SvelteComponentTyped<

--- a/types/UIShell/SideNavLink.svelte.d.ts
+++ b/types/UIShell/SideNavLink.svelte.d.ts
@@ -32,30 +32,6 @@ export interface SideNavLinkProps
    * @default null
    */
   ref?: null | HTMLAnchorElement;
-
-  /**
-   * SvelteKit attribute to enable data prefetching
-   * if a link is hovered over or touched on mobile.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
-   * @default false
-   */
-  "sveltekit:prefetch"?: boolean;
-
-  /**
-   * SvelteKit attribute to trigger a full page
-   * reload after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-reload
-   * @default false
-   */
-  "sveltekit:reload"?: boolean;
-
-  /**
-   * SvelteKit attribute to prevent scrolling
-   * after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-noscroll
-   * @default false
-   */
-  "sveltekit:noscroll"?: boolean;
 }
 
 export default class SideNavLink extends SvelteComponentTyped<

--- a/types/UIShell/SideNavMenuItem.svelte.d.ts
+++ b/types/UIShell/SideNavMenuItem.svelte.d.ts
@@ -26,30 +26,6 @@ export interface SideNavMenuItemProps
    * @default null
    */
   ref?: null | HTMLAnchorElement;
-
-  /**
-   * SvelteKit attribute to enable data prefetching
-   * if a link is hovered over or touched on mobile.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
-   * @default false
-   */
-  "sveltekit:prefetch"?: boolean;
-
-  /**
-   * SvelteKit attribute to trigger a full page
-   * reload after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-reload
-   * @default false
-   */
-  "sveltekit:reload"?: boolean;
-
-  /**
-   * SvelteKit attribute to prevent scrolling
-   * after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-noscroll
-   * @default false
-   */
-  "sveltekit:noscroll"?: boolean;
 }
 
 export default class SideNavMenuItem extends SvelteComponentTyped<

--- a/types/UIShell/SkipToContent.svelte.d.ts
+++ b/types/UIShell/SkipToContent.svelte.d.ts
@@ -14,30 +14,6 @@ export interface SkipToContentProps
    * @default "0"
    */
   tabindex?: string;
-
-  /**
-   * SvelteKit attribute to enable data prefetching
-   * if a link is hovered over or touched on mobile.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-prefetch
-   * @default false
-   */
-  "sveltekit:prefetch"?: boolean;
-
-  /**
-   * SvelteKit attribute to trigger a full page
-   * reload after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-reload
-   * @default false
-   */
-  "sveltekit:reload"?: boolean;
-
-  /**
-   * SvelteKit attribute to prevent scrolling
-   * after the link is clicked.
-   * @see https://kit.svelte.dev/docs/a-options#sveltekit-noscroll
-   * @default false
-   */
-  "sveltekit:noscroll"?: boolean;
 }
 
 export default class SkipToContent extends SvelteComponentTyped<

--- a/yarn.lock
+++ b/yarn.lock
@@ -167,10 +167,15 @@
   dependencies:
     "@types/node" "*"
 
-acorn@^8.5.0, acorn@^8.7.0:
+acorn@^8.5.0:
   version "8.8.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.0.tgz#88c0187620435c7f6015803f5539dae05a9dbea8"
   integrity sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==
+
+acorn@^8.8.0:
+  version "8.8.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.1.tgz#0a3f9cbecc4ec3bea6f0a80b66ae8dd2da250b73"
+  integrity sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==
 
 aggregate-error@^3.0.0:
   version "3.0.1"
@@ -542,7 +547,18 @@ execa@^6.1.0:
     signal-exit "^3.0.7"
     strip-final-newline "^3.0.0"
 
-fast-glob@^3.2.11, fast-glob@^3.2.7:
+fast-glob@^3.2.12:
+  version "3.2.12"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.12.tgz#7f39ec99c2e6ab030337142da9e0c18f37afae80"
+  integrity sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.2"
+    merge2 "^1.3.0"
+    micromatch "^4.0.4"
+
+fast-glob@^3.2.7:
   version "3.2.11"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.11.tgz#a1172ad95ceb8a16e20caa5c5e56480e5129c1d9"
   integrity sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==
@@ -1362,21 +1378,21 @@ supports-color@^7.0.0:
   dependencies:
     has-flag "^4.0.0"
 
-sveld@^0.17.2:
-  version "0.17.2"
-  resolved "https://registry.yarnpkg.com/sveld/-/sveld-0.17.2.tgz#da40c9c2d700e0eaea739eda9f5da34f2ba6ab3e"
-  integrity sha512-R9coRXZlqM0vTL9zPp8aRk+KR+SqKtzGGcpnqWm53IeP+Ncs0DiOFT8wCTJLC1XnRl4K3nvoXw0Btk5aQ87SYg==
+sveld@^0.18.0:
+  version "0.18.0"
+  resolved "https://registry.yarnpkg.com/sveld/-/sveld-0.18.0.tgz#0061232b6edc9ed5df949db6e34d39817cf4dcc4"
+  integrity sha512-J/hwohOIUHibT5Zo7n4jQPjFDm4KxRnRMpl5NU6nzsm/A/2dr1Xls4BPDT0qRyDKMHNz+50fyxlyxCP26S6HLw==
   dependencies:
     "@rollup/plugin-node-resolve" "^13.2.1"
-    acorn "^8.7.0"
+    acorn "^8.8.0"
     comment-parser "^1.3.1"
-    fast-glob "^3.2.11"
+    fast-glob "^3.2.12"
     prettier "^2.6.2"
     rollup "^2.70.2"
     rollup-plugin-svelte "^7.1.0"
-    svelte "^3.47.0"
+    svelte "^3.52.0"
     svelte-preprocess "^4.10.6"
-    typescript "^4.6.3"
+    typescript "^4.8.4"
 
 svelte-check@^2.8.1:
   version "2.8.1"
@@ -1414,15 +1430,15 @@ svelte-preprocess@^4.10.6:
     sorcery "^0.10.0"
     strip-indent "^3.0.0"
 
-svelte@^3.47.0:
-  version "3.49.0"
-  resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.49.0.tgz#5baee3c672306de1070c3b7888fc2204e36a4029"
-  integrity sha512-+lmjic1pApJWDfPCpUUTc1m8azDqYCG1JN9YEngrx/hUyIcFJo6VZhj0A1Ai0wqoHcEIuQy+e9tk+4uDgdtsFA==
-
 svelte@^3.51.0:
   version "3.51.0"
   resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.51.0.tgz#a1a0afb25dc518217f353dd73ea6471c128ddf84"
   integrity sha512-PBITYIrsNOuW+Dtds00gSY68raNZQn7i59Dg/fjgf6WwyawPKeBwle692coO7ILZqSO+UJe9899aDn9sMdeOHA==
+
+svelte@^3.52.0:
+  version "3.54.0"
+  resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.54.0.tgz#b4bcd865bd9e927f9f7b76563288ef5f4d72867a"
+  integrity sha512-tdrgeJU0hob0ZWAMoKXkhcxXA7dpTg6lZGxUeko5YqvPdJBiyRspGsCwV27kIrbrqPP2WUoSV9ca0gnLlw8YzQ==
 
 terser@^5.0.0:
   version "5.14.2"
@@ -1461,15 +1477,15 @@ typescript@*:
   resolved "https://registry.npmjs.org/typescript/-/typescript-4.0.5.tgz#ae9dddfd1069f1cb5beb3ef3b2170dd7c1332389"
   integrity sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==
 
-typescript@^4.6.3:
-  version "4.6.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.3.tgz#eefeafa6afdd31d725584c67a0eaba80f6fc6c6c"
-  integrity sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==
-
 typescript@^4.7.4:
   version "4.7.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
   integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
+
+typescript@^4.8.4:
+  version "4.9.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.4.tgz#a2a3d2756c079abda241d75f149df9d561091e78"
+  integrity sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==
 
 update-browserslist-db@^1.0.5:
   version "1.0.5"


### PR DESCRIPTION
[`sveltekit:` attributes were removed](https://github.com/sveltejs/kit/blob/20ed756c822615564326e300b4e44d0a4060a214/packages/kit/CHANGELOG.md#100-next454) from SvelteKit almost half a year ago.

This upgrades `sveld` and removes the attributes from the types.