### PR TITLE
fix(overflow-menu): self-unregister items on destroy

### DIFF
--- a/src/OverflowMenu/OverflowMenu.svelte
+++ b/src/OverflowMenu/OverflowMenu.svelte
@@ -117,6 +117,11 @@
     });
   };
 
+  /** @type {(id: string) => void} */
+  const remove = (id) => {
+    items.update((_) => _.filter((item) => item.id !== id));
+  };
+
   /**
    * @type {(id: string, item: { id: string; text: string; primaryFocus: boolean; disabled: boolean; index: number }) => void}
    */
@@ -183,6 +188,7 @@
     focusedId,
     items,
     add,
+    remove,
     update,
     change,
     first,
@@ -223,7 +229,6 @@
     }
 
     if (!open) {
-      items.set([]);
       currentId.set(undefined);
       currentIndex.set(0);
     }

--- a/src/OverflowMenu/OverflowMenuItem.svelte
+++ b/src/OverflowMenu/OverflowMenuItem.svelte
@@ -53,18 +53,24 @@
   /** Obtain a reference to the HTML element */
   export let ref = null;
 
-  import { afterUpdate, createEventDispatcher, getContext } from "svelte";
+  import {
+    afterUpdate,
+    createEventDispatcher,
+    getContext,
+    onMount,
+  } from "svelte";
 
   const dispatch = createEventDispatcher();
-  const { focusedId, add, update, change, first, last, items } = getContext(
-    "carbon:OverflowMenu",
-  );
+  const { focusedId, add, remove, update, change, first, last, items } =
+    getContext("carbon:OverflowMenu");
 
   $: item = $items.find((_) => _.id === id);
 
   add({ id, text, primaryFocus, disabled });
 
   $: focused = $focusedId === id;
+
+  onMount(() => () => remove(id));
 
   afterUpdate(() => {
     if (ref && focused) {

--- a/tests/OverflowMenu/OverflowMenu.dynamicItems.test.svelte
+++ b/tests/OverflowMenu/OverflowMenu.dynamicItems.test.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+  import { OverflowMenu, OverflowMenuItem } from "carbon-components-svelte";
+
+  export let showMiddle = true;
+</script>
+
+<OverflowMenu>
+  <OverflowMenuItem text="First" />
+  {#if showMiddle}
+    <OverflowMenuItem text="Middle" />
+  {/if}
+  <OverflowMenuItem text="Last" />
+</OverflowMenu>

--- a/tests/OverflowMenu/OverflowMenu.test.ts
+++ b/tests/OverflowMenu/OverflowMenu.test.ts
@@ -6,6 +6,7 @@ import { user } from "../setup-tests";
 import OverflowMenuAllDisabled from "./OverflowMenu.allDisabled.test.svelte";
 import OverflowMenuDisabled from "./OverflowMenu.disabled.test.svelte";
 import OverflowMenuDisabledLink from "./OverflowMenu.disabledLink.test.svelte";
+import OverflowMenuDynamicItems from "./OverflowMenu.dynamicItems.test.svelte";
 import OverflowMenuPreventDefault from "./OverflowMenu.preventDefault.test.svelte";
 import OverflowMenuRel from "./OverflowMenu.rel.test.svelte";
 import OverflowMenu from "./OverflowMenu.test.svelte";
@@ -526,6 +527,33 @@ describe("OverflowMenu", () => {
 
     expect(menuButton).toHaveAttribute("aria-expanded", "false");
     expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+  });
+
+  it("removes destroyed items from the registry so arrow nav skips them", async () => {
+    const { rerender } = render(OverflowMenuDynamicItems, {
+      props: { showMiddle: true },
+    });
+
+    const menuButton = screen.getByRole("button");
+    await user.click(menuButton);
+
+    let menuItems = screen.getAllByRole("menuitem");
+    expect(menuItems).toHaveLength(3);
+    expect(menuItems[0]).toHaveTextContent("First");
+    expect(menuItems[0]).toHaveFocus();
+
+    await rerender({ showMiddle: false });
+    await tick();
+
+    menuItems = screen.getAllByRole("menuitem");
+    expect(menuItems).toHaveLength(2);
+    expect(menuItems[0]).toHaveTextContent("First");
+    expect(menuItems[1]).toHaveTextContent("Last");
+
+    // ArrowDown from First should jump straight to Last — the removed
+    // "Middle" must no longer be in the internal registry.
+    await user.keyboard("{ArrowDown}");
+    expect(menuItems[1]).toHaveFocus();
   });
 
   describe("portalMenu", () => {


### PR DESCRIPTION
If an `OverflowMenuItem` is conditionally rendered, it's not removed from the registry, so keyboard navigation will navigate to the phantom item. This also removes it on destroy.

