### PR TITLE
feat(data-table): support generics

### DIFF
--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -932,7 +932,7 @@ export type DataTableKey<Row = DataTableRow> =
 export type DataTableValue = any;
 
 export interface DataTableEmptyHeader<Row = DataTableRow> {
-  key: DataTableKey<Row> | string;
+  key: DataTableKey<Row> | (string & {});
   empty: boolean;
   display?: (item: Value, row: Row) => DataTableValue;
   sort?: false | ((a: DataTableValue, b: DataTableValue) => number);

--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -932,7 +932,7 @@ export type DataTableKey<Row = DataTableRow> =
 export type DataTableValue = any;
 
 export interface DataTableEmptyHeader<Row = DataTableRow> {
-  key: DataTableKey<Row>;
+  key: DataTableKey<Row> | string;
   empty: boolean;
   display?: (item: Value, row: Row) => DataTableValue;
   sort?: false | ((a: DataTableValue, b: DataTableValue) => number);

--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -926,31 +926,33 @@ None.
 ### Types
 
 ```ts
-export type DataTableKey = string;
+export type DataTableKey<Row = DataTableRow> = Exclude<keyof Row, "id">;
 
 export type DataTableValue = any;
 
-export interface DataTableEmptyHeader {
-  key: DataTableKey;
+export interface DataTableEmptyHeader<Row = DataTableRow> {
+  key: DataTableKey<Row>;
   empty: boolean;
-  display?: (item: DataTableValue, row: DataTableRow) => DataTableValue;
+  display?: (item: DataTableValue, row: Row) => DataTableValue;
   sort?: false | ((a: DataTableValue, b: DataTableValue) => number);
   columnMenu?: boolean;
   width?: string;
   minWidth?: string;
 }
 
-export interface DataTableNonEmptyHeader {
-  key: DataTableKey;
+export interface DataTableNonEmptyHeader<Row = DataTableRow> {
+  key: DataTableKey<Row>;
   value: DataTableValue;
-  display?: (item: DataTableValue, row: DataTableRow) => DataTableValue;
+  display?: (item: DataTableValue, row: Row) => DataTableValue;
   sort?: false | ((a: DataTableValue, b: DataTableValue) => number);
   columnMenu?: boolean;
   width?: string;
   minWidth?: string;
 }
 
-export type DataTableHeader = DataTableNonEmptyHeader | DataTableEmptyHeader;
+export type DataTableHeader<Row = DataTableRow> =
+  | DataTableNonEmptyHeader<Row>
+  | DataTableEmptyHeader<Row>;
 
 export interface DataTableRow {
   id: any;
@@ -959,8 +961,8 @@ export interface DataTableRow {
 
 export type DataTableRowId = any;
 
-export interface DataTableCell {
-  key: DataTableKey;
+export interface DataTableCell<Row = DataTableRow> {
+  key: DataTableKey<Row>;
   value: DataTableValue;
   display?: (item: DataTableValue, row: DataTableRow) => DataTableValue;
 }
@@ -975,9 +977,9 @@ export interface DataTableCell {
 | expandedRowIds      | No       | <code>let</code> | Yes      | <code>ReadonlyArray<DataTableRowId></code>                          | <code>[]</code>        | Specify the row ids to be expanded                                                                                  |
 | expandable          | No       | <code>let</code> | Yes      | <code>boolean</code>                                                | <code>false</code>     | Set to `true` for the expandable variant<br />Automatically set to `true` if `batchExpansion` is `true`             |
 | sortDirection       | No       | <code>let</code> | Yes      | <code>"none" &#124; "ascending" &#124; "descending"</code>          | <code>"none"</code>    | Specify the sort direction                                                                                          |
-| sortKey             | No       | <code>let</code> | Yes      | <code>DataTableKey</code>                                           | <code>null</code>      | Specify the header key to sort by                                                                                   |
-| headers             | No       | <code>let</code> | No       | <code>ReadonlyArray<DataTableHeader></code>                         | <code>[]</code>        | Specify the data table headers                                                                                      |
-| rows                | No       | <code>let</code> | No       | <code>ReadonlyArray<DataTableRow></code>                            | <code>[]</code>        | Specify the rows the data table should render<br />keys defined in `headers` are used for the row ids               |
+| sortKey             | No       | <code>let</code> | Yes      | <code>DataTableKey<Row></code>                                      | <code>null</code>      | Specify the header key to sort by                                                                                   |
+| headers             | No       | <code>let</code> | No       | <code>ReadonlyArray<DataTableHeader<Row>></code>                    | <code>[]</code>        | Specify the data table headers                                                                                      |
+| rows                | No       | <code>let</code> | No       | <code>ReadonlyArray<Row></code>                                     | <code>[]</code>        | Specify the rows the data table should render<br />keys defined in `headers` are used for the row ids               |
 | size                | No       | <code>let</code> | No       | <code>"compact" &#124; "short" &#124; "medium" &#124; "tall"</code> | <code>undefined</code> | Set the size of the data table                                                                                      |
 | title               | No       | <code>let</code> | No       | <code>string</code>                                                 | <code>""</code>        | Specify the title of the data table                                                                                 |
 | description         | No       | <code>let</code> | No       | <code>string</code>                                                 | <code>""</code>        | Specify the description of the data table                                                                           |
@@ -995,29 +997,29 @@ export interface DataTableCell {
 
 ### Slots
 
-| Slot name    | Default | Props                                                                                          | Fallback                                                                 |
-| :----------- | :------ | :--------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------- |
-| --           | Yes     | --                                                                                             | --                                                                       |
-| cell         | No      | <code>{ row: DataTableRow; cell: DataTableCell; rowIndex: number; cellIndex: number; } </code> | <code>{cell.display ? cell.display(cell.value, row) : cell.value}</code> |
-| cell-header  | No      | <code>{ header: DataTableNonEmptyHeader; } </code>                                             | <code>{header.value}</code>                                              |
-| description  | No      | --                                                                                             | <code>{description}</code>                                               |
-| expanded-row | No      | <code>{ row: DataTableRow; } </code>                                                           | --                                                                       |
-| title        | No      | --                                                                                             | <code>{title}</code>                                                     |
+| Slot name    | Default | Props                                                                                      | Fallback                                                                 |
+| :----------- | :------ | :----------------------------------------------------------------------------------------- | :----------------------------------------------------------------------- |
+| --           | Yes     | --                                                                                         | --                                                                       |
+| cell         | No      | <code>{ row: Row; cell: DataTableCell<Row>; rowIndex: number; cellIndex: number; } </code> | <code>{cell.display ? cell.display(cell.value, row) : cell.value}</code> |
+| cell-header  | No      | <code>{ header: DataTableNonEmptyHeader; } </code>                                         | <code>{header.value}</code>                                              |
+| description  | No      | --                                                                                         | <code>{description}</code>                                               |
+| expanded-row | No      | <code>{ row: Row; } </code>                                                                | --                                                                       |
+| title        | No      | --                                                                                         | <code>{title}</code>                                                     |
 
 ### Events
 
-| Event name           | Type       | Detail                                                                                                  |
-| :------------------- | :--------- | :------------------------------------------------------------------------------------------------------ |
-| click                | dispatched | <code>{ header?: DataTableHeader; row?: DataTableRow; cell?: DataTableCell; }</code>                    |
-| click:header--expand | dispatched | <code>{ expanded: boolean; }</code>                                                                     |
-| click:header         | dispatched | <code>{ header: DataTableHeader; sortDirection?: "ascending" &#124; "descending" &#124; "none" }</code> |
-| click:header--select | dispatched | <code>{ indeterminate: boolean; selected: boolean; }</code>                                             |
-| click:row            | dispatched | <code>DataTableRow</code>                                                                               |
-| mouseenter:row       | dispatched | <code>DataTableRow</code>                                                                               |
-| mouseleave:row       | dispatched | <code>DataTableRow</code>                                                                               |
-| click:row--expand    | dispatched | <code>{ expanded: boolean; row: DataTableRow; }</code>                                                  |
-| click:row--select    | dispatched | <code>{ selected: boolean; row: DataTableRow; }</code>                                                  |
-| click:cell           | dispatched | <code>DataTableCell</code>                                                                              |
+| Event name           | Type       | Detail                                                                                                       |
+| :------------------- | :--------- | :----------------------------------------------------------------------------------------------------------- |
+| click                | dispatched | <code>{ header?: DataTableHeader<Row>; row?: Row; cell?: DataTableCell<Row>; }</code>                        |
+| click:header--expand | dispatched | <code>{ expanded: boolean; }</code>                                                                          |
+| click:header         | dispatched | <code>{ header: DataTableHeader<Row>; sortDirection?: "ascending" &#124; "descending" &#124; "none" }</code> |
+| click:header--select | dispatched | <code>{ indeterminate: boolean; selected: boolean; }</code>                                                  |
+| click:row            | dispatched | <code>Row</code>                                                                                             |
+| mouseenter:row       | dispatched | <code>Row</code>                                                                                             |
+| mouseleave:row       | dispatched | <code>Row</code>                                                                                             |
+| click:row--expand    | dispatched | <code>{ expanded: boolean; row: Row; }</code>                                                                |
+| click:row--select    | dispatched | <code>{ selected: boolean; row: Row; }</code>                                                                |
+| click:cell           | dispatched | <code>DataTableCell<Row></code>                                                                              |
 
 ## `DataTableSkeleton`
 

--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -926,14 +926,15 @@ None.
 ### Types
 
 ```ts
-export type DataTableKey<Row = DataTableRow> = Exclude<keyof Row, "id">;
+export type DataTableKey<Row = DataTableRow> =
+  import("./DataTableTypes.d.ts").PropertyPath<Row>;
 
 export type DataTableValue = any;
 
 export interface DataTableEmptyHeader<Row = DataTableRow> {
   key: DataTableKey<Row>;
   empty: boolean;
-  display?: (item: DataTableValue, row: Row) => DataTableValue;
+  display?: (item: Value, row: Row) => DataTableValue;
   sort?: false | ((a: DataTableValue, b: DataTableValue) => number);
   columnMenu?: boolean;
   width?: string;
@@ -943,7 +944,7 @@ export interface DataTableEmptyHeader<Row = DataTableRow> {
 export interface DataTableNonEmptyHeader<Row = DataTableRow> {
   key: DataTableKey<Row>;
   value: DataTableValue;
-  display?: (item: DataTableValue, row: Row) => DataTableValue;
+  display?: (item: Value, row: Row) => DataTableValue;
   sort?: false | ((a: DataTableValue, b: DataTableValue) => number);
   columnMenu?: boolean;
   width?: string;
@@ -962,9 +963,9 @@ export interface DataTableRow {
 export type DataTableRowId = any;
 
 export interface DataTableCell<Row = DataTableRow> {
-  key: DataTableKey<Row>;
+  key: DataTableKey<Row> | (string & {});
   value: DataTableValue;
-  display?: (item: DataTableValue, row: DataTableRow) => DataTableValue;
+  display?: (item: Value, row: DataTableRow) => DataTableValue;
 }
 ```
 

--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -934,7 +934,7 @@ export type DataTableValue = any;
 export interface DataTableEmptyHeader<Row = DataTableRow> {
   key: DataTableKey<Row> | (string & {});
   empty: boolean;
-  display?: (item: Value, row: Row) => DataTableValue;
+  display?: (item: DataTableValue, row: Row) => DataTableValue;
   sort?: false | ((a: DataTableValue, b: DataTableValue) => number);
   columnMenu?: boolean;
   width?: string;
@@ -944,7 +944,7 @@ export interface DataTableEmptyHeader<Row = DataTableRow> {
 export interface DataTableNonEmptyHeader<Row = DataTableRow> {
   key: DataTableKey<Row>;
   value: DataTableValue;
-  display?: (item: Value, row: Row) => DataTableValue;
+  display?: (item: DataTableValue, row: Row) => DataTableValue;
   sort?: false | ((a: DataTableValue, b: DataTableValue) => number);
   columnMenu?: boolean;
   width?: string;
@@ -965,7 +965,7 @@ export type DataTableRowId = any;
 export interface DataTableCell<Row = DataTableRow> {
   key: DataTableKey<Row> | (string & {});
   value: DataTableValue;
-  display?: (item: Value, row: DataTableRow) => DataTableValue;
+  display?: (item: DataTableValue, row: DataTableRow) => DataTableValue;
 }
 ```
 

--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -2716,9 +2716,9 @@
       ],
       "typedefs": [
         {
-          "type": "Exclude<keyof Row, \"id\">",
+          "type": "import('./DataTableTypes.d.ts').PropertyPath<Row>",
           "name": "DataTableKey<Row=DataTableRow>",
-          "ts": "type DataTableKey<Row=DataTableRow> = Exclude<keyof Row, \"id\">"
+          "ts": "type DataTableKey<Row=DataTableRow> = import('./DataTableTypes.d.ts').PropertyPath<Row>"
         },
         {
           "type": "any",
@@ -2726,14 +2726,14 @@
           "ts": "type DataTableValue = any"
         },
         {
-          "type": "{ key: DataTableKey<Row>; empty: boolean; display?: (item: DataTableValue, row: Row) => DataTableValue; sort?: false | ((a: DataTableValue, b: DataTableValue) => number); columnMenu?: boolean; width?: string; minWidth?: string; }",
+          "type": "{\n   key: DataTableKey<Row>;\n   empty: boolean;\n   display?: (item: Value, row: Row) => DataTableValue;\n   sort?: false | ((a: DataTableValue, b: DataTableValue) => number);\n   columnMenu?: boolean;\n   width?: string;\n   minWidth?: string;\n}",
           "name": "DataTableEmptyHeader<Row=DataTableRow>",
-          "ts": "interface DataTableEmptyHeader<Row=DataTableRow> { key: DataTableKey<Row>; empty: boolean; display?: (item: DataTableValue, row: Row) => DataTableValue; sort?: false | ((a: DataTableValue, b: DataTableValue) => number); columnMenu?: boolean; width?: string; minWidth?: string; }"
+          "ts": "interface DataTableEmptyHeader<Row=DataTableRow> {\n   key: DataTableKey<Row>;\n   empty: boolean;\n   display?: (item: Value, row: Row) => DataTableValue;\n   sort?: false | ((a: DataTableValue, b: DataTableValue) => number);\n   columnMenu?: boolean;\n   width?: string;\n   minWidth?: string;\n}"
         },
         {
-          "type": "{ key: DataTableKey<Row>; value: DataTableValue; display?: (item: DataTableValue, row: Row) => DataTableValue; sort?: false | ((a: DataTableValue, b: DataTableValue) => number); columnMenu?: boolean; width?: string; minWidth?: string; }",
+          "type": "{\n   key: DataTableKey<Row>;\n   value: DataTableValue;\n   display?: (item: Value, row: Row) => DataTableValue;\n   sort?: false | ((a: DataTableValue, b: DataTableValue) => number);\n   columnMenu?: boolean;\n   width?: string;\n   minWidth?: string;\n}",
           "name": "DataTableNonEmptyHeader<Row=DataTableRow>",
-          "ts": "interface DataTableNonEmptyHeader<Row=DataTableRow> { key: DataTableKey<Row>; value: DataTableValue; display?: (item: DataTableValue, row: Row) => DataTableValue; sort?: false | ((a: DataTableValue, b: DataTableValue) => number); columnMenu?: boolean; width?: string; minWidth?: string; }"
+          "ts": "interface DataTableNonEmptyHeader<Row=DataTableRow> {\n   key: DataTableKey<Row>;\n   value: DataTableValue;\n   display?: (item: Value, row: Row) => DataTableValue;\n   sort?: false | ((a: DataTableValue, b: DataTableValue) => number);\n   columnMenu?: boolean;\n   width?: string;\n   minWidth?: string;\n}"
         },
         {
           "type": "DataTableNonEmptyHeader<Row> | DataTableEmptyHeader<Row>",
@@ -2751,9 +2751,9 @@
           "ts": "type DataTableRowId = any"
         },
         {
-          "type": "{ key: DataTableKey<Row>; value: DataTableValue; display?: (item: DataTableValue, row: DataTableRow) => DataTableValue; }",
+          "type": "{\n   key: DataTableKey<Row> | (string & {});\n   value: DataTableValue;\n   display?: (item: Value, row: DataTableRow) => DataTableValue;\n}",
           "name": "DataTableCell<Row=DataTableRow>",
-          "ts": "interface DataTableCell<Row=DataTableRow> { key: DataTableKey<Row>; value: DataTableValue; display?: (item: DataTableValue, row: DataTableRow) => DataTableValue; }"
+          "ts": "interface DataTableCell<Row=DataTableRow> {\n   key: DataTableKey<Row> | (string & {});\n   value: DataTableValue;\n   display?: (item: Value, row: DataTableRow) => DataTableValue;\n}"
         }
       ],
       "generics": ["Row", "Row extends DataTableRow = DataTableRow"],

--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -2726,9 +2726,9 @@
           "ts": "type DataTableValue = any"
         },
         {
-          "type": "{\n   key: DataTableKey<Row>;\n   empty: boolean;\n   display?: (item: Value, row: Row) => DataTableValue;\n   sort?: false | ((a: DataTableValue, b: DataTableValue) => number);\n   columnMenu?: boolean;\n   width?: string;\n   minWidth?: string;\n}",
+          "type": "{\n   key: DataTableKey<Row> | string;\n   empty: boolean;\n   display?: (item: Value, row: Row) => DataTableValue;\n   sort?: false | ((a: DataTableValue, b: DataTableValue) => number);\n   columnMenu?: boolean;\n   width?: string;\n   minWidth?: string;\n}",
           "name": "DataTableEmptyHeader<Row=DataTableRow>",
-          "ts": "interface DataTableEmptyHeader<Row=DataTableRow> {\n   key: DataTableKey<Row>;\n   empty: boolean;\n   display?: (item: Value, row: Row) => DataTableValue;\n   sort?: false | ((a: DataTableValue, b: DataTableValue) => number);\n   columnMenu?: boolean;\n   width?: string;\n   minWidth?: string;\n}"
+          "ts": "interface DataTableEmptyHeader<Row=DataTableRow> {\n   key: DataTableKey<Row> | string;\n   empty: boolean;\n   display?: (item: Value, row: Row) => DataTableValue;\n   sort?: false | ((a: DataTableValue, b: DataTableValue) => number);\n   columnMenu?: boolean;\n   width?: string;\n   minWidth?: string;\n}"
         },
         {
           "type": "{\n   key: DataTableKey<Row>;\n   value: DataTableValue;\n   display?: (item: Value, row: Row) => DataTableValue;\n   sort?: false | ((a: DataTableValue, b: DataTableValue) => number);\n   columnMenu?: boolean;\n   width?: string;\n   minWidth?: string;\n}",

--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -2726,9 +2726,9 @@
           "ts": "type DataTableValue = any"
         },
         {
-          "type": "{\n   key: DataTableKey<Row> | string;\n   empty: boolean;\n   display?: (item: Value, row: Row) => DataTableValue;\n   sort?: false | ((a: DataTableValue, b: DataTableValue) => number);\n   columnMenu?: boolean;\n   width?: string;\n   minWidth?: string;\n}",
+          "type": "{\n   key: DataTableKey<Row> | (string & {});\n   empty: boolean;\n   display?: (item: Value, row: Row) => DataTableValue;\n   sort?: false | ((a: DataTableValue, b: DataTableValue) => number);\n   columnMenu?: boolean;\n   width?: string;\n   minWidth?: string;\n}",
           "name": "DataTableEmptyHeader<Row=DataTableRow>",
-          "ts": "interface DataTableEmptyHeader<Row=DataTableRow> {\n   key: DataTableKey<Row> | string;\n   empty: boolean;\n   display?: (item: Value, row: Row) => DataTableValue;\n   sort?: false | ((a: DataTableValue, b: DataTableValue) => number);\n   columnMenu?: boolean;\n   width?: string;\n   minWidth?: string;\n}"
+          "ts": "interface DataTableEmptyHeader<Row=DataTableRow> {\n   key: DataTableKey<Row> | (string & {});\n   empty: boolean;\n   display?: (item: Value, row: Row) => DataTableValue;\n   sort?: false | ((a: DataTableValue, b: DataTableValue) => number);\n   columnMenu?: boolean;\n   width?: string;\n   minWidth?: string;\n}"
         },
         {
           "type": "{\n   key: DataTableKey<Row>;\n   value: DataTableValue;\n   display?: (item: Value, row: Row) => DataTableValue;\n   sort?: false | ((a: DataTableValue, b: DataTableValue) => number);\n   columnMenu?: boolean;\n   width?: string;\n   minWidth?: string;\n}",

--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -2381,7 +2381,7 @@
           "name": "headers",
           "kind": "let",
           "description": "Specify the data table headers",
-          "type": "ReadonlyArray<DataTableHeader>",
+          "type": "ReadonlyArray<DataTableHeader<Row>>",
           "value": "[]",
           "isFunction": false,
           "isFunctionDeclaration": false,
@@ -2393,7 +2393,7 @@
           "name": "rows",
           "kind": "let",
           "description": "Specify the rows the data table should render\nkeys defined in `headers` are used for the row ids",
-          "type": "ReadonlyArray<DataTableRow>",
+          "type": "ReadonlyArray<Row>",
           "value": "[]",
           "isFunction": false,
           "isFunctionDeclaration": false,
@@ -2464,7 +2464,7 @@
           "name": "sortKey",
           "kind": "let",
           "description": "Specify the header key to sort by",
-          "type": "DataTableKey",
+          "type": "DataTableKey<Row>",
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
@@ -2648,7 +2648,7 @@
           "name": "cell",
           "default": false,
           "fallback": "{cell.display ? cell.display(cell.value, row) : cell.value}",
-          "slot_props": "{ row: DataTableRow; cell: DataTableCell; rowIndex: number; cellIndex: number; }"
+          "slot_props": "{ row: Row; cell: DataTableCell<Row>; rowIndex: number; cellIndex: number; }"
         },
         {
           "name": "cell-header",
@@ -2665,7 +2665,7 @@
         {
           "name": "expanded-row",
           "default": false,
-          "slot_props": "{ row: DataTableRow; }"
+          "slot_props": "{ row: Row; }"
         },
         {
           "name": "title",
@@ -2678,7 +2678,7 @@
         {
           "type": "dispatched",
           "name": "click",
-          "detail": "{ header?: DataTableHeader; row?: DataTableRow; cell?: DataTableCell; }"
+          "detail": "{ header?: DataTableHeader<Row>; row?: Row; cell?: DataTableCell<Row>; }"
         },
         {
           "type": "dispatched",
@@ -2688,45 +2688,37 @@
         {
           "type": "dispatched",
           "name": "click:header",
-          "detail": "{ header: DataTableHeader; sortDirection?: \"ascending\" | \"descending\" | \"none\" }"
+          "detail": "{ header: DataTableHeader<Row>; sortDirection?: \"ascending\" | \"descending\" | \"none\" }"
         },
         {
           "type": "dispatched",
           "name": "click:header--select",
           "detail": "{ indeterminate: boolean; selected: boolean; }"
         },
-        { "type": "dispatched", "name": "click:row", "detail": "DataTableRow" },
-        {
-          "type": "dispatched",
-          "name": "mouseenter:row",
-          "detail": "DataTableRow"
-        },
-        {
-          "type": "dispatched",
-          "name": "mouseleave:row",
-          "detail": "DataTableRow"
-        },
+        { "type": "dispatched", "name": "click:row", "detail": "Row" },
+        { "type": "dispatched", "name": "mouseenter:row", "detail": "Row" },
+        { "type": "dispatched", "name": "mouseleave:row", "detail": "Row" },
         {
           "type": "dispatched",
           "name": "click:row--expand",
-          "detail": "{ expanded: boolean; row: DataTableRow; }"
+          "detail": "{ expanded: boolean; row: Row; }"
         },
         {
           "type": "dispatched",
           "name": "click:row--select",
-          "detail": "{ selected: boolean; row: DataTableRow; }"
+          "detail": "{ selected: boolean; row: Row; }"
         },
         {
           "type": "dispatched",
           "name": "click:cell",
-          "detail": "DataTableCell"
+          "detail": "DataTableCell<Row>"
         }
       ],
       "typedefs": [
         {
-          "type": "string",
-          "name": "DataTableKey",
-          "ts": "type DataTableKey = string"
+          "type": "Exclude<keyof Row, \"id\">",
+          "name": "DataTableKey<Row=DataTableRow>",
+          "ts": "type DataTableKey<Row=DataTableRow> = Exclude<keyof Row, \"id\">"
         },
         {
           "type": "any",
@@ -2734,19 +2726,19 @@
           "ts": "type DataTableValue = any"
         },
         {
-          "type": "{ key: DataTableKey; empty: boolean; display?: (item: DataTableValue, row: DataTableRow) => DataTableValue; sort?: false | ((a: DataTableValue, b: DataTableValue) => number); columnMenu?: boolean; width?: string; minWidth?: string; }",
-          "name": "DataTableEmptyHeader",
-          "ts": "interface DataTableEmptyHeader { key: DataTableKey; empty: boolean; display?: (item: DataTableValue, row: DataTableRow) => DataTableValue; sort?: false | ((a: DataTableValue, b: DataTableValue) => number); columnMenu?: boolean; width?: string; minWidth?: string; }"
+          "type": "{ key: DataTableKey<Row>; empty: boolean; display?: (item: DataTableValue, row: Row) => DataTableValue; sort?: false | ((a: DataTableValue, b: DataTableValue) => number); columnMenu?: boolean; width?: string; minWidth?: string; }",
+          "name": "DataTableEmptyHeader<Row=DataTableRow>",
+          "ts": "interface DataTableEmptyHeader<Row=DataTableRow> { key: DataTableKey<Row>; empty: boolean; display?: (item: DataTableValue, row: Row) => DataTableValue; sort?: false | ((a: DataTableValue, b: DataTableValue) => number); columnMenu?: boolean; width?: string; minWidth?: string; }"
         },
         {
-          "type": "{ key: DataTableKey; value: DataTableValue; display?: (item: DataTableValue, row: DataTableRow) => DataTableValue; sort?: false | ((a: DataTableValue, b: DataTableValue) => number); columnMenu?: boolean; width?: string; minWidth?: string; }",
-          "name": "DataTableNonEmptyHeader",
-          "ts": "interface DataTableNonEmptyHeader { key: DataTableKey; value: DataTableValue; display?: (item: DataTableValue, row: DataTableRow) => DataTableValue; sort?: false | ((a: DataTableValue, b: DataTableValue) => number); columnMenu?: boolean; width?: string; minWidth?: string; }"
+          "type": "{ key: DataTableKey<Row>; value: DataTableValue; display?: (item: DataTableValue, row: Row) => DataTableValue; sort?: false | ((a: DataTableValue, b: DataTableValue) => number); columnMenu?: boolean; width?: string; minWidth?: string; }",
+          "name": "DataTableNonEmptyHeader<Row=DataTableRow>",
+          "ts": "interface DataTableNonEmptyHeader<Row=DataTableRow> { key: DataTableKey<Row>; value: DataTableValue; display?: (item: DataTableValue, row: Row) => DataTableValue; sort?: false | ((a: DataTableValue, b: DataTableValue) => number); columnMenu?: boolean; width?: string; minWidth?: string; }"
         },
         {
-          "type": "DataTableNonEmptyHeader | DataTableEmptyHeader",
-          "name": "DataTableHeader",
-          "ts": "type DataTableHeader = DataTableNonEmptyHeader | DataTableEmptyHeader"
+          "type": "DataTableNonEmptyHeader<Row> | DataTableEmptyHeader<Row>",
+          "name": "DataTableHeader<Row=DataTableRow>",
+          "ts": "type DataTableHeader<Row=DataTableRow> = DataTableNonEmptyHeader<Row> | DataTableEmptyHeader<Row>"
         },
         {
           "type": "{ id: any; [key: string]: DataTableValue; }",
@@ -2759,12 +2751,12 @@
           "ts": "type DataTableRowId = any"
         },
         {
-          "type": "{ key: DataTableKey; value: DataTableValue; display?: (item: DataTableValue, row: DataTableRow) => DataTableValue; }",
-          "name": "DataTableCell",
-          "ts": "interface DataTableCell { key: DataTableKey; value: DataTableValue; display?: (item: DataTableValue, row: DataTableRow) => DataTableValue; }"
+          "type": "{ key: DataTableKey<Row>; value: DataTableValue; display?: (item: DataTableValue, row: DataTableRow) => DataTableValue; }",
+          "name": "DataTableCell<Row=DataTableRow>",
+          "ts": "interface DataTableCell<Row=DataTableRow> { key: DataTableKey<Row>; value: DataTableValue; display?: (item: DataTableValue, row: DataTableRow) => DataTableValue; }"
         }
       ],
-      "generics": null,
+      "generics": ["Row", "Row extends DataTableRow = DataTableRow"],
       "rest_props": { "type": "Element", "name": "div" }
     },
     {

--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -2726,14 +2726,14 @@
           "ts": "type DataTableValue = any"
         },
         {
-          "type": "{\n   key: DataTableKey<Row> | (string & {});\n   empty: boolean;\n   display?: (item: Value, row: Row) => DataTableValue;\n   sort?: false | ((a: DataTableValue, b: DataTableValue) => number);\n   columnMenu?: boolean;\n   width?: string;\n   minWidth?: string;\n}",
+          "type": "{\n   key: DataTableKey<Row> | (string & {});\n   empty: boolean;\n   display?: (item: DataTableValue, row: Row) => DataTableValue;\n   sort?: false | ((a: DataTableValue, b: DataTableValue) => number);\n   columnMenu?: boolean;\n   width?: string;\n   minWidth?: string;\n}",
           "name": "DataTableEmptyHeader<Row=DataTableRow>",
-          "ts": "interface DataTableEmptyHeader<Row=DataTableRow> {\n   key: DataTableKey<Row> | (string & {});\n   empty: boolean;\n   display?: (item: Value, row: Row) => DataTableValue;\n   sort?: false | ((a: DataTableValue, b: DataTableValue) => number);\n   columnMenu?: boolean;\n   width?: string;\n   minWidth?: string;\n}"
+          "ts": "interface DataTableEmptyHeader<Row=DataTableRow> {\n   key: DataTableKey<Row> | (string & {});\n   empty: boolean;\n   display?: (item: DataTableValue, row: Row) => DataTableValue;\n   sort?: false | ((a: DataTableValue, b: DataTableValue) => number);\n   columnMenu?: boolean;\n   width?: string;\n   minWidth?: string;\n}"
         },
         {
-          "type": "{\n   key: DataTableKey<Row>;\n   value: DataTableValue;\n   display?: (item: Value, row: Row) => DataTableValue;\n   sort?: false | ((a: DataTableValue, b: DataTableValue) => number);\n   columnMenu?: boolean;\n   width?: string;\n   minWidth?: string;\n}",
+          "type": "{\n   key: DataTableKey<Row>;\n   value: DataTableValue;\n   display?: (item: DataTableValue, row: Row) => DataTableValue;\n   sort?: false | ((a: DataTableValue, b: DataTableValue) => number);\n   columnMenu?: boolean;\n   width?: string;\n   minWidth?: string;\n}",
           "name": "DataTableNonEmptyHeader<Row=DataTableRow>",
-          "ts": "interface DataTableNonEmptyHeader<Row=DataTableRow> {\n   key: DataTableKey<Row>;\n   value: DataTableValue;\n   display?: (item: Value, row: Row) => DataTableValue;\n   sort?: false | ((a: DataTableValue, b: DataTableValue) => number);\n   columnMenu?: boolean;\n   width?: string;\n   minWidth?: string;\n}"
+          "ts": "interface DataTableNonEmptyHeader<Row=DataTableRow> {\n   key: DataTableKey<Row>;\n   value: DataTableValue;\n   display?: (item: DataTableValue, row: Row) => DataTableValue;\n   sort?: false | ((a: DataTableValue, b: DataTableValue) => number);\n   columnMenu?: boolean;\n   width?: string;\n   minWidth?: string;\n}"
         },
         {
           "type": "DataTableNonEmptyHeader<Row> | DataTableEmptyHeader<Row>",
@@ -2751,9 +2751,9 @@
           "ts": "type DataTableRowId = any"
         },
         {
-          "type": "{\n   key: DataTableKey<Row> | (string & {});\n   value: DataTableValue;\n   display?: (item: Value, row: DataTableRow) => DataTableValue;\n}",
+          "type": "{\n   key: DataTableKey<Row> | (string & {});\n   value: DataTableValue;\n   display?: (item: DataTableValue, row: DataTableRow) => DataTableValue;\n}",
           "name": "DataTableCell<Row=DataTableRow>",
-          "ts": "interface DataTableCell<Row=DataTableRow> {\n   key: DataTableKey<Row> | (string & {});\n   value: DataTableValue;\n   display?: (item: Value, row: DataTableRow) => DataTableValue;\n}"
+          "ts": "interface DataTableCell<Row=DataTableRow> {\n   key: DataTableKey<Row> | (string & {});\n   value: DataTableValue;\n   display?: (item: DataTableValue, row: DataTableRow) => DataTableValue;\n}"
         }
       ],
       "generics": ["Row", "Row extends DataTableRow = DataTableRow"],

--- a/src/DataTable/DataTable.svelte
+++ b/src/DataTable/DataTable.svelte
@@ -5,7 +5,7 @@
    * @typedef {import('./DataTableTypes.d.ts').PropertyPath<Row>} DataTableKey<Row=DataTableRow>
    * @typedef {any} DataTableValue
    * @typedef {{
-   *    key: DataTableKey<Row> | string;
+   *    key: DataTableKey<Row> | (string & {});
    *    empty: boolean;
    *    display?: (item: Value, row: Row) => DataTableValue;
    *    sort?: false | ((a: DataTableValue, b: DataTableValue) => number);

--- a/src/DataTable/DataTable.svelte
+++ b/src/DataTable/DataTable.svelte
@@ -5,7 +5,7 @@
    * @typedef {import('./DataTableTypes.d.ts').PropertyPath<Row>} DataTableKey<Row=DataTableRow>
    * @typedef {any} DataTableValue
    * @typedef {{
-   *    key: DataTableKey<Row>;
+   *    key: DataTableKey<Row> | string;
    *    empty: boolean;
    *    display?: (item: Value, row: Row) => DataTableValue;
    *    sort?: false | ((a: DataTableValue, b: DataTableValue) => number);

--- a/src/DataTable/DataTable.svelte
+++ b/src/DataTable/DataTable.svelte
@@ -2,14 +2,34 @@
   /**
    * @generics {Row extends DataTableRow = DataTableRow} Row
    * @template {DataTableRow} Row
-   * @typedef {Exclude<keyof Row, "id">} DataTableKey<Row=DataTableRow>
+   * @typedef {import('./DataTableTypes.d.ts').PropertyPath<Row>} DataTableKey<Row=DataTableRow>
    * @typedef {any} DataTableValue
-   * @typedef {{ key: DataTableKey<Row>; empty: boolean; display?: (item: DataTableValue, row: Row) => DataTableValue; sort?: false | ((a: DataTableValue, b: DataTableValue) => number); columnMenu?: boolean; width?: string; minWidth?: string; }} DataTableEmptyHeader<Row=DataTableRow>
-   * @typedef {{ key: DataTableKey<Row>; value: DataTableValue; display?: (item: DataTableValue, row: Row) => DataTableValue; sort?: false | ((a: DataTableValue, b: DataTableValue) => number); columnMenu?: boolean; width?: string; minWidth?: string; }} DataTableNonEmptyHeader<Row=DataTableRow>
+   * @typedef {{
+   *    key: DataTableKey<Row>;
+   *    empty: boolean;
+   *    display?: (item: Value, row: Row) => DataTableValue;
+   *    sort?: false | ((a: DataTableValue, b: DataTableValue) => number);
+   *    columnMenu?: boolean;
+   *    width?: string;
+   *    minWidth?: string;
+   * }} DataTableEmptyHeader<Row=DataTableRow>
+   * @typedef {{
+   *    key: DataTableKey<Row>;
+   *    value: DataTableValue;
+   *    display?: (item: Value, row: Row) => DataTableValue;
+   *    sort?: false | ((a: DataTableValue, b: DataTableValue) => number);
+   *    columnMenu?: boolean;
+   *    width?: string;
+   *    minWidth?: string;
+   * }} DataTableNonEmptyHeader<Row=DataTableRow>
    * @typedef {DataTableNonEmptyHeader<Row> | DataTableEmptyHeader<Row>} DataTableHeader<Row=DataTableRow>
    * @typedef {{ id: any; [key: string]: DataTableValue; }} DataTableRow
    * @typedef {any} DataTableRowId
-   * @typedef {{ key: DataTableKey<Row>; value: DataTableValue; display?: (item: DataTableValue, row: DataTableRow) => DataTableValue; }} DataTableCell<Row=DataTableRow>
+   * @typedef {{
+   *    key: DataTableKey<Row> | (string & {});
+   *    value: DataTableValue;
+   *    display?: (item: Value, row: DataTableRow) => DataTableValue;
+   * }} DataTableCell<Row=DataTableRow>
    * @slot {{ row: Row; }} expanded-row
    * @slot {{ header: DataTableNonEmptyHeader; }} cell-header
    * @slot {{ row: Row; cell: DataTableCell<Row>; rowIndex: number; cellIndex: number; }} cell

--- a/src/DataTable/DataTable.svelte
+++ b/src/DataTable/DataTable.svelte
@@ -7,7 +7,7 @@
    * @typedef {{
    *    key: DataTableKey<Row> | (string & {});
    *    empty: boolean;
-   *    display?: (item: Value, row: Row) => DataTableValue;
+   *    display?: (item: DataTableValue, row: Row) => DataTableValue;
    *    sort?: false | ((a: DataTableValue, b: DataTableValue) => number);
    *    columnMenu?: boolean;
    *    width?: string;
@@ -16,7 +16,7 @@
    * @typedef {{
    *    key: DataTableKey<Row>;
    *    value: DataTableValue;
-   *    display?: (item: Value, row: Row) => DataTableValue;
+   *    display?: (item: DataTableValue, row: Row) => DataTableValue;
    *    sort?: false | ((a: DataTableValue, b: DataTableValue) => number);
    *    columnMenu?: boolean;
    *    width?: string;
@@ -28,7 +28,7 @@
    * @typedef {{
    *    key: DataTableKey<Row> | (string & {});
    *    value: DataTableValue;
-   *    display?: (item: Value, row: DataTableRow) => DataTableValue;
+   *    display?: (item: DataTableValue, row: DataTableRow) => DataTableValue;
    * }} DataTableCell<Row=DataTableRow>
    * @slot {{ row: Row; }} expanded-row
    * @slot {{ header: DataTableNonEmptyHeader; }} cell-header

--- a/src/DataTable/DataTable.svelte
+++ b/src/DataTable/DataTable.svelte
@@ -1,39 +1,41 @@
 <script>
   /**
-   * @typedef {string} DataTableKey
+   * @generics {Row extends DataTableRow = DataTableRow} Row
+   * @template {DataTableRow} Row
+   * @typedef {Exclude<keyof Row, "id">} DataTableKey<Row=DataTableRow>
    * @typedef {any} DataTableValue
-   * @typedef {{ key: DataTableKey; empty: boolean; display?: (item: DataTableValue, row: DataTableRow) => DataTableValue; sort?: false | ((a: DataTableValue, b: DataTableValue) => number); columnMenu?: boolean; width?: string; minWidth?: string; }} DataTableEmptyHeader
-   * @typedef {{ key: DataTableKey; value: DataTableValue; display?: (item: DataTableValue, row: DataTableRow) => DataTableValue; sort?: false | ((a: DataTableValue, b: DataTableValue) => number); columnMenu?: boolean; width?: string; minWidth?: string; }} DataTableNonEmptyHeader
-   * @typedef {DataTableNonEmptyHeader | DataTableEmptyHeader} DataTableHeader
+   * @typedef {{ key: DataTableKey<Row>; empty: boolean; display?: (item: DataTableValue, row: Row) => DataTableValue; sort?: false | ((a: DataTableValue, b: DataTableValue) => number); columnMenu?: boolean; width?: string; minWidth?: string; }} DataTableEmptyHeader<Row=DataTableRow>
+   * @typedef {{ key: DataTableKey<Row>; value: DataTableValue; display?: (item: DataTableValue, row: Row) => DataTableValue; sort?: false | ((a: DataTableValue, b: DataTableValue) => number); columnMenu?: boolean; width?: string; minWidth?: string; }} DataTableNonEmptyHeader<Row=DataTableRow>
+   * @typedef {DataTableNonEmptyHeader<Row> | DataTableEmptyHeader<Row>} DataTableHeader<Row=DataTableRow>
    * @typedef {{ id: any; [key: string]: DataTableValue; }} DataTableRow
    * @typedef {any} DataTableRowId
-   * @typedef {{ key: DataTableKey; value: DataTableValue; display?: (item: DataTableValue, row: DataTableRow) => DataTableValue; }} DataTableCell
-   * @slot {{ row: DataTableRow; }} expanded-row
+   * @typedef {{ key: DataTableKey<Row>; value: DataTableValue; display?: (item: DataTableValue, row: DataTableRow) => DataTableValue; }} DataTableCell<Row=DataTableRow>
+   * @slot {{ row: Row; }} expanded-row
    * @slot {{ header: DataTableNonEmptyHeader; }} cell-header
-   * @slot {{ row: DataTableRow; cell: DataTableCell; rowIndex: number; cellIndex: number; }} cell
-   * @event {{ header?: DataTableHeader; row?: DataTableRow; cell?: DataTableCell; }} click
+   * @slot {{ row: Row; cell: DataTableCell<Row>; rowIndex: number; cellIndex: number; }} cell
+   * @event {{ header?: DataTableHeader<Row>; row?: Row; cell?: DataTableCell<Row>; }} click
    * @event {{ expanded: boolean; }} click:header--expand
-   * @event {{ header: DataTableHeader; sortDirection?: "ascending" | "descending" | "none" }} click:header
+   * @event {{ header: DataTableHeader<Row>; sortDirection?: "ascending" | "descending" | "none" }} click:header
    * @event {{ indeterminate: boolean; selected: boolean; }} click:header--select
-   * @event {DataTableRow} click:row
-   * @event {DataTableRow} mouseenter:row
-   * @event {DataTableRow} mouseleave:row
-   * @event {{ expanded: boolean; row: DataTableRow; }} click:row--expand
-   * @event {{ selected: boolean; row: DataTableRow; }} click:row--select
-   * @event {DataTableCell} click:cell
+   * @event {Row} click:row
+   * @event {Row} mouseenter:row
+   * @event {Row} mouseleave:row
+   * @event {{ expanded: boolean; row: Row; }} click:row--expand
+   * @event {{ selected: boolean; row: Row; }} click:row--select
+   * @event {DataTableCell<Row>} click:cell
    * @restProps {div}
    */
 
   /**
    * Specify the data table headers
-   * @type {ReadonlyArray<DataTableHeader>}
+   * @type {ReadonlyArray<DataTableHeader<Row>>}
    */
   export let headers = [];
 
   /**
    * Specify the rows the data table should render
    * keys defined in `headers` are used for the row ids
-   * @type {ReadonlyArray<DataTableRow>}
+   * @type {ReadonlyArray<Row>}
    */
   export let rows = [];
 
@@ -57,7 +59,7 @@
 
   /**
    * Specify the header key to sort by
-   * @type {DataTableKey}
+   * @type {DataTableKey<Row>}
    */
   export let sortKey = null;
 

--- a/src/DataTable/DataTableTypes.d.ts
+++ b/src/DataTable/DataTableTypes.d.ts
@@ -1,0 +1,17 @@
+type PathDepth = [never, 0, 1, 2, ...0[]];
+
+type Join<K, P> = K extends string | number
+  ? P extends string | number
+    ? `${K}${"" extends P ? "" : "."}${P}`
+    : never
+  : never;
+
+export type PropertyPath<T, D extends number = 10> = [D] extends [never]
+  ? never
+  : T extends object
+  ? {
+      [K in keyof T]-?: K extends string | number
+        ? `${K}` | Join<K, PropertyPath<T[K], PathDepth[D]>>
+        : never;
+    }[keyof T]
+  : "";

--- a/src/DataTable/DataTableTypes.d.ts
+++ b/src/DataTable/DataTableTypes.d.ts
@@ -2,16 +2,17 @@ type PathDepth = [never, 0, 1, 2, ...0[]];
 
 type Join<K, P> = K extends string | number
   ? P extends string | number
-    ? `${K}${"" extends P ? "" : "."}${P}`
-    : never
+  ? `${K}${"" extends P ? "" : "."}${P}`
+  : never
   : never;
 
+// For performance, the maximum traversal depth is 10.
 export type PropertyPath<T, D extends number = 10> = [D] extends [never]
   ? never
   : T extends object
   ? {
-      [K in keyof T]-?: K extends string | number
-        ? `${K}` | Join<K, PropertyPath<T[K], PathDepth[D]>>
-        : never;
-    }[keyof T]
+    [K in keyof T]-?: K extends string | number
+    ? `${K}` | Join<K, PropertyPath<T[K], PathDepth[D]>>
+    : never;
+  }[keyof T]
   : "";

--- a/tests/DataTable.test.svelte
+++ b/tests/DataTable.test.svelte
@@ -285,3 +285,66 @@
 <DataTableSkeleton showHeader="{false}" showToolbar="{false}" size="short" />
 
 <DataTableSkeleton showHeader="{false}" showToolbar="{false}" size="compact" />
+
+<DataTable
+  rows="{[
+    {
+      name: 'Load Balancer 3',
+      protocol: 'HTTP',
+      port: 3000,
+      rule: 'Round robin',
+      id: '-',
+    },
+  ]}"
+  headers="{[
+    {
+      key: 'name',
+      value: 'Name',
+    },
+    {
+      key: 'protocol',
+      value: 'Protocol',
+      display: (value) => {
+        return value + ' Protocol';
+      },
+    },
+    {
+      key: 'port',
+      value: 'Port',
+      display: (value, row) => {
+        return value + ' €';
+      },
+      sort: (a, b) => {
+        if (a > b) return 1;
+        return 0;
+      },
+    },
+    {
+      key: 'rule',
+      value: 'Rule',
+    },
+  ]}"
+  sortKey="name"
+  on:click:row="{(e) => {
+    const detail = e.detail;
+    detail.name;
+    detail.port;
+  }}"
+  on:click:cell="{(e) => {
+    const detail = e.detail;
+    switch (detail.key) {
+      case 'name':
+        detail.value;
+        break;
+    }
+  }}"
+  on:click="{(e) => {
+    e.detail.cell;
+    e.detail.row.name;
+  }}"
+  on:click:row--expand="{(e) => {
+    const detail = e.detail;
+    detail.row.id;
+    detail.row.name;
+  }}"
+/>

