### PR TITLE
docs: set `loading="lazy"` on iframes

### DIFF
--- a/docs/src/components/Preview.svelte
+++ b/docs/src/components/Preview.svelte
@@ -35,7 +35,7 @@
   {/if}
   <div class="preview-viewer" class:framed>
     {#if framed}
-      <iframe title={src.split("/").pop()} src={themedSrcUrl}></iframe>
+      <iframe loading="lazy" title={src.split("/").pop()} src={themedSrcUrl}></iframe>
     {:else}
       <slot />
     {/if}


### PR DESCRIPTION
Many docs examples are loaded via iframe. This is particularly so for DataTable.

Set [`loading="lazy"`](https://web.dev/articles/iframe-lazy-loading) on the iframe so that supported browsers defer loading (i.e., until the iframe is in the viewport).