### PR TITLE
fix(overflow-menu): use `aria-haspopup="menu"`

### DIFF
--- a/src/OverflowMenu/OverflowMenu.svelte
+++ b/src/OverflowMenu/OverflowMenu.svelte
@@ -237,7 +237,7 @@
 <button
   bind:this={buttonRef}
   type="button"
-  aria-haspopup="true"
+  aria-haspopup="menu"
   aria-expanded={open}
   aria-label={ariaLabel}
   aria-controls={open ? menuId : undefined}

--- a/tests/OverflowMenu/OverflowMenu.test.ts
+++ b/tests/OverflowMenu/OverflowMenu.test.ts
@@ -20,7 +20,7 @@ describe("OverflowMenu", () => {
     render(OverflowMenu);
 
     const menuButton = screen.getByRole("button");
-    expect(menuButton).toHaveAttribute("aria-haspopup", "true");
+    expect(menuButton).toHaveAttribute("aria-haspopup", "menu");
     expect(menuButton).toHaveAttribute("aria-expanded", "false");
 
     await user.click(menuButton);


### PR DESCRIPTION
`aria-haspopup="true"` is the legacy spelling, which AT maps to `"menu"` by default. The modern, precise value is `aria-haspopup="menu"`. When the popup type isn't explicit, some AT (older NVDA, JAWS variations) announce "submenu" or "list" inconsistently.