### PR TITLE
fix(select): falsy item `text` should not override value

### DIFF
--- a/src/Select/SelectItem.svelte
+++ b/src/Select/SelectItem.svelte
@@ -55,5 +55,5 @@
   class={className}
   {style}
 >
-  {text || value}
+  {text ?? value}
 </option>

--- a/tests/Select/Select.falsy.test.svelte
+++ b/tests/Select/Select.falsy.test.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+  import { Select, SelectItem } from "carbon-components-svelte";
+</script>
+
+<Select labelText="Falsy text">
+  <SelectItem value={-1} text="" />
+  <SelectItem value={0} text="Zero" />
+  <SelectItem value={1} text="One" />
+</Select>

--- a/tests/Select/Select.test.ts
+++ b/tests/Select/Select.test.ts
@@ -3,6 +3,7 @@ import { user } from "../setup-tests";
 import Select from "./Select.test.svelte";
 import SelectGroup from "./Select.group.test.svelte";
 import SelectSkeleton from "./Select.skeleton.test.svelte";
+import SelectFalsy from "./Select.falsy.test.svelte";
 
 describe("Select", () => {
   beforeEach(() => {
@@ -237,5 +238,12 @@ describe("Select", () => {
     const skeleton = screen.getByTestId("select-skeleton");
     expect(skeleton).toBeInTheDocument();
     expect(skeleton.children[0]).toHaveClass("bx--skeleton");
+  });
+
+  it("renders value if `text` is falsy", () => {
+    render(SelectFalsy);
+
+    expect(screen.getByLabelText("Falsy text")).toHaveValue("-1");
+    expect(screen.getByDisplayValue("")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Fixes #2117

The logical OR operator in `SelectItem` currently defaults to `value` if the provided `text` is falsy (e.g., empty string).

Intead, it should coalesce to `value` if `text` is `null` or `undefined`.