### PR TITLE
docs: implement rudimentary full-text search

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,3 +1,4 @@
 /node_modules
 /dist
 /.routify
+src/SEARCH_INDEX.json

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,10 +1,11 @@
 {
   "private": true,
   "scripts": {
-    "dev": "run-p dev:*",
+    "dev": "yarn build:index-docs && run-p dev:*",
     "dev:routify": "cross-env NODE_ENV=development routify run",
     "dev:svite": "vite dev",
     "build": "run-s build:*",
+    "build:index-docs": "node scripts/index-docs.js",
     "build:routify": "routify run -b",
     "build:svite": "vite build"
   },
@@ -16,6 +17,7 @@
     "clipboard-copy": "^4.0.1",
     "cross-env": "^7.0.3",
     "mdsvex": "^0.10.6",
+    "minisearch": "^6.2.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.7.1",
     "prettier-plugin-svelte": "^2.7.0",

--- a/docs/scripts/index-docs.js
+++ b/docs/scripts/index-docs.js
@@ -1,0 +1,43 @@
+// @ts-check
+const fs = require("fs");
+const path = require("path");
+const { slug } = require("github-slugger");
+
+const COMPONENTS_PATH = "./src/pages/components";
+const SEARCH_INDEX_PATH = "./src/SEARCH_INDEX.json";
+const H2_DELMIMITER = "## ";
+
+const files = fs.readdirSync(COMPONENTS_PATH);
+
+/**
+ * @typedef {Object} Document
+ * @property {string} id
+ * @property {string} text
+ * @property {string} description
+ * @property {string} href
+ */
+
+/** @type {Document[]} */
+const documents = [];
+
+for (const file of files) {
+  const [component_name] = file.split(".");
+  const file_path = path.join(COMPONENTS_PATH, file);
+  const file_content = fs.readFileSync(file_path, "utf8");
+
+  file_content.split("\n").forEach((line) => {
+    if (line.startsWith(H2_DELMIMITER)) {
+      const [, h2] = line.split(H2_DELMIMITER);
+      const hash = slug(h2);
+
+      documents.push({
+        id: component_name + hash,
+        text: component_name,
+        description: h2,
+        href: `/components/${component_name}#${hash}`,
+      });
+    }
+  });
+}
+
+fs.writeFileSync(SEARCH_INDEX_PATH, JSON.stringify(documents, null, 2));

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -165,7 +165,7 @@ bufferutil@^4.0.1:
     node-gyp-build "~3.7.0"
 
 carbon-components-svelte@../:
-  version "0.81.1"
+  version "0.82.1"
   dependencies:
     flatpickr "4.6.9"
 
@@ -878,6 +878,11 @@ minimist@^1.2.5:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
   integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
+
+minisearch@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/minisearch/-/minisearch-6.2.0.tgz#310b50508551f22e10815f5baedeeeded03a6b5d"
+  integrity sha512-BECkorDF1TY2rGKt9XHdSeP9TP29yUbrAaCh/C03wpyf1vx3uYcP/+8XlMcpTkgoU0rBVnHMAOaP83Rc9Tm+TQ==
 
 ms@2.1.2:
   version "2.1.2"


### PR DESCRIPTION
This PR aims to improve the docs UX by adding client-side, full-text search using [minisearch](https://www.npmjs.com/package/minisearch).

The search index is extremely basic; it only searches the component name and example heading. More weight is given to the heading. A maximum of 10 results are shown.

For example: searching "bat" should yield `DataTable – batch selection`.

**Future Work**

- Example description text should also be indexed.

---

<img width="795" alt="Screenshot 2023-11-20 at 1 19 24 PM" src="https://github.com/carbon-design-system/carbon-components-svelte/assets/10718366/3f963c03-e6f3-4898-8610-9b983ec2618b">
