### PR TITLE
feat(dropdown)!: `DropdownItem` id generic, defaulting to `any`

### DIFF
--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -1209,13 +1209,9 @@ None.
 ### Types
 
 ```ts
-export type DropdownItemId = any;
-
-export type DropdownItemText = string;
-
-export type DropdownItem = {
-  id: DropdownItemId;
-  text: DropdownItemText;
+export type DropdownItem<Id = any> = {
+  id: Id;
+  text: string;
   /** Whether the item is disabled */ disabled?: boolean;
 };
 ```
@@ -1226,7 +1222,7 @@ export type DropdownItem = {
 | :-------------- | :------- | :--------------- | :------- | ----------------------------------------------------------------------------------------------------- | -------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
 | ref             | No       | <code>let</code> | Yes      | <code>null &#124; HTMLButtonElement</code>                                                            | <code>null</code>                                  | Obtain a reference to the button HTML element                                                                                 |
 | open            | No       | <code>let</code> | Yes      | <code>boolean</code>                                                                                  | <code>false</code>                                 | Set to `true` to open the dropdown                                                                                            |
-| selectedId      | Yes      | <code>let</code> | Yes      | <code>DropdownItemId</code>                                                                           | --                                                 | Specify the selected item id.                                                                                                 |
+| selectedId      | Yes      | <code>let</code> | Yes      | <code>Item["id"]</code>                                                                               | --                                                 | Specify the selected item id.                                                                                                 |
 | items           | No       | <code>let</code> | No       | <code>ReadonlyArray<Item></code>                                                                      | <code>[]</code>                                    | Set the dropdown items.                                                                                                       |
 | itemToString    | No       | <code>let</code> | No       | <code>(item: Item) => string</code>                                                                   | --                                                 | Override the display of a dropdown item.                                                                                      |
 | type            | No       | <code>let</code> | No       | <code>"default" &#124; "inline"</code>                                                                | <code>"default"</code>                             | Specify the type of dropdown.                                                                                                 |
@@ -1254,9 +1250,9 @@ export type DropdownItem = {
 
 ### Events
 
-| Event name | Type       | Detail                                                           | Description |
-| :--------- | :--------- | :--------------------------------------------------------------- | :---------- |
-| select     | dispatched | <code>{ selectedId: DropdownItemId; selectedItem: Item; }</code> | --          |
+| Event name | Type       | Detail                                                       | Description |
+| :--------- | :--------- | :----------------------------------------------------------- | :---------- |
+| select     | dispatched | <code>{ selectedId: Item["id"]; selectedItem: Item; }</code> | --          |
 
 ## `DropdownSkeleton`
 

--- a/docs/src/COMPONENT_API.json
+++ b/docs/src/COMPONENT_API.json
@@ -4484,7 +4484,7 @@
           "name": "selectedId",
           "kind": "let",
           "description": "Specify the selected item id.",
-          "type": "DropdownItemId",
+          "type": "Item[\"id\"]",
           "isFunction": false,
           "isFunctionDeclaration": false,
           "isRequired": true,
@@ -4721,29 +4721,19 @@
         {
           "type": "dispatched",
           "name": "select",
-          "detail": "{\n  selectedId: DropdownItemId;\n  selectedItem: Item;\n}"
+          "detail": "{\n  selectedId: Item[\"id\"];\n  selectedItem: Item;\n}"
         }
       ],
       "typedefs": [
         {
-          "type": "any",
-          "name": "DropdownItemId",
-          "ts": "type DropdownItemId = any;\n"
-        },
-        {
-          "type": "string",
-          "name": "DropdownItemText",
-          "ts": "type DropdownItemText = string;\n"
-        },
-        {
-          "type": "{ id: DropdownItemId; text: DropdownItemText; /** Whether the item is disabled */ disabled?: boolean; }",
-          "name": "DropdownItem",
-          "ts": "type DropdownItem = {\n  id: DropdownItemId;\n  text: DropdownItemText;\n  /** Whether the item is disabled */ disabled?: boolean;\n};\n"
+          "type": "{ id: Id; text: string; /** Whether the item is disabled */ disabled?: boolean; }",
+          "name": "DropdownItem<Id=any>",
+          "ts": "type DropdownItem<Id = any> = {\n  id: Id;\n  text: string;\n  /** Whether the item is disabled */ disabled?: boolean;\n};\n"
         }
       ],
       "generics": [
         "Item",
-        "Item extends DropdownItem = DropdownItem"
+        "Item extends DropdownItem<any> = DropdownItem<any>"
       ],
       "rest_props": {
         "type": "Element",

--- a/src/Dropdown/Dropdown.svelte
+++ b/src/Dropdown/Dropdown.svelte
@@ -1,16 +1,14 @@
 <script>
   /**
-   * @generics {Item extends DropdownItem = DropdownItem} Item
-   * @template {DropdownItem} Item
-   * @typedef {any} DropdownItemId
-   * @typedef {string} DropdownItemText
-   * @typedef {object} DropdownItem
-   * @property {DropdownItemId} id
-   * @property {DropdownItemText} text
+   * @generics {Item extends DropdownItem<any> = DropdownItem<any>} Item
+   * @template {DropdownItem<any>} Item
+   * @typedef {object} DropdownItem<Id=any>
+   * @property {Id} id
+   * @property {string} text
    * @property {boolean} [disabled] - Whether the item is disabled
    * @event select
    * @type {object}
-   * @property {DropdownItemId} selectedId
+   * @property {Item["id"]} selectedId
    * @property {Item} selectedItem
    * @slot {{ item: Item; index: number; }}
    */
@@ -29,7 +27,7 @@
 
   /**
    * Specify the selected item id.
-   * @type {DropdownItemId}
+   * @type {Item["id"]}
    */
   export let selectedId;
 

--- a/tests/Dropdown/DropdownGenerics.test.svelte
+++ b/tests/Dropdown/DropdownGenerics.test.svelte
@@ -1,26 +1,26 @@
-  <script lang="ts">
+<script lang="ts">
   import { Dropdown } from "carbon-components-svelte";
 
   const items = [
     { id: "1", text: "Laptop", price: 999, category: "Electronics" },
     { id: "2", text: "Phone", price: 599, category: "Electronics" },
     { id: "3", text: "Desk", price: 299, category: "Furniture" },
-  ];
+  ] as const;
 </script>
 
-  <Dropdown
-    {items}
-    selectedId={undefined}
-    label="Choose a product"
-    labelText="Products"
-    on:select={(e) => {
-      console.log("selected:", e.detail.selectedItem);
-    }}
-    let:item
-  >
-    {@const { text, price, category } = item}
-    <div>
-      <strong>{text}</strong> - ${price}
-      <span>({category})</span>
-    </div>
-  </Dropdown>
+<Dropdown
+  {items}
+  selectedId="1"
+  label="Choose a product"
+  labelText="Products"
+  on:select={(e) => {
+    console.log("selected:", e.detail.selectedItem);
+  }}
+  let:item
+>
+  {@const { id, text, price, category } = item}
+  <div>
+    <strong>{text}</strong> - ${price} - {id}
+    <span>({category})</span>
+  </div>
+</Dropdown>

--- a/types/Dropdown/Dropdown.svelte.d.ts
+++ b/types/Dropdown/Dropdown.svelte.d.ts
@@ -1,19 +1,15 @@
 import { SvelteComponentTyped } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 
-export type DropdownItemId = any;
-
-export type DropdownItemText = string;
-
-export type DropdownItem = {
-  id: DropdownItemId;
-  text: DropdownItemText;
+export type DropdownItem<Id = any> = {
+  id: Id;
+  text: string;
   /** Whether the item is disabled */ disabled?: boolean;
 };
 
 type $RestProps = SvelteHTMLElements["div"];
 
-type $Props<Item extends DropdownItem = DropdownItem> = {
+type $Props<Item extends DropdownItem<any> = DropdownItem<any>> = {
   /**
    * Set the dropdown items.
    * @default []
@@ -29,7 +25,7 @@ type $Props<Item extends DropdownItem = DropdownItem> = {
    * Specify the selected item id.
    * @default undefined
    */
-  selectedId: DropdownItemId;
+  selectedId: Item["id"];
 
   /**
    * Specify the type of dropdown.
@@ -147,16 +143,13 @@ type $Props<Item extends DropdownItem = DropdownItem> = {
   [key: `data-${string}`]: any;
 };
 
-export type DropdownProps<Item extends DropdownItem = DropdownItem> = Omit<
-  $RestProps,
-  keyof $Props<Item>
-> &
-  $Props<Item>;
+export type DropdownProps<Item extends DropdownItem<any> = DropdownItem<any>> =
+  Omit<$RestProps, keyof $Props<Item>> & $Props<Item>;
 
 export default class Dropdown<
-  Item extends DropdownItem = DropdownItem,
+  Item extends DropdownItem<any> = DropdownItem<any>,
 > extends SvelteComponentTyped<
   DropdownProps<Item>,
-  { select: CustomEvent<{ selectedId: DropdownItemId; selectedItem: Item }> },
+  { select: CustomEvent<{ selectedId: Item["id"]; selectedItem: Item }> },
   { default: { item: Item; index: number } }
 > {}


### PR DESCRIPTION
Makes `Dropdown` id generic, defaulting to `any` (existing type), allowing readonly values to infer the `id`. Now, both the `item.id` and `selectedId` props are generic, falling back to `any`.

This removes the auto-generated `DropdownItemId` typedef, matching the pattern from #2564.

**Notably**, unlike `ComboBox` or `MultiSelect` where an item may not be initially selected, `Dropdown` *does* require that an item ID is specified as the inital selected item.

---

<img width="611" height="486" alt="Screenshot 2026-01-25 at 2 21 27 PM" src="https://github.com/user-attachments/assets/613520e5-9399-477b-84f5-5f1270edba5b" />
