### PR TITLE
Alias types folder in `/tests`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "standard-version": "^9.5.0",
         "sveld": "^0.20.3",
         "svelte": "^4.2.10",
-        "svelte-check": "^3.6.4",
+        "svelte-check": "^3.8.6",
         "typescript": "^5.6.3"
       }
     },
@@ -3176,9 +3176,9 @@
       }
     },
     "node_modules/svelte-check": {
-      "version": "3.8.5",
-      "resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-3.8.5.tgz",
-      "integrity": "sha512-3OGGgr9+bJ/+1nbPgsvulkLC48xBsqsgtc8Wam281H4G9F5v3mYGa2bHRsPuwHC5brKl4AxJH95QF73kmfihGQ==",
+      "version": "3.8.6",
+      "resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-3.8.6.tgz",
+      "integrity": "sha512-ij0u4Lw/sOTREP13BdWZjiXD/BlHE6/e2e34XzmVmsp5IN4kVa3PWP65NM32JAgwjZlwBg/+JtiNV1MM8khu0Q==",
       "dev": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.17",
@@ -3258,9 +3258,9 @@
       }
     },
     "node_modules/svelte-preprocess/node_modules/magic-string": {
-      "version": "0.30.11",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.11.tgz",
-      "integrity": "sha512-+Wri9p0QHMy+545hKww7YAu5NyzF8iomPL/RQazugQ9+Ez4Ic3mERMd8ZTX5rfK944j+560ZJi8iAwgak1Ac7A==",
+      "version": "0.30.12",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.12.tgz",
+      "integrity": "sha512-Ea8I3sQMVXr8JhN4z+H/d8zwo+tYDgHE9+5G4Wnrwhs0gaK9fXTKx0Tw5Xwsd/bCPTTZNRAdpyzvoeORe9LYpw==",
       "dev": true,
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "css/*.css"
   ],
   "scripts": {
-    "test:types": "svelte-check --workspace tests --no-tsconfig --ignore 'docs,examples'",
+    "test:types": "svelte-check --workspace tests",
     "lint": "prettier --write \"**/*.{svelte,md,js,json,ts}\"",
     "build:css": "node scripts/build-css",
     "build:docs": "node scripts/build-docs",
@@ -59,7 +59,7 @@
     "standard-version": "^9.5.0",
     "sveld": "^0.20.3",
     "svelte": "^4.2.10",
-    "svelte-check": "^3.6.4",
+    "svelte-check": "^3.8.6",
     "typescript": "^5.6.3"
   },
   "standard-version": {

--- a/tests/Accordion.test.svelte
+++ b/tests/Accordion.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Accordion, AccordionItem } from "../types";
+  import { Accordion, AccordionItem } from "carbon-components-svelte";
 </script>
 
 <Accordion>

--- a/tests/AspectRatio.test.svelte
+++ b/tests/AspectRatio.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { AspectRatio, Tile } from "../types";
+  import { AspectRatio, Tile } from "carbon-components-svelte";
 </script>
 
 <AspectRatio ratio="16x9">

--- a/tests/AspectRatioColumns.test.svelte
+++ b/tests/AspectRatioColumns.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Grid, Row, Column } from "../types";
+  import { Grid, Row, Column } from "carbon-components-svelte";
 </script>
 
 <Grid>

--- a/tests/Breadcrumb.test.svelte
+++ b/tests/Breadcrumb.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Breadcrumb, BreadcrumbItem } from "../types";
+  import { Breadcrumb, BreadcrumbItem } from "carbon-components-svelte";
 </script>
 
 <Breadcrumb>

--- a/tests/Breadcrumbs.test.svelte
+++ b/tests/Breadcrumbs.test.svelte
@@ -7,7 +7,7 @@
     { href: "/reports/2019", text: "2019" },
   ];
 
-  import { Row, Column, Breadcrumb, BreadcrumbItem } from "../types";
+  import { Row, Column, Breadcrumb, BreadcrumbItem } from "carbon-components-svelte";
 </script>
 
 <Row>

--- a/tests/Breakpoint.test.svelte
+++ b/tests/Breakpoint.test.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  import { Breakpoint, breakpointObserver, breakpoints } from "../types";
-  import type { BreakpointProps } from "../types/Breakpoint/Breakpoint.svelte";
+  import { Breakpoint, breakpointObserver, breakpoints } from "carbon-components-svelte";
+  import type { BreakpointProps } from "carbon-components-svelte/Breakpoint/Breakpoint.svelte";
 
   let size: BreakpointProps["size"];
 

--- a/tests/Button.test.svelte
+++ b/tests/Button.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Button } from "../types";
+  import { Button } from "carbon-components-svelte";
   import Add from "carbon-icons-svelte/lib/Add.svelte";
 </script>
 

