### PR TITLE
perf(data-table): remove unused `thKeys` computation

### DIFF
--- a/src/DataTable/DataTable.svelte
+++ b/src/DataTable/DataTable.svelte
@@ -341,11 +341,6 @@
   // Store a copy of the original rows for filter restoration.
   $: originalRows = [...rows];
 
-  $: thKeys = headers.reduce((a, c) => {
-    a[c.key] = c.key;
-    return a;
-  }, {});
-
   /**
    * @type {() => void}
    */
@@ -707,7 +702,7 @@
                         };
                     sortDirection = sortDirectionMap[currentSortDirection];
                     sortKey =
-                      sortDirection === "none" ? null : thKeys[header.key];
+                      sortDirection === "none" ? null : header.key;
                     dispatch("click:header", {
                       header,
                       sortDirection,


### PR DESCRIPTION
`thKeys` does not need derivation, and can be removed.