### PR TITLE
fix(checkbox): bind indeterminate for Svelte 5 compatibility

### DIFF
--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -458,10 +458,10 @@ None.
 | :------------ | :------- | :--------------- | :------- | ----------------------------------------- | ------------------------------------------------ | ------------------------------------------------- |
 | ref           | No       | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code> | <code>null</code>                                | Obtain a reference to the input HTML element      |
 | title         | No       | <code>let</code> | Yes      | <code>string</code>                       | <code>undefined</code>                           | Specify the title attribute for the label element |
+| indeterminate | No       | <code>let</code> | Yes      | <code>boolean</code>                      | <code>false</code>                               | Specify whether the checkbox is indeterminate     |
 | group         | No       | <code>let</code> | Yes      | <code>ReadonlyArray<any></code>           | <code>undefined</code>                           | Specify the bound group                           |
 | checked       | No       | <code>let</code> | Yes      | <code>boolean</code>                      | <code>false</code>                               | Specify whether the checkbox is checked           |
 | value         | No       | <code>let</code> | No       | <code>any</code>                          | <code>""</code>                                  | Specify the value of the checkbox                 |
-| indeterminate | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Specify whether the checkbox is indeterminate     |
 | skeleton      | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to display the skeleton state       |
 | required      | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` to mark the field as required       |
 | readonly      | No       | <code>let</code> | No       | <code>boolean</code>                      | <code>false</code>                               | Set to `true` for the checkbox to be read-only    |

--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -787,7 +787,7 @@
           "isFunctionDeclaration": false,
           "isRequired": false,
           "constant": false,
-          "reactive": false
+          "reactive": true
         },
         {
           "name": "skeleton",

--- a/src/Checkbox/Checkbox.svelte
+++ b/src/Checkbox/Checkbox.svelte
@@ -97,7 +97,7 @@
       checked="{checked}"
       disabled="{disabled}"
       id="{id}"
-      indeterminate="{indeterminate}"
+      bind:indeterminate
       name="{name}"
       required="{required}"
       readonly="{readonly}"


### PR DESCRIPTION
Fixes #2039

In Svelte 5, `<input indeterminate={indeterminate} />` does not update the value. Binding the variable seems to work.

Tested the following with Svelte 4 and Svelte 5. The difference now is that `indeterminate` is reactive (two-way).

```svelte
<script>
  import { Checkbox } from "carbon-components-svelte";

  let indeterminate = true;
</script>

<Checkbox labelText="Label text" bind:indeterminate />

<p>Indeterminate: {indeterminate}</p>

<button on:click={() => (indeterminate = !indeterminate)}>Toggle indeterminate</button>
```

---


https://github.com/user-attachments/assets/7814d0e7-2c92-4e7e-ad1d-981043a878b1

