### PR TITLE
fix(multi-select): close menu on focus leaving wrapper

### DIFF
--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -557,6 +557,12 @@
       open = false;
     }
   }}
+  on:focusin={({ target }) => {
+    if (!open) return;
+    if (multiSelectRef?.contains(target)) return;
+    if (effectivePortalMenu && listRef?.contains(target)) return;
+    open = false;
+  }}
 />
 
 <div
@@ -852,9 +858,6 @@
                       ? selectAllIndeterminate
                       : false}
                     disabled={item.disabled}
-                    on:blur={() => {
-                      if (actualIndex === itemsToUse.length - 1) open = false;
-                    }}
                   >
                     <slot slot="labelChildren" {item} index={actualIndex}>
                       {itemToString(item)}
@@ -907,9 +910,6 @@
                   ? selectAllIndeterminate
                   : false}
                 disabled={item.disabled}
-                on:blur={() => {
-                  if (i === itemsToUse.length - 1) open = false;
-                }}
               >
                 <slot slot="labelChildren" {item} index={i}>
                   {itemToString(item)}

--- a/tests/MultiSelect/MultiSelect.test.ts
+++ b/tests/MultiSelect/MultiSelect.test.ts
@@ -2135,6 +2135,39 @@ describe("MultiSelect", () => {
       expect(menu.style.maxHeight).toBeTruthy();
       expect(menu.style.overflowY).toBe("auto");
     });
+
+    // Regression: with virtualization, the data-last item is not mounted
+    // until scrolled into view, so a per-item blur handler bound to it
+    // never fires when focus leaves the menu. The menu must close based
+    // on focus leaving the wrapper, not blur of a specific list index.
+    it("closes menu when focus moves outside the wrapper (virtualized)", async () => {
+      const largeItems = createLargeItemList(500);
+      render(MultiSelect, {
+        props: { items: largeItems, virtualize: true },
+      });
+
+      const externalButton = document.createElement("button");
+      externalButton.textContent = "Outside";
+      document.body.appendChild(externalButton);
+
+      try {
+        await openMenu();
+        const combobox = screen.getByRole("combobox");
+        expect(combobox).toHaveAttribute("aria-expanded", "true");
+
+        // The data-last item (index 499) is far below the viewport and
+        // not mounted, so any close logic tied to it cannot fire.
+        const visibleOptions = screen.getAllByRole("option");
+        expect(visibleOptions.length).toBeLessThan(500);
+
+        externalButton.focus();
+        await tick();
+
+        expect(combobox).toHaveAttribute("aria-expanded", "false");
+      } finally {
+        externalButton.remove();
+      }
+    });
   });
 
   describe("portalMenu", () => {


### PR DESCRIPTION
Per-item `Checkbox` blur tied to data-last index never fires under virtualization (last item unmounted) or with `selectAll` + `selectionFeedback="top"` (visual last row != data-last).

Replace with a `focusin` handler mirroring the existing outside-click logic.