### PR TITLE
fix(search): prevent dispatching initial "collapse" event in Svelte 5

### DIFF
--- a/src/Search/Search.svelte
+++ b/src/Search/Search.svelte
@@ -73,9 +73,13 @@
   const dispatch = createEventDispatcher();
 
   let searchRef = null;
+  let prevExpanded = expanded;
 
   $: if (expanded && ref) ref.focus();
-  $: dispatch(expanded ? "expand" : "collapse");
+  $: if (expanded !== prevExpanded) {
+    dispatch(expanded ? "expand" : "collapse");
+    prevExpanded = expanded;
+  }
 </script>
 
 <!-- svelte-ignore a11y-autofocus -->

--- a/tests/Search/Search.test.ts
+++ b/tests/Search/Search.test.ts
@@ -3,6 +3,7 @@ import { user } from "../setup-tests";
 import SearchSlot from "./Search.slot.test.svelte";
 import Search from "./Search.test.svelte";
 import SearchExpandable from "./SearchExpandable.test.svelte";
+import SearchInitialEvent from "./SearchInitialEvent.test.svelte";
 import SearchSkeleton from "./SearchSkeleton.test.svelte";
 
 describe("Search", () => {
@@ -10,6 +11,24 @@ describe("Search", () => {
     screen.getByRole("searchbox", { name: label });
   const getClearButton = (label = "Clear search input") =>
     screen.getByRole("button", { name: label });
+
+  // Regression test for initial event dispatch in Svelte 5
+  // https://github.com/carbon-design-system/carbon-components-svelte/issues/2529
+  it("does not fire expand/collapse event on initial render", () => {
+    render(SearchInitialEvent);
+
+    expect(screen.getByTestId("expand-event")).toHaveTextContent("false");
+    expect(screen.getByTestId("collapse-event")).toHaveTextContent("false");
+  });
+
+  // Regression test for initial event dispatch in Svelte 5
+  // https://github.com/carbon-design-system/carbon-components-svelte/issues/2529
+  it("does not fire expand/collapse event on initial render when expanded is true", () => {
+    render(SearchInitialEvent, { props: { expanded: true } });
+
+    expect(screen.getByTestId("expand-event")).toHaveTextContent("false");
+    expect(screen.getByTestId("collapse-event")).toHaveTextContent("false");
+  });
 
   it("renders and functions correctly", async () => {
     const consoleLog = vi.spyOn(console, "log");

--- a/tests/Search/SearchInitialEvent.test.svelte
+++ b/tests/Search/SearchInitialEvent.test.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+  import { Search } from "carbon-components-svelte";
+
+  export let expanded = false;
+
+  let expandEvent = false;
+  let collapseEvent = false;
+</script>
+
+<Search
+  expandable
+  {expanded}
+  labelText="Initial event search"
+  placeholder="Search..."
+  on:expand={() => {
+    expandEvent = true;
+  }}
+  on:collapse={() => {
+    collapseEvent = true;
+  }}
+/>
+
+<div data-testid="expand-event">{expandEvent}</div>
+<div data-testid="collapse-event">{collapseEvent}</div>


### PR DESCRIPTION
Fixes #2529