### PR TITLE
fix(types): allow `data-*` attributes for props forwarded to HTML elements

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "rollup-plugin-terser": "^7.0.2",
     "sass": "^1.49.11",
     "standard-version": "^9.5.0",
-    "sveld": "^0.18.0",
+    "sveld": "^0.18.1",
     "svelte": "^3.58.0",
     "svelte-check": "^2.8.1",
     "typescript": "^4.7.4"

--- a/tests/Button.test.svelte
+++ b/tests/Button.test.svelte
@@ -3,7 +3,7 @@
   import Add from "carbon-icons-svelte/lib/Add.svelte";
 </script>
 
-<Button>Primary button</Button>
+<Button data-test-id="btn">Primary button</Button>
 
 <Button kind="secondary">Secondary button</Button>
 

--- a/types/Accordion/AccordionItem.svelte.d.ts
+++ b/types/Accordion/AccordionItem.svelte.d.ts
@@ -27,6 +27,8 @@ export interface AccordionItemProps
    * @default "Expand/Collapse"
    */
   iconDescription?: string;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class AccordionItem extends SvelteComponentTyped<

--- a/types/Accordion/AccordionSkeleton.svelte.d.ts
+++ b/types/Accordion/AccordionSkeleton.svelte.d.ts
@@ -26,6 +26,8 @@ export interface AccordionSkeletonProps
    * @default true
    */
   open?: boolean;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class AccordionSkeleton extends SvelteComponentTyped<

--- a/types/AspectRatio/AspectRatio.svelte.d.ts
+++ b/types/AspectRatio/AspectRatio.svelte.d.ts
@@ -17,6 +17,8 @@ export interface AspectRatioProps
     | "3x2"
     | "9x16"
     | "1x2";
+
+  [key: `data-${string}`]: any;
 }
 
 export default class AspectRatio extends SvelteComponentTyped<

--- a/types/Breadcrumb/BreadcrumbItem.svelte.d.ts
+++ b/types/Breadcrumb/BreadcrumbItem.svelte.d.ts
@@ -14,6 +14,8 @@ export interface BreadcrumbItemProps
    * @default false
    */
   isCurrentPage?: boolean;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class BreadcrumbItem extends SvelteComponentTyped<

--- a/types/Breadcrumb/BreadcrumbSkeleton.svelte.d.ts
+++ b/types/Breadcrumb/BreadcrumbSkeleton.svelte.d.ts
@@ -14,6 +14,8 @@ export interface BreadcrumbSkeletonProps
    * @default 3
    */
   count?: number;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class BreadcrumbSkeleton extends SvelteComponentTyped<

--- a/types/Button/Button.svelte.d.ts
+++ b/types/Button/Button.svelte.d.ts
@@ -105,6 +105,8 @@ export interface ButtonProps
    * @default null
    */
   ref?: null | HTMLAnchorElement | HTMLButtonElement;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class Button extends SvelteComponentTyped<

--- a/types/Button/ButtonSet.svelte.d.ts
+++ b/types/Button/ButtonSet.svelte.d.ts
@@ -8,6 +8,8 @@ export interface ButtonSetProps
    * @default false
    */
   stacked?: boolean;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class ButtonSet extends SvelteComponentTyped<

--- a/types/Button/ButtonSkeleton.svelte.d.ts
+++ b/types/Button/ButtonSkeleton.svelte.d.ts
@@ -14,6 +14,8 @@ export interface ButtonSkeletonProps
    * @default "default"
    */
   size?: "default" | "field" | "small" | "lg" | "xl";
+
+  [key: `data-${string}`]: any;
 }
 
 export default class ButtonSkeleton extends SvelteComponentTyped<

--- a/types/Checkbox/Checkbox.svelte.d.ts
+++ b/types/Checkbox/Checkbox.svelte.d.ts
@@ -86,6 +86,8 @@ export interface CheckboxProps
    * @default null
    */
   ref?: null | HTMLInputElement;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class Checkbox extends SvelteComponentTyped<

--- a/types/Checkbox/CheckboxSkeleton.svelte.d.ts
+++ b/types/Checkbox/CheckboxSkeleton.svelte.d.ts
@@ -2,7 +2,9 @@
 import type { SvelteComponentTyped } from "svelte";
 
 export interface CheckboxSkeletonProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {}
+  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+  [key: `data-${string}`]: any;
+}
 
 export default class CheckboxSkeleton extends SvelteComponentTyped<
   CheckboxSkeletonProps,

--- a/types/CodeSnippet/CodeSnippetSkeleton.svelte.d.ts
+++ b/types/CodeSnippet/CodeSnippetSkeleton.svelte.d.ts
@@ -8,6 +8,8 @@ export interface CodeSnippetSkeletonProps
    * @default "single"
    */
   type?: "single" | "multi";
+
+  [key: `data-${string}`]: any;
 }
 
 export default class CodeSnippetSkeleton extends SvelteComponentTyped<

--- a/types/ComboBox/ComboBox.svelte.d.ts
+++ b/types/ComboBox/ComboBox.svelte.d.ts
@@ -152,6 +152,8 @@ export interface ComboBoxProps
    * @default null
    */
   listRef?: null | HTMLDivElement;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class ComboBox extends SvelteComponentTyped<

--- a/types/ComposedModal/ComposedModal.svelte.d.ts
+++ b/types/ComposedModal/ComposedModal.svelte.d.ts
@@ -44,6 +44,8 @@ export interface ComposedModalProps
    * @default null
    */
   ref?: null | HTMLDivElement;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class ComposedModal extends SvelteComponentTyped<

--- a/types/ComposedModal/ModalBody.svelte.d.ts
+++ b/types/ComposedModal/ModalBody.svelte.d.ts
@@ -14,6 +14,8 @@ export interface ModalBodyProps
    * @default false
    */
   hasScrollingContent?: boolean;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class ModalBody extends SvelteComponentTyped<

--- a/types/ComposedModal/ModalFooter.svelte.d.ts
+++ b/types/ComposedModal/ModalFooter.svelte.d.ts
@@ -51,6 +51,8 @@ export interface ModalFooterProps
    * @default false
    */
   danger?: boolean;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class ModalFooter extends SvelteComponentTyped<

--- a/types/ComposedModal/ModalHeader.svelte.d.ts
+++ b/types/ComposedModal/ModalHeader.svelte.d.ts
@@ -44,6 +44,8 @@ export interface ModalHeaderProps
    * @default "Close"
    */
   iconDescription?: string;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class ModalHeader extends SvelteComponentTyped<

