### PR TITLE
fix(tooltip-definition): prevent dispatching initial "close" event in Svelte 5

### DIFF
--- a/src/TooltipDefinition/TooltipDefinition.svelte
+++ b/src/TooltipDefinition/TooltipDefinition.svelte
@@ -38,7 +38,14 @@
 
   const show = () => (open = true);
 
-  $: dispatch(open ? "open" : "close");
+  let isInitialRender = true;
+
+  $: {
+    if (!isInitialRender) {
+      dispatch(open ? "open" : "close");
+    }
+    isInitialRender = false;
+  }
 </script>
 
 <svelte:window

--- a/tests/TooltipDefinition/TooltipDefinition.test.ts
+++ b/tests/TooltipDefinition/TooltipDefinition.test.ts
@@ -13,6 +13,24 @@ describe("TooltipDefinition", () => {
     vi.restoreAllMocks();
   });
 
+  // Regression test for initial event dispatch in Svelte 5
+  // https://github.com/carbon-design-system/carbon-components-svelte/issues/2531
+  it("does not fire open/close event on initial render", () => {
+    render(TooltipDefinition);
+
+    expect(consoleLog).not.toHaveBeenCalledWith("open");
+    expect(consoleLog).not.toHaveBeenCalledWith("close");
+  });
+
+  // Regression test for initial event dispatch in Svelte 5
+  // https://github.com/carbon-design-system/carbon-components-svelte/issues/2531
+  it("does not fire open/close event on initial render when open is true", () => {
+    render(TooltipDefinition, { props: { open: true } });
+
+    expect(consoleLog).not.toHaveBeenCalledWith("open");
+    expect(consoleLog).not.toHaveBeenCalledWith("close");
+  });
+
   it("should render with default props", () => {
     render(TooltipDefinition);
 


### PR DESCRIPTION
Fixes #2531