### PR TITLE
fix(theme): remove invalid `themes` prop from markup

### DIFF
--- a/src/Theme/Theme.svelte
+++ b/src/Theme/Theme.svelte
@@ -100,16 +100,18 @@
 {/if}
 
 {#if render === "toggle"}
+  {@const { themes: toggleThemes, ...toggleProps } = toggle}
   <Toggle
-    {...toggle}
-    toggled={theme === toggle.themes[1]}
+    {...toggleProps}
+    toggled={theme === toggleThemes[1]}
     on:toggle={({ detail }) => {
-      theme = detail.toggled ? toggle.themes[1] : toggle.themes[0];
+      theme = detail.toggled ? toggleThemes[1] : toggleThemes[0];
     }}
   />
 {:else if render === "select"}
-  <Select {...select} bind:selected={theme}>
-    {#each select.themes as theme (theme)}
+  {@const { themes: selectThemes, ...selectProps } = select}
+  <Select {...selectProps} bind:selected={theme}>
+    {#each selectThemes as theme (theme)}
       <SelectItem value={theme} text={themes[theme]} />
     {/each}
   </Select>

--- a/tests/Theme/Theme.test.ts
+++ b/tests/Theme/Theme.test.ts
@@ -130,14 +130,20 @@ describe("Theme", () => {
   it("should render custom toggle when render prop is set to toggle and custom toggle options are provided", async () => {
     render(ThemeToggleCustom);
 
+    const checkbox = screen.getByRole("switch");
+    assert(checkbox);
+    expect(checkbox).not.toBeChecked();
+
     const toggle = screen.getAllByText("Enable dark mode")[0];
     expect(toggle).toBeInTheDocument();
 
     await user.click(toggle);
     expect(consoleLog).toHaveBeenCalledWith("update", { theme: "g80" });
+    expect(checkbox).toBeChecked();
 
     await user.click(toggle);
     expect(consoleLog).toHaveBeenCalledWith("update", { theme: "g10" });
+    expect(checkbox).not.toBeChecked();
   });
 
   it("should render select when render prop is set to select", async () => {
@@ -145,11 +151,17 @@ describe("Theme", () => {
 
     const select = screen.getByLabelText("Themes");
     expect(select).toBeInTheDocument();
+    expect(select).toHaveTextContent("White");
+    expect(select).toHaveValue("white");
 
     await user.selectOptions(select, "g100");
+    expect(select).toHaveTextContent("Gray 100");
+    expect(select).toHaveValue("g100");
     expect(consoleLog).toHaveBeenCalledWith("update", { theme: "g100" });
 
     await user.selectOptions(select, "white");
+    expect(select).toHaveTextContent("White");
+    expect(select).toHaveValue("white");
     expect(consoleLog).toHaveBeenCalledWith("update", { theme: "white" });
   });
 
@@ -158,11 +170,17 @@ describe("Theme", () => {
 
     const select = screen.getByLabelText("Select a theme");
     expect(select).toBeInTheDocument();
+    expect(select).toHaveTextContent("White");
+    expect(select).toHaveValue("white");
 
     await user.selectOptions(select, "g100");
+    expect(select).toHaveTextContent("Gray 100");
+    expect(select).toHaveValue("g100");
     expect(consoleLog).toHaveBeenCalledWith("update", { theme: "g100" });
 
     await user.selectOptions(select, "white");
+    expect(select).toHaveTextContent("White");
+    expect(select).toHaveValue("white");
     expect(consoleLog).toHaveBeenCalledWith("update", { theme: "white" });
   });
 });


### PR DESCRIPTION
Similar to #2126, using `Theme` as either a toggle or select will pass the internal `themes` prop down to the DOM element.

Nothing breaking with this, but it feels unpolished.

This fixes it to avoid passing `themes` down to the rendered element.