### PR TITLE
fix(notification)!: remove decorative `statusIconDescription` prop

### DIFF
--- a/docs/src/pages/components/InlineNotification.svx
+++ b/docs/src/pages/components/InlineNotification.svx
@@ -48,14 +48,13 @@ Title and subtitle are optional and only render when provided.
 <InlineNotification subtitle="An internal server error occurred." />
 <InlineNotification title="An error occurred." />
 
-## Accessible icon descriptions
+## Translating the close button label
 
-Make notifications more accessible by providing custom descriptions for icons.
+The status icon is decorative and hidden from assistive technology. Translate the close button label via `closeButtonDescription`.
 
-<InlineNotification 
+<InlineNotification
   title="错误"
   subtitle="发生内部服务器错误"
-  statusIconDescription="错误图标"
   closeButtonDescription="关闭通知"
 />
 

--- a/docs/src/pages/components/ToastNotification.svx
+++ b/docs/src/pages/components/ToastNotification.svx
@@ -65,14 +65,13 @@ Subtitle and caption are optional and only render when provided.
 <ToastNotification subtitle="An internal server error occurred." caption="{new Date().toLocaleString()}" />
 <ToastNotification title="Success" caption="{new Date().toLocaleString()}" />
 
-## Accessible icon descriptions
+## Translating the close button label
 
-Provide custom descriptions for icons to improve accessibility.
+The status icon is decorative and hidden from assistive technology. Translate the close button label via `closeButtonDescription`.
 
-<ToastNotification 
+<ToastNotification
   title="错误"
   subtitle="发生内部服务器错误"
-  statusIconDescription="错误图标"
   closeButtonDescription="关闭通知"
 />
 

--- a/src/Notification/InlineNotification.svelte
+++ b/src/Notification/InlineNotification.svelte
@@ -28,12 +28,6 @@
   /** Set to `true` to hide the close button */
   export let hideCloseButton = false;
 
-  /**
-   * Specify the ARIA label for the status icon.
-   * @type {string}
-   * */
-  export let statusIconDescription = `${kind} icon`;
-
   /** Specify the ARIA label for the close button */
   export let closeButtonDescription = "Close notification";
 
@@ -95,11 +89,7 @@
     on:mouseleave
   >
     <div class:bx--inline-notification__details={true}>