--- a/tests/ButtonSet.test.svelte
+++ b/tests/ButtonSet.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Button, ButtonSet } from "../types";
+  import { Button, ButtonSet } from "carbon-components-svelte";
   import Login from "carbon-icons-svelte/lib/Login.svelte";
 </script>
 

--- a/tests/Checkbox.test.svelte
+++ b/tests/Checkbox.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Checkbox } from "../types";
+  import { Checkbox } from "carbon-components-svelte";
 </script>
 
 <Checkbox labelText="Label text" style="margin: 1rem" />

--- a/tests/ClickableTile.test.svelte
+++ b/tests/ClickableTile.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { ClickableTile } from "../types";
+  import { ClickableTile } from "carbon-components-svelte";
 </script>
 
 <ClickableTile href="https://www.carbondesignsystem.com/">

--- a/tests/CodeSnippet.test.svelte
+++ b/tests/CodeSnippet.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { CodeSnippet } from "../types";
+  import { CodeSnippet } from "carbon-components-svelte";
 </script>
 
 <CodeSnippet

--- a/tests/ComboBox.test.svelte
+++ b/tests/ComboBox.test.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  import { ComboBox } from "../types";
-  import type { ComboBoxItem } from "../types/ComboBox/ComboBox.svelte";
+  import { ComboBox } from "carbon-components-svelte";
+  import type { ComboBoxItem } from "carbon-components-svelte/ComboBox/ComboBox.svelte";
 
   const items: ComboBoxItem[] = [
     { id: 0, text: "Slack" },

--- a/tests/ComposedModal.test.svelte
+++ b/tests/ComposedModal.test.svelte
@@ -5,7 +5,7 @@
     ModalBody,
     ModalFooter,
     Checkbox,
-  } from "../types";
+  } from "carbon-components-svelte";
 
   let checked = false;
 </script>

--- a/tests/CondensedGrid.test.svelte
+++ b/tests/CondensedGrid.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Grid, Row, Column } from "../types";
+  import { Grid, Row, Column } from "carbon-components-svelte";
 </script>
 
 <Grid condensed>

--- a/tests/ContentSwitcher.test.svelte
+++ b/tests/ContentSwitcher.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { ContentSwitcher, Switch } from "../types";
+  import { ContentSwitcher, Switch } from "carbon-components-svelte";
   import Analytics from "carbon-icons-svelte/lib/Analytics.svelte";
 </script>
 

--- a/tests/ContextMenu.test.svelte
+++ b/tests/ContextMenu.test.svelte
@@ -8,10 +8,11 @@
   } from "carbon-components-svelte";
   import CopyFile from "carbon-icons-svelte/lib/CopyFile.svelte";
   import Cut from "carbon-icons-svelte/lib/Cut.svelte";
+  import type { ComponentProps } from "svelte";
 
   let ref: HTMLElement;
   let selectedId = "0";
-  let selectedIds = [];
+  let selectedIds: ComponentProps<ContextMenuGroup>["selectedIds"] = [];
 
   $: console.log("selectedId", selectedId);
 </script>
@@ -29,7 +30,10 @@
   <ContextMenuOption indented labelText="Cut" shortcutText="⌘X" icon="{Cut}" />
   <ContextMenuDivider />
   <ContextMenuOption indented labelText="Export as">
-    <ContextMenuGroup labelText="Export options" bind:selectedIds>
+    <ContextMenuGroup
+      labelText="Export options"
+      bind:selectedIds="{selectedIds}"
+    >
       <ContextMenuOption id="pdf" labelText="PDF" />
       <ContextMenuOption id="txt" labelText="TXT" />
       <ContextMenuOption id="mp3" labelText="MP3" />
@@ -48,7 +52,7 @@
 <ContextMenu target="{[null, ref]}" on:open on:close>
   <ContextMenuOption indented labelText="Open" />
   <ContextMenuDivider />
-  <ContextMenuRadioGroup bind:selectedId labelText="Radio group">
+  <ContextMenuRadioGroup bind:selectedId="{selectedId}" labelText="Radio group">
     <ContextMenuOption id="0" labelText="Set as foreground" />
     <ContextMenuOption id="1" labelText="Set as background" />
   </ContextMenuRadioGroup>

--- a/tests/ContextMenu.test.svelte
+++ b/tests/ContextMenu.test.svelte
@@ -5,7 +5,7 @@
     ContextMenuOption,
     ContextMenuRadioGroup,
     ContextMenuGroup,
-  } from "../types";
+  } from "carbon-components-svelte";
   import CopyFile from "carbon-icons-svelte/lib/CopyFile.svelte";
   import Cut from "carbon-icons-svelte/lib/Cut.svelte";
 

--- a/tests/CopyButton.test.svelte
+++ b/tests/CopyButton.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { CopyButton } from "../types";
+  import { CopyButton } from "carbon-components-svelte";
 </script>
 
 <CopyButton

