### PR TITLE
fix(package): include types in exports map

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,10 +6,18 @@
   "svelte": "./src/index.js",
   "exports": {
     ".": {
+      "types": "./types/index.d.ts",
       "svelte": "./src/index.js"
     },
     "./css/*": "./css/*",
-    "./src/*": "./src/*"
+    "./src/*.svelte": {
+      "types": "./types/*.svelte.d.ts",
+      "import": "./src/*.svelte"
+    },
+    "./src/*": {
+      "types": "./types/*.d.ts",
+      "import": "./src/*.js"
+    }
   },
   "main": "./lib/index.js",
   "module": "./lib/index.mjs",


### PR DESCRIPTION
Fast-follow to #1864, Fixes #1863

Types must also be specified in the `exports` map.