### PR TITLE
fix(tooltip-icon): only one tooltip is visible at a time

### DIFF
--- a/src/TooltipIcon/TooltipIcon.svelte
+++ b/src/TooltipIcon/TooltipIcon.svelte
@@ -3,6 +3,10 @@
    * @generics {Icon = any} Icon
    */
 
+  import { onMount } from "svelte";
+  import { get } from "svelte/store";
+  import { activeTooltipIcon } from "./tooltip-icon-store.js";
+
   /**
    * Specify the tooltip text.
    * Alternatively, use the "tooltipText" slot.
@@ -43,13 +47,29 @@
   /** Obtain a reference to the button HTML element */
   export let ref = null;
 
+  const tooltipId = {};
+
   let hidden = false;
+
+  $: tooltipHidden =
+    $activeTooltipIcon !== null && $activeTooltipIcon !== tooltipId;
+
+  onMount(() => {
+    return () => {
+      if (get(activeTooltipIcon) === tooltipId) {
+        activeTooltipIcon.set(null);
+      }
+    };
+  });
 </script>
 
 <svelte:window
   on:keydown={({ key }) => {
     if (key === "Escape") {
       hidden = true;
+      if ($activeTooltipIcon === tooltipId) {
+        activeTooltipIcon.set(null);
+      }
     }
   }}
 />
@@ -61,7 +81,7 @@
   aria-describedby={id}
   class:bx--tooltip__trigger={true}
   class:bx--tooltip--a11y={true}
-  class:bx--tooltip--hidden={hidden || disabled}
+  class:bx--tooltip--hidden={hidden || disabled || tooltipHidden}
   class:bx--tooltip--top={direction === "top"}
   class:bx--tooltip--right={direction === "right"}
   class:bx--tooltip--bottom={direction === "bottom"}
@@ -77,15 +97,22 @@
   on:mouseenter={() => {
     if (disabled) return;
     hidden = false;
+    activeTooltipIcon.set(tooltipId);
   }}
   on:mouseleave
+  on:mouseleave={() => {
+    if ($activeTooltipIcon === tooltipId) {
+      activeTooltipIcon.set(null);
+    }
+  }}
   on:focus
   on:focus={() => {
     if (disabled) return;
     hidden = false;
+    activeTooltipIcon.set(tooltipId);
   }}
 >
-  <span {id} class:bx--assistive-text={true}>
+  <span {id} class:bx--assistive-text={true} style:pointer-events="none">
     <slot name="tooltipText">{tooltipText}</slot>
   </span>
   <slot> <svelte:component this={icon} {size} /> </slot>

--- a/src/TooltipIcon/tooltip-icon-store.d.ts
+++ b/src/TooltipIcon/tooltip-icon-store.d.ts
@@ -1,0 +1,3 @@
+import type { Writable } from "svelte/store";
+
+export declare const activeTooltipIcon: Writable<object | null>;

--- a/src/TooltipIcon/tooltip-icon-store.js
+++ b/src/TooltipIcon/tooltip-icon-store.js
@@ -1,0 +1,4 @@
+import { writable } from "svelte/store";
+
+/** @type {import('svelte/store').Writable<object | null>} */
+export const activeTooltipIcon = writable(null);

--- a/tests/TooltipIcon/TooltipIcon.test.ts
+++ b/tests/TooltipIcon/TooltipIcon.test.ts
@@ -1,10 +1,11 @@
-import { render, screen } from "@testing-library/svelte";
+import { fireEvent, render, screen } from "@testing-library/svelte";
 import type { TooltipIcon as TooltipIconSource } from "carbon-components-svelte";
 import type TooltipIconComponent from "carbon-components-svelte/TooltipIcon/TooltipIcon.svelte";
 import type { ComponentProps } from "svelte";
 import { user } from "../setup-tests";
 import TooltipIconSize from "./TooltipIcon.size.test.svelte";
 import TooltipIcon from "./TooltipIcon.test.svelte";
+import TooltipIconMultiple from "./TooltipIconMultiple.test.svelte";
 
 type Props = ComponentProps<TooltipIconSource>;
 
@@ -154,6 +155,47 @@ describe("TooltipIcon", () => {
       expectTypeOf<24>().toExtend<Props["size"]>();
       expectTypeOf<32>().toExtend<Props["size"]>();
       expectTypeOf<number>().toExtend<NonNullable<Props["size"]>>();
+    });
+  });
+
+  describe("adjacent tooltip icons", () => {
+    it("should only show one tooltip at a time when hovering between icons", async () => {
+      render(TooltipIconMultiple);
+
+      const btnA = screen.getByTestId("tooltip-a");
+      const btnB = screen.getByTestId("tooltip-b");
+      const btnC = screen.getByTestId("tooltip-c");
+
+      // Initially no button should have bx--tooltip--hidden.
+      expect(btnA).not.toHaveClass("bx--tooltip--hidden");
+      expect(btnB).not.toHaveClass("bx--tooltip--hidden");
+      expect(btnC).not.toHaveClass("bx--tooltip--hidden");
+
+      // Hover tooltip A: others should get bx--tooltip--hidden.
+      await fireEvent.mouseEnter(btnA);
+      expect(btnA).not.toHaveClass("bx--tooltip--hidden");
+      expect(btnB).toHaveClass("bx--tooltip--hidden");
+      expect(btnC).toHaveClass("bx--tooltip--hidden");
+
+      // Hover tooltip B: A and C should get bx--tooltip--hidden.
+      await fireEvent.mouseEnter(btnB);
+      expect(btnA).toHaveClass("bx--tooltip--hidden");
+      expect(btnB).not.toHaveClass("bx--tooltip--hidden");
+      expect(btnC).toHaveClass("bx--tooltip--hidden");
+    });
+
+    it("should clear tooltip hidden state on mouseleave", async () => {
+      render(TooltipIconMultiple);
+
+      const btnA = screen.getByTestId("tooltip-a");
+      const btnB = screen.getByTestId("tooltip-b");
+
+      await fireEvent.mouseEnter(btnA);
+      expect(btnB).toHaveClass("bx--tooltip--hidden");
+
+      await fireEvent.mouseLeave(btnA);
+      expect(btnA).not.toHaveClass("bx--tooltip--hidden");
+      expect(btnB).not.toHaveClass("bx--tooltip--hidden");
     });
   });
 

--- a/tests/TooltipIcon/TooltipIconMultiple.test.svelte
+++ b/tests/TooltipIcon/TooltipIconMultiple.test.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+  import { TooltipIcon } from "carbon-components-svelte";
+  import Carbon from "carbon-icons-svelte/lib/Carbon.svelte";
+</script>
+
+<TooltipIcon data-testid="tooltip-a" tooltipText="Tooltip A" icon={Carbon} />
+<TooltipIcon data-testid="tooltip-b" tooltipText="Tooltip B" icon={Carbon} />
+<TooltipIcon data-testid="tooltip-c" tooltipText="Tooltip C" icon={Carbon} />


### PR DESCRIPTION
Related #2638

Only one tooltip should be visible at a time. This avoids the papercut where mousing over a right-aligned tooltip unintentionally keeps it open.

---

## Before

https://github.com/user-attachments/assets/8abb96b5-d986-4d32-a70c-57d18bb838d4

## After

https://github.com/user-attachments/assets/db5d6cbb-ab6e-4af1-b2d4-77443b0b90e5

