### PR TITLE
fix: avoid manual `blur` in `Dropdown`, `MultiSelect` to allow keyboard navigation in Firefox

### DIFF
--- a/src/Dropdown/Dropdown.svelte
+++ b/src/Dropdown/Dropdown.svelte
@@ -250,7 +250,6 @@
           }
         } else if (key === "Tab") {
           open = false;
-          ref.blur();
         } else if (key === "ArrowDown") {
           if (!open) open = true;
           change(1);

--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -374,7 +374,6 @@
             selectionRef.focus();
           } else {
             open = false;
-            fieldRef.blur();
           }
         } else if (key === "ArrowDown") {
           change(1);
@@ -414,7 +413,6 @@
               ...item,
               checked: false,
             }));
-            if (fieldRef) fieldRef.blur();
           }}
           translateWithId={translateWithIdSelection}
           {disabled}
@@ -450,7 +448,6 @@
               }
             } else if (key === "Tab") {
               open = false;
-              inputRef.blur();
             } else if (key === "ArrowDown") {
               change(1);
             } else if (key === "ArrowUp") {


### PR DESCRIPTION
Fixes #2083

There's a bug in Firefox where the focus is trapped inside the Dropdown button and MultiSelect field. I was able to repro with the latest FF version 134.0.1 (64-bit).

From my research, the symptoms seem similar to this [bug report](https://bugzilla.mozilla.org/show_bug.cgi?id=53579) (although the report itself is over a decade old, and has reportedly been fixed).

This removes the unnecessary manual `blur` in the "Tab" events. I've also tested Chrome, Safari, and the behavior is consistent.