### PR TITLE
fix(inline-notification): title uses `strong` element for emphasis

### DIFF
--- a/src/Notification/InlineNotification.svelte
+++ b/src/Notification/InlineNotification.svelte
@@ -103,7 +103,7 @@
       <div class:bx--inline-notification__text-wrapper={true}>
         {#if title || $$slots.titleChildren}
           <p class:bx--inline-notification__title={true}>
-            <slot name="titleChildren">{title}</slot>
+            <strong><slot name="titleChildren">{title}</slot></strong>
           </p>
         {/if}
         {#if subtitle || $$slots.subtitleChildren}


### PR DESCRIPTION
Wrapping the title slot with a `<strong>` so that bolded text is conveyed semantically. 

This should help with [WCAG 1.3.1 "Info and Relationships (Level A)"](https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships) by using [technique H49 "Using semantic markup to mark emphasized or special text" ](https://www.w3.org/WAI/WCAG21/Techniques/html/H49)