--- a/tests/CopyableCodeSnippet.test.svelte
+++ b/tests/CopyableCodeSnippet.test.svelte
@@ -2,7 +2,7 @@
   export let copy = (text: string) => text;
   export let code = "npm i carbon-component-svelte";
 
-  import { CodeSnippet } from "../types";
+  import { CodeSnippet } from "carbon-components-svelte";
 </script>
 
 <CodeSnippet on:click="{() => copy(code)}">{code}</CodeSnippet>

--- a/tests/DangerModal.test.svelte
+++ b/tests/DangerModal.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Button, Modal } from "../types";
+  import { Button, Modal } from "carbon-components-svelte";
 
   let open = false;
 </script>

--- a/tests/DataTable.test.svelte
+++ b/tests/DataTable.test.svelte
@@ -9,8 +9,8 @@
     ToolbarMenuItem,
     Button,
     Link,
-  } from "../types";
-  import type { DataTableHeader } from "../types/DataTable/DataTable.svelte";
+  } from "carbon-components-svelte";
+  import type { DataTableHeader } from "carbon-components-svelte/DataTable/DataTable.svelte";
   import Launch from "carbon-icons-svelte/lib/Launch.svelte";
 
   const headers: DataTableHeader[] = [

--- a/tests/DataTable.test.svelte
+++ b/tests/DataTable.test.svelte
@@ -12,6 +12,7 @@
   } from "carbon-components-svelte";
   import type { DataTableHeader } from "carbon-components-svelte/DataTable/DataTable.svelte";
   import Launch from "carbon-icons-svelte/lib/Launch.svelte";
+  import type { ComponentProps } from "svelte";
 
   const headers: DataTableHeader[] = [
     { key: "name", value: "Name" },
@@ -69,7 +70,7 @@
     return 0;
   }
 
-  let filteredRowIds = [];
+  let filteredRowIds: ComponentProps<ToolbarSearch>["filteredRowIds"] = [];
 </script>
 
 <DataTable
@@ -119,7 +120,7 @@
   <Toolbar>
     <ToolbarContent>
       <ToolbarSearch
-        bind:filteredRowIds
+        bind:filteredRowIds="{filteredRowIds}"
         shouldFilterRows="{(row, value) => {
           return row.name.includes(value);
         }}"

--- a/tests/DataTableAppendColumns.test.svelte
+++ b/tests/DataTableAppendColumns.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { DataTable, OverflowMenu, OverflowMenuItem } from "../types";
+  import { DataTable, OverflowMenu, OverflowMenuItem } from "carbon-components-svelte";
 
   const headers = [
     { key: "name", value: "Name" },

--- a/tests/DataTableBatchSelection.test.svelte
+++ b/tests/DataTableBatchSelection.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { DataTable } from "../types";
+  import { DataTable } from "carbon-components-svelte";
 
   const headers = [
     { key: "name", value: "Name" },

--- a/tests/DataTableBatchSelectionToolbar.test.svelte
+++ b/tests/DataTableBatchSelectionToolbar.test.svelte
@@ -8,7 +8,7 @@
     ToolbarMenuItem,
     ToolbarBatchActions,
     Button,
-  } from "../types";
+  } from "carbon-components-svelte";
   import Save from "carbon-icons-svelte/lib/Save.svelte";
 
   const headers = [

--- a/tests/DatePicker.test.svelte
+++ b/tests/DatePicker.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { DatePicker, DatePickerSkeleton, DatePickerInput } from "../types";
+  import { DatePicker, DatePickerSkeleton, DatePickerInput } from "carbon-components-svelte";
   import { Russian } from "flatpickr/dist/l10n/ru.js";
 </script>
 

--- a/tests/Dropdown.test.svelte
+++ b/tests/Dropdown.test.svelte
@@ -2,11 +2,11 @@
   import { Dropdown, DropdownSkeleton } from "carbon-components-svelte";
   import type { DropdownProps } from "carbon-components-svelte/Dropdown/Dropdown.svelte";
 
-  let items: DropdownProps["items"] = [
+  let items = [
     { id: 0, text: "Slack" },
     { id: "1", text: "Email" },
     { id: "2", text: "Fax" },
-  ] as const;
+  ] satisfies NonNullable<DropdownProps["items"]>;
 
   let itemsWithoutConst = [...items];
 
@@ -14,10 +14,8 @@
 
   export const fieldId: FieldId = "bar";
 
-  // @ts-expect-error
   $: items[0] = { id: "0", text: "Slack" };
   $: {
-    // @ts-expect-error
     items[0] = { id: "0", text: "Slack" };
   }
   $: {

--- a/tests/Dropdown.test.svelte
+++ b/tests/Dropdown.test.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  import { Dropdown, DropdownSkeleton } from "../types";
-  import type { DropdownProps } from "../types/Dropdown/Dropdown.svelte";
+  import { Dropdown, DropdownSkeleton } from "carbon-components-svelte";
+  import type { DropdownProps } from "carbon-components-svelte/Dropdown/Dropdown.svelte";
 
   let items: DropdownProps["items"] = [
     { id: 0, text: "Slack" },

--- a/tests/DynamicCodeSnippet.test.svelte
+++ b/tests/DynamicCodeSnippet.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { CodeSnippet } from "../types";
+  import { CodeSnippet } from "carbon-components-svelte";
 
   let toggled = false;
 

--- a/tests/ExpandableTile.test.svelte
+++ b/tests/ExpandableTile.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { ExpandableTile } from "../types";
+  import { ExpandableTile } from "carbon-components-svelte";
 </script>
 
 <ExpandableTile>

--- a/tests/FileUploader.test.svelte
+++ b/tests/FileUploader.test.svelte
@@ -5,8 +5,8 @@
     FileUploaderDropContainer,
     FileUploaderItem,
     FileUploaderSkeleton,
-  } from "../types";
-  import type { FileUploaderProps } from "../types/FileUploader/FileUploader.svelte";
+  } from "carbon-components-svelte";
+  import type { FileUploaderProps } from "carbon-components-svelte/FileUploader/FileUploader.svelte";
 
   let fileUploader: FileUploader;
   let files: FileUploaderProps["files"] = [];

--- a/tests/FilterableComboBox.test.svelte
+++ b/tests/FilterableComboBox.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { ComboBox } from "../types";
+  import { ComboBox } from "carbon-components-svelte";
 
   function shouldFilterItem(item: { text: string }, value?: any) {
     if (!value) return true;

--- a/tests/FluidForm.test.svelte
+++ b/tests/FluidForm.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { FluidForm, TextInput, PasswordInput } from "../types";
+  import { FluidForm, TextInput, PasswordInput } from "carbon-components-svelte";
 </script>
 
 <FluidForm action="" method="get">

--- a/tests/Form.test.svelte
+++ b/tests/Form.test.svelte
@@ -8,7 +8,7 @@
     Select,
     SelectItem,
     Button,
-  } from "../types";
+  } from "carbon-components-svelte";
 
   let ref: HTMLFormElement;
 </script>

