### PR TITLE
fix(text-area): allow visually hidden label

### DIFF
--- a/src/TextArea/TextArea.svelte
+++ b/src/TextArea/TextArea.svelte
@@ -71,7 +71,7 @@
   on:mouseleave
   class:bx--form-item={true}
 >
-  {#if (labelText || $$slots.labelText) && !hideLabel}
+  {#if (labelText || $$slots.labelText)}
     <div class:bx--text-area__label-wrapper={true}>
       <label
         for={id}

--- a/tests/TextArea/TextArea.test.ts
+++ b/tests/TextArea/TextArea.test.ts
@@ -79,8 +79,7 @@ describe("TextArea", () => {
     );
   });
 
-  // TODO(bug): hidden label should still be rendered.
-  it.skip("should handle hidden label", () => {
+  it("should handle hidden label", () => {
     render(TextArea, { props: { hideLabel: true } });
 
     expect(screen.getByLabelText("App description")).toBeInTheDocument();


### PR DESCRIPTION
Identified in https://github.com/carbon-design-system/carbon-components-svelte/pull/2131

This fixes an accessibility issue with `TextArea`.

Currently, if `hideLabel` is `true`, the label for the `textarea` is not rendered at all. The expected behavior is that it should be visually hidden to still be available to screen readers.