### PR TITLE
fix(multi-select): selected options have `aria-checked` state

### DIFF
--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -546,6 +546,7 @@
             role="option"
             aria-labelledby="checkbox-{item.id}"
             aria-selected={item.checked}
+            aria-checked={item.checked}
             active={item.checked}
             highlighted={highlightedIndex === i}
             disabled={item.disabled}

--- a/tests/MultiSelect/MultiSelect.test.ts
+++ b/tests/MultiSelect/MultiSelect.test.ts
@@ -491,6 +491,24 @@ describe("MultiSelect", () => {
       expect(options[1]).toHaveAttribute("aria-selected", "false");
       expect(options[2]).toHaveAttribute("aria-selected", "false");
     });
+
+    it("options have correct aria-checked state for screen reader announcement", async () => {
+      render(MultiSelect, {
+        props: {
+          items,
+          selectedIds: ["0"],
+        },
+      });
+
+      await openMenu();
+      const options = screen.getAllByRole("option");
+      expect(options[0]).toHaveAttribute("aria-checked", "true");
+      expect(options[1]).toHaveAttribute("aria-checked", "false");
+      expect(options[2]).toHaveAttribute("aria-checked", "false");
+
+      await toggleOption("Email");
+      expect(options[1]).toHaveAttribute("aria-checked", "true");
+    });
   });
 
   describe("custom formatting", () => {


### PR DESCRIPTION
Ports fix from https://github.com/carbon-design-system/carbon/pull/21177

Fixes a11y for the `MultiSelect` by setting `aria-checked` on items.