### PR TITLE
feat(breadcrumb): add `labelText` prop for the nav `aria-label`

### DIFF
--- a/src/Breadcrumb/Breadcrumb.svelte
+++ b/src/Breadcrumb/Breadcrumb.svelte
@@ -7,6 +7,9 @@
   /** Set to `true` to display skeleton state */
   export let skeleton = false;
 
+  /** Specify the ARIA label for the nav */
+  export let labelText = "Breadcrumb";
+
   import BreadcrumbSkeleton from "./BreadcrumbSkeleton.svelte";
 </script>
 
@@ -23,7 +26,7 @@
 {:else}
   <!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
   <nav
-    aria-label="Breadcrumb"
+    aria-label={labelText}
     {...$$restProps}
     on:click
     on:mouseover

--- a/tests/Breadcrumb/Breadcrumb.labelText.test.svelte
+++ b/tests/Breadcrumb/Breadcrumb.labelText.test.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+  import { Breadcrumb, BreadcrumbItem } from "carbon-components-svelte";
+</script>
+
+<Breadcrumb labelText="Page navigation">
+  <BreadcrumbItem href="/">Dashboard</BreadcrumbItem>
+  <BreadcrumbItem href="/reports" isCurrentPage>Reports</BreadcrumbItem>
+</Breadcrumb>

--- a/tests/Breadcrumb/Breadcrumb.test.ts
+++ b/tests/Breadcrumb/Breadcrumb.test.ts
@@ -1,5 +1,6 @@
 import { render, screen, within } from "@testing-library/svelte";
 import BreadcrumbDynamic from "./Breadcrumb.dynamic.test.svelte";
+import BreadcrumbLabelText from "./Breadcrumb.labelText.test.svelte";
 import BreadcrumbNoTrailingSlash from "./Breadcrumb.noTrailingSlash.test.svelte";
 import BreadcrumbSkeleton from "./Breadcrumb.skeleton.test.svelte";
 import Breadcrumb from "./Breadcrumb.test.svelte";
@@ -30,6 +31,13 @@ describe("Breadcrumb", () => {
     expect(links[2]).toHaveTextContent("2019");
     expect(links[2]).toHaveAttribute("href", "/reports/2019");
     expect(items[2]).toHaveClass("bx--breadcrumb-item--current");
+  });
+
+  it("supports custom labelText", () => {
+    render(BreadcrumbLabelText);
+
+    const nav = screen.getByRole("navigation", { name: "Page navigation" });
+    expect(nav).toBeInTheDocument();
   });
 
   it("renders with noTrailingSlash", () => {


### PR DESCRIPTION
Lets localized apps set the `aria-label` directly instead of reaching through `$$restProps`, and surfaces the contract to
TypeScript users. Defaults to `"Breadcrumb"` (no behavior change).