### PR TITLE
feat(data-table)!: rename `expanded-row` slot to `expandedRow` for Svelte 5 snippet support

### DIFF
--- a/docs/src/pages/components/DataTable.svx
+++ b/docs/src/pages/components/DataTable.svx
@@ -1158,7 +1158,7 @@ Use `nonSelectableRowIds` to prevent selection of specific rows.
 
 ## Expandable rows
 
-Set `expandable` to `true` to make rows expandable. Use the `expanded-row` slot to customize expanded content.
+Set `expandable` to `true` to make rows expandable. Use the `expandedRow` slot to customize expanded content.
 
 <DataTable expandable
   headers="{[
@@ -1212,7 +1212,7 @@ Set `expandable` to `true` to make rows expandable. Use the `expanded-row` slot 
     },
   ]}"
 >
-  <svelte:fragment slot="expanded-row" let:row>
+  <svelte:fragment slot="expandedRow" let:row>
     <pre>{JSON.stringify(row, null, 2)}</pre>
   </svelte:fragment>
 </DataTable>
@@ -1291,7 +1291,7 @@ Set `size="compact"` for expandable rows with minimal height.
     },
   ]}"
 >
-  <svelte:fragment slot="expanded-row" let:row>
+  <svelte:fragment slot="expandedRow" let:row>
     <pre>{JSON.stringify(row, null, 2)}</pre>
   </svelte:fragment>
 </DataTable>
@@ -1352,7 +1352,7 @@ Set `size="short"` for expandable rows with compact height.
     },
   ]}"
 >
-  <svelte:fragment slot="expanded-row" let:row>
+  <svelte:fragment slot="expandedRow" let:row>
     <pre>{JSON.stringify(row, null, 2)}</pre>
   </svelte:fragment>
 </DataTable>
@@ -1413,7 +1413,7 @@ Set `size="tall"` for expandable rows with increased height.
     },
   ]}"
 >
-  <svelte:fragment slot="expanded-row" let:row>
+  <svelte:fragment slot="expandedRow" let:row>
     <pre>{JSON.stringify(row, null, 2)}</pre>
   </svelte:fragment>
 </DataTable>
@@ -1474,7 +1474,7 @@ Set `batchExpansion` to `true` to expand and collapse all rows at once.
     },
   ]}"
 >
-  <svelte:fragment slot="expanded-row" let:row>
+  <svelte:fragment slot="expandedRow" let:row>
     <pre>{JSON.stringify(row, null, 2)}</pre>
   </svelte:fragment>
 </DataTable>

--- a/docs/src/pages/framed/DataTable/DataTableCustomCellRowState.svelte
+++ b/docs/src/pages/framed/DataTable/DataTableCustomCellRowState.svelte
@@ -52,7 +52,7 @@
       {cell.value}
     {/if}
   </svelte:fragment>
-  <svelte:fragment slot="expanded-row" let:row let:rowSelected>
+  <svelte:fragment slot="expandedRow" let:row let:rowSelected>
     <div>
       Additional details for <strong>{row.name}</strong>
       {rowSelected ? "(Currently selected)" : ""}

--- a/docs/src/pages/framed/DataTable/DataTableExpandIcon.svelte
+++ b/docs/src/pages/framed/DataTable/DataTableExpandIcon.svelte
@@ -62,7 +62,7 @@
       style="display: inline-block; transition: transform 0.2s ease; transform: {expanded ? 'rotate(45deg)' : 'rotate(0deg)'}"
     />
   </svelte:fragment>
-  <svelte:fragment slot="expanded-row" let:row>
+  <svelte:fragment slot="expandedRow" let:row>
     <pre>{JSON.stringify(row, null, 2)}</pre>
   </svelte:fragment>
 </DataTable>

--- a/docs/src/pages/framed/DataTable/DataTableExpandableSelectable.svelte
+++ b/docs/src/pages/framed/DataTable/DataTableExpandableSelectable.svelte
@@ -29,7 +29,7 @@
     rule: i % 3 ? "Round robin" : "DNS delegation",
   }))}
 >
-  <svelte:fragment slot="expanded-row" let:row>
+  <svelte:fragment slot="expandedRow" let:row>
     <pre> {JSON.stringify(row, null, 2)}</pre>
   </svelte:fragment>
 </DataTable>

--- a/docs/src/pages/framed/DataTable/DataTableExpandableZebra.svelte
+++ b/docs/src/pages/framed/DataTable/DataTableExpandableZebra.svelte
@@ -57,7 +57,7 @@
     },
   ]}
 >
-  <svelte:fragment slot="expanded-row" let:row>
+  <svelte:fragment slot="expandedRow" let:row>
     <pre>{JSON.stringify(row, null, 2)}</pre>
   </svelte:fragment>
 </DataTable>

--- a/docs/src/pages/framed/DataTable/DataTableNonExpandableRows.svelte
+++ b/docs/src/pages/framed/DataTable/DataTableNonExpandableRows.svelte
@@ -60,7 +60,7 @@
   ]}
   {rows}
 >
