### PR TITLE
fix(toolbar-search): skip expanded toggle when persistent

### DIFF
--- a/src/DataTable/ToolbarSearch.svelte
+++ b/src/DataTable/ToolbarSearch.svelte
@@ -89,7 +89,7 @@
     ref.focus();
   }
 
-  $: expanded = String(value ?? "").length > 0;
+  $: if (!persistent) expanded = String(value ?? "").length > 0;
   $: classes = [
     expanded && "bx--toolbar-search-container-active",
     persistent

--- a/tests/DataTable/DataTableSearch.test.ts
+++ b/tests/DataTable/DataTableSearch.test.ts
@@ -101,6 +101,26 @@ describe("DataTableSearch", () => {
     allRowsRendered();
   });
 
+  it("persistent search bar does not toggle the active class when typing", async () => {
+    render(DataTableSearch, {
+      props: {
+        persistent: true,
+      } satisfies ComponentProps<DataTableSearch>,
+    });
+
+    const searchBar = screen.getByRole("search");
+    expect(searchBar).toHaveClass("bx--toolbar-search-container-persistent");
+    expect(searchBar).not.toHaveClass("bx--toolbar-search-container-active");
+
+    const searchInput = screen.getByRole("searchbox");
+    await user.type(searchInput, "dns");
+
+    // Persistent search should remain persistent only; the "active" class
+    // (meant for expandable mode) should not coexist with "persistent".
+    expect(searchBar).toHaveClass("bx--toolbar-search-container-persistent");
+    expect(searchBar).not.toHaveClass("bx--toolbar-search-container-active");
+  });
+
   it("renders with initial search value in non-persistent search input", async () => {
     render(DataTableSearch, {
       props: {


### PR DESCRIPTION
The reactive `$: expanded = !!value.length` ran regardless of `persistent`, so typing added the expandable-mode `-active` class alongside `-persistent`. Gate the write on `!persistent`.