### PR TITLE
feat(clickable-tile): add `ref` prop for link reference

### DIFF
--- a/src/Tile/ClickableTile.svelte
+++ b/src/Tile/ClickableTile.svelte
@@ -16,6 +16,9 @@
    */
   export let href = undefined;
 
+  /** Obtain a reference to the underlying anchor HTML element */
+  export let ref = null;
+
   import Link from "../Link/Link.svelte";
 
   $: linkClass = [
@@ -30,6 +33,7 @@
 </script>
 
 <Link
+  bind:ref
   {...$$restProps}
   {disabled}
   class={linkClass}

--- a/tests/Tile/ClickableTile.test.svelte
+++ b/tests/Tile/ClickableTile.test.svelte
@@ -1,8 +1,13 @@
+<svelte:options accessors />
+
 <script lang="ts">
   import { ClickableTile } from "carbon-components-svelte";
+  import type { ComponentProps } from "svelte";
+
+  export let ref: ComponentProps<ClickableTile>["ref"] = undefined;
 </script>
 
-<ClickableTile href="https://www.carbondesignsystem.com/">
+<ClickableTile href="https://www.carbondesignsystem.com/" bind:ref>
   Link only
 </ClickableTile>
 

--- a/tests/Tile/ClickableTile.test.ts
+++ b/tests/Tile/ClickableTile.test.ts
@@ -67,4 +67,11 @@ describe("ClickableTile", () => {
     await user.click(disabledTile);
     expect(disabledTile).not.toHaveClass("bx--tile--is-clicked");
   });
+
+  it("should expose a reference to the underlying anchor element", () => {
+    const { component } = render(ClickableTile);
+
+    expect(component.ref).toBeInstanceOf(HTMLAnchorElement);
+    expect(component.ref).toHaveClass("bx--tile--clickable");
+  });
 });


### PR DESCRIPTION
Allow binding to the link reference for imperative focusing etc..