### PR TITLE
fix(dropdown): menu should close if `portalMenu` is true

### DIFF
--- a/src/Dropdown/Dropdown.svelte
+++ b/src/Dropdown/Dropdown.svelte
@@ -583,6 +583,7 @@
                     }
                     selectedId = item.id;
                     dispatchSelect();
+                    open = false;
                     ref.focus();
                   }}
                   on:mouseenter={() => {
@@ -611,6 +612,7 @@
                 }
                 selectedId = item.id;
                 dispatchSelect();
+                open = false;
                 ref.focus();
               }}
               on:mouseenter={() => {

--- a/tests/Dropdown/Dropdown.test.ts
+++ b/tests/Dropdown/Dropdown.test.ts
@@ -1445,6 +1445,35 @@ describe("Dropdown", () => {
       expect(floatingPortal?.parentElement).toBe(document.body);
     });
 
+    // Regression test for https://github.com/carbon-design-system/carbon-components-svelte/issues/2699
+    it("should close after item click selection with portalMenu", async () => {
+      const selectHandler = vi.fn();
+      render(Dropdown, {
+        props: {
+          items,
+          selectedId: "0",
+          portalMenu: true,
+          onselect: selectHandler,
+        },
+      });
+
+      const button = screen.getByRole("button");
+      await user.click(button);
+      expect(screen.getByRole("listbox")).toBeInTheDocument();
+
+      const menuItemText = screen.getByText("Email");
+      const menuItem = menuItemText.closest(".bx--list-box__menu-item");
+      assert(menuItem);
+      await user.click(menuItem);
+
+      expect(selectHandler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          detail: { selectedId: "1", selectedItem: items[1] },
+        }),
+      );
+      expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    });
+
     it("should not render menu in FloatingPortal when inside Modal with portalMenu=false", () => {
       render(DropdownInModal, {
         props: {


### PR DESCRIPTION
Fixes #2699

`Dropdown` with `portalMenu` does not close the dropdown after selection.