### PR TITLE
chore(deps-dev): upgrade `sveld` to v0.22

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "rollup-plugin-terser": "^7.0.2",
         "sass": "^1.49.11",
         "standard-version": "^9.5.0",
-        "sveld": "^0.21.0",
+        "sveld": "^0.22.0",
         "svelte": "^4.2.10",
         "svelte-check": "^4.0.6",
         "tinyglobby": "^0.2.10",
@@ -3003,15 +3003,15 @@
       }
     },
     "node_modules/sveld": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/sveld/-/sveld-0.21.0.tgz",
-      "integrity": "sha512-I1KPSTOBhEw9wOj6GsKH4w5Y8ZM0ymsWyhyXbJYdcBAuk1S21OPBOKc1IgMgbEUImXSEoF60L7soghfQz4gZQQ==",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/sveld/-/sveld-0.22.0.tgz",
+      "integrity": "sha512-oejfWV7//gqgyFDe09qyInaSKBYCjfJ2xTgZS8oWyYTmpy4Eyi4s0Rh9IJbSHxtlAjcmWpIGKiKwVb6cjxgtfw==",
       "dev": true,
       "dependencies": {
         "@rollup/plugin-node-resolve": "^13.3.0",
         "acorn": "^8.12.1",
         "comment-parser": "^1.4.1",
-        "prettier": "^2.8.8",
+        "prettier": "^3.3.3",
         "rollup": "^2.79.1",
         "rollup-plugin-svelte": "^7.2.2",
         "svelte": "^4.2.19",
@@ -3021,6 +3021,21 @@
       },
       "bin": {
         "sveld": "cli.js"
+      }
+    },
+    "node_modules/sveld/node_modules/prettier": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
+      "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/sveld/node_modules/svelte-preprocess": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "rollup-plugin-terser": "^7.0.2",
     "sass": "^1.49.11",
     "standard-version": "^9.5.0",
-    "sveld": "^0.21.0",
+    "sveld": "^0.22.0",
     "svelte": "^4.2.10",
     "svelte-check": "^4.0.6",
     "tinyglobby": "^0.2.10",

--- a/types/ComboBox/ComboBox.svelte.d.ts
+++ b/types/ComboBox/ComboBox.svelte.d.ts
@@ -120,7 +120,7 @@ type $Props = {
    * @default undefined
    */
   translateWithId?: (
-    id: import("../ListBox/ListBoxMenuIcon.svelte").ListBoxMenuIconTranslationId
+    id: import("../ListBox/ListBoxMenuIcon.svelte").ListBoxMenuIconTranslationId,
   ) => string;
 
   /**

--- a/types/DataTable/ToolbarSearch.svelte.d.ts
+++ b/types/DataTable/ToolbarSearch.svelte.d.ts
@@ -42,7 +42,7 @@ type $Props = {
     | boolean
     | ((
         row: import("./DataTable.svelte").DataTableRow,
-        value: number | string
+        value: number | string,
       ) => boolean);
 
   /**

--- a/types/Dropdown/Dropdown.svelte.d.ts
+++ b/types/Dropdown/Dropdown.svelte.d.ts
@@ -122,7 +122,7 @@ type $Props = {
    * @default undefined
    */
   translateWithId?: (
-    id: import("../ListBox/ListBoxMenuIcon.svelte").ListBoxMenuIconTranslationId
+    id: import("../ListBox/ListBoxMenuIcon.svelte").ListBoxMenuIconTranslationId,
   ) => string;
 
   /**

--- a/types/MultiSelect/MultiSelect.svelte.d.ts
+++ b/types/MultiSelect/MultiSelect.svelte.d.ts
@@ -131,7 +131,7 @@ type $Props = {
    * @default undefined
    */
   translateWithId?: (
-    id: import("../ListBox/ListBoxMenuIcon.svelte").ListBoxMenuIconTranslationId
+    id: import("../ListBox/ListBoxMenuIcon.svelte").ListBoxMenuIconTranslationId,
   ) => string;
 
   /**
@@ -140,7 +140,7 @@ type $Props = {
    * @default undefined
    */
   translateWithIdSelection?: (
-    id: import("../ListBox/ListBoxSelection.svelte").ListBoxSelectionTranslationId
+    id: import("../ListBox/ListBoxSelection.svelte").ListBoxSelectionTranslationId,
   ) => string;
 
   /**


### PR DESCRIPTION
Upgrades `sveld` to v0.22, which upgrades Prettier to v3. By default, trailing commas are enabled.