### PR TITLE
fix(dropdown): wire `aria-describedby` to helper/error/warn messages

### DIFF
--- a/src/Dropdown/Dropdown.svelte
+++ b/src/Dropdown/Dropdown.svelte
@@ -195,6 +195,9 @@
     }
   }
   $: menuId = `menu-${id}`;
+  $: helperId = `helper-${id}`;
+  $: errorId = `error-${id}`;
+  $: warnId = `warn-${id}`;
   $: highlightedId =
     highlightedIndex > -1 && items[highlightedIndex]
       ? items[highlightedIndex].id
@@ -500,10 +503,8 @@
     {disabled}
     {open}
     {invalid}
-    {invalidText}
     {light}
     {warn}
-    {warnText}
   >
     {#if invalid}
       <WarningFilled class="bx--list-box__invalid-icon" />
@@ -523,6 +524,13 @@
       aria-haspopup="listbox"
       aria-activedescendant={highlightedId ?? ""}
       aria-controls={open ? menuId : undefined}
+      aria-describedby={invalid && invalidText
+        ? errorId
+        : !invalid && warn && warnText
+          ? warnId
+          : !inline && !invalid && !warn && helperText
+            ? helperId
+            : undefined}
       on:keydown={(e) => {
         if (e.key === "Enter" || e.key === "ArrowDown" || e.key === "ArrowUp") {
           e.preventDefault();
@@ -666,8 +674,15 @@
       </ListBoxMenu>
     {/if}
   </ListBox>
+  {#if invalid && invalidText}
+    <div id={errorId} class:bx--form-requirement={true}>{invalidText}</div>
+  {/if}
+  {#if !invalid && warn && warnText}
+    <div id={warnId} class:bx--form-requirement={true}>{warnText}</div>
+  {/if}
   {#if !inline && !invalid && !warn && helperText}
     <div
+      id={helperId}
       class:bx--form__helper-text={true}
       class:bx--form__helper-text--disabled={disabled}
     >

--- a/tests/Dropdown/Dropdown.test.ts
+++ b/tests/Dropdown/Dropdown.test.ts
@@ -207,6 +207,46 @@ describe("Dropdown", () => {
     expect(screen.getByText("Help text")).toHaveClass("bx--form__helper-text");
   });
 
+  it("should describe the button by helperText", () => {
+    render(Dropdown, {
+      props: { items, id: "dd", helperText: "Help" },
+    });
+    expect(screen.getByRole("combobox")).toHaveAttribute(
+      "aria-describedby",
+      "helper-dd",
+    );
+    expect(screen.getByText("Help")).toHaveAttribute("id", "helper-dd");
+  });
+
+  it("should describe the button by warnText when warn is true", () => {
+    render(Dropdown, {
+      props: { items, id: "dd", warn: true, warnText: "Warn" },
+    });
+    expect(screen.getByRole("combobox")).toHaveAttribute(
+      "aria-describedby",
+      "warn-dd",
+    );
+    expect(screen.getByText("Warn")).toHaveAttribute("id", "warn-dd");
+  });
+
+  it("should describe the button by invalidText when invalid is true", () => {
+    render(Dropdown, {
+      props: { items, id: "dd", invalid: true, invalidText: "Bad" },
+    });
+    expect(screen.getByRole("combobox")).toHaveAttribute(
+      "aria-describedby",
+      "error-dd",
+    );
+    expect(screen.getByText("Bad")).toHaveAttribute("id", "error-dd");
+  });
+
+  it("should not set aria-describedby when no message is shown", () => {
+    render(Dropdown, { props: { items, id: "dd" } });
+    expect(screen.getByRole("combobox")).not.toHaveAttribute(
+      "aria-describedby",
+    );
+  });
+
   it("should handle item selection", async () => {
     const selectHandler = vi.fn();
     render(Dropdown, {


### PR DESCRIPTION
Render `helperText`, `invalidText`, and `warnText` in the wrapper with stable IDs so the input's `aria-describedby` targets the active one. `ListBox` now skips empty `bx--form-requirement` divs to avoid dupes.

Similar to #2925