### PR TITLE
fix(toolbar-search): re-filter rows if `DataTable` rows change

### DIFF
--- a/tests/DataTable/DataTableSearch.test.ts
+++ b/tests/DataTable/DataTableSearch.test.ts
@@ -182,8 +182,7 @@ describe("DataTableSearch", () => {
     });
   });
 
-  // TODO: fix reactivity
-  it.skip("re-filters rows when toggled", async () => {
+  it("re-filters rows when toggled", async () => {
     render(DataTableSearch);
 
     allRowsRendered();


### PR DESCRIPTION
Fixes #2143

Currently, `ToolbarSearch` filtering is not reactive. The component reads `DataTable` rows passed via Svelte context. The expected behavior is that the filtered rows are updated if `rows` passed to `DataTable` (the source of truth) updates.

The solution is to subscribe to the rows passed down from `DataTable`. The key is to only run `filterRows` in the `afterUpdate` callback to avoid an infinite update loop.