### PR TITLE
fix(button): prevent literal `true` from leaking into `class`

### DIFF
--- a/src/Button/Button.svelte
+++ b/src/Button/Button.svelte
@@ -163,8 +163,7 @@
         (size === "sm" && !expressive) ||
         (size === "small" && !expressive)) &&
         "bx--btn--sm",
-      (size === "field" && !expressive) ||
-        (size === "md" && !expressive && "bx--btn--md"),
+      size === "md" && !expressive && "bx--btn--md",
       size === "field" && "bx--btn--field",
       size === "small" && "bx--btn--sm",
       size === "lg" && "bx--btn--lg",


### PR DESCRIPTION
Operator precedence (`&&` over `||`) made the `size === "field"` branch evaluate to `true`, which survived `.filter(Boolean)` and stringified into the rendered `class`.

`bx--btn--field` is added by the next entry, so drop the redundant half.