### PR TITLE
fix(button): omit `href` when `disabled` to avoid invalid `<button href>`

### DIFF
--- a/src/Button/Button.svelte
+++ b/src/Button/Button.svelte
@@ -151,9 +151,9 @@
     type: href && !disabled ? undefined : type,
     tabindex,
     disabled: disabled === true ? true : undefined,
-    href,
+    href: href && !disabled ? href : undefined,
     rel:
-      href && $$restProps.target === "_blank"
+      href && !disabled && $$restProps.target === "_blank"
         ? "noopener noreferrer"
         : undefined,
     "aria-pressed":

--- a/tests/Button/Button.test.svelte
+++ b/tests/Button/Button.test.svelte
@@ -36,6 +36,10 @@
 
 <Button disabled>Disabled button</Button>
 
+<Button data-testid="btn-disabled-href" href="#" disabled>
+  Disabled link button
+</Button>
+
 <Button icon={Add}>With icon</Button>
 
 <Button

--- a/tests/Button/Button.test.ts
+++ b/tests/Button/Button.test.ts
@@ -89,6 +89,15 @@ describe("Button", () => {
     expect(disabledButton).toHaveClass("bx--btn--disabled");
   });
 
+  it("should strip href when disabled is also set", () => {
+    render(Button);
+
+    const button = screen.getByTestId("btn-disabled-href");
+    expect(button.tagName).toBe("BUTTON");
+    expect(button).toBeDisabled();
+    expect(button).not.toHaveAttribute("href");
+  });
+
   it("should render skeleton state", () => {
     render(Button);
 


### PR DESCRIPTION
When both `href` and `disabled` are passed, the anchor branch is skipped and `buttonProps.href` would spread onto `<button>`, producing invalid HTML.

Mirror the existing `type` ternary to drop `href` if `disabled` is true.