### PR TITLE
fix(breadcrumb): apply current class when `aria-current="page"` is set

### DIFF
--- a/src/Breadcrumb/BreadcrumbItem.svelte
+++ b/src/Breadcrumb/BreadcrumbItem.svelte
@@ -22,8 +22,8 @@
 <!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
 <li
   class:bx--breadcrumb-item={true}
-  class:bx--breadcrumb-item--current={isCurrentPage &&
-    $$restProps["aria-current"] !== "page"}
+  class:bx--breadcrumb-item--current={isCurrentPage ||
+    $$restProps["aria-current"] === "page"}
   {...$$restProps}
   on:click
   on:mouseover

--- a/tests/Breadcrumb/Breadcrumb.ariaCurrent.test.svelte
+++ b/tests/Breadcrumb/Breadcrumb.ariaCurrent.test.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+  import { Breadcrumb, BreadcrumbItem } from "carbon-components-svelte";
+</script>
+
+<Breadcrumb>
+  <BreadcrumbItem href="/">Dashboard</BreadcrumbItem>
+  <BreadcrumbItem href="/reports">Annual reports</BreadcrumbItem>
+  <BreadcrumbItem href="/reports/2019" isCurrentPage aria-current="page">
+    2019
+  </BreadcrumbItem>
+</Breadcrumb>

--- a/tests/Breadcrumb/Breadcrumb.test.ts
+++ b/tests/Breadcrumb/Breadcrumb.test.ts
@@ -1,4 +1,5 @@
 import { render, screen, within } from "@testing-library/svelte";
+import BreadcrumbAriaCurrent from "./Breadcrumb.ariaCurrent.test.svelte";
 import BreadcrumbDynamic from "./Breadcrumb.dynamic.test.svelte";
 import BreadcrumbNoTrailingSlash from "./Breadcrumb.noTrailingSlash.test.svelte";
 import BreadcrumbSkeleton from "./Breadcrumb.skeleton.test.svelte";
@@ -90,6 +91,14 @@ describe("Breadcrumb", () => {
     expect(links[2]).toHaveTextContent("2019");
     expect(links[2]).toHaveAttribute("href", "/reports/2019");
     expect(items[2]).toHaveClass("bx--breadcrumb-item--current");
+  });
+
+  it("applies current class when aria-current='page' is set alongside isCurrentPage", () => {
+    render(BreadcrumbAriaCurrent);
+
+    const items = screen.getAllByRole("listitem");
+    expect(items[2]).toHaveClass("bx--breadcrumb-item--current");
+    expect(items[2]).toHaveAttribute("aria-current", "page");
   });
 
   it("updates when dynamic items change", async () => {


### PR DESCRIPTION
The class was suppressed when consumers paired `isCurrentPage` with the ARIA-conventional `aria-current="page"`, de-styling the current item. Apply the class when either signal is present.