--- a/types/ContentSwitcher/ContentSwitcher.svelte.d.ts
+++ b/types/ContentSwitcher/ContentSwitcher.svelte.d.ts
@@ -14,6 +14,8 @@ export interface ContentSwitcherProps
    * @default undefined
    */
   size?: "sm" | "xl";
+
+  [key: `data-${string}`]: any;
 }
 
 export default class ContentSwitcher extends SvelteComponentTyped<

--- a/types/ContentSwitcher/Switch.svelte.d.ts
+++ b/types/ContentSwitcher/Switch.svelte.d.ts
@@ -33,6 +33,8 @@ export interface SwitchProps
    * @default null
    */
   ref?: null | HTMLButtonElement;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class Switch extends SvelteComponentTyped<

--- a/types/ContextMenu/ContextMenu.svelte.d.ts
+++ b/types/ContextMenu/ContextMenu.svelte.d.ts
@@ -34,6 +34,8 @@ export interface ContextMenuProps
    * @default null
    */
   ref?: null | HTMLUListElement;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class ContextMenu extends SvelteComponentTyped<

--- a/types/ContextMenu/ContextMenuOption.svelte.d.ts
+++ b/types/ContextMenu/ContextMenuOption.svelte.d.ts
@@ -67,6 +67,8 @@ export interface ContextMenuOptionProps
    * @default null
    */
   ref?: null | HTMLLIElement;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class ContextMenuOption extends SvelteComponentTyped<

--- a/types/CopyButton/CopyButton.svelte.d.ts
+++ b/types/CopyButton/CopyButton.svelte.d.ts
@@ -32,6 +32,8 @@ export interface CopyButtonProps
    * @default async (text) => { try { await navigator.clipboard.writeText(text); } catch (e) { console.log(e); } }
    */
   copy?: (text: string) => void;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class CopyButton extends SvelteComponentTyped<

--- a/types/DataTable/DataTable.svelte.d.ts
+++ b/types/DataTable/DataTable.svelte.d.ts
@@ -176,6 +176,8 @@ export interface DataTableProps
    * @default 0
    */
   page?: number;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class DataTable extends SvelteComponentTyped<

--- a/types/DataTable/DataTableSkeleton.svelte.d.ts
+++ b/types/DataTable/DataTableSkeleton.svelte.d.ts
@@ -48,6 +48,8 @@ export interface DataTableSkeletonProps
    * @default true
    */
   showToolbar?: boolean;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class DataTableSkeleton extends SvelteComponentTyped<

--- a/types/DataTable/Table.svelte.d.ts
+++ b/types/DataTable/Table.svelte.d.ts
@@ -38,6 +38,8 @@ export interface TableProps
    * @default undefined
    */
   tableStyle?: string;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class Table extends SvelteComponentTyped<

--- a/types/DataTable/TableBody.svelte.d.ts
+++ b/types/DataTable/TableBody.svelte.d.ts
@@ -2,7 +2,9 @@
 import type { SvelteComponentTyped } from "svelte";
 
 export interface TableBodyProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["tbody"]> {}
+  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["tbody"]> {
+  [key: `data-${string}`]: any;
+}
 
 export default class TableBody extends SvelteComponentTyped<
   TableBodyProps,

--- a/types/DataTable/TableCell.svelte.d.ts
+++ b/types/DataTable/TableCell.svelte.d.ts
@@ -2,7 +2,9 @@
 import type { SvelteComponentTyped } from "svelte";
 
 export interface TableCellProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["td"]> {}
+  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["td"]> {
+  [key: `data-${string}`]: any;
+}
 
 export default class TableCell extends SvelteComponentTyped<
   TableCellProps,

--- a/types/DataTable/TableContainer.svelte.d.ts
+++ b/types/DataTable/TableContainer.svelte.d.ts
@@ -26,6 +26,8 @@ export interface TableContainerProps
    * @default false
    */
   useStaticWidth?: boolean;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class TableContainer extends SvelteComponentTyped<

--- a/types/DataTable/TableHead.svelte.d.ts
+++ b/types/DataTable/TableHead.svelte.d.ts
@@ -2,7 +2,9 @@
 import type { SvelteComponentTyped } from "svelte";
 
 export interface TableHeadProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["thead"]> {}
+  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["thead"]> {
+  [key: `data-${string}`]: any;
+}
 
 export default class TableHead extends SvelteComponentTyped<
   TableHeadProps,

--- a/types/DataTable/TableHeader.svelte.d.ts
+++ b/types/DataTable/TableHeader.svelte.d.ts
@@ -38,6 +38,8 @@ export interface TableHeaderProps
    * @default "ccs-" + Math.random().toString(36)
    */
   id?: string;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class TableHeader extends SvelteComponentTyped<

--- a/types/DataTable/TableRow.svelte.d.ts
+++ b/types/DataTable/TableRow.svelte.d.ts
@@ -2,7 +2,9 @@
 import type { SvelteComponentTyped } from "svelte";
 
 export interface TableRowProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["tr"]> {}
+  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["tr"]> {
+  [key: `data-${string}`]: any;
+}
 
 export default class TableRow extends SvelteComponentTyped<
   TableRowProps,

--- a/types/DataTable/Toolbar.svelte.d.ts
+++ b/types/DataTable/Toolbar.svelte.d.ts
@@ -8,6 +8,8 @@ export interface ToolbarProps
    * @default "default"
    */
   size?: "sm" | "default";
+
+  [key: `data-${string}`]: any;
 }
 
 export default class Toolbar extends SvelteComponentTyped<

--- a/types/DataTable/ToolbarBatchActions.svelte.d.ts
+++ b/types/DataTable/ToolbarBatchActions.svelte.d.ts
@@ -14,6 +14,8 @@ export interface ToolbarBatchActionsProps
    * @default undefined
    */
   active?: undefined | boolean;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class ToolbarBatchActions extends SvelteComponentTyped<

--- a/types/DataTable/ToolbarSearch.svelte.d.ts
+++ b/types/DataTable/ToolbarSearch.svelte.d.ts
@@ -61,6 +61,8 @@ export interface ToolbarSearchProps
    * @default null
    */
   ref?: null | HTMLInputElement;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class ToolbarSearch extends SvelteComponentTyped<

--- a/types/DatePicker/DatePicker.svelte.d.ts
+++ b/types/DatePicker/DatePicker.svelte.d.ts
@@ -79,6 +79,8 @@ export interface DatePickerProps
    * @default { static: true }
    */
   flatpickrProps?: import("flatpickr/dist/types/options").Options;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class DatePicker extends SvelteComponentTyped<

