### PR TITLE
fix(text-area): type `value` prop as nullable

### DIFF
--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -4056,7 +4056,7 @@ None.
 | Prop name   | Required | Kind             | Reactive | Type                                         | Default value                                    | Description                                     |
 | :---------- | :------- | :--------------- | :------- | -------------------------------------------- | ------------------------------------------------ | ----------------------------------------------- |
 | ref         | No       | <code>let</code> | Yes      | <code>null &#124; HTMLTextAreaElement</code> | <code>null</code>                                | Obtain a reference to the textarea HTML element |
-| value       | No       | <code>let</code> | Yes      | <code>string</code>                          | <code>""</code>                                  | Specify the textarea value                      |
+| value       | No       | <code>let</code> | Yes      | <code>null &#124; string</code>              | <code>""</code>                                  | Specify the textarea value.                     |
 | placeholder | No       | <code>let</code> | No       | <code>string</code>                          | <code>""</code>                                  | Specify the placeholder text                    |
 | cols        | No       | <code>let</code> | No       | <code>number</code>                          | <code>50</code>                                  | Specify the number of cols                      |
 | rows        | No       | <code>let</code> | No       | <code>number</code>                          | <code>4</code>                                   | Specify the number of rows                      |

--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -12467,8 +12467,8 @@
         {
           "name": "value",
           "kind": "let",
-          "description": "Specify the textarea value",
-          "type": "string",
+          "description": "Specify the textarea value.",
+          "type": "null | string",
           "value": "\"\"",
           "isFunction": false,
           "isFunctionDeclaration": false,

--- a/src/TextArea/TextArea.svelte
+++ b/src/TextArea/TextArea.svelte
@@ -1,5 +1,10 @@
 <script>
-  /** Specify the textarea value */
+  /**
+   * Specify the textarea value.
+   *
+   * and the value is empty.
+   * @type {null | string}
+   */
   export let value = "";
 
   /** Specify the placeholder text */

--- a/src/TextArea/TextArea.svelte
+++ b/src/TextArea/TextArea.svelte
@@ -1,8 +1,6 @@
 <script>
   /**
    * Specify the textarea value.
-   *
-   * and the value is empty.
    * @type {null | string}
    */
   export let value = "";

--- a/types/TextArea/TextArea.svelte.d.ts
+++ b/types/TextArea/TextArea.svelte.d.ts
@@ -5,10 +5,10 @@ type RestProps = SvelteHTMLElements["textarea"];
 
 export interface TextAreaProps extends RestProps {
   /**
-   * Specify the textarea value
+   * Specify the textarea value.
    * @default ""
    */
-  value?: string;
+  value?: null | string;
 
   /**
    * Specify the placeholder text

--- a/types/TextArea/TextArea.svelte.d.ts
+++ b/types/TextArea/TextArea.svelte.d.ts
@@ -5,10 +5,12 @@ type RestProps = SvelteHTMLElements["textarea"];
 
 export interface TextAreaProps extends RestProps {
   /**
-   * Specify the textarea value
+   * Specify the textarea value.
+   *
+   * and the value is empty.
    * @default ""
    */
-  value?: null | string;
+  value?: string;
 
   /**
    * Specify the placeholder text

--- a/types/TextArea/TextArea.svelte.d.ts
+++ b/types/TextArea/TextArea.svelte.d.ts
@@ -6,8 +6,6 @@ type RestProps = SvelteHTMLElements["textarea"];
 export interface TextAreaProps extends RestProps {
   /**
    * Specify the textarea value.
-   *
-   * and the value is empty.
    * @default ""
    */
   value?: string;

--- a/types/TextArea/TextArea.svelte.d.ts
+++ b/types/TextArea/TextArea.svelte.d.ts
@@ -8,7 +8,7 @@ export interface TextAreaProps extends RestProps {
    * Specify the textarea value
    * @default ""
    */
-  value?: string;
+  value?: null | string;
 
   /**
    * Specify the placeholder text

--- a/types/TextArea/TextArea.svelte.d.ts
+++ b/types/TextArea/TextArea.svelte.d.ts
@@ -5,7 +5,7 @@ type RestProps = SvelteHTMLElements["textarea"];
 
 export interface TextAreaProps extends RestProps {
   /**
-   * Specify the textarea value.
+   * Specify the textarea value
    * @default ""
    */
   value?: string;


### PR DESCRIPTION
Allow null as value attribute on TextArea as on TextInput