### PR TITLE
fix(multi-select): Backspace/Delete should clear selection

### DIFF
--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -657,6 +657,23 @@
               open = false;
             } else if (key === " ") {
               if (!open) open = true;
+            } else if (key === "Backspace" && value === "") {
+              selectedIds = [];
+              sortedItems = sortedItems.map((item) => ({
+                ...item,
+                checked: false,
+              }));
+            } else if (key === "Delete") {
+              if (open) {
+                value = "";
+              } else {
+                value = "";
+                selectedIds = [];
+                sortedItems = sortedItems.map((item) => ({
+                  ...item,
+                  checked: false,
+                }));
+              }
             }
           }}
           on:input

--- a/tests/MultiSelect/MultiSelect.test.ts
+++ b/tests/MultiSelect/MultiSelect.test.ts
@@ -2161,4 +2161,103 @@ describe("MultiSelect", () => {
       expect(floatingPortal).not.toBeInTheDocument();
     });
   });
+
+  describe("filterable: Backspace/Delete clears selection", () => {
+    it("Backspace clears selection when input is empty", async () => {
+      render(MultiSelect, {
+        props: {
+          items,
+          filterable: true,
+          placeholder: "Filter...",
+          selectedIds: ["0", "1"],
+        },
+      });
+
+      const input = screen.getByPlaceholderText("Filter...");
+      await user.click(input);
+
+      const options = screen.getAllByRole("option");
+      expect(options[0]).toHaveAttribute("aria-selected", "true");
+      expect(options[1]).toHaveAttribute("aria-selected", "true");
+      expect(options[2]).toHaveAttribute("aria-selected", "false");
+
+      await user.keyboard("{Backspace}");
+
+      expect(options[0]).toHaveAttribute("aria-selected", "false");
+      expect(options[1]).toHaveAttribute("aria-selected", "false");
+      expect(options[2]).toHaveAttribute("aria-selected", "false");
+    });
+
+    it("Backspace does not clear selection when input has text", async () => {
+      render(MultiSelect, {
+        props: {
+          items,
+          filterable: true,
+          placeholder: "Filter...",
+          selectedIds: ["0"],
+        },
+      });
+
+      const input = screen.getByPlaceholderText("Filter...");
+      await user.click(input);
+      await user.type(input, "Sl");
+
+      // Backspace should remove a character, not clear selection
+      await user.keyboard("{Backspace}");
+
+      // Re-open to check all options since filter may hide some
+      // The selection should still be intact
+      await user.clear(input);
+
+      const options = screen.getAllByRole("option");
+      expect(options[0]).toHaveAttribute("aria-selected", "true");
+    });
+
+    it("Delete clears input text when menu is open", async () => {
+      render(MultiSelect, {
+        props: {
+          items,
+          filterable: true,
+          placeholder: "Filter...",
+          selectedIds: ["0"],
+        },
+      });
+
+      const input = screen.getByPlaceholderText("Filter...");
+      await user.click(input);
+      await user.type(input, "Sl");
+      expect(input).toHaveValue("Sl");
+
+      await user.keyboard("{Delete}");
+
+      // Delete clears the entire input value when menu is open
+      expect(input).toHaveValue("");
+    });
+
+    it("Delete clears selection when menu is closed", async () => {
+      render(MultiSelect, {
+        props: {
+          items,
+          filterable: true,
+          placeholder: "Filter...",
+          selectedIds: ["0", "1"],
+        },
+      });
+
+      const input = screen.getByPlaceholderText("Filter...");
+      // Focus input then close menu
+      await user.click(input);
+      await user.keyboard("{Escape}");
+      expect(input).toHaveAttribute("aria-expanded", "false");
+
+      await user.keyboard("{Delete}");
+
+      // Open menu to verify selections were cleared
+      await user.click(input);
+      const options = screen.getAllByRole("option");
+      expect(options[0]).toHaveAttribute("aria-selected", "false");
+      expect(options[1]).toHaveAttribute("aria-selected", "false");
+      expect(options[2]).toHaveAttribute("aria-selected", "false");
+    });
+  });
 });


### PR DESCRIPTION
Per the spec ([React implementation as reference](https://github.com/carbon-design-system/carbon/blob/main/packages/react/src/components/MultiSelect/FilterableMultiSelect.tsx)), the Backspace/Delete keys should clear the selection for a filterable multi-select.

The nuance with Delete is that is should only clear the selection if the menu is closed and input focused (e.g., focus the input, press "Escape" to close the menu).