### PR TITLE
fix(time-picker): allow longer labels

### DIFF
--- a/src/TimePicker/TimePicker.svelte
+++ b/src/TimePicker/TimePicker.svelte
@@ -49,6 +49,8 @@
 
   /** Obtain a reference to the input HTML element */
   export let ref = null;
+
+  import Stack from "../Stack/Stack.svelte";
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
@@ -82,32 +84,34 @@
           </slot>
         </label>
       {/if}
-      <input
-        bind:this={ref}
-        bind:value
-        type="text"
-        data-invalid={invalid || undefined}
-        {pattern}
-        {placeholder}
-        {maxlength}
-        {id}
-        {name}
-        {disabled}
-        {...$$restProps}
-        class:bx--time-picker__input-field={true}
-        class:bx--text-input={true}
-        class:bx--text-input--light={light}
-        class:bx--text-input--invalid={invalid}
-        on:change
-        on:input
-        on:keydown
-        on:keyup
-        on:focus
-        on:blur
-        on:paste
-      />
+      <Stack orientation="horizontal" gap={0}>
+        <input
+          bind:this={ref}
+          bind:value
+          type="text"
+          data-invalid={invalid || undefined}
+          {pattern}
+          {placeholder}
+          {maxlength}
+          {id}
+          {name}
+          {disabled}
+          {...$$restProps}
+          class:bx--time-picker__input-field={true}
+          class:bx--text-input={true}
+          class:bx--text-input--light={light}
+          class:bx--text-input--invalid={invalid}
+          on:change
+          on:input
+          on:keydown
+          on:keyup
+          on:focus
+          on:blur
+          on:paste
+        />
+        <slot />
+      </Stack>
     </div>
-    <slot />
   </div>
   {#if invalid}
     <div class:bx--form-requirement={true}>{invalidText}</div>


### PR DESCRIPTION
Fixes #1749, closes #1751

Allows longer labels by wrapping input and slot in `Stack`.

---

## Before
<img width="412" height="138" alt="Screenshot 2025-12-13 at 12 11 20 PM" src="https://github.com/user-attachments/assets/c7fea5d5-69af-4bfa-8dda-8f6949bb2a64" />

## After
<img width="391" height="107" alt="Screenshot 2025-12-13 at 12 11 24 PM" src="https://github.com/user-attachments/assets/a8e92004-81cc-4b0f-89af-448119cbd9dd" />
