### PR TITLE
fix(content-switcher): unregister `Switch` from parent on destroy

### DIFF
--- a/src/ContentSwitcher/ContentSwitcher.svelte
+++ b/src/ContentSwitcher/ContentSwitcher.svelte
@@ -48,11 +48,22 @@
    * @type {(data: { id: string; text: string; selected: boolean }) => void}
    */
   const add = ({ id, text, selected }) => {
+    if (switches.some((s) => s.id === id)) {
+      return;
+    }
+
     if (selected) {
       selectedIndex = switches.length;
     }
 
     switches = [...switches, { id, text, selected }];
+  };
+
+  /**
+   * @type {(id: string) => void}
+   */
+  const remove = (id) => {
+    switches = switches.filter((s) => s.id !== id);
   };
 
   /**
@@ -113,6 +124,7 @@
   setContext("carbon:ContentSwitcher", {
     currentId,
     add,
+    remove,
     update,
     change,
     focus,

--- a/src/ContentSwitcher/Switch.svelte
+++ b/src/ContentSwitcher/Switch.svelte
@@ -34,7 +34,10 @@
   });
 
   onMount(() => {
-    return () => unsubscribe();
+    return () => {
+      ctx.remove(id);
+      unsubscribe();
+    };
   });
 </script>
 

--- a/tests/ContentSwitcher/ContentSwitcher.dynamic.test.svelte
+++ b/tests/ContentSwitcher/ContentSwitcher.dynamic.test.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+  import { ContentSwitcher, Switch } from "carbon-components-svelte";
+
+  export let show = true;
+</script>
+
+<ContentSwitcher>
+  <Switch text="First" />
+  {#if show}
+    <Switch text="Middle" />
+  {/if}
+  <Switch text="Last" />
+</ContentSwitcher>

--- a/tests/ContentSwitcher/ContentSwitcher.test.ts
+++ b/tests/ContentSwitcher/ContentSwitcher.test.ts
@@ -2,6 +2,7 @@ import { render, screen, within } from "@testing-library/svelte";
 import { user } from "../setup-tests";
 import ContentSwitcherCustom from "./ContentSwitcher.custom.test.svelte";
 import ContentSwitcherDisabled from "./ContentSwitcher.disabled.test.svelte";
+import ContentSwitcherDynamic from "./ContentSwitcher.dynamic.test.svelte";
 import ContentSwitcherSelectedIndex from "./ContentSwitcher.selectedIndex.test.svelte";
 import ContentSwitcherSelectionMode from "./ContentSwitcher.selectionMode.test.svelte";
 import ContentSwitcherSize from "./ContentSwitcher.size.test.svelte";
@@ -242,6 +243,31 @@ describe("ContentSwitcher", () => {
     assert(component.switchRef);
     expect(component.switchRef).toBeInstanceOf(HTMLButtonElement);
     expect(component.switchRef.type).toBe("button");
+  });
+
+  it("unregisters a destroyed Switch so keyboard wrap-around uses the visible tabs", async () => {
+    const { rerender } = render(ContentSwitcherDynamic, {
+      props: { show: true },
+    });
+
+    expect(screen.getAllByRole("tab")).toHaveLength(3);
+
+    await rerender({ show: false });
+
+    const tabs = screen.getAllByRole("tab");
+    expect(tabs).toHaveLength(2);
+    expect(tabs[0]).toHaveTextContent("First");
+    expect(tabs[1]).toHaveTextContent("Last");
+
+    await user.tab();
+    expect(document.activeElement).toBe(tabs[0]);
+
+    // ArrowLeft from the first tab should wrap to the last visible tab.
+    // If the destroyed middle Switch is still in the parent's registry,
+    // currentIndex wraps onto a phantom entry and focus never moves.
+    await user.keyboard("{ArrowLeft}");
+    expect(document.activeElement).toBe(tabs[1]);
+    expect(tabs[1]).toHaveClass("bx--content-switcher--selected");
   });
 
   describe('selectionMode="manual"', () => {


### PR DESCRIPTION
`Switch` only unsubscribed from `currentId` on destroy, leaving its entry in the parent's `switches` array. Conditional or keyed Switches caused stale entries, so `selectedIndex` and arrow-key wrap-around could land on phantom tabs whose DOM no longer existed.