### PR TITLE
fix(data-table): `click:header` reports intended direction even when `sort` is cancelled

### DIFF
--- a/src/DataTable/DataTable.svelte
+++ b/src/DataTable/DataTable.svelte
@@ -51,7 +51,7 @@
    * @event click:header
    * @type {object}
    * @property {DataTableHeader<Row>} header
-   * @property {"ascending" | "descending" | "none"} [sortDirection]
+   * @property {"ascending" | "descending" | "none"} [sortDirection] - The intended next sort direction for this click, reported regardless of whether the `sort` event was cancelled.
    * @property {EventTarget} target
    * @property {EventTarget} currentTarget
    * @event click:header--select
@@ -778,7 +778,7 @@
                     }
                     dispatch("click:header", {
                       header,
-                      sortDirection,
+                      sortDirection: nextSortDirection,
                       target: e.target,
                       currentTarget: e.currentTarget,
                     });

--- a/tests/DataTable/DataTable.sort.preventDefault.test.svelte
+++ b/tests/DataTable/DataTable.sort.preventDefault.test.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { DataTable } from "carbon-components-svelte";
+  import type { DataTableHeader } from "carbon-components-svelte/DataTable/DataTable.svelte";
 
   const headers = [
     { key: "name", value: "Name" },
@@ -11,6 +12,8 @@
     { id: "b", name: "Alpha", port: 2 },
   ] as const;
 
+  type Row = (typeof rows)[number];
+
   /** When true, `on:sort` calls preventDefault() so the table does not apply client-side sort. */
   export let preventSortDefault = false;
 
@@ -19,6 +22,17 @@
         e: CustomEvent<{
           key: string | null;
           direction: "none" | "ascending" | "descending";
+        }>,
+      ) => void)
+    | undefined = undefined;
+
+  export let onclickheader:
+    | ((
+        e: CustomEvent<{
+          header: DataTableHeader<Row>;
+          sortDirection?: "none" | "ascending" | "descending";
+          target: EventTarget;
+          currentTarget: EventTarget;
         }>,
       ) => void)
     | undefined = undefined;
@@ -32,4 +46,5 @@
     onsort?.(e);
     if (preventSortDefault) e.preventDefault();
   }}
+  on:click:header={(e) => onclickheader?.(e)}
 />

--- a/tests/DataTable/DataTable.test.ts
+++ b/tests/DataTable/DataTable.test.ts
@@ -254,6 +254,24 @@ describe("DataTable", () => {
     expect(within(bodyRows[0]).getByText("Zebra")).toBeInTheDocument();
   });
 
+  it("sort: cancelled sort still reports intended direction in click:header", async () => {
+    const onclickheader = vi.fn();
+    render(DataTableSortPreventDefault, {
+      props: { preventSortDefault: true, onclickheader },
+    });
+
+    await user.click(screen.getByText("Name"));
+    await tick();
+
+    expect(onclickheader).toHaveBeenCalledTimes(1);
+    expect(onclickheader.mock.calls[0][0].detail).toEqual(
+      expect.objectContaining({
+        header: expect.objectContaining({ key: "name" }),
+        sortDirection: "ascending",
+      }),
+    );
+  });
+
   it("sort: without preventDefault applies client-side sort", async () => {
     const onsort = vi.fn();
     render(DataTableSortPreventDefault, {


### PR DESCRIPTION
#2829 add the `on:sort` event, which is cancellable.

This fixes an edge case: the `click:header` event should report the intended direction. If canceled, the current direction (stale) is used.