### PR TITLE
fix(header-search): "Escape" should close empty search bar

### DIFF
--- a/src/UIShell/HeaderSearch.svelte
+++ b/src/UIShell/HeaderSearch.svelte
@@ -115,6 +115,11 @@
             }
             break;
           case 'Escape':
+            if (value === '') {
+              // If the search bar is empty, close it.
+              active = false;
+            }
+
             // Reset the search query but keep the search bar active.
             // Do not dispatch "clear" event as that should fire only on the "x" button.
             value = '';


### PR DESCRIPTION
Follow-up to #1851.

"Escape" should reset the query but keep the search bar focused *if* the value is not empty.

For an empty value, "Escape" should blur and deactivate the search input. This is consistent with search inputs in general.