### PR TITLE
fix(ui-shell): `HeaderShell` uses unique IDs

### DIFF
--- a/e2e/uishell.test.ts
+++ b/e2e/uishell.test.ts
@@ -88,13 +88,13 @@ test.describe("UIShell HeaderSearch", () => {
     await page.keyboard.press("ArrowDown");
     await expect(input).toHaveAttribute(
       "aria-activedescendant",
-      "search-menuitem-1",
+      /^ccs-[a-z0-9.]+-menuitem-1$/,
     );
 
     await page.keyboard.press("ArrowDown");
     await expect(input).toHaveAttribute(
       "aria-activedescendant",
-      "search-menuitem-0",
+      /^ccs-[a-z0-9.]+-menuitem-0$/,
     );
 
     await page.getByTestId("outside-header-search").click();

--- a/src/UIShell/HeaderSearch.svelte
+++ b/src/UIShell/HeaderSearch.svelte
@@ -46,6 +46,11 @@
 
   const dispatch = createEventDispatcher();
 
+  const id = `ccs-${Math.random().toString(36)}`;
+  const inputId = `${id}-input`;
+  const labelId = `${id}-label`;
+  const menuId = `${id}-menu`;
+
   /** @type {null | HTMLDivElement} */
   let refSearch = null;
   let prevActive;
@@ -71,7 +76,7 @@
   }
   $: selectedResult = results[selectedResultIndex];
   $: selectedId = selectedResult
-    ? `search-menuitem-${selectedResultIndex}`
+    ? `${id}-menuitem-${selectedResultIndex}`
     : undefined;
 </script>
 
@@ -87,15 +92,12 @@
   role="search"
   class:bx--header__search--active={active}
 >
-  <label
-    class:bx--header__search-label={true}
-    for="search-input"
-    id="search-label"
+  <label class:bx--header__search-label={true} for={inputId} id={labelId}
     >Search</label
   >
   <div
     class:bx--header__search-menu={true}
-    aria-owns="search-menu"
+    aria-owns={menuId}
     aria-haspopup="menu"
   >
     <button
@@ -121,9 +123,9 @@
       class:bx--header__search-input={true}
       class:bx--header__search--active={active}
       {...$$restProps}
-      id="search-input"
+      id={inputId}
       aria-autocomplete="list"
-      aria-controls="search-menu"
+      aria-controls={menuId}
       aria-activedescendant={selectedId}
       bind:value
       on:change
@@ -187,21 +189,21 @@
   {#if active && results.length > 0}
     <!-- svelte-ignore a11y-no-noninteractive-element-to-interactive-role -->
     <ul
-      aria-labelledby="search-label"
+      aria-labelledby={labelId}
       role="menu"
-      id="search-menu"
+      id={menuId}
       class:bx--header-search-menu={true}
     >
       {#each results as result, i}
         <li role="none">
           <a
             tabindex="-1"
-            id="search-menuitem-{i}"
+            id="{id}-menuitem-{i}"
             role="menuitem"
             href={result.href}
             class:bx--header-search-menu-item={true}
             class:bx--header-search-menu-item--selected={selectedId ===
-              `search-menuitem-${i}`}
+              `${id}-menuitem-${i}`}
             on:click|preventDefault={async () => {
               selectedResultIndex = i;
               await tick();

--- a/tests/UIShell/HeaderSearch.test.ts
+++ b/tests/UIShell/HeaderSearch.test.ts
@@ -41,7 +41,23 @@ describe("HeaderSearch", () => {
 
       const searchInput = screen.getByRole("textbox");
       expect(searchInput).toHaveAttribute("placeholder", "Search...");
-      expect(searchInput).toHaveAttribute("id", "search-input");
+      expect(searchInput.id).toMatch(/^ccs-[a-z0-9.]+-input$/);
+    });
+
+    it("should generate unique ids per instance to avoid collisions", () => {
+      const { container: a } = render(HeaderSearchTest);
+      const { container: b } = render(HeaderSearchTest);
+
+      const inputA = a.querySelector("input");
+      const inputB = b.querySelector("input");
+      expect(inputA?.id).toBeTruthy();
+      expect(inputB?.id).toBeTruthy();
+      expect(inputA?.id).not.toBe(inputB?.id);
+
+      const labelA = a.querySelector("label");
+      const labelB = b.querySelector("label");
+      expect(labelA?.getAttribute("for")).toBe(inputA?.id);
+      expect(labelB?.getAttribute("for")).toBe(inputB?.id);
     });
 
     it("should render search button", () => {
@@ -91,9 +107,8 @@ describe("HeaderSearch", () => {
       render(HeaderSearchTest, { props: { results, selectedResultIndex: 1 } });
 
       const searchInput = screen.getByRole("textbox");
-      expect(searchInput).toHaveAttribute(
-        "aria-activedescendant",
-        "search-menuitem-1",
+      expect(searchInput.getAttribute("aria-activedescendant")).toMatch(
+        /^ccs-[a-z0-9.]+-menuitem-1$/,
       );
     });
 
@@ -106,7 +121,8 @@ describe("HeaderSearch", () => {
 
       const menu = screen.getByRole("menu");
       expect(menu).toBeInTheDocument();
-      expect(menu).toHaveAttribute("aria-labelledby", "search-label");
+      const label = screen.getByText("Search", { selector: "label" });
+      expect(menu.getAttribute("aria-labelledby")).toBe(label.id);
 
       const menuItems = screen.getAllByRole("menuitem");
       expect(menuItems).toHaveLength(2);
@@ -217,9 +233,8 @@ describe("HeaderSearch", () => {
       await user.click(searchInput);
       await user.keyboard("{ArrowDown}");
 
-      expect(searchInput).toHaveAttribute(
-        "aria-activedescendant",
-        "search-menuitem-1",
+      expect(searchInput.getAttribute("aria-activedescendant")).toMatch(
+        /^ccs-[a-z0-9.]+-menuitem-1$/,
       );
     });
 
@@ -237,9 +252,8 @@ describe("HeaderSearch", () => {
       await user.click(searchInput);
       await user.keyboard("{ArrowUp}");
 
-      expect(searchInput).toHaveAttribute(
-        "aria-activedescendant",
-        "search-menuitem-0",
+      expect(searchInput.getAttribute("aria-activedescendant")).toMatch(
+        /^ccs-[a-z0-9.]+-menuitem-0$/,
       );
     });
 
@@ -256,9 +270,8 @@ describe("HeaderSearch", () => {
       await user.click(searchInput);
       await user.keyboard("{ArrowDown}");
 
-      expect(searchInput).toHaveAttribute(
-        "aria-activedescendant",
-        "search-menuitem-0",
+      expect(searchInput.getAttribute("aria-activedescendant")).toMatch(
+        /^ccs-[a-z0-9.]+-menuitem-0$/,
       );
     });
 
@@ -275,9 +288,8 @@ describe("HeaderSearch", () => {
       await user.click(searchInput);
       await user.keyboard("{ArrowUp}");
 
-      expect(searchInput).toHaveAttribute(
-        "aria-activedescendant",
-        "search-menuitem-1",
+      expect(searchInput.getAttribute("aria-activedescendant")).toMatch(
+        /^ccs-[a-z0-9.]+-menuitem-1$/,
       );
     });
 
@@ -371,7 +383,9 @@ describe("HeaderSearch", () => {
 
       const searchInput = screen.getByRole("textbox");
       expect(searchInput).toHaveAttribute("aria-autocomplete", "list");
-      expect(searchInput).toHaveAttribute("aria-controls", "search-menu");
+      expect(searchInput.getAttribute("aria-controls")).toMatch(
+        /^ccs-[a-z0-9.]+-menu$/,
+      );
     });
 
     it("should have proper tabindex attributes", () => {


### PR DESCRIPTION
This fixes `HeaderShell` to use unique IDs for ARIA labels. It currently hardcodes "search-menu," which can plausibly clash with consumer IDs on the same page.

Additionally, collisions also occur if multiple `HeaderShell` instances are created. In practice, this is unlikely, as an app should only have one UI Shell.