### PR TITLE
fix(code-snippet): default inline copy button label to "Copy code"

### DIFF
--- a/src/CodeSnippet/CodeSnippet.svelte
+++ b/src/CodeSnippet/CodeSnippet.svelte
@@ -74,7 +74,7 @@
    * Specify the ARIA label of the copy button.
    * @type {string}
    */
-  export let copyLabel = undefined;
+  export let copyLabel = "Copy code";
 
   /** Specify the feedback text displayed when clicking the snippet */
   export let feedback = "Copied!";

--- a/tests/CodeSnippet/CodeSnippet.test.ts
+++ b/tests/CodeSnippet/CodeSnippet.test.ts
@@ -40,6 +40,13 @@ describe("CodeSnippet", () => {
     expect(screen.getByText("npm install -g @carbon/cli")).toBeInTheDocument();
   });
 
+  // Inline copy button defaults its accessible name to "Copy code"
+  // so AT users don't hear the full snippet read as the button name.
+  test("inline copy button has default 'Copy code' aria-label", () => {
+    render(CodeSnippetInline);
+    expect(screen.getByLabelText("Copy code")).toBeInTheDocument();
+  });
+
   test("should render multiline variant", () => {
     const { container } = render(CodeSnippetMultiline);
     expect(container.querySelector(".bx--snippet--multi")).toBeInTheDocument();


### PR DESCRIPTION
Without a default, `aria-label={copyLabel}` resolved to no value and the inline `<button>` took its accessible name from the
`<code>` content (AT users heard the full snippet read aloud).