### PR TITLE
perf(data-table): avoid virtualized scroll set-up after any reactive update

### DIFF
--- a/src/DataTable/DataTable.svelte
+++ b/src/DataTable/DataTable.svelte
@@ -236,13 +236,7 @@
    */
   export let tableHeaderTranslateWithId = undefined;
 
-  import {
-    afterUpdate,
-    createEventDispatcher,
-    onMount,
-    setContext,
-    tick,
-  } from "svelte";
+  import { createEventDispatcher, onMount, setContext, tick } from "svelte";
   import { writable } from "svelte/store";
   import InlineCheckbox from "../Checkbox/InlineCheckbox.svelte";
   import ChevronRight from "../icons/ChevronRight.svelte";
@@ -300,33 +294,27 @@
   }
 
   // Set up scroll listener for sticky header container
-  afterUpdate(() => {
-    if (
-      virtualConfig &&
-      stickyHeader &&
-      tableRef &&
-      calculatedContainerHeight
-    ) {
-      tick().then(() => {
-        const container = tableRef;
-        if (container) {
-          if (scrollListenerCleanup) {
-            scrollListenerCleanup();
-            scrollListenerCleanup = null;
-          }
-          container.style.maxHeight = `${calculatedContainerHeight}px`;
-          container.style.overflowY = "auto";
-          const handleScroll = () => {
-            tableBodyScrollTop = container.scrollTop || 0;
-          };
-          container.addEventListener("scroll", handleScroll, { passive: true });
-          scrollListenerCleanup = () => {
-            container.removeEventListener("scroll", handleScroll);
-          };
-        }
-      });
+  $: if (
+    virtualConfig &&
+    stickyHeader &&
+    tableRef &&
+    calculatedContainerHeight
+  ) {
+    if (scrollListenerCleanup) {
+      scrollListenerCleanup();
+      scrollListenerCleanup = null;
     }
-  });
+    const container = tableRef;
+    container.style.maxHeight = `${calculatedContainerHeight}px`;
+    container.style.overflowY = "auto";
+    const handleScroll = () => {
+      tableBodyScrollTop = container.scrollTop || 0;
+    };
+    container.addEventListener("scroll", handleScroll, { passive: true });
+    scrollListenerCleanup = () => {
+      container.removeEventListener("scroll", handleScroll);
+    };
+  }
 
   onMount(() => {
     return () => {

--- a/tests/DataTable/DataTable.test.ts
+++ b/tests/DataTable/DataTable.test.ts
@@ -2379,6 +2379,46 @@ describe("DataTable", () => {
       expect(dataRows.length).toBeLessThan(500);
     });
 
+    it("should not re-attach scroll listener on unrelated state changes", async () => {
+      const largeRows = createLargeRowList(500);
+      const { rerender } = render(DataTable, {
+        props: {
+          headers,
+          rows: largeRows,
+          stickyHeader: true,
+          selectable: true,
+          virtualize: true,
+        },
+      });
+
+      await tick();
+
+      // Find the sticky header scroll container (section.bx--data-table_inner-container)
+      const innerContainer = document.querySelector(
+        ".bx--data-table_inner-container",
+      );
+      expect(innerContainer).toBeInstanceOf(HTMLElement);
+      assert(innerContainer instanceof HTMLElement);
+
+      // Scroll listener should already be attached after initial render
+      const addSpy = vi.spyOn(innerContainer, "addEventListener");
+
+      // Trigger an unrelated state change (selecting a row)
+      await rerender({ selectedRowIds: ["0"] });
+      await tick();
+
+      // With the old afterUpdate approach, addEventListener("scroll") would be
+      // called again here because afterUpdate fires on every reactive update.
+      // With the reactive $: block, it should NOT re-attach because none of
+      // virtualConfig, stickyHeader, tableRef, or calculatedContainerHeight changed.
+      const scrollCalls = addSpy.mock.calls.filter(
+        ([event]) => event === "scroll",
+      );
+      expect(scrollCalls).toHaveLength(0);
+
+      addSpy.mockRestore();
+    });
+
     it("should work with zebra striping", () => {
       const largeRows = createLargeRowList(500);
       render(DataTable, {


### PR DESCRIPTION
The afterUpdate callback in `DataTable` sets up a scroll event listener for the sticky-header + virtualization case.

Because afterUpdate fires after every reactive update, this cleanup/re-attach cycle runs even on unrelated state changes (row selection, sorting, etc.).

This is wasteful, as the listener only needs to change when virtualConfig, stickyHeader, tableRef, or calculatedContainerHeight change.