### PR TITLE
fix(progress-indicator): remove unmounted steps from context

### DIFF
--- a/src/ProgressIndicator/ProgressIndicator.svelte
+++ b/src/ProgressIndicator/ProgressIndicator.svelte
@@ -65,6 +65,18 @@
   };
 
   /**
+   * @type {(id: string) => void}
+   */
+  const remove = (id) => {
+    steps.update((_) =>
+      _.filter((step) => step.id !== id).map((step, i) => ({
+        ...step,
+        index: i,
+      })),
+    );
+  };
+
+  /**
    * @type {(index: number) => void}
    */
   const change = (index) => {
@@ -80,6 +92,7 @@
     stepsById,
     preventChangeOnClick: preventChangeOnClickReadable,
     add,
+    remove,
     change,
   });
 

--- a/src/ProgressIndicator/ProgressStep.svelte
+++ b/src/ProgressIndicator/ProgressStep.svelte
@@ -34,7 +34,7 @@
 
   let step = {};
 
-  const { stepsById, add, change, preventChangeOnClick } = getContext(
+  const { stepsById, add, remove, change, preventChangeOnClick } = getContext(
     "carbon:ProgressIndicator",
   );
 
@@ -50,6 +50,7 @@
   onMount(() => {
     return () => {
       unsubscribe();
+      remove(id);
     };
   });
 </script>

--- a/tests/ProgressIndicator/ProgressIndicator.test.ts
+++ b/tests/ProgressIndicator/ProgressIndicator.test.ts
@@ -1,6 +1,7 @@
 import { render, screen, waitFor } from "@testing-library/svelte";
 import { user } from "../utils/user";
 import ProgressIndicator from "./ProgressIndicator.test.svelte";
+import ProgressIndicatorConditional from "./ProgressIndicatorConditional.test.svelte";
 import ProgressIndicatorIssue1249 from "./ProgressIndicatorIssue1249.test.svelte";
 import ProgressIndicatorReactive from "./ProgressIndicatorReactive.test.svelte";
 
@@ -245,6 +246,28 @@ describe("ProgressIndicator", () => {
 
       await user.keyboard(" ");
       expect(consoleLog).toHaveBeenCalledWith("change", 0);
+    });
+  });
+
+  describe("Conditional step rendering", () => {
+    it("should remove unmounted steps and re-index, so change emits the correct index", async () => {
+      const consoleLog = vi.spyOn(console, "log");
+      const { rerender } = render(ProgressIndicatorConditional, {
+        showOptional: true,
+        currentIndex: 0,
+      });
+
+      expect(screen.getAllByRole("listitem")).toHaveLength(3);
+
+      rerender({ showOptional: false, currentIndex: 0 });
+
+      await waitFor(() => {
+        expect(screen.getAllByRole("listitem")).toHaveLength(2);
+      });
+
+      // The remaining "Step 3" must now report index 1, not 2.
+      await user.click(screen.getByText("Step 3"));
+      expect(consoleLog).toHaveBeenLastCalledWith("change", 1);
     });
   });
 

--- a/tests/ProgressIndicator/ProgressIndicatorConditional.test.svelte
+++ b/tests/ProgressIndicator/ProgressIndicatorConditional.test.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  import { ProgressIndicator, ProgressStep } from "carbon-components-svelte";
+
+  export let showOptional = true;
+  export let currentIndex = 0;
+</script>
+
+<ProgressIndicator
+  {currentIndex}
+  on:change={(e) => console.log("change", e.detail)}
+>
+  <ProgressStep label="Step 1" complete />
+  {#if showOptional}
+    <ProgressStep label="Optional" complete />
+  {/if}
+  <ProgressStep label="Step 3" complete />
+</ProgressIndicator>


### PR DESCRIPTION
Conditionally rendered `ProgressStep`s left phantom entries in the shared store, so `change` fired with stale indexes. Expose `remove(id)` via context and call it from the step's teardown to re-index siblings.