### PR TITLE
chore: annotate reactive props with `@bindable`

### DIFF
--- a/src/Accordion/AccordionItem.svelte
+++ b/src/Accordion/AccordionItem.svelte
@@ -11,16 +11,25 @@
    */
   export let title = "title";
 
-  /** Set to `true` to open the first accordion item */
+  /**
+   * Set to `true` to open the first accordion item.
+   * @bindable writable
+   */
   export let open = false;
 
-  /** Set to `true` to disable the accordion item */
+  /**
+   * Set to `true` to disable the accordion item.
+   * @bindable writable
+   */
   export let disabled = false;
 
   /** Specify the ARIA label for the accordion item chevron icon */
   export let iconDescription = "Expand/Collapse";
 
-  /** Obtain a reference to the heading button HTML element */
+  /**
+   * Obtain a reference to the heading button HTML element.
+   * @bindable readonly
+   */
   export let ref = null;
 
   import { getContext, onMount } from "svelte";

--- a/src/Breakpoint/Breakpoint.svelte
+++ b/src/Breakpoint/Breakpoint.svelte
@@ -12,12 +12,14 @@
   /**
    * Determine the current Carbon grid breakpoint size.
    * @type {BreakpointSize}
+   * @bindable readonly
    */
   export let size = undefined;
 
   /**
    * Carbon grid sizes as an object.
    * @type {Record<BreakpointSize, boolean>}
+   * @bindable readonly
    */
   export let sizes = {
     sm: false,

--- a/src/Button/Button.svelte
+++ b/src/Button/Button.svelte
@@ -103,7 +103,10 @@
   /** Specify the `type` attribute for the button element */
   export let type = "button";
 
-  /** Obtain a reference to the HTML element */
+  /**
+   * Obtain a reference to the HTML element.
+   * @bindable readonly
+   */
   export let ref = null;
 
   import { getContext, onMount } from "svelte";

--- a/src/Checkbox/Checkbox.svelte
+++ b/src/Checkbox/Checkbox.svelte
@@ -11,16 +11,23 @@
    */
   export let value = /** @type {T} */ ("");
 
-  /** Specify whether the checkbox is checked */
+  /**
+   * Specify whether the checkbox is checked.
+   * @bindable writable
+   */
   export let checked = false;
 
   /**
    * Specify the bound group.
    * @type {ReadonlyArray<T> | undefined}
+   * @bindable writable
    */
   export let group = undefined;
 
-  /** Specify whether the checkbox is indeterminate */
+  /**
+   * Specify whether the checkbox is indeterminate.
+   * @bindable writable
+   */
   export let indeterminate = false;
 
   /** Set to `true` to display the skeleton state */
@@ -50,13 +57,17 @@
   /**
    * Specify the title attribute for the label element.
    * @type {string}
+   * @bindable readonly
    */
   export let title = undefined;
 
   /** Set an id for the input label */
   export let id = `ccs-${Math.random().toString(36)}`;
 
-  /** Obtain a reference to the input HTML element */
+  /**
+   * Obtain a reference to the input HTML element.
+   * @bindable readonly
+   */
   export let ref = null;
 
   import { createEventDispatcher, getContext } from "svelte";

--- a/src/Checkbox/CheckboxGroup.svelte
+++ b/src/Checkbox/CheckboxGroup.svelte
@@ -6,6 +6,7 @@
   /**
    * Set the selected checkbox values.
    * @type {ReadonlyArray<string | number>}
+   * @bindable writable
    */
   export let selected = [];
 

--- a/src/CodeSnippet/CodeSnippet.svelte
+++ b/src/CodeSnippet/CodeSnippet.svelte
@@ -39,7 +39,10 @@
     }
   };
 
-  /** Set to `true` to expand a multi-line code snippet (type="multi") */
+  /**
+   * Set to `true` to expand a multi-line code snippet (type="multi").
+   * @bindable writable
+   */
   export let expanded = false;
 
   /** Set to `true` to hide the copy button */
@@ -100,13 +103,17 @@
    * Set to `false` to hide the show more/less button.
    *
    * NOTE: this prop only works with the `type="multi"` variant.
+   * @bindable writable
    */
   export let showMoreLess = true;
 
   /** Set an id for the code element */
   export let id = `ccs-${Math.random().toString(36)}`;
 
-  /** Obtain a reference to the pre HTML element */
+  /**
+   * Obtain a reference to the pre HTML element.
+   * @bindable readonly
+   */
   export let ref = null;
 
   /**

--- a/src/ComboBox/ComboBox.svelte
+++ b/src/ComboBox/ComboBox.svelte
@@ -31,10 +31,14 @@
   /**
    * Set the selected item by value id.
    * @type {Item["id"]}
+   * @bindable writable
    */
   export let selectedId = undefined;
 
-  /** Specify the selected combobox value */
+  /**
+   * Specify the selected combobox value.
+   * @bindable writable
+   */
   export let value = "";
 
   /**
@@ -79,7 +83,10 @@
   /** Set to `true` to enable the light variant */
   export let light = false;
 
-  /** Set to `true` to open the combobox menu dropdown */
+  /**
+   * Set to `true` to open the combobox menu dropdown.
+   * @bindable writable
+   */
   export let open = false;
 
   /** Set to `true` to use the read-only variant */
@@ -156,12 +163,16 @@
    */
   export let name = undefined;
 
-  /** Obtain a reference to the input HTML element */
+  /**
+   * Obtain a reference to the input HTML element.
+   * @bindable readonly
+   */
   export let ref = null;
 
   /**
    * Obtain a reference to the list HTML element.
    * @type {null | HTMLDivElement}
+   * @bindable readonly
    */
   export let listRef = null;
 

--- a/src/ComposedModal/ComposedModal.svelte
+++ b/src/ComposedModal/ComposedModal.svelte
@@ -12,7 +12,10 @@
    */
   export let size = undefined;
 
-  /** Set to `true` to open the modal */
+  /**
+   * Set to `true` to open the modal.
+   * @bindable writable
+   */
   export let open = false;
 
   /** Set to `true` to use the danger variant */
@@ -30,7 +33,10 @@
    */
   export let selectorPrimaryFocus = "[data-modal-primary-focus]";
 
-  /** Obtain a reference to the top-level HTML element */
+  /**
+   * Obtain a reference to the top-level HTML element.
+   * @bindable readonly
+   */
   export let ref = null;
 
   import {

--- a/src/ContentSwitcher/ContentSwitcher.svelte
+++ b/src/ContentSwitcher/ContentSwitcher.svelte
@@ -3,7 +3,10 @@
    * @event {number} change
    */
 
-  /** Set the selected index of the switch item */
+  /**
+   * Set the selected index of the switch item.
+   * @bindable writable
+   */
   export let selectedIndex = 0;
 
   /**
@@ -22,6 +25,7 @@
   /**
    * Obtain a reference to the tablist HTML element.
    * @type {HTMLDivElement | null}
+   * @bindable readonly
    */
   export let ref = null;
 

--- a/src/ContentSwitcher/Switch.svelte
+++ b/src/ContentSwitcher/Switch.svelte
@@ -11,7 +11,10 @@
    */
   export let text = "Provide text";
 
-  /** Set to `true` for the switch to be selected */
+  /**
+   * Set to `true` for the switch to be selected.
+   * @bindable writable
+   */
   export let selected = false;
 
   /** Set to `true` to disable the switch */
@@ -20,7 +23,10 @@
   /** Set an id for the button element */
   export let id = `ccs-${Math.random().toString(36)}`;
 
-  /** Obtain a reference to the button HTML element */
+  /**
+   * Obtain a reference to the button HTML element.
+   * @bindable readonly
+   */
   export let ref = null;
 
   import { getContext, onMount } from "svelte";

--- a/src/ContextMenu/ContextMenu.svelte
+++ b/src/ContextMenu/ContextMenu.svelte
@@ -13,16 +13,26 @@
   /**
    * Set to `true` to open the menu.
    * Either `x` and `y` must be greater than zero.
+   * @bindable writable
    */
   export let open = false;
 
-  /** Specify the horizontal offset of the menu position */
+  /**
+   * Specify the horizontal offset of the menu position.
+   * @bindable writable
+   */
   export let x = 0;
 
-  /** Specify the vertical offset of the menu position */
+  /**
+   * Specify the vertical offset of the menu position.
+   * @bindable writable
+   */
   export let y = 0;
 
-  /** Obtain a reference to the unordered list HTML element */
+  /**
+   * Obtain a reference to the unordered list HTML element.
+   * @bindable readonly
+   */
   export let ref = null;
 
   /**

--- a/src/ContextMenu/ContextMenuGroup.svelte
+++ b/src/ContextMenu/ContextMenuGroup.svelte
@@ -1,5 +1,8 @@
 <script>
-  /** @type {ReadonlyArray<string>} */
+  /**
+   * @type {ReadonlyArray<string>}
+   * @bindable writable
+   */
   export let selectedIds = [];
 
   /** Specify the label text */

--- a/src/ContextMenu/ContextMenuOption.svelte
+++ b/src/ContextMenu/ContextMenuOption.svelte
@@ -16,13 +16,17 @@
   /** Set to `true` to enable the disabled state */
   export let disabled = false;
 
-  /** Set to `true` to indent the label */
+  /**
+   * Set to `true` to indent the label.
+   * @bindable writable
+   */
   export let indented = false;
 
   /**
    * Specify the icon to render.
    * Icon is rendered to the left of the label text.
    * @type {Icon}
+   * @bindable writable
    */
   export let icon = /** @type {Icon} */ (undefined);
 
@@ -38,12 +42,16 @@
    */
   export let labelText = "";
 
-  /** Set to `true` to use the selected variant */
+  /**
+   * Set to `true` to use the selected variant.
+   * @bindable writable
+   */
   export let selected = false;
 
   /**
    * Set to `true` to enable the selectable variant.
    * Automatically set to `true` if `selected` is `true`.
+   * @bindable writable
    */
   export let selectable = false;
 
@@ -65,7 +73,10 @@
    */
   export let id = `ccs-${Math.random().toString(36)}`;
 
-  /** Obtain a reference to the list item HTML element */
+  /**
+   * Obtain a reference to the list item HTML element.
+   * @bindable readonly
+   */
   export let ref = null;
 
   import { createEventDispatcher, getContext, onMount, tick } from "svelte";

--- a/src/ContextMenu/ContextMenuRadioGroup.svelte
+++ b/src/ContextMenu/ContextMenuRadioGroup.svelte
@@ -1,5 +1,8 @@
 <script>
-  /** Set the selected radio group id */
+  /**
+   * Set the selected radio group id.
+   * @bindable writable
+   */
   export let selectedId = "";
 
   /** Specify the label text */

--- a/src/DataTable/DataTable.svelte
+++ b/src/DataTable/DataTable.svelte
@@ -151,12 +151,14 @@
   /**
    * Specify the header key to sort by.
    * @type {DataTableKey<Row>}
+   * @bindable writable
    */
   export let sortKey = null;
 
   /**
    * Specify the sort direction.
    * @type {"none" | "ascending" | "descending"}
+   * @bindable writable
    */
   export let sortDirection = "none";
 
@@ -194,6 +196,7 @@
   /**
    * Set to `true` for the expandable variant.
    * Automatically set to `true` if `batchExpansion` is `true`.
+   * @bindable writable
    */
   export let expandable = false;
 
@@ -205,6 +208,7 @@
   /**
    * Specify the row ids to be expanded.
    * @type {ReadonlyArray<Row["id"]>}
+   * @bindable writable
    */
   export let expandedRowIds = [];
 
@@ -220,6 +224,7 @@
   /**
    * Set to `true` for the selectable variant.
    * Automatically set to `true` if `radio` or `batchSelection` are `true`.
+   * @bindable writable
    */
   export let selectable = false;
 
@@ -229,6 +234,7 @@
   /**
    * Specify the row ids to be selected.
    * @type {ReadonlyArray<Row["id"]>}
+   * @bindable writable
    */
   export let selectedRowIds = [];
 
@@ -271,6 +277,7 @@
   /**
    * Obtain a reference to the table wrapper element. When virtualization is enabled and `stickyHeader` is false, this element is the scroll container—use `bind:scrollContainerRef` to programmatically control scroll position (e.g. `scrollContainerRef.scrollTop = 0`).
    * @type {null | HTMLDivElement}
+   * @bindable readonly
    */
   export let scrollContainerRef = null;
 

--- a/src/DataTable/Table.svelte
+++ b/src/DataTable/Table.svelte
@@ -26,6 +26,7 @@
   /**
    * Obtain a reference to the section HTML element (when stickyHeader is enabled) or table HTML element.
    * @type {null | HTMLElement | HTMLTableElement}
+   * @bindable readonly
    */
   export let ref = null;
 </script>

--- a/src/DataTable/ToolbarSearch.svelte
+++ b/src/DataTable/ToolbarSearch.svelte
@@ -8,10 +8,14 @@
   /**
    * Specify the value of the search input.
    * @type {number | string}
+   * @bindable writable
    */
   export let value = "";
 
-  /** Set to `true` to expand the search bar */
+  /**
+   * Set to `true` to expand the search bar.
+   * @bindable writable
+   */
   export let expanded = false;
 
   /** Set to `true` to keep the search bar expanded */
@@ -35,6 +39,7 @@
   /**
    * The filtered row ids.
    * @type {ReadonlyArray<Row["id"]>}
+   * @bindable readonly
    */
   export let filteredRowIds = [];
 
@@ -47,6 +52,7 @@
   /**
    * Obtain a reference to the input HTML element.
    * @type {null | HTMLInputElement}
+   * @bindable readonly
    */
   export let ref = null;
 

--- a/src/DatePicker/DatePicker.svelte
+++ b/src/DatePicker/DatePicker.svelte
@@ -12,6 +12,7 @@
   /**
    * Specify the date picker input value.
    * @type {number | string}
+   * @bindable writable
    */
   export let value = "";
 
@@ -19,6 +20,7 @@
    * Specify the date picker start date value (from).
    * Only works with the "range" date picker type.
    * @type {string}
+   * @bindable writable
    */
   export let valueFrom = "";
 
@@ -26,6 +28,7 @@
    * Specify the date picker end date value (to).
    * Only works with the "range" date picker type.
    * @type {string}
+   * @bindable writable
    */
   export let valueTo = "";
 
@@ -83,6 +86,7 @@
    * Only available when `datePickerType` is `"single"` or `"range"`.
    * @see https://flatpickr.js.org/instance-methods-properties-elements/
    * @type {import("flatpickr/dist/types/instance").Instance | null}
+   * @bindable readonly
    */
   export let calendar = null;
 

--- a/src/DatePicker/DatePickerInput.svelte
+++ b/src/DatePicker/DatePickerInput.svelte
@@ -58,7 +58,10 @@
    */
   export let name = undefined;
 
-  /** Obtain a reference to the input HTML element */
+  /**
+   * Obtain a reference to the input HTML element.
+   * @bindable readonly
+   */
   export let ref = null;
 
   import { getContext } from "svelte";

--- a/src/Dropdown/Dropdown.svelte
+++ b/src/Dropdown/Dropdown.svelte
@@ -30,6 +30,7 @@
   /**
    * Specify the selected item id.
    * @type {Item["id"] | undefined}
+   * @bindable writable
    */
   export let selectedId = undefined;
 
@@ -51,7 +52,10 @@
    */
   export let size = undefined;
 
-  /** Set to `true` to open the dropdown */
+  /**
+   * Set to `true` to open the dropdown.
+   * @bindable writable
+   */
   export let open = false;
 
   /** Set to `true` to enable the light variant */
@@ -133,12 +137,16 @@
    */
   export let name = undefined;
 
-  /** Obtain a reference to the button HTML element */
+  /**
+   * Obtain a reference to the button HTML element.
+   * @bindable readonly
+   */
   export let ref = null;
 
   /**
    * Obtain a reference to the list HTML element.
    * @type {null | HTMLDivElement}
+   * @bindable readonly
    */
   export let listRef = null;
 

--- a/src/FileUploader/FileUploader.svelte
+++ b/src/FileUploader/FileUploader.svelte
@@ -38,6 +38,7 @@
   /**
    * Obtain a reference to the uploaded files.
    * @type {ReadonlyArray<File>}
+   * @bindable writable
    */
   export let files = [];
 

--- a/src/FileUploader/FileUploaderButton.svelte
+++ b/src/FileUploader/FileUploaderButton.svelte
@@ -13,6 +13,7 @@
   /**
    * Obtain a reference to the uploaded files.
    * @type {ReadonlyArray<File>}
+   * @bindable writable
    */
   export let files = [];
 
@@ -37,7 +38,10 @@
    */
   export let size = "small";
 
-  /** Specify the label text */
+  /**
+   * Specify the label text.
+   * @bindable writable
+   */
   export let labelText = "Add file";
 
   /** Set an id for the input element */
@@ -46,7 +50,10 @@
   /** Specify a name attribute for the input */
   export let name = "";
 
-  /** Obtain a reference to the input HTML element */
+  /**
+   * Obtain a reference to the input HTML element.
+   * @bindable readonly
+   */
   export let ref = null;
 
   /**

--- a/src/FileUploader/FileUploaderDropContainer.svelte
+++ b/src/FileUploader/FileUploaderDropContainer.svelte
@@ -13,6 +13,7 @@
   /**
    * Obtain a reference to the uploaded files.
    * @type {ReadonlyArray<File>}
+   * @bindable writable
    */
   export let files = [];
 
@@ -47,7 +48,10 @@
   /** Specify a name attribute for the input */
   export let name = "";
 
-  /** Obtain a reference to the input HTML element */
+  /**
+   * Obtain a reference to the input HTML element.
+   * @bindable readonly
+   */
   export let ref = null;
 
   import { createEventDispatcher } from "svelte";

--- a/src/Form/Form.svelte
+++ b/src/Form/Form.svelte
@@ -1,5 +1,8 @@
 <script>
-  /** Obtain a reference to the form element */
+  /**
+   * Obtain a reference to the form element.
+   * @bindable readonly
+   */
   export let ref = null;
 </script>
 

--- a/src/ImageLoader/ImageLoader.svelte
+++ b/src/ImageLoader/ImageLoader.svelte
@@ -22,16 +22,19 @@
 
   /**
    * Set to `true` when `loaded` is `true` and `error` is false.
+   * @bindable readonly
    */
   export let loading = false;
 
   /**
    * Set to `true` when the image is loaded.
+   * @bindable readonly
    */
   export let loaded = false;
 
   /**
    * Set to `true` if an error occurs when loading the image.
+   * @bindable readonly
    */
   export let error = false;
 

--- a/src/Link/Link.svelte
+++ b/src/Link/Link.svelte
@@ -31,7 +31,10 @@
   /** Set to `true` to allow visited styles */
   export let visited = false;
 
-  /** Obtain a reference to the top-level HTML element */
+  /**
+   * Obtain a reference to the top-level HTML element.
+   * @bindable readonly
+   */
   export let ref = null;
 </script>
 

--- a/src/ListBox/ListBoxField.svelte
+++ b/src/ListBox/ListBoxField.svelte
@@ -30,7 +30,10 @@
   /** Set an id for the top-level element */
   export let id = `ccs-${Math.random().toString(36)}`;
 
-  /** Obtain a reference to the top-level HTML element */
+  /**
+   * Obtain a reference to the top-level HTML element.
+   * @bindable readonly
+   */
   export let ref = null;
 
   import { getContext } from "svelte";

--- a/src/ListBox/ListBoxMenu.svelte
+++ b/src/ListBox/ListBoxMenu.svelte
@@ -2,7 +2,10 @@
   /** Set an id for the top-level element */
   export let id = `ccs-${Math.random().toString(36)}`;
 
-  /** Obtain a reference to the HTML element */
+  /**
+   * Obtain a reference to the HTML element.
+   * @bindable readonly
+   */
   export let ref = null;
 
   /**

--- a/src/ListBox/ListBoxSelection.svelte
+++ b/src/ListBox/ListBoxSelection.svelte
@@ -31,7 +31,10 @@
    */
   export let translateWithId = (id) => defaultTranslations[id];
 
-  /** Obtain a reference to the top-level HTML element */
+  /**
+   * Obtain a reference to the top-level HTML element.
+   * @bindable readonly
+   */
   export let ref = null;
 
   import { createEventDispatcher, getContext } from "svelte";

--- a/src/LocalStorage/LocalStorage.svelte
+++ b/src/LocalStorage/LocalStorage.svelte
@@ -15,6 +15,7 @@
   /**
    * Provide a value to persist.
    * @type {T}
+   * @bindable writable
    */
   export let value = /** @type {T} */ ("");
 

--- a/src/Modal/Modal.svelte
+++ b/src/Modal/Modal.svelte
@@ -18,7 +18,10 @@
    */
   export let size = undefined;
 
-  /** Set to `true` to open the modal */
+  /**
+   * Set to `true` to open the modal.
+   * @bindable writable
+   */
   export let open = false;
 
   /** Set to `true` to use the danger variant */
@@ -101,7 +104,10 @@
   /** Set an id for the top-level element */
   export let id = `ccs-${Math.random().toString(36)}`;
 
-  /** Obtain a reference to the top-level HTML element */
+  /**
+   * Obtain a reference to the top-level HTML element.
+   * @bindable readonly
+   */
   export let ref = null;
 
   import { afterUpdate, createEventDispatcher, setContext } from "svelte";

--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -41,10 +41,14 @@
   /**
    * Set the selected ids.
    * @type {ReadonlyArray<Item["id"]>}
+   * @bindable writable
    */
   export let selectedIds = [];
 
-  /** Specify the multiselect value */
+  /**
+   * Specify the multiselect value.
+   * @bindable writable
+   */
   export let value = "";
 
   /**
@@ -85,7 +89,10 @@
   export let filterItem = (item, value) =>
     item.text.toLowerCase().includes(value.trim().toLowerCase());
 
-  /** Set to `true` to open the dropdown */
+  /**
+   * Set to `true` to open the dropdown.
+   * @bindable writable
+   */
   export let open = false;
 
   /** Set to `true` to enable the light variant */
@@ -158,27 +165,36 @@
    */
   export let name = undefined;
 
-  /** Obtain a reference to the input HTML element */
+  /**
+   * Obtain a reference to the input HTML element.
+   * @bindable readonly
+   */
   export let inputRef = null;
 
-  /** Obtain a reference to the outer div element */
+  /**
+   * Obtain a reference to the outer div element.
+   * @bindable readonly
+   */
   export let multiSelectRef = null;
 
   /**
    * Obtain a reference to the field box element.
    * @type {null | HTMLDivElement}
+   * @bindable readonly
    */
   export let fieldRef = null;
 
   /**
    * Obtain a reference to the selection element.
    * @type {null | HTMLDivElement}
+   * @bindable readonly
    */
   export let selectionRef = null;
 
   /**
    * Id of the highlighted ListBoxMenuItem.
    * @type {null | Item["id"]}
+   * @bindable readonly
    */
   export let highlightedId = null;
 
@@ -212,6 +228,7 @@
   /**
    * Obtain a reference to the list HTML element.
    * @type {null | HTMLDivElement}
+   * @bindable readonly
    */
   export let listRef = null;
 

--- a/src/Notification/InlineNotification.svelte
+++ b/src/Notification/InlineNotification.svelte
@@ -36,6 +36,7 @@
 
   /**
    * Set to `true` to show the notification, `false` to hide it.
+   * @bindable writable
    */
   export let open = true;
 

--- a/src/Notification/ToastNotification.svelte
+++ b/src/Notification/ToastNotification.svelte
@@ -45,6 +45,7 @@
 
   /**
    * Set to `true` to show the notification, `false` to hide it.
+   * @bindable writable
    */
   export let open = true;
 

--- a/src/NumberInput/NumberInput.svelte
+++ b/src/NumberInput/NumberInput.svelte
@@ -18,6 +18,7 @@
    * Specify the input value.
    * Use `null` to denote "no value".
    * @type {null | number}
+   * @bindable writable
    */
   export let value = null;
 
@@ -153,7 +154,10 @@
    */
   export let name = undefined;
 
-  /** Obtain a reference to the input HTML element */
+  /**
+   * Obtain a reference to the input HTML element.
+   * @bindable readonly
+   */
   export let ref = null;
 
   import { createEventDispatcher } from "svelte";

--- a/src/OverflowMenu/OverflowMenu.svelte
+++ b/src/OverflowMenu/OverflowMenu.svelte
@@ -18,7 +18,10 @@
    */
   export let direction = "bottom";
 
-  /** Set to `true` to open the menu */
+  /**
+   * Set to `true` to open the menu.
+   * @bindable writable
+   */
   export let open = false;
 
   /** Set to `true` to enable the light variant */
@@ -39,6 +42,7 @@
   /**
    * Specify the icon to render.
    * @type {Icon}
+   * @bindable writable
    */
   export let icon = /** @type {Icon} */ (OverflowMenuVertical);
 
@@ -54,10 +58,16 @@
   /** Set an id for the button element */
   export let id = `ccs-${Math.random().toString(36)}`;
 
-  /** Obtain a reference to the trigger button element */
+  /**
+   * Obtain a reference to the trigger button element.
+   * @bindable readonly
+   */
   export let buttonRef = null;
 
-  /** Obtain a reference to the overflow menu element */
+  /**
+   * Obtain a reference to the overflow menu element.
+   * @bindable readonly
+   */
   export let menuRef = null;
 
   /**

--- a/src/OverflowMenu/OverflowMenuItem.svelte
+++ b/src/OverflowMenu/OverflowMenuItem.svelte
@@ -50,7 +50,10 @@
   /** Set an id for the top-level element */
   export let id = `ccs-${Math.random().toString(36)}`;
 
-  /** Obtain a reference to the HTML element */
+  /**
+   * Obtain a reference to the HTML element.
+   * @bindable readonly
+   */
   export let ref = null;
 
   import {

--- a/src/Pagination/Pagination.svelte
+++ b/src/Pagination/Pagination.svelte
@@ -20,7 +20,10 @@
    * @property {number} page
    */
 
-  /** Specify the current page index */
+  /**
+   * Specify the current page index.
+   * @bindable writable
+   */
   export let page = 1;
 
   /** Specify the total number of items */
@@ -68,7 +71,10 @@
   /** Set to `true` to disable the page size input */
   export let pageSizeInputDisabled = false;
 
-  /** Specify the number of items to display in a page */
+  /**
+   * Specify the number of items to display in a page.
+   * @bindable writable
+   */
   export let pageSize = 10;
 
   /**

--- a/src/PaginationNav/PaginationNav.svelte
+++ b/src/PaginationNav/PaginationNav.svelte
@@ -8,7 +8,10 @@
    * @property {number} page
    */
 
-  /** Specify the current page index */
+  /**
+   * Specify the current page index.
+   * @bindable writable
+   */
   export let page = 1;
 
   /** Specify the total number of pages */

--- a/src/Popover/Popover.svelte
+++ b/src/Popover/Popover.svelte
@@ -4,7 +4,10 @@
    * @property {HTMLElement} target
    */
 
-  /** Set to `true` to display the popover */
+  /**
+   * Set to `true` to display the popover.
+   * @bindable writable
+   */
   export let open = false;
 
   /** Set to `true` to close the popover on an outside click */

--- a/src/Portal/FloatingPortal.svelte
+++ b/src/Portal/FloatingPortal.svelte
@@ -87,6 +87,7 @@
   /**
    * Obtain a reference to the floating portal element.
    * @type {null | HTMLElement}
+   * @bindable readonly
    */
   export let ref = null;
 

--- a/src/Portal/Portal.svelte
+++ b/src/Portal/Portal.svelte
@@ -15,6 +15,7 @@
   /**
    * Obtain a reference to the portal element.
    * @type {null | HTMLElement}
+   * @bindable readonly
    */
   export let ref = null;
 

--- a/src/ProgressIndicator/ProgressIndicator.svelte
+++ b/src/ProgressIndicator/ProgressIndicator.svelte
@@ -1,5 +1,8 @@
 <script>
-  /** Specify the current step index */
+  /**
+   * Specify the current step index.
+   * @bindable writable
+   */
   export let currentIndex = 0;
 
   /** Set to `true` to use the vertical variant */

--- a/src/ProgressIndicator/ProgressStep.svelte
+++ b/src/ProgressIndicator/ProgressStep.svelte
@@ -2,7 +2,10 @@
   /** Set to `true` for the complete variant */
   export let complete = false;
 
-  /** Set to `true` to use the current variant */
+  /**
+   * Set to `true` to use the current variant.
+   * @bindable writable
+   */
   export let current = false;
 
   /** Set to `true` to disable the progress step */

--- a/src/RadioButton/RadioButton.svelte
+++ b/src/RadioButton/RadioButton.svelte
@@ -9,7 +9,10 @@
    */
   export let value = "";
 
-  /** Set to `true` to check the radio button */
+  /**
+   * Set to `true` to check the radio button.
+   * @bindable writable
+   */
   export let checked = false;
 
   /** Set to `true` to disable the radio button */
@@ -41,7 +44,10 @@
    */
   export let name = undefined;
 
-  /** Obtain a reference to the input HTML element */
+  /**
+   * Obtain a reference to the input HTML element.
+   * @bindable readonly
+   */
   export let ref = null;
 
   import { getContext, onMount } from "svelte";

--- a/src/RadioButtonGroup/RadioButtonGroup.svelte
+++ b/src/RadioButtonGroup/RadioButtonGroup.svelte
@@ -7,6 +7,7 @@
   /**
    * Set the selected radio button value.
    * @type {Value | undefined}
+   * @bindable writable
    */
   export let selected = undefined;
 

--- a/src/Search/Search.svelte
+++ b/src/Search/Search.svelte
@@ -10,6 +10,7 @@
   /**
    * Specify the value of the search input.
    * @type {T}
+   * @bindable writable
    */
   export let value = /** @type {T} */ ("");
 
@@ -34,7 +35,10 @@
   /** Set to `true` to enable the expandable variant */
   export let expandable = false;
 
-  /** Set to `true to expand the search input */
+  /**
+   * Set to `true to expand the search input.
+   * @bindable writable
+   */
   export let expanded = false;
 
   /** Specify the `placeholder` attribute of the search input */
@@ -64,7 +68,10 @@
   /** Set an id for the input element */
   export let id = `ccs-${Math.random().toString(36)}`;
 
-  /** Obtain a reference to the input HTML element */
+  /**
+   * Obtain a reference to the input HTML element.
+   * @bindable readonly
+   */
   export let ref = null;
 
   import { createEventDispatcher } from "svelte";

--- a/src/Select/Select.svelte
+++ b/src/Select/Select.svelte
@@ -7,6 +7,7 @@
   /**
    * Specify the selected item value.
    * @type {Value | undefined}
+   * @bindable writable
    */
   export let selected = undefined;
 
@@ -58,7 +59,10 @@
   /** Set to `true` to visually hide the label text */
   export let hideLabel = false;
 
-  /** Obtain a reference to the select HTML element */
+  /**
+   * Obtain a reference to the select HTML element.
+   * @bindable readonly
+   */
   export let ref = null;
 
   /** Set to `true` to mark the field as required */

--- a/src/SessionStorage/SessionStorage.svelte
+++ b/src/SessionStorage/SessionStorage.svelte
@@ -15,6 +15,7 @@
   /**
    * Provide a value to persist.
    * @type {T}
+   * @bindable writable
    */
   export let value = /** @type {T} */ ("");
 

--- a/src/Slider/Slider.svelte
+++ b/src/Slider/Slider.svelte
@@ -4,7 +4,10 @@
    * @event {number} input
    */
 
-  /** Specify the value of the slider */
+  /**
+   * Specify the value of the slider.
+   * @bindable writable
+   */
   export let value = 0;
 
   /** Set the maximum slider value */
@@ -82,7 +85,10 @@
   /** Set a name for the slider element */
   export let name = "";
 
-  /** Obtain a reference to the HTML element */
+  /**
+   * Obtain a reference to the HTML element.
+   * @bindable readonly
+   */
   export let ref = null;
 
   import { createEventDispatcher } from "svelte";

--- a/src/StructuredList/StructuredList.svelte
+++ b/src/StructuredList/StructuredList.svelte
@@ -7,6 +7,7 @@
   /**
    * Specify the selected structured list row value.
    * @type {Value | undefined}
+   * @bindable writable
    */
   export let selected = undefined;
 

--- a/src/StructuredList/StructuredListInput.svelte
+++ b/src/StructuredList/StructuredListInput.svelte
@@ -3,7 +3,10 @@
    * @template {string} [Value=string]
    */
 
-  /** Set to `true` to check the input */
+  /**
+   * Set to `true` to check the input.
+   * @bindable writable
+   */
   export let checked = false;
 
   /** Specify the title of the input */
@@ -21,7 +24,10 @@
   /** Specify a name attribute for the input */
   export let name = "";
 
-  /** Obtain a reference to the input HTML element */
+  /**
+   * Obtain a reference to the input HTML element.
+   * @bindable readonly
+   */
   export let ref = null;
 
   import { getContext } from "svelte";

--- a/src/Tabs/Tab.svelte
+++ b/src/Tabs/Tab.svelte
@@ -44,7 +44,10 @@
    */
   export let icon = /** @type {Icon} */ (undefined);
 
-  /** Obtain a reference to the anchor HTML element */
+  /**
+   * Obtain a reference to the anchor HTML element.
+   * @bindable readonly
+   */
   export let ref = null;
 
   import { getContext, onMount } from "svelte";

--- a/src/Tabs/Tabs.svelte
+++ b/src/Tabs/Tabs.svelte
@@ -3,7 +3,10 @@
    * @event {number} change
    */
 
-  /** Specify the selected tab index */
+  /**
+   * Specify the selected tab index.
+   * @bindable writable
+   */
   export let selected = 0;
 
   /**

--- a/src/Tag/SelectableTag.svelte
+++ b/src/Tag/SelectableTag.svelte
@@ -5,7 +5,10 @@
    * @event {{ selected: boolean }} "change"
    */
 
-  /** Set to `true` to select the tag */
+  /**
+   * Set to `true` to select the tag.
+   * @bindable writable
+   */
   export let selected = false;
 
   /**

--- a/src/TextArea/TextArea.svelte
+++ b/src/TextArea/TextArea.svelte
@@ -2,6 +2,7 @@
   /**
    * Specify the textarea value.
    * @type {null | string}
+   * @bindable writable
    */
   export let value = "";
 
@@ -64,7 +65,10 @@
    */
   export let name = undefined;
 
-  /** Obtain a reference to the textarea HTML element */
+  /**
+   * Obtain a reference to the textarea HTML element.
+   * @bindable readonly
+   */
   export let ref = null;
 
   import WarningAltFilled from "../icons/WarningAltFilled.svelte";

--- a/src/TextInput/PasswordInput.svelte
+++ b/src/TextInput/PasswordInput.svelte
@@ -8,12 +8,14 @@
   /**
    * Specify the input value.
    * @type {number | string}
+   * @bindable writable
    */
   export let value = "";
 
   /**
    * Set to `"text"` to toggle the password visibility.
    * @type {"text" | "password"}
+   * @bindable writable
    */
   export let type = "password";
 
@@ -77,7 +79,10 @@
    */
   export let name = undefined;
 
-  /** Obtain a reference to the input HTML element */
+  /**
+   * Obtain a reference to the input HTML element.
+   * @bindable readonly
+   */
   export let ref = null;
 
   /**

--- a/src/TextInput/TextInput.svelte
+++ b/src/TextInput/TextInput.svelte
@@ -15,6 +15,7 @@
    *
    * `value` will be set to `null` if type="number" and the value is empty.
    * @type {null | number | string}
+   * @bindable writable
    */
   export let value = "";
 
@@ -57,7 +58,10 @@
   /** Specify the warning state text */
   export let warnText = "";
 
-  /** Obtain a reference to the input HTML element */
+  /**
+   * Obtain a reference to the input HTML element.
+   * @bindable readonly
+   */
   export let ref = null;
 
   /** Set to `true` to mark the field as required */

--- a/src/Theme/Theme.svelte
+++ b/src/Theme/Theme.svelte
@@ -30,6 +30,7 @@
   /**
    * Set the current Carbon theme.
    * @type {CarbonTheme}
+   * @bindable writable
    */
   export let theme = "white";
 

--- a/src/Tile/ClickableTile.svelte
+++ b/src/Tile/ClickableTile.svelte
@@ -1,7 +1,10 @@
 <script>
   /** @restProps {a | p} */
 
-  /** Set to `true` to click the tile */
+  /**
+   * Set to `true` to click the tile.
+   * @bindable readonly
+   */
   export let clicked = false;
 
   /** Set to `true` to enable the light variant */
@@ -16,7 +19,10 @@
    */
   export let href = undefined;
 
-  /** Obtain a reference to the underlying anchor HTML element */
+  /**
+   * Obtain a reference to the underlying anchor HTML element.
+   * @bindable readonly
+   */
   export let ref = null;
 
   import Link from "../Link/Link.svelte";

--- a/src/Tile/ExpandableTile.svelte
+++ b/src/Tile/ExpandableTile.svelte
@@ -1,14 +1,23 @@
 <script>
-  /** Set to `true` to expand the tile */
+  /**
+   * Set to `true` to expand the tile.
+   * @bindable writable
+   */
   export let expanded = false;
 
   /** Set to `true` to enable the light variant */
   export let light = false;
 
-  /** Specify the max height of the tile  (number of pixels) */
+  /**
+   * Specify the max height of the tile  (number of pixels).
+   * @bindable writable
+   */
   export let tileMaxHeight = 0;
 
-  /** Specify the padding of the tile (number of pixels) */
+  /**
+   * Specify the padding of the tile (number of pixels).
+   * @bindable writable
+   */
   export let tilePadding = 0;
 
   /** Specify the icon text of the collapsed tile */
@@ -40,7 +49,10 @@
    */
   export let hasInteractiveContent = false;
 
-  /** Obtain a reference to the top-level element */
+  /**
+   * Obtain a reference to the top-level element.
+   * @bindable readonly
+   */
   export let ref = null;
 
   import { afterUpdate, onMount } from "svelte";

--- a/src/Tile/RadioTile.svelte
+++ b/src/Tile/RadioTile.svelte
@@ -4,7 +4,10 @@
    * @template {string} [Value=string]
    */
 
-  /** Set to `true` to check the tile */
+  /**
+   * Set to `true` to check the tile.
+   * @bindable writable
+   */
   export let checked = false;
 
   /** Set to `true` to enable the light variant */

--- a/src/Tile/SelectableTile.svelte
+++ b/src/Tile/SelectableTile.svelte
@@ -4,7 +4,10 @@
    * @event {string} "deselect"
    */
 
-  /** Set to `true` to select the tile */
+  /**
+   * Set to `true` to select the tile.
+   * @bindable writable
+   */
   export let selected = false;
 
   /** Set to `true` to enable the light variant */
@@ -37,7 +40,10 @@
    */
   export let name = "";
 
-  /** Obtain a reference to the input HTML element */
+  /**
+   * Obtain a reference to the input HTML element.
+   * @bindable readonly
+   */
   export let ref = null;
 
   import { createEventDispatcher, getContext } from "svelte";

--- a/src/Tile/SelectableTileGroup.svelte
+++ b/src/Tile/SelectableTileGroup.svelte
@@ -8,6 +8,7 @@
   /**
    * Specify the selected tile values.
    * @type {T[]}
+   * @bindable writable
    */
   export let selected = [];
 

--- a/src/Tile/TileGroup.svelte
+++ b/src/Tile/TileGroup.svelte
@@ -7,6 +7,7 @@
   /**
    * Specify the selected tile value.
    * @type {T | undefined}
+   * @bindable writable
    */
   export let selected = undefined;
 

--- a/src/TimePicker/TimePicker.svelte
+++ b/src/TimePicker/TimePicker.svelte
@@ -8,6 +8,7 @@
   /**
    * Specify the input value.
    * @type {string}
+   * @bindable writable
    */
   export let value = "";
 
@@ -59,7 +60,10 @@
    */
   export let name = undefined;
 
-  /** Obtain a reference to the input HTML element */
+  /**
+   * Obtain a reference to the input HTML element.
+   * @bindable readonly
+   */
   export let ref = null;
 
   import WarningAltFilled from "../icons/WarningAltFilled.svelte";

--- a/src/TimePicker/TimePickerSelect.svelte
+++ b/src/TimePicker/TimePickerSelect.svelte
@@ -2,6 +2,7 @@
   /**
    * Specify the select value.
    * @type {number | string}
+   * @bindable writable
    */
   export let value = "";
 
@@ -26,7 +27,10 @@
    */
   export let name = undefined;
 
-  /** Obtain a reference to the select HTML element */
+  /**
+   * Obtain a reference to the select HTML element.
+   * @bindable readonly
+   */
   export let ref = null;
 
   import { setContext } from "svelte";

--- a/src/Toggle/Toggle.svelte
+++ b/src/Toggle/Toggle.svelte
@@ -9,7 +9,10 @@
    */
   export let size = "default";
 
-  /** Set to `true` to toggle the checkbox input */
+  /**
+   * Set to `true` to toggle the checkbox input.
+   * @bindable writable
+   */
   export let toggled = false;
 
   /** Set to `true` to disable checkbox input */
@@ -39,7 +42,10 @@
    */
   export let name = undefined;
 
-  /** Obtain a reference to the input HTML element */
+  /**
+   * Obtain a reference to the input HTML element.
+   * @bindable readonly
+   */
   export let ref = null;
 
   import { createEventDispatcher } from "svelte";

--- a/src/Tooltip/Tooltip.svelte
+++ b/src/Tooltip/Tooltip.svelte
@@ -20,6 +20,7 @@
   /**
    * Set to `true` to open the tooltip.
    * @type {boolean}
+   * @bindable writable
    */
   export let open = false;
 
@@ -75,13 +76,22 @@
    */
   export let leaveDelayMs = 300;
 
-  /** Obtain a reference to the trigger text HTML element */
+  /**
+   * Obtain a reference to the trigger text HTML element.
+   * @bindable readonly
+   */
   export let ref = null;
 
-  /** Obtain a reference to the tooltip HTML element */
+  /**
+   * Obtain a reference to the tooltip HTML element.
+   * @bindable readonly
+   */
   export let refTooltip = null;
 
-  /** Obtain a reference to the icon HTML element */
+  /**
+   * Obtain a reference to the icon HTML element.
+   * @bindable readonly
+   */
   export let refIcon = null;
 
   /**

--- a/src/TooltipDefinition/TooltipDefinition.svelte
+++ b/src/TooltipDefinition/TooltipDefinition.svelte
@@ -9,6 +9,7 @@
 
   /**
    * Set to `true` to open the tooltip.
+   * @bindable writable
    */
   export let open = false;
 
@@ -46,7 +47,10 @@
    */
   export let leaveDelayMs = 300;
 
-  /** Obtain a reference to the button HTML element */
+  /**
+   * Obtain a reference to the button HTML element.
+   * @bindable readonly
+   */
   export let ref = null;
 
   /**

--- a/src/TooltipIcon/TooltipIcon.svelte
+++ b/src/TooltipIcon/TooltipIcon.svelte
@@ -18,6 +18,7 @@
 
   /**
    * Set to `true` to open the tooltip.
+   * @bindable writable
    */
   export let open = false;
 
@@ -64,7 +65,10 @@
    */
   export let leaveDelayMs = 300;
 
-  /** Obtain a reference to the button HTML element */
+  /**
+   * Obtain a reference to the button HTML element.
+   * @bindable readonly
+   */
   export let ref = null;
 
   /**

--- a/src/TreeView/TreeView.svelte
+++ b/src/TreeView/TreeView.svelte
@@ -214,18 +214,21 @@
    * Set the current active node id.
    * Only one node can be active.
    * @type {Node["id"]}
+   * @bindable writable
    */
   export let activeId = "";
 
   /**
    * Set the node ids to be selected.
    * @type {ReadonlyArray<Node["id"]>}
+   * @bindable writable
    */
   export let selectedIds = [];
 
   /**
    * Set the node ids to be expanded.
    * @type {ReadonlyArray<Node["id"]>}
+   * @bindable writable
    */
   export let expandedIds = [];
 

--- a/src/UIShell/Header.svelte
+++ b/src/UIShell/Header.svelte
@@ -6,7 +6,10 @@
   /** Set to `false` to hide the side nav by default */
   export let expandedByDefault = true;
 
-  /** Set to `true` to open the side nav */
+  /**
+   * Set to `true` to open the side nav.
+   * @bindable writable
+   */
   export let isSideNavOpen = false;
 
   /**
@@ -61,7 +64,10 @@
    */
   export let expansionBreakpoint = 1056;
 
-  /** Obtain a reference to the HTML anchor element */
+  /**
+   * Obtain a reference to the HTML anchor element.
+   * @bindable readonly
+   */
   export let ref = null;
 
   /**

--- a/src/UIShell/HeaderAction.svelte
+++ b/src/UIShell/HeaderAction.svelte
@@ -5,7 +5,10 @@
    * @event {null} close
    */
 
-  /** Set to `true` to open the panel */
+  /**
+   * Set to `true` to open the panel.
+   * @bindable writable
+   */
   export let isOpen = false;
 
   /**
@@ -47,7 +50,10 @@
    */
   export let tooltipAlignment = "center";
 
-  /** Obtain a reference to the button HTML element */
+  /**
+   * Obtain a reference to the button HTML element.
+   * @bindable readonly
+   */
   export let ref = null;
 
   /**

--- a/src/UIShell/HeaderActionLink.svelte
+++ b/src/UIShell/HeaderActionLink.svelte
@@ -18,7 +18,10 @@
    */
   export let icon = /** @type {Icon} */ (undefined);
 
-  /** Obtain a reference to the HTML anchor element */
+  /**
+   * Obtain a reference to the HTML anchor element.
+   * @bindable readonly
+   */
   export let ref = null;
 </script>
 

--- a/src/UIShell/HeaderGlobalAction.svelte
+++ b/src/UIShell/HeaderGlobalAction.svelte
@@ -13,8 +13,10 @@
    */
   export let icon = /** @type {Icon} */ (undefined);
 
-  /** Obtain a reference to the HTML button element.
+  /**
+   * Obtain a reference to the HTML button element.
    * @type {HTMLButtonElement}
+   * @bindable readonly
    */
   export let ref = null;
 

--- a/src/UIShell/HeaderNavItem.svelte
+++ b/src/UIShell/HeaderNavItem.svelte
@@ -14,7 +14,10 @@
   /** Set to `true` to select the item */
   export let isSelected = false;
 
-  /** Obtain a reference to the HTML anchor element */
+  /**
+   * Obtain a reference to the HTML anchor element.
+   * @bindable readonly
+   */
   export let ref = null;
 
   import { getContext, onMount } from "svelte";

--- a/src/UIShell/HeaderNavMenu.svelte
+++ b/src/UIShell/HeaderNavMenu.svelte
@@ -1,5 +1,8 @@
 <script>
-  /** Set to `true` to toggle the expanded state */
+  /**
+   * Set to `true` to toggle the expanded state.
+   * @bindable writable
+   */
   export let expanded = false;
 
   /** Specify the `href` attribute */
@@ -14,6 +17,7 @@
   /**
    * Obtain a reference to the HTML anchor element.
    * @type {HTMLAnchorElement | null}
+   * @bindable readonly
    */
   export let ref = null;
 

--- a/src/UIShell/HeaderPanelLink.svelte
+++ b/src/UIShell/HeaderPanelLink.svelte
@@ -5,7 +5,10 @@
    */
   export let href = undefined;
 
-  /** Obtain a reference to the HTML anchor element */
+  /**
+   * Obtain a reference to the HTML anchor element.
+   * @bindable readonly
+   */
   export let ref = null;
 </script>
 

--- a/src/UIShell/HeaderSearch.svelte
+++ b/src/UIShell/HeaderSearch.svelte
@@ -19,15 +19,22 @@
    * @slot {{ result: Result; index: number }}
    */
 
-  /** Specify the search input value */
+  /**
+   * Specify the search input value.
+   * @bindable writable
+   */
   export let value = "";
 
-  /** Set to `true` to activate and focus the search bar */
+  /**
+   * Set to `true` to activate and focus the search bar.
+   * @bindable writable
+   */
   export let active = false;
 
   /**
    * Obtain a reference to the input HTML element.
    * @type {HTMLInputElement | null}
+   * @bindable readonly
    */
   export let ref = null;
 
@@ -37,7 +44,10 @@
    */
   export let results = [];
 
-  /** Specify the selected result index. */
+  /**
+   * Specify the selected result index.
+   * @bindable readonly
+   */
   export let selectedResultIndex = 0;
 
   import { createEventDispatcher, tick } from "svelte";

--- a/src/UIShell/SideNav.svelte
+++ b/src/UIShell/SideNav.svelte
@@ -17,7 +17,10 @@
    */
   export let ariaLabel = undefined;
 
-  /** Set to `true` to toggle the expanded state */
+  /**
+   * Set to `true` to toggle the expanded state.
+   * @bindable writable
+   */
   export let isOpen = false;
 
   /**

--- a/src/UIShell/SideNavLink.svelte
+++ b/src/UIShell/SideNavLink.svelte
@@ -24,7 +24,10 @@
    */
   export let icon = /** @type {Icon} */ (undefined);
 
-  /** Obtain a reference to the HTML anchor element */
+  /**
+   * Obtain a reference to the HTML anchor element.
+   * @bindable readonly
+   */
   export let ref = null;
 </script>
 

--- a/src/UIShell/SideNavMenu.svelte
+++ b/src/UIShell/SideNavMenu.svelte
@@ -3,7 +3,10 @@
    * @template [Icon=any]
    */
 
-  /** Set to `true` to toggle the expanded state */
+  /**
+   * Set to `true` to toggle the expanded state.
+   * @bindable writable
+   */
   export let expanded = false;
 
   /**
@@ -18,7 +21,10 @@
    */
   export let icon = /** @type {Icon} */ (undefined);
 
-  /** Obtain a reference to the HTML button element */
+  /**
+   * Obtain a reference to the HTML button element.
+   * @bindable readonly
+   */
   export let ref = null;
 
   import ChevronDown from "../icons/ChevronDown.svelte";

--- a/src/UIShell/SideNavMenuItem.svelte
+++ b/src/UIShell/SideNavMenuItem.svelte
@@ -14,7 +14,10 @@
    */
   export let text = undefined;
 
-  /** Obtain a reference to the HTML anchor element */
+  /**
+   * Obtain a reference to the HTML anchor element.
+   * @bindable readonly
+   */
   export let ref = null;
 </script>
 


### PR DESCRIPTION
Some props are reactive. Reactive props are either two-way or one-way binding. Two-way binding means a consumer update to the prop value will update the component internally ("writable"). A one-way bound prop flows to the consumer ("readonly").

This uses the new syntax in svelte@0.32.0 to allow explicit annotation for reactive props. There is no change to the generated TypeScript definitions; this only updates the auto-generated JSON for component API docs (not yet surfaced in docs).

My plan is to update the Props table design in the docs to delineate whether or not a reactive prop is writable/readonly.