### PR TITLE
feat(toolbar-search): add `clear` accessor

### DIFF
--- a/docs/src/pages/components/Toolbar.svx
+++ b/docs/src/pages/components/Toolbar.svx
@@ -56,6 +56,12 @@ Bind to the `value` prop for reactive updates.
 
 <FileSource src="/framed/Toolbar/ToolbarSearchReactive" />
 
+## Programmatically clear the search
+
+Use `bind:this` to obtain a reference to `ToolbarSearch` and call `clear()` to reset the value.
+
+<FileSource src="/framed/Toolbar/ToolbarSearchClear" />
+
 ## With menu
 
 Add an overflow menu using toolbar menu and toolbar menu item.

--- a/docs/src/pages/framed/Toolbar/ToolbarSearchClear.svelte
+++ b/docs/src/pages/framed/Toolbar/ToolbarSearchClear.svelte
@@ -1,0 +1,37 @@
+<script>
+  import {
+    Button,
+    Stack,
+    Toolbar,
+    ToolbarContent,
+    ToolbarSearch,
+  } from "carbon-components-svelte";
+
+  let toolbarSearch;
+  let value = "";
+</script>
+
+<Stack gap={6}>
+  <Toolbar>
+    <ToolbarContent>
+      <ToolbarSearch
+        bind:this={toolbarSearch}
+        bind:value
+        persistent
+        placeholder="Search..."
+      />
+      <Button
+        kind="ghost"
+        size="small"
+        disabled={value.length === 0}
+        on:click={() => toolbarSearch.clear()}
+      >
+        Clear search
+      </Button>
+    </ToolbarContent>
+  </Toolbar>
+  <div>
+    <strong>Search value:</strong>
+    {value}
+  </div>
+</Stack>

--- a/src/DataTable/ToolbarSearch.svelte
+++ b/src/DataTable/ToolbarSearch.svelte
@@ -89,6 +89,21 @@
     ref.focus();
   }
 
+  /**
+   * Programmatically clear the search input.
+   * Resets `value` and collapses the search bar (unless `persistent`).
+   * @type {() => void}
+   * @example
+   * ```svelte
+   * <ToolbarSearch bind:this={search} />
+   * <Button on:click={() => search.clear()}>Clear search</Button>
+   * ```
+   */
+  export function clear() {
+    value = "";
+    if (!persistent) expanded = false;
+  }
+
   $: if (!persistent) expanded = String(value ?? "").length > 0;
   $: classes = [
     expanded && "bx--toolbar-search-container-active",
@@ -109,7 +124,7 @@
   bind:ref
   bind:value
   on:clear
-  on:clear={expandSearch}
+  on:clear={clear}
   on:change
   on:input
   on:focus

--- a/tests/DataTable/ToolbarSearchClear.test.svelte
+++ b/tests/DataTable/ToolbarSearchClear.test.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+  import {
+    DataTable,
+    Toolbar,
+    ToolbarContent,
+    ToolbarSearch,
+  } from "carbon-components-svelte";
+  import type { DataTableHeader } from "carbon-components-svelte/DataTable/DataTable.svelte";
+
+  export let persistent = false;
+
+  let search: ToolbarSearch;
+  let value = "";
+
+  type Row = { id: string; name: string };
+
+  const rows: Row[] = [
+    { id: "a", name: "Alpha" },
+    { id: "b", name: "Bravo" },
+  ];
+
+  const headers: ReadonlyArray<DataTableHeader<Row>> = [
+    { key: "name", value: "Name" },
+  ];
+</script>
+
+<DataTable {headers} {rows}>
+  <Toolbar>
+    <ToolbarContent>
+      <ToolbarSearch bind:this={search} bind:value {persistent} />
+    </ToolbarContent>
+  </Toolbar>
+</DataTable>
+
+<div data-testid="value">{value}</div>
+<button type="button" data-testid="clear" on:click={() => search.clear()}>
+  Clear
+</button>

--- a/tests/DataTable/ToolbarSearchClear.test.ts
+++ b/tests/DataTable/ToolbarSearchClear.test.ts
@@ -1,0 +1,50 @@
+import { render, screen, waitFor } from "@testing-library/svelte";
+import { user } from "../setup-tests";
+import ToolbarSearchClear from "./ToolbarSearchClear.test.svelte";
+
+describe("ToolbarSearch clear()", () => {
+  it("resets value and collapses the search", async () => {
+    render(ToolbarSearchClear);
+
+    const input = screen.getByRole("searchbox") as HTMLInputElement;
+    await user.type(input, "Alpha");
+
+    await waitFor(() => {
+      expect(screen.getByTestId("value").textContent).toBe("Alpha");
+    });
+
+    const container = input.closest(".bx--toolbar-search-container-expandable");
+    expect(
+      container?.classList.contains("bx--toolbar-search-container-active"),
+    ).toBe(true);
+
+    await user.click(screen.getByTestId("clear"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("value").textContent).toBe("");
+    });
+    expect(
+      container?.classList.contains("bx--toolbar-search-container-active"),
+    ).toBe(false);
+  });
+
+  it("keeps the search expanded when persistent", async () => {
+    render(ToolbarSearchClear, { props: { persistent: true } });
+
+    const input = screen.getByRole("searchbox") as HTMLInputElement;
+    await user.type(input, "Bravo");
+
+    await waitFor(() => {
+      expect(screen.getByTestId("value").textContent).toBe("Bravo");
+    });
+
+    await user.click(screen.getByTestId("clear"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("value").textContent).toBe("");
+    });
+
+    const container = input.closest(".bx--toolbar-search-container-persistent");
+    expect(container).not.toBeNull();
+  });
+});


### PR DESCRIPTION
Add a `clear` accessor to allow programmatically clearing the toolbar search bar.