### PR TITLE
docs: update number of `carbon-icons-svelte` to 2,600+

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Design systems facilitate design and development through reuse, consistency, and
 
 The Carbon Svelte portfolio also includes:
 
-- **[Carbon Icons Svelte](https://github.com/carbon-design-system/carbon-icons-svelte)**: 2,500+ Carbon icons as Svelte components
+- **[Carbon Icons Svelte](https://github.com/carbon-design-system/carbon-icons-svelte)**: 2,600+ Carbon icons as Svelte components
 - **[Carbon Pictograms Svelte](https://github.com/carbon-design-system/carbon-pictograms-svelte)**: 1,500+ Carbon pictograms as Svelte components
 - **[Carbon Charts Svelte](https://github.com/carbon-design-system/carbon-charts/tree/master/packages/svelte)**: 25+ charts, powered by d3
 - **[Carbon Preprocess Svelte](https://github.com/carbon-design-system/carbon-preprocess-svelte)**: Collection of Svelte preprocessors for Carbon

--- a/docs/content/overview.md
+++ b/docs/content/overview.md
@@ -141,7 +141,7 @@ You can use the `Theme` component to update the theme at runtime.
 The Carbon Svelte collection includes packages for icons, pictograms, and data visualization:
 
 - **Carbon Components Svelte** — 50+ components — [GitHub](https://github.com/carbon-design-system/carbon-components-svelte)
-- **Carbon Icons Svelte** — 2,500+ icons — [GitHub](https://github.com/carbon-design-system/carbon-icons-svelte)
+- **Carbon Icons Svelte** — 2,600+ icons — [GitHub](https://github.com/carbon-design-system/carbon-icons-svelte)
 - **Carbon Pictograms Svelte** — 1,500+ pictograms — [GitHub](https://github.com/carbon-design-system/carbon-pictograms-svelte)
 - **Carbon Charts Svelte** — 25+ charts, powered by d3 — [GitHub](https://github.com/carbon-design-system/carbon-charts/tree/master/packages/svelte)
 - **Carbon Preprocess Svelte** — Collection of Carbon Svelte preprocessors — [GitHub](https://github.com/carbon-design-system/carbon-preprocess-svelte)

--- a/docs/src/pages/index.svelte
+++ b/docs/src/pages/index.svelte
@@ -288,7 +288,7 @@
         <TileCard
           borderBottom
           title="Carbon Icons Svelte"
-          subtitle="2,500+ icons"
+          subtitle="2,600+ icons"
           target="_blank"
           href="https://github.com/carbon-design-system/carbon-icons-svelte"
         />


### PR DESCRIPTION
https://github.com/carbon-design-system/carbon-icons-svelte/releases/tag/v13.9.0