### PR TITLE
feat(types): annotate typedefs and dispatched events

### DIFF
--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -610,10 +610,7 @@ None.
 ```ts
 export type ColumnSize = boolean | number;
 
-export interface ColumnSizeDescriptor {
-  span?: ColumnSize;
-  offset: number;
-}
+export type ColumnSizeDescriptor = { span?: ColumnSize; offset: number };
 
 export type ColumnBreakpoint = ColumnSize | ColumnSizeDescriptor;
 ```
@@ -651,11 +648,11 @@ None.
 ```ts
 export type ComboBoxItemId = any;
 
-export interface ComboBoxItem {
+export type ComboBoxItem = {
   id: ComboBoxItemId;
   text: string;
-  disabled?: boolean;
-}
+  /** Whether the item is disabled */ disabled?: boolean;
+};
 ```
 
 ### Props
@@ -699,17 +696,17 @@ export interface ComboBoxItem {
 
 ### Events
 
-| Event name | Type       | Detail                                                          | Description |
-| :--------- | :--------- | :-------------------------------------------------------------- | :---------- |
-| select     | dispatched | <code>{ selectedId: ComboBoxItemId; selectedItem: Item }</code> | --          |
-| clear      | forwarded  | --                                                              | --          |
-| input      | forwarded  | --                                                              | --          |
-| keydown    | forwarded  | --                                                              | --          |
-| keyup      | forwarded  | --                                                              | --          |
-| focus      | forwarded  | --                                                              | --          |
-| blur       | forwarded  | --                                                              | --          |
-| paste      | forwarded  | --                                                              | --          |
-| scroll     | forwarded  | --                                                              | --          |
+| Event name | Type       | Detail                                                           | Description |
+| :--------- | :--------- | :--------------------------------------------------------------- | :---------- |
+| select     | dispatched | <code>{ selectedId: ComboBoxItemId; selectedItem: Item; }</code> | --          |
+| clear      | forwarded  | --                                                               | --          |
+| input      | forwarded  | --                                                               | --          |
+| keydown    | forwarded  | --                                                               | --          |
+| keyup      | forwarded  | --                                                               | --          |
+| focus      | forwarded  | --                                                               | --          |
+| blur       | forwarded  | --                                                               | --          |
+| paste      | forwarded  | --                                                               | --          |
+| scroll     | forwarded  | --                                                               | --          |
 
 ## `ComposedModal`
 
@@ -733,18 +730,18 @@ export interface ComboBoxItem {
 
 ### Events
 
-| Event name            | Type       | Detail                                                                              | Description |
-| :-------------------- | :--------- | :---------------------------------------------------------------------------------- | :---------- |
-| close                 | dispatched | <code>{ trigger: "escape-key" &#124; "outside-click" &#124; "close-button" }</code> | --          |
-| transitionend         | dispatched | <code>{ open: boolean; }</code>                                                     | --          |
-| keydown               | forwarded  | --                                                                                  | --          |
-| click                 | forwarded  | --                                                                                  | --          |
-| mouseover             | forwarded  | --                                                                                  | --          |
-| mouseenter            | forwarded  | --                                                                                  | --          |
-| mouseleave            | forwarded  | --                                                                                  | --          |
-| submit                | dispatched | <code>null</code>                                                                   | --          |
-| click:button--primary | dispatched | <code>null</code>                                                                   | --          |
-| open                  | dispatched | <code>null</code>                                                                   | --          |
+| Event name            | Type       | Detail                                                                               | Description |
+| :-------------------- | :--------- | :----------------------------------------------------------------------------------- | :---------- |
+| close                 | dispatched | <code>{ trigger: "escape-key" &#124; "outside-click" &#124; "close-button"; }</code> | --          |
+| transitionend         | dispatched | <code>{ open: boolean; }</code>                                                      | --          |
+| keydown               | forwarded  | --                                                                                   | --          |
+| click                 | forwarded  | --                                                                                   | --          |
+| mouseover             | forwarded  | --                                                                                   | --          |
+| mouseenter            | forwarded  | --                                                                                   | --          |
+| mouseleave            | forwarded  | --                                                                                   | --          |
+| submit                | dispatched | <code>null</code>                                                                    | --          |
+| click:button--primary | dispatched | <code>null</code>                                                                    | --          |
+| open                  | dispatched | <code>null</code>                                                                    | --          |
 
 ## `Content`
 
@@ -937,25 +934,25 @@ export type DataTableKey<Row = DataTableRow> =
 
 export type DataTableValue = any;
 
-export interface DataTableEmptyHeader<Row = DataTableRow> {
+export type DataTableEmptyHeader<Row = DataTableRow> = {
   key: DataTableKey<Row> | (string & {});
-  empty: boolean;
+  /** Whether the header is empty */ empty: boolean;
   display?: (item: DataTableValue, row: Row) => DataTableValue;
   sort?: false | ((a: DataTableValue, b: DataTableValue) => number);
-  columnMenu?: boolean;
+  /** Whether the column menu is enabled */ columnMenu?: boolean;
   width?: string;
   minWidth?: string;
-}
+};
 
-export interface DataTableNonEmptyHeader<Row = DataTableRow> {
+export type DataTableNonEmptyHeader<Row = DataTableRow> = {
   key: DataTableKey<Row>;
   value: DataTableValue;
   display?: (item: DataTableValue, row: Row) => DataTableValue;
   sort?: false | ((a: DataTableValue, b: DataTableValue) => number);
-  columnMenu?: boolean;
+  /** Whether the column menu is enabled */ columnMenu?: boolean;
   width?: string;
   minWidth?: string;
-}
+};
 
 export type DataTableHeader<Row = DataTableRow> =
   | DataTableNonEmptyHeader<Row>
@@ -968,11 +965,11 @@ export interface DataTableRow {
 
 export type DataTableRowId = any;
 
-export interface DataTableCell<Row = DataTableRow> {
+export type DataTableCell<Row = DataTableRow> = {
   key: DataTableKey<Row> | (string & {});
   value: DataTableValue;
   display?: (item: DataTableValue, row: DataTableRow) => DataTableValue;
-}
+};
 ```
 
 ### Props
@@ -1016,18 +1013,18 @@ export interface DataTableCell<Row = DataTableRow> {
 
 ### Events
 
-| Event name           | Type       | Detail                                                                                                                                                         | Description |
-| :------------------- | :--------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------- | :---------- |
-| click                | dispatched | <code>{ header?: DataTableHeader<Row>; row?: Row; cell?: DataTableCell<Row>; }</code>                                                                          | --          |
-| click:header--expand | dispatched | <code>{ expanded: boolean; }</code>                                                                                                                            | --          |
-| click:header         | dispatched | <code>{ header: DataTableHeader<Row>; sortDirection?: "ascending" &#124; "descending" &#124; "none"; target: EventTarget; currentTarget: EventTarget; }</code> | --          |
-| click:header--select | dispatched | <code>{ indeterminate: boolean; selected: boolean; }</code>                                                                                                    | --          |
-| click:row            | dispatched | <code>{ row: Row; target: EventTarget; currentTarget: EventTarget; }</code>                                                                                    | --          |
-| mouseenter:row       | dispatched | <code>Row</code>                                                                                                                                               | --          |
-| mouseleave:row       | dispatched | <code>Row</code>                                                                                                                                               | --          |
-| click:row--expand    | dispatched | <code>{ expanded: boolean; row: Row; }</code>                                                                                                                  | --          |
-| click:row--select    | dispatched | <code>{ selected: boolean; row: Row; }</code>                                                                                                                  | --          |
-| click:cell           | dispatched | <code>{ cell: DataTableCell<Row>; target: EventTarget; currentTarget: EventTarget; }</code>                                                                    | --          |
+| Event name           | Type       | Detail                                                                                                        | Description |
+| :------------------- | :--------- | :------------------------------------------------------------------------------------------------------------ | :---------- |
+| click                | dispatched | <code>{ header?: DataTableHeader<Row>; row?: Row; cell?: DataTableCell<Row>; }</code>                         | --          |
+| click:header--expand | dispatched | <code>{ expanded: boolean; }</code>                                                                           | --          |
+| click:header         | dispatched | <code>{ header: DataTableHeader<Row>; sortDirection?: "ascending" &#124; "descending" &#124; "none"; }</code> | --          |
+| click:header--select | dispatched | <code>{ indeterminate: boolean; selected: boolean; }</code>                                                   | --          |
+| click:row            | dispatched | <code>{ row: Row; }</code>                                                                                    | --          |
+| mouseenter:row       | dispatched | <code>Row</code>                                                                                              | --          |
+| mouseleave:row       | dispatched | <code>Row</code>                                                                                              | --          |
+| click:row--expand    | dispatched | <code>{ expanded: boolean; row: Row; }</code>                                                                 | --          |
+| click:row--select    | dispatched | <code>{ selected: boolean; row: Row; }</code>                                                                 | --          |
+| click:cell           | dispatched | <code>{ cell: DataTableCell<Row>; }</code>                                                                    | --          |
 
 ## `DataTableSkeleton`
 
@@ -1161,11 +1158,11 @@ export type DropdownItemId = any;
 
 export type DropdownItemText = string;
 
-export interface DropdownItem {
+export type DropdownItem = {
   id: DropdownItemId;
   text: DropdownItemText;
-  disabled?: boolean;
-}
+  /** Whether the item is disabled */ disabled?: boolean;
+};
 ```
 
 ### Props
@@ -1202,9 +1199,9 @@ export interface DropdownItem {
 
 ### Events
 
-| Event name | Type       | Detail                                                          | Description |
-| :--------- | :--------- | :-------------------------------------------------------------- | :---------- |
-| select     | dispatched | <code>{ selectedId: DropdownItemId, selectedItem: Item }</code> | --          |
+| Event name | Type       | Detail                                                           | Description |
+| :--------- | :--------- | :--------------------------------------------------------------- | :---------- |
+| select     | dispatched | <code>{ selectedId: DropdownItemId; selectedItem: Item; }</code> | --          |
 
 ## `DropdownSkeleton`
 
@@ -1829,11 +1826,11 @@ None.
 ### Types
 
 ```ts
-export interface HeaderSearchResult {
+export type HeaderSearchResult = {
   href: string;
   text: string;
   description?: string;
-}
+};
 ```
 
 ### Props
@@ -1854,18 +1851,18 @@ export interface HeaderSearchResult {
 
 ### Events
 
-| Event name | Type       | Detail                                                                                          | Description |
-| :--------- | :--------- | :---------------------------------------------------------------------------------------------- | :---------- |
-| active     | dispatched | <code>null</code>                                                                               | --          |
-| inactive   | dispatched | <code>null</code>                                                                               | --          |
-| clear      | dispatched | <code>null</code>                                                                               | --          |
-| select     | dispatched | <code>{ value: string; selectedResultIndex: number; selectedResult: HeaderSearchResult }</code> | --          |
-| change     | forwarded  | --                                                                                              | --          |
-| input      | forwarded  | --                                                                                              | --          |
-| focus      | forwarded  | --                                                                                              | --          |
-| blur       | forwarded  | --                                                                                              | --          |
-| keydown    | forwarded  | --                                                                                              | --          |
-| paste      | forwarded  | --                                                                                              | --          |
+| Event name | Type       | Detail                                                                                           | Description |
+| :--------- | :--------- | :----------------------------------------------------------------------------------------------- | :---------- |
+| active     | dispatched | <code>null</code>                                                                                | --          |
+| inactive   | dispatched | <code>null</code>                                                                                | --          |
+| clear      | dispatched | <code>null</code>                                                                                | --          |
+| select     | dispatched | <code>{ value: string; selectedResultIndex: number; selectedResult: HeaderSearchResult; }</code> | --          |
+| change     | forwarded  | --                                                                                               | --          |
+| input      | forwarded  | --                                                                                               | --          |
+| focus      | forwarded  | --                                                                                               | --          |
+| blur       | forwarded  | --                                                                                               | --          |
+| keydown    | forwarded  | --                                                                                               | --          |
+| paste      | forwarded  | --                                                                                               | --          |
 
 ## `HeaderUtilities`
 
@@ -1964,13 +1961,13 @@ None.
 
 ### Events
 
-| Event name | Type       | Detail                            | Description |
-| :--------- | :--------- | :-------------------------------- | :---------- |
-| close      | dispatched | <code>{ timeout: boolean }</code> | --          |
-| click      | forwarded  | --                                | --          |
-| mouseover  | forwarded  | --                                | --          |
-| mouseenter | forwarded  | --                                | --          |
-| mouseleave | forwarded  | --                                | --          |
+| Event name | Type       | Detail                             | Description |
+| :--------- | :--------- | :--------------------------------- | :---------- |
+| close      | dispatched | <code>{ timeout: boolean; }</code> | --          |
+| click      | forwarded  | --                                 | --          |
+| mouseover  | forwarded  | --                                 | --          |
+| mouseenter | forwarded  | --                                 | --          |
+| mouseleave | forwarded  | --                                 | --          |
 
 ## `Link`
 
@@ -2268,19 +2265,19 @@ None.
 
 ### Events
 
-| Event name              | Type       | Detail                                                                              | Description |
-| :---------------------- | :--------- | :---------------------------------------------------------------------------------- | :---------- |
-| close                   | dispatched | <code>{ trigger: "escape-key" &#124; "outside-click" &#124; "close-button" }</code> | --          |
-| transitionend           | dispatched | <code>{ open: boolean; }</code>                                                     | --          |
-| click:button--secondary | dispatched | <code>{ text: string; }</code>                                                      | --          |
-| keydown                 | forwarded  | --                                                                                  | --          |
-| click                   | forwarded  | --                                                                                  | --          |
-| mouseover               | forwarded  | --                                                                                  | --          |
-| mouseenter              | forwarded  | --                                                                                  | --          |
-| mouseleave              | forwarded  | --                                                                                  | --          |
-| submit                  | dispatched | <code>null</code>                                                                   | --          |
-| click:button--primary   | dispatched | <code>null</code>                                                                   | --          |
-| open                    | dispatched | <code>null</code>                                                                   | --          |
+| Event name              | Type       | Detail                                                                               | Description |
+| :---------------------- | :--------- | :----------------------------------------------------------------------------------- | :---------- |
+| close                   | dispatched | <code>{ trigger: "escape-key" &#124; "outside-click" &#124; "close-button"; }</code> | --          |
+| transitionend           | dispatched | <code>{ open: boolean; }</code>                                                      | --          |
+| click:button--secondary | dispatched | <code>{ text: string; }</code>                                                       | --          |
+| keydown                 | forwarded  | --                                                                                   | --          |
+| click                   | forwarded  | --                                                                                   | --          |
+| mouseover               | forwarded  | --                                                                                   | --          |
+| mouseenter              | forwarded  | --                                                                                   | --          |
+| mouseleave              | forwarded  | --                                                                                   | --          |
+| submit                  | dispatched | <code>null</code>                                                                    | --          |
+| click:button--primary   | dispatched | <code>null</code>                                                                    | --          |
+| open                    | dispatched | <code>null</code>                                                                    | --          |
 
 ## `ModalBody`
 
@@ -2363,11 +2360,11 @@ export type MultiSelectItemId = any;
 
 export type MultiSelectItemText = string;
 
-export interface MultiSelectItem {
+export type MultiSelectItem = {
   id: MultiSelectItemId;
   text: MultiSelectItemText;
-  disabled?: boolean;
-}
+  /** Whether the item is disabled */ disabled?: boolean;
+};
 ```
 
 ### Props
@@ -2647,14 +2644,14 @@ None.
 
 ### Events
 
-| Event name | Type       | Detail                                                    | Description |
-| :--------- | :--------- | :-------------------------------------------------------- | :---------- |
-| close      | dispatched | <code>null &#124; { index: number; text: string; }</code> | --          |
-| click      | forwarded  | --                                                        | --          |
-| mouseover  | forwarded  | --                                                        | --          |
-| mouseenter | forwarded  | --                                                        | --          |
-| mouseleave | forwarded  | --                                                        | --          |
-| keydown    | forwarded  | --                                                        | --          |
+| Event name | Type       | Detail                                          | Description |
+| :--------- | :--------- | :---------------------------------------------- | :---------- |
+| close      | dispatched | <code>{ index?: number; text?: string; }</code> | --          |
+| click      | forwarded  | --                                              | --          |
+| mouseover  | forwarded  | --                                              | --          |
+| mouseenter | forwarded  | --                                              | --          |
+| mouseleave | forwarded  | --                                              | --          |
+| keydown    | forwarded  | --                                              | --          |
 
 ## `OverflowMenuItem`
 
@@ -2715,12 +2712,12 @@ None.
 
 ### Events
 
-| Event name             | Type       | Detail                                            | Description                           |
-| :--------------------- | :--------- | :------------------------------------------------ | :------------------------------------ |
-| change                 | dispatched | <code>{ page?: number; pageSize?: number }</code> | Dispatched after any user interaction |
-| click:button--previous | dispatched | <code>{ page: number; }</code>                    | --                                    |
-| click:button--next     | dispatched | <code>{ page: number; }</code>                    | --                                    |
-| update                 | dispatched | <code>{ pageSize: number; page: number; }</code>  | --                                    |
+| Event name             | Type       | Detail                                             | Description                           |
+| :--------------------- | :--------- | :------------------------------------------------- | :------------------------------------ |
+| change                 | dispatched | <code>{ page?: number; pageSize?: number; }</code> | Dispatched after any user interaction |
+| click:button--previous | dispatched | <code>{ page: number; }</code>                     | Dispatched after any user interaction |
+| click:button--next     | dispatched | <code>{ page: number; }</code>                     | Dispatched after any user interaction |
+| update                 | dispatched | <code>{ pageSize: number; page: number; }</code>   | Dispatched after any user interaction |
 
 ## `PaginationNav`
 
@@ -2744,7 +2741,7 @@ None.
 
 | Event name             | Type       | Detail                         | Description                        |
 | :--------------------- | :--------- | :----------------------------- | :--------------------------------- |
-| change                 | dispatched | <code>{ page: number; }</code> | fires after every user interaction |
+| change                 | dispatched | <code>{ page: number; }</code> | Fires after every user interaction |
 | click:button--previous | dispatched | <code>{ page: number; }</code> | --                                 |
 | click:button--next     | dispatched | <code>{ page: number; }</code> | --                                 |
 
@@ -3071,11 +3068,11 @@ None.
 ### Types
 
 ```ts
-export interface RecursiveListNode {
-  text?: string;
-  href?: string;
-  html?: string;
-}
+export type RecursiveListNode = {
+  /** Node text content */ text?: string;
+  /** Node link URL */ href?: string;
+  /** Node HTML content */ html?: string;
+};
 ```
 
 ### Props
@@ -4386,13 +4383,13 @@ export type CarbonTheme = "white" | "g10" | "g80" | "g90" | "g100";
 
 ### Events
 
-| Event name | Type       | Detail                            | Description |
-| :--------- | :--------- | :-------------------------------- | :---------- |
-| close      | dispatched | <code>{ timeout: boolean }</code> | --          |
-| click      | forwarded  | --                                | --          |
-| mouseover  | forwarded  | --                                | --          |
-| mouseenter | forwarded  | --                                | --          |
-| mouseleave | forwarded  | --                                | --          |
+| Event name | Type       | Detail                             | Description |
+| :--------- | :--------- | :--------------------------------- | :---------- |
+| close      | dispatched | <code>{ timeout: boolean; }</code> | --          |
+| click      | forwarded  | --                                 | --          |
+| mouseover  | forwarded  | --                                 | --          |
+| mouseenter | forwarded  | --                                 | --          |
+| mouseleave | forwarded  | --                                 | --          |
 
 ## `Toggle`
 
@@ -4708,13 +4705,13 @@ None.
 ```ts
 export type TreeNodeId = string | number;
 
-export interface TreeNode {
+export type TreeNode = {
   id: TreeNodeId;
   text: any;
   icon?: any;
-  disabled?: boolean;
+  /** Whether the node is disabled */ disabled?: boolean;
   nodes?: TreeNode[];
-}
+};
 ```
 
 ### Props
@@ -4743,12 +4740,12 @@ export interface TreeNode {
 
 ### Events
 
-| Event name | Type       | Detail                                                        | Description |
-| :--------- | :--------- | :------------------------------------------------------------ | :---------- |
-| select     | dispatched | <code>TreeNode & { expanded: boolean; leaf: boolean; }</code> | --          |
-| toggle     | dispatched | <code>TreeNode & { expanded: boolean; leaf: boolean; }</code> | --          |
-| focus      | dispatched | <code>TreeNode & { expanded: boolean; leaf: boolean; }</code> | --          |
-| keydown    | forwarded  | --                                                            | --          |
+| Event name | Type       | Detail                                                                                                                            | Description |
+| :--------- | :--------- | :-------------------------------------------------------------------------------------------------------------------------------- | :---------- |
+| select     | dispatched | <code>{ id: TreeNodeId; text: any; icon?: any; disabled?: boolean; nodes?: TreeNode[]; expanded: boolean; leaf: boolean; }</code> | --          |
+| toggle     | dispatched | <code>{ id: TreeNodeId; text: any; icon?: any; disabled?: boolean; nodes?: TreeNode[]; expanded: boolean; leaf: boolean; }</code> | --          |
+| focus      | dispatched | <code>{ id: TreeNodeId; text: any; icon?: any; disabled?: boolean; nodes?: TreeNode[]; expanded: boolean; leaf: boolean; }</code> | --          |
+| keydown    | forwarded  | --                                                                                                                                | --          |
 
 ## `Truncate`
 

--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -1815,9 +1815,9 @@
           "ts": "type ColumnSize = boolean | number;\n"
         },
         {
-          "type": "{span?: ColumnSize; offset: number;}",
+          "type": "{ span?: ColumnSize; offset: number; }",
           "name": "ColumnSizeDescriptor",
-          "ts": "interface ColumnSizeDescriptor {\n  span?: ColumnSize;\n  offset: number;\n}\n"
+          "ts": "type ColumnSizeDescriptor = {\n  span?: ColumnSize;\n  offset: number;\n};\n"
         },
         {
           "type": "ColumnSize | ColumnSizeDescriptor",
@@ -2228,9 +2228,9 @@
           "ts": "type ComboBoxItemId = any;\n"
         },
         {
-          "type": "{ id: ComboBoxItemId; text: string; disabled?: boolean; }",
+          "type": "{ id: ComboBoxItemId; text: string; /** Whether the item is disabled */ disabled?: boolean; }",
           "name": "ComboBoxItem",
-          "ts": "interface ComboBoxItem {\n  id: ComboBoxItemId;\n  text: string;\n  disabled?: boolean;\n}\n"
+          "ts": "type ComboBoxItem = {\n  id: ComboBoxItemId;\n  text: string;\n  /** Whether the item is disabled */ disabled?: boolean;\n};\n"
         }
       ],
       "generics": [
@@ -3461,7 +3461,7 @@
         {
           "type": "dispatched",
           "name": "click:header",
-          "detail": "{\n  header: DataTableHeader<Row>;\n  sortDirection?:\n    | \"ascending\"\n    | \"descending\"\n    | \"none\";\n  target: EventTarget;\n  currentTarget: EventTarget;\n}"
+          "detail": "{\n  header: DataTableHeader<Row>;\n  sortDirection?:\n    | \"ascending\"\n    | \"descending\"\n    | \"none\";\n}"
         },
         {
           "type": "dispatched",
@@ -3471,7 +3471,7 @@
         {
           "type": "dispatched",
           "name": "click:row",
-          "detail": "{\n  row: Row;\n  target: EventTarget;\n  currentTarget: EventTarget;\n}"
+          "detail": "{ row: Row }"
         },
         {
           "type": "dispatched",
@@ -3496,7 +3496,7 @@
         {
           "type": "dispatched",
           "name": "click:cell",
-          "detail": "{\n  cell: DataTableCell<Row>;\n  target: EventTarget;\n  currentTarget: EventTarget;\n}"
+          "detail": "{\n  cell: DataTableCell<Row>;\n}"
         }
       ],
       "typedefs": [
@@ -3511,14 +3511,14 @@
           "ts": "type DataTableValue = any;\n"
         },
         {
-          "type": "{\n   key: DataTableKey<Row> | (string & {});\n   empty: boolean;\n   display?: (item: DataTableValue, row: Row) => DataTableValue;\n   sort?: false | ((a: DataTableValue, b: DataTableValue) => number);\n   columnMenu?: boolean;\n   width?: string;\n   minWidth?: string;\n}",
+          "type": "{ key: DataTableKey<Row> | (string & {}); /** Whether the header is empty */ empty: boolean; display?: (item: DataTableValue, row: Row) => DataTableValue; sort?: false | ((a: DataTableValue, b: DataTableValue) => number); /** Whether the column menu is enabled */ columnMenu?: boolean; width?: string; minWidth?: string; }",
           "name": "DataTableEmptyHeader<Row=DataTableRow>",
-          "ts": "interface DataTableEmptyHeader<\n  Row = DataTableRow,\n> {\n  key:\n    | DataTableKey<Row>\n    | (string & {});\n  empty: boolean;\n  display?: (\n    item: DataTableValue,\n    row: Row,\n  ) => DataTableValue;\n  sort?:\n    | false\n    | ((\n        a: DataTableValue,\n        b: DataTableValue,\n      ) => number);\n  columnMenu?: boolean;\n  width?: string;\n  minWidth?: string;\n}\n"
+          "ts": "type DataTableEmptyHeader<\n  Row = DataTableRow,\n> = {\n  key:\n    | DataTableKey<Row>\n    | (string & {});\n  /** Whether the header is empty */ empty: boolean;\n  display?: (\n    item: DataTableValue,\n    row: Row,\n  ) => DataTableValue;\n  sort?:\n    | false\n    | ((\n        a: DataTableValue,\n        b: DataTableValue,\n      ) => number);\n  /** Whether the column menu is enabled */ columnMenu?: boolean;\n  width?: string;\n  minWidth?: string;\n};\n"
         },
         {
-          "type": "{\n   key: DataTableKey<Row>;\n   value: DataTableValue;\n   display?: (item: DataTableValue, row: Row) => DataTableValue;\n   sort?: false | ((a: DataTableValue, b: DataTableValue) => number);\n   columnMenu?: boolean;\n   width?: string;\n   minWidth?: string;\n}",
+          "type": "{ key: DataTableKey<Row>; value: DataTableValue; display?: (item: DataTableValue, row: Row) => DataTableValue; sort?: false | ((a: DataTableValue, b: DataTableValue) => number); /** Whether the column menu is enabled */ columnMenu?: boolean; width?: string; minWidth?: string; }",
           "name": "DataTableNonEmptyHeader<Row=DataTableRow>",
-          "ts": "interface DataTableNonEmptyHeader<\n  Row = DataTableRow,\n> {\n  key: DataTableKey<Row>;\n  value: DataTableValue;\n  display?: (\n    item: DataTableValue,\n    row: Row,\n  ) => DataTableValue;\n  sort?:\n    | false\n    | ((\n        a: DataTableValue,\n        b: DataTableValue,\n      ) => number);\n  columnMenu?: boolean;\n  width?: string;\n  minWidth?: string;\n}\n"
+          "ts": "type DataTableNonEmptyHeader<\n  Row = DataTableRow,\n> = {\n  key: DataTableKey<Row>;\n  value: DataTableValue;\n  display?: (\n    item: DataTableValue,\n    row: Row,\n  ) => DataTableValue;\n  sort?:\n    | false\n    | ((\n        a: DataTableValue,\n        b: DataTableValue,\n      ) => number);\n  /** Whether the column menu is enabled */ columnMenu?: boolean;\n  width?: string;\n  minWidth?: string;\n};\n"
         },
         {
           "type": "DataTableNonEmptyHeader<Row> | DataTableEmptyHeader<Row>",
@@ -3536,9 +3536,9 @@
           "ts": "type DataTableRowId = any;\n"
         },
         {
-          "type": "{\n   key: DataTableKey<Row> | (string & {});\n   value: DataTableValue;\n   display?: (item: DataTableValue, row: DataTableRow) => DataTableValue;\n}",
+          "type": "{ key: DataTableKey<Row> | (string & {}); value: DataTableValue; display?: (item: DataTableValue, row: DataTableRow) => DataTableValue; }",
           "name": "DataTableCell<Row=DataTableRow>",
-          "ts": "interface DataTableCell<\n  Row = DataTableRow,\n> {\n  key:\n    | DataTableKey<Row>\n    | (string & {});\n  value: DataTableValue;\n  display?: (\n    item: DataTableValue,\n    row: DataTableRow,\n  ) => DataTableValue;\n}\n"
+          "ts": "type DataTableCell<Row = DataTableRow> =\n  {\n    key:\n      | DataTableKey<Row>\n      | (string & {});\n    value: DataTableValue;\n    display?: (\n      item: DataTableValue,\n      row: DataTableRow,\n    ) => DataTableValue;\n  };\n"
         }
       ],
       "generics": [
@@ -4563,9 +4563,9 @@
           "ts": "type DropdownItemText = string;\n"
         },
         {
-          "type": "{ id: DropdownItemId; text: DropdownItemText; disabled?: boolean; }",
+          "type": "{ id: DropdownItemId; text: DropdownItemText; /** Whether the item is disabled */ disabled?: boolean; }",
           "name": "DropdownItem",
-          "ts": "interface DropdownItem {\n  id: DropdownItemId;\n  text: DropdownItemText;\n  disabled?: boolean;\n}\n"
+          "ts": "type DropdownItem = {\n  id: DropdownItemId;\n  text: DropdownItemText;\n  /** Whether the item is disabled */ disabled?: boolean;\n};\n"
         }
       ],
       "generics": [
@@ -7110,7 +7110,7 @@
         {
           "type": "{ href: string; text: string; description?: string; }",
           "name": "HeaderSearchResult",
-          "ts": "interface HeaderSearchResult {\n  href: string;\n  text: string;\n  description?: string;\n}\n"
+          "ts": "type HeaderSearchResult = {\n  href: string;\n  text: string;\n  description?: string;\n};\n"
         }
       ],
       "generics": null,
@@ -9520,9 +9520,9 @@
           "ts": "type MultiSelectItemText = string;\n"
         },
         {
-          "type": "{ id: MultiSelectItemId; text: MultiSelectItemText; disabled?: boolean; }",
+          "type": "{ id: MultiSelectItemId; text: MultiSelectItemText; /** Whether the item is disabled */ disabled?: boolean; }",
           "name": "MultiSelectItem",
-          "ts": "interface MultiSelectItem {\n  id: MultiSelectItemId;\n  text: MultiSelectItemText;\n  disabled?: boolean;\n}\n"
+          "ts": "type MultiSelectItem = {\n  id: MultiSelectItemId;\n  text: MultiSelectItemText;\n  /** Whether the item is disabled */ disabled?: boolean;\n};\n"
         }
       ],
       "generics": [
@@ -10438,7 +10438,7 @@
         {
           "type": "dispatched",
           "name": "close",
-          "detail": "null | {\n  index: number;\n  text: string;\n}"
+          "detail": "{\n  index?: number;\n  text?: string;\n}"
         },
         {
           "type": "forwarded",
@@ -10870,17 +10870,20 @@
         {
           "type": "dispatched",
           "name": "click:button--previous",
-          "detail": "{ page: number }"
+          "detail": "{ page: number }",
+          "description": "Dispatched after any user interaction"
         },
         {
           "type": "dispatched",
           "name": "click:button--next",
-          "detail": "{ page: number }"
+          "detail": "{ page: number }",
+          "description": "Dispatched after any user interaction"
         },
         {
           "type": "dispatched",
           "name": "update",
-          "detail": "{\n  pageSize: number;\n  page: number;\n}"
+          "detail": "{\n  pageSize: number;\n  page: number;\n}",
+          "description": "Dispatched after any user interaction"
         }
       ],
       "typedefs": [],
@@ -10987,7 +10990,7 @@
           "type": "dispatched",
           "name": "change",
           "detail": "{ page: number }",
-          "description": "fires after every user interaction"
+          "description": "Fires after every user interaction"
         },
         {
           "type": "dispatched",
@@ -12556,9 +12559,9 @@
       "events": [],
       "typedefs": [
         {
-          "type": "{ text?: string; href?: string; html?: string; }",
+          "type": "{ /** Node text content */ text?: string; /** Node link URL */ href?: string; /** Node HTML content */ html?: string; }",
           "name": "RecursiveListNode",
-          "ts": "interface RecursiveListNode {\n  text?: string;\n  href?: string;\n  html?: string;\n}\n"
+          "ts": "type RecursiveListNode = {\n  /** Node text content */ text?: string;\n  /** Node link URL */ href?: string;\n  /** Node HTML content */ html?: string;\n};\n"
         }
       ],
       "generics": null,
@@ -19053,17 +19056,17 @@
         {
           "type": "dispatched",
           "name": "select",
-          "detail": "TreeNode & {\n  expanded: boolean;\n  leaf: boolean;\n}"
+          "detail": "{\n  id: TreeNodeId;\n  text: any;\n  icon?: any;\n  disabled?: boolean;\n  nodes?: TreeNode[];\n  expanded: boolean;\n  leaf: boolean;\n}"
         },
         {
           "type": "dispatched",
           "name": "toggle",
-          "detail": "TreeNode & {\n  expanded: boolean;\n  leaf: boolean;\n}"
+          "detail": "{\n  id: TreeNodeId;\n  text: any;\n  icon?: any;\n  disabled?: boolean;\n  nodes?: TreeNode[];\n  expanded: boolean;\n  leaf: boolean;\n}"
         },
         {
           "type": "dispatched",
           "name": "focus",
-          "detail": "TreeNode & {\n  expanded: boolean;\n  leaf: boolean;\n}"
+          "detail": "{\n  id: TreeNodeId;\n  text: any;\n  icon?: any;\n  disabled?: boolean;\n  nodes?: TreeNode[];\n  expanded: boolean;\n  leaf: boolean;\n}"
         },
         {
           "type": "forwarded",
@@ -19078,9 +19081,9 @@
           "ts": "type TreeNodeId = string | number;\n"
         },
         {
-          "type": "{ id: TreeNodeId; text: any; icon?: any; disabled?: boolean; nodes?: TreeNode[]; }",
+          "type": "{ id: TreeNodeId; text: any; icon?: any; /** Whether the node is disabled */ disabled?: boolean; nodes?: TreeNode[]; }",
           "name": "TreeNode",
-          "ts": "interface TreeNode {\n  id: TreeNodeId;\n  text: any;\n  icon?: any;\n  disabled?: boolean;\n  nodes?: TreeNode[];\n}\n"
+          "ts": "type TreeNode = {\n  id: TreeNodeId;\n  text: any;\n  icon?: any;\n  /** Whether the node is disabled */ disabled?: boolean;\n  nodes?: TreeNode[];\n};\n"
         }
       ],
       "generics": null,

--- a/src/Breakpoint/Breakpoint.svelte
+++ b/src/Breakpoint/Breakpoint.svelte
@@ -2,7 +2,10 @@
   /**
    * @typedef {"sm" | "md" | "lg" | "xlg" | "max"} BreakpointSize
    * @typedef {320 | 672 | 1056 | 1312 | 1584} BreakpointValue
-   * @event {{ size: BreakpointSize; breakpointValue: BreakpointValue; }} change
+   * @event change
+   * @type {object}
+   * @property {BreakpointSize} size
+   * @property {BreakpointValue} breakpointValue
    * @slot {{ size: BreakpointSize; sizes: Record<BreakpointSize, boolean>; }}
    */
 

--- a/src/ComboBox/ComboBox.svelte
+++ b/src/ComboBox/ComboBox.svelte
@@ -3,8 +3,14 @@
    * @generics {Item extends ComboBoxItem = ComboBoxItem} Item
    * @template {ComboBoxItem} Item
    * @typedef {any} ComboBoxItemId
-   * @typedef {{ id: ComboBoxItemId; text: string; disabled?: boolean; }} ComboBoxItem
-   * @event {{ selectedId: ComboBoxItemId; selectedItem: Item }} select
+   * @typedef {object} ComboBoxItem
+   * @property {ComboBoxItemId} id
+   * @property {string} text
+   * @property {boolean} [disabled] - Whether the item is disabled
+   * @event select
+   * @type {object}
+   * @property {ComboBoxItemId} selectedId
+   * @property {Item} selectedItem
    * @event {KeyboardEvent | MouseEvent} clear
    * @slot {{ item: Item; index: number }}
    */

--- a/src/ComposedModal/ComposedModal.svelte
+++ b/src/ComposedModal/ComposedModal.svelte
@@ -1,7 +1,9 @@
 <script>
   /**
-   * @event {{ trigger: "escape-key" | "outside-click" | "close-button" }} close
-   * @event {{ open: boolean; }} transitionend
+   * @event close
+   * @property {"escape-key" | "outside-click" | "close-button"} trigger
+   * @event transitionend
+   * @property {boolean} open
    */
 
   /**

--- a/src/ComposedModal/ModalFooter.svelte
+++ b/src/ComposedModal/ModalFooter.svelte
@@ -1,6 +1,7 @@
 <script>
   /**
-   * @event {{ text: string; }} click:button--secondary
+   * @event click:button--secondary
+   * @property {string} text
    */
 
   /** Specify the primary button text */

--- a/src/DataTable/DataTable.svelte
+++ b/src/DataTable/DataTable.svelte
@@ -4,45 +4,64 @@
    * @template {DataTableRow} Row
    * @typedef {import('./DataTableTypes.d.ts').PropertyPath<Row>} DataTableKey<Row=DataTableRow>
    * @typedef {any} DataTableValue
-   * @typedef {{
-   *    key: DataTableKey<Row> | (string & {});
-   *    empty: boolean;
-   *    display?: (item: DataTableValue, row: Row) => DataTableValue;
-   *    sort?: false | ((a: DataTableValue, b: DataTableValue) => number);
-   *    columnMenu?: boolean;
-   *    width?: string;
-   *    minWidth?: string;
-   * }} DataTableEmptyHeader<Row=DataTableRow>
-   * @typedef {{
-   *    key: DataTableKey<Row>;
-   *    value: DataTableValue;
-   *    display?: (item: DataTableValue, row: Row) => DataTableValue;
-   *    sort?: false | ((a: DataTableValue, b: DataTableValue) => number);
-   *    columnMenu?: boolean;
-   *    width?: string;
-   *    minWidth?: string;
-   * }} DataTableNonEmptyHeader<Row=DataTableRow>
+   * @typedef {object} DataTableEmptyHeader<Row=DataTableRow>
+   * @property {DataTableKey<Row> | (string & {})} key
+   * @property {boolean} empty - Whether the header is empty
+   * @property {(item: DataTableValue, row: Row) => DataTableValue} [display]
+   * @property {false | ((a: DataTableValue, b: DataTableValue) => number)} [sort]
+   * @property {boolean} [columnMenu] - Whether the column menu is enabled
+   * @property {string} [width]
+   * @property {string} [minWidth]
+   * @typedef {object} DataTableNonEmptyHeader<Row=DataTableRow>
+   * @property {DataTableKey<Row>} key
+   * @property {DataTableValue} value
+   * @property {(item: DataTableValue, row: Row) => DataTableValue} [display]
+   * @property {false | ((a: DataTableValue, b: DataTableValue) => number)} [sort]
+   * @property {boolean} [columnMenu] - Whether the column menu is enabled
+   * @property {string} [width]
+   * @property {string} [minWidth]
    * @typedef {DataTableNonEmptyHeader<Row> | DataTableEmptyHeader<Row>} DataTableHeader<Row=DataTableRow>
    * @typedef {{ id: any; [key: string]: DataTableValue; }} DataTableRow
    * @typedef {any} DataTableRowId
-   * @typedef {{
-   *    key: DataTableKey<Row> | (string & {});
-   *    value: DataTableValue;
-   *    display?: (item: DataTableValue, row: DataTableRow) => DataTableValue;
-   * }} DataTableCell<Row=DataTableRow>
+   * @typedef {object} DataTableCell<Row=DataTableRow>
+   * @property {DataTableKey<Row> | (string & {})} key
+   * @property {DataTableValue} value
+   * @property {(item: DataTableValue, row: DataTableRow) => DataTableValue} [display]
    * @slot {{ row: Row; rowSelected: boolean; }} expanded-row
    * @slot {{ header: DataTableNonEmptyHeader; }} cell-header
    * @slot {{ row: Row; cell: DataTableCell<Row>; rowIndex: number; cellIndex: number; rowSelected: boolean; rowExpanded: boolean; }} cell
-   * @event {{ header?: DataTableHeader<Row>; row?: Row; cell?: DataTableCell<Row>; }} click
-   * @event {{ expanded: boolean; }} click:header--expand
-   * @event {{ header: DataTableHeader<Row>; sortDirection?: "ascending" | "descending" | "none"; target: EventTarget; currentTarget: EventTarget; }} click:header
-   * @event {{ indeterminate: boolean; selected: boolean; }} click:header--select
-   * @event {{ row: Row; target: EventTarget; currentTarget: EventTarget; }} click:row
+   * @event click
+   * @type {object}
+   * @property {DataTableHeader<Row>} [header]
+   * @property {Row} [row]
+   * @property {DataTableCell<Row>} [cell]
+   * @event click:header--expand
+   * @type {object}
+   * @property {boolean} expanded
+   * @event click:header
+   * @type {object}
+   * @property {DataTableHeader<Row>} header
+   * @property {"ascending" | "descending" | "none"} [sortDirection]
+   * @event click:header--select
+   * @type {object}
+   * @property {boolean} indeterminate
+   * @property {boolean} selected
+   * @event click:row
+   * @type {object}
+   * @property {Row} row
    * @event {Row} mouseenter:row
    * @event {Row} mouseleave:row
-   * @event {{ expanded: boolean; row: Row; }} click:row--expand
-   * @event {{ selected: boolean; row: Row; }} click:row--select
-   * @event {{ cell: DataTableCell<Row>; target: EventTarget; currentTarget: EventTarget; }} click:cell
+   * @event click:row--expand
+   * @type {object}
+   * @property {boolean} expanded
+   * @property {Row} row
+   * @event click:row--select
+   * @type {object}
+   * @property {boolean} selected
+   * @property {Row} row
+   * @event click:cell
+   * @type {object}
+   * @property {DataTableCell<Row>} cell
    * @restProps {div}
    */
 

--- a/src/Dropdown/Dropdown.svelte
+++ b/src/Dropdown/Dropdown.svelte
@@ -4,8 +4,14 @@
    * @template {DropdownItem} Item
    * @typedef {any} DropdownItemId
    * @typedef {string} DropdownItemText
-   * @typedef {{ id: DropdownItemId; text: DropdownItemText; disabled?: boolean; }} DropdownItem
-   * @event {{ selectedId: DropdownItemId, selectedItem: Item }} select
+   * @typedef {object} DropdownItem
+   * @property {DropdownItemId} id
+   * @property {DropdownItemText} text
+   * @property {boolean} [disabled] - Whether the item is disabled
+   * @event select
+   * @type {object}
+   * @property {DropdownItemId} selectedId
+   * @property {Item} selectedItem
    * @slot {{ item: Item; index: number; }}
    */
 

--- a/src/Grid/Column.svelte
+++ b/src/Grid/Column.svelte
@@ -1,7 +1,9 @@
 <script>
   /**
    * @typedef {boolean | number} ColumnSize
-   * @typedef {{span?: ColumnSize; offset: number;}} ColumnSizeDescriptor
+   * @typedef ColumnSizeDescriptor
+   * @property {ColumnSize} [span]
+   * @property {number} offset
    * @typedef {ColumnSize | ColumnSizeDescriptor} ColumnBreakpoint
    * @restProps {div}
    * @slot {{props: { class: string; [key: string]: any; }}}

--- a/src/LocalStorage/LocalStorage.svelte
+++ b/src/LocalStorage/LocalStorage.svelte
@@ -1,7 +1,9 @@
 <script>
   /**
    * @event {null} save
-   * @event {{ prevValue: any; value: any; }} update
+   * @event update
+   * @property {any} prevValue
+   * @property {any} value
    */
 
   /**

--- a/src/Modal/Modal.svelte
+++ b/src/Modal/Modal.svelte
@@ -1,8 +1,14 @@
 <script>
   /**
-   * @event {{ trigger: "escape-key" | "outside-click" | "close-button" }} close
-   * @event {{ open: boolean; }} transitionend
-   * @event {{ text: string; }} click:button--secondary
+   * @event close
+   * @type {object}
+   * @property {"escape-key" | "outside-click" | "close-button"} trigger
+   * @event transitionend
+   * @type {object}
+   * @property {boolean} open
+   * @event click:button--secondary
+   * @type {object}
+   * @property {string} text
    */
 
   /**

--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -4,8 +4,15 @@
    * @template {MultiSelectItem} Item
    * @typedef {any} MultiSelectItemId
    * @typedef {string} MultiSelectItemText
-   * @typedef {{ id: MultiSelectItemId; text: MultiSelectItemText; disabled?: boolean; }} MultiSelectItem
-   * @event {{ selectedIds: MultiSelectItemId[]; selected: Item[]; unselected: Item[]; }} select
+   * @typedef {object} MultiSelectItem
+   * @property {MultiSelectItemId} id
+   * @property {MultiSelectItemText} text
+   * @property {boolean} [disabled] - Whether the item is disabled
+   * @event select
+   * @type {object}
+   * @property {MultiSelectItemId[]} selectedIds
+   * @property {Item[]} selected
+   * @property {Item[]} unselected
    * @event {null} clear
    * @event {FocusEvent | CustomEvent<FocusEvent>} blur
    * @slot {{ item: Item; index: number }}

--- a/src/Notification/InlineNotification.svelte
+++ b/src/Notification/InlineNotification.svelte
@@ -1,6 +1,7 @@
 <script>
   /**
-   * @event {{ timeout: boolean }} close
+   * @event close
+   * @property {boolean} timeout
    */
 
   /**

--- a/src/Notification/ToastNotification.svelte
+++ b/src/Notification/ToastNotification.svelte
@@ -1,6 +1,7 @@
 <script>
   /**
-   * @event {{ timeout: boolean }} close
+   * @event close
+   * @property {boolean} timeout
    */
 
   /**

--- a/src/OverflowMenu/OverflowMenu.svelte
+++ b/src/OverflowMenu/OverflowMenu.svelte
@@ -1,6 +1,8 @@
 <script>
   /**
-   * @event {null | { index: number; text: string; }} close
+   * @event close
+   * @property {number} [index]
+   * @property {string} [text]
    */
 
   /**

--- a/src/Pagination/Pagination.svelte
+++ b/src/Pagination/Pagination.svelte
@@ -1,9 +1,20 @@
 <script>
   /**
-   * @event {{ page?: number; pageSize?: number }} change - Dispatched after any user interaction
-   * @event {{ page: number; }} click:button--previous
-   * @event {{ page: number; }} click:button--next
-   * @event {{ pageSize: number; page: number; }} update
+   * Dispatched after any user interaction
+   * @event change
+   * @type {object}
+   * @property {number} [page]
+   * @property {number} [pageSize]
+   * @event click:button--previous
+   * @type {object}
+   * @property {number} page
+   * @event click:button--next
+   * @type {object}
+   * @property {number} page
+   * @event update
+   * @type {object}
+   * @property {number} pageSize
+   * @property {number} page
    */
 
   /** Specify the current page index */

--- a/src/PaginationNav/PaginationNav.svelte
+++ b/src/PaginationNav/PaginationNav.svelte
@@ -1,8 +1,11 @@
 <script>
   /**
-   * @event {{ page: number; }} change - fires after every user interaction
-   * @event {{ page: number; }} click:button--previous
-   * @event {{ page: number; }} click:button--next
+   * @event change - Fires after every user interaction
+   * @property {number} page
+   * @event click:button--previous
+   * @property {number} page
+   * @event click:button--next
+   * @property {number} page
    */
 
   /** Specify the current page index */

--- a/src/Popover/Popover.svelte
+++ b/src/Popover/Popover.svelte
@@ -1,6 +1,7 @@
 <script>
   /**
-   * @event {{ target: HTMLElement; }} click:outside
+   * @event click:outside
+   * @property {HTMLElement} target
    */
 
   /** Set to `true` to display the popover */

--- a/src/RecursiveList/RecursiveList.svelte
+++ b/src/RecursiveList/RecursiveList.svelte
@@ -1,6 +1,9 @@
 <script>
   /**
-   * @typedef {{ text?: string; href?: string; html?: string; }} RecursiveListNode
+   * @typedef RecursiveListNode
+   * @property {string} [text] - Node text content
+   * @property {string} [href] - Node link URL
+   * @property {string} [html] - Node HTML content
    * @restProps {ul | ol}
    */
 

--- a/src/Theme/Theme.svelte
+++ b/src/Theme/Theme.svelte
@@ -6,7 +6,9 @@
 
   /**
    * @typedef {"white" | "g10" | "g80" | "g90" | "g100"} CarbonTheme
-   * @event {{ theme: CarbonTheme; }} update
+   * @event update
+   * @type {object}
+   * @property {CarbonTheme} theme
    * @slot {{ theme: CarbonTheme; }}
    */
 

--- a/src/TreeView/TreeView.svelte
+++ b/src/TreeView/TreeView.svelte
@@ -29,11 +29,40 @@
 <script>
   /**
    * @typedef {string | number} TreeNodeId
-   * @typedef {{ id: TreeNodeId; text: any; icon?: any; disabled?: boolean; nodes?: TreeNode[]; }} TreeNode
+   * @typedef {object} TreeNode
+   * @property {TreeNodeId} id
+   * @property {any} text
+   * @property {any} [icon]
+   * @property {boolean} [disabled] - Whether the node is disabled
+   * @property {TreeNode[]} [nodes]
    * @slot {{ node: { id: TreeNodeId; text: string; expanded: boolean, leaf: boolean; disabled: boolean; selected: boolean; } }}
-   * @event {TreeNode & { expanded: boolean; leaf: boolean; }} select
-   * @event {TreeNode & { expanded: boolean; leaf: boolean; }} toggle
-   * @event {TreeNode & { expanded: boolean; leaf: boolean; }} focus
+   * @event select
+   * @type {object}
+   * @property {TreeNodeId} id
+   * @property {any} text
+   * @property {any} [icon]
+   * @property {boolean} [disabled]
+   * @property {TreeNode[]} [nodes]
+   * @property {boolean} expanded
+   * @property {boolean} leaf
+   * @event toggle
+   * @type {object}
+   * @property {TreeNodeId} id
+   * @property {any} text
+   * @property {any} [icon]
+   * @property {boolean} [disabled]
+   * @property {TreeNode[]} [nodes]
+   * @property {boolean} expanded
+   * @property {boolean} leaf
+   * @event focus
+   * @type {object}
+   * @property {TreeNodeId} id
+   * @property {any} text
+   * @property {any} [icon]
+   * @property {boolean} [disabled]
+   * @property {TreeNode[]} [nodes]
+   * @property {boolean} expanded
+   * @property {boolean} leaf
    */
 
   /**

--- a/src/UIShell/HeaderSearch.svelte
+++ b/src/UIShell/HeaderSearch.svelte
@@ -1,10 +1,16 @@
 <script>
   /**
-   * @typedef {{ href: string; text: string; description?: string; }} HeaderSearchResult
+   * @typedef HeaderSearchResult
+   * @property {string} href
+   * @property {string} text
+   * @property {string} [description]
    * @event {null} active
    * @event {null} inactive
    * @event {null} clear
-   * @event {{ value: string; selectedResultIndex: number; selectedResult: HeaderSearchResult }} select
+   * @event select
+   * @property {string} value
+   * @property {number} selectedResultIndex
+   * @property {HeaderSearchResult} selectedResult
    * @slot {{ result: HeaderSearchResult; index: number }}
    */
 

--- a/types/ComboBox/ComboBox.svelte.d.ts
+++ b/types/ComboBox/ComboBox.svelte.d.ts
@@ -3,11 +3,11 @@ import type { SvelteHTMLElements } from "svelte/elements";
 
 export type ComboBoxItemId = any;
 
-export interface ComboBoxItem {
+export type ComboBoxItem = {
   id: ComboBoxItemId;
   text: string;
-  disabled?: boolean;
-}
+  /** Whether the item is disabled */ disabled?: boolean;
+};
 
 type $RestProps = SvelteHTMLElements["input"];
 

--- a/types/DataTable/DataTable.svelte.d.ts
+++ b/types/DataTable/DataTable.svelte.d.ts
@@ -6,25 +6,25 @@ export type DataTableKey<Row = DataTableRow> =
 
 export type DataTableValue = any;
 
-export interface DataTableEmptyHeader<Row = DataTableRow> {
+export type DataTableEmptyHeader<Row = DataTableRow> = {
   key: DataTableKey<Row> | (string & {});
-  empty: boolean;
+  /** Whether the header is empty */ empty: boolean;
   display?: (item: DataTableValue, row: Row) => DataTableValue;
   sort?: false | ((a: DataTableValue, b: DataTableValue) => number);
-  columnMenu?: boolean;
+  /** Whether the column menu is enabled */ columnMenu?: boolean;
   width?: string;
   minWidth?: string;
-}
+};
 
-export interface DataTableNonEmptyHeader<Row = DataTableRow> {
+export type DataTableNonEmptyHeader<Row = DataTableRow> = {
   key: DataTableKey<Row>;
   value: DataTableValue;
   display?: (item: DataTableValue, row: Row) => DataTableValue;
   sort?: false | ((a: DataTableValue, b: DataTableValue) => number);
-  columnMenu?: boolean;
+  /** Whether the column menu is enabled */ columnMenu?: boolean;
   width?: string;
   minWidth?: string;
-}
+};
 
 export type DataTableHeader<Row = DataTableRow> =
   | DataTableNonEmptyHeader<Row>
@@ -37,11 +37,11 @@ export interface DataTableRow {
 
 export type DataTableRowId = any;
 
-export interface DataTableCell<Row = DataTableRow> {
+export type DataTableCell<Row = DataTableRow> = {
   key: DataTableKey<Row> | (string & {});
   value: DataTableValue;
   display?: (item: DataTableValue, row: DataTableRow) => DataTableValue;
-}
+};
 export type DataTableContext = {
   batchSelectedIds: import("svelte/store").Writable<
     ReadonlyArray<DataTableRowId>
@@ -221,27 +221,17 @@ export default class DataTable<
     "click:header": CustomEvent<{
       header: DataTableHeader<Row>;
       sortDirection?: "ascending" | "descending" | "none";
-      target: EventTarget;
-      currentTarget: EventTarget;
     }>;
     "click:header--select": CustomEvent<{
       indeterminate: boolean;
       selected: boolean;
     }>;
-    "click:row": CustomEvent<{
-      row: Row;
-      target: EventTarget;
-      currentTarget: EventTarget;
-    }>;
+    "click:row": CustomEvent<{ row: Row }>;
     "mouseenter:row": CustomEvent<Row>;
     "mouseleave:row": CustomEvent<Row>;
     "click:row--expand": CustomEvent<{ expanded: boolean; row: Row }>;
     "click:row--select": CustomEvent<{ selected: boolean; row: Row }>;
-    "click:cell": CustomEvent<{
-      cell: DataTableCell<Row>;
-      target: EventTarget;
-      currentTarget: EventTarget;
-    }>;
+    "click:cell": CustomEvent<{ cell: DataTableCell<Row> }>;
   },
   {
     cell: {

--- a/types/Dropdown/Dropdown.svelte.d.ts
+++ b/types/Dropdown/Dropdown.svelte.d.ts
@@ -5,11 +5,11 @@ export type DropdownItemId = any;
 
 export type DropdownItemText = string;
 
-export interface DropdownItem {
+export type DropdownItem = {
   id: DropdownItemId;
   text: DropdownItemText;
-  disabled?: boolean;
-}
+  /** Whether the item is disabled */ disabled?: boolean;
+};
 
 type $RestProps = SvelteHTMLElements["div"];
 

--- a/types/Grid/Column.svelte.d.ts
+++ b/types/Grid/Column.svelte.d.ts
@@ -3,10 +3,7 @@ import type { SvelteHTMLElements } from "svelte/elements";
 
 export type ColumnSize = boolean | number;
 
-export interface ColumnSizeDescriptor {
-  span?: ColumnSize;
-  offset: number;
-}
+export type ColumnSizeDescriptor = { span?: ColumnSize; offset: number };
 
 export type ColumnBreakpoint = ColumnSize | ColumnSizeDescriptor;
 

--- a/types/MultiSelect/MultiSelect.svelte.d.ts
+++ b/types/MultiSelect/MultiSelect.svelte.d.ts
@@ -5,11 +5,11 @@ export type MultiSelectItemId = any;
 
 export type MultiSelectItemText = string;
 
-export interface MultiSelectItem {
+export type MultiSelectItem = {
   id: MultiSelectItemId;
   text: MultiSelectItemText;
-  disabled?: boolean;
-}
+  /** Whether the item is disabled */ disabled?: boolean;
+};
 export type MultiSelectContext = {
   declareRef: (data: {
     key: "field" | "selection";

--- a/types/OverflowMenu/OverflowMenu.svelte.d.ts
+++ b/types/OverflowMenu/OverflowMenu.svelte.d.ts
@@ -114,7 +114,7 @@ export type OverflowMenuProps = Omit<$RestProps, keyof $Props> & $Props;
 export default class OverflowMenu extends SvelteComponentTyped<
   OverflowMenuProps,
   {
-    close: CustomEvent<null | { index: number; text: string }>;
+    close: CustomEvent<{ index?: number; text?: string }>;
     click: WindowEventMap["click"];
     mouseover: WindowEventMap["mouseover"];
     mouseenter: WindowEventMap["mouseenter"];

--- a/types/Pagination/Pagination.svelte.d.ts
+++ b/types/Pagination/Pagination.svelte.d.ts
@@ -117,8 +117,11 @@ export default class Pagination extends SvelteComponentTyped<
   {
     /** Dispatched after any user interaction */
     change: CustomEvent<{ page?: number; pageSize?: number }>;
+    /** Dispatched after any user interaction */
     "click:button--previous": CustomEvent<{ page: number }>;
+    /** Dispatched after any user interaction */
     "click:button--next": CustomEvent<{ page: number }>;
+    /** Dispatched after any user interaction */
     update: CustomEvent<{ pageSize: number; page: number }>;
   },
   Record<string, never>

--- a/types/PaginationNav/PaginationNav.svelte.d.ts
+++ b/types/PaginationNav/PaginationNav.svelte.d.ts
@@ -54,7 +54,7 @@ export type PaginationNavProps = Omit<$RestProps, keyof $Props> & $Props;
 export default class PaginationNav extends SvelteComponentTyped<
   PaginationNavProps,
   {
-    /** fires after every user interaction */
+    /** Fires after every user interaction */
     change: CustomEvent<{ page: number }>;
     "click:button--previous": CustomEvent<{ page: number }>;
     "click:button--next": CustomEvent<{ page: number }>;

--- a/types/RecursiveList/RecursiveList.svelte.d.ts
+++ b/types/RecursiveList/RecursiveList.svelte.d.ts
@@ -1,11 +1,11 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface RecursiveListNode {
-  text?: string;
-  href?: string;
-  html?: string;
-}
+export type RecursiveListNode = {
+  /** Node text content */ text?: string;
+  /** Node link URL */ href?: string;
+  /** Node HTML content */ html?: string;
+};
 
 type $RestProps = SvelteHTMLElements["ul"] & SvelteHTMLElements["ol"];
 

--- a/types/TreeView/TreeView.svelte.d.ts
+++ b/types/TreeView/TreeView.svelte.d.ts
@@ -3,13 +3,13 @@ import type { SvelteHTMLElements } from "svelte/elements";
 
 export type TreeNodeId = string | number;
 
-export interface TreeNode {
+export type TreeNode = {
   id: TreeNodeId;
   text: any;
   icon?: any;
-  disabled?: boolean;
+  /** Whether the node is disabled */ disabled?: boolean;
   nodes?: TreeNode[];
-}
+};
 export type TreeViewContext = {
   activeNodeId: import("svelte/store").Writable<TreeNodeId>;
   selectedNodeIds: import("svelte/store").Writable<ReadonlyArray<TreeNodeId>>;
@@ -75,9 +75,33 @@ export type TreeViewProps = Omit<$RestProps, keyof $Props> & $Props;
 export default class TreeView extends SvelteComponentTyped<
   TreeViewProps,
   {
-    select: CustomEvent<TreeNode & { expanded: boolean; leaf: boolean }>;
-    toggle: CustomEvent<TreeNode & { expanded: boolean; leaf: boolean }>;
-    focus: CustomEvent<TreeNode & { expanded: boolean; leaf: boolean }>;
+    select: CustomEvent<{
+      id: TreeNodeId;
+      text: any;
+      icon?: any;
+      disabled?: boolean;
+      nodes?: TreeNode[];
+      expanded: boolean;
+      leaf: boolean;
+    }>;
+    toggle: CustomEvent<{
+      id: TreeNodeId;
+      text: any;
+      icon?: any;
+      disabled?: boolean;
+      nodes?: TreeNode[];
+      expanded: boolean;
+      leaf: boolean;
+    }>;
+    focus: CustomEvent<{
+      id: TreeNodeId;
+      text: any;
+      icon?: any;
+      disabled?: boolean;
+      nodes?: TreeNode[];
+      expanded: boolean;
+      leaf: boolean;
+    }>;
     keydown: WindowEventMap["keydown"];
   },
   {

--- a/types/UIShell/HeaderSearch.svelte.d.ts
+++ b/types/UIShell/HeaderSearch.svelte.d.ts
@@ -1,11 +1,11 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-export interface HeaderSearchResult {
+export type HeaderSearchResult = {
   href: string;
   text: string;
   description?: string;
-}
+};
 
 type $RestProps = SvelteHTMLElements["input"];
 


### PR DESCRIPTION
sveld@0.23 supports `@property` notation in typedefs, allowing JSDoc descriptions to be added to typedefs and events.

This improves developer experience for IDEs with hover definition support.

---

<img width="647" height="181" alt="Screenshot 2025-11-08 at 3 20 38 PM" src="https://github.com/user-attachments/assets/a4fa0229-8f44-4199-a971-892453409f48" />
