### PR TITLE
feat(floating-portal): auto-detect native `dialog` as target

### DIFF
--- a/docs/src/pages/components/FloatingPortal.svx
+++ b/docs/src/pages/components/FloatingPortal.svx
@@ -69,3 +69,7 @@ By default, the floating content is rendered below the anchor element. However, 
 Use the `direction` slot prop to read the actual rendered direction after auto-flipping for conditional logic, like styles.
 
 <FileSource src="/framed/FloatingPortal/FloatingPortalSlotDirection" />
+
+## Custom target
+
+Use the `target` prop to mount the floating content into a specific DOM element instead of `document.body`. Positioning is always driven by the `anchor`, so `target` only changes which DOM subtree the floating content lives in. See the [Portal custom target example](/components/Portal#custom-target) for typical use cases.

--- a/docs/src/pages/components/FloatingPortal.svx
+++ b/docs/src/pages/components/FloatingPortal.svx
@@ -73,3 +73,11 @@ Use the `direction` slot prop to read the actual rendered direction after auto-f
 ## Custom target
 
 Use the `target` prop to mount the floating content into a specific DOM element instead of `document.body`. Positioning is always driven by the `anchor`, so `target` only changes which DOM subtree the floating content lives in. See the [Portal custom target example](/components/Portal#custom-target) for typical use cases.
+
+## Inside a native dialog
+
+When the anchor is inside a [native dialog](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/dialog), floating content is automatically mounted into that dialog (via `anchor.closest("dialog")`). This ensures the content exists in the dialog's top layer to remain visible and interactive.
+
+Components inside the `dialog` must still enable `portalMenu` for its menu or content to be portalled. Pass an explicit `target` to override this behavior.
+
+<FileSource src="/framed/FloatingPortal/FloatingPortalDialog" />

--- a/docs/src/pages/components/Portal.svx
+++ b/docs/src/pages/components/Portal.svx
@@ -29,3 +29,9 @@ Use the `tag` prop to specify a custom HTML element. By default, the portal uses
 Wrap the modal in a portal to escape parent containers with `overflow: hidden` or z-index stacking contexts. This ensures the modal appears above all content and isn't clipped by parent boundaries.
 
 <FileSource src="/framed/Portal/ModalPortal" />
+
+## Custom target
+
+Use the `target` prop to mount the portal into a specific DOM element instead of `document.body`.
+
+<FileSource src="/framed/Portal/CustomTargetPortal" />

--- a/docs/src/pages/framed/FloatingPortal/FloatingPortalDialog.svelte
+++ b/docs/src/pages/framed/FloatingPortal/FloatingPortalDialog.svelte
@@ -1,0 +1,50 @@
+<script>
+  import {
+    Button,
+    Dropdown,
+    OverflowMenu,
+    OverflowMenuItem,
+    Stack,
+  } from "carbon-components-svelte";
+
+  let dialog = null;
+</script>
+
+<Button on:click={() => dialog?.showModal()}>Open dialog</Button>
+
+<dialog bind:this={dialog}>
+  <Stack gap={5}>
+    <p>
+      Carbon components that portal their floating content (dropdowns, overflow
+      menus, tooltips, date pickers, etc.) are automatically mounted into the
+      nearest <code>&lt;dialog&gt;</code> ancestor, so they render above the
+      modal backdrop in the top layer.
+    </p>
+    <Dropdown
+      portalMenu
+      titleText="Region"
+      selectedId="us-south"
+      items={[
+        { id: "us-south", text: "Dallas (us-south)" },
+        { id: "us-east", text: "Washington DC (us-east)" },
+        { id: "eu-de", text: "Frankfurt (eu-de)" },
+        { id: "jp-tok", text: "Tokyo (jp-tok)" },
+        { id: "br-sao", text: "São Paulo (br-sao)" },
+        { id: "au-syd", text: "Sydney (au-syd)" },
+        { id: "ca-tor", text: "Toronto (ca-tor)" },
+        { id: "de-fra", text: "Frankfurt (de-fra)" },
+        { id: "es-mad", text: "Madrid (es-mad)" },
+        { id: "fr-par", text: "Paris (fr-par)" },
+        { id: "in-mum", text: "Mumbai (in-mum)" },
+        { id: "it-mil", text: "Milan (it-mil)" },
+        { id: "jp-osa", text: "Osaka (jp-osa)" },
+      ]}
+    />
+    <OverflowMenu portalMenu>
+      <OverflowMenuItem text="Edit" />
+      <OverflowMenuItem text="Duplicate" />
+      <OverflowMenuItem danger text="Delete" />
+    </OverflowMenu>
+    <Button kind="secondary" on:click={() => dialog.close()}>Close</Button>
+  </Stack>
+</dialog>

--- a/docs/src/pages/framed/Portal/CustomTargetPortal.svelte
+++ b/docs/src/pages/framed/Portal/CustomTargetPortal.svelte
@@ -1,0 +1,17 @@
+<script>
+  import { Portal, Stack, Tile } from "carbon-components-svelte";
+
+  let target = null;
+</script>
+
+<Stack gap={4}>
+  <Tile>
+    <div>Portal is declared here.</div>
+    <Portal {target}><strong>Portalled content</strong></Portal>
+  </Tile>
+  <Tile>
+    <div bind:this={target}>
+      But mounted into this container via <code>target</code>.
+    </div>
+  </Tile>
+</Stack>

--- a/e2e/fixtures/FloatingPortalDialogFixture.svelte
+++ b/e2e/fixtures/FloatingPortalDialogFixture.svelte
@@ -1,0 +1,42 @@
+<script>
+  import {
+    Button,
+    Dropdown,
+    OverflowMenu,
+    OverflowMenuItem,
+    Stack,
+  } from "carbon-components-svelte";
+
+  let dialog = null;
+</script>
+
+<button
+  type="button"
+  data-testid="open-dialog"
+  on:click={() => dialog?.showModal()}
+>
+  Open dialog
+</button>
+
+<dialog data-testid="native-dialog" bind:this={dialog}>
+  <Stack gap={5}>
+    <p>Floating content auto-mounts into the nearest dialog ancestor.</p>
+    <Dropdown
+      portalMenu
+      labelText="Region"
+      selectedId="us-south"
+      items={[
+        { id: "us-south", text: "Dallas" },
+        { id: "us-east", text: "Washington DC" },
+        { id: "eu-de", text: "Frankfurt" },
+        { id: "jp-tok", text: "Tokyo" },
+      ]}
+    />
+    <OverflowMenu portalMenu>
+      <OverflowMenuItem text="Edit" />
+      <OverflowMenuItem text="Duplicate" />
+      <OverflowMenuItem danger text="Delete" />
+    </OverflowMenu>
+    <Button kind="secondary" on:click={() => dialog?.close()}>Close</Button>
+  </Stack>
+</dialog>

--- a/e2e/fixtures/floating-portal-dialog.html
+++ b/e2e/fixtures/floating-portal-dialog.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>FloatingPortal in native dialog Test</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="./floating-portal-dialog.ts"></script>
+  </body>
+</html>

--- a/e2e/fixtures/floating-portal-dialog.ts
+++ b/e2e/fixtures/floating-portal-dialog.ts
@@ -1,0 +1,4 @@
+import FloatingPortalDialogFixture from "./FloatingPortalDialogFixture.svelte";
+import { mount } from "./mount";
+
+mount(FloatingPortalDialogFixture);

--- a/e2e/floating-portal-dialog.test.ts
+++ b/e2e/floating-portal-dialog.test.ts
@@ -1,0 +1,99 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("FloatingPortal inside native dialog", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/floating-portal-dialog.html");
+    await page.getByTestId("open-dialog").click();
+    await expect(page.getByTestId("native-dialog")).toBeVisible();
+  });
+
+  test("OverflowMenu portal mounts inside the dialog (not document.body)", async ({
+    page,
+  }) => {
+    await page.getByRole("button", { name: "menu" }).click();
+
+    await expect(page.getByRole("menuitem", { name: "Edit" })).toBeVisible();
+
+    const parentTag = await page.evaluate(() => {
+      const portal = document.querySelector("[data-floating-portal]");
+      return portal?.parentElement?.tagName.toLowerCase() ?? null;
+    });
+    expect(parentTag).toBe("dialog");
+  });
+
+  test("OverflowMenu portal uses position: fixed inside the dialog", async ({
+    page,
+  }) => {
+    await page.getByRole("button", { name: "menu" }).click();
+    await expect(page.getByRole("menuitem", { name: "Edit" })).toBeVisible();
+
+    const style = await page
+      .locator("[data-floating-portal]")
+      .getAttribute("style");
+    expect(style).toContain("position: fixed");
+    expect(style).not.toContain("position: absolute");
+  });
+
+  test("OverflowMenu menu is anchored under its trigger inside the dialog", async ({
+    page,
+  }) => {
+    const trigger = page.getByRole("button", { name: "menu" });
+    await trigger.click();
+    await expect(page.getByRole("menuitem", { name: "Edit" })).toBeVisible();
+
+    const triggerBox = await trigger.boundingBox();
+    const portalBox = await page
+      .locator("[data-floating-portal]")
+      .boundingBox();
+
+    expect(triggerBox).not.toBeNull();
+    expect(portalBox).not.toBeNull();
+    if (triggerBox && portalBox) {
+      // The menu should sit directly below the trigger (within a few px), not
+      // offset by the dialog's top — that was the regression in #2873.
+      expect(
+        Math.abs(portalBox.y - (triggerBox.y + triggerBox.height)),
+      ).toBeLessThan(8);
+      expect(Math.abs(portalBox.x - triggerBox.x)).toBeLessThan(8);
+    }
+  });
+
+  test("OverflowMenu menu is visible above the modal backdrop", async ({
+    page,
+  }) => {
+    await page.getByRole("button", { name: "menu" }).click();
+    const item = page.getByRole("menuitem", { name: "Edit" });
+    await expect(item).toBeVisible();
+
+    // The item must be the topmost element at its center — if it were behind
+    // the backdrop, elementFromPoint would return the backdrop / dialog.
+    const isOnTop = await item.evaluate((el) => {
+      const rect = el.getBoundingClientRect();
+      const cx = rect.left + rect.width / 2;
+      const cy = rect.top + rect.height / 2;
+      const hit = document.elementFromPoint(cx, cy);
+      return hit === el || el.contains(hit);
+    });
+    expect(isOnTop).toBe(true);
+  });
+
+  test("Dropdown menu also auto-mounts into the dialog", async ({ page }) => {
+    await page.getByRole("combobox", { name: "Region" }).click();
+
+    const menu = page.getByRole("listbox", { name: "Region" });
+    await expect(menu).toBeVisible();
+
+    const parentTag = await menu.evaluate((el) => {
+      const node: HTMLElement | null = el.closest("[data-floating-portal]");
+      return node?.parentElement?.tagName.toLowerCase() ?? null;
+    });
+    expect(parentTag).toBe("dialog");
+  });
+
+  test("dialog closes via secondary button while menu fixture is mounted", async ({
+    page,
+  }) => {
+    await page.getByRole("button", { name: "Close" }).click();
+    await expect(page.getByTestId("native-dialog")).not.toBeVisible();
+  });
+});

