### PR TITLE
ci: skip checks for docs-only pushes to master

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -8,6 +8,7 @@ on:
     branches: [master]
     paths-ignore:
       - "**.md"
+      - "docs/**"
       - "examples/**"
   workflow_dispatch:
 


### PR DESCRIPTION
Add `docs/**` to push paths-ignore so docs-only merges match PR behavior and do not run lint or tests.