### PR TITLE
fix(context-menu): rebind listeners when target changes

### DIFF
--- a/src/ContextMenu/ContextMenu.svelte
+++ b/src/ContextMenu/ContextMenu.svelte
@@ -96,26 +96,24 @@
     openDetail = e.target;
   }
 
-  $: if (target != null) {
-    if (Array.isArray(target)) {
-      for (const node of target) {
-        node?.addEventListener("contextmenu", openMenu);
-      }
-    } else {
-      target.addEventListener("contextmenu", openMenu);
+  /** @type {Array<HTMLElement | null>} */
+  let boundTargets = [];
+
+  $: {
+    for (const node of boundTargets) {
+      node?.removeEventListener("contextmenu", openMenu);
+    }
+    boundTargets =
+      target == null ? [] : Array.isArray(target) ? [...target] : [target];
+    for (const node of boundTargets) {
+      node?.addEventListener("contextmenu", openMenu);
     }
   }
 
   onMount(() => {
     return () => {
-      if (target != null) {
-        if (Array.isArray(target)) {
-          for (const node of target) {
-            node?.removeEventListener("contextmenu", openMenu);
-          }
-        } else {
-          target.removeEventListener("contextmenu", openMenu);
-        }
+      for (const node of boundTargets) {
+        node?.removeEventListener("contextmenu", openMenu);
       }
     };
   });

--- a/tests/ContextMenu/ContextMenu.target.test.svelte
+++ b/tests/ContextMenu/ContextMenu.target.test.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+  import { ContextMenu, ContextMenuOption } from "carbon-components-svelte";
+  import { onMount } from "svelte";
+
+  let targetA: HTMLElement | null = null;
+  let targetB: HTMLElement | null = null;
+  let target: ReadonlyArray<HTMLElement | null> | null = null;
+
+  onMount(() => {
+    target = [targetA];
+  });
+
+  function swap() {
+    target = [targetB];
+  }
+</script>
+
+<div data-testid="target-a" bind:this={targetA}>A</div>
+<div data-testid="target-b" bind:this={targetB}>B</div>
+<button type="button" data-testid="swap" on:click={swap}>swap</button>
+
+<ContextMenu
+  {target}
+  on:open={(e) => {
+    console.log("open", e.detail);
+  }}
+>
+  <ContextMenuOption labelText="Option 1" />
+  <ContextMenuOption labelText="Option 2" />
+</ContextMenu>

--- a/tests/ContextMenu/ContextMenu.test.ts
+++ b/tests/ContextMenu/ContextMenu.test.ts
@@ -3,6 +3,7 @@ import type ContextMenuOptionComponent from "carbon-components-svelte/ContextMen
 import type { ComponentProps } from "svelte";
 import { user } from "../setup-tests";
 import ContextMenuPreventDefault from "./ContextMenu.preventDefault.test.svelte";
+import ContextMenuTarget from "./ContextMenu.target.test.svelte";
 import ContextMenu from "./ContextMenu.test.svelte";
 import ContextMenuOptionIcon from "./ContextMenuOption.icon.test.svelte";
 import ContextMenuOptionSlot from "./ContextMenuOption.slot.test.svelte";
@@ -81,6 +82,27 @@ describe("ContextMenu", () => {
     const target = screen.getByTestId("target");
     await user.pointer({ target, keys: "[MouseRight]" });
     expect(consoleLog).toHaveBeenCalledWith("open", target);
+  });
+
+  // Regression test: when `target` is updated to a new set of nodes,
+  // the previously-bound nodes should have their `contextmenu`
+  // listener removed. Otherwise, right-clicking a node that is no
+  // longer in `target` still triggers `openMenu`.
+  it("should remove contextmenu listener from nodes no longer in target", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(ContextMenuTarget);
+
+    // Initial target is [A]. Swap to [B].
+    await user.click(screen.getByTestId("swap"));
+
+    // Right-clicking A should no longer open the menu.
+    const targetA = screen.getByTestId("target-a");
+    await user.pointer({ target: targetA, keys: "[MouseRight]" });
+
+    const openCalls = consoleLog.mock.calls.filter(
+      ([label]) => label === "open",
+    );
+    expect(openCalls).toHaveLength(0);
   });
 
   it("should handle custom position", () => {


### PR DESCRIPTION
Reactive binding only added listeners; updating `target` left stale handlers on old nodes. Remove prior `boundTargets` each run and when the component instance is destroyed. Adds a regression test that swaps target between elements.