### PR TITLE
fix(tree-view): parity for keyboard navigation, walker, and subtree a11y

### DIFF
--- a/src/TreeView/TreeView.svelte
+++ b/src/TreeView/TreeView.svelte
@@ -34,9 +34,16 @@
   function createTreeWalkerInstance(root) {
     return document.createTreeWalker(root, NodeFilter.SHOW_ELEMENT, {
       acceptNode: (node) => {
-        if (node.classList.contains("bx--tree-node--disabled"))
+        if (!(node instanceof Element)) return NodeFilter.FILTER_SKIP;
+        if (
+          node.classList.contains("bx--tree-node--disabled") ||
+          node.classList.contains("bx--tree-node--hidden")
+        ) {
           return NodeFilter.FILTER_REJECT;
-        if (node.matches("li.bx--tree-node")) return NodeFilter.FILTER_ACCEPT;
+        }
+        if (node.classList.contains("bx--tree-node")) {
+          return NodeFilter.FILTER_ACCEPT;
+        }
         return NodeFilter.FILTER_SKIP;
       },
     });
@@ -392,7 +399,13 @@
     }
   }
 
-  import { createEventDispatcher, onMount, setContext, tick } from "svelte";
+  import {
+    afterUpdate,
+    createEventDispatcher,
+    onMount,
+    setContext,
+    tick,
+  } from "svelte";
   import { writable } from "svelte/store";
   import TreeViewNodeList from "./TreeViewNodeList.svelte";
 
@@ -627,30 +640,136 @@
     toggleNode,
   });
 
