### PR TITLE
fix(header-search): blur input when `active` is false

### DIFF
--- a/src/UIShell/HeaderSearch.svelte
+++ b/src/UIShell/HeaderSearch.svelte
@@ -46,6 +46,7 @@
   }
 
   $: if (active && ref) ref.focus();
+  $: if (!active && ref) ref.blur();
   $: dispatch(active ? "active" : "inactive");
   $: selectedResult = results[selectedResultIndex];
   $: selectedId = selectedResult
@@ -116,9 +117,8 @@
             break;
           case 'Escape':
             if (value === '') {
-              // If the search bar is empty, deactivate and blur the input.
+              // If the search bar is empty, deactivate the input.
               active = false;
-              ref?.blur();
             }
 
             // Reset the search query but keep the search bar active.


### PR DESCRIPTION
Fast-follow to [#1855](https://github.com/carbon-design-system/carbon-components-svelte/issues/1855)

#1855 correctly blurred the input on "Escape." However, if programmatically de-activating the search bar (e.g., setting `active` to `false` or selecting an option), the input remains focused.

For example, the following bug occurs:

1. Activate search bar.
2. Select an option in the menu.
3. The input is "visually" collapsed but the element retains focus.

A more holistic approach would be to use a reactive statement and blur the input when `active` becomes `false`. This is similar to how the input is focused when `active` is `true`.