### PR TITLE
fix(ui-shell): `SideNav` locks body scroll when used with modal

### DIFF
--- a/docs/src/pages/components/UIShell.svx
+++ b/docs/src/pages/components/UIShell.svx
@@ -94,6 +94,12 @@ Create a header with a persistent hamburger menu state.
 
 <FileSource src="/framed/UIShell/PersistedHamburgerMenu" />
 
+## Header with modal
+
+Opening a `Modal` while the mobile `SideNav` overlay is also open keeps the body scroll locked until both close. The body lock class is ref-counted across components.
+
+<FileSource src="/framed/UIShell/HeaderWithModal" />
+
 ## Header with toast notification
 
 Integrate toasts with the UI Shell. This example triggers a toast, which appears in the top right corner, below the header.

--- a/docs/src/pages/framed/UIShell/HeaderWithModal.svelte
+++ b/docs/src/pages/framed/UIShell/HeaderWithModal.svelte
@@ -1,0 +1,69 @@
+<script>
+  import {
+    Button,
+    Column,
+    Content,
+    Grid,
+    Header,
+    HeaderNav,
+    HeaderNavItem,
+    Modal,
+    Row,
+    SideNav,
+    SideNavItems,
+    SideNavLink,
+    SideNavMenu,
+    SideNavMenuItem,
+    SkipToContent,
+    Stack,
+  } from "carbon-components-svelte";
+
+  let isSideNavOpen = false;
+  let open = false;
+</script>
+
+<Header companyName="IBM" platformName="Carbon Svelte" bind:isSideNavOpen>
+  <svelte:fragment slot="skipToContent"> <SkipToContent /> </svelte:fragment>
+  <HeaderNav>
+    <HeaderNavItem href="/" text="Link 1" />
+    <HeaderNavItem href="/" text="Link 2" />
+  </HeaderNav>
+</Header>
+
+<SideNav bind:isOpen={isSideNavOpen}>
+  <SideNavItems>
+    <SideNavLink text="Link 1" />
+    <SideNavLink text="Link 2" />
+    <SideNavMenu text="Menu">
+      <SideNavMenuItem href="/" text="Link 1" />
+      <SideNavMenuItem href="/" text="Link 2" />
+    </SideNavMenu>
+  </SideNavItems>
+</SideNav>
+
+<Modal
+  bind:open
+  modalHeading="Confirm action"
+  primaryButtonText="Confirm"
+  secondaryButtonText="Cancel"
+  on:click:button--secondary={() => (open = false)}
+  on:submit={() => (open = false)}
+>
+  <p>
+    The body scroll lock is ref-counted, so opening this modal while the side
+    nav overlay is also open keeps the page locked until both are closed.
+  </p>
+</Modal>
+
+<Content>
+  <Grid>
+    <Row>
+      <Column>
+        <Stack gap={6}>
+          <h1>Welcome</h1>
+          <Button on:click={() => (open = true)}>Open modal</Button>
+        </Stack>
+      </Column>
+    </Row>
+  </Grid>
+</Content>

--- a/src/Modal/modalStore.js
+++ b/src/Modal/modalStore.js
@@ -30,7 +30,34 @@ export const trackModal = (openStore) =>
     };
   });
 
+// Ref-counted body scroll lock so multiple components (Modal, SideNav mobile
+// overlay, etc.) can independently request the `bx--body--with-modal-open`
+// class without racing. The class is added on the first acquire and removed
+// only when the last holder releases.
+let lockCount = 0;
+
+export const acquireBodyScrollLock = () => {
+  lockCount += 1;
+  if (typeof document !== "undefined" && lockCount === 1) {
+    document.body.classList.add("bx--body--with-modal-open");
+  }
+};
+
+export const releaseBodyScrollLock = () => {
+  if (lockCount === 0) return;
+  lockCount -= 1;
+  if (typeof document !== "undefined" && lockCount === 0) {
+    document.body.classList.remove("bx--body--with-modal-open");
+  }
+};
+
+let modalsHoldLock = false;
 modalsOpen.subscribe((openCount) => {
-  if (typeof document !== "undefined")
-    document.body.classList.toggle("bx--body--with-modal-open", openCount > 0);
+  if (openCount > 0 && !modalsHoldLock) {
+    modalsHoldLock = true;
+    acquireBodyScrollLock();
+  } else if (openCount === 0 && modalsHoldLock) {
+    modalsHoldLock = false;
+    releaseBodyScrollLock();
+  }
 });

