### PR TITLE
fix(combo-box): prevent dispatching initial "close" event in Svelte 5

### DIFF
--- a/src/ComboBox/ComboBox.svelte
+++ b/src/ComboBox/ComboBox.svelte
@@ -264,6 +264,8 @@
 
   $: if (selectedId !== undefined) {
     if (prevSelectedId !== selectedId) {
+      // Only dispatch select event if not initial render (prevSelectedId was not null)
+      const isInitialRender = prevSelectedId === null;
       prevSelectedId = selectedId;
       if (filteredItems?.length === 1 && open) {
         selectedId = filteredItems[0].id;
@@ -273,7 +275,9 @@
       } else {
         selectedItem = items.find((item) => item.id === selectedId);
       }
-      dispatch("select", { selectedId, selectedItem });
+      if (!isInitialRender) {
+        dispatch("select", { selectedId, selectedItem });
+      }
     }
   } else {
     prevSelectedId = selectedId;

--- a/tests/ComboBox/ComboBox.test.ts
+++ b/tests/ComboBox/ComboBox.test.ts
@@ -2,7 +2,7 @@ import { render, screen } from "@testing-library/svelte";
 import type ComboBoxComponent from "carbon-components-svelte/ComboBox/ComboBox.svelte";
 import type { ComponentEvents, ComponentProps } from "svelte";
 import { tick } from "svelte";
-import { isSvelte5, user } from "../setup-tests";
+import { user } from "../setup-tests";
 import ComboBoxSlot from "./ComboBox.slot.test.svelte";
 import ComboBox from "./ComboBox.test.svelte";
 import ComboBoxCustom from "./ComboBoxCustom.test.svelte";
@@ -88,10 +88,6 @@ describe("ComboBox", () => {
       },
     });
 
-    if (isSvelte5) {
-      // Svelte 5 may emit select event on initial render, so clear the mock
-      consoleLog.mockClear();
-    }
     expect(consoleLog).not.toHaveBeenCalled();
     expect(getInput()).toHaveValue("Email");
 
@@ -113,10 +109,6 @@ describe("ComboBox", () => {
       },
     });
 
-    if (isSvelte5) {
-      // Svelte 5 may emit select event on initial render, so clear the mock
-      consoleLog.mockClear();
-    }
     expect(consoleLog).not.toHaveBeenCalled();
     expect(getInput()).toHaveValue("Email");
 
@@ -248,10 +240,6 @@ describe("ComboBox", () => {
     const consoleLog = vi.spyOn(console, "log");
     render(ComboBox, { props: { selectedId: "1" } });
 
-    if (isSvelte5) {
-      // Svelte 5 may emit select event on initial render, so clear the mock
-      consoleLog.mockClear();
-    }
     expect(consoleLog).not.toBeCalled();
     await user.click(getClearButton());
 


### PR DESCRIPTION
Follow-up to https://github.com/carbon-design-system/carbon-components-svelte/pull/2464

Fixes https://github.com/carbon-design-system/carbon-components-svelte/issues/2472, supports https://github.com/carbon-design-system/carbon-components-svelte/issues/2463

This PR fixes `ComboBox` emitting a select event on initial render in Svelte 5.

When a ComboBox is rendered with a `selectedId` prop, the reactive statement would dispatch a select event during mount because `prevSelectedId` starts as `null` and differs from the initial `selectedId`.