### PR TITLE
feat(data-table): add `rowClass` prop

### DIFF
--- a/src/DataTable/DataTable.svelte
+++ b/src/DataTable/DataTable.svelte
@@ -67,6 +67,10 @@
    * @property {DataTableCell<Row>} cell
    * @property {EventTarget} target
    * @property {EventTarget} currentTarget
+   * @typedef {{ row: Row, rowIndex: number, selected: boolean, expanded: boolean }} DataTableRowClassArgs<Row=DataTableRow>
+   * @typedef {string | ((row: DataTableRowClassArgs<Row>) => string | undefined)} DataTableRowClass<Row=DataTableRow>
+   * @type {object}
+   * @property {DataTableRowClass<Row>} [rowClass]
    * @restProps {div}
    */
 
@@ -94,6 +98,21 @@
 
   /** Specify the description of the data table */
   export let description = "";
+
+  /**
+   * Specify a custom class name for each row.
+   * Provide a function to return a class name based
+   * on row properties, allowing conditional classes
+   * based on selected/expanded state.
+   * @example
+   * ```svelte
+   * <DataTable rowClass={({ row, rowIndex, selected, expanded }) => {
+   *   return `row-${rowIndex} ${selected ? 'selected' : ''} ${expanded ? 'expanded' : ''}`;
+   * }} />
+   * ```
+   * @type {DataTableRowClass<Row>}
+   */
+  export let rowClass = undefined;
 
   /**
    * Specify a name attribute for the input elements
@@ -507,6 +526,10 @@
         {@const isExpanded = !!expandedRows[row.id]}
         {@const isExpandable = !nonExpandableRowIdsSet.has(row.id)}
         {@const isSelectable = !nonSelectableRowIdsSet.has(row.id)}
+        {@const rowClassValue =
+          typeof rowClass === "function"
+            ? rowClass({ row, rowIndex: i, selected: isSelected, expanded: isExpanded })
+            : rowClass}
         <TableRow
           data-row={row.id}
           data-parent-row={expandable ? true : undefined}
@@ -516,7 +539,7 @@
             ? 'bx--parent-row'
             : ''} {expandable && parentRowId === row.id
             ? 'bx--expandable-row--hover'
-            : ''}"
+            : ''} {rowClassValue ?? ''}"
           on:click={(e) => {
             // forgo "click", "click:row" events if target
             // resembles an overflow menu, a checkbox, or radio button

--- a/tests/DataTable/DataTable.test.svelte
+++ b/tests/DataTable/DataTable.test.svelte
@@ -72,6 +72,15 @@
   export let page = 0;
   export let tableHeaderTranslateWithId: ((id: string) => string) | undefined =
     undefined;
+  export let rowClass:
+    | string
+    | ((row: {
+        row: BaseRow;
+        rowIndex: number;
+        selected: boolean;
+        expanded: boolean;
+      }) => string | undefined)
+    | undefined = undefined;
 </script>
 
 <DataTable
@@ -95,6 +104,7 @@
   {expandedRowIds}
   {pageSize}
   {page}
+  {rowClass}
   {tableHeaderTranslateWithId}
   on:click={(e) => {
     console.log("click", e.detail);


### PR DESCRIPTION
### Summary
Added a new `rowClass` prop to the `DataTable` component. This allows passing a custom CSS class to <tr> elements, enabling per-row styling.

### Motivation
In some use cases, developers need to apply different styles to table rows (e.g., highlight specific rows based on data). Currently, `DataTable` does not provide a way to inject custom classes into <tr>.

### Implementation
- Added optional `rowClass?: string | ((row: DataTableRow) => string)` prop to DataTable.
- Applied `rowClass` to each <tr> in the table body.
- Updated TypeScript types and added a small example in documentation/tests.

### Checklist
- [x] Tests added / updated
- [x] Documentation updated
- [x] Code compiles correctly
