### PR TITLE
fix(tag): allow `on:close` to work with Svelte 5

### DIFF
--- a/src/Tag/Tag.svelte
+++ b/src/Tag/Tag.svelte
@@ -82,7 +82,7 @@
       class:bx--tag__close-icon={true}
       {disabled}
       {title}
-      on:click|stopPropagation
+      on:click
       on:click|stopPropagation={() => {
         dispatch("close");
       }}


### PR DESCRIPTION
Fixes #2096

Interestingly, `<Tag filter on:close />` does not fire because the forwarded `on:click` uses the `stopPropagation` modifier.

Removing it allows the dispatched "close" event to fire. `on:close` is effectively an alias for `on:click`, which is only forwarded to the button for a filterable tag.

## Expected

Both "click" and "close" should be logged.

```svelte
<Tag
  filter
  on:click={() => {
    console.log("click");
  }}
  on:close={() => {
    console.log("close");
  }}
>
  Tag
</Tag>
```

## Expected

If the consumer manually stops propagation, "click" is logged but "close" will not. This works in Svelte 5, but not Svelte 4.

```svelte
<Tag
  filter
  on:click={(e) => {
    e.stopPropagation();
    console.log("click");
  }}
  on:close={() => {
    console.log("close");
  }}
>
  Tag
</Tag>
```