### PR TITLE
feat(data-table)!: include `target` and `currentTarget` in row/cell click events

### DIFF
--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -1014,18 +1014,18 @@ export interface DataTableCell<Row = DataTableRow> {
 
 ### Events
 
-| Event name           | Type       | Detail                                                                                                       |
-| :------------------- | :--------- | :----------------------------------------------------------------------------------------------------------- |
-| click                | dispatched | <code>{ header?: DataTableHeader<Row>; row?: Row; cell?: DataTableCell<Row>; }</code>                        |
-| click:header--expand | dispatched | <code>{ expanded: boolean; }</code>                                                                          |
-| click:header         | dispatched | <code>{ header: DataTableHeader<Row>; sortDirection?: "ascending" &#124; "descending" &#124; "none" }</code> |
-| click:header--select | dispatched | <code>{ indeterminate: boolean; selected: boolean; }</code>                                                  |
-| click:row            | dispatched | <code>Row</code>                                                                                             |
-| mouseenter:row       | dispatched | <code>Row</code>                                                                                             |
-| mouseleave:row       | dispatched | <code>Row</code>                                                                                             |
-| click:row--expand    | dispatched | <code>{ expanded: boolean; row: Row; }</code>                                                                |
-| click:row--select    | dispatched | <code>{ selected: boolean; row: Row; }</code>                                                                |
-| click:cell           | dispatched | <code>DataTableCell<Row></code>                                                                              |
+| Event name           | Type       | Detail                                                                                                                                                         |
+| :------------------- | :--------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| click                | dispatched | <code>{ header?: DataTableHeader<Row>; row?: Row; cell?: DataTableCell<Row>; }</code>                                                                          |
+| click:header--expand | dispatched | <code>{ expanded: boolean; }</code>                                                                                                                            |
+| click:header         | dispatched | <code>{ header: DataTableHeader<Row>; sortDirection?: "ascending" &#124; "descending" &#124; "none"; target: EventTarget; currentTarget: EventTarget; }</code> |
+| click:header--select | dispatched | <code>{ indeterminate: boolean; selected: boolean; }</code>                                                                                                    |
+| click:row            | dispatched | <code>{ row: Row; target: EventTarget; currentTarget: EventTarget; }</code>                                                                                    |
+| mouseenter:row       | dispatched | <code>Row</code>                                                                                                                                               |
+| mouseleave:row       | dispatched | <code>Row</code>                                                                                                                                               |
+| click:row--expand    | dispatched | <code>{ expanded: boolean; row: Row; }</code>                                                                                                                  |
+| click:row--select    | dispatched | <code>{ selected: boolean; row: Row; }</code>                                                                                                                  |
+| click:cell           | dispatched | <code>{ cell: DataTableCell<Row>; target: EventTarget; currentTarget: EventTarget; }</code>                                                                    |
 
 ## `DataTableSkeleton`
 

--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -3208,7 +3208,7 @@
         {
           "type": "dispatched",
           "name": "click:header",
-          "detail": "{\n  header: DataTableHeader<Row>;\n  sortDirection?:\n    | \"ascending\"\n    | \"descending\"\n    | \"none\";\n}"
+          "detail": "{\n  header: DataTableHeader<Row>;\n  sortDirection?:\n    | \"ascending\"\n    | \"descending\"\n    | \"none\";\n  target: EventTarget;\n  currentTarget: EventTarget;\n}"
         },
         {
           "type": "dispatched",
@@ -3218,7 +3218,7 @@
         {
           "type": "dispatched",
           "name": "click:row",
-          "detail": "Row"
+          "detail": "{\n  row: Row;\n  target: EventTarget;\n  currentTarget: EventTarget;\n}"
         },
         {
           "type": "dispatched",
@@ -3243,7 +3243,7 @@
         {
           "type": "dispatched",
           "name": "click:cell",
-          "detail": "DataTableCell<Row>"
+          "detail": "{\n  cell: DataTableCell<Row>;\n  target: EventTarget;\n  currentTarget: EventTarget;\n}"
         }
       ],
       "typedefs": [

--- a/src/DataTable/DataTable.svelte
+++ b/src/DataTable/DataTable.svelte
@@ -35,14 +35,14 @@
    * @slot {{ row: Row; cell: DataTableCell<Row>; rowIndex: number; cellIndex: number; rowSelected: boolean; rowExpanded: boolean; }} cell
    * @event {{ header?: DataTableHeader<Row>; row?: Row; cell?: DataTableCell<Row>; }} click
    * @event {{ expanded: boolean; }} click:header--expand
-   * @event {{ header: DataTableHeader<Row>; sortDirection?: "ascending" | "descending" | "none" }} click:header
+   * @event {{ header: DataTableHeader<Row>; sortDirection?: "ascending" | "descending" | "none"; target: EventTarget; currentTarget: EventTarget; }} click:header
    * @event {{ indeterminate: boolean; selected: boolean; }} click:header--select
-   * @event {Row} click:row
+   * @event {{ row: Row; target: EventTarget; currentTarget: EventTarget; }} click:row
    * @event {Row} mouseenter:row
    * @event {Row} mouseleave:row
    * @event {{ expanded: boolean; row: Row; }} click:row--expand
    * @event {{ selected: boolean; row: Row; }} click:row--select
-   * @event {DataTableCell<Row>} click:cell
+   * @event {{ cell: DataTableCell<Row>; target: EventTarget; currentTarget: EventTarget; }} click:cell
    * @restProps {div}
    */
 
@@ -436,18 +436,27 @@
               sortable={sortable && header.sort !== false}
               sortDirection={sortKey === header.key ? sortDirection : "none"}
               active={sortKey === header.key}
-              on:click={() => {
+              on:click={(e) => {
                 dispatch("click", { header });
 
                 if (header.sort === false) {
-                  dispatch("click:header", { header });
+                  dispatch("click:header", {
+                    header,
+                    target: e.target,
+                    currentTarget: e.currentTarget,
+                  });
                 } else {
                   let currentSortDirection =
                     sortKey === header.key ? sortDirection : "none";
                   sortDirection = sortDirectionMap[currentSortDirection];
                   sortKey =
                     sortDirection === "none" ? null : thKeys[header.key];
-                  dispatch("click:header", { header, sortDirection });
+                  dispatch("click:header", {
+                    header,
+                    sortDirection,
+                    target: e.target,
+                    currentTarget: e.currentTarget,
+                  });
                 }
               }}
             >
@@ -469,18 +478,22 @@
             : ''} {expandable && parentRowId === row.id
             ? 'bx--expandable-row--hover'
             : ''}"
-          on:click={({ target }) => {
+          on:click={(e) => {
             // forgo "click", "click:row" events if target
             // resembles an overflow menu, a checkbox, or radio button
             if (
-              [...target.classList].some((name) =>
+              [...e.target.classList].some((name) =>
                 /^bx--(overflow-menu|checkbox|radio-button)/.test(name),
               )
             ) {
               return;
             }
             dispatch("click", { row });
-            dispatch("click:row", row);
+            dispatch("click:row", {
+              row,
+              target: e.target,
+              currentTarget: e.currentTarget,
+            });
           }}
           on:mouseenter={() => {
             dispatch("mouseenter:row", row);
@@ -584,9 +597,13 @@
               </td>
             {:else}
               <TableCell
-                on:click={() => {
+                on:click={(e) => {
                   dispatch("click", { row, cell });
-                  dispatch("click:cell", cell);
+                  dispatch("click:cell", {
+                    cell,
+                    target: e.target,
+                    currentTarget: e.currentTarget,
+                  });
                 }}
               >
                 <slot

--- a/types/DataTable/DataTable.svelte.d.ts
+++ b/types/DataTable/DataTable.svelte.d.ts
@@ -210,17 +210,27 @@ export default class DataTable<
     ["click:header"]: CustomEvent<{
       header: DataTableHeader<Row>;
       sortDirection?: "ascending" | "descending" | "none";
+      target: EventTarget;
+      currentTarget: EventTarget;
     }>;
     ["click:header--select"]: CustomEvent<{
       indeterminate: boolean;
       selected: boolean;
     }>;
-    ["click:row"]: CustomEvent<Row>;
+    ["click:row"]: CustomEvent<{
+      row: Row;
+      target: EventTarget;
+      currentTarget: EventTarget;
+    }>;
     ["mouseenter:row"]: CustomEvent<Row>;
     ["mouseleave:row"]: CustomEvent<Row>;
     ["click:row--expand"]: CustomEvent<{ expanded: boolean; row: Row }>;
     ["click:row--select"]: CustomEvent<{ selected: boolean; row: Row }>;
-    ["click:cell"]: CustomEvent<DataTableCell<Row>>;
+    ["click:cell"]: CustomEvent<{
+      cell: DataTableCell<Row>;
+      target: EventTarget;
+      currentTarget: EventTarget;
+    }>;
   },
   {
     default: {};


### PR DESCRIPTION
Closes #1904

The click:row, click:cell, and click:header events now include target and currentTarget properties in addition to their existing data. This allows the consumer to determine which specific element was clicked and implement conditional logic based on the click target.

**Breaking change**: Event detail structure has changed from a single value to an object:
- click:row: Row -> `{ row, target, currentTarget }`
- click:cell: DataTableCell -> `{ cell, target, currentTarget }`
- click:header: maintains `header` and `sortDirection`, adds target and currentTarget