### PR TITLE
fix(number-input): remove `pattern` for number type input

### DIFF
--- a/src/NumberInput/NumberInput.svelte
+++ b/src/NumberInput/NumberInput.svelte
@@ -509,7 +509,6 @@
         <input
           bind:this={ref}
           type="number"
-          pattern="[0-9]*"
           aria-describedby={hasErrorMessage
             ? errorId
             : warn

--- a/tests/NumberInput/NumberInput.test.ts
+++ b/tests/NumberInput/NumberInput.test.ts
@@ -382,11 +382,11 @@ describe("NumberInput", () => {
     expect(input).not.toHaveAttribute("aria-label");
   });
 
-  it("should set pattern attribute for numeric input", () => {
+  it("should not set pattern attribute on type=number input (ignored per HTML spec)", () => {
     render(NumberInput);
 
     const input = screen.getByRole("spinbutton");
-    expect(input).toHaveAttribute("pattern", "[0-9]*");
+    expect(input).not.toHaveAttribute("pattern");
   });
 
   it("should support aria-label override via restProps", () => {


### PR DESCRIPTION
Removes dead code: `pattern` is not respected if `type="number"` ([docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input/number#pattern_validation)).