### PR TITLE
fix: drop literal "undefined" token from interpolated class strings

### DIFF
--- a/src/DataTable/ToolbarMenu.svelte
+++ b/src/DataTable/ToolbarMenu.svelte
@@ -16,7 +16,9 @@
   bind:menuRef
   icon={Settings}
   {...$$restProps}
-  class="bx--toolbar-action bx--overflow-menu {$$restProps.class}"
+  class={["bx--toolbar-action", "bx--overflow-menu", $$restProps.class]
+    .filter(Boolean)
+    .join(" ")}
   flipped
 >
   <slot />

--- a/src/DataTable/ToolbarSearch.svelte
+++ b/src/DataTable/ToolbarSearch.svelte
@@ -108,7 +108,7 @@
   {tabindex}
   {disabled}
   {...$$restProps}
-  searchClass="{classes} {$$restProps.class}"
+  searchClass={[classes, $$restProps.class].filter(Boolean).join(" ")}
   bind:ref
   bind:value
   on:clear

--- a/src/FluidForm/FluidForm.svelte
+++ b/src/FluidForm/FluidForm.svelte
@@ -16,7 +16,7 @@
 
 <Form
   {...$$restProps}
-  class="bx--form--fluid {$$restProps.class}"
+  class={["bx--form--fluid", $$restProps.class].filter(Boolean).join(" ")}
   on:click
   on:keydown
   on:mouseover

--- a/src/Notification/NotificationActionButton.svelte
+++ b/src/Notification/NotificationActionButton.svelte
@@ -8,7 +8,9 @@
   kind="ghost"
   size="small"
   {...$$restProps}
-  class="bx--inline-notification__action-button {$$restProps.class}"
+  class={["bx--inline-notification__action-button", $$restProps.class]
+    .filter(Boolean)
+    .join(" ")}
   on:click
   on:mouseover
   on:mouseenter


### PR DESCRIPTION
Interpolating `$$restProps.class` into a class template emitted `"undefined"` when consumers passed no class. Switch to the `[…].filter(Boolean).join(" ")` pattern already used elsewhere.