### PR TITLE
docs(style): code blocks match theme

### DIFF
--- a/docs/src/components/Preview.svelte
+++ b/docs/src/components/Preview.svelte
@@ -57,7 +57,7 @@
   }
 
   .code-override {
-    border: 1px solid #262626;
+    border: 1px solid var(--cds-ui-03);
   }
 
   .preview-viewer {

--- a/docs/src/global.css
+++ b/docs/src/global.css
@@ -4,9 +4,16 @@ html[theme="g90"] .code-override {
 
 .prose > pre,
 .code-override .bx--snippet {
-  /** Docs code snippet is always dark mode */
   color-scheme: dark;
   max-width: none;
+}
+
+/* Light themes use light color scheme */
+[theme="white"] .prose > pre,
+[theme="g10"] .prose > pre,
+[theme="white"] .code-override .bx--snippet,
+[theme="g10"] .code-override .bx--snippet {
+  color-scheme: light;
 }
 
 .prose > pre {
@@ -14,11 +21,12 @@ html[theme="g90"] .code-override {
   margin-bottom: 1rem;
 }
 
+/* Dark theme code block styles (default for g80, g90, g100) */
 .prose > pre,
 .code-override .bx--copy-btn,
 .code-override .bx--snippet,
 .code-override button.bx--btn.bx--snippet-btn--expand {
-  background-color: #262626;
+  background-color: var(--cds-ui-background);
   color: #f4f4f4;
 }
 
@@ -29,6 +37,31 @@ html[theme="g90"] .code-override {
 
 .code-override .bx--snippet__icon {
   fill: #f4f4f4;
+}
+
+/* Light theme code block styles (white, g10) */
+[theme="white"] .prose > pre,
+[theme="g10"] .prose > pre,
+[theme="white"] .code-override .bx--copy-btn,
+[theme="g10"] .code-override .bx--copy-btn,
+[theme="white"] .code-override .bx--snippet,
+[theme="g10"] .code-override .bx--snippet,
+[theme="white"] button.bx--btn.bx--snippet-btn--expand,
+[theme="g10"] button.bx--btn.bx--snippet-btn--expand {
+  background-color: var(--cds-ui-background);
+  color: var(--cds-text-01, #161616);
+}
+
+[theme="white"] .code-override .bx--copy-btn:hover,
+[theme="g10"] .code-override .bx--copy-btn:hover,
+[theme="white"] button.bx--btn.bx--snippet-btn--expand:hover,
+[theme="g10"] button.bx--btn.bx--snippet-btn--expand:hover {
+  background-color: var(--cds-field-hover-01, #e8e8e8);
+}
+
+[theme="white"] .code-override .bx--snippet__icon,
+[theme="g10"] .code-override .bx--snippet__icon {
+  fill: var(--cds-icon-01, #161616);
 }
 
 .prose > pre,
@@ -53,15 +86,16 @@ html[theme="g90"] .code-override {
   color: #6ea6ff;
 }
 
-/* Override syntax highlighting for light theme inline code .*/
-[theme="white"] .code-override-inline .token,
-[theme="g10"] .code-override-inline .token {
-  color: var(--cds-text-01, #161616);
+/* Light theme inline code background */
+[theme="white"] .code-override-inline,
+[theme="g10"] .code-override-inline {
+  background-color: var(--cds-field-01, #f4f4f4);
 }
 
 /** Gray 80 is the "lighted" dark theme. Ensure the background is dark. */
+[theme="g80"] .code-override,
 [theme="g80"] .code-override-inline {
-  background-color: #262626;
+  background-color: var(--cds-ui-background);
 }
 
 .token.builtin,
@@ -106,14 +140,72 @@ html[theme="g90"] .code-override {
   color: #bebebe;
 }
 
+/* Light theme syntax highlighting (white, g10) */
+[theme="white"] .token.tag,
+[theme="g10"] .token.tag,
+[theme="white"] .token.operator,
+[theme="g10"] .token.operator {
+  color: #0043ce; /* blue 70 */
+}
+
+[theme="white"] .token.builtin,
+[theme="g10"] .token.builtin,
+[theme="white"] .token.attr-name,
+[theme="g10"] .token.attr-name {
+  color: #005d5d; /* teal 70 */
+}
+
+[theme="white"] .token.function,
+[theme="g10"] .token.function {
+  color: #007d79; /* teal 60 */
+}
+
+[theme="white"] .token.token.language-javascript,
+[theme="g10"] .token.token.language-javascript,
+[theme="white"] .token.attr-value,
+[theme="g10"] .token.attr-value {
+  color: #8a3ffc; /* purple 60 */
+}
+
+[theme="white"] .token.keyword,
+[theme="g10"] .token.keyword {
+  color: #6929c4; /* purple 70 */
+}
+
+[theme="white"] .token.punctuation,
+[theme="g10"] .token.punctuation {
+  color: #525252; /* gray 70 */
+}
+
+[theme="white"] .token.script .token.language-javascript,
+[theme="g10"] .token.script .token.language-javascript {
+  color: #005d5d; /* teal 70 */
+}
+
+[theme="white"] .token.string,
+[theme="g10"] .token.string {
+  color: #9f1853; /* magenta 70 */
+}
+
+[theme="white"] .token.boolean,
+[theme="g10"] .token.boolean {
+  color: #6929c4; /* purple 70 */
+}
+
+[theme="white"] .token.number,
+[theme="g10"] .token.number {
+  color: #0e6027; /* green 70 */
+}
+
+[theme="white"] .token.comment,
+[theme="g10"] .token.comment {
+  color: #6f6f6f; /* gray 60 */
+}
+
 .override-tabs a.bx--tabs__nav-link,
 .override-tabs a.bx--tabs__nav-link:focus,
 .override-tabs a.bx--tabs__nav-link:active {
   width: auto !important;
-}
-
-#select-theme {
-  width: auto;
 }
 
 /*
@@ -192,14 +284,6 @@ html[theme="g90"] .code-override {
 
 #select-theme {
   width: auto;
-}
-
-.prose > p > .bx--link {
-  font-size: inherit;
-}
-
-.prose .toc {
-  margin-bottom: var(--cds-layout-01);
 }
 
 .code-01 {


### PR DESCRIPTION
This updates the documentation code block styles to be properly themed.

This helps primarily with Gestalt: dark code blocks on a light theme steal visual focus. Theming the code blocks emphasizes the actual code examples.

The remaining piece for full "theming" remains #2490.

---

## Before
<img width="800" height="813" alt="Screenshot 2026-01-19 at 3 30 39 PM" src="https://github.com/user-attachments/assets/9f0f7d18-e8d2-47e5-8a71-fcea23415647" />

## After
<img width="800" height="810" alt="Screenshot 2026-01-19 at 3 30 49 PM" src="https://github.com/user-attachments/assets/7180abcb-b5f5-4e1d-9f98-1a6e09e52a7e" />
