### PR TITLE
fix(date-picker): support portal menu inside native `dialog`, `popover`

### DIFF
--- a/docs/src/pages/components/DatePicker.svx
+++ b/docs/src/pages/components/DatePicker.svx
@@ -43,9 +43,15 @@ Set `portalMenu` to `true` to render the calendar in a floating portal. This pre
 
 ## Inside a native dialog
 
-When the date picker is rendered inside a native `<dialog>` (opened with `showModal()`) or an open `[popover]` element, the calendar auto-mounts into that top-layer ancestor and uses `position: fixed` so it appears above the backdrop.
+When the date picker is inside a native `<dialog>` opened with `showModal()`, `portalMenu` mounts the calendar into that dialog so it appears above the modal backdrop. The calendar uses `position: fixed` with viewport coordinates.
 
 <FileSource src="/framed/DatePicker/DatePickerDialog" />
+
+## Inside a native popover
+
+When the date picker is inside an open element with a [`popover`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/popover) attribute (see the [Popover API](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API)), `portalMenu` mounts the calendar into that ancestor so it stays in the popover top layer.
+
+<FileSource src="/framed/DatePicker/DatePickerPopover" />
 
 ## Simple
 

--- a/docs/src/pages/components/DatePicker.svx
+++ b/docs/src/pages/components/DatePicker.svx
@@ -41,6 +41,12 @@ Set `portalMenu` to `true` to render the calendar in a floating portal. This pre
 
 <FileSource src="/framed/DatePicker/DatePickerModal" />
 
+## Inside a native dialog
+
+When the date picker is rendered inside a native `<dialog>` (opened with `showModal()`) or an open `[popover]` element, the calendar auto-mounts into that top-layer ancestor and uses `position: fixed` so it appears above the backdrop.
+
+<FileSource src="/framed/DatePicker/DatePickerDialog" />
+
 ## Simple
 
 Create a simple date picker without a dropdown calendar.

--- a/docs/src/pages/components/FloatingPortal.svx
+++ b/docs/src/pages/components/FloatingPortal.svx
@@ -76,8 +76,14 @@ Use the `target` prop to mount the floating content into a specific DOM element 
 
 ## Inside a native dialog
 
-When the anchor is inside a [native dialog](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/dialog), floating content is automatically mounted into that dialog (via `anchor.closest("dialog")`). This ensures the content exists in the dialog's top layer to remain visible and interactive.
+When the anchor is inside a [native dialog](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/dialog), floating content is automatically mounted into that dialog (default `target` is `anchor.closest("dialog,[popover]")`, which resolves to the dialog when the anchor is nested under it). This keeps the content in the dialog top layer so it stays visible and interactive.
 
 Components inside the `dialog` must still enable `portalMenu` for its menu or content to be portalled. Pass an explicit `target` to override this behavior.
 
 <FileSource src="/framed/FloatingPortal/FloatingPortalDialog" />
+
+## Inside a native popover
+
+When the anchor is inside an element with a [`popover`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/popover) attribute (see the [Popover API](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API)), the same default `target` applies: floating content mounts into that popover element so it participates in the popover top layer.
+
+<FileSource src="/framed/FloatingPortal/FloatingPortalPopover" />

--- a/docs/src/pages/framed/DatePicker/DatePickerDialog.svelte
+++ b/docs/src/pages/framed/DatePicker/DatePickerDialog.svelte
@@ -1,0 +1,23 @@
+<script>
+  import {
+    Button,
+    DatePicker,
+    DatePickerInput,
+  } from "carbon-components-svelte";
+
+  let dialog = null;
+</script>
+
+<Button on:click={() => dialog?.showModal()}>Open dialog</Button>
+
+<dialog bind:this={dialog}>
+  <p>
+    With <code>portalMenu</code>, the calendar auto-mounts into the nearest
+    <code>&lt;dialog&gt;</code>
+    ancestor so it renders above the modal backdrop.
+  </p>
+  <DatePicker portalMenu datePickerType="single">
+    <DatePickerInput labelText="Meeting date" placeholder="mm/dd/yyyy" />
+  </DatePicker>
+  <Button kind="secondary" on:click={() => dialog?.close()}>Close</Button>
+</dialog>