--- a/types/DatePicker/DatePickerInput.svelte.d.ts
+++ b/types/DatePicker/DatePickerInput.svelte.d.ts
@@ -98,6 +98,8 @@ export interface DatePickerInputProps
    * @default null
    */
   ref?: null | HTMLInputElement;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class DatePickerInput extends SvelteComponentTyped<

--- a/types/DatePicker/DatePickerSkeleton.svelte.d.ts
+++ b/types/DatePicker/DatePickerSkeleton.svelte.d.ts
@@ -14,6 +14,8 @@ export interface DatePickerSkeletonProps
    * @default "ccs-" + Math.random().toString(36)
    */
   id?: string;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class DatePickerSkeleton extends SvelteComponentTyped<

--- a/types/Dropdown/Dropdown.svelte.d.ts
+++ b/types/Dropdown/Dropdown.svelte.d.ts
@@ -141,6 +141,8 @@ export interface DropdownProps
    * @default null
    */
   ref?: null | HTMLButtonElement;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class Dropdown extends SvelteComponentTyped<

--- a/types/Dropdown/DropdownSkeleton.svelte.d.ts
+++ b/types/Dropdown/DropdownSkeleton.svelte.d.ts
@@ -8,6 +8,8 @@ export interface DropdownSkeletonProps
    * @default false
    */
   inline?: boolean;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class DropdownSkeleton extends SvelteComponentTyped<

--- a/types/FileUploader/FileUploader.svelte.d.ts
+++ b/types/FileUploader/FileUploader.svelte.d.ts
@@ -68,6 +68,8 @@ export interface FileUploaderProps
    * @default ""
    */
   name?: string;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class FileUploader extends SvelteComponentTyped<

--- a/types/FileUploader/FileUploaderButton.svelte.d.ts
+++ b/types/FileUploader/FileUploaderButton.svelte.d.ts
@@ -74,6 +74,8 @@ export interface FileUploaderButtonProps
    * @default null
    */
   ref?: null | HTMLInputElement;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class FileUploaderButton extends SvelteComponentTyped<

--- a/types/FileUploader/FileUploaderDropContainer.svelte.d.ts
+++ b/types/FileUploader/FileUploaderDropContainer.svelte.d.ts
@@ -69,6 +69,8 @@ export interface FileUploaderDropContainerProps
    * @default null
    */
   ref?: null | HTMLInputElement;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class FileUploaderDropContainer extends SvelteComponentTyped<

--- a/types/FileUploader/FileUploaderItem.svelte.d.ts
+++ b/types/FileUploader/FileUploaderItem.svelte.d.ts
@@ -50,6 +50,8 @@ export interface FileUploaderItemProps
    * @default ""
    */
   name?: string;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class FileUploaderItem extends SvelteComponentTyped<

--- a/types/FileUploader/FileUploaderSkeleton.svelte.d.ts
+++ b/types/FileUploader/FileUploaderSkeleton.svelte.d.ts
@@ -2,7 +2,9 @@
 import type { SvelteComponentTyped } from "svelte";
 
 export interface FileUploaderSkeletonProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {}
+  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+  [key: `data-${string}`]: any;
+}
 
 export default class FileUploaderSkeleton extends SvelteComponentTyped<
   FileUploaderSkeletonProps,

--- a/types/FileUploader/Filename.svelte.d.ts
+++ b/types/FileUploader/Filename.svelte.d.ts
@@ -22,6 +22,8 @@ export interface FilenameProps
    * @default false
    */
   invalid?: boolean;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class Filename extends SvelteComponentTyped<

--- a/types/FluidForm/FluidForm.svelte.d.ts
+++ b/types/FluidForm/FluidForm.svelte.d.ts
@@ -2,7 +2,9 @@
 import type { SvelteComponentTyped } from "svelte";
 
 export interface FluidFormProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["form"]> {}
+  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["form"]> {
+  [key: `data-${string}`]: any;
+}
 
 export default class FluidForm extends SvelteComponentTyped<
   FluidFormProps,

--- a/types/Form/Form.svelte.d.ts
+++ b/types/Form/Form.svelte.d.ts
@@ -8,6 +8,8 @@ export interface FormProps
    * @default null
    */
   ref?: null | HTMLFormElement;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class Form extends SvelteComponentTyped<

--- a/types/FormGroup/FormGroup.svelte.d.ts
+++ b/types/FormGroup/FormGroup.svelte.d.ts
@@ -38,6 +38,8 @@ export interface FormGroupProps
    * @default ""
    */
   legendId?: string;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class FormGroup extends SvelteComponentTyped<

--- a/types/FormItem/FormItem.svelte.d.ts
+++ b/types/FormItem/FormItem.svelte.d.ts
@@ -2,7 +2,9 @@
 import type { SvelteComponentTyped } from "svelte";
 
 export interface FormItemProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {}
+  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+  [key: `data-${string}`]: any;
+}
 
 export default class FormItem extends SvelteComponentTyped<
   FormItemProps,

--- a/types/FormLabel/FormLabel.svelte.d.ts
+++ b/types/FormLabel/FormLabel.svelte.d.ts
@@ -8,6 +8,8 @@ export interface FormLabelProps
    * @default "ccs-" + Math.random().toString(36)
    */
   id?: string;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class FormLabel extends SvelteComponentTyped<

--- a/types/Grid/Column.svelte.d.ts
+++ b/types/Grid/Column.svelte.d.ts
@@ -78,6 +78,8 @@ export interface ColumnProps
    * @default undefined
    */
   max?: ColumnBreakpoint;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class Column extends SvelteComponentTyped<

--- a/types/Grid/Grid.svelte.d.ts
+++ b/types/Grid/Grid.svelte.d.ts
@@ -51,6 +51,8 @@ export interface GridProps
    * @default false
    */
   padding?: boolean;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class Grid extends SvelteComponentTyped<

--- a/types/Grid/Row.svelte.d.ts
+++ b/types/Grid/Row.svelte.d.ts
@@ -45,6 +45,8 @@ export interface RowProps
    * @default false
    */
   padding?: boolean;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class Row extends SvelteComponentTyped<

--- a/types/ImageLoader/ImageLoader.svelte.d.ts
+++ b/types/ImageLoader/ImageLoader.svelte.d.ts
@@ -45,6 +45,8 @@ export interface ImageLoaderProps
    * @default false
    */
   fadeIn?: boolean;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class ImageLoader extends SvelteComponentTyped<

--- a/types/InlineLoading/InlineLoading.svelte.d.ts
+++ b/types/InlineLoading/InlineLoading.svelte.d.ts
@@ -26,6 +26,8 @@ export interface InlineLoadingProps
    * @default 1500
    */
   successDelay?: number;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class InlineLoading extends SvelteComponentTyped<

