### PR TITLE
fix(tabs): avoid infinite update loop in Svelte 5

### DIFF
--- a/src/Tabs/Tabs.svelte
+++ b/src/Tabs/Tabs.svelte
@@ -204,7 +204,9 @@
       return reorderedContent;
     });
 
-    selected = currentIndex;
+    if (selected !== currentIndex) {
+      selected = currentIndex;
+    }
 
     if (prevIndex > -1 && prevIndex !== currentIndex) {
       dispatch("change", currentIndex);


### PR DESCRIPTION
Fixes #2366

This adds a similar guard `selected = currentIndex` assignment in `afterUpdate` to break the reactive cycle with `$: currentIndex = selected`. Same fix pattern as `Select` component in PR #2108.

Existing tests should pass.
