### PR TITLE
feat(ui-shell): support button tooltip in `HeaderGlobalAction`

### DIFF
--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -1667,7 +1667,7 @@ None.
 
 | Prop name | Required | Kind             | Reactive | Type                                                      | Default value          | Description                                   |
 | :-------- | :------- | :--------------- | :------- | --------------------------------------------------------- | ---------------------- | --------------------------------------------- |
-| ref       | No       | <code>let</code> | Yes      | --                                                        | <code>null</code>      | Obtain a reference to the HTML button element |
+| ref       | No       | <code>let</code> | Yes      | <code>HTMLButtonElement</code>                            | <code>null</code>      | Obtain a reference to the HTML button element |
 | isActive  | No       | <code>let</code> | No       | <code>boolean</code>                                      | <code>false</code>     | Set to `true` to use the active variant       |
 | icon      | No       | <code>let</code> | No       | <code>typeof import("svelte").SvelteComponent<any></code> | <code>undefined</code> | Specify the icon to render                    |
 

--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -379,7 +379,7 @@ export type BreakpointValue = 320 | 672 | 1056 | 1312 | 1584;
 | size             | No       | <code>let</code> | No       | <code>"default" &#124; "field" &#124; "small" &#124; "lg" &#124; "xl"</code>                                                              | <code>"default"</code> | Specify the size of button                                                                                                                                                                    |
 | expressive       | No       | <code>let</code> | No       | <code>boolean</code>                                                                                                                      | <code>false</code>     | Set to `true` to use Carbon's expressive typesetting                                                                                                                                          |
 | isSelected       | No       | <code>let</code> | No       | <code>boolean</code>                                                                                                                      | <code>false</code>     | Set to `true` to enable the selected state for an icon-only, ghost button                                                                                                                     |
-| icon             | No       | <code>let</code> | No       | <code>typeof import("svelte").SvelteComponent<any></code>                                                                                 | <code>undefined</code> | Specify the icon to render                                                                                                                                                                    |
+| icon             | No       | <code>let</code> | No       | <code>typeof import("svelte").SvelteComponent<any></code>                                                                                 | <code>undefined</code> | Specify the icon to render<br />Alternatively, use the named slot "icon" (e.g., `&lt;Icon slot="icon" size="{20}" /&gt;`)                                                                     |
 | iconDescription  | No       | <code>let</code> | No       | <code>string</code>                                                                                                                       | <code>undefined</code> | Specify the ARIA label for the button icon                                                                                                                                                    |
 | tooltipAlignment | No       | <code>let</code> | No       | <code>"start" &#124; "center" &#124; "end"</code>                                                                                         | <code>"center"</code>  | Set the alignment of the tooltip relative to the icon.<br />Only applies to icon-only buttons                                                                                                 |
 | tooltipPosition  | No       | <code>let</code> | No       | <code>"top" &#124; "right" &#124; "bottom" &#124; "left"</code>                                                                           | <code>"bottom"</code>  | Set the position of the tooltip relative to the icon                                                                                                                                          |
@@ -395,6 +395,7 @@ export type BreakpointValue = 320 | 672 | 1056 | 1312 | 1584;
 | Slot name | Default | Props                                                                                                                                           | Fallback |
 | :-------- | :------ | :---------------------------------------------------------------------------------------------------------------------------------------------- | :------- |
 | --        | Yes     | <code>{ props: { role: "button"; type?: string; tabindex: any; disabled: boolean; href?: string; class: string; [key: string]: any; } } </code> | --       |
+| icon      | No      | --                                                                                                                                              | --       |
 
 ### Events
 
@@ -1666,15 +1667,13 @@ None.
 
 | Prop name | Required | Kind             | Reactive | Type                                                      | Default value          | Description                                   |
 | :-------- | :------- | :--------------- | :------- | --------------------------------------------------------- | ---------------------- | --------------------------------------------- |
-| ref       | No       | <code>let</code> | Yes      | <code>null &#124; HTMLButtonElement</code>                | <code>null</code>      | Obtain a reference to the HTML button element |
+| ref       | No       | <code>let</code> | Yes      | --                                                        | <code>null</code>      | Obtain a reference to the HTML button element |
 | isActive  | No       | <code>let</code> | No       | <code>boolean</code>                                      | <code>false</code>     | Set to `true` to use the active variant       |
 | icon      | No       | <code>let</code> | No       | <code>typeof import("svelte").SvelteComponent<any></code> | <code>undefined</code> | Specify the icon to render                    |
 
 ### Slots
 