--- a/types/Link/Link.svelte.d.ts
+++ b/types/Link/Link.svelte.d.ts
@@ -46,6 +46,8 @@ export interface LinkProps
    * @default null
    */
   ref?: null | HTMLAnchorElement | HTMLParagraphElement;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class Link extends SvelteComponentTyped<

--- a/types/ListBox/ListBox.svelte.d.ts
+++ b/types/ListBox/ListBox.svelte.d.ts
@@ -56,6 +56,8 @@ export interface ListBoxProps
    * @default ""
    */
   warnText?: string;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class ListBox extends SvelteComponentTyped<

--- a/types/ListBox/ListBoxField.svelte.d.ts
+++ b/types/ListBox/ListBoxField.svelte.d.ts
@@ -40,6 +40,8 @@ export interface ListBoxFieldProps
    * @default null
    */
   ref?: null | HTMLDivElement;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class ListBoxField extends SvelteComponentTyped<

--- a/types/ListBox/ListBoxMenu.svelte.d.ts
+++ b/types/ListBox/ListBoxMenu.svelte.d.ts
@@ -14,6 +14,8 @@ export interface ListBoxMenuProps
    * @default null
    */
   ref?: null | HTMLDivElement;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class ListBoxMenu extends SvelteComponentTyped<

--- a/types/ListBox/ListBoxMenuIcon.svelte.d.ts
+++ b/types/ListBox/ListBoxMenuIcon.svelte.d.ts
@@ -16,6 +16,8 @@ export interface ListBoxMenuIconProps
    * @default (id) => defaultTranslations[id]
    */
   translateWithId?: (id: ListBoxMenuIconTranslationId) => string;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class ListBoxMenuIcon extends SvelteComponentTyped<

--- a/types/ListBox/ListBoxMenuItem.svelte.d.ts
+++ b/types/ListBox/ListBoxMenuItem.svelte.d.ts
@@ -20,6 +20,8 @@ export interface ListBoxMenuItemProps
    * @default false
    */
   disabled?: boolean;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class ListBoxMenuItem extends SvelteComponentTyped<

--- a/types/ListBox/ListBoxSelection.svelte.d.ts
+++ b/types/ListBox/ListBoxSelection.svelte.d.ts
@@ -28,6 +28,8 @@ export interface ListBoxSelectionProps
    * @default null
    */
   ref?: null | HTMLDivElement;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class ListBoxSelection extends SvelteComponentTyped<

--- a/types/ListItem/ListItem.svelte.d.ts
+++ b/types/ListItem/ListItem.svelte.d.ts
@@ -2,7 +2,9 @@
 import type { SvelteComponentTyped } from "svelte";
 
 export interface ListItemProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["li"]> {}
+  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["li"]> {
+  [key: `data-${string}`]: any;
+}
 
 export default class ListItem extends SvelteComponentTyped<
   ListItemProps,

--- a/types/Loading/Loading.svelte.d.ts
+++ b/types/Loading/Loading.svelte.d.ts
@@ -32,6 +32,8 @@ export interface LoadingProps
    * @default "ccs-" + Math.random().toString(36)
    */
   id?: string;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class Loading extends SvelteComponentTyped<

--- a/types/Modal/Modal.svelte.d.ts
+++ b/types/Modal/Modal.svelte.d.ts
@@ -130,6 +130,8 @@ export interface ModalProps
    * @default null
    */
   ref?: null | HTMLDivElement;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class Modal extends SvelteComponentTyped<

--- a/types/MultiSelect/MultiSelect.svelte.d.ts
+++ b/types/MultiSelect/MultiSelect.svelte.d.ts
@@ -236,6 +236,8 @@ export interface MultiSelectProps
    * @default null
    */
   highlightedId?: null | MultiSelectItemId;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class MultiSelect extends SvelteComponentTyped<

--- a/types/Notification/InlineNotification.svelte.d.ts
+++ b/types/Notification/InlineNotification.svelte.d.ts
@@ -62,6 +62,8 @@ export interface InlineNotificationProps
    * @default "Close notification"
    */
   closeButtonDescription?: string;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class InlineNotification extends SvelteComponentTyped<

--- a/types/Notification/NotificationButton.svelte.d.ts
+++ b/types/Notification/NotificationButton.svelte.d.ts
@@ -26,6 +26,8 @@ export interface NotificationButtonProps
    * @default "Close icon"
    */
   iconDescription?: string;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class NotificationButton extends SvelteComponentTyped<

--- a/types/Notification/ToastNotification.svelte.d.ts
+++ b/types/Notification/ToastNotification.svelte.d.ts
@@ -75,6 +75,8 @@ export interface ToastNotificationProps
    * @default false
    */
   fullWidth?: boolean;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class ToastNotification extends SvelteComponentTyped<

--- a/types/NumberInput/NumberInput.svelte.d.ts
+++ b/types/NumberInput/NumberInput.svelte.d.ts
@@ -137,6 +137,8 @@ export interface NumberInputProps
    * @default null
    */
   ref?: null | HTMLInputElement;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class NumberInput extends SvelteComponentTyped<

--- a/types/NumberInput/NumberInputSkeleton.svelte.d.ts
+++ b/types/NumberInput/NumberInputSkeleton.svelte.d.ts
@@ -8,6 +8,8 @@ export interface NumberInputSkeletonProps
    * @default false
    */
   hideLabel?: boolean;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class NumberInputSkeleton extends SvelteComponentTyped<

--- a/types/OrderedList/OrderedList.svelte.d.ts
+++ b/types/OrderedList/OrderedList.svelte.d.ts
@@ -20,6 +20,8 @@ export interface OrderedListProps
    * @default false
    */
   expressive?: boolean;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class OrderedList extends SvelteComponentTyped<

--- a/types/OverflowMenu/OverflowMenu.svelte.d.ts
+++ b/types/OverflowMenu/OverflowMenu.svelte.d.ts
@@ -75,6 +75,8 @@ export interface OverflowMenuProps
    * @default null
    */
   menuRef?: null | HTMLUListElement;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class OverflowMenu extends SvelteComponentTyped<

--- a/types/OverflowMenu/OverflowMenuItem.svelte.d.ts
+++ b/types/OverflowMenu/OverflowMenuItem.svelte.d.ts
@@ -57,6 +57,8 @@ export interface OverflowMenuItemProps
    * @default null
    */
   ref?: null | HTMLAnchorElement | HTMLButtonElement;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class OverflowMenuItem extends SvelteComponentTyped<

