### PR TITLE
docs: remove theme URL param from "Open in new tab" link

### DIFF
--- a/docs/src/components/Preview.svelte
+++ b/docs/src/components/Preview.svelte
@@ -28,7 +28,7 @@
         kind="ghost"
         target="_blank"
         size="field"
-        href={themedSrcUrl}
+        href={$url(src)}
         icon={Launch}
       >
         Open in new tab


### PR DESCRIPTION
This removes the current theme from the framed URLs for the cleanest presentation (sharing, etc.).

This still supports the scenario where you want a framed example with a specific theme (`?theme=g90`).