### PR TITLE
feat(accordion-item): add `ref` prop for button reference

### DIFF
--- a/src/Accordion/AccordionItem.svelte
+++ b/src/Accordion/AccordionItem.svelte
@@ -20,6 +20,9 @@
   /** Specify the ARIA label for the accordion item chevron icon */
   export let iconDescription = "Expand/Collapse";
 
+  /** Obtain a reference to the heading button HTML element */
+  export let ref = null;
+
   import { getContext, onMount } from "svelte";
   import ChevronRight from "../icons/ChevronRight.svelte";
 
@@ -54,6 +57,7 @@
   }}
 >
   <button
+    bind:this={ref}
     type="button"
     class:bx--accordion__heading={true}
     title={iconDescription}

--- a/tests/Accordion/Accordion.test.svelte
+++ b/tests/Accordion/Accordion.test.svelte
@@ -1,3 +1,5 @@
+<svelte:options accessors />
+
 <script lang="ts">
   import { Accordion, AccordionItem } from "carbon-components-svelte";
   import type { ComponentProps } from "svelte";
@@ -8,6 +10,7 @@
   export let itemClass = "";
   export let useSlot = false;
   export let iconDescription = "Expand/Collapse";
+  export let ref: ComponentProps<AccordionItem>["ref"] = null;
 </script>
 
 <Accordion
@@ -33,7 +36,9 @@
       Slot content
     </AccordionItem>
   {:else}
-    <AccordionItem title="Natural Language Classifier">1</AccordionItem>
+    <AccordionItem title="Natural Language Classifier" bind:ref
+      >1</AccordionItem
+    >
     <AccordionItem title="Natural Language Understanding" disabled
       >2</AccordionItem
     >

--- a/tests/Accordion/Accordion.test.ts
+++ b/tests/Accordion/Accordion.test.ts
@@ -402,6 +402,16 @@ describe("Accordion", () => {
     itemIsCollapsed(/Language Translator/);
   });
 
+  it("should expose ref to the heading button", () => {
+    const { component } = render(Accordion);
+
+    expect(component.ref).toBeInstanceOf(HTMLButtonElement);
+    expect(component.ref).toHaveAttribute(
+      "class",
+      expect.stringContaining("bx--accordion__heading"),
+    );
+  });
+
   it("should use custom iconDescription", () => {
     render(Accordion, {
       props: { useSlot: true, iconDescription: "Custom description" },


### PR DESCRIPTION
Allow binding to the button reference for imperative focusing etc..