-  function handleKeyDown(e) {
-    if (e.key === "ArrowUp" || e.key === "ArrowDown") e.preventDefault();
-
-    treeWalker.currentNode = e.target;
-
-    let node = null;
-
-    if (e.key === "ArrowUp") node = treeWalker.previousNode();
-    if (e.key === "ArrowDown") node = treeWalker.nextNode();
-    if (node && node !== e.target) {
-      node.tabIndex = "0";
-      node.focus();
+  /** @param {HTMLElement | null} root */
+  function resetNodeTabIndices(root) {
+    if (!root) return;
+    const items = root.querySelectorAll('[tabindex="0"]');
+    for (let i = 0; i < items.length; i++) {
+      const el = items[i];
+      if (el instanceof HTMLElement) el.tabIndex = -1;
     }
   }
 
-  onMount(() => {
-    const firstFocusableNode = ref.querySelector(
-      "li.bx--tree-node:not(.bx--tree-node--disabled)",
-    );
+  /** @param {EventTarget | null} target */
+  function getTreeItemFromTarget(target) {
+    if (!(target instanceof Element)) return null;
+    if (target.classList.contains("bx--tree-node")) return target;
+    return target.closest(".bx--tree-node");
+  }
 
-    if (firstFocusableNode != null) {
-      firstFocusableNode.tabIndex = "0";
+  function handleKeyDown(e) {
+    e.stopPropagation();
+
+    if (
+      e.key === "ArrowUp" ||
+      e.key === "ArrowDown" ||
+      e.key === "Home" ||
+      e.key === "End"
+    ) {
+      e.preventDefault();
     }
 
+    if (!treeWalker || !ref) return;
+
+    const treeItem = getTreeItemFromTarget(e.target);
+    if (!treeItem) return;
+
+    treeWalker.currentNode = treeItem;
+
+    /** @type {Node | null} */
+    let nextFocusNode = null;
+
+    if (e.key === "ArrowUp") {
+      nextFocusNode = treeWalker.previousNode();
+    }
+    if (e.key === "ArrowDown") {
+      nextFocusNode = treeWalker.nextNode();
+    }
+
+    const isHomeOrEnd = e.key === "Home" || e.key === "End";
+    const isSelectAll =
+      (e.code === "KeyA" || e.key === "a" || e.key === "A") && e.ctrlKey;
+
+    if (isHomeOrEnd || isSelectAll) {
+      /** @type {Array<string | number>} */
+      const nodeIds = [];
+
+      if (isHomeOrEnd) {
+        if (
+          multiselect &&
+          e.shiftKey &&
+          e.ctrlKey &&
+          treeItem instanceof HTMLElement &&
+          !treeItem.getAttribute("aria-disabled") &&
+          !treeItem.classList.contains("bx--tree-node--hidden")
+        ) {
+          const hid = treeItem.id;
+          if (hid) nodeIds.push(hid);
+        }
+        while (
+          e.key === "Home" ? treeWalker.previousNode() : treeWalker.nextNode()
+        ) {
+          nextFocusNode = treeWalker.currentNode;
+          if (
+            multiselect &&
+            e.shiftKey &&
+            e.ctrlKey &&
+            nextFocusNode instanceof Element &&
+            !nextFocusNode.getAttribute("aria-disabled") &&
+            !nextFocusNode.classList.contains("bx--tree-node--hidden")
+          ) {
+            const nid = nextFocusNode.id;
+            if (nid) nodeIds.push(nid);
+          }
+        }
+      }
+
+      if (isSelectAll) {
+        e.preventDefault();
+        treeWalker.currentNode = treeWalker.root;
+        while (treeWalker.nextNode()) {
+          const cur = treeWalker.currentNode;
+          if (
+            cur instanceof Element &&
+            !cur.getAttribute("aria-disabled") &&
+            !cur.classList.contains("bx--tree-node--hidden")
+          ) {
+            const nid = cur.id;
+            if (nid) nodeIds.push(nid);
+          }
+        }
+      }
+
+      selectedIds = selectedIds.concat(nodeIds);
+    }
+
+    if (nextFocusNode && nextFocusNode !== treeItem) {
+      resetNodeTabIndices(ref);
+      if (nextFocusNode instanceof HTMLElement) {
+        nextFocusNode.tabIndex = 0;
+        nextFocusNode.focus();
+      }
+    }
+  }
+
+  /** @type {ReadonlyArray<Node> | null} */
+  let prevNodesForFirstTab = null;
+
+  afterUpdate(() => {
+    if (!ref) return;
+    if (nodes === prevNodesForFirstTab) return;
+    prevNodesForFirstTab = nodes;
+
+    const firstFocusableNode = ref.querySelector(
+      ".bx--tree-node:not(.bx--tree-node--disabled):not(.bx--tree-node--hidden)",
+    );
+
+    if (firstFocusableNode instanceof HTMLElement) {
+      firstFocusableNode.tabIndex = 0;
+    }
+  });
+
+  onMount(() => {
     if (ref && !treeWalker) {
       treeWalker = createTreeWalkerInstance(ref);
     }

--- a/src/TreeView/TreeViewNode.svelte
+++ b/src/TreeView/TreeViewNode.svelte
@@ -41,7 +41,7 @@
    * @param {HTMLElement | null} node
    * @returns {null | HTMLElement}
    */
-  function findParentTreeNode(node) {
+  export function findParentTreeNode(node) {
     if (node == null || !(node instanceof HTMLElement)) return null;
     if (node.classList.contains("bx--tree-parent-node")) return node;
     if (node.classList.contains("bx--tree-node-link-parent")) {

--- a/src/TreeView/TreeViewNodeList.svelte
+++ b/src/TreeView/TreeViewNodeList.svelte
@@ -22,7 +22,23 @@
 
   import { afterUpdate, getContext } from "svelte";
   import CaretDown from "../icons/CaretDown.svelte";
-  import TreeViewNode, { computeTreeLeafDepth } from "./TreeViewNode.svelte";
+  import TreeViewNode, {
+    computeTreeLeafDepth,
+    findParentTreeNode,
+  } from "./TreeViewNode.svelte";
+
+  /**
+   * First focusable tree item in a subtree `ul` (handles `li` rows and `li[role="none"] > a` link rows).
+   * @param {HTMLElement} groupUl
+   * @returns {HTMLElement | null}
+   */
+  function firstTreeItemInGroup(groupUl) {
+    const row = groupUl.firstElementChild;
+    if (!(row instanceof HTMLElement)) return null;
+    if (row.classList.contains("bx--tree-node")) return row;
+    const nested = row.querySelector(".bx--tree-node");
+    return nested instanceof HTMLElement ? nested : null;
+  }
 
   let ref = null;
   let refLabel = null;
@@ -99,6 +115,7 @@
     class:bx--tree-node--disabled={disabled}
     class:bx--tree-node--with-icon={icon}
     aria-expanded={expanded}
+    aria-owns={`${id}-subtree`}
     on:click|stopPropagation={(e) => {
       if (disabled) return;
       clickNode(node, e);
@@ -113,16 +130,23 @@
       }
 
       if (parent && e.key === "ArrowLeft") {
-        expanded = false;
-        expandNode(node, false);
-        toggleNode(node);
+        if (expanded) {
+          expandNode(node, false);
+          toggleNode(node);
+        } else {
+          const parentNode = findParentTreeNode(ref.parentElement);
+          if (parentNode instanceof HTMLElement) parentNode.focus();
+        }
       }
 
       if (parent && e.key === "ArrowRight") {
         if (expanded) {
-          ref.lastChild.firstElementChild?.focus();
+          const groupUl = ref.lastElementChild;
+          if (groupUl instanceof HTMLElement) {
+            const next = firstTreeItemInGroup(groupUl);
+            next?.focus();
+          }
         } else {
-          expanded = true;
           expandNode(node, true);
           toggleNode(node);
         }
@@ -131,10 +155,12 @@
       if (e.key === "Enter" || e.key === " ") {
         e.preventDefault();
         if (disabled) return;
-        expanded = !expanded;
-        toggleNode(node);
+        if (e.key === "Enter" && parent) {
+          const nextExpanded = !expanded;
+          expandNode(node, nextExpanded);
+          toggleNode(node);
+        }
         clickNode(node, e);
-        expandNode(node, expanded);
         ref.focus();
       }
     }}
@@ -150,8 +176,8 @@
         {disabled}
         on:click={() => {
           if (disabled) return;
-          expanded = !expanded;
-          expandNode(node, expanded);
+          const nextExpanded = !expanded;
+          expandNode(node, nextExpanded);
           toggleNode(node);
         }}
       >
@@ -162,11 +188,18 @@
       </span>
       <span class:bx--tree-node__label__details={true}>
         <svelte:component this={icon} class="bx--tree-node__icon" />
-        <slot {node} />
+        <span id={`${id}__label`} class:bx--tree-node__label__text={true}>
+          <slot {node} />
+        </span>
       </span>
     </div>
     {#if expanded}
-      <ul role="group" class:bx--tree-node__children={true}>
+      <ul
+        id={`${id}-subtree`}
+        role="group"
+        aria-labelledby={`${id}__label`}
+        class:bx--tree-node__children={true}
+      >
         {#each nodes as child (child.id)}
           {#if Array.isArray(child.nodes)}
             <svelte:self {...child} let:node> <slot {node} /> </svelte:self>

--- a/tests/TreeView/TreeView.test.ts
+++ b/tests/TreeView/TreeView.test.ts
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/svelte";
+import { render, screen, within } from "@testing-library/svelte";
 import type TreeViewComponent from "carbon-components-svelte/TreeView/TreeView.svelte";
 import type { TreeNode } from "carbon-components-svelte/TreeView/TreeView.svelte";
 import type TreeViewNodeComponent from "carbon-components-svelte/TreeView/TreeViewNode.svelte";
@@ -101,9 +101,15 @@ describe.each(testCases)("$name", ({ component }) => {
 
     expect(getAllExpandedItems()).toHaveLength(2);
 
+    const tree = screen.getByRole("tree");
+    const expandedItems = within(tree).getAllByRole("treeitem", {
+      expanded: true,
+    });
     expect(
-      screen.getByText("IBM Analytics Engine").parentNode?.parentNode,
-    ).toHaveAttribute("aria-expanded", "true");
+      expandedItems.some((el) =>
+        el.textContent?.includes("IBM Analytics Engine"),
+      ),
+    ).toBe(true);
   });
 
   it("can collapse all nodes", async () => {
@@ -1522,7 +1528,7 @@ describe("TreeView autoCollapse", () => {
     expect(folder1).toHaveAttribute("aria-expanded", "false");
   });
 
-  it("works when expanding via Enter/Space key", async () => {
+  it("works when expanding via Enter key (Carbon: Space selects parent without toggling expand)", async () => {
     render(TreeViewAutoCollapse, { autoCollapse: true });
 
     const folder1 = screen.getByRole("treeitem", { name: /Folder 1/ });
@@ -1533,7 +1539,7 @@ describe("TreeView autoCollapse", () => {
     expect(folder1).toHaveAttribute("aria-expanded", "true");
 
     folder2.focus();
-    await user.keyboard(" ");
+    await user.keyboard("{Enter}");
     expect(folder2).toHaveAttribute("aria-expanded", "true");
     expect(folder1).toHaveAttribute("aria-expanded", "false");
   });


### PR DESCRIPTION
Aligns closer with the upstream React implementation for `TreeView`.