### PR TITLE
feat(overflowmenu): Allow to keep menu open after clicking items

### DIFF
--- a/src/OverflowMenu/OverflowMenu.svelte
+++ b/src/OverflowMenu/OverflowMenu.svelte
@@ -55,6 +55,9 @@
   /** Obtain a reference to the overflow menu element */
   export let menuRef = null;
 
+  /** Persist the open state when click the items */
+  export let persistentClickItems = true;
+
   import {
     createEventDispatcher,
     getContext,
@@ -202,8 +205,11 @@
   class:bx--overflow-menu--xl="{size === 'xl'}"
   {...$$restProps}
   on:click
-  on:click="{({ target }) => {
-    if (!(menuRef && menuRef.contains(target))) {
+  on:click="{(e) => {
+    if (persistentClickItems) {
+      e.stopPropagation();  // this propagate to window.click to cause close
+    }
+    if (!(menuRef && menuRef.contains(e.target))) {
       open = !open;
       if (!open) dispatch('close');
     }

--- a/types/OverflowMenu/OverflowMenu.svelte.d.ts
+++ b/types/OverflowMenu/OverflowMenu.svelte.d.ts
@@ -35,6 +35,12 @@ export interface OverflowMenuProps extends RestProps {
   flipped?: boolean;
 
   /**
+   * Set to `true` to keep menu open after clicking the items
+   * @default false
+   */
+  persistentClickItems?: boolean;
+
+  /**
    * Specify the menu options class
    * @default undefined
    */


### PR DESCRIPTION
Added an option `persistentClickItems` to allow the menu to keep open after clicking the items.