### PR TITLE
fix(types): `tabindex` type allows number or string

### DIFF
--- a/src/Button/Button.svelte
+++ b/src/Button/Button.svelte
@@ -91,7 +91,10 @@
    */
   export let href = undefined;
 
-  /** Specify the tabindex */
+  /**
+   * Specify the tabindex
+   * @type {number | string | undefined}
+   */
   export let tabindex = "0";
 
   /** Specify the `type` attribute for the button element */

--- a/src/DataTable/ToolbarSearch.svelte
+++ b/src/DataTable/ToolbarSearch.svelte
@@ -38,7 +38,10 @@
    */
   export let filteredRowIds = [];
 
-  /** Specify the tabindex */
+  /**
+   * Specify the tabindex
+   * @type {number | string | undefined}
+   */
   export let tabindex = "0";
 
   /**

--- a/src/FileUploader/FileUploaderDropContainer.svelte
+++ b/src/FileUploader/FileUploaderDropContainer.svelte
@@ -35,7 +35,10 @@
   /** Set to `true` to disable the input */
   export let disabled = false;
 
-  /** Specify `tabindex` attribute */
+  /**
+   * Specify `tabindex` attribute
+   * @type {number | string | undefined}
+   */
   export let tabindex = "0";
 
   /** Set an id for the input element */

--- a/src/ListBox/ListBoxField.svelte
+++ b/src/ListBox/ListBoxField.svelte
@@ -9,7 +9,10 @@
   /** Specify the role attribute */
   export let role = "combobox";
 
-  /** Specify the tabindex */
+  /**
+   * Specify the tabindex
+   * @type {number | string | undefined}
+   */
   export let tabindex = "-1";
 
   /** Default translation ids */

--- a/src/StructuredList/StructuredListRow.svelte
+++ b/src/StructuredList/StructuredListRow.svelte
@@ -5,7 +5,10 @@
   /** Set to `true` to render a label slot */
   export let label = false;
 
-  /** Specify the tabindex */
+  /**
+   * Specify the tabindex
+   * @type {number | string | undefined}
+   */
   export let tabindex = "0";
 </script>
 

--- a/src/Tabs/Tab.svelte
+++ b/src/Tabs/Tab.svelte
@@ -21,7 +21,10 @@
   /** Set to `true` to disable the tab */
   export let disabled = false;
 
-  /** Specify the tabindex */
+  /**
+   * Specify the tabindex
+   * @type {number | string | undefined}
+   */
   export let tabindex = "0";
 
   /** Set an id for the top-level element */

--- a/src/Tile/ExpandableTile.svelte
+++ b/src/Tile/ExpandableTile.svelte
@@ -23,7 +23,10 @@
   /** Specify the icon label of the collapsed tile */
   export let tileCollapsedLabel = "";
 
-  /** Specify the tabindex */
+  /**
+   * Specify the tabindex
+   * @type {number | string | undefined}
+   */
   export let tabindex = "0";
 
   /** Set an id for the top-level div element */

--- a/src/Tile/RadioTile.svelte
+++ b/src/Tile/RadioTile.svelte
@@ -22,7 +22,10 @@
    */
   export let value = "";
 
-  /** Specify the tabindex */
+  /**
+   * Specify the tabindex
+   * @type {number | string | undefined}
+   */
   export let tabindex = "0";
 
   /** Specify the ARIA label for the radio tile checkmark icon */

--- a/src/Tile/SelectableTile.svelte
+++ b/src/Tile/SelectableTile.svelte
@@ -19,7 +19,10 @@
   /** Specify the value of the selectable tile */
   export let value = "value";
 
-  /** Specify the tabindex */
+  /**
+   * Specify the tabindex
+   * @type {number | string | undefined}
+   */
   export let tabindex = "0";
 
   /** Specify the ARIA label for the selectable tile checkmark icon */

--- a/src/Tooltip/Tooltip.svelte
+++ b/src/Tooltip/Tooltip.svelte
@@ -42,7 +42,10 @@
   /** Specify the icon name attribute */
   export let iconName = "";
 
-  /** Set the button tabindex */
+  /**
+   * Set the button tabindex
+   * @type {number | string | undefined}
+   */
   export let tabindex = "0";
 
   /**

--- a/src/UIShell/SkipToContent.svelte
+++ b/src/UIShell/SkipToContent.svelte
@@ -2,7 +2,10 @@
   /** Specify the `href` attribute */
   export let href = "#main-content";
 
-  /** Specify the tabindex */
+  /**
+   * Specify the tabindex
+   * @type {number | string | undefined}
+   */
   export let tabindex = "0";
 </script>
 


### PR DESCRIPTION
#1524

The official Svelte types have `tabindex` as `number | undefined`. Historically, this library has left the inferred type to be string. This isn't incorrect, but the type is too narrow. This prop should explicitly allow number or string (I myself gravitate towards using numbers, because of React).