### PR TITLE
build(scripts): use `compileAsync` for faster CSS builds

### DIFF
--- a/scripts/build-css.ts
+++ b/scripts/build-css.ts
@@ -2,7 +2,7 @@ import path from "node:path";
 import autoprefixer from "autoprefixer";
 import { Glob } from "bun";
 import postcss from "postcss";
-import sass from "sass";
+import { compileAsync } from "sass";
 
 const PARTIAL_FILE_REGEX = /^_/;
 
@@ -18,12 +18,10 @@ await Promise.all(
 
     console.log("[build-css]", file, "-->", outFile);
 
-    const { css } = sass.renderSync({
-      file,
-      outFile,
-      outputStyle: "compressed",
-      omitSourceMapUrl: true,
-      includePaths: ["node_modules"],
+    const { css } = await compileAsync(file, {
+      style: "compressed",
+      sourceMap: false,
+      loadPaths: ["node_modules"],
     });
 
     const prefixed = await postcss([


### PR DESCRIPTION
Use `sass.compileAsync` for faster CSS builds.

## Baseline

```sh
hyperfine --runs 3 "bun build:css"
Benchmark 1: bun build:css
  Time (mean ± σ):     130.032 s ±  6.739 s    [User: 136.742 s, System: 9.422 s]
  Range (min … max):   125.702 s … 137.796 s    3 runs
```

## After (~2.54x faster, ~60.6% time reduction)

```sh
hyperfine --runs 3 "bun build:css"
Benchmark 1: bun build:css
  Time (mean ± σ):     51.220 s ±  2.308 s    [User: 72.146 s, System: 2.183 s]
  Range (min … max):   48.727 s … 53.284 s    3 runs
```