### PR TITLE
fix(overflow-menu): `OverflowMenuItem` has explicit `type="button"` to prevent form submission

### DIFF
--- a/src/OverflowMenu/OverflowMenuItem.svelte
+++ b/src/OverflowMenu/OverflowMenuItem.svelte
@@ -73,6 +73,7 @@
     role: "menuitem",
     tabindex: "-1",
     class: "bx--overflow-menu-options__btn",
+    type: href ? undefined : "button",
     disabled: href ? undefined : disabled,
     href: href ? href : undefined,
     target: href && target ? target : undefined,

--- a/tests/OverflowMenu/OverflowMenu.test.ts
+++ b/tests/OverflowMenu/OverflowMenu.test.ts
@@ -224,6 +224,20 @@ describe("OverflowMenu", () => {
     );
   });
 
+  it("renders button menu items with type='button' to prevent form submission", async () => {
+    render(OverflowMenu);
+
+    const menuButton = screen.getByRole("button");
+    await user.click(menuButton);
+
+    const menuItems = screen.getAllByRole("menuitem");
+    const buttonItem = menuItems.find(
+      (item) => item.textContent === "Manage credentials",
+    );
+    expect(buttonItem?.tagName).toBe("BUTTON");
+    expect(buttonItem).toHaveAttribute("type", "button");
+  });
+
   it("handles link menu items correctly", async () => {
     render(OverflowMenu);
 


### PR DESCRIPTION
Identified via linting in #2655 

The overflow menu item uses a button for non-links. It should have an explicit `type="button"` to avoid accidental form submission (implicitly `"submit"` when used inside a form).