### PR TITLE
fix(tree-view): use correct leaf depth to restore active node style

### DIFF
--- a/src/TreeView/TreeViewNode.svelte
+++ b/src/TreeView/TreeViewNode.svelte
@@ -87,7 +87,7 @@
     focusNode,
   } = getContext("carbon:TreeView");
   const offset = () =>
-    computeTreeLeafDepth(refLabel) + (leaf && icon ? 2 : 2.5);
+    computeTreeLeafDepth(refLabel) - 1 + (leaf && icon ? 2 : 2.5);
 
   afterUpdate(() => {
     if (id === $activeNodeId && prevActiveId !== $activeNodeId) {

--- a/src/TreeView/TreeViewNodeList.svelte
+++ b/src/TreeView/TreeViewNodeList.svelte
@@ -41,7 +41,7 @@
   } = getContext("carbon:TreeView");
 
   const offset = () => {
-    const depth = computeTreeLeafDepth(refLabel);
+    const depth = computeTreeLeafDepth(refLabel) - 1;
 
     if (parent) return depth + 1;
     if (icon) return depth + 2;

--- a/tests/TreeView/TreeView.test.ts
+++ b/tests/TreeView/TreeView.test.ts
@@ -346,6 +346,64 @@ describe("TreeView Props", () => {
     expect(node2).toHaveClass("bx--tree-node--active");
   });
 
+  describe("active node label indentation regression", () => {
+    it("applies correct offset to root-level leaf node label (prevents active indicator clipping)", () => {
+      render(TreeViewProps, { activeId: 1 });
+
+      const activeNode = screen.getByRole("treeitem", { name: /Node 2/ });
+      const label = activeNode.querySelector(".bx--tree-node__label");
+      expect.assert(label instanceof HTMLElement);
+      expect(label.style.paddingLeft).toBe("2.5rem");
+      expect(label.style.marginLeft).toBe("-2.5rem");
+    });
+
+    it("applies correct offset to nested leaf node label when expanded", () => {
+      render(TreeViewProps, {
+        activeId: 5,
+        expandedIds: [1],
+        nodes: [
+          { id: 0, text: "Node 1" },
+          {
+            id: 1,
+            text: "Node 2",
+            nodes: [
+              { id: 2, text: "Node 2a" },
+              { id: 5, text: "Node 2b" },
+            ],
+          },
+        ],
+      });
+
+      const activeNode = screen.getByRole("treeitem", { current: true });
+      const label = activeNode.querySelector(".bx--tree-node__label");
+      expect.assert(label instanceof HTMLElement);
+      // Nested at depth 2: offset = (2 - 1) + 2.5 = 3.5rem
+      expect(label.style.paddingLeft).toBe("3.5rem");
+      expect(label.style.marginLeft).toBe("-3.5rem");
+    });
+
+    it("applies correct offset to root-level parent node label", () => {
+      render(TreeViewProps, {
+        activeId: 1,
+        nodes: [
+          { id: 0, text: "Node 1" },
+          {
+            id: 1,
+            text: "Node 2",
+            nodes: [{ id: 2, text: "Node 2a" }],
+          },
+        ],
+      });
+
+      const activeNode = screen.getByRole("treeitem", { name: /Node 2/ });
+      const label = activeNode.querySelector(".bx--tree-node__label");
+      expect.assert(label instanceof HTMLElement);
+      // Root parent: offset = (1 - 1) + 1 = 1rem
+      expect(label.style.paddingLeft).toBe("1rem");
+      expect(label.style.marginLeft).toBe("-1rem");
+    });
+  });
+
   it("handles multiple selectedIds", () => {
     render(TreeViewMultiselect, { selectedIds: [0, 7, 9] });
 


### PR DESCRIPTION
This fixes a visual regression where the active node's left outline is cut off.

The issue was that `computeTreeLeafDepth(refLabel)` counts the node's own `<li>` wrapper as a depth level, so root nodes returned depth=1 instead of 0. This made every node's indentation 1rem too large (e.g., root: 3.5rem instead of 2.5rem).

The fix subtracts 1 from the depth in both `TreeViewNode.svelte` and `TreeViewNodeList.svelte` offset calculations, so:
- **Root leaf node**: 0 + 2.5 = **2.5rem** (was 3.5)
- **Root parent node**: 0 + 1 = **1rem** (was 2)
- Each nesting level still adds 1rem as expected

---

## Before
<img width="747" height="260" alt="Screenshot 2026-03-07 at 9 54 53 AM" src="https://github.com/user-attachments/assets/ff4cbc77-e643-4453-9b9b-114f146a336d" />


## After
<img width="728" height="266" alt="Screenshot 2026-03-07 at 9 50 04 AM" src="https://github.com/user-attachments/assets/7ceeb625-4481-479f-8cd0-716812c5d61e" />
