### PR TITLE
fix(code-snippet): mark `textbox` container as readonly

### DIFF
--- a/src/CodeSnippet/CodeSnippet.svelte
+++ b/src/CodeSnippet/CodeSnippet.svelte
@@ -289,8 +289,10 @@
   >
     <!-- svelte-ignore a11y-no-noninteractive-tabindex -->
     <div
-      role={type === "single" ? "textbox" : undefined}
-      tabindex={type === "single" && !disabled ? "0" : undefined}
+      role="textbox"
+      tabindex={disabled ? undefined : "0"}
+      aria-readonly="true"
+      aria-multiline={type === "multi" ? "true" : undefined}
       aria-label={$$restProps["aria-label"] ?? copyLabel ?? "code-snippet"}
       class:bx--snippet-container={true}
       style:width="100%"

--- a/tests/CodeSnippet/CodeSnippet.test.ts
+++ b/tests/CodeSnippet/CodeSnippet.test.ts
@@ -2,6 +2,7 @@ import { render, screen } from "@testing-library/svelte";
 import { user } from "../setup-tests";
 import CodeSnippetCopyButton from "./CodeSnippetCopyButton.test.svelte";
 import CodeSnippetCustomEvents from "./CodeSnippetCustomEvents.test.svelte";
+import CodeSnippetDisabled from "./CodeSnippetDisabled.test.svelte";
 import CodeSnippetExpandable from "./CodeSnippetExpandable.test.svelte";
 import CodeSnippetExpandedByDefault from "./CodeSnippetExpandedByDefault.svelte";
 import CodeSnippetInitialEvent from "./CodeSnippetInitialEvent.test.svelte";
@@ -169,6 +170,47 @@ describe("CodeSnippet", () => {
     expect(root).toBeInTheDocument();
     expect(root.tagName.toLowerCase()).toBe("div");
     expect(root).toHaveClass("bx--snippet--single");
+  });
+
+  // Regression: textbox role must declare aria-readonly since the
+  // container is non-editable (pairs textbox with WAI readonly pattern)
+  test("marks single variant as a readonly textbox", () => {
+    const { container } = render(CodeSnippetCopyButton);
+    const snippet = container.querySelector(".bx--snippet-container");
+    expect(snippet).toHaveAttribute("role", "textbox");
+    expect(snippet).toHaveAttribute("aria-readonly", "true");
+    expect(snippet).toHaveAttribute("tabindex", "0");
+    expect(snippet).not.toHaveAttribute("aria-multiline");
+  });
+
+  test("marks multi variant as a readonly multiline textbox", () => {
+    const { container } = render(CodeSnippetMultiline);
+    const snippet = container.querySelector(".bx--snippet-container");
+    expect(snippet).toHaveAttribute("role", "textbox");
+    expect(snippet).toHaveAttribute("aria-readonly", "true");
+    expect(snippet).toHaveAttribute("aria-multiline", "true");
+    expect(snippet).toHaveAttribute("tabindex", "0");
+  });
+
+  test("omits tabindex when disabled (single)", () => {
+    const { container } = render(CodeSnippetDisabled, {
+      props: { type: "single" },
+    });
+    const snippet = container.querySelector(".bx--snippet-container");
+    expect(snippet).toHaveAttribute("role", "textbox");
+    expect(snippet).toHaveAttribute("aria-readonly", "true");
+    expect(snippet).not.toHaveAttribute("tabindex");
+  });
+
+  test("omits tabindex when disabled (multi)", () => {
+    const { container } = render(CodeSnippetDisabled, {
+      props: { type: "multi" },
+    });
+    const snippet = container.querySelector(".bx--snippet-container");
+    expect(snippet).toHaveAttribute("role", "textbox");
+    expect(snippet).toHaveAttribute("aria-readonly", "true");
+    expect(snippet).toHaveAttribute("aria-multiline", "true");
+    expect(snippet).not.toHaveAttribute("tabindex");
   });
 
   // Regression: ?? for aria-label so empty string is used (not fallback)

--- a/tests/CodeSnippet/CodeSnippetDisabled.test.svelte
+++ b/tests/CodeSnippet/CodeSnippetDisabled.test.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  import { CodeSnippet } from "carbon-components-svelte";
+
+  export let type: "single" | "multi" = "single";
+</script>
+
+<CodeSnippet {type} disabled code="npm install --save @carbon/icons" />


### PR DESCRIPTION
ARIA `textbox` implies editable input; pair it with `aria-readonly` (plus `aria-multiline` for `multi`) so AT no longer expose phantom edit affordances on the `<pre>` container.