### PR TITLE
fix(select): add missing warn icon/text for inline variant

### DIFF
--- a/src/Select/Select.svelte
+++ b/src/Select/Select.svelte
@@ -211,10 +211,20 @@
           {#if invalid && !readonly}
             <WarningFilled class="bx--select__invalid-icon" />
           {/if}
+          {#if !invalid && warn && !readonly}
+            <WarningAltFilled
+              class="bx--select__invalid-icon bx--select__invalid-icon--warning"
+            />
+          {/if}
         </div>
         {#if invalid && !readonly}
           <div class:bx--form-requirement={true} id={errorId}>
             {invalidText}
+          </div>
+        {/if}
+        {#if !invalid && warn && !readonly}
+          <div class:bx--form-requirement={true} id={warnId}>
+            {warnText}
           </div>
         {/if}
       </div>

--- a/tests/Select/Select.test.ts
+++ b/tests/Select/Select.test.ts
@@ -220,6 +220,29 @@ describe("Select", () => {
     );
   });
 
+  it("renders warning state for inline variant", () => {
+    render(Select, {
+      id: "test-select",
+      inline: true,
+      warn: true,
+      warnText: "Warning message",
+    });
+
+    const selectElement = screen.getByLabelText("Select label");
+    const selectWrapper = selectElement.closest(".bx--select");
+    assert(selectWrapper);
+    expect(selectWrapper).toHaveClass("bx--select--warning");
+
+    const warnElement = screen.getByText("Warning message");
+    expect(warnElement).toHaveAttribute("id", "warn-test-select");
+    expect(warnElement).toHaveClass("bx--form-requirement");
+
+    const warningIcon = selectWrapper.querySelector(
+      ".bx--select__invalid-icon--warning",
+    );
+    expect(warningIcon).toBeInTheDocument();
+  });
+
   it("renders without helper text by default", () => {
     render(Select);
     expect(screen.queryByText(/helper/i)).not.toBeInTheDocument();


### PR DESCRIPTION
The `Select` inline variant was missing the warn icon/text. It was also not associating the ID properly.