### PR TITLE
ci: set `env` globally

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -14,6 +14,9 @@ on:
 permissions:
   contents: read
 
+env:
+  IBM_TELEMETRY_DISABLED: true
+
 jobs:
   lint:
     runs-on: macos-15
@@ -21,8 +24,6 @@ jobs:
       - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
       - run: bun ci
-        env:
-          IBM_TELEMETRY_DISABLED: true
       - run: bunx biome ci --error-on-warnings
 
   test:
@@ -31,8 +32,6 @@ jobs:
       - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
       - run: bun ci
-        env:
-          IBM_TELEMETRY_DISABLED: true
       - run: bun run test
 
   types:
@@ -41,8 +40,6 @@ jobs:
       - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
       - run: bun ci
-        env:
-          IBM_TELEMETRY_DISABLED: true
 
       - name: Build docs
         run: bun build:docs


### PR DESCRIPTION
Closes #2399 

Disables IBM Telemetry in CI as a global env var.