### PR TITLE
test(config): remove `optimizeDeps.exclude`

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -47,9 +47,6 @@ function generateAliasesFromExports() {
 export default defineConfig({
   root: "./tests",
   plugins: [svelte({ preprocess: [vitePreprocess()] })],
-  optimizeDeps: {
-    exclude: ["carbon-components-svelte", "carbon-icons-svelte"],
-  },
   resolve: {
     conditions: ["browser"],
     alias: generateAliasesFromExports(),


### PR DESCRIPTION
`carbon-preprocess-svelte` was removed from the testing config, since it causes friction when testing newly exported components.

Consequently, `optimizeDeps.exclude` should be removed.