--- a/src/Portal/FloatingPortal.svelte
+++ b/src/Portal/FloatingPortal.svelte
@@ -92,7 +92,9 @@
 
   /**
    * Specify the DOM element to mount the portal into.
-   * Defaults to `document.body`.
+   * When not set, mounts into the anchor's nearest `<dialog>` ancestor if one
+   * exists (so the portal participates in the dialog's top layer), otherwise
+   * falls back to `document.body`.
    * @type {HTMLElement | null}
    */
   export let target = null;
@@ -188,6 +190,11 @@
     }
   }
 
+  // Auto-detect the nearest <dialog> ancestor of the anchor so that portalled
+  // content participates in the dialog's top layer by default. An explicit
+  // `target` prop overrides this.
+  $: effectiveTarget = target ?? anchor?.closest("dialog") ?? null;
+
   // When the portal is mounted into a custom target (e.g. a native <dialog>
   // opened with showModal()), `position: absolute` resolves against the target's
   // containing block rather than the viewport. Use `position: fixed` in that
@@ -195,9 +202,9 @@
   // skip the document scroll offsets, which only apply to absolute positioning
   // relative to `document.body`.
   $: useFixedPosition =
-    target != null &&
+    effectiveTarget != null &&
     typeof document !== "undefined" &&
-    target !== document.body;
+    effectiveTarget !== document.body;
 
   function updatePosition() {
     if (!mounted || !anchor || !ref) return;
@@ -442,7 +449,7 @@
 {#if open}
   <Portal
     bind:ref
-    {target}
+    target={effectiveTarget}
     {...$$restProps}
     data-floating-portal
     data-floating-direction={pos.actualDirection}

--- a/src/Portal/FloatingPortal.svelte
+++ b/src/Portal/FloatingPortal.svelte
@@ -90,6 +90,13 @@
    */
   export let ref = null;
 
+  /**
+   * Specify the DOM element to mount the portal into.
+   * Defaults to `document.body`.
+   * @type {HTMLElement | null}
+   */
+  export let target = null;
+
   import { onMount, tick } from "svelte";
   import Portal from "./Portal.svelte";
 
@@ -181,11 +188,24 @@
     }
   }
 
