### PR TITLE
build: set up separate publish jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,7 @@ on:
       - "v*"
 
 jobs:
-  build-stable:
-    if: ${{ ! contains(github.ref, '-next') }}
+  build:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -16,36 +15,23 @@ jobs:
         with:
           node-version: "18.x"
           registry-url: "https://registry.npmjs.org"
-      - name: Publish package
+      - name: Build
+        run: |
+          npm install --force
+          npm run build:docs & npm run build:lib
+      - name: Publish package (stable)
+        if: ${{ ! contains(github.ref, '-next') }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
 
         # Currently, only npm supports publishing packages with provenance
         # https://docs.npmjs.com/generating-provenance-statements
         run: |
-          npm install --force
-          npm run build:docs & npm run build:lib
           npm publish --provenance --access public
-
-  # Publish with `next` tag
-  build-next:
-    if: ${{ contains(github.ref, '-next') }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "18.x"
-          registry-url: "https://registry.npmjs.org"
-      - name: Publish package
+      - name: Publish package (next)
+        if: ${{ contains(github.ref, '-next') }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
-
-        # Currently, only npm supports publishing packages with provenance
-        # https://docs.npmjs.com/generating-provenance-statements
         run: |
           npm install --force
           npm run build:docs & npm run build:lib

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,8 @@ on:
       - "v*"
 
 jobs:
-  build:
+  build-stable:
+    if: ${{ ! contains(github.ref, '-next') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -25,3 +26,27 @@ jobs:
           npm install --force
           npm run build:docs & npm run build:lib
           npm publish --provenance --access public
+
+  # Publish with `next` tag
+  build-next:
+    if: ${{ contains(github.ref, '-next') }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "18.x"
+          registry-url: "https://registry.npmjs.org"
+      - name: Publish package
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+
+        # Currently, only npm supports publishing packages with provenance
+        # https://docs.npmjs.com/generating-provenance-statements
+        run: |
+          npm install --force
+          npm run build:docs & npm run build:lib
+          npm publish --provenance --access public --tag next

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,4 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
         run: |
-          npm install --force
-          npm run build:docs & npm run build:lib
           npm publish --provenance --access public --tag next


### PR DESCRIPTION
One for stable and one for next tags.

- conditionally run a `publish` job that sets `--tag next` when the Git tag includes the string `-next`; otherwise use `latest` by default