### PR TITLE
perf(data-table): reduce recomputations and lookups for large tables

### DIFF
--- a/src/DataTable/DataTable.svelte
+++ b/src/DataTable/DataTable.svelte
@@ -299,7 +299,14 @@
 
   let refSelectAll = null;
 
-  $: batchSelectedIds.set(selectedRowIds);
+  let prevBatchSelected = [];
+  $: if (
+    prevBatchSelected.length !== selectedRowIds.length ||
+    selectedRowIds.some((id, i) => id !== prevBatchSelected[i])
+  ) {
+    prevBatchSelected = selectedRowIds;
+    batchSelectedIds.set(selectedRowIds);
+  }
   $: rowIds = $tableRows.map((row) => row.id);
 
   // Use Sets for faster row lookups.


### PR DESCRIPTION
Similar to #2589, this adds more performance optimizations for `DataTable`, especially when used with many rows. Another benefit of reuse is readability.

- only update `batchSelectedIds` when the value of `selectedRowIds` changes
- only recompute `tableCellsByRowId` if rows/headers change
- do not shallow copy rows if sorting is off
- use `@const` per-row (isSelected, isExpanded, isExpandable, isSelectable) instead of multiple lookups
- use Set lookups for expand / select handlers instead of Array filtering


---



| Optimization           | Before                          | After                                      |
|------------------------|----------------------------------|--------------------------------------------|
| batchSelectedIds       | Store write every run            | O(m) compare; write only when value changes |
| tableCellsByRowId      | O(n×h) whenever deps run         | O(n×h) only when `rows`/`headers` ref changes |
| sortedRows             | O(n) every update (always copy)   | O(1) when not sorting; O(n)+O(n log n) when sorting |
| `@const` per row         | O(n×k) lookups (k = uses per row) | O(n) lookups (4 per row)                   |
| Expand/select handlers | O(e) or O(m) filter/spread       | O(e) or O(m) with O(1) toggle step         |

Where: **n** = rows, **h** = headers, **m** = selected rows, **e** = expanded rows, **k** = number of lookup uses per row in template.
