### PR TITLE
fix(toolbar-menu): remove redundant menu offset for Svelte 5 compatibility

### DIFF
--- a/src/DataTable/ToolbarMenu.svelte
+++ b/src/DataTable/ToolbarMenu.svelte
@@ -5,12 +5,11 @@
   import Settings from "../icons/Settings.svelte";
   import OverflowMenu from "../OverflowMenu/OverflowMenu.svelte";
 
-  const ctx = getContext("Toolbar");
+  const ctx = getContext("Toolbar") ?? {};
 
   let menuRef = null;
 
-  $: ctx.setOverflowVisible(menuRef != null);
-  $: if (menuRef) menuRef.style.top = "100%";
+  $: ctx.setOverflowVisible?.(menuRef != null);
 </script>
 
 <OverflowMenu


### PR DESCRIPTION
Fixes #2040

The `$: if (menuRef) menuRef.style.top = "100%";` statement is causing an infinite update loop.

Setting `style` causes `menuRef` to update. Wrapped in a reactive statement, this produces an infinite update error in Svelte 5.

I looked up the Git blame for this line (#369). Historically, it seems this line was used for offsetting the menu position. However, `OverflowMenu` now manually handles this offset based on the button height, so this statement is redundant.