### PR TITLE
fix(data-table-skeleton): do not require `DataTableHeader` key/empty/value properties

### DIFF
--- a/src/DataTable/DataTableSkeleton.svelte
+++ b/src/DataTable/DataTableSkeleton.svelte
@@ -1,6 +1,4 @@
 <script>
-  /** @extends {"./DataTable.svelte"} DataTableHeader */
-
   /**
    * Specify the number of columns.
    * Superseded by `headers` if `headers` is a non-empty array.
@@ -25,7 +23,7 @@
   /**
    * Set the column headers.
    * Supersedes `columns` if value is a non-empty array.
-   * @type {ReadonlyArray<string | Partial<DataTableHeader>>}
+   * @type {ReadonlyArray<string | Partial<import('./DataTable.svelte').DataTableHeader>>}
    */
   export let headers = [];
 

--- a/tests/DataTable/DataTableSkeleton.test.svelte
+++ b/tests/DataTable/DataTableSkeleton.test.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+  import { DataTableSkeleton } from "carbon-components-svelte";
+
+  // Regression test for https://github.com/carbon-design-system/carbon-components-svelte/issues/2869
+  // DataTableSkeletonProps should not require `key` / `empty` from DataTableHeader.
+</script>
+
+<DataTableSkeleton
+  size="tall"
+  showHeader={false}
+  showToolbar={false}
+  rows={10}
+/>
+
+<DataTableSkeleton />
+
+<DataTableSkeleton headers={["Name", "Protocol", "Port", "Rule"]} rows={10} />
+
+<DataTableSkeleton
+  headers={[{ value: "Name" }, { value: "Protocol" }, { value: "Port" }, { value: "Rule" }]}
+  rows={10}
+/>
+
+<DataTableSkeleton
+  headers={[{ value: "Name" }, { value: "Protocol" }, { value: "Port" }, { value: "Rule" }, { empty: true }]}
+  rows={10}
+/>
+
+<DataTableSkeleton showHeader={false} showToolbar={false} />
+
+<DataTableSkeleton showHeader={false} showToolbar={false} size="tall" />
+
+<DataTableSkeleton showHeader={false} showToolbar={false} size="short" />
+
+<DataTableSkeleton showHeader={false} showToolbar={false} size="compact" />


### PR DESCRIPTION
Fixes #2869