### PR TITLE
fix(number-input): set `aria-readonly` for readonly state

### DIFF
--- a/src/NumberInput/NumberInput.svelte
+++ b/src/NumberInput/NumberInput.svelte
@@ -489,6 +489,7 @@
           data-invalid={effectiveInvalid || undefined}
           aria-invalid={effectiveInvalid || undefined}
           aria-label={labelText ? undefined : ariaLabel}
+          aria-readonly={readonly || undefined}
           {disabled}
           {id}
           {name}
@@ -523,6 +524,7 @@
           data-invalid={effectiveInvalid || undefined}
           aria-invalid={effectiveInvalid || undefined}
           aria-label={labelText ? undefined : ariaLabel}
+          aria-readonly={readonly || undefined}
           {disabled}
           {id}
           {name}

--- a/tests/NumberInput/NumberInput.test.ts
+++ b/tests/NumberInput/NumberInput.test.ts
@@ -121,7 +121,9 @@ describe("NumberInput", () => {
   it("should handle readonly state", () => {
     render(NumberInput, { props: { readonly: true } });
 
-    expect(screen.getByRole("spinbutton")).toHaveAttribute("readonly");
+    const input = screen.getByRole("spinbutton");
+    expect(input).toHaveAttribute("readonly");
+    expect(input).toHaveAttribute("aria-readonly", "true");
   });
 
   it("should handle hidden steppers", () => {


### PR DESCRIPTION
Cherry-picks the fix for `NumberInput` from https://github.com/carbon-design-system/carbon-components-svelte/pull/2981