### PR TITLE
fix(tooltip-footer): do not throw if rendered outside context

### DIFF
--- a/src/Tooltip/TooltipFooter.svelte
+++ b/src/Tooltip/TooltipFooter.svelte
@@ -7,14 +7,14 @@
   let ref = null;
   let open = false;
 
-  const ctx = getContext("carbon:Tooltip");
-  const unsubscribe = ctx.tooltipOpen.subscribe((tooltipOpen) => {
+  const ctx = getContext("carbon:Tooltip") ?? null;
+  const unsubscribe = ctx?.tooltipOpen.subscribe((tooltipOpen) => {
     open = tooltipOpen;
   });
 
   onMount(() => {
     return () => {
-      unsubscribe();
+      unsubscribe?.();
     };
   });
 

--- a/tests/Tooltip/Tooltip.test.ts
+++ b/tests/Tooltip/Tooltip.test.ts
@@ -7,6 +7,7 @@ import TooltipCustomIcon from "./TooltipCustomIcon.test.svelte";
 import TooltipDefault from "./TooltipDefault.test.svelte";
 import TooltipDirections from "./TooltipDirections.test.svelte";
 import TooltipEvents from "./TooltipEvents.test.svelte";
+import TooltipFooterStandalone from "./TooltipFooterStandalone.test.svelte";
 import TooltipHideIcon from "./TooltipHideIcon.test.svelte";
 import TooltipOpen from "./TooltipOpen.test.svelte";
 import TooltipPortalDirections from "./TooltipPortalDirections.test.svelte";
@@ -251,6 +252,10 @@ describe("Tooltip", () => {
     await fireEvent.focus(trigger);
 
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  test("TooltipFooter should not throw when rendered outside a Tooltip", () => {
+    expect(() => render(TooltipFooterStandalone)).not.toThrow();
   });
 
   describe("Generics", () => {

--- a/tests/Tooltip/TooltipFooterStandalone.test.svelte
+++ b/tests/Tooltip/TooltipFooterStandalone.test.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+  import { TooltipFooter } from "carbon-components-svelte";
+</script>
+
+<TooltipFooter />


### PR DESCRIPTION
Defensive fix; `TooltipFooter` should be used inside `Tooltip`, but avoid throwing if not.