### PR TITLE
feat(multi-select)!: `MultiSelectItemId` is generic, defaulting to `any`

### DIFF
--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -2441,12 +2441,10 @@ None.
 ### Types
 
 ```ts
-export type MultiSelectItemId = any;
-
 export type MultiSelectItemText = string;
 
-export type MultiSelectItem = {
-  id: MultiSelectItemId;
+export type MultiSelectItem<Id = any> = {
+  id: Id;
   text: MultiSelectItemText;
   /** Whether the item is disabled */ disabled?: boolean;
 };
@@ -2456,14 +2454,14 @@ export type MultiSelectItem = {
 
 | Prop name                | Required | Kind             | Reactive | Type                                                                                                    | Default value                                      | Description                                                                                                                                                            |
 | :----------------------- | :------- | :--------------- | :------- | ------------------------------------------------------------------------------------------------------- | -------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| highlightedId            | No       | <code>let</code> | Yes      | <code>null &#124; MultiSelectItemId</code>                                                              | <code>null</code>                                  | Id of the highlighted ListBoxMenuItem.                                                                                                                                 |
+| highlightedId            | No       | <code>let</code> | Yes      | <code>null &#124; Item["id"]</code>                                                                     | <code>null</code>                                  | Id of the highlighted ListBoxMenuItem.                                                                                                                                 |
 | selectionRef             | No       | <code>let</code> | Yes      | <code>null &#124; HTMLDivElement</code>                                                                 | <code>null</code>                                  | Obtain a reference to the selection element.                                                                                                                           |
 | fieldRef                 | No       | <code>let</code> | Yes      | <code>null &#124; HTMLDivElement</code>                                                                 | <code>null</code>                                  | Obtain a reference to the field box element.                                                                                                                           |
 | multiSelectRef           | No       | <code>let</code> | Yes      | <code>null &#124; HTMLDivElement</code>                                                                 | <code>null</code>                                  | Obtain a reference to the outer div element                                                                                                                            |
 | inputRef                 | No       | <code>let</code> | Yes      | <code>null &#124; HTMLInputElement</code>                                                               | <code>null</code>                                  | Obtain a reference to the input HTML element                                                                                                                           |
 | open                     | No       | <code>let</code> | Yes      | <code>boolean</code>                                                                                    | <code>false</code>                                 | Set to `true` to open the dropdown                                                                                                                                     |
 | value                    | No       | <code>let</code> | Yes      | <code>string</code>                                                                                     | <code>""</code>                                    | Specify the multiselect value                                                                                                                                          |
-| selectedIds              | No       | <code>let</code> | Yes      | <code>ReadonlyArray<MultiSelectItemId></code>                                                           | <code>[]</code>                                    | Set the selected ids.                                                                                                                                                  |
+| selectedIds              | No       | <code>let</code> | Yes      | <code>ReadonlyArray<Item["id"]></code>                                                                  | <code>[]</code>                                    | Set the selected ids.                                                                                                                                                  |
 | items                    | No       | <code>let</code> | No       | <code>ReadonlyArray<Item></code>                                                                        | <code>[]</code>                                    | Set the multiselect items.                                                                                                                                             |
 | itemToString             | No       | <code>let</code> | No       | <code>(item: Item) => any</code>                                                                        | --                                                 | Override the display of a multiselect item.                                                                                                                            |
 | itemToInput              | No       | <code>let</code> | No       | <code>(item: Item) => { name?: string; labelText?: any; title?: string; value?: string }</code>         | --                                                 | Override the item name, title, labelText, or value passed to the user-selectable checkbox input as well as the hidden inputs.                                          |
@@ -2501,16 +2499,16 @@ export type MultiSelectItem = {
 
 ### Events
 
-| Event name | Type       | Detail                                                                                   | Description |
-| :--------- | :--------- | :--------------------------------------------------------------------------------------- | :---------- |
-| select     | dispatched | <code>{ selectedIds: MultiSelectItemId[]; selected: Item[]; unselected: Item[]; }</code> | --          |
-| clear      | forwarded  | --                                                                                       | --          |
-| blur       | dispatched | <code>FocusEvent &#124; CustomEvent<FocusEvent></code>                                   | --          |
-| keydown    | forwarded  | --                                                                                       | --          |
-| input      | forwarded  | --                                                                                       | --          |
-| keyup      | forwarded  | --                                                                                       | --          |
-| focus      | forwarded  | --                                                                                       | --          |
-| paste      | forwarded  | --                                                                                       | --          |
+| Event name | Type       | Detail                                                                            | Description |
+| :--------- | :--------- | :-------------------------------------------------------------------------------- | :---------- |
+| select     | dispatched | <code>{ selectedIds: Item["id"][]; selected: Item[]; unselected: Item[]; }</code> | --          |
+| clear      | forwarded  | --                                                                                | --          |
+| blur       | dispatched | <code>FocusEvent &#124; CustomEvent<FocusEvent></code>                            | --          |
+| keydown    | forwarded  | --                                                                                | --          |
+| input      | forwarded  | --                                                                                | --          |
+| keyup      | forwarded  | --                                                                                | --          |
+| focus      | forwarded  | --                                                                                | --          |
+| paste      | forwarded  | --                                                                                | --          |
 
 ## `NotificationActionButton`
 

--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -9347,7 +9347,7 @@
           "name": "selectedIds",
           "kind": "let",
           "description": "Set the selected ids.",
-          "type": "ReadonlyArray<MultiSelectItemId>",
+          "type": "ReadonlyArray<Item[\"id\"]>",
           "value": "[]",
           "isFunction": false,
           "isFunctionDeclaration": false,
@@ -9717,7 +9717,7 @@
           "name": "highlightedId",
           "kind": "let",
           "description": "Id of the highlighted ListBoxMenuItem.",
-          "type": "null | MultiSelectItemId",
+          "type": "null | Item[\"id\"]",
           "value": "null",
           "isFunction": false,
           "isFunctionDeclaration": false,
@@ -9745,7 +9745,7 @@
         {
           "type": "dispatched",
           "name": "select",
-          "detail": "{\n  selectedIds: MultiSelectItemId[];\n  selected: Item[];\n  unselected: Item[];\n}"
+          "detail": "{\n  selectedIds: Item[\"id\"][];\n  selected: Item[];\n  unselected: Item[];\n}"
         },
         {
           "type": "forwarded",
@@ -9786,24 +9786,19 @@
       ],
       "typedefs": [
         {
-          "type": "any",
-          "name": "MultiSelectItemId",
-          "ts": "type MultiSelectItemId = any;\n"
-        },
-        {
           "type": "string",
           "name": "MultiSelectItemText",
           "ts": "type MultiSelectItemText = string;\n"
         },
         {
-          "type": "{ id: MultiSelectItemId; text: MultiSelectItemText; /** Whether the item is disabled */ disabled?: boolean; }",
-          "name": "MultiSelectItem",
-          "ts": "type MultiSelectItem = {\n  id: MultiSelectItemId;\n  text: MultiSelectItemText;\n  /** Whether the item is disabled */ disabled?: boolean;\n};\n"
+          "type": "{ id: Id; text: MultiSelectItemText; /** Whether the item is disabled */ disabled?: boolean; }",
+          "name": "MultiSelectItem<Id=any>",
+          "ts": "type MultiSelectItem<Id = any> = {\n  id: Id;\n  text: MultiSelectItemText;\n  /** Whether the item is disabled */ disabled?: boolean;\n};\n"
         }
       ],
       "generics": [
         "Item",
-        "Item extends MultiSelectItem = MultiSelectItem"
+        "Item extends MultiSelectItem<any> = MultiSelectItem<any>"
       ],
       "rest_props": {
         "type": "Element",

--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -1,16 +1,15 @@
 <script>
   /**
-   * @generics {Item extends MultiSelectItem = MultiSelectItem} Item
-   * @template {MultiSelectItem} Item
-   * @typedef {any} MultiSelectItemId
+   * @generics {Item extends MultiSelectItem<any> = MultiSelectItem<any>} Item
+   * @template {MultiSelectItem<any>} Item
    * @typedef {string} MultiSelectItemText
-   * @typedef {object} MultiSelectItem
-   * @property {MultiSelectItemId} id
+   * @typedef {object} MultiSelectItem<Id=any>
+   * @property {Id} id
    * @property {MultiSelectItemText} text
    * @property {boolean} [disabled] - Whether the item is disabled
    * @event select
    * @type {object}
-   * @property {MultiSelectItemId[]} selectedIds
+   * @property {Item["id"][]} selectedIds
    * @property {Item[]} selected
    * @property {Item[]} unselected
    * @event {null} clear
@@ -38,7 +37,7 @@
 
   /**
    * Set the selected ids.
-   * @type {ReadonlyArray<MultiSelectItemId>}
+   * @type {ReadonlyArray<Item["id"]>}
    */
   export let selectedIds = [];
 
@@ -173,7 +172,7 @@
 
   /**
    * Id of the highlighted ListBoxMenuItem.
-   * @type {null | MultiSelectItemId}
+   * @type {null | Item["id"]}
    */
   export let highlightedId = null;
 

--- a/tests/MultiSelect/MultiSelect.test.ts
+++ b/tests/MultiSelect/MultiSelect.test.ts
@@ -1013,6 +1013,85 @@ describe("MultiSelect", () => {
         readonly MultiSelectItem[]
       >();
     });
+
+    describe("Id generic parameter", () => {
+      it("should default Id to any when not specified", () => {
+        type ComponentType = MultiSelectComponent;
+        type Props = ComponentProps<ComponentType>;
+        type Events = ComponentEvents<ComponentType>;
+
+        expectTypeOf<Props["selectedIds"]>().toEqualTypeOf<
+          // biome-ignore lint/suspicious/noExplicitAny: Testing default any type
+          readonly any[] | undefined
+        >();
+
+        type SelectEvent = Events["select"];
+        type SelectEventDetail =
+          SelectEvent extends CustomEvent<infer T> ? T : never;
+        // biome-ignore lint/suspicious/noExplicitAny: Testing default any type
+        expectTypeOf<SelectEventDetail["selectedIds"]>().toEqualTypeOf<any[]>();
+      });
+
+      it("should support different ID types (string, number, union)", () => {
+        // String ID
+        type StringItem = { id: string; text: string };
+        type StringComponent = MultiSelectComponent<StringItem>;
+        expectTypeOf<
+          ComponentProps<StringComponent>["selectedIds"]
+        >().toEqualTypeOf<readonly string[] | undefined>();
+
+        // Number ID
+        type NumberItem = { id: number; text: string };
+        type NumberComponent = MultiSelectComponent<NumberItem>;
+        expectTypeOf<
+          ComponentProps<NumberComponent>["selectedIds"]
+        >().toEqualTypeOf<readonly number[] | undefined>();
+
+        // Union ID
+        type UnionId = "a" | "b" | "c";
+        type UnionItem = { id: UnionId; text: string };
+        type UnionComponent = MultiSelectComponent<UnionItem>;
+        type UnionEvents = ComponentEvents<UnionComponent>;
+        type UnionSelectDetail =
+          UnionEvents["select"] extends CustomEvent<infer T> ? T : never;
+        expectTypeOf<UnionSelectDetail["selectedIds"]>().toEqualTypeOf<
+          UnionId[]
+        >();
+      });
+
+      it("should work with 'as const' for literal type inference", () => {
+        const items = [
+          { id: "option1", text: "Option 1" },
+          { id: "option2", text: "Option 2" },
+          { id: "option3", text: "Option 3" },
+        ] as const;
+
+        type InferredItem = (typeof items)[number];
+        type InferredId = InferredItem["id"];
+
+        expectTypeOf<InferredId>().toEqualTypeOf<
+          "option1" | "option2" | "option3"
+        >();
+
+        type ComponentType = MultiSelectComponent<InferredItem>;
+        type Props = ComponentProps<ComponentType>;
+        type Events = ComponentEvents<ComponentType>;
+
+        expectTypeOf<Props["selectedIds"]>().toEqualTypeOf<
+          readonly InferredId[] | undefined
+        >();
+
+        type SelectEvent = Events["select"];
+        type SelectEventDetail =
+          SelectEvent extends CustomEvent<infer T> ? T : never;
+        expectTypeOf<SelectEventDetail["selectedIds"]>().toEqualTypeOf<
+          InferredId[]
+        >();
+        expectTypeOf<
+          SelectEventDetail["selected"][0]
+        >().toEqualTypeOf<InferredItem>();
+      });
+    });
   });
 
   it("supports custom label slot", () => {

--- a/tests/MultiSelect/MultiSelectGenerics.test.svelte
+++ b/tests/MultiSelect/MultiSelectGenerics.test.svelte
@@ -5,7 +5,7 @@
     { id: "1", text: "Laptop", price: 999, category: "Electronics" },
     { id: "2", text: "Phone", price: 599, category: "Electronics" },
     { id: "3", text: "Desk", price: 299, category: "Furniture" },
-  ];
+  ] as const;
 </script>
 
 <MultiSelect
@@ -17,9 +17,9 @@
   }}
   let:item
 >
-  {@const { text, price, category } = item}
+  {@const { id, text, price, category } = item}
   <div>
-    <strong>{text}</strong> - ${price}
+    <strong>{text}</strong> - ${price} - {id}
     <span>({category})</span>
   </div>
 </MultiSelect>

--- a/types/MultiSelect/MultiSelect.svelte.d.ts
+++ b/types/MultiSelect/MultiSelect.svelte.d.ts
@@ -1,12 +1,10 @@
 import { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-export type MultiSelectItemId = any;
-
 export type MultiSelectItemText = string;
 
-export type MultiSelectItem = {
-  id: MultiSelectItemId;
+export type MultiSelectItem<Id = any> = {
+  id: Id;
   text: MultiSelectItemText;
   /** Whether the item is disabled */ disabled?: boolean;
 };
@@ -20,7 +18,7 @@ export type MultiSelectContext = {
 
 type $RestProps = SvelteHTMLElements["input"];
 
-type $Props<Item extends MultiSelectItem = MultiSelectItem> = {
+type $Props<Item extends MultiSelectItem<any> = MultiSelectItem<any>> = {
   /**
    * Set the multiselect items.
    * @default []
@@ -46,7 +44,7 @@ type $Props<Item extends MultiSelectItem = MultiSelectItem> = {
    * Set the selected ids.
    * @default []
    */
-  selectedIds?: ReadonlyArray<MultiSelectItemId>;
+  selectedIds?: ReadonlyArray<Item["id"]>;
 
   /**
    * Specify the multiselect value
@@ -238,7 +236,7 @@ type $Props<Item extends MultiSelectItem = MultiSelectItem> = {
    * Id of the highlighted ListBoxMenuItem.
    * @default null
    */
-  highlightedId?: null | MultiSelectItemId;
+  highlightedId?: null | Item["id"];
 
   labelChildren?: (this: void) => void;
 
@@ -247,16 +245,17 @@ type $Props<Item extends MultiSelectItem = MultiSelectItem> = {
   [key: `data-${string}`]: any;
 };
 
-export type MultiSelectProps<Item extends MultiSelectItem = MultiSelectItem> =
-  Omit<$RestProps, keyof $Props<Item>> & $Props<Item>;
+export type MultiSelectProps<
+  Item extends MultiSelectItem<any> = MultiSelectItem<any>,
+> = Omit<$RestProps, keyof $Props<Item>> & $Props<Item>;
 
 export default class MultiSelect<
-  Item extends MultiSelectItem = MultiSelectItem,
+  Item extends MultiSelectItem<any> = MultiSelectItem<any>,
 > extends SvelteComponentTyped<
   MultiSelectProps<Item>,
   {
     select: CustomEvent<{
-      selectedIds: MultiSelectItemId[];
+      selectedIds: Item["id"][];
       selected: Item[];
       unselected: Item[];
     }>;


### PR DESCRIPTION
This makes `MultiSelectItem` id generic, allowing readonly values to infer the id type. Now, both the `item.id` and `selectedIds` props are generic, falling back to `any`. The auto-generated `MultiSelectItemId` typedef has been removed (trivial breaking change).

This change mirrors the implementation in the ComboBox component (PR #2564) and includes comprehensive type tests.

---

<img width="647" height="525" alt="Screenshot 2026-01-25 at 2 15 08 PM" src="https://github.com/user-attachments/assets/9c35c683-6ed7-4799-b05a-103542dd2368" />

