### PR TITLE
fix(data-table): move `ToolbarSearch` filtering to `DataTable` for Svelte 5 compatibility

### DIFF
--- a/src/DataTable/ToolbarSearch.svelte
+++ b/src/DataTable/ToolbarSearch.svelte
@@ -49,32 +49,10 @@
   import { tick, getContext } from "svelte";
   import Search from "../Search/Search.svelte";
 
-  const { tableRows } = getContext("DataTable") ?? {};
+  const ctx = getContext("DataTable") ?? {};
 
-  $: originalRows = tableRows ? [...$tableRows] : [];
   $: if (shouldFilterRows) {
-    let rows = originalRows;
-
-    if (value.trim().length > 0) {
-      if (shouldFilterRows === true) {
-        rows = rows.filter((row) => {
-          return Object.entries(row)
-            .filter(([key]) => key !== "id")
-            .some(([key, _value]) => {
-              if (typeof _value === "string" || typeof _value === "number") {
-                return (_value + "")
-                  ?.toLowerCase()
-                  .includes(value.trim().toLowerCase());
-              }
-            });
-        });
-      } else if (typeof shouldFilterRows === "function") {
-        rows = rows.filter((row) => shouldFilterRows(row, value) ?? false);
-      }
-    }
-
-    tableRows.set(rows);
-    filteredRowIds = rows.map((row) => row.id);
+    filteredRowIds = ctx?.filterRows(value, shouldFilterRows);
   }
 
   async function expandSearch() {


### PR DESCRIPTION
Fixes #2033 

Svelte 5 exposes a bug when using `DataTable` and `ToolbarSearch`. Initial filtering might work, but original rows are not reset.

The root cause is a reset loop caused by `ToolbarSearch`. It currently reads and writes `$tableRows`, which is the source of truth used by `DataTable`.

One of the constraints is for `filteredIds` to be bindable to `ToolbarSearch` (but not two-way reactivity). Beyond that, `ToolbarSearch` should not need to read the source `rows` or manipulate them directly.

The solution is to move the filtering logic to the parent `DataTable`. A copy of the original rows is set (unless `rows` changes). Filtering will then filter on a subset of the copy without modifying the source.