### PR TITLE
fix(dropdown): scroll selected option into view when menu overflows

### DIFF
--- a/docs/src/pages/components/Dropdown.svx
+++ b/docs/src/pages/components/Dropdown.svx
@@ -30,6 +30,14 @@ Omit `selectedId` to render the dropdown with no item selected. The `label` prop
   {id: "1", text: "Email"},
   {id: "2", text: "Fax"}]}" />
 
+## With initial selection
+
+Set `selectedId` to the `id` of the item that should appear chosen when the dropdown first renders. The trigger shows that item's label in the closed state.
+
+When the user opens the menu, if the option list is taller than the menu's maximum height, the menu scrolls so the selected option stays visible. That applies to lists rendered in full and to [virtualized lists](#virtualized-items-large-lists).
+
+<FileSource src="/framed/Dropdown/ScrollToSelected" />
+
 ## Custom label
 
 Use the `labelChildren` slot to provide custom label content instead of using the `labelText` prop.

--- a/docs/src/pages/framed/Dropdown/ScrollToSelected.svelte
+++ b/docs/src/pages/framed/Dropdown/ScrollToSelected.svelte
@@ -1,0 +1,12 @@
+<script>
+  import { Dropdown } from "carbon-components-svelte";
+
+  const items = Array.from({ length: 50 }, (_, i) => ({
+    id: i,
+    text: `Item ${i + 1}`,
+  }));
+
+  let selectedId = 42;
+</script>
+
+<Dropdown labelText="Items" {items} bind:selectedId />

--- a/e2e/dropdown-scroll-to-selected.test.ts
+++ b/e2e/dropdown-scroll-to-selected.test.ts
@@ -1,0 +1,28 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("Dropdown scroll to selected", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/dropdown-scroll-to-selected.html");
+  });
+
+  test("shows selected option within menu bounds when opened", async ({
+    page,
+  }) => {
+    await page.getByRole("combobox", { name: "Items" }).click();
+
+    const selected = page.getByRole("option", { name: "Item 43" });
+    await expect(selected).toBeVisible();
+    await expect(selected).toHaveAttribute("aria-selected", "true");
+
+    const intersectsMenu = await selected.evaluate((el) => {
+      const menu = el.closest('[role="listbox"]');
+      if (!(menu instanceof HTMLElement)) return false;
+      const mr = menu.getBoundingClientRect();
+      const er = el.getBoundingClientRect();
+      const overlap = Math.min(mr.bottom, er.bottom) - Math.max(mr.top, er.top);
+      return overlap > 0;
+    });
+
+    expect(intersectsMenu).toBe(true);
+  });
+});

--- a/e2e/fixtures/DropdownScrollToSelectedFixture.svelte
+++ b/e2e/fixtures/DropdownScrollToSelectedFixture.svelte
@@ -1,0 +1,12 @@
+<script>
+  import { Dropdown } from "carbon-components-svelte";
+
+  const items = Array.from({ length: 50 }, (_, i) => ({
+    id: i,
+    text: `Item ${i + 1}`,
+  }));
+
+  let selectedId = 42;
+</script>
+
+<Dropdown labelText="Items" {items} bind:selectedId />

--- a/e2e/fixtures/dropdown-scroll-to-selected.html
+++ b/e2e/fixtures/dropdown-scroll-to-selected.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Dropdown scroll to selected</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="./dropdown-scroll-to-selected.ts"></script>
+  </body>
+</html>

--- a/e2e/fixtures/dropdown-scroll-to-selected.ts
+++ b/e2e/fixtures/dropdown-scroll-to-selected.ts
@@ -1,0 +1,4 @@
+import DropdownScrollToSelectedFixture from "./DropdownScrollToSelectedFixture.svelte";
+import { mount } from "./mount";
+
+mount(DropdownScrollToSelectedFixture);

--- a/src/Dropdown/Dropdown.svelte
+++ b/src/Dropdown/Dropdown.svelte
@@ -306,6 +306,27 @@
       }
     }
 
+    // Scroll to selected item when menu opens without virtualization.
+    // The list may overflow its max-height even below the virtualization threshold.
+    if (
+      wasJustOpened &&
+      !shouldVirtualize &&
+      listRef &&
+      selectedId !== undefined &&
+      selectedItem
+    ) {
+      tick().then(() => {
+        if (!listRef) return;
+        const selectedEl = listRef.querySelector('[aria-selected="true"]');
+        if (!selectedEl) return;
+        // Adjust the menu's own scrollTop instead of scrollIntoView,
+        // which would also scroll the document.
+        listRef.scrollTop +=
+          selectedEl.getBoundingClientRect().top -
+          listRef.getBoundingClientRect().top;
+      });
+    }
+
     // Scroll to selected item when menu opens with virtualization
     if (wasJustOpened && shouldVirtualize && listRef) {
       tick().then(() => {

--- a/tests/Dropdown/Dropdown.test.ts
+++ b/tests/Dropdown/Dropdown.test.ts
@@ -858,6 +858,68 @@ describe("Dropdown", () => {
     expect(bananaOption).toHaveClass("bx--list-box__menu-item--highlighted");
   });
 
+  // Regression: non-virtualized lists that overflow the menu's max-height
+  // must still scroll the selected option into view when the menu opens.
+  // Selected item is aligned to the top of the menu, matching the
+  // virtualized branch's behavior.
+  it("should scroll selected item to top of menu on open (non-virtualized)", async () => {
+    const ITEM_HEIGHT = 40;
+    const rectSpy = vi
+      .spyOn(Element.prototype, "getBoundingClientRect")
+      .mockImplementation(function (this: Element) {
+        const role = this.getAttribute("role");
+        if (role === "option") {
+          const index = Number(this.getAttribute("id"));
+          const top = index * ITEM_HEIGHT;
+          return {
+            top,
+            bottom: top + ITEM_HEIGHT,
+            height: ITEM_HEIGHT,
+            left: 0,
+            right: 0,
+            width: 0,
+            x: 0,
+            y: top,
+            toJSON: () => ({}),
+          } as DOMRect;
+        }
+        if (role === "listbox") {
+          return {
+            top: 0,
+            bottom: 0,
+            height: 0,
+            left: 0,
+            right: 0,
+            width: 0,
+            x: 0,
+            y: 0,
+            toJSON: () => ({}),
+          } as DOMRect;
+        }
+        return new DOMRect();
+      });
+
+    try {
+      const manyItems = Array.from({ length: 50 }, (_, i) => ({
+        id: String(i),
+        text: `Item ${i + 1}`,
+      }));
+
+      render(Dropdown, {
+        props: { items: manyItems, selectedId: "42", labelText: "Items" },
+      });
+
+      await user.click(screen.getByRole("combobox"));
+
+      await waitFor(() => {
+        const menu = screen.getByRole("listbox");
+        expect(menu.scrollTop).toBe(42 * ITEM_HEIGHT);
+      });
+    } finally {
+      rectSpy.mockRestore();
+    }
+  });
+
   describe("virtualization", () => {
     const createLargeItemList = (count: number) => {
       return Array.from({ length: count }, (_, i) => ({


### PR DESCRIPTION
Similar to other menus (including virtualized Dropdown), the selected item should be scrolled into view for long lists.

---

<img width="1010" height="375" alt="Screenshot 2026-05-09 at 12 22 03 PM" src="https://github.com/user-attachments/assets/1f247245-6cfc-47e1-b826-79b972e8b2bf" />
