### PR TITLE
Use type alias instead of interface

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "rollup-plugin-terser": "^7.0.2",
         "sass": "^1.49.11",
         "standard-version": "^9.5.0",
-        "sveld": "^0.20.3",
+        "sveld": "^0.21.0",
         "svelte": "^4.2.10",
         "svelte-check": "^3.6.4",
         "typescript": "^5.6.3"
@@ -3075,9 +3075,9 @@
       }
     },
     "node_modules/sveld": {
-      "version": "0.20.3",
-      "resolved": "https://registry.npmjs.org/sveld/-/sveld-0.20.3.tgz",
-      "integrity": "sha512-8BFxsG65J/25/+ShuljW4xv2Ax5VtZYnDUyiYt83YS+VS3qGDifppzAsX10IVUuhJpJyEfwOUBGWPeoPdsfdew==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/sveld/-/sveld-0.21.0.tgz",
+      "integrity": "sha512-I1KPSTOBhEw9wOj6GsKH4w5Y8ZM0ymsWyhyXbJYdcBAuk1S21OPBOKc1IgMgbEUImXSEoF60L7soghfQz4gZQQ==",
       "dev": true,
       "dependencies": {
         "@rollup/plugin-node-resolve": "^13.3.0",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "rollup-plugin-terser": "^7.0.2",
     "sass": "^1.49.11",
     "standard-version": "^9.5.0",
-    "sveld": "^0.20.3",
+    "sveld": "^0.21.0",
     "svelte": "^4.2.10",
     "svelte-check": "^3.6.4",
     "typescript": "^5.6.3"

--- a/types/Accordion/Accordion.svelte.d.ts
+++ b/types/Accordion/Accordion.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { AccordionSkeletonProps } from "./AccordionSkeleton.svelte";
 
-export interface AccordionProps extends AccordionSkeletonProps {
+export type AccordionProps = AccordionSkeletonProps & {
   /**
    * Specify alignment of accordion item chevron icon
    * @default "end"
@@ -25,7 +25,7 @@ export interface AccordionProps extends AccordionSkeletonProps {
    * @default false
    */
   skeleton?: boolean;
-}
+};
 
 export default class Accordion extends SvelteComponentTyped<
   AccordionProps,

--- a/types/Accordion/AccordionItem.svelte.d.ts
+++ b/types/Accordion/AccordionItem.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["li"];
+type $RestProps = SvelteHTMLElements["li"];
 
-export interface AccordionItemProps extends RestProps {
+type $Props = {
   /**
    * Specify the title of the accordion item heading.
    * Alternatively, use the "title" slot (e.g., `<div slot="title">...</div>`)
@@ -30,7 +30,9 @@ export interface AccordionItemProps extends RestProps {
   iconDescription?: string;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type AccordionItemProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class AccordionItem extends SvelteComponentTyped<
   AccordionItemProps,

--- a/types/Accordion/AccordionSkeleton.svelte.d.ts
+++ b/types/Accordion/AccordionSkeleton.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["ul"];
+type $RestProps = SvelteHTMLElements["ul"];
 
-export interface AccordionSkeletonProps extends RestProps {
+type $Props = {
   /**
    * Specify the number of accordion items to render
    * @default 4
@@ -29,7 +29,9 @@ export interface AccordionSkeletonProps extends RestProps {
   open?: boolean;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type AccordionSkeletonProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class AccordionSkeleton extends SvelteComponentTyped<
   AccordionSkeletonProps,

--- a/types/AspectRatio/AspectRatio.svelte.d.ts
+++ b/types/AspectRatio/AspectRatio.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
-export interface AspectRatioProps extends RestProps {
+type $Props = {
   /**
    * Specify the aspect ratio
    * @default "2x1"
@@ -20,7 +20,9 @@ export interface AspectRatioProps extends RestProps {
     | "1x2";
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type AspectRatioProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class AspectRatio extends SvelteComponentTyped<
   AspectRatioProps,

--- a/types/Breadcrumb/Breadcrumb.svelte.d.ts
+++ b/types/Breadcrumb/Breadcrumb.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { BreadcrumbSkeletonProps } from "./BreadcrumbSkeleton.svelte";
 
-export interface BreadcrumbProps extends BreadcrumbSkeletonProps {
+export type BreadcrumbProps = BreadcrumbSkeletonProps & {
   /**
    * Set to `true` to hide the breadcrumb trailing slash
    * @default false
@@ -13,7 +13,7 @@ export interface BreadcrumbProps extends BreadcrumbSkeletonProps {
    * @default false
    */
   skeleton?: boolean;
-}
+};
 
 export default class Breadcrumb extends SvelteComponentTyped<
   BreadcrumbProps,

--- a/types/Breadcrumb/BreadcrumbItem.svelte.d.ts
+++ b/types/Breadcrumb/BreadcrumbItem.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["li"];
+type $RestProps = SvelteHTMLElements["li"];
 
-export interface BreadcrumbItemProps extends RestProps {
+type $Props = {
   /**
    * Set the `href` to use an anchor link
    * @default undefined
@@ -17,7 +17,9 @@ export interface BreadcrumbItemProps extends RestProps {
   isCurrentPage?: boolean;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type BreadcrumbItemProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class BreadcrumbItem extends SvelteComponentTyped<
   BreadcrumbItemProps,

--- a/types/Breadcrumb/BreadcrumbSkeleton.svelte.d.ts
+++ b/types/Breadcrumb/BreadcrumbSkeleton.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
-export interface BreadcrumbSkeletonProps extends RestProps {
+type $Props = {
   /**
    * Set to `true` to hide the breadcrumb trailing slash
    * @default false
@@ -17,7 +17,9 @@ export interface BreadcrumbSkeletonProps extends RestProps {
   count?: number;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type BreadcrumbSkeletonProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class BreadcrumbSkeleton extends SvelteComponentTyped<
   BreadcrumbSkeletonProps,

--- a/types/Breakpoint/Breakpoint.svelte.d.ts
+++ b/types/Breakpoint/Breakpoint.svelte.d.ts
@@ -4,7 +4,7 @@ export type BreakpointSize = "sm" | "md" | "lg" | "xlg" | "max";
 
 export type BreakpointValue = 320 | 672 | 1056 | 1312 | 1584;
 
-export interface BreakpointProps {
+export type BreakpointProps = {
   /**
    * Determine the current Carbon grid breakpoint size
    * @default undefined
@@ -16,7 +16,7 @@ export interface BreakpointProps {
    * @default { sm: false, md: false, lg: false, xlg: false, max: false, }
    */
   sizes?: Record<BreakpointSize, boolean>;
-}
+};
 
 export default class Breakpoint extends SvelteComponentTyped<
   BreakpointProps,

--- a/types/Button/Button.svelte.d.ts
+++ b/types/Button/Button.svelte.d.ts
@@ -3,11 +3,11 @@ import type { SvelteHTMLElements } from "svelte/elements";
 
 import type { ButtonSkeletonProps } from "./ButtonSkeleton.svelte";
 
-type RestProps = SvelteHTMLElements["button"] &
+type $RestProps = SvelteHTMLElements["button"] &
   SvelteHTMLElements["a"] &
   SvelteHTMLElements["div"];
 
-export interface ButtonProps extends ButtonSkeletonProps, RestProps {
+type $Props = {
   /**
    * Specify the kind of button
    * @default "primary"
@@ -109,7 +109,9 @@ export interface ButtonProps extends ButtonSkeletonProps, RestProps {
   ref?: null | HTMLAnchorElement | HTMLButtonElement;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type ButtonProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class Button extends SvelteComponentTyped<
   ButtonProps,

--- a/types/Button/ButtonSet.svelte.d.ts
+++ b/types/Button/ButtonSet.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
-export interface ButtonSetProps extends RestProps {
+type $Props = {
   /**
    * Set to `true` to stack the buttons vertically
    * @default false
@@ -11,7 +11,9 @@ export interface ButtonSetProps extends RestProps {
   stacked?: boolean;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type ButtonSetProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class ButtonSet extends SvelteComponentTyped<
   ButtonSetProps,

--- a/types/Button/ButtonSkeleton.svelte.d.ts
+++ b/types/Button/ButtonSkeleton.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["a"];
+type $RestProps = SvelteHTMLElements["a"];
 
-export interface ButtonSkeletonProps extends RestProps {
+type $Props = {
   /**
    * Set the `href` to use an anchor link
    * @default undefined
@@ -17,7 +17,9 @@ export interface ButtonSkeletonProps extends RestProps {
   size?: "default" | "field" | "small" | "lg" | "xl";
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type ButtonSkeletonProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class ButtonSkeleton extends SvelteComponentTyped<
   ButtonSkeletonProps,

--- a/types/Checkbox/Checkbox.svelte.d.ts
+++ b/types/Checkbox/Checkbox.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
-export interface CheckboxProps extends RestProps {
+type $Props = {
   /**
    * Specify the value of the checkbox
    * @default ""
@@ -89,7 +89,9 @@ export interface CheckboxProps extends RestProps {
   ref?: null | HTMLInputElement;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type CheckboxProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class Checkbox extends SvelteComponentTyped<
   CheckboxProps,

--- a/types/Checkbox/CheckboxSkeleton.svelte.d.ts
+++ b/types/Checkbox/CheckboxSkeleton.svelte.d.ts
@@ -1,11 +1,13 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
-export interface CheckboxSkeletonProps extends RestProps {
+type $Props = {
   [key: `data-${string}`]: any;
-}
+};
+
+export type CheckboxSkeletonProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class CheckboxSkeleton extends SvelteComponentTyped<
   CheckboxSkeletonProps,

--- a/types/CodeSnippet/CodeSnippet.svelte.d.ts
+++ b/types/CodeSnippet/CodeSnippet.svelte.d.ts
@@ -1,6 +1,6 @@
 import type { SvelteComponentTyped } from "svelte";
 
-export interface CodeSnippetProps {
+export type CodeSnippetProps = {
   /**
    * Set the type of code snippet
    * @default "single"
@@ -122,7 +122,7 @@ export interface CodeSnippetProps {
    * @default null
    */
   ref?: null | HTMLPreElement;
-}
+};
 
 export default class CodeSnippet extends SvelteComponentTyped<
   CodeSnippetProps,

--- a/types/CodeSnippet/CodeSnippetSkeleton.svelte.d.ts
+++ b/types/CodeSnippet/CodeSnippetSkeleton.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
-export interface CodeSnippetSkeletonProps extends RestProps {
+type $Props = {
   /**
    * Set the type of code snippet
    * @default "single"
@@ -11,7 +11,9 @@ export interface CodeSnippetSkeletonProps extends RestProps {
   type?: "single" | "multi";
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type CodeSnippetSkeletonProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class CodeSnippetSkeleton extends SvelteComponentTyped<
   CodeSnippetSkeletonProps,

--- a/types/ComboBox/ComboBox.svelte.d.ts
+++ b/types/ComboBox/ComboBox.svelte.d.ts
@@ -9,9 +9,9 @@ export interface ComboBoxItem {
   disabled?: boolean;
 }
 
-type RestProps = SvelteHTMLElements["input"];
+type $RestProps = SvelteHTMLElements["input"];
 
-export interface ComboBoxProps extends RestProps {
+type $Props = {
   /**
    * Set the combobox items
    * @default []
@@ -155,7 +155,9 @@ export interface ComboBoxProps extends RestProps {
   listRef?: null | HTMLDivElement;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type ComboBoxProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class ComboBox extends SvelteComponentTyped<
   ComboBoxProps,

--- a/types/ComposedModal/ComposedModal.svelte.d.ts
+++ b/types/ComposedModal/ComposedModal.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
-export interface ComposedModalProps extends RestProps {
+type $Props = {
   /**
    * Set the size of the composed modal
    * @default undefined
@@ -47,7 +47,9 @@ export interface ComposedModalProps extends RestProps {
   ref?: null | HTMLDivElement;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type ComposedModalProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class ComposedModal extends SvelteComponentTyped<
   ComposedModalProps,

--- a/types/ComposedModal/ModalBody.svelte.d.ts
+++ b/types/ComposedModal/ModalBody.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
-export interface ModalBodyProps extends RestProps {
+type $Props = {
   /**
    * Set to `true` if the modal contains form elements
    * @default false
@@ -17,7 +17,9 @@ export interface ModalBodyProps extends RestProps {
   hasScrollingContent?: boolean;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type ModalBodyProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class ModalBody extends SvelteComponentTyped<
   ModalBodyProps,

--- a/types/ComposedModal/ModalFooter.svelte.d.ts
+++ b/types/ComposedModal/ModalFooter.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
-export interface ModalFooterProps extends RestProps {
+type $Props = {
   /**
    * Specify the primary button text
    * @default ""
@@ -54,7 +54,9 @@ export interface ModalFooterProps extends RestProps {
   danger?: boolean;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type ModalFooterProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class ModalFooter extends SvelteComponentTyped<
   ModalFooterProps,

--- a/types/ComposedModal/ModalHeader.svelte.d.ts
+++ b/types/ComposedModal/ModalHeader.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
-export interface ModalHeaderProps extends RestProps {
+type $Props = {
   /**
    * Specify the modal title
    * @default ""
@@ -47,7 +47,9 @@ export interface ModalHeaderProps extends RestProps {
   iconDescription?: string;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type ModalHeaderProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class ModalHeader extends SvelteComponentTyped<
   ModalHeaderProps,

--- a/types/ContentSwitcher/ContentSwitcher.svelte.d.ts
+++ b/types/ContentSwitcher/ContentSwitcher.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
-export interface ContentSwitcherProps extends RestProps {
+type $Props = {
   /**
    * Set the selected index of the switch item
    * @default 0
@@ -17,7 +17,9 @@ export interface ContentSwitcherProps extends RestProps {
   size?: "sm" | "xl";
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type ContentSwitcherProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class ContentSwitcher extends SvelteComponentTyped<
   ContentSwitcherProps,

--- a/types/ContentSwitcher/Switch.svelte.d.ts
+++ b/types/ContentSwitcher/Switch.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["button"];
+type $RestProps = SvelteHTMLElements["button"];
 
-export interface SwitchProps extends RestProps {
+type $Props = {
   /**
    * Specify the switch text.
    * Alternatively, use the "text" slot  (e.g., `<span slot="text">...</span>`)
@@ -36,7 +36,9 @@ export interface SwitchProps extends RestProps {
   ref?: null | HTMLButtonElement;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type SwitchProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class Switch extends SvelteComponentTyped<
   SwitchProps,

--- a/types/ContextMenu/ContextMenu.svelte.d.ts
+++ b/types/ContextMenu/ContextMenu.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["ul"];
+type $RestProps = SvelteHTMLElements["ul"];
 
-export interface ContextMenuProps extends RestProps {
+type $Props = {
   /**
    * Specify an element or list of elements to trigger the context menu.
    * If no element is specified, the context menu applies to the entire window
@@ -37,7 +37,9 @@ export interface ContextMenuProps extends RestProps {
   ref?: null | HTMLUListElement;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type ContextMenuProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class ContextMenu extends SvelteComponentTyped<
   ContextMenuProps,

--- a/types/ContextMenu/ContextMenuDivider.svelte.d.ts
+++ b/types/ContextMenu/ContextMenuDivider.svelte.d.ts
@@ -1,6 +1,6 @@
 import type { SvelteComponentTyped } from "svelte";
 
-export interface ContextMenuDividerProps {}
+export type ContextMenuDividerProps = {};
 
 export default class ContextMenuDivider extends SvelteComponentTyped<
   ContextMenuDividerProps,

--- a/types/ContextMenu/ContextMenuGroup.svelte.d.ts
+++ b/types/ContextMenu/ContextMenuGroup.svelte.d.ts
@@ -1,6 +1,6 @@
 import type { SvelteComponentTyped } from "svelte";
 
-export interface ContextMenuGroupProps {
+export type ContextMenuGroupProps = {
   /**
    * @default []
    */
@@ -11,7 +11,7 @@ export interface ContextMenuGroupProps {
    * @default ""
    */
   labelText?: string;
-}
+};
 
 export default class ContextMenuGroup extends SvelteComponentTyped<
   ContextMenuGroupProps,

--- a/types/ContextMenu/ContextMenuOption.svelte.d.ts
+++ b/types/ContextMenu/ContextMenuOption.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["li"];
+type $RestProps = SvelteHTMLElements["li"];
 
-export interface ContextMenuOptionProps extends RestProps {
+type $Props = {
   /**
    * Specify the kind of option
    * @default "default"
@@ -70,7 +70,9 @@ export interface ContextMenuOptionProps extends RestProps {
   ref?: null | HTMLLIElement;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type ContextMenuOptionProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class ContextMenuOption extends SvelteComponentTyped<
   ContextMenuOptionProps,

--- a/types/ContextMenu/ContextMenuRadioGroup.svelte.d.ts
+++ b/types/ContextMenu/ContextMenuRadioGroup.svelte.d.ts
@@ -1,6 +1,6 @@
 import type { SvelteComponentTyped } from "svelte";
 
-export interface ContextMenuRadioGroupProps {
+export type ContextMenuRadioGroupProps = {
   /**
    * Set the selected radio group id
    * @default ""
@@ -12,7 +12,7 @@ export interface ContextMenuRadioGroupProps {
    * @default ""
    */
   labelText?: string;
-}
+};
 
 export default class ContextMenuRadioGroup extends SvelteComponentTyped<
   ContextMenuRadioGroupProps,

--- a/types/CopyButton/CopyButton.svelte.d.ts
+++ b/types/CopyButton/CopyButton.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["button"];
+type $RestProps = SvelteHTMLElements["button"];
 
-export interface CopyButtonProps extends RestProps {
+type $Props = {
   /**
    * Set the feedback text shown after clicking the button
    * @default "Copied!"
@@ -35,7 +35,9 @@ export interface CopyButtonProps extends RestProps {
   copy?: (text: string) => void;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type CopyButtonProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class CopyButton extends SvelteComponentTyped<
   CopyButtonProps,

--- a/types/DataTable/DataTable.svelte.d.ts
+++ b/types/DataTable/DataTable.svelte.d.ts
@@ -40,9 +40,9 @@ export interface DataTableCell {
   display?: (item: DataTableValue, row: DataTableRow) => DataTableValue;
 }
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
-export interface DataTableProps extends RestProps {
+type $Props = {
   /**
    * Specify the data table headers
    * @default []
@@ -179,7 +179,9 @@ export interface DataTableProps extends RestProps {
   page?: number;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type DataTableProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class DataTable extends SvelteComponentTyped<
   DataTableProps,

--- a/types/DataTable/DataTableSkeleton.svelte.d.ts
+++ b/types/DataTable/DataTableSkeleton.svelte.d.ts
@@ -3,9 +3,9 @@ import type { SvelteHTMLElements } from "svelte/elements";
 
 import type { DataTableHeader } from "./DataTable.svelte";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
-export interface DataTableSkeletonProps extends DataTableHeader, RestProps {
+type $Props = {
   /**
    * Specify the number of columns
    * Superseded by `headers` if `headers` is a non-empty array
@@ -51,7 +51,9 @@ export interface DataTableSkeletonProps extends DataTableHeader, RestProps {
   showToolbar?: boolean;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type DataTableSkeletonProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class DataTableSkeleton extends SvelteComponentTyped<
   DataTableSkeletonProps,

--- a/types/DataTable/Table.svelte.d.ts
+++ b/types/DataTable/Table.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["section"];
+type $RestProps = SvelteHTMLElements["section"];
 
-export interface TableProps extends RestProps {
+type $Props = {
   /**
    * Set the size of the table
    * @default undefined
@@ -41,7 +41,9 @@ export interface TableProps extends RestProps {
   tableStyle?: string;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type TableProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class Table extends SvelteComponentTyped<
   TableProps,

--- a/types/DataTable/TableBody.svelte.d.ts
+++ b/types/DataTable/TableBody.svelte.d.ts
@@ -1,11 +1,13 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["tbody"];
+type $RestProps = SvelteHTMLElements["tbody"];
 
-export interface TableBodyProps extends RestProps {
+type $Props = {
   [key: `data-${string}`]: any;
-}
+};
+
+export type TableBodyProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class TableBody extends SvelteComponentTyped<
   TableBodyProps,

--- a/types/DataTable/TableCell.svelte.d.ts
+++ b/types/DataTable/TableCell.svelte.d.ts
@@ -1,11 +1,13 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["td"];
+type $RestProps = SvelteHTMLElements["td"];
 
-export interface TableCellProps extends RestProps {
+type $Props = {
   [key: `data-${string}`]: any;
-}
+};
+
+export type TableCellProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class TableCell extends SvelteComponentTyped<
   TableCellProps,

--- a/types/DataTable/TableContainer.svelte.d.ts
+++ b/types/DataTable/TableContainer.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
-export interface TableContainerProps extends RestProps {
+type $Props = {
   /**
    * Specify the title of the data table
    * @default ""
@@ -29,7 +29,9 @@ export interface TableContainerProps extends RestProps {
   useStaticWidth?: boolean;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type TableContainerProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class TableContainer extends SvelteComponentTyped<
   TableContainerProps,

--- a/types/DataTable/TableHead.svelte.d.ts
+++ b/types/DataTable/TableHead.svelte.d.ts
@@ -1,11 +1,13 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["thead"];
+type $RestProps = SvelteHTMLElements["thead"];
 
-export interface TableHeadProps extends RestProps {
+type $Props = {
   [key: `data-${string}`]: any;
-}
+};
+
+export type TableHeadProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class TableHead extends SvelteComponentTyped<
   TableHeadProps,

--- a/types/DataTable/TableHeader.svelte.d.ts
+++ b/types/DataTable/TableHeader.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["th"];
+type $RestProps = SvelteHTMLElements["th"];
 
-export interface TableHeaderProps extends RestProps {
+type $Props = {
   /**
    * Set to `true` for the sortable variant
    * @default false
@@ -41,7 +41,9 @@ export interface TableHeaderProps extends RestProps {
   id?: string;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type TableHeaderProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class TableHeader extends SvelteComponentTyped<
   TableHeaderProps,

--- a/types/DataTable/TableRow.svelte.d.ts
+++ b/types/DataTable/TableRow.svelte.d.ts
@@ -1,11 +1,13 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["tr"];
+type $RestProps = SvelteHTMLElements["tr"];
 
-export interface TableRowProps extends RestProps {
+type $Props = {
   [key: `data-${string}`]: any;
-}
+};
+
+export type TableRowProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class TableRow extends SvelteComponentTyped<
   TableRowProps,

--- a/types/DataTable/Toolbar.svelte.d.ts
+++ b/types/DataTable/Toolbar.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["section"];
+type $RestProps = SvelteHTMLElements["section"];
 
-export interface ToolbarProps extends RestProps {
+type $Props = {
   /**
    * Specify the toolbar size
    * @default "default"
@@ -11,7 +11,9 @@ export interface ToolbarProps extends RestProps {
   size?: "sm" | "default";
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type ToolbarProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class Toolbar extends SvelteComponentTyped<
   ToolbarProps,

--- a/types/DataTable/ToolbarBatchActions.svelte.d.ts
+++ b/types/DataTable/ToolbarBatchActions.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
-export interface ToolbarBatchActionsProps extends RestProps {
+type $Props = {
   /**
    * Override the total items selected text
    * @default (totalSelected) => `${totalSelected} item${totalSelected === 1 ? "" : "s"} selected`
@@ -17,7 +17,9 @@ export interface ToolbarBatchActionsProps extends RestProps {
   active?: undefined | boolean;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type ToolbarBatchActionsProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class ToolbarBatchActions extends SvelteComponentTyped<
   ToolbarBatchActionsProps,

--- a/types/DataTable/ToolbarContent.svelte.d.ts
+++ b/types/DataTable/ToolbarContent.svelte.d.ts
@@ -1,6 +1,6 @@
 import type { SvelteComponentTyped } from "svelte";
 
-export interface ToolbarContentProps {}
+export type ToolbarContentProps = {};
 
 export default class ToolbarContent extends SvelteComponentTyped<
   ToolbarContentProps,

--- a/types/DataTable/ToolbarMenu.svelte.d.ts
+++ b/types/DataTable/ToolbarMenu.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { OverflowMenuProps } from "../OverflowMenu/OverflowMenu.svelte";
 
-export interface ToolbarMenuProps extends OverflowMenuProps {}
+export type ToolbarMenuProps = OverflowMenuProps & {};
 
 export default class ToolbarMenu extends SvelteComponentTyped<
   ToolbarMenuProps,

--- a/types/DataTable/ToolbarMenuItem.svelte.d.ts
+++ b/types/DataTable/ToolbarMenuItem.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { OverflowMenuItemProps } from "../OverflowMenu/OverflowMenuItem.svelte";
 
-export interface ToolbarMenuItemProps extends OverflowMenuItemProps {}
+export type ToolbarMenuItemProps = OverflowMenuItemProps & {};
 
 export default class ToolbarMenuItem extends SvelteComponentTyped<
   ToolbarMenuItemProps,

--- a/types/DataTable/ToolbarSearch.svelte.d.ts
+++ b/types/DataTable/ToolbarSearch.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["input"];
+type $RestProps = SvelteHTMLElements["input"];
 
-export interface ToolbarSearchProps extends RestProps {
+type $Props = {
   /**
    * Specify the value of the search input
    * @default ""
@@ -64,7 +64,9 @@ export interface ToolbarSearchProps extends RestProps {
   ref?: null | HTMLInputElement;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type ToolbarSearchProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class ToolbarSearch extends SvelteComponentTyped<
   ToolbarSearchProps,

--- a/types/DatePicker/DatePicker.svelte.d.ts
+++ b/types/DatePicker/DatePicker.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
-export interface DatePickerProps extends RestProps {
+type $Props = {
   /**
    * Specify the date picker type
    * @default "simple"
@@ -82,7 +82,9 @@ export interface DatePickerProps extends RestProps {
   flatpickrProps?: import("flatpickr/dist/types/options").Options;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type DatePickerProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class DatePicker extends SvelteComponentTyped<
   DatePickerProps,

--- a/types/DatePicker/DatePickerInput.svelte.d.ts
+++ b/types/DatePicker/DatePickerInput.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["input"];
+type $RestProps = SvelteHTMLElements["input"];
 
-export interface DatePickerInputProps extends RestProps {
+type $Props = {
   /**
    * Set the size of the input
    * @default undefined
@@ -101,7 +101,9 @@ export interface DatePickerInputProps extends RestProps {
   ref?: null | HTMLInputElement;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type DatePickerInputProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class DatePickerInput extends SvelteComponentTyped<
   DatePickerInputProps,

--- a/types/DatePicker/DatePickerSkeleton.svelte.d.ts
+++ b/types/DatePicker/DatePickerSkeleton.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
-export interface DatePickerSkeletonProps extends RestProps {
+type $Props = {
   /**
    * Set to `true` to use the range variant
    * @default false
@@ -17,7 +17,9 @@ export interface DatePickerSkeletonProps extends RestProps {
   id?: string;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type DatePickerSkeletonProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class DatePickerSkeleton extends SvelteComponentTyped<
   DatePickerSkeletonProps,

--- a/types/Dropdown/Dropdown.svelte.d.ts
+++ b/types/Dropdown/Dropdown.svelte.d.ts
@@ -11,9 +11,9 @@ export interface DropdownItem {
   disabled?: boolean;
 }
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
-export interface DropdownProps extends RestProps {
+type $Props = {
   /**
    * Set the dropdown items
    * @default []
@@ -144,7 +144,9 @@ export interface DropdownProps extends RestProps {
   ref?: null | HTMLButtonElement;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type DropdownProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class Dropdown extends SvelteComponentTyped<
   DropdownProps,

--- a/types/Dropdown/DropdownSkeleton.svelte.d.ts
+++ b/types/Dropdown/DropdownSkeleton.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
-export interface DropdownSkeletonProps extends RestProps {
+type $Props = {
   /**
    * Set to `true` to use the inline variant
    * @default false
@@ -11,7 +11,9 @@ export interface DropdownSkeletonProps extends RestProps {
   inline?: boolean;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type DropdownSkeletonProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class DropdownSkeleton extends SvelteComponentTyped<
   DropdownSkeletonProps,

--- a/types/FileUploader/FileUploader.svelte.d.ts
+++ b/types/FileUploader/FileUploader.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
-export interface FileUploaderProps extends RestProps {
+type $Props = {
   /**
    * Specify the file uploader status
    * @default "uploading"
@@ -79,7 +79,9 @@ export interface FileUploaderProps extends RestProps {
   name?: string;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type FileUploaderProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class FileUploader extends SvelteComponentTyped<
   FileUploaderProps,

--- a/types/FileUploader/FileUploaderButton.svelte.d.ts
+++ b/types/FileUploader/FileUploaderButton.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["input"];
+type $RestProps = SvelteHTMLElements["input"];
 
-export interface FileUploaderButtonProps extends RestProps {
+type $Props = {
   /**
    * Specify the accepted file types
    * @default []
@@ -83,7 +83,9 @@ export interface FileUploaderButtonProps extends RestProps {
   ref?: null | HTMLInputElement;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type FileUploaderButtonProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class FileUploaderButton extends SvelteComponentTyped<
   FileUploaderButtonProps,

--- a/types/FileUploader/FileUploaderDropContainer.svelte.d.ts
+++ b/types/FileUploader/FileUploaderDropContainer.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
-export interface FileUploaderDropContainerProps extends RestProps {
+type $Props = {
   /**
    * Specify the accepted file types
    * @default []
@@ -72,7 +72,10 @@ export interface FileUploaderDropContainerProps extends RestProps {
   ref?: null | HTMLInputElement;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type FileUploaderDropContainerProps = Omit<$RestProps, keyof $Props> &
+  $Props;
 
 export default class FileUploaderDropContainer extends SvelteComponentTyped<
   FileUploaderDropContainerProps,

--- a/types/FileUploader/FileUploaderItem.svelte.d.ts
+++ b/types/FileUploader/FileUploaderItem.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["span"];
+type $RestProps = SvelteHTMLElements["span"];
 
-export interface FileUploaderItemProps extends RestProps {
+type $Props = {
   /**
    * Specify the file uploader status
    * @default "uploading"
@@ -53,7 +53,9 @@ export interface FileUploaderItemProps extends RestProps {
   name?: string;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type FileUploaderItemProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class FileUploaderItem extends SvelteComponentTyped<
   FileUploaderItemProps,

--- a/types/FileUploader/FileUploaderSkeleton.svelte.d.ts
+++ b/types/FileUploader/FileUploaderSkeleton.svelte.d.ts
@@ -1,11 +1,13 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
-export interface FileUploaderSkeletonProps extends RestProps {
+type $Props = {
   [key: `data-${string}`]: any;
-}
+};
+
+export type FileUploaderSkeletonProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class FileUploaderSkeleton extends SvelteComponentTyped<
   FileUploaderSkeletonProps,

--- a/types/FileUploader/Filename.svelte.d.ts
+++ b/types/FileUploader/Filename.svelte.d.ts
@@ -1,11 +1,11 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"] &
+type $RestProps = SvelteHTMLElements["div"] &
   SvelteHTMLElements["button"] &
   SvelteHTMLElements["svg"];
 
-export interface FilenameProps extends RestProps {
+type $Props = {
   /**
    * Specify the file name status
    * @default "uploading"
@@ -25,7 +25,9 @@ export interface FilenameProps extends RestProps {
   invalid?: boolean;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type FilenameProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class Filename extends SvelteComponentTyped<
   FilenameProps,

--- a/types/FluidForm/FluidForm.svelte.d.ts
+++ b/types/FluidForm/FluidForm.svelte.d.ts
@@ -1,11 +1,13 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["form"];
+type $RestProps = SvelteHTMLElements["form"];
 
-export interface FluidFormProps extends RestProps {
+type $Props = {
   [key: `data-${string}`]: any;
-}
+};
+
+export type FluidFormProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class FluidForm extends SvelteComponentTyped<
   FluidFormProps,

--- a/types/Form/Form.svelte.d.ts
+++ b/types/Form/Form.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["form"];
+type $RestProps = SvelteHTMLElements["form"];
 
-export interface FormProps extends RestProps {
+type $Props = {
   /**
    * Obtain a reference to the form element
    * @default null
@@ -11,7 +11,9 @@ export interface FormProps extends RestProps {
   ref?: null | HTMLFormElement;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type FormProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class Form extends SvelteComponentTyped<
   FormProps,

--- a/types/FormGroup/FormGroup.svelte.d.ts
+++ b/types/FormGroup/FormGroup.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["fieldset"];
+type $RestProps = SvelteHTMLElements["fieldset"];
 
-export interface FormGroupProps extends RestProps {
+type $Props = {
   /**
    * Set to `true` for to remove the bottom margin
    * @default false
@@ -41,7 +41,9 @@ export interface FormGroupProps extends RestProps {
   legendId?: string;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type FormGroupProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class FormGroup extends SvelteComponentTyped<
   FormGroupProps,

--- a/types/FormItem/FormItem.svelte.d.ts
+++ b/types/FormItem/FormItem.svelte.d.ts
@@ -1,11 +1,13 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
-export interface FormItemProps extends RestProps {
+type $Props = {
   [key: `data-${string}`]: any;
-}
+};
+
+export type FormItemProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class FormItem extends SvelteComponentTyped<
   FormItemProps,

--- a/types/FormLabel/FormLabel.svelte.d.ts
+++ b/types/FormLabel/FormLabel.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["label"];
+type $RestProps = SvelteHTMLElements["label"];
 
-export interface FormLabelProps extends RestProps {
+type $Props = {
   /**
    * Set an id to be used by the label element
    * @default "ccs-" + Math.random().toString(36)
@@ -11,7 +11,9 @@ export interface FormLabelProps extends RestProps {
   id?: string;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type FormLabelProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class FormLabel extends SvelteComponentTyped<
   FormLabelProps,

--- a/types/Grid/Column.svelte.d.ts
+++ b/types/Grid/Column.svelte.d.ts
@@ -10,9 +10,9 @@ export interface ColumnSizeDescriptor {
 
 export type ColumnBreakpoint = ColumnSize | ColumnSizeDescriptor;
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
-export interface ColumnProps extends RestProps {
+type $Props = {
   /**
    * Set to `true` to render a custom HTML element
    * Props are destructured as `props` in the default slot (e.g., <Column let:props><article {...props}>...</article></Column>)
@@ -81,7 +81,9 @@ export interface ColumnProps extends RestProps {
   max?: ColumnBreakpoint;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type ColumnProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class Column extends SvelteComponentTyped<
   ColumnProps,

--- a/types/Grid/Grid.svelte.d.ts
+++ b/types/Grid/Grid.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
-export interface GridProps extends RestProps {
+type $Props = {
   /**
    * Set to `true` to render a custom HTML element
    * Props are destructured as `props` in the default slot (e.g., <Grid let:props><header {...props}>...</header></Grid>)
@@ -54,7 +54,9 @@ export interface GridProps extends RestProps {
   padding?: boolean;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type GridProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class Grid extends SvelteComponentTyped<
   GridProps,

--- a/types/Grid/Row.svelte.d.ts
+++ b/types/Grid/Row.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
-export interface RowProps extends RestProps {
+type $Props = {
   /**
    * Set to `true` to render a custom HTML element
    * Props are destructured as `props` in the default slot (e.g., <Row let:props><section {...props}>...</section></Row>)
@@ -48,7 +48,9 @@ export interface RowProps extends RestProps {
   padding?: boolean;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type RowProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class Row extends SvelteComponentTyped<
   RowProps,

--- a/types/ImageLoader/ImageLoader.svelte.d.ts
+++ b/types/ImageLoader/ImageLoader.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["img"];
+type $RestProps = SvelteHTMLElements["img"];
 
-export interface ImageLoaderProps extends RestProps {
+type $Props = {
   /**
    * Specify the image source
    * @default ""
@@ -48,7 +48,9 @@ export interface ImageLoaderProps extends RestProps {
   fadeIn?: boolean;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type ImageLoaderProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class ImageLoader extends SvelteComponentTyped<
   ImageLoaderProps,

--- a/types/InlineLoading/InlineLoading.svelte.d.ts
+++ b/types/InlineLoading/InlineLoading.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
-export interface InlineLoadingProps extends RestProps {
+type $Props = {
   /**
    * Set the loading status
    * @default "active"
@@ -30,7 +30,9 @@ export interface InlineLoadingProps extends RestProps {
   successDelay?: number;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type InlineLoadingProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class InlineLoading extends SvelteComponentTyped<
   InlineLoadingProps,

--- a/types/Link/Link.svelte.d.ts
+++ b/types/Link/Link.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["a"];
+type $RestProps = SvelteHTMLElements["a"];
 
-export interface LinkProps extends RestProps {
+type $Props = {
   /**
    * Specify the size of the link
    * @default undefined
@@ -48,7 +48,9 @@ export interface LinkProps extends RestProps {
   ref?: null | HTMLAnchorElement;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type LinkProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class Link extends SvelteComponentTyped<
   LinkProps,

--- a/types/Link/OutboundLink.svelte.d.ts
+++ b/types/Link/OutboundLink.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { LinkProps } from "./Link.svelte";
 
-export interface OutboundLinkProps extends LinkProps {}
+export type OutboundLinkProps = LinkProps & {};
 
 export default class OutboundLink extends SvelteComponentTyped<
   OutboundLinkProps,

--- a/types/ListBox/ListBox.svelte.d.ts
+++ b/types/ListBox/ListBox.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
-export interface ListBoxProps extends RestProps {
+type $Props = {
   /**
    * Set the size of the list box
    * @default undefined
@@ -59,7 +59,9 @@ export interface ListBoxProps extends RestProps {
   warnText?: string;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type ListBoxProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class ListBox extends SvelteComponentTyped<
   ListBoxProps,

--- a/types/ListBox/ListBoxField.svelte.d.ts
+++ b/types/ListBox/ListBoxField.svelte.d.ts
@@ -3,9 +3,9 @@ import type { SvelteHTMLElements } from "svelte/elements";
 
 export type ListBoxFieldTranslationId = "close" | "open";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
-export interface ListBoxFieldProps extends RestProps {
+type $Props = {
   /**
    * Set to `true` to disable the list box field
    * @default false
@@ -43,7 +43,9 @@ export interface ListBoxFieldProps extends RestProps {
   ref?: null | HTMLDivElement;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type ListBoxFieldProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class ListBoxField extends SvelteComponentTyped<
   ListBoxFieldProps,

--- a/types/ListBox/ListBoxMenu.svelte.d.ts
+++ b/types/ListBox/ListBoxMenu.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
-export interface ListBoxMenuProps extends RestProps {
+type $Props = {
   /**
    * Set an id for the top-level element
    * @default "ccs-" + Math.random().toString(36)
@@ -17,7 +17,9 @@ export interface ListBoxMenuProps extends RestProps {
   ref?: null | HTMLDivElement;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type ListBoxMenuProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class ListBoxMenu extends SvelteComponentTyped<
   ListBoxMenuProps,

--- a/types/ListBox/ListBoxMenuIcon.svelte.d.ts
+++ b/types/ListBox/ListBoxMenuIcon.svelte.d.ts
@@ -3,9 +3,9 @@ import type { SvelteHTMLElements } from "svelte/elements";
 
 export type ListBoxMenuIconTranslationId = "close" | "open";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
-export interface ListBoxMenuIconProps extends RestProps {
+type $Props = {
   /**
    * Set to `true` to open the list box menu icon
    * @default false
@@ -19,7 +19,9 @@ export interface ListBoxMenuIconProps extends RestProps {
   translateWithId?: (id: ListBoxMenuIconTranslationId) => string;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type ListBoxMenuIconProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class ListBoxMenuIcon extends SvelteComponentTyped<
   ListBoxMenuIconProps,

--- a/types/ListBox/ListBoxMenuItem.svelte.d.ts
+++ b/types/ListBox/ListBoxMenuItem.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
-export interface ListBoxMenuItemProps extends RestProps {
+type $Props = {
   /**
    * Set to `true` to enable the active state
    * @default false
@@ -23,7 +23,9 @@ export interface ListBoxMenuItemProps extends RestProps {
   disabled?: boolean;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type ListBoxMenuItemProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class ListBoxMenuItem extends SvelteComponentTyped<
   ListBoxMenuItemProps,

--- a/types/ListBox/ListBoxSelection.svelte.d.ts
+++ b/types/ListBox/ListBoxSelection.svelte.d.ts
@@ -3,9 +3,9 @@ import type { SvelteHTMLElements } from "svelte/elements";
 
 export type ListBoxSelectionTranslationId = "clearAll" | "clearSelection";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
-export interface ListBoxSelectionProps extends RestProps {
+type $Props = {
   /**
    * Specify the number of selected items
    * @default undefined
@@ -31,7 +31,9 @@ export interface ListBoxSelectionProps extends RestProps {
   ref?: null | HTMLDivElement;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type ListBoxSelectionProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class ListBoxSelection extends SvelteComponentTyped<
   ListBoxSelectionProps,

--- a/types/ListItem/ListItem.svelte.d.ts
+++ b/types/ListItem/ListItem.svelte.d.ts
@@ -1,11 +1,13 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["li"];
+type $RestProps = SvelteHTMLElements["li"];
 
-export interface ListItemProps extends RestProps {
+type $Props = {
   [key: `data-${string}`]: any;
-}
+};
+
+export type ListItemProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class ListItem extends SvelteComponentTyped<
   ListItemProps,

--- a/types/Loading/Loading.svelte.d.ts
+++ b/types/Loading/Loading.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
-export interface LoadingProps extends RestProps {
+type $Props = {
   /**
    * Set to `true` to use the small variant
    * @default false
@@ -29,7 +29,9 @@ export interface LoadingProps extends RestProps {
   description?: string;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type LoadingProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class Loading extends SvelteComponentTyped<
   LoadingProps,

--- a/types/LocalStorage/LocalStorage.svelte.d.ts
+++ b/types/LocalStorage/LocalStorage.svelte.d.ts
@@ -1,6 +1,6 @@
 import type { SvelteComponentTyped } from "svelte";
 
-export interface LocalStorageProps {
+export type LocalStorageProps = {
   /**
    * Specify the local storage key
    * @default "local-storage-key"
@@ -12,7 +12,7 @@ export interface LocalStorageProps {
    * @default ""
    */
   value?: any;
-}
+};
 
 export default class LocalStorage extends SvelteComponentTyped<
   LocalStorageProps,

--- a/types/Modal/Modal.svelte.d.ts
+++ b/types/Modal/Modal.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
-export interface ModalProps extends RestProps {
+type $Props = {
   /**
    * Set the size of the modal
    * @default undefined
@@ -133,7 +133,9 @@ export interface ModalProps extends RestProps {
   ref?: null | HTMLDivElement;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type ModalProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class Modal extends SvelteComponentTyped<
   ModalProps,

--- a/types/MultiSelect/MultiSelect.svelte.d.ts
+++ b/types/MultiSelect/MultiSelect.svelte.d.ts
@@ -11,9 +11,9 @@ export interface MultiSelectItem {
   disabled?: boolean;
 }
 
-type RestProps = SvelteHTMLElements["input"];
+type $RestProps = SvelteHTMLElements["input"];
 
-export interface MultiSelectProps extends RestProps {
+type $Props = {
   /**
    * Set the multiselect items
    * @default []
@@ -240,7 +240,9 @@ export interface MultiSelectProps extends RestProps {
   highlightedId?: null | MultiSelectItemId;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type MultiSelectProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class MultiSelect extends SvelteComponentTyped<
   MultiSelectProps,

--- a/types/Notification/InlineNotification.svelte.d.ts
+++ b/types/Notification/InlineNotification.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
-export interface InlineNotificationProps extends RestProps {
+type $Props = {
   /**
    * Specify the kind of notification
    * @default "error"
@@ -65,7 +65,9 @@ export interface InlineNotificationProps extends RestProps {
   closeButtonDescription?: string;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type InlineNotificationProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class InlineNotification extends SvelteComponentTyped<
   InlineNotificationProps,

--- a/types/Notification/NotificationActionButton.svelte.d.ts
+++ b/types/Notification/NotificationActionButton.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { ButtonProps } from "../Button/Button.svelte";
 
-export interface NotificationActionButtonProps extends ButtonProps {}
+export type NotificationActionButtonProps = ButtonProps & {};
 
 export default class NotificationActionButton extends SvelteComponentTyped<
   NotificationActionButtonProps,

--- a/types/Notification/NotificationButton.svelte.d.ts
+++ b/types/Notification/NotificationButton.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["button"];
+type $RestProps = SvelteHTMLElements["button"];
 
-export interface NotificationButtonProps extends RestProps {
+type $Props = {
   /**
    * Set the type of notification
    * @default "toast"
@@ -29,7 +29,9 @@ export interface NotificationButtonProps extends RestProps {
   iconDescription?: string;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type NotificationButtonProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class NotificationButton extends SvelteComponentTyped<
   NotificationButtonProps,

--- a/types/Notification/NotificationIcon.svelte.d.ts
+++ b/types/Notification/NotificationIcon.svelte.d.ts
@@ -1,6 +1,6 @@
 import type { SvelteComponentTyped } from "svelte";
 
-export interface NotificationIconProps {
+export type NotificationIconProps = {
   /**
    * Specify the kind of notification icon
    * @default "error"
@@ -24,7 +24,7 @@ export interface NotificationIconProps {
    * @default undefined
    */
   iconDescription: undefined;
-}
+};
 
 export default class NotificationIcon extends SvelteComponentTyped<
   NotificationIconProps,

--- a/types/Notification/ToastNotification.svelte.d.ts
+++ b/types/Notification/ToastNotification.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
-export interface ToastNotificationProps extends RestProps {
+type $Props = {
   /**
    * Specify the kind of notification
    * @default "error"
@@ -78,7 +78,9 @@ export interface ToastNotificationProps extends RestProps {
   fullWidth?: boolean;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type ToastNotificationProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class ToastNotification extends SvelteComponentTyped<
   ToastNotificationProps,

--- a/types/NumberInput/NumberInput.svelte.d.ts
+++ b/types/NumberInput/NumberInput.svelte.d.ts
@@ -3,9 +3,9 @@ import type { SvelteHTMLElements } from "svelte/elements";
 
 export type NumberInputTranslationId = "increment" | "decrement";
 
-type RestProps = SvelteHTMLElements["input"];
+type $RestProps = SvelteHTMLElements["input"];
 
-export interface NumberInputProps extends RestProps {
+type $Props = {
   /**
    * Set the size of the input
    * @default undefined
@@ -140,7 +140,9 @@ export interface NumberInputProps extends RestProps {
   ref?: null | HTMLInputElement;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type NumberInputProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class NumberInput extends SvelteComponentTyped<
   NumberInputProps,

--- a/types/NumberInput/NumberInputSkeleton.svelte.d.ts
+++ b/types/NumberInput/NumberInputSkeleton.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
-export interface NumberInputSkeletonProps extends RestProps {
+type $Props = {
   /**
    * Set to `true` to hide the label text
    * @default false
@@ -11,7 +11,9 @@ export interface NumberInputSkeletonProps extends RestProps {
   hideLabel?: boolean;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type NumberInputSkeletonProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class NumberInputSkeleton extends SvelteComponentTyped<
   NumberInputSkeletonProps,

--- a/types/OrderedList/OrderedList.svelte.d.ts
+++ b/types/OrderedList/OrderedList.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["ol"];
+type $RestProps = SvelteHTMLElements["ol"];
 
-export interface OrderedListProps extends RestProps {
+type $Props = {
   /**
    * Set to `true` to use the nested variant
    * @default false
@@ -23,7 +23,9 @@ export interface OrderedListProps extends RestProps {
   expressive?: boolean;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type OrderedListProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class OrderedList extends SvelteComponentTyped<
   OrderedListProps,

--- a/types/OverflowMenu/OverflowMenu.svelte.d.ts
+++ b/types/OverflowMenu/OverflowMenu.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["button"];
+type $RestProps = SvelteHTMLElements["button"];
 
-export interface OverflowMenuProps extends RestProps {
+type $Props = {
   /**
    * Specify the size of the overflow menu
    * @default undefined
@@ -78,7 +78,9 @@ export interface OverflowMenuProps extends RestProps {
   menuRef?: null | HTMLUListElement;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type OverflowMenuProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class OverflowMenu extends SvelteComponentTyped<
   OverflowMenuProps,

--- a/types/OverflowMenu/OverflowMenuItem.svelte.d.ts
+++ b/types/OverflowMenu/OverflowMenuItem.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["li"];
+type $RestProps = SvelteHTMLElements["li"];
 
-export interface OverflowMenuItemProps extends RestProps {
+type $Props = {
   /**
    * Specify the item text.
    * Alternatively, use the default slot
@@ -60,7 +60,9 @@ export interface OverflowMenuItemProps extends RestProps {
   ref?: null | HTMLAnchorElement | HTMLButtonElement;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type OverflowMenuItemProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class OverflowMenuItem extends SvelteComponentTyped<
   OverflowMenuItemProps,

--- a/types/Pagination/Pagination.svelte.d.ts
+++ b/types/Pagination/Pagination.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
-export interface PaginationProps extends RestProps {
+type $Props = {
   /**
    * Specify the current page index
    * @default 1
@@ -101,7 +101,9 @@ export interface PaginationProps extends RestProps {
   id?: string;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type PaginationProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class Pagination extends SvelteComponentTyped<
   PaginationProps,

--- a/types/Pagination/PaginationSkeleton.svelte.d.ts
+++ b/types/Pagination/PaginationSkeleton.svelte.d.ts
@@ -1,11 +1,13 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
-export interface PaginationSkeletonProps extends RestProps {
+type $Props = {
   [key: `data-${string}`]: any;
-}
+};
+
+export type PaginationSkeletonProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class PaginationSkeleton extends SvelteComponentTyped<
   PaginationSkeletonProps,

--- a/types/PaginationNav/PaginationNav.svelte.d.ts
+++ b/types/PaginationNav/PaginationNav.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["nav"];
+type $RestProps = SvelteHTMLElements["nav"];
 
-export interface PaginationNavProps extends RestProps {
+type $Props = {
   /**
    * Specify the current page index
    * @default 1
@@ -47,7 +47,9 @@ export interface PaginationNavProps extends RestProps {
   tooltipPosition?: "top" | "right" | "bottom" | "left" | "outside" | "inside";
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type PaginationNavProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class PaginationNav extends SvelteComponentTyped<
   PaginationNavProps,

--- a/types/Popover/Popover.svelte.d.ts
+++ b/types/Popover/Popover.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
-export interface PopoverProps extends RestProps {
+type $Props = {
   /**
    * Set to `true` to display the popover
    * @default false
@@ -59,7 +59,9 @@ export interface PopoverProps extends RestProps {
   relative?: boolean;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type PopoverProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class Popover extends SvelteComponentTyped<
   PopoverProps,

--- a/types/ProgressBar/ProgressBar.svelte.d.ts
+++ b/types/ProgressBar/ProgressBar.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
-export interface ProgressBarProps extends RestProps {
+type $Props = {
   /**
    * Specify the current value
    * @default undefined
@@ -59,7 +59,9 @@ export interface ProgressBarProps extends RestProps {
   id?: string;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type ProgressBarProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class ProgressBar extends SvelteComponentTyped<
   ProgressBarProps,

--- a/types/ProgressIndicator/ProgressIndicator.svelte.d.ts
+++ b/types/ProgressIndicator/ProgressIndicator.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["ul"];
+type $RestProps = SvelteHTMLElements["ul"];
 
-export interface ProgressIndicatorProps extends RestProps {
+type $Props = {
   /**
    * Specify the current step index
    * @default 0
@@ -29,7 +29,9 @@ export interface ProgressIndicatorProps extends RestProps {
   preventChangeOnClick?: boolean;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type ProgressIndicatorProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class ProgressIndicator extends SvelteComponentTyped<
   ProgressIndicatorProps,

--- a/types/ProgressIndicator/ProgressIndicatorSkeleton.svelte.d.ts
+++ b/types/ProgressIndicator/ProgressIndicatorSkeleton.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["ul"];
+type $RestProps = SvelteHTMLElements["ul"];
 
-export interface ProgressIndicatorSkeletonProps extends RestProps {
+type $Props = {
   /**
    * Set to `true` to use the vertical variant
    * @default false
@@ -17,7 +17,10 @@ export interface ProgressIndicatorSkeletonProps extends RestProps {
   count?: number;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type ProgressIndicatorSkeletonProps = Omit<$RestProps, keyof $Props> &
+  $Props;
 
 export default class ProgressIndicatorSkeleton extends SvelteComponentTyped<
   ProgressIndicatorSkeletonProps,

--- a/types/ProgressIndicator/ProgressStep.svelte.d.ts
+++ b/types/ProgressIndicator/ProgressStep.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["li"];
+type $RestProps = SvelteHTMLElements["li"];
 
-export interface ProgressStepProps extends RestProps {
+type $Props = {
   /**
    * Set to `true` for the complete variant
    * @default false
@@ -53,7 +53,9 @@ export interface ProgressStepProps extends RestProps {
   id?: string;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type ProgressStepProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class ProgressStep extends SvelteComponentTyped<
   ProgressStepProps,

--- a/types/RadioButton/RadioButton.svelte.d.ts
+++ b/types/RadioButton/RadioButton.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
-export interface RadioButtonProps extends RestProps {
+type $Props = {
   /**
    * Specify the value of the radio button
    * @default ""
@@ -65,7 +65,9 @@ export interface RadioButtonProps extends RestProps {
   ref?: null | HTMLInputElement;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type RadioButtonProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class RadioButton extends SvelteComponentTyped<
   RadioButtonProps,

--- a/types/RadioButton/RadioButtonSkeleton.svelte.d.ts
+++ b/types/RadioButton/RadioButtonSkeleton.svelte.d.ts
@@ -1,11 +1,13 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
-export interface RadioButtonSkeletonProps extends RestProps {
+type $Props = {
   [key: `data-${string}`]: any;
-}
+};
+
+export type RadioButtonSkeletonProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class RadioButtonSkeleton extends SvelteComponentTyped<
   RadioButtonSkeletonProps,

--- a/types/RadioButtonGroup/RadioButtonGroup.svelte.d.ts
+++ b/types/RadioButtonGroup/RadioButtonGroup.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
-export interface RadioButtonGroupProps extends RestProps {
+type $Props = {
   /**
    * Set the selected radio button value
    * @default undefined
@@ -59,7 +59,9 @@ export interface RadioButtonGroupProps extends RestProps {
   id?: string;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type RadioButtonGroupProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class RadioButtonGroup extends SvelteComponentTyped<
   RadioButtonGroupProps,

--- a/types/RecursiveList/RecursiveList.svelte.d.ts
+++ b/types/RecursiveList/RecursiveList.svelte.d.ts
@@ -7,9 +7,9 @@ export interface RecursiveListNode {
   html?: string;
 }
 
-type RestProps = SvelteHTMLElements["ul"] & SvelteHTMLElements["ol"];
+type $RestProps = SvelteHTMLElements["ul"] & SvelteHTMLElements["ol"];
 
-export interface RecursiveListProps extends RestProps {
+type $Props = {
   /**
    * Specify the children to render
    * @default []
@@ -23,7 +23,9 @@ export interface RecursiveListProps extends RestProps {
   type?: "unordered" | "ordered" | "ordered-native";
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type RecursiveListProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class RecursiveList extends SvelteComponentTyped<
   RecursiveListProps,

--- a/types/Search/Search.svelte.d.ts
+++ b/types/Search/Search.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["input"];
+type $RestProps = SvelteHTMLElements["input"];
 
-export interface SearchProps extends RestProps {
+type $Props = {
   /**
    * Specify the value of the search input
    * @default ""
@@ -102,7 +102,9 @@ export interface SearchProps extends RestProps {
   ref?: null | HTMLInputElement;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type SearchProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class Search extends SvelteComponentTyped<
   SearchProps,

--- a/types/Search/SearchSkeleton.svelte.d.ts
+++ b/types/Search/SearchSkeleton.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
-export interface SearchSkeletonProps extends RestProps {
+type $Props = {
   /**
    * Specify the size of the search input
    * @default "xl"
@@ -11,7 +11,9 @@ export interface SearchSkeletonProps extends RestProps {
   size?: "sm" | "lg" | "xl";
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type SearchSkeletonProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class SearchSkeleton extends SvelteComponentTyped<
   SearchSkeletonProps,

--- a/types/Select/Select.svelte.d.ts
+++ b/types/Select/Select.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
-export interface SelectProps extends RestProps {
+type $Props = {
   /**
    * Specify the selected item value
    * @default undefined
@@ -107,7 +107,9 @@ export interface SelectProps extends RestProps {
   required?: boolean;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type SelectProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class Select extends SvelteComponentTyped<
   SelectProps,

--- a/types/Select/SelectItem.svelte.d.ts
+++ b/types/Select/SelectItem.svelte.d.ts
@@ -1,6 +1,6 @@
 import type { SvelteComponentTyped } from "svelte";
 
-export interface SelectItemProps {
+export type SelectItemProps = {
   /**
    * Specify the option value
    * @default ""
@@ -36,7 +36,7 @@ export interface SelectItemProps {
    * @default undefined
    */
   style?: string;
-}
+};
 
 export default class SelectItem extends SvelteComponentTyped<
   SelectItemProps,

--- a/types/Select/SelectItemGroup.svelte.d.ts
+++ b/types/Select/SelectItemGroup.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["optgroup"];
+type $RestProps = SvelteHTMLElements["optgroup"];
 
-export interface SelectItemGroupProps extends RestProps {
+type $Props = {
   /**
    * Set to `true` to disable the optgroup element
    * @default false
@@ -17,7 +17,9 @@ export interface SelectItemGroupProps extends RestProps {
   label?: string;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type SelectItemGroupProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class SelectItemGroup extends SvelteComponentTyped<
   SelectItemGroupProps,

--- a/types/Select/SelectSkeleton.svelte.d.ts
+++ b/types/Select/SelectSkeleton.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
-export interface SelectSkeletonProps extends RestProps {
+type $Props = {
   /**
    * Set to `true` to hide the label text
    * @default false
@@ -11,7 +11,9 @@ export interface SelectSkeletonProps extends RestProps {
   hideLabel?: boolean;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type SelectSkeletonProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class SelectSkeleton extends SvelteComponentTyped<
   SelectSkeletonProps,

--- a/types/SkeletonPlaceholder/SkeletonPlaceholder.svelte.d.ts
+++ b/types/SkeletonPlaceholder/SkeletonPlaceholder.svelte.d.ts
@@ -1,11 +1,13 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
-export interface SkeletonPlaceholderProps extends RestProps {
+type $Props = {
   [key: `data-${string}`]: any;
-}
+};
+
+export type SkeletonPlaceholderProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class SkeletonPlaceholder extends SvelteComponentTyped<
   SkeletonPlaceholderProps,

--- a/types/SkeletonText/SkeletonText.svelte.d.ts
+++ b/types/SkeletonText/SkeletonText.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
-export interface SkeletonTextProps extends RestProps {
+type $Props = {
   /**
    * Specify the number of lines to render
    * @default 3
@@ -29,7 +29,9 @@ export interface SkeletonTextProps extends RestProps {
   width?: string;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type SkeletonTextProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class SkeletonText extends SvelteComponentTyped<
   SkeletonTextProps,

--- a/types/Slider/Slider.svelte.d.ts
+++ b/types/Slider/Slider.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
-export interface SliderProps extends RestProps {
+type $Props = {
   /**
    * Specify the value of the slider
    * @default 0
@@ -121,7 +121,9 @@ export interface SliderProps extends RestProps {
   ref?: null | HTMLDivElement;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type SliderProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class Slider extends SvelteComponentTyped<
   SliderProps,

--- a/types/Slider/SliderSkeleton.svelte.d.ts
+++ b/types/Slider/SliderSkeleton.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
-export interface SliderSkeletonProps extends RestProps {
+type $Props = {
   /**
    * Set to `true` to hide the label text
    * @default false
@@ -11,7 +11,9 @@ export interface SliderSkeletonProps extends RestProps {
   hideLabel?: boolean;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type SliderSkeletonProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class SliderSkeleton extends SvelteComponentTyped<
   SliderSkeletonProps,

--- a/types/StructuredList/StructuredList.svelte.d.ts
+++ b/types/StructuredList/StructuredList.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
-export interface StructuredListProps extends RestProps {
+type $Props = {
   /**
    * Specify the selected structured list row value
    * @default undefined
@@ -29,7 +29,9 @@ export interface StructuredListProps extends RestProps {
   selection?: boolean;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type StructuredListProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class StructuredList extends SvelteComponentTyped<
   StructuredListProps,

--- a/types/StructuredList/StructuredListBody.svelte.d.ts
+++ b/types/StructuredList/StructuredListBody.svelte.d.ts
@@ -1,11 +1,13 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
-export interface StructuredListBodyProps extends RestProps {
+type $Props = {
   [key: `data-${string}`]: any;
-}
+};
+
+export type StructuredListBodyProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class StructuredListBody extends SvelteComponentTyped<
   StructuredListBodyProps,

--- a/types/StructuredList/StructuredListCell.svelte.d.ts
+++ b/types/StructuredList/StructuredListCell.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
-export interface StructuredListCellProps extends RestProps {
+type $Props = {
   /**
    * Set to `true` to use as a header
    * @default false
@@ -17,7 +17,9 @@ export interface StructuredListCellProps extends RestProps {
   noWrap?: boolean;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type StructuredListCellProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class StructuredListCell extends SvelteComponentTyped<
   StructuredListCellProps,

--- a/types/StructuredList/StructuredListHead.svelte.d.ts
+++ b/types/StructuredList/StructuredListHead.svelte.d.ts
@@ -1,11 +1,13 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
-export interface StructuredListHeadProps extends RestProps {
+type $Props = {
   [key: `data-${string}`]: any;
-}
+};
+
+export type StructuredListHeadProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class StructuredListHead extends SvelteComponentTyped<
   StructuredListHeadProps,

--- a/types/StructuredList/StructuredListInput.svelte.d.ts
+++ b/types/StructuredList/StructuredListInput.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["input"];
+type $RestProps = SvelteHTMLElements["input"];
 
-export interface StructuredListInputProps extends RestProps {
+type $Props = {
   /**
    * Set to `true` to check the input
    * @default false
@@ -41,7 +41,9 @@ export interface StructuredListInputProps extends RestProps {
   ref?: null | HTMLInputElement;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type StructuredListInputProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class StructuredListInput extends SvelteComponentTyped<
   StructuredListInputProps,

--- a/types/StructuredList/StructuredListRow.svelte.d.ts
+++ b/types/StructuredList/StructuredListRow.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["label"];
+type $RestProps = SvelteHTMLElements["label"];
 
-export interface StructuredListRowProps extends RestProps {
+type $Props = {
   /**
    * Set to `true` to use as a header
    * @default false
@@ -23,7 +23,9 @@ export interface StructuredListRowProps extends RestProps {
   tabindex?: string;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type StructuredListRowProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class StructuredListRow extends SvelteComponentTyped<
   StructuredListRowProps,

--- a/types/StructuredList/StructuredListSkeleton.svelte.d.ts
+++ b/types/StructuredList/StructuredListSkeleton.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
-export interface StructuredListSkeletonProps extends RestProps {
+type $Props = {
   /**
    * Specify the number of rows
    * @default 5
@@ -11,7 +11,10 @@ export interface StructuredListSkeletonProps extends RestProps {
   rows?: number;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type StructuredListSkeletonProps = Omit<$RestProps, keyof $Props> &
+  $Props;
 
 export default class StructuredListSkeleton extends SvelteComponentTyped<
   StructuredListSkeletonProps,

--- a/types/Tabs/Tab.svelte.d.ts
+++ b/types/Tabs/Tab.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["li"];
+type $RestProps = SvelteHTMLElements["li"];
 
-export interface TabProps extends RestProps {
+type $Props = {
   /**
    * Specify the tab label.
    * Alternatively, use the default slot (e.g., `<Tab><span>Label</span></Tab>`)
@@ -42,7 +42,9 @@ export interface TabProps extends RestProps {
   ref?: null | HTMLAnchorElement;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type TabProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class Tab extends SvelteComponentTyped<
   TabProps,

--- a/types/Tabs/TabContent.svelte.d.ts
+++ b/types/Tabs/TabContent.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
-export interface TabContentProps extends RestProps {
+type $Props = {
   /**
    * Set an id for the top-level element
    * @default "ccs-" + Math.random().toString(36)
@@ -11,7 +11,9 @@ export interface TabContentProps extends RestProps {
   id?: string;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type TabContentProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class TabContent extends SvelteComponentTyped<
   TabContentProps,

--- a/types/Tabs/Tabs.svelte.d.ts
+++ b/types/Tabs/Tabs.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
-export interface TabsProps extends RestProps {
+type $Props = {
   /**
    * Specify the selected tab index
    * @default 0
@@ -35,7 +35,9 @@ export interface TabsProps extends RestProps {
   triggerHref?: string;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type TabsProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class Tabs extends SvelteComponentTyped<
   TabsProps,

--- a/types/Tabs/TabsSkeleton.svelte.d.ts
+++ b/types/Tabs/TabsSkeleton.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
-export interface TabsSkeletonProps extends RestProps {
+type $Props = {
   /**
    * Specify the number of tabs to render
    * @default 4
@@ -17,7 +17,9 @@ export interface TabsSkeletonProps extends RestProps {
   type?: "default" | "container";
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type TabsSkeletonProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class TabsSkeleton extends SvelteComponentTyped<
   TabsSkeletonProps,

--- a/types/Tag/Tag.svelte.d.ts
+++ b/types/Tag/Tag.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"] & SvelteHTMLElements["span"];
+type $RestProps = SvelteHTMLElements["div"] & SvelteHTMLElements["span"];
 
-export interface TagProps extends RestProps {
+type $Props = {
   /**
    * Specify the type of tag
    * @default undefined
@@ -70,7 +70,9 @@ export interface TagProps extends RestProps {
   id?: string;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type TagProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class Tag extends SvelteComponentTyped<
   TagProps,

--- a/types/Tag/TagSkeleton.svelte.d.ts
+++ b/types/Tag/TagSkeleton.svelte.d.ts
@@ -1,16 +1,18 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["span"];
+type $RestProps = SvelteHTMLElements["span"];
 
-export interface TagSkeletonProps extends RestProps {
+type $Props = {
   /**
    * @default "default"
    */
   size?: "sm" | "default";
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type TagSkeletonProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class TagSkeleton extends SvelteComponentTyped<
   TagSkeletonProps,

--- a/types/TextArea/TextArea.svelte.d.ts
+++ b/types/TextArea/TextArea.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["textarea"];
+type $RestProps = SvelteHTMLElements["textarea"];
 
-export interface TextAreaProps extends RestProps {
+type $Props = {
   /**
    * Specify the textarea value.
    * @default ""
@@ -101,7 +101,9 @@ export interface TextAreaProps extends RestProps {
   ref?: null | HTMLTextAreaElement;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type TextAreaProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class TextArea extends SvelteComponentTyped<
   TextAreaProps,

--- a/types/TextArea/TextAreaSkeleton.svelte.d.ts
+++ b/types/TextArea/TextAreaSkeleton.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
-export interface TextAreaSkeletonProps extends RestProps {
+type $Props = {
   /**
    * Set to `true` to visually hide the label text
    * @default false
@@ -11,7 +11,9 @@ export interface TextAreaSkeletonProps extends RestProps {
   hideLabel?: boolean;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type TextAreaSkeletonProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class TextAreaSkeleton extends SvelteComponentTyped<
   TextAreaSkeletonProps,

--- a/types/TextInput/PasswordInput.svelte.d.ts
+++ b/types/TextInput/PasswordInput.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["input"];
+type $RestProps = SvelteHTMLElements["input"];
 
-export interface PasswordInputProps extends RestProps {
+type $Props = {
   /**
    * Set the size of the input
    * @default undefined
@@ -131,7 +131,9 @@ export interface PasswordInputProps extends RestProps {
   ref?: null | HTMLInputElement;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type PasswordInputProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class PasswordInput extends SvelteComponentTyped<
   PasswordInputProps,

--- a/types/TextInput/TextInput.svelte.d.ts
+++ b/types/TextInput/TextInput.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["input"];
+type $RestProps = SvelteHTMLElements["input"];
 
-export interface TextInputProps extends RestProps {
+type $Props = {
   /**
    * Set the size of the input
    * @default undefined
@@ -116,7 +116,9 @@ export interface TextInputProps extends RestProps {
   readonly?: boolean;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type TextInputProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class TextInput extends SvelteComponentTyped<
   TextInputProps,

--- a/types/TextInput/TextInputSkeleton.svelte.d.ts
+++ b/types/TextInput/TextInputSkeleton.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
-export interface TextInputSkeletonProps extends RestProps {
+type $Props = {
   /**
    * Set to `true` to hide the label text
    * @default false
@@ -11,7 +11,9 @@ export interface TextInputSkeletonProps extends RestProps {
   hideLabel?: boolean;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type TextInputSkeletonProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class TextInputSkeleton extends SvelteComponentTyped<
   TextInputSkeletonProps,

--- a/types/Theme/Theme.svelte.d.ts
+++ b/types/Theme/Theme.svelte.d.ts
@@ -2,7 +2,7 @@ import type { SvelteComponentTyped } from "svelte";
 
 export type CarbonTheme = "white" | "g10" | "g80" | "g90" | "g100";
 
-export interface ThemeProps {
+export type ThemeProps = {
   /**
    * Set the current Carbon theme
    * @default "white"
@@ -49,7 +49,7 @@ export interface ThemeProps {
   select?: import("../Select/Select.svelte").SelectProps & {
     themes?: CarbonTheme[];
   };
-}
+};
 
 export default class Theme extends SvelteComponentTyped<
   ThemeProps,

--- a/types/Tile/ClickableTile.svelte.d.ts
+++ b/types/Tile/ClickableTile.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["a"] & SvelteHTMLElements["p"];
+type $RestProps = SvelteHTMLElements["a"] & SvelteHTMLElements["p"];
 
-export interface ClickableTileProps extends RestProps {
+type $Props = {
   /**
    * Set to `true` to click the tile
    * @default false
@@ -29,7 +29,9 @@ export interface ClickableTileProps extends RestProps {
   href?: string;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type ClickableTileProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class ClickableTile extends SvelteComponentTyped<
   ClickableTileProps,

--- a/types/Tile/ExpandableTile.svelte.d.ts
+++ b/types/Tile/ExpandableTile.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["button"];
+type $RestProps = SvelteHTMLElements["button"];
 
-export interface ExpandableTileProps extends RestProps {
+type $Props = {
   /**
    * Set to `true` to expand the tile
    * @default false
@@ -71,7 +71,9 @@ export interface ExpandableTileProps extends RestProps {
   ref?: null | HTMLButtonElement;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type ExpandableTileProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class ExpandableTile extends SvelteComponentTyped<
   ExpandableTileProps,

--- a/types/Tile/RadioTile.svelte.d.ts
+++ b/types/Tile/RadioTile.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["label"];
+type $RestProps = SvelteHTMLElements["label"];
 
-export interface RadioTileProps extends RestProps {
+type $Props = {
   /**
    * Set to `true` to check the tile
    * @default false
@@ -59,7 +59,9 @@ export interface RadioTileProps extends RestProps {
   name?: string;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type RadioTileProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class RadioTile extends SvelteComponentTyped<
   RadioTileProps,

--- a/types/Tile/SelectableTile.svelte.d.ts
+++ b/types/Tile/SelectableTile.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["label"];
+type $RestProps = SvelteHTMLElements["label"];
 
-export interface SelectableTileProps extends RestProps {
+type $Props = {
   /**
    * Set to `true` to select the tile
    * @default false
@@ -65,7 +65,9 @@ export interface SelectableTileProps extends RestProps {
   ref?: null | HTMLInputElement;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type SelectableTileProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class SelectableTile extends SvelteComponentTyped<
   SelectableTileProps,

--- a/types/Tile/Tile.svelte.d.ts
+++ b/types/Tile/Tile.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
-export interface TileProps extends RestProps {
+type $Props = {
   /**
    * Set to `true` to enable the light variant
    * @default false
@@ -11,7 +11,9 @@ export interface TileProps extends RestProps {
   light?: boolean;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type TileProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class Tile extends SvelteComponentTyped<
   TileProps,

--- a/types/Tile/TileGroup.svelte.d.ts
+++ b/types/Tile/TileGroup.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["fieldset"];
+type $RestProps = SvelteHTMLElements["fieldset"];
 
-export interface TileGroupProps extends RestProps {
+type $Props = {
   /**
    * Specify the selected tile value
    * @default undefined
@@ -35,7 +35,9 @@ export interface TileGroupProps extends RestProps {
   legend?: string;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type TileGroupProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class TileGroup extends SvelteComponentTyped<
   TileGroupProps,

--- a/types/TimePicker/TimePicker.svelte.d.ts
+++ b/types/TimePicker/TimePicker.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["input"];
+type $RestProps = SvelteHTMLElements["input"];
 
-export interface TimePickerProps extends RestProps {
+type $Props = {
   /**
    * Specify the size of the input
    * @default undefined
@@ -89,7 +89,9 @@ export interface TimePickerProps extends RestProps {
   ref?: null | HTMLInputElement;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type TimePickerProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class TimePicker extends SvelteComponentTyped<
   TimePickerProps,

--- a/types/TimePicker/TimePickerSelect.svelte.d.ts
+++ b/types/TimePicker/TimePickerSelect.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
-export interface TimePickerSelectProps extends RestProps {
+type $Props = {
   /**
    * Specify the select value
    * @default ""
@@ -47,7 +47,9 @@ export interface TimePickerSelectProps extends RestProps {
   ref?: null | HTMLSelectElement;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type TimePickerSelectProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class TimePickerSelect extends SvelteComponentTyped<
   TimePickerSelectProps,

--- a/types/Toggle/Toggle.svelte.d.ts
+++ b/types/Toggle/Toggle.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
-export interface ToggleProps extends RestProps {
+type $Props = {
   /**
    * Specify the toggle size
    * @default "default"
@@ -59,7 +59,9 @@ export interface ToggleProps extends RestProps {
   name?: string;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type ToggleProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class Toggle extends SvelteComponentTyped<
   ToggleProps,

--- a/types/Toggle/ToggleSkeleton.svelte.d.ts
+++ b/types/Toggle/ToggleSkeleton.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
-export interface ToggleSkeletonProps extends RestProps {
+type $Props = {
   /**
    * Specify the toggle size
    * @default "default"
@@ -23,7 +23,9 @@ export interface ToggleSkeletonProps extends RestProps {
   id?: string;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type ToggleSkeletonProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class ToggleSkeleton extends SvelteComponentTyped<
   ToggleSkeletonProps,

--- a/types/Tooltip/Tooltip.svelte.d.ts
+++ b/types/Tooltip/Tooltip.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["div"];
+type $RestProps = SvelteHTMLElements["div"];
 
-export interface TooltipProps extends RestProps {
+type $Props = {
   /**
    * Set the alignment of the tooltip relative to the icon
    * @default "center"
@@ -90,7 +90,9 @@ export interface TooltipProps extends RestProps {
   refIcon?: null | HTMLDivElement;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type TooltipProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class Tooltip extends SvelteComponentTyped<
   TooltipProps,

--- a/types/Tooltip/TooltipFooter.svelte.d.ts
+++ b/types/Tooltip/TooltipFooter.svelte.d.ts
@@ -1,12 +1,12 @@
 import type { SvelteComponentTyped } from "svelte";
 
-export interface TooltipFooterProps {
+export type TooltipFooterProps = {
   /**
    * Specify a selector to be focused inside the footer when opening the tooltip
    * @default "a[href], button:not([disabled])"
    */
   selectorPrimaryFocus?: string;
-}
+};
 
 export default class TooltipFooter extends SvelteComponentTyped<
   TooltipFooterProps,

--- a/types/TooltipDefinition/TooltipDefinition.svelte.d.ts
+++ b/types/TooltipDefinition/TooltipDefinition.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["span"];
+type $RestProps = SvelteHTMLElements["span"];
 
-export interface TooltipDefinitionProps extends RestProps {
+type $Props = {
   /**
    * Specify the tooltip text
    * @default ""
@@ -41,7 +41,9 @@ export interface TooltipDefinitionProps extends RestProps {
   ref?: null | HTMLButtonElement;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type TooltipDefinitionProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class TooltipDefinition extends SvelteComponentTyped<
   TooltipDefinitionProps,

--- a/types/TooltipIcon/TooltipIcon.svelte.d.ts
+++ b/types/TooltipIcon/TooltipIcon.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["button"];
+type $RestProps = SvelteHTMLElements["button"];
 
-export interface TooltipIconProps extends RestProps {
+type $Props = {
   /**
    * Specify the tooltip text.
    * Alternatively, use the "tooltipText" slot
@@ -48,7 +48,9 @@ export interface TooltipIconProps extends RestProps {
   ref?: null | HTMLButtonElement;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type TooltipIconProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class TooltipIcon extends SvelteComponentTyped<
   TooltipIconProps,

--- a/types/TreeView/TreeView.svelte.d.ts
+++ b/types/TreeView/TreeView.svelte.d.ts
@@ -11,9 +11,9 @@ export interface TreeNode {
   children?: TreeNode[];
 }
 
-type RestProps = SvelteHTMLElements["ul"];
+type $RestProps = SvelteHTMLElements["ul"];
 
-export interface TreeViewProps extends RestProps {
+type $Props = {
   /**
    * Provide an array of children nodes to render
    * @default []
@@ -58,7 +58,9 @@ export interface TreeViewProps extends RestProps {
   hideLabel?: boolean;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type TreeViewProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class TreeView extends SvelteComponentTyped<
   TreeViewProps,

--- a/types/Truncate/Truncate.svelte.d.ts
+++ b/types/Truncate/Truncate.svelte.d.ts
@@ -1,16 +1,18 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["p"];
+type $RestProps = SvelteHTMLElements["p"];
 
-export interface TruncateProps extends RestProps {
+type $Props = {
   /**
    * @default "end"
    */
   clamp?: "end" | "front";
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type TruncateProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class Truncate extends SvelteComponentTyped<
   TruncateProps,

--- a/types/UIShell/Content.svelte.d.ts
+++ b/types/UIShell/Content.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["main"];
+type $RestProps = SvelteHTMLElements["main"];
 
-export interface ContentProps extends RestProps {
+type $Props = {
   /**
    * Specify the id for the main element
    * @default "main-content"
@@ -11,7 +11,9 @@ export interface ContentProps extends RestProps {
   id?: string;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type ContentProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class Content extends SvelteComponentTyped<
   ContentProps,

--- a/types/UIShell/Header.svelte.d.ts
+++ b/types/UIShell/Header.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["a"];
+type $RestProps = SvelteHTMLElements["a"];
 
-export interface HeaderProps extends RestProps {
+type $Props = {
   /**
    * Set to `false` to hide the side nav by default
    * @default true
@@ -82,7 +82,9 @@ export interface HeaderProps extends RestProps {
   iconClose?: typeof import("svelte").SvelteComponent<any>;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type HeaderProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class Header extends SvelteComponentTyped<
   HeaderProps,

--- a/types/UIShell/HeaderAction.svelte.d.ts
+++ b/types/UIShell/HeaderAction.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["button"];
+type $RestProps = SvelteHTMLElements["button"];
 
-export interface HeaderActionProps extends RestProps {
+type $Props = {
   /**
    * Set to `true` to open the panel
    * @default false
@@ -51,7 +51,9 @@ export interface HeaderActionProps extends RestProps {
   preventCloseOnClickOutside?: boolean;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type HeaderActionProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class HeaderAction extends SvelteComponentTyped<
   HeaderActionProps,

--- a/types/UIShell/HeaderActionLink.svelte.d.ts
+++ b/types/UIShell/HeaderActionLink.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["a"];
+type $RestProps = SvelteHTMLElements["a"];
 
-export interface HeaderActionLinkProps extends RestProps {
+type $Props = {
   /**
    * Set to `true` to use the active state
    * @default false
@@ -29,7 +29,9 @@ export interface HeaderActionLinkProps extends RestProps {
   ref?: null | HTMLAnchorElement;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type HeaderActionLinkProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class HeaderActionLink extends SvelteComponentTyped<
   HeaderActionLinkProps,

--- a/types/UIShell/HeaderGlobalAction.svelte.d.ts
+++ b/types/UIShell/HeaderGlobalAction.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { ButtonProps } from "../Button/Button.svelte";
 
-export interface HeaderGlobalActionProps extends ButtonProps {
+export type HeaderGlobalActionProps = ButtonProps & {
   /**
    * Set to `true` to use the active variant
    * @default false
@@ -19,7 +19,7 @@ export interface HeaderGlobalActionProps extends ButtonProps {
    * @default null
    */
   ref?: HTMLButtonElement;
-}
+};
 
 export default class HeaderGlobalAction extends SvelteComponentTyped<
   HeaderGlobalActionProps,

--- a/types/UIShell/HeaderNav.svelte.d.ts
+++ b/types/UIShell/HeaderNav.svelte.d.ts
@@ -1,11 +1,13 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["nav"];
+type $RestProps = SvelteHTMLElements["nav"];
 
-export interface HeaderNavProps extends RestProps {
+type $Props = {
   [key: `data-${string}`]: any;
-}
+};
+
+export type HeaderNavProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class HeaderNav extends SvelteComponentTyped<
   HeaderNavProps,

--- a/types/UIShell/HeaderNavItem.svelte.d.ts
+++ b/types/UIShell/HeaderNavItem.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["a"];
+type $RestProps = SvelteHTMLElements["a"];
 
-export interface HeaderNavItemProps extends RestProps {
+type $Props = {
   /**
    * Specify the `href` attribute
    * @default undefined
@@ -29,7 +29,9 @@ export interface HeaderNavItemProps extends RestProps {
   ref?: null | HTMLAnchorElement;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type HeaderNavItemProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class HeaderNavItem extends SvelteComponentTyped<
   HeaderNavItemProps,

--- a/types/UIShell/HeaderNavMenu.svelte.d.ts
+++ b/types/UIShell/HeaderNavMenu.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["a"];
+type $RestProps = SvelteHTMLElements["a"];
 
-export interface HeaderNavMenuProps extends RestProps {
+type $Props = {
   /**
    * Set to `true` to toggle the expanded state
    * @default false
@@ -29,7 +29,9 @@ export interface HeaderNavMenuProps extends RestProps {
   ref?: null | HTMLAnchorElement;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type HeaderNavMenuProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class HeaderNavMenu extends SvelteComponentTyped<
   HeaderNavMenuProps,

--- a/types/UIShell/HeaderPanelDivider.svelte.d.ts
+++ b/types/UIShell/HeaderPanelDivider.svelte.d.ts
@@ -1,6 +1,6 @@
 import type { SvelteComponentTyped } from "svelte";
 
-export interface HeaderPanelDividerProps {}
+export type HeaderPanelDividerProps = {};
 
 export default class HeaderPanelDivider extends SvelteComponentTyped<
   HeaderPanelDividerProps,

--- a/types/UIShell/HeaderPanelLink.svelte.d.ts
+++ b/types/UIShell/HeaderPanelLink.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["a"];
+type $RestProps = SvelteHTMLElements["a"];
 
-export interface HeaderPanelLinkProps extends RestProps {
+type $Props = {
   /**
    * Specify the `href` attribute
    * @default undefined
@@ -17,7 +17,9 @@ export interface HeaderPanelLinkProps extends RestProps {
   ref?: null | HTMLAnchorElement;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type HeaderPanelLinkProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class HeaderPanelLink extends SvelteComponentTyped<
   HeaderPanelLinkProps,

--- a/types/UIShell/HeaderPanelLinks.svelte.d.ts
+++ b/types/UIShell/HeaderPanelLinks.svelte.d.ts
@@ -1,6 +1,6 @@
 import type { SvelteComponentTyped } from "svelte";
 
-export interface HeaderPanelLinksProps {}
+export type HeaderPanelLinksProps = {};
 
 export default class HeaderPanelLinks extends SvelteComponentTyped<
   HeaderPanelLinksProps,

--- a/types/UIShell/HeaderSearch.svelte.d.ts
+++ b/types/UIShell/HeaderSearch.svelte.d.ts
@@ -7,9 +7,9 @@ export interface HeaderSearchResult {
   description?: string;
 }
 
-type RestProps = SvelteHTMLElements["input"];
+type $RestProps = SvelteHTMLElements["input"];
 
-export interface HeaderSearchProps extends RestProps {
+type $Props = {
   /**
    * Specify the search input value
    * @default ""
@@ -41,7 +41,9 @@ export interface HeaderSearchProps extends RestProps {
   selectedResultIndex?: number;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type HeaderSearchProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class HeaderSearch extends SvelteComponentTyped<
   HeaderSearchProps,

--- a/types/UIShell/HeaderUtilities.svelte.d.ts
+++ b/types/UIShell/HeaderUtilities.svelte.d.ts
@@ -1,6 +1,6 @@
 import type { SvelteComponentTyped } from "svelte";
 
-export interface HeaderUtilitiesProps {}
+export type HeaderUtilitiesProps = {};
 
 export default class HeaderUtilities extends SvelteComponentTyped<
   HeaderUtilitiesProps,

--- a/types/UIShell/SideNav.svelte.d.ts
+++ b/types/UIShell/SideNav.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["nav"];
+type $RestProps = SvelteHTMLElements["nav"];
 
-export interface SideNavProps extends RestProps {
+type $Props = {
   /**
    * Set to `true` to use the fixed variant
    * @default false
@@ -41,7 +41,9 @@ export interface SideNavProps extends RestProps {
   expansionBreakpoint?: number;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type SideNavProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class SideNav extends SvelteComponentTyped<
   SideNavProps,

--- a/types/UIShell/SideNavDivider.svelte.d.ts
+++ b/types/UIShell/SideNavDivider.svelte.d.ts
@@ -1,11 +1,13 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["li"];
+type $RestProps = SvelteHTMLElements["li"];
 
-export interface SideNavDividerProps extends RestProps {
+type $Props = {
   [key: `data-${string}`]: any;
-}
+};
+
+export type SideNavDividerProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class SideNavDivider extends SvelteComponentTyped<
   SideNavDividerProps,

--- a/types/UIShell/SideNavItems.svelte.d.ts
+++ b/types/UIShell/SideNavItems.svelte.d.ts
@@ -1,6 +1,6 @@
 import type { SvelteComponentTyped } from "svelte";
 
-export interface SideNavItemsProps {}
+export type SideNavItemsProps = {};
 
 export default class SideNavItems extends SvelteComponentTyped<
   SideNavItemsProps,

--- a/types/UIShell/SideNavLink.svelte.d.ts
+++ b/types/UIShell/SideNavLink.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["a"];
+type $RestProps = SvelteHTMLElements["a"];
 
-export interface SideNavLinkProps extends RestProps {
+type $Props = {
   /**
    * Set to `true` to select the current link
    * @default false
@@ -35,7 +35,9 @@ export interface SideNavLinkProps extends RestProps {
   ref?: null | HTMLAnchorElement;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type SideNavLinkProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class SideNavLink extends SvelteComponentTyped<
   SideNavLinkProps,

--- a/types/UIShell/SideNavMenu.svelte.d.ts
+++ b/types/UIShell/SideNavMenu.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["button"];
+type $RestProps = SvelteHTMLElements["button"];
 
-export interface SideNavMenuProps extends RestProps {
+type $Props = {
   /**
    * Set to `true` to toggle the expanded state
    * @default false
@@ -29,7 +29,9 @@ export interface SideNavMenuProps extends RestProps {
   ref?: null | HTMLButtonElement;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type SideNavMenuProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class SideNavMenu extends SvelteComponentTyped<
   SideNavMenuProps,

--- a/types/UIShell/SideNavMenuItem.svelte.d.ts
+++ b/types/UIShell/SideNavMenuItem.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["a"];
+type $RestProps = SvelteHTMLElements["a"];
 
-export interface SideNavMenuItemProps extends RestProps {
+type $Props = {
   /**
    * Set to `true` to select the item
    * @default false
@@ -29,7 +29,9 @@ export interface SideNavMenuItemProps extends RestProps {
   ref?: null | HTMLAnchorElement;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type SideNavMenuItemProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class SideNavMenuItem extends SvelteComponentTyped<
   SideNavMenuItemProps,

--- a/types/UIShell/SkipToContent.svelte.d.ts
+++ b/types/UIShell/SkipToContent.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["a"];
+type $RestProps = SvelteHTMLElements["a"];
 
-export interface SkipToContentProps extends RestProps {
+type $Props = {
   /**
    * Specify the `href` attribute
    * @default "#main-content"
@@ -17,7 +17,9 @@ export interface SkipToContentProps extends RestProps {
   tabindex?: string;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type SkipToContentProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class SkipToContent extends SvelteComponentTyped<
   SkipToContentProps,

--- a/types/UnorderedList/UnorderedList.svelte.d.ts
+++ b/types/UnorderedList/UnorderedList.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-type RestProps = SvelteHTMLElements["ul"];
+type $RestProps = SvelteHTMLElements["ul"];
 
-export interface UnorderedListProps extends RestProps {
+type $Props = {
   /**
    * Set to `true` to use the nested variant
    * @default false
@@ -17,7 +17,9 @@ export interface UnorderedListProps extends RestProps {
   expressive?: boolean;
 
   [key: `data-${string}`]: any;
-}
+};
+
+export type UnorderedListProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class UnorderedList extends SvelteComponentTyped<
   UnorderedListProps,


### PR DESCRIPTION
This resolves the TypeScript errors for the generated types, but now causes issues for consumption.

This is because certain attributes that exist on RestProps do not overlap, resulting in  `Error: Type <X> is not assignable to type 'never'. (ts)`.

The overlapping custom props would need to be omitted from RestProps, e.g., `Omit<RestProps, "size">`.