### PR TITLE
fix(theme): prevent dispatching initial "update" event in Svelte 5

### DIFF
--- a/src/Theme/Theme.svelte
+++ b/src/Theme/Theme.svelte
@@ -73,13 +73,26 @@
     hideLabel: false,
   };
 
-  import { createEventDispatcher } from "svelte";
+  import { afterUpdate, createEventDispatcher } from "svelte";
   import LocalStorage from "../LocalStorage/LocalStorage.svelte";
   import Select from "../Select/Select.svelte";
   import SelectItem from "../Select/SelectItem.svelte";
   import Toggle from "../Toggle/Toggle.svelte";
 
   const dispatch = createEventDispatcher();
+
+  let prevTheme = theme;
+  let isInitialRender = true;
+
+  afterUpdate(() => {
+    if (prevTheme !== theme) {
+      prevTheme = theme;
+      if (!isInitialRender) {
+        dispatch("update", { theme });
+      }
+    }
+    isInitialRender = false;
+  });
 
   $: if (typeof window !== "undefined") {
     for (const [token, value] of Object.entries(tokens)) {
@@ -88,7 +101,6 @@
 
     if (theme in themes) {
       document.documentElement.setAttribute("theme", theme);
-      dispatch("update", { theme });
     } else {
       console.warn(
         `[Theme.svelte] invalid theme "${theme}". Value must be one of: ${JSON.stringify(

--- a/tests/Theme/Theme.test.ts
+++ b/tests/Theme/Theme.test.ts
@@ -60,6 +60,22 @@ describe("Theme", () => {
     localStorageMock = {};
   });
 
+  // Regression test for initial event dispatch in Svelte 5
+  // https://github.com/carbon-design-system/carbon-components-svelte/issues/2530
+  it("does not fire update event on initial render", () => {
+    render(Theme);
+
+    expect(consoleLog).not.toHaveBeenCalledWith("update", expect.anything());
+  });
+
+  // Regression test for initial event dispatch in Svelte 5
+  // https://github.com/carbon-design-system/carbon-components-svelte/issues/2530
+  it("does not fire update event on initial render with custom theme", () => {
+    render(Theme, { props: { theme: "g100" } });
+
+    expect(consoleLog).not.toHaveBeenCalledWith("update", expect.anything());
+  });
+
   it("should set default theme to white", () => {
     render(Theme);
     expect(documentMock.setAttribute).toHaveBeenCalledWith("theme", "white");


### PR DESCRIPTION
Fixes #2530