### PR TITLE
refactor(radio-button): trim unused fields from group `add` payload

### DIFF
--- a/src/RadioButton/RadioButton.svelte
+++ b/src/RadioButton/RadioButton.svelte
@@ -129,7 +129,7 @@
   }
 
   if (add) {
-    add({ id, checked, disabled, value });
+    add({ checked, value });
   }
 
   // Only sync checked when inside RadioButtonGroup.


### PR DESCRIPTION
The group's `add` only reads `checked`/`value`; passing `id` and `disabled` was dead payload that misled readers about what the group tracks.