--- a/docs/src/pages/framed/DatePicker/DatePickerPopover.svelte
+++ b/docs/src/pages/framed/DatePicker/DatePickerPopover.svelte
@@ -1,0 +1,35 @@
+<script>
+  import {
+    Button,
+    DatePicker,
+    DatePickerInput,
+  } from "carbon-components-svelte";
+
+  let popover = null;
+</script>
+
+<Button type="button" on:click={() => popover?.showPopover()}
+  >Open popover</Button
+>
+
+<div
+  bind:this={popover}
+  popover="manual"
+  style="width: min(100%, 28rem); padding: 1rem; border: 1px dashed var(--cds-border-subtle);"
+>
+  <p>
+    With <code>portalMenu</code>, the calendar auto-mounts into the nearest
+    <code>[popover]</code>
+    ancestor so it renders in the popover top layer instead of behind it.
+  </p>
+  <DatePicker portalMenu datePickerType="single">
+    <DatePickerInput labelText="Meeting date" placeholder="mm/dd/yyyy" />
+  </DatePicker>
+  <Button
+    kind="secondary"
+    type="button"
+    on:click={() => popover?.hidePopover()}
+  >
+    Close
+  </Button>
+</div>

--- a/docs/src/pages/framed/FloatingPortal/FloatingPortalPopover.svelte
+++ b/docs/src/pages/framed/FloatingPortal/FloatingPortalPopover.svelte
@@ -1,0 +1,62 @@
+<script>
+  import {
+    Button,
+    Dropdown,
+    OverflowMenu,
+    OverflowMenuItem,
+    Stack,
+  } from "carbon-components-svelte";
+
+  let popover = null;
+</script>
+
+<Button type="button" on:click={() => popover?.showPopover()}
+  >Open popover</Button
+>
+
+<div
+  bind:this={popover}
+  popover="manual"
+  style="width: min(100%, 28rem); padding: 1rem; border: 1px dashed var(--cds-border-subtle);"
+>
+  <Stack gap={5}>
+    <p>
+      With the same default <code>target</code> resolution as inside a
+      <code>&lt;dialog&gt;</code>, portalled menus mount into this
+      <code>[popover]</code>
+      element so they stay in the popover top layer.
+    </p>
+    <Dropdown
+      portalMenu
+      titleText="Region"
+      selectedId="us-south"
+      items={[
+        { id: "us-south", text: "Dallas (us-south)" },
+        { id: "us-east", text: "Washington DC (us-east)" },
+        { id: "eu-de", text: "Frankfurt (eu-de)" },
+        { id: "jp-tok", text: "Tokyo (jp-tok)" },
+        { id: "br-sao", text: "São Paulo (br-sao)" },
+        { id: "au-syd", text: "Sydney (au-syd)" },
+        { id: "ca-tor", text: "Toronto (ca-tor)" },
+        { id: "de-fra", text: "Frankfurt (de-fra)" },
+        { id: "es-mad", text: "Madrid (es-mad)" },
+        { id: "fr-par", text: "Paris (fr-par)" },
+        { id: "in-mum", text: "Mumbai (in-mum)" },
+        { id: "it-mil", text: "Milan (it-mil)" },
+        { id: "jp-osa", text: "Osaka (jp-osa)" },
+      ]}
+    />
+    <OverflowMenu portalMenu>
+      <OverflowMenuItem text="Edit" />
+      <OverflowMenuItem text="Duplicate" />
+      <OverflowMenuItem danger text="Delete" />
+    </OverflowMenu>
+    <Button
+      kind="secondary"
+      type="button"
+      on:click={() => popover?.hidePopover()}
+    >
+      Close
+    </Button>
+  </Stack>
+</div>

