### PR TITLE
chore(radio-button-group): make `readonly` reactive across context

### DIFF
--- a/src/RadioButton/RadioButton.svelte
+++ b/src/RadioButton/RadioButton.svelte
@@ -64,7 +64,7 @@
       groupName: readable(undefined),
       groupRequired: readable(undefined),
       selectedValue: readable(checked ? value : undefined),
-      readonly: false,
+      readonly: readable(false),
     };
 
   // Track if we're in standalone mode (no RadioButtonGroup context)
@@ -163,10 +163,10 @@
     on:focus
     on:blur
     on:click={(e) => {
-      if (readonly) e.preventDefault();
+      if ($readonly) e.preventDefault();
     }}
     on:change={(e) => {
-      if (readonly) {
+      if ($readonly) {
         e.stopImmediatePropagation();
         return;
       }

--- a/src/RadioButtonGroup/RadioButtonGroup.svelte
+++ b/src/RadioButtonGroup/RadioButtonGroup.svelte
@@ -84,6 +84,7 @@
   const selectedValue = writable(selected);
   const groupName = writable(name);
   const groupRequired = writable(required);
+  const groupReadonly = writable(readonly);
   let isInitialRender = true;
 
   /**
@@ -107,9 +108,9 @@
     selectedValue,
     groupName: readOnly(groupName),
     groupRequired: readOnly(groupRequired),
+    readonly: readOnly(groupReadonly),
     add,
     update,
-    readonly,
   });
 
   beforeUpdate(() => {
@@ -136,6 +137,7 @@
 
   $: $groupName = name;
   $: $groupRequired = required;
+  $: $groupReadonly = readonly;
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->

--- a/tests/RadioButton/RadioButton.test.ts
+++ b/tests/RadioButton/RadioButton.test.ts
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen } from "@testing-library/svelte";
 import type RadioButtonComponent from "carbon-components-svelte/RadioButton/RadioButton.svelte";
-import type { ComponentProps } from "svelte";
+import { type ComponentProps, tick } from "svelte";
 import { user } from "../utils/user";
 import RadioButton from "./RadioButton.test.svelte";
 import RadioButtonCustom from "./RadioButtonCustom.test.svelte";
@@ -183,6 +183,24 @@ describe("RadioButton", () => {
 
       expect(pro).toBeChecked();
       expect(consoleLog).toHaveBeenCalledWith("change", "2");
+    });
+
+    it("should not change selection when readonly flips to true after mount", async () => {
+      const consoleLog = vi.spyOn(console, "log");
+      const { rerender } = render(RadioButtonGroupReadonly, {
+        selected: "1",
+        readonly: false,
+      });
+
+      await rerender({ selected: "1", readonly: true });
+      await tick();
+
+      const pro = screen.getByRole("radio", { name: "Pro" });
+      await user.click(pro);
+
+      expect(screen.getByRole("radio", { name: "Free" })).toBeChecked();
+      expect(pro).not.toBeChecked();
+      expect(consoleLog).not.toHaveBeenCalledWith("change", "2");
     });
   });
 


### PR DESCRIPTION
`readonly` was passed through `setContext` as a plain boolean snapshot, so child `RadioButton`s never observed prop changes after mount. Share it as a `readable` store and dereference via `$readonly` in handlers.

This isn't a fix since #3019 is not released yet.