### PR TITLE
fix(header-search): prevent dispatching initial "inactive" event in Svelte 5

### DIFF
--- a/src/UIShell/HeaderSearch.svelte
+++ b/src/UIShell/HeaderSearch.svelte
@@ -42,6 +42,7 @@
   const dispatch = createEventDispatcher();
 
   let refSearch = null;
+  let prevActive;
 
   function reset() {
     active = false;
@@ -56,7 +57,12 @@
 
   $: if (active && ref) ref.focus();
   $: if (!active && ref) ref.blur();
-  $: dispatch(active ? "active" : "inactive");
+  $: {
+    if (prevActive !== undefined) {
+      dispatch(active ? "active" : "inactive");
+    }
+    prevActive = active;
+  }
   $: selectedResult = results[selectedResultIndex];
   $: selectedId = selectedResult
     ? `search-menuitem-${selectedResultIndex}`

--- a/tests/UIShell/HeaderSearch.test.ts
+++ b/tests/UIShell/HeaderSearch.test.ts
@@ -7,6 +7,24 @@ describe("HeaderSearch", () => {
     vi.clearAllMocks();
   });
 
+  // Regression test for initial event dispatch in Svelte 5
+  // https://github.com/carbon-design-system/carbon-components-svelte/issues/2532
+  it("does not fire active/inactive event on initial render", () => {
+    render(HeaderSearchTest);
+
+    expect(screen.getByTestId("active-event")).toHaveTextContent("false");
+    expect(screen.getByTestId("inactive-event")).toHaveTextContent("false");
+  });
+
+  // Regression test for initial event dispatch in Svelte 5
+  // https://github.com/carbon-design-system/carbon-components-svelte/issues/2532
+  it("does not fire active/inactive event on initial render when active is true", () => {
+    render(HeaderSearchTest, { props: { active: true } });
+
+    expect(screen.getByTestId("active-event")).toHaveTextContent("false");
+    expect(screen.getByTestId("inactive-event")).toHaveTextContent("false");
+  });
+
   describe("Rendering", () => {
     it("should render with default props", () => {
       render(HeaderSearchTest);


### PR DESCRIPTION
Fixes #2532