### PR TITLE
feat(ui-shell): forward onclick event for HeaderActionLink

### DIFF
--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -1652,7 +1652,9 @@ None.
 
 ### Events
 
-None.
+| Event name | Type      | Detail |
+| :--------- | :-------- | :----- |
+| click      | forwarded | --     |
 
 ## `HeaderGlobalAction`
 

--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -5064,7 +5064,7 @@
           "slot_props": "{}"
         }
       ],
-      "events": [],
+      "events": [{ "type": "forwarded", "name": "click", "element": "a" }],
       "typedefs": [],
       "rest_props": { "type": "Element", "name": "a" }
     },

--- a/src/UIShell/HeaderActionLink.svelte
+++ b/src/UIShell/HeaderActionLink.svelte
@@ -25,6 +25,7 @@
   href="{href}"
   rel="{$$restProps.target === '_blank' ? 'noopener noreferrer' : undefined}"
   {...$$restProps}
+  on:click
 >
   <slot name="icon">
     <svelte:component this="{icon}" size="{20}" />

--- a/types/UIShell/HeaderActionLink.svelte.d.ts
+++ b/types/UIShell/HeaderActionLink.svelte.d.ts
@@ -33,6 +33,6 @@ export interface HeaderActionLinkProps extends RestProps {
 
 export default class HeaderActionLink extends SvelteComponentTyped<
   HeaderActionLinkProps,
-  Record<string, any>,
+  { click: WindowEventMap["click"] },
   { icon: {} }
 > {}


### PR DESCRIPTION
As mentioned in #1796, this change forwards the `on:click` event from the wrapped anchor element for the `HeaderActionLink` component similar to other UIShell components that wrap anchor elements such as `HeaderPanelLink`, `SideNavLink`, or `SkipToContent`.

closes #1796