### PR TITLE
fix(ui-shell): prevent focus on hidden links when `SideNav` is collapsed

### DIFF
--- a/src/UIShell/SideNav.svelte
+++ b/src/UIShell/SideNav.svelte
@@ -78,6 +78,7 @@
     : isOpen}
   class:bx--side-nav--collapsed={!isOpen && !rail}
   class:bx--side-nav--rail={rail}
+  style:visibility={!isOpen && !rail ? "hidden" : undefined}
   {...$$restProps}
 >
   <slot />

--- a/tests/UIShell/UIShell.test.ts
+++ b/tests/UIShell/UIShell.test.ts
@@ -244,6 +244,37 @@ describe("UIShell", () => {
 
       expect(links?.length).toBeGreaterThan(0);
     });
+
+    // Regression test for https://github.com/carbon-design-system/carbon-components-svelte/issues/604
+    it("should prevent focus on links when closed (not rail mode)", () => {
+      const { container } = render(UIShell, {
+        props: { sideNavIsOpen: false },
+      });
+
+      const nav = container.querySelector(".bx--side-nav");
+      expect(nav).toHaveAttribute("aria-hidden", "true");
+      expect(nav).toHaveStyle({ visibility: "hidden" });
+    });
+
+    it("should allow focus on links when open", () => {
+      const { container } = render(UIShell, {
+        props: { sideNavIsOpen: true },
+      });
+
+      const nav = container.querySelector(".bx--side-nav");
+      expect(nav).toHaveAttribute("aria-hidden", "false");
+      expect(nav).not.toHaveStyle({ visibility: "hidden" });
+    });
+
+    it("should not apply visibility:hidden in rail mode when closed", () => {
+      const { container } = render(UIShell, {
+        props: { sideNavIsOpen: false, sideNavRail: true },
+      });
+
+      const nav = container.querySelector(".bx--side-nav");
+      expect(nav).toHaveClass("bx--side-nav--rail");
+      expect(nav).not.toHaveStyle({ visibility: "hidden" });
+    });
   });
 
   describe("Content", () => {


### PR DESCRIPTION
Fixes #604

Fixes an accessibility issue where `SideNav` links remained keyboard-focusable even when the navigation was visually hidden. This created a confusing experience for keyboard users who could tab to invisible elements.

Assigning Git commit co-authorship to @brunnerh 

- All existing tests pass
- Added 3 new unit tests covering:
  - Collapsed state applies `visibility: hidden`
  - Open state does not apply `visibility: hidden`
  - Rail mode when closed does not apply `visibility: hidden`