### PR TITLE
chore: replace `@generics` with `@template`

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -24,7 +24,7 @@
         "jsdom": "^29.0.1",
         "postcss": "^8.5.5",
         "sass": "^1.98.0",
-        "sveld": "^0.30.3",
+        "sveld": "0.31.0",
         "svelte": "^5.55.0",
         "svelte-check": "^4.4.8",
         "typescript": "^6.0.2",
@@ -445,7 +445,7 @@
 
     "strip-indent": ["strip-indent@3.0.0", "", { "dependencies": { "min-indent": "^1.0.0" } }, "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ=="],
 
-    "sveld": ["sveld@0.30.3", "", { "dependencies": { "prettier": "^3.8.0" }, "bin": { "sveld": "cli.js" } }, "sha512-90ydTwNSEQDYJ7F2hyo4DrM6qRWfUPZHu494zYzgpGPEjEVBMOIVynM22mRgnr7xlPmTPWv36/SLG5ckisT/Nw=="],
+    "sveld": ["sveld@0.31.0", "", { "dependencies": { "prettier": "^3.8.0" }, "bin": { "sveld": "cli.js" } }, "sha512-1R40i/0rsze5i6iRUH2YeysVNwsiZ0ekRG6Xc0LIueZ19uCoHSisgu5bGKI+L0H13dw3Tk56AHQ7v473Fd6IdQ=="],
 
     "svelte": ["svelte@5.55.0", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "@jridgewell/sourcemap-codec": "^1.5.0", "@sveltejs/acorn-typescript": "^1.0.5", "@types/estree": "^1.0.5", "@types/trusted-types": "^2.0.7", "acorn": "^8.12.1", "aria-query": "5.3.1", "axobject-query": "^4.1.0", "clsx": "^2.1.1", "devalue": "^5.6.4", "esm-env": "^1.2.1", "esrap": "^2.2.2", "is-reference": "^3.0.3", "locate-character": "^3.0.0", "magic-string": "^0.30.11", "zimmerframe": "^1.1.2" } }, "sha512-SThllKq6TRMBwPtat7ASnm/9CDXnIhBR0NPGw0ujn2DVYx9rVwsPZxDaDQcYGdUz/3BYVsCzdq7pZarRQoGvtw=="],
 

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "jsdom": "^29.0.1",
     "postcss": "^8.5.5",
     "sass": "^1.98.0",
-    "sveld": "^0.30.3",
+    "sveld": "0.31.0",
     "svelte": "^5.55.0",
     "svelte-check": "^4.4.8",
     "typescript": "^6.0.2",

--- a/src/Button/Button.svelte
+++ b/src/Button/Button.svelte
@@ -1,6 +1,9 @@
 <script>
   /**
-   * @generics {Icon = any} Icon
+   * @template [Icon=any]
+   */
+
+  /**
    * @extends {"./ButtonSkeleton.svelte"} ButtonSkeletonProps
    * @restProps {button | a | div}
    * @slot {{ props: { role: "button"; type?: string; tabindex: any; disabled: boolean; href?: string; class: string; [key: string]: any; } }}

--- a/src/Checkbox/Checkbox.svelte
+++ b/src/Checkbox/Checkbox.svelte
@@ -1,6 +1,6 @@
 <script>
   /**
-   * @generics {T = any} T
+   * @template [T=any]
    * @restProps {div}
    * @event {boolean} check
    */

--- a/src/ComboBox/ComboBox.svelte
+++ b/src/ComboBox/ComboBox.svelte
@@ -1,6 +1,9 @@
 <script>
   /**
-   * @generics {Item extends ComboBoxItem<any> = ComboBoxItem<any>} Item
+   * @template {ComboBoxItem<any>} [Item=ComboBoxItem<any>]
+   */
+
+  /**
    * @typedef {object} ComboBoxItem<Id=any>
    * @property {Id} id
    * @property {string} text

--- a/src/ComposedModal/ModalFooter.svelte
+++ b/src/ComposedModal/ModalFooter.svelte
@@ -1,6 +1,6 @@
 <script>
   /**
-   * @generics {Icon = any} Icon
+   * @template [Icon=any]
    * @event click:button--secondary
    * @property {string} text
    */

--- a/src/ContainedList/ContainedListItem.svelte
+++ b/src/ContainedList/ContainedListItem.svelte
@@ -1,6 +1,6 @@
 <script>
   /**
-   * @generics {Icon = any} Icon
+   * @template [Icon=any]
    */
 
   /** Set to `true` to render a `button` element instead of a `div` */

