### PR TITLE
docs: avoid code formatting on client-side

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -33,9 +33,15 @@
         "flatpickr": "4.6.9"
       },
       "devDependencies": {
+        "@sveltejs/vite-plugin-svelte": "^3.1.2",
+        "@testing-library/jest-dom": "^6.6.3",
+        "@testing-library/svelte": "^5.2.6",
+        "@testing-library/user-event": "^14.5.2",
         "autoprefixer": "^10.4.8",
         "carbon-components": "10.58.12",
         "carbon-icons-svelte": "^12.1.0",
+        "carbon-preprocess-svelte": "^0.11.7",
+        "jsdom": "^25.0.1",
         "postcss": "^8.4.16",
         "prettier": "^3.3.3",
         "prettier-plugin-svelte": "^3.2.8",
@@ -45,7 +51,8 @@
         "svelte": "^4.2.10",
         "svelte-check": "^4.0.6",
         "tinyglobby": "^0.2.10",
-        "typescript": "^5.6.3"
+        "typescript": "^5.6.3",
+        "vitest": "^2.1.5"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -54,7 +54,13 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "{}"
+        }
+      ],
       "events": [
         {
           "type": "forwarded",
@@ -79,7 +85,10 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "InlineComponent", "name": "AccordionSkeleton" },
+      "rest_props": {
+        "type": "InlineComponent",
+        "name": "AccordionSkeleton"
+      },
       "extends": {
         "interface": "AccordionSkeletonProps",
         "import": "\"./AccordionSkeleton.svelte\""
@@ -140,7 +149,11 @@
       ],
       "moduleExports": [],
       "slots": [
-        { "name": "__default__", "default": true, "slot_props": "{}" },
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "{}"
+        },
         {
           "name": "title",
           "default": false,
@@ -149,16 +162,43 @@
         }
       ],
       "events": [
-        { "type": "forwarded", "name": "animationend", "element": "li" },
-        { "type": "forwarded", "name": "click", "element": "button" },
-        { "type": "forwarded", "name": "mouseover", "element": "button" },
-        { "type": "forwarded", "name": "mouseenter", "element": "button" },
-        { "type": "forwarded", "name": "mouseleave", "element": "button" },
-        { "type": "forwarded", "name": "keydown", "element": "button" }
+        {
+          "type": "forwarded",
+          "name": "animationend",
+          "element": "li"
+        },
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "button"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseover",
+          "element": "button"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "button"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "button"
+        },
+        {
+          "type": "forwarded",
+          "name": "keydown",
+          "element": "button"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "li" }
+      "rest_props": {
+        "type": "Element",
+        "name": "li"
+      }
     },
     {
       "moduleName": "AccordionSkeleton",
@@ -215,14 +255,33 @@
       "moduleExports": [],
       "slots": [],
       "events": [
-        { "type": "forwarded", "name": "click", "element": "ul" },
-        { "type": "forwarded", "name": "mouseover", "element": "ul" },
-        { "type": "forwarded", "name": "mouseenter", "element": "ul" },
-        { "type": "forwarded", "name": "mouseleave", "element": "ul" }
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "ul"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseover",
+          "element": "ul"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "ul"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "ul"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "ul" }
+      "rest_props": {
+        "type": "Element",
+        "name": "ul"
+      }
     },
     {
       "moduleName": "AspectRatio",
@@ -242,11 +301,20 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "{}"
+        }
+      ],
       "events": [],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": {
+        "type": "Element",
+        "name": "div"
+      }
     },
     {
       "moduleName": "Breadcrumb",
@@ -278,7 +346,13 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "{}"
+        }
+      ],
       "events": [
         {
           "type": "forwarded",
@@ -303,7 +377,10 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "InlineComponent", "name": "BreadcrumbSkeleton" },
+      "rest_props": {
+        "type": "InlineComponent",
+        "name": "BreadcrumbSkeleton"
+      },
       "extends": {
         "interface": "BreadcrumbSkeletonProps",
         "import": "\"./BreadcrumbSkeleton.svelte\""
@@ -342,18 +419,37 @@
         {
           "name": "__default__",
           "default": true,
-          "slot_props": "{props?: { [\"aria-current\"]?: string; class: \"bx--link\"; }}"
+          "slot_props": "{ props?: { [\"aria-current\"]?: string; class: \"bx--link\" } }"
         }
       ],
       "events": [
-        { "type": "forwarded", "name": "click", "element": "li" },
-        { "type": "forwarded", "name": "mouseover", "element": "li" },
-        { "type": "forwarded", "name": "mouseenter", "element": "li" },
-        { "type": "forwarded", "name": "mouseleave", "element": "li" }
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "li"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseover",
+          "element": "li"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "li"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "li"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "li" }
+      "rest_props": {
+        "type": "Element",
+        "name": "li"
+      }
     },
     {
       "moduleName": "BreadcrumbSkeleton",
@@ -387,14 +483,33 @@
       "moduleExports": [],
       "slots": [],
       "events": [
-        { "type": "forwarded", "name": "click", "element": "div" },
-        { "type": "forwarded", "name": "mouseover", "element": "div" },
-        { "type": "forwarded", "name": "mouseenter", "element": "div" },
-        { "type": "forwarded", "name": "mouseleave", "element": "div" }
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseover",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "div"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": {
+        "type": "Element",
+        "name": "div"
+      }
     },
     {
       "moduleName": "Breakpoint",
@@ -416,7 +531,7 @@
           "kind": "let",
           "description": "Carbon grid sizes as an object",
           "type": "Record<BreakpointSize, boolean>",
-          "value": "{     sm: false,     md: false,     lg: false,     xlg: false,     max: false,   }",
+          "value": "{ sm: false, md: false, lg: false, xlg: false, max: false }",
           "isFunction": false,
           "isFunctionDeclaration": false,
           "isRequired": false,
@@ -429,26 +544,26 @@
         {
           "name": "__default__",
           "default": true,
-          "slot_props": "{ size: BreakpointSize; sizes: Record<BreakpointSize, boolean>; }"
+          "slot_props": "{\n  size: BreakpointSize;\n  sizes: Record<BreakpointSize, boolean>;\n}"
         }
       ],
       "events": [
         {
           "type": "dispatched",
           "name": "change",
-          "detail": "{ size: BreakpointSize; breakpointValue: BreakpointValue; }"
+          "detail": "{ size: BreakpointSize; breakpointValue: BreakpointValue }"
         }
       ],
       "typedefs": [
         {
           "type": "\"sm\" | \"md\" | \"lg\" | \"xlg\" | \"max\"",
           "name": "BreakpointSize",
-          "ts": "type BreakpointSize = \"sm\" | \"md\" | \"lg\" | \"xlg\" | \"max\""
+          "ts": "type BreakpointSize = \"sm\" | \"md\" | \"lg\" | \"xlg\" | \"max\";\n"
         },
         {
           "type": "320 | 672 | 1056 | 1312 | 1584",
           "name": "BreakpointValue",
-          "ts": "type BreakpointValue = 320 | 672 | 1056 | 1312 | 1584"
+          "ts": "type BreakpointValue = 320 | 672 | 1056 | 1312 | 1584;\n"
         }
       ],
       "generics": null
@@ -640,14 +755,30 @@
         {
           "name": "__default__",
           "default": true,
-          "slot_props": "{ props: { role: \"button\"; type?: string; tabindex: any; disabled: boolean; href?: string; class: string; [key: string]: any; } }"
+          "slot_props": "{\n  props: {\n    role: \"button\";\n    type?: string;\n    tabindex: any;\n    disabled: boolean;\n    href?: string;\n    class: string;\n    [key: string]: any;\n  };\n}"
         },
-        { "name": "icon", "default": false, "slot_props": "{}" }
+        {
+          "name": "icon",
+          "default": false,
+          "slot_props": "{}"
+        }
       ],
       "events": [
-        { "type": "forwarded", "name": "click", "element": "ButtonSkeleton" },
-        { "type": "forwarded", "name": "focus", "element": "ButtonSkeleton" },
-        { "type": "forwarded", "name": "blur", "element": "ButtonSkeleton" },
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "ButtonSkeleton"
+        },
+        {
+          "type": "forwarded",
+          "name": "focus",
+          "element": "ButtonSkeleton"
+        },
+        {
+          "type": "forwarded",
+          "name": "blur",
+          "element": "ButtonSkeleton"
+        },
         {
           "type": "forwarded",
           "name": "mouseover",
@@ -666,7 +797,10 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "button | a | div" },
+      "rest_props": {
+        "type": "Element",
+        "name": "button | a | div"
+      },
       "extends": {
         "interface": "ButtonSkeletonProps",
         "import": "\"./ButtonSkeleton.svelte\""
@@ -690,11 +824,20 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "{}"
+        }
+      ],
       "events": [],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": {
+        "type": "Element",
+        "name": "div"
+      }
     },
     {
       "moduleName": "ButtonSkeleton",
@@ -727,16 +870,43 @@
       "moduleExports": [],
       "slots": [],
       "events": [
-        { "type": "forwarded", "name": "click", "element": "a" },
-        { "type": "forwarded", "name": "focus", "element": "a" },
-        { "type": "forwarded", "name": "blur", "element": "a" },
-        { "type": "forwarded", "name": "mouseover", "element": "a" },
-        { "type": "forwarded", "name": "mouseenter", "element": "a" },
-        { "type": "forwarded", "name": "mouseleave", "element": "a" }
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "a"
+        },
+        {
+          "type": "forwarded",
+          "name": "focus",
+          "element": "a"
+        },
+        {
+          "type": "forwarded",
+          "name": "blur",
+          "element": "a"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseover",
+          "element": "a"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "a"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "a"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "a" }
+      "rest_props": {
+        "type": "Element",
+        "name": "a"
+      }
     },
     {
       "moduleName": "Checkbox",
@@ -919,8 +1089,16 @@
         }
       ],
       "events": [
-        { "type": "dispatched", "name": "check", "detail": "boolean" },
-        { "type": "forwarded", "name": "click", "element": "CheckboxSkeleton" },
+        {
+          "type": "dispatched",
+          "name": "check",
+          "detail": "boolean"
+        },
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "CheckboxSkeleton"
+        },
         {
           "type": "forwarded",
           "name": "mouseover",
@@ -936,13 +1114,28 @@
           "name": "mouseleave",
           "element": "CheckboxSkeleton"
         },
-        { "type": "forwarded", "name": "change", "element": "input" },
-        { "type": "forwarded", "name": "focus", "element": "input" },
-        { "type": "forwarded", "name": "blur", "element": "input" }
+        {
+          "type": "forwarded",
+          "name": "change",
+          "element": "input"
+        },
+        {
+          "type": "forwarded",
+          "name": "focus",
+          "element": "input"
+        },
+        {
+          "type": "forwarded",
+          "name": "blur",
+          "element": "input"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": {
+        "type": "Element",
+        "name": "div"
+      }
     },
     {
       "moduleName": "CheckboxSkeleton",
@@ -951,14 +1144,33 @@
       "moduleExports": [],
       "slots": [],
       "events": [
-        { "type": "forwarded", "name": "click", "element": "div" },
-        { "type": "forwarded", "name": "mouseover", "element": "div" },
-        { "type": "forwarded", "name": "mouseenter", "element": "div" },
-        { "type": "forwarded", "name": "mouseleave", "element": "div" }
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseover",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "div"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": {
+        "type": "Element",
+        "name": "div"
+      }
     },
     {
       "moduleName": "ClickableTile",
@@ -1013,17 +1225,46 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "{}"
+        }
+      ],
       "events": [
-        { "type": "forwarded", "name": "click", "element": "Link" },
-        { "type": "forwarded", "name": "keydown", "element": "Link" },
-        { "type": "forwarded", "name": "mouseover", "element": "Link" },
-        { "type": "forwarded", "name": "mouseenter", "element": "Link" },
-        { "type": "forwarded", "name": "mouseleave", "element": "Link" }
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "Link"
+        },
+        {
+          "type": "forwarded",
+          "name": "keydown",
+          "element": "Link"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseover",
+          "element": "Link"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "Link"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "Link"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "a | p" }
+      "rest_props": {
+        "type": "Element",
+        "name": "a | p"
+      }
     },
     {
       "moduleName": "CodeSnippet",
@@ -1057,7 +1298,7 @@
           "kind": "let",
           "description": "By default, this component uses `navigator.clipboard.writeText` API to copy text to the user's clipboard.\n\nProvide a custom function to override this behavior.",
           "type": "(code: string) => void",
-          "value": "async (code) => {     try {       await navigator.clipboard.writeText(code);     } catch (e) {       console.log(e);     }   }",
+          "value": "async (code) => {\n  try {\n    await navigator.clipboard.writeText(code);\n  } catch (e) {\n    console.log(e);\n  }\n}",
           "isFunction": true,
           "isFunctionDeclaration": false,
           "isRequired": false,
@@ -1253,9 +1494,21 @@
         }
       ],
       "events": [
-        { "type": "dispatched", "name": "expand", "detail": "null" },
-        { "type": "dispatched", "name": "collapse", "detail": "null" },
-        { "type": "dispatched", "name": "copy", "detail": "null" },
+        {
+          "type": "dispatched",
+          "name": "expand",
+          "detail": "null"
+        },
+        {
+          "type": "dispatched",
+          "name": "collapse",
+          "detail": "null"
+        },
+        {
+          "type": "dispatched",
+          "name": "copy",
+          "detail": "null"
+        },
         {
           "type": "forwarded",
           "name": "click",
@@ -1276,11 +1529,18 @@
           "name": "mouseleave",
           "element": "CodeSnippetSkeleton"
         },
-        { "type": "forwarded", "name": "animationend", "element": "CopyButton" }
+        {
+          "type": "forwarded",
+          "name": "animationend",
+          "element": "CopyButton"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "InlineComponent", "name": "CodeSnippetSkeleton" }
+      "rest_props": {
+        "type": "InlineComponent",
+        "name": "CodeSnippetSkeleton"
+      }
     },
     {
       "moduleName": "CodeSnippetSkeleton",
@@ -1302,14 +1562,33 @@
       "moduleExports": [],
       "slots": [],
       "events": [
-        { "type": "forwarded", "name": "click", "element": "div" },
-        { "type": "forwarded", "name": "mouseover", "element": "div" },
-        { "type": "forwarded", "name": "mouseenter", "element": "div" },
-        { "type": "forwarded", "name": "mouseleave", "element": "div" }
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseover",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "div"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": {
+        "type": "Element",
+        "name": "div"
+      }
     },
     {
       "moduleName": "Column",
@@ -1447,7 +1726,7 @@
         {
           "name": "__default__",
           "default": true,
-          "slot_props": "{props: { class: string; [key: string]: any; }}"
+          "slot_props": "{ props: { class: string; [key: string]: any } }"
         }
       ],
       "events": [],
@@ -1455,21 +1734,24 @@
         {
           "type": "boolean | number",
           "name": "ColumnSize",
-          "ts": "type ColumnSize = boolean | number"
+          "ts": "type ColumnSize = boolean | number;\n"
         },
         {
           "type": "{span?: ColumnSize; offset: number;}",
           "name": "ColumnSizeDescriptor",
-          "ts": "interface ColumnSizeDescriptor {span?: ColumnSize; offset: number;}"
+          "ts": "interface ColumnSizeDescriptor {\n  span?: ColumnSize;\n  offset: number;\n}\n"
         },
         {
           "type": "ColumnSize | ColumnSizeDescriptor",
           "name": "ColumnBreakpoint",
-          "ts": "type ColumnBreakpoint = ColumnSize | ColumnSizeDescriptor"
+          "ts": "type ColumnBreakpoint = ColumnSize | ColumnSizeDescriptor;\n"
         }
       ],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": {
+        "type": "Element",
+        "name": "div"
+      }
     },
     {
       "moduleName": "ComboBox",
@@ -1751,7 +2033,7 @@
           "kind": "function",
           "description": "Clear the combo box programmatically",
           "type": "(options?: { focus?: boolean; }) => void",
-          "value": "() => {     prevSelectedId = null;     highlightedIndex = -1;     highlightedId = undefined;     selectedId = undefined;     selectedItem = undefined;     open = false;     value = \"\";     if (options?.focus !== false) ref?.focus();   }",
+          "value": "() => {\n  prevSelectedId = null;\n  highlightedIndex = -1;\n  highlightedId = undefined;\n  selectedId = undefined;\n  selectedItem = undefined;\n  open = false;\n  value = \"\";\n  if (options?.focus !== false) ref?.focus();\n}",
           "isFunction": true,
           "isFunctionDeclaration": true,
           "isRequired": false,
@@ -1785,27 +2067,54 @@
           "name": "clear",
           "detail": "KeyboardEvent | MouseEvent"
         },
-        { "type": "forwarded", "name": "keydown", "element": "input" },
-        { "type": "forwarded", "name": "keyup", "element": "input" },
-        { "type": "forwarded", "name": "focus", "element": "input" },
-        { "type": "forwarded", "name": "blur", "element": "input" },
-        { "type": "forwarded", "name": "paste", "element": "input" },
-        { "type": "forwarded", "name": "scroll", "element": "ListBoxMenu" }
+        {
+          "type": "forwarded",
+          "name": "keydown",
+          "element": "input"
+        },
+        {
+          "type": "forwarded",
+          "name": "keyup",
+          "element": "input"
+        },
+        {
+          "type": "forwarded",
+          "name": "focus",
+          "element": "input"
+        },
+        {
+          "type": "forwarded",
+          "name": "blur",
+          "element": "input"
+        },
+        {
+          "type": "forwarded",
+          "name": "paste",
+          "element": "input"
+        },
+        {
+          "type": "forwarded",
+          "name": "scroll",
+          "element": "ListBoxMenu"
+        }
       ],
       "typedefs": [
         {
           "type": "any",
           "name": "ComboBoxItemId",
-          "ts": "type ComboBoxItemId = any"
+          "ts": "type ComboBoxItemId = any;\n"
         },
         {
           "type": "{ id: ComboBoxItemId; text: string; disabled?: boolean; }",
           "name": "ComboBoxItem",
-          "ts": "interface ComboBoxItem { id: ComboBoxItemId; text: string; disabled?: boolean; }"
+          "ts": "interface ComboBoxItem {\n  id: ComboBoxItemId;\n  text: string;\n  disabled?: boolean;\n}\n"
         }
       ],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "input" }
