### PR TITLE
fix(combo-box): do not trap focus when clicking outside element

### DIFF
--- a/e2e/combobox.test.ts
+++ b/e2e/combobox.test.ts
@@ -74,6 +74,21 @@ test.describe("ComboBox", () => {
     await expect(page.locator(".bx--list-box__menu")).not.toBeVisible();
   });
 
+  test("does not trap focus when clicking an outside element while menu is open", async ({
+    page,
+  }) => {
+    const combobox = page.getByTestId("combobox-contact");
+    await combobox.click();
+    await expect(page.locator(".bx--list-box__menu")).toBeVisible();
+
+    // Click an outside focusable element while the menu is open.
+    // The blur handler should not yank focus back to the input.
+    const outsideLink = page.getByTestId("outside-link");
+    await outsideLink.focus();
+
+    await expect(outsideLink).toBeFocused();
+  });
+
   test("selects all text on focus when selectTextOnFocus is true", async ({
     page,
   }) => {

--- a/e2e/fixtures/ComboBoxFixture.svelte
+++ b/e2e/fixtures/ComboBoxFixture.svelte
@@ -21,6 +21,8 @@
   {shouldFilterItem}
 />
 
+<a href="#" data-testid="outside-link">Outside</a>
+
 <ComboBox
   data-testid="combobox-select-on-focus"
   labelText="Select on focus"

--- a/src/ComboBox/ComboBox.svelte
+++ b/src/ComboBox/ComboBox.svelte
@@ -623,10 +623,8 @@
         on:blur={({ relatedTarget }) => {
           if (!open || !relatedTarget) return;
           if (
-            relatedTarget &&
-            relatedTarget.tagName !== "INPUT" && relatedTarget.tagName !== "SELECT" && relatedTarget.tagName !== "TEXTAREA" &&
-            relatedTarget.getAttribute("role") !== "button" &&
-            relatedTarget.getAttribute("role") !== "searchbox"
+            fieldRef?.contains(relatedTarget) ||
+            listRef?.contains(relatedTarget)
           ) {
             ref.focus();
           }

--- a/tests/ComboBox/ComboBox.test.ts
+++ b/tests/ComboBox/ComboBox.test.ts
@@ -1861,4 +1861,30 @@ describe("ComboBox", () => {
       expect(floatingPortal).not.toBeInTheDocument();
     });
   });
+
+  it("should not trap focus when tabbing away from an open menu", async () => {
+    const { container } = render(ComboBox);
+
+    // Add an external focusable element after the combobox.
+    const externalButton = document.createElement("button");
+    externalButton.textContent = "Outside";
+    container.appendChild(externalButton);
+
+    const input = getInput();
+    await user.click(input);
+
+    // Menu should be open.
+    expect(screen.getAllByRole("listbox")[1]).toBeVisible();
+
+    // Simulate a blur where focus moves to an element outside the combobox.
+    // In a real browser, Tab triggers blur with relatedTarget = next element.
+    // A buggy handler will call ref.focus() synchronously, trapping focus.
+    const focusSpy = vi.spyOn(input, "focus");
+    input.dispatchEvent(
+      new FocusEvent("blur", { relatedTarget: externalButton, bubbles: true }),
+    );
+
+    // The blur handler should NOT refocus the input when focus leaves the component.
+    expect(focusSpy).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
When the `ComboBox` menu is open, tabbing away from the combobox triggers ref.focus() for any relatedTarget that isn’t an input-like element. This means if a keyboard user tabs to a plain link or any other focusable element outside the combobox, focus remains trapped in the combo box input.

The current allowlist approach is too restrictive; instead, use a more general `relatedTarget` check.