### PR TITLE
fix(slider): `disabled` Slider should not submit a form

### DIFF
--- a/src/Slider/Slider.svelte
+++ b/src/Slider/Slider.svelte
@@ -193,21 +193,10 @@
         class:bx--slider__filled-track="{true}"
         style="transform: translate(0, -50%) scaleX({left / 100})"
       ></div>
-      <input
-        type="hidden"
-        class:bx--slider__input="{true}"
-        name="{name}"
-        value="{value}"
-        required="{required}"
-        min="{min}"
-        max="{max}"
-        step="{step}"
-      />
     </div>
     <span class:bx--slider__range-label="{true}">{maxLabel || max}</span>
     <input
       type="{hideTextInput ? 'hidden' : inputType}"
-      style="{hideTextInput ? 'display: none' : undefined}"
       id="input-{id}"
       name="{name}"
       class:bx--text-input="{true}"


### PR DESCRIPTION
PR contains small changes for slider to improve it's behavior on form submit.

1. Removed redundant input which causes double value submit and submit once when input is disabled.

Form data before: 
```jsonc
{
  "FormData": [
    {
      "name": "basicSlider",
      "value": "27"
    },
    {
      "name": "basicSlider", // Data submitted twice here
      "value": "27"
    },
    {
      "name": "disableSlider", // It shouldn't submit disabled input with the form
      "value": "30"
    }
  ]
}
```

Form data after:

```jsonc
{
  "FormData": [
    {
      "name": "basicSlider",
      "value": "27"
    }
  ]
}
```

Tested with both `hideTextInput` `true` and `false`.

2. Removed extra styling since it always sets input type to `hidden` when `hideTextInput` is `true`.

