### PR TITLE
docs: add `link rel="canonical"` to pages

### DIFF
--- a/docs/src/layouts/ComponentLayout.svelte
+++ b/docs/src/layouts/ComponentLayout.svelte
@@ -65,6 +65,13 @@
   )}`;
 </script>
 
+<svelte:head>
+  <link
+    rel="canonical"
+    href="https://svelte.carbondesignsystem.com/components/{component}"
+  />
+</svelte:head>
+
 <Content data-components>
   <Grid class="fix-overflow">
     <Row>

--- a/docs/src/pages/index.svelte
+++ b/docs/src/pages/index.svelte
@@ -59,6 +59,10 @@
 </svelte:head>`;
 </script>
 
+<svelte:head>
+  <link rel="canonical" href="https://svelte.carbondesignsystem.com/" />
+</svelte:head>
+
 <Content>
   <Grid>
     <Row>


### PR DESCRIPTION
Encourage search engines to prefer https://svelte.carbondesignsystem.com.