### PR TITLE
feat(content-switcher): add `ref` prop for tablist reference

### DIFF
--- a/src/ContentSwitcher/ContentSwitcher.svelte
+++ b/src/ContentSwitcher/ContentSwitcher.svelte
@@ -19,6 +19,12 @@
    */
   export let selectionMode = "automatic";
 
+  /**
+   * Obtain a reference to the tablist HTML element.
+   * @type {HTMLDivElement | null}
+   */
+  export let ref = null;
+
   import { afterUpdate, createEventDispatcher, setContext, tick } from "svelte";
   import { writable } from "svelte/store";
 
@@ -27,9 +33,6 @@
    * @type {import("svelte/store").Writable<string | null>}
    */
   const currentId = writable(null);
-
-  /** @type {HTMLDivElement | null} */
-  let refContainer = null;
 
   let prevIndex = -1;
 
@@ -162,7 +165,7 @@
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <!-- svelte-ignore a11y-interactive-supports-focus -->
 <div
-  bind:this={refContainer}
+  bind:this={ref}
   role="tablist"
   class:bx--content-switcher={true}
   class:bx--content-switcher--sm={size === "sm"}

--- a/tests/ContentSwitcher/ContentSwitcher.test.svelte
+++ b/tests/ContentSwitcher/ContentSwitcher.test.svelte
@@ -8,9 +8,11 @@
   export let customClass = "";
   export let switchId: ComponentProps<Switch>["id"] = undefined;
   export let switchRef: ComponentProps<Switch>["ref"] = null;
+  export let ref: ComponentProps<ContentSwitcher>["ref"] = null;
 </script>
 
 <ContentSwitcher
+  bind:ref
   {selectedIndex}
   class={customClass}
   on:change={(e) => {

--- a/tests/ContentSwitcher/ContentSwitcher.test.ts
+++ b/tests/ContentSwitcher/ContentSwitcher.test.ts
@@ -320,6 +320,15 @@ describe("ContentSwitcher", () => {
     expect(tabs[1]).toHaveClass("bx--content-switcher--selected");
   });
 
+  it("should bind ref to the tablist element", () => {
+    const { component } = render(ContentSwitcher);
+
+    assert(component.ref);
+    expect(component.ref).toBeInstanceOf(HTMLDivElement);
+    expect(component.ref).toHaveAttribute("role", "tablist");
+    expect(component.ref).toHaveClass("bx--content-switcher");
+  });
+
   describe('selectionMode="manual"', () => {
     it("arrow keys move focus without changing selection", async () => {
       render(ContentSwitcherSelectionMode);


### PR DESCRIPTION
Allow binding to the tablist reference (e.g., for imperative focusing).