### PR TITLE
fix(progress-step): dispatch `change` once per keypress

### DIFF
--- a/src/ProgressIndicator/ProgressStep.svelte
+++ b/src/ProgressIndicator/ProgressStep.svelte
@@ -81,12 +81,6 @@
     on:mouseenter
     on:mouseleave
     on:keydown
-    on:keydown={(e) => {
-      if (!step.complete) return;
-      if (e.key === " " || e.key === "Enter") {
-        change(step.index);
-      }
-    }}
   >
     {#if invalid}
       <Warning class="bx--progress__warning" title={description} />

--- a/tests/ProgressIndicator/ProgressIndicator.test.ts
+++ b/tests/ProgressIndicator/ProgressIndicator.test.ts
@@ -246,6 +246,28 @@ describe("ProgressIndicator", () => {
       await user.keyboard(" ");
       expect(consoleLog).toHaveBeenCalledWith("change", 0);
     });
+
+    it("should dispatch change exactly once per keypress on a complete step", async () => {
+      const changeHandler = vi.fn();
+      render(ProgressIndicator, {
+        currentIndex: 1,
+        steps: [
+          { label: "Step 1", description: "First step", complete: true },
+          { label: "Step 2", description: "Second step", complete: false },
+        ],
+        onchange: changeHandler,
+      });
+
+      const completeStepButton = screen.getAllByRole("button")[0];
+      await user.tab();
+      expect(completeStepButton).toHaveFocus();
+
+      await user.keyboard("{Enter}");
+      expect(changeHandler).toHaveBeenCalledTimes(1);
+
+      await user.keyboard(" ");
+      expect(changeHandler).toHaveBeenCalledTimes(2);
+    });
   });
 
   describe("Reactive complete prop (#1249)", () => {


### PR DESCRIPTION
The button had a manual `on:keydown` calling `change()` on Enter/Space, but the native `<button>` already fires a `click`
for those keys, so `change` dispatched twice per keystroke.

Repro:

```svelte
<script>
  import "carbon-components-svelte/css/white.css";
  import { ProgressIndicator, ProgressStep } from "carbon-components-svelte";

  let count = 0;
  let lastIndex = null;

  function handleChange(e) {
    count += 1;
    lastIndex = e.detail;
  }
</script>

<p>
  Tab to the first step ("Step 1"), then press <kbd>Enter</kbd> (or
  <kbd>Space</kbd>) once. The <code>change</code> event should fire once,
  but it fires twice.
</p>

<p><strong>change events:</strong> {count} &nbsp; <strong>last index:</strong> {lastIndex}</p>

<ProgressIndicator currentIndex={1} on:change={handleChange}>
  <ProgressStep complete label="Step 1" description="First step" />
  <ProgressStep label="Step 2" description="Second step" />
  <ProgressStep label="Step 3" description="Third step" />
</ProgressIndicator>
```