### PR TITLE
fix(ui-shell): remove incorrect role="menu" from `SideNavMenu`

### DIFF
--- a/src/UIShell/SideNavMenu.svelte
+++ b/src/UIShell/SideNavMenu.svelte
@@ -53,9 +53,7 @@
       <ChevronDown />
     </div>
   </button>
-  <!-- svelte-ignore a11y-no-noninteractive-element-to-interactive-role -->
   <ul
-    role="menu"
     inert={expanded ? undefined : "true"}
     class:bx--side-nav__menu={true}
     style:max-height={expanded ? "none" : undefined}


### PR DESCRIPTION
aria `menu` role on SideNavMenu was getting flagged in automated accessibility testing because it's descendants do not have a compatible role (e.g. `menuitem`). This list serves as navigation, is wrapped in `<nav>`, and does not need a menu role or enhanced aria markup at all. 

https://web.dev/articles/website-navigation#navigations_versus_menus