### PR TITLE
feat(structured-list-skeleton): add `columns` prop

### DIFF
--- a/docs/src/pages/components/StructuredList.svx
+++ b/docs/src/pages/components/StructuredList.svx
@@ -163,4 +163,12 @@ Enable row selection with the `selection` prop and structured list input compone
 
 Show a loading state with the skeleton variant.
 
-<StructuredListSkeleton rows={3} />
+By default, the skeleton renders 3 columns and 5 rows.
+
+<StructuredListSkeleton />
+
+## Skeleton with custom columns and rows
+
+Use `columns` and `rows` to customize the values.
+
+<StructuredListSkeleton columns={5} rows={3} />

--- a/src/StructuredList/StructuredListSkeleton.svelte
+++ b/src/StructuredList/StructuredListSkeleton.svelte
@@ -1,6 +1,11 @@
 <script>
   /** Specify the number of rows */
   export let rows = 5;
+
+  /** Specify the number of columns */
+  export let columns = 3;
+
+  $: cols = Array.from({ length: columns }, (_, i) => i);
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
@@ -19,17 +24,17 @@
       class:bx--structured-list-row={true}
       class:bx--structured-list-row--header-row={true}
     >
-      <div class:bx--structured-list-th={true}><span></span></div>
-      <div class:bx--structured-list-th={true}><span></span></div>
-      <div class:bx--structured-list-th={true}><span></span></div>
+      {#each cols as col (col)}
+        <div class:bx--structured-list-th={true}><span></span></div>
+      {/each}
     </div>
   </div>
   <div class:bx--structured-list-tbody={true}>
     {#each Array.from({ length: rows }, (_, i) => i) as row, i (row)}
       <div class:bx--structured-list-row={true}>
-        <div class:bx--structured-list-td={true}></div>
-        <div class:bx--structured-list-td={true}></div>
-        <div class:bx--structured-list-td={true}></div>
+        {#each cols as col (col)}
+          <div class:bx--structured-list-td={true}></div>
+        {/each}
       </div>
     {/each}
   </div>

--- a/tests/StructuredList/StructuredListSkeleton.test.svelte
+++ b/tests/StructuredList/StructuredListSkeleton.test.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+  import { StructuredListSkeleton } from "carbon-components-svelte";
+</script>
+
+<StructuredListSkeleton {...$$props} />

--- a/tests/StructuredList/StructuredListSkeleton.test.ts
+++ b/tests/StructuredList/StructuredListSkeleton.test.ts
@@ -1,0 +1,29 @@
+import { render } from "@testing-library/svelte";
+import StructuredListSkeleton from "./StructuredListSkeleton.test.svelte";
+
+describe("StructuredListSkeleton", () => {
+  it("renders 3 columns by default", () => {
+    const { container } = render(StructuredListSkeleton);
+
+    expect(container.querySelectorAll(".bx--structured-list-th")).toHaveLength(
+      3,
+    );
+    // 5 default rows x 3 columns
+    expect(container.querySelectorAll(".bx--structured-list-td")).toHaveLength(
+      15,
+    );
+  });
+
+  it("respects the columns prop in both head and body rows", () => {
+    const { container } = render(StructuredListSkeleton, {
+      props: { columns: 6, rows: 4 },
+    });
+
+    expect(container.querySelectorAll(".bx--structured-list-th")).toHaveLength(
+      6,
+    );
+    expect(container.querySelectorAll(".bx--structured-list-td")).toHaveLength(
+      24,
+    );
+  });
+});


### PR DESCRIPTION
Allow the `columns` count in `StructuredListSkeleton` to be customizable. Default is 3.

---

<img width="822" height="379" alt="Screenshot 2026-05-17 at 10 08 57 AM" src="https://github.com/user-attachments/assets/7210a20d-a4f7-466e-8448-6864236a544d" />