+      "rest_props": {
+        "type": "Element",
+        "name": "input"
+      }
     },
     {
       "moduleName": "ComposedModal",
@@ -1896,30 +2205,71 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "{}"
+        }
+      ],
       "events": [
         {
           "type": "dispatched",
           "name": "transitionend",
-          "detail": "{ open: boolean; }"
+          "detail": "{ open: boolean }"
         },
-        { "type": "forwarded", "name": "keydown", "element": "div" },
-        { "type": "forwarded", "name": "click", "element": "div" },
-        { "type": "forwarded", "name": "mouseover", "element": "div" },
-        { "type": "forwarded", "name": "mouseenter", "element": "div" },
-        { "type": "forwarded", "name": "mouseleave", "element": "div" },
-        { "type": "dispatched", "name": "submit", "detail": "null" },
+        {
+          "type": "forwarded",
+          "name": "keydown",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseover",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "div"
+        },
+        {
+          "type": "dispatched",
+          "name": "submit",
+          "detail": "null"
+        },
         {
           "type": "dispatched",
           "name": "click:button--primary",
           "detail": "null"
         },
-        { "type": "dispatched", "name": "close", "detail": "null" },
-        { "type": "dispatched", "name": "open", "detail": "null" }
+        {
+          "type": "dispatched",
+          "name": "close",
+          "detail": "null"
+        },
+        {
+          "type": "dispatched",
+          "name": "open",
+          "detail": "null"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": {
+        "type": "Element",
+        "name": "div"
+      }
     },
     {
       "moduleName": "Content",
@@ -1939,11 +2289,20 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "{}"
+        }
+      ],
       "events": [],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "main" }
+      "rest_props": {
+        "type": "Element",
+        "name": "main"
+      }
     },
     {
       "moduleName": "ContentSwitcher",
@@ -1974,17 +2333,46 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "{}"
+        }
+      ],
       "events": [
-        { "type": "dispatched", "name": "change", "detail": "number" },
-        { "type": "forwarded", "name": "click", "element": "div" },
-        { "type": "forwarded", "name": "mouseover", "element": "div" },
-        { "type": "forwarded", "name": "mouseenter", "element": "div" },
-        { "type": "forwarded", "name": "mouseleave", "element": "div" }
+        {
+          "type": "dispatched",
+          "name": "change",
+          "detail": "number"
+        },
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseover",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "div"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": {
+        "type": "Element",
+        "name": "div"
+      }
     },
     {
       "moduleName": "ContextMenu",
@@ -2052,16 +2440,41 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "{}"
+        }
+      ],
       "events": [
-        { "type": "dispatched", "name": "open", "detail": "HTMLElement" },
-        { "type": "forwarded", "name": "click", "element": "ul" },
-        { "type": "forwarded", "name": "keydown", "element": "ul" },
-        { "type": "dispatched", "name": "close", "detail": "null" }
+        {
+          "type": "dispatched",
+          "name": "open",
+          "detail": "HTMLElement"
+        },
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "ul"
+        },
+        {
+          "type": "forwarded",
+          "name": "keydown",
+          "element": "ul"
+        },
+        {
+          "type": "dispatched",
+          "name": "close",
+          "detail": "null"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "ul" }
+      "rest_props": {
+        "type": "Element",
+        "name": "ul"
+      }
     },
     {
       "moduleName": "ContextMenuDivider",
@@ -2102,7 +2515,13 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "{}"
+        }
+      ],
       "events": [],
       "typedefs": [],
       "generics": null
@@ -2233,7 +2652,11 @@
       ],
       "moduleExports": [],
       "slots": [
-        { "name": "__default__", "default": true, "slot_props": "{}" },
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "{}"
+        },
         {
           "name": "icon",
           "default": false,
@@ -2254,14 +2677,33 @@
         }
       ],
       "events": [
-        { "type": "forwarded", "name": "keydown", "element": "li" },
-        { "type": "forwarded", "name": "mouseenter", "element": "li" },
-        { "type": "forwarded", "name": "mouseleave", "element": "li" },
-        { "type": "dispatched", "name": "click", "detail": "null" }
+        {
+          "type": "forwarded",
+          "name": "keydown",
+          "element": "li"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "li"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "li"
+        },
+        {
+          "type": "dispatched",
+          "name": "click",
+          "detail": "null"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "li" }
+      "rest_props": {
+        "type": "Element",
+        "name": "li"
+      }
     },
     {
       "moduleName": "ContextMenuRadioGroup",
@@ -2293,7 +2735,13 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "{}"
+        }
+      ],
       "events": [],
       "typedefs": [],
       "generics": null
@@ -2354,7 +2802,7 @@
           "kind": "let",
           "description": "Override the default copy behavior of using the navigator.clipboard.writeText API to copy text",
           "type": "(text: string) => void",
-          "value": "async (text) => {     try {       await navigator.clipboard.writeText(text);     } catch (e) {       console.log(e);     }   }",
+          "value": "async (text) => {\n  try {\n    await navigator.clipboard.writeText(text);\n  } catch (e) {\n    console.log(e);\n  }\n}",
           "isFunction": true,
           "isFunctionDeclaration": false,
           "isRequired": false,
@@ -2365,13 +2813,28 @@
       "moduleExports": [],
       "slots": [],
       "events": [
-        { "type": "forwarded", "name": "click", "element": "button" },
-        { "type": "forwarded", "name": "animationend", "element": "button" },
-        { "type": "dispatched", "name": "copy", "detail": "null" }
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "button"
+        },
+        {
+          "type": "forwarded",
+          "name": "animationend",
+          "element": "button"
+        },
+        {
+          "type": "dispatched",
+          "name": "copy",
+          "detail": "null"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "button" }
+      "rest_props": {
+        "type": "Element",
+        "name": "button"
+      }
     },
     {
       "moduleName": "DataTable",
@@ -2643,18 +3106,22 @@
       ],
       "moduleExports": [],
       "slots": [
-        { "name": "__default__", "default": true, "slot_props": "{}" },
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "{}"
+        },
         {
           "name": "cell",
           "default": false,
           "fallback": "{cell.display ? cell.display(cell.value, row) : cell.value}",
-          "slot_props": "{ row: Row; cell: DataTableCell<Row>; rowIndex: number; cellIndex: number; }"
+          "slot_props": "{\n  row: Row;\n  cell: DataTableCell<Row>;\n  rowIndex: number;\n  cellIndex: number;\n}"
         },
         {
           "name": "cell-header",
           "default": false,
           "fallback": "{header.value}",
-          "slot_props": "{ header: DataTableNonEmptyHeader; }"
+          "slot_props": "{ header: DataTableNonEmptyHeader }"
         },
         {
           "name": "description",
@@ -2665,7 +3132,7 @@
         {
           "name": "expanded-row",
           "default": false,
-          "slot_props": "{ row: Row; }"
+          "slot_props": "{ row: Row }"
         },
         {
           "name": "title",
@@ -2678,35 +3145,47 @@
         {
           "type": "dispatched",
           "name": "click",
-          "detail": "{ header?: DataTableHeader<Row>; row?: Row; cell?: DataTableCell<Row>; }"
+          "detail": "{\n  header?: DataTableHeader<Row>;\n  row?: Row;\n  cell?: DataTableCell<Row>;\n}"
         },
         {
           "type": "dispatched",
           "name": "click:header--expand",
-          "detail": "{ expanded: boolean; }"
+          "detail": "{ expanded: boolean }"
         },
         {
           "type": "dispatched",
           "name": "click:header",
-          "detail": "{ header: DataTableHeader<Row>; sortDirection?: \"ascending\" | \"descending\" | \"none\" }"
+          "detail": "{\n  header: DataTableHeader<Row>;\n  sortDirection?: \"ascending\" | \"descending\" | \"none\";\n}"
         },
         {
           "type": "dispatched",
           "name": "click:header--select",
-          "detail": "{ indeterminate: boolean; selected: boolean; }"
+          "detail": "{ indeterminate: boolean; selected: boolean }"
         },
-        { "type": "dispatched", "name": "click:row", "detail": "Row" },
-        { "type": "dispatched", "name": "mouseenter:row", "detail": "Row" },
-        { "type": "dispatched", "name": "mouseleave:row", "detail": "Row" },
+        {
+          "type": "dispatched",
+          "name": "click:row",
+          "detail": "Row"
+        },
+        {
+          "type": "dispatched",
+          "name": "mouseenter:row",
+          "detail": "Row"
+        },
+        {
+          "type": "dispatched",
+          "name": "mouseleave:row",
+          "detail": "Row"
+        },
         {
           "type": "dispatched",
           "name": "click:row--expand",
-          "detail": "{ expanded: boolean; row: Row; }"
+          "detail": "{ expanded: boolean; row: Row }"
         },
         {
           "type": "dispatched",
           "name": "click:row--select",
-          "detail": "{ selected: boolean; row: Row; }"
+          "detail": "{ selected: boolean; row: Row }"
         },
         {
           "type": "dispatched",
@@ -2718,46 +3197,49 @@
         {
           "type": "import('./DataTableTypes.d.ts').PropertyPath<Row>",
           "name": "DataTableKey<Row=DataTableRow>",
-          "ts": "type DataTableKey<Row=DataTableRow> = import('./DataTableTypes.d.ts').PropertyPath<Row>"
+          "ts": "type DataTableKey<Row = DataTableRow> =\n  import(\"./DataTableTypes.d.ts\").PropertyPath<Row>;\n"
         },
         {
           "type": "any",
           "name": "DataTableValue",
-          "ts": "type DataTableValue = any"
+          "ts": "type DataTableValue = any;\n"
         },
         {
           "type": "{\n   key: DataTableKey<Row> | (string & {});\n   empty: boolean;\n   display?: (item: DataTableValue, row: Row) => DataTableValue;\n   sort?: false | ((a: DataTableValue, b: DataTableValue) => number);\n   columnMenu?: boolean;\n   width?: string;\n   minWidth?: string;\n}",
           "name": "DataTableEmptyHeader<Row=DataTableRow>",
-          "ts": "interface DataTableEmptyHeader<Row=DataTableRow> {\n   key: DataTableKey<Row> | (string & {});\n   empty: boolean;\n   display?: (item: DataTableValue, row: Row) => DataTableValue;\n   sort?: false | ((a: DataTableValue, b: DataTableValue) => number);\n   columnMenu?: boolean;\n   width?: string;\n   minWidth?: string;\n}"
+          "ts": "interface DataTableEmptyHeader<Row = DataTableRow> {\n  key: DataTableKey<Row> | (string & {});\n  empty: boolean;\n  display?: (item: DataTableValue, row: Row) => DataTableValue;\n  sort?: false | ((a: DataTableValue, b: DataTableValue) => number);\n  columnMenu?: boolean;\n  width?: string;\n  minWidth?: string;\n}\n"
         },
         {
           "type": "{\n   key: DataTableKey<Row>;\n   value: DataTableValue;\n   display?: (item: DataTableValue, row: Row) => DataTableValue;\n   sort?: false | ((a: DataTableValue, b: DataTableValue) => number);\n   columnMenu?: boolean;\n   width?: string;\n   minWidth?: string;\n}",
           "name": "DataTableNonEmptyHeader<Row=DataTableRow>",
-          "ts": "interface DataTableNonEmptyHeader<Row=DataTableRow> {\n   key: DataTableKey<Row>;\n   value: DataTableValue;\n   display?: (item: DataTableValue, row: Row) => DataTableValue;\n   sort?: false | ((a: DataTableValue, b: DataTableValue) => number);\n   columnMenu?: boolean;\n   width?: string;\n   minWidth?: string;\n}"
+          "ts": "interface DataTableNonEmptyHeader<Row = DataTableRow> {\n  key: DataTableKey<Row>;\n  value: DataTableValue;\n  display?: (item: DataTableValue, row: Row) => DataTableValue;\n  sort?: false | ((a: DataTableValue, b: DataTableValue) => number);\n  columnMenu?: boolean;\n  width?: string;\n  minWidth?: string;\n}\n"
         },
         {
           "type": "DataTableNonEmptyHeader<Row> | DataTableEmptyHeader<Row>",
           "name": "DataTableHeader<Row=DataTableRow>",
-          "ts": "type DataTableHeader<Row=DataTableRow> = DataTableNonEmptyHeader<Row> | DataTableEmptyHeader<Row>"
+          "ts": "type DataTableHeader<Row = DataTableRow> =\n  | DataTableNonEmptyHeader<Row>\n  | DataTableEmptyHeader<Row>;\n"
         },
         {
           "type": "{ id: any; [key: string]: DataTableValue; }",
           "name": "DataTableRow",
-          "ts": "interface DataTableRow { id: any; [key: string]: DataTableValue; }"
+          "ts": "interface DataTableRow {\n  id: any;\n  [key: string]: DataTableValue;\n}\n"
         },
         {
           "type": "any",
           "name": "DataTableRowId",
-          "ts": "type DataTableRowId = any"
+          "ts": "type DataTableRowId = any;\n"
         },
         {
           "type": "{\n   key: DataTableKey<Row> | (string & {});\n   value: DataTableValue;\n   display?: (item: DataTableValue, row: DataTableRow) => DataTableValue;\n}",
           "name": "DataTableCell<Row=DataTableRow>",
-          "ts": "interface DataTableCell<Row=DataTableRow> {\n   key: DataTableKey<Row> | (string & {});\n   value: DataTableValue;\n   display?: (item: DataTableValue, row: DataTableRow) => DataTableValue;\n}"
+          "ts": "interface DataTableCell<Row = DataTableRow> {\n  key: DataTableKey<Row> | (string & {});\n  value: DataTableValue;\n  display?: (item: DataTableValue, row: DataTableRow) => DataTableValue;\n}\n"
         }
       ],
       "generics": ["Row", "Row extends DataTableRow = DataTableRow"],
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": {
+        "type": "Element",
+        "name": "div"
+      }
     },
     {
       "moduleName": "DataTableSkeleton",
@@ -2850,14 +3332,33 @@
       "moduleExports": [],
       "slots": [],
       "events": [
-        { "type": "forwarded", "name": "click", "element": "table" },
-        { "type": "forwarded", "name": "mouseover", "element": "table" },
-        { "type": "forwarded", "name": "mouseenter", "element": "table" },
-        { "type": "forwarded", "name": "mouseleave", "element": "table" }
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "table"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseover",
+          "element": "table"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "table"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "table"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" },
+      "rest_props": {
+        "type": "Element",
+        "name": "div"
+      },
       "extends": {
         "interface": "DataTableHeader",
         "import": "\"./DataTable.svelte\""
@@ -3013,21 +3514,46 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "{}"
+        }
+      ],
       "events": [
         {
           "type": "dispatched",
           "name": "change",
-          "detail": "string | { selectedDates: [dateFrom: Date, dateTo?: Date]; dateStr: string | { from: string; to: string; } }"
+          "detail": "type EventDetail =\n  | string\n  | {\n      selectedDates: [dateFrom: Date, dateTo?: Date];\n      dateStr: string | { from: string; to: string };\n    }"
         },
-        { "type": "forwarded", "name": "click", "element": "div" },
-        { "type": "forwarded", "name": "mouseover", "element": "div" },
-        { "type": "forwarded", "name": "mouseenter", "element": "div" },
-        { "type": "forwarded", "name": "mouseleave", "element": "div" }
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseover",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "div"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": {
+        "type": "Element",
+        "name": "div"
+      }
     },
     {
       "moduleName": "DatePickerInput",
@@ -3234,15 +3760,38 @@
         }
       ],
       "events": [
-        { "type": "forwarded", "name": "input", "element": "input" },
-        { "type": "forwarded", "name": "keydown", "element": "input" },
-        { "type": "forwarded", "name": "keyup", "element": "input" },
-        { "type": "forwarded", "name": "blur", "element": "input" },
-        { "type": "forwarded", "name": "paste", "element": "input" }
+        {
+          "type": "forwarded",
+          "name": "input",
+          "element": "input"
+        },
+        {
+          "type": "forwarded",
+          "name": "keydown",
+          "element": "input"
+        },
+        {
+          "type": "forwarded",
+          "name": "keyup",
+          "element": "input"
+        },
+        {
+          "type": "forwarded",
+          "name": "blur",
+          "element": "input"
+        },
+        {
+          "type": "forwarded",
+          "name": "paste",
+          "element": "input"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "input" }
+      "rest_props": {
+        "type": "Element",
+        "name": "input"
+      }
     },
     {
       "moduleName": "DatePickerSkeleton",
@@ -3276,14 +3825,33 @@
       "moduleExports": [],
       "slots": [],
       "events": [
-        { "type": "forwarded", "name": "click", "element": "div" },
-        { "type": "forwarded", "name": "mouseover", "element": "div" },
-        { "type": "forwarded", "name": "mouseenter", "element": "div" },
-        { "type": "forwarded", "name": "mouseleave", "element": "div" }
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseover",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "div"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": {
+        "type": "Element",
+        "name": "div"
+      }
     },
     {
       "moduleName": "Dropdown",
@@ -3543,35 +4111,38 @@
           "name": "__default__",
           "default": true,
           "fallback": "{itemToString(item)}",
-          "slot_props": "{ item: DropdownItem; index: number; }"
+          "slot_props": "{ item: DropdownItem; index: number }"
         }
       ],
       "events": [
         {
           "type": "dispatched",
           "name": "select",
-          "detail": "{ selectedId: DropdownItemId, selectedItem: DropdownItem }"
+          "detail": "{ selectedId: DropdownItemId; selectedItem: DropdownItem }"
         }
       ],
       "typedefs": [
         {
           "type": "any",
           "name": "DropdownItemId",
-          "ts": "type DropdownItemId = any"
+          "ts": "type DropdownItemId = any;\n"
         },
         {
           "type": "string",
           "name": "DropdownItemText",
-          "ts": "type DropdownItemText = string"
+          "ts": "type DropdownItemText = string;\n"
         },
         {
           "type": "{ id: DropdownItemId; text: DropdownItemText; disabled?: boolean; }",
           "name": "DropdownItem",
-          "ts": "interface DropdownItem { id: DropdownItemId; text: DropdownItemText; disabled?: boolean; }"
+          "ts": "interface DropdownItem {\n  id: DropdownItemId;\n  text: DropdownItemText;\n  disabled?: boolean;\n}\n"
         }
       ],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": {
