### PR TITLE
fix(radio-button-group): strongly type dispatched change/select events

### DIFF
--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -2983,13 +2983,13 @@ None.
 
 ### Events
 
-| Event name | Type       | Detail |
-| :--------- | :--------- | :----- |
-| click      | forwarded  | --     |
-| mouseover  | forwarded  | --     |
-| mouseenter | forwarded  | --     |
-| mouseleave | forwarded  | --     |
-| change     | dispatched | --     |
+| Event name | Type       | Detail              |
+| :--------- | :--------- | :------------------ |
+| change     | dispatched | <code>string</code> |
+| click      | forwarded  | --                  |
+| mouseover  | forwarded  | --                  |
+| mouseenter | forwarded  | --                  |
+| mouseleave | forwarded  | --                  |
 
 ## `RadioButtonSkeleton`
 
@@ -4251,9 +4251,9 @@ export type CarbonTheme = "white" | "g10" | "g80" | "g90" | "g100";
 
 ### Events
 
-| Event name | Type       | Detail |
-| :--------- | :--------- | :----- |
-| select     | dispatched | --     |
+| Event name | Type       | Detail              |
+| :--------- | :--------- | :------------------ |
+| select     | dispatched | <code>string</code> |
 
 ## `TimePicker`
 

--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -9615,11 +9615,11 @@
         }
       ],
       "events": [
+        { "type": "dispatched", "name": "change", "detail": "string" },
         { "type": "forwarded", "name": "click", "element": "div" },
         { "type": "forwarded", "name": "mouseover", "element": "div" },
         { "type": "forwarded", "name": "mouseenter", "element": "div" },
-        { "type": "forwarded", "name": "mouseleave", "element": "div" },
-        { "type": "dispatched", "name": "change" }
+        { "type": "forwarded", "name": "mouseleave", "element": "div" }
       ],
       "typedefs": [],
       "rest_props": { "type": "Element", "name": "div" }
@@ -13158,7 +13158,9 @@
       ],
       "moduleExports": [],
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
-      "events": [{ "type": "dispatched", "name": "select" }],
+      "events": [
+        { "type": "dispatched", "name": "select", "detail": "string" }
+      ],
       "typedefs": [],
       "rest_props": { "type": "Element", "name": "fieldset" }
     },

--- a/src/RadioButtonGroup/RadioButtonGroup.svelte
+++ b/src/RadioButtonGroup/RadioButtonGroup.svelte
@@ -1,5 +1,9 @@
 <script>
   /**
+   * @event {string} change
+   */
+
+  /**
    * Set the selected radio button value
    * @type {string}
    */

--- a/src/Tile/TileGroup.svelte
+++ b/src/Tile/TileGroup.svelte
@@ -1,5 +1,9 @@
 <script>
   /**
+   * @event {string} select
+   */
+
+  /**
    * Specify the selected tile value
    * @type {string}
    */

--- a/tests/RadioButton.test.svelte
+++ b/tests/RadioButton.test.svelte
@@ -2,7 +2,13 @@
   import { RadioButton, RadioButtonSkeleton, RadioButtonGroup } from "../types";
 </script>
 
-<RadioButtonGroup legendText="Storage tier (disk)" selected="standard">
+<RadioButtonGroup
+  legendText="Storage tier (disk)"
+  selected="standard"
+  on:change="{(e) => {
+    console.log(e.detail); // string
+  }}"
+>
   <RadioButton labelText="Free (1 GB)" value="free" />
   <RadioButton labelText="Standard (10 GB)" value="standard" />
   <RadioButton labelText="Pro (128 GB)" value="pro" />

--- a/tests/RadioTile.test.svelte
+++ b/tests/RadioTile.test.svelte
@@ -2,8 +2,16 @@
   import { TileGroup, RadioTile } from "../types";
 </script>
 
-<TileGroup name="plan" required legend="Service pricing tiers">
-  <RadioTile light value="0" checked>Lite plan</RadioTile>
+<TileGroup
+  name="plan"
+  required
+  legend="Service pricing tiers"
+  selected="0"
+  on:select="{(e) => {
+    console.log(e.detail); // string
+  }}"
+>
+  <RadioTile light checked value="0">Lite plan</RadioTile>
   <RadioTile value="1">Standard plan</RadioTile>
   <RadioTile value="2">Plus plan</RadioTile>
 </TileGroup>

--- a/types/RadioButtonGroup/RadioButtonGroup.svelte.d.ts
+++ b/types/RadioButtonGroup/RadioButtonGroup.svelte.d.ts
@@ -64,11 +64,11 @@ export interface RadioButtonGroupProps extends RestProps {
 export default class RadioButtonGroup extends SvelteComponentTyped<
   RadioButtonGroupProps,
   {
+    change: CustomEvent<string>;
     click: WindowEventMap["click"];
     mouseover: WindowEventMap["mouseover"];
     mouseenter: WindowEventMap["mouseenter"];
     mouseleave: WindowEventMap["mouseleave"];
-    change: CustomEvent<any>;
   },
   { default: {}; legendText: {} }
 > {}

--- a/types/Tile/TileGroup.svelte.d.ts
+++ b/types/Tile/TileGroup.svelte.d.ts
@@ -39,6 +39,6 @@ export interface TileGroupProps extends RestProps {
 
 export default class TileGroup extends SvelteComponentTyped<
   TileGroupProps,
-  { select: CustomEvent<any> },
+  { select: CustomEvent<string> },
   { default: {} }
 > {}


### PR DESCRIPTION
Strongly type the `event.detail` as `string` for `RadioButtonGroup` and `TileGroup`. Currently, it defaults to `any` since the type is not explicitly annotated.

```svelte
<RadioButtonGroup
  legendText="Storage tier (disk)"
  selected="standard"
  on:change="{(e) => {
    console.log(e.detail); // string
  }}"
/>
```