--- a/src/UIShell/SideNav.svelte
+++ b/src/UIShell/SideNav.svelte
@@ -41,6 +41,10 @@
 
   import { createEventDispatcher, onMount } from "svelte";
   import {
+    acquireBodyScrollLock,
+    releaseBodyScrollLock,
+  } from "../Modal/modalStore";
+  import {
     isSideNavCollapsed,
     isSideNavMobile,
     isSideNavRail,
@@ -67,13 +71,18 @@
     winWidth !== undefined && winWidth < expansionBreakpoint && !fixed;
 
   // Lock body scroll when SideNav is open on mobile (below breakpoint).
-  // Only applies to non-fixed, non-rail variants.
-  $: if (typeof document !== "undefined") {
+  // Only applies to non-fixed, non-rail variants. Uses the shared ref-counted
+  // lock so a Modal opened concurrently is not affected by this toggle.
+  let holdsBodyLock = false;
+  $: {
     const shouldLockScroll = isOpen && !fixed && !rail && $isSideNavMobile;
-    document.body.classList.toggle(
-      "bx--body--with-modal-open",
-      shouldLockScroll,
-    );
+    if (shouldLockScroll && !holdsBodyLock) {
+      holdsBodyLock = true;
+      acquireBodyScrollLock();
+    } else if (!shouldLockScroll && holdsBodyLock) {
+      holdsBodyLock = false;
+      releaseBodyScrollLock();
+    }
   }
 
   onMount(() => {
@@ -81,8 +90,9 @@
     return () => {
       shouldRenderHamburgerMenu.set(false);
       isSideNavMobile.set(false);
-      if (typeof document !== "undefined") {
-        document.body.classList.remove("bx--body--with-modal-open");
+      if (holdsBodyLock) {
+        holdsBodyLock = false;
+        releaseBodyScrollLock();
       }
     };
   });

--- a/tests/Modal/Modal.test.ts
+++ b/tests/Modal/Modal.test.ts
@@ -8,6 +8,7 @@ import ModalFocusReturnTest from "./ModalFocusReturn.test.svelte";
 import ModalFocusTrapTest from "./ModalFocusTrap.test.svelte";
 import ModalFormIdTest from "./ModalFormId.test.svelte";
 import ModalNullishAriaLabel from "./ModalNullishAriaLabel.test.svelte";
+import ModalSideNavBodyLockTest from "./ModalSideNavBodyLock.test.svelte";
 import ModalTextareaEnterTest from "./ModalTextareaEnter.test.svelte";
 
 describe("Modal", () => {
@@ -788,6 +789,67 @@ describe("Modal", () => {
 
       // biome-ignore lint/suspicious/noExplicitAny: Testing default any type
       expectTypeOf<Props["primaryButtonIcon"]>().toEqualTypeOf<any>();
+    });
+  });
+
+  // Regression: Modal and SideNav must coordinate on the body scroll lock
+  // class via a shared ref counter, so neither component clobbers the other.
+  describe("body scroll lock coordination with SideNav", () => {
+    const setViewportWidth = (width: number) => {
+      Object.defineProperty(window, "innerWidth", {
+        writable: true,
+        configurable: true,
+        value: width,
+      });
+      window.dispatchEvent(new Event("resize"));
+    };
+
+    afterEach(() => {
+      setViewportWidth(1024);
+      document.body.classList.remove("bx--body--with-modal-open");
+    });
+
+    it("keeps the body lock class when SideNav closes while a Modal is still open", async () => {
+      setViewportWidth(500);
+
+      const { component } = render(ModalSideNavBodyLockTest, {
+        props: { modalOpen: false, sideNavOpen: false },
+      });
+
+      component.modalOpen = true;
+      component.sideNavOpen = true;
+      await tick();
+      expect(document.body).toHaveClass("bx--body--with-modal-open");
+
+      component.sideNavOpen = false;
+      await tick();
+      // Modal is still open — the class must remain.
+      expect(document.body).toHaveClass("bx--body--with-modal-open");
+
+      component.modalOpen = false;
+      await tick();
+      expect(document.body).not.toHaveClass("bx--body--with-modal-open");
+    });
+
+    it("keeps the body lock class when a Modal closes while SideNav is still open", async () => {
+      setViewportWidth(500);
+
+      const { component } = render(ModalSideNavBodyLockTest, {
+        props: { modalOpen: false, sideNavOpen: false },
+      });
+
+      component.sideNavOpen = true;
+      component.modalOpen = true;
+      await tick();
+      expect(document.body).toHaveClass("bx--body--with-modal-open");
+
+      component.modalOpen = false;
+      await tick();
+      expect(document.body).toHaveClass("bx--body--with-modal-open");
+
+      component.sideNavOpen = false;
+      await tick();
+      expect(document.body).not.toHaveClass("bx--body--with-modal-open");
     });
   });
 });

--- a/tests/Modal/ModalSideNavBodyLock.test.svelte
+++ b/tests/Modal/ModalSideNavBodyLock.test.svelte
@@ -1,0 +1,21 @@
+<svelte:options accessors />
+
+<script lang="ts">
+  import {
+    Modal,
+    SideNav,
+    SideNavItems,
+    SideNavLink,
+  } from "carbon-components-svelte";
+
+  export let modalOpen = false;
+  export let sideNavOpen = false;
+</script>
+
+<Modal bind:open={modalOpen} modalHeading="Heading" passiveModal />
+
+<SideNav bind:isOpen={sideNavOpen} ariaLabel="Nav">
+  <SideNavItems>
+    <SideNavLink href="#" text="Link" />
+  </SideNavItems>
+</SideNav>


### PR DESCRIPTION
Currently, `Modal` and `UIShell` both leverage scroll locking on `document.body` if either the modal is open or side nav is open on mobile.

However, there is a scenario where:

1. Open modal
2. Resize viewport to trigger mobile design for side nav
3. The scroll lock is removed (although the modal is still open)

The modal body scroll lock should allow coordination so that the lock is only released when both call sites reset it to 0.

This adds a documentation example that illustrates the above issue (without the change).