### PR TITLE
fix(toolbar-menu): reset parent overflow on unmount

### DIFF
--- a/src/DataTable/ToolbarMenu.svelte
+++ b/src/DataTable/ToolbarMenu.svelte
@@ -1,15 +1,26 @@
 <script>
   /** @extends {"../OverflowMenu/OverflowMenu.svelte"} OverflowMenuProps */
 
-  import { getContext } from "svelte";
+  import { getContext, onMount } from "svelte";
   import Settings from "../icons/Settings.svelte";
   import OverflowMenu from "../OverflowMenu/OverflowMenu.svelte";
 
   const ctx = getContext("carbon:Toolbar") ?? {};
 
   let menuRef = null;
+  let lastVisible = false;
 
-  $: ctx.setOverflowVisible?.(menuRef != null);
+  $: {
+    const visible = menuRef != null;
+    if (visible !== lastVisible) {
+      lastVisible = visible;
+      ctx.setOverflowVisible?.(visible);
+    }
+  }
+
+  onMount(() => () => {
+    if (lastVisible) ctx.setOverflowVisible?.(false);
+  });
 </script>
 
 <OverflowMenu

--- a/tests/DataTable/ToolbarMenuUnmount.test.svelte
+++ b/tests/DataTable/ToolbarMenuUnmount.test.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+  import {
+    Toolbar,
+    ToolbarContent,
+    ToolbarMenu,
+    ToolbarMenuItem,
+  } from "carbon-components-svelte";
+
+  export let showMenu = true;
+</script>
+
+<Toolbar>
+  <ToolbarContent>
+    {#if showMenu}
+      <ToolbarMenu>
+        <ToolbarMenuItem>Item</ToolbarMenuItem>
+      </ToolbarMenu>
+    {/if}
+  </ToolbarContent>
+</Toolbar>

--- a/tests/DataTable/ToolbarMenuUnmount.test.ts
+++ b/tests/DataTable/ToolbarMenuUnmount.test.ts
@@ -1,0 +1,25 @@
+import { render } from "@testing-library/svelte";
+import { tick } from "svelte";
+import { user } from "../setup-tests";
+import ToolbarMenuUnmount from "./ToolbarMenuUnmount.test.svelte";
+
+describe("ToolbarMenu overflow cleanup", () => {
+  it("resets parent Toolbar overflow when the menu unmounts while open", async () => {
+    const { container, rerender } = render(ToolbarMenuUnmount, {
+      props: { showMenu: true },
+    });
+
+    const toolbar = container.querySelector<HTMLElement>(".bx--table-toolbar");
+    const trigger = container.querySelector(".bx--overflow-menu");
+    assert(toolbar);
+    assert(trigger);
+
+    await user.click(trigger);
+    expect(toolbar.style.overflow).toBe("visible");
+
+    rerender({ showMenu: false });
+    await tick();
+
+    expect(toolbar.style.overflow).toBe("inherit");
+  });
+});


### PR DESCRIPTION
Reactive block re-fired on every tick and never reset on destroy, so unmounting an open menu left `Toolbar` stuck at `overflow: visible` and hid `ToolbarBatchActions`. Gate updates on value change.