### PR TITLE
fix(radio-button-group): unsubscribe from `selectedValue` on destroy

### DIFF
--- a/src/RadioButtonGroup/RadioButtonGroup.svelte
+++ b/src/RadioButtonGroup/RadioButtonGroup.svelte
@@ -112,21 +112,22 @@
     readonly,
   });
 
-  onMount(() => {
-    $selectedValue = selected;
-  });
-
   beforeUpdate(() => {
     if (readonly) return;
     $selectedValue = selected;
   });
 
-  selectedValue.subscribe((value) => {
+  const unsubscribe = selectedValue.subscribe((value) => {
     if (readonly) return;
     selected = value;
     if (!isInitialRender) {
       dispatch("change", value);
     }
+  });
+
+  onMount(() => {
+    $selectedValue = selected;
+    return unsubscribe;
   });
 
   afterUpdate(() => {


### PR DESCRIPTION
Invoke unsubscribe when the component is destroyed to avoid leaks.