### PR TITLE
fix(select): dynamically set `aria-describedby` based on state

### DIFF
--- a/src/Select/Select.svelte
+++ b/src/Select/Select.svelte
@@ -129,6 +129,8 @@
   });
 
   $: errorId = `error-${id}`;
+  $: warnId = `warn-${id}`;
+  $: helperId = `helper-${id}`;
   $: selectedValue.set(selected ?? $defaultValue);
 </script>
 
@@ -161,7 +163,13 @@
         >
           <select
             bind:this={ref}
-            aria-describedby={invalid ? errorId : undefined}
+            aria-describedby={invalid
+              ? errorId
+              : warn
+                ? warnId
+                : helperText
+                  ? helperId
+                  : undefined}
             aria-invalid={invalid || undefined}
             disabled={disabled || undefined}
             required={required || undefined}
@@ -192,6 +200,7 @@
       </div>
       {#if !invalid && !warn && helperText}
         <div
+          id={helperId}
           class:bx--form__helper-text={true}
           class:bx--form__helper-text--disabled={disabled}
         >
@@ -208,7 +217,13 @@
           bind:this={ref}
           {id}
           {name}
-          aria-describedby={invalid ? errorId : undefined}
+          aria-describedby={invalid
+            ? errorId
+            : warn
+              ? warnId
+              : helperText
+                ? helperId
+                : undefined}
           disabled={disabled || undefined}
           required={required || undefined}
           aria-invalid={invalid || undefined}
@@ -234,8 +249,9 @@
           />
         {/if}
       </div>
-      {#if !invalid && helperText}
+      {#if !invalid && !warn && helperText}
         <div
+          id={helperId}
           class:bx--form__helper-text={true}
           class:bx--form__helper-text--disabled={disabled}
         >
@@ -248,7 +264,7 @@
         </div>
       {/if}
       {#if !invalid && warn}
-        <div id={errorId} class:bx--form-requirement={true}>
+        <div id={warnId} class:bx--form-requirement={true}>
           {warnText}
         </div>
       {/if}

--- a/tests/Select/Select.test.svelte
+++ b/tests/Select/Select.test.svelte
@@ -3,6 +3,7 @@
 
   export let selected: string | number | undefined = undefined;
   export let disabled = false;
+  export let id = "test-select";
   export let invalid = false;
   export let invalidText = "";
   export let warn = false;
@@ -18,6 +19,7 @@
 <Select
   bind:selected
   {disabled}
+  {id}
   {invalid}
   {invalidText}
   {warn}

--- a/tests/Select/Select.test.ts
+++ b/tests/Select/Select.test.ts
@@ -179,6 +179,131 @@ describe("Select", () => {
     expect(helperElement).toHaveTextContent("Helper text");
   });
 
+  describe("aria-describedby", () => {
+    it("references error message when invalid", () => {
+      render(Select, {
+        id: "test-select",
+        invalid: true,
+        invalidText: "Error message",
+      });
+
+      const selectElement = screen.getByLabelText("Select label");
+      expect(selectElement).toHaveAttribute(
+        "aria-describedby",
+        "error-test-select",
+      );
+
+      const errorElement = screen.getByText("Error message");
+      expect(errorElement).toHaveAttribute("id", "error-test-select");
+    });
+
+    it("references warning message when warn and not invalid", () => {
+      render(Select, {
+        id: "test-select",
+        warn: true,
+        warnText: "Warning message",
+      });
+
+      const selectElement = screen.getByLabelText("Select label");
+      expect(selectElement).toHaveAttribute(
+        "aria-describedby",
+        "warn-test-select",
+      );
+
+      const warnElement = screen.getByText("Warning message");
+      expect(warnElement).toHaveAttribute("id", "warn-test-select");
+    });
+
+    it("references helper text when provided and not invalid or warn", () => {
+      render(Select, {
+        id: "test-select",
+        helperText: "Helper text",
+      });
+
+      const selectElement = screen.getByLabelText("Select label");
+      expect(selectElement).toHaveAttribute(
+        "aria-describedby",
+        "helper-test-select",
+      );
+
+      const helperElement = screen.getByText("Helper text");
+      expect(helperElement).toHaveAttribute("id", "helper-test-select");
+    });
+
+    it("has no aria-describedby when no messages are present", () => {
+      render(Select, { id: "test-select" });
+
+      const selectElement = screen.getByLabelText("Select label");
+      expect(selectElement).not.toHaveAttribute("aria-describedby");
+    });
+
+    it("prioritizes error over warning", () => {
+      render(Select, {
+        id: "test-select",
+        invalid: true,
+        invalidText: "Error message",
+        warn: true,
+        warnText: "Warning message",
+      });
+
+      const selectElement = screen.getByLabelText("Select label");
+      expect(selectElement).toHaveAttribute(
+        "aria-describedby",
+        "error-test-select",
+      );
+    });
+
+    it("prioritizes warning over helper text", () => {
+      render(Select, {
+        id: "test-select",
+        warn: true,
+        warnText: "Warning message",
+        helperText: "Helper text",
+      });
+
+      const selectElement = screen.getByLabelText("Select label");
+      expect(selectElement).toHaveAttribute(
+        "aria-describedby",
+        "warn-test-select",
+      );
+
+      // Helper text should not be rendered when warn is true
+      expect(screen.queryByText("Helper text")).not.toBeInTheDocument();
+    });
+
+    it("works correctly for inline variant with invalid state", () => {
+      render(Select, {
+        id: "test-select",
+        inline: true,
+        invalid: true,
+        invalidText: "Error message",
+      });
+
+      const selectElement = screen.getByLabelText("Select label");
+      expect(selectElement).toHaveAttribute(
+        "aria-describedby",
+        "error-test-select",
+      );
+    });
+
+    it("works correctly for inline variant with helper text", () => {
+      render(Select, {
+        id: "test-select",
+        inline: true,
+        helperText: "Helper text",
+      });
+
+      const selectElement = screen.getByLabelText("Select label");
+      expect(selectElement).toHaveAttribute(
+        "aria-describedby",
+        "helper-test-select",
+      );
+
+      const helperElement = screen.getByText("Helper text");
+      expect(helperElement).toHaveAttribute("id", "helper-test-select");
+    });
+  });
+
   it("renders visible label by default", () => {
     render(Select);
     const label = screen.getByText("Select label");


### PR DESCRIPTION
Related #2620

Currently, `aria-describedby` only references `errorId`, ignoring warning and helper text states. Now dynamically references the appropriate ID based on priority: error > warn > helper.