--- a/types/Pagination/Pagination.svelte.d.ts
+++ b/types/Pagination/Pagination.svelte.d.ts
@@ -98,6 +98,8 @@ export interface PaginationProps
    * @default "ccs-" + Math.random().toString(36)
    */
   id?: string;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class Pagination extends SvelteComponentTyped<

--- a/types/Pagination/PaginationSkeleton.svelte.d.ts
+++ b/types/Pagination/PaginationSkeleton.svelte.d.ts
@@ -2,7 +2,9 @@
 import type { SvelteComponentTyped } from "svelte";
 
 export interface PaginationSkeletonProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {}
+  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+  [key: `data-${string}`]: any;
+}
 
 export default class PaginationSkeleton extends SvelteComponentTyped<
   PaginationSkeletonProps,

--- a/types/PaginationNav/PaginationNav.svelte.d.ts
+++ b/types/PaginationNav/PaginationNav.svelte.d.ts
@@ -44,6 +44,8 @@ export interface PaginationNavProps
    * @default "bottom"
    */
   tooltipPosition?: "top" | "right" | "bottom" | "left" | "outside" | "inside";
+
+  [key: `data-${string}`]: any;
 }
 
 export default class PaginationNav extends SvelteComponentTyped<

--- a/types/Popover/Popover.svelte.d.ts
+++ b/types/Popover/Popover.svelte.d.ts
@@ -56,6 +56,8 @@ export interface PopoverProps
    * @default false
    */
   relative?: boolean;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class Popover extends SvelteComponentTyped<

--- a/types/ProgressBar/ProgressBar.svelte.d.ts
+++ b/types/ProgressBar/ProgressBar.svelte.d.ts
@@ -56,6 +56,8 @@ export interface ProgressBarProps
    * @default "ccs-" + Math.random().toString(36)
    */
   id?: string;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class ProgressBar extends SvelteComponentTyped<

--- a/types/ProgressIndicator/ProgressIndicator.svelte.d.ts
+++ b/types/ProgressIndicator/ProgressIndicator.svelte.d.ts
@@ -26,6 +26,8 @@ export interface ProgressIndicatorProps
    * @default false
    */
   preventChangeOnClick?: boolean;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class ProgressIndicator extends SvelteComponentTyped<

--- a/types/ProgressIndicator/ProgressIndicatorSkeleton.svelte.d.ts
+++ b/types/ProgressIndicator/ProgressIndicatorSkeleton.svelte.d.ts
@@ -14,6 +14,8 @@ export interface ProgressIndicatorSkeletonProps
    * @default 4
    */
   count?: number;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class ProgressIndicatorSkeleton extends SvelteComponentTyped<

--- a/types/ProgressIndicator/ProgressStep.svelte.d.ts
+++ b/types/ProgressIndicator/ProgressStep.svelte.d.ts
@@ -50,6 +50,8 @@ export interface ProgressStepProps
    * @default "ccs-" + Math.random().toString(36)
    */
   id?: string;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class ProgressStep extends SvelteComponentTyped<

--- a/types/RadioButton/RadioButton.svelte.d.ts
+++ b/types/RadioButton/RadioButton.svelte.d.ts
@@ -62,6 +62,8 @@ export interface RadioButtonProps
    * @default null
    */
   ref?: null | HTMLInputElement;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class RadioButton extends SvelteComponentTyped<

--- a/types/RadioButton/RadioButtonSkeleton.svelte.d.ts
+++ b/types/RadioButton/RadioButtonSkeleton.svelte.d.ts
@@ -2,7 +2,9 @@
 import type { SvelteComponentTyped } from "svelte";
 
 export interface RadioButtonSkeletonProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {}
+  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+  [key: `data-${string}`]: any;
+}
 
 export default class RadioButtonSkeleton extends SvelteComponentTyped<
   RadioButtonSkeletonProps,

--- a/types/RadioButtonGroup/RadioButtonGroup.svelte.d.ts
+++ b/types/RadioButtonGroup/RadioButtonGroup.svelte.d.ts
@@ -44,6 +44,8 @@ export interface RadioButtonGroupProps
    * @default undefined
    */
   id?: string;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class RadioButtonGroup extends SvelteComponentTyped<

--- a/types/RecursiveList/RecursiveList.svelte.d.ts
+++ b/types/RecursiveList/RecursiveList.svelte.d.ts
@@ -21,6 +21,8 @@ export interface RecursiveListProps
    * @default "unordered"
    */
   type?: "unordered" | "ordered" | "ordered-native";
+
+  [key: `data-${string}`]: any;
 }
 
 export default class RecursiveList extends SvelteComponentTyped<

--- a/types/Search/Search.svelte.d.ts
+++ b/types/Search/Search.svelte.d.ts
@@ -99,6 +99,8 @@ export interface SearchProps
    * @default null
    */
   ref?: null | HTMLInputElement;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class Search extends SvelteComponentTyped<

--- a/types/Search/SearchSkeleton.svelte.d.ts
+++ b/types/Search/SearchSkeleton.svelte.d.ts
@@ -8,6 +8,8 @@ export interface SearchSkeletonProps
    * @default "xl"
    */
   size?: "sm" | "lg" | "xl";
+
+  [key: `data-${string}`]: any;
 }
 
 export default class SearchSkeleton extends SvelteComponentTyped<

--- a/types/Select/Select.svelte.d.ts
+++ b/types/Select/Select.svelte.d.ts
@@ -104,6 +104,8 @@ export interface SelectProps
    * @default false
    */
   required?: boolean;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class Select extends SvelteComponentTyped<

--- a/types/Select/SelectItemGroup.svelte.d.ts
+++ b/types/Select/SelectItemGroup.svelte.d.ts
@@ -14,6 +14,8 @@ export interface SelectItemGroupProps
    * @default "Provide label"
    */
   label?: string;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class SelectItemGroup extends SvelteComponentTyped<

--- a/types/Select/SelectSkeleton.svelte.d.ts
+++ b/types/Select/SelectSkeleton.svelte.d.ts
@@ -8,6 +8,8 @@ export interface SelectSkeletonProps
    * @default false
    */
   hideLabel?: boolean;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class SelectSkeleton extends SvelteComponentTyped<

--- a/types/SkeletonPlaceholder/SkeletonPlaceholder.svelte.d.ts
+++ b/types/SkeletonPlaceholder/SkeletonPlaceholder.svelte.d.ts
@@ -2,7 +2,9 @@
 import type { SvelteComponentTyped } from "svelte";
 
 export interface SkeletonPlaceholderProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {}
+  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+  [key: `data-${string}`]: any;
+}
 
 export default class SkeletonPlaceholder extends SvelteComponentTyped<
   SkeletonPlaceholderProps,

