### PR TITLE
fix(toggle): dispatch change event for keyboard interactions

### DIFF
--- a/src/Toggle/Toggle.svelte
+++ b/src/Toggle/Toggle.svelte
@@ -39,6 +39,8 @@
   import { createEventDispatcher } from "svelte";
 
   const dispatch = createEventDispatcher();
+
+  let ref = null;
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
@@ -54,6 +56,7 @@
 >
   <!-- svelte-ignore a11y-role-has-required-aria-props -->
   <input
+    bind:this={ref}
     role="switch"
     type="checkbox"
     class:bx--toggle-input={true}
@@ -64,11 +67,10 @@
       dispatch("toggle", { toggled });
     }}
     on:change
-    on:keyup={(e) => {
-      if (e.key === " " || e.key === "Enter") {
+    on:keydown={(e) => {
+      if (e.key === "Enter") {
         e.preventDefault();
-        toggled = !toggled;
-        dispatch("toggle", { toggled });
+        ref?.click();
       }
     }}
     on:keyup

--- a/tests/Toggle/Toggle.test.svelte
+++ b/tests/Toggle/Toggle.test.svelte
@@ -11,6 +11,11 @@
   on:toggle={(e) => {
     console.log("toggled:", e.detail.toggled);
   }}
+  on:change={(e) => {
+    if (e.target instanceof HTMLInputElement) {
+      console.log("change:", e.target.checked);
+    }
+  }}
 />
 
 <Toggle labelText="Custom labels" labelA="Inactive" labelB="Active" />

--- a/tests/Toggle/Toggle.test.ts
+++ b/tests/Toggle/Toggle.test.ts
@@ -16,10 +16,12 @@ describe("Toggle", () => {
     await user.click(toggle);
     expect(toggle).toBeChecked();
     expect(consoleLog).toHaveBeenCalledWith("toggled:", true);
+    expect(consoleLog).toHaveBeenCalledWith("change:", true);
 
     await user.click(toggle);
     expect(toggle).not.toBeChecked();
     expect(consoleLog).toHaveBeenCalledWith("toggled:", false);
+    expect(consoleLog).toHaveBeenCalledWith("change:", false);
   });
 
   it("supports custom labels", () => {
@@ -73,10 +75,12 @@ describe("Toggle", () => {
     await user.keyboard(" ");
     expect(toggle).toBeChecked();
     expect(consoleLog).toHaveBeenCalledWith("toggled:", true);
+    expect(consoleLog).toHaveBeenCalledWith("change:", true);
 
     await user.keyboard(" ");
     expect(toggle).not.toBeChecked();
     expect(consoleLog).toHaveBeenCalledWith("toggled:", false);
+    expect(consoleLog).toHaveBeenCalledWith("change:", false);
   });
 
   it("handles keyboard interactions (Enter)", async () => {
@@ -89,10 +93,12 @@ describe("Toggle", () => {
     await user.keyboard("{Enter}");
     expect(toggle).toBeChecked();
     expect(consoleLog).toHaveBeenCalledWith("toggled:", true);
+    expect(consoleLog).toHaveBeenCalledWith("change:", true);
 
     await user.keyboard("{Enter}");
     expect(toggle).not.toBeChecked();
     expect(consoleLog).toHaveBeenCalledWith("toggled:", false);
+    expect(consoleLog).toHaveBeenCalledWith("change:", false);
   });
 
   it("ignores other key presses", async () => {
@@ -118,22 +124,22 @@ describe("Toggle", () => {
     expect(toggle).toHaveAttribute("name", "custom-name-toggle");
   });
 
-  it("prevents default on space and enter keys", async () => {
+  it("prevents default on enter key", async () => {
     render(Toggle);
 
     const toggle = getToggle("Default toggle");
     toggle.focus();
 
-    const spaceEvent = new KeyboardEvent("keyup", { key: " " });
-    const enterEvent = new KeyboardEvent("keyup", { key: "Enter" });
+    const enterEvent = new KeyboardEvent("keydown", {
+      key: "Enter",
+      bubbles: true,
+      cancelable: true,
+    });
 
-    const spacePreventDefault = vi.spyOn(spaceEvent, "preventDefault");
     const enterPreventDefault = vi.spyOn(enterEvent, "preventDefault");
 
-    toggle.dispatchEvent(spaceEvent);
     toggle.dispatchEvent(enterEvent);
 
-    expect(spacePreventDefault).toHaveBeenCalled();
     expect(enterPreventDefault).toHaveBeenCalled();
   });
 
@@ -175,7 +181,7 @@ describe("Toggle", () => {
     await user.click(toggle);
 
     expect(toggle).toBeChecked();
-    expect(consoleLog).toHaveBeenCalledTimes(3);
+    expect(consoleLog).toHaveBeenCalledTimes(6); // 3 toggle events + 3 change events
   });
 
   it("visually hides label when hideLabel is true", () => {


### PR DESCRIPTION
Fixes #1611

The Toggle component's keyboard handlers (Space and Enter keys) were preventing the native `change` event from firing due to `e.preventDefault()` being called in the `keyup` handler. This created inconsistent behavior where `on:change` listeners worked for mouse clicks but not keyboard interactions.

**Changes**
- Removed Space key from custom handler to allow native checkbox behavior
- Modified Enter key handler to call `click()` instead of manually toggling state
- Moved Enter key handling from `keyup` to `keydown` for proper preventDefault timing
- Added input element ref binding to enable programmatic click
- Updated tests to verify `change` event fires for both click and keyboard events

The `change` event now fires consistently across all interaction methods while maintaining backward compatibility with the existing `toggle` event.