### PR TITLE
feat(combo-box)!: `ComboBoxItemId` is generic, defaulting to `any`

### DIFF
--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -654,10 +654,8 @@ None.
 ### Types
 
 ```ts
-export type ComboBoxItemId = any;
-
-export type ComboBoxItem = {
-  id: ComboBoxItemId;
+export type ComboBoxItem<Id = any> = {
+  id: Id;
   text: string;
   /** Whether the item is disabled */ disabled?: boolean;
 };
@@ -671,7 +669,7 @@ export type ComboBoxItem = {
 | ref                      | No       | <code>let</code>      | Yes      | <code>null &#124; HTMLInputElement</code>                                                             | <code>null</code>                                  | Obtain a reference to the input HTML element                                                                                                                                                                                                                                                                                                                                                                                        |
 | open                     | No       | <code>let</code>      | Yes      | <code>boolean</code>                                                                                  | <code>false</code>                                 | Set to `true` to open the combobox menu dropdown                                                                                                                                                                                                                                                                                                                                                                                    |
 | value                    | No       | <code>let</code>      | Yes      | <code>string</code>                                                                                   | <code>""</code>                                    | Specify the selected combobox value                                                                                                                                                                                                                                                                                                                                                                                                 |
-| selectedId               | No       | <code>let</code>      | Yes      | <code>ComboBoxItemId</code>                                                                           | <code>undefined</code>                             | Set the selected item by value id.                                                                                                                                                                                                                                                                                                                                                                                                  |
+| selectedId               | No       | <code>let</code>      | Yes      | <code>Item["id"]</code>                                                                               | <code>undefined</code>                             | Set the selected item by value id.                                                                                                                                                                                                                                                                                                                                                                                                  |
 | items                    | No       | <code>let</code>      | No       | <code>ReadonlyArray<Item></code>                                                                      | <code>[]</code>                                    | Set the combobox items.                                                                                                                                                                                                                                                                                                                                                                                                             |
 | itemToString             | No       | <code>let</code>      | No       | <code>(item: Item) => string</code>                                                                   | --                                                 | Override the display of a combobox item.                                                                                                                                                                                                                                                                                                                                                                                            |
 | direction                | No       | <code>let</code>      | No       | <code>"bottom" &#124; "top"</code>                                                                    | <code>"bottom"</code>                              | Specify the direction of the combobox dropdown menu.                                                                                                                                                                                                                                                                                                                                                                                |
@@ -705,17 +703,17 @@ export type ComboBoxItem = {
 
 ### Events
 
-| Event name | Type       | Detail                                                           | Description |
-| :--------- | :--------- | :--------------------------------------------------------------- | :---------- |
-| select     | dispatched | <code>{ selectedId: ComboBoxItemId; selectedItem: Item; }</code> | --          |
-| clear      | forwarded  | --                                                               | --          |
-| input      | forwarded  | --                                                               | --          |
-| keydown    | forwarded  | --                                                               | --          |
-| keyup      | forwarded  | --                                                               | --          |
-| focus      | forwarded  | --                                                               | --          |
-| blur       | forwarded  | --                                                               | --          |
-| paste      | forwarded  | --                                                               | --          |
-| scroll     | forwarded  | --                                                               | --          |
+| Event name | Type       | Detail                                                       | Description |
+| :--------- | :--------- | :----------------------------------------------------------- | :---------- |
+| select     | dispatched | <code>{ selectedId: Item["id"]; selectedItem: Item; }</code> | --          |
+| clear      | forwarded  | --                                                           | --          |
+| input      | forwarded  | --                                                           | --          |
+| keydown    | forwarded  | --                                                           | --          |
+| keyup      | forwarded  | --                                                           | --          |
+| focus      | forwarded  | --                                                           | --          |
+| blur       | forwarded  | --                                                           | --          |
+| paste      | forwarded  | --                                                           | --          |
+| scroll     | forwarded  | --                                                           | --          |
 
 ## `ComposedModal`
 

--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -1863,7 +1863,7 @@
           "name": "selectedId",
           "kind": "let",
           "description": "Set the selected item by value id.",
-          "type": "ComboBoxItemId",
+          "type": "Item[\"id\"]",
           "value": "undefined",
           "isFunction": false,
           "isFunctionDeclaration": false,
@@ -2189,7 +2189,7 @@
         {
           "type": "dispatched",
           "name": "select",
-          "detail": "{\n  selectedId: ComboBoxItemId;\n  selectedItem: Item;\n}"
+          "detail": "{\n  selectedId: Item[\"id\"];\n  selectedItem: Item;\n}"
         },
         {
           "type": "forwarded",
@@ -2235,19 +2235,14 @@
       ],
       "typedefs": [
         {
-          "type": "any",
-          "name": "ComboBoxItemId",
-          "ts": "type ComboBoxItemId = any;\n"
-        },
-        {
-          "type": "{ id: ComboBoxItemId; text: string; /** Whether the item is disabled */ disabled?: boolean; }",
-          "name": "ComboBoxItem",
-          "ts": "type ComboBoxItem = {\n  id: ComboBoxItemId;\n  text: string;\n  /** Whether the item is disabled */ disabled?: boolean;\n};\n"
+          "type": "{ id: Id; text: string; /** Whether the item is disabled */ disabled?: boolean; }",
+          "name": "ComboBoxItem<Id=any>",
+          "ts": "type ComboBoxItem<Id = any> = {\n  id: Id;\n  text: string;\n  /** Whether the item is disabled */ disabled?: boolean;\n};\n"
         }
       ],
       "generics": [
         "Item",
-        "Item extends ComboBoxItem = ComboBoxItem"
+        "Item extends ComboBoxItem<any> = ComboBoxItem<any>"
       ],
       "rest_props": {
         "type": "Element",

--- a/src/ComboBox/ComboBox.svelte
+++ b/src/ComboBox/ComboBox.svelte
@@ -1,15 +1,14 @@
 <script>
   /**
-   * @generics {Item extends ComboBoxItem = ComboBoxItem} Item
-   * @template {ComboBoxItem} Item
-   * @typedef {any} ComboBoxItemId
-   * @typedef {object} ComboBoxItem
-   * @property {ComboBoxItemId} id
+   * @generics {Item extends ComboBoxItem<any> = ComboBoxItem<any>} Item
+   * @template {ComboBoxItem<any>} Item
+   * @typedef {object} ComboBoxItem<Id=any>
+   * @property {Id} id
    * @property {string} text
    * @property {boolean} [disabled] - Whether the item is disabled
    * @event select
    * @type {object}
-   * @property {ComboBoxItemId} selectedId
+   * @property {Item["id"]} selectedId
    * @property {Item} selectedItem
    * @event {KeyboardEvent | MouseEvent} clear
    * @slot {{ item: Item; index: number }}
@@ -29,7 +28,7 @@
 
   /**
    * Set the selected item by value id.
-   * @type {ComboBoxItemId}
+   * @type {Item["id"]}
    */
   export let selectedId = undefined;
 

--- a/tests/ComboBox/ComboBox.test.ts
+++ b/tests/ComboBox/ComboBox.test.ts
@@ -984,6 +984,83 @@ describe("ComboBox", () => {
         readonly ComboBoxItem[]
       >();
     });
+
+    describe("Id generic parameter", () => {
+      it("should default Id to any when not specified", () => {
+        type ComponentType = ComboBoxComponent;
+        type Props = ComponentProps<ComponentType>;
+        type Events = ComponentEvents<ComponentType>;
+
+        // biome-ignore lint/suspicious/noExplicitAny: Testing default any type
+        expectTypeOf<Props["selectedId"]>().toEqualTypeOf<any | undefined>();
+
+        type SelectEvent = Events["select"];
+        type SelectEventDetail =
+          SelectEvent extends CustomEvent<infer T> ? T : never;
+        // biome-ignore lint/suspicious/noExplicitAny: Testing default any type
+        expectTypeOf<SelectEventDetail["selectedId"]>().toEqualTypeOf<any>();
+      });
+
+      it("should support different ID types (string, number, union)", () => {
+        // String ID
+        type StringItem = { id: string; text: string };
+        type StringComponent = ComboBoxComponent<StringItem>;
+        expectTypeOf<
+          ComponentProps<StringComponent>["selectedId"]
+        >().toEqualTypeOf<string | undefined>();
+
+        // Number ID
+        type NumberItem = { id: number; text: string };
+        type NumberComponent = ComboBoxComponent<NumberItem>;
+        expectTypeOf<
+          ComponentProps<NumberComponent>["selectedId"]
+        >().toEqualTypeOf<number | undefined>();
+
+        // Union ID
+        type UnionId = "a" | "b" | "c";
+        type UnionItem = { id: UnionId; text: string };
+        type UnionComponent = ComboBoxComponent<UnionItem>;
+        type UnionEvents = ComponentEvents<UnionComponent>;
+        type UnionSelectDetail =
+          UnionEvents["select"] extends CustomEvent<infer T> ? T : never;
+        expectTypeOf<
+          UnionSelectDetail["selectedId"]
+        >().toEqualTypeOf<UnionId>();
+      });
+
+      it("should work with 'as const' for literal type inference", () => {
+        const items = [
+          { id: "option1", text: "Option 1" },
+          { id: "option2", text: "Option 2" },
+          { id: "option3", text: "Option 3" },
+        ] as const;
+
+        type InferredItem = (typeof items)[number];
+        type InferredId = InferredItem["id"];
+
+        expectTypeOf<InferredId>().toEqualTypeOf<
+          "option1" | "option2" | "option3"
+        >();
+
+        type ComponentType = ComboBoxComponent<InferredItem>;
+        type Props = ComponentProps<ComponentType>;
+        type Events = ComponentEvents<ComponentType>;
+
+        expectTypeOf<Props["selectedId"]>().toEqualTypeOf<
+          InferredId | undefined
+        >();
+
+        type SelectEvent = Events["select"];
+        type SelectEventDetail =
+          SelectEvent extends CustomEvent<infer T> ? T : never;
+        expectTypeOf<
+          SelectEventDetail["selectedId"]
+        >().toEqualTypeOf<InferredId>();
+        expectTypeOf<
+          SelectEventDetail["selectedItem"]
+        >().toEqualTypeOf<InferredItem>();
+      });
+    });
   });
 
   it("supports custom label slot", () => {

--- a/tests/ComboBox/ComboBoxGenerics.test.svelte
+++ b/tests/ComboBox/ComboBoxGenerics.test.svelte
@@ -5,7 +5,7 @@
     { id: "1", text: "Laptop", price: 999, category: "Electronics" },
     { id: "2", text: "Phone", price: 599, category: "Electronics" },
     { id: "3", text: "Desk", price: 299, category: "Furniture" },
-  ];
+  ] as const;
 </script>
 
 <ComboBox
@@ -17,9 +17,9 @@
   }}
   let:item
 >
-  {@const { text, price, category } = item}
+  {@const { id, text, price, category } = item}
   <div>
-    <strong>{text}</strong> - ${price}
+    <strong>{text}</strong> - ${price} - {id}
     <span>({category})</span>
   </div>
 </ComboBox>

--- a/types/ComboBox/ComboBox.svelte.d.ts
+++ b/types/ComboBox/ComboBox.svelte.d.ts
@@ -1,17 +1,15 @@
 import { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-export type ComboBoxItemId = any;
-
-export type ComboBoxItem = {
-  id: ComboBoxItemId;
+export type ComboBoxItem<Id = any> = {
+  id: Id;
   text: string;
   /** Whether the item is disabled */ disabled?: boolean;
 };
 
 type $RestProps = SvelteHTMLElements["input"];
 
-type $Props<Item extends ComboBoxItem = ComboBoxItem> = {
+type $Props<Item extends ComboBoxItem<any> = ComboBoxItem<any>> = {
   /**
    * Set the combobox items.
    * @default []
@@ -27,7 +25,7 @@ type $Props<Item extends ComboBoxItem = ComboBoxItem> = {
    * Set the selected item by value id.
    * @default undefined
    */
-  selectedId?: ComboBoxItemId;
+  selectedId?: Item["id"];
 
   /**
    * Specify the selected combobox value
@@ -188,18 +186,15 @@ type $Props<Item extends ComboBoxItem = ComboBoxItem> = {
   [key: `data-${string}`]: any;
 };
 
-export type ComboBoxProps<Item extends ComboBoxItem = ComboBoxItem> = Omit<
-  $RestProps,
-  keyof $Props<Item>
-> &
-  $Props<Item>;
+export type ComboBoxProps<Item extends ComboBoxItem<any> = ComboBoxItem<any>> =
+  Omit<$RestProps, keyof $Props<Item>> & $Props<Item>;
 
 export default class ComboBox<
-  Item extends ComboBoxItem = ComboBoxItem,
+  Item extends ComboBoxItem<any> = ComboBoxItem<any>,
 > extends SvelteComponentTyped<
   ComboBoxProps<Item>,
   {
-    select: CustomEvent<{ selectedId: ComboBoxItemId; selectedItem: Item }>;
+    select: CustomEvent<{ selectedId: Item["id"]; selectedItem: Item }>;
     clear: CustomEvent<KeyboardEvent | MouseEvent>;
     input: WindowEventMap["input"];
     keydown: WindowEventMap["keydown"];


### PR DESCRIPTION
This makes `ComboBox` id generic, defaulting to `any` (existing type), allowing readonly values to infer the `id`. Now, both the `item.id` and `selectedId` props are generic, falling back to `any`.

This removes the auto-generated `ComboBoxId`, but this is a trivial breaking change.

---

## Destructured items

<img width="644" height="483" alt="Screenshot 2026-01-25 at 1 26 16 PM" src="https://github.com/user-attachments/assets/1ce09a0f-d7bd-4030-8aca-cf0be5e9b744" />

## `selectedId`

<img width="552" height="311" alt="Screenshot 2026-01-25 at 1 40 00 PM" src="https://github.com/user-attachments/assets/428883b3-566a-4590-9334-3617e3e22d74" />

