### PR TITLE
test: add test cases for more initial dispatched events in Svelte 5

### DIFF
--- a/tests/CodeSnippet/CodeSnippet.test.ts
+++ b/tests/CodeSnippet/CodeSnippet.test.ts
@@ -4,6 +4,7 @@ import CodeSnippetCopyButton from "./CodeSnippetCopyButton.test.svelte";
 import CodeSnippetCustomEvents from "./CodeSnippetCustomEvents.test.svelte";
 import CodeSnippetExpandable from "./CodeSnippetExpandable.test.svelte";
 import CodeSnippetExpandedByDefault from "./CodeSnippetExpandedByDefault.svelte";
+import CodeSnippetInitialEvent from "./CodeSnippetInitialEvent.test.svelte";
 import CodeSnippetInline from "./CodeSnippetInline.test.svelte";
 import CodeSnippetMultiline from "./CodeSnippetMultiline.test.svelte";
 import CodeSnippetWithCustomCopyText from "./CodeSnippetWithCustomCopyText.test.svelte";
@@ -11,6 +12,24 @@ import CodeSnippetWithHideShowMore from "./CodeSnippetWithHideShowMore.test.svel
 import CodeSnippetWithWrapText from "./CodeSnippetWithWrapText.test.svelte";
 
 describe("CodeSnippet", () => {
+  // Regression test for initial event dispatch in Svelte 5
+  // https://github.com/carbon-design-system/carbon-components-svelte/issues/2525
+  test("does not fire expand/collapse event on initial render", () => {
+    render(CodeSnippetInitialEvent);
+
+    expect(screen.getByTestId("expand-event")).toHaveTextContent("false");
+    expect(screen.getByTestId("collapse-event")).toHaveTextContent("false");
+  });
+
+  // Regression test for initial event dispatch in Svelte 5
+  // https://github.com/carbon-design-system/carbon-components-svelte/issues/2525
+  test("does not fire expand/collapse event on initial render when expanded is true", () => {
+    render(CodeSnippetInitialEvent, { props: { expanded: true } });
+
+    expect(screen.getByTestId("expand-event")).toHaveTextContent("false");
+    expect(screen.getByTestId("collapse-event")).toHaveTextContent("false");
+  });
+
   test("should render inline variant", () => {
     const { container } = render(CodeSnippetInline);
     expect(container.querySelector(".bx--snippet--inline")).toBeInTheDocument();

--- a/tests/CodeSnippet/CodeSnippetInitialEvent.test.svelte
+++ b/tests/CodeSnippet/CodeSnippetInitialEvent.test.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+  import { CodeSnippet } from "carbon-components-svelte";
+
+  export let expanded = false;
+
+  let expandEvent = false;
+  let collapseEvent = false;
+</script>
+
+<CodeSnippet
+  type="multi"
+  {expanded}
+  code={`node -v
+npm -v`}
+  on:expand={() => {
+    expandEvent = true;
+  }}
+  on:collapse={() => {
+    collapseEvent = true;
+  }}
+/>
+
+<div data-testid="expand-event">{expandEvent}</div>
+<div data-testid="collapse-event">{collapseEvent}</div>

--- a/tests/Pagination/Pagination.test.ts
+++ b/tests/Pagination/Pagination.test.ts
@@ -8,6 +8,17 @@ describe("Pagination", () => {
     vi.clearAllMocks();
   });
 
+  // Regression test for initial event dispatch in Svelte 5
+  // https://github.com/carbon-design-system/carbon-components-svelte/issues/2525
+  it("does not fire update event on initial render", () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(Pagination, {
+      props: { totalItems: 100, page: 1, pageSize: 10 },
+    });
+
+    expect(consoleLog).not.toHaveBeenCalledWith("update", expect.anything());
+  });
+
   it("should render with default props", () => {
     render(Pagination);
 

--- a/tests/Search/Search.test.ts
+++ b/tests/Search/Search.test.ts
@@ -3,6 +3,7 @@ import { user } from "../setup-tests";
 import SearchSlot from "./Search.slot.test.svelte";
 import Search from "./Search.test.svelte";
 import SearchExpandable from "./SearchExpandable.test.svelte";
+import SearchInitialEvent from "./SearchInitialEvent.test.svelte";
 import SearchSkeleton from "./SearchSkeleton.test.svelte";
 
 describe("Search", () => {
@@ -10,6 +11,24 @@ describe("Search", () => {
     screen.getByRole("searchbox", { name: label });
   const getClearButton = (label = "Clear search input") =>
     screen.getByRole("button", { name: label });
+
+  // Regression test for initial event dispatch in Svelte 5
+  // https://github.com/carbon-design-system/carbon-components-svelte/issues/2525
+  it("does not fire expand/collapse event on initial render", () => {
+    render(SearchInitialEvent);
+
+    expect(screen.getByTestId("expand-event")).toHaveTextContent("false");
+    expect(screen.getByTestId("collapse-event")).toHaveTextContent("false");
+  });
+
+  // Regression test for initial event dispatch in Svelte 5
+  // https://github.com/carbon-design-system/carbon-components-svelte/issues/2525
+  it("does not fire expand/collapse event on initial render when expanded is true", () => {
+    render(SearchInitialEvent, { props: { expanded: true } });
+
+    expect(screen.getByTestId("expand-event")).toHaveTextContent("false");
+    expect(screen.getByTestId("collapse-event")).toHaveTextContent("false");
+  });
 
   it("renders and functions correctly", async () => {
     const consoleLog = vi.spyOn(console, "log");

--- a/tests/Search/SearchInitialEvent.test.svelte
+++ b/tests/Search/SearchInitialEvent.test.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+  import { Search } from "carbon-components-svelte";
+
+  export let expanded = false;
+
+  let expandEvent = false;
+  let collapseEvent = false;
+</script>
+
+<Search
+  expandable
+  {expanded}
+  labelText="Initial event search"
+  placeholder="Search..."
+  on:expand={() => {
+    expandEvent = true;
+  }}
+  on:collapse={() => {
+    collapseEvent = true;
+  }}
+/>
+
+<div data-testid="expand-event">{expandEvent}</div>
+<div data-testid="collapse-event">{collapseEvent}</div>

--- a/tests/Theme/Theme.test.ts
+++ b/tests/Theme/Theme.test.ts
@@ -60,6 +60,22 @@ describe("Theme", () => {
     localStorageMock = {};
   });
 
+  // Regression test for initial event dispatch in Svelte 5
+  // https://github.com/carbon-design-system/carbon-components-svelte/issues/2525
+  it("does not fire update event on initial render", () => {
+    render(Theme);
+
+    expect(consoleLog).not.toHaveBeenCalledWith("update", expect.anything());
+  });
+
+  // Regression test for initial event dispatch in Svelte 5
+  // https://github.com/carbon-design-system/carbon-components-svelte/issues/2525
+  it("does not fire update event on initial render with custom theme", () => {
+    render(Theme, { props: { theme: "g100" } });
+
+    expect(consoleLog).not.toHaveBeenCalledWith("update", expect.anything());
+  });
+
   it("should set default theme to white", () => {
     render(Theme);
     expect(documentMock.setAttribute).toHaveBeenCalledWith("theme", "white");

--- a/tests/TooltipDefinition/TooltipDefinition.test.ts
+++ b/tests/TooltipDefinition/TooltipDefinition.test.ts
@@ -13,6 +13,24 @@ describe("TooltipDefinition", () => {
     vi.restoreAllMocks();
   });
 
+  // Regression test for initial event dispatch in Svelte 5
+  // https://github.com/carbon-design-system/carbon-components-svelte/issues/2525
+  it("does not fire open/close event on initial render", () => {
+    render(TooltipDefinition);
+
+    expect(consoleLog).not.toHaveBeenCalledWith("open");
+    expect(consoleLog).not.toHaveBeenCalledWith("close");
+  });
+
+  // Regression test for initial event dispatch in Svelte 5
+  // https://github.com/carbon-design-system/carbon-components-svelte/issues/2525
+  it("does not fire open/close event on initial render when open is true", () => {
+    render(TooltipDefinition, { props: { open: true } });
+
+    expect(consoleLog).not.toHaveBeenCalledWith("open");
+    expect(consoleLog).not.toHaveBeenCalledWith("close");
+  });
+
   it("should render with default props", () => {
     render(TooltipDefinition);
 

--- a/tests/UIShell/HeaderSearch.test.ts
+++ b/tests/UIShell/HeaderSearch.test.ts
@@ -7,6 +7,24 @@ describe("HeaderSearch", () => {
     vi.clearAllMocks();
   });
 
+  // Regression test for initial event dispatch in Svelte 5
+  // https://github.com/carbon-design-system/carbon-components-svelte/issues/2525
+  it("does not fire active/inactive event on initial render", () => {
+    render(HeaderSearchTest);
+
+    expect(screen.getByTestId("active-event")).toHaveTextContent("false");
+    expect(screen.getByTestId("inactive-event")).toHaveTextContent("false");
+  });
+
+  // Regression test for initial event dispatch in Svelte 5
+  // https://github.com/carbon-design-system/carbon-components-svelte/issues/2525
+  it("does not fire active/inactive event on initial render when active is true", () => {
+    render(HeaderSearchTest, { props: { active: true } });
+
+    expect(screen.getByTestId("active-event")).toHaveTextContent("false");
+    expect(screen.getByTestId("inactive-event")).toHaveTextContent("false");
+  });
+
   describe("Rendering", () => {
     it("should render with default props", () => {
       render(HeaderSearchTest);

--- a/tests/UIShell/UIShell.test.ts
+++ b/tests/UIShell/UIShell.test.ts
@@ -239,6 +239,30 @@ describe("UIShell", () => {
       expect(nav).toBeInTheDocument();
     });
 
+    // Regression test for initial event dispatch in Svelte 5
+    // https://github.com/carbon-design-system/carbon-components-svelte/issues/2525
+    it("does not fire open/close event on initial render", () => {
+      const consoleLog = vi.spyOn(console, "log");
+      render(UiShell, {
+        props: { sideNavIsOpen: false },
+      });
+
+      expect(consoleLog).not.toHaveBeenCalledWith("sidenav-open");
+      expect(consoleLog).not.toHaveBeenCalledWith("sidenav-close");
+    });
+
+    // Regression test for initial event dispatch in Svelte 5
+    // https://github.com/carbon-design-system/carbon-components-svelte/issues/2525
+    it("does not fire open/close event on initial render when isOpen is true", () => {
+      const consoleLog = vi.spyOn(console, "log");
+      render(UiShell, {
+        props: { sideNavIsOpen: true },
+      });
+
+      expect(consoleLog).not.toHaveBeenCalledWith("sidenav-open");
+      expect(consoleLog).not.toHaveBeenCalledWith("sidenav-close");
+    });
+
     describe("body scroll lock", () => {
       const setViewportWidth = (width: number) => {
         Object.defineProperty(window, "innerWidth", {


### PR DESCRIPTION
Supports #2012

These tests should fail in Svelte 5.

