### PR TITLE
fix(breadcrumb): avoid leaking `aria-current` onto `<li>` wrapper

### DIFF
--- a/src/Breadcrumb/BreadcrumbItem.svelte
+++ b/src/Breadcrumb/BreadcrumbItem.svelte
@@ -24,26 +24,27 @@
   import Link from "../Link/Link.svelte";
 
   setContext("carbon:BreadcrumbItem", {});
+
+  $: ({ "aria-current": ariaCurrent, ...liProps } = $$restProps);
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
 <li
   class:bx--breadcrumb-item={true}
-  class:bx--breadcrumb-item--current={isCurrentPage ||
-    $$restProps["aria-current"] === "page"}
-  {...$$restProps}
+  class:bx--breadcrumb-item--current={isCurrentPage || ariaCurrent === "page"}
+  {...liProps}
   on:click
   on:mouseover
   on:mouseenter
   on:mouseleave
 >
   {#if href}
-    <Link {href} aria-current={$$restProps["aria-current"]}> <slot /> </Link>
+    <Link {href} aria-current={ariaCurrent}> <slot /> </Link>
   {:else}
     <slot
       props={{
-        "aria-current": $$restProps["aria-current"],
+        "aria-current": ariaCurrent,
         class: "bx--link",
       }}
     />

--- a/src/Breadcrumb/BreadcrumbItem.svelte
+++ b/src/Breadcrumb/BreadcrumbItem.svelte
@@ -8,6 +8,7 @@
    *   <a {...props} href="/">Home</a>
    * </BreadcrumbItem>
    * ```
+   * @restProps {li}
    * @slot {{props?: { "aria-current"?: string; class: "bx--link"; }}}
    */
 

--- a/tests/Breadcrumb/Breadcrumb.test.ts
+++ b/tests/Breadcrumb/Breadcrumb.test.ts
@@ -94,12 +94,16 @@ describe("Breadcrumb", () => {
     expect(items[2]).toHaveClass("bx--breadcrumb-item--current");
   });
 
-  it("applies current class when aria-current='page' is set alongside isCurrentPage", () => {
+  it("applies current class and forwards aria-current to the link, not the <li>", () => {
     render(BreadcrumbAriaCurrent);
 
     const items = screen.getAllByRole("listitem");
+    expect(items).toHaveLength(3);
     expect(items[2]).toHaveClass("bx--breadcrumb-item--current");
-    expect(items[2]).toHaveAttribute("aria-current", "page");
+    expect(items[2]).not.toHaveAttribute("aria-current");
+
+    const links = screen.getAllByRole("link");
+    expect(links[2]).toHaveAttribute("aria-current", "page");
   });
 
   it("updates when dynamic items change", async () => {


### PR DESCRIPTION
Destructure `aria-current` out of `$$restProps` so it lands only on the inner `<Link>`, preventing duplicate "current page" announcements since it can be set on the anchor link and also forwarded to the `<li>` parent.