### PR TITLE
fix(ui-shell): guard `ref` access in window click handlers

### DIFF
--- a/src/UIShell/HeaderNavMenu.svelte
+++ b/src/UIShell/HeaderNavMenu.svelte
@@ -11,7 +11,10 @@
    */
   export let text = undefined;
 
-  /** Obtain a reference to the HTML anchor element */
+  /**
+   * Obtain a reference to the HTML anchor element.
+   * @type {HTMLAnchorElement | null}
+   */
   export let ref = null;
 
   import { setContext, tick } from "svelte";
@@ -77,7 +80,7 @@
 
 <svelte:window
   on:click={({ target }) => {
-    if (!ref.contains(target)) {
+    if (!ref?.contains(target)) {
       expanded = false;
     }
   }}

--- a/src/UIShell/HeaderSearch.svelte
+++ b/src/UIShell/HeaderSearch.svelte
@@ -25,7 +25,10 @@
   /** Set to `true` to activate and focus the search bar */
   export let active = false;
 
-  /** Obtain a reference to the input HTML element */
+  /**
+   * Obtain a reference to the input HTML element.
+   * @type {HTMLInputElement | null}
+   */
   export let ref = null;
 
   /**
@@ -43,6 +46,7 @@
 
   const dispatch = createEventDispatcher();
 
+  /** @type {null | HTMLDivElement} */
   let refSearch = null;
   let prevActive;
 
@@ -73,7 +77,7 @@
 
 <svelte:window
   on:mouseup={({ target }) => {
-    if (active && !refSearch.contains(target)) active = false;
+    if (active && !refSearch?.contains(target)) active = false;
   }}
 />
 


### PR DESCRIPTION
This is a correctness fix.

`HeaderNavMenu` and `HeaderSearch` invoke `ref.contains(target)` from `svelte:window` listeners; `ref` is `null` until mount, so synchronous clicks during render could throw. Use optional chaining and add explicit JSDoc types for the anchor/input/div refs.