### PR TITLE
fix(side-nav): prevent dispatching initial "close" event in Svelte 5

### DIFF
--- a/src/UIShell/SideNav.svelte
+++ b/src/UIShell/SideNav.svelte
@@ -42,8 +42,12 @@
   const dispatch = createEventDispatcher();
 
   let winWidth = undefined;
+  let prevIsOpen = isOpen;
 
-  $: dispatch(isOpen ? "open" : "close");
+  $: if (prevIsOpen !== isOpen) {
+    dispatch(isOpen ? "open" : "close");
+    prevIsOpen = isOpen;
+  }
   $: $isSideNavCollapsed = !isOpen;
   $: $isSideNavRail = rail;
   $: $isSideNavMobile =

--- a/tests/UIShell/UIShell.test.ts
+++ b/tests/UIShell/UIShell.test.ts
@@ -232,6 +232,30 @@ describe("UIShell", () => {
   });
 
   describe("SideNav", () => {
+    // Regression test for initial event dispatch in Svelte 5
+    // https://github.com/carbon-design-system/carbon-components-svelte/issues/2533
+    it("does not fire open/close event on initial render", () => {
+      const consoleLog = vi.spyOn(console, "log");
+      render(UiShell, {
+        props: { sideNavIsOpen: false },
+      });
+
+      expect(consoleLog).not.toHaveBeenCalledWith("sidenav-open");
+      expect(consoleLog).not.toHaveBeenCalledWith("sidenav-close");
+    });
+
+    // Regression test for initial event dispatch in Svelte 5
+    // https://github.com/carbon-design-system/carbon-components-svelte/issues/2533
+    it("does not fire open/close event on initial render when isOpen is true", () => {
+      const consoleLog = vi.spyOn(console, "log");
+      render(UiShell, {
+        props: { sideNavIsOpen: true },
+      });
+
+      expect(consoleLog).not.toHaveBeenCalledWith("sidenav-open");
+      expect(consoleLog).not.toHaveBeenCalledWith("sidenav-close");
+    });
+
     it("should render with default props", () => {
       const { container } = render(UiShell);
 


### PR DESCRIPTION
Fixes #2533, closes #2534