### PR TITLE
fix(checkbox): prevent duplicate "check" event dispatches in Svelte 5

### DIFF
--- a/src/Checkbox/Checkbox.svelte
+++ b/src/Checkbox/Checkbox.svelte
@@ -65,7 +65,17 @@
 
   $: useGroup = Array.isArray(group);
   $: if (useGroup) checked = group.includes(value);
-  $: dispatch("check", checked);
+
+  // Track previous checked value to avoid duplicate dispatches in Svelte 5
+  // The reactive statement will only dispatch when checked changes externally (e.g., via bind:checked)
+  let previousChecked = checked;
+  $: {
+    const hasChanged = previousChecked !== checked;
+    if (hasChanged) {
+      previousChecked = checked;
+      dispatch("check", checked);
+    }
+  }
 
   let refLabel = null;
 
@@ -121,7 +131,11 @@
             ? group.filter((_value) => _value !== value)
             : [...group, value];
         } else {
-          checked = !checked;
+          const newChecked = !checked;
+          previousChecked = newChecked;
+          checked = newChecked;
+          // Dispatch directly for user-initiated changes to avoid duplicate events in Svelte 5
+          dispatch("check", newChecked);
         }
       }}
       on:change

--- a/tests/Checkbox/Checkbox.test.ts
+++ b/tests/Checkbox/Checkbox.test.ts
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/svelte";
 import { tick } from "svelte";
-import { isSvelte5, user } from "../setup-tests";
+import { user } from "../setup-tests";
 import CheckboxGroup from "./Checkbox.group.test.svelte";
 import CheckboxReadonly from "./Checkbox.readonly.test.svelte";
 import CheckboxSkeleton from "./Checkbox.skeleton.test.svelte";
@@ -51,13 +51,7 @@ describe("Checkbox", () => {
     await user.click(input);
     expect(consoleLog).toHaveBeenCalledWith("check");
     expect(consoleLog).toHaveBeenCalledWith("click");
-    // TODO(svelte-5): Investigate multiple event emissions - check event may be emitted multiple times in Svelte 5, verify if this is expected framework behavior or component bug
-    if (isSvelte5) {
-      // Svelte 5 may emit check event multiple times
-      expect(consoleLog.mock.calls.length).toBeGreaterThanOrEqual(2);
-    } else {
-      expect(consoleLog).toHaveBeenCalledTimes(2);
-    }
+    expect(consoleLog).toHaveBeenCalledTimes(2);
   });
 
   it("emits exactly one check event per click", async () => {
@@ -120,12 +114,7 @@ describe("Checkbox", () => {
     const checkCalls = consoleLog.mock.calls.filter(
       (call) => call[0] === "check",
     );
-    if (isSvelte5) {
-      // Svelte 5 may emit check event multiple times
-      expect(checkCalls.length).toBeGreaterThanOrEqual(3);
-    } else {
-      expect(checkCalls).toHaveLength(3);
-    }
+    expect(checkCalls).toHaveLength(3);
   });
 
   it("renders indeterminate state", () => {
@@ -213,13 +202,7 @@ describe("Checkbox", () => {
       (call) => call[0] === "check" && call[1] === "option-1",
     );
     expect(checkCalls1).toHaveLength(1);
-
-    if (isSvelte5) {
-      // Svelte 5 may emit check event multiple times
-      expect(checkCalls1[0][3]).toBeGreaterThanOrEqual(2);
-    } else {
-      expect(checkCalls1[0][3]).toBe(1);
-    }
+    expect(checkCalls1[0][3]).toBe(1);
 
     consoleLog.mockClear();
     await user.click(checkbox2);
@@ -234,12 +217,7 @@ describe("Checkbox", () => {
       (call) => call[0] === "check" && call[1] === "option-3",
     );
     expect(checkCalls3).toHaveLength(1);
-    if (isSvelte5) {
-      // Svelte 5 may emit check event multiple times
-      expect(checkCalls3[0][3]).toBeGreaterThanOrEqual(2);
-    } else {
-      expect(checkCalls3[0][3]).toBe(1);
-    }
+    expect(checkCalls3[0][3]).toBe(1);
   });
 
   it("handles rapid group checkbox interactions without duplicate events", async () => {


### PR DESCRIPTION
Follow-up to #2464

Fixes [#2467](https://github.com/carbon-design-system/carbon-components-svelte/issues/2467), supports #2463

This fixes a quirk where the "change" event can be dispatched multiple times in Svelte 5.

In Svelte 5, the Checkbox component was emitting the `check` event multiple times for a single user interaction. The test suite had a workaround that accepted `>= 2` calls in Svelte 5, but the expected behavior is exactly one `check` event per state change.

**Root Cause**

The component used a reactive statement to dispatch the `check` event whenever `checked` changed:

```svelte
$: dispatch("check", checked);
```

In Svelte 5, reactive statements can execute multiple times during a single update cycle due to changes in the reactivity system. This can cause the same event to be dispatched multiple times even when `checked` only changes once. Reference: https://github.com/sveltejs/svelte/issues/6732

**Solution**

This implements a guard mechanism that tracks the previous `checked` value and only dispatches the event when the value actually changes.

**Testing**

The testing matrix for Checkbox across Svelte 3/4/5 should all pass.

Additionally, more comprehensive tests around reactivity and dispatched events were added in #2466