### PR TITLE
fix(data-table): improve `expandable` accessibility

### DIFF
--- a/src/DataTable/DataTable.svelte
+++ b/src/DataTable/DataTable.svelte
@@ -350,6 +350,8 @@
               <button
                 type="button"
                 class:bx--table-expand__button={true}
+                aria-label={expanded ? "Collapse all rows" : "Expand all rows"}
+                aria-controls={expandableRowIds.map(id => `expandable-row-${id}`).join(" ")}
                 on:click={() => {
                   expanded = !expanded;
                   expandedRowIds = expanded ? expandableRowIds : [];
@@ -357,7 +359,7 @@
                   dispatch("click:header--expand", { expanded });
                 }}
               >
-                <ChevronRight class="bx--table-expand__svg" />
+                <ChevronRight aria-hidden="true" class="bx--table-expand__svg" />
               </button>
             {/if}
           </th>
@@ -470,6 +472,7 @@
                 <button
                   type="button"
                   class:bx--table-expand__button={true}
+                  aria-controls={`expandable-row-${row.id}`}
                   aria-label={expandedRows[row.id]
                     ? "Collapse current row"
                     : "Expand current row"}
@@ -486,7 +489,7 @@
                     });
                   }}
                 >
-                  <ChevronRight class="bx--table-expand__svg" />
+                  <ChevronRight aria-hidden="true" class="bx--table-expand__svg" />
                 </button>
               {/if}
             </TableCell>
@@ -550,6 +553,7 @@
 
         {#if expandable}
           <tr
+            id={`expandable-row-${row.id}`}
             data-child-row
             class:bx--expandable-row={true}
             on:mouseenter={() => {


### PR DESCRIPTION
Improves the accessibility of an expandable `DataTable`.

Adds in missing:

- `aria-controls` < > `id` attributes
- Sets `aria-hidden="true"` on expandable icons since the button already has a label