### PR TITLE
fix(header-search): "Escape" should clear search query

### DIFF
--- a/src/UIShell/HeaderSearch.svelte
+++ b/src/UIShell/HeaderSearch.svelte
@@ -114,6 +114,12 @@
               selectedResultIndex -= 1;
             }
             break;
+          case 'Escape':
+            // Reset the search query but keep the search bar active.
+            // Do not dispatch "clear" event as that should fire only on the "x" button.
+            value = '';
+            selectedResultIndex = 0;
+            break;
         }
       }}"
       on:paste


### PR DESCRIPTION
Pressing "Escape" in `HeaderSearch` should reset the search query without deactivating the search bar.