### PR TITLE
perf(toolbar-search): avoid refiltering on unrelated updates

### DIFF
--- a/src/DataTable/ToolbarSearch.svelte
+++ b/src/DataTable/ToolbarSearch.svelte
@@ -50,7 +50,7 @@
    */
   export let ref = null;
 
-  import { afterUpdate, getContext, onMount, tick } from "svelte";
+  import { getContext, onMount, tick } from "svelte";
   import Search from "../Search/Search.svelte";
   import { rowsEqual } from "./data-table-utils.js";
 
@@ -77,12 +77,9 @@
     };
   });
 
-  afterUpdate(() => {
-    // Only filter rows in a callback to avoid an infinite update loop.
-    if (rows !== null) {
-      filteredRowIds = ctx?.filterRows(value, shouldFilterRows);
-    }
-  });
+  $: if (rows !== null) {
+    filteredRowIds = ctx.filterRows(value, shouldFilterRows);
+  }
 
   async function expandSearch() {
     await tick();

--- a/tests/DataTable/FilterRowsSpy.svelte
+++ b/tests/DataTable/FilterRowsSpy.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+  import { getContext, setContext } from "svelte";
+
+  type Ctx = {
+    filterRows: (
+      value: string | number,
+      shouldFilterRows?: unknown,
+    ) => readonly (string | number)[];
+    [key: string]: unknown;
+  };
+
+  export let count = 0;
+
+  const ctx = getContext<Ctx>("carbon:DataTable");
+  const original = ctx.filterRows;
+
+  setContext("carbon:DataTable", {
+    ...ctx,
+    filterRows: (value: string | number, shouldFilterRows?: unknown) => {
+      count += 1;
+      return original(value, shouldFilterRows);
+    },
+  });
+</script>
+
+<slot />

--- a/tests/DataTable/ToolbarSearchExtraUpdates.test.svelte
+++ b/tests/DataTable/ToolbarSearchExtraUpdates.test.svelte
@@ -1,0 +1,41 @@
+<svelte:options accessors />
+
+<script lang="ts">
+  import {
+    Button,
+    DataTable,
+    Toolbar,
+    ToolbarContent,
+    ToolbarSearch,
+  } from "carbon-components-svelte";
+  import FilterRowsSpy from "./FilterRowsSpy.svelte";
+
+  export let filterRowsCount = 0;
+
+  const rows = Array.from({ length: 10 }).map((_, i) => ({
+    id: i,
+    name: `Load Balancer ${i + 1}`,
+    rule: i % 2 ? "Round robin" : "DNS delegation",
+  }));
+
+  // Unrelated reactive state that should NOT cause re-filtering when toggled.
+  let unrelated = 0;
+</script>
+
+<Button on:click={() => (unrelated += 1)}>Bump unrelated</Button>
+
+<DataTable
+  headers={[
+    { key: "name", value: "Name" },
+    { key: "rule", value: "Rule" },
+  ]}
+  {rows}
+>
+  <Toolbar>
+    <ToolbarContent>
+      <FilterRowsSpy bind:count={filterRowsCount}>
+        <ToolbarSearch shouldFilterRows value="round" tabindex={unrelated} />
+      </FilterRowsSpy>
+    </ToolbarContent>
+  </Toolbar>
+</DataTable>

--- a/tests/DataTable/ToolbarSearchExtraUpdates.test.ts
+++ b/tests/DataTable/ToolbarSearchExtraUpdates.test.ts
@@ -1,0 +1,23 @@
+import { render, screen } from "@testing-library/svelte";
+import { user } from "../setup-tests";
+import ToolbarSearchExtraUpdates from "./ToolbarSearchExtraUpdates.test.svelte";
+
+describe("ToolbarSearch does not refilter on unrelated updates", () => {
+  it("only calls filterRows when value/rows/shouldFilterRows change", async () => {
+    const { component } = render(ToolbarSearchExtraUpdates);
+
+    // Snapshot the call count after mount; we don't assert an exact mount
+    // count since the initial filter may legitimately run during setup.
+    const baseline = component.filterRowsCount;
+    expect(baseline).toBeGreaterThan(0);
+
+    // Click a button that only bumps an unrelated reactive value (which
+    // changes ToolbarSearch's `tabindex` prop). This should NOT trigger a
+    // refilter; the search value, rows, and shouldFilterRows are unchanged.
+    await user.click(screen.getByRole("button", { name: "Bump unrelated" }));
+    expect(component.filterRowsCount).toBe(baseline);
+
+    await user.click(screen.getByRole("button", { name: "Bump unrelated" }));
+    expect(component.filterRowsCount).toBe(baseline);
+  });
+});


### PR DESCRIPTION
Replace `afterUpdate` with a reactive statement so `filterRows` only runs when `value`, `rows`, or `shouldFilterRows` change. The prior hook fired on every tick, wasting work and breaking `===` checks on `filteredRowIds`. The subscriber's `rowsEqual` guard prevents loops.