### PR TITLE
Resolve `a11y` warnings from Svelte version 3.58

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -22,7 +22,7 @@
     "prism-svelte": "^0.4.7",
     "prismjs": "^1.28.0",
     "remark-slug": "^6.0.0",
-    "svelte": "^3.57.0",
+    "svelte": "^3.58.0",
     "vite": "^3.0.9"
   },
   "routify": {

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -165,7 +165,7 @@ bufferutil@^4.0.1:
     node-gyp-build "~3.7.0"
 
 carbon-components-svelte@../:
-  version "0.73.3"
+  version "0.73.5"
   dependencies:
     flatpickr "4.6.9"
 
@@ -1280,10 +1280,10 @@ svelte-hmr@^0.14.12:
   resolved "https://registry.yarnpkg.com/svelte-hmr/-/svelte-hmr-0.14.12.tgz#a127aec02f1896500b10148b2d4d21ddde39973f"
   integrity sha512-4QSW/VvXuqVcFZ+RhxiR8/newmwOCTlbYIezvkeN6302YFRE8cXy0naamHcjz8Y9Ce3ITTZtrHrIL0AGfyo61w==
 
-svelte@^3.57.0:
-  version "3.57.0"
-  resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.57.0.tgz#a3969cfe51f25f2a55e75f7b98dbd02c3af0980b"
-  integrity sha512-WMXEvF+RtAaclw0t3bPDTUe19pplMlfyKDsixbHQYgCWi9+O9VN0kXU1OppzrB9gPAvz4NALuoca2LfW2bOjTQ==
+svelte@^3.58.0:
+  version "3.58.0"
+  resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.58.0.tgz#d3e6f103efd6129e51c7d709225ad3b4c052b64e"
+  integrity sha512-brIBNNB76mXFmU/Kerm4wFnkskBbluBDCjx/8TcpYRb298Yh2dztS2kQ6bhtjMcvUhd5ynClfwpz5h2gnzdQ1A==
 
 symbol-tree@^3.2.4:
   version "3.2.4"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "sass": "^1.49.11",
     "standard-version": "^9.5.0",
     "sveld": "^0.18.0",
-    "svelte": "^3.57.0",
+    "svelte": "^3.58.0",
     "svelte-check": "^2.8.1",
     "typescript": "^4.7.4"
   },

--- a/src/ContentSwitcher/ContentSwitcher.svelte
+++ b/src/ContentSwitcher/ContentSwitcher.svelte
@@ -58,6 +58,7 @@
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
+<!-- svelte-ignore a11y-interactive-supports-focus -->
 <div
   role="tablist"
   class:bx--content-switcher="{true}"

--- a/src/ListBox/ListBoxMenuItem.svelte
+++ b/src/ListBox/ListBoxMenuItem.svelte
@@ -20,6 +20,7 @@
 
 <div
   role="option"
+  tabindex="-1"
   class:bx--list-box__menu-item="{true}"
   class:bx--list-box__menu-item--active="{active}"
   class:bx--list-box__menu-item--highlighted="{highlighted || active}"

--- a/src/ListBox/ListBoxSelection.svelte
+++ b/src/ListBox/ListBoxSelection.svelte
@@ -62,7 +62,7 @@
     <div
       bind:this="{ref}"
       role="button"
-      tabIndex="{disabled ? -1 : 0}"
+      tabindex="{disabled ? -1 : 0}"
       class:bx--tag__close-icon="{true}"
       on:click|preventDefault|stopPropagation="{(e) => {
         if (!disabled) {

--- a/src/StructuredList/StructuredListRow.svelte
+++ b/src/StructuredList/StructuredListRow.svelte
@@ -27,6 +27,7 @@
     <slot />
   </label>
 {:else}
+  <!-- svelte-ignore a11y-interactive-supports-focus -->
   <div
     role="row"
     class:bx--structured-list-row="{true}"

--- a/src/Tooltip/Tooltip.svelte
+++ b/src/Tooltip/Tooltip.svelte
@@ -254,7 +254,7 @@
         on:click|stopPropagation
         on:mousedown|stopPropagation
         class:bx--tooltip__content="{true}"
-        tabIndex="-1"
+        tabindex="-1"
         role="dialog"
       >
         <slot />

--- a/yarn.lock
+++ b/yarn.lock
@@ -2023,10 +2023,10 @@ svelte@^3.52.0:
   resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.54.0.tgz#b4bcd865bd9e927f9f7b76563288ef5f4d72867a"
   integrity sha512-tdrgeJU0hob0ZWAMoKXkhcxXA7dpTg6lZGxUeko5YqvPdJBiyRspGsCwV27kIrbrqPP2WUoSV9ca0gnLlw8YzQ==
 
-svelte@^3.57.0:
-  version "3.57.0"
-  resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.57.0.tgz#a3969cfe51f25f2a55e75f7b98dbd02c3af0980b"
-  integrity sha512-WMXEvF+RtAaclw0t3bPDTUe19pplMlfyKDsixbHQYgCWi9+O9VN0kXU1OppzrB9gPAvz4NALuoca2LfW2bOjTQ==
+svelte@^3.58.0:
+  version "3.58.0"
+  resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.58.0.tgz#d3e6f103efd6129e51c7d709225ad3b4c052b64e"
+  integrity sha512-brIBNNB76mXFmU/Kerm4wFnkskBbluBDCjx/8TcpYRb298Yh2dztS2kQ6bhtjMcvUhd5ynClfwpz5h2gnzdQ1A==
 
 terser@^5.0.0:
   version "5.14.2"


### PR DESCRIPTION
Now that Svelte version [3.58](https://github.com/sveltejs/svelte/blob/e45a1e05a341e95d30ddb097bc144d8d6f5b3573/CHANGELOG.md#3580) has been released, a new slew of static a11y warnings needs to be addressed.

To repro the warnings, run the following at the root of this repository on `master`:

```sh
yarn add -D svelte; yarn build:lib;
# ... a11y warnings emitted
```

This PR is best reviewed by commit because it actually contains a fix.

For each warning, I referenced the upstream Carbon React implementation. There are a couple of cases where the a11y warning can be ignored. There is one fix for `ListBoxMenuItem`. For the `tabIndex` -> `tabindex` capitalization, I don't think there is any user-facing change (Svelte Language Server does not seem to pick up `tabIndex`).

@theetrain If approved, should this PR *not* be squash merged? Will `standard-version` automatically pick up the fix for de921e63ec6bf6862f5e4f8cbb042cea939f8ec9?