--- a/e2e/date-picker-top-layer.test.ts
+++ b/e2e/date-picker-top-layer.test.ts
@@ -1,0 +1,134 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("DatePicker inside native dialog", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/date-picker-top-layer.html");
+    await page.getByTestId("open-dialog").click();
+    await expect(page.getByTestId("native-dialog")).toBeVisible();
+  });
+
+  test("portalMenu calendar mounts inside the dialog (not document.body)", async ({
+    page,
+  }) => {
+    await page.getByTestId("dialog-date-picker-portal-input").click();
+
+    const calendar = page
+      .getByTestId("native-dialog")
+      .locator(".flatpickr-calendar.open");
+    await expect(calendar).toBeVisible();
+
+    const parentTag = await calendar.evaluate(
+      (el) => el.parentElement?.tagName.toLowerCase() ?? null,
+    );
+    expect(parentTag).toBe("dialog");
+  });
+
+  test("portalMenu calendar uses position: fixed inside the dialog", async ({
+    page,
+  }) => {
+    await page.getByTestId("dialog-date-picker-portal-input").click();
+
+    const calendar = page
+      .getByTestId("native-dialog")
+      .locator(".flatpickr-calendar.open");
+    await expect(calendar).toBeVisible();
+
+    const position = await calendar.evaluate(
+      (el) => (el as HTMLElement).style.position,
+    );
+    expect(position).toBe("fixed");
+  });
+
+  test("portalMenu calendar is anchored to its input inside the dialog", async ({
+    page,
+  }) => {
+    const input = page.getByTestId("dialog-date-picker-portal-input");
+    await input.click();
+
+    const calendar = page
+      .getByTestId("native-dialog")
+      .locator(".flatpickr-calendar.open");
+    await expect(calendar).toBeVisible();
+
+    const inputBox = await input.boundingBox();
+    const calendarBox = await calendar.boundingBox();
+
+    expect(inputBox).not.toBeNull();
+    expect(calendarBox).not.toBeNull();
+    if (inputBox && calendarBox) {
+      // The calendar should sit immediately above or below the input — not
+      // offset by the dialog's top, which is the regression in #2881.
+      const distanceBelow = Math.abs(
+        calendarBox.y - (inputBox.y + inputBox.height),
+      );
+      const distanceAbove = Math.abs(
+        calendarBox.y + calendarBox.height - inputBox.y,
+      );
+      expect(Math.min(distanceBelow, distanceAbove)).toBeLessThan(32);
+    }
+  });
+});
+
+test.describe("DatePicker inside native [popover]", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/date-picker-top-layer.html");
+    await page.getByTestId("open-popover").click();
+    await expect(page.getByTestId("native-popover")).toBeVisible();
+  });
+
+  test("portalMenu calendar mounts inside the popover", async ({ page }) => {
+    await page.getByTestId("popover-date-picker-portal-input").focus();
+
+    const calendar = page
+      .getByTestId("native-popover")
+      .locator(".flatpickr-calendar.open");
+    await expect(calendar).toBeVisible();
+
+    const parentTestId = await calendar.evaluate(
+      (el) => el.parentElement?.getAttribute("data-testid") ?? null,
+    );
+    expect(parentTestId).toBe("native-popover");
+  });
+
+  test("portalMenu calendar uses position: fixed inside the popover", async ({
+    page,
+  }) => {
+    await page.getByTestId("popover-date-picker-portal-input").focus();
+    const calendar = page
+      .getByTestId("native-popover")
+      .locator(".flatpickr-calendar.open");
+    await expect(calendar).toBeVisible();
+
+    const position = await calendar.evaluate(
+      (el) => (el as HTMLElement).style.position,
+    );
+    expect(position).toBe("fixed");
+  });
+
+  test("portalMenu calendar is anchored to its input inside the popover", async ({
+    page,
+  }) => {
+    const input = page.getByTestId("popover-date-picker-portal-input");
+    await input.focus();
+
+    const calendar = page
+      .getByTestId("native-popover")
+      .locator(".flatpickr-calendar.open");
+    await expect(calendar).toBeVisible();
+
+    const inputBox = await input.boundingBox();
+    const calendarBox = await calendar.boundingBox();
+
+    expect(inputBox).not.toBeNull();
+    expect(calendarBox).not.toBeNull();
+    if (inputBox && calendarBox) {
+      const distanceBelow = Math.abs(
+        calendarBox.y - (inputBox.y + inputBox.height),
+      );
+      const distanceAbove = Math.abs(
+        calendarBox.y + calendarBox.height - inputBox.y,
+      );
+      expect(Math.min(distanceBelow, distanceAbove)).toBeLessThan(32);
+    }
+  });
+});

