### PR TITLE
fix(toggle): dispatch change event on change, not as effect

### DIFF
--- a/src/Toggle/Toggle.svelte
+++ b/src/Toggle/Toggle.svelte
@@ -39,8 +39,6 @@
   import { createEventDispatcher } from "svelte";
 
   const dispatch = createEventDispatcher();
-
-  $: dispatch("toggle", { toggled });
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
@@ -63,12 +61,14 @@
     checked={toggled}
     on:change={() => {
       toggled = !toggled;
+      dispatch("toggle", { toggled });
     }}
     on:change
     on:keyup={(e) => {
       if (e.key === " " || e.key === "Enter") {
         e.preventDefault();
         toggled = !toggled;
+        dispatch("toggle", { toggled });
       }
     }}
     on:keyup


### PR DESCRIPTION
Changes in this PR make the Svelte implementation consistent with React's behavior where the toggle event acts as onChange wrapper.

In current implementation toggle event is dispatched as an effect whenever `toggled` state is changed. Because of that, toggle event handler runs when component is mounted, which does not make sense.
Also, in React implementation it works differently and `onToggle` handler behaves like a convenient onChange wrapper:
https://stackblitz.com/edit/vitejs-vite-ze6q4qgm?file=src%2FApp.tsx

In svelte, `on:toggle` handler is called when component is mounted, which is very counter-intuitive and is harder to work-around:
https://stackblitz.com/edit/vitejs-vite-eyr7trez?file=src%2FApp.svelte