### PR TITLE
fix(combo-box): set `aria-haspopup="listbox"` on input

### DIFF
--- a/src/ComboBox/ComboBox.svelte
+++ b/src/ComboBox/ComboBox.svelte
@@ -589,6 +589,7 @@
         tabindex="0"
         autocomplete="off"
         aria-autocomplete="list"
+        aria-haspopup="listbox"
         aria-expanded={open}
         aria-activedescendant={highlightedId}
         aria-labelledby={comboId}


### PR DESCRIPTION
For a11y consistency with `Dropdown`, add a similar ARIA attribute.