### PR TITLE
docs(button): add example of disabled, icon-only button

### DIFF
--- a/docs/src/pages/components/Button.svx
+++ b/docs/src/pages/components/Button.svx
@@ -120,9 +120,10 @@ If an `href` value is specified, the component will render an [anchor element](h
 <Button size="xl" kind="ghost">Ghost</Button>
 <Button size="xl" kind="danger">Danger</Button>
 
-## Disabled button
+## Disabled state
 
 <Button disabled>Disabled button</Button>
+<Button disabled iconDescription="Tooltip text" icon={Add} />
 
 ## Expressive styles
 


### PR DESCRIPTION
Inspired by this [message from Discord](https://discord.com/channels/689212587170201628/756226301475684543/1070663479645720636).

> Hi — is there a disabled state for Icon only buttons?  I can see the disabled state for standard buttons and buttons with icon, but can't find the disabled behaviour for Icon only buttons.

I think it would be helpful to showcase what a disabled, icon-only button looks like.

This PR also changes "Disabled button" to "Disabled state" to be consistent with other docs pages.

---

<img width="801" alt="Disabled state" src="https://user-images.githubusercontent.com/10718366/217090658-8c9f5d1b-6c78-4ded-a252-5034ac2a3bf4.png">
