### PR TITLE
docs: use consistent headings

### DIFF
--- a/docs/src/pages/components/Accordion.svx
+++ b/docs/src/pages/components/Accordion.svx
@@ -145,7 +145,7 @@ a secondary UI element.
   </AccordionItem>
 </Accordion>
 
-## Disabled
+## Disabled state
 
 Set the `disabled` prop on the `Accordion` component to disable all items at once.
 This prevents users from expanding or collapsing any items in the accordion.

--- a/docs/src/pages/components/Checkbox.svx
+++ b/docs/src/pages/components/Checkbox.svx
@@ -37,7 +37,7 @@ Set `disabled` to `true` to prevent user interaction.
 
 <Checkbox labelText="Label text" disabled />
 
-## Readonly state
+## Read-only state
 
 Set `readonly` to `true` to make the checkbox non-interactive while keeping the label text readable. Unlike `disabled`, the readonly state is intended for displaying checkbox values that can only be changed programmatically.
 

--- a/docs/src/pages/components/CodeSnippet.svx
+++ b/docs/src/pages/components/CodeSnippet.svx
@@ -107,7 +107,7 @@ Set `showMoreText` and `showLessText` to customize the expand/collapse button te
 
 <CodeSnippet type="multi" {code} showMoreText="Expand" showLessText="Collapse" />
 
-## Disabled
+## Disabled state
 
 Set `disabled` to `true` to disable interaction. This only applies to `"single"` and `"multi"` types.
 

--- a/docs/src/pages/components/ContentSwitcher.svx
+++ b/docs/src/pages/components/ContentSwitcher.svx
@@ -73,7 +73,7 @@ Set `size` to `"sm"` for a small content switcher.
   <Switch text="Archived" />
 </ContentSwitcher>
 
-## Disabled
+## Disabled state
 
 Set `disabled` to `true` on individual switches to prevent interaction.
 

--- a/docs/src/pages/components/Select.svx
+++ b/docs/src/pages/components/Select.svx
@@ -182,6 +182,6 @@ Display a loading state using the skeleton variant.
 
 <SelectSkeleton />
 
-## Skeleton (hidden label)
+## Skeleton without label
 
 <SelectSkeleton hideLabel />

--- a/docs/src/pages/components/Slider.svx
+++ b/docs/src/pages/components/Slider.svx
@@ -69,7 +69,7 @@ Show a loading state with the skeleton variant.
 
 <SliderSkeleton />
 
-## Skeleton (hidden label)
+## Skeleton without label
 
 Show a loading state without a label.
 

--- a/docs/src/pages/components/Tag.svx
+++ b/docs/src/pages/components/Tag.svx
@@ -69,7 +69,7 @@ Set `interactive` to `true` to render a `button` element instead of a `div`. Thi
 
 <Tag interactive>Machine learning</Tag>
 
-## Disabled
+## Disabled state
 
 Both filterable and interactive tag variants support a disabled state.
 


### PR DESCRIPTION

There were several inconsistencies in heading capitalization and wording within the `.svx` documentation files, making the documentation less uniform.

- `docs/src/pages/components/Accordion.svx`: Changed heading from "Disabled" to "Disabled state".
- `docs/src/pages/components/Checkbox.svx`: Changed heading from "Readonly state" to "Read-only state".
- `docs/src/pages/components/CodeSnippet.svx`: Changed heading from "Disabled" to "Disabled state".
- `docs/src/pages/components/ContentSwitcher.svx`: Changed heading from "Disabled" to "Disabled state".
- `docs/src/pages/components/Select.svx`: Changed heading from "Skeleton (hidden label)" to "Skeleton without label".
- `docs/src/pages/components/Slider.svx`: Changed heading from "Skeleton (hidden label)" to "Skeleton without label".
- `docs/src/pages/components/Tag.svx`: Changed heading from "Disabled" to "Disabled state".


