### PR TITLE
fix(content-switcher): fix focus management for Svelte 5 compatibility

### DIFF
--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -2734,7 +2734,7 @@
             },
             {
               "name": "change",
-              "type": "(direction: number) => void",
+              "type": "(direction: number) => Promise<void>",
               "description": "",
               "optional": false
             }

--- a/src/ContentSwitcher/ContentSwitcher.svelte
+++ b/src/ContentSwitcher/ContentSwitcher.svelte
@@ -12,7 +12,7 @@
    */
   export let size = undefined;
 
-  import { afterUpdate, createEventDispatcher, setContext } from "svelte";
+  import { afterUpdate, createEventDispatcher, setContext, tick } from "svelte";
   import { writable } from "svelte/store";
 
   const dispatch = createEventDispatcher();
@@ -20,6 +20,9 @@
    * @type {import("svelte/store").Writable<string | null>}
    */
   const currentId = writable(null);
+
+  /** @type {HTMLDivElement | null} */
+  let refContainer = null;
 
   $: currentIndex = -1;
   $: switches = [];
@@ -47,9 +50,9 @@
   };
 
   /**
-   * @type {(direction: number) => void}
+   * @type {(direction: number) => Promise<void>}
    */
-  const change = (direction) => {
+  const change = async (direction) => {
     let index = currentIndex + direction;
 
     if (index < 0) {
@@ -59,6 +62,14 @@
     }
 
     selectedIndex = index;
+
+    await tick();
+    const tabs = refContainer?.querySelectorAll("[role='tab']");
+    const tab = tabs?.[index];
+
+    if (tab instanceof HTMLElement) {
+      tab.focus();
+    }
   };
 
   setContext("ContentSwitcher", {
@@ -78,6 +89,7 @@
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <!-- svelte-ignore a11y-interactive-supports-focus -->
 <div
+  bind:this={refContainer}
   role="tablist"
   class:bx--content-switcher={true}
   class:bx--content-switcher--sm={size === "sm"}

--- a/src/ContentSwitcher/Switch.svelte
+++ b/src/ContentSwitcher/Switch.svelte
@@ -23,7 +23,7 @@
   /** Obtain a reference to the button HTML element */
   export let ref = null;
 
-  import { afterUpdate, getContext, onMount } from "svelte";
+  import { getContext, onMount } from "svelte";
 
   const ctx = getContext("ContentSwitcher");
 
@@ -31,12 +31,6 @@
 
   const unsubscribe = ctx.currentId.subscribe((currentId) => {
     selected = currentId === id;
-  });
-
-  afterUpdate(() => {
-    if (selected) {
-      ref.focus();
-    }
   });
 
   onMount(() => {

--- a/tests/ContentSwitcher/ContentSwitcher.test.ts
+++ b/tests/ContentSwitcher/ContentSwitcher.test.ts
@@ -1,5 +1,5 @@
 import { render, screen, within } from "@testing-library/svelte";
-import { isSvelte5, user } from "../setup-tests";
+import { user } from "../setup-tests";
 import ContentSwitcherCustom from "./ContentSwitcher.custom.test.svelte";
 import ContentSwitcherDisabled from "./ContentSwitcher.disabled.test.svelte";
 import ContentSwitcherSelectedIndex from "./ContentSwitcher.selectedIndex.test.svelte";
@@ -113,15 +113,8 @@ describe("ContentSwitcher", () => {
     const tabs = screen.getAllByRole("tab");
     expect(tabs[0]).toHaveClass("bx--content-switcher--selected");
 
-    // TODO(svelte-5): Investigate focus management difference - focus behavior may differ in Svelte 5, verify if this is expected framework behavior or component issue
-    if (isSvelte5) {
-      // In Svelte 5, focus behavior may differ - just verify the first tab is selected
-      // Focus management in Svelte 5 may work differently, so we skip the focus check
-      // and just verify the selection state changes work correctly
-    } else {
-      await user.tab();
-      expect(document.activeElement).toBe(tabs[0]);
-    }
+    await user.tab();
+    expect(document.activeElement).toBe(tabs[0]);
 
     await user.keyboard("{ArrowRight}");
     expect(tabs[0]).not.toHaveClass("bx--content-switcher--selected");

--- a/types/ContentSwitcher/ContentSwitcher.svelte.d.ts
+++ b/types/ContentSwitcher/ContentSwitcher.svelte.d.ts
@@ -5,7 +5,7 @@ export type ContentSwitcherContext = {
   currentId: import("svelte/store").Writable<string | null>;
   add: (data: { id: string; text: string; selected: boolean }) => void;
   update: (id: string) => void;
-  change: (direction: number) => void;
+  change: (direction: number) => Promise<void>;
 };
 
 type $RestProps = SvelteHTMLElements["div"];


### PR DESCRIPTION
Follow-up to https://github.com/carbon-design-system/carbon-components-svelte/pull/2464

Fixes #2468, supports https://github.com/carbon-design-system/carbon-components-svelte/issues/2463

This PR fixes focus management in ContentSwitcher to work consistently across all Svelte versions. The previous implementation used `afterUpdate()` in the Switch component to auto-focus whenever a tab became selected, which caused timing issues in Svelte 5.

This makes the internal `change` method async to await the next tick before updating.