### PR TITLE
fix(structured-list): prevent dispatching initial "change" event

### DIFF
--- a/src/StructuredList/StructuredList.svelte
+++ b/src/StructuredList/StructuredList.svelte
@@ -19,7 +19,7 @@
   /** Set to `true` to use the selection variant */
   export let selection = false;
 
-  import { createEventDispatcher, setContext } from "svelte";
+  import { createEventDispatcher, onMount, setContext } from "svelte";
   import { writable } from "svelte/store";
 
   const dispatch = createEventDispatcher();
@@ -28,7 +28,7 @@
    */
   const selectedValue = writable(selected);
 
-  let prevSelectedValue = undefined;
+  let prevSelectedValue = selected;
   let isInitialRender = true;
 
   /**
@@ -43,13 +43,16 @@
     update,
   });
 
+  onMount(() => {
+    isInitialRender = false;
+  });
+
   $: selected = $selectedValue;
   $: {
     if (!isInitialRender && prevSelectedValue !== $selectedValue) {
       dispatch("change", $selectedValue);
     }
     prevSelectedValue = $selectedValue;
-    isInitialRender = false;
   }
 </script>
 

--- a/tests/StructuredList/StructuredList.test.ts
+++ b/tests/StructuredList/StructuredList.test.ts
@@ -3,6 +3,7 @@ import type StructuredListComponent from "carbon-components-svelte/StructuredLis
 import type { ComponentEvents, ComponentProps } from "svelte";
 import { user } from "../setup-tests";
 import StructuredList from "./StructuredList.test.svelte";
+import StructuredListChecked from "./StructuredListChecked.test.svelte";
 import StructuredListCustom from "./StructuredListCustom.test.svelte";
 
 describe("StructuredList", () => {
@@ -129,6 +130,13 @@ describe("StructuredList", () => {
 
     await user.click(screen.getAllByRole("radio")[0]);
     expect(consoleLog).toHaveBeenCalledWith("change", "row-1-value");
+  });
+
+  it("should not emit change event on initial render when a child has checked={true}", () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(StructuredListChecked);
+
+    expect(consoleLog).not.toHaveBeenCalledWith("change", expect.anything());
   });
 });
 

--- a/tests/StructuredList/StructuredListChecked.test.svelte
+++ b/tests/StructuredList/StructuredListChecked.test.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+  import {
+    StructuredList,
+    StructuredListBody,
+    StructuredListCell,
+    StructuredListHead,
+    StructuredListInput,
+    StructuredListRow,
+  } from "carbon-components-svelte";
+  import type { ComponentProps } from "svelte";
+
+  export let selected: ComponentProps<StructuredList>["selected"] = undefined;
+</script>
+
+<StructuredList
+  selection
+  bind:selected
+  on:change={(e) => {
+    console.log("change", e.detail);
+  }}
+>
+  <StructuredListHead>
+    <StructuredListRow head>
+      <StructuredListCell head>Column A</StructuredListCell>
+    </StructuredListRow>
+  </StructuredListHead>
+  <StructuredListBody>
+    <StructuredListRow label for="row-1">
+      <StructuredListCell>Row 1</StructuredListCell>
+      <StructuredListInput id="row-1" value="row-1-value" name="row-name" />
+    </StructuredListRow>
+    <StructuredListRow label for="row-2">
+      <StructuredListCell>Row 2</StructuredListCell>
+      <StructuredListInput
+        id="row-2"
+        value="row-2-value"
+        name="row-name"
+        checked
+      />
+    </StructuredListRow>
+  </StructuredListBody>
+</StructuredList>


### PR DESCRIPTION
The change event should not be dispatched on initial component render. Not a Svelte 5-specific issue. Also impacts Svelte 3/4.

Repro:

```svelte
<script>
  import {
    StructuredList,
    StructuredListBody,
    StructuredListCell,
    StructuredListHead,
    StructuredListInput,
    StructuredListRow,
  } from "carbon-components-svelte";

  export let selected = undefined;
</script>

<StructuredList
  selection
  bind:selected
  on:change={(e) => {
    console.log("change", e.detail);
  }}
>
  <StructuredListHead>
    <StructuredListRow head>
      <StructuredListCell head>Column A</StructuredListCell>
    </StructuredListRow>
  </StructuredListHead>
  <StructuredListBody>
    <StructuredListRow label for="row-1">
      <StructuredListCell>Row 1</StructuredListCell>
      <StructuredListInput
        id="row-1"
        value="row-1-value"
        name="row-name"
      />
    </StructuredListRow>
    <StructuredListRow label for="row-2">
      <StructuredListCell>Row 2</StructuredListCell>
      <StructuredListInput
        id="row-2"
        value="row-2-value"
        name="row-name"
        checked
      />
    </StructuredListRow>
  </StructuredListBody>
</StructuredList>
```