### PR TITLE
fix(list-box): set `aria-disabled` if `disabled` (#2125)

### DIFF
--- a/src/ListBox/ListBoxMenuItem.svelte
+++ b/src/ListBox/ListBoxMenuItem.svelte
@@ -25,6 +25,7 @@
   class:bx--list-box__menu-item--active={active}
   class:bx--list-box__menu-item--highlighted={highlighted || active}
   aria-selected={active}
+  aria-disabled={disabled ? true : undefined}
   disabled={disabled ? true : undefined}
   {...$$restProps}
   on:click

--- a/tests/ComboBox/ComboBox.test.ts
+++ b/tests/ComboBox/ComboBox.test.ts
@@ -166,6 +166,7 @@ describe("ComboBox", () => {
     const disabledOption = screen.getByText(/Fax/).closest('[role="option"]');
     assert(disabledOption);
     expect(disabledOption).toHaveAttribute("disabled", "true");
+    expect(disabledOption).toHaveAttribute("aria-disabled", "true");
 
     await user.click(disabledOption);
     expect(screen.getByRole("textbox")).toHaveValue("");


### PR DESCRIPTION
This re-applies https://github.com/carbon-design-system/carbon-components-svelte/pull/2125, which was reverted in #2130

Carbon styles depend on the `[disabled]` attribute. The `disabled` attribute is not valid mark-up when applied to `div role="option"`, so this PR preserved the existing `disabled` attribute while also setting `aria-disabled`.