--- a/tests/FullWidthGrid.test.svelte
+++ b/tests/FullWidthGrid.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Grid, Row, Column } from "../types";
+  import { Grid, Row, Column } from "carbon-components-svelte";
 </script>
 
 <Grid fullWidth>

--- a/tests/Grid.test.svelte
+++ b/tests/Grid.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Grid, Row, Column } from "../types";
+  import { Grid, Row, Column } from "carbon-components-svelte";
 </script>
 
 <Grid>

--- a/tests/HeaderNav.test.svelte
+++ b/tests/HeaderNav.test.svelte
@@ -14,7 +14,7 @@
     Grid,
     Row,
     Column,
-  } from "../types";
+  } from "carbon-components-svelte";
 
   let isSideNavOpen = false;
 </script>

--- a/tests/HeaderSearch.svelte
+++ b/tests/HeaderSearch.svelte
@@ -18,11 +18,12 @@
     Row,
     Column,
   } from "carbon-components-svelte";
+    import type { ComponentProps } from "svelte";
 
   let isSideNavOpen = false;
   let isOpen = false;
 
-  let ref = null;
+  let ref: ComponentProps<HeaderSearch>["ref"] = null;
   let active = false;
   let value = "";
   let selectedResultIndex = 1;

--- a/tests/HeaderSearch.svelte
+++ b/tests/HeaderSearch.svelte
@@ -17,7 +17,7 @@
     Grid,
     Row,
     Column,
-  } from "../types";
+  } from "carbon-components-svelte";
 
   let isSideNavOpen = false;
   let isOpen = false;

--- a/tests/HeaderSwitcher.test.svelte
+++ b/tests/HeaderSwitcher.test.svelte
@@ -16,7 +16,7 @@
     Grid,
     Row,
     Column,
-  } from "../types";
+  } from "carbon-components-svelte";
 
   let isSideNavOpen = false;
   let isOpen = false;

--- a/tests/HeaderUtilities.test.svelte
+++ b/tests/HeaderUtilities.test.svelte
@@ -17,7 +17,7 @@
     Grid,
     Row,
     Column,
-  } from "../types";
+  } from "carbon-components-svelte";
   import SettingsAdjust from "carbon-icons-svelte/lib/SettingsAdjust.svelte";
   import { quintOut } from "svelte/easing";
 

--- a/tests/HiddenCodeSnippet.test.svelte
+++ b/tests/HiddenCodeSnippet.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { CodeSnippet } from "../types";
+  import { CodeSnippet } from "carbon-components-svelte";
 
   let toggled = false;
 

