### PR TITLE
fix(modal): skip Enter submit when target is textarea/select/contenteditable

### DIFF
--- a/src/Modal/Modal.svelte
+++ b/src/Modal/Modal.svelte
@@ -253,6 +253,11 @@
         e.key === "Enter" &&
         !primaryButtonDisabled
       ) {
+        const target = e.target;
+        const tag = target?.tagName;
+        if (tag === "TEXTAREA" || tag === "SELECT" || target?.isContentEditable) {
+          return;
+        }
         if (formId && primaryButtonRef) {
           primaryButtonRef.click();
         } else {

--- a/tests/Modal/Modal.test.ts
+++ b/tests/Modal/Modal.test.ts
@@ -8,6 +8,7 @@ import ModalFocusReturnTest from "./ModalFocusReturn.test.svelte";
 import ModalFocusTrapTest from "./ModalFocusTrap.test.svelte";
 import ModalFormIdTest from "./ModalFormId.test.svelte";
 import ModalNullishAriaLabel from "./ModalNullishAriaLabel.test.svelte";
+import ModalTextareaEnterTest from "./ModalTextareaEnter.test.svelte";
 
 describe("Modal", () => {
   beforeEach(() => {
@@ -745,6 +746,28 @@ describe("Modal", () => {
       expect(submitHandler).toHaveBeenCalledTimes(1);
       expect(clickPrimaryHandler).toHaveBeenCalledTimes(1);
     });
+  });
+
+  it("should NOT dispatch submit when pressing Enter inside a textarea", async () => {
+    const submitHandler = vi.fn();
+    const clickPrimaryHandler = vi.fn();
+    render(ModalTextareaEnterTest, {
+      props: {
+        open: true,
+        shouldSubmitOnEnter: true,
+        onsubmit: submitHandler,
+        onclickbuttonprimary: clickPrimaryHandler,
+      },
+    });
+
+    const textarea = screen.getByTestId("modal-textarea");
+    expect.assert(textarea instanceof HTMLTextAreaElement);
+    textarea.focus();
+    await user.keyboard("{Enter}");
+    await tick();
+
+    expect(submitHandler).not.toHaveBeenCalled();
+    expect(clickPrimaryHandler).not.toHaveBeenCalled();
   });
 
   describe("Generics", () => {

--- a/tests/Modal/ModalTextareaEnter.test.svelte
+++ b/tests/Modal/ModalTextareaEnter.test.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import { Modal } from "carbon-components-svelte";
+
+  export let open = true;
+  export let shouldSubmitOnEnter = true;
+  export let onsubmit: ((event: CustomEvent) => void) | undefined = undefined;
+  export let onclickbuttonprimary: ((event: CustomEvent) => void) | undefined =
+    undefined;
+</script>
+
+<Modal
+  bind:open
+  modalHeading="Textarea Modal"
+  primaryButtonText="Save"
+  secondaryButtonText="Cancel"
+  {shouldSubmitOnEnter}
+  on:submit={(e) => onsubmit?.(e)}
+  on:click:button--primary={(e) => onclickbuttonprimary?.(e)}
+>
+  <textarea data-testid="modal-textarea"></textarea>
+</Modal>


### PR DESCRIPTION
When `shouldSubmitOnEnter` is true, a bug can occur where pressing Enter inside a `<textarea>`, `<select>`, or `contenteditable` element bubbled to the modal keydown handler and dispatched `submit`, overriding the native behavior.

A textarea should not constrain Enter because it allows multiple lines.