-  <svelte:fragment slot="expanded-row" let:row>
+  <svelte:fragment slot="expandedRow" let:row>
     <pre>{JSON.stringify(row, null, 2)}</pre>
   </svelte:fragment>
 </DataTable>

--- a/docs/src/pages/framed/DataTable/DataTableRowClass.svelte
+++ b/docs/src/pages/framed/DataTable/DataTableRowClass.svelte
@@ -68,7 +68,7 @@
     return classes.join(" ") || undefined;
   }}
 >
-  <svelte:fragment slot="expanded-row" let:row>
+  <svelte:fragment slot="expandedRow" let:row>
     <pre>{JSON.stringify(row, null, 2)}</pre>
   </svelte:fragment>
 </DataTable>

--- a/src/DataTable/DataTable.svelte
+++ b/src/DataTable/DataTable.svelte
@@ -27,7 +27,7 @@
    * @property {DataTableValue} value
    * @property {(item: DataTableValue, row: DataTableRow) => DataTableValue} [display]
    * @slot {{ expanded: boolean; row: Row | undefined; props: { "aria-hidden": "true" | "false"; class: string; }; }} expandIcon
-   * @slot {{ row: Row; rowSelected: boolean; }} expanded-row
+   * @slot {{ row: Row; rowSelected: boolean; }} expandedRow
    * @slot {{ header: DataTableNonEmptyHeader; }} cellHeader
    * @slot {{ row: Row; cell: DataTableCell<Row>; rowIndex: number; cellIndex: number; rowSelected: boolean; rowExpanded: boolean; }} cell
    * @event click
@@ -901,7 +901,7 @@
                   >
                     <div class:bx--child-row-inner-container={true}>
                       <slot
-                        name="expanded-row"
+                        name="expandedRow"
                         {row}
                         rowSelected={selectedRowIdsSet.has(row.id)}
                       />
@@ -1100,7 +1100,7 @@
                   >
                     <div class:bx--child-row-inner-container={true}>
                       <slot
-                        name="expanded-row"
+                        name="expandedRow"
                         {row}
                         rowSelected={isSelected}
                       />

--- a/tests-svelte5/svelte5/snippets/Snippets.test.svelte
+++ b/tests-svelte5/svelte5/snippets/Snippets.test.svelte
@@ -37,9 +37,9 @@
       data-expanded={expanded}
     ></span>
   {/snippet}
-  <svelte:fragment slot="expanded-row" let:row>
+  {#snippet expandedRow({ row, rowSelected })}
     <pre>{JSON.stringify(row, null, 2)}</pre>
-  </svelte:fragment>
+  {/snippet}
 </DataTable>
 
 <Dropdown data-testid="dropdown-snippet" {items} selectedId="1">
@@ -49,7 +49,9 @@
 </Dropdown>
 
 <Dropdown data-testid="dropdown-label-children" {items} selectedId="1">
-  <span slot="labelChildren" data-testid="dropdown-custom-label">Custom label content</span>
+  {#snippet labelChildren()}
+    <span data-testid="dropdown-custom-label">Custom label content</span>
+  {/snippet}
 </Dropdown>
 
 <ComboBox data-testid="combobox-snippet" {items}>

--- a/tests/DataTable/DataTable.test.ts
+++ b/tests/DataTable/DataTable.test.ts
@@ -1050,7 +1050,7 @@ describe("DataTable", () => {
     expect(expandedRow).toHaveClass("bx--expandable-row");
   });
 
-  it("passes rowSelected prop to expanded-row slot", () => {
+  it("passes rowSelected prop to expandedRow slot", () => {
     const { container } = render(DataTable, {
       props: {
         selectable: true,

--- a/tests/DataTable/DataTableExpandIcon.test.svelte
+++ b/tests/DataTable/DataTableExpandIcon.test.svelte
@@ -21,7 +21,7 @@
       data-expanded={expanded}
     />
   </svelte:fragment>
-  <svelte:fragment slot="expanded-row" let:row>
+  <svelte:fragment slot="expandedRow" let:row>
     <pre>{JSON.stringify(row, null, 2)}</pre>
   </svelte:fragment>
 </DataTable>

--- a/tests/DataTable/DataTableGenerics.test.svelte
+++ b/tests/DataTable/DataTableGenerics.test.svelte
@@ -104,7 +104,7 @@
     console.log("Expanded:", row.id);
   }}
 >
-  <svelte:fragment slot="expanded-row" let:row>
+  <svelte:fragment slot="expandedRow" let:row>
     <p>Expanded content for {row.name}</p>
   </svelte:fragment>
 </DataTable>

--- a/tests/DataTable/DataTableGenerics.test.ts
+++ b/tests/DataTable/DataTableGenerics.test.ts
@@ -306,7 +306,7 @@ describe("DataTable Generics", () => {
       consoleLog.mockRestore();
     });
 
-    it("should provide correctly typed row to expanded-row slot", async () => {
+    it("should provide correctly typed row to expandedRow slot", async () => {
       const { container } = render(DataTableGenerics);
 
       // Find expand button in the third table


### PR DESCRIPTION
Stacked on #2709

The `expanded-row` slot should be renamed so that it can be used using Svelte 5 snippet syntax.