### PR TITLE
fix(combo-box): fix types for `on:clear`

### DIFF
--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -697,12 +697,12 @@ export interface ComboBoxItem {
 | Event name | Type       | Detail                                                                  |
 | :--------- | :--------- | :---------------------------------------------------------------------- |
 | select     | dispatched | <code>{ selectedId: ComboBoxItemId; selectedItem: ComboBoxItem }</code> |
+| clear      | dispatched | <code>KeyboardEvent &#124; MouseEvent</code>                            |
 | keydown    | forwarded  | --                                                                      |
 | keyup      | forwarded  | --                                                                      |
 | focus      | forwarded  | --                                                                      |
 | blur       | forwarded  | --                                                                      |
 | paste      | forwarded  | --                                                                      |
-| clear      | forwarded  | --                                                                      |
 | scroll     | forwarded  | --                                                                      |
 
 ## `ComposedModal`

--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -1780,12 +1780,16 @@
           "name": "select",
           "detail": "{ selectedId: ComboBoxItemId; selectedItem: ComboBoxItem }"
         },
+        {
+          "type": "dispatched",
+          "name": "clear",
+          "detail": "KeyboardEvent | MouseEvent"
+        },
         { "type": "forwarded", "name": "keydown", "element": "input" },
         { "type": "forwarded", "name": "keyup", "element": "input" },
         { "type": "forwarded", "name": "focus", "element": "input" },
         { "type": "forwarded", "name": "blur", "element": "input" },
         { "type": "forwarded", "name": "paste", "element": "input" },
-        { "type": "forwarded", "name": "clear", "element": "ListBoxSelection" },
         { "type": "forwarded", "name": "scroll", "element": "ListBoxMenu" }
       ],
       "typedefs": [

--- a/src/ComboBox/ComboBox.svelte
+++ b/src/ComboBox/ComboBox.svelte
@@ -3,6 +3,7 @@
    * @typedef {any} ComboBoxItemId
    * @typedef {{ id: ComboBoxItemId; text: string; disabled?: boolean; }} ComboBoxItem
    * @event {{ selectedId: ComboBoxItemId; selectedItem: ComboBoxItem }} select
+   * @event {KeyboardEvent | MouseEvent} clear
    * @slot {{ item: ComboBoxItem; index: number }}
    */
 

--- a/tests/ComboBox.test.svelte
+++ b/tests/ComboBox.test.svelte
@@ -23,6 +23,9 @@
   on:select="{(e) => {
     console.log(e.detail.selectedId);
   }}"
+  on:clear="{(e) => {
+    console.log(e.detail);
+  }}"
   translateWithId="{(id) => {
     console.log(id); // "open" | "close"
     return id;

--- a/types/ComboBox/ComboBox.svelte.d.ts
+++ b/types/ComboBox/ComboBox.svelte.d.ts
@@ -164,12 +164,12 @@ export default class ComboBox extends SvelteComponentTyped<
       selectedId: ComboBoxItemId;
       selectedItem: ComboBoxItem;
     }>;
+    clear: CustomEvent<KeyboardEvent | MouseEvent>;
     keydown: WindowEventMap["keydown"];
     keyup: WindowEventMap["keyup"];
     focus: WindowEventMap["focus"];
     blur: WindowEventMap["blur"];
     paste: DocumentAndElementEventHandlersEventMap["paste"];
-    clear: WindowEventMap["clear"];
     scroll: WindowEventMap["scroll"];
   },
   { default: { item: ComboBoxItem; index: number }; titleText: {} }


### PR DESCRIPTION
In `ComboBox`, on:clear is forwarded to `ListBoxSelection`, and is a dispatched event.

This event must be explicitly typed in `ComboBox`.