### PR TITLE
fix(multi-select): apply wrapper classes to portal host if `portalMenu` is `true`

### DIFF
--- a/src/ListBox/ListBoxMenu.svelte
+++ b/src/ListBox/ListBoxMenu.svelte
@@ -33,21 +33,30 @@
    */
   export let direction = "bottom";
 
+  /**
+   * Class applied to a wrapper element inside the portal.
+   * Only used when `portal` is `true`.
+   * @type {string}
+   */
+  export let portalHostClass = undefined;
+
   import FloatingPortal from "../Portal/FloatingPortal.svelte";
 </script>
 
 {#if portal}
   <FloatingPortal {anchor} {direction} {open}>
-    <div
-      bind:this={ref}
-      role="listbox"
-      id="menu-{id}"
-      class:bx--list-box__menu={true}
-      style="position: static; {$$restProps.style || ''}"
-      {...$$restProps}
-      on:scroll
-    >
-      <slot />
+    <div class={portalHostClass}>
+      <div
+        bind:this={ref}
+        role="listbox"
+        id="menu-{id}"
+        class:bx--list-box__menu={true}
+        style="position: static; {$$restProps.style || ''}"
+        {...$$restProps}
+        on:scroll
+      >
+        <slot />
+      </div>
     </div>
   </FloatingPortal>
 {:else}

--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -788,6 +788,7 @@
         aria-label={ariaLabel}
         {id}
         portal={effectivePortalMenu}
+        portalHostClass="bx--multi-select bx--list-box--expanded"
         {open}
         anchor={fieldRef}
         {direction}

--- a/tests/ListBox/ListBoxMenu.test.ts
+++ b/tests/ListBox/ListBoxMenu.test.ts
@@ -165,5 +165,22 @@ describe("ListBoxMenu", () => {
       expect(component.ref).toHaveClass("bx--list-box__menu");
       expect(component.ref).toContainElement(menu);
     });
+
+    it("should wrap menu with portalHostClass so descendant CSS selectors match", async () => {
+      render(ListBoxMenu, {
+        props: {
+          slotContent: "Wrapped menu",
+          portal: true,
+          open: true,
+          portalHostClass: "bx--multi-select bx--list-box--expanded",
+        },
+      });
+
+      const menu = await screen.findByText("Wrapped menu");
+      const wrapper = menu.closest(".bx--list-box__menu")?.parentElement;
+      expect(wrapper).toHaveClass("bx--multi-select");
+      expect(wrapper).toHaveClass("bx--list-box--expanded");
+      expect(wrapper?.parentElement).toHaveAttribute("data-floating-portal");
+    });
   });
 });

--- a/tests/MultiSelect/MultiSelect.test.ts
+++ b/tests/MultiSelect/MultiSelect.test.ts
@@ -2192,6 +2192,27 @@ describe("MultiSelect", () => {
       const floatingPortal = menu.closest("[data-floating-portal]");
       expect(floatingPortal).not.toBeInTheDocument();
     });
+
+    // Regression: when portaled, the menu loses its `.bx--multi-select`
+    // ancestor, so descendant CSS rules (e.g. checkbox-wrapper sizing) stop
+    // matching and the checkbox/label visually shift down inside each row.
+    // The menu must be wrapped with `bx--multi-select bx--list-box--expanded`
+    // so those selectors keep matching.
+    it("should wrap portaled menu with multi-select host classes", () => {
+      render(MultiSelect, {
+        props: {
+          items: [{ id: "0", text: "Slack" }],
+          portalMenu: true,
+          open: true,
+        },
+      });
+
+      const menu = screen.getByRole("listbox");
+      const host = menu.parentElement;
+      expect(host).toHaveClass("bx--multi-select");
+      expect(host).toHaveClass("bx--list-box--expanded");
+      expect(host?.parentElement).toHaveAttribute("data-floating-portal");
+    });
   });
 
   describe("filterable: Backspace/Delete clears selection", () => {


### PR DESCRIPTION
There's a visual bug for portaled `MultiSelect` menus. When portalled, certain wrapper classes are dropped. The CSS depends on the wrapper class selecting descendants.

This currently causes the menu item checkbox and label text to appear slightly visually misaligned. This fixes it by passing through the necessary wrapper classes to the portal host.

---

## Before
<img width="771" height="284" alt="Screenshot 2026-05-07 at 9 38 06 PM" src="https://github.com/user-attachments/assets/93503dbd-5422-4661-9f29-d7d41138de47" />

## After
<img width="770" height="276" alt="Screenshot 2026-05-07 at 9 35 45 PM" src="https://github.com/user-attachments/assets/64b537e9-422e-4bd4-a08c-0c6163c404c8" />