### PR TITLE
feat(select-item): `value` is generic

### DIFF
--- a/src/Select/SelectItem.svelte
+++ b/src/Select/SelectItem.svelte
@@ -1,7 +1,12 @@
 <script>
   /**
+   * @generics {Value extends string | number = string | number} Value
+   * @template {string | number} Value
+   */
+
+  /**
    * Specify the option value.
-   * @type {string | number}
+   * @type {Value}
    */
   export let value = "";
 

--- a/tests/Select/Select.test.ts
+++ b/tests/Select/Select.test.ts
@@ -1,5 +1,6 @@
 import { render, screen, within } from "@testing-library/svelte";
 import type SelectComponent from "carbon-components-svelte/Select/Select.svelte";
+import type SelectItemComponent from "carbon-components-svelte/Select/SelectItem.svelte";
 import type { ComponentProps } from "svelte";
 import { user } from "../setup-tests";
 import SelectFalsy from "./Select.falsy.test.svelte";
@@ -466,5 +467,21 @@ describe("Select Generics", () => {
 
     const customLabel = screen.getByText("Custom label content");
     expect(customLabel).toBeInTheDocument();
+  });
+
+  it("should type SelectItem value to match Select generic", () => {
+    type CustomValue = "option1" | "option2" | "option3";
+
+    type ComponentType = SelectItemComponent<CustomValue>;
+    type Props = ComponentProps<ComponentType>;
+
+    expectTypeOf<Props["value"]>().toEqualTypeOf<CustomValue | undefined>();
+  });
+
+  it("should default SelectItem to string | number when generic is not specified", () => {
+    type ComponentType = SelectItemComponent;
+    type Props = ComponentProps<ComponentType>;
+
+    expectTypeOf<Props["value"]>().toEqualTypeOf<string | number | undefined>();
   });
 });


### PR DESCRIPTION
Like `Select`, make `value` generic.