### PR TITLE
fix(context-menu): close on any click instead of only outside clicks

### DIFF
--- a/src/ContextMenu/ContextMenu.svelte
+++ b/src/ContextMenu/ContextMenu.svelte
@@ -166,7 +166,9 @@
   }}
   on:click={(e) => {
     if (!open) return;
-    close();
+    if (ref && !ref.contains(e.target)) {
+      close();
+    }
   }}
   on:keydown={(e) => {
     if (open && e.key === "Escape") close();


### PR DESCRIPTION
Fixes #578

Fixes a bug where the ContextMenu component was closing on any window click instead of only closing when clicking outside the menu. This caused issues in scenarios with multiple context menu triggers (like table rows) where clicking a different trigger would close the currently open menu before the new one could open.

The root cause was that the window click handler didn't distinguish between clicks inside and outside the menu element. The fix adds a `ref.contains(e.target)` check to ensure the menu only closes when clicking outside its DOM tree.