### PR TITLE
fix(combo-box): default `aria-activedescendant` to empty when none highlighted

### DIFF
--- a/src/ComboBox/ComboBox.svelte
+++ b/src/ComboBox/ComboBox.svelte
@@ -588,7 +588,7 @@
         aria-autocomplete="list"
         aria-haspopup="listbox"
         aria-expanded={open}
-        aria-activedescendant={highlightedId}
+        aria-activedescendant={highlightedId ?? ""}
         aria-disabled={disabled}
         aria-controls={open ? menuId : undefined}
         aria-owns={open ? menuId : undefined}

--- a/tests/ComboBox/ComboBox.test.ts
+++ b/tests/ComboBox/ComboBox.test.ts
@@ -80,6 +80,19 @@ describe("ComboBox", () => {
     expect(input).toHaveAttribute("aria-activedescendant", "2");
   });
 
+  it("should set aria-activedescendant only when an item is highlighted", async () => {
+    render(ComboBox, { props: { shouldFilterItem: () => true } });
+
+    const input = getInput();
+    expect(input).toHaveAttribute("aria-activedescendant", "");
+
+    await user.click(input);
+    expect(input).toHaveAttribute("aria-activedescendant", "");
+
+    await user.keyboard("{ArrowDown}");
+    expect(input.getAttribute("aria-activedescendant")).not.toBe("");
+  });
+
   it("should start keyboard navigation at selected item index", async () => {
     render(ComboBox, {
       props: {


### PR DESCRIPTION
The `0` fallback rendered an invalid `aria-activedescendant` that could collide with an item whose id is `0`. Default `highlightedId` to `undefined` and coalesce to `""`, matching `Dropdown`.