### PR TITLE
fix(1684): hide helper text container in password input when not used

### DIFF
--- a/docs/src/pages/components/PasswordInput.svx
+++ b/docs/src/pages/components/PasswordInput.svx
@@ -50,3 +50,7 @@ Set prop `type` to `"text"` to toggle password visibility.
 ## Disabled state
 
 <PasswordInput disabled labelText="Password" placeholder="Enter password..." />
+
+## With helper text
+
+<PasswordInput helperText="Your password should be hard to guess" labelText="Password" placeholder="Enter password..." />

--- a/src/TextInput/PasswordInput.svelte
+++ b/src/TextInput/PasswordInput.svelte
@@ -248,7 +248,7 @@
         {invalidText}
       </div>
     {/if}
-    {#if !invalid && !warn && !isFluid && !inline}
+    {#if !invalid && !warn && !isFluid && !inline && helperText}
       <div
         class:bx--form__helper-text="{true}"
         class:bx--form__helper-text--disabled="{disabled}"


### PR DESCRIPTION
- hides the whole helper text container when helper text is not provided (same behaviour as in TextInput) (screenshot 1)
- added an example in docs showing the helper text prop being used (screenshot 2)

<img width="703" alt="Screenshot 2023-03-11 at 17 14 39" src="https://user-images.githubusercontent.com/92097847/224502354-389cfe64-bb27-425d-9049-e701e9b3f32f.png">
<img width="703" alt="Screenshot 2023-03-11 at 17 14 55" src="https://user-images.githubusercontent.com/92097847/224502355-5cc9ad01-71c8-4831-9417-89080c3af028.png">


fixes #1684 