### PR TITLE
fix(tree-view): escape node ID when using `querySelector` for focusing

### DIFF
--- a/src/TreeView/TreeView.svelte
+++ b/src/TreeView/TreeView.svelte
@@ -293,7 +293,7 @@
 
         if (focus) {
           tick().then(() => {
-            ref?.querySelector(`[id="${lastId}"]`)?.focus();
+            ref?.querySelector(`[id="${CSS.escape(lastId)}"]`)?.focus();
           });
         }
 

--- a/tests/TreeView/TreeView.showNode.idEscape.test.svelte
+++ b/tests/TreeView/TreeView.showNode.idEscape.test.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+  import { Button, TreeView } from "carbon-components-svelte";
+  import type { ComponentProps } from "svelte";
+
+  /** Id contains `"`, which breaks a naive `[id="..."]` selector without CSS.escape */
+  const targetId = 'node-with-"-char';
+
+  let treeview: TreeView;
+  let nodes: ComponentProps<TreeView>["nodes"] = [
+    {
+      id: "folder",
+      text: "Folder",
+      nodes: [{ id: targetId, text: "Leaf" }],
+    },
+  ];
+</script>
+
+<TreeView bind:this={treeview} labelText="showNode id escape" {nodes} let:node>
+  {node.text}
+</TreeView>
+
+<Button
+  data-testid="show-special-id"
+  on:click={() => treeview.showNode(targetId)}
+>
+  Show node with special id
+</Button>

--- a/tests/TreeView/TreeView.showNode.test.ts
+++ b/tests/TreeView/TreeView.showNode.test.ts
@@ -1,5 +1,6 @@
-import { render, screen } from "@testing-library/svelte";
+import { render, screen, waitFor } from "@testing-library/svelte";
 import { user } from "../setup-tests";
+import TreeViewShowNodeIdEscape from "./TreeView.showNode.idEscape.test.svelte";
 import TreeViewShowNode from "./TreeView.showNode.test.svelte";
 
 describe("TreeView.showNode with options", () => {
@@ -50,5 +51,19 @@ describe("TreeView.showNode with options", () => {
     expect(getSelectedItem()).not.toBeInTheDocument();
     expect(consoleLog).toHaveBeenCalledWith("activeId", "");
     expect(consoleLog).toHaveBeenCalledWith("selectedIds", [3]);
+  });
+});
+
+describe("TreeView.showNode id selector escaping", () => {
+  it("focuses a node whose string id contains characters that must be CSS-escaped", async () => {
+    render(TreeViewShowNodeIdEscape);
+
+    await user.click(screen.getByTestId("show-special-id"));
+
+    const target = screen.getByRole("treeitem", { name: /^Leaf$/ });
+    await waitFor(() => {
+      expect(target).toHaveFocus();
+    });
+    expect(target).toHaveAttribute("aria-selected", "true");
   });
 });


### PR DESCRIPTION
`TreeView` uses the user-supplied node ID for focusing in `showNode`.

However, interpolating the id directly breaks when the id contains characters that are special in CSS selectors or that terminate the attribute value. The id is now passed through `CSS.escape()` so the selector is valid and matches the real DOM `id` attribute.

Examples:

- `node-with-"-char`
- `"leading-quote`
- `trailing-quote"`