--- a/tests/DataTable.test.svelte
+++ b/tests/DataTable.test.svelte
@@ -10,16 +10,15 @@
     Button,
     Link,
   } from "carbon-components-svelte";
-  import type { DataTableHeader } from "carbon-components-svelte/DataTable/DataTable.svelte";
   import Launch from "carbon-icons-svelte/lib/Launch.svelte";
   import type { ComponentProps } from "svelte";
 
-  const headers: DataTableHeader[] = [
+  const headers = [
     { key: "name", value: "Name" },
     { key: "protocol", value: "Protocol", width: "400px", minWidth: "40%" },
     { key: "port", value: "Port" },
     { key: "rule", value: "Rule", sort: false },
-  ];
+  ] as const;
   const rows = [
     {
       id: "a",
@@ -312,6 +311,7 @@
       key: 'port',
       value: 'Port',
       display: (value, row) => {
+        console.log(row.port);
         return value + ' €';
       },
       sort: (a, b) => {
@@ -340,7 +340,7 @@
   }}"
   on:click="{(e) => {
     e.detail.cell;
-    e.detail.row.name;
+    e.detail.row?.name;
   }}"
   on:click:row--expand="{(e) => {
     const detail = e.detail;

--- a/tests/DataTableAppendColumns.test.svelte
+++ b/tests/DataTableAppendColumns.test.svelte
@@ -54,11 +54,7 @@
   ];
 </script>
 
