### PR TITLE
fix(slider): clamp keyboard value and dispatch `change` from handler

### DIFF
--- a/e2e/slider.test.ts
+++ b/e2e/slider.test.ts
@@ -43,4 +43,16 @@ test.describe("Slider", () => {
     // step=1, range=100, stepMultiplier=4 -> delta = 100/4 = 25
     await expect(page.getByTestId("value-display")).toHaveText("75");
   });
+
+  test("keyboard cannot move the value past max", async ({ page }) => {
+    const thumb = page.getByTestId("slider").locator('[role="slider"]');
+    await thumb.focus();
+    // Shift+ArrowRight adds 25 per press; from 50 three presses would land
+    // at 125 without clamping against max (100).
+    await page.keyboard.press("Shift+ArrowRight");
+    await page.keyboard.press("Shift+ArrowRight");
+    await page.keyboard.press("Shift+ArrowRight");
+    await expect(page.getByTestId("value-display")).toHaveText("100");
+    await expect(thumb).toHaveAttribute("aria-valuenow", "100");
+  });
 });

--- a/src/Slider/RangeSlider.svelte
+++ b/src/Slider/RangeSlider.svelte
@@ -170,9 +170,13 @@
 
   /** @type {() => void} */
   function stopHolding() {
+    const wasHolding = holding;
     holding = false;
     dragging = false;
     currentEvent = null;
+    if (wasHolding && !disabled && !readonly) {
+      dispatch("change", { value, valueUpper });
+    }
   }
 
   /** @type {(e: PointerLikeEvent) => void} */
@@ -237,6 +241,7 @@
       valueUpper = next;
     }
     dispatch("input", { value, valueUpper });
+    dispatch("change", { value, valueUpper });
   }
 
   $: labelId = `label-${id}`;
@@ -257,10 +262,6 @@
     if (dragging && currentEvent) {
       calcValue(currentEvent);
       dragging = false;
-    }
-
-    if (!holding && !disabled && !readonly) {
-      dispatch("change", { value, valueUpper });
     }
   }
 </script>
@@ -332,6 +333,7 @@
           if (next < min) next = min;
           if (next > valueUpper) next = valueUpper;
           value = next;
+          dispatch("change", { value, valueUpper });
         }}
         data-invalid={invalid || null}
         data-warn={(warn && !invalid) || null}
@@ -486,6 +488,7 @@
           if (next > max) next = max;
           if (next < value) next = value;
           valueUpper = next;
+          dispatch("change", { value, valueUpper });
         }}
         data-invalid={invalid || null}
         data-warn={(warn && !invalid) || null}

--- a/src/Slider/Slider.svelte
+++ b/src/Slider/Slider.svelte
@@ -111,9 +111,13 @@
   }
 
   function stopHolding() {
+    const wasHolding = holding;
     holding = false;
     dragging = false;
     currentEvent = null;
+    if (wasHolding && !disabled && !readonly) {
+      dispatch("change", value);
+    }
   }
 
   function move(event) {
@@ -161,10 +165,6 @@
     if (dragging && currentEvent) {
       calcValue(currentEvent);
       dragging = false;
-    }
-
-    if (!holding && !disabled && !readonly) {
-      dispatch("change", value);
     }
   }
 </script>
@@ -242,8 +242,12 @@
               step *
               (event.shiftKey ? range / step / stepMultiplier : 1) *
               keys[event.key];
-            value = Math.round((value + delta) / step) * step;
+            let next = Math.round((value + delta) / step) * step;
+            if (next < min) next = min;
+            else if (next > max) next = max;
+            value = next;
             dispatch("input", value);
+            dispatch("change", value);
           }
         }}
       ></div>
@@ -282,7 +286,11 @@
         {step}
         on:change={(event) => {
           if (!readonly) {
-            value = Number(event.target.value);
+            let next = Number(event.target.value);
+            if (next < min) next = min;
+            else if (next > max) next = max;
+            value = next;
+            dispatch("change", value);
           }
         }}
         data-invalid={showInvalid || null}

--- a/tests/Slider/RangeSlider.test.ts
+++ b/tests/Slider/RangeSlider.test.ts
@@ -110,6 +110,47 @@ describe("RangeSlider", () => {
     });
   });
 
+  it("should clamp keyboard arrow values to min and max", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(RangeSlider, { props: { value: 0, valueUpper: 100 } });
+
+    const [lowerThumb, upperThumb] = screen.getAllByRole("slider");
+
+    upperThumb.focus();
+    await user.keyboard("{ArrowRight}");
+    expect(consoleLog).toHaveBeenCalledWith("input", {
+      value: 0,
+      valueUpper: 100,
+    });
+    expect(consoleLog).toHaveBeenCalledWith("change", {
+      value: 0,
+      valueUpper: 100,
+    });
+
+    vi.clearAllMocks();
+    lowerThumb.focus();
+    await user.keyboard("{Shift>}{ArrowLeft}{/Shift}");
+    expect(consoleLog).toHaveBeenCalledWith("input", {
+      value: 0,
+      valueUpper: 100,
+    });
+    expect(consoleLog).toHaveBeenCalledWith("change", {
+      value: 0,
+      valueUpper: 100,
+    });
+  });
+
+  it("should not dispatch change on programmatic value updates", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    const { rerender } = render(RangeSlider, {
+      props: { value: 10, valueUpper: 90 },
+    });
+
+    await rerender({ value: 20, valueUpper: 80 });
+
+    expect(consoleLog).not.toHaveBeenCalledWith("change", expect.anything());
+  });
+
   it("should apply name attributes to lower and upper inputs", () => {
     render(RangeSlider, {
       props: { name: "lower", nameUpper: "upper" },

--- a/tests/Slider/Slider.test.ts
+++ b/tests/Slider/Slider.test.ts
@@ -663,6 +663,33 @@ describe("Slider", () => {
     expect(consoleLog).toHaveBeenCalledWith("change", 0);
   });
 
+  it("should clamp keyboard arrow values to min and max", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(Slider, { props: { min: 0, max: 100, value: 100 } });
+
+    const slider = screen.getByRole("slider");
+    await user.tab();
+    expect(slider).toHaveFocus();
+
+    await user.keyboard("{ArrowRight}");
+    expect(consoleLog).toHaveBeenCalledWith("input", 100);
+    expect(consoleLog).toHaveBeenCalledWith("change", 100);
+
+    vi.clearAllMocks();
+    await user.keyboard("{Shift>}{ArrowRight}{/Shift}");
+    expect(consoleLog).toHaveBeenCalledWith("input", 100);
+    expect(consoleLog).toHaveBeenCalledWith("change", 100);
+  });
+
+  it("should not dispatch change on programmatic value updates", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    const { rerender } = render(Slider, { props: { value: 10 } });
+
+    await rerender({ value: 20 });
+
+    expect(consoleLog).not.toHaveBeenCalledWith("change", expect.anything());
+  });
+
   // Regression: ?? for aria-label so empty string is used (not fallback)
   it("uses empty aria-label when passed (nullish coalescing)", () => {
     render(Slider, {


### PR DESCRIPTION
Arrow/Shift+Arrow now clamps to `[min, max]` inline and emits both `input` and `change` directly. The reactive block's blanket `change` dispatch is removed; drag end and text input emit `change` explicitly.