### PR TITLE
fix(select): avoid rendering empty label element

### DIFF
--- a/src/Select/Select.svelte
+++ b/src/Select/Select.svelte
@@ -134,7 +134,7 @@
     class:bx--select--disabled={disabled}
     class:bx--select--warning={warn}
   >
-    {#if !noLabel}
+    {#if !noLabel && (labelText || $$slots.labelText)}
       <label
         for={id}
         class:bx--label={true}

--- a/tests/Select/Select.test.ts
+++ b/tests/Select/Select.test.ts
@@ -258,4 +258,12 @@ describe("Select", () => {
     expect(screen.getByLabelText("Undefined text")).toHaveValue("2");
     expect(screen.getByRole("option", { name: "2" })).toBeInTheDocument();
   });
+
+  // Regression test for https://github.com/carbon-design-system/carbon-components-svelte/issues/1977
+  it("should not render label element when labelText is empty string", () => {
+    render(Select, { props: { labelText: "" } });
+    const wrapper = screen.getByTestId("select");
+    const label = wrapper.querySelector("label");
+    expect(label).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
Fixes #1977

Cherry-picked this fix from #2245 

This fixes the inconsistent top margin issue when Select is used alongside other form inputs without label text.

- **Before:** Empty label element was always rendered when `noLabel=false`.
- **After:** Label element only renders when labelText or slot has content.