### PR TITLE
fix(toolbar-search): fix types for `on:clear`

### DIFF
--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -4548,16 +4548,16 @@ None.
 
 ### Events
 
-| Event name | Type      | Detail |
-| :--------- | :-------- | :----- |
-| clear      | forwarded | --     |
-| change     | forwarded | --     |
-| input      | forwarded | --     |
-| focus      | forwarded | --     |
-| blur       | forwarded | --     |
-| keyup      | forwarded | --     |
-| keydown    | forwarded | --     |
-| paste      | forwarded | --     |
+| Event name | Type       | Detail            |
+| :--------- | :--------- | :---------------- |
+| clear      | dispatched | <code>null</code> |
+| change     | forwarded  | --                |
+| input      | forwarded  | --                |
+| focus      | forwarded  | --                |
+| blur       | forwarded  | --                |
+| keyup      | forwarded  | --                |
+| keydown    | forwarded  | --                |
+| paste      | forwarded  | --                |
 
 ## `Tooltip`
 

--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -14253,7 +14253,7 @@
       "moduleExports": [],
       "slots": [],
       "events": [
-        { "type": "forwarded", "name": "clear", "element": "Search" },
+        { "type": "dispatched", "name": "clear", "detail": "null" },
         { "type": "forwarded", "name": "change", "element": "Search" },
         { "type": "forwarded", "name": "input", "element": "Search" },
         { "type": "forwarded", "name": "focus", "element": "Search" },

--- a/src/DataTable/ToolbarSearch.svelte
+++ b/src/DataTable/ToolbarSearch.svelte
@@ -1,5 +1,8 @@
 <script>
-  /** @restProps {input} */
+  /**
+   * @restProps {input}
+   * @event {null} clear
+   */
 
   /**
    * Specify the value of the search input

--- a/types/DataTable/ToolbarSearch.svelte.d.ts
+++ b/types/DataTable/ToolbarSearch.svelte.d.ts
@@ -69,7 +69,7 @@ export interface ToolbarSearchProps extends RestProps {
 export default class ToolbarSearch extends SvelteComponentTyped<
   ToolbarSearchProps,
   {
-    clear: WindowEventMap["clear"];
+    clear: CustomEvent<null>;
     change: WindowEventMap["change"];
     input: WindowEventMap["input"];
     focus: WindowEventMap["focus"];


### PR DESCRIPTION
Related #2020

`on:clear` is forwarded to `Search`. It needs to be explicitly annotated to pick up the correct type. Otherwise, it defaults to assuming it's a native event.