### PR TITLE
SideNav should overlay Content in UIShell

### DIFF
--- a/src/UIShell/Content.svelte
+++ b/src/UIShell/Content.svelte
@@ -1,24 +1,8 @@
 <script>
   /** Specify the id for the main element */
   export let id = "main-content";
-
-  import { isSideNavCollapsed, isSideNavRail } from "./navStore";
-
-  /**
-   * By default, the `SideNav` applies a left margin of `3rem` to `Content`
-   * if it's a sibling component (e.g., .bx--side-nav ~ .bx--content).
-   *
-   * We manually unset the left margin if the `SideNav`
-   * is collapsed and if it's not the `rail` variant.
-   */
-  $: unsetLeftMargin = $isSideNavCollapsed && !$isSideNavRail;
 </script>
 
-<main
-  id="{id}"
-  class:bx--content="{true}"
-  {...$$restProps}
-  style="{unsetLeftMargin ? 'margin-left: 0;' : ''} {$$restProps.style}"
->
+<main id="{id}" class:bx--content="{true}" {...$$restProps}>
   <slot />
 </main>

--- a/src/UIShell/SideNav.svelte
+++ b/src/UIShell/SideNav.svelte
@@ -72,9 +72,8 @@
   class:bx--side-nav__navigation="{true}"
   class:bx--side-nav="{true}"
   class:bx--side-nav--ux="{true}"
-  class:bx--side-nav--expanded="{rail && winWidth >= expansionBreakpoint
-    ? false
-    : isOpen}"
+  class:bx--side-nav--fixed="{isOpen && !rail}"
+  class:bx--side-nav--expanded="{!rail && winWidth >= expansionBreakpoint}"
   class:bx--side-nav--collapsed="{!isOpen && !rail}"
   class:bx--side-nav--rail="{rail}"
   {...$$restProps}


### PR DESCRIPTION
Fixes #1463

The expended class should not be applied when the `sideNav` is below the breaking point. I added the `bx--sidenav-fixed` class instead, it seems to works perfectly.

This PR also fixes the hack of `bx--content` that was set previously. 

