### PR TITLE
fix(time-picker): associate `invalidText` with input via `aria-describedby`

### DIFF
--- a/src/TimePicker/TimePicker.svelte
+++ b/src/TimePicker/TimePicker.svelte
@@ -51,6 +51,8 @@
   export let ref = null;
 
   import Stack from "../Stack/Stack.svelte";
+
+  $: errorId = `error-${id}`;
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
@@ -88,6 +90,8 @@
           bind:value
           type="text"
           data-invalid={invalid || undefined}
+          aria-invalid={invalid || undefined}
+          aria-describedby={invalid ? errorId : undefined}
           {pattern}
           {placeholder}
           {maxlength}
@@ -112,6 +116,6 @@
     </div>
   </div>
   {#if invalid}
-    <div class:bx--form-requirement={true}>{invalidText}</div>
+    <div id={errorId} class:bx--form-requirement={true}>{invalidText}</div>
   {/if}
 </div>

--- a/tests/TimePicker/TimePicker.test.ts
+++ b/tests/TimePicker/TimePicker.test.ts
@@ -52,15 +52,29 @@ describe("TimePicker", () => {
 
   it("should handle invalid state", () => {
     render(TimePicker, {
-      props: { invalid: true, invalidText: "Invalid time" },
+      props: {
+        id: "time-input",
+        invalid: true,
+        invalidText: "Invalid time",
+      },
     });
 
     const input = screen.getByRole("textbox");
     expect(input).toHaveClass("bx--text-input--invalid");
     expect(input).toHaveAttribute("data-invalid");
-    expect(screen.getByText("Invalid time")).toHaveClass(
-      "bx--form-requirement",
-    );
+    expect(input).toHaveAttribute("aria-invalid", "true");
+    expect(input).toHaveAttribute("aria-describedby", "error-time-input");
+    const errorText = screen.getByText("Invalid time");
+    expect(errorText).toHaveClass("bx--form-requirement");
+    expect(errorText).toHaveAttribute("id", "error-time-input");
+  });
+
+  it("should not set aria-describedby when valid", () => {
+    render(TimePicker);
+
+    const input = screen.getByRole("textbox");
+    expect(input).not.toHaveAttribute("aria-describedby");
+    expect(input).not.toHaveAttribute("aria-invalid");
   });
 
   it("should handle hidden label", () => {


### PR DESCRIPTION
Without the assocation, screen readers don't announce the error message when the input is focused. Mirrors the pattern used in `TextArea` and other related components.