--- a/src/ContextMenu/ContextMenuOption.svelte
+++ b/src/ContextMenu/ContextMenuOption.svelte
@@ -4,7 +4,7 @@
    */
 
   /**
-   * @generics {Icon = any} Icon
+   * @template [Icon=any]
    */
 
   /**

--- a/src/DataTable/DataTable.svelte
+++ b/src/DataTable/DataTable.svelte
@@ -1,6 +1,9 @@
 <script>
   /**
-   * @generics {Row extends DataTableRow = DataTableRow} Row
+   * @template {DataTableRow} [Row=DataTableRow]
+   */
+
+  /**
    * @typedef {any} DataTableValue
    * @typedef {{ id: Id; [key: string]: DataTableValue; }} DataTableRow<Id=any>
    * @typedef {(

--- a/src/DataTable/ToolbarBatchActions.svelte
+++ b/src/DataTable/ToolbarBatchActions.svelte
@@ -1,6 +1,6 @@
 <script>
   /**
-   * @generics {Id = any} Id
+   * @template [Id=any]
    * @event {null} cancel
    */
 

--- a/src/DataTable/ToolbarSearch.svelte
+++ b/src/DataTable/ToolbarSearch.svelte
@@ -1,6 +1,6 @@
 <script>
   /**
-   * @generics {Row extends import("./DataTable.svelte").DataTableRow = import("./DataTable.svelte").DataTableRow} Row
+   * @template {import("./DataTable.svelte").DataTableRow} [Row=import("./DataTable.svelte").DataTableRow]
    * @restProps {input}
    * @event {null} clear
    */

--- a/src/Dropdown/Dropdown.svelte
+++ b/src/Dropdown/Dropdown.svelte
@@ -1,6 +1,9 @@
 <script>
   /**
-   * @generics {Item extends DropdownItem<any> = DropdownItem<any>} Item
+   * @template {DropdownItem<any>} [Item=DropdownItem<any>]
+   */
+
+  /**
    * @typedef {object} DropdownItem<Id=any>
    * @property {Id} id
    * @property {string} text

--- a/src/FileUploader/FileUploaderButton.svelte
+++ b/src/FileUploader/FileUploaderButton.svelte
@@ -1,6 +1,6 @@
 <script>
   /**
-   * @generics {Icon = any} Icon
+   * @template [Icon=any]
    * @event {ReadonlyArray<File>} change
    */
 

--- a/src/Link/Link.svelte
+++ b/src/Link/Link.svelte
@@ -1,6 +1,6 @@
 <script>
   /**
-   * @generics {Icon = any} Icon
+   * @template [Icon=any]
    */
 
   /**

--- a/src/LocalStorage/LocalStorage.svelte
+++ b/src/LocalStorage/LocalStorage.svelte
@@ -1,6 +1,6 @@
 <script>
   /**
-   * @generics {T = any} T
+   * @template [T=any]
    * @event {null} save
    * @event update - Fires when the stored value changes, either from a bound value update or when localStorage is modified from another tab/window.
    * @property {T} prevValue

--- a/src/Modal/Modal.svelte
+++ b/src/Modal/Modal.svelte
@@ -1,6 +1,6 @@
 <script>
   /**
-   * @generics {Icon = any} Icon
+   * @template [Icon=any]
    * @event close
    * @type {object}
    * @property {"escape-key" | "outside-click" | "close-button"} trigger

--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -1,6 +1,9 @@
 <script>
   /**
-   * @generics {Item extends MultiSelectItem<any> = MultiSelectItem<any>} Item
+   * @template {MultiSelectItem<any>} [Item=MultiSelectItem<any>]
+   */
+
+  /**
    * @typedef {string} MultiSelectItemText
    * @typedef {object} MultiSelectItem<Id=any>
    * @property {Id} id

--- a/src/Notification/NotificationButton.svelte
+++ b/src/Notification/NotificationButton.svelte
@@ -1,6 +1,6 @@
 <script>
   /**
-   * @generics {Icon = any} Icon
+   * @template [Icon=any]
    */
 
   /**

--- a/src/OverflowMenu/OverflowMenu.svelte
+++ b/src/OverflowMenu/OverflowMenu.svelte
@@ -1,6 +1,6 @@
 <script>
   /**
-   * @generics {Icon = any} Icon
+   * @template [Icon=any]
    * @event close
    * @property {number} [index]
    * @property {string} [text]

--- a/src/RadioButton/RadioButton.svelte
+++ b/src/RadioButton/RadioButton.svelte
@@ -1,6 +1,6 @@
 <script>
   /**
-   * @generics {Value extends string | number = string | number} Value
+   * @template {string | number} [Value=string | number]
    */
 
   /**

--- a/src/RadioButtonGroup/RadioButtonGroup.svelte
+++ b/src/RadioButtonGroup/RadioButtonGroup.svelte
@@ -1,6 +1,6 @@
 <script>
   /**
-   * @generics {Value extends string | number = string | number} Value
+   * @template {string | number} [Value=string | number]
    * @event {Value} change
    */
 

