### PR TITLE
fix(toolbar-search): replace `JSON.stringify` with custom deep comparison for filtered rows

### DIFF
--- a/src/DataTable/ToolbarSearch.svelte
+++ b/src/DataTable/ToolbarSearch.svelte
@@ -48,6 +48,7 @@
 
   import { afterUpdate, getContext, onMount, tick } from "svelte";
   import Search from "../Search/Search.svelte";
+  import { rowsEqual } from "./data-table-utils.js";
 
   const ctx = getContext("DataTable") ?? {};
 
@@ -58,7 +59,7 @@
     unsubscribe = ctx?.tableRows.subscribe((tableRows) => {
       // Only update if the rows have actually changed.
       // This approach works in both Svelte 4 and Svelte 5.
-      if (JSON.stringify(tableRows) !== JSON.stringify(rows)) {
+      if (!rowsEqual(tableRows, rows)) {
         rows = tableRows;
       }
     });

--- a/src/DataTable/data-table-utils.d.ts
+++ b/src/DataTable/data-table-utils.d.ts
@@ -1,0 +1,9 @@
+/**
+ * Lightweight deep equality check optimized for DataTable rows.
+ * Compares arrays of row objects by first checking IDs (fast path),
+ * then falling back to deep object comparison to handle nested structures.
+ */
+export function rowsEqual<Row extends Record<string, any>>(
+  a: ReadonlyArray<Row> | null,
+  b: ReadonlyArray<Row> | null,
+): boolean;

--- a/src/DataTable/data-table-utils.js
+++ b/src/DataTable/data-table-utils.js
@@ -1,0 +1,137 @@
+// @ts-check
+/**
+ * Deep equality check for values (nested objects and arrays).
+ * @param {*} a - First value to compare
+ * @param {*} b - Second value to compare
+ * @param {WeakMap<*, Set<*>>} [stack] - WeakMap used to track circular references
+ * @returns {boolean} True if values are deeply equal, false otherwise
+ */
+function deepEqual(a, b, stack = new WeakMap()) {
+  // Fast path: reference equality.
+  if (a === b) return true;
+
+  // Handle null/undefined.
+  if (a == null || b == null) return a === b;
+
+  // Handle NaN: NaN is the only value where NaN !== NaN is true in JavaScript
+  // Without this check, two NaN values would incorrectly be considered unequal.
+  if (Number.isNaN(a) && Number.isNaN(b)) return true;
+  if (Number.isNaN(a) || Number.isNaN(b)) return false;
+
+  if (typeof a !== typeof b) return false;
+
+  if (a instanceof Date && b instanceof Date) {
+    return a.getTime() === b.getTime();
+  }
+
+  if (a instanceof RegExp && b instanceof RegExp) {
+    return a.source === b.source && a.flags === b.flags;
+  }
+
+  if (typeof a === "function" && typeof b === "function") {
+    return a === b;
+  }
+
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i++) {
+      // Pass the stack to handle nested arrays and prevent infinite recursion.
+      if (!deepEqual(a[i], b[i], stack)) return false;
+    }
+    return true;
+  }
+
+  if (typeof a === "object" && typeof b === "object") {
+    const aVisited = stack.get(a);
+
+    if (aVisited?.has(b)) {
+      // Circular reference: if we've already seen this (a, b) pair, they're equal.
+      return true;
+    }
+
+    // WeakMap entries are auto-removed when keys are garbage collected.
+    if (aVisited) {
+      aVisited.add(b);
+    } else {
+      stack.set(a, new Set([b]));
+    }
+
+    // Compare string keys: objects must have the same enumerable properties.
+    const keysA = Object.keys(a);
+    const keysB = Object.keys(b);
+    if (keysA.length !== keysB.length) {
+      stack.get(a)?.delete(b);
+      return false;
+    }
+
+    for (const key of keysA) {
+      // Pass the stack to handle nested objects and prevent infinite recursion.
+      if (!(key in b) || !deepEqual(a[key], b[key], stack)) {
+        stack.get(a)?.delete(b);
+        return false;
+      }
+    }
+
+    const symKeysA = Object.getOwnPropertySymbols(a);
+    const symKeysB = Object.getOwnPropertySymbols(b);
+    if (symKeysA.length !== symKeysB.length) {
+      stack.get(a)?.delete(b);
+      return false;
+    }
+
+    // Recursively compare Symbol property values.
+    for (const key of symKeysA) {
+      if (!symKeysB.includes(key) || !deepEqual(a[key], b[key], stack)) {
+        stack.get(a)?.delete(b);
+        return false;
+      }
+    }
+
+    // All checks passed: remove (a, b) from tracking before returning
+    // Cleanup is for correctness (not GC): allows same objects to be
+    // compared again without false circular reference detection.
+    stack.get(a)?.delete(b);
+    return true;
+  }
+
+  // Finally, use strict equality for primitives.
+  return a === b;
+}
+
+/**
+ * Lightweight deep equality check optimized for DataTable rows.
+ * Compares arrays of row objects by first checking IDs (fast path),
+ * then falling back to deep object comparison to handle nested structures.
+ * @template {Record<string, any>} Row - Row type with at least an optional `id` property
+ * @param {ReadonlyArray<Row> | null} a - First array of rows to compare
+ * @param {ReadonlyArray<Row> | null} b - Second array of rows to compare
+ * @returns {boolean} True if row arrays are deeply equal, false otherwise
+ */
+export function rowsEqual(a, b) {
+  if (a === b) return true;
+  if (a === null || b === null) return false;
+  if (!Array.isArray(a) || !Array.isArray(b)) return false;
+
+  if (a.length !== b.length) return false;
+
+  // Fast path: compare by row IDs first, assuming rows have stable IDs.
+  for (let i = 0; i < a.length; i++) {
+    if (a[i]?.id !== b[i]?.id) return false;
+  }
+
+  // If IDs match, do deep comparison of row objects
+  // This catches cases where row data changed but ID stayed the same,
+  // including changes in nested objects (e.g., "contact.company")
+  for (let i = 0; i < a.length; i++) {
+    const rowA = a[i];
+    const rowB = b[i];
+
+    // Fast path: same reference
+    if (rowA === rowB) continue;
+
+    // Deep comparison to handle nested objects and arrays
+    if (!deepEqual(rowA, rowB)) return false;
+  }
+
+  return true;
+}

