### PR TITLE
perf(combo-box): remove dead code for single-filtered-item

### DIFF
--- a/src/ComboBox/ComboBox.svelte
+++ b/src/ComboBox/ComboBox.svelte
@@ -445,13 +445,7 @@
       // Only dispatch select event if not initial render (prevSelectedId was not null)
       const isInitialRender = prevSelectedId === null;
       prevSelectedId = selectedId;
-      if (filteredItems?.length === 1 && open) {
-        selectedId = filteredItems[0].id;
-        selectedItem = filteredItems[0];
-        highlightedIndex = -1;
-      } else {
-        selectedItem = itemsById.get(selectedId);
-      }
+      selectedItem = itemsById.get(selectedId);
       if (!isInitialRender) {
         dispatch("select", { selectedId, selectedItem });
       }


### PR DESCRIPTION
This branch is a vestige of the old `selectedIndex` API (#926); after #995 migrated the reactive block to `selectedId`, all internal handlers set `open = false` before `selectedId`, so `filteredItems` is empty when this block runs.