-<DataTable
-  sortable
-  headers="{headers}"
-  rows="{rows}"
->
+<DataTable sortable headers="{headers}" rows="{rows}">
   <span slot="cell" let:cell>
     {#if cell.key === "overflow"}
       <OverflowMenu flipped>

--- a/tests/DataTableAppendColumns.test.svelte
+++ b/tests/DataTableAppendColumns.test.svelte
@@ -9,48 +9,12 @@
   ] as const;
 
   const rows = [
-    {
-      id: "a",
-      name: "Load Balancer 3",
-      port: 3000,
-      rule: "Round robin",
-      overflow: null,
-    },
-    {
-      id: "b",
-      name: "Load Balancer 1",
-      port: 443,
-      rule: "Round robin",
-      overflow: null,
-    },
-    {
-      id: "c",
-      name: "Load Balancer 2",
-      port: 80,
-      rule: "DNS delegation",
-      overflow: null,
-    },
-    {
-      id: "d",
-      name: "Load Balancer 6",
-      port: 3000,
-      rule: "Round robin",
-      overflow: null,
-    },
-    {
-      id: "e",
-      name: "Load Balancer 4",
-      port: 443,
-      rule: "Round robin",
-      overflow: null,
-    },
-    {
-      id: "f",
-      name: "Load Balancer 5",
-      port: 80,
-      rule: "DNS delegation",
-      overflow: null,
-    },
+    { id: "a", name: "Load Balancer 3", port: 3000, rule: "Round robin" },
+    { id: "b", name: "Load Balancer 1", port: 443, rule: "Round robin" },
+    { id: "c", name: "Load Balancer 2", port: 80, rule: "DNS delegation" },
+    { id: "d", name: "Load Balancer 6", port: 3000, rule: "Round robin" },
+    { id: "e", name: "Load Balancer 4", port: 443, rule: "Round robin" },
+    { id: "f", name: "Load Balancer 5", port: 80, rule: "DNS delegation" },
   ];
 </script>
 

