### PR TITLE
fix(multi-select): filterable variant should not use read-only checkbox

### DIFF
--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -547,7 +547,6 @@
               name={item.id}
               title={useTitleInItem ? itemToString(item) : undefined}
               {...itemToInput(item)}
-              readonly
               tabindex="-1"
               id="checkbox-{item.id}"
               checked={item.checked}


### PR DESCRIPTION
Note that, although this PR is stylized as a bug fix, the bug was not released. This is an expected progression,  not a regression.

Fixes #2255

Follow-up to #2237, which fixed how a readonly Checkbox works.