### PR TITLE
fix(slider): store event object for drag calculations

### DIFF
--- a/src/Slider/Slider.svelte
+++ b/src/Slider/Slider.svelte
@@ -74,6 +74,7 @@
   let trackRef = null;
   let dragging = false;
   let holding = false;
+  let currentEvent = null;
 
   function startDragging() {
     dragging = true;
@@ -86,16 +87,18 @@
   function stopHolding() {
     holding = false;
     dragging = false;
+    currentEvent = null;
   }
 
-  function move() {
+  function move(e) {
     if (holding) {
+      currentEvent = e;
       startDragging();
     }
   }
 
   function calcValue(e) {
-    if (disabled) return;
+    if (disabled || !e) return;
 
     const offsetX = e.touches ? e.touches[0].clientX : e.clientX;
     const { left, width } = trackRef.getBoundingClientRect();
@@ -123,8 +126,8 @@
       value = max;
     }
 
-    if (dragging) {
-      calcValue(event);
+    if (dragging && currentEvent) {
+      calcValue(currentEvent);
       dragging = false;
     }
 

--- a/tests/Slider/Slider.test.ts
+++ b/tests/Slider/Slider.test.ts
@@ -153,6 +153,24 @@ describe("Slider", () => {
     expect(consoleLog).toHaveBeenCalledWith("change", 990);
   });
 
+  it("should handle mouse dragging without errors", async () => {
+    render(Slider);
+
+    const container = screen.getByRole("presentation");
+    const { left, width } = container.getBoundingClientRect();
+
+    await user.pointer({ target: container, keys: "[MouseLeft]" });
+    await user.pointer({
+      target: container,
+      coords: { x: left + width / 2 },
+    });
+
+    await user.pointer({ target: container, keys: "[/MouseLeft]" });
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(container).toBeInTheDocument();
+  });
+
   it("should not respond to dragging when disabled", async () => {
     const consoleLog = vi.spyOn(console, "log");
     render(Slider, {


### PR DESCRIPTION
Blocks #2319

Fixes a TypeError when dragging by storing the event object in the `move()` handler instead of relying on an undefined global event variable.