### PR TITLE
fix(structured-list): prevent dispatching initial "change" event in Svelte 5

### DIFF
--- a/src/StructuredList/StructuredList.svelte
+++ b/src/StructuredList/StructuredList.svelte
@@ -27,6 +27,9 @@
    */
   const selectedValue = writable(selected);
 
+  let prevSelectedValue = undefined;
+  let isInitialRender = true;
+
   /**
    * @type {(value: string) => void}
    */
@@ -40,7 +43,13 @@
   });
 
   $: selected = $selectedValue;
-  $: dispatch("change", $selectedValue);
+  $: {
+    if (!isInitialRender && prevSelectedValue !== $selectedValue) {
+      dispatch("change", $selectedValue);
+    }
+    prevSelectedValue = $selectedValue;
+    isInitialRender = false;
+  }
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->

--- a/tests/StructuredList/StructuredList.test.ts
+++ b/tests/StructuredList/StructuredList.test.ts
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/svelte";
-import { isSvelte5, user } from "../setup-tests";
+import { user } from "../setup-tests";
 import StructuredList from "./StructuredList.test.svelte";
 import StructuredListCustom from "./StructuredListCustom.test.svelte";
 
@@ -120,12 +120,7 @@ describe("StructuredList", () => {
     const consoleLog = vi.spyOn(console, "log");
     render(StructuredList, { props: { selection: true } });
 
-    if (isSvelte5) {
-      // Svelte 5 may emit change event on initial render, so clear the mock
-      consoleLog.mockClear();
-    } else {
-      expect(consoleLog).not.toHaveBeenCalled();
-    }
+    expect(consoleLog).not.toHaveBeenCalled();
 
     await user.click(screen.getAllByRole("radio")[1]);
     expect(consoleLog).toHaveBeenCalledWith("change", "row-2-value");


### PR DESCRIPTION
Follow-up to https://github.com/carbon-design-system/carbon-components-svelte/pull/2464

Fixes https://github.com/carbon-design-system/carbon-components-svelte/issues/2478, supports https://github.com/carbon-design-system/carbon-components-svelte/issues/2463

Related #2473, #2476


This PR fixes `StructuredList` emitting a change event on initial render in Svelte 5. The reactive statement `$: dispatch("change", $selectedValue)` was dispatching a change event during component mount when `selected` was `undefined`.