### PR TITLE
fix(toolbar-batch-actions): stop mutating controlled `active` prop

### DIFF
--- a/src/DataTable/ToolbarBatchActions.svelte
+++ b/src/DataTable/ToolbarBatchActions.svelte
@@ -24,17 +24,11 @@
    */
   export let selectedIds = [];
 
-  import {
-    afterUpdate,
-    createEventDispatcher,
-    getContext,
-    onMount,
-  } from "svelte";
+  import { createEventDispatcher, getContext, onMount } from "svelte";
 
   import Button from "../Button/Button.svelte";
 
   let batchSelectedIds = [];
-  let prevActive;
 
   const dispatch = createEventDispatcher();
 
@@ -62,14 +56,7 @@
     batchSelectedIds = selectedIds;
   }
 
-  $: showActions = batchSelectedIds.length > 0 || active;
-  $: {
-    if (prevActive !== active && active === false) {
-      showActions = false;
-    }
-
-    prevActive = active;
-  }
+  $: showActions = active ?? batchSelectedIds.length > 0;
   $: inertProps = showActions ? {} : { inert: true };
 
   let overflowVisible = false;
@@ -92,12 +79,6 @@
       unsubscribe?.();
       unsubscribeOverflow?.();
     };
-  });
-
-  afterUpdate(() => {
-    if (active === false && showActions) {
-      active = true;
-    }
   });
 </script>
 

--- a/tests/DataTable/DataTableBatchSelectionToolbar.test.ts
+++ b/tests/DataTable/DataTableBatchSelectionToolbar.test.ts
@@ -109,6 +109,21 @@ describe("DataTableBatchSelectionToolbar", () => {
     expect(toolbar).toHaveClass("bx--batch-actions--active");
   });
 
+  it("does not silently flip controlled active=false back to true when rows are selected", async () => {
+    const { container, rerender } = render(DataTableBatchSelectionToolbar, {
+      props: {
+        selectedRowIds: [],
+        active: false,
+      },
+    });
+
+    rerender({ selectedRowIds: ["a", "b"], active: false });
+    await tick();
+
+    const toolbar = container.querySelector(".bx--batch-actions");
+    expect(toolbar).not.toHaveClass("bx--batch-actions--active");
+  });
+
   it("prevents default cancel behavior when controlled", async () => {
     render(DataTableBatchSelectionToolbar, {
       props: {


### PR DESCRIPTION
Derive `showActions` from `active ?? batchSelectedIds.length > 0` and drop the `afterUpdate` write-back. Consumers binding `active={false}` no longer see it silently flipped to `true` when rows get selected.