### PR TITLE
feat(file-uploader-button): support `danger-tertiary`, `danger-ghost` button variants

### DIFF
--- a/docs/src/pages/components/FileUploader.svx
+++ b/docs/src/pages/components/FileUploader.svx
@@ -11,9 +11,15 @@ components: ["FileUploaderButton", "FileUploader", "FileUploaderDropContainer", 
 
 By default, the file uploader only accepts one file.
 
-Set `multiple` to `true` for multiple files to be uploaded.
+Set `multiple` to `true` for multiple files to be accepted.
 
 <FileUploaderButton labelText="Add files" />
+
+## Custom button kind
+
+By default, the `primary` button kind is used.
+
+<FileUploaderButton kind="secondary" labelText="Add files" />
 
 ## File uploader
 

--- a/src/FileUploader/FileUploaderButton.svelte
+++ b/src/FileUploader/FileUploaderButton.svelte
@@ -74,6 +74,8 @@
   class:bx--btn--tertiary="{kind === 'tertiary'}"
   class:bx--btn--ghost="{kind === 'ghost'}"
   class:bx--btn--danger="{kind === 'danger'}"
+  class:bx--btn--danger-tertiary="{kind === 'danger-tertiary'}"
+  class:bx--btn--danger-ghost="{kind === 'danger-ghost'}"
   on:keydown
   on:keydown="{({ key }) => {
     if (key === ' ' || key === 'Enter') {


### PR DESCRIPTION
#1781 fixed the `kind` prop type, but `FileUploaderButton` actually does not use the `Button`. Rather, it's an `input` element, so the classes must be manually applied.