### PR TITLE
fix(toolbar-search): coerce `value` to string before reading length

### DIFF
--- a/src/DataTable/ToolbarSearch.svelte
+++ b/src/DataTable/ToolbarSearch.svelte
@@ -92,7 +92,7 @@
     ref.focus();
   }
 
-  $: expanded = !!value.length;
+  $: expanded = String(value ?? "").length > 0;
   $: classes = [
     expanded && "bx--toolbar-search-container-active",
     persistent
@@ -119,7 +119,7 @@
   on:focus={expandSearch}
   on:blur
   on:blur={() => {
-    expanded = !persistent && !!value.length;
+    expanded = !persistent && String(value ?? "").length > 0;
   }}
   on:keyup
   on:keydown

--- a/tests/DataTable/ToolbarSearchNumericValue.test.svelte
+++ b/tests/DataTable/ToolbarSearchNumericValue.test.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import {
+    DataTable,
+    Toolbar,
+    ToolbarContent,
+    ToolbarSearch,
+  } from "carbon-components-svelte";
+
+  export let value: number | string = "";
+</script>
+
+<DataTable
+  headers={[{ key: "name", value: "Name" }]}
+  rows={[{ id: 1, name: "Row 1" }]}
+>
+  <Toolbar>
+    <ToolbarContent>
+      <ToolbarSearch {value} />
+    </ToolbarContent>
+  </Toolbar>
+</DataTable>

--- a/tests/DataTable/ToolbarSearchNumericValue.test.ts
+++ b/tests/DataTable/ToolbarSearchNumericValue.test.ts
@@ -1,0 +1,38 @@
+import { render } from "@testing-library/svelte";
+import ToolbarSearchNumericValue from "./ToolbarSearchNumericValue.test.svelte";
+
+describe("ToolbarSearch numeric value", () => {
+  it("does not crash when value is a number and expands when non-zero", () => {
+    const { container } = render(ToolbarSearchNumericValue, {
+      props: { value: 123 },
+    });
+
+    const wrapper = container.querySelector(".bx--search");
+    expect(wrapper).not.toBeNull();
+    expect(
+      wrapper?.classList.contains("bx--toolbar-search-container-active"),
+    ).toBe(true);
+  });
+
+  it("treats numeric 0 as a value and expands (no longer swallowed)", () => {
+    const { container } = render(ToolbarSearchNumericValue, {
+      props: { value: 0 },
+    });
+
+    const wrapper = container.querySelector(".bx--search");
+    expect(
+      wrapper?.classList.contains("bx--toolbar-search-container-active"),
+    ).toBe(true);
+  });
+
+  it("does not expand when value is the empty string", () => {
+    const { container } = render(ToolbarSearchNumericValue, {
+      props: { value: "" },
+    });
+
+    const wrapper = container.querySelector(".bx--search");
+    expect(
+      wrapper?.classList.contains("bx--toolbar-search-container-active"),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
Numeric `value` props (e.g. `0` or `123`) previously read `.length` on the number, yielding `undefined` and silently collapsing the bar. Coercing via `String(value ?? "")` keeps numeric values working.