### PR TITLE
fix(toolbar-search): remove redundant `<any>` from Row generics

### DIFF
--- a/src/DataTable/ToolbarSearch.svelte
+++ b/src/DataTable/ToolbarSearch.svelte
@@ -1,7 +1,7 @@
 <script>
   /**
-   * @generics {Row extends import("./DataTable.svelte").DataTableRow<any> = import("./DataTable.svelte").DataTableRow<any>} Row
-   * @template {import("./DataTable.svelte").DataTableRow<any>} Row
+   * @generics {Row extends import("./DataTable.svelte").DataTableRow = import("./DataTable.svelte").DataTableRow} Row
+   * @template {import("./DataTable.svelte").DataTableRow} Row
    * @restProps {input}
    * @event {null} clear
    */


### PR DESCRIPTION
`DataTableRow` ID already defaults to `any`.