### PR TITLE
fix(code-snippet): re-attach modal observer when `portalTooltip` toggles

### DIFF
--- a/src/CodeSnippet/CodeSnippet.svelte
+++ b/src/CodeSnippet/CodeSnippet.svelte
@@ -171,13 +171,18 @@
     prevExpanded = expanded;
   }
 
-  onMount(() => {
+  let disconnectModalObserver = () => {};
+
+  $: {
     const el = inlineButtonRef || ref;
-    const disconnectModalObserver =
+    disconnectModalObserver();
+    disconnectModalObserver =
       effectivePortalTooltip && el
         ? observeModalClose(el, dismissFeedback)
         : () => {};
+  }
 
+  onMount(() => {
     return () => {
       clearTimeout(timeout);
       feedbackOpen = false;

--- a/src/CopyButton/CopyButton.svelte
+++ b/src/CopyButton/CopyButton.svelte
@@ -59,12 +59,17 @@
     clearTimeout(timeout);
   }
 
-  onMount(() => {
-    const disconnectModalObserver =
+  let disconnectModalObserver = () => {};
+
+  $: {
+    disconnectModalObserver();
+    disconnectModalObserver =
       effectivePortalTooltip && buttonRef
         ? observeModalClose(buttonRef, dismissFeedback)
         : () => {};
+  }
 
+  onMount(() => {
     return () => {
       clearTimeout(timeout);
       feedbackOpen = false;

--- a/tests/CodeSnippet/CodeSnippetPortalTooltip.test.ts
+++ b/tests/CodeSnippet/CodeSnippetPortalTooltip.test.ts
@@ -46,5 +46,27 @@ describe("CodeSnippet portal tooltip", () => {
         button.querySelector(".bx--copy-btn__feedback"),
       ).toBeInTheDocument();
     });
+
+    // Regression: observer must re-attach when portalTooltip flips after mount.
+    it("should dismiss portal feedback when modal closes after portalTooltip toggled on", async () => {
+      const { rerender } = render(CodeSnippetInlineInModal, {
+        props: { modalOpen: true, portalTooltip: false },
+      });
+
+      rerender({ modalOpen: true, portalTooltip: true });
+
+      const button = screen.getByRole("button", { name: "Copy code" });
+      await user.click(button);
+      expect(
+        document.querySelector("[data-floating-portal]"),
+      ).toBeInTheDocument();
+
+      rerender({ modalOpen: false, portalTooltip: true });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(
+        document.querySelector("[data-floating-portal]"),
+      ).not.toBeInTheDocument();
+    });
   });
 });

--- a/tests/CopyButton/CopyButton.test.ts
+++ b/tests/CopyButton/CopyButton.test.ts
@@ -140,5 +140,30 @@ describe("CopyButton", () => {
         button.querySelector(".bx--copy-btn__feedback"),
       ).toBeInTheDocument();
     });
+
+    // Regression: observer must re-attach when portalTooltip flips after mount.
+    // Previously, the observer was registered once in onMount; toggling
+    // portalTooltip from false -> true left no observer, so closing the modal
+    // did not dismiss the open portal tooltip.
+    it("should dismiss portal feedback when modal closes after portalTooltip toggled on", async () => {
+      const { rerender } = render(CopyButtonInModal, {
+        props: { modalOpen: true, portalTooltip: false },
+      });
+
+      rerender({ modalOpen: true, portalTooltip: true });
+
+      const button = getCopyButton("Copy");
+      await user.click(button);
+      expect(
+        document.querySelector("[data-floating-portal]"),
+      ).toBeInTheDocument();
+
+      rerender({ modalOpen: false, portalTooltip: true });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(
+        document.querySelector("[data-floating-portal]"),
+      ).not.toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
The modal-close `MutationObserver` was attached once in `onMount`, so flipping `portalTooltip` after mount left no observer registered and the portalled feedback stayed visible when the modal closed. Move setup into a reactive block keyed on `effectivePortalTooltip`.

Affects `portalTooltip` usage in `CopyButton` and `CodeSnippet`.