### PR TITLE
fix(overflow-menu): avoid dynamic style injection for performance

### DIFF
--- a/src/OverflowMenu/OverflowMenu.svelte
+++ b/src/OverflowMenu/OverflowMenu.svelte
@@ -167,16 +167,11 @@
   $: if ($items[$currentIndex]) {
     focusedId.set($items[$currentIndex].id);
   }
-  $: styles = `<style>
-    #${id} .bx--overflow-menu-options.bx--overflow-menu-options:after {
-      width: ${buttonWidth ? buttonWidth + "px" : "2rem"};
-    }
-  <\/style>`;
+  // Use CSS custom properties instead of dynamic style injection for better
+  // performance. The previous approach created individual `style` tags per
+  // instance, causing overhead when many OverflowMenu components are rendered.
+  $: overflowMenuOptionsAfterWidth = buttonWidth ? buttonWidth + "px" : "2rem";
 </script>
-
-<svelte:head>
-  {@html styles}
-</svelte:head>
 
 <svelte:window
   on:click={({ target }) => {
@@ -252,8 +247,15 @@
       class:bx--overflow-menu-options--xl={size === "xl"}
       class:bx--breadcrumb-menu-options={!!ctxBreadcrumbItem}
       class={menuOptionsClass}
+      style="--overflow-menu-options-after-width: {overflowMenuOptionsAfterWidth}"
     >
       <slot />
     </ul>
   {/if}
 </button>
+
+<style>
+  .bx--overflow-menu-options:after {
+    width: var(--overflow-menu-options-after-width, 2rem);
+  }
+</style>


### PR DESCRIPTION
Fixes #2197

The dynamically computed width is used to control the width of the shadow on `:after`. Without this, the shadow of the menu will overshadow the button when it is opened.

There is a performance issue: an overflow menu may be rendered hundreds of times. This is not uncommon with tables.

The fix, suggested by @brunnerh in #2197, is elegant: instead of injecting styles into the DOM for each overflow menu, re-use a CSS global rule referencing a single custom property.

**Performance Improvements**

- Linear performance: there will only be one global class for *n* component instantiations.
- Less specificity. Previously, the `id` was used to scope styles.
- Avoids DOM pollution and reduces browser memory usage.

This PR also adds unit tests to guard against regressions.