### PR TITLE
fix(multi-select): recompute `sortedItems` when `items` prop changes

### DIFF
--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -477,11 +477,16 @@
   }
 
   let sortedItems = sort();
+  let prevItemsRef = items;
 
   $: menuId = `menu-${id}`;
   $: comboId = `combo-${id}`;
   $: inline = type === "inline";
   $: ariaLabel = $$props["aria-label"] ?? "Choose an item";
+  $: if (items !== prevItemsRef) {
+    prevItemsRef = items;
+    sortedItems = sort();
+  }
   $: if (
     selectedIds &&
     ((selectionFeedback === "top" && selectedIds !== internalSelectedIdsRef) ||

--- a/tests/MultiSelect/MultiSelect.test.ts
+++ b/tests/MultiSelect/MultiSelect.test.ts
@@ -696,6 +696,45 @@ describe("MultiSelect", () => {
       await openMenu();
       expect(nthRenderedOptionText(0)).toBe("A");
     });
+
+    it("recomputes sortedItems when the items prop changes", async () => {
+      const { rerender } = render(MultiSelect, {
+        props: {
+          items: [
+            { id: "1", text: "A" },
+            { id: "2", text: "B" },
+          ],
+        },
+      });
+
+      await openMenu();
+      expect(screen.getAllByRole("option")).toHaveLength(2);
+      expect(nthRenderedOptionText(0)).toBe("A");
+      expect(nthRenderedOptionText(1)).toBe("B");
+
+      await rerender({
+        items: [
+          { id: "1", text: "A" },
+          { id: "2", text: "B" },
+          { id: "3", text: "C" },
+        ],
+      });
+      await tick();
+
+      expect(screen.getAllByRole("option")).toHaveLength(3);
+      expect(nthRenderedOptionText(2)).toBe("C");
+
+      await rerender({
+        items: [
+          { id: "1", text: "Alpha" },
+          { id: "2", text: "B" },
+          { id: "3", text: "C" },
+        ],
+      });
+      await tick();
+
+      expect(nthRenderedOptionText(0)).toBe("Alpha");
+    });
   });
 
   describe("variants and states", () => {


### PR DESCRIPTION
`sortedItems` was initialized once and only re-sorted on `selectedIds`/`open` changes, so parent-driven appends, removals, or relabels were ignored. Use a reference equality check to re-sort items if `items` (external) updates.