### PR TITLE
Update install commands in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,17 +28,18 @@ Other forms of documentation are auto-generated:
 
 ## Installation
 
-Install `carbon-components-svelte` as a development dependency.
-
 ```sh
-# Yarn
-yarn add carbon-components-svelte
-
 # npm
 npm i carbon-components-svelte
 
 # pnpm
 pnpm i carbon-components-svelte
+
+# Yarn
+yarn add carbon-components-svelte
+
+# Bun
+bun add carbon-components-svelte
 ```
 
 ## Usage
@@ -146,17 +147,20 @@ Import components from `carbon-components-svelte` in the `script` tag of your Sv
 [carbon-preprocess-svelte](https://github.com/carbon-design-system/carbon-preprocess-svelte) is a collection of Svelte preprocessors for Carbon.
 
 > [!NOTE]
-> Using `carbon-preprocess-svelte` is optional and not a prerequisite for this library.
+> Using `carbon-preprocess-svelte` is optional and not a prerequisite for this library. It should be installed as a development dependency.
 
 ```sh
-# Yarn
-yarn add -D carbon-preprocess-svelte
-
 # npm
 npm i -D carbon-preprocess-svelte
 
 # pnpm
 pnpm i -D carbon-preprocess-svelte
+
+# Yarn
+yarn add -D carbon-preprocess-svelte
+
+# Bun
+bun add -D carbon-preprocess-svelte
 ```
 
 ### `optimizeImports`

--- a/README.md
+++ b/README.md
@@ -32,13 +32,13 @@ Install `carbon-components-svelte` as a development dependency.
 
 ```sh
 # Yarn
-yarn add -D carbon-components-svelte
+yarn add carbon-components-svelte
 
 # npm
-npm i -D carbon-components-svelte
+npm i carbon-components-svelte
 
 # pnpm
-pnpm i -D carbon-components-svelte
+pnpm i carbon-components-svelte
 ```
 
 ## Usage

--- a/docs/src/pages/components/CodeSnippet.svx
+++ b/docs/src/pages/components/CodeSnippet.svx
@@ -36,7 +36,7 @@ You can override the default copy functionality with your own implementation. Se
 
 ## Default (single-line)
 
-<CodeSnippet code="yarn add -D carbon-components-svelte" />
+<CodeSnippet code="yarn add carbon-components-svelte" />
 
 ## Overriding copy functionality
 
@@ -50,7 +50,7 @@ In this example, we use the open source module [clipboard-copy](https://github.c
 
 To prevent text from being copied entirely, pass a no-op function to the `copy` prop.
 
-<CodeSnippet code="yarn add -D carbon-components-svelte" copy={() => {}} />
+<CodeSnippet code="yarn add carbon-components-svelte" copy={() => {}} />
 
 ## Inline
 
@@ -104,7 +104,7 @@ Use the `showMoreText` and `showLessText` props to override the default "Show mo
 
 The `disabled` prop applies only to the `"single"` and `"multi"` code snippet types.
 
-<CodeSnippet disabled code="yarn add -D carbon-components-svelte" />
+<CodeSnippet disabled code="yarn add carbon-components-svelte" />
 <br />
 <CodeSnippet disabled type="multi" code="{comment}" />
 

--- a/docs/src/pages/components/CodeSnippet.svx
+++ b/docs/src/pages/components/CodeSnippet.svx
@@ -36,7 +36,7 @@ You can override the default copy functionality with your own implementation. Se
 
 ## Default (single-line)
 
-<CodeSnippet code="yarn add carbon-components-svelte" />
+<CodeSnippet code="npm i carbon-components-svelte" />
 
 ## Overriding copy functionality
 
@@ -50,7 +50,7 @@ In this example, we use the open source module [clipboard-copy](https://github.c
 
 To prevent text from being copied entirely, pass a no-op function to the `copy` prop.
 
-<CodeSnippet code="yarn add carbon-components-svelte" copy={() => {}} />
+<CodeSnippet code="npm i carbon-components-svelte" copy={() => {}} />
 
 ## Inline
 
@@ -104,7 +104,7 @@ Use the `showMoreText` and `showLessText` props to override the default "Show mo
 
 The `disabled` prop applies only to the `"single"` and `"multi"` code snippet types.
 
-<CodeSnippet disabled code="yarn add carbon-components-svelte" />
+<CodeSnippet disabled code="npm i carbon-components-svelte" />
 <br />
 <CodeSnippet disabled type="multi" code="{comment}" />
 

--- a/docs/src/pages/framed/CodeSnippet/CodeSnippetOverride.svelte
+++ b/docs/src/pages/framed/CodeSnippet/CodeSnippetOverride.svelte
@@ -4,6 +4,6 @@
 </script>
 
 <CodeSnippet
-  code="yarn add carbon-components-svelte"
+  code="npm i carbon-components-svelte"
   copy="{(text) => copy(text)}"
 />

--- a/docs/src/pages/framed/CodeSnippet/CodeSnippetOverride.svelte
+++ b/docs/src/pages/framed/CodeSnippet/CodeSnippetOverride.svelte
@@ -4,6 +4,6 @@
 </script>
 
 <CodeSnippet
-  code="yarn add -D carbon-components-svelte"
+  code="yarn add carbon-components-svelte"
   copy="{(text) => copy(text)}"
 />

--- a/docs/src/pages/index.svelte
+++ b/docs/src/pages/index.svelte
@@ -21,9 +21,9 @@
   metatags.description =
     "The Svelte implementation of the Carbon Design System featuring UI components, icons, pictograms, and charts.";
 
-  const installYarn = "yarn add -D carbon-components-svelte";
-  const installNpm = "npm i -D carbon-components-svelte";
-  const installPnpm = "pnpm i -D carbon-components-svelte";
+  const installYarn = "yarn add carbon-components-svelte";
+  const installNpm = "npm i carbon-components-svelte";
+  const installPnpm = "pnpm i carbon-components-svelte";
   const themes = {
     white: "White",
     g10: "Gray 10",

--- a/docs/src/pages/index.svelte
+++ b/docs/src/pages/index.svelte
@@ -21,9 +21,9 @@
   metatags.description =
     "The Svelte implementation of the Carbon Design System featuring UI components, icons, pictograms, and charts.";
 
-  const installYarn = "yarn add carbon-components-svelte";
   const installNpm = "npm i carbon-components-svelte";
   const installPnpm = "pnpm i carbon-components-svelte";
+  const installYarn = "yarn add carbon-components-svelte";
   const themes = {
     white: "White",
     g10: "Gray 10",
@@ -85,18 +85,18 @@
     <Row style="margin-bottom: var(--cds-layout-02)">
       <Column noGutter>
         <Tabs>
-          <Tab label="Yarn" />
           <Tab label="NPM" />
           <Tab label="pnpm" />
+          <Tab label="Yarn" />
           <div slot="content" style="margin: 1rem -1rem">
-            <TabContent>
-              <CodeSnippet code="{installYarn}" />
-            </TabContent>
             <TabContent>
               <CodeSnippet code="{installNpm}" />
             </TabContent>
             <TabContent>
               <CodeSnippet code="{installPnpm}" />
+            </TabContent>
+            <TabContent>
+              <CodeSnippet code="{installYarn}" />
             </TabContent>
           </div>
         </Tabs>

--- a/docs/src/pages/index.svelte
+++ b/docs/src/pages/index.svelte
@@ -24,6 +24,7 @@
   const installNpm = "npm i carbon-components-svelte";
   const installPnpm = "pnpm i carbon-components-svelte";
   const installYarn = "yarn add carbon-components-svelte";
+  const installBun = "bun add carbon-components-svelte";
   const themes = {
     white: "White",
     g10: "Gray 10",
@@ -88,6 +89,7 @@
           <Tab label="NPM" />
           <Tab label="pnpm" />
           <Tab label="Yarn" />
+          <Tab label="Bun" />
           <div slot="content" style="margin: 1rem -1rem">
             <TabContent>
               <CodeSnippet code="{installNpm}" />
@@ -97,6 +99,9 @@
             </TabContent>
             <TabContent>
               <CodeSnippet code="{installYarn}" />
+            </TabContent>
+            <TabContent>
+              <CodeSnippet code="{installBun}" />
             </TabContent>
           </div>
         </Tabs>

--- a/docs/src/pages/index.svelte
+++ b/docs/src/pages/index.svelte
@@ -85,7 +85,7 @@
     </Row>
     <Row style="margin-bottom: var(--cds-layout-02)">
       <Column noGutter>
-        <Tabs>
+        <Tabs autoWidth>
           <Tab label="NPM" />
           <Tab label="pnpm" />
           <Tab label="Yarn" />
@@ -129,7 +129,7 @@
 
     <Row>
       <Column max="{8}" xlg="{8}" noGutter>
-        <Tabs>
+        <Tabs autoWidth>
           <Tab label="CSS StyleSheet" />
           <Tab label="SCSS" />
           <svelte:fragment slot="content">

--- a/tests/CodeSnippet.test.svelte
+++ b/tests/CodeSnippet.test.svelte
@@ -17,5 +17,5 @@
   on:expand
   on:collapse
 >
-  yarn add -D carbon-components-svelte
+  yarn add carbon-components-svelte
 </CodeSnippet>

--- a/tests/CopyableCodeSnippet.test.svelte
+++ b/tests/CopyableCodeSnippet.test.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   export let copy = (text: string) => text;
-  export let code = "yarn add -D carbon-component-svelte";
+  export let code = "yarn add carbon-component-svelte";
 
   import { CodeSnippet } from "../types";
 </script>

--- a/tests/CopyableCodeSnippet.test.svelte
+++ b/tests/CopyableCodeSnippet.test.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   export let copy = (text: string) => text;
-  export let code = "yarn add carbon-component-svelte";
+  export let code = "npm i carbon-component-svelte";
 
   import { CodeSnippet } from "../types";
 </script>


### PR DESCRIPTION
For consistency with [carbon-icons-svelte](https://github.com/carbon-design-system/carbon-icons-svelte) and [carbon-pictograms-svelte](https://github.com/carbon-design-system/carbon-icons-svelte):

- Drop the `-D` flag from install commands (this library should be a dependency, not a `devDependency`). It's also cleaner.
- Add Bun an install command
- Re-order command so that `npm --> pnpm --> yarn --> bun`
- Style-wise, update the docs home page to use `<Tabs autoWidth />` since the added tab can look a bit crowded.