### PR TITLE
fix(combo-box): index `aria-activedescendant` against filtered items

### DIFF
--- a/src/ComboBox/ComboBox.svelte
+++ b/src/ComboBox/ComboBox.svelte
@@ -465,8 +465,8 @@
   $: ariaLabel = $$props["aria-label"] ?? (labelText || "Choose an item");
   $: menuId = `menu-${id}`;
   $: comboId = `combo-${id}`;
-  $: highlightedId = items[highlightedIndex] ? items[highlightedIndex].id : 0;
   $: filteredItems = open ? items.filter((item) => filterFn(item, value)) : [];
+  $: highlightedId = filteredItems[highlightedIndex]?.id;
   $: filteredItemIndexById = new Map(
     filteredItems.map((item, i) => [item.id, i]),
   );

--- a/tests/ComboBox/ComboBox.test.ts
+++ b/tests/ComboBox/ComboBox.test.ts
@@ -67,6 +67,19 @@ describe("ComboBox", () => {
     expect(input).toHaveValue("Slack");
   });
 
+  it("should set aria-activedescendant to the highlighted filtered item", async () => {
+    render(ComboBox);
+
+    const input = getInput();
+    await user.click(input);
+    await user.keyboard("fax");
+    await user.keyboard("{ArrowDown}");
+
+    // After filtering to "Fax" (id="2"), ArrowDown highlights filteredItems[0].
+    // aria-activedescendant must reference that item, not items[0] ("Slack").
+    expect(input).toHaveAttribute("aria-activedescendant", "2");
+  });
+
   it("should start keyboard navigation at selected item index", async () => {
     render(ComboBox, {
       props: {


### PR DESCRIPTION
`highlightedIndex` navigates `filteredItems`, so deriving `highlightedId` from `items` pointed the descendant at the wrong
row (or none) once the user typed and the list filtered.