### PR TITLE
fix(overflow-menu): use `SvelteHTMLElements` to type target/rel props

### DIFF
--- a/src/OverflowMenu/OverflowMenuItem.svelte
+++ b/src/OverflowMenu/OverflowMenuItem.svelte
@@ -20,7 +20,7 @@
 
   /**
    * Specify the `target` attribute if the item is a link
-   * @type {HTMLAnchorElement["target"]}
+   * @type {import("svelte/elements").SvelteHTMLElements["a"]["target"]}
    */
   export let target = "";
 
@@ -28,7 +28,7 @@
    * Specify the `rel` attribute if the item is a link.
    * By default, `noopener noreferrer` is added if
    * `target="_blank"` unless `rel` is specified.
-   * @type {HTMLAnchorElement["rel"]}
+   * @type {import("svelte/elements").SvelteHTMLElements["a"]["rel"]}
    */
   export let rel = undefined;
 


### PR DESCRIPTION
This improves TypeScript DX; `SvelteHTMLElements` has better typeahead (enum as opposed to plain string) for `target`.

---

<img width="609" height="259" alt="Screenshot 2026-05-14 at 8 55 02 PM" src="https://github.com/user-attachments/assets/c5bb7e1f-fa78-4fde-8a79-a42c8e22c692" />
