### PR TITLE
docs: sync framed example theme with `localStorage` changes

### DIFF
--- a/docs/src/pages/framed/_reset.svelte
+++ b/docs/src/pages/framed/_reset.svelte
@@ -8,10 +8,40 @@
   $: metatags.title = `${exampleName} – Carbon Components Svelte`;
   $: metatags.description = `${exampleName} example for the ${componentName} component in Carbon Components Svelte.`;
 
+  const validThemes = ["white", "g10", "g80", "g90", "g100"];
+
+  function applyTheme(theme) {
+    if (validThemes.includes(theme)) {
+      document.documentElement.setAttribute("theme", theme);
+      document.documentElement.style.setProperty(
+        "color-scheme",
+        ["white", "g10"].includes(theme) ? "light" : "dark",
+      );
+    }
+  }
+
   onMount(() => {
     document.body.classList.add("framed");
+
+    // Intercept localStorage.setItem in this frame so that
+    // theme changes made via localStorage are applied immediately.
+    const _setItem = localStorage.setItem.bind(localStorage);
+    localStorage.setItem = (key, value) => {
+      _setItem(key, value);
+      if (key === "theme") applyTheme(value);
+    };
+
+    // Listen for cross-document storage changes (e.g., from the parent docs page).
+    function handleStorage(event) {
+      if (event.key === "theme") applyTheme(event.newValue);
+    }
+
+    window.addEventListener("storage", handleStorage);
+
     return () => {
       document.body.classList.remove("framed");
+      localStorage.setItem = _setItem;
+      window.removeEventListener("storage", handleStorage);
     };
   });
 
@@ -22,13 +52,7 @@
     // NOTE: we *do not* want to persist the theme as this can
     // conflict with how the iframe is displayed in the docs.
     // Instead, we want the theme to be overridden in the standalone page.
-    if (["white", "g10", "g80", "g90", "g100"].includes(current_theme)) {
-      document.documentElement.setAttribute("theme", current_theme);
-      document.documentElement.style.setProperty(
-        "color-scheme",
-        ["white", "g10"].includes(current_theme) ? "light" : "dark",
-      );
-    }
+    applyTheme(current_theme);
   }
 </script>
 


### PR DESCRIPTION
The `storage` event doesn't fire in the same browsing context. For framed examples, intercept `localStorage.setItem` for same-document reactivity and listen for cross-document `storage` events from the parent.