### PR TITLE
test(data-table): ensure binding updates complete for Svelte 5

### DIFF
--- a/tests/DataTable/DataTableBatchSelectionToolbar.test.svelte
+++ b/tests/DataTable/DataTableBatchSelectionToolbar.test.svelte
@@ -6,6 +6,7 @@
     ToolbarBatchActions,
     ToolbarContent,
   } from "carbon-components-svelte";
+  import { tick } from "svelte";
 
   const headers = [
     { key: "name", value: "Name" },
@@ -33,9 +34,10 @@
   <Toolbar>
     <ToolbarBatchActions
       {active}
-      on:cancel={() => {
+      on:cancel={async () => {
         if (!controlled) {
           selectedRowIds = [];
+          await tick();
         }
       }}
     >

--- a/tests/DataTable/DataTableBatchSelectionToolbar.test.ts
+++ b/tests/DataTable/DataTableBatchSelectionToolbar.test.ts
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/svelte";
 import { tick } from "svelte";
-import { isSvelte5, user } from "../setup-tests";
+import { user } from "../setup-tests";
 import DataTableBatchSelectionToolbar from "./DataTableBatchSelectionToolbar.test.svelte";
 
 describe("DataTableBatchSelectionToolbar", () => {
@@ -37,7 +37,7 @@ describe("DataTableBatchSelectionToolbar", () => {
   });
 
   it("handles cancel action", async () => {
-    const { component } = render(DataTableBatchSelectionToolbar, {
+    render(DataTableBatchSelectionToolbar, {
       props: {
         selectedRowIds: ["a", "b"],
       },
@@ -46,16 +46,12 @@ describe("DataTableBatchSelectionToolbar", () => {
     // Click cancel button
     const cancelButton = screen.getByText("Cancel");
     await user.click(cancelButton);
+    // Wait for binding updates to complete
     await tick();
 
-    if (isSvelte5) {
-      // Verify selected rows are cleared by checking the displayed value (Svelte 5)
-      const selectedIdsElement = screen.getByTestId("selected-ids");
-      expect(selectedIdsElement.textContent).toBe("[]");
-    } else {
-      // Verify selected rows are cleared using internal API (Svelte 4)
-      expect(component.$$.ctx[component.$$.props.selectedRowIds]).toEqual([]);
-    }
+    // Verify selected rows are cleared by checking the displayed value
+    const selectedIdsElement = screen.getByTestId("selected-ids");
+    expect(selectedIdsElement.textContent).toBe("[]");
   });
 
   it("handles custom batch actions", async () => {
@@ -95,7 +91,7 @@ describe("DataTableBatchSelectionToolbar", () => {
   });
 
   it("prevents default cancel behavior when controlled", async () => {
-    const { component } = render(DataTableBatchSelectionToolbar, {
+    render(DataTableBatchSelectionToolbar, {
       props: {
         selectedRowIds: ["a", "b"],
         active: true,
@@ -108,17 +104,9 @@ describe("DataTableBatchSelectionToolbar", () => {
     await user.click(cancelButton);
     await tick();
 
-    if (isSvelte5) {
-      // Verify selected rows are not cleared by checking the displayed value (Svelte 5)
-      const selectedIdsElement = screen.getByTestId("selected-ids");
-      expect(selectedIdsElement.textContent).toBe('["a","b"]');
-    } else {
-      // Verify selected rows are not cleared using internal API (Svelte 4)
-      expect(component.$$.ctx[component.$$.props.selectedRowIds]).toEqual([
-        "a",
-        "b",
-      ]);
-    }
+    // Verify selected rows are not cleared by checking the displayed value
+    const selectedIdsElement = screen.getByTestId("selected-ids");
+    expect(selectedIdsElement.textContent).toBe('["a","b"]');
   });
 
   it("handles multiple batch actions", async () => {


### PR DESCRIPTION
Not an issue with the source code, but the example file. Make the cancel handler async with tick() to wait for `selectedRowIds` binding updates in Svelte 5.