### PR TITLE
fix(dropdown): dispatch correct `selectedItem` in `select` event

### DIFF
--- a/src/Dropdown/Dropdown.svelte
+++ b/src/Dropdown/Dropdown.svelte
@@ -146,7 +146,10 @@
   }
 
   const dispatchSelect = () => {
-    dispatch("select", { selectedId, selectedItem });
+    dispatch("select", {
+      selectedId,
+      selectedItem: items.find((item) => item.id === selectedId),
+    });
   };
 
   const pageClickHandler = ({ target }) => {
@@ -164,7 +167,7 @@
       if (parent) {
         parent.removeEventListener("click", pageClickHandler);
       }
-    }
+    };
   });
 </script>
 


### PR DESCRIPTION
Fixes #1645

The `select` event dispatched in `Dropdown` uses the previous `selectedItem` value. One solution is to use the `tick` method to wait for all state changes to be applied.