### PR TITLE
feat(ui-shell): make `company` in `Header` slottable

### DIFF
--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -1584,11 +1584,12 @@ None.
 
 ### Slots
 
-| Slot name       | Default | Props | Fallback                    |
-| :-------------- | :------ | :---- | :-------------------------- |
-| --              | Yes     | --    | --                          |
-| platform        | No      | --    | <code>{platformName}</code> |
-| skip-to-content | No      | --    | --                          |
+| Slot name       | Default | Props | Fallback                     |
+| :-------------- | :------ | :---- | :--------------------------- |
+| --              | Yes     | --    | --                           |
+| company         | No      | --    | <code>{company}&nbsp;</code> |
+| platform        | No      | --    | <code>{platformName}</code>  |
+| skip-to-content | No      | --    | --                           |
 
 ### Events
 

--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -4834,6 +4834,12 @@
       "slots": [
         { "name": "__default__", "default": true, "slot_props": "{}" },
         {
+          "name": "company",
+          "default": false,
+          "fallback": "{company}&nbsp;",
+          "slot_props": "{}"
+        },
+        {
           "name": "platform",
           "default": false,
           "fallback": "{platformName}",

--- a/src/UIShell/Header.svelte
+++ b/src/UIShell/Header.svelte
@@ -103,9 +103,3 @@
   </a>
   <slot />
 </header>
-
-<style>
-  .bx--header__name--prefix {
-    padding-right: 0.2rem;
-  }
-</style>

--- a/src/UIShell/Header.svelte
+++ b/src/UIShell/Header.svelte
@@ -94,13 +94,16 @@
     {...$$restProps}
     on:click
   >
-    {#if company}
-      <span class:bx--header__name--prefix="{true}">{company}</span>
+    {#if company || $$slots.company}
+      <span class:bx--header__name--prefix="{true}"
+        ><slot name="company">{company}&nbsp;</slot></span
+      >
     {/if}
     <slot name="platform">{platformName}</slot>
   </a>
   <slot />
 </header>
+
 <style>
   .bx--header__name--prefix {
     padding-right: 0.2rem;

--- a/src/UIShell/Header.svelte
+++ b/src/UIShell/Header.svelte
@@ -95,9 +95,14 @@
     on:click
   >
     {#if company}
-      <span class:bx--header__name--prefix="{true}">{company}&nbsp;</span>
+      <span class:bx--header__name--prefix="{true}">{company}</span>
     {/if}
     <slot name="platform">{platformName}</slot>
   </a>
   <slot />
 </header>
+<style>
+  .bx--header__name--prefix {
+    padding-right: 0.2rem;
+  }
+</style>

--- a/types/UIShell/Header.svelte.d.ts
+++ b/types/UIShell/Header.svelte.d.ts
@@ -28,15 +28,15 @@ export interface HeaderProps
   href?: string;
 
   /**
-   * Specify the company name
-   * Alternatively, use the named slot "company" (e.g., <span slot="company">...</span>)
+   * Specify the company name.  
+   * Alternatively, use the named slot "company" (e.g., `<span slot="company">...</span>`)
    * @default undefined
    */
   company?: string;
 
   /**
-   * Specify the platform name
-   * Alternatively, use the named slot "platform" (e.g., <span slot="platform">...</span>)
+   * Specify the platform name.  
+   * Alternatively, use the named slot "platform" (e.g., `<span slot="platform">...</span>`)
    * @default ""
    */
   platformName?: string;
@@ -48,13 +48,13 @@ export interface HeaderProps
   persistentHamburgerMenu?: boolean;
 
   /**
-   * The window width (px) at which the SideNav is expanded and the hamburger menu is hidden
-   * 1056 represents the "large" breakpoint in pixels from the Carbon Design System:
-   * small: 320
-   * medium: 672
-   * large: 1056
-   * x-large: 1312
-   * max: 1584
+   * The window width (px) at which the SideNav is expanded and the hamburger menu is hidden.  
+   * 1056 represents the "large" breakpoint in pixels from the Carbon Design System:  
+   * small: 320  
+   * medium: 672  
+   * large: 1056  
+   * x-large: 1312  
+   * max: 1584  
    * @default 1056
    */
   expansionBreakpoint?: number;
@@ -66,15 +66,15 @@ export interface HeaderProps
   ref?: null | HTMLAnchorElement;
 
   /**
-   * Specify the icon to render for the closed state.
-   * Defaults to `<Menu size={20} />`
+   * Specify the icon to render for the closed state.  
+   * Defaults to `<Menu size={20} />`  
    * @default undefined
    */
   iconMenu?: typeof import("svelte").SvelteComponent;
 
   /**
-   * Specify the icon to render for the opened state.
-   * Defaults to `<Close size={20} />`
+   * Specify the icon to render for the opened state.  
+   * Defaults to `<Close size={20} />`  
    * @default undefined
    */
   iconClose?: typeof import("svelte").SvelteComponent;

--- a/types/UIShell/Header.svelte.d.ts
+++ b/types/UIShell/Header.svelte.d.ts
@@ -29,6 +29,7 @@ export interface HeaderProps
 
   /**
    * Specify the company name
+   * Alternatively, use the named slot "company" (e.g., <span slot="company">...</span>)
    * @default undefined
    */
   company?: string;

--- a/types/UIShell/Header.svelte.d.ts
+++ b/types/UIShell/Header.svelte.d.ts
@@ -84,5 +84,5 @@ export interface HeaderProps
 export default class Header extends SvelteComponentTyped<
   HeaderProps,
   { click: WindowEventMap["click"] },
-  { default: {}; platform: {}; ["skip-to-content"]: {} }
+  { default: {}; company: {}; platform: {}; ["skip-to-content"]: {} }
 > {}

--- a/types/UIShell/Header.svelte.d.ts
+++ b/types/UIShell/Header.svelte.d.ts
@@ -28,15 +28,14 @@ export interface HeaderProps
   href?: string;
 
   /**
-   * Specify the company name.  
-   * Alternatively, use the named slot "company" (e.g., `<span slot="company">...</span>`)
+   * Specify the company name
    * @default undefined
    */
   company?: string;
 
   /**
-   * Specify the platform name.  
-   * Alternatively, use the named slot "platform" (e.g., `<span slot="platform">...</span>`)
+   * Specify the platform name
+   * Alternatively, use the named slot "platform" (e.g., <span slot="platform">...</span>)
    * @default ""
    */
   platformName?: string;
@@ -48,13 +47,13 @@ export interface HeaderProps
   persistentHamburgerMenu?: boolean;
 
   /**
-   * The window width (px) at which the SideNav is expanded and the hamburger menu is hidden.  
-   * 1056 represents the "large" breakpoint in pixels from the Carbon Design System:  
-   * small: 320  
-   * medium: 672  
-   * large: 1056  
-   * x-large: 1312  
-   * max: 1584  
+   * The window width (px) at which the SideNav is expanded and the hamburger menu is hidden
+   * 1056 represents the "large" breakpoint in pixels from the Carbon Design System:
+   * small: 320
+   * medium: 672
+   * large: 1056
+   * x-large: 1312
+   * max: 1584
    * @default 1056
    */
   expansionBreakpoint?: number;
@@ -66,15 +65,15 @@ export interface HeaderProps
   ref?: null | HTMLAnchorElement;
 
   /**
-   * Specify the icon to render for the closed state.  
-   * Defaults to `<Menu size={20} />`  
+   * Specify the icon to render for the closed state.
+   * Defaults to `<Menu size={20} />`
    * @default undefined
    */
   iconMenu?: typeof import("svelte").SvelteComponent;
 
   /**
-   * Specify the icon to render for the opened state.  
-   * Defaults to `<Close size={20} />`  
+   * Specify the icon to render for the opened state.
+   * Defaults to `<Close size={20} />`
    * @default undefined
    */
   iconClose?: typeof import("svelte").SvelteComponent;


### PR DESCRIPTION
I've noticed that the ui shell has a little glitch during load in our app.

![image](https://github.com/carbon-design-system/carbon-components-svelte/assets/2803621/f69b3972-957b-4095-a963-d218eaf66e69)

The `Â` disappearing after load but it causes a glitch.

The root cause is an `&nbsp;` character in the company text span.
Maybe somebody else faced with this glitch too, so I created a small improvement for that.