### PR TITLE
feat(theme): set `color-scheme` on root element

### DIFF
--- a/src/Theme/Theme.svelte
+++ b/src/Theme/Theme.svelte
@@ -102,6 +102,10 @@
 
     if (theme in themes) {
       document.documentElement.setAttribute("theme", theme);
+      document.documentElement.style.setProperty(
+        "color-scheme",
+        theme === "white" || theme === "g10" ? "light" : "dark",
+      );
     } else {
       console.warn(
         `[Theme.svelte] invalid theme "${theme}". Value must be one of: ${JSON.stringify(

--- a/tests/Theme/Theme.test.ts
+++ b/tests/Theme/Theme.test.ts
@@ -83,6 +83,37 @@ describe("Theme", () => {
     expect(documentMock.setAttribute).toHaveBeenCalledWith("theme", "white");
   });
 
+  it.each<[CarbonTheme, "light" | "dark"]>([
+    ["white", "light"],
+    ["g10", "light"],
+    ["g80", "dark"],
+    ["g90", "dark"],
+    ["g100", "dark"],
+  ])("when theme is %s, should set color-scheme to %s", (theme, expected) => {
+    render(Theme, { props: { theme } });
+    expect(documentMock.style.setProperty).toHaveBeenCalledWith(
+      "color-scheme",
+      expected,
+    );
+  });
+
+  it("should update color-scheme when theme changes", async () => {
+    const { rerender } = render(Theme);
+
+    expect(documentMock.style.setProperty).toHaveBeenCalledWith(
+      "color-scheme",
+      "light",
+    );
+
+    rerender({ theme: "g100" });
+    await tick();
+
+    expect(documentMock.style.setProperty).toHaveBeenCalledWith(
+      "color-scheme",
+      "dark",
+    );
+  });
+
   it("should update theme attribute when theme changes", async () => {
     const { rerender } = render(Theme);
 


### PR DESCRIPTION
`Theme` should also set `color-scheme` (impacting browser default scrollbar colors) based on theme classification.