### PR TITLE
fix(combo-box): wire `aria-describedby` to helper/error/warn messages

### DIFF
--- a/src/ComboBox/ComboBox.svelte
+++ b/src/ComboBox/ComboBox.svelte
@@ -462,6 +462,9 @@
   $: ariaLabel = $$props["aria-label"] ?? (labelText || "Choose an item");
   $: menuId = `menu-${id}`;
   $: comboId = `combo-${id}`;
+  $: helperId = `helper-${id}`;
+  $: errorId = `error-${id}`;
+  $: warnId = `warn-${id}`;
   $: filteredItems = open ? items.filter((item) => filterFn(item, value)) : [];
   $: highlightedId = filteredItems[highlightedIndex]?.id;
   $: filteredItemIndexById = new Map(
@@ -570,12 +573,10 @@
     aria-label={ariaLabel}
     {disabled}
     {invalid}
-    {invalidText}
     {open}
     {light}
     {size}
     {warn}
-    {warnText}
   >
     <div bind:this={fieldRef} class:bx--list-box__field={true}>
       <input
@@ -592,6 +593,13 @@
         aria-disabled={disabled}
         aria-controls={open ? menuId : undefined}
         aria-owns={open ? menuId : undefined}
+        aria-describedby={invalid && invalidText
+          ? errorId
+          : !invalid && warn && warnText
+            ? warnId
+            : !invalid && !warn && helperText
+              ? helperId
+              : undefined}
         {disabled}
         {placeholder}
         {id}
@@ -800,8 +808,15 @@
       </ListBoxMenu>
     {/if}
   </ListBox>
-  {#if !invalid && helperText && !warn}
+  {#if invalid && invalidText}
+    <div id={errorId} class:bx--form-requirement={true}>{invalidText}</div>
+  {/if}
+  {#if !invalid && warn && warnText}
+    <div id={warnId} class:bx--form-requirement={true}>{warnText}</div>
+  {/if}
+  {#if !invalid && !warn && helperText}
     <div
+      id={helperId}
       class:bx--form__helper-text={true}
       class:bx--form__helper-text--disabled={disabled}
     >

--- a/src/ListBox/ListBox.svelte
+++ b/src/ListBox/ListBox.svelte
@@ -57,9 +57,9 @@
 >
   <slot />
 </div>
-{#if invalid}
+{#if invalid && invalidText}
   <div class:bx--form-requirement={true}>{invalidText}</div>
 {/if}
-{#if !invalid && warn}
+{#if !invalid && warn && warnText}
   <div class:bx--form-requirement={true}>{warnText}</div>
 {/if}

--- a/tests/ComboBox/ComboBox.test.ts
+++ b/tests/ComboBox/ComboBox.test.ts
@@ -680,6 +680,33 @@ describe("ComboBox", () => {
     expect(screen.queryByText("Help")).not.toBeInTheDocument();
   });
 
+  it("should describe the input by helperText", () => {
+    render(ComboBoxReal, { props: { id: "cb", helperText: "Help" } });
+    expect(getInput()).toHaveAttribute("aria-describedby", "helper-cb");
+    expect(screen.getByText("Help")).toHaveAttribute("id", "helper-cb");
+  });
+
+  it("should describe the input by warnText when warn is true", () => {
+    render(ComboBoxReal, {
+      props: { id: "cb", warn: true, warnText: "Warn" },
+    });
+    expect(getInput()).toHaveAttribute("aria-describedby", "warn-cb");
+    expect(screen.getByText("Warn")).toHaveAttribute("id", "warn-cb");
+  });
+
+  it("should describe the input by invalidText when invalid is true", () => {
+    render(ComboBoxReal, {
+      props: { id: "cb", invalid: true, invalidText: "Bad" },
+    });
+    expect(getInput()).toHaveAttribute("aria-describedby", "error-cb");
+    expect(screen.getByText("Bad")).toHaveAttribute("id", "error-cb");
+  });
+
+  it("should not set aria-describedby when no message is shown", () => {
+    render(ComboBoxReal, { props: { id: "cb" } });
+    expect(getInput()).not.toHaveAttribute("aria-describedby");
+  });
+
   it("should not open menu when input is focused via keyboard", async () => {
     render(ComboBox);
 


### PR DESCRIPTION
Render `helperText`, `invalidText`, and `warnText` in the wrapper with stable IDs so the input's `aria-describedby` targets the active one. `ListBox` now skips empty `bx--form-requirement` divs to avoid dupes.