### PR TITLE
fix(modal): `ModalFooter` prop type `secondaryButtons` allows empty array

### DIFF
--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -2299,16 +2299,16 @@ None.
 
 ### Props
 
-| Prop name             | Required | Kind             | Reactive | Type                                                | Default value          | Description                                                                                             |
-| :-------------------- | :------- | :--------------- | :------- | --------------------------------------------------- | ---------------------- | ------------------------------------------------------------------------------------------------------- |
-| primaryButtonText     | No       | <code>let</code> | No       | <code>string</code>                                 | <code>""</code>        | Specify the primary button text                                                                         |
-| primaryButtonIcon     | No       | <code>let</code> | No       | <code>any</code>                                    | <code>undefined</code> | Specify the primary button icon                                                                         |
-| primaryButtonDisabled | No       | <code>let</code> | No       | <code>boolean</code>                                | <code>false</code>     | Set to `true` to disable the primary button                                                             |
-| primaryClass          | No       | <code>let</code> | No       | <code>string</code>                                 | <code>undefined</code> | Specify a class for the primary button                                                                  |
-| secondaryButtonText   | No       | <code>let</code> | No       | <code>string</code>                                 | <code>""</code>        | Specify the secondary button text                                                                       |
-| secondaryButtons      | No       | <code>let</code> | No       | <code>[{ text: string; }, { text: string; }]</code> | <code>[]</code>        | 2-tuple prop to render two secondary buttons for a 3 button modal<br />supersedes `secondaryButtonText` |
-| secondaryClass        | No       | <code>let</code> | No       | <code>string</code>                                 | <code>undefined</code> | Specify a class for the secondary button                                                                |
-| danger                | No       | <code>let</code> | No       | <code>boolean</code>                                | <code>false</code>     | Set to `true` to use the danger variant                                                                 |
+| Prop name             | Required | Kind             | Reactive | Type                                                          | Default value          | Description                                                                                             |
+| :-------------------- | :------- | :--------------- | :------- | ------------------------------------------------------------- | ---------------------- | ------------------------------------------------------------------------------------------------------- |
+| primaryButtonText     | No       | <code>let</code> | No       | <code>string</code>                                           | <code>""</code>        | Specify the primary button text                                                                         |
+| primaryButtonIcon     | No       | <code>let</code> | No       | <code>any</code>                                              | <code>undefined</code> | Specify the primary button icon                                                                         |
+| primaryButtonDisabled | No       | <code>let</code> | No       | <code>boolean</code>                                          | <code>false</code>     | Set to `true` to disable the primary button                                                             |
+| primaryClass          | No       | <code>let</code> | No       | <code>string</code>                                           | <code>undefined</code> | Specify a class for the primary button                                                                  |
+| secondaryButtonText   | No       | <code>let</code> | No       | <code>string</code>                                           | <code>""</code>        | Specify the secondary button text                                                                       |
+| secondaryButtons      | No       | <code>let</code> | No       | <code>[] &#124; [{ text: string; }, { text: string; }]</code> | <code>[]</code>        | 2-tuple prop to render two secondary buttons for a 3 button modal<br />supersedes `secondaryButtonText` |
+| secondaryClass        | No       | <code>let</code> | No       | <code>string</code>                                           | <code>undefined</code> | Specify a class for the secondary button                                                                |
+| danger                | No       | <code>let</code> | No       | <code>boolean</code>                                          | <code>false</code>     | Set to `true` to use the danger variant                                                                 |
 
 ### Slots
 

--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -8321,7 +8321,7 @@
           "name": "secondaryButtons",
           "kind": "let",
           "description": "2-tuple prop to render two secondary buttons for a 3 button modal\nsupersedes `secondaryButtonText`",
-          "type": "[{ text: string; }, { text: string; }]",
+          "type": "[] | [{ text: string; }, { text: string; }]",
           "value": "[]",
           "isFunction": false,
           "isFunctionDeclaration": false,

--- a/src/ComposedModal/ModalFooter.svelte
+++ b/src/ComposedModal/ModalFooter.svelte
@@ -27,7 +27,7 @@
   /**
    * 2-tuple prop to render two secondary buttons for a 3 button modal
    * supersedes `secondaryButtonText`
-   * @type {[{ text: string; }, { text: string; }]}
+   * @type {[] | [{ text: string; }, { text: string; }]}
    */
   export let secondaryButtons = [];
 

--- a/types/ComposedModal/ModalFooter.svelte.d.ts
+++ b/types/ComposedModal/ModalFooter.svelte.d.ts
@@ -39,7 +39,7 @@ type $Props = {
    * supersedes `secondaryButtonText`
    * @default []
    */
-  secondaryButtons?: [{ text: string }, { text: string }];
+  secondaryButtons?: [] | [{ text: string }, { text: string }];
 
   /**
    * Specify a class for the secondary button


### PR DESCRIPTION
Identified via #2210

`ModalFooter` secondaryButtons is typed as a two-tuple. However, the default value is an empty array. The prop type should allow an empty array to match this default value.