### PR TITLE
fix(file-uploader-button): prevent crash when `files` is cleared

### DIFF
--- a/src/FileUploader/FileUploaderButton.svelte
+++ b/src/FileUploader/FileUploaderButton.svelte
@@ -188,7 +188,7 @@
   on:change|stopPropagation={({ target }) => {
     files = multiple ? [...files, ...target.files] : [...target.files];
 
-    if (files && !disableLabelChanges) {
+    if (files && files.length > 0 && !disableLabelChanges) {
       labelText = files.length > 1 ? `${files.length} files` : files[0].name;
     }
 

--- a/tests/FileUploader/FileUploaderButton.test.ts
+++ b/tests/FileUploader/FileUploaderButton.test.ts
@@ -114,7 +114,8 @@ describe("FileUploaderButton", () => {
     });
   });
 
-  it.skip("should reset label text when files are cleared", async () => {
+  // Regression test for https://github.com/carbon-design-system/carbon-components-svelte/issues/2436
+  it("should reset label text when files are cleared", async () => {
     const { container } = render(FileUploaderButton, {
       props: { labelText: "Add file" },
     });


### PR DESCRIPTION
Fixes #2436

Empty arrays are truthy in JavaScript, so `files &&` check passed even when `files.length === 0`, causing `files[0].name` to throw. Added an explicit length check to prevent accessing an undefined array element.