### PR TITLE
ci: skip build/validate docs for tagged release

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -6,6 +6,8 @@ on:
       - "examples/**"
   push:
     branches: [master]
+    tags:
+      - "v*"
     paths-ignore:
       - "**.md"
       - "examples/**"
@@ -44,9 +46,11 @@ jobs:
           IBM_TELEMETRY_DISABLED: true
 
       - name: Build docs
+        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
         run: bun build:docs
 
       - name: Validate docs
+        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
         run: |
           if ! git diff --quiet --exit-code; then
             echo "Error: Auto-generated documentation is out of date."


### PR DESCRIPTION
https://github.com/carbon-design-system/carbon-components-svelte/actions/runs/19237188761/job/54990173745

The tagged release pushed to `master` will include a diff in the version in COMPONENT_INDEX.md.

Skip the build/validate docs for these tagged commits.