### PR TITLE
fix(ui-shell): `Header` preserves user-toggled side nav across breakpoints

### DIFF
--- a/src/UIShell/Header.svelte
+++ b/src/UIShell/Header.svelte
@@ -115,9 +115,11 @@
       // Initial mount: set based on current viewport
       isSideNavOpen = shouldAutoExpand;
     } else if (wasAboveBreakpoint !== isAboveBreakpoint) {
-      // Crossed breakpoint threshold - reset user flag and auto-expand if appropriate
+      // Crossed breakpoint threshold: skip auto-write if the user just
+      // toggled the nav so their choice isn't clobbered by the resize.
+      // The flag is one-shot — reset so subsequent crossings auto-expand.
+      if (!userExplicitlySet) isSideNavOpen = shouldAutoExpand;
       userExplicitlySet = false;
-      isSideNavOpen = shouldAutoExpand;
     }
 
     wasAboveBreakpoint = isAboveBreakpoint;

--- a/tests/UIShell/UIShell.test.ts
+++ b/tests/UIShell/UIShell.test.ts
@@ -195,6 +195,30 @@ describe("UIShell", () => {
         expect(component.isSideNavOpen).toBe(true);
       });
 
+      it("preserves a user-toggled state across the next breakpoint crossing", async () => {
+        // Regression: `userExplicitlySet` was set on hamburger click but never
+        // gated the auto-write, so a viewport resize clobbered the user's choice.
+        setViewportWidth(500); // Mobile
+
+        const { container, component } = render(UiShell, {
+          props: { persistentHamburgerMenu: true, isSideNavOpen: false },
+        });
+
+        const hamburgerButton = container.querySelector(
+          ".bx--header__menu-trigger",
+        );
+        assert(hamburgerButton);
+        await user.click(hamburgerButton);
+        expect(component.isSideNavOpen).toBe(true);
+
+        // With `persistentHamburgerMenu: true`, `shouldAutoExpand` is always
+        // false. Without the gate, crossing to desktop would force-close
+        // the nav the user just opened.
+        setViewportWidth(1200);
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        expect(component.isSideNavOpen).toBe(true);
+      });
+
       it("should auto-expand when crossing breakpoint to desktop", async () => {
         setViewportWidth(500); // Start on mobile
 


### PR DESCRIPTION
The `userExplicitlySet` flag was set on hamburger click but never gated the auto-write, so a resize clobbered the user's choice. Gate the breakpoint-cross assignment on it as an override.

Before:

1. Toggling the menu and resizing to mobile would immediately reset the open state.

After:

1. Toggling the menu and resizing to mobile keeps the menu open.

---


https://github.com/user-attachments/assets/36a4af9f-ec65-4e86-be22-c488f4db45ba

