### PR TITLE
fix(multi-select): preserve bound `value` on non-filterable close

### DIFF
--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -367,7 +367,9 @@
 
     if (!open) {
       highlightedIndex = -1;
-      value = "";
+      if (prevOpen && filterable) {
+        value = "";
+      }
     }
 
     // Scroll to first selected item when menu opens with virtualization

--- a/tests/MultiSelect/MultiSelect.test.ts
+++ b/tests/MultiSelect/MultiSelect.test.ts
@@ -6,6 +6,7 @@ import { tick } from "svelte";
 import { user } from "../setup-tests";
 import MultiSelectLabelSlot from "./MultiSelect.slot.test.svelte";
 import MultiSelect from "./MultiSelect.test.svelte";
+import MultiSelectBindValue from "./MultiSelectBindValue.test.svelte";
 import MultiSelectGenerics from "./MultiSelectGenerics.test.svelte";
 import MultiSelectInModal from "./MultiSelectInModal.test.svelte";
 import MultiSelectItemToStringId from "./MultiSelectItemToStringId.test.svelte";
@@ -548,6 +549,16 @@ describe("MultiSelect", () => {
           { id: "0", text: "Slack", checked: false },
         ],
       });
+    });
+
+    it("does not clear bound `value` on initial render when not filterable", async () => {
+      render(MultiSelectBindValue, {
+        props: { items, filterable: false, value: "hello" },
+      });
+
+      await tick();
+
+      expect(screen.getByTestId("bound-value")).toHaveTextContent("hello");
     });
   });
 

--- a/tests/MultiSelect/MultiSelectBindValue.test.svelte
+++ b/tests/MultiSelect/MultiSelectBindValue.test.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+  import { MultiSelect } from "carbon-components-svelte";
+  import type { ComponentProps } from "svelte";
+
+  export let items: ComponentProps<MultiSelect>["items"] = [];
+  export let filterable = false;
+  export let value = "";
+  export let open: ComponentProps<MultiSelect>["open"] = false;
+</script>
+
+<MultiSelect {items} {filterable} bind:value bind:open labelText="Test" />
+
+<div data-testid="bound-value">{value}</div>


### PR DESCRIPTION
`afterUpdate` cleared `value` on every tick where `open` was false, wiping `bind:value` on initial render and non-filterable closes. The fix is to only reset `value` on the open-to-close transition (gate on `prevOpen && !open`) and only when `filterable` is true.

**Repro**

```svelte
<script>
  import { MultiSelect, Button } from "carbon-components-svelte";
  import "carbon-components-svelte/css/white.css";

  let value = "";
  let open = false;
  const items = [
    { id: "0", text: "Slack" },
    { id: "1", text: "Email" },
    { id: "2", text: "Fax" },
  ];
</script>

<MultiSelect filterable {items} bind:value bind:open labelText="Contact" />
<Button on:click={() => (open = false)}>Close programmatically</Button>

<p>Filter text: <code>"{value}"</code></p>
```


https://github.com/user-attachments/assets/3ec55bdd-b0f0-4681-af16-2964eee41339

