### PR TITLE
fix(number-input): dynamically set `aria-describedby` based on state

### DIFF
--- a/src/NumberInput/NumberInput.svelte
+++ b/src/NumberInput/NumberInput.svelte
@@ -180,6 +180,8 @@
   $: decrementLabel = translateWithId("decrement");
   $: hasError = invalid && invalidText && !readonly;
   $: errorId = `error-${id}`;
+  $: warnId = `warn-${id}`;
+  $: helperId = `helper-${id}`;
   $: ariaLabel =
     $$props["aria-label"] ||
     "Numeric input field with increment and decrement buttons";
@@ -346,7 +348,13 @@
           value={inputValue}
           type="text"
           inputmode="decimal"
-          aria-describedby={errorId}
+          aria-describedby={hasError
+            ? errorId
+            : warn
+              ? warnId
+              : helperText
+                ? helperId
+                : undefined}
           data-invalid={hasError || undefined}
           aria-invalid={hasError || undefined}
           aria-label={labelText ? undefined : ariaLabel}
@@ -369,7 +377,13 @@
           bind:this={ref}
           type="number"
           pattern="[0-9]*"
-          aria-describedby={errorId}
+          aria-describedby={hasError
+            ? errorId
+            : warn
+              ? warnId
+              : helperText
+                ? helperId
+                : undefined}
           data-invalid={hasError || undefined}
           aria-invalid={hasError || undefined}
           aria-label={labelText ? undefined : ariaLabel}
@@ -441,6 +455,7 @@
     </div>
     {#if !hasError && !warn && helperText}
       <div
+        id={helperId}
         class:bx--form__helper-text={true}
         class:bx--form__helper-text--disabled={disabled}
       >
@@ -453,7 +468,7 @@
       </div>
     {/if}
     {#if !hasError && warn}
-      <div id={errorId} class:bx--form-requirement={true}>{warnText}</div>
+      <div id={warnId} class:bx--form-requirement={true}>{warnText}</div>
     {/if}
   </div>
 </div>

--- a/tests/NumberInput/NumberInput.test.ts
+++ b/tests/NumberInput/NumberInput.test.ts
@@ -323,13 +323,40 @@ describe("NumberInput", () => {
     expect(true).toBe(true);
   });
 
-  it("should set aria-describedby attribute", () => {
+  it("should set aria-describedby to error id when invalid", () => {
+    render(NumberInput, {
+      props: { id: "test-input", invalid: true, invalidText: "Error" },
+    });
+
+    const input = screen.getByRole("spinbutton");
+    expect(input).toHaveAttribute("aria-describedby", "error-test-input");
+  });
+
+  it("should set aria-describedby to warn id when warn", () => {
+    render(NumberInput, {
+      props: { id: "test-input", warn: true, warnText: "Warning" },
+    });
+
+    const input = screen.getByRole("spinbutton");
+    expect(input).toHaveAttribute("aria-describedby", "warn-test-input");
+  });
+
+  it("should set aria-describedby to helper id when helperText is provided", () => {
+    render(NumberInput, {
+      props: { id: "test-input", helperText: "Helper" },
+    });
+
+    const input = screen.getByRole("spinbutton");
+    expect(input).toHaveAttribute("aria-describedby", "helper-test-input");
+  });
+
+  it("should not set aria-describedby when no error, warn, or helperText", () => {
     render(NumberInput, {
       props: { id: "test-input" },
     });
 
     const input = screen.getByRole("spinbutton");
-    expect(input).toHaveAttribute("aria-describedby", "error-test-input");
+    expect(input).not.toHaveAttribute("aria-describedby");
   });
 
   it("should set aria-label when no label is provided", () => {


### PR DESCRIPTION
Fixes #2613

Previously, `aria-describedby` always pointed to `errorId` regardless of component state. Now it correctly references the error, warning, or helper text element ID, matching the behavior of `TextInput`.