### PR TITLE
fix(multi-select): fix keyboard navigation for disabled items

### DIFF
--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -201,7 +201,8 @@
 
   function change(direction) {
     let index = highlightedIndex + direction;
-    const length = filterable ? filteredItems.length : items.length;
+    const itemsToUse = filterable ? filteredItems : sortedItems;
+    const length = itemsToUse.length;
     if (length === 0) return;
     if (index < 0) {
       index = length - 1;
@@ -209,18 +210,18 @@
       index = 0;
     }
 
-    let disabled = items[index].disabled;
+    let disabled = itemsToUse[index].disabled;
 
     while (disabled) {
       index = index + direction;
 
       if (index < 0) {
-        index = items.length - 1;
-      } else if (index >= items.length) {
+        index = length - 1;
+      } else if (index >= length) {
         index = 0;
       }
 
-      disabled = items[index].disabled;
+      disabled = itemsToUse[index].disabled;
     }
 
     highlightedIndex = index;


### PR DESCRIPTION
Fixes #2128

If `MultiSelect` is provided `disabled` items, keyboard navigation (up/down arrows) should "skip" over disabled items. Currently, there's a bug where it's out-of-sync. The reason is that the keyboard logic references `items` when `MultiSelect` computes it as either `filteredItems` or `sortedItems`. Repro with the ["Disabled items"](https://svelte.carbondesignsystem.com/components/MultiSelect#disabled-items) example in the docs.

```svelte
<MultiSelect
  items={[
    { id: "0", text: "Slack" },
    { id: "1", text: "Email", disabled: true },
    { id: "2", text: "Fax" },
  ]}
/>
```

After internal sorting, "Email" is surfaced on top.

The solution is to use either the `filteredItems` or `sortedItems` in the skip logic. An additional optimization is to store the `length` of `itemsToUse` instead of computing it on every `while` iteration.

```ts
const itemsToUse = filterable ? filteredItems : sortedItems;
const length = itemsToUse.length;
```

---

https://github.com/user-attachments/assets/8a763d75-04c4-4faf-be79-8c46a2f79db8



