### PR TITLE
ci: test types first

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -33,11 +33,11 @@ jobs:
       - uses: oven-sh/setup-bun@v2
       - run: bun ci
 
-      - name: Test Svelte 4
-        run: bun run test
-
       - name: Test Svelte 4 Types
         run: bun run test:types
+
+      - name: Test Svelte 4
+        run: bun run test
 
   test-svelte3:
     runs-on: macos-15
@@ -51,15 +51,15 @@ jobs:
           cd tests-svelte3
           bun ci
 
-      - name: Test Svelte 3
-        run: |
-          cd tests-svelte3
-          bun run test
-
       - name: Test Svelte 3 Types
         run: |
           cd tests-svelte3
           bun run test:types
+
+      - name: Test Svelte 3
+        run: |
+          cd tests-svelte3
+          bun run test
 
   test-svelte5:
     runs-on: macos-15
@@ -73,15 +73,15 @@ jobs:
           cd tests-svelte5
           bun ci
 
-      - name: Test Svelte 5
-        run: |
-          cd tests-svelte5
-          bun run test
-
       - name: Test Svelte 5 Types
         run: |
           cd tests-svelte5
           bun run test:types
+
+      - name: Test Svelte 5
+        run: |
+          cd tests-svelte5
+          bun run test
 
   types:
     runs-on: macos-15


### PR DESCRIPTION
Fail fast by testing types first.

This should be faster and likely indicate a bigger issue before needing to run the entire test suite (1900+ unit tests).