### PR TITLE
fix(date-picker-input): forward `focus` event to input

### DIFF
--- a/src/DatePicker/DatePickerInput.svelte
+++ b/src/DatePicker/DatePickerInput.svelte
@@ -167,6 +167,7 @@
         }
       }}
       on:keyup
+      on:focus
       on:blur
       on:blur={({ relatedTarget }) => {
         blurInput(relatedTarget);

--- a/tests/DatePicker/DatePicker.test.svelte
+++ b/tests/DatePicker/DatePicker.test.svelte
@@ -26,6 +26,7 @@
   export let portalMenu = false;
   export let pattern: ComponentProps<DatePickerInput>["pattern"] = undefined;
   export let onchange: ((event: CustomEvent) => void) | undefined = undefined;
+  export let onfocus: ((event: FocusEvent) => void) | undefined = undefined;
 </script>
 
 <DatePicker
@@ -54,5 +55,6 @@
     {helperText}
     {hideLabel}
     {pattern}
+    on:focus={(e) => onfocus?.(e)}
   />
 </DatePicker>

--- a/tests/DatePicker/DatePicker.test.ts
+++ b/tests/DatePicker/DatePicker.test.ts
@@ -110,6 +110,21 @@ describe("DatePicker", () => {
     expect(screen.getByText("Date")).toHaveClass("bx--visually-hidden");
   });
 
+  it("forwards focus event from the input", () => {
+    const focusHandler = vi.fn();
+    render(DatePicker, {
+      props: {
+        onfocus: focusHandler,
+      },
+    });
+
+    const input = screen.getByLabelText("Date");
+    input.focus();
+
+    expect(focusHandler).toHaveBeenCalled();
+    expect(focusHandler.mock.lastCall?.[0]).toBeInstanceOf(FocusEvent);
+  });
+
   it("dispatches change event when manually typing in simple mode", async () => {
     const changeHandler = vi.fn();
     render(DatePicker, {


### PR DESCRIPTION
The `blur` event is forwarded, but not `focus`.