### PR TITLE
fix(pagination): cap rendered page options at `pageWindow`

### DIFF
--- a/src/Pagination/Pagination.svelte
+++ b/src/Pagination/Pagination.svelte
@@ -149,11 +149,17 @@
    * Returns a subset of page numbers centered around the current page to prevent
    * performance issues with large datasets. Creates a capped window of pages
    * instead of potentially thousands, improving render speed and memory usage.
+   * @param {number} currentPage - The current page number.
+   * @param {number} totalPages - Total number of pages.
+   * @param {number} window - Maximum number of pages to render.
    * @returns {number[]} Array of page numbers to display.
    */
   function getWindowedPages(currentPage, totalPages, window) {
-    const start = Math.max(1, currentPage - window);
-    const end = Math.min(totalPages, currentPage + window);
+    const size = Math.min(window, totalPages);
+    const half = Math.floor(size / 2);
+    let start = Math.max(1, currentPage - half);
+    const end = Math.min(totalPages, start + size - 1);
+    start = Math.max(1, end - size + 1);
     return Array.from({ length: end - start + 1 }, (_, i) => start + i);
   }
 

--- a/tests/Pagination/Pagination.test.ts
+++ b/tests/Pagination/Pagination.test.ts
@@ -287,7 +287,7 @@ describe("Pagination", () => {
     });
 
     const pageNumbers = screen.getByLabelText(/Page number, of 10000 pages/);
-    expect(pageNumbers).toHaveLength(1_000 + 1);
+    expect(pageNumbers).toHaveLength(1_000);
   });
 
   it("renders a custom page window", () => {
@@ -296,7 +296,16 @@ describe("Pagination", () => {
     });
 
     const pageNumbers = screen.getByLabelText(/Page number, of 10000 pages/);
-    expect(pageNumbers).toHaveLength(100 + 1);
+    expect(pageNumbers).toHaveLength(100);
+  });
+
+  it("caps total rendered page options at pageWindow when current page is in the middle", () => {
+    render(Pagination, {
+      props: { totalItems: 100_000, pageWindow: 100, page: 5000 },
+    });
+
+    const pageNumbers = screen.getByLabelText(/Page number, of 10000 pages/);
+    expect(pageNumbers).toHaveLength(100);
   });
 
   it("formats larger numbers using `toLocaleString`", () => {


### PR DESCRIPTION
The `pageWindow` prop is documented as "a maximum of 1000 select items are rendered," but `getWindowedPages` built a symmetric `±window` range around the current page:

```js
const start = Math.max(1, currentPage - window);
const end = Math.min(totalPages, currentPage + window);
```

When the current page sat far enough from both boundaries, the dropdown rendered up to `2 * pageWindow + 1` options: `2001` by default, doubling the intended perf budget for very large datasets.

### Fix

Center a single window of size `pageWindow` around the current page and clamp it to `[1, totalPages]`, preserving the full window size near edges:

```js
const size = Math.min(window, totalPages);
const half = Math.floor(size / 2);
let start = Math.max(1, currentPage - half);
const end = Math.min(totalPages, start + size - 1);
start = Math.max(1, end - size + 1);
```

Total rendered options now equal `min(pageWindow, totalPages)` regardless of where the current page sits.
