### PR TITLE
fix(exports): resolve imports with explicit *.js extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,10 @@
       "types": "./types/*.svelte.d.ts",
       "import": "./src/*.svelte"
     },
+    "./src/*.js": {
+      "types": "./types/*.d.ts",
+      "import": "./src/*.js"
+    },
     "./src/*": {
       "types": "./types/*.d.ts",
       "import": "./src/*.js"


### PR DESCRIPTION
Fixes #1925

Importing using the explicit `.*js` extension will throw an error as these are not included in the package exports map. Normally, this would be acceptable if it's not part of the API.

However, the `optimizeImports` Carbon preprocessor rewrites certain imports (e.g., `breakpoints`) to the source `*.js` file.

```sh
Internal server error: Failed to resolve import "carbon-components-svelte/src/Breakpoint/breakpoints.js" from "src/App.svelte".
```