### PR TITLE
chore(form): remove useless svelte-ignore warnings

### DIFF
--- a/src/Form/Form.svelte
+++ b/src/Form/Form.svelte
@@ -6,8 +6,6 @@
   export let ref = null;
 </script>
 
-<!-- svelte-ignore a11y-mouse-events-have-key-events -->
-<!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
 <form
   class:bx--form={true}
   bind:this={ref}


### PR DESCRIPTION
Svelte Check does not flag warnings for Svelte 3/4/5.