### PR TITLE
fix(header-search): blur input when deactivating

### DIFF
--- a/src/UIShell/HeaderSearch.svelte
+++ b/src/UIShell/HeaderSearch.svelte
@@ -116,8 +116,9 @@
             break;
           case 'Escape':
             if (value === '') {
-              // If the search bar is empty, close it.
+              // If the search bar is empty, deactivate and blur the input.
               active = false;
+              ref?.blur();
             }
 
             // Reset the search query but keep the search bar active.


### PR DESCRIPTION
Fast-follow to [#1853](https://github.com/carbon-design-system/carbon-components-svelte/issues/1853).

"Escape" should deactivate the search input if no query is present. However, after deactivating, the input retains focus. It should also be blurred.