### PR TITLE
docs: rework keyboard shortcuts to focus search bar

### DIFF
--- a/docs/src/pages/_layout.svelte
+++ b/docs/src/pages/_layout.svelte
@@ -1,8 +1,3 @@
-<script context="module">
-  // Pressing these keys will focus the search bar.
-  const FOCUS_KEYS = new Set(["/", "Metak"]);
-</script>
-
 <script>
   import {
     isActive,
@@ -47,7 +42,6 @@
   const deprecated = [];
   const new_components = [];
 
-  let keys = "";
   let value = "";
   let active = false;
   $: results = miniSearch.search(value).slice(0, 10);
@@ -72,25 +66,18 @@
 
 <svelte:body
   on:keydown="{(e) => {
-    keys += e.key;
-  }}"
-  on:keyup="{(e) => {
     if (active) return;
-
-    if (FOCUS_KEYS.has(keys)) {
-      if (
-        document.activeElement instanceof HTMLInputElement ||
-        document.activeElement instanceof HTMLTextAreaElement
-      ) {
-        // Exit early if an inputtable element is already focused.
-        return;
-      }
-
+    if (
+      document.activeElement instanceof HTMLInputElement ||
+      document.activeElement instanceof HTMLTextAreaElement
+    ) {
+      // Exit early if an inputtable element is already focused.
+      return;
+    }
+    if ((e.metaKey && e.key === 'k') || e.key === '/') {
       e.preventDefault();
       active = true;
     }
-
-    keys = '';
   }}" />
 
 <Theme persist bind:theme="{$theme}">


### PR DESCRIPTION
Reworks #1852

The keyboard shortcut behavior should trigger on keydown, not keyup. This is most noticeable when holding down CMD+K and nothing happens. Pressing CMD+K should immediately focus the search bar.