### PR TITLE
fix: ComboBox tab handling

### DIFF
--- a/src/ComboBox/ComboBox.svelte
+++ b/src/ComboBox/ComboBox.svelte
@@ -175,7 +175,6 @@
       filteredItems = [];
       if (!selectedItem) {
         selectedId = undefined;
-        value = "";
         highlightedIndex = -1;
         highlightedId = undefined;
       } else {
@@ -283,7 +282,13 @@
             open = true;
           }
         }}
-        on:keydown
+        on:keydown={(e) => {
+          // If there's a selection and user types a printable character, clear selection immediately
+          if (e.key.length === 1 && selectedItem) {
+            selectedId = undefined;
+            selectedItem = undefined;
+          }
+        }}
         on:keydown|stopPropagation={(e) => {
           const { key } = e;
           if (["Enter", "ArrowDown", "ArrowUp"].includes(key)) {


### PR DESCRIPTION
Trying to fix two issues with this:

1. when tabbing into a combobox, the initial character was not being input. Fixed via afterUpdate adjustment.
2. when tabbing into a combobox that already had a selection, the current selection was highlighted, but typing would not overwrite it. Instead it would place text (after skipping the first character) after the selection. Fixed via additional on:keydown