### PR TITLE
fix(tooltip-icon): `button` should have explicit `type`

### DIFF
--- a/src/TooltipIcon/TooltipIcon.svelte
+++ b/src/TooltipIcon/TooltipIcon.svelte
@@ -46,6 +46,7 @@
 <button
   bind:this={ref}
   {disabled}
+  type="button"
   aria-describedby={id}
   class:bx--tooltip__trigger={true}
   class:bx--tooltip--a11y={true}


### PR DESCRIPTION
The button element should have an explicit `type="button"` to avoid inadvertent form submission. If inside a `form`, the implicit role is "submit."