### PR TITLE
feat(recursive-list): integrate `RecursiveList` with v11

### DIFF
--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -3071,10 +3071,10 @@ export interface RecursiveListNode {
 
 ### Props
 
-| Prop name | Required | Kind             | Reactive | Type                                                                        | Default value            | Description                        |
-| :-------- | :------- | :--------------- | :------- | --------------------------------------------------------------------------- | ------------------------ | ---------------------------------- |
-| children  | No       | <code>let</code> | No       | <code>Array<RecursiveListNode & { children?: RecursiveListNode[]; }></code> | <code>[]</code>          | Specify the children to render     |
-| type      | No       | <code>let</code> | No       | <code>"unordered" &#124; "ordered" &#124; "ordered-native"</code>           | <code>"unordered"</code> | Specify the type of list to render |
+| Prop name | Required | Kind             | Reactive | Type                                                                                             | Default value            | Description                        |
+| :-------- | :------- | :--------------- | :------- | ------------------------------------------------------------------------------------------------ | ------------------------ | ---------------------------------- |
+| children  | No       | <code>let</code> | No       | <code>ReadonlyArray<RecursiveListNode & { children?: ReadonlyArray<RecursiveListNode>; }></code> | <code>[]</code>          | Specify the children to render     |
+| type      | No       | <code>let</code> | No       | <code>"unordered" &#124; "ordered" &#124; "ordered-native"</code>                                | <code>"unordered"</code> | Specify the type of list to render |
 
 ### Slots
 

--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -9783,7 +9783,7 @@
           "name": "children",
           "kind": "let",
           "description": "Specify the children to render",
-          "type": "Array<RecursiveListNode & { children?: RecursiveListNode[]; }>",
+          "type": "ReadonlyArray<RecursiveListNode & { children?: ReadonlyArray<RecursiveListNode>; }>",
           "value": "[]",
           "isFunction": false,
           "isFunctionDeclaration": false,

--- a/src/RecursiveList/RecursiveList.svelte
+++ b/src/RecursiveList/RecursiveList.svelte
@@ -6,7 +6,7 @@
 
   /**
    * Specify the children to render
-   * @type {Array<RecursiveListNode & { children?: RecursiveListNode[]; }>}
+   * @type {ReadonlyArray<RecursiveListNode & { children?: ReadonlyArray<RecursiveListNode>; }>}
    */
   export let children = [];
 

--- a/tests/RecursiveList.test.svelte
+++ b/tests/RecursiveList.test.svelte
@@ -4,29 +4,14 @@
   const children = [
     {
       text: "Item 1",
-      children: [
-        {
-          text: "Item 1a",
-          children: [{ html: "<h5>HTML content</h5>" }],
-        },
-      ],
+      children: [{ text: "Item 1a", children: [] }],
     },
     {
       text: "Item 2",
-      children: [
-        {
-          href: "https://svelte.dev/",
-        },
-        {
-          href: "https://svelte.dev/",
-          text: "Link with custom text",
-        },
-      ],
+      children: [{ href: "https://svelte.dev/" }],
     },
-    {
-      text: "Item 3",
-    },
-  ];
+    { text: "Item 3" },
+  ] as const;
 </script>
 
 <RecursiveList type="ordered" children="{children}" />

--- a/types/RecursiveList/RecursiveList.svelte.d.ts
+++ b/types/RecursiveList/RecursiveList.svelte.d.ts
@@ -14,7 +14,9 @@ export interface RecursiveListProps extends RestProps {
    * Specify the children to render
    * @default []
    */
-  children?: Array<RecursiveListNode & { children?: RecursiveListNode[] }>;
+  children?: ReadonlyArray<
+    RecursiveListNode & { children?: ReadonlyArray<RecursiveListNode> }
+  >;
 
   /**
    * Specify the type of list to render


### PR DESCRIPTION
No breaking changes.

**Features**

- TypeScript improvement: allow `children` to be typed as a read-only array.

```svelte
<script lang="ts">
  import { RecursiveList } from "carbon-components-svelte";

  const children = [
    ...
  ] as const;
</script>

<RecursiveList type="ordered" children="{children}" />

```