-      <NotificationIcon
-        notificationType="inline"
-        {kind}
-        iconDescription={statusIconDescription}
-      />
+      <NotificationIcon notificationType="inline" {kind} />
       <div class:bx--inline-notification__text-wrapper={true}>
         {#if title || $$slots.titleChildren}
           <p class:bx--inline-notification__title={true}>

--- a/src/Notification/NotificationIcon.svelte
+++ b/src/Notification/NotificationIcon.svelte
@@ -11,9 +11,6 @@
    */
   export let notificationType = "toast";
 
-  /** Specify the ARIA label for the icon */
-  export let iconDescription;
-
   import CheckmarkFilled from "../icons/CheckmarkFilled.svelte";
   import ErrorFilled from "../icons/ErrorFilled.svelte";
   import InformationFilled from "../icons/InformationFilled.svelte";
@@ -38,9 +35,4 @@
     .join(" ");
 </script>
 
-<svelte:component
-  this={icons[kind]}
-  size={20}
-  title={iconDescription}
-  class={iconClass}
-/>
+<svelte:component this={icons[kind]} size={20} class={iconClass} />

--- a/src/Notification/NotificationQueue.svelte
+++ b/src/Notification/NotificationQueue.svelte
@@ -9,7 +9,6 @@
    * @property {number} [timeout]
    * @property {boolean} [lowContrast]
    * @property {string} [closeButtonDescription]
-   * @property {string} [statusIconDescription]
    * @property {boolean} [hideCloseButton]
    */
 

--- a/src/Notification/ToastNotification.svelte
+++ b/src/Notification/ToastNotification.svelte
@@ -28,12 +28,6 @@
   /** Specify the caption text */
   export let caption = "";
 
-  /**
-   * Specify the ARIA label for the status icon.
-   * @type {string}
-   * */
-  export let statusIconDescription = `${kind} icon`;
-
   /** Specify the ARIA label for the close button */
   export let closeButtonDescription = "Close notification";
 
@@ -113,7 +107,7 @@
     on:mouseenter
     on:mouseleave
   >
-    <NotificationIcon {kind} iconDescription={statusIconDescription} />
+    <NotificationIcon {kind} />
     <div class:bx--toast-notification__details={true}>
       <h3 class:bx--toast-notification__title={true}>
         <slot name="titleChildren">{title}</slot>

--- a/tests/InlineNotification/InlineNotification.test.svelte
+++ b/tests/InlineNotification/InlineNotification.test.svelte
@@ -8,8 +8,6 @@
   export let role: ComponentProps<InlineNotification>["role"] = "alert";
   export let title: ComponentProps<InlineNotification>["title"] = "";
   export let subtitle: ComponentProps<InlineNotification>["subtitle"] = "";
-  export let statusIconDescription: ComponentProps<InlineNotification>["statusIconDescription"] =
-    undefined;
   export let closeButtonDescription: ComponentProps<InlineNotification>["closeButtonDescription"] =
     "Close notification";
   export let hideCloseButton: ComponentProps<InlineNotification>["hideCloseButton"] = false;
@@ -24,7 +22,6 @@
   {role}
   {title}
   {subtitle}
-  {statusIconDescription}
   {closeButtonDescription}
   {hideCloseButton}
   on:close={(e) => onclose?.(e)}

--- a/tests/InlineNotification/InlineNotification.test.ts
+++ b/tests/InlineNotification/InlineNotification.test.ts
@@ -222,6 +222,16 @@ describe("InlineNotification", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("should render the status icon as decorative (aria-hidden)", () => {
+    render(InlineNotificationTest, { props: { kind: "error" } });
+
+    const icon = document.querySelector(".bx--inline-notification__icon");
+    expect(icon).toBeInTheDocument();
+    expect(icon).toHaveAttribute("aria-hidden", "true");
+    expect(icon).not.toHaveAttribute("role", "img");
+    expect(icon?.querySelector("title")).toBeNull();
+  });
+
   it("should prevent close when event is cancelled", async () => {
     vi.useRealTimers();
     const closeHandler = vi.fn((e) => {

--- a/tests/Notification/NotificationQueue.test.ts
+++ b/tests/Notification/NotificationQueue.test.ts
@@ -409,7 +409,6 @@ describe("NotificationQueue", () => {
       timeout: 5000,
       lowContrast: true,
       closeButtonDescription: "Custom close",
-      statusIconDescription: "Custom status",
       hideCloseButton: false,
     });
     await tick();

--- a/tests/ToastNotification/ToastNotification.test.svelte
+++ b/tests/ToastNotification/ToastNotification.test.svelte
@@ -9,8 +9,6 @@
   export let title: ComponentProps<ToastNotification>["title"] = "";
   export let subtitle: ComponentProps<ToastNotification>["subtitle"] = "";
   export let caption: ComponentProps<ToastNotification>["caption"] = "";
-  export let statusIconDescription: ComponentProps<ToastNotification>["statusIconDescription"] =
-    undefined;
   export let closeButtonDescription: ComponentProps<ToastNotification>["closeButtonDescription"] =
     "Close notification";
   export let hideCloseButton: ComponentProps<ToastNotification>["hideCloseButton"] = false;
@@ -27,7 +25,6 @@
   {title}
   {subtitle}
   {caption}
-  {statusIconDescription}
   {closeButtonDescription}
   {hideCloseButton}
   {fullWidth}

--- a/tests/ToastNotification/ToastNotification.test.ts
+++ b/tests/ToastNotification/ToastNotification.test.ts
@@ -286,4 +286,14 @@ describe("ToastNotification", () => {
       document.querySelector(".bx--toast-notification"),
     ).toBeInTheDocument();
   });
+
+  it("should render the status icon as decorative (aria-hidden)", () => {
+    render(ToastNotificationTest, { props: { kind: "error" } });
+
+    const icon = document.querySelector(".bx--toast-notification__icon");
+    expect(icon).toBeInTheDocument();
+    expect(icon).toHaveAttribute("aria-hidden", "true");
+    expect(icon).not.toHaveAttribute("role", "img");
+    expect(icon?.querySelector("title")).toBeNull();
+  });
 });


### PR DESCRIPTION
Closes #2996

The icon displayed in notification components should not have a dedicated description. Instead, it should be treated as a decorative element so screen readers don't read out the icon description.