### PR TITLE
fix(types): add missing `$$restProps` for `Checkbox`, `Filename`, `FluidForm`

### DIFF
--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -924,7 +924,7 @@
         { "type": "forwarded", "name": "blur", "element": "input" }
       ],
       "typedefs": [],
-      "rest_props": { "type": "InlineComponent", "name": "CheckboxSkeleton" }
+      "rest_props": { "type": "Element", "name": "div" }
     },
     {
       "moduleName": "CheckboxSkeleton",
@@ -4399,7 +4399,7 @@
         { "type": "forwarded", "name": "keydown", "element": "button" }
       ],
       "typedefs": [],
-      "rest_props": { "type": "InlineComponent", "name": "Loading" }
+      "rest_props": { "type": "Element", "name": "div | button | svg" }
     },
     {
       "moduleName": "FluidForm",
@@ -4416,7 +4416,7 @@
         { "type": "forwarded", "name": "submit", "element": "Form" }
       ],
       "typedefs": [],
-      "rest_props": { "type": "InlineComponent", "name": "Form" }
+      "rest_props": { "type": "Element", "name": "form" }
     },
     {
       "moduleName": "Form",

--- a/src/Checkbox/Checkbox.svelte
+++ b/src/Checkbox/Checkbox.svelte
@@ -1,5 +1,6 @@
 <script>
   /**
+   * @restProps {div}
    * @event {boolean} check
    */
 

--- a/src/FileUploader/Filename.svelte
+++ b/src/FileUploader/Filename.svelte
@@ -1,5 +1,9 @@
 <script>
   /**
+   * @restProps {div | button | svg}
+   */
+
+  /**
    * Specify the file name status
    * @type {"uploading" | "edit" | "complete"}
    */

--- a/src/FluidForm/FluidForm.svelte
+++ b/src/FluidForm/FluidForm.svelte
@@ -1,4 +1,8 @@
 <script>
+  /**
+   * @restProps {form}
+   */
+
   import { setContext } from "svelte";
   import Form from "../Form/Form.svelte";
 

--- a/tests/Checkbox.test.svelte
+++ b/tests/Checkbox.test.svelte
@@ -2,7 +2,7 @@
   import { Checkbox } from "../types";
 </script>
 
-<Checkbox labelText="Label text" />
+<Checkbox labelText="Label text" style="margin: 1rem" />
 
 <Checkbox labelText="Label text" checked />
 

--- a/tests/FluidForm.test.svelte
+++ b/tests/FluidForm.test.svelte
@@ -2,7 +2,7 @@
   import { FluidForm, TextInput, PasswordInput } from "../types";
 </script>
 
-<FluidForm>
+<FluidForm action="" method="get">
   <TextInput labelText="User name" placeholder="Enter user name..." required />
   <PasswordInput
     required

--- a/types/Checkbox/Checkbox.svelte.d.ts
+++ b/types/Checkbox/Checkbox.svelte.d.ts
@@ -1,7 +1,8 @@
 /// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
 
-export interface CheckboxProps {
+export interface CheckboxProps
+  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
   /**
    * Specify the value of the checkbox
    * @default ""

--- a/types/FileUploader/Filename.svelte.d.ts
+++ b/types/FileUploader/Filename.svelte.d.ts
@@ -1,7 +1,10 @@
 /// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
 
-export interface FilenameProps {
+export interface FilenameProps
+  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]>,
+    svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["button"]>,
+    svelte.JSX.SVGAttributes<SVGSVGElement> {
   /**
    * Specify the file name status
    * @default "uploading"

--- a/types/FluidForm/FluidForm.svelte.d.ts
+++ b/types/FluidForm/FluidForm.svelte.d.ts
@@ -1,7 +1,8 @@
 /// <reference types="svelte" />
 import type { SvelteComponentTyped } from "svelte";
 
-export interface FluidFormProps {}
+export interface FluidFormProps
+  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["form"]> {}
 
 export default class FluidForm extends SvelteComponentTyped<
   FluidFormProps,


### PR DESCRIPTION
A user [reported in Discord](https://discord.com/channels/689212587170201628/1048235099583418448/1073080988957151343) that `$$restProps` types in `Checkbox` are missing from the type definitions.

https://github.com/carbon-design-system/carbon-components-svelte/issues/1621 proposes that we remove `$$restProps` for both clarity and performance reasons. This PR is a hotfix that addresses the existing bugs pre-v1.

The solution is to manually add a `@restProps` tag that sveld uses to generate types from.