### PR TITLE
fix(radio-button): forward `focus`, `blur` events

### DIFF
--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -2966,6 +2966,8 @@ None.
 
 | Event name | Type      | Detail |
 | :--------- | :-------- | :----- |
+| focus      | forwarded | --     |
+| blur       | forwarded | --     |
 | change     | forwarded | --     |
 
 ## `RadioButtonGroup`

--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -11391,6 +11391,16 @@
       "events": [
         {
           "type": "forwarded",
+          "name": "focus",
+          "element": "input"
+        },
+        {
+          "type": "forwarded",
+          "name": "blur",
+          "element": "input"
+        },
+        {
+          "type": "forwarded",
           "name": "change",
           "element": "input"
         }

--- a/src/RadioButton/RadioButton.svelte
+++ b/src/RadioButton/RadioButton.svelte
@@ -71,6 +71,8 @@
     required={$groupRequired ?? required}
     {value}
     class:bx--radio-button={true}
+    on:focus
+    on:blur
     on:change
     on:change={() => {
       if (update) {

--- a/tests/RadioButton/RadioButton.test.svelte
+++ b/tests/RadioButton/RadioButton.test.svelte
@@ -26,6 +26,12 @@
   {id}
   {name}
   {ref}
+  on:focus={() => {
+    console.log("focus");
+  }}
+  on:blur={() => {
+    console.log("blur");
+  }}
   on:change={() => {
     console.log("change");
   }}

--- a/tests/RadioButton/RadioButton.test.ts
+++ b/tests/RadioButton/RadioButton.test.ts
@@ -91,8 +91,7 @@ describe("RadioButton", () => {
     expect(consoleLog).toHaveBeenCalledWith("change");
   });
 
-  // TODO(bug): forward focus/blur events.
-  it.skip("should handle focus and blur events", async () => {
+  it("should handle focus and blur events", async () => {
     const consoleLog = vi.spyOn(console, "log");
     render(RadioButton);
 

--- a/types/RadioButton/RadioButton.svelte.d.ts
+++ b/types/RadioButton/RadioButton.svelte.d.ts
@@ -71,6 +71,10 @@ export type RadioButtonProps = Omit<$RestProps, keyof $Props> & $Props;
 
 export default class RadioButton extends SvelteComponentTyped<
   RadioButtonProps,
-  { change: WindowEventMap["change"] },
+  {
+    focus: WindowEventMap["focus"];
+    blur: WindowEventMap["blur"];
+    change: WindowEventMap["change"];
+  },
   { labelText: {} }
 > {}


### PR DESCRIPTION
Identified in https://github.com/carbon-design-system/carbon-components-svelte/pull/2131

`focus` and `blur` events should be forwarded to the underlying `input` element used in `RadioButton`.

```svelte
<RadioButton on:focus on:blur />
```