### PR TITLE
fix(contained-list): remove redundant `role="list"`

### DIFF
--- a/src/ContainedList/ContainedList.svelte
+++ b/src/ContainedList/ContainedList.svelte
@@ -61,7 +61,6 @@
     </div>
   {/if}
   <ul
-    role="list"
     aria-labelledby={labelText || $$slots.labelChildren ? labelId : undefined}
   >
     <slot />


### PR DESCRIPTION
Addresses a Svelte a11y warning: A11y: Redundant role 'list'