### PR TITLE
docs(radio-button): fix legend text slot example

### DIFF
--- a/docs/src/pages/components/RadioButton.svx
+++ b/docs/src/pages/components/RadioButton.svx
@@ -3,7 +3,7 @@ components: ["RadioButtonGroup", "RadioButton", "RadioButtonSkeleton"]
 ---
 
 <script>
-  import { RadioButton, RadioButtonSkeleton, RadioButtonGroup, Tooltip } from "carbon-components-svelte";
+  import { RadioButton, RadioButtonSkeleton, RadioButtonGroup, Tooltip, Stack } from "carbon-components-svelte";
   import Preview from "../../components/Preview.svelte";
 </script>
 
@@ -37,19 +37,19 @@ Visually hide the legend while maintaining accessibility.
   <RadioButton labelText="Pro (128 GB)" value="pro" />
 </RadioButtonGroup>
 
-## Legend text slot
+## Custom label content
 
-Customize the legend text with additional content.
+Use the `labelChildren` slot to provide custom label content instead of using the `labelText` prop.
 
 <RadioButtonGroup name="plan-legend-slot" selected="standard">
-  <div slot="legendText" style:display="flex">
+  <Stack slot="legendChildren" orientation="horizontal">
     Storage tier (disk)
     <Tooltip>
       <p>
         Storage tiers may vary based on geolocation.
       </p>
     </Tooltip>
-  </div>
+  </Stack>
   <RadioButton labelText="Free (1 GB)" value="free" />
   <RadioButton labelText="Standard (10 GB)" value="standard" />
   <RadioButton labelText="Pro (128 GB)" value="pro" />


### PR DESCRIPTION
Named slots have been renamed to support Svelte 5 `#snippet` usage.

This updates the radio button group example to use the correct named slot.