### PR TITLE
feat(multi-select): expose `sortedItems` as a bindable prop

### DIFF
--- a/docs/src/pages/components/MultiSelect.svx
+++ b/docs/src/pages/components/MultiSelect.svx
@@ -77,6 +77,12 @@ Move selected items to the top of the list immediately after selection by settin
     {id: "2", text: "Fax"}]}"
   />
 
+## Bind to sorted items
+
+Bind to `sortedItems` to read the resolved list after sorting and selection feedback is applied. This avoids recomputing the order from `items`, `selectedIds`, and `sortItem` in consumer code.
+
+<FileSource src="/framed/MultiSelect/MultiSelectSortedItems" />
+
 ## Multiple multi-select dropdowns
 
 This example demonstrates how to manage multiple dropdowns in a form with coordinated state.

--- a/docs/src/pages/framed/MultiSelect/MultiSelectSortedItems.svelte
+++ b/docs/src/pages/framed/MultiSelect/MultiSelectSortedItems.svelte
@@ -1,0 +1,19 @@
+<script>
+  import { MultiSelect } from "carbon-components-svelte";
+
+  let sortedItems = [];
+</script>
+
+<MultiSelect
+  selectionFeedback="top"
+  labelText="Contact"
+  label="Select contact methods..."
+  items={[
+    { id: "0", text: "Slack" },
+    { id: "1", text: "Email" },
+    { id: "2", text: "Fax" },
+  ]}
+  bind:sortedItems
+/>
+
+<pre>{JSON.stringify(sortedItems, null, 2)}</pre>

--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -199,6 +199,14 @@
   export let highlightedId = null;
 
   /**
+   * The post-sort, post-selection-feedback list of items rendered by the dropdown.
+   * Bind to read the resolved order without recomputing it from `items`, `selectedIds`, and `sortItem`.
+   * @type {ReadonlyArray<Item & { checked: boolean }>}
+   * @bindable readonly
+   */
+  export let sortedItems = [];
+
+  /**
    * Enable virtualization for large lists. Virtualization renders only the items currently visible in the viewport, improving performance for large lists.
    *
    * By default, virtualization is automatically enabled for lists with more than 100 items.
@@ -505,7 +513,7 @@
     ];
   }
 
-  let sortedItems = sort();
+  sortedItems = sort();
   let prevItemsRef = items;
 
   $: menuId = `menu-${id}`;

--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -177,6 +177,13 @@
   export let highlightedId = null;
 
   /**
+   * The post-sort, post-selection-feedback list of items rendered by the dropdown.
+   * Bind to read the resolved order without recomputing it from `items`, `selectedIds`, and `sortItem`.
+   * @type {ReadonlyArray<Item & { checked: boolean }>}
+   */
+  export let sortedItems = [];
+
+  /**
    * Enable virtualization for large lists. Virtualization renders only the items currently visible in the viewport, improving performance for large lists.
    *
    * By default, virtualization is automatically enabled for lists with more than 100 items.
@@ -478,7 +485,7 @@
     ];
   }
 
-  let sortedItems = sort();
+  sortedItems = sort();
   let prevItemsRef = items;
 
   $: menuId = `menu-${id}`;

--- a/tests/MultiSelect/MultiSelect.test.svelte
+++ b/tests/MultiSelect/MultiSelect.test.svelte
@@ -1,3 +1,5 @@
+<svelte:options accessors />
+
 <script lang="ts">
   import { MultiSelect } from "carbon-components-svelte";
   import type { ComponentProps } from "svelte";
@@ -32,6 +34,7 @@
   export let sortItem: ComponentProps<MultiSelect>["sortItem"] = undefined;
   export let open: ComponentProps<MultiSelect>["open"] = undefined;
   export let ariaLabel: ComponentProps<MultiSelect>["aria-label"] = undefined;
+  export let sortedItems: ComponentProps<MultiSelect>["sortedItems"] = [];
 </script>
 
 <MultiSelect
@@ -60,6 +63,7 @@
   {portalMenu}
   {sortItem}
   {open}
+  bind:sortedItems
   on:select={(e) => {
     console.log("select", e.detail);
   }}

--- a/tests/MultiSelect/MultiSelect.test.svelte
+++ b/tests/MultiSelect/MultiSelect.test.svelte
@@ -1,3 +1,5 @@
+<svelte:options accessors />
+
 <script lang="ts">
   import { MultiSelect } from "carbon-components-svelte";
   import type { ComponentProps } from "svelte";
@@ -31,6 +33,7 @@
   export let sortItem: ComponentProps<MultiSelect>["sortItem"] = undefined;
   export let open: ComponentProps<MultiSelect>["open"] = undefined;
   export let ariaLabel: ComponentProps<MultiSelect>["aria-label"] = undefined;
+  export let sortedItems: ComponentProps<MultiSelect>["sortedItems"] = [];
 </script>
 
 <MultiSelect
@@ -58,6 +61,7 @@
   {portalMenu}
   {sortItem}
   {open}
+  bind:sortedItems
   on:select={(e) => {
     console.log("select", e.detail);
   }}

--- a/tests/MultiSelect/MultiSelect.test.ts
+++ b/tests/MultiSelect/MultiSelect.test.ts
@@ -746,6 +746,40 @@ describe("MultiSelect", () => {
 
       expect(nthRenderedOptionText(0)).toBe("Alpha");
     });
+
+    it("exposes sortedItems via bind", async () => {
+      const { component } = render(MultiSelect, {
+        props: {
+          items: [
+            { id: "3", text: "C" },
+            { id: "1", text: "A" },
+            { id: "2", text: "B" },
+          ],
+          selectionFeedback: "top",
+        },
+      });
+
+      await tick();
+      expect(component.sortedItems?.map((item) => item.id)).toEqual([
+        "1",
+        "2",
+        "3",
+      ]);
+      expect(component.sortedItems?.every((item) => !item.checked)).toBe(true);
+
+      await openMenu();
+      await toggleOption("C");
+      await tick();
+
+      expect(component.sortedItems?.map((item) => item.id)).toEqual([
+        "3",
+        "1",
+        "2",
+      ]);
+      expect(
+        component.sortedItems?.find((item) => item.id === "3")?.checked,
+      ).toBe(true);
+    });
   });
 
   describe("variants and states", () => {


### PR DESCRIPTION
Currently, `sortedItems` is internal. This exposes it as a one-way, reactive prop.

```svelte
<script>
  import { MultiSelect } from "carbon-components-svelte";
  let sortedItems = [];
</script>

<MultiSelect
  selectionFeedback="top"
  labelText="Contact"
  label="Select contact methods..."
  items={[
    { id: "0", text: "Slack" },
    { id: "1", text: "Email" },
    { id: "2", text: "Fax" },
  ]}
  bind:sortedItems
/>

<pre>{JSON.stringify(sortedItems, null, 2)}</pre>
```