### PR TITLE
feat(fluid-form): add `ref` prop for form reference

### DIFF
--- a/src/FluidForm/FluidForm.svelte
+++ b/src/FluidForm/FluidForm.svelte
@@ -7,6 +7,13 @@
   import Form from "../Form/Form.svelte";
 
   /**
+   * Obtain a reference to the form element.
+   * @type {null | HTMLFormElement}
+   * @bindable readonly
+   */
+  export let ref = null;
+
+  /**
    * Context published under the key `"carbon:Form"` for descendant inputs.
    * Custom fluid-aware inputs can subscribe with:
    * `const ctx = getContext("carbon:Form");`
@@ -19,6 +26,7 @@
 </script>
 
 <Form
+  bind:ref
   {...$$restProps}
   class={["bx--form--fluid", $$restProps.class].filter(Boolean).join(" ")}
   on:click

--- a/tests/FluidForm/FluidForm.test.svelte
+++ b/tests/FluidForm/FluidForm.test.svelte
@@ -7,9 +7,13 @@
   } from "carbon-components-svelte";
 
   export let preventDefault = false;
+  export let onRef: (ref: null | HTMLFormElement) => void = () => {};
+  let ref: null | HTMLFormElement = null;
+  $: onRef(ref);
 </script>
 
 <FluidForm
+  bind:ref
   data-testid="fluid-form"
   on:submit={(e) => {
     if (preventDefault) {

--- a/tests/FluidForm/FluidForm.test.ts
+++ b/tests/FluidForm/FluidForm.test.ts
@@ -10,6 +10,20 @@ describe("FluidForm", () => {
     expect(form).toHaveClass("bx--form--fluid");
   });
 
+  it("exposes ref to the underlying form element", () => {
+    let captured: null | HTMLFormElement = null;
+    render(FluidFormTest, {
+      onRef: (ref) => {
+        captured = ref;
+      },
+    });
+    const form = screen.getByTestId("fluid-form");
+    expect(captured).toBe(form);
+    expect((captured as unknown as HTMLFormElement | null)?.tagName).toBe(
+      "FORM",
+    );
+  });
+
   it("renders form elements correctly", () => {
     render(FluidFormTest);
 


### PR DESCRIPTION
Allow binding on the `form`.