### PR TITLE
fix(data-table): default filtering supports nested keys

### DIFF
--- a/src/DataTable/DataTable.svelte
+++ b/src/DataTable/DataTable.svelte
@@ -217,15 +217,22 @@
         // Apply custom filter if provided.
         filteredRows = originalRows.filter((row) => customFilter(row, value));
       } else {
-        // Default filter checks all non-id fields for a basic, case-insensitive match (non-fuzzy).
+        // Get searchable keys from headers (non-empty headers with keys).
+        const searchableKeys = headers
+          .filter((header) => !header.empty && header.key)
+          .map((header) => header.key);
+
+        // Default filter checks fields defined in headers
+        // for a basic, case-insensitive match (non-fuzzy).
+        // This supports nested keys like "contact.company".
         filteredRows = originalRows.filter((row) => {
-          return Object.entries(row)
-            .filter(([key]) => key !== "id")
-            .some(([key, _value]) => {
-              if (typeof _value === "string" || typeof _value === "number") {
-                return (_value + "")?.toLowerCase().includes(value);
-              }
-            });
+          return searchableKeys.some((key) => {
+            const _value = resolvePath(row, key);
+            if (typeof _value === "string" || typeof _value === "number") {
+              return (_value + "")?.toLowerCase().includes(value);
+            }
+            return false;
+          });
         });
       }
 

--- a/tests/DataTable/DataTableSearchNested.test.svelte
+++ b/tests/DataTable/DataTableSearchNested.test.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+  import {
+    DataTable,
+    Toolbar,
+    ToolbarContent,
+    ToolbarSearch,
+  } from "carbon-components-svelte";
+
+  export let value = "";
+
+  const rows = [
+    { id: "1", contact: { company: "Super Wheels" } },
+    { id: "2", contact: { company: "Mini Wheels" } },
+    { id: "3", contact: { company: "Mega Corp" } },
+  ];
+
+  let filteredRowIds: string[] = [];
+</script>
+
+<DataTable
+  headers={[
+    { key: "id", value: "ID" },
+    { key: "contact.company", value: "Company name" },
+  ]}
+  {rows}
+>
+  <Toolbar>
+    <ToolbarContent>
+      <ToolbarSearch persistent {value} shouldFilterRows bind:filteredRowIds />
+    </ToolbarContent>
+  </Toolbar>
+</DataTable>

--- a/tests/DataTable/DataTableSearchNested.test.ts
+++ b/tests/DataTable/DataTableSearchNested.test.ts
@@ -1,0 +1,78 @@
+import { render, screen } from "@testing-library/svelte";
+import { user } from "../setup-tests";
+import DataTableSearchNested from "./DataTableSearchNested.test.svelte";
+
+describe("DataTableSearch with nested keys", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const getTableRows = () => screen.getAllByRole("row").slice(1);
+
+  it("filters rows by nested property values", async () => {
+    render(DataTableSearchNested);
+
+    const searchInput = screen.getByRole("searchbox");
+    expect(searchInput).toHaveValue("");
+
+    let tableRows = getTableRows();
+    expect(tableRows).toHaveLength(3);
+
+    await user.type(searchInput, "super");
+    expect(searchInput).toHaveValue("super");
+
+    tableRows = getTableRows();
+    expect(tableRows).toHaveLength(1);
+    expect(tableRows[0]).toHaveTextContent("Super Wheels");
+    expect(tableRows[0]).toHaveTextContent("1");
+
+    await user.clear(searchInput);
+    await user.type(searchInput, "wheels");
+    expect(searchInput).toHaveValue("wheels");
+
+    tableRows = getTableRows();
+    expect(tableRows).toHaveLength(2);
+    expect(tableRows[0]).toHaveTextContent("Super Wheels");
+    expect(tableRows[1]).toHaveTextContent("Mini Wheels");
+
+    await user.clear(searchInput);
+    await user.type(searchInput, "mega");
+    expect(searchInput).toHaveValue("mega");
+
+    tableRows = getTableRows();
+    expect(tableRows).toHaveLength(1);
+    expect(tableRows[0]).toHaveTextContent("Mega Corp");
+
+    await user.clear(searchInput);
+    expect(searchInput).toHaveValue("");
+
+    tableRows = getTableRows();
+    expect(tableRows).toHaveLength(3);
+  });
+
+  it("can still search by non-nested id field", async () => {
+    render(DataTableSearchNested);
+
+    const searchInput = screen.getByRole("searchbox");
+
+    await user.type(searchInput, "1");
+    expect(searchInput).toHaveValue("1");
+
+    const tableRows = getTableRows();
+    expect(tableRows).toHaveLength(1);
+    expect(tableRows[0]).toHaveTextContent("1");
+    expect(tableRows[0]).toHaveTextContent("Super Wheels");
+  });
+
+  it("returns no results when search does not match", async () => {
+    render(DataTableSearchNested);
+
+    const searchInput = screen.getByRole("searchbox");
+
+    await user.type(searchInput, "nonexistent");
+    expect(searchInput).toHaveValue("nonexistent");
+
+    const tableRows = getTableRows();
+    expect(tableRows).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Fixes #1897

The default datatable filter behavior should account for nested keys, expressed via dot notation (i.e., `a.b.c`). This adds a regression test.

```svelte
<DataTable
  headers={[
    { key: "id", value: "ID" },
    { key: "contact.company", value: "Company name" },
  ]}
  {rows}
>
  <Toolbar>
    <ToolbarContent>
      <ToolbarSearch persistent {value} shouldFilterRows bind:filteredRowIds />
    </ToolbarContent>
  </Toolbar>
</DataTable>
```