### PR TITLE
fix(code-snippet): remove redundant `aria-label` from expand chevron

### DIFF
--- a/src/CodeSnippet/CodeSnippet.svelte
+++ b/src/CodeSnippet/CodeSnippet.svelte
@@ -326,7 +326,7 @@
         <span class:bx--snippet-btn--text={true}>{expandText}</span>
         <ChevronDown
           class="bx--icon-chevron--down bx--snippet__icon"
-          aria-label={expandText}
+          aria-hidden="true"
         />
       </Button>
     {/if}

--- a/tests/CodeSnippet/CodeSnippet.test.ts
+++ b/tests/CodeSnippet/CodeSnippet.test.ts
@@ -68,6 +68,16 @@ describe("CodeSnippet", () => {
     expect(screen.getByText("Show more")).toBeInTheDocument();
   });
 
+  // Regression: chevron should not duplicate the button's accessible name
+  test("should not set aria-label on the expand chevron", () => {
+    const { container } = render(CodeSnippetExpandable);
+
+    const chevron = container.querySelector(".bx--icon-chevron--down");
+    assert(chevron);
+    expect(chevron).toHaveAttribute("aria-hidden", "true");
+    expect(chevron).not.toHaveAttribute("aria-label");
+  });
+
   test("should render expanded by default", async () => {
     const { container } = render(CodeSnippetExpandedByDefault);
 


### PR DESCRIPTION
The visible "Show more"/"Show less" text in the sibling span already labels the button, so the chevron's `aria-label` duplicated the accessible name. Mark it `aria-hidden` instead.