### PR TITLE
fix(dropdown): selected item has checkmark icon

### DIFF
--- a/src/Dropdown/Dropdown.svelte
+++ b/src/Dropdown/Dropdown.svelte
@@ -143,6 +143,7 @@
     onMount,
     tick,
   } from "svelte";
+  import Checkmark from "../icons/Checkmark.svelte";
   import WarningAltFilled from "../icons/WarningAltFilled.svelte";
   import WarningFilled from "../icons/WarningFilled.svelte";
   import {
@@ -593,6 +594,9 @@
                   }}
                 >
                   <slot {item} index={actualIndex}> {itemToString(item)} </slot>
+                  {#if selectedId === item.id}
+                    <Checkmark class="bx--list-box__menu-item__selected-icon" />
+                  {/if}
                 </ListBoxMenuItem>
               {/each}
             </div>
@@ -620,6 +624,9 @@
               }}
             >
               <slot {item} index={i}> {itemToString(item)} </slot>
+              {#if selectedId === item.id}
+                <Checkmark class="bx--list-box__menu-item__selected-icon" />
+              {/if}
             </ListBoxMenuItem>
           {/each}
         {/if}

--- a/tests/Dropdown/Dropdown.test.ts
+++ b/tests/Dropdown/Dropdown.test.ts
@@ -1489,4 +1489,75 @@ describe("Dropdown", () => {
       expect(floatingPortal).not.toBeInTheDocument();
     });
   });
+
+  describe("checkmark icon", () => {
+    it("should render a checkmark icon for the selected item", async () => {
+      render(Dropdown, {
+        props: { items, selectedId: "1", labelText: "Contact" },
+      });
+
+      await user.click(screen.getByRole("button"));
+
+      const options = screen.getAllByRole("option");
+      // "Email" (index 1) is selected – should have the checkmark icon
+      const selectedOption = options[1];
+      const checkmark = selectedOption.querySelector(
+        ".bx--list-box__menu-item__selected-icon",
+      );
+      expect(checkmark).toBeInTheDocument();
+
+      // Non-selected options should not have the checkmark icon
+      expect(
+        options[0].querySelector(".bx--list-box__menu-item__selected-icon"),
+      ).not.toBeInTheDocument();
+      expect(
+        options[2].querySelector(".bx--list-box__menu-item__selected-icon"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("should move the checkmark icon when selection changes", async () => {
+      render(Dropdown, {
+        props: { items, selectedId: "0", labelText: "Contact" },
+      });
+
+      await user.click(screen.getByRole("button"));
+
+      let options = screen.getAllByRole("option");
+      expect(
+        options[0].querySelector(".bx--list-box__menu-item__selected-icon"),
+      ).toBeInTheDocument();
+      expect(
+        options[1].querySelector(".bx--list-box__menu-item__selected-icon"),
+      ).not.toBeInTheDocument();
+
+      // Select "Email"
+      await user.click(options[1]);
+
+      // Re-open the menu
+      await user.click(screen.getByRole("button"));
+
+      options = screen.getAllByRole("option");
+      expect(
+        options[0].querySelector(".bx--list-box__menu-item__selected-icon"),
+      ).not.toBeInTheDocument();
+      expect(
+        options[1].querySelector(".bx--list-box__menu-item__selected-icon"),
+      ).toBeInTheDocument();
+    });
+
+    it("should not render a checkmark when no item is selected", async () => {
+      render(Dropdown, {
+        props: { items, labelText: "Contact" },
+      });
+
+      await user.click(screen.getByRole("button"));
+
+      const options = screen.getAllByRole("option");
+      for (const option of options) {
+        expect(
+          option.querySelector(".bx--list-box__menu-item__selected-icon"),
+        ).not.toBeInTheDocument();
+      }
+    });
+  });
 });


### PR DESCRIPTION
Not sure how this was missed for so long.

The selected `Dropdown` item should have a checkmark icon. This greatly helps visually; before, a slight background color difference was the only way to differentiate the selected item.

...

<img width="876" height="249" alt="Screenshot 2026-04-04 at 10 56 22 AM" src="https://github.com/user-attachments/assets/6d84add9-78fd-4931-9caf-bcc909516c48" />
