### PR TITLE
fix(list-box): use `aria-disabled` instead of invalid `disabled` attribute

### DIFF
--- a/src/ListBox/ListBoxMenuItem.svelte
+++ b/src/ListBox/ListBoxMenuItem.svelte
@@ -25,7 +25,7 @@
   class:bx--list-box__menu-item--active={active}
   class:bx--list-box__menu-item--highlighted={highlighted || active}
   aria-selected={active}
-  disabled={disabled ? true : undefined}
+  aria-disabled={disabled ? true : undefined}
   {...$$restProps}
   on:click
   on:mouseenter

--- a/tests/ComboBox/ComboBox.test.ts
+++ b/tests/ComboBox/ComboBox.test.ts
@@ -165,7 +165,7 @@ describe("ComboBox", () => {
     await user.click(screen.getByRole("textbox"));
     const disabledOption = screen.getByText(/Fax/).closest('[role="option"]');
     assert(disabledOption);
-    expect(disabledOption).toHaveAttribute("disabled", "true");
+    expect(disabledOption).toHaveAttribute("aria-disabled", "true");
 
     await user.click(disabledOption);
     expect(screen.getByRole("textbox")).toHaveValue("");


### PR DESCRIPTION
`ListBoxMenuItem` is used by `ComboBox`, `Dropdown`, and `MultiSelect`.

When the item has `disabled: true`, the disabled state for the item is applied. However, the `disabled` attribute on `<div role="option"` is invalid markup. This fixes it to use `aria-disabled` instead.