### PR TITLE
fix(dropdown): do not spread `translateWithId` to raw `button` element

### DIFF
--- a/src/Dropdown/Dropdown.svelte
+++ b/src/Dropdown/Dropdown.svelte
@@ -539,7 +539,6 @@
         }
       }}
       {disabled}
-      {translateWithId}
       {id}
     >
       <span class:bx--list-box__label={true}>

--- a/tests/Dropdown/Dropdown.test.ts
+++ b/tests/Dropdown/Dropdown.test.ts
@@ -1633,4 +1633,19 @@ describe("Dropdown", () => {
       }
     });
   });
+
+  // Regression: translateWithId function prop should not be rendered as a DOM attribute.
+  it("should not render translateWithId as a DOM attribute on the button", () => {
+    const { container } = render(Dropdown, {
+      props: {
+        items,
+        labelText: "Contact",
+        translateWithId: (id: string) => id,
+      },
+    });
+    const button = container.querySelector("button.bx--list-box__field");
+    expect(button).toBeInTheDocument();
+    expect(button).not.toHaveAttribute("translateWithId");
+    expect(button).not.toHaveAttribute("translatewithid");
+  });
 });


### PR DESCRIPTION
`translateWithId` is already passed to `ListBoxMenuIcon`, and should not be spread to the raw `button` element in `Dropdown`.