### PR TITLE
docs: fix layout for smaller screens

### DIFF
--- a/docs/src/global.css
+++ b/docs/src/global.css
@@ -33,6 +33,11 @@ html[theme="g90"] .code-override {
   overflow-x: auto;
 }
 
+/* Addig this to the layout grid fixes overstretching. */
+.fix-overflow {
+  min-width: 0;
+}
+
 .token.tag,
 .token.operator {
   color: #6ea6ff;

--- a/docs/src/layouts/ComponentLayout.svelte
+++ b/docs/src/layouts/ComponentLayout.svelte
@@ -66,7 +66,7 @@
 </script>
 
 <Content data-components>
-  <Grid>
+  <Grid class="fix-overflow">
     <Row>
       <Column>
         <h1>{component}</h1>


### PR DESCRIPTION
This patch fixes #1649. The documentation layout is currently broken. The fix adds scroll behavior to:

- Code snippets
- Component props table

Like this the layout is no longer overstretched.

**Before**

![image](https://user-images.githubusercontent.com/988276/227775665-5dc32251-3d74-40f9-a98f-e05dc901e273.png)

![image](https://user-images.githubusercontent.com/988276/227775707-9434a7d2-06ce-477c-81c5-56ef0ae4f30e.png)

**After**

![image](https://user-images.githubusercontent.com/988276/227775717-1e3bd9b2-380f-4176-8d94-af2f3f8c6e44.png)

![image](https://user-images.githubusercontent.com/988276/227775724-1ba29119-6492-4e43-b3d5-b2a1eddbfca5.png)

This is a better fix than #1706 which is inspired by https://defensivecss.dev/tip/flexbox-min-content-size.