### PR TITLE
fix(select): prevent dispatching initial "update" event in Svelte 5

### DIFF
--- a/src/Select/Select.svelte
+++ b/src/Select/Select.svelte
@@ -115,12 +115,13 @@
     selectedValue.set(value);
   };
 
-  let prevSelected = undefined;
+  let prevSelected = null;
 
   afterUpdate(() => {
     if (selected !== $selectedValue) {
+      const isInitialRender = prevSelected === null;
       selected = $selectedValue;
-      if (prevSelected !== undefined) {
+      if (!isInitialRender) {
         dispatch("update", $selectedValue);
       }
     }

--- a/tests/Select/Select.test.ts
+++ b/tests/Select/Select.test.ts
@@ -8,6 +8,7 @@ import SelectGroup from "./Select.group.test.svelte";
 import SelectSkeleton from "./Select.skeleton.test.svelte";
 import SelectSlot from "./Select.slot.test.svelte";
 import Select from "./Select.test.svelte";
+import SelectToggle from "./Select.toggle.test.svelte";
 
 describe("Select", () => {
   beforeEach(() => {
@@ -49,6 +50,25 @@ describe("Select", () => {
     expect(consoleLog).toHaveBeenCalledWith("input");
     expect(consoleLog).toHaveBeenCalledWith("update", "option-2");
     expect(consoleLog).toHaveBeenCalledTimes(3);
+  });
+
+  // Regression test for https://github.com/carbon-design-system/carbon-components-svelte/issues/2871
+  it("does not dispatch update event on initial render", () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(Select);
+
+    expect(consoleLog).not.toHaveBeenCalledWith("update", expect.anything());
+  });
+
+  // Regression test for https://github.com/carbon-design-system/carbon-components-svelte/issues/2871
+  it("does not dispatch update event when toggled into view", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(SelectToggle, { open: false });
+
+    await user.click(screen.getByRole("button", { name: "toggle" }));
+
+    expect(screen.getByLabelText("Toggled select")).toBeInTheDocument();
+    expect(consoleLog).not.toHaveBeenCalledWith("update", expect.anything());
   });
 
   it("renders default size", () => {

--- a/tests/Select/Select.toggle.test.svelte
+++ b/tests/Select/Select.toggle.test.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  import { Select, SelectItem } from "carbon-components-svelte";
+
+  export let open = false;
+</script>
+
+<button type="button" on:click={() => (open = !open)}>toggle</button>
+{#if open}
+  <Select
+    labelText="Toggled select"
+    on:update={(e) => console.log("update", e.detail)}
+  >
+    <SelectItem value="test" text="test" />
+  </Select>
+{/if}


### PR DESCRIPTION
Fixes #2871

The "update" event should not be initially fired when the component is initially mounted. Similar to #2473 and other affected components in the https://github.com/carbon-design-system/carbon-components-svelte/issues/2012 parent issue.