### PR TITLE
feat(recursive-list): support string nodes as `{ text }` shorthand

### DIFF
--- a/docs/src/pages/components/RecursiveList.svx
+++ b/docs/src/pages/components/RecursiveList.svx
@@ -13,6 +13,12 @@ Create a hierarchical list using the `nodes` prop. Each node can contain text, l
 
 <FileSource src="/framed/RecursiveList/RecursiveList" />
 
+## String shorthand
+
+A string entry in `nodes` is shorthand for `{ text: "..." }`. Strings can mix freely with object nodes, including inside nested `nodes` arrays.
+
+<FileSource src="/framed/RecursiveList/RecursiveListStringShorthand" />
+
 ## Ordered
 
 Set `type` to `"ordered"` to use numbered lists with proper indentation.

--- a/docs/src/pages/framed/RecursiveList/RecursiveListStringShorthand.svelte
+++ b/docs/src/pages/framed/RecursiveList/RecursiveListStringShorthand.svelte
@@ -1,0 +1,14 @@
+<script>
+  import { RecursiveList } from "carbon-components-svelte";
+
+  const nodes = [
+    "Item 1",
+    {
+      text: "Item 2",
+      nodes: ["Item 2a", "Item 2b"],
+    },
+    "Item 3",
+  ];
+</script>
+
+<RecursiveList {nodes} />

--- a/src/RecursiveList/RecursiveList.svelte
+++ b/src/RecursiveList/RecursiveList.svelte
@@ -8,13 +8,14 @@
    * @property {string} [html] - Node HTML content
    * @property {import("svelte/elements").SvelteHTMLElements["a"]["target"]} [target] - Node link target
    * @property {import("svelte/elements").SvelteHTMLElements["a"]["rel"]} [rel] - Node link rel
-   * @property {RecursiveListNode[]} [nodes] - Child nodes
+   * @property {Array<string | RecursiveListNode>} [nodes] - Child nodes
    * @restProps {ul | ol}
    */
 
   /**
    * Specify the nodes to render.
-   * @type {ReadonlyArray<Node & { nodes?: Node[] }>}
+   * A string entry is shorthand for `{ text: "..." }`.
+   * @type {ReadonlyArray<string | (Node & { nodes?: Array<string | Node> })>}
    */
   export let nodes = [];
 
@@ -38,13 +39,14 @@
   {expressive}
   {...$$restProps}
 >
-  {#each nodes as child, index (child.id ?? index)}
-    {#if Array.isArray(child.nodes)}
-      <RecursiveListItem {...child}>
-        <svelte:self {...child} {type} {expressive} nested />
+  {#each nodes as child, index (typeof child === "string" ? child : child.id ?? index)}
+    {@const node = typeof child === "string" ? { text: child } : child}
+    {#if Array.isArray(node.nodes)}
+      <RecursiveListItem {...node}>
+        <svelte:self {...node} {type} {expressive} nested />
       </RecursiveListItem>
     {:else}
-      <RecursiveListItem {...child} />
+      <RecursiveListItem {...node} />
     {/if}
   {/each}
 </svelte:component>

--- a/tests/RecursiveList/RecursiveList.string-shorthand.test.svelte
+++ b/tests/RecursiveList/RecursiveList.string-shorthand.test.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+  import { RecursiveList } from "carbon-components-svelte";
+
+  const nodes = [
+    "Item 1",
+    {
+      text: "Item 2",
+      nodes: ["Item 2a", { text: "Item 2b" }],
+    },
+    "Item 3",
+  ];
+</script>
+
+<RecursiveList {nodes} />

--- a/tests/RecursiveList/RecursiveList.test.ts
+++ b/tests/RecursiveList/RecursiveList.test.ts
@@ -5,6 +5,7 @@ import RecursiveList from "carbon-components-svelte/RecursiveList/RecursiveList.
 import type { ComponentProps } from "svelte";
 import RecursiveListHierarchyTest from "./RecursiveList.hierarchy.test.svelte";
 import RecursiveListIdTest from "./RecursiveList.id.test.svelte";
+import RecursiveListStringShorthandTest from "./RecursiveList.string-shorthand.test.svelte";
 import RecursiveListTest from "./RecursiveList.test.svelte";
 
 const testCases = [
@@ -105,6 +106,30 @@ describe("RecursiveList props", () => {
     const lists = screen.getAllByRole("list");
     expect(lists).toHaveLength(2);
     expect(lists[1]).toHaveClass("bx--list--nested");
+  });
+});
+
+describe("RecursiveList string shorthand", () => {
+  it("renders string entries as text nodes", () => {
+    render(RecursiveListStringShorthandTest);
+
+    expect(screen.getByText("Item 1")).toBeInTheDocument();
+    expect(screen.getByText("Item 2")).toBeInTheDocument();
+    expect(screen.getByText("Item 3")).toBeInTheDocument();
+  });
+
+  it("renders nested string entries as text nodes", () => {
+    render(RecursiveListStringShorthandTest);
+
+    expect(screen.getByText("Item 2a")).toBeInTheDocument();
+    expect(screen.getByText("Item 2b")).toBeInTheDocument();
+  });
+
+  it("renders the correct number of lists for nested strings", () => {
+    render(RecursiveListStringShorthandTest);
+
+    // One outer list + one nested list under "Item 2"
+    expect(screen.getAllByRole("list")).toHaveLength(2);
   });
 });
 
@@ -282,13 +307,18 @@ describe("RecursiveList Generics", () => {
     type Props = ComponentProps<ComponentType>;
 
     expectTypeOf<NonNullable<Props["nodes"]>>().toEqualTypeOf<
-      ReadonlyArray<CustomNode & { nodes?: CustomNode[] }>
+      ReadonlyArray<
+        string | (CustomNode & { nodes?: Array<string | CustomNode> })
+      >
     >();
 
     type BaseComponentType = RecursiveListComponent<RecursiveListNode>;
     type BaseProps = ComponentProps<BaseComponentType>;
     expectTypeOf<NonNullable<BaseProps["nodes"]>>().toEqualTypeOf<
-      ReadonlyArray<RecursiveListNode & { nodes?: RecursiveListNode[] }>
+      ReadonlyArray<
+        | string
+        | (RecursiveListNode & { nodes?: Array<string | RecursiveListNode> })
+      >
     >();
   });
 });


### PR DESCRIPTION
`["a", "b"]` is a common ergonomic shape; requiring `{ text }` on every node added boilerplate without enabling any new behavior. Strings are normalized at the `{#each}` boundary so nested arrays mix freely with object nodes.