### PR TITLE
fix(pagination): use clear suffixes for internal IDs

### DIFF
--- a/src/Pagination/Pagination.svelte
+++ b/src/Pagination/Pagination.svelte
@@ -168,14 +168,14 @@
   <div class:bx--pagination__left={true}>
     {#if !pageSizeInputDisabled}
       <label
-        id="bx--pagination-select-{id}-count-label"
-        for="bx--pagination-select-{id}"
+        id="bx--pagination-select-{id}-sizes-label"
+        for="bx--pagination-select-{id}-sizes"
         class:bx--pagination__text={true}
       >
         {itemsPerPageText}
       </label>
       <Select
-        id="bx--pagination-select-{id}"
+        id="bx--pagination-select-{id}-sizes"
         class="bx--select__item-count"
         hideLabel
         noLabel
@@ -205,7 +205,7 @@
   <div class:bx--pagination__right={true}>
     {#if !pageInputDisabled}
       <Select
-        id="bx--pagination-select-{id + 2}"
+        id="bx--pagination-select-{id}-pages"
         class="bx--select__page-number"
         labelText="Page number, of {totalPages} pages"
         inline

--- a/tests/Pagination/Pagination.test.ts
+++ b/tests/Pagination/Pagination.test.ts
@@ -300,6 +300,32 @@ describe("Pagination", () => {
     expect(pagination).toBeInTheDocument();
   });
 
+  it("derives select ids with semantic suffixes from the root id", () => {
+    render(Pagination, {
+      props: { id: "page-1", totalItems: 30, pageSizes: [10, 20] },
+    });
+
+    const sizeSelect = document.getElementById(
+      "bx--pagination-select-page-1-sizes",
+    );
+    const pageSelect = document.getElementById(
+      "bx--pagination-select-page-1-pages",
+    );
+    const sizeLabel = document.getElementById(
+      "bx--pagination-select-page-1-sizes-label",
+    );
+
+    expect(sizeSelect).toBeInTheDocument();
+    expect(pageSelect).toBeInTheDocument();
+    expect(sizeLabel).toHaveAttribute(
+      "for",
+      "bx--pagination-select-page-1-sizes",
+    );
+    expect(
+      document.getElementById("bx--pagination-select-page-12"),
+    ).not.toBeInTheDocument();
+  });
+
   it("should apply custom class", () => {
     render(Pagination, {
       props: { customClass: "custom-pagination" },


### PR DESCRIPTION
Use clear, semantic suffixes for the IDs for internal elements.