### PR TITLE
fix(image-loader): updated `src` should update the image 

### DIFF
--- a/docs/src/pages/components/ImageLoader.svx
+++ b/docs/src/pages/components/ImageLoader.svx
@@ -44,3 +44,9 @@ Set `fadeIn` to `true` to fade in the image if successfully loaded.
 In this example, a component reference is obtained to programmatically trigger the `loadImage` method.
 
 <FileSource src="/framed/ImageLoader/ProgrammaticImageLoader" />
+
+## Dynamic image source
+
+The same `ImageLoader` instance can be used to load different images.
+
+<FileSource src="/framed/ImageLoader/DynamicImageLoader" />

--- a/docs/src/pages/framed/ImageLoader/DynamicImageLoader.svelte
+++ b/docs/src/pages/framed/ImageLoader/DynamicImageLoader.svelte
@@ -1,0 +1,25 @@
+<script>
+  import { ImageLoader, Button } from "carbon-components-svelte";
+
+  const images = [
+    "https://upload.wikimedia.org/wikipedia/commons/1/1b/Svelte_Logo.svg",
+    "https://upload.wikimedia.org/wikipedia/commons/b/b9/Carbon-design-system-logo.png",
+  ];
+
+  let index = 0;
+
+  $: src = images[index];
+</script>
+
+<Button
+  kind="ghost"
+  on:click="{() => {
+    index = index === 0 ? 1 : 0;
+  }}"
+>
+  Toggle image
+</Button>
+
+<div style:margin-top="1rem" style:width="100%" style:max-width="120px">
+  <ImageLoader ratio="1x1" fadeIn src="{src}" alt="{src}" />
+</div>

--- a/src/ImageLoader/ImageLoader.svelte
+++ b/src/ImageLoader/ImageLoader.svelte
@@ -80,23 +80,7 @@
   {#if loading}
     <slot name="loading" />
   {/if}
-  {#if loaded}
-    <img
-      style:width="100%"
-      {...$$restProps}
-      src="{src}"
-      alt="{alt}"
-      transition:fade|local="{{ duration: fadeIn ? fast02 : 0 }}"
-    />
-  {/if}
-  {#if error}
-    <slot name="error" />
-  {/if}
-{:else}
-  <AspectRatio ratio="{ratio}">
-    {#if loading}
-      <slot name="loading" />
-    {/if}
+  {#key src}
     {#if loaded}
       <img
         style:width="100%"
@@ -106,6 +90,26 @@
         transition:fade|local="{{ duration: fadeIn ? fast02 : 0 }}"
       />
     {/if}
+  {/key}
+  {#if error}
+    <slot name="error" />
+  {/if}
+{:else}
+  <AspectRatio ratio="{ratio}">
+    {#if loading}
+      <slot name="loading" />
+    {/if}
+    {#key src}
+      {#if loaded}
+        <img
+          style:width="100%"
+          {...$$restProps}
+          src="{src}"
+          alt="{alt}"
+          transition:fade|local="{{ duration: fadeIn ? fast02 : 0 }}"
+        />
+      {/if}
+    {/key}
     {#if error}
       <slot name="error" />
     {/if}


### PR DESCRIPTION
Fixes https://github.com/carbon-design-system/carbon-components-svelte/issues/1677

This one was interesting. The `src` prop was indeed correct, but the DOM was not updated to reflect this. The workaround here is to use a `key` block to recreate the element if `src` changes.