### PR TITLE
fix(select): hide `helperText` if invalid or warning state

### DIFF
--- a/src/Select/Select.svelte
+++ b/src/Select/Select.svelte
@@ -181,7 +181,7 @@
           </div>
         {/if}
       </div>
-      {#if helperText}
+      {#if !invalid && !warn && helperText}
         <div
           class:bx--form__helper-text="{true}"
           class:bx--form__helper-text--disabled="{disabled}"


### PR DESCRIPTION
Related #1757

Did a quick search for `helperText` usage and confirmed [upstream](https://github.com/carbon-design-system/carbon/blob/bb0e5d1f4d84ce71a3131892993b76a5a6805495/packages/react/src/components/Select/Select.tsx#L292) that `Select` should not show helper text if in the invalid or warn states. This is consistent with other inputs.