--- a/tests/DataTableAppendColumns.test.svelte
+++ b/tests/DataTableAppendColumns.test.svelte
@@ -6,19 +6,59 @@
     { key: "port", value: "Port" },
     { key: "rule", value: "Rule" },
     { key: "overflow", empty: true },
-  ];
+  ] as const;
 
   const rows = [
-    { id: "a", name: "Load Balancer 3", port: 3000, rule: "Round robin" },
-    { id: "b", name: "Load Balancer 1", port: 443, rule: "Round robin" },
-    { id: "c", name: "Load Balancer 2", port: 80, rule: "DNS delegation" },
-    { id: "d", name: "Load Balancer 6", port: 3000, rule: "Round robin" },
-    { id: "e", name: "Load Balancer 4", port: 443, rule: "Round robin" },
-    { id: "f", name: "Load Balancer 5", port: 80, rule: "DNS delegation" },
+    {
+      id: "a",
+      name: "Load Balancer 3",
+      port: 3000,
+      rule: "Round robin",
+      overflow: null,
+    },
+    {
+      id: "b",
+      name: "Load Balancer 1",
+      port: 443,
+      rule: "Round robin",
+      overflow: null,
+    },
+    {
+      id: "c",
+      name: "Load Balancer 2",
+      port: 80,
+      rule: "DNS delegation",
+      overflow: null,
+    },
+    {
+      id: "d",
+      name: "Load Balancer 6",
+      port: 3000,
+      rule: "Round robin",
+      overflow: null,
+    },
+    {
+      id: "e",
+      name: "Load Balancer 4",
+      port: 443,
+      rule: "Round robin",
+      overflow: null,
+    },
+    {
+      id: "f",
+      name: "Load Balancer 5",
+      port: 80,
+      rule: "DNS delegation",
+      overflow: null,
+    },
   ];
 </script>
 
