### PR TITLE
Revert "fix(list-box): use `aria-disabled` instead of invalid `disabled` attribute"

### DIFF
--- a/src/ListBox/ListBoxMenuItem.svelte
+++ b/src/ListBox/ListBoxMenuItem.svelte
@@ -25,7 +25,7 @@
   class:bx--list-box__menu-item--active={active}
   class:bx--list-box__menu-item--highlighted={highlighted || active}
   aria-selected={active}
-  aria-disabled={disabled ? true : undefined}
+  disabled={disabled ? true : undefined}
   {...$$restProps}
   on:click
   on:mouseenter

--- a/tests/ComboBox/ComboBox.test.ts
+++ b/tests/ComboBox/ComboBox.test.ts
@@ -165,7 +165,7 @@ describe("ComboBox", () => {
     await user.click(screen.getByRole("textbox"));
     const disabledOption = screen.getByText(/Fax/).closest('[role="option"]');
     assert(disabledOption);
-    expect(disabledOption).toHaveAttribute("aria-disabled", "true");
+    expect(disabledOption).toHaveAttribute("disabled", "true");
 
     await user.click(disabledOption);
     expect(screen.getByRole("textbox")).toHaveValue("");


### PR DESCRIPTION
Reverts carbon-design-system/carbon-components-svelte#2125

It turns out that changing `disabled` --> `aria-disabled` did cause a style regression here. Carbon v10 styles targets the `[disabled]` attribute.

Reverting this change.

<img width="291" alt="Screenshot 2025-03-19 at 1 01 43 PM" src="https://github.com/user-attachments/assets/a33b323c-ad4c-4c8e-93fa-bdb125af9ce5" />
