### PR TITLE
fix(progress-step): remove one-update delay for `step.complete` prop

### DIFF
--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -2922,7 +2922,7 @@ None.
 | Prop name      | Required | Kind             | Reactive | Type                 | Default value                                    | Description                                |
 | :------------- | :------- | :--------------- | :------- | -------------------- | ------------------------------------------------ | ------------------------------------------ |
 | current        | No       | <code>let</code> | Yes      | <code>boolean</code> | <code>false</code>                               | Set to `true` to use the current variant   |
-| complete       | No       | <code>let</code> | Yes      | <code>boolean</code> | <code>false</code>                               | Set to `true` for the complete variant     |
+| complete       | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code>                               | Set to `true` for the complete variant     |
 | disabled       | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code>                               | Set to `true` to disable the progress step |
 | invalid        | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code>                               | Set to `true` to indicate an invalid state |
 | description    | No       | <code>let</code> | No       | <code>string</code>  | <code>""</code>                                  | Specify the step description               |

--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -11833,7 +11833,7 @@
           "isFunctionDeclaration": false,
           "isRequired": false,
           "constant": false,
-          "reactive": true
+          "reactive": false
         },
         {
           "name": "current",

--- a/src/ProgressIndicator/ProgressStep.svelte
+++ b/src/ProgressIndicator/ProgressStep.svelte
@@ -40,7 +40,6 @@
     if (value[id]) {
       step = value[id];
       current = step.current;
-      complete = step.complete;
     }
   });
 

--- a/tests/ProgressIndicator/ProgressIndicatorIssue1249.test.svelte
+++ b/tests/ProgressIndicator/ProgressIndicatorIssue1249.test.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+  import { ProgressIndicator, ProgressStep } from "carbon-components-svelte";
+  import { onMount } from "svelte";
+
+  export let stepsCompleted = [false, false, false];
+
+  let currentIndex = 0;
+
+  onMount(() => {
+    stepsCompleted = [true, true, false];
+    currentIndex = 0;
+  });
+
+  export function completeStep3() {
+    stepsCompleted[2] = true;
+  }
+</script>
+
+<ProgressIndicator bind:currentIndex>
+  <ProgressStep complete={stepsCompleted[0]} label="Step 1" />
+  <ProgressStep complete={stepsCompleted[1]} label="Step 2" />
+  <ProgressStep complete={stepsCompleted[2]} label="Step 3" />
+</ProgressIndicator>
+
+<button on:click={completeStep3}>
+  Click me twice
+</button>

--- a/tests/ProgressIndicator/ProgressIndicatorReactive.test.svelte
+++ b/tests/ProgressIndicator/ProgressIndicatorReactive.test.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  import { ProgressIndicator, ProgressStep } from "carbon-components-svelte";
+
+  export let step1Complete = false;
+  export let step2Complete = false;
+</script>
+
+<ProgressIndicator>
+  <ProgressStep
+    label="Step 1"
+    description="First step"
+    complete={step1Complete}
+  />
+  <ProgressStep
+    label="Step 2"
+    description="Second step"
+    complete={step2Complete}
+  />
+</ProgressIndicator>


### PR DESCRIPTION
Fixes #1249

`ProgressStep` has a one-update delay when the `complete` prop changes reactively. Setting `complete` to `true` wouldn't visually update until the *next* state change occurred, requiring users to click buttons twice or trigger additional updates to see the expected result.

The root cause was in the `stepsById` subscription callback, which was overwriting the `complete` prop with stale store values before propagation finished:

```js
const unsubscribe = stepsById.subscribe((value) => {
  if (value[id]) {
    step = value[id];
    current = step.current;
    complete = step.complete;  // overwrote prop with stale value
  }
});
```

The `complete` prop should be driven by the parent, not read back from the store. The `current` prop still needs to come from the store since it's computed by `ProgressIndicator` based on `currentIndex`.