### PR TITLE
feat(select): support `readonly` prop

### DIFF
--- a/docs/src/pages/components/Select.svx
+++ b/docs/src/pages/components/Select.svx
@@ -175,6 +175,18 @@ Disable the select menu to prevent interaction.
   <SelectItem value="g100" text="Gray 100" />
 </Select>
 
+## Read-only state
+
+Use the read-only state to display the selected value without allowing changes.
+
+<Select readonly labelText="Carbon theme" selected="g10" >
+  <SelectItem value="white" text="White" />
+  <SelectItem value="g10" text="Gray 10" />
+  <SelectItem value="g80" text="Gray 80" />
+  <SelectItem value="g90" text="Gray 90" />
+  <SelectItem value="g100" text="Gray 100" />
+</Select>
+
 ## Skeleton
 
 Display a loading state using the skeleton variant.

--- a/src/Select/Select.svelte
+++ b/src/Select/Select.svelte
@@ -64,6 +64,9 @@
   /** Set to `true` to mark the field as required */
   export let required = false;
 
+  /** Set to `true` for the select to be read-only */
+  export let readonly = false;
+
   import { afterUpdate, createEventDispatcher, setContext } from "svelte";
   import { writable } from "svelte/store";
   import ChevronDown from "../icons/ChevronDown.svelte";
@@ -140,9 +143,10 @@
     class:bx--select={true}
     class:bx--select--inline={inline}
     class:bx--select--light={light}
-    class:bx--select--invalid={invalid}
+    class:bx--select--invalid={invalid && !readonly}
     class:bx--select--disabled={disabled}
