### PR TITLE
fix(pagination-nav): set `button type="button"` to prevent form submission

### DIFF
--- a/src/PaginationNav/PaginationItem.svelte
+++ b/src/PaginationNav/PaginationItem.svelte
@@ -8,6 +8,7 @@
 
 <li class:bx--pagination-nav__list-item="{true}">
   <button
+    type="button"
     data-page="{page}"
     aria-current="{active ? 'page' : undefined}"
     class:bx--pagination-nav__page="{true}"


### PR DESCRIPTION
When `PaginationNav` is used inside a `form`, the form will be submitted when clicking a page button.

This is because the `button` lacks an explicit `type` attribute. If contained within a form, the default type is "submit."

```html
<form>
  <PaginationNav />
</form>
```