### PR TITLE
fix(ui-shell): `HeaderNav` does not forward `aria-label` to menu bar

### DIFF
--- a/src/UIShell/HeaderNav.svelte
+++ b/src/UIShell/HeaderNav.svelte
@@ -1,13 +1,6 @@
-<script>
-  $: props = {
-    "aria-label": $$props["aria-label"],
-    "aria-labelledby": $$props["aria-labelledby"],
-  };
-</script>
-
-<nav {...props} class:bx--header__nav={true} {...$$restProps}>
+<nav class:bx--header__nav={true} {...$$restProps}>
   <!-- svelte-ignore a11y-no-noninteractive-element-to-interactive-role -->
-  <ul {...props} role="menubar" class:bx--header__menu-bar={true}>
+  <ul role="menubar" class:bx--header__menu-bar={true}>
     <slot />
   </ul>
 </nav>

--- a/tests/UIShell/UIShell.test.ts
+++ b/tests/UIShell/UIShell.test.ts
@@ -253,6 +253,20 @@ describe("UIShell", () => {
       const nav = screen.getByRole("navigation");
       expect(nav).toHaveClass("custom-nav");
     });
+
+    // Regression: aria-label belongs on the <nav> landmark only, not on the
+    // inner <ul role="menubar"> (avoids screen readers announcing the label
+    // twice).
+    it("should not duplicate aria-label onto the menubar", () => {
+      render(UiShell);
+
+      const nav = screen.getByRole("navigation", { name: "Navigation" });
+      expect(nav).toHaveAttribute("aria-label", "Navigation");
+
+      const menubar = screen.getByRole("menubar");
+      expect(menubar).not.toHaveAttribute("aria-label");
+      expect(menubar).not.toHaveAttribute("aria-labelledby");
+    });
   });
 
   describe("SideNav", () => {


### PR DESCRIPTION
The `<nav>` is a landmark and the `<ul role="menubar">` is a separate widget container. Screen readers announce each in turn, both with the same label.

This forwards `aria-label`/`aria-labelledby` on the `<ul role="menubar">` (the actual menubar widget needs the name) and leave the `<nav>` to inherit its name from page context.