### PR TITLE
fix(expandable-tile): prevent height animation on initial load

### DIFF
--- a/src/Tile/ExpandableTile.svelte
+++ b/src/Tile/ExpandableTile.svelte
@@ -89,7 +89,7 @@
     class:bx--tile--expandable--interactive={true}
     class:bx--tile--is-expanded={expanded}
     class:bx--tile--light={light}
-    style:max-height={expanded ? "none" : `${tileMaxHeight + tilePadding}px`}
+    style:max-height={expanded || tileMaxHeight <= 0 ? "none" : `${tileMaxHeight + tilePadding}px`}
     {...$$restProps}
     on:click
     on:mouseover
@@ -135,7 +135,7 @@
     class:bx--tile--expandable={true}
     class:bx--tile--is-expanded={expanded}
     class:bx--tile--light={light}
-    style:max-height={expanded ? "none" : `${tileMaxHeight + tilePadding}px`}
+    style:max-height={expanded || tileMaxHeight <= 0 ? "none" : `${tileMaxHeight + tilePadding}px`}
     {...$$restProps}
     on:click
     on:click={() => {

--- a/tests/ExpandableTile/ExpandableTile.test.ts
+++ b/tests/ExpandableTile/ExpandableTile.test.ts
@@ -149,4 +149,23 @@ describe("ExpandableTile", () => {
     await user.click(tile);
     expect(tile.getAttribute("style")).toBe("max-height: none;");
   });
+
+  it("should set max-height to none when tileMaxHeight is 0 to prevent height animation on initial load", () => {
+    render(ExpandableTile, {
+      props: {
+        tileMaxHeight: 0,
+        tilePadding: 20,
+      },
+    });
+
+    const tile = screen.getByRole("button");
+    expect(tile.getAttribute("style")).toBe("max-height: none;");
+  });
+
+  it("should set max-height to none when tileMaxHeight is 0 with default props", () => {
+    render(ExpandableTile);
+
+    const tile = screen.getByRole("button");
+    expect(tile.getAttribute("style")).toBe("max-height: none;");
+  });
 });

--- a/tests/Tile/ExpandableTile.test.ts
+++ b/tests/Tile/ExpandableTile.test.ts
@@ -80,4 +80,11 @@ describe("ExpandableTile", () => {
       expect(tile.tagName).not.toBe("BUTTON");
     });
   });
+
+  it("should set max-height to none when tileMaxHeight is 0 to prevent height animation on initial load", () => {
+    render(ExpandableTile);
+
+    const tile = screen.getByTestId("basic");
+    expect(tile.getAttribute("style")).toBe("max-height: none;");
+  });
 });


### PR DESCRIPTION
On initial load, `ExpandableTile` has an unexpected height animation.

The issue is that `max-height` starts at 0 before DOM measurement, which triggers the Carbon CSS transition when the height is actually measured. The animation should not apply if the max height is not measured yet.