### PR TITLE
test(svelte-5): add `#snippet` tests

### DIFF
--- a/tests-svelte5/bun.lock
+++ b/tests-svelte5/bun.lock
@@ -8,6 +8,7 @@
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/svelte": "^5.2.9",
         "@testing-library/user-event": "^14.6.1",
+        "@typescript/native-preview": "^7.0.0-dev.20251205.1",
         "jsdom": "^27.2.0",
         "svelte": "^5.45.2",
         "svelte-check": "^4.3.5",
@@ -173,6 +174,22 @@
     "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
+
+    "@typescript/native-preview": ["@typescript/native-preview@7.0.0-dev.20260117.1", "", { "optionalDependencies": { "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260117.1", "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260117.1", "@typescript/native-preview-linux-arm": "7.0.0-dev.20260117.1", "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260117.1", "@typescript/native-preview-linux-x64": "7.0.0-dev.20260117.1", "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260117.1", "@typescript/native-preview-win32-x64": "7.0.0-dev.20260117.1" }, "bin": { "tsgo": "bin/tsgo.js" } }, "sha512-5peFvGyf+TOlU6KYMLzfPiPJdxYwG0O/oQN4Z+EzDOzrN8tbY/H58+QOQww4Lo8m4b7+4o/0r+zopD/sYR6uMw=="],
+
+    "@typescript/native-preview-darwin-arm64": ["@typescript/native-preview-darwin-arm64@7.0.0-dev.20260117.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-sf8/7keXq1auS7XI0vyAs3t/vgss4/EwACZmzSYtO75dug8TRmuSQDPHxx4R16VURijO/GQ3Bz6rA8VivREzsA=="],
+
+    "@typescript/native-preview-darwin-x64": ["@typescript/native-preview-darwin-x64@7.0.0-dev.20260117.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-3DhQdRUbDq7YduIaRYJtH5MXqCzOry+GT4DjkLPJ08vOGOFypZjgd6G+moEQHgitnefisC1PkNcL1baF4B7+og=="],
+
+    "@typescript/native-preview-linux-arm": ["@typescript/native-preview-linux-arm@7.0.0-dev.20260117.1", "", { "os": "linux", "cpu": "arm" }, "sha512-RKSKINs23agj0MJJ2Tzkhe/MuwhcPqRNRRfLmpVRjrNWI43Ta6a5+5Lah+7GYjt00wHUOhay94ZT3iHJkeHATg=="],
+
+    "@typescript/native-preview-linux-arm64": ["@typescript/native-preview-linux-arm64@7.0.0-dev.20260117.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-R9h8cX5C0yBtE8xnpAxZBSHWPiVW3d5o3mup0ei1n/8w98lwtMFLWURnPD8N4kRgql9L40IbRXW6jqWdjDUe4Q=="],
+
+    "@typescript/native-preview-linux-x64": ["@typescript/native-preview-linux-x64@7.0.0-dev.20260117.1", "", { "os": "linux", "cpu": "x64" }, "sha512-KI5UprUMIVT4wehBcbGZQm0I3z1uls8fsOmCUzdEpmaLpVu8NbTahgJPVtMyS/nDUiN3At4Uj8ciL36kgbqRmQ=="],
+
+    "@typescript/native-preview-win32-arm64": ["@typescript/native-preview-win32-arm64@7.0.0-dev.20260117.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-dUJTLMD24TQ4XiyYAxxqKs6hPrq8wS9BiFt+ucjCuWXBGQLbnfiT4bgYz2a4yfbtyxVkG7mxV8udo+gRXtaWRQ=="],
+
+    "@typescript/native-preview-win32-x64": ["@typescript/native-preview-win32-x64@7.0.0-dev.20260117.1", "", { "os": "win32", "cpu": "x64" }, "sha512-SdKCAtNZee2TMdZ/bGjfKWX43qIAZhBwLlkPU1G0uxKqmDG1mVRbg/krxm5MnKOjFL00X/gozth6d3LmimonnA=="],
 
     "@vitest/expect": ["@vitest/expect@4.0.17", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.0.17", "@vitest/utils": "4.0.17", "chai": "^6.2.1", "tinyrainbow": "^3.0.3" } }, "sha512-mEoqP3RqhKlbmUmntNDDCJeTDavDR+fVYkSOw8qRwJFaW/0/5zA9zFeTrHqNtcmwh6j26yMmwx2PqUDPzt5ZAQ=="],
 

--- a/tests-svelte5/package.json
+++ b/tests-svelte5/package.json
@@ -3,13 +3,14 @@
   "type": "module",
   "scripts": {
     "test": "vitest",
-    "test:types": "svelte-check --workspace ../tests --fail-on-warnings"
+    "test:types": "svelte-check --workspace ../tests --fail-on-warnings && svelte-check --workspace ./svelte5 --fail-on-warnings"
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^6.2.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/svelte": "^5.2.9",
     "@testing-library/user-event": "^14.6.1",
+    "@typescript/native-preview": "^7.0.0-dev.20251205.1",
     "jsdom": "^27.2.0",
     "svelte": "^5.45.2",
     "svelte-check": "^4.3.5",

--- a/tests-svelte5/svelte5/snippets/Snippets.test.svelte
+++ b/tests-svelte5/svelte5/snippets/Snippets.test.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+  import { Button, ComboBox, Dropdown, Theme } from "carbon-components-svelte";
+
+  const items = [
+    { id: "1", text: "Option 1" },
+    { id: "2", text: "Option 2" },
+    { id: "3", text: "Option 3" },
+  ] as const;
+</script>
+
+<Dropdown data-testid="dropdown-snippet" {items} selectedId="1">
+  {#snippet children({ item, index })}
+    <span data-testid="dropdown-item-{index}">{item.text} (#{index})</span>
+  {/snippet}
+</Dropdown>
+
+<ComboBox data-testid="combobox-snippet" {items}>
+  {#snippet children({ item, index })}
+    <span data-testid="combobox-item-{index}">{item.text} - index {index}</span>
+  {/snippet}
+</ComboBox>
+
+<Button data-testid="button-snippet" as>
+  {#snippet children({ props })}
+    <div {...props} data-testid="custom-button">Custom Button Element</div>
+  {/snippet}
+</Button>
+
+<div data-testid="theme-snippet">
+  <Theme>
+    {#snippet children({ theme })}
+      <div data-testid="theme-value">Current theme: {theme}</div>
+    {/snippet}
+  </Theme>
+</div>

--- a/tests-svelte5/svelte5/snippets/Snippets.test.ts
+++ b/tests-svelte5/svelte5/snippets/Snippets.test.ts
@@ -1,0 +1,73 @@
+import { render, screen } from "@testing-library/svelte";
+import { user } from "../../setup-tests";
+import Snippets from "./Snippets.test.svelte";
+
+describe("Svelte 5 Snippets", () => {
+  describe("Dropdown", () => {
+    it("should render snippet with item and index arguments", async () => {
+      render(Snippets);
+
+      const dropdown = screen.getByTestId("dropdown-snippet");
+      expect(dropdown).toBeInTheDocument();
+
+      const button = dropdown.querySelector("button");
+      expect.assert(button);
+      await user.click(button);
+
+      const item0 = screen.getByTestId("dropdown-item-0");
+      const item1 = screen.getByTestId("dropdown-item-1");
+      const item2 = screen.getByTestId("dropdown-item-2");
+
+      expect(item0).toHaveTextContent("Option 1 (#0)");
+      expect(item1).toHaveTextContent("Option 2 (#1)");
+      expect(item2).toHaveTextContent("Option 3 (#2)");
+    });
+  });
+
+  describe("ComboBox", () => {
+    it("should render snippet with item and index arguments", async () => {
+      render(Snippets);
+
+      const inputs = screen.getAllByRole("combobox");
+      const comboboxInput = inputs[0];
+      expect(comboboxInput).toBeInTheDocument();
+
+      await user.click(comboboxInput);
+
+      const item0 = screen.getByTestId("combobox-item-0");
+      const item1 = screen.getByTestId("combobox-item-1");
+      const item2 = screen.getByTestId("combobox-item-2");
+
+      expect(item0).toHaveTextContent("Option 1 - index 0");
+      expect(item1).toHaveTextContent("Option 2 - index 1");
+      expect(item2).toHaveTextContent("Option 3 - index 2");
+    });
+  });
+
+  describe("Button", () => {
+    it("should render snippet with props argument when using 'as' prop", () => {
+      render(Snippets);
+
+      const customButton = screen.getByTestId("custom-button");
+      expect(customButton).toBeInTheDocument();
+      expect(customButton).toHaveTextContent("Custom Button Element");
+
+      expect(customButton.tagName).toBe("DIV");
+      expect(customButton).toHaveClass("bx--btn");
+    });
+  });
+
+  describe("Theme", () => {
+    it("should render snippet with theme argument", () => {
+      render(Snippets);
+
+      const themeValue = screen.getByTestId("theme-value");
+      expect(themeValue).toBeInTheDocument();
+
+      expect(themeValue).toHaveTextContent("Current theme:");
+      expect(themeValue.textContent).toMatch(
+        /Current theme: (white|g10|g80|g90|g100)/,
+      );
+    });
+  });
+});

--- a/tests-svelte5/svelte5/tsconfig.json
+++ b/tests-svelte5/svelte5/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "noEmit": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "resolveJsonModule": true,
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "paths": {
+      "carbon-components-svelte": ["../../types"],
+      "carbon-components-svelte/*": ["../../types/*"]
+    }
+  },
+  "include": ["./**/*.ts", "./**/*.svelte"]
+}

--- a/tests-svelte5/vite.config.ts
+++ b/tests-svelte5/vite.config.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { svelte } from "@sveltejs/vite-plugin-svelte";
 import { defineConfig } from "vitest/config";
 import {
@@ -11,7 +12,10 @@ const __dirname = getDirname(import.meta.url);
 export default defineConfig({
   resolve: {
     conditions: ["browser"],
-    alias: generateAliasesFromExports(__dirname, "../src"),
+    alias: {
+      ...generateAliasesFromExports(__dirname, "../src"),
+      "carbon-components-svelte": path.resolve(__dirname, "../src/index.js"),
+    },
   },
   // @ts-expect-error
   plugins: [svelte()],
@@ -22,7 +26,7 @@ export default defineConfig({
   },
   test: {
     ...testConfig,
-    include: ["../tests/**/*.test.ts"],
+    include: ["../tests/**/*.test.ts", "./svelte5/**/*.test.ts"],
     setupFiles: ["./setup-tests.ts"],
   },
 });


### PR DESCRIPTION
Related #2505 

Follow-up to #2508, #2506

This adds regression tests that validate `#snippet` usage for Svelte 5.

Adding these tests also identifies another issue: the default `children` snippet also requires prop type generation.