### PR TITLE
perf: optimize barrel file exports

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,155 +1,169 @@
-export { Accordion, AccordionItem, AccordionSkeleton } from "./Accordion";
-export { AspectRatio } from "./AspectRatio";
-export { Breadcrumb, BreadcrumbItem, BreadcrumbSkeleton } from "./Breadcrumb";
-export { Breakpoint } from "./Breakpoint";
+export { default as Accordion } from "./Accordion/Accordion.svelte";
+export { default as AccordionItem } from "./Accordion/AccordionItem.svelte";
+export { default as AccordionSkeleton } from "./Accordion/AccordionSkeleton.svelte";
+export { default as AspectRatio } from "./AspectRatio/AspectRatio.svelte";
+export { default as Breadcrumb } from "./Breadcrumb/Breadcrumb.svelte";
+export { default as BreadcrumbItem } from "./Breadcrumb/BreadcrumbItem.svelte";
+export { default as BreadcrumbSkeleton } from "./Breadcrumb/BreadcrumbSkeleton.svelte";
+export { default as Breakpoint } from "./Breakpoint/Breakpoint.svelte";
 export { default as breakpointObserver } from "./Breakpoint/breakpointObserver";
 export { default as breakpoints } from "./Breakpoint/breakpoints";
-export { Button, ButtonSet, ButtonSkeleton } from "./Button";
-export { Checkbox, CheckboxSkeleton } from "./Checkbox";
-export { CodeSnippet, CodeSnippetSkeleton } from "./CodeSnippet";
-export { ComboBox } from "./ComboBox";
-export {
-  ComposedModal,
-  ModalBody,
-  ModalFooter,
-  ModalHeader,
-} from "./ComposedModal";
-export { ContentSwitcher, Switch } from "./ContentSwitcher";
-export {
-  ContextMenu,
-  ContextMenuDivider,
-  ContextMenuGroup,
-  ContextMenuOption,
-  ContextMenuRadioGroup,
-} from "./ContextMenu";
-export { CopyButton } from "./CopyButton";
-export {
-  DataTable,
-  DataTableSkeleton,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableHeader,
-  TableRow,
-  Toolbar,
-  ToolbarBatchActions,
-  ToolbarContent,
-  ToolbarMenu,
-  ToolbarMenuItem,
-  ToolbarSearch,
-} from "./DataTable";
-export { DatePicker, DatePickerInput, DatePickerSkeleton } from "./DatePicker";
-export { Dropdown, DropdownSkeleton } from "./Dropdown";
-export {
-  Filename,
-  FileUploader,
-  FileUploaderButton,
-  FileUploaderDropContainer,
-  FileUploaderItem,
-  FileUploaderSkeleton,
-} from "./FileUploader";
-export { FluidForm } from "./FluidForm";
-export { Form } from "./Form";
-export { FormGroup } from "./FormGroup";
-export { FormItem } from "./FormItem";
-export { FormLabel } from "./FormLabel";
-export { Column, Grid, Row } from "./Grid";
-export { ImageLoader } from "./ImageLoader";
-export { InlineLoading } from "./InlineLoading";
-export { Link, OutboundLink } from "./Link";
-export {
-  ListBox,
-  ListBoxField,
-  ListBoxMenu,
-  ListBoxMenuIcon,
-  ListBoxMenuItem,
-  ListBoxSelection,
-} from "./ListBox";
-export { ListItem } from "./ListItem";
-export { Loading } from "./Loading";
-export { LocalStorage } from "./LocalStorage";
-export { Modal } from "./Modal";
-export { MultiSelect } from "./MultiSelect";
-export {
-  InlineNotification,
-  NotificationActionButton,
-  NotificationButton,
-  NotificationIcon,
-  ToastNotification,
-} from "./Notification";
-export { NumberInput, NumberInputSkeleton } from "./NumberInput";
-export { OrderedList } from "./OrderedList";
-export { OverflowMenu, OverflowMenuItem } from "./OverflowMenu";
-export { Pagination, PaginationSkeleton } from "./Pagination";
-export { PaginationNav } from "./PaginationNav";
-export { Popover } from "./Popover";
-export { ProgressBar } from "./ProgressBar";
-export {
-  ProgressIndicator,
-  ProgressIndicatorSkeleton,
-  ProgressStep,
-} from "./ProgressIndicator";
-export { RadioButton, RadioButtonSkeleton } from "./RadioButton";
-export { RadioButtonGroup } from "./RadioButtonGroup";
-export { RecursiveList } from "./RecursiveList";
-export { Search, SearchSkeleton } from "./Search";
-export { Select, SelectItem, SelectItemGroup, SelectSkeleton } from "./Select";
-export { SkeletonPlaceholder } from "./SkeletonPlaceholder";
-export { SkeletonText } from "./SkeletonText";
-export { Slider, SliderSkeleton } from "./Slider";
-export {
-  StructuredList,
-  StructuredListBody,
-  StructuredListCell,
-  StructuredListHead,
-  StructuredListInput,
-  StructuredListRow,
-  StructuredListSkeleton,
-} from "./StructuredList";
-export { Tab, TabContent, Tabs, TabsSkeleton } from "./Tabs";
-export { Tag, TagSkeleton } from "./Tag";
-export { TextArea, TextAreaSkeleton } from "./TextArea";
-export { PasswordInput, TextInput, TextInputSkeleton } from "./TextInput";
-export { Theme } from "./Theme";
-export {
-  ClickableTile,
-  ExpandableTile,
-  RadioTile,
-  SelectableTile,
-  Tile,
-  TileGroup,
-} from "./Tile";
-export { TimePicker, TimePickerSelect } from "./TimePicker";
-export { Toggle, ToggleSkeleton } from "./Toggle";
-export { Tooltip, TooltipFooter } from "./Tooltip";
-export { TooltipDefinition } from "./TooltipDefinition";
-export { TooltipIcon } from "./TooltipIcon";
-export { TreeView } from "./TreeView";
-export { Truncate } from "./Truncate";
-export { default as truncate } from "./Truncate/truncate";
-export {
-  Content,
-  Header,
-  HeaderAction,
-  HeaderActionLink,
-  HeaderGlobalAction,
-  HeaderNav,
-  HeaderNavItem,
-  HeaderNavMenu,
-  HeaderPanelDivider,
-  HeaderPanelLink,
-  HeaderPanelLinks,
-  HeaderSearch,
-  HeaderUtilities,
-  SideNav,
-  SideNavDivider,
-  SideNavItems,
-  SideNavLink,
-  SideNavMenu,
-  SideNavMenuItem,
-  SkipToContent,
-} from "./UIShell";
-export { UnorderedList } from "./UnorderedList";
+export { default as Button } from "./Button/Button.svelte";
+export { default as ButtonSet } from "./Button/ButtonSet.svelte";
+export { default as ButtonSkeleton } from "./Button/ButtonSkeleton.svelte";
+export { default as Checkbox } from "./Checkbox/Checkbox.svelte";
+export { default as CheckboxSkeleton } from "./Checkbox/CheckboxSkeleton.svelte";
+export { default as CodeSnippet } from "./CodeSnippet/CodeSnippet.svelte";
+export { default as CodeSnippetSkeleton } from "./CodeSnippet/CodeSnippetSkeleton.svelte";
+export { default as ComboBox } from "./ComboBox/ComboBox.svelte";
+export { default as ComposedModal } from "./ComposedModal/ComposedModal.svelte";
+export { default as ModalBody } from "./ComposedModal/ModalBody.svelte";
+export { default as ModalFooter } from "./ComposedModal/ModalFooter.svelte";
+export { default as ModalHeader } from "./ComposedModal/ModalHeader.svelte";
+export { default as ContentSwitcher } from "./ContentSwitcher/ContentSwitcher.svelte";
+export { default as Switch } from "./ContentSwitcher/Switch.svelte";
+export { default as ContextMenu } from "./ContextMenu/ContextMenu.svelte";
+export { default as ContextMenuDivider } from "./ContextMenu/ContextMenuDivider.svelte";
+export { default as ContextMenuGroup } from "./ContextMenu/ContextMenuGroup.svelte";
+export { default as ContextMenuOption } from "./ContextMenu/ContextMenuOption.svelte";
+export { default as ContextMenuRadioGroup } from "./ContextMenu/ContextMenuRadioGroup.svelte";
+export { default as CopyButton } from "./CopyButton/CopyButton.svelte";
+export { default as DataTable } from "./DataTable/DataTable.svelte";
+export { default as DataTableSkeleton } from "./DataTable/DataTableSkeleton.svelte";
+export { default as Table } from "./DataTable/Table.svelte";
+export { default as TableBody } from "./DataTable/TableBody.svelte";
+export { default as TableCell } from "./DataTable/TableCell.svelte";
+export { default as TableContainer } from "./DataTable/TableContainer.svelte";
+export { default as TableHead } from "./DataTable/TableHead.svelte";
+export { default as TableHeader } from "./DataTable/TableHeader.svelte";
+export { default as TableRow } from "./DataTable/TableRow.svelte";
+export { default as Toolbar } from "./DataTable/Toolbar.svelte";
+export { default as ToolbarBatchActions } from "./DataTable/ToolbarBatchActions.svelte";
+export { default as ToolbarContent } from "./DataTable/ToolbarContent.svelte";
+export { default as ToolbarMenu } from "./DataTable/ToolbarMenu.svelte";
+export { default as ToolbarMenuItem } from "./DataTable/ToolbarMenuItem.svelte";
+export { default as ToolbarSearch } from "./DataTable/ToolbarSearch.svelte";
+export { default as DatePicker } from "./DatePicker/DatePicker.svelte";
+export { default as DatePickerInput } from "./DatePicker/DatePickerInput.svelte";
+export { default as DatePickerSkeleton } from "./DatePicker/DatePickerSkeleton.svelte";
+export { default as Dropdown } from "./Dropdown/Dropdown.svelte";
+export { default as DropdownSkeleton } from "./Dropdown/DropdownSkeleton.svelte";
+export { default as Filename } from "./FileUploader/Filename.svelte";
+export { default as FileUploader } from "./FileUploader/FileUploader.svelte";
+export { default as FileUploaderButton } from "./FileUploader/FileUploaderButton.svelte";
+export { default as FileUploaderDropContainer } from "./FileUploader/FileUploaderDropContainer.svelte";
+export { default as FileUploaderItem } from "./FileUploader/FileUploaderItem.svelte";
+export { default as FileUploaderSkeleton } from "./FileUploader/FileUploaderSkeleton.svelte";
+export { default as FluidForm } from "./FluidForm/FluidForm.svelte";
+export { default as Form } from "./Form/Form.svelte";
+export { default as FormGroup } from "./FormGroup/FormGroup.svelte";
+export { default as FormItem } from "./FormItem/FormItem.svelte";
+export { default as FormLabel } from "./FormLabel/FormLabel.svelte";
+export { default as Column } from "./Grid/Column.svelte";
+export { default as Grid } from "./Grid/Grid.svelte";
+export { default as Row } from "./Grid/Row.svelte";
+export { default as ImageLoader } from "./ImageLoader/ImageLoader.svelte";
+export { default as InlineLoading } from "./InlineLoading/InlineLoading.svelte";
+export { default as Link } from "./Link/Link.svelte";
+export { default as OutboundLink } from "./Link/OutboundLink.svelte";
+export { default as ListBox } from "./ListBox/ListBox.svelte";
+export { default as ListBoxField } from "./ListBox/ListBoxField.svelte";
+export { default as ListBoxMenu } from "./ListBox/ListBoxMenu.svelte";
+export { default as ListBoxMenuIcon } from "./ListBox/ListBoxMenuIcon.svelte";
+export { default as ListBoxMenuItem } from "./ListBox/ListBoxMenuItem.svelte";
+export { default as ListBoxSelection } from "./ListBox/ListBoxSelection.svelte";
+export { default as ListItem } from "./ListItem/ListItem.svelte";
+export { default as Loading } from "./Loading/Loading.svelte";
+export { default as LocalStorage } from "./LocalStorage/LocalStorage.svelte";
+export { default as Modal } from "./Modal/Modal.svelte";
+export { default as MultiSelect } from "./MultiSelect/MultiSelect.svelte";
+export { default as InlineNotification } from "./Notification/InlineNotification.svelte";
+export { default as NotificationActionButton } from "./Notification/NotificationActionButton.svelte";
+export { default as NotificationButton } from "./Notification/NotificationButton.svelte";
+export { default as NotificationIcon } from "./Notification/NotificationIcon.svelte";
+export { default as ToastNotification } from "./Notification/ToastNotification.svelte";
+export { default as NumberInput } from "./NumberInput/NumberInput.svelte";
+export { default as NumberInputSkeleton } from "./NumberInput/NumberInputSkeleton.svelte";
+export { default as OrderedList } from "./OrderedList/OrderedList.svelte";
+export { default as OverflowMenu } from "./OverflowMenu/OverflowMenu.svelte";
+export { default as OverflowMenuItem } from "./OverflowMenu/OverflowMenuItem.svelte";
+export { default as Pagination } from "./Pagination/Pagination.svelte";
+export { default as PaginationSkeleton } from "./Pagination/PaginationSkeleton.svelte";
+export { default as PaginationNav } from "./PaginationNav/PaginationNav.svelte";
+export { default as Popover } from "./Popover/Popover.svelte";
+export { default as ProgressBar } from "./ProgressBar/ProgressBar.svelte";
+export { default as ProgressIndicator } from "./ProgressIndicator/ProgressIndicator.svelte";
+export { default as ProgressIndicatorSkeleton } from "./ProgressIndicator/ProgressIndicatorSkeleton.svelte";
+export { default as ProgressStep } from "./ProgressIndicator/ProgressStep.svelte";
+export { default as RadioButton } from "./RadioButton/RadioButton.svelte";
+export { default as RadioButtonSkeleton } from "./RadioButton/RadioButtonSkeleton.svelte";
+export { default as RadioButtonGroup } from "./RadioButtonGroup/RadioButtonGroup.svelte";
+export { default as RecursiveList } from "./RecursiveList/RecursiveList.svelte";
+export { default as Search } from "./Search/Search.svelte";
+export { default as SearchSkeleton } from "./Search/SearchSkeleton.svelte";
+export { default as Select } from "./Select/Select.svelte";
+export { default as SelectItem } from "./Select/SelectItem.svelte";
+export { default as SelectItemGroup } from "./Select/SelectItemGroup.svelte";
+export { default as SelectSkeleton } from "./Select/SelectSkeleton.svelte";
+export { default as SkeletonPlaceholder } from "./SkeletonPlaceholder/SkeletonPlaceholder.svelte";
+export { default as SkeletonText } from "./SkeletonText/SkeletonText.svelte";
+export { default as Slider } from "./Slider/Slider.svelte";
+export { default as SliderSkeleton } from "./Slider/SliderSkeleton.svelte";
+export { default as StructuredList } from "./StructuredList/StructuredList.svelte";
+export { default as StructuredListBody } from "./StructuredList/StructuredListBody.svelte";
+export { default as StructuredListCell } from "./StructuredList/StructuredListCell.svelte";
+export { default as StructuredListHead } from "./StructuredList/StructuredListHead.svelte";
+export { default as StructuredListInput } from "./StructuredList/StructuredListInput.svelte";
+export { default as StructuredListRow } from "./StructuredList/StructuredListRow.svelte";
+export { default as StructuredListSkeleton } from "./StructuredList/StructuredListSkeleton.svelte";
+export { default as Tab } from "./Tabs/Tab.svelte";
+export { default as TabContent } from "./Tabs/TabContent.svelte";
+export { default as Tabs } from "./Tabs/Tabs.svelte";
+export { default as TabsSkeleton } from "./Tabs/TabsSkeleton.svelte";
+export { default as Tag } from "./Tag/Tag.svelte";
+export { default as TagSkeleton } from "./Tag/TagSkeleton.svelte";
+export { default as TextArea } from "./TextArea/TextArea.svelte";
+export { default as TextAreaSkeleton } from "./TextArea/TextAreaSkeleton.svelte";
+export { default as PasswordInput } from "./TextInput/PasswordInput.svelte";
+export { default as TextInput } from "./TextInput/TextInput.svelte";
+export { default as TextInputSkeleton } from "./TextInput/TextInputSkeleton.svelte";
+export { default as Theme } from "./Theme/Theme.svelte";
+export { default as ClickableTile } from "./Tile/ClickableTile.svelte";
+export { default as ExpandableTile } from "./Tile/ExpandableTile.svelte";
+export { default as RadioTile } from "./Tile/RadioTile.svelte";
+export { default as SelectableTile } from "./Tile/SelectableTile.svelte";
+export { default as Tile } from "./Tile/Tile.svelte";
+export { default as TileGroup } from "./Tile/TileGroup.svelte";
+export { default as TimePicker } from "./TimePicker/TimePicker.svelte";
+export { default as TimePickerSelect } from "./TimePicker/TimePickerSelect.svelte";
+export { default as Toggle } from "./Toggle/Toggle.svelte";
+export { default as ToggleSkeleton } from "./Toggle/ToggleSkeleton.svelte";
+export { default as Tooltip } from "./Tooltip/Tooltip.svelte";
+export { default as TooltipFooter } from "./Tooltip/TooltipFooter.svelte";
+export { default as TooltipDefinition } from "./TooltipDefinition/TooltipDefinition.svelte";
+export { default as TooltipIcon } from "./TooltipIcon/TooltipIcon.svelte";
+export { default as TreeView } from "./TreeView/TreeView.svelte";
+export { default as Truncate } from "./Truncate/Truncate.svelte";
+export { truncate } from "./Truncate/truncate";
+export { default as Content } from "./UIShell/Content.svelte";
+export { default as Header } from "./UIShell/Header.svelte";
+export { default as HeaderAction } from "./UIShell/HeaderAction.svelte";
+export { default as HeaderActionLink } from "./UIShell/HeaderActionLink.svelte";
+export { default as HeaderGlobalAction } from "./UIShell/HeaderGlobalAction.svelte";
+export { default as HeaderNav } from "./UIShell/HeaderNav.svelte";
+export { default as HeaderNavItem } from "./UIShell/HeaderNavItem.svelte";
+export { default as HeaderNavMenu } from "./UIShell/HeaderNavMenu.svelte";
+export { default as HeaderPanelDivider } from "./UIShell/HeaderPanelDivider.svelte";
+export { default as HeaderPanelLink } from "./UIShell/HeaderPanelLink.svelte";
+export { default as HeaderPanelLinks } from "./UIShell/HeaderPanelLinks.svelte";
+export { default as HeaderSearch } from "./UIShell/HeaderSearch.svelte";
+export { default as HeaderUtilities } from "./UIShell/HeaderUtilities.svelte";
+export { default as SideNav } from "./UIShell/SideNav.svelte";
+export { default as SideNavDivider } from "./UIShell/SideNavDivider.svelte";
+export { default as SideNavItems } from "./UIShell/SideNavItems.svelte";
+export { default as SideNavLink } from "./UIShell/SideNavLink.svelte";
+export { default as SideNavMenu } from "./UIShell/SideNavMenu.svelte";
+export { default as SideNavMenuItem } from "./UIShell/SideNavMenuItem.svelte";
+export { default as SkipToContent } from "./UIShell/SkipToContent.svelte";
+export { default as UnorderedList } from "./UnorderedList/UnorderedList.svelte";
 export { toHierarchy } from "./utils/toHierarchy";

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -144,7 +144,7 @@ export { default as TooltipDefinition } from "./TooltipDefinition/TooltipDefinit
 export { default as TooltipIcon } from "./TooltipIcon/TooltipIcon.svelte";
 export { default as TreeView } from "./TreeView/TreeView.svelte";
 export { default as Truncate } from "./Truncate/Truncate.svelte";
-export { default as truncate } from "./Truncate/truncate";
+export { truncate } from "./Truncate/truncate";
 export { default as Content } from "./UIShell/Content.svelte";
 export { default as Header } from "./UIShell/Header.svelte";
 export { default as HeaderAction } from "./UIShell/HeaderAction.svelte";


### PR DESCRIPTION
Blocked by #2329

The current `src/index.js` re-exports components from the intermediate, component-specific barrel file (e.g., `src/Accordion/index.js`).

This optimizes the barrel file to directly export the entity. It also manually updates `types/index.d.ts` to mirror the file exactly.