-| Slot name | Default | Props | Fallback                                                          |
-| :-------- | :------ | :---- | :---------------------------------------------------------------- |
-| --        | Yes     | --    | <code>&lt;svelte:component this="{icon}" size="{20}" /&gt;</code> |
+None.
 
 ### Events
 

--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -5104,6 +5104,7 @@
           "name": "ref",
           "kind": "let",
           "description": "Obtain a reference to the HTML button element",
+          "type": "HTMLButtonElement",
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,

--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -500,7 +500,7 @@
         {
           "name": "icon",
           "kind": "let",
-          "description": "Specify the icon to render",
+          "description": "Specify the icon to render\nAlternatively, use the named slot \"icon\" (e.g., `<Icon slot=\"icon\" size=\"{20}\" />`)",
           "type": "typeof import(\"svelte\").SvelteComponent<any>",
           "isFunction": false,
           "isFunctionDeclaration": false,
@@ -633,7 +633,8 @@
           "name": "__default__",
           "default": true,
           "slot_props": "{ props: { role: \"button\"; type?: string; tabindex: any; disabled: boolean; href?: string; class: string; [key: string]: any; } }"
-        }
+        },
+        { "name": "icon", "default": false, "slot_props": "{}" }
       ],
       "events": [
         { "type": "forwarded", "name": "click", "element": "ButtonSkeleton" },
@@ -5103,7 +5104,6 @@
           "name": "ref",
           "kind": "let",
           "description": "Obtain a reference to the HTML button element",
-          "type": "null | HTMLButtonElement",
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
@@ -5113,17 +5113,14 @@
         }
       ],
       "moduleExports": [],
-      "slots": [
-        {
-          "name": "__default__",
-          "default": true,
-          "fallback": "<svelte:component this=\"{icon}\" size=\"{20}\" />",
-          "slot_props": "{}"
-        }
-      ],
-      "events": [{ "type": "forwarded", "name": "click", "element": "button" }],
+      "slots": [],
+      "events": [{ "type": "forwarded", "name": "click", "element": "Button" }],
       "typedefs": [],
