### PR TITLE
fix(text-input): correctly set input padding for warning state

### DIFF
--- a/src/TextInput/TextInput.svelte
+++ b/src/TextInput/TextInput.svelte
@@ -202,7 +202,7 @@
         class:bx--text-input="{true}"
         class:bx--text-input--light="{light}"
         class:bx--text-input--invalid="{error}"
-        class:bx--text-input--warn="{warn}"
+        class:bx--text-input--warning="{warn}"
         class:bx--text-input--sm="{size === 'sm'}"
         class:bx--text-input--xl="{size === 'xl'}"
         {...$$restProps}


### PR DESCRIPTION
# Summary
`--warn` to `--warning`

Fixes #1687

# Before
![before](https://user-images.githubusercontent.com/78584173/224683716-08451c9b-51e6-4701-bf94-cf4c11b1c909.png)

# After
![fixed](https://user-images.githubusercontent.com/78584173/224683729-0cefc3a3-d877-427c-83d0-e21b59a2b938.png)
