### PR TITLE
docs: extract `data-centered` and `data-outline` style utilities

### DIFF
--- a/docs/src/pages/framed/ContextMenu/ContextMenu.svelte
+++ b/docs/src/pages/framed/ContextMenu/ContextMenu.svelte
@@ -41,18 +41,6 @@
   <ContextMenuOption indented kind="danger" labelText="Delete" />
 </ContextMenu>
 
-<div>
+<div data-centered>
   <p>Right click anywhere on this page</p>
 </div>
-
-<style>
-  div {
-    position: absolute;
-    width: calc(100% - var(--cds-spacing-05));
-    height: calc(100% - var(--cds-spacing-06));
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    color: var(--cds-text-02);
-  }
-</style>

--- a/docs/src/pages/framed/ContextMenu/ContextMenuGroups.svelte
+++ b/docs/src/pages/framed/ContextMenu/ContextMenuGroups.svelte
@@ -22,18 +22,6 @@
   <ContextMenuOption selectable labelText="Lock layer" />
 </ContextMenu>
 
-<div>
+<div data-centered>
   <p>Right click anywhere on this page</p>
 </div>
-
-<style>
-  div {
-    position: absolute;
-    width: calc(100% - var(--cds-spacing-05));
-    height: calc(100% - var(--cds-spacing-06));
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    color: var(--cds-text-02);
-  }
-</style>

--- a/docs/src/pages/framed/ContextMenu/ContextMenuPreventDefault.svelte
+++ b/docs/src/pages/framed/ContextMenu/ContextMenuPreventDefault.svelte
@@ -44,18 +44,6 @@
   />
 </ContextMenu>
 
-<div>
+<div data-centered>
   <p>Right click anywhere on this page</p>
 </div>
-
-<style>
-  div {
-    position: absolute;
-    width: calc(100% - var(--cds-spacing-05));
-    height: calc(100% - var(--cds-spacing-06));
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    color: var(--cds-text-02);
-  }
-</style>

--- a/docs/src/pages/framed/ContextMenu/ContextMenuTarget.svelte
+++ b/docs/src/pages/framed/ContextMenu/ContextMenuTarget.svelte
@@ -39,22 +39,6 @@
   <ContextMenuOption indented kind="danger" labelText="Delete" />
 </ContextMenu>
 
-<div>
-  <p bind:this={target}>Right click this element</p>
+<div data-centered>
+  <p data-outline bind:this={target}>Right click this element</p>
 </div>
-
-<style>
-  div {
-    position: absolute;
-    width: calc(100% - var(--cds-spacing-05));
-    height: calc(100% - var(--cds-spacing-06));
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    color: var(--cds-text-02);
-  }
-
-  p {
-    outline: 1px solid var(--cds-interactive-01);
-  }
-</style>

--- a/docs/src/pages/framed/ContextMenu/ContextMenuTargets.svelte
+++ b/docs/src/pages/framed/ContextMenu/ContextMenuTargets.svelte
@@ -40,23 +40,7 @@
   <ContextMenuOption indented kind="danger" labelText="Delete" />
 </ContextMenu>
 
-<div>
-  <p bind:this={target}>Right click this element</p>
-  <p bind:this={target2}>... or this one</p>
+<div data-centered>
+  <p data-outline bind:this={target}>Right click this element</p>
+  <p data-outline bind:this={target2}>... or this one</p>
 </div>
-
-<style>
-  div {
-    position: absolute;
-    width: calc(100% - var(--cds-spacing-05));
-    height: calc(100% - var(--cds-spacing-06));
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    color: var(--cds-text-02);
-  }
-
-  p {
-    outline: 1px solid var(--cds-interactive-01);
-  }
-</style>

--- a/docs/src/pages/framed/_reset.svelte
+++ b/docs/src/pages/framed/_reset.svelte
@@ -79,4 +79,18 @@
   :global(.framed .bx--content [class^="bx--col"]) {
     outline: 0;
   }
+
+  :global([data-outline]) {
+    outline: 1px solid var(--cds-interactive-01);
+  }
+
+  :global([data-centered]) {
+    position: absolute;
+    width: calc(100% - var(--cds-spacing-05));
+    height: calc(100% - var(--cds-spacing-06));
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--cds-text-02);
+  }
 </style>


### PR DESCRIPTION
Avoid including bespoke CSS in docs examples.