### PR TITLE
fix(date-picker-skeleton)!: replace unused `label` with `span`

### DIFF
--- a/src/DatePicker/DatePickerSkeleton.svelte
+++ b/src/DatePicker/DatePickerSkeleton.svelte
@@ -1,9 +1,6 @@
 <script>
   /** Set to `true` to use the range variant */
   export let range = false;
-
-  /** Set an id to be used by the label element */
-  export let id = `ccs-${Math.random().toString(36)}`;
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
@@ -23,9 +20,9 @@
     class:bx--date-picker--short={!range}
     class:bx--date-picker--simple={!range}
   >
-    {#each Array.from({ length: range ? 2 : 1 }, (_, i) => i) as input, i (input)}
+    {#each Array.from({ length: range ? 2 : 1 }, (_, i) => i) as input (input)}
       <div class:bx--date-picker-container={true}>
-        <label for={id} class:bx--label={true}></label>
+        <span class:bx--label={true}></span>
         <div
           class:bx--date-picker__input={true}
           class:bx--skeleton={true}

--- a/tests/DatePicker/DatePicker.test.ts
+++ b/tests/DatePicker/DatePicker.test.ts
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/svelte";
+import { DatePickerSkeleton } from "carbon-components-svelte";
 import { tick } from "svelte";
 import { user } from "../setup-tests";
 import DatePicker from "./DatePicker.test.svelte";
@@ -393,5 +394,14 @@ describe("DatePicker", () => {
       expect(wrapper?.contains(calendar)).toBe(true);
       expect(calendar.classList.contains("static")).toBe(true);
     });
+  });
+});
+
+describe("DatePickerSkeleton", () => {
+  it("renders decorative label placeholders without label elements in range mode", () => {
+    const { container } = render(DatePickerSkeleton, { range: true });
+
+    expect(container.querySelectorAll("label")).toHaveLength(0);
+    expect(container.querySelectorAll("span.bx--label")).toHaveLength(2);
   });
 });


### PR DESCRIPTION
There's currently a bug where, for a ranged `DatePickerSkeleton`, duplicate IDs are used.

However, this doesn't make sense to have a useless/disassociated `label` in the first place, since it's labeling nothing.

This is an acceptable breaking change: it removes the `id` prop from the skeleton component.