### PR TITLE
fix(checkbox): prevent potential effect loop.

### DIFF
--- a/src/Checkbox/Checkbox.svelte
+++ b/src/Checkbox/Checkbox.svelte
@@ -61,7 +61,7 @@
   const dispatch = createEventDispatcher();
 
   $: useGroup = Array.isArray(group);
-  $: checked = useGroup ? group.includes(value) : checked;
+  $: if (useGroup) checked = group.includes(value);
   $: dispatch("check", checked);
 
   let refLabel = null;


### PR DESCRIPTION
Removes dependency of `checked` on itself which causes issues if an entire object is invalidated that way.

Fixes #2177.