### PR TITLE
fix(overflow-menu): use computed floating portal direction

### DIFF
--- a/src/OverflowMenu/OverflowMenu.svelte
+++ b/src/OverflowMenu/OverflowMenu.svelte
@@ -305,7 +305,7 @@
 </button>
 
 {#if portalMenu}
-  <FloatingPortal anchor={buttonRef} {direction} {open}>
+  <FloatingPortal anchor={buttonRef} {direction} {open} let:direction={portalDirection}>
     <!-- svelte-ignore a11y-no-noninteractive-element-to-interactive-role -->
     <ul
       bind:this={menuRef}
@@ -313,7 +313,7 @@
       tabindex="-1"
       id={menuId}
       aria-label={ariaLabel}
-      data-floating-menu-direction={direction}
+      data-floating-menu-direction={portalDirection}
       class:bx--overflow-menu-options={true}
       class:bx--overflow-menu--flip={flipped}
       class:bx--overflow-menu-options--open={open}
@@ -322,7 +322,7 @@
       class:bx--overflow-menu-options--xl={size === "xl"}
       class:bx--breadcrumb-menu-options={!!ctxBreadcrumbItem}
       class={menuOptionsClass}
-      style="position: static; --overflow-menu-options-after-width: {overflowMenuOptionsAfterWidth}"
+      style="position: relative; top: auto; left: auto; --overflow-menu-options-after-width: {overflowMenuOptionsAfterWidth}"
       on:keydown={(e) => {
         if (["ArrowDown", "ArrowLeft", "ArrowRight", "ArrowUp"].includes(e.key)) {
           e.preventDefault();


### PR DESCRIPTION
Follow-up to #2639

The computed direction should be used so the pseudo-element on the menu is correctly positioned.

---

<img width="445" height="259" alt="Screenshot 2026-02-14 at 12 10 18 PM" src="https://github.com/user-attachments/assets/2e5cf2ee-01f7-45c1-8739-634999748f32" />
