### PR TITLE
feat(tile-group): make `selectedValue` and `selected` generic

### DIFF
--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -4320,13 +4320,13 @@ export type CarbonTheme = "white" | "g10" | "g80" | "g90" | "g100";
 
 ### Props
 
-| Prop name | Required | Kind             | Reactive | Type                 | Default value          | Description                                              |
-| :-------- | :------- | :--------------- | :------- | -------------------- | ---------------------- | -------------------------------------------------------- |
-| selected  | No       | <code>let</code> | Yes      | <code>string</code>  | <code>undefined</code> | Specify the selected tile value                          |
-| disabled  | No       | <code>let</code> | No       | <code>boolean</code> | <code>false</code>     | Set to `true` to disable the tile group                  |
-| required  | No       | <code>let</code> | No       | <code>boolean</code> | <code>undefined</code> | Set to `true` to require the selection of a radio button |
-| name      | No       | <code>let</code> | No       | <code>string</code>  | <code>undefined</code> | Specify a name attribute for the radio button inputs     |
-| legend    | No       | <code>let</code> | No       | <code>string</code>  | <code>""</code>        | Specify the legend text                                  |
+| Prop name | Required | Kind             | Reactive | Type                            | Default value          | Description                                              |
+| :-------- | :------- | :--------------- | :------- | ------------------------------- | ---------------------- | -------------------------------------------------------- |
+| selected  | No       | <code>let</code> | Yes      | <code>T &#124; undefined</code> | <code>undefined</code> | Specify the selected tile value                          |
+| disabled  | No       | <code>let</code> | No       | <code>boolean</code>            | <code>false</code>     | Set to `true` to disable the tile group                  |
+| required  | No       | <code>let</code> | No       | <code>boolean</code>            | <code>undefined</code> | Set to `true` to require the selection of a radio button |
+| name      | No       | <code>let</code> | No       | <code>string</code>             | <code>undefined</code> | Specify a name attribute for the radio button inputs     |
+| legend    | No       | <code>let</code> | No       | <code>string</code>             | <code>""</code>        | Specify the legend text                                  |
 
 ### Slots
 
@@ -4336,9 +4336,9 @@ export type CarbonTheme = "white" | "g10" | "g80" | "g90" | "g100";
 
 ### Events
 
-| Event name | Type       | Detail              | Description |
-| :--------- | :--------- | :------------------ | :---------- |
-| select     | dispatched | <code>string</code> | --          |
+| Event name | Type       | Detail         | Description |
+| :--------- | :--------- | :------------- | :---------- |
+| select     | dispatched | <code>T</code> | --          |
 
 ## `TimePicker`
 

--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -17231,7 +17231,7 @@
           "name": "selected",
           "kind": "let",
           "description": "Specify the selected tile value",
-          "type": "string",
+          "type": "T | undefined",
           "value": "undefined",
           "isFunction": false,
           "isFunctionDeclaration": false,
@@ -17300,11 +17300,14 @@
         {
           "type": "dispatched",
           "name": "select",
-          "detail": "string"
+          "detail": "T"
         }
       ],
       "typedefs": [],