+        "type": "Element",
+        "name": "div"
+      }
     },
     {
       "moduleName": "DropdownSkeleton",
@@ -3593,14 +4164,33 @@
       "moduleExports": [],
       "slots": [],
       "events": [
-        { "type": "forwarded", "name": "click", "element": "div" },
-        { "type": "forwarded", "name": "mouseover", "element": "div" },
-        { "type": "forwarded", "name": "mouseenter", "element": "div" },
-        { "type": "forwarded", "name": "mouseleave", "element": "div" }
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseover",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "div"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": {
+        "type": "Element",
+        "name": "div"
+      }
     },
     {
       "moduleName": "ExpandableTile",
@@ -3741,19 +4331,50 @@
       ],
       "moduleExports": [],
       "slots": [
-        { "name": "above", "default": false, "slot_props": "{}" },
-        { "name": "below", "default": false, "slot_props": "{}" }
+        {
+          "name": "above",
+          "default": false,
+          "slot_props": "{}"
+        },
+        {
+          "name": "below",
+          "default": false,
+          "slot_props": "{}"
+        }
       ],
       "events": [
-        { "type": "forwarded", "name": "click", "element": "button" },
-        { "type": "forwarded", "name": "keypress", "element": "button" },
-        { "type": "forwarded", "name": "mouseover", "element": "button" },
-        { "type": "forwarded", "name": "mouseenter", "element": "button" },
-        { "type": "forwarded", "name": "mouseleave", "element": "button" }
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "button"
+        },
+        {
+          "type": "forwarded",
+          "name": "keypress",
+          "element": "button"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseover",
+          "element": "button"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "button"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "button"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "button" }
+      "rest_props": {
+        "type": "Element",
+        "name": "button"
+      }
     },
     {
       "moduleName": "FileUploader",
@@ -3824,7 +4445,7 @@
           "kind": "const",
           "description": "Programmatically clear the uploaded files",
           "type": "() => void",
-          "value": "() => {     files = [];   }",
+          "value": "() => {\n  files = [];\n}",
           "isFunction": true,
           "isFunctionDeclaration": false,
           "isRequired": false,
@@ -3947,15 +4568,38 @@
           "name": "change",
           "detail": "ReadonlyArray<File>"
         },
-        { "type": "forwarded", "name": "click", "element": "div" },
-        { "type": "forwarded", "name": "mouseover", "element": "div" },
-        { "type": "forwarded", "name": "mouseenter", "element": "div" },
-        { "type": "forwarded", "name": "mouseleave", "element": "div" },
-        { "type": "forwarded", "name": "keydown", "element": "Filename" }
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseover",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "keydown",
+          "element": "Filename"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": {
+        "type": "Element",
+        "name": "div"
+      }
     },
     {
       "moduleName": "FileUploaderButton",
@@ -4133,12 +4777,23 @@
           "name": "change",
           "detail": "ReadonlyArray<File>"
         },
-        { "type": "forwarded", "name": "keydown", "element": "label" },
-        { "type": "forwarded", "name": "click", "element": "input" }
+        {
+          "type": "forwarded",
+          "name": "keydown",
+          "element": "label"
+        },
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "input"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "input" }
+      "rest_props": {
+        "type": "Element",
+        "name": "input"
+      }
     },
     {
       "moduleName": "FileUploaderDropContainer",
@@ -4297,15 +4952,38 @@
           "name": "change",
           "detail": "ReadonlyArray<File>"
         },
-        { "type": "forwarded", "name": "dragover", "element": "div" },
-        { "type": "forwarded", "name": "dragleave", "element": "div" },
-        { "type": "forwarded", "name": "drop", "element": "div" },
-        { "type": "forwarded", "name": "keydown", "element": "label" },
-        { "type": "forwarded", "name": "click", "element": "input" }
+        {
+          "type": "forwarded",
+          "name": "dragover",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "dragleave",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "drop",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "keydown",
+          "element": "label"
+        },
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "input"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": {
+        "type": "Element",
+        "name": "div"
+      }
     },
     {
       "moduleName": "FileUploaderItem",
@@ -4411,14 +5089,33 @@
       "moduleExports": [],
       "slots": [],
       "events": [
-        { "type": "dispatched", "name": "delete", "detail": "string" },
-        { "type": "forwarded", "name": "mouseover", "element": "span" },
-        { "type": "forwarded", "name": "mouseenter", "element": "span" },
-        { "type": "forwarded", "name": "mouseleave", "element": "span" }
+        {
+          "type": "dispatched",
+          "name": "delete",
+          "detail": "string"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseover",
+          "element": "span"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "span"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "span"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "span" }
+      "rest_props": {
+        "type": "Element",
+        "name": "span"
+      }
     },
     {
       "moduleName": "FileUploaderSkeleton",
@@ -4427,14 +5124,33 @@
       "moduleExports": [],
       "slots": [],
       "events": [
-        { "type": "forwarded", "name": "click", "element": "div" },
-        { "type": "forwarded", "name": "mouseover", "element": "div" },
-        { "type": "forwarded", "name": "mouseenter", "element": "div" },
-        { "type": "forwarded", "name": "mouseleave", "element": "div" }
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseover",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "div"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": {
+        "type": "Element",
+        "name": "div"
+      }
     },
     {
       "moduleName": "Filename",
@@ -4480,30 +5196,74 @@
       "moduleExports": [],
       "slots": [],
       "events": [
-        { "type": "forwarded", "name": "click", "element": "button" },
-        { "type": "forwarded", "name": "keydown", "element": "button" }
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "button"
+        },
+        {
+          "type": "forwarded",
+          "name": "keydown",
+          "element": "button"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div | button | svg" }
+      "rest_props": {
+        "type": "Element",
+        "name": "div | button | svg"
+      }
     },
     {
       "moduleName": "FluidForm",
       "filePath": "src/FluidForm/FluidForm.svelte",
       "props": [],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "{}"
+        }
+      ],
       "events": [
-        { "type": "forwarded", "name": "click", "element": "Form" },
-        { "type": "forwarded", "name": "keydown", "element": "Form" },
-        { "type": "forwarded", "name": "mouseover", "element": "Form" },
-        { "type": "forwarded", "name": "mouseenter", "element": "Form" },
-        { "type": "forwarded", "name": "mouseleave", "element": "Form" },
-        { "type": "forwarded", "name": "submit", "element": "Form" }
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "Form"
+        },
+        {
+          "type": "forwarded",
+          "name": "keydown",
+          "element": "Form"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseover",
+          "element": "Form"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "Form"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "Form"
+        },
+        {
+          "type": "forwarded",
+          "name": "submit",
+          "element": "Form"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "form" }
+      "rest_props": {
+        "type": "Element",
+        "name": "form"
+      }
     },
     {
       "moduleName": "Form",
@@ -4523,18 +5283,51 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "{}"
+        }
+      ],
       "events": [
-        { "type": "forwarded", "name": "click", "element": "form" },
-        { "type": "forwarded", "name": "keydown", "element": "form" },
-        { "type": "forwarded", "name": "mouseover", "element": "form" },
-        { "type": "forwarded", "name": "mouseenter", "element": "form" },
-        { "type": "forwarded", "name": "mouseleave", "element": "form" },
-        { "type": "forwarded", "name": "submit", "element": "form" }
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "form"
+        },
+        {
+          "type": "forwarded",
+          "name": "keydown",
+          "element": "form"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseover",
+          "element": "form"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "form"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "form"
+        },
+        {
+          "type": "forwarded",
+          "name": "submit",
+          "element": "form"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "form" }
+      "rest_props": {
+        "type": "Element",
+        "name": "form"
+      }
     },
     {
       "moduleName": "FormGroup",
@@ -4614,32 +5407,82 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "{}"
+        }
+      ],
       "events": [
-        { "type": "forwarded", "name": "click", "element": "fieldset" },
-        { "type": "forwarded", "name": "mouseover", "element": "fieldset" },
-        { "type": "forwarded", "name": "mouseenter", "element": "fieldset" },
-        { "type": "forwarded", "name": "mouseleave", "element": "fieldset" }
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "fieldset"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseover",
+          "element": "fieldset"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "fieldset"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "fieldset"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "fieldset" }
+      "rest_props": {
+        "type": "Element",
+        "name": "fieldset"
+      }
     },
     {
       "moduleName": "FormItem",
       "filePath": "src/FormItem/FormItem.svelte",
       "props": [],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "{}"
+        }
+      ],
       "events": [
-        { "type": "forwarded", "name": "click", "element": "div" },
-        { "type": "forwarded", "name": "mouseover", "element": "div" },
-        { "type": "forwarded", "name": "mouseenter", "element": "div" },
-        { "type": "forwarded", "name": "mouseleave", "element": "div" }
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseover",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "div"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": {
+        "type": "Element",
+        "name": "div"
+      }
     },
     {
       "moduleName": "FormLabel",
@@ -4659,16 +5502,41 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "{}"
+        }
+      ],
       "events": [
-        { "type": "forwarded", "name": "click", "element": "label" },
-        { "type": "forwarded", "name": "mouseover", "element": "label" },
-        { "type": "forwarded", "name": "mouseenter", "element": "label" },
-        { "type": "forwarded", "name": "mouseleave", "element": "label" }
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "label"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseover",
+          "element": "label"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "label"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "label"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "label" }
+      "rest_props": {
+        "type": "Element",
+        "name": "label"
+      }
     },
     {
       "moduleName": "Grid",
@@ -4776,13 +5644,16 @@
         {
           "name": "__default__",
           "default": true,
-          "slot_props": "{ props: { class: string; [key: string]: any; } }"
+          "slot_props": "{ props: { class: string; [key: string]: any } }"
         }
       ],
       "events": [],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": {
+        "type": "Element",
+        "name": "div"
+      }
     },
     {
       "moduleName": "Header",
@@ -4918,7 +5789,11 @@
       ],
       "moduleExports": [],
       "slots": [
-        { "name": "__default__", "default": true, "slot_props": "{}" },
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "{}"
+        },
         {
           "name": "company",
           "default": false,
@@ -4931,12 +5806,25 @@
           "fallback": "{platformName}",
           "slot_props": "{}"
         },
-        { "name": "skip-to-content", "default": false, "slot_props": "{}" }
+        {
+          "name": "skip-to-content",
+          "default": false,
+          "slot_props": "{}"
+        }
       ],
-      "events": [{ "type": "forwarded", "name": "click", "element": "a" }],
+      "events": [
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "a"
+        }
+      ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "a" }
+      "rest_props": {
+        "type": "Element",
+        "name": "a"
+      }
     },
     {
       "moduleName": "HeaderAction",
@@ -5026,7 +5914,11 @@
       ],
       "moduleExports": [],
       "slots": [
-        { "name": "__default__", "default": true, "slot_props": "{}" },
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "{}"
+        },
         {
           "name": "closeIcon",
           "default": false,
@@ -5047,13 +5939,28 @@
         }
       ],
       "events": [
-        { "type": "dispatched", "name": "open", "detail": "null" },
-        { "type": "dispatched", "name": "close", "detail": "null" },
-        { "type": "forwarded", "name": "click", "element": "button" }
+        {
+          "type": "dispatched",
+          "name": "open",
+          "detail": "null"
+        },
+        {
+          "type": "dispatched",
+          "name": "close",
+          "detail": "null"
+        },
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "button"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "button" }
+      "rest_props": {
+        "type": "Element",
+        "name": "button"
+      }
     },
     {
       "moduleName": "HeaderActionLink",
@@ -5115,10 +6022,19 @@
           "slot_props": "{}"
         }
       ],
-      "events": [{ "type": "forwarded", "name": "click", "element": "a" }],
+      "events": [
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "a"
+        }
+      ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "a" }
+      "rest_props": {
+        "type": "Element",
+        "name": "a"
+      }
     },
     {
       "moduleName": "HeaderGlobalAction",
@@ -5162,10 +6078,19 @@
       ],
       "moduleExports": [],
       "slots": [],
-      "events": [{ "type": "forwarded", "name": "click", "element": "Button" }],
+      "events": [
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "Button"
+        }
+      ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "InlineComponent", "name": "Button" },
+      "rest_props": {
+        "type": "InlineComponent",
+        "name": "Button"
+      },
       "extends": {
         "interface": "ButtonProps",
         "import": "\"../Button/Button.svelte\""
@@ -5176,11 +6101,20 @@
       "filePath": "src/UIShell/HeaderNav.svelte",
       "props": [],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "{}"
+        }
+      ],
       "events": [],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "nav" }
+      "rest_props": {
+        "type": "Element",
+        "name": "nav"
+      }
     },
     {
       "moduleName": "HeaderNavItem",
@@ -5243,18 +6177,53 @@
         }
       ],
       "events": [
-        { "type": "forwarded", "name": "click", "element": "a" },
-        { "type": "forwarded", "name": "mouseover", "element": "a" },
-        { "type": "forwarded", "name": "mouseenter", "element": "a" },
-        { "type": "forwarded", "name": "mouseleave", "element": "a" },
-        { "type": "forwarded", "name": "keyup", "element": "a" },
-        { "type": "forwarded", "name": "keydown", "element": "a" },
-        { "type": "forwarded", "name": "focus", "element": "a" },
-        { "type": "forwarded", "name": "blur", "element": "a" }
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "a"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseover",
+          "element": "a"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "a"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "a"
+        },
+        {
+          "type": "forwarded",
+          "name": "keyup",
+          "element": "a"
+        },
+        {
+          "type": "forwarded",
+          "name": "keydown",
+          "element": "a"
+        },
+        {
+          "type": "forwarded",
+          "name": "focus",
+          "element": "a"
+        },
+        {
+          "type": "forwarded",
+          "name": "blur",
+          "element": "a"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "a" }
+      "rest_props": {
+        "type": "Element",
+        "name": "a"
+      }
     },
     {
       "moduleName": "HeaderNavMenu",
@@ -5309,27 +6278,74 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "{}"
+        }
+      ],
       "events": [
-        { "type": "forwarded", "name": "keydown", "element": "a" },
-        { "type": "forwarded", "name": "click", "element": "a" },
-        { "type": "forwarded", "name": "mouseover", "element": "a" },
-        { "type": "forwarded", "name": "mouseenter", "element": "a" },
-        { "type": "forwarded", "name": "mouseleave", "element": "a" },
-        { "type": "forwarded", "name": "keyup", "element": "a" },
-        { "type": "forwarded", "name": "focus", "element": "a" },
-        { "type": "forwarded", "name": "blur", "element": "a" }
+        {
+          "type": "forwarded",
+          "name": "keydown",
+          "element": "a"
+        },
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "a"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseover",
+          "element": "a"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "a"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "a"
+        },
+        {
+          "type": "forwarded",
+          "name": "keyup",
+          "element": "a"
+        },
+        {
+          "type": "forwarded",
+          "name": "focus",
+          "element": "a"
+        },
+        {
+          "type": "forwarded",
+          "name": "blur",
+          "element": "a"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "a" }
+      "rest_props": {
+        "type": "Element",
+        "name": "a"
+      }
     },
     {
       "moduleName": "HeaderPanelDivider",
       "filePath": "src/UIShell/HeaderPanelDivider.svelte",
       "props": [],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "{}"
+        }
+      ],
       "events": [],
       "typedefs": [],
       "generics": null
@@ -5363,18 +6379,39 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
-      "events": [{ "type": "forwarded", "name": "click", "element": "a" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "{}"
+        }
+      ],
+      "events": [
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "a"
+        }
+      ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "a" }
+      "rest_props": {
+        "type": "Element",
+        "name": "a"
+      }
     },
     {
       "moduleName": "HeaderPanelLinks",
       "filePath": "src/UIShell/HeaderPanelLinks.svelte",
       "props": [],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "{}"
+        }
+      ],
       "events": [],
       "typedefs": [],
       "generics": null
@@ -5454,37 +6491,82 @@
         }
       ],
       "events": [
-        { "type": "dispatched", "name": "active", "detail": "null" },
-        { "type": "dispatched", "name": "inactive", "detail": "null" },
-        { "type": "dispatched", "name": "clear", "detail": "null" },
+        {
+          "type": "dispatched",
+          "name": "active",
+          "detail": "null"
+        },
+        {
+          "type": "dispatched",
+          "name": "inactive",
+          "detail": "null"
+        },
+        {
+          "type": "dispatched",
+          "name": "clear",
+          "detail": "null"
+        },
         {
           "type": "dispatched",
           "name": "select",
-          "detail": "{ value: string; selectedResultIndex: number; selectedResult: HeaderSearchResult }"
+          "detail": "{\n  value: string;\n  selectedResultIndex: number;\n  selectedResult: HeaderSearchResult;\n}"
         },
-        { "type": "forwarded", "name": "change", "element": "input" },
-        { "type": "forwarded", "name": "input", "element": "input" },
-        { "type": "forwarded", "name": "focus", "element": "input" },
-        { "type": "forwarded", "name": "blur", "element": "input" },
-        { "type": "forwarded", "name": "keydown", "element": "input" },
-        { "type": "forwarded", "name": "paste", "element": "input" }
+        {
+          "type": "forwarded",
+          "name": "change",
+          "element": "input"
+        },
+        {
+          "type": "forwarded",
+          "name": "input",
+          "element": "input"
+        },
+        {
+          "type": "forwarded",
+          "name": "focus",
+          "element": "input"
+        },
+        {
+          "type": "forwarded",
+          "name": "blur",
+          "element": "input"
+        },
+        {
+          "type": "forwarded",
+          "name": "keydown",
+          "element": "input"
+        },
+        {
+          "type": "forwarded",
+          "name": "paste",
+          "element": "input"
+        }
       ],
       "typedefs": [
         {
           "type": "{ href: string; text: string; description?: string; }",
           "name": "HeaderSearchResult",
-          "ts": "interface HeaderSearchResult { href: string; text: string; description?: string; }"
+          "ts": "interface HeaderSearchResult {\n  href: string;\n  text: string;\n  description?: string;\n}\n"
         }
       ],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "input" }
+      "rest_props": {
+        "type": "Element",
+        "name": "input"
+      }
     },
     {
       "moduleName": "HeaderUtilities",
       "filePath": "src/UIShell/HeaderUtilities.svelte",
       "props": [],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "{}"
+        }
+      ],
       "events": [],
       "typedefs": [],
       "generics": null
@@ -5581,7 +6663,7 @@
           "kind": "const",
           "description": "Method invoked to load the image provided a `src` value",
           "type": "(url?: string) => void",
-          "value": "(url) => {     if (image != null) image = null;     loaded = false;     error = false;     image = new Image();     image.src = url || src;     image.onload = () => (loaded = true);     image.onerror = () => (error = true);   }",
+          "value": "(url) => {\n  if (image != null) image = null;\n  loaded = false;\n  error = false;\n  image = new Image();\n  image.src = url || src;\n  image.onload = () => (loaded = true);\n  image.onerror = () => (error = true);\n}",
           "isFunction": true,
           "isFunctionDeclaration": false,
           "isRequired": false,
