### PR TITLE
fix(button): dedupe size class logic

### DIFF
--- a/src/Button/Button.svelte
+++ b/src/Button/Button.svelte
@@ -159,14 +159,8 @@
     class: [
       "bx--btn",
       expressive && "bx--btn--expressive",
-      ((size === "small" && !expressive) ||
-        (size === "sm" && !expressive) ||
-        (size === "small" && !expressive)) &&
-        "bx--btn--sm",
-      (size === "field" && !expressive) ||
-        (size === "md" && !expressive && "bx--btn--md"),
-      size === "field" && "bx--btn--field",
       size === "small" && "bx--btn--sm",
+      size === "field" && "bx--btn--field",
       size === "lg" && "bx--btn--lg",
       size === "xl" && "bx--btn--xl",
       kind && `bx--btn--${kind}`,


### PR DESCRIPTION
Remove unnecessary string-building logic. For expressive styles, "small" doesn't work with it anyway (field-size minimum), so loosen/simplify this runtime check.