### PR TITLE
docs: move IBM analytics script to `_layout.svelte`

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -20,40 +20,6 @@
         }
       } catch (e) {}
     </script>
-
-    <!-- Tealium/GA Set up -->
-    <script type="text/javascript">
-      window._ibmAnalytics = {
-        settings: {
-          name: "CarbonSvelte",
-          isSpa: true,
-          tealiumProfileName: "ibm-web-app",
-        },
-        onLoad: [["ibmStats.pageview", []]],
-      };
-      digitalData = {
-        page: {
-          pageInfo: {
-            ibm: {
-              siteId: "IBM_" + _ibmAnalytics.settings.name,
-            },
-          },
-          category: {
-            primaryCategory: "PC100",
-          },
-        },
-      };
-    </script>
-    <script
-      type="module"
-      async
-      src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/footer.min.js"
-    ></script>
-    <script
-      src="//1.www.s81c.com/common/stats/ibm-common.js"
-      type="text/javascript"
-      async
-    ></script>
   </head>
   <body>
     <script type="module" src="/src/index.js"></script>

--- a/docs/src/pages/_layout.svelte
+++ b/docs/src/pages/_layout.svelte
@@ -111,13 +111,13 @@
   </script>
   <script
     type="module"
-    async
+    defer
     src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/footer.min.js"
   ></script>
   <script
     src="//1.www.s81c.com/common/stats/ibm-common.js"
     type="text/javascript"
-    async
+    defer
   ></script>
 </svelte:head>
 

--- a/docs/src/pages/_layout.svelte
+++ b/docs/src/pages/_layout.svelte
@@ -85,6 +85,42 @@
     }
   }}" />
 
+<svelte:head>
+  <!-- Tealium/GA Set up -->
+  <script type="text/javascript">
+    window._ibmAnalytics = {
+      settings: {
+        name: "CarbonSvelte",
+        isSpa: true,
+        tealiumProfileName: "ibm-web-app",
+      },
+      onLoad: [["ibmStats.pageview", []]],
+    };
+    digitalData = {
+      page: {
+        pageInfo: {
+          ibm: {
+            siteId: "IBM_" + _ibmAnalytics.settings.name,
+          },
+        },
+        category: {
+          primaryCategory: "PC100",
+        },
+      },
+    };
+  </script>
+  <script
+    type="module"
+    async
+    src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/footer.min.js"
+  ></script>
+  <script
+    src="//1.www.s81c.com/common/stats/ibm-common.js"
+    type="text/javascript"
+    async
+  ></script>
+</svelte:head>
+
 <Theme
   persist
   bind:theme="{$theme}"


### PR DESCRIPTION
Moves the script to the base app layout, meaning it should not be loaded or shown in isolated layouts (like `/framed/*` used for `iframe` examples).

Another small performance change is to use `defer` instead of `async` for script loading.

- async: load script asynchronously but execute once it's downloaded (regardless of HTML parsing)
- defer: load script asynchronously AND defer execution until HTML is parsed