### PR TITLE
Fix horizontal scrollbars on small screens

### DIFF
--- a/docs/src/components/InlineSnippet.svelte
+++ b/docs/src/components/InlineSnippet.svelte
@@ -6,7 +6,12 @@
 </script>
 
 <div>
-  <CodeSnippet code="{code}" type="inline" copy="{(text) => copy(text)}" />
+  <CodeSnippet
+    code="{code}"
+    type="inline"
+    copy="{(text) => copy(text)}"
+    class="code-override"
+  />
 </div>
 
 <style>

--- a/docs/src/global.css
+++ b/docs/src/global.css
@@ -27,6 +27,13 @@ html[theme="g90"] .code-override {
   line-height: var(--cds-code-02-line-height);
   letter-spacing: var(--cds-code-02-letter-spacing);
   cursor: text;
+  /* This override is needed to get code snippets to wrap properly and not overstretch the layout.
+   * Code snippets are used for specific examples but also for type definitions at the bottom of the page. */
+  white-space: pre-wrap;
+}
+
+.code-override code {
+  word-break: break-all;
 }
 
 .code-override .bx--snippet--multi .bx--snippet-container pre {


### PR DESCRIPTION
This patch addresses #1649 to fix documentation layout. In fact there are multiple issues with the current layout:

1. Flex layout might have an issue with overflowing content. See [CodePen](https://codepen.io/gregorw/full/gOdqreo).
2. The props table at the bottom of each page doesn’t overflow and stretches the layout.

This minimal change fixes code snippets in such a way that they are wrapped on small screens, since `overflow-x: scroll` doesn’t seem to work with the flexbox layout used. See code pen for problem description and solution A. 

**Before**

<img width="1280" alt="image" src="https://user-images.githubusercontent.com/988276/227771366-180df8f1-1b0f-46db-af16-2cbcf3b2a08b.png">

**After**

<img width="1280" alt="image" src="https://user-images.githubusercontent.com/988276/227771414-844e23e6-871e-40b9-b2e4-d024d583ef2d.png">

This fixes horizontal scrollbars on all pages that don’t have other issues such as a large non-overflowing props table at the bottom. It also makes code snippets in the props table break a bit more.

**Before**

<img width="1279" alt="image" src="https://user-images.githubusercontent.com/988276/227770948-e1812213-586c-418c-ab11-11e021c951dd.png">

**After**

<img width="1279" alt="image" src="https://user-images.githubusercontent.com/988276/227770964-ed909222-ee5b-4969-8093-558bcc07d5b6.png">

The prop table at the bottom needs a separate PR. Possible solutions are that we get overflow/scroll to work or that we change to the mobile table of contents earlier. Maybe using a non-flexbox layout would solve some of the problems, too. See solution B of code pen above.