### PR TITLE
Fix `Dropdown` click outside

### DIFF
--- a/src/Dropdown/Dropdown.svelte
+++ b/src/Dropdown/Dropdown.svelte
@@ -281,7 +281,7 @@
             active="{selectedId === item.id}"
             highlighted="{highlightedIndex === i}"
             disabled="{item.disabled}"
-            on:click="{(e) => {
+            on:mousedown="{(e) => {
               if (item.disabled) {
                 e.stopPropagation();
                 return;

--- a/src/Dropdown/Dropdown.svelte
+++ b/src/Dropdown/Dropdown.svelte
@@ -150,14 +150,6 @@
   };
 </script>
 
-<svelte:window
-  on:click="{({ target }) => {
-    if (open && ref && !ref.contains(target)) {
-      open = false;
-    }
-  }}"
-/>
-
 <div
   class:bx--dropdown__wrapper="{true}"
   class:bx--list-box__wrapper="{true}"
@@ -182,10 +174,11 @@
     size="{size}"
     name="{name}"
     aria-label="{$$props['aria-label']}"
-    class="bx--dropdown {direction === 'top' && 'bx--list-box--up'} {invalid &&
-      'bx--dropdown--invalid'} {!invalid &&
-      warn &&
-      'bx--dropdown--warning'} {open && 'bx--dropdown--open'}
+    class="bx--dropdown 
+      {direction === 'top' && 'bx--list-box--up'} 
+      {invalid && 'bx--dropdown--invalid'} 
+      {!invalid && warn && 'bx--dropdown--warning'} 
+      {open && 'bx--dropdown--open'}
       {size === 'sm' && 'bx--dropdown--sm'}
       {size === 'xl' && 'bx--dropdown--xl'}
       {inline && 'bx--dropdown--inline'}
@@ -233,7 +226,6 @@
             open = false;
           }
         } else if (key === 'Tab') {
-          open = false;
           ref.blur();
         } else if (key === 'ArrowDown') {
           if (!open) open = true;
@@ -245,6 +237,7 @@
           open = false;
         }
       }}"
+      on:blur="{() => (open = false)}"
       on:keyup="{(e) => {
         const { key } = e;
         if ([' '].includes(key)) {

--- a/src/Dropdown/Dropdown.svelte
+++ b/src/Dropdown/Dropdown.svelte
@@ -240,6 +240,7 @@
             open = false;
           }
         } else if (key === 'Tab') {
+          open = false;
           ref.blur();
         } else if (key === 'ArrowDown') {
           if (!open) open = true;

--- a/src/Dropdown/Dropdown.svelte
+++ b/src/Dropdown/Dropdown.svelte
@@ -98,7 +98,7 @@
   /** Obtain a reference to the button HTML element */
   export let ref = null;
 
-  import { createEventDispatcher } from "svelte";
+  import { createEventDispatcher, onMount } from "svelte";
   import WarningFilled from "../icons/WarningFilled.svelte";
   import WarningAltFilled from "../icons/WarningAltFilled.svelte";
   import {
@@ -148,7 +148,21 @@
   const dispatchSelect = () => {
     dispatch("select", { selectedId, selectedItem });
   };
+
+  const pageClickHandler = ({ target }) => {
+    if (open && ref && !ref.contains(target)) {
+      open = false;
+    }
+  };
+
+  onMount(() => {
+    if (parent) {
+      parent.addEventListener("click", pageClickHandler);
+    }
+  });
 </script>
+
+<svelte:window on:click="{pageClickHandler}" />
 
 <div
   class:bx--dropdown__wrapper="{true}"
@@ -237,7 +251,6 @@
           open = false;
         }
       }}"
-      on:blur="{() => (open = false)}"
       on:keyup="{(e) => {
         const { key } = e;
         if ([' '].includes(key)) {
@@ -281,7 +294,7 @@
             active="{selectedId === item.id}"
             highlighted="{highlightedIndex === i}"
             disabled="{item.disabled}"
-            on:mousedown="{(e) => {
+            on:click="{(e) => {
               if (item.disabled) {
                 e.stopPropagation();
                 return;

--- a/src/Dropdown/Dropdown.svelte
+++ b/src/Dropdown/Dropdown.svelte
@@ -98,7 +98,7 @@
   /** Obtain a reference to the button HTML element */
   export let ref = null;
 
-  import { createEventDispatcher, onMount } from "svelte";
+  import { createEventDispatcher, onDestroy, onMount } from "svelte";
   import WarningFilled from "../icons/WarningFilled.svelte";
   import WarningAltFilled from "../icons/WarningAltFilled.svelte";
   import {
@@ -158,6 +158,12 @@
   onMount(() => {
     if (parent) {
       parent.addEventListener("click", pageClickHandler);
+    }
+  });
+
+  onDestroy(() => {
+    if (parent) {
+      parent.removeEventListener("click", pageClickHandler);
     }
   });
 </script>

--- a/src/Dropdown/Dropdown.svelte
+++ b/src/Dropdown/Dropdown.svelte
@@ -111,7 +111,6 @@
   const dispatch = createEventDispatcher();
 
   let highlightedIndex = -1;
-  let mainDivRef;
 
   $: inline = type === "inline";
   $: selectedItem = items.find((item) => item.id === selectedId);
@@ -166,7 +165,6 @@
 <svelte:window on:click="{pageClickHandler}" />
 
 <div
-  bind:this="{mainDivRef}"
   class:bx--dropdown__wrapper="{true}"
   class:bx--list-box__wrapper="{true}"
   class:bx--dropdown__wrapper--inline="{inline}"

--- a/src/ListBox/ListBoxMenuItem.svelte
+++ b/src/ListBox/ListBoxMenuItem.svelte
@@ -27,7 +27,6 @@
   disabled="{disabled ? true : undefined}"
   {...$$restProps}
   on:click
-  on:mousedown
   on:mouseenter
   on:mouseleave
 >

--- a/src/ListBox/ListBoxMenuItem.svelte
+++ b/src/ListBox/ListBoxMenuItem.svelte
@@ -27,6 +27,7 @@
   disabled="{disabled ? true : undefined}"
   {...$$restProps}
   on:click
+  on:mousedown
   on:mouseenter
   on:mouseleave
 >


### PR DESCRIPTION
Fixes #1595

Instead of registering the click on the `window` element, we can simply use the `blur` method on the `bx--list-box__field` button. This fix make it works in every situation even in `iframe`.