### PR TITLE
fix(overflow-menu): `aria-controls` is stable

### DIFF
--- a/src/OverflowMenu/OverflowMenu.svelte
+++ b/src/OverflowMenu/OverflowMenu.svelte
@@ -240,7 +240,7 @@
   aria-haspopup="true"
   aria-expanded={open}
   aria-label={ariaLabel}
-  aria-controls={open ? menuId : undefined}
+  aria-controls={menuId}
   {id}
   class:bx--overflow-menu={true}
   class:bx--overflow-menu--open={open}

--- a/tests/OverflowMenu/OverflowMenu.test.ts
+++ b/tests/OverflowMenu/OverflowMenu.test.ts
@@ -16,6 +16,21 @@ describe("OverflowMenu", () => {
     expect(menuButton).toHaveAttribute("aria-label", "");
   });
 
+  it("keeps aria-controls stable regardless of open state", async () => {
+    render(OverflowMenu, { props: { id: "test-id" } });
+
+    const menuButton = screen.getByRole("button");
+    expect(menuButton).toHaveAttribute("aria-controls", "menu-test-id");
+
+    await user.click(menuButton);
+    expect(menuButton).toHaveAttribute("aria-expanded", "true");
+    expect(menuButton).toHaveAttribute("aria-controls", "menu-test-id");
+
+    await user.keyboard("{Escape}");
+    expect(menuButton).toHaveAttribute("aria-expanded", "false");
+    expect(menuButton).toHaveAttribute("aria-controls", "menu-test-id");
+  });
+
   it("renders and functions correctly", async () => {
     render(OverflowMenu);
 


### PR DESCRIPTION
ARIA 1.2 allows `aria-controls` to point to an element that doesn't yet exist (the spec was relaxed to handle popup patterns), and AT prefer the relationship to be stable. Toggling `aria-controls` on every open/close adds churn.