### PR TITLE
chore(multi-select): add comment around `on:select` dispatch behavior

### DIFF
--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -330,6 +330,11 @@
   }
 
   afterUpdate(() => {
+    // Compare by length, not by IDs. This is intentional: `on:select`
+    // should only fire in response to UI interaction (toggle/clear),
+    // not programmatic `selectedIds` changes. A length check is sufficient
+    // because `selectItem` only ever toggles one item at a time, so user-
+    // driven changes always alter the count.
     if (checked.length !== prevChecked.length) {
       prevChecked = checked;
       selectedIds = checked


### PR DESCRIPTION
Add a code comment explaining that `on:select` is intentionally based on a length check.