### PR TITLE
docs(form): fix typo in "Form" example

### DIFF
--- a/docs/src/pages/components/Form.svx
+++ b/docs/src/pages/components/Form.svx
@@ -46,7 +46,7 @@ components: ["Form", "FormGroup"]
     </RadioButtonGroup>
   </FormGroup>
   <FormGroup>
-  <Select id="select-1" labelText="Select menu" value="placeholder-item">
+  <Select id="select-1" labelText="Select menu">
     <SelectItem
       disabled
       hidden


### PR DESCRIPTION
Closes #1813

`value` is not a valid prop on `Select`. This is a typo as it should be the `selected` prop. In this case, removing it still works because the value of the first `SelectItem` is used as the default selected value.