--- a/types/SkeletonText/SkeletonText.svelte.d.ts
+++ b/types/SkeletonText/SkeletonText.svelte.d.ts
@@ -26,6 +26,8 @@ export interface SkeletonTextProps
    * @default "100%"
    */
   width?: string;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class SkeletonText extends SvelteComponentTyped<

--- a/types/Slider/Slider.svelte.d.ts
+++ b/types/Slider/Slider.svelte.d.ts
@@ -111,6 +111,8 @@ export interface SliderProps
    * @default null
    */
   ref?: null | HTMLDivElement;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class Slider extends SvelteComponentTyped<

--- a/types/Slider/SliderSkeleton.svelte.d.ts
+++ b/types/Slider/SliderSkeleton.svelte.d.ts
@@ -8,6 +8,8 @@ export interface SliderSkeletonProps
    * @default false
    */
   hideLabel?: boolean;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class SliderSkeleton extends SvelteComponentTyped<

--- a/types/StructuredList/StructuredList.svelte.d.ts
+++ b/types/StructuredList/StructuredList.svelte.d.ts
@@ -26,6 +26,8 @@ export interface StructuredListProps
    * @default false
    */
   selection?: boolean;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class StructuredList extends SvelteComponentTyped<

--- a/types/StructuredList/StructuredListBody.svelte.d.ts
+++ b/types/StructuredList/StructuredListBody.svelte.d.ts
@@ -2,7 +2,9 @@
 import type { SvelteComponentTyped } from "svelte";
 
 export interface StructuredListBodyProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {}
+  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+  [key: `data-${string}`]: any;
+}
 
 export default class StructuredListBody extends SvelteComponentTyped<
   StructuredListBodyProps,

--- a/types/StructuredList/StructuredListCell.svelte.d.ts
+++ b/types/StructuredList/StructuredListCell.svelte.d.ts
@@ -14,6 +14,8 @@ export interface StructuredListCellProps
    * @default false
    */
   noWrap?: boolean;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class StructuredListCell extends SvelteComponentTyped<

--- a/types/StructuredList/StructuredListHead.svelte.d.ts
+++ b/types/StructuredList/StructuredListHead.svelte.d.ts
@@ -2,7 +2,9 @@
 import type { SvelteComponentTyped } from "svelte";
 
 export interface StructuredListHeadProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {}
+  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["div"]> {
+  [key: `data-${string}`]: any;
+}
 
 export default class StructuredListHead extends SvelteComponentTyped<
   StructuredListHeadProps,

--- a/types/StructuredList/StructuredListInput.svelte.d.ts
+++ b/types/StructuredList/StructuredListInput.svelte.d.ts
@@ -38,6 +38,8 @@ export interface StructuredListInputProps
    * @default null
    */
   ref?: null | HTMLInputElement;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class StructuredListInput extends SvelteComponentTyped<

--- a/types/StructuredList/StructuredListRow.svelte.d.ts
+++ b/types/StructuredList/StructuredListRow.svelte.d.ts
@@ -20,6 +20,8 @@ export interface StructuredListRowProps
    * @default "0"
    */
   tabindex?: string;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class StructuredListRow extends SvelteComponentTyped<

--- a/types/StructuredList/StructuredListSkeleton.svelte.d.ts
+++ b/types/StructuredList/StructuredListSkeleton.svelte.d.ts
@@ -8,6 +8,8 @@ export interface StructuredListSkeletonProps
    * @default 5
    */
   rows?: number;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class StructuredListSkeleton extends SvelteComponentTyped<

--- a/types/Tabs/Tab.svelte.d.ts
+++ b/types/Tabs/Tab.svelte.d.ts
@@ -39,6 +39,8 @@ export interface TabProps
    * @default null
    */
   ref?: null | HTMLAnchorElement;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class Tab extends SvelteComponentTyped<

--- a/types/Tabs/TabContent.svelte.d.ts
+++ b/types/Tabs/TabContent.svelte.d.ts
@@ -8,6 +8,8 @@ export interface TabContentProps
    * @default "ccs-" + Math.random().toString(36)
    */
   id?: string;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class TabContent extends SvelteComponentTyped<

--- a/types/Tabs/Tabs.svelte.d.ts
+++ b/types/Tabs/Tabs.svelte.d.ts
@@ -32,6 +32,8 @@ export interface TabsProps
    * @default "#"
    */
   triggerHref?: string;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class Tabs extends SvelteComponentTyped<

--- a/types/Tabs/TabsSkeleton.svelte.d.ts
+++ b/types/Tabs/TabsSkeleton.svelte.d.ts
@@ -14,6 +14,8 @@ export interface TabsSkeletonProps
    * @default "default"
    */
   type?: "default" | "container";
+
+  [key: `data-${string}`]: any;
 }
 
 export default class TabsSkeleton extends SvelteComponentTyped<

--- a/types/Tag/Tag.svelte.d.ts
+++ b/types/Tag/Tag.svelte.d.ts
@@ -68,6 +68,8 @@ export interface TagProps
    * @default "ccs-" + Math.random().toString(36)
    */
   id?: string;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class Tag extends SvelteComponentTyped<

--- a/types/Tag/TagSkeleton.svelte.d.ts
+++ b/types/Tag/TagSkeleton.svelte.d.ts
@@ -7,6 +7,8 @@ export interface TagSkeletonProps
    * @default "default"
    */
   size?: "sm" | "default";
+
+  [key: `data-${string}`]: any;
 }
 
 export default class TagSkeleton extends SvelteComponentTyped<

--- a/types/TextArea/TextArea.svelte.d.ts
+++ b/types/TextArea/TextArea.svelte.d.ts
@@ -98,6 +98,8 @@ export interface TextAreaProps
    * @default null
    */
   ref?: null | HTMLTextAreaElement;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class TextArea extends SvelteComponentTyped<

--- a/types/TextArea/TextAreaSkeleton.svelte.d.ts
+++ b/types/TextArea/TextAreaSkeleton.svelte.d.ts
@@ -8,6 +8,8 @@ export interface TextAreaSkeletonProps
    * @default false
    */
   hideLabel?: boolean;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class TextAreaSkeleton extends SvelteComponentTyped<

--- a/types/TextInput/PasswordInput.svelte.d.ts
+++ b/types/TextInput/PasswordInput.svelte.d.ts
@@ -128,6 +128,8 @@ export interface PasswordInputProps
    * @default null
    */
   ref?: null | HTMLInputElement;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class PasswordInput extends SvelteComponentTyped<

