### PR TITLE
fix(tooltip): prevent dispatching events on initial render in Svelte 5

### DIFF
--- a/src/Tooltip/Tooltip.svelte
+++ b/src/Tooltip/Tooltip.svelte
@@ -78,6 +78,8 @@
    */
   const tooltipOpen = writable(open);
 
+  let prevOpen = undefined;
+
   setContext("Tooltip", { tooltipOpen });
 
   function onKeydown(e) {
@@ -175,7 +177,12 @@
   });
 
   $: tooltipOpen.set(open);
-  $: dispatch(open ? "open" : "close");
+  $: {
+    if (prevOpen !== undefined) {
+      dispatch(open ? "open" : "close");
+    }
+    prevOpen = open;
+  }
   $: buttonProps = {
     role: "button",
     "aria-haspopup": "true",

--- a/tests/Tooltip/Tooltip.test.ts
+++ b/tests/Tooltip/Tooltip.test.ts
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from "@testing-library/svelte";
-import { isSvelte5, user } from "../setup-tests";
+import { user } from "../setup-tests";
 import TooltipAlignments from "./TooltipAlignments.test.svelte";
 import TooltipCustomContent from "./TooltipCustomContent.test.svelte";
 import TooltipCustomIcon from "./TooltipCustomIcon.test.svelte";
@@ -141,49 +141,15 @@ describe("Tooltip", () => {
   test("should dispatch events when tooltip opens and closes", async () => {
     render(TooltipEvents);
 
-    if (isSvelte5) {
-      // In Svelte 5, a close event may be emitted on initial render
-      const openEventsText = screen.getByText(/Open events: \d+/);
-      const closeEventsText = screen.getByText(/Close events: \d+/);
-      expect(openEventsText).toBeInTheDocument();
-      expect(closeEventsText).toBeInTheDocument();
-    } else {
-      expect(screen.getByText("Open events: 0")).toBeInTheDocument();
-      expect(screen.getByText("Close events: 0")).toBeInTheDocument();
-    }
-
-    // Get initial counts (may be 0 or 1 for close in Svelte 5)
-    const openEventsText = screen.getByText(/Open events: \d+/);
-    const closeEventsText = screen.getByText(/Close events: \d+/);
-    const initialOpenCount = Number.parseInt(
-      openEventsText.textContent?.match(/\d+/)?.[0] || "0",
-      10,
-    );
-    const initialCloseCount = Number.parseInt(
-      closeEventsText.textContent?.match(/\d+/)?.[0] || "0",
-      10,
-    );
+    expect(screen.getByText("Open events: 0")).toBeInTheDocument();
+    expect(screen.getByText("Close events: 0")).toBeInTheDocument();
 
     const trigger = screen.getByRole("button");
     await user.click(trigger);
-    if (isSvelte5) {
-      // Open count should increase by 1
-      expect(
-        screen.getByText(new RegExp(`Open events: ${initialOpenCount + 1}`)),
-      ).toBeInTheDocument();
-    } else {
-      expect(screen.getByText("Open events: 1")).toBeInTheDocument();
-    }
+    expect(screen.getByText("Open events: 1")).toBeInTheDocument();
 
     await user.keyboard("{Escape}");
-    if (isSvelte5) {
-      // Close count should increase by 1 from initial
-      expect(
-        screen.getByText(new RegExp(`Close events: ${initialCloseCount + 1}`)),
-      ).toBeInTheDocument();
-    } else {
-      expect(screen.getByText("Close events: 1")).toBeInTheDocument();
-    }
+    expect(screen.getByText("Close events: 1")).toBeInTheDocument();
   });
 
   test("should close tooltip when clicking outside", async () => {


### PR DESCRIPTION
Follow-up to https://github.com/carbon-design-system/carbon-components-svelte/pull/2464

Fixes https://github.com/carbon-design-system/carbon-components-svelte/issues/2475, supports https://github.com/carbon-design-system/carbon-components-svelte/issues/2463

Related #2473

This PR fixes `Tooltip` emitting events on initial render in Svelte 5.

The reactive statement `$: dispatch(open ? "open" : "close")` was dispatching a "close" event during component mount because `open` defaults to `false`.

```svelte
<Tooltip on:close={() => {console.log('close')}}>
  <p>Resources are provisioned based on your account's organization.</p>
</Tooltip>
```