@@ -5591,16 +6673,35 @@
       ],
       "moduleExports": [],
       "slots": [
-        { "name": "error", "default": false, "slot_props": "{}" },
-        { "name": "loading", "default": false, "slot_props": "{}" }
+        {
+          "name": "error",
+          "default": false,
+          "slot_props": "{}"
+        },
+        {
+          "name": "loading",
+          "default": false,
+          "slot_props": "{}"
+        }
       ],
       "events": [
-        { "type": "dispatched", "name": "load", "detail": "null" },
-        { "type": "dispatched", "name": "error", "detail": "null" }
+        {
+          "type": "dispatched",
+          "name": "load",
+          "detail": "null"
+        },
+        {
+          "type": "dispatched",
+          "name": "error",
+          "detail": "null"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "img" }
+      "rest_props": {
+        "type": "Element",
+        "name": "img"
+      }
     },
     {
       "moduleName": "InlineLoading",
@@ -5656,15 +6757,38 @@
       "moduleExports": [],
       "slots": [],
       "events": [
-        { "type": "forwarded", "name": "click", "element": "div" },
-        { "type": "forwarded", "name": "mouseover", "element": "div" },
-        { "type": "forwarded", "name": "mouseenter", "element": "div" },
-        { "type": "forwarded", "name": "mouseleave", "element": "div" },
-        { "type": "dispatched", "name": "success", "detail": "null" }
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseover",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "div"
+        },
+        {
+          "type": "dispatched",
+          "name": "success",
+          "detail": "null"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": {
+        "type": "Element",
+        "name": "div"
+      }
     },
     {
       "moduleName": "InlineNotification",
@@ -5781,8 +6905,16 @@
       ],
       "moduleExports": [],
       "slots": [
-        { "name": "__default__", "default": true, "slot_props": "{}" },
-        { "name": "actions", "default": false, "slot_props": "{}" },
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "{}"
+        },
+        {
+          "name": "actions",
+          "default": false,
+          "slot_props": "{}"
+        },
         {
           "name": "subtitle",
           "default": false,
@@ -5802,14 +6934,33 @@
           "name": "close",
           "detail": "{ timeout: boolean }"
         },
-        { "type": "forwarded", "name": "click", "element": "div" },
-        { "type": "forwarded", "name": "mouseover", "element": "div" },
-        { "type": "forwarded", "name": "mouseenter", "element": "div" },
-        { "type": "forwarded", "name": "mouseleave", "element": "div" }
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseover",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "div"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": {
+        "type": "Element",
+        "name": "div"
+      }
     },
     {
       "moduleName": "Link",
@@ -5899,7 +7050,11 @@
       ],
       "moduleExports": [],
       "slots": [
-        { "name": "__default__", "default": true, "slot_props": "{}" },
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "{}"
+        },
         {
           "name": "icon",
           "default": false,
@@ -5908,14 +7063,33 @@
         }
       ],
       "events": [
-        { "type": "forwarded", "name": "click", "element": "a" },
-        { "type": "forwarded", "name": "mouseover", "element": "a" },
-        { "type": "forwarded", "name": "mouseenter", "element": "a" },
-        { "type": "forwarded", "name": "mouseleave", "element": "a" }
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "a"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseover",
+          "element": "a"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "a"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "a"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "a" }
+      "rest_props": {
+        "type": "Element",
+        "name": "a"
+      }
     },
     {
       "moduleName": "ListBox",
@@ -6030,14 +7204,31 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "{}"
+        }
+      ],
       "events": [
-        { "type": "forwarded", "name": "keydown", "element": "div" },
-        { "type": "forwarded", "name": "click", "element": "div" }
+        {
+          "type": "forwarded",
+          "name": "keydown",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "div"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": {
+        "type": "Element",
+        "name": "div"
+      }
     },
     {
       "moduleName": "ListBoxField",
@@ -6129,25 +7320,62 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "{}"
+        }
+      ],
       "events": [
-        { "type": "forwarded", "name": "click", "element": "div" },
-        { "type": "forwarded", "name": "mouseover", "element": "div" },
-        { "type": "forwarded", "name": "mouseenter", "element": "div" },
-        { "type": "forwarded", "name": "mouseleave", "element": "div" },
-        { "type": "forwarded", "name": "keydown", "element": "div" },
-        { "type": "forwarded", "name": "focus", "element": "div" },
-        { "type": "forwarded", "name": "blur", "element": "div" }
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseover",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "keydown",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "focus",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "blur",
+          "element": "div"
+        }
       ],
       "typedefs": [
         {
           "type": "\"close\" | \"open\"",
           "name": "ListBoxFieldTranslationId",
-          "ts": "type ListBoxFieldTranslationId = \"close\" | \"open\""
+          "ts": "type ListBoxFieldTranslationId = \"close\" | \"open\";\n"
         }
       ],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": {
+        "type": "Element",
+        "name": "div"
+      }
     },
     {
       "moduleName": "ListBoxMenu",
@@ -6179,11 +7407,26 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
-      "events": [{ "type": "forwarded", "name": "scroll", "element": "div" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "{}"
+        }
+      ],
+      "events": [
+        {
+          "type": "forwarded",
+          "name": "scroll",
+          "element": "div"
+        }
+      ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": {
+        "type": "Element",
+        "name": "div"
+      }
     },
     {
       "moduleName": "ListBoxMenuIcon",
@@ -6228,16 +7471,25 @@
       ],
       "moduleExports": [],
       "slots": [],
-      "events": [{ "type": "forwarded", "name": "click", "element": "div" }],
+      "events": [
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "div"
+        }
+      ],
       "typedefs": [
         {
           "type": "\"close\" | \"open\"",
           "name": "ListBoxMenuIconTranslationId",
-          "ts": "type ListBoxMenuIconTranslationId = \"close\" | \"open\""
+          "ts": "type ListBoxMenuIconTranslationId = \"close\" | \"open\";\n"
         }
       ],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": {
+        "type": "Element",
+        "name": "div"
+      }
     },
     {
       "moduleName": "ListBoxMenuItem",
@@ -6281,15 +7533,36 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "{}"
+        }
+      ],
       "events": [
-        { "type": "forwarded", "name": "click", "element": "div" },
-        { "type": "forwarded", "name": "mouseenter", "element": "div" },
-        { "type": "forwarded", "name": "mouseleave", "element": "div" }
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "div"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": {
+        "type": "Element",
+        "name": "div"
+      }
     },
     {
       "moduleName": "ListBoxSelection",
@@ -6323,7 +7596,7 @@
           "kind": "const",
           "description": "Default translation ids",
           "type": "{     clearAll: \"clearAll\",     clearSelection: \"clearSelection\",   }",
-          "value": "{     clearAll: \"clearAll\",     clearSelection: \"clearSelection\",   }",
+          "value": "{\n  clearAll: \"clearAll\",\n  clearSelection: \"clearSelection\",\n}",
           "isFunction": false,
           "isFunctionDeclaration": false,
           "isRequired": false,
@@ -6368,27 +7641,55 @@
         {
           "type": "\"clearAll\" | \"clearSelection\"",
           "name": "ListBoxSelectionTranslationId",
-          "ts": "type ListBoxSelectionTranslationId = \"clearAll\" | \"clearSelection\""
+          "ts": "type ListBoxSelectionTranslationId = \"clearAll\" | \"clearSelection\";\n"
         }
       ],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": {
+        "type": "Element",
+        "name": "div"
+      }
     },
     {
       "moduleName": "ListItem",
       "filePath": "src/ListItem/ListItem.svelte",
       "props": [],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "{}"
+        }
+      ],
       "events": [
-        { "type": "forwarded", "name": "click", "element": "li" },
-        { "type": "forwarded", "name": "mouseover", "element": "li" },
-        { "type": "forwarded", "name": "mouseenter", "element": "li" },
-        { "type": "forwarded", "name": "mouseleave", "element": "li" }
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "li"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseover",
+          "element": "li"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "li"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "li"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "li" }
+      "rest_props": {
+        "type": "Element",
+        "name": "li"
+      }
     },
     {
       "moduleName": "Loading",
@@ -6448,7 +7749,10 @@
       "events": [],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": {
+        "type": "Element",
+        "name": "div"
+      }
     },
     {
       "moduleName": "LocalStorage",
@@ -6483,7 +7787,7 @@
           "kind": "function",
           "description": "Remove the persisted key value from the browser's local storage",
           "type": "() => void",
-          "value": "() => {     localStorage.removeItem(key);   }",
+          "value": "() => {\n  localStorage.removeItem(key);\n}",
           "isFunction": true,
           "isFunctionDeclaration": true,
           "isRequired": false,
@@ -6495,7 +7799,7 @@
           "kind": "function",
           "description": "Clear all key values from the browser's local storage",
           "type": "() => void",
-          "value": "() => {     localStorage.clear();   }",
+          "value": "() => {\n  localStorage.clear();\n}",
           "isFunction": true,
           "isFunctionDeclaration": true,
           "isRequired": false,
@@ -6506,11 +7810,15 @@
       "moduleExports": [],
       "slots": [],
       "events": [
-        { "type": "dispatched", "name": "save", "detail": "null" },
+        {
+          "type": "dispatched",
+          "name": "save",
+          "detail": "null"
+        },
         {
           "type": "dispatched",
           "name": "update",
-          "detail": "{ prevValue: any; value: any; }"
+          "detail": "{ prevValue: any; value: any }"
         }
       ],
       "typedefs": [],
@@ -6770,7 +8078,11 @@
       ],
       "moduleExports": [],
       "slots": [
-        { "name": "__default__", "default": true, "slot_props": "{}" },
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "{}"
+        },
         {
           "name": "heading",
           "default": false,
@@ -6788,30 +8100,65 @@
         {
           "type": "dispatched",
           "name": "transitionend",
-          "detail": "{ open: boolean; }"
+          "detail": "{ open: boolean }"
         },
         {
           "type": "dispatched",
           "name": "click:button--secondary",
-          "detail": "{ text: string; }"
+          "detail": "{ text: string }"
         },
-        { "type": "forwarded", "name": "keydown", "element": "div" },
-        { "type": "forwarded", "name": "click", "element": "div" },
-        { "type": "forwarded", "name": "mouseover", "element": "div" },
-        { "type": "forwarded", "name": "mouseenter", "element": "div" },
-        { "type": "forwarded", "name": "mouseleave", "element": "div" },
-        { "type": "dispatched", "name": "submit", "detail": "null" },
+        {
+          "type": "forwarded",
+          "name": "keydown",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseover",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "div"
+        },
+        {
+          "type": "dispatched",
+          "name": "submit",
+          "detail": "null"
+        },
         {
           "type": "dispatched",
           "name": "click:button--primary",
           "detail": "null"
         },
-        { "type": "dispatched", "name": "close", "detail": "null" },
-        { "type": "dispatched", "name": "open", "detail": "null" }
+        {
+          "type": "dispatched",
+          "name": "close",
+          "detail": "null"
+        },
+        {
+          "type": "dispatched",
+          "name": "open",
+          "detail": "null"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": {
+        "type": "Element",
+        "name": "div"
+      }
     },
     {
       "moduleName": "ModalBody",
@@ -6843,11 +8190,20 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "{}"
+        }
+      ],
       "events": [],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": {
+        "type": "Element",
+        "name": "div"
+      }
     },
     {
       "moduleName": "ModalFooter",
@@ -6948,17 +8304,26 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "{}"
+        }
+      ],
       "events": [
         {
           "type": "dispatched",
           "name": "click:button--secondary",
-          "detail": "{ text: string; }"
+          "detail": "{ text: string }"
         }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": {
+        "type": "Element",
+        "name": "div"
+      }
     },
     {
       "moduleName": "ModalHeader",
@@ -7050,11 +8415,26 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
-      "events": [{ "type": "forwarded", "name": "click", "element": "button" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "{}"
+        }
+      ],
+      "events": [
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "button"
+        }
+      ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": {
+        "type": "Element",
+        "name": "div"
+      }
     },
     {
       "moduleName": "MultiSelect",
@@ -7196,7 +8576,7 @@
           "kind": "let",
           "description": "Override the filtering logic\nThe default filtering is an exact string comparison",
           "type": "(item: MultiSelectItem, value: string) => boolean",
-          "value": "(item, value) =>     item.text.toLowerCase().includes(value.trim().toLowerCase())",
+          "value": "(item, value) =>\n  item.text.toLowerCase().includes(value.trim().toLowerCase())",
           "isFunction": true,
           "isFunctionDeclaration": false,
           "isRequired": false,
@@ -7256,7 +8636,7 @@
           "kind": "let",
           "description": "Override the sorting logic\nThe default sorting compare the item text value",
           "type": "((a: MultiSelectItem, b: MultiSelectItem) => MultiSelectItem) | (() => void)",
-          "value": "(a, b) =>     a.text.localeCompare(b.text, locale, { numeric: true })",
+          "value": "(a, b) =>\n  a.text.localeCompare(b.text, locale, { numeric: true })",
           "isFunction": true,
           "isFunctionDeclaration": false,
           "isRequired": false,
@@ -7496,54 +8876,102 @@
         {
           "type": "dispatched",
           "name": "select",
-          "detail": "{ selectedIds: MultiSelectItemId[]; selected: MultiSelectItem[]; unselected: MultiSelectItem[]; }"
+          "detail": "{\n  selectedIds: MultiSelectItemId[];\n  selected: MultiSelectItem[];\n  unselected: MultiSelectItem[];\n}"
         },
-        { "type": "dispatched", "name": "clear", "detail": "null" },
+        {
+          "type": "dispatched",
+          "name": "clear",
+          "detail": "null"
+        },
         {
           "type": "dispatched",
           "name": "blur",
           "detail": "FocusEvent | CustomEvent<FocusEvent>"
         },
-        { "type": "forwarded", "name": "keydown", "element": "input" },
-        { "type": "forwarded", "name": "keyup", "element": "input" },
-        { "type": "forwarded", "name": "focus", "element": "input" },
-        { "type": "forwarded", "name": "paste", "element": "input" }
+        {
+          "type": "forwarded",
+          "name": "keydown",
+          "element": "input"
+        },
+        {
+          "type": "forwarded",
+          "name": "keyup",
+          "element": "input"
+        },
+        {
+          "type": "forwarded",
+          "name": "focus",
+          "element": "input"
+        },
+        {
+          "type": "forwarded",
+          "name": "paste",
+          "element": "input"
+        }
       ],
       "typedefs": [
         {
           "type": "any",
           "name": "MultiSelectItemId",
-          "ts": "type MultiSelectItemId = any"
+          "ts": "type MultiSelectItemId = any;\n"
         },
         {
           "type": "string",
           "name": "MultiSelectItemText",
-          "ts": "type MultiSelectItemText = string"
+          "ts": "type MultiSelectItemText = string;\n"
         },
         {
           "type": "{ id: MultiSelectItemId; text: MultiSelectItemText; disabled?: boolean; }",
           "name": "MultiSelectItem",
-          "ts": "interface MultiSelectItem { id: MultiSelectItemId; text: MultiSelectItemText; disabled?: boolean; }"
+          "ts": "interface MultiSelectItem {\n  id: MultiSelectItemId;\n  text: MultiSelectItemText;\n  disabled?: boolean;\n}\n"
         }
       ],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "input" }
+      "rest_props": {
+        "type": "Element",
+        "name": "input"
+      }
     },
     {
       "moduleName": "NotificationActionButton",
       "filePath": "src/Notification/NotificationActionButton.svelte",
       "props": [],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "{}"
+        }
+      ],
       "events": [
-        { "type": "forwarded", "name": "click", "element": "Button" },
-        { "type": "forwarded", "name": "mouseover", "element": "Button" },
-        { "type": "forwarded", "name": "mouseenter", "element": "Button" },
-        { "type": "forwarded", "name": "mouseleave", "element": "Button" }
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "Button"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseover",
+          "element": "Button"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "Button"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "Button"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "InlineComponent", "name": "Button" },
+      "rest_props": {
+        "type": "InlineComponent",
+        "name": "Button"
+      },
       "extends": {
         "interface": "ButtonProps",
         "import": "\"../Button/Button.svelte\""
@@ -7603,14 +9031,33 @@
       "moduleExports": [],
       "slots": [],
       "events": [
-        { "type": "forwarded", "name": "click", "element": "button" },
-        { "type": "forwarded", "name": "mouseover", "element": "button" },
-        { "type": "forwarded", "name": "mouseenter", "element": "button" },
-        { "type": "forwarded", "name": "mouseleave", "element": "button" }
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "button"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseover",
+          "element": "button"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "button"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "button"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "button" }
+      "rest_props": {
+        "type": "Element",
+        "name": "button"
+      }
     },
     {
       "moduleName": "NotificationIcon",
@@ -7891,7 +9338,7 @@
           "kind": "const",
           "description": "Default translation ids",
           "type": "{ increment: \"increment\"; decrement: \"decrement\" }",
-          "value": "{     increment: \"increment\",     decrement: \"decrement\",   }",
+          "value": "{ increment: \"increment\", decrement: \"decrement\" }",
           "isFunction": false,
           "isFunctionDeclaration": false,
           "isRequired": false,
@@ -7944,27 +9391,74 @@
         }
       ],
       "events": [
-        { "type": "dispatched", "name": "change", "detail": "null | number" },
-        { "type": "dispatched", "name": "input", "detail": "null | number" },
-        { "type": "forwarded", "name": "click", "element": "div" },
-        { "type": "forwarded", "name": "mouseover", "element": "div" },
-        { "type": "forwarded", "name": "mouseenter", "element": "div" },
-        { "type": "forwarded", "name": "mouseleave", "element": "div" },
-        { "type": "forwarded", "name": "keydown", "element": "input" },
-        { "type": "forwarded", "name": "keyup", "element": "input" },
-        { "type": "forwarded", "name": "focus", "element": "input" },
-        { "type": "forwarded", "name": "blur", "element": "input" },
-        { "type": "forwarded", "name": "paste", "element": "input" }
+        {
+          "type": "dispatched",
+          "name": "change",
+          "detail": "null | number"
+        },
+        {
+          "type": "dispatched",
+          "name": "input",
+          "detail": "null | number"
+        },
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseover",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "keydown",
+          "element": "input"
+        },
+        {
+          "type": "forwarded",
+          "name": "keyup",
+          "element": "input"
+        },
+        {
+          "type": "forwarded",
+          "name": "focus",
+          "element": "input"
+        },
+        {
+          "type": "forwarded",
+          "name": "blur",
+          "element": "input"
+        },
+        {
+          "type": "forwarded",
+          "name": "paste",
+          "element": "input"
+        }
       ],
       "typedefs": [
         {
           "type": "\"increment\" | \"decrement\"",
           "name": "NumberInputTranslationId",
-          "ts": "type NumberInputTranslationId = \"increment\" | \"decrement\""
+          "ts": "type NumberInputTranslationId = \"increment\" | \"decrement\";\n"
         }
       ],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "input" }