-    class:bx--select--warning={warn}
+    class:bx--select--warning={warn && !readonly}
+    class:bx--select--readonly={readonly}
   >
     {#if !noLabel && (labelText || $$slots.labelChildren)}
       <label
@@ -158,18 +162,19 @@
       <div class:bx--select-input--inline__wrapper={true}>
         <div
           class:bx--select-input__wrapper={true}
-          data-invalid={invalid || undefined}
+          data-invalid={(invalid && !readonly) || undefined}
         >
           <select
             bind:this={ref}
-            aria-describedby={invalid
+            aria-describedby={invalid && !readonly
               ? errorId
-              : warn
+              : warn && !readonly
                 ? warnId
                 : helperText
                   ? helperId
                   : undefined}
-            aria-invalid={invalid || undefined}
+            aria-invalid={(invalid && !readonly) || undefined}
+            aria-readonly={readonly || undefined}
             disabled={disabled || undefined}
             required={required || undefined}
             {id}
@@ -183,21 +188,37 @@
             on:input
             on:focus
             on:blur
+            on:mousedown={(e) => {
+              if (readonly) {
+                e.preventDefault();
+                e.currentTarget.focus();
+              }
+            }}
+            on:keydown={(e) => {
+              if (
+                readonly &&
+                (e.key === "ArrowDown" ||
+                  e.key === "ArrowUp" ||
+                  e.key === " ")
+              ) {
+                e.preventDefault();
+              }
+            }}
           >
             <slot />
           </select>
           <ChevronDown class="bx--select__arrow" />
-          {#if invalid}
+          {#if invalid && !readonly}
             <WarningFilled class="bx--select__invalid-icon" />
           {/if}
         </div>
-        {#if invalid}
+        {#if invalid && !readonly}
           <div class:bx--form-requirement={true} id={errorId}>
             {invalidText}
           </div>
         {/if}
       </div>
-      {#if !invalid && !warn && helperText}
+      {#if (!invalid && !warn && helperText) || (readonly && helperText)}
         <div
           id={helperId}
           class:bx--form__helper-text={true}
@@ -210,22 +231,23 @@
     {#if !inline}
       <div
         class:bx--select-input__wrapper={true}
-        data-invalid={invalid || undefined}
+        data-invalid={(invalid && !readonly) || undefined}
       >
         <select
           bind:this={ref}
           {id}
           {name}
-          aria-describedby={invalid
+          aria-describedby={invalid && !readonly
             ? errorId
-            : warn
+            : warn && !readonly
               ? warnId
               : helperText
                 ? helperId
                 : undefined}
           disabled={disabled || undefined}
           required={required || undefined}
-          aria-invalid={invalid || undefined}
+          aria-invalid={(invalid && !readonly) || undefined}
+          aria-readonly={readonly || undefined}
           class:bx--select-input={true}
           class:bx--select-input--sm={size === "sm"}
           class:bx--select-input--xl={size === "xl"}
@@ -235,20 +257,33 @@
           on:input
           on:focus
           on:blur
+          on:mousedown={(e) => {
+            if (readonly) e.preventDefault();
+          }}
+          on:keydown={(e) => {
+            if (
+              readonly &&
+              e.key !== "Tab" &&
+              e.key !== "Shift" &&
+              !(e.altKey && e.key === "ArrowDown")
+            ) {
+              e.preventDefault();
+            }
+          }}
         >
           <slot />
         </select>
         <ChevronDown class="bx--select__arrow" />
-        {#if invalid}
+        {#if invalid && !readonly}
           <WarningFilled class="bx--select__invalid-icon" />
         {/if}
-        {#if !invalid && warn}
+        {#if !invalid && warn && !readonly}
           <WarningAltFilled
             class="bx--select__invalid-icon bx--select__invalid-icon--warning"
           />
         {/if}
       </div>
-      {#if !invalid && !warn && helperText}
+      {#if (!invalid && !warn && helperText) || (readonly && helperText)}
         <div
           id={helperId}
           class:bx--form__helper-text={true}
@@ -257,12 +292,20 @@
           {helperText}
         </div>
       {/if}
-      {#if invalid}
+      {#if invalid && !readonly}
         <div id={errorId} class:bx--form-requirement={true}>{invalidText}</div>
       {/if}
-      {#if !invalid && warn}
+      {#if !invalid && warn && !readonly}
         <div id={warnId} class:bx--form-requirement={true}>{warnText}</div>
       {/if}
     {/if}
   </div>
 </div>
+
+<style>
+  :global(.bx--select--readonly .bx--select-input) {
+    background-color: transparent;
+    border-block-end-color: var(--cds-border-subtle, #c6c6c6);
+    cursor: default;
+  }
+</style>

--- a/tests/Select/Select.test.svelte
+++ b/tests/Select/Select.test.svelte
@@ -15,6 +15,7 @@
   export let size: ComponentProps<Select>["size"] = undefined;
   export let inline = false;
   export let light = false;
+  export let readonly = false;
 </script>
 
 <Select
@@ -31,6 +32,7 @@
   {size}
   {inline}
   {light}
+  {readonly}
   on:change={() => console.log("change")}
   on:input={() => console.log("input")}
   on:update={(e) => console.log("update", e.detail)}

--- a/tests/Select/Select.test.ts
+++ b/tests/Select/Select.test.ts
@@ -136,6 +136,37 @@ describe("Select", () => {
     expect(selectElement).toBeDisabled();
   });
 
+  it("renders read-only state", () => {
+    render(Select, { readonly: true });
+    const selectElement = screen.getByLabelText("Select label");
+    const selectWrapper = selectElement.closest(".bx--select");
+    assert(selectWrapper);
+
+    expect(selectWrapper).toHaveClass("bx--select--readonly");
+    expect(selectElement).toHaveAttribute("aria-readonly", "true");
+    expect(selectElement).not.toBeDisabled();
+  });
+
+  it("suppresses invalid and warn states when read-only", () => {
+    render(Select, {
+      readonly: true,
+      invalid: true,
+      invalidText: "Invalid selection",
+      warn: true,
+      warnText: "Warning message",
+    });
+
+    const selectElement = screen.getByLabelText("Select label");
+    const selectWrapper = selectElement.closest(".bx--select");
+    assert(selectWrapper);
+
+    expect(selectWrapper).not.toHaveClass("bx--select--invalid");
+    expect(selectWrapper).not.toHaveClass("bx--select--warning");
+    expect(selectElement).not.toHaveAttribute("aria-invalid");
+    expect(screen.queryByText("Invalid selection")).not.toBeInTheDocument();
+    expect(screen.queryByText("Warning message")).not.toBeInTheDocument();
+  });
+
   it("renders valid by default", () => {
     render(Select);
     const selectElement = screen.getByLabelText("Select label");


### PR DESCRIPTION
Similar to other input components, support a read-only state.

---

<img width="886" height="218" alt="Screenshot 2026-05-07 at 9 03 32 PM" src="https://github.com/user-attachments/assets/49210b90-d01a-488d-b759-96e29fa92609" />
