### PR TITLE
feat(overflow-menu): support Home/End keyboard shortcuts

### DIFF
--- a/src/OverflowMenu/OverflowMenu.svelte
+++ b/src/OverflowMenu/OverflowMenu.svelte
@@ -162,12 +162,28 @@
     currentIndex.set(index);
   };
 
+  const first = () => {
+    const index = $items.findIndex((_) => !_.disabled);
+    if (index >= 0) currentIndex.set(index);
+  };
+
+  const last = () => {
+    for (let index = $items.length - 1; index >= 0; index--) {
+      if (!$items[index].disabled) {
+        currentIndex.set(index);
+        return;
+      }
+    }
+  };
+
   setContext("carbon:OverflowMenu", {
     focusedId,
     items,
     add,
     update,
     change,
+    first,
+    last,
   });
 
   afterUpdate(() => {
@@ -271,6 +287,12 @@
     if (open) {
       if (["ArrowDown", "ArrowLeft", "ArrowRight", "ArrowUp"].includes(e.key)) {
         e.preventDefault();
+      } else if (e.key === "Home") {
+        e.preventDefault();
+        first();
+      } else if (e.key === "End") {
+        e.preventDefault();
+        last();
       } else if (e.key === "Escape") {
         e.stopPropagation();
         const shouldContinue = dispatch("close", null, { cancelable: true });
@@ -341,6 +363,12 @@
       on:keydown={(e) => {
         if (["ArrowDown", "ArrowLeft", "ArrowRight", "ArrowUp"].includes(e.key)) {
           e.preventDefault();
+        } else if (e.key === "Home") {
+          e.preventDefault();
+          first();
+        } else if (e.key === "End") {
+          e.preventDefault();
+          last();
         } else if (e.key === "Escape") {
           e.stopPropagation();
           const shouldContinue = dispatch("close", null, { cancelable: true });

--- a/src/OverflowMenu/OverflowMenuItem.svelte
+++ b/src/OverflowMenu/OverflowMenuItem.svelte
@@ -56,7 +56,7 @@
   import { afterUpdate, createEventDispatcher, getContext } from "svelte";
 
   const dispatch = createEventDispatcher();
-  const { focusedId, add, update, change, items } = getContext(
+  const { focusedId, add, update, change, first, last, items } = getContext(
     "carbon:OverflowMenu",
   );
 
@@ -124,11 +124,17 @@
       {...buttonProps}
       on:click={handleClick}
       on:keydown
-      on:keydown={({ key }) => {
-        if (key === "ArrowDown") {
+      on:keydown={(e) => {
+        if (e.key === "ArrowDown") {
           change(1);
-        } else if (key === "ArrowUp") {
+        } else if (e.key === "ArrowUp") {
           change(-1);
+        } else if (e.key === "Home") {
+          e.preventDefault();
+          first();
+        } else if (e.key === "End") {
+          e.preventDefault();
+          last();
         }
       }}
     >
@@ -143,11 +149,17 @@
       {...buttonProps}
       on:click={handleClick}
       on:keydown
-      on:keydown={({ key }) => {
-        if (key === "ArrowDown") {
+      on:keydown={(e) => {
+        if (e.key === "ArrowDown") {
           change(1);
-        } else if (key === "ArrowUp") {
+        } else if (e.key === "ArrowUp") {
           change(-1);
+        } else if (e.key === "Home") {
+          e.preventDefault();
+          first();
+        } else if (e.key === "End") {
+          e.preventDefault();
+          last();
         }
       }}
     >

--- a/tests/OverflowMenu/OverflowMenu.disabled.test.svelte
+++ b/tests/OverflowMenu/OverflowMenu.disabled.test.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+  import { OverflowMenu, OverflowMenuItem } from "carbon-components-svelte";
+</script>
+
+<OverflowMenu>
+  <OverflowMenuItem text="First" />
+  <OverflowMenuItem disabled text="Second (disabled)" />
+  <OverflowMenuItem text="Third" />
+  <OverflowMenuItem disabled text="Fourth (disabled)" />
+</OverflowMenu>

--- a/tests/OverflowMenu/OverflowMenu.test.ts
+++ b/tests/OverflowMenu/OverflowMenu.test.ts
@@ -4,6 +4,7 @@ import type { ComponentProps } from "svelte";
 import { tick } from "svelte";
 import { user } from "../setup-tests";
 import OverflowMenuAllDisabled from "./OverflowMenu.allDisabled.test.svelte";
+import OverflowMenuDisabled from "./OverflowMenu.disabled.test.svelte";
 import OverflowMenuDisabledLink from "./OverflowMenu.disabledLink.test.svelte";
 import OverflowMenuPreventDefault from "./OverflowMenu.preventDefault.test.svelte";
 import OverflowMenuRel from "./OverflowMenu.rel.test.svelte";
@@ -113,6 +114,41 @@ describe("OverflowMenu", () => {
     await user.keyboard("{ArrowDown}");
 
     expect(menuButton).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("supports Home and End to jump to first/last item", async () => {
+    render(OverflowMenu);
+
+    const menuButton = screen.getByRole("button");
+    await user.click(menuButton);
+
+    const menuItems = screen.getAllByRole("menuitem");
+    expect(menuItems[0]).toHaveFocus();
+
+    await user.keyboard("{End}");
+    expect(menuItems[2]).toHaveFocus();
+
+    await user.keyboard("{Home}");
+    expect(menuItems[0]).toHaveFocus();
+  });
+
+  it("Home and End skip disabled items", async () => {
+    render(OverflowMenuDisabled);
+
+    const menuButton = screen.getByRole("button");
+    await user.click(menuButton);
+
+    const menuItems = screen.getAllByRole("menuitem");
+    expect(menuItems).toHaveLength(4);
+    expect(menuItems[0]).toHaveFocus();
+
+    // Last non-disabled item is index 2 ("Third").
+    await user.keyboard("{End}");
+    expect(menuItems[2]).toHaveFocus();
+
+    // First non-disabled item is index 0 ("First").
+    await user.keyboard("{Home}");
+    expect(menuItems[0]).toHaveFocus();
   });
 
   it("closes when clicking outside", async () => {


### PR DESCRIPTION
Similar to #2974, the overflow menu should support Home/End shortcuts. Helpful especially for long menus.