### PR TITLE
feat(dropdown): add `disableTypeahead` prop

### DIFF
--- a/docs/src/pages/components/Dropdown.svx
+++ b/docs/src/pages/components/Dropdown.svx
@@ -186,6 +186,14 @@ selections.
   ]}
 />
 
+## Disable typeahead
+
+By default, typing character keys while the menu is open jumps to matching items. Set `disableTypeahead` to `true` to opt out, restricting keyboard interaction to arrow keys only.
+
+<Dropdown disableTypeahead labelText="Contact" selectedId="0" items="{[{id: "0", text: "Slack"},
+  {id: "1", text: "Email"},
+  {id: "2", text: "Fax"}]}" />
+
 ## Virtualized items (large lists)
 
 Virtualization is a technique that allows only the items currently visible in the viewport to be rendered in the DOM, improving performance for large lists.

--- a/src/Dropdown/Dropdown.svelte
+++ b/src/Dropdown/Dropdown.svelte
@@ -127,6 +127,13 @@
    */
   export let name = undefined;
 
+  /**
+   * Set to `true` to disable typeahead (type-to-search).
+   * When disabled, character keys do not jump to matching items
+   * and only arrow-key navigation is used.
+   */
+  export let disableTypeahead = false;
+
   /** Obtain a reference to the button HTML element */
   export let ref = null;
 
@@ -541,6 +548,7 @@
         } else if (e.key === "Escape") {
           open = false;
         } else if (
+          !disableTypeahead &&
           open &&
           e.key.length === 1 &&
           e.key !== " " &&

--- a/tests/Dropdown/Dropdown.test.ts
+++ b/tests/Dropdown/Dropdown.test.ts
@@ -865,6 +865,34 @@ describe("Dropdown", () => {
     expect(cherryOption).toHaveClass("bx--list-box__menu-item--highlighted");
   });
 
+  it("should not perform typeahead when disableTypeahead is true", async () => {
+    render(Dropdown, {
+      props: {
+        items: [
+          { id: "0", text: "Apple" },
+          { id: "1", text: "Banana" },
+          { id: "2", text: "Cherry" },
+        ],
+        selectedId: "0",
+        disableTypeahead: true,
+      },
+    });
+
+    const button = screen.getByRole("combobox");
+    await user.click(button);
+
+    await user.keyboard("b");
+
+    const bananaOption = screen.getByRole("option", { name: "Banana" });
+    expect(bananaOption).not.toHaveClass(
+      "bx--list-box__menu-item--highlighted",
+    );
+
+    // Arrow keys should still navigate
+    await user.keyboard("{ArrowDown}");
+    expect(bananaOption).toHaveClass("bx--list-box__menu-item--highlighted");
+  });
+
   it("should wrap around to beginning in typeahead search", async () => {
     render(Dropdown, {
       props: {


### PR DESCRIPTION
By default, `Dropdown` supports typeahead. This allows the ability to opt out of this behavior.