### PR TITLE
feat(notification-queue): add `update` prop

### DIFF
--- a/docs/src/pages/components/NotificationQueue.svx
+++ b/docs/src/pages/components/NotificationQueue.svx
@@ -28,9 +28,17 @@ The `top-right` position assumes usage of the [UIShell](/components/UIShell) com
 
 By default, the `id` prop is optional; a unique id will be generated for the notification. The queue [keys](https://svelte.dev/docs/svelte/each#Keyed-each-blocks) notifications by `id` for performance reasons.
 
-Notifications are deduplicated by `id`. If you add a notification with an `id` that already exists in the queue, the call is ignored. This prevents duplicate notifications from appearing.
+Notifications are deduplicated by `id`. If you add a notification with an `id` that already exists in the queue, the call is ignored. This prevents duplicate notifications from appearing. To change an existing notification in place, use [update](#update).
 
 <FileSource src="/framed/NotificationQueue/NotificationQueueDeduplication" />
+
+## Update
+
+Use `update(id, patch)` to change an existing notification in place. The `patch` is merged into the matching notification, which is useful for reflecting progress (for example, transitioning a "loading" toast to "success" without removing and re-adding it).
+
+`update` returns `true` if a notification with the given `id` was found, `false` otherwise.
+
+<FileSource src="/framed/NotificationQueue/NotificationQueueUpdate" />
 
 ## Max notifications
 

--- a/docs/src/pages/framed/NotificationQueue/NotificationQueueUpdate.svelte
+++ b/docs/src/pages/framed/NotificationQueue/NotificationQueueUpdate.svelte
@@ -1,0 +1,38 @@
+<script>
+  import { Button, NotificationQueue } from "carbon-components-svelte";
+
+  let queue;
+</script>
+
+<NotificationQueue bind:this={queue} />
+
+<Button
+  on:click={() => {
+    const id = queue.add({
+      id: "upload",
+      kind: "info",
+      title: "Uploading...",
+      subtitle: "0%",
+      hideCloseButton: true,
+    });
+
+    let progress = 0;
+    const interval = setInterval(() => {
+      progress += 25;
+      if (progress < 100) {
+        queue.update(id, { subtitle: `${progress}%` });
+      } else {
+        clearInterval(interval);
+        queue.update(id, {
+          kind: "success",
+          title: "Upload complete",
+          subtitle: "All files have been uploaded.",
+          hideCloseButton: false,
+          timeout: 3000,
+        });
+      }
+    }, 600);
+  }}
+>
+  Start upload
+</Button>

--- a/src/Notification/NotificationQueue.svelte
+++ b/src/Notification/NotificationQueue.svelte
@@ -51,7 +51,8 @@
 
   /**
    * Add a notification to the queue.
-   * If a notification with the same id exists, the call is ignored.
+   * If a notification with the same id already exists, the call is ignored.
+   * To change an existing notification in place, use `update`.
    * Returns the notification id (either the provided id or a generated one).
    * @type {(notification: NotificationData) => string}
    */
@@ -79,6 +80,21 @@
     notifications = notifications;
 
     return id;
+  }
+
+  /**
+   * Update an existing notification by id, merging `patch` into it.
+   * The id of the notification cannot be changed.
+   * Returns true if the notification was found and updated, false otherwise.
+   * @type {(id: string, patch: Partial<NotificationData>) => boolean}
+   */
+  export function update(id, patch) {
+    const index = notifications.findIndex((n) => n.id === id);
+    if (index === -1) return false;
+
+    notifications[index] = { ...notifications[index], ...patch, id };
+    notifications = notifications;
+    return true;
   }
 
   /**

--- a/tests/Notification/NotificationQueue.test.ts
+++ b/tests/Notification/NotificationQueue.test.ts
@@ -188,6 +188,87 @@ describe("NotificationQueue", () => {
     expect(removed).toBe(false);
   });
 
+  it("should update an existing notification in place", async () => {
+    const { component } = render(NotificationQueueTest);
+
+    const id = getQueue(component).add({
+      id: "progress",
+      kind: "info",
+      title: "Uploading...",
+      subtitle: "0%",
+    });
+    await tick();
+
+    expect(screen.getByText("Uploading...")).toBeInTheDocument();
+    expect(screen.getByText("0%")).toBeInTheDocument();
+
+    const updated = getQueue(component).update(id, {
+      kind: "success",
+      title: "Upload complete",
+      subtitle: "100%",
+    });
+    await tick();
+
+    expect(updated).toBe(true);
+    expect(screen.queryByText("Uploading...")).not.toBeInTheDocument();
+    expect(screen.queryByText("0%")).not.toBeInTheDocument();
+    expect(screen.getByText("Upload complete")).toBeInTheDocument();
+    expect(screen.getByText("100%")).toBeInTheDocument();
+    expect(screen.getAllByRole("alert")).toHaveLength(1);
+  });
+
+  it("should merge patch into existing notification on update", async () => {
+    const { component } = render(NotificationQueueTest);
+
+    const id = getQueue(component).add({
+      id: "merge",
+      kind: "info",
+      title: "Title",
+      subtitle: "Subtitle",
+    });
+    await tick();
+
+    getQueue(component).update(id, { kind: "success" });
+    await tick();
+
+    expect(screen.getByText("Title")).toBeInTheDocument();
+    expect(screen.getByText("Subtitle")).toBeInTheDocument();
+  });
+
+  it("should ignore id changes on update", async () => {
+    const { component } = render(NotificationQueueTest);
+
+    const id = getQueue(component).add({
+      id: "original",
+      kind: "info",
+      title: "Original",
+    });
+    await tick();
+
+    const updated = getQueue(component).update(id, {
+      id: "different",
+      title: "Updated",
+    });
+    await tick();
+
+    expect(updated).toBe(true);
+    expect(screen.getByText("Updated")).toBeInTheDocument();
+
+    const removed = getQueue(component).remove("original");
+    await tick();
+    expect(removed).toBe(true);
+    expect(screen.queryByText("Updated")).not.toBeInTheDocument();
+  });
+
+  it("should return false when updating non-existent notification", () => {
+    const { component } = render(NotificationQueueTest);
+
+    const updated = getQueue(component).update("non-existent-id", {
+      title: "New title",
+    });
+    expect(updated).toBe(false);
+  });
+
   it("should clear all notifications", async () => {
     const { component } = render(NotificationQueueTest);
 


### PR DESCRIPTION
Add an `update` prop to allow updating an existing notification in place.

---

https://github.com/user-attachments/assets/6339b59e-2686-43b2-b867-4b4026205460

