### PR TITLE
fix(text-area): counter supports null `value`

### DIFF
--- a/src/TextArea/TextArea.svelte
+++ b/src/TextArea/TextArea.svelte
@@ -85,7 +85,7 @@
       </label>
       {#if maxCount}
         <div class:bx--label={true} class:bx--label--disabled={disabled}>
-          {value.length}/{maxCount}
+          {value?.length || 0}/{maxCount}
         </div>
       {/if}
     </div>

--- a/src/TextArea/TextArea.svelte
+++ b/src/TextArea/TextArea.svelte
@@ -85,7 +85,7 @@
       </label>
       {#if maxCount}
         <div class:bx--label={true} class:bx--label--disabled={disabled}>
-          {((value ?? '').length)}/{maxCount}
+          {(value ?? "").length}/{maxCount}
         </div>
       {/if}
     </div>

--- a/src/TextArea/TextArea.svelte
+++ b/src/TextArea/TextArea.svelte
@@ -85,7 +85,7 @@
       </label>
       {#if maxCount}
         <div class:bx--label={true} class:bx--label--disabled={disabled}>
-          {value?.length || 0}/{maxCount}
+          {((value ?? '').length)}/{maxCount}
         </div>
       {/if}
     </div>


### PR DESCRIPTION
The [TextArea](https://svelte.carbondesignsystem.com/components/TextArea) component allows `null` [value](https://github.com/carbon-design-system/carbon-components-svelte/blob/master/src/TextArea/TextArea.svelte#L2-L6), however the component breaks when a null value is provided/bound to the value property since "_Cannot read properties of null (reading 'length')_" at [line 88](https://github.com/carbon-design-system/carbon-components-svelte/blob/master/src/TextArea/TextArea.svelte#L88).