### PR TITLE
docs(data-table): set width on empty column with overflow menu

### DIFF
--- a/docs/src/pages/framed/DataTable/DataTableAppendColumns.svelte
+++ b/docs/src/pages/framed/DataTable/DataTableAppendColumns.svelte
@@ -9,7 +9,7 @@
     { key: "name", value: "Name" },
     { key: "port", value: "Port" },
     { key: "rule", value: "Rule" },
-    { key: "overflow", empty: true },
+    { key: "overflow", empty: true, width: "72px" },
   ];
 
   const rows = [


### PR DESCRIPTION
The overflow column has an auto-width by default. Fix the example to demonstrate usage of the a fixed width column as applied to the example.

```
40px button width + 32px padding = 72px
```

More generally:

- Are width/minWidth props documented? Do they only apply on table header cells?
- What are the "reserved" header keys? Are these enforced/documented via TypeScript?

---
## Before / After
<img width="600" height="624" alt="Screenshot 2025-09-04 at 7 58 56 AM" src="https://github.com/user-attachments/assets/d1067198-5083-4ee8-a6d5-a84592880dc6" />
<img width="600" height="435" alt="Screenshot 2025-09-04 at 7 59 33 AM" src="https://github.com/user-attachments/assets/1110609d-1f07-4335-9809-b8d026b54d95" />
