### PR TITLE
test: remove unused exports

### DIFF
--- a/tests-svelte3/setup-tests.ts
+++ b/tests-svelte3/setup-tests.ts
@@ -2,10 +2,7 @@
 import "@testing-library/jest-dom/vitest";
 
 export {
-  isSvelte3,
-  isSvelte4,
   isSvelte5,
-  SVELTE_VERSION,
   setupLocalStorageMock,
   user,
 } from "../tests/utils/setup-shared";

--- a/tests-svelte4/setup-tests.ts
+++ b/tests-svelte4/setup-tests.ts
@@ -2,10 +2,7 @@
 import "@testing-library/jest-dom/vitest";
 
 export {
-  isSvelte3,
-  isSvelte4,
   isSvelte5,
-  SVELTE_VERSION,
   setupLocalStorageMock,
   user,
 } from "../tests/utils/setup-shared";

--- a/tests/setup-tests.ts
+++ b/tests/setup-tests.ts
@@ -2,10 +2,7 @@
 import "@testing-library/jest-dom/vitest";
 
 export {
-  isSvelte3,
-  isSvelte4,
   isSvelte5,
-  SVELTE_VERSION,
   setupLocalStorageMock,
   setupSessionStorageEventMock,
   setupSessionStorageMock,

--- a/tests/utils/setup-shared.ts
+++ b/tests/utils/setup-shared.ts
@@ -7,12 +7,7 @@ import { userEvent } from "@testing-library/user-event";
 // Using dynamic import() to ensure it loads from the correct location at runtime
 const sveltePkg = await import("svelte/package.json");
 
-export const SVELTE_VERSION = Number.parseInt(
-  sveltePkg.version.split(".")[0],
-  10,
-);
-export const isSvelte3 = SVELTE_VERSION === 3;
-export const isSvelte4 = SVELTE_VERSION === 4;
+const SVELTE_VERSION = Number.parseInt(sveltePkg.version.split(".")[0], 10);
 export const isSvelte5 = SVELTE_VERSION === 5;
 
 Element.prototype.scrollIntoView = vi.fn();


### PR DESCRIPTION
Remove these unused exports. Only `isSvelte5` is used/needed.