### PR TITLE
fix(multi-select): do not open menu on filterable input focus

### DIFF
--- a/e2e/multiselect.test.ts
+++ b/e2e/multiselect.test.ts
@@ -49,10 +49,10 @@ test.describe("MultiSelect", () => {
     await expect(page.getByTestId("selected-count")).not.toBeVisible();
   });
 
-  test("opens with Enter and closes with Escape", async ({ page }) => {
+  test("opens with ArrowDown and closes with Escape", async ({ page }) => {
     const trigger = page.getByTestId("multiselect-fruits");
     await trigger.focus();
-    await page.keyboard.press("Enter");
+    await page.keyboard.press("ArrowDown");
     await expect(page.getByRole("option", { name: "Apple" })).toBeVisible();
     await page.keyboard.press("Escape");
     await expect(page.getByRole("option", { name: "Apple" })).not.toBeVisible();

--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -687,10 +687,6 @@
           }}
           on:keyup
           on:focus
-          on:focus={() => {
-            if (disabled) return;
-            open = true;
-          }}
           on:blur
           on:paste
           {disabled}

--- a/tests/MultiSelect/MultiSelect.test.ts
+++ b/tests/MultiSelect/MultiSelect.test.ts
@@ -1138,7 +1138,7 @@ describe("MultiSelect", () => {
 
   // Regression test for https://github.com/carbon-design-system/carbon-components-svelte/issues/2313
   describe("keyboard navigation (issue #2313)", () => {
-    it("filterable: menu opens when tabbing into field", async () => {
+    it("filterable: menu does not open on focus alone (WAI-ARIA combobox)", async () => {
       render(MultiSelect, {
         props: {
           items,
@@ -1152,6 +1152,10 @@ describe("MultiSelect", () => {
       await user.tab();
       expect(input).toHaveFocus();
 
+      expect(input).toHaveAttribute("aria-expanded", "false");
+      expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+
+      await user.keyboard("{ArrowDown}");
       expect(input).toHaveAttribute("aria-expanded", "true");
       expect(screen.getByRole("listbox")).toBeInTheDocument();
     });
@@ -1215,7 +1219,7 @@ describe("MultiSelect", () => {
 
       expect(input).toHaveFocus();
       expect(clearButton).not.toHaveFocus();
-      expect(input).toHaveAttribute("aria-expanded", "true");
+      expect(input).toHaveAttribute("aria-expanded", "false");
     });
 
     it("filterable: clear button is not keyboard accessible but works with mouse", async () => {


### PR DESCRIPTION
Per WAI-ARIA's combobox pattern, the menu should open on click, ArrowDown, or character input, not on focus. This is also what the [React implementation](https://react.carbondesignsystem.com/?path=/story/components-multiselect--filterable) does.

Opening on focus violated the WAI-ARIA combobox pattern and conflicted with the Tab-to-close branch: Tab closed the menu, and the next focus landing reopened it.

---

https://github.com/user-attachments/assets/eb552dfc-1419-4053-89ba-a955a33ef4b9

