### PR TITLE
feat(recursive-list): support link `target`/`rel` and forward `on:click`

### DIFF
--- a/src/RecursiveList/RecursiveList.svelte
+++ b/src/RecursiveList/RecursiveList.svelte
@@ -5,6 +5,8 @@
    * @property {string} [text] - Node text content
    * @property {string} [href] - Node link URL
    * @property {string} [html] - Node HTML content
+   * @property {import("svelte/elements").SvelteHTMLElements["a"]["target"]} [target] - Node link target
+   * @property {import("svelte/elements").SvelteHTMLElements["a"]["rel"]} [rel] - Node link rel
    * @property {RecursiveListNode[]} [nodes] - Child nodes
    * @restProps {ul | ol}
    */

--- a/src/RecursiveList/RecursiveListItem.svelte
+++ b/src/RecursiveList/RecursiveListItem.svelte
@@ -8,6 +8,19 @@
   /** Specify HTML to render using `@html` */
   export let html = "";
 
+  /**
+   * Specify the link target.
+   * @type {import("svelte/elements").HTMLAnchorAttributes["target"]}
+   */
+  export let target = undefined;
+
+  /**
+   * Specify the link rel. When `target` is `"_blank"`,
+   * `rel` defaults to `"noopener noreferrer"`.
+   * @type {import("svelte/elements").HTMLAnchorAttributes["rel"]}
+   */
+  export let rel = undefined;
+
   import ListItem from "../ListItem/ListItem.svelte";
 </script>
 
@@ -16,7 +29,14 @@
     {text}
   {/if}
   {#if href}
-    <a class:bx--link={true} {href}>{text || href}</a>
+    <a
+      class:bx--link={true}
+      {href}
+      {target}
+      rel={rel ?? (target === "_blank" ? "noopener noreferrer" : undefined)}
+    >
+      {text || href}
+    </a>
   {/if}
   {#if !text && html}
     {@html html}

--- a/tests/RecursiveList/RecursiveList.hierarchy.test.svelte
+++ b/tests/RecursiveList/RecursiveList.hierarchy.test.svelte
@@ -1,16 +1,7 @@
 <script lang="ts">
   import { RecursiveList, toHierarchy } from "carbon-components-svelte";
 
-  type TestNode = {
-    id?: number;
-    text?: string;
-    href?: string;
-    html?: string;
-    pid?: number;
-    nodes?: TestNode[];
-  };
-
-  let nodes: TestNode[] = toHierarchy(
+  let nodes = toHierarchy(
     [
       { id: 1, text: "Item 1" },
       { id: 2, text: "Item 1a", pid: 1 },
@@ -21,6 +12,21 @@
         id: 6,
         href: "https://svelte.dev/",
         text: "Link with custom text",
+        pid: 4,
+      },
+      {
+        id: 8,
+        href: "https://svelte.dev/",
+        text: "External link",
+        target: "_blank",
+        pid: 4,
+      },
+      {
+        id: 9,
+        href: "https://svelte.dev/",
+        text: "External link with custom rel",
+        target: "_blank",
+        rel: "noopener",
         pid: 4,
       },
       { id: 7, text: "Item 3" },

--- a/tests/RecursiveList/RecursiveList.test.svelte
+++ b/tests/RecursiveList/RecursiveList.test.svelte
@@ -1,14 +1,8 @@
 <script lang="ts">
   import { RecursiveList } from "carbon-components-svelte";
+  import type { RecursiveListNode } from "../../src/RecursiveList/RecursiveList.svelte";
 
-  type TestNode = {
-    text?: string;
-    href?: string;
-    html?: string;
-    nodes?: TestNode[];
-  };
-
-  const nodes: TestNode[] = [
+  const nodes: RecursiveListNode[] = [
     {
       text: "Item 1",
       nodes: [
@@ -25,6 +19,17 @@
         {
           href: "https://svelte.dev/",
           text: "Link with custom text",
+        },
+        {
+          href: "https://svelte.dev/",
+          text: "External link",
+          target: "_blank",
+        },
+        {
+          href: "https://svelte.dev/",
+          text: "External link with custom rel",
+          target: "_blank",
+          rel: "noopener",
         },
       ],
     },

--- a/tests/RecursiveList/RecursiveList.test.ts
+++ b/tests/RecursiveList/RecursiveList.test.ts
@@ -35,7 +35,7 @@ describe.each(testCases)("$name", ({ component }) => {
     render(component);
 
     const links = screen.getAllByRole("link");
-    expect(links).toHaveLength(2);
+    expect(links).toHaveLength(4);
 
     // Link with custom text
     const customLink = screen.getByText("Link with custom text");
@@ -43,9 +43,23 @@ describe.each(testCases)("$name", ({ component }) => {
 
     // Plain link
     const plainLink = links.find(
-      (link) => link.textContent === "https://svelte.dev/",
+      (link) => link.textContent?.trim() === "https://svelte.dev/",
     );
     expect(plainLink).toHaveAttribute("href", "https://svelte.dev/");
+  });
+
+  it("renders link target and computes rel for `_blank`", () => {
+    render(component);
+
+    const externalLink = screen.getByText("External link");
+    expect(externalLink).toHaveAttribute("target", "_blank");
+    expect(externalLink).toHaveAttribute("rel", "noopener noreferrer");
+
+    const externalLinkCustomRel = screen.getByText(
+      "External link with custom rel",
+    );
+    expect(externalLinkCustomRel).toHaveAttribute("target", "_blank");
+    expect(externalLinkCustomRel).toHaveAttribute("rel", "noopener");
   });
 });
 


### PR DESCRIPTION
Extend `RecursiveListNode` with `target` and `rel` so consumers can render external links. `rel` auto-defaults to `noopener noreferrer` when `target="_blank"`, matching `Link.svelte`.