+  // When the portal is mounted into a custom target (e.g. a native <dialog>
+  // opened with showModal()), `position: absolute` resolves against the target's
+  // containing block rather than the viewport. Use `position: fixed` in that
+  // case — fixed stays viewport-relative even inside a top-layer dialog — and
+  // skip the document scroll offsets, which only apply to absolute positioning
+  // relative to `document.body`.
+  $: useFixedPosition =
+    target != null &&
+    typeof document !== "undefined" &&
+    target !== document.body;
+
   function updatePosition() {
     if (!mounted || !anchor || !ref) return;
 
     const rect = anchor.getBoundingClientRect();
     const floatingRect = ref.getBoundingClientRect();
+    const scrollYOffset = useFixedPosition ? 0 : window.scrollY;
+    const scrollXOffset = useFixedPosition ? 0 : window.scrollX;
 
     const isVertical = direction === "top" || direction === "bottom";
     let actualDirection = direction;
@@ -234,27 +254,27 @@
     let width;
 
     if (actualDirection === "bottom") {
-      top = rect.bottom + window.scrollY + gapBottom;
-      left = rect.left + window.scrollX;
+      top = rect.bottom + scrollYOffset + gapBottom;
+      left = rect.left + scrollXOffset;
       width = rect.width;
     } else if (actualDirection === "top") {
-      top = rect.top + window.scrollY - floatingRect.height - gapTop;
-      left = rect.left + window.scrollX;
+      top = rect.top + scrollYOffset - floatingRect.height - gapTop;
+      left = rect.left + scrollXOffset;
       width = rect.width;
     } else if (actualDirection === "right") {
       if (intrinsicWidth) {
         if (intrinsicAlign === "start") {
-          top = rect.top + window.scrollY + verticalAlignOffsetRight;
+          top = rect.top + scrollYOffset + verticalAlignOffsetRight;
         } else if (intrinsicAlign === "end") {
           top =
             rect.bottom +
-            window.scrollY -
+            scrollYOffset -
             floatingRect.height +
             verticalAlignOffsetRight;
         } else {
           top =
             rect.top +
-            window.scrollY +
+            scrollYOffset +
             rect.height / 2 -
             floatingRect.height / 2 +
             verticalAlignOffsetRight;
@@ -262,27 +282,27 @@
       } else {
         top =
           rect.top +
-          window.scrollY +
+          scrollYOffset +
           rect.height / 2 -
           floatingRect.height / 2 +
           verticalAlignOffsetRight;
       }
-      left = rect.right + window.scrollX + horizontalGapRight;
+      left = rect.right + scrollXOffset + horizontalGapRight;
     } else {
       // left
       if (intrinsicWidth) {
         if (intrinsicAlign === "start") {
-          top = rect.top + window.scrollY + verticalAlignOffsetLeft;
+          top = rect.top + scrollYOffset + verticalAlignOffsetLeft;
         } else if (intrinsicAlign === "end") {
           top =
             rect.bottom +
-            window.scrollY -
+            scrollYOffset -
             floatingRect.height +
             verticalAlignOffsetLeft;
         } else {
           top =
             rect.top +
-            window.scrollY +
+            scrollYOffset +
             rect.height / 2 -
             floatingRect.height / 2 +
             verticalAlignOffsetLeft;
@@ -290,13 +310,12 @@
       } else {
         top =
           rect.top +
-          window.scrollY +
+          scrollYOffset +
           rect.height / 2 -
           floatingRect.height / 2 +
           verticalAlignOffsetLeft;
       }
-      left =
-        rect.left + window.scrollX - floatingRect.width - horizontalGapLeft;
+      left = rect.left + scrollXOffset - floatingRect.width - horizontalGapLeft;
     }
 
     let posLeft = left;
@@ -308,11 +327,11 @@
       (actualDirection === "top" || actualDirection === "bottom")
     ) {
       if (intrinsicAlign === "center") {
-        posLeft = rect.left + window.scrollX + rect.width / 2;
+        posLeft = rect.left + scrollXOffset + rect.width / 2;
       } else if (intrinsicAlign === "start") {
-        posLeft = rect.left + window.scrollX;
+        posLeft = rect.left + scrollXOffset;
       } else {
-        posLeft = rect.right + window.scrollX;
+        posLeft = rect.right + scrollXOffset;
       }
       posWidth = undefined;
     }
@@ -370,7 +389,7 @@
     : null;
 
   $: portalStyle = [
-    "position: absolute",
+    useFixedPosition ? "position: fixed" : "position: absolute",
     `top: ${pos.top}px`,
     `left: ${pos.left}px`,
     intrinsicTranslateX,
@@ -423,6 +442,7 @@
 {#if open}
   <Portal
     bind:ref
+    {target}
     {...$$restProps}
     data-floating-portal
     data-floating-direction={pos.actualDirection}

--- a/src/Portal/Portal.svelte
+++ b/src/Portal/Portal.svelte
@@ -6,6 +6,13 @@
   export let tag = "div";
 
   /**
+   * Specify the DOM element to mount the portal into.
+   * Defaults to `document.body`.
+   * @type {HTMLElement | null}
+   */
+  export let target = null;
+
+  /**
    * Obtain a reference to the portal element.
    * @type {null | HTMLElement}
    */
@@ -27,11 +34,14 @@
     };
   });
 
-  $: if (mounted && ref) {
-    if (typeof document !== "undefined" && ref.parentNode !== document.body) {
+  $: effectiveTarget =
+    target ?? (typeof document === "undefined" ? null : document.body);
+
+  $: if (mounted && ref && effectiveTarget) {
+    if (ref.parentNode !== effectiveTarget) {
       const activeEl = document.activeElement;
       const hadFocus = ref.contains(activeEl);
-      document.body.appendChild(ref);
+      effectiveTarget.appendChild(ref);
       if (hadFocus && activeEl instanceof HTMLElement) {
         activeEl.focus();
       }

--- a/tests/Portal/FloatingPortal.test.svelte
+++ b/tests/Portal/FloatingPortal.test.svelte
@@ -21,6 +21,7 @@
   export let verticalAlignOffsetRight = 0;
   export let intrinsicAlign: ComponentProps<FloatingPortal>["intrinsicAlign"] =
     "center";
+  export let target: ComponentProps<FloatingPortal>["target"] = null;
 </script>
 
 {#if scrollableContainer}
@@ -48,6 +49,7 @@
   {verticalAlignOffsetLeft}
   {verticalAlignOffsetRight}
   {intrinsicAlign}
+  {target}
   bind:ref
 >
   {content}

--- a/tests/Portal/FloatingPortal.test.svelte
+++ b/tests/Portal/FloatingPortal.test.svelte
@@ -22,6 +22,8 @@
   export let intrinsicAlign: ComponentProps<FloatingPortal>["intrinsicAlign"] =
     "center";
   export let target: ComponentProps<FloatingPortal>["target"] = null;
+  export let dialogAncestor = false;
+  export let dialogRef: HTMLDialogElement | null = null;
 </script>
 
 {#if scrollableContainer}
@@ -32,6 +34,10 @@
   >
     <div data-testid="anchor" bind:this={anchor}>Anchor element</div>
   </div>
+{:else if dialogAncestor}
+  <dialog data-testid="dialog-ancestor" bind:this={dialogRef} open>
+    <div data-testid="anchor" bind:this={anchor}>Anchor element</div>
+  </dialog>
 {:else}
   <div data-testid="anchor" bind:this={anchor}>Anchor element</div>
 {/if}

--- a/tests/Portal/FloatingPortal.test.ts
+++ b/tests/Portal/FloatingPortal.test.ts
@@ -188,6 +188,39 @@ describe("FloatingPortal", () => {
     customTarget.remove();
   });
 
+  it("auto-mounts into the anchor's nearest <dialog> ancestor", async () => {
+    render(FloatingPortalTest, {
+      props: { open: true, dialogAncestor: true },
+    });
+
+    const content = await screen.findByText("Floating content");
+    const portalElement = content.closest("[data-floating-portal]");
+    assert(portalElement instanceof HTMLElement);
+
+    const dialog = screen.getByTestId("dialog-ancestor");
+    expect(portalElement.parentElement).toBe(dialog);
+    expect(portalElement.getAttribute("style") ?? "").toContain(
+      "position: fixed",
+    );
+  });
+
+  it("explicit target overrides the auto-detected <dialog> ancestor", async () => {
+    const customTarget = document.createElement("div");
+    document.body.appendChild(customTarget);
+
+    render(FloatingPortalTest, {
+      props: { open: true, dialogAncestor: true, target: customTarget },
+    });
+
+    const content = await screen.findByText("Floating content");
+    const portalElement = content.closest("[data-floating-portal]");
+    assert(portalElement instanceof HTMLElement);
+
+    expect(portalElement.parentElement).toBe(customTarget);
+
+    customTarget.remove();
+  });
+
   describe("intrinsicWidth", () => {
     it("applies width and no translateX when intrinsicWidth is false (default)", async () => {
       render(FloatingPortalTest, {

--- a/tests/Portal/FloatingPortal.test.ts
+++ b/tests/Portal/FloatingPortal.test.ts
@@ -168,6 +168,26 @@ describe("FloatingPortal", () => {
     expect(style).toMatch(/width:\s*\d+px/);
   });
 
+  it("uses position: fixed when mounted into a non-body target", async () => {
+    const customTarget = document.createElement("div");
+    document.body.appendChild(customTarget);
+
+    render(FloatingPortalTest, {
+      props: { open: true, target: customTarget },
+    });
+
+    const content = await screen.findByText("Floating content");
+    const portalElement = content.closest("[data-floating-portal]");
+    assert(portalElement instanceof HTMLElement);
+
+    expect(portalElement.parentElement).toBe(customTarget);
+    const style = portalElement.getAttribute("style") ?? "";
+    expect(style).toContain("position: fixed");
+    expect(style).not.toContain("position: absolute");
+
+    customTarget.remove();
+  });
+
   describe("intrinsicWidth", () => {
     it("applies width and no translateX when intrinsicWidth is false (default)", async () => {
       render(FloatingPortalTest, {

--- a/tests/Portal/Portal.test.svelte
+++ b/tests/Portal/Portal.test.svelte
@@ -8,8 +8,9 @@
   export let portalContent = "Portal content";
   export let tag: ComponentProps<Portal>["tag"] = "div";
   export let ref: ComponentProps<Portal>["ref"] = null;
+  export let target: ComponentProps<Portal>["target"] = null;
 </script>
 
 {#if showPortal}
-  <Portal {tag} bind:ref {...$$restProps}> {portalContent} </Portal>
+  <Portal {tag} {target} bind:ref {...$$restProps}> {portalContent} </Portal>
 {/if}

--- a/tests/Portal/Portal.test.ts
+++ b/tests/Portal/Portal.test.ts
@@ -228,6 +228,60 @@ describe("Portal", () => {
     expect(portalElement.getAttribute("style")).toContain("background-color");
   });
 
+  describe("custom target", () => {
+    it("mounts into the provided target element", async () => {
+      const customTarget = document.createElement("div");
+      customTarget.setAttribute("data-testid", "custom-target");
+      document.body.appendChild(customTarget);
+
+      render(PortalTest, { props: { target: customTarget } });
+
+      const portalContent = await screen.findByText("Portal content");
+      const portalElement = portalContent.closest("[data-portal]");
+      assert(portalElement instanceof HTMLElement);
+
+      expect(portalElement.parentElement).toBe(customTarget);
+      expect(portalElement.parentElement).not.toBe(document.body);
+
+      customTarget.remove();
+    });
+
+    it("falls back to document.body when target is null", async () => {
+      render(PortalTest, { props: { target: null } });
+
+      const portalContent = await screen.findByText("Portal content");
+      const portalElement = portalContent.closest("[data-portal]");
+      assert(portalElement instanceof HTMLElement);
+
+      expect(portalElement.parentElement).toBe(document.body);
+    });
+
+    it("moves the portal when target changes", async () => {
+      const firstTarget = document.createElement("div");
+      const secondTarget = document.createElement("div");
+      document.body.appendChild(firstTarget);
+      document.body.appendChild(secondTarget);
+
+      const { rerender } = render(PortalTest, {
+        props: { target: firstTarget },
+      });
+
+      const portalContent = await screen.findByText("Portal content");
+      const portalElement = portalContent.closest("[data-portal]");
+      assert(portalElement instanceof HTMLElement);
+
+      expect(portalElement.parentElement).toBe(firstTarget);
+
+      rerender({ target: secondTarget });
+      await tick();
+
+      expect(portalElement.parentElement).toBe(secondTarget);
+
+      firstTarget.remove();
+      secondTarget.remove();
+    });
+  });
+
   describe("focus preservation when moving to body", () => {
     it("preserves focus on element inside portal when it is moved to document.body", async () => {
       render(PortalFocusTest);


### PR DESCRIPTION
Fixes [#2873](https://github.com/carbon-design-system/carbon-components-svelte/issues/2873)

If portallable-components (like `OverflowMenu`) are used inside a [native dialog](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/dialog), portalling doesn't work as expected, as the portal is rendered to `document.body`, not inside the `dialog` layer.

The solution is two-fold:

- Allow a custom `target` override for `Portal` and `FloatingPortal`
- Auto-detect `dialog` so that a component like `OverflowMenu` will automatically target the `dialog` if `portalMenu` is true.

**Repro**

```svelte
<script>
  import {
    Button,
    OverflowMenu,
    OverflowMenuItem,
  } from "carbon-components-svelte";

  let dialog = null;
</script>

<button
  type="button"
  on:click={() => dialog?.showModal()}
>
  Open dialog
</button>

<dialog bind:this={dialog}>
  <OverflowMenu portalMenu>
    <OverflowMenuItem text="Edit" />
    <OverflowMenuItem text="Duplicate" />
    <OverflowMenuItem danger text="Delete" />
  </OverflowMenu>
  <Button kind="secondary" on:click={() => dialog?.close()}>Close</Button>
</dialog>

```

<img width="648" height="285" alt="Screenshot 2026-04-24 at 8 58 36 PM" src="https://github.com/user-attachments/assets/8bb5b6f5-27ee-44a3-97da-07843b7af4fb" />
