### PR TITLE
fix(session-storage): suppress spurious `update` on initial hydration

### DIFF
--- a/src/LocalStorage/LocalStorage.svelte
+++ b/src/LocalStorage/LocalStorage.svelte
@@ -75,6 +75,7 @@
       }
     }
 
+    prevValue = value;
     mounted = true;
 
     function handleStorageChange(event) {

--- a/src/SessionStorage/SessionStorage.svelte
+++ b/src/SessionStorage/SessionStorage.svelte
@@ -75,6 +75,7 @@
       }
     }
 
+    prevValue = value;
     mounted = true;
 
     function handleStorageChange(event) {

--- a/tests/LocalStorage/LocalStoragePrimitive.test.ts
+++ b/tests/LocalStorage/LocalStoragePrimitive.test.ts
@@ -1,4 +1,5 @@
 import { render } from "@testing-library/svelte";
+import { tick } from "svelte";
 import { setupLocalStorageMock } from "../utils/storage-mocks";
 import LocalStoragePrimitive from "./LocalStoragePrimitive.test.svelte";
 
@@ -32,5 +33,17 @@ describe("LocalStorage - Primitive Values", () => {
 
     render(LocalStoragePrimitive);
     expect(localStorage.getItem).toHaveBeenCalledWith("test-key");
+  });
+
+  it("does not dispatch a spurious update event when hydrating from storage on mount", async () => {
+    setMockItem("test-key", "existing-value");
+
+    render(LocalStoragePrimitive);
+    await tick();
+
+    expect(consoleLog).not.toHaveBeenCalledWith(
+      "update event",
+      expect.anything(),
+    );
   });
 });

--- a/tests/SessionStorage/SessionStoragePrimitive.test.ts
+++ b/tests/SessionStorage/SessionStoragePrimitive.test.ts
@@ -1,4 +1,5 @@
 import { render } from "@testing-library/svelte";
+import { tick } from "svelte";
 import { setupSessionStorageMock } from "../utils/storage-mocks";
 import SessionStoragePrimitive from "./SessionStoragePrimitive.test.svelte";
 
@@ -35,5 +36,17 @@ describe("SessionStorage - Primitive Values", () => {
 
     render(SessionStoragePrimitive);
     expect(sessionStorage.getItem).toHaveBeenCalledWith("test-key");
+  });
+
+  it("does not dispatch a spurious update event when hydrating from storage on mount", async () => {
+    setMockItem("test-key", "existing-value");
+
+    render(SessionStoragePrimitive);
+    await tick();
+
+    expect(consoleLog).not.toHaveBeenCalledWith(
+      "update event",
+      expect.anything(),
+    );
   });
 });


### PR DESCRIPTION
Sync `prevValue` with `value` after `onMount` reads from storage so `afterUpdate` does not diff the loaded value against the prop's mount-time default and dispatch a phantom `update` event.