### PR TITLE
feat(date-picker-skeleton): add `short` prop

### DIFF
--- a/docs/src/pages/components/DatePicker.svx
+++ b/docs/src/pages/components/DatePicker.svx
@@ -144,3 +144,15 @@ Disable the date picker to prevent user interaction.
 Show a loading state with the skeleton component.
 
 <DatePickerSkeleton />
+
+## Skeleton (range)
+
+Set `range` to `true` to render a skeleton for the range variant.
+
+<DatePickerSkeleton range />
+
+## Skeleton (short)
+
+Set `short` to `true` to render a skeleton for the short variant.
+
+<DatePickerSkeleton short />

--- a/src/DatePicker/DatePickerSkeleton.svelte
+++ b/src/DatePicker/DatePickerSkeleton.svelte
@@ -1,6 +1,9 @@
 <script>
   /** Set to `true` to use the range variant */
   export let range = false;
+
+  /** Set to `true` to use the short variant */
+  export let short = false;
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
@@ -16,9 +19,9 @@
   <div
     class:bx--date-picker={true}
     class:bx--skeleton={true}
-    class:bx--date-picker--range={true}
-    class:bx--date-picker--short={!range}
+    class:bx--date-picker--range={range}
     class:bx--date-picker--simple={!range}
+    class:bx--date-picker--short={short}
   >
     {#each Array.from({ length: range ? 2 : 1 }, (_, i) => i) as input (input)}
       <div class:bx--date-picker-container={true}>

--- a/tests/DatePicker/DatePickerSkeleton.test.svelte
+++ b/tests/DatePicker/DatePickerSkeleton.test.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+  import { DatePickerSkeleton } from "carbon-components-svelte";
+</script>
+
+<DatePickerSkeleton
+  data-testid="date-picker-skeleton"
+  {...$$props}
+  on:click={() => {
+    console.log("click");
+  }}
+  on:mouseover={() => {
+    console.log("mouseover");
+  }}
+  on:mouseenter={() => {
+    console.log("mouseenter");
+  }}
+  on:mouseleave={() => {
+    console.log("mouseleave");
+  }}
+/>

--- a/tests/DatePicker/DatePickerSkeleton.test.ts
+++ b/tests/DatePicker/DatePickerSkeleton.test.ts
@@ -1,0 +1,90 @@
+import { render, screen } from "@testing-library/svelte";
+import { user } from "../setup-tests";
+import DatePickerSkeleton from "./DatePickerSkeleton.test.svelte";
+
+describe("DatePickerSkeleton", () => {
+  it("renders the simple variant by default", () => {
+    const { container } = render(DatePickerSkeleton);
+
+    const wrapper = container.querySelector(".bx--date-picker");
+    expect(wrapper).toHaveClass("bx--date-picker", "bx--skeleton");
+    expect(wrapper).toHaveClass("bx--date-picker--simple");
+    expect(wrapper).not.toHaveClass("bx--date-picker--range");
+    expect(wrapper).not.toHaveClass("bx--date-picker--short");
+
+    expect(
+      container.querySelectorAll(".bx--date-picker-container"),
+    ).toHaveLength(1);
+  });
+
+  it("renders the range variant", () => {
+    const { container } = render(DatePickerSkeleton, {
+      props: { range: true },
+    });
+
+    const wrapper = container.querySelector(".bx--date-picker");
+    expect(wrapper).toHaveClass("bx--date-picker--range");
+    expect(wrapper).not.toHaveClass("bx--date-picker--simple");
+
+    expect(
+      container.querySelectorAll(".bx--date-picker-container"),
+    ).toHaveLength(2);
+  });
+
+  it("applies the short modifier independently of range", () => {
+    const { container } = render(DatePickerSkeleton, {
+      props: { short: true },
+    });
+
+    const wrapper = container.querySelector(".bx--date-picker");
+    expect(wrapper).toHaveClass("bx--date-picker--short");
+    expect(wrapper).toHaveClass("bx--date-picker--simple");
+    expect(wrapper).not.toHaveClass("bx--date-picker--range");
+  });
+
+  it("supports short combined with range", () => {
+    const { container } = render(DatePickerSkeleton, {
+      props: { range: true, short: true },
+    });
+
+    const wrapper = container.querySelector(".bx--date-picker");
+    expect(wrapper).toHaveClass("bx--date-picker--range");
+    expect(wrapper).toHaveClass("bx--date-picker--short");
+    expect(wrapper).not.toHaveClass("bx--date-picker--simple");
+  });
+
+  it("renders decorative span labels in range mode", () => {
+    const { container } = render(DatePickerSkeleton, {
+      props: { range: true },
+    });
+
+    expect(container.querySelectorAll("label")).toHaveLength(0);
+    expect(container.querySelectorAll("span.bx--label")).toHaveLength(2);
+  });
+
+  it("forwards mouse and click events", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(DatePickerSkeleton);
+
+    const element = screen.getByTestId("date-picker-skeleton");
+
+    await user.click(element);
+    expect(consoleLog).toHaveBeenCalledWith("click");
+
+    await user.hover(element);
+    expect(consoleLog).toHaveBeenCalledWith("mouseover");
+
+    await user.unhover(element);
+    expect(consoleLog).toHaveBeenCalledWith("mouseleave");
+  });
+
+  it("forwards additional attributes to the form item wrapper", () => {
+    render(DatePickerSkeleton, {
+      props: { "data-testid": "custom-skeleton", "aria-label": "Loading" },
+    });
+
+    const element = screen.getByTestId("custom-skeleton");
+    expect(element).toHaveClass("bx--form-item");
+    expect(element).toHaveAttribute("aria-label", "Loading");
+  });
+});


### PR DESCRIPTION
This fixes the inverted class logic: --range now applies only when range is true, --simple only when range is false, and added a short prop that drives --short independently (missing skeleton variant).

---

<img width="919" height="425" alt="Screenshot 2026-05-07 at 5 39 16 PM" src="https://github.com/user-attachments/assets/abff92a1-d8b4-47b0-9ca2-47b650b07ccb" />
<img width="915" height="412" alt="Screenshot 2026-05-07 at 5 39 38 PM" src="https://github.com/user-attachments/assets/b0e57dd2-5fbc-45ac-b072-4df3f569b33c" />
