### PR TITLE
perf(date-picker): skip redundant `flatpickr` updates on reactive ticks

### DIFF
--- a/src/DatePicker/DatePicker.svelte
+++ b/src/DatePicker/DatePicker.svelte
@@ -135,6 +135,10 @@
   let datePickerRef = null;
   let inputRef = null;
   let inputRefTo = null;
+  let prevValue = value;
+  let prevValueFrom = valueFrom;
+  let prevValueTo = valueTo;
+  let lastAppliedOptions = {};
 
   /**
    * @type {(data: { id: string; labelText: string }) => void}
@@ -236,14 +240,21 @@
     focusCalendar,
   });
 
+  function applyOptionIfChanged(key, value, appliedValue = value) {
+    if (lastAppliedOptions[key] !== value) {
+      calendar.set(key, appliedValue);
+      lastAppliedOptions[key] = value;
+    }
+  }
+
   async function initCalendar(options) {
     if (calendar) {
-      calendar.set("minDate", minDate);
-      calendar.set("maxDate", maxDate);
-      calendar.set("locale", resolveLocale(locale));
-      calendar.set("dateFormat", dateFormat);
+      applyOptionIfChanged("minDate", minDate);
+      applyOptionIfChanged("maxDate", maxDate);
+      applyOptionIfChanged("locale", locale, resolveLocale(locale));
+      applyOptionIfChanged("dateFormat", dateFormat);
       for (const [option, value] of Object.entries(flatpickrProps)) {
-        calendar.set(option, value);
+        applyOptionIfChanged(option, value);
       }
       return;
     }
@@ -310,17 +321,25 @@
   afterUpdate(() => {
     if (calendar) {
       if ($range) {
-        calendar.setDate([$inputValueFrom, $inputValueTo]);
+        if (
+          $inputValueFrom !== prevValueFrom ||
+          $inputValueTo !== prevValueTo
+        ) {
+          calendar.setDate([$inputValueFrom, $inputValueTo]);
+          prevValueFrom = $inputValueFrom;
+          prevValueTo = $inputValueTo;
 
-        // workaround to remove the default range plugin separator "to"
-        if ($inputValueFrom !== "") {
-          inputRef.value = $inputValueFrom;
+          // workaround to remove the default range plugin separator "to"
+          if ($inputValueFrom !== "") {
+            inputRef.value = $inputValueFrom;
+          }
+          if ($inputValueTo !== "") {
+            inputRefTo.value = $inputValueTo;
+          }
         }
-        if ($inputValueTo !== "") {
-          inputRefTo.value = $inputValueTo;
-        }
-      } else {
+      } else if ($inputValue !== prevValue) {
         calendar.setDate($inputValue);
+        prevValue = $inputValue;
       }
     }
   });

--- a/tests/DatePicker/DatePicker.test.ts
+++ b/tests/DatePicker/DatePicker.test.ts
@@ -258,6 +258,33 @@ describe("DatePicker", () => {
     expect(inputEnd).toHaveValue("03/31/2024");
   });
 
+  // Regression test: afterUpdate should not call calendar.setDate
+  // when the bound value has not actually changed. Previously every
+  // reactive tick (e.g. an unrelated prop update) re-applied setDate.
+  it("does not call calendar.setDate on unrelated reactive updates", async () => {
+    const { rerender } = render(DatePicker, {
+      props: {
+        datePickerType: "single",
+        value: "01/15/2024",
+      },
+    });
+
+    const input = screen.getByLabelText("Date") as HTMLInputElement;
+    await user.click(input);
+    await screen.findByLabelText("calendar-container");
+
+    const fp = (input as unknown as { _flatpickr: { setDate: () => void } })
+      ._flatpickr;
+    expect(fp).toBeTruthy();
+    const setDateSpy = vi.spyOn(fp, "setDate");
+
+    // Trigger a reactive update that does not change value/min/max/format.
+    await rerender({ light: true });
+    await tick();
+
+    expect(setDateSpy).not.toHaveBeenCalled();
+  });
+
   it("supports custom label slot for DatePickerInput", () => {
     render(DatePickerInputSlot);
 


### PR DESCRIPTION
`afterUpdate` previously called `calendar.setDate` on every reactive tick, and `initCalendar` re-applied every option whenever any dep changed. Now diff against last-applied values before updating.