### PR TITLE
fix: `CheckboxGroup`, `ContentSwitcher`, `RadioButtonGroup` do not dispatch initial "change" event

### DIFF
--- a/src/Checkbox/CheckboxGroup.svelte
+++ b/src/Checkbox/CheckboxGroup.svelte
@@ -69,6 +69,13 @@
   const groupRequired = writable(required);
   const groupDisabled = writable(disabled);
   let isInitialRender = true;
+  let isSyncingSelected = false;
+
+  function syncSelectedValues() {
+    isSyncingSelected = true;
+    $selectedValues = selected;
+    isSyncingSelected = false;
+  }
 
   /**
    * @type {(value: string | number, checked: boolean) => void}
@@ -91,19 +98,19 @@
   });
 
   onMount(() => {
-    $selectedValues = selected;
+    syncSelectedValues();
     tick().then(() => {
       isInitialRender = false;
     });
   });
 
   beforeUpdate(() => {
-    $selectedValues = selected;
+    syncSelectedValues();
   });
 
   selectedValues.subscribe((value) => {
     selected = value;
-    if (!isInitialRender) {
+    if (!isInitialRender && !isSyncingSelected) {
       dispatch("change", value);
     }
   });

--- a/src/Checkbox/CheckboxGroup.svelte
+++ b/src/Checkbox/CheckboxGroup.svelte
@@ -55,6 +55,7 @@
     createEventDispatcher,
     onMount,
     setContext,
+    tick,
   } from "svelte";
   import { readonly, writable } from "svelte/store";
 
@@ -67,6 +68,7 @@
   const groupName = writable(name);
   const groupRequired = writable(required);
   const groupDisabled = writable(disabled);
+  let isInitialRender = true;
 
   /**
    * @type {(value: string | number, checked: boolean) => void}
@@ -90,6 +92,9 @@
 
   onMount(() => {
     $selectedValues = selected;
+    tick().then(() => {
+      isInitialRender = false;
+    });
   });
 
   beforeUpdate(() => {
@@ -98,7 +103,9 @@
 
   selectedValues.subscribe((value) => {
     selected = value;
-    dispatch("change", value);
+    if (!isInitialRender) {
+      dispatch("change", value);
+    }
   });
 
   $: $groupName = name;

--- a/src/ContentSwitcher/ContentSwitcher.svelte
+++ b/src/ContentSwitcher/ContentSwitcher.svelte
@@ -31,11 +31,16 @@
   /** @type {HTMLDivElement | null} */
   let refContainer = null;
 
+  let prevIndex = -1;
+
   $: currentIndex = -1;
   $: focusedIndex = -1;
   $: switches = [];
   $: if (switches[currentIndex]) {
-    dispatch("change", currentIndex);
+    if (prevIndex > -1 && prevIndex !== currentIndex) {
+      dispatch("change", currentIndex);
+    }
+    prevIndex = currentIndex;
     currentId.set(switches[currentIndex].id);
   }
 