-      "generics": null,
+      "generics": [
+        "T",
+        "T extends string = string"
+      ],
       "rest_props": {
         "type": "Element",
         "name": "fieldset"
@@ -17316,7 +17319,7 @@
           "properties": [
             {
               "name": "selectedValue",
-              "type": "import(\"svelte/store\").Writable<string | undefined>",
+              "type": "import(\"svelte/store\").Writable<T | undefined>",
               "description": "",
               "optional": false
             },
@@ -17332,13 +17335,13 @@
             },
             {
               "name": "add",
-              "type": "(data: { checked: boolean; value: string }) => void",
+              "type": "(data: { checked: boolean; value: T }) => void",
               "description": "",
               "optional": false
             },
             {
               "name": "update",
-              "type": "(value: string) => void",
+              "type": "(value: T) => void",
               "description": "",
               "optional": false
             }

--- a/src/Tile/TileGroup.svelte
+++ b/src/Tile/TileGroup.svelte
@@ -1,11 +1,13 @@
 <script>
   /**
-   * @event {string} select
+   * @generics {T extends string = string} T
+   * @template {string} T
+   * @event {T} select
    */
 
   /**
    * Specify the selected tile value
-   * @type {string}
+   * @type {T | undefined}
    */
   export let selected = undefined;
 
@@ -32,14 +34,14 @@
 
   const dispatch = createEventDispatcher();
   /**
-   * @type {import("svelte/store").Writable<string | undefined>}
+   * @type {import("svelte/store").Writable<T | undefined>}
    */
   const selectedValue = writable(selected);
   const groupName = writable(name);
   const groupRequired = writable(required);
 
   /**
-   * @type {(data: { checked: boolean; value: string }) => void}
+   * @type {(data: { checked: boolean; value: T }) => void}
    */
   const add = ({ checked, value }) => {
     if (checked) {
@@ -48,7 +50,7 @@
   };
 
   /**
-   * @type {(value: string) => void}
+   * @type {(value: T) => void}
    */
   const update = (value) => {
     selectedValue.set(value);

--- a/tests/Tile/TileGroup.test.ts
+++ b/tests/Tile/TileGroup.test.ts
@@ -1,4 +1,6 @@
 import { render, screen } from "@testing-library/svelte";
+import type TileGroupComponent from "carbon-components-svelte/Tile/TileGroup.svelte";
+import type { ComponentEvents, ComponentProps } from "svelte";
 import { user } from "../setup-tests";
 import TileGroup from "./TileGroup.test.svelte";
 
@@ -155,5 +157,105 @@ describe("TileGroup", () => {
 
     const legend = screen.queryByRole("legend");
     expect(legend).not.toBeInTheDocument();
+  });
+
+  describe("Generics", () => {
+    it("should support custom string literal types with generics", () => {
+      type CustomValue = "option1" | "option2" | "option3";
+
+      type ComponentType = TileGroupComponent<CustomValue>;
+      type Props = ComponentProps<ComponentType>;
+      type Events = ComponentEvents<ComponentType>;
+
+      expectTypeOf<Props["selected"]>().toEqualTypeOf<
+        CustomValue | undefined
+      >();
+
+      type SelectEvent = Events["select"];
+      type SelectEventDetail = SelectEvent extends CustomEvent<infer T>
+        ? T
+        : never;
+      expectTypeOf<SelectEventDetail>().toEqualTypeOf<CustomValue>();
+    });
+
+    it("should default to string type when generic is not specified", () => {
+      type ComponentType = TileGroupComponent;
+      type Props = ComponentProps<ComponentType>;
+      type Events = ComponentEvents<ComponentType>;
+
+      expectTypeOf<Props["selected"]>().toEqualTypeOf<string | undefined>();
+
+      type SelectEvent = Events["select"];
+      type SelectEventDetail = SelectEvent extends CustomEvent<infer T>
+        ? T
+        : never;
+      expectTypeOf<SelectEventDetail>().toEqualTypeOf<string>();
+    });
+
+    it("should provide type-safe access to custom string literal types in event handlers", () => {
+      type Status = "pending" | "approved" | "rejected";
+
+      const handleSelect = (value: Status) => {
+        expectTypeOf(value).toEqualTypeOf<Status>();
+        if (value === "pending") {
+          expectTypeOf(value).toEqualTypeOf<"pending">();
+        }
+      };
+
+      expectTypeOf(handleSelect).parameter(0).toEqualTypeOf<Status>();
+
+      type ComponentType = TileGroupComponent<Status>;
+      type Events = ComponentEvents<ComponentType>;
+      type SelectEvent = Events["select"];
+      type SelectEventDetail = SelectEvent extends CustomEvent<infer T>
+        ? T
+        : never;
+
+      expectTypeOf<SelectEventDetail>().toEqualTypeOf<
+        Parameters<typeof handleSelect>[0]
+      >();
+    });
+
+    it("should enforce string constraint on generic type", () => {
+      type ValidStringLiteral = "a" | "b" | "c";
+      type ComponentType = TileGroupComponent<ValidStringLiteral>;
+      type Props = ComponentProps<ComponentType>;
+
+      expectTypeOf<Props["selected"]>().toEqualTypeOf<
+        ValidStringLiteral | undefined
+      >();
+
+      type StringComponentType = TileGroupComponent<string>;
+      type StringProps = ComponentProps<StringComponentType>;
+      expectTypeOf<StringProps["selected"]>().toEqualTypeOf<
+        string | undefined
+      >();
+    });
+
+    it("should work with 'as const' for type inference", () => {
+      const selectedValues = ["option1", "option2", "option3"] as const;
+      type InferredType = (typeof selectedValues)[number];
+
+      expectTypeOf<typeof selectedValues>().toEqualTypeOf<
+        readonly ["option1", "option2", "option3"]
+      >();
+      expectTypeOf<InferredType>().toEqualTypeOf<
+        "option1" | "option2" | "option3"
+      >();
+
+      type ComponentType = TileGroupComponent<InferredType>;
+      type Props = ComponentProps<ComponentType>;
+      type Events = ComponentEvents<ComponentType>;
+
+      expectTypeOf<Props["selected"]>().toEqualTypeOf<
+        InferredType | undefined
+      >();
+
+      type SelectEvent = Events["select"];
+      type SelectEventDetail = SelectEvent extends CustomEvent<infer T>
+        ? T
+        : never;
+      expectTypeOf<SelectEventDetail>().toEqualTypeOf<InferredType>();
+    });
   });
 });

--- a/types/Tile/TileGroup.svelte.d.ts
+++ b/types/Tile/TileGroup.svelte.d.ts
@@ -2,21 +2,21 @@ import type { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
 export type TileGroupContext = {
-  selectedValue: import("svelte/store").Writable<string | undefined>;
+  selectedValue: import("svelte/store").Writable<T | undefined>;
   groupName: any;
   groupRequired: any;
-  add: (data: { checked: boolean; value: string }) => void;
-  update: (value: string) => void;
+  add: (data: { checked: boolean; value: T }) => void;
+  update: (value: T) => void;
 };
 
 type $RestProps = SvelteHTMLElements["fieldset"];
 
-type $Props = {
+type $Props<T> = {
   /**
    * Specify the selected tile value
    * @default undefined
    */
-  selected?: string;
+  selected?: T | undefined;
 
   /**
    * Set to `true` to disable the tile group
@@ -45,10 +45,12 @@ type $Props = {
   [key: `data-${string}`]: any;
 };
 
-export type TileGroupProps = Omit<$RestProps, keyof $Props> & $Props;
+export type TileGroupProps<T> = Omit<$RestProps, keyof $Props<T>> & $Props<T>;
 
-export default class TileGroup extends SvelteComponentTyped<
-  TileGroupProps,
-  { select: CustomEvent<string> },
+export default class TileGroup<
+  T extends string = string,
+> extends SvelteComponentTyped<
+  TileGroupProps<T>,
+  { select: CustomEvent<T> },
   { default: Record<string, never> }
 > {}


### PR DESCRIPTION
Related #2372, #2371

This PR adds TypeScript generics support to the `TileGroup`, bringing it in line with SelectableTileGroup. This enhances type safety and improves the developer experience when working with custom string literal types. No functional changes.

**Changes**

- Add generic type parameter `T extends string = string` to `TileGroup.svelte`
- Update `selected` prop type from `string | undefined` to `T | undefined`
- Update `select` event to dispatch `T` instead of `string`
- Update context functions (`add`, `update`) to use generic type parameter
- Add generic type tests to `TileGroup.test.ts` mirroring `SelectableTileGroup.test.ts`
- Regenerate TypeScript definitions via `bun build:docs`

