### PR TITLE
fix: avoid literal false tokens in composed class attributes

### DIFF
--- a/src/ComboBox/ComboBox.svelte
+++ b/src/ComboBox/ComboBox.svelte
@@ -534,6 +534,14 @@
   ) {
     highlightedIndex = -1;
   }
+
+  $: comboBoxListBoxClass = [
+    "bx--combo-box",
+    direction === "top" && "bx--list-box--up",
+    !invalid && warn && "bx--combo-box--warning",
+  ]
+    .filter(Boolean)
+    .join(" ");
 </script>
 
 <svelte:window
@@ -561,8 +569,7 @@
     </label>
   {/if}
   <ListBox
-    class="bx--combo-box {direction === 'top' &&
-      'bx--list-box--up'} {!invalid && warn && 'bx--combo-box--warning'}"
+    class={comboBoxListBoxClass}
     id={comboId}
     aria-label={ariaLabel}
     {disabled}

--- a/src/Dropdown/Dropdown.svelte
+++ b/src/Dropdown/Dropdown.svelte
@@ -451,6 +451,21 @@
       open = false;
     }
   }
+
+  $: dropdownListBoxClass = [
+    "bx--dropdown",
+    direction === "top" && "bx--list-box--up",
+    invalid && "bx--dropdown--invalid",
+    !invalid && warn && "bx--dropdown--warning",
+    open && "bx--dropdown--open",
+    size === "sm" && "bx--dropdown--sm",
+    size === "xl" && "bx--dropdown--xl",
+    inline && "bx--dropdown--inline",
+    disabled && "bx--dropdown--disabled",
+    light && "bx--dropdown--light",
+  ]
+    .filter(Boolean)
+    .join(" ");
 </script>
 
 <svelte:window
@@ -486,16 +501,7 @@
     {size}
     {name}
     aria-label={$$props["aria-label"]}
-    class="bx--dropdown
-      {direction === 'top' && 'bx--list-box--up'}
-      {invalid && 'bx--dropdown--invalid'}
-      {!invalid && warn && 'bx--dropdown--warning'}
-      {open && 'bx--dropdown--open'}
-      {size === 'sm' && 'bx--dropdown--sm'}
-      {size === 'xl' && 'bx--dropdown--xl'}
-      {inline && 'bx--dropdown--inline'}
-      {disabled && 'bx--dropdown--disabled'}
-      {light && 'bx--dropdown--light'}"
+    class={dropdownListBoxClass}
     on:click={({ target }) => {
       if (disabled) return;
       open = ref.contains(target) ? !open : false;

--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -555,6 +555,19 @@
   $: itemsToRender = virtualData?.isVirtualized
     ? virtualData.visibleItems
     : itemsToUse;
+
+  $: multiSelectListBoxClass = [
+    "bx--multi-select",
+    direction === "top" && "bx--list-box--up",
+    filterable && "bx--combo-box",
+    filterable && "bx--multi-select--filterable",
+    invalid && "bx--multi-select--invalid",
+    inline && "bx--multi-select--inline",
+    selectionCount > 0 && "bx--multi-select--selected",
+    hasSelectAll && "bx--multi-select--selectall",
+  ]
+    .filter(Boolean)
+    .join(" ");
 </script>
 
 <svelte:window
@@ -602,13 +615,7 @@
     {size}
     {warn}
     {warnText}
-    class="bx--multi-select {direction === 'top' &&
-      'bx--list-box--up'} {filterable && 'bx--combo-box'}
-      {filterable && 'bx--multi-select--filterable'}
-      {invalid && 'bx--multi-select--invalid'}
-      {inline && 'bx--multi-select--inline'}
-      {selectionCount > 0 && 'bx--multi-select--selected'}
-      {hasSelectAll && 'bx--multi-select--selectall'}"
+    class={multiSelectListBoxClass}
   >
     {#if invalid}
       <WarningFilled class="bx--list-box__invalid-icon" />

--- a/src/Notification/NotificationButton.svelte
+++ b/src/Notification/NotificationButton.svelte
@@ -25,6 +25,13 @@
   export let iconDescription = "Close icon";
 
   import Close from "../icons/Close.svelte";
+
+  $: iconClass = [
+    notificationType === "toast" && "bx--toast-notification__close-icon",
+    notificationType === "inline" && "bx--inline-notification__close-icon",
+  ]
+    .filter(Boolean)
+    .join(" ");
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
@@ -40,12 +47,5 @@
   on:mouseenter
   on:mouseleave
 >
-  <svelte:component
-    this={icon}
-    size={20}
-    {title}
-    class="{notificationType === 'toast' &&
-      'bx--toast-notification__close-icon'} {notificationType === 'inline' &&
-      'bx--inline-notification__close-icon'}"
-  />
+  <svelte:component this={icon} size={20} {title} class={iconClass} />
 </button>

--- a/src/Notification/NotificationIcon.svelte
+++ b/src/Notification/NotificationIcon.svelte
@@ -29,13 +29,18 @@
     warning: WarningFilled,
     "warning-alt": WarningAltFilled,
   };