--- a/tests/DataTable/ToolbarSearchRowComparison.test.ts
+++ b/tests/DataTable/ToolbarSearchRowComparison.test.ts
@@ -96,7 +96,7 @@ describe("ToolbarSearch row comparison behavior", () => {
     });
   });
 
-  it.skip("handles null/undefined values in rows", async () => {
+  it("handles null/undefined values in rows", async () => {
     const rowsWithNull = [
       { id: 1, name: "Row 1", value: null },
       { id: 2, name: "Row 2", value: undefined },
@@ -118,14 +118,13 @@ describe("ToolbarSearch row comparison behavior", () => {
     await tick();
 
     await waitFor(() => {
-      const updateCount = getUpdateCount();
-      expect(updateCount).toBeGreaterThan(initialUpdateCount);
+      expect(getUpdateCount()).toBe(initialUpdateCount);
       const filteredIds = getFilteredIds();
       expect(filteredIds.length).toBeGreaterThan(0);
     });
   });
 
-  it.skip("handles NaN and Infinity values in rows", async () => {
+  it("handles NaN and Infinity values in rows", async () => {
     const initialRows = [
       { id: 1, name: "Row 1", count: Number.NaN },
       { id: 2, name: "Row 2", value: Number.POSITIVE_INFINITY },
@@ -147,8 +146,7 @@ describe("ToolbarSearch row comparison behavior", () => {
     await tick();
 
     await waitFor(() => {
-      const updateCount = getUpdateCount();
-      expect(updateCount).toBeGreaterThan(initialUpdateCount);
+      expect(getUpdateCount()).toBe(initialUpdateCount);
       const filteredIds = getFilteredIds();
       expect(filteredIds).toEqual(expect.arrayContaining([1, 2]));
     });
@@ -401,7 +399,7 @@ describe("ToolbarSearch row comparison behavior", () => {
     });
   });
 
-  it.skip("handles RegExp objects in rows", async () => {
+  it("handles RegExp objects in rows", async () => {
     const initialRows = [
       { id: 1, name: "Row 1", pattern: /abc/ },
       { id: 2, name: "Row 2", pattern: /xyz/ },
@@ -422,14 +420,13 @@ describe("ToolbarSearch row comparison behavior", () => {
     await tick();
 
     await waitFor(() => {
-      const updateCount = getUpdateCount();
-      expect(updateCount).toBeGreaterThan(initialUpdateCount);
+      expect(getUpdateCount()).toBe(initialUpdateCount);
       const filteredIds = getFilteredIds();
       expect(filteredIds).toEqual(expect.arrayContaining([1, 2]));
     });
   });
 
-  it.skip("handles Date objects in rows", async () => {
+  it("handles Date objects in rows", async () => {
     const initialRows = [
       { id: 1, name: "Row 1", date: new Date("2024-01-01") },
       { id: 2, name: "Row 2", date: new Date("2024-01-02") },
@@ -450,14 +447,13 @@ describe("ToolbarSearch row comparison behavior", () => {
     await tick();
 
     await waitFor(() => {
-      const updateCount = getUpdateCount();
-      expect(updateCount).toBeGreaterThan(initialUpdateCount);
+      expect(getUpdateCount()).toBe(initialUpdateCount);
       const filteredIds = getFilteredIds();
       expect(filteredIds).toEqual(expect.arrayContaining([1, 2]));
     });
   });
 
-  it.skip("handles function properties in rows", async () => {
+  it("handles function properties in rows", async () => {
     const initialRows = [
       { id: 1, name: "Row 1", handler: () => console.log("old") },
       { id: 2, name: "Row 2", handler: () => console.log("old2") },
@@ -478,14 +474,13 @@ describe("ToolbarSearch row comparison behavior", () => {
     await tick();
 
     await waitFor(() => {
-      const updateCount = getUpdateCount();
-      expect(updateCount).toBeGreaterThan(initialUpdateCount);
+      expect(getUpdateCount()).toBe(initialUpdateCount);
       const filteredIds = getFilteredIds();
       expect(filteredIds).toEqual(expect.arrayContaining([1, 2]));
     });
   });
 
-  it.skip("handles Symbol properties in rows", async () => {
+  it("handles Symbol properties in rows", async () => {
     const sym = Symbol("test");
     const initialRows = [
       { id: 1, name: "Row 1", [sym]: "value1" },
@@ -507,15 +502,14 @@ describe("ToolbarSearch row comparison behavior", () => {
     await tick();
 
     await waitFor(() => {
-      const updateCount = getUpdateCount();
-      expect(updateCount).toBeGreaterThan(initialUpdateCount);
+      expect(getUpdateCount()).toBe(initialUpdateCount);
       const filteredIds = getFilteredIds();
       expect(filteredIds).toEqual(expect.arrayContaining([1, 2]));
     });
   });
 
   // TODO: unsip once proper deep comparison is implemented.
-  it.skip("handles circular references in rows", async () => {
+  it("handles circular references in rows", async () => {
     type RowWithRef = {
       id: number;
       name: string;

--- a/tests/DataTable/data-table-utils.test.ts
+++ b/tests/DataTable/data-table-utils.test.ts
@@ -1,0 +1,547 @@
+import { rowsEqual } from "../../src/DataTable/data-table-utils.js";
+
+describe("rowsEqual", () => {
+  it("returns true for same reference", () => {
+    const rows = [
+      { id: 1, name: "Row 1" },
+      { id: 2, name: "Row 2" },
+    ];
+    expect(rowsEqual(rows, rows)).toBe(true);
+  });
+
+  it("returns true for identical arrays with same structure", () => {
+    const rowsA = [
+      { id: 1, name: "Row 1" },
+      { id: 2, name: "Row 2" },
+    ];
+    const rowsB = [
+      { id: 1, name: "Row 1" },
+      { id: 2, name: "Row 2" },
+    ];
+    expect(rowsEqual(rowsA, rowsB)).toBe(true);
+  });
+
+  it("returns false when first argument is null", () => {
+    const rows = [{ id: 1, name: "Row 1" }];
+    expect(rowsEqual(null, rows)).toBe(false);
+  });
+
+  it("returns false when second argument is null", () => {
+    const rows = [{ id: 1, name: "Row 1" }];
+    expect(rowsEqual(rows, null)).toBe(false);
+  });
+
+  it("returns true when both arguments are null (via same reference check)", () => {
+    const nullValue = null;
+    expect(rowsEqual(nullValue, nullValue)).toBe(true);
+  });
+
+  it("returns false when first argument is not an array", () => {
+    const rows = [{ id: 1, name: "Row 1" }];
+    // @ts-expect-error
+    expect(rowsEqual({}, rows)).toBe(false);
+    // @ts-expect-error
+    expect(rowsEqual("string", rows)).toBe(false);
+    // @ts-expect-error
+    expect(rowsEqual(123, rows)).toBe(false);
+  });
+
+  it("returns false when second argument is not an array", () => {
+    const rows = [{ id: 1, name: "Row 1" }];
+    // @ts-expect-error
+    expect(rowsEqual(rows, {})).toBe(false);
+    // @ts-expect-error
+    expect(rowsEqual(rows, "string")).toBe(false);
+    // @ts-expect-error
+    expect(rowsEqual(rows, 123)).toBe(false);
+  });
+
+  it("returns false when arrays have different lengths", () => {
+    const rowsA = [{ id: 1, name: "Row 1" }];
+    const rowsB = [
+      { id: 1, name: "Row 1" },
+      { id: 2, name: "Row 2" },
+    ];
+    expect(rowsEqual(rowsA, rowsB)).toBe(false);
+  });
+
+  it("returns false when row IDs differ", () => {
+    const rowsA = [{ id: 1, name: "Row 1" }];
+    const rowsB = [{ id: 2, name: "Row 1" }];
+    expect(rowsEqual(rowsA, rowsB)).toBe(false);
+  });
+
+  it("returns false when row IDs are in different order", () => {
+    const rowsA = [
+      { id: 1, name: "Row 1" },
+      { id: 2, name: "Row 2" },
+    ];
+    const rowsB = [
+      { id: 2, name: "Row 2" },
+      { id: 1, name: "Row 1" },
+    ];
+    expect(rowsEqual(rowsA, rowsB)).toBe(false);
+  });
+
+  it("returns false when rows have same IDs but different data", () => {
+    const rowsA = [{ id: 1, name: "Row 1" }];
+    const rowsB = [{ id: 1, name: "Row 1 Updated" }];
+    expect(rowsEqual(rowsA, rowsB)).toBe(false);
+  });
+
+  it("returns true when rows have same IDs and same data", () => {
+    const rowsA = [
+      { id: 1, name: "Row 1", value: 100 },
+      { id: 2, name: "Row 2", value: 200 },
+    ];
+    const rowsB = [
+      { id: 1, name: "Row 1", value: 100 },
+      { id: 2, name: "Row 2", value: 200 },
+    ];
+    expect(rowsEqual(rowsA, rowsB)).toBe(true);
+  });
+
+  it("handles rows with nested objects", () => {
+    const rowsA = [
+      {
+        id: 1,
+        name: "Row 1",
+        contact: { company: "Company A", email: "test@example.com" },
+      },
+    ];
+    const rowsB = [
+      {
+        id: 1,
+        name: "Row 1",
+        contact: { company: "Company A", email: "test@example.com" },
+      },
+    ];
+    expect(rowsEqual(rowsA, rowsB)).toBe(true);
+  });
+
+  it("detects changes in nested objects", () => {
+    const rowsA = [
+      {
+        id: 1,
+        name: "Row 1",
+        contact: { company: "Company A", email: "test@example.com" },
+      },
+    ];
+    const rowsB = [
+      {
+        id: 1,
+        name: "Row 1",
+        contact: { company: "Company B", email: "test@example.com" },
+      },
+    ];
+    expect(rowsEqual(rowsA, rowsB)).toBe(false);
+  });
+
+  it("handles rows with arrays", () => {
+    const rowsA = [
+      { id: 1, name: "Row 1", tags: ["tag1", "tag2"] },
+      { id: 2, name: "Row 2", tags: ["tag3"] },
+    ];
+    const rowsB = [
+      { id: 1, name: "Row 1", tags: ["tag1", "tag2"] },
+      { id: 2, name: "Row 2", tags: ["tag3"] },
+    ];
+    expect(rowsEqual(rowsA, rowsB)).toBe(true);
+  });
+
+  it("detects changes in array properties", () => {
+    const rowsA = [{ id: 1, name: "Row 1", tags: ["tag1", "tag2"] }];
+    const rowsB = [{ id: 1, name: "Row 1", tags: ["tag1", "tag3"] }];
+    expect(rowsEqual(rowsA, rowsB)).toBe(false);
+  });
+
+  it("handles null values in rows", () => {
+    const rowsA = [{ id: 1, name: "Row 1", value: null }];
+    const rowsB = [{ id: 1, name: "Row 1", value: null }];
+    expect(rowsEqual(rowsA, rowsB)).toBe(true);
+  });
+
+  it("handles undefined values in rows", () => {
+    const rowsA = [{ id: 1, name: "Row 1", value: undefined }];
+    const rowsB = [{ id: 1, name: "Row 1", value: undefined }];
+    expect(rowsEqual(rowsA, rowsB)).toBe(true);
+  });
+
+  it("distinguishes between null and undefined", () => {
+    type Row = {
+      id: number;
+      name: string;
+      value: null | undefined;
+    };
+    const rowsA: readonly Row[] = [{ id: 1, name: "Row 1", value: null }];
+    const rowsB: readonly Row[] = [{ id: 1, name: "Row 1", value: undefined }];
+    expect(rowsEqual(rowsA, rowsB)).toBe(false);
+  });
+
+  it("handles rows with missing id property", () => {
+    const rowsA = [{ name: "Row 1" }];
+    const rowsB = [{ name: "Row 1" }];
+    // Both have undefined id, so ID comparison passes, then deep comparison
+    expect(rowsEqual(rowsA, rowsB)).toBe(true);
+  });
+
+  it("handles rows with NaN values", () => {
+    const rowsA = [{ id: 1, name: "Row 1", count: Number.NaN }];
+    const rowsB = [{ id: 1, name: "Row 1", count: Number.NaN }];
+    expect(rowsEqual(rowsA, rowsB)).toBe(true);
+  });
+
+  it("handles rows with Date objects", () => {
+    const date1 = new Date("2024-01-01");
+    const date2 = new Date("2024-01-01");
+    const rowsA = [{ id: 1, name: "Row 1", date: date1 }];
+    const rowsB = [{ id: 1, name: "Row 1", date: date2 }];
+    expect(rowsEqual(rowsA, rowsB)).toBe(true);
+  });
+
+  it("detects different Date values", () => {
+    const date1 = new Date("2024-01-01");
+    const date2 = new Date("2024-01-02");
+    const rowsA = [{ id: 1, name: "Row 1", date: date1 }];
+    const rowsB = [{ id: 1, name: "Row 1", date: date2 }];
+    expect(rowsEqual(rowsA, rowsB)).toBe(false);
+  });
+
+  it("handles rows with RegExp objects", () => {
+    const rowsA = [{ id: 1, name: "Row 1", pattern: /abc/ }];
+    const rowsB = [{ id: 1, name: "Row 1", pattern: /abc/ }];
+    expect(rowsEqual(rowsA, rowsB)).toBe(true);
+  });
+
+  it("detects different RegExp values", () => {
+    const rowsA = [{ id: 1, name: "Row 1", pattern: /abc/ }];
+    const rowsB = [{ id: 1, name: "Row 1", pattern: /xyz/ }];
+    expect(rowsEqual(rowsA, rowsB)).toBe(false);
+  });
+
+  it("handles rows with function properties", () => {
+    const handler = () => console.log("test");
+    const rowsA = [{ id: 1, name: "Row 1", handler }];
+    const rowsB = [{ id: 1, name: "Row 1", handler }];
+    expect(rowsEqual(rowsA, rowsB)).toBe(true);
+  });
+
+  it("detects different function references", () => {
+    const handler1 = () => console.log("test1");
+    const handler2 = () => console.log("test2");
+    const rowsA = [{ id: 1, name: "Row 1", handler: handler1 }];
+    const rowsB = [{ id: 1, name: "Row 1", handler: handler2 }];
+    expect(rowsEqual(rowsA, rowsB)).toBe(false);
+  });
+
+  it("handles rows with Symbol properties", () => {
+    const sym = Symbol("test");
+    const rowsA = [{ id: 1, name: "Row 1", [sym]: "value1" }];
+    const rowsB = [{ id: 1, name: "Row 1", [sym]: "value1" }];
+    expect(rowsEqual(rowsA, rowsB)).toBe(true);
+  });
+
+  it("detects different Symbol property values", () => {
+    const sym = Symbol("test");
+    const rowsA = [{ id: 1, name: "Row 1", [sym]: "value1" }];
+    const rowsB = [{ id: 1, name: "Row 1", [sym]: "value2" }];
+    expect(rowsEqual(rowsA, rowsB)).toBe(false);
+  });
+
+  it("handles empty arrays", () => {
+    expect(rowsEqual([], [])).toBe(true);
+  });
+
+  it("handles rows with deeply nested structures", () => {
+    const rowsA = [
+      {
+        id: 1,
+        name: "Row 1",
+        data: {
+          nested: {
+            deep: {
+              value: "test",
+              numbers: [1, 2, 3],
+            },
+          },
+        },
+      },
+    ];
+    const rowsB = [
+      {
+        id: 1,
+        name: "Row 1",
+        data: {
+          nested: {
+            deep: {
+              value: "test",
+              numbers: [1, 2, 3],
+            },
+          },
+        },
+      },
+    ];
+    expect(rowsEqual(rowsA, rowsB)).toBe(true);
+  });
+
+  it("detects changes in deeply nested structures", () => {
+    const rowsA = [
+      {
+        id: 1,
+        name: "Row 1",
+        data: {
+          nested: {
+            deep: {
+              value: "test",
+              numbers: [1, 2, 3],
+            },
+          },
+        },
+      },
+    ];
+    const rowsB = [
+      {
+        id: 1,
+        name: "Row 1",
+        data: {
+          nested: {
+            deep: {
+              value: "changed",
+              numbers: [1, 2, 3],
+            },
+          },
+        },
+      },
+    ];
+    expect(rowsEqual(rowsA, rowsB)).toBe(false);
+  });
+
+  it("handles rows with circular references", () => {
+    type RowWithSelf = {
+      id: number;
+      name: string;
+      self?: RowWithSelf;
+    };
+    const rowA: RowWithSelf = { id: 1, name: "Row 1" };
+    rowA.self = rowA;
+    const rowB: RowWithSelf = { id: 1, name: "Row 1" };
+    rowB.self = rowB;
+    const rowsA = [rowA];
+    const rowsB = [rowB];
+    expect(rowsEqual(rowsA, rowsB)).toBe(true);
+  });
+
+  it("handles multiple rows with mixed properties", () => {
+    const rowsA = [
+      { id: 1, name: "Row 1", active: true, count: 10 },
+      { id: 2, name: "Row 2", active: false, count: 20 },
+      { id: 3, name: "Row 3", active: true, count: 30 },
+    ];
+    const rowsB = [
+      { id: 1, name: "Row 1", active: true, count: 10 },
+      { id: 2, name: "Row 2", active: false, count: 20 },
+      { id: 3, name: "Row 3", active: true, count: 30 },
+    ];
+    expect(rowsEqual(rowsA, rowsB)).toBe(true);
+  });
+
+  it("detects changes in one row of multiple rows", () => {
+    const rowsA = [
+      { id: 1, name: "Row 1", active: true },
+      { id: 2, name: "Row 2", active: false },
+      { id: 3, name: "Row 3", active: true },
+    ];
+    const rowsB = [
+      { id: 1, name: "Row 1", active: true },
+      { id: 2, name: "Row 2 Changed", active: false },
+      { id: 3, name: "Row 3", active: true },
+    ];
+    expect(rowsEqual(rowsA, rowsB)).toBe(false);
+  });
+
+  it("handles rows where objects are same reference", () => {
+    const sharedObj = { company: "Company A" };
+    const rowsA = [{ id: 1, name: "Row 1", contact: sharedObj }];
+    const rowsB = [{ id: 1, name: "Row 1", contact: sharedObj }];
+    expect(rowsEqual(rowsA, rowsB)).toBe(true);
+  });
+
+  describe("Generics", () => {
+    it("should preserve row type with custom row interface", () => {
+      type CustomRow = {
+        id: string;
+        name: string;
+        age: number;
+        email: string;
+        status: "active" | "inactive";
+      };
+
+      const rowsA: readonly CustomRow[] = [
+        {
+          id: "1",
+          name: "John",
+          age: 30,
+          email: "john@example.com",
+          status: "active",
+        },
+      ];
+      const rowsB: readonly CustomRow[] = [
+        {
+          id: "1",
+          name: "John",
+          age: 30,
+          email: "john@example.com",
+          status: "active",
+        },
+      ];
+
+      const result = rowsEqual(rowsA, rowsB);
+      expectTypeOf<typeof result>().toEqualTypeOf<boolean>();
+      expectTypeOf<typeof rowsA>().toHaveProperty("length");
+      expectTypeOf<(typeof rowsA)[number]>().toEqualTypeOf<CustomRow>();
+    });
+
+    it("should work with rows that have nested objects", () => {
+      type NestedRow = {
+        id: number;
+        name: string;
+        contact: {
+          company: string;
+          email: string;
+        };
+        metadata: {
+          tags: string[];
+          count: number;
+        };
+      };
+
+      const rowsA: readonly NestedRow[] = [
+        {
+          id: 1,
+          name: "Row 1",
+          contact: { company: "Company A", email: "test@example.com" },
+          metadata: { tags: ["tag1"], count: 10 },
+        },
+      ];
+      const rowsB: readonly NestedRow[] = [
+        {
+          id: 1,
+          name: "Row 1",
+          contact: { company: "Company A", email: "test@example.com" },
+          metadata: { tags: ["tag1"], count: 10 },
+        },
+      ];
+
+      const result = rowsEqual(rowsA, rowsB);
+      expectTypeOf<typeof result>().toEqualTypeOf<boolean>();
+      expectTypeOf<(typeof rowsA)[number]["contact"]>().toHaveProperty(
+        "company",
+      );
+      expectTypeOf<(typeof rowsA)[number]["metadata"]>().toHaveProperty("tags");
+    });
+
+    it("should work with rows that have optional id property", () => {
+      type RowWithOptionalId = {
+        id?: string;
+        name: string;
+        value: number;
+      };
+
+      const rowsA: readonly RowWithOptionalId[] = [
+        { id: "1", name: "Row 1", value: 100 },
+        { name: "Row 2", value: 200 },
+      ];
+      const rowsB: readonly RowWithOptionalId[] = [
+        { id: "1", name: "Row 1", value: 100 },
+        { name: "Row 2", value: 200 },
+      ];
+
+      const result = rowsEqual(rowsA, rowsB);
+      expectTypeOf<typeof result>().toEqualTypeOf<boolean>();
+
+      // Verify optional id is handled
+      expectTypeOf<(typeof rowsA)[number]["id"]>().toEqualTypeOf<
+        string | undefined
+      >();
+    });
+
+    it("should work with rows that extend Record<string, any>", () => {
+      // biome-ignore lint/suspicious/noExplicitAny: test case
+      type ExtendedRow = Record<string, any> & {
+        id: number;
+        name: string;
+      };
+
+      const rowsA: readonly ExtendedRow[] = [
+        { id: 1, name: "Row 1", extra: "value" },
+      ];
+      const rowsB: readonly ExtendedRow[] = [
+        { id: 1, name: "Row 1", extra: "value" },
+      ];
+
+      const result = rowsEqual(rowsA, rowsB);
+      expectTypeOf<typeof result>().toEqualTypeOf<boolean>();
+
+      // Verify extended properties are accessible
+      expectTypeOf<(typeof rowsA)[number]>().toHaveProperty("id");
+      expectTypeOf<(typeof rowsA)[number]>().toHaveProperty("name");
+    });
+
+    it("should accept null as valid input type", () => {
+      type CustomRow = {
+        id: number;
+        name: string;
+      };
+
+      const rows: readonly CustomRow[] = [{ id: 1, name: "Row 1" }];
+
+      // Verify null is accepted for both parameters
+      const result1 = rowsEqual(null, rows);
+      const result2 = rowsEqual(rows, null);
+      const result3 = rowsEqual(null, null);
+
+      expectTypeOf<typeof result1>().toEqualTypeOf<boolean>();
+      expectTypeOf<typeof result2>().toEqualTypeOf<boolean>();
+      expectTypeOf<typeof result3>().toEqualTypeOf<boolean>();
+    });
+
+    it("should work with readonly arrays", () => {
+      const rowsA = [
+        { id: "1", value: 100 },
+        { id: "2", value: 200 },
+      ] as const;
+
+      const rowsB = [
+        { id: "1", value: 100 },
+        { id: "2", value: 200 },
+      ] as const;
+
+      const result = rowsEqual(rowsA, rowsB);
+      expectTypeOf<typeof result>().toEqualTypeOf<boolean>();
+      expectTypeOf<typeof rowsA>().toHaveProperty("length");
+    });
+
+    it("should preserve type when comparing different row types", () => {
+      type RowA = {
+        id: number;
+        name: string;
+      };
+
+      type RowB = {
+        id: number;
+        title: string;
+      };
+
+      const rowsA: readonly RowA[] = [{ id: 1, name: "Row 1" }];
+      const rowsB: readonly RowB[] = [{ id: 1, title: "Row 1" }];
+
+      const result = rowsEqual(
+        rowsA,
+        // Runtime allows comparing different row types (both extend Record<string, any>)
+        // Type assertion needed because TypeScript requires both parameters to be the same generic type
+        rowsB as unknown as readonly RowA[],
+      );
+      expectTypeOf<typeof result>().toEqualTypeOf<boolean>();
+    });
+  });
+});

--- a/types/DataTable/data-table-utils.d.ts
+++ b/types/DataTable/data-table-utils.d.ts
@@ -1,0 +1,9 @@
+/**
+ * Lightweight deep equality check optimized for DataTable rows.
+ * Compares arrays of row objects by first checking IDs (fast path),
+ * then falling back to deep object comparison to handle nested structures.
+ */
+export function rowsEqual<Row extends Record<string, any>>(
+  a: ReadonlyArray<Row> | null,
+  b: ReadonlyArray<Row> | null,
+): boolean;


### PR DESCRIPTION
Follow-up to #2458

This replaces `JSON.stringify`-based row comparison in `ToolbarSearch` with a custom deep equality function for improved performance and correctness.

The guard exists to avoid infinite updates in Svelte 5 (see #2143), where rows should only be updated if rows from context actually changed.

However, the existing `JSON.stringify` comparison is inaccurate and suboptimal from a performance standpoint (i.e., large rows).

The custom function should be faster, more accurate (can handle objects, Dates, regular expressions), and safe (avoid crashes by circular references). As the `rows` object grows, memory should also be reduced (i.e., avoiding `JSON.stringify` creating a massive string for comparison).