### PR TITLE
perf(to-hierarchy): optimize to use single-pass approach

### DIFF
--- a/src/utils/toHierarchy.js
+++ b/src/utils/toHierarchy.js
@@ -13,35 +13,22 @@
 export function toHierarchy(flatArray, getParentId) {
   /** @type {NodeLike[]} */
   const tree = [];
-  const childrenOf = new Map();
-  const itemsMap = new Map(flatArray.map((item) => [item.id, item]));
+  const nodeMap = new Map();
 
-  flatArray.forEach((item) => {
+  for (const item of flatArray) {
     const parentId = getParentId(item);
+    nodeMap.set(item.id, item);
 
-    // Only create nodes array if we have children.
-    const children = childrenOf.get(item.id);
-    if (children) {
-      item.nodes = children;
-    }
-
-    // Check if parentId exists using Map instead of array lookup.
-    const parentExists = parentId && itemsMap.has(parentId);
-
-    if (parentId && parentExists) {
-      if (!childrenOf.has(parentId)) {
-        childrenOf.set(parentId, []);
-      }
-      childrenOf.get(parentId).push(item);
-
-      const parent = itemsMap.get(parentId);
-      if (parent) {
-        parent.nodes = childrenOf.get(parentId);
-      }
-    } else {
+    if (!parentId || !nodeMap.has(parentId)) {
       tree.push(item);
+    } else {
+      const parent = nodeMap.get(parentId);
+      if (!parent.nodes) {
+        parent.nodes = [];
+      }
+      parent.nodes.push(item);
     }
-  });
+  }
 
   return tree;
 }

--- a/tests/TreeView/toHierarchy.test.ts
+++ b/tests/TreeView/toHierarchy.test.ts
@@ -1,4 +1,4 @@
-import { toHierarchy } from "../../src/utils/toHierarchy";
+import { toHierarchy } from "carbon-components-svelte";
 
 describe("toHierarchy", () => {
   test("should create a flat hierarchy when no items have parents", () => {
@@ -101,5 +101,155 @@ describe("toHierarchy", () => {
     ]);
 
     expect(result[0].nodes?.[0]).not.toHaveProperty("nodes");
+  });
+
+  test("should handle empty input array", () => {
+    const result = toHierarchy<
+      { id: string | number; parentId?: string | number },
+      "parentId"
+    >([], (item) => item.parentId || null);
+    expect(result).toEqual([]);
+  });
+
+  test("should handle non-existent parent IDs", () => {
+    const input = [
+      { id: 1, name: "Root" },
+      { id: 2, name: "Child", pid: 999 },
+    ];
+    const result = toHierarchy(input, (item) => item.pid);
+    expect(result).toEqual([
+      { id: 1, name: "Root" },
+      { id: 2, name: "Child", pid: 999 },
+    ]);
+  });
+
+  test("should handle deeply nested structures", () => {
+    const input = [
+      { id: 1, name: "Level 1" },
+      { id: 2, name: "Level 2", pid: 1 },
+      { id: 3, name: "Level 3", pid: 2 },
+      { id: 4, name: "Level 4", pid: 3 },
+      { id: 5, name: "Level 5", pid: 4 },
+    ];
+    const result = toHierarchy(input, (item) => item.pid);
+    expect(result).toEqual([
+      {
+        id: 1,
+        name: "Level 1",
+        nodes: [
+          {
+            id: 2,
+            name: "Level 2",
+            pid: 1,
+            nodes: [
+              {
+                id: 3,
+                name: "Level 3",
+                pid: 2,
+                nodes: [
+                  {
+                    id: 4,
+                    name: "Level 4",
+                    pid: 3,
+                    nodes: [
+                      {
+                        id: 5,
+                        name: "Level 5",
+                        pid: 4,
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ]);
+  });
+
+  test("should handle mixed ID types", () => {
+    const input = [
+      { id: "root", name: "Root" },
+      { id: 1, name: "Child 1", pid: "root" },
+      { id: "2", name: "Child 2", pid: "root" },
+    ];
+    const result = toHierarchy(input, (item) => item.pid);
+    expect(result).toEqual([
+      {
+        id: "root",
+        name: "Root",
+        nodes: [
+          {
+            id: 1,
+            name: "Child 1",
+            pid: "root",
+          },
+          {
+            id: "2",
+            name: "Child 2",
+            pid: "root",
+          },
+        ],
+      },
+    ]);
+  });
+
+  test("should preserve additional properties", () => {
+    const input = [
+      { id: 1, name: "Root", extra: "data", meta: { key: "value" } },
+      { id: 2, name: "Child", pid: 1, flag: true, count: 42 },
+    ];
+    const result = toHierarchy(input, (item) => item.pid);
+    expect(result).toEqual([
+      {
+        id: 1,
+        name: "Root",
+        extra: "data",
+        meta: { key: "value" },
+        nodes: [
+          {
+            id: 2,
+            name: "Child",
+            pid: 1,
+            flag: true,
+            count: 42,
+          },
+        ],
+      },
+    ]);
+  });
+
+  test("should handle null/undefined parent IDs", () => {
+    const input = [
+      { id: 1, name: "Root 1" },
+      { id: 2, name: "Root 2", pid: null },
+      { id: 3, name: "Root 3", pid: undefined },
+      { id: 4, name: "Child", pid: 1 },
+    ];
+    const result = toHierarchy(input, (item) => item.pid);
+    expect(result).toEqual([
+      {
+        id: 1,
+        name: "Root 1",
+        nodes: [
+          {
+            id: 4,
+            name: "Child",
+            pid: 1,
+          },
+        ],
+      },
+      {
+        id: 2,
+        name: "Root 2",
+        pid: null,
+      },
+      {
+        id: 3,
+        name: "Root 3",
+        pid: undefined,
+      },
+    ]);
   });
 });


### PR DESCRIPTION
Use a single-pass approach (one Map, one for loop) for `toHierarchy` used to flatten nodes.