+      "rest_props": {
+        "type": "Element",
+        "name": "input"
+      }
     },
     {
       "moduleName": "NumberInputSkeleton",
@@ -7986,14 +9480,33 @@
       "moduleExports": [],
       "slots": [],
       "events": [
-        { "type": "forwarded", "name": "click", "element": "div" },
-        { "type": "forwarded", "name": "mouseover", "element": "div" },
-        { "type": "forwarded", "name": "mouseenter", "element": "div" },
-        { "type": "forwarded", "name": "mouseleave", "element": "div" }
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseover",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "div"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": {
+        "type": "Element",
+        "name": "div"
+      }
     },
     {
       "moduleName": "OrderedList",
@@ -8037,33 +9550,86 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "{}"
+        }
+      ],
       "events": [
-        { "type": "forwarded", "name": "click", "element": "ol" },
-        { "type": "forwarded", "name": "mouseover", "element": "ol" },
-        { "type": "forwarded", "name": "mouseenter", "element": "ol" },
-        { "type": "forwarded", "name": "mouseleave", "element": "ol" }
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "ol"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseover",
+          "element": "ol"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "ol"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "ol"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "ol" }
+      "rest_props": {
+        "type": "Element",
+        "name": "ol"
+      }
     },
     {
       "moduleName": "OutboundLink",
       "filePath": "src/Link/OutboundLink.svelte",
       "props": [],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "{}"
+        }
+      ],
       "events": [
-        { "type": "forwarded", "name": "click", "element": "Link" },
-        { "type": "forwarded", "name": "mouseover", "element": "Link" },
-        { "type": "forwarded", "name": "mouseenter", "element": "Link" },
-        { "type": "forwarded", "name": "mouseleave", "element": "Link" }
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "Link"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseover",
+          "element": "Link"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "Link"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "Link"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "InlineComponent", "name": "Link" },
-      "extends": { "interface": "LinkProps", "import": "\"./Link.svelte\"" }
+      "rest_props": {
+        "type": "InlineComponent",
+        "name": "Link"
+      },
+      "extends": {
+        "interface": "LinkProps",
+        "import": "\"./Link.svelte\""
+      }
     },
     {
       "moduleName": "OverflowMenu",
@@ -8212,7 +9778,11 @@
       ],
       "moduleExports": [],
       "slots": [
-        { "name": "__default__", "default": true, "slot_props": "{}" },
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "{}"
+        },
         {
           "name": "menu",
           "default": false,
@@ -8224,17 +9794,40 @@
         {
           "type": "dispatched",
           "name": "close",
-          "detail": "null | { index: number; text: string; }"
+          "detail": "null | { index: number; text: string }"
         },
-        { "type": "forwarded", "name": "click", "element": "button" },
-        { "type": "forwarded", "name": "mouseover", "element": "button" },
-        { "type": "forwarded", "name": "mouseenter", "element": "button" },
-        { "type": "forwarded", "name": "mouseleave", "element": "button" },
-        { "type": "forwarded", "name": "keydown", "element": "button" }
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "button"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseover",
+          "element": "button"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "button"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "button"
+        },
+        {
+          "type": "forwarded",
+          "name": "keydown",
+          "element": "button"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "button" }
+      "rest_props": {
+        "type": "Element",
+        "name": "button"
+      }
     },
     {
       "moduleName": "OverflowMenuItem",
@@ -8359,12 +9952,23 @@
         }
       ],
       "events": [
-        { "type": "forwarded", "name": "click", "element": "a" },
-        { "type": "forwarded", "name": "keydown", "element": "a" }
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "a"
+        },
+        {
+          "type": "forwarded",
+          "name": "keydown",
+          "element": "a"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "li" }
+      "rest_props": {
+        "type": "Element",
+        "name": "li"
+      }
     },
     {
       "moduleName": "Pagination",
@@ -8447,7 +10051,7 @@
           "kind": "let",
           "description": "Override the item text",
           "type": "(min: number, max: number) => string",
-          "value": "(min, max) =>     `${min}–${max} item${max === 1 ? \"\" : \"s\"}`",
+          "value": "(min, max) => `${min}–${max} item${max === 1 ? \"\" : \"s\"}`",
           "isFunction": true,
           "isFunctionDeclaration": false,
           "isRequired": false,
@@ -8459,7 +10063,7 @@
           "kind": "let",
           "description": "Override the item range text",
           "type": "(min: number, max: number, total: number) => string",
-          "value": "(min, max, total) =>     `${min}–${max} of ${total} item${max === 1 ? \"\" : \"s\"}`",
+          "value": "(min, max, total) =>\n  `${min}–${max} of ${total} item${max === 1 ? \"\" : \"s\"}`",
           "isFunction": true,
           "isFunctionDeclaration": false,
           "isRequired": false,
@@ -8543,7 +10147,7 @@
           "kind": "let",
           "description": "Override the page range text",
           "type": "(current: number, total: number) => string",
-          "value": "(current, total) =>     `of ${total} page${total === 1 ? \"\" : \"s\"}`",
+          "value": "(current, total) =>\n  `of ${total} page${total === 1 ? \"\" : \"s\"}`",
           "isFunction": true,
           "isFunctionDeclaration": false,
           "isRequired": false,
@@ -8575,22 +10179,25 @@
         {
           "type": "dispatched",
           "name": "click:button--previous",
-          "detail": "{ page: number; }"
+          "detail": "{ page: number }"
         },
         {
           "type": "dispatched",
           "name": "click:button--next",
-          "detail": "{ page: number; }"
+          "detail": "{ page: number }"
         },
         {
           "type": "dispatched",
           "name": "update",
-          "detail": "{ pageSize: number; page: number; }"
+          "detail": "{ pageSize: number; page: number }"
         }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": {
+        "type": "Element",
+        "name": "div"
+      }
     },
     {
       "moduleName": "PaginationNav",
@@ -8687,23 +10294,26 @@
         {
           "type": "dispatched",
           "name": "change",
-          "detail": "{ page: number; }",
+          "detail": "{ page: number }",
           "description": "fires after every user interaction"
         },
         {
           "type": "dispatched",
           "name": "click:button--previous",
-          "detail": "{ page: number; }"
+          "detail": "{ page: number }"
         },
         {
           "type": "dispatched",
           "name": "click:button--next",
-          "detail": "{ page: number; }"
+          "detail": "{ page: number }"
         }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "nav" }
+      "rest_props": {
+        "type": "Element",
+        "name": "nav"
+      }
     },
     {
       "moduleName": "PaginationSkeleton",
@@ -8712,14 +10322,33 @@
       "moduleExports": [],
       "slots": [],
       "events": [
-        { "type": "forwarded", "name": "click", "element": "div" },
-        { "type": "forwarded", "name": "mouseover", "element": "div" },
-        { "type": "forwarded", "name": "mouseenter", "element": "div" },
-        { "type": "forwarded", "name": "mouseleave", "element": "div" }
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseover",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "div"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": {
+        "type": "Element",
+        "name": "div"
+      }
     },
     {
       "moduleName": "PasswordInput",
@@ -8986,21 +10615,68 @@
         }
       ],
       "events": [
-        { "type": "forwarded", "name": "click", "element": "div" },
-        { "type": "forwarded", "name": "mouseover", "element": "div" },
-        { "type": "forwarded", "name": "mouseenter", "element": "div" },
-        { "type": "forwarded", "name": "mouseleave", "element": "div" },
-        { "type": "forwarded", "name": "change", "element": "input" },
-        { "type": "forwarded", "name": "input", "element": "input" },
-        { "type": "forwarded", "name": "keydown", "element": "input" },
-        { "type": "forwarded", "name": "keyup", "element": "input" },
-        { "type": "forwarded", "name": "focus", "element": "input" },
-        { "type": "forwarded", "name": "blur", "element": "input" },
-        { "type": "forwarded", "name": "paste", "element": "input" }
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseover",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "change",
+          "element": "input"
+        },
+        {
+          "type": "forwarded",
+          "name": "input",
+          "element": "input"
+        },
+        {
+          "type": "forwarded",
+          "name": "keydown",
+          "element": "input"
+        },
+        {
+          "type": "forwarded",
+          "name": "keyup",
+          "element": "input"
+        },
+        {
+          "type": "forwarded",
+          "name": "focus",
+          "element": "input"
+        },
+        {
+          "type": "forwarded",
+          "name": "blur",
+          "element": "input"
+        },
+        {
+          "type": "forwarded",
+          "name": "paste",
+          "element": "input"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "input" }
+      "rest_props": {
+        "type": "Element",
+        "name": "input"
+      }
     },
     {
       "moduleName": "Popover",
@@ -9092,17 +10768,26 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "{}"
+        }
+      ],
       "events": [
         {
           "type": "dispatched",
           "name": "click:outside",
-          "detail": "{ target: HTMLElement; }"
+          "detail": "{ target: HTMLElement }"
         }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": {
+        "type": "Element",
+        "name": "div"
+      }
     },
     {
       "moduleName": "ProgressBar",
@@ -9228,7 +10913,10 @@
       "events": [],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": {
+        "type": "Element",
+        "name": "div"
+      }
     },
     {
       "moduleName": "ProgressIndicator",
@@ -9284,17 +10972,46 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "{}"
+        }
+      ],
       "events": [
-        { "type": "dispatched", "name": "change", "detail": "number" },
-        { "type": "forwarded", "name": "click", "element": "ul" },
-        { "type": "forwarded", "name": "mouseover", "element": "ul" },
-        { "type": "forwarded", "name": "mouseenter", "element": "ul" },
-        { "type": "forwarded", "name": "mouseleave", "element": "ul" }
+        {
+          "type": "dispatched",
+          "name": "change",
+          "detail": "number"
+        },
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "ul"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseover",
+          "element": "ul"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "ul"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "ul"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "ul" }
+      "rest_props": {
+        "type": "Element",
+        "name": "ul"
+      }
     },
     {
       "moduleName": "ProgressIndicatorSkeleton",
@@ -9328,14 +11045,33 @@
       "moduleExports": [],
       "slots": [],
       "events": [
-        { "type": "forwarded", "name": "click", "element": "ul" },
-        { "type": "forwarded", "name": "mouseover", "element": "ul" },
-        { "type": "forwarded", "name": "mouseenter", "element": "ul" },
-        { "type": "forwarded", "name": "mouseleave", "element": "ul" }
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "ul"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseover",
+          "element": "ul"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "ul"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "ul"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "ul" }
+      "rest_props": {
+        "type": "Element",
+        "name": "ul"
+      }
     },
     {
       "moduleName": "ProgressStep",
@@ -9448,15 +11184,38 @@
         }
       ],
       "events": [
-        { "type": "forwarded", "name": "click", "element": "button" },
-        { "type": "forwarded", "name": "mouseover", "element": "button" },
-        { "type": "forwarded", "name": "mouseenter", "element": "button" },
-        { "type": "forwarded", "name": "mouseleave", "element": "button" },
-        { "type": "forwarded", "name": "keydown", "element": "button" }
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "button"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseover",
+          "element": "button"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "button"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "button"
+        },
+        {
+          "type": "forwarded",
+          "name": "keydown",
+          "element": "button"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "li" }
+      "rest_props": {
+        "type": "Element",
+        "name": "li"
+      }
     },
     {
       "moduleName": "RadioButton",
@@ -9591,10 +11350,19 @@
           "slot_props": "{}"
         }
       ],
-      "events": [{ "type": "forwarded", "name": "change", "element": "input" }],
+      "events": [
+        {
+          "type": "forwarded",
+          "name": "change",
+          "element": "input"
+        }
+      ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": {
+        "type": "Element",
+        "name": "div"
+      }
     },
     {
       "moduleName": "RadioButtonGroup",
@@ -9707,7 +11475,11 @@
       ],
       "moduleExports": [],
       "slots": [
-        { "name": "__default__", "default": true, "slot_props": "{}" },
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "{}"
+        },
         {
           "name": "legendText",
           "default": false,
@@ -9716,15 +11488,38 @@
         }
       ],
       "events": [
-        { "type": "dispatched", "name": "change", "detail": "string | number" },
-        { "type": "forwarded", "name": "click", "element": "div" },
-        { "type": "forwarded", "name": "mouseover", "element": "div" },
-        { "type": "forwarded", "name": "mouseenter", "element": "div" },
-        { "type": "forwarded", "name": "mouseleave", "element": "div" }
+        {
+          "type": "dispatched",
+          "name": "change",
+          "detail": "string | number"
+        },
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseover",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "div"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": {
+        "type": "Element",
+        "name": "div"
+      }
     },
     {
       "moduleName": "RadioButtonSkeleton",
@@ -9733,14 +11528,33 @@
       "moduleExports": [],
       "slots": [],
       "events": [
-        { "type": "forwarded", "name": "click", "element": "div" },
-        { "type": "forwarded", "name": "mouseover", "element": "div" },
-        { "type": "forwarded", "name": "mouseenter", "element": "div" },
-        { "type": "forwarded", "name": "mouseleave", "element": "div" }
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseover",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "div"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": {
+        "type": "Element",
+        "name": "div"
+      }
     },
     {
       "moduleName": "RadioTile",
@@ -9855,18 +11669,51 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "{}"
+        }
+      ],
       "events": [
-        { "type": "forwarded", "name": "change", "element": "input" },
-        { "type": "forwarded", "name": "keydown", "element": "input" },
-        { "type": "forwarded", "name": "click", "element": "label" },
-        { "type": "forwarded", "name": "mouseover", "element": "label" },
-        { "type": "forwarded", "name": "mouseenter", "element": "label" },
-        { "type": "forwarded", "name": "mouseleave", "element": "label" }
+        {
+          "type": "forwarded",
+          "name": "change",
+          "element": "input"
+        },
+        {
+          "type": "forwarded",
+          "name": "keydown",
+          "element": "input"
+        },
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "label"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseover",
+          "element": "label"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "label"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "label"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "label" }
+      "rest_props": {
+        "type": "Element",
+        "name": "label"
+      }
     },
     {
       "moduleName": "RecursiveList",
@@ -9904,11 +11751,14 @@
         {
           "type": "{ text?: string; href?: string; html?: string; }",
           "name": "RecursiveListNode",
-          "ts": "interface RecursiveListNode { text?: string; href?: string; html?: string; }"
+          "ts": "interface RecursiveListNode {\n  text?: string;\n  href?: string;\n  html?: string;\n}\n"
         }
       ],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "ul | ol" }
+      "rest_props": {
+        "type": "Element",
+        "name": "ul | ol"
+      }
     },
     {
       "moduleName": "Row",
@@ -10004,13 +11854,16 @@
         {
           "name": "__default__",
           "default": true,
-          "slot_props": "{ props: { class: string; [key: string]: any; } }"
+          "slot_props": "{ props: { class: string; [key: string]: any } }"
         }
       ],
       "events": [],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": {
+        "type": "Element",
+        "name": "div"
+      }
     },
     {
       "moduleName": "Search",
@@ -10218,9 +12071,21 @@
         }
       ],
       "events": [
-        { "type": "dispatched", "name": "expand", "detail": "null" },
-        { "type": "dispatched", "name": "collapse", "detail": "null" },
-        { "type": "forwarded", "name": "click", "element": "SearchSkeleton" },
+        {
+          "type": "dispatched",
+          "name": "expand",
+          "detail": "null"
+        },
+        {
+          "type": "dispatched",
+          "name": "collapse",
+          "detail": "null"
+        },
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "SearchSkeleton"
+        },
         {
           "type": "forwarded",
           "name": "mouseover",
@@ -10236,18 +12101,53 @@
           "name": "mouseleave",
           "element": "SearchSkeleton"
         },
-        { "type": "forwarded", "name": "change", "element": "input" },
-        { "type": "forwarded", "name": "input", "element": "input" },
-        { "type": "forwarded", "name": "focus", "element": "input" },
-        { "type": "forwarded", "name": "blur", "element": "input" },
-        { "type": "forwarded", "name": "keydown", "element": "input" },
-        { "type": "forwarded", "name": "keyup", "element": "input" },
-        { "type": "forwarded", "name": "paste", "element": "input" },
-        { "type": "dispatched", "name": "clear", "detail": "null" }
+        {
+          "type": "forwarded",
+          "name": "change",
+          "element": "input"
+        },
+        {
+          "type": "forwarded",
+          "name": "input",
+          "element": "input"
+        },
+        {
+          "type": "forwarded",
+          "name": "focus",
+          "element": "input"
+        },
+        {
+          "type": "forwarded",
+          "name": "blur",
+          "element": "input"
+        },
+        {
+          "type": "forwarded",
+          "name": "keydown",
+          "element": "input"
+        },
+        {
+          "type": "forwarded",
+          "name": "keyup",
+          "element": "input"
+        },
+        {
+          "type": "forwarded",
+          "name": "paste",
+          "element": "input"
+        },
+        {
+          "type": "dispatched",
+          "name": "clear",
+          "detail": "null"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "input" }
+      "rest_props": {
+        "type": "Element",
+        "name": "input"
+      }
     },
     {
       "moduleName": "SearchSkeleton",
@@ -10269,14 +12169,33 @@
       "moduleExports": [],
       "slots": [],
       "events": [
-        { "type": "forwarded", "name": "click", "element": "div" },
-        { "type": "forwarded", "name": "mouseover", "element": "div" },
-        { "type": "forwarded", "name": "mouseenter", "element": "div" },
-        { "type": "forwarded", "name": "mouseleave", "element": "div" }
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseover",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "div"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": {
+        "type": "Element",
+        "name": "div"
+      }
     },
     {
       "moduleName": "Select",
@@ -10486,7 +12405,11 @@
       ],
       "moduleExports": [],
       "slots": [
-        { "name": "__default__", "default": true, "slot_props": "{}" },
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "{}"
+        },
         {
           "name": "labelText",
           "default": false,
@@ -10501,14 +12424,33 @@
           "detail": "string | number",
           "description": "The selected value."
         },
-        { "type": "forwarded", "name": "change", "element": "select" },
-        { "type": "forwarded", "name": "input", "element": "select" },
-        { "type": "forwarded", "name": "focus", "element": "select" },
-        { "type": "forwarded", "name": "blur", "element": "select" }
+        {
+          "type": "forwarded",
+          "name": "change",
+          "element": "select"
+        },
+        {
+          "type": "forwarded",
+          "name": "input",
+          "element": "select"
+        },
+        {
+          "type": "forwarded",
+          "name": "focus",
+          "element": "select"
+        },
+        {
+          "type": "forwarded",
+          "name": "blur",
+          "element": "select"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": {
+        "type": "Element",
+        "name": "div"
+      }
     },
     {
       "moduleName": "SelectItem",
@@ -10621,11 +12563,20 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "{}"
+        }
+      ],
       "events": [],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "optgroup" }