--- a/src/RadioButtonGroup/RadioButtonGroup.svelte
+++ b/src/RadioButtonGroup/RadioButtonGroup.svelte
@@ -65,6 +65,7 @@
   export let id = undefined;
 
   import {
+    afterUpdate,
     beforeUpdate,
     createEventDispatcher,
     onMount,
@@ -79,6 +80,7 @@
   const selectedValue = writable(selected);
   const groupName = writable(name);
   const groupRequired = writable(required);
+  let isInitialRender = true;
 
   /**
    * @type {(data: { checked: boolean; value: Value }) => void}
@@ -114,7 +116,13 @@
 
   selectedValue.subscribe((value) => {
     selected = value;
-    dispatch("change", value);
+    if (!isInitialRender) {
+      dispatch("change", value);
+    }
+  });
+
+  afterUpdate(() => {
+    isInitialRender = false;
   });
 
   $: $groupName = name;

--- a/tests/Checkbox/CheckboxGroupComponent.test.ts
+++ b/tests/Checkbox/CheckboxGroupComponent.test.ts
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/svelte";
 import { user } from "../setup-tests";
 import CheckboxGroupComponent from "./CheckboxGroupComponent.test.svelte";
+import CheckboxGroupStaticSelected from "./CheckboxGroupStaticSelected.test.svelte";
 
 describe("CheckboxGroup", () => {
   it("should render with default props", () => {
@@ -44,6 +45,28 @@ describe("CheckboxGroup", () => {
     expect(consoleLog.mock.calls.some(([event]) => event === "change")).toBe(
       false,
     );
+  });
+
+  it("does not dispatch change event on initial render with a static selected array", () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(CheckboxGroupStaticSelected);
+
+    expect(consoleLog.mock.calls.some(([event]) => event === "change")).toBe(
+      false,
+    );
+  });
+
+  it("dispatches one change event after interacting with a static selected array", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(CheckboxGroupStaticSelected);
+
+    const smsCheckbox = screen.getByRole("checkbox", { name: "SMS" });
+    await user.click(smsCheckbox);
+
+    const changeCalls = consoleLog.mock.calls.filter(
+      ([event]) => event === "change",
+    );
+    expect(changeCalls).toEqual([["change", ["email", "sms"]]]);
   });
 
   it("should handle disabled state", () => {

--- a/tests/Checkbox/CheckboxGroupComponent.test.ts
+++ b/tests/Checkbox/CheckboxGroupComponent.test.ts
@@ -28,6 +28,24 @@ describe("CheckboxGroup", () => {
     expect(screen.getByRole("checkbox", { name: "Option 3" })).toBeChecked();
   });
 
+  it("does not dispatch change event on initial render", () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(CheckboxGroupComponent);
+
+    expect(consoleLog.mock.calls.some(([event]) => event === "change")).toBe(
+      false,
+    );
+  });
+
+  it("does not dispatch change event on initial render with selected values", () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(CheckboxGroupComponent, { props: { selected: ["2"] } });
+
+    expect(consoleLog.mock.calls.some(([event]) => event === "change")).toBe(
+      false,
+    );
+  });
+
   it("should handle disabled state", () => {
     render(CheckboxGroupComponent, { props: { disabled: true } });
 

--- a/tests/Checkbox/CheckboxGroupStaticSelected.test.svelte
+++ b/tests/Checkbox/CheckboxGroupStaticSelected.test.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  import { Checkbox, CheckboxGroup } from "carbon-components-svelte";
+</script>
+
+<CheckboxGroup
+  legendText="Notification preferences"
+  name="prefs"
+  selected={["email"]}
+  on:change={(e) => {
+    console.log("change", e.detail);
+  }}
+>
+  <Checkbox value="email" labelText="Email" />
+  <Checkbox value="sms" labelText="SMS" />
+  <Checkbox value="push" labelText="Push notifications" />
+</CheckboxGroup>

--- a/tests/ContentSwitcher/ContentSwitcher.test.svelte
+++ b/tests/ContentSwitcher/ContentSwitcher.test.svelte
@@ -4,12 +4,14 @@
   import { ContentSwitcher, Switch } from "carbon-components-svelte";
   import type { ComponentProps } from "svelte";
 
+  export let selectedIndex: ComponentProps<ContentSwitcher>["selectedIndex"] = 0;
   export let customClass = "";
   export let switchId: ComponentProps<Switch>["id"] = undefined;
   export let switchRef: ComponentProps<Switch>["ref"] = null;
 </script>
 
 <ContentSwitcher
+  {selectedIndex}
   class={customClass}
   on:change={(e) => {
     console.log("change", e.detail);

--- a/tests/ContentSwitcher/ContentSwitcher.test.ts
+++ b/tests/ContentSwitcher/ContentSwitcher.test.ts
@@ -78,6 +78,24 @@ describe("ContentSwitcher", () => {
     expect(tabs[2]).toHaveAttribute("tabindex", "-1");
   });
 
+  it("does not dispatch change event on initial render", () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(ContentSwitcher);
+
+    expect(consoleLog.mock.calls.some(([event]) => event === "change")).toBe(
+      false,
+    );
+  });
+
+  it("does not dispatch change event on initial render with selectedIndex", () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(ContentSwitcher, { props: { selectedIndex: 1 } });
+
+    expect(consoleLog.mock.calls.some(([event]) => event === "change")).toBe(
+      false,
+    );
+  });
+
   it("updates when selectedIndex changes", async () => {
     const { rerender } = render(ContentSwitcherSelectedIndex);
 

--- a/tests/RadioButtonGroup/RadioButtonGroup.test.ts
+++ b/tests/RadioButtonGroup/RadioButtonGroup.test.ts
@@ -20,6 +20,24 @@ describe("RadioButtonGroup", () => {
     expect(screen.getByRole("radio", { name: "Option 2" })).toBeChecked();
   });
 
+  it("does not dispatch change event on initial render", () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(RadioButtonGroup);
+
+    expect(consoleLog.mock.calls.some(([event]) => event === "change")).toBe(
+      false,
+    );
+  });
+
+  it("does not dispatch change event on initial render with selected value", () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(RadioButtonGroup, { props: { selected: "2" } });
+
+    expect(consoleLog.mock.calls.some(([event]) => event === "change")).toBe(
+      false,
+    );
+  });
+
   it("should handle disabled state", () => {
     render(RadioButtonGroup, { props: { disabled: true } });
 


### PR DESCRIPTION
More fixes, follow-up to https://github.com/carbon-design-system/carbon-components-svelte/pull/2872

In Svelte 5, certain components immediately dispatch a "change" event. This fixes them, and adds regression tests.