### PR TITLE
fix(types): fix `truncate` function type

### DIFF
--- a/src/Truncate/truncate.d.ts
+++ b/src/Truncate/truncate.d.ts
@@ -2,11 +2,11 @@ interface TruncateOptions {
   clamp?: "end" | "front";
 }
 
-export function TruncateAction(
+export function truncate(
   node: HTMLElement,
   options?: TruncateOptions,
 ): {
   update: (options?: TruncateOptions) => void;
 };
 
-export default TruncateAction;
+export default truncate;

--- a/types/Truncate/truncate.d.ts
+++ b/types/Truncate/truncate.d.ts
@@ -2,11 +2,11 @@ interface TruncateOptions {
   clamp?: "end" | "front";
 }
 
-export function TruncateAction(
+export function truncate(
   node: HTMLElement,
   options?: TruncateOptions,
 ): {
   update: (options?: TruncateOptions) => void;
 };
 
-export default TruncateAction;
+export default truncate;


### PR DESCRIPTION
The named export type should match the function name.