### PR TITLE
fix: remove pointer-events style from multiselect dropdown

### DIFF
--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -466,7 +466,6 @@
           />
         {/if}
         <ListBoxMenuIcon
-          style="pointer-events: {open ? 'auto' : 'none'}"
           on:click="{(e) => {
             e.stopPropagation();
             open = !open;


### PR DESCRIPTION
Resolves #1647 
This makes the component more consistent with other components that have the dropdown, and also more consistent with the flagship react library.