### PR TITLE
fix(data-table): prefix internal ID for radio button, checkbox

### DIFF
--- a/src/DataTable/DataTable.svelte
+++ b/src/DataTable/DataTable.svelte
@@ -170,6 +170,10 @@
   const batchSelectedIds = writable(false);
   const tableRows = writable(rows);
 
+  // Internal ID prefix for radio buttons, checkboxes, etc.
+  // since there may be multiple `DataTable` instances that have overlapping row ids.
+  const id = "ccs-" + Math.random().toString(36);
+
   // Store a copy of the original rows for filter restoration.
   $: originalRows = [...rows];
 
@@ -499,7 +503,7 @@
               {#if !nonSelectableRowIds.includes(row.id)}
                 {#if radio}
                   <RadioButton
-                    name="select-row-{row.id}"
+                    name="{id}-{row.id}"
                     checked={selectedRowIds.includes(row.id)}
                     on:change={() => {
                       selectedRowIds = [row.id];
@@ -508,7 +512,7 @@
                   />
                 {:else}
                   <InlineCheckbox
-                    name="select-row-{row.id}"
+                    name="{id}-{row.id}"
                     checked={selectedRowIds.includes(row.id)}
                     on:change={() => {
                       if (selectedRowIds.includes(row.id)) {

--- a/tests/App.test.svelte
+++ b/tests/App.test.svelte
@@ -4,6 +4,7 @@
   import Accordion from "./Accordion/Accordion.test.svelte";
   import AccordionProgrammatic from "./Accordion/Accordion.programmatic.test.svelte";
   import AccordionDisabled from "./Accordion/Accordion.disabled.test.svelte";
+  import DuplicateDataTables from "./DataTable/DuplicateDataTables.test.svelte";
   import TreeView from "./TreeView/TreeView.test.svelte";
   import TreeViewHierarchy from "./TreeView/TreeView.hierarchy.test.svelte";
   import RecursiveList from "./RecursiveList/RecursiveList.test.svelte";
@@ -31,6 +32,11 @@
       path: "/accordion-disabled",
       name: "AccordionDisabled",
       component: AccordionDisabled,
+    },
+    {
+      path: "/data-table",
+      name: "DataTable",
+      component: DuplicateDataTables,
     },
     {
       path: "/recursive-list",

--- a/tests/DataTable/DuplicateDataTables.test.svelte
+++ b/tests/DataTable/DuplicateDataTables.test.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  import { DataTable } from "carbon-components-svelte";
+
+  const headers = [
+    { key: "id", value: "id" },
+    { key: "contact.company", value: "Company name" },
+  ] as const;
+
+  const rows = [
+    { id: "1", contact: { company: "Company 1" } },
+    { id: "2", contact: { company: "Company 2" } },
+  ];
+</script>
+
+<DataTable radio {headers} {rows} />
+<DataTable radio {headers} {rows} />


### PR DESCRIPTION
Fixes #2081

Create an internal ID prefix for the radio buttons and checkboxes used within `DataTable`.

This addresses the case where multiple `DataTable` instances may be instantiated, and the data contains overlapping IDs in `rows`.