+
+  $: iconClass = [
+    notificationType === "toast" && "bx--toast-notification__icon",
+    notificationType === "inline" && "bx--inline-notification__icon",
+  ]
+    .filter(Boolean)
+    .join(" ");
 </script>
 
 <svelte:component
   this={icons[kind]}
   size={20}
   title={iconDescription}
-  class="{notificationType === 'toast' &&
-    'bx--toast-notification__icon'} {notificationType === 'inline' &&
-    'bx--inline-notification__icon'}"
+  class={iconClass}
 />

--- a/src/Tile/ClickableTile.svelte
+++ b/src/Tile/ClickableTile.svelte
@@ -17,13 +17,22 @@
   export let href = undefined;
 
   import Link from "../Link/Link.svelte";
+
+  $: linkClass = [
+    "bx--tile",
+    "bx--tile--clickable",
+    clicked && "bx--tile--is-clicked",
+    light && "bx--tile--light",
+    $$restProps.class,
+  ]
+    .filter(Boolean)
+    .join(" ");
 </script>
 
 <Link
   {...$$restProps}
   {disabled}
-  class="bx--tile bx--tile--clickable {clicked &&
-    'bx--tile--is-clicked'} {light && 'bx--tile--light'} {$$restProps.class}"
+  class={linkClass}
   {href}
   on:click
   on:click={() => {

--- a/src/TreeView/TreeViewNodeList.svelte
+++ b/src/TreeView/TreeViewNodeList.svelte
@@ -156,8 +156,12 @@
         }}
       >
         <CaretDown
-          class="bx--tree-parent-node__toggle-icon {expanded &&
-            'bx--tree-parent-node__toggle-icon--expanded'}"
+          class={[
+            "bx--tree-parent-node__toggle-icon",
+            expanded && "bx--tree-parent-node__toggle-icon--expanded",
+          ]
+            .filter(Boolean)
+            .join(" ")}
         />
       </span>
       <span class:bx--tree-node__label__details={true}>

--- a/tests/Tile/ClickableTile.test.ts
+++ b/tests/Tile/ClickableTile.test.ts
@@ -11,6 +11,13 @@ describe("ClickableTile", () => {
     expect(tile).toHaveClass("bx--tile", "bx--tile--clickable");
   });
 
+  it("should not include a literal false token in the class attribute", () => {
+    render(ClickableTile);
+
+    const tile = screen.getByText("Link only");
+    expect(tile.className).not.toMatch(/\bfalse\b/);
+  });
+
   it("should render light variant with other attributes", () => {
     render(ClickableTile);
 


### PR DESCRIPTION
Svelte turns `{cond && 'class'}` inside quoted `class="..."` into the substring `false`. This leaks "false" as a class in the DOM.

Instead, compose classes in a reactive array and use `.filter(Boolean).join(" ")` to filter out falsy values.