### PR TITLE
chore: replace Prettier with Biome

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,9 +1,0 @@
-/css
-/types
-.svelte-kit
-.routify
-dist
-client
-build
-*.svx
-COMPONENT_API.json

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "vcs": {
+    "enabled": false,
+    "clientKind": "git",
+    "useIgnoreFile": false
+  },
+  "files": {
+    "ignoreUnknown": false,
+    "ignore": [
+      "./css",
+      "./types",
+      "dist",
+      "build",
+      "client",
+      ".svelte-kit",
+      ".routify",
+      "*.svx",
+      "COMPONENT_API.json"
+    ]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space"
+  },
+  "organizeImports": {
+    "enabled": true
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true
+    }
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "double"
+    }
+  },
+  "overrides": [
+    {
+      "include": ["*.svelte"],
+      "linter": {
+        "rules": {
+          "style": {
+            "useConst": "off",
+            "useImportType": "off"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/docs/package.json
+++ b/docs/package.json
@@ -30,10 +30,7 @@
   "routify": {
     "routifyDir": ".routify",
     "dynamicImports": true,
-    "extensions": [
-      "svelte",
-      "svx"
-    ]
+    "extensions": ["svelte", "svx"]
   },
   "type": "module"
 }

--- a/docs/src/App.svelte
+++ b/docs/src/App.svelte
@@ -1,6 +1,6 @@
 <script>
-  import { Router } from "@sveltech/routify";
-  import { routes } from "../.routify/routes";
+import { Router } from "@sveltech/routify";
+import { routes } from "../.routify/routes";
 </script>
 
 <Router {routes} />

--- a/docs/src/components/ComponentApi.svelte
+++ b/docs/src/components/ComponentApi.svelte
@@ -1,49 +1,48 @@
 <script>
-  export let component = {
-    props: [],
-    slots: [],
-    events: [],
-    rest_props: undefined,
-    typedefs: [],
-  };
+export let component = {
+  props: [],
+  slots: [],
+  events: [],
+  rest_props: undefined,
+  typedefs: [],
+};
 
-  import { onMount } from "svelte";
-  import {
-    OutboundLink,
-    StructuredList,
-    StructuredListHead,
-    StructuredListRow,
-    StructuredListCell,
-    StructuredListBody,
-    UnorderedList,
-    ListItem,
-    Tag,
-  } from "carbon-components-svelte";
-  import InlineSnippet from "./InlineSnippet.svelte";
+import { onMount } from "svelte";
+import {
+  OutboundLink,
+  StructuredList,
+  StructuredListHead,
+  StructuredListRow,
+  StructuredListCell,
+  StructuredListBody,
+  UnorderedList,
+  ListItem,
+  Tag,
+} from "carbon-components-svelte";
+import InlineSnippet from "./InlineSnippet.svelte";
 
-  let AsyncPreviewTypeScript;
+let AsyncPreviewTypeScript;
 
-  onMount(async () => {
-    AsyncPreviewTypeScript = (await import("./PreviewTypeScript.svelte"))
-      .default;
-  });
+onMount(async () => {
+  AsyncPreviewTypeScript = (await import("./PreviewTypeScript.svelte")).default;
+});
 
-  const mdn_api = "https://developer.mozilla.org/en-US/docs/Web/API/";
-  const typeMap = {
-    string: "string",
-    boolean: "boolean",
-    number: "number",
-    null: "null",
-    Date: "JavaScript Date",
-  };
+const mdn_api = "https://developer.mozilla.org/en-US/docs/Web/API/";
+const typeMap = {
+  string: "string",
+  boolean: "boolean",
+  number: "number",
+  null: "null",
+  Date: "JavaScript Date",
+};
 
-  $: source = `https://github.com/carbon-design-system/carbon-components-svelte/tree/master/${component.filePath}`;
-  $: forwarded_events = component.events.filter(
-    (event) => event.type === "forwarded",
-  );
-  $: dispatched_events = component.events.filter(
-    (event) => event.type === "dispatched",
-  );
+$: source = `https://github.com/carbon-design-system/carbon-components-svelte/tree/master/${component.filePath}`;
+$: forwarded_events = component.events.filter(
+  (event) => event.type === "forwarded",
+);
+$: dispatched_events = component.events.filter(
+  (event) => event.type === "dispatched",
+);
 </script>
 
 <p style="margin-bottom: var(--cds-layout-02)">

--- a/docs/src/components/InlineSnippet.svelte
+++ b/docs/src/components/InlineSnippet.svelte
@@ -1,8 +1,8 @@
 <script>
-  export let code = "";
+export let code = "";
 
-  import copy from "clipboard-copy";
-  import { CodeSnippet } from "carbon-components-svelte";
+import copy from "clipboard-copy";
+import { CodeSnippet } from "carbon-components-svelte";
 </script>
 
 <div>

--- a/docs/src/components/Preview.svelte
+++ b/docs/src/components/Preview.svelte
@@ -1,16 +1,16 @@
 <script>
-  export let code = "";
-  export let codeRaw = "";
-  export let src = "";
-  export let framed = false;
+export let code = "";
+export let codeRaw = "";
+export let src = "";
+export let framed = false;
 
-  import copy from "clipboard-copy";
-  import { CodeSnippet, Button } from "carbon-components-svelte";
-  import Launch from "carbon-icons-svelte/lib/Launch.svelte";
-  import { url } from "@sveltech/routify";
-  import { theme } from "../store";
+import copy from "clipboard-copy";
+import { CodeSnippet, Button } from "carbon-components-svelte";
+import Launch from "carbon-icons-svelte/lib/Launch.svelte";
+import { url } from "@sveltech/routify";
+import { theme } from "../store";
 
-  $: themedSrcUrl = $url(`${src}?theme=${$theme}`);
+$: themedSrcUrl = $url(`${src}?theme=${$theme}`);
 </script>
 
 <div class="preview">

--- a/docs/src/components/PreviewTypeScript.svelte
+++ b/docs/src/components/PreviewTypeScript.svelte
@@ -1,17 +1,13 @@
 <script>
-  export let code = "";
-  export let type = "multi";
+export let code = "";
+export let type = "multi";
 
-  import { CodeSnippet } from "carbon-components-svelte";
-  import { highlight } from "prismjs";
-  import "prismjs/components/prism-typescript";
-  import copy from "clipboard-copy";
+import { CodeSnippet } from "carbon-components-svelte";
+import { highlight } from "prismjs";
+import "prismjs/components/prism-typescript";
+import copy from "clipboard-copy";
 
-  $: highlightedCode = highlight(
-    code,
-    Prism.languages.typescript,
-    "typescript",
-  );
+$: highlightedCode = highlight(code, Prism.languages.typescript, "typescript");
 </script>
 
 {#if type === "multi"}

--- a/docs/src/components/TileCard.svelte
+++ b/docs/src/components/TileCard.svelte
@@ -1,15 +1,15 @@
 <script>
-  export let href = undefined;
-  export let title = "";
-  export let subtitle = "";
-  export let borderRight = false;
-  export let borderBottom = false;
+export let href = undefined;
+export let title = "";
+export let subtitle = "";
+export let borderRight = false;
+export let borderBottom = false;
 
-  import { AspectRatio, ClickableTile, Tile } from "carbon-components-svelte";
-  import LogoGithub from "carbon-icons-svelte/lib/LogoGithub.svelte";
-  import Launch from "carbon-icons-svelte/lib/Launch.svelte";
+import { AspectRatio, ClickableTile, Tile } from "carbon-components-svelte";
+import LogoGithub from "carbon-icons-svelte/lib/LogoGithub.svelte";
+import Launch from "carbon-icons-svelte/lib/Launch.svelte";
 
-  $: tileComponent = href ? ClickableTile : Tile;
+$: tileComponent = href ? ClickableTile : Tile;
 </script>
 
 <div class="card-wrapper" class:borderRight class:borderBottom>

--- a/docs/src/layouts/ComponentLayout.svelte
+++ b/docs/src/layouts/ComponentLayout.svelte
@@ -1,69 +1,69 @@
 <script>
-  import {
-    Grid,
-    Link,
-    Row,
-    Column,
-    Content,
-    Button,
-    Select,
-    SelectItem,
-    InlineNotification,
-    Tabs,
-    Tab,
-    TabContent,
-  } from "carbon-components-svelte";
-  import Code from "carbon-icons-svelte/lib/Code.svelte";
-  import { page, metatags } from "@sveltech/routify";
-  import { onMount } from "svelte";
-  import { theme } from "../store";
-  import ComponentApi from "../components/ComponentApi.svelte";
-  import COMPONENT_API from "../COMPONENT_API.json";
+import {
+  Grid,
+  Link,
+  Row,
+  Column,
+  Content,
+  Button,
+  Select,
+  SelectItem,
+  InlineNotification,
+  Tabs,
+  Tab,
+  TabContent,
+} from "carbon-components-svelte";
+import Code from "carbon-icons-svelte/lib/Code.svelte";
+import { page, metatags } from "@sveltech/routify";
+import { onMount } from "svelte";
+import { theme } from "../store";
+import ComponentApi from "../components/ComponentApi.svelte";
+import COMPONENT_API from "../COMPONENT_API.json";
 
-  export let component = $page.title;
-  export let components = [component];
-  export let unreleased = false;
-  export let unstable = false;
+export let component = $page.title;
+export let components = [component];
+export let unreleased = false;
+export let unstable = false;
 
-  metatags.title = $page.title;
+metatags.title = $page.title;
 
-  // TODO: `find` is not supported in IE
-  $: api_components = components.map((i) =>
-    COMPONENT_API.components.find((_) => _.moduleName === i),
-  );
-  $: multiple = api_components.length > 1;
+// TODO: `find` is not supported in IE
+$: api_components = components.map((i) =>
+  COMPONENT_API.components.find((_) => _.moduleName === i),
+);
+$: multiple = api_components.length > 1;
 
-  onMount(() => {
-    const searchParams = new URLSearchParams(window.location.search);
-    const current_theme = searchParams.get("theme");
+onMount(() => {
+  const searchParams = new URLSearchParams(window.location.search);
+  const current_theme = searchParams.get("theme");
 
-    if (["white", "g10", "g80", "g90", "g100"].includes(current_theme)) {
-      theme.set(current_theme);
-    }
-  });
+  if (["white", "g10", "g80", "g90", "g100"].includes(current_theme)) {
+    theme.set(current_theme);
+  }
+});
 
-  function formatSourceURL(multiple) {
-    const filePath = api_components[0]?.filePath ?? "";
+function formatSourceURL(multiple) {
+  const filePath = api_components[0]?.filePath ?? "";
 
-    if (multiple) {
-      /**
-       * Link to folder for doc with multiple components.
-       * @example "src/Breadcrumb"
-       */
-      return filePath.split("/").slice(0, -1).join("/");
-    }
-
+  if (multiple) {
     /**
-     * Else, link to the component source.
-     * @example "src/Tile/ClickableTile.svelte"
+     * Link to folder for doc with multiple components.
+     * @example "src/Breadcrumb"
      */
-    return filePath;
+    return filePath.split("/").slice(0, -1).join("/");
   }
 
-  // TODO: [refactor] read from package.json value
-  $: sourceCode = `https://github.com/carbon-design-system/carbon-components-svelte/tree/master/${formatSourceURL(
-    multiple,
-  )}`;
+  /**
+   * Else, link to the component source.
+   * @example "src/Tile/ClickableTile.svelte"
+   */
+  return filePath;
+}
+
+// TODO: [refactor] read from package.json value
+$: sourceCode = `https://github.com/carbon-design-system/carbon-components-svelte/tree/master/${formatSourceURL(
+  multiple,
+)}`;
 </script>
 
 <svelte:head>

--- a/docs/src/pages/_fallback.svelte
+++ b/docs/src/pages/_fallback.svelte
@@ -1,8 +1,8 @@
 <script>
-  import { Content, Grid, Row, Column, Link } from "carbon-components-svelte";
-  import { url, metatags } from "@sveltech/routify";
+import { Content, Grid, Row, Column, Link } from "carbon-components-svelte";
+import { url, metatags } from "@sveltech/routify";
 
-  metatags.title = "404";
+metatags.title = "404";
 </script>
 
 <Content>

--- a/docs/src/pages/_layout.svelte
+++ b/docs/src/pages/_layout.svelte
@@ -1,64 +1,64 @@
 <script>
-  import {
-    isActive,
-    url,
-    layout,
-    beforeUrlChange,
-    goto,
-  } from "@sveltech/routify";
-  import {
-    Header,
-    HeaderUtilities,
-    HeaderAction,
-    HeaderActionLink,
-    HeaderPanelLinks,
-    HeaderPanelLink,
-    HeaderPanelDivider,
-    HeaderSearch,
-    SkipToContent,
-    SideNav,
-    SideNavItems,
-    SideNavMenuItem,
-    Theme,
-    Tag,
-  } from "carbon-components-svelte";
-  import MiniSearch from "minisearch";
-  import LogoGithub from "carbon-icons-svelte/lib/LogoGithub.svelte";
-  import { theme } from "../store";
-  import SEARCH_INDEX from "../SEARCH_INDEX.json";
+import {
+  isActive,
+  url,
+  layout,
+  beforeUrlChange,
+  goto,
+} from "@sveltech/routify";
+import {
+  Header,
+  HeaderUtilities,
+  HeaderAction,
+  HeaderActionLink,
+  HeaderPanelLinks,
+  HeaderPanelLink,
+  HeaderPanelDivider,
+  HeaderSearch,
+  SkipToContent,
+  SideNav,
+  SideNavItems,
+  SideNavMenuItem,
+  Theme,
+  Tag,
+} from "carbon-components-svelte";
+import MiniSearch from "minisearch";
+import LogoGithub from "carbon-icons-svelte/lib/LogoGithub.svelte";
+import { theme } from "../store";
+import SEARCH_INDEX from "../SEARCH_INDEX.json";
 
-  const miniSearch = new MiniSearch({
-    fields: ["text", "description"],
-    storeFields: ["text", "description", "href"],
-    searchOptions: {
-      prefix: true,
-      boost: { description: 2 },
-      fuzzy: 0.1,
-    },
-  });
+const miniSearch = new MiniSearch({
+  fields: ["text", "description"],
+  storeFields: ["text", "description", "href"],
+  searchOptions: {
+    prefix: true,
+    boost: { description: 2 },
+    fuzzy: 0.1,
+  },
+});
 
-  miniSearch.addAll(SEARCH_INDEX);
+miniSearch.addAll(SEARCH_INDEX);
 
-  const deprecated = [];
-  const new_components = [];
+const deprecated = [];
+const new_components = [];
 
-  let value = "";
-  let active = false;
-  $: results = miniSearch.search(value).slice(0, 10);
+let value = "";
+let active = false;
+$: results = miniSearch.search(value).slice(0, 10);
 
-  let isOpen = false;
-  let isSideNavOpen = true;
-  let innerWidth = 2048;
+let isOpen = false;
+let isSideNavOpen = true;
+let innerWidth = 2048;
 
-  $: isMobile = innerWidth < 1056;
-  $: components = $layout.children.filter(
-    (child) => child.title === "components",
-  )[0];
+$: isMobile = innerWidth < 1056;
+$: components = $layout.children.filter(
+  (child) => child.title === "components",
+)[0];
 
-  $beforeUrlChange(() => {
-    if (isMobile) isSideNavOpen = false;
-    return true;
-  });
+$beforeUrlChange(() => {
+  if (isMobile) isSideNavOpen = false;
+  return true;
+});
 </script>
 
 <!-- routify:options bundle=true -->

--- a/docs/src/pages/framed/Accordion/ExpandableAccordion.svelte
+++ b/docs/src/pages/framed/Accordion/ExpandableAccordion.svelte
@@ -1,25 +1,25 @@
 <script>
-  import { Accordion, AccordionItem, Button } from "carbon-components-svelte";
+import { Accordion, AccordionItem, Button } from "carbon-components-svelte";
 
-  const items = [
-    {
-      title: "Natural Language Classifier",
-      description:
-        "Natural Language Classifier uses advanced natural language processing and machine learning techniques to create custom classification models. Users train their data and the service predicts the appropriate category for the inputted text.",
-    },
-    {
-      title: "Natural Language Understanding",
-      description:
-        "Analyze text to extract meta-data from content such as concepts, entities, emotion, relations, sentiment and more.",
-    },
-    {
-      title: "Language Translator",
-      description:
-        "Translate text, documents, and websites from one language to another. Create industry or region-specific translations via the service's customization capability.",
-    },
-  ];
+const items = [
+  {
+    title: "Natural Language Classifier",
+    description:
+      "Natural Language Classifier uses advanced natural language processing and machine learning techniques to create custom classification models. Users train their data and the service predicts the appropriate category for the inputted text.",
+  },
+  {
+    title: "Natural Language Understanding",
+    description:
+      "Analyze text to extract meta-data from content such as concepts, entities, emotion, relations, sentiment and more.",
+  },
+  {
+    title: "Language Translator",
+    description:
+      "Translate text, documents, and websites from one language to another. Create industry or region-specific translations via the service's customization capability.",
+  },
+];
 
-  let open = false;
+let open = false;
 </script>
 
 <Button kind="ghost" size="field" on:click={() => (open = !open)}>

--- a/docs/src/pages/framed/Breadcrumbs/Breadcrumbs.svelte
+++ b/docs/src/pages/framed/Breadcrumbs/Breadcrumbs.svelte
@@ -1,11 +1,11 @@
 <script>
-  import { Breadcrumb, BreadcrumbItem } from "carbon-components-svelte";
+import { Breadcrumb, BreadcrumbItem } from "carbon-components-svelte";
 
-  const items = [
-    { href: "/", text: "Dashboard" },
-    { href: "/reports", text: "Annual reports" },
-    { href: "/reports/2019", text: "2019" },
-  ];
+const items = [
+  { href: "/", text: "Dashboard" },
+  { href: "/reports", text: "Annual reports" },
+  { href: "/reports/2019", text: "2019" },
+];
 </script>
 
 <Breadcrumb>

--- a/docs/src/pages/framed/Breakpoint/Breakpoint.svelte
+++ b/docs/src/pages/framed/Breakpoint/Breakpoint.svelte
@@ -1,8 +1,8 @@
 <script>
-  import { Breakpoint } from "carbon-components-svelte";
+import { Breakpoint } from "carbon-components-svelte";
 
-  let size;
-  let events = [];
+let size;
+let events = [];
 </script>
 
 <Breakpoint bind:size on:change={(e) => (events = [...events, e.detail])} />

--- a/docs/src/pages/framed/Breakpoint/BreakpointObserver.svelte
+++ b/docs/src/pages/framed/Breakpoint/BreakpointObserver.svelte
@@ -1,9 +1,9 @@
 <script>
-  import { breakpointObserver, breakpoints } from "carbon-components-svelte";
+import { breakpointObserver, breakpoints } from "carbon-components-svelte";
 
-  const size = breakpointObserver();
-  const smaller = size.smallerThan("md");
-  const larger = size.largerThan("md");
+const size = breakpointObserver();
+const smaller = size.smallerThan("md");
+const larger = size.largerThan("md");
 </script>
 
 <p>Current breakpoint size: {$size}</p>

--- a/docs/src/pages/framed/Button/ProgrammaticFocus.svelte
+++ b/docs/src/pages/framed/Button/ProgrammaticFocus.svelte
@@ -1,7 +1,7 @@
 <script>
-  import { Button } from "carbon-components-svelte";
+import { Button } from "carbon-components-svelte";
 
-  let ref;
+let ref;
 </script>
 
 <Button bind:ref>Primary button</Button>

--- a/docs/src/pages/framed/Button/SelectedIconOnlyButton.svelte
+++ b/docs/src/pages/framed/Button/SelectedIconOnlyButton.svelte
@@ -1,10 +1,10 @@
 <script>
-  import { Button } from "carbon-components-svelte";
-  import TextBold from "carbon-icons-svelte/lib/TextBold.svelte";
-  import TextItalic from "carbon-icons-svelte/lib/TextItalic.svelte";
-  import TextUnderline from "carbon-icons-svelte/lib/TextUnderline.svelte";
+import { Button } from "carbon-components-svelte";
+import TextBold from "carbon-icons-svelte/lib/TextBold.svelte";
+import TextItalic from "carbon-icons-svelte/lib/TextItalic.svelte";
+import TextUnderline from "carbon-icons-svelte/lib/TextUnderline.svelte";
 
-  let index = 1;
+let index = 1;
 </script>
 
 <Button

--- a/docs/src/pages/framed/Checkbox/CheckboxReactive.svelte
+++ b/docs/src/pages/framed/Checkbox/CheckboxReactive.svelte
@@ -1,7 +1,7 @@
 <script>
-  import { Checkbox, Button } from "carbon-components-svelte";
+import { Checkbox, Button } from "carbon-components-svelte";
 
-  let checked = false;
+let checked = false;
 </script>
 
 <Checkbox labelText="Label text" bind:checked />

--- a/docs/src/pages/framed/Checkbox/MultipleCheckboxes.svelte
+++ b/docs/src/pages/framed/Checkbox/MultipleCheckboxes.svelte
@@ -1,8 +1,8 @@
 <script>
-  import { Checkbox, Button } from "carbon-components-svelte";
+import { Checkbox, Button } from "carbon-components-svelte";
 
-  let values = ["Apple", "Banana", "Coconut"];
-  let group = values.slice(0, 2);
+let values = ["Apple", "Banana", "Coconut"];
+let group = values.slice(0, 2);
 </script>
 
 {#each values as value}

--- a/docs/src/pages/framed/CodeSnippet/CodeSnippetOverride.svelte
+++ b/docs/src/pages/framed/CodeSnippet/CodeSnippetOverride.svelte
@@ -1,6 +1,6 @@
 <script>
-  import copy from "clipboard-copy";
-  import { CodeSnippet } from "carbon-components-svelte";
+import copy from "clipboard-copy";
+import { CodeSnippet } from "carbon-components-svelte";
 </script>
 
 <CodeSnippet

--- a/docs/src/pages/framed/CodeSnippet/CodeSnippetReactive.svelte
+++ b/docs/src/pages/framed/CodeSnippet/CodeSnippetReactive.svelte
@@ -1,7 +1,7 @@
 <script>
-  import { CodeSnippet, Button } from "carbon-components-svelte";
+import { CodeSnippet, Button } from "carbon-components-svelte";
 
-  let expanded = false;
+let expanded = false;
 </script>
 
 <Button on:click={() => (expanded = !expanded)}>Toggle expansion</Button>

--- a/docs/src/pages/framed/CodeSnippet/DynamicCodeSnippet.svelte
+++ b/docs/src/pages/framed/CodeSnippet/DynamicCodeSnippet.svelte
@@ -1,10 +1,10 @@
 <script>
-  import { Toggle, CodeSnippet } from "carbon-components-svelte";
+import { Toggle, CodeSnippet } from "carbon-components-svelte";
 
-  let toggled = false;
+let toggled = false;
 
-  $: length = toggled ? 20 : 10;
-  $: code = Array.from({ length }, (_, i) => i + 1).join("\n");
+$: length = toggled ? 20 : 10;
+$: code = Array.from({ length }, (_, i) => i + 1).join("\n");
 </script>
 
 <Toggle

--- a/docs/src/pages/framed/CodeSnippet/HiddenCodeSnippet.svelte
+++ b/docs/src/pages/framed/CodeSnippet/HiddenCodeSnippet.svelte
@@ -1,9 +1,9 @@
 <script>
-  import { Toggle, CodeSnippet } from "carbon-components-svelte";
+import { Toggle, CodeSnippet } from "carbon-components-svelte";
 
-  let toggled = false;
+let toggled = false;
 
-  const code = Array.from({ length: 20 }, (_, i) => i + 1).join("\n");
+const code = Array.from({ length: 20 }, (_, i) => i + 1).join("\n");
 </script>
 
 <Toggle

--- a/docs/src/pages/framed/ComboBox/ComboBoxClear.svelte
+++ b/docs/src/pages/framed/ComboBox/ComboBoxClear.svelte
@@ -1,7 +1,7 @@
 <script>
-  import { ComboBox, Button } from "carbon-components-svelte";
+import { ComboBox, Button } from "carbon-components-svelte";
 
-  let ref;
+let ref;
 </script>
 
 <ComboBox

--- a/docs/src/pages/framed/ComboBox/ComboBoxSlot.svelte
+++ b/docs/src/pages/framed/ComboBox/ComboBoxSlot.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { ComboBox } from "carbon-components-svelte";
+import { ComboBox } from "carbon-components-svelte";
 </script>
 
 <ComboBox

--- a/docs/src/pages/framed/ComboBox/FilterableComboBox.svelte
+++ b/docs/src/pages/framed/ComboBox/FilterableComboBox.svelte
@@ -1,10 +1,10 @@
 <script>
-  import { ComboBox } from "carbon-components-svelte";
+import { ComboBox } from "carbon-components-svelte";
 
-  function shouldFilterItem(item, value) {
-    if (!value) return true;
-    return item.text.toLowerCase().includes(value.toLowerCase());
-  }
+function shouldFilterItem(item, value) {
+  if (!value) return true;
+  return item.text.toLowerCase().includes(value.toLowerCase());
+}
 </script>
 
 <ComboBox

--- a/docs/src/pages/framed/ComboBox/FilterableComboBoxCustomLabel.svelte
+++ b/docs/src/pages/framed/ComboBox/FilterableComboBoxCustomLabel.svelte
@@ -1,24 +1,24 @@
 <script>
-  import { ComboBox } from "carbon-components-svelte";
+import { ComboBox } from "carbon-components-svelte";
 
-  const translation = {
-    Slack: 'Custom label for "Slack"',
-    Email: 'Custom label for "Email"',
-    Fax: 'Custom label for "Fax"',
-  };
+const translation = {
+  Slack: 'Custom label for "Slack"',
+  Email: 'Custom label for "Email"',
+  Fax: 'Custom label for "Fax"',
+};
 
-  function itemToString(item) {
-    return translation[item.key];
-  }
+function itemToString(item) {
+  return translation[item.key];
+}
 
-  function shouldFilterItem(item, value) {
-    if (!value) return true;
-    const comparison = value.toLowerCase();
-    return (
-      item.key.toLowerCase().includes(comparison) ||
-      itemToString(item).toLowerCase().includes(comparison)
-    );
-  }
+function shouldFilterItem(item, value) {
+  if (!value) return true;
+  const comparison = value.toLowerCase();
+  return (
+    item.key.toLowerCase().includes(comparison) ||
+    itemToString(item).toLowerCase().includes(comparison)
+  );
+}
 </script>
 
 <ComboBox

--- a/docs/src/pages/framed/ComboBox/MultipleComboBox.svelte
+++ b/docs/src/pages/framed/ComboBox/MultipleComboBox.svelte
@@ -1,20 +1,20 @@
 <script>
-  import { ComboBox } from "carbon-components-svelte";
+import { ComboBox } from "carbon-components-svelte";
 
-  const items = [
-    { id: "0", text: "Slack" },
-    { id: "1", text: "Email" },
-    { id: "2", text: "Fax" },
-  ];
+const items = [
+  { id: "0", text: "Slack" },
+  { id: "1", text: "Email" },
+  { id: "2", text: "Fax" },
+];
 
-  let comboBox1_selectedId = undefined;
-  let comboBox2_selectedId = undefined;
+let comboBox1_selectedId = undefined;
+let comboBox2_selectedId = undefined;
 
-  const formatSelected = (id) =>
-    items.find((item) => item.id === id)?.text ?? "N/A";
+const formatSelected = (id) =>
+  items.find((item) => item.id === id)?.text ?? "N/A";
 
-  $: primary = formatSelected(comboBox1_selectedId);
-  $: secondary = formatSelected(comboBox2_selectedId);
+$: primary = formatSelected(comboBox1_selectedId);
+$: secondary = formatSelected(comboBox2_selectedId);
 </script>
 
 <ComboBox

--- a/docs/src/pages/framed/ComboBox/ReactiveComboBox.svelte
+++ b/docs/src/pages/framed/ComboBox/ReactiveComboBox.svelte
@@ -1,6 +1,6 @@
 <script>
-  import { ComboBox, Button } from "carbon-components-svelte";
-  let selectedId = "1";
+import { ComboBox, Button } from "carbon-components-svelte";
+let selectedId = "1";
 </script>
 
 <ComboBox

--- a/docs/src/pages/framed/ContentSwitcher/ContentSwitcherReactive.svelte
+++ b/docs/src/pages/framed/ContentSwitcher/ContentSwitcherReactive.svelte
@@ -1,7 +1,7 @@
 <script>
-  import { ContentSwitcher, Switch, Button } from "carbon-components-svelte";
+import { ContentSwitcher, Switch, Button } from "carbon-components-svelte";
 
-  let selectedIndex = 1;
+let selectedIndex = 1;
 </script>
 
 <ContentSwitcher bind:selectedIndex>

--- a/docs/src/pages/framed/ContextMenu/ContextMenu.svelte
+++ b/docs/src/pages/framed/ContextMenu/ContextMenu.svelte
@@ -1,16 +1,16 @@
 <script>
-  import {
-    ContextMenu,
-    ContextMenuDivider,
-    ContextMenuGroup,
-    ContextMenuOption,
-  } from "carbon-components-svelte";
-  import CopyFile from "carbon-icons-svelte/lib/CopyFile.svelte";
-  import Cut from "carbon-icons-svelte/lib/Cut.svelte";
+import {
+  ContextMenu,
+  ContextMenuDivider,
+  ContextMenuGroup,
+  ContextMenuOption,
+} from "carbon-components-svelte";
+import CopyFile from "carbon-icons-svelte/lib/CopyFile.svelte";
+import Cut from "carbon-icons-svelte/lib/Cut.svelte";
 
-  let selectedIds = [];
+let selectedIds = [];
 
-  $: console.log("selectedIds", selectedIds);
+$: console.log("selectedIds", selectedIds);
 </script>
 
 <ContextMenu>

--- a/docs/src/pages/framed/ContextMenu/ContextMenuGroups.svelte
+++ b/docs/src/pages/framed/ContextMenu/ContextMenuGroups.svelte
@@ -1,14 +1,14 @@
 <script>
-  import {
-    ContextMenu,
-    ContextMenuDivider,
-    ContextMenuOption,
-    ContextMenuRadioGroup,
-  } from "carbon-components-svelte";
+import {
+  ContextMenu,
+  ContextMenuDivider,
+  ContextMenuOption,
+  ContextMenuRadioGroup,
+} from "carbon-components-svelte";
 
-  let selectedId = "0";
+let selectedId = "0";
 
-  $: console.log("selectedId", selectedId);
+$: console.log("selectedId", selectedId);
 </script>
 
 <ContextMenu>

--- a/docs/src/pages/framed/ContextMenu/ContextMenuTarget.svelte
+++ b/docs/src/pages/framed/ContextMenu/ContextMenuTarget.svelte
@@ -1,14 +1,14 @@
 <script>
-  import {
-    ContextMenu,
-    ContextMenuDivider,
-    ContextMenuGroup,
-    ContextMenuOption,
-  } from "carbon-components-svelte";
-  import CopyFile from "carbon-icons-svelte/lib/CopyFile.svelte";
-  import Cut from "carbon-icons-svelte/lib/Cut.svelte";
+import {
+  ContextMenu,
+  ContextMenuDivider,
+  ContextMenuGroup,
+  ContextMenuOption,
+} from "carbon-components-svelte";
+import CopyFile from "carbon-icons-svelte/lib/CopyFile.svelte";
+import Cut from "carbon-icons-svelte/lib/Cut.svelte";
 
-  let target;
+let target;
 </script>
 
 <ContextMenu {target} on:open={(e) => console.log(e.detail)}>

--- a/docs/src/pages/framed/ContextMenu/ContextMenuTargets.svelte
+++ b/docs/src/pages/framed/ContextMenu/ContextMenuTargets.svelte
@@ -1,15 +1,15 @@
 <script>
-  import {
-    ContextMenu,
-    ContextMenuDivider,
-    ContextMenuGroup,
-    ContextMenuOption,
-  } from "carbon-components-svelte";
-  import CopyFile from "carbon-icons-svelte/lib/CopyFile.svelte";
-  import Cut from "carbon-icons-svelte/lib/Cut.svelte";
+import {
+  ContextMenu,
+  ContextMenuDivider,
+  ContextMenuGroup,
+  ContextMenuOption,
+} from "carbon-components-svelte";
+import CopyFile from "carbon-icons-svelte/lib/CopyFile.svelte";
+import Cut from "carbon-icons-svelte/lib/Cut.svelte";
 
-  let target;
-  let target2;
+let target;
+let target2;
 </script>
 
 <ContextMenu target={[target, target2]} on:open={(e) => console.log(e.detail)}>

--- a/docs/src/pages/framed/CopyButton/CopyButtonOverride.svelte
+++ b/docs/src/pages/framed/CopyButton/CopyButtonOverride.svelte
@@ -1,6 +1,6 @@
 <script>
-  import copy from "clipboard-copy";
-  import { CopyButton } from "carbon-components-svelte";
+import copy from "clipboard-copy";
+import { CopyButton } from "carbon-components-svelte";
 </script>
 
 <CopyButton text="Carbon svelte" copy={(text) => copy(text)} />

--- a/docs/src/pages/framed/DataTable/DataTableAppendColumns.svelte
+++ b/docs/src/pages/framed/DataTable/DataTableAppendColumns.svelte
@@ -1,25 +1,25 @@
 <script>
-  import {
-    DataTable,
-    OverflowMenu,
-    OverflowMenuItem,
-  } from "carbon-components-svelte";
+import {
+  DataTable,
+  OverflowMenu,
+  OverflowMenuItem,
+} from "carbon-components-svelte";
 
-  const headers = [
-    { key: "name", value: "Name" },
-    { key: "port", value: "Port" },
-    { key: "rule", value: "Rule" },
-    { key: "overflow", empty: true },
-  ];
+const headers = [
+  { key: "name", value: "Name" },
+  { key: "port", value: "Port" },
+  { key: "rule", value: "Rule" },
+  { key: "overflow", empty: true },
+];
 
-  const rows = [
-    { id: "a", name: "Load Balancer 3", port: 3000, rule: "Round robin" },
-    { id: "b", name: "Load Balancer 1", port: 443, rule: "Round robin" },
-    { id: "c", name: "Load Balancer 2", port: 80, rule: "DNS delegation" },
-    { id: "d", name: "Load Balancer 6", port: 3000, rule: "Round robin" },
-    { id: "e", name: "Load Balancer 4", port: 443, rule: "Round robin" },
-    { id: "f", name: "Load Balancer 5", port: 80, rule: "DNS delegation" },
-  ];
+const rows = [
+  { id: "a", name: "Load Balancer 3", port: 3000, rule: "Round robin" },
+  { id: "b", name: "Load Balancer 1", port: 443, rule: "Round robin" },
+  { id: "c", name: "Load Balancer 2", port: 80, rule: "DNS delegation" },
+  { id: "d", name: "Load Balancer 6", port: 3000, rule: "Round robin" },
+  { id: "e", name: "Load Balancer 4", port: 443, rule: "Round robin" },
+  { id: "f", name: "Load Balancer 5", port: 80, rule: "DNS delegation" },
+];
 </script>
 
 <DataTable sortable {headers} {rows}>

--- a/docs/src/pages/framed/DataTable/DataTableBatchSelection.svelte
+++ b/docs/src/pages/framed/DataTable/DataTableBatchSelection.svelte
@@ -1,9 +1,9 @@
 <script>
-  import { DataTable } from "carbon-components-svelte";
+import { DataTable } from "carbon-components-svelte";
 
-  let selectedRowIds = [];
+let selectedRowIds = [];
 
-  $: console.log("selectedRowIds", selectedRowIds);
+$: console.log("selectedRowIds", selectedRowIds);
 </script>
 
 <DataTable

--- a/docs/src/pages/framed/DataTable/DataTableBatchSelectionInitial.svelte
+++ b/docs/src/pages/framed/DataTable/DataTableBatchSelectionInitial.svelte
@@ -1,9 +1,9 @@
 <script>
-  import { DataTable } from "carbon-components-svelte";
+import { DataTable } from "carbon-components-svelte";
 
-  let selectedRowIds = [2, 4];
+let selectedRowIds = [2, 4];
 
-  $: console.log("selectedRowIds", selectedRowIds);
+$: console.log("selectedRowIds", selectedRowIds);
 </script>
 
 <DataTable

--- a/docs/src/pages/framed/DataTable/DataTableBatchSelectionToolbar.svelte
+++ b/docs/src/pages/framed/DataTable/DataTableBatchSelectionToolbar.svelte
@@ -1,34 +1,34 @@
 <script>
-  import {
-    DataTable,
-    Toolbar,
-    ToolbarContent,
-    ToolbarSearch,
-    ToolbarMenu,
-    ToolbarMenuItem,
-    ToolbarBatchActions,
-    Button,
-  } from "carbon-components-svelte";
-  import Save from "carbon-icons-svelte/lib/Save.svelte";
+import {
+  DataTable,
+  Toolbar,
+  ToolbarContent,
+  ToolbarSearch,
+  ToolbarMenu,
+  ToolbarMenuItem,
+  ToolbarBatchActions,
+  Button,
+} from "carbon-components-svelte";
+import Save from "carbon-icons-svelte/lib/Save.svelte";
 
-  const headers = [
-    { key: "name", value: "Name" },
-    { key: "port", value: "Port" },
-    { key: "rule", value: "Rule" },
-  ];
+const headers = [
+  { key: "name", value: "Name" },
+  { key: "port", value: "Port" },
+  { key: "rule", value: "Rule" },
+];
 
-  const rows = [
-    { id: "a", name: "Load Balancer 3", port: 3000, rule: "Round robin" },
-    { id: "b", name: "Load Balancer 1", port: 443, rule: "Round robin" },
-    { id: "c", name: "Load Balancer 2", port: 80, rule: "DNS delegation" },
-    { id: "d", name: "Load Balancer 6", port: 3000, rule: "Round robin" },
-    { id: "e", name: "Load Balancer 4", port: 443, rule: "Round robin" },
-    { id: "f", name: "Load Balancer 5", port: 80, rule: "DNS delegation" },
-  ];
+const rows = [
+  { id: "a", name: "Load Balancer 3", port: 3000, rule: "Round robin" },
+  { id: "b", name: "Load Balancer 1", port: 443, rule: "Round robin" },
+  { id: "c", name: "Load Balancer 2", port: 80, rule: "DNS delegation" },
+  { id: "d", name: "Load Balancer 6", port: 3000, rule: "Round robin" },
+  { id: "e", name: "Load Balancer 4", port: 443, rule: "Round robin" },
+  { id: "f", name: "Load Balancer 5", port: 80, rule: "DNS delegation" },
+];
 
-  let selectedRowIds = [rows[0].id, rows[1].id];
+let selectedRowIds = [rows[0].id, rows[1].id];
 
-  $: console.log("selectedRowIds", selectedRowIds);
+$: console.log("selectedRowIds", selectedRowIds);
 </script>
 
 <DataTable batchSelection bind:selectedRowIds {headers} {rows}>

--- a/docs/src/pages/framed/DataTable/DataTableBatchSelectionToolbarControlled.svelte
+++ b/docs/src/pages/framed/DataTable/DataTableBatchSelectionToolbarControlled.svelte
@@ -1,33 +1,33 @@
 <script>
-  import {
-    DataTable,
-    Toolbar,
-    ToolbarContent,
-    ToolbarBatchActions,
-    Button,
-  } from "carbon-components-svelte";
-  import TrashCan from "carbon-icons-svelte/lib/TrashCan.svelte";
+import {
+  DataTable,
+  Toolbar,
+  ToolbarContent,
+  ToolbarBatchActions,
+  Button,
+} from "carbon-components-svelte";
+import TrashCan from "carbon-icons-svelte/lib/TrashCan.svelte";
 
-  const headers = [
-    { key: "name", value: "Name" },
-    { key: "port", value: "Port" },
-    { key: "rule", value: "Rule" },
-  ];
+const headers = [
+  { key: "name", value: "Name" },
+  { key: "port", value: "Port" },
+  { key: "rule", value: "Rule" },
+];
 
-  let rows = [
-    { id: "a", name: "Load Balancer 3", port: 3000, rule: "Round robin" },
-    { id: "b", name: "Load Balancer 1", port: 443, rule: "Round robin" },
-    { id: "c", name: "Load Balancer 2", port: 80, rule: "DNS delegation" },
-    { id: "d", name: "Load Balancer 6", port: 3000, rule: "Round robin" },
-    { id: "e", name: "Load Balancer 4", port: 443, rule: "Round robin" },
-    { id: "f", name: "Load Balancer 5", port: 80, rule: "DNS delegation" },
-  ];
+let rows = [
+  { id: "a", name: "Load Balancer 3", port: 3000, rule: "Round robin" },
+  { id: "b", name: "Load Balancer 1", port: 443, rule: "Round robin" },
+  { id: "c", name: "Load Balancer 2", port: 80, rule: "DNS delegation" },
+  { id: "d", name: "Load Balancer 6", port: 3000, rule: "Round robin" },
+  { id: "e", name: "Load Balancer 4", port: 443, rule: "Round robin" },
+  { id: "f", name: "Load Balancer 5", port: 80, rule: "DNS delegation" },
+];
 
-  let active = false;
-  let selectedRowIds = [];
+let active = false;
+let selectedRowIds = [];
 
-  $: console.log("active", active);
-  $: console.log("selectedRowIds", selectedRowIds);
+$: console.log("active", active);
+$: console.log("selectedRowIds", selectedRowIds);
 </script>
 
 <DataTable

--- a/docs/src/pages/framed/DataTable/DataTableExpandableSelectable.svelte
+++ b/docs/src/pages/framed/DataTable/DataTableExpandableSelectable.svelte
@@ -1,13 +1,13 @@
 <script>
-  import { DataTable } from "carbon-components-svelte";
+import { DataTable } from "carbon-components-svelte";
 
-  let expandedRowIds = [];
-  let selectedRowIds = [];
+let expandedRowIds = [];
+let selectedRowIds = [];
 
-  $: {
-    console.log("expandedRowIds", expandedRowIds);
-    console.log("selectedRowIds", selectedRowIds);
-  }
+$: {
+  console.log("expandedRowIds", expandedRowIds);
+  console.log("selectedRowIds", selectedRowIds);
+}
 </script>
 
 <DataTable

--- a/docs/src/pages/framed/DataTable/DataTableExpandableZebra.svelte
+++ b/docs/src/pages/framed/DataTable/DataTableExpandableZebra.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { DataTable } from "carbon-components-svelte";
+import { DataTable } from "carbon-components-svelte";
 </script>
 
 <DataTable

--- a/docs/src/pages/framed/DataTable/DataTableFilterCustom.svelte
+++ b/docs/src/pages/framed/DataTable/DataTableFilterCustom.svelte
@@ -1,24 +1,24 @@
 <script>
-  import {
-    DataTable,
-    Toolbar,
-    ToolbarContent,
-    ToolbarSearch,
-    Pagination,
-  } from "carbon-components-svelte";
+import {
+  DataTable,
+  Toolbar,
+  ToolbarContent,
+  ToolbarSearch,
+  Pagination,
+} from "carbon-components-svelte";
 
-  let rows = Array.from({ length: 10 }).map((_, i) => ({
-    id: i,
-    name: "Load Balancer " + (i + 1),
-    protocol: "HTTP",
-    port: 3000 + i * 10,
-    rule: i % 2 ? "Round robin" : "DNS delegation",
-  }));
-  let pageSize = 5;
-  let page = 1;
-  let filteredRowIds = [];
+let rows = Array.from({ length: 10 }).map((_, i) => ({
+  id: i,
+  name: "Load Balancer " + (i + 1),
+  protocol: "HTTP",
+  port: 3000 + i * 10,
+  rule: i % 2 ? "Round robin" : "DNS delegation",
+}));
+let pageSize = 5;
+let page = 1;
+let filteredRowIds = [];
 
-  $: console.log("filteredRowIds", filteredRowIds);
+$: console.log("filteredRowIds", filteredRowIds);
 </script>
 
 <DataTable

--- a/docs/src/pages/framed/DataTable/DataTableFilterable.svelte
+++ b/docs/src/pages/framed/DataTable/DataTableFilterable.svelte
@@ -1,24 +1,24 @@
 <script>
-  import {
-    DataTable,
-    Toolbar,
-    ToolbarContent,
-    ToolbarSearch,
-    Pagination,
-  } from "carbon-components-svelte";
+import {
+  DataTable,
+  Toolbar,
+  ToolbarContent,
+  ToolbarSearch,
+  Pagination,
+} from "carbon-components-svelte";
 
-  let rows = Array.from({ length: 10 }).map((_, i) => ({
-    id: i,
-    name: "Load Balancer " + (i + 1),
-    protocol: "HTTP",
-    port: 3000 + i * 10,
-    rule: i % 2 ? "Round robin" : "DNS delegation",
-  }));
-  let pageSize = 5;
-  let page = 1;
-  let filteredRowIds = [];
+let rows = Array.from({ length: 10 }).map((_, i) => ({
+  id: i,
+  name: "Load Balancer " + (i + 1),
+  protocol: "HTTP",
+  port: 3000 + i * 10,
+  rule: i % 2 ? "Round robin" : "DNS delegation",
+}));
+let pageSize = 5;
+let page = 1;
+let filteredRowIds = [];
 
-  $: console.log("filteredRowIds", filteredRowIds);
+$: console.log("filteredRowIds", filteredRowIds);
 </script>
 
 <DataTable

--- a/docs/src/pages/framed/DataTable/DataTableHeaderWidth.svelte
+++ b/docs/src/pages/framed/DataTable/DataTableHeaderWidth.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { DataTable } from "carbon-components-svelte";
+import { DataTable } from "carbon-components-svelte";
 </script>
 
 <DataTable

--- a/docs/src/pages/framed/DataTable/DataTableNonExpandableRows.svelte
+++ b/docs/src/pages/framed/DataTable/DataTableNonExpandableRows.svelte
@@ -1,50 +1,50 @@
 <script>
-  import { DataTable } from "carbon-components-svelte";
+import { DataTable } from "carbon-components-svelte";
 
-  const rows = [
-    {
-      id: "a",
-      name: "Load Balancer 3",
-      protocol: "HTTP",
-      port: 3000,
-      rule: "Round robin",
-    },
-    {
-      id: "b",
-      name: "Load Balancer 1",
-      protocol: "HTTP",
-      port: 443,
-      rule: "Round robin",
-    },
-    {
-      id: "c",
-      name: "Load Balancer 2",
-      protocol: "HTTP",
-      port: 80,
-      rule: "DNS delegation",
-    },
-    {
-      id: "d",
-      name: "Load Balancer 6",
-      protocol: "HTTP",
-      port: 3000,
-      rule: "Round robin",
-    },
-    {
-      id: "e",
-      name: "Load Balancer 4",
-      protocol: "HTTP",
-      port: 443,
-      rule: "Round robin",
-    },
-    {
-      id: "f",
-      name: "Load Balancer 5",
-      protocol: "HTTP",
-      port: 80,
-      rule: "DNS delegation",
-    },
-  ];
+const rows = [
+  {
+    id: "a",
+    name: "Load Balancer 3",
+    protocol: "HTTP",
+    port: 3000,
+    rule: "Round robin",
+  },
+  {
+    id: "b",
+    name: "Load Balancer 1",
+    protocol: "HTTP",
+    port: 443,
+    rule: "Round robin",
+  },
+  {
+    id: "c",
+    name: "Load Balancer 2",
+    protocol: "HTTP",
+    port: 80,
+    rule: "DNS delegation",
+  },
+  {
+    id: "d",
+    name: "Load Balancer 6",
+    protocol: "HTTP",
+    port: 3000,
+    rule: "Round robin",
+  },
+  {
+    id: "e",
+    name: "Load Balancer 4",
+    protocol: "HTTP",
+    port: 443,
+    rule: "Round robin",
+  },
+  {
+    id: "f",
+    name: "Load Balancer 5",
+    protocol: "HTTP",
+    port: 80,
+    rule: "DNS delegation",
+  },
+];
 </script>
 
 <DataTable

--- a/docs/src/pages/framed/DataTable/DataTableNonSelectableRows.svelte
+++ b/docs/src/pages/framed/DataTable/DataTableNonSelectableRows.svelte
@@ -1,50 +1,50 @@
 <script>
-  import { DataTable } from "carbon-components-svelte";
+import { DataTable } from "carbon-components-svelte";
 
-  const rows = [
-    {
-      id: "a",
-      name: "Load Balancer 3",
-      protocol: "HTTP",
-      port: 3000,
-      rule: "Round robin",
-    },
-    {
-      id: "b",
-      name: "Load Balancer 1",
-      protocol: "HTTP",
-      port: 443,
-      rule: "Round robin",
-    },
-    {
-      id: "c",
-      name: "Load Balancer 2",
-      protocol: "HTTP",
-      port: 80,
-      rule: "DNS delegation",
-    },
-    {
-      id: "d",
-      name: "Load Balancer 6",
-      protocol: "HTTP",
-      port: 3000,
-      rule: "Round robin",
-    },
-    {
-      id: "e",
-      name: "Load Balancer 4",
-      protocol: "HTTP",
-      port: 443,
-      rule: "Round robin",
-    },
-    {
-      id: "f",
-      name: "Load Balancer 5",
-      protocol: "HTTP",
-      port: 80,
-      rule: "DNS delegation",
-    },
-  ];
+const rows = [
+  {
+    id: "a",
+    name: "Load Balancer 3",
+    protocol: "HTTP",
+    port: 3000,
+    rule: "Round robin",
+  },
+  {
+    id: "b",
+    name: "Load Balancer 1",
+    protocol: "HTTP",
+    port: 443,
+    rule: "Round robin",
+  },
+  {
+    id: "c",
+    name: "Load Balancer 2",
+    protocol: "HTTP",
+    port: 80,
+    rule: "DNS delegation",
+  },
+  {
+    id: "d",
+    name: "Load Balancer 6",
+    protocol: "HTTP",
+    port: 3000,
+    rule: "Round robin",
+  },
+  {
+    id: "e",
+    name: "Load Balancer 4",
+    protocol: "HTTP",
+    port: 443,
+    rule: "Round robin",
+  },
+  {
+    id: "f",
+    name: "Load Balancer 5",
+    protocol: "HTTP",
+    port: 80,
+    rule: "DNS delegation",
+  },
+];
 </script>
 
 <DataTable

--- a/docs/src/pages/framed/DataTable/DataTablePagination.svelte
+++ b/docs/src/pages/framed/DataTable/DataTablePagination.svelte
@@ -1,15 +1,15 @@
 <script>
-  import { DataTable, Pagination } from "carbon-components-svelte";
+import { DataTable, Pagination } from "carbon-components-svelte";
 
-  let rows = Array.from({ length: 10 }).map((_, i) => ({
-    id: i,
-    name: "Load Balancer " + (i + 1),
-    protocol: "HTTP",
-    port: 3000 + i * 10,
-    rule: i % 2 ? "Round robin" : "DNS delegation",
-  }));
-  let pageSize = 5;
-  let page = 1;
+let rows = Array.from({ length: 10 }).map((_, i) => ({
+  id: i,
+  name: "Load Balancer " + (i + 1),
+  protocol: "HTTP",
+  port: 3000 + i * 10,
+  rule: i % 2 ? "Round robin" : "DNS delegation",
+}));
+let pageSize = 5;
+let page = 1;
 </script>
 
 <DataTable

--- a/docs/src/pages/framed/DataTable/DataTableProgrammaticSorting.svelte
+++ b/docs/src/pages/framed/DataTable/DataTableProgrammaticSorting.svelte
@@ -1,11 +1,11 @@
 <script>
-  import { DataTable, Button } from "carbon-components-svelte";
+import { DataTable, Button } from "carbon-components-svelte";
 
-  let sortKey = "port";
-  let sortDirection = "ascending";
+let sortKey = "port";
+let sortDirection = "ascending";
 
-  $: console.log("sortKey", sortKey);
-  $: console.log("sortDirection", sortDirection);
+$: console.log("sortKey", sortKey);
+$: console.log("sortDirection", sortDirection);
 </script>
 
 <Button

--- a/docs/src/pages/framed/DataTable/RadioSelectableDataTable.svelte
+++ b/docs/src/pages/framed/DataTable/RadioSelectableDataTable.svelte
@@ -1,24 +1,24 @@
 <script>
-  import { DataTable } from "carbon-components-svelte";
+import { DataTable } from "carbon-components-svelte";
 
-  const headers = [
-    { key: "name", value: "Name" },
-    { key: "port", value: "Port" },
-    { key: "rule", value: "Rule" },
-  ];
+const headers = [
+  { key: "name", value: "Name" },
+  { key: "port", value: "Port" },
+  { key: "rule", value: "Rule" },
+];
 
-  const rows = [
-    { id: "a", name: "Load Balancer 3", port: 3000, rule: "Round robin" },
-    { id: "b", name: "Load Balancer 1", port: 443, rule: "Round robin" },
-    { id: "c", name: "Load Balancer 2", port: 80, rule: "DNS delegation" },
-    { id: "d", name: "Load Balancer 6", port: 3000, rule: "Round robin" },
-    { id: "e", name: "Load Balancer 4", port: 443, rule: "Round robin" },
-    { id: "f", name: "Load Balancer 5", port: 80, rule: "DNS delegation" },
-  ];
+const rows = [
+  { id: "a", name: "Load Balancer 3", port: 3000, rule: "Round robin" },
+  { id: "b", name: "Load Balancer 1", port: 443, rule: "Round robin" },
+  { id: "c", name: "Load Balancer 2", port: 80, rule: "DNS delegation" },
+  { id: "d", name: "Load Balancer 6", port: 3000, rule: "Round robin" },
+  { id: "e", name: "Load Balancer 4", port: 443, rule: "Round robin" },
+  { id: "f", name: "Load Balancer 5", port: 80, rule: "DNS delegation" },
+];
 
-  let selectedRowIds = [rows[1].id];
+let selectedRowIds = [rows[1].id];
 
-  $: console.log("selectedRowIds", selectedRowIds);
+$: console.log("selectedRowIds", selectedRowIds);
 </script>
 
 <DataTable radio bind:selectedRowIds {headers} {rows} />

--- a/docs/src/pages/framed/DataTable/SelectableDataTable.svelte
+++ b/docs/src/pages/framed/DataTable/SelectableDataTable.svelte
@@ -1,9 +1,9 @@
 <script>
-  import { DataTable } from "carbon-components-svelte";
+import { DataTable } from "carbon-components-svelte";
 
-  let selectedRowIds = [];
+let selectedRowIds = [];
 
-  $: console.log("selectedRowIds", selectedRowIds);
+$: console.log("selectedRowIds", selectedRowIds);
 </script>
 
 <DataTable

--- a/docs/src/pages/framed/DatePicker/DatePickerModal.svelte
+++ b/docs/src/pages/framed/DatePicker/DatePickerModal.svelte
@@ -1,12 +1,12 @@
 <script>
-  import {
-    Button,
-    Modal,
-    DatePicker,
-    DatePickerInput,
-  } from "carbon-components-svelte";
+import {
+  Button,
+  Modal,
+  DatePicker,
+  DatePickerInput,
+} from "carbon-components-svelte";
 
-  let open = false;
+let open = false;
 </script>
 
 <Button on:click={() => (open = true)}>Select date</Button>

--- a/docs/src/pages/framed/DatePicker/DatePickerRange.svelte
+++ b/docs/src/pages/framed/DatePicker/DatePickerRange.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { DatePicker, DatePickerInput } from "carbon-components-svelte";
+import { DatePicker, DatePickerInput } from "carbon-components-svelte";
 </script>
 
 <DatePicker datePickerType="range" on:change>

--- a/docs/src/pages/framed/DatePicker/DatePickerSingle.svelte
+++ b/docs/src/pages/framed/DatePicker/DatePickerSingle.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { DatePicker, DatePickerInput } from "carbon-components-svelte";
+import { DatePicker, DatePickerInput } from "carbon-components-svelte";
 </script>
 
 <DatePicker datePickerType="single" on:change>

--- a/docs/src/pages/framed/Dropdown/DropdownSlot.svelte
+++ b/docs/src/pages/framed/Dropdown/DropdownSlot.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { Dropdown } from "carbon-components-svelte";
+import { Dropdown } from "carbon-components-svelte";
 </script>
 
 <Dropdown

--- a/docs/src/pages/framed/Dropdown/MultipleDropdown.svelte
+++ b/docs/src/pages/framed/Dropdown/MultipleDropdown.svelte
@@ -1,20 +1,20 @@
 <script>
-  import { Dropdown } from "carbon-components-svelte";
+import { Dropdown } from "carbon-components-svelte";
 
-  const items = [
-    { id: "0", text: "Slack" },
-    { id: "1", text: "Email" },
-    { id: "2", text: "Fax" },
-  ];
+const items = [
+  { id: "0", text: "Slack" },
+  { id: "1", text: "Email" },
+  { id: "2", text: "Fax" },
+];
 
-  let dropdown1_selectedId = "0";
-  let dropdown2_selectedId = "1";
+let dropdown1_selectedId = "0";
+let dropdown2_selectedId = "1";
 
-  const formatSelected = (id) =>
-    items.find((item) => item.id === id)?.text ?? "N/A";
+const formatSelected = (id) =>
+  items.find((item) => item.id === id)?.text ?? "N/A";
 
-  $: primary = formatSelected(dropdown1_selectedId);
-  $: secondary = formatSelected(dropdown2_selectedId);
+$: primary = formatSelected(dropdown1_selectedId);
+$: secondary = formatSelected(dropdown2_selectedId);
 </script>
 
 <Dropdown

--- a/docs/src/pages/framed/FileUploader/FileUploaderClearFiles.svelte
+++ b/docs/src/pages/framed/FileUploader/FileUploaderClearFiles.svelte
@@ -1,8 +1,8 @@
 <script>
-  import { FileUploader, Button } from "carbon-components-svelte";
+import { FileUploader, Button } from "carbon-components-svelte";
 
-  let fileUploader;
-  let files = [];
+let fileUploader;
+let files = [];
 </script>
 
 <FileUploader

--- a/docs/src/pages/framed/FluidForm/FluidFormInvalid.svelte
+++ b/docs/src/pages/framed/FluidForm/FluidFormInvalid.svelte
@@ -1,14 +1,10 @@
 <script>
-  import {
-    FluidForm,
-    TextInput,
-    PasswordInput,
-  } from "carbon-components-svelte";
+import { FluidForm, TextInput, PasswordInput } from "carbon-components-svelte";
 
-  let password = "";
-  let invalid = false;
+let password = "";
+let invalid = false;
 
-  $: invalid = !/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[a-zA-Z\d]{6,}$/.test(password);
+$: invalid = !/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[a-zA-Z\d]{6,}$/.test(password);
 </script>
 
 <FluidForm>

--- a/docs/src/pages/framed/Grid/AspectRatioColumns.svelte
+++ b/docs/src/pages/framed/Grid/AspectRatioColumns.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { Grid, Row, Column } from "carbon-components-svelte";
+import { Grid, Row, Column } from "carbon-components-svelte";
 </script>
 
 <Grid>

--- a/docs/src/pages/framed/Grid/CondensedGrid.svelte
+++ b/docs/src/pages/framed/Grid/CondensedGrid.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { Grid, Row, Column } from "carbon-components-svelte";
+import { Grid, Row, Column } from "carbon-components-svelte";
 </script>
 
 <Grid condensed>

--- a/docs/src/pages/framed/Grid/FullWidthGrid.svelte
+++ b/docs/src/pages/framed/Grid/FullWidthGrid.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { Grid, Row, Column } from "carbon-components-svelte";
+import { Grid, Row, Column } from "carbon-components-svelte";
 </script>
 
 <Grid fullWidth>

--- a/docs/src/pages/framed/Grid/Grid.svelte
+++ b/docs/src/pages/framed/Grid/Grid.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { Grid, Row, Column } from "carbon-components-svelte";
+import { Grid, Row, Column } from "carbon-components-svelte";
 </script>
 
 <Grid>

--- a/docs/src/pages/framed/Grid/NarrowGrid.svelte
+++ b/docs/src/pages/framed/Grid/NarrowGrid.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { Grid, Row, Column } from "carbon-components-svelte";
+import { Grid, Row, Column } from "carbon-components-svelte";
 </script>
 
 <Grid narrow>

--- a/docs/src/pages/framed/Grid/OffsetColumns.svelte
+++ b/docs/src/pages/framed/Grid/OffsetColumns.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { Grid, Row, Column } from "carbon-components-svelte";
+import { Grid, Row, Column } from "carbon-components-svelte";
 </script>
 
 <Grid>

--- a/docs/src/pages/framed/Grid/PaddedGrid.svelte
+++ b/docs/src/pages/framed/Grid/PaddedGrid.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { Grid, Row, Column } from "carbon-components-svelte";
+import { Grid, Row, Column } from "carbon-components-svelte";
 </script>
 
 <div>Adding padding to Grid applies it to columns in all rows:</div>

--- a/docs/src/pages/framed/Grid/ResponsiveGrid.svelte
+++ b/docs/src/pages/framed/Grid/ResponsiveGrid.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { Grid, Row, Column } from "carbon-components-svelte";
+import { Grid, Row, Column } from "carbon-components-svelte";
 </script>
 
 <Grid>

--- a/docs/src/pages/framed/ImageLoader/DynamicImageLoader.svelte
+++ b/docs/src/pages/framed/ImageLoader/DynamicImageLoader.svelte
@@ -1,14 +1,14 @@
 <script>
-  import { ImageLoader, Button } from "carbon-components-svelte";
+import { ImageLoader, Button } from "carbon-components-svelte";
 
-  const images = [
-    "https://upload.wikimedia.org/wikipedia/commons/1/1b/Svelte_Logo.svg",
-    "https://upload.wikimedia.org/wikipedia/commons/b/b9/Carbon-design-system-logo.png",
-  ];
+const images = [
+  "https://upload.wikimedia.org/wikipedia/commons/1/1b/Svelte_Logo.svg",
+  "https://upload.wikimedia.org/wikipedia/commons/b/b9/Carbon-design-system-logo.png",
+];
 
-  let index = 0;
+let index = 0;
 
-  $: src = images[index];
+$: src = images[index];
 </script>
 
 <Button

--- a/docs/src/pages/framed/ImageLoader/ProgrammaticImageLoader.svelte
+++ b/docs/src/pages/framed/ImageLoader/ProgrammaticImageLoader.svelte
@@ -1,12 +1,11 @@
 <script>
-  import { ImageLoader, Button } from "carbon-components-svelte";
+import { ImageLoader, Button } from "carbon-components-svelte";
 
-  const src =
-    "https://upload.wikimedia.org/wikipedia/commons/5/51/IBM_logo.svg";
-  const srcError = src + "1";
+const src = "https://upload.wikimedia.org/wikipedia/commons/5/51/IBM_logo.svg";
+const srcError = src + "1";
 
-  let imageLoader;
-  let error;
+let imageLoader;
+let error;
 </script>
 
 <Button

--- a/docs/src/pages/framed/InlineLoading/InlineLoadingUx.svelte
+++ b/docs/src/pages/framed/InlineLoading/InlineLoadingUx.svelte
@@ -1,37 +1,37 @@
 <script>
-  import { Button, ButtonSet, InlineLoading } from "carbon-components-svelte";
-  import { onDestroy } from "svelte";
+import { Button, ButtonSet, InlineLoading } from "carbon-components-svelte";
+import { onDestroy } from "svelte";
 
-  const descriptionMap = {
-    active: "Submitting...",
-    finished: "Success",
-    inactive: "Cancelling...",
-  };
+const descriptionMap = {
+  active: "Submitting...",
+  finished: "Success",
+  inactive: "Cancelling...",
+};
 
-  const stateMap = {
-    active: "finished",
-    inactive: "dormant",
-    finished: "dormant",
-  };
+const stateMap = {
+  active: "finished",
+  inactive: "dormant",
+  finished: "dormant",
+};
 
-  let timeout = undefined;
-  let state = "dormant"; // "dormant" | "active" | "finished" | "inactive"
+let timeout = undefined;
+let state = "dormant"; // "dormant" | "active" | "finished" | "inactive"
 
-  function reset(incomingState) {
-    if (typeof timeout === "number") {
-      clearTimeout(timeout);
-    }
-
-    if (incomingState) {
-      timeout = setTimeout(() => {
-        state = incomingState;
-      }, 2000);
-    }
+function reset(incomingState) {
+  if (typeof timeout === "number") {
+    clearTimeout(timeout);
   }
 
-  onDestroy(reset);
+  if (incomingState) {
+    timeout = setTimeout(() => {
+      state = incomingState;
+    }, 2000);
+  }
+}
 
-  $: reset(stateMap[state]);
+onDestroy(reset);
+
+$: reset(stateMap[state]);
 </script>
 
 <ButtonSet>

--- a/docs/src/pages/framed/Loading/Loading.svelte
+++ b/docs/src/pages/framed/Loading/Loading.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { Loading } from "carbon-components-svelte";
+import { Loading } from "carbon-components-svelte";
 </script>
 
 <Loading />

--- a/docs/src/pages/framed/LocalStorage/LocalStorage.svelte
+++ b/docs/src/pages/framed/LocalStorage/LocalStorage.svelte
@@ -1,10 +1,10 @@
 <script>
-  import { LocalStorage, Toggle } from "carbon-components-svelte";
+import { LocalStorage, Toggle } from "carbon-components-svelte";
 
-  let toggled = false;
-  let events = [];
+let toggled = false;
+let events = [];
 
-  $: document.documentElement.setAttribute("theme", toggled ? "g100" : "white");
+$: document.documentElement.setAttribute("theme", toggled ? "g100" : "white");
 </script>
 
 <LocalStorage

--- a/docs/src/pages/framed/LocalStorage/LocalStorageClear.svelte
+++ b/docs/src/pages/framed/LocalStorage/LocalStorageClear.svelte
@@ -1,10 +1,10 @@
 <script>
-  import { LocalStorage, Toggle, Button } from "carbon-components-svelte";
+import { LocalStorage, Toggle, Button } from "carbon-components-svelte";
 
-  let storage;
-  let toggled = false;
+let storage;
+let toggled = false;
 
-  $: document.documentElement.setAttribute("theme", toggled ? "g100" : "white");
+$: document.documentElement.setAttribute("theme", toggled ? "g100" : "white");
 </script>
 
 <LocalStorage bind:this={storage} bind:value={toggled} />

--- a/docs/src/pages/framed/Modal/3ButtonComposedModal.svelte
+++ b/docs/src/pages/framed/Modal/3ButtonComposedModal.svelte
@@ -1,15 +1,15 @@
 <script>
-  import {
-    Button,
-    ComposedModal,
-    ModalHeader,
-    ModalBody,
-    ModalFooter,
-    Checkbox,
-  } from "carbon-components-svelte";
+import {
+  Button,
+  ComposedModal,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+  Checkbox,
+} from "carbon-components-svelte";
 
-  let open = true;
-  let checked = false;
+let open = true;
+let checked = false;
 </script>
 
 <Button on:click={() => (open = true)}>Review changes</Button>

--- a/docs/src/pages/framed/Modal/3ButtonModal.svelte
+++ b/docs/src/pages/framed/Modal/3ButtonModal.svelte
@@ -1,7 +1,7 @@
 <script>
-  import { Button, Modal } from "carbon-components-svelte";
+import { Button, Modal } from "carbon-components-svelte";
 
-  let open = false;
+let open = false;
 </script>
 
 <Button on:click={() => (open = true)}>Create database</Button>

--- a/docs/src/pages/framed/Modal/ComposedModal.svelte
+++ b/docs/src/pages/framed/Modal/ComposedModal.svelte
@@ -1,13 +1,13 @@
 <script>
-  import {
-    ComposedModal,
-    ModalHeader,
-    ModalBody,
-    ModalFooter,
-    Checkbox,
-  } from "carbon-components-svelte";
+import {
+  ComposedModal,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+  Checkbox,
+} from "carbon-components-svelte";
 
-  let checked = false;
+let checked = false;
 </script>
 
 <ComposedModal open>

--- a/docs/src/pages/framed/Modal/DangerModal.svelte
+++ b/docs/src/pages/framed/Modal/DangerModal.svelte
@@ -1,7 +1,7 @@
 <script>
-  import { Button, Modal } from "carbon-components-svelte";
+import { Button, Modal } from "carbon-components-svelte";
 
-  let open = false;
+let open = false;
 </script>
 
 <Button kind="danger" on:click={() => (open = true)}>Delete all</Button>

--- a/docs/src/pages/framed/Modal/Modal.svelte
+++ b/docs/src/pages/framed/Modal/Modal.svelte
@@ -1,7 +1,7 @@
 <script>
-  import { Button, Modal } from "carbon-components-svelte";
+import { Button, Modal } from "carbon-components-svelte";
 
-  let open = false;
+let open = false;
 </script>
 
 <Button on:click={() => (open = true)}>Create database</Button>

--- a/docs/src/pages/framed/Modal/ModalButtonWithIcon.svelte
+++ b/docs/src/pages/framed/Modal/ModalButtonWithIcon.svelte
@@ -1,8 +1,8 @@
 <script>
-  import { Button, Modal } from "carbon-components-svelte";
-  import Send from "carbon-icons-svelte/lib/Send.svelte";
+import { Button, Modal } from "carbon-components-svelte";
+import Send from "carbon-icons-svelte/lib/Send.svelte";
 
-  let open = false;
+let open = false;
 </script>
 
 <Button on:click={() => (open = true)}>Create database</Button>

--- a/docs/src/pages/framed/Modal/ModalCustomFocus.svelte
+++ b/docs/src/pages/framed/Modal/ModalCustomFocus.svelte
@@ -1,7 +1,7 @@
 <script>
-  import { Button, Modal, TextInput } from "carbon-components-svelte";
+import { Button, Modal, TextInput } from "carbon-components-svelte";
 
-  let open = false;
+let open = false;
 </script>
 
 <Button on:click={() => (open = true)}>Create database</Button>

--- a/docs/src/pages/framed/Modal/ModalExtraSmall.svelte
+++ b/docs/src/pages/framed/Modal/ModalExtraSmall.svelte
@@ -1,7 +1,7 @@
 <script>
-  import { Button, Modal } from "carbon-components-svelte";
+import { Button, Modal } from "carbon-components-svelte";
 
-  let open = false;
+let open = false;
 </script>
 
 <Button on:click={() => (open = true)}>Create database</Button>

--- a/docs/src/pages/framed/Modal/ModalLarge.svelte
+++ b/docs/src/pages/framed/Modal/ModalLarge.svelte
@@ -1,7 +1,7 @@
 <script>
-  import { Button, Modal } from "carbon-components-svelte";
+import { Button, Modal } from "carbon-components-svelte";
 
-  let open = false;
+let open = false;
 </script>
 
 <Button on:click={() => (open = true)}>Create database</Button>

--- a/docs/src/pages/framed/Modal/ModalMultiple.svelte
+++ b/docs/src/pages/framed/Modal/ModalMultiple.svelte
@@ -1,8 +1,8 @@
 <script>
-  import { Button, Modal } from "carbon-components-svelte";
+import { Button, Modal } from "carbon-components-svelte";
 
-  let openCreate = false;
-  let openDelete = false;
+let openCreate = false;
+let openDelete = false;
 </script>
 
 <Button on:click={() => (openCreate = true)}>Create database</Button>

--- a/docs/src/pages/framed/Modal/ModalPreventOutsideClick.svelte
+++ b/docs/src/pages/framed/Modal/ModalPreventOutsideClick.svelte
@@ -1,7 +1,7 @@
 <script>
-  import { Button, Modal } from "carbon-components-svelte";
+import { Button, Modal } from "carbon-components-svelte";
 
-  let open = false;
+let open = false;
 </script>
 
 <Button on:click={() => (open = true)}>Create database</Button>

--- a/docs/src/pages/framed/Modal/ModalScrollingContent.svelte
+++ b/docs/src/pages/framed/Modal/ModalScrollingContent.svelte
@@ -1,7 +1,7 @@
 <script>
-  import { Button, Modal } from "carbon-components-svelte";
+import { Button, Modal } from "carbon-components-svelte";
 
-  let open = false;
+let open = false;
 </script>
 
 <Button on:click={() => (open = true)}>Create database</Button>

--- a/docs/src/pages/framed/Modal/ModalSmall.svelte
+++ b/docs/src/pages/framed/Modal/ModalSmall.svelte
@@ -1,7 +1,7 @@
 <script>
-  import { Button, Modal } from "carbon-components-svelte";
+import { Button, Modal } from "carbon-components-svelte";
 
-  let open = false;
+let open = false;
 </script>
 
 <Button on:click={() => (open = true)}>Create database</Button>

--- a/docs/src/pages/framed/Modal/PassiveModal.svelte
+++ b/docs/src/pages/framed/Modal/PassiveModal.svelte
@@ -1,7 +1,7 @@
 <script>
-  import { Button, Modal } from "carbon-components-svelte";
+import { Button, Modal } from "carbon-components-svelte";
 
-  let open = false;
+let open = false;
 </script>
 
 <Button kind="tertiary" on:click={() => (open = true)}>Learn more</Button>

--- a/docs/src/pages/framed/MultiSelect/MultiSelectSlot.svelte
+++ b/docs/src/pages/framed/MultiSelect/MultiSelectSlot.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { MultiSelect } from "carbon-components-svelte";
+import { MultiSelect } from "carbon-components-svelte";
 </script>
 
 <MultiSelect

--- a/docs/src/pages/framed/MultiSelect/MultipleMultiSelect.svelte
+++ b/docs/src/pages/framed/MultiSelect/MultipleMultiSelect.svelte
@@ -1,22 +1,22 @@
 <script>
-  import { MultiSelect } from "carbon-components-svelte";
+import { MultiSelect } from "carbon-components-svelte";
 
-  const items = [
-    { id: "0", text: "Slack" },
-    { id: "1", text: "Email" },
-    { id: "2", text: "Fax" },
-  ];
+const items = [
+  { id: "0", text: "Slack" },
+  { id: "1", text: "Email" },
+  { id: "2", text: "Fax" },
+];
 
-  let multiselect1_selectedIds = ["0"];
-  let multiselect2_selectedIds = ["1", "2"];
+let multiselect1_selectedIds = ["0"];
+let multiselect2_selectedIds = ["1", "2"];
 
-  const formatSelected = (i) =>
-    i.length === 0
-      ? "N/A"
-      : i.map((id) => items.find((item) => item.id === id).text).join(", ");
+const formatSelected = (i) =>
+  i.length === 0
+    ? "N/A"
+    : i.map((id) => items.find((item) => item.id === id).text).join(", ");
 
-  $: primary = formatSelected(multiselect1_selectedIds);
-  $: secondary = formatSelected(multiselect2_selectedIds);
+$: primary = formatSelected(multiselect1_selectedIds);
+$: secondary = formatSelected(multiselect2_selectedIds);
 </script>
 
 <MultiSelect

--- a/docs/src/pages/framed/NumberInput/NumberInputEmpty.svelte
+++ b/docs/src/pages/framed/NumberInput/NumberInputEmpty.svelte
@@ -1,7 +1,7 @@
 <script>
-  import { NumberInput, Button } from "carbon-components-svelte";
+import { NumberInput, Button } from "carbon-components-svelte";
 
-  let value = null;
+let value = null;
 </script>
 
 <NumberInput allowEmpty bind:value />

--- a/docs/src/pages/framed/PaginationNav/PaginationNavReactive.svelte
+++ b/docs/src/pages/framed/PaginationNav/PaginationNavReactive.svelte
@@ -1,7 +1,7 @@
 <script>
-  import { PaginationNav, Button } from "carbon-components-svelte";
+import { PaginationNav, Button } from "carbon-components-svelte";
 
-  let page = 2;
+let page = 2;
 </script>
 
 <PaginationNav bind:page />

--- a/docs/src/pages/framed/Popover/WithButton.svelte
+++ b/docs/src/pages/framed/Popover/WithButton.svelte
@@ -1,8 +1,8 @@
 <script>
-  import { Popover, Button } from "carbon-components-svelte";
+import { Popover, Button } from "carbon-components-svelte";
 
-  let open = true;
-  let ref = null;
+let open = true;
+let ref = null;
 </script>
 
 <div bind:this={ref} style:position="relative">

--- a/docs/src/pages/framed/ProgressBar/ProgressBarUx.svelte
+++ b/docs/src/pages/framed/ProgressBar/ProgressBarUx.svelte
@@ -1,16 +1,16 @@
 <script>
-  import { ProgressBar, ButtonSet, Button } from "carbon-components-svelte";
+import { ProgressBar, ButtonSet, Button } from "carbon-components-svelte";
 
-  let max = 328;
-  let value = 0;
-  let status = "active";
+let max = 328;
+let value = 0;
+let status = "active";
 
-  $: helperText =
-    value > 0 ? value.toFixed(0) + "MB of " + max + "MB" : "Press start";
-  $: if (value === max) {
-    helperText = "Done";
-    status = "finished";
-  }
+$: helperText =
+  value > 0 ? value.toFixed(0) + "MB of " + max + "MB" : "Press start";
+$: if (value === max) {
+  helperText = "Done";
+  status = "finished";
+}
 </script>
 
 <ProgressBar labelText="Upload status" {value} {max} {helperText} {status} />

--- a/docs/src/pages/framed/ProgressIndicator/ProgrammaticProgressIndicator.svelte
+++ b/docs/src/pages/framed/ProgressIndicator/ProgrammaticProgressIndicator.svelte
@@ -1,12 +1,12 @@
 <script>
-  import {
-    ProgressIndicator,
-    ProgressStep,
-    Button,
-  } from "carbon-components-svelte";
+import {
+  ProgressIndicator,
+  ProgressStep,
+  Button,
+} from "carbon-components-svelte";
 
-  let currentIndex = 1;
-  let thirdStepCurrent = false;
+let currentIndex = 1;
+let thirdStepCurrent = false;
 </script>
 
 <ProgressIndicator bind:currentIndex>

--- a/docs/src/pages/framed/RadioButton/RadioButtonReactive.svelte
+++ b/docs/src/pages/framed/RadioButton/RadioButtonReactive.svelte
@@ -1,13 +1,13 @@
 <script>
-  import {
-    Button,
-    RadioButtonGroup,
-    RadioButton,
-  } from "carbon-components-svelte";
+import {
+  Button,
+  RadioButtonGroup,
+  RadioButton,
+} from "carbon-components-svelte";
 
-  const plans = ["Free (1 GB)", "Standard (10 GB)", "Pro (128 GB)"];
+const plans = ["Free (1 GB)", "Standard (10 GB)", "Pro (128 GB)"];
 
-  let plan = plans[1];
+let plan = plans[1];
 </script>
 
 <RadioButtonGroup

--- a/docs/src/pages/framed/RadioTile/RadioTileReactive.svelte
+++ b/docs/src/pages/framed/RadioTile/RadioTileReactive.svelte
@@ -1,9 +1,9 @@
 <script>
-  import { TileGroup, RadioTile, Button } from "carbon-components-svelte";
+import { TileGroup, RadioTile, Button } from "carbon-components-svelte";
 
-  const values = ["Lite plan", "Standard plan", "Plus plan"];
+const values = ["Lite plan", "Standard plan", "Plus plan"];
 
-  let selected = values[1];
+let selected = values[1];
 </script>
 
 <TileGroup legend="Service pricing tiers" name="plan" bind:selected>

--- a/docs/src/pages/framed/RadioTile/RadioTileReactiveOneWay.svelte
+++ b/docs/src/pages/framed/RadioTile/RadioTileReactiveOneWay.svelte
@@ -1,9 +1,9 @@
 <script>
-  import { TileGroup, RadioTile } from "carbon-components-svelte";
+import { TileGroup, RadioTile } from "carbon-components-svelte";
 
-  const values = ["Lite plan", "Standard plan", "Plus plan"];
+const values = ["Lite plan", "Standard plan", "Plus plan"];
 
-  let selected = values[1];
+let selected = values[1];
 </script>
 
 <TileGroup

--- a/docs/src/pages/framed/RecursiveList/RecursiveList.svelte
+++ b/docs/src/pages/framed/RecursiveList/RecursiveList.svelte
@@ -1,32 +1,32 @@
 <script>
-  import { RecursiveList } from "carbon-components-svelte";
+import { RecursiveList } from "carbon-components-svelte";
 
-  const nodes = [
-    {
-      text: "Item 1",
-      nodes: [
-        {
-          text: "Item 1a",
-          nodes: [{ html: "<h5>HTML content</h5>" }],
-        },
-      ],
-    },
-    {
-      text: "Item 2",
-      nodes: [
-        {
-          href: "https://svelte.dev/",
-        },
-        {
-          href: "https://svelte.dev/",
-          text: "Link with custom text",
-        },
-      ],
-    },
-    {
-      text: "Item 3",
-    },
-  ];
+const nodes = [
+  {
+    text: "Item 1",
+    nodes: [
+      {
+        text: "Item 1a",
+        nodes: [{ html: "<h5>HTML content</h5>" }],
+      },
+    ],
+  },
+  {
+    text: "Item 2",
+    nodes: [
+      {
+        href: "https://svelte.dev/",
+      },
+      {
+        href: "https://svelte.dev/",
+        text: "Link with custom text",
+      },
+    ],
+  },
+  {
+    text: "Item 3",
+  },
+];
 </script>
 
 <RecursiveList {nodes} />

--- a/docs/src/pages/framed/RecursiveList/RecursiveListFlatArray.svelte
+++ b/docs/src/pages/framed/RecursiveList/RecursiveListFlatArray.svelte
@@ -1,20 +1,20 @@
 <script>
-  import { RecursiveList, toHierarchy } from "carbon-components-svelte";
+import { RecursiveList, toHierarchy } from "carbon-components-svelte";
 
-  const nodesFlat = [
-    { id: 1, text: "Item 1" },
-    { id: 2, text: "Item 1a", pid: 1 },
-    { id: 3, html: "<h5>HTML content</h5>", pid: 2 },
-    { id: 4, text: "Item 2" },
-    { id: 5, href: "https://svelte.dev/", pid: 4 },
-    {
-      id: 6,
-      href: "https://svelte.dev/",
-      text: "Link with custom text",
-      pid: 4,
-    },
-    { id: 7, text: "Item 3" },
-  ];
+const nodesFlat = [
+  { id: 1, text: "Item 1" },
+  { id: 2, text: "Item 1a", pid: 1 },
+  { id: 3, html: "<h5>HTML content</h5>", pid: 2 },
+  { id: 4, text: "Item 2" },
+  { id: 5, href: "https://svelte.dev/", pid: 4 },
+  {
+    id: 6,
+    href: "https://svelte.dev/",
+    text: "Link with custom text",
+    pid: 4,
+  },
+  { id: 7, text: "Item 3" },
+];
 </script>
 
 <RecursiveList nodes={toHierarchy(nodesFlat, (node) => node.pid)} />

--- a/docs/src/pages/framed/RecursiveList/RecursiveListOrdered.svelte
+++ b/docs/src/pages/framed/RecursiveList/RecursiveListOrdered.svelte
@@ -1,32 +1,32 @@
 <script>
-  import { RecursiveList } from "carbon-components-svelte";
+import { RecursiveList } from "carbon-components-svelte";
 
-  const nodes = [
-    {
-      text: "Item 1",
-      nodes: [
-        {
-          text: "Item 1a",
-          nodes: [{ html: "<h5>HTML content</h5>" }],
-        },
-      ],
-    },
-    {
-      text: "Item 2",
-      nodes: [
-        {
-          href: "https://svelte.dev/",
-        },
-        {
-          href: "https://svelte.dev/",
-          text: "Link with custom text",
-        },
-      ],
-    },
-    {
-      text: "Item 3",
-    },
-  ];
+const nodes = [
+  {
+    text: "Item 1",
+    nodes: [
+      {
+        text: "Item 1a",
+        nodes: [{ html: "<h5>HTML content</h5>" }],
+      },
+    ],
+  },
+  {
+    text: "Item 2",
+    nodes: [
+      {
+        href: "https://svelte.dev/",
+      },
+      {
+        href: "https://svelte.dev/",
+        text: "Link with custom text",
+      },
+    ],
+  },
+  {
+    text: "Item 3",
+  },
+];
 </script>
 
 <RecursiveList type="ordered" {nodes} />

--- a/docs/src/pages/framed/RecursiveList/RecursiveListOrderedNative.svelte
+++ b/docs/src/pages/framed/RecursiveList/RecursiveListOrderedNative.svelte
@@ -1,32 +1,32 @@
 <script>
-  import { RecursiveList } from "carbon-components-svelte";
+import { RecursiveList } from "carbon-components-svelte";
 
-  const nodes = [
-    {
-      text: "Item 1",
-      nodes: [
-        {
-          text: "Item 1a",
-          nodes: [{ html: "<h5>HTML content</h5>" }],
-        },
-      ],
-    },
-    {
-      text: "Item 2",
-      nodes: [
-        {
-          href: "https://svelte.dev/",
-        },
-        {
-          href: "https://svelte.dev/",
-          text: "Link with custom text",
-        },
-      ],
-    },
-    {
-      text: "Item 3",
-    },
-  ];
+const nodes = [
+  {
+    text: "Item 1",
+    nodes: [
+      {
+        text: "Item 1a",
+        nodes: [{ html: "<h5>HTML content</h5>" }],
+      },
+    ],
+  },
+  {
+    text: "Item 2",
+    nodes: [
+      {
+        href: "https://svelte.dev/",
+      },
+      {
+        href: "https://svelte.dev/",
+        text: "Link with custom text",
+      },
+    ],
+  },
+  {
+    text: "Item 3",
+  },
+];
 </script>
 
 <RecursiveList type="ordered-native" {nodes} />

--- a/docs/src/pages/framed/Search/SearchExpandableReactive.svelte
+++ b/docs/src/pages/framed/Search/SearchExpandableReactive.svelte
@@ -1,7 +1,7 @@
 <script>
-  import { Search } from "carbon-components-svelte";
+import { Search } from "carbon-components-svelte";
 
-  let expanded = false;
+let expanded = false;
 </script>
 
 <Search expandable bind:expanded on:expand on:collapse />

--- a/docs/src/pages/framed/Search/SearchReactive.svelte
+++ b/docs/src/pages/framed/Search/SearchReactive.svelte
@@ -1,7 +1,7 @@
 <script>
-  import { Search, ButtonSet, Button } from "carbon-components-svelte";
+import { Search, ButtonSet, Button } from "carbon-components-svelte";
 
-  let value = "";
+let value = "";
 </script>
 
 <Search bind:value />

--- a/docs/src/pages/framed/Select/SelectReactive.svelte
+++ b/docs/src/pages/framed/Select/SelectReactive.svelte
@@ -1,7 +1,7 @@
 <script>
-  import { Select, SelectItem, Button } from "carbon-components-svelte";
+import { Select, SelectItem, Button } from "carbon-components-svelte";
 
-  let selected = "g10";
+let selected = "g10";
 </script>
 
 <Select labelText="Carbon theme" bind:selected>

--- a/docs/src/pages/framed/Tabs/TabsReactive.svelte
+++ b/docs/src/pages/framed/Tabs/TabsReactive.svelte
@@ -1,7 +1,7 @@
 <script>
-  import { Tabs, Tab, TabContent, Button } from "carbon-components-svelte";
+import { Tabs, Tab, TabContent, Button } from "carbon-components-svelte";
 
-  let selected = 0;
+let selected = 0;
 </script>
 
 <Tabs bind:selected>

--- a/docs/src/pages/framed/Theme/Theme.svelte
+++ b/docs/src/pages/framed/Theme/Theme.svelte
@@ -1,11 +1,7 @@
 <script>
-  import {
-    Theme,
-    RadioButtonGroup,
-    RadioButton,
-  } from "carbon-components-svelte";
+import { Theme, RadioButtonGroup, RadioButton } from "carbon-components-svelte";
 
-  let theme = "g90";
+let theme = "g90";
 </script>
 
 <Theme bind:theme />

--- a/docs/src/pages/framed/Theme/ThemePersist.svelte
+++ b/docs/src/pages/framed/Theme/ThemePersist.svelte
@@ -1,11 +1,7 @@
 <script>
-  import {
-    Theme,
-    RadioButtonGroup,
-    RadioButton,
-  } from "carbon-components-svelte";
+import { Theme, RadioButtonGroup, RadioButton } from "carbon-components-svelte";
 
-  let theme = "g90";
+let theme = "g90";
 </script>
 
 <Theme bind:theme persist persistKey="__carbon-theme" />

--- a/docs/src/pages/framed/Theme/ThemeSelect.svelte
+++ b/docs/src/pages/framed/Theme/ThemeSelect.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { Theme } from "carbon-components-svelte";
+import { Theme } from "carbon-components-svelte";
 </script>
 
 <Theme render="select" />

--- a/docs/src/pages/framed/Theme/ThemeSelectCustom.svelte
+++ b/docs/src/pages/framed/Theme/ThemeSelectCustom.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { Theme } from "carbon-components-svelte";
+import { Theme } from "carbon-components-svelte";
 </script>
 
 <Theme

--- a/docs/src/pages/framed/Theme/ThemeToggle.svelte
+++ b/docs/src/pages/framed/Theme/ThemeToggle.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { Theme } from "carbon-components-svelte";
+import { Theme } from "carbon-components-svelte";
 </script>
 
 <Theme render="toggle" />

--- a/docs/src/pages/framed/Theme/ThemeToggleCustom.svelte
+++ b/docs/src/pages/framed/Theme/ThemeToggleCustom.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { Theme } from "carbon-components-svelte";
+import { Theme } from "carbon-components-svelte";
 </script>
 
 <Theme

--- a/docs/src/pages/framed/Theme/ThemeTokens.svelte
+++ b/docs/src/pages/framed/Theme/ThemeTokens.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { Theme, Button } from "carbon-components-svelte";
+import { Theme, Button } from "carbon-components-svelte";
 </script>
 
 <Theme

--- a/docs/src/pages/framed/ToastNotification/ToastNotificationTimeout.svelte
+++ b/docs/src/pages/framed/ToastNotification/ToastNotificationTimeout.svelte
@@ -1,9 +1,9 @@
 <script>
-  import { Button, ToastNotification } from "carbon-components-svelte";
-  import { fade } from "svelte/transition";
+import { Button, ToastNotification } from "carbon-components-svelte";
+import { fade } from "svelte/transition";
 
-  let timeout = undefined;
-  $: showNotification = timeout !== undefined;
+let timeout = undefined;
+$: showNotification = timeout !== undefined;
 </script>
 
 <Button

--- a/docs/src/pages/framed/Toggle/ToggleReactive.svelte
+++ b/docs/src/pages/framed/Toggle/ToggleReactive.svelte
@@ -1,7 +1,7 @@
 <script>
-  import { Toggle, Button } from "carbon-components-svelte";
+import { Toggle, Button } from "carbon-components-svelte";
 
-  let toggled = true;
+let toggled = true;
 </script>
 
 <Toggle labelText="Push notifications" bind:toggled />

--- a/docs/src/pages/framed/Tooltip/TooltipReactive.svelte
+++ b/docs/src/pages/framed/Tooltip/TooltipReactive.svelte
@@ -1,7 +1,7 @@
 <script>
-  import { Tooltip, Button } from "carbon-components-svelte";
+import { Tooltip, Button } from "carbon-components-svelte";
 
-  let open = true;
+let open = true;
 </script>
 
 <Tooltip bind:open triggerText="Resource list" align="start">

--- a/docs/src/pages/framed/TreeView/TreeView.svelte
+++ b/docs/src/pages/framed/TreeView/TreeView.svelte
@@ -1,48 +1,48 @@
 <script>
-  import { TreeView } from "carbon-components-svelte";
+import { TreeView } from "carbon-components-svelte";
 
-  let activeId = "";
-  let selectedIds = [];
-  let nodes = [
-    { id: 0, text: "AI / Machine learning" },
-    {
-      id: 1,
-      text: "Analytics",
-      nodes: [
-        {
-          id: 2,
-          text: "IBM Analytics Engine",
-          nodes: [
-            { id: 3, text: "Apache Spark" },
-            { id: 4, text: "Hadoop" },
-          ],
-        },
-        { id: 5, text: "IBM Cloud SQL Query" },
-        { id: 6, text: "IBM Db2 Warehouse on Cloud" },
-      ],
-    },
-    {
-      id: 7,
-      text: "Blockchain",
-      nodes: [{ id: 8, text: "IBM Blockchain Platform" }],
-    },
-    {
-      id: 9,
-      text: "Databases",
-      nodes: [
-        { id: 10, text: "IBM Cloud Databases for Elasticsearch" },
-        { id: 11, text: "IBM Cloud Databases for Enterprise DB" },
-        { id: 12, text: "IBM Cloud Databases for MongoDB" },
-        { id: 13, text: "IBM Cloud Databases for PostgreSQL" },
-      ],
-    },
-    {
-      id: 14,
-      text: "Integration",
-      disabled: true,
-      nodes: [{ id: 15, text: "IBM API Connect", disabled: true }],
-    },
-  ];
+let activeId = "";
+let selectedIds = [];
+let nodes = [
+  { id: 0, text: "AI / Machine learning" },
+  {
+    id: 1,
+    text: "Analytics",
+    nodes: [
+      {
+        id: 2,
+        text: "IBM Analytics Engine",
+        nodes: [
+          { id: 3, text: "Apache Spark" },
+          { id: 4, text: "Hadoop" },
+        ],
+      },
+      { id: 5, text: "IBM Cloud SQL Query" },
+      { id: 6, text: "IBM Db2 Warehouse on Cloud" },
+    ],
+  },
+  {
+    id: 7,
+    text: "Blockchain",
+    nodes: [{ id: 8, text: "IBM Blockchain Platform" }],
+  },
+  {
+    id: 9,
+    text: "Databases",
+    nodes: [
+      { id: 10, text: "IBM Cloud Databases for Elasticsearch" },
+      { id: 11, text: "IBM Cloud Databases for Enterprise DB" },
+      { id: 12, text: "IBM Cloud Databases for MongoDB" },
+      { id: 13, text: "IBM Cloud Databases for PostgreSQL" },
+    ],
+  },
+  {
+    id: 14,
+    text: "Integration",
+    disabled: true,
+    nodes: [{ id: 15, text: "IBM API Connect", disabled: true }],
+  },
+];
 </script>
 
 <TreeView

--- a/docs/src/pages/framed/TreeView/TreeViewActive.svelte
+++ b/docs/src/pages/framed/TreeView/TreeViewActive.svelte
@@ -1,48 +1,48 @@
 <script>
-  import { TreeView } from "carbon-components-svelte";
+import { TreeView } from "carbon-components-svelte";
 
-  let activeId = 0;
-  let selectedIds = [];
-  let nodes = [
-    { id: 0, text: "AI / Machine learning" },
-    {
-      id: 1,
-      text: "Analytics",
-      nodes: [
-        {
-          id: 2,
-          text: "IBM Analytics Engine",
-          nodes: [
-            { id: 3, text: "Apache Spark" },
-            { id: 4, text: "Hadoop" },
-          ],
-        },
-        { id: 5, text: "IBM Cloud SQL Query" },
-        { id: 6, text: "IBM Db2 Warehouse on Cloud" },
-      ],
-    },
-    {
-      id: 7,
-      text: "Blockchain",
-      nodes: [{ id: 8, text: "IBM Blockchain Platform" }],
-    },
-    {
-      id: 9,
-      text: "Databases",
-      nodes: [
-        { id: 10, text: "IBM Cloud Databases for Elasticsearch" },
-        { id: 11, text: "IBM Cloud Databases for Enterprise DB" },
-        { id: 12, text: "IBM Cloud Databases for MongoDB" },
-        { id: 13, text: "IBM Cloud Databases for PostgreSQL" },
-      ],
-    },
-    {
-      id: 14,
-      text: "Integration",
-      disabled: true,
-      nodes: [{ id: 15, text: "IBM API Connect", disabled: true }],
-    },
-  ];
+let activeId = 0;
+let selectedIds = [];
+let nodes = [
+  { id: 0, text: "AI / Machine learning" },
+  {
+    id: 1,
+    text: "Analytics",
+    nodes: [
+      {
+        id: 2,
+        text: "IBM Analytics Engine",
+        nodes: [
+          { id: 3, text: "Apache Spark" },
+          { id: 4, text: "Hadoop" },
+        ],
+      },
+      { id: 5, text: "IBM Cloud SQL Query" },
+      { id: 6, text: "IBM Db2 Warehouse on Cloud" },
+    ],
+  },
+  {
+    id: 7,
+    text: "Blockchain",
+    nodes: [{ id: 8, text: "IBM Blockchain Platform" }],
+  },
+  {
+    id: 9,
+    text: "Databases",
+    nodes: [
+      { id: 10, text: "IBM Cloud Databases for Elasticsearch" },
+      { id: 11, text: "IBM Cloud Databases for Enterprise DB" },
+      { id: 12, text: "IBM Cloud Databases for MongoDB" },
+      { id: 13, text: "IBM Cloud Databases for PostgreSQL" },
+    ],
+  },
+  {
+    id: 14,
+    text: "Integration",
+    disabled: true,
+    nodes: [{ id: 15, text: "IBM API Connect", disabled: true }],
+  },
+];
 </script>
 
 <TreeView

--- a/docs/src/pages/framed/TreeView/TreeViewCollapseAll.svelte
+++ b/docs/src/pages/framed/TreeView/TreeViewCollapseAll.svelte
@@ -1,48 +1,48 @@
 <script>
-  import { TreeView, Button } from "carbon-components-svelte";
+import { TreeView, Button } from "carbon-components-svelte";
 
-  let treeview = null;
-  let expandedIds = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
-  let nodes = [
-    { id: 0, text: "AI / Machine learning" },
-    {
-      id: 1,
-      text: "Analytics",
-      nodes: [
-        {
-          id: 2,
-          text: "IBM Analytics Engine",
-          nodes: [
-            { id: 3, text: "Apache Spark" },
-            { id: 4, text: "Hadoop" },
-          ],
-        },
-        { id: 5, text: "IBM Cloud SQL Query" },
-        { id: 6, text: "IBM Db2 Warehouse on Cloud" },
-      ],
-    },
-    {
-      id: 7,
-      text: "Blockchain",
-      nodes: [{ id: 8, text: "IBM Blockchain Platform" }],
-    },
-    {
-      id: 9,
-      text: "Databases",
-      nodes: [
-        { id: 10, text: "IBM Cloud Databases for Elasticsearch" },
-        { id: 11, text: "IBM Cloud Databases for Enterprise DB" },
-        { id: 12, text: "IBM Cloud Databases for MongoDB" },
-        { id: 13, text: "IBM Cloud Databases for PostgreSQL" },
-      ],
-    },
-    {
-      id: 14,
-      text: "Integration",
-      disabled: true,
-      nodes: [{ id: 15, text: "IBM API Connect", disabled: true }],
-    },
-  ];
+let treeview = null;
+let expandedIds = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+let nodes = [
+  { id: 0, text: "AI / Machine learning" },
+  {
+    id: 1,
+    text: "Analytics",
+    nodes: [
+      {
+        id: 2,
+        text: "IBM Analytics Engine",
+        nodes: [
+          { id: 3, text: "Apache Spark" },
+          { id: 4, text: "Hadoop" },
+        ],
+      },
+      { id: 5, text: "IBM Cloud SQL Query" },
+      { id: 6, text: "IBM Db2 Warehouse on Cloud" },
+    ],
+  },
+  {
+    id: 7,
+    text: "Blockchain",
+    nodes: [{ id: 8, text: "IBM Blockchain Platform" }],
+  },
+  {
+    id: 9,
+    text: "Databases",
+    nodes: [
+      { id: 10, text: "IBM Cloud Databases for Elasticsearch" },
+      { id: 11, text: "IBM Cloud Databases for Enterprise DB" },
+      { id: 12, text: "IBM Cloud Databases for MongoDB" },
+      { id: 13, text: "IBM Cloud Databases for PostgreSQL" },
+    ],
+  },
+  {
+    id: 14,
+    text: "Integration",
+    disabled: true,
+    nodes: [{ id: 15, text: "IBM API Connect", disabled: true }],
+  },
+];
 </script>
 
 <div>

--- a/docs/src/pages/framed/TreeView/TreeViewCollapseNodes.svelte
+++ b/docs/src/pages/framed/TreeView/TreeViewCollapseNodes.svelte
@@ -1,50 +1,50 @@
 <script>
-  import { TreeView, Button } from "carbon-components-svelte";
+import { TreeView, Button } from "carbon-components-svelte";
 
-  let treeview = null;
-  let expandedIds = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 14];
-  let nodes = [
-    { id: 0, text: "AI / Machine learning" },
-    {
-      id: 1,
-      text: "Analytics",
-      disabled: true,
-      nodes: [
-        {
-          id: 2,
-          text: "IBM Analytics Engine",
-          disabled: true,
-          nodes: [
-            { id: 3, text: "Apache Spark", disabled: true },
-            { id: 4, text: "Hadoop", disabled: true },
-          ],
-        },
-        { id: 5, text: "IBM Cloud SQL Query", disabled: true },
-        { id: 6, text: "IBM Db2 Warehouse on Cloud", disabled: true },
-      ],
-    },
-    {
-      id: 7,
-      text: "Blockchain",
-      nodes: [{ id: 8, text: "IBM Blockchain Platform" }],
-    },
-    {
-      id: 9,
-      text: "Databases",
-      nodes: [
-        { id: 10, text: "IBM Cloud Databases for Elasticsearch" },
-        { id: 11, text: "IBM Cloud Databases for Enterprise DB" },
-        { id: 12, text: "IBM Cloud Databases for MongoDB" },
-        { id: 13, text: "IBM Cloud Databases for PostgreSQL" },
-      ],
-    },
-    {
-      id: 14,
-      text: "Integration",
-      disabled: true,
-      nodes: [{ id: 15, text: "IBM API Connect", disabled: true }],
-    },
-  ];
+let treeview = null;
+let expandedIds = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 14];
+let nodes = [
+  { id: 0, text: "AI / Machine learning" },
+  {
+    id: 1,
+    text: "Analytics",
+    disabled: true,
+    nodes: [
+      {
+        id: 2,
+        text: "IBM Analytics Engine",
+        disabled: true,
+        nodes: [
+          { id: 3, text: "Apache Spark", disabled: true },
+          { id: 4, text: "Hadoop", disabled: true },
+        ],
+      },
+      { id: 5, text: "IBM Cloud SQL Query", disabled: true },
+      { id: 6, text: "IBM Db2 Warehouse on Cloud", disabled: true },
+    ],
+  },
+  {
+    id: 7,
+    text: "Blockchain",
+    nodes: [{ id: 8, text: "IBM Blockchain Platform" }],
+  },
+  {
+    id: 9,
+    text: "Databases",
+    nodes: [
+      { id: 10, text: "IBM Cloud Databases for Elasticsearch" },
+      { id: 11, text: "IBM Cloud Databases for Enterprise DB" },
+      { id: 12, text: "IBM Cloud Databases for MongoDB" },
+      { id: 13, text: "IBM Cloud Databases for PostgreSQL" },
+    ],
+  },
+  {
+    id: 14,
+    text: "Integration",
+    disabled: true,
+    nodes: [{ id: 15, text: "IBM API Connect", disabled: true }],
+  },
+];
 </script>
 
 <div>

--- a/docs/src/pages/framed/TreeView/TreeViewCompact.svelte
+++ b/docs/src/pages/framed/TreeView/TreeViewCompact.svelte
@@ -1,48 +1,48 @@
 <script>
-  import { TreeView } from "carbon-components-svelte";
+import { TreeView } from "carbon-components-svelte";
 
-  let activeId = 0;
-  let selectedIds = [];
-  let nodes = [
-    { id: 0, text: "AI / Machine learning" },
-    {
-      id: 1,
-      text: "Analytics",
-      nodes: [
-        {
-          id: 2,
-          text: "IBM Analytics Engine",
-          nodes: [
-            { id: 3, text: "Apache Spark" },
-            { id: 4, text: "Hadoop" },
-          ],
-        },
-        { id: 5, text: "IBM Cloud SQL Query" },
-        { id: 6, text: "IBM Db2 Warehouse on Cloud" },
-      ],
-    },
-    {
-      id: 7,
-      text: "Blockchain",
-      nodes: [{ id: 8, text: "IBM Blockchain Platform" }],
-    },
-    {
-      id: 9,
-      text: "Databases",
-      nodes: [
-        { id: 10, text: "IBM Cloud Databases for Elasticsearch" },
-        { id: 11, text: "IBM Cloud Databases for Enterprise DB" },
-        { id: 12, text: "IBM Cloud Databases for MongoDB" },
-        { id: 13, text: "IBM Cloud Databases for PostgreSQL" },
-      ],
-    },
-    {
-      id: 14,
-      text: "Integration",
-      disabled: true,
-      nodes: [{ id: 15, text: "IBM API Connect", disabled: true }],
-    },
-  ];
+let activeId = 0;
+let selectedIds = [];
+let nodes = [
+  { id: 0, text: "AI / Machine learning" },
+  {
+    id: 1,
+    text: "Analytics",
+    nodes: [
+      {
+        id: 2,
+        text: "IBM Analytics Engine",
+        nodes: [
+          { id: 3, text: "Apache Spark" },
+          { id: 4, text: "Hadoop" },
+        ],
+      },
+      { id: 5, text: "IBM Cloud SQL Query" },
+      { id: 6, text: "IBM Db2 Warehouse on Cloud" },
+    ],
+  },
+  {
+    id: 7,
+    text: "Blockchain",
+    nodes: [{ id: 8, text: "IBM Blockchain Platform" }],
+  },
+  {
+    id: 9,
+    text: "Databases",
+    nodes: [
+      { id: 10, text: "IBM Cloud Databases for Elasticsearch" },
+      { id: 11, text: "IBM Cloud Databases for Enterprise DB" },
+      { id: 12, text: "IBM Cloud Databases for MongoDB" },
+      { id: 13, text: "IBM Cloud Databases for PostgreSQL" },
+    ],
+  },
+  {
+    id: 14,
+    text: "Integration",
+    disabled: true,
+    nodes: [{ id: 15, text: "IBM API Connect", disabled: true }],
+  },
+];
 </script>
 
 <TreeView

--- a/docs/src/pages/framed/TreeView/TreeViewExpandAll.svelte
+++ b/docs/src/pages/framed/TreeView/TreeViewExpandAll.svelte
@@ -1,47 +1,47 @@
 <script>
-  import { TreeView, Button } from "carbon-components-svelte";
+import { TreeView, Button } from "carbon-components-svelte";
 
-  let treeview = null;
-  let nodes = [
-    { id: 0, text: "AI / Machine learning" },
-    {
-      id: 1,
-      text: "Analytics",
-      nodes: [
-        {
-          id: 2,
-          text: "IBM Analytics Engine",
-          nodes: [
-            { id: 3, text: "Apache Spark" },
-            { id: 4, text: "Hadoop" },
-          ],
-        },
-        { id: 5, text: "IBM Cloud SQL Query" },
-        { id: 6, text: "IBM Db2 Warehouse on Cloud" },
-      ],
-    },
-    {
-      id: 7,
-      text: "Blockchain",
-      nodes: [{ id: 8, text: "IBM Blockchain Platform" }],
-    },
-    {
-      id: 9,
-      text: "Databases",
-      nodes: [
-        { id: 10, text: "IBM Cloud Databases for Elasticsearch" },
-        { id: 11, text: "IBM Cloud Databases for Enterprise DB" },
-        { id: 12, text: "IBM Cloud Databases for MongoDB" },
-        { id: 13, text: "IBM Cloud Databases for PostgreSQL" },
-      ],
-    },
-    {
-      id: 14,
-      text: "Integration",
-      disabled: true,
-      nodes: [{ id: 15, text: "IBM API Connect", disabled: true }],
-    },
-  ];
+let treeview = null;
+let nodes = [
+  { id: 0, text: "AI / Machine learning" },
+  {
+    id: 1,
+    text: "Analytics",
+    nodes: [
+      {
+        id: 2,
+        text: "IBM Analytics Engine",
+        nodes: [
+          { id: 3, text: "Apache Spark" },
+          { id: 4, text: "Hadoop" },
+        ],
+      },
+      { id: 5, text: "IBM Cloud SQL Query" },
+      { id: 6, text: "IBM Db2 Warehouse on Cloud" },
+    ],
+  },
+  {
+    id: 7,
+    text: "Blockchain",
+    nodes: [{ id: 8, text: "IBM Blockchain Platform" }],
+  },
+  {
+    id: 9,
+    text: "Databases",
+    nodes: [
+      { id: 10, text: "IBM Cloud Databases for Elasticsearch" },
+      { id: 11, text: "IBM Cloud Databases for Enterprise DB" },
+      { id: 12, text: "IBM Cloud Databases for MongoDB" },
+      { id: 13, text: "IBM Cloud Databases for PostgreSQL" },
+    ],
+  },
+  {
+    id: 14,
+    text: "Integration",
+    disabled: true,
+    nodes: [{ id: 15, text: "IBM API Connect", disabled: true }],
+  },
+];
 </script>
 
 <div>

--- a/docs/src/pages/framed/TreeView/TreeViewExpandNodes.svelte
+++ b/docs/src/pages/framed/TreeView/TreeViewExpandNodes.svelte
@@ -1,47 +1,47 @@
 <script>
-  import { TreeView, Button } from "carbon-components-svelte";
+import { TreeView, Button } from "carbon-components-svelte";
 
-  let treeview = null;
-  let nodes = [
-    { id: 0, text: "AI / Machine learning" },
-    {
-      id: 1,
-      text: "Analytics",
-      nodes: [
-        {
-          id: 2,
-          text: "IBM Analytics Engine",
-          nodes: [
-            { id: 3, text: "Apache Spark" },
-            { id: 4, text: "Hadoop" },
-          ],
-        },
-        { id: 5, text: "IBM Cloud SQL Query" },
-        { id: 6, text: "IBM Db2 Warehouse on Cloud" },
-      ],
-    },
-    {
-      id: 7,
-      text: "Blockchain",
-      nodes: [{ id: 8, text: "IBM Blockchain Platform" }],
-    },
-    {
-      id: 9,
-      text: "Databases",
-      nodes: [
-        { id: 10, text: "IBM Cloud Databases for Elasticsearch" },
-        { id: 11, text: "IBM Cloud Databases for Enterprise DB" },
-        { id: 12, text: "IBM Cloud Databases for MongoDB" },
-        { id: 13, text: "IBM Cloud Databases for PostgreSQL" },
-      ],
-    },
-    {
-      id: 14,
-      text: "Integration",
-      disabled: true,
-      nodes: [{ id: 15, text: "IBM API Connect", disabled: true }],
-    },
-  ];
+let treeview = null;
+let nodes = [
+  { id: 0, text: "AI / Machine learning" },
+  {
+    id: 1,
+    text: "Analytics",
+    nodes: [
+      {
+        id: 2,
+        text: "IBM Analytics Engine",
+        nodes: [
+          { id: 3, text: "Apache Spark" },
+          { id: 4, text: "Hadoop" },
+        ],
+      },
+      { id: 5, text: "IBM Cloud SQL Query" },
+      { id: 6, text: "IBM Db2 Warehouse on Cloud" },
+    ],
+  },
+  {
+    id: 7,
+    text: "Blockchain",
+    nodes: [{ id: 8, text: "IBM Blockchain Platform" }],
+  },
+  {
+    id: 9,
+    text: "Databases",
+    nodes: [
+      { id: 10, text: "IBM Cloud Databases for Elasticsearch" },
+      { id: 11, text: "IBM Cloud Databases for Enterprise DB" },
+      { id: 12, text: "IBM Cloud Databases for MongoDB" },
+      { id: 13, text: "IBM Cloud Databases for PostgreSQL" },
+    ],
+  },
+  {
+    id: 14,
+    text: "Integration",
+    disabled: true,
+    nodes: [{ id: 15, text: "IBM API Connect", disabled: true }],
+  },
+];
 </script>
 
 <div>

--- a/docs/src/pages/framed/TreeView/TreeViewExpanded.svelte
+++ b/docs/src/pages/framed/TreeView/TreeViewExpanded.svelte
@@ -1,49 +1,49 @@
 <script>
-  import { TreeView } from "carbon-components-svelte";
+import { TreeView } from "carbon-components-svelte";
 
-  let activeId = 1;
-  let selectedIds = [];
-  let expandedIds = [1, 2, 14];
-  let nodes = [
-    { id: 0, text: "AI / Machine learning" },
-    {
-      id: 1,
-      text: "Analytics",
-      nodes: [
-        {
-          id: 2,
-          text: "IBM Analytics Engine",
-          nodes: [
-            { id: 3, text: "Apache Spark" },
-            { id: 4, text: "Hadoop" },
-          ],
-        },
-        { id: 5, text: "IBM Cloud SQL Query" },
-        { id: 6, text: "IBM Db2 Warehouse on Cloud" },
-      ],
-    },
-    {
-      id: 7,
-      text: "Blockchain",
-      nodes: [{ id: 8, text: "IBM Blockchain Platform" }],
-    },
-    {
-      id: 9,
-      text: "Databases",
-      nodes: [
-        { id: 10, text: "IBM Cloud Databases for Elasticsearch" },
-        { id: 11, text: "IBM Cloud Databases for Enterprise DB" },
-        { id: 12, text: "IBM Cloud Databases for MongoDB" },
-        { id: 13, text: "IBM Cloud Databases for PostgreSQL" },
-      ],
-    },
-    {
-      id: 14,
-      text: "Integration",
-      disabled: true,
-      nodes: [{ id: 15, text: "IBM API Connect", disabled: true }],
-    },
-  ];
+let activeId = 1;
+let selectedIds = [];
+let expandedIds = [1, 2, 14];
+let nodes = [
+  { id: 0, text: "AI / Machine learning" },
+  {
+    id: 1,
+    text: "Analytics",
+    nodes: [
+      {
+        id: 2,
+        text: "IBM Analytics Engine",
+        nodes: [
+          { id: 3, text: "Apache Spark" },
+          { id: 4, text: "Hadoop" },
+        ],
+      },
+      { id: 5, text: "IBM Cloud SQL Query" },
+      { id: 6, text: "IBM Db2 Warehouse on Cloud" },
+    ],
+  },
+  {
+    id: 7,
+    text: "Blockchain",
+    nodes: [{ id: 8, text: "IBM Blockchain Platform" }],
+  },
+  {
+    id: 9,
+    text: "Databases",
+    nodes: [
+      { id: 10, text: "IBM Cloud Databases for Elasticsearch" },
+      { id: 11, text: "IBM Cloud Databases for Enterprise DB" },
+      { id: 12, text: "IBM Cloud Databases for MongoDB" },
+      { id: 13, text: "IBM Cloud Databases for PostgreSQL" },
+    ],
+  },
+  {
+    id: 14,
+    text: "Integration",
+    disabled: true,
+    nodes: [{ id: 15, text: "IBM API Connect", disabled: true }],
+  },
+];
 </script>
 
 <TreeView

--- a/docs/src/pages/framed/TreeView/TreeViewFlatArray.svelte
+++ b/docs/src/pages/framed/TreeView/TreeViewFlatArray.svelte
@@ -1,25 +1,25 @@
 <script>
-  import { TreeView, toHierarchy } from "carbon-components-svelte";
-  import Analytics from "carbon-icons-svelte/lib/Analytics.svelte";
+import { TreeView, toHierarchy } from "carbon-components-svelte";
+import Analytics from "carbon-icons-svelte/lib/Analytics.svelte";
 
-  let nodesFlat = [
-    { id: 0, text: "AI / Machine learning", icon: Analytics },
-    { id: 1, text: "Analytics" },
-    { id: 2, text: "IBM Analytics Engine", pid: 1 },
-    { id: 3, text: "Apache Spark", pid: 2 },
-    { id: 4, text: "Hadoop", pid: 2 },
-    { id: 5, text: "IBM Cloud SQL Query", pid: 1 },
-    { id: 6, text: "IBM Db2 Warehouse on Cloud", pid: 1 },
-    { id: 7, text: "Blockchain" },
-    { id: 8, text: "IBM Blockchain Platform", pid: 7 },
-    { id: 9, text: "Databases" },
-    { id: 10, text: "IBM Cloud Databases for Elasticsearch", pid: 9 },
-    { id: 11, text: "IBM Cloud Databases for Enterprise DB", pid: 9 },
-    { id: 12, text: "IBM Cloud Databases for MongoDB", pid: 9 },
-    { id: 13, text: "IBM Cloud Databases for PostgreSQL", pid: 9 },
-    { id: 14, text: "Integration", disabled: true },
-    { id: 15, text: "IBM API Connect", disabled: true, pid: 14 },
-  ];
+let nodesFlat = [
+  { id: 0, text: "AI / Machine learning", icon: Analytics },
+  { id: 1, text: "Analytics" },
+  { id: 2, text: "IBM Analytics Engine", pid: 1 },
+  { id: 3, text: "Apache Spark", pid: 2 },
+  { id: 4, text: "Hadoop", pid: 2 },
+  { id: 5, text: "IBM Cloud SQL Query", pid: 1 },
+  { id: 6, text: "IBM Db2 Warehouse on Cloud", pid: 1 },
+  { id: 7, text: "Blockchain" },
+  { id: 8, text: "IBM Blockchain Platform", pid: 7 },
+  { id: 9, text: "Databases" },
+  { id: 10, text: "IBM Cloud Databases for Elasticsearch", pid: 9 },
+  { id: 11, text: "IBM Cloud Databases for Enterprise DB", pid: 9 },
+  { id: 12, text: "IBM Cloud Databases for MongoDB", pid: 9 },
+  { id: 13, text: "IBM Cloud Databases for PostgreSQL", pid: 9 },
+  { id: 14, text: "Integration", disabled: true },
+  { id: 15, text: "IBM API Connect", disabled: true, pid: 14 },
+];
 </script>
 
 <TreeView

--- a/docs/src/pages/framed/TreeView/TreeViewIcons.svelte
+++ b/docs/src/pages/framed/TreeView/TreeViewIcons.svelte
@@ -1,77 +1,77 @@
 <script>
-  import { TreeView } from "carbon-components-svelte";
-  import WatsonMachineLearning from "carbon-icons-svelte/lib/WatsonMachineLearning.svelte";
-  import Analytics from "carbon-icons-svelte/lib/Analytics.svelte";
-  import Blockchain from "carbon-icons-svelte/lib/Blockchain.svelte";
-  import DataBase from "carbon-icons-svelte/lib/DataBase.svelte";
-  import SignalStrength from "carbon-icons-svelte/lib/SignalStrength.svelte";
+import { TreeView } from "carbon-components-svelte";
+import WatsonMachineLearning from "carbon-icons-svelte/lib/WatsonMachineLearning.svelte";
+import Analytics from "carbon-icons-svelte/lib/Analytics.svelte";
+import Blockchain from "carbon-icons-svelte/lib/Blockchain.svelte";
+import DataBase from "carbon-icons-svelte/lib/DataBase.svelte";
+import SignalStrength from "carbon-icons-svelte/lib/SignalStrength.svelte";
 
-  let activeId = 1;
-  let selectedIds = [];
-  let nodes = [
-    { id: 0, text: "AI / Machine learning", icon: WatsonMachineLearning },
-    {
-      id: 1,
-      text: "Analytics",
-      icon: Analytics,
-      nodes: [
-        {
-          id: 2,
-          text: "IBM Analytics Engine",
-          icon: Analytics,
-          nodes: [
-            { id: 3, text: "Apache Spark", icon: Analytics },
-            { id: 4, text: "Hadoop", icon: Analytics },
-          ],
-        },
-        { id: 5, text: "IBM Cloud SQL Query", icon: Analytics },
-        { id: 6, text: "IBM Db2 Warehouse on Cloud", icon: Analytics },
-      ],
-    },
-    {
-      id: 7,
-      text: "Blockchain",
-      icon: Blockchain,
-      nodes: [{ id: 8, text: "IBM Blockchain Platform", icon: Blockchain }],
-    },
-    {
-      id: 9,
-      text: "Databases",
-      icon: DataBase,
-      nodes: [
-        {
-          id: 10,
-          text: "IBM Cloud Databases for Elasticsearch",
-          icon: DataBase,
-        },
-        {
-          id: 11,
-          text: "IBM Cloud Databases for Enterprise DB",
-          icon: DataBase,
-        },
-        { id: 12, text: "IBM Cloud Databases for MongoDB", icon: DataBase },
-        {
-          id: 13,
-          text: "IBM Cloud Databases for PostgreSQL",
-          icon: DataBase,
-        },
-      ],
-    },
-    {
-      id: 14,
-      text: "Integration",
-      icon: SignalStrength,
-      disabled: true,
-      nodes: [
-        {
-          id: 15,
-          text: "IBM API Connect",
-          icon: SignalStrength,
-          disabled: true,
-        },
-      ],
-    },
-  ];
+let activeId = 1;
+let selectedIds = [];
+let nodes = [
+  { id: 0, text: "AI / Machine learning", icon: WatsonMachineLearning },
+  {
+    id: 1,
+    text: "Analytics",
+    icon: Analytics,
+    nodes: [
+      {
+        id: 2,
+        text: "IBM Analytics Engine",
+        icon: Analytics,
+        nodes: [
+          { id: 3, text: "Apache Spark", icon: Analytics },
+          { id: 4, text: "Hadoop", icon: Analytics },
+        ],
+      },
+      { id: 5, text: "IBM Cloud SQL Query", icon: Analytics },
+      { id: 6, text: "IBM Db2 Warehouse on Cloud", icon: Analytics },
+    ],
+  },
+  {
+    id: 7,
+    text: "Blockchain",
+    icon: Blockchain,
+    nodes: [{ id: 8, text: "IBM Blockchain Platform", icon: Blockchain }],
+  },
+  {
+    id: 9,
+    text: "Databases",
+    icon: DataBase,
+    nodes: [
+      {
+        id: 10,
+        text: "IBM Cloud Databases for Elasticsearch",
+        icon: DataBase,
+      },
+      {
+        id: 11,
+        text: "IBM Cloud Databases for Enterprise DB",
+        icon: DataBase,
+      },
+      { id: 12, text: "IBM Cloud Databases for MongoDB", icon: DataBase },
+      {
+        id: 13,
+        text: "IBM Cloud Databases for PostgreSQL",
+        icon: DataBase,
+      },
+    ],
+  },
+  {
+    id: 14,
+    text: "Integration",
+    icon: SignalStrength,
+    disabled: true,
+    nodes: [
+      {
+        id: 15,
+        text: "IBM API Connect",
+        icon: SignalStrength,
+        disabled: true,
+      },
+    ],
+  },
+];
 </script>
 
 <TreeView

--- a/docs/src/pages/framed/TreeView/TreeViewMultiselect.svelte
+++ b/docs/src/pages/framed/TreeView/TreeViewMultiselect.svelte
@@ -1,48 +1,48 @@
 <script>
-  import { TreeView } from "carbon-components-svelte";
+import { TreeView } from "carbon-components-svelte";
 
-  let activeId = 0;
-  let selectedIds = [0, 7, 9];
-  let nodes = [
-    { id: 0, text: "AI / Machine learning" },
-    {
-      id: 1,
-      text: "Analytics",
-      nodes: [
-        {
-          id: 2,
-          text: "IBM Analytics Engine",
-          nodes: [
-            { id: 3, text: "Apache Spark" },
-            { id: 4, text: "Hadoop" },
-          ],
-        },
-        { id: 5, text: "IBM Cloud SQL Query" },
-        { id: 6, text: "IBM Db2 Warehouse on Cloud" },
-      ],
-    },
-    {
-      id: 7,
-      text: "Blockchain",
-      nodes: [{ id: 8, text: "IBM Blockchain Platform" }],
-    },
-    {
-      id: 9,
-      text: "Databases",
-      nodes: [
-        { id: 10, text: "IBM Cloud Databases for Elasticsearch" },
-        { id: 11, text: "IBM Cloud Databases for Enterprise DB" },
-        { id: 12, text: "IBM Cloud Databases for MongoDB" },
-        { id: 13, text: "IBM Cloud Databases for PostgreSQL" },
-      ],
-    },
-    {
-      id: 14,
-      text: "Integration",
-      disabled: true,
-      nodes: [{ id: 15, text: "IBM API Connect", disabled: true }],
-    },
-  ];
+let activeId = 0;
+let selectedIds = [0, 7, 9];
+let nodes = [
+  { id: 0, text: "AI / Machine learning" },
+  {
+    id: 1,
+    text: "Analytics",
+    nodes: [
+      {
+        id: 2,
+        text: "IBM Analytics Engine",
+        nodes: [
+          { id: 3, text: "Apache Spark" },
+          { id: 4, text: "Hadoop" },
+        ],
+      },
+      { id: 5, text: "IBM Cloud SQL Query" },
+      { id: 6, text: "IBM Db2 Warehouse on Cloud" },
+    ],
+  },
+  {
+    id: 7,
+    text: "Blockchain",
+    nodes: [{ id: 8, text: "IBM Blockchain Platform" }],
+  },
+  {
+    id: 9,
+    text: "Databases",
+    nodes: [
+      { id: 10, text: "IBM Cloud Databases for Elasticsearch" },
+      { id: 11, text: "IBM Cloud Databases for Enterprise DB" },
+      { id: 12, text: "IBM Cloud Databases for MongoDB" },
+      { id: 13, text: "IBM Cloud Databases for PostgreSQL" },
+    ],
+  },
+  {
+    id: 14,
+    text: "Integration",
+    disabled: true,
+    nodes: [{ id: 15, text: "IBM API Connect", disabled: true }],
+  },
+];
 </script>
 
 <TreeView

--- a/docs/src/pages/framed/TreeView/TreeViewShowNode.svelte
+++ b/docs/src/pages/framed/TreeView/TreeViewShowNode.svelte
@@ -1,31 +1,31 @@
 <script>
-  import { Button, ButtonSet, TreeView } from "carbon-components-svelte";
+import { Button, ButtonSet, TreeView } from "carbon-components-svelte";
 
-  const nodeSpark = { id: 3, text: "Apache Spark" };
-  const nodeBlockchain = { id: 8, text: "IBM Blockchain Platform" };
+const nodeSpark = { id: 3, text: "Apache Spark" };
+const nodeBlockchain = { id: 8, text: "IBM Blockchain Platform" };
 
-  let treeview = null;
-  let nodes = [
-    { id: 0, text: "AI / Machine learning" },
-    {
-      id: 1,
-      text: "Analytics",
-      nodes: [
-        {
-          id: 2,
-          text: "IBM Analytics Engine",
-          nodes: [nodeSpark, { id: 4, text: "Hadoop" }],
-        },
-        { id: 5, text: "IBM Cloud SQL Query" },
-        { id: 6, text: "IBM Db2 Warehouse on Cloud" },
-      ],
-    },
-    {
-      id: 7,
-      text: "Blockchain",
-      nodes: [{ id: 8, text: "IBM Blockchain Platform" }],
-    },
-  ];
+let treeview = null;
+let nodes = [
+  { id: 0, text: "AI / Machine learning" },
+  {
+    id: 1,
+    text: "Analytics",
+    nodes: [
+      {
+        id: 2,
+        text: "IBM Analytics Engine",
+        nodes: [nodeSpark, { id: 4, text: "Hadoop" }],
+      },
+      { id: 5, text: "IBM Cloud SQL Query" },
+      { id: 6, text: "IBM Db2 Warehouse on Cloud" },
+    ],
+  },
+  {
+    id: 7,
+    text: "Blockchain",
+    nodes: [{ id: 8, text: "IBM Blockchain Platform" }],
+  },
+];
 </script>
 
 <ButtonSet style="margin-bottom: var(--cds-spacing-05)">

--- a/docs/src/pages/framed/TreeView/TreeViewSlot.svelte
+++ b/docs/src/pages/framed/TreeView/TreeViewSlot.svelte
@@ -1,48 +1,48 @@
 <script>
-  import { TreeView } from "carbon-components-svelte";
+import { TreeView } from "carbon-components-svelte";
 
-  let activeId = 0;
-  let selectedIds = [0, 7, 9];
-  let nodes = [
-    { id: 0, text: "AI / Machine learning" },
-    {
-      id: 1,
-      text: "Analytics",
-      nodes: [
-        {
-          id: 2,
-          text: "IBM Analytics Engine",
-          nodes: [
-            { id: 3, text: "Apache Spark" },
-            { id: 4, text: "Hadoop" },
-          ],
-        },
-        { id: 5, text: "IBM Cloud SQL Query" },
-        { id: 6, text: "IBM Db2 Warehouse on Cloud" },
-      ],
-    },
-    {
-      id: 7,
-      text: "Blockchain",
-      nodes: [{ id: 8, text: "IBM Blockchain Platform" }],
-    },
-    {
-      id: 9,
-      text: "Databases",
-      nodes: [
-        { id: 10, text: "IBM Cloud Databases for Elasticsearch" },
-        { id: 11, text: "IBM Cloud Databases for Enterprise DB" },
-        { id: 12, text: "IBM Cloud Databases for MongoDB" },
-        { id: 13, text: "IBM Cloud Databases for PostgreSQL" },
-      ],
-    },
-    {
-      id: 14,
-      text: "Integration",
-      disabled: true,
-      nodes: [{ id: 15, text: "IBM API Connect", disabled: true }],
-    },
-  ];
+let activeId = 0;
+let selectedIds = [0, 7, 9];
+let nodes = [
+  { id: 0, text: "AI / Machine learning" },
+  {
+    id: 1,
+    text: "Analytics",
+    nodes: [
+      {
+        id: 2,
+        text: "IBM Analytics Engine",
+        nodes: [
+          { id: 3, text: "Apache Spark" },
+          { id: 4, text: "Hadoop" },
+        ],
+      },
+      { id: 5, text: "IBM Cloud SQL Query" },
+      { id: 6, text: "IBM Db2 Warehouse on Cloud" },
+    ],
+  },
+  {
+    id: 7,
+    text: "Blockchain",
+    nodes: [{ id: 8, text: "IBM Blockchain Platform" }],
+  },
+  {
+    id: 9,
+    text: "Databases",
+    nodes: [
+      { id: 10, text: "IBM Cloud Databases for Elasticsearch" },
+      { id: 11, text: "IBM Cloud Databases for Enterprise DB" },
+      { id: 12, text: "IBM Cloud Databases for MongoDB" },
+      { id: 13, text: "IBM Cloud Databases for PostgreSQL" },
+    ],
+  },
+  {
+    id: 14,
+    text: "Integration",
+    disabled: true,
+    nodes: [{ id: 15, text: "IBM API Connect", disabled: true }],
+  },
+];
 </script>
 
 <TreeView labelText="Cloud Products" {activeId} {selectedIds} {nodes} let:node>

--- a/docs/src/pages/framed/UIShell/Header.svelte
+++ b/docs/src/pages/framed/UIShell/Header.svelte
@@ -1,17 +1,17 @@
 <script>
-  import {
-    Header,
-    HeaderNav,
-    HeaderNavItem,
-    HeaderNavMenu,
-    SkipToContent,
-    Content,
-    Grid,
-    Row,
-    Column,
-  } from "carbon-components-svelte";
+import {
+  Header,
+  HeaderNav,
+  HeaderNavItem,
+  HeaderNavMenu,
+  SkipToContent,
+  Content,
+  Grid,
+  Row,
+  Column,
+} from "carbon-components-svelte";
 
-  let isSideNavOpen = false;
+let isSideNavOpen = false;
 </script>
 
 <Header company="IBM" platformName="Carbon Svelte" bind:isSideNavOpen>

--- a/docs/src/pages/framed/UIShell/HeaderMultipleSwitcher.svelte
+++ b/docs/src/pages/framed/UIShell/HeaderMultipleSwitcher.svelte
@@ -1,23 +1,23 @@
 <script>
-  import {
-    Header,
-    HeaderUtilities,
-    HeaderAction,
-    HeaderPanelLinks,
-    HeaderPanelDivider,
-    HeaderPanelLink,
-    SkipToContent,
-    Content,
-    Grid,
-    Row,
-    Column,
-  } from "carbon-components-svelte";
-  import SettingsAdjust from "carbon-icons-svelte/lib/SettingsAdjust.svelte";
-  import UserAvatarFilledAlt from "carbon-icons-svelte/lib/UserAvatarFilledAlt.svelte";
+import {
+  Header,
+  HeaderUtilities,
+  HeaderAction,
+  HeaderPanelLinks,
+  HeaderPanelDivider,
+  HeaderPanelLink,
+  SkipToContent,
+  Content,
+  Grid,
+  Row,
+  Column,
+} from "carbon-components-svelte";
+import SettingsAdjust from "carbon-icons-svelte/lib/SettingsAdjust.svelte";
+import UserAvatarFilledAlt from "carbon-icons-svelte/lib/UserAvatarFilledAlt.svelte";
 
-  let isOpen1 = false;
-  let isOpen2 = false;
-  let isOpen3 = false;
+let isOpen1 = false;
+let isOpen2 = false;
+let isOpen3 = false;
 </script>
 
 <Header company="IBM" platformName="Carbon Svelte" isSideNavOpen>

--- a/docs/src/pages/framed/UIShell/HeaderNav.svelte
+++ b/docs/src/pages/framed/UIShell/HeaderNav.svelte
@@ -1,23 +1,23 @@
 <script>
-  import {
-    Header,
-    HeaderNav,
-    HeaderNavItem,
-    HeaderNavMenu,
-    SideNav,
-    SideNavItems,
-    SideNavMenu,
-    SideNavMenuItem,
-    SideNavLink,
-    SideNavDivider,
-    SkipToContent,
-    Content,
-    Grid,
-    Row,
-    Column,
-  } from "carbon-components-svelte";
+import {
+  Header,
+  HeaderNav,
+  HeaderNavItem,
+  HeaderNavMenu,
+  SideNav,
+  SideNavItems,
+  SideNavMenu,
+  SideNavMenuItem,
+  SideNavLink,
+  SideNavDivider,
+  SkipToContent,
+  Content,
+  Grid,
+  Row,
+  Column,
+} from "carbon-components-svelte";
 
-  let isSideNavOpen = false;
+let isSideNavOpen = false;
 </script>
 
 <Header company="IBM" platformName="Carbon Svelte" bind:isSideNavOpen>

--- a/docs/src/pages/framed/UIShell/HeaderNavRail.svelte
+++ b/docs/src/pages/framed/UIShell/HeaderNavRail.svelte
@@ -1,24 +1,24 @@
 <script>
-  import {
-    Header,
-    HeaderNav,
-    HeaderNavItem,
-    HeaderNavMenu,
-    SideNav,
-    SideNavItems,
-    SideNavMenu,
-    SideNavMenuItem,
-    SideNavLink,
-    SideNavDivider,
-    SkipToContent,
-    Content,
-    Grid,
-    Row,
-    Column,
-  } from "carbon-components-svelte";
-  import Fade from "carbon-icons-svelte/lib/Fade.svelte";
+import {
+  Header,
+  HeaderNav,
+  HeaderNavItem,
+  HeaderNavMenu,
+  SideNav,
+  SideNavItems,
+  SideNavMenu,
+  SideNavMenuItem,
+  SideNavLink,
+  SideNavDivider,
+  SkipToContent,
+  Content,
+  Grid,
+  Row,
+  Column,
+} from "carbon-components-svelte";
+import Fade from "carbon-icons-svelte/lib/Fade.svelte";
 
-  let isSideNavOpen = false;
+let isSideNavOpen = false;
 </script>
 
 <Header company="IBM" platformName="Carbon Svelte" bind:isSideNavOpen>

--- a/docs/src/pages/framed/UIShell/HeaderSearch.svelte
+++ b/docs/src/pages/framed/UIShell/HeaderSearch.svelte
@@ -1,64 +1,64 @@
 <script>
-  import {
-    Header,
-    HeaderUtilities,
-    HeaderSearch,
-    SkipToContent,
-    Content,
-    Grid,
-    Row,
-    Column,
-    Button,
-  } from "carbon-components-svelte";
+import {
+  Header,
+  HeaderUtilities,
+  HeaderSearch,
+  SkipToContent,
+  Content,
+  Grid,
+  Row,
+  Column,
+  Button,
+} from "carbon-components-svelte";
 
-  const data = [
-    {
-      href: "/",
-      text: "Kubernetes Service",
-      description:
-        "Deploy secure, highly available apps in a native Kubernetes experience. IBM Cloud Kubernetes Service creates a cluster of compute hosts and deploys highly available containers.",
-    },
-    {
-      href: "/",
-      text: "Red Hat OpenShift on IBM Cloud",
-      description:
-        "Deploy and secure enterprise workloads on native OpenShift with developer focused tools to run highly available apps. OpenShift clusters build on Kubernetes container orchestration that offers consistency and flexibility in operations.",
-    },
-    {
-      href: "/",
-      text: "Container Registry",
-      description:
-        "Securely store container images and monitor their vulnerabilities in a private registry.",
-    },
-    {
-      href: "/",
-      text: "Code Engine",
-      description:
-        "Run your application, job, or container on a managed serverless platform.",
-    },
-  ];
+const data = [
+  {
+    href: "/",
+    text: "Kubernetes Service",
+    description:
+      "Deploy secure, highly available apps in a native Kubernetes experience. IBM Cloud Kubernetes Service creates a cluster of compute hosts and deploys highly available containers.",
+  },
+  {
+    href: "/",
+    text: "Red Hat OpenShift on IBM Cloud",
+    description:
+      "Deploy and secure enterprise workloads on native OpenShift with developer focused tools to run highly available apps. OpenShift clusters build on Kubernetes container orchestration that offers consistency and flexibility in operations.",
+  },
+  {
+    href: "/",
+    text: "Container Registry",
+    description:
+      "Securely store container images and monitor their vulnerabilities in a private registry.",
+  },
+  {
+    href: "/",
+    text: "Code Engine",
+    description:
+      "Run your application, job, or container on a managed serverless platform.",
+  },
+];
 
-  let ref = null;
-  let active = false;
-  let value = "";
-  let selectedResultIndex = 0;
-  let events = [];
+let ref = null;
+let active = false;
+let value = "";
+let selectedResultIndex = 0;
+let events = [];
 
-  $: lowerCaseValue = value.toLowerCase();
-  $: results =
-    value.length > 0
-      ? data.filter((item) => {
-          return (
-            item.text.toLowerCase().includes(lowerCaseValue) ||
-            item.description.includes(lowerCaseValue)
-          );
-        })
-      : [];
+$: lowerCaseValue = value.toLowerCase();
+$: results =
+  value.length > 0
+    ? data.filter((item) => {
+        return (
+          item.text.toLowerCase().includes(lowerCaseValue) ||
+          item.description.includes(lowerCaseValue)
+        );
+      })
+    : [];
 
-  $: console.log("ref", ref);
-  $: console.log("active", active);
-  $: console.log("value", value);
-  $: console.log("selectedResultIndex", selectedResultIndex);
+$: console.log("ref", ref);
+$: console.log("active", active);
+$: console.log("value", value);
+$: console.log("selectedResultIndex", selectedResultIndex);
 </script>
 
 <Header company="IBM" platformName="Carbon Svelte">

--- a/docs/src/pages/framed/UIShell/HeaderSwitcher.svelte
+++ b/docs/src/pages/framed/UIShell/HeaderSwitcher.svelte
@@ -1,43 +1,43 @@
 <script>
-  import {
-    Header,
-    HeaderUtilities,
-    HeaderAction,
-    HeaderPanelLinks,
-    HeaderPanelDivider,
-    HeaderPanelLink,
-    SideNav,
-    SideNavItems,
-    SideNavMenu,
-    SideNavMenuItem,
-    SideNavLink,
-    SkipToContent,
-    Content,
-    Grid,
-    Row,
-    Column,
-    TileGroup,
-    RadioTile,
-  } from "carbon-components-svelte";
-  import { expoIn } from "svelte/easing";
+import {
+  Header,
+  HeaderUtilities,
+  HeaderAction,
+  HeaderPanelLinks,
+  HeaderPanelDivider,
+  HeaderPanelLink,
+  SideNav,
+  SideNavItems,
+  SideNavMenu,
+  SideNavMenuItem,
+  SideNavLink,
+  SkipToContent,
+  Content,
+  Grid,
+  Row,
+  Column,
+  TileGroup,
+  RadioTile,
+} from "carbon-components-svelte";
+import { expoIn } from "svelte/easing";
 
-  let isSideNavOpen = false;
-  let isOpen = false;
-  let selected = "0";
-  let transitions = {
-    "0": {
-      text: "Default (duration: 200ms)",
-      value: { duration: 200 },
-    },
-    "1": {
-      text: "Custom (duration: 600ms, delay: 50ms, easing: expoIn)",
-      value: { duration: 600, delay: 50, easing: expoIn },
-    },
-    "2": {
-      text: "Disabled",
-      value: false,
-    },
-  };
+let isSideNavOpen = false;
+let isOpen = false;
+let selected = "0";
+let transitions = {
+  0: {
+    text: "Default (duration: 200ms)",
+    value: { duration: 200 },
+  },
+  1: {
+    text: "Custom (duration: 600ms, delay: 50ms, easing: expoIn)",
+    value: { duration: 600, delay: 50, easing: expoIn },
+  },
+  2: {
+    text: "Disabled",
+    value: false,
+  },
+};
 </script>
 
 <Header company="IBM" platformName="Carbon Svelte" bind:isSideNavOpen>

--- a/docs/src/pages/framed/UIShell/HeaderUtilities.svelte
+++ b/docs/src/pages/framed/UIShell/HeaderUtilities.svelte
@@ -1,24 +1,24 @@
 <script>
-  import {
-    Header,
-    HeaderUtilities,
-    HeaderGlobalAction,
-    SideNav,
-    SideNavItems,
-    SideNavMenu,
-    SideNavMenuItem,
-    SideNavLink,
-    SkipToContent,
-    Content,
-    Grid,
-    Row,
-    Column,
-  } from "carbon-components-svelte";
-  import Logout from "carbon-icons-svelte/lib/Logout.svelte";
-  import SettingsAdjust from "carbon-icons-svelte/lib/SettingsAdjust.svelte";
-  import UserAvatarFilledAlt from "carbon-icons-svelte/lib/UserAvatarFilledAlt.svelte";
+import {
+  Header,
+  HeaderUtilities,
+  HeaderGlobalAction,
+  SideNav,
+  SideNavItems,
+  SideNavMenu,
+  SideNavMenuItem,
+  SideNavLink,
+  SkipToContent,
+  Content,
+  Grid,
+  Row,
+  Column,
+} from "carbon-components-svelte";
+import Logout from "carbon-icons-svelte/lib/Logout.svelte";
+import SettingsAdjust from "carbon-icons-svelte/lib/SettingsAdjust.svelte";
+import UserAvatarFilledAlt from "carbon-icons-svelte/lib/UserAvatarFilledAlt.svelte";
 
-  let isSideNavOpen = false;
+let isSideNavOpen = false;
 </script>
 
 <Header company="IBM" platformName="Carbon Svelte" bind:isSideNavOpen>

--- a/docs/src/pages/framed/UIShell/PersistedHamburgerMenu.svelte
+++ b/docs/src/pages/framed/UIShell/PersistedHamburgerMenu.svelte
@@ -1,22 +1,22 @@
 <script>
-  import {
-    Header,
-    HeaderNav,
-    HeaderNavItem,
-    HeaderNavMenu,
-    SideNav,
-    SideNavItems,
-    SideNavMenu,
-    SideNavMenuItem,
-    SideNavLink,
-    SkipToContent,
-    Content,
-    Grid,
-    Row,
-    Column,
-  } from "carbon-components-svelte";
+import {
+  Header,
+  HeaderNav,
+  HeaderNavItem,
+  HeaderNavMenu,
+  SideNav,
+  SideNavItems,
+  SideNavMenu,
+  SideNavMenuItem,
+  SideNavLink,
+  SkipToContent,
+  Content,
+  Grid,
+  Row,
+  Column,
+} from "carbon-components-svelte";
 
-  let isSideNavOpen = false;
+let isSideNavOpen = false;
 </script>
 
 <Header

--- a/docs/src/pages/framed/_reset.svelte
+++ b/docs/src/pages/framed/_reset.svelte
@@ -1,28 +1,28 @@
 <script>
-  import { onMount } from "svelte";
+import { onMount } from "svelte";
 
-  onMount(() => {
-    document.body.classList.add("framed");
-    return () => {
-      document.body.classList.remove("framed");
-    };
-  });
+onMount(() => {
+  document.body.classList.add("framed");
+  return () => {
+    document.body.classList.remove("framed");
+  };
+});
 
-  $: {
-    const searchParams = new URLSearchParams(window.location.search);
-    const current_theme = searchParams.get("theme");
+$: {
+  const searchParams = new URLSearchParams(window.location.search);
+  const current_theme = searchParams.get("theme");
 
-    // NOTE: we *do not* want to persist the theme as this can
-    // conflict with how the iframe is displayed in the docs.
-    // Instead, we want the theme to be overridden in the standalone page.
-    if (["white", "g10", "g80", "g90", "g100"].includes(current_theme)) {
-      document.documentElement.setAttribute("theme", current_theme);
-      document.documentElement.style.setProperty(
-        "color-scheme",
-        ["white", "g10"].includes(current_theme) ? "light" : "dark",
-      );
-    }
+  // NOTE: we *do not* want to persist the theme as this can
+  // conflict with how the iframe is displayed in the docs.
+  // Instead, we want the theme to be overridden in the standalone page.
+  if (["white", "g10", "g80", "g90", "g100"].includes(current_theme)) {
+    document.documentElement.setAttribute("theme", current_theme);
+    document.documentElement.style.setProperty(
+      "color-scheme",
+      ["white", "g10"].includes(current_theme) ? "light" : "dark",
+    );
   }
+}
 </script>
 
 <slot />

--- a/docs/src/pages/index.svelte
+++ b/docs/src/pages/index.svelte
@@ -1,48 +1,48 @@
 <script>
-  import {
-    Content,
-    Grid,
-    Row,
-    Column,
-    CodeSnippet,
-    Link,
-    Tabs,
-    Tab,
-    TabContent,
-    OutboundLink,
-    RadioButtonGroup,
-    RadioButton,
-  } from "carbon-components-svelte";
-  import TileCard from "../components/TileCard.svelte";
-  import { theme } from "../store";
-  import { metatags } from "@sveltech/routify";
+import {
+  Content,
+  Grid,
+  Row,
+  Column,
+  CodeSnippet,
+  Link,
+  Tabs,
+  Tab,
+  TabContent,
+  OutboundLink,
+  RadioButtonGroup,
+  RadioButton,
+} from "carbon-components-svelte";
+import TileCard from "../components/TileCard.svelte";
+import { theme } from "../store";
+import { metatags } from "@sveltech/routify";
 
-  metatags.title = "Carbon Components Svelte";
-  metatags.description =
-    "The Svelte implementation of the Carbon Design System featuring UI components, icons, pictograms, and charts.";
+metatags.title = "Carbon Components Svelte";
+metatags.description =
+  "The Svelte implementation of the Carbon Design System featuring UI components, icons, pictograms, and charts.";
 
-  const installNpm = "npm i carbon-components-svelte";
-  const installPnpm = "pnpm i carbon-components-svelte";
-  const installYarn = "yarn add carbon-components-svelte";
-  const installBun = "bun add carbon-components-svelte";
-  const themes = {
-    white: "White",
-    g10: "Gray 10",
-    g80: "Gray 80",
-    g90: "Gray 90",
-    g100: "Gray 100",
-    all: "All",
-  };
+const installNpm = "npm i carbon-components-svelte";
+const installPnpm = "pnpm i carbon-components-svelte";
+const installYarn = "yarn add carbon-components-svelte";
+const installBun = "bun add carbon-components-svelte";
+const themes = {
+  white: "White",
+  g10: "Gray 10",
+  g80: "Gray 80",
+  g90: "Gray 90",
+  g100: "Gray 100",
+  all: "All",
+};
 
-  const cssImportAll = `import "carbon-components-svelte/css/all.css";`;
-  const cssThemeToggle = `<script>
+const cssImportAll = `import "carbon-components-svelte/css/all.css";`;
+const cssThemeToggle = `<script>
   let theme = "${$theme}"; // "white" | "g10" | "g80" | "g90" | "g100"
 
   $: document.documentElement.setAttribute("theme", theme);
 <\/script>
 `;
 
-  $: cssImport = `import "carbon-components-svelte/css/${$theme}.css";`;
+$: cssImport = `import "carbon-components-svelte/css/${$theme}.css";`;
 </script>
 
 <svelte:head>

--- a/examples/rollup/src/App.svelte
+++ b/examples/rollup/src/App.svelte
@@ -1,6 +1,6 @@
 <script>
-  import "carbon-components-svelte/css/white.css";
-  import { Button } from "carbon-components-svelte";
+import "carbon-components-svelte/css/white.css";
+import { Button } from "carbon-components-svelte";
 </script>
 
 <Button>Primary button</Button>

--- a/examples/sveltekit/src/routes/+layout.svelte
+++ b/examples/sveltekit/src/routes/+layout.svelte
@@ -1,5 +1,5 @@
 <script>
-  import "carbon-components-svelte/css/white.css";
+import "carbon-components-svelte/css/white.css";
 </script>
 
 <slot />

--- a/examples/sveltekit/src/routes/+page.svelte
+++ b/examples/sveltekit/src/routes/+page.svelte
@@ -1,6 +1,6 @@
 <script>
-  import { Button, breakpoints } from "carbon-components-svelte";
-  import { Airplane } from "carbon-pictograms-svelte";
+import { Button, breakpoints } from "carbon-components-svelte";
+import { Airplane } from "carbon-pictograms-svelte";
 </script>
 
 <Button>Primary button</Button>

--- a/examples/vite/src/App.svelte
+++ b/examples/vite/src/App.svelte
@@ -1,6 +1,6 @@
 <script>
-  import "carbon-components-svelte/css/white.css";
-  import { Button, breakpoints } from "carbon-components-svelte";
+import "carbon-components-svelte/css/white.css";
+import { Button, breakpoints } from "carbon-components-svelte";
 </script>
 
 <Button>Primary button</Button>

--- a/examples/webpack/src/App.svelte
+++ b/examples/webpack/src/App.svelte
@@ -1,6 +1,6 @@
 <script>
-  import "carbon-components-svelte/css/white.css";
-  import { Button } from "carbon-components-svelte";
+import "carbon-components-svelte/css/white.css";
+import { Button } from "carbon-components-svelte";
 </script>
 
 <Button>Primary button</Button>

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "flatpickr": "4.6.9"
       },
       "devDependencies": {
+        "@biomejs/biome": "1.9.4",
         "@sveltejs/vite-plugin-svelte": "^3.1.2",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/svelte": "^5.2.7",
@@ -25,8 +26,6 @@
         "culls": "^0.1.1",
         "jsdom": "^26.0.0",
         "postcss": "^8.5.3",
-        "prettier": "^3.5.3",
-        "prettier-plugin-svelte": "^3.3.3",
         "sass": "^1.49.11",
         "standard-version": "^9.5.0",
         "sveld": "^0.22.1",
@@ -126,6 +125,170 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@biomejs/biome": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-1.9.4.tgz",
+      "integrity": "sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT OR Apache-2.0",
+      "bin": {
+        "biome": "bin/biome"
+      },
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/biome"
+      },
+      "optionalDependencies": {
+        "@biomejs/cli-darwin-arm64": "1.9.4",
+        "@biomejs/cli-darwin-x64": "1.9.4",
+        "@biomejs/cli-linux-arm64": "1.9.4",
+        "@biomejs/cli-linux-arm64-musl": "1.9.4",
+        "@biomejs/cli-linux-x64": "1.9.4",
+        "@biomejs/cli-linux-x64-musl": "1.9.4",
+        "@biomejs/cli-win32-arm64": "1.9.4",
+        "@biomejs/cli-win32-x64": "1.9.4"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-arm64": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-1.9.4.tgz",
+      "integrity": "sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-x64": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-1.9.4.tgz",
+      "integrity": "sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-1.9.4.tgz",
+      "integrity": "sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64-musl": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-1.9.4.tgz",
+      "integrity": "sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-1.9.4.tgz",
+      "integrity": "sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64-musl": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-1.9.4.tgz",
+      "integrity": "sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-arm64": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-1.9.4.tgz",
+      "integrity": "sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-x64": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-1.9.4.tgz",
+      "integrity": "sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
       }
     },
     "node_modules/@carbon/telemetry": {
@@ -3986,17 +4149,6 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
-    "node_modules/prettier-plugin-svelte": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-svelte/-/prettier-plugin-svelte-3.3.3.tgz",
-      "integrity": "sha512-yViK9zqQ+H2qZD1w/bH7W8i+bVfKrD8GIFjkFe4Thl6kCT9SlAsXVNmt3jCvQOCsnOhcvYgsoVlRV/Eu6x5nNw==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "prettier": "^3.0.0",
-        "svelte": "^3.2.0 || ^4.0.0-next.0 || ^5.0.0-next.0"
       }
     },
     "node_modules/pretty-format": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "test:ui": "vite",
     "test:src-types": "tsc types/**/*.ts",
     "test:types": "svelte-check --workspace tests",
-    "lint": "prettier --write --cache \"**/*.{svelte,md,js,json,ts}\"",
+    "lint": "biome format --write ./",
     "build:css": "node scripts/build-css",
     "build:docs": "node scripts/build-docs && node scripts/format-component-api",
     "postinstall": "ibmtelemetry --config=telemetry.yml",
@@ -45,6 +45,7 @@
     "flatpickr": "4.6.9"
   },
   "devDependencies": {
+    "@biomejs/biome": "1.9.4",
     "@sveltejs/vite-plugin-svelte": "^3.1.2",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/svelte": "^5.2.7",
@@ -56,8 +57,6 @@
     "culls": "^0.1.1",
     "jsdom": "^26.0.0",
     "postcss": "^8.5.3",
-    "prettier": "^3.5.3",
-    "prettier-plugin-svelte": "^3.3.3",
     "sass": "^1.49.11",
     "standard-version": "^9.5.0",
     "sveld": "^0.22.1",
@@ -72,11 +71,6 @@
       "commit": true,
       "tag": true
     }
-  },
-  "prettier": {
-    "plugins": [
-      "prettier-plugin-svelte"
-    ]
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -26,9 +26,7 @@
       "import": "./src/*.js"
     }
   },
-  "sideEffects": [
-    "css/*.css"
-  ],
+  "sideEffects": ["css/*.css"],
   "scripts": {
     "test": "vitest",
     "test:ui": "vite",
@@ -85,12 +83,7 @@
     "component library",
     "carbon design system"
   ],
-  "files": [
-    "src",
-    "types",
-    "css",
-    "telemetry.yml"
-  ],
+  "files": ["src", "types", "css", "telemetry.yml"],
   "maintainers": [
     "Eric Liu (https://github.com/metonym)",
     "Enrico Sacchetti (https://github.com/theetrain)"

--- a/scripts/format-component-api.js
+++ b/scripts/format-component-api.js
@@ -1,6 +1,8 @@
 // @ts-check
 import fs from "node:fs";
-import componentApi from "../docs/src/COMPONENT_API.json" assert { type: "json" };
+import componentApi from "../docs/src/COMPONENT_API.json" assert {
+  type: "json",
+};
 import { format } from "prettier";
 import plugin from "prettier/plugins/typescript";
 

--- a/src/Accordion/Accordion.svelte
+++ b/src/Accordion/Accordion.svelte
@@ -1,33 +1,33 @@
 <script>
-  /** @extends {"./AccordionSkeleton.svelte"} AccordionSkeletonProps */
+/** @extends {"./AccordionSkeleton.svelte"} AccordionSkeletonProps */
 
-  /**
-   * Specify alignment of accordion item chevron icon
-   * @type {"start" | "end"}
-   */
-  export let align = "end";
+/**
+ * Specify alignment of accordion item chevron icon
+ * @type {"start" | "end"}
+ */
+export let align = "end";
 
-  /**
-   * Specify the size of the accordion
-   * @type {"sm" | "xl"}
-   */
-  export let size = undefined;
+/**
+ * Specify the size of the accordion
+ * @type {"sm" | "xl"}
+ */
+export let size = undefined;
 
-  /** Set to `true` to disable the accordion */
-  export let disabled = false;
+/** Set to `true` to disable the accordion */
+export let disabled = false;
 
-  /** Set to `true` to display the skeleton state */
-  export let skeleton = false;
+/** Set to `true` to display the skeleton state */
+export let skeleton = false;
 
-  import { setContext } from "svelte";
-  import { writable } from "svelte/store";
-  import AccordionSkeleton from "./AccordionSkeleton.svelte";
+import { setContext } from "svelte";
+import { writable } from "svelte/store";
+import AccordionSkeleton from "./AccordionSkeleton.svelte";
 
-  const disableItems = writable(disabled);
+const disableItems = writable(disabled);
 
-  $: disableItems.set(disabled);
+$: disableItems.set(disabled);
 
-  setContext("Accordion", { disableItems });
+setContext("Accordion", { disableItems });
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->

--- a/src/Accordion/AccordionItem.svelte
+++ b/src/Accordion/AccordionItem.svelte
@@ -1,37 +1,37 @@
 <script>
-  /**
-   * Specify the title of the accordion item heading.
-   * Alternatively, use the "title" slot (e.g., `<div slot="title">...</div>`)
-   */
-  export let title = "title";
+/**
+ * Specify the title of the accordion item heading.
+ * Alternatively, use the "title" slot (e.g., `<div slot="title">...</div>`)
+ */
+export let title = "title";
 
-  /** Set to `true` to open the first accordion item */
-  export let open = false;
+/** Set to `true` to open the first accordion item */
+export let open = false;
 
-  /** Set to `true` to disable the accordion item */
-  export let disabled = false;
+/** Set to `true` to disable the accordion item */
+export let disabled = false;
 
-  /** Specify the ARIA label for the accordion item chevron icon */
-  export let iconDescription = "Expand/Collapse";
+/** Specify the ARIA label for the accordion item chevron icon */
+export let iconDescription = "Expand/Collapse";
 
-  import { onMount, getContext } from "svelte";
-  import ChevronRight from "../icons/ChevronRight.svelte";
+import { onMount, getContext } from "svelte";
+import ChevronRight from "../icons/ChevronRight.svelte";
 
-  let initialDisabled = disabled;
+let initialDisabled = disabled;
 
-  const ctx = getContext("Accordion");
-  const unsubscribe = ctx.disableItems.subscribe((value) => {
-    if (!value && initialDisabled) return;
-    disabled = value;
-  });
+const ctx = getContext("Accordion");
+const unsubscribe = ctx.disableItems.subscribe((value) => {
+  if (!value && initialDisabled) return;
+  disabled = value;
+});
 
-  let animation = undefined;
+let animation = undefined;
 
-  onMount(() => {
-    return () => {
-      unsubscribe();
-    };
-  });
+onMount(() => {
+  return () => {
+    unsubscribe();
+  };
+});
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->

--- a/src/Accordion/AccordionSkeleton.svelte
+++ b/src/Accordion/AccordionSkeleton.svelte
@@ -1,24 +1,24 @@
 <script>
-  /** Specify the number of accordion items to render */
-  export let count = 4;
+/** Specify the number of accordion items to render */
+export let count = 4;
 
-  /**
-   * Specify alignment of accordion item chevron icon
-   * @type {"start" | "end"}
-   */
-  export let align = "end";
+/**
+ * Specify alignment of accordion item chevron icon
+ * @type {"start" | "end"}
+ */
+export let align = "end";
 
-  /**
-   * Specify the size of the accordion
-   * @type {"sm" | "xl"}
-   */
-  export let size = undefined;
+/**
+ * Specify the size of the accordion
+ * @type {"sm" | "xl"}
+ */
+export let size = undefined;
 
-  /** Set to `false` to close the first accordion item */
-  export let open = true;
+/** Set to `false` to close the first accordion item */
+export let open = true;
 
-  import ChevronRight from "../icons/ChevronRight.svelte";
-  import SkeletonText from "../SkeletonText/SkeletonText.svelte";
+import ChevronRight from "../icons/ChevronRight.svelte";
+import SkeletonText from "../SkeletonText/SkeletonText.svelte";
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->

--- a/src/AspectRatio/AspectRatio.svelte
+++ b/src/AspectRatio/AspectRatio.svelte
@@ -1,9 +1,9 @@
 <script>
-  /**
-   * Specify the aspect ratio
-   * @type {"2x1" | "2x3" | "16x9" | "4x3" | "1x1" | "3x4" | "3x2" | "9x16" | "1x2"}
-   */
-  export let ratio = "2x1";
+/**
+ * Specify the aspect ratio
+ * @type {"2x1" | "2x3" | "16x9" | "4x3" | "1x1" | "3x4" | "3x2" | "9x16" | "1x2"}
+ */
+export let ratio = "2x1";
 </script>
 
 <div

--- a/src/Breadcrumb/Breadcrumb.svelte
+++ b/src/Breadcrumb/Breadcrumb.svelte
@@ -1,13 +1,13 @@
 <script>
-  /** @extends {"./BreadcrumbSkeleton.svelte"} BreadcrumbSkeletonProps */
+/** @extends {"./BreadcrumbSkeleton.svelte"} BreadcrumbSkeletonProps */
 
-  /** Set to `true` to hide the breadcrumb trailing slash */
-  export let noTrailingSlash = false;
+/** Set to `true` to hide the breadcrumb trailing slash */
+export let noTrailingSlash = false;
 
-  /** Set to `true` to display skeleton state */
-  export let skeleton = false;
+/** Set to `true` to display skeleton state */
+export let skeleton = false;
 
-  import BreadcrumbSkeleton from "./BreadcrumbSkeleton.svelte";
+import BreadcrumbSkeleton from "./BreadcrumbSkeleton.svelte";
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->

--- a/src/Breadcrumb/BreadcrumbItem.svelte
+++ b/src/Breadcrumb/BreadcrumbItem.svelte
@@ -1,22 +1,22 @@
 <script>
-  /**
-   * @slot {{props?: { ["aria-current"]?: string; class: "bx--link"; }}}
-   */
+/**
+ * @slot {{props?: { ["aria-current"]?: string; class: "bx--link"; }}}
+ */
 
-  /**
-   * Set the `href` to use an anchor link
-   * @type {string}
-   */
-  export let href = undefined;
+/**
+ * Set the `href` to use an anchor link
+ * @type {string}
+ */
+export let href = undefined;
 
-  /** Set to `true` if the breadcrumb item represents the current page */
-  export let isCurrentPage = false;
+/** Set to `true` if the breadcrumb item represents the current page */
+export let isCurrentPage = false;
 
-  import Link from "../Link/Link.svelte";
+import Link from "../Link/Link.svelte";
 
-  import { setContext } from "svelte";
+import { setContext } from "svelte";
 
-  setContext("BreadcrumbItem", {});
+setContext("BreadcrumbItem", {});
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->

--- a/src/Breadcrumb/BreadcrumbSkeleton.svelte
+++ b/src/Breadcrumb/BreadcrumbSkeleton.svelte
@@ -1,9 +1,9 @@
 <script>
-  /** Set to `true` to hide the breadcrumb trailing slash */
-  export let noTrailingSlash = false;
+/** Set to `true` to hide the breadcrumb trailing slash */
+export let noTrailingSlash = false;
 
-  /** Specify the number of breadcrumb items to render */
-  export let count = 3;
+/** Specify the number of breadcrumb items to render */
+export let count = 3;
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->

--- a/src/Breakpoint/Breakpoint.svelte
+++ b/src/Breakpoint/Breakpoint.svelte
@@ -1,47 +1,47 @@
 <script>
-  /**
-   * @typedef {"sm" | "md" | "lg" | "xlg" | "max"} BreakpointSize
-   * @typedef {320 | 672 | 1056 | 1312 | 1584} BreakpointValue
-   * @event {{ size: BreakpointSize; breakpointValue: BreakpointValue; }} change
-   * @slot {{ size: BreakpointSize; sizes: Record<BreakpointSize, boolean>; }}
-   */
+/**
+ * @typedef {"sm" | "md" | "lg" | "xlg" | "max"} BreakpointSize
+ * @typedef {320 | 672 | 1056 | 1312 | 1584} BreakpointValue
+ * @event {{ size: BreakpointSize; breakpointValue: BreakpointValue; }} change
+ * @slot {{ size: BreakpointSize; sizes: Record<BreakpointSize, boolean>; }}
+ */
 
-  /**
-   * Determine the current Carbon grid breakpoint size
-   * @type {BreakpointSize}
-   */
-  export let size = undefined;
+/**
+ * Determine the current Carbon grid breakpoint size
+ * @type {BreakpointSize}
+ */
+export let size = undefined;
 
-  /**
-   * Carbon grid sizes as an object
-   * @type {Record<BreakpointSize, boolean>}
-   */
-  export let sizes = {
-    sm: false,
-    md: false,
-    lg: false,
-    xlg: false,
-    max: false,
-  };
+/**
+ * Carbon grid sizes as an object
+ * @type {Record<BreakpointSize, boolean>}
+ */
+export let sizes = {
+  sm: false,
+  md: false,
+  lg: false,
+  xlg: false,
+  max: false,
+};
 
-  import { createEventDispatcher } from "svelte";
-  import { breakpointObserver } from "./breakpointObserver";
-  import { breakpoints } from "./breakpoints";
+import { createEventDispatcher } from "svelte";
+import { breakpointObserver } from "./breakpointObserver";
+import { breakpoints } from "./breakpoints";
 
-  const dispatch = createEventDispatcher();
-  const observer = breakpointObserver();
+const dispatch = createEventDispatcher();
+const observer = breakpointObserver();
 
-  $: size = $observer;
-  $: sizes = {
-    sm: size == "sm",
-    md: size == "md",
-    lg: size == "lg",
-    xlg: size == "xlg",
-    max: size == "max",
-  };
-  $: if (size != undefined)
-    // svelte-ignore reactive_declaration_non_reactive_property
-    dispatch("change", { size, breakpointValue: breakpoints[size] });
+$: size = $observer;
+$: sizes = {
+  sm: size == "sm",
+  md: size == "md",
+  lg: size == "lg",
+  xlg: size == "xlg",
+  max: size == "max",
+};
+$: if (size != undefined)
+  // svelte-ignore reactive_declaration_non_reactive_property
+  dispatch("change", { size, breakpointValue: breakpoints[size] });
 </script>
 
 <slot {size} {sizes} />

--- a/src/Button/Button.svelte
+++ b/src/Button/Button.svelte
@@ -1,136 +1,132 @@
 <script>
-  /**
-   * @extends {"./ButtonSkeleton.svelte"} ButtonSkeletonProps
-   * @restProps {button | a | div}
-   * @slot {{ props: { role: "button"; type?: string; tabindex: any; disabled: boolean; href?: string; class: string; [key: string]: any; } }}
-   */
+/**
+ * @extends {"./ButtonSkeleton.svelte"} ButtonSkeletonProps
+ * @restProps {button | a | div}
+ * @slot {{ props: { role: "button"; type?: string; tabindex: any; disabled: boolean; href?: string; class: string; [key: string]: any; } }}
+ */
 
-  /**
-   * Specify the kind of button
-   * @type {"primary" | "secondary" | "tertiary" | "ghost" | "danger" | "danger-tertiary" | "danger-ghost"}
-   */
-  export let kind = "primary";
+/**
+ * Specify the kind of button
+ * @type {"primary" | "secondary" | "tertiary" | "ghost" | "danger" | "danger-tertiary" | "danger-ghost"}
+ */
+export let kind = "primary";
 
-  /**
-   * Specify the size of button
-   * @type {"default" | "field" | "small" | "lg" | "xl"}
-   */
-  export let size = "default";
+/**
+ * Specify the size of button
+ * @type {"default" | "field" | "small" | "lg" | "xl"}
+ */
+export let size = "default";
 
-  /** Set to `true` to use Carbon's expressive typesetting */
-  export let expressive = false;
+/** Set to `true` to use Carbon's expressive typesetting */
+export let expressive = false;
 
-  /**
-   * Set to `true` to enable the selected state for an icon-only, ghost button
-   */
-  export let isSelected = false;
+/**
+ * Set to `true` to enable the selected state for an icon-only, ghost button
+ */
+export let isSelected = false;
 
-  /**
-   * Specify the icon to render
-   * Alternatively, use the named slot "icon" (e.g., `<Icon slot="icon" size="{20}" />`)
-   *
-   * @type {any}
-   */
-  export let icon = undefined;
+/**
+ * Specify the icon to render
+ * Alternatively, use the named slot "icon" (e.g., `<Icon slot="icon" size="{20}" />`)
+ *
+ * @type {any}
+ */
+export let icon = undefined;
 
-  /**
-   * Specify the ARIA label for the button icon
-   * @type {string}
-   */
-  export let iconDescription = undefined;
+/**
+ * Specify the ARIA label for the button icon
+ * @type {string}
+ */
+export let iconDescription = undefined;
 
-  /**
-   * Set the alignment of the tooltip relative to the icon.
-   * Only applies to icon-only buttons
-   * @type {"start" | "center" | "end"}
-   */
-  export let tooltipAlignment = "center";
+/**
+ * Set the alignment of the tooltip relative to the icon.
+ * Only applies to icon-only buttons
+ * @type {"start" | "center" | "end"}
+ */
+export let tooltipAlignment = "center";
 
-  /**
-   * Set the position of the tooltip relative to the icon
-   * @type {"top" | "right" | "bottom" | "left"}
-   */
-  export let tooltipPosition = "bottom";
+/**
+ * Set the position of the tooltip relative to the icon
+ * @type {"top" | "right" | "bottom" | "left"}
+ */
+export let tooltipPosition = "bottom";
 
-  /**
-   * Set to `true` to render a custom HTML element
-   * Props are destructured as `props` in the default slot (e.g., <Button let:props><div {...props}>...</div></Button>)
-   */
-  export let as = false;
+/**
+ * Set to `true` to render a custom HTML element
+ * Props are destructured as `props` in the default slot (e.g., <Button let:props><div {...props}>...</div></Button>)
+ */
+export let as = false;
 
-  /** Set to `true` to display the skeleton state */
-  export let skeleton = false;
+/** Set to `true` to display the skeleton state */
+export let skeleton = false;
 
-  /** Set to `true` to disable the button */
-  export let disabled = false;
+/** Set to `true` to disable the button */
+export let disabled = false;
 
-  /**
-   * Set the `href` to use an anchor link
-   * @type {string}
-   */
-  export let href = undefined;
+/**
+ * Set the `href` to use an anchor link
+ * @type {string}
+ */
+export let href = undefined;
 
-  /** Specify the tabindex */
-  export let tabindex = "0";
+/** Specify the tabindex */
+export let tabindex = "0";
 
-  /** Specify the `type` attribute for the button element */
-  export let type = "button";
+/** Specify the `type` attribute for the button element */
+export let type = "button";
 
-  /** Obtain a reference to the HTML element */
-  export let ref = null;
+/** Obtain a reference to the HTML element */
+export let ref = null;
 
-  import { getContext } from "svelte";
-  import ButtonSkeleton from "./ButtonSkeleton.svelte";
+import { getContext } from "svelte";
+import ButtonSkeleton from "./ButtonSkeleton.svelte";
 
-  const ctx = getContext("ComposedModal");
+const ctx = getContext("ComposedModal");
 
-  $: if (ctx && ref) {
-    ctx.declareRef(ref);
-  }
-  $: hasIconOnly = (icon || $$slots.icon) && !$$slots.default;
-  $: iconProps = {
-    "aria-hidden": "true",
-    class: "bx--btn__icon",
-    "aria-label": iconDescription,
-  };
-  $: buttonProps = {
-    type: href && !disabled ? undefined : type,
-    tabindex,
-    disabled: disabled === true ? true : undefined,
-    href,
-    "aria-pressed":
-      hasIconOnly && kind === "ghost" && !href ? isSelected : undefined,
-    ...$$restProps,
-    class: [
-      "bx--btn",
-      expressive && "bx--btn--expressive",
-      ((size === "small" && !expressive) ||
-        (size === "sm" && !expressive) ||
-        (size === "small" && !expressive)) &&
-        "bx--btn--sm",
-      (size === "field" && !expressive) ||
-        (size === "md" && !expressive && "bx--btn--md"),
-      size === "field" && "bx--btn--field",
-      size === "small" && "bx--btn--sm",
-      size === "lg" && "bx--btn--lg",
-      size === "xl" && "bx--btn--xl",
-      kind && `bx--btn--${kind}`,
-      disabled && "bx--btn--disabled",
-      hasIconOnly && "bx--btn--icon-only",
-      hasIconOnly && "bx--tooltip__trigger",
-      hasIconOnly && "bx--tooltip--a11y",
-      hasIconOnly &&
-        tooltipPosition &&
-        `bx--btn--icon-only--${tooltipPosition}`,
-      hasIconOnly &&
-        tooltipAlignment &&
-        `bx--tooltip--align-${tooltipAlignment}`,
-      hasIconOnly && isSelected && kind === "ghost" && "bx--btn--selected",
-      $$restProps.class,
-    ]
-      .filter(Boolean)
-      .join(" "),
-  };
+$: if (ctx && ref) {
+  ctx.declareRef(ref);
+}
+$: hasIconOnly = (icon || $$slots.icon) && !$$slots.default;
+$: iconProps = {
+  "aria-hidden": "true",
+  class: "bx--btn__icon",
+  "aria-label": iconDescription,
+};
+$: buttonProps = {
+  type: href && !disabled ? undefined : type,
+  tabindex,
+  disabled: disabled === true ? true : undefined,
+  href,
+  "aria-pressed":
+    hasIconOnly && kind === "ghost" && !href ? isSelected : undefined,
+  ...$$restProps,
+  class: [
+    "bx--btn",
+    expressive && "bx--btn--expressive",
+    ((size === "small" && !expressive) ||
+      (size === "sm" && !expressive) ||
+      (size === "small" && !expressive)) &&
+      "bx--btn--sm",
+    (size === "field" && !expressive) ||
+      (size === "md" && !expressive && "bx--btn--md"),
+    size === "field" && "bx--btn--field",
+    size === "small" && "bx--btn--sm",
+    size === "lg" && "bx--btn--lg",
+    size === "xl" && "bx--btn--xl",
+    kind && `bx--btn--${kind}`,
+    disabled && "bx--btn--disabled",
+    hasIconOnly && "bx--btn--icon-only",
+    hasIconOnly && "bx--tooltip__trigger",
+    hasIconOnly && "bx--tooltip--a11y",
+    hasIconOnly && tooltipPosition && `bx--btn--icon-only--${tooltipPosition}`,
+    hasIconOnly && tooltipAlignment && `bx--tooltip--align-${tooltipAlignment}`,
+    hasIconOnly && isSelected && kind === "ghost" && "bx--btn--selected",
+    $$restProps.class,
+  ]
+    .filter(Boolean)
+    .join(" "),
+};
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->

--- a/src/Button/ButtonSet.svelte
+++ b/src/Button/ButtonSet.svelte
@@ -1,6 +1,6 @@
 <script>
-  /** Set to `true` to stack the buttons vertically */
-  export let stacked = false;
+/** Set to `true` to stack the buttons vertically */
+export let stacked = false;
 </script>
 
 <div

--- a/src/Button/ButtonSkeleton.svelte
+++ b/src/Button/ButtonSkeleton.svelte
@@ -1,15 +1,15 @@
 <script>
-  /**
-   * Set the `href` to use an anchor link
-   * @type {string}
-   */
-  export let href = undefined;
+/**
+ * Set the `href` to use an anchor link
+ * @type {string}
+ */
+export let href = undefined;
 
-  /**
-   * Specify the size of button skeleton
-   * @type {"default" | "field" | "small" | "lg" | "xl"}
-   */
-  export let size = "default";
+/**
+ * Specify the size of button skeleton
+ * @type {"default" | "field" | "small" | "lg" | "xl"}
+ */
+export let size = "default";
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->

--- a/src/Checkbox/Checkbox.svelte
+++ b/src/Checkbox/Checkbox.svelte
@@ -1,73 +1,73 @@
 <script>
-  /**
-   * @restProps {div}
-   * @event {boolean} check
-   */
+/**
+ * @restProps {div}
+ * @event {boolean} check
+ */
 
-  /**
-   * Specify the value of the checkbox
-   * @type {any}
-   */
-  export let value = "";
+/**
+ * Specify the value of the checkbox
+ * @type {any}
+ */
+export let value = "";
 
-  /** Specify whether the checkbox is checked */
-  export let checked = false;
+/** Specify whether the checkbox is checked */
+export let checked = false;
 
-  /**
-   * Specify the bound group
-   * @type {ReadonlyArray<any>}
-   */
-  export let group = undefined;
+/**
+ * Specify the bound group
+ * @type {ReadonlyArray<any>}
+ */
+export let group = undefined;
 
-  /** Specify whether the checkbox is indeterminate */
-  export let indeterminate = false;
+/** Specify whether the checkbox is indeterminate */
+export let indeterminate = false;
 
-  /** Set to `true` to display the skeleton state */
-  export let skeleton = false;
+/** Set to `true` to display the skeleton state */
+export let skeleton = false;
 
-  /** Set to `true` to mark the field as required */
-  export let required = false;
+/** Set to `true` to mark the field as required */
+export let required = false;
 
-  /** Set to `true` for the checkbox to be read-only */
-  export let readonly = false;
+/** Set to `true` for the checkbox to be read-only */
+export let readonly = false;
 
-  /** Set to `true` to disable the checkbox */
-  export let disabled = false;
+/** Set to `true` to disable the checkbox */
+export let disabled = false;
 
-  /** Specify the label text */
-  export let labelText = "";
+/** Specify the label text */
+export let labelText = "";
 
-  /** Set to `true` to visually hide the label text */
-  export let hideLabel = false;
+/** Set to `true` to visually hide the label text */
+export let hideLabel = false;
 
-  /** Set a name for the input element */
-  export let name = "";
+/** Set a name for the input element */
+export let name = "";
 
-  /**
-   * Specify the title attribute for the label element
-   * @type {string}
-   */
-  export let title = undefined;
+/**
+ * Specify the title attribute for the label element
+ * @type {string}
+ */
+export let title = undefined;
 
-  /** Set an id for the input label */
-  export let id = "ccs-" + Math.random().toString(36);
+/** Set an id for the input label */
+export let id = "ccs-" + Math.random().toString(36);
 
-  /** Obtain a reference to the input HTML element */
-  export let ref = null;
+/** Obtain a reference to the input HTML element */
+export let ref = null;
 
-  import { createEventDispatcher } from "svelte";
-  import CheckboxSkeleton from "./CheckboxSkeleton.svelte";
+import { createEventDispatcher } from "svelte";
+import CheckboxSkeleton from "./CheckboxSkeleton.svelte";
 
-  const dispatch = createEventDispatcher();
+const dispatch = createEventDispatcher();
 
-  $: useGroup = Array.isArray(group);
-  $: checked = useGroup ? group.includes(value) : checked;
-  $: dispatch("check", checked);
+$: useGroup = Array.isArray(group);
+$: checked = useGroup ? group.includes(value) : checked;
+$: dispatch("check", checked);
 
-  let refLabel = null;
+let refLabel = null;
 
-  $: isTruncated = refLabel?.offsetWidth < refLabel?.scrollWidth;
-  $: title = !title && isTruncated ? refLabel?.innerText : title;
+$: isTruncated = refLabel?.offsetWidth < refLabel?.scrollWidth;
+$: title = !title && isTruncated ? refLabel?.innerText : title;
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->

--- a/src/Checkbox/InlineCheckbox.svelte
+++ b/src/Checkbox/InlineCheckbox.svelte
@@ -1,21 +1,21 @@
 <script>
-  /** Specify whether the checkbox is checked */
-  export let checked = false;
+/** Specify whether the checkbox is checked */
+export let checked = false;
 
-  /** Specify whether the checkbox is indeterminate */
-  export let indeterminate = false;
+/** Specify whether the checkbox is indeterminate */
+export let indeterminate = false;
 
-  /**
-   * Specify the title attribute for the label element
-   * @type {string}
-   */
-  export let title = undefined;
+/**
+ * Specify the title attribute for the label element
+ * @type {string}
+ */
+export let title = undefined;
 
-  /** Set an id for the input label */
-  export let id = "ccs-" + Math.random().toString(36);
+/** Set an id for the input label */
+export let id = "ccs-" + Math.random().toString(36);
 
-  /** Obtain a reference to the input HTML element */
-  export let ref = null;
+/** Obtain a reference to the input HTML element */
+export let ref = null;
 </script>
 
 <div class:bx--checkbox--inline={true}>

--- a/src/CodeSnippet/CodeSnippet.svelte
+++ b/src/CodeSnippet/CodeSnippet.svelte
@@ -1,146 +1,146 @@
 <script>
-  /**
-   * @event {null} expand
-   * @event {null} collapse
-   * @event {null} copy
-   */
+/**
+ * @event {null} expand
+ * @event {null} collapse
+ * @event {null} copy
+ */
 
-  /**
-   * Set the type of code snippet
-   * @type {"single" | "inline" | "multi"}
-   */
-  export let type = "single";
+/**
+ * Set the type of code snippet
+ * @type {"single" | "inline" | "multi"}
+ */
+export let type = "single";
 
-  /**
-   * Set the code snippet text.
-   * Alternatively, use the default slot (e.g., `<CodeSnippet>{code}</CodeSnippet>`).
-   *
-   * NOTE: you *must* use the `code` prop for the copy-to-clipboard functionality.
-   * @type {string}
-   */
-  export let code = undefined;
+/**
+ * Set the code snippet text.
+ * Alternatively, use the default slot (e.g., `<CodeSnippet>{code}</CodeSnippet>`).
+ *
+ * NOTE: you *must* use the `code` prop for the copy-to-clipboard functionality.
+ * @type {string}
+ */
+export let code = undefined;
 
-  /**
-   * By default, this component uses `navigator.clipboard.writeText` API to copy text to the user's clipboard.
-   *
-   * Provide a custom function to override this behavior.
-   * @type {(code: string) => void}
-   */
-  export let copy = async (code) => {
-    try {
-      await navigator.clipboard.writeText(code);
-    } catch (e) {
-      console.log(e);
-    }
-  };
-
-  /** Set to `true` to expand a multi-line code snippet (type="multi") */
-  export let expanded = false;
-
-  /** Set to `true` to hide the copy button */
-  export let hideCopyButton = false;
-
-  /**
-   * Set to `true` for the disabled variant.
-   * Only applies to the "single", "multi" types
-   */
-  export let disabled = false;
-
-  /**
-   * Set to `true` to wrap the text.
-   *
-   * NOTE: this prop only works with the `type="multi"` variant
-   */
-  export let wrapText = false;
-
-  /** Set to `true` to enable the light variant */
-  export let light = false;
-
-  /** Set to `true` to display the skeleton state */
-  export let skeleton = false;
-
-  /**
-   * Specify the ARIA label for the copy button icon
-   * @type {string}
-   */
-  export let copyButtonDescription = undefined;
-
-  /**
-   * Specify the ARIA label of the copy button
-   * @type {string}
-   */
-  export let copyLabel = undefined;
-
-  /** Specify the feedback text displayed when clicking the snippet */
-  export let feedback = "Copied!";
-
-  /** Set the timeout duration (ms) to display feedback text */
-  export let feedbackTimeout = 2000;
-
-  /**
-   * Specify the show less text.
-   *
-   * NOTE: this prop only works with the `type="multi"` variant
-   */
-  export let showLessText = "Show less";
-
-  /**
-   * Specify the show more text
-   *
-   * NOTE: this prop only works with the `type="multi"` variant
-   */
-  export let showMoreText = "Show more";
-
-  /**
-   * Set to `false` to hide the show more/less button
-   *
-   * NOTE: this prop only works with the `type="multi"` variant
-   */
-  export let showMoreLess = true;
-
-  /** Set an id for the code element */
-  export let id = "ccs-" + Math.random().toString(36);
-
-  /** Obtain a reference to the pre HTML element */
-  export let ref = null;
-
-  import { createEventDispatcher, tick, onMount } from "svelte";
-  import ChevronDown from "../icons/ChevronDown.svelte";
-  import Button from "../Button/Button.svelte";
-  import CopyButton from "../CopyButton/CopyButton.svelte";
-  import CodeSnippetSkeleton from "./CodeSnippetSkeleton.svelte";
-
-  const dispatch = createEventDispatcher();
-
-  /** @type {"fade-in" | "fade-out"} */
-  let animation = undefined;
-  let timeout = undefined;
-
-  function setShowMoreLess() {
-    const { height } = ref.getBoundingClientRect();
-    if (height > 0) showMoreLess = ref.getBoundingClientRect().height > 255;
+/**
+ * By default, this component uses `navigator.clipboard.writeText` API to copy text to the user's clipboard.
+ *
+ * Provide a custom function to override this behavior.
+ * @type {(code: string) => void}
+ */
+export let copy = async (code) => {
+  try {
+    await navigator.clipboard.writeText(code);
+  } catch (e) {
+    console.log(e);
   }
+};
 
-  $: expandText = expanded ? showLessText : showMoreText;
-  $: minHeight = expanded ? 16 * 15 : 48;
-  $: maxHeight = expanded ? "none" : 16 * 15 + "px";
+/** Set to `true` to expand a multi-line code snippet (type="multi") */
+export let expanded = false;
 
-  // Show more/less only applies to multi-line code snippets
-  $: if (type !== "multi") showMoreLess = false;
+/** Set to `true` to hide the copy button */
+export let hideCopyButton = false;
 
-  $: if (type === "multi" && ref) {
-    if (showMoreLess) {
-      // Only compute the show more/less button if the consumer has not opted out
-      if (code === undefined) setShowMoreLess();
-      if (code) tick().then(setShowMoreLess);
-    }
+/**
+ * Set to `true` for the disabled variant.
+ * Only applies to the "single", "multi" types
+ */
+export let disabled = false;
+
+/**
+ * Set to `true` to wrap the text.
+ *
+ * NOTE: this prop only works with the `type="multi"` variant
+ */
+export let wrapText = false;
+
+/** Set to `true` to enable the light variant */
+export let light = false;
+
+/** Set to `true` to display the skeleton state */
+export let skeleton = false;
+
+/**
+ * Specify the ARIA label for the copy button icon
+ * @type {string}
+ */
+export let copyButtonDescription = undefined;
+
+/**
+ * Specify the ARIA label of the copy button
+ * @type {string}
+ */
+export let copyLabel = undefined;
+
+/** Specify the feedback text displayed when clicking the snippet */
+export let feedback = "Copied!";
+
+/** Set the timeout duration (ms) to display feedback text */
+export let feedbackTimeout = 2000;
+
+/**
+ * Specify the show less text.
+ *
+ * NOTE: this prop only works with the `type="multi"` variant
+ */
+export let showLessText = "Show less";
+
+/**
+ * Specify the show more text
+ *
+ * NOTE: this prop only works with the `type="multi"` variant
+ */
+export let showMoreText = "Show more";
+
+/**
+ * Set to `false` to hide the show more/less button
+ *
+ * NOTE: this prop only works with the `type="multi"` variant
+ */
+export let showMoreLess = true;
+
+/** Set an id for the code element */
+export let id = "ccs-" + Math.random().toString(36);
+
+/** Obtain a reference to the pre HTML element */
+export let ref = null;
+
+import { createEventDispatcher, tick, onMount } from "svelte";
+import ChevronDown from "../icons/ChevronDown.svelte";
+import Button from "../Button/Button.svelte";
+import CopyButton from "../CopyButton/CopyButton.svelte";
+import CodeSnippetSkeleton from "./CodeSnippetSkeleton.svelte";
+
+const dispatch = createEventDispatcher();
+
+/** @type {"fade-in" | "fade-out"} */
+let animation = undefined;
+let timeout = undefined;
+
+function setShowMoreLess() {
+  const { height } = ref.getBoundingClientRect();
+  if (height > 0) showMoreLess = ref.getBoundingClientRect().height > 255;
+}
+
+$: expandText = expanded ? showLessText : showMoreText;
+$: minHeight = expanded ? 16 * 15 : 48;
+$: maxHeight = expanded ? "none" : 16 * 15 + "px";
+
+// Show more/less only applies to multi-line code snippets
+$: if (type !== "multi") showMoreLess = false;
+
+$: if (type === "multi" && ref) {
+  if (showMoreLess) {
+    // Only compute the show more/less button if the consumer has not opted out
+    if (code === undefined) setShowMoreLess();
+    if (code) tick().then(setShowMoreLess);
   }
+}
 
-  $: if (type === "multi") dispatch(expanded ? "expand" : "collapse");
+$: if (type === "multi") dispatch(expanded ? "expand" : "collapse");
 
-  onMount(() => {
-    return () => clearTimeout(timeout);
-  });
+onMount(() => {
+  return () => clearTimeout(timeout);
+});
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->

--- a/src/CodeSnippet/CodeSnippetSkeleton.svelte
+++ b/src/CodeSnippet/CodeSnippetSkeleton.svelte
@@ -1,9 +1,9 @@
 <script>
-  /**
-   * Set the type of code snippet
-   * @type {"single" | "multi"}
-   */
-  export let type = "single";
+/**
+ * Set the type of code snippet
+ * @type {"single" | "multi"}
+ */
+export let type = "single";
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->

--- a/src/ComboBox/ComboBox.svelte
+++ b/src/ComboBox/ComboBox.svelte
@@ -1,219 +1,219 @@
 <script>
-  /**
-   * @typedef {any} ComboBoxItemId
-   * @typedef {{ id: ComboBoxItemId; text: string; disabled?: boolean; }} ComboBoxItem
-   * @event {{ selectedId: ComboBoxItemId; selectedItem: ComboBoxItem }} select
-   * @event {KeyboardEvent | MouseEvent} clear
-   * @slot {{ item: ComboBoxItem; index: number }}
-   */
+/**
+ * @typedef {any} ComboBoxItemId
+ * @typedef {{ id: ComboBoxItemId; text: string; disabled?: boolean; }} ComboBoxItem
+ * @event {{ selectedId: ComboBoxItemId; selectedItem: ComboBoxItem }} select
+ * @event {KeyboardEvent | MouseEvent} clear
+ * @slot {{ item: ComboBoxItem; index: number }}
+ */
 
-  /**
-   * Set the combobox items
-   * @type {ReadonlyArray<ComboBoxItem>}
-   */
-  export let items = [];
+/**
+ * Set the combobox items
+ * @type {ReadonlyArray<ComboBoxItem>}
+ */
+export let items = [];
 
-  /**
-   * Override the display of a combobox item
-   * @type {(item: ComboBoxItem) => string}
-   */
-  export let itemToString = (item) => item.text || item.id;
+/**
+ * Override the display of a combobox item
+ * @type {(item: ComboBoxItem) => string}
+ */
+export let itemToString = (item) => item.text || item.id;
 
-  /**
-   * Set the selected item by value id
-   * @type {ComboBoxItemId}
-   */
-  export let selectedId = undefined;
+/**
+ * Set the selected item by value id
+ * @type {ComboBoxItemId}
+ */
+export let selectedId = undefined;
 
-  /** Specify the selected combobox value */
-  export let value = "";
+/** Specify the selected combobox value */
+export let value = "";
 
-  /**
-   * Specify the direction of the combobox dropdown menu
-   * @type {"bottom" | "top"}
-   */
-  export let direction = "bottom";
+/**
+ * Specify the direction of the combobox dropdown menu
+ * @type {"bottom" | "top"}
+ */
+export let direction = "bottom";
 
-  /**
-   * Set the size of the combobox
-   * @type {"sm" | "xl"}
-   */
-  export let size = undefined;
+/**
+ * Set the size of the combobox
+ * @type {"sm" | "xl"}
+ */
+export let size = undefined;
 
-  /** Set to `true` to disable the combobox */
-  export let disabled = false;
+/** Set to `true` to disable the combobox */
+export let disabled = false;
 
-  /** Specify the title text of the combobox */
-  export let titleText = "";
+/** Specify the title text of the combobox */
+export let titleText = "";
 
-  /** Specify the placeholder text */
-  export let placeholder = "";
+/** Specify the placeholder text */
+export let placeholder = "";
 
-  /** Specify the helper text */
-  export let helperText = "";
+/** Specify the helper text */
+export let helperText = "";
 
-  /** Specify the invalid state text */
-  export let invalidText = "";
+/** Specify the invalid state text */
+export let invalidText = "";
 
-  /** Set to `true` to indicate an invalid state */
-  export let invalid = false;
+/** Set to `true` to indicate an invalid state */
+export let invalid = false;
 
-  /** Set to `true` to indicate an warning state */
-  export let warn = false;
+/** Set to `true` to indicate an warning state */
+export let warn = false;
 
-  /** Specify the warning state text */
-  export let warnText = "";
+/** Specify the warning state text */
+export let warnText = "";
 
-  /** Set to `true` to enable the light variant */
-  export let light = false;
+/** Set to `true` to enable the light variant */
+export let light = false;
 
-  /** Set to `true` to open the combobox menu dropdown */
-  export let open = false;
+/** Set to `true` to open the combobox menu dropdown */
+export let open = false;
 
-  /**
-   * Determine if an item should be filtered given the current combobox value
-   * @type {(item: ComboBoxItem, value: string) => boolean}
-   */
-  export let shouldFilterItem = () => true;
+/**
+ * Determine if an item should be filtered given the current combobox value
+ * @type {(item: ComboBoxItem, value: string) => boolean}
+ */
+export let shouldFilterItem = () => true;
 
-  /**
-   * Override the chevron icon label based on the open state.
-   * Defaults to "Open menu" when closed and "Close menu" when open
-   * @type {(id: import("../ListBox/ListBoxMenuIcon.svelte").ListBoxMenuIconTranslationId) => string}
-   */
-  export let translateWithId = undefined;
+/**
+ * Override the chevron icon label based on the open state.
+ * Defaults to "Open menu" when closed and "Close menu" when open
+ * @type {(id: import("../ListBox/ListBoxMenuIcon.svelte").ListBoxMenuIconTranslationId) => string}
+ */
+export let translateWithId = undefined;
 
-  /**
-   * Override the label of the clear button when the input has a selection.
-   * Defaults to "Clear selected item" since a combo box can only have on selection.
-   * @type {(id: "clearSelection") => string}
-   */
-  export let translateWithIdSelection = undefined;
+/**
+ * Override the label of the clear button when the input has a selection.
+ * Defaults to "Clear selected item" since a combo box can only have on selection.
+ * @type {(id: "clearSelection") => string}
+ */
+export let translateWithIdSelection = undefined;
 
-  /** Set an id for the list box component */
-  export let id = "ccs-" + Math.random().toString(36);
+/** Set an id for the list box component */
+export let id = "ccs-" + Math.random().toString(36);
 
-  /**
-   * Specify a name attribute for the input
-   * @type {string}
-   */
-  export let name = undefined;
+/**
+ * Specify a name attribute for the input
+ * @type {string}
+ */
+export let name = undefined;
 
-  /** Obtain a reference to the input HTML element */
-  export let ref = null;
+/** Obtain a reference to the input HTML element */
+export let ref = null;
 
-  /**
-   * Obtain a reference to the list HTML element
-   * @type {null | HTMLDivElement}
-   */
-  export let listRef = null;
+/**
+ * Obtain a reference to the list HTML element
+ * @type {null | HTMLDivElement}
+ */
+export let listRef = null;
 
-  import { createEventDispatcher, afterUpdate, tick } from "svelte";
-  import Checkmark from "../icons/Checkmark.svelte";
-  import WarningFilled from "../icons/WarningFilled.svelte";
-  import WarningAltFilled from "../icons/WarningAltFilled.svelte";
-  import ListBox from "../ListBox/ListBox.svelte";
-  import ListBoxField from "../ListBox/ListBoxField.svelte";
-  import ListBoxMenu from "../ListBox/ListBoxMenu.svelte";
-  import ListBoxMenuIcon from "../ListBox/ListBoxMenuIcon.svelte";
-  import ListBoxMenuItem from "../ListBox/ListBoxMenuItem.svelte";
-  import ListBoxSelection from "../ListBox/ListBoxSelection.svelte";
+import { createEventDispatcher, afterUpdate, tick } from "svelte";
+import Checkmark from "../icons/Checkmark.svelte";
+import WarningFilled from "../icons/WarningFilled.svelte";
+import WarningAltFilled from "../icons/WarningAltFilled.svelte";
+import ListBox from "../ListBox/ListBox.svelte";
+import ListBoxField from "../ListBox/ListBoxField.svelte";
+import ListBoxMenu from "../ListBox/ListBoxMenu.svelte";
+import ListBoxMenuIcon from "../ListBox/ListBoxMenuIcon.svelte";
+import ListBoxMenuItem from "../ListBox/ListBoxMenuItem.svelte";
+import ListBoxSelection from "../ListBox/ListBoxSelection.svelte";
 
-  const dispatch = createEventDispatcher();
+const dispatch = createEventDispatcher();
 
-  let selectedItem = undefined;
-  let prevSelectedId = null;
-  let highlightedIndex = -1;
+let selectedItem = undefined;
+let prevSelectedId = null;
+let highlightedIndex = -1;
 
-  function change(dir) {
-    let index = highlightedIndex + dir;
-    let _items = !filteredItems?.length ? items : filteredItems;
-    if (_items.length === 0) return;
+function change(dir) {
+  let index = highlightedIndex + dir;
+  let _items = !filteredItems?.length ? items : filteredItems;
+  if (_items.length === 0) return;
+  if (index < 0) {
+    index = _items.length - 1;
+  } else if (index >= _items.length) {
+    index = 0;
+  }
+  let disabled = items[index].disabled;
+
+  while (disabled) {
+    index = index + dir;
+
     if (index < 0) {
-      index = _items.length - 1;
-    } else if (index >= _items.length) {
+      index = items.length - 1;
+    } else if (index >= items.length) {
       index = 0;
     }
-    let disabled = items[index].disabled;
 
-    while (disabled) {
-      index = index + dir;
-
-      if (index < 0) {
-        index = items.length - 1;
-      } else if (index >= items.length) {
-        index = 0;
-      }
-
-      disabled = items[index].disabled;
-    }
-
-    highlightedIndex = index;
+    disabled = items[index].disabled;
   }
 
-  /**
-   * Clear the combo box programmatically
-   * @type {(options?: { focus?: boolean; }) => void}
-   */
-  export function clear(options = {}) {
-    prevSelectedId = null;
-    highlightedIndex = -1;
-    highlightedId = undefined;
-    selectedId = undefined;
-    selectedItem = undefined;
-    open = false;
-    value = "";
-    if (options?.focus !== false) ref?.focus();
-  }
+  highlightedIndex = index;
+}
 
-  afterUpdate(() => {
-    if (open) {
-      ref.focus();
-      filteredItems = items.filter((item) => shouldFilterItem(item, value));
-    } else {
-      highlightedIndex = -1;
-      filteredItems = [];
-      if (!selectedItem) {
-        selectedId = undefined;
-        // Only reset value if the input is not focused
-        if (!ref.contains(document.activeElement)) {
-          value = "";
-        }
-        highlightedIndex = -1;
-        highlightedId = undefined;
-      } else {
-        // Only set value if the input is not focused
-        if (!ref.contains(document.activeElement)) {
-          // programmatically set value
-          value = itemToString(selectedItem);
-        }
-      }
-    }
-  });
+/**
+ * Clear the combo box programmatically
+ * @type {(options?: { focus?: boolean; }) => void}
+ */
+export function clear(options = {}) {
+  prevSelectedId = null;
+  highlightedIndex = -1;
+  highlightedId = undefined;
+  selectedId = undefined;
+  selectedItem = undefined;
+  open = false;
+  value = "";
+  if (options?.focus !== false) ref?.focus();
+}
 
-  $: if (selectedId !== undefined) {
-    if (prevSelectedId !== selectedId) {
-      prevSelectedId = selectedId;
-      if (filteredItems?.length === 1 && open) {
-        selectedId = filteredItems[0].id;
-        selectedItem = filteredItems[0];
-        highlightedIndex = -1;
-        highlightedId = undefined;
-      } else {
-        selectedItem = items.find((item) => item.id === selectedId);
-      }
-      dispatch("select", { selectedId, selectedItem });
-    }
+afterUpdate(() => {
+  if (open) {
+    ref.focus();
+    filteredItems = items.filter((item) => shouldFilterItem(item, value));
   } else {
-    prevSelectedId = selectedId;
-    selectedItem = undefined;
+    highlightedIndex = -1;
+    filteredItems = [];
+    if (!selectedItem) {
+      selectedId = undefined;
+      // Only reset value if the input is not focused
+      if (!ref.contains(document.activeElement)) {
+        value = "";
+      }
+      highlightedIndex = -1;
+      highlightedId = undefined;
+    } else {
+      // Only set value if the input is not focused
+      if (!ref.contains(document.activeElement)) {
+        // programmatically set value
+        value = itemToString(selectedItem);
+      }
+    }
   }
+});
 
-  $: ariaLabel = $$props["aria-label"] || "Choose an item";
-  $: menuId = `menu-${id}`;
-  $: comboId = `combo-${id}`;
-  $: highlightedId = items[highlightedIndex] ? items[highlightedIndex].id : 0;
-  $: filteredItems = items.filter((item) => shouldFilterItem(item, value));
+$: if (selectedId !== undefined) {
+  if (prevSelectedId !== selectedId) {
+    prevSelectedId = selectedId;
+    if (filteredItems?.length === 1 && open) {
+      selectedId = filteredItems[0].id;
+      selectedItem = filteredItems[0];
+      highlightedIndex = -1;
+      highlightedId = undefined;
+    } else {
+      selectedItem = items.find((item) => item.id === selectedId);
+    }
+    dispatch("select", { selectedId, selectedItem });
+  }
+} else {
+  prevSelectedId = selectedId;
+  selectedItem = undefined;
+}
+
+$: ariaLabel = $$props["aria-label"] || "Choose an item";
+$: menuId = `menu-${id}`;
+$: comboId = `combo-${id}`;
+$: highlightedId = items[highlightedIndex] ? items[highlightedIndex].id : 0;
+$: filteredItems = items.filter((item) => shouldFilterItem(item, value));
 </script>
 
 <svelte:window

--- a/src/ComposedModal/ComposedModal.svelte
+++ b/src/ComposedModal/ComposedModal.svelte
@@ -1,99 +1,99 @@
 <script>
-  /**
-   * @event {{ open: boolean; }} transitionend
-   */
+/**
+ * @event {{ open: boolean; }} transitionend
+ */
 
-  /**
-   * Set the size of the composed modal
-   * @type {"xs" | "sm" | "lg"}
-   */
-  export let size = undefined;
+/**
+ * Set the size of the composed modal
+ * @type {"xs" | "sm" | "lg"}
+ */
+export let size = undefined;
 
-  /** Set to `true` to open the modal */
-  export let open = false;
+/** Set to `true` to open the modal */
+export let open = false;
 
-  /** Set to `true` to use the danger variant */
-  export let danger = false;
+/** Set to `true` to use the danger variant */
+export let danger = false;
 
-  /** Set to `true` to prevent the modal from closing when clicking outside */
-  export let preventCloseOnClickOutside = false;
+/** Set to `true` to prevent the modal from closing when clicking outside */
+export let preventCloseOnClickOutside = false;
 
-  /** Specify a class for the inner modal */
-  export let containerClass = "";
+/** Specify a class for the inner modal */
+export let containerClass = "";
 
-  /**
-   * Specify a selector to be focused when opening the modal
-   * @type {null | string}
-   */
-  export let selectorPrimaryFocus = "[data-modal-primary-focus]";
+/**
+ * Specify a selector to be focused when opening the modal
+ * @type {null | string}
+ */
+export let selectorPrimaryFocus = "[data-modal-primary-focus]";
 
-  /** Obtain a reference to the top-level HTML element */
-  export let ref = null;
+/** Obtain a reference to the top-level HTML element */
+export let ref = null;
 
-  import {
-    createEventDispatcher,
-    tick,
-    setContext,
-    onMount,
-    afterUpdate,
-  } from "svelte";
-  import { writable } from "svelte/store";
-  import { trackModal } from "../Modal/modalStore";
+import {
+  createEventDispatcher,
+  tick,
+  setContext,
+  onMount,
+  afterUpdate,
+} from "svelte";
+import { writable } from "svelte/store";
+import { trackModal } from "../Modal/modalStore";
 
-  const dispatch = createEventDispatcher();
-  const label = writable(undefined);
+const dispatch = createEventDispatcher();
+const label = writable(undefined);
 
-  let buttonRef = null;
-  let innerModal = null;
-  let didClickInnerModal = false;
+let buttonRef = null;
+let innerModal = null;
+let didClickInnerModal = false;
 
-  setContext("ComposedModal", {
-    closeModal: () => {
-      open = false;
-    },
-    submit: () => {
-      dispatch("submit");
-      dispatch("click:button--primary");
-    },
-    declareRef: (ref) => {
-      buttonRef = ref;
-    },
-    updateLabel: (value) => {
-      label.set(value);
-    },
+setContext("ComposedModal", {
+  closeModal: () => {
+    open = false;
+  },
+  submit: () => {
+    dispatch("submit");
+    dispatch("click:button--primary");
+  },
+  declareRef: (ref) => {
+    buttonRef = ref;
+  },
+  updateLabel: (value) => {
+    label.set(value);
+  },
+});
+
+function focus(element) {
+  if (selectorPrimaryFocus == null) return;
+  const node =
+    (element || innerModal)?.querySelector(selectorPrimaryFocus) || buttonRef;
+  if (node != null) node.focus();
+}
+
+let opened = false;
+$: didOpen = open;
+
+const openStore = writable(open);
+$: $openStore = open;
+trackModal(openStore);
+
+onMount(() => {
+  tick().then(() => {
+    focus();
   });
+});
 
-  function focus(element) {
-    if (selectorPrimaryFocus == null) return;
-    const node =
-      (element || innerModal)?.querySelector(selectorPrimaryFocus) || buttonRef;
-    if (node != null) node.focus();
-  }
-
-  let opened = false;
-  $: didOpen = open;
-
-  const openStore = writable(open);
-  $: $openStore = open;
-  trackModal(openStore);
-
-  onMount(() => {
-    tick().then(() => {
-      focus();
-    });
-  });
-
-  afterUpdate(() => {
-    if (opened) {
-      if (!open) {
-        opened = false;
-        dispatch("close");
-      }
-    } else if (open) {
-      opened = true;
-      dispatch("open");
+afterUpdate(() => {
+  if (opened) {
+    if (!open) {
+      opened = false;
+      dispatch("close");
     }
-  });
+  } else if (open) {
+    opened = true;
+    dispatch("open");
+  }
+});
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->

--- a/src/ComposedModal/ModalBody.svelte
+++ b/src/ComposedModal/ModalBody.svelte
@@ -1,9 +1,9 @@
 <script>
-  /** Set to `true` if the modal contains form elements */
-  export let hasForm = false;
+/** Set to `true` if the modal contains form elements */
+export let hasForm = false;
 
-  /** Set to `true` if the modal contains scrolling content */
-  export let hasScrollingContent = false;
+/** Set to `true` if the modal contains scrolling content */
+export let hasScrollingContent = false;
 </script>
 
 <!-- svelte-ignore a11y-no-noninteractive-tabindex -->

--- a/src/ComposedModal/ModalFooter.svelte
+++ b/src/ComposedModal/ModalFooter.svelte
@@ -1,50 +1,50 @@
 <script>
-  /**
-   * @event {{ text: string; }} click:button--secondary
-   */
+/**
+ * @event {{ text: string; }} click:button--secondary
+ */
 
-  /** Specify the primary button text */
-  export let primaryButtonText = "";
+/** Specify the primary button text */
+export let primaryButtonText = "";
 
-  /**
-   * Specify the primary button icon
-   * @type {any}
-   */
-  export let primaryButtonIcon = undefined;
+/**
+ * Specify the primary button icon
+ * @type {any}
+ */
+export let primaryButtonIcon = undefined;
 
-  /** Set to `true` to disable the primary button */
-  export let primaryButtonDisabled = false;
+/** Set to `true` to disable the primary button */
+export let primaryButtonDisabled = false;
 
-  /**
-   * Specify a class for the primary button
-   * @type {string}
-   */
-  export let primaryClass = undefined;
+/**
+ * Specify a class for the primary button
+ * @type {string}
+ */
+export let primaryClass = undefined;
 
-  /** Specify the secondary button text */
-  export let secondaryButtonText = "";
+/** Specify the secondary button text */
+export let secondaryButtonText = "";
 
-  /**
-   * 2-tuple prop to render two secondary buttons for a 3 button modal
-   * supersedes `secondaryButtonText`
-   * @type {[{ text: string; }, { text: string; }]}
-   */
-  export let secondaryButtons = [];
+/**
+ * 2-tuple prop to render two secondary buttons for a 3 button modal
+ * supersedes `secondaryButtonText`
+ * @type {[{ text: string; }, { text: string; }]}
+ */
+export let secondaryButtons = [];
 
-  /**
-   * Specify a class for the secondary button
-   * @type {string}
-   */
-  export let secondaryClass = undefined;
+/**
+ * Specify a class for the secondary button
+ * @type {string}
+ */
+export let secondaryClass = undefined;
 
-  /** Set to `true` to use the danger variant */
-  export let danger = false;
+/** Set to `true` to use the danger variant */
+export let danger = false;
 
-  import { getContext, createEventDispatcher } from "svelte";
-  import Button from "../Button/Button.svelte";
+import { getContext, createEventDispatcher } from "svelte";
+import Button from "../Button/Button.svelte";
 
-  const dispatch = createEventDispatcher();
-  const { closeModal, submit } = getContext("ComposedModal");
+const dispatch = createEventDispatcher();
+const { closeModal, submit } = getContext("ComposedModal");
 </script>
 
 <div

--- a/src/ComposedModal/ModalHeader.svelte
+++ b/src/ComposedModal/ModalHeader.svelte
@@ -1,31 +1,31 @@
 <script>
-  /** Specify the modal title */
-  export let title = "";
+/** Specify the modal title */
+export let title = "";
 
-  /** Specify the modal label */
-  export let label = "";
+/** Specify the modal label */
+export let label = "";
 
-  /** Specify the label class */
-  export let labelClass = "";
+/** Specify the label class */
+export let labelClass = "";
 
-  /** Specify the title class */
-  export let titleClass = "";
+/** Specify the title class */
+export let titleClass = "";
 
-  /** Specify the close class */
-  export let closeClass = "";
+/** Specify the close class */
+export let closeClass = "";
 
-  /** Specify the close icon class */
-  export let closeIconClass = "";
+/** Specify the close icon class */
+export let closeIconClass = "";
 
-  /** Specify the ARIA label for the close icon */
-  export let iconDescription = "Close";
+/** Specify the ARIA label for the close icon */
+export let iconDescription = "Close";
 
-  import { getContext } from "svelte";
-  import Close from "../icons/Close.svelte";
+import { getContext } from "svelte";
+import Close from "../icons/Close.svelte";
 
-  const { closeModal, updateLabel } = getContext("ComposedModal");
+const { closeModal, updateLabel } = getContext("ComposedModal");
 
-  $: updateLabel(label);
+$: updateLabel(label);
 </script>
 
 <div class:bx--modal-header={true} {...$$restProps}>

--- a/src/ContentSwitcher/ContentSwitcher.svelte
+++ b/src/ContentSwitcher/ContentSwitcher.svelte
@@ -1,60 +1,60 @@
 <script>
-  /**
-   * @event {number} change
-   */
+/**
+ * @event {number} change
+ */
 
-  /** Set the selected index of the switch item */
-  export let selectedIndex = 0;
+/** Set the selected index of the switch item */
+export let selectedIndex = 0;
 
-  /**
-   * Specify the size of the content switcher
-   * @type {"sm" | "xl"}
-   */
-  export let size = undefined;
+/**
+ * Specify the size of the content switcher
+ * @type {"sm" | "xl"}
+ */
+export let size = undefined;
 
-  import { afterUpdate, createEventDispatcher, setContext } from "svelte";
-  import { writable } from "svelte/store";
+import { afterUpdate, createEventDispatcher, setContext } from "svelte";
+import { writable } from "svelte/store";
 
-  const dispatch = createEventDispatcher();
-  const currentId = writable(null);
+const dispatch = createEventDispatcher();
+const currentId = writable(null);
 
-  $: currentIndex = -1;
-  $: switches = [];
-  $: if (switches[currentIndex]) {
-    dispatch("change", currentIndex);
-    currentId.set(switches[currentIndex].id);
-  }
+$: currentIndex = -1;
+$: switches = [];
+$: if (switches[currentIndex]) {
+  dispatch("change", currentIndex);
+  currentId.set(switches[currentIndex].id);
+}
 
-  setContext("ContentSwitcher", {
-    currentId,
-    add: ({ id, text, selected }) => {
-      if (selected) {
-        selectedIndex = switches.length;
-      }
-
-      switches = [...switches, { id, text, selected }];
-    },
-    update: (id) => {
-      selectedIndex = switches.map(({ id }) => id).indexOf(id);
-    },
-    change: (direction) => {
-      let index = currentIndex + direction;
-
-      if (index < 0) {
-        index = switches.length - 1;
-      } else if (index >= switches.length) {
-        index = 0;
-      }
-
-      selectedIndex = index;
-    },
-  });
-
-  afterUpdate(() => {
-    if (selectedIndex !== currentIndex) {
-      currentIndex = selectedIndex;
+setContext("ContentSwitcher", {
+  currentId,
+  add: ({ id, text, selected }) => {
+    if (selected) {
+      selectedIndex = switches.length;
     }
-  });
+
+    switches = [...switches, { id, text, selected }];
+  },
+  update: (id) => {
+    selectedIndex = switches.map(({ id }) => id).indexOf(id);
+  },
+  change: (direction) => {
+    let index = currentIndex + direction;
+
+    if (index < 0) {
+      index = switches.length - 1;
+    } else if (index >= switches.length) {
+      index = 0;
+    }
+
+    selectedIndex = index;
+  },
+});
+
+afterUpdate(() => {
+  if (selectedIndex !== currentIndex) {
+    currentIndex = selectedIndex;
+  }
+});
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->

--- a/src/ContentSwitcher/Switch.svelte
+++ b/src/ContentSwitcher/Switch.svelte
@@ -1,41 +1,41 @@
 <script>
-  /**
-   * Specify the switch text.
-   * Alternatively, use the "text" slot  (e.g., `<span slot="text">...</span>`)
-   */
-  export let text = "Provide text";
+/**
+ * Specify the switch text.
+ * Alternatively, use the "text" slot  (e.g., `<span slot="text">...</span>`)
+ */
+export let text = "Provide text";
 
-  /** Set to `true` for the switch to be selected */
-  export let selected = false;
+/** Set to `true` for the switch to be selected */
+export let selected = false;
 
-  /** Set to `true` to disable the switch */
-  export let disabled = false;
+/** Set to `true` to disable the switch */
+export let disabled = false;
 
-  /** Set an id for the button element */
-  export let id = "ccs-" + Math.random().toString(36);
+/** Set an id for the button element */
+export let id = "ccs-" + Math.random().toString(36);
 
-  /** Obtain a reference to the button HTML element */
-  export let ref = null;
+/** Obtain a reference to the button HTML element */
+export let ref = null;
 
-  import { afterUpdate, getContext, onMount } from "svelte";
+import { afterUpdate, getContext, onMount } from "svelte";
 
-  const ctx = getContext("ContentSwitcher");
+const ctx = getContext("ContentSwitcher");
 
-  ctx.add({ id, text, selected });
+ctx.add({ id, text, selected });
 
-  const unsubscribe = ctx.currentId.subscribe((currentId) => {
-    selected = currentId === id;
-  });
+const unsubscribe = ctx.currentId.subscribe((currentId) => {
+  selected = currentId === id;
+});
 
-  afterUpdate(() => {
-    if (selected) {
-      ref.focus();
-    }
-  });
+afterUpdate(() => {
+  if (selected) {
+    ref.focus();
+  }
+});
 
-  onMount(() => {
-    return () => unsubscribe();
-  });
+onMount(() => {
+  return () => unsubscribe();
+});
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->

--- a/src/ContextMenu/ContextMenu.svelte
+++ b/src/ContextMenu/ContextMenu.svelte
@@ -1,141 +1,141 @@
 <script>
-  /**
-   * @event {HTMLElement} open
-   */
+/**
+ * @event {HTMLElement} open
+ */
 
-  /**
-   * Specify an element or list of elements to trigger the context menu.
-   * If no element is specified, the context menu applies to the entire window
-   * @type {null | ReadonlyArray<null | HTMLElement>}
-   */
-  export let target = null;
+/**
+ * Specify an element or list of elements to trigger the context menu.
+ * If no element is specified, the context menu applies to the entire window
+ * @type {null | ReadonlyArray<null | HTMLElement>}
+ */
+export let target = null;
 
-  /**
-   * Set to `true` to open the menu
-   * Either `x` and `y` must be greater than zero
-   */
-  export let open = false;
+/**
+ * Set to `true` to open the menu
+ * Either `x` and `y` must be greater than zero
+ */
+export let open = false;
 
-  /** Specify the horizontal offset of the menu position */
-  export let x = 0;
+/** Specify the horizontal offset of the menu position */
+export let x = 0;
 
-  /** Specify the vertical offset of the menu position */
-  export let y = 0;
+/** Specify the vertical offset of the menu position */
+export let y = 0;
 
-  /** Obtain a reference to the unordered list HTML element */
-  export let ref = null;
+/** Obtain a reference to the unordered list HTML element */
+export let ref = null;
 
-  import {
-    onMount,
-    setContext,
-    getContext,
-    afterUpdate,
-    createEventDispatcher,
-  } from "svelte";
-  import { writable } from "svelte/store";
+import {
+  onMount,
+  setContext,
+  getContext,
+  afterUpdate,
+  createEventDispatcher,
+} from "svelte";
+import { writable } from "svelte/store";
 
-  const dispatch = createEventDispatcher();
-  const position = writable([x, y]);
-  const currentIndex = writable(-1);
-  const hasPopup = writable(false);
-  const menuOffsetX = writable(0);
-  const ctx = getContext("ContextMenu");
+const dispatch = createEventDispatcher();
+const position = writable([x, y]);
+const currentIndex = writable(-1);
+const hasPopup = writable(false);
+const menuOffsetX = writable(0);
+const ctx = getContext("ContextMenu");
 
-  let options = [];
-  let direction = 1;
-  let prevX = 0;
-  let prevY = 0;
-  let focusIndex = -1;
-  let openDetail = null;
+let options = [];
+let direction = 1;
+let prevX = 0;
+let prevY = 0;
+let focusIndex = -1;
+let openDetail = null;
 
-  function close() {
-    open = false;
-    x = 0;
-    y = 0;
-    prevX = 0;
-    prevY = 0;
-    focusIndex = -1;
-  }
+function close() {
+  open = false;
+  x = 0;
+  y = 0;
+  prevX = 0;
+  prevY = 0;
+  focusIndex = -1;
+}
 
-  /** @type {(e: MouseEvent) => void} */
-  function openMenu(e) {
-    e.preventDefault();
-    const { height, width } = ref.getBoundingClientRect();
+/** @type {(e: MouseEvent) => void} */
+function openMenu(e) {
+  e.preventDefault();
+  const { height, width } = ref.getBoundingClientRect();
 
-    if (open || x === 0) {
-      if (window.innerWidth - width < e.x) {
-        x = e.x - width;
-      } else {
-        x = e.x;
-      }
-    }
-
-    if (open || y === 0) {
-      menuOffsetX.set(e.x);
-
-      if (window.innerHeight - height < e.y) {
-        y = e.y - height;
-      } else {
-        y = e.y;
-      }
-    }
-    position.set([x, y]);
-    open = true;
-    openDetail = e.target;
-  }
-
-  $: if (target != null) {
-    if (Array.isArray(target)) {
-      target.forEach((node) => node?.addEventListener("contextmenu", openMenu));
+  if (open || x === 0) {
+    if (window.innerWidth - width < e.x) {
+      x = e.x - width;
     } else {
-      target.addEventListener("contextmenu", openMenu);
+      x = e.x;
     }
   }
 
-  onMount(() => {
-    return () => {
-      if (target != null) {
-        if (Array.isArray(target)) {
-          target.forEach((node) =>
-            node?.removeEventListener("contextmenu", openMenu),
-          );
-        } else {
-          target.removeEventListener("contextmenu", openMenu);
-        }
-      }
-    };
-  });
+  if (open || y === 0) {
+    menuOffsetX.set(e.x);
 
-  setContext("ContextMenu", {
-    menuOffsetX,
-    currentIndex,
-    position,
-    close,
-    setPopup: (popup) => {
-      hasPopup.set(popup);
-    },
-  });
-
-  afterUpdate(() => {
-    if (open) {
-      options = [...ref.querySelectorAll("li[data-nested='false']")];
-
-      if (level === 1) {
-        if (prevX !== x || prevY !== y) ref.focus();
-        prevX = x;
-        prevY = y;
-      }
-
-      dispatch("open", openDetail);
+    if (window.innerHeight - height < e.y) {
+      y = e.y - height;
     } else {
-      dispatch("close");
+      y = e.y;
+    }
+  }
+  position.set([x, y]);
+  open = true;
+  openDetail = e.target;
+}
+
+$: if (target != null) {
+  if (Array.isArray(target)) {
+    target.forEach((node) => node?.addEventListener("contextmenu", openMenu));
+  } else {
+    target.addEventListener("contextmenu", openMenu);
+  }
+}
+
+onMount(() => {
+  return () => {
+    if (target != null) {
+      if (Array.isArray(target)) {
+        target.forEach((node) =>
+          node?.removeEventListener("contextmenu", openMenu),
+        );
+      } else {
+        target.removeEventListener("contextmenu", openMenu);
+      }
+    }
+  };
+});
+
+setContext("ContextMenu", {
+  menuOffsetX,
+  currentIndex,
+  position,
+  close,
+  setPopup: (popup) => {
+    hasPopup.set(popup);
+  },
+});
+
+afterUpdate(() => {
+  if (open) {
+    options = [...ref.querySelectorAll("li[data-nested='false']")];
+
+    if (level === 1) {
+      if (prevX !== x || prevY !== y) ref.focus();
+      prevX = x;
+      prevY = y;
     }
 
-    if (!$hasPopup && options[focusIndex]) options[focusIndex].focus();
-  });
+    dispatch("open", openDetail);
+  } else {
+    dispatch("close");
+  }
 
-  $: level = !ctx ? 1 : 2;
-  $: currentIndex.set(focusIndex);
+  if (!$hasPopup && options[focusIndex]) options[focusIndex].focus();
+});
+
+$: level = !ctx ? 1 : 2;
+$: currentIndex.set(focusIndex);
 </script>
 
 <svelte:window

--- a/src/ContextMenu/ContextMenuGroup.svelte
+++ b/src/ContextMenu/ContextMenuGroup.svelte
@@ -1,32 +1,32 @@
 <script>
-  /** @type {ReadonlyArray<string>} */
-  export let selectedIds = [];
+/** @type {ReadonlyArray<string>} */
+export let selectedIds = [];
 
-  /** Specify the label text */
-  export let labelText = "";
+/** Specify the label text */
+export let labelText = "";
 
-  import { setContext } from "svelte";
-  import { writable } from "svelte/store";
+import { setContext } from "svelte";
+import { writable } from "svelte/store";
 
-  const currentIds = writable([]);
+const currentIds = writable([]);
 
-  setContext("ContextMenuGroup", {
-    currentIds,
-    addOption: ({ id }) => {
-      if (!selectedIds.includes(id)) {
-        selectedIds = [...selectedIds, id];
-      }
-    },
-    toggleOption: ({ id }) => {
-      if (!selectedIds.includes(id)) {
-        selectedIds = [...selectedIds, id];
-      } else {
-        selectedIds = selectedIds.filter((_) => _ !== id);
-      }
-    },
-  });
+setContext("ContextMenuGroup", {
+  currentIds,
+  addOption: ({ id }) => {
+    if (!selectedIds.includes(id)) {
+      selectedIds = [...selectedIds, id];
+    }
+  },
+  toggleOption: ({ id }) => {
+    if (!selectedIds.includes(id)) {
+      selectedIds = [...selectedIds, id];
+    } else {
+      selectedIds = selectedIds.filter((_) => _ !== id);
+    }
+  },
+});
 
-  $: currentIds.set(selectedIds);
+$: currentIds.set(selectedIds);
 </script>
 
 <li role="none">

--- a/src/ContextMenu/ContextMenuOption.svelte
+++ b/src/ContextMenu/ContextMenuOption.svelte
@@ -1,169 +1,169 @@
 <script>
-  /**
-   * Specify the kind of option
-   * @type {"default" | "danger"}
-   */
-  export let kind = "default";
+/**
+ * Specify the kind of option
+ * @type {"default" | "danger"}
+ */
+export let kind = "default";
 
-  /** Set to `true` to enable the disabled state */
-  export let disabled = false;
+/** Set to `true` to enable the disabled state */
+export let disabled = false;
 
-  /** Set to `true` to indent the label */
-  export let indented = false;
+/** Set to `true` to indent the label */
+export let indented = false;
 
-  /**
-   * Specify the icon to render
-   * Icon is rendered to the left of the label text
-   * @type {any}
-   */
-  export let icon = undefined;
+/**
+ * Specify the icon to render
+ * Icon is rendered to the left of the label text
+ * @type {any}
+ */
+export let icon = undefined;
 
-  /**
-   * Specify the label text.
-   * Alternatively, use the "labelText" slot (e.g., `<span slot="labelText">...</span>`)
-   */
-  export let labelText = "";
+/**
+ * Specify the label text.
+ * Alternatively, use the "labelText" slot (e.g., `<span slot="labelText">...</span>`)
+ */
+export let labelText = "";
 
-  /** Set to `true` to use the selected variant */
-  export let selected = false;
+/** Set to `true` to use the selected variant */
+export let selected = false;
 
-  /**
-   * Set to `true` to enable the selectable variant
-   * Automatically set to `true` if `selected` is `true`
-   */
-  export let selectable = false;
+/**
+ * Set to `true` to enable the selectable variant
+ * Automatically set to `true` if `selected` is `true`
+ */
+export let selectable = false;
 
-  /**
-   * Specify the shortcut text.
-   * Alternatively, use the "shortcutText" slot (e.g., `<span slot="shortcutText">...</span>`)
-   */
-  export let shortcutText = "";
+/**
+ * Specify the shortcut text.
+ * Alternatively, use the "shortcutText" slot (e.g., `<span slot="shortcutText">...</span>`)
+ */
+export let shortcutText = "";
 
-  /**
-   * Specify the id
-   * It's recommended to provide an id as a value to bind to within a selectable/radio menu group
-   */
-  export let id = "ccs-" + Math.random().toString(36);
+/**
+ * Specify the id
+ * It's recommended to provide an id as a value to bind to within a selectable/radio menu group
+ */
+export let id = "ccs-" + Math.random().toString(36);
 
-  /** Obtain a reference to the list item HTML element */
-  export let ref = null;
+/** Obtain a reference to the list item HTML element */
+export let ref = null;
 
-  import { onMount, getContext, createEventDispatcher, tick } from "svelte";
-  import ContextMenu from "./ContextMenu.svelte";
-  import Checkmark from "../icons/Checkmark.svelte";
-  import CaretRight from "../icons/CaretRight.svelte";
+import { onMount, getContext, createEventDispatcher, tick } from "svelte";
+import ContextMenu from "./ContextMenu.svelte";
+import Checkmark from "../icons/Checkmark.svelte";
+import CaretRight from "../icons/CaretRight.svelte";
 
-  const dispatch = createEventDispatcher();
-  const ctx = getContext("ContextMenu");
-  const ctxGroup = getContext("ContextMenuGroup");
-  const ctxRadioGroup = getContext("ContextMenuRadioGroup");
+const dispatch = createEventDispatcher();
+const ctx = getContext("ContextMenu");
+const ctxGroup = getContext("ContextMenuGroup");
+const ctxRadioGroup = getContext("ContextMenuRadioGroup");
 
-  // "moderate-01" duration (ms) from Carbon motion recommended for small expansion, short distance movements
-  const moderate01 = 150;
+// "moderate-01" duration (ms) from Carbon motion recommended for small expansion, short distance movements
+const moderate01 = 150;
 
-  let unsubCurrentIds = undefined;
-  let unsubCurrentId = undefined;
-  let timeoutHover = undefined;
-  let rootMenuPosition = [0, 0];
-  let focusIndex = 0;
-  let options = [];
-  let role = "menuitem";
-  let submenuOpen = false;
-  let submenuPosition = [0, 0];
-  let menuOffsetX = 0;
+let unsubCurrentIds = undefined;
+let unsubCurrentId = undefined;
+let timeoutHover = undefined;
+let rootMenuPosition = [0, 0];
+let focusIndex = 0;
+let options = [];
+let role = "menuitem";
+let submenuOpen = false;
+let submenuPosition = [0, 0];
+let menuOffsetX = 0;
 
-  const unsubPosition = ctx.position.subscribe((position) => {
-    rootMenuPosition = position;
-  });
+const unsubPosition = ctx.position.subscribe((position) => {
+  rootMenuPosition = position;
+});
 
-  const unsubMenuOffsetX = ctx.menuOffsetX.subscribe((_menuOffsetX) => {
-    menuOffsetX = _menuOffsetX;
-  });
+const unsubMenuOffsetX = ctx.menuOffsetX.subscribe((_menuOffsetX) => {
+  menuOffsetX = _menuOffsetX;
+});
 
-  function handleClick(opts = {}) {
-    if (disabled) return ctx.close();
-    if (subOptions) return;
+function handleClick(opts = {}) {
+  if (disabled) return ctx.close();
+  if (subOptions) return;
 
-    if (!!ctxGroup) {
-      ctxGroup.toggleOption({ id });
-    } else if (!!ctxRadioGroup) {
-      if (opts.fromKeyboard) {
-        ctxRadioGroup.setOption({ id: opts.id });
-      } else {
-        ctxRadioGroup.setOption({ id });
-      }
+  if (!!ctxGroup) {
+    ctxGroup.toggleOption({ id });
+  } else if (!!ctxRadioGroup) {
+    if (opts.fromKeyboard) {
+      ctxRadioGroup.setOption({ id: opts.id });
     } else {
-      selected = !selected;
+      ctxRadioGroup.setOption({ id });
     }
-
-    ctx.close();
-    dispatch("click");
+  } else {
+    selected = !selected;
   }
 
-  onMount(() => {
-    if (selected === true) selectable = true;
+  ctx.close();
+  dispatch("click");
+}
 
-    if (ctxGroup) {
-      unsubCurrentIds = ctxGroup.currentIds.subscribe((_currentIds) => {
-        selected = _currentIds.includes(id);
-      });
-    }
+onMount(() => {
+  if (selected === true) selectable = true;
 
-    if (ctxRadioGroup) {
-      unsubCurrentId = ctxRadioGroup.currentId.subscribe((_id) => {
-        selected = id === _id;
-      });
-    }
-
-    return () => {
-      unsubPosition();
-      unsubMenuOffsetX();
-      if (unsubCurrentIds) unsubCurrentIds();
-      if (unsubCurrentId) unsubCurrentId();
-      if (typeof timeoutHover === "number") clearTimeout(timeoutHover);
-    };
-  });
-
-  $: isSelectable = !!ctxGroup || selectable;
-  $: isRadio = !!ctxRadioGroup;
-  $: subOptions = $$slots.default;
-  $: ctx.setPopup(submenuOpen);
-  $: if (submenuOpen) {
-    const { width, y } = ref.getBoundingClientRect();
-    let x = rootMenuPosition[0] + width;
-
-    if (window.innerWidth - menuOffsetX < width) {
-      x = rootMenuPosition[0] - width;
-    }
-
-    submenuPosition = [x, y];
+  if (ctxGroup) {
+    unsubCurrentIds = ctxGroup.currentIds.subscribe((_currentIds) => {
+      selected = _currentIds.includes(id);
+    });
   }
-  $: {
-    if (isSelectable) {
-      indented = true;
-      role = "menuitemcheckbox";
 
-      if (selected) {
-        if (ctxGroup) ctxGroup.addOption({ id });
-        icon = Checkmark;
-      } else {
-        icon = undefined;
-      }
-    }
+  if (ctxRadioGroup) {
+    unsubCurrentId = ctxRadioGroup.currentId.subscribe((_id) => {
+      selected = id === _id;
+    });
+  }
 
-    if (isRadio) {
-      indented = true;
-      role = "menuitemradio";
-      ctxRadioGroup.addOption({ id });
+  return () => {
+    unsubPosition();
+    unsubMenuOffsetX();
+    if (unsubCurrentIds) unsubCurrentIds();
+    if (unsubCurrentId) unsubCurrentId();
+    if (typeof timeoutHover === "number") clearTimeout(timeoutHover);
+  };
+});
 
-      if (selected) {
-        if (ctxRadioGroup) ctxRadioGroup.setOption({ id });
-        icon = Checkmark;
-      } else {
-        icon = undefined;
-      }
+$: isSelectable = !!ctxGroup || selectable;
+$: isRadio = !!ctxRadioGroup;
+$: subOptions = $$slots.default;
+$: ctx.setPopup(submenuOpen);
+$: if (submenuOpen) {
+  const { width, y } = ref.getBoundingClientRect();
+  let x = rootMenuPosition[0] + width;
+
+  if (window.innerWidth - menuOffsetX < width) {
+    x = rootMenuPosition[0] - width;
+  }
+
+  submenuPosition = [x, y];
+}
+$: {
+  if (isSelectable) {
+    indented = true;
+    role = "menuitemcheckbox";
+
+    if (selected) {
+      if (ctxGroup) ctxGroup.addOption({ id });
+      icon = Checkmark;
+    } else {
+      icon = undefined;
     }
   }
+
+  if (isRadio) {
+    indented = true;
+    role = "menuitemradio";
+    ctxRadioGroup.addOption({ id });
+
+    if (selected) {
+      if (ctxRadioGroup) ctxRadioGroup.setOption({ id });
+      icon = Checkmark;
+    } else {
+      icon = undefined;
+    }
+  }
+}
 </script>
 
 <li

--- a/src/ContextMenu/ContextMenuRadioGroup.svelte
+++ b/src/ContextMenu/ContextMenuRadioGroup.svelte
@@ -1,30 +1,30 @@
 <script>
-  /** Set the selected radio group id */
-  export let selectedId = "";
+/** Set the selected radio group id */
+export let selectedId = "";
 
-  /** Specify the label text */
-  export let labelText = "";
+/** Specify the label text */
+export let labelText = "";
 
-  import { setContext } from "svelte";
-  import { writable } from "svelte/store";
+import { setContext } from "svelte";
+import { writable } from "svelte/store";
 
-  const currentId = writable("");
-  const radioIds = writable([]);
+const currentId = writable("");
+const radioIds = writable([]);
 
-  setContext("ContextMenuRadioGroup", {
-    currentId,
-    radioIds,
-    addOption: ({ id }) => {
-      if (!$radioIds.includes(id)) {
-        radioIds.update((_) => [..._, id]);
-      }
-    },
-    setOption: ({ id }) => {
-      selectedId = id;
-    },
-  });
+setContext("ContextMenuRadioGroup", {
+  currentId,
+  radioIds,
+  addOption: ({ id }) => {
+    if (!$radioIds.includes(id)) {
+      radioIds.update((_) => [..._, id]);
+    }
+  },
+  setOption: ({ id }) => {
+    selectedId = id;
+  },
+});
 
-  $: currentId.set(selectedId);
+$: currentId.set(selectedId);
 </script>
 
 <li role="none">

--- a/src/CopyButton/CopyButton.svelte
+++ b/src/CopyButton/CopyButton.svelte
@@ -1,43 +1,43 @@
 <script>
-  /** Set the feedback text shown after clicking the button */
-  export let feedback = "Copied!";
+/** Set the feedback text shown after clicking the button */
+export let feedback = "Copied!";
 
-  /** Set the timeout duration (ms) to display feedback text */
-  export let feedbackTimeout = 2000;
+/** Set the timeout duration (ms) to display feedback text */
+export let feedbackTimeout = 2000;
 
-  /** Set the title and ARIA label for the copy button */
-  export let iconDescription = "Copy to clipboard";
+/** Set the title and ARIA label for the copy button */
+export let iconDescription = "Copy to clipboard";
 
-  /**
-   * Specify the text to copy
-   * @type {string}
-   */
-  export let text;
+/**
+ * Specify the text to copy
+ * @type {string}
+ */
+export let text;
 
-  /**
-   * Override the default copy behavior of using the navigator.clipboard.writeText API to copy text
-   * @type {(text: string) => void}
-   */
-  export let copy = async (text) => {
-    try {
-      await navigator.clipboard.writeText(text);
-    } catch (e) {
-      console.log(e);
-    }
-  };
+/**
+ * Override the default copy behavior of using the navigator.clipboard.writeText API to copy text
+ * @type {(text: string) => void}
+ */
+export let copy = async (text) => {
+  try {
+    await navigator.clipboard.writeText(text);
+  } catch (e) {
+    console.log(e);
+  }
+};
 
-  import { createEventDispatcher, onMount } from "svelte";
-  import Copy from "../icons/Copy.svelte";
+import { createEventDispatcher, onMount } from "svelte";
+import Copy from "../icons/Copy.svelte";
 
-  const dispatch = createEventDispatcher();
+const dispatch = createEventDispatcher();
 
-  /** @type {"fade-in" | "fade-out"} */
-  let animation = undefined;
-  let timeout = undefined;
+/** @type {"fade-in" | "fade-out"} */
+let animation = undefined;
+let timeout = undefined;
 
-  onMount(() => {
-    return () => clearTimeout(timeout);
-  });
+onMount(() => {
+  return () => clearTimeout(timeout);
+});
 </script>
 
 <button

--- a/src/DataTable/DataTable.svelte
+++ b/src/DataTable/DataTable.svelte
@@ -1,329 +1,319 @@
 <script>
-  /**
-   * @generics {Row extends DataTableRow = DataTableRow} Row
-   * @template {DataTableRow} Row
-   * @typedef {import('./DataTableTypes.d.ts').PropertyPath<Row>} DataTableKey<Row=DataTableRow>
-   * @typedef {any} DataTableValue
-   * @typedef {{
-   *    key: DataTableKey<Row> | (string & {});
-   *    empty: boolean;
-   *    display?: (item: DataTableValue, row: Row) => DataTableValue;
-   *    sort?: false | ((a: DataTableValue, b: DataTableValue) => number);
-   *    columnMenu?: boolean;
-   *    width?: string;
-   *    minWidth?: string;
-   * }} DataTableEmptyHeader<Row=DataTableRow>
-   * @typedef {{
-   *    key: DataTableKey<Row>;
-   *    value: DataTableValue;
-   *    display?: (item: DataTableValue, row: Row) => DataTableValue;
-   *    sort?: false | ((a: DataTableValue, b: DataTableValue) => number);
-   *    columnMenu?: boolean;
-   *    width?: string;
-   *    minWidth?: string;
-   * }} DataTableNonEmptyHeader<Row=DataTableRow>
-   * @typedef {DataTableNonEmptyHeader<Row> | DataTableEmptyHeader<Row>} DataTableHeader<Row=DataTableRow>
-   * @typedef {{ id: any; [key: string]: DataTableValue; }} DataTableRow
-   * @typedef {any} DataTableRowId
-   * @typedef {{
-   *    key: DataTableKey<Row> | (string & {});
-   *    value: DataTableValue;
-   *    display?: (item: DataTableValue, row: DataTableRow) => DataTableValue;
-   * }} DataTableCell<Row=DataTableRow>
-   * @slot {{ row: Row; }} expanded-row
-   * @slot {{ header: DataTableNonEmptyHeader; }} cell-header
-   * @slot {{ row: Row; cell: DataTableCell<Row>; rowIndex: number; cellIndex: number; }} cell
-   * @event {{ header?: DataTableHeader<Row>; row?: Row; cell?: DataTableCell<Row>; }} click
-   * @event {{ expanded: boolean; }} click:header--expand
-   * @event {{ header: DataTableHeader<Row>; sortDirection?: "ascending" | "descending" | "none" }} click:header
-   * @event {{ indeterminate: boolean; selected: boolean; }} click:header--select
-   * @event {Row} click:row
-   * @event {Row} mouseenter:row
-   * @event {Row} mouseleave:row
-   * @event {{ expanded: boolean; row: Row; }} click:row--expand
-   * @event {{ selected: boolean; row: Row; }} click:row--select
-   * @event {DataTableCell<Row>} click:cell
-   * @restProps {div}
-   */
+/**
+ * @generics {Row extends DataTableRow = DataTableRow} Row
+ * @template {DataTableRow} Row
+ * @typedef {import('./DataTableTypes.d.ts').PropertyPath<Row>} DataTableKey<Row=DataTableRow>
+ * @typedef {any} DataTableValue
+ * @typedef {{
+ *    key: DataTableKey<Row> | (string & {});
+ *    empty: boolean;
+ *    display?: (item: DataTableValue, row: Row) => DataTableValue;
+ *    sort?: false | ((a: DataTableValue, b: DataTableValue) => number);
+ *    columnMenu?: boolean;
+ *    width?: string;
+ *    minWidth?: string;
+ * }} DataTableEmptyHeader<Row=DataTableRow>
+ * @typedef {{
+ *    key: DataTableKey<Row>;
+ *    value: DataTableValue;
+ *    display?: (item: DataTableValue, row: Row) => DataTableValue;
+ *    sort?: false | ((a: DataTableValue, b: DataTableValue) => number);
+ *    columnMenu?: boolean;
+ *    width?: string;
+ *    minWidth?: string;
+ * }} DataTableNonEmptyHeader<Row=DataTableRow>
+ * @typedef {DataTableNonEmptyHeader<Row> | DataTableEmptyHeader<Row>} DataTableHeader<Row=DataTableRow>
+ * @typedef {{ id: any; [key: string]: DataTableValue; }} DataTableRow
+ * @typedef {any} DataTableRowId
+ * @typedef {{
+ *    key: DataTableKey<Row> | (string & {});
+ *    value: DataTableValue;
+ *    display?: (item: DataTableValue, row: DataTableRow) => DataTableValue;
+ * }} DataTableCell<Row=DataTableRow>
+ * @slot {{ row: Row; }} expanded-row
+ * @slot {{ header: DataTableNonEmptyHeader; }} cell-header
+ * @slot {{ row: Row; cell: DataTableCell<Row>; rowIndex: number; cellIndex: number; }} cell
+ * @event {{ header?: DataTableHeader<Row>; row?: Row; cell?: DataTableCell<Row>; }} click
+ * @event {{ expanded: boolean; }} click:header--expand
+ * @event {{ header: DataTableHeader<Row>; sortDirection?: "ascending" | "descending" | "none" }} click:header
+ * @event {{ indeterminate: boolean; selected: boolean; }} click:header--select
+ * @event {Row} click:row
+ * @event {Row} mouseenter:row
+ * @event {Row} mouseleave:row
+ * @event {{ expanded: boolean; row: Row; }} click:row--expand
+ * @event {{ selected: boolean; row: Row; }} click:row--select
+ * @event {DataTableCell<Row>} click:cell
+ * @restProps {div}
+ */
 
-  /**
-   * Specify the data table headers
-   * @type {ReadonlyArray<DataTableHeader<Row>>}
-   */
-  export let headers = [];
+/**
+ * Specify the data table headers
+ * @type {ReadonlyArray<DataTableHeader<Row>>}
+ */
+export let headers = [];
 
-  /**
-   * Specify the rows the data table should render
-   * keys defined in `headers` are used for the row ids
-   * @type {ReadonlyArray<Row>}
-   */
-  export let rows = [];
+/**
+ * Specify the rows the data table should render
+ * keys defined in `headers` are used for the row ids
+ * @type {ReadonlyArray<Row>}
+ */
+export let rows = [];
 
-  /**
-   * Set the size of the data table
-   * @type {"compact" | "short" | "medium" | "tall"}
-   */
-  export let size = undefined;
+/**
+ * Set the size of the data table
+ * @type {"compact" | "short" | "medium" | "tall"}
+ */
+export let size = undefined;
 
-  /** Specify the title of the data table */
-  export let title = "";
+/** Specify the title of the data table */
+export let title = "";
 
-  /** Specify the description of the data table */
-  export let description = "";
+/** Specify the description of the data table */
+export let description = "";
 
-  /**
-   * Specify a name attribute for the input elements
-   * in a selectable data table (radio or checkbox).
-   * When the table is inside a form, this name will
-   * be included in the form data on submit.
-   */
-  export let inputName = "ccs-" + Math.random().toString(36);
+/**
+ * Specify a name attribute for the input elements
+ * in a selectable data table (radio or checkbox).
+ * When the table is inside a form, this name will
+ * be included in the form data on submit.
+ */
+export let inputName = "ccs-" + Math.random().toString(36);
 
-  /** Set to `true` to use zebra styles */
-  export let zebra = false;
+/** Set to `true` to use zebra styles */
+export let zebra = false;
 
-  /** Set to `true` for the sortable variant */
-  export let sortable = false;
+/** Set to `true` for the sortable variant */
+export let sortable = false;
 
-  /**
-   * Specify the header key to sort by
-   * @type {DataTableKey<Row>}
-   */
-  export let sortKey = null;
+/**
+ * Specify the header key to sort by
+ * @type {DataTableKey<Row>}
+ */
+export let sortKey = null;
 
-  /**
-   * Specify the sort direction
-   * @type {"none" | "ascending" | "descending"}
-   */
-  export let sortDirection = "none";
+/**
+ * Specify the sort direction
+ * @type {"none" | "ascending" | "descending"}
+ */
+export let sortDirection = "none";
 
-  /**
-   * Set to `true` for the expandable variant
-   * Automatically set to `true` if `batchExpansion` is `true`
-   */
-  export let expandable = false;
+/**
+ * Set to `true` for the expandable variant
+ * Automatically set to `true` if `batchExpansion` is `true`
+ */
+export let expandable = false;
 
-  /**
-   * Set to `true` to enable batch expansion
-   */
-  export let batchExpansion = false;
+/**
+ * Set to `true` to enable batch expansion
+ */
+export let batchExpansion = false;
 
-  /**
-   * Specify the row ids to be expanded
-   * @type {ReadonlyArray<DataTableRowId>}
-   */
-  export let expandedRowIds = [];
+/**
+ * Specify the row ids to be expanded
+ * @type {ReadonlyArray<DataTableRowId>}
+ */
+export let expandedRowIds = [];
 
-  /**
-   * Specify the ids for rows that should not be expandable
-   * @type {ReadonlyArray<DataTableRowId>}
-   */
-  export let nonExpandableRowIds = [];
+/**
+ * Specify the ids for rows that should not be expandable
+ * @type {ReadonlyArray<DataTableRowId>}
+ */
+export let nonExpandableRowIds = [];
 
-  /** Set to `true` for the radio selection variant */
-  export let radio = false;
+/** Set to `true` for the radio selection variant */
+export let radio = false;
 
-  /**
-   * Set to `true` for the selectable variant
-   * Automatically set to `true` if `radio` or `batchSelection` are `true`
-   */
-  export let selectable = false;
+/**
+ * Set to `true` for the selectable variant
+ * Automatically set to `true` if `radio` or `batchSelection` are `true`
+ */
+export let selectable = false;
 
-  /** Set to `true` to enable batch selection */
-  export let batchSelection = false;
+/** Set to `true` to enable batch selection */
+export let batchSelection = false;
 
-  /**
-   * Specify the row ids to be selected
-   * @type {ReadonlyArray<DataTableRowId>}
-   */
-  export let selectedRowIds = [];
+/**
+ * Specify the row ids to be selected
+ * @type {ReadonlyArray<DataTableRowId>}
+ */
+export let selectedRowIds = [];
 
-  /**
-   * Specify the ids of rows that should not be selectable
-   * @type {ReadonlyArray<DataTableRowId>}
-   */
-  export let nonSelectableRowIds = [];
+/**
+ * Specify the ids of rows that should not be selectable
+ * @type {ReadonlyArray<DataTableRowId>}
+ */
+export let nonSelectableRowIds = [];
 
-  /** Set to `true` to enable a sticky header */
-  export let stickyHeader = false;
+/** Set to `true` to enable a sticky header */
+export let stickyHeader = false;
 
-  /** Set to `true` to use static width */
-  export let useStaticWidth = false;
+/** Set to `true` to use static width */
+export let useStaticWidth = false;
 
-  /** Specify the number of items to display in a page */
-  export let pageSize = 0;
+/** Specify the number of items to display in a page */
+export let pageSize = 0;
 
-  /** Set to `number` to set current page */
-  export let page = 0;
+/** Set to `number` to set current page */
+export let page = 0;
 
-  import { createEventDispatcher, setContext } from "svelte";
-  import { writable } from "svelte/store";
-  import ChevronRight from "../icons/ChevronRight.svelte";
-  import InlineCheckbox from "../Checkbox/InlineCheckbox.svelte";
-  import RadioButton from "../RadioButton/RadioButton.svelte";
-  import Table from "./Table.svelte";
-  import TableBody from "./TableBody.svelte";
-  import TableCell from "./TableCell.svelte";
-  import TableContainer from "./TableContainer.svelte";
-  import TableHead from "./TableHead.svelte";
-  import TableHeader from "./TableHeader.svelte";
-  import TableRow from "./TableRow.svelte";
+import { createEventDispatcher, setContext } from "svelte";
+import { writable } from "svelte/store";
+import ChevronRight from "../icons/ChevronRight.svelte";
+import InlineCheckbox from "../Checkbox/InlineCheckbox.svelte";
+import RadioButton from "../RadioButton/RadioButton.svelte";
+import Table from "./Table.svelte";
+import TableBody from "./TableBody.svelte";
+import TableCell from "./TableCell.svelte";
+import TableContainer from "./TableContainer.svelte";
+import TableHead from "./TableHead.svelte";
+import TableHeader from "./TableHeader.svelte";
+import TableRow from "./TableRow.svelte";
 
-  const sortDirectionMap = {
-    none: "ascending",
-    ascending: "descending",
-    descending: "none",
-  };
-  const dispatch = createEventDispatcher();
-  const batchSelectedIds = writable(false);
-  const tableRows = writable(rows);
+const sortDirectionMap = {
+  none: "ascending",
+  ascending: "descending",
+  descending: "none",
+};
+const dispatch = createEventDispatcher();
+const batchSelectedIds = writable(false);
+const tableRows = writable(rows);
 
-  // Internal ID prefix for radio buttons, checkboxes, etc.
-  // since there may be multiple `DataTable` instances that have overlapping row ids.
-  const id = "ccs-" + Math.random().toString(36);
+// Internal ID prefix for radio buttons, checkboxes, etc.
+// since there may be multiple `DataTable` instances that have overlapping row ids.
+const id = "ccs-" + Math.random().toString(36);
 
-  // Store a copy of the original rows for filter restoration.
-  $: originalRows = [...rows];
+// Store a copy of the original rows for filter restoration.
+$: originalRows = [...rows];
 
-  $: thKeys = headers.reduce((a, c) => ({ ...a, [c.key]: c.key }), {});
-  const resolvePath = (object, path) => {
-    if (path in object) return object[path];
-    return path
-      .split(/[\.\[\]\'\"]/)
-      .filter((p) => p)
-      .reduce((o, p) => (o && typeof o === "object" ? o[p] : o), object);
-  };
+$: thKeys = headers.reduce((a, c) => ({ ...a, [c.key]: c.key }), {});
+const resolvePath = (object, path) => {
+  if (path in object) return object[path];
+  return path
+    .split(/[\.\[\]\'\"]/)
+    .filter((p) => p)
+    .reduce((o, p) => (o && typeof o === "object" ? o[p] : o), object);
+};
 
-  setContext("DataTable", {
-    batchSelectedIds,
-    tableRows,
-    resetSelectedRowIds: () => {
-      selectAll = false;
-      selectedRowIds = [];
-      if (refSelectAll) refSelectAll.checked = false;
-    },
-    filterRows: (searchValue, customFilter) => {
-      const value = searchValue.trim().toLowerCase();
+setContext("DataTable", {
+  batchSelectedIds,
+  tableRows,
+  resetSelectedRowIds: () => {
+    selectAll = false;
+    selectedRowIds = [];
+    if (refSelectAll) refSelectAll.checked = false;
+  },
+  filterRows: (searchValue, customFilter) => {
+    const value = searchValue.trim().toLowerCase();
 
-      if (value.length === 0) {
-        // Reset to original rows.
-        tableRows.set(originalRows);
-        return originalRows.map((row) => row.id);
-      }
+    if (value.length === 0) {
+      // Reset to original rows.
+      tableRows.set(originalRows);
+      return originalRows.map((row) => row.id);
+    }
 
-      let filteredRows = [];
+    let filteredRows = [];
 
-      if (typeof customFilter === "function") {
-        // Apply custom filter if provided.
-        filteredRows = originalRows.filter((row) => customFilter(row, value));
-      } else {
-        // Default filter checks all non-id fields for a basic, case-insensitive match (non-fuzzy).
-        filteredRows = originalRows.filter((row) => {
-          return Object.entries(row)
-            .filter(([key]) => key !== "id")
-            .some(([key, _value]) => {
-              if (typeof _value === "string" || typeof _value === "number") {
-                return (_value + "")?.toLowerCase().includes(value);
-              }
-            });
-        });
-      }
-
-      tableRows.set(filteredRows);
-      return filteredRows.map((row) => row.id);
-    },
-  });
-
-  let expanded = false;
-  let parentRowId = null;
-
-  $: expandedRows = expandedRowIds.reduce(
-    (a, id) => ({ ...a, [id]: true }),
-    {},
-  );
-
-  let refSelectAll = null;
-
-  $: batchSelectedIds.set(selectedRowIds);
-  $: rowIds = $tableRows.map((row) => row.id);
-  $: expandableRowIds = rowIds.filter(
-    (id) => !nonExpandableRowIds.includes(id),
-  );
-  $: selectableRowIds = rowIds.filter(
-    (id) => !nonSelectableRowIds.includes(id),
-  );
-  $: selectAll =
-    selectableRowIds.length > 0 &&
-    selectedRowIds.length === selectableRowIds.length;
-  $: indeterminate =
-    selectedRowIds.length > 0 &&
-    selectedRowIds.length < selectableRowIds.length;
-  $: if (batchExpansion) {
-    expandable = true;
-    expanded = expandedRowIds.length === expandableRowIds.length;
-  }
-  $: if (radio || batchSelection) selectable = true;
-  $: headerKeys = headers.map(({ key }) => key);
-  $: tableCellsByRowId = rows.reduce((rows, row) => {
-    rows[row.id] = headerKeys.map((key, index) => ({
-      key,
-      value: resolvePath(row, key),
-      display: headers[index].display,
-    }));
-    return rows;
-  }, {});
-  $: $tableRows = rows;
-  $: sortedRows = [...$tableRows];
-  $: ascending = sortDirection === "ascending";
-  $: sorting = sortable && sortKey != null;
-  $: sortingHeader = headers.find((header) => header.key === sortKey);
-  $: if (sorting) {
-    if (sortDirection === "none") {
-      sortedRows = $tableRows;
+    if (typeof customFilter === "function") {
+      // Apply custom filter if provided.
+      filteredRows = originalRows.filter((row) => customFilter(row, value));
     } else {
-      sortedRows = [...$tableRows].sort((a, b) => {
-        const itemA = ascending
-          ? resolvePath(a, sortKey)
-          : resolvePath(b, sortKey);
-        const itemB = ascending
-          ? resolvePath(b, sortKey)
-          : resolvePath(a, sortKey);
-
-        if (sortingHeader?.sort) return sortingHeader.sort(itemA, itemB);
-
-        if (typeof itemA === "number" && typeof itemB === "number")
-          return itemA - itemB;
-
-        if ([itemA, itemB].every((item) => !item && item !== 0)) return 0;
-        if (!itemA && itemA !== 0) return ascending ? 1 : -1;
-        if (!itemB && itemB !== 0) return ascending ? -1 : 1;
-
-        return itemA
-          .toString()
-          .localeCompare(itemB.toString(), "en", { numeric: true });
+      // Default filter checks all non-id fields for a basic, case-insensitive match (non-fuzzy).
+      filteredRows = originalRows.filter((row) => {
+        return Object.entries(row)
+          .filter(([key]) => key !== "id")
+          .some(([key, _value]) => {
+            if (typeof _value === "string" || typeof _value === "number") {
+              return (_value + "")?.toLowerCase().includes(value);
+            }
+          });
       });
     }
+
+    tableRows.set(filteredRows);
+    return filteredRows.map((row) => row.id);
+  },
+});
+
+let expanded = false;
+let parentRowId = null;
+
+$: expandedRows = expandedRowIds.reduce((a, id) => ({ ...a, [id]: true }), {});
+
+let refSelectAll = null;
+
+$: batchSelectedIds.set(selectedRowIds);
+$: rowIds = $tableRows.map((row) => row.id);
+$: expandableRowIds = rowIds.filter((id) => !nonExpandableRowIds.includes(id));
+$: selectableRowIds = rowIds.filter((id) => !nonSelectableRowIds.includes(id));
+$: selectAll =
+  selectableRowIds.length > 0 &&
+  selectedRowIds.length === selectableRowIds.length;
+$: indeterminate =
+  selectedRowIds.length > 0 && selectedRowIds.length < selectableRowIds.length;
+$: if (batchExpansion) {
+  expandable = true;
+  expanded = expandedRowIds.length === expandableRowIds.length;
+}
+$: if (radio || batchSelection) selectable = true;
+$: headerKeys = headers.map(({ key }) => key);
+$: tableCellsByRowId = rows.reduce((rows, row) => {
+  rows[row.id] = headerKeys.map((key, index) => ({
+    key,
+    value: resolvePath(row, key),
+    display: headers[index].display,
+  }));
+  return rows;
+}, {});
+$: $tableRows = rows;
+$: sortedRows = [...$tableRows];
+$: ascending = sortDirection === "ascending";
+$: sorting = sortable && sortKey != null;
+$: sortingHeader = headers.find((header) => header.key === sortKey);
+$: if (sorting) {
+  if (sortDirection === "none") {
+    sortedRows = $tableRows;
+  } else {
+    sortedRows = [...$tableRows].sort((a, b) => {
+      const itemA = ascending
+        ? resolvePath(a, sortKey)
+        : resolvePath(b, sortKey);
+      const itemB = ascending
+        ? resolvePath(b, sortKey)
+        : resolvePath(a, sortKey);
+
+      if (sortingHeader?.sort) return sortingHeader.sort(itemA, itemB);
+
+      if (typeof itemA === "number" && typeof itemB === "number")
+        return itemA - itemB;
+
+      if ([itemA, itemB].every((item) => !item && item !== 0)) return 0;
+      if (!itemA && itemA !== 0) return ascending ? 1 : -1;
+      if (!itemB && itemB !== 0) return ascending ? -1 : 1;
+
+      return itemA
+        .toString()
+        .localeCompare(itemB.toString(), "en", { numeric: true });
+    });
   }
-  const getDisplayedRows = (rows, page, pageSize) =>
-    page && pageSize
-      ? rows.slice((page - 1) * pageSize, page * pageSize)
-      : rows;
-  $: displayedRows = getDisplayedRows($tableRows, page, pageSize);
-  $: displayedSortedRows = getDisplayedRows(sortedRows, page, pageSize);
+}
+const getDisplayedRows = (rows, page, pageSize) =>
+  page && pageSize ? rows.slice((page - 1) * pageSize, page * pageSize) : rows;
+$: displayedRows = getDisplayedRows($tableRows, page, pageSize);
+$: displayedSortedRows = getDisplayedRows(sortedRows, page, pageSize);
 
-  $: hasCustomHeaderWidth = headers.some(
-    (header) => header.width || header.minWidth,
-  );
+$: hasCustomHeaderWidth = headers.some(
+  (header) => header.width || header.minWidth,
+);
 
-  /** @type {(header: DataTableHeader) => undefined | string} */
-  const formatHeaderWidth = (header) => {
-    const styles = [
-      header.width && `width: ${header.width}`,
-      header.minWidth && `min-width: ${header.minWidth}`,
-    ].filter(Boolean);
-    if (styles.length === 0) return undefined;
-    return styles.join(";");
-  };
+/** @type {(header: DataTableHeader) => undefined | string} */
+const formatHeaderWidth = (header) => {
+  const styles = [
+    header.width && `width: ${header.width}`,
+    header.minWidth && `min-width: ${header.minWidth}`,
+  ].filter(Boolean);
+  if (styles.length === 0) return undefined;
+  return styles.join(";");
+};
 </script>
 
 <TableContainer {useStaticWidth} {...$$restProps}>

--- a/src/DataTable/DataTableSkeleton.svelte
+++ b/src/DataTable/DataTableSkeleton.svelte
@@ -1,44 +1,44 @@
 <script>
-  /** @extends {"./DataTable.svelte"} DataTableHeader */
+/** @extends {"./DataTable.svelte"} DataTableHeader */
 
-  /**
-   * Specify the number of columns
-   * Superseded by `headers` if `headers` is a non-empty array
-   */
-  export let columns = 5;
+/**
+ * Specify the number of columns
+ * Superseded by `headers` if `headers` is a non-empty array
+ */
+export let columns = 5;
 
-  /** Specify the number of rows */
-  export let rows = 5;
+/** Specify the number of rows */
+export let rows = 5;
 
-  /**
-   * Set the size of the data table
-   * @type {"compact" | "short" | "tall"}
-   */
-  export let size = undefined;
+/**
+ * Set the size of the data table
+ * @type {"compact" | "short" | "tall"}
+ */
+export let size = undefined;
 
-  /** Set to `true` to apply zebra styles to the datatable rows */
-  export let zebra = false;
+/** Set to `true` to apply zebra styles to the datatable rows */
+export let zebra = false;
 
-  /** Set to `false` to hide the header */
-  export let showHeader = true;
+/** Set to `false` to hide the header */
+export let showHeader = true;
 
-  /**
-   * Set the column headers
-   * Supersedes `columns` if value is a non-empty array
-   * @type {ReadonlyArray<string | Partial<DataTableHeader>>}
-   */
-  export let headers = [];
+/**
+ * Set the column headers
+ * Supersedes `columns` if value is a non-empty array
+ * @type {ReadonlyArray<string | Partial<DataTableHeader>>}
+ */
+export let headers = [];
 
-  /** Set to `false` to hide the toolbar */
-  export let showToolbar = true;
+/** Set to `false` to hide the toolbar */
+export let showToolbar = true;
 
-  $: values = headers.map((header) =>
-    header.value !== undefined ? header.value : header,
-  );
-  $: cols = Array.from(
-    { length: headers.length > 0 ? headers.length : columns },
-    (_, i) => i,
-  );
+$: values = headers.map((header) =>
+  header.value !== undefined ? header.value : header,
+);
+$: cols = Array.from(
+  { length: headers.length > 0 ? headers.length : columns },
+  (_, i) => i,
+);
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->

--- a/src/DataTable/Table.svelte
+++ b/src/DataTable/Table.svelte
@@ -1,27 +1,27 @@
 <script>
-  /**
-   * Set the size of the table
-   * @type {"compact" | "short" | "medium" | "tall"}
-   */
-  export let size = undefined;
+/**
+ * Set the size of the table
+ * @type {"compact" | "short" | "medium" | "tall"}
+ */
+export let size = undefined;
 
-  /** Set to `true` to use zebra styles */
-  export let zebra = false;
+/** Set to `true` to use zebra styles */
+export let zebra = false;
 
-  /** Set to `true` to use static width */
-  export let useStaticWidth = false;
+/** Set to `true` to use static width */
+export let useStaticWidth = false;
 
-  /** Set to `true` for the sortable variant */
-  export let sortable = false;
+/** Set to `true` for the sortable variant */
+export let sortable = false;
 
-  /** Set to `true` to enable a sticky header */
-  export let stickyHeader = false;
+/** Set to `true` to enable a sticky header */
+export let stickyHeader = false;
 
-  /**
-   * Set the style attribute on the `table` element
-   * @type {string}
-   */
-  export let tableStyle = undefined;
+/**
+ * Set the style attribute on the `table` element
+ * @type {string}
+ */
+export let tableStyle = undefined;
 </script>
 
 {#if stickyHeader}

--- a/src/DataTable/TableContainer.svelte
+++ b/src/DataTable/TableContainer.svelte
@@ -1,15 +1,15 @@
 <script>
-  /** Specify the title of the data table */
-  export let title = "";
+/** Specify the title of the data table */
+export let title = "";
 
-  /** Specify the description of the data table */
-  export let description = "";
+/** Specify the description of the data table */
+export let description = "";
 
-  /** Set to `true` to enable a sticky header */
-  export let stickyHeader = false;
+/** Set to `true` to enable a sticky header */
+export let stickyHeader = false;
 
-  /** Set to `true` to use static width */
-  export let useStaticWidth = false;
+/** Set to `true` to use static width */
+export let useStaticWidth = false;
 </script>
 
 <div

--- a/src/DataTable/TableHeader.svelte
+++ b/src/DataTable/TableHeader.svelte
@@ -1,33 +1,33 @@
 <script>
-  /** Set to `true` for the sortable variant */
-  export let sortable = false;
+/** Set to `true` for the sortable variant */
+export let sortable = false;
 
-  /**
-   * Specify the sort direction
-   * @type {"none" | "ascending" | "descending"}
-   */
-  export let sortDirection = "none";
+/**
+ * Specify the sort direction
+ * @type {"none" | "ascending" | "descending"}
+ */
+export let sortDirection = "none";
 
-  /** Set to `true` if the column sorting */
-  export let active = false;
+/** Set to `true` if the column sorting */
+export let active = false;
 
-  /** Specify the `scope` attribute */
-  export let scope = "col";
+/** Specify the `scope` attribute */
+export let scope = "col";
 
-  /**
-   * Override the default id translations
-   * @type {() => string}
-   */
-  export let translateWithId = () => "";
+/**
+ * Override the default id translations
+ * @type {() => string}
+ */
+export let translateWithId = () => "";
 
-  /** Set an id for the top-level element */
-  export let id = "ccs-" + Math.random().toString(36);
+/** Set an id for the top-level element */
+export let id = "ccs-" + Math.random().toString(36);
 
-  import ArrowUp from "../icons/ArrowUp.svelte";
-  import ArrowsVertical from "../icons/ArrowsVertical.svelte";
+import ArrowUp from "../icons/ArrowUp.svelte";
+import ArrowsVertical from "../icons/ArrowsVertical.svelte";
 
-  // TODO: translate with id
-  $: ariaLabel = translateWithId();
+// TODO: translate with id
+$: ariaLabel = translateWithId();
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->

--- a/src/DataTable/Toolbar.svelte
+++ b/src/DataTable/Toolbar.svelte
@@ -1,24 +1,24 @@
 <script>
-  /**
-   * Specify the toolbar size
-   * @type {"sm" | "default"}
-   */
-  export let size = "default";
+/**
+ * Specify the toolbar size
+ * @type {"sm" | "default"}
+ */
+export let size = "default";
 
-  import { setContext } from "svelte";
-  import { writable } from "svelte/store";
+import { setContext } from "svelte";
+import { writable } from "svelte/store";
 
-  let ref = null;
+let ref = null;
 
-  const overflowVisible = writable(false);
+const overflowVisible = writable(false);
 
-  setContext("Toolbar", {
-    overflowVisible,
-    setOverflowVisible: (visible) => {
-      overflowVisible.set(visible);
-      if (ref) ref.style.overflow = visible ? "visible" : "inherit";
-    },
-  });
+setContext("Toolbar", {
+  overflowVisible,
+  setOverflowVisible: (visible) => {
+    overflowVisible.set(visible);
+    if (ref) ref.style.overflow = visible ? "visible" : "inherit";
+  },
+});
 </script>
 
 <section

--- a/src/DataTable/ToolbarBatchActions.svelte
+++ b/src/DataTable/ToolbarBatchActions.svelte
@@ -1,77 +1,77 @@
 <script>
-  /**
-   * @event {null} cancel
-   */
+/**
+ * @event {null} cancel
+ */
 
-  /**
-   * Override the total items selected text
-   * @type {(totalSelected: number) => string}
-   */
-  export let formatTotalSelected = (totalSelected) =>
-    `${totalSelected} item${totalSelected === 1 ? "" : "s"} selected`;
+/**
+ * Override the total items selected text
+ * @type {(totalSelected: number) => string}
+ */
+export let formatTotalSelected = (totalSelected) =>
+  `${totalSelected} item${totalSelected === 1 ? "" : "s"} selected`;
 
-  /**
-   * Use a boolean to show or hide the toolbar
-   * @type {undefined | boolean}
-   */
-  export let active = undefined;
+/**
+ * Use a boolean to show or hide the toolbar
+ * @type {undefined | boolean}
+ */
+export let active = undefined;
 
-  import {
-    onMount,
-    getContext,
-    createEventDispatcher,
-    afterUpdate,
-  } from "svelte";
+import {
+  onMount,
+  getContext,
+  createEventDispatcher,
+  afterUpdate,
+} from "svelte";
 
-  import Button from "../Button/Button.svelte";
+import Button from "../Button/Button.svelte";
 
-  let batchSelectedIds = [];
-  let prevActive;
+let batchSelectedIds = [];
+let prevActive;
 
-  const dispatch = createEventDispatcher();
+const dispatch = createEventDispatcher();
 
-  const ctx = getContext("DataTable");
+const ctx = getContext("DataTable");
 
-  function cancel() {
-    const shouldContinue = dispatch("cancel", null, { cancelable: true });
+function cancel() {
+  const shouldContinue = dispatch("cancel", null, { cancelable: true });
 
-    if (shouldContinue) {
-      ctx.resetSelectedRowIds();
-    }
+  if (shouldContinue) {
+    ctx.resetSelectedRowIds();
+  }
+}
+
+$: showActions = batchSelectedIds.length > 0 || active;
+$: {
+  if (prevActive !== active && active === false) {
+    showActions = false;
   }
 
-  $: showActions = batchSelectedIds.length > 0 || active;
-  $: {
-    if (prevActive !== active && active === false) {
-      showActions = false;
-    }
+  prevActive = active;
+}
 
-    prevActive = active;
+const unsubscribe = ctx.batchSelectedIds.subscribe((value) => {
+  batchSelectedIds = value;
+});
+
+let overflowVisible = false;
+
+const ctxToolbar = getContext("Toolbar");
+const unsubscribeOverflow = ctxToolbar.overflowVisible.subscribe((value) => {
+  overflowVisible = value;
+});
+
+onMount(() => {
+  return () => {
+    unsubscribe();
+    unsubscribeOverflow();
+  };
+});
+
+afterUpdate(() => {
+  if (active === false && showActions) {
+    active = true;
   }
-
-  const unsubscribe = ctx.batchSelectedIds.subscribe((value) => {
-    batchSelectedIds = value;
-  });
-
-  let overflowVisible = false;
-
-  const ctxToolbar = getContext("Toolbar");
-  const unsubscribeOverflow = ctxToolbar.overflowVisible.subscribe((value) => {
-    overflowVisible = value;
-  });
-
-  onMount(() => {
-    return () => {
-      unsubscribe();
-      unsubscribeOverflow();
-    };
-  });
-
-  afterUpdate(() => {
-    if (active === false && showActions) {
-      active = true;
-    }
-  });
+});
 </script>
 
 {#if !overflowVisible}

--- a/src/DataTable/ToolbarMenu.svelte
+++ b/src/DataTable/ToolbarMenu.svelte
@@ -1,15 +1,15 @@
 <script>
-  /** @extends {"../OverflowMenu/OverflowMenu.svelte"} OverflowMenuProps */
+/** @extends {"../OverflowMenu/OverflowMenu.svelte"} OverflowMenuProps */
 
-  import { getContext } from "svelte";
-  import Settings from "../icons/Settings.svelte";
-  import OverflowMenu from "../OverflowMenu/OverflowMenu.svelte";
+import { getContext } from "svelte";
+import Settings from "../icons/Settings.svelte";
+import OverflowMenu from "../OverflowMenu/OverflowMenu.svelte";
 
-  const ctx = getContext("Toolbar") ?? {};
+const ctx = getContext("Toolbar") ?? {};
 
-  let menuRef = null;
+let menuRef = null;
 
-  $: ctx.setOverflowVisible?.(menuRef != null);
+$: ctx.setOverflowVisible?.(menuRef != null);
 </script>
 
 <OverflowMenu

--- a/src/DataTable/ToolbarMenuItem.svelte
+++ b/src/DataTable/ToolbarMenuItem.svelte
@@ -1,7 +1,7 @@
 <script>
-  /** @extends {"../OverflowMenu/OverflowMenuItem.svelte"} OverflowMenuItemProps */
+/** @extends {"../OverflowMenu/OverflowMenuItem.svelte"} OverflowMenuItemProps */
 
-  import OverflowMenuItem from "../OverflowMenu/OverflowMenuItem.svelte";
+import OverflowMenuItem from "../OverflowMenu/OverflowMenuItem.svelte";
 </script>
 
 <OverflowMenuItem {...$$restProps} on:click on:keydown>

--- a/src/DataTable/ToolbarSearch.svelte
+++ b/src/DataTable/ToolbarSearch.svelte
@@ -1,78 +1,78 @@
 <script>
-  /**
-   * @restProps {input}
-   * @event {null} clear
-   */
+/**
+ * @restProps {input}
+ * @event {null} clear
+ */
 
-  /**
-   * Specify the value of the search input
-   * @type {number | string}
-   */
-  export let value = "";
+/**
+ * Specify the value of the search input
+ * @type {number | string}
+ */
+export let value = "";
 
-  /** Set to `true` to expand the search bar */
-  export let expanded = false;
+/** Set to `true` to expand the search bar */
+export let expanded = false;
 
-  /** Set to `true` to keep the search bar expanded */
-  export let persistent = false;
+/** Set to `true` to keep the search bar expanded */
+export let persistent = false;
 
-  /** Set to `true` to disable the search bar */
-  export let disabled = false;
+/** Set to `true` to disable the search bar */
+export let disabled = false;
 
-  /**
-   * Set to `true` to filter table rows using the search value.
-   *
-   * If `true`, the default search excludes `id`, `cells` fields and
-   * only does a basic comparison on string and number type cell values.
-   *
-   * To implement your own client-side filtering, pass a function
-   * that accepts a row and value and returns a boolean.
-   * @type {boolean | ((row: import("./DataTable.svelte").DataTableRow, value: number | string) => boolean)}
-   */
-  export let shouldFilterRows = false;
+/**
+ * Set to `true` to filter table rows using the search value.
+ *
+ * If `true`, the default search excludes `id`, `cells` fields and
+ * only does a basic comparison on string and number type cell values.
+ *
+ * To implement your own client-side filtering, pass a function
+ * that accepts a row and value and returns a boolean.
+ * @type {boolean | ((row: import("./DataTable.svelte").DataTableRow, value: number | string) => boolean)}
+ */
+export let shouldFilterRows = false;
 
-  /**
-   * The filtered row ids
-   * @type {ReadonlyArray<import("./DataTable.svelte").DataTableRowId>}
-   */
-  export let filteredRowIds = [];
+/**
+ * The filtered row ids
+ * @type {ReadonlyArray<import("./DataTable.svelte").DataTableRowId>}
+ */
+export let filteredRowIds = [];
 
-  /** Specify the tabindex */
-  export let tabindex = "0";
+/** Specify the tabindex */
+export let tabindex = "0";
 
-  /**
-   * Obtain a reference to the input HTML element
-   * @type {null | HTMLInputElement}
-   */
-  export let ref = null;
+/**
+ * Obtain a reference to the input HTML element
+ * @type {null | HTMLInputElement}
+ */
+export let ref = null;
 
-  import { tick, getContext } from "svelte";
-  import Search from "../Search/Search.svelte";
+import { tick, getContext } from "svelte";
+import Search from "../Search/Search.svelte";
 
-  const ctx = getContext("DataTable") ?? {};
+const ctx = getContext("DataTable") ?? {};
 
-  $: if (shouldFilterRows) {
-    filteredRowIds = ctx?.filterRows(value, shouldFilterRows);
-  }
+$: if (shouldFilterRows) {
+  filteredRowIds = ctx?.filterRows(value, shouldFilterRows);
+}
 
-  async function expandSearch() {
-    await tick();
-    if (disabled || persistent || expanded) return;
-    expanded = true;
-    await tick();
-    ref.focus();
-  }
+async function expandSearch() {
+  await tick();
+  if (disabled || persistent || expanded) return;
+  expanded = true;
+  await tick();
+  ref.focus();
+}
 
-  $: expanded = !!value.length;
-  $: classes = [
-    expanded && "bx--toolbar-search-container-active",
-    persistent
-      ? "bx--toolbar-search-container-persistent"
-      : "bx--toolbar-search-container-expandable",
-    disabled && "bx--toolbar-search-container-disabled",
-  ]
-    .filter(Boolean)
-    .join(" ");
+$: expanded = !!value.length;
+$: classes = [
+  expanded && "bx--toolbar-search-container-active",
+  persistent
+    ? "bx--toolbar-search-container-persistent"
+    : "bx--toolbar-search-container-expandable",
+  disabled && "bx--toolbar-search-container-disabled",
+]
+  .filter(Boolean)
+  .join(" ");
 </script>
 
 <Search

--- a/src/DatePicker/DatePicker.svelte
+++ b/src/DatePicker/DatePicker.svelte
@@ -1,232 +1,229 @@
 <script>
-  /**
-   * @event {string | { selectedDates: [dateFrom: Date, dateTo?: Date]; dateStr: string | { from: string; to: string; } }} change
-   */
+/**
+ * @event {string | { selectedDates: [dateFrom: Date, dateTo?: Date]; dateStr: string | { from: string; to: string; } }} change
+ */
 
-  /**
-   * Specify the date picker type
-   * @type {"simple" | "single" | "range"}
-   */
-  export let datePickerType = "simple";
+/**
+ * Specify the date picker type
+ * @type {"simple" | "single" | "range"}
+ */
+export let datePickerType = "simple";
 
-  /**
-   * Specify the date picker input value
-   * @type {number | string}
-   */
-  export let value = "";
+/**
+ * Specify the date picker input value
+ * @type {number | string}
+ */
+export let value = "";
 
-  /**
-   * Specify the date picker start date value (from)
-   * Only works with the "range" date picker type
-   * @type {string}
-   */
-  export let valueFrom = "";
+/**
+ * Specify the date picker start date value (from)
+ * Only works with the "range" date picker type
+ * @type {string}
+ */
+export let valueFrom = "";
 
-  /**
-   * Specify the date picker end date value (to)
-   * Only works with the "range" date picker type
-   * @type {string}
-   */
-  export let valueTo = "";
+/**
+ * Specify the date picker end date value (to)
+ * Only works with the "range" date picker type
+ * @type {string}
+ */
+export let valueTo = "";
 
-  /** Specify the date format */
-  export let dateFormat = "m/d/Y";
+/** Specify the date format */
+export let dateFormat = "m/d/Y";
 
-  /**
-   * Specify the maximum date
-   * @type {null | string | Date}
-   */
-  export let maxDate = null;
+/**
+ * Specify the maximum date
+ * @type {null | string | Date}
+ */
+export let maxDate = null;
 
-  /**
-   * Specify the minimum date
-   * @type {null | string | Date}
-   */
-  export let minDate = null;
+/**
+ * Specify the minimum date
+ * @type {null | string | Date}
+ */
+export let minDate = null;
 
-  /**
-   * Specify the locale
-   * @type {import("flatpickr/dist/types/locale").CustomLocale | import("flatpickr/dist/types/locale").key}
-   */
-  export let locale = "en";
+/**
+ * Specify the locale
+ * @type {import("flatpickr/dist/types/locale").CustomLocale | import("flatpickr/dist/types/locale").key}
+ */
+export let locale = "en";
 
-  /** Set to `true` to use the short variant */
-  export let short = false;
+/** Set to `true` to use the short variant */
+export let short = false;
 
-  /** Set to `true` to enable the light variant */
-  export let light = false;
+/** Set to `true` to enable the light variant */
+export let light = false;
 
-  /** Set an id for the date picker element */
-  export let id = "ccs-" + Math.random().toString(36);
+/** Set an id for the date picker element */
+export let id = "ccs-" + Math.random().toString(36);
 
-  /**
-   * Override the options passed to the Flatpickr instance.
-   * @see https://flatpickr.js.org/options
-   * @type {import("flatpickr/dist/types/options").Options}
-   */
-  export let flatpickrProps = { static: true };
+/**
+ * Override the options passed to the Flatpickr instance.
+ * @see https://flatpickr.js.org/options
+ * @type {import("flatpickr/dist/types/options").Options}
+ */
+export let flatpickrProps = { static: true };
 
-  import {
-    createEventDispatcher,
-    setContext,
-    afterUpdate,
-    onMount,
-  } from "svelte";
-  import { writable, derived } from "svelte/store";
-  import { createCalendar } from "./createCalendar";
+import {
+  createEventDispatcher,
+  setContext,
+  afterUpdate,
+  onMount,
+} from "svelte";
+import { writable, derived } from "svelte/store";
+import { createCalendar } from "./createCalendar";
 
-  const dispatch = createEventDispatcher();
-  const inputs = writable([]);
-  const inputIds = derived(inputs, (_) => _.map(({ id }) => id));
-  const labelTextEmpty = derived(
-    inputs,
-    (_) => _.filter(({ labelText }) => !!labelText).length === 0,
-  );
-  const inputValue = writable(value);
-  const inputValueFrom = writable(valueFrom);
-  const inputValueTo = writable(valueTo);
-  const mode = writable(datePickerType);
-  const range = derived(mode, (_) => _ === "range");
-  const hasCalendar = derived(mode, (_) => _ === "single" || _ === "range");
+const dispatch = createEventDispatcher();
+const inputs = writable([]);
+const inputIds = derived(inputs, (_) => _.map(({ id }) => id));
+const labelTextEmpty = derived(
+  inputs,
+  (_) => _.filter(({ labelText }) => !!labelText).length === 0,
+);
+const inputValue = writable(value);
+const inputValueFrom = writable(valueFrom);
+const inputValueTo = writable(valueTo);
+const mode = writable(datePickerType);
+const range = derived(mode, (_) => _ === "range");
+const hasCalendar = derived(mode, (_) => _ === "single" || _ === "range");
 
-  let calendar = null;
-  let datePickerRef = null;
-  let inputRef = null;
-  let inputRefTo = null;
+let calendar = null;
+let datePickerRef = null;
+let inputRef = null;
+let inputRefTo = null;
 
-  setContext("DatePicker", {
-    range,
-    inputValue,
-    inputValueFrom,
-    inputValueTo,
-    inputIds,
-    hasCalendar,
-    add: (data) => {
-      inputs.update((_) => [..._, data]);
-    },
-    declareRef: ({ id, ref }) => {
-      if ($inputIds.indexOf(id) === 0) {
-        inputRef = ref;
-      } else {
-        inputRefTo = ref;
-      }
-    },
-    updateValue: ({ type, value }) => {
-      if ((!calendar && type === "input") || type === "change") {
-        inputValue.set(value);
-      }
-
-      if (!calendar && type === "change") {
-        dispatch("change", value);
-      }
-    },
-    blurInput: (relatedTarget) => {
-      if (calendar && !calendar.calendarContainer.contains(relatedTarget)) {
-        calendar.close();
-      }
-    },
-    openCalendar: () => {
-      calendar.open();
-    },
-    focusCalendar: () => {
-      (
-        calendar.selectedDateElem ||
-        calendar.todayDateElem ||
-        calendar.calendarContainer.querySelector(".flatpickr-day[tabindex]") ||
-        calendar.calendarContainer
-      ).focus();
-    },
-  });
-
-  async function initCalendar(options) {
-    if (calendar) {
-      calendar.set("minDate", minDate);
-      calendar.set("maxDate", maxDate);
-      calendar.set("locale", locale);
-      calendar.set("dateFormat", dateFormat);
-      Object.entries(flatpickrProps).forEach(([option, value]) => {
-        calendar.set(options, value);
-      });
-      return;
+setContext("DatePicker", {
+  range,
+  inputValue,
+  inputValueFrom,
+  inputValueTo,
+  inputIds,
+  hasCalendar,
+  add: (data) => {
+    inputs.update((_) => [..._, data]);
+  },
+  declareRef: ({ id, ref }) => {
+    if ($inputIds.indexOf(id) === 0) {
+      inputRef = ref;
+    } else {
+      inputRefTo = ref;
+    }
+  },
+  updateValue: ({ type, value }) => {
+    if ((!calendar && type === "input") || type === "change") {
+      inputValue.set(value);
     }
 
-    calendar = await createCalendar({
-      options: {
-        ...options,
-        appendTo: datePickerRef,
-        defaultDate: $inputValue,
-        mode: $mode,
-      },
-      base: inputRef,
-      input: inputRefTo,
-      dispatch: (event) => {
-        const detail = { selectedDates: calendar.selectedDates };
+    if (!calendar && type === "change") {
+      dispatch("change", value);
+    }
+  },
+  blurInput: (relatedTarget) => {
+    if (calendar && !calendar.calendarContainer.contains(relatedTarget)) {
+      calendar.close();
+    }
+  },
+  openCalendar: () => {
+    calendar.open();
+  },
+  focusCalendar: () => {
+    (
+      calendar.selectedDateElem ||
+      calendar.todayDateElem ||
+      calendar.calendarContainer.querySelector(".flatpickr-day[tabindex]") ||
+      calendar.calendarContainer
+    ).focus();
+  },
+});
 
-        if ($range) {
-          const from = inputRef.value;
-          const to = inputRefTo.value;
-
-          detail.dateStr = {
-            from: inputRef.value,
-            to: inputRefTo.value,
-          };
-
-          valueFrom = from;
-          valueTo = to;
-        } else {
-          detail.dateStr = inputRef.value;
-        }
-
-        return dispatch(event, detail);
-      },
+async function initCalendar(options) {
+  if (calendar) {
+    calendar.set("minDate", minDate);
+    calendar.set("maxDate", maxDate);
+    calendar.set("locale", locale);
+    calendar.set("dateFormat", dateFormat);
+    Object.entries(flatpickrProps).forEach(([option, value]) => {
+      calendar.set(options, value);
     });
-    calendar?.calendarContainer?.setAttribute("role", "application");
-    calendar?.calendarContainer?.setAttribute(
-      "aria-label",
-      "calendar-container",
-    );
+    return;
   }
 
-  onMount(() => {
-    return () => {
-      if (calendar) {
-        calendar.destroy();
-        calendar = null;
-      }
-    };
-  });
+  calendar = await createCalendar({
+    options: {
+      ...options,
+      appendTo: datePickerRef,
+      defaultDate: $inputValue,
+      mode: $mode,
+    },
+    base: inputRef,
+    input: inputRefTo,
+    dispatch: (event) => {
+      const detail = { selectedDates: calendar.selectedDates };
 
-  afterUpdate(() => {
-    if (calendar) {
       if ($range) {
-        calendar.setDate([$inputValueFrom, $inputValueTo]);
+        const from = inputRef.value;
+        const to = inputRefTo.value;
 
-        // workaround to remove the default range plugin separator "to"
-        inputRef.value = $inputValueFrom;
+        detail.dateStr = {
+          from: inputRef.value,
+          to: inputRefTo.value,
+        };
+
+        valueFrom = from;
+        valueTo = to;
       } else {
-        calendar.setDate($inputValue);
+        detail.dateStr = inputRef.value;
       }
-    }
-  });
 
-  $: inputValue.set(value);
-  $: value = $inputValue;
-  $: inputValueFrom.set(valueFrom);
-  $: valueFrom = $inputValueFrom;
-  $: inputValueTo.set(valueTo);
-  $: valueTo = $inputValueTo;
-  $: if ($hasCalendar && inputRef) {
-    initCalendar({
-      dateFormat,
-      locale,
-      maxDate,
-      minDate,
-      // default to static: true so the
-      // date picker works inside a modal
-      static: true,
-      ...flatpickrProps,
-    });
+      return dispatch(event, detail);
+    },
+  });
+  calendar?.calendarContainer?.setAttribute("role", "application");
+  calendar?.calendarContainer?.setAttribute("aria-label", "calendar-container");
+}
+
+onMount(() => {
+  return () => {
+    if (calendar) {
+      calendar.destroy();
+      calendar = null;
+    }
+  };
+});
+
+afterUpdate(() => {
+  if (calendar) {
+    if ($range) {
+      calendar.setDate([$inputValueFrom, $inputValueTo]);
+
+      // workaround to remove the default range plugin separator "to"
+      inputRef.value = $inputValueFrom;
+    } else {
+      calendar.setDate($inputValue);
+    }
   }
+});
+
+$: inputValue.set(value);
+$: value = $inputValue;
+$: inputValueFrom.set(valueFrom);
+$: valueFrom = $inputValueFrom;
+$: inputValueTo.set(valueTo);
+$: valueTo = $inputValueTo;
+$: if ($hasCalendar && inputRef) {
+  initCalendar({
+    dateFormat,
+    locale,
+    maxDate,
+    minDate,
+    // default to static: true so the
+    // date picker works inside a modal
+    static: true,
+    ...flatpickrProps,
+  });
+}
 </script>
 
 <svelte:window

--- a/src/DatePicker/DatePickerInput.svelte
+++ b/src/DatePicker/DatePickerInput.svelte
@@ -1,81 +1,81 @@
 <script>
-  /**
-   * Set the size of the input
-   * @type {"sm" | "xl"}
-   */
-  export let size = undefined;
+/**
+ * Set the size of the input
+ * @type {"sm" | "xl"}
+ */
+export let size = undefined;
 
-  /** Specify the input type */
-  export let type = "text";
+/** Specify the input type */
+export let type = "text";
 
-  /** Specify the input placeholder text */
-  export let placeholder = "";
+/** Specify the input placeholder text */
+export let placeholder = "";
 
-  /** Specify the Regular Expression for the input value */
-  export let pattern = "\\d{1,2}\\/\\d{1,2}\\/\\d{4}";
+/** Specify the Regular Expression for the input value */
+export let pattern = "\\d{1,2}\\/\\d{1,2}\\/\\d{4}";
 
-  /** Set to `true` to disable the input */
-  export let disabled = false;
+/** Set to `true` to disable the input */
+export let disabled = false;
 
-  /** Specify the helper text */
-  export let helperText = "";
+/** Specify the helper text */
+export let helperText = "";
 
-  /** Specify the ARIA label for the calendar icon */
-  export let iconDescription = "";
+/** Specify the ARIA label for the calendar icon */
+export let iconDescription = "";
 
-  /** Set an id for the input element */
-  export let id = "ccs-" + Math.random().toString(36);
+/** Set an id for the input element */
+export let id = "ccs-" + Math.random().toString(36);
 
-  /** Specify the label text */
-  export let labelText = "";
+/** Specify the label text */
+export let labelText = "";
 
-  /** Set to `true` to visually hide the label text */
-  export let hideLabel = false;
+/** Set to `true` to visually hide the label text */
+export let hideLabel = false;
 
-  /** Set to `true` to indicate an invalid state */
-  export let invalid = false;
+/** Set to `true` to indicate an invalid state */
+export let invalid = false;
 
-  /** Specify the invalid state text */
-  export let invalidText = "";
+/** Specify the invalid state text */
+export let invalidText = "";
 
-  /** Set to `true` to indicate an warning state */
-  export let warn = false;
+/** Set to `true` to indicate an warning state */
+export let warn = false;
 
-  /** Specify the warning state text */
-  export let warnText = "";
+/** Specify the warning state text */
+export let warnText = "";
 
-  /**
-   * Set a name for the input element
-   * @type {string}
-   */
-  export let name = undefined;
+/**
+ * Set a name for the input element
+ * @type {string}
+ */
+export let name = undefined;
 
-  /** Obtain a reference to the input HTML element */
-  export let ref = null;
+/** Obtain a reference to the input HTML element */
+export let ref = null;
 
-  import { getContext } from "svelte";
-  import Calendar from "../icons/Calendar.svelte";
-  import WarningFilled from "../icons/WarningFilled.svelte";
-  import WarningAltFilled from "../icons/WarningAltFilled.svelte";
+import { getContext } from "svelte";
+import Calendar from "../icons/Calendar.svelte";
+import WarningFilled from "../icons/WarningFilled.svelte";
+import WarningAltFilled from "../icons/WarningAltFilled.svelte";
 
-  const {
-    range,
-    add,
-    hasCalendar,
-    declareRef,
-    inputIds,
-    updateValue,
-    blurInput,
-    openCalendar,
-    focusCalendar,
-    inputValue,
-    inputValueFrom,
-    inputValueTo,
-  } = getContext("DatePicker");
+const {
+  range,
+  add,
+  hasCalendar,
+  declareRef,
+  inputIds,
+  updateValue,
+  blurInput,
+  openCalendar,
+  focusCalendar,
+  inputValue,
+  inputValueFrom,
+  inputValueTo,
+} = getContext("DatePicker");
 
-  add({ id, labelText });
+add({ id, labelText });
 
-  $: if (ref) declareRef({ id, ref });
+$: if (ref) declareRef({ id, ref });
 </script>
 
 <div

--- a/src/DatePicker/DatePickerSkeleton.svelte
+++ b/src/DatePicker/DatePickerSkeleton.svelte
@@ -1,9 +1,9 @@
 <script>
-  /** Set to `true` to use the range variant */
-  export let range = false;
+/** Set to `true` to use the range variant */
+export let range = false;
 
-  /** Set an id to be used by the label element */
-  export let id = "ccs-" + Math.random().toString(36);
+/** Set an id to be used by the label element */
+export let id = "ccs-" + Math.random().toString(36);
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->

--- a/src/Dropdown/Dropdown.svelte
+++ b/src/Dropdown/Dropdown.svelte
@@ -1,174 +1,174 @@
 <script>
-  /**
-   * @typedef {any} DropdownItemId
-   * @typedef {string} DropdownItemText
-   * @typedef {{ id: DropdownItemId; text: DropdownItemText; disabled?: boolean; }} DropdownItem
-   * @event {{ selectedId: DropdownItemId, selectedItem: DropdownItem }} select
-   * @slot {{ item: DropdownItem; index: number; }}
-   */
+/**
+ * @typedef {any} DropdownItemId
+ * @typedef {string} DropdownItemText
+ * @typedef {{ id: DropdownItemId; text: DropdownItemText; disabled?: boolean; }} DropdownItem
+ * @event {{ selectedId: DropdownItemId, selectedItem: DropdownItem }} select
+ * @slot {{ item: DropdownItem; index: number; }}
+ */
 
-  /**
-   * Set the dropdown items
-   * @type {ReadonlyArray<DropdownItem>}
-   */
-  export let items = [];
+/**
+ * Set the dropdown items
+ * @type {ReadonlyArray<DropdownItem>}
+ */
+export let items = [];
 
-  /**
-   * Override the display of a dropdown item
-   * @type {(item: DropdownItem) => string}
-   */
-  export let itemToString = (item) => item.text || item.id;
+/**
+ * Override the display of a dropdown item
+ * @type {(item: DropdownItem) => string}
+ */
+export let itemToString = (item) => item.text || item.id;
 
-  /**
-   * Specify the selected item id
-   * @type {DropdownItemId}
-   */
-  export let selectedId;
+/**
+ * Specify the selected item id
+ * @type {DropdownItemId}
+ */
+export let selectedId;
 
-  /**
-   * Specify the type of dropdown
-   * @type {"default" | "inline"}
-   */
-  export let type = "default";
+/**
+ * Specify the type of dropdown
+ * @type {"default" | "inline"}
+ */
+export let type = "default";
 
-  /**
-   * Specify the direction of the dropdown menu
-   * @type {"bottom" | "top"}
-   */
-  export let direction = "bottom";
+/**
+ * Specify the direction of the dropdown menu
+ * @type {"bottom" | "top"}
+ */
+export let direction = "bottom";
 
-  /**
-   * Specify the size of the dropdown field
-   * @type {"sm" | "lg" | "xl"}
-   */
-  export let size = undefined;
+/**
+ * Specify the size of the dropdown field
+ * @type {"sm" | "lg" | "xl"}
+ */
+export let size = undefined;
 
-  /** Set to `true` to open the dropdown */
-  export let open = false;
+/** Set to `true` to open the dropdown */
+export let open = false;
 
-  /** Set to `true` to enable the light variant */
-  export let light = false;
+/** Set to `true` to enable the light variant */
+export let light = false;
 
-  /** Set to `true` to disable the dropdown */
-  export let disabled = false;
+/** Set to `true` to disable the dropdown */
+export let disabled = false;
 
-  /** Specify the title text */
-  export let titleText = "";
+/** Specify the title text */
+export let titleText = "";
 
-  /** Set to `true` to indicate an invalid state */
-  export let invalid = false;
+/** Set to `true` to indicate an invalid state */
+export let invalid = false;
 
-  /** Specify the invalid state text */
-  export let invalidText = "";
+/** Specify the invalid state text */
+export let invalidText = "";
 
-  /** Set to `true` to indicate an warning state */
-  export let warn = false;
+/** Set to `true` to indicate an warning state */
+export let warn = false;
 
-  /** Specify the warning state text */
-  export let warnText = "";
+/** Specify the warning state text */
+export let warnText = "";
 
-  /** Specify the helper text */
-  export let helperText = "";
+/** Specify the helper text */
+export let helperText = "";
 
-  /**
-   * Specify the list box label
-   * @type {string}
-   */
-  export let label = undefined;
+/**
+ * Specify the list box label
+ * @type {string}
+ */
+export let label = undefined;
 
-  /** Set to `true` to visually hide the label text */
-  export let hideLabel = false;
+/** Set to `true` to visually hide the label text */
+export let hideLabel = false;
 
-  /**
-   * Override the chevron icon label based on the open state.
-   * Defaults to "Open menu" when closed and "Close menu" when open
-   * @type {(id: import("../ListBox/ListBoxMenuIcon.svelte").ListBoxMenuIconTranslationId) => string}
-   */
-  export let translateWithId = undefined;
+/**
+ * Override the chevron icon label based on the open state.
+ * Defaults to "Open menu" when closed and "Close menu" when open
+ * @type {(id: import("../ListBox/ListBoxMenuIcon.svelte").ListBoxMenuIconTranslationId) => string}
+ */
+export let translateWithId = undefined;
 
-  /** Set an id for the list box component */
-  export let id = "ccs-" + Math.random().toString(36);
+/** Set an id for the list box component */
+export let id = "ccs-" + Math.random().toString(36);
 
-  /**
-   * Specify a name attribute for the list box
-   * @type {string}
-   */
-  export let name = undefined;
+/**
+ * Specify a name attribute for the list box
+ * @type {string}
+ */
+export let name = undefined;
 
-  /** Obtain a reference to the button HTML element */
-  export let ref = null;
+/** Obtain a reference to the button HTML element */
+export let ref = null;
 
-  import { createEventDispatcher, onMount } from "svelte";
-  import WarningFilled from "../icons/WarningFilled.svelte";
-  import WarningAltFilled from "../icons/WarningAltFilled.svelte";
-  import {
-    ListBox,
-    ListBoxMenu,
-    ListBoxMenuIcon,
-    ListBoxMenuItem,
-  } from "../ListBox";
+import { createEventDispatcher, onMount } from "svelte";
+import WarningFilled from "../icons/WarningFilled.svelte";
+import WarningAltFilled from "../icons/WarningAltFilled.svelte";
+import {
+  ListBox,
+  ListBoxMenu,
+  ListBoxMenuIcon,
+  ListBoxMenuItem,
+} from "../ListBox";
 
-  const dispatch = createEventDispatcher();
+const dispatch = createEventDispatcher();
 
-  let highlightedIndex = -1;
+let highlightedIndex = -1;
 
-  $: inline = type === "inline";
-  $: selectedItem = items.find((item) => item.id === selectedId);
-  $: if (!open) {
-    highlightedIndex = -1;
+$: inline = type === "inline";
+$: selectedItem = items.find((item) => item.id === selectedId);
+$: if (!open) {
+  highlightedIndex = -1;
+}
+
+function change(dir) {
+  let index = highlightedIndex + dir;
+
+  if (items.length === 0) return;
+  if (index < 0) {
+    index = items.length - 1;
+  } else if (index >= items.length) {
+    index = 0;
   }
 
-  function change(dir) {
-    let index = highlightedIndex + dir;
+  let disabled = items[index].disabled;
 
-    if (items.length === 0) return;
+  while (disabled) {
+    index = index + dir;
+
     if (index < 0) {
       index = items.length - 1;
     } else if (index >= items.length) {
       index = 0;
     }
 
-    let disabled = items[index].disabled;
-
-    while (disabled) {
-      index = index + dir;
-
-      if (index < 0) {
-        index = items.length - 1;
-      } else if (index >= items.length) {
-        index = 0;
-      }
-
-      disabled = items[index].disabled;
-    }
-
-    highlightedIndex = index;
+    disabled = items[index].disabled;
   }
 
-  const dispatchSelect = () => {
-    dispatch("select", {
-      selectedId,
-      selectedItem: items.find((item) => item.id === selectedId),
-    });
-  };
+  highlightedIndex = index;
+}
 
-  const pageClickHandler = ({ target }) => {
-    if (open && ref && !ref.contains(target)) {
-      open = false;
-    }
-  };
-
-  onMount(() => {
-    if (parent) {
-      parent.addEventListener("click", pageClickHandler);
-    }
-
-    return () => {
-      if (parent) {
-        parent.removeEventListener("click", pageClickHandler);
-      }
-    };
+const dispatchSelect = () => {
+  dispatch("select", {
+    selectedId,
+    selectedItem: items.find((item) => item.id === selectedId),
   });
+};
+
+const pageClickHandler = ({ target }) => {
+  if (open && ref && !ref.contains(target)) {
+    open = false;
+  }
+};
+
+onMount(() => {
+  if (parent) {
+    parent.addEventListener("click", pageClickHandler);
+  }
+
+  return () => {
+    if (parent) {
+      parent.removeEventListener("click", pageClickHandler);
+    }
+  };
+});
 </script>
 
 <svelte:window on:click={pageClickHandler} />

--- a/src/Dropdown/DropdownSkeleton.svelte
+++ b/src/Dropdown/DropdownSkeleton.svelte
@@ -1,6 +1,6 @@
 <script>
-  /** Set to `true` to use the inline variant */
-  export let inline = false;
+/** Set to `true` to use the inline variant */
+export let inline = false;
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->

--- a/src/FileUploader/FileUploader.svelte
+++ b/src/FileUploader/FileUploader.svelte
@@ -1,110 +1,108 @@
 <script>
-  /**
-   * @event {ReadonlyArray<File>} add
-   * @event {ReadonlyArray<File>} remove
-   * @event {ReadonlyArray<File>} change
-   */
+/**
+ * @event {ReadonlyArray<File>} add
+ * @event {ReadonlyArray<File>} remove
+ * @event {ReadonlyArray<File>} change
+ */
 
-  /**
-   * Specify the file uploader status
-   * @type {"uploading" | "edit" | "complete"}
-   */
-  export let status = "uploading";
+/**
+ * Specify the file uploader status
+ * @type {"uploading" | "edit" | "complete"}
+ */
+export let status = "uploading";
 
-  /** Set to `true` to disable the file uploader */
-  export let disabled = false;
+/** Set to `true` to disable the file uploader */
+export let disabled = false;
 
-  /**
-   * Specify the accepted file types
-   * @type {ReadonlyArray<string>}
-   */
-  export let accept = [];
+/**
+ * Specify the accepted file types
+ * @type {ReadonlyArray<string>}
+ */
+export let accept = [];
 
-  /**
-   * Obtain a reference to the uploaded files
-   * @type {ReadonlyArray<File>}
-   */
-  export let files = [];
+/**
+ * Obtain a reference to the uploaded files
+ * @type {ReadonlyArray<File>}
+ */
+export let files = [];
 
-  /** Set to `true` to allow multiple files */
-  export let multiple = false;
+/** Set to `true` to allow multiple files */
+export let multiple = false;
 
-  /**
-   * Programmatically clear the uploaded files
-   * @type {() => void}
-   */
-  export const clearFiles = () => {
-    files = [];
-  };
+/**
+ * Programmatically clear the uploaded files
+ * @type {() => void}
+ */
+export const clearFiles = () => {
+  files = [];
+};
 
-  /**
-   * Specify the label title.
-   * Alternatively, use the named slot "labelTitle" (e.g., `<span slot="labelTitle">...</span>`)
-   */
-  export let labelTitle = "";
+/**
+ * Specify the label title.
+ * Alternatively, use the named slot "labelTitle" (e.g., `<span slot="labelTitle">...</span>`)
+ */
+export let labelTitle = "";
 
-  /**
-   * Specify the label description.
-   * Alternatively, use the named slot "labelDescription" (e.g., `<span slot="labelDescription">...</span>`)
-   */
-  export let labelDescription = "";
+/**
+ * Specify the label description.
+ * Alternatively, use the named slot "labelDescription" (e.g., `<span slot="labelDescription">...</span>`)
+ */
+export let labelDescription = "";
 
-  /**
-   * Specify the kind of file uploader button
-   * @type {import("../Button/Button.svelte").ButtonProps["kind"]}
-   */
-  export let kind = "primary";
+/**
+ * Specify the kind of file uploader button
+ * @type {import("../Button/Button.svelte").ButtonProps["kind"]}
+ */
+export let kind = "primary";
 
-  /**
-   * Specify the size of the file uploader button
-   * @type {import("../Button/Button.svelte").ButtonProps["size"]}
-   */
-  export let size = "small";
+/**
+ * Specify the size of the file uploader button
+ * @type {import("../Button/Button.svelte").ButtonProps["size"]}
+ */
+export let size = "small";
 
-  /** Specify the button label */
-  export let buttonLabel = "";
+/** Specify the button label */
+export let buttonLabel = "";
 
-  /** Specify the ARIA label used for the status icons */
-  export let iconDescription = "Provide icon description";
+/** Specify the ARIA label used for the status icons */
+export let iconDescription = "Provide icon description";
 
-  /** Specify a name attribute for the file button uploader input */
-  export let name = "";
+/** Specify a name attribute for the file button uploader input */
+export let name = "";
 
-  import { createEventDispatcher, afterUpdate } from "svelte";
-  import Filename from "./Filename.svelte";
-  import FileUploaderButton from "./FileUploaderButton.svelte";
+import { createEventDispatcher, afterUpdate } from "svelte";
+import Filename from "./Filename.svelte";
+import FileUploaderButton from "./FileUploaderButton.svelte";
 
-  const dispatch = createEventDispatcher();
+const dispatch = createEventDispatcher();
 
-  let prevFiles = [];
+let prevFiles = [];
 
-  /** @type {(file: File) => string} */
-  const getFileId = (file) => file.lastModified + file.name;
+/** @type {(file: File) => string} */
+const getFileId = (file) => file.lastModified + file.name;
 
-  afterUpdate(() => {
-    const fileIds = files.map(getFileId);
-    const prevFileIds = prevFiles.map(getFileId);
-    const addedIds = fileIds.filter((_) => !prevFileIds.includes(_));
-    const removedIds = prevFileIds.filter((_) => !fileIds.includes(_));
+afterUpdate(() => {
+  const fileIds = files.map(getFileId);
+  const prevFileIds = prevFiles.map(getFileId);
+  const addedIds = fileIds.filter((_) => !prevFileIds.includes(_));
+  const removedIds = prevFileIds.filter((_) => !fileIds.includes(_));
 
-    if (addedIds.length > 0) {
-      dispatch(
-        "add",
-        addedIds.map((id) => files.find((file) => id === getFileId(file))),
-      );
-    }
+  if (addedIds.length > 0) {
+    dispatch(
+      "add",
+      addedIds.map((id) => files.find((file) => id === getFileId(file))),
+    );
+  }
 
-    if (removedIds.length > 0) {
-      dispatch(
-        "remove",
-        removedIds.map((id) =>
-          prevFiles.find((file) => id === getFileId(file)),
-        ),
-      );
-    }
+  if (removedIds.length > 0) {
+    dispatch(
+      "remove",
+      removedIds.map((id) => prevFiles.find((file) => id === getFileId(file))),
+    );
+  }
 
-    prevFiles = [...files];
-  });
+  prevFiles = [...files];
+});
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->

--- a/src/FileUploader/FileUploaderButton.svelte
+++ b/src/FileUploader/FileUploaderButton.svelte
@@ -1,69 +1,69 @@
 <script>
-  /**
-   * @event {ReadonlyArray<File>} change
-   */
+/**
+ * @event {ReadonlyArray<File>} change
+ */
 
-  /**
-   * Specify the accepted file types
-   * @type {ReadonlyArray<string>}
-   */
-  export let accept = [];
+/**
+ * Specify the accepted file types
+ * @type {ReadonlyArray<string>}
+ */
+export let accept = [];
 
-  /**
-   * Obtain a reference to the uploaded files
-   * @type {ReadonlyArray<File>}
-   */
-  export let files = [];
+/**
+ * Obtain a reference to the uploaded files
+ * @type {ReadonlyArray<File>}
+ */
+export let files = [];
 
-  /** Set to `true` to allow multiple files */
-  export let multiple = false;
+/** Set to `true` to allow multiple files */
+export let multiple = false;
 
-  /** Set to `true` to disable the input */
-  export let disabled = false;
+/** Set to `true` to disable the input */
+export let disabled = false;
 
-  /** Set to `true` to disable label changes */
-  export let disableLabelChanges = false;
+/** Set to `true` to disable label changes */
+export let disableLabelChanges = false;
 
-  /**
-   * Specify the kind of file uploader button
-   * @type {import("../Button/Button.svelte").ButtonProps["kind"]}
-   */
-  export let kind = "primary";
+/**
+ * Specify the kind of file uploader button
+ * @type {import("../Button/Button.svelte").ButtonProps["kind"]}
+ */
+export let kind = "primary";
 
-  /**
-   * Specify the size of the file uploader button
-   * @type {import("../Button/Button.svelte").ButtonProps["size"]}
-   */
-  export let size = "small";
+/**
+ * Specify the size of the file uploader button
+ * @type {import("../Button/Button.svelte").ButtonProps["size"]}
+ */
+export let size = "small";
 
-  /** Specify the label text */
-  export let labelText = "Add file";
+/** Specify the label text */
+export let labelText = "Add file";
 
-  /** Specify the label role */
-  export let role = "button";
+/** Specify the label role */
+export let role = "button";
 
-  /** Specify `tabindex` attribute */
-  export let tabindex = "0";
+/** Specify `tabindex` attribute */
+export let tabindex = "0";
 
-  /** Set an id for the input element */
-  export let id = "ccs-" + Math.random().toString(36);
+/** Set an id for the input element */
+export let id = "ccs-" + Math.random().toString(36);
 
-  /** Specify a name attribute for the input */
-  export let name = "";
+/** Specify a name attribute for the input */
+export let name = "";
 
-  /** Obtain a reference to the input HTML element */
-  export let ref = null;
+/** Obtain a reference to the input HTML element */
+export let ref = null;
 
-  import { createEventDispatcher } from "svelte";
+import { createEventDispatcher } from "svelte";
 
-  const dispatch = createEventDispatcher();
+const dispatch = createEventDispatcher();
 
-  let initialLabelText = labelText;
+let initialLabelText = labelText;
 
-  $: if (ref && files.length === 0) {
-    labelText = initialLabelText;
-    ref.value = "";
-  }
+$: if (ref && files.length === 0) {
+  labelText = initialLabelText;
+  ref.value = "";
+}
 </script>
 
 <!-- svelte-ignore a11y-no-noninteractive-tabindex -->

--- a/src/FileUploader/FileUploaderDropContainer.svelte
+++ b/src/FileUploader/FileUploaderDropContainer.svelte
@@ -1,57 +1,57 @@
 <script>
-  /**
-   * @event {ReadonlyArray<File>} add
-   * @event {ReadonlyArray<File>} change
-   */
+/**
+ * @event {ReadonlyArray<File>} add
+ * @event {ReadonlyArray<File>} change
+ */
 
-  /**
-   * Specify the accepted file types
-   * @type {ReadonlyArray<string>}
-   */
-  export let accept = [];
+/**
+ * Specify the accepted file types
+ * @type {ReadonlyArray<string>}
+ */
+export let accept = [];
 
-  /**
-   * Obtain a reference to the uploaded files
-   * @type {ReadonlyArray<File>}
-   */
-  export let files = [];
+/**
+ * Obtain a reference to the uploaded files
+ * @type {ReadonlyArray<File>}
+ */
+export let files = [];
 
-  /** Set to `true` to allow multiple files */
-  export let multiple = false;
+/** Set to `true` to allow multiple files */
+export let multiple = false;
 
-  /**
-   * Override the default behavior of validating uploaded files.
-   * By default, files are not validated
-   * @type {(files: ReadonlyArray<File>) => ReadonlyArray<File>}
-   */
-  export let validateFiles = (files) => files;
+/**
+ * Override the default behavior of validating uploaded files.
+ * By default, files are not validated
+ * @type {(files: ReadonlyArray<File>) => ReadonlyArray<File>}
+ */
+export let validateFiles = (files) => files;
 
-  /** Specify the label text */
-  export let labelText = "Add file";
+/** Specify the label text */
+export let labelText = "Add file";
 
-  /** Specify the `role` attribute of the drop container */
-  export let role = "button";
+/** Specify the `role` attribute of the drop container */
+export let role = "button";
 
-  /** Set to `true` to disable the input */
-  export let disabled = false;
+/** Set to `true` to disable the input */
+export let disabled = false;
 
-  /** Specify `tabindex` attribute */
-  export let tabindex = "0";
+/** Specify `tabindex` attribute */
+export let tabindex = "0";
 
-  /** Set an id for the input element */
-  export let id = "ccs-" + Math.random().toString(36);
+/** Set an id for the input element */
+export let id = "ccs-" + Math.random().toString(36);
 
-  /** Specify a name attribute for the input */
-  export let name = "";
+/** Specify a name attribute for the input */
+export let name = "";
 
-  /** Obtain a reference to the input HTML element */
-  export let ref = null;
+/** Obtain a reference to the input HTML element */
+export let ref = null;
 
-  import { createEventDispatcher } from "svelte";
+import { createEventDispatcher } from "svelte";
 
-  const dispatch = createEventDispatcher();
+const dispatch = createEventDispatcher();
 
-  let over = false;
+let over = false;
 </script>
 
 <!-- svelte-ignore a11y-no-static-element-interactions -->

--- a/src/FileUploader/FileUploaderItem.svelte
+++ b/src/FileUploader/FileUploaderItem.svelte
@@ -1,42 +1,42 @@
 <script>
-  /**
-   * @event {string} delete
-   */
+/**
+ * @event {string} delete
+ */
 
-  /**
-   * Specify the file uploader status
-   * @type {"uploading" | "edit" | "complete"}
-   */
-  export let status = "uploading";
+/**
+ * Specify the file uploader status
+ * @type {"uploading" | "edit" | "complete"}
+ */
+export let status = "uploading";
 
-  /**
-   * Specify the size of button skeleton
-   * @type {"default" | "field" | "small"}
-   */
-  export let size = "default";
+/**
+ * Specify the size of button skeleton
+ * @type {"default" | "field" | "small"}
+ */
+export let size = "default";
 
-  /** Specify the ARIA label used for the status icons */
-  export let iconDescription = "";
+/** Specify the ARIA label used for the status icons */
+export let iconDescription = "";
 
-  /** Set to `true` to indicate an invalid state */
-  export let invalid = false;
+/** Set to `true` to indicate an invalid state */
+export let invalid = false;
 
-  /** Specify the error subject text */
-  export let errorSubject = "";
+/** Specify the error subject text */
+export let errorSubject = "";
 
-  /** Specify the error body text */
-  export let errorBody = "";
+/** Specify the error body text */
+export let errorBody = "";
 
-  /** Set an id for the top-level element */
-  export let id = "ccs-" + Math.random().toString(36);
+/** Set an id for the top-level element */
+export let id = "ccs-" + Math.random().toString(36);
 
-  /** Specify the file uploader name */
-  export let name = "";
+/** Specify the file uploader name */
+export let name = "";
 
-  import { createEventDispatcher } from "svelte";
-  import Filename from "./Filename.svelte";
+import { createEventDispatcher } from "svelte";
+import Filename from "./Filename.svelte";
 
-  const dispatch = createEventDispatcher();
+const dispatch = createEventDispatcher();
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->

--- a/src/FileUploader/FileUploaderSkeleton.svelte
+++ b/src/FileUploader/FileUploaderSkeleton.svelte
@@ -1,6 +1,6 @@
 <script>
-  import ButtonSkeleton from "../Button/ButtonSkeleton.svelte";
-  import SkeletonText from "../SkeletonText/SkeletonText.svelte";
+import ButtonSkeleton from "../Button/ButtonSkeleton.svelte";
+import SkeletonText from "../SkeletonText/SkeletonText.svelte";
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->

--- a/src/FileUploader/Filename.svelte
+++ b/src/FileUploader/Filename.svelte
@@ -1,24 +1,24 @@
 <script>
-  /**
-   * @restProps {div | button | svg}
-   */
+/**
+ * @restProps {div | button | svg}
+ */
 
-  /**
-   * Specify the file name status
-   * @type {"uploading" | "edit" | "complete"}
-   */
-  export let status = "uploading";
+/**
+ * Specify the file name status
+ * @type {"uploading" | "edit" | "complete"}
+ */
+export let status = "uploading";
 
-  /** Specify the ARIA label used for the status icons */
-  export let iconDescription = "";
+/** Specify the ARIA label used for the status icons */
+export let iconDescription = "";
 
-  /** Set to `true` to indicate an invalid state */
-  export let invalid = false;
+/** Set to `true` to indicate an invalid state */
+export let invalid = false;
 
-  import Close from "../icons/Close.svelte";
-  import CheckmarkFilled from "../icons/CheckmarkFilled.svelte";
-  import WarningFilled from "../icons/WarningFilled.svelte";
-  import Loading from "../Loading/Loading.svelte";
+import Close from "../icons/Close.svelte";
+import CheckmarkFilled from "../icons/CheckmarkFilled.svelte";
+import WarningFilled from "../icons/WarningFilled.svelte";
+import Loading from "../Loading/Loading.svelte";
 </script>
 
 {#if status === "uploading"}

--- a/src/FluidForm/FluidForm.svelte
+++ b/src/FluidForm/FluidForm.svelte
@@ -1,12 +1,12 @@
 <script>
-  /**
-   * @restProps {form}
-   */
+/**
+ * @restProps {form}
+ */
 
-  import { setContext } from "svelte";
-  import Form from "../Form/Form.svelte";
+import { setContext } from "svelte";
+import Form from "../Form/Form.svelte";
 
-  setContext("Form", { isFluid: true });
+setContext("Form", { isFluid: true });
 </script>
 
 <Form

--- a/src/Form/Form.svelte
+++ b/src/Form/Form.svelte
@@ -1,6 +1,6 @@
 <script>
-  /** Obtain a reference to the form element */
-  export let ref = null;
+/** Obtain a reference to the form element */
+export let ref = null;
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->

--- a/src/FormGroup/FormGroup.svelte
+++ b/src/FormGroup/FormGroup.svelte
@@ -1,21 +1,21 @@
 <script>
-  /** Set to `true` for to remove the bottom margin */
-  export let noMargin = false;
+/** Set to `true` for to remove the bottom margin */
+export let noMargin = false;
 
-  /** Set to `true` to indicate an invalid state */
-  export let invalid = false;
+/** Set to `true` to indicate an invalid state */
+export let invalid = false;
 
-  /** Set to `true` to render a form requirement */
-  export let message = false;
+/** Set to `true` to render a form requirement */
+export let message = false;
 
-  /** Specify the message text */
-  export let messageText = "";
+/** Specify the message text */
+export let messageText = "";
 
-  /** Specify the legend text */
-  export let legendText = "";
+/** Specify the legend text */
+export let legendText = "";
 
-  /** Specify an id for the legend element */
-  export let legendId = "";
+/** Specify an id for the legend element */
+export let legendId = "";
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->

--- a/src/FormLabel/FormLabel.svelte
+++ b/src/FormLabel/FormLabel.svelte
@@ -1,6 +1,6 @@
 <script>
-  /** Set an id to be used by the label element */
-  export let id = "ccs-" + Math.random().toString(36);
+/** Set an id to be used by the label element */
+export let id = "ccs-" + Math.random().toString(36);
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->

--- a/src/Grid/Column.svelte
+++ b/src/Grid/Column.svelte
@@ -1,113 +1,113 @@
 <script>
-  /**
-   * @typedef {boolean | number} ColumnSize
-   * @typedef {{span?: ColumnSize; offset: number;}} ColumnSizeDescriptor
-   * @typedef {ColumnSize | ColumnSizeDescriptor} ColumnBreakpoint
-   * @restProps {div}
-   * @slot {{props: { class: string; [key: string]: any; }}}
-   */
+/**
+ * @typedef {boolean | number} ColumnSize
+ * @typedef {{span?: ColumnSize; offset: number;}} ColumnSizeDescriptor
+ * @typedef {ColumnSize | ColumnSizeDescriptor} ColumnBreakpoint
+ * @restProps {div}
+ * @slot {{props: { class: string; [key: string]: any; }}}
+ */
 
-  /**
-   * @slot {{ props?: { class: string; } }}
-   */
+/**
+ * @slot {{ props?: { class: string; } }}
+ */
 
-  /**
-   * Set to `true` to render a custom HTML element
-   * Props are destructured as `props` in the default slot (e.g., <Column let:props><article {...props}>...</article></Column>)
-   */
-  export let as = false;
+/**
+ * Set to `true` to render a custom HTML element
+ * Props are destructured as `props` in the default slot (e.g., <Column let:props><article {...props}>...</article></Column>)
+ */
+export let as = false;
 
-  /** Set to `true` to remove the gutter */
-  export let noGutter = false;
+/** Set to `true` to remove the gutter */
+export let noGutter = false;
 
-  /** Set to `true` to remove the left gutter */
-  export let noGutterLeft = false;
+/** Set to `true` to remove the left gutter */
+export let noGutterLeft = false;
 
-  /** Set to `true` to remove the right gutter */
-  export let noGutterRight = false;
+/** Set to `true` to remove the right gutter */
+export let noGutterRight = false;
 
-  /** Set to `true` to add top and bottom padding to the column */
-  export let padding = false;
+/** Set to `true` to add top and bottom padding to the column */
+export let padding = false;
 
-  /**
-   * Specify the aspect ratio of the column
-   * @type {"2x1" | "16x9" | "9x16" | "1x2" | "4x3" | "3x4" | "1x1"}
-   */
-  export let aspectRatio = undefined;
+/**
+ * Specify the aspect ratio of the column
+ * @type {"2x1" | "16x9" | "9x16" | "1x2" | "4x3" | "3x4" | "1x1"}
+ */
+export let aspectRatio = undefined;
 
-  /**
-   * Set the small breakpoint
-   * @type {ColumnBreakpoint}
-   */
-  export let sm = undefined;
+/**
+ * Set the small breakpoint
+ * @type {ColumnBreakpoint}
+ */
+export let sm = undefined;
 
-  /**
-   * Set the medium breakpoint
-   * @type {ColumnBreakpoint}
-   */
-  export let md = undefined;
+/**
+ * Set the medium breakpoint
+ * @type {ColumnBreakpoint}
+ */
+export let md = undefined;
 
-  /**
-   * Set the large breakpoint
-   * @type {ColumnBreakpoint}
-   */
-  export let lg = undefined;
+/**
+ * Set the large breakpoint
+ * @type {ColumnBreakpoint}
+ */
+export let lg = undefined;
 
-  /**
-   * Set the extra large breakpoint
-   * @type {ColumnBreakpoint}
-   */
-  export let xlg = undefined;
+/**
+ * Set the extra large breakpoint
+ * @type {ColumnBreakpoint}
+ */
+export let xlg = undefined;
 
-  /**
-   * Set the maximum breakpoint
-   * @type {ColumnBreakpoint}
-   */
-  export let max = undefined;
+/**
+ * Set the maximum breakpoint
+ * @type {ColumnBreakpoint}
+ */
+export let max = undefined;
 
-  const breakpoints = ["sm", "md", "lg", "xlg", "max"];
+const breakpoints = ["sm", "md", "lg", "xlg", "max"];
 
-  $: columnClass = [sm, md, lg, xlg, max]
-    .map((breakpoint, i) => {
-      const name = breakpoints[i];
+$: columnClass = [sm, md, lg, xlg, max]
+  .map((breakpoint, i) => {
+    const name = breakpoints[i];
 
-      if (breakpoint === true) {
-        return `bx--col-${name}`;
-      } else if (typeof breakpoint === "number") {
-        return `bx--col-${name}-${breakpoint}`;
-      } else if (typeof breakpoint === "object") {
-        let bp = [];
+    if (breakpoint === true) {
+      return `bx--col-${name}`;
+    } else if (typeof breakpoint === "number") {
+      return `bx--col-${name}-${breakpoint}`;
+    } else if (typeof breakpoint === "object") {
+      let bp = [];
 
-        if (typeof breakpoint.span === "number") {
-          bp = [...bp, `bx--col-${name}-${breakpoint.span}`];
-        } else if (breakpoint.span === true) {
-          bp = [...bp, `bx--col-${name}`];
-        }
-
-        if (typeof breakpoint.offset === "number") {
-          bp = [...bp, `bx--offset-${name}-${breakpoint.offset}`];
-        }
-
-        return bp.join(" ");
+      if (typeof breakpoint.span === "number") {
+        bp = [...bp, `bx--col-${name}-${breakpoint.span}`];
+      } else if (breakpoint.span === true) {
+        bp = [...bp, `bx--col-${name}`];
       }
-    })
+
+      if (typeof breakpoint.offset === "number") {
+        bp = [...bp, `bx--offset-${name}-${breakpoint.offset}`];
+      }
+
+      return bp.join(" ");
+    }
+  })
+  .filter(Boolean)
+  .join(" ");
+$: props = {
+  ...$$restProps,
+  class: [
+    $$restProps.class,
+    columnClass,
+    !columnClass && "bx--col",
+    noGutter && "bx--no-gutter",
+    noGutterLeft && "bx--no-gutter--left",
+    noGutterRight && "bx--no-gutter--right",
+    aspectRatio && `bx--aspect-ratio bx--aspect-ratio--${aspectRatio}`,
+    padding && "bx--col-padding",
+  ]
     .filter(Boolean)
-    .join(" ");
-  $: props = {
-    ...$$restProps,
-    class: [
-      $$restProps.class,
-      columnClass,
-      !columnClass && "bx--col",
-      noGutter && "bx--no-gutter",
-      noGutterLeft && "bx--no-gutter--left",
-      noGutterRight && "bx--no-gutter--right",
-      aspectRatio && `bx--aspect-ratio bx--aspect-ratio--${aspectRatio}`,
-      padding && "bx--col-padding",
-    ]
-      .filter(Boolean)
-      .join(" "),
-  };
+    .join(" "),
+};
 </script>
 
 {#if as}

--- a/src/Grid/Grid.svelte
+++ b/src/Grid/Grid.svelte
@@ -1,52 +1,52 @@
 <script>
-  /**
-   * @restProps {div}
-   * @slot {{ props: { class: string; [key: string]: any; } }}
-   */
+/**
+ * @restProps {div}
+ * @slot {{ props: { class: string; [key: string]: any; } }}
+ */
 
-  /**
-   * Set to `true` to render a custom HTML element
-   * Props are destructured as `props` in the default slot (e.g., <Grid let:props><header {...props}>...</header></Grid>)
-   */
-  export let as = false;
+/**
+ * Set to `true` to render a custom HTML element
+ * Props are destructured as `props` in the default slot (e.g., <Grid let:props><header {...props}>...</header></Grid>)
+ */
+export let as = false;
 
-  /** Set to `true` to use the condensed variant */
-  export let condensed = false;
+/** Set to `true` to use the condensed variant */
+export let condensed = false;
 
-  /** Set to `true` to use the narrow variant */
-  export let narrow = false;
+/** Set to `true` to use the narrow variant */
+export let narrow = false;
 
-  /** Set to `true` to use the fullWidth variant */
-  export let fullWidth = false;
+/** Set to `true` to use the fullWidth variant */
+export let fullWidth = false;
 
-  /** Set to `true` to remove the gutter */
-  export let noGutter = false;
+/** Set to `true` to remove the gutter */
+export let noGutter = false;
 
-  /** Set to `true` to remove the left gutter */
-  export let noGutterLeft = false;
+/** Set to `true` to remove the left gutter */
+export let noGutterLeft = false;
 
-  /** Set to `true` to remove the right gutter */
-  export let noGutterRight = false;
+/** Set to `true` to remove the right gutter */
+export let noGutterRight = false;
 
-  /** Set to `true` to add top and bottom padding to all columns */
-  export let padding = false;
+/** Set to `true` to add top and bottom padding to all columns */
+export let padding = false;
 
-  $: props = {
-    ...$$restProps,
-    class: [
-      $$restProps.class,
-      "bx--grid",
-      condensed && "bx--grid--condensed",
-      narrow && "bx--grid--narrow",
-      fullWidth && "bx--grid--full-width",
-      noGutter && "bx--no-gutter",
-      noGutterLeft && "bx--no-gutter--left",
-      noGutterRight && "bx--no-gutter--right",
-      padding && "bx--row-padding",
-    ]
-      .filter(Boolean)
-      .join(" "),
-  };
+$: props = {
+  ...$$restProps,
+  class: [
+    $$restProps.class,
+    "bx--grid",
+    condensed && "bx--grid--condensed",
+    narrow && "bx--grid--narrow",
+    fullWidth && "bx--grid--full-width",
+    noGutter && "bx--no-gutter",
+    noGutterLeft && "bx--no-gutter--left",
+    noGutterRight && "bx--no-gutter--right",
+    padding && "bx--row-padding",
+  ]
+    .filter(Boolean)
+    .join(" "),
+};
 </script>
 
 {#if as}

--- a/src/Grid/Row.svelte
+++ b/src/Grid/Row.svelte
@@ -1,48 +1,48 @@
 <script>
-  /**
-   * @restProps {div}
-   * @slot {{ props: { class: string; [key: string]: any; } }}
-   */
+/**
+ * @restProps {div}
+ * @slot {{ props: { class: string; [key: string]: any; } }}
+ */
 
-  /**
-   * Set to `true` to render a custom HTML element
-   * Props are destructured as `props` in the default slot (e.g., <Row let:props><section {...props}>...</section></Row>)
-   */
-  export let as = false;
+/**
+ * Set to `true` to render a custom HTML element
+ * Props are destructured as `props` in the default slot (e.g., <Row let:props><section {...props}>...</section></Row>)
+ */
+export let as = false;
 
-  /** Set to `true` to use the condensed variant */
-  export let condensed = false;
+/** Set to `true` to use the condensed variant */
+export let condensed = false;
 
-  /** Set to `true` to use the narrow variant */
-  export let narrow = false;
+/** Set to `true` to use the narrow variant */
+export let narrow = false;
 
-  /** Set to `true` to remove the gutter */
-  export let noGutter = false;
+/** Set to `true` to remove the gutter */
+export let noGutter = false;
 
-  /** Set to `true` to remove the left gutter */
-  export let noGutterLeft = false;
+/** Set to `true` to remove the left gutter */
+export let noGutterLeft = false;
 
-  /** Set to `true` to remove the right gutter */
-  export let noGutterRight = false;
+/** Set to `true` to remove the right gutter */
+export let noGutterRight = false;
 
-  /** Set to `true` to add top and bottom padding to all columns */
-  export let padding = false;
+/** Set to `true` to add top and bottom padding to all columns */
+export let padding = false;
 
-  $: props = {
-    ...$$restProps,
-    class: [
-      $$restProps.class,
-      "bx--row",
-      condensed && "bx--row--condensed",
-      narrow && "bx--row--narrow",
-      noGutter && "bx--no-gutter",
-      noGutterLeft && "bx--no-gutter--left",
-      noGutterRight && "bx--no-gutter--right",
-      padding && "bx--row-padding",
-    ]
-      .filter(Boolean)
-      .join(" "),
-  };
+$: props = {
+  ...$$restProps,
+  class: [
+    $$restProps.class,
+    "bx--row",
+    condensed && "bx--row--condensed",
+    narrow && "bx--row--narrow",
+    noGutter && "bx--no-gutter",
+    noGutterLeft && "bx--no-gutter--left",
+    noGutterRight && "bx--no-gutter--right",
+    padding && "bx--row-padding",
+  ]
+    .filter(Boolean)
+    .join(" "),
+};
 </script>
 
 {#if as}

--- a/src/ImageLoader/ImageLoader.svelte
+++ b/src/ImageLoader/ImageLoader.svelte
@@ -1,79 +1,79 @@
 <script>
-  /**
-   * @event {null} load
-   * @event {null} error
-   */
+/**
+ * @event {null} load
+ * @event {null} error
+ */
 
-  /**
-   * Specify the image source
-   */
-  export let src = "";
+/**
+ * Specify the image source
+ */
+export let src = "";
 
-  /**
-   * Specify the image alt text
-   */
-  export let alt = "";
+/**
+ * Specify the image alt text
+ */
+export let alt = "";
 
-  /**
-   * Specify the aspect ratio for the image wrapper
-   * @type {"2x1" | "16x9" | "4x3" | "1x1" | "3x4" | "3x2" | "9x16" | "1x2"}
-   */
-  export let ratio = undefined;
+/**
+ * Specify the aspect ratio for the image wrapper
+ * @type {"2x1" | "16x9" | "4x3" | "1x1" | "3x4" | "3x2" | "9x16" | "1x2"}
+ */
+export let ratio = undefined;
 
-  /**
-   * Set to `true` when `loaded` is `true` and `error` is false
-   */
-  export let loading = false;
+/**
+ * Set to `true` when `loaded` is `true` and `error` is false
+ */
+export let loading = false;
 
-  /**
-   * Set to `true` when the image is loaded
-   */
-  export let loaded = false;
+/**
+ * Set to `true` when the image is loaded
+ */
+export let loaded = false;
 
-  /**
-   * Set to `true` if an error occurs when loading the image
-   */
-  export let error = false;
+/**
+ * Set to `true` if an error occurs when loading the image
+ */
+export let error = false;
 
-  /**
-   * Set to `true` to fade in the image on load
-   * The duration uses the `fast-02` value following Carbon guidelines on motion
-   */
-  export let fadeIn = false;
+/**
+ * Set to `true` to fade in the image on load
+ * The duration uses the `fast-02` value following Carbon guidelines on motion
+ */
+export let fadeIn = false;
 
-  /**
-   * Method invoked to load the image provided a `src` value
-   * @type {(url?: string) => void}
-   */
-  export const loadImage = (url) => {
-    if (image != null) image = null;
-    loaded = false;
-    error = false;
-    image = new Image();
-    image.src = url || src;
-    image.onload = () => (loaded = true);
-    image.onerror = () => (error = true);
-  };
+/**
+ * Method invoked to load the image provided a `src` value
+ * @type {(url?: string) => void}
+ */
+export const loadImage = (url) => {
+  if (image != null) image = null;
+  loaded = false;
+  error = false;
+  image = new Image();
+  image.src = url || src;
+  image.onload = () => (loaded = true);
+  image.onerror = () => (error = true);
+};
 
-  import { onMount, createEventDispatcher } from "svelte";
-  import { fade } from "svelte/transition";
-  import AspectRatio from "../AspectRatio/AspectRatio.svelte";
+import { onMount, createEventDispatcher } from "svelte";
+import { fade } from "svelte/transition";
+import AspectRatio from "../AspectRatio/AspectRatio.svelte";
 
-  const dispatch = createEventDispatcher();
+const dispatch = createEventDispatcher();
 
-  // "fast-02" duration (ms) from Carbon motion recommended for fading micro-interactions
-  const fast02 = 110;
+// "fast-02" duration (ms) from Carbon motion recommended for fading micro-interactions
+const fast02 = 110;
 
-  let image = null;
+let image = null;
 
-  $: loading = !loaded && !error;
-  $: if (src && typeof window !== "undefined") loadImage();
-  $: if (loaded) dispatch("load");
-  $: if (error) dispatch("error");
+$: loading = !loaded && !error;
+$: if (src && typeof window !== "undefined") loadImage();
+$: if (loaded) dispatch("load");
+$: if (error) dispatch("error");
 
-  onMount(() => {
-    return () => (image = null);
-  });
+onMount(() => {
+  return () => (image = null);
+});
 </script>
 
 {#if ratio === undefined}

--- a/src/InlineLoading/InlineLoading.svelte
+++ b/src/InlineLoading/InlineLoading.svelte
@@ -1,48 +1,48 @@
 <script>
-  /**
-   * Set the loading status
-   * @type {"active" | "inactive" | "finished" | "error"}
-   */
-  export let status = "active";
+/**
+ * Set the loading status
+ * @type {"active" | "inactive" | "finished" | "error"}
+ */
+export let status = "active";
 
-  /**
-   * Set the loading description
-   * @type {string}
-   */
-  export let description = undefined;
+/**
+ * Set the loading description
+ * @type {string}
+ */
+export let description = undefined;
 
-  /**
-   * Specify a description for the loading icon.
-   * Defaults to the `status` prop for the "error" and "finished" states
-   * @type {string}
-   */
-  export let iconDescription = undefined;
+/**
+ * Specify a description for the loading icon.
+ * Defaults to the `status` prop for the "error" and "finished" states
+ * @type {string}
+ */
+export let iconDescription = undefined;
 
-  /** Specify the timeout delay (ms) after `status` is set to "success" */
-  export let successDelay = 1500;
+/** Specify the timeout delay (ms) after `status` is set to "success" */
+export let successDelay = 1500;
 
-  import { createEventDispatcher, afterUpdate, onMount } from "svelte";
-  import CheckmarkFilled from "../icons/CheckmarkFilled.svelte";
-  import ErrorFilled from "../icons/ErrorFilled.svelte";
-  import Loading from "../Loading/Loading.svelte";
+import { createEventDispatcher, afterUpdate, onMount } from "svelte";
+import CheckmarkFilled from "../icons/CheckmarkFilled.svelte";
+import ErrorFilled from "../icons/ErrorFilled.svelte";
+import Loading from "../Loading/Loading.svelte";
 
-  const dispatch = createEventDispatcher();
+const dispatch = createEventDispatcher();
 
-  let timeout = undefined;
+let timeout = undefined;
 
-  onMount(() => {
-    return () => {
-      clearTimeout(timeout);
-    };
-  });
+onMount(() => {
+  return () => {
+    clearTimeout(timeout);
+  };
+});
 
-  afterUpdate(() => {
-    if (status === "finished") {
-      timeout = setTimeout(() => {
-        dispatch("success");
-      }, successDelay);
-    }
-  });
+afterUpdate(() => {
+  if (status === "finished") {
+    timeout = setTimeout(() => {
+      dispatch("success");
+    }, successDelay);
+  }
+});
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->

--- a/src/Link/Link.svelte
+++ b/src/Link/Link.svelte
@@ -1,34 +1,34 @@
 <script>
-  /**
-   * Specify the size of the link
-   * @type {"sm" | "lg"}
-   */
-  export let size = undefined;
+/**
+ * Specify the size of the link
+ * @type {"sm" | "lg"}
+ */
+export let size = undefined;
 
-  /**
-   * Specify the href value
-   * @type {string}
-   */
-  export let href = undefined;
+/**
+ * Specify the href value
+ * @type {string}
+ */
+export let href = undefined;
 
-  /** Set to `true` to use the inline variant */
-  export let inline = false;
+/** Set to `true` to use the inline variant */
+export let inline = false;
 
-  /**
-   * Specify the icon to render
-   * `inline` must be `false`
-   * @type {any}
-   */
-  export let icon = undefined;
+/**
+ * Specify the icon to render
+ * `inline` must be `false`
+ * @type {any}
+ */
+export let icon = undefined;
 
-  /** Set to `true` to disable the checkbox */
-  export let disabled = false;
+/** Set to `true` to disable the checkbox */
+export let disabled = false;
 
-  /** Set to `true` to allow visited styles */
-  export let visited = false;
+/** Set to `true` to allow visited styles */
+export let visited = false;
 
-  /** Obtain a reference to the top-level HTML element */
-  export let ref = null;
+/** Obtain a reference to the top-level HTML element */
+export let ref = null;
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->

--- a/src/Link/OutboundLink.svelte
+++ b/src/Link/OutboundLink.svelte
@@ -1,8 +1,8 @@
 <script>
-  /** @extends {"./Link.svelte"} LinkProps */
+/** @extends {"./Link.svelte"} LinkProps */
 
-  import Link from "./Link.svelte";
-  import Launch from "../icons/Launch.svelte";
+import Link from "./Link.svelte";
+import Launch from "../icons/Launch.svelte";
 </script>
 
 <Link

--- a/src/ListBox/ListBox.svelte
+++ b/src/ListBox/ListBox.svelte
@@ -1,36 +1,36 @@
 <script>
-  /**
-   * Set the size of the list box
-   * @type {"sm" | "xl"}
-   */
-  export let size = undefined;
+/**
+ * Set the size of the list box
+ * @type {"sm" | "xl"}
+ */
+export let size = undefined;
 
-  /**
-   * Set the type of the list box
-   * @type {"default" | "inline"}
-   */
-  export let type = "default";
+/**
+ * Set the type of the list box
+ * @type {"default" | "inline"}
+ */
+export let type = "default";
 
-  /** Set to `true` to open the list box */
-  export let open = false;
+/** Set to `true` to open the list box */
+export let open = false;
 
-  /** Set to `true` to enable the light variant */
-  export let light = false;
+/** Set to `true` to enable the light variant */
+export let light = false;
 
-  /** Set to `true` to disable the list box */
-  export let disabled = false;
+/** Set to `true` to disable the list box */
+export let disabled = false;
 
-  /** Set to `true` to indicate an invalid state */
-  export let invalid = false;
+/** Set to `true` to indicate an invalid state */
+export let invalid = false;
 
-  /** Specify the invalid state text */
-  export let invalidText = "";
+/** Specify the invalid state text */
+export let invalidText = "";
 
-  /** Set to `true` to indicate an warning state */
-  export let warn = false;
+/** Set to `true` to indicate an warning state */
+export let warn = false;
 
-  /** Specify the warning state text */
-  export let warnText = "";
+/** Specify the warning state text */
+export let warnText = "";
 </script>
 
 <div

--- a/src/ListBox/ListBoxField.svelte
+++ b/src/ListBox/ListBoxField.svelte
@@ -1,46 +1,46 @@
 <script>
-  /**
-   * @typedef {"close" | "open"} ListBoxFieldTranslationId
-   */
+/**
+ * @typedef {"close" | "open"} ListBoxFieldTranslationId
+ */
 
-  /** Set to `true` to disable the list box field */
-  export let disabled = false;
+/** Set to `true` to disable the list box field */
+export let disabled = false;
 
-  /** Specify the role attribute */
-  export let role = "combobox";
+/** Specify the role attribute */
+export let role = "combobox";
 
-  /** Specify the tabindex */
-  export let tabindex = "-1";
+/** Specify the tabindex */
+export let tabindex = "-1";
 
-  /** Default translation ids */
-  export const translationIds = { close: "close", open: "open" };
+/** Default translation ids */
+export const translationIds = { close: "close", open: "open" };
 
-  /**
-   * Override the default translation ids
-   * @type {(id: ListBoxFieldTranslationId) => string}
-   */
-  export let translateWithId = (id) => defaultTranslations[id];
+/**
+ * Override the default translation ids
+ * @type {(id: ListBoxFieldTranslationId) => string}
+ */
+export let translateWithId = (id) => defaultTranslations[id];
 
-  /** Set an id for the top-level element */
-  export let id = "ccs-" + Math.random().toString(36);
+/** Set an id for the top-level element */
+export let id = "ccs-" + Math.random().toString(36);
 
-  /** Obtain a reference to the top-level HTML element */
-  export let ref = null;
+/** Obtain a reference to the top-level HTML element */
+export let ref = null;
 
-  import { getContext } from "svelte";
+import { getContext } from "svelte";
 
-  const defaultTranslations = {
-    [translationIds.close]: "Close menu",
-    [translationIds.open]: "Open menu",
-  };
-  const ctx = getContext("MultiSelect");
+const defaultTranslations = {
+  [translationIds.close]: "Close menu",
+  [translationIds.open]: "Open menu",
+};
+const ctx = getContext("MultiSelect");
 
-  $: if (ctx && ref) {
-    ctx.declareRef({ key: "field", ref });
-  }
+$: if (ctx && ref) {
+  ctx.declareRef({ key: "field", ref });
+}
 
-  $: ariaExpanded = $$props["aria-expanded"];
-  $: menuId = `menu-${id}`;
+$: ariaExpanded = $$props["aria-expanded"];
+$: menuId = `menu-${id}`;
 </script>
 
 <!-- svelte-ignore a11y-no-noninteractive-tabindex -->

--- a/src/ListBox/ListBoxMenu.svelte
+++ b/src/ListBox/ListBoxMenu.svelte
@@ -1,9 +1,9 @@
 <script>
-  /** Set an id for the top-level element */
-  export let id = "ccs-" + Math.random().toString(36);
+/** Set an id for the top-level element */
+export let id = "ccs-" + Math.random().toString(36);
 
-  /** Obtain a reference to the HTML element */
-  export let ref = null;
+/** Obtain a reference to the HTML element */
+export let ref = null;
 </script>
 
 <div

--- a/src/ListBox/ListBoxMenuIcon.svelte
+++ b/src/ListBox/ListBoxMenuIcon.svelte
@@ -1,30 +1,30 @@
 <script>
-  /**
-   * @typedef {"close" | "open"} ListBoxMenuIconTranslationId
-   */
+/**
+ * @typedef {"close" | "open"} ListBoxMenuIconTranslationId
+ */
 
-  /** Set to `true` to open the list box menu icon */
-  export let open = false;
+/** Set to `true` to open the list box menu icon */
+export let open = false;
 
-  /** Default translation ids */
-  export const translationIds = { close: "close", open: "open" };
+/** Default translation ids */
+export const translationIds = { close: "close", open: "open" };
 
-  /**
-   * Override the default translation ids
-   * @type {(id: ListBoxMenuIconTranslationId) => string}
-   */
-  export let translateWithId = (id) => defaultTranslations[id];
+/**
+ * Override the default translation ids
+ * @type {(id: ListBoxMenuIconTranslationId) => string}
+ */
+export let translateWithId = (id) => defaultTranslations[id];
 
-  import ChevronDown from "../icons/ChevronDown.svelte";
+import ChevronDown from "../icons/ChevronDown.svelte";
 
-  const defaultTranslations = {
-    [translationIds.close]: "Close menu",
-    [translationIds.open]: "Open menu",
-  };
+const defaultTranslations = {
+  [translationIds.close]: "Close menu",
+  [translationIds.open]: "Open menu",
+};
 
-  $: translationId = open ? translationIds.close : translationIds.open;
-  $: description =
-    translateWithId?.(translationId) ?? defaultTranslations[translationId];
+$: translationId = open ? translationIds.close : translationIds.open;
+$: description =
+  translateWithId?.(translationId) ?? defaultTranslations[translationId];
 </script>
 
 <!-- svelte-ignore a11y-no-static-element-interactions -->

--- a/src/ListBox/ListBoxMenuItem.svelte
+++ b/src/ListBox/ListBoxMenuItem.svelte
@@ -1,21 +1,21 @@
 <script>
-  /** Set to `true` to enable the active state */
-  export let active = false;
+/** Set to `true` to enable the active state */
+export let active = false;
 
-  /** Set to `true` to enable the highlighted state */
-  export let highlighted = false;
+/** Set to `true` to enable the highlighted state */
+export let highlighted = false;
 
-  /** Set to `true` to disable the menu item */
-  export let disabled = false;
+/** Set to `true` to disable the menu item */
+export let disabled = false;
 
-  let ref = null;
+let ref = null;
 
-  $: isTruncated = ref?.offsetWidth < ref?.scrollWidth;
-  $: title = isTruncated ? ref?.innerText : undefined;
-  $: if (highlighted && ref && !ref.matches(":hover")) {
-    // Scroll highlighted item into view if using keyboard navigation
-    ref.scrollIntoView({ block: "nearest" });
-  }
+$: isTruncated = ref?.offsetWidth < ref?.scrollWidth;
+$: title = isTruncated ? ref?.innerText : undefined;
+$: if (highlighted && ref && !ref.matches(":hover")) {
+  // Scroll highlighted item into view if using keyboard navigation
+  ref.scrollIntoView({ block: "nearest" });
+}
 </script>
 
 <div

--- a/src/ListBox/ListBoxSelection.svelte
+++ b/src/ListBox/ListBoxSelection.svelte
@@ -1,57 +1,57 @@
 <script>
-  /**
-   * @event {KeyboardEvent | MouseEvent} clear
-   */
+/**
+ * @event {KeyboardEvent | MouseEvent} clear
+ */
 
-  /**
-   * @typedef {"clearAll" | "clearSelection"} ListBoxSelectionTranslationId
-   */
+/**
+ * @typedef {"clearAll" | "clearSelection"} ListBoxSelectionTranslationId
+ */
 
-  /**
-   * Specify the number of selected items
-   * @type {number}
-   */
-  export let selectionCount = undefined;
+/**
+ * Specify the number of selected items
+ * @type {number}
+ */
+export let selectionCount = undefined;
 
-  /** Set to `true` to disable the list box selection */
-  export let disabled = false;
+/** Set to `true` to disable the list box selection */
+export let disabled = false;
 
-  /** Default translation ids */
-  export const translationIds = {
-    clearAll: "clearAll",
-    clearSelection: "clearSelection",
-  };
+/** Default translation ids */
+export const translationIds = {
+  clearAll: "clearAll",
+  clearSelection: "clearSelection",
+};
 
-  /**
-   * Override the default translation ids
-   * @type {(id: ListBoxSelectionTranslationId) => string}
-   */
-  export let translateWithId = (id) => defaultTranslations[id];
+/**
+ * Override the default translation ids
+ * @type {(id: ListBoxSelectionTranslationId) => string}
+ */
+export let translateWithId = (id) => defaultTranslations[id];
 
-  /** Obtain a reference to the top-level HTML element */
-  export let ref = null;
+/** Obtain a reference to the top-level HTML element */
+export let ref = null;
 
-  import { createEventDispatcher, getContext } from "svelte";
-  import Close from "../icons/Close.svelte";
+import { createEventDispatcher, getContext } from "svelte";
+import Close from "../icons/Close.svelte";
 
-  const defaultTranslations = {
-    [translationIds.clearAll]: "Clear all selected items",
-    [translationIds.clearSelection]: "Clear selected item",
-  };
-  const dispatch = createEventDispatcher();
-  const ctx = getContext("MultiSelect");
+const defaultTranslations = {
+  [translationIds.clearAll]: "Clear all selected items",
+  [translationIds.clearSelection]: "Clear selected item",
+};
+const dispatch = createEventDispatcher();
+const ctx = getContext("MultiSelect");
 
-  $: if (ctx && ref) {
-    ctx.declareRef({ key: "selection", ref });
-  }
-  $: translationId =
-    selectionCount === undefined
-      ? translationIds.clearSelection
-      : translationIds.clearAll;
-  $: buttonLabel =
-    translateWithId?.(translationId) ?? defaultTranslations[translationId];
-  $: description =
-    translateWithId?.(translationId) ?? defaultTranslations[translationId];
+$: if (ctx && ref) {
+  ctx.declareRef({ key: "selection", ref });
+}
+$: translationId =
+  selectionCount === undefined
+    ? translationIds.clearSelection
+    : translationIds.clearAll;
+$: buttonLabel =
+  translateWithId?.(translationId) ?? defaultTranslations[translationId];
+$: description =
+  translateWithId?.(translationId) ?? defaultTranslations[translationId];
 </script>
 
 {#if selectionCount !== undefined}

--- a/src/Loading/Loading.svelte
+++ b/src/Loading/Loading.svelte
@@ -1,17 +1,17 @@
 <script>
-  /** Set to `true` to use the small variant */
-  export let small = false;
+/** Set to `true` to use the small variant */
+export let small = false;
 
-  /** Set to `false` to disable the active state */
-  export let active = true;
+/** Set to `false` to disable the active state */
+export let active = true;
 
-  /** Set to `false` to disable the overlay */
-  export let withOverlay = true;
+/** Set to `false` to disable the overlay */
+export let withOverlay = true;
 
-  /** Specify the description to describe the loading state */
-  export let description = "loading";
+/** Specify the description to describe the loading state */
+export let description = "loading";
 
-  $: spinnerRadius = small ? "42" : "44";
+$: spinnerRadius = small ? "42" : "44";
 </script>
 
 {#if withOverlay}

--- a/src/LocalStorage/LocalStorage.svelte
+++ b/src/LocalStorage/LocalStorage.svelte
@@ -1,71 +1,71 @@
 <script>
-  /**
-   * @event {null} save
-   * @event {{ prevValue: any; value: any; }} update
-   */
+/**
+ * @event {null} save
+ * @event {{ prevValue: any; value: any; }} update
+ */
 
-  /**
-   * Specify the local storage key
-   */
-  export let key = "local-storage-key";
+/**
+ * Specify the local storage key
+ */
+export let key = "local-storage-key";
 
-  /**
-   * Provide a value to persist
-   * @type {any}
-   */
-  export let value = "";
+/**
+ * Provide a value to persist
+ * @type {any}
+ */
+export let value = "";
 
-  /**
-   * Remove the persisted key value from the browser's local storage
-   * @type {() => void}
-   */
-  export function clearItem() {
-    localStorage.removeItem(key);
+/**
+ * Remove the persisted key value from the browser's local storage
+ * @type {() => void}
+ */
+export function clearItem() {
+  localStorage.removeItem(key);
+}
+
+/**
+ * Clear all key values from the browser's local storage
+ * @type {() => void}
+ */
+export function clearAll() {
+  localStorage.clear();
+}
+
+import { onMount, afterUpdate, createEventDispatcher } from "svelte";
+
+const dispatch = createEventDispatcher();
+
+let prevValue = value;
+
+function setItem() {
+  if (typeof value === "object") {
+    localStorage.setItem(key, JSON.stringify(value));
+  } else {
+    localStorage.setItem(key, value);
+  }
+}
+
+onMount(() => {
+  const item = localStorage.getItem(key);
+
+  if (item != null) {
+    try {
+      value = JSON.parse(item);
+    } catch (e) {
+      value = item;
+    }
+  } else {
+    setItem(value);
+    dispatch("save");
+  }
+});
+
+afterUpdate(() => {
+  if (prevValue !== value) {
+    setItem(value);
+    dispatch("update", { prevValue, value });
   }
 
-  /**
-   * Clear all key values from the browser's local storage
-   * @type {() => void}
-   */
-  export function clearAll() {
-    localStorage.clear();
-  }
-
-  import { onMount, afterUpdate, createEventDispatcher } from "svelte";
-
-  const dispatch = createEventDispatcher();
-
-  let prevValue = value;
-
-  function setItem() {
-    if (typeof value === "object") {
-      localStorage.setItem(key, JSON.stringify(value));
-    } else {
-      localStorage.setItem(key, value);
-    }
-  }
-
-  onMount(() => {
-    const item = localStorage.getItem(key);
-
-    if (item != null) {
-      try {
-        value = JSON.parse(item);
-      } catch (e) {
-        value = item;
-      }
-    } else {
-      setItem(value);
-      dispatch("save");
-    }
-  });
-
-  afterUpdate(() => {
-    if (prevValue !== value) {
-      setItem(value);
-      dispatch("update", { prevValue, value });
-    }
-
-    prevValue = value;
-  });
+  prevValue = value;
+});
 </script>

--- a/src/Modal/Modal.svelte
+++ b/src/Modal/Modal.svelte
@@ -1,135 +1,135 @@
 <script>
-  /**
-   * @event {{ open: boolean; }} transitionend
-   * @event {{ text: string; }} click:button--secondary
-   */
+/**
+ * @event {{ open: boolean; }} transitionend
+ * @event {{ text: string; }} click:button--secondary
+ */
 
-  /**
-   * Set the size of the modal
-   * @type {"xs" | "sm" | "lg"}
-   */
-  export let size = undefined;
+/**
+ * Set the size of the modal
+ * @type {"xs" | "sm" | "lg"}
+ */
+export let size = undefined;
 
-  /** Set to `true` to open the modal */
-  export let open = false;
+/** Set to `true` to open the modal */
+export let open = false;
 
-  /** Set to `true` to use the danger variant */
-  export let danger = false;
+/** Set to `true` to use the danger variant */
+export let danger = false;
 
-  /** Set to `true` to enable alert mode */
-  export let alert = false;
+/** Set to `true` to enable alert mode */
+export let alert = false;
 
-  /** Set to `true` to use the passive variant */
-  export let passiveModal = false;
+/** Set to `true` to use the passive variant */
+export let passiveModal = false;
 
-  /**
-   * Specify the modal heading
-   * @type {string}
-   */
-  export let modalHeading = undefined;
+/**
+ * Specify the modal heading
+ * @type {string}
+ */
+export let modalHeading = undefined;
 
-  /**
-   * Specify the modal label
-   * @type {string}
-   */
-  export let modalLabel = undefined;
+/**
+ * Specify the modal label
+ * @type {string}
+ */
+export let modalLabel = undefined;
 
-  /**
-   * Specify the ARIA label for the modal
-   * @type {string}
-   */
-  export let modalAriaLabel = undefined;
+/**
+ * Specify the ARIA label for the modal
+ * @type {string}
+ */
+export let modalAriaLabel = undefined;
 
-  /** Specify the ARIA label for the close icon */
-  export let iconDescription = "Close the modal";
+/** Specify the ARIA label for the close icon */
+export let iconDescription = "Close the modal";
 
-  /** Set to `true` if the modal contains form elements */
-  export let hasForm = false;
+/** Set to `true` if the modal contains form elements */
+export let hasForm = false;
 
-  /** Set to `true` if the modal contains scrolling content */
-  export let hasScrollingContent = false;
+/** Set to `true` if the modal contains scrolling content */
+export let hasScrollingContent = false;
 
-  /** Specify the primary button text */
-  export let primaryButtonText = "";
+/** Specify the primary button text */
+export let primaryButtonText = "";
 
-  /** Set to `true` to disable the primary button */
-  export let primaryButtonDisabled = false;
+/** Set to `true` to disable the primary button */
+export let primaryButtonDisabled = false;
 
-  /**
-   * Specify the primary button icon
-   * @type {any}
-   */
-  export let primaryButtonIcon = undefined;
+/**
+ * Specify the primary button icon
+ * @type {any}
+ */
+export let primaryButtonIcon = undefined;
 
-  /**
-   * Set to `true` for the "submit" and "click:button--primary" events
-   * to be dispatched when pressing "Enter"
-   */
-  export let shouldSubmitOnEnter = true;
+/**
+ * Set to `true` for the "submit" and "click:button--primary" events
+ * to be dispatched when pressing "Enter"
+ */
+export let shouldSubmitOnEnter = true;
 
-  /** Specify the secondary button text */
-  export let secondaryButtonText = "";
+/** Specify the secondary button text */
+export let secondaryButtonText = "";
 
-  /**
-   * 2-tuple prop to render two secondary buttons for a 3 button modal
-   * supersedes `secondaryButtonText`
-   * @type {[{ text: string; }, { text: string; }]}
-   */
-  export let secondaryButtons = [];
+/**
+ * 2-tuple prop to render two secondary buttons for a 3 button modal
+ * supersedes `secondaryButtonText`
+ * @type {[{ text: string; }, { text: string; }]}
+ */
+export let secondaryButtons = [];
 
-  /** Specify a selector to be focused when opening the modal */
-  export let selectorPrimaryFocus = "[data-modal-primary-focus]";
+/** Specify a selector to be focused when opening the modal */
+export let selectorPrimaryFocus = "[data-modal-primary-focus]";
 
-  /** Set to `true` to prevent the modal from closing when clicking outside */
-  export let preventCloseOnClickOutside = false;
+/** Set to `true` to prevent the modal from closing when clicking outside */
+export let preventCloseOnClickOutside = false;
 
-  /** Set an id for the top-level element */
-  export let id = "ccs-" + Math.random().toString(36);
+/** Set an id for the top-level element */
+export let id = "ccs-" + Math.random().toString(36);
 
-  /** Obtain a reference to the top-level HTML element */
-  export let ref = null;
+/** Obtain a reference to the top-level HTML element */
+export let ref = null;
 
-  import { createEventDispatcher, afterUpdate } from "svelte";
-  import Close from "../icons/Close.svelte";
-  import Button from "../Button/Button.svelte";
-  import { trackModal } from "./modalStore";
-  import { writable } from "svelte/store";
+import { createEventDispatcher, afterUpdate } from "svelte";
+import Close from "../icons/Close.svelte";
+import Button from "../Button/Button.svelte";
+import { trackModal } from "./modalStore";
+import { writable } from "svelte/store";
 
-  const dispatch = createEventDispatcher();
+const dispatch = createEventDispatcher();
 
-  let buttonRef = null;
-  let innerModal = null;
-  let opened = false;
-  let didClickInnerModal = false;
+let buttonRef = null;
+let innerModal = null;
+let opened = false;
+let didClickInnerModal = false;
 
-  function focus(element) {
-    const node =
-      (element || innerModal).querySelector(selectorPrimaryFocus) || buttonRef;
-    node.focus();
-  }
+function focus(element) {
+  const node =
+    (element || innerModal).querySelector(selectorPrimaryFocus) || buttonRef;
+  node.focus();
+}
 
-  const openStore = writable(open);
-  $: $openStore = open;
-  trackModal(openStore);
+const openStore = writable(open);
+$: $openStore = open;
+trackModal(openStore);
 
-  afterUpdate(() => {
-    if (opened) {
-      if (!open) {
-        opened = false;
-        dispatch("close");
-      }
-    } else if (open) {
-      opened = true;
-      focus();
-      dispatch("open");
+afterUpdate(() => {
+  if (opened) {
+    if (!open) {
+      opened = false;
+      dispatch("close");
     }
-  });
+  } else if (open) {
+    opened = true;
+    focus();
+    dispatch("open");
+  }
+});
 
-  $: modalLabelId = `bx--modal-header__label--modal-${id}`;
-  $: modalHeadingId = `bx--modal-header__heading--modal-${id}`;
-  $: modalBodyId = `bx--modal-body--${id}`;
-  $: ariaLabel =
-    modalLabel || $$props["aria-label"] || modalAriaLabel || modalHeading;
+$: modalLabelId = `bx--modal-header__label--modal-${id}`;
+$: modalHeadingId = `bx--modal-header__heading--modal-${id}`;
+$: modalBodyId = `bx--modal-body--${id}`;
+$: ariaLabel =
+  modalLabel || $$props["aria-label"] || modalAriaLabel || modalHeading;
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->

--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -1,297 +1,291 @@
 <script>
-  /**
-   * @typedef {any} MultiSelectItemId
-   * @typedef {string} MultiSelectItemText
-   * @typedef {{ id: MultiSelectItemId; text: MultiSelectItemText; disabled?: boolean; }} MultiSelectItem
-   * @event {{ selectedIds: MultiSelectItemId[]; selected: MultiSelectItem[]; unselected: MultiSelectItem[]; }} select
-   * @event {null} clear
-   * @event {FocusEvent | CustomEvent<FocusEvent>} blur
-   * @slot {{ item: MultiSelectItem; index: number }}
-   */
+/**
+ * @typedef {any} MultiSelectItemId
+ * @typedef {string} MultiSelectItemText
+ * @typedef {{ id: MultiSelectItemId; text: MultiSelectItemText; disabled?: boolean; }} MultiSelectItem
+ * @event {{ selectedIds: MultiSelectItemId[]; selected: MultiSelectItem[]; unselected: MultiSelectItem[]; }} select
+ * @event {null} clear
+ * @event {FocusEvent | CustomEvent<FocusEvent>} blur
+ * @slot {{ item: MultiSelectItem; index: number }}
+ */
 
-  /**
-   * Set the multiselect items
-   * @type {ReadonlyArray<MultiSelectItem>}
-   */
-  export let items = [];
+/**
+ * Set the multiselect items
+ * @type {ReadonlyArray<MultiSelectItem>}
+ */
+export let items = [];
 
-  /**
-   * Override the display of a multiselect item
-   * @type {(item: MultiSelectItem) => any}
-   */
-  export let itemToString = (item) => item.text || item.id;
+/**
+ * Override the display of a multiselect item
+ * @type {(item: MultiSelectItem) => any}
+ */
+export let itemToString = (item) => item.text || item.id;
 
-  /**
-   * Override the item name, title, labelText, or value passed to the user-selectable checkbox input as well as the hidden inputs.
-   * @type {(item: MultiSelectItem) => { name?: string; labelText?: any; title?: string; value?: string }}
-   */
-  export let itemToInput = (item) => {};
+/**
+ * Override the item name, title, labelText, or value passed to the user-selectable checkbox input as well as the hidden inputs.
+ * @type {(item: MultiSelectItem) => { name?: string; labelText?: any; title?: string; value?: string }}
+ */
+export let itemToInput = (item) => {};
 
-  /**
-   * Set the selected ids
-   * @type {ReadonlyArray<MultiSelectItemId>}
-   */
-  export let selectedIds = [];
+/**
+ * Set the selected ids
+ * @type {ReadonlyArray<MultiSelectItemId>}
+ */
+export let selectedIds = [];
 
-  /** Specify the multiselect value */
-  export let value = "";
+/** Specify the multiselect value */
+export let value = "";
 
-  /**
-   * Set the size of the combobox
-   * @type {"sm" | "lg" | "xl"}
-   */
-  export let size = undefined;
+/**
+ * Set the size of the combobox
+ * @type {"sm" | "lg" | "xl"}
+ */
+export let size = undefined;
 
-  /**
-   * Specify the type of multiselect
-   * @type {"default" | "inline"}
-   */
-  export let type = "default";
+/**
+ * Specify the type of multiselect
+ * @type {"default" | "inline"}
+ */
+export let type = "default";
 
-  /**
-   * Specify the direction of the multiselect dropdown menu
-   * @type {"bottom" | "top"}
-   */
-  export let direction = "bottom";
+/**
+ * Specify the direction of the multiselect dropdown menu
+ * @type {"bottom" | "top"}
+ */
+export let direction = "bottom";
 
-  /**
-   * Specify the selection feedback after selecting items
-   * @type {"top" | "fixed" | "top-after-reopen"}
-   */
-  export let selectionFeedback = "top-after-reopen";
+/**
+ * Specify the selection feedback after selecting items
+ * @type {"top" | "fixed" | "top-after-reopen"}
+ */
+export let selectionFeedback = "top-after-reopen";
 
-  /** Set to `true` to disable the dropdown */
-  export let disabled = false;
+/** Set to `true` to disable the dropdown */
+export let disabled = false;
 
-  /** Set to `true` to filter items */
-  export let filterable = false;
+/** Set to `true` to filter items */
+export let filterable = false;
 
-  /**
-   * Override the filtering logic
-   * The default filtering is an exact string comparison
-   * @type {(item: MultiSelectItem, value: string) => boolean}
-   */
-  export let filterItem = (item, value) =>
-    item.text.toLowerCase().includes(value.trim().toLowerCase());
+/**
+ * Override the filtering logic
+ * The default filtering is an exact string comparison
+ * @type {(item: MultiSelectItem, value: string) => boolean}
+ */
+export let filterItem = (item, value) =>
+  item.text.toLowerCase().includes(value.trim().toLowerCase());
 
-  /** Set to `true` to open the dropdown */
-  export let open = false;
+/** Set to `true` to open the dropdown */
+export let open = false;
 
-  /** Set to `true` to enable the light variant */
-  export let light = false;
+/** Set to `true` to enable the light variant */
+export let light = false;
 
-  /** Specify the locale */
-  export let locale = "en";
+/** Specify the locale */
+export let locale = "en";
 
-  /** Specify the placeholder text */
-  export let placeholder = "";
+/** Specify the placeholder text */
+export let placeholder = "";
 
-  /**
-   * Override the sorting logic
-   * The default sorting compare the item text value
-   * @type {((a: MultiSelectItem, b: MultiSelectItem) => MultiSelectItem) | (() => void)}
-   */
-  export let sortItem = (a, b) =>
-    a.text.localeCompare(b.text, locale, { numeric: true });
+/**
+ * Override the sorting logic
+ * The default sorting compare the item text value
+ * @type {((a: MultiSelectItem, b: MultiSelectItem) => MultiSelectItem) | (() => void)}
+ */
+export let sortItem = (a, b) =>
+  a.text.localeCompare(b.text, locale, { numeric: true });
 
-  /**
-   * Override the chevron icon label based on the open state.
-   * Defaults to "Open menu" when closed and "Close menu" when open
-   * @type {(id: import("../ListBox/ListBoxMenuIcon.svelte").ListBoxMenuIconTranslationId) => string}
-   */
-  export let translateWithId = undefined;
+/**
+ * Override the chevron icon label based on the open state.
+ * Defaults to "Open menu" when closed and "Close menu" when open
+ * @type {(id: import("../ListBox/ListBoxMenuIcon.svelte").ListBoxMenuIconTranslationId) => string}
+ */
+export let translateWithId = undefined;
 
-  /**
-   * Override the label of the clear button when the input has a selection.
-   * Defaults to "Clear selected item" and "Clear all items" if more than one item is selected
-   * @type {(id: import("../ListBox/ListBoxSelection.svelte").ListBoxSelectionTranslationId) => string}
-   */
-  export let translateWithIdSelection = undefined;
+/**
+ * Override the label of the clear button when the input has a selection.
+ * Defaults to "Clear selected item" and "Clear all items" if more than one item is selected
+ * @type {(id: import("../ListBox/ListBoxSelection.svelte").ListBoxSelectionTranslationId) => string}
+ */
+export let translateWithIdSelection = undefined;
 
-  /** Specify the title text */
-  export let titleText = "";
+/** Specify the title text */
+export let titleText = "";
 
-  /** Set to `true` to pass the item to `itemToString` in the checkbox */
-  export let useTitleInItem = false;
+/** Set to `true` to pass the item to `itemToString` in the checkbox */
+export let useTitleInItem = false;
 
-  /** Set to `true` to indicate an invalid state */
-  export let invalid = false;
+/** Set to `true` to indicate an invalid state */
+export let invalid = false;
 
-  /** Specify the invalid state text */
-  export let invalidText = "";
+/** Specify the invalid state text */
+export let invalidText = "";
 
-  /** Set to `true` to indicate an warning state */
-  export let warn = false;
+/** Set to `true` to indicate an warning state */
+export let warn = false;
 
-  /** Specify the warning state text */
-  export let warnText = "";
+/** Specify the warning state text */
+export let warnText = "";
 
-  /** Specify the helper text */
-  export let helperText = "";
+/** Specify the helper text */
+export let helperText = "";
 
-  /** Specify the list box label */
-  export let label = "";
+/** Specify the list box label */
+export let label = "";
 
-  /** Set to `true` to visually hide the label text */
-  export let hideLabel = false;
+/** Set to `true` to visually hide the label text */
+export let hideLabel = false;
 
-  /** Set an id for the list box component */
-  export let id = "ccs-" + Math.random().toString(36);
+/** Set an id for the list box component */
+export let id = "ccs-" + Math.random().toString(36);
 
-  /**
-   * Specify a name attribute for the select
-   * @type {string}
-   */
-  export let name = undefined;
+/**
+ * Specify a name attribute for the select
+ * @type {string}
+ */
+export let name = undefined;
 
-  /** Obtain a reference to the input HTML element */
-  export let inputRef = null;
+/** Obtain a reference to the input HTML element */
+export let inputRef = null;
 
-  /** Obtain a reference to the outer div element */
-  export let multiSelectRef = null;
+/** Obtain a reference to the outer div element */
+export let multiSelectRef = null;
 
-  /**
-   * Obtain a reference to the field box element
-   * @type {null | HTMLDivElement}
-   */
-  export let fieldRef = null;
+/**
+ * Obtain a reference to the field box element
+ * @type {null | HTMLDivElement}
+ */
+export let fieldRef = null;
 
-  /**
-   * Obtain a reference to the selection element
-   * @type {null | HTMLDivElement}
-   */
-  export let selectionRef = null;
+/**
+ * Obtain a reference to the selection element
+ * @type {null | HTMLDivElement}
+ */
+export let selectionRef = null;
 
-  /**
-   * Id of the highlighted ListBoxMenuItem
-   * @type {null | MultiSelectItemId}
-   */
-  export let highlightedId = null;
+/**
+ * Id of the highlighted ListBoxMenuItem
+ * @type {null | MultiSelectItemId}
+ */
+export let highlightedId = null;
 
-  import { afterUpdate, createEventDispatcher, setContext } from "svelte";
-  import WarningFilled from "../icons/WarningFilled.svelte";
-  import WarningAltFilled from "../icons/WarningAltFilled.svelte";
-  import Checkbox from "../Checkbox/Checkbox.svelte";
-  import {
-    ListBox,
-    ListBoxField,
-    ListBoxMenu,
-    ListBoxMenuIcon,
-    ListBoxMenuItem,
-    ListBoxSelection,
-  } from "../ListBox";
+import { afterUpdate, createEventDispatcher, setContext } from "svelte";
+import WarningFilled from "../icons/WarningFilled.svelte";
+import WarningAltFilled from "../icons/WarningAltFilled.svelte";
+import Checkbox from "../Checkbox/Checkbox.svelte";
+import {
+  ListBox,
+  ListBoxField,
+  ListBoxMenu,
+  ListBoxMenuIcon,
+  ListBoxMenuItem,
+  ListBoxSelection,
+} from "../ListBox";
 
-  const dispatch = createEventDispatcher();
+const dispatch = createEventDispatcher();
 
-  let highlightedIndex = -1;
-  let prevChecked = [];
+let highlightedIndex = -1;
+let prevChecked = [];
 
-  setContext("MultiSelect", {
-    declareRef: ({ key, ref }) => {
-      switch (key) {
-        case "field":
-          fieldRef = ref;
-          break;
-        case "selection":
-          selectionRef = ref;
-          break;
-      }
-    },
-  });
+setContext("MultiSelect", {
+  declareRef: ({ key, ref }) => {
+    switch (key) {
+      case "field":
+        fieldRef = ref;
+        break;
+      case "selection":
+        selectionRef = ref;
+        break;
+    }
+  },
+});
 
-  function change(direction) {
-    let index = highlightedIndex + direction;
-    const itemsToUse = filterable ? filteredItems : sortedItems;
-    const length = itemsToUse.length;
-    if (length === 0) return;
+function change(direction) {
+  let index = highlightedIndex + direction;
+  const itemsToUse = filterable ? filteredItems : sortedItems;
+  const length = itemsToUse.length;
+  if (length === 0) return;
+  if (index < 0) {
+    index = length - 1;
+  } else if (index >= length) {
+    index = 0;
+  }
+
+  let disabled = itemsToUse[index].disabled;
+
+  while (disabled) {
+    index = index + direction;
+
     if (index < 0) {
       index = length - 1;
     } else if (index >= length) {
       index = 0;
     }
 
-    let disabled = itemsToUse[index].disabled;
-
-    while (disabled) {
-      index = index + direction;
-
-      if (index < 0) {
-        index = length - 1;
-      } else if (index >= length) {
-        index = 0;
-      }
-
-      disabled = itemsToUse[index].disabled;
-    }
-
-    highlightedIndex = index;
+    disabled = itemsToUse[index].disabled;
   }
 
-  afterUpdate(() => {
-    if (checked.length !== prevChecked.length) {
-      prevChecked = checked;
-      selectedIds = checked.map(({ id }) => id);
-      dispatch("select", {
-        selectedIds,
-        selected: checked,
-        unselected: unchecked,
-      });
-    }
+  highlightedIndex = index;
+}
 
-    if (!open) {
-      highlightedIndex = -1;
-      value = "";
-    }
-  });
-
-  function sort() {
-    if (
-      selectionFeedback === "top" ||
-      selectionFeedback === "top-after-reopen"
-    ) {
-      const checkedItems = items
-        .filter((item) => selectedIds.includes(item.id))
-        .map((item) => ({ ...item, checked: true }));
-      const uncheckedItems = items
-        .filter((item) => !selectedIds.includes(item.id))
-        .map((item) => ({ ...item, checked: false }));
-
-      return [
-        ...(checkedItems.length > 1
-          ? checkedItems.sort(sortItem)
-          : checkedItems),
-        ...uncheckedItems.sort(sortItem),
-      ];
-    }
-
-    return items
-      .map((item) => ({
-        ...item,
-        checked: selectedIds.includes(item.id),
-      }))
-      .sort(sortItem);
+afterUpdate(() => {
+  if (checked.length !== prevChecked.length) {
+    prevChecked = checked;
+    selectedIds = checked.map(({ id }) => id);
+    dispatch("select", {
+      selectedIds,
+      selected: checked,
+      unselected: unchecked,
+    });
   }
 
-  let sortedItems = sort();
-
-  $: menuId = `menu-${id}`;
-  $: inline = type === "inline";
-  $: ariaLabel = $$props["aria-label"] || "Choose an item";
-  $: if (
-    selectedIds &&
-    (selectionFeedback === "top" ||
-      (selectionFeedback === "top-after-reopen" && open === false))
-  ) {
-    sortedItems = sort();
+  if (!open) {
+    highlightedIndex = -1;
+    value = "";
   }
-  $: checked = sortedItems.filter(({ checked }) => checked);
-  $: unchecked = sortedItems.filter(({ checked }) => !checked);
-  $: filteredItems = sortedItems.filter((item) => filterItem(item, value));
-  $: highlightedId =
-    highlightedIndex > -1
-      ? ((filterable ? filteredItems : sortedItems)[highlightedIndex]?.id ??
-        null)
-      : null;
+});
+
+function sort() {
+  if (selectionFeedback === "top" || selectionFeedback === "top-after-reopen") {
+    const checkedItems = items
+      .filter((item) => selectedIds.includes(item.id))
+      .map((item) => ({ ...item, checked: true }));
+    const uncheckedItems = items
+      .filter((item) => !selectedIds.includes(item.id))
+      .map((item) => ({ ...item, checked: false }));
+
+    return [
+      ...(checkedItems.length > 1 ? checkedItems.sort(sortItem) : checkedItems),
+      ...uncheckedItems.sort(sortItem),
+    ];
+  }
+
+  return items
+    .map((item) => ({
+      ...item,
+      checked: selectedIds.includes(item.id),
+    }))
+    .sort(sortItem);
+}
+
+let sortedItems = sort();
+
+$: menuId = `menu-${id}`;
+$: inline = type === "inline";
+$: ariaLabel = $$props["aria-label"] || "Choose an item";
+$: if (
+  selectedIds &&
+  (selectionFeedback === "top" ||
+    (selectionFeedback === "top-after-reopen" && open === false))
+) {
+  sortedItems = sort();
+}
+$: checked = sortedItems.filter(({ checked }) => checked);
+$: unchecked = sortedItems.filter(({ checked }) => !checked);
+$: filteredItems = sortedItems.filter((item) => filterItem(item, value));
+$: highlightedId =
+  highlightedIndex > -1
+    ? ((filterable ? filteredItems : sortedItems)[highlightedIndex]?.id ?? null)
+    : null;
 </script>
 
 <svelte:window

--- a/src/Notification/InlineNotification.svelte
+++ b/src/Notification/InlineNotification.svelte
@@ -1,70 +1,70 @@
 <script>
-  /**
-   * @event {{ timeout: boolean }} close
-   */
+/**
+ * @event {{ timeout: boolean }} close
+ */
 
-  /**
-   * Specify the kind of notification
-   * @type {"error" | "info" | "info-square" | "success" | "warning" | "warning-alt"}
-   */
-  export let kind = "error";
+/**
+ * Specify the kind of notification
+ * @type {"error" | "info" | "info-square" | "success" | "warning" | "warning-alt"}
+ */
+export let kind = "error";
 
-  /** Set to `true` to use the low contrast variant */
-  export let lowContrast = false;
+/** Set to `true` to use the low contrast variant */
+export let lowContrast = false;
 
-  /** Set the timeout duration (ms) to hide the notification after opening it */
-  export let timeout = 0;
+/** Set the timeout duration (ms) to hide the notification after opening it */
+export let timeout = 0;
 
-  /** Set the `role` attribute */
-  export let role = "alert";
+/** Set the `role` attribute */
+export let role = "alert";
 
-  /** Specify the title text */
-  export let title = "";
+/** Specify the title text */
+export let title = "";
 
-  /** Specify the subtitle text */
-  export let subtitle = "";
+/** Specify the subtitle text */
+export let subtitle = "";
 
-  /** Set to `true` to hide the close button */
-  export let hideCloseButton = false;
+/** Set to `true` to hide the close button */
+export let hideCloseButton = false;
 
-  /**
-   * Specify the ARIA label for the status icon
-   * @type {string}
-   * */
-  export let statusIconDescription = kind + " icon";
+/**
+ * Specify the ARIA label for the status icon
+ * @type {string}
+ * */
+export let statusIconDescription = kind + " icon";
 
-  /** Specify the ARIA label for the close button */
-  export let closeButtonDescription = "Close notification";
+/** Specify the ARIA label for the close button */
+export let closeButtonDescription = "Close notification";
 
-  import { createEventDispatcher, onMount } from "svelte";
-  import NotificationIcon from "./NotificationIcon.svelte";
-  import NotificationButton from "./NotificationButton.svelte";
+import { createEventDispatcher, onMount } from "svelte";
+import NotificationIcon from "./NotificationIcon.svelte";
+import NotificationButton from "./NotificationButton.svelte";
 
-  const dispatch = createEventDispatcher();
+const dispatch = createEventDispatcher();
 
-  let open = true;
-  let timeoutId = undefined;
+let open = true;
+let timeoutId = undefined;
 
-  function close(closeFromTimeout) {
-    const shouldContinue = dispatch(
-      "close",
-      { timeout: closeFromTimeout === true },
-      { cancelable: true },
-    );
-    if (shouldContinue) {
-      open = false;
-    }
+function close(closeFromTimeout) {
+  const shouldContinue = dispatch(
+    "close",
+    { timeout: closeFromTimeout === true },
+    { cancelable: true },
+  );
+  if (shouldContinue) {
+    open = false;
+  }
+}
+
+onMount(() => {
+  if (timeout) {
+    timeoutId = setTimeout(() => close(true), timeout);
   }
 
-  onMount(() => {
-    if (timeout) {
-      timeoutId = setTimeout(() => close(true), timeout);
-    }
-
-    return () => {
-      clearTimeout(timeoutId);
-    };
-  });
+  return () => {
+    clearTimeout(timeoutId);
+  };
+});
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->

--- a/src/Notification/NotificationActionButton.svelte
+++ b/src/Notification/NotificationActionButton.svelte
@@ -1,7 +1,7 @@
 <script>
-  /** @extends {"../Button/Button.svelte"} ButtonProps */
+/** @extends {"../Button/Button.svelte"} ButtonProps */
 
-  import Button from "../Button/Button.svelte";
+import Button from "../Button/Button.svelte";
 </script>
 
 <Button

--- a/src/Notification/NotificationButton.svelte
+++ b/src/Notification/NotificationButton.svelte
@@ -1,26 +1,26 @@
 <script>
-  /**
-   * Set the type of notification
-   * @type {"toast" | "inline"}
-   */
-  export let notificationType = "toast";
+/**
+ * Set the type of notification
+ * @type {"toast" | "inline"}
+ */
+export let notificationType = "toast";
 
-  /**
-   * Specify the icon to render
-   * @type {any}
-   */
-  export let icon = Close;
+/**
+ * Specify the icon to render
+ * @type {any}
+ */
+export let icon = Close;
 
-  /**
-   * Specify the title of the icon
-   * @type {string}
-   */
-  export let title = undefined;
+/**
+ * Specify the title of the icon
+ * @type {string}
+ */
+export let title = undefined;
 
-  /** Specify the ARIA label for the icon */
-  export let iconDescription = "Close icon";
+/** Specify the ARIA label for the icon */
+export let iconDescription = "Close icon";
 
-  import Close from "../icons/Close.svelte";
+import Close from "../icons/Close.svelte";
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->

--- a/src/Notification/NotificationIcon.svelte
+++ b/src/Notification/NotificationIcon.svelte
@@ -1,34 +1,34 @@
 <script>
-  /**
-   * Specify the kind of notification icon
-   * @type {"error" | "info" | "info-square" | "success" | "warning" | "warning-alt"}
-   */
-  export let kind = "error";
+/**
+ * Specify the kind of notification icon
+ * @type {"error" | "info" | "info-square" | "success" | "warning" | "warning-alt"}
+ */
+export let kind = "error";
 
-  /**
-   * Set the type of notification
-   * @type {"toast" | "inline"}
-   */
-  export let notificationType = "toast";
+/**
+ * Set the type of notification
+ * @type {"toast" | "inline"}
+ */
+export let notificationType = "toast";
 
-  /** Specify the ARIA label for the icon */
-  export let iconDescription;
+/** Specify the ARIA label for the icon */
+export let iconDescription;
 
-  import CheckmarkFilled from "../icons/CheckmarkFilled.svelte";
-  import ErrorFilled from "../icons/ErrorFilled.svelte";
-  import InformationFilled from "../icons/InformationFilled.svelte";
-  import InformationSquareFilled from "../icons/InformationSquareFilled.svelte";
-  import WarningFilled from "../icons/WarningFilled.svelte";
-  import WarningAltFilled from "../icons/WarningAltFilled.svelte";
+import CheckmarkFilled from "../icons/CheckmarkFilled.svelte";
+import ErrorFilled from "../icons/ErrorFilled.svelte";
+import InformationFilled from "../icons/InformationFilled.svelte";
+import InformationSquareFilled from "../icons/InformationSquareFilled.svelte";
+import WarningFilled from "../icons/WarningFilled.svelte";
+import WarningAltFilled from "../icons/WarningAltFilled.svelte";
 
-  const icons = {
-    error: ErrorFilled,
-    "info-square": InformationSquareFilled,
-    info: InformationFilled,
-    success: CheckmarkFilled,
-    warning: WarningFilled,
-    "warning-alt": WarningAltFilled,
-  };
+const icons = {
+  error: ErrorFilled,
+  "info-square": InformationSquareFilled,
+  info: InformationFilled,
+  success: CheckmarkFilled,
+  warning: WarningFilled,
+  "warning-alt": WarningAltFilled,
+};
 </script>
 
 <svelte:component

--- a/src/Notification/ToastNotification.svelte
+++ b/src/Notification/ToastNotification.svelte
@@ -1,92 +1,92 @@
 <script>
-  /**
-   * @event {{ timeout: boolean }} close
-   */
+/**
+ * @event {{ timeout: boolean }} close
+ */
 
-  /**
-   * Specify the kind of notification
-   * @type {"error" | "info" | "info-square" | "success" | "warning" | "warning-alt"}
-   */
-  export let kind = "error";
+/**
+ * Specify the kind of notification
+ * @type {"error" | "info" | "info-square" | "success" | "warning" | "warning-alt"}
+ */
+export let kind = "error";
 
-  /** Set to `true` to use the low contrast variant */
-  export let lowContrast = false;
+/** Set to `true` to use the low contrast variant */
+export let lowContrast = false;
 
-  /** Set the timeout duration (ms) to hide the notification after opening it */
-  export let timeout = 0;
+/** Set the timeout duration (ms) to hide the notification after opening it */
+export let timeout = 0;
 
-  /** Set the `role` attribute */
-  export let role = "alert";
+/** Set the `role` attribute */
+export let role = "alert";
 
-  /** Specify the title text */
-  export let title = "";
+/** Specify the title text */
+export let title = "";
 
-  /** Specify the subtitle text */
-  export let subtitle = "";
+/** Specify the subtitle text */
+export let subtitle = "";
 
-  /** Specify the caption text */
-  export let caption = "";
+/** Specify the caption text */
+export let caption = "";
 
-  /**
-   * Specify the ARIA label for the status icon
-   * @type {string}
-   * */
-  export let statusIconDescription = kind + " icon";
+/**
+ * Specify the ARIA label for the status icon
+ * @type {string}
+ * */
+export let statusIconDescription = kind + " icon";
 
-  /** Specify the ARIA label for the close button */
-  export let closeButtonDescription = "Close notification";
+/** Specify the ARIA label for the close button */
+export let closeButtonDescription = "Close notification";
 
-  /** Set to `true` to hide the close button */
-  export let hideCloseButton = false;
+/** Set to `true` to hide the close button */
+export let hideCloseButton = false;
 
-  /**
-   * Set to `true` for the notification to span
-   * the full width of its containing element.
-   */
-  export let fullWidth = false;
+/**
+ * Set to `true` for the notification to span
+ * the full width of its containing element.
+ */
+export let fullWidth = false;
 
-  import { createEventDispatcher, onMount } from "svelte";
-  import NotificationButton from "./NotificationButton.svelte";
-  import NotificationIcon from "./NotificationIcon.svelte";
+import { createEventDispatcher, onMount } from "svelte";
+import NotificationButton from "./NotificationButton.svelte";
+import NotificationIcon from "./NotificationIcon.svelte";
 
-  const dispatch = createEventDispatcher();
+const dispatch = createEventDispatcher();
 
-  let open = true;
-  let timeoutId = undefined;
+let open = true;
+let timeoutId = undefined;
 
-  function close(closeFromTimeout) {
-    // Clear the timer if the close button was clicked.
-    clearTimeout(timeoutId);
+function close(closeFromTimeout) {
+  // Clear the timer if the close button was clicked.
+  clearTimeout(timeoutId);
 
-    const shouldContinue = dispatch(
-      "close",
-      { timeout: closeFromTimeout === true },
-      { cancelable: true },
-    );
-    if (shouldContinue) {
-      open = false;
-    }
+  const shouldContinue = dispatch(
+    "close",
+    { timeout: closeFromTimeout === true },
+    { cancelable: true },
+  );
+  if (shouldContinue) {
+    open = false;
   }
+}
 
-  onMount(() => {
-    return () => {
-      clearTimeout(timeoutId);
-    };
-  });
-
-  $: if (typeof window !== "undefined") {
-    /**
-     * Clear the timer if {@link timeout} changes.
-     * If set to `0`, no new timeout is started.
-     * Else, a new timeout is started if {@link open} is not set to `false`.
-     */
+onMount(() => {
+  return () => {
     clearTimeout(timeoutId);
+  };
+});
 
-    /** Only start the timer of {@link open} has not been set to `false`. */
-    if (open && timeout) {
-      timeoutId = setTimeout(() => close(true), timeout);
-    }
+$: if (typeof window !== "undefined") {
+  /**
+   * Clear the timer if {@link timeout} changes.
+   * If set to `0`, no new timeout is started.
+   * Else, a new timeout is started if {@link open} is not set to `false`.
+   */
+  clearTimeout(timeoutId);
+
+  /** Only start the timer of {@link open} has not been set to `false`. */
+  if (open && timeout) {
+    timeoutId = setTimeout(() => close(true), timeout);
   }
+}
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->

--- a/src/NumberInput/NumberInput.svelte
+++ b/src/NumberInput/NumberInput.svelte
@@ -1,155 +1,155 @@
 <script>
-  /**
-   * @typedef {"increment" | "decrement"} NumberInputTranslationId
-   * @event {null | number} change
-   * @event {null | number} input
-   */
+/**
+ * @typedef {"increment" | "decrement"} NumberInputTranslationId
+ * @event {null | number} change
+ * @event {null | number} input
+ */
 
-  /**
-   * Set the size of the input
-   * @type {"sm" | "xl"}
-   */
-  export let size = undefined;
+/**
+ * Set the size of the input
+ * @type {"sm" | "xl"}
+ */
+export let size = undefined;
 
-  /**
-   * Specify the input value.
-   * Use `null` to denote "no value"
-   * @type {null | number}
-   */
-  export let value = null;
+/**
+ * Specify the input value.
+ * Use `null` to denote "no value"
+ * @type {null | number}
+ */
+export let value = null;
 
-  /** Specify the step increment */
-  export let step = 1;
+/** Specify the step increment */
+export let step = 1;
 
-  /**
-   * Specify the maximum value
-   * @type {number}
-   */
-  export let max = undefined;
+/**
+ * Specify the maximum value
+ * @type {number}
+ */
+export let max = undefined;
 
-  /**
-   * Specify the minimum value
-   * @type {number}
-   */
-  export let min = undefined;
+/**
+ * Specify the minimum value
+ * @type {number}
+ */
+export let min = undefined;
 
-  /** Set to `true` to enable the light variant */
-  export let light = false;
+/** Set to `true` to enable the light variant */
+export let light = false;
 
-  /** Set to `true` for the input to be read-only */
-  export let readonly = false;
+/** Set to `true` for the input to be read-only */
+export let readonly = false;
 
-  /** Set to `true` to allow for an empty value */
-  export let allowEmpty = false;
+/** Set to `true` to allow for an empty value */
+export let allowEmpty = false;
 
-  /** Set to `true` to disable the input */
-  export let disabled = false;
+/** Set to `true` to disable the input */
+export let disabled = false;
 
-  /** Set to `true` to hide the input stepper buttons */
-  export let hideSteppers = false;
+/** Set to `true` to hide the input stepper buttons */
+export let hideSteppers = false;
 
-  /** Specify the ARIA label for the increment icons */
-  export let iconDescription = "";
+/** Specify the ARIA label for the increment icons */
+export let iconDescription = "";
 
-  /** Set to `true` to indicate an invalid state */
-  export let invalid = false;
+/** Set to `true` to indicate an invalid state */
+export let invalid = false;
 
-  /** Specify the invalid state text */
-  export let invalidText = "";
+/** Specify the invalid state text */
+export let invalidText = "";
 
-  /** Set to `true` to indicate an warning state */
-  export let warn = false;
+/** Set to `true` to indicate an warning state */
+export let warn = false;
 
-  /** Specify the warning state text */
-  export let warnText = "";
+/** Specify the warning state text */
+export let warnText = "";
 
-  /** Specify the helper text */
-  export let helperText = "";
+/** Specify the helper text */
+export let helperText = "";
 
-  /** Specify the label text */
-  export let label = "";
+/** Specify the label text */
+export let label = "";
 
-  /** Set to `true` to visually hide the label text */
-  export let hideLabel = false;
+/** Set to `true` to visually hide the label text */
+export let hideLabel = false;
 
-  /**
-   * Override the default translation ids
-   * @type {(id: NumberInputTranslationId) => string}
-   */
-  export let translateWithId = (id) => defaultTranslations[id];
+/**
+ * Override the default translation ids
+ * @type {(id: NumberInputTranslationId) => string}
+ */
+export let translateWithId = (id) => defaultTranslations[id];
 
-  /**
-   * Default translation ids
-   * @type {{ increment: "increment"; decrement: "decrement" }}
-   */
-  export const translationIds = {
-    increment: "increment",
-    decrement: "decrement",
-  };
+/**
+ * Default translation ids
+ * @type {{ increment: "increment"; decrement: "decrement" }}
+ */
+export const translationIds = {
+  increment: "increment",
+  decrement: "decrement",
+};
 
-  /** Set an id for the input element */
-  export let id = "ccs-" + Math.random().toString(36);
+/** Set an id for the input element */
+export let id = "ccs-" + Math.random().toString(36);
 
-  /**
-   * Specify a name attribute for the input
-   * @type {string}
-   */
-  export let name = undefined;
+/**
+ * Specify a name attribute for the input
+ * @type {string}
+ */
+export let name = undefined;
 
-  /** Obtain a reference to the input HTML element */
-  export let ref = null;
+/** Obtain a reference to the input HTML element */
+export let ref = null;
 
-  import { createEventDispatcher } from "svelte";
-  import Add from "../icons/Add.svelte";
-  import Subtract from "../icons/Subtract.svelte";
-  import WarningFilled from "../icons/WarningFilled.svelte";
-  import WarningAltFilled from "../icons/WarningAltFilled.svelte";
-  import EditOff from "../icons/EditOff.svelte";
+import { createEventDispatcher } from "svelte";
+import Add from "../icons/Add.svelte";
+import Subtract from "../icons/Subtract.svelte";
+import WarningFilled from "../icons/WarningFilled.svelte";
+import WarningAltFilled from "../icons/WarningAltFilled.svelte";
+import EditOff from "../icons/EditOff.svelte";
 
-  const defaultTranslations = {
-    [translationIds.increment]: "Increment number",
-    [translationIds.decrement]: "Decrement number",
-  };
+const defaultTranslations = {
+  [translationIds.increment]: "Increment number",
+  [translationIds.decrement]: "Decrement number",
+};
 
-  const dispatch = createEventDispatcher();
+const dispatch = createEventDispatcher();
 
-  function updateValue(isIncrementing) {
-    if (isIncrementing) {
-      ref.stepUp();
-    } else {
-      ref.stepDown();
-    }
-    value = +ref.value;
-
-    dispatch("input", value);
-    dispatch("change", value);
+function updateValue(isIncrementing) {
+  if (isIncrementing) {
+    ref.stepUp();
+  } else {
+    ref.stepDown();
   }
+  value = +ref.value;
 
-  $: incrementLabel = translateWithId("increment");
-  $: decrementLabel = translateWithId("decrement");
-  $: error =
-    (invalid && !readonly) ||
-    (!allowEmpty && value == null) ||
-    value > max ||
-    (typeof value === "number" && value < min);
-  $: errorId = `error-${id}`;
-  $: ariaLabel =
-    $$props["aria-label"] ||
-    "Numeric input field with increment and decrement buttons";
+  dispatch("input", value);
+  dispatch("change", value);
+}
 
-  function parse(raw) {
-    return raw != "" ? Number(raw) : null;
-  }
+$: incrementLabel = translateWithId("increment");
+$: decrementLabel = translateWithId("decrement");
+$: error =
+  (invalid && !readonly) ||
+  (!allowEmpty && value == null) ||
+  value > max ||
+  (typeof value === "number" && value < min);
+$: errorId = `error-${id}`;
+$: ariaLabel =
+  $$props["aria-label"] ||
+  "Numeric input field with increment and decrement buttons";
 
-  function onInput({ target }) {
-    value = parse(target.value);
+function parse(raw) {
+  return raw != "" ? Number(raw) : null;
+}
 
-    dispatch("input", value);
-  }
+function onInput({ target }) {
+  value = parse(target.value);
 
-  function onChange({ target }) {
-    dispatch("change", parse(target.value));
-  }
+  dispatch("input", value);
+}
+
+function onChange({ target }) {
+  dispatch("change", parse(target.value));
+}
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->

--- a/src/NumberInput/NumberInputSkeleton.svelte
+++ b/src/NumberInput/NumberInputSkeleton.svelte
@@ -1,6 +1,6 @@
 <script>
-  /** Set to `true` to hide the label text */
-  export let hideLabel = false;
+/** Set to `true` to hide the label text */
+export let hideLabel = false;
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->

--- a/src/OrderedList/OrderedList.svelte
+++ b/src/OrderedList/OrderedList.svelte
@@ -1,12 +1,12 @@
 <script>
-  /** Set to `true` to use the nested variant */
-  export let nested = false;
+/** Set to `true` to use the nested variant */
+export let nested = false;
 
-  /** Set to `true` to use native list styles */
-  export let native = false;
+/** Set to `true` to use native list styles */
+export let native = false;
 
-  /** Set to `true` to use Carbon's expressive typesetting */
-  export let expressive = false;
+/** Set to `true` to use Carbon's expressive typesetting */
+export let expressive = false;
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->

--- a/src/OverflowMenu/OverflowMenuItem.svelte
+++ b/src/OverflowMenu/OverflowMenuItem.svelte
@@ -1,57 +1,57 @@
 <script>
-  /**
-   * Specify the item text.
-   * Alternatively, use the default slot
-   */
-  export let text = "Provide text";
+/**
+ * Specify the item text.
+ * Alternatively, use the default slot
+ */
+export let text = "Provide text";
 
-  /** Specify the `href` attribute if the item is a link */
-  export let href = "";
+/** Specify the `href` attribute if the item is a link */
+export let href = "";
 
-  /** Set to `true` if the item should be focused when opening the menu */
-  export let primaryFocus = false;
+/** Set to `true` if the item should be focused when opening the menu */
+export let primaryFocus = false;
 
-  /** Set to `true` to disable the item */
-  export let disabled = false;
+/** Set to `true` to disable the item */
+export let disabled = false;
 
-  /** Set to `true` to include a divider */
-  export let hasDivider = false;
+/** Set to `true` to include a divider */
+export let hasDivider = false;
 
-  /** Set to `true` to use the danger variant */
-  export let danger = false;
+/** Set to `true` to use the danger variant */
+export let danger = false;
 
-  /** Set to `false` to omit the button `title` attribute */
-  export let requireTitle = true;
+/** Set to `false` to omit the button `title` attribute */
+export let requireTitle = true;
 
-  /** Set an id for the top-level element */
-  export let id = "ccs-" + Math.random().toString(36);
+/** Set an id for the top-level element */
+export let id = "ccs-" + Math.random().toString(36);
 
-  /** Obtain a reference to the HTML element */
-  export let ref = null;
+/** Obtain a reference to the HTML element */
+export let ref = null;
 
-  import { getContext, afterUpdate } from "svelte";
+import { getContext, afterUpdate } from "svelte";
 
-  const { focusedId, add, update, change, items } = getContext("OverflowMenu");
+const { focusedId, add, update, change, items } = getContext("OverflowMenu");
 
-  $: item = $items.find((_) => _.id === id);
+$: item = $items.find((_) => _.id === id);
 
-  add({ id, text, primaryFocus, disabled });
+add({ id, text, primaryFocus, disabled });
 
-  afterUpdate(() => {
-    if (ref && primaryFocus) {
-      ref.focus();
-    }
-  });
+afterUpdate(() => {
+  if (ref && primaryFocus) {
+    ref.focus();
+  }
+});
 
-  $: primaryFocus = $focusedId === id;
-  $: buttonProps = {
-    role: "menuitem",
-    tabindex: "-1",
-    class: "bx--overflow-menu-options__btn",
-    disabled: href ? undefined : disabled,
-    href: href ? href : undefined,
-    title: requireTitle ? ($$slots.default ? undefined : text) : undefined,
-  };
+$: primaryFocus = $focusedId === id;
+$: buttonProps = {
+  role: "menuitem",
+  tabindex: "-1",
+  class: "bx--overflow-menu-options__btn",
+  disabled: href ? undefined : disabled,
+  href: href ? href : undefined,
+  title: requireTitle ? ($$slots.default ? undefined : text) : undefined,
+};
 </script>
 
 <li

--- a/src/Pagination/Pagination.svelte
+++ b/src/Pagination/Pagination.svelte
@@ -1,97 +1,96 @@
 <script>
-  /**
-   * @event {{ page?: number; pageSize?: number }} change - Dispatched after any user interaction
-   * @event {{ page: number; }} click:button--previous
-   * @event {{ page: number; }} click:button--next
-   * @event {{ pageSize: number; page: number; }} update
-   */
+/**
+ * @event {{ page?: number; pageSize?: number }} change - Dispatched after any user interaction
+ * @event {{ page: number; }} click:button--previous
+ * @event {{ page: number; }} click:button--next
+ * @event {{ pageSize: number; page: number; }} update
+ */
 
-  /** Specify the current page index */
-  export let page = 1;
+/** Specify the current page index */
+export let page = 1;
 
-  /** Specify the total number of items */
-  export let totalItems = 0;
+/** Specify the total number of items */
+export let totalItems = 0;
 
-  /** Set to `true` to disable the pagination */
-  export let disabled = false;
+/** Set to `true` to disable the pagination */
+export let disabled = false;
 
-  /** Specify the forward button text */
-  export let forwardText = "Next page";
+/** Specify the forward button text */
+export let forwardText = "Next page";
 
-  /** Specify the backward button text */
-  export let backwardText = "Previous page";
+/** Specify the backward button text */
+export let backwardText = "Previous page";
 
-  /** Specify the items per page text */
-  export let itemsPerPageText = "Items per page:";
+/** Specify the items per page text */
+export let itemsPerPageText = "Items per page:";
 
-  /**
-   * Override the item text
-   * @type {(min: number, max: number) => string}
-   */
-  export let itemText = (min, max) =>
-    `${min}–${max} item${max === 1 ? "" : "s"}`;
+/**
+ * Override the item text
+ * @type {(min: number, max: number) => string}
+ */
+export let itemText = (min, max) => `${min}–${max} item${max === 1 ? "" : "s"}`;
 
-  /**
-   * Override the item range text
-   * @type {(min: number, max: number, total: number) => string}
-   */
-  export let itemRangeText = (min, max, total) =>
-    `${min}–${max} of ${total} item${max === 1 ? "" : "s"}`;
+/**
+ * Override the item range text
+ * @type {(min: number, max: number, total: number) => string}
+ */
+export let itemRangeText = (min, max, total) =>
+  `${min}–${max} of ${total} item${max === 1 ? "" : "s"}`;
 
-  /** Set to `true` to disable the page input */
-  export let pageInputDisabled = false;
+/** Set to `true` to disable the page input */
+export let pageInputDisabled = false;
 
-  /** Set to `true` to disable the page size input */
-  export let pageSizeInputDisabled = false;
+/** Set to `true` to disable the page size input */
+export let pageSizeInputDisabled = false;
 
-  /** Specify the number of items to display in a page */
-  export let pageSize = 10;
+/** Specify the number of items to display in a page */
+export let pageSize = 10;
 
-  /**
-   * Specify the available page sizes
-   * @type {ReadonlyArray<number>}
-   */
-  export let pageSizes = [10];
+/**
+ * Specify the available page sizes
+ * @type {ReadonlyArray<number>}
+ */
+export let pageSizes = [10];
 
-  /** Set to `true` if the number of pages is unknown */
-  export let pagesUnknown = false;
+/** Set to `true` if the number of pages is unknown */
+export let pagesUnknown = false;
 
-  /**
-   * Override the page text
-   * @type {(page: number) => string}
-   */
-  export let pageText = (page) => `page ${page}`;
+/**
+ * Override the page text
+ * @type {(page: number) => string}
+ */
+export let pageText = (page) => `page ${page}`;
 
-  /**
-   * Override the page range text
-   * @type {(current: number, total: number) => string}
-   */
-  export let pageRangeText = (current, total) =>
-    `of ${total} page${total === 1 ? "" : "s"}`;
+/**
+ * Override the page range text
+ * @type {(current: number, total: number) => string}
+ */
+export let pageRangeText = (current, total) =>
+  `of ${total} page${total === 1 ? "" : "s"}`;
 
-  /** Set an id for the top-level element */
-  export let id = "ccs-" + Math.random().toString(36);
+/** Set an id for the top-level element */
+export let id = "ccs-" + Math.random().toString(36);
 
-  import { afterUpdate, createEventDispatcher } from "svelte";
-  import CaretLeft from "../icons/CaretLeft.svelte";
-  import CaretRight from "../icons/CaretRight.svelte";
-  import Button from "../Button/Button.svelte";
-  import Select from "../Select/Select.svelte";
-  import SelectItem from "../Select/SelectItem.svelte";
+import { afterUpdate, createEventDispatcher } from "svelte";
+import CaretLeft from "../icons/CaretLeft.svelte";
+import CaretRight from "../icons/CaretRight.svelte";
+import Button from "../Button/Button.svelte";
+import Select from "../Select/Select.svelte";
+import SelectItem from "../Select/SelectItem.svelte";
 
-  const dispatch = createEventDispatcher();
+const dispatch = createEventDispatcher();
 
-  afterUpdate(() => {
-    if (page > totalPages) {
-      page = totalPages;
-    }
-  });
+afterUpdate(() => {
+  if (page > totalPages) {
+    page = totalPages;
+  }
+});
 
-  $: dispatch("update", { pageSize, page });
-  $: totalPages = Math.max(Math.ceil(totalItems / pageSize), 1);
-  $: selectItems = Array.from({ length: totalPages }, (_, i) => i);
-  $: backButtonDisabled = disabled || page === 1;
-  $: forwardButtonDisabled = disabled || page === totalPages;
+$: dispatch("update", { pageSize, page });
+$: totalPages = Math.max(Math.ceil(totalItems / pageSize), 1);
+$: selectItems = Array.from({ length: totalPages }, (_, i) => i);
+$: backButtonDisabled = disabled || page === 1;
+$: forwardButtonDisabled = disabled || page === totalPages;
 </script>
 
 <div {id} class:bx--pagination={true} {...$$restProps}>

--- a/src/Pagination/PaginationSkeleton.svelte
+++ b/src/Pagination/PaginationSkeleton.svelte
@@ -1,5 +1,5 @@
 <script>
-  import SkeletonText from "../SkeletonText/SkeletonText.svelte";
+import SkeletonText from "../SkeletonText/SkeletonText.svelte";
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->

--- a/src/PaginationNav/PaginationItem.svelte
+++ b/src/PaginationNav/PaginationItem.svelte
@@ -1,9 +1,9 @@
 <script>
-  /** Specify the current page index */
-  export let page = 1;
+/** Specify the current page index */
+export let page = 1;
 
-  /** Set to `true` to use the active state */
-  export let active = false;
+/** Set to `true` to use the active state */
+export let active = false;
 </script>
 
 <li class:bx--pagination-nav__list-item={true}>

--- a/src/PaginationNav/PaginationNav.svelte
+++ b/src/PaginationNav/PaginationNav.svelte
@@ -1,79 +1,79 @@
 <script>
-  /**
-   * @event {{ page: number; }} change - fires after every user interaction
-   * @event {{ page: number; }} click:button--previous
-   * @event {{ page: number; }} click:button--next
-   */
+/**
+ * @event {{ page: number; }} change - fires after every user interaction
+ * @event {{ page: number; }} click:button--previous
+ * @event {{ page: number; }} click:button--next
+ */
 
-  /** Specify the current page index */
-  export let page = 1;
+/** Specify the current page index */
+export let page = 1;
 
-  /** Specify the total number of pages */
-  export let total = 10;
+/** Specify the total number of pages */
+export let total = 10;
 
-  /** Specify the total number of pages to show */
-  export let shown = 10;
+/** Specify the total number of pages to show */
+export let shown = 10;
 
-  /** Set to `true` to loop the navigation */
-  export let loop = false;
+/** Set to `true` to loop the navigation */
+export let loop = false;
 
-  /** Specify the forward button text */
-  export let forwardText = "Next page";
+/** Specify the forward button text */
+export let forwardText = "Next page";
 
-  /** Specify the backward button text */
-  export let backwardText = "Previous page";
+/** Specify the backward button text */
+export let backwardText = "Previous page";
 
-  /**
-   * Set the position of the tooltip relative to the pagination buttons.
-   * @type {"top" | "right" | "bottom" | "left" | "outside" | "inside"}
-   */
-  export let tooltipPosition = "bottom";
+/**
+ * Set the position of the tooltip relative to the pagination buttons.
+ * @type {"top" | "right" | "bottom" | "left" | "outside" | "inside"}
+ */
+export let tooltipPosition = "bottom";
 
-  import { createEventDispatcher } from "svelte";
-  import CaretLeft from "../icons/CaretLeft.svelte";
-  import CaretRight from "../icons/CaretRight.svelte";
-  import PaginationItem from "./PaginationItem.svelte";
-  import PaginationOverflow from "./PaginationOverflow.svelte";
-  import Button from "../Button/Button.svelte";
+import { createEventDispatcher } from "svelte";
+import CaretLeft from "../icons/CaretLeft.svelte";
+import CaretRight from "../icons/CaretRight.svelte";
+import PaginationItem from "./PaginationItem.svelte";
+import PaginationOverflow from "./PaginationOverflow.svelte";
+import Button from "../Button/Button.svelte";
 
-  const dispatch = createEventDispatcher();
-  const MIN = 4;
+const dispatch = createEventDispatcher();
+const MIN = 4;
 
-  // number of overflow pages near the beginning of the nav
-  let front = 0;
+// number of overflow pages near the beginning of the nav
+let front = 0;
 
-  // number of overflow pages near the end of the nav
-  let back = 0;
+// number of overflow pages near the end of the nav
+let back = 0;
 
-  // number of nav overflow or items that may appear
-  $: fit = shown >= MIN ? shown : MIN;
-  $: startOffset = fit <= MIN && page > 1 ? 0 : 1;
-  $: if (fit >= total) {
+// number of nav overflow or items that may appear
+$: fit = shown >= MIN ? shown : MIN;
+$: startOffset = fit <= MIN && page > 1 ? 0 : 1;
+$: if (fit >= total) {
+  front = 0;
+  back = 0;
+}
+$: if (fit < total) {
+  const split = Math.ceil(fit / 2) - 1;
+
+  front = page - split;
+  back = total - page - (fit - split) + 2;
+
+  if (front <= 1) {
+    back -= front <= 0 ? Math.abs(front) + 1 : 0;
     front = 0;
+  }
+
+  if (back <= 1) {
+    front -= back <= 0 ? Math.abs(back) + 1 : 0;
     back = 0;
   }
-  $: if (fit < total) {
-    const split = Math.ceil(fit / 2) - 1;
+}
 
-    front = page - split;
-    back = total - page - (fit - split) + 2;
-
-    if (front <= 1) {
-      back -= front <= 0 ? Math.abs(front) + 1 : 0;
-      front = 0;
-    }
-
-    if (back <= 1) {
-      front -= back <= 0 ? Math.abs(back) + 1 : 0;
-      back = 0;
-    }
-  }
-
-  // all enumerable items to render in between
-  // overflow menus
-  $: items = Array.from({ length: total })
-    .map((e, i) => i)
-    .slice(startOffset + front, (back + 1) * -1);
+// all enumerable items to render in between
+// overflow menus
+$: items = Array.from({ length: total })
+  .map((e, i) => i)
+  .slice(startOffset + front, (back + 1) * -1);
 </script>
 
 <nav aria-label="pagination" class:bx--pagination-nav={true} {...$$restProps}>

--- a/src/PaginationNav/PaginationOverflow.svelte
+++ b/src/PaginationNav/PaginationOverflow.svelte
@@ -1,21 +1,21 @@
 <script>
-  /**
-   * @event {{ index: number; }} select
-   */
+/**
+ * @event {{ index: number; }} select
+ */
 
-  /** Specify the pivot start index */
-  export let fromIndex = 0;
+/** Specify the pivot start index */
+export let fromIndex = 0;
 
-  /** Specify the pivot end index */
-  export let count = 0;
+/** Specify the pivot end index */
+export let count = 0;
 
-  import { createEventDispatcher } from "svelte";
-  import OverflowMenuHorizontal from "../icons/OverflowMenuHorizontal.svelte";
-  import PaginationItem from "./PaginationItem.svelte";
+import { createEventDispatcher } from "svelte";
+import OverflowMenuHorizontal from "../icons/OverflowMenuHorizontal.svelte";
+import PaginationItem from "./PaginationItem.svelte";
 
-  const dispatch = createEventDispatcher();
+const dispatch = createEventDispatcher();
 
-  let value = "";
+let value = "";
 </script>
 
 {#if count > 1}

--- a/src/Popover/Popover.svelte
+++ b/src/Popover/Popover.svelte
@@ -1,37 +1,37 @@
 <script>
-  /**
-   * @event {{ target: HTMLElement; }} click:outside
-   */
+/**
+ * @event {{ target: HTMLElement; }} click:outside
+ */
 
-  /** Set to `true` to display the popover */
-  export let open = false;
+/** Set to `true` to display the popover */
+export let open = false;
 
-  /** Set to `true` to close the popover on an outside click */
-  export let closeOnOutsideClick = false;
+/** Set to `true` to close the popover on an outside click */
+export let closeOnOutsideClick = false;
 
-  /** Set to `true` render a caret */
-  export let caret = false;
+/** Set to `true` render a caret */
+export let caret = false;
 
-  /**
-   * Specify the alignment of the caret
-   * @type {"top" | "top-left" | "top-right" | "bottom" | "bottom-left" | "bottom-right" | "left" | "left-bottom" | "left-top" | "right" | "right-bottom" | "right-top"}
-   */
-  export let align = "top";
+/**
+ * Specify the alignment of the caret
+ * @type {"top" | "top-left" | "top-right" | "bottom" | "bottom-left" | "bottom-right" | "left" | "left-bottom" | "left-top" | "right" | "right-bottom" | "right-top"}
+ */
+export let align = "top";
 
-  /** Set to `true` to enable the light variant */
-  export let light = false;
+/** Set to `true` to enable the light variant */
+export let light = false;
 
-  /** Set to `true` to enable the high contrast variant */
-  export let highContrast = false;
+/** Set to `true` to enable the high contrast variant */
+export let highContrast = false;
 
-  /** Set to `true` to use a relative position */
-  export let relative = false;
+/** Set to `true` to use a relative position */
+export let relative = false;
 
-  import { createEventDispatcher } from "svelte";
+import { createEventDispatcher } from "svelte";
 
-  const dispatch = createEventDispatcher();
+const dispatch = createEventDispatcher();
 
-  let ref = null;
+let ref = null;
 </script>
 
 <svelte:window

--- a/src/ProgressBar/ProgressBar.svelte
+++ b/src/ProgressBar/ProgressBar.svelte
@@ -1,64 +1,64 @@
 <script>
-  /**
-   * Specify the current value
-   * @type {number}
-   */
-  export let value = undefined;
+/**
+ * Specify the current value
+ * @type {number}
+ */
+export let value = undefined;
 
-  /** Specify the maximum value */
-  export let max = 100;
+/** Specify the maximum value */
+export let max = 100;
 
-  /**
-   * Specify the kind of progress bar
-   * @type {"default" | "inline" | "indented"}
-   */
-  export let kind = "default";
+/**
+ * Specify the kind of progress bar
+ * @type {"default" | "inline" | "indented"}
+ */
+export let kind = "default";
 
-  /**
-   * Specify the status
-   * @type {"active" | "finished" | "error"}
-   */
-  export let status = "active";
+/**
+ * Specify the status
+ * @type {"active" | "finished" | "error"}
+ */
+export let status = "active";
 
-  /**
-   * Specify the size
-   * @type {"sm" | "md"}
-   */
-  export let size = "md";
+/**
+ * Specify the size
+ * @type {"sm" | "md"}
+ */
+export let size = "md";
 
-  /** Specify the label text */
-  export let labelText = "";
+/** Specify the label text */
+export let labelText = "";
 
-  /** Set to `true` to visually hide the label text */
-  export let hideLabel = false;
+/** Set to `true` to visually hide the label text */
+export let hideLabel = false;
 
-  /** Specify the helper text */
-  export let helperText = "";
+/** Specify the helper text */
+export let helperText = "";
 
-  /** Set an id for the progress bar element */
-  export let id = "ccs-" + Math.random().toString(36);
+/** Set an id for the progress bar element */
+export let id = "ccs-" + Math.random().toString(36);
 
-  import CheckmarkFilled from "../icons/CheckmarkFilled.svelte";
-  import ErrorFilled from "../icons/ErrorFilled.svelte";
+import CheckmarkFilled from "../icons/CheckmarkFilled.svelte";
+import ErrorFilled from "../icons/ErrorFilled.svelte";
 
-  const statusIcons = {
-    error: ErrorFilled,
-    finished: CheckmarkFilled,
-  };
+const statusIcons = {
+  error: ErrorFilled,
+  finished: CheckmarkFilled,
+};
 
-  let helperId = "ccs-" + Math.random().toString(36);
+let helperId = "ccs-" + Math.random().toString(36);
 
-  $: indeterminate = value === undefined && status === "active";
-  let capped;
-  $: {
-    if (status === "error" || value < 0) {
-      capped = 0;
-    } else if (value > max) {
-      capped = max;
-    } else {
-      capped = value;
-    }
+$: indeterminate = value === undefined && status === "active";
+let capped;
+$: {
+  if (status === "error" || value < 0) {
+    capped = 0;
+  } else if (value > max) {
+    capped = max;
+  } else {
+    capped = value;
   }
+}
 </script>
 
 <div

--- a/src/ProgressIndicator/ProgressIndicator.svelte
+++ b/src/ProgressIndicator/ProgressIndicator.svelte
@@ -1,66 +1,66 @@
 <script>
-  /** Specify the current step index */
-  export let currentIndex = 0;
+/** Specify the current step index */
+export let currentIndex = 0;
 
-  /** Set to `true` to use the vertical variant */
-  export let vertical = false;
+/** Set to `true` to use the vertical variant */
+export let vertical = false;
 
-  /** Set to `true` to specify whether the progress steps should be split equally in size in the div */
-  export let spaceEqually = false;
+/** Set to `true` to specify whether the progress steps should be split equally in size in the div */
+export let spaceEqually = false;
 
-  /** Set to `true` to prevent `currentIndex` from updating */
-  export let preventChangeOnClick = false;
+/** Set to `true` to prevent `currentIndex` from updating */
+export let preventChangeOnClick = false;
 
-  import { createEventDispatcher, setContext } from "svelte";
-  import { writable, derived } from "svelte/store";
+import { createEventDispatcher, setContext } from "svelte";
+import { writable, derived } from "svelte/store";
 
-  const dispatch = createEventDispatcher();
-  const steps = writable([]);
-  const stepsById = derived(steps, (steps) =>
-    steps.reduce((a, c) => ({ ...a, [c.id]: c }), {}),
-  );
-  const preventChangeOnClickStore = writable(preventChangeOnClick);
+const dispatch = createEventDispatcher();
+const steps = writable([]);
+const stepsById = derived(steps, (steps) =>
+  steps.reduce((a, c) => ({ ...a, [c.id]: c }), {}),
+);
+const preventChangeOnClickStore = writable(preventChangeOnClick);
 
-  setContext("ProgressIndicator", {
-    steps,
-    stepsById,
-    preventChangeOnClick: { subscribe: preventChangeOnClickStore.subscribe },
-    add: (step) => {
-      steps.update((_) => {
-        if (step.id in $stepsById) {
-          return _.map((_step) => {
-            if (_step.id === step.id) return { ..._step, ...step };
-            return _step;
-          });
-        }
+setContext("ProgressIndicator", {
+  steps,
+  stepsById,
+  preventChangeOnClick: { subscribe: preventChangeOnClickStore.subscribe },
+  add: (step) => {
+    steps.update((_) => {
+      if (step.id in $stepsById) {
+        return _.map((_step) => {
+          if (_step.id === step.id) return { ..._step, ...step };
+          return _step;
+        });
+      }
 
-        return [
-          ..._,
-          {
-            ...step,
-            index: _.length,
-            current: _.length === currentIndex,
-            complete: step.complete,
-          },
-        ];
-      });
-    },
-    change: (index) => {
-      if (preventChangeOnClick) return;
-      currentIndex = index;
+      return [
+        ..._,
+        {
+          ...step,
+          index: _.length,
+          current: _.length === currentIndex,
+          complete: step.complete,
+        },
+      ];
+    });
+  },
+  change: (index) => {
+    if (preventChangeOnClick) return;
+    currentIndex = index;
 
-      /** @event {number} change */
-      dispatch("change", index);
-    },
-  });
+    /** @event {number} change */
+    dispatch("change", index);
+  },
+});
 
-  $: steps.update((_) =>
-    _.map((step, i) => ({
-      ...step,
-      current: i === currentIndex,
-    })),
-  );
-  $: preventChangeOnClickStore.set(preventChangeOnClick);
+$: steps.update((_) =>
+  _.map((step, i) => ({
+    ...step,
+    current: i === currentIndex,
+  })),
+);
+$: preventChangeOnClickStore.set(preventChangeOnClick);
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->

--- a/src/ProgressIndicator/ProgressIndicatorSkeleton.svelte
+++ b/src/ProgressIndicator/ProgressIndicatorSkeleton.svelte
@@ -1,9 +1,9 @@
 <script>
-  /** Set to `true` to use the vertical variant */
-  export let vertical = false;
+/** Set to `true` to use the vertical variant */
+export let vertical = false;
 
-  /** Specify the number of steps to render */
-  export let count = 4;
+/** Specify the number of steps to render */
+export let count = 4;
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->

--- a/src/ProgressIndicator/ProgressStep.svelte
+++ b/src/ProgressIndicator/ProgressStep.svelte
@@ -1,54 +1,54 @@
 <script>
-  /** Set to `true` for the complete variant */
-  export let complete = false;
+/** Set to `true` for the complete variant */
+export let complete = false;
 
-  /** Set to `true` to use the current variant */
-  export let current = false;
+/** Set to `true` to use the current variant */
+export let current = false;
 
-  /** Set to `true` to disable the progress step */
-  export let disabled = false;
+/** Set to `true` to disable the progress step */
+export let disabled = false;
 
-  /** Set to `true` to indicate an invalid state */
-  export let invalid = false;
+/** Set to `true` to indicate an invalid state */
+export let invalid = false;
 
-  /** Specify the step description */
-  export let description = "";
+/** Specify the step description */
+export let description = "";
 
-  /** Specify the step label */
-  export let label = "";
+/** Specify the step label */
+export let label = "";
 
-  /** Specify the step secondary label */
-  export let secondaryLabel = "";
+/** Specify the step secondary label */
+export let secondaryLabel = "";
 
-  /** Set an id for the top-level element */
-  export let id = "ccs-" + Math.random().toString(36);
+/** Set an id for the top-level element */
+export let id = "ccs-" + Math.random().toString(36);
 
-  import { onMount, getContext } from "svelte";
-  import CheckmarkOutline from "../icons/CheckmarkOutline.svelte";
-  import Warning from "../icons/Warning.svelte";
-  import CircleDash from "../icons/CircleDash.svelte";
-  import Incomplete from "../icons/Incomplete.svelte";
+import { onMount, getContext } from "svelte";
+import CheckmarkOutline from "../icons/CheckmarkOutline.svelte";
+import Warning from "../icons/Warning.svelte";
+import CircleDash from "../icons/CircleDash.svelte";
+import Incomplete from "../icons/Incomplete.svelte";
 
-  let step = {};
+let step = {};
 
-  const { stepsById, add, change, preventChangeOnClick } =
-    getContext("ProgressIndicator");
+const { stepsById, add, change, preventChangeOnClick } =
+  getContext("ProgressIndicator");
 
-  $: add({ id, complete, disabled });
+$: add({ id, complete, disabled });
 
-  const unsubscribe = stepsById.subscribe((value) => {
-    if (value[id]) {
-      step = value[id];
-      current = step.current;
-      complete = step.complete;
-    }
-  });
+const unsubscribe = stepsById.subscribe((value) => {
+  if (value[id]) {
+    step = value[id];
+    current = step.current;
+    complete = step.complete;
+  }
+});
 
-  onMount(() => {
-    return () => {
-      unsubscribe();
-    };
-  });
+onMount(() => {
+  return () => {
+    unsubscribe();
+  };
+});
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->

--- a/src/RadioButton/RadioButton.svelte
+++ b/src/RadioButton/RadioButton.svelte
@@ -1,59 +1,59 @@
 <script>
-  /**
-   * Specify the value of the radio button
-   * @type {string | number}
-   */
-  export let value = "";
+/**
+ * Specify the value of the radio button
+ * @type {string | number}
+ */
+export let value = "";
 
-  /** Set to `true` to check the radio button */
-  export let checked = false;
+/** Set to `true` to check the radio button */
+export let checked = false;
 
-  /** Set to `true` to disable the radio button */
-  export let disabled = false;
+/** Set to `true` to disable the radio button */
+export let disabled = false;
 
-  /** Set to `true` to mark the field as required */
-  export let required = false;
+/** Set to `true` to mark the field as required */
+export let required = false;
 
-  /**
-   * Specify the label position
-   * @type {"right" | "left"}
-   */
-  export let labelPosition = "right";
+/**
+ * Specify the label position
+ * @type {"right" | "left"}
+ */
+export let labelPosition = "right";
 
-  /** Specify the label text */
-  export let labelText = "";
+/** Specify the label text */
+export let labelText = "";
 
-  /** Set to `true` to visually hide the label text */
-  export let hideLabel = false;
+/** Set to `true` to visually hide the label text */
+export let hideLabel = false;
 
-  /** Set an id for the input element */
-  export let id = "ccs-" + Math.random().toString(36);
+/** Set an id for the input element */
+export let id = "ccs-" + Math.random().toString(36);
 
-  /**
-   * Specify a name attribute for the radio button input
-   * @type {string}
-   */
-  export let name = undefined;
+/**
+ * Specify a name attribute for the radio button input
+ * @type {string}
+ */
+export let name = undefined;
 
-  /** Obtain a reference to the input HTML element */
-  export let ref = null;
+/** Obtain a reference to the input HTML element */
+export let ref = null;
 
-  import { getContext } from "svelte";
-  import { readable } from "svelte/store";
+import { getContext } from "svelte";
+import { readable } from "svelte/store";
 
-  const { add, update, selectedValue, groupName, groupRequired } = getContext(
-    "RadioButtonGroup",
-  ) ?? {
-    groupName: readable(undefined),
-    groupRequired: readable(undefined),
-    selectedValue: readable(checked ? value : undefined),
-  };
+const { add, update, selectedValue, groupName, groupRequired } = getContext(
+  "RadioButtonGroup",
+) ?? {
+  groupName: readable(undefined),
+  groupRequired: readable(undefined),
+  selectedValue: readable(checked ? value : undefined),
+};
 
-  if (add) {
-    add({ id, checked, disabled, value });
-  }
+if (add) {
+  add({ id, checked, disabled, value });
+}
 
-  $: checked = $selectedValue === value;
+$: checked = $selectedValue === value;
 </script>
 
 <div

--- a/src/RadioButtonGroup/RadioButtonGroup.svelte
+++ b/src/RadioButtonGroup/RadioButtonGroup.svelte
@@ -1,95 +1,95 @@
 <script>
-  /**
-   * @event {string | number} change
-   */
+/**
+ * @event {string | number} change
+ */
 
-  /**
-   * Set the selected radio button value
-   * @type {string | number}
-   */
-  export let selected = undefined;
+/**
+ * Set the selected radio button value
+ * @type {string | number}
+ */
+export let selected = undefined;
 
-  /** Set to `true` to disable the radio buttons */
-  export let disabled = false;
+/** Set to `true` to disable the radio buttons */
+export let disabled = false;
 
-  /**
-   * Set to `true` to require the selection of a radio button
-   * @type {boolean}
-   */
-  export let required = undefined;
+/**
+ * Set to `true` to require the selection of a radio button
+ * @type {boolean}
+ */
+export let required = undefined;
 
-  /**
-   * Specify a name attribute for the radio button inputs
-   * @type {string}
-   */
-  export let name = undefined;
+/**
+ * Specify a name attribute for the radio button inputs
+ * @type {string}
+ */
+export let name = undefined;
 
-  /** Specify the legend text */
-  export let legendText = "";
+/** Specify the legend text */
+export let legendText = "";
 
-  /** Set to `true` to visually hide the legend */
-  export let hideLegend = false;
+/** Set to `true` to visually hide the legend */
+export let hideLegend = false;
 
-  /**
-   * Specify the label position
-   * @type {"right" | "left"}
-   */
-  export let labelPosition = "right";
+/**
+ * Specify the label position
+ * @type {"right" | "left"}
+ */
+export let labelPosition = "right";
 
-  /**
-   * Specify the orientation of the radio buttons
-   * @type {"horizontal" | "vertical"}
-   */
-  export let orientation = "horizontal";
+/**
+ * Specify the orientation of the radio buttons
+ * @type {"horizontal" | "vertical"}
+ */
+export let orientation = "horizontal";
 
-  /**
-   * Set an id for the container div element
-   * @type {string}
-   */
-  export let id = undefined;
+/**
+ * Set an id for the container div element
+ * @type {string}
+ */
+export let id = undefined;
 
-  import {
-    beforeUpdate,
-    createEventDispatcher,
-    onMount,
-    setContext,
-  } from "svelte";
-  import { readonly, writable } from "svelte/store";
+import {
+  beforeUpdate,
+  createEventDispatcher,
+  onMount,
+  setContext,
+} from "svelte";
+import { readonly, writable } from "svelte/store";
 
-  const dispatch = createEventDispatcher();
-  const selectedValue = writable(selected);
-  const groupName = writable(name);
-  const groupRequired = writable(required);
+const dispatch = createEventDispatcher();
+const selectedValue = writable(selected);
+const groupName = writable(name);
+const groupRequired = writable(required);
 
-  setContext("RadioButtonGroup", {
-    selectedValue,
-    groupName: readonly(groupName),
-    groupRequired: readonly(groupRequired),
-    add: ({ checked, value }) => {
-      if (checked) {
-        selectedValue.set(value);
-      }
-    },
-    update: (value) => {
-      selected = value;
-    },
-  });
-
-  onMount(() => {
-    $selectedValue = selected;
-  });
-
-  beforeUpdate(() => {
-    $selectedValue = selected;
-  });
-
-  selectedValue.subscribe((value) => {
+setContext("RadioButtonGroup", {
+  selectedValue,
+  groupName: readonly(groupName),
+  groupRequired: readonly(groupRequired),
+  add: ({ checked, value }) => {
+    if (checked) {
+      selectedValue.set(value);
+    }
+  },
+  update: (value) => {
     selected = value;
-    dispatch("change", value);
-  });
+  },
+});
 
-  $: $groupName = name;
-  $: $groupRequired = required;
+onMount(() => {
+  $selectedValue = selected;
+});
+
+beforeUpdate(() => {
+  $selectedValue = selected;
+});
+
+selectedValue.subscribe((value) => {
+  selected = value;
+  dispatch("change", value);
+});
+
+$: $groupName = name;
+$: $groupRequired = required;
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->

--- a/src/RecursiveList/RecursiveList.svelte
+++ b/src/RecursiveList/RecursiveList.svelte
@@ -1,24 +1,24 @@
 <script>
-  /**
-   * @typedef {{ text?: string; href?: string; html?: string; }} RecursiveListNode
-   * @restProps {ul | ol}
-   */
+/**
+ * @typedef {{ text?: string; href?: string; html?: string; }} RecursiveListNode
+ * @restProps {ul | ol}
+ */
 
-  /**
-   * Specify the nodes to render
-   * @type {Array<RecursiveListNode & { nodes?: RecursiveListNode[]; }>}
-   */
-  export let nodes = [];
+/**
+ * Specify the nodes to render
+ * @type {Array<RecursiveListNode & { nodes?: RecursiveListNode[]; }>}
+ */
+export let nodes = [];
 
-  /**
-   * Specify the type of list to render
-   * @type {"unordered" | "ordered" | "ordered-native"}
-   */
-  export let type = "unordered";
+/**
+ * Specify the type of list to render
+ * @type {"unordered" | "ordered" | "ordered-native"}
+ */
+export let type = "unordered";
 
-  import UnorderedList from "../UnorderedList/UnorderedList.svelte";
-  import OrderedList from "../OrderedList/OrderedList.svelte";
-  import RecursiveListItem from "./RecursiveListItem.svelte";
+import UnorderedList from "../UnorderedList/UnorderedList.svelte";
+import OrderedList from "../OrderedList/OrderedList.svelte";
+import RecursiveListItem from "./RecursiveListItem.svelte";
 </script>
 
 <svelte:component

--- a/src/RecursiveList/RecursiveListItem.svelte
+++ b/src/RecursiveList/RecursiveListItem.svelte
@@ -1,14 +1,14 @@
 <script>
-  /** Specify the text to render*/
-  export let text = "";
+/** Specify the text to render*/
+export let text = "";
 
-  /** Specify a link href */
-  export let href = "";
+/** Specify a link href */
+export let href = "";
 
-  /** Specify HTML to render using `@html` */
-  export let html = "";
+/** Specify HTML to render using `@html` */
+export let html = "";
 
-  import ListItem from "../ListItem/ListItem.svelte";
+import ListItem from "../ListItem/ListItem.svelte";
 </script>
 
 <ListItem>

--- a/src/Search/Search.svelte
+++ b/src/Search/Search.svelte
@@ -1,82 +1,82 @@
 <script>
-  /**
-   * @event {null} expand
-   * @event {null} collapse
-   * @restProps {input}
-   */
+/**
+ * @event {null} expand
+ * @event {null} collapse
+ * @restProps {input}
+ */
 
-  /**
-   * Specify the value of the search input
-   * @type {any}
-   */
-  export let value = "";
+/**
+ * Specify the value of the search input
+ * @type {any}
+ */
+export let value = "";
 
-  /**
-   * Specify the size of the search input
-   * @type {"sm" | "lg" | "xl"}
-   */
-  export let size = "xl";
+/**
+ * Specify the size of the search input
+ * @type {"sm" | "lg" | "xl"}
+ */
+export let size = "xl";
 
-  /** Specify the class name passed to the outer div element */
-  export let searchClass = "";
+/** Specify the class name passed to the outer div element */
+export let searchClass = "";
 
-  /** Set to `true` to display the skeleton state  */
-  export let skeleton = false;
+/** Set to `true` to display the skeleton state  */
+export let skeleton = false;
 
-  /** Set to `true` to enable the light variant */
-  export let light = false;
+/** Set to `true` to enable the light variant */
+export let light = false;
 
-  /** Set to `true` to disable the search input */
-  export let disabled = false;
+/** Set to `true` to disable the search input */
+export let disabled = false;
 
-  /** Set to `true` to enable the expandable variant */
-  export let expandable = false;
+/** Set to `true` to enable the expandable variant */
+export let expandable = false;
 
-  /** Set to `true to expand the search input */
-  export let expanded = false;
+/** Set to `true to expand the search input */
+export let expanded = false;
 
-  /** Specify the `placeholder` attribute of the search input */
-  export let placeholder = "Search...";
+/** Specify the `placeholder` attribute of the search input */
+export let placeholder = "Search...";
 
-  /**
-   * Specify the `autocomplete` attribute
-   * @type {"on" | "off"}
-   */
-  export let autocomplete = "off";
+/**
+ * Specify the `autocomplete` attribute
+ * @type {"on" | "off"}
+ */
+export let autocomplete = "off";
 
-  /** Set to `true` to auto focus the search element */
-  export let autofocus = false;
+/** Set to `true` to auto focus the search element */
+export let autofocus = false;
 
-  /** Specify the close button label text */
-  export let closeButtonLabelText = "Clear search input";
+/** Specify the close button label text */
+export let closeButtonLabelText = "Clear search input";
 
-  /** Specify the label text */
-  export let labelText = "";
+/** Specify the label text */
+export let labelText = "";
 
-  /**
-   * Specify the icon to render.
-   * Defaults to `<Search />`
-   * @type {any}
-   */
-  export let icon = IconSearch;
+/**
+ * Specify the icon to render.
+ * Defaults to `<Search />`
+ * @type {any}
+ */
+export let icon = IconSearch;
 
-  /** Set an id for the input element */
-  export let id = "ccs-" + Math.random().toString(36);
+/** Set an id for the input element */
+export let id = "ccs-" + Math.random().toString(36);
 
-  /** Obtain a reference to the input HTML element */
-  export let ref = null;
+/** Obtain a reference to the input HTML element */
+export let ref = null;
 
-  import { createEventDispatcher } from "svelte";
-  import Close from "../icons/Close.svelte";
-  import IconSearch from "../icons/IconSearch.svelte";
-  import SearchSkeleton from "./SearchSkeleton.svelte";
+import { createEventDispatcher } from "svelte";
+import Close from "../icons/Close.svelte";
+import IconSearch from "../icons/IconSearch.svelte";
+import SearchSkeleton from "./SearchSkeleton.svelte";
 
-  const dispatch = createEventDispatcher();
+const dispatch = createEventDispatcher();
 
-  let searchRef = null;
+let searchRef = null;
 
-  $: if (expanded && ref) ref.focus();
-  $: dispatch(expanded ? "expand" : "collapse");
+$: if (expanded && ref) ref.focus();
+$: dispatch(expanded ? "expand" : "collapse");
 </script>
 
 <!-- svelte-ignore a11y-autofocus -->

--- a/src/Search/SearchSkeleton.svelte
+++ b/src/Search/SearchSkeleton.svelte
@@ -1,9 +1,9 @@
 <script>
-  /**
-   * Specify the size of the search input
-   * @type {"sm" | "lg" | "xl"}
-   */
-  export let size = "xl";
+/**
+ * Specify the size of the search input
+ * @type {"sm" | "lg" | "xl"}
+ */
+export let size = "xl";
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->

--- a/src/Select/Select.svelte
+++ b/src/Select/Select.svelte
@@ -1,128 +1,128 @@
 <script>
-  /**
-   * @event {string | number} update The selected value.
-   */
+/**
+ * @event {string | number} update The selected value.
+ */
 
-  /**
-   * Specify the selected item value
-   * @type {string | number}
-   */
-  export let selected = undefined;
+/**
+ * Specify the selected item value
+ * @type {string | number}
+ */
+export let selected = undefined;
 
-  /**
-   * Set the size of the select input
-   * @type {"sm" | "xl"}
-   */
-  export let size = undefined;
+/**
+ * Set the size of the select input
+ * @type {"sm" | "xl"}
+ */
+export let size = undefined;
 
-  /** Set to `true` to use the inline variant */
-  export let inline = false;
+/** Set to `true` to use the inline variant */
+export let inline = false;
 
-  /** Set to `true` to enable the light variant */
-  export let light = false;
+/** Set to `true` to enable the light variant */
+export let light = false;
 
-  /** Set to `true` to disable the select element */
-  export let disabled = false;
+/** Set to `true` to disable the select element */
+export let disabled = false;
 
-  /** Set an id for the select element */
-  export let id = "ccs-" + Math.random().toString(36);
+/** Set an id for the select element */
+export let id = "ccs-" + Math.random().toString(36);
 
-  /**
-   * Specify a name attribute for the select element
-   * @type {string}
-   */
-  export let name = undefined;
+/**
+ * Specify a name attribute for the select element
+ * @type {string}
+ */
+export let name = undefined;
 
-  /** Set to `true` to indicate an invalid state */
-  export let invalid = false;
+/** Set to `true` to indicate an invalid state */
+export let invalid = false;
 
-  /** Specify the invalid state text */
-  export let invalidText = "";
+/** Specify the invalid state text */
+export let invalidText = "";
 
-  /** Set to `true` to indicate an warning state */
-  export let warn = false;
+/** Set to `true` to indicate an warning state */
+export let warn = false;
 
-  /** Specify the warning state text */
-  export let warnText = "";
+/** Specify the warning state text */
+export let warnText = "";
 
-  /** Specify the helper text */
-  export let helperText = "";
+/** Specify the helper text */
+export let helperText = "";
 
-  /** Set to `true` to not render a label */
-  export let noLabel = false;
+/** Set to `true` to not render a label */
+export let noLabel = false;
 
-  /** Specify the label text */
-  export let labelText = "";
+/** Specify the label text */
+export let labelText = "";
 
-  /** Set to `true` to visually hide the label text */
-  export let hideLabel = false;
+/** Set to `true` to visually hide the label text */
+export let hideLabel = false;
 
-  /** Obtain a reference to the select HTML element */
-  export let ref = null;
+/** Obtain a reference to the select HTML element */
+export let ref = null;
 
-  /** Set to `true` to mark the field as required */
-  export let required = false;
+/** Set to `true` to mark the field as required */
+export let required = false;
 
-  import { createEventDispatcher, setContext, afterUpdate } from "svelte";
-  import { writable } from "svelte/store";
-  import ChevronDown from "../icons/ChevronDown.svelte";
-  import WarningFilled from "../icons/WarningFilled.svelte";
-  import WarningAltFilled from "../icons/WarningAltFilled.svelte";
+import { createEventDispatcher, setContext, afterUpdate } from "svelte";
+import { writable } from "svelte/store";
+import ChevronDown from "../icons/ChevronDown.svelte";
+import WarningFilled from "../icons/WarningFilled.svelte";
+import WarningAltFilled from "../icons/WarningAltFilled.svelte";
 
-  const dispatch = createEventDispatcher();
-  const selectedValue = writable(selected);
-  const defaultSelectId = writable(null);
-  const defaultValue = writable(null);
-  const itemTypesByValue = writable({});
+const dispatch = createEventDispatcher();
+const selectedValue = writable(selected);
+const defaultSelectId = writable(null);
+const defaultValue = writable(null);
+const itemTypesByValue = writable({});
 
-  setContext("Select", {
-    selectedValue,
-    setDefaultValue: (id, value) => {
-      /**
-       * Use the first `SelectItem` value as the
-       * default value if `selected` is `undefined`.
-       */
-      if ($defaultValue === null) {
-        defaultSelectId.set(id);
-        defaultValue.set(value);
-      } else {
-        if ($defaultSelectId === id) {
-          selectedValue.set(value);
-        }
-      }
-
-      itemTypesByValue.update((types) => ({
-        ...types,
-        [value]: typeof value,
-      }));
-    },
-  });
-
-  const handleChange = ({ target }) => {
-    let value = target.value;
-
-    if ($itemTypesByValue[value] === "number") {
-      value = Number(value);
-    }
-
-    selectedValue.set(value);
-  };
-
-  let prevSelected = undefined;
-
-  afterUpdate(() => {
-    if (selected !== $selectedValue) {
-      selected = $selectedValue;
-      if (prevSelected !== undefined) {
-        dispatch("update", $selectedValue);
+setContext("Select", {
+  selectedValue,
+  setDefaultValue: (id, value) => {
+    /**
+     * Use the first `SelectItem` value as the
+     * default value if `selected` is `undefined`.
+     */
+    if ($defaultValue === null) {
+      defaultSelectId.set(id);
+      defaultValue.set(value);
+    } else {
+      if ($defaultSelectId === id) {
+        selectedValue.set(value);
       }
     }
 
-    prevSelected = selected;
-  });
+    itemTypesByValue.update((types) => ({
+      ...types,
+      [value]: typeof value,
+    }));
+  },
+});
 
-  $: errorId = `error-${id}`;
-  $: selectedValue.set(selected ?? $defaultValue);
+const handleChange = ({ target }) => {
+  let value = target.value;
+
+  if ($itemTypesByValue[value] === "number") {
+    value = Number(value);
+  }
+
+  selectedValue.set(value);
+};
+
+let prevSelected = undefined;
+
+afterUpdate(() => {
+  if (selected !== $selectedValue) {
+    selected = $selectedValue;
+    if (prevSelected !== undefined) {
+      dispatch("update", $selectedValue);
+    }
+  }
+
+  prevSelected = selected;
+});
+
+$: errorId = `error-${id}`;
+$: selectedValue.set(selected ?? $defaultValue);
 </script>
 
 <div class:bx--form-item={true} {...$$restProps}>

--- a/src/Select/SelectItem.svelte
+++ b/src/Select/SelectItem.svelte
@@ -1,49 +1,49 @@
 <script>
-  /**
-   * Specify the option value
-   * @type {string | number}
-   */
-  export let value = "";
+/**
+ * Specify the option value
+ * @type {string | number}
+ */
+export let value = "";
 
-  /** Specify the option text */
-  export let text = "";
+/** Specify the option text */
+export let text = "";
 
-  /** Set to `true` to hide the option */
-  export let hidden = false;
+/** Set to `true` to hide the option */
+export let hidden = false;
 
-  /** Set to `true` to disable the option */
-  export let disabled = false;
+/** Set to `true` to disable the option */
+export let disabled = false;
 
-  let className = undefined;
+let className = undefined;
 
-  /**
-   * Specify the class of the `option` element
-   * @type {string}
-   */
-  export { className as class };
+/**
+ * Specify the class of the `option` element
+ * @type {string}
+ */
+export { className as class };
 
-  /**
-   * Specify the style of the `option` element
-   * @type {string}
-   */
-  export let style = undefined;
+/**
+ * Specify the style of the `option` element
+ * @type {string}
+ */
+export let style = undefined;
 
-  import { getContext, onMount } from "svelte";
+import { getContext, onMount } from "svelte";
 
-  const id = "ccs-" + Math.random().toString(36);
-  const ctx = getContext("Select") || getContext("TimePickerSelect");
+const id = "ccs-" + Math.random().toString(36);
+const ctx = getContext("Select") || getContext("TimePickerSelect");
 
-  $: ctx?.setDefaultValue?.(id, value);
+$: ctx?.setDefaultValue?.(id, value);
 
-  let selected = false;
+let selected = false;
 
-  const unsubscribe = ctx.selectedValue.subscribe((currentValue) => {
-    selected = currentValue === value;
-  });
+const unsubscribe = ctx.selectedValue.subscribe((currentValue) => {
+  selected = currentValue === value;
+});
 
-  onMount(() => {
-    return () => unsubscribe();
-  });
+onMount(() => {
+  return () => unsubscribe();
+});
 </script>
 
 <option

--- a/src/Select/SelectItemGroup.svelte
+++ b/src/Select/SelectItemGroup.svelte
@@ -1,9 +1,9 @@
 <script>
-  /** Set to `true` to disable the optgroup element */
-  export let disabled = false;
+/** Set to `true` to disable the optgroup element */
+export let disabled = false;
 
-  /** Specify the label attribute of the optgroup element */
-  export let label = "Provide label";
+/** Specify the label attribute of the optgroup element */
+export let label = "Provide label";
 </script>
 
 <optgroup {label} {disabled} class:bx--select-optgroup={true} {...$$restProps}>

--- a/src/Select/SelectSkeleton.svelte
+++ b/src/Select/SelectSkeleton.svelte
@@ -1,6 +1,6 @@
 <script>
-  /** Set to `true` to hide the label text */
-  export let hideLabel = false;
+/** Set to `true` to hide the label text */
+export let hideLabel = false;
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->

--- a/src/SkeletonText/SkeletonText.svelte
+++ b/src/SkeletonText/SkeletonText.svelte
@@ -1,20 +1,20 @@
 <script>
-  /** Specify the number of lines to render */
-  export let lines = 3;
+/** Specify the number of lines to render */
+export let lines = 3;
 
-  /** Set to `true` to use the heading size variant */
-  export let heading = false;
+/** Set to `true` to use the heading size variant */
+export let heading = false;
 
-  /** Set to `true` to use the paragraph size variant */
-  export let paragraph = false;
+/** Set to `true` to use the paragraph size variant */
+export let paragraph = false;
 
-  /** Specify the width of the text (% or px) */
-  export let width = "100%";
+/** Specify the width of the text (% or px) */
+export let width = "100%";
 
-  const RANDOM = [0.973, 0.153, 0.567];
+const RANDOM = [0.973, 0.153, 0.567];
 
-  $: widthNum = parseInt(width, 10);
-  $: widthPx = width.includes("px");
+$: widthNum = parseInt(width, 10);
+$: widthPx = width.includes("px");
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->

--- a/src/Slider/Slider.svelte
+++ b/src/Slider/Slider.svelte
@@ -1,137 +1,136 @@
 <script>
-  /**
-   * @event {number} change
-   * @event {number} input
-   */
+/**
+ * @event {number} change
+ * @event {number} input
+ */
 
-  /** Specify the value of the slider */
-  export let value = 0;
+/** Specify the value of the slider */
+export let value = 0;
 
-  /** Set the maximum slider value */
-  export let max = 100;
+/** Set the maximum slider value */
+export let max = 100;
 
-  /** Specify the label for the max value */
-  export let maxLabel = "";
+/** Specify the label for the max value */
+export let maxLabel = "";
 
-  /** Set the minimum slider value */
-  export let min = 0;
+/** Set the minimum slider value */
+export let min = 0;
 
-  /** Specify the label for the min value */
-  export let minLabel = "";
+/** Specify the label for the min value */
+export let minLabel = "";
 
-  /** Set the step value */
-  export let step = 1;
+/** Set the step value */
+export let step = 1;
 
-  /** Set the step multiplier value */
-  export let stepMultiplier = 4;
+/** Set the step multiplier value */
+export let stepMultiplier = 4;
 
-  /** Set to `true` to require a value */
-  export let required = false;
+/** Set to `true` to require a value */
+export let required = false;
 
-  /** Specify the input type */
-  export let inputType = "number";
+/** Specify the input type */
+export let inputType = "number";
 
-  /** Set to `true` to disable the slider */
-  export let disabled = false;
+/** Set to `true` to disable the slider */
+export let disabled = false;
 
-  /** Set to `true` to enable the light variant */
-  export let light = false;
+/** Set to `true` to enable the light variant */
+export let light = false;
 
-  /** Set to `true` to hide the text input */
-  export let hideTextInput = false;
+/** Set to `true` to hide the text input */
+export let hideTextInput = false;
 
-  /**
-   * Set to `true` for the slider to span
-   * the full width of its containing element.
-   */
-  export let fullWidth = false;
+/**
+ * Set to `true` for the slider to span
+ * the full width of its containing element.
+ */
+export let fullWidth = false;
 
-  /** Set an id for the slider div element */
-  export let id = "ccs-" + Math.random().toString(36);
+/** Set an id for the slider div element */
+export let id = "ccs-" + Math.random().toString(36);
 
-  /** Set to `true` to indicate an invalid state */
-  export let invalid = false;
+/** Set to `true` to indicate an invalid state */
+export let invalid = false;
 
-  /**
-   * Specify the label text.
-   * Alternatively, use the "labelText" slot (e.g., `<span slot="labelText">...</span>`)
-   */
-  export let labelText = "";
+/**
+ * Specify the label text.
+ * Alternatively, use the "labelText" slot (e.g., `<span slot="labelText">...</span>`)
+ */
+export let labelText = "";
 
-  /** Set to `true` to visually hide the label text */
-  export let hideLabel = false;
+/** Set to `true` to visually hide the label text */
+export let hideLabel = false;
 
-  /** Set a name for the slider element */
-  export let name = "";
+/** Set a name for the slider element */
+export let name = "";
 
-  /** Obtain a reference to the HTML element */
-  export let ref = null;
+/** Obtain a reference to the HTML element */
+export let ref = null;
 
-  import { createEventDispatcher } from "svelte";
+import { createEventDispatcher } from "svelte";
 
-  const dispatch = createEventDispatcher();
+const dispatch = createEventDispatcher();
 
-  let trackRef = null;
-  let dragging = false;
-  let holding = false;
+let trackRef = null;
+let dragging = false;
+let holding = false;
 
-  function startDragging() {
-    dragging = true;
+function startDragging() {
+  dragging = true;
+}
+
+function startHolding() {
+  holding = true;
+}
+
+function stopHolding() {
+  holding = false;
+  dragging = false;
+}
+
+function move() {
+  if (holding) {
+    startDragging();
+  }
+}
+
+function calcValue(e) {
+  if (disabled) return;
+
+  const offsetX = e.touches ? e.touches[0].clientX : e.clientX;
+  const { left, width } = trackRef.getBoundingClientRect();
+  let nextValue =
+    min + Math.round(((max - min) * ((offsetX - left) / width)) / step) * step;
+
+  if (nextValue <= min) {
+    nextValue = min;
+  } else if (nextValue >= max) {
+    nextValue = max;
   }
 
-  function startHolding() {
-    holding = true;
+  value = nextValue;
+  dispatch("input", value);
+}
+
+$: labelId = `label-${id}`;
+$: range = max - min;
+$: left = ((value - min) / range) * 100;
+$: {
+  if (value <= min) {
+    value = min;
+  } else if (value >= max) {
+    value = max;
   }
 
-  function stopHolding() {
-    holding = false;
+  if (dragging) {
+    calcValue(event);
     dragging = false;
   }
 
-  function move() {
-    if (holding) {
-      startDragging();
-    }
+  if (!holding && !disabled) {
+    dispatch("change", value);
   }
-
-  function calcValue(e) {
-    if (disabled) return;
-
-    const offsetX = e.touches ? e.touches[0].clientX : e.clientX;
-    const { left, width } = trackRef.getBoundingClientRect();
-    let nextValue =
-      min +
-      Math.round(((max - min) * ((offsetX - left) / width)) / step) * step;
-
-    if (nextValue <= min) {
-      nextValue = min;
-    } else if (nextValue >= max) {
-      nextValue = max;
-    }
-
-    value = nextValue;
-    dispatch("input", value);
-  }
-
-  $: labelId = `label-${id}`;
-  $: range = max - min;
-  $: left = ((value - min) / range) * 100;
-  $: {
-    if (value <= min) {
-      value = min;
-    } else if (value >= max) {
-      value = max;
-    }
-
-    if (dragging) {
-      calcValue(event);
-      dragging = false;
-    }
-
-    if (!holding && !disabled) {
-      dispatch("change", value);
-    }
-  }
+}
 </script>
 
 <svelte:window

--- a/src/Slider/SliderSkeleton.svelte
+++ b/src/Slider/SliderSkeleton.svelte
@@ -1,6 +1,6 @@
 <script>
-  /** Set to `true` to hide the label text */
-  export let hideLabel = false;
+/** Set to `true` to hide the label text */
+export let hideLabel = false;
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->

--- a/src/StructuredList/StructuredList.svelte
+++ b/src/StructuredList/StructuredList.svelte
@@ -1,38 +1,38 @@
 <script>
-  /**
-   * @event {string} change
-   */
+/**
+ * @event {string} change
+ */
 
-  /**
-   * Specify the selected structured list row value
-   * @type {string}
-   */
-  export let selected = undefined;
+/**
+ * Specify the selected structured list row value
+ * @type {string}
+ */
+export let selected = undefined;
 
-  /** Set to `true` to use the condensed variant */
-  export let condensed = false;
+/** Set to `true` to use the condensed variant */
+export let condensed = false;
 
-  /** Set to `true` to flush the list */
-  export let flush = false;
+/** Set to `true` to flush the list */
+export let flush = false;
 
-  /** Set to `true` to use the selection variant */
-  export let selection = false;
+/** Set to `true` to use the selection variant */
+export let selection = false;
 
-  import { createEventDispatcher, setContext } from "svelte";
-  import { writable } from "svelte/store";
+import { createEventDispatcher, setContext } from "svelte";
+import { writable } from "svelte/store";
 
-  const dispatch = createEventDispatcher();
-  const selectedValue = writable(selected);
+const dispatch = createEventDispatcher();
+const selectedValue = writable(selected);
 
-  setContext("StructuredListWrapper", {
-    selectedValue,
-    update: (value) => {
-      selectedValue.set(value);
-    },
-  });
+setContext("StructuredListWrapper", {
+  selectedValue,
+  update: (value) => {
+    selectedValue.set(value);
+  },
+});
 
-  $: selected = $selectedValue;
-  $: dispatch("change", $selectedValue);
+$: selected = $selectedValue;
+$: dispatch("change", $selectedValue);
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->

--- a/src/StructuredList/StructuredListCell.svelte
+++ b/src/StructuredList/StructuredListCell.svelte
@@ -1,9 +1,9 @@
 <script>
-  /** Set to `true` to use as a header */
-  export let head = false;
+/** Set to `true` to use as a header */
+export let head = false;
 
-  /** Set to `true` to prevent wrapping */
-  export let noWrap = false;
+/** Set to `true` to prevent wrapping */
+export let noWrap = false;
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->

--- a/src/StructuredList/StructuredListInput.svelte
+++ b/src/StructuredList/StructuredListInput.svelte
@@ -1,31 +1,31 @@
 <script>
-  /** Set to `true` to check the input */
-  export let checked = false;
+/** Set to `true` to check the input */
+export let checked = false;
 
-  /** Specify the title of the input */
-  export let title = "title";
+/** Specify the title of the input */
+export let title = "title";
 
-  /** Specify the value of the input */
-  export let value = "value";
+/** Specify the value of the input */
+export let value = "value";
 
-  /** Set an id for the input element */
-  export let id = "ccs-" + Math.random().toString(36);
+/** Set an id for the input element */
+export let id = "ccs-" + Math.random().toString(36);
 
-  /** Specify a name attribute for the input */
-  export let name = "";
+/** Specify a name attribute for the input */
+export let name = "";
 
-  /** Obtain a reference to the input HTML element */
-  export let ref = null;
+/** Obtain a reference to the input HTML element */
+export let ref = null;
 
-  import { getContext } from "svelte";
+import { getContext } from "svelte";
 
-  const { selectedValue, update } = getContext("StructuredListWrapper");
+const { selectedValue, update } = getContext("StructuredListWrapper");
 
-  if (checked) {
-    update(value);
-  }
+if (checked) {
+  update(value);
+}
 
-  $: checked = $selectedValue === value;
+$: checked = $selectedValue === value;
 </script>
 
 <input

--- a/src/StructuredList/StructuredListRow.svelte
+++ b/src/StructuredList/StructuredListRow.svelte
@@ -1,12 +1,12 @@
 <script>
-  /** Set to `true` to use as a header */
-  export let head = false;
+/** Set to `true` to use as a header */
+export let head = false;
 
-  /** Set to `true` to render a label slot */
-  export let label = false;
+/** Set to `true` to render a label slot */
+export let label = false;
 
-  /** Specify the tabindex */
-  export let tabindex = "0";
+/** Specify the tabindex */
+export let tabindex = "0";
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->

--- a/src/StructuredList/StructuredListSkeleton.svelte
+++ b/src/StructuredList/StructuredListSkeleton.svelte
@@ -1,6 +1,6 @@
 <script>
-  /** Specify the number of rows */
-  export let rows = 5;
+/** Specify the number of rows */
+export let rows = 5;
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->

--- a/src/Tabs/Tab.svelte
+++ b/src/Tabs/Tab.svelte
@@ -1,32 +1,32 @@
 <script>
-  /**
-   * Specify the tab label.
-   * Alternatively, use the default slot (e.g., `<Tab><span>Label</span></Tab>`)
-   */
-  export let label = "";
+/**
+ * Specify the tab label.
+ * Alternatively, use the default slot (e.g., `<Tab><span>Label</span></Tab>`)
+ */
+export let label = "";
 
-  /** Specify the href attribute */
-  export let href = "#";
+/** Specify the href attribute */
+export let href = "#";
 
-  /** Set to `true` to disable the tab */
-  export let disabled = false;
+/** Set to `true` to disable the tab */
+export let disabled = false;
 
-  /** Specify the tabindex */
-  export let tabindex = "0";
+/** Specify the tabindex */
+export let tabindex = "0";
 
-  /** Set an id for the top-level element */
-  export let id = "ccs-" + Math.random().toString(36);
+/** Set an id for the top-level element */
+export let id = "ccs-" + Math.random().toString(36);
 
-  /** Obtain a reference to the anchor HTML element */
-  export let ref = null;
+/** Obtain a reference to the anchor HTML element */
+export let ref = null;
 
-  import { getContext } from "svelte";
+import { getContext } from "svelte";
 
-  const { selectedTab, useAutoWidth, add, update, change } = getContext("Tabs");
+const { selectedTab, useAutoWidth, add, update, change } = getContext("Tabs");
 
-  add({ id, label, disabled });
+add({ id, label, disabled });
 
-  $: selected = $selectedTab === id;
+$: selected = $selectedTab === id;
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->

--- a/src/Tabs/TabContent.svelte
+++ b/src/Tabs/TabContent.svelte
@@ -1,16 +1,16 @@
 <script>
-  /** Set an id for the top-level element */
-  export let id = "ccs-" + Math.random().toString(36);
+/** Set an id for the top-level element */
+export let id = "ccs-" + Math.random().toString(36);
 
-  import { getContext } from "svelte";
+import { getContext } from "svelte";
 
-  const { selectedContent, addContent, tabs, contentById } = getContext("Tabs");
+const { selectedContent, addContent, tabs, contentById } = getContext("Tabs");
 
-  addContent({ id });
+addContent({ id });
 
-  $: selected = $selectedContent === id;
-  $: index = $contentById[id].index;
-  $: tabId = $tabs[index].id;
+$: selected = $selectedContent === id;
+$: index = $contentById[id].index;
+$: tabId = $tabs[index].id;
 </script>
 
 <div

--- a/src/Tabs/Tabs.svelte
+++ b/src/Tabs/Tabs.svelte
@@ -1,66 +1,77 @@
 <script>
-  /**
-   * @event {number} change
-   */
+/**
+ * @event {number} change
+ */
 
-  /** Specify the selected tab index */
-  export let selected = 0;
+/** Specify the selected tab index */
+export let selected = 0;
 
-  /**
-   * Specify the type of tabs
-   * @type {"default" | "container"}
-   */
-  export let type = "default";
+/**
+ * Specify the type of tabs
+ * @type {"default" | "container"}
+ */
+export let type = "default";
 
-  /** Set to `true` for tabs to have an auto-width */
-  export let autoWidth = false;
+/** Set to `true` for tabs to have an auto-width */
+export let autoWidth = false;
 
-  /**
-   * Specify the ARIA label for the chevron icon
-   * @type {string}
-   */
-  export let iconDescription = "Show menu options";
+/**
+ * Specify the ARIA label for the chevron icon
+ * @type {string}
+ */
+export let iconDescription = "Show menu options";
 
-  /** Specify the tab trigger href attribute */
-  export let triggerHref = "#";
+/** Specify the tab trigger href attribute */
+export let triggerHref = "#";
 
-  import { createEventDispatcher, afterUpdate, setContext, tick } from "svelte";
-  import { writable, derived } from "svelte/store";
-  import ChevronDown from "../icons/ChevronDown.svelte";
+import { createEventDispatcher, afterUpdate, setContext, tick } from "svelte";
+import { writable, derived } from "svelte/store";
+import ChevronDown from "../icons/ChevronDown.svelte";
 
-  const dispatch = createEventDispatcher();
+const dispatch = createEventDispatcher();
 
-  const tabs = writable([]);
-  const tabsById = derived(tabs, (_) =>
-    _.reduce((a, c) => ({ ...a, [c.id]: c }), {}),
-  );
-  const useAutoWidth = writable(autoWidth);
-  const selectedTab = writable(undefined);
-  const content = writable([]);
-  const contentById = derived(content, (_) =>
-    _.reduce((a, c) => ({ ...a, [c.id]: c }), {}),
-  );
-  const selectedContent = writable(undefined);
+const tabs = writable([]);
+const tabsById = derived(tabs, (_) =>
+  _.reduce((a, c) => ({ ...a, [c.id]: c }), {}),
+);
+const useAutoWidth = writable(autoWidth);
+const selectedTab = writable(undefined);
+const content = writable([]);
+const contentById = derived(content, (_) =>
+  _.reduce((a, c) => ({ ...a, [c.id]: c }), {}),
+);
+const selectedContent = writable(undefined);
 
-  let refTabList = null;
+let refTabList = null;
 
-  setContext("Tabs", {
-    tabs,
-    contentById,
-    selectedTab,
-    selectedContent,
-    useAutoWidth,
-    add: (data) => {
-      tabs.update((_) => [..._, { ...data, index: _.length }]);
-    },
-    addContent: (data) => {
-      content.update((_) => [..._, { ...data, index: _.length }]);
-    },
-    update: (id) => {
-      currentIndex = $tabsById[id].index;
-    },
-    change: async (direction) => {
-      let index = currentIndex + direction;
+setContext("Tabs", {
+  tabs,
+  contentById,
+  selectedTab,
+  selectedContent,
+  useAutoWidth,
+  add: (data) => {
+    tabs.update((_) => [..._, { ...data, index: _.length }]);
+  },
+  addContent: (data) => {
+    content.update((_) => [..._, { ...data, index: _.length }]);
+  },
+  update: (id) => {
+    currentIndex = $tabsById[id].index;
+  },
+  change: async (direction) => {
+    let index = currentIndex + direction;
+
+    if (index < 0) {
+      index = $tabs.length - 1;
+    } else if (index >= $tabs.length) {
+      index = 0;
+    }
+
+    let disabled = $tabs[index].disabled;
+
+    while (disabled) {
+      index = index + direction;
 
       if (index < 0) {
         index = $tabs.length - 1;
@@ -68,59 +79,48 @@
         index = 0;
       }
 
-      let disabled = $tabs[index].disabled;
-
-      while (disabled) {
-        index = index + direction;
-
-        if (index < 0) {
-          index = $tabs.length - 1;
-        } else if (index >= $tabs.length) {
-          index = 0;
-        }
-
-        disabled = $tabs[index].disabled;
-      }
-
-      currentIndex = index;
-
-      await tick();
-      const activeTab =
-        refTabList?.querySelectorAll("[role='tab']")[currentIndex];
-      activeTab?.focus();
-    },
-  });
-
-  afterUpdate(() => {
-    selected = currentIndex;
-
-    if (prevIndex > -1 && prevIndex !== currentIndex) {
-      dispatch("change", currentIndex);
+      disabled = $tabs[index].disabled;
     }
 
-    prevIndex = currentIndex;
-  });
+    currentIndex = index;
 
-  let dropdownHidden = true;
-  let currentIndex = selected;
-  let prevIndex = -1;
+    await tick();
+    const activeTab =
+      refTabList?.querySelectorAll("[role='tab']")[currentIndex];
+    activeTab?.focus();
+  },
+});
 
-  $: currentIndex = selected;
-  $: currentTab = $tabs[currentIndex] || undefined;
-  $: currentContent = $content[currentIndex] || undefined;
-  $: {
-    if (currentTab) {
-      selectedTab.set(currentTab.id);
-    }
+afterUpdate(() => {
+  selected = currentIndex;
 
-    if (currentContent) {
-      selectedContent.set(currentContent.id);
-    }
+  if (prevIndex > -1 && prevIndex !== currentIndex) {
+    dispatch("change", currentIndex);
   }
-  $: if ($selectedTab) {
-    dropdownHidden = true;
+
+  prevIndex = currentIndex;
+});
+
+let dropdownHidden = true;
+let currentIndex = selected;
+let prevIndex = -1;
+
+$: currentIndex = selected;
+$: currentTab = $tabs[currentIndex] || undefined;
+$: currentContent = $content[currentIndex] || undefined;
+$: {
+  if (currentTab) {
+    selectedTab.set(currentTab.id);
   }
-  $: useAutoWidth.set(autoWidth);
+
+  if (currentContent) {
+    selectedContent.set(currentContent.id);
+  }
+}
+$: if ($selectedTab) {
+  dropdownHidden = true;
+}
+$: useAutoWidth.set(autoWidth);
 </script>
 
 <div

--- a/src/Tabs/TabsSkeleton.svelte
+++ b/src/Tabs/TabsSkeleton.svelte
@@ -1,12 +1,12 @@
 <script>
-  /** Specify the number of tabs to render */
-  export let count = 4;
+/** Specify the number of tabs to render */
+export let count = 4;
 
-  /**
-   * Specify the type of tabs
-   * @type {"default" | "container"}
-   */
-  export let type = "default";
+/**
+ * Specify the type of tabs
+ * @type {"default" | "container"}
+ */
+export let type = "default";
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->

--- a/src/Tag/Tag.svelte
+++ b/src/Tag/Tag.svelte
@@ -1,44 +1,44 @@
 <script>
-  /** @restProps {div | span} */
+/** @restProps {div | span} */
 
-  /**
-   * Specify the type of tag
-   * @type {"red" | "magenta" | "purple" | "blue" | "cyan" | "teal" | "green" | "gray" | "cool-gray" | "warm-gray" | "high-contrast" | "outline"}
-   */
-  export let type = undefined;
+/**
+ * Specify the type of tag
+ * @type {"red" | "magenta" | "purple" | "blue" | "cyan" | "teal" | "green" | "gray" | "cool-gray" | "warm-gray" | "high-contrast" | "outline"}
+ */
+export let type = undefined;
 
-  /** @type {"sm" | "default"} */
-  export let size = "default";
+/** @type {"sm" | "default"} */
+export let size = "default";
 
-  /** Set to `true` to use filterable variant */
-  export let filter = false;
+/** Set to `true` to use filterable variant */
+export let filter = false;
 
-  /** Set to `true` to disable a filterable tag */
-  export let disabled = false;
+/** Set to `true` to disable a filterable tag */
+export let disabled = false;
 
-  /** Set to `true` to render a `button` element instead of a `div` */
-  export let interactive = false;
+/** Set to `true` to render a `button` element instead of a `div` */
+export let interactive = false;
 
-  /** Set to `true` to display the skeleton state */
-  export let skeleton = false;
+/** Set to `true` to display the skeleton state */
+export let skeleton = false;
 
-  /** Set the title for the close button in a filterable tag */
-  export let title = "Clear filter";
+/** Set the title for the close button in a filterable tag */
+export let title = "Clear filter";
 
-  /**
-   * Specify the icon to render
-   * @type {any}
-   */
-  export let icon = undefined;
+/**
+ * Specify the icon to render
+ * @type {any}
+ */
+export let icon = undefined;
 
-  /** Set an id for the filterable tag */
-  export let id = "ccs-" + Math.random().toString(36);
+/** Set an id for the filterable tag */
+export let id = "ccs-" + Math.random().toString(36);
 
-  import { createEventDispatcher } from "svelte";
-  import Close from "../icons/Close.svelte";
-  import TagSkeleton from "./TagSkeleton.svelte";
+import { createEventDispatcher } from "svelte";
+import Close from "../icons/Close.svelte";
+import TagSkeleton from "./TagSkeleton.svelte";
 
-  const dispatch = createEventDispatcher();
+const dispatch = createEventDispatcher();
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->

--- a/src/Tag/TagSkeleton.svelte
+++ b/src/Tag/TagSkeleton.svelte
@@ -1,6 +1,6 @@
 <script>
-  /** @type {"sm" | "default"} */
-  export let size = "default";
+/** @type {"sm" | "default"} */
+export let size = "default";
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->

--- a/src/TextArea/TextArea.svelte
+++ b/src/TextArea/TextArea.svelte
@@ -1,64 +1,64 @@
 <script>
-  /**
-   * Specify the textarea value.
-   * @type {null | string}
-   */
-  export let value = "";
+/**
+ * Specify the textarea value.
+ * @type {null | string}
+ */
+export let value = "";
 
-  /** Specify the placeholder text */
-  export let placeholder = "";
+/** Specify the placeholder text */
+export let placeholder = "";
 
-  /** Specify the number of cols */
-  export let cols = 50;
+/** Specify the number of cols */
+export let cols = 50;
 
-  /** Specify the number of rows */
-  export let rows = 4;
+/** Specify the number of rows */
+export let rows = 4;
 
-  /**
-   * Specify the max character count
-   * @type {number}
-   */
-  export let maxCount = undefined;
+/**
+ * Specify the max character count
+ * @type {number}
+ */
+export let maxCount = undefined;
 
-  /** Set to `true` to enable the light variant */
-  export let light = false;
+/** Set to `true` to enable the light variant */
+export let light = false;
 
-  /** Set to `true` to disable the input */
-  export let disabled = false;
+/** Set to `true` to disable the input */
+export let disabled = false;
 
-  /** Set to `true` to use the read-only variant */
-  export let readonly = false;
+/** Set to `true` to use the read-only variant */
+export let readonly = false;
 
-  /** Specify the helper text */
-  export let helperText = "";
+/** Specify the helper text */
+export let helperText = "";
 
-  /** Specify the label text */
-  export let labelText = "";
+/** Specify the label text */
+export let labelText = "";
 
-  /** Set to `true` to visually hide the label text */
-  export let hideLabel = false;
+/** Set to `true` to visually hide the label text */
+export let hideLabel = false;
 
-  /** Set to `true` to indicate an invalid state */
-  export let invalid = false;
+/** Set to `true` to indicate an invalid state */
+export let invalid = false;
 
-  /** Specify the text for the invalid state */
-  export let invalidText = "";
+/** Specify the text for the invalid state */
+export let invalidText = "";
 
-  /** Set an id for the textarea element */
-  export let id = "ccs-" + Math.random().toString(36);
+/** Set an id for the textarea element */
+export let id = "ccs-" + Math.random().toString(36);
 
-  /**
-   * Specify a name attribute for the input
-   * @type {string}
-   */
-  export let name = undefined;
+/**
+ * Specify a name attribute for the input
+ * @type {string}
+ */
+export let name = undefined;
 
-  /** Obtain a reference to the textarea HTML element */
-  export let ref = null;
+/** Obtain a reference to the textarea HTML element */
+export let ref = null;
 
-  import WarningFilled from "../icons/WarningFilled.svelte";
+import WarningFilled from "../icons/WarningFilled.svelte";
 
-  $: errorId = `error-${id}`;
+$: errorId = `error-${id}`;
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->

--- a/src/TextArea/TextAreaSkeleton.svelte
+++ b/src/TextArea/TextAreaSkeleton.svelte
@@ -1,6 +1,6 @@
 <script>
-  /** Set to `true` to visually hide the label text */
-  export let hideLabel = false;
+/** Set to `true` to visually hide the label text */
+export let hideLabel = false;
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->

--- a/src/TextInput/PasswordInput.svelte
+++ b/src/TextInput/PasswordInput.svelte
@@ -1,97 +1,97 @@
 <script>
-  /**
-   * Set the size of the input
-   * @type {"sm" | "xl"}
-   */
-  export let size = undefined;
+/**
+ * Set the size of the input
+ * @type {"sm" | "xl"}
+ */
+export let size = undefined;
 
-  /**
-   * Specify the input value
-   * @type {number | string}
-   */
-  export let value = "";
+/**
+ * Specify the input value
+ * @type {number | string}
+ */
+export let value = "";
 
-  /**
-   * Set to `"text"` to toggle the password visibility
-   * @type {"text" | "password"}
-   */
-  export let type = "password";
+/**
+ * Set to `"text"` to toggle the password visibility
+ * @type {"text" | "password"}
+ */
+export let type = "password";
 
-  /** Specify the placeholder text */
-  export let placeholder = "";
+/** Specify the placeholder text */
+export let placeholder = "";
 
-  /** Specify the hide password label text */
-  export let hidePasswordLabel = "Hide password";
+/** Specify the hide password label text */
+export let hidePasswordLabel = "Hide password";
 
-  /** Specify the show password label text */
-  export let showPasswordLabel = "Show password";
+/** Specify the show password label text */
+export let showPasswordLabel = "Show password";
 
-  /**
-   * Set the alignment of the tooltip relative to the icon
-   * @type {"start" | "center" | "end"}
-   */
-  export let tooltipAlignment = "center";
+/**
+ * Set the alignment of the tooltip relative to the icon
+ * @type {"start" | "center" | "end"}
+ */
+export let tooltipAlignment = "center";
 
-  /**
-   * Set the position of the tooltip relative to the icon
-   * @type {"top" | "right" | "bottom" | "left"}
-   */
-  export let tooltipPosition = "bottom";
+/**
+ * Set the position of the tooltip relative to the icon
+ * @type {"top" | "right" | "bottom" | "left"}
+ */
+export let tooltipPosition = "bottom";
 
-  /** Set to `true` to enable the light variant */
-  export let light = false;
+/** Set to `true` to enable the light variant */
+export let light = false;
 
-  /** Set to `true` to disable the input */
-  export let disabled = false;
+/** Set to `true` to disable the input */
+export let disabled = false;
 
-  /** Specify the helper text */
-  export let helperText = "";
+/** Specify the helper text */
+export let helperText = "";
 
-  /** Specify the label text */
-  export let labelText = "";
+/** Specify the label text */
+export let labelText = "";
 
-  /** Set to `true` to visually hide the label text */
-  export let hideLabel = false;
+/** Set to `true` to visually hide the label text */
+export let hideLabel = false;
 
-  /** Set to `true` to indicate an invalid state */
-  export let invalid = false;
+/** Set to `true` to indicate an invalid state */
+export let invalid = false;
 
-  /** Specify the text for the invalid state */
-  export let invalidText = "";
+/** Specify the text for the invalid state */
+export let invalidText = "";
 
-  /** Set to `true` to indicate an warning state */
-  export let warn = false;
+/** Set to `true` to indicate an warning state */
+export let warn = false;
 
-  /** Specify the warning state text */
-  export let warnText = "";
+/** Specify the warning state text */
+export let warnText = "";
 
-  /** Set to `true` to use inline version */
-  export let inline = false;
+/** Set to `true` to use inline version */
+export let inline = false;
 
-  /** Set an id for the input element */
-  export let id = "ccs-" + Math.random().toString(36);
+/** Set an id for the input element */
+export let id = "ccs-" + Math.random().toString(36);
 
-  /**
-   * Specify a name attribute for the input
-   * @type {string}
-   */
-  export let name = undefined;
+/**
+ * Specify a name attribute for the input
+ * @type {string}
+ */
+export let name = undefined;
 
-  /** Obtain a reference to the input HTML element */
-  export let ref = null;
+/** Obtain a reference to the input HTML element */
+export let ref = null;
 
-  import { getContext } from "svelte";
-  import WarningFilled from "../icons/WarningFilled.svelte";
-  import WarningAltFilled from "../icons/WarningAltFilled.svelte";
-  import View from "../icons/View.svelte";
-  import ViewOff from "../icons/ViewOff.svelte";
+import { getContext } from "svelte";
+import WarningFilled from "../icons/WarningFilled.svelte";
+import WarningAltFilled from "../icons/WarningAltFilled.svelte";
+import View from "../icons/View.svelte";
+import ViewOff from "../icons/ViewOff.svelte";
 
-  const ctx = getContext("Form");
+const ctx = getContext("Form");
 
-  const isFluid = !!ctx && ctx.isFluid;
-  $: helperId = `helper-${id}`;
-  $: errorId = `error-${id}`;
-  $: warnId = `warn-${id}`;
+const isFluid = !!ctx && ctx.isFluid;
+$: helperId = `helper-${id}`;
+$: errorId = `error-${id}`;
+$: warnId = `warn-${id}`;
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->

--- a/src/TextInput/TextInput.svelte
+++ b/src/TextInput/TextInput.svelte
@@ -1,104 +1,104 @@
 <script>
-  /**
-   * @event {null | number | string} change
-   * @event {null | number | string} input
-   */
+/**
+ * @event {null | number | string} change
+ * @event {null | number | string} input
+ */
 
-  /**
-   * Set the size of the input
-   * @type {"sm" | "xl"}
-   */
-  export let size = undefined;
+/**
+ * Set the size of the input
+ * @type {"sm" | "xl"}
+ */
+export let size = undefined;
 
-  /**
-   * Specify the input value.
-   *
-   * `value` will be set to `null` if type="number"
-   * and the value is empty.
-   * @type {null | number | string}
-   */
-  export let value = "";
+/**
+ * Specify the input value.
+ *
+ * `value` will be set to `null` if type="number"
+ * and the value is empty.
+ * @type {null | number | string}
+ */
+export let value = "";
 
-  /** Specify the placeholder text */
-  export let placeholder = "";
+/** Specify the placeholder text */
+export let placeholder = "";
 
-  /** Set to `true` to enable the light variant */
-  export let light = false;
+/** Set to `true` to enable the light variant */
+export let light = false;
 
-  /** Set to `true` to disable the input */
-  export let disabled = false;
+/** Set to `true` to disable the input */
+export let disabled = false;
 
-  /** Specify the helper text */
-  export let helperText = "";
+/** Specify the helper text */
+export let helperText = "";
 
-  /** Set an id for the input element */
-  export let id = "ccs-" + Math.random().toString(36);
+/** Set an id for the input element */
+export let id = "ccs-" + Math.random().toString(36);
 
-  /**
-   * Specify a name attribute for the input
-   * @type {string}
-   */
-  export let name = undefined;
+/**
+ * Specify a name attribute for the input
+ * @type {string}
+ */
+export let name = undefined;
 
-  /** Specify the label text */
-  export let labelText = "";
+/** Specify the label text */
+export let labelText = "";
 
-  /** Set to `true` to visually hide the label text */
-  export let hideLabel = false;
+/** Set to `true` to visually hide the label text */
+export let hideLabel = false;
 
-  /** Set to `true` to indicate an invalid state */
-  export let invalid = false;
+/** Set to `true` to indicate an invalid state */
+export let invalid = false;
 
-  /** Specify the invalid state text */
-  export let invalidText = "";
+/** Specify the invalid state text */
+export let invalidText = "";
 
-  /** Set to `true` to indicate an warning state */
-  export let warn = false;
+/** Set to `true` to indicate an warning state */
+export let warn = false;
 
-  /** Specify the warning state text */
-  export let warnText = "";
+/** Specify the warning state text */
+export let warnText = "";
 
-  /** Obtain a reference to the input HTML element */
-  export let ref = null;
+/** Obtain a reference to the input HTML element */
+export let ref = null;
 
-  /** Set to `true` to mark the field as required */
-  export let required = false;
+/** Set to `true` to mark the field as required */
+export let required = false;
 
-  /** Set to `true` to use the inline variant */
-  export let inline = false;
+/** Set to `true` to use the inline variant */
+export let inline = false;
 
-  /** Set to `true` to use the read-only variant */
-  export let readonly = false;
+/** Set to `true` to use the read-only variant */
+export let readonly = false;
 
-  import { createEventDispatcher, getContext } from "svelte";
-  import WarningFilled from "../icons/WarningFilled.svelte";
-  import WarningAltFilled from "../icons/WarningAltFilled.svelte";
-  import EditOff from "../icons/EditOff.svelte";
+import { createEventDispatcher, getContext } from "svelte";
+import WarningFilled from "../icons/WarningFilled.svelte";
+import WarningAltFilled from "../icons/WarningAltFilled.svelte";
+import EditOff from "../icons/EditOff.svelte";
 
-  const ctx = getContext("Form");
-  const dispatch = createEventDispatcher();
+const ctx = getContext("Form");
+const dispatch = createEventDispatcher();
 
-  function parse(raw) {
-    if ($$restProps.type !== "number") return raw;
-    return raw != "" ? Number(raw) : null;
-  }
+function parse(raw) {
+  if ($$restProps.type !== "number") return raw;
+  return raw != "" ? Number(raw) : null;
+}
 
-  /** @type {(e: Event) => void} */
-  const onInput = (e) => {
-    value = parse(e.target.value);
-    dispatch("input", value);
-  };
+/** @type {(e: Event) => void} */
+const onInput = (e) => {
+  value = parse(e.target.value);
+  dispatch("input", value);
+};
 
-  /** @type {(e: Event) => void} */
-  const onChange = (e) => {
-    dispatch("change", parse(e.target.value));
-  };
+/** @type {(e: Event) => void} */
+const onChange = (e) => {
+  dispatch("change", parse(e.target.value));
+};
 
-  const isFluid = !!ctx && ctx.isFluid;
-  $: error = invalid && !readonly;
-  $: helperId = `helper-${id}`;
-  $: errorId = `error-${id}`;
-  $: warnId = `warn-${id}`;
+const isFluid = !!ctx && ctx.isFluid;
+$: error = invalid && !readonly;
+$: helperId = `helper-${id}`;
+$: errorId = `error-${id}`;
+$: warnId = `warn-${id}`;
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->

--- a/src/TextInput/TextInputSkeleton.svelte
+++ b/src/TextInput/TextInputSkeleton.svelte
@@ -1,6 +1,6 @@
 <script>
-  /** Set to `true` to hide the label text */
-  export let hideLabel = false;
+/** Set to `true` to hide the label text */
+export let hideLabel = false;
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->

--- a/src/Theme/Theme.svelte
+++ b/src/Theme/Theme.svelte
@@ -1,98 +1,98 @@
 <script>
-  /**
-   * Dynamic, client-side theming using CSS variables
-   * Only works with `carbon-components-svelte/css/all.css`
-   */
+/**
+ * Dynamic, client-side theming using CSS variables
+ * Only works with `carbon-components-svelte/css/all.css`
+ */
 
-  /**
-   * @typedef {"white" | "g10" | "g80" | "g90" | "g100"} CarbonTheme
-   * @event {{ theme: CarbonTheme; }} update
-   * @slot {{ theme: CarbonTheme; }}
-   */
+/**
+ * @typedef {"white" | "g10" | "g80" | "g90" | "g100"} CarbonTheme
+ * @event {{ theme: CarbonTheme; }} update
+ * @slot {{ theme: CarbonTheme; }}
+ */
 
-  /**
-   * Set the current Carbon theme
-   * @type {CarbonTheme}
-   */
-  export let theme = "white";
+/**
+ * Set the current Carbon theme
+ * @type {CarbonTheme}
+ */
+export let theme = "white";
 
-  /**
-   * Customize a theme with your own tokens
-   * @see https://carbondesignsystem.com/guidelines/themes/overview#customizing-a-theme
-   * @type {{ [token: string]: any; }}
-   */
-  export let tokens = {};
+/**
+ * Customize a theme with your own tokens
+ * @see https://carbondesignsystem.com/guidelines/themes/overview#customizing-a-theme
+ * @type {{ [token: string]: any; }}
+ */
+export let tokens = {};
 
-  /** Set to `true` to persist the theme using window.localStorage */
-  export let persist = false;
+/** Set to `true` to persist the theme using window.localStorage */
+export let persist = false;
 
-  /** Specify the local storage key */
-  export let persistKey = "theme";
+/** Specify the local storage key */
+export let persistKey = "theme";
 
-  /**
-   * Render a toggle or select dropdown to control the theme
-   * @type {"toggle" | "select"}
-   */
-  export let render = undefined;
+/**
+ * Render a toggle or select dropdown to control the theme
+ * @type {"toggle" | "select"}
+ */
+export let render = undefined;
 
-  /**
-   * Override the default toggle props
-   * @type {import("../Toggle/Toggle.svelte").ToggleProps & { themes?: [labelA: CarbonTheme, labelB: CarbonTheme]; }}
-   */
-  export let toggle = {
-    themes: ["white", "g100"],
-    labelA: "",
-    labelB: "",
-    labelText: "Dark mode",
-    hideLabel: false,
-  };
+/**
+ * Override the default toggle props
+ * @type {import("../Toggle/Toggle.svelte").ToggleProps & { themes?: [labelA: CarbonTheme, labelB: CarbonTheme]; }}
+ */
+export let toggle = {
+  themes: ["white", "g100"],
+  labelA: "",
+  labelB: "",
+  labelText: "Dark mode",
+  hideLabel: false,
+};
 
-  /** @type {Record<CarbonTheme, string>} */
-  const themes = {
-    white: "White",
-    g10: "Gray 10",
-    g80: "Gray 80",
-    g90: "Gray 90",
-    g100: "Gray 100",
-  };
+/** @type {Record<CarbonTheme, string>} */
+const themes = {
+  white: "White",
+  g10: "Gray 10",
+  g80: "Gray 80",
+  g90: "Gray 90",
+  g100: "Gray 100",
+};
 
-  /** @type {CarbonTheme} */
-  const themeKeys = Object.keys(themes);
+/** @type {CarbonTheme} */
+const themeKeys = Object.keys(themes);
 
-  /**
-   * Override the default select props
-   * @type {import("../Select/Select.svelte").SelectProps & { themes?: CarbonTheme[]; }}
-   */
-  export let select = {
-    themes: themeKeys,
-    labelText: "Themes",
-    hideLabel: false,
-  };
+/**
+ * Override the default select props
+ * @type {import("../Select/Select.svelte").SelectProps & { themes?: CarbonTheme[]; }}
+ */
+export let select = {
+  themes: themeKeys,
+  labelText: "Themes",
+  hideLabel: false,
+};
 
-  import { createEventDispatcher } from "svelte";
-  import Toggle from "../Toggle/Toggle.svelte";
-  import Select from "../Select/Select.svelte";
-  import SelectItem from "../Select/SelectItem.svelte";
-  import LocalStorage from "../LocalStorage/LocalStorage.svelte";
+import { createEventDispatcher } from "svelte";
+import Toggle from "../Toggle/Toggle.svelte";
+import Select from "../Select/Select.svelte";
+import SelectItem from "../Select/SelectItem.svelte";
+import LocalStorage from "../LocalStorage/LocalStorage.svelte";
 
-  const dispatch = createEventDispatcher();
+const dispatch = createEventDispatcher();
 
-  $: if (typeof window !== "undefined") {
-    Object.entries(tokens).forEach(([token, value]) => {
-      document.documentElement.style.setProperty(`--cds-${token}`, value);
-    });
+$: if (typeof window !== "undefined") {
+  Object.entries(tokens).forEach(([token, value]) => {
+    document.documentElement.style.setProperty(`--cds-${token}`, value);
+  });
 
-    if (theme in themes) {
-      document.documentElement.setAttribute("theme", theme);
-      dispatch("update", { theme });
-    } else {
-      console.warn(
-        `[Theme.svelte] invalid theme "${theme}". Value must be one of: ${JSON.stringify(
-          Object.keys(themes),
-        )}`,
-      );
-    }
+  if (theme in themes) {
+    document.documentElement.setAttribute("theme", theme);
+    dispatch("update", { theme });
+  } else {
+    console.warn(
+      `[Theme.svelte] invalid theme "${theme}". Value must be one of: ${JSON.stringify(
+        Object.keys(themes),
+      )}`,
+    );
   }
+}
 </script>
 
 {#if persist}

--- a/src/Tile/ClickableTile.svelte
+++ b/src/Tile/ClickableTile.svelte
@@ -1,22 +1,22 @@
 <script>
-  /** @restProps {a | p} */
+/** @restProps {a | p} */
 
-  /** Set to `true` to click the tile */
-  export let clicked = false;
+/** Set to `true` to click the tile */
+export let clicked = false;
 
-  /** Set to `true` to enable the light variant */
-  export let light = false;
+/** Set to `true` to enable the light variant */
+export let light = false;
 
-  /** Set to `true` to disable the tile */
-  export let disabled = false;
+/** Set to `true` to disable the tile */
+export let disabled = false;
 
-  /**
-   * Set the `href`
-   * @type {string}
-   */
-  export let href = undefined;
+/**
+ * Set the `href`
+ * @type {string}
+ */
+export let href = undefined;
 
-  import Link from "../Link/Link.svelte";
+import Link from "../Link/Link.svelte";
 </script>
 
 <Link

--- a/src/Tile/ExpandableTile.svelte
+++ b/src/Tile/ExpandableTile.svelte
@@ -1,65 +1,65 @@
 <script>
-  /** Set to `true` to expand the tile */
-  export let expanded = false;
+/** Set to `true` to expand the tile */
+export let expanded = false;
 
-  /** Set to `true` to enable the light variant */
-  export let light = false;
+/** Set to `true` to enable the light variant */
+export let light = false;
 
-  /** Specify the max height of the tile  (number of pixels) */
-  export let tileMaxHeight = 0;
+/** Specify the max height of the tile  (number of pixels) */
+export let tileMaxHeight = 0;
 
-  /** Specify the padding of the tile (number of pixels) */
-  export let tilePadding = 0;
+/** Specify the padding of the tile (number of pixels) */
+export let tilePadding = 0;
 
-  /** Specify the icon text of the collapsed tile */
-  export let tileCollapsedIconText = "Interact to expand Tile";
+/** Specify the icon text of the collapsed tile */
+export let tileCollapsedIconText = "Interact to expand Tile";
 
-  /** Specify the icon text of the expanded tile */
-  export let tileExpandedIconText = "Interact to collapse Tile";
+/** Specify the icon text of the expanded tile */
+export let tileExpandedIconText = "Interact to collapse Tile";
 
-  /** Specify the icon label of the expanded tile */
-  export let tileExpandedLabel = "";
+/** Specify the icon label of the expanded tile */
+export let tileExpandedLabel = "";
 
-  /** Specify the icon label of the collapsed tile */
-  export let tileCollapsedLabel = "";
+/** Specify the icon label of the collapsed tile */
+export let tileCollapsedLabel = "";
 
-  /** Specify the tabindex */
-  export let tabindex = "0";
+/** Specify the tabindex */
+export let tabindex = "0";
 
-  /** Set an id for the top-level div element */
-  export let id = "ccs-" + Math.random().toString(36);
+/** Set an id for the top-level div element */
+export let id = "ccs-" + Math.random().toString(36);
 
-  /** Obtain a reference to the top-level element */
-  export let ref = null;
+/** Obtain a reference to the top-level element */
+export let ref = null;
 
-  import { afterUpdate, onMount } from "svelte";
-  import ChevronDown from "../icons/ChevronDown.svelte";
+import { afterUpdate, onMount } from "svelte";
+import ChevronDown from "../icons/ChevronDown.svelte";
 
-  let refAbove = null;
+let refAbove = null;
 
-  onMount(() => {
-    const resizeObserver = new ResizeObserver(([elem]) => {
-      tileMaxHeight = elem.contentRect.height;
-    });
-
-    resizeObserver.observe(refAbove);
-
-    return () => {
-      resizeObserver.disconnect();
-    };
+onMount(() => {
+  const resizeObserver = new ResizeObserver(([elem]) => {
+    tileMaxHeight = elem.contentRect.height;
   });
 
-  afterUpdate(() => {
-    if (tileMaxHeight === 0) {
-      tileMaxHeight = refAbove.getBoundingClientRect().height;
-    }
+  resizeObserver.observe(refAbove);
 
-    const style = getComputedStyle(ref);
+  return () => {
+    resizeObserver.disconnect();
+  };
+});
 
-    tilePadding =
-      parseInt(style.getPropertyValue("padding-top"), 10) +
-      parseInt(style.getPropertyValue("padding-bottom"), 10);
-  });
+afterUpdate(() => {
+  if (tileMaxHeight === 0) {
+    tileMaxHeight = refAbove.getBoundingClientRect().height;
+  }
+
+  const style = getComputedStyle(ref);
+
+  tilePadding =
+    parseInt(style.getPropertyValue("padding-top"), 10) +
+    parseInt(style.getPropertyValue("padding-bottom"), 10);
+});
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->

--- a/src/Tile/RadioTile.svelte
+++ b/src/Tile/RadioTile.svelte
@@ -1,50 +1,50 @@
 <script>
-  /** Set to `true` to check the tile */
-  export let checked = false;
+/** Set to `true` to check the tile */
+export let checked = false;
 
-  /** Set to `true` to enable the light variant */
-  export let light = false;
+/** Set to `true` to enable the light variant */
+export let light = false;
 
-  /** Set to `true` to disable the tile */
-  export let disabled = false;
+/** Set to `true` to disable the tile */
+export let disabled = false;
 
-  /** Set to `true` to mark the field as required */
-  export let required = false;
+/** Set to `true` to mark the field as required */
+export let required = false;
 
-  /** Specify the value of the radio input */
-  export let value = "";
+/** Specify the value of the radio input */
+export let value = "";
 
-  /** Specify the tabindex */
-  export let tabindex = "0";
+/** Specify the tabindex */
+export let tabindex = "0";
 
-  /** Specify the ARIA label for the radio tile checkmark icon */
-  export let iconDescription = "Tile checkmark";
+/** Specify the ARIA label for the radio tile checkmark icon */
+export let iconDescription = "Tile checkmark";
 
-  /** Set an id for the input element */
-  export let id = "ccs-" + Math.random().toString(36);
+/** Set an id for the input element */
+export let id = "ccs-" + Math.random().toString(36);
 
-  /**
-   * Specify a name attribute for the radio tile input
-   * @type {string}
-   */
-  export let name = undefined;
+/**
+ * Specify a name attribute for the radio tile input
+ * @type {string}
+ */
+export let name = undefined;
 
-  import { getContext } from "svelte";
-  import { readable } from "svelte/store";
-  import CheckmarkFilled from "../icons/CheckmarkFilled.svelte";
+import { getContext } from "svelte";
+import { readable } from "svelte/store";
+import CheckmarkFilled from "../icons/CheckmarkFilled.svelte";
 
-  const { add, update, selectedValue, groupName, groupRequired } = getContext(
-    "TileGroup",
-  ) ?? {
-    add: () => {},
-    groupName: readable(undefined),
-    groupRequired: readable(undefined),
-    selectedValue: readable(checked ? value : undefined),
-  };
+const { add, update, selectedValue, groupName, groupRequired } = getContext(
+  "TileGroup",
+) ?? {
+  add: () => {},
+  groupName: readable(undefined),
+  groupRequired: readable(undefined),
+  selectedValue: readable(checked ? value : undefined),
+};
 
-  add({ value, checked });
+add({ value, checked });
 
-  $: checked = value === $selectedValue;
+$: checked = value === $selectedValue;
 </script>
 
 <input

--- a/src/Tile/SelectableTile.svelte
+++ b/src/Tile/SelectableTile.svelte
@@ -1,48 +1,48 @@
 <script>
-  /**
-   * @event {string} "select"
-   * @event {string} "deselect"
-   */
+/**
+ * @event {string} "select"
+ * @event {string} "deselect"
+ */
 
-  /** Set to `true` to select the tile */
-  export let selected = false;
+/** Set to `true` to select the tile */
+export let selected = false;
 
-  /** Set to `true` to enable the light variant */
-  export let light = false;
+/** Set to `true` to enable the light variant */
+export let light = false;
 
-  /** Set to `true` to disable the tile */
-  export let disabled = false;
+/** Set to `true` to disable the tile */
+export let disabled = false;
 
-  /** Specify the title of the selectable tile */
-  export let title = "title";
+/** Specify the title of the selectable tile */
+export let title = "title";
 
-  /** Specify the value of the selectable tile */
-  export let value = "value";
+/** Specify the value of the selectable tile */
+export let value = "value";
 
-  /** Specify the tabindex */
-  export let tabindex = "0";
+/** Specify the tabindex */
+export let tabindex = "0";
 
-  /** Specify the ARIA label for the selectable tile checkmark icon */
-  export let iconDescription = "Tile checkmark";
+/** Specify the ARIA label for the selectable tile checkmark icon */
+export let iconDescription = "Tile checkmark";
 
-  /** Set an id for the input element */
-  export let id = "ccs-" + Math.random().toString(36);
+/** Set an id for the input element */
+export let id = "ccs-" + Math.random().toString(36);
 
-  /**
-   * Specify a name attribute for the input
-   * @type {string}
-   */
-  export let name = "";
+/**
+ * Specify a name attribute for the input
+ * @type {string}
+ */
+export let name = "";
 
-  /** Obtain a reference to the input HTML element */
-  export let ref = null;
+/** Obtain a reference to the input HTML element */
+export let ref = null;
 
-  import { createEventDispatcher } from "svelte";
-  import CheckmarkFilled from "../icons/CheckmarkFilled.svelte";
+import { createEventDispatcher } from "svelte";
+import CheckmarkFilled from "../icons/CheckmarkFilled.svelte";
 
-  const dispatch = createEventDispatcher();
+const dispatch = createEventDispatcher();
 
-  $: if (!disabled) dispatch(selected ? "select" : "deselect", id);
+$: if (!disabled) dispatch(selected ? "select" : "deselect", id);
 </script>
 
 <input

--- a/src/Tile/Tile.svelte
+++ b/src/Tile/Tile.svelte
@@ -1,6 +1,6 @@
 <script>
-  /** Set to `true` to enable the light variant */
-  export let light = false;
+/** Set to `true` to enable the light variant */
+export let light = false;
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->

--- a/src/Tile/TileGroup.svelte
+++ b/src/Tile/TileGroup.svelte
@@ -1,59 +1,59 @@
 <script>
-  /**
-   * @event {string} select
-   */
+/**
+ * @event {string} select
+ */
 
-  /**
-   * Specify the selected tile value
-   * @type {string}
-   */
-  export let selected = undefined;
+/**
+ * Specify the selected tile value
+ * @type {string}
+ */
+export let selected = undefined;
 
-  /** Set to `true` to disable the tile group */
-  export let disabled = false;
+/** Set to `true` to disable the tile group */
+export let disabled = false;
 
-  /**
-   * Set to `true` to require the selection of a radio button
-   * @type {boolean}
-   */
-  export let required = undefined;
+/**
+ * Set to `true` to require the selection of a radio button
+ * @type {boolean}
+ */
+export let required = undefined;
 
-  /**
-   * Specify a name attribute for the radio button inputs
-   * @type {string}
-   */
-  export let name = undefined;
+/**
+ * Specify a name attribute for the radio button inputs
+ * @type {string}
+ */
+export let name = undefined;
 
-  /** Specify the legend text */
-  export let legend = "";
+/** Specify the legend text */
+export let legend = "";
 
-  import { createEventDispatcher, setContext } from "svelte";
-  import { writable, readonly } from "svelte/store";
+import { createEventDispatcher, setContext } from "svelte";
+import { writable, readonly } from "svelte/store";
 
-  const dispatch = createEventDispatcher();
-  const selectedValue = writable(selected);
-  const groupName = writable(name);
-  const groupRequired = writable(required);
+const dispatch = createEventDispatcher();
+const selectedValue = writable(selected);
+const groupName = writable(name);
+const groupRequired = writable(required);
 
-  setContext("TileGroup", {
-    selectedValue,
-    groupName: readonly(groupName),
-    groupRequired: readonly(groupRequired),
-    add: ({ checked, value }) => {
-      if (checked) {
-        selectedValue.set(value);
-      }
-    },
-    update: (value) => {
+setContext("TileGroup", {
+  selectedValue,
+  groupName: readonly(groupName),
+  groupRequired: readonly(groupRequired),
+  add: ({ checked, value }) => {
+    if (checked) {
       selectedValue.set(value);
-      dispatch("select", value);
-    },
-  });
+    }
+  },
+  update: (value) => {
+    selectedValue.set(value);
+    dispatch("select", value);
+  },
+});
 
-  $: selected = $selectedValue;
-  $: selectedValue.set(selected);
-  $: $groupName = name;
-  $: $groupRequired = required;
+$: selected = $selectedValue;
+$: selectedValue.set(selected);
+$: $groupName = name;
+$: $groupRequired = required;
 </script>
 
 <fieldset {disabled} class:bx--tile-group={true} {...$$restProps}>

--- a/src/TimePicker/TimePicker.svelte
+++ b/src/TimePicker/TimePicker.svelte
@@ -1,54 +1,54 @@
 <script>
-  /**
-   * Specify the size of the input
-   * @type {"sm" | "xl"}
-   */
-  export let size = undefined;
+/**
+ * Specify the size of the input
+ * @type {"sm" | "xl"}
+ */
+export let size = undefined;
 
-  /**
-   * Specify the input value
-   * @type {string}
-   */
-  export let value = "";
+/**
+ * Specify the input value
+ * @type {string}
+ */
+export let value = "";
 
-  /** Specify the input placeholder text */
-  export let placeholder = "hh:mm";
+/** Specify the input placeholder text */
+export let placeholder = "hh:mm";
 
-  /** Specify the `pattern` attribute for the input element */
-  export let pattern = "(1[012]|[1-9]):[0-5][0-9](\\s)?";
+/** Specify the `pattern` attribute for the input element */
+export let pattern = "(1[012]|[1-9]):[0-5][0-9](\\s)?";
 
-  /** Specify the `maxlength` input attribute */
-  export let maxlength = 5;
+/** Specify the `maxlength` input attribute */
+export let maxlength = 5;
 
-  /** Set to `true` to enable the light variant */
-  export let light = false;
+/** Set to `true` to enable the light variant */
+export let light = false;
 
-  /** Set to `true` to disable the input */
-  export let disabled = false;
+/** Set to `true` to disable the input */
+export let disabled = false;
 
-  /** Specify the label text */
-  export let labelText = "";
+/** Specify the label text */
+export let labelText = "";
 
-  /** Set to `true` to visually hide the label text */
-  export let hideLabel = false;
+/** Set to `true` to visually hide the label text */
+export let hideLabel = false;
 
-  /** Set to `true` to indicate an invalid state */
-  export let invalid = false;
+/** Set to `true` to indicate an invalid state */
+export let invalid = false;
 
-  /** Specify the invalid state text */
-  export let invalidText = "";
+/** Specify the invalid state text */
+export let invalidText = "";
 
-  /** Set an id for the input element */
-  export let id = "ccs-" + Math.random().toString(36);
+/** Set an id for the input element */
+export let id = "ccs-" + Math.random().toString(36);
 
-  /**
-   * Specify a name attribute for the input
-   * @type {string}
-   */
-  export let name = undefined;
+/**
+ * Specify a name attribute for the input
+ * @type {string}
+ */
+export let name = undefined;
 
-  /** Obtain a reference to the input HTML element */
-  export let ref = null;
+/** Obtain a reference to the input HTML element */
+export let ref = null;
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->

--- a/src/TimePicker/TimePickerSelect.svelte
+++ b/src/TimePicker/TimePickerSelect.svelte
@@ -1,41 +1,41 @@
 <script>
-  /**
-   * Specify the select value
-   * @type {number | string}
-   */
-  export let value = "";
+/**
+ * Specify the select value
+ * @type {number | string}
+ */
+export let value = "";
 
-  /** Set to `true` to disable the select */
-  export let disabled = false;
+/** Set to `true` to disable the select */
+export let disabled = false;
 
-  /** Specify the ARIA label for the chevron icon */
-  export let iconDescription = "Open list of options";
+/** Specify the ARIA label for the chevron icon */
+export let iconDescription = "Open list of options";
 
-  /** Specify the label text */
-  export let labelText = "";
+/** Specify the label text */
+export let labelText = "";
 
-  /** Set an id for the select element */
-  export let id = "ccs-" + Math.random().toString(36);
+/** Set an id for the select element */
+export let id = "ccs-" + Math.random().toString(36);
 
-  /**
-   * Specify a name attribute for the select element
-   * @type {string}
-   */
-  export let name = undefined;
+/**
+ * Specify a name attribute for the select element
+ * @type {string}
+ */
+export let name = undefined;
 
-  /** Obtain a reference to the select HTML element */
-  export let ref = null;
+/** Obtain a reference to the select HTML element */
+export let ref = null;
 
-  import { setContext } from "svelte";
-  import { writable } from "svelte/store";
-  import ChevronDown from "../icons/ChevronDown.svelte";
+import { setContext } from "svelte";
+import { writable } from "svelte/store";
+import ChevronDown from "../icons/ChevronDown.svelte";
 
-  const selectedValue = writable(value);
+const selectedValue = writable(value);
 
-  setContext("TimePickerSelect", { selectedValue });
+setContext("TimePickerSelect", { selectedValue });
 
-  $: selectedValue.set(value);
-  $: value = $selectedValue;
+$: selectedValue.set(value);
+$: value = $selectedValue;
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->

--- a/src/Toggle/Toggle.svelte
+++ b/src/Toggle/Toggle.svelte
@@ -1,46 +1,46 @@
 <script>
-  /**
-   * @event {{ toggled: boolean; }} toggle
-   */
+/**
+ * @event {{ toggled: boolean; }} toggle
+ */
 
-  /**
-   * Specify the toggle size
-   * @type {"default" | "sm"}
-   */
-  export let size = "default";
+/**
+ * Specify the toggle size
+ * @type {"default" | "sm"}
+ */
+export let size = "default";
 
-  /** Set to `true` to toggle the checkbox input */
-  export let toggled = false;
+/** Set to `true` to toggle the checkbox input */
+export let toggled = false;
 
-  /** Set to `true` to disable checkbox input */
-  export let disabled = false;
+/** Set to `true` to disable checkbox input */
+export let disabled = false;
 
-  /** Specify the label for the untoggled state */
-  export let labelA = "Off";
+/** Specify the label for the untoggled state */
+export let labelA = "Off";
 
-  /** Specify the label for the toggled state */
-  export let labelB = "On";
+/** Specify the label for the toggled state */
+export let labelB = "On";
 
-  /** Specify the label text */
-  export let labelText = "";
+/** Specify the label text */
+export let labelText = "";
 
-  /** Set to `true` to visually hide the label text */
-  export let hideLabel = false;
+/** Set to `true` to visually hide the label text */
+export let hideLabel = false;
 
-  /** Set an id for the input element */
-  export let id = "ccs-" + Math.random().toString(36);
+/** Set an id for the input element */
+export let id = "ccs-" + Math.random().toString(36);
 
-  /**
-   * Specify a name attribute for the checkbox input
-   * @type {string}
-   */
-  export let name = undefined;
+/**
+ * Specify a name attribute for the checkbox input
+ * @type {string}
+ */
+export let name = undefined;
 
-  import { createEventDispatcher } from "svelte";
+import { createEventDispatcher } from "svelte";
 
-  const dispatch = createEventDispatcher();
+const dispatch = createEventDispatcher();
 
-  $: dispatch("toggle", { toggled });
+$: dispatch("toggle", { toggled });
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->

--- a/src/Toggle/ToggleSkeleton.svelte
+++ b/src/Toggle/ToggleSkeleton.svelte
@@ -1,15 +1,15 @@
 <script>
-  /**
-   * Specify the toggle size
-   * @type {"default" | "sm"}
-   */
-  export let size = "default";
+/**
+ * Specify the toggle size
+ * @type {"default" | "sm"}
+ */
+export let size = "default";
 
-  /** Specify the label text */
-  export let labelText = "";
+/** Specify the label text */
+export let labelText = "";
 
-  /** Set an id for the input element */
-  export let id = "ccs-" + Math.random().toString(36);
+/** Set an id for the input element */
+export let id = "ccs-" + Math.random().toString(36);
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->

--- a/src/Tooltip/Tooltip.svelte
+++ b/src/Tooltip/Tooltip.svelte
@@ -1,181 +1,180 @@
 <script>
-  /**
-   * @event {null} open
-   * @event {null} close
-   */
+/**
+ * @event {null} open
+ * @event {null} close
+ */
 
-  /**
-   * Set the alignment of the tooltip relative to the icon
-   * @type {"start" | "center" | "end"}
-   */
-  export let align = "center";
+/**
+ * Set the alignment of the tooltip relative to the icon
+ * @type {"start" | "center" | "end"}
+ */
+export let align = "center";
 
-  /**
-   * Set the direction of the tooltip relative to the button
-   * @type {"top" | "right" | "bottom" | "left"}
-   */
-  export let direction = "bottom";
+/**
+ * Set the direction of the tooltip relative to the button
+ * @type {"top" | "right" | "bottom" | "left"}
+ */
+export let direction = "bottom";
 
-  /**
-   * Set to `true` to open the tooltip
-   * @type {boolean}
-   */
-  export let open = false;
+/**
+ * Set to `true` to open the tooltip
+ * @type {boolean}
+ */
+export let open = false;
 
-  /**
-   * Set to `true` to hide the tooltip icon
-   * @type {boolean}
-   */
-  export let hideIcon = false;
+/**
+ * Set to `true` to hide the tooltip icon
+ * @type {boolean}
+ */
+export let hideIcon = false;
 
-  /**
-   * Specify the icon to render for the tooltip button.
-   * Default to `<Information />`
-   * @type {any}
-   */
-  export let icon = Information;
+/**
+ * Specify the icon to render for the tooltip button.
+ * Default to `<Information />`
+ * @type {any}
+ */
+export let icon = Information;
 
-  /** Specify the ARIA label for the tooltip button */
-  export let iconDescription = "";
+/** Specify the ARIA label for the tooltip button */
+export let iconDescription = "";
 
-  /** Specify the icon name attribute */
-  export let iconName = "";
+/** Specify the icon name attribute */
+export let iconName = "";
 
-  /** Set the button tabindex */
-  export let tabindex = "0";
+/** Set the button tabindex */
+export let tabindex = "0";
 
-  /**
-   * Set an id for the tooltip
-   * @type {string}
-   */
-  export let tooltipId = "ccs-" + Math.random().toString(36);
+/**
+ * Set an id for the tooltip
+ * @type {string}
+ */
+export let tooltipId = "ccs-" + Math.random().toString(36);
 
-  /**
-   * Set an id for the tooltip button
-   * @type {string}
-   */
-  export let triggerId = "ccs-" + Math.random().toString(36);
+/**
+ * Set an id for the tooltip button
+ * @type {string}
+ */
+export let triggerId = "ccs-" + Math.random().toString(36);
 
-  /** Set the tooltip button text */
-  export let triggerText = "";
+/** Set the tooltip button text */
+export let triggerText = "";
 
-  /** Obtain a reference to the trigger text HTML element */
-  export let ref = null;
+/** Obtain a reference to the trigger text HTML element */
+export let ref = null;
 
-  /** Obtain a reference to the tooltip HTML element */
-  export let refTooltip = null;
+/** Obtain a reference to the tooltip HTML element */
+export let refTooltip = null;
 
-  /** Obtain a reference to the icon HTML element */
-  export let refIcon = null;
+/** Obtain a reference to the icon HTML element */
+export let refIcon = null;
 
-  import { createEventDispatcher, afterUpdate, setContext } from "svelte";
-  import { writable } from "svelte/store";
-  import Information from "../icons/Information.svelte";
+import { createEventDispatcher, afterUpdate, setContext } from "svelte";
+import { writable } from "svelte/store";
+import Information from "../icons/Information.svelte";
 
-  const dispatch = createEventDispatcher();
-  const tooltipOpen = writable(open);
+const dispatch = createEventDispatcher();
+const tooltipOpen = writable(open);
 
-  setContext("Tooltip", { tooltipOpen });
+setContext("Tooltip", { tooltipOpen });
 
-  function onKeydown(e) {
-    if (e.key === "Escape" || e.key === "Tab") {
-      e.stopPropagation();
-      if (e.key === "Escape") refIcon?.focus();
-      open = false;
-    } else if (e.key === " " || e.key === "Enter") {
-      e.stopPropagation();
-      e.preventDefault();
-      open = true;
-    }
-  }
-
-  function onBlur({ relatedTarget }) {
-    if (refTooltip && !refTooltip.contains(relatedTarget)) {
-      open = false;
-    }
-  }
-
-  function onFocus() {
+function onKeydown(e) {
+  if (e.key === "Escape" || e.key === "Tab") {
+    e.stopPropagation();
+    if (e.key === "Escape") refIcon?.focus();
+    open = false;
+  } else if (e.key === " " || e.key === "Enter") {
+    e.stopPropagation();
+    e.preventDefault();
     open = true;
   }
+}
 
-  function onMousedown() {
-    // determine the desired state before the focus event triggers.
-    const shouldClose = open;
-    // ensure changes are scheduled at the end, i.e. after the possible focus event.
-    setTimeout(() => {
-      open = shouldClose ? false : true;
-    });
+function onBlur({ relatedTarget }) {
+  if (refTooltip && !refTooltip.contains(relatedTarget)) {
+    open = false;
   }
+}
 
-  afterUpdate(() => {
-    if (open) {
-      const button = ref.getBoundingClientRect();
-      const tooltip = refTooltip.getBoundingClientRect();
+function onFocus() {
+  open = true;
+}
 
-      let iconWidth = 16;
-      let iconHeight = 16;
-
-      if (refIcon) {
-        const icon = refIcon.getBoundingClientRect();
-        iconWidth = icon.width;
-        iconHeight = icon.height;
-      }
-
-      let offsetX = 0;
-      let offsetY = 0;
-
-      switch (direction) {
-        case "bottom":
-          if (hideIcon) {
-            offsetX = -1 * (tooltip.width / 2 - button.width / 2);
-          } else {
-            offsetX = -1 * (tooltip.width / 2 - button.width + iconWidth / 2);
-          }
-          offsetY = iconHeight / 2;
-          break;
-        case "right":
-          offsetX = button.width + 6;
-          offsetY = -1 * (tooltip.height / 2 + iconWidth / 2 - 3);
-          break;
-        case "left":
-          if (hideIcon) {
-            offsetX = -1 * (tooltip.width + 6 + 1);
-          } else {
-            offsetX = -1 * (tooltip.width - button.width + iconWidth + 8);
-          }
-          offsetY = -1 * (tooltip.height / 2 + button.height) - 2;
-          break;
-        case "top":
-          if (hideIcon) {
-            offsetX = -1 * (tooltip.width / 2 - button.width / 2);
-          } else {
-            offsetX =
-              -1 * (tooltip.width / 2 - button.width + iconWidth / 2 + 1);
-          }
-          offsetY = -1 * (tooltip.height + button.height + iconWidth / 2 - 1);
-          break;
-      }
-
-      refTooltip.style.left = offsetX + "px";
-      refTooltip.style.marginTop = offsetY + "px";
-    }
+function onMousedown() {
+  // determine the desired state before the focus event triggers.
+  const shouldClose = open;
+  // ensure changes are scheduled at the end, i.e. after the possible focus event.
+  setTimeout(() => {
+    open = shouldClose ? false : true;
   });
+}
 
-  $: tooltipOpen.set(open);
-  $: dispatch(open ? "open" : "close");
-  $: buttonProps = {
-    role: "button",
-    "aria-haspopup": "true",
-    id: hideIcon ? triggerId : undefined,
-    class: hideIcon ? "bx--tooltip__label" : "bx--tooltip__trigger",
-    "aria-expanded": open,
-    "aria-describedby": open ? tooltipId : undefined,
-    "aria-labelledby": triggerText ? triggerId : undefined,
-    "aria-label": triggerText ? undefined : iconDescription,
-    tabindex,
-    style: hideIcon ? $$restProps.style : undefined,
-  };
+afterUpdate(() => {
+  if (open) {
+    const button = ref.getBoundingClientRect();
+    const tooltip = refTooltip.getBoundingClientRect();
+
+    let iconWidth = 16;
+    let iconHeight = 16;
+
+    if (refIcon) {
+      const icon = refIcon.getBoundingClientRect();
+      iconWidth = icon.width;
+      iconHeight = icon.height;
+    }
+
+    let offsetX = 0;
+    let offsetY = 0;
+
+    switch (direction) {
+      case "bottom":
+        if (hideIcon) {
+          offsetX = -1 * (tooltip.width / 2 - button.width / 2);
+        } else {
+          offsetX = -1 * (tooltip.width / 2 - button.width + iconWidth / 2);
+        }
+        offsetY = iconHeight / 2;
+        break;
+      case "right":
+        offsetX = button.width + 6;
+        offsetY = -1 * (tooltip.height / 2 + iconWidth / 2 - 3);
+        break;
+      case "left":
+        if (hideIcon) {
+          offsetX = -1 * (tooltip.width + 6 + 1);
+        } else {
+          offsetX = -1 * (tooltip.width - button.width + iconWidth + 8);
+        }
+        offsetY = -1 * (tooltip.height / 2 + button.height) - 2;
+        break;
+      case "top":
+        if (hideIcon) {
+          offsetX = -1 * (tooltip.width / 2 - button.width / 2);
+        } else {
+          offsetX = -1 * (tooltip.width / 2 - button.width + iconWidth / 2 + 1);
+        }
+        offsetY = -1 * (tooltip.height + button.height + iconWidth / 2 - 1);
+        break;
+    }
+
+    refTooltip.style.left = offsetX + "px";
+    refTooltip.style.marginTop = offsetY + "px";
+  }
+});
+
+$: tooltipOpen.set(open);
+$: dispatch(open ? "open" : "close");
+$: buttonProps = {
+  role: "button",
+  "aria-haspopup": "true",
+  id: hideIcon ? triggerId : undefined,
+  class: hideIcon ? "bx--tooltip__label" : "bx--tooltip__trigger",
+  "aria-expanded": open,
+  "aria-describedby": open ? tooltipId : undefined,
+  "aria-labelledby": triggerText ? triggerId : undefined,
+  "aria-label": triggerText ? undefined : iconDescription,
+  tabindex,
+  style: hideIcon ? $$restProps.style : undefined,
+};
 </script>
 
 <svelte:window

--- a/src/Tooltip/TooltipFooter.svelte
+++ b/src/Tooltip/TooltipFooter.svelte
@@ -1,27 +1,27 @@
 <script>
-  /** Specify a selector to be focused inside the footer when opening the tooltip */
-  export let selectorPrimaryFocus = "a[href], button:not([disabled])";
+/** Specify a selector to be focused inside the footer when opening the tooltip */
+export let selectorPrimaryFocus = "a[href], button:not([disabled])";
 
-  import { getContext, onMount } from "svelte";
+import { getContext, onMount } from "svelte";
 
-  let ref = null;
-  let open = false;
+let ref = null;
+let open = false;
 
-  const ctx = getContext("Tooltip");
-  const unsubscribe = ctx.tooltipOpen.subscribe((tooltipOpen) => {
-    open = tooltipOpen;
-  });
+const ctx = getContext("Tooltip");
+const unsubscribe = ctx.tooltipOpen.subscribe((tooltipOpen) => {
+  open = tooltipOpen;
+});
 
-  onMount(() => {
-    return () => {
-      unsubscribe();
-    };
-  });
+onMount(() => {
+  return () => {
+    unsubscribe();
+  };
+});
 
-  $: if (open && ref) {
-    const node = ref.querySelector(selectorPrimaryFocus);
-    if (node) node.focus();
-  }
+$: if (open && ref) {
+  const node = ref.querySelector(selectorPrimaryFocus);
+  if (node) node.focus();
+}
 </script>
 
 <div bind:this={ref} class:bx--tooltip__footer={true}>

--- a/src/TooltipDefinition/TooltipDefinition.svelte
+++ b/src/TooltipDefinition/TooltipDefinition.svelte
@@ -1,44 +1,44 @@
 <script>
-  /**
-   * @event {null} open
-   * @event {null} close
-   */
+/**
+ * @event {null} open
+ * @event {null} close
+ */
 
-  /** Specify the tooltip text */
-  export let tooltipText = "";
+/** Specify the tooltip text */
+export let tooltipText = "";
 
-  /**
-   * Set to `true` to open the tooltip
-   */
-  export let open = false;
+/**
+ * Set to `true` to open the tooltip
+ */
+export let open = false;
 
-  /**
-   * Set the alignment of the tooltip relative to the icon
-   * @type {"start" | "center" | "end"}
-   */
-  export let align = "center";
+/**
+ * Set the alignment of the tooltip relative to the icon
+ * @type {"start" | "center" | "end"}
+ */
+export let align = "center";
 
-  /**
-   * Set the direction of the tooltip relative to the icon
-   * @type {"top" | "bottom"}
-   */
-  export let direction = "bottom";
+/**
+ * Set the direction of the tooltip relative to the icon
+ * @type {"top" | "bottom"}
+ */
+export let direction = "bottom";
 
-  /** Set an id for the tooltip div element */
-  export let id = "ccs-" + Math.random().toString(36);
+/** Set an id for the tooltip div element */
+export let id = "ccs-" + Math.random().toString(36);
 
-  /** Obtain a reference to the button HTML element */
-  export let ref = null;
+/** Obtain a reference to the button HTML element */
+export let ref = null;
 
-  import { createEventDispatcher } from "svelte";
+import { createEventDispatcher } from "svelte";
 
-  const dispatch = createEventDispatcher();
+const dispatch = createEventDispatcher();
 
-  const hide = () => (open = false);
+const hide = () => (open = false);
 
-  const show = () => (open = true);
+const show = () => (open = true);
 
-  $: dispatch(open ? "open" : "close");
+$: dispatch(open ? "open" : "close");
 </script>
 
 <svelte:window

--- a/src/TooltipIcon/TooltipIcon.svelte
+++ b/src/TooltipIcon/TooltipIcon.svelte
@@ -1,38 +1,38 @@
 <script>
-  /**
-   * Specify the tooltip text.
-   * Alternatively, use the "tooltipText" slot
-   */
-  export let tooltipText = "";
+/**
+ * Specify the tooltip text.
+ * Alternatively, use the "tooltipText" slot
+ */
+export let tooltipText = "";
 
-  /**
-   * Specify the icon to render
-   * @type {any}
-   */
-  export let icon = undefined;
+/**
+ * Specify the icon to render
+ * @type {any}
+ */
+export let icon = undefined;
 
-  /** Set to `true` to disable the tooltip icon */
-  export let disabled = false;
+/** Set to `true` to disable the tooltip icon */
+export let disabled = false;
 
-  /**
-   * Set the alignment of the tooltip relative to the icon
-   * @type {"start" | "center" | "end"}
-   */
-  export let align = "center";
+/**
+ * Set the alignment of the tooltip relative to the icon
+ * @type {"start" | "center" | "end"}
+ */
+export let align = "center";
 
-  /**
-   * Set the direction of the tooltip relative to the icon
-   * @type {"top" | "right" | "bottom" | "left"}
-   */
-  export let direction = "bottom";
+/**
+ * Set the direction of the tooltip relative to the icon
+ * @type {"top" | "right" | "bottom" | "left"}
+ */
+export let direction = "bottom";
 
-  /** Set an id for the span element */
-  export let id = "ccs-" + Math.random().toString(36);
+/** Set an id for the span element */
+export let id = "ccs-" + Math.random().toString(36);
 
-  /** Obtain a reference to the button HTML element */
-  export let ref = null;
+/** Obtain a reference to the button HTML element */
+export let ref = null;
 
-  let hidden = false;
+let hidden = false;
 </script>
 
 <svelte:window

--- a/src/TreeView/TreeView.svelte
+++ b/src/TreeView/TreeView.svelte
@@ -1,29 +1,29 @@
 <script context="module">
-  /**
-   * Depth-first search to find a node by id; returns an array
-   * of nodes from the initial node to the matching leaf.
-   * @param {TreeNode} node
-   * @param {TreeNodeId} id
-   * @returns {null | TreeNode[]}
-   */
-  function findNodeById(node, id) {
-    if (node === null) return null;
-    if (node.id === id) return [node];
-    if (!Array.isArray(node.nodes)) {
-      return null;
-    }
-
-    for (const child of node.nodes) {
-      const nodes = findNodeById(child, id);
-
-      if (Array.isArray(nodes)) {
-        nodes.unshift(node);
-        return nodes;
-      }
-    }
-
+/**
+ * Depth-first search to find a node by id; returns an array
+ * of nodes from the initial node to the matching leaf.
+ * @param {TreeNode} node
+ * @param {TreeNodeId} id
+ * @returns {null | TreeNode[]}
+ */
+function findNodeById(node, id) {
+  if (node === null) return null;
+  if (node.id === id) return [node];
+  if (!Array.isArray(node.nodes)) {
     return null;
   }
+
+  for (const child of node.nodes) {
+    const nodes = findNodeById(child, id);
+
+    if (Array.isArray(nodes)) {
+      nodes.unshift(node);
+      return nodes;
+    }
+  }
+
+  return null;
+}
 </script>
 
 <script>

--- a/src/TreeView/TreeViewNode.svelte
+++ b/src/TreeView/TreeViewNode.svelte
@@ -1,34 +1,34 @@
 <script context="module">
-  /**
-   * Computes the depth of a tree leaf node relative to <ul role="tree" />
-   * @param {HTMLLIElement} node
-   * @returns {number} depth
-   */
-  export function computeTreeLeafDepth(node) {
-    let depth = 0;
+/**
+ * Computes the depth of a tree leaf node relative to <ul role="tree" />
+ * @param {HTMLLIElement} node
+ * @returns {number} depth
+ */
+export function computeTreeLeafDepth(node) {
+  let depth = 0;
 
-    if (node == null) return depth;
+  if (node == null) return depth;
 
-    let parentNode = node.parentNode;
+  let parentNode = node.parentNode;
 
-    while (parentNode != null && parentNode.getAttribute("role") !== "tree") {
-      parentNode = parentNode.parentNode;
-      if (parentNode.tagName === "LI") depth++;
-    }
-
-    return depth;
+  while (parentNode != null && parentNode.getAttribute("role") !== "tree") {
+    parentNode = parentNode.parentNode;
+    if (parentNode.tagName === "LI") depth++;
   }
 
-  /**
-   * Finds the nearest parent tree node
-   * @param {HTMLElement} node
-   * @returns {null | HTMLElement}
-   */
-  function findParentTreeNode(node) {
-    if (node.classList.contains("bx--tree-parent-node")) return node;
-    if (node.classList.contains("bx--tree")) return null;
-    return findParentTreeNode(node.parentNode);
-  }
+  return depth;
+}
+
+/**
+ * Finds the nearest parent tree node
+ * @param {HTMLElement} node
+ * @returns {null | HTMLElement}
+ */
+function findParentTreeNode(node) {
+  if (node.classList.contains("bx--tree-parent-node")) return node;
+  if (node.classList.contains("bx--tree")) return null;
+  return findParentTreeNode(node.parentNode);
+}
 </script>
 
 <script>

--- a/src/TreeView/TreeViewNodeList.svelte
+++ b/src/TreeView/TreeViewNodeList.svelte
@@ -1,67 +1,67 @@
 <script>
-  /**
-   * @typedef {string | number} TreeNodeId
-   * @typedef {{ id: TreeNodeId; text: string; disabled?: boolean; expanded?: boolean; }} TreeNode
-   * @slot {{ node: { id: TreeNodeId; text: string; expanded: boolean, leaf: boolean; disabled: boolean; selected: boolean; } }}
-   */
+/**
+ * @typedef {string | number} TreeNodeId
+ * @typedef {{ id: TreeNodeId; text: string; disabled?: boolean; expanded?: boolean; }} TreeNode
+ * @slot {{ node: { id: TreeNodeId; text: string; expanded: boolean, leaf: boolean; disabled: boolean; selected: boolean; } }}
+ */
 
-  /** @type {Array<TreeNode & { nodes?: TreeNode[] }>} */
-  export let nodes = [];
-  export let root = false;
+/** @type {Array<TreeNode & { nodes?: TreeNode[] }>} */
+export let nodes = [];
+export let root = false;
 
-  /** @type {string | number} */
-  export let id = "";
-  export let text = "";
-  export let disabled = false;
+/** @type {string | number} */
+export let id = "";
+export let text = "";
+export let disabled = false;
 
-  /**
-   * Specify the icon to render
-   * @type {any}
-   */
-  export let icon = undefined;
+/**
+ * Specify the icon to render
+ * @type {any}
+ */
+export let icon = undefined;
 
-  import { afterUpdate, getContext } from "svelte";
-  import CaretDown from "../icons/CaretDown.svelte";
-  import TreeViewNode, { computeTreeLeafDepth } from "./TreeViewNode.svelte";
+import { afterUpdate, getContext } from "svelte";
+import CaretDown from "../icons/CaretDown.svelte";
+import TreeViewNode, { computeTreeLeafDepth } from "./TreeViewNode.svelte";
 
-  let ref = null;
-  let refLabel = null;
-  let prevActiveId = undefined;
+let ref = null;
+let refLabel = null;
+let prevActiveId = undefined;
 
-  const {
-    activeNodeId,
-    selectedNodeIds,
-    expandedNodeIds,
-    clickNode,
-    selectNode,
-    expandNode,
-    focusNode,
-    toggleNode,
-  } = getContext("TreeView");
+const {
+  activeNodeId,
+  selectedNodeIds,
+  expandedNodeIds,
+  clickNode,
+  selectNode,
+  expandNode,
+  focusNode,
+  toggleNode,
+} = getContext("TreeView");
 
-  const offset = () => {
-    const depth = computeTreeLeafDepth(refLabel);
+const offset = () => {
+  const depth = computeTreeLeafDepth(refLabel);
 
-    if (parent) return depth + 1;
-    if (icon) return depth + 2;
-    return depth + 2.5;
-  };
+  if (parent) return depth + 1;
+  if (icon) return depth + 2;
+  return depth + 2.5;
+};
 
-  afterUpdate(() => {
-    if (id === $activeNodeId && prevActiveId !== $activeNodeId) {
-      if (!$selectedNodeIds.includes(id)) selectNode(node);
-    }
-
-    prevActiveId = $activeNodeId;
-  });
-
-  $: parent = Array.isArray(nodes);
-  $: node = { id, text, expanded, leaf: !parent };
-  $: if (refLabel) {
-    refLabel.style.marginLeft = `-${offset()}rem`;
-    refLabel.style.paddingLeft = `${offset()}rem`;
+afterUpdate(() => {
+  if (id === $activeNodeId && prevActiveId !== $activeNodeId) {
+    if (!$selectedNodeIds.includes(id)) selectNode(node);
   }
-  $: expanded = $expandedNodeIds.includes(id);
+
+  prevActiveId = $activeNodeId;
+});
+
+$: parent = Array.isArray(nodes);
+$: node = { id, text, expanded, leaf: !parent };
+$: if (refLabel) {
+  refLabel.style.marginLeft = `-${offset()}rem`;
+  refLabel.style.paddingLeft = `${offset()}rem`;
+}
+$: expanded = $expandedNodeIds.includes(id);
 </script>
 
 {#if root}

--- a/src/Truncate/Truncate.svelte
+++ b/src/Truncate/Truncate.svelte
@@ -1,6 +1,6 @@
 <script>
-  /** @type {"end" | "front"}*/
-  export let clamp = "end";
+/** @type {"end" | "front"}*/
+export let clamp = "end";
 </script>
 
 <p

--- a/src/UIShell/Content.svelte
+++ b/src/UIShell/Content.svelte
@@ -1,17 +1,17 @@
 <script>
-  /** Specify the id for the main element */
-  export let id = "main-content";
+/** Specify the id for the main element */
+export let id = "main-content";
 
-  import { isSideNavCollapsed, isSideNavRail } from "./navStore";
+import { isSideNavCollapsed, isSideNavRail } from "./navStore";
 
-  /**
-   * By default, the `SideNav` applies a left margin of `3rem` to `Content`
-   * if it's a sibling component (e.g., .bx--side-nav ~ .bx--content).
-   *
-   * We manually unset the left margin if the `SideNav`
-   * is collapsed and if it's not the `rail` variant.
-   */
-  $: unsetLeftMargin = $isSideNavCollapsed && !$isSideNavRail;
+/**
+ * By default, the `SideNav` applies a left margin of `3rem` to `Content`
+ * if it's a sibling component (e.g., .bx--side-nav ~ .bx--content).
+ *
+ * We manually unset the left margin if the `SideNav`
+ * is collapsed and if it's not the `rail` variant.
+ */
+$: unsetLeftMargin = $isSideNavCollapsed && !$isSideNavRail;
 </script>
 
 <main

--- a/src/UIShell/HamburgerMenu.svelte
+++ b/src/UIShell/HamburgerMenu.svelte
@@ -1,32 +1,32 @@
 <script>
-  /**
-   * Specify the ARIA label for the button
-   * @type {string}
-   */
-  export let ariaLabel = undefined;
+/**
+ * Specify the ARIA label for the button
+ * @type {string}
+ */
+export let ariaLabel = undefined;
 
-  /** Set to `true` to toggle the open state */
-  export let isOpen = false;
+/** Set to `true` to toggle the open state */
+export let isOpen = false;
 
-  /**
-   * Specify the icon to render for the closed state.
-   * Defaults to `<Menu size={20} />`
-   * @type {any}
-   */
-  export let iconMenu = Menu;
+/**
+ * Specify the icon to render for the closed state.
+ * Defaults to `<Menu size={20} />`
+ * @type {any}
+ */
+export let iconMenu = Menu;
 
-  /**
-   * Specify the icon to render for the opened state.
-   * Defaults to `<Close size={20} />`
-   * @type {any}
-   */
-  export let iconClose = Close;
+/**
+ * Specify the icon to render for the opened state.
+ * Defaults to `<Close size={20} />`
+ * @type {any}
+ */
+export let iconClose = Close;
 
-  /** Obtain a reference to the HTML button element */
-  export let ref = null;
+/** Obtain a reference to the HTML button element */
+export let ref = null;
 
-  import Close from "../icons/Close.svelte";
-  import Menu from "../icons/Menu.svelte";
+import Close from "../icons/Close.svelte";
+import Menu from "../icons/Menu.svelte";
 </script>
 
 <button

--- a/src/UIShell/Header.svelte
+++ b/src/UIShell/Header.svelte
@@ -1,81 +1,81 @@
 <script>
-  /** Set to `false` to hide the side nav by default */
-  export let expandedByDefault = true;
+/** Set to `false` to hide the side nav by default */
+export let expandedByDefault = true;
 
-  /** Set to `true` to open the side nav */
-  export let isSideNavOpen = false;
+/** Set to `true` to open the side nav */
+export let isSideNavOpen = false;
 
-  /**
-   * Specify the ARIA label for the header
-   * @type {string}
-   */
-  export let uiShellAriaLabel = undefined;
+/**
+ * Specify the ARIA label for the header
+ * @type {string}
+ */
+export let uiShellAriaLabel = undefined;
 
-  /**
-   * Specify the `href` attribute
-   * @type {string}
-   */
-  export let href = undefined;
+/**
+ * Specify the `href` attribute
+ * @type {string}
+ */
+export let href = undefined;
 
-  /**
-   * Specify the company name.
-   *
-   * Alternatively, use the named slot "company" (e.g., `<span slot="company">...</span>`)
-   * @type {string}
-   */
-  export let company = undefined;
+/**
+ * Specify the company name.
+ *
+ * Alternatively, use the named slot "company" (e.g., `<span slot="company">...</span>`)
+ * @type {string}
+ */
+export let company = undefined;
 
-  /**
-   * Specify the platform name.
-   * Alternatively, use the named slot "platform" (e.g., `<span slot="platform">...</span>`)
-   */
-  export let platformName = "";
+/**
+ * Specify the platform name.
+ * Alternatively, use the named slot "platform" (e.g., `<span slot="platform">...</span>`)
+ */
+export let platformName = "";
 
-  /** Set to `true` to persist the hamburger menu */
-  export let persistentHamburgerMenu = false;
+/** Set to `true` to persist the hamburger menu */
+export let persistentHamburgerMenu = false;
 
-  /**
-   * The window width (px) at which the SideNav is expanded and the hamburger menu is hidden.
-   * 1056 represents the "large" breakpoint in pixels from the Carbon Design System:
-   * - small: 320
-   * - medium: 672
-   * - large: 1056
-   * - x-large: 1312
-   * - max: 1584
-   */
-  export let expansionBreakpoint = 1056;
+/**
+ * The window width (px) at which the SideNav is expanded and the hamburger menu is hidden.
+ * 1056 represents the "large" breakpoint in pixels from the Carbon Design System:
+ * - small: 320
+ * - medium: 672
+ * - large: 1056
+ * - x-large: 1312
+ * - max: 1584
+ */
+export let expansionBreakpoint = 1056;
 
-  /** Obtain a reference to the HTML anchor element */
-  export let ref = null;
+/** Obtain a reference to the HTML anchor element */
+export let ref = null;
 
-  /**
-   * Specify the icon to render for the closed state.
-   * Defaults to `<Menu size={20} />`
-   * @type {any}
-   */
-  export let iconMenu = Menu;
+/**
+ * Specify the icon to render for the closed state.
+ * Defaults to `<Menu size={20} />`
+ * @type {any}
+ */
+export let iconMenu = Menu;
 
-  /**
-   * Specify the icon to render for the opened state.
-   * Defaults to `<Close size={20} />`
-   * @type {any}
-   */
-  export let iconClose = Close;
+/**
+ * Specify the icon to render for the opened state.
+ * Defaults to `<Close size={20} />`
+ * @type {any}
+ */
+export let iconClose = Close;
 
-  import Close from "../icons/Close.svelte";
-  import Menu from "../icons/Menu.svelte";
-  import { shouldRenderHamburgerMenu } from "./navStore";
-  import HamburgerMenu from "./HamburgerMenu.svelte";
+import Close from "../icons/Close.svelte";
+import Menu from "../icons/Menu.svelte";
+import { shouldRenderHamburgerMenu } from "./navStore";
+import HamburgerMenu from "./HamburgerMenu.svelte";
 
-  let winWidth = undefined;
+let winWidth = undefined;
 
-  $: isSideNavOpen =
-    expandedByDefault &&
-    winWidth >= expansionBreakpoint &&
-    !persistentHamburgerMenu;
-  $: ariaLabel = company
-    ? `${company} `
-    : "" + (uiShellAriaLabel || $$props["aria-label"] || platformName);
+$: isSideNavOpen =
+  expandedByDefault &&
+  winWidth >= expansionBreakpoint &&
+  !persistentHamburgerMenu;
+$: ariaLabel = company
+  ? `${company} `
+  : "" + (uiShellAriaLabel || $$props["aria-label"] || platformName);
 </script>
 
 <svelte:window bind:innerWidth={winWidth} />

--- a/src/UIShell/HeaderAction.svelte
+++ b/src/UIShell/HeaderAction.svelte
@@ -1,79 +1,79 @@
 <script>
-  /**
-   * @event {null} open
-   * @event {null} close
-   */
+/**
+ * @event {null} open
+ * @event {null} close
+ */
 
-  /** Set to `true` to open the panel */
-  export let isOpen = false;
+/** Set to `true` to open the panel */
+export let isOpen = false;
 
-  /**
-   * Specify the icon to render when the action panel is closed.
-   * Defaults to `<Switcher size={20} />`
-   * @type {any}
-   */
-  export let icon = Switcher;
+/**
+ * Specify the icon to render when the action panel is closed.
+ * Defaults to `<Switcher size={20} />`
+ * @type {any}
+ */
+export let icon = Switcher;
 
-  /**
-   * Specify the icon to render when the action panel is open.
-   * Defaults to `<Close size={20} />`
-   * @type {any}
-   */
-  export let closeIcon = Close;
+/**
+ * Specify the icon to render when the action panel is open.
+ * Defaults to `<Close size={20} />`
+ * @type {any}
+ */
+export let closeIcon = Close;
 
-  /**
-   * Specify the text displayed next to the icon.
-   * Alternatively, use the named slot "text" (e.g., `<div slot="text">...</div>`)
-   * @type {string}
-   */
-  export let text = undefined;
+/**
+ * Specify the text displayed next to the icon.
+ * Alternatively, use the named slot "text" (e.g., `<div slot="text">...</div>`)
+ * @type {string}
+ */
+export let text = undefined;
 
-  /**
-   * Specify an icon tooltip. The tooltip will not be displayed
-   * if either the `text` prop or a named slot="text" is used
-   * @type {string}
-   */
-  export let iconDescription = undefined;
+/**
+ * Specify an icon tooltip. The tooltip will not be displayed
+ * if either the `text` prop or a named slot="text" is used
+ * @type {string}
+ */
+export let iconDescription = undefined;
 
-  /**
-   * Set the alignment of the tooltip relative to the icon.
-   * Only applies when `iconDescription` is provided
-   * @type {"start" | "center" | "end"}
-   */
-  export let tooltipAlignment = "center";
+/**
+ * Set the alignment of the tooltip relative to the icon.
+ * Only applies when `iconDescription` is provided
+ * @type {"start" | "center" | "end"}
+ */
+export let tooltipAlignment = "center";
 
-  /** Obtain a reference to the button HTML element */
-  export let ref = null;
+/** Obtain a reference to the button HTML element */
+export let ref = null;
 
-  /**
-   * Customize the panel transition (i.e., `transition:slide`).
-   * Set to `false` to disable the transition
-   * @type {false | import("svelte/transition").SlideParams}
-   */
-  export let transition = { duration: 200 };
+/**
+ * Customize the panel transition (i.e., `transition:slide`).
+ * Set to `false` to disable the transition
+ * @type {false | import("svelte/transition").SlideParams}
+ */
+export let transition = { duration: 200 };
 
-  /** Set to `true` to prevent the panel from closing when clicking outside */
-  export let preventCloseOnClickOutside = false;
+/** Set to `true` to prevent the panel from closing when clicking outside */
+export let preventCloseOnClickOutside = false;
 
-  import { createEventDispatcher } from "svelte";
-  import { slide } from "svelte/transition";
-  import Close from "../icons/Close.svelte";
-  import Switcher from "../icons/Switcher.svelte";
+import { createEventDispatcher } from "svelte";
+import { slide } from "svelte/transition";
+import Close from "../icons/Close.svelte";
+import Switcher from "../icons/Switcher.svelte";
 
-  const dispatch = createEventDispatcher();
+const dispatch = createEventDispatcher();
 
-  let refPanel = null;
+let refPanel = null;
 
-  $: hasIconOnly = iconDescription && !(text || $$slots.text);
-  $: buttonClass = [
-    hasIconOnly && "bx--btn bx--btn--primary",
-    hasIconOnly && "bx--tooltip__trigger bx--tooltip--a11y",
-    hasIconOnly && "bx--btn--icon-only bx--btn--icon-only--bottom",
-    hasIconOnly && `bx--tooltip--align-${tooltipAlignment}`,
-    $$restProps.class,
-  ]
-    .filter(Boolean)
-    .join(" ");
+$: hasIconOnly = iconDescription && !(text || $$slots.text);
+$: buttonClass = [
+  hasIconOnly && "bx--btn bx--btn--primary",
+  hasIconOnly && "bx--tooltip__trigger bx--tooltip--a11y",
+  hasIconOnly && "bx--btn--icon-only bx--btn--icon-only--bottom",
+  hasIconOnly && `bx--tooltip--align-${tooltipAlignment}`,
+  $$restProps.class,
+]
+  .filter(Boolean)
+  .join(" ");
 </script>
 
 <svelte:window

--- a/src/UIShell/HeaderActionLink.svelte
+++ b/src/UIShell/HeaderActionLink.svelte
@@ -1,21 +1,21 @@
 <script>
-  /** Set to `true` to use the active state */
-  export let linkIsActive = false;
+/** Set to `true` to use the active state */
+export let linkIsActive = false;
 
-  /**
-   * Specify the `href` attribute
-   * @type {string}
-   */
-  export let href = undefined;
+/**
+ * Specify the `href` attribute
+ * @type {string}
+ */
+export let href = undefined;
 
-  /**
-   * Specify the icon to render
-   * @type {any}
-   */
-  export let icon = undefined;
+/**
+ * Specify the icon to render
+ * @type {any}
+ */
+export let icon = undefined;
 
-  /** Obtain a reference to the HTML anchor element */
-  export let ref = null;
+/** Obtain a reference to the HTML anchor element */
+export let ref = null;
 </script>
 
 <a

--- a/src/UIShell/HeaderGlobalAction.svelte
+++ b/src/UIShell/HeaderGlobalAction.svelte
@@ -1,31 +1,31 @@
 <script>
-  /**
-   * @extends {"../Button/Button.svelte"} ButtonProps
-   */
+/**
+ * @extends {"../Button/Button.svelte"} ButtonProps
+ */
 
-  /** Set to `true` to use the active variant */
-  export let isActive = false;
+/** Set to `true` to use the active variant */
+export let isActive = false;
 
-  /**
-   * Specify the icon to render
-   * @type {any}
-   */
-  export let icon = undefined;
+/**
+ * Specify the icon to render
+ * @type {any}
+ */
+export let icon = undefined;
 
-  /** Obtain a reference to the HTML button element
-   * @type {HTMLButtonElement}
-   */
-  export let ref = null;
+/** Obtain a reference to the HTML button element
+ * @type {HTMLButtonElement}
+ */
+export let ref = null;
 
-  import Button from "../Button/Button.svelte";
+import Button from "../Button/Button.svelte";
 
-  $: buttonClass = [
-    "bx--header__action",
-    isActive && " bx--header__action--active",
-    $$restProps.class,
-  ]
-    .filter(Boolean)
-    .join(" ");
+$: buttonClass = [
+  "bx--header__action",
+  isActive && " bx--header__action--active",
+  $$restProps.class,
+]
+  .filter(Boolean)
+  .join(" ");
 </script>
 
 <Button bind:ref {...$$restProps} class={buttonClass} on:click>

--- a/src/UIShell/HeaderNav.svelte
+++ b/src/UIShell/HeaderNav.svelte
@@ -1,8 +1,8 @@
 <script>
-  $: props = {
-    "aria-label": $$props["aria-label"],
-    "aria-labelledby": $$props["aria-labelledby"],
-  };
+$: props = {
+  "aria-label": $$props["aria-label"],
+  "aria-labelledby": $$props["aria-labelledby"],
+};
 </script>
 
 <nav {...props} class:bx--header__nav={true} {...$$restProps}>

--- a/src/UIShell/HeaderNavItem.svelte
+++ b/src/UIShell/HeaderNavItem.svelte
@@ -1,40 +1,40 @@
 <script>
-  /**
-   * Specify the `href` attribute
-   * @type {string}
-   */
-  export let href = undefined;
+/**
+ * Specify the `href` attribute
+ * @type {string}
+ */
+export let href = undefined;
 
-  /**
-   * Specify the text
-   * @type {string}
-   */
-  export let text = undefined;
+/**
+ * Specify the text
+ * @type {string}
+ */
+export let text = undefined;
 
-  /** Set to `true` to select the item */
-  export let isSelected = false;
+/** Set to `true` to select the item */
+export let isSelected = false;
 
-  /** Obtain a reference to the HTML anchor element */
-  export let ref = null;
+/** Obtain a reference to the HTML anchor element */
+export let ref = null;
 
-  import { getContext, onMount } from "svelte";
+import { getContext, onMount } from "svelte";
 
-  const id = "ccs-" + Math.random().toString(36);
-  const ctx = getContext("HeaderNavMenu");
+const id = "ccs-" + Math.random().toString(36);
+const ctx = getContext("HeaderNavMenu");
 
-  let selectedItemIds = [];
+let selectedItemIds = [];
 
-  const unsubSelectedItems = ctx?.selectedItems.subscribe((_selectedItems) => {
-    selectedItemIds = Object.keys(_selectedItems);
-  });
+const unsubSelectedItems = ctx?.selectedItems.subscribe((_selectedItems) => {
+  selectedItemIds = Object.keys(_selectedItems);
+});
 
-  $: ctx?.updateSelectedItems({ id, isSelected });
+$: ctx?.updateSelectedItems({ id, isSelected });
 
-  onMount(() => {
-    return () => {
-      if (unsubSelectedItems) unsubSelectedItems();
-    };
-  });
+onMount(() => {
+  return () => {
+    if (unsubSelectedItems) unsubSelectedItems();
+  };
+});
 </script>
 
 <li role="none">

--- a/src/UIShell/HeaderNavMenu.svelte
+++ b/src/UIShell/HeaderNavMenu.svelte
@@ -1,42 +1,41 @@
 <script>
-  /** Set to `true` to toggle the expanded state */
-  export let expanded = false;
+/** Set to `true` to toggle the expanded state */
+export let expanded = false;
 
-  /** Specify the `href` attribute */
-  export let href = "/";
+/** Specify the `href` attribute */
+export let href = "/";
 
-  /**
-   * Specify the text
-   * @type {string}
-   */
-  export let text = undefined;
+/**
+ * Specify the text
+ * @type {string}
+ */
+export let text = undefined;
 
-  /** Obtain a reference to the HTML anchor element */
-  export let ref = null;
+/** Obtain a reference to the HTML anchor element */
+export let ref = null;
 
-  import { setContext } from "svelte";
-  import { writable } from "svelte/store";
-  import ChevronDown from "../icons/ChevronDown.svelte";
+import { setContext } from "svelte";
+import { writable } from "svelte/store";
+import ChevronDown from "../icons/ChevronDown.svelte";
 
-  const selectedItems = writable({});
+const selectedItems = writable({});
 
-  let menuRef = null;
+let menuRef = null;
 
-  setContext("HeaderNavMenu", {
-    selectedItems,
-    updateSelectedItems(item) {
-      selectedItems.update((_items) => ({
-        ..._items,
-        [item.id]: item.isSelected,
-      }));
-    },
-    closeMenu() {
-      expanded = false;
-    },
-  });
+setContext("HeaderNavMenu", {
+  selectedItems,
+  updateSelectedItems(item) {
+    selectedItems.update((_items) => ({
+      ..._items,
+      [item.id]: item.isSelected,
+    }));
+  },
+  closeMenu() {
+    expanded = false;
+  },
+});
 
-  $: isCurrentSubmenu =
-    Object.values($selectedItems).filter(Boolean).length > 0;
+$: isCurrentSubmenu = Object.values($selectedItems).filter(Boolean).length > 0;
 </script>
 
 <svelte:window

--- a/src/UIShell/HeaderPanelLink.svelte
+++ b/src/UIShell/HeaderPanelLink.svelte
@@ -1,12 +1,12 @@
 <script>
-  /**
-   * Specify the `href` attribute
-   * @type {string}
-   */
-  export let href = undefined;
+/**
+ * Specify the `href` attribute
+ * @type {string}
+ */
+export let href = undefined;
 
-  /** Obtain a reference to the HTML anchor element */
-  export let ref = null;
+/** Obtain a reference to the HTML anchor element */
+export let ref = null;
 </script>
 
 <li class:bx--switcher__item={true}>

--- a/src/UIShell/HeaderSearch.svelte
+++ b/src/UIShell/HeaderSearch.svelte
@@ -1,57 +1,57 @@
 <script>
-  /**
-   * @typedef {{ href: string; text: string; description?: string; }} HeaderSearchResult
-   * @event {null} active
-   * @event {null} inactive
-   * @event {null} clear
-   * @event {{ value: string; selectedResultIndex: number; selectedResult: HeaderSearchResult }} select
-   * @slot {{ result: HeaderSearchResult; index: number }}
-   */
+/**
+ * @typedef {{ href: string; text: string; description?: string; }} HeaderSearchResult
+ * @event {null} active
+ * @event {null} inactive
+ * @event {null} clear
+ * @event {{ value: string; selectedResultIndex: number; selectedResult: HeaderSearchResult }} select
+ * @slot {{ result: HeaderSearchResult; index: number }}
+ */
 
-  /** Specify the search input value */
-  export let value = "";
+/** Specify the search input value */
+export let value = "";
 
-  /** Set to `true` to activate and focus the search bar */
-  export let active = false;
+/** Set to `true` to activate and focus the search bar */
+export let active = false;
 
-  /** Obtain a reference to the input HTML element */
-  export let ref = null;
+/** Obtain a reference to the input HTML element */
+export let ref = null;
 
-  /**
-   * Render a list of search results
-   * @type {ReadonlyArray<HeaderSearchResult>}
-   */
-  export let results = [];
+/**
+ * Render a list of search results
+ * @type {ReadonlyArray<HeaderSearchResult>}
+ */
+export let results = [];
 
-  /** Specify the selected result index */
-  export let selectedResultIndex = 0;
+/** Specify the selected result index */
+export let selectedResultIndex = 0;
 
-  import { createEventDispatcher, tick } from "svelte";
-  import Close from "../icons/Close.svelte";
-  import IconSearch from "../icons/IconSearch.svelte";
+import { createEventDispatcher, tick } from "svelte";
+import Close from "../icons/Close.svelte";
+import IconSearch from "../icons/IconSearch.svelte";
 
-  const dispatch = createEventDispatcher();
+const dispatch = createEventDispatcher();
 
-  let refSearch = null;
+let refSearch = null;
 
-  function reset() {
-    active = false;
-    value = "";
-    selectedResultIndex = 0;
-  }
+function reset() {
+  active = false;
+  value = "";
+  selectedResultIndex = 0;
+}
 
-  function selectResult() {
-    dispatch("select", { value, selectedResultIndex, selectedResult });
-    reset();
-  }
+function selectResult() {
+  dispatch("select", { value, selectedResultIndex, selectedResult });
+  reset();
+}
 
-  $: if (active && ref) ref.focus();
-  $: if (!active && ref) ref.blur();
-  $: dispatch(active ? "active" : "inactive");
-  $: selectedResult = results[selectedResultIndex];
-  $: selectedId = selectedResult
-    ? `search-menuitem-${selectedResultIndex}`
-    : undefined;
+$: if (active && ref) ref.focus();
+$: if (!active && ref) ref.blur();
+$: dispatch(active ? "active" : "inactive");
+$: selectedResult = results[selectedResultIndex];
+$: selectedId = selectedResult
+  ? `search-menuitem-${selectedResultIndex}`
+  : undefined;
 </script>
 
 <svelte:window

--- a/src/UIShell/SideNav.svelte
+++ b/src/UIShell/SideNav.svelte
@@ -1,55 +1,55 @@
 <script>
-  /**
-   * @event {null} open
-   * @event {null} close
-   * @event {null} click:overlay
-   */
+/**
+ * @event {null} open
+ * @event {null} close
+ * @event {null} click:overlay
+ */
 
-  /** Set to `true` to use the fixed variant */
-  export let fixed = false;
+/** Set to `true` to use the fixed variant */
+export let fixed = false;
 
-  /** Set to `true` to use the rail variant */
-  export let rail = false;
+/** Set to `true` to use the rail variant */
+export let rail = false;
 
-  /**
-   * Specify the ARIA label for the nav
-   * @type {string}
-   */
-  export let ariaLabel = undefined;
+/**
+ * Specify the ARIA label for the nav
+ * @type {string}
+ */
+export let ariaLabel = undefined;
 
-  /** Set to `true` to toggle the expanded state */
-  export let isOpen = false;
+/** Set to `true` to toggle the expanded state */
+export let isOpen = false;
 
-  /**
-   * The window width (px) at which the SideNav is expanded and the hamburger menu is hidden.
-   * 1056 represents the "large" breakpoint in pixels from the Carbon Design System:
-   * - small: 320
-   * - medium: 672
-   * - large: 1056
-   * - x-large: 1312
-   * - max: 1584
-   */
-  export let expansionBreakpoint = 1056;
+/**
+ * The window width (px) at which the SideNav is expanded and the hamburger menu is hidden.
+ * 1056 represents the "large" breakpoint in pixels from the Carbon Design System:
+ * - small: 320
+ * - medium: 672
+ * - large: 1056
+ * - x-large: 1312
+ * - max: 1584
+ */
+export let expansionBreakpoint = 1056;
 
-  import { onMount, createEventDispatcher } from "svelte";
-  import {
-    shouldRenderHamburgerMenu,
-    isSideNavCollapsed,
-    isSideNavRail,
-  } from "./navStore";
+import { onMount, createEventDispatcher } from "svelte";
+import {
+  shouldRenderHamburgerMenu,
+  isSideNavCollapsed,
+  isSideNavRail,
+} from "./navStore";
 
-  const dispatch = createEventDispatcher();
+const dispatch = createEventDispatcher();
 
-  let winWidth = undefined;
+let winWidth = undefined;
 
-  $: dispatch(isOpen ? "open" : "close");
-  $: $isSideNavCollapsed = !isOpen;
-  $: $isSideNavRail = rail;
+$: dispatch(isOpen ? "open" : "close");
+$: $isSideNavCollapsed = !isOpen;
+$: $isSideNavRail = rail;
 
-  onMount(() => {
-    shouldRenderHamburgerMenu.set(true);
-    return () => shouldRenderHamburgerMenu.set(false);
-  });
+onMount(() => {
+  shouldRenderHamburgerMenu.set(true);
+  return () => shouldRenderHamburgerMenu.set(false);
+});
 </script>
 
 <svelte:window bind:innerWidth={winWidth} />

--- a/src/UIShell/SideNavLink.svelte
+++ b/src/UIShell/SideNavLink.svelte
@@ -1,27 +1,27 @@
 <script>
-  /** Set to `true` to select the current link */
-  export let isSelected = false;
+/** Set to `true` to select the current link */
+export let isSelected = false;
 
-  /**
-   * Specify the `href` attribute
-   * @type {string}
-   */
-  export let href = undefined;
+/**
+ * Specify the `href` attribute
+ * @type {string}
+ */
+export let href = undefined;
 
-  /**
-   * Specify the text
-   * @type {string}
-   */
-  export let text = undefined;
+/**
+ * Specify the text
+ * @type {string}
+ */
+export let text = undefined;
 
-  /**
-   * Specify the icon to render
-   * @type {any}
-   */
-  export let icon = undefined;
+/**
+ * Specify the icon to render
+ * @type {any}
+ */
+export let icon = undefined;
 
-  /** Obtain a reference to the HTML anchor element */
-  export let ref = null;
+/** Obtain a reference to the HTML anchor element */
+export let ref = null;
 </script>
 
 <li class:bx--side-nav__item={true}>

--- a/src/UIShell/SideNavMenu.svelte
+++ b/src/UIShell/SideNavMenu.svelte
@@ -1,23 +1,23 @@
 <script>
-  /** Set to `true` to toggle the expanded state */
-  export let expanded = false;
+/** Set to `true` to toggle the expanded state */
+export let expanded = false;
 
-  /**
-   * Specify the text
-   * @type {string}
-   */
-  export let text = undefined;
+/**
+ * Specify the text
+ * @type {string}
+ */
+export let text = undefined;
 
-  /**
-   * Specify the icon to render
-   * @type {any}
-   */
-  export let icon = undefined;
+/**
+ * Specify the icon to render
+ * @type {any}
+ */
+export let icon = undefined;
 
-  /** Obtain a reference to the HTML button element */
-  export let ref = null;
+/** Obtain a reference to the HTML button element */
+export let ref = null;
 
-  import ChevronDown from "../icons/ChevronDown.svelte";
+import ChevronDown from "../icons/ChevronDown.svelte";
 </script>
 
 <li class:bx--side-nav__item={true} class:bx--side-nav__item--icon={icon}>

--- a/src/UIShell/SideNavMenuItem.svelte
+++ b/src/UIShell/SideNavMenuItem.svelte
@@ -1,21 +1,21 @@
 <script>
-  /** Set to `true` to select the item */
-  export let isSelected = false;
+/** Set to `true` to select the item */
+export let isSelected = false;
 
-  /**
-   * Specify the `href` attribute
-   * @type {string}
-   */
-  export let href = undefined;
+/**
+ * Specify the `href` attribute
+ * @type {string}
+ */
+export let href = undefined;
 
-  /**
-   * Specify the item text
-   * @type {string}
-   */
-  export let text = undefined;
+/**
+ * Specify the item text
+ * @type {string}
+ */
+export let text = undefined;
 
-  /** Obtain a reference to the HTML anchor element */
-  export let ref = null;
+/** Obtain a reference to the HTML anchor element */
+export let ref = null;
 </script>
 
 <li class:bx--side-nav__menu-item={true}>

--- a/src/UIShell/SkipToContent.svelte
+++ b/src/UIShell/SkipToContent.svelte
@@ -1,9 +1,9 @@
 <script>
-  /** Specify the `href` attribute */
-  export let href = "#main-content";
+/** Specify the `href` attribute */
+export let href = "#main-content";
 
-  /** Specify the tabindex */
-  export let tabindex = "0";
+/** Specify the tabindex */
+export let tabindex = "0";
 </script>
 
 <a {href} {tabindex} class:bx--skip-to-content={true} {...$$restProps} on:click>

--- a/src/UnorderedList/UnorderedList.svelte
+++ b/src/UnorderedList/UnorderedList.svelte
@@ -1,9 +1,9 @@
 <script>
-  /** Set to `true` to use the nested variant */
-  export let nested = false;
+/** Set to `true` to use the nested variant */
+export let nested = false;
 
-  /** Set to `true` to use Carbon's expressive typesetting */
-  export let expressive = false;
+/** Set to `true` to use Carbon's expressive typesetting */
+export let expressive = false;
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->

--- a/src/icons/Add.svelte
+++ b/src/icons/Add.svelte
@@ -1,14 +1,14 @@
 <script>
-  export let size = 16;
+export let size = 16;
 
-  export let title = undefined;
+export let title = undefined;
 
-  $: labelled = $$props["aria-label"] || $$props["aria-labelledby"] || title;
-  $: attributes = {
-    "aria-hidden": labelled ? undefined : true,
-    role: labelled ? "img" : undefined,
-    focusable: Number($$props["tabindex"]) === 0 ? true : undefined,
-  };
+$: labelled = $$props["aria-label"] || $$props["aria-labelledby"] || title;
+$: attributes = {
+  "aria-hidden": labelled ? undefined : true,
+  role: labelled ? "img" : undefined,
+  focusable: Number($$props["tabindex"]) === 0 ? true : undefined,
+};
 </script>
 
 <svg

--- a/src/icons/ArrowUp.svelte
+++ b/src/icons/ArrowUp.svelte
@@ -1,14 +1,14 @@
 <script>
-  export let size = 16;
+export let size = 16;
 
-  export let title = undefined;
+export let title = undefined;
 
-  $: labelled = $$props["aria-label"] || $$props["aria-labelledby"] || title;
-  $: attributes = {
-    "aria-hidden": labelled ? undefined : true,
-    role: labelled ? "img" : undefined,
-    focusable: Number($$props["tabindex"]) === 0 ? true : undefined,
-  };
+$: labelled = $$props["aria-label"] || $$props["aria-labelledby"] || title;
+$: attributes = {
+  "aria-hidden": labelled ? undefined : true,
+  role: labelled ? "img" : undefined,
+  focusable: Number($$props["tabindex"]) === 0 ? true : undefined,
+};
 </script>
 
 <svg

--- a/src/icons/ArrowsVertical.svelte
+++ b/src/icons/ArrowsVertical.svelte
@@ -1,14 +1,14 @@
 <script>
-  export let size = 16;
+export let size = 16;
 
-  export let title = undefined;
+export let title = undefined;
 
-  $: labelled = $$props["aria-label"] || $$props["aria-labelledby"] || title;
-  $: attributes = {
-    "aria-hidden": labelled ? undefined : true,
-    role: labelled ? "img" : undefined,
-    focusable: Number($$props["tabindex"]) === 0 ? true : undefined,
-  };
+$: labelled = $$props["aria-label"] || $$props["aria-labelledby"] || title;
+$: attributes = {
+  "aria-hidden": labelled ? undefined : true,
+  role: labelled ? "img" : undefined,
+  focusable: Number($$props["tabindex"]) === 0 ? true : undefined,
+};
 </script>
 
 <svg

--- a/src/icons/Calendar.svelte
+++ b/src/icons/Calendar.svelte
@@ -1,14 +1,14 @@
 <script>
-  export let size = 16;
+export let size = 16;
 
-  export let title = undefined;
+export let title = undefined;
 
-  $: labelled = $$props["aria-label"] || $$props["aria-labelledby"] || title;
-  $: attributes = {
-    "aria-hidden": labelled ? undefined : true,
-    role: labelled ? "img" : undefined,
-    focusable: Number($$props["tabindex"]) === 0 ? true : undefined,
-  };
+$: labelled = $$props["aria-label"] || $$props["aria-labelledby"] || title;
+$: attributes = {
+  "aria-hidden": labelled ? undefined : true,
+  role: labelled ? "img" : undefined,
+  focusable: Number($$props["tabindex"]) === 0 ? true : undefined,
+};
 </script>
 
 <svg

--- a/src/icons/CaretDown.svelte
+++ b/src/icons/CaretDown.svelte
@@ -1,14 +1,14 @@
 <script>
-  export let size = 16;
+export let size = 16;
 
-  export let title = undefined;
+export let title = undefined;
 
-  $: labelled = $$props["aria-label"] || $$props["aria-labelledby"] || title;
-  $: attributes = {
-    "aria-hidden": labelled ? undefined : true,
-    role: labelled ? "img" : undefined,
-    focusable: Number($$props["tabindex"]) === 0 ? true : undefined,
-  };
+$: labelled = $$props["aria-label"] || $$props["aria-labelledby"] || title;
+$: attributes = {
+  "aria-hidden": labelled ? undefined : true,
+  role: labelled ? "img" : undefined,
+  focusable: Number($$props["tabindex"]) === 0 ? true : undefined,
+};
 </script>
 
 <svg

--- a/src/icons/CaretLeft.svelte
+++ b/src/icons/CaretLeft.svelte
@@ -1,14 +1,14 @@
 <script>
-  export let size = 16;
+export let size = 16;
 
-  export let title = undefined;
+export let title = undefined;
 
-  $: labelled = $$props["aria-label"] || $$props["aria-labelledby"] || title;
-  $: attributes = {
-    "aria-hidden": labelled ? undefined : true,
-    role: labelled ? "img" : undefined,
-    focusable: Number($$props["tabindex"]) === 0 ? true : undefined,
-  };
+$: labelled = $$props["aria-label"] || $$props["aria-labelledby"] || title;
+$: attributes = {
+  "aria-hidden": labelled ? undefined : true,
+  role: labelled ? "img" : undefined,
+  focusable: Number($$props["tabindex"]) === 0 ? true : undefined,
+};
 </script>
 
 <svg

--- a/src/icons/CaretRight.svelte
+++ b/src/icons/CaretRight.svelte
@@ -1,14 +1,14 @@
 <script>
-  export let size = 16;
+export let size = 16;
 
-  export let title = undefined;
+export let title = undefined;
 
-  $: labelled = $$props["aria-label"] || $$props["aria-labelledby"] || title;
-  $: attributes = {
-    "aria-hidden": labelled ? undefined : true,
-    role: labelled ? "img" : undefined,
-    focusable: Number($$props["tabindex"]) === 0 ? true : undefined,
-  };
+$: labelled = $$props["aria-label"] || $$props["aria-labelledby"] || title;
+$: attributes = {
+  "aria-hidden": labelled ? undefined : true,
+  role: labelled ? "img" : undefined,
+  focusable: Number($$props["tabindex"]) === 0 ? true : undefined,
+};
 </script>
 
 <svg

--- a/src/icons/Checkmark.svelte
+++ b/src/icons/Checkmark.svelte
@@ -1,14 +1,14 @@
 <script>
-  export let size = 16;
+export let size = 16;
 
-  export let title = undefined;
+export let title = undefined;
 
-  $: labelled = $$props["aria-label"] || $$props["aria-labelledby"] || title;
-  $: attributes = {
-    "aria-hidden": labelled ? undefined : true,
-    role: labelled ? "img" : undefined,
-    focusable: Number($$props["tabindex"]) === 0 ? true : undefined,
-  };
+$: labelled = $$props["aria-label"] || $$props["aria-labelledby"] || title;
+$: attributes = {
+  "aria-hidden": labelled ? undefined : true,
+  role: labelled ? "img" : undefined,
+  focusable: Number($$props["tabindex"]) === 0 ? true : undefined,
+};
 </script>
 
 <svg

--- a/src/icons/CheckmarkFilled.svelte
+++ b/src/icons/CheckmarkFilled.svelte
@@ -1,14 +1,14 @@
 <script>
-  export let size = 16;
+export let size = 16;
 
-  export let title = undefined;
+export let title = undefined;
 
-  $: labelled = $$props["aria-label"] || $$props["aria-labelledby"] || title;
-  $: attributes = {
-    "aria-hidden": labelled ? undefined : true,
-    role: labelled ? "img" : undefined,
-    focusable: Number($$props["tabindex"]) === 0 ? true : undefined,
-  };
+$: labelled = $$props["aria-label"] || $$props["aria-labelledby"] || title;
+$: attributes = {
+  "aria-hidden": labelled ? undefined : true,
+  role: labelled ? "img" : undefined,
+  focusable: Number($$props["tabindex"]) === 0 ? true : undefined,
+};
 </script>
 
 <svg

--- a/src/icons/CheckmarkOutline.svelte
+++ b/src/icons/CheckmarkOutline.svelte
@@ -1,14 +1,14 @@
 <script>
-  export let size = 16;
+export let size = 16;
 
-  export let title = undefined;
+export let title = undefined;
 
-  $: labelled = $$props["aria-label"] || $$props["aria-labelledby"] || title;
-  $: attributes = {
-    "aria-hidden": labelled ? undefined : true,
-    role: labelled ? "img" : undefined,
-    focusable: Number($$props["tabindex"]) === 0 ? true : undefined,
-  };
+$: labelled = $$props["aria-label"] || $$props["aria-labelledby"] || title;
+$: attributes = {
+  "aria-hidden": labelled ? undefined : true,
+  role: labelled ? "img" : undefined,
+  focusable: Number($$props["tabindex"]) === 0 ? true : undefined,
+};
 </script>
 
 <svg

--- a/src/icons/ChevronDown.svelte
+++ b/src/icons/ChevronDown.svelte
@@ -1,14 +1,14 @@
 <script>
-  export let size = 16;
+export let size = 16;
 
-  export let title = undefined;
+export let title = undefined;
 
-  $: labelled = $$props["aria-label"] || $$props["aria-labelledby"] || title;
-  $: attributes = {
-    "aria-hidden": labelled ? undefined : true,
-    role: labelled ? "img" : undefined,
-    focusable: Number($$props["tabindex"]) === 0 ? true : undefined,
-  };
+$: labelled = $$props["aria-label"] || $$props["aria-labelledby"] || title;
+$: attributes = {
+  "aria-hidden": labelled ? undefined : true,
+  role: labelled ? "img" : undefined,
+  focusable: Number($$props["tabindex"]) === 0 ? true : undefined,
+};
 </script>
 
 <svg

--- a/src/icons/ChevronRight.svelte
+++ b/src/icons/ChevronRight.svelte
@@ -1,14 +1,14 @@
 <script>
-  export let size = 16;
+export let size = 16;
 
-  export let title = undefined;
+export let title = undefined;
 
-  $: labelled = $$props["aria-label"] || $$props["aria-labelledby"] || title;
-  $: attributes = {
-    "aria-hidden": labelled ? undefined : true,
-    role: labelled ? "img" : undefined,
-    focusable: Number($$props["tabindex"]) === 0 ? true : undefined,
-  };
+$: labelled = $$props["aria-label"] || $$props["aria-labelledby"] || title;
+$: attributes = {
+  "aria-hidden": labelled ? undefined : true,
+  role: labelled ? "img" : undefined,
+  focusable: Number($$props["tabindex"]) === 0 ? true : undefined,
+};
 </script>
 
 <svg

--- a/src/icons/CircleDash.svelte
+++ b/src/icons/CircleDash.svelte
@@ -1,14 +1,14 @@
 <script>
-  export let size = 16;
+export let size = 16;
 
-  export let title = undefined;
+export let title = undefined;
 
-  $: labelled = $$props["aria-label"] || $$props["aria-labelledby"] || title;
-  $: attributes = {
-    "aria-hidden": labelled ? undefined : true,
-    role: labelled ? "img" : undefined,
-    focusable: Number($$props["tabindex"]) === 0 ? true : undefined,
-  };
+$: labelled = $$props["aria-label"] || $$props["aria-labelledby"] || title;
+$: attributes = {
+  "aria-hidden": labelled ? undefined : true,
+  role: labelled ? "img" : undefined,
+  focusable: Number($$props["tabindex"]) === 0 ? true : undefined,
+};
 </script>
 
 <svg

--- a/src/icons/Close.svelte
+++ b/src/icons/Close.svelte
@@ -1,14 +1,14 @@
 <script>
-  export let size = 16;
+export let size = 16;
 
-  export let title = undefined;
+export let title = undefined;
 
-  $: labelled = $$props["aria-label"] || $$props["aria-labelledby"] || title;
-  $: attributes = {
-    "aria-hidden": labelled ? undefined : true,
-    role: labelled ? "img" : undefined,
-    focusable: Number($$props["tabindex"]) === 0 ? true : undefined,
-  };
+$: labelled = $$props["aria-label"] || $$props["aria-labelledby"] || title;
+$: attributes = {
+  "aria-hidden": labelled ? undefined : true,
+  role: labelled ? "img" : undefined,
+  focusable: Number($$props["tabindex"]) === 0 ? true : undefined,
+};
 </script>
 
 <svg

--- a/src/icons/Copy.svelte
+++ b/src/icons/Copy.svelte
@@ -1,14 +1,14 @@
 <script>
-  export let size = 16;
+export let size = 16;
 
-  export let title = undefined;
+export let title = undefined;
 
-  $: labelled = $$props["aria-label"] || $$props["aria-labelledby"] || title;
-  $: attributes = {
-    "aria-hidden": labelled ? undefined : true,
-    role: labelled ? "img" : undefined,
-    focusable: Number($$props["tabindex"]) === 0 ? true : undefined,
-  };
+$: labelled = $$props["aria-label"] || $$props["aria-labelledby"] || title;
+$: attributes = {
+  "aria-hidden": labelled ? undefined : true,
+  role: labelled ? "img" : undefined,
+  focusable: Number($$props["tabindex"]) === 0 ? true : undefined,
+};
 </script>
 
 <svg

--- a/src/icons/EditOff.svelte
+++ b/src/icons/EditOff.svelte
@@ -1,14 +1,14 @@
 <script>
-  export let size = 16;
+export let size = 16;
 
-  export let title = undefined;
+export let title = undefined;
 
-  $: labelled = $$props["aria-label"] || $$props["aria-labelledby"] || title;
-  $: attributes = {
-    "aria-hidden": labelled ? undefined : true,
-    role: labelled ? "img" : undefined,
-    focusable: Number($$props["tabindex"]) === 0 ? true : undefined,
-  };
+$: labelled = $$props["aria-label"] || $$props["aria-labelledby"] || title;
+$: attributes = {
+  "aria-hidden": labelled ? undefined : true,
+  role: labelled ? "img" : undefined,
+  focusable: Number($$props["tabindex"]) === 0 ? true : undefined,
+};
 </script>
 
 <svg

--- a/src/icons/ErrorFilled.svelte
+++ b/src/icons/ErrorFilled.svelte
@@ -1,14 +1,14 @@
 <script>
-  export let size = 16;
+export let size = 16;
 
-  export let title = undefined;
+export let title = undefined;
 
-  $: labelled = $$props["aria-label"] || $$props["aria-labelledby"] || title;
-  $: attributes = {
-    "aria-hidden": labelled ? undefined : true,
-    role: labelled ? "img" : undefined,
-    focusable: Number($$props["tabindex"]) === 0 ? true : undefined,
-  };
+$: labelled = $$props["aria-label"] || $$props["aria-labelledby"] || title;
+$: attributes = {
+  "aria-hidden": labelled ? undefined : true,
+  role: labelled ? "img" : undefined,
+  focusable: Number($$props["tabindex"]) === 0 ? true : undefined,
+};
 </script>
 
 <svg

--- a/src/icons/IconSearch.svelte
+++ b/src/icons/IconSearch.svelte
@@ -1,14 +1,14 @@
 <script>
-  export let size = 16;
+export let size = 16;
 
-  export let title = undefined;
+export let title = undefined;
 
-  $: labelled = $$props["aria-label"] || $$props["aria-labelledby"] || title;
-  $: attributes = {
-    "aria-hidden": labelled ? undefined : true,
-    role: labelled ? "img" : undefined,
-    focusable: Number($$props["tabindex"]) === 0 ? true : undefined,
-  };
+$: labelled = $$props["aria-label"] || $$props["aria-labelledby"] || title;
+$: attributes = {
+  "aria-hidden": labelled ? undefined : true,
+  role: labelled ? "img" : undefined,
+  focusable: Number($$props["tabindex"]) === 0 ? true : undefined,
+};
 </script>
 
 <svg

--- a/src/icons/Incomplete.svelte
+++ b/src/icons/Incomplete.svelte
@@ -1,14 +1,14 @@
 <script>
-  export let size = 16;
+export let size = 16;
 
-  export let title = undefined;
+export let title = undefined;
 
-  $: labelled = $$props["aria-label"] || $$props["aria-labelledby"] || title;
-  $: attributes = {
-    "aria-hidden": labelled ? undefined : true,
-    role: labelled ? "img" : undefined,
-    focusable: Number($$props["tabindex"]) === 0 ? true : undefined,
-  };
+$: labelled = $$props["aria-label"] || $$props["aria-labelledby"] || title;
+$: attributes = {
+  "aria-hidden": labelled ? undefined : true,
+  role: labelled ? "img" : undefined,
+  focusable: Number($$props["tabindex"]) === 0 ? true : undefined,
+};
 </script>
 
 <svg

--- a/src/icons/Information.svelte
+++ b/src/icons/Information.svelte
@@ -1,14 +1,14 @@
 <script>
-  export let size = 16;
+export let size = 16;
 
-  export let title = undefined;
+export let title = undefined;
 
-  $: labelled = $$props["aria-label"] || $$props["aria-labelledby"] || title;
-  $: attributes = {
-    "aria-hidden": labelled ? undefined : true,
-    role: labelled ? "img" : undefined,
-    focusable: Number($$props["tabindex"]) === 0 ? true : undefined,
-  };
+$: labelled = $$props["aria-label"] || $$props["aria-labelledby"] || title;
+$: attributes = {
+  "aria-hidden": labelled ? undefined : true,
+  role: labelled ? "img" : undefined,
+  focusable: Number($$props["tabindex"]) === 0 ? true : undefined,
+};
 </script>
 
 <svg

--- a/src/icons/InformationFilled.svelte
+++ b/src/icons/InformationFilled.svelte
@@ -1,14 +1,14 @@
 <script>
-  export let size = 16;
+export let size = 16;
 
-  export let title = undefined;
+export let title = undefined;
 
-  $: labelled = $$props["aria-label"] || $$props["aria-labelledby"] || title;
-  $: attributes = {
-    "aria-hidden": labelled ? undefined : true,
-    role: labelled ? "img" : undefined,
-    focusable: Number($$props["tabindex"]) === 0 ? true : undefined,
-  };
+$: labelled = $$props["aria-label"] || $$props["aria-labelledby"] || title;
+$: attributes = {
+  "aria-hidden": labelled ? undefined : true,
+  role: labelled ? "img" : undefined,
+  focusable: Number($$props["tabindex"]) === 0 ? true : undefined,
+};
 </script>
 
 <svg

--- a/src/icons/InformationSquareFilled.svelte
+++ b/src/icons/InformationSquareFilled.svelte
@@ -1,14 +1,14 @@
 <script>
-  export let size = 16;
+export let size = 16;
 
-  export let title = undefined;
+export let title = undefined;
 
-  $: labelled = $$props["aria-label"] || $$props["aria-labelledby"] || title;
-  $: attributes = {
-    "aria-hidden": labelled ? undefined : true,
-    role: labelled ? "img" : undefined,
-    focusable: Number($$props["tabindex"]) === 0 ? true : undefined,
-  };
+$: labelled = $$props["aria-label"] || $$props["aria-labelledby"] || title;
+$: attributes = {
+  "aria-hidden": labelled ? undefined : true,
+  role: labelled ? "img" : undefined,
+  focusable: Number($$props["tabindex"]) === 0 ? true : undefined,
+};
 </script>
 
 <svg

--- a/src/icons/Launch.svelte
+++ b/src/icons/Launch.svelte
@@ -1,14 +1,14 @@
 <script>
-  export let size = 16;
+export let size = 16;
 
-  export let title = undefined;
+export let title = undefined;
 
-  $: labelled = $$props["aria-label"] || $$props["aria-labelledby"] || title;
-  $: attributes = {
-    "aria-hidden": labelled ? undefined : true,
-    role: labelled ? "img" : undefined,
-    focusable: Number($$props["tabindex"]) === 0 ? true : undefined,
-  };
+$: labelled = $$props["aria-label"] || $$props["aria-labelledby"] || title;
+$: attributes = {
+  "aria-hidden": labelled ? undefined : true,
+  role: labelled ? "img" : undefined,
+  focusable: Number($$props["tabindex"]) === 0 ? true : undefined,
+};
 </script>
 
 <svg

--- a/src/icons/Menu.svelte
+++ b/src/icons/Menu.svelte
@@ -1,14 +1,14 @@
 <script>
-  export let size = 16;
+export let size = 16;
 
-  export let title = undefined;
+export let title = undefined;
 
-  $: labelled = $$props["aria-label"] || $$props["aria-labelledby"] || title;
-  $: attributes = {
-    "aria-hidden": labelled ? undefined : true,
-    role: labelled ? "img" : undefined,
-    focusable: Number($$props["tabindex"]) === 0 ? true : undefined,
-  };
+$: labelled = $$props["aria-label"] || $$props["aria-labelledby"] || title;
+$: attributes = {
+  "aria-hidden": labelled ? undefined : true,
+  role: labelled ? "img" : undefined,
+  focusable: Number($$props["tabindex"]) === 0 ? true : undefined,
+};
 </script>
 
 <svg

--- a/src/icons/OverflowMenuHorizontal.svelte
+++ b/src/icons/OverflowMenuHorizontal.svelte
@@ -1,14 +1,14 @@
 <script>
-  export let size = 16;
+export let size = 16;
 
-  export let title = undefined;
+export let title = undefined;
 
-  $: labelled = $$props["aria-label"] || $$props["aria-labelledby"] || title;
-  $: attributes = {
-    "aria-hidden": labelled ? undefined : true,
-    role: labelled ? "img" : undefined,
-    focusable: Number($$props["tabindex"]) === 0 ? true : undefined,
-  };
+$: labelled = $$props["aria-label"] || $$props["aria-labelledby"] || title;
+$: attributes = {
+  "aria-hidden": labelled ? undefined : true,
+  role: labelled ? "img" : undefined,
+  focusable: Number($$props["tabindex"]) === 0 ? true : undefined,
+};
 </script>
 
 <svg

--- a/src/icons/OverflowMenuVertical.svelte
+++ b/src/icons/OverflowMenuVertical.svelte
@@ -1,14 +1,14 @@
 <script>
-  export let size = 16;
+export let size = 16;
 
-  export let title = undefined;
+export let title = undefined;
 
-  $: labelled = $$props["aria-label"] || $$props["aria-labelledby"] || title;
-  $: attributes = {
-    "aria-hidden": labelled ? undefined : true,
-    role: labelled ? "img" : undefined,
-    focusable: Number($$props["tabindex"]) === 0 ? true : undefined,
-  };
+$: labelled = $$props["aria-label"] || $$props["aria-labelledby"] || title;
+$: attributes = {
+  "aria-hidden": labelled ? undefined : true,
+  role: labelled ? "img" : undefined,
+  focusable: Number($$props["tabindex"]) === 0 ? true : undefined,
+};
 </script>
 
 <svg

--- a/src/icons/Settings.svelte
+++ b/src/icons/Settings.svelte
@@ -1,14 +1,14 @@
 <script>
-  export let size = 16;
+export let size = 16;
 
-  export let title = undefined;
+export let title = undefined;
 
-  $: labelled = $$props["aria-label"] || $$props["aria-labelledby"] || title;
-  $: attributes = {
-    "aria-hidden": labelled ? undefined : true,
-    role: labelled ? "img" : undefined,
-    focusable: Number($$props["tabindex"]) === 0 ? true : undefined,
-  };
+$: labelled = $$props["aria-label"] || $$props["aria-labelledby"] || title;
+$: attributes = {
+  "aria-hidden": labelled ? undefined : true,
+  role: labelled ? "img" : undefined,
+  focusable: Number($$props["tabindex"]) === 0 ? true : undefined,
+};
 </script>
 
 <svg

--- a/src/icons/Subtract.svelte
+++ b/src/icons/Subtract.svelte
@@ -1,14 +1,14 @@
 <script>
-  export let size = 16;
+export let size = 16;
 
-  export let title = undefined;
+export let title = undefined;
 
-  $: labelled = $$props["aria-label"] || $$props["aria-labelledby"] || title;
-  $: attributes = {
-    "aria-hidden": labelled ? undefined : true,
-    role: labelled ? "img" : undefined,
-    focusable: Number($$props["tabindex"]) === 0 ? true : undefined,
-  };
+$: labelled = $$props["aria-label"] || $$props["aria-labelledby"] || title;
+$: attributes = {
+  "aria-hidden": labelled ? undefined : true,
+  role: labelled ? "img" : undefined,
+  focusable: Number($$props["tabindex"]) === 0 ? true : undefined,
+};
 </script>
 
 <svg

--- a/src/icons/Switcher.svelte
+++ b/src/icons/Switcher.svelte
@@ -1,14 +1,14 @@
 <script>
-  export let size = 16;
+export let size = 16;
 
-  export let title = undefined;
+export let title = undefined;
 
-  $: labelled = $$props["aria-label"] || $$props["aria-labelledby"] || title;
-  $: attributes = {
-    "aria-hidden": labelled ? undefined : true,
-    role: labelled ? "img" : undefined,
-    focusable: Number($$props["tabindex"]) === 0 ? true : undefined,
-  };
+$: labelled = $$props["aria-label"] || $$props["aria-labelledby"] || title;
+$: attributes = {
+  "aria-hidden": labelled ? undefined : true,
+  role: labelled ? "img" : undefined,
+  focusable: Number($$props["tabindex"]) === 0 ? true : undefined,
+};
 </script>
 
 <svg

--- a/src/icons/View.svelte
+++ b/src/icons/View.svelte
@@ -1,14 +1,14 @@
 <script>
-  export let size = 16;
+export let size = 16;
 
-  export let title = undefined;
+export let title = undefined;
 
-  $: labelled = $$props["aria-label"] || $$props["aria-labelledby"] || title;
-  $: attributes = {
-    "aria-hidden": labelled ? undefined : true,
-    role: labelled ? "img" : undefined,
-    focusable: Number($$props["tabindex"]) === 0 ? true : undefined,
-  };
+$: labelled = $$props["aria-label"] || $$props["aria-labelledby"] || title;
+$: attributes = {
+  "aria-hidden": labelled ? undefined : true,
+  role: labelled ? "img" : undefined,
+  focusable: Number($$props["tabindex"]) === 0 ? true : undefined,
+};
 </script>
 
 <svg

--- a/src/icons/ViewOff.svelte
+++ b/src/icons/ViewOff.svelte
@@ -1,14 +1,14 @@
 <script>
-  export let size = 16;
+export let size = 16;
 
-  export let title = undefined;
+export let title = undefined;
 
-  $: labelled = $$props["aria-label"] || $$props["aria-labelledby"] || title;
-  $: attributes = {
-    "aria-hidden": labelled ? undefined : true,
-    role: labelled ? "img" : undefined,
-    focusable: Number($$props["tabindex"]) === 0 ? true : undefined,
-  };
+$: labelled = $$props["aria-label"] || $$props["aria-labelledby"] || title;
+$: attributes = {
+  "aria-hidden": labelled ? undefined : true,
+  role: labelled ? "img" : undefined,
+  focusable: Number($$props["tabindex"]) === 0 ? true : undefined,
+};
 </script>
 
 <svg

--- a/src/icons/Warning.svelte
+++ b/src/icons/Warning.svelte
@@ -1,14 +1,14 @@
 <script>
-  export let size = 16;
+export let size = 16;
 
-  export let title = undefined;
+export let title = undefined;
 
-  $: labelled = $$props["aria-label"] || $$props["aria-labelledby"] || title;
-  $: attributes = {
-    "aria-hidden": labelled ? undefined : true,
-    role: labelled ? "img" : undefined,
-    focusable: Number($$props["tabindex"]) === 0 ? true : undefined,
-  };
+$: labelled = $$props["aria-label"] || $$props["aria-labelledby"] || title;
+$: attributes = {
+  "aria-hidden": labelled ? undefined : true,
+  role: labelled ? "img" : undefined,
+  focusable: Number($$props["tabindex"]) === 0 ? true : undefined,
+};
 </script>
 
 <svg

--- a/src/icons/WarningAltFilled.svelte
+++ b/src/icons/WarningAltFilled.svelte
@@ -1,14 +1,14 @@
 <script>
-  export let size = 16;
+export let size = 16;
 
-  export let title = undefined;
+export let title = undefined;
 
-  $: labelled = $$props["aria-label"] || $$props["aria-labelledby"] || title;
-  $: attributes = {
-    "aria-hidden": labelled ? undefined : true,
-    role: labelled ? "img" : undefined,
-    focusable: Number($$props["tabindex"]) === 0 ? true : undefined,
-  };
+$: labelled = $$props["aria-label"] || $$props["aria-labelledby"] || title;
+$: attributes = {
+  "aria-hidden": labelled ? undefined : true,
+  role: labelled ? "img" : undefined,
+  focusable: Number($$props["tabindex"]) === 0 ? true : undefined,
+};
 </script>
 
 <svg

--- a/src/icons/WarningFilled.svelte
+++ b/src/icons/WarningFilled.svelte
@@ -1,14 +1,14 @@
 <script>
-  export let size = 16;
+export let size = 16;
 
-  export let title = undefined;
+export let title = undefined;
 
-  $: labelled = $$props["aria-label"] || $$props["aria-labelledby"] || title;
-  $: attributes = {
-    "aria-hidden": labelled ? undefined : true,
-    role: labelled ? "img" : undefined,
-    focusable: Number($$props["tabindex"]) === 0 ? true : undefined,
-  };
+$: labelled = $$props["aria-label"] || $$props["aria-labelledby"] || title;
+$: attributes = {
+  "aria-hidden": labelled ? undefined : true,
+  role: labelled ? "img" : undefined,
+  focusable: Number($$props["tabindex"]) === 0 ? true : undefined,
+};
 </script>
 
 <svg

--- a/tests/Accordion/Accordion.disabled.test.svelte
+++ b/tests/Accordion/Accordion.disabled.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Accordion, AccordionItem } from "carbon-components-svelte";
+import { Accordion, AccordionItem } from "carbon-components-svelte";
 </script>
 
 <Accordion disabled>

--- a/tests/Accordion/Accordion.programmatic.test.svelte
+++ b/tests/Accordion/Accordion.programmatic.test.svelte
@@ -1,25 +1,25 @@
 <script lang="ts">
-  import { Accordion, AccordionItem, Button } from "carbon-components-svelte";
+import { Accordion, AccordionItem, Button } from "carbon-components-svelte";
 
-  const items = [
-    {
-      title: "Natural Language Classifier",
-      description:
-        "Natural Language Classifier uses advanced natural language processing and machine learning techniques to create custom classification models. Users train their data and the service predicts the appropriate category for the inputted text.",
-    },
-    {
-      title: "Natural Language Understanding",
-      description:
-        "Analyze text to extract meta-data from content such as concepts, entities, emotion, relations, sentiment and more.",
-    },
-    {
-      title: "Language Translator",
-      description:
-        "Translate text, documents, and websites from one language to another. Create industry or region-specific translations via the service's customization capability.",
-    },
-  ];
+const items = [
+  {
+    title: "Natural Language Classifier",
+    description:
+      "Natural Language Classifier uses advanced natural language processing and machine learning techniques to create custom classification models. Users train their data and the service predicts the appropriate category for the inputted text.",
+  },
+  {
+    title: "Natural Language Understanding",
+    description:
+      "Analyze text to extract meta-data from content such as concepts, entities, emotion, relations, sentiment and more.",
+  },
+  {
+    title: "Language Translator",
+    description:
+      "Translate text, documents, and websites from one language to another. Create industry or region-specific translations via the service's customization capability.",
+  },
+];
 
-  let open = false;
+let open = false;
 </script>
 
 <Button kind="ghost" size="field" on:click={() => (open = !open)}>

--- a/tests/Accordion/Accordion.skeleton.test.svelte
+++ b/tests/Accordion/Accordion.skeleton.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Accordion } from "carbon-components-svelte";
+import { Accordion } from "carbon-components-svelte";
 </script>
 
 <Accordion skeleton />

--- a/tests/Accordion/Accordion.test.svelte
+++ b/tests/Accordion/Accordion.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Accordion, AccordionItem } from "carbon-components-svelte";
+import { Accordion, AccordionItem } from "carbon-components-svelte";
 </script>
 
 <Accordion>

--- a/tests/App.test.svelte
+++ b/tests/App.test.svelte
@@ -1,94 +1,94 @@
 <script lang="ts">
-  import { TreeView as TreeViewNav } from "carbon-components-svelte";
-  import AspectRatio from "./AspectRatio/AspectRatio.test.svelte";
-  import Accordion from "./Accordion/Accordion.test.svelte";
-  import AccordionProgrammatic from "./Accordion/Accordion.programmatic.test.svelte";
-  import AccordionDisabled from "./Accordion/Accordion.disabled.test.svelte";
-  import DuplicateDataTables from "./DataTable/DuplicateDataTables.test.svelte";
-  import TreeView from "./TreeView/TreeView.test.svelte";
-  import TreeViewHierarchy from "./TreeView/TreeView.hierarchy.test.svelte";
-  import RecursiveList from "./RecursiveList/RecursiveList.test.svelte";
-  import RecursiveListHierarchy from "./RecursiveList/RecursiveList.hierarchy.test.svelte";
-  import Tag from "./Tag/Tag.test.svelte";
-  import OverflowMenu from "./OverflowMenu/OverflowMenu.test.svelte";
-  import { onMount } from "svelte";
+import { TreeView as TreeViewNav } from "carbon-components-svelte";
+import AspectRatio from "./AspectRatio/AspectRatio.test.svelte";
+import Accordion from "./Accordion/Accordion.test.svelte";
+import AccordionProgrammatic from "./Accordion/Accordion.programmatic.test.svelte";
+import AccordionDisabled from "./Accordion/Accordion.disabled.test.svelte";
+import DuplicateDataTables from "./DataTable/DuplicateDataTables.test.svelte";
+import TreeView from "./TreeView/TreeView.test.svelte";
+import TreeViewHierarchy from "./TreeView/TreeView.hierarchy.test.svelte";
+import RecursiveList from "./RecursiveList/RecursiveList.test.svelte";
+import RecursiveListHierarchy from "./RecursiveList/RecursiveList.hierarchy.test.svelte";
+import Tag from "./Tag/Tag.test.svelte";
+import OverflowMenu from "./OverflowMenu/OverflowMenu.test.svelte";
+import { onMount } from "svelte";
 
-  const routes = [
-    {
-      path: "/aspect-ratio",
-      name: "AspectRatio",
-      component: AspectRatio,
-    },
-    {
-      path: "/accordion",
-      name: "Accordion",
-      component: Accordion,
-    },
-    {
-      path: "/accordion-programmatic",
-      name: "AccordionProgrammatic",
-      component: AccordionProgrammatic,
-    },
-    {
-      path: "/accordion-disabled",
-      name: "AccordionDisabled",
-      component: AccordionDisabled,
-    },
-    {
-      path: "/data-table",
-      name: "DataTable",
-      component: DuplicateDataTables,
-    },
-    {
-      path: "/recursive-list",
-      name: "RecursiveList",
-      component: RecursiveList,
-    },
-    {
-      path: "/recursive-list-hierarchy",
-      name: "RecursiveListHierarchy",
-      component: RecursiveListHierarchy,
-    },
-    {
-      path: "/treeview",
-      name: "TreeView",
-      component: TreeView,
-    },
-    {
-      path: "/treeview-hierarchy",
-      name: "TreeViewHierarchy",
-      component: TreeViewHierarchy,
-    },
-    {
-      path: "/tag",
-      name: "Tag",
-      component: Tag,
-    },
-    {
-      path: "/overflow-menu",
-      name: "OverflowMenu",
-      component: OverflowMenu,
-    },
-  ] as const;
+const routes = [
+  {
+    path: "/aspect-ratio",
+    name: "AspectRatio",
+    component: AspectRatio,
+  },
+  {
+    path: "/accordion",
+    name: "Accordion",
+    component: Accordion,
+  },
+  {
+    path: "/accordion-programmatic",
+    name: "AccordionProgrammatic",
+    component: AccordionProgrammatic,
+  },
+  {
+    path: "/accordion-disabled",
+    name: "AccordionDisabled",
+    component: AccordionDisabled,
+  },
+  {
+    path: "/data-table",
+    name: "DataTable",
+    component: DuplicateDataTables,
+  },
+  {
+    path: "/recursive-list",
+    name: "RecursiveList",
+    component: RecursiveList,
+  },
+  {
+    path: "/recursive-list-hierarchy",
+    name: "RecursiveListHierarchy",
+    component: RecursiveListHierarchy,
+  },
+  {
+    path: "/treeview",
+    name: "TreeView",
+    component: TreeView,
+  },
+  {
+    path: "/treeview-hierarchy",
+    name: "TreeViewHierarchy",
+    component: TreeViewHierarchy,
+  },
+  {
+    path: "/tag",
+    name: "Tag",
+    component: Tag,
+  },
+  {
+    path: "/overflow-menu",
+    name: "OverflowMenu",
+    component: OverflowMenu,
+  },
+] as const;
 
-  let currentPath = window.location.pathname;
+let currentPath = window.location.pathname;
 
-  function navigate(path: string) {
-    history.pushState({}, "", path);
-    currentPath = path;
-  }
+function navigate(path: string) {
+  history.pushState({}, "", path);
+  currentPath = path;
+}
 
-  onMount(() => {
-    const handlePopState = () => {
-      currentPath = window.location.pathname;
-    };
+onMount(() => {
+  const handlePopState = () => {
+    currentPath = window.location.pathname;
+  };
 
-    window.addEventListener("popstate", handlePopState);
+  window.addEventListener("popstate", handlePopState);
 
-    return () => {
-      window.removeEventListener("popstate", handlePopState);
-    };
-  });
+  return () => {
+    window.removeEventListener("popstate", handlePopState);
+  };
+});
 </script>
 
 <div style:display="flex">

--- a/tests/AspectRatio/AspectRatio.test.svelte
+++ b/tests/AspectRatio/AspectRatio.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { AspectRatio } from "carbon-components-svelte";
+import { AspectRatio } from "carbon-components-svelte";
 </script>
 
 <AspectRatio>2x1</AspectRatio>

--- a/tests/AspectRatioColumns.test.svelte
+++ b/tests/AspectRatioColumns.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Grid, Row, Column } from "carbon-components-svelte";
+import { Grid, Row, Column } from "carbon-components-svelte";
 </script>
 
 <Grid>

--- a/tests/Breadcrumb/Breadcrumb.dynamic.test.svelte
+++ b/tests/Breadcrumb/Breadcrumb.dynamic.test.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
-  import { Breadcrumb, BreadcrumbItem } from "carbon-components-svelte";
+import { Breadcrumb, BreadcrumbItem } from "carbon-components-svelte";
 
-  type BreadcrumbItemType = { href?: string; text: string };
+type BreadcrumbItemType = { href?: string; text: string };
 
-  export let items: BreadcrumbItemType[] = [
-    { href: "/", text: "Dashboard" },
-    { href: "/reports", text: "Annual reports" },
-    { href: "/reports/2019", text: "2019" },
-  ];
+export let items: BreadcrumbItemType[] = [
+  { href: "/", text: "Dashboard" },
+  { href: "/reports", text: "Annual reports" },
+  { href: "/reports/2019", text: "2019" },
+];
 </script>
 
 <Breadcrumb>

--- a/tests/Breadcrumb/Breadcrumb.noTrailingSlash.test.svelte
+++ b/tests/Breadcrumb/Breadcrumb.noTrailingSlash.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Breadcrumb, BreadcrumbItem } from "carbon-components-svelte";
+import { Breadcrumb, BreadcrumbItem } from "carbon-components-svelte";
 </script>
 
 <Breadcrumb noTrailingSlash>

--- a/tests/Breadcrumb/Breadcrumb.skeleton.test.svelte
+++ b/tests/Breadcrumb/Breadcrumb.skeleton.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Breadcrumb } from "carbon-components-svelte";
+import { Breadcrumb } from "carbon-components-svelte";
 </script>
 
 <Breadcrumb skeleton count={3} />

--- a/tests/Breadcrumb/Breadcrumb.test.svelte
+++ b/tests/Breadcrumb/Breadcrumb.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Breadcrumb, BreadcrumbItem } from "carbon-components-svelte";
+import { Breadcrumb, BreadcrumbItem } from "carbon-components-svelte";
 </script>
 
 <Breadcrumb>

--- a/tests/Breakpoint/Breakpoint.test.svelte
+++ b/tests/Breakpoint/Breakpoint.test.svelte
@@ -1,15 +1,15 @@
 <script lang="ts">
-  import { Breakpoint } from "carbon-components-svelte";
-  import type { BreakpointSize } from "carbon-components-svelte/Breakpoint/breakpoints";
+import { Breakpoint } from "carbon-components-svelte";
+import type { BreakpointSize } from "carbon-components-svelte/Breakpoint/breakpoints";
 
-  export let size: BreakpointSize | undefined = undefined;
-  export let sizes: Record<BreakpointSize, boolean> = {
-    sm: false,
-    md: false,
-    lg: false,
-    xlg: false,
-    max: false,
-  };
+export let size: BreakpointSize | undefined = undefined;
+export let sizes: Record<BreakpointSize, boolean> = {
+  sm: false,
+  md: false,
+  lg: false,
+  xlg: false,
+  max: false,
+};
 </script>
 
 <Breakpoint

--- a/tests/Breakpoint/BreakpointObserver.test.svelte
+++ b/tests/Breakpoint/BreakpointObserver.test.svelte
@@ -1,20 +1,20 @@
 <script lang="ts">
-  import { breakpointObserver } from "carbon-components-svelte";
+import { breakpointObserver } from "carbon-components-svelte";
 
-  export let smallerThanMd = false;
-  export let largerThanMd = false;
+export let smallerThanMd = false;
+export let largerThanMd = false;
 
-  const observer = breakpointObserver();
-  const smallerThan = observer.smallerThan("md");
-  const largerThan = observer.largerThan("md");
+const observer = breakpointObserver();
+const smallerThan = observer.smallerThan("md");
+const largerThan = observer.largerThan("md");
 
-  smallerThan.subscribe((value) => {
-    smallerThanMd = value;
-  });
+smallerThan.subscribe((value) => {
+  smallerThanMd = value;
+});
 
-  largerThan.subscribe((value) => {
-    largerThanMd = value;
-  });
+largerThan.subscribe((value) => {
+  largerThanMd = value;
+});
 </script>
 
 <div data-testid="smaller-than-md">{smallerThanMd}</div>

--- a/tests/Breakpoint/Breakpoints.test.svelte
+++ b/tests/Breakpoint/Breakpoints.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { breakpoints } from "carbon-components-svelte";
+import { breakpoints } from "carbon-components-svelte";
 </script>
 
 <div data-testid="sm">{breakpoints.sm}</div>

--- a/tests/Button/Button.test.svelte
+++ b/tests/Button/Button.test.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  import { Button } from "carbon-components-svelte";
-  import Add from "carbon-icons-svelte/lib/Add.svelte";
+import { Button } from "carbon-components-svelte";
+import Add from "carbon-icons-svelte/lib/Add.svelte";
 </script>
 
 <Button>primary</Button>

--- a/tests/ButtonSet.test.svelte
+++ b/tests/ButtonSet.test.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  import { Button, ButtonSet } from "carbon-components-svelte";
-  import Login from "carbon-icons-svelte/lib/Login.svelte";
+import { Button, ButtonSet } from "carbon-components-svelte";
+import Login from "carbon-icons-svelte/lib/Login.svelte";
 </script>
 
 <ButtonSet>

--- a/tests/Checkbox/Checkbox.group.test.svelte
+++ b/tests/Checkbox/Checkbox.group.test.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-  import { Checkbox } from "carbon-components-svelte";
+import { Checkbox } from "carbon-components-svelte";
 
-  export let group = ["option-2"];
+export let group = ["option-2"];
 
-  $: console.log(group);
+$: console.log(group);
 </script>
 
 <Checkbox

--- a/tests/Checkbox/Checkbox.skeleton.test.svelte
+++ b/tests/Checkbox/Checkbox.skeleton.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Checkbox } from "carbon-components-svelte";
+import { Checkbox } from "carbon-components-svelte";
 </script>
 
 <Checkbox skeleton data-testid="checkbox-skeleton" />

--- a/tests/Checkbox/Checkbox.slot.test.svelte
+++ b/tests/Checkbox/Checkbox.slot.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Checkbox } from "carbon-components-svelte";
+import { Checkbox } from "carbon-components-svelte";
 </script>
 
 <Checkbox data-testid="checkbox-slot">

--- a/tests/Checkbox/Checkbox.test.svelte
+++ b/tests/Checkbox/Checkbox.test.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
-  import { Checkbox } from "carbon-components-svelte";
+import { Checkbox } from "carbon-components-svelte";
 
-  export let checked = false;
-  export let indeterminate = false;
-  export let disabled = false;
-  export let hideLabel = false;
-  export let labelText = "Checkbox label";
+export let checked = false;
+export let indeterminate = false;
+export let disabled = false;
+export let hideLabel = false;
+export let labelText = "Checkbox label";
 </script>
 
 <Checkbox

--- a/tests/CodeSnippet/CodeSnippetCopyButton.test.svelte
+++ b/tests/CodeSnippet/CodeSnippetCopyButton.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { CodeSnippet } from "carbon-components-svelte";
+import { CodeSnippet } from "carbon-components-svelte";
 </script>
 
 <CodeSnippet type="single" code="npm install --save @carbon/icons" />

--- a/tests/CodeSnippet/CodeSnippetCustomEvents.test.svelte
+++ b/tests/CodeSnippet/CodeSnippetCustomEvents.test.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
-  import { CodeSnippet } from "carbon-components-svelte";
+import { CodeSnippet } from "carbon-components-svelte";
 
-  let copyCount = 0;
+let copyCount = 0;
 
-  function handleCopy() {
-    copyCount += 1;
-  }
+function handleCopy() {
+  copyCount += 1;
+}
 </script>
 
 Copy events: {copyCount}

--- a/tests/CodeSnippet/CodeSnippetExpandable.test.svelte
+++ b/tests/CodeSnippet/CodeSnippetExpandable.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { CodeSnippet } from "carbon-components-svelte";
+import { CodeSnippet } from "carbon-components-svelte";
 </script>
 
 <CodeSnippet

--- a/tests/CodeSnippet/CodeSnippetExpandedByDefault.svelte
+++ b/tests/CodeSnippet/CodeSnippetExpandedByDefault.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { CodeSnippet } from "carbon-components-svelte";
+import { CodeSnippet } from "carbon-components-svelte";
 </script>
 
 <CodeSnippet

--- a/tests/CodeSnippet/CodeSnippetInline.test.svelte
+++ b/tests/CodeSnippet/CodeSnippetInline.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { CodeSnippet } from "carbon-components-svelte";
+import { CodeSnippet } from "carbon-components-svelte";
 </script>
 
 <CodeSnippet type="inline" code="npm install -g @carbon/cli" />

--- a/tests/CodeSnippet/CodeSnippetMultiline.test.svelte
+++ b/tests/CodeSnippet/CodeSnippetMultiline.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { CodeSnippet } from "carbon-components-svelte";
+import { CodeSnippet } from "carbon-components-svelte";
 </script>
 
 <CodeSnippet

--- a/tests/CodeSnippet/CodeSnippetWithCustomCopyText.test.svelte
+++ b/tests/CodeSnippet/CodeSnippetWithCustomCopyText.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { CodeSnippet } from "carbon-components-svelte";
+import { CodeSnippet } from "carbon-components-svelte";
 </script>
 
 <CodeSnippet

--- a/tests/CodeSnippet/CodeSnippetWithHideShowMore.test.svelte
+++ b/tests/CodeSnippet/CodeSnippetWithHideShowMore.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { CodeSnippet } from "carbon-components-svelte";
+import { CodeSnippet } from "carbon-components-svelte";
 </script>
 
 <CodeSnippet

--- a/tests/CodeSnippet/CodeSnippetWithWrapText.test.svelte
+++ b/tests/CodeSnippet/CodeSnippetWithWrapText.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { CodeSnippet } from "carbon-components-svelte";
+import { CodeSnippet } from "carbon-components-svelte";
 </script>
 
 <CodeSnippet

--- a/tests/ComboBox/ComboBox.test.svelte
+++ b/tests/ComboBox/ComboBox.test.svelte
@@ -1,31 +1,31 @@
 <script lang="ts">
-  import { ComboBox } from "carbon-components-svelte";
-  import type { ComponentProps } from "svelte";
+import { ComboBox } from "carbon-components-svelte";
+import type { ComponentProps } from "svelte";
 
-  export let items: ComponentProps<ComboBox>["items"] = [
-    { id: "0", text: "Slack" },
-    { id: "1", text: "Email" },
-    { id: "2", text: "Fax" },
-  ];
-  export let selectedId: ComponentProps<ComboBox>["selectedId"] = undefined;
-  export let value = "";
-  export let disabled = false;
-  export let invalid = false;
-  export let warn = false;
-  export let light = false;
-  export let open = false;
-  export let titleText = "Contact";
-  export let placeholder = "Select contact method";
-  export let invalidText = "";
-  export let warnText = "";
-  export let helperText = "";
-  export let size: "sm" | "xl" | undefined = undefined;
-  export let shouldFilterItem: ComponentProps<ComboBox>["shouldFilterItem"] = (
-    item,
-    value,
-  ) => item.text.toLowerCase().includes(value.toLowerCase());
-  export let translateWithIdSelection: ComponentProps<ComboBox>["translateWithIdSelection"] =
-    undefined;
+export let items: ComponentProps<ComboBox>["items"] = [
+  { id: "0", text: "Slack" },
+  { id: "1", text: "Email" },
+  { id: "2", text: "Fax" },
+];
+export let selectedId: ComponentProps<ComboBox>["selectedId"] = undefined;
+export let value = "";
+export let disabled = false;
+export let invalid = false;
+export let warn = false;
+export let light = false;
+export let open = false;
+export let titleText = "Contact";
+export let placeholder = "Select contact method";
+export let invalidText = "";
+export let warnText = "";
+export let helperText = "";
+export let size: "sm" | "xl" | undefined = undefined;
+export let shouldFilterItem: ComponentProps<ComboBox>["shouldFilterItem"] = (
+  item,
+  value,
+) => item.text.toLowerCase().includes(value.toLowerCase());
+export let translateWithIdSelection: ComponentProps<ComboBox>["translateWithIdSelection"] =
+  undefined;
 </script>
 
 <ComboBox

--- a/tests/ComboBox/ComboBoxCustom.test.svelte
+++ b/tests/ComboBox/ComboBoxCustom.test.svelte
@@ -1,20 +1,20 @@
 <script lang="ts">
-  import { ComboBox } from "carbon-components-svelte";
-  import type { ComboBoxItem } from "carbon-components-svelte/ComboBox/ComboBox.svelte";
+import { ComboBox } from "carbon-components-svelte";
+import type { ComboBoxItem } from "carbon-components-svelte/ComboBox/ComboBox.svelte";
 
-  let comboBoxRef: ComboBox;
+let comboBoxRef: ComboBox;
 
-  export let items: ComboBoxItem[] = [
-    { id: "0", text: "Slack" },
-    { id: "1", text: "Email" },
-    { id: "2", text: "Fax", disabled: true },
-  ];
-  export let selectedId: string | undefined = undefined;
-  export let direction: "top" | "bottom" = "bottom";
-  export let clearOptions: { focus?: boolean } = {};
-  export let shouldFilterItem = (item: ComboBoxItem, value: string) =>
-    item.text.toLowerCase().includes(value.toLowerCase());
-  export let itemToString = (item: ComboBoxItem) => item.text;
+export let items: ComboBoxItem[] = [
+  { id: "0", text: "Slack" },
+  { id: "1", text: "Email" },
+  { id: "2", text: "Fax", disabled: true },
+];
+export let selectedId: string | undefined = undefined;
+export let direction: "top" | "bottom" = "bottom";
+export let clearOptions: { focus?: boolean } = {};
+export let shouldFilterItem = (item: ComboBoxItem, value: string) =>
+  item.text.toLowerCase().includes(value.toLowerCase());
+export let itemToString = (item: ComboBoxItem) => item.text;
 </script>
 
 <ComboBox

--- a/tests/ComposedModal.test.svelte
+++ b/tests/ComposedModal.test.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
-  import {
-    ComposedModal,
-    ModalHeader,
-    ModalBody,
-    ModalFooter,
-    Checkbox,
-  } from "carbon-components-svelte";
+import {
+  ComposedModal,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+  Checkbox,
+} from "carbon-components-svelte";
 
-  let checked = false;
+let checked = false;
 </script>
 
 <ComposedModal open on:close on:click:button--primary>

--- a/tests/CondensedGrid.test.svelte
+++ b/tests/CondensedGrid.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Grid, Row, Column } from "carbon-components-svelte";
+import { Grid, Row, Column } from "carbon-components-svelte";
 </script>
 
 <Grid condensed>

--- a/tests/ContentSwitcher/ContentSwitcher.custom.test.svelte
+++ b/tests/ContentSwitcher/ContentSwitcher.custom.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { ContentSwitcher, Switch } from "carbon-components-svelte";
+import { ContentSwitcher, Switch } from "carbon-components-svelte";
 </script>
 
 <ContentSwitcher>

--- a/tests/ContentSwitcher/ContentSwitcher.disabled.test.svelte
+++ b/tests/ContentSwitcher/ContentSwitcher.disabled.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { ContentSwitcher, Switch } from "carbon-components-svelte";
+import { ContentSwitcher, Switch } from "carbon-components-svelte";
 </script>
 
 <ContentSwitcher>

--- a/tests/ContentSwitcher/ContentSwitcher.selectedIndex.test.svelte
+++ b/tests/ContentSwitcher/ContentSwitcher.selectedIndex.test.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-  import { ContentSwitcher, Switch } from "carbon-components-svelte";
+import { ContentSwitcher, Switch } from "carbon-components-svelte";
 
-  export let selectedIndex = 1;
+export let selectedIndex = 1;
 </script>
 
 <ContentSwitcher {selectedIndex}>

--- a/tests/ContentSwitcher/ContentSwitcher.size.test.svelte
+++ b/tests/ContentSwitcher/ContentSwitcher.size.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { ContentSwitcher, Switch } from "carbon-components-svelte";
+import { ContentSwitcher, Switch } from "carbon-components-svelte";
 </script>
 
 <ContentSwitcher size="sm">

--- a/tests/ContentSwitcher/ContentSwitcher.test.svelte
+++ b/tests/ContentSwitcher/ContentSwitcher.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { ContentSwitcher, Switch } from "carbon-components-svelte";
+import { ContentSwitcher, Switch } from "carbon-components-svelte";
 </script>
 
 <ContentSwitcher>

--- a/tests/ContextMenu.test.svelte
+++ b/tests/ContextMenu.test.svelte
@@ -1,20 +1,20 @@
 <script lang="ts">
-  import {
-    ContextMenu,
-    ContextMenuDivider,
-    ContextMenuOption,
-    ContextMenuRadioGroup,
-    ContextMenuGroup,
-  } from "carbon-components-svelte";
-  import CopyFile from "carbon-icons-svelte/lib/CopyFile.svelte";
-  import Cut from "carbon-icons-svelte/lib/Cut.svelte";
-  import type { ComponentProps } from "svelte";
+import {
+  ContextMenu,
+  ContextMenuDivider,
+  ContextMenuOption,
+  ContextMenuRadioGroup,
+  ContextMenuGroup,
+} from "carbon-components-svelte";
+import CopyFile from "carbon-icons-svelte/lib/CopyFile.svelte";
+import Cut from "carbon-icons-svelte/lib/Cut.svelte";
+import type { ComponentProps } from "svelte";
 
-  let ref: HTMLElement;
-  let selectedId = "0";
-  let selectedIds: ComponentProps<ContextMenuGroup>["selectedIds"] = [];
+let ref: HTMLElement;
+let selectedId = "0";
+let selectedIds: ComponentProps<ContextMenuGroup>["selectedIds"] = [];
 
-  $: console.log("selectedId", selectedId);
+$: console.log("selectedId", selectedId);
 </script>
 
 <div bind:this={ref}></div>

--- a/tests/CopyButton/CopyButton.test.svelte
+++ b/tests/CopyButton/CopyButton.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { CopyButton } from "carbon-components-svelte";
+import { CopyButton } from "carbon-components-svelte";
 </script>
 
 <CopyButton

--- a/tests/DangerModal.test.svelte
+++ b/tests/DangerModal.test.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-  import { Button, Modal } from "carbon-components-svelte";
+import { Button, Modal } from "carbon-components-svelte";
 
-  let open = false;
+let open = false;
 </script>
 
 <Button kind="danger" on:click={() => (open = true)}>Delete all</Button>

--- a/tests/DataTable.test.svelte
+++ b/tests/DataTable.test.svelte
@@ -1,75 +1,75 @@
 <script lang="ts">
-  import {
-    DataTable,
-    DataTableSkeleton,
-    Toolbar,
-    ToolbarContent,
-    ToolbarSearch,
-    ToolbarMenu,
-    ToolbarMenuItem,
-    Button,
-    Link,
-  } from "carbon-components-svelte";
-  import Launch from "carbon-icons-svelte/lib/Launch.svelte";
-  import type { ComponentProps } from "svelte";
+import {
+  DataTable,
+  DataTableSkeleton,
+  Toolbar,
+  ToolbarContent,
+  ToolbarSearch,
+  ToolbarMenu,
+  ToolbarMenuItem,
+  Button,
+  Link,
+} from "carbon-components-svelte";
+import Launch from "carbon-icons-svelte/lib/Launch.svelte";
+import type { ComponentProps } from "svelte";
 
-  const headers = [
-    { key: "name", value: "Name" },
-    { key: "protocol", value: "Protocol", width: "400px", minWidth: "40%" },
-    { key: "port", value: "Port" },
-    { key: "rule", value: "Rule", sort: false },
-  ] as const;
-  const rows = [
-    {
-      id: "a",
-      name: "Load Balancer 3",
-      protocol: "HTTP",
-      port: 3000,
-      rule: "Round robin",
-    },
-    {
-      id: "b",
-      name: "Load Balancer 1",
-      protocol: "HTTP",
-      port: 443,
-      rule: "Round robin",
-    },
-    {
-      id: "c",
-      name: "Load Balancer 2",
-      protocol: "HTTP",
-      port: 80,
-      rule: "DNS delegation",
-    },
-    {
-      id: "d",
-      name: "Load Balancer 6",
-      protocol: "HTTP",
-      port: 3000,
-      rule: "Round robin",
-    },
-    {
-      id: "e",
-      name: "Load Balancer 4",
-      protocol: "HTTP",
-      port: 443,
-      rule: "Round robin",
-    },
-    {
-      id: "f",
-      name: "Load Balancer 5",
-      protocol: "HTTP",
-      port: 80,
-      rule: "DNS delegation",
-    },
-  ];
+const headers = [
+  { key: "name", value: "Name" },
+  { key: "protocol", value: "Protocol", width: "400px", minWidth: "40%" },
+  { key: "port", value: "Port" },
+  { key: "rule", value: "Rule", sort: false },
+] as const;
+const rows = [
+  {
+    id: "a",
+    name: "Load Balancer 3",
+    protocol: "HTTP",
+    port: 3000,
+    rule: "Round robin",
+  },
+  {
+    id: "b",
+    name: "Load Balancer 1",
+    protocol: "HTTP",
+    port: 443,
+    rule: "Round robin",
+  },
+  {
+    id: "c",
+    name: "Load Balancer 2",
+    protocol: "HTTP",
+    port: 80,
+    rule: "DNS delegation",
+  },
+  {
+    id: "d",
+    name: "Load Balancer 6",
+    protocol: "HTTP",
+    port: 3000,
+    rule: "Round robin",
+  },
+  {
+    id: "e",
+    name: "Load Balancer 4",
+    protocol: "HTTP",
+    port: 443,
+    rule: "Round robin",
+  },
+  {
+    id: "f",
+    name: "Load Balancer 5",
+    protocol: "HTTP",
+    port: 80,
+    rule: "DNS delegation",
+  },
+];
 
-  function sort(a: any, b: any) {
-    if (new Date(a) > new Date(b)) return 1;
-    return 0;
-  }
+function sort(a: any, b: any) {
+  if (new Date(a) > new Date(b)) return 1;
+  return 0;
+}
 
-  let filteredRowIds: ComponentProps<ToolbarSearch>["filteredRowIds"] = [];
+let filteredRowIds: ComponentProps<ToolbarSearch>["filteredRowIds"] = [];
 </script>
 
 <DataTable

--- a/tests/DataTable/DuplicateDataTables.test.svelte
+++ b/tests/DataTable/DuplicateDataTables.test.svelte
@@ -1,15 +1,15 @@
 <script lang="ts">
-  import { DataTable } from "carbon-components-svelte";
+import { DataTable } from "carbon-components-svelte";
 
-  const headers = [
-    { key: "id", value: "id" },
-    { key: "contact.company", value: "Company name" },
-  ] as const;
+const headers = [
+  { key: "id", value: "id" },
+  { key: "contact.company", value: "Company name" },
+] as const;
 
-  const rows = [
-    { id: "1", contact: { company: "Company 1" } },
-    { id: "2", contact: { company: "Company 2" } },
-  ];
+const rows = [
+  { id: "1", contact: { company: "Company 1" } },
+  { id: "2", contact: { company: "Company 2" } },
+];
 </script>
 
 <DataTable inputName="radio-select" radio {headers} {rows} />

--- a/tests/DataTableAppendColumns.test.svelte
+++ b/tests/DataTableAppendColumns.test.svelte
@@ -1,25 +1,25 @@
 <script lang="ts">
-  import {
-    DataTable,
-    OverflowMenu,
-    OverflowMenuItem,
-  } from "carbon-components-svelte";
+import {
+  DataTable,
+  OverflowMenu,
+  OverflowMenuItem,
+} from "carbon-components-svelte";
 
-  const headers = [
-    { key: "name", value: "Name" },
-    { key: "port", value: "Port" },
-    { key: "rule", value: "Rule" },
-    { key: "overflow", empty: true },
-  ] as const;
+const headers = [
+  { key: "name", value: "Name" },
+  { key: "port", value: "Port" },
+  { key: "rule", value: "Rule" },
+  { key: "overflow", empty: true },
+] as const;
 
-  const rows = [
-    { id: "a", name: "Load Balancer 3", port: 3000, rule: "Round robin" },
-    { id: "b", name: "Load Balancer 1", port: 443, rule: "Round robin" },
-    { id: "c", name: "Load Balancer 2", port: 80, rule: "DNS delegation" },
-    { id: "d", name: "Load Balancer 6", port: 3000, rule: "Round robin" },
-    { id: "e", name: "Load Balancer 4", port: 443, rule: "Round robin" },
-    { id: "f", name: "Load Balancer 5", port: 80, rule: "DNS delegation" },
-  ];
+const rows = [
+  { id: "a", name: "Load Balancer 3", port: 3000, rule: "Round robin" },
+  { id: "b", name: "Load Balancer 1", port: 443, rule: "Round robin" },
+  { id: "c", name: "Load Balancer 2", port: 80, rule: "DNS delegation" },
+  { id: "d", name: "Load Balancer 6", port: 3000, rule: "Round robin" },
+  { id: "e", name: "Load Balancer 4", port: 443, rule: "Round robin" },
+  { id: "f", name: "Load Balancer 5", port: 80, rule: "DNS delegation" },
+];
 </script>
 
 <DataTable sortable {headers} {rows}>

--- a/tests/DataTableBatchSelection.test.svelte
+++ b/tests/DataTableBatchSelection.test.svelte
@@ -1,24 +1,24 @@
 <script lang="ts">
-  import { DataTable } from "carbon-components-svelte";
+import { DataTable } from "carbon-components-svelte";
 
-  const headers = [
-    { key: "name", value: "Name" },
-    { key: "port", value: "Port" },
-    { key: "rule", value: "Rule" },
-  ] as const;
+const headers = [
+  { key: "name", value: "Name" },
+  { key: "port", value: "Port" },
+  { key: "rule", value: "Rule" },
+] as const;
 
-  const rows = [
-    { id: "a", name: "Load Balancer 3", port: 3000, rule: "Round robin" },
-    { id: "b", name: "Load Balancer 1", port: 443, rule: "Round robin" },
-    { id: "c", name: "Load Balancer 2", port: 80, rule: "DNS delegation" },
-    { id: "d", name: "Load Balancer 6", port: 3000, rule: "Round robin" },
-    { id: "e", name: "Load Balancer 4", port: 443, rule: "Round robin" },
-    { id: "f", name: "Load Balancer 5", port: 80, rule: "DNS delegation" },
-  ];
+const rows = [
+  { id: "a", name: "Load Balancer 3", port: 3000, rule: "Round robin" },
+  { id: "b", name: "Load Balancer 1", port: 443, rule: "Round robin" },
+  { id: "c", name: "Load Balancer 2", port: 80, rule: "DNS delegation" },
+  { id: "d", name: "Load Balancer 6", port: 3000, rule: "Round robin" },
+  { id: "e", name: "Load Balancer 4", port: 443, rule: "Round robin" },
+  { id: "f", name: "Load Balancer 5", port: 80, rule: "DNS delegation" },
+];
 
-  let selectedRowIds = [rows[0].id, rows[1].id];
+let selectedRowIds = [rows[0].id, rows[1].id];
 
-  $: console.log("selectedRowIds", selectedRowIds);
+$: console.log("selectedRowIds", selectedRowIds);
 </script>
 
 <DataTable batchSelection bind:selectedRowIds {headers} {rows} />

--- a/tests/DataTableBatchSelectionToolbar.test.svelte
+++ b/tests/DataTableBatchSelectionToolbar.test.svelte
@@ -1,34 +1,34 @@
 <script lang="ts">
-  import {
-    DataTable,
-    Toolbar,
-    ToolbarContent,
-    ToolbarSearch,
-    ToolbarMenu,
-    ToolbarMenuItem,
-    ToolbarBatchActions,
-    Button,
-  } from "carbon-components-svelte";
-  import Save from "carbon-icons-svelte/lib/Save.svelte";
+import {
+  DataTable,
+  Toolbar,
+  ToolbarContent,
+  ToolbarSearch,
+  ToolbarMenu,
+  ToolbarMenuItem,
+  ToolbarBatchActions,
+  Button,
+} from "carbon-components-svelte";
+import Save from "carbon-icons-svelte/lib/Save.svelte";
 
-  const headers = [
-    { key: "name", value: "Name" },
-    { key: "port", value: "Port" },
-    { key: "rule", value: "Rule" },
-  ] as const;
+const headers = [
+  { key: "name", value: "Name" },
+  { key: "port", value: "Port" },
+  { key: "rule", value: "Rule" },
+] as const;
 
-  const rows = [
-    { id: "a", name: "Load Balancer 3", port: 3000, rule: "Round robin" },
-    { id: "b", name: "Load Balancer 1", port: 443, rule: "Round robin" },
-    { id: "c", name: "Load Balancer 2", port: 80, rule: "DNS delegation" },
-    { id: "d", name: "Load Balancer 6", port: 3000, rule: "Round robin" },
-    { id: "e", name: "Load Balancer 4", port: 443, rule: "Round robin" },
-    { id: "f", name: "Load Balancer 5", port: 80, rule: "DNS delegation" },
-  ];
+const rows = [
+  { id: "a", name: "Load Balancer 3", port: 3000, rule: "Round robin" },
+  { id: "b", name: "Load Balancer 1", port: 443, rule: "Round robin" },
+  { id: "c", name: "Load Balancer 2", port: 80, rule: "DNS delegation" },
+  { id: "d", name: "Load Balancer 6", port: 3000, rule: "Round robin" },
+  { id: "e", name: "Load Balancer 4", port: 443, rule: "Round robin" },
+  { id: "f", name: "Load Balancer 5", port: 80, rule: "DNS delegation" },
+];
 
-  let selectedRowIds = [rows[0].id, rows[1].id];
+let selectedRowIds = [rows[0].id, rows[1].id];
 
-  $: console.log("selectedRowIds", selectedRowIds);
+$: console.log("selectedRowIds", selectedRowIds);
 </script>
 
 <DataTable batchSelection bind:selectedRowIds {headers} {rows}>

--- a/tests/DataTableNestedHeaders.test.svelte
+++ b/tests/DataTableNestedHeaders.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { DataTable } from "../types";
+import { DataTable } from "../types";
 </script>
 
 <DataTable

--- a/tests/DatePicker.test.svelte
+++ b/tests/DatePicker.test.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
-  import {
-    DatePicker,
-    DatePickerSkeleton,
-    DatePickerInput,
-  } from "carbon-components-svelte";
-  import { Russian } from "flatpickr/dist/l10n/ru.js";
+import {
+  DatePicker,
+  DatePickerSkeleton,
+  DatePickerInput,
+} from "carbon-components-svelte";
+import { Russian } from "flatpickr/dist/l10n/ru.js";
 </script>
 
 <DatePicker

--- a/tests/Dropdown/Dropdown.test.svelte
+++ b/tests/Dropdown/Dropdown.test.svelte
@@ -1,29 +1,29 @@
 <script lang="ts">
-  import { Dropdown } from "carbon-components-svelte";
-  import type { ComponentProps } from "svelte";
+import { Dropdown } from "carbon-components-svelte";
+import type { ComponentProps } from "svelte";
 
-  export let items: ComponentProps<Dropdown>["items"] = [];
-  export let itemToString: ComponentProps<Dropdown>["itemToString"] = undefined;
-  export let selectedId: ComponentProps<Dropdown>["selectedId"] = undefined;
-  export let type: ComponentProps<Dropdown>["type"] = "default";
-  export let direction: ComponentProps<Dropdown>["direction"] = "bottom";
-  export let size: ComponentProps<Dropdown>["size"] = undefined;
-  export let open: ComponentProps<Dropdown>["open"] = false;
-  export let light: ComponentProps<Dropdown>["light"] = false;
-  export let disabled: ComponentProps<Dropdown>["disabled"] = false;
-  export let titleText: ComponentProps<Dropdown>["titleText"] = "";
-  export let invalid: ComponentProps<Dropdown>["invalid"] = false;
-  export let invalidText: ComponentProps<Dropdown>["invalidText"] = "";
-  export let warn: ComponentProps<Dropdown>["warn"] = false;
-  export let warnText: ComponentProps<Dropdown>["warnText"] = "";
-  export let helperText: ComponentProps<Dropdown>["helperText"] = "";
-  export let label: ComponentProps<Dropdown>["label"] = undefined;
-  export let hideLabel: ComponentProps<Dropdown>["hideLabel"] = false;
-  export let translateWithId: ComponentProps<Dropdown>["translateWithId"] =
-    undefined;
-  export let id: ComponentProps<Dropdown>["id"] = "test-dropdown";
-  export let name: ComponentProps<Dropdown>["name"] = undefined;
-  export let ref: ComponentProps<Dropdown>["ref"] = null;
+export let items: ComponentProps<Dropdown>["items"] = [];
+export let itemToString: ComponentProps<Dropdown>["itemToString"] = undefined;
+export let selectedId: ComponentProps<Dropdown>["selectedId"] = undefined;
+export let type: ComponentProps<Dropdown>["type"] = "default";
+export let direction: ComponentProps<Dropdown>["direction"] = "bottom";
+export let size: ComponentProps<Dropdown>["size"] = undefined;
+export let open: ComponentProps<Dropdown>["open"] = false;
+export let light: ComponentProps<Dropdown>["light"] = false;
+export let disabled: ComponentProps<Dropdown>["disabled"] = false;
+export let titleText: ComponentProps<Dropdown>["titleText"] = "";
+export let invalid: ComponentProps<Dropdown>["invalid"] = false;
+export let invalidText: ComponentProps<Dropdown>["invalidText"] = "";
+export let warn: ComponentProps<Dropdown>["warn"] = false;
+export let warnText: ComponentProps<Dropdown>["warnText"] = "";
+export let helperText: ComponentProps<Dropdown>["helperText"] = "";
+export let label: ComponentProps<Dropdown>["label"] = undefined;
+export let hideLabel: ComponentProps<Dropdown>["hideLabel"] = false;
+export let translateWithId: ComponentProps<Dropdown>["translateWithId"] =
+  undefined;
+export let id: ComponentProps<Dropdown>["id"] = "test-dropdown";
+export let name: ComponentProps<Dropdown>["name"] = undefined;
+export let ref: ComponentProps<Dropdown>["ref"] = null;
 </script>
 
 <Dropdown

--- a/tests/Dropdown/DropdownSlot.test.svelte
+++ b/tests/Dropdown/DropdownSlot.test.svelte
@@ -1,14 +1,14 @@
 <script lang="ts">
-  import { Dropdown } from "carbon-components-svelte";
-  import type { ComponentProps } from "svelte";
+import { Dropdown } from "carbon-components-svelte";
+import type { ComponentProps } from "svelte";
 
-  export let items: ComponentProps<Dropdown>["items"] = [
-    { id: "0", text: "Option 1" },
-    { id: "1", text: "Option 2" },
-    { id: "2", text: "Option 3" },
-  ];
-  export let selectedId: ComponentProps<Dropdown>["selectedId"] = "0";
-  export let id: ComponentProps<Dropdown>["id"] = "test-dropdown-slot";
+export let items: ComponentProps<Dropdown>["items"] = [
+  { id: "0", text: "Option 1" },
+  { id: "1", text: "Option 2" },
+  { id: "2", text: "Option 3" },
+];
+export let selectedId: ComponentProps<Dropdown>["selectedId"] = "0";
+export let id: ComponentProps<Dropdown>["id"] = "test-dropdown-slot";
 </script>
 
 <Dropdown

--- a/tests/ExpandableTile/ExpandableTile.test.svelte
+++ b/tests/ExpandableTile/ExpandableTile.test.svelte
@@ -1,22 +1,22 @@
 <script lang="ts">
-  import { ExpandableTile } from "carbon-components-svelte";
-  import type { ComponentProps } from "svelte";
+import { ExpandableTile } from "carbon-components-svelte";
+import type { ComponentProps } from "svelte";
 
-  export let expanded: ComponentProps<ExpandableTile>["expanded"] = false;
-  export let light: ComponentProps<ExpandableTile>["light"] = false;
-  export let tileMaxHeight: ComponentProps<ExpandableTile>["tileMaxHeight"] = 0;
-  export let tilePadding: ComponentProps<ExpandableTile>["tilePadding"] = 0;
-  export let tileCollapsedIconText: ComponentProps<ExpandableTile>["tileCollapsedIconText"] =
-    "Interact to expand Tile";
-  export let tileExpandedIconText: ComponentProps<ExpandableTile>["tileExpandedIconText"] =
-    "Interact to collapse Tile";
-  export let tileExpandedLabel: ComponentProps<ExpandableTile>["tileExpandedLabel"] =
-    "";
-  export let tileCollapsedLabel: ComponentProps<ExpandableTile>["tileCollapsedLabel"] =
-    "";
-  export let tabindex: ComponentProps<ExpandableTile>["tabindex"] = "0";
-  export let id: ComponentProps<ExpandableTile>["id"] = "ccs-test";
-  export let ref: ComponentProps<ExpandableTile>["ref"] = null;
+export let expanded: ComponentProps<ExpandableTile>["expanded"] = false;
+export let light: ComponentProps<ExpandableTile>["light"] = false;
+export let tileMaxHeight: ComponentProps<ExpandableTile>["tileMaxHeight"] = 0;
+export let tilePadding: ComponentProps<ExpandableTile>["tilePadding"] = 0;
+export let tileCollapsedIconText: ComponentProps<ExpandableTile>["tileCollapsedIconText"] =
+  "Interact to expand Tile";
+export let tileExpandedIconText: ComponentProps<ExpandableTile>["tileExpandedIconText"] =
+  "Interact to collapse Tile";
+export let tileExpandedLabel: ComponentProps<ExpandableTile>["tileExpandedLabel"] =
+  "";
+export let tileCollapsedLabel: ComponentProps<ExpandableTile>["tileCollapsedLabel"] =
+  "";
+export let tabindex: ComponentProps<ExpandableTile>["tabindex"] = "0";
+export let id: ComponentProps<ExpandableTile>["id"] = "ccs-test";
+export let ref: ComponentProps<ExpandableTile>["ref"] = null;
 </script>
 
 <ExpandableTile

--- a/tests/ExpandableTile/ExpandableTileCustom.test.svelte
+++ b/tests/ExpandableTile/ExpandableTileCustom.test.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
-  import { ExpandableTile, Button } from "carbon-components-svelte";
+import { ExpandableTile, Button } from "carbon-components-svelte";
 
-  export let buttonClicked = false;
-  export let linkClicked = false;
+export let buttonClicked = false;
+export let linkClicked = false;
 </script>
 
 <ExpandableTile tileExpandedLabel="View less" tileCollapsedLabel="View more">

--- a/tests/FileUploader.test.svelte
+++ b/tests/FileUploader.test.svelte
@@ -1,22 +1,22 @@
 <script lang="ts">
-  import {
-    FileUploaderButton,
-    FileUploader,
-    FileUploaderDropContainer,
-    FileUploaderItem,
-    FileUploaderSkeleton,
-  } from "carbon-components-svelte";
-  import type { FileUploaderProps } from "carbon-components-svelte/FileUploader/FileUploader.svelte";
+import {
+  FileUploaderButton,
+  FileUploader,
+  FileUploaderDropContainer,
+  FileUploaderItem,
+  FileUploaderSkeleton,
+} from "carbon-components-svelte";
+import type { FileUploaderProps } from "carbon-components-svelte/FileUploader/FileUploader.svelte";
 
-  let fileUploader: FileUploader;
-  let files: FileUploaderProps["files"] = [];
+let fileUploader: FileUploader;
+let files: FileUploaderProps["files"] = [];
 
-  $: {
-    // @ts-expect-error
-    files[0] = null;
-  }
+$: {
+  // @ts-expect-error
+  files[0] = null;
+}
 
-  $: fileUploader?.clearFiles();
+$: fileUploader?.clearFiles();
 </script>
 
 <FileUploaderButton

--- a/tests/FluidForm.test.svelte
+++ b/tests/FluidForm.test.svelte
@@ -1,9 +1,5 @@
 <script lang="ts">
-  import {
-    FluidForm,
-    TextInput,
-    PasswordInput,
-  } from "carbon-components-svelte";
+import { FluidForm, TextInput, PasswordInput } from "carbon-components-svelte";
 </script>
 
 <FluidForm action="" method="get">

--- a/tests/Form.test.svelte
+++ b/tests/Form.test.svelte
@@ -1,16 +1,16 @@
 <script lang="ts">
-  import {
-    Form,
-    FormGroup,
-    Checkbox,
-    RadioButtonGroup,
-    RadioButton,
-    Select,
-    SelectItem,
-    Button,
-  } from "carbon-components-svelte";
+import {
+  Form,
+  FormGroup,
+  Checkbox,
+  RadioButtonGroup,
+  RadioButton,
+  Select,
+  SelectItem,
+  Button,
+} from "carbon-components-svelte";
 
-  let ref: HTMLFormElement;
+let ref: HTMLFormElement;
 </script>
 
 <Form on:submit bind:ref>

--- a/tests/Grid/Grid.test.svelte
+++ b/tests/Grid/Grid.test.svelte
@@ -1,14 +1,14 @@
 <script lang="ts">
-  import { Grid } from "carbon-components-svelte";
+import { Grid } from "carbon-components-svelte";
 
-  export let condensed = false;
-  export let narrow = false;
-  export let fullWidth = false;
-  export let noGutter = false;
-  export let noGutterLeft = false;
-  export let noGutterRight = false;
-  export let padding = false;
-  export let as = false;
+export let condensed = false;
+export let narrow = false;
+export let fullWidth = false;
+export let noGutter = false;
+export let noGutterLeft = false;
+export let noGutterRight = false;
+export let padding = false;
+export let as = false;
 </script>
 
 {#if as}

--- a/tests/HeaderNav.test.svelte
+++ b/tests/HeaderNav.test.svelte
@@ -1,22 +1,22 @@
 <script lang="ts">
-  import {
-    Header,
-    HeaderNav,
-    HeaderNavItem,
-    HeaderNavMenu,
-    SideNav,
-    SideNavItems,
-    SideNavMenu,
-    SideNavMenuItem,
-    SideNavLink,
-    SkipToContent,
-    Content,
-    Grid,
-    Row,
-    Column,
-  } from "carbon-components-svelte";
+import {
+  Header,
+  HeaderNav,
+  HeaderNavItem,
+  HeaderNavMenu,
+  SideNav,
+  SideNavItems,
+  SideNavMenu,
+  SideNavMenuItem,
+  SideNavLink,
+  SkipToContent,
+  Content,
+  Grid,
+  Row,
+  Column,
+} from "carbon-components-svelte";
 
-  let isSideNavOpen = false;
+let isSideNavOpen = false;
 </script>
 
 <Header company="IBM" platformName="Carbon Svelte" bind:isSideNavOpen>

--- a/tests/HeaderSearch.svelte
+++ b/tests/HeaderSearch.svelte
@@ -1,58 +1,58 @@
 <script lang="ts">
-  import {
-    Header,
-    HeaderUtilities,
-    HeaderAction,
-    HeaderSearch,
-    HeaderPanelLinks,
-    HeaderPanelDivider,
-    HeaderPanelLink,
-    SideNav,
-    SideNavItems,
-    SideNavMenu,
-    SideNavMenuItem,
-    SideNavLink,
-    SkipToContent,
-    Content,
-    Grid,
-    Row,
-    Column,
-  } from "carbon-components-svelte";
-  import type { ComponentProps } from "svelte";
+import {
+  Header,
+  HeaderUtilities,
+  HeaderAction,
+  HeaderSearch,
+  HeaderPanelLinks,
+  HeaderPanelDivider,
+  HeaderPanelLink,
+  SideNav,
+  SideNavItems,
+  SideNavMenu,
+  SideNavMenuItem,
+  SideNavLink,
+  SkipToContent,
+  Content,
+  Grid,
+  Row,
+  Column,
+} from "carbon-components-svelte";
+import type { ComponentProps } from "svelte";
 
-  let isSideNavOpen = false;
-  let isOpen = false;
+let isSideNavOpen = false;
+let isOpen = false;
 
-  let ref: ComponentProps<HeaderSearch>["ref"] = null;
-  let active = false;
-  let value = "";
-  let selectedResultIndex = 1;
+let ref: ComponentProps<HeaderSearch>["ref"] = null;
+let active = false;
+let value = "";
+let selectedResultIndex = 1;
 
-  $: results =
-    value.length > 2
-      ? [
-          {
-            href: "/",
-            text: "Result 1",
-            description: "Result description",
-          },
-          {
-            href: "/",
-            text: "Result 2",
-            description: "Result description",
-          },
-          {
-            href: "/",
-            text: "Result 3",
-            description: "Result description",
-          },
-        ]
-      : [];
+$: results =
+  value.length > 2
+    ? [
+        {
+          href: "/",
+          text: "Result 1",
+          description: "Result description",
+        },
+        {
+          href: "/",
+          text: "Result 2",
+          description: "Result description",
+        },
+        {
+          href: "/",
+          text: "Result 3",
+          description: "Result description",
+        },
+      ]
+    : [];
 
-  $: console.log("ref", ref);
-  $: console.log("active", active);
-  $: console.log("value", value);
-  $: console.log("selectedResultIndex", selectedResultIndex);
+$: console.log("ref", ref);
+$: console.log("active", active);
+$: console.log("value", value);
+$: console.log("selectedResultIndex", selectedResultIndex);
 </script>
 
 <Header company="IBM" platformName="Carbon Svelte" bind:isSideNavOpen>

--- a/tests/HeaderSwitcher.test.svelte
+++ b/tests/HeaderSwitcher.test.svelte
@@ -1,25 +1,25 @@
 <script lang="ts">
-  import {
-    Header,
-    HeaderUtilities,
-    HeaderAction,
-    HeaderPanelLinks,
-    HeaderPanelDivider,
-    HeaderPanelLink,
-    SideNav,
-    SideNavItems,
-    SideNavMenu,
-    SideNavMenuItem,
-    SideNavLink,
-    SkipToContent,
-    Content,
-    Grid,
-    Row,
-    Column,
-  } from "carbon-components-svelte";
+import {
+  Header,
+  HeaderUtilities,
+  HeaderAction,
+  HeaderPanelLinks,
+  HeaderPanelDivider,
+  HeaderPanelLink,
+  SideNav,
+  SideNavItems,
+  SideNavMenu,
+  SideNavMenuItem,
+  SideNavLink,
+  SkipToContent,
+  Content,
+  Grid,
+  Row,
+  Column,
+} from "carbon-components-svelte";
 
-  let isSideNavOpen = false;
-  let isOpen = false;
+let isSideNavOpen = false;
+let isOpen = false;
 </script>
 
 <Header company="IBM" platformName="Carbon Svelte" bind:isSideNavOpen>

--- a/tests/HeaderUtilities.test.svelte
+++ b/tests/HeaderUtilities.test.svelte
@@ -1,28 +1,28 @@
 <script lang="ts">
-  import {
-    Header,
-    HeaderUtilities,
-    HeaderAction,
-    HeaderGlobalAction,
-    HeaderPanelLinks,
-    HeaderPanelDivider,
-    HeaderPanelLink,
-    SideNav,
-    SideNavItems,
-    SideNavMenu,
-    SideNavMenuItem,
-    SideNavLink,
-    SkipToContent,
-    Content,
-    Grid,
-    Row,
-    Column,
-  } from "carbon-components-svelte";
-  import SettingsAdjust from "carbon-icons-svelte/lib/SettingsAdjust.svelte";
-  import { quintOut } from "svelte/easing";
+import {
+  Header,
+  HeaderUtilities,
+  HeaderAction,
+  HeaderGlobalAction,
+  HeaderPanelLinks,
+  HeaderPanelDivider,
+  HeaderPanelLink,
+  SideNav,
+  SideNavItems,
+  SideNavMenu,
+  SideNavMenuItem,
+  SideNavLink,
+  SkipToContent,
+  Content,
+  Grid,
+  Row,
+  Column,
+} from "carbon-components-svelte";
+import SettingsAdjust from "carbon-icons-svelte/lib/SettingsAdjust.svelte";
+import { quintOut } from "svelte/easing";
 
-  let isSideNavOpen = false;
-  let isOpen = false;
+let isSideNavOpen = false;
+let isOpen = false;
 </script>
 
 <Header company="IBM" platformName="Carbon Svelte" bind:isSideNavOpen>

--- a/tests/HiddenCodeSnippet.test.svelte
+++ b/tests/HiddenCodeSnippet.test.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-  import { CodeSnippet } from "carbon-components-svelte";
+import { CodeSnippet } from "carbon-components-svelte";
 
-  let toggled = false;
+let toggled = false;
 
-  const code = Array.from({ length: 20 }, (_, i) => i + 1).join("\n");
+const code = Array.from({ length: 20 }, (_, i) => i + 1).join("\n");
 </script>
 
 {#if toggled}

--- a/tests/ImageLoader/ImageLoader.test.svelte
+++ b/tests/ImageLoader/ImageLoader.test.svelte
@@ -1,15 +1,15 @@
 <svelte:options accessors />
 
 <script lang="ts">
-  import { ImageLoader, InlineLoading } from "carbon-components-svelte";
+import { ImageLoader, InlineLoading } from "carbon-components-svelte";
 
-  // Valid image URL for testing successful loads
-  const validImageSrc =
-    "https://upload.wikimedia.org/wikipedia/commons/5/51/IBM_logo.svg";
-  // Invalid image URL for testing error states
-  const invalidImageSrc = "https://invalid-url/nonexistent.png";
+// Valid image URL for testing successful loads
+const validImageSrc =
+  "https://upload.wikimedia.org/wikipedia/commons/5/51/IBM_logo.svg";
+// Invalid image URL for testing error states
+const invalidImageSrc = "https://invalid-url/nonexistent.png";
 
-  export let imageLoader: ImageLoader;
+export let imageLoader: ImageLoader;
 </script>
 
 <!-- Default image loader -->

--- a/tests/InlineLoading/InlineLoading.test.svelte
+++ b/tests/InlineLoading/InlineLoading.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { InlineLoading } from "carbon-components-svelte";
+import { InlineLoading } from "carbon-components-svelte";
 </script>
 
 <!-- Default inline loading -->

--- a/tests/InlineNotification/InlineNotification.close.test.svelte
+++ b/tests/InlineNotification/InlineNotification.close.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { InlineNotification } from "carbon-components-svelte";
+import { InlineNotification } from "carbon-components-svelte";
 </script>
 
 <InlineNotification

--- a/tests/InlineNotification/InlineNotification.test.svelte
+++ b/tests/InlineNotification/InlineNotification.test.svelte
@@ -1,16 +1,16 @@
 <script lang="ts">
-  import { InlineNotification } from "carbon-components-svelte";
-  import type { ComponentProps } from "svelte";
+import { InlineNotification } from "carbon-components-svelte";
+import type { ComponentProps } from "svelte";
 
-  export let kind: ComponentProps<InlineNotification>["kind"] = "error";
-  export let lowContrast = false;
-  export let timeout = 0;
-  export let role = "alert";
-  export let title = "Error:";
-  export let subtitle = "An internal server error occurred.";
-  export let hideCloseButton = false;
-  export let statusIconDescription = "";
-  export let closeButtonDescription = "";
+export let kind: ComponentProps<InlineNotification>["kind"] = "error";
+export let lowContrast = false;
+export let timeout = 0;
+export let role = "alert";
+export let title = "Error:";
+export let subtitle = "An internal server error occurred.";
+export let hideCloseButton = false;
+export let statusIconDescription = "";
+export let closeButtonDescription = "";
 </script>
 
 <InlineNotification

--- a/tests/InlineNotification/InlineNotificationCustom.test.svelte
+++ b/tests/InlineNotification/InlineNotificationCustom.test.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
-  import {
-    InlineNotification,
-    NotificationActionButton,
-  } from "carbon-components-svelte";
+import {
+  InlineNotification,
+  NotificationActionButton,
+} from "carbon-components-svelte";
 </script>
 
 <InlineNotification kind="warning">

--- a/tests/Link/Link.test.svelte
+++ b/tests/Link/Link.test.svelte
@@ -1,8 +1,8 @@
 <svelte:options accessors />
 
 <script lang="ts">
-  import { Link } from "carbon-components-svelte";
-  import Carbon from "carbon-icons-svelte/lib/Carbon.svelte";
+import { Link } from "carbon-components-svelte";
+import Carbon from "carbon-icons-svelte/lib/Carbon.svelte";
 </script>
 
 <!-- Default link -->

--- a/tests/Loading/Loading.test.svelte
+++ b/tests/Loading/Loading.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Loading } from "carbon-components-svelte";
+import { Loading } from "carbon-components-svelte";
 </script>
 
 <!-- Default loading (with overlay) -->

--- a/tests/LocalStorage/LocalStorage.test.svelte
+++ b/tests/LocalStorage/LocalStorage.test.svelte
@@ -1,11 +1,11 @@
 <svelte:options accessors />
 
 <script lang="ts">
-  import { LocalStorage } from "carbon-components-svelte";
+import { LocalStorage } from "carbon-components-svelte";
 
-  // Example values for testing
-  const primitiveValue = "test-value";
-  const objectValue = { theme: "dark", fontSize: 16 };
+// Example values for testing
+const primitiveValue = "test-value";
+const objectValue = { theme: "dark", fontSize: 16 };
 </script>
 
 <!-- Default local storage -->

--- a/tests/LocalStorage/LocalStorageObject.test.svelte
+++ b/tests/LocalStorage/LocalStorageObject.test.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-  import { LocalStorage } from "carbon-components-svelte";
+import { LocalStorage } from "carbon-components-svelte";
 
-  const objectValue = { theme: "dark", fontSize: 16 };
+const objectValue = { theme: "dark", fontSize: 16 };
 </script>
 
 <div data-testid="object-storage">

--- a/tests/LocalStorage/LocalStoragePrimitive.test.svelte
+++ b/tests/LocalStorage/LocalStoragePrimitive.test.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-  import { LocalStorage } from "carbon-components-svelte";
+import { LocalStorage } from "carbon-components-svelte";
 
-  const primitiveValue = "test-value";
+const primitiveValue = "test-value";
 </script>
 
 <div data-testid="primitive-storage">

--- a/tests/Modal.test.svelte
+++ b/tests/Modal.test.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-  import { Button, Modal } from "carbon-components-svelte";
+import { Button, Modal } from "carbon-components-svelte";
 
-  let open = false;
+let open = false;
 </script>
 
 <Button on:click={() => (open = true)}>Create database</Button>

--- a/tests/ModalExtraSmall.test.svelte
+++ b/tests/ModalExtraSmall.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Modal } from "carbon-components-svelte";
+import { Modal } from "carbon-components-svelte";
 </script>
 
 <Modal

--- a/tests/ModalLarge.test.svelte
+++ b/tests/ModalLarge.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Modal } from "carbon-components-svelte";
+import { Modal } from "carbon-components-svelte";
 </script>
 
 <Modal

--- a/tests/ModalPreventOutsideClick.test.svelte
+++ b/tests/ModalPreventOutsideClick.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Modal } from "carbon-components-svelte";
+import { Modal } from "carbon-components-svelte";
 </script>
 
 <Modal

--- a/tests/ModalSmall.test.svelte
+++ b/tests/ModalSmall.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Modal } from "carbon-components-svelte";
+import { Modal } from "carbon-components-svelte";
 </script>
 
 <Modal

--- a/tests/MultiSelect.test.svelte
+++ b/tests/MultiSelect.test.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
-  import { MultiSelect } from "carbon-components-svelte";
-  import type { MultiSelectProps } from "carbon-components-svelte/MultiSelect/MultiSelect.svelte";
+import { MultiSelect } from "carbon-components-svelte";
+import type { MultiSelectProps } from "carbon-components-svelte/MultiSelect/MultiSelect.svelte";
 
-  let selectedIds: MultiSelectProps["selectedIds"] = [0];
+let selectedIds: MultiSelectProps["selectedIds"] = [0];
 
-  $: {
-    // @ts-expect-error
-    selectedIds[0] = [0];
-  }
+$: {
+  // @ts-expect-error
+  selectedIds[0] = [0];
+}
 </script>
 
 <MultiSelect

--- a/tests/NumberInput/NumberInput.test.svelte
+++ b/tests/NumberInput/NumberInput.test.svelte
@@ -1,28 +1,28 @@
 <script lang="ts">
-  import { NumberInput } from "carbon-components-svelte";
-  import type { ComponentProps } from "svelte";
+import { NumberInput } from "carbon-components-svelte";
+import type { ComponentProps } from "svelte";
 
-  export let value: ComponentProps<NumberInput>["value"] = 0;
-  export let step: ComponentProps<NumberInput>["step"] = 1;
-  export let min: ComponentProps<NumberInput>["min"] = undefined;
-  export let max: ComponentProps<NumberInput>["max"] = undefined;
-  export let size: ComponentProps<NumberInput>["size"] = undefined;
-  export let light = false;
-  export let readonly = false;
-  export let allowEmpty = false;
-  export let disabled = false;
-  export let hideSteppers = false;
-  export let iconDescription = "";
-  export let invalid = false;
-  export let invalidText = "";
-  export let warn = false;
-  export let warnText = "";
-  export let helperText = "";
-  export let label = "Clusters";
-  export let hideLabel = false;
-  export let id = "ccs-test";
-  export let name: ComponentProps<NumberInput>["name"] = undefined;
-  export let ref: ComponentProps<NumberInput>["ref"] = null;
+export let value: ComponentProps<NumberInput>["value"] = 0;
+export let step: ComponentProps<NumberInput>["step"] = 1;
+export let min: ComponentProps<NumberInput>["min"] = undefined;
+export let max: ComponentProps<NumberInput>["max"] = undefined;
+export let size: ComponentProps<NumberInput>["size"] = undefined;
+export let light = false;
+export let readonly = false;
+export let allowEmpty = false;
+export let disabled = false;
+export let hideSteppers = false;
+export let iconDescription = "";
+export let invalid = false;
+export let invalidText = "";
+export let warn = false;
+export let warnText = "";
+export let helperText = "";
+export let label = "Clusters";
+export let hideLabel = false;
+export let id = "ccs-test";
+export let name: ComponentProps<NumberInput>["name"] = undefined;
+export let ref: ComponentProps<NumberInput>["ref"] = null;
 </script>
 
 <NumberInput

--- a/tests/NumberInput/NumberInputCustom.test.svelte
+++ b/tests/NumberInput/NumberInputCustom.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { NumberInput } from "carbon-components-svelte";
+import { NumberInput } from "carbon-components-svelte";
 </script>
 
 <NumberInput label="Custom label" value={0}>

--- a/tests/OffsetColumns.test.svelte
+++ b/tests/OffsetColumns.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Grid, Row, Column } from "carbon-components-svelte";
+import { Grid, Row, Column } from "carbon-components-svelte";
 </script>
 
 <Grid>

--- a/tests/OrderedList/OrderedList.test.svelte
+++ b/tests/OrderedList/OrderedList.test.svelte
@@ -1,13 +1,13 @@
 <svelte:options accessors />
 
 <script lang="ts">
-  import { OrderedList, ListItem } from "carbon-components-svelte";
+import { OrderedList, ListItem } from "carbon-components-svelte";
 
-  export let nested = false;
-  export let native = false;
-  export let expressive = false;
-  export let items: string[] = ["Item 1", "Item 2", "Item 3"];
-  export let nestedItems: string[] = [];
+export let nested = false;
+export let native = false;
+export let expressive = false;
+export let items: string[] = ["Item 1", "Item 2", "Item 3"];
+export let nestedItems: string[] = [];
 </script>
 
 <div data-testid="list-wrapper">

--- a/tests/OverflowMenu/OverflowMenu.test.svelte
+++ b/tests/OverflowMenu/OverflowMenu.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { OverflowMenu, OverflowMenuItem } from "carbon-components-svelte";
+import { OverflowMenu, OverflowMenuItem } from "carbon-components-svelte";
 </script>
 
 <OverflowMenu

--- a/tests/PaddedGrid.test.svelte
+++ b/tests/PaddedGrid.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Grid, Row, Column } from "carbon-components-svelte";
+import { Grid, Row, Column } from "carbon-components-svelte";
 </script>
 
 <Grid padding>

--- a/tests/Pagination/Pagination.test.svelte
+++ b/tests/Pagination/Pagination.test.svelte
@@ -1,17 +1,17 @@
 <script lang="ts">
-  import { Pagination } from "carbon-components-svelte";
+import { Pagination } from "carbon-components-svelte";
 
-  export let page = 1;
-  export let totalItems = 0;
-  export let disabled = false;
-  export let forwardText = "Next page";
-  export let backwardText = "Previous page";
-  export let itemsPerPageText = "Items per page:";
-  export let pageInputDisabled = false;
-  export let pageSizeInputDisabled = false;
-  export let pageSize = 10;
-  export let pageSizes: ReadonlyArray<number> = [10];
-  export let pagesUnknown = false;
+export let page = 1;
+export let totalItems = 0;
+export let disabled = false;
+export let forwardText = "Next page";
+export let backwardText = "Previous page";
+export let itemsPerPageText = "Items per page:";
+export let pageInputDisabled = false;
+export let pageSizeInputDisabled = false;
+export let pageSize = 10;
+export let pageSizes: ReadonlyArray<number> = [10];
+export let pagesUnknown = false;
 </script>
 
 <Pagination

--- a/tests/PaginationNav/PaginationNav.test.svelte
+++ b/tests/PaginationNav/PaginationNav.test.svelte
@@ -1,19 +1,19 @@
 <script lang="ts">
-  import { PaginationNav } from "carbon-components-svelte";
+import { PaginationNav } from "carbon-components-svelte";
 
-  export let page = 1;
-  export let total = 10;
-  export let shown = 10;
-  export let loop = false;
-  export let forwardText = "Next page";
-  export let backwardText = "Previous page";
-  export let tooltipPosition:
-    | "top"
-    | "right"
-    | "bottom"
-    | "left"
-    | "outside"
-    | "inside" = "bottom";
+export let page = 1;
+export let total = 10;
+export let shown = 10;
+export let loop = false;
+export let forwardText = "Next page";
+export let backwardText = "Previous page";
+export let tooltipPosition:
+  | "top"
+  | "right"
+  | "bottom"
+  | "left"
+  | "outside"
+  | "inside" = "bottom";
 </script>
 
 <PaginationNav

--- a/tests/PassiveModal.test.svelte
+++ b/tests/PassiveModal.test.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-  import { Button, Modal } from "carbon-components-svelte";
+import { Button, Modal } from "carbon-components-svelte";
 
-  let open = false;
+let open = false;
 </script>
 
 <Button kind="tertiary" on:click={() => (open = true)}>Learn more</Button>

--- a/tests/PasswordInput/PasswordInput.test.svelte
+++ b/tests/PasswordInput/PasswordInput.test.svelte
@@ -1,27 +1,27 @@
 <script lang="ts">
-  import { PasswordInput } from "carbon-components-svelte";
+import { PasswordInput } from "carbon-components-svelte";
 
-  export let size: "sm" | "xl" | undefined = undefined;
-  export let value: string | number = "";
-  export let type: "text" | "password" = "password";
-  export let placeholder = "";
-  export let hidePasswordLabel = "Hide password";
-  export let showPasswordLabel = "Show password";
-  export let tooltipAlignment: "start" | "center" | "end" = "center";
-  export let tooltipPosition: "top" | "right" | "bottom" | "left" = "bottom";
-  export let light = false;
-  export let disabled = false;
-  export let helperText = "";
-  export let labelText = "";
-  export let hideLabel = false;
-  export let invalid = false;
-  export let invalidText = "";
-  export let warn = false;
-  export let warnText = "";
-  export let inline = false;
-  export let id = "test-password-input";
-  export let name = "";
-  export let ref: HTMLInputElement | null = null;
+export let size: "sm" | "xl" | undefined = undefined;
+export let value: string | number = "";
+export let type: "text" | "password" = "password";
+export let placeholder = "";
+export let hidePasswordLabel = "Hide password";
+export let showPasswordLabel = "Show password";
+export let tooltipAlignment: "start" | "center" | "end" = "center";
+export let tooltipPosition: "top" | "right" | "bottom" | "left" = "bottom";
+export let light = false;
+export let disabled = false;
+export let helperText = "";
+export let labelText = "";
+export let hideLabel = false;
+export let invalid = false;
+export let invalidText = "";
+export let warn = false;
+export let warnText = "";
+export let inline = false;
+export let id = "test-password-input";
+export let name = "";
+export let ref: HTMLInputElement | null = null;
 </script>
 
 <PasswordInput

--- a/tests/PersistedHamburgerMenu.test.svelte
+++ b/tests/PersistedHamburgerMenu.test.svelte
@@ -1,22 +1,22 @@
 <script lang="ts">
-  import {
-    Header,
-    HeaderNav,
-    HeaderNavItem,
-    HeaderNavMenu,
-    SideNav,
-    SideNavItems,
-    SideNavMenu,
-    SideNavMenuItem,
-    SideNavLink,
-    SkipToContent,
-    Content,
-    Grid,
-    Row,
-    Column,
-  } from "carbon-components-svelte";
+import {
+  Header,
+  HeaderNav,
+  HeaderNavItem,
+  HeaderNavMenu,
+  SideNav,
+  SideNavItems,
+  SideNavMenu,
+  SideNavMenuItem,
+  SideNavLink,
+  SkipToContent,
+  Content,
+  Grid,
+  Row,
+  Column,
+} from "carbon-components-svelte";
 
-  let isSideNavOpen = false;
+let isSideNavOpen = false;
 </script>
 
 <Header

--- a/tests/Popover/Popover.test.svelte
+++ b/tests/Popover/Popover.test.svelte
@@ -1,25 +1,25 @@
 <script lang="ts">
-  import { Popover } from "carbon-components-svelte";
+import { Popover } from "carbon-components-svelte";
 
-  export let open = false;
-  export let align:
-    | "top"
-    | "top-left"
-    | "top-right"
-    | "bottom"
-    | "bottom-left"
-    | "bottom-right"
-    | "left"
-    | "left-bottom"
-    | "left-top"
-    | "right"
-    | "right-bottom"
-    | "right-top" = "top";
-  export let caret = false;
-  export let light = false;
-  export let highContrast = false;
-  export let relative = false;
-  export let closeOnOutsideClick = false;
+export let open = false;
+export let align:
+  | "top"
+  | "top-left"
+  | "top-right"
+  | "bottom"
+  | "bottom-left"
+  | "bottom-right"
+  | "left"
+  | "left-bottom"
+  | "left-top"
+  | "right"
+  | "right-bottom"
+  | "right-top" = "top";
+export let caret = false;
+export let light = false;
+export let highContrast = false;
+export let relative = false;
+export let closeOnOutsideClick = false;
 </script>
 
 <div data-testid="parent">

--- a/tests/ProgressBar/ProgressBar.test.svelte
+++ b/tests/ProgressBar/ProgressBar.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { ProgressBar } from "carbon-components-svelte";
+import { ProgressBar } from "carbon-components-svelte";
 </script>
 
 <ProgressBar status="active" data-testid="indeterminate-progress" />

--- a/tests/ProgressIndicator/ProgressIndicator.test.svelte
+++ b/tests/ProgressIndicator/ProgressIndicator.test.svelte
@@ -1,17 +1,17 @@
 <script lang="ts">
-  import { ProgressIndicator, ProgressStep } from "carbon-components-svelte";
+import { ProgressIndicator, ProgressStep } from "carbon-components-svelte";
 
-  export let currentIndex = 0;
-  export let vertical = false;
-  export let spaceEqually = false;
-  export let preventChangeOnClick = false;
-  export let steps: Array<{
-    label: string;
-    description: string;
-    complete: boolean;
-    invalid?: boolean;
-    disabled?: boolean;
-  }> = [];
+export let currentIndex = 0;
+export let vertical = false;
+export let spaceEqually = false;
+export let preventChangeOnClick = false;
+export let steps: Array<{
+  label: string;
+  description: string;
+  complete: boolean;
+  invalid?: boolean;
+  disabled?: boolean;
+}> = [];
 </script>
 
 <ProgressIndicator

--- a/tests/RadioButton/RadioButton.test.svelte
+++ b/tests/RadioButton/RadioButton.test.svelte
@@ -1,18 +1,18 @@
 <script lang="ts">
-  import { RadioButton } from "carbon-components-svelte";
-  import type { ComponentProps } from "svelte";
+import { RadioButton } from "carbon-components-svelte";
+import type { ComponentProps } from "svelte";
 
-  export let value: ComponentProps<RadioButton>["value"] = "";
-  export let checked: ComponentProps<RadioButton>["checked"] = false;
-  export let disabled: ComponentProps<RadioButton>["disabled"] = false;
-  export let required: ComponentProps<RadioButton>["required"] = false;
-  export let labelPosition: ComponentProps<RadioButton>["labelPosition"] =
-    "right";
-  export let labelText: ComponentProps<RadioButton>["labelText"] = "Option 1";
-  export let hideLabel: ComponentProps<RadioButton>["hideLabel"] = false;
-  export let id: ComponentProps<RadioButton>["id"] = "ccs-test";
-  export let name: ComponentProps<RadioButton>["name"] = "test-group";
-  export let ref: ComponentProps<RadioButton>["ref"] = null;
+export let value: ComponentProps<RadioButton>["value"] = "";
+export let checked: ComponentProps<RadioButton>["checked"] = false;
+export let disabled: ComponentProps<RadioButton>["disabled"] = false;
+export let required: ComponentProps<RadioButton>["required"] = false;
+export let labelPosition: ComponentProps<RadioButton>["labelPosition"] =
+  "right";
+export let labelText: ComponentProps<RadioButton>["labelText"] = "Option 1";
+export let hideLabel: ComponentProps<RadioButton>["hideLabel"] = false;
+export let id: ComponentProps<RadioButton>["id"] = "ccs-test";
+export let name: ComponentProps<RadioButton>["name"] = "test-group";
+export let ref: ComponentProps<RadioButton>["ref"] = null;
 </script>
 
 <RadioButton

--- a/tests/RadioButton/RadioButtonCustom.test.svelte
+++ b/tests/RadioButton/RadioButtonCustom.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { RadioButton } from "carbon-components-svelte";
+import { RadioButton } from "carbon-components-svelte";
 </script>
 
 <RadioButton labelText="Custom label" value="custom" name="test-group">

--- a/tests/RadioSelectableDataTable.test.svelte
+++ b/tests/RadioSelectableDataTable.test.svelte
@@ -1,24 +1,24 @@
 <script lang="ts">
-  import { DataTable } from "carbon-components-svelte";
+import { DataTable } from "carbon-components-svelte";
 
-  const headers = [
-    { key: "name", value: "Name" },
-    { key: "port", value: "Port" },
-    { key: "rule", value: "Rule" },
-  ] as const;
+const headers = [
+  { key: "name", value: "Name" },
+  { key: "port", value: "Port" },
+  { key: "rule", value: "Rule" },
+] as const;
 
-  const rows = [
-    { id: "a", name: "Load Balancer 3", port: 3000, rule: "Round robin" },
-    { id: "b", name: "Load Balancer 1", port: 443, rule: "Round robin" },
-    { id: "c", name: "Load Balancer 2", port: 80, rule: "DNS delegation" },
-    { id: "d", name: "Load Balancer 6", port: 3000, rule: "Round robin" },
-    { id: "e", name: "Load Balancer 4", port: 443, rule: "Round robin" },
-    { id: "f", name: "Load Balancer 5", port: 80, rule: "DNS delegation" },
-  ];
+const rows = [
+  { id: "a", name: "Load Balancer 3", port: 3000, rule: "Round robin" },
+  { id: "b", name: "Load Balancer 1", port: 443, rule: "Round robin" },
+  { id: "c", name: "Load Balancer 2", port: 80, rule: "DNS delegation" },
+  { id: "d", name: "Load Balancer 6", port: 3000, rule: "Round robin" },
+  { id: "e", name: "Load Balancer 4", port: 443, rule: "Round robin" },
+  { id: "f", name: "Load Balancer 5", port: 80, rule: "DNS delegation" },
+];
 
-  let selectedRowIds = [rows[1].id];
+let selectedRowIds = [rows[1].id];
 
-  $: console.log("selectedRowIds", selectedRowIds);
+$: console.log("selectedRowIds", selectedRowIds);
 </script>
 
 <DataTable radio bind:selectedRowIds {headers} {rows} />

--- a/tests/RadioTile/RadioTile.group.test.svelte
+++ b/tests/RadioTile/RadioTile.group.test.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-  import { TileGroup, RadioTile, Button } from "carbon-components-svelte";
+import { TileGroup, RadioTile, Button } from "carbon-components-svelte";
 
-  const values = ["Lite plan", "Standard plan", "Plus plan"];
+const values = ["Lite plan", "Standard plan", "Plus plan"];
 
-  let selected = values[1];
+let selected = values[1];
 </script>
 
 <TileGroup legend="Service pricing tiers" name="plan" bind:selected>

--- a/tests/RadioTile/RadioTile.single.test.svelte
+++ b/tests/RadioTile/RadioTile.single.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { RadioTile } from "carbon-components-svelte";
+import { RadioTile } from "carbon-components-svelte";
 </script>
 
 <RadioTile name="custom-name" value="test">

--- a/tests/RadioTile/RadioTile.test.svelte
+++ b/tests/RadioTile/RadioTile.test.svelte
@@ -1,17 +1,17 @@
 <script lang="ts">
-  import { RadioTile, TileGroup } from "carbon-components-svelte";
-  import type { ComponentProps } from "svelte";
+import { RadioTile, TileGroup } from "carbon-components-svelte";
+import type { ComponentProps } from "svelte";
 
-  export let checked: ComponentProps<RadioTile>["checked"] = false;
-  export let light: ComponentProps<RadioTile>["light"] = false;
-  export let disabled: ComponentProps<RadioTile>["disabled"] = false;
-  export let required: ComponentProps<RadioTile>["required"] = false;
-  export let value: ComponentProps<RadioTile>["value"] = "test";
-  export let tabindex: ComponentProps<RadioTile>["tabindex"] = "0";
-  export let iconDescription: ComponentProps<RadioTile>["iconDescription"] =
-    "Tile checkmark";
-  export let id: ComponentProps<RadioTile>["id"] = "ccs-test";
-  export let name: ComponentProps<RadioTile>["name"] = "test-group";
+export let checked: ComponentProps<RadioTile>["checked"] = false;
+export let light: ComponentProps<RadioTile>["light"] = false;
+export let disabled: ComponentProps<RadioTile>["disabled"] = false;
+export let required: ComponentProps<RadioTile>["required"] = false;
+export let value: ComponentProps<RadioTile>["value"] = "test";
+export let tabindex: ComponentProps<RadioTile>["tabindex"] = "0";
+export let iconDescription: ComponentProps<RadioTile>["iconDescription"] =
+  "Tile checkmark";
+export let id: ComponentProps<RadioTile>["id"] = "ccs-test";
+export let name: ComponentProps<RadioTile>["name"] = "test-group";
 </script>
 
 <TileGroup

--- a/tests/RadioTile/RadioTileCustom.test.svelte
+++ b/tests/RadioTile/RadioTileCustom.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { RadioTile, TileGroup } from "carbon-components-svelte";
+import { RadioTile, TileGroup } from "carbon-components-svelte";
 </script>
 
 <TileGroup legend="Test group" name="test-group" selected="test">

--- a/tests/RecursiveList/RecursiveList.hierarchy.test.svelte
+++ b/tests/RecursiveList/RecursiveList.hierarchy.test.svelte
@@ -1,24 +1,24 @@
 <script lang="ts">
-  import { RecursiveList } from "carbon-components-svelte";
-  import toHierarchy from "../../src/utils/toHierarchy";
+import { RecursiveList } from "carbon-components-svelte";
+import toHierarchy from "../../src/utils/toHierarchy";
 
-  let nodes = toHierarchy(
-    [
-      { id: 1, text: "Item 1" },
-      { id: 2, text: "Item 1a", pid: 1 },
-      { id: 3, html: "<h5>HTML content</h5>", pid: 2 },
-      { id: 4, text: "Item 2" },
-      { id: 5, href: "https://svelte.dev/", pid: 4 },
-      {
-        id: 6,
-        href: "https://svelte.dev/",
-        text: "Link with custom text",
-        pid: 4,
-      },
-      { id: 7, text: "Item 3" },
-    ],
-    (node) => node.pid,
-  );
+let nodes = toHierarchy(
+  [
+    { id: 1, text: "Item 1" },
+    { id: 2, text: "Item 1a", pid: 1 },
+    { id: 3, html: "<h5>HTML content</h5>", pid: 2 },
+    { id: 4, text: "Item 2" },
+    { id: 5, href: "https://svelte.dev/", pid: 4 },
+    {
+      id: 6,
+      href: "https://svelte.dev/",
+      text: "Link with custom text",
+      pid: 4,
+    },
+    { id: 7, text: "Item 3" },
+  ],
+  (node) => node.pid,
+);
 </script>
 
 <RecursiveList type="ordered" {nodes} />

--- a/tests/RecursiveList/RecursiveList.test.svelte
+++ b/tests/RecursiveList/RecursiveList.test.svelte
@@ -1,28 +1,28 @@
 <script lang="ts">
-  import { RecursiveList } from "carbon-components-svelte";
+import { RecursiveList } from "carbon-components-svelte";
 
-  const nodes = [
-    {
-      text: "Item 1",
-      nodes: [
-        {
-          text: "Item 1a",
-          nodes: [{ html: "<h5>HTML content</h5>" }],
-        },
-      ],
-    },
-    {
-      text: "Item 2",
-      nodes: [
-        { href: "https://svelte.dev/" },
-        {
-          href: "https://svelte.dev/",
-          text: "Link with custom text",
-        },
-      ],
-    },
-    { text: "Item 3" },
-  ];
+const nodes = [
+  {
+    text: "Item 1",
+    nodes: [
+      {
+        text: "Item 1a",
+        nodes: [{ html: "<h5>HTML content</h5>" }],
+      },
+    ],
+  },
+  {
+    text: "Item 2",
+    nodes: [
+      { href: "https://svelte.dev/" },
+      {
+        href: "https://svelte.dev/",
+        text: "Link with custom text",
+      },
+    ],
+  },
+  { text: "Item 3" },
+];
 </script>
 
 <RecursiveList type="ordered" {nodes} />

--- a/tests/ResponsiveGrid.test.svelte
+++ b/tests/ResponsiveGrid.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Grid, Row, Column } from "carbon-components-svelte";
+import { Grid, Row, Column } from "carbon-components-svelte";
 </script>
 
 <Grid>

--- a/tests/Search/Search.test.svelte
+++ b/tests/Search/Search.test.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-  import { Search } from "carbon-components-svelte";
+import { Search } from "carbon-components-svelte";
 
-  let value = "";
+let value = "";
 </script>
 
 <Search

--- a/tests/Search/SearchExpandable.test.svelte
+++ b/tests/Search/SearchExpandable.test.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
-  import { Search } from "carbon-components-svelte";
+import { Search } from "carbon-components-svelte";
 
-  let expanded = false;
-  let value = "";
+let expanded = false;
+let value = "";
 </script>
 
 <Search

--- a/tests/Search/SearchSkeleton.test.svelte
+++ b/tests/Search/SearchSkeleton.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Search } from "carbon-components-svelte";
+import { Search } from "carbon-components-svelte";
 </script>
 
 <Search skeleton labelText="Default skeleton" />

--- a/tests/Select/Select.falsy.test.svelte
+++ b/tests/Select/Select.falsy.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Select, SelectItem } from "carbon-components-svelte";
+import { Select, SelectItem } from "carbon-components-svelte";
 </script>
 
 <Select labelText="Falsy text">

--- a/tests/Select/Select.group.test.svelte
+++ b/tests/Select/Select.group.test.svelte
@@ -1,11 +1,7 @@
 <script lang="ts">
-  import {
-    Select,
-    SelectItem,
-    SelectItemGroup,
-  } from "carbon-components-svelte";
+import { Select, SelectItem, SelectItemGroup } from "carbon-components-svelte";
 
-  export let selected: string | number | undefined = undefined;
+export let selected: string | number | undefined = undefined;
 </script>
 
 <Select bind:selected data-testid="select-group">

--- a/tests/Select/Select.skeleton.test.svelte
+++ b/tests/Select/Select.skeleton.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { SelectSkeleton } from "carbon-components-svelte";
+import { SelectSkeleton } from "carbon-components-svelte";
 </script>
 
 <SelectSkeleton data-testid="select-skeleton" />

--- a/tests/Select/Select.test.svelte
+++ b/tests/Select/Select.test.svelte
@@ -1,18 +1,18 @@
 <script lang="ts">
-  import { Select, SelectItem } from "carbon-components-svelte";
+import { Select, SelectItem } from "carbon-components-svelte";
 
-  export let selected: string | number | undefined = undefined;
-  export let disabled = false;
-  export let invalid = false;
-  export let invalidText = "";
-  export let warn = false;
-  export let warnText = "";
-  export let helperText = "";
-  export let hideLabel = false;
-  export let labelText = "Select label";
-  export let size: "sm" | "xl" | undefined = undefined;
-  export let inline = false;
-  export let light = false;
+export let selected: string | number | undefined = undefined;
+export let disabled = false;
+export let invalid = false;
+export let invalidText = "";
+export let warn = false;
+export let warnText = "";
+export let helperText = "";
+export let hideLabel = false;
+export let labelText = "Select label";
+export let size: "sm" | "xl" | undefined = undefined;
+export let inline = false;
+export let light = false;
 </script>
 
 <Select

--- a/tests/SelectableDataTable.test.svelte
+++ b/tests/SelectableDataTable.test.svelte
@@ -1,24 +1,24 @@
 <script lang="ts">
-  import { DataTable } from "carbon-components-svelte";
-  import type { ComponentProps } from "svelte";
-  const headers = [
-    { key: "name", value: "Name" },
-    { key: "port", value: "Port" },
-    { key: "rule", value: "Rule" },
-  ] as const;
+import { DataTable } from "carbon-components-svelte";
+import type { ComponentProps } from "svelte";
+const headers = [
+  { key: "name", value: "Name" },
+  { key: "port", value: "Port" },
+  { key: "rule", value: "Rule" },
+] as const;
 
-  const rows = [
-    { id: "a", name: "Load Balancer 3", port: 3000, rule: "Round robin" },
-    { id: "b", name: "Load Balancer 1", port: 443, rule: "Round robin" },
-    { id: "c", name: "Load Balancer 2", port: 80, rule: "DNS delegation" },
-    { id: "d", name: "Load Balancer 6", port: 3000, rule: "Round robin" },
-    { id: "e", name: "Load Balancer 4", port: 443, rule: "Round robin" },
-    { id: "f", name: "Load Balancer 5", port: 80, rule: "DNS delegation" },
-  ];
+const rows = [
+  { id: "a", name: "Load Balancer 3", port: 3000, rule: "Round robin" },
+  { id: "b", name: "Load Balancer 1", port: 443, rule: "Round robin" },
+  { id: "c", name: "Load Balancer 2", port: 80, rule: "DNS delegation" },
+  { id: "d", name: "Load Balancer 6", port: 3000, rule: "Round robin" },
+  { id: "e", name: "Load Balancer 4", port: 443, rule: "Round robin" },
+  { id: "f", name: "Load Balancer 5", port: 80, rule: "DNS delegation" },
+];
 
-  let selectedRowIds: ComponentProps<DataTable>["selectedRowIds"] = [];
+let selectedRowIds: ComponentProps<DataTable>["selectedRowIds"] = [];
 
-  $: console.log("selectedRowIds", selectedRowIds);
+$: console.log("selectedRowIds", selectedRowIds);
 </script>
 
 <DataTable selectable bind:selectedRowIds {headers} {rows} />

--- a/tests/SelectableTile.test.svelte
+++ b/tests/SelectableTile.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { SelectableTile } from "carbon-components-svelte";
+import { SelectableTile } from "carbon-components-svelte";
 </script>
 
 <SelectableTile selected>Multi-select Tile</SelectableTile>

--- a/tests/SkeletonPlaceholder/SkeletonPlaceholder.test.svelte
+++ b/tests/SkeletonPlaceholder/SkeletonPlaceholder.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { SkeletonPlaceholder } from "carbon-components-svelte";
+import { SkeletonPlaceholder } from "carbon-components-svelte";
 </script>
 
 <SkeletonPlaceholder

--- a/tests/SkeletonText/SkeletonText.test.svelte
+++ b/tests/SkeletonText/SkeletonText.test.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
-  import { SkeletonText } from "carbon-components-svelte";
+import { SkeletonText } from "carbon-components-svelte";
 
-  export let lines = 3;
-  export let heading = false;
-  export let paragraph = false;
-  export let width = "100%";
+export let lines = 3;
+export let heading = false;
+export let paragraph = false;
+export let width = "100%";
 </script>
 
 <SkeletonText

--- a/tests/Slider/Slider.test.svelte
+++ b/tests/Slider/Slider.test.svelte
@@ -1,18 +1,18 @@
 <script lang="ts">
-  import { Slider } from "carbon-components-svelte";
+import { Slider } from "carbon-components-svelte";
 
-  let value = 0;
+let value = 0;
 
-  export let disabled = false;
-  export let invalid = false;
-  export let required = false;
-  export let minLabel = "";
-  export let maxLabel = "";
-  export let hideTextInput = false;
-  export let fullWidth = false;
-  export let min = 0;
-  export let max = 100;
-  export let step = 1;
+export let disabled = false;
+export let invalid = false;
+export let required = false;
+export let minLabel = "";
+export let maxLabel = "";
+export let hideTextInput = false;
+export let fullWidth = false;
+export let min = 0;
+export let max = 100;
+export let step = 1;
 </script>
 
 <Slider

--- a/tests/StructuredList/StructuredList.test.svelte
+++ b/tests/StructuredList/StructuredList.test.svelte
@@ -1,19 +1,19 @@
 <script lang="ts">
-  import {
-    StructuredList,
-    StructuredListBody,
-    StructuredListHead,
-    StructuredListCell,
-    StructuredListRow,
-    StructuredListInput,
-  } from "carbon-components-svelte";
-  import CheckmarkFilled from "carbon-icons-svelte/lib/CheckmarkFilled.svelte";
-  import type { ComponentProps } from "svelte";
+import {
+  StructuredList,
+  StructuredListBody,
+  StructuredListHead,
+  StructuredListCell,
+  StructuredListRow,
+  StructuredListInput,
+} from "carbon-components-svelte";
+import CheckmarkFilled from "carbon-icons-svelte/lib/CheckmarkFilled.svelte";
+import type { ComponentProps } from "svelte";
 
-  export let selected: ComponentProps<StructuredList>["selected"] = undefined;
-  export let condensed: ComponentProps<StructuredList>["condensed"] = false;
-  export let flush: ComponentProps<StructuredList>["flush"] = false;
-  export let selection: ComponentProps<StructuredList>["selection"] = false;
+export let selected: ComponentProps<StructuredList>["selected"] = undefined;
+export let condensed: ComponentProps<StructuredList>["condensed"] = false;
+export let flush: ComponentProps<StructuredList>["flush"] = false;
+export let selection: ComponentProps<StructuredList>["selection"] = false;
 </script>
 
 <StructuredList

--- a/tests/StructuredList/StructuredListCustom.test.svelte
+++ b/tests/StructuredList/StructuredListCustom.test.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
-  import {
-    StructuredList,
-    StructuredListBody,
-    StructuredListHead,
-    StructuredListCell,
-    StructuredListRow,
-  } from "carbon-components-svelte";
+import {
+  StructuredList,
+  StructuredListBody,
+  StructuredListHead,
+  StructuredListCell,
+  StructuredListRow,
+} from "carbon-components-svelte";
 </script>
 
 <StructuredList>

--- a/tests/Tabs/Tabs.test.svelte
+++ b/tests/Tabs/Tabs.test.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
-  import { Tabs, Tab, TabContent } from "carbon-components-svelte";
+import { Tabs, Tab, TabContent } from "carbon-components-svelte";
 
-  export let selected = 0;
-  export let type: "default" | "container" = "default";
-  export let autoWidth = false;
-  export let iconDescription = "Show menu options";
-  export let triggerHref = "#";
+export let selected = 0;
+export let type: "default" | "container" = "default";
+export let autoWidth = false;
+export let iconDescription = "Show menu options";
+export let triggerHref = "#";
 </script>
 
 <Tabs

--- a/tests/Tag/Tag.test.svelte
+++ b/tests/Tag/Tag.test.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  import { Tag } from "carbon-components-svelte";
-  import Add from "carbon-icons-svelte/lib/Add.svelte";
+import { Tag } from "carbon-components-svelte";
+import Add from "carbon-icons-svelte/lib/Add.svelte";
 </script>
 
 <Tag class="my-class" style="margin: 1rem;">IBM Cloud</Tag>

--- a/tests/TextArea/TextArea.test.svelte
+++ b/tests/TextArea/TextArea.test.svelte
@@ -1,23 +1,23 @@
 <script lang="ts">
-  import { TextArea } from "carbon-components-svelte";
-  import type { ComponentProps } from "svelte";
+import { TextArea } from "carbon-components-svelte";
+import type { ComponentProps } from "svelte";
 
-  export let value: ComponentProps<TextArea>["value"] = "";
-  export let placeholder = "";
-  export let cols = 50;
-  export let rows = 4;
-  export let maxCount: ComponentProps<TextArea>["maxCount"] = undefined;
-  export let light = false;
-  export let disabled = false;
-  export let readonly = false;
-  export let helperText = "";
-  export let labelText = "App description";
-  export let hideLabel = false;
-  export let invalid = false;
-  export let invalidText = "";
-  export let id = "ccs-test";
-  export let name: ComponentProps<TextArea>["name"] = undefined;
-  export let ref: ComponentProps<TextArea>["ref"] = null;
+export let value: ComponentProps<TextArea>["value"] = "";
+export let placeholder = "";
+export let cols = 50;
+export let rows = 4;
+export let maxCount: ComponentProps<TextArea>["maxCount"] = undefined;
+export let light = false;
+export let disabled = false;
+export let readonly = false;
+export let helperText = "";
+export let labelText = "App description";
+export let hideLabel = false;
+export let invalid = false;
+export let invalidText = "";
+export let id = "ccs-test";
+export let name: ComponentProps<TextArea>["name"] = undefined;
+export let ref: ComponentProps<TextArea>["ref"] = null;
 </script>
 
 <TextArea

--- a/tests/TextArea/TextAreaCustom.test.svelte
+++ b/tests/TextArea/TextAreaCustom.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { TextArea } from "carbon-components-svelte";
+import { TextArea } from "carbon-components-svelte";
 </script>
 
 <TextArea labelText="Custom label">

--- a/tests/TextInput/TextInput.test.svelte
+++ b/tests/TextInput/TextInput.test.svelte
@@ -1,26 +1,26 @@
 <script lang="ts">
-  import { TextInput } from "carbon-components-svelte";
-  import type { ComponentProps } from "svelte";
+import { TextInput } from "carbon-components-svelte";
+import type { ComponentProps } from "svelte";
 
-  export let value: ComponentProps<TextInput>["value"] = "";
-  export let placeholder = "";
-  export let size: ComponentProps<TextInput>["size"] = undefined;
-  export let light = false;
-  export let disabled = false;
-  export let helperText = "";
-  export let labelText = "User name";
-  export let hideLabel = false;
-  export let invalid = false;
-  export let invalidText = "";
-  export let warn = false;
-  export let warnText = "";
-  export let id = "ccs-test";
-  export let name: ComponentProps<TextInput>["name"] = undefined;
-  export let ref: ComponentProps<TextInput>["ref"] = null;
-  export let required = false;
-  export let inline = false;
-  export let readonly = false;
-  export let type: ComponentProps<TextInput>["type"] = "text";
+export let value: ComponentProps<TextInput>["value"] = "";
+export let placeholder = "";
+export let size: ComponentProps<TextInput>["size"] = undefined;
+export let light = false;
+export let disabled = false;
+export let helperText = "";
+export let labelText = "User name";
+export let hideLabel = false;
+export let invalid = false;
+export let invalidText = "";
+export let warn = false;
+export let warnText = "";
+export let id = "ccs-test";
+export let name: ComponentProps<TextInput>["name"] = undefined;
+export let ref: ComponentProps<TextInput>["ref"] = null;
+export let required = false;
+export let inline = false;
+export let readonly = false;
+export let type: ComponentProps<TextInput>["type"] = "text";
 </script>
 
 <TextInput

--- a/tests/TextInput/TextInputCustom.test.svelte
+++ b/tests/TextInput/TextInputCustom.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { TextInput } from "carbon-components-svelte";
+import { TextInput } from "carbon-components-svelte";
 </script>
 
 <TextInput labelText="Custom label">

--- a/tests/Theme/Theme.test.svelte
+++ b/tests/Theme/Theme.test.svelte
@@ -1,12 +1,12 @@
 <svelte:options accessors />
 
 <script lang="ts">
-  import { Theme } from "carbon-components-svelte";
-  import type { CarbonTheme } from "carbon-components-svelte/Theme/Theme.svelte";
+import { Theme } from "carbon-components-svelte";
+import type { CarbonTheme } from "carbon-components-svelte/Theme/Theme.svelte";
 
-  export let theme: CarbonTheme = "white";
-  export let persist = false;
-  export let tokens = {};
+export let theme: CarbonTheme = "white";
+export let persist = false;
+export let tokens = {};
 </script>
 
 <div data-testid="theme-wrapper">

--- a/tests/Theme/ThemeSelect.test.svelte
+++ b/tests/Theme/ThemeSelect.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Theme } from "carbon-components-svelte";
+import { Theme } from "carbon-components-svelte";
 </script>
 
 <Theme

--- a/tests/Theme/ThemeSelectCustom.test.svelte
+++ b/tests/Theme/ThemeSelectCustom.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Theme } from "carbon-components-svelte";
+import { Theme } from "carbon-components-svelte";
 </script>
 
 <Theme

--- a/tests/Theme/ThemeToggle.test.svelte
+++ b/tests/Theme/ThemeToggle.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Theme } from "carbon-components-svelte";
+import { Theme } from "carbon-components-svelte";
 </script>
 
 <Theme

--- a/tests/Theme/ThemeToggleCustom.test.svelte
+++ b/tests/Theme/ThemeToggleCustom.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Theme } from "carbon-components-svelte";
+import { Theme } from "carbon-components-svelte";
 </script>
 
 <Theme

--- a/tests/Tile/ClickableTile.test.svelte
+++ b/tests/Tile/ClickableTile.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { ClickableTile } from "carbon-components-svelte";
+import { ClickableTile } from "carbon-components-svelte";
 </script>
 
 <ClickableTile href="https://www.carbondesignsystem.com/">

--- a/tests/Tile/Tile.test.svelte
+++ b/tests/Tile/Tile.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Tile } from "carbon-components-svelte";
+import { Tile } from "carbon-components-svelte";
 </script>
 
 <Tile>Default tile</Tile>

--- a/tests/TimePicker/TimePicker.test.svelte
+++ b/tests/TimePicker/TimePicker.test.svelte
@@ -1,26 +1,26 @@
 <script lang="ts">
-  import {
-    TimePicker,
-    TimePickerSelect,
-    SelectItem,
-  } from "carbon-components-svelte";
-  import type { ComponentProps } from "svelte";
+import {
+  TimePicker,
+  TimePickerSelect,
+  SelectItem,
+} from "carbon-components-svelte";
+import type { ComponentProps } from "svelte";
 
-  export let size: ComponentProps<TimePicker>["size"] = undefined;
-  export let value: ComponentProps<TimePicker>["value"] = "";
-  export let placeholder: ComponentProps<TimePicker>["placeholder"] = "hh:mm";
-  export let pattern: ComponentProps<TimePicker>["pattern"] =
-    "(1[012]|[1-9]):[0-5][0-9](\\s)?";
-  export let maxlength: ComponentProps<TimePicker>["maxlength"] = 5;
-  export let light: ComponentProps<TimePicker>["light"] = false;
-  export let disabled: ComponentProps<TimePicker>["disabled"] = false;
-  export let labelText: ComponentProps<TimePicker>["labelText"] = "Time";
-  export let hideLabel: ComponentProps<TimePicker>["hideLabel"] = false;
-  export let invalid: ComponentProps<TimePicker>["invalid"] = false;
-  export let invalidText: ComponentProps<TimePicker>["invalidText"] = "";
-  export let id: ComponentProps<TimePicker>["id"] = "ccs-test";
-  export let name: ComponentProps<TimePicker>["name"] = "test-time";
-  export let ref: ComponentProps<TimePicker>["ref"] = null;
+export let size: ComponentProps<TimePicker>["size"] = undefined;
+export let value: ComponentProps<TimePicker>["value"] = "";
+export let placeholder: ComponentProps<TimePicker>["placeholder"] = "hh:mm";
+export let pattern: ComponentProps<TimePicker>["pattern"] =
+  "(1[012]|[1-9]):[0-5][0-9](\\s)?";
+export let maxlength: ComponentProps<TimePicker>["maxlength"] = 5;
+export let light: ComponentProps<TimePicker>["light"] = false;
+export let disabled: ComponentProps<TimePicker>["disabled"] = false;
+export let labelText: ComponentProps<TimePicker>["labelText"] = "Time";
+export let hideLabel: ComponentProps<TimePicker>["hideLabel"] = false;
+export let invalid: ComponentProps<TimePicker>["invalid"] = false;
+export let invalidText: ComponentProps<TimePicker>["invalidText"] = "";
+export let id: ComponentProps<TimePicker>["id"] = "ccs-test";
+export let name: ComponentProps<TimePicker>["name"] = "test-time";
+export let ref: ComponentProps<TimePicker>["ref"] = null;
 </script>
 
 <TimePicker

--- a/tests/TimePicker/TimePickerCustom.test.svelte
+++ b/tests/TimePicker/TimePickerCustom.test.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-  import {
-    TimePicker,
-    TimePickerSelect,
-    SelectItem,
-  } from "carbon-components-svelte";
+import {
+  TimePicker,
+  TimePickerSelect,
+  SelectItem,
+} from "carbon-components-svelte";
 </script>
 
 <TimePicker labelText="Custom label">

--- a/tests/ToastNotification/ToastNotification.close.test.svelte
+++ b/tests/ToastNotification/ToastNotification.close.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { ToastNotification } from "carbon-components-svelte";
+import { ToastNotification } from "carbon-components-svelte";
 </script>
 
 <ToastNotification

--- a/tests/ToastNotification/ToastNotification.test.svelte
+++ b/tests/ToastNotification/ToastNotification.test.svelte
@@ -1,18 +1,18 @@
 <script lang="ts">
-  import { ToastNotification } from "carbon-components-svelte";
-  import type { ComponentProps } from "svelte";
+import { ToastNotification } from "carbon-components-svelte";
+import type { ComponentProps } from "svelte";
 
-  export let kind: ComponentProps<ToastNotification>["kind"] = "error";
-  export let lowContrast = false;
-  export let timeout = 0;
-  export let role = "alert";
-  export let title = "Error";
-  export let subtitle = "An internal server error occurred.";
-  export let caption = "2024-03-21 12:00:00";
-  export let hideCloseButton = false;
-  export let fullWidth = false;
-  export let statusIconDescription = "";
-  export let closeButtonDescription = "";
+export let kind: ComponentProps<ToastNotification>["kind"] = "error";
+export let lowContrast = false;
+export let timeout = 0;
+export let role = "alert";
+export let title = "Error";
+export let subtitle = "An internal server error occurred.";
+export let caption = "2024-03-21 12:00:00";
+export let hideCloseButton = false;
+export let fullWidth = false;
+export let statusIconDescription = "";
+export let closeButtonDescription = "";
 </script>
 
 <ToastNotification

--- a/tests/ToastNotification/ToastNotificationCustom.test.svelte
+++ b/tests/ToastNotification/ToastNotificationCustom.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { ToastNotification } from "carbon-components-svelte";
+import { ToastNotification } from "carbon-components-svelte";
 </script>
 
 <ToastNotification kind="warning">

--- a/tests/Toggle/Toggle.test.svelte
+++ b/tests/Toggle/Toggle.test.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-  import { Toggle } from "carbon-components-svelte";
+import { Toggle } from "carbon-components-svelte";
 
-  let toggled = false;
+let toggled = false;
 </script>
 
 <Toggle

--- a/tests/Tooltip/TooltipAlignments.test.svelte
+++ b/tests/Tooltip/TooltipAlignments.test.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-  import { Tooltip } from "carbon-components-svelte";
+import { Tooltip } from "carbon-components-svelte";
 
-  const alignments = ["start", "center", "end"] as const;
+const alignments = ["start", "center", "end"] as const;
 </script>
 
 <div>

--- a/tests/Tooltip/TooltipCustomContent.test.svelte
+++ b/tests/Tooltip/TooltipCustomContent.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Tooltip } from "carbon-components-svelte";
+import { Tooltip } from "carbon-components-svelte";
 </script>
 
 <Tooltip open={true} iconDescription="Information">

--- a/tests/Tooltip/TooltipCustomIcon.test.svelte
+++ b/tests/Tooltip/TooltipCustomIcon.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Tooltip } from "carbon-components-svelte";
+import { Tooltip } from "carbon-components-svelte";
 </script>
 
 <Tooltip iconDescription="Information">

--- a/tests/Tooltip/TooltipDefault.test.svelte
+++ b/tests/Tooltip/TooltipDefault.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Tooltip } from "carbon-components-svelte";
+import { Tooltip } from "carbon-components-svelte";
 </script>
 
 <Tooltip iconDescription="Information" />

--- a/tests/Tooltip/TooltipDirections.test.svelte
+++ b/tests/Tooltip/TooltipDirections.test.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-  import { Tooltip } from "carbon-components-svelte";
+import { Tooltip } from "carbon-components-svelte";
 
-  const directions = ["top", "right", "bottom", "left"] as const;
+const directions = ["top", "right", "bottom", "left"] as const;
 </script>
 
 <div>

--- a/tests/Tooltip/TooltipEvents.test.svelte
+++ b/tests/Tooltip/TooltipEvents.test.svelte
@@ -1,16 +1,16 @@
 <script lang="ts">
-  import { Tooltip } from "carbon-components-svelte";
+import { Tooltip } from "carbon-components-svelte";
 
-  let openCount = 0;
-  let closeCount = 0;
+let openCount = 0;
+let closeCount = 0;
 
-  function handleOpen() {
-    openCount += 1;
-  }
+function handleOpen() {
+  openCount += 1;
+}
 
-  function handleClose() {
-    closeCount += 1;
-  }
+function handleClose() {
+  closeCount += 1;
+}
 </script>
 
 <div>

--- a/tests/Tooltip/TooltipHideIcon.test.svelte
+++ b/tests/Tooltip/TooltipHideIcon.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Tooltip } from "carbon-components-svelte";
+import { Tooltip } from "carbon-components-svelte";
 </script>
 
 <Tooltip

--- a/tests/Tooltip/TooltipOpen.test.svelte
+++ b/tests/Tooltip/TooltipOpen.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Tooltip } from "carbon-components-svelte";
+import { Tooltip } from "carbon-components-svelte";
 </script>
 
 <Tooltip open={true} iconDescription="Information">

--- a/tests/TooltipDefinition/TooltipDefinition.test.svelte
+++ b/tests/TooltipDefinition/TooltipDefinition.test.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
-  import { TooltipDefinition } from "carbon-components-svelte";
+import { TooltipDefinition } from "carbon-components-svelte";
 
-  export let tooltipText = "Test tooltip text";
-  export let open = false;
-  export let align: "start" | "center" | "end" = "center";
-  export let direction: "top" | "bottom" = "bottom";
-  export let id = "test-tooltip";
-  export let triggerContent = "Tooltip trigger";
+export let tooltipText = "Test tooltip text";
+export let open = false;
+export let align: "start" | "center" | "end" = "center";
+export let direction: "top" | "bottom" = "bottom";
+export let id = "test-tooltip";
+export let triggerContent = "Tooltip trigger";
 </script>
 
 <TooltipDefinition

--- a/tests/TooltipIcon/TooltipIcon.test.svelte
+++ b/tests/TooltipIcon/TooltipIcon.test.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
-  import { TooltipIcon } from "carbon-components-svelte";
-  import Carbon from "carbon-icons-svelte/lib/Carbon.svelte";
+import { TooltipIcon } from "carbon-components-svelte";
+import Carbon from "carbon-icons-svelte/lib/Carbon.svelte";
 
-  export let tooltipText = "Test tooltip text";
-  export let disabled = false;
-  export let align: "start" | "center" | "end" = "center";
-  export let direction: "top" | "right" | "bottom" | "left" = "bottom";
-  export let id = "test-tooltip";
-  export let icon = Carbon;
+export let tooltipText = "Test tooltip text";
+export let disabled = false;
+export let align: "start" | "center" | "end" = "center";
+export let direction: "top" | "right" | "bottom" | "left" = "bottom";
+export let id = "test-tooltip";
+export let icon = Carbon;
 </script>
 
 <TooltipIcon

--- a/tests/TreeView/TreeView.hierarchy.test.svelte
+++ b/tests/TreeView/TreeView.hierarchy.test.svelte
@@ -1,36 +1,36 @@
 <script lang="ts">
-  import { Button, TreeView } from "carbon-components-svelte";
-  import { toHierarchy } from "../../src/utils/toHierarchy";
-  import type { TreeNodeId } from "carbon-components-svelte/TreeView/TreeView.svelte";
-  import Analytics from "carbon-icons-svelte/lib/Analytics.svelte";
+import { Button, TreeView } from "carbon-components-svelte";
+import { toHierarchy } from "../../src/utils/toHierarchy";
+import type { TreeNodeId } from "carbon-components-svelte/TreeView/TreeView.svelte";
+import Analytics from "carbon-icons-svelte/lib/Analytics.svelte";
 
-  let treeview: TreeView;
-  let activeId: TreeNodeId = "";
-  let selectedIds: TreeNodeId[] = [];
-  let expandedIds: TreeNodeId[] = [];
-  let nodes = toHierarchy(
-    [
-      { id: 0, text: "AI / Machine learning", icon: Analytics },
-      { id: 1, text: "Analytics" },
-      { id: 2, text: "IBM Analytics Engine", pid: 1 },
-      { id: 3, text: "Apache Spark", pid: 2 },
-      { id: 4, text: "Hadoop", pid: 2 },
-      { id: 5, text: "IBM Cloud SQL Query", pid: 1 },
-      { id: 6, text: "IBM Db2 Warehouse on Cloud", pid: 1 },
-      { id: 7, text: "Blockchain" },
-      { id: 8, text: "IBM Blockchain Platform", pid: 7 },
-      { id: 9, text: "Databases" },
-      { id: 10, text: "IBM Cloud Databases for Elasticsearch", pid: 9 },
-      { id: 11, text: "IBM Cloud Databases for Enterprise DB", pid: 9 },
-      { id: 12, text: "IBM Cloud Databases for MongoDB", pid: 9 },
-      { id: 13, text: "IBM Cloud Databases for PostgreSQL", pid: 9 },
-      { id: 14, text: "Integration", disabled: true },
-      { id: 15, text: "IBM API Connect", disabled: true, pid: 14 },
-    ],
-    (node) => node.pid,
-  );
+let treeview: TreeView;
+let activeId: TreeNodeId = "";
+let selectedIds: TreeNodeId[] = [];
+let expandedIds: TreeNodeId[] = [];
+let nodes = toHierarchy(
+  [
+    { id: 0, text: "AI / Machine learning", icon: Analytics },
+    { id: 1, text: "Analytics" },
+    { id: 2, text: "IBM Analytics Engine", pid: 1 },
+    { id: 3, text: "Apache Spark", pid: 2 },
+    { id: 4, text: "Hadoop", pid: 2 },
+    { id: 5, text: "IBM Cloud SQL Query", pid: 1 },
+    { id: 6, text: "IBM Db2 Warehouse on Cloud", pid: 1 },
+    { id: 7, text: "Blockchain" },
+    { id: 8, text: "IBM Blockchain Platform", pid: 7 },
+    { id: 9, text: "Databases" },
+    { id: 10, text: "IBM Cloud Databases for Elasticsearch", pid: 9 },
+    { id: 11, text: "IBM Cloud Databases for Enterprise DB", pid: 9 },
+    { id: 12, text: "IBM Cloud Databases for MongoDB", pid: 9 },
+    { id: 13, text: "IBM Cloud Databases for PostgreSQL", pid: 9 },
+    { id: 14, text: "Integration", disabled: true },
+    { id: 15, text: "IBM API Connect", disabled: true, pid: 14 },
+  ],
+  (node) => node.pid,
+);
 
-  $: console.log("selectedIds", selectedIds);
+$: console.log("selectedIds", selectedIds);
 </script>
 
 <TreeView

--- a/tests/TreeView/TreeView.test.svelte
+++ b/tests/TreeView/TreeView.test.svelte
@@ -1,55 +1,55 @@
 <script lang="ts">
-  import type { ComponentProps } from "svelte";
-  import { Button, TreeView } from "carbon-components-svelte";
-  import type { TreeNodeId } from "carbon-components-svelte/TreeView/TreeView.svelte";
-  import Analytics from "carbon-icons-svelte/lib/Analytics.svelte";
+import type { ComponentProps } from "svelte";
+import { Button, TreeView } from "carbon-components-svelte";
+import type { TreeNodeId } from "carbon-components-svelte/TreeView/TreeView.svelte";
+import Analytics from "carbon-icons-svelte/lib/Analytics.svelte";
 
-  let treeview: TreeView;
-  let activeId: TreeNodeId = "";
-  let selectedIds: TreeNodeId[] = [];
-  let expandedIds: TreeNodeId[] = [];
-  let nodes: ComponentProps<TreeView>["nodes"] = [
-    { id: 0, text: "AI / Machine learning", icon: Analytics },
-    {
-      id: 1,
-      text: "Analytics",
-      nodes: [
-        {
-          id: 2,
-          text: "IBM Analytics Engine",
-          nodes: [
-            { id: 3, text: "Apache Spark" },
-            { id: 4, text: "Hadoop" },
-          ],
-        },
-        { id: 5, text: "IBM Cloud SQL Query" },
-        { id: 6, text: "IBM Db2 Warehouse on Cloud" },
-      ],
-    },
-    {
-      id: 7,
-      text: "Blockchain",
-      nodes: [{ id: 8, text: "IBM Blockchain Platform" }],
-    },
-    {
-      id: 9,
-      text: "Databases",
-      nodes: [
-        { id: 10, text: "IBM Cloud Databases for Elasticsearch" },
-        { id: 11, text: "IBM Cloud Databases for Enterprise DB" },
-        { id: 12, text: "IBM Cloud Databases for MongoDB" },
-        { id: 13, text: "IBM Cloud Databases for PostgreSQL" },
-      ],
-    },
-    {
-      id: 14,
-      text: "Integration",
-      disabled: true,
-      nodes: [{ id: 15, text: "IBM API Connect", disabled: true }],
-    },
-  ];
+let treeview: TreeView;
+let activeId: TreeNodeId = "";
+let selectedIds: TreeNodeId[] = [];
+let expandedIds: TreeNodeId[] = [];
+let nodes: ComponentProps<TreeView>["nodes"] = [
+  { id: 0, text: "AI / Machine learning", icon: Analytics },
+  {
+    id: 1,
+    text: "Analytics",
+    nodes: [
+      {
+        id: 2,
+        text: "IBM Analytics Engine",
+        nodes: [
+          { id: 3, text: "Apache Spark" },
+          { id: 4, text: "Hadoop" },
+        ],
+      },
+      { id: 5, text: "IBM Cloud SQL Query" },
+      { id: 6, text: "IBM Db2 Warehouse on Cloud" },
+    ],
+  },
+  {
+    id: 7,
+    text: "Blockchain",
+    nodes: [{ id: 8, text: "IBM Blockchain Platform" }],
+  },
+  {
+    id: 9,
+    text: "Databases",
+    nodes: [
+      { id: 10, text: "IBM Cloud Databases for Elasticsearch" },
+      { id: 11, text: "IBM Cloud Databases for Enterprise DB" },
+      { id: 12, text: "IBM Cloud Databases for MongoDB" },
+      { id: 13, text: "IBM Cloud Databases for PostgreSQL" },
+    ],
+  },
+  {
+    id: 14,
+    text: "Integration",
+    disabled: true,
+    nodes: [{ id: 15, text: "IBM API Connect", disabled: true }],
+  },
+];
 
-  $: console.log("selectedIds", selectedIds);
+$: console.log("selectedIds", selectedIds);
 </script>
 
 <TreeView

--- a/tests/Truncate/Truncate.test.svelte
+++ b/tests/Truncate/Truncate.test.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-  import { Truncate } from "carbon-components-svelte";
+import { Truncate } from "carbon-components-svelte";
 
-  export let clamp: "end" | "front" = "end";
-  export let text =
-    "This is a long text that should be truncated when it exceeds the available space";
+export let clamp: "end" | "front" = "end";
+export let text =
+  "This is a long text that should be truncated when it exceeds the available space";
 </script>
 
 <Truncate {clamp}>

--- a/tests/Truncate/TruncateAction.test.svelte
+++ b/tests/Truncate/TruncateAction.test.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
-  import { truncate } from "carbon-components-svelte";
+import { truncate } from "carbon-components-svelte";
 
-  export let clamp: "end" | "front" = "end";
-  export let text =
-    "This is a long text that should be truncated when it exceeds the available space";
-  export let element: "h1" | "h2" | "h3" | "h4" | "p" | "span" = "p";
+export let clamp: "end" | "front" = "end";
+export let text =
+  "This is a long text that should be truncated when it exceeds the available space";
+export let element: "h1" | "h2" | "h3" | "h4" | "p" | "span" = "p";
 </script>
 
 {#if element === "h1"}

--- a/tests/UnorderedList/UnorderedList.test.svelte
+++ b/tests/UnorderedList/UnorderedList.test.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
-  import { UnorderedList, ListItem } from "carbon-components-svelte";
+import { UnorderedList, ListItem } from "carbon-components-svelte";
 
-  export let nested = false;
-  export let expressive = false;
-  export let items: string[] = ["Item 1", "Item 2", "Item 3"];
-  export let nestedItems: string[] = [];
+export let nested = false;
+export let expressive = false;
+export let items: string[] = ["Item 1", "Item 2", "Item 3"];
+export let nestedItems: string[] = [];
 </script>
 
 <UnorderedList


### PR DESCRIPTION
Interesting experiment.

Biome is much faster, and it does linting. However, this is currently a no-go as Biome only supports formatting inside the script block for Svelte files.

## Prettier (format only)

<img width="1140" alt="Screenshot 2025-03-25 at 5 11 50 PM" src="https://github.com/user-attachments/assets/9f9af72e-86d3-4a30-8783-56cabc81bd12" />

## Biome (format + lint)

<img width="1145" alt="Screenshot 2025-03-25 at 5 11 21 PM" src="https://github.com/user-attachments/assets/4a9cd289-e66d-41db-bbd4-b6902acf61e6" />
