### PR TITLE
docs(pictograms): update number of pictograms

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Design systems facilitate design and development through reuse, consistency, and
 The Carbon Svelte portfolio also includes:
 
 - **[Carbon Icons Svelte](https://github.com/carbon-design-system/carbon-icons-svelte)**: 2,000+ Carbon icons as Svelte components
-- **[Carbon Pictograms Svelte](https://github.com/carbon-design-system/carbon-pictograms-svelte)**: 900+ Carbon pictograms as Svelte components
+- **[Carbon Pictograms Svelte](https://github.com/carbon-design-system/carbon-pictograms-svelte)**: 1,000+ Carbon pictograms as Svelte components
 - **[Carbon Charts Svelte](https://github.com/carbon-design-system/carbon-charts/tree/master/packages/svelte)**: 20+ charts, powered by d3
 - **[Carbon Preprocess Svelte](https://github.com/carbon-design-system/carbon-preprocess-svelte)**: Collection of Svelte preprocessors for Carbon
 

--- a/docs/src/pages/index.svelte
+++ b/docs/src/pages/index.svelte
@@ -280,7 +280,7 @@
           borderBottom
           borderRight
           title="Carbon Pictograms Svelte"
-          subtitle="900+ pictograms"
+          subtitle="1,000+ pictograms"
           target="_blank"
           href="https://github.com/carbon-design-system/carbon-pictograms-svelte"
         />


### PR DESCRIPTION
`carbon-pictograms-svelte` [version 12.7.0](https://github.com/carbon-design-system/carbon-pictograms-svelte/releases/tag/v12.7.0) has 1,024 pictograms.