### PR TITLE
chore(local-storage,session-storage): clarify `clearItem`/`clearAll` do not reset bound `value`

### DIFF
--- a/src/LocalStorage/LocalStorage.svelte
+++ b/src/LocalStorage/LocalStorage.svelte
@@ -20,12 +20,15 @@
   export let value = /** @type {T} */ ("");
 
   /**
-   * Remove the persisted key value from the browser's local storage
+   * Remove the persisted key value from the browser's local storage.
+   * Note: this only clears storage; the bound `value` is left untouched.
+   * If `value` mutates afterwards, it will be re-persisted. Reset `value`
+   * yourself if you want it cleared as well.
    * @type {() => void}
    * @example
    * ```svelte
    * <LocalStorage bind:this={storage} key="my-key" bind:value={data} />
-   * <button on:click={() => storage.clearItem()}>Clear Item</button>
+   * <button on:click={() => { storage.clearItem(); data = ""; }}>Clear Item</button>
    * ```
    */
   export function clearItem() {
@@ -33,12 +36,15 @@
   }
 
   /**
-   * Clear all key values from the browser's local storage
+   * Clear all key values from the browser's local storage.
+   * Note: this only clears storage; the bound `value` is left untouched.
+   * If `value` mutates afterwards, it will be re-persisted. Reset `value`
+   * yourself if you want it cleared as well.
    * @type {() => void}
    * @example
    * ```svelte
    * <LocalStorage bind:this={storage} key="my-key" bind:value={data} />
-   * <button on:click={() => storage.clearAll()}>Clear All Storage</button>
+   * <button on:click={() => { storage.clearAll(); data = ""; }}>Clear All Storage</button>
    * ```
    */
   export function clearAll() {

--- a/src/SessionStorage/SessionStorage.svelte
+++ b/src/SessionStorage/SessionStorage.svelte
@@ -20,12 +20,15 @@
   export let value = /** @type {T} */ ("");
 
   /**
-   * Remove the persisted key value from the browser's session storage
+   * Remove the persisted key value from the browser's session storage.
+   * Note: this only clears storage; the bound `value` is left untouched.
+   * If `value` mutates afterwards, it will be re-persisted. Reset `value`
+   * yourself if you want it cleared as well.
    * @type {() => void}
    * @example
    * ```svelte
    * <SessionStorage bind:this={storage} key="my-key" bind:value={data} />
-   * <button on:click={() => storage.clearItem()}>Clear Item</button>
+   * <button on:click={() => { storage.clearItem(); data = ""; }}>Clear Item</button>
    * ```
    */
   export function clearItem() {
@@ -33,12 +36,15 @@
   }
 
   /**
-   * Clear all key values from the browser's session storage
+   * Clear all key values from the browser's session storage.
+   * Note: this only clears storage; the bound `value` is left untouched.
+   * If `value` mutates afterwards, it will be re-persisted. Reset `value`
+   * yourself if you want it cleared as well.
    * @type {() => void}
    * @example
    * ```svelte
    * <SessionStorage bind:this={storage} key="my-key" bind:value={data} />
-   * <button on:click={() => storage.clearAll()}>Clear All Storage</button>
+   * <button on:click={() => { storage.clearAll(); data = ""; }}>Clear All Storage</button>
    * ```
    */
   export function clearAll() {


### PR DESCRIPTION
The methods only clear storage; the bound `value` is left untouched and will be re-persisted on the next mutation. Update JSDoc and examples so callers explicitly reset `value` themselves.