### PR TITLE
chore(data-table): extract table utilities

### DIFF
--- a/src/DataTable/data-table-utils.d.ts
+++ b/src/DataTable/data-table-utils.d.ts
@@ -7,3 +7,48 @@ export function rowsEqual<Row extends Record<string, any>>(
   a: ReadonlyArray<Row> | null,
   b: ReadonlyArray<Row> | null,
 ): boolean;
+
+/**
+ * Resolves a nested property path in an object.
+ * Supports both direct property access and nested paths like "contact.company".
+ */
+export function resolvePath<T extends Record<string, unknown>>(
+  object: T,
+  path: string,
+): unknown;
+
+/**
+ * Paginates an array of rows based on page number and page size.
+ */
+export function getDisplayedRows<Row extends Record<string, unknown>>(
+  rows: ReadonlyArray<Row>,
+  page: number,
+  pageSize: number,
+): ReadonlyArray<Row>;
+
+/**
+ * Formats header width styles for table headers.
+ * Combines width and minWidth into a CSS style string.
+ */
+export function formatHeaderWidth<
+  Header extends {
+    width?: string | null | number;
+    minWidth?: string | null | number;
+    [key: string]: unknown;
+  } = {
+    width?: string | null | number;
+    minWidth?: string | null | number;
+    [key: string]: unknown;
+  },
+>(header: Header): string | undefined;
+
+/**
+ * Compares two values for sorting in a data table.
+ * Handles numbers, strings, null/undefined values, and custom sort functions.
+ */
+export function compareValues<T = unknown>(
+  itemA: T,
+  itemB: T,
+  ascending: boolean,
+  customSort?: ((a: T, b: T) => number) | false | undefined,
+): number;

--- a/types/DataTable/data-table-utils.d.ts
+++ b/types/DataTable/data-table-utils.d.ts
@@ -7,3 +7,48 @@ export function rowsEqual<Row extends Record<string, any>>(
   a: ReadonlyArray<Row> | null,
   b: ReadonlyArray<Row> | null,
 ): boolean;
+
+/**
+ * Resolves a nested property path in an object.
+ * Supports both direct property access and nested paths like "contact.company".
+ */
+export function resolvePath<T extends Record<string, unknown>>(
+  object: T,
+  path: string,
+): unknown;
+
+/**
+ * Paginates an array of rows based on page number and page size.
+ */
+export function getDisplayedRows<Row extends Record<string, unknown>>(
+  rows: ReadonlyArray<Row>,
+  page: number,
+  pageSize: number,
+): ReadonlyArray<Row>;
+
+/**
+ * Formats header width styles for table headers.
+ * Combines width and minWidth into a CSS style string.
+ */
+export function formatHeaderWidth<
+  Header extends {
+    width?: string | null | number;
+    minWidth?: string | null | number;
+    [key: string]: unknown;
+  } = {
+    width?: string | null | number;
+    minWidth?: string | null | number;
+    [key: string]: unknown;
+  },
+>(header: Header): string | undefined;
+
+/**
+ * Compares two values for sorting in a data table.
+ * Handles numbers, strings, null/undefined values, and custom sort functions.
+ */
+export function compareValues<T = unknown>(
+  itemA: T,
+  itemB: T,
+  ascending: boolean,
+  customSort?: ((a: T, b: T) => number) | false | undefined,
+): number;


### PR DESCRIPTION
Extracts `resolvePath`, `getDisplayedRows`, `formatHeaderWidth`, and `compareValues` utilities from `DataTable`.

This makes it easier to maintain and adds a baseline of unit tests.