+      "rest_props": {
+        "type": "Element",
+        "name": "optgroup"
+      }
     },
     {
       "moduleName": "SelectSkeleton",
@@ -10647,14 +12598,33 @@
       "moduleExports": [],
       "slots": [],
       "events": [
-        { "type": "forwarded", "name": "click", "element": "div" },
-        { "type": "forwarded", "name": "mouseover", "element": "div" },
-        { "type": "forwarded", "name": "mouseenter", "element": "div" },
-        { "type": "forwarded", "name": "mouseleave", "element": "div" }
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseover",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "div"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": {
+        "type": "Element",
+        "name": "div"
+      }
     },
     {
       "moduleName": "SelectableTile",
@@ -10782,19 +12752,56 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "{}"
+        }
+      ],
       "events": [
-        { "type": "dispatched", "name": "select", "detail": "string" },
-        { "type": "dispatched", "name": "deselect", "detail": "string" },
-        { "type": "forwarded", "name": "click", "element": "label" },
-        { "type": "forwarded", "name": "mouseover", "element": "label" },
-        { "type": "forwarded", "name": "mouseenter", "element": "label" },
-        { "type": "forwarded", "name": "mouseleave", "element": "label" },
-        { "type": "forwarded", "name": "keydown", "element": "label" }
+        {
+          "type": "dispatched",
+          "name": "select",
+          "detail": "string"
+        },
+        {
+          "type": "dispatched",
+          "name": "deselect",
+          "detail": "string"
+        },
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "label"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseover",
+          "element": "label"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "label"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "label"
+        },
+        {
+          "type": "forwarded",
+          "name": "keydown",
+          "element": "label"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "label" }
+      "rest_props": {
+        "type": "Element",
+        "name": "label"
+      }
     },
     {
       "moduleName": "SideNav",
@@ -10861,15 +12868,36 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "{}"
+        }
+      ],
       "events": [
-        { "type": "dispatched", "name": "open", "detail": "null" },
-        { "type": "dispatched", "name": "close", "detail": "null" },
-        { "type": "dispatched", "name": "click:overlay", "detail": "null" }
+        {
+          "type": "dispatched",
+          "name": "open",
+          "detail": "null"
+        },
+        {
+          "type": "dispatched",
+          "name": "close",
+          "detail": "null"
+        },
+        {
+          "type": "dispatched",
+          "name": "click:overlay",
+          "detail": "null"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "nav" }
+      "rest_props": {
+        "type": "Element",
+        "name": "nav"
+      }
     },
     {
       "moduleName": "SideNavDivider",
@@ -10880,14 +12908,23 @@
       "events": [],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "li" }
+      "rest_props": {
+        "type": "Element",
+        "name": "li"
+      }
     },
     {
       "moduleName": "SideNavItems",
       "filePath": "src/UIShell/SideNavItems.svelte",
       "props": [],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "{}"
+        }
+      ],
       "events": [],
       "typedefs": [],
       "generics": null
@@ -10969,10 +13006,19 @@
           "slot_props": "{}"
         }
       ],
-      "events": [{ "type": "forwarded", "name": "click", "element": "a" }],
+      "events": [
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "a"
+        }
+      ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "a" }
+      "rest_props": {
+        "type": "Element",
+        "name": "a"
+      }
     },
     {
       "moduleName": "SideNavMenu",
@@ -11027,7 +13073,11 @@
       ],
       "moduleExports": [],
       "slots": [
-        { "name": "__default__", "default": true, "slot_props": "{}" },
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "{}"
+        },
         {
           "name": "icon",
           "default": false,
@@ -11035,10 +13085,19 @@
           "slot_props": "{}"
         }
       ],
-      "events": [{ "type": "forwarded", "name": "click", "element": "button" }],
+      "events": [
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "button"
+        }
+      ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "button" }
+      "rest_props": {
+        "type": "Element",
+        "name": "button"
+      }
     },
     {
       "moduleName": "SideNavMenuItem",
@@ -11100,10 +13159,19 @@
           "slot_props": "{}"
         }
       ],
-      "events": [{ "type": "forwarded", "name": "click", "element": "a" }],
+      "events": [
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "a"
+        }
+      ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "a" }
+      "rest_props": {
+        "type": "Element",
+        "name": "a"
+      }
     },
     {
       "moduleName": "SkeletonPlaceholder",
@@ -11112,14 +13180,33 @@
       "moduleExports": [],
       "slots": [],
       "events": [
-        { "type": "forwarded", "name": "click", "element": "div" },
-        { "type": "forwarded", "name": "mouseover", "element": "div" },
-        { "type": "forwarded", "name": "mouseenter", "element": "div" },
-        { "type": "forwarded", "name": "mouseleave", "element": "div" }
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseover",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "div"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": {
+        "type": "Element",
+        "name": "div"
+      }
     },
     {
       "moduleName": "SkeletonText",
@@ -11177,14 +13264,33 @@
       "moduleExports": [],
       "slots": [],
       "events": [
-        { "type": "forwarded", "name": "click", "element": "div" },
-        { "type": "forwarded", "name": "mouseover", "element": "div" },
-        { "type": "forwarded", "name": "mouseenter", "element": "div" },
-        { "type": "forwarded", "name": "mouseleave", "element": "div" }
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseover",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "div"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": {
+        "type": "Element",
+        "name": "div"
+      }
     },
     {
       "moduleName": "SkipToContent",
@@ -11224,10 +13330,19 @@
           "slot_props": "{}"
         }
       ],
-      "events": [{ "type": "forwarded", "name": "click", "element": "a" }],
+      "events": [
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "a"
+        }
+      ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "a" }
+      "rest_props": {
+        "type": "Element",
+        "name": "a"
+      }
     },
     {
       "moduleName": "Slider",
@@ -11472,16 +13587,43 @@
         }
       ],
       "events": [
-        { "type": "dispatched", "name": "change", "detail": "number" },
-        { "type": "dispatched", "name": "input", "detail": "number" },
-        { "type": "forwarded", "name": "click", "element": "div" },
-        { "type": "forwarded", "name": "mouseover", "element": "div" },
-        { "type": "forwarded", "name": "mouseenter", "element": "div" },
-        { "type": "forwarded", "name": "mouseleave", "element": "div" }
+        {
+          "type": "dispatched",
+          "name": "change",
+          "detail": "number"
+        },
+        {
+          "type": "dispatched",
+          "name": "input",
+          "detail": "number"
+        },
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseover",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "div"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": {
+        "type": "Element",
+        "name": "div"
+      }
     },
     {
       "moduleName": "SliderSkeleton",
@@ -11503,14 +13645,33 @@
       "moduleExports": [],
       "slots": [],
       "events": [
-        { "type": "forwarded", "name": "click", "element": "div" },
-        { "type": "forwarded", "name": "mouseover", "element": "div" },
-        { "type": "forwarded", "name": "mouseenter", "element": "div" },
-        { "type": "forwarded", "name": "mouseleave", "element": "div" }
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseover",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "div"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": {
+        "type": "Element",
+        "name": "div"
+      }
     },
     {
       "moduleName": "StructuredList",
@@ -11565,33 +13726,87 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "{}"
+        }
+      ],
       "events": [
-        { "type": "dispatched", "name": "change", "detail": "string" },
-        { "type": "forwarded", "name": "click", "element": "div" },
-        { "type": "forwarded", "name": "mouseover", "element": "div" },
-        { "type": "forwarded", "name": "mouseenter", "element": "div" },
-        { "type": "forwarded", "name": "mouseleave", "element": "div" }
+        {
+          "type": "dispatched",
+          "name": "change",
+          "detail": "string"
+        },
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseover",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "div"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": {
+        "type": "Element",
+        "name": "div"
+      }
     },
     {
       "moduleName": "StructuredListBody",
       "filePath": "src/StructuredList/StructuredListBody.svelte",
       "props": [],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "{}"
+        }
+      ],
       "events": [
-        { "type": "forwarded", "name": "click", "element": "div" },
-        { "type": "forwarded", "name": "mouseover", "element": "div" },
-        { "type": "forwarded", "name": "mouseenter", "element": "div" },
-        { "type": "forwarded", "name": "mouseleave", "element": "div" }
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseover",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "div"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": {
+        "type": "Element",
+        "name": "div"
+      }
     },
     {
       "moduleName": "StructuredListCell",
@@ -11623,32 +13838,82 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "{}"
+        }
+      ],
       "events": [
-        { "type": "forwarded", "name": "click", "element": "div" },
-        { "type": "forwarded", "name": "mouseover", "element": "div" },
-        { "type": "forwarded", "name": "mouseenter", "element": "div" },
-        { "type": "forwarded", "name": "mouseleave", "element": "div" }
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseover",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "div"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": {
+        "type": "Element",
+        "name": "div"
+      }
     },
     {
       "moduleName": "StructuredListHead",
       "filePath": "src/StructuredList/StructuredListHead.svelte",
       "props": [],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "{}"
+        }
+      ],
       "events": [
-        { "type": "forwarded", "name": "click", "element": "div" },
-        { "type": "forwarded", "name": "mouseover", "element": "div" },
-        { "type": "forwarded", "name": "mouseenter", "element": "div" },
-        { "type": "forwarded", "name": "mouseleave", "element": "div" }
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseover",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "div"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": {
+        "type": "Element",
+        "name": "div"
+      }
     },
     {
       "moduleName": "StructuredListInput",
@@ -11732,7 +13997,10 @@
       "events": [],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "input" }
+      "rest_props": {
+        "type": "Element",
+        "name": "input"
+      }
     },
     {
       "moduleName": "StructuredListRow",
@@ -11776,17 +14044,46 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "{}"
+        }
+      ],
       "events": [
-        { "type": "forwarded", "name": "click", "element": "label" },
-        { "type": "forwarded", "name": "mouseover", "element": "label" },
-        { "type": "forwarded", "name": "mouseenter", "element": "label" },
-        { "type": "forwarded", "name": "mouseleave", "element": "label" },
-        { "type": "forwarded", "name": "keydown", "element": "label" }
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "label"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseover",
+          "element": "label"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "label"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "label"
+        },
+        {
+          "type": "forwarded",
+          "name": "keydown",
+          "element": "label"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "label" }
+      "rest_props": {
+        "type": "Element",
+        "name": "label"
+      }
     },
     {
       "moduleName": "StructuredListSkeleton",
@@ -11808,14 +14105,33 @@
       "moduleExports": [],
       "slots": [],
       "events": [
-        { "type": "forwarded", "name": "click", "element": "div" },
-        { "type": "forwarded", "name": "mouseover", "element": "div" },
-        { "type": "forwarded", "name": "mouseenter", "element": "div" },
-        { "type": "forwarded", "name": "mouseleave", "element": "div" }
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseover",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "div"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": {
+        "type": "Element",
+        "name": "div"
+      }
     },
     {
       "moduleName": "Switch",
@@ -11892,15 +14208,38 @@
         }
       ],
       "events": [
-        { "type": "forwarded", "name": "click", "element": "button" },
-        { "type": "forwarded", "name": "mouseover", "element": "button" },
-        { "type": "forwarded", "name": "mouseenter", "element": "button" },
-        { "type": "forwarded", "name": "mouseleave", "element": "button" },
-        { "type": "forwarded", "name": "keydown", "element": "button" }
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "button"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseover",
+          "element": "button"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "button"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "button"
+        },
+        {
+          "type": "forwarded",
+          "name": "keydown",
+          "element": "button"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "button" }
+      "rest_props": {
+        "type": "Element",
+        "name": "button"
+      }
     },
     {
       "moduleName": "Tab",
@@ -11989,14 +14328,33 @@
         }
       ],
       "events": [
-        { "type": "forwarded", "name": "click", "element": "li" },
-        { "type": "forwarded", "name": "mouseover", "element": "li" },
-        { "type": "forwarded", "name": "mouseenter", "element": "li" },
-        { "type": "forwarded", "name": "mouseleave", "element": "li" }
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "li"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseover",
+          "element": "li"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "li"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "li"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "li" }
+      "rest_props": {
+        "type": "Element",
+        "name": "li"
+      }
     },
     {
       "moduleName": "TabContent",
@@ -12016,11 +14374,20 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "{}"
+        }
+      ],
       "events": [],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": {
+        "type": "Element",
+        "name": "div"
+      }
     },
     {
       "moduleName": "Table",
@@ -12098,38 +14465,81 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "{}"
+        }
+      ],
       "events": [],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "section" }
+      "rest_props": {
+        "type": "Element",
+        "name": "section"
+      }
     },
     {
       "moduleName": "TableBody",
       "filePath": "src/DataTable/TableBody.svelte",
       "props": [],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "{}"
+        }
+      ],
       "events": [],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "tbody" }
+      "rest_props": {
+        "type": "Element",
+        "name": "tbody"
+      }
     },
     {
       "moduleName": "TableCell",
       "filePath": "src/DataTable/TableCell.svelte",
       "props": [],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "{}"
+        }
+      ],
       "events": [
-        { "type": "forwarded", "name": "click", "element": "td" },
-        { "type": "forwarded", "name": "mouseover", "element": "td" },
-        { "type": "forwarded", "name": "mouseenter", "element": "td" },
-        { "type": "forwarded", "name": "mouseleave", "element": "td" }
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "td"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseover",
+          "element": "td"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "td"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "td"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "td" }
+      "rest_props": {
+        "type": "Element",
+        "name": "td"
+      }
     },
     {
       "moduleName": "TableContainer",
@@ -12185,27 +14595,61 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "{}"
+        }
+      ],
       "events": [],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": {
