### PR TITLE
fix(file-uploader): stable per-file ids for add/remove events

### DIFF
--- a/src/FileUploader/FileUploader.svelte
+++ b/src/FileUploader/FileUploader.svelte
@@ -132,39 +132,45 @@
 
   let prevFiles = [];
 
-  /** @type {(file: File, index: number) => string} */
-  const getFileId = (file, index) =>
-    `${file.lastModified + file.name}-${index}`;
+  // Per-file stable id: assigned once on first sight and carried with the
+  // File reference, so reorders and removals don't shift other files' ids.
+  // Two files with the same name/size/lastModified get distinct ids via a
+  // `#n` suffix.
+  /** @type {WeakMap<File, string>} */
+  const fileKeys = new WeakMap();
+
+  /** @param {ReadonlyArray<File>} list */
+  function keyFiles(list) {
+    const used = new Set();
+    for (const f of list) {
+      const cached = fileKeys.get(f);
+      if (cached !== undefined) used.add(cached);
+    }
+    return list.map((file) => {
+      let key = fileKeys.get(file);
+      if (key === undefined) {
+        const base = `${file.name}-${file.size}-${file.lastModified}`;
+        key = base;
+        let n = 1;
+        while (used.has(key)) key = `${base}#${n++}`;
+        fileKeys.set(file, key);
+        used.add(key);
+      }
+      return { file, key };
+    });
+  }
 
   /** Stable keys for `{#each}` (and Biome-safe: no commas in the each header). */
-  $: filesWithKeys = files.map((file, index) => ({
-    file,
-    key: getFileId(file, index),
-  }));
+  $: filesWithKeys = keyFiles(files);
 
   afterUpdate(() => {
-    const fileIds = files.map((f, i) => getFileId(f, i));
-    const prevFileIds = prevFiles.map((f, i) => getFileId(f, i));
-    const addedIds = fileIds.filter((_) => !prevFileIds.includes(_));
-    const removedIds = prevFileIds.filter((_) => !fileIds.includes(_));
+    const prevSet = new Set(prevFiles);
+    const currentSet = new Set(files);
+    const added = files.filter((f) => !prevSet.has(f));
+    const removed = prevFiles.filter((f) => !currentSet.has(f));
 
-    if (addedIds.length > 0) {
-      dispatch(
-        "add",
-        addedIds.map((id) =>
-          files.find((file, i) => id === getFileId(file, i)),
-        ),
-      );
-    }
-
-    if (removedIds.length > 0) {
-      dispatch(
-        "remove",
-        removedIds.map((id) =>
-          prevFiles.find((file, i) => id === getFileId(file, i)),
-        ),
-      );
-    }
+    if (added.length > 0) dispatch("add", added);
+    if (removed.length > 0) dispatch("remove", removed);
 
     if (prevFiles.length > 0 && files.length === 0) {
       dispatch("change", []);

--- a/tests/FileUploader/FileUploader.test.ts
+++ b/tests/FileUploader/FileUploader.test.ts
@@ -102,6 +102,84 @@ describe("FileUploader", () => {
     expect(screen.queryByText("file3.txt")).toBeInTheDocument();
   });
 
+  it("should dispatch remove with only the deleted middle file (not shifted neighbors)", async () => {
+    const addHandler = vi.fn();
+    const removeHandler = vi.fn();
+    const { component } = render(FileUploader, {
+      props: { onAdd: addHandler, onRemove: removeHandler, multiple: true },
+    });
+
+    const file1 = new File(["content1"], "file1.txt", { type: "text/plain" });
+    const file2 = new File(["content2"], "file2.txt", { type: "text/plain" });
+    const file3 = new File(["content3"], "file3.txt", { type: "text/plain" });
+
+    const input = component.getInputElement();
+    simulateFileSelection(input, [file1, file2, file3]);
+
+    await vi.waitFor(() => {
+      const fileNames = screen.queryAllByText(/file\d\.txt/);
+      expect(fileNames).toHaveLength(3);
+    });
+
+    addHandler.mockClear();
+    removeHandler.mockClear();
+
+    const closeButtons = document.querySelectorAll(
+      ".bx--file__state-container button, .bx--file__state-container .bx--file-close",
+    );
+    expect(closeButtons.length).toBe(3);
+    const middleCloseButton = closeButtons[1];
+    assert(middleCloseButton instanceof HTMLElement);
+    await user.click(middleCloseButton);
+
+    await vi.waitFor(() => {
+      expect(screen.queryByText("file2.txt")).not.toBeInTheDocument();
+    });
+
+    expect(addHandler).not.toHaveBeenCalled();
+    expect(removeHandler).toHaveBeenCalledTimes(1);
+    const removed = removeHandler.mock.calls[0][0].detail;
+    expect(removed).toHaveLength(1);
+    expect(removed[0].name).toBe("file2.txt");
+  });
+
+  it("should not dispatch spurious add/remove when new files are prepended", async () => {
+    const addHandler = vi.fn();
+    const removeHandler = vi.fn();
+    const { component } = render(FileUploader, {
+      props: {
+        onAdd: addHandler,
+        onRemove: removeHandler,
+        multiple: true,
+        orderFiles: "prepend",
+      },
+    });
+
+    const fileA = new File(["a"], "a.txt", { type: "text/plain" });
+    const input = component.getInputElement();
+    simulateFileSelection(input, [fileA]);
+
+    await vi.waitFor(() => {
+      expect(screen.queryByText("a.txt")).toBeInTheDocument();
+    });
+
+    addHandler.mockClear();
+    removeHandler.mockClear();
+
+    const fileB = new File(["b"], "b.txt", { type: "text/plain" });
+    simulateFileSelection(input, [fileB]);
+
+    await vi.waitFor(() => {
+      expect(screen.queryByText("b.txt")).toBeInTheDocument();
+    });
+
+    expect(removeHandler).not.toHaveBeenCalled();
+    expect(addHandler).toHaveBeenCalledTimes(1);
+    const added = addHandler.mock.calls[0][0].detail;
+    expect(added).toHaveLength(1);
+    expect(added[0].name).toBe("b.txt");
+  });
+
   it("should clear input.files when all files are removed", async () => {
     const { component } = render(FileUploader);
 


### PR DESCRIPTION
The previous id encoded array position, so removing or reordering a file shifted every later file's id: `add`/`remove` events fired for files that didn't actually change. Use a `WeakMap<File, string>` keyed by `name-size-lastModified` with `#n` suffix on collision.