--- a/types/TextInput/TextInput.svelte.d.ts
+++ b/types/TextInput/TextInput.svelte.d.ts
@@ -113,6 +113,8 @@ export interface TextInputProps
    * @default false
    */
   readonly?: boolean;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class TextInput extends SvelteComponentTyped<

--- a/types/TextInput/TextInputSkeleton.svelte.d.ts
+++ b/types/TextInput/TextInputSkeleton.svelte.d.ts
@@ -8,6 +8,8 @@ export interface TextInputSkeletonProps
    * @default false
    */
   hideLabel?: boolean;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class TextInputSkeleton extends SvelteComponentTyped<

--- a/types/Tile/ClickableTile.svelte.d.ts
+++ b/types/Tile/ClickableTile.svelte.d.ts
@@ -27,6 +27,8 @@ export interface ClickableTileProps
    * @default undefined
    */
   href?: string;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class ClickableTile extends SvelteComponentTyped<

--- a/types/Tile/ExpandableTile.svelte.d.ts
+++ b/types/Tile/ExpandableTile.svelte.d.ts
@@ -68,6 +68,8 @@ export interface ExpandableTileProps
    * @default null
    */
   ref?: null | HTMLButtonElement;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class ExpandableTile extends SvelteComponentTyped<

--- a/types/Tile/RadioTile.svelte.d.ts
+++ b/types/Tile/RadioTile.svelte.d.ts
@@ -50,6 +50,8 @@ export interface RadioTileProps
    * @default ""
    */
   name?: string;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class RadioTile extends SvelteComponentTyped<

--- a/types/Tile/SelectableTile.svelte.d.ts
+++ b/types/Tile/SelectableTile.svelte.d.ts
@@ -62,6 +62,8 @@ export interface SelectableTileProps
    * @default null
    */
   ref?: null | HTMLInputElement;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class SelectableTile extends SvelteComponentTyped<

--- a/types/Tile/Tile.svelte.d.ts
+++ b/types/Tile/Tile.svelte.d.ts
@@ -8,6 +8,8 @@ export interface TileProps
    * @default false
    */
   light?: boolean;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class Tile extends SvelteComponentTyped<

--- a/types/Tile/TileGroup.svelte.d.ts
+++ b/types/Tile/TileGroup.svelte.d.ts
@@ -20,6 +20,8 @@ export interface TileGroupProps
    * @default ""
    */
   legend?: string;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class TileGroup extends SvelteComponentTyped<

--- a/types/TimePicker/TimePicker.svelte.d.ts
+++ b/types/TimePicker/TimePicker.svelte.d.ts
@@ -86,6 +86,8 @@ export interface TimePickerProps
    * @default null
    */
   ref?: null | HTMLInputElement;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class TimePicker extends SvelteComponentTyped<

--- a/types/TimePicker/TimePickerSelect.svelte.d.ts
+++ b/types/TimePicker/TimePickerSelect.svelte.d.ts
@@ -44,6 +44,8 @@ export interface TimePickerSelectProps
    * @default null
    */
   ref?: null | HTMLSelectElement;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class TimePickerSelect extends SvelteComponentTyped<

--- a/types/Toggle/Toggle.svelte.d.ts
+++ b/types/Toggle/Toggle.svelte.d.ts
@@ -56,6 +56,8 @@ export interface ToggleProps
    * @default undefined
    */
   name?: string;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class Toggle extends SvelteComponentTyped<

--- a/types/Toggle/ToggleSkeleton.svelte.d.ts
+++ b/types/Toggle/ToggleSkeleton.svelte.d.ts
@@ -20,6 +20,8 @@ export interface ToggleSkeletonProps
    * @default "ccs-" + Math.random().toString(36)
    */
   id?: string;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class ToggleSkeleton extends SvelteComponentTyped<

--- a/types/Tooltip/Tooltip.svelte.d.ts
+++ b/types/Tooltip/Tooltip.svelte.d.ts
@@ -87,6 +87,8 @@ export interface TooltipProps
    * @default null
    */
   refIcon?: null | HTMLDivElement;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class Tooltip extends SvelteComponentTyped<

--- a/types/TooltipDefinition/TooltipDefinition.svelte.d.ts
+++ b/types/TooltipDefinition/TooltipDefinition.svelte.d.ts
@@ -38,6 +38,8 @@ export interface TooltipDefinitionProps
    * @default null
    */
   ref?: null | HTMLButtonElement;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class TooltipDefinition extends SvelteComponentTyped<

--- a/types/TooltipIcon/TooltipIcon.svelte.d.ts
+++ b/types/TooltipIcon/TooltipIcon.svelte.d.ts
@@ -45,6 +45,8 @@ export interface TooltipIconProps
    * @default null
    */
   ref?: null | HTMLButtonElement;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class TooltipIcon extends SvelteComponentTyped<

--- a/types/TreeView/TreeView.svelte.d.ts
+++ b/types/TreeView/TreeView.svelte.d.ts
@@ -55,6 +55,8 @@ export interface TreeViewProps
    * @default false
    */
   hideLabel?: boolean;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class TreeView extends SvelteComponentTyped<

--- a/types/Truncate/Truncate.svelte.d.ts
+++ b/types/Truncate/Truncate.svelte.d.ts
@@ -7,6 +7,8 @@ export interface TruncateProps
    * @default "end"
    */
   clamp?: "end" | "front";
+
+  [key: `data-${string}`]: any;
 }
 
 export default class Truncate extends SvelteComponentTyped<

--- a/types/UIShell/Content.svelte.d.ts
+++ b/types/UIShell/Content.svelte.d.ts
@@ -8,6 +8,8 @@ export interface ContentProps
    * @default "main-content"
    */
   id?: string;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class Content extends SvelteComponentTyped<

--- a/types/UIShell/Header.svelte.d.ts
+++ b/types/UIShell/Header.svelte.d.ts
@@ -77,6 +77,8 @@ export interface HeaderProps
    * @default undefined
    */
   iconClose?: typeof import("svelte").SvelteComponent;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class Header extends SvelteComponentTyped<

--- a/types/UIShell/HeaderAction.svelte.d.ts
+++ b/types/UIShell/HeaderAction.svelte.d.ts
@@ -42,6 +42,8 @@ export interface HeaderActionProps
    * @default { duration: 200 }
    */
   transition?: false | import("svelte/transition").SlideParams;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class HeaderAction extends SvelteComponentTyped<

--- a/types/UIShell/HeaderActionLink.svelte.d.ts
+++ b/types/UIShell/HeaderActionLink.svelte.d.ts
@@ -26,6 +26,8 @@ export interface HeaderActionLinkProps
    * @default null
    */
   ref?: null | HTMLAnchorElement;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class HeaderActionLink extends SvelteComponentTyped<

