### PR TITLE
chore(content-switcher): replace reactive assignments with `let`

### DIFF
--- a/src/ContentSwitcher/ContentSwitcher.svelte
+++ b/src/ContentSwitcher/ContentSwitcher.svelte
@@ -33,9 +33,9 @@
 
   let prevIndex = -1;
 
-  $: currentIndex = -1;
-  $: focusedIndex = -1;
-  $: switches = [];
+  let currentIndex = -1;
+  let focusedIndex = -1;
+  let switches = [];
   $: if (switches[currentIndex]) {
     if (prevIndex > -1 && prevIndex !== currentIndex) {
       dispatch("change", currentIndex);


### PR DESCRIPTION
These lines declare reactive statements with no dependencies, so they execute once at component init. The `$:` prefix misleads readers into thinking they re-run, and `currentIndex` is then reassigned imperatively in `afterUpdate`. Mixing reactive declarations and imperative writes makes the data flow harder to reason about than it needs to be.