### PR TITLE
feat(context-menu): add `labelText` prop

### DIFF
--- a/docs/src/pages/components/ContextMenu.svx
+++ b/docs/src/pages/components/ContextMenu.svx
@@ -12,6 +12,8 @@ In the examples, right click anywhere within the iframe.
 ## Basic
 
 The context menu appears when right-clicking anywhere in the window. Use context menu option for menu items and context menu divider for visual separation.
+
+The root element has `role="menu"`. Set `labelText` or `aria-label` on `ContextMenu` so assistive technologies get a meaningful name. This matters most for the default window-wide behavior (`target` unset), where there is no visible trigger to label the menu with `aria-labelledby`.
   
 <FileSource src="/framed/ContextMenu/ContextMenu" />
 

--- a/docs/src/pages/framed/ContextMenu/ContextMenu.svelte
+++ b/docs/src/pages/framed/ContextMenu/ContextMenu.svelte
@@ -9,7 +9,7 @@
   import TrashCan from "carbon-icons-svelte/lib/TrashCan.svelte";
 </script>
 
-<ContextMenu>
+<ContextMenu labelText="Menu actions">
   <ContextMenuOption labelText="Copy" shortcutText="⌘C" icon={CopyFile} />
   <ContextMenuOption labelText="Cut" shortcutText="⌘X" icon={Cut} />
   <ContextMenuDivider />

--- a/src/ContextMenu/ContextMenu.svelte
+++ b/src/ContextMenu/ContextMenu.svelte
@@ -25,6 +25,14 @@
   /** Obtain a reference to the unordered list HTML element */
   export let ref = null;
 
+  /**
+   * Accessible name for the menu.
+   * Prefer setting this (or `aria-label`) when the menu is opened from the window
+   * (`target` unset), where there is no visible trigger for `aria-labelledby`.
+   * @type {string | undefined}
+   */
+  export let labelText = undefined;
+
   import {
     afterUpdate,
     createEventDispatcher,
@@ -155,6 +163,7 @@
 
   $: level = ctx ? 2 : 1;
   $: currentIndex.set(focusIndex);
+  $: menuAriaLabel = ($$props["aria-label"] ?? labelText) || undefined;
 </script>
 
 <svelte:window
@@ -189,6 +198,7 @@
   style:left="{x}px"
   style:top="{y}px"
   {...$$restProps}
+  aria-label={menuAriaLabel}
   on:click
   on:click={({ target }) => {
     const closestOption = target.closest("[tabindex]");

--- a/tests/ContextMenu/ContextMenu.test.svelte
+++ b/tests/ContextMenu/ContextMenu.test.svelte
@@ -11,6 +11,8 @@
   export let withDisabled = false;
   export let submenuDisabled = false;
   export let optionDisabled = false;
+  export let labelText: ComponentProps<ContextMenu>["labelText"] = undefined;
+  export let ariaLabel: string | undefined = undefined;
 </script>
 
 <div data-testid="target">Right click me</div>
@@ -20,6 +22,8 @@
   bind:open
   {x}
   {y}
+  {labelText}
+  aria-label={ariaLabel}
   bind:ref
   on:open={(e) => {
     console.log("open", e.detail);

--- a/tests/ContextMenu/ContextMenu.test.ts
+++ b/tests/ContextMenu/ContextMenu.test.ts
@@ -26,6 +26,37 @@ describe("ContextMenu", () => {
     expect(menu[0]).toHaveClass("bx--menu");
   });
 
+  it("should set aria-label on root menu from labelText", () => {
+    render(ContextMenu, {
+      props: { open: true, labelText: "Page actions" },
+    });
+
+    const menu = screen.getAllByRole("menu")[0];
+    expect(menu).toHaveAttribute("aria-label", "Page actions");
+  });
+
+  it("should set aria-label from aria-label prop", () => {
+    render(ContextMenu, {
+      props: { open: true, ariaLabel: "Custom menu name" },
+    });
+
+    const menu = screen.getAllByRole("menu")[0];
+    expect(menu).toHaveAttribute("aria-label", "Custom menu name");
+  });
+
+  it("should prefer aria-label over labelText when both are set", () => {
+    render(ContextMenu, {
+      props: {
+        open: true,
+        labelText: "From labelText",
+        ariaLabel: "From aria-label",
+      },
+    });
+
+    const menu = screen.getAllByRole("menu")[0];
+    expect(menu).toHaveAttribute("aria-label", "From aria-label");
+  });
+
   it("should render menu options", () => {
     render(ContextMenu);
 


### PR DESCRIPTION
Add a prop to explicitly support a `labelText` for the context menu.