### PR TITLE
fix(tabs): avoid infinite update loop in Svelte 5

### DIFF
--- a/src/Tabs/TabContent.svelte
+++ b/src/Tabs/TabContent.svelte
@@ -16,8 +16,8 @@
   });
 
   $: selected = $selectedContent === id;
-  $: index = $contentById[id].index;
-  $: tabId = $tabs[index].id;
+  $: index = $contentById[id]?.index ?? 0;
+  $: tabId = $tabs[index]?.id;
 </script>
 
 <div


### PR DESCRIPTION
Fixes #2366, https://github.com/carbon-design-system/carbon-components-svelte/issues/2366#issuecomment-3593491629

Previous attempt: #2367

#2350 fixed a tab-order bug but introduced a regression for `Tabs` with Svelte 5 (see https://github.com/carbon-design-system/carbon-components-svelte/issues/2366).

The regression was introduced in v0.93.0.

This attempts to break the infinite effect loop using an internal `needsDomSync` flag that only triggers DOM-to-store synchronization when tabs or content are actually added or removed, breaking the infinite loop cycle.
