### PR TITLE
perf(number-input): cache `Intl.NumberFormat` locale usage

### DIFF
--- a/src/NumberInput/NumberInput.svelte
+++ b/src/NumberInput/NumberInput.svelte
@@ -244,6 +244,15 @@
     ((min !== undefined && value < min) || (max !== undefined && value > max));
   $: formatter = locale ? new Intl.NumberFormat(locale, formatOptions) : null;
   $: useTextMode = allowDecimal || !!locale;
+  $: separatorParts = locale
+    ? new Intl.NumberFormat(locale).formatToParts(12345.6)
+    : null;
+  $: groupSeparator = separatorParts
+    ? (separatorParts.find((p) => p.type === "group")?.value ?? "")
+    : "";
+  $: decimalSeparator = separatorParts
+    ? (separatorParts.find((p) => p.type === "decimal")?.value ?? ".")
+    : ".";
 
   let inputValue = value?.toString() ?? "";
   let prevValue;
@@ -336,15 +345,12 @@
    */
   function parseLocaleValue(raw) {
     if (raw === "" || raw === "-") return null;
-    const parts = new Intl.NumberFormat(locale).formatToParts(12345.6);
-    const group = parts.find((p) => p.type === "group")?.value ?? "";
-    const decimal = parts.find((p) => p.type === "decimal")?.value ?? ".";
     let normalized = raw;
-    if (group) {
-      normalized = normalized.split(group).join("");
+    if (groupSeparator) {
+      normalized = normalized.split(groupSeparator).join("");
     }
-    if (decimal !== ".") {
-      normalized = normalized.replace(decimal, ".");
+    if (decimalSeparator !== ".") {
+      normalized = normalized.replace(decimalSeparator, ".");
     }
     const num = Number(normalized);
     return Number.isNaN(num) ? null : num;

--- a/tests/NumberInput/NumberInput.test.ts
+++ b/tests/NumberInput/NumberInput.test.ts
@@ -1520,6 +1520,73 @@ describe("NumberInput", () => {
       await tick();
       expect(input.value).toBe("");
     });
+
+    it("should parse locale input with group separators", async () => {
+      render(NumberInput, {
+        props: { locale: "de-DE", value: null, allowEmpty: true },
+      });
+
+      const input = screen.getByRole("textbox");
+      expect.assert(input instanceof HTMLInputElement);
+      await user.type(input, "1.234,56");
+      await user.tab();
+
+      expect(screen.getByTestId("value").textContent).toBe("1234.56");
+    });
+
+    it("should parse locale input without group separators", async () => {
+      render(NumberInput, {
+        props: { locale: "de-DE", value: null, allowEmpty: true },
+      });
+
+      const input = screen.getByRole("textbox");
+      expect.assert(input instanceof HTMLInputElement);
+      await user.type(input, "1234,5");
+      await user.tab();
+
+      expect(screen.getByTestId("value").textContent).toBe("1234.5");
+    });
+
+    it("should update separator cache when locale changes", async () => {
+      const { rerender } = render(NumberInput, {
+        props: { locale: "en-US", value: null, allowEmpty: true },
+      });
+
+      const input = screen.getByRole("textbox");
+      expect.assert(input instanceof HTMLInputElement);
+
+      // Type in en-US format and blur
+      await user.type(input, "1,234.5");
+      await user.tab();
+      expect(screen.getByTestId("value").textContent).toBe("1234.5");
+
+      // Switch to de-DE
+      rerender({ locale: "de-DE", value: null, allowEmpty: true });
+      await tick();
+
+      await user.clear(input);
+      await user.type(input, "1.234,5");
+      await user.tab();
+      expect(screen.getByTestId("value").textContent).toBe("1234.5");
+    });
+
+    it("should fall back to standard parsing when locale is removed", async () => {
+      const { rerender } = render(NumberInput, {
+        props: { locale: "de-DE", value: 1234.5, allowEmpty: true },
+      });
+
+      const input = screen.getByRole("textbox");
+      expect.assert(input instanceof HTMLInputElement);
+      expect(input.value).toBe("1.234,5");
+
+      // Remove locale — should switch to number input
+      rerender({ locale: undefined, value: 1234.5, allowEmpty: true });
+      await tick();
+
+      const spinbutton = screen.getByRole("spinbutton");
+      expect(spinbutton).toHaveAttribute("type", "number");
+      expect(spinbutton).toHaveValue(1234.5);
+    });
   });
 
   describe("click:stepper event", () => {


### PR DESCRIPTION
Currently, `Intl.NumberFormat` is called on every key stroke if a custom locale is used. This caches these calls.