### PR TITLE
fix(multi-select): set `aria-haspopup="listbox"` on input

### DIFF
--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -630,6 +630,7 @@
           tabindex="0"
           autocomplete="off"
           aria-autocomplete="list"
+          aria-haspopup="listbox"
           aria-expanded={open}
           aria-activedescendant={highlightedId}
           aria-labelledby={comboId}


### PR DESCRIPTION
For a11y consistency with `Dropdown` and `MultiSelect` (#2914), add a similar ARIA attribute.