### PR TITLE
fix(radio-tile): forward `aria-*` attributes to input element

### DIFF
--- a/src/Tile/RadioTile.svelte
+++ b/src/Tile/RadioTile.svelte
@@ -1,4 +1,8 @@
 <script>
+  /**
+   * @restProps {label}
+   */
+
   /** Set to `true` to check the tile */
   export let checked = false;
 
@@ -33,6 +37,15 @@
   import { readable } from "svelte/store";
   import CheckmarkFilled from "../icons/CheckmarkFilled.svelte";
 
+  // aria attributes should go to the input element, not the label.
+  $: ariaDescribedBy = $$restProps["aria-describedby"];
+  $: ariaLabelledBy = $$restProps["aria-labelledby"];
+  $: labelRestProps = Object.fromEntries(
+    Object.entries($$restProps).filter(
+      ([key]) => key !== "aria-describedby" && key !== "aria-labelledby",
+    ),
+  );
+
   const { add, update, selectedValue, groupName, groupRequired } = getContext(
     "TileGroup",
   ) ?? {
@@ -56,6 +69,8 @@
   tabindex={disabled ? undefined : tabindex}
   {disabled}
   required={$groupRequired ?? required}
+  aria-describedby={ariaDescribedBy}
+  aria-labelledby={ariaLabelledBy}
   class:bx--tile-input={true}
   on:change
   on:change={() => {
@@ -80,7 +95,7 @@
   class:bx--tile--is-selected={checked}
   class:bx--tile--light={light}
   class:bx--tile--disabled={disabled}
-  {...$$restProps}
+  {...labelRestProps}
   on:click
   on:mouseover
   on:mouseenter

--- a/tests/Tile/RadioTile.test.svelte
+++ b/tests/Tile/RadioTile.test.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+  import { RadioTile, TileGroup } from "carbon-components-svelte";
+  import type { ComponentProps } from "svelte";
+
+  export let selected: ComponentProps<TileGroup>["selected"] = undefined;
+  export let ariaDescribedBy: string | undefined = undefined;
+  export let ariaLabelledBy: string | undefined = undefined;
+</script>
+
+<TileGroup bind:selected>
+  <RadioTile
+    value="option1"
+    aria-describedby={ariaDescribedBy}
+    aria-labelledby={ariaLabelledBy}
+  >
+    Option 1
+  </RadioTile>
+</TileGroup>
+
+{#if ariaDescribedBy}
+  <div id={ariaDescribedBy}>Description for the radio tile</div>
+{/if}
+
+{#if ariaLabelledBy}
+  <div id={ariaLabelledBy}>Label for the radio tile</div>
+{/if}

--- a/tests/Tile/RadioTile.test.ts
+++ b/tests/Tile/RadioTile.test.ts
@@ -1,0 +1,47 @@
+import { render, screen } from "@testing-library/svelte";
+import RadioTileTest from "./RadioTile.test.svelte";
+
+describe("RadioTile", () => {
+  describe("aria attributes", () => {
+    it("should apply aria-describedby to the input element, not the label", () => {
+      render(RadioTileTest, { ariaDescribedBy: "description-id" });
+
+      const input = screen.getByRole("radio");
+      expect(input).toHaveAttribute("aria-describedby", "description-id");
+
+      const label = input.nextElementSibling;
+      assert(label instanceof HTMLLabelElement);
+      expect(label.tagName).toBe("LABEL");
+      expect(label).not.toHaveAttribute("aria-describedby");
+    });
+
+    it("should apply aria-labelledby to the input element, not the label", () => {
+      render(RadioTileTest, { ariaLabelledBy: "label-id" });
+
+      const input = screen.getByRole("radio");
+      expect(input).toHaveAttribute("aria-labelledby", "label-id");
+
+      const label = input.nextElementSibling;
+      assert(label instanceof HTMLLabelElement);
+      expect(label.tagName).toBe("LABEL");
+      expect(label).not.toHaveAttribute("aria-labelledby");
+    });
+
+    it("should apply both aria-describedby and aria-labelledby to the input element", () => {
+      render(RadioTileTest, {
+        ariaDescribedBy: "description-id",
+        ariaLabelledBy: "label-id",
+      });
+
+      const input = screen.getByRole("radio");
+      expect(input).toHaveAttribute("aria-describedby", "description-id");
+      expect(input).toHaveAttribute("aria-labelledby", "label-id");
+
+      const label = input.nextElementSibling;
+      assert(label instanceof HTMLLabelElement);
+      expect(label.tagName).toBe("LABEL");
+      expect(label).not.toHaveAttribute("aria-describedby");
+      expect(label).not.toHaveAttribute("aria-labelledby");
+    });
+  });
+});


### PR DESCRIPTION
Ports fix from https://github.com/carbon-design-system/carbon/pull/21068

Accessibility attributes provided to `RadioTile` should go to the input, not the label.