### PR TITLE
fix(context-menu): dispatch open/close only on open-state transitions

### DIFF
--- a/src/ContextMenu/ContextMenu.svelte
+++ b/src/ContextMenu/ContextMenu.svelte
@@ -54,6 +54,7 @@
   let direction = 1;
   let prevX = 0;
   let prevY = 0;
+  let prevOpen = false;
   let focusIndex = -1;
   let openDetail = null;
 
@@ -145,10 +146,11 @@
         prevY = y;
       }
 
-      dispatch("open", openDetail);
-    } else {
+      if (!prevOpen) dispatch("open", openDetail);
+    } else if (prevOpen) {
       dispatch("close");
     }
+    prevOpen = open;
 
     if (!$hasPopup && options[focusIndex]) options[focusIndex].focus();
   });

--- a/tests/ContextMenu/ContextMenu.test.ts
+++ b/tests/ContextMenu/ContextMenu.test.ts
@@ -42,6 +42,40 @@ describe("ContextMenu", () => {
     expect(consoleLog).toHaveBeenCalledWith("open", expect.any(HTMLElement));
   });
 
+  it("should dispatch open only when open transitions to true", () => {
+    const consoleLog = vi.spyOn(console, "log");
+    const { rerender } = render(ContextMenu, {
+      props: { open: true, x: 100, y: 100 },
+    });
+
+    const openCallsAfterMount = consoleLog.mock.calls.filter(
+      (call) => call[0] === "open",
+    ).length;
+
+    rerender({ open: true, x: 150, y: 150 });
+    rerender({ open: true, x: 200, y: 200 });
+
+    const openCallsAfterRerender = consoleLog.mock.calls.filter(
+      (call) => call[0] === "open",
+    ).length;
+
+    expect(openCallsAfterRerender).toBe(openCallsAfterMount);
+  });
+
+  it("should dispatch close only when open transitions to false", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(ContextMenu, { props: { open: false } });
+
+    await user.keyboard("{Escape}");
+    await user.click(document.body);
+
+    const closeCalls = consoleLog.mock.calls.filter(
+      (call) => call[0] === "close",
+    ).length;
+
+    expect(closeCalls).toBe(0);
+  });
+
   it("should close on escape key", async () => {
     const consoleLog = vi.spyOn(console, "log");
     render(ContextMenu, { props: { open: true } });


### PR DESCRIPTION
Currently, `open` is dispatched on every reactive update (e.g., using arrow keys to navigate the list). It should only dispatch when the menu actually transitions (clicking out of the menu or clicking an option etc..).