### PR TITLE
fix(context-menu): prevent parent menu closure when clicking submenu on mobile

### DIFF
--- a/src/ContextMenu/ContextMenuOption.svelte
+++ b/src/ContextMenu/ContextMenuOption.svelte
@@ -236,7 +236,14 @@
       submenuOpen = false;
     }
   }}
-  on:click={handleClick}
+  on:click={(e) => {
+    if (subOptions) {
+      e.stopPropagation();
+      submenuOpen = true;
+      return;
+    }
+    handleClick();
+  }}
 >
   {#if subOptions}
     <div

--- a/tests/ContextMenu/ContextMenu.test.svelte
+++ b/tests/ContextMenu/ContextMenu.test.svelte
@@ -7,6 +7,7 @@
   export let x = 0;
   export let y = 0;
   export let ref: ComponentProps<ContextMenu>["ref"] = null;
+  export let withSubmenu = false;
 </script>
 
 <div data-testid="target">Right click me</div>
@@ -24,6 +25,13 @@
     console.log("close");
   }}
 >
-  <ContextMenuOption>Option 1</ContextMenuOption>
-  <ContextMenuOption>Option 2</ContextMenuOption>
+  <ContextMenuOption labelText="Option 1" />
+  {#if withSubmenu}
+    <ContextMenuOption labelText="Option with submenu">
+      <ContextMenuOption labelText="Submenu option 1" />
+      <ContextMenuOption labelText="Submenu option 2" />
+    </ContextMenuOption>
+  {:else}
+    <ContextMenuOption labelText="Option 2" />
+  {/if}
 </ContextMenu>

--- a/tests/ContextMenu/ContextMenu.test.ts
+++ b/tests/ContextMenu/ContextMenu.test.ts
@@ -105,4 +105,45 @@ describe("ContextMenu", () => {
     nestedMenu.setAttribute("data-level", "2");
     menus[0].appendChild(nestedMenu);
   });
+
+  // Regression test for https://github.com/carbon-design-system/carbon-components-svelte/issues/1848
+  it("should not close parent menu when clicking submenu trigger", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(ContextMenu, {
+      props: {
+        open: true,
+        withSubmenu: true,
+        x: 100,
+        y: 100,
+      },
+    });
+
+    const submenuTrigger = screen.getByText("Option with submenu");
+    expect(submenuTrigger).toBeInTheDocument();
+
+    await user.click(submenuTrigger);
+
+    expect(consoleLog).not.toHaveBeenCalledWith("close");
+
+    const submenuOptions = screen.getByText("Submenu option 1");
+    expect(submenuOptions).toBeInTheDocument();
+  });
+
+  it("should close menu when clicking regular option", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(ContextMenu, {
+      props: {
+        open: true,
+        x: 100,
+        y: 100,
+      },
+    });
+
+    // Click a regular option
+    const option = screen.getByText("Option 1");
+    await user.click(option);
+
+    // Menu should close
+    expect(consoleLog).toHaveBeenCalledWith("close");
+  });
 });


### PR DESCRIPTION
Fixes #1848

Fixes a mobile interaction bug where clicking a `ContextMenu` item with a submenu would close the entire menu instead of opening the submenu. This made nested menus inaccessible on touch devices.

The fix modifies `ContextMenuOption` to prevent click events from bubbling up to the window-level handler when clicking submenu triggers. Now, clicking a submenu trigger stops propagation and explicitly opens the submenu, enabling mobile users to navigate nested menus while preserving the existing desktop hover behavior.