### PR TITLE
fix(breadcrumb): hide skeleton from assistive tech

### DIFF
--- a/src/Breadcrumb/BreadcrumbSkeleton.svelte
+++ b/src/Breadcrumb/BreadcrumbSkeleton.svelte
@@ -9,6 +9,7 @@
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <!-- svelte-ignore a11y-no-static-element-interactions -->
 <div
+  aria-hidden="true"
   class:bx--skeleton={true}
   class:bx--breadcrumb={true}
   class:bx--breadcrumb--no-trailing-slash={noTrailingSlash}

--- a/tests/Breadcrumb/Breadcrumb.test.ts
+++ b/tests/Breadcrumb/Breadcrumb.test.ts
@@ -59,6 +59,7 @@ describe("Breadcrumb", () => {
 
     const firstSkeleton = skeletons[0];
     expect(firstSkeleton).not.toHaveClass("bx--breadcrumb--no-trailing-slash");
+    expect(firstSkeleton).toHaveAttribute("aria-hidden", "true");
 
     const firstSkeletonItems = firstSkeleton.querySelectorAll(
       ".bx--breadcrumb-item",


### PR DESCRIPTION
The skeleton wrapper is a non-semantic `<div>`, so screen readers would announce the placeholder dashes as content if using `<Breadcrumb skeleton />`. Mark it `aria-hidden` to suppress the noise.