### PR TITLE
docs(composed-modal): add "Progress modal" example

### DIFF
--- a/docs/src/pages/components/ComposedModal.svx
+++ b/docs/src/pages/components/ComposedModal.svx
@@ -30,6 +30,12 @@ The modal dispatches a cancelable `close` event, allowing you to prevent the mod
 
 <FileSource src="/framed/Modal/ComposedModalPreventClose" />
 
+## Progress modal
+
+Combine `ComposedModal` with `ProgressIndicator` to create a multi-step flow within a modal. Use `ModalFooter`'s default slot to render Cancel (ghost), Previous (secondary), and Next (primary) buttons. Track the current step to control which content is displayed and update the button label on the final step.
+
+<FileSource src="/framed/Modal/ProgressModal" />
+
 ## Multiple secondary buttons
 
 Set `secondaryButtons` in `ModalFooter` to create a 3-button modal. This prop replaces `secondaryButtonText` and takes a tuple of two button configurations.

--- a/docs/src/pages/framed/Modal/ProgressModal.svelte
+++ b/docs/src/pages/framed/Modal/ProgressModal.svelte
@@ -1,0 +1,99 @@
+<script>
+  import {
+    Button,
+    ComposedModal,
+    ModalBody,
+    ModalFooter,
+    ModalHeader,
+    ProgressIndicator,
+    ProgressStep,
+    Stack,
+    TextInput,
+  } from "carbon-components-svelte";
+  import { tick } from "svelte";
+
+  let open = true;
+  let step = 0;
+  let name = "";
+  let region = "";
+
+  async function goNext() {
+    if (step < 2) {
+      step++;
+      await tick();
+      const nextInput = document.querySelector(
+        step === 1 ? "#region-input" : ".bx--modal-container .bx--btn--primary",
+      );
+      nextInput?.focus();
+    } else {
+      open = false;
+    }
+  }
+
+  function handleSubmit() {
+    goNext();
+  }
+</script>
+
+<Button
+  on:click={() => {
+    open = true;
+    step = 0;
+    name = "";
+    region = "";
+  }}
+>
+  Create workspace
+</Button>
+
+<ComposedModal bind:open selectorPrimaryFocus="#name-input">
+  <ModalHeader title="Create workspace" />
+  <ModalBody hasForm>
+    <form id="workspace-form" on:submit|preventDefault={handleSubmit}>
+      <Stack gap={6}>
+        <ProgressIndicator
+          currentIndex={step}
+          spaceEqually
+          preventChangeOnClick
+        >
+          <ProgressStep complete={step > 0} label="General" />
+          <ProgressStep complete={step > 1} label="Configure" />
+          <ProgressStep label="Review" />
+        </ProgressIndicator>
+        {#if step === 0}
+          <TextInput
+            id="name-input"
+            bind:value={name}
+            labelText="Name"
+            placeholder="e.g., My workspace"
+          />
+        {:else if step === 1}
+          <TextInput
+            id="region-input"
+            bind:value={region}
+            labelText="Region"
+            placeholder="e.g., us-east-1"
+          />
+        {:else}
+          <p>Review your workspace configuration before creating.</p>
+          {#if name || region}
+            <p>
+              <strong>Name:</strong>
+              {name || "(not set)"} · <strong>Region:</strong>
+              {region || "(not set)"}
+            </p>
+          {/if}
+        {/if}
+      </Stack>
+    </form>
+  </ModalBody>
+  <ModalFooter>
+    <Button kind="ghost" on:click={() => (open = false)}>Cancel</Button>
+    <Button kind="secondary" disabled={step === 0} on:click={() => step--}>
+      Previous
+    </Button>
+    <Button type="submit" form="workspace-form">
+      {step < 2 ? "Next" : "Create"}
+    </Button>
+  </ModalFooter>
+</ComposedModal>


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon-components-svelte/discussions/1952

Adds an example of a Progress modal (`ComposedModal` + `ProgressIndicator`) with form semantics, auto-focus management, etc..

---

<img width="1085" height="591" alt="Screenshot 2026-02-16 at 12 03 31 PM" src="https://github.com/user-attachments/assets/6290d458-9466-448f-adbe-5e88f5da01bb" />
