### PR TITLE
fix(pagination): prevent dispatching initial "update" event in Svelte 5

### DIFF
--- a/src/Pagination/Pagination.svelte
+++ b/src/Pagination/Pagination.svelte
@@ -105,6 +105,9 @@
 
   const dispatch = createEventDispatcher();
 
+  let prevPage = page;
+  let prevPageSize = pageSize;
+
   /**
    * Returns a subset of page numbers centered around the current page to prevent
    * performance issues with large datasets. Creates a capped window of pages
@@ -122,7 +125,11 @@
 
   $: totalPages = Math.max(Math.ceil(totalItems / pageSize), 1);
   $: if (page > totalPages) page = totalPages;
-  $: dispatch("update", { pageSize, page });
+  $: if (prevPage !== page || prevPageSize !== pageSize) {
+    dispatch("update", { pageSize, page });
+    prevPage = page;
+    prevPageSize = pageSize;
+  }
   $: selectItems = getWindowedPages(page, totalPages, pageWindow);
   $: backButtonDisabled = disabled || page === 1;
   $: forwardButtonDisabled = disabled || page === totalPages;

--- a/tests/Pagination/Pagination.test.ts
+++ b/tests/Pagination/Pagination.test.ts
@@ -8,6 +8,17 @@ describe("Pagination", () => {
     vi.clearAllMocks();
   });
 
+  // Regression test for initial event dispatch in Svelte 5
+  // https://github.com/carbon-design-system/carbon-components-svelte/issues/2528
+  it("does not fire update event on initial render", () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(Pagination, {
+      props: { totalItems: 100, page: 1, pageSize: 10 },
+    });
+
+    expect(consoleLog).not.toHaveBeenCalledWith("update", expect.anything());
+  });
+
   it("should render with default props", () => {
     render(Pagination);
 


### PR DESCRIPTION
Fixes #2528