### PR TITLE
fix(overflow-menu): prevent infinite loop when all items are disabled

### DIFF
--- a/src/OverflowMenu/OverflowMenu.svelte
+++ b/src/OverflowMenu/OverflowMenu.svelte
@@ -142,6 +142,7 @@
       index = 0;
     }
 
+    const start = index;
     let disabled = $items[index].disabled;
 
     while (disabled) {
@@ -152,6 +153,8 @@
       } else if (index >= $items.length) {
         index = 0;
       }
+
+      if (index === start) return;
 
       disabled = $items[index].disabled;
     }

--- a/tests/OverflowMenu/OverflowMenu.allDisabled.test.svelte
+++ b/tests/OverflowMenu/OverflowMenu.allDisabled.test.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+  import { OverflowMenu, OverflowMenuItem } from "carbon-components-svelte";
+</script>
+
+<OverflowMenu>
+  <OverflowMenuItem disabled text="Manage credentials" />
+  <OverflowMenuItem disabled text="API documentation" />
+  <OverflowMenuItem disabled text="Delete service" />
+</OverflowMenu>

--- a/tests/OverflowMenu/OverflowMenu.test.ts
+++ b/tests/OverflowMenu/OverflowMenu.test.ts
@@ -3,6 +3,7 @@ import type OverflowMenuComponent from "carbon-components-svelte/OverflowMenu/Ov
 import type { ComponentProps } from "svelte";
 import { tick } from "svelte";
 import { user } from "../setup-tests";
+import OverflowMenuAllDisabled from "./OverflowMenu.allDisabled.test.svelte";
 import OverflowMenuDisabledLink from "./OverflowMenu.disabledLink.test.svelte";
 import OverflowMenuPreventDefault from "./OverflowMenu.preventDefault.test.svelte";
 import OverflowMenuRel from "./OverflowMenu.rel.test.svelte";
@@ -98,6 +99,20 @@ describe("OverflowMenu", () => {
     await user.keyboard("{Escape}");
     expect(menuButton).toHaveAttribute("aria-expanded", "false");
     expect(spy).toHaveBeenCalledWith("close", null);
+  });
+
+  it("does not infinite-loop when all items are disabled", async () => {
+    render(OverflowMenuAllDisabled);
+
+    const menuButton = screen.getByRole("button");
+    await user.click(menuButton);
+    expect(menuButton).toHaveAttribute("aria-expanded", "true");
+
+    await user.keyboard("{ArrowDown}");
+    await user.keyboard("{ArrowUp}");
+    await user.keyboard("{ArrowDown}");
+
+    expect(menuButton).toHaveAttribute("aria-expanded", "true");
   });
 
   it("closes when clicking outside", async () => {


### PR DESCRIPTION
Similar to #2824

Fixes an edge case where an infinite loop can occur if using keyboard navigation while all items are disabled.