### PR TITLE
ci: add job to automatically deploy docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,3 +23,13 @@ jobs:
           yarn build:lib
           yarn test:types
           yarn lint
+
+  deploy-docs:
+    if: github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger deploy
+        env:
+          deploy_url: ${{ secrets.RENDER_DEPLOY_HOOK_URL }}
+        run: |
+          curl -X GET "$deploy_url"


### PR DESCRIPTION
Currently, docs are [manually deployed](https://github.com/carbon-design-system/carbon-components-svelte/pull/1688#issuecomment-1480882478).

Let's automate the process. I added a repository secret containing the Deploy Hook URL. If hit, the documentation site will automatically redeploy the `master` branch.

This PR updates the GitHub workflow with a job that triggers the deploy hook URL only on `master`.