### PR TITLE
feat(file-uploader-button): add `preventDuplicate` prop

### DIFF
--- a/docs/src/pages/components/DatePicker.svx
+++ b/docs/src/pages/components/DatePicker.svx
@@ -56,7 +56,7 @@ Use the `dateFormat` prop to customize the date format (default: `"m/d/Y"`). The
 
 ## Custom locale
 
-The `locale` prop accepts either a [flatpickr locale key](https://github.com/flatpickr/flatpickr/tree/master/src/l10n) or a [`CustomLocale`](https://github.com/flatpickr/flatpickr/blob/master/src/types/locale.ts) object. It defaults to `"en"`, which renders Carbon-spec single-letter weekday abbreviations (`S, M, T, W, Th, F, S`).
+The `locale` prop accepts either a [flatpickr locale key](https://github.com/flatpickr/flatpickr/tree/master/src/l10n) or a [CustomLocale](https://github.com/flatpickr/flatpickr/blob/master/src/types/locale.ts) object. It defaults to `"en"`, which renders Carbon-spec single-letter weekday abbreviations (`S, M, T, W, Th, F, S`).
 
 To customize the weekday labels (e.g., to restore flatpickr's default English `Sun, Mon, Tue, ...` shorthands), pass a `CustomLocale` object.
 
@@ -82,7 +82,7 @@ When the date picker is inside a native `<dialog>` opened with `showModal()`, `p
 
 ## Inside a native popover
 
-When the date picker is inside an open element with a [`popover`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/popover) attribute (see the [Popover API](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API)), `portalMenu` mounts the calendar into that ancestor so it stays in the popover top layer.
+When the date picker is inside an open element with a [popover](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/popover) attribute (see the [Popover API](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API)), `portalMenu` mounts the calendar into that ancestor so it stays in the popover top layer.
 
 <FileSource src="/framed/DatePicker/DatePickerPopover" />
 

--- a/docs/src/pages/components/FileUploader.svx
+++ b/docs/src/pages/components/FileUploader.svx
@@ -26,6 +26,15 @@ allows users to select multiple files at once.
 
 <FileUploaderButton multiple labelText="Add files" />
 
+## Prevent duplicate files
+
+Set `preventDuplicate` to `true` to skip re-selected files that match an
+already-selected file (by name, size, and lastModified). Only applies when
+`multiple` is `true`. For richer behavior with rejection events, use
+[`FileUploader`](#duplicate-detection) instead.
+
+<FileUploaderButton multiple preventDuplicate labelText="Add files" />
+
 ## Custom button kind, size
 
 Customize the button appearance using the `kind` and `size` props. The default is

--- a/docs/src/pages/components/FileUploader.svx
+++ b/docs/src/pages/components/FileUploader.svx
@@ -31,7 +31,7 @@ allows users to select multiple files at once.
 Set `preventDuplicate` to `true` to skip re-selected files that match an
 already-selected file (by name, size, and lastModified). Only applies when
 `multiple` is `true`. For richer behavior with rejection events, use
-[`FileUploader`](#duplicate-detection) instead.
+[FileUploader](#duplicate-detection) instead.
 
 <FileUploaderButton multiple preventDuplicate labelText="Add files" />
 

--- a/docs/src/pages/components/FloatingPortal.svx
+++ b/docs/src/pages/components/FloatingPortal.svx
@@ -84,6 +84,6 @@ Components inside the `dialog` must still enable `portalMenu` for its menu or co
 
 ## Inside a native popover
 
-When the anchor is inside an element with a [`popover`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/popover) attribute (see the [Popover API](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API)), the same default `target` applies: floating content mounts into that popover element so it participates in the popover top layer.
+When the anchor is inside an element with a [popover](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/popover) attribute (see the [Popover API](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API)), the same default `target` applies: floating content mounts into that popover element so it participates in the popover top layer.
 
 <FileSource src="/framed/FloatingPortal/FloatingPortalPopover" />

--- a/src/FileUploader/FileUploaderButton.svelte
+++ b/src/FileUploader/FileUploaderButton.svelte
@@ -20,6 +20,14 @@
   /** Set to `true` to allow multiple files */
   export let multiple = false;
 
+  /**
+   * Set to `true` to skip files that match an already-selected file
+   * (by name, size, and lastModified). Only applies when `multiple` is `true`.
+   * For richer behavior (rejection reporting via the `rejected` event),
+   * see `FileUploader`'s `preventDuplicate` prop.
+   */
+  export let preventDuplicate = false;
+
   /** Set to `true` to disable the input */
   export let disabled = false;
 
@@ -192,7 +200,20 @@
   class:bx--visually-hidden={true}
   {...$$restProps}
   on:change|stopPropagation={({ target }) => {
-    files = multiple ? [...files, ...target.files] : [...target.files];
+    if (multiple) {
+      let incoming = [...target.files];
+      if (preventDuplicate) {
+        const existingKeys = new Set(
+          files.map((f) => `${f.name}\0${f.size}\0${f.lastModified}`),
+        );
+        incoming = incoming.filter(
+          (f) => !existingKeys.has(`${f.name}\0${f.size}\0${f.lastModified}`),
+        );
+      }
+      files = [...files, ...incoming];
+    } else {
+      files = [...target.files];
+    }
 
     if (files && files.length > 0 && !disableLabelChanges) {
       labelText = files.length > 1 ? `${files.length} files` : files[0].name;

--- a/tests/FileUploader/FileUploaderButton.test.ts
+++ b/tests/FileUploader/FileUploaderButton.test.ts
@@ -187,6 +187,74 @@ describe("FileUploaderButton", () => {
     expect(event.detail[0].name).toBe("test.txt");
   });
 
+  it("should dedupe re-selected files when preventDuplicate and multiple are true", async () => {
+    const changeHandler = vi.fn();
+    const { container } = render(FileUploaderButton, {
+      props: {
+        multiple: true,
+        preventDuplicate: true,
+        onchange: changeHandler,
+      },
+    });
+
+    const input = container.querySelector('input[type="file"]');
+    assert(input instanceof HTMLInputElement);
+
+    const lastModified = 1700000000000;
+    const fileA = new File(["a"], "a.txt", {
+      type: "text/plain",
+      lastModified,
+    });
+    simulateFileSelection(input, [fileA]);
+
+    await vi.waitFor(() => {
+      expect(changeHandler).toHaveBeenCalledTimes(1);
+    });
+    expect(changeHandler.mock.calls[0][0].detail).toHaveLength(1);
+
+    const fileADup = new File(["a"], "a.txt", {
+      type: "text/plain",
+      lastModified,
+    });
+    const fileB = new File(["b"], "b.txt", { type: "text/plain" });
+    simulateFileSelection(input, [fileADup, fileB]);
+
+    await vi.waitFor(() => {
+      expect(changeHandler).toHaveBeenCalledTimes(2);
+    });
+    const second = changeHandler.mock.calls[1][0].detail;
+    expect(second).toHaveLength(2);
+    expect(second.map((f: File) => f.name)).toEqual(["a.txt", "b.txt"]);
+  });
+
+  it("should concatenate duplicates when preventDuplicate is false (default)", async () => {
+    const changeHandler = vi.fn();
+    const { container } = render(FileUploaderButton, {
+      props: { multiple: true, onchange: changeHandler },
+    });
+
+    const input = container.querySelector('input[type="file"]');
+    assert(input instanceof HTMLInputElement);
+
+    const lastModified = 1700000000000;
+    const fileA = new File(["a"], "a.txt", {
+      type: "text/plain",
+      lastModified,
+    });
+    simulateFileSelection(input, [fileA]);
+
+    const fileADup = new File(["a"], "a.txt", {
+      type: "text/plain",
+      lastModified,
+    });
+    simulateFileSelection(input, [fileADup]);
+
+    await vi.waitFor(() => {
+      expect(changeHandler).toHaveBeenCalledTimes(2);
+    });
+    expect(changeHandler.mock.calls[1][0].detail).toHaveLength(2);
+  });
+
   it("should handle different button kinds", () => {
     const { container: container1 } = render(FileUploaderButton, {
       props: { kind: "primary" },


### PR DESCRIPTION
Re-selecting the same file in `multiple` mode previously appended a duplicate `File` object. Mirrors `FileUploader`'s `preventDuplicate` so the standalone button can dedupe by `(name, size, lastModified)` implemented in #2774.