### PR TITLE
chore(a11y): ignore `svelte@4` a11y warnings

### DIFF
--- a/src/Accordion/Accordion.svelte
+++ b/src/Accordion/Accordion.svelte
@@ -42,6 +42,7 @@
     on:mouseleave
   />
 {:else}
+  <!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
   <ul
     class:bx--accordion="{true}"
     class:bx--accordion--start="{align === 'start'}"

--- a/src/Accordion/AccordionSkeleton.svelte
+++ b/src/Accordion/AccordionSkeleton.svelte
@@ -22,6 +22,7 @@
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
+<!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
 <ul
   class:bx--skeleton="{true}"
   class:bx--accordion="{true}"

--- a/src/Breadcrumb/Breadcrumb.svelte
+++ b/src/Breadcrumb/Breadcrumb.svelte
@@ -21,6 +21,7 @@
     on:mouseleave
   />
 {:else}
+  <!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
   <nav
     aria-label="Breadcrumb"
     {...$$restProps}

--- a/src/Breadcrumb/BreadcrumbItem.svelte
+++ b/src/Breadcrumb/BreadcrumbItem.svelte
@@ -20,6 +20,7 @@
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
+<!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
 <li
   class:bx--breadcrumb-item="{true}"
   class:bx--breadcrumb-item--current="{isCurrentPage &&

--- a/src/Breadcrumb/BreadcrumbSkeleton.svelte
+++ b/src/Breadcrumb/BreadcrumbSkeleton.svelte
@@ -7,6 +7,7 @@
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
+<!-- svelte-ignore a11y-no-static-element-interactions -->
 <div
   class:bx--skeleton="{true}"
   class:bx--breadcrumb="{true}"

--- a/src/Button/Button.svelte
+++ b/src/Button/Button.svelte
@@ -142,6 +142,7 @@
   <slot props="{buttonProps}" />
 {:else if href && !disabled}
   <!-- svelte-ignore a11y-missing-attribute -->
+  <!-- svelte-ignore a11y-no-static-element-interactions -->
   <a
     bind:this="{ref}"
     {...buttonProps}

--- a/src/Button/ButtonSkeleton.svelte
+++ b/src/Button/ButtonSkeleton.svelte
@@ -33,6 +33,7 @@
     {""}
   </a>
 {:else}
+  <!-- svelte-ignore a11y-no-static-element-interactions -->
   <div
     class:bx--skeleton="{true}"
     class:bx--btn="{true}"

--- a/src/Checkbox/Checkbox.svelte
+++ b/src/Checkbox/Checkbox.svelte
@@ -80,6 +80,7 @@
     on:mouseleave
   />
 {:else}
+  <!-- svelte-ignore a11y-no-static-element-interactions -->
   <div
     class:bx--form-item="{true}"
     class:bx--checkbox-wrapper="{true}"

--- a/src/Checkbox/CheckboxSkeleton.svelte
+++ b/src/Checkbox/CheckboxSkeleton.svelte
@@ -1,4 +1,5 @@
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
+<!-- svelte-ignore a11y-no-static-element-interactions -->
 <div
   class:bx--form-item="{true}"
   class:bx--checkbox-wrapper="{true}"

--- a/src/CodeSnippet/CodeSnippet.svelte
+++ b/src/CodeSnippet/CodeSnippet.svelte
@@ -200,6 +200,7 @@
     </button>
   {/if}
 {:else}
+  <!-- svelte-ignore a11y-no-static-element-interactions -->
   <div
     class:bx--snippet="{true}"
     class:bx--snippet--expand="{expanded}"

--- a/src/CodeSnippet/CodeSnippetSkeleton.svelte
+++ b/src/CodeSnippet/CodeSnippetSkeleton.svelte
@@ -7,6 +7,7 @@
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
+<!-- svelte-ignore a11y-no-static-element-interactions -->
 <div
   class:bx--skeleton="{true}"
   class:bx--snippet="{true}"

--- a/src/ComposedModal/ComposedModal.svelte
+++ b/src/ComposedModal/ComposedModal.svelte
@@ -151,6 +151,7 @@
   }}"
 >
   <!-- svelte-ignore a11y-click-events-have-key-events -->
+  <!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
   <div
     bind:this="{innerModal}"
     role="dialog"

