### PR TITLE
ci: add script to test generated types

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -20,6 +20,9 @@ jobs:
       - name: Build the codebase
         run: npm run build:lib
 
+      - name: Test generated source types
+        run: npm run test:src-types
+
       - name: Test types
         run: npm run test:types
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "css/*.css"
   ],
   "scripts": {
+    "test:src-types": "tsc types/**/*.ts",
     "test:types": "svelte-check --workspace tests",
     "lint": "prettier --write \"**/*.{svelte,md,js,json,ts}\"",
     "build:css": "node scripts/build-css",


### PR DESCRIPTION
The generated TypeScript definitions need to be periodically validated.

A flurry of recent PRs have aimed to correct type issues:

- #2019
- #2020
- #2022
- #2023
- #2027

Additionally, TypeScript was upgraded to the latest minor version in #2024.

This PR adds a script to type check generated definitions for the library to ensure basic workability and guard against regressions.

The current check should expectedly fail as there are still TypeScript errors that I'm working through.