### PR TITLE
perf(data-table): rebuild `tableCellsByRowId` for changed headers only

### DIFF
--- a/src/DataTable/DataTable.svelte
+++ b/src/DataTable/DataTable.svelte
@@ -446,17 +446,30 @@
   let tableCellsByRowId = {};
   let prevRows;
   let prevHeaders;
+  let rowRefById = {};
+
   $: if (rows !== prevRows || headers !== prevHeaders) {
-    tableCellsByRowId = rows.reduce((rowsAcc, row) => {
-      rowsAcc[row.id] = headers.map((header, index) => ({
-        key: header.key ?? `key-${index}`,
-        value: header.key ? resolvePath(row, header.key) : undefined,
-        display: header.display,
-        empty: header.empty,
-        columnMenu: header.columnMenu,
-      }));
-      return rowsAcc;
-    }, {});
+    const headersChanged = headers !== prevHeaders;
+    const next = {};
+    const nextRefs = {};
+
+    for (const row of rows) {
+      if (!headersChanged && rowRefById[row.id] === row) {
+        next[row.id] = tableCellsByRowId[row.id];
+      } else {
+        next[row.id] = headers.map((header, index) => ({
+          key: header.key ?? `key-${index}`,
+          value: header.key ? resolvePath(row, header.key) : undefined,
+          display: header.display,
+          empty: header.empty,
+          columnMenu: header.columnMenu,
+        }));
+      }
+      nextRefs[row.id] = row;
+    }
+
+    tableCellsByRowId = next;
+    rowRefById = nextRefs;
     prevRows = rows;
     prevHeaders = headers;
   }

--- a/tests/DataTable/DataTableTableCellsCache.test.svelte
+++ b/tests/DataTable/DataTableTableCellsCache.test.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import { DataTable } from "carbon-components-svelte";
+  import type { DataTableHeader } from "carbon-components-svelte/DataTable/DataTable.svelte";
+
+  type Row = {
+    id: string;
+    name: string;
+    protocol?: string;
+  };
+
+  export let headers: ReadonlyArray<DataTableHeader<Row>> = [
+    { key: "name", value: "Name" },
+  ];
+
+  export let rows: ReadonlyArray<Row>;
+
+  export let onCellClick: (cell: { key: string; value: unknown }) => void =
+    () => {};
+</script>
+
+<DataTable {headers} {rows} on:click:cell={(e) => onCellClick(e.detail.cell)} />

--- a/tests/DataTable/DataTableTableCellsCache.test.ts
+++ b/tests/DataTable/DataTableTableCellsCache.test.ts
@@ -1,0 +1,111 @@
+import { render, screen, within } from "@testing-library/svelte";
+import { tick } from "svelte";
+import { user } from "../setup-tests";
+import DataTableTableCellsCache from "./DataTableTableCellsCache.test.svelte";
+
+function getFirstBodyRow(): HTMLElement {
+  const rows = screen
+    .getAllByRole("row")
+    .filter((r) => r.closest("tbody") !== null);
+  expect(rows.length).toBeGreaterThan(0);
+  return rows[0];
+}
+
+describe("DataTable tableCellsByRowId caching", () => {
+  const headers = [{ key: "name", value: "Name" }] as const;
+
+  it("reuses cell objects when rows is a new array but row references are unchanged", async () => {
+    const row = { id: "a", name: "Alpha" };
+    let lastCell: { key: string; value: unknown } | undefined;
+
+    const { rerender } = render(DataTableTableCellsCache, {
+      props: {
+        headers,
+        rows: [row],
+        onCellClick: (cell) => {
+          lastCell = cell;
+        },
+      },
+    });
+
+    const bodyRow = getFirstBodyRow();
+    const nameCell = within(bodyRow).getByRole("cell", { name: "Alpha" });
+    await user.click(nameCell);
+    const first = lastCell;
+    expect(first).toBeDefined();
+    expect(first).toEqual(expect.objectContaining({ key: "name" }));
+
+    await rerender({
+      rows: [row],
+    });
+    await tick();
+
+    await user.click(within(bodyRow).getByRole("cell", { name: "Alpha" }));
+    expect(lastCell).toBe(first);
+  });
+
+  it("rebuilds cell objects when the row object for an id is replaced", async () => {
+    const rowV1 = { id: "a", name: "Alpha" };
+    const rowV2 = { id: "a", name: "Beta" };
+    let lastCell: { key: string; value: unknown } | undefined;
+
+    const { rerender } = render(DataTableTableCellsCache, {
+      props: {
+        headers,
+        rows: [rowV1],
+        onCellClick: (cell) => {
+          lastCell = cell;
+        },
+      },
+    });
+
+    await user.click(
+      within(getFirstBodyRow()).getByRole("cell", { name: "Alpha" }),
+    );
+    const first = lastCell;
+    expect(first).toBeDefined();
+
+    await rerender({ rows: [rowV2] });
+    await tick();
+
+    await user.click(
+      within(getFirstBodyRow()).getByRole("cell", { name: "Beta" }),
+    );
+    expect(lastCell).not.toBe(first);
+    expect(lastCell).toEqual(expect.objectContaining({ value: "Beta" }));
+  });
+
+  it("rebuilds cell objects when headers change", async () => {
+    const row = { id: "a", name: "Alpha", protocol: "HTTP" };
+    const headersWide = [
+      { key: "name", value: "Name" },
+      { key: "protocol", value: "Protocol" },
+    ] as const;
+
+    let lastCell: { key: string; value: unknown } | undefined;
+
+    const { rerender } = render(DataTableTableCellsCache, {
+      props: {
+        headers,
+        rows: [row],
+        onCellClick: (cell) => {
+          lastCell = cell;
+        },
+      },
+    });
+
+    await user.click(
+      within(getFirstBodyRow()).getByRole("cell", { name: "Alpha" }),
+    );
+    const first = lastCell;
+    expect(first).toBeDefined();
+
+    await rerender({ headers: headersWide, rows: [row] });
+    await tick();
+
+    await user.click(
+      within(getFirstBodyRow()).getByRole("cell", { name: "Alpha" }),
+    );
+    expect(lastCell).not.toBe(first);
+  });
+});


### PR DESCRIPTION
`tableCellsByRowId` rebuilds the entire cell map whenever rows or headers change, even if only one row was added/modified. For large tables (e.g., 10k rows × 10 columns), this means 100k object allocations on every update.

**Approach**

Use a Map keyed by row ID to track the source row reference alongside cached cells. On update:

1. If headers changed: full rebuild (cell structure depends on headers)
2. If only rows changed: reuse cached cells for rows whose object reference is unchanged