### PR TITLE
perf(data-table): guard rows assignment with reference check

### DIFF
--- a/src/DataTable/DataTable.svelte
+++ b/src/DataTable/DataTable.svelte
@@ -339,7 +339,13 @@
   const id = `ccs-${Math.random().toString(36)}`;
 
   // Store a copy of the original rows for filter restoration.
-  $: originalRows = [...rows];
+  let prevRows_ref = rows;
+  let originalRows = [...rows];
+  $: if (rows !== prevRows_ref) {
+    originalRows = [...rows];
+    $tableRows = rows;
+    prevRows_ref = rows;
+  }
 
   $: thKeys = headers.reduce((a, c) => {
     a[c.key] = c.key;
@@ -460,7 +466,6 @@
     prevHeaders = headers;
   }
 
-  $: $tableRows = rows;
   $: ascending = sortDirection === "ascending";
   $: sorting = sortable && sortKey != null;
   $: sortingHeader = headers.find((header) => header.key === sortKey);


### PR DESCRIPTION
Closes #2819, alternative to #2819

Use a cheap reference check for syncing the original rows from filtered rows.