### PR TITLE
fix: address Svelte 5 warnings

### DIFF
--- a/src/Breakpoint/Breakpoint.svelte
+++ b/src/Breakpoint/Breakpoint.svelte
@@ -40,6 +40,7 @@
     max: size == "max",
   };
   $: if (size != undefined)
+    // svelte-ignore reactive_declaration_non_reactive_property
     dispatch("change", { size, breakpointValue: breakpoints[size] });
 </script>
 

--- a/src/OverflowMenu/OverflowMenu.svelte
+++ b/src/OverflowMenu/OverflowMenu.svelte
@@ -192,7 +192,7 @@
 <button
   bind:this="{buttonRef}"
   type="button"
-  aria-haspopup
+  aria-haspopup="true"
   aria-expanded="{open}"
   aria-label="{ariaLabel}"
   id="{id}"

--- a/src/TextInput/PasswordInput.svelte
+++ b/src/TextInput/PasswordInput.svelte
@@ -88,6 +88,7 @@
 
   const ctx = getContext("Form");
 
+  // svelte-ignore reactive_declaration_non_reactive_property
   $: isFluid = !!ctx && ctx.isFluid;
   $: helperId = `helper-${id}`;
   $: errorId = `error-${id}`;

--- a/src/TextInput/PasswordInput.svelte
+++ b/src/TextInput/PasswordInput.svelte
@@ -88,8 +88,7 @@
 
   const ctx = getContext("Form");
 
-  // svelte-ignore reactive_declaration_non_reactive_property
-  $: isFluid = !!ctx && ctx.isFluid;
+  const isFluid = !!ctx && ctx.isFluid;
   $: helperId = `helper-${id}`;
   $: errorId = `error-${id}`;
   $: warnId = `warn-${id}`;

--- a/src/TextInput/TextInput.svelte
+++ b/src/TextInput/TextInput.svelte
@@ -94,6 +94,7 @@
     dispatch("change", parse(e.target.value));
   };
 
+  // svelte-ignore reactive_declaration_non_reactive_property
   $: isFluid = !!ctx && ctx.isFluid;
   $: error = invalid && !readonly;
   $: helperId = `helper-${id}`;

--- a/src/TextInput/TextInput.svelte
+++ b/src/TextInput/TextInput.svelte
@@ -94,8 +94,7 @@
     dispatch("change", parse(e.target.value));
   };
 
-  // svelte-ignore reactive_declaration_non_reactive_property
-  $: isFluid = !!ctx && ctx.isFluid;
+  const isFluid = !!ctx && ctx.isFluid;
   $: error = invalid && !readonly;
   $: helperId = `helper-${id}`;
   $: errorId = `error-${id}`;


### PR DESCRIPTION
Fixes #2016.

When using this library with Svelte 5, I'm seeing development warnings in the console.

```sh
11:18:07 [vite] ✨ new dependencies optimized: svelte/internal/client
11:18:07 [vite] ✨ optimized dependencies changed. reloading
11:18:07 AM [vite-plugin-svelte] node_modules/carbon-components-svelte/src/Breakpoint/Breakpoint.svelte:43:48 Properties of objects and arrays are not reactive unless in runes mode. Changes to this property will not cause the reactive statement to update
11:18:08 AM [vite-plugin-svelte] node_modules/carbon-components-svelte/src/OverflowMenu/OverflowMenu.svelte:195:2 The value of 'aria-haspopup' must be exactly one of "false", "true", "menu", "listbox", "tree", "grid" or "dialog"
11:18:08 AM [vite-plugin-svelte] node_modules/carbon-components-svelte/src/TextInput/TextInput.svelte:97:24 Properties of objects and arrays are not reactive unless in runes mode. Changes to this property will not cause the reactive statement to update
11:18:08 AM [vite-plugin-svelte] node_modules/carbon-components-svelte/src/TextInput/PasswordInput.svelte:91:24 Properties of objects and arrays are not reactive unless in runes mode. Changes to this property will not cause the reactive statement to update
```

This isn't a blocker, but it'd be nice to address these, especially if it's a backwards-compatible change.

My approach in #2010:

1. Upgrade tooling to Svelte 5 (including upgrading TypeScript).
2. Run `svelte-check` on source code and/or run `npm run build:lib` to identify warnings emitted by Svelte 5.
3. Address the warnings until they disappear.
4. Cherry pick https://github.com/carbon-design-system/carbon-components-svelte/pull/2010/commits/c2644a59baa72f7f01e3ddbe0b8183f58a651b8c and open this PR.