### PR TITLE
feat(toolbar): add `ariaLabel` prop

### DIFF
--- a/src/DataTable/Toolbar.svelte
+++ b/src/DataTable/Toolbar.svelte
@@ -5,6 +5,11 @@
    */
   export let size = "default";
 
+  /**
+   * Specify the ARIA label for the toolbar.
+   */
+  export let ariaLabel = "data table toolbar";
+
   import { setContext } from "svelte";
   import { writable } from "svelte/store";
 
@@ -37,7 +42,7 @@
 
 <section
   bind:this={ref}
-  aria-label="data table toolbar"
+  aria-label={ariaLabel}
   class:bx--table-toolbar={true}
   class:bx--table-toolbar--small={size === "sm"}
   class:bx--table-toolbar--normal={size === "default"}

--- a/tests/DataTable/Toolbar.test.svelte
+++ b/tests/DataTable/Toolbar.test.svelte
@@ -11,6 +11,7 @@
     | "ToolbarContent"
     | "ToolbarBatchActions" = "Toolbar";
   export let size: ComponentProps<Toolbar>["size"] = "default";
+  export let ariaLabel: ComponentProps<Toolbar>["ariaLabel"] = undefined;
   export let slotContent = "";
   export let selectedIds: ComponentProps<ToolbarBatchActions>["selectedIds"] =
     [];
@@ -19,7 +20,7 @@
 </script>
 
 {#if testComponent === "Toolbar"}
-  <Toolbar {size} {...$$restProps}>
+  <Toolbar {size} {ariaLabel} {...$$restProps}>
     {#if slotContent}
       {slotContent}
     {/if}

--- a/tests/DataTable/Toolbar.test.ts
+++ b/tests/DataTable/Toolbar.test.ts
@@ -56,6 +56,15 @@ describe("DataTable Toolbar", () => {
       expect(screen.getByText("Custom toolbar content")).toBeInTheDocument();
     });
 
+    it("should support a custom aria-label", () => {
+      const { container } = render(Toolbar, {
+        props: { testComponent: "Toolbar", ariaLabel: "Users table toolbar" },
+      });
+
+      const toolbar = container.querySelector(".bx--table-toolbar");
+      expect(toolbar).toHaveAttribute("aria-label", "Users table toolbar");
+    });
+
     it("should apply custom attributes", () => {
       const { container } = render(Toolbar, {
         props: {


### PR DESCRIPTION
Currently, the ARIA label is hardcoded. Allow it to be customizable.