### PR TITLE
fix(date-picker): allow clearing range dates by setting values to empty strings

### DIFF
--- a/src/DatePicker/DatePicker.svelte
+++ b/src/DatePicker/DatePicker.svelte
@@ -217,7 +217,9 @@
         calendar.setDate([$inputValueFrom, $inputValueTo]);
 
         // workaround to remove the default range plugin separator "to"
-        inputRef.value = $inputValueFrom;
+        if ($inputValueFrom !== "") {
+          inputRef.value = $inputValueFrom;
+        }
       } else {
         calendar.setDate($inputValue);
       }

--- a/tests/DatePicker/DatePicker.test.ts
+++ b/tests/DatePicker/DatePicker.test.ts
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/svelte";
+import { tick } from "svelte";
 import { user } from "../setup-tests";
 import DatePicker from "./DatePicker.test.svelte";
 import DatePickerRange from "./DatePickerRange.test.svelte";
@@ -160,5 +161,30 @@ describe("DatePicker", () => {
     expect(changeHandler.mock.lastCall?.[0]?.detail).toMatchObject({
       dateStr: "",
     });
+  });
+
+  // Regression test for https://github.com/carbon-design-system/carbon-components-svelte/issues/1862
+  it("allows clearing range dates by setting valueFrom and valueTo to empty strings", async () => {
+    const { component } = render(DatePickerRange, {
+      valueFrom: "01/15/2024",
+      valueTo: "01/20/2024",
+    });
+
+    const inputStart = screen.getByLabelText("Start date");
+    const inputEnd = screen.getByLabelText("End date");
+
+    await user.click(inputStart);
+    expect(
+      await screen.findByLabelText("calendar-container"),
+    ).toBeInTheDocument();
+    expect(inputStart).toHaveValue("01/15/2024");
+    expect(inputEnd).toHaveValue("01/20/2024");
+
+    // Clear the dates by setting both values to empty strings
+    component.$set({ valueFrom: "", valueTo: "" });
+    await tick();
+
+    expect(inputStart).toHaveValue("");
+    expect(inputEnd).toHaveValue("");
   });
 });

--- a/tests/DatePicker/DatePickerRange.test.svelte
+++ b/tests/DatePicker/DatePickerRange.test.svelte
@@ -1,8 +1,11 @@
 <script lang="ts">
   import { DatePicker, DatePickerInput } from "carbon-components-svelte";
+
+  export let valueFrom = "";
+  export let valueTo = "";
 </script>
 
-<DatePicker datePickerType="range" on:change>
+<DatePicker datePickerType="range" {valueFrom} {valueTo} on:change>
   <DatePickerInput labelText="Start date" placeholder="mm/dd/yyyy" />
   <DatePickerInput labelText="End date" placeholder="mm/dd/yyyy" />
 </DatePicker>


### PR DESCRIPTION
Fixes #1862

Addresses an issue where setting valueFrom and valueTo to "" would not clear the input fields in range mode due to unconditional value assignment in the `afterUpdate` method. Incorporates the valid fix suggested by @JOldak in #1862.

It now only applies the range separator workaround when a value exists.