### PR TITLE
fix(breadcrumb-item): improve description for slot usage

### DIFF
--- a/docs/src/pages/components/Breadcrumb.svx
+++ b/docs/src/pages/components/Breadcrumb.svx
@@ -56,6 +56,22 @@ Build a full breadcrumb trail with multiple items and a current page indicator.
 
 <FileSource src="/framed/Breadcrumbs/Breadcrumbs" />
 
+## Custom link element
+
+Omit `href` and use `let:props` to render a custom link element (for example, a router link). Spread `props` onto the element to apply the Carbon link class and forward `aria-current` when `isCurrentPage` is set.
+
+<Breadcrumb>
+  <BreadcrumbItem let:props>
+    <a {...props} href="/">Dashboard</a>
+  </BreadcrumbItem>
+  <BreadcrumbItem let:props>
+    <a {...props} href="/reports">Annual reports</a>
+  </BreadcrumbItem>
+  <BreadcrumbItem isCurrentPage let:props>
+    <a {...props} href="/reports/2019">2019</a>
+  </BreadcrumbItem>
+</Breadcrumb>
+
 ## Skeleton
 
 Display a loading state with `skeleton` prop. Use `count` to specify the number of items.

--- a/src/Breadcrumb/BreadcrumbItem.svelte
+++ b/src/Breadcrumb/BreadcrumbItem.svelte
@@ -1,5 +1,13 @@
 <script>
   /**
+   * Spread `props` onto a custom element to inherit the link class
+   * and `aria-current` attribute when `isCurrentPage` is set.
+   * @example
+   * ```svelte
+   * <BreadcrumbItem let:props>
+   *   <a {...props} href="/">Home</a>
+   * </BreadcrumbItem>
+   * ```
    * @slot {{props?: { "aria-current"?: string; class: "bx--link"; }}}
    */
 


### PR DESCRIPTION
The `@slot` annotation describes `props.aria-current` and `props.class`, but it isn't surfaced in the typings file the same way `Button.svelte`'s `as` slot is. Consumers who don't read the JSDoc end up writing `<a class="bx--link">` and forgetting `aria-current`.