### PR TITLE
fix(expandable-tile): set tile height using resize observer

### DIFF
--- a/docs/src/pages/components/ExpandableTile.svx
+++ b/docs/src/pages/components/ExpandableTile.svx
@@ -3,7 +3,29 @@
   import Preview from "../../components/Preview.svelte";
 </script>
 
-## Default (unexpanded)
+## Default
+
+This component uses a [resize observer](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver) to determine the height of the above-the-fold content.
+
+It's unexpanded by default.
+
+<ExpandableTile>
+  <div slot="above">
+    <div>
+      Above the fold content here
+    </div>
+    <br />
+    <br />
+    <div>
+      More above the fold content
+    </div>
+  </div>
+  <div slot="below">Below the fold content here</div>
+</ExpandableTile>
+
+## Custom tile heights
+
+Set a custom height for the tiles on the "above" and "below" slots.
 
 <ExpandableTile>
   <div slot="above" style="height: 10rem">Above the fold content here</div>
@@ -13,22 +35,22 @@
 ## Expanded
 
 <ExpandableTile expanded>
-  <div slot="above" style="height: 10rem">Above the fold content here</div>
-  <div slot="below" style="height: 10rem">Below the fold content here</div>
+  <div slot="above">Above the fold content here</div>
+  <div slot="below">Below the fold content here</div>
 </ExpandableTile>
 
 ## Light variant
 
 <ExpandableTile light>
-  <div slot="above" style="height: 10rem">Above the fold content here</div>
-  <div slot="below" style="height: 10rem">Below the fold content here</div>
+  <div slot="above">Above the fold content here</div>
+  <div slot="below">Below the fold content here</div>
 </ExpandableTile>
 
 ## With icon labels
 
 <ExpandableTile tileExpandedLabel="View less" tileCollapsedLabel="View more">
-  <div slot="above" style="height: 10rem">Above the fold content here</div>
-  <div slot="below" style="height: 10rem">Below the fold content here</div>
+  <div slot="above">Above the fold content here</div>
+  <div slot="below">Below the fold content here</div>
 </ExpandableTile>
 
 ## With interactive content
@@ -36,7 +58,7 @@
 For tiles containing interactive content, use `stopPropagation` to prevent the tile from toggling.
 
 <ExpandableTile tileExpandedLabel="View less" tileCollapsedLabel="View more">
-  <div slot="above" style="height: 10rem">
+  <div slot="above">
     <a href="/" on:click|preventDefault|stopPropagation={() => console.log("Hello world")}>
       Native element
     </a>
@@ -48,5 +70,5 @@ For tiles containing interactive content, use `stopPropagation` to prevent the t
       Svelte component
     </Button>
   </div>
-  <div slot="below" style="height: 10rem">Below the fold content here</div>
+  <div slot="below">Below the fold content here</div>
 </ExpandableTile>

--- a/src/Tile/ExpandableTile.svelte
+++ b/src/Tile/ExpandableTile.svelte
@@ -32,10 +32,22 @@
   /** Obtain a reference to the top-level element */
   export let ref = null;
 
-  import { afterUpdate } from "svelte";
+  import { afterUpdate, onMount } from "svelte";
   import ChevronDown from "../icons/ChevronDown.svelte";
 
   let refAbove = null;
+
+  onMount(() => {
+    const resizeObserver = new ResizeObserver(([elem]) => {
+      tileMaxHeight = elem.contentRect.height;
+    });
+
+    resizeObserver.observe(refAbove);
+
+    return () => {
+      resizeObserver.disconnect();
+    };
+  });
 
   afterUpdate(() => {
     if (tileMaxHeight === 0) {
@@ -62,10 +74,8 @@
   class:bx--tile--expandable="{true}"
   class:bx--tile--is-expanded="{expanded}"
   class:bx--tile--light="{light}"
+  style:max-height="{expanded ? "none" : `${tileMaxHeight + tilePadding}px`}"
   {...$$restProps}
-  style="{expanded
-    ? $$restProps.style
-    : `${$$restProps.style}; max-height: ${tileMaxHeight + tilePadding}px`}"
   on:click
   on:click="{() => {
     expanded = !expanded;


### PR DESCRIPTION
Fixes #1730

Currently, the `ExpandableTile` does not dynamically set the height of the above-the-fold content. In cases where the content is dynamic (a lot of text), this can result in clipped content.

This PR aims to fix this problem by using the Resize Observer to set the height of the tile, and adjust it if the height changes. It implements the [approach of the upstream React library](https://github.com/carbon-design-system/carbon/blob/97b6ca3e90fd9f95869792e4e6b27ea236cc7932/packages/react/src/components/Tile/Tile.js#L500-L509) almost verbatim.






In terms of behavior, this should not be a breaking change since you can still specify a custom tile height on the "above" and "below" slots.

**Changes**

- Fix `ExpandableTile` to use Resize Observer to set the tile max height
- Rework the docs to promote *not* setting a height; add an example for customizing the tile heights

---

## Example

In the following example, I am clicking a button that doubles the text in the above-the-fold tile. Note how the tile height adjusts itself dynamically.

https://github.com/carbon-design-system/carbon-components-svelte/assets/10718366/fa875e6e-124e-4eeb-a470-570c2b603fda

## Issue #1730 (before)

https://github.com/carbon-design-system/carbon-components-svelte/assets/10718366/33e0ca54-c519-4d50-8d47-7d63c2d2b9c0


## Issue #1730 (after)


https://github.com/carbon-design-system/carbon-components-svelte/assets/10718366/02dd432c-cc31-4314-aee4-2c2f411c81f3





