### PR TITLE
docs: change dispatched events label

### DIFF
--- a/docs/src/components/ComponentApi.svelte
+++ b/docs/src/components/ComponentApi.svelte
@@ -173,7 +173,7 @@
     <StructuredListHead>
       <StructuredListRow>
         <StructuredListCell>Event name</StructuredListCell>
-        <StructuredListCell><code>event.details</code> type</StructuredListCell>
+        <StructuredListCell><code>event.detail</code> type</StructuredListCell>
         {#if hasDescription}
           <StructuredListCell>Description</StructuredListCell>
         {/if}


### PR DESCRIPTION
Svelte dispatches `event.detail` and not plural `event.details`.