### PR TITLE
fix(tree-view): parity for keyboard navigation, subtree a11y

### DIFF
--- a/src/TreeView/TreeView.svelte
+++ b/src/TreeView/TreeView.svelte
@@ -406,7 +406,13 @@
     }
   }
 
-  import { createEventDispatcher, onMount, setContext, tick } from "svelte";
+  import {
+    afterUpdate,
+    createEventDispatcher,
+    onMount,
+    setContext,
+    tick,
+  } from "svelte";
   import { writable } from "svelte/store";
   import TreeViewNodeList from "./TreeViewNodeList.svelte";
 
@@ -749,15 +755,24 @@
     }
   }
 
-  onMount(() => {
+  /** @type {ReadonlyArray<Node> | null} */
+  let prevNodesForFirstTab = null;
+
+  afterUpdate(() => {
+    if (!ref) return;
+    if (nodes === prevNodesForFirstTab) return;
+    prevNodesForFirstTab = nodes;
+
     const firstFocusableNode = ref.querySelector(
-      "li.bx--tree-node:not(.bx--tree-node--disabled)",
+      ".bx--tree-node:not(.bx--tree-node--disabled):not(.bx--tree-node--hidden)",
     );
 
-    if (firstFocusableNode != null) {
-      firstFocusableNode.tabIndex = "0";
+    if (firstFocusableNode instanceof HTMLElement) {
+      firstFocusableNode.tabIndex = 0;
     }
+  });
 
+  onMount(() => {
     if (ref && !treeWalker) {
       treeWalker = createTreeWalkerInstance(ref);
     }

--- a/src/TreeView/TreeView.svelte
+++ b/src/TreeView/TreeView.svelte
@@ -641,18 +641,51 @@
     toggleNode,
   });
 
+  /** @param {HTMLElement | null} root */
+  function resetNodeTabIndices(root) {
+    if (!root) return;
+    const items = root.querySelectorAll('[tabindex="0"]');
+    for (let i = 0; i < items.length; i++) {
+      const el = items[i];
+      if (el instanceof HTMLElement) el.tabIndex = -1;
+    }
+  }
+
+  /** @param {EventTarget | null} target */
+  function getTreeItemFromTarget(target) {
+    if (!(target instanceof Element)) return null;
+    if (target.classList.contains("bx--tree-node")) return target;
+    return target.closest(".bx--tree-node");
+  }
+
   function handleKeyDown(e) {
+    e.stopPropagation();
+
     if (e.key === "ArrowUp" || e.key === "ArrowDown") e.preventDefault();
 
-    treeWalker.currentNode = e.target;
+    if (!treeWalker || !ref) return;
 
-    let node = null;
+    const treeItem = getTreeItemFromTarget(e.target);
+    if (!treeItem) return;
 
-    if (e.key === "ArrowUp") node = treeWalker.previousNode();
-    if (e.key === "ArrowDown") node = treeWalker.nextNode();
-    if (node && node !== e.target) {
-      node.tabIndex = "0";
-      node.focus();
+    treeWalker.currentNode = treeItem;
+
+    /** @type {Node | null} */
+    let nextFocusNode = null;
+
+    if (e.key === "ArrowUp") {
+      nextFocusNode = treeWalker.previousNode();
+    }
+    if (e.key === "ArrowDown") {
+      nextFocusNode = treeWalker.nextNode();
+    }
+
+    if (nextFocusNode && nextFocusNode !== treeItem) {
+      resetNodeTabIndices(ref);
+      if (nextFocusNode instanceof HTMLElement) {
+        nextFocusNode.tabIndex = 0;
+        nextFocusNode.focus();
+      }
     }
   }
 

--- a/src/TreeView/TreeView.svelte
+++ b/src/TreeView/TreeView.svelte
@@ -687,35 +687,53 @@
       nextFocusNode = treeWalker.nextNode();
     }
 
-    if (e.key === "Home" || e.key === "End") {
+    const isHomeOrEnd = e.key === "Home" || e.key === "End";
+    const isSelectAll =
+      (e.code === "KeyA" || e.key === "a" || e.key === "A") && e.ctrlKey;
+
+    if (isHomeOrEnd || isSelectAll) {
       /** @type {Array<string | number>} */
       const nodeIds = [];
 
-      if (
-        multiselect &&
-        e.shiftKey &&
-        e.ctrlKey &&
-        treeItem instanceof HTMLElement &&
-        !treeItem.getAttribute("aria-disabled") &&
-        !treeItem.classList.contains("bx--tree-node--hidden")
-      ) {
-        const hid = treeItem.id;
-        if (hid) nodeIds.push(hid);
-      }
-      while (
-        e.key === "Home" ? treeWalker.previousNode() : treeWalker.nextNode()
-      ) {
-        nextFocusNode = treeWalker.currentNode;
+      if (isHomeOrEnd) {
         if (
           multiselect &&
           e.shiftKey &&
           e.ctrlKey &&
-          nextFocusNode instanceof Element &&
-          !nextFocusNode.getAttribute("aria-disabled") &&
-          !nextFocusNode.classList.contains("bx--tree-node--hidden")
+          treeItem instanceof HTMLElement
         ) {
-          const nid = nextFocusNode.id;
-          if (nid) nodeIds.push(nid);
+          const hid = treeItem.id;
+          if (hid) nodeIds.push(hid);
+        }
+        while (
+          e.key === "Home" ? treeWalker.previousNode() : treeWalker.nextNode()
+        ) {
+          nextFocusNode = treeWalker.currentNode;
+          if (
+            multiselect &&
+            e.shiftKey &&
+            e.ctrlKey &&
+            nextFocusNode instanceof Element
+          ) {
+            const nid = nextFocusNode.id;
+            if (nid) nodeIds.push(nid);
+          }
+        }
+      }
+
+      if (isSelectAll) {
+        e.preventDefault();
+        for (const n of flattenedNodes) {
+          if (n.disabled) continue;
+          const el = ref?.querySelector(`[id="${CSS.escape(String(n.id))}"]`);
+          if (!el) continue;
+          if (
+            el.classList.contains("bx--tree-node--hidden") ||
+            isUnderCollapsedSubtree(el)
+          ) {
+            continue;
+          }
+          nodeIds.push(n.id);
         }
       }
 

--- a/src/TreeView/TreeView.svelte
+++ b/src/TreeView/TreeView.svelte
@@ -661,7 +661,14 @@
   function handleKeyDown(e) {
     e.stopPropagation();
 
-    if (e.key === "ArrowUp" || e.key === "ArrowDown") e.preventDefault();
+    if (
+      e.key === "ArrowUp" ||
+      e.key === "ArrowDown" ||
+      e.key === "Home" ||
+      e.key === "End"
+    ) {
+      e.preventDefault();
+    }
 
     if (!treeWalker || !ref) return;
 
@@ -678,6 +685,41 @@
     }
     if (e.key === "ArrowDown") {
       nextFocusNode = treeWalker.nextNode();
+    }
+
+    if (e.key === "Home" || e.key === "End") {
+      /** @type {Array<string | number>} */
+      const nodeIds = [];
+
+      if (
+        multiselect &&
+        e.shiftKey &&
+        e.ctrlKey &&
+        treeItem instanceof HTMLElement &&
+        !treeItem.getAttribute("aria-disabled") &&
+        !treeItem.classList.contains("bx--tree-node--hidden")
+      ) {
+        const hid = treeItem.id;
+        if (hid) nodeIds.push(hid);
+      }
+      while (
+        e.key === "Home" ? treeWalker.previousNode() : treeWalker.nextNode()
+      ) {
+        nextFocusNode = treeWalker.currentNode;
+        if (
+          multiselect &&
+          e.shiftKey &&
+          e.ctrlKey &&
+          nextFocusNode instanceof Element &&
+          !nextFocusNode.getAttribute("aria-disabled") &&
+          !nextFocusNode.classList.contains("bx--tree-node--hidden")
+        ) {
+          const nid = nextFocusNode.id;
+          if (nid) nodeIds.push(nid);
+        }
+      }
+
+      selectedIds = selectedIds.concat(nodeIds);
     }
 
     if (nextFocusNode && nextFocusNode !== treeItem) {

--- a/src/TreeView/TreeView.svelte
+++ b/src/TreeView/TreeView.svelte
@@ -26,6 +26,10 @@
     return null;
   }
 
+  function isUnderCollapsedSubtree(el) {
+    return Boolean(el.closest("ul.bx--tree-node--hidden"));
+  }
+
   /**
    * Creates a TreeWalker instance for keyboard navigation.
    * @param {HTMLElement} root - The root element to traverse
@@ -34,14 +38,17 @@
   function createTreeWalkerInstance(root) {
     return document.createTreeWalker(root, NodeFilter.SHOW_ELEMENT, {
       acceptNode: (node) => {
-        if (node.classList.contains("bx--tree-node--disabled"))
+        if (!(node instanceof Element)) return NodeFilter.FILTER_SKIP;
+        if (
+          node.classList.contains("bx--tree-node--disabled") ||
+          node.classList.contains("bx--tree-node--hidden")
+        ) {
           return NodeFilter.FILTER_REJECT;
+        }
         if (node.matches("li.bx--tree-node")) {
-          // Collapsed branches keep children in the DOM under
-          // `ul.bx--tree-node--hidden`; skip them so ArrowUp/ArrowDown follow
-          // visible order only (matches prior unmount behavior).
-          if (node.closest("ul.bx--tree-node--hidden"))
-            return NodeFilter.FILTER_REJECT;
+          // Children stay mounted under a hidden subtree `ul`; skip so Arrow keys
+          // follow visible rows only (same as when branches were unmounted).
+          if (isUnderCollapsedSubtree(node)) return NodeFilter.FILTER_REJECT;
           return NodeFilter.FILTER_ACCEPT;
         }
         return NodeFilter.FILTER_SKIP;

--- a/src/TreeView/TreeViewNode.svelte
+++ b/src/TreeView/TreeViewNode.svelte
@@ -41,7 +41,7 @@
    * @param {HTMLElement | null} node
    * @returns {null | HTMLElement}
    */
-  function findParentTreeNode(node) {
+  export function findParentTreeNode(node) {
     if (node == null || !(node instanceof HTMLElement)) return null;
     if (node.classList.contains("bx--tree-parent-node")) return node;
     if (node.classList.contains("bx--tree-node-link-parent")) {

--- a/src/TreeView/TreeViewNodeList.svelte
+++ b/src/TreeView/TreeViewNodeList.svelte
@@ -155,10 +155,12 @@
       if (e.key === "Enter" || e.key === " ") {
         e.preventDefault();
         if (disabled) return;
-        expanded = !expanded;
-        toggleNode(node);
+        if (e.key === "Enter" && parent) {
+          const nextExpanded = !expanded;
+          expandNode(node, nextExpanded);
+          toggleNode(node);
+        }
         clickNode(node, e);
-        expandNode(node, expanded);
         ref.focus();
       }
     }}
@@ -174,8 +176,8 @@
         {disabled}
         on:click={() => {
           if (disabled) return;
-          expanded = !expanded;
-          expandNode(node, expanded);
+          const nextExpanded = !expanded;
+          expandNode(node, nextExpanded);
           toggleNode(node);
         }}
       >

--- a/src/TreeView/TreeViewNodeList.svelte
+++ b/src/TreeView/TreeViewNodeList.svelte
@@ -27,6 +27,20 @@
     findParentTreeNode,
   } from "./TreeViewNode.svelte";
 
+  /**
+   * First focusable tree item in a subtree `ul` — handles both bare
+   * `li.bx--tree-node` rows and the link variant (`li[role="none"] > a`).
+   * @param {HTMLElement} groupUl
+   * @returns {HTMLElement | null}
+   */
+  function firstTreeItemInGroup(groupUl) {
+    const row = groupUl.firstElementChild;
+    if (!(row instanceof HTMLElement)) return null;
+    if (row.classList.contains("bx--tree-node")) return row;
+    const nested = row.querySelector(".bx--tree-node");
+    return nested instanceof HTMLElement ? nested : null;
+  }
+
   let ref = null;
   let refLabel = null;
   let prevActiveId = undefined;
@@ -127,9 +141,12 @@
 
       if (parent && e.key === "ArrowRight") {
         if (expanded) {
-          ref.lastChild.firstElementChild?.focus();
+          const groupUl = ref.lastElementChild;
+          if (groupUl instanceof HTMLElement) {
+            const next = firstTreeItemInGroup(groupUl);
+            next?.focus();
+          }
         } else {
-          expanded = true;
           expandNode(node, true);
           toggleNode(node);
         }

--- a/src/TreeView/TreeViewNodeList.svelte
+++ b/src/TreeView/TreeViewNodeList.svelte
@@ -116,6 +116,7 @@
     class:bx--tree-node--disabled={disabled}
     class:bx--tree-node--with-icon={icon}
     aria-expanded={expanded}
+    aria-owns={`${id}-subtree`}
     on:click|stopPropagation={(e) => {
       if (disabled) return;
       clickNode(node, e);
@@ -192,11 +193,15 @@
       </span>
       <span class:bx--tree-node__label__details={true}>
         <svelte:component this={icon} class="bx--tree-node__icon" />
-        <slot {node} />
+        <span id={`${id}__label`} class:bx--tree-node__label__text={true}>
+          <slot {node} />
+        </span>
       </span>
     </div>
     <ul
+      id={`${id}-subtree`}
       role="group"
+      aria-labelledby={`${id}__label`}
       class:bx--tree-node__children={true}
       class:bx--tree-node--hidden={!expanded}
     >

--- a/src/TreeView/TreeViewNodeList.svelte
+++ b/src/TreeView/TreeViewNodeList.svelte
@@ -22,7 +22,10 @@
 
   import { afterUpdate, getContext } from "svelte";
   import CaretDown from "../icons/CaretDown.svelte";
-  import TreeViewNode, { computeTreeLeafDepth } from "./TreeViewNode.svelte";
+  import TreeViewNode, {
+    computeTreeLeafDepth,
+    findParentTreeNode,
+  } from "./TreeViewNode.svelte";
 
   let ref = null;
   let refLabel = null;
@@ -113,9 +116,13 @@
       }
 
       if (parent && e.key === "ArrowLeft") {
-        expanded = false;
-        expandNode(node, false);
-        toggleNode(node);
+        if (expanded) {
+          expandNode(node, false);
+          toggleNode(node);
+        } else {
+          const parentNode = findParentTreeNode(ref.parentElement);
+          if (parentNode instanceof HTMLElement) parentNode.focus();
+        }
       }
 
       if (parent && e.key === "ArrowRight") {

--- a/tests/TreeView/TreeView.test.ts
+++ b/tests/TreeView/TreeView.test.ts
@@ -2,6 +2,7 @@ import { render, screen } from "@testing-library/svelte";
 import type TreeViewComponent from "carbon-components-svelte/TreeView/TreeView.svelte";
 import type { TreeNode } from "carbon-components-svelte/TreeView/TreeView.svelte";
 import type TreeViewNodeComponent from "carbon-components-svelte/TreeView/TreeViewNode.svelte";
+import { findParentTreeNode } from "carbon-components-svelte/TreeView/TreeViewNode.svelte";
 import type TreeViewNodeListComponent from "carbon-components-svelte/TreeView/TreeViewNodeList.svelte";
 import type {
   ComponentEvents,
@@ -1661,6 +1662,36 @@ describe("TreeView autoCollapse", () => {
 
       // biome-ignore lint/suspicious/noExplicitAny: Testing default any type
       expectTypeOf<Props["icon"]>().toEqualTypeOf<any>();
+    });
+  });
+
+  describe("findParentTreeNode", () => {
+    it("walks up to the nearest bx--tree-parent-node", () => {
+      const tree = document.createElement("ul");
+      tree.classList.add("bx--tree");
+
+      const parent = document.createElement("li");
+      parent.classList.add("bx--tree-node", "bx--tree-parent-node");
+      tree.appendChild(parent);
+
+      const group = document.createElement("ul");
+      parent.appendChild(group);
+
+      const child = document.createElement("li");
+      child.classList.add("bx--tree-node");
+      group.appendChild(child);
+
+      expect(findParentTreeNode(child.parentElement)).toBe(parent);
+    });
+
+    it("returns null when there is no enclosing parent tree node", () => {
+      const tree = document.createElement("ul");
+      tree.classList.add("bx--tree");
+      const leaf = document.createElement("li");
+      leaf.classList.add("bx--tree-node");
+      tree.appendChild(leaf);
+
+      expect(findParentTreeNode(leaf.parentElement)).toBeNull();
     });
   });
 

--- a/tests/TreeView/TreeView.test.ts
+++ b/tests/TreeView/TreeView.test.ts
@@ -23,6 +23,22 @@ function treeItemById(id: string | number): HTMLElement {
   return el;
 }
 
+/**
+ * `getByRole({ name })` matches descendant text (#3007).
+ * Pick the expandable parent row.
+ */
+function getNamedParentTreeitem(name: RegExp): HTMLElement {
+  const found = screen
+    .getAllByRole("treeitem", { name })
+    .find(
+      (n) =>
+        n instanceof HTMLElement &&
+        n.classList.contains("bx--tree-parent-node"),
+    );
+  expect.assert(found instanceof HTMLElement);
+  return found;
+}
+
 const testCases = [
   { name: "TreeView", component: TreeView },
   { name: "TreeView hierarchy", component: TreeViewHierarchy },
@@ -264,6 +280,29 @@ describe.each(testCases)("$name", ({ component }) => {
     expect(analytics).toHaveFocus();
     expect(ibmEngine).not.toHaveFocus();
     expect(apacheSpark).not.toHaveFocus();
+  });
+
+  it("End key moves focus to the last non-disabled treeitem", async () => {
+    render(component);
+
+    const firstItem = getItemByName(/AI \/ Machine learning/);
+    firstItem.focus();
+
+    await user.keyboard("{End}");
+
+    expect(getNamedParentTreeitem(/Databases/)).toHaveFocus();
+  });
+
+  it("Home key moves focus to the first treeitem", async () => {
+    render(component);
+
+    const databases = getNamedParentTreeitem(/Databases/);
+    databases.focus();
+
+    await user.keyboard("{Home}");
+
+    const firstItem = getItemByName(/AI \/ Machine learning/);
+    expect(firstItem).toHaveFocus();
   });
 
   it("expands parent node with ArrowRight key", async () => {

--- a/tests/TreeView/TreeView.test.ts
+++ b/tests/TreeView/TreeView.test.ts
@@ -1682,6 +1682,32 @@ describe("TreeView autoCollapse", () => {
     });
   });
 
+  it("ArrowRight on an expanded parent focuses link-first-child treeitem", async () => {
+    const { container } = render(TreeViewProps, {
+      expandedIds: ["p"],
+      nodes: [
+        {
+          id: "p",
+          text: "Parent",
+          nodes: [
+            { id: "child-link", text: "Link Child", href: "/x" },
+            { id: "child-leaf", text: "Leaf Child" },
+          ],
+        },
+      ],
+    });
+
+    const parent = container.querySelector("#p");
+    expect.assert(parent instanceof HTMLElement);
+    parent.focus();
+
+    await user.keyboard("{ArrowRight}");
+
+    const linkChild = container.querySelector("#child-link");
+    expect(linkChild?.tagName).toBe("A");
+    expect(linkChild).toHaveFocus();
+  });
+
   describe("findParentTreeNode", () => {
     it("walks up to the nearest bx--tree-parent-node", () => {
       const tree = document.createElement("ul");

--- a/tests/TreeView/TreeView.test.ts
+++ b/tests/TreeView/TreeView.test.ts
@@ -1630,7 +1630,7 @@ describe("TreeView autoCollapse", () => {
     expect(folder3).toHaveFocus();
   });
 
-  it("works when expanding via Enter/Space key", async () => {
+  it("Enter toggles parent expansion; Space selects without toggling", async () => {
     render(TreeViewAutoCollapse, { autoCollapse: true });
 
     const folder1 = treeItemById("folder1");
@@ -1642,7 +1642,16 @@ describe("TreeView autoCollapse", () => {
 
     folder2.focus();
     await user.keyboard(" ");
+    // Space selects but does NOT toggle expand on parent rows (Carbon parity).
+    expect(folder2).toHaveAttribute("aria-expanded", "false");
+    expect(folder2).toHaveAttribute("aria-selected", "true");
+    // Folder1 is unaffected (still expanded; autoCollapse hasn't fired since
+    // folder2 isn't being expanded).
+    expect(folder1).toHaveAttribute("aria-expanded", "true");
+
+    await user.keyboard("{Enter}");
     expect(folder2).toHaveAttribute("aria-expanded", "true");
+    // Now autoCollapse kicks in.
     expect(folder1).toHaveAttribute("aria-expanded", "false");
   });
 

--- a/tests/TreeView/TreeView.test.ts
+++ b/tests/TreeView/TreeView.test.ts
@@ -1613,6 +1613,23 @@ describe("TreeView autoCollapse", () => {
     expect(folder1).toHaveAttribute("aria-expanded", "false");
   });
 
+  it("ArrowLeft on a collapsed parent moves focus to its ancestor", async () => {
+    render(TreeViewAutoCollapse, { autoCollapse: false });
+
+    const folder3 = screen.getByRole("treeitem", { name: /Folder 3/ });
+    await user.click(getToggleButton(folder3));
+
+    const subfolder1 = within(folder3).getByRole("treeitem", {
+      name: /^Subfolder 1\b/,
+    });
+    expect(subfolder1).toHaveAttribute("aria-expanded", "false");
+
+    subfolder1.focus();
+    await user.keyboard("{ArrowLeft}");
+
+    expect(folder3).toHaveFocus();
+  });
+
   it("works when expanding via Enter/Space key", async () => {
     render(TreeViewAutoCollapse, { autoCollapse: true });
 

--- a/tests/TreeView/TreeView.test.ts
+++ b/tests/TreeView/TreeView.test.ts
@@ -184,6 +184,29 @@ describe.each(testCases)("$name", ({ component }) => {
     expect(disabledNode).not.toHaveAttribute("aria-selected", "true");
   });
 
+  it("moves tabindex=0 along with focus (roving tabindex)", async () => {
+    render(component);
+
+    const firstItem = getItemByName(/AI \/ Machine learning/);
+    expect(firstItem).toHaveAttribute("tabindex", "0");
+
+    firstItem.focus();
+    await user.keyboard("{ArrowDown}");
+
+    const analyticsItems = screen.getAllByRole("treeitem", {
+      name: /Analytics/,
+      selected: false,
+    });
+    const nextItem = analyticsItems[0];
+
+    expect(nextItem).toHaveFocus();
+    expect(nextItem).toHaveAttribute("tabindex", "0");
+    expect(firstItem).toHaveAttribute("tabindex", "-1");
+
+    const tree = screen.getByRole("tree");
+    expect(tree.querySelectorAll('[tabindex="0"]')).toHaveLength(1);
+  });
+
   it("navigates with ArrowDown key", async () => {
     render(component);
 

--- a/tests/TreeView/TreeView.test.ts
+++ b/tests/TreeView/TreeView.test.ts
@@ -213,6 +213,33 @@ describe.each(testCases)("$name", ({ component }) => {
     expect(disabledNode).not.toHaveAttribute("aria-selected", "true");
   });
 
+  it("re-applies tabindex=0 to the new first focusable when nodes change", async () => {
+    const { rerender } = render(TreeViewProps, {
+      nodes: [
+        { id: "a", text: "Alpha" },
+        { id: "b", text: "Beta" },
+      ],
+    });
+
+    expect(screen.getByRole("treeitem", { name: /Alpha/ })).toHaveAttribute(
+      "tabindex",
+      "0",
+    );
+
+    await rerender({
+      nodes: [
+        { id: "x", text: "Xray" },
+        { id: "y", text: "Yankee" },
+      ],
+    });
+
+    expect(screen.getByRole("treeitem", { name: /Xray/ })).toHaveAttribute(
+      "tabindex",
+      "0",
+    );
+    expect(screen.queryByRole("treeitem", { name: /Alpha/ })).toBeNull();
+  });
+
   it("moves tabindex=0 along with focus (roving tabindex)", async () => {
     render(component);
 

--- a/tests/TreeView/TreeView.test.ts
+++ b/tests/TreeView/TreeView.test.ts
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/svelte";
+import { render, screen, within } from "@testing-library/svelte";
 import type TreeViewComponent from "carbon-components-svelte/TreeView/TreeView.svelte";
 import type { TreeNode } from "carbon-components-svelte/TreeView/TreeView.svelte";
 import type TreeViewNodeComponent from "carbon-components-svelte/TreeView/TreeViewNode.svelte";
@@ -126,9 +126,15 @@ describe.each(testCases)("$name", ({ component }) => {
 
     expect(getAllExpandedItems()).toHaveLength(2);
 
+    const tree = screen.getByRole("tree");
+    const expandedItems = within(tree).getAllByRole("treeitem", {
+      expanded: true,
+    });
     expect(
-      screen.getByText("IBM Analytics Engine").parentNode?.parentNode,
-    ).toHaveAttribute("aria-expanded", "true");
+      expandedItems.some((el) =>
+        el.textContent?.includes("IBM Analytics Engine"),
+      ),
+    ).toBe(true);
   });
 
   it("can collapse all nodes", async () => {
@@ -1689,6 +1695,32 @@ describe("TreeView autoCollapse", () => {
       // biome-ignore lint/suspicious/noExplicitAny: Testing default any type
       expectTypeOf<Props["icon"]>().toEqualTypeOf<any>();
     });
+  });
+
+  it("wires aria-owns and aria-labelledby for expanded subtrees", () => {
+    const { container } = render(TreeViewProps, {
+      expandedIds: ["parent"],
+      nodes: [
+        {
+          id: "parent",
+          text: "Top Parent",
+          nodes: [{ id: "child", text: "Child" }],
+        },
+      ],
+    });
+
+    const parent = container.querySelector("#parent");
+    const subtreeId = parent?.getAttribute("aria-owns");
+    expect(subtreeId).toBe("parent-subtree");
+
+    const subtree = container.querySelector(`#${subtreeId}`);
+    expect(subtree?.getAttribute("role")).toBe("group");
+
+    const labelledBy = subtree?.getAttribute("aria-labelledby");
+    expect(labelledBy).toBe("parent__label");
+
+    const labelEl = container.querySelector(`#${labelledBy}`);
+    expect(labelEl?.textContent?.trim()).toBe("Top Parent");
   });
 
   it("ArrowRight on an expanded parent focuses link-first-child treeitem", async () => {

--- a/tests/TreeView/TreeView.test.ts
+++ b/tests/TreeView/TreeView.test.ts
@@ -39,6 +39,9 @@ describe.each(testCases)("$name", ({ component }) => {
     return screen.getAllByRole("treeitem", { expanded: true });
   };
 
+  const getItemByName = (name: string | RegExp): HTMLElement =>
+    screen.getByRole("treeitem", { name }) as HTMLElement;
+
   it("can select a node", async () => {
     const consoleLog = vi.spyOn(console, "log");
 
@@ -218,6 +221,26 @@ describe.each(testCases)("$name", ({ component }) => {
 
     const disabledNode = treeItemById(14);
     expect(disabledNode).not.toHaveFocus();
+  });
+
+  it("skips descendants under collapsed subtree in keyboard navigation", async () => {
+    render(component);
+
+    const firstItem = treeItemById(0);
+    const analytics = treeItemById(1);
+    const ibmEngine = treeItemById(2); // descendant of collapsed Analytics
+    const apacheSpark = treeItemById(3); // leaf, descendant of collapsed IBM Engine
+
+    // Both descendants stay in the DOM but inside `ul.bx--tree-node--hidden`.
+    expect(ibmEngine.closest("ul.bx--tree-node--hidden")).not.toBeNull();
+    expect(apacheSpark.closest("ul.bx--tree-node--hidden")).not.toBeNull();
+
+    firstItem.focus();
+    await user.keyboard("{ArrowDown}");
+
+    expect(analytics).toHaveFocus();
+    expect(ibmEngine).not.toHaveFocus();
+    expect(apacheSpark).not.toHaveFocus();
   });
 
   it("expands parent node with ArrowRight key", async () => {

--- a/tests/TreeView/TreeView.test.ts
+++ b/tests/TreeView/TreeView.test.ts
@@ -24,6 +24,19 @@ function treeItemById(id: string | number): HTMLElement {
 }
 
 /**
+ * Primary row label: parent markup uses `.bx--tree-node__label__text`.
+ * Leaves use `.bx--tree-node__label` only (#3007).
+ */
+function treeitemPrimaryLabel(el: HTMLElement): string {
+  const labelled = el.querySelector(".bx--tree-node__label__text");
+  if (labelled?.textContent) {
+    return labelled.textContent.replace(/\s+/g, " ").trim();
+  }
+  const label = el.querySelector(".bx--tree-node__label");
+  return label?.textContent?.replace(/\s+/g, " ").trim() ?? "";
+}
+
+/**
  * `getByRole({ name })` matches descendant text (#3007).
  * Pick the expandable parent row.
  */
@@ -465,6 +478,33 @@ describe("TreeView Props", () => {
       expect(label.style.paddingLeft).toBe("1rem");
       expect(label.style.marginLeft).toBe("-1rem");
     });
+  });
+
+  it("Ctrl+A selects every non-disabled visible row in multiselect mode", async () => {
+    render(TreeViewMultiselect, {
+      multiselect: true,
+      selectedIds: [],
+    });
+
+    const aiItem = screen.getByRole("treeitem", {
+      name: /AI \/ Machine learning/,
+    });
+    aiItem.focus();
+
+    await user.keyboard("{Control>}a{/Control}");
+
+    const selectedItems = screen.getAllByRole("treeitem", { selected: true });
+    const names = selectedItems.map(treeitemPrimaryLabel).sort();
+    expect(names).toEqual([
+      "AI / Machine learning",
+      "Analytics",
+      "Blockchain",
+      "Databases",
+    ]);
+    // Integration is disabled and excluded.
+    expect(
+      screen.getByRole("treeitem", { name: /Integration/ }),
+    ).toHaveAttribute("aria-disabled", "true");
   });
 
   it("handles multiple selectedIds with multiselect", () => {


### PR DESCRIPTION
Closes #2978

Re-implements #2978 but breaks each change down by commit.

## Motivation

Align `TreeView` keyboard handling, tree-walker filtering, and subtree ARIA wiring with Carbon's React implementation. Closes the gaps that surface when consumers use link-row children, dynamic node lists, multiselect keyboard shortcuts, or ARIA-only navigation.

## Changes

- **Tree walker filter is more robust.** Handles non-Element nodes safely, rejects rows with `bx--tree-node--hidden`, and accepts link rows (`<a role="treeitem">`), not just `<li>`.
- **Roving tabindex resets the previous row.** New `resetNodeTabIndices` clears any stale `tabindex="0"` before promoting the next focused row. `handleKeyDown` now guards against an uninitialized walker and resolves the tree item from `e.target` (so events targeting descendants still work).
- **Home / End focus the first / last row.** Plus `Ctrl+Shift+Home` and `Ctrl+Shift+End` sweep-select the walked range when `multiselect` is on.
- **Ctrl+A selects every visible non-disabled row** when `multiselect` is on. Uses the data list rather than the DOM walker so node ids keep their original numeric / string type.
- **First focusable row updates when nodes change.** Moved from `onMount` into `afterUpdate` guarded by node identity, so filter / swap / reload still leaves a focusable entry point. Selector also accepts the link-row variant.
- **`findParentTreeNode` is exported** from `TreeViewNode.svelte` for reuse by `TreeViewNodeList`.
- **ArrowLeft on a collapsed parent now focuses its ancestor.** When the parent is already expanded, ArrowLeft still collapses it (unchanged).
- **ArrowRight on an expanded parent reliably focuses the first child**, including the link variant (`<li role="none"> > <a>`), where the previous `firstElementChild` lookup landed on a non-focusable `<li>`.
- **Enter toggles expand on parent; Space only selects.** Matches the ARIA tree pattern. Both keyboard and toggle-button paths now drive the expanded state through the store instead of mutating a local variable.
- **Subtree ARIA wiring.** Parent row carries `aria-owns="<id>-subtree"`; subtree `<ul role="group">` has matching `id` plus `aria-labelledby="<id>__label"` pointing at a new wrapper span around the parent's slot content.

## Notable behavior changes

- **Space no longer toggles parent expansion.** It now only selects. Use Enter (or the chevron / click) to expand or collapse. This is intentional ARIA-tree parity — apps that relied on Space toggling will need to switch to Enter.
- **ArrowLeft from a collapsed parent moves focus up instead of being a no-op.** Previously it called `expandNode(false)` redundantly.
- **An extra wrapper span is rendered around the parent label** for `aria-labelledby`. CSS selectors that drilled into the DOM hierarchy of `.bx--tree-node__label__details` may need to account for the new `.bx--tree-node__label__text` element.
- **Tests that asserted `getByText(...).parentNode.parentNode` against the parent row** will now find a deeper structure. Prefer role-based queries (the test suite was updated accordingly).
