### PR TITLE
fix(multi-select): reset `selectedIds` when clearing selection

### DIFF
--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -393,6 +393,7 @@
           selectionCount="{checked.length}"
           on:clear
           on:clear="{() => {
+            selectedIds = [];
             sortedItems = sortedItems.map((item) => ({
               ...item,
               checked: false,


### PR DESCRIPTION
Here I have a fix for issue #1831. I am unable to reproduce the issue (reproducible with `master` branch [here](https://svelte.dev/repl/63e6f961f6b1483fab1eac28da08c011?version=4.2.2)) after applying this patch.

If there is a better way to handle initial state set from `onMount()`, I would love to implement a better solution. Please let me know.