### PR TITLE
fix(multi-select): prevent dispatching initial "select" event in Svelte 5

### DIFF
--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -194,6 +194,7 @@
 
   let highlightedIndex = -1;
   let prevChecked = [];
+  let isInitialRender = true;
 
   /**
    * @type {(data: { key: "field" | "selection"; ref: HTMLDivElement }) => void}
@@ -245,12 +246,15 @@
     if (checked.length !== prevChecked.length) {
       prevChecked = checked;
       selectedIds = checked.map(({ id }) => id);
-      dispatch("select", {
-        selectedIds,
-        selected: checked,
-        unselected: unchecked,
-      });
+      if (!isInitialRender) {
+        dispatch("select", {
+          selectedIds,
+          selected: checked,
+          unselected: unchecked,
+        });
+      }
     }
+    isInitialRender = false;
 
     if (!open) {
       highlightedIndex = -1;

--- a/tests/MultiSelect/MultiSelect.test.ts
+++ b/tests/MultiSelect/MultiSelect.test.ts
@@ -61,6 +61,40 @@ describe("MultiSelect", () => {
   });
 
   describe("selection behavior", () => {
+    // Regression test for https://github.com/carbon-design-system/carbon-components-svelte/issues/2525
+    it("does not fire select event on initial render", async () => {
+      const consoleLog = vi.spyOn(console, "log");
+      render(MultiSelect, {
+        props: {
+          items,
+          selectedIds: ["0"],
+        },
+      });
+
+      expect(consoleLog).not.toHaveBeenCalled();
+
+      await openMenu();
+      await toggleOption("Email");
+      expect(consoleLog).toHaveBeenCalledWith("select", {
+        selectedIds: ["0", "1"],
+        selected: [
+          { id: "0", text: "Slack", checked: true },
+          { id: "1", text: "Email", checked: true },
+        ],
+        unselected: [{ id: "2", text: "Fax", checked: false }],
+      });
+    });
+
+    // Regression test for https://github.com/carbon-design-system/carbon-components-svelte/issues/2525
+    it("does not fire select event on initial render without selectedIds", () => {
+      const consoleLog = vi.spyOn(console, "log");
+      render(MultiSelect, {
+        props: { items },
+      });
+
+      expect(consoleLog).not.toHaveBeenCalled();
+    });
+
     it("handles item selection", async () => {
       const consoleLog = vi.spyOn(console, "log");
       render(MultiSelect, {


### PR DESCRIPTION
Fixes #2525

Prior art https://github.com/carbon-design-system/carbon-components-svelte/pull/2473

In Svelte 5, an initial `select` event is dispatched if `selectedIds` is specified. Similar to #2473, this adds a flag to avoid the initial dispatch.

Added regression tests.