### PR TITLE
fix(data-table): detect in-place row mutations in cell cache

### DIFF
--- a/src/DataTable/DataTable.svelte
+++ b/src/DataTable/DataTable.svelte
@@ -474,30 +474,44 @@
   let tableCellsByRowId = {};
   let prevRows;
   let prevHeaders;
-  let rowRefById = {};
 
   $: if (rows !== prevRows || headers !== prevHeaders) {
-    const headersChanged = headers !== prevHeaders;
     const next = {};
-    const nextRefs = {};
 
     for (const row of rows) {
-      if (!headersChanged && rowRefById[row.id] === row) {
-        next[row.id] = tableCellsByRowId[row.id];
+      const prevCells = tableCellsByRowId[row.id];
+      const newCells = headers.map((header, index) => ({
+        key: header.key ?? `key-${index}`,
+        value: header.key ? resolvePath(row, header.key) : undefined,
+        display: header.display,
+        empty: header.empty,
+        columnMenu: header.columnMenu,
+      }));
+
+      if (prevCells && prevCells.length === newCells.length) {
+        let allEqual = true;
+        for (let i = 0; i < newCells.length; i++) {
+          const a = prevCells[i];
+          const b = newCells[i];
+          if (
+            a.key === b.key &&
+            a.value === b.value &&
+            a.display === b.display &&
+            a.empty === b.empty &&
+            a.columnMenu === b.columnMenu
+          ) {
+            newCells[i] = a;
+          } else {
+            allEqual = false;
+          }
+        }
+        next[row.id] = allEqual ? prevCells : newCells;
       } else {
-        next[row.id] = headers.map((header, index) => ({
-          key: header.key ?? `key-${index}`,
-          value: header.key ? resolvePath(row, header.key) : undefined,
-          display: header.display,
-          empty: header.empty,
-          columnMenu: header.columnMenu,
-        }));
+        next[row.id] = newCells;
       }
-      nextRefs[row.id] = row;
     }
 
     tableCellsByRowId = next;
-    rowRefById = nextRefs;
     prevRows = rows;
     prevHeaders = headers;
   }

--- a/tests/DataTable/DataTableTableCellsCache.test.ts
+++ b/tests/DataTable/DataTableTableCellsCache.test.ts
@@ -75,6 +75,29 @@ describe("DataTable tableCellsByRowId caching", () => {
     expect(lastCell).toEqual(expect.objectContaining({ value: "Beta" }));
   });
 
+  it("reflects in-place row mutations when the row reference is unchanged", async () => {
+    const row = { id: "a", name: "Alpha" };
+
+    const { rerender } = render(DataTableTableCellsCache, {
+      props: { headers, rows: [row] },
+    });
+
+    expect(
+      within(getFirstBodyRow()).queryByRole("cell", { name: "Alpha" }),
+    ).not.toBeNull();
+
+    row.name = "Beta";
+    await rerender({ rows: [row] });
+    await tick();
+
+    expect(
+      within(getFirstBodyRow()).queryByRole("cell", { name: "Beta" }),
+    ).not.toBeNull();
+    expect(
+      within(getFirstBodyRow()).queryByRole("cell", { name: "Alpha" }),
+    ).toBeNull();
+  });
+
   it("rebuilds cell objects when headers change", async () => {
     const row = { id: "a", name: "Alpha", protocol: "HTTP" };
     const headersWide = [


### PR DESCRIPTION
From #2821, the cache key is `rowRefById[row.id] === row`, pure reference equality. A consumer that mutates a row in place (e.g. `rows[0].name = "new"; rows = rows;`) will hit the cache and render the previous `value` for that row even though the row content changed.

Compare cells by content instead, preserving cell/array identity when unchanged.