### PR TITLE
fix(data-table): preserve active filter when `rows` prop changes

### DIFF
--- a/src/DataTable/DataTable.svelte
+++ b/src/DataTable/DataTable.svelte
@@ -370,24 +370,17 @@
   // Store a copy of the original rows for filter restoration.
   let prevRows_ref = rows;
   let originalRows = [...rows];
-  $: if (rows !== prevRows_ref) {
-    originalRows = [...rows];
-    $tableRows = rows;
-    prevRows_ref = rows;
-  }
-
-  /**
-   * @type {() => void}
-   */
-  const resetSelectedRowIds = () => {
-    selectAll = false;
-    selectedRowIds = [];
-  };
+  // Last filter applied via `filterRows`, replayed when `rows` changes so
+  // an active search is not silently dropped on row reassignment.
+  let lastSearchValue = "";
+  let lastCustomFilter = undefined;
 
   /**
    * @type {(searchValue: string, customFilter?: (row: Row, value: string) => boolean) => ReadonlyArray<Row["id"]>}
    */
   const filterRows = (searchValue, customFilter) => {
+    lastSearchValue = searchValue;
+    lastCustomFilter = customFilter;
     const value = searchValue.trim().toLowerCase();
 
     if (value.length === 0) {
@@ -423,6 +416,24 @@
 
     tableRows.set(filteredRows);
     return filteredRows.map((row) => row.id);
+  };
+
+  $: if (rows !== prevRows_ref) {
+    originalRows = [...rows];
+    prevRows_ref = rows;
+    if (lastSearchValue.trim().length > 0) {
+      filterRows(lastSearchValue, lastCustomFilter);
+    } else {
+      $tableRows = rows;
+    }
+  }
+
+  /**
+   * @type {() => void}
+   */
+  const resetSelectedRowIds = () => {
+    selectAll = false;
+    selectedRowIds = [];
   };
 
   setContext("carbon:DataTable", {

--- a/tests/DataTable/DataTableRefilterOnRowsChange.test.svelte
+++ b/tests/DataTable/DataTableRefilterOnRowsChange.test.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+  import { Button, DataTable } from "carbon-components-svelte";
+  import FilterRowsCaller from "./FilterRowsCaller.svelte";
+
+  const initialRows = Array.from({ length: 10 }).map((_, i) => ({
+    id: i,
+    name: `Load Balancer ${i + 1}`,
+    rule: i % 2 ? "Round robin" : "DNS delegation",
+  }));
+
+  const toggledRows = Array.from({ length: 4 }).map((_, i) => ({
+    id: i,
+    name: `Server instance ${i + 1}`,
+    rule: i % 2 ? "Round!" : "DNS!",
+  }));
+
+  let rows: typeof initialRows = initialRows;
+</script>
+
+<Button on:click={() => (rows = toggledRows)}>Toggle rows</Button>
+
+<DataTable
+  headers={[
+    { key: "name", value: "Name" },
+    { key: "rule", value: "Rule" },
+  ]}
+  {rows}
+>
+  <FilterRowsCaller searchValue="round" />
+</DataTable>

--- a/tests/DataTable/DataTableRefilterOnRowsChange.test.ts
+++ b/tests/DataTable/DataTableRefilterOnRowsChange.test.ts
@@ -1,0 +1,30 @@
+import { render, screen } from "@testing-library/svelte";
+import { user } from "../setup-tests";
+import DataTableRefilterOnRowsChange from "./DataTableRefilterOnRowsChange.test.svelte";
+
+describe("DataTable re-filters when rows change", () => {
+  // Skip the header row.
+  const getTableRows = () => screen.getAllByRole("row").slice(1);
+
+  it("preserves an active filter when the rows prop is reassigned", async () => {
+    render(DataTableRefilterOnRowsChange);
+
+    // Initial filter ("round") was applied on mount via the context's
+    // filterRows. Five of the ten initial rows match "Round robin".
+    let tableRows = getTableRows();
+    expect(tableRows).toHaveLength(5);
+    for (const row of tableRows) {
+      expect(row).toHaveTextContent("Round robin");
+    }
+
+    // Reassign `rows` to a new set. The filter ("round") should still apply
+    // and only match rows containing "Round!" — two of the four new rows.
+    await user.click(screen.getByRole("button", { name: "Toggle rows" }));
+
+    tableRows = getTableRows();
+    expect(tableRows).toHaveLength(2);
+    for (const row of tableRows) {
+      expect(row).toHaveTextContent("Round!");
+    }
+  });
+});

--- a/tests/DataTable/FilterRowsCaller.svelte
+++ b/tests/DataTable/FilterRowsCaller.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+  import { getContext, onMount } from "svelte";
+
+  export let searchValue: string;
+
+  const ctx = getContext<{
+    filterRows: (value: string) => readonly (string | number)[];
+  }>("carbon:DataTable");
+
+  onMount(() => {
+    ctx?.filterRows(searchValue);
+  });
+</script>


### PR DESCRIPTION
When `ToolbarSearch` (or any consumer) calls `filterRows`, the visible rows are stored in `$tableRows` while `originalRows` keeps the full set. As soon as the parent re-assigns `rows` (e.g. after a fetch), the reactive resets `originalRows = [...rows]; $tableRows = rows;` and the user's search is wiped without warning, even though the search input still shows the query.

The fix is to track the last `filterRows` inputs and replay them when `rows` is reassigned, so consumers calling `filterRows` via context don't silently lose the filter on row updates.

Svelte REPL repro: https://svelte.dev/playground/a43647f2061240ec9ef6b4852b15ca95?version=latest