### PR TITLE
fix(date-picker): portalled menu should track scroll/resize events

### DIFF
--- a/src/DatePicker/DatePicker.svelte
+++ b/src/DatePicker/DatePicker.svelte
@@ -149,6 +149,22 @@
   let prevValueFrom = valueFrom;
   let prevValueTo = valueTo;
   let lastAppliedOptions = {};
+  let calendarUsesFixedPositioning = false;
+  let onCalendarReposition = null;
+
+  function attachFixedRepositionListeners() {
+    if (!calendar || onCalendarReposition) return;
+    onCalendarReposition = () => positionFlatpickrCalendarFixed(calendar);
+    window.addEventListener("scroll", onCalendarReposition, true);
+    window.addEventListener("resize", onCalendarReposition);
+  }
+
+  function detachFixedRepositionListeners() {
+    if (!onCalendarReposition) return;
+    window.removeEventListener("scroll", onCalendarReposition, true);
+    window.removeEventListener("resize", onCalendarReposition);
+    onCalendarReposition = null;
+  }
 
   /**
    * @type {(data: { id: string; labelText: string }) => void}
@@ -283,6 +299,7 @@
     // calendar can participate in its top layer instead of being clipped behind
     // the backdrop. Computed at creation time — appendTo cannot change after.
     const topLayerAncestor = getTopLayerAncestor(datePickerRef);
+    calendarUsesFixedPositioning = effectivePortalMenu && !!topLayerAncestor;
 
     calendar = await createCalendar({
       options: {
@@ -302,6 +319,10 @@
       base: inputRef,
       input: inputRefTo,
       dispatch: (event) => {
+        if (calendarUsesFixedPositioning) {
+          if (event === "open") attachFixedRepositionListeners();
+          else if (event === "close") detachFixedRepositionListeners();
+        }
         const detail = { selectedDates: calendar?.selectedDates || [] };
 
         if ($range) {
@@ -331,6 +352,7 @@
 
   onMount(() => {
     return () => {
+      detachFixedRepositionListeners();
       if (calendar) {
         calendar.destroy();
         calendar = null;


### PR DESCRIPTION
While the calendar is portalled into a top-layer ancestor and positioned with `position: fixed`, scrolling/resizing now keeps it anchored to the input.

---

https://github.com/user-attachments/assets/d901bde4-cbb2-4d94-ad18-08a4787726a1

