### PR TITLE
test: replace `as` type casts with `expect.assert(instanceof)`

### DIFF
--- a/tests/DataTable/DataTableGenerics.test.ts
+++ b/tests/DataTable/DataTableGenerics.test.ts
@@ -29,7 +29,8 @@ describe("DataTable Generics", () => {
 
       // Get first table
       const firstTable = tables[0];
-      const firstTableContainer = within(firstTable as HTMLElement);
+      expect.assert(firstTable instanceof HTMLElement);
+      const firstTableContainer = within(firstTable);
 
       // Verify rows are rendered
       const rows = getTableRows(container, 0);
@@ -53,9 +54,7 @@ describe("DataTable Generics", () => {
       const { container } = render(DataTableGenerics);
 
       // Find checkboxes in the first table
-      const checkboxes = container.querySelectorAll(
-        'input[type="checkbox"]',
-      ) as NodeListOf<HTMLInputElement>;
+      const checkboxes = container.querySelectorAll('input[type="checkbox"]');
       const firstTableCheckboxes = Array.from(checkboxes).filter((cb) => {
         const row = cb.closest("tr");
         return row && getTableRows(container, 0).includes(row);
@@ -66,7 +65,8 @@ describe("DataTable Generics", () => {
       // Click the first checkbox (row-1 should be pre-selected)
       if (firstTableCheckboxes.length > 0) {
         const firstCheckbox = firstTableCheckboxes[0];
-        expect(firstCheckbox?.checked).toBe(true); // row-1 is pre-selected
+        expect.assert(firstCheckbox instanceof HTMLInputElement);
+        expect(firstCheckbox.checked).toBe(true); // row-1 is pre-selected
 
         // Click to deselect
         await user.click(firstCheckbox);
@@ -113,7 +113,8 @@ describe("DataTable Generics", () => {
 
       // Get second table
       const secondTable = tables[1];
-      const secondTableContainer = within(secondTable as HTMLElement);
+      expect.assert(secondTable instanceof HTMLElement);
+      const secondTableContainer = within(secondTable);
 
       // Verify rows are rendered in second table
       const rows = getTableRows(container, 1);
@@ -132,9 +133,7 @@ describe("DataTable Generics", () => {
       const { container } = render(DataTableGenerics);
 
       // Find checkboxes in the second table
-      const checkboxes = container.querySelectorAll(
-        'input[type="checkbox"]',
-      ) as NodeListOf<HTMLInputElement>;
+      const checkboxes = container.querySelectorAll('input[type="checkbox"]');
       const secondTableCheckboxes = Array.from(checkboxes).filter((cb) => {
         const row = cb.closest("tr");
         return row && getTableRows(container, 1).includes(row);
@@ -143,7 +142,10 @@ describe("DataTable Generics", () => {
       expect(secondTableCheckboxes.length).toBeGreaterThan(0);
 
       // Verify pre-selected rows (1 and 2 should be pre-selected)
-      const checkedBoxes = secondTableCheckboxes.filter((cb) => cb?.checked);
+      const checkedBoxes = secondTableCheckboxes.filter((cb) => {
+        expect.assert(cb instanceof HTMLInputElement);
+        return cb.checked;
+      });
       expect(checkedBoxes.length).toBeGreaterThanOrEqual(0);
     });
 
@@ -182,7 +184,8 @@ describe("DataTable Generics", () => {
 
       // Get third table
       const thirdTable = tables[2];
-      const thirdTableContainer = within(thirdTable as HTMLElement);
+      expect.assert(thirdTable instanceof HTMLElement);
+      const thirdTableContainer = within(thirdTable);
 
       // Verify rows are rendered in third table
       const rows = getTableRows(container, 2);
@@ -204,9 +207,7 @@ describe("DataTable Generics", () => {
       const { container } = render(DataTableGenerics);
 
       // Find checkboxes in the third table
-      const checkboxes = container.querySelectorAll(
-        'input[type="checkbox"]',
-      ) as NodeListOf<HTMLInputElement>;
+      const checkboxes = container.querySelectorAll('input[type="checkbox"]');
       const thirdTableCheckboxes = Array.from(checkboxes).filter((cb) => {
         const row = cb.closest("tr");
         return row && getTableRows(container, 2).includes(row);
@@ -215,7 +216,10 @@ describe("DataTable Generics", () => {
       expect(thirdTableCheckboxes.length).toBeGreaterThan(0);
 
       // Verify pre-selected row (prod-1 should be pre-selected)
-      const checkedBoxes = thirdTableCheckboxes.filter((cb) => cb?.checked);
+      const checkedBoxes = thirdTableCheckboxes.filter((cb) => {
+        expect.assert(cb instanceof HTMLInputElement);
+        return cb.checked;
+      });
       expect(checkedBoxes.length).toBeGreaterThanOrEqual(0);
     });
 
@@ -234,8 +238,8 @@ describe("DataTable Generics", () => {
       );
 
       if (thirdTableExpandButtons.length > 0) {
-        const firstExpandButton =
-          thirdTableExpandButtons[0] as HTMLButtonElement;
+        const firstExpandButton = thirdTableExpandButtons[0];
+        expect.assert(firstExpandButton instanceof HTMLButtonElement);
         await user.click(firstExpandButton);
         await tick();
 
@@ -284,7 +288,8 @@ describe("DataTable Generics", () => {
       );
 
       if (thirdTableExpandButtons.length > 0) {
-        const expandButton = thirdTableExpandButtons[0] as HTMLButtonElement;
+        const expandButton = thirdTableExpandButtons[0];
+        expect.assert(expandButton instanceof HTMLButtonElement);
         await user.click(expandButton);
         await tick();
 
@@ -316,7 +321,8 @@ describe("DataTable Generics", () => {
       );
 
       if (thirdTableExpandButtons.length > 0) {
-        const expandButton = thirdTableExpandButtons[0] as HTMLButtonElement;
+        const expandButton = thirdTableExpandButtons[0];
+        expect.assert(expandButton instanceof HTMLButtonElement);
         await user.click(expandButton);
         await tick();
 

--- a/tests/FileUploader/FileUploader.test.svelte
+++ b/tests/FileUploader/FileUploader.test.svelte
@@ -34,9 +34,10 @@
   }
 
   export function getInputElement() {
-    const input = document.querySelector(
-      'input[type="file"]',
-    ) as HTMLInputElement;
+    const input = document.querySelector('input[type="file"]');
+    if (!(input instanceof HTMLInputElement)) {
+      throw new Error("Expected input[type='file'] to be an HTMLInputElement");
+    }
     return input;
   }
 

--- a/tests/MultiSelect/MultiSelect.test.ts
+++ b/tests/MultiSelect/MultiSelect.test.ts
@@ -1438,7 +1438,8 @@ describe("MultiSelect", () => {
       expect(firstCheckbox).toBeDefined();
 
       // Get the current checked state
-      const wasChecked = (firstCheckbox as HTMLInputElement).checked;
+      expect.assert(firstCheckbox instanceof HTMLInputElement);
+      const wasChecked = firstCheckbox.checked;
 
       // Click the checkbox to toggle it
       await user.click(firstCheckbox);
@@ -1449,9 +1450,8 @@ describe("MultiSelect", () => {
       await waitFor(() => {
         const updatedCheckboxes = screen.getAllByRole("checkbox");
         const firstUpdatedCheckbox = updatedCheckboxes[0];
-        expect((firstUpdatedCheckbox as HTMLInputElement).checked).toBe(
-          !wasChecked,
-        );
+        expect.assert(firstUpdatedCheckbox instanceof HTMLInputElement);
+        expect(firstUpdatedCheckbox.checked).toBe(!wasChecked);
       });
     });
 
@@ -1525,9 +1525,10 @@ describe("MultiSelect", () => {
       // Verify the item is selected - check if any checkbox is checked
       await waitFor(() => {
         const checkboxes = screen.getAllByRole("checkbox");
-        const checkedCheckboxes = checkboxes.filter(
-          (cb) => (cb as HTMLInputElement).checked,
-        );
+        const checkedCheckboxes = checkboxes.filter((cb) => {
+          expect.assert(cb instanceof HTMLInputElement);
+          return cb.checked;
+        });
         expect(checkedCheckboxes.length).toBeGreaterThan(0);
 
         // Also verify we can find Item 2 if it's visible
@@ -1536,7 +1537,8 @@ describe("MultiSelect", () => {
           return label?.textContent?.trim() === "Item 2";
         });
         if (item2Checkbox) {
-          expect((item2Checkbox as HTMLInputElement).checked).toBe(true);
+          expect.assert(item2Checkbox instanceof HTMLInputElement);
+          expect(item2Checkbox.checked).toBe(true);
         }
       });
     });

--- a/tests/NumberInput/NumberInput.test.ts
+++ b/tests/NumberInput/NumberInput.test.ts
@@ -546,7 +546,8 @@ describe("NumberInput", () => {
       props: { allowDecimal: true, step: 0.1, value: null },
     });
 
-    const input = screen.getByRole("textbox") as HTMLInputElement;
+    const input = screen.getByRole("textbox");
+    expect.assert(input instanceof HTMLInputElement);
 
     await user.type(input, "1.0");
     expect(input.value).toBe("1.0");
@@ -958,7 +959,8 @@ describe("NumberInput", () => {
       props: { allowDecimal: true, allowEmpty: true, value: null },
     });
 
-    const input = screen.getByRole("textbox") as HTMLInputElement;
+    const input = screen.getByRole("textbox");
+    expect.assert(input instanceof HTMLInputElement);
 
     // Type a valid decimal
     await user.type(input, "1.5");
@@ -980,7 +982,8 @@ describe("NumberInput", () => {
       props: { allowDecimal: true, allowEmpty: true, value: null },
     });
 
-    const input = screen.getByRole("textbox") as HTMLInputElement;
+    const input = screen.getByRole("textbox");
+    expect.assert(input instanceof HTMLInputElement);
 
     // Type a valid decimal then an invalid character
     await user.type(input, "1.5.");
@@ -1391,7 +1394,8 @@ describe("NumberInput", () => {
     it("should format initial value with locale", () => {
       render(NumberInput, { props: { locale: "de-DE", value: 1234.5 } });
 
-      const input = screen.getByRole("textbox") as HTMLInputElement;
+      const input = screen.getByRole("textbox");
+      expect.assert(input instanceof HTMLInputElement);
       // German locale uses period for thousands and comma for decimal
       expect(input.value).toBe("1.234,5");
     });
@@ -1401,7 +1405,8 @@ describe("NumberInput", () => {
         props: { locale: "en-US", value: null, allowEmpty: true },
       });
 
-      const input = screen.getByRole("textbox") as HTMLInputElement;
+      const input = screen.getByRole("textbox");
+      expect.assert(input instanceof HTMLInputElement);
       await user.type(input, "1234.5");
       await user.tab();
 
@@ -1415,7 +1420,8 @@ describe("NumberInput", () => {
         props: { locale: "de-DE", value: null, allowEmpty: true },
       });
 
-      const input = screen.getByRole("textbox") as HTMLInputElement;
+      const input = screen.getByRole("textbox");
+      expect.assert(input instanceof HTMLInputElement);
       await user.type(input, "3,14");
       await user.tab();
 
@@ -1427,7 +1433,8 @@ describe("NumberInput", () => {
         props: { locale: "en-US", value: null, allowEmpty: true },
       });
 
-      const input = screen.getByRole("textbox") as HTMLInputElement;
+      const input = screen.getByRole("textbox");
+      expect.assert(input instanceof HTMLInputElement);
       expect(input.value).toBe("");
     });
 
@@ -1442,7 +1449,8 @@ describe("NumberInput", () => {
 
       await user.click(incrementButton);
 
-      const input = screen.getByRole("textbox") as HTMLInputElement;
+      const input = screen.getByRole("textbox");
+      expect.assert(input instanceof HTMLInputElement);
       expect(input.value).toBe("1.001");
       expect(screen.getByTestId("value").textContent).toBe("1001");
     });
@@ -1458,7 +1466,8 @@ describe("NumberInput", () => {
 
       await user.click(decrementButton);
 
-      const input = screen.getByRole("textbox") as HTMLInputElement;
+      const input = screen.getByRole("textbox");
+      expect.assert(input instanceof HTMLInputElement);
       expect(input.value).toBe("999");
       expect(screen.getByTestId("value").textContent).toBe("999");
     });
@@ -1489,7 +1498,8 @@ describe("NumberInput", () => {
         },
       });
 
-      const input = screen.getByRole("textbox") as HTMLInputElement;
+      const input = screen.getByRole("textbox");
+      expect.assert(input instanceof HTMLInputElement);
       expect(input.value).toBe("1,234.50");
     });
 
@@ -1498,7 +1508,8 @@ describe("NumberInput", () => {
         props: { locale: "de-DE", value: 100, allowEmpty: true },
       });
 
-      const input = screen.getByRole("textbox") as HTMLInputElement;
+      const input = screen.getByRole("textbox");
+      expect.assert(input instanceof HTMLInputElement);
       expect(input.value).toBe("100");
 
       rerender({ locale: "de-DE", value: 1234.5, allowEmpty: true });

--- a/tests/RadioButton/RadioButtonStandalone.test.ts
+++ b/tests/RadioButton/RadioButtonStandalone.test.ts
@@ -8,7 +8,8 @@ describe("RadioButton (Standalone)", () => {
       props: { checked: false },
     });
 
-    const input = screen.getByRole("radio") as HTMLInputElement;
+    const input = screen.getByRole("radio");
+    expect.assert(input instanceof HTMLInputElement);
     expect(input).not.toBeChecked();
 
     component.checked = true;

--- a/tests/TreeView/TreeView.test.ts
+++ b/tests/TreeView/TreeView.test.ts
@@ -137,7 +137,8 @@ describe.each(testCases)("$name", ({ component }) => {
 
     expect(toggleButton).toBeInTheDocument();
 
-    await user.click(toggleButton as HTMLElement);
+    expect.assert(toggleButton instanceof HTMLElement);
+    await user.click(toggleButton);
 
     expect(consoleLog).toHaveBeenCalledWith(
       "toggle",
@@ -801,7 +802,9 @@ describe("TreeView Generics", () => {
 
 describe("TreeView autoCollapse", () => {
   const getToggleButton = (node: HTMLElement) => {
-    return node.querySelector(".bx--tree-parent-node__toggle") as HTMLElement;
+    const button = node.querySelector(".bx--tree-parent-node__toggle");
+    expect.assert(button instanceof HTMLElement);
+    return button;
   };
 
   const getAllExpandedItems = () => {


### PR DESCRIPTION
Runtime instanceof checks are safer than compile-time-only `as` casts.