### PR TITLE
fix(date-picker): dispatch `change` for "single" variant

### DIFF
--- a/src/DatePicker/DatePicker.svelte
+++ b/src/DatePicker/DatePicker.svelte
@@ -116,8 +116,23 @@
         inputValue.set(value);
       }
 
-      if (!calendar && type === "change") {
-        dispatch("change", value);
+      if (type === "change") {
+        if (calendar) {
+          const detail = { selectedDates: calendar.selectedDates || [] };
+
+          if ($range) {
+            detail.dateStr = {
+              from: inputRef?.value || "",
+              to: inputRefTo?.value || "",
+            };
+          } else {
+            detail.dateStr = inputRef?.value || "";
+          }
+
+          dispatch("change", detail);
+        } else {
+          dispatch("change", value);
+        }
       }
     },
     blurInput: (relatedTarget) => {
@@ -160,7 +175,7 @@
       base: inputRef,
       input: inputRefTo,
       dispatch: (event) => {
-        const detail = { selectedDates: calendar.selectedDates };
+        const detail = { selectedDates: calendar?.selectedDates || [] };
 
         if ($range) {
           const from = inputRef.value;

--- a/tests/DatePicker/DatePicker.test.svelte
+++ b/tests/DatePicker/DatePicker.test.svelte
@@ -37,9 +37,7 @@
   {short}
   {light}
   {flatpickrProps}
-  on:change={(e) => {
-    console.log("change", e.detail);
-  }}
+  on:change
 >
   <DatePickerInput
     labelText="Date"

--- a/tests/DatePicker/DatePicker.test.ts
+++ b/tests/DatePicker/DatePicker.test.ts
@@ -106,4 +106,59 @@ describe("DatePicker", () => {
     expect(input).toHaveAttribute("placeholder", "mm/dd/yyyy");
     expect(screen.getByText("Date")).toHaveClass("bx--visually-hidden");
   });
+
+  it("dispatches change event when manually typing in simple mode", async () => {
+    const changeHandler = vi.fn();
+    const { component } = render(DatePicker, {
+      datePickerType: "simple",
+    });
+
+    component.$on("change", changeHandler);
+
+    const input = screen.getByLabelText("Date");
+    await user.type(input, "01/15/2024");
+    await user.tab();
+
+    expect(changeHandler).toHaveBeenCalled();
+    expect(changeHandler.mock.lastCall?.[0]?.detail).toBe("01/15/2024");
+  });
+
+  it("dispatches change event when manually typing in single mode", async () => {
+    const changeHandler = vi.fn();
+    const { component } = render(DatePicker, {
+      datePickerType: "single",
+    });
+
+    component.$on("change", changeHandler);
+
+    const input = screen.getByLabelText("Date");
+    await user.type(input, "01/15/2024");
+    await user.tab();
+
+    expect(changeHandler).toHaveBeenCalled();
+    expect(changeHandler.mock.lastCall?.[0]?.detail).toMatchObject({
+      dateStr: "01/15/2024",
+    });
+  });
+
+  // Regression tests for https://github.com/carbon-design-system/carbon-components-svelte/issues/314
+  // and https://github.com/carbon-design-system/carbon-components-svelte/issues/950
+  it("dispatches change event when manually clearing in single mode", async () => {
+    const changeHandler = vi.fn();
+    const { component } = render(DatePicker, {
+      datePickerType: "single",
+      value: "01/15/2024",
+    });
+
+    component.$on("change", changeHandler);
+
+    const input = screen.getByLabelText("Date");
+    await user.clear(input);
+    await user.tab();
+
+    expect(changeHandler).toHaveBeenCalled();
+    expect(changeHandler.mock.lastCall?.[0]?.detail).toMatchObject({
+      dateStr: "",
+    });
+  });
 });


### PR DESCRIPTION
Fixes #314, fixes #950

Fixes `DatePicker` not dispatching `change` events when manually typing or clearing dates in `single`/`range` modes (#314, #950).

The bug was caused by a condition that blocked events when a Flatpickr calendar existed, assuming Flatpickr would handle all cases, but it only fires for calendar selections, not manual input. This fix removes that blocking condition, ensuring `change` events are dispatched consistently for all input methods while maintaining backward compatibility. Includes unit tests for manual typing and clearing.