### PR TITLE
chore: exclude auto-generated `COMPONENT_API` from formatting

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -6,3 +6,4 @@ dist
 client
 build
 *.svx
+COMPONENT_API.json

--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -3235,7 +3235,10 @@
           "ts": "interface DataTableCell<\n  Row = DataTableRow,\n> {\n  key:\n    | DataTableKey<Row>\n    | (string & {});\n  value: DataTableValue;\n  display?: (\n    item: DataTableValue,\n    row: DataTableRow,\n  ) => DataTableValue;\n}\n"
         }
       ],
-      "generics": ["Row", "Row extends DataTableRow = DataTableRow"],
+      "generics": [
+        "Row",
+        "Row extends DataTableRow = DataTableRow"
+      ],
       "rest_props": {
         "type": "Element",
         "name": "div"


### PR DESCRIPTION
`COMPONENT_API.json` is auto-generated by Sveld and has its own format style.

Instruct Prettier to ignore this file. This should also make the lint step slightly faster.