### PR TITLE
fix(content-switcher): support Home/End keyboard shortcuts

### DIFF
--- a/src/ContentSwitcher/ContentSwitcher.svelte
+++ b/src/ContentSwitcher/ContentSwitcher.svelte
@@ -74,6 +74,20 @@
   };
 
   /**
+   * @type {(index: number) => Promise<void>}
+   */
+  const changeTo = async (index) => {
+    selectedIndex = index;
+
+    await tick();
+    const tab = document.getElementById(switches[index].id);
+
+    if (tab instanceof HTMLElement) {
+      tab.focus();
+    }
+  };
+
+  /**
    * @type {(direction: number) => Promise<void>}
    */
   const change = async (direction) => {
@@ -85,7 +99,15 @@
       index = 0;
     }
 
-    selectedIndex = index;
+    await changeTo(index);
+  };
+
+  /**
+   * Move focus to a switch at an absolute index without changing selection.
+   * @type {(index: number) => Promise<void>}
+   */
+  const focusTo = async (index) => {
+    focusedIndex = index;
 
     await tick();
     const tab = document.getElementById(switches[index].id);
@@ -109,14 +131,7 @@
       index = 0;
     }
 
-    focusedIndex = index;
-
-    await tick();
-    const tab = document.getElementById(switches[index].id);
-
-    if (tab instanceof HTMLElement) {
-      tab.focus();
-    }
+    await focusTo(index);
   };
 
   setContext("carbon:ContentSwitcher", {
@@ -125,7 +140,12 @@
     remove,
     update,
     change,
+    changeTo,
     focus,
+    focusTo,
+    get switchCount() {
+      return switches.length;
+    },
     get selectionMode() {
       return selectionMode;
     },

--- a/src/ContentSwitcher/Switch.svelte
+++ b/src/ContentSwitcher/Switch.svelte
@@ -61,11 +61,18 @@
   on:mouseenter
   on:mouseleave
   on:keydown
-  on:keydown={({ key }) => {
-    if (key === "ArrowRight") {
+  on:keydown={(e) => {
+    if (e.key === "ArrowRight") {
       ctx.selectionMode === "manual" ? ctx.focus(1) : ctx.change(1);
-    } else if (key === "ArrowLeft") {
+    } else if (e.key === "ArrowLeft") {
       ctx.selectionMode === "manual" ? ctx.focus(-1) : ctx.change(-1);
+    } else if (e.key === "Home") {
+      e.preventDefault();
+      ctx.selectionMode === "manual" ? ctx.focusTo(0) : ctx.changeTo(0);
+    } else if (e.key === "End") {
+      e.preventDefault();
+      const last = ctx.switchCount - 1;
+      ctx.selectionMode === "manual" ? ctx.focusTo(last) : ctx.changeTo(last);
     }
   }}
 >

--- a/tests/ContentSwitcher/ContentSwitcher.test.ts
+++ b/tests/ContentSwitcher/ContentSwitcher.test.ts
@@ -189,6 +189,24 @@ describe("ContentSwitcher", () => {
     expect(outerTabs[0]).toHaveClass("bx--content-switcher--selected");
   });
 
+  it("Home/End jump to first/last tab", async () => {
+    render(ContentSwitcher);
+
+    const tabs = screen.getAllByRole("tab");
+    await user.tab();
+    expect(document.activeElement).toBe(tabs[0]);
+
+    await user.keyboard("{End}");
+    expect(document.activeElement).toBe(tabs[2]);
+    expect(tabs[2]).toHaveClass("bx--content-switcher--selected");
+    expect(tabs[0]).not.toHaveClass("bx--content-switcher--selected");
+
+    await user.keyboard("{Home}");
+    expect(document.activeElement).toBe(tabs[0]);
+    expect(tabs[0]).toHaveClass("bx--content-switcher--selected");
+    expect(tabs[2]).not.toHaveClass("bx--content-switcher--selected");
+  });
+
   it("respects disabled state", async () => {
     render(ContentSwitcherDisabled);
 
@@ -386,6 +404,23 @@ describe("ContentSwitcher", () => {
       expect(document.activeElement).toBe(tabs[2]);
 
       await user.keyboard("{ArrowRight}");
+      expect(document.activeElement).toBe(tabs[0]);
+      expect(tabs[0]).toHaveClass("bx--content-switcher--selected");
+    });
+
+    it("Home/End move focus without changing selection", async () => {
+      render(ContentSwitcherSelectionMode);
+
+      const tabs = screen.getAllByRole("tab");
+      await user.tab();
+      expect(document.activeElement).toBe(tabs[0]);
+
+      await user.keyboard("{End}");
+      expect(document.activeElement).toBe(tabs[2]);
+      expect(tabs[0]).toHaveClass("bx--content-switcher--selected");
+      expect(tabs[2]).not.toHaveClass("bx--content-switcher--selected");
+
+      await user.keyboard("{Home}");
       expect(document.activeElement).toBe(tabs[0]);
       expect(tabs[0]).toHaveClass("bx--content-switcher--selected");
     });


### PR DESCRIPTION
The keydown handler responds to ArrowLeft/ArrowRight but not Home or End. WAI-ARIA's tablist pattern requires Home → first tab, End → last tab.