### PR TITLE
fix(date-picker): restore single-letter weekday abbreviations for `locale="en"`

### DIFF
--- a/docs/src/pages/components/DatePicker.svx
+++ b/docs/src/pages/components/DatePicker.svx
@@ -35,6 +35,20 @@ Use the `dateFormat` prop to customize the date format (default: `"m/d/Y"`). The
 
 <FileSource src="/framed/DatePicker/DatePickerCustomFormat" />
 
+## Custom locale
+
+The `locale` prop accepts either a [flatpickr locale key](https://github.com/flatpickr/flatpickr/tree/master/src/l10n) or a [`CustomLocale`](https://github.com/flatpickr/flatpickr/blob/master/src/types/locale.ts) object. It defaults to `"en"`, which renders Carbon-spec single-letter weekday abbreviations (`S, M, T, W, Th, F, S`).
+
+To customize the weekday labels (e.g., to restore flatpickr's default English `Sun, Mon, Tue, ...` shorthands), pass a `CustomLocale` object.
+
+<FileSource src="/framed/DatePicker/DatePickerLocale" />
+
+## Non-English locale
+
+Import the corresponding locale module from `flatpickr/dist/l10n/<key>` and pass it to the `locale` prop. The example below uses German (`de`).
+
+<FileSource src="/framed/DatePicker/DatePickerNonEnglishLocale" />
+
 ## Portal menu
 
 Set `portalMenu` to `true` to render the calendar in a floating portal. This prevents the calendar from being clipped by parent containers with `overflow: hidden` or z-index stacking contexts. When inside a Modal, `portalMenu` defaults to `true` unless explicitly set to `false`.

--- a/docs/src/pages/framed/DatePicker/DatePickerLocale.svelte
+++ b/docs/src/pages/framed/DatePicker/DatePickerLocale.svelte
@@ -1,0 +1,22 @@
+<script>
+  import { DatePicker, DatePickerInput } from "carbon-components-svelte";
+
+  const englishLongShorthand = {
+    weekdays: {
+      shorthand: ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"],
+      longhand: [
+        "Sunday",
+        "Monday",
+        "Tuesday",
+        "Wednesday",
+        "Thursday",
+        "Friday",
+        "Saturday",
+      ],
+    },
+  };
+</script>
+
+<DatePicker datePickerType="single" locale={englishLongShorthand} on:change>
+  <DatePickerInput labelText="Meeting date" placeholder="mm/dd/yyyy" />
+</DatePicker>

--- a/docs/src/pages/framed/DatePicker/DatePickerNonEnglishLocale.svelte
+++ b/docs/src/pages/framed/DatePicker/DatePickerNonEnglishLocale.svelte
@@ -1,0 +1,8 @@
+<script>
+  import { DatePicker, DatePickerInput } from "carbon-components-svelte";
+  import { German } from "flatpickr/dist/l10n/de";
+</script>
+
+<DatePicker datePickerType="single" locale={German} on:change>
+  <DatePickerInput labelText="Termin" placeholder="tt.mm.jjjj" />
+</DatePicker>

--- a/src/DatePicker/DatePicker.svelte
+++ b/src/DatePicker/DatePicker.svelte
@@ -86,7 +86,7 @@
     setContext,
   } from "svelte";
   import { derived, writable } from "svelte/store";
-  import { createCalendar } from "./createCalendar";
+  import { createCalendar, resolveLocale } from "./createCalendar";
   import {
     getTopLayerAncestor,
     isEventTargetInsidePortaledCalendar,
@@ -230,7 +230,7 @@
     if (calendar) {
       calendar.set("minDate", minDate);
       calendar.set("maxDate", maxDate);
-      calendar.set("locale", locale);
+      calendar.set("locale", resolveLocale(locale));
       calendar.set("dateFormat", dateFormat);
       for (const [option, value] of Object.entries(flatpickrProps)) {
         calendar.set(option, value);

--- a/src/DatePicker/createCalendar.js
+++ b/src/DatePicker/createCalendar.js
@@ -1,6 +1,35 @@
 import flatpickr from "flatpickr";
 
 /**
+ * Carbon-styled English locale: single-letter weekday abbreviations
+ * with "Th" disambiguating Thursday from Tuesday.
+ * Longhand is included so flatpickr's shallow locale merge does not
+ * drop the weekday longhand (used by ARIA labels on day cells).
+ */
+const ENGLISH_LOCALE = {
+  weekdays: {
+    shorthand: ["S", "M", "T", "W", "Th", "F", "S"],
+    longhand: [
+      "Sunday",
+      "Monday",
+      "Tuesday",
+      "Wednesday",
+      "Thursday",
+      "Friday",
+      "Saturday",
+    ],
+  },
+};
+
+/**
+ * @param {unknown} locale
+ * @returns {unknown}
+ */
+export function resolveLocale(locale) {
+  return locale === "en" ? ENGLISH_LOCALE : locale;
+}
+
+/**
  * Minimal flatpickr instance shape used by updateClasses and updateMonthNode.
  * Matches flatpickr's Instance where some elements may be optional.
  * @typedef {{
@@ -15,14 +44,6 @@ import flatpickr from "flatpickr";
  *   monthsDropdownContainer: HTMLElement;
  * }} FlatpickrInstance
  */
-
-/**
- * Locale override with optional en.weekdays.shorthand for custom formatting.
- * @typedef {{ en?: { weekdays: { shorthand: string[] } } }} L10nOverrides
- */
-
-/** @type {L10nOverrides | undefined} */
-let l10n;
 
 /**
  * @param {FlatpickrInstance} instance
@@ -90,22 +111,7 @@ function updateMonthNode(instance) {
  * @param {CreateCalendarArgs} args
  * @returns {Promise<FlatpickrInstance>}
  */
-async function createCalendar({ options, base, input, dispatch }) {
-  /** @type {string | L10nOverrides["en"]} */
-  let locale = options.locale;
-
-  if (options.locale === "en" && l10n && l10n.en) {
-    const shorthand = l10n.en.weekdays.shorthand;
-    if (shorthand) {
-      for (let index = 0; index < shorthand.length; index++) {
-        const _ = shorthand[index];
-        const s = _.slice(0, 2);
-        shorthand[index] = s === "Th" ? "Th" : s.charAt(0);
-      }
-    }
-    locale = l10n.en;
-  }
-
+export async function createCalendar({ options, base, input, dispatch }) {
   /** @type {((new (config: { position: string; input: HTMLInputElement }) => unknown) | undefined)} */
   let RangePlugin;
 
@@ -124,7 +130,6 @@ async function createCalendar({ options, base, input, dispatch }) {
     allowInput: true,
     disableMobile: true,
     clickOpens: true,
-    locale,
     plugins,
     nextArrow:
       '<svg width="16px" height="16px" viewBox="0 0 16 16"><polygon points="11,8 6,13 5.3,12.3 9.6,8 5.3,3.7 6,3 "/><rect width="16" height="16" style="fill: none" /></svg>',
@@ -153,8 +158,7 @@ async function createCalendar({ options, base, input, dispatch }) {
       updateMonthNode(instance);
     },
     ...options,
+    locale: resolveLocale(options.locale),
   };
   return new /** @type {any} */ (flatpickr)(base, config);
 }
-
-export { createCalendar };

--- a/tests/DatePicker/DatePicker.test.ts
+++ b/tests/DatePicker/DatePicker.test.ts
@@ -51,6 +51,19 @@ describe("DatePicker", () => {
     ).toBeInTheDocument();
   });
 
+  it("renders single-letter weekday shorthands for locale='en'", async () => {
+    const { container } = render(DatePicker, { datePickerType: "single" });
+
+    await user.click(screen.getByLabelText("Date"));
+    await screen.findByLabelText("calendar-container");
+
+    const weekdays = Array.from(
+      container.querySelectorAll(".flatpickr-weekday"),
+    ).map((node) => node.textContent?.trim());
+
+    expect(weekdays).toEqual(["S", "M", "T", "W", "Th", "F", "S"]);
+  });
+
   it("renders range mode", async () => {
     const { container } = render(DatePickerRange);
 


### PR DESCRIPTION
This restores the Carbon-styled single-letter weekday abbreviations (`S, M, T, W, Th, F, S`) in `DatePicker` when `locale="en"`, matching the design spec. The customization existed in `createCalendar.js` but had silently regressed to dead code years ago, so calendars were rendering flatpickr's default English shorthands (`Sun, Mon, Tue, ...`) instead.

Carbon's design uses the shorthand.

---

## Before
<img width="725" height="500" alt="Screenshot 2026-05-07 at 6 07 48 PM" src="https://github.com/user-attachments/assets/4de17d7d-f434-4378-97d7-c97e8dbf9908" />

## After
<img width="660" height="508" alt="Screenshot 2026-05-07 at 6 07 36 PM" src="https://github.com/user-attachments/assets/05096a52-6a79-4293-b566-1b29ea9a0710" />

---


**Root cause**

The regression has two distinct origins, roughly 17 months apart:

In October 2020, commit 032595e4 ("remove locales from DatePicker / flatpickr") deleted `import l10n from "flatpickr/dist/l10n/index.js"`, the source of weekday data the customization branch read from. Two days later, 55bdffd6 ("add blank l10n variable to replace the missing l10n strings") added an uninitialized `var l10n` to silence the resulting `ReferenceError`. Net effect: the `if (options.locale === "en" && l10n && l10n.en)` branch became permanently false (dead code), and single-letter weekdays disappeared from shipped builds.

In March 2022, #1198 ("allow `flatpickrProps` to override default `flatpickr` options", fixes #1197) moved `...options` from the first position in the config object to the last, so user options could override defaults like `nextArrow` and `disableMobile`. Correct intent, but it also meant `options.locale` (the raw `"en"` string) now overwrote any locale object computed earlier in the function, so even if the 2020 breakage were repaired, the spread reorder would have silently re-broken it.

Neither caused a runtime error and no test asserted weekday text, so the regression went unnoticed.

**Changes**

Adds an `ENGLISH_LOCALE` constant in `src/DatePicker/createCalendar.js` containing the Carbon shorthand `["S", "M", "T", "W", "Th", "F", "S"]` (longhand is included so flatpickr's shallow locale merge doesn't drop weekday longhand used by day-cell ARIA labels). Exports a `resolveLocale` helper that returns the override when `locale === "en"` and passes through otherwise — so non-English locales and user-supplied custom locale objects are unaffected.

```js
locale: resolveLocale(options.locale),
```

The config now applies `locale` *after* the `...options` spread to prevent it from being clobbered. `DatePicker.svelte` also routes its post-init `calendar.set("locale", locale)` call through `resolveLocale` so the override survives reactive locale updates, not just the initial construction.

A regression test in `tests/DatePicker/DatePicker.test.ts` opens the calendar with the default `locale="en"` and asserts weekday text equals `["S", "M", "T", "W", "Th", "F", "S"]`. If either cause is reintroduced, this test fails.