### PR TITLE
docs(tree-view): fix inline editing example

### DIFF
--- a/docs/src/pages/framed/TreeView/TreeViewInlineEditing.svelte
+++ b/docs/src/pages/framed/TreeView/TreeViewInlineEditing.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { TreeView } from "carbon-components-svelte";
+  import { TreeView, RecursiveList } from "carbon-components-svelte";
   import Edit from "carbon-icons-svelte/lib/Edit.svelte";
 
   let nodes = [
@@ -34,6 +34,23 @@
       ],
     },
   ];
+
+  function updateNodeText(id, text) {
+    const findAndUpdate = (items) => {
+      for (const item of items) {
+        if (item.id === id) {
+          item.text = text;
+          return true;
+        }
+        if (item.nodes && findAndUpdate(item.nodes)) {
+          return true;
+        }
+      }
+      return false;
+    };
+    findAndUpdate(nodes);
+    nodes = nodes;
+  }
 </script>
 
 <TreeView labelText="Cloud Products" {nodes} let:node>
@@ -51,3 +68,6 @@
     </span>
   </div>
 </TreeView>
+
+<br />
+<RecursiveList {nodes} />


### PR DESCRIPTION
This fixes the inline node editing example for TreeView. It also adds the `RecursiveList` to visualize the edits.

---

<img width="671" height="670" alt="Screenshot 2025-10-18 at 3 46 41 PM" src="https://github.com/user-attachments/assets/5d770fcb-d6bd-4c8f-98b2-b1a0927153fd" />
