### PR TITLE
docs: link source code to folder for multiple components

### DIFF
--- a/docs/src/layouts/ComponentLayout.svelte
+++ b/docs/src/layouts/ComponentLayout.svelte
@@ -22,7 +22,6 @@
 
   export let component = $page.title;
   export let components = [component];
-  export let source = "";
   export let unreleased = false;
   export let unstable = false;
 
@@ -42,10 +41,28 @@
     }
   });
 
+  function formatSourceURL(multiple) {
+    const filePath = api_components[0]?.filePath ?? "";
+
+    if (multiple) {
+      /**
+       * Link to folder for doc with multiple components.
+       * @example "src/Breadcrumb"
+       */
+      return filePath.split("/").slice(0, -1).join("/");
+    }
+
+    /**
+     * Else, link to the component source.
+     * @example "src/Tile/ClickableTile.svelte"
+     */
+    return filePath;
+  }
+
   // TODO: [refactor] read from package.json value
-  $: sourceCode = `https://github.com/carbon-design-system/carbon-components-svelte/tree/master/src/${
-    source || `${$page.title}/${$page.title}.svelte`
-  }`;
+  $: sourceCode = `https://github.com/carbon-design-system/carbon-components-svelte/tree/master/${formatSourceURL(
+    multiple
+  )}`;
 </script>
 
 <Content data-components>

--- a/docs/src/pages/components/ButtonSet.svx
+++ b/docs/src/pages/components/ButtonSet.svx
@@ -1,7 +1,3 @@
----
-source: Button/ButtonSet.svelte
----
-
 <script>
   import { Button, ButtonSet } from "carbon-components-svelte";
   import Login from "carbon-icons-svelte/lib/Login.svelte";

--- a/docs/src/pages/components/ClickableTile.svx
+++ b/docs/src/pages/components/ClickableTile.svx
@@ -1,7 +1,3 @@
----
-source: Tile/ClickableTile.svelte
----
-
 <script>
   import { ClickableTile } from "carbon-components-svelte";
   import Preview from "../../components/Preview.svelte";

--- a/docs/src/pages/components/ExpandableTile.svx
+++ b/docs/src/pages/components/ExpandableTile.svx
@@ -1,7 +1,3 @@
----
-source: Tile/ExpandableTile.svelte
----
-
 <script>
   import { ExpandableTile, Button } from "carbon-components-svelte";
   import Preview from "../../components/Preview.svelte";

--- a/docs/src/pages/components/InlineNotification.svx
+++ b/docs/src/pages/components/InlineNotification.svx
@@ -1,6 +1,5 @@
 ---
 components: ["InlineNotification", "NotificationActionButton"]
-source: Notification/InlineNotification.svelte
 ---
 
 <script>

--- a/docs/src/pages/components/PasswordInput.svx
+++ b/docs/src/pages/components/PasswordInput.svx
@@ -1,7 +1,3 @@
----
-source: TextInput/PasswordInput.svelte
----
-
 <script>
   import { PasswordInput } from "carbon-components-svelte";
   import Preview from "../../components/Preview.svelte";

--- a/docs/src/pages/components/RadioTile.svx
+++ b/docs/src/pages/components/RadioTile.svx
@@ -1,6 +1,5 @@
 ---
 components: ["TileGroup", "RadioTile"]
-source: Tile/RadioTile.svelte
 ---
 
 <script>

--- a/docs/src/pages/components/SelectableTile.svx
+++ b/docs/src/pages/components/SelectableTile.svx
@@ -1,6 +1,5 @@
 ---
 components: ["SelectableTile"]
-source: Tile/SelectableTile.svelte
 ---
 
 <script>

--- a/docs/src/pages/components/Tile.svx
+++ b/docs/src/pages/components/Tile.svx
@@ -1,7 +1,3 @@
----
-source: Tile/Tile.svelte
----
-
 <script>
   import { Tile } from "carbon-components-svelte";
   import Preview from "../../components/Preview.svelte";

--- a/docs/src/pages/components/ToastNotification.svx
+++ b/docs/src/pages/components/ToastNotification.svx
@@ -1,7 +1,3 @@
----
-source: Notification/ToastNotification.svelte
----
-
 <script>
   import { ToastNotification } from "carbon-components-svelte";
   import Preview from "../../components/Preview.svelte";


### PR DESCRIPTION
Currently, the "Source code" link at the top of a component docs navigates to a single component.

This is confusing since many components actually contain related components. One example is `ContentSwitcher`, which comprises of `ContentSwitcher` and `Switch`.

The expected behavior is that it should navigate to the folder (e.g., `src/ContentSwitcher`).

This PR does the following:

- link to folder if doc contains multiple components (e.g., Breadcrumbs, DataTable etc.)
- remove `source` from frontmatter (the metadata is already available in the Sveld auto-generated docs)
  - additionally, the current implementation defaults to the [`page.title` for the source code path](https://github.com/carbon-design-system/carbon-components-svelte/compare/docs-source-code?expand=1#diff-d41ad8b8ac387e8248685fc8e6fcc261dc5ca5b05c71a7d515c28372b4af880bL47), which may be flaky

I've tested:

- `ContentSwitcher` source code links to the folder
- `CodeSnippet` source code links to the `.svelte` file

---

<img width="1052" alt="Screen Shot 2022-12-10 at 10 03 20 AM" src="https://user-images.githubusercontent.com/10718366/206869260-ac8dd068-ed15-470f-9112-78f9b5808cf4.png">
