### PR TITLE
fix(file-uploader-button): clear value by setting to `""` instead of `null`

### DIFF
--- a/src/FileUploader/FileUploaderButton.svelte
+++ b/src/FileUploader/FileUploaderButton.svelte
@@ -62,7 +62,7 @@
 
   $: if (ref && files.length === 0) {
     labelText = initialLabelText;
-    ref.value = '';
+    ref.value = "";
   }
 </script>
 

--- a/src/FileUploader/FileUploaderButton.svelte
+++ b/src/FileUploader/FileUploaderButton.svelte
@@ -62,7 +62,7 @@
 
   $: if (ref && files.length === 0) {
     labelText = initialLabelText;
-    ref.value = null;
+    ref.value = '';
   }
 </script>
 


### PR DESCRIPTION
This fixes the following error I got:

> InvalidStateError: Failed to set the 'value' property on 'HTMLInputElement': This input element accepts a filename, which may only be programmatically set to the empty string

which made my tests in vitest fail.