### PR TITLE
fix(number-input): only show invalid state when `invalid` and `invalidText` are set

### DIFF
--- a/src/NumberInput/NumberInput.svelte
+++ b/src/NumberInput/NumberInput.svelte
@@ -163,11 +163,7 @@
 
   $: incrementLabel = translateWithId("increment");
   $: decrementLabel = translateWithId("decrement");
-  $: hasError =
-    (invalid && !readonly) ||
-    (!allowEmpty && value == null) ||
-    value > max ||
-    (typeof value === "number" && value < min);
+  $: hasError = invalid && invalidText && !readonly;
   $: errorId = `error-${id}`;
   $: ariaLabel =
     $$props["aria-label"] ||


### PR DESCRIPTION
Fixes #1180.

`NumberInput` now behaves consistently with `TextInput`. The invalid state requires explicit `invalid={true}` plus truthy `invalidText`, rather than auto-triggering on min/max violations.

`NumberInput` was automatically showing an invalid state based on min/max constraints or empty value validation. This behavior was inconsistent with TextInput, which only shows an invalid state when explicitly set via the `invalid` prop.

The component now requires both `invalid={true}` and a non-empty `invalidText` prop to display the invalid state, matching the behavior of TextInput. This gives developers full control over validation feedback, preventing automatic validation from interfering with custom validation logic.

**Changes**

- Simplified the `hasError` computed property in NumberInput.svelte to only check `invalid && invalidText && !readonly`, removing automatic validation checks for min/max bounds and empty values
  - Added regression tests for issue #1180 covering cases where values exceed max, fall below min, or are null without the invalid prop

**Example**

Previously, NumberInput would automatically show invalid state when values exceeded min/max constraints:

```svelte
<!-- Before: automatically shows invalid state when value > max -->
<NumberInput max={10} value={15} />
```

Now, the invalid state must be explicitly set:

```svelte
<!-- After: requires explicit invalid prop to show invalid state -->
<NumberInput max={10} value={15} invalid={true} invalidText="Value exceeds maximum" />
```