### PR TITLE
feat(time-picker): add `helperText` prop

### DIFF
--- a/docs/src/pages/components/TimePicker.svx
+++ b/docs/src/pages/components/TimePicker.svx
@@ -68,6 +68,21 @@ Use the small size for more compact time pickers by setting `size` to `"sm"`.
   </TimePickerSelect>
 </TimePicker>
 
+## Helper text
+
+Add helper text to provide additional context or formatting instructions.
+
+<TimePicker labelText="Cron job" placeholder="hh:mm" helperText="24-hour, e.g. 14:30">
+  <TimePickerSelect value="pm">
+    <SelectItem value="am" text="AM" />
+    <SelectItem value="pm" text="PM" />
+  </TimePickerSelect>
+  <TimePickerSelect value="pdt">
+    <SelectItem value="pdt" text="PDT" />
+    <SelectItem value="gmt" text="GMT" />
+  </TimePickerSelect>
+</TimePicker>
+
 ## Invalid state
 
 Indicate an invalid state with an error message by setting `invalid` to `true` and providing `invalidText`.

--- a/src/TimePicker/TimePicker.svelte
+++ b/src/TimePicker/TimePicker.svelte
@@ -44,6 +44,9 @@
   /** Specify the warning state text */
   export let warnText = "";
 
+  /** Specify the helper text */
+  export let helperText = "";
+
   /** Set an id for the input element */
   export let id = `ccs-${Math.random().toString(36)}`;
 
@@ -59,7 +62,9 @@
   import WarningAltFilled from "../icons/WarningAltFilled.svelte";
   import Stack from "../Stack/Stack.svelte";
 
+  $: helperId = `helper-${id}`;
   $: errorId = `error-${id}`;
+  $: warnId = `warn-${id}`;
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
@@ -111,7 +116,13 @@
             type="text"
             data-invalid={invalid || undefined}
             aria-invalid={invalid || undefined}
-            aria-describedby={invalid ? errorId : undefined}
+            aria-describedby={invalid
+              ? errorId
+              : warn
+                ? warnId
+                : helperText
+                  ? helperId
+                  : undefined}
             {pattern}
             {placeholder}
             {maxlength}
@@ -140,6 +151,14 @@
   {#if invalid}
     <div id={errorId} class:bx--form-requirement={true}>{invalidText}</div>
   {:else if warn}
-    <div class:bx--form-requirement={true}>{warnText}</div>
+    <div id={warnId} class:bx--form-requirement={true}>{warnText}</div>
+  {:else if helperText}
+    <div
+      id={helperId}
+      class:bx--form__helper-text={true}
+      class:bx--form__helper-text--disabled={disabled}
+    >
+      {helperText}
+    </div>
   {/if}
 </div>

--- a/tests/TimePicker/TimePicker.test.svelte
+++ b/tests/TimePicker/TimePicker.test.svelte
@@ -20,6 +20,7 @@
   export let invalidText: ComponentProps<TimePicker>["invalidText"] = "";
   export let warn: ComponentProps<TimePicker>["warn"] = false;
   export let warnText: ComponentProps<TimePicker>["warnText"] = "";
+  export let helperText: ComponentProps<TimePicker>["helperText"] = "";
   export let id: ComponentProps<TimePicker>["id"] = "ccs-test";
   export let name: ComponentProps<TimePicker>["name"] = "test-time";
   export let ref: ComponentProps<TimePicker>["ref"] = null;
@@ -39,6 +40,7 @@
   {invalidText}
   {warn}
   {warnText}
+  {helperText}
   {id}
   {name}
   {ref}

--- a/tests/TimePicker/TimePicker.test.ts
+++ b/tests/TimePicker/TimePicker.test.ts
@@ -209,6 +209,58 @@ describe("TimePicker", () => {
     expect(screen.getByText("Invalid time")).toBeInTheDocument();
   });
 
+  it("should render helper text", () => {
+    render(TimePicker, {
+      props: { id: "test-id", helperText: "24-hour, e.g. 14:30" },
+    });
+
+    const helper = screen.getByText("24-hour, e.g. 14:30");
+    expect(helper).toBeInTheDocument();
+    expect(helper).toHaveClass("bx--form__helper-text");
+    expect(helper).toHaveAttribute("id", "helper-test-id");
+    expect(screen.getByRole("textbox")).toHaveAttribute(
+      "aria-describedby",
+      "helper-test-id",
+    );
+  });
+
+  it("should associate error message via aria-describedby when invalid", () => {
+    render(TimePicker, {
+      props: { id: "test-id", invalid: true, invalidText: "Invalid time" },
+    });
+
+    expect(screen.getByText("Invalid time")).toHaveAttribute(
+      "id",
+      "error-test-id",
+    );
+    const input = screen.getByRole("textbox");
+    expect(input).toHaveAttribute("aria-describedby", "error-test-id");
+    expect(input).toHaveAttribute("aria-invalid", "true");
+  });
+
+  it("should not render helper text when invalid", () => {
+    render(TimePicker, {
+      props: {
+        helperText: "24-hour, e.g. 14:30",
+        invalid: true,
+        invalidText: "Invalid time",
+      },
+    });
+
+    expect(screen.queryByText("24-hour, e.g. 14:30")).not.toBeInTheDocument();
+    expect(screen.getByText("Invalid time")).toBeInTheDocument();
+  });
+
+  it("should apply disabled class to helper text when disabled", () => {
+    render(TimePicker, {
+      props: { helperText: "24-hour, e.g. 14:30", disabled: true },
+    });
+
+    expect(screen.getByText("24-hour, e.g. 14:30")).toHaveClass(
+      "bx--form__helper-text--disabled",
+    );
+  });
+
   it("should handle label text slot", () => {
     render(TimePickerCustom);
 


### PR DESCRIPTION
Similar to other inputs, support `helperText`. Also, fix the label association for warn text.

---

<img width="755" height="284" alt="Screenshot 2026-05-07 at 7 30 56 PM" src="https://github.com/user-attachments/assets/8a6bf850-d6d1-413c-aa8c-64a12fc872ce" />
