### PR TITLE
fix(select)!: remove unused `SelectValue` type

### DIFF
--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -3360,12 +3360,6 @@ None.
 
 ## `Select`
 
-### Types
-
-```ts
-export type SelectValue = string | number;
-```
-
 ### Props
 
 | Prop name   | Required | Kind             | Reactive | Type                                       | Default value                                      | Description                                      |

--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -13746,13 +13746,7 @@
           "element": "select"
         }
       ],
-      "typedefs": [
-        {
-          "type": "string | number",
-          "name": "SelectValue",
-          "ts": "type SelectValue = string | number;\n"
-        }
-      ],
+      "typedefs": [],
       "generics": [
         "Value",
         "Value extends string | number = string | number"

--- a/src/Select/Select.svelte
+++ b/src/Select/Select.svelte
@@ -1,8 +1,6 @@
 <script>
   /**
    * @generics {Value extends string | number = string | number} Value
-   * @template {string | number} Value
-   * @typedef {string | number} SelectValue
    * @event {Value} update The selected value.
    */
 

--- a/types/Select/Select.svelte.d.ts
+++ b/types/Select/Select.svelte.d.ts
@@ -1,8 +1,6 @@
 import { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-export type SelectValue = string | number;
-
 export type SelectContext = {
   selectedValue: import("svelte/store").Writable<string | number | undefined>;
   /** Use the first `SelectItem` value as the


### PR DESCRIPTION
Remove the old `SelectValue` type.

`Select` is now generic, and the type signature is the same. This is a small breaking change but is easy to mitigate.