### PR TITLE
fix(tree-view)!: remove `expanded` property from `TreeNode` interface

### DIFF
--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -4661,7 +4661,6 @@ export interface TreeNode {
   text: any;
   icon?: typeof import("svelte").SvelteComponent;
   disabled?: boolean;
-  expanded?: boolean;
   children?: TreeNode[];
 }
 ```

--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -14522,9 +14522,9 @@
           "ts": "type TreeNodeId = string | number"
         },
         {
-          "type": "{ id: TreeNodeId; text: any; icon?: typeof import(\"svelte\").SvelteComponent; disabled?: boolean; expanded?: boolean; children?: TreeNode[]; }",
+          "type": "{ id: TreeNodeId; text: any; icon?: typeof import(\"svelte\").SvelteComponent; disabled?: boolean; children?: TreeNode[]; }",
           "name": "TreeNode",
-          "ts": "interface TreeNode { id: TreeNodeId; text: any; icon?: typeof import(\"svelte\").SvelteComponent; disabled?: boolean; expanded?: boolean; children?: TreeNode[]; }"
+          "ts": "interface TreeNode { id: TreeNodeId; text: any; icon?: typeof import(\"svelte\").SvelteComponent; disabled?: boolean; children?: TreeNode[]; }"
         }
       ],
       "rest_props": { "type": "Element", "name": "ul" }

--- a/docs/src/pages/components/TreeView.svx
+++ b/docs/src/pages/components/TreeView.svx
@@ -7,7 +7,7 @@
 
 The `children` prop accepts an array of child nodes. Each node should contain `id` and `text` properties.
 
-Optional properties include `disabled`, `expanded`, `icon`, and `children`.
+Optional properties include `disabled`, `icon`, and `children`.
 
 A parent node contains `children` while a leaf node does not.
 

--- a/docs/src/pages/framed/TreeView/TreeViewIcons.svelte
+++ b/docs/src/pages/framed/TreeView/TreeViewIcons.svelte
@@ -14,13 +14,11 @@
       id: 1,
       text: "Analytics",
       icon: Analytics,
-      expanded: true,
       children: [
         {
           id: 2,
           text: "IBM Analytics Engine",
           icon: Analytics,
-          expanded: true,
           children: [
             { id: 3, text: "Apache Spark", icon: Analytics },
             { id: 4, text: "Hadoop", icon: Analytics },

--- a/src/TreeView/TreeView.svelte
+++ b/src/TreeView/TreeView.svelte
@@ -1,7 +1,7 @@
 <script>
   /**
    * @typedef {string | number} TreeNodeId
-   * @typedef {{ id: TreeNodeId; text: any; icon?: typeof import("svelte").SvelteComponent; disabled?: boolean; expanded?: boolean; children?: TreeNode[]; }} TreeNode
+   * @typedef {{ id: TreeNodeId; text: any; icon?: typeof import("svelte").SvelteComponent; disabled?: boolean; children?: TreeNode[]; }} TreeNode
    * @event {TreeNode & { expanded: boolean; leaf: boolean; }} select
    * @event {TreeNode & { expanded: boolean; leaf: boolean; }} toggle
    * @event {TreeNode & { expanded: boolean; leaf: boolean; }} focus

--- a/src/TreeView/TreeViewNodeList.svelte
+++ b/src/TreeView/TreeViewNodeList.svelte
@@ -6,7 +6,6 @@
 
   /** @type {Array<TreeNode & { children?: TreeNode[] }>} */
   export let children = [];
-  export let expanded = false;
   export let root = false;
 
   /** @type {string | number} */

--- a/types/TreeView/TreeView.svelte.d.ts
+++ b/types/TreeView/TreeView.svelte.d.ts
@@ -8,7 +8,6 @@ export interface TreeNode {
   text: any;
   icon?: typeof import("svelte").SvelteComponent;
   disabled?: boolean;
-  expanded?: boolean;
   children?: TreeNode[];
 }
 


### PR DESCRIPTION
Fixes #1630

**Changes**

- breaking: remove `expanded` from the `TreeNode` interface
- fix: remove unused `expanded` prop from internal `TreeViewNodeList`
- docs: remove `expanded` as a property usage

<!--
**Notes**

`TreeViewNodeList` and `TreeViewNode` are not exported from the entry point (`src/index.js`) because they are considered "internal" component. As such, running `yarn build:docs` has no effect as it only generates types for components exported from the root.
-->