### PR TITLE
build(scripts): replace `glob` with `tinyglobby`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "sveld": "^0.21.0",
         "svelte": "^4.2.10",
         "svelte-check": "^3.8.6",
+        "tinyglobby": "^0.2.10",
         "typescript": "^5.6.3"
       }
     },
@@ -3342,12 +3343,12 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.6.tgz",
-      "integrity": "sha512-NbBoFBpqfcgd1tCiO8Lkfdk+xrA7mlLR9zgvZcZWQQwU63XAfUePyd6wZBaU93Hqw347lHnwFzttAkemHzzz4g==",
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.10.tgz",
+      "integrity": "sha512-Zc+8eJlFMvgatPZTl6A9L/yht8QqdmUNtURHaKZLmKBE12hNPSrqNkUp2cs3M/UKmNVVAMFQYSjYIVHDjW5zew==",
       "dev": true,
       "dependencies": {
-        "fdir": "^6.3.0",
+        "fdir": "^6.4.2",
         "picomatch": "^4.0.2"
       },
       "engines": {
@@ -3355,9 +3356,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/fdir": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.3.0.tgz",
-      "integrity": "sha512-QOnuT+BOtivR77wYvCWHfGt9s4Pz1VIMbD463vegT5MLqNXy8rYFT/lPVEqf/bhYeT6qmqrNHhsX+rWwe3rOCQ==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.2.tgz",
+      "integrity": "sha512-KnhMXsKSPZlAhp7+IjUkRZKPb4fUyccpDrdFXbi4QL1qkmFh9kVY09Yox+n4MaOb3lHZ1Tv829C3oaaXoMYPDQ==",
       "dev": true,
       "peerDependencies": {
         "picomatch": "^3 || ^4"

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "sveld": "^0.21.0",
     "svelte": "^4.2.10",
     "svelte-check": "^3.8.6",
+    "tinyglobby": "^0.2.10",
     "typescript": "^5.6.3"
   },
   "standard-version": {

--- a/scripts/build-docs.js
+++ b/scripts/build-docs.js
@@ -1,5 +1,5 @@
 const fs = require("node:fs");
-const glob = require("glob");
+const { globSync }= require("tinyglobby");
 const { sveld } = require("sveld");
 const pkg = require("../package.json");
 
@@ -21,7 +21,7 @@ sveld({
   },
 });
 
-glob.sync("./src/**/*.d.ts").forEach((file) => {
+globSync("./src/**/*.d.ts").forEach((file) => {
   console.log("Copying", file, " to types/");
   fs.copyFileSync(file, file.replace(/src/, "types"));
 });


### PR DESCRIPTION
Replace `glob` used in a build script with a lighter weight alternative (~26 deps down to 2 deps).

Unfortunately, other packages still have `glob` as a transitive, but this can be resolved once they are removed (e.g., #1995).