### PR TITLE
fix(button): remove redundant `aria-label` from icon

### DIFF
--- a/src/Button/Button.svelte
+++ b/src/Button/Button.svelte
@@ -146,7 +146,6 @@
   $: iconProps = {
     "aria-hidden": "true",
     class: "bx--btn__icon",
-    "aria-label": iconDescription,
   };
   $: buttonProps = {
     type: href && !disabled ? undefined : type,

--- a/tests/Button/Button.test.ts
+++ b/tests/Button/Button.test.ts
@@ -109,6 +109,16 @@ describe("Button", () => {
     expect(icon).toBeInTheDocument();
   });
 
+  it("should not set aria-label on the icon (relies on assistive text)", () => {
+    render(Button);
+
+    const btnA = screen.getByTestId("btn-icon-a");
+    const icon = btnA.querySelector(".bx--btn__icon");
+    assert(icon);
+    expect(icon).toHaveAttribute("aria-hidden", "true");
+    expect(icon).not.toHaveAttribute("aria-label");
+  });
+
   it("should set pointer-events to none on assistive text for icon-only buttons", () => {
     render(Button);
 


### PR DESCRIPTION
The icon already has `aria-hidden="true"`, which removes it from the accessibility tree and makes a sibling `aria-label` meaningless. The accessible name comes from the `bx--assistive-text` span.