### PR TITLE
fix(context-menu): avoid clipping nested menu on narrow screens

### DIFF
--- a/src/ContextMenu/ContextMenuOption.svelte
+++ b/src/ContextMenu/ContextMenuOption.svelte
@@ -74,6 +74,7 @@
   let submenuPosition = [0, 0];
   let menuOffsetX = 0;
   let mousePosition = { x: 0, y: 0 };
+  /** @type {HTMLUListElement | null} */
   let submenuRef = null;
 
   const unsubPosition = ctx.position.subscribe((position) => {
@@ -220,8 +221,15 @@
     const { width, y } = ref.getBoundingClientRect();
     let x = rootMenuPosition[0] + width;
 
-    if (window.innerWidth - menuOffsetX < width) {
-      x = rootMenuPosition[0] - width;
+    const submenuWidth = submenuRef?.getBoundingClientRect().width ?? width;
+
+    if (x + submenuWidth > window.innerWidth) {
+      x = rootMenuPosition[0] - submenuWidth;
+
+      // On narrow screens, position submenu at edge to avoid clipping.
+      if (x < 0) {
+        x = Math.max(0, window.innerWidth - submenuWidth);
+      }
     }
 
     submenuPosition = [x, y];


### PR DESCRIPTION
Fixes #1847

This fixes submenu positioning on narrow viewports by improving the horizontal constraint logic in `ContextMenuOption.svelte`. 

Currently, the submenu overflows the viewport on small screens because it only checks if there's space on the right side using an incorrect reference point (`menuOffsetX`). The fix now uses the actual submenu width to check both right and left viewport boundaries, falling back to the viewport edge when the submenu would overflow on both sides.

This fix is consistent with the React implementation.

---

## Before

<img width="276" height="189" alt="Screenshot 2025-10-16 at 2 53 01 PM" src="https://github.com/user-attachments/assets/cd3ab2e4-0af7-46dc-9009-1d9a0444daf5" />

## After

<img width="384" height="208" alt="Screenshot 2025-10-16 at 2 53 34 PM" src="https://github.com/user-attachments/assets/852acf14-6f94-4c0d-b183-468e14ed4c7d" />


