### PR TITLE
feat(recursive-list): support optional `id` key

### DIFF
--- a/docs/src/pages/components/RecursiveList.svx
+++ b/docs/src/pages/components/RecursiveList.svx
@@ -30,3 +30,9 @@ Set `type` to `"ordered-native"` to use browser-native numbering styles.
 Convert flat data structures to hierarchical arrays using the `toHierarchy` utility function.
 
 <FileSource src="/framed/RecursiveList/RecursiveListFlatArray" />
+
+## Stable keys
+
+Each node accepts an optional `id` (string or number) which is used as the each-block key. Supply an `id` when node `text` or `href` values can repeat, so reordering or filtering preserves DOM identity.
+
+<FileSource src="/framed/RecursiveList/RecursiveListStableKeys" />

--- a/docs/src/pages/framed/RecursiveList/RecursiveListStableKeys.svelte
+++ b/docs/src/pages/framed/RecursiveList/RecursiveListStableKeys.svelte
@@ -1,0 +1,11 @@
+<script>
+  import { RecursiveList } from "carbon-components-svelte";
+
+  const nodes = [
+    { id: "intro", text: "Introduction" },
+    { id: "guide", text: "Guide", nodes: [{ id: "guide-1", text: "Setup" }] },
+    { id: "api", text: "API reference" },
+  ];
+</script>
+
+<RecursiveList {nodes} />

--- a/src/RecursiveList/RecursiveList.svelte
+++ b/src/RecursiveList/RecursiveList.svelte
@@ -2,6 +2,7 @@
   /**
    * @template {RecursiveListNode} [Node=RecursiveListNode]
    * @typedef {object} RecursiveListNode
+   * @property {string | number} [id] - Unique node identifier; used as the each-block key when provided
    * @property {string} [text] - Node text content
    * @property {string} [href] - Node link URL
    * @property {string} [html] - Node HTML content
@@ -31,7 +32,7 @@
   native={type === "ordered-native"}
   {...$$restProps}
 >
-  {#each nodes as child}
+  {#each nodes as child, index (child.id ?? index)}
     {#if Array.isArray(child.nodes)}
       <RecursiveListItem {...child}>
         <svelte:self {...child} {type} nested />

--- a/tests/RecursiveList/RecursiveList.id.test.svelte
+++ b/tests/RecursiveList/RecursiveList.id.test.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  import { RecursiveList } from "carbon-components-svelte";
+
+  type TestNode = {
+    id?: string | number;
+    text?: string;
+    nodes?: TestNode[];
+  };
+
+  export let nodes: TestNode[] = [
+    { id: "a", text: "Item A" },
+    { id: 2, text: "Item B" },
+    { id: "c", text: "Item C", nodes: [{ id: "c1", text: "Item C1" }] },
+  ];
+</script>
+
+<RecursiveList {nodes} />

--- a/tests/RecursiveList/RecursiveList.test.ts
+++ b/tests/RecursiveList/RecursiveList.test.ts
@@ -3,6 +3,7 @@ import type RecursiveListComponent from "carbon-components-svelte/RecursiveList/
 import type { RecursiveListNode } from "carbon-components-svelte/RecursiveList/RecursiveList.svelte";
 import type { ComponentProps } from "svelte";
 import RecursiveListHierarchyTest from "./RecursiveList.hierarchy.test.svelte";
+import RecursiveListIdTest from "./RecursiveList.id.test.svelte";
 import RecursiveListTest from "./RecursiveList.test.svelte";
 
 const testCases = [
@@ -46,6 +47,17 @@ describe.each(testCases)("$name", ({ component }) => {
       (link) => link.textContent === "https://svelte.dev/",
     );
     expect(plainLink).toHaveAttribute("href", "https://svelte.dev/");
+  });
+});
+
+describe("RecursiveList id field", () => {
+  it("renders nodes that supply an id (string or number)", () => {
+    render(RecursiveListIdTest);
+
+    expect(screen.getByText("Item A")).toBeInTheDocument();
+    expect(screen.getByText("Item B")).toBeInTheDocument();
+    expect(screen.getByText("Item C")).toBeInTheDocument();
+    expect(screen.getByText("Item C1")).toBeInTheDocument();
   });
 });
 
@@ -198,6 +210,16 @@ describe("RecursiveList Generics", () => {
     expectTypeOf<NodesPropType>().toEqualTypeOf<
       ReadonlyArray<MinimalNode & { nodes?: MinimalNode[] }> | undefined
     >();
+  });
+
+  it("should accept an optional id field on RecursiveListNode", () => {
+    const withStringId: RecursiveListNode = { id: "a", text: "Item" };
+    const withNumberId: RecursiveListNode = { id: 1, text: "Item" };
+    const withoutId: RecursiveListNode = { text: "Item" };
+
+    expectTypeOf(withStringId.id).toEqualTypeOf<string | number | undefined>();
+    expectTypeOf(withNumberId.id).toEqualTypeOf<string | number | undefined>();
+    expectTypeOf(withoutId.id).toEqualTypeOf<string | number | undefined>();
   });
 
   it("should enforce RecursiveListNode constraint on generic type", () => {


### PR DESCRIPTION
Support an optional `id` key and use it to key the list for performance.