### PR TITLE
ci: `svelte-check` should fail on warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "scripts": {
     "test": "vitest",
     "test:src-types": "tsgo",
-    "test:types": "svelte-check --workspace tests",
+    "test:types": "svelte-check --workspace tests --fail-on-warnings",
     "lint": "biome check --write .",
     "build:css": "bun scripts/build-css",
     "build:docs": "bun scripts/build-docs && bun scripts/format-component-api",


### PR DESCRIPTION
`bun test:types` runs svelte-check, and should fail on warnings.