### PR TITLE
fix(types): fix types for `on:paste` event

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "rollup-plugin-terser": "^7.0.2",
         "sass": "^1.49.11",
         "standard-version": "^9.5.0",
-        "sveld": "^0.20.2",
+        "sveld": "^0.20.3",
         "svelte": "^4.2.10",
         "svelte-check": "^3.6.4",
         "typescript": "^4.7.4"
@@ -3075,9 +3075,9 @@
       }
     },
     "node_modules/sveld": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/sveld/-/sveld-0.20.2.tgz",
-      "integrity": "sha512-pd/RZ4TR7oaX6XphE8uhwAjKIVw1lg19aysYM5lYpD97AthlAJD8kSEgtEXHXw6xFYXsfnhrj0XxGHnbKFsnlA==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/sveld/-/sveld-0.20.3.tgz",
+      "integrity": "sha512-8BFxsG65J/25/+ShuljW4xv2Ax5VtZYnDUyiYt83YS+VS3qGDifppzAsX10IVUuhJpJyEfwOUBGWPeoPdsfdew==",
       "dev": true,
       "dependencies": {
         "@rollup/plugin-node-resolve": "^13.3.0",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "rollup-plugin-terser": "^7.0.2",
     "sass": "^1.49.11",
     "standard-version": "^9.5.0",
-    "sveld": "^0.20.2",
+    "sveld": "^0.20.3",
     "svelte": "^4.2.10",
     "svelte-check": "^3.6.4",
     "typescript": "^4.7.4"

--- a/types/ComboBox/ComboBox.svelte.d.ts
+++ b/types/ComboBox/ComboBox.svelte.d.ts
@@ -169,7 +169,7 @@ export default class ComboBox extends SvelteComponentTyped<
     keyup: WindowEventMap["keyup"];
     focus: WindowEventMap["focus"];
     blur: WindowEventMap["blur"];
-    paste: DocumentAndElementEventHandlersEventMap["paste"];
+    paste: WindowEventMap["paste"];
     scroll: WindowEventMap["scroll"];
   },
   { default: { item: ComboBoxItem; index: number }; titleText: {} }

--- a/types/DataTable/ToolbarSearch.svelte.d.ts
+++ b/types/DataTable/ToolbarSearch.svelte.d.ts
@@ -76,7 +76,7 @@ export default class ToolbarSearch extends SvelteComponentTyped<
     blur: WindowEventMap["blur"];
     keyup: WindowEventMap["keyup"];
     keydown: WindowEventMap["keydown"];
-    paste: DocumentAndElementEventHandlersEventMap["paste"];
+    paste: WindowEventMap["paste"];
   },
   {}
 > {}

--- a/types/DatePicker/DatePickerInput.svelte.d.ts
+++ b/types/DatePicker/DatePickerInput.svelte.d.ts
@@ -110,7 +110,7 @@ export default class DatePickerInput extends SvelteComponentTyped<
     keydown: WindowEventMap["keydown"];
     keyup: WindowEventMap["keyup"];
     blur: WindowEventMap["blur"];
-    paste: DocumentAndElementEventHandlersEventMap["paste"];
+    paste: WindowEventMap["paste"];
   },
   { labelText: {} }
 > {}

--- a/types/MultiSelect/MultiSelect.svelte.d.ts
+++ b/types/MultiSelect/MultiSelect.svelte.d.ts
@@ -255,7 +255,7 @@ export default class MultiSelect extends SvelteComponentTyped<
     keydown: WindowEventMap["keydown"];
     keyup: WindowEventMap["keyup"];
     focus: WindowEventMap["focus"];
-    paste: DocumentAndElementEventHandlersEventMap["paste"];
+    paste: WindowEventMap["paste"];
   },
   { default: { item: MultiSelectItem; index: number }; titleText: {} }
 > {}

