### PR TITLE
fix(switch): remove useless `preventDefault` modifier

### DIFF
--- a/src/ContentSwitcher/Switch.svelte
+++ b/src/ContentSwitcher/Switch.svelte
@@ -51,7 +51,7 @@
   class:bx--content-switcher--selected={selected}
   {...$$restProps}
   on:click
-  on:click|preventDefault={() => {
+  on:click={() => {
     ctx.update(id);
   }}
   on:mouseover


### PR DESCRIPTION
Drop the `|preventDefault` modifier since it's unnecessary on `button type="button"`.