### PR TITLE
fix(multi-select): only focus input if filterable

### DIFF
--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -536,7 +536,11 @@
               sortedItems = sortedItems.map((_) =>
                 _.id === item.id ? { ..._, checked: !_.checked } : _,
               );
-              fieldRef.focus();
+              if (filterable) {
+                inputRef?.focus();
+              } else {
+                fieldRef?.focus();
+              }
             }}
             on:mouseenter={() => {
               if (item.disabled) return;

--- a/tests/MultiSelect/MultiSelect.test.ts
+++ b/tests/MultiSelect/MultiSelect.test.ts
@@ -632,4 +632,23 @@ describe("MultiSelect", () => {
     await user.click(disabledOption);
     expect(disabledOption).toHaveAttribute("aria-selected", "false");
   });
+
+  // Regression test for https://github.com/carbon-design-system/carbon-components-svelte/issues/2288
+  it("clicking checkbox in filterable variant should not throw error", async () => {
+    render(MultiSelect, {
+      props: {
+        items,
+        filterable: true,
+        placeholder: "Filter...",
+      },
+    });
+
+    const input = screen.getByPlaceholderText("Filter...");
+    await user.click(input);
+    await toggleOption("Slack");
+
+    const options = screen.getAllByRole("option");
+    expect(options[2]).toHaveAttribute("aria-selected", "true");
+    expect(input).toHaveFocus();
+  });
 });


### PR DESCRIPTION
Fixes #2288

#2231 addressed a11y issues with `MultiSelect`, but caused a regression. For the filterable variant, selecting an option would throw a type error.

This forward fixes it, and adds a regression test. I'll backport this to v0.89.x.