### PR TITLE
fix(multi-select): `sortItem` comparator returns a number, not `Item`

### DIFF
--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -97,7 +97,7 @@
   /**
    * Override the sorting logic.
    * The default sorting compare the item text value.
-   * @type {((a: Item, b: Item) => Item) | (() => void)}
+   * @type {((a: Item, b: Item) => number) | (() => void)}
    */
   export let sortItem = (a, b) =>
     a.text.localeCompare(b.text, locale, { numeric: true });

--- a/tests/MultiSelect/MultiSelect.test.ts
+++ b/tests/MultiSelect/MultiSelect.test.ts
@@ -1229,6 +1229,18 @@ describe("MultiSelect", () => {
       expectTypeOf(filterItem).parameter(0).toEqualTypeOf<Tag>();
     });
 
+    it("sortItem should return number, not Item", () => {
+      type Item = { id: string; text: string };
+
+      const sortItem: ComponentProps<MultiSelectComponent<Item>>["sortItem"] = (
+        a: Item,
+        b: Item,
+      ) => a.text.localeCompare(b.text, "en", { numeric: true });
+
+      expectTypeOf(sortItem).returns.toEqualTypeOf<number>();
+      expectTypeOf(sortItem).parameters.toEqualTypeOf<[Item, Item]>();
+    });
+
     it("should support slot props with generic item type", () => {
       type MenuItem = {
         id: string;


### PR DESCRIPTION
The TypeScript type for `MultiSelect` sortItem is incorrect, in the case the user returns the comparator.

It should be a number, not the `Item`.