### PR TITLE
feat(recursive-list)!: rename `children` prop to `nodes` for Svelte 5 compatibility

### DIFF
--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -3061,10 +3061,10 @@ export interface RecursiveListNode {
 
 ### Props
 
-| Prop name | Required | Kind             | Reactive | Type                                                                        | Default value            | Description                        |
-| :-------- | :------- | :--------------- | :------- | --------------------------------------------------------------------------- | ------------------------ | ---------------------------------- |
-| children  | No       | <code>let</code> | No       | <code>Array<RecursiveListNode & { children?: RecursiveListNode[]; }></code> | <code>[]</code>          | Specify the children to render     |
-| type      | No       | <code>let</code> | No       | <code>"unordered" &#124; "ordered" &#124; "ordered-native"</code>           | <code>"unordered"</code> | Specify the type of list to render |
+| Prop name | Required | Kind             | Reactive | Type                                                                     | Default value            | Description                        |
+| :-------- | :------- | :--------------- | :------- | ------------------------------------------------------------------------ | ------------------------ | ---------------------------------- |
+| nodes     | No       | <code>let</code> | No       | <code>Array<RecursiveListNode & { nodes?: RecursiveListNode[]; }></code> | <code>[]</code>          | Specify the nodes to render        |
+| type      | No       | <code>let</code> | No       | <code>"unordered" &#124; "ordered" &#124; "ordered-native"</code>        | <code>"unordered"</code> | Specify the type of list to render |
 
 ### Slots
 

--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -9881,10 +9881,10 @@
       "filePath": "src/RecursiveList/RecursiveList.svelte",
       "props": [
         {
-          "name": "children",
+          "name": "nodes",
           "kind": "let",
-          "description": "Specify the children to render",
-          "type": "Array<RecursiveListNode & { children?: RecursiveListNode[]; }>",
+          "description": "Specify the nodes to render",
+          "type": "Array<RecursiveListNode & { nodes?: RecursiveListNode[]; }>",
           "value": "[]",
           "isFunction": false,
           "isFunctionDeclaration": false,

--- a/docs/src/pages/framed/RecursiveList/RecursiveList.svelte
+++ b/docs/src/pages/framed/RecursiveList/RecursiveList.svelte
@@ -1,19 +1,19 @@
 <script>
   import { RecursiveList } from "carbon-components-svelte";
 
-  const children = [
+  const nodes = [
     {
       text: "Item 1",
-      children: [
+      nodes: [
         {
           text: "Item 1a",
-          children: [{ html: "<h5>HTML content</h5>" }],
+          nodes: [{ html: "<h5>HTML content</h5>" }],
         },
       ],
     },
     {
       text: "Item 2",
-      children: [
+      nodes: [
         {
           href: "https://svelte.dev/",
         },
@@ -29,4 +29,4 @@
   ];
 </script>
 
-<RecursiveList children="{children}" />
+<RecursiveList nodes="{nodes}" />

--- a/docs/src/pages/framed/RecursiveList/RecursiveListOrdered.svelte
+++ b/docs/src/pages/framed/RecursiveList/RecursiveListOrdered.svelte
@@ -1,19 +1,19 @@
 <script>
   import { RecursiveList } from "carbon-components-svelte";
 
-  const children = [
+  const nodes = [
     {
       text: "Item 1",
-      children: [
+      nodes: [
         {
           text: "Item 1a",
-          children: [{ html: "<h5>HTML content</h5>" }],
+          nodes: [{ html: "<h5>HTML content</h5>" }],
         },
       ],
     },
     {
       text: "Item 2",
-      children: [
+      nodes: [
         {
           href: "https://svelte.dev/",
         },
@@ -29,4 +29,4 @@
   ];
 </script>
 
-<RecursiveList type="ordered" children="{children}" />
+<RecursiveList type="ordered" nodes="{nodes}" />

--- a/docs/src/pages/framed/RecursiveList/RecursiveListOrderedNative.svelte
+++ b/docs/src/pages/framed/RecursiveList/RecursiveListOrderedNative.svelte
@@ -1,19 +1,19 @@
 <script>
   import { RecursiveList } from "carbon-components-svelte";
 
-  const children = [
+  const nodes = [
     {
       text: "Item 1",
-      children: [
+      nodes: [
         {
           text: "Item 1a",
-          children: [{ html: "<h5>HTML content</h5>" }],
+          nodes: [{ html: "<h5>HTML content</h5>" }],
         },
       ],
     },
     {
       text: "Item 2",
-      children: [
+      nodes: [
         {
           href: "https://svelte.dev/",
         },
@@ -29,4 +29,4 @@
   ];
 </script>
 
-<RecursiveList type="ordered-native" children="{children}" />
+<RecursiveList type="ordered-native" nodes="{nodes}" />

--- a/src/RecursiveList/RecursiveList.svelte
+++ b/src/RecursiveList/RecursiveList.svelte
@@ -5,10 +5,10 @@
    */
 
   /**
-   * Specify the children to render
-   * @type {Array<RecursiveListNode & { children?: RecursiveListNode[]; }>}
+   * Specify the nodes to render
+   * @type {Array<RecursiveListNode & { nodes?: RecursiveListNode[]; }>}
    */
-  export let children = [];
+  export let nodes = [];
 
   /**
    * Specify the type of list to render
@@ -26,8 +26,8 @@
   native="{type === 'ordered-native'}"
   {...$$restProps}
 >
-  {#each children as child}
-    {#if Array.isArray(child.children)}
+  {#each nodes as child}
+    {#if Array.isArray(child.nodes)}
       <RecursiveListItem {...child}>
         <svelte:self {...child} type="{type}" nested />
       </RecursiveListItem>

--- a/tests/RecursiveList.test.svelte
+++ b/tests/RecursiveList.test.svelte
@@ -1,19 +1,19 @@
 <script lang="ts">
   import { RecursiveList } from "carbon-components-svelte";
 
-  const children = [
+  const nodes = [
     {
       text: "Item 1",
-      children: [
+      nodes: [
         {
           text: "Item 1a",
-          children: [{ html: "<h5>HTML content</h5>" }],
+          nodes: [{ html: "<h5>HTML content</h5>" }],
         },
       ],
     },
     {
       text: "Item 2",
-      children: [
+      nodes: [
         {
           href: "https://svelte.dev/",
         },
@@ -29,4 +29,4 @@
   ];
 </script>
 
-<RecursiveList type="ordered" children="{children}" />
+<RecursiveList type="ordered" nodes="{nodes}" />

--- a/types/RecursiveList/RecursiveList.svelte.d.ts
+++ b/types/RecursiveList/RecursiveList.svelte.d.ts
@@ -11,10 +11,10 @@ type $RestProps = SvelteHTMLElements["ul"] & SvelteHTMLElements["ol"];
 
 type $Props = {
   /**
-   * Specify the children to render
+   * Specify the nodes to render
    * @default []
    */
-  children?: Array<RecursiveListNode & { children?: RecursiveListNode[] }>;
+  nodes?: Array<RecursiveListNode & { nodes?: RecursiveListNode[] }>;
 
   /**
    * Specify the type of list to render


### PR DESCRIPTION
Fixes [#2013](https://github.com/carbon-design-system/carbon-components-svelte/issues/2013)