--- a/e2e/fixtures/DatePickerTopLayerFixture.svelte
+++ b/e2e/fixtures/DatePickerTopLayerFixture.svelte
@@ -1,0 +1,53 @@
+<script>
+  import {
+    Button,
+    DatePicker,
+    DatePickerInput,
+  } from "carbon-components-svelte";
+
+  let dialog = null;
+  let popover = null;
+</script>
+
+<button
+  type="button"
+  data-testid="open-dialog"
+  on:click={() => dialog?.showModal()}
+>
+  Open dialog
+</button>
+
+<dialog data-testid="native-dialog" bind:this={dialog}>
+  <Button kind="secondary" on:click={() => dialog?.close()}>Close</Button>
+  <DatePicker portalMenu datePickerType="single">
+    <DatePickerInput
+      data-testid="dialog-date-picker-portal-input"
+      labelText="Dialog date (portalMenu)"
+      placeholder="mm/dd/yyyy"
+    />
+  </DatePicker>
+</dialog>
+
+<button
+  type="button"
+  data-testid="open-popover"
+  on:click={() => popover?.showPopover()}
+>
+  Open popover
+</button>
+
+<div
+  data-testid="native-popover"
+  popover="manual"
+  bind:this={popover}
+  style="width: 600px; padding: 1rem;"
+>
+  <button type="button" on:click={() => popover?.hidePopover()}>Close</button>
+  <DatePicker portalMenu datePickerType="single">
+    <DatePickerInput
+      data-testid="popover-date-picker-portal-input"
+      labelText="Popover date (portalMenu)"
+      placeholder="mm/dd/yyyy"
+    />
+  </DatePicker>
+</div>

--- a/e2e/fixtures/FloatingPortalPopoverFixture.svelte
+++ b/e2e/fixtures/FloatingPortalPopoverFixture.svelte
@@ -1,0 +1,53 @@
+<script>
+  import {
+    Button,
+    Dropdown,
+    OverflowMenu,
+    OverflowMenuItem,
+    Stack,
+  } from "carbon-components-svelte";
+
+  let popover = null;
+</script>
+
+<button
+  type="button"
+  data-testid="open-popover"
+  on:click={() => popover?.showPopover()}
+>
+  Open popover
+</button>
+
+<div
+  data-testid="native-popover"
+  popover="manual"
+  bind:this={popover}
+  style="width: min(100%, 28rem); padding: 1rem;"
+>
+  <Stack gap={5}>
+    <p>Floating content auto-mounts into the nearest popover ancestor.</p>
+    <Dropdown
+      portalMenu
+      labelText="Region"
+      selectedId="us-south"
+      items={[
+        { id: "us-south", text: "Dallas" },
+        { id: "us-east", text: "Washington DC" },
+        { id: "eu-de", text: "Frankfurt" },
+        { id: "jp-tok", text: "Tokyo" },
+      ]}
+    />
+    <OverflowMenu portalMenu>
+      <OverflowMenuItem text="Edit" />
+      <OverflowMenuItem text="Duplicate" />
+      <OverflowMenuItem danger text="Delete" />
+    </OverflowMenu>
+    <Button
+      kind="secondary"
+      type="button"
+      on:click={() => popover?.hidePopover()}
+    >
+      Close
+    </Button>
+  </Stack>
+</div>

--- a/e2e/fixtures/date-picker-top-layer.html
+++ b/e2e/fixtures/date-picker-top-layer.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>DatePicker in dialog/popover Test</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="./date-picker-top-layer.ts"></script>
+  </body>
+</html>

--- a/e2e/fixtures/date-picker-top-layer.ts
+++ b/e2e/fixtures/date-picker-top-layer.ts
@@ -1,0 +1,4 @@
+import DatePickerTopLayerFixture from "./DatePickerTopLayerFixture.svelte";
+import { mount } from "./mount";
+
+mount(DatePickerTopLayerFixture);

--- a/e2e/fixtures/floating-portal-popover.html
+++ b/e2e/fixtures/floating-portal-popover.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>FloatingPortal in native popover Test</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="./floating-portal-popover.ts"></script>
+  </body>
+</html>

