### PR TITLE
chore: update docs site link with new URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1602,9 +1602,9 @@ Svelte version >=3.48.0 is required.
 
 **Documentation**
 
-- add DataTable example ["Sortable with nested object values"](https://carbon-components-svelte.onrender.com/components/DataTable#sortable-with-nested-object-values)
-- add ClickableTile example ["Disabled state"](https://carbon-components-svelte.onrender.com/components/ClickableTile#disabled-state)
-- add Link example ["Link with icon"](https://carbon-components-svelte.onrender.com/components/Link#link-with-icon)
+- add DataTable example ["Sortable with nested object values"](https://svelte.carbondesignsystem.com/components/DataTable#sortable-with-nested-object-values)
+- add ClickableTile example ["Disabled state"](https://svelte.carbondesignsystem.com/components/ClickableTile#disabled-state)
+- add Link example ["Link with icon"](https://svelte.carbondesignsystem.com/components/Link#link-with-icon)
 
 **Housekeeping**
 
@@ -1950,9 +1950,9 @@ Svelte version >=3.48.0 is required.
 
 **Documentation**
 
-- add ["Padded columns"](https://carbon-components-svelte.onrender.com/components/Grid#padded-columns) example to Grid docs
-- demo different transitions in ["Header with app switcher"](https://carbon-components-svelte.onrender.com/components/UIShell#header-with-app-switcher) example in UI Shell
-- describe use case for [using native styles in OrderedList](https://carbon-components-svelte.onrender.com/components/OrderedList#native-list-styles)
+- add ["Padded columns"](https://svelte.carbondesignsystem.com/components/Grid#padded-columns) example to Grid docs
+- demo different transitions in ["Header with app switcher"](https://svelte.carbondesignsystem.com/components/UIShell#header-with-app-switcher) example in UI Shell
+- describe use case for [using native styles in OrderedList](https://svelte.carbondesignsystem.com/components/OrderedList#native-list-styles)
 
 **Housekeeping**
 
@@ -1978,8 +1978,8 @@ Svelte version >=3.48.0 is required.
 
 **Documentation**
 
-- Add example ["Skeleton with object headers"](https://carbon-components-svelte.onrender.com/components/DataTable#skeleton-with-object-headers) to the DataTable docs
-- Add example ["Header with global search"](https://carbon-components-svelte.onrender.com/components/UIShell#header-with-global-search) to the UI Shell docs
+- Add example ["Skeleton with object headers"](https://svelte.carbondesignsystem.com/components/DataTable#skeleton-with-object-headers) to the DataTable docs
+- Add example ["Header with global search"](https://svelte.carbondesignsystem.com/components/UIShell#header-with-global-search) to the UI Shell docs
 - deprecate HeaderActionSearch in favor of HeaderSearch
 
 ## [0.23.2](https://github.com/carbon-design-system/carbon-components-svelte/releases/tag/v0.23.2) - 2020-11-25
@@ -1998,17 +1998,17 @@ Svelte version >=3.48.0 is required.
 
 **Documentation**
 
-- Add [programmatic RadioButton example](https://carbon-components-svelte.onrender.com/components/RadioButton#programmatic-usage)
-- Add [multiple ComboBox example](https://carbon-components-svelte.onrender.com/components/ComboBox#multiple-combo-boxes)
-- Add [multiple Dropdown example](https://carbon-components-svelte.onrender.com/components/Dropdown#multiple-dropdowns)
-- Add [multiple MultiSelect example](https://carbon-components-svelte.onrender.com/components/MultiSelect#multiple-multi-select-dropdowns)
-- Add [ExpandableAccordion recipe](https://carbon-components-svelte.onrender.com/recipes/ExpandableAccordion#expandable-accordion)
+- Add [programmatic RadioButton example](https://svelte.carbondesignsystem.com/components/RadioButton#programmatic-usage)
+- Add [multiple ComboBox example](https://svelte.carbondesignsystem.com/components/ComboBox#multiple-combo-boxes)
+- Add [multiple Dropdown example](https://svelte.carbondesignsystem.com/components/Dropdown#multiple-dropdowns)
+- Add [multiple MultiSelect example](https://svelte.carbondesignsystem.com/components/MultiSelect#multiple-multi-select-dropdowns)
+- Add [ExpandableAccordion recipe](https://svelte.carbondesignsystem.com/recipes/ExpandableAccordion#expandable-accordion)
 
 ## [0.23.0](https://github.com/carbon-design-system/carbon-components-svelte/releases/tag/v0.23.0) - 2020-11-20
 
 **Features**
 
-- Persist UI Shell Header hamburger menu if `persistentHamburgerMenu` is `true` ([PR #396](https://github.com/carbon-design-system/carbon-components-svelte/pull/396), [issue #374](https://github.com/carbon-design-system/carbon-components-svelte/issues/374), [rendered example](https://carbon-components-svelte.onrender.com/framed/UIShell/PersistedHamburgerMenu))
+- Persist UI Shell Header hamburger menu if `persistentHamburgerMenu` is `true` ([PR #396](https://github.com/carbon-design-system/carbon-components-svelte/pull/396), [issue #374](https://github.com/carbon-design-system/carbon-components-svelte/issues/374), [rendered example](https://svelte.carbondesignsystem.com/framed/UIShell/PersistedHamburgerMenu))
 - Disable auto focus in ComposedModal if `selectorPrimaryFocus` is `null` ([PR #393](https://github.com/carbon-design-system/carbon-components-svelte/pull/393))
 - Use small size Toggle variant if `size` is `"sm"`; deprecate ToggleSmall which will be removed in the next major release ([PR #401](https://github.com/carbon-design-system/carbon-components-svelte/pull/401))
 
@@ -2026,9 +2026,9 @@ Svelte version >=3.48.0 is required.
 - Update auto-generated Component API documentation with output from [sveld](https://github.com/carbon-design-system/sveld)
 - Label reactive component props and list them first
 - Replace back ticks in Component API prop descriptions with a `code` tag ([PR #392](https://github.com/carbon-design-system/carbon-components-svelte/pull/392), [issue #390](https://github.com/carbon-design-system/carbon-components-svelte/issues/390))
-- Simplify date sort method in ["Sortable with custom display and sort methods"](https://carbon-components-svelte.onrender.com/components/DataTable#sortable-with-custom-display-and-sort-methods) DataTable example ([PR #382](https://github.com/carbon-design-system/carbon-components-svelte/pull/382))
-- Add [programmatic ProgressIndicator](https://carbon-components-svelte.onrender.com/components/ProgressIndicator#programmatic-usage) example
-- Add [vertical ProgressIndicatorSkeleton](https://carbon-components-svelte.onrender.com/components/ProgressIndicator#skeleton-vertical) example
+- Simplify date sort method in ["Sortable with custom display and sort methods"](https://svelte.carbondesignsystem.com/components/DataTable#sortable-with-custom-display-and-sort-methods) DataTable example ([PR #382](https://github.com/carbon-design-system/carbon-components-svelte/pull/382))
+- Add [programmatic ProgressIndicator](https://svelte.carbondesignsystem.com/components/ProgressIndicator#programmatic-usage) example
+- Add [vertical ProgressIndicatorSkeleton](https://svelte.carbondesignsystem.com/components/ProgressIndicator#skeleton-vertical) example
 - Add deprecation warning to the ToggleSmall component
 
 **Housekeeping**
@@ -2086,7 +2086,7 @@ Svelte version >=3.48.0 is required.
 
 **Documentation**
 
-- DataTable: add example ["Empty column with overflow menu"](https://carbon-components-svelte.onrender.com/components/DataTable#empty-column-with-overflow-menu)
+- DataTable: add example ["Empty column with overflow menu"](https://svelte.carbondesignsystem.com/components/DataTable#empty-column-with-overflow-menu)
 - hand off current theme for examples opened in a new tab
 - add field size examples for `Dropdown`, `MultiSelect`, `Select`
 
@@ -2112,13 +2112,13 @@ Svelte version >=3.48.0 is required.
 **Documentation**
 
 - new DataTable examples:
-  - [With custom display and sort methods](https://carbon-components-svelte.onrender.com/components/DataTable#with-custom-display-and-sort-methods)
-  - [With toolbar](https://carbon-components-svelte.onrender.com/components/DataTable#with-toolbar)
-  - [With toolbar (small size)](https://carbon-components-svelte.onrender.com/components/DataTable#with-toolbar-small-size)
-  - [Selectable](https://carbon-components-svelte.onrender.com/components/DataTable#selectable)
-  - [Initial selected rows](https://carbon-components-svelte.onrender.com/components/DataTable#initial-selected-rows)
-  - [Selectable with batch actions](https://carbon-components-svelte.onrender.com/components/DataTable#selectable-with-batch-actions)
-  - [Selectable (radio)](https://carbon-components-svelte.onrender.com/components/DataTable#selectable-radio)
+  - [With custom display and sort methods](https://svelte.carbondesignsystem.com/components/DataTable#with-custom-display-and-sort-methods)
+  - [With toolbar](https://svelte.carbondesignsystem.com/components/DataTable#with-toolbar)
+  - [With toolbar (small size)](https://svelte.carbondesignsystem.com/components/DataTable#with-toolbar-small-size)
+  - [Selectable](https://svelte.carbondesignsystem.com/components/DataTable#selectable)
+  - [Initial selected rows](https://svelte.carbondesignsystem.com/components/DataTable#initial-selected-rows)
+  - [Selectable with batch actions](https://svelte.carbondesignsystem.com/components/DataTable#selectable-with-batch-actions)
+  - [Selectable (radio)](https://svelte.carbondesignsystem.com/components/DataTable#selectable-radio)
 - fix(docgen): list both default and named slots in `COMPONENT_INDEX.md`
 
 ## [0.19.0](https://github.com/carbon-design-system/carbon-components-svelte/releases/tag/v0.19.0) - 2020-10-23
@@ -2250,7 +2250,7 @@ Svelte version >=3.48.0 is required.
 
 **Documentation**
 
-- Redesign component [documentation website](https://carbon-components-svelte.onrender.com/)
+- Redesign component [documentation website](https://svelte.carbondesignsystem.com/)
 - Update development workflow in `CONTRIBUTING.md`
 - Typo fixes in `README.md` ([PR #324](https://github.com/carbon-design-system/carbon-components-svelte/pull/324), [PR #325](https://github.com/carbon-design-system/carbon-components-svelte/pull/325))
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The Carbon Svelte portfolio also includes:
 - **[Carbon Charts Svelte](https://github.com/carbon-design-system/carbon-charts/tree/master/packages/svelte)**: 20+ charts, powered by d3
 - **[Carbon Preprocess Svelte](https://github.com/carbon-design-system/carbon-preprocess-svelte)**: Collection of Svelte preprocessors for Carbon
 
-## [Documentation](https://carbon-components-svelte.onrender.com)
+## [Documentation](https://svelte.carbondesignsystem.com)
 
 Other forms of documentation are auto-generated:
 
@@ -155,7 +155,7 @@ Programmatically switch between each of the five Carbon themes by setting the "t
 
 ### Importing components
 
-Import components from `carbon-components-svelte` in the `script` tag of your Svelte file. Visit the [documentation site](https://carbon-components-svelte.onrender.com) for examples.
+Import components from `carbon-components-svelte` in the `script` tag of your Svelte file. Visit the [documentation site](https://svelte.carbondesignsystem.com) for examples.
 
 ```html
 <!-- App.svelte -->

--- a/carbon.yml
+++ b/carbon.yml
@@ -3,7 +3,7 @@ library:
   id: carbon-components-svelte
   name: Carbon Svelte
   description: Build user interfaces with Carbon's core components.
-  externalDocsUrl: https://carbon-components-svelte.onrender.com
+  externalDocsUrl: https://svelte.carbondesignsystem.com
   inherits: carbon-styles
   navData:
   - title: Get started
@@ -52,7 +52,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-components-svelte.onrender.com/components/Accordion
+        url: https://svelte.carbondesignsystem.com/components/Accordion
   aspect-ratio:
     status: stable
     framework: svelte
@@ -60,7 +60,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-components-svelte.onrender.com/components/AspectRatio
+        url: https://svelte.carbondesignsystem.com/components/AspectRatio
   breadcrumb:
     status: stable
     externalDocsUrl: https://www.carbondesignsystem.com/components/breadcrumb/usage
@@ -69,7 +69,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-components-svelte.onrender.com/components/Breadcrumb
+        url: https://svelte.carbondesignsystem.com/components/Breadcrumb
   breakpoint:
     name: Breakpoint
     status: stable
@@ -81,7 +81,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-components-svelte.onrender.com/components/Breakpoint
+        url: https://svelte.carbondesignsystem.com/components/Breakpoint
     tags:
       - shell
   button:
@@ -92,7 +92,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-components-svelte.onrender.com/components/Button
+        url: https://svelte.carbondesignsystem.com/components/Button
   button-set:
     name: Button set
     description: Buttons in a button set are juxtaposed by default.
@@ -105,7 +105,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-components-svelte.onrender.com/components/ButtonSet
+        url: https://svelte.carbondesignsystem.com/components/ButtonSet
     tags:
       - input-control
   checkbox:
@@ -116,7 +116,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-components-svelte.onrender.com/components/Checkbox
+        url: https://svelte.carbondesignsystem.com/components/Checkbox
   clickable-tile:
     name: Clickable tile
     status: stable
@@ -128,7 +128,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-components-svelte.onrender.com/components/ClickableTile
+        url: https://svelte.carbondesignsystem.com/components/ClickableTile
     tags:
       - contextual-navigation
   code-snippet:
@@ -139,7 +139,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-components-svelte.onrender.com/components/CodeSnippet
+        url: https://svelte.carbondesignsystem.com/components/CodeSnippet
   combo-box:
     status: stable
     framework: svelte
@@ -147,7 +147,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-components-svelte.onrender.com/components/ComboBox
+        url: https://svelte.carbondesignsystem.com/components/ComboBox
   composed-modal:
     name: Composed modal
     status: stable
@@ -159,7 +159,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-components-svelte.onrender.com/components/ComposedModal
+        url: https://svelte.carbondesignsystem.com/components/ComposedModal
     tags:
       - input-control
   content-switcher:
@@ -170,7 +170,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-components-svelte.onrender.com/components/ContentSwitcher
+        url: https://svelte.carbondesignsystem.com/components/ContentSwitcher
   context-menu:
     name: Context menu
     status: stable
@@ -182,7 +182,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-components-svelte.onrender.com/components/ContextMenu
+        url: https://svelte.carbondesignsystem.com/components/ContextMenu
     tags:
       - input-control
       - contextual-navigation
@@ -193,7 +193,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-components-svelte.onrender.com/components/CopyButton
+        url: https://svelte.carbondesignsystem.com/components/CopyButton
   data-table:
     status: stable
     framework: svelte
@@ -202,7 +202,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-components-svelte.onrender.com/components/DataTable
+        url: https://svelte.carbondesignsystem.com/components/DataTable
   date-picker:
     status: stable
     framework: svelte
@@ -211,7 +211,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-components-svelte.onrender.com/components/DatePicker
+        url: https://svelte.carbondesignsystem.com/components/DatePicker
   definition-tooltip:
     status: stable
     framework: svelte
@@ -219,7 +219,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-components-svelte.onrender.com/components/TooltipDefinition
+        url: https://svelte.carbondesignsystem.com/components/TooltipDefinition
   dropdown:
     status: stable
     framework: svelte
@@ -228,7 +228,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-components-svelte.onrender.com/components/Dropdown
+        url: https://svelte.carbondesignsystem.com/components/Dropdown
   expandable-tile:
     name: Expandable tile
     status: stable
@@ -240,7 +240,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-components-svelte.onrender.com/components/ExpandableTile
+        url: https://svelte.carbondesignsystem.com/components/ExpandableTile
     tags:
       - data-display
       - content-element
@@ -252,7 +252,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-components-svelte.onrender.com/components/FileUploader
+        url: https://svelte.carbondesignsystem.com/components/FileUploader
   fluid-form:
     name: Fluid form
     status: stable
@@ -264,7 +264,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-components-svelte.onrender.com/components/FluidForm
+        url: https://svelte.carbondesignsystem.com/components/FluidForm
     tags:
       - form
   form:
@@ -275,7 +275,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-components-svelte.onrender.com/components/Form
+        url: https://svelte.carbondesignsystem.com/components/Form
   grid:
     status: stable
     framework: svelte
@@ -283,7 +283,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-components-svelte.onrender.com/components/Grid
+        url: https://svelte.carbondesignsystem.com/components/Grid
   image-loader:
     name: Image loader
     status: stable
@@ -295,7 +295,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-components-svelte.onrender.com/components/ImageLoader
+        url: https://svelte.carbondesignsystem.com/components/ImageLoader
     tags:
       - shell
       - media
@@ -308,7 +308,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-components-svelte.onrender.com/components/InlineLoading
+        url: https://svelte.carbondesignsystem.com/components/InlineLoading
   inline-notification:
     name: Inline notification
     status: stable
@@ -320,7 +320,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-components-svelte.onrender.com/components/InlineNotification
+        url: https://svelte.carbondesignsystem.com/components/InlineNotification
     tags:
       - system-feedback
   link:
@@ -331,7 +331,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-components-svelte.onrender.com/components/Link
+        url: https://svelte.carbondesignsystem.com/components/Link
   loading:
     status: stable
     framework: svelte
@@ -340,7 +340,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-components-svelte.onrender.com/components/Loading
+        url: https://svelte.carbondesignsystem.com/components/Loading
   local-storage:
     name: Local storage
     status: stable
@@ -352,7 +352,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-components-svelte.onrender.com/components/LocalStorage
+        url: https://svelte.carbondesignsystem.com/components/LocalStorage
     tags:
       - input-control
   modal:
@@ -363,7 +363,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-components-svelte.onrender.com/components/Modal
+        url: https://svelte.carbondesignsystem.com/components/Modal
   multiselect:
     status: stable
     framework: svelte
@@ -372,7 +372,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-components-svelte.onrender.com/components/MultiSelect
+        url: https://svelte.carbondesignsystem.com/components/MultiSelect
   number-input:
     status: stable
     framework: svelte
@@ -381,7 +381,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-components-svelte.onrender.com/components/NumberInput
+        url: https://svelte.carbondesignsystem.com/components/NumberInput
   ordered-list:
     name: Ordered list
     status: stable
@@ -393,7 +393,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-components-svelte.onrender.com/components/OrderedList
+        url: https://svelte.carbondesignsystem.com/components/OrderedList
     tags:
       - data-display
   overflow-menu:
@@ -407,7 +407,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-components-svelte.onrender.com/components/OverflowMenu
+        url: https://svelte.carbondesignsystem.com/components/OverflowMenu
     tags:
       - input-control
   pagination:
@@ -418,7 +418,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-components-svelte.onrender.com/components/Pagination
+        url: https://svelte.carbondesignsystem.com/components/Pagination
   pagination-nav:
     status: stable
     framework: svelte
@@ -426,7 +426,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-components-svelte.onrender.com/components/PaginationNav
+        url: https://svelte.carbondesignsystem.com/components/PaginationNav
   password-input:
     name: Password input
     status: stable
@@ -438,7 +438,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-components-svelte.onrender.com/components/PasswordInput
+        url: https://svelte.carbondesignsystem.com/components/PasswordInput
     tags:
       - form
       - contextual-navigation
@@ -449,7 +449,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-components-svelte.onrender.com/components/Popover
+        url: https://svelte.carbondesignsystem.com/components/Popover
   progress-bar:
     status: stable
     framework: svelte
@@ -458,7 +458,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-components-svelte.onrender.com/components/ProgressBar
+        url: https://svelte.carbondesignsystem.com/components/ProgressBar
   progress-indicator:
     status: stable
     framework: svelte
@@ -467,7 +467,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-components-svelte.onrender.com/components/ProgressIndicator
+        url: https://svelte.carbondesignsystem.com/components/ProgressIndicator
   radio-button:
     status: stable
     framework: svelte
@@ -476,7 +476,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-components-svelte.onrender.com/components/RadioButton
+        url: https://svelte.carbondesignsystem.com/components/RadioButton
   radio-tile:
     name: Radio tile
     status: stable
@@ -488,7 +488,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-components-svelte.onrender.com/components/RadioTile
+        url: https://svelte.carbondesignsystem.com/components/RadioTile
     tags:
       - input-control
   recursive-list:
@@ -502,7 +502,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-components-svelte.onrender.com/components/RecursiveList
+        url: https://svelte.carbondesignsystem.com/components/RecursiveList
     tags:
       - data-display
   search:
@@ -513,7 +513,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-components-svelte.onrender.com/components/Search
+        url: https://svelte.carbondesignsystem.com/components/Search
   select:
     status: stable
     framework: svelte
@@ -522,7 +522,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-components-svelte.onrender.com/components/Select
+        url: https://svelte.carbondesignsystem.com/components/Select
   selectable-tile:
     name: Selectable tile
     status: stable
@@ -534,7 +534,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-components-svelte.onrender.com/components/SelectableTile
+        url: https://svelte.carbondesignsystem.com/components/SelectableTile
     tags:
       - input-control
   skeleton-placeholder:
@@ -548,7 +548,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-components-svelte.onrender.com/components/SkeletonPlaceholder
+        url: https://svelte.carbondesignsystem.com/components/SkeletonPlaceholder
     tags:
       - system-feedback
   skeleton-text:
@@ -562,7 +562,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-components-svelte.onrender.com/components/SkeletonText
+        url: https://svelte.carbondesignsystem.com/components/SkeletonText
     tags:
       - shell
   slider:
@@ -573,7 +573,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-components-svelte.onrender.com/components/Slider
+        url: https://svelte.carbondesignsystem.com/components/Slider
   structured-list:
     status: stable
     framework: svelte
@@ -582,7 +582,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-components-svelte.onrender.com/components/StructuredList
+        url: https://svelte.carbondesignsystem.com/components/StructuredList
   tabs:
     status: stable
     framework: svelte
@@ -591,7 +591,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-components-svelte.onrender.com/components/Tabs
+        url: https://svelte.carbondesignsystem.com/components/Tabs
   tag:
     status: stable
     framework: svelte
@@ -600,7 +600,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-components-svelte.onrender.com/components/Tag
+        url: https://svelte.carbondesignsystem.com/components/Tag
   text-area:
     status: stable
     framework: svelte
@@ -608,7 +608,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-components-svelte.onrender.com/components/TextArea
+        url: https://svelte.carbondesignsystem.com/components/TextArea
   text-input:
     status: stable
     framework: svelte
@@ -617,7 +617,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-components-svelte.onrender.com/components/TextInput
+        url: https://svelte.carbondesignsystem.com/components/TextInput
   theme:
     status: stable
     framework: svelte
@@ -625,7 +625,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-components-svelte.onrender.com/components/Theme
+        url: https://svelte.carbondesignsystem.com/components/Theme
   tile:
     status: stable
     framework: svelte
@@ -634,7 +634,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-components-svelte.onrender.com/components/Tile
+        url: https://svelte.carbondesignsystem.com/components/Tile
   time-picker:
     status: stable
     framework: svelte
@@ -642,7 +642,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-components-svelte.onrender.com/components/TimePicker
+        url: https://svelte.carbondesignsystem.com/components/TimePicker
   toast-notification:
     name: Toast notification
     status: stable
@@ -654,7 +654,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-components-svelte.onrender.com/components/ToastNotification
+        url: https://svelte.carbondesignsystem.com/components/ToastNotification
     tags:
       - input-control
   toggle:
@@ -665,7 +665,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-components-svelte.onrender.com/components/Toggle
+        url: https://svelte.carbondesignsystem.com/components/Toggle
   tooltip:
     status: stable
     framework: svelte
@@ -674,7 +674,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-components-svelte.onrender.com/components/Tooltip
+        url: https://svelte.carbondesignsystem.com/components/Tooltip
   tooltip-icon:
     name: Tootlip icon
     status: stable
@@ -686,7 +686,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-components-svelte.onrender.com/components/TooltipIcon
+        url: https://svelte.carbondesignsystem.com/components/TooltipIcon
     tags:
       - content-element
   tree-view:
@@ -696,7 +696,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-components-svelte.onrender.com/components/TreeView
+        url: https://svelte.carbondesignsystem.com/components/TreeView
   truncate:
     name: Truncate
     status: stable
@@ -708,7 +708,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-components-svelte.onrender.com/components/Truncate
+        url: https://svelte.carbondesignsystem.com/components/Truncate
     tags:
       - data-display
   ui-shell-header:
@@ -719,7 +719,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-components-svelte.onrender.com/components/UIShell
+        url: https://svelte.carbondesignsystem.com/components/UIShell
   unordered-list:
     name: Unordered list
     status: stable
@@ -731,7 +731,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-components-svelte.onrender.com/components/UnorderedList
+        url: https://svelte.carbondesignsystem.com/components/UnorderedList
     tags:
       - data-display
       


### PR DESCRIPTION
https://svelte.carbondesignsystem.com/ is the new domain for the docs site.

This URL is more concise, professional, and consistent with other Carbon libraries (e.g., [react](https://react.carbondesignsystem.com)).

https://carbon-components-svelte.onrender.com/ will continue to work.