-<DataTable sortable headers="{headers}" rows="{rows}">
+<DataTable
+  sortable
+  headers="{headers}"
+  rows="{rows}"
+>
   <span slot="cell" let:cell>
     {#if cell.key === "overflow"}
       <OverflowMenu flipped>

--- a/tests/DataTableBatchSelection.test.svelte
+++ b/tests/DataTableBatchSelection.test.svelte
@@ -5,7 +5,7 @@
     { key: "name", value: "Name" },
     { key: "port", value: "Port" },
     { key: "rule", value: "Rule" },
-  ];
+  ] as const;
 
   const rows = [
     { id: "a", name: "Load Balancer 3", port: 3000, rule: "Round robin" },

--- a/tests/DataTableBatchSelectionToolbar.test.svelte
+++ b/tests/DataTableBatchSelectionToolbar.test.svelte
@@ -15,7 +15,7 @@
     { key: "name", value: "Name" },
     { key: "port", value: "Port" },
     { key: "rule", value: "Rule" },
-  ];
+  ] as const;
 
   const rows = [
     { id: "a", name: "Load Balancer 3", port: 3000, rule: "Round robin" },

--- a/tests/DataTableNestedHeaders.test.svelte
+++ b/tests/DataTableNestedHeaders.test.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+  import { DataTable } from "../types";
+</script>
+
+<DataTable
+  headers="{[
+    { key: 'name', value: 'Name' },
+    { key: 'protocol', value: 'Protocol', width: '400px', minWidth: '40%' },
+    { key: 'port', value: 'Port' },
+    { key: 'rule.name', value: 'Rule', sort: false },
+  ]}"
+  rows="{[
+    {
+      id: 'a',
+      name: 'Load Balancer 3',
+      protocol: 'HTTP',
+      port: 3000,
+      'rule.name': 'Round robin',
+    },
+  ]}"
+>
+  <span slot="cell" let:cell let:row>
+    {cell.key === "rule.name"}
+    {#if cell.key === "name"}
+      {row.name} {row.id}
+    {:else}
+      {cell.value}
+    {/if}
+  </span>
+</DataTable>

--- a/tests/RadioSelectableDataTable.test.svelte
+++ b/tests/RadioSelectableDataTable.test.svelte
@@ -5,7 +5,7 @@
     { key: "name", value: "Name" },
     { key: "port", value: "Port" },
     { key: "rule", value: "Rule" },
-  ];
+  ] as const;
 
   const rows = [
     { id: "a", name: "Load Balancer 3", port: 3000, rule: "Round robin" },

--- a/tests/SelectableDataTable.test.svelte
+++ b/tests/SelectableDataTable.test.svelte
@@ -5,7 +5,7 @@
     { key: "name", value: "Name" },
     { key: "port", value: "Port" },
     { key: "rule", value: "Rule" },
-  ];
+  ] as const;
 
   const rows = [
     { id: "a", name: "Load Balancer 3", port: 3000, rule: "Round robin" },

--- a/types/DataTable/DataTable.svelte.d.ts
+++ b/types/DataTable/DataTable.svelte.d.ts
@@ -7,7 +7,7 @@ export type DataTableKey<Row = DataTableRow> =
 export type DataTableValue = any;
 
 export interface DataTableEmptyHeader<Row = DataTableRow> {
-  key: DataTableKey<Row>;
+  key: DataTableKey<Row> | string;
   empty: boolean;
   display?: (item: Value, row: Row) => DataTableValue;
   sort?: false | ((a: DataTableValue, b: DataTableValue) => number);

--- a/types/DataTable/DataTable.svelte.d.ts
+++ b/types/DataTable/DataTable.svelte.d.ts
@@ -7,7 +7,7 @@ export type DataTableKey<Row = DataTableRow> =
 export type DataTableValue = any;
 
 export interface DataTableEmptyHeader<Row = DataTableRow> {
-  key: DataTableKey<Row> | string;
+  key: DataTableKey<Row> | (string & {});
   empty: boolean;
   display?: (item: Value, row: Row) => DataTableValue;
   sort?: false | ((a: DataTableValue, b: DataTableValue) => number);

--- a/types/DataTable/DataTable.svelte.d.ts
+++ b/types/DataTable/DataTable.svelte.d.ts
@@ -1,14 +1,15 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-export type DataTableKey<Row = DataTableRow> = Exclude<keyof Row, "id">;
+export type DataTableKey<Row = DataTableRow> =
+  import("./DataTableTypes.d.ts").PropertyPath<Row>;
 
 export type DataTableValue = any;
 
 export interface DataTableEmptyHeader<Row = DataTableRow> {
   key: DataTableKey<Row>;
   empty: boolean;
-  display?: (item: DataTableValue, row: Row) => DataTableValue;
+  display?: (item: Value, row: Row) => DataTableValue;
   sort?: false | ((a: DataTableValue, b: DataTableValue) => number);
   columnMenu?: boolean;
   width?: string;
@@ -18,7 +19,7 @@ export interface DataTableEmptyHeader<Row = DataTableRow> {
 export interface DataTableNonEmptyHeader<Row = DataTableRow> {
   key: DataTableKey<Row>;
   value: DataTableValue;
-  display?: (item: DataTableValue, row: Row) => DataTableValue;
+  display?: (item: Value, row: Row) => DataTableValue;
   sort?: false | ((a: DataTableValue, b: DataTableValue) => number);
   columnMenu?: boolean;
   width?: string;
@@ -37,9 +38,9 @@ export interface DataTableRow {
 export type DataTableRowId = any;
 
 export interface DataTableCell<Row = DataTableRow> {
-  key: DataTableKey<Row>;
+  key: DataTableKey<Row> | (string & {});
   value: DataTableValue;
-  display?: (item: DataTableValue, row: DataTableRow) => DataTableValue;
+  display?: (item: Value, row: DataTableRow) => DataTableValue;
 }
 
 type $RestProps = SvelteHTMLElements["div"];

--- a/types/DataTable/DataTable.svelte.d.ts
+++ b/types/DataTable/DataTable.svelte.d.ts
@@ -188,7 +188,7 @@ export type DataTableProps<Row> = Omit<$RestProps, keyof $Props<Row>> &
   $Props<Row>;
 
 export default class DataTable<
-  Row extends DataTableRow = DataTableRow
+  Row extends DataTableRow = DataTableRow,
 > extends SvelteComponentTyped<
   DataTableProps<Row>,
   {

--- a/types/DataTable/DataTable.svelte.d.ts
+++ b/types/DataTable/DataTable.svelte.d.ts
@@ -5,8 +5,8 @@ export type DataTableKey = string;
 
 export type DataTableValue = any;
 
-export interface DataTableEmptyHeader {
-  key: DataTableKey;
+export interface DataTableEmptyHeader<Row extends DataTableRow = DataTableRow> {
+  key: keyof Row;
   empty: boolean;
   display?: (item: DataTableValue, row: DataTableRow) => DataTableValue;
   sort?: false | ((a: DataTableValue, b: DataTableValue) => number);
@@ -15,8 +15,10 @@ export interface DataTableEmptyHeader {
   minWidth?: string;
 }
 
-export interface DataTableNonEmptyHeader {
-  key: DataTableKey;
+export interface DataTableNonEmptyHeader<
+  Row extends DataTableRow = DataTableRow
+> {
+  key: keyof Row;
   value: DataTableValue;
   display?: (item: DataTableValue, row: DataTableRow) => DataTableValue;
   sort?: false | ((a: DataTableValue, b: DataTableValue) => number);
@@ -25,7 +27,9 @@ export interface DataTableNonEmptyHeader {
   minWidth?: string;
 }
 
-export type DataTableHeader = DataTableNonEmptyHeader | DataTableEmptyHeader;
+export type DataTableHeader<Row extends DataTableRow = DataTableRow> =
+  | DataTableNonEmptyHeader<Row>
+  | DataTableEmptyHeader<Row>;
 
 export interface DataTableRow {
   id: any;
@@ -34,8 +38,8 @@ export interface DataTableRow {
 
 export type DataTableRowId = any;
 
-export interface DataTableCell {
-  key: DataTableKey;
+export interface DataTableCell<Row extends DataTableRow = DataTableRow> {
+  key: keyof Row;
   value: DataTableValue;
   display?: (item: DataTableValue, row: DataTableRow) => DataTableValue;
 }
@@ -47,14 +51,14 @@ type $Props = {
    * Specify the data table headers
    * @default []
    */
-  headers?: ReadonlyArray<DataTableHeader>;
+  headers?: ReadonlyArray<DataTableHeader<Row>>;
 
   /**
    * Specify the rows the data table should render
    * keys defined in `headers` are used for the row ids
    * @default []
    */
-  rows?: ReadonlyArray<DataTableRow>;
+  rows?: ReadonlyArray<Row>;
 
   /**
    * Set the size of the data table
@@ -183,33 +187,35 @@ type $Props = {
 
 export type DataTableProps = Omit<$RestProps, keyof $Props> & $Props;
 
-export default class DataTable extends SvelteComponentTyped<
-  DataTableProps,
+export default class DataTable<
+  Row extends DataTableRow = DataTableRow
+> extends SvelteComponentTyped<
+  DataTableProps<Row>,
   {
     click: CustomEvent<{
-      header?: DataTableHeader;
-      row?: DataTableRow;
-      cell?: DataTableCell;
+      header?: DataTableHeader<Row>;
+      row?: Row;
+      cell?: DataTableCell<Row>;
     }>;
     ["click:header--expand"]: CustomEvent<{ expanded: boolean }>;
     ["click:header"]: CustomEvent<{
-      header: DataTableHeader;
+      header: DataTableHeader<Row>;
       sortDirection?: "ascending" | "descending" | "none";
     }>;
     ["click:header--select"]: CustomEvent<{
       indeterminate: boolean;
       selected: boolean;
     }>;
-    ["click:row"]: CustomEvent<DataTableRow>;
-    ["mouseenter:row"]: CustomEvent<DataTableRow>;
-    ["mouseleave:row"]: CustomEvent<DataTableRow>;
+    ["click:row"]: CustomEvent<Row>;
+    ["mouseenter:row"]: CustomEvent<Row>;
+    ["mouseleave:row"]: CustomEvent<Row>;
     ["click:row--expand"]: CustomEvent<{
       expanded: boolean;
-      row: DataTableRow;
+      row: Row;
     }>;
     ["click:row--select"]: CustomEvent<{
       selected: boolean;
-      row: DataTableRow;
+      row: Row;
     }>;
     ["click:cell"]: CustomEvent<DataTableCell>;
   },
@@ -223,7 +229,7 @@ export default class DataTable extends SvelteComponentTyped<
     };
     ["cell-header"]: { header: DataTableNonEmptyHeader };
     description: {};
-    ["expanded-row"]: { row: DataTableRow };
+    ["expanded-row"]: { row: Row };
     title: {};
   }
 > {}

--- a/types/DataTable/DataTable.svelte.d.ts
+++ b/types/DataTable/DataTable.svelte.d.ts
@@ -1,33 +1,31 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-export type DataTableKey = string;
+export type DataTableKey<Row = DataTableRow> = Exclude<keyof Row, "id">;
 
 export type DataTableValue = any;
 
-export interface DataTableEmptyHeader<Row extends DataTableRow = DataTableRow> {
-  key: keyof Row;
+export interface DataTableEmptyHeader<Row = DataTableRow> {
+  key: DataTableKey<Row>;
   empty: boolean;
-  display?: (item: DataTableValue, row: DataTableRow) => DataTableValue;
+  display?: (item: DataTableValue, row: Row) => DataTableValue;
   sort?: false | ((a: DataTableValue, b: DataTableValue) => number);
   columnMenu?: boolean;
   width?: string;
   minWidth?: string;
 }
 
-export interface DataTableNonEmptyHeader<
-  Row extends DataTableRow = DataTableRow
-> {
-  key: keyof Row;
+export interface DataTableNonEmptyHeader<Row = DataTableRow> {
+  key: DataTableKey<Row>;
   value: DataTableValue;
-  display?: (item: DataTableValue, row: DataTableRow) => DataTableValue;
+  display?: (item: DataTableValue, row: Row) => DataTableValue;
   sort?: false | ((a: DataTableValue, b: DataTableValue) => number);
   columnMenu?: boolean;
   width?: string;
   minWidth?: string;
 }
 
-export type DataTableHeader<Row extends DataTableRow = DataTableRow> =
+export type DataTableHeader<Row = DataTableRow> =
   | DataTableNonEmptyHeader<Row>
   | DataTableEmptyHeader<Row>;
 
@@ -38,15 +36,15 @@ export interface DataTableRow {
 
 export type DataTableRowId = any;
 
-export interface DataTableCell<Row extends DataTableRow = DataTableRow> {
-  key: keyof Row;
+export interface DataTableCell<Row = DataTableRow> {
+  key: DataTableKey<Row>;
   value: DataTableValue;
   display?: (item: DataTableValue, row: DataTableRow) => DataTableValue;
 }
 
 type $RestProps = SvelteHTMLElements["div"];
 
-type $Props = {
+type $Props<Row> = {
   /**
    * Specify the data table headers
    * @default []
@@ -94,7 +92,7 @@ type $Props = {
    * Specify the header key to sort by
    * @default null
    */
-  sortKey?: DataTableKey;
+  sortKey?: DataTableKey<Row>;
 
   /**
    * Specify the sort direction
@@ -185,7 +183,8 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type DataTableProps = Omit<$RestProps, keyof $Props> & $Props;
+export type DataTableProps<Row> = Omit<$RestProps, keyof $Props<Row>> &
+  $Props<Row>;
 
 export default class DataTable<
   Row extends DataTableRow = DataTableRow
@@ -209,21 +208,15 @@ export default class DataTable<
     ["click:row"]: CustomEvent<Row>;
     ["mouseenter:row"]: CustomEvent<Row>;
     ["mouseleave:row"]: CustomEvent<Row>;
-    ["click:row--expand"]: CustomEvent<{
-      expanded: boolean;
-      row: Row;
-    }>;
-    ["click:row--select"]: CustomEvent<{
-      selected: boolean;
-      row: Row;
-    }>;
-    ["click:cell"]: CustomEvent<DataTableCell>;
+    ["click:row--expand"]: CustomEvent<{ expanded: boolean; row: Row }>;
+    ["click:row--select"]: CustomEvent<{ selected: boolean; row: Row }>;
+    ["click:cell"]: CustomEvent<DataTableCell<Row>>;
   },
   {
     default: {};
     cell: {
-      row: DataTableRow;
-      cell: DataTableCell;
+      row: Row;
+      cell: DataTableCell<Row>;
       rowIndex: number;
       cellIndex: number;
     };

--- a/types/DataTable/DataTable.svelte.d.ts
+++ b/types/DataTable/DataTable.svelte.d.ts
@@ -9,7 +9,7 @@ export type DataTableValue = any;
 export interface DataTableEmptyHeader<Row = DataTableRow> {
   key: DataTableKey<Row> | (string & {});
   empty: boolean;
-  display?: (item: Value, row: Row) => DataTableValue;
+  display?: (item: DataTableValue, row: Row) => DataTableValue;
   sort?: false | ((a: DataTableValue, b: DataTableValue) => number);
   columnMenu?: boolean;
   width?: string;
@@ -19,7 +19,7 @@ export interface DataTableEmptyHeader<Row = DataTableRow> {
 export interface DataTableNonEmptyHeader<Row = DataTableRow> {
   key: DataTableKey<Row>;
   value: DataTableValue;
-  display?: (item: Value, row: Row) => DataTableValue;
+  display?: (item: DataTableValue, row: Row) => DataTableValue;
   sort?: false | ((a: DataTableValue, b: DataTableValue) => number);
   columnMenu?: boolean;
   width?: string;
@@ -40,7 +40,7 @@ export type DataTableRowId = any;
 export interface DataTableCell<Row = DataTableRow> {
   key: DataTableKey<Row> | (string & {});
   value: DataTableValue;
-  display?: (item: Value, row: DataTableRow) => DataTableValue;
+  display?: (item: DataTableValue, row: DataTableRow) => DataTableValue;
 }
 
 type $RestProps = SvelteHTMLElements["div"];

--- a/types/DataTable/DataTableTypes.d.ts
+++ b/types/DataTable/DataTableTypes.d.ts
@@ -1,0 +1,17 @@
+type PathDepth = [never, 0, 1, 2, ...0[]];
+
+type Join<K, P> = K extends string | number
+  ? P extends string | number
+    ? `${K}${"" extends P ? "" : "."}${P}`
+    : never
+  : never;
+
+export type PropertyPath<T, D extends number = 10> = [D] extends [never]
+  ? never
+  : T extends object
+  ? {
+      [K in keyof T]-?: K extends string | number
+        ? `${K}` | Join<K, PropertyPath<T[K], PathDepth[D]>>
+        : never;
+    }[keyof T]
+  : "";

--- a/types/DataTable/DataTableTypes.d.ts
+++ b/types/DataTable/DataTableTypes.d.ts
@@ -2,16 +2,17 @@ type PathDepth = [never, 0, 1, 2, ...0[]];
 
 type Join<K, P> = K extends string | number
   ? P extends string | number
-    ? `${K}${"" extends P ? "" : "."}${P}`
-    : never
+  ? `${K}${"" extends P ? "" : "."}${P}`
+  : never
   : never;
 
+// For performance, the maximum traversal depth is 10.
 export type PropertyPath<T, D extends number = 10> = [D] extends [never]
   ? never
   : T extends object
   ? {
-      [K in keyof T]-?: K extends string | number
-        ? `${K}` | Join<K, PropertyPath<T[K], PathDepth[D]>>
-        : never;
-    }[keyof T]
+    [K in keyof T]-?: K extends string | number
+    ? `${K}` | Join<K, PropertyPath<T[K], PathDepth[D]>>
+    : never;
+  }[keyof T]
   : "";


### PR DESCRIPTION
This PR is based on #816. Closes #816

- Ugprades `sveld` to v0.20 to use generics
- Uses generics to type `DataTable` so that types for `rows` and `headers` can be inferred

@brunnerh Would love your thoughts on this. Seems like a straightforward win. I love the inferred types based on keys in `rows`. FWIW, this doesn't break existing usage (see the `DataTable.test.svelte` file) of exported props, since the generic parameter is optional (`<Row = DataTableRow>`).

<img width="919" alt="Screenshot 2024-04-20 at 4 15 18 PM" src="https://github.com/carbon-design-system/carbon-components-svelte/assets/10718366/42ca6f31-350f-4209-9f84-4d9671f6d2c5">

<img width="847" alt="Screenshot 2024-04-20 at 4 15 30 PM" src="https://github.com/carbon-design-system/carbon-components-svelte/assets/10718366/ed973c36-c77f-4df7-add1-83e6258c0678">