### PR TITLE
fix(ui-shell): `HeaderAction` uses dark color scheme

### DIFF
--- a/src/UIShell/HeaderAction.svelte
+++ b/src/UIShell/HeaderAction.svelte
@@ -126,6 +126,7 @@
     class:bx--header-panel={true}
     class:bx--header-panel--expanded={true}
     style:overflow-y="auto"
+    style:color-scheme="dark"
     transition:slide|local={{
       ...transition,
       duration: transition === false ? 0 : transition.duration,


### PR DESCRIPTION
Currently, the UI Shell only supports the dark theme. The `HeaderAction` panel should instruct browsers to apply a dark color scheme to the scrollbar.

## Before

<img width="454" alt="Screenshot 2025-03-11 at 5 12 45 PM" src="https://github.com/user-attachments/assets/27876c30-7dcd-4dbb-b7eb-3ab98bad0af8" />

## After

<img width="454" alt="Screenshot 2025-03-11 at 5 12 35 PM" src="https://github.com/user-attachments/assets/c6341c17-720f-448c-9cec-c4cb14447113" />

