### PR TITLE
fix(slider): no label is rendered when the labelText property is not specified.

### DIFF
--- a/src/Slider/Slider.svelte
+++ b/src/Slider/Slider.svelte
@@ -139,16 +139,18 @@
   on:mouseenter
   on:mouseleave
 >
-  <label
-    for="{id}"
-    id="{labelId}"
-    class:bx--label="{true}"
-    class:bx--label--disabled="{disabled}"
-  >
-    <slot name="labelText">
-      {labelText}
-    </slot>
-  </label>
+  {#if labelText || $$slots.labelText}
+    <label
+      for="{id}"
+      id="{labelId}"
+      class:bx--label="{true}"
+      class:bx--label--disabled="{disabled}"
+    >
+      <slot name="labelText">
+        {labelText}
+      </slot>
+    </label>
+  {/if}
   <div
     class:bx--slider-container="{true}"
     style="{fullWidth ? 'width: 100%' : undefined}"


### PR DESCRIPTION
label elements are not rendered when no `labelText` or `labelText` slot is passed.

Close #1682 

#### Before
![image](https://user-images.githubusercontent.com/24749324/226527345-4fc900e6-ad01-41e8-b7ef-f3f471b2b24b.png)

#### After
![image](https://user-images.githubusercontent.com/24749324/226527383-614a9798-d1cf-46df-b25e-87758fb43c73.png)
