### PR TITLE
docs: update number of `carbon-icons-svelte` to 2,400+

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Design systems facilitate design and development through reuse, consistency, and
 
 The Carbon Svelte portfolio also includes:
 
-- **[Carbon Icons Svelte](https://github.com/carbon-design-system/carbon-icons-svelte)**: 2,300+ Carbon icons as Svelte components
+- **[Carbon Icons Svelte](https://github.com/carbon-design-system/carbon-icons-svelte)**: 2,400+ Carbon icons as Svelte components
 - **[Carbon Pictograms Svelte](https://github.com/carbon-design-system/carbon-pictograms-svelte)**: 1,100+ Carbon pictograms as Svelte components
 - **[Carbon Charts Svelte](https://github.com/carbon-design-system/carbon-charts/tree/master/packages/svelte)**: 20+ charts, powered by d3
 - **[Carbon Preprocess Svelte](https://github.com/carbon-design-system/carbon-preprocess-svelte)**: Collection of Svelte preprocessors for Carbon

--- a/docs/src/pages/index.svelte
+++ b/docs/src/pages/index.svelte
@@ -230,7 +230,7 @@
         <TileCard
           borderBottom
           title="Carbon Icons Svelte"
-          subtitle="2,300+ icons"
+          subtitle="2,400+ icons"
           target="_blank"
           href="https://github.com/carbon-design-system/carbon-icons-svelte"
         />


### PR DESCRIPTION
https://github.com/carbon-design-system/carbon-icons-svelte/releases/tag/v12.13.0

The latest `@carbon/icons@11.52` brings the total `carbon-icons-svelte` to 2421. Update the docs to reflect this.