### PR TITLE
test(svelte-5): flag Svelte 5 quirks

### DIFF
--- a/tests/Checkbox/Checkbox.test.ts
+++ b/tests/Checkbox/Checkbox.test.ts
@@ -47,6 +47,7 @@ describe("Checkbox", () => {
     await user.click(input);
     expect(consoleLog).toHaveBeenCalledWith("check");
     expect(consoleLog).toHaveBeenCalledWith("click");
+    // TODO(svelte-5): Investigate multiple event emissions - check event may be emitted multiple times in Svelte 5, verify if this is expected framework behavior or component bug
     if (isSvelte5) {
       // Svelte 5 may emit check event multiple times
       expect(consoleLog.mock.calls.length).toBeGreaterThanOrEqual(2);

--- a/tests/ComboBox/ComboBox.test.ts
+++ b/tests/ComboBox/ComboBox.test.ts
@@ -127,6 +127,7 @@ describe("ComboBox", () => {
     await tick();
 
     expect(consoleLog).toHaveBeenCalledWith("clear", expect.any(String));
+    // TODO(svelte-5): Investigate reactive binding timing issue - input value may not update immediately after clear event in Svelte 5
     if (isSvelte5) {
       // In Svelte 5, the clear event handler in the test component sets value="" and selectedId=undefined
       // but the input value binding may not update immediately. The key behavior is that clear was called.

--- a/tests/ContentSwitcher/ContentSwitcher.test.ts
+++ b/tests/ContentSwitcher/ContentSwitcher.test.ts
@@ -113,6 +113,7 @@ describe("ContentSwitcher", () => {
     const tabs = screen.getAllByRole("tab");
     expect(tabs[0]).toHaveClass("bx--content-switcher--selected");
 
+    // TODO(svelte-5): Investigate focus management difference - focus behavior may differ in Svelte 5, verify if this is expected framework behavior or component issue
     if (isSvelte5) {
       // In Svelte 5, focus behavior may differ - just verify the first tab is selected
       // Focus management in Svelte 5 may work differently, so we skip the focus check

--- a/tests/NumberInput/NumberInput.test.ts
+++ b/tests/NumberInput/NumberInput.test.ts
@@ -743,6 +743,7 @@ describe("NumberInput", () => {
     await user.clear(input);
     await user.tab();
 
+    // TODO(svelte-5): Investigate inconsistent value representation - cleared inputs may display as empty string instead of "null" in Svelte 5
     if (isSvelte5) {
       // In Svelte 5, cleared inputs may result in empty string instead of null
       const valueText = screen.getByTestId("value").textContent;
@@ -789,6 +790,7 @@ describe("NumberInput", () => {
     const input = screen.getByRole("spinbutton");
     await user.clear(input);
 
+    // TODO(svelte-5): Investigate inconsistent value representation - cleared inputs may display as empty string instead of "null" in Svelte 5
     if (isSvelte5) {
       // In Svelte 5, cleared inputs may result in empty string instead of null
       const valueText = screen.getByTestId("value").textContent;

--- a/tests/TextInput/TextInput.test.ts
+++ b/tests/TextInput/TextInput.test.ts
@@ -452,6 +452,7 @@ describe("TextInput", () => {
     const input = screen.getByRole("spinbutton");
     await user.clear(input);
 
+    // TODO(svelte-5): Investigate inconsistent value handling - cleared number inputs may result in empty string instead of null in Svelte 5
     if (isSvelte5) {
       // In Svelte 5, cleared inputs may result in empty string instead of null
       const valueDisplay = screen.getByTestId("value").textContent;


### PR DESCRIPTION
Supporting #2463

#2397 added dedicated tests for Svelte 5, ensuring that existing source code and unit tests are compatible with Svelte 5.

This is important to guard against regressions and to achieve confidence in Svelte 5 compatibility.

However, in unit tests, there are cases where Svelte 5 behavior differs https://github.com/carbon-design-system/carbon-components-svelte/commit/2fbd4e883b23d646511f7981b2342c5a3ced8ef8. These quirks are guarded behind the `isSvelte5` condition. Some may be false positives, but most cases signal an actual difference in Svelte 5 behavior.

The comments in this PR indicate the locations that are likely true positives. If possible, it would be great to address these for consistent behavior, especially regarding behavior (reactivity, `null` values being preserved, etc.)