### PR TITLE
fix(content-switcher): scope tab lookup to registered switches

### DIFF
--- a/src/ContentSwitcher/ContentSwitcher.svelte
+++ b/src/ContentSwitcher/ContentSwitcher.svelte
@@ -88,8 +88,7 @@
     selectedIndex = index;
 
     await tick();
-    const tabs = refContainer?.querySelectorAll("[role='tab']");
-    const tab = tabs?.[index];
+    const tab = document.getElementById(switches[index].id);
 
     if (tab instanceof HTMLElement) {
       tab.focus();
@@ -113,8 +112,7 @@
     focusedIndex = index;
 
     await tick();
-    const tabs = refContainer?.querySelectorAll("[role='tab']");
-    const tab = tabs?.[index];
+    const tab = document.getElementById(switches[index].id);
 
     if (tab instanceof HTMLElement) {
       tab.focus();

--- a/tests/ContentSwitcher/ContentSwitcher.nested.test.svelte
+++ b/tests/ContentSwitcher/ContentSwitcher.nested.test.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+  import { ContentSwitcher, Switch } from "carbon-components-svelte";
+</script>
+
+<ContentSwitcher>
+  <Switch text="Outer 1" />
+  <Switch>
+    <span data-testid="nested-tab" role="tab">Nested tab</span>
+  </Switch>
+  <Switch text="Outer 3" />
+</ContentSwitcher>

--- a/tests/ContentSwitcher/ContentSwitcher.test.ts
+++ b/tests/ContentSwitcher/ContentSwitcher.test.ts
@@ -3,6 +3,7 @@ import { user } from "../setup-tests";
 import ContentSwitcherCustom from "./ContentSwitcher.custom.test.svelte";
 import ContentSwitcherDisabled from "./ContentSwitcher.disabled.test.svelte";
 import ContentSwitcherDynamic from "./ContentSwitcher.dynamic.test.svelte";
+import ContentSwitcherNested from "./ContentSwitcher.nested.test.svelte";
 import ContentSwitcherSelectedIndex from "./ContentSwitcher.selectedIndex.test.svelte";
 import ContentSwitcherSelectionMode from "./ContentSwitcher.selectionMode.test.svelte";
 import ContentSwitcherSize from "./ContentSwitcher.size.test.svelte";
@@ -155,6 +156,37 @@ describe("ContentSwitcher", () => {
     expect(tabs[0]).not.toHaveClass("bx--content-switcher--selected");
     expect(tabs[2]).toHaveClass("bx--content-switcher--selected");
     expect(document.activeElement).toBe(tabs[2]);
+  });
+
+  it("ignores nested [role='tab'] elements inside switch slots when navigating", async () => {
+    render(ContentSwitcherNested);
+
+    const tablist = screen.getByRole("tablist");
+    const switchTabs = within(tablist).getAllByRole("tab", {
+      name: /Outer|Nested tab/,
+    });
+    expect(switchTabs).toHaveLength(4);
+
+    const outerTabs = within(tablist)
+      .getAllByRole("tab")
+      .filter((el) => el.tagName === "BUTTON");
+    expect(outerTabs).toHaveLength(3);
+    expect(outerTabs[0]).toHaveClass("bx--content-switcher--selected");
+
+    await user.tab();
+    expect(document.activeElement).toBe(outerTabs[0]);
+
+    await user.keyboard("{ArrowRight}");
+    expect(document.activeElement).toBe(outerTabs[1]);
+    expect(outerTabs[1]).toHaveClass("bx--content-switcher--selected");
+
+    await user.keyboard("{ArrowRight}");
+    expect(document.activeElement).toBe(outerTabs[2]);
+    expect(outerTabs[2]).toHaveClass("bx--content-switcher--selected");
+
+    await user.keyboard("{ArrowRight}");
+    expect(document.activeElement).toBe(outerTabs[0]);
+    expect(outerTabs[0]).toHaveClass("bx--content-switcher--selected");
   });
 
   it("respects disabled state", async () => {


### PR DESCRIPTION
`querySelectorAll("[role='tab']")` on the container was unscoped, so a nested `[role='tab']` rendered inside a `Switch` slot polluted the navigation set. Look up the element by `switches[index].id`, which is more elegant, anyway.