### PR TITLE
feat(button): support `portalTooltip`

### DIFF
--- a/docs/src/pages/components/Button.svx
+++ b/docs/src/pages/components/Button.svx
@@ -80,6 +80,14 @@ Control the tooltip position and alignment with `tooltipPosition` and `tooltipAl
 
 <Button tooltipPosition="right" tooltipAlignment="end" iconDescription="Tooltip text" icon={Add} />
 
+## Icon-only button (portalled tooltip)
+
+Set `portalTooltip` to `true` to render the icon-only tooltip in a portal. This prevents the tooltip from being clipped by `overflow: hidden` containers and auto-flips when the preferred direction lacks viewport space.
+
+By default (`portalTooltip` unset), the tooltip is portalled only when the button is inside a `Modal`. Set `portalTooltip={false}` to always use the inline (non-portalled) tooltip.
+
+<Button portalTooltip iconDescription="Tooltip text" icon={Add} />
+
 ## Icon-only button (hidden tooltip)
 
 Set `hideTooltip` to `true` to visually hide the tooltip while maintaining accessibility for screen readers.

--- a/src/Button/Button.svelte
+++ b/src/Button/Button.svelte
@@ -109,19 +109,80 @@
    */
   export let ref = null;
 
+  /**
+   * Set to `true` to render the icon-only tooltip in a portal,
+   * preventing it from being clipped by `overflow: hidden` containers
+   * and enabling auto-flipping when the preferred direction lacks space.
+   * By default, the tooltip is portalled when inside a `Modal`.
+   * @type {boolean | undefined}
+   */
+  export let portalTooltip = undefined;
+
   import { getContext, onMount } from "svelte";
   import { get } from "svelte/store";
+  import PortalTooltip from "../Portal/PortalTooltip.svelte";
+  import { observeModalClose } from "../Portal/portal-utils.js";
   import ButtonSkeleton from "./ButtonSkeleton.svelte";
   import { activeButtonTooltip } from "./button-tooltip-store.js";
 
   const ctx = getContext("carbon:ComposedModal");
+  const insideModal = getContext("carbon:Modal");
 
   $: if (ctx && ref) {
     ctx.declareRef(ref);
   }
   $: hasIconOnly = (icon || $$slots.icon) && !$$slots.default;
+  $: effectivePortalTooltip =
+    portalTooltip === undefined ? !!insideModal : portalTooltip;
+  $: usePortal = hasIconOnly && !hideTooltip && effectivePortalTooltip;
 
   const tooltipId = {};
+
+  // Hardcoded for parity with TooltipIcon defaults; not exposed as props yet.
+  const ENTER_DELAY_MS = 100;
+  const LEAVE_DELAY_MS = 300;
+
+  let hovered = false;
+  let focused = false;
+  let portalTimeout;
+
+  // Gate on the shared store so only one icon-only tooltip can be open at a
+  // time. When another button claims the store, this one closes immediately —
+  // preventing overlapping tooltips (e.g. Pagination's adjacent buttons).
+  $: portalOpen =
+    usePortal &&
+    !disabled &&
+    (hovered || focused) &&
+    $activeButtonTooltip === tooltipId;
+
+  function claimActiveTooltip() {
+    activeButtonTooltip.set(tooltipId);
+  }
+
+  function releaseActiveTooltip() {
+    if (get(activeButtonTooltip) === tooltipId) {
+      activeButtonTooltip.set(null);
+    }
+  }
+
+  function dismissPortalTooltip() {
+    clearTimeout(portalTimeout);
+    hovered = false;
+    focused = false;
+    releaseActiveTooltip();
+  }
+
+  // Re-attach the portal observer so the tooltip dismisses when an
+  // ancestor modal closes (mirrors CopyButton).
+  let disconnectModalObserver = () => {};
+
+  $: {
+    disconnectModalObserver();
+    disconnectModalObserver =
+      usePortal && ref
+        ? observeModalClose(ref, dismissPortalTooltip)
+        : () => {};
+  }
 
   $: tooltipHidden =
     hasIconOnly &&
@@ -130,19 +191,90 @@
     $activeButtonTooltip !== tooltipId;
 
   function handleMouseEnter() {
-    if (hasIconOnly && !hideTooltip) {
-      activeButtonTooltip.set(tooltipId);
+    if (hasIconOnly && !hideTooltip && !usePortal) {
+      claimActiveTooltip();
     }
   }
 
   function handleMouseLeave() {
-    if ($activeButtonTooltip === tooltipId) {
-      activeButtonTooltip.set(null);
-    }
+    if (usePortal) return;
+    releaseActiveTooltip();
   }
+
+  function handlePortalMouseEnter() {
+    if (!usePortal || disabled) return;
+    clearTimeout(portalTimeout);
+    // Warm handoff: if another icon-only tooltip is already showing, skip the
+    // enter delay so moving between adjacent buttons feels instant.
+    const warmHandoff =
+      get(activeButtonTooltip) !== null &&
+      get(activeButtonTooltip) !== tooltipId;
+    portalTimeout = setTimeout(
+      () => {
+        hovered = true;
+        claimActiveTooltip();
+      },
+      warmHandoff ? 0 : ENTER_DELAY_MS,
+    );
+  }
+
+  function handlePortalMouseLeave() {
+    if (!usePortal) return;
+    clearTimeout(portalTimeout);
+    portalTimeout = setTimeout(() => {
+      hovered = false;
+      if (!focused) releaseActiveTooltip();
+    }, LEAVE_DELAY_MS);
+  }
+
+  function handlePortalFocus() {
+    if (!usePortal || disabled) return;
+    focused = true;
+    claimActiveTooltip();
+  }
+
+  function handlePortalBlur() {
+    if (!usePortal) return;
+    focused = false;
+    if (!hovered) releaseActiveTooltip();
+  }
+
+  const PORTAL_HORIZONTAL_GAP_LEFT_PX = 2;
+  const PORTAL_HORIZONTAL_GAP_RIGHT_PX = 2;
+  const PORTAL_VERTICAL_GAP_TOP_PX = 1;
+  const PORTAL_VERTICAL_GAP_BOTTOM_PX = 1;
+  const PORTAL_VERTICAL_ALIGN_OFFSET_LEFT_START_PX = -3;
+  const PORTAL_VERTICAL_ALIGN_OFFSET_RIGHT_END_PX = 1;
+
+  $: portalHorizontalGapLeft =
+    tooltipPosition === "left" || tooltipPosition === "right"
+      ? PORTAL_HORIZONTAL_GAP_LEFT_PX
+      : 0;
+  $: portalHorizontalGapRight =
+    tooltipPosition === "left" || tooltipPosition === "right"
+      ? PORTAL_HORIZONTAL_GAP_RIGHT_PX
+      : 0;
+  $: portalGapTop =
+    tooltipPosition === "top" || tooltipPosition === "bottom"
+      ? PORTAL_VERTICAL_GAP_TOP_PX
+      : 0;
+  $: portalGapBottom =
+    tooltipPosition === "top" || tooltipPosition === "bottom"
+      ? PORTAL_VERTICAL_GAP_BOTTOM_PX
+      : 0;
+  $: portalVerticalAlignOffsetLeft =
+    tooltipPosition === "left" && tooltipAlignment === "start"
+      ? PORTAL_VERTICAL_ALIGN_OFFSET_LEFT_START_PX
+      : 0;
+  $: portalVerticalAlignOffsetRight =
+    tooltipPosition === "right" && tooltipAlignment === "end"
+      ? PORTAL_VERTICAL_ALIGN_OFFSET_RIGHT_END_PX
+      : 0;
 
   onMount(() => {
     return () => {
+      clearTimeout(portalTimeout);
+      disconnectModalObserver();
       if (get(activeButtonTooltip) === tooltipId) {
         activeButtonTooltip.set(null);
       }
@@ -176,17 +308,23 @@
       kind && `bx--btn--${kind}`,
       isDisabled && "bx--btn--disabled",
       hasIconOnly && "bx--btn--icon-only",
-      hasIconOnly && !hideTooltip && "bx--tooltip__trigger",
-      hasIconOnly && !hideTooltip && "bx--tooltip--a11y",
+      hasIconOnly && !hideTooltip && !usePortal && "bx--tooltip__trigger",
+      hasIconOnly && !hideTooltip && !usePortal && "bx--tooltip--a11y",
       hasIconOnly &&
         !hideTooltip &&
+        !usePortal &&
         tooltipPosition &&
         `bx--btn--icon-only--${tooltipPosition}`,
       hasIconOnly &&
         !hideTooltip &&
+        !usePortal &&
         tooltipAlignment &&
         `bx--tooltip--align-${tooltipAlignment}`,
-      hasIconOnly && !hideTooltip && tooltipHidden && "bx--tooltip--hidden",
+      hasIconOnly &&
+        !hideTooltip &&
+        !usePortal &&
+        tooltipHidden &&
+        "bx--tooltip--hidden",
       hasIconOnly && isSelected && kind === "ghost" && "bx--btn--selected",
       $$restProps.class,
     ]
@@ -219,12 +357,16 @@
     {...buttonProps}
     on:click
     on:focus
+    on:focus={handlePortalFocus}
     on:blur
+    on:blur={handlePortalBlur}
     on:mouseover
     on:mouseenter
     on:mouseenter={handleMouseEnter}
+    on:mouseenter={handlePortalMouseEnter}
     on:mouseleave
     on:mouseleave={handleMouseLeave}
+    on:mouseleave={handlePortalMouseLeave}
   >
     {#if hasIconOnly}
       <span class:bx--assistive-text={true} style:pointer-events="none">
@@ -253,12 +395,16 @@
     {...buttonProps}
     on:click
     on:focus
+    on:focus={handlePortalFocus}
     on:blur
+    on:blur={handlePortalBlur}
     on:mouseover
     on:mouseenter
     on:mouseenter={handleMouseEnter}
+    on:mouseenter={handlePortalMouseEnter}
     on:mouseleave
     on:mouseleave={handleMouseLeave}
+    on:mouseleave={handlePortalMouseLeave}
   >
     {#if hasIconOnly}
       <span class:bx--assistive-text={true} style:pointer-events="none">
@@ -280,4 +426,21 @@
       />
     {/if}
   </button>
+{/if}
+
+{#if usePortal}
+  <PortalTooltip
+    anchor={ref}
+    direction={tooltipPosition}
+    open={portalOpen}
+    text={iconDescription}
+    tooltipType="icon"
+    intrinsicAlign={tooltipAlignment}
+    horizontalGapLeft={portalHorizontalGapLeft}
+    horizontalGapRight={portalHorizontalGapRight}
+    gapTop={portalGapTop}
+    gapBottom={portalGapBottom}
+    verticalAlignOffsetLeft={portalVerticalAlignOffsetLeft}
+    verticalAlignOffsetRight={portalVerticalAlignOffsetRight}
+  />
 {/if}

--- a/src/Pagination/Pagination.svelte
+++ b/src/Pagination/Pagination.svelte
@@ -246,6 +246,7 @@
       kind="ghost"
       tooltipAlignment="center"
       tooltipPosition="top"
+      portalTooltip
       icon={CaretLeft}
       iconDescription={backwardText}
       disabled={backButtonDisabled}
@@ -262,6 +263,7 @@
       kind="ghost"
       tooltipAlignment="end"
       tooltipPosition="top"
+      portalTooltip
       icon={CaretRight}
       iconDescription={forwardText}
       disabled={forwardButtonDisabled}

--- a/tests/Button/Button.test.svelte
+++ b/tests/Button/Button.test.svelte
@@ -28,6 +28,15 @@
   iconDescription="Add item"
 />
 
+<Button
+  data-testid="btn-icon-portal"
+  icon={Add}
+  portalTooltip
+  tooltipPosition="top"
+  tooltipAlignment="center"
+  iconDescription="Portal tooltip text"
+/>
+
 <Button href="#">Link button</Button>
 
 <Button href="https://example.com" target="_blank">External link</Button>

--- a/tests/Button/Button.test.ts
+++ b/tests/Button/Button.test.ts
@@ -3,6 +3,9 @@ import type ButtonComponent from "carbon-components-svelte/Button/Button.svelte"
 import type { ComponentProps } from "svelte";
 import { user } from "../utils/user";
 import Button from "./Button.test.svelte";
+import ButtonInModal from "./ButtonInModal.test.svelte";
+import ButtonPortalAdjacent from "./ButtonPortalAdjacent.test.svelte";
+import HeaderGlobalActionPortal from "./HeaderGlobalActionPortal.test.svelte";
 
 describe("Button", () => {
   beforeEach(() => {
@@ -201,6 +204,120 @@ describe("Button", () => {
     const assistiveText = iconButton.querySelector(".bx--assistive-text");
     assert(assistiveText);
     expect(assistiveText).toHaveTextContent("Add item");
+  });
+
+  describe("portalTooltip", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("should not apply legacy CSS tooltip classes when portalTooltip is true", () => {
+      render(Button);
+
+      const button = screen.getByTestId("btn-icon-portal");
+      expect(button).toHaveClass("bx--btn--icon-only");
+      expect(button).not.toHaveClass("bx--tooltip__trigger");
+      expect(button).not.toHaveClass("bx--tooltip--a11y");
+      expect(button).not.toHaveClass("bx--btn--icon-only--top");
+      expect(button).not.toHaveClass("bx--tooltip--align-center");
+    });
+
+    it("should render portal tooltip on mouseenter and remove on mouseleave", async () => {
+      render(Button);
+
+      const button = screen.getByTestId("btn-icon-portal");
+
+      expect(
+        document.body.querySelector(".bx--tooltip-portal"),
+      ).not.toBeInTheDocument();
+
+      await fireEvent.mouseEnter(button);
+      await vi.advanceTimersByTimeAsync(100);
+
+      const portal = document.body.querySelector(".bx--tooltip-portal");
+      expect(portal).toBeInTheDocument();
+      expect(portal).toHaveAttribute("data-tooltip-type", "icon");
+      expect(portal).toHaveTextContent("Portal tooltip text");
+
+      await fireEvent.mouseLeave(button);
+      await vi.advanceTimersByTimeAsync(300);
+
+      expect(
+        document.body.querySelector(".bx--tooltip-portal"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("should only show one portal tooltip at a time for adjacent buttons", async () => {
+      render(ButtonPortalAdjacent);
+
+      const btnA = screen.getByTestId("btn-portal-a");
+      const btnB = screen.getByTestId("btn-portal-b");
+
+      await fireEvent.mouseEnter(btnA);
+      await vi.advanceTimersByTimeAsync(100);
+
+      let portals = document.body.querySelectorAll(".bx--tooltip-portal");
+      expect(portals).toHaveLength(1);
+      expect(portals[0]).toHaveTextContent("Tooltip A");
+
+      // Move to the adjacent button: A's tooltip must close as B's opens, so
+      // the two never overlap. Warm handoff skips the enter delay.
+      await fireEvent.mouseEnter(btnB);
+      await vi.advanceTimersByTimeAsync(100);
+
+      portals = document.body.querySelectorAll(".bx--tooltip-portal");
+      expect(portals).toHaveLength(1);
+      expect(portals[0]).toHaveTextContent("Tooltip B");
+    });
+  });
+
+  describe("portalTooltip (modal auto-portal)", () => {
+    it("should portal the tooltip by default when inside a Modal", () => {
+      render(ButtonInModal, { props: { modalOpen: true } });
+
+      const button = screen.getByTestId("btn-icon-modal");
+      expect(button).toHaveClass("bx--btn--icon-only");
+      // Portal mode suppresses the inline CSS tooltip classes.
+      expect(button).not.toHaveClass("bx--tooltip__trigger");
+      expect(button).not.toHaveClass("bx--tooltip--a11y");
+    });
+
+    it("should not portal inside a Modal when portalTooltip is false", () => {
+      render(ButtonInModal, {
+        props: { modalOpen: true, portalTooltip: false },
+      });
+
+      const button = screen.getByTestId("btn-icon-modal");
+      expect(button).toHaveClass("bx--tooltip__trigger");
+      expect(button).toHaveClass("bx--tooltip--a11y");
+    });
+
+    it("should not portal outside a Modal by default", () => {
+      render(Button);
+
+      // Default icon-only button (no portalTooltip, no Modal) stays inline.
+      const button = screen.getByText("Tooltip text").parentElement;
+      assert(button);
+      expect(button).toHaveClass("bx--tooltip__trigger");
+      expect(button).toHaveClass("bx--tooltip--a11y");
+    });
+  });
+
+  describe("HeaderGlobalAction", () => {
+    it("should forward portalTooltip to the underlying Button", () => {
+      render(HeaderGlobalActionPortal);
+
+      const button = screen.getByTestId("header-global-action");
+      expect(button).toHaveClass("bx--header__action");
+      expect(button).toHaveClass("bx--btn--icon-only");
+      // portalTooltip reached the Button: inline CSS tooltip classes suppressed.
+      expect(button).not.toHaveClass("bx--tooltip__trigger");
+      expect(button).not.toHaveClass("bx--tooltip--a11y");
+    });
   });
 
   describe("Generics", () => {

--- a/tests/Button/ButtonInModal.test.svelte
+++ b/tests/Button/ButtonInModal.test.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  import Button from "carbon-components-svelte/Button/Button.svelte";
+  import Modal from "carbon-components-svelte/Modal/Modal.svelte";
+  import Add from "carbon-icons-svelte/lib/Add.svelte";
+  import type { ComponentProps } from "svelte";
+
+  export let modalOpen = true;
+  export let portalTooltip: ComponentProps<Button>["portalTooltip"] = undefined;
+</script>
+
+<Modal
+  bind:open={modalOpen}
+  modalHeading="Test"
+  primaryButtonText="OK"
+  secondaryButtonText="Cancel"
+>
+  <Button
+    data-testid="btn-icon-modal"
+    icon={Add}
+    iconDescription="Tooltip text"
+    {portalTooltip}
+  />
+</Modal>

--- a/tests/Button/ButtonPortalAdjacent.test.svelte
+++ b/tests/Button/ButtonPortalAdjacent.test.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  import Button from "carbon-components-svelte/Button/Button.svelte";
+  import Add from "carbon-icons-svelte/lib/Add.svelte";
+</script>
+
+<Button
+  data-testid="btn-portal-a"
+  icon={Add}
+  portalTooltip
+  tooltipPosition="top"
+  iconDescription="Tooltip A"
+/>
+<Button
+  data-testid="btn-portal-b"
+  icon={Add}
+  portalTooltip
+  tooltipPosition="top"
+  iconDescription="Tooltip B"
+/>

--- a/tests/Button/HeaderGlobalActionPortal.test.svelte
+++ b/tests/Button/HeaderGlobalActionPortal.test.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+  import HeaderGlobalAction from "carbon-components-svelte/UIShell/HeaderGlobalAction.svelte";
+  import Add from "carbon-icons-svelte/lib/Add.svelte";
+</script>
+
+<HeaderGlobalAction
+  data-testid="header-global-action"
+  icon={Add}
+  iconDescription="Tooltip text"
+  portalTooltip
+/>


### PR DESCRIPTION
Similar to tooltip, icon tooltip, the `Button` has an icon-only variant that renders a tooltip.

It should support portalling for parity. It's also needed by `Pagination`, which uses the icon-only variant. It needs to be portalled to avoid clipping.

TODO:

- Expose enter/leave delay; however, this requires also changing the default CSS tooltip hover.

---

<img width="933" height="230" alt="Screenshot 2026-05-15 at 9 20 27 PM" src="https://github.com/user-attachments/assets/155d1c61-78cf-42bb-95d7-c4d678dac6fe" />
