### PR TITLE
fix(context-menu): reset role to "menuitem" when option no longer selectable

### DIFF
--- a/src/ContextMenu/ContextMenuOption.svelte
+++ b/src/ContextMenu/ContextMenuOption.svelte
@@ -259,9 +259,13 @@
       indented = true;
     }
 
+    let nextRole = "menuitem";
+    if (isSelectable) nextRole = "menuitemcheckbox";
+    if (isRadio) nextRole = "menuitemradio";
+    role = nextRole;
+
     if (isSelectable) {
       indented = true;
-      role = "menuitemcheckbox";
 
       if (selected) {
         if (ctxGroup) ctxGroup.addOption({ id });
@@ -273,7 +277,6 @@
 
     if (isRadio) {
       indented = true;
-      role = "menuitemradio";
       ctxRadioGroup.addOption({ id });
 
       if (selected) {

--- a/tests/ContextMenu/ContextMenu.test.ts
+++ b/tests/ContextMenu/ContextMenu.test.ts
@@ -5,6 +5,7 @@ import { user } from "../setup-tests";
 import ContextMenuPreventDefault from "./ContextMenu.preventDefault.test.svelte";
 import ContextMenu from "./ContextMenu.test.svelte";
 import ContextMenuOptionIcon from "./ContextMenuOption.icon.test.svelte";
+import ContextMenuOptionRole from "./ContextMenuOption.role.test.svelte";
 import ContextMenuOptionSlot from "./ContextMenuOption.slot.test.svelte";
 
 describe("ContextMenu", () => {
@@ -564,6 +565,21 @@ describe("ContextMenu", () => {
       expect(enabledOption).not.toHaveClass("bx--menu-option--disabled");
       expect(disabledOption).toHaveClass("bx--menu-option--disabled");
       expect(disabledOption).toHaveAttribute("aria-disabled", "true");
+    });
+  });
+
+  describe("ContextMenuOption role", () => {
+    it("should reset role to menuitem when selectable toggles from true to false", async () => {
+      const { rerender } = render(ContextMenuOptionRole, {
+        props: { selectable: true },
+      });
+
+      expect(screen.getByRole("menuitemcheckbox")).toBeInTheDocument();
+
+      await rerender({ selectable: false });
+
+      expect(screen.queryByRole("menuitemcheckbox")).not.toBeInTheDocument();
+      expect(screen.getByRole("menuitem")).toBeInTheDocument();
     });
   });
 

--- a/tests/ContextMenu/ContextMenuOption.role.test.svelte
+++ b/tests/ContextMenu/ContextMenuOption.role.test.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+  import { ContextMenu, ContextMenuOption } from "carbon-components-svelte";
+
+  export let selectable = true;
+</script>
+
+<ContextMenu open={true} x={100} y={100}>
+  <ContextMenuOption id="opt" labelText="Toggle me" {selectable} />
+</ContextMenu>


### PR DESCRIPTION
The reactive block only ever assigned `"menuitemcheckbox"`/`"menuitemradio"` but never reset, so toggling `selectable` off left the stale role and AT kept announcing checkbox/radio state.