### PR TITLE
fix(tabs): address a11y issues

### DIFF
--- a/src/Tabs/Tab.svelte
+++ b/src/Tabs/Tab.svelte
@@ -32,7 +32,9 @@
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <li
   tabindex="-1"
-  role="presentation"
+  role="tab"
+  aria-selected={selected}
+  aria-disabled={disabled}
   class:bx--tabs__nav-item={true}
   class:bx--tabs__nav-item--disabled={disabled}
   class:bx--tabs__nav-item--selected={selected}
@@ -60,10 +62,7 @@
 >
   <a
     bind:this={ref}
-    role="tab"
     tabindex={disabled ? "-1" : tabindex}
-    aria-selected={selected}
-    aria-disabled={disabled}
     {id}
     {href}
     class:bx--tabs__nav-link={true}

--- a/tests/Tabs/Tabs.test.ts
+++ b/tests/Tabs/Tabs.test.ts
@@ -136,9 +136,12 @@ describe("Tab", () => {
 
     const tab = screen.getByRole("tab", { name: "Test Tab" });
     expect(tab).toBeInTheDocument();
-    expect(tab).toHaveAttribute("href", "#test");
-    expect(tab).toHaveAttribute("tabindex", "0");
-    expect(tab).toHaveAttribute("id", "test-tab");
+    expect(tab).toHaveAttribute("aria-selected", "true");
+
+    const link = tab.querySelector("a");
+    expect(link).toHaveAttribute("href", "#test");
+    expect(link).toHaveAttribute("tabindex", "0");
+    expect(link).toHaveAttribute("id", "test-tab");
   });
 
   it("should render with custom label", () => {
@@ -153,7 +156,8 @@ describe("Tab", () => {
     render(Tab, { props: { href: "/custom" } });
 
     const tab = screen.getByRole("tab");
-    expect(tab).toHaveAttribute("href", "/custom");
+    const link = tab.querySelector("a");
+    expect(link).toHaveAttribute("href", "/custom");
   });
 
   it("should handle disabled state", () => {
@@ -161,21 +165,25 @@ describe("Tab", () => {
 
     const tab = screen.getByRole("tab");
     expect(tab).toHaveAttribute("aria-disabled", "true");
-    expect(tab).toHaveAttribute("tabindex", "-1");
+
+    const link = tab.querySelector("a");
+    expect(link).toHaveAttribute("tabindex", "-1");
   });
 
   it("should handle custom tabindex", () => {
     render(Tab, { props: { tabindex: "1" } });
 
     const tab = screen.getByRole("tab");
-    expect(tab).toHaveAttribute("tabindex", "1");
+    const link = tab.querySelector("a");
+    expect(link).toHaveAttribute("tabindex", "1");
   });
 
   it("should handle custom id", () => {
     render(Tab, { props: { id: "custom-id" } });
 
     const tab = screen.getByRole("tab");
-    expect(tab).toHaveAttribute("id", "custom-id");
+    const link = tab.querySelector("a");
+    expect(link).toHaveAttribute("id", "custom-id");
   });
 
   it("should be clickable when enabled", async () => {


### PR DESCRIPTION
This attempts to fix a11y issues reported by axe-core. The issue stems from how the ul with role="tablist" relates to the underlying li and a. 

<img width="1365" height="766" alt="Screenshot 2025-09-05 at 11 10 54 AM" src="https://github.com/user-attachments/assets/873f51b6-34c7-4f3d-8f2f-dfad36ad9b90" />
<img width="1366" height="514" alt="Screenshot 2025-09-05 at 11 10 48 AM" src="https://github.com/user-attachments/assets/35210c37-566c-4c67-848d-8b38cfaf0bc2" />

Moving the tab role to the direct descendant of tablist fixes this error. 