### PR TITLE
fix(tooltip): prevent closing on layout shift

### DIFF
--- a/src/Tooltip/Tooltip.svelte
+++ b/src/Tooltip/Tooltip.svelte
@@ -99,13 +99,22 @@
     open = true;
   }
 
-  function onMousedown() {
+  function onPointerdown(e) {
+    if (e.currentTarget.setPointerCapture) {
+      e.currentTarget.setPointerCapture(e.pointerId);
+    }
     // determine the desired state before the focus event triggers.
     const shouldClose = open;
     // ensure changes are scheduled at the end, i.e. after the possible focus event.
     setTimeout(() => {
       open = shouldClose ? false : true;
     });
+  }
+
+  function onPointerup(e) {
+    if (e.currentTarget.releasePointerCapture) {
+      e.currentTarget.releasePointerCapture(e.pointerId);
+    }
   }
 
   afterUpdate(() => {
@@ -212,7 +221,8 @@
         bind:this={refIcon}
         {...buttonProps}
         aria-describedby={tooltipId}
-        on:mousedown={onMousedown}
+        on:pointerdown={onPointerdown}
+        on:pointerup={onPointerup}
         on:focus={onFocus}
         on:keydown={onKeydown}
       >
@@ -227,7 +237,8 @@
       bind:this={ref}
       {...buttonProps}
       aria-describedby={tooltipId}
-      on:mousedown={onMousedown}
+      on:pointerdown={onPointerdown}
+      on:pointerup={onPointerup}
       on:focus={onFocus}
       on:blur={onBlur}
       on:keydown={onKeydown}

--- a/tests/Tooltip/TooltipPointerCapture.test.svelte
+++ b/tests/Tooltip/TooltipPointerCapture.test.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  import { Tooltip } from "carbon-components-svelte";
+</script>
+
+<Tooltip iconDescription="Information">
+  <input type="text" autofocus />
+</Tooltip>


### PR DESCRIPTION
Fixes #925

Fixes an issue where tooltips would close immediately after opening when positioned near the document edge. The problem occurred because focus events could cause layout changes that moved the trigger button away from the cursor, causing the click handler to interpret this as clicking outside the tooltip. This change replaces mousedown/mouseup events with pointerdown/pointerup and uses setPointerCapture() (suggested by @brunnerh) to ensure all pointer events remain captured to the trigger element even if it moves during interaction, preventing premature closure.

Crediting Git commit co-authorship to @brunnerh.
