### PR TITLE
fix(combo-box): do not auto-select partial match when pressing "Enter"

### DIFF
--- a/src/ComboBox/ComboBox.svelte
+++ b/src/ComboBox/ComboBox.svelte
@@ -586,14 +586,14 @@
               }
             } else {
               // searching typed value in text list with lowercase
-              const matchedItem =
-                filteredItems.find(
-                  (e) =>
-                    e.text.toLowerCase() === value?.toLowerCase() &&
-                    !e.disabled,
-                ) ?? filteredItems.find((e) => !e.disabled);
+              const inputValue = ref?.value ?? value;
+              const matchedItem = filteredItems.find(
+                (e) =>
+                  e.text.toLowerCase() === inputValue?.toLowerCase() &&
+                  !e.disabled,
+              );
               if (matchedItem) {
-                // typed value has matched or fallback to first enabled item
+                // typed value has matched
                 open = false;
                 valueBeforeOpen = "";
                 selectedItem = matchedItem;

--- a/tests/ComboBox/ComboBox.test.ts
+++ b/tests/ComboBox/ComboBox.test.ts
@@ -511,6 +511,20 @@ describe("ComboBox", () => {
     expect(input).toHaveValue("");
   });
 
+  it("should not auto-select an unrelated item when Enter is pressed with a partial match", async () => {
+    render(ComboBox);
+
+    const input = getInput();
+    await user.click(input);
+    // "a" matches "Slack" and "Fax" via the filter, but is not an exact
+    // text match for either. Pressing Enter should not silently select
+    // the first filtered item.
+    await user.type(input, "a");
+    await user.keyboard("{Enter}");
+
+    expect(input).toHaveValue("a");
+  });
+
   it("should skip disabled items in filtered list, not unfiltered list", async () => {
     // Regression: `change()` previously checked `items[index].disabled`
     // instead of `_items[index].disabled`, indexing into the wrong array


### PR DESCRIPTION
A bug occurs where, if using a filterable `ComboBox`, pressing Enter will select the first partial match.

This may need auditing first to align better with the upstream implementation. The upstream implementation has a different approach: for a partial match, it first focuses the first match in the menu, allowing the user to then press Enter to select it.