### PR TITLE
NumberInput : Fix error states

### DIFF
--- a/src/NumberInput/NumberInput.svelte
+++ b/src/NumberInput/NumberInput.svelte
@@ -39,8 +39,8 @@
   /** Set to `true` for the input to be read-only */
   export let readonly = false;
 
-  /** Set to `true` to allow for an empty value */
-  export let allowEmpty = false;
+  /** Set to `true` for the input to be required */
+  export let required = true;
 
   /** Set to `true` to disable the input */
   export let disabled = false;
@@ -99,6 +99,8 @@
   /** Obtain a reference to the input HTML element */
   export let ref = null;
 
+  let error = false;
+
   import { createEventDispatcher } from "svelte";
   import Add from "../icons/Add.svelte";
   import Subtract from "../icons/Subtract.svelte";
@@ -127,11 +129,6 @@
 
   $: incrementLabel = translateWithId("increment");
   $: decrementLabel = translateWithId("decrement");
-  $: error =
-    invalid ||
-    (!allowEmpty && value == null) ||
-    value > max ||
-    (typeof value === "number" && value < min);
   $: errorId = `error-${id}`;
   $: ariaLabel =
     $$props["aria-label"] ||
@@ -143,11 +140,14 @@
 
   function onInput({ target }) {
     value = parse(target.value);
+    error = !ref.checkValidity() || invalid;
 
     dispatch("input", value);
   }
 
   function onChange({ target }) {
+    error = !ref.checkValidity() || invalid;
+
     dispatch("change", parse(target.value));
   }
 </script>
@@ -202,6 +202,7 @@
         step="{step}"
         value="{value ?? ''}"
         readonly="{readonly}"
+        required="{required}"
         {...$$restProps}
         on:change="{onChange}"
         on:input="{onInput}"
@@ -211,10 +212,10 @@
         on:blur
         on:paste
       />
-      {#if invalid}
+      {#if invalid || error}
         <WarningFilled class="bx--number__invalid" />
       {/if}
-      {#if !invalid && warn}
+      {#if !invalid && !error && warn}
         <WarningAltFilled
           class="bx--number__invalid bx--number__invalid--warning"
         />
@@ -265,7 +266,7 @@
         {helperText}
       </div>
     {/if}
-    {#if error}
+    {#if invalid || error}
       <div id="{errorId}" class:bx--form-requirement="{true}">
         {invalidText}
       </div>


### PR DESCRIPTION
1. Breaking change : Change `allowEmpty` attribute to `required`. `allowEmpty` makes no sense, it should always be `required` to match base `HTML input` atrributes. 
2. The input was in `invalid state` with a red outline and the validity of the input would stay `valid` (only if empty). This patch fix this.

** NOTE TO DISCUSS : This bug was caused by the ambiguity between `invalid` and `error` variables. I think that we need to remove the `export invalid` and let it be local only. If OP wants to validate the input, we can export the `pattern` or change the `setCustomValidity` with the `ref`. Since this PR check the validity of the input on `input` and `change`, the `setCustomValidity` will set the error.