-      "rest_props": { "type": "Element", "name": "button" }
+      "rest_props": { "type": "InlineComponent", "name": "Button" },
+      "extends": {
+        "interface": "ButtonProps",
+        "import": "\"../Button/Button.svelte\""
+      }
     },
     {
       "moduleName": "HeaderNav",

--- a/docs/src/pages/framed/UIShell/HeaderUtilities.svelte
+++ b/docs/src/pages/framed/UIShell/HeaderUtilities.svelte
@@ -31,7 +31,7 @@
     <SkipToContent />
   </svelte:fragment>
   <HeaderUtilities>
-    <HeaderGlobalAction aria-label="Settings" icon="{SettingsAdjust}" />
+    <HeaderGlobalAction iconDescription="Settings" icon="{SettingsAdjust}" />
     <HeaderAction
       bind:isOpen="{isOpen1}"
       icon="{UserAvatarFilledAlt}"

--- a/docs/src/pages/framed/UIShell/HeaderUtilities.svelte
+++ b/docs/src/pages/framed/UIShell/HeaderUtilities.svelte
@@ -2,11 +2,7 @@
   import {
     Header,
     HeaderUtilities,
-    HeaderAction,
     HeaderGlobalAction,
-    HeaderPanelLinks,
-    HeaderPanelDivider,
-    HeaderPanelLink,
     SideNav,
     SideNavItems,
     SideNavMenu,
@@ -18,12 +14,11 @@
     Row,
     Column,
   } from "carbon-components-svelte";
+  import Logout from "carbon-icons-svelte/lib/Logout.svelte";
   import SettingsAdjust from "carbon-icons-svelte/lib/SettingsAdjust.svelte";
   import UserAvatarFilledAlt from "carbon-icons-svelte/lib/UserAvatarFilledAlt.svelte";
 
   let isSideNavOpen = false;
-  let isOpen1 = false;
-  let isOpen2 = false;
 </script>
 
 <Header company="IBM" platformName="Carbon Svelte" bind:isSideNavOpen>
@@ -31,37 +26,20 @@
     <SkipToContent />
   </svelte:fragment>
   <HeaderUtilities>
-    <HeaderGlobalAction iconDescription="Settings" icon="{SettingsAdjust}" />
-    <HeaderAction
-      bind:isOpen="{isOpen1}"
+    <HeaderGlobalAction
+      iconDescription="Settings"
+      tooltipAlignment="start"
+      icon="{SettingsAdjust}"
+    />
+    <HeaderGlobalAction
+      iconDescription="Profile"
       icon="{UserAvatarFilledAlt}"
-      closeIcon="{UserAvatarFilledAlt}"
-    >
-      <HeaderPanelLinks>
-        <HeaderPanelDivider>Switcher subject 1</HeaderPanelDivider>
-        <HeaderPanelLink>Switcher item 1</HeaderPanelLink>
-        <HeaderPanelLink>Switcher item 2</HeaderPanelLink>
-        <HeaderPanelLink>Switcher item 3</HeaderPanelLink>
-        <HeaderPanelLink>Switcher item 4</HeaderPanelLink>
-        <HeaderPanelDivider>Switcher subject 2</HeaderPanelDivider>
-        <HeaderPanelLink>Switcher item 1</HeaderPanelLink>
-        <HeaderPanelLink>Switcher item 2</HeaderPanelLink>
-        <HeaderPanelDivider>Switcher subject 3</HeaderPanelDivider>
-        <HeaderPanelLink>Switcher item 1</HeaderPanelLink>
-      </HeaderPanelLinks>
-    </HeaderAction>
-    <HeaderAction bind:isOpen="{isOpen2}">
-      <HeaderPanelLinks>
-        <HeaderPanelDivider>Switcher subject 1</HeaderPanelDivider>
-        <HeaderPanelLink>Switcher item 1</HeaderPanelLink>
-        <HeaderPanelDivider>Switcher subject 2</HeaderPanelDivider>
-        <HeaderPanelLink>Switcher item 1</HeaderPanelLink>
-        <HeaderPanelLink>Switcher item 2</HeaderPanelLink>
-        <HeaderPanelLink>Switcher item 3</HeaderPanelLink>
-        <HeaderPanelLink>Switcher item 4</HeaderPanelLink>
-        <HeaderPanelLink>Switcher item 5</HeaderPanelLink>
-      </HeaderPanelLinks>
-    </HeaderAction>
+    />
+    <HeaderGlobalAction
+      iconDescription="Log out"
+      tooltipAlignment="end"
+      icon="{Logout}"
+    />
   </HeaderUtilities>
 </Header>
 

--- a/docs/src/pages/framed/UIShell/HeaderUtilities.svelte
+++ b/docs/src/pages/framed/UIShell/HeaderUtilities.svelte
@@ -31,7 +31,7 @@
     <SkipToContent />
   </svelte:fragment>
   <HeaderUtilities>
-    <HeaderGlobalAction iconDescription="Settings" icon="{SettingsAdjust}" />
+    <HeaderGlobalAction aria-label="Settings" icon="{SettingsAdjust}" />
     <HeaderAction
       bind:isOpen="{isOpen1}"
       icon="{UserAvatarFilledAlt}"

--- a/src/Button/Button.svelte
+++ b/src/Button/Button.svelte
@@ -27,6 +27,8 @@
 
   /**
    * Specify the icon to render
+   * Alternatively, use the named slot "icon" (e.g., `<Icon slot="icon" size="{20}" />`)
+   *
    * @type {typeof import("svelte").SvelteComponent<any>}
    */
   export let icon = undefined;
@@ -85,7 +87,12 @@
   $: if (ctx && ref) {
     ctx.declareRef(ref);
   }
-  $: hasIconOnly = icon && !$$slots.default;
+  $: hasIconOnly = (icon || $$slots.icon) && !$$slots.default;
+  $: iconProps = {
+    "aria-hidden": "true",
+    class: "bx--btn__icon",
+    "aria-label": iconDescription,
+  };
   $: buttonProps = {
     type: href && !disabled ? undefined : type,
     tabindex,
@@ -158,12 +165,12 @@
     {#if hasIconOnly}
       <span class:bx--assistive-text="{true}">{iconDescription}</span>
     {/if}
-    <slot /><svelte:component
-      this="{icon}"
-      aria-hidden="true"
-      class="bx--btn__icon"
-      aria-label="{iconDescription}"
-    />
+    <slot />
+    {#if $$slots.icon}
+      <svelte:component this="{icon}" {...iconProps} />
+    {:else if icon}
+      <slot name="icon" {...iconProps} />
+    {/if}
   </a>
 {:else}
   <button
@@ -179,12 +186,19 @@
     {#if hasIconOnly}
       <span class:bx--assistive-text="{true}">{iconDescription}</span>
     {/if}
-    <slot /><svelte:component
-      this="{icon}"
-      aria-hidden="true"
-      class="bx--btn__icon"
-      style="{hasIconOnly ? 'margin-left: 0' : undefined}"
-      aria-label="{iconDescription}"
-    />
+    <slot />
+    {#if $$slots.icon}
+      <slot
+        name="icon"
+        style="{hasIconOnly ? 'margin-left: 0' : undefined}"
+        {...iconProps}
+      />
+    {:else if icon}
+      <svelte:component
+        this="{icon}"
+        style="{hasIconOnly ? 'margin-left: 0' : undefined}"
+        {...iconProps}
+      />
+    {/if}
   </button>
 {/if}

--- a/src/Button/Button.svelte
+++ b/src/Button/Button.svelte
@@ -167,9 +167,17 @@
     {/if}
     <slot />
     {#if $$slots.icon}
-      <svelte:component this="{icon}" {...iconProps} />
+      <slot
+        name="icon"
+        style="{hasIconOnly ? 'margin-left: 0' : undefined}"
+        {...iconProps}
+      />
     {:else if icon}
-      <slot name="icon" {...iconProps} />
+      <svelte:component
+        this="{icon}"
+        style="{hasIconOnly ? 'margin-left: 0' : undefined}"
+        {...iconProps}
+      />
     {/if}
   </a>
 {:else}

--- a/src/UIShell/HeaderGlobalAction.svelte
+++ b/src/UIShell/HeaderGlobalAction.svelte
@@ -1,4 +1,8 @@
 <script>
+  /**
+   * @extends {"../Button/Button.svelte"} ButtonProps
+   */
+
   /** Set to `true` to use the active variant */
   export let isActive = false;
 
@@ -10,17 +14,18 @@
 
   /** Obtain a reference to the HTML button element */
   export let ref = null;
+
+  import Button from "../Button/Button.svelte";
+
+  $: buttonClass = [
+    "bx--header__action",
+    isActive && " bx--header__action--active",
+    $$restProps.class,
+  ]
+    .filter(Boolean)
+    .join(" ");
 </script>
 
-<button
-  type="button"
-  bind:this="{ref}"
-  class:bx--header__action="{true}"
-  class:bx--header__action--active="{isActive}"
-  {...$$restProps}
-  on:click
->
-  <slot>
-    <svelte:component this="{icon}" size="{20}" />
-  </slot>
-</button>
+<Button bind:this="{ref}" class="{buttonClass}" {...$$restProps} on:click>
+  <svelte:component this="{icon}" slot="icon" size="{20}" />
+</Button>

--- a/src/UIShell/HeaderGlobalAction.svelte
+++ b/src/UIShell/HeaderGlobalAction.svelte
@@ -12,7 +12,9 @@
    */
   export let icon = undefined;
 
-  /** Obtain a reference to the HTML button element */
+  /** Obtain a reference to the HTML button element
+   * @type {HTMLButtonElement}
+   */
   export let ref = null;
 
   import Button from "../Button/Button.svelte";

--- a/src/UIShell/HeaderGlobalAction.svelte
+++ b/src/UIShell/HeaderGlobalAction.svelte
@@ -26,6 +26,6 @@
     .join(" ");
 </script>
 
-<Button bind:this="{ref}" class="{buttonClass}" {...$$restProps} on:click>
+<Button bind:ref {...$$restProps} class="{buttonClass}" on:click>
   <svelte:component this="{icon}" slot="icon" size="{20}" />
 </Button>

--- a/tests/HeaderUtilities.test.svelte
+++ b/tests/HeaderUtilities.test.svelte
@@ -30,7 +30,7 @@
     <SkipToContent />
   </div>
   <HeaderUtilities>
-    <HeaderGlobalAction aria-label="Settings" icon="{SettingsAdjust}" />
+    <HeaderGlobalAction iconDescription="Settings" icon="{SettingsAdjust}" />
     <HeaderAction
       bind:isOpen
       on:open

--- a/tests/HeaderUtilities.test.svelte
+++ b/tests/HeaderUtilities.test.svelte
@@ -30,7 +30,7 @@
     <SkipToContent />
   </div>
   <HeaderUtilities>
-    <HeaderGlobalAction iconDescription="Settings" icon="{SettingsAdjust}" />
+    <HeaderGlobalAction aria-label="Settings" icon="{SettingsAdjust}" />
     <HeaderAction
       bind:isOpen
       on:open

--- a/types/Button/Button.svelte.d.ts
+++ b/types/Button/Button.svelte.d.ts
@@ -41,6 +41,7 @@ export interface ButtonProps extends ButtonSkeletonProps, RestProps {
 
   /**
    * Specify the icon to render
+   * Alternatively, use the named slot "icon" (e.g., `<Icon slot="icon" size="{20}" />`)
    * @default undefined
    */
   icon?: typeof import("svelte").SvelteComponent<any>;
@@ -132,5 +133,6 @@ export default class Button extends SvelteComponentTyped<
         [key: string]: any;
       };
     };
+    icon: {};
   }
 > {}

--- a/types/UIShell/HeaderGlobalAction.svelte.d.ts
+++ b/types/UIShell/HeaderGlobalAction.svelte.d.ts
@@ -1,7 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
-import type { ButtonProps } from "../Button/Button.svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface HeaderGlobalActionProps extends ButtonProps {
+type RestProps = SvelteHTMLElements["button"];
+
+export interface HeaderGlobalActionProps extends RestProps {
   /**
    * Set to `true` to use the active variant
    * @default false

--- a/types/UIShell/HeaderGlobalAction.svelte.d.ts
+++ b/types/UIShell/HeaderGlobalAction.svelte.d.ts
@@ -1,9 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
-import type { SvelteHTMLElements } from "svelte/elements";
+import type { ButtonProps } from "../Button/Button.svelte";
 
-type RestProps = SvelteHTMLElements["button"];
-
-export interface HeaderGlobalActionProps extends RestProps {
+export interface HeaderGlobalActionProps extends ButtonProps {
   /**
    * Set to `true` to use the active variant
    * @default false

--- a/types/UIShell/HeaderGlobalAction.svelte.d.ts
+++ b/types/UIShell/HeaderGlobalAction.svelte.d.ts
@@ -1,9 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
-import type { SvelteHTMLElements } from "svelte/elements";
+import type { ButtonProps } from "../Button/Button.svelte";
 
-type RestProps = SvelteHTMLElements["button"];
-
-export interface HeaderGlobalActionProps extends RestProps {
+export interface HeaderGlobalActionProps extends ButtonProps {
   /**
    * Set to `true` to use the active variant
    * @default false
@@ -20,7 +18,7 @@ export interface HeaderGlobalActionProps extends RestProps {
    * Obtain a reference to the HTML button element
    * @default null
    */
-  ref?: undefined;
+  ref?: HTMLButtonElement;
 }
 
 export default class HeaderGlobalAction extends SvelteComponentTyped<

--- a/types/UIShell/HeaderGlobalAction.svelte.d.ts
+++ b/types/UIShell/HeaderGlobalAction.svelte.d.ts
@@ -18,13 +18,11 @@ export interface HeaderGlobalActionProps extends ButtonProps {
    * Obtain a reference to the HTML button element
    * @default null
    */
-  ref?: null | HTMLButtonElement;
-
-  [key: `data-${string}`]: any;
+  ref?: undefined;
 }
 
 export default class HeaderGlobalAction extends SvelteComponentTyped<
   HeaderGlobalActionProps,
   { click: WindowEventMap["click"] },
-  { default: {} }
+  {}
 > {}


### PR DESCRIPTION
Breaking change : Use Button component in HeaderGlobalAction

** Issue: [#1893](https://github.com/carbon-design-system/carbon-components-svelte/issues/1893)

** Edit: an example of updated HeaderGlobalAction

![image](https://github.com/carbon-design-system/carbon-components-svelte/assets/74183548/e6cc2da1-0f2d-4ae8-a641-00bec212966d)