+        "type": "Element",
+        "name": "div"
+      }
     },
     {
       "moduleName": "TableHead",
       "filePath": "src/DataTable/TableHead.svelte",
       "props": [],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "{}"
+        }
+      ],
       "events": [
-        { "type": "forwarded", "name": "click", "element": "thead" },
-        { "type": "forwarded", "name": "mouseover", "element": "thead" },
-        { "type": "forwarded", "name": "mouseenter", "element": "thead" },
-        { "type": "forwarded", "name": "mouseleave", "element": "thead" }
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "thead"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseover",
+          "element": "thead"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "thead"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "thead"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "thead" }
+      "rest_props": {
+        "type": "Element",
+        "name": "thead"
+      }
     },
     {
       "moduleName": "TableHeader",
@@ -12285,32 +14729,82 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "{}"
+        }
+      ],
       "events": [
-        { "type": "forwarded", "name": "mouseover", "element": "th" },
-        { "type": "forwarded", "name": "mouseenter", "element": "th" },
-        { "type": "forwarded", "name": "mouseleave", "element": "th" },
-        { "type": "forwarded", "name": "click", "element": "button" }
+        {
+          "type": "forwarded",
+          "name": "mouseover",
+          "element": "th"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "th"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "th"
+        },
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "button"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "th" }
+      "rest_props": {
+        "type": "Element",
+        "name": "th"
+      }
     },
     {
       "moduleName": "TableRow",
       "filePath": "src/DataTable/TableRow.svelte",
       "props": [],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "{}"
+        }
+      ],
       "events": [
-        { "type": "forwarded", "name": "click", "element": "tr" },
-        { "type": "forwarded", "name": "mouseover", "element": "tr" },
-        { "type": "forwarded", "name": "mouseenter", "element": "tr" },
-        { "type": "forwarded", "name": "mouseleave", "element": "tr" }
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "tr"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseover",
+          "element": "tr"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "tr"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "tr"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "tr" }
+      "rest_props": {
+        "type": "Element",
+        "name": "tr"
+      }
     },
     {
       "moduleName": "Tabs",
@@ -12379,17 +14873,40 @@
       ],
       "moduleExports": [],
       "slots": [
-        { "name": "__default__", "default": true, "slot_props": "{}" },
-        { "name": "content", "default": false, "slot_props": "{}" }
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "{}"
+        },
+        {
+          "name": "content",
+          "default": false,
+          "slot_props": "{}"
+        }
       ],
       "events": [
-        { "type": "dispatched", "name": "change", "detail": "number" },
-        { "type": "forwarded", "name": "keypress", "element": "div" },
-        { "type": "forwarded", "name": "click", "element": "a" }
+        {
+          "type": "dispatched",
+          "name": "change",
+          "detail": "number"
+        },
+        {
+          "type": "forwarded",
+          "name": "keypress",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "a"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": {
+        "type": "Element",
+        "name": "div"
+      }
     },
     {
       "moduleName": "TabsSkeleton",
@@ -12423,14 +14940,33 @@
       "moduleExports": [],
       "slots": [],
       "events": [
-        { "type": "forwarded", "name": "click", "element": "div" },
-        { "type": "forwarded", "name": "mouseover", "element": "div" },
-        { "type": "forwarded", "name": "mouseenter", "element": "div" },
-        { "type": "forwarded", "name": "mouseleave", "element": "div" }
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseover",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "div"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": {
+        "type": "Element",
+        "name": "div"
+      }
     },
     {
       "moduleName": "Tag",
@@ -12557,15 +15093,38 @@
         }
       ],
       "events": [
-        { "type": "forwarded", "name": "click", "element": "TagSkeleton" },
-        { "type": "forwarded", "name": "mouseover", "element": "TagSkeleton" },
-        { "type": "forwarded", "name": "mouseenter", "element": "TagSkeleton" },
-        { "type": "forwarded", "name": "mouseleave", "element": "TagSkeleton" },
-        { "type": "dispatched", "name": "close", "detail": "null" }
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "TagSkeleton"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseover",
+          "element": "TagSkeleton"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "TagSkeleton"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "TagSkeleton"
+        },
+        {
+          "type": "dispatched",
+          "name": "close",
+          "detail": "null"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div | span" }
+      "rest_props": {
+        "type": "Element",
+        "name": "div | span"
+      }
     },
     {
       "moduleName": "TagSkeleton",
@@ -12586,14 +15145,33 @@
       "moduleExports": [],
       "slots": [],
       "events": [
-        { "type": "forwarded", "name": "click", "element": "span" },
-        { "type": "forwarded", "name": "mouseover", "element": "span" },
-        { "type": "forwarded", "name": "mouseenter", "element": "span" },
-        { "type": "forwarded", "name": "mouseleave", "element": "span" }
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "span"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseover",
+          "element": "span"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "span"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "span"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "span" }
+      "rest_props": {
+        "type": "Element",
+        "name": "span"
+      }
     },
     {
       "moduleName": "TextArea",
@@ -12800,21 +15378,68 @@
         }
       ],
       "events": [
-        { "type": "forwarded", "name": "click", "element": "div" },
-        { "type": "forwarded", "name": "mouseover", "element": "div" },
-        { "type": "forwarded", "name": "mouseenter", "element": "div" },
-        { "type": "forwarded", "name": "mouseleave", "element": "div" },
-        { "type": "forwarded", "name": "change", "element": "textarea" },
-        { "type": "forwarded", "name": "input", "element": "textarea" },
-        { "type": "forwarded", "name": "keydown", "element": "textarea" },
-        { "type": "forwarded", "name": "keyup", "element": "textarea" },
-        { "type": "forwarded", "name": "focus", "element": "textarea" },
-        { "type": "forwarded", "name": "blur", "element": "textarea" },
-        { "type": "forwarded", "name": "paste", "element": "textarea" }
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseover",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "change",
+          "element": "textarea"
+        },
+        {
+          "type": "forwarded",
+          "name": "input",
+          "element": "textarea"
+        },
+        {
+          "type": "forwarded",
+          "name": "keydown",
+          "element": "textarea"
+        },
+        {
+          "type": "forwarded",
+          "name": "keyup",
+          "element": "textarea"
+        },
+        {
+          "type": "forwarded",
+          "name": "focus",
+          "element": "textarea"
+        },
+        {
+          "type": "forwarded",
+          "name": "blur",
+          "element": "textarea"
+        },
+        {
+          "type": "forwarded",
+          "name": "paste",
+          "element": "textarea"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "textarea" }
+      "rest_props": {
+        "type": "Element",
+        "name": "textarea"
+      }
     },
     {
       "moduleName": "TextAreaSkeleton",
@@ -12836,14 +15461,33 @@
       "moduleExports": [],
       "slots": [],
       "events": [
-        { "type": "forwarded", "name": "click", "element": "div" },
-        { "type": "forwarded", "name": "mouseover", "element": "div" },
-        { "type": "forwarded", "name": "mouseenter", "element": "div" },
-        { "type": "forwarded", "name": "mouseleave", "element": "div" }
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseover",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "div"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": {
+        "type": "Element",
+        "name": "div"
+      }
     },
     {
       "moduleName": "TextInput",
@@ -13084,19 +15728,58 @@
           "name": "input",
           "detail": "null | number | string"
         },
-        { "type": "forwarded", "name": "click", "element": "div" },
-        { "type": "forwarded", "name": "mouseover", "element": "div" },
-        { "type": "forwarded", "name": "mouseenter", "element": "div" },
-        { "type": "forwarded", "name": "mouseleave", "element": "div" },
-        { "type": "forwarded", "name": "keydown", "element": "input" },
-        { "type": "forwarded", "name": "keyup", "element": "input" },
-        { "type": "forwarded", "name": "focus", "element": "input" },
-        { "type": "forwarded", "name": "blur", "element": "input" },
-        { "type": "forwarded", "name": "paste", "element": "input" }
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseover",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "keydown",
+          "element": "input"
+        },
+        {
+          "type": "forwarded",
+          "name": "keyup",
+          "element": "input"
+        },
+        {
+          "type": "forwarded",
+          "name": "focus",
+          "element": "input"
+        },
+        {
+          "type": "forwarded",
+          "name": "blur",
+          "element": "input"
+        },
+        {
+          "type": "forwarded",
+          "name": "paste",
+          "element": "input"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "input" }
+      "rest_props": {
+        "type": "Element",
+        "name": "input"
+      }
     },
     {
       "moduleName": "TextInputSkeleton",
@@ -13118,14 +15801,33 @@
       "moduleExports": [],
       "slots": [],
       "events": [
-        { "type": "forwarded", "name": "click", "element": "div" },
-        { "type": "forwarded", "name": "mouseover", "element": "div" },
-        { "type": "forwarded", "name": "mouseenter", "element": "div" },
-        { "type": "forwarded", "name": "mouseleave", "element": "div" }
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseover",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "div"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": {
+        "type": "Element",
+        "name": "div"
+      }
     },
     {
       "moduleName": "Theme",
@@ -13195,7 +15897,7 @@
           "kind": "let",
           "description": "Override the default toggle props",
           "type": "import(\"../Toggle/Toggle.svelte\").ToggleProps & { themes?: [labelA: CarbonTheme, labelB: CarbonTheme]; }",
-          "value": "{     themes: [\"white\", \"g100\"],     labelA: \"\",     labelB: \"\",     labelText: \"Dark mode\",     hideLabel: false,   }",
+          "value": "{\n  themes: [\"white\", \"g100\"],\n  labelA: \"\",\n  labelB: \"\",\n  labelText: \"Dark mode\",\n  hideLabel: false,\n}",
           "isFunction": false,
           "isFunctionDeclaration": false,
           "isRequired": false,
@@ -13207,7 +15909,7 @@
           "kind": "let",
           "description": "Override the default select props",
           "type": "import(\"../Select/Select.svelte\").SelectProps & { themes?: CarbonTheme[]; }",
-          "value": "{     themes: themeKeys,     labelText: \"Themes\",     hideLabel: false,   }",
+          "value": "{ themes: themeKeys, labelText: \"Themes\", hideLabel: false }",
           "isFunction": false,
           "isFunctionDeclaration": false,
           "isRequired": false,
@@ -13220,21 +15922,21 @@
         {
           "name": "__default__",
           "default": true,
-          "slot_props": "{ theme: CarbonTheme; }"
+          "slot_props": "{ theme: CarbonTheme }"
         }
       ],
       "events": [
         {
           "type": "dispatched",
           "name": "update",
-          "detail": "{ theme: CarbonTheme; }"
+          "detail": "{ theme: CarbonTheme }"
         }
       ],
       "typedefs": [
         {
           "type": "\"white\" | \"g10\" | \"g80\" | \"g90\" | \"g100\"",
           "name": "CarbonTheme",
-          "ts": "type CarbonTheme = \"white\" | \"g10\" | \"g80\" | \"g90\" | \"g100\""
+          "ts": "type CarbonTheme = \"white\" | \"g10\" | \"g80\" | \"g90\" | \"g100\";\n"
         }
       ],
       "generics": null
@@ -13257,16 +15959,41 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "{}"
+        }
+      ],
       "events": [
-        { "type": "forwarded", "name": "click", "element": "div" },
-        { "type": "forwarded", "name": "mouseover", "element": "div" },
-        { "type": "forwarded", "name": "mouseenter", "element": "div" },
-        { "type": "forwarded", "name": "mouseleave", "element": "div" }
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseover",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "div"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": {
+        "type": "Element",
+        "name": "div"
+      }
     },
     {
       "moduleName": "TileGroup",
@@ -13331,13 +16058,26 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "{}"
+        }
+      ],
       "events": [
-        { "type": "dispatched", "name": "select", "detail": "string" }
+        {
+          "type": "dispatched",
+          "name": "select",
+          "detail": "string"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "fieldset" }
+      "rest_props": {
+        "type": "Element",
+        "name": "fieldset"
+      }
     },
     {
       "moduleName": "TimePicker",
@@ -13512,7 +16252,11 @@
       ],
       "moduleExports": [],
       "slots": [
-        { "name": "__default__", "default": true, "slot_props": "{}" },
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "{}"
+        },
         {
           "name": "labelText",
           "default": false,
@@ -13521,21 +16265,68 @@
         }
       ],
       "events": [
-        { "type": "forwarded", "name": "click", "element": "div" },
-        { "type": "forwarded", "name": "mouseover", "element": "div" },
-        { "type": "forwarded", "name": "mouseenter", "element": "div" },
-        { "type": "forwarded", "name": "mouseleave", "element": "div" },
-        { "type": "forwarded", "name": "change", "element": "input" },
-        { "type": "forwarded", "name": "input", "element": "input" },
-        { "type": "forwarded", "name": "keydown", "element": "input" },
-        { "type": "forwarded", "name": "keyup", "element": "input" },
-        { "type": "forwarded", "name": "focus", "element": "input" },
-        { "type": "forwarded", "name": "blur", "element": "input" },
-        { "type": "forwarded", "name": "paste", "element": "input" }
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseover",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "change",
+          "element": "input"
+        },
+        {
+          "type": "forwarded",
+          "name": "input",
+          "element": "input"
+        },
+        {
+          "type": "forwarded",
+          "name": "keydown",
+          "element": "input"
+        },
+        {
+          "type": "forwarded",
+          "name": "keyup",
+          "element": "input"
+        },
+        {
+          "type": "forwarded",
+          "name": "focus",
+          "element": "input"
+        },
+        {
+          "type": "forwarded",
+          "name": "blur",
+          "element": "input"
+        },
+        {
+          "type": "forwarded",
+          "name": "paste",
+          "element": "input"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "input" }
+      "rest_props": {
+        "type": "Element",
+        "name": "input"
+      }
     },
     {
       "moduleName": "TimePickerSelect",
@@ -13627,7 +16418,11 @@
       ],
       "moduleExports": [],
       "slots": [
-        { "name": "__default__", "default": true, "slot_props": "{}" },
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "{}"
+        },
         {
           "name": "labelText",
           "default": false,
@@ -13636,14 +16431,33 @@
         }
       ],
       "events": [
-        { "type": "forwarded", "name": "click", "element": "div" },
-        { "type": "forwarded", "name": "mouseover", "element": "div" },
-        { "type": "forwarded", "name": "mouseenter", "element": "div" },
-        { "type": "forwarded", "name": "mouseleave", "element": "div" }
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseover",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "div"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": {
+        "type": "Element",
+        "name": "div"
+      }
     },
     {
       "moduleName": "ToastNotification",
@@ -13784,7 +16598,11 @@
       ],
       "moduleExports": [],
       "slots": [
-        { "name": "__default__", "default": true, "slot_props": "{}" },
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "{}"
+        },
         {
           "name": "caption",
           "default": false,
@@ -13810,14 +16628,33 @@
           "name": "close",
           "detail": "{ timeout: boolean }"
         },
-        { "type": "forwarded", "name": "click", "element": "div" },
-        { "type": "forwarded", "name": "mouseover", "element": "div" },
-        { "type": "forwarded", "name": "mouseenter", "element": "div" },
-        { "type": "forwarded", "name": "mouseleave", "element": "div" }
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseover",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "div"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": {
+        "type": "Element",
+        "name": "div"
+      }
     },
     {
       "moduleName": "Toggle",
@@ -13956,20 +16793,55 @@
         {
           "type": "dispatched",
           "name": "toggle",
-          "detail": "{ toggled: boolean; }"
+          "detail": "{ toggled: boolean }"
         },
-        { "type": "forwarded", "name": "click", "element": "div" },
-        { "type": "forwarded", "name": "mouseover", "element": "div" },
-        { "type": "forwarded", "name": "mouseenter", "element": "div" },
-        { "type": "forwarded", "name": "mouseleave", "element": "div" },
-        { "type": "forwarded", "name": "change", "element": "input" },
-        { "type": "forwarded", "name": "keyup", "element": "input" },
-        { "type": "forwarded", "name": "focus", "element": "input" },
-        { "type": "forwarded", "name": "blur", "element": "input" }
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseover",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "change",
+          "element": "input"
+        },
+        {
+          "type": "forwarded",
+          "name": "keyup",
+          "element": "input"
+        },
+        {
+          "type": "forwarded",
+          "name": "focus",
+          "element": "input"
+        },
+        {
+          "type": "forwarded",
+          "name": "blur",
+          "element": "input"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": {
+        "type": "Element",
+        "name": "div"
+      }
     },
     {
       "moduleName": "ToggleSkeleton",
@@ -14022,14 +16894,33 @@
         }
       ],
       "events": [
-        { "type": "forwarded", "name": "click", "element": "div" },
-        { "type": "forwarded", "name": "mouseover", "element": "div" },
-        { "type": "forwarded", "name": "mouseenter", "element": "div" },
-        { "type": "forwarded", "name": "mouseleave", "element": "div" }
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseover",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "div"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": {
+        "type": "Element",
+        "name": "div"
+      }
     },
     {
       "moduleName": "Toolbar",
@@ -14049,11 +16940,20 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "{}"
+        }
+      ],
       "events": [],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "section" }
+      "rest_props": {
+        "type": "Element",
+        "name": "section"
+      }
     },
     {
       "moduleName": "ToolbarBatchActions",
@@ -14064,7 +16964,7 @@
           "kind": "let",
           "description": "Override the total items selected text",
           "type": "(totalSelected: number) => string",
-          "value": "(totalSelected) =>     `${totalSelected} item${totalSelected === 1 ? \"\" : \"s\"} selected`",
+          "value": "(totalSelected) =>\n  `${totalSelected} item${totalSelected === 1 ? \"\" : \"s\"} selected`",
           "isFunction": true,
           "isFunctionDeclaration": false,
           "isRequired": false,
@@ -14085,7 +16985,11 @@
       ],
       "moduleExports": [],
       "slots": [
-        { "name": "__default__", "default": true, "slot_props": "{}" },
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "{}"
+        },
         {
           "name": "cancel",
           "default": false,
@@ -14093,17 +16997,32 @@
           "slot_props": "{}"
         }
       ],
-      "events": [{ "type": "dispatched", "name": "cancel", "detail": "null" }],
+      "events": [
+        {
+          "type": "dispatched",
+          "name": "cancel",
+          "detail": "null"
+        }
+      ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": {
+        "type": "Element",
+        "name": "div"
+      }
     },
     {
       "moduleName": "ToolbarContent",
       "filePath": "src/DataTable/ToolbarContent.svelte",
       "props": [],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "{}"
+        }
+      ],
       "events": [],
       "typedefs": [],
       "generics": null
@@ -14113,11 +17032,20 @@
       "filePath": "src/DataTable/ToolbarMenu.svelte",
       "props": [],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "{}"
+        }
+      ],
       "events": [],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "InlineComponent", "name": "OverflowMenu" },
+      "rest_props": {
+        "type": "InlineComponent",
+        "name": "OverflowMenu"
+      },
       "extends": {
         "interface": "OverflowMenuProps",
         "import": "\"../OverflowMenu/OverflowMenu.svelte\""
@@ -14128,9 +17056,19 @@
       "filePath": "src/DataTable/ToolbarMenuItem.svelte",
       "props": [],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "{}"
+        }
+      ],
       "events": [
-        { "type": "forwarded", "name": "click", "element": "OverflowMenuItem" },
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "OverflowMenuItem"
+        },
         {
           "type": "forwarded",
           "name": "keydown",
@@ -14139,7 +17077,10 @@
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "InlineComponent", "name": "OverflowMenuItem" },
+      "rest_props": {
+        "type": "InlineComponent",
+        "name": "OverflowMenuItem"
+      },
       "extends": {
         "interface": "OverflowMenuItemProps",
         "import": "\"../OverflowMenu/OverflowMenuItem.svelte\""
@@ -14249,18 +17190,53 @@
       "moduleExports": [],
       "slots": [],
       "events": [
-        { "type": "dispatched", "name": "clear", "detail": "null" },
-        { "type": "forwarded", "name": "change", "element": "Search" },
-        { "type": "forwarded", "name": "input", "element": "Search" },
-        { "type": "forwarded", "name": "focus", "element": "Search" },
-        { "type": "forwarded", "name": "blur", "element": "Search" },
-        { "type": "forwarded", "name": "keyup", "element": "Search" },
-        { "type": "forwarded", "name": "keydown", "element": "Search" },
-        { "type": "forwarded", "name": "paste", "element": "Search" }
+        {
+          "type": "dispatched",
+          "name": "clear",
+          "detail": "null"
+        },
+        {
+          "type": "forwarded",
+          "name": "change",
+          "element": "Search"
+        },
+        {
+          "type": "forwarded",
+          "name": "input",
+          "element": "Search"
+        },
+        {
+          "type": "forwarded",
+          "name": "focus",
+          "element": "Search"
+        },
+        {
+          "type": "forwarded",
+          "name": "blur",
+          "element": "Search"
+        },
+        {
+          "type": "forwarded",
+          "name": "keyup",
+          "element": "Search"
+        },
+        {
+          "type": "forwarded",
+          "name": "keydown",
+          "element": "Search"
+        },
+        {
+          "type": "forwarded",
+          "name": "paste",
+          "element": "Search"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "input" }
+      "rest_props": {
+        "type": "Element",
+        "name": "input"
+      }
     },
     {
       "moduleName": "Tooltip",
@@ -14436,7 +17412,11 @@
       ],
       "moduleExports": [],
       "slots": [
-        { "name": "__default__", "default": true, "slot_props": "{}" },
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "{}"
+        },
         {
           "name": "icon",
           "default": false,
@@ -14451,14 +17431,33 @@
         }
       ],
       "events": [
-        { "type": "dispatched", "name": "open", "detail": "null" },
-        { "type": "dispatched", "name": "close", "detail": "null" },
-        { "type": "forwarded", "name": "click", "element": "div" },
-        { "type": "forwarded", "name": "mousedown", "element": "div" }
+        {
+          "type": "dispatched",
+          "name": "open",
+          "detail": "null"
+        },
+        {
+          "type": "dispatched",
+          "name": "close",
+          "detail": "null"
+        },
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "div"
+        },
+        {
+          "type": "forwarded",
+          "name": "mousedown",
+          "element": "div"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "div" }
+      "rest_props": {
+        "type": "Element",
+        "name": "div"
+      }
     },
     {
       "moduleName": "TooltipDefinition",
@@ -14539,7 +17538,11 @@
       ],
       "moduleExports": [],
       "slots": [
-        { "name": "__default__", "default": true, "slot_props": "{}" },
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "{}"
+        },
         {
           "name": "tooltip",
           "default": false,
@@ -14548,17 +17551,48 @@
         }
       ],
       "events": [
-        { "type": "dispatched", "name": "open", "detail": "null" },
-        { "type": "dispatched", "name": "close", "detail": "null" },
-        { "type": "forwarded", "name": "click", "element": "button" },
-        { "type": "forwarded", "name": "mouseover", "element": "button" },
-        { "type": "forwarded", "name": "mouseenter", "element": "button" },
-        { "type": "forwarded", "name": "mouseleave", "element": "button" },
-        { "type": "forwarded", "name": "focus", "element": "button" }
+        {
+          "type": "dispatched",
+          "name": "open",
+          "detail": "null"
+        },
+        {
+          "type": "dispatched",
+          "name": "close",
+          "detail": "null"
+        },
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "button"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseover",
+          "element": "button"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "button"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "button"
+        },
+        {
+          "type": "forwarded",
+          "name": "focus",
+          "element": "button"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "span" }
+      "rest_props": {
+        "type": "Element",
+        "name": "span"
+      }
     },
     {
       "moduleName": "TooltipFooter",
@@ -14578,7 +17612,13 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "{}"
+        }
+      ],
       "events": [],
       "typedefs": [],
       "generics": null
