### PR TITLE
fix(context-menu-option): only apply class if `disabled`

### DIFF
--- a/src/ContextMenu/ContextMenuOption.svelte
+++ b/src/ContextMenu/ContextMenuOption.svelte
@@ -296,7 +296,7 @@
   aria-haspopup={subOptions ? true : undefined}
   aria-expanded={subOptions ? submenuOpen : undefined}
   class:bx--menu-option={true}
-  class:bx--menu-option--disabled={true}
+  class:bx--menu-option--disabled={disabled}
   class:bx--menu-option--active={subOptions && submenuOpen}
   class:bx--menu-option--danger={!subOptions && kind === "danger"}
   {indented}

--- a/tests/ContextMenu/ContextMenu.test.svelte
+++ b/tests/ContextMenu/ContextMenu.test.svelte
@@ -8,6 +8,7 @@
   export let y = 0;
   export let ref: ComponentProps<ContextMenu>["ref"] = null;
   export let withSubmenu = false;
+  export let withDisabled = false;
 </script>
 
 <div data-testid="target">Right click me</div>
@@ -31,6 +32,8 @@
       <ContextMenuOption labelText="Submenu option 1" />
       <ContextMenuOption labelText="Submenu option 2" />
     </ContextMenuOption>
+  {:else if withDisabled}
+    <ContextMenuOption labelText="Disabled option" disabled />
   {:else}
     <ContextMenuOption labelText="Option 2" />
   {/if}

--- a/tests/ContextMenu/ContextMenu.test.ts
+++ b/tests/ContextMenu/ContextMenu.test.ts
@@ -387,6 +387,28 @@ describe("ContextMenu", () => {
     });
   });
 
+  describe("ContextMenuOption disabled", () => {
+    it("should apply disabled class only when disabled is true", () => {
+      render(ContextMenu, {
+        props: { open: true, x: 100, y: 100, withDisabled: true },
+      });
+
+      const options = screen.getAllByRole("menuitem");
+      const enabledOption = options.find((o) =>
+        o.textContent?.includes("Option 1"),
+      );
+      const disabledOption = options.find((o) =>
+        o.textContent?.includes("Disabled option"),
+      );
+      assert(enabledOption);
+      assert(disabledOption);
+
+      expect(enabledOption).not.toHaveClass("bx--menu-option--disabled");
+      expect(disabledOption).toHaveClass("bx--menu-option--disabled");
+      expect(disabledOption).toHaveAttribute("aria-disabled", "true");
+    });
+  });
+
   describe("ContextMenuOption Generics", () => {
     it("should support custom Icon types with generics", () => {
       type CustomIcon = new (...args: unknown[]) => unknown;


### PR DESCRIPTION
Fixes a benign bug (no styling issues); the disabled class should only apply if `disabled` is true.