### PR TITLE
forward on:input from Multiselect text input when filterable prop is true

### DIFF
--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -2419,6 +2419,7 @@ export interface MultiSelectItem {
 | clear      | dispatched | <code>null</code>                                                                                              |
 | blur       | dispatched | <code>FocusEvent &#124; CustomEvent<FocusEvent></code>                                                         |
 | keydown    | forwarded  | --                                                                                                             |
+| input      | forwarded  | --                                                                                                             |
 | keyup      | forwarded  | --                                                                                                             |
 | focus      | forwarded  | --                                                                                                             |
 | paste      | forwarded  | --                                                                                                             |

--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -8945,6 +8945,11 @@
         },
         {
           "type": "forwarded",
+          "name": "input",
+          "element": "input"
+        },
+        {
+          "type": "forwarded",
           "name": "keyup",
           "element": "input"
         },

--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -459,6 +459,7 @@
               if (!open) open = true;
             }
           }}
+          on:input
           on:keyup
           on:focus
           on:blur

--- a/types/MultiSelect/MultiSelect.svelte.d.ts
+++ b/types/MultiSelect/MultiSelect.svelte.d.ts
@@ -255,6 +255,7 @@ export default class MultiSelect extends SvelteComponentTyped<
     clear: CustomEvent<null>;
     blur: FocusEvent | CustomEvent<FocusEvent>;
     keydown: WindowEventMap["keydown"];
+    input: WindowEventMap["input"];
     keyup: WindowEventMap["keyup"];
     focus: WindowEventMap["focus"];
     paste: WindowEventMap["paste"];


### PR DESCRIPTION
I ran into a case where bind:value wasn't very convenient because I'm generating multiple Multiselect components inside an `{#each}` and trying to search for options individually.

```
{#each category as cat}
  <Multiselect on:input={(e) => { searchForOptions(cat.id, e.target.value) }} />
{/each}
```
is a lot easier.