### PR TITLE
#1726 - ComboBox: add ability to type arbitrary values that weren't provided in `items`

### DIFF
--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -1506,6 +1506,18 @@
           "reactive": true
         },
         {
+          "name": "allowArbitraryValues",
+          "kind": "let",
+          "description": "Set to `true` to allow values that aren't included in `items`",
+          "type": "boolean",
+          "value": "false",
+          "isFunction": false,
+          "isFunctionDeclaration": false,
+          "isRequired": false,
+          "constant": false,
+          "reactive": false
+        },
+        {
           "name": "direction",
           "kind": "let",
           "description": "Specify the direction of the combobox dropdown menu",

--- a/docs/src/pages/components/ComboBox.svx
+++ b/docs/src/pages/components/ComboBox.svx
@@ -34,6 +34,19 @@ items={[
   {id: "2", text: "Fax"}
   ]}  />
 
+## Arbitrary Values
+
+Set `allowArbitraryValues` to `true` to allow the user to type in whatever value they want, even if it's not present in `items`.
+`selectedId` will be set to `undefined` when the value is arbitrary.
+
+<ComboBox allowArbitraryValues titleText="Contact" placeholder="Select contact method"
+selectedId="1"
+items={[
+  {id: "0", text: "Slack"},
+  {id: "1", text: "Email"},
+  {id: "2", text: "Fax"}
+  ]}  />
+
 ## Reactive example
 
 <FileSource src="/framed/ComboBox/ReactiveComboBox" />

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -120,6 +120,11 @@
   resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.19.9.tgz#b2da6219b603e3fa371a78f53f5361260d0c5585"
   integrity sha512-oxoQgglOP7RH6iasDrhY+R/3cHrfwIDvRlT4CGChflq6twk8iENeVvMJjmvBb94Ik1Z+93iGO27err7w6l54GQ==
 
+"@ibm/telemetry-js@^1.2.1":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@ibm/telemetry-js/-/telemetry-js-1.3.0.tgz#321f2ed4bbbc78d69dc1ee9cb6f83d2d2af9baef"
+  integrity sha512-9gIkyF2B9RizWN6rsdQN76DN6D+/Xbr4HGTwm6EUujfXvEVtWbf4jzxDFwKvZkeTC2tjHpkUNJQKdivbMKt8yg==
+
 "@jridgewell/gen-mapping@^0.3.0":
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz#7e02e6eb5df901aaedb08514203b096614024098"
@@ -399,8 +404,9 @@ bufferutil@^4.0.1:
     node-gyp-build "~3.7.0"
 
 carbon-components-svelte@../:
-  version "0.82.5"
+  version "0.84.1"
   dependencies:
+    "@ibm/telemetry-js" "^1.2.1"
     flatpickr "4.6.9"
 
 carbon-icons-svelte@^12.4.1:


### PR DESCRIPTION
This change implements the ability for users to type in any text they want into a `ComboBox`, without having it removed. This functionality is behind a new flag, called `allowArbitraryValues`. The default is `false`, which means that the `ComboBox` will continue to function the same as it did before if the user does not enable it.

When the value is not present in `items` (it is an arbitrary value), the value of `selectedId` will be `undefined`.

Please let me know what changes are needed. If a separate component is desired instead, I'm happy to make the change. 

Thanks!