### PR TITLE
docs: update number of `carbon-pictograms-svelte` to 1,400+

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Design systems facilitate design and development through reuse, consistency, and
 The Carbon Svelte portfolio also includes:
 
 - **[Carbon Icons Svelte](https://github.com/carbon-design-system/carbon-icons-svelte)**: 2,500+ Carbon icons as Svelte components
-- **[Carbon Pictograms Svelte](https://github.com/carbon-design-system/carbon-pictograms-svelte)**: 1,300+ Carbon pictograms as Svelte components
+- **[Carbon Pictograms Svelte](https://github.com/carbon-design-system/carbon-pictograms-svelte)**: 1,400+ Carbon pictograms as Svelte components
 - **[Carbon Charts Svelte](https://github.com/carbon-design-system/carbon-charts/tree/master/packages/svelte)**: 25+ charts, powered by d3
 - **[Carbon Preprocess Svelte](https://github.com/carbon-design-system/carbon-preprocess-svelte)**: Collection of Svelte preprocessors for Carbon
 

--- a/docs/src/pages/index.svelte
+++ b/docs/src/pages/index.svelte
@@ -247,7 +247,7 @@
           borderBottom
           borderRight
           title="Carbon Pictograms Svelte"
-          subtitle="1,300+ pictograms"
+          subtitle="1,400+ pictograms"
           target="_blank"
           href="https://github.com/carbon-design-system/carbon-pictograms-svelte"
         />


### PR DESCRIPTION
https://github.com/carbon-design-system/carbon-pictograms-svelte/releases/tag/v13.10.0