### PR TITLE
feat(text-area)!: integrate `TextArea` with v11

### DIFF
--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -4110,6 +4110,7 @@ None.
 | cols        | No       | <code>let</code> | No       | <code>number</code>                          | <code>undefined</code>                           | Specify the number of cols                      |
 | rows        | No       | <code>let</code> | No       | <code>number</code>                          | <code>4</code>                                   | Specify the number of rows                      |
 | maxCount    | No       | <code>let</code> | No       | <code>number</code>                          | <code>undefined</code>                           | Specify the max character count                 |
+| counterMode | No       | <code>let</code> | No       | <code>"character" &#124; "word"</code>       | <code>"character"</code>                         | Specify the counter mode                        |
 | light       | No       | <code>let</code> | No       | <code>boolean</code>                         | <code>false</code>                               | Set to `true` to enable the light variant       |
 | disabled    | No       | <code>let</code> | No       | <code>boolean</code>                         | <code>false</code>                               | Set to `true` to disable the input              |
 | readonly    | No       | <code>let</code> | No       | <code>boolean</code>                         | <code>false</code>                               | Set to `true` to use the read-only variant      |
@@ -4118,23 +4119,23 @@ None.
 | hideLabel   | No       | <code>let</code> | No       | <code>boolean</code>                         | <code>false</code>                               | Set to `true` to visually hide the label text   |
 | invalid     | No       | <code>let</code> | No       | <code>boolean</code>                         | <code>false</code>                               | Set to `true` to indicate an invalid state      |
 | invalidText | No       | <code>let</code> | No       | <code>string</code>                          | <code>""</code>                                  | Specify the text for the invalid state          |
+| warn        | No       | <code>let</code> | No       | <code>boolean</code>                         | <code>false</code>                               | Set to `true` to indicate an warning state      |
+| warnText    | No       | <code>let</code> | No       | <code>string</code>                          | <code>""</code>                                  | Specify the warning state text                  |
 | id          | No       | <code>let</code> | No       | <code>string</code>                          | <code>"ccs-" + Math.random().toString(36)</code> | Set an id for the textarea element              |
 | name        | No       | <code>let</code> | No       | <code>string</code>                          | <code>undefined</code>                           | Specify a name attribute for the input          |
 
 ### Slots
 
-| Slot name | Default | Props | Fallback                 |
-| :-------- | :------ | :---- | :----------------------- |
-| labelText | No      | --    | <code>{labelText}</code> |
+| Slot name   | Default | Props | Fallback                   |
+| :---------- | :------ | :---- | :------------------------- |
+| invalidText | No      | --    | <code>{invalidText}</code> |
+| labelText   | No      | --    | <code>{labelText}</code>   |
+| warnText    | No      | --    | <code>{warnText}</code>    |
 
 ### Events
 
 | Event name | Type      | Detail |
 | :--------- | :-------- | :----- |
-| click      | forwarded | --     |
-| mouseover  | forwarded | --     |
-| mouseenter | forwarded | --     |
-| mouseleave | forwarded | --     |
 | change     | forwarded | --     |
 | input      | forwarded | --     |
 | keydown    | forwarded | --     |
@@ -4157,12 +4158,7 @@ None.
 
 ### Events
 
-| Event name | Type      | Detail |
-| :--------- | :-------- | :----- |
-| click      | forwarded | --     |
-| mouseover  | forwarded | --     |
-| mouseenter | forwarded | --     |
-| mouseleave | forwarded | --     |
+None.
 
 ## `TextInput`
 

--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -12563,6 +12563,18 @@
           "reactive": false
         },
         {
+          "name": "counterMode",
+          "kind": "let",
+          "description": "Specify the counter mode",
+          "type": "\"character\" | \"word\"",
+          "value": "\"character\"",
+          "isFunction": false,
+          "isFunctionDeclaration": false,
+          "isRequired": false,
+          "constant": false,
+          "reactive": false
+        },
+        {
           "name": "light",
           "kind": "let",
           "description": "Set to `true` to enable the light variant",
@@ -12659,6 +12671,30 @@
           "reactive": false
         },
         {
+          "name": "warn",
+          "kind": "let",
+          "description": "Set to `true` to indicate an warning state",
+          "type": "boolean",
+          "value": "false",
+          "isFunction": false,
+          "isFunctionDeclaration": false,
+          "isRequired": false,
+          "constant": false,
+          "reactive": false
+        },
+        {
+          "name": "warnText",
+          "kind": "let",
+          "description": "Specify the warning state text",
+          "type": "string",
+          "value": "\"\"",
+          "isFunction": false,
+          "isFunctionDeclaration": false,
+          "isRequired": false,
+          "constant": false,
+          "reactive": false
+        },
+        {
           "name": "id",
           "kind": "let",
           "description": "Set an id for the textarea element",
@@ -12697,17 +12733,25 @@
       "moduleExports": [],
       "slots": [
         {
+          "name": "invalidText",
+          "default": false,
+          "fallback": "{invalidText}",
+          "slot_props": "{}"
+        },
+        {
           "name": "labelText",
           "default": false,
           "fallback": "{labelText}",
           "slot_props": "{}"
+        },
+        {
+          "name": "warnText",
+          "default": false,
+          "fallback": "{warnText}",
+          "slot_props": "{}"
         }
       ],
       "events": [
-        { "type": "forwarded", "name": "click", "element": "div" },
-        { "type": "forwarded", "name": "mouseover", "element": "div" },
-        { "type": "forwarded", "name": "mouseenter", "element": "div" },
-        { "type": "forwarded", "name": "mouseleave", "element": "div" },
         { "type": "forwarded", "name": "change", "element": "textarea" },
         { "type": "forwarded", "name": "input", "element": "textarea" },
         { "type": "forwarded", "name": "keydown", "element": "textarea" },
@@ -12738,14 +12782,8 @@
       ],
       "moduleExports": [],
       "slots": [],
-      "events": [
-        { "type": "forwarded", "name": "click", "element": "div" },
-        { "type": "forwarded", "name": "mouseover", "element": "div" },
-        { "type": "forwarded", "name": "mouseenter", "element": "div" },
-        { "type": "forwarded", "name": "mouseleave", "element": "div" }
-      ],
-      "typedefs": [],
-      "rest_props": { "type": "Element", "name": "div" }
+      "events": [],
+      "typedefs": []
     },
     {
       "moduleName": "TextInput",

--- a/docs/src/pages/components/TextArea.svx
+++ b/docs/src/pages/components/TextArea.svx
@@ -11,13 +11,19 @@ components: ["TextArea", "TextAreaSkeleton"]
 
 <TextArea labelText="App description" placeholder="Enter a description..." />
 
-## Maximum character count
+## Counter (character)
 
-Specify the max character count using the `maxCount` prop. A character counter will be displayed to the right of the label.
+Specify a number using the `maxCount` prop to show a character counter. The default mode is `"charcacter"`.
 
-You can always use the native `maxlength` attribute if you'd prefer that a counter not be shown.
+The `maxlength` attribute is set to `maxCount` in this mode. You can override this by specifying `maxlength={undefined}`.
 
 <TextArea labelText="App description" placeholder="Enter a description..." maxCount={100} />
+
+## Counter (word)
+
+Specify `counterMode="word"` for the counter to count words instead of characters.
+
+<TextArea labelText="App description" placeholder="Enter a description..." maxCount={100} counterMode="word" />
 
 ## With helper text
 
@@ -31,13 +37,31 @@ You can always use the native `maxlength` attribute if you'd prefer that a count
 
 <TextArea light labelText="App description" placeholder="Enter a description..." />
 
+## Read-only variant
+
+<TextArea readonly labelText="App description" placeholder="Enter a description..." />
+
 ## Custom rows
 
+Specify `rows` to adjust the height of the textarea.
+
+By default, `rows` is set to `4`.
+
 <TextArea rows={10} labelText="App description" placeholder="Enter a description..." />
+
+## Custom cols
+
+If `cols` is a number, the `textarea` will not be resizeable.
+
+<TextArea cols={50} labelText="App description" placeholder="Enter a description..." />
 
 ## Invalid state
 
 <TextArea invalid invalidText="Only plain text characters are allowed" labelText="App description" placeholder="Enter a description..." />
+
+## Warning state
+
+<TextArea warn warnText="The app description requires additional approval." labelText="App description" placeholder="Enter a description..." />
 
 ## Disabled state
 

--- a/src/TextArea/TextAreaSkeleton.svelte
+++ b/src/TextArea/TextAreaSkeleton.svelte
@@ -1,18 +1,11 @@
 <script>
+  // @ts-check
+
   /** Set to `true` to visually hide the label text */
   export let hideLabel = false;
 </script>
 
-<!-- svelte-ignore a11y-mouse-events-have-key-events -->
-<!-- svelte-ignore a11y-no-static-element-interactions -->
-<div
-  class:bx--form-item="{true}"
-  {...$$restProps}
-  on:click
-  on:mouseover
-  on:mouseenter
-  on:mouseleave
->
+<div class:bx--form-item="{true}">
   {#if !hideLabel}
     <span class:bx--label="{true}" class:bx--skeleton="{true}"></span>
   {/if}

--- a/types/TextArea/TextArea.svelte.d.ts
+++ b/types/TextArea/TextArea.svelte.d.ts
@@ -35,6 +35,12 @@ export interface TextAreaProps extends RestProps {
   maxCount?: number;
 
   /**
+   * Specify the counter mode
+   * @default "character"
+   */
+  counterMode?: "character" | "word";
+
+  /**
    * Set to `true` to enable the light variant
    * @default false
    */
@@ -83,6 +89,18 @@ export interface TextAreaProps extends RestProps {
   invalidText?: string;
 
   /**
+   * Set to `true` to indicate an warning state
+   * @default false
+   */
+  warn?: boolean;
+
+  /**
+   * Specify the warning state text
+   * @default ""
+   */
+  warnText?: string;
+
+  /**
    * Set an id for the textarea element
    * @default "ccs-" + Math.random().toString(36)
    */
@@ -106,10 +124,6 @@ export interface TextAreaProps extends RestProps {
 export default class TextArea extends SvelteComponentTyped<
   TextAreaProps,
   {
-    click: WindowEventMap["click"];
-    mouseover: WindowEventMap["mouseover"];
-    mouseenter: WindowEventMap["mouseenter"];
-    mouseleave: WindowEventMap["mouseleave"];
     change: WindowEventMap["change"];
     input: WindowEventMap["input"];
     keydown: WindowEventMap["keydown"];
@@ -118,5 +132,5 @@ export default class TextArea extends SvelteComponentTyped<
     blur: WindowEventMap["blur"];
     paste: DocumentAndElementEventHandlersEventMap["paste"];
   },
-  { labelText: {} }
+  { invalidText: {}; labelText: {}; warnText: {} }
 > {}

--- a/types/TextArea/TextAreaSkeleton.svelte.d.ts
+++ b/types/TextArea/TextAreaSkeleton.svelte.d.ts
@@ -1,25 +1,15 @@
 import type { SvelteComponentTyped } from "svelte";
-import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
-
-export interface TextAreaSkeletonProps extends RestProps {
+export interface TextAreaSkeletonProps {
   /**
    * Set to `true` to visually hide the label text
    * @default false
    */
   hideLabel?: boolean;
-
-  [key: `data-${string}`]: any;
 }
 
 export default class TextAreaSkeleton extends SvelteComponentTyped<
   TextAreaSkeletonProps,
-  {
-    click: WindowEventMap["click"];
-    mouseover: WindowEventMap["mouseover"];
-    mouseenter: WindowEventMap["mouseenter"];
-    mouseleave: WindowEventMap["mouseleave"];
-  },
+  Record<string, any>,
   {}
 > {}


### PR DESCRIPTION
Does a pass at integrating `TextArea` with v11. To scope down, will support fluid form in a separate PR.

Closes #1668, closes #1661

Will address #978, #1136.

- Support warn state
- Support readonly state
- Make `invalidText` slottable
- Add `counterMode`
- Disable `resize` if `cols` is a number