--- a/types/NumberInput/NumberInput.svelte.d.ts
+++ b/types/NumberInput/NumberInput.svelte.d.ts
@@ -155,7 +155,7 @@ export default class NumberInput extends SvelteComponentTyped<
     keyup: WindowEventMap["keyup"];
     focus: WindowEventMap["focus"];
     blur: WindowEventMap["blur"];
-    paste: DocumentAndElementEventHandlersEventMap["paste"];
+    paste: WindowEventMap["paste"];
   },
   { label: {} }
 > {

--- a/types/Search/Search.svelte.d.ts
+++ b/types/Search/Search.svelte.d.ts
@@ -119,7 +119,7 @@ export default class Search extends SvelteComponentTyped<
     blur: WindowEventMap["blur"];
     keydown: WindowEventMap["keydown"];
     keyup: WindowEventMap["keyup"];
-    paste: DocumentAndElementEventHandlersEventMap["paste"];
+    paste: WindowEventMap["paste"];
     clear: CustomEvent<null>;
   },
   { labelText: {} }

--- a/types/TextArea/TextArea.svelte.d.ts
+++ b/types/TextArea/TextArea.svelte.d.ts
@@ -116,7 +116,7 @@ export default class TextArea extends SvelteComponentTyped<
     keyup: WindowEventMap["keyup"];
     focus: WindowEventMap["focus"];
     blur: WindowEventMap["blur"];
-    paste: DocumentAndElementEventHandlersEventMap["paste"];
+    paste: WindowEventMap["paste"];
   },
   { labelText: {} }
 > {}

--- a/types/TextInput/PasswordInput.svelte.d.ts
+++ b/types/TextInput/PasswordInput.svelte.d.ts
@@ -146,7 +146,7 @@ export default class PasswordInput extends SvelteComponentTyped<
     keyup: WindowEventMap["keyup"];
     focus: WindowEventMap["focus"];
     blur: WindowEventMap["blur"];
-    paste: DocumentAndElementEventHandlersEventMap["paste"];
+    paste: WindowEventMap["paste"];
   },
   { labelText: {} }
 > {}

--- a/types/TextInput/TextInput.svelte.d.ts
+++ b/types/TextInput/TextInput.svelte.d.ts
@@ -131,7 +131,7 @@ export default class TextInput extends SvelteComponentTyped<
     keyup: WindowEventMap["keyup"];
     focus: WindowEventMap["focus"];
     blur: WindowEventMap["blur"];
-    paste: DocumentAndElementEventHandlersEventMap["paste"];
+    paste: WindowEventMap["paste"];
   },
   { labelText: {} }
 > {}

--- a/types/TimePicker/TimePicker.svelte.d.ts
+++ b/types/TimePicker/TimePicker.svelte.d.ts
@@ -104,7 +104,7 @@ export default class TimePicker extends SvelteComponentTyped<
     keyup: WindowEventMap["keyup"];
     focus: WindowEventMap["focus"];
     blur: WindowEventMap["blur"];
-    paste: DocumentAndElementEventHandlersEventMap["paste"];
+    paste: WindowEventMap["paste"];
   },
   { default: {}; labelText: {} }
 > {}

--- a/types/UIShell/HeaderSearch.svelte.d.ts
+++ b/types/UIShell/HeaderSearch.svelte.d.ts
@@ -59,7 +59,7 @@ export default class HeaderSearch extends SvelteComponentTyped<
     focus: WindowEventMap["focus"];
     blur: WindowEventMap["blur"];
     keydown: WindowEventMap["keydown"];
-    paste: DocumentAndElementEventHandlersEventMap["paste"];
+    paste: WindowEventMap["paste"];
   },
   { default: { result: HeaderSearchResult; index: number } }
 > {}


### PR DESCRIPTION
Upgrades Sveld to v0.20.3 to fix the generated types for the `paste` event.

TypeScript lib.dom.d.ts now includes cut/copy/paste on the `WindowEventMap` interface.