### PR TITLE
fix(notification): remove invalid `kind` prop from markup

### DIFF
--- a/src/Notification/InlineNotification.svelte
+++ b/src/Notification/InlineNotification.svelte
@@ -71,7 +71,6 @@
 {#if open}
   <div
     {role}
-    {kind}
     class:bx--inline-notification={true}
     class:bx--inline-notification--low-contrast={lowContrast}
     class:bx--inline-notification--hide-close-button={hideCloseButton}

--- a/src/Notification/ToastNotification.svelte
+++ b/src/Notification/ToastNotification.svelte
@@ -93,7 +93,6 @@
 {#if open}
   <div
     {role}
-    {kind}
     class:bx--toast-notification={true}
     class:bx--toast-notification--low-contrast={lowContrast}
     class:bx--toast-notification--error={kind === "error"}


### PR DESCRIPTION
The `kind` prop influences the style used for `InlineNotification` and `ToastNotification`.

However, the raw value is currently set on the underlying `div` element (e.g., `<div kind="info"`). `kind` is not a valid attribute, and exposing it in the markup feels unpolished. It was initially added [six years ago.](https://github.com/carbon-design-system/carbon-components-svelte/commit/94dceae1fba3c9ae37fb2e1d58b84a64f4ecfad7#diff-b2b441bceba9a2a52c4a99d48160c7a45775a0dfd044b60f9d82d862b8a162f0R37) This will no doubt [cause breakage](https://www.hyrumslaw.com/) if consumers rely on `[kind=*]` for styling or selection.