### PR TITLE
fix(tile-group): improve context types for `SelectableTileGroup` and `TileGroup`

### DIFF
--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -13746,7 +13746,8 @@
             },
             {
               "name": "groupName",
-              "type": "any",
+              "type": "import(\"svelte/store\").Readable<string | undefined>",
+              "description": "",
               "optional": false
             },
             {
@@ -17325,12 +17326,14 @@
             },
             {
               "name": "groupName",
-              "type": "any",
+              "type": "import(\"svelte/store\").Readable<string | undefined>",
+              "description": "",
               "optional": false
             },
             {
               "name": "groupRequired",
-              "type": "any",
+              "type": "import(\"svelte/store\").Readable<boolean | undefined>",
+              "description": "",
               "optional": false
             },
             {

--- a/src/Tile/SelectableTileGroup.svelte
+++ b/src/Tile/SelectableTileGroup.svelte
@@ -36,6 +36,10 @@
    * @type {import("svelte/store").Writable<string | undefined>}
    */
   const groupName = writable(name);
+  /**
+   * @type {import("svelte/store").Readable<string | undefined>}
+   */
+  const groupNameReadonly = readonly(groupName);
 
   /**
    * @type {(data: { selected: boolean; value: T }) => void}
@@ -65,14 +69,14 @@
 
   setContext("SelectableTileGroup", {
     selectedValues,
-    groupName: readonly(groupName),
+    groupName: groupNameReadonly,
     add,
     update,
   });
 
   $: selected = $selectedValues;
   $: selectedValues.set(selected);
-  $: $groupName = name;
+  $: groupName.set(name);
 </script>
 
 <fieldset {disabled} class:bx--tile-group={true} {...$$restProps}>

--- a/src/Tile/TileGroup.svelte
+++ b/src/Tile/TileGroup.svelte
@@ -37,8 +37,22 @@
    * @type {import("svelte/store").Writable<T | undefined>}
    */
   const selectedValue = writable(selected);
+  /**
+   * @type {import("svelte/store").Writable<string | undefined>}
+   */
   const groupName = writable(name);
+  /**
+   * @type {import("svelte/store").Writable<boolean | undefined>}
+   */
   const groupRequired = writable(required);
+  /**
+   * @type {import("svelte/store").Readable<string | undefined>}
+   */
+  const groupNameReadonly = readonly(groupName);
+  /**
+   * @type {import("svelte/store").Readable<boolean | undefined>}
+   */
+  const groupRequiredReadonly = readonly(groupRequired);
 
   /**
    * @type {(data: { checked: boolean; value: T }) => void}
@@ -59,16 +73,16 @@
 
   setContext("TileGroup", {
     selectedValue,
-    groupName: readonly(groupName),
-    groupRequired: readonly(groupRequired),
+    groupName: groupNameReadonly,
+    groupRequired: groupRequiredReadonly,
     add,
     update,
   });
 
   $: selected = $selectedValue;
   $: selectedValue.set(selected);
-  $: $groupName = name;
-  $: $groupRequired = required;
+  $: groupName.set(name);
+  $: groupRequired.set(required);
 </script>
 
 <fieldset {disabled} class:bx--tile-group={true} {...$$restProps}>

--- a/types/Tile/SelectableTileGroup.svelte.d.ts
+++ b/types/Tile/SelectableTileGroup.svelte.d.ts
@@ -3,7 +3,7 @@ import type { SvelteHTMLElements } from "svelte/elements";
 
 export type SelectableTileGroupContext = {
   selectedValues: import("svelte/store").Writable<T[]>;
-  groupName: any;
+  groupName: import("svelte/store").Readable<string | undefined>;
   add: (data: { selected: boolean; value: T }) => void;
   update: (data: { value: T; selected: boolean }) => void;
 };

--- a/types/Tile/TileGroup.svelte.d.ts
+++ b/types/Tile/TileGroup.svelte.d.ts
@@ -3,8 +3,8 @@ import type { SvelteHTMLElements } from "svelte/elements";
 
 export type TileGroupContext = {
   selectedValue: import("svelte/store").Writable<T | undefined>;
-  groupName: any;
-  groupRequired: any;
+  groupName: import("svelte/store").Readable<string | undefined>;
+  groupRequired: import("svelte/store").Readable<boolean | undefined>;
   add: (data: { checked: boolean; value: T }) => void;
   update: (value: T) => void;
 };


### PR DESCRIPTION
Strongly type `groupName` and `groupRequired` context properties in `TileGroup` components.

**Changes**

- Added explicit JSDoc type annotations for `groupName` and `groupRequired` writable stores in both `TileGroup.svelte` and `SelectableTileGroup.svelte`
- Created typed readonly store variables (`groupNameReadonly`, `groupRequiredReadonly`) with explicit `Readable<string | undefined>` and `Readable<boolean | undefined>` types before passing to `setContext`
- Replaced inline `readonly(groupName)` calls with the typed readonly store variables to enable proper type inference by sveld
- Updated reactive statements to use `.set()` method calls instead of direct assignment for writable stores