### PR TITLE
fix(structured-list-input): do not throw if rendered outside context

### DIFF
--- a/src/StructuredList/StructuredListInput.svelte
+++ b/src/StructuredList/StructuredListInput.svelte
@@ -25,10 +25,15 @@
   export let ref = null;
 
   import { getContext } from "svelte";
+  import { writable } from "svelte/store";
 
-  const { selectedValue, update } = getContext("carbon:StructuredListWrapper");
+  const initialChecked = checked;
+  const ctx = getContext("carbon:StructuredListWrapper");
+  const selectedValue =
+    ctx?.selectedValue ?? writable(initialChecked ? value : undefined);
+  const update = ctx?.update ?? ((v) => selectedValue.set(v));
 
-  if (checked) {
+  if (initialChecked && ctx) {
     update(value);
   }
 

--- a/tests/StructuredList/StructuredList.test.ts
+++ b/tests/StructuredList/StructuredList.test.ts
@@ -5,6 +5,7 @@ import { user } from "../setup-tests";
 import StructuredList from "./StructuredList.test.svelte";
 import StructuredListChecked from "./StructuredListChecked.test.svelte";
 import StructuredListCustom from "./StructuredListCustom.test.svelte";
+import StructuredListInputStandalone from "./StructuredListInputStandalone.test.svelte";
 
 describe("StructuredList", () => {
   it("should render with default props", () => {
@@ -117,6 +118,10 @@ describe("StructuredList", () => {
     for (const cell of noWrapCells) {
       expect(cell).toHaveClass("bx--structured-list-td");
     }
+  });
+
+  it("should not throw when rendered outside a StructuredList", () => {
+    expect(() => render(StructuredListInputStandalone)).not.toThrow();
   });
 
   it("should emit change event on selection", async () => {

--- a/tests/StructuredList/StructuredListInputStandalone.test.svelte
+++ b/tests/StructuredList/StructuredListInputStandalone.test.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+  import { StructuredListInput } from "carbon-components-svelte";
+</script>
+
+<StructuredListInput id="standalone" value="standalone-value" name="solo" />


### PR DESCRIPTION
`StructuredListInput` is not intended to be used without `StructuredList`, but this adds a defensive guard to avoid runtime errors.