### PR TITLE
fix(header-search): vertically center button icons

### DIFF
--- a/src/UIShell/HeaderSearch.svelte
+++ b/src/UIShell/HeaderSearch.svelte
@@ -226,6 +226,9 @@
   }
 
   button {
+    display: flex;
+    align-items: center;
+    justify-content: center;
     width: 3rem;
     height: 100%;
     padding: 0;


### PR DESCRIPTION
The search and clear button icons in the `UIShell` `HeaderSearch` component are currently misaligned. They should be vertically centered.