### PR TITLE
fix(search): collapse expandable search if value is falsy

### DIFF
--- a/src/Search/Search.svelte
+++ b/src/Search/Search.svelte
@@ -140,7 +140,7 @@
       }}"
       on:blur
       on:blur="{() => {
-        if (expanded && value.trim().length === 0) {
+        if (expanded && (value === '' || value == null)) {
           expanded = false;
         }
       }}"
@@ -159,7 +159,7 @@
       aria-label="{closeButtonLabelText}"
       disabled="{disabled}"
       class:bx--search-close="{true}"
-      class:bx--search-close--hidden="{value === ''}"
+      class:bx--search-close--hidden="{value === '' || value == null}"
       on:click
       on:click="{() => {
         value = '';


### PR DESCRIPTION
Fixes #1981

Changed the value checks to also consider `null`/`undefined` since it's typed as `any`.