### PR TITLE
fix(overflow-menu-item): set `aria-disabled` on disabled link

### DIFF
--- a/src/OverflowMenu/OverflowMenuItem.svelte
+++ b/src/OverflowMenu/OverflowMenuItem.svelte
@@ -77,6 +77,7 @@
     class: "bx--overflow-menu-options__btn",
     type: href ? undefined : "button",
     disabled: href ? undefined : disabled,
+    "aria-disabled": href && disabled ? "true" : undefined,
     href: href ? href : undefined,
     target: href && target ? target : undefined,
     rel:
@@ -90,6 +91,11 @@
 
   function handleClick(e) {
     e.stopPropagation();
+
+    if (disabled) {
+      e.preventDefault();
+      return;
+    }
 
     const shouldContinue = dispatch("click", e, { cancelable: true });
 

--- a/tests/OverflowMenu/OverflowMenu.disabledLink.test.svelte
+++ b/tests/OverflowMenu/OverflowMenu.disabledLink.test.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+  import { OverflowMenu, OverflowMenuItem } from "carbon-components-svelte";
+</script>
+
+<OverflowMenu
+  on:close={(e) => {
+    console.log("close", e.detail);
+  }}
+>
+  <OverflowMenuItem
+    disabled
+    href="https://cloud.ibm.com/docs/api-gateway/"
+    text="API documentation"
+    on:click={() => {
+      console.log("click", "API documentation");
+    }}
+  />
+  <OverflowMenuItem
+    text="Manage credentials"
+    on:click={() => {
+      console.log("click", "Manage credentials");
+    }}
+  />
+</OverflowMenu>

--- a/tests/OverflowMenu/OverflowMenu.test.ts
+++ b/tests/OverflowMenu/OverflowMenu.test.ts
@@ -3,6 +3,7 @@ import type OverflowMenuComponent from "carbon-components-svelte/OverflowMenu/Ov
 import type { ComponentProps } from "svelte";
 import { tick } from "svelte";
 import { user } from "../setup-tests";
+import OverflowMenuDisabledLink from "./OverflowMenu.disabledLink.test.svelte";
 import OverflowMenuPreventDefault from "./OverflowMenu.preventDefault.test.svelte";
 import OverflowMenuRel from "./OverflowMenu.rel.test.svelte";
 import OverflowMenu from "./OverflowMenu.test.svelte";
@@ -400,6 +401,40 @@ describe("OverflowMenu", () => {
 
     expect(menuButton).toHaveAttribute("aria-expanded", "true");
     expect(screen.queryByRole("menu")).toBeInTheDocument();
+  });
+
+  it("does not navigate, dispatch click, or close menu for disabled link item", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(OverflowMenuDisabledLink);
+
+    const menuButton = screen.getByRole("button");
+    await user.click(menuButton);
+    expect(menuButton).toHaveAttribute("aria-expanded", "true");
+
+    const menuItems = screen.getAllByRole("menuitem");
+    const disabledLink = menuItems.find(
+      (item) => item.textContent === "API documentation",
+    );
+    expect(disabledLink?.tagName).toBe("A");
+    expect(disabledLink).toHaveAttribute("aria-disabled", "true");
+    expect(disabledLink).toHaveAttribute("tabindex", "-1");
+    expect(disabledLink?.parentElement).toHaveClass(
+      "bx--overflow-menu-options__option--disabled",
+    );
+
+    const clickEvent = new MouseEvent("click", {
+      bubbles: true,
+      cancelable: true,
+    });
+    disabledLink?.dispatchEvent(clickEvent);
+
+    expect(clickEvent.defaultPrevented).toBe(true);
+    expect(consoleLog).not.toHaveBeenCalledWith("click", "API documentation");
+    expect(consoleLog).not.toHaveBeenCalledWith("close", {
+      index: 0,
+      text: "API documentation",
+    });
+    expect(menuButton).toHaveAttribute("aria-expanded", "true");
   });
 
   it("closes menu normally when preventDefault is not called", async () => {


### PR DESCRIPTION
When `href` is set, `disabled` was dropped from props, so the `<a>` should set `aria-disabled`.