### PR TITLE
fix(button): set `rel="noopener noreferrer"` on `target="_blank"` anchors

### DIFF
--- a/src/Button/Button.svelte
+++ b/src/Button/Button.svelte
@@ -153,6 +153,10 @@
     tabindex,
     disabled: disabled === true ? true : undefined,
     href,
+    rel:
+      href && $$restProps.target === "_blank"
+        ? "noopener noreferrer"
+        : undefined,
     "aria-pressed":
       hasIconOnly && kind === "ghost" && !href ? isSelected : undefined,
     ...$$restProps,

--- a/tests/Button/Button.test.svelte
+++ b/tests/Button/Button.test.svelte
@@ -30,6 +30,8 @@
 
 <Button href="#">Link button</Button>
 
+<Button href="https://example.com" target="_blank">External link</Button>
+
 <Button as let:props> <p {...props}>Custom element</p> </Button>
 
 <Button disabled>Disabled button</Button>

--- a/tests/Button/Button.test.ts
+++ b/tests/Button/Button.test.ts
@@ -64,6 +64,15 @@ describe("Button", () => {
     expect(linkButton).toHaveAttribute("href", "#");
   });
 
+  it('should set rel="noopener noreferrer" on link when target="_blank"', () => {
+    render(Button);
+
+    const externalLink = screen.getByText("External link");
+    expect(externalLink.tagName).toBe("A");
+    expect(externalLink).toHaveAttribute("target", "_blank");
+    expect(externalLink).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
   it("should render custom element when as prop is used", () => {
     render(Button);
 


### PR DESCRIPTION
Matches behavior for link components.