### PR TITLE
docs: remove Deploy to Render CTA

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,6 @@ The Carbon Svelte portfolio also includes:
 
 ## [Documentation](https://carbon-components-svelte.onrender.com)
 
-The documentation site is deployed to [Render](https://render.com) as a Static Site. See [render.yaml](render.yaml) for details.
-
-[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/carbon-design-system/carbon-components-svelte)
-
 Other forms of documentation are auto-generated:
 
 - **[TypeScript definitions](types)**: Component TypeScript definitions


### PR DESCRIPTION
The above-the-fold `README` is critical for first-time users. We should minimize the number of call-to-actions.

I feel that the Deploy-to-Render button is not relevant to the majority of users who simply want to use the library.