### PR TITLE
docs: generate llms-full.txt

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -3,5 +3,6 @@
 /public/sitemap.xml
 /public/components/
 /public/llms.txt
+/public/llms-full.txt
 /.routify
 src/SEARCH_INDEX.json

--- a/docs/content/overview.md
+++ b/docs/content/overview.md
@@ -1,0 +1,147 @@
+Carbon Components Svelte is a [Svelte](https://github.com/sveltejs/svelte) component library that implements the [Carbon Design System](https://www.carbondesignsystem.com/), an open source design system by IBM.
+
+## Installation
+
+```sh
+# npm
+npm i carbon-components-svelte
+
+# pnpm
+pnpm i carbon-components-svelte
+
+# Yarn
+yarn add carbon-components-svelte
+
+# Bun
+bun add carbon-components-svelte
+```
+
+## Styling
+
+Before importing components, you will need to first apply Carbon component styles. The Carbon Design System supports five themes (2 light, 3 dark): White, Gray 10, Gray 80, Gray 90, Gray 100.
+
+This CSS needs only to be imported once, preferably at the root of your application.
+
+```javascript
+// White theme
+import "carbon-components-svelte/css/white.css";
+
+// Gray 10 theme
+import "carbon-components-svelte/css/g10.css";
+
+// Gray 80 theme
+import "carbon-components-svelte/css/g80.css";
+
+// Gray 90 theme
+import "carbon-components-svelte/css/g90.css";
+
+// Gray 100 theme
+import "carbon-components-svelte/css/g100.css";
+
+// All themes
+import "carbon-components-svelte/css/all.css";
+```
+
+The `all.css` StyleSheet uses CSS variables to dynamically switch between themes.
+
+## Optimization
+
+For smaller bundles and faster builds, use [carbon-preprocess-svelte](https://github.com/carbon-design-system/carbon-preprocess-svelte) with `optimizeImports` and `optimizeCss` below.
+
+Install [carbon-preprocess-svelte](https://github.com/carbon-design-system/carbon-preprocess-svelte) as a development dependency:
+
+```bash
+npm i -D carbon-preprocess-svelte
+
+# pnpm
+pnpm i -D carbon-preprocess-svelte
+
+# Yarn
+yarn add -D carbon-preprocess-svelte
+
+# Bun
+bun add -D carbon-preprocess-svelte
+```
+
+### optimizeImports
+
+`optimizeImports` is a Svelte preprocessor that rewrites barrel imports from Carbon components/icons/pictograms packages to their source Svelte code paths. This speeds up development and production build compile times while preserving IDE typeahead and autocompletion.
+
+It optimizes imports from `carbon-components-svelte`, `carbon-icons-svelte`, and `carbon-pictograms-svelte`. Example transformation:
+
+```diff
+- import { Button } from "carbon-components-svelte";
++ import Button from "carbon-components-svelte/src/Button/Button.svelte";
+
+- import { Add } from "carbon-icons-svelte";
++ import Add from "carbon-icons-svelte/lib/Add.svelte";
+```
+
+**SvelteKit:** add it to `svelte.config.js`. If you use Vite, `vitePreprocess` should run before `optimizeImports`:
+
+```javascript
+// svelte.config.js (SvelteKit)
+import { vitePreprocess } from "@sveltejs/vite-plugin-svelte";
+import { optimizeImports } from "carbon-preprocess-svelte";
+
+export default {
+  preprocess: [vitePreprocess(), optimizeImports()],
+};
+```
+
+**Plain Vite:** pass the preprocessor in `vite.config.js` when calling the Svelte plugin:
+
+```javascript
+// vite.config.js (plain Vite + Svelte)
+import { svelte } from "@sveltejs/vite-plugin-svelte";
+import { optimizeCss, optimizeImports } from "carbon-preprocess-svelte";
+
+export default {
+  plugins: [svelte({ preprocess: [optimizeImports()] }), optimizeCss()],
+};
+```
+
+### optimizeCss
+
+`optimizeCss` is a Vite plugin that removes unused Carbon styles at build time. `carbon-components-svelte@0.85.0` or greater is required. Add it to your Vite config:
+
+```javascript
+// vite.config.js
+import { sveltekit } from "@sveltejs/kit/vite";
+import { optimizeCss } from "carbon-preprocess-svelte";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [sveltekit(), optimizeCss()],
+});
+```
+
+## Dynamic theming
+
+Use the `all.css` StyleSheet for dynamic, client-side theming:
+
+```javascript
+import "carbon-components-svelte/css/all.css";
+```
+
+Programmatically switch between each of the five Carbon themes by setting the "theme" attribute on the HTML element:
+
+```svelte
+<script>
+  let theme = "white"; // "white" | "g10" | "g80" | "g90" | "g100"
+
+  $: document.documentElement.setAttribute("theme", theme);
+</script>
+```
+
+You can use the `Theme` component to update the theme at runtime.
+
+## Collection
+
+The Carbon Svelte collection includes packages for icons, pictograms, and data visualization:
+
+- **Carbon Components Svelte** — 50+ components — [GitHub](https://github.com/carbon-design-system/carbon-components-svelte)
+- **Carbon Icons Svelte** — 2,500+ icons — [GitHub](https://github.com/carbon-design-system/carbon-icons-svelte)
+- **Carbon Pictograms Svelte** — 1,500+ pictograms — [GitHub](https://github.com/carbon-design-system/carbon-pictograms-svelte)
+- **Carbon Charts Svelte** — 25+ charts, powered by d3 — [GitHub](https://github.com/carbon-design-system/carbon-charts/tree/master/packages/svelte)
+- **Carbon Preprocess Svelte** — Collection of Carbon Svelte preprocessors — [GitHub](https://github.com/carbon-design-system/carbon-preprocess-svelte)

--- a/docs/scripts/constants.js
+++ b/docs/scripts/constants.js
@@ -1,0 +1,6 @@
+// @ts-check
+
+export const BASE_URL = "https://svelte.carbondesignsystem.com";
+export const COMPONENTS_PATH = "./src/pages/components";
+export const RAW_COMPONENTS_OUT_DIR = "./public/components";
+export const SITEMAP_PATH = "./public/sitemap.xml";

--- a/docs/scripts/generate-sitemap.js
+++ b/docs/scripts/generate-sitemap.js
@@ -1,11 +1,7 @@
 // @ts-check
 import fs from "node:fs";
-
-const BASE_URL = "https://svelte.carbondesignsystem.com";
-const COMPONENTS_PATH = "./src/pages/components";
-const SITEMAP_PATH = "./public/sitemap.xml";
-
-const files = fs.readdirSync(COMPONENTS_PATH);
+import { BASE_URL, SITEMAP_PATH } from "./constants.js";
+import { getComponentNames } from "./utils.js";
 
 /** @type {string[]} */
 const urls = [];
@@ -19,8 +15,7 @@ urls.push(`
   </url>`);
 
 // Component pages
-for (const file of files) {
-  const [componentName] = file.split(".");
+for (const componentName of getComponentNames()) {
   urls.push(`
   <url>
     <loc>${BASE_URL}/components/${componentName}</loc>
@@ -33,6 +28,14 @@ for (const file of files) {
 urls.push(`
   <url>
     <loc>${BASE_URL}/llms.txt</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
+  </url>`);
+
+// llms-full.txt
+urls.push(`
+  <url>
+    <loc>${BASE_URL}/llms-full.txt</loc>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>`);

--- a/docs/scripts/utils.js
+++ b/docs/scripts/utils.js
@@ -1,0 +1,15 @@
+// @ts-check
+import fs from "node:fs";
+import { COMPONENTS_PATH } from "./constants.js";
+
+/**
+ * Component names from .svx files in the components docs directory, sorted.
+ * @returns {string[]}
+ */
+export function getComponentNames() {
+  const files = fs.readdirSync(COMPONENTS_PATH);
+  return files
+    .filter((f) => f.endsWith(".svx"))
+    .map((f) => f.split(".")[0])
+    .sort((a, b) => a.localeCompare(b));
+}


### PR DESCRIPTION
Follow-up to #2558 and #2555

This adds `llms-full.txt`, composing individual component documentation with an intro overview.

Documentation on the golden path needs improving: SCSS should be mentioned, but less prominently. Using the precompiled CSS + optimizer plugin is faster/better DX.

Ideally, `README.md` is used as the source for the intro, eliminating the need to maintain instructions in three separate places.