### PR TITLE
fix(toast-notification): clear `autoclose` timeout correctly 

### DIFF
--- a/docs/src/pages/components/ToastNotification.svx
+++ b/docs/src/pages/components/ToastNotification.svx
@@ -14,6 +14,14 @@ See also: [InlineNotification](InlineNotification)
 
 <ToastNotification title="Error" subtitle="An internal server error occurred." caption="{new Date().toLocaleString()}" />
 
+## Autoclose
+
+By default, `ToastNotification` does not automatically close.
+
+Specify the `timeout` prop to automatically close the notification after a specified duration (in milliseconds).
+
+<FileSource src="/framed/ToastNotification/ToastNotificationTimeout" />
+
 ## Prevent default close behavior
 
 `ToastNotification` is a controlled component. Prevent the default close behavior using the `e.preventDefault()` method in the dispatched `on:close` event.

--- a/docs/src/pages/framed/ToastNotification/ToastNotificationTimeout.svelte
+++ b/docs/src/pages/framed/ToastNotification/ToastNotificationTimeout.svelte
@@ -1,0 +1,32 @@
+<script>
+  import { Button, ToastNotification } from "carbon-components-svelte";
+  import { fade } from "svelte/transition";
+
+  let timeout = undefined;
+  $: showNotification = timeout !== undefined;
+</script>
+
+<Button
+  disabled="{showNotification}"
+  on:click="{() => {
+    timeout = 3_000; // 3 seconds
+  }}"
+>
+  Show notification
+</Button>
+
+{#if showNotification}
+  <div transition:fade>
+    <ToastNotification
+      timeout="{timeout}"
+      kind="success"
+      title="Success"
+      subtitle="This notification will autoclose in {timeout.toLocaleString()} ms."
+      caption="{new Date().toLocaleString()}"
+      on:close="{(e) => {
+        timeout = undefined;
+        console.log(e.detail.timeout); // true if closed via timeout
+      }}"
+    />
+  </div>
+{/if}

--- a/src/Notification/ToastNotification.svelte
+++ b/src/Notification/ToastNotification.svelte
@@ -55,6 +55,9 @@
   let timeoutId = undefined;
 
   function close(closeFromTimeout) {
+    // Clear the timer if the close button was clicked.
+    clearTimeout(timeoutId);
+
     const shouldContinue = dispatch(
       "close",
       { timeout: closeFromTimeout === true },
@@ -66,14 +69,24 @@
   }
 
   onMount(() => {
-    if (timeout) {
-      timeoutId = setTimeout(() => close(true), timeout);
-    }
-
     return () => {
       clearTimeout(timeoutId);
     };
   });
+
+  $: if (typeof window !== "undefined") {
+    /**
+     * Clear the timer if {@link timeout} changes.
+     * If set to `0`, no new timeout is started.
+     * Else, a new timeout is started if {@link open} is not set to `false`.
+     */
+    clearTimeout(timeoutId);
+
+    /** Only start the timer of {@link open} has not been set to `false`. */
+    if (open && timeout) {
+      timeoutId = setTimeout(() => close(true), timeout);
+    }
+  }
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->


### PR DESCRIPTION
Does several things:

**Docs**
- Adds an example using the autoclose `timeout` prop.

**Fixes #1914**


- Fixes `ToastNotification` to start the timer in a reactive statement instead of `onMount`. This means if the `timeout` prop is set or changed after component initialization, the timeout should work as expected.
- Fixes `ToastNotifcation` to reset the timer if the close button is clicked.

---


https://github.com/carbon-design-system/carbon-components-svelte/assets/10718366/eacea953-d93d-4018-bd9f-796b547839c0

