### PR TITLE
fix(multi-select): remove `aria-labelledby` shadowing label association

### DIFF
--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -632,7 +632,6 @@
           aria-autocomplete="list"
           aria-expanded={open}
           aria-activedescendant={highlightedId}
-          aria-labelledby={comboId}
           aria-disabled={disabled}
           aria-controls={open ? menuId : undefined}
           aria-owns={open ? menuId : undefined}


### PR DESCRIPTION
The `aria-labelledby` pointed at the unnamed `ListBox` wrapper, overriding the `<label for>` association so screen readers announced the wrapper's content instead of `labelText`.

Similar to #2917