--- a/src/RecursiveList/RecursiveList.svelte
+++ b/src/RecursiveList/RecursiveList.svelte
@@ -1,6 +1,6 @@
 <script>
   /**
-   * @generics {Node extends RecursiveListNode = RecursiveListNode} Node
+   * @template {RecursiveListNode} [Node=RecursiveListNode]
    * @typedef {object} RecursiveListNode
    * @property {string} [text] - Node text content
    * @property {string} [href] - Node link URL

--- a/src/Search/Search.svelte
+++ b/src/Search/Search.svelte
@@ -1,6 +1,7 @@
 <script>
   /**
-   * @generics {T = any, Icon = any} T,Icon
+   * @template [T=any]
+   * @template [Icon=any]
    * @event {null} expand
    * @event {null} collapse
    * @restProps {input}

--- a/src/Select/Select.svelte
+++ b/src/Select/Select.svelte
@@ -1,6 +1,6 @@
 <script>
   /**
-   * @generics {Value extends string | number = string | number} Value
+   * @template {string | number} [Value=string | number]
    * @event {Value} update The selected value.
    */
 

--- a/src/Select/SelectItem.svelte
+++ b/src/Select/SelectItem.svelte
@@ -1,6 +1,6 @@
 <script>
   /**
-   * @generics {Value extends string | number = string | number} Value
+   * @template {string | number} [Value=string | number]
    */
 
   /**

--- a/src/SessionStorage/SessionStorage.svelte
+++ b/src/SessionStorage/SessionStorage.svelte
@@ -1,6 +1,6 @@
 <script>
   /**
-   * @generics {T = any} T
+   * @template [T=any]
    * @event {null} save
    * @event update - Fires when the stored value changes, either from a bound value update or when sessionStorage is modified from another tab/window.
    * @property {T} prevValue

--- a/src/StructuredList/StructuredList.svelte
+++ b/src/StructuredList/StructuredList.svelte
@@ -1,6 +1,6 @@
 <script>
   /**
-   * @generics {Value extends string = string} Value
+   * @template {string} [Value=string]
    * @event {Value} change
    */
 

--- a/src/StructuredList/StructuredListInput.svelte
+++ b/src/StructuredList/StructuredListInput.svelte
@@ -1,6 +1,6 @@
 <script>
   /**
-   * @generics {Value extends string = string} Value
+   * @template {string} [Value=string]
    */
 
   /** Set to `true` to check the input */

--- a/src/Tabs/Tab.svelte
+++ b/src/Tabs/Tab.svelte
@@ -1,6 +1,6 @@
 <script>
   /**
-   * @generics {Icon = any} Icon
+   * @template [Icon=any]
    */
 
   /**

--- a/src/Tag/SelectableTag.svelte
+++ b/src/Tag/SelectableTag.svelte
@@ -1,6 +1,6 @@
 <script>
   /**
-   * @generics {Icon = any} Icon
+   * @template [Icon=any]
    * @restProps {button}
    * @event {{ selected: boolean }} "change"
    */

--- a/src/Tag/Tag.svelte
+++ b/src/Tag/Tag.svelte
@@ -1,6 +1,6 @@
 <script>
   /**
-   * @generics {Icon = any} Icon
+   * @template [Icon=any]
    * @restProps {div | span}
    */
 

--- a/src/Theme/Theme.svelte
+++ b/src/Theme/Theme.svelte
@@ -16,7 +16,10 @@
    */
 
   /**
-   * @generics {Tokens = Record<string, any>} Tokens
+   * @template [Tokens=Record<string, any>]
+   */
+
+  /**
    * @typedef {"white" | "g10" | "g80" | "g90" | "g100"} CarbonTheme
    * @event update
    * @type {object}

--- a/src/Tile/RadioTile.svelte
+++ b/src/Tile/RadioTile.svelte
@@ -1,7 +1,7 @@
 <script>
   /**
    * @restProps {label}
-   * @generics {Value extends string = string} Value
+   * @template {string} [Value=string]
    */
 
   /** Set to `true` to check the tile */

