### PR TITLE
fix(list-box): address a11y issues

### DIFF
--- a/src/ListBox/ListBoxSelection.svelte
+++ b/src/ListBox/ListBoxSelection.svelte
@@ -64,10 +64,9 @@
     <span class:bx--tag__label={true} title={selectionCount}>
       {selectionCount}
     </span>
-    <div
+    <button
       bind:this={ref}
-      role="button"
-      tabindex={disabled ? -1 : 0}
+      type="button"
       class:bx--tag__close-icon={true}
       on:click|preventDefault|stopPropagation={(e) => {
         if (!disabled) {
@@ -84,15 +83,15 @@
       title={description}
     >
       <Close />
-    </div>
+    </button>
   </div>
 {:else}
-  <div
+  <button
     bind:this={ref}
-    role="button"
+    type="button"
+    {disabled}
     aria-label={description}
     title={description}
-    tabindex={disabled ? "-1" : "0"}
     class:bx--list-box__selection={true}
     class:bx--tag--filter={selectionCount}
     class:bx--list-box__selection--multi={selectionCount}
@@ -110,5 +109,5 @@
   >
     {#if selectionCount !== undefined}{selectionCount}{/if}
     <Close />
-  </div>
+  </button>
 {/if}


### PR DESCRIPTION
Supports #2172

This actually may not be the correct fix; I'm opening this PR as a reference.

The issue is more so in the usage of `ListBoxField`, where there are nested buttons. Referencing the upstream React implementation, these buttons should be siblings.

<img width="1132" height="140" alt="Screenshot 2025-08-17 at 12 47 30 PM" src="https://github.com/user-attachments/assets/8657ad5e-92e4-4ab8-893a-558692cb03c0" />
