### PR TITLE
fix(code-snippet): prevent dispatching initial "collapse" event in Svelte 5

### DIFF
--- a/src/CodeSnippet/CodeSnippet.svelte
+++ b/src/CodeSnippet/CodeSnippet.svelte
@@ -119,6 +119,7 @@
   /** @type {"fade-in" | "fade-out"} */
   let animation = undefined;
   let timeout = undefined;
+  let prevExpanded = expanded;
 
   function setShowMoreLess() {
     const { height } = ref.getBoundingClientRect();
@@ -140,7 +141,10 @@
     }
   }
 
-  $: if (type === "multi") dispatch(expanded ? "expand" : "collapse");
+  $: if (type === "multi" && prevExpanded !== expanded) {
+    dispatch(expanded ? "expand" : "collapse");
+    prevExpanded = expanded;
+  }
 
   onMount(() => {
     return () => clearTimeout(timeout);

--- a/tests/CodeSnippet/CodeSnippet.test.ts
+++ b/tests/CodeSnippet/CodeSnippet.test.ts
@@ -4,6 +4,7 @@ import CodeSnippetCopyButton from "./CodeSnippetCopyButton.test.svelte";
 import CodeSnippetCustomEvents from "./CodeSnippetCustomEvents.test.svelte";
 import CodeSnippetExpandable from "./CodeSnippetExpandable.test.svelte";
 import CodeSnippetExpandedByDefault from "./CodeSnippetExpandedByDefault.svelte";
+import CodeSnippetInitialEvent from "./CodeSnippetInitialEvent.test.svelte";
 import CodeSnippetInline from "./CodeSnippetInline.test.svelte";
 import CodeSnippetMultiline from "./CodeSnippetMultiline.test.svelte";
 import CodeSnippetWithCustomCopyText from "./CodeSnippetWithCustomCopyText.test.svelte";
@@ -11,6 +12,24 @@ import CodeSnippetWithHideShowMore from "./CodeSnippetWithHideShowMore.test.svel
 import CodeSnippetWithWrapText from "./CodeSnippetWithWrapText.test.svelte";
 
 describe("CodeSnippet", () => {
+  // Regression test for initial event dispatch in Svelte 5
+  // https://github.com/carbon-design-system/carbon-components-svelte/issues/2527
+  test("does not fire expand/collapse event on initial render", () => {
+    render(CodeSnippetInitialEvent);
+
+    expect(screen.getByTestId("expand-event")).toHaveTextContent("false");
+    expect(screen.getByTestId("collapse-event")).toHaveTextContent("false");
+  });
+
+  // Regression test for initial event dispatch in Svelte 5
+  // https://github.com/carbon-design-system/carbon-components-svelte/issues/2527
+  test("does not fire expand/collapse event on initial render when expanded is true", () => {
+    render(CodeSnippetInitialEvent, { props: { expanded: true } });
+
+    expect(screen.getByTestId("expand-event")).toHaveTextContent("false");
+    expect(screen.getByTestId("collapse-event")).toHaveTextContent("false");
+  });
+
   test("should render inline variant", () => {
     const { container } = render(CodeSnippetInline);
     expect(container.querySelector(".bx--snippet--inline")).toBeInTheDocument();

--- a/tests/CodeSnippet/CodeSnippetInitialEvent.test.svelte
+++ b/tests/CodeSnippet/CodeSnippetInitialEvent.test.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+  import { CodeSnippet } from "carbon-components-svelte";
+
+  export let expanded = false;
+
+  let expandEvent = false;
+  let collapseEvent = false;
+</script>
+
+<CodeSnippet
+  type="multi"
+  {expanded}
+  code={`node -v
+npm -v`}
+  on:expand={() => {
+    expandEvent = true;
+  }}
+  on:collapse={() => {
+    collapseEvent = true;
+  }}
+/>
+
+<div data-testid="expand-event">{expandEvent}</div>
+<div data-testid="collapse-event">{collapseEvent}</div>


### PR DESCRIPTION
Fixes #2527