### PR TITLE
fix(radio-tile): allow standalone `RadioTile` usage

### DIFF
--- a/src/Tile/RadioTile.svelte
+++ b/src/Tile/RadioTile.svelte
@@ -36,6 +36,7 @@
   const { add, update, selectedValue, groupName, groupRequired } = getContext(
     "TileGroup",
   ) ?? {
+    add: () => {},
     groupName: readable(undefined),
     groupRequired: readable(undefined),
     selectedValue: readable(checked ? value : undefined),

--- a/tests/RadioTile/RadioTile.test.ts
+++ b/tests/RadioTile/RadioTile.test.ts
@@ -94,8 +94,7 @@ describe("RadioTile", () => {
     expect(radioTileLabel).toHaveAttribute("for", "custom-id");
   });
 
-  // TODO(bug): support standalone radio tile.
-  it.skip("should handle custom name", () => {
+  it("should handle custom name", () => {
     render(RadioTileSingle);
 
     expect(screen.getByRole("radio")).toHaveAttribute("name", "custom-name");


### PR DESCRIPTION
Identified in https://github.com/carbon-design-system/carbon-components-svelte/pull/2131

Although `RadioTile` is intended to be used inside a `TileGroup`, it feels unpolished for standalone usage to crash. This is because no parent context is found.

This fixes `RadioTile` to fail open by supplying an `add: () => {}` no-op in the case where `TileGroup` context does not exist.