### PR TITLE
fix(breakpoint): use `declare const` in types

### DIFF
--- a/src/Breakpoint/breakpoints.d.ts
+++ b/src/Breakpoint/breakpoints.d.ts
@@ -2,7 +2,7 @@
  * Pixel sizes of Carbon grid breakpoints.
  * @type {Record<BreakpointSize, BreakpointValue>}
  */
-export const breakpoints: Record<BreakpointSize, BreakpointValue>;
+export declare const breakpoints: Record<BreakpointSize, BreakpointValue>;
 
 export type BreakpointSize = "sm" | "md" | "lg" | "xlg" | "max";
 

--- a/types/Breakpoint/breakpoints.d.ts
+++ b/types/Breakpoint/breakpoints.d.ts
@@ -2,7 +2,7 @@
  * Pixel sizes of Carbon grid breakpoints.
  * @type {Record<BreakpointSize, BreakpointValue>}
  */
-export const breakpoints: Record<BreakpointSize, BreakpointValue>;
+export declare const breakpoints: Record<BreakpointSize, BreakpointValue>;
 
 export type BreakpointSize = "sm" | "md" | "lg" | "xlg" | "max";
 


### PR DESCRIPTION
Breakpoint types were manually authored; the const should include the `declare` keyword.