### PR TITLE
fix: `readonly` should override `error` behavior in `TextInput`, `NumberInput`

### DIFF
--- a/src/NumberInput/NumberInput.svelte
+++ b/src/NumberInput/NumberInput.svelte
@@ -128,7 +128,7 @@
   $: incrementLabel = translateWithId("increment");
   $: decrementLabel = translateWithId("decrement");
   $: error =
-    invalid ||
+    (invalid && !readonly) ||
     (!allowEmpty && value == null) ||
     value > max ||
     (typeof value === "number" && value < min);
@@ -191,8 +191,8 @@
         type="number"
         pattern="[0-9]*"
         aria-describedby="{errorId}"
-        data-invalid="{invalid || undefined}"
-        aria-invalid="{invalid || undefined}"
+        data-invalid="{(error) || undefined}"
+        aria-invalid="{(error) || undefined}"
         aria-label="{label ? undefined : ariaLabel}"
         disabled="{disabled}"
         id="{id}"

--- a/src/NumberInput/NumberInput.svelte
+++ b/src/NumberInput/NumberInput.svelte
@@ -211,16 +211,17 @@
         on:blur
         on:paste
       />
-      {#if invalid}
-        <WarningFilled class="bx--number__invalid" />
-      {/if}
-      {#if !invalid && warn}
-        <WarningAltFilled
-          class="bx--number__invalid bx--number__invalid--warning"
-        />
-      {/if}
       {#if readonly}
         <EditOff class="bx--text-input__readonly-icon" />
+      {:else}
+        {#if invalid}
+          <WarningFilled class="bx--number__invalid" />
+        {/if}
+        {#if !invalid && warn}
+          <WarningAltFilled
+            class="bx--number__invalid bx--number__invalid--warning"
+          />
+        {/if}
       {/if}
       {#if !hideSteppers}
         <div class:bx--number__controls="{true}">

--- a/src/TextInput/TextInput.svelte
+++ b/src/TextInput/TextInput.svelte
@@ -95,6 +95,7 @@
   };
 
   $: isFluid = !!ctx && ctx.isFluid;
+  $: error = invalid && !readonly;
   $: helperId = `helper-${id}`;
   $: errorId = `error-${id}`;
   $: warnId = `warn-${id}`;
@@ -161,7 +162,7 @@
     class:bx--text-input__field-outer-wrapper--inline="{inline}"
   >
     <div
-      data-invalid="{invalid || undefined}"
+      data-invalid="{error || undefined}"
       data-warn="{warn || undefined}"
       class:bx--text-input__field-wrapper="{true}"
       class:bx--text-input__field-wrapper--warning="{!invalid && warn}"
@@ -181,10 +182,10 @@
       {/if}
       <input
         bind:this="{ref}"
-        data-invalid="{invalid || undefined}"
-        aria-invalid="{invalid || undefined}"
+        data-invalid="{error || undefined}"
+        aria-invalid="{error || undefined}"
         data-warn="{warn || undefined}"
-        aria-describedby="{invalid
+        aria-describedby="{error
           ? errorId
           : warn
           ? warnId
@@ -200,7 +201,7 @@
         readonly="{readonly}"
         class:bx--text-input="{true}"
         class:bx--text-input--light="{light}"
-        class:bx--text-input--invalid="{invalid}"
+        class:bx--text-input--invalid="{error}"
         class:bx--text-input--warn="{warn}"
         class:bx--text-input--sm="{size === 'sm'}"
         class:bx--text-input--xl="{size === 'xl'}"

--- a/src/TextInput/TextInput.svelte
+++ b/src/TextInput/TextInput.svelte
@@ -166,17 +166,18 @@
       class:bx--text-input__field-wrapper="{true}"
       class:bx--text-input__field-wrapper--warning="{!invalid && warn}"
     >
-      {#if invalid}
-        <WarningFilled class="bx--text-input__invalid-icon" />
-      {/if}
-      {#if !invalid && warn}
-        <WarningAltFilled
-          class="bx--text-input__invalid-icon
-            bx--text-input__invalid-icon--warning"
-        />
-      {/if}
       {#if readonly}
         <EditOff class="bx--text-input__readonly-icon" />
+      {:else}
+        {#if invalid}
+          <WarningFilled class="bx--text-input__invalid-icon" />
+        {/if}
+        {#if !invalid && warn}
+          <WarningAltFilled
+            class="bx--text-input__invalid-icon
+            bx--text-input__invalid-icon--warning"
+          />
+        {/if}
       {/if}
       <input
         bind:this="{ref}"


### PR DESCRIPTION
Fixes #1664

This primarily fixes a bug where setting both `readonly` and `invalid` in `TextInput` would display two icons. The solution is to separate the `readonly` state from the `invalid/warn` states. This PR applies a similar logic to `NumberInput`, although icons will not clash in that component.

Furthermore, the `readonly` state will override the `error` state. That is, if both `readonly` and `error` are set, the `readonly` behavior will prevail.

The diff is best reviewed with [whitespace hidden](https://github.com/carbon-design-system/carbon-components-svelte/pull/1666/files?diff=split&w=1).

See a before/after:

```svelte
<TextInput
  labelText="TextInput (readonly + invalid)"
  value="Text"
  readonly
  invalid
  invalidText="Invalid text"
/>

<FluidForm>
  <TextInput
    labelText="Fluid TextInput (readonly + invalid)"
    value="Text"
    readonly
    invalid
    invalidText="Invalid text"
  />
</FluidForm>

<NumberInput
  label="NumberInput (readonly + invalid)"
  value={0}
  readonly
  invalid
  invalidText="Invalid text"
/>
```

<img width="912" alt="Before/After" src="https://user-images.githubusercontent.com/10718366/221378238-ce595020-b473-46a5-b979-26a63d6555ea.png">

