### PR TITLE
fix(notification): track reactive `kind` for default `statusIconDescription`

### DIFF
--- a/src/Notification/InlineNotification.svelte
+++ b/src/Notification/InlineNotification.svelte
@@ -32,7 +32,7 @@
    * Specify the ARIA label for the status icon.
    * @type {string}
    * */
-  export let statusIconDescription = `${kind} icon`;
+  export let statusIconDescription = undefined;
 
   /** Specify the ARIA label for the close button */
   export let closeButtonDescription = "Close notification";
@@ -60,6 +60,8 @@
       open = false;
     }
   }
+
+  $: defaultStatusIconDescription = `${kind} icon`;
 
   $: if (open && timeout) {
     clearTimeout(timeoutId);
@@ -98,7 +100,7 @@
       <NotificationIcon
         notificationType="inline"
         {kind}
-        iconDescription={statusIconDescription}
+        iconDescription={statusIconDescription ?? defaultStatusIconDescription}
       />
       <div class:bx--inline-notification__text-wrapper={true}>
         {#if title || $$slots.titleChildren}

--- a/src/Notification/ToastNotification.svelte
+++ b/src/Notification/ToastNotification.svelte
@@ -32,7 +32,7 @@
    * Specify the ARIA label for the status icon.
    * @type {string}
    * */
-  export let statusIconDescription = `${kind} icon`;
+  export let statusIconDescription = undefined;
 
   /** Specify the ARIA label for the close button */
   export let closeButtonDescription = "Close notification";
@@ -79,6 +79,8 @@
     };
   });
 
+  $: defaultStatusIconDescription = `${kind} icon`;
+
   $: if (typeof window !== "undefined") {
     /**
      * Clear the timer if {@link timeout} or {@link open} changes.
@@ -113,7 +115,10 @@
     on:mouseenter
     on:mouseleave
   >
-    <NotificationIcon {kind} iconDescription={statusIconDescription} />
+    <NotificationIcon
+      {kind}
+      iconDescription={statusIconDescription ?? defaultStatusIconDescription}
+    />
     <div class:bx--toast-notification__details={true}>
       <h3 class:bx--toast-notification__title={true}>
         <slot name="titleChildren">{title}</slot>

--- a/tests/InlineNotification/InlineNotification.test.ts
+++ b/tests/InlineNotification/InlineNotification.test.ts
@@ -196,6 +196,22 @@ describe("InlineNotification", () => {
     expect(closeHandler.mock.calls[0][0].detail).toEqual({ timeout: true });
   });
 
+  it("default statusIconDescription should track reactive kind changes", async () => {
+    const { rerender } = render(InlineNotificationTest, {
+      props: { kind: "info" },
+    });
+
+    expect(
+      document.querySelector(".bx--inline-notification__icon title"),
+    ).toHaveTextContent("info icon");
+
+    await rerender({ kind: "success" });
+
+    expect(
+      document.querySelector(".bx--inline-notification__icon title"),
+    ).toHaveTextContent("success icon");
+  });
+
   it("should use custom role", () => {
     render(InlineNotificationTest, {
       props: { role: "status" },


### PR DESCRIPTION
The default `${kind} icon` was evaluated once at script init, so toggling `kind` after mount kept announcing the original value. Default the prop to `undefined` and fall back to a reactive derived label.