--- a/types/UIShell/HeaderGlobalAction.svelte.d.ts
+++ b/types/UIShell/HeaderGlobalAction.svelte.d.ts
@@ -20,6 +20,8 @@ export interface HeaderGlobalActionProps
    * @default null
    */
   ref?: null | HTMLButtonElement;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class HeaderGlobalAction extends SvelteComponentTyped<

--- a/types/UIShell/HeaderNav.svelte.d.ts
+++ b/types/UIShell/HeaderNav.svelte.d.ts
@@ -2,7 +2,9 @@
 import type { SvelteComponentTyped } from "svelte";
 
 export interface HeaderNavProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["nav"]> {}
+  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["nav"]> {
+  [key: `data-${string}`]: any;
+}
 
 export default class HeaderNav extends SvelteComponentTyped<
   HeaderNavProps,

--- a/types/UIShell/HeaderNavItem.svelte.d.ts
+++ b/types/UIShell/HeaderNavItem.svelte.d.ts
@@ -26,6 +26,8 @@ export interface HeaderNavItemProps
    * @default null
    */
   ref?: null | HTMLAnchorElement;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class HeaderNavItem extends SvelteComponentTyped<

--- a/types/UIShell/HeaderNavMenu.svelte.d.ts
+++ b/types/UIShell/HeaderNavMenu.svelte.d.ts
@@ -26,6 +26,8 @@ export interface HeaderNavMenuProps
    * @default null
    */
   ref?: null | HTMLAnchorElement;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class HeaderNavMenu extends SvelteComponentTyped<

--- a/types/UIShell/HeaderPanelLink.svelte.d.ts
+++ b/types/UIShell/HeaderPanelLink.svelte.d.ts
@@ -14,6 +14,8 @@ export interface HeaderPanelLinkProps
    * @default null
    */
   ref?: null | HTMLAnchorElement;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class HeaderPanelLink extends SvelteComponentTyped<

--- a/types/UIShell/HeaderSearch.svelte.d.ts
+++ b/types/UIShell/HeaderSearch.svelte.d.ts
@@ -38,6 +38,8 @@ export interface HeaderSearchProps
    * @default 0
    */
   selectedResultIndex?: number;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class HeaderSearch extends SvelteComponentTyped<

--- a/types/UIShell/SideNav.svelte.d.ts
+++ b/types/UIShell/SideNav.svelte.d.ts
@@ -38,6 +38,8 @@ export interface SideNavProps
    * @default 1056
    */
   expansionBreakpoint?: number;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class SideNav extends SvelteComponentTyped<

--- a/types/UIShell/SideNavDivider.svelte.d.ts
+++ b/types/UIShell/SideNavDivider.svelte.d.ts
@@ -2,7 +2,9 @@
 import type { SvelteComponentTyped } from "svelte";
 
 export interface SideNavDividerProps
-  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["li"]> {}
+  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["li"]> {
+  [key: `data-${string}`]: any;
+}
 
 export default class SideNavDivider extends SvelteComponentTyped<
   SideNavDividerProps,

--- a/types/UIShell/SideNavLink.svelte.d.ts
+++ b/types/UIShell/SideNavLink.svelte.d.ts
@@ -32,6 +32,8 @@ export interface SideNavLinkProps
    * @default null
    */
   ref?: null | HTMLAnchorElement;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class SideNavLink extends SvelteComponentTyped<

--- a/types/UIShell/SideNavMenu.svelte.d.ts
+++ b/types/UIShell/SideNavMenu.svelte.d.ts
@@ -26,6 +26,8 @@ export interface SideNavMenuProps
    * @default null
    */
   ref?: null | HTMLButtonElement;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class SideNavMenu extends SvelteComponentTyped<

--- a/types/UIShell/SideNavMenuItem.svelte.d.ts
+++ b/types/UIShell/SideNavMenuItem.svelte.d.ts
@@ -26,6 +26,8 @@ export interface SideNavMenuItemProps
    * @default null
    */
   ref?: null | HTMLAnchorElement;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class SideNavMenuItem extends SvelteComponentTyped<

--- a/types/UIShell/SkipToContent.svelte.d.ts
+++ b/types/UIShell/SkipToContent.svelte.d.ts
@@ -14,6 +14,8 @@ export interface SkipToContentProps
    * @default "0"
    */
   tabindex?: string;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class SkipToContent extends SvelteComponentTyped<

--- a/types/UnorderedList/UnorderedList.svelte.d.ts
+++ b/types/UnorderedList/UnorderedList.svelte.d.ts
@@ -14,6 +14,8 @@ export interface UnorderedListProps
    * @default false
    */
   expressive?: boolean;
+
+  [key: `data-${string}`]: any;
 }
 
 export default class UnorderedList extends SvelteComponentTyped<

--- a/yarn.lock
+++ b/yarn.lock
@@ -1966,10 +1966,10 @@ supports-preserve-symlinks-flag@^1.0.0:
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
-sveld@^0.18.0:
-  version "0.18.0"
-  resolved "https://registry.yarnpkg.com/sveld/-/sveld-0.18.0.tgz#0061232b6edc9ed5df949db6e34d39817cf4dcc4"
-  integrity sha512-J/hwohOIUHibT5Zo7n4jQPjFDm4KxRnRMpl5NU6nzsm/A/2dr1Xls4BPDT0qRyDKMHNz+50fyxlyxCP26S6HLw==
+sveld@^0.18.1:
+  version "0.18.1"
+  resolved "https://registry.yarnpkg.com/sveld/-/sveld-0.18.1.tgz#3357c632732f6bab3fde26dc78ef2d3e706b74e5"
+  integrity sha512-GiVTHdCKbd2abil/oKNeB/tR8wRnvfCElsJ9I04JwVYbdioR6fx4VYb9GKO4X5KXciExyOdgSm551+0MqBCDmA==
   dependencies:
     "@rollup/plugin-node-resolve" "^13.2.1"
     acorn "^8.8.0"


### PR DESCRIPTION
Fixes issue #1740, related PR #1739

Best reviewed by commit.

I [patched `sveld`](https://github.com/carbon-design-system/sveld/releases/tag/v0.18.1) to allow `data-*` attributes to be passed to components that extend HTML elements.

As a result, `data-*` attributes should be valid, while other attributes not included in the HTML attributes or component props should still produce a type error:

<img width="600" alt="Screen Shot 2023-06-04 at 9 52 05 AM" src="https://github.com/carbon-design-system/carbon-components-svelte/assets/10718366/03c49272-5148-474e-8b13-7cd05cc1e99b">
