### PR TITLE
feat(truncate): integrate `Truncate` with v11

### DIFF
--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -4729,9 +4729,10 @@ export interface TreeNode {
 
 ### Props
 
-| Prop name | Required | Kind             | Reactive | Type                              | Default value      | Description |
-| :-------- | :------- | :--------------- | :------- | --------------------------------- | ------------------ | ----------- |
-| clamp     | No       | <code>let</code> | No       | <code>"end" &#124; "front"</code> | <code>"end"</code> | --          |
+| Prop name | Required | Kind             | Reactive | Type                                     | Default value      | Description                      |
+| :-------- | :------- | :--------------- | :------- | ---------------------------------------- | ------------------ | -------------------------------- |
+| clamp     | No       | <code>let</code> | No       | <code>"end" &#124; "front"</code>        | <code>"end"</code> | Specify the truncation direction |
+| tag       | No       | <code>let</code> | No       | <code>keyof HTMLElementTagNameMap</code> | <code>"p"</code>   | Specify the tag name             |
 
 ### Slots
 

--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -14723,8 +14723,21 @@
         {
           "name": "clamp",
           "kind": "let",
+          "description": "Specify the truncation direction",
           "type": "\"end\" | \"front\"",
           "value": "\"end\"",
+          "isFunction": false,
+          "isFunctionDeclaration": false,
+          "isRequired": false,
+          "constant": false,
+          "reactive": false
+        },
+        {
+          "name": "tag",
+          "kind": "let",
+          "description": "Specify the tag name",
+          "type": "keyof HTMLElementTagNameMap",
+          "value": "\"p\"",
           "isFunction": false,
           "isFunctionDeclaration": false,
           "isRequired": false,
@@ -14736,7 +14749,7 @@
       "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
       "events": [],
       "typedefs": [],
-      "rest_props": { "type": "Element", "name": "p" }
+      "rest_props": { "type": "Element", "name": "svelte:element" }
     },
     {
       "moduleName": "UnorderedList",

--- a/src/Truncate/Truncate.svelte
+++ b/src/Truncate/Truncate.svelte
@@ -1,12 +1,24 @@
 <script>
-  /** @type {"end" | "front"}*/
+  // @ts-check
+  
+  /**
+   * Specify the truncation direction
+   * @type {"end" | "front"}
+   */
   export let clamp = "end";
+
+  /**
+   * Specify the tag name
+   * @type {keyof HTMLElementTagNameMap}
+   */
+  export let tag = "p";
 </script>
 
-<p
+<svelte:element
+  this="{tag}"
   class:bx--text-truncate-end="{clamp === 'end'}"
   class:bx--text-truncate-front="{clamp === 'front'}"
   {...$$restProps}
 >
   <slot />
-</p>
+</svelte:element>

--- a/src/Truncate/truncate.d.ts
+++ b/src/Truncate/truncate.d.ts
@@ -1,12 +1,9 @@
+import type { Action } from "svelte/action";
+
 interface TruncateOptions {
   clamp?: "end" | "front";
 }
 
-export function TruncateAction(
-  node: HTMLElement,
-  options?: TruncateOptions
-): {
-  update: (options?: TruncateOptions) => void;
-};
+export declare const truncate: Action<HTMLElement, TruncateOptions>;
 
-export default TruncateAction;
+export default truncate;

--- a/src/Truncate/truncate.js
+++ b/src/Truncate/truncate.js
@@ -1,7 +1,9 @@
+// @ts-check
+
 /**
  * Svelte action that applies single-line text truncation to an element
  * @typedef {{ clamp?: "end" | "front" }} TruncateOptions
- * @type {(node: HTMLElement, options?: TruncateOptions) => { update: (options?: TruncateOptions) => void; }}
+ * @type {import ("svelte/action").Action<HTMLElement, TruncateOptions>}
  * @example
  * <h1 use:truncate>...</h1>
  * <h1 use:truncate={{ clamp: "front" }}>...</h1>

--- a/tests/Truncate.test.svelte
+++ b/tests/Truncate.test.svelte
@@ -1,23 +1,10 @@
 <script lang="ts">
-  import { Truncate } from "../types";
-  import { truncate } from "../types";
+  import { Truncate, truncate } from "../types";
 </script>
 
-<Truncate>
-  Carbon Components Svelte is a Svelte component library that implements the
-  Carbon Design System, an open source design system by IBM.
+<Truncate tag="div" clamp="front" aria-label="">
+  Carbon Components Svelte is a Svelte component library.
 </Truncate>
 
-<Truncate clamp="front">
-  Carbon Components Svelte is a Svelte component library that implements the
-  Carbon Design System, an open source design system by IBM.
-</Truncate>
-
-<h4 use:truncate>
-  Carbon Components Svelte is a Svelte component library that implements the
-  Carbon Design System, an open source design system by IBM.
-</h4>
-<h4 use:truncate="{{ clamp: 'front' }}">
-  Carbon Components Svelte is a Svelte component library that implements the
-  Carbon Design System, an open source design system by IBM.
-</h4>
+<div use:truncate></div>
+<div use:truncate="{{ clamp: 'front' }}"></div>

--- a/types/Truncate/Truncate.svelte.d.ts
+++ b/types/Truncate/Truncate.svelte.d.ts
@@ -1,13 +1,20 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["p"];
+type RestProps = SvelteHTMLElements["svelte:element"];
 
 export interface TruncateProps extends RestProps {
   /**
+   * Specify the truncation direction
    * @default "end"
    */
   clamp?: "end" | "front";
+
+  /**
+   * Specify the tag name
+   * @default "p"
+   */
+  tag?: keyof HTMLElementTagNameMap;
 
   [key: `data-${string}`]: any;
 }

--- a/types/Truncate/truncate.d.ts
+++ b/types/Truncate/truncate.d.ts
@@ -1,12 +1,9 @@
+import type { Action } from "svelte/action";
+
 interface TruncateOptions {
   clamp?: "end" | "front";
 }
 
-export function TruncateAction(
-  node: HTMLElement,
-  options?: TruncateOptions
-): {
-  update: (options?: TruncateOptions) => void;
-};
+export declare const truncate: Action<HTMLElement, TruncateOptions>;
 
-export default TruncateAction;
+export default truncate;


### PR DESCRIPTION
- No breaking changes.
- Allows tag customization.
- Uses the official `Action` type from `svelte/action` to type the action.