### PR TITLE
fix(overflow-menu-item): `primaryFocus` should not be reactive

### DIFF
--- a/src/OverflowMenu/OverflowMenuItem.svelte
+++ b/src/OverflowMenu/OverflowMenuItem.svelte
@@ -64,13 +64,14 @@
 
   add({ id, text, primaryFocus, disabled });
 
+  $: focused = $focusedId === id;
+
   afterUpdate(() => {
-    if (ref && primaryFocus) {
+    if (ref && focused) {
       ref.focus();
     }
   });
 
-  $: primaryFocus = $focusedId === id;
   $: buttonProps = {
     role: "menuitem",
     tabindex: "-1",


### PR DESCRIPTION
`primaryFocus` is designed as a one-off prop for `OverflowMenuItem`. However, it's intentionally made reactive as it's reassigned internally to the current focused ID.

This doesn't directly impact the initial focused item. It cleans up the behavior so that `primaryFocus` is not reactive and mutated on arrow keypress.