### PR TITLE
fix(composed-modal): ignore a11y warning in Svelte 5

### DIFF
--- a/src/ComposedModal/ComposedModal.svelte
+++ b/src/ComposedModal/ComposedModal.svelte
@@ -152,6 +152,7 @@
 >
   <!-- svelte-ignore a11y-click-events-have-key-events -->
   <!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
+  <!-- svelte-ignore a11y_interactive_supports_focus -->
   <div
     bind:this={innerModal}
     role="dialog"


### PR DESCRIPTION
Silence another a11y warning if using Svelte 5.