--- a/src/Tile/SelectableTileGroup.svelte
+++ b/src/Tile/SelectableTileGroup.svelte
@@ -1,6 +1,6 @@
 <script>
   /**
-   * @generics {T extends string = string} T
+   * @template {string} [T=string]
    * @event {T} select
    * @event {T} deselect
    */

--- a/src/Tile/TileGroup.svelte
+++ b/src/Tile/TileGroup.svelte
@@ -1,6 +1,6 @@
 <script>
   /**
-   * @generics {T extends string = string} T
+   * @template {string} [T=string]
    * @event {T} select
    */
 

--- a/src/Tooltip/Tooltip.svelte
+++ b/src/Tooltip/Tooltip.svelte
@@ -1,6 +1,6 @@
 <script>
   /**
-   * @generics {Icon = any} Icon
+   * @template [Icon=any]
    * @event {null} open
    * @event {null} close
    */

--- a/src/TooltipIcon/TooltipIcon.svelte
+++ b/src/TooltipIcon/TooltipIcon.svelte
@@ -1,6 +1,6 @@
 <script>
   /**
-   * @generics {Icon = any} Icon
+   * @template [Icon=any]
    * @event {null} open
    * @event {null} close
    */

--- a/src/UIShell/HamburgerMenu.svelte
+++ b/src/UIShell/HamburgerMenu.svelte
@@ -1,6 +1,6 @@
 <script>
   /**
-   * @generics {Icon = any} Icon
+   * @template [Icon=any]
    */
 
   /**

--- a/src/UIShell/Header.svelte
+++ b/src/UIShell/Header.svelte
@@ -1,6 +1,6 @@
 <script>
   /**
-   * @generics {Icon = any} Icon
+   * @template [Icon=any]
    */
 
   /** Set to `false` to hide the side nav by default */

--- a/src/UIShell/HeaderAction.svelte
+++ b/src/UIShell/HeaderAction.svelte
@@ -1,6 +1,6 @@
 <script>
   /**
-   * @generics {Icon = any} Icon
+   * @template [Icon=any]
    * @event {null} open
    * @event {null} close
    */

--- a/src/UIShell/HeaderActionLink.svelte
+++ b/src/UIShell/HeaderActionLink.svelte
@@ -1,6 +1,6 @@
 <script>
   /**
-   * @generics {Icon = any} Icon
+   * @template [Icon=any]
    */
 
   /** Set to `true` to use the active state */

--- a/src/UIShell/HeaderGlobalAction.svelte
+++ b/src/UIShell/HeaderGlobalAction.svelte
@@ -1,6 +1,6 @@
 <script>
   /**
-   * @generics {Icon = any} Icon
+   * @template [Icon=any]
    * @extends {"../Button/Button.svelte"} ButtonProps
    */
 

--- a/src/UIShell/HeaderSearch.svelte
+++ b/src/UIShell/HeaderSearch.svelte
@@ -1,6 +1,9 @@
 <script>
   /**
-   * @generics {Result extends HeaderSearchResult = HeaderSearchResult} Result
+   * @template {HeaderSearchResult} [Result=HeaderSearchResult]
+   */
+
+  /**
    * @typedef {object} HeaderSearchResult
    * @property {string} href
    * @property {string} text

--- a/src/UIShell/SideNavLink.svelte
+++ b/src/UIShell/SideNavLink.svelte
@@ -1,6 +1,6 @@
 <script>
   /**
-   * @generics {Icon = any} Icon
+   * @template [Icon=any]
    */
 
   /** Set to `true` to select the current link */

--- a/src/UIShell/SideNavMenu.svelte
+++ b/src/UIShell/SideNavMenu.svelte
@@ -1,6 +1,6 @@
 <script>
   /**
-   * @generics {Icon = any} Icon
+   * @template [Icon=any]
    */
 
   /** Set to `true` to toggle the expanded state */


### PR DESCRIPTION
Upgrade `sveld` to 0.31.0 and replace the bespoke `@generics` tag with `@template` for typing generics.

`@template` is the official JSDoc tag to denote generics.