### PR TITLE
docs(component-api): linkify URLs in JSDoc descriptions

### DIFF
--- a/docs/src/components/ComponentApi.svelte
+++ b/docs/src/components/ComponentApi.svelte
@@ -212,7 +212,12 @@
                     {@html parsed.mainDescription
                       .replace(/\</g, "&lt;")
                       .replace(/\>/g, "&gt;")
-                      .replace(/`(.*?)`/g, "<code>$1</code>")}
+                      .replace(/`(.*?)`/g, "<code>$1</code>")
+                      .replace(/https?:\/\/[^\s<]+/g, (url) => {
+                        const trailing = url.match(/[.,;:!?)\]]+$/)?.[0] ?? "";
+                        const href = url.slice(0, url.length - trailing.length);
+                        return `<a class="bx--link" href="${href}" target="_blank" rel="noopener noreferrer">${href}</a>${trailing}`;
+                      })}
                   </div>
                 {/if}
                 {#if parsed.exampleCode}

--- a/src/Theme/Theme.svelte
+++ b/src/Theme/Theme.svelte
@@ -32,7 +32,7 @@
 
   /**
    * Customize a theme with your own tokens.
-   * @see https://carbondesignsystem.com/guidelines/themes/overview#customizing-a-theme
+   * @see https://carbondesignsystem.com/elements/themes/overview/#customizing-a-theme
    * @type {Tokens}
    */
   export let tokens = /** @type {Tokens} */ ({});


### PR DESCRIPTION
<img width="940" height="212" alt="Screenshot 2026-05-08 at 10 46 43 AM" src="https://github.com/user-attachments/assets/533123f5-da6b-4314-8864-bb3b2e77147d" />
