### PR TITLE
fix(slider): update value on click without drag

### DIFF
--- a/src/Slider/Slider.svelte
+++ b/src/Slider/Slider.svelte
@@ -96,14 +96,11 @@
   let holding = false;
   let currentEvent = null;
 
-  function startDragging() {
+  function startInteraction(e) {
     if (disabled || readonly) return;
-    dragging = true;
-  }
-
-  function startHolding() {
-    if (disabled || readonly) return;
+    currentEvent = e;
     holding = true;
+    dragging = true;
   }
 
   function stopHolding() {
@@ -115,7 +112,7 @@
   function move(e) {
     if (holding) {
       currentEvent = e;
-      startDragging();
+      dragging = true;
     }
   }
 
@@ -203,9 +200,8 @@
       class:bx--slider--disabled={disabled}
       class:bx--slider--readonly={readonly}
       style:max-width={fullWidth ? "none" : undefined}
-      on:mousedown={startDragging}
-      on:mousedown={startHolding}
-      on:touchstart={startHolding}
+      on:mousedown={startInteraction}
+      on:touchstart={startInteraction}
       on:keydown={({ shiftKey, key }) => {
         if (disabled || readonly) return;
         const keys = {

--- a/tests/Slider/Slider.test.ts
+++ b/tests/Slider/Slider.test.ts
@@ -1,4 +1,5 @@
-import { render, screen } from "@testing-library/svelte";
+import { fireEvent, render, screen } from "@testing-library/svelte";
+import { tick } from "svelte";
 import { user } from "../utils/user";
 import Slider from "./Slider.test.svelte";
 
@@ -552,6 +553,39 @@ describe("Slider", () => {
 
     const formItem = container.querySelector(".bx--form-item");
     expect(formItem).toHaveClass("custom-slider");
+  });
+
+  // Regression: a stationary click on the track should move the thumb,
+  // not only a click followed by a mousemove.
+  it("should update value on a click without dragging", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    const { container } = render(Slider, {
+      props: { value: 0, min: 0, max: 100 },
+    });
+
+    const slider = container.querySelector(".bx--slider");
+    const track = container.querySelector(".bx--slider__track");
+    assert(slider instanceof HTMLElement);
+    assert(track instanceof HTMLElement);
+
+    vi.spyOn(track, "getBoundingClientRect").mockReturnValue({
+      left: 0,
+      right: 200,
+      width: 200,
+      top: 0,
+      bottom: 0,
+      height: 2,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    });
+
+    await fireEvent.mouseDown(slider, { clientX: 100 });
+    await tick();
+    await fireEvent.mouseUp(window);
+
+    expect(consoleLog).toHaveBeenCalledWith("input", 50);
+    expect(screen.getByRole("spinbutton")).toHaveValue(50);
   });
 
   // Regression test for https://github.com/carbon-design-system/carbon-components-svelte/issues/1980


### PR DESCRIPTION
**Bug**

Currently, there is a dead region in the Slider where clicking doesn't update the bar. Compare this to the React implementation, and the UX bug is evident. See recordings below.

**Root cause & fix**

The `mousedown` handlers only flipped `dragging`/`holding` flags without capturing the event, so the reactive block's `calcValue(currentEvent)` no-opped until a `mousemove` fired. Collapse to a single `startInteraction(e)` that primes `currentEvent` on press, matching upstream React behavior.

---

## Before

I'm clicking the input, but nothing happens.

https://github.com/user-attachments/assets/845b1ac2-0789-448e-b025-8cef8fc08da6


## After

The click registers, and the thumb is updated.

https://github.com/user-attachments/assets/854dca7c-320e-4e5e-8410-e23528add930




