### PR TITLE
ci: `test-e2e` depends on `lint`, `test` jobs

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -67,7 +67,8 @@ jobs:
         run: bun --bun run test
 
   test-e2e:
-    needs: [lint]
+    needs: [lint, test]
+    if: ${{ !failure() && !cancelled() }}
     runs-on: macos-15
     timeout-minutes: 20
     steps:


### PR DESCRIPTION
Don't waste an e2e run if the base `test` job fails or is canceled.