### PR TITLE
docs(slider): add label text, value

### DIFF
--- a/docs/src/pages/components/Slider.svx
+++ b/docs/src/pages/components/Slider.svx
@@ -9,17 +9,17 @@ components: ["Slider", "SliderSkeleton"]
 
 ## Default
 
-<Slider />
+<Slider labelText="Instances" value={0} />
 
 ## Full width
 
 Set `fullWidth` to `true` for the slider to span the full width of its containing element.
 
-<Slider fullWidth />
+<Slider labelText="Instances" fullWidth value={0} />
 
 ## Hidden text input
 
-<Slider hideTextInput />
+<Slider labelText="Instances" hideTextInput value={0} />
 
 ## Custom minimum, maximum values
 


### PR DESCRIPTION
The initial `Slider` examples are too minimal. We should encourage the use of `labelText` for accessibility. Also, even though the default `value` is `0`, exposing that attribute in the examples is a nice affordance.