### PR TITLE
perf(data-table): remove imperative `refSelectAll.checked`

### DIFF
--- a/src/DataTable/DataTable.svelte
+++ b/src/DataTable/DataTable.svelte
@@ -381,7 +381,6 @@
   const resetSelectedRowIds = () => {
     selectAll = false;
     selectedRowIds = [];
-    if (refSelectAll) refSelectAll.checked = false;
   };
 
   /**
@@ -439,8 +438,6 @@
     a[id] = true;
     return a;
   }, {});
-
-  let refSelectAll = null;
 
   let prevBatchSelected = [];
   $: if (
@@ -695,7 +692,6 @@
           {#if batchSelection && !radio}
             <th scope="col" class:bx--table-column-checkbox={true}>
               <InlineCheckbox
-                bind:ref={refSelectAll}
                 aria-label="Select all rows"
                 name="{id}-select-all"
                 value="all"

--- a/tests/DataTable/DataTableBatchSelectionToolbar.test.ts
+++ b/tests/DataTable/DataTableBatchSelectionToolbar.test.ts
@@ -54,6 +54,25 @@ describe("DataTableBatchSelectionToolbar", () => {
     expect(selectedIdsElement.textContent).toBe("[]");
   });
 
+  it("unchecks the select-all checkbox after cancel", async () => {
+    render(DataTableBatchSelectionToolbar, {
+      props: {
+        selectedRowIds: ["a", "b", "c", "d", "e", "f"],
+      },
+    });
+
+    const selectAll = screen.getByRole("checkbox", {
+      name: "Select all rows",
+    });
+    expect(selectAll).toBeChecked();
+
+    await user.click(screen.getByText("Cancel"));
+    await tick();
+
+    expect(selectAll).not.toBeChecked();
+    expect(screen.getByTestId("selected-ids").textContent).toBe("[]");
+  });
+
   it("handles custom batch actions", async () => {
     const consoleLog = vi.spyOn(console, "log");
     render(DataTableBatchSelectionToolbar, {


### PR DESCRIPTION
`checked` is derived from `selectAll`, so the `refSelectAll` reference is no longer necessary.