### PR TITLE
perf(tree-view): remove unused tree walker reactive initialization

### DIFF
--- a/src/TreeView/TreeView.svelte
+++ b/src/TreeView/TreeView.svelte
@@ -490,10 +490,6 @@
       expandedNodeIds.set(expandedIds);
     }
   }
-
-  $: if (ref && (nodes !== cachedNodes || !treeWalker)) {
-    treeWalker = createTreeWalkerInstance(ref);
-  }
 </script>
 
 {#if !hideLabel}


### PR DESCRIPTION
Removes dead code: `treeWalker` is already initialized in on mount, and does not require re-creating.