### PR TITLE
feat(date-picker): export `calendar` instance for programmatic control

### DIFF
--- a/docs/src/pages/components/DatePicker.svx
+++ b/docs/src/pages/components/DatePicker.svx
@@ -67,6 +67,12 @@ When the date picker is inside an open element with a [`popover`](https://develo
 
 <FileSource src="/framed/DatePicker/DatePickerPopover" />
 
+## Programmatic calendar access
+
+Use `bind:calendar` to access the underlying [Flatpickr instance](https://flatpickr.js.org/instance-methods-properties-elements/) for programmatic control, such as opening the calendar from an external trigger or updating options at runtime via `set`.
+
+<FileSource src="/framed/DatePicker/DatePickerCalendarInstance" />
+
 ## Simple
 
 Create a simple date picker without a dropdown calendar.

--- a/docs/src/pages/framed/DatePicker/DatePickerCalendarInstance.svelte
+++ b/docs/src/pages/framed/DatePicker/DatePickerCalendarInstance.svelte
@@ -1,0 +1,41 @@
+<script>
+  import {
+    Button,
+    DatePicker,
+    DatePickerInput,
+    Stack,
+  } from "carbon-components-svelte";
+
+  let calendar = null;
+  let weekendsDisabled = false;
+
+  function openCalendar(e) {
+    // Prevent the click from bubbling to the outside click
+    // handler and closing the calendar immediately.
+    e.stopPropagation();
+    calendar?.open();
+  }
+
+  function toggleWeekends() {
+    weekendsDisabled = !weekendsDisabled;
+    calendar?.set(
+      "disable",
+      weekendsDisabled
+        ? [(date) => date.getDay() === 0 || date.getDay() === 6]
+        : [],
+    );
+  }
+</script>
+
+<Stack gap={4}>
+  <DatePicker datePickerType="single" bind:calendar on:change>
+    <DatePickerInput labelText="Appointment" placeholder="mm/dd/yyyy" />
+  </DatePicker>
+  <Stack gap={3} orientation="horizontal">
+    <Button kind="tertiary" on:click={openCalendar}>Open calendar</Button>
+    <Button kind="tertiary" on:click={toggleWeekends}>
+      {weekendsDisabled ? "Enable" : "Disable"}
+      weekends
+    </Button>
+  </Stack>
+</Stack>

--- a/src/DatePicker/DatePicker.svelte
+++ b/src/DatePicker/DatePicker.svelte
@@ -78,6 +78,14 @@
    */
   export let flatpickrProps = { static: true };
 
+  /**
+   * Bind to the Flatpickr calendar instance for programmatic control.
+   * Only available when `datePickerType` is `"single"` or `"range"`.
+   * @see https://flatpickr.js.org/instance-methods-properties-elements/
+   * @type {import("flatpickr/dist/types/instance").Instance | null}
+   */
+  export let calendar = null;
+
   import {
     afterUpdate,
     createEventDispatcher,
@@ -131,7 +139,6 @@
    */
   const hasCalendar = derived(mode, (_) => _ === "single" || _ === "range");
 
-  let calendar = null;
   let datePickerRef = null;
   let inputRef = null;
   let inputRefTo = null;

--- a/tests/DatePicker/DatePicker.test.ts
+++ b/tests/DatePicker/DatePicker.test.ts
@@ -1,8 +1,10 @@
 import { render, screen } from "@testing-library/svelte";
 import { DatePickerSkeleton } from "carbon-components-svelte";
+import type { Instance } from "flatpickr/dist/types/instance";
 import { tick } from "svelte";
 import { user } from "../setup-tests";
 import DatePicker from "./DatePicker.test.svelte";
+import DatePickerCalendar from "./DatePickerCalendar.test.svelte";
 import DatePickerInModal from "./DatePickerInModal.test.svelte";
 import DatePickerInputSlot from "./DatePickerInput.slot.test.svelte";
 import DatePickerRange from "./DatePickerRange.test.svelte";
@@ -352,6 +354,79 @@ describe("DatePicker", () => {
       // This is how browsers evaluate the HTML pattern attribute.
       const re = new RegExp(`^(?:${pattern})$`, "u");
       expect(re.test(sampleValue)).toBe(true);
+    });
+  });
+
+  describe("bind:calendar", () => {
+    it("is null in simple mode (no calendar is created)", async () => {
+      let captured: unknown = "unset";
+      render(DatePickerCalendar, {
+        props: {
+          datePickerType: "simple",
+          oncalendar: (cal) => {
+            captured = cal;
+          },
+        },
+      });
+
+      await tick();
+      expect(captured).toBeNull();
+    });
+
+    it("exposes the flatpickr instance in single mode", async () => {
+      let captured: Instance | null | undefined = null;
+      render(DatePickerCalendar, {
+        props: {
+          datePickerType: "single",
+          oncalendar: (cal) => {
+            captured = cal;
+          },
+        },
+      });
+
+      const instance = await vi.waitFor(() => {
+        if (!captured) throw new Error("calendar not set");
+        return captured;
+      });
+
+      // Smoke-check the flatpickr API surface — these are the methods
+      // consumers are most likely to call imperatively.
+      expect(typeof instance.open).toBe("function");
+      expect(typeof instance.close).toBe("function");
+      expect(typeof instance.setDate).toBe("function");
+      expect(typeof instance.jumpToDate).toBe("function");
+      expect(typeof instance.set).toBe("function");
+      expect(instance.isOpen).toBe(false);
+    });
+
+    it("can open and close the calendar via the bound instance", async () => {
+      let captured: Instance | null | undefined = null;
+      render(DatePickerCalendar, {
+        props: {
+          datePickerType: "single",
+          oncalendar: (cal) => {
+            captured = cal;
+          },
+        },
+      });
+
+      const instance = await vi.waitFor(() => {
+        if (!captured) throw new Error("calendar not set");
+        return captured;
+      });
+
+      expect(instance.isOpen).toBe(false);
+
+      instance.open();
+      await tick();
+      expect(instance.isOpen).toBe(true);
+      const calendar = await screen.findByLabelText("calendar-container");
+      expect(calendar).toHaveClass("open");
+
+      instance.close();
+      await tick();
+      expect(instance.isOpen).toBe(false);
+      expect(calendar).not.toHaveClass("open");
     });
   });
 

--- a/tests/DatePicker/DatePickerCalendar.test.svelte
+++ b/tests/DatePicker/DatePickerCalendar.test.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  import { DatePicker, DatePickerInput } from "carbon-components-svelte";
+  import type { ComponentProps } from "svelte";
+
+  export let datePickerType: ComponentProps<DatePicker>["datePickerType"] =
+    "single";
+  export let oncalendar: (cal: ComponentProps<DatePicker>["calendar"]) => void =
+    () => {};
+
+  let calendar: ComponentProps<DatePicker>["calendar"] = null;
+
+  $: oncalendar(calendar);
+</script>
+
+<DatePicker {datePickerType} bind:calendar>
+  <DatePickerInput labelText="Date" placeholder="mm/dd/yyyy" />
+</DatePicker>


### PR DESCRIPTION
Export `calendar` as a prop to allow programmatic access and control of the calendar (e.g., setting dates, opening the calendar).


```svelte
<script>
  import {
    Button,
    DatePicker,
    DatePickerInput,
    Stack,
  } from "carbon-components-svelte";

  let calendar = null;
  let weekendsDisabled = false;

  function openCalendar(e) {
    // Prevent the click from bubbling to the outside click
    // handler and closing the calendar immediately.
    e.stopPropagation();
    calendar?.open();
  }

  function toggleWeekends() {
    weekendsDisabled = !weekendsDisabled;
    calendar?.set(
      "disable",
      weekendsDisabled
        ? [(date) => date.getDay() === 0 || date.getDay() === 6]
        : [],
    );
  }
</script>

<Stack gap={4}>
  <DatePicker datePickerType="single" bind:calendar on:change>
    <DatePickerInput labelText="Appointment" placeholder="mm/dd/yyyy" />
  </DatePicker>
  <Stack gap={3} orientation="horizontal">
    <Button kind="tertiary" on:click={openCalendar}>Open calendar</Button>
    <Button kind="tertiary" on:click={toggleWeekends}>
      {weekendsDisabled ? "Enable" : "Disable"}
      weekends
    </Button>
  </Stack>
</Stack>

```

<img width="712" height="470" alt="Screenshot 2026-05-07 at 5 41 19 PM" src="https://github.com/user-attachments/assets/af2c33d1-2e7c-40e7-a865-9a1302e4e711" />
