### PR TITLE
fix(pagination): make `pagesUnknown` actually navigable

### DIFF
--- a/docs/src/pages/components/Pagination.svx
+++ b/docs/src/pages/components/Pagination.svx
@@ -54,9 +54,11 @@ For example, with a total of 9 items and page sizes of `[5, 10, 15]`, the page s
 
 ## Unknown pages
 
-Set `pagesUnknown` to `true` when the total number of pages is unknown. This renders the item range text without factoring in the total number of pages.
+Set `pagesUnknown` to `true` when the total number of pages is unknown (for example, paging through a cursor-based API). The item range text is rendered without a total, and the forward button is not constrained by `totalItems`.
 
-<Pagination pagesUnknown />
+Because the component cannot know when the last page is reached, the consumer is responsible for the page bounds. Bind to `page` and toggle `forwardButtonDisabled` when there is no more data to load.
+
+<FileSource src="/framed/Pagination/PaginationUnknown" />
 
 ## Page window
 

--- a/docs/src/pages/framed/Pagination/PaginationUnknown.svelte
+++ b/docs/src/pages/framed/Pagination/PaginationUnknown.svelte
@@ -1,0 +1,13 @@
+<script>
+  import { Pagination } from "carbon-components-svelte";
+
+  // Simulate a cursor-based API where the total is unknown.
+  const LAST_PAGE = 5;
+
+  let page = 1;
+  let pageSize = 10;
+
+  $: forwardButtonDisabled = page >= LAST_PAGE;
+</script>
+
+<Pagination pagesUnknown bind:page bind:pageSize {forwardButtonDisabled} />

--- a/src/Pagination/Pagination.svelte
+++ b/src/Pagination/Pagination.svelte
@@ -96,6 +96,22 @@
   export let pagesUnknown = false;
 
   /**
+   * Override the disabled state of the forward (next page) button.
+   * Intended for use with `pagesUnknown` (controlled), where the consumer
+   * knows when there is no more data to load.
+   * @type {boolean | undefined}
+   */
+  export let forwardButtonDisabled = undefined;
+
+  /**
+   * Override the disabled state of the backward (previous page) button.
+   * Intended for use with `pagesUnknown` (controlled), where the consumer
+   * manages page bounds.
+   * @type {boolean | undefined}
+   */
+  export let backButtonDisabled = undefined;
+
+  /**
    * Override the page text.
    * @type {(page: number) => string}
    */
@@ -157,7 +173,7 @@
   }
 
   $: totalPages = Math.max(Math.ceil(totalItems / pageSize), 1);
-  $: if (page > totalPages) page = totalPages;
+  $: if (!pagesUnknown && page > totalPages) page = totalPages;
   $: if (prevPage !== page || prevPageSize !== pageSize) {
     dispatch("update", { pageSize, page });
     prevPage = page;
@@ -167,8 +183,11 @@
   $: effectivePageSizes = dynamicPageSizes
     ? getFilteredPageSizes(pageSizes, totalItems)
     : pageSizes;
-  $: backButtonDisabled = disabled || page === 1;
-  $: forwardButtonDisabled = disabled || page === totalPages;
+  $: internalBackButtonDisabled =
+    backButtonDisabled ?? (disabled || page === 1);
+  $: internalForwardButtonDisabled =
+    forwardButtonDisabled ??
+    (disabled || (!pagesUnknown && page === totalPages));
 </script>
 
 <div
@@ -249,8 +268,8 @@
       portalTooltip
       icon={CaretLeft}
       iconDescription={backwardText}
-      disabled={backButtonDisabled}
-      class="bx--pagination__button bx--pagination__button--backward {backButtonDisabled
+      disabled={internalBackButtonDisabled}
+      class="bx--pagination__button bx--pagination__button--backward {internalBackButtonDisabled
         ? 'bx--pagination__button--no-index'
         : ''}"
       on:click={() => {
@@ -266,8 +285,8 @@
       portalTooltip
       icon={CaretRight}
       iconDescription={forwardText}
-      disabled={forwardButtonDisabled}
-      class="bx--pagination__button bx--pagination__button--forward {forwardButtonDisabled
+      disabled={internalForwardButtonDisabled}
+      class="bx--pagination__button bx--pagination__button--forward {internalForwardButtonDisabled
         ? 'bx--pagination__button--no-index'
         : ''}"
       on:click={() => {

--- a/tests/Pagination/Pagination.test.svelte
+++ b/tests/Pagination/Pagination.test.svelte
@@ -23,6 +23,10 @@
   export let id: ComponentProps<Pagination>["id"] = undefined;
   export let size: ComponentProps<Pagination>["size"] = undefined;
   export let customClass = "";
+  export let forwardButtonDisabled: ComponentProps<Pagination>["forwardButtonDisabled"] =
+    undefined;
+  export let backButtonDisabled: ComponentProps<Pagination>["backButtonDisabled"] =
+    undefined;
 </script>
 
 <Pagination
@@ -44,6 +48,8 @@
   {itemRangeText}
   {id}
   {size}
+  {forwardButtonDisabled}
+  {backButtonDisabled}
   class={customClass}
   on:change={(e) => {
     console.log("change", e.detail);

--- a/tests/Pagination/Pagination.test.ts
+++ b/tests/Pagination/Pagination.test.ts
@@ -191,6 +191,59 @@ describe("Pagination", () => {
     expect(screen.getByText("page 1")).toBeInTheDocument();
   });
 
+  // When `pagesUnknown` is true, the total number of pages is unknown, so the
+  // forward button should remain enabled at page 1 — otherwise the user can
+  // never advance past the first page.
+  it("should not disable the forward button at page 1 when pagesUnknown is true", () => {
+    render(Pagination, {
+      props: { pagesUnknown: true, page: 1 },
+    });
+
+    const nextButton = screen.getByRole("button", { name: "Next page" });
+    const prevButton = screen.getByRole("button", { name: "Previous page" });
+
+    expect(nextButton).not.toBeDisabled();
+    expect(prevButton).toBeDisabled();
+  });
+
+  it("should advance the page when pagesUnknown is true", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(Pagination, {
+      props: { pagesUnknown: true, page: 1 },
+    });
+
+    await user.click(screen.getByRole("button", { name: "Next page" }));
+
+    expect(consoleLog).toHaveBeenCalledWith("next", { page: 2 });
+    expect(screen.getByText("page 2")).toBeInTheDocument();
+  });
+
+  it("should allow overriding forwardButtonDisabled", () => {
+    render(Pagination, {
+      props: {
+        pagesUnknown: true,
+        page: 1,
+        forwardButtonDisabled: true,
+      },
+    });
+
+    expect(screen.getByRole("button", { name: "Next page" })).toBeDisabled();
+  });
+
+  it("should allow overriding backButtonDisabled", () => {
+    render(Pagination, {
+      props: {
+        totalItems: 102,
+        page: 2,
+        backButtonDisabled: true,
+      },
+    });
+
+    expect(
+      screen.getByRole("button", { name: "Previous page" }),
+    ).toBeDisabled();
+  });
+
   it("should update when page or pageSize changes", async () => {
     const consoleLog = vi.spyOn(console, "log");
     render(Pagination, {


### PR DESCRIPTION
Currently, the `pagesUnknown` features is not usable in a realistic setting, as the page navigation buttons are disabled. 

For example, the forward button was stuck disabled at page 1 and any advance was immediately clamped back by `page > totalPages`. The consumer should be allowed to control these buttons.

Both now respect `pagesUnknown`. This adds `forwardButtonDisabled`/`backButtonDisabled` as overrides so consumers can signal end-of-data in cursor-based flows.