### PR TITLE
feat(context-menu): support Home/End keyboard shortcuts

### DIFF
--- a/src/ContextMenu/ContextMenu.svelte
+++ b/src/ContextMenu/ContextMenu.svelte
@@ -210,6 +210,10 @@
       } else {
         if (focusIndex > 0) focusIndex--;
       }
+    } else if (e.key === "Home") {
+      if (options.length > 0) focusIndex = 0;
+    } else if (e.key === "End") {
+      if (options.length > 0) focusIndex = options.length - 1;
     }
   }}
 >

--- a/src/ContextMenu/ContextMenuOption.svelte
+++ b/src/ContextMenu/ContextMenuOption.svelte
@@ -339,6 +339,10 @@
         } else {
           if (focusIndex > 0) focusIndex--;
         }
+      } else if (key === "Home") {
+        if (options.length > 0) focusIndex = 0;
+      } else if (key === "End") {
+        if (options.length > 0) focusIndex = options.length - 1;
       }
 
       if (options[focusIndex]) options[focusIndex].focus();

--- a/tests/ContextMenu/ContextMenu.test.svelte
+++ b/tests/ContextMenu/ContextMenu.test.svelte
@@ -41,5 +41,6 @@
     <ContextMenuOption labelText="Disabled option" disabled />
   {:else}
     <ContextMenuOption labelText="Option 2" disabled={optionDisabled} />
+    <ContextMenuOption labelText="Option 3" />
   {/if}
 </ContextMenu>

--- a/tests/ContextMenu/ContextMenu.test.ts
+++ b/tests/ContextMenu/ContextMenu.test.ts
@@ -30,9 +30,10 @@ describe("ContextMenu", () => {
     render(ContextMenu);
 
     const options = screen.getAllByRole("menuitem");
-    expect(options).toHaveLength(2);
+    expect(options).toHaveLength(3);
     expect(options[0]).toHaveTextContent("Option 1");
     expect(options[1]).toHaveTextContent("Option 2");
+    expect(options[2]).toHaveTextContent("Option 3");
   });
 
   it("should open on right click", async () => {
@@ -105,9 +106,18 @@ describe("ContextMenu", () => {
     const options = screen.getAllByRole("menuitem");
     expect(options[0].parentElement).toHaveFocus();
 
-    // Arrow up
+    // Arrow up wraps to the last option from the initial position.
+    // After ArrowDown, focusIndex is 0, so ArrowUp stays at 0.
     await user.keyboard("{ArrowUp}");
-    expect(options[1].parentElement).toHaveFocus();
+    expect(options[0].parentElement).toHaveFocus();
+
+    // End jumps to the last option.
+    await user.keyboard("{End}");
+    expect(options[options.length - 1].parentElement).toHaveFocus();
+
+    // Home jumps back to the first option.
+    await user.keyboard("{Home}");
+    expect(options[0].parentElement).toHaveFocus();
   });
 
   it("should handle custom target", async () => {


### PR DESCRIPTION
Arrow keys work, but the WAI-ARIA menu pattern also expects Home/End keyboard shortcuts to jump to matching items. Useful for long menus.