### PR TITLE
 fix(side-nav-menu): `button` should not nest `div` elements

### DIFF
--- a/src/UIShell/SideNavMenu.svelte
+++ b/src/UIShell/SideNavMenu.svelte
@@ -42,18 +42,18 @@
     }}
   >
     {#if $$slots.icon || icon}
-      <div class:bx--side-nav__icon={true}>
+      <span class:bx--side-nav__icon={true}>
         <slot name="icon"> <svelte:component this={icon} /> </slot>
-      </div>
+      </span>
     {/if}
     <span class:bx--side-nav__submenu-title={true}>{text}</span>
-    <div
+    <span
       class:bx--side-nav__icon={true}
       class:bx--side-nav__icon--small={true}
       class:bx--side-nav__submenu-chevron={true}
     >
       <ChevronDown />
-    </div>
+    </span>
   </button>
   <ul
     inert={expanded ? undefined : "true"}


### PR DESCRIPTION
div is flow content and not valid inside button elements. Need to use [phrasing content](https://html.spec.whatwg.org/multipage/dom.html#phrasing-content) per the HTML spec.