### PR TITLE
fix text overflow when progressIndicator space-equally

### DIFF
--- a/src/ProgressIndicator/ProgressStep.svelte
+++ b/src/ProgressIndicator/ProgressStep.svelte
@@ -70,6 +70,7 @@
     class:bx--progress-step-button="{true}"
     class:bx--progress-step-button--unclickable="{current ||
       $preventChangeOnClick}"
+    style="width: 100%; padding-right: 16px;"
     on:click
     on:click="{() => {
       if (!step.complete) return;
@@ -95,7 +96,7 @@
     {:else}
       <CircleDash title="{description}" />
     {/if}
-    <div class:bx--progress-text="{true}">
+    <div class:bx--progress-text="{true}" style="width: 100%;">
       <slot props="{{ class: 'bx--progress-label' }}">
         <p class:bx--progress-label="{true}">{label}</p>
       </slot>

--- a/src/ProgressIndicator/ProgressStep.svelte
+++ b/src/ProgressIndicator/ProgressStep.svelte
@@ -70,7 +70,6 @@
     class:bx--progress-step-button="{true}"
     class:bx--progress-step-button--unclickable="{current ||
       $preventChangeOnClick}"
-    style="width: 100%; padding-right: 16px;"
     on:click
     on:click="{() => {
       if (!step.complete) return;
@@ -96,7 +95,7 @@
     {:else}
       <CircleDash title="{description}" />
     {/if}
-    <div class:bx--progress-text="{true}" style="width: 100%;">
+    <div class:bx--progress-text="{true}" class="bx--progress-step">
       <slot props="{{ class: 'bx--progress-label' }}">
         <p class:bx--progress-label="{true}">{label}</p>
       </slot>


### PR DESCRIPTION
when progressIndicator enable space-equally text became overflow
before fix
![before](https://user-images.githubusercontent.com/21374073/225613269-d78a4f8f-cc88-42f8-8d0f-4afe290052be.png)
after
![after](https://user-images.githubusercontent.com/21374073/225613333-0645e03d-7866-459c-8cb2-c1f124bd0bf4.png)
