### PR TITLE
fix(breadcrumb): set `aria-current="page"` on link when `isCurrentPage` is true

### DIFF
--- a/src/Breadcrumb/BreadcrumbItem.svelte
+++ b/src/Breadcrumb/BreadcrumbItem.svelte
@@ -41,11 +41,16 @@
   on:mouseleave
 >
   {#if href}
-    <Link {href} aria-current={ariaCurrent}> <slot /> </Link>
+    <Link
+      {href}
+      aria-current={ariaCurrent ?? (isCurrentPage ? "page" : undefined)}
+    >
+      <slot />
+    </Link>
   {:else}
     <slot
       props={{
-        "aria-current": ariaCurrent,
+        "aria-current": ariaCurrent ?? (isCurrentPage ? "page" : undefined),
         class: "bx--link",
       }}
     />

--- a/tests/Breadcrumb/Breadcrumb.test.ts
+++ b/tests/Breadcrumb/Breadcrumb.test.ts
@@ -31,6 +31,7 @@ describe("Breadcrumb", () => {
     expect(links[2]).toHaveTextContent("2019");
     expect(links[2]).toHaveAttribute("href", "/reports/2019");
     expect(items[2]).toHaveClass("bx--breadcrumb-item--current");
+    expect(links[2]).toHaveAttribute("aria-current", "page");
   });
 
   it("renders with noTrailingSlash", () => {


### PR DESCRIPTION
Currently, `isCurrentPage` prop styled the `<li>` but never propagated to the rendered `<Link>`, so screen readers had no signal for the current page.

Derive a default of `"page"` while letting consumers override via `$$restProps`, and actually apply it to the link.