### PR TITLE
chore: add JSDoc type annotations for strict checking

### DIFF
--- a/docs/scripts/generate-md-docs.js
+++ b/docs/scripts/generate-md-docs.js
@@ -55,10 +55,14 @@ const componentApi = JSON.parse(
 );
 
 /** @type {Record<string, true>} */
-const componentApiByName = componentApi.components.reduce((a, c) => {
-  a[c.moduleName] = true;
-  return a;
-}, {});
+const componentApiByName = componentApi.components.reduce(
+  /** @type {(acc: Record<string, true>, component: any) => Record<string, true>} */
+  (a, c) => {
+    a[c.moduleName] = true;
+    return a;
+  },
+  {},
+);
 
 /** @type {Map<string, any>} */
 const componentApiByModuleName = new Map(

--- a/src/DataTable/data-table-utils.js
+++ b/src/DataTable/data-table-utils.js
@@ -138,6 +138,7 @@ export function rowsEqual(a, b) {
 
 const PATH_SPLIT_REGEX = /[.[\]'"]/;
 const MAX_PATH_CACHE_SIZE = 1000;
+/** @type {Map<string, string[]>} */
 const pathCache = new Map();
 
 /**
@@ -164,8 +165,9 @@ export function resolvePath(object, path) {
   }
 
   return segments.reduce(
+    /** @type {(acc: unknown, prop: string) => unknown} */
     (o, p) => (o && typeof o === "object" ? o[p] : o),
-    object,
+    /** @type {unknown} */ (object),
   );
 }
 

--- a/src/utils/toHierarchy.js
+++ b/src/utils/toHierarchy.js
@@ -32,7 +32,7 @@ export function toHierarchy(flatArray, getParentId) {
       if (!childrenOf.has(parentId)) {
         childrenOf.set(parentId, []);
       }
-      childrenOf.get(parentId).push(item);
+      /** @type {NodeLike[]} */ (childrenOf.get(parentId)).push(item);
 
       const parent = itemsMap.get(parentId);
       if (parent) {


### PR DESCRIPTION
Resolve implicit any and overload matching errors in `@ts-check` files by adding explicit type annotations to Maps and callbacks.