--- a/e2e/fixtures/floating-portal-popover.ts
+++ b/e2e/fixtures/floating-portal-popover.ts
@@ -1,0 +1,4 @@
+import FloatingPortalPopoverFixture from "./FloatingPortalPopoverFixture.svelte";
+import { mount } from "./mount";
+
+mount(FloatingPortalPopoverFixture);

--- a/e2e/floating-portal-popover.test.ts
+++ b/e2e/floating-portal-popover.test.ts
@@ -1,0 +1,95 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("FloatingPortal inside native popover", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/floating-portal-popover.html");
+    await page.getByTestId("open-popover").click();
+    await expect(page.getByTestId("native-popover")).toBeVisible();
+  });
+
+  test("OverflowMenu portal mounts inside the popover (not document.body)", async ({
+    page,
+  }) => {
+    await page.getByRole("button", { name: "menu" }).click();
+
+    await expect(page.getByRole("menuitem", { name: "Edit" })).toBeVisible();
+
+    const parentTestId = await page.evaluate(() => {
+      const portal = document.querySelector("[data-floating-portal]");
+      return portal?.parentElement?.getAttribute("data-testid") ?? null;
+    });
+    expect(parentTestId).toBe("native-popover");
+  });
+
+  test("OverflowMenu portal uses position: fixed inside the popover", async ({
+    page,
+  }) => {
+    await page.getByRole("button", { name: "menu" }).click();
+    await expect(page.getByRole("menuitem", { name: "Edit" })).toBeVisible();
+
+    const style = await page
+      .locator("[data-floating-portal]")
+      .getAttribute("style");
+    expect(style).toContain("position: fixed");
+    expect(style).not.toContain("position: absolute");
+  });
+
+  test("OverflowMenu menu is anchored under its trigger inside the popover", async ({
+    page,
+  }) => {
+    const trigger = page.getByRole("button", { name: "menu" });
+    await trigger.click();
+    await expect(page.getByRole("menuitem", { name: "Edit" })).toBeVisible();
+
+    const triggerBox = await trigger.boundingBox();
+    const portalBox = await page
+      .locator("[data-floating-portal]")
+      .boundingBox();
+
+    expect(triggerBox).not.toBeNull();
+    expect(portalBox).not.toBeNull();
+    if (triggerBox && portalBox) {
+      expect(
+        Math.abs(portalBox.y - (triggerBox.y + triggerBox.height)),
+      ).toBeLessThan(8);
+      expect(Math.abs(portalBox.x - triggerBox.x)).toBeLessThan(8);
+    }
+  });
+
+  test("OverflowMenu menu is hit-testable at its center (popover top layer)", async ({
+    page,
+  }) => {
+    await page.getByRole("button", { name: "menu" }).click();
+    const item = page.getByRole("menuitem", { name: "Edit" });
+    await expect(item).toBeVisible();
+
+    const isOnTop = await item.evaluate((el) => {
+      const rect = el.getBoundingClientRect();
+      const cx = rect.left + rect.width / 2;
+      const cy = rect.top + rect.height / 2;
+      const hit = document.elementFromPoint(cx, cy);
+      return hit === el || el.contains(hit);
+    });
+    expect(isOnTop).toBe(true);
+  });
+
+  test("Dropdown menu also auto-mounts into the popover", async ({ page }) => {
+    await page.getByRole("combobox", { name: "Region" }).click();
+
+    const menu = page.getByRole("listbox", { name: "Region" });
+    await expect(menu).toBeVisible();
+
+    const parentTestId = await menu.evaluate((el) => {
+      const node: HTMLElement | null = el.closest("[data-floating-portal]");
+      return node?.parentElement?.getAttribute("data-testid") ?? null;
+    });
+    expect(parentTestId).toBe("native-popover");
+  });
+
+  test("popover closes via secondary button while menu fixture is mounted", async ({
+    page,
+  }) => {
+    await page.getByRole("button", { name: "Close" }).click();
+    await expect(page.getByTestId("native-popover")).not.toBeVisible();
+  });
+});