--- a/src/DataTable/DataTableSkeleton.svelte
+++ b/src/DataTable/DataTableSkeleton.svelte
@@ -64,6 +64,7 @@
     </section>
   {/if}
   <!-- svelte-ignore a11y-click-events-have-key-events -->
+  <!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
   <table
     class:bx--skeleton="{true}"
     class:bx--data-table="{true}"

--- a/src/DataTable/TableHead.svelte
+++ b/src/DataTable/TableHead.svelte
@@ -1,4 +1,5 @@
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
+<!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
 <thead {...$$restProps} on:click on:mouseover on:mouseenter on:mouseleave>
   <slot />
 </thead>

--- a/src/DatePicker/DatePicker.svelte
+++ b/src/DatePicker/DatePicker.svelte
@@ -238,6 +238,7 @@
 />
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
+<!-- svelte-ignore a11y-no-static-element-interactions -->
 <div
   class:bx--form-item="{true}"
   {...$$restProps}
@@ -246,6 +247,7 @@
   on:mouseenter
   on:mouseleave
 >
+  <!-- svelte-ignore a11y-no-static-element-interactions -->
   <div
     bind:this="{datePickerRef}"
     id="{id}"

--- a/src/DatePicker/DatePickerSkeleton.svelte
+++ b/src/DatePicker/DatePickerSkeleton.svelte
@@ -7,6 +7,7 @@
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
+<!-- svelte-ignore a11y-no-static-element-interactions -->
 <div
   class:bx--form-item="{true}"
   {...$$restProps}

--- a/src/Dropdown/DropdownSkeleton.svelte
+++ b/src/Dropdown/DropdownSkeleton.svelte
@@ -4,6 +4,7 @@
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
+<!-- svelte-ignore a11y-no-static-element-interactions -->
 <div
   class:bx--skeleton="{true}"
   class:bx--dropdown-v2="{true}"

--- a/src/FileUploader/FileUploader.svelte
+++ b/src/FileUploader/FileUploader.svelte
@@ -94,6 +94,7 @@
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
+<!-- svelte-ignore a11y-no-static-element-interactions -->
 <div
   class:bx--form-item="{true}"
   {...$$restProps}

--- a/src/FileUploader/FileUploaderButton.svelte
+++ b/src/FileUploader/FileUploaderButton.svelte
@@ -61,6 +61,7 @@
 </script>
 
 <!-- svelte-ignore a11y-no-noninteractive-tabindex -->
+<!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
 <label
   aria-disabled="{disabled}"
   for="{id}"

--- a/src/FileUploader/FileUploaderDropContainer.svelte
+++ b/src/FileUploader/FileUploaderDropContainer.svelte
@@ -54,6 +54,7 @@
   let over = false;
 </script>
 
+<!-- svelte-ignore a11y-no-static-element-interactions -->
 <div
   class:bx--file="{true}"
   {...$$restProps}
@@ -82,6 +83,7 @@
   }}"
 >
   <!-- svelte-ignore a11y-no-noninteractive-tabindex -->
+  <!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
   <label
     for="{id}"
     tabindex="{tabindex}"

--- a/src/FileUploader/FileUploaderItem.svelte
+++ b/src/FileUploader/FileUploaderItem.svelte
@@ -40,6 +40,7 @@
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
+<!-- svelte-ignore a11y-no-static-element-interactions -->
 <span
   id="{id}"
   class:bx--file__selected-file="{true}"

--- a/src/FileUploader/FileUploaderSkeleton.svelte
+++ b/src/FileUploader/FileUploaderSkeleton.svelte
@@ -4,6 +4,7 @@
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
+<!-- svelte-ignore a11y-no-static-element-interactions -->
 <div
   class:bx--form-item="{true}"
   {...$$restProps}

--- a/src/Form/Form.svelte
+++ b/src/Form/Form.svelte
@@ -4,6 +4,7 @@
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
+<!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
 <form
   class:bx--form="{true}"
   bind:this="{ref}"

--- a/src/FormGroup/FormGroup.svelte
+++ b/src/FormGroup/FormGroup.svelte
@@ -19,6 +19,7 @@
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
+<!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
 <fieldset
   data-invalid="{invalid || undefined}"
   class:bx--fieldset="{true}"

--- a/src/FormItem/FormItem.svelte
+++ b/src/FormItem/FormItem.svelte
@@ -1,4 +1,5 @@
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
+<!-- svelte-ignore a11y-no-static-element-interactions -->
 <div
   class:bx--form-item="{true}"
   {...$$restProps}

--- a/src/FormLabel/FormLabel.svelte
+++ b/src/FormLabel/FormLabel.svelte
@@ -4,6 +4,7 @@
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
+<!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
 <label
   class:bx--label="{true}"
   for="{id}"

--- a/src/InlineLoading/InlineLoading.svelte
+++ b/src/InlineLoading/InlineLoading.svelte
@@ -45,6 +45,7 @@
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
+<!-- svelte-ignore a11y-no-static-element-interactions -->
 <div
   class:bx--inline-loading="{true}"
   aria-live="assertive"

--- a/src/Link/Link.svelte
+++ b/src/Link/Link.svelte
@@ -35,6 +35,7 @@
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
 {#if disabled}
+  <!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
   <p
     bind:this="{ref}"
     class:bx--link="{true}"

--- a/src/ListBox/ListBoxMenuIcon.svelte
+++ b/src/ListBox/ListBoxMenuIcon.svelte
@@ -27,6 +27,7 @@
     translateWithId?.(translationId) ?? defaultTranslations[translationId];
 </script>
 
+<!-- svelte-ignore a11y-no-static-element-interactions -->
 <div
   class:bx--list-box__menu-icon="{true}"
   class:bx--list-box__menu-icon--open="{open}"

--- a/src/ListItem/ListItem.svelte
+++ b/src/ListItem/ListItem.svelte
@@ -1,4 +1,5 @@
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
+<!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
 <li
   class:bx--list__item="{true}"
   {...$$restProps}

--- a/src/NumberInput/NumberInput.svelte
+++ b/src/NumberInput/NumberInput.svelte
@@ -154,6 +154,7 @@
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <!-- svelte-ignore a11y-click-events-have-key-events -->
+<!-- svelte-ignore a11y-no-static-element-interactions -->
 <div
   class:bx--form-item="{true}"
   on:click

--- a/src/NumberInput/NumberInputSkeleton.svelte
+++ b/src/NumberInput/NumberInputSkeleton.svelte
@@ -4,6 +4,7 @@
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
+<!-- svelte-ignore a11y-no-static-element-interactions -->
 <div
   class:bx--form-item="{true}"
   {...$$restProps}

--- a/src/OrderedList/OrderedList.svelte
+++ b/src/OrderedList/OrderedList.svelte
@@ -10,6 +10,7 @@
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
+<!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
 <ol
   class:bx--list--ordered="{!native}"
   class:bx--list--ordered--native="{native}"

--- a/src/OverflowMenu/OverflowMenuItem.svelte
+++ b/src/OverflowMenu/OverflowMenuItem.svelte
@@ -63,6 +63,7 @@
 >
   {#if href}
     <!-- svelte-ignore a11y-missing-attribute -->
+    <!-- svelte-ignore a11y-no-static-element-interactions -->
     <a
       bind:this="{ref}"
       {...buttonProps}

--- a/src/Pagination/PaginationSkeleton.svelte
+++ b/src/Pagination/PaginationSkeleton.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
+<!-- svelte-ignore a11y-no-static-element-interactions -->
 <div
   class:bx--pagination="{true}"
   class:bx--skeleton="{true}"

--- a/src/ProgressIndicator/ProgressIndicator.svelte
+++ b/src/ProgressIndicator/ProgressIndicator.svelte
@@ -64,6 +64,7 @@
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
+<!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
 <ul
   class:bx--progress="{true}"
   class:bx--progress--vertical="{vertical}"

--- a/src/ProgressIndicator/ProgressIndicatorSkeleton.svelte
+++ b/src/ProgressIndicator/ProgressIndicatorSkeleton.svelte
@@ -7,6 +7,7 @@
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
+<!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
 <ul
   class:bx--progress="{true}"
   class:bx--progress--vertical="{vertical}"

--- a/src/RadioButton/RadioButtonSkeleton.svelte
+++ b/src/RadioButton/RadioButtonSkeleton.svelte
@@ -1,4 +1,5 @@
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
+<!-- svelte-ignore a11y-no-static-element-interactions -->
 <div
   class:bx--radio-button-wrapper="{true}"
   {...$$restProps}

--- a/src/RadioButtonGroup/RadioButtonGroup.svelte
+++ b/src/RadioButtonGroup/RadioButtonGroup.svelte
@@ -70,6 +70,7 @@
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
+<!-- svelte-ignore a11y-no-static-element-interactions -->
 <div
   id="{id}"
   class:bx--form-item="{true}"

--- a/src/Search/Search.svelte
+++ b/src/Search/Search.svelte
@@ -103,6 +103,7 @@
     class="{searchClass}"
   >
     <!-- svelte-ignore a11y-click-events-have-key-events -->
+    <!-- svelte-ignore a11y-no-static-element-interactions -->
     <div
       bind:this="{searchRef}"
       class:bx--search-magnifier="{true}"

--- a/src/Search/SearchSkeleton.svelte
+++ b/src/Search/SearchSkeleton.svelte
@@ -7,6 +7,7 @@
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
+<!-- svelte-ignore a11y-no-static-element-interactions -->
 <div
   class:bx--skeleton="{true}"
   class:bx--search--sm="{size === 'sm'}"

--- a/src/Select/SelectSkeleton.svelte
+++ b/src/Select/SelectSkeleton.svelte
@@ -4,6 +4,7 @@
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
+<!-- svelte-ignore a11y-no-static-element-interactions -->
 <div
   class:bx--form-item="{true}"
   {...$$restProps}

--- a/src/SkeletonPlaceholder/SkeletonPlaceholder.svelte
+++ b/src/SkeletonPlaceholder/SkeletonPlaceholder.svelte
@@ -1,4 +1,5 @@
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
+<!-- svelte-ignore a11y-no-static-element-interactions -->
 <div
   class:bx--skeleton__placeholder="{true}"
   {...$$restProps}

--- a/src/SkeletonText/SkeletonText.svelte
+++ b/src/SkeletonText/SkeletonText.svelte
@@ -28,6 +28,7 @@
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
 {#if paragraph}
+  <!-- svelte-ignore a11y-no-static-element-interactions -->
   <div {...$$restProps} on:click on:mouseover on:mouseenter on:mouseleave>
     {#each rows as { width }}
       <p
@@ -38,6 +39,7 @@
     {/each}
   </div>
 {:else}
+  <!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
   <p
     class:bx--skeleton__text="{true}"
     class:bx--skeleton__heading="{heading}"

--- a/src/Slider/Slider.svelte
+++ b/src/Slider/Slider.svelte
@@ -131,6 +131,7 @@
 />
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
+<!-- svelte-ignore a11y-no-static-element-interactions -->
 <div
   class:bx--form-item="{true}"
   {...$$restProps}

--- a/src/Slider/SliderSkeleton.svelte
+++ b/src/Slider/SliderSkeleton.svelte
@@ -4,6 +4,7 @@
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
+<!-- svelte-ignore a11y-no-static-element-interactions -->
 <div
   class:bx--form-item="{true}"
   {...$$restProps}

--- a/src/StructuredList/StructuredList.svelte
+++ b/src/StructuredList/StructuredList.svelte
@@ -32,6 +32,7 @@
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
+<!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
 <div
   role="table"
   class:bx--structured-list="{true}"

--- a/src/StructuredList/StructuredListBody.svelte
+++ b/src/StructuredList/StructuredListBody.svelte
@@ -1,4 +1,5 @@
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
+<!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
 <div
   role="rowgroup"
   class:bx--structured-list-tbody="{true}"

--- a/src/StructuredList/StructuredListHead.svelte
+++ b/src/StructuredList/StructuredListHead.svelte
@@ -1,4 +1,5 @@
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
+<!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
 <div
   role="rowgroup"
   class:bx--structured-list-thead="{true}"

--- a/src/StructuredList/StructuredListRow.svelte
+++ b/src/StructuredList/StructuredListRow.svelte
@@ -13,6 +13,7 @@
 {#if label}
   <!-- svelte-ignore a11y-label-has-associated-control -->
   <!-- svelte-ignore a11y-no-noninteractive-tabindex -->
+  <!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
   <label
     tabindex="{tabindex}"
     class:bx--structured-list-row="{true}"

--- a/src/StructuredList/StructuredListSkeleton.svelte
+++ b/src/StructuredList/StructuredListSkeleton.svelte
@@ -4,6 +4,7 @@
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
+<!-- svelte-ignore a11y-no-static-element-interactions -->
 <div
   class:bx--skeleton="{true}"
   class:bx--structured-list="{true}"

--- a/src/Tabs/TabsSkeleton.svelte
+++ b/src/Tabs/TabsSkeleton.svelte
@@ -10,6 +10,7 @@
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
+<!-- svelte-ignore a11y-no-static-element-interactions -->
 <div
   class:bx--tabs="{true}"
   class:bx--skeleton="{true}"

--- a/src/Tag/Tag.svelte
+++ b/src/Tag/Tag.svelte
@@ -134,6 +134,7 @@
     </span>
   </button>
 {:else}
+  <!-- svelte-ignore a11y-no-static-element-interactions -->
   <div
     id="{id}"
     class:bx--tag="{true}"

--- a/src/Tag/TagSkeleton.svelte
+++ b/src/Tag/TagSkeleton.svelte
@@ -4,6 +4,7 @@
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
+<!-- svelte-ignore a11y-no-static-element-interactions -->
 <span
   class:bx--tag="{true}"
   class:bx--tag--sm="{size === 'sm'}"

--- a/src/TextArea/TextArea.svelte
+++ b/src/TextArea/TextArea.svelte
@@ -60,6 +60,7 @@
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <!-- svelte-ignore a11y-click-events-have-key-events -->
+<!-- svelte-ignore a11y-no-static-element-interactions -->
 <div
   on:click
   on:mouseover

--- a/src/TextArea/TextAreaSkeleton.svelte
+++ b/src/TextArea/TextAreaSkeleton.svelte
@@ -4,6 +4,7 @@
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
+<!-- svelte-ignore a11y-no-static-element-interactions -->
 <div
   class:bx--form-item="{true}"
   {...$$restProps}

--- a/src/TextInput/PasswordInput.svelte
+++ b/src/TextInput/PasswordInput.svelte
@@ -96,6 +96,7 @@
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <!-- svelte-ignore a11y-click-events-have-key-events -->
+<!-- svelte-ignore a11y-no-static-element-interactions -->
 <div
   class:bx--form-item="{true}"
   class:bx--text-input-wrapper="{true}"

--- a/src/TextInput/TextInput.svelte
+++ b/src/TextInput/TextInput.svelte
@@ -103,6 +103,7 @@
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <!-- svelte-ignore a11y-click-events-have-key-events -->
+<!-- svelte-ignore a11y-no-static-element-interactions -->
 <div
   class:bx--form-item="{true}"
   class:bx--text-input-wrapper="{true}"

--- a/src/TextInput/TextInputSkeleton.svelte
+++ b/src/TextInput/TextInputSkeleton.svelte
@@ -4,6 +4,7 @@
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
+<!-- svelte-ignore a11y-no-static-element-interactions -->
 <div
   class:bx--form-item="{true}"
   {...$$restProps}

--- a/src/Tile/RadioTile.svelte
+++ b/src/Tile/RadioTile.svelte
@@ -57,6 +57,7 @@
   }}"
 />
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
+<!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
 <label
   for="{id}"
   class:bx--tile="{true}"

--- a/src/Tile/SelectableTile.svelte
+++ b/src/Tile/SelectableTile.svelte
@@ -59,6 +59,7 @@
 />
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <!-- svelte-ignore a11y-no-noninteractive-tabindex -->
+<!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
 <label
   for="{id}"
   tabindex="{disabled ? undefined : tabindex}"

--- a/src/Tile/Tile.svelte
+++ b/src/Tile/Tile.svelte
@@ -4,6 +4,7 @@
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
+<!-- svelte-ignore a11y-no-static-element-interactions -->
 <div
   class:bx--tile="{true}"
   class:bx--tile--light="{light}"

--- a/src/TimePicker/TimePicker.svelte
+++ b/src/TimePicker/TimePicker.svelte
@@ -53,6 +53,7 @@
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <!-- svelte-ignore a11y-click-events-have-key-events -->
+<!-- svelte-ignore a11y-no-static-element-interactions -->
 <div
   class:bx--form-item="{true}"
   on:click

--- a/src/TimePicker/TimePickerSelect.svelte
+++ b/src/TimePicker/TimePickerSelect.svelte
@@ -39,6 +39,7 @@
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
+<!-- svelte-ignore a11y-no-static-element-interactions -->
 <div
   class:bx--select="{true}"
   class:bx--time-picker__select="{true}"

--- a/src/Toggle/Toggle.svelte
+++ b/src/Toggle/Toggle.svelte
@@ -44,6 +44,7 @@
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
+<!-- svelte-ignore a11y-no-static-element-interactions -->
 <div
   class:bx--form-item="{true}"
   {...$$restProps}

--- a/src/Toggle/ToggleSkeleton.svelte
+++ b/src/Toggle/ToggleSkeleton.svelte
@@ -13,6 +13,7 @@
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
+<!-- svelte-ignore a11y-no-static-element-interactions -->
 <div
   class:bx--form-item="{true}"
   {...$$restProps}

--- a/src/Tooltip/Tooltip.svelte
+++ b/src/Tooltip/Tooltip.svelte
@@ -206,6 +206,7 @@
   {#if !hideIcon}
     <div bind:this="{ref}" id="{triggerId}" class:bx--tooltip__label="{true}">
       <slot name="triggerText">{triggerText}</slot>
+      <!-- svelte-ignore a11y-no-static-element-interactions -->
       <div
         bind:this="{refIcon}"
         {...buttonProps}
@@ -220,6 +221,7 @@
       </div>
     </div>
   {:else}
+    <!-- svelte-ignore a11y-no-static-element-interactions -->
     <div
       bind:this="{ref}"
       {...buttonProps}
@@ -233,6 +235,7 @@
     </div>
   {/if}
   {#if open}
+    <!-- svelte-ignore a11y-no-static-element-interactions -->
     <div
       bind:this="{refTooltip}"
       id="{tooltipId}"
@@ -250,6 +253,7 @@
     >
       <span class:bx--tooltip__caret="{true}"></span>
       <!-- svelte-ignore a11y-click-events-have-key-events -->
+      <!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
       <div
         on:click|stopPropagation
         on:mousedown|stopPropagation

--- a/src/TooltipDefinition/TooltipDefinition.svelte
+++ b/src/TooltipDefinition/TooltipDefinition.svelte
@@ -47,6 +47,7 @@
   }}"
 />
 
+<!-- svelte-ignore a11y-no-static-element-interactions -->
 <span
   class:bx--tooltip--definition="{true}"
   class:bx--tooltip--a11y="{true}"

--- a/src/TreeView/TreeViewNodeList.svelte
+++ b/src/TreeView/TreeViewNodeList.svelte
@@ -133,6 +133,7 @@
   >
     <div class:bx--tree-node__label="{true}" bind:this="{refLabel}">
       <!-- svelte-ignore a11y-click-events-have-key-events -->
+      <!-- svelte-ignore a11y-no-static-element-interactions -->
       <span
         class:bx--tree-parent-node__toggle="{true}"
         disabled="{disabled}"

--- a/src/UIShell/SideNav.svelte
+++ b/src/UIShell/SideNav.svelte
@@ -56,6 +56,7 @@
 
 {#if !fixed}
   <!-- svelte-ignore a11y-click-events-have-key-events -->
+  <!-- svelte-ignore a11y-no-static-element-interactions -->
   <div
     on:click="{() => {
       dispatch('click:overlay');

--- a/src/UnorderedList/UnorderedList.svelte
+++ b/src/UnorderedList/UnorderedList.svelte
@@ -7,6 +7,7 @@
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
+<!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
 <ul
   class:bx--list--unordered="{true}"
   class:bx--list--nested="{nested}"


### PR DESCRIPTION
There are a couple of new a11y rules in `svelte@4` that affect this library.

Note that both warnings are actually true; non-interactive elements like `div` or `label` should *not* have forwarded events.

To avoid breaking changes in this PR, I've ignored these warnings for now.

There's already an issue (#1621) to standardize events/props.