### PR TITLE
docs(data-table): apply `portalMenu` to "Empty column with overflow menu" example

### DIFF
--- a/docs/src/pages/framed/DataTable/DataTableAppendColumns.svelte
+++ b/docs/src/pages/framed/DataTable/DataTableAppendColumns.svelte
@@ -25,7 +25,7 @@
 <DataTable sortable {headers} {rows}>
   <svelte:fragment slot="cell" let:cell>
     {#if cell.key === "overflow"}
-      <OverflowMenu flipped>
+      <OverflowMenu portalMenu flipped>
         <OverflowMenuItem text="Restart" />
         <OverflowMenuItem
           href="https://cloud.ibm.com/docs/loadbalancer-service"


### PR DESCRIPTION
Fixes https://github.com/carbon-design-system/carbon-components-svelte/issues/796

#2639 added portal support to `OverflowMenu`.

This updates the data table example to portal the menu.