### PR TITLE
fix(context-menu-option): apply `aria-disabled` to submenu triggers

### DIFF
--- a/docs/src/pages/framed/ContextMenu/ContextMenuNested.svelte
+++ b/docs/src/pages/framed/ContextMenu/ContextMenuNested.svelte
@@ -27,6 +27,11 @@
       <ContextMenuOption id="png" labelText="PNG" />
     </ContextMenuGroup>
   </ContextMenuOption>
+  <ContextMenuDivider />
+  <ContextMenuOption disabled indented labelText="Share">
+    <ContextMenuOption labelText="Email link" />
+    <ContextMenuOption labelText="Copy link" />
+  </ContextMenuOption>
 </ContextMenu>
 
 <div data-centered>

--- a/src/ContextMenu/ContextMenuOption.svelte
+++ b/src/ContextMenu/ContextMenuOption.svelte
@@ -173,7 +173,7 @@
   }
 
   function handleClick(e, opts = {}) {
-    if (disabled) return ctx.close();
+    if (disabled) return;
     if (subOptions) return;
 
     const shouldContinue = dispatch("click", e, { cancelable: true });

--- a/src/ContextMenu/ContextMenuOption.svelte
+++ b/src/ContextMenu/ContextMenuOption.svelte
@@ -292,7 +292,7 @@
   bind:this={ref}
   {role}
   tabindex="-1"
-  aria-disabled={!subOptions && disabled}
+  aria-disabled={disabled}
   aria-haspopup={subOptions ? true : undefined}
   aria-expanded={subOptions ? submenuOpen : undefined}
   class:bx--menu-option={true}
@@ -313,6 +313,7 @@
       subOptions &&
       (key === "ArrowRight" || key === " " || key === "Enter")
     ) {
+      if (disabled) return;
       submenuOpen = true;
       await tick();
       options = [...ref.querySelectorAll("li[tabindex]")];
@@ -346,7 +347,7 @@
   }}
   on:mouseenter
   on:mouseenter={() => {
-    if (subOptions) {
+    if (subOptions && !disabled) {
       if (typeof timeoutClose === "number") {
         clearTimeout(timeoutClose);
         timeoutClose = undefined;
@@ -377,6 +378,7 @@
   on:click={(e) => {
     if (subOptions) {
       e.stopPropagation();
+      if (disabled) return;
       submenuOpen = true;
       return;
     }

--- a/tests/ContextMenu/ContextMenu.test.svelte
+++ b/tests/ContextMenu/ContextMenu.test.svelte
@@ -9,6 +9,7 @@
   export let ref: ComponentProps<ContextMenu>["ref"] = null;
   export let withSubmenu = false;
   export let withDisabled = false;
+  export let submenuDisabled = false;
 </script>
 
 <div data-testid="target">Right click me</div>
@@ -28,7 +29,10 @@
 >
   <ContextMenuOption labelText="Option 1" />
   {#if withSubmenu}
-    <ContextMenuOption labelText="Option with submenu">
+    <ContextMenuOption
+      labelText="Option with submenu"
+      disabled={submenuDisabled}
+    >
       <ContextMenuOption labelText="Submenu option 1" />
       <ContextMenuOption labelText="Submenu option 2" />
     </ContextMenuOption>

--- a/tests/ContextMenu/ContextMenu.test.svelte
+++ b/tests/ContextMenu/ContextMenu.test.svelte
@@ -10,6 +10,7 @@
   export let withSubmenu = false;
   export let withDisabled = false;
   export let submenuDisabled = false;
+  export let optionDisabled = false;
 </script>
 
 <div data-testid="target">Right click me</div>
@@ -39,6 +40,6 @@
   {:else if withDisabled}
     <ContextMenuOption labelText="Disabled option" disabled />
   {:else}
-    <ContextMenuOption labelText="Option 2" />
+    <ContextMenuOption labelText="Option 2" disabled={optionDisabled} />
   {/if}
 </ContextMenu>

--- a/tests/ContextMenu/ContextMenu.test.ts
+++ b/tests/ContextMenu/ContextMenu.test.ts
@@ -179,6 +179,32 @@ describe("ContextMenu", () => {
     expect(consoleLog).toHaveBeenCalledWith("close");
   });
 
+  it("should not close menu when activating disabled regular option", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(ContextMenu, {
+      props: {
+        open: true,
+        optionDisabled: true,
+        x: 100,
+        y: 100,
+      },
+    });
+
+    const disabledOption = screen.getByText("Option 2");
+    await user.click(disabledOption);
+    expect(consoleLog).not.toHaveBeenCalledWith("close");
+
+    const trigger = disabledOption.closest("li");
+    assert(trigger);
+    trigger.focus();
+
+    await user.keyboard("{Enter}");
+    expect(consoleLog).not.toHaveBeenCalledWith("close");
+
+    await user.keyboard(" ");
+    expect(consoleLog).not.toHaveBeenCalledWith("close");
+  });
+
   // Regression test for https://github.com/carbon-design-system/carbon-components-svelte/issues/1847
   it("should position submenu to the left when it would overflow right viewport edge", async () => {
     Object.defineProperty(window, "innerWidth", {

--- a/tests/ContextMenu/ContextMenu.test.ts
+++ b/tests/ContextMenu/ContextMenu.test.ts
@@ -280,6 +280,104 @@ describe("ContextMenu", () => {
     expect(submenuX).toBeGreaterThanOrEqual(0);
   });
 
+  // Regression test: a disabled submenu trigger should expose
+  // `aria-disabled` and ignore keyboard, hover, and click activation.
+  describe("disabled submenu trigger", () => {
+    it("should set aria-disabled on a disabled submenu trigger", () => {
+      render(ContextMenu, {
+        props: {
+          open: true,
+          withSubmenu: true,
+          submenuDisabled: true,
+          x: 100,
+          y: 100,
+        },
+      });
+
+      const trigger = screen.getByText("Option with submenu").closest("li");
+      assert(trigger);
+      expect(trigger).toHaveAttribute("aria-disabled", "true");
+      expect(trigger).toHaveAttribute("aria-haspopup", "true");
+      expect(trigger).toHaveAttribute("aria-expanded", "false");
+    });
+
+    it("should not open submenu via Enter/Space when disabled", async () => {
+      render(ContextMenu, {
+        props: {
+          open: true,
+          withSubmenu: true,
+          submenuDisabled: true,
+          x: 100,
+          y: 100,
+        },
+      });
+
+      const trigger = screen.getByText("Option with submenu").closest("li");
+      assert(trigger);
+      trigger.focus();
+
+      await user.keyboard("{Enter}");
+      expect(trigger).toHaveAttribute("aria-expanded", "false");
+
+      await user.keyboard(" ");
+      expect(trigger).toHaveAttribute("aria-expanded", "false");
+
+      const submenu = screen
+        .getAllByRole("menu")
+        .find((menu) => menu.getAttribute("data-level") === "2");
+      expect(submenu).not.toHaveClass("bx--menu--open");
+    });
+
+    it("should not open submenu on hover when disabled", async () => {
+      render(ContextMenu, {
+        props: {
+          open: true,
+          withSubmenu: true,
+          submenuDisabled: true,
+          x: 100,
+          y: 100,
+        },
+      });
+
+      const submenuTrigger = screen.getByText("Option with submenu");
+      await user.hover(submenuTrigger);
+      await new Promise((resolve) => setTimeout(resolve, 200));
+
+      const trigger = submenuTrigger.closest("li");
+      assert(trigger);
+      expect(trigger).toHaveAttribute("aria-expanded", "false");
+
+      const submenu = screen
+        .getAllByRole("menu")
+        .find((menu) => menu.getAttribute("data-level") === "2");
+      expect(submenu).not.toHaveClass("bx--menu--open");
+    });
+
+    it("should not open submenu on click when disabled", async () => {
+      render(ContextMenu, {
+        props: {
+          open: true,
+          withSubmenu: true,
+          submenuDisabled: true,
+          x: 100,
+          y: 100,
+        },
+      });
+
+      const submenuTrigger = screen.getByText("Option with submenu");
+      await user.click(submenuTrigger);
+
+      const trigger = submenuTrigger.closest("li");
+      assert(trigger);
+      expect(trigger).toHaveAttribute("aria-expanded", "false");
+
+      const submenu = screen
+        .getAllByRole("menu")
+        .find((menu) => menu.getAttribute("data-level") === "2");
+      expect(submenu).not.toHaveClass("bx--menu--open");
+    });
+  });
+
   it("supports custom label slot for ContextMenuOption", () => {
     render(ContextMenuOptionSlot);
 


### PR DESCRIPTION
Previously `aria-disabled` was only set on non-submenu options, so a disabled submenu trigger announced as "expanded, has popup" and could still be opened via Enter/Space, hover, or click. Set it unconditionally and guard the keydown, mouseenter, and click paths.

The disabled options should still be focusable (click/keyboard), but they should not trigger events nor close the menu.

---

<img width="587" height="287" alt="Screenshot 2026-05-11 at 6 47 54 PM" src="https://github.com/user-attachments/assets/a76eb374-a14d-46ef-8a4e-3dbce5c137fc" />