@@ -14687,15 +17727,38 @@
         }
       ],
       "events": [
-        { "type": "forwarded", "name": "click", "element": "button" },
-        { "type": "forwarded", "name": "mouseover", "element": "button" },
-        { "type": "forwarded", "name": "mouseenter", "element": "button" },
-        { "type": "forwarded", "name": "mouseleave", "element": "button" },
-        { "type": "forwarded", "name": "focus", "element": "button" }
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "button"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseover",
+          "element": "button"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "button"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "button"
+        },
+        {
+          "type": "forwarded",
+          "name": "focus",
+          "element": "button"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "button" }
+      "rest_props": {
+        "type": "Element",
+        "name": "button"
+      }
     },
     {
       "moduleName": "TreeView",
@@ -14790,7 +17853,7 @@
           "kind": "function",
           "description": "Programmatically expand all nodes",
           "type": "() => void",
-          "value": "() => {     expandedIds = [...nodeIds];   }",
+          "value": "() => {\n  expandedIds = [...nodeIds];\n}",
           "isFunction": true,
           "isFunctionDeclaration": true,
           "isRequired": false,
@@ -14802,7 +17865,7 @@
           "kind": "function",
           "description": "Programmatically collapse all nodes",
           "type": "() => void",
-          "value": "() => {     expandedIds = [];   }",
+          "value": "() => {\n  expandedIds = [];\n}",
           "isFunction": true,
           "isFunctionDeclaration": true,
           "isRequired": false,
@@ -14814,7 +17877,7 @@
           "kind": "function",
           "description": "Programmatically expand a subset of nodes.\nExpands all nodes if no argument is provided",
           "type": "(filterId?: (node: TreeNode) => boolean) => void",
-          "value": "() => {     expandedIds = flattenedNodes       .filter(         (node) =>           filterNode(node) ||           node.nodes?.some((child) => filterNode(child) && child.nodes),       )       .map((node) => node.id);   }",
+          "value": "() => {\n  expandedIds = flattenedNodes\n    .filter(\n      (node) =>\n        filterNode(node) ||\n        node.nodes?.some((child) => filterNode(child) && child.nodes),\n    )\n    .map((node) => node.id);\n}",
           "isFunction": true,
           "isFunctionDeclaration": true,
           "isRequired": false,
@@ -14826,7 +17889,7 @@
           "kind": "function",
           "description": "Programmatically collapse a subset of nodes.\nCollapses all nodes if no argument is provided",
           "type": "(filterId?: (node: TreeNode) => boolean) => void",
-          "value": "() => {     expandedIds = flattenedNodes       .filter((node) => expandedIds.includes(node.id) && !filterNode(node))       .map((node) => node.id);   }",
+          "value": "() => {\n  expandedIds = flattenedNodes\n    .filter((node) => expandedIds.includes(node.id) && !filterNode(node))\n    .map((node) => node.id);\n}",
           "isFunction": true,
           "isFunctionDeclaration": true,
           "isRequired": false,
@@ -14838,7 +17901,7 @@
           "kind": "function",
           "description": "Programmatically show a node by `id`.\nThe matching node will be expanded, selected, and focused",
           "type": "(id: TreeNodeId) => void",
-          "value": "() => {     for (const child of nodes) {       const nodes = findNodeById(child, id);       if (nodes) {         const ids = nodes.map((node) => node.id);         const nodeIds = new Set(ids);         expandNodes((node) => nodeIds.has(node.id));         const lastId = ids[ids.length - 1];         activeId = lastId;         selectedIds = [lastId];         tick().then(() => {           ref?.querySelector(`[id=\"${lastId}\"]`)?.focus();         });         break;       }     }   }",
+          "value": "() => {\n  for (const child of nodes) {\n    const nodes = findNodeById(child, id);\n    if (nodes) {\n      const ids = nodes.map((node) => node.id);\n      const nodeIds = new Set(ids);\n      expandNodes((node) => nodeIds.has(node.id));\n      const lastId = ids[ids.length - 1];\n      activeId = lastId;\n      selectedIds = [lastId];\n      tick().then(() => {\n        ref?.querySelector(`[id=\"${lastId}\"]`)?.focus();\n      });\n      break;\n    }\n  }\n}",
           "isFunction": true,
           "isFunctionDeclaration": true,
           "isRequired": false,
@@ -14852,7 +17915,7 @@
           "name": "__default__",
           "default": true,
           "fallback": "{node.text}",
-          "slot_props": "{ node: { id: TreeNodeId; text: string; expanded: boolean, leaf: boolean; disabled: boolean; selected: boolean; } }"
+          "slot_props": "{\n  node: {\n    id: TreeNodeId;\n    text: string;\n    expanded: boolean;\n    leaf: boolean;\n    disabled: boolean;\n    selected: boolean;\n  };\n}"
         },
         {
           "name": "labelText",
@@ -14865,34 +17928,41 @@
         {
           "type": "dispatched",
           "name": "select",
-          "detail": "TreeNode & { expanded: boolean; leaf: boolean; }"
+          "detail": "TreeNode & { expanded: boolean; leaf: boolean }"
         },
         {
           "type": "dispatched",
           "name": "toggle",
-          "detail": "TreeNode & { expanded: boolean; leaf: boolean; }"
+          "detail": "TreeNode & { expanded: boolean; leaf: boolean }"
         },
         {
           "type": "dispatched",
           "name": "focus",
-          "detail": "TreeNode & { expanded: boolean; leaf: boolean; }"
+          "detail": "TreeNode & { expanded: boolean; leaf: boolean }"
         },
-        { "type": "forwarded", "name": "keydown", "element": "ul" }
+        {
+          "type": "forwarded",
+          "name": "keydown",
+          "element": "ul"
+        }
       ],
       "typedefs": [
         {
           "type": "string | number",
           "name": "TreeNodeId",
-          "ts": "type TreeNodeId = string | number"
+          "ts": "type TreeNodeId = string | number;\n"
         },
         {
           "type": "{ id: TreeNodeId; text: any; icon?: typeof import(\"svelte\").SvelteComponent<any>; disabled?: boolean; nodes?: TreeNode[]; }",
           "name": "TreeNode",
-          "ts": "interface TreeNode { id: TreeNodeId; text: any; icon?: typeof import(\"svelte\").SvelteComponent<any>; disabled?: boolean; nodes?: TreeNode[]; }"
+          "ts": "interface TreeNode {\n  id: TreeNodeId;\n  text: any;\n  icon?: typeof import(\"svelte\").SvelteComponent<any>;\n  disabled?: boolean;\n  nodes?: TreeNode[];\n}\n"
         }
       ],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "ul" }
+      "rest_props": {
+        "type": "Element",
+        "name": "ul"
+      }
     },
     {
       "moduleName": "Truncate",
@@ -14911,11 +17981,20 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "{}"
+        }
+      ],
       "events": [],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "p" }
+      "rest_props": {
+        "type": "Element",
+        "name": "p"
+      }
     },
     {
       "moduleName": "UnorderedList",
@@ -14947,16 +18026,41 @@
         }
       ],
       "moduleExports": [],
-      "slots": [{ "name": "__default__", "default": true, "slot_props": "{}" }],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "slot_props": "{}"
+        }
+      ],
       "events": [
-        { "type": "forwarded", "name": "click", "element": "ul" },
-        { "type": "forwarded", "name": "mouseover", "element": "ul" },
-        { "type": "forwarded", "name": "mouseenter", "element": "ul" },
-        { "type": "forwarded", "name": "mouseleave", "element": "ul" }
+        {
+          "type": "forwarded",
+          "name": "click",
+          "element": "ul"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseover",
+          "element": "ul"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseenter",
+          "element": "ul"
+        },
+        {
+          "type": "forwarded",
+          "name": "mouseleave",
+          "element": "ul"
+        }
       ],
       "typedefs": [],
       "generics": null,
-      "rest_props": { "type": "Element", "name": "ul" }
+      "rest_props": {
+        "type": "Element",
+        "name": "ul"
+      }
     }
   ]
 }

--- a/docs/src/components/ComponentApi.svelte
+++ b/docs/src/components/ComponentApi.svelte
@@ -127,7 +127,6 @@
                       <svelte:component
                         this={AsyncPreviewTypeScript}
                         type="inline"
-                        noFormat
                         code={typeMap[type]}
                       />
                     </div>
@@ -138,7 +137,6 @@
                       <svelte:component
                         this={AsyncPreviewTypeScript}
                         type="inline"
-                        noFormat
                         code={type}
                       />
                     </div>
@@ -152,7 +150,6 @@
                       <svelte:component
                         this={AsyncPreviewTypeScript}
                         type="inline"
-                        noFormat
                         code={type}
                       />
                     </div>
@@ -179,8 +176,7 @@
                   <svelte:component
                     this={AsyncPreviewTypeScript}
                     type="inline"
-                    noFormat
-                    code={prop.value.replace(/\s+/g, " ")}
+                    code={prop.value}
                   />
                 {/if}
               {:else if prop.value === undefined}
@@ -189,7 +185,6 @@
                 <svelte:component
                   this={AsyncPreviewTypeScript}
                   type="inline"
-                  noFormat
                   code={prop.value}
                 />
               {/if}
@@ -220,21 +215,41 @@
 <h2 id="typedefs">Typedefs</h2>
 
 {#if component.typedefs.length > 0}
-  <svelte:component
-    this={AsyncPreviewTypeScript}
-    code={component.typedefs.map((t) => t.ts).join(";\n\n")}
-  />
+  <div class="my-layout-01-03">
+    <svelte:component
+      this={AsyncPreviewTypeScript}
+      code={component.typedefs.map((t) => t.ts).join("\n")}
+    />
+  </div>
 {:else}
   <p class="my-layout-01-03">No typedefs.</p>
 {/if}
 
 <h2 id="slots">Slots</h2>
 {#if component.slots.length > 0}
-  <UnorderedList class="my-layout-01-03">
-    {#each component.slots as slot (slot.name)}
-      <ListItem>{slot.default ? "default" : slot.name}</ListItem>
-    {/each}
-  </UnorderedList>
+  <StructuredList class="my-layout-01-03">
+    <StructuredListHead>
+      <StructuredListRow>
+        <StructuredListCell>Slot name</StructuredListCell>
+        <StructuredListCell>Slot detail</StructuredListCell>
+      </StructuredListRow>
+    </StructuredListHead>
+    <StructuredListBody>
+      {#each component.slots as slot (slot.name)}
+        <StructuredListRow>
+          <StructuredListCell>
+            <strong>{slot.default ? "default" : slot.name}</strong>
+          </StructuredListCell>
+          <StructuredListCell>
+            <svelte:component
+              this={AsyncPreviewTypeScript}
+              code={slot.slot_props}
+            />
+          </StructuredListCell>
+        </StructuredListRow>
+      {/each}
+    </StructuredListBody>
+  </StructuredList>
 {:else}
   <p class="my-layout-01-03">No slots.</p>
 {/if}
@@ -273,7 +288,7 @@
           <StructuredListCell>
             <svelte:component
               this={AsyncPreviewTypeScript}
-              code={"type EventDetail = " + event.detail}
+              code={event.detail}
             />
           </StructuredListCell>
           <StructuredListCell>
@@ -317,12 +332,7 @@
     </div>
   {/if}
   {#if full_code}
-    <svelte:component
-      this={AsyncPreviewTypeScript}
-      code={full_code.startsWith("()")
-        ? `const ${full_code_prop} = ` + full_code
-        : full_code}
-    />
+    <svelte:component this={AsyncPreviewTypeScript} code={full_code} />
   {/if}
 </Modal>
 

--- a/docs/src/components/Preview.svelte
+++ b/docs/src/components/Preview.svelte
@@ -35,7 +35,8 @@
   {/if}
   <div class="preview-viewer" class:framed>
     {#if framed}
-      <iframe loading="lazy" title={src.split("/").pop()} src={themedSrcUrl}></iframe>
+      <iframe loading="lazy" title={src.split("/").pop()} src={themedSrcUrl}
+      ></iframe>
     {:else}
       <slot />
     {/if}

--- a/docs/src/components/PreviewTypeScript.svelte
+++ b/docs/src/components/PreviewTypeScript.svelte
@@ -1,30 +1,14 @@
 <script>
   export let code = "";
-  export let noFormat = false;
   export let type = "multi";
 
   import { CodeSnippet } from "carbon-components-svelte";
-  import { format } from "prettier/standalone";
   import { highlight } from "prismjs";
   import "prismjs/components/prism-typescript";
-  import plugin from "prettier/parser-typescript";
   import copy from "clipboard-copy";
 
-  let formattedCode = "";
-  let highlightedCode = "";
-
-  $: {
-    try {
-      formattedCode = noFormat
-        ? code
-        : format(code, { parser: "typescript", plugins: [plugin] });
-    } catch (e) {
-      formattedCode = code;
-    }
-  }
-
   $: highlightedCode = highlight(
-    formattedCode,
+    code,
     Prism.languages.typescript,
     "typescript",
   );
@@ -32,19 +16,14 @@
 
 {#if type === "multi"}
   <div class="code-override">
-    <CodeSnippet type="multi" code={formattedCode} {copy}>
+    <CodeSnippet type="multi" {code} {copy}>
       {@html highlightedCode}
     </CodeSnippet>
   </div>
 {/if}
 
 {#if type === "inline"}
-  <CodeSnippet
-    type="inline"
-    class="code-override-inline"
-    code={formattedCode}
-    {copy}
-  >
+  <CodeSnippet type="inline" class="code-override-inline" {code} {copy}>
     {@html highlightedCode}
   </CodeSnippet>
 {/if}

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "test:types": "svelte-check --workspace tests",
     "lint": "prettier --write --cache \"**/*.{svelte,md,js,json,ts}\"",
     "build:css": "node scripts/build-css",
-    "build:docs": "node scripts/build-docs",
+    "build:docs": "node scripts/build-docs && node scripts/format-component-api",
     "postinstall": "ibmtelemetry --config=telemetry.yml",
     "release": "standard-version && npm run build:docs"
   },

--- a/scripts/format-component-api.js
+++ b/scripts/format-component-api.js
@@ -1,0 +1,111 @@
+// @ts-check
+import fs from "node:fs";
+import componentApi from "../docs/src/COMPONENT_API.json" assert { type: "json" };
+import { format } from "prettier";
+import plugin from "prettier/plugins/typescript";
+
+const formatTypeScript = async (value) => {
+  return await format(value, { parser: "typescript", plugins: [plugin] });
+};
+
+console.time("formatComponentApi");
+
+let modified = { ...componentApi };
+
+modified.components = await Promise.all(
+  componentApi.components.map(async (component) => {
+    component.props = await Promise.all(
+      component.props.map(async (prop) => {
+        if (!prop.value || !/\s{2,}/.test(prop.value)) {
+          return prop;
+        }
+
+        let normalizedValue = prop.value;
+        let prefix = `const ${prop.name} = `;
+
+        if (prop.isFunction || prop.value.startsWith("{")) {
+          normalizedValue = prefix + prop.value;
+        }
+
+        const formatted = (await formatTypeScript(normalizedValue))
+          // Remove prefix needed for formatting.
+          .replace(new RegExp(`^${prefix}`), "")
+          // Remove trailing semi-colon.
+          .replace(/;\s*$/, "");
+
+        return {
+          ...prop,
+          value: formatted,
+        };
+      }),
+    );
+
+    component.typedefs = await Promise.all(
+      component.typedefs.map(async (typedef) => {
+        if (!typedef.ts) {
+          return typedef;
+        }
+
+        return {
+          ...typedef,
+          ts: await formatTypeScript(typedef.ts),
+        };
+      }),
+    );
+
+    component.events = await Promise.all(
+      component.events.map(async (event) => {
+        if (event.type === "forwarded") {
+          return event;
+        }
+
+        let normalizedValue = `type EventDetail = ` + event.detail;
+
+        const formatted = (await formatTypeScript(normalizedValue))
+          // Remove prefix needed for formatting.
+          .replace(/type EventDetail = /, "")
+          // Remove trailing semi-colon.
+          .replace(/;\s*$/, "");
+
+        return {
+          ...event,
+          detail: formatted,
+        };
+      }),
+    );
+
+    component.slots = await Promise.all(
+      component.slots.map(async (slot) => {
+        if (!slot.slot_props) {
+          return slot;
+        }
+
+        let normalizedValue = slot.slot_props;
+
+        if (normalizedValue.startsWith("{")) {
+          normalizedValue = `type SlotProps = ` + normalizedValue;
+        }
+
+        const formatted = (await formatTypeScript(normalizedValue))
+          // Remove prefix needed for formatting.
+          .replace(/type SlotProps = /, "")
+          // Remove trailing semi-colon.
+          .replace(/;\s*$/, "");
+
+        return {
+          ...slot,
+          slot_props: formatted,
+        };
+      }),
+    );
+
+    return component;
+  }),
+);
+
+fs.writeFileSync(
+  "./docs/src/COMPONENT_API.json",
+  JSON.stringify(modified, null, 2),
+);
+
+console.timeEnd("formatComponentApi");


### PR DESCRIPTION
Pre-process the COMPONENT_API.json to avoid using Prettier on the client-side. Reduces the bundle size. This also adds the slot detail to the component metadata section. Previously, only the slot name was included.