### PR TITLE
fix(ui-shell): `SideNav` overlays `UIShell` content

### DIFF
--- a/src/UIShell/Content.svelte
+++ b/src/UIShell/Content.svelte
@@ -2,16 +2,22 @@
   /** Specify the id for the main element */
   export let id = "main-content";
 
-  import { isSideNavCollapsed, isSideNavRail } from "./navStore";
+  import {
+    isSideNavCollapsed,
+    isSideNavMobile,
+    isSideNavRail,
+  } from "./navStore";
 
   /**
    * By default, the `SideNav` applies a left margin of `3rem` to `Content`
    * if it's a sibling component (e.g., .bx--side-nav ~ .bx--content).
    *
-   * We manually unset the left margin if the `SideNav`
-   * is collapsed and if it's not the `rail` variant.
+   * Unset the left margin if:
+   * - `SideNav` is collapsed and it's not the `rail` variant, OR
+   * - `SideNav` overlays content on mobile (below the breakpoint)
    */
-  $: unsetLeftMargin = $isSideNavCollapsed && !$isSideNavRail;
+  $: unsetLeftMargin =
+    ($isSideNavCollapsed && !$isSideNavRail) || $isSideNavMobile;
 </script>
 
 <main

--- a/src/UIShell/SideNav.svelte
+++ b/src/UIShell/SideNav.svelte
@@ -34,6 +34,7 @@
   import { createEventDispatcher, onMount } from "svelte";
   import {
     isSideNavCollapsed,
+    isSideNavMobile,
     isSideNavRail,
     shouldRenderHamburgerMenu,
   } from "./navStore";
@@ -45,10 +46,28 @@
   $: dispatch(isOpen ? "open" : "close");
   $: $isSideNavCollapsed = !isOpen;
   $: $isSideNavRail = rail;
+  $: $isSideNavMobile =
+    winWidth !== undefined && winWidth < expansionBreakpoint;
+
+  // Lock body scroll when SideNav is open on mobile (below breakpoint).
+  // Only applies to non-fixed, non-rail variants.
+  $: if (typeof document !== "undefined") {
+    const shouldLockScroll = isOpen && !fixed && !rail && $isSideNavMobile;
+    document.body.classList.toggle(
+      "bx--body--with-modal-open",
+      shouldLockScroll,
+    );
+  }
 
   onMount(() => {
     shouldRenderHamburgerMenu.set(true);
-    return () => shouldRenderHamburgerMenu.set(false);
+    return () => {
+      shouldRenderHamburgerMenu.set(false);
+      isSideNavMobile.set(false);
+      if (typeof document !== "undefined") {
+        document.body.classList.remove("bx--body--with-modal-open");
+      }
+    };
   });
 </script>
 

--- a/src/UIShell/navStore.js
+++ b/src/UIShell/navStore.js
@@ -5,3 +5,5 @@ export const shouldRenderHamburgerMenu = writable(false);
 export const isSideNavCollapsed = writable(false);
 
 export const isSideNavRail = writable(false);
+
+export const isSideNavMobile = writable(false);


### PR DESCRIPTION
Fixes #2520, fixes #1463, fixes #544

This addresses a long-standing visual bug in UI Shell, where the `SideNav` would "push" the Shell content rather than overlay it. Additionally, when the side nav is open on mobile, shell content should be scroll-locked.

The UI Shell needs a larger audit and refactoring, but this fixes the bug in the meantime.

---

## Before / After

<img width="300" height="683" alt="Screenshot 2026-01-18 at 10 33 10 AM" src="https://github.com/user-attachments/assets/c5d99450-ac21-43f1-8034-bb3d16a70d3a" />
<img width="300" height="684" alt="Screenshot 2026-01-18 at 10 33 20 AM" src="https://github.com/user-attachments/assets/5744338d-d39d-4458-b124-dde99aa46df6" />