--- a/src/DatePicker/DatePicker.svelte
+++ b/src/DatePicker/DatePicker.svelte
@@ -59,6 +59,11 @@
   /**
    * Set to `true` to render the calendar in a portal to prevent clipping.
    * When inside a Modal, defaults to `true` unless explicitly set to `false`.
+   *
+   * When the date picker is inside a native `<dialog>` (opened with
+   * `showModal()`) or an open `[popover]` element, the calendar auto-mounts
+   * into that top-layer ancestor and uses `position: fixed` so it renders
+   * above the backdrop instead of behind it.
    * @type {boolean | undefined}
    */
   export let portalMenu = undefined;
@@ -82,6 +87,11 @@
   } from "svelte";
   import { derived, writable } from "svelte/store";
   import { createCalendar } from "./createCalendar";
+  import {
+    getTopLayerAncestor,
+    isEventTargetInsidePortaledCalendar,
+    positionFlatpickrCalendarFixed,
+  } from "./datePickerTopLayer";
 
   const dispatch = createEventDispatcher();
   const insideModal = getContext("carbon:Modal");
@@ -228,11 +238,22 @@
       return;
     }
 
+    // Auto-detect a top-layer ancestor (native dialog or open popover) so the
+    // calendar can participate in its top layer instead of being clipped behind
+    // the backdrop. Computed at creation time — appendTo cannot change after.
+    const topLayerAncestor = getTopLayerAncestor(datePickerRef);
+
     calendar = await createCalendar({
       options: {
         ...options,
         ...(effectivePortalMenu
-          ? { static: false }
+          ? {
+              static: false,
+              ...(topLayerAncestor && {
+                appendTo: topLayerAncestor,
+                position: positionFlatpickrCalendarFixed,
+              }),
+            }
           : { appendTo: datePickerRef }),
         defaultDate: $inputValue,
         mode: $mode,
@@ -320,8 +341,16 @@
 <svelte:window
   on:click={({ target }) => {
     if (!calendar?.isOpen) return;
-    if (datePickerRef?.contains(target)) return;
-    if (!calendar.calendarContainer.contains(target)) calendar.close();
+    if (
+      isEventTargetInsidePortaledCalendar(
+        datePickerRef,
+        calendar.calendarContainer,
+        target,
+      )
+    ) {
+      return;
+    }
+    calendar.close();
   }}
 />
 

--- a/src/DatePicker/datePickerTopLayer.d.ts
+++ b/src/DatePicker/datePickerTopLayer.d.ts
@@ -1,0 +1,25 @@
+/**
+ * Minimal flatpickr instance shape for {@link positionFlatpickrCalendarFixed}.
+ */
+export interface FlatpickrTopLayerPositionInstance {
+  calendarContainer: HTMLElement;
+  _positionElement?: HTMLElement;
+  _input?: HTMLInputElement;
+}
+
+export declare const TOP_LAYER_ANCESTOR_SELECTOR: "dialog,[popover]";
+
+export function getTopLayerAncestor(
+  root: HTMLElement | null | undefined,
+): HTMLElement | null;
+
+export function positionFlatpickrCalendarFixed(
+  instance: FlatpickrTopLayerPositionInstance,
+  customPositionElement?: HTMLElement,
+): void;
+
+export function isEventTargetInsidePortaledCalendar(
+  datePickerRef: HTMLElement | null | undefined,
+  calendarContainer: HTMLElement,
+  target: EventTarget | null,
+): boolean;

--- a/src/DatePicker/datePickerTopLayer.js
+++ b/src/DatePicker/datePickerTopLayer.js
@@ -1,0 +1,88 @@
+/**
+ * Native `<dialog>` / `[popover]` ancestors used when portalling the flatpickr
+ * calendar with `portalMenu` so it participates in the correct top layer.
+ */
+export const TOP_LAYER_ANCESTOR_SELECTOR = "dialog,[popover]";
+
+/**
+ * @param {HTMLElement | null | undefined} root
+ * @returns {HTMLElement | null}
+ */
+export function getTopLayerAncestor(root) {
+  return root?.closest(TOP_LAYER_ANCESTOR_SELECTOR) ?? null;
+}
+
+/**
+ * Flatpickr `position` hook: `position: fixed` with viewport-relative coordinates.
+ * Used when the calendar is appended into a top-layer ancestor — `position: absolute`
+ * would resolve against that element’s containing block and mis-place the calendar.
+ *
+ * @param {import("./datePickerTopLayer").FlatpickrTopLayerPositionInstance} instance
+ * @param {HTMLElement | undefined} customPositionElement
+ */
+export function positionFlatpickrCalendarFixed(
+  instance,
+  customPositionElement,
+) {
+  const positionElement =
+    customPositionElement || instance._positionElement || instance._input;
+  const calendarContainer = instance.calendarContainer;
+  if (!calendarContainer || !positionElement) return;
+
+  const calendarHeight = Array.prototype.reduce.call(
+    calendarContainer.children,
+    (/** @type {number} */ acc, /** @type {HTMLElement} */ child) =>
+      acc + child.offsetHeight,
+    0,
+  );
+  const calendarWidth = calendarContainer.offsetWidth;
+  const inputBounds = positionElement.getBoundingClientRect();
+  const distanceFromBottom = window.innerHeight - inputBounds.bottom;
+  const showOnTop =
+    distanceFromBottom < calendarHeight && inputBounds.top > calendarHeight;
+
+  const top =
+    inputBounds.top +
+    (showOnTop ? -calendarHeight - 2 : positionElement.offsetHeight + 2);
+  const left = inputBounds.left;
+  const rightMost = left + calendarWidth > window.innerWidth;
+
+  calendarContainer.classList.toggle("arrowTop", !showOnTop);
+  calendarContainer.classList.toggle("arrowBottom", showOnTop);
+  calendarContainer.classList.toggle("arrowLeft", !rightMost);
+  calendarContainer.classList.toggle("arrowRight", rightMost);
+  calendarContainer.classList.toggle("arrowCenter", false);
+  calendarContainer.classList.toggle("rightMost", rightMost);
+
+  calendarContainer.style.position = "fixed";
+  calendarContainer.style.top = `${top}px`;
+  if (rightMost) {
+    calendarContainer.style.left = "auto";
+    calendarContainer.style.right = `${window.innerWidth - inputBounds.right}px`;
+  } else {
+    calendarContainer.style.left = `${left}px`;
+    calendarContainer.style.right = "auto";
+  }
+}
+
+/**
+ * Whether a click/focus event target is still “inside” the date picker UI when
+ * the calendar is portalled into a top-layer ancestor — including the subtree
+ * of that ancestor so brief hit-testing quirks during open animations do not
+ * close the calendar.
+ *
+ * @param {HTMLElement | null | undefined} datePickerRef
+ * @param {HTMLElement} calendarContainer
+ * @param {EventTarget | null} target
+ */
+export function isEventTargetInsidePortaledCalendar(
+  datePickerRef,
+  calendarContainer,
+  target,
+) {
+  if (!(target instanceof Node)) return false;
+  if (datePickerRef?.contains(target)) return true;
+  if (calendarContainer.contains(target)) return true;
+  const topLayer = getTopLayerAncestor(datePickerRef);
+  return !!topLayer?.contains(target);
+}

--- a/src/Portal/FloatingPortal.svelte
+++ b/src/Portal/FloatingPortal.svelte
@@ -92,9 +92,10 @@
 
   /**
    * Specify the DOM element to mount the portal into.
-   * When not set, mounts into the anchor's nearest `<dialog>` ancestor if one
-   * exists (so the portal participates in the dialog's top layer), otherwise
-   * falls back to `document.body`.
+   * When not set, mounts into the anchor's nearest top-layer ancestor —
+   * a `<dialog>` or `[popover]` element — if one exists, so the portal
+   * participates in the dialog/popover top layer. Otherwise falls back
+   * to `document.body`.
    * @type {HTMLElement | null}
    */
   export let target = null;
@@ -190,17 +191,17 @@
     }
   }
 
-  // Auto-detect the nearest <dialog> ancestor of the anchor so that portalled
-  // content participates in the dialog's top layer by default. An explicit
-  // `target` prop overrides this.
-  $: effectiveTarget = target ?? anchor?.closest("dialog") ?? null;
+  // Auto-detect the nearest top-layer ancestor of the anchor — a <dialog> or
+  // [popover] element — so portalled content participates in their top layer
+  // by default. An explicit `target` prop overrides this.
+  $: effectiveTarget = target ?? anchor?.closest("dialog,[popover]") ?? null;
 
   // When the portal is mounted into a custom target (e.g. a native <dialog>
-  // opened with showModal()), `position: absolute` resolves against the target's
-  // containing block rather than the viewport. Use `position: fixed` in that
-  // case — fixed stays viewport-relative even inside a top-layer dialog — and
-  // skip the document scroll offsets, which only apply to absolute positioning
-  // relative to `document.body`.
+  // opened with showModal() or an open [popover]), `position: absolute`
+  // resolves against the target's containing block rather than the viewport.
+  // Use `position: fixed` in that case — fixed stays viewport-relative even
+  // inside a top-layer element — and skip the document scroll offsets, which
+  // only apply to absolute positioning relative to `document.body`.
   $: useFixedPosition =
     effectiveTarget != null &&
     typeof document !== "undefined" &&

--- a/tests/Portal/FloatingPortal.test.svelte
+++ b/tests/Portal/FloatingPortal.test.svelte
@@ -24,6 +24,8 @@
   export let target: ComponentProps<FloatingPortal>["target"] = null;
   export let dialogAncestor = false;
   export let dialogRef: HTMLDialogElement | null = null;
+  export let popoverAncestor = false;
+  export let popoverRef: HTMLElement | null = null;
 </script>
 
 {#if scrollableContainer}
@@ -38,6 +40,10 @@
   <dialog data-testid="dialog-ancestor" bind:this={dialogRef} open>
     <div data-testid="anchor" bind:this={anchor}>Anchor element</div>
   </dialog>
+{:else if popoverAncestor}
+  <div data-testid="popover-ancestor" popover="manual" bind:this={popoverRef}>
+    <div data-testid="anchor" bind:this={anchor}>Anchor element</div>
+  </div>
 {:else}
   <div data-testid="anchor" bind:this={anchor}>Anchor element</div>
 {/if}

--- a/tests/Portal/FloatingPortal.test.ts
+++ b/tests/Portal/FloatingPortal.test.ts
@@ -221,6 +221,22 @@ describe("FloatingPortal", () => {
     customTarget.remove();
   });
 
+  it("auto-mounts into the anchor's nearest [popover] ancestor", async () => {
+    render(FloatingPortalTest, {
+      props: { open: true, popoverAncestor: true },
+    });
+
+    const content = await screen.findByText("Floating content");
+    const portalElement = content.closest("[data-floating-portal]");
+    assert(portalElement instanceof HTMLElement);
+
+    const popover = screen.getByTestId("popover-ancestor");
+    expect(portalElement.parentElement).toBe(popover);
+    expect(portalElement.getAttribute("style") ?? "").toContain(
+      "position: fixed",
+    );
+  });
+
   describe("intrinsicWidth", () => {
     it("applies width and no translateX when intrinsicWidth is false (default)", async () => {
       render(FloatingPortalTest, {


### PR DESCRIPTION
Fixes [#2881](https://github.com/carbon-design-system/carbon-components-svelte/issues/2881), Fixes [#2882](https://github.com/carbon-design-system/carbon-components-svelte/issues/2882)

Native top-layer UI (`<dialog showModal()>` and the Popover API) creates its own stacking context and backdrop.

With `portalMenu`, the flatpickr calendar was still ending up in the wrong place or behind the backdrop because absolute positioning was tied to the wrong containing block. This PR fixes the floating portal auto-detection to also include the nearest native `dialog` or `[popover]`.

For `DatePicker` specifically, because it's a third-party library, we need to use the `appendTo` and `position` props.

**Testing**

- Regression test coverage (unit + e2e tests)
- Examples added to docs

---

<img width="600" height="506" alt="Screenshot 2026-04-28 at 6 18 22 PM" src="https://github.com/user-attachments/assets/76cc0709-2f3c-4844-ba19-fff9e3ab7ca2" />
<img width="600" height="555" alt="Screenshot 2026-04-28 at 6 18 15 PM" src="https://github.com/user-attachments/assets/5f63af73-29bf-49b8-97c1-69c0f85c7534" />
