### PR TITLE
fix(header-action): allow vertical scroll when expanded

### DIFF
--- a/src/UIShell/HeaderAction.svelte
+++ b/src/UIShell/HeaderAction.svelte
@@ -96,6 +96,7 @@
     bind:this="{refPanel}"
     class:bx--header-panel="{true}"
     class:bx--header-panel--expanded="{true}"
+    style:overflow-y="auto"
     transition:slide|local="{{
       ...transition,
       duration: transition === false ? 0 : transition.duration,


### PR DESCRIPTION
This PR hot fixes a usability issue – if the `HeaderAction` has vertical overflow, the `overflow: hidden` rule is not overridden. Note that this should ideally be fixed upstream: https://github.com/carbon-design-system/carbon/pull/17160

In the meantime, the fix for Carbon Svelte ensures that the content is vertically scrollable (if necessary).

<img width="429" alt="Screenshot 2024-08-13 at 9 27 13 AM" src="https://github.com/user-attachments/assets/afbe4c09-36ad-482a-8c17-7ded1b351783">
