### PR TITLE
fix(data-table): inferred `PropertyPath` depth limit supports 3 nested levels

### DIFF
--- a/src/DataTable/DataTableTypes.d.ts
+++ b/src/DataTable/DataTableTypes.d.ts
@@ -6,8 +6,8 @@ type Join<K, P> = K extends string | number
     : never
   : never;
 
-// For performance, the maximum traversal depth is 10.
-export type PropertyPath<T, D extends number = 10> = [D] extends [never]
+// For performance, the maximum traversal depth is 3.
+export type PropertyPath<T, D extends number = 3> = [D] extends [never]
   ? never
   : T extends object
     ? {

--- a/tests/DataTable/DataTable.test.ts
+++ b/tests/DataTable/DataTable.test.ts
@@ -1593,19 +1593,7 @@ describe("DataTable", () => {
           level2: {
             level3: {
               level4: {
-                level5: {
-                  level6: {
-                    level7: {
-                      level8: {
-                        level9: {
-                          level10: {
-                            level11: string;
-                          };
-                        };
-                      };
-                    };
-                  };
-                };
+                level5: string;
               };
             };
           };
@@ -1618,40 +1606,15 @@ describe("DataTable", () => {
       expectTypeOf<
         Extract<Paths, "level1.level2">
       >().toEqualTypeOf<"level1.level2">();
-      // TODO: path depth should support 10 levels
       expectTypeOf<
         Extract<Paths, "level1.level2.level3">
-      >().not.toEqualTypeOf<"level1.level2.level3">();
+      >().toEqualTypeOf<"level1.level2.level3">();
       expectTypeOf<
         Extract<Paths, "level1.level2.level3.level4">
-      >().not.toEqualTypeOf<"level1.level2.level3.level4">();
+      >().toEqualTypeOf<"level1.level2.level3.level4">();
       expectTypeOf<
         Extract<Paths, "level1.level2.level3.level4.level5">
-      >().not.toEqualTypeOf<"level1.level2.level3.level4.level5">();
-      expectTypeOf<
-        Extract<Paths, "level1.level2.level3.level4.level5.level6">
-      >().not.toEqualTypeOf<"level1.level2.level3.level4.level5.level6">();
-      expectTypeOf<
-        Extract<Paths, "level1.level2.level3.level4.level5.level6.level7">
-      >().not.toEqualTypeOf<"level1.level2.level3.level4.level5.level6.level7">();
-      expectTypeOf<
-        Extract<
-          Paths,
-          "level1.level2.level3.level4.level5.level6.level7.level8"
-        >
-      >().not.toEqualTypeOf<"level1.level2.level3.level4.level5.level6.level7.level8">();
-      expectTypeOf<
-        Extract<
-          Paths,
-          "level1.level2.level3.level4.level5.level6.level7.level8.level9"
-        >
-      >().not.toEqualTypeOf<"level1.level2.level3.level4.level5.level6.level7.level8.level9">();
-      expectTypeOf<
-        Extract<
-          Paths,
-          "level1.level2.level3.level4.level5.level6.level7.level8.level9.level10"
-        >
-      >().not.toEqualTypeOf<"level1.level2.level3.level4.level5.level6.level7.level8.level9.level10">();
+      >().toEqualTypeOf<never>();
     });
 
     it("should validate PropertyPath with arrays and primitives", () => {

--- a/tests/DataTable/DataTableDeepNesting.test.svelte
+++ b/tests/DataTable/DataTableDeepNesting.test.svelte
@@ -21,8 +21,7 @@
       key: "level1.level2.level3.name",
       value: "Level 3 (4 levels)",
     },
-    // TODO: remove casting after PropertyPath depth extends beyond 2 levels.
-  ] as const as ReadonlyArray<DataTableHeader<DataTableRow>>;
+  ] as const;
 
   const rows = [
     {

--- a/tests/DataTable/DataTableExplicitGenerics.test.svelte
+++ b/tests/DataTable/DataTableExplicitGenerics.test.svelte
@@ -27,11 +27,8 @@
     { key: "name", value: "Product Name" },
     { key: "price", value: "Price" },
     { key: "category.name", value: "Category" },
-    // @ts-expect-error - PropertyPath depth limit is 2
     { key: "category.department.name", value: "Department" },
-    // @ts-expect-error - PropertyPath depth limit is 2
     { key: "category.department.location.city", value: "City" },
-    // @ts-expect-error - PropertyPath depth limit is 2
     { key: "category.department.location.country", value: "Country" },
     { key: "inStock", value: "In Stock" },
   ] as const;

--- a/types/DataTable/DataTableTypes.d.ts
+++ b/types/DataTable/DataTableTypes.d.ts
@@ -6,8 +6,8 @@ type Join<K, P> = K extends string | number
     : never
   : never;
 
-// For performance, the maximum traversal depth is 10.
-export type PropertyPath<T, D extends number = 10> = [D] extends [never]
+// For performance, the maximum traversal depth is 3.
+export type PropertyPath<T, D extends number = 3> = [D] extends [never]
   ? never
   : T extends object
     ? {


### PR DESCRIPTION
Follow-up to #2460

`DataTable` headers is generic. It uses the `PropertyPath` utility type to infer keys based on the object structure of the provided `rows`.

```ts
export type DataTableKey<Row = DataTableRow> = import("./DataTableTypes.d.ts").PropertyPath<Row>;
```

However, the current inferred depth is only two levels deep (e.g., `category.department`). A nesting like `category.department.name` would not work). Test cases added in #2462 illustrate this bug.

```ts
type PathDepth = [never, 0, 1, 2, ...0[]];

// With `D = 10` (default):
// - Level 1: `PathDepth[10] = 0` (from `...0[]` spread) → recurse with `D = 0`
// - Level 2: `PathDepth[0] = never` → **STOP**
```

The issue is that `PathDepth[10]` falls back to `never`, and stops recursing.

Updating it to `PathDepth[3]` correctly uses the `2` in the `PathDepth` mapping:

```ts
type PathDepth = [never, 0, 1, 2, ...0[]]; // PathDepth[3] --> 2
```

**Performance Considerations**

- [Per feedback](https://github.com/carbon-design-system/carbon-components-svelte/pull/2461#issuecomment-3685145457), restrict to 3 nested levels instead of the intended 10 for performance (guard against runaway growth).

---



## Before (inferred depth limit is 2)

<img width="400" height="377" alt="Screenshot 2025-12-23 at 8 11 57 AM" src="https://github.com/user-attachments/assets/25ff3f15-7024-4763-8b3c-db690b023d82" />

## After (inferred depth limit is 3 nested levels)

<img width="600" height="317" alt="Screenshot 2025-12-23 at 8 12 37 AM" src="https://github.com/user-attachments/assets/f2f4d49e-3439-4747-a621-abf4c590b851" />

## Explicit generics

The nesting cap of 3 levels deep also applies to explict generics (e.g., `DataTableHeader<ProductRow>`). This is a reasonable constraint; it's left to the user to map values at a shallower depth.

```ts
type ProductRow = {
  id: string;
  name: string;
  price: number;
  category: {
    name: string;
    department: {
      name: string;
      location: {
        // Inferred keys stops at "region"
        region: {
          city: string;
          country: string;
        };
      };
    };
  };
  inStock: boolean;
};
```

<img width="1029" height="710" alt="Screenshot 2025-12-23 at 8 29 38 AM" src="https://github.com/user-attachments/assets/f5b82649-5df3-4c8a-bab4-22fee0a9f923" />