### PR TITLE
fix(multi-select): restore keyboard navigation for filterable variant

### DIFF
--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -408,8 +408,10 @@
             } else if (key === "Tab") {
               open = false;
             } else if (key === "ArrowDown") {
+              if (!open) open = true;
               change(1);
             } else if (key === "ArrowUp") {
+              if (!open) open = true;
               change(-1);
             } else if (key === "Escape") {
               open = false;
@@ -418,6 +420,9 @@
             }
           }}
           on:input
+          on:input={() => {
+            if (!open) open = true;
+          }}
           on:keyup
           on:focus
           on:blur
@@ -476,14 +481,12 @@
           if (key === " ") {
             open = !open;
           } else if (key === "Tab") {
-            if (selectionRef && checked.length > 0) {
-              selectionRef.focus();
-            } else {
-              open = false;
-            }
+            open = false;
           } else if (key === "ArrowDown") {
+            if (!open) open = true;
             change(1);
           } else if (key === "ArrowUp") {
+            if (!open) open = true;
             change(-1);
           } else if (key === "Enter") {
             if (highlightedIndex > -1) {


### PR DESCRIPTION
Fixes #2313

#2231 introduced a regression to keyboard navigation when attempting to resolve accessibility issues. It unintentionally removed the focus handler that would open the menu. As such, tabbing into the field no longer opened the menu.

This fixes the bug, and adds regression tests.