### PR TITLE
fix(radio-button-group): set `name` attribute on inputs

### DIFF
--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -2936,6 +2936,7 @@ None.
 | Prop name     | Required | Kind             | Reactive | Type                                      | Default value                                    | Description                                         |
 | :------------ | :------- | :--------------- | :------- | ----------------------------------------- | ------------------------------------------------ | --------------------------------------------------- |
 | ref           | No       | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code> | <code>null</code>                                | Obtain a reference to the input HTML element        |
+| name          | No       | <code>let</code> | Yes      | <code>string</code>                       | <code>""</code>                                  | Specify a name attribute for the radio button input |
 | checked       | No       | <code>let</code> | Yes      | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to check the radio button             |
 | value         | No       | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Specify the value of the radio button               |
 | disabled      | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to disable the radio button           |
@@ -2944,7 +2945,6 @@ None.
 | labelText     | No       | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Specify the label text                              |
 | hideLabel     | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to visually hide the label text       |
 | id            | No       | <code>let</code> | No       | <code>string</code>                       | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the input element                     |
-| name          | No       | <code>let</code> | No       | <code>string</code>                       | <code>""</code>                                  | Specify a name attribute for the radio button input |
 
 ### Slots
 
@@ -2962,15 +2962,16 @@ None.
 
 ### Props
 
-| Prop name     | Required | Kind             | Reactive | Type                                        | Default value             | Description                                  |
-| :------------ | :------- | :--------------- | :------- | ------------------------------------------- | ------------------------- | -------------------------------------------- |
-| selected      | No       | <code>let</code> | Yes      | <code>string</code>                         | <code>undefined</code>    | Set the selected radio button value          |
-| disabled      | No       | <code>let</code> | No       | <code>boolean</code>                        | <code>false</code>        | Set to `true` to disable the radio buttons   |
-| legendText    | No       | <code>let</code> | No       | <code>string</code>                         | <code>""</code>           | Specify the legend text                      |
-| hideLegend    | No       | <code>let</code> | No       | <code>boolean</code>                        | <code>false</code>        | Set to `true` to visually hide the legend    |
-| labelPosition | No       | <code>let</code> | No       | <code>"right" &#124; "left"</code>          | <code>"right"</code>      | Specify the label position                   |
-| orientation   | No       | <code>let</code> | No       | <code>"horizontal" &#124; "vertical"</code> | <code>"horizontal"</code> | Specify the orientation of the radio buttons |
-| id            | No       | <code>let</code> | No       | <code>string</code>                         | <code>undefined</code>    | Set an id for the container div element      |
+| Prop name     | Required | Kind             | Reactive | Type                                        | Default value             | Description                                                     |
+| :------------ | :------- | :--------------- | :------- | ------------------------------------------- | ------------------------- | --------------------------------------------------------------- |
+| selected      | No       | <code>let</code> | Yes      | <code>string</code>                         | <code>undefined</code>    | Set the selected radio button value                             |
+| disabled      | No       | <code>let</code> | No       | <code>boolean</code>                        | <code>false</code>        | Set to `true` to disable the radio buttons                      |
+| legendText    | No       | <code>let</code> | No       | <code>string</code>                         | <code>""</code>           | Specify the legend text                                         |
+| hideLegend    | No       | <code>let</code> | No       | <code>boolean</code>                        | <code>false</code>        | Set to `true` to visually hide the legend                       |
+| labelPosition | No       | <code>let</code> | No       | <code>"right" &#124; "left"</code>          | <code>"right"</code>      | Specify the label position                                      |
+| orientation   | No       | <code>let</code> | No       | <code>"horizontal" &#124; "vertical"</code> | <code>"horizontal"</code> | Specify the orientation of the radio buttons                    |
+| name          | No       | <code>let</code> | No       | <code>string</code>                         | <code>undefined</code>    | Set a name for all radio button input elements within the group |
+| id            | No       | <code>let</code> | No       | <code>string</code>                         | <code>undefined</code>    | Set an id for the container div element                         |
 
 ### Slots
 

--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -9468,7 +9468,7 @@
           "isFunctionDeclaration": false,
           "isRequired": false,
           "constant": false,
-          "reactive": false
+          "reactive": true
         },
         {
           "name": "ref",
@@ -9565,6 +9565,17 @@
           "description": "Specify the orientation of the radio buttons",
           "type": "\"horizontal\" | \"vertical\"",
           "value": "\"horizontal\"",
+          "isFunction": false,
+          "isFunctionDeclaration": false,
+          "isRequired": false,
+          "constant": false,
+          "reactive": false
+        },
+        {
+          "name": "name",
+          "kind": "let",
+          "description": "Set a name for all radio button input elements within the group",
+          "type": "string",
           "isFunction": false,
           "isFunctionDeclaration": false,
           "isRequired": false,

--- a/src/RadioButton/RadioButton.svelte
+++ b/src/RadioButton/RadioButton.svelte
@@ -32,13 +32,25 @@
   /** Obtain a reference to the input HTML element */
   export let ref = null;
 
-  import { getContext } from "svelte";
+  import { getContext, onMount } from "svelte";
   import { writable } from "svelte/store";
 
   const ctx = getContext("RadioButtonGroup");
   const selectedValue = ctx
     ? ctx.selectedValue
     : writable(checked ? value : undefined);
+
+  const unsubName = ctx?.name.subscribe((value) => {
+    // Use `name` if set on the `RadioButtonGroup`
+    if (value) {
+      name = value;
+    }
+  });
+  console.log(ctx)
+
+  onMount(() => {
+    return () => unsubName?.();
+  });
 
   if (ctx) {
     ctx.add({ id, checked, disabled, value });

--- a/src/RadioButtonGroup/RadioButtonGroup.svelte
+++ b/src/RadioButtonGroup/RadioButtonGroup.svelte
@@ -27,6 +27,12 @@
   export let orientation = "horizontal";
 
   /**
+   * Set a name for all radio button input elements within the group
+   * @type {string}
+   */
+  export let name = undefined;
+
+  /**
    * Set an id for the container div element
    * @type {string}
    */
@@ -42,9 +48,11 @@
 
   const dispatch = createEventDispatcher();
   const selectedValue = writable(selected);
+  const inputName = writable(name);
 
   setContext("RadioButtonGroup", {
     selectedValue,
+    name: inputName,
     add: ({ checked, value }) => {
       if (checked) {
         selectedValue.set(value);
@@ -67,6 +75,8 @@
     selected = value;
     dispatch("change", value);
   });
+
+  $: inputName.set(name);
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->

--- a/types/RadioButtonGroup/RadioButtonGroup.svelte.d.ts
+++ b/types/RadioButtonGroup/RadioButtonGroup.svelte.d.ts
@@ -41,6 +41,12 @@ export interface RadioButtonGroupProps extends RestProps {
   orientation?: "horizontal" | "vertical";
 
   /**
+   * Set a name for all radio button input elements within the group
+   * @default undefined
+   */
+  name?: string;
+
+  /**
    * Set an id for the container div element
    * @default undefined
    */


### PR DESCRIPTION
Fixes #1814, partially addresses #1813 

Adds a `name` prop to `RadioButtonGroup`. If provided, `name` is set on the rendered `input` elements.

```svelte
<RadioButtonGroup name="choices">
  <RadioButton id="1" value="1" />
  <RadioButton  id="2" value="2" />
</RadioButtonGroup>

<!-- DOM representation (abridged) -->
<fieldset>
  <input name="choices"  id="1" value="1" />
  <input name="choices"  id="2" value="2" />
</fieldset>
```

