### PR TITLE
fix(clickable-tile): guard `clicked` toggle when `disabled`

### DIFF
--- a/src/Tile/ClickableTile.svelte
+++ b/src/Tile/ClickableTile.svelte
@@ -27,10 +27,12 @@
   {href}
   on:click
   on:click={() => {
+    if (disabled) return;
     clicked = !clicked;
   }}
   on:keydown
   on:keydown={({ key }) => {
+    if (disabled) return;
     if (key === " " || key === "Enter") {
       clicked = !clicked;
     }

--- a/tests/Tile/ClickableTile.test.ts
+++ b/tests/Tile/ClickableTile.test.ts
@@ -50,4 +50,14 @@ describe("ClickableTile", () => {
     expect(disabledTile).toHaveAttribute("aria-disabled", "true");
     expect(disabledTile).toHaveClass("bx--tile--clickable");
   });
+
+  it("should not toggle clicked state when disabled", async () => {
+    render(ClickableTile);
+
+    const disabledTile = screen.getByTestId("disabled-test");
+    expect(disabledTile).not.toHaveClass("bx--tile--is-clicked");
+
+    await user.click(disabledTile);
+    expect(disabledTile).not.toHaveClass("bx--tile--is-clicked");
+  });
 });


### PR DESCRIPTION
The inline `on:click`/`on:keydown` handlers flipped `clicked` unconditionally, so a disabled tile still toggled its
`bx--tile--is-clicked` styling. Skip the toggle when `disabled`.