### PR TITLE
fix(inline-checkbox): bind indeterminate for Svelte 5 compatibility

### DIFF
--- a/src/Checkbox/InlineCheckbox.svelte
+++ b/src/Checkbox/InlineCheckbox.svelte
@@ -24,7 +24,7 @@
     type="checkbox"
     class:bx--checkbox="{true}"
     checked="{indeterminate ? false : checked}"
-    indeterminate="{indeterminate}"
+    bind:indeterminate
     id="{id}"
     {...$$restProps}
     aria-checked="{indeterminate ? undefined : checked}"


### PR DESCRIPTION
Related #2044

`InlineCheckbox` is an internal component used by `DataTable` for batch selectable rows.

Bind `indeterminate` to the underlying input.