### PR TITLE
fix(modal): improve focus trap for `Dropdown` and other components

### DIFF
--- a/src/Modal/Modal.svelte
+++ b/src/Modal/Modal.svelte
@@ -180,13 +180,43 @@
   iframe, object, embed, *[tabindex]:not([tabindex='-1']):not([disabled]), *[contenteditable=true]
 `;
 
-        const tabbable = Array.from(ref.querySelectorAll(selectorTabbable));
+        const tabbable = Array.from(
+          ref.querySelectorAll(selectorTabbable)
+        ).filter((el) => {
+          // Filter out elements that are not visible.
+          const style = getComputedStyle(el);
+          if (style.visibility === "hidden" || style.display === "none") {
+            return false;
+          }
+
+          // Check for zero dimensions, but only if the element has been laid out
+          // (offsetParent is null for hidden elements or elements not in the DOM.
+          if (
+            el.offsetParent !== null &&
+            el.offsetWidth === 0 &&
+            el.offsetHeight === 0
+          ) {
+            return false;
+          }
+          
+          return true;
+        });
+
+        if (tabbable.length === 0) {
+          e.preventDefault();
+          return;
+        }
 
         let index = tabbable.indexOf(document.activeElement);
-        if (index === -1 && e.shiftKey) index = 0;
+        if (index === -1) {
+          // Active element not in tabbable list, find closest tabbable element
+          // For forward Tab, start from beginning (-1 + 1 = 0)
+          // For Shift+Tab, start from end (length + -1 = length - 1)
+          index = e.shiftKey ? tabbable.length : -1;
+        }
 
-        index += tabbable.length + (e.shiftKey ? -1 : 1);
-        index %= tabbable.length;
+        index += e.shiftKey ? -1 : 1;
+        index = (index + tabbable.length) % tabbable.length;
 
         tabbable[index].focus();
         e.preventDefault();

--- a/tests/ComposedModal/ComposedModal.test.ts
+++ b/tests/ComposedModal/ComposedModal.test.ts
@@ -2,6 +2,7 @@ import { render, screen } from "@testing-library/svelte";
 import { tick } from "svelte";
 import { user } from "../setup-tests";
 import ComposedModalTest from "./ComposedModal.test.svelte";
+import ComposedModalFocusTrapTest from "./ComposedModalFocusTrap.test.svelte";
 
 describe("ComposedModal", () => {
   beforeEach(() => {
@@ -394,5 +395,84 @@ describe("ComposedModal", () => {
     await tick();
 
     expect(modalOverlay).toHaveAttribute("inert");
+  });
+
+  // Regression tests for https://github.com/carbon-design-system/carbon-components-svelte/issues/1392
+  describe("focus trap with Dropdown and TextInput (issue #1392)", () => {
+    it("should tab from Dropdown to TextInput (forward navigation)", async () => {
+      render(ComposedModalFocusTrapTest, {
+        props: { open: true },
+      });
+
+      await tick();
+
+      const dropdownButton = screen.getByLabelText("Select source");
+      const loginInput = screen.getByLabelText("Login");
+
+      dropdownButton.focus();
+      expect(dropdownButton).toHaveFocus();
+
+      await user.keyboard("{Tab}");
+      await tick();
+
+      expect(loginInput).toHaveFocus();
+    });
+
+    it("should shift-tab from TextInput to Dropdown (reverse navigation)", async () => {
+      render(ComposedModalFocusTrapTest, {
+        props: { open: true },
+      });
+
+      await tick();
+
+      const dropdownButton = screen.getByLabelText("Select source");
+      const loginInput = screen.getByLabelText("Login");
+
+      loginInput.focus();
+      expect(loginInput).toHaveFocus();
+
+      await user.keyboard("{Shift>}{Tab}{/Shift}");
+      await tick();
+
+      expect(dropdownButton).toHaveFocus();
+    });
+
+    it("should tab through all inputs in order", async () => {
+      render(ComposedModalFocusTrapTest, {
+        props: { open: true },
+      });
+
+      await tick();
+
+      const dropdownButton = screen.getByLabelText("Select source");
+      const loginInput = screen.getByLabelText("Login");
+      const passwordInput = screen.getByLabelText("Password");
+      const cancelButton = screen.getByRole("button", { name: "Cancel" });
+      const okButton = screen.getByRole("button", { name: "OK" });
+
+      // Start from dropdown.
+      dropdownButton.focus();
+      expect(dropdownButton).toHaveFocus();
+
+      // Tab to login input.
+      await user.keyboard("{Tab}");
+      await tick();
+      expect(loginInput).toHaveFocus();
+
+      // Tab to password input.
+      await user.keyboard("{Tab}");
+      await tick();
+      expect(passwordInput).toHaveFocus();
+
+      // Tab to Cancel button.
+      await user.keyboard("{Tab}");
+      await tick();
+      expect(cancelButton).toHaveFocus();
+
+      // Tab to OK button.
+      await user.keyboard("{Tab}");
+      await tick();
+      expect(okButton).toHaveFocus();
+    });
   });
 });

--- a/tests/ComposedModal/ComposedModalFocusTrap.test.svelte
+++ b/tests/ComposedModal/ComposedModalFocusTrap.test.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+  import {
+    ComposedModal,
+    Dropdown,
+    ModalBody,
+    ModalFooter,
+    ModalHeader,
+    TextInput,
+  } from "carbon-components-svelte";
+
+  export let open = false;
+</script>
+
+<ComposedModal bind:open on:open on:close>
+  <ModalHeader title="A11y issue" />
+  <ModalBody hasScrollingContent>
+    <Dropdown
+      labelText="Select source"
+      selectedId="0"
+      items={[
+        { id: "0", text: "First item" },
+        { id: "1", text: "Second item" },
+      ]}
+    />
+    <TextInput
+      placeholder="text"
+      name="text"
+      labelText="Login"
+    />
+    <TextInput
+      placeholder="password"
+      type="password"
+      labelText="Password"
+    />
+  </ModalBody>
+  <ModalFooter primaryButtonText="OK" secondaryButtonText="Cancel" />
+</ComposedModal>

--- a/tests/Modal/ModalFocusTrap.test.svelte
+++ b/tests/Modal/ModalFocusTrap.test.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+  import { Dropdown, Modal, TextInput } from "carbon-components-svelte";
+
+  export let open = false;
+</script>
+
+<Modal
+  bind:open
+  modalHeading="A11y issue"
+  primaryButtonText="OK"
+  secondaryButtonText="Cancel"
+  hasScrollingContent={true}
+  on:open
+  on:close
+>
+  <Dropdown
+    labelText="Select source"
+    selectedId="0"
+    items={[
+      { id: "0", text: "First item" },
+      { id: "1", text: "Second item" },
+    ]}
+  />
+  <TextInput
+    placeholder="text"
+    name="text"
+    labelText="Login"
+  />
+  <TextInput
+    placeholder="password"
+    type="password"
+    labelText="Password"
+  />
+</Modal>


### PR DESCRIPTION
Fixes #1392

The focus trap in `Modal` and `ComposedModal` would fail when elements like Dropdown were present, causing Tab keyboard behavior to jump to the close button instead of the next focusable element.

The workaround is to check element visibility/display, and also skip elements with zero dimensions.

Adds regression tests using the user-provided repro.

```svelte
<Modal
  bind:open
  modalHeading="A11y issue"
  primaryButtonText="OK"
  secondaryButtonText="Cancel"
  hasScrollingContent={true}
  on:open
  on:close
>
  <Dropdown
    labelText="Select source"
    selectedId="0"
    items={[
      { id: "0", text: "First item" },
      { id: "1", text: "Second item" },
    ]}
  />
  <TextInput
    placeholder="text"
    name="text"
    labelText="Login"
  />
  <TextInput
    placeholder="password"
    type="password"
    labelText="Password"
  />
</Modal>

```