### PR TITLE
fix(file-uploader): do not render empty element if `labelTitle`, `labelDescription` not provided

### DIFF
--- a/src/FileUploader/FileUploader.svelte
+++ b/src/FileUploader/FileUploader.svelte
@@ -103,18 +103,22 @@
   on:mouseenter
   on:mouseleave
 >
-  <p
-    class:bx--file--label="{true}"
-    class:bx--label-description--disabled="{disabled}"
-  >
-    {labelTitle}
-  </p>
-  <p
-    class:bx--label-description="{true}"
-    class:bx--label-description--disabled="{disabled}"
-  >
-    {labelDescription}
-  </p>
+  {#if labelTitle}
+    <p
+      class:bx--file--label="{true}"
+      class:bx--label-description--disabled="{disabled}"
+    >
+      {labelTitle}
+    </p>
+  {/if}
+  {#if labelDescription}
+    <p
+      class:bx--label-description="{true}"
+      class:bx--label-description--disabled="{disabled}"
+    >
+      {labelDescription}
+    </p>
+  {/if}
   <FileUploaderButton
     disabled="{disabled}"
     disableLabelChanges


### PR DESCRIPTION
Fixes #1775

In this case, the `labelTitle` and `labelDescription` are not accessible, so they can be conditionally rendered if truthy.