### PR TITLE
fix(content-switcher): forward focus/blur events

### DIFF
--- a/src/ContentSwitcher/ContentSwitcher.svelte
+++ b/src/ContentSwitcher/ContentSwitcher.svelte
@@ -142,6 +142,8 @@
   on:mouseover
   on:mouseenter
   on:mouseleave
+  on:focus
+  on:blur
 >
   <slot />
 </div>

--- a/src/ContentSwitcher/Switch.svelte
+++ b/src/ContentSwitcher/Switch.svelte
@@ -57,6 +57,9 @@
   on:mouseover
   on:mouseenter
   on:mouseleave
+  on:focus
+  on:blur
+  on:keyup
   on:keydown
   on:keydown={({ key }) => {
     if (key === "ArrowRight") {


### PR DESCRIPTION
For `ContentSwitcher`, forward missing events to tablist panel.

For `Switch`, support focus/blur/keyup events on the button.