### PR TITLE
chore(telemetry): updated URL

### DIFF
--- a/telemetry.yml
+++ b/telemetry.yml
@@ -2,7 +2,7 @@
 
 version: 1
 projectId: 449708c0-69d7-4b6b-b12a-c4afe605be24
-endpoint: https://www-api.ibm.com/ibm-telemetry/v1/telemetry
+endpoint: https://www-api.ibm.com/ibm-telemetry/v1/metrics
 collect:
   npm:
     dependencies: null


### PR DESCRIPTION
The PR opened a few days ago updating the endpoint URL had the wrong one -- this PR fixes that.