### PR TITLE
docs: simplify setup instructions by removing CDN section

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,37 +87,6 @@ import "carbon-components-svelte/css/g100.css";
 import "carbon-components-svelte/css/all.css";
 ```
 
-#### CDN
-
-An alternative to loading styles is to link an external StyleSheet from a Content Delivery Network (CDN) like [unpkg.com](https://unpkg.com/).
-
-This is best suited for rapid prototyping.
-
-##### HTML
-
-```html
-<!DOCTYPE html>
-<html>
-  <head>
-    <link
-      rel="stylesheet"
-      href="https://unpkg.com/carbon-components-svelte/css/white.css"
-    />
-  </head>
-</html>
-```
-
-##### `svelte:head`
-
-```html
-<svelte:head>
-  <link
-    rel="stylesheet"
-    href="https://unpkg.com/carbon-components-svelte/css/white.css"
-  />
-</svelte:head>
-```
-
 ### SCSS
 
 The most performant method to load styles is to import SCSS directly from carbon-components. Although it requires more set up, you can reduce the size of the bundle CSS by importing individual component styles instead of a pre-compiled CSS StyleSheet.


### PR DESCRIPTION
I don't understand why you would ever load it from a CDN. The setup instructions already had you install `carbon-components-svelte`, so if it's available from local disk, why not just use it? It's the same or less code to use the one from npm. Providing multiple ways to do things just complicates the setup instructions 