--- a/tests/ImageLoader.test.svelte
+++ b/tests/ImageLoader.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { ImageLoader } from "../types";
+  import { ImageLoader } from "carbon-components-svelte";
 
   let loading = false;
   let loaded = false;

--- a/tests/InlineLoading.test.svelte
+++ b/tests/InlineLoading.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { InlineLoading } from "../types";
+  import { InlineLoading } from "carbon-components-svelte";
 </script>
 
 <InlineLoading />

--- a/tests/InlineLoadingUx.test.svelte
+++ b/tests/InlineLoadingUx.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Button, ButtonSet, InlineLoading } from "../types";
+  import { Button, ButtonSet, InlineLoading } from "carbon-components-svelte";
   import { onDestroy } from "svelte";
 
   type State = "dormant" | "active" | "finished" | "inactive";

--- a/tests/InlineLoadingUx.test.svelte
+++ b/tests/InlineLoadingUx.test.svelte
@@ -8,16 +8,18 @@
     active: "Submitting...",
     finished: "Success",
     inactive: "Cancelling...",
-  };
+    dormant: "Submit",
+  } as const satisfies Record<State, string>;
 
   const stateMap = {
     active: "finished",
     inactive: "dormant",
     finished: "dormant",
-  };
+    dormant: "inactive",
+  } as const satisfies Record<State, State>;
 
-  let timeout = undefined;
-  let state: State = "dormant";
+  let timeout: NodeJS.Timeout | undefined = undefined;
+  let state: State= "dormant";
 
   function reset(incomingState?: State) {
     if (typeof timeout === "number") {

--- a/tests/InlineNotification.test.svelte
+++ b/tests/InlineNotification.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { InlineNotification, NotificationActionButton } from "../types";
+  import { InlineNotification, NotificationActionButton } from "carbon-components-svelte";
 </script>
 
 <InlineNotification on:close />

--- a/tests/Link.test.svelte
+++ b/tests/Link.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Link, OutboundLink } from "../types";
+  import { Link, OutboundLink } from "carbon-components-svelte";
 </script>
 
 <Link size="sm" inline disabled download visited href="/" target="_blank">

--- a/tests/Loading.test.svelte
+++ b/tests/Loading.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Loading } from "../types";
+  import { Loading } from "carbon-components-svelte";
 </script>
 
 <Loading withOverlay="{false}" />

--- a/tests/LocalStorage.test.svelte
+++ b/tests/LocalStorage.test.svelte
@@ -3,7 +3,7 @@
 
   let storage: LocalStorage;
   let toggled = false;
-  let events = [];
+  let events: { event: string; detail?: any }[] = [];
 
   $: if (storage) storage.clearItem();
   $: if (storage) storage.clearAll();

--- a/tests/LocalStorage.test.svelte
+++ b/tests/LocalStorage.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { LocalStorage } from "../types";
+  import { LocalStorage } from "carbon-components-svelte";
 
   let storage: LocalStorage;
   let toggled = false;

--- a/tests/Modal.test.svelte
+++ b/tests/Modal.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Button, Modal } from "../types";
+  import { Button, Modal } from "carbon-components-svelte";
 
   let open = false;
 </script>

--- a/tests/ModalExtraSmall.test.svelte
+++ b/tests/ModalExtraSmall.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Modal } from "../types";
+  import { Modal } from "carbon-components-svelte";
 </script>
 
 <Modal

--- a/tests/ModalLarge.test.svelte
+++ b/tests/ModalLarge.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Modal } from "../types";
+  import { Modal } from "carbon-components-svelte";
 </script>
 
 <Modal

--- a/tests/ModalPreventOutsideClick.test.svelte
+++ b/tests/ModalPreventOutsideClick.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Modal } from "../types";
+  import { Modal } from "carbon-components-svelte";
 </script>
 
 <Modal

--- a/tests/ModalSmall.test.svelte
+++ b/tests/ModalSmall.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Modal } from "../types";
+  import { Modal } from "carbon-components-svelte";
 </script>
 
 <Modal

--- a/tests/MultiSelect.test.svelte
+++ b/tests/MultiSelect.test.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  import { MultiSelect } from "../types";
-  import type { MultiSelectProps } from "../types/MultiSelect/MultiSelect.svelte";
+  import { MultiSelect } from "carbon-components-svelte";
+  import type { MultiSelectProps } from "carbon-components-svelte/MultiSelect/MultiSelect.svelte";
 
   let selectedIds: MultiSelectProps["selectedIds"] = [0];
 

--- a/tests/NarrowGrid.test.svelte
+++ b/tests/NarrowGrid.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Grid, Row, Column } from "../types";
+  import { Grid, Row, Column } from "carbon-components-svelte";
 </script>
 
 <Grid narrow>

--- a/tests/NumberInput.test.svelte
+++ b/tests/NumberInput.test.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  import { NumberInput, NumberInputSkeleton } from "../types";
-  import type { NumberInputProps } from "../types/NumberInput/NumberInput.svelte";
+  import { NumberInput, NumberInputSkeleton } from "carbon-components-svelte";
+  import type { NumberInputProps } from "carbon-components-svelte/NumberInput/NumberInput.svelte";
 
   let value: NumberInputProps["value"] = null;
 </script>

--- a/tests/OffsetColumns.test.svelte
+++ b/tests/OffsetColumns.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Grid, Row, Column } from "../types";
+  import { Grid, Row, Column } from "carbon-components-svelte";
 </script>
 
 <Grid>

--- a/tests/OrderedList.test.svelte
+++ b/tests/OrderedList.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { OrderedList, ListItem, Link } from "../types";
+  import { OrderedList, ListItem, Link } from "carbon-components-svelte";
 </script>
 
 <OrderedList>

--- a/tests/OverflowMenu.test.svelte
+++ b/tests/OverflowMenu.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { OverflowMenu, OverflowMenuItem } from "../types";
+  import { OverflowMenu, OverflowMenuItem } from "carbon-components-svelte";
   import Add from "carbon-icons-svelte/lib/Add.svelte";
 </script>
 

--- a/tests/PaddedGrid.test.svelte
+++ b/tests/PaddedGrid.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Grid, Row, Column } from "../types";
+  import { Grid, Row, Column } from "carbon-components-svelte";
 </script>
 
 <Grid padding>

--- a/tests/Pagination.test.svelte
+++ b/tests/Pagination.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Pagination, PaginationSkeleton } from "../types";
+  import { Pagination, PaginationSkeleton } from "carbon-components-svelte";
 </script>
 
 <Pagination

--- a/tests/PaginationNav.test.svelte
+++ b/tests/PaginationNav.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { PaginationNav } from "../types";
+  import { PaginationNav } from "carbon-components-svelte";
 </script>
 
 <PaginationNav />

--- a/tests/PassiveModal.test.svelte
+++ b/tests/PassiveModal.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Button, Modal } from "../types";
+  import { Button, Modal } from "carbon-components-svelte";
 
   let open = false;
 </script>

--- a/tests/PasswordInput.test.svelte
+++ b/tests/PasswordInput.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { PasswordInput } from "../types";
+  import { PasswordInput } from "carbon-components-svelte";
 </script>
 
 <PasswordInput labelText="Password" placeholder="Enter password..." />

--- a/tests/PersistedHamburgerMenu.test.svelte
+++ b/tests/PersistedHamburgerMenu.test.svelte
@@ -14,7 +14,7 @@
     Grid,
     Row,
     Column,
-  } from "../types";
+  } from "carbon-components-svelte";
 
   let isSideNavOpen = false;
 </script>

--- a/tests/Popover.test.svelte
+++ b/tests/Popover.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Popover } from "../types";
+  import { Popover } from "carbon-components-svelte";
 
   let open = false;
 </script>

--- a/tests/ProgressBar.test.svelte
+++ b/tests/ProgressBar.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { ProgressBar } from "../types";
+  import { ProgressBar } from "carbon-components-svelte";
 </script>
 
 <ProgressBar helperText="Loading..." />

--- a/tests/ProgressIndicator.test.svelte
+++ b/tests/ProgressIndicator.test.svelte
@@ -3,7 +3,7 @@
     ProgressIndicator,
     ProgressStep,
     ProgressIndicatorSkeleton,
-  } from "../types";
+  } from "carbon-components-svelte";
 </script>
 
 <ProgressIndicator currentIndex="{2}">

--- a/tests/RadioButton.test.svelte
+++ b/tests/RadioButton.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { RadioButton, RadioButtonSkeleton, RadioButtonGroup } from "../types";
+  import { RadioButton, RadioButtonSkeleton, RadioButtonGroup } from "carbon-components-svelte";
 </script>
 
 <RadioButtonGroup

--- a/tests/RadioSelectableDataTable.test.svelte
+++ b/tests/RadioSelectableDataTable.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { DataTable } from "../types";
+  import { DataTable } from "carbon-components-svelte";
 
   const headers = [
     { key: "name", value: "Name" },

--- a/tests/RadioTile.test.svelte
+++ b/tests/RadioTile.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { TileGroup, RadioTile } from "../types";
+  import { TileGroup, RadioTile } from "carbon-components-svelte";
 </script>
 
 <TileGroup

--- a/tests/RecursiveList.test.svelte
+++ b/tests/RecursiveList.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { RecursiveList } from "../types";
+  import { RecursiveList } from "carbon-components-svelte";
 
   const children = [
     {

--- a/tests/ResponsiveGrid.test.svelte
+++ b/tests/ResponsiveGrid.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Grid, Row, Column } from "../types";
+  import { Grid, Row, Column } from "carbon-components-svelte";
 </script>
 
 <Grid>

--- a/tests/Search.test.svelte
+++ b/tests/Search.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Search } from "../types";
+  import { Search } from "carbon-components-svelte";
 </script>
 
 <Search on:paste />

--- a/tests/Select.test.svelte
+++ b/tests/Select.test.svelte
@@ -4,7 +4,7 @@
     SelectItem,
     SelectItemGroup,
     SelectSkeleton,
-  } from "../types";
+  } from "carbon-components-svelte";
 </script>
 
 <Select labelText="Carbon theme" selected="g10">

--- a/tests/SelectableDataTable.test.svelte
+++ b/tests/SelectableDataTable.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { DataTable } from "../types";
+  import { DataTable } from "carbon-components-svelte";
 
   const headers = [
     { key: "name", value: "Name" },

--- a/tests/SelectableDataTable.test.svelte
+++ b/tests/SelectableDataTable.test.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { DataTable } from "carbon-components-svelte";
-
+  import type { ComponentProps } from "svelte";
   const headers = [
     { key: "name", value: "Name" },
     { key: "port", value: "Port" },
@@ -16,7 +16,7 @@
     { id: "f", name: "Load Balancer 5", port: 80, rule: "DNS delegation" },
   ];
 
-  let selectedRowIds = [];
+  let selectedRowIds: ComponentProps<DataTable>["selectedRowIds"] = [];
 
   $: console.log("selectedRowIds", selectedRowIds);
 </script>

--- a/tests/SelectableTile.test.svelte
+++ b/tests/SelectableTile.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { SelectableTile } from "../types";
+  import { SelectableTile } from "carbon-components-svelte";
 </script>
 
 <SelectableTile selected>Multi-select Tile</SelectableTile>

--- a/tests/SkeletonPlaceholder.test.svelte
+++ b/tests/SkeletonPlaceholder.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { SkeletonPlaceholder } from "../types";
+  import { SkeletonPlaceholder } from "carbon-components-svelte";
 </script>
 
 <SkeletonPlaceholder />

--- a/tests/SkeletonText.test.svelte
+++ b/tests/SkeletonText.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { SkeletonText } from "../types";
+  import { SkeletonText } from "carbon-components-svelte";
 </script>
 
 <SkeletonText />

--- a/tests/Slider.test.svelte
+++ b/tests/Slider.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Slider, SliderSkeleton } from "../types";
+  import { Slider, SliderSkeleton } from "carbon-components-svelte";
 </script>
 
 <Slider />

--- a/tests/StructuredList.test.svelte
+++ b/tests/StructuredList.test.svelte
@@ -7,7 +7,7 @@
     StructuredListCell,
     StructuredListRow,
     StructuredListInput,
-  } from "../types";
+  } from "carbon-components-svelte";
   import CheckmarkFilled from "carbon-icons-svelte/lib/CheckmarkFilled.svelte";
 </script>
 

--- a/tests/Tabs.test.svelte
+++ b/tests/Tabs.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Tabs, Tab, TabContent, TabsSkeleton } from "../types";
+  import { Tabs, Tab, TabContent, TabsSkeleton } from "carbon-components-svelte";
 </script>
 
 <Tabs

--- a/tests/Tag.test.svelte
+++ b/tests/Tag.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Tag } from "../types";
+  import { Tag } from "carbon-components-svelte";
   import Add from "carbon-icons-svelte/lib/Add.svelte";
 </script>
 

--- a/tests/TextArea.test.svelte
+++ b/tests/TextArea.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { TextArea, TextAreaSkeleton } from "../types";
+  import { TextArea, TextAreaSkeleton } from "carbon-components-svelte";
 </script>
 
 <TextArea

--- a/tests/TextInput.test.svelte
+++ b/tests/TextInput.test.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
   import { TextInput, TextInputSkeleton } from "carbon-components-svelte";
+  import type { ComponentProps } from "svelte";
 
-  let value = null;
+  let value: ComponentProps<TextInput>["value"] = null;
 </script>
 
 <TextInput

--- a/tests/TextInput.test.svelte
+++ b/tests/TextInput.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { TextInput, TextInputSkeleton } from "../types";
+  import { TextInput, TextInputSkeleton } from "carbon-components-svelte";
 
   let value = null;
 </script>

--- a/tests/Theme.test.svelte
+++ b/tests/Theme.test.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  import { Theme } from "../types";
-  import type { CarbonTheme } from "../types/Theme/Theme.svelte";
+  import { Theme } from "carbon-components-svelte";
+  import type { CarbonTheme } from "carbon-components-svelte/Theme/Theme.svelte";
 
   let theme: CarbonTheme = "g10";
 </script>

--- a/tests/Tile.test.svelte
+++ b/tests/Tile.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Tile } from "../types";
+  import { Tile } from "carbon-components-svelte";
 </script>
 
 <Tile>Content</Tile>

--- a/tests/TimePicker.test.svelte
+++ b/tests/TimePicker.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { TimePicker, TimePickerSelect, SelectItem } from "../types";
+  import { TimePicker, TimePickerSelect, SelectItem } from "carbon-components-svelte";
 </script>
 
 <TimePicker

--- a/tests/ToastNotification.test.svelte
+++ b/tests/ToastNotification.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { ToastNotification } from "../types";
+  import { ToastNotification } from "carbon-components-svelte";
 </script>
 
 <ToastNotification fullWidth />

--- a/tests/Toggle.test.svelte
+++ b/tests/Toggle.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Toggle, ToggleSkeleton } from "../types";
+  import { Toggle, ToggleSkeleton } from "carbon-components-svelte";
 </script>
 
 <Toggle labelText="Push notifications" hideLabel />

--- a/tests/Tooltip.test.svelte
+++ b/tests/Tooltip.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Tooltip, Link, Button } from "../types";
+  import { Tooltip, Link, Button } from "carbon-components-svelte";
   import Catalog from "carbon-icons-svelte/lib/Catalog.svelte";
 
   let open = true;

--- a/tests/TooltipDefinition.test.svelte
+++ b/tests/TooltipDefinition.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { TooltipDefinition } from "../types";
+  import { TooltipDefinition } from "carbon-components-svelte";
 
   let open = false;
 </script>

--- a/tests/TooltipIcon.test.svelte
+++ b/tests/TooltipIcon.test.svelte
@@ -26,7 +26,7 @@
 </TooltipIcon>
 
 <TooltipIcon>
-  <span slot="text" style="color: red"
+  <span slot="tooltipText" style="color: red"
     >Carbon is an open source design system by IBM.</span
   >
   <Carbon />

--- a/tests/TooltipIcon.test.svelte
+++ b/tests/TooltipIcon.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { TooltipIcon } from "../types";
+  import { TooltipIcon } from "carbon-components-svelte";
   import Carbon from "carbon-icons-svelte/lib/Carbon.svelte";
   import Filter from "carbon-icons-svelte/lib/Filter.svelte";
   import FilterReset from "carbon-icons-svelte/lib/FilterReset.svelte";

--- a/tests/TreeView.test.svelte
+++ b/tests/TreeView.test.svelte
@@ -6,8 +6,8 @@
 
   let treeview: TreeView;
   let activeId: TreeNodeId = "";
-  let selectedIds = [];
-  let expandedIds = [1];
+  let selectedIds: TreeNodeId[] = [];
+  let expandedIds: TreeNodeId[] = [1];
   let children: ComponentProps<TreeView>["children"] = [
     { id: 0, text: "AI / Machine learning", icon: Analytics },
     {
@@ -56,7 +56,7 @@
     });
     treeview.collapseAll();
     treeview.collapseNodes((node) => {
-      return node.disabled;
+      return node.disabled === true;
     });
     treeview.showNode(1);
   }

--- a/tests/TreeView.test.svelte
+++ b/tests/TreeView.test.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import type { ComponentProps } from "svelte";
-  import { TreeView } from "../types";
-  import type { TreeNodeId } from "../types/TreeView/TreeView.svelte";
+  import { TreeView } from "carbon-components-svelte";
+  import type { TreeNodeId } from "carbon-components-svelte/TreeView/TreeView.svelte";
   import Analytics from "carbon-icons-svelte/lib/Analytics.svelte";
 
   let treeview: TreeView;

--- a/tests/Truncate.test.svelte
+++ b/tests/Truncate.test.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
-  import { Truncate } from "../types";
-  import { truncate } from "../types";
+  import { Truncate, truncate } from "carbon-components-svelte";
 </script>
 
 <Truncate>

--- a/tests/UnorderedList.test.svelte
+++ b/tests/UnorderedList.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { UnorderedList, ListItem, Link } from "../types";
+  import { UnorderedList, ListItem, Link } from "carbon-components-svelte";
 </script>
 
 <UnorderedList>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,8 @@
       "target": "ESNext",
       "module": "ESNext",
       "moduleResolution": "node",
+      "noUnusedLocals": true,
+      "noUnusedParameters": true,
       "strict": true,
     },
     "include": ["src", "tests"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,10 @@
       "noUnusedLocals": true,
       "noUnusedParameters": true,
       "strict": true,
+      "paths": {
+        "carbon-components-svelte": ["./types"],
+        "carbon-components-svelte/*": ["./types/*"]
+      }
     },
     "include": ["src", "tests"]
   }


### PR DESCRIPTION
Currently, import paths in types tests use a relative path ("../types").

This maps the path to the library name (mirroring the exports map) to better simulate real usage.

It also:

- Upgrades `svelte-check` minor version to the latest (below Svelte 5)
- Increases strictness in tsconfig
- Fixes outstanding type errors in the type files