### PR TITLE
test(toggle): more keyboard tests

### DIFF
--- a/tests/Toggle/Toggle.test.ts
+++ b/tests/Toggle/Toggle.test.ts
@@ -328,6 +328,22 @@ describe("Toggle", () => {
       await user.click(toggle);
       expect(toggle).toBeChecked();
     });
+
+    it("should not toggle on keyboard when readonly", async () => {
+      const consoleLog = vi.spyOn(console, "log");
+      render(ToggleReadonly, { readonly: true });
+
+      const toggle = screen.getByRole("switch", { name: /Readonly toggle/i });
+      toggle.focus();
+
+      await user.keyboard(" ");
+      expect(toggle).not.toBeChecked();
+      expect(consoleLog).not.toHaveBeenCalledWith("toggle", true);
+
+      await user.keyboard("{Enter}");
+      expect(toggle).not.toBeChecked();
+      expect(consoleLog).not.toHaveBeenCalledWith("toggle", true);
+    });
   });
 
   // Regression: ?? for aria-label so empty string is used (not fallback)

--- a/tests/Toggle/Toggle.test.ts
+++ b/tests/Toggle/Toggle.test.ts
@@ -156,6 +156,10 @@ describe("Toggle", () => {
     await user.keyboard(" ");
     expect(toggle).not.toBeChecked();
     expect(consoleLog).not.toHaveBeenCalled();
+
+    await user.keyboard("{Enter}");
+    expect(toggle).not.toBeChecked();
+    expect(consoleLog).not.toHaveBeenCalled();
   });
 
   it("supports initial toggled state", () => {


### PR DESCRIPTION
For the disabled state, validate that "Enter" does not toggle it. Similarly, add keyboard tests for the readonly state (added in #3019).