### PR TITLE
refactor(radio-button-group): replace `beforeUpdate` with reactive statement

### DIFF
--- a/src/RadioButtonGroup/RadioButtonGroup.svelte
+++ b/src/RadioButtonGroup/RadioButtonGroup.svelte
@@ -70,7 +70,6 @@
 
   import {
     afterUpdate,
-    beforeUpdate,
     createEventDispatcher,
     onMount,
     setContext,
@@ -117,10 +116,7 @@
     update,
   });
 
-  beforeUpdate(() => {
-    if (readonly) return;
-    $selectedValue = selected;
-  });
+  $: if (!readonly) $selectedValue = selected;
 
   const unsubscribe = selectedValue.subscribe((value) => {
     if (readonly) return;

--- a/tests/RadioButton/RadioButton.test.ts
+++ b/tests/RadioButton/RadioButton.test.ts
@@ -202,6 +202,21 @@ describe("RadioButton", () => {
       expect(pro).not.toBeChecked();
       expect(consoleLog).not.toHaveBeenCalledWith("change", "2");
     });
+
+    it("should not propagate external selected updates to children when readonly", async () => {
+      const { component } = render(RadioButtonGroupReadonly, {
+        selected: "1",
+        readonly: true,
+      });
+
+      expect(screen.getByRole("radio", { name: "Free" })).toBeChecked();
+
+      component.selected = "2";
+      await tick();
+
+      expect(screen.getByRole("radio", { name: "Free" })).toBeChecked();
+      expect(screen.getByRole("radio", { name: "Pro" })).not.toBeChecked();
+    });
   });
 
   describe("Generics", () => {

--- a/tests/RadioButton/RadioButtonGroup.readonly.test.svelte
+++ b/tests/RadioButton/RadioButtonGroup.readonly.test.svelte
@@ -1,3 +1,5 @@
+<svelte:options accessors />
+
 <script lang="ts">
   import { RadioButton, RadioButtonGroup } from "carbon-components-svelte";
 

--- a/tests/RadioButtonGroup/RadioButtonGroup.test.ts
+++ b/tests/RadioButtonGroup/RadioButtonGroup.test.ts
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/svelte";
 import type RadioButtonGroupComponent from "carbon-components-svelte/RadioButtonGroup/RadioButtonGroup.svelte";
-import type { ComponentEvents, ComponentProps } from "svelte";
+import { type ComponentEvents, type ComponentProps, tick } from "svelte";
 import { user } from "../utils/user";
 import RadioButtonGroup from "./RadioButtonGroup.test.svelte";
 
@@ -141,6 +141,20 @@ describe("RadioButtonGroup", () => {
     const formItem = fieldset.closest(".bx--form-item");
     assert(formItem);
     expect(formItem).toHaveClass("custom-group");
+  });
+
+  it("should propagate external selected updates to child radios", async () => {
+    const { component } = render(RadioButtonGroup, {
+      props: { selected: "1" },
+    });
+
+    expect(screen.getByRole("radio", { name: "Option 1" })).toBeChecked();
+
+    component.selected = "3";
+    await tick();
+
+    expect(screen.getByRole("radio", { name: "Option 3" })).toBeChecked();
+    expect(screen.getByRole("radio", { name: "Option 1" })).not.toBeChecked();
   });
 
   it("should update selected value on radio change", async () => {


### PR DESCRIPTION
The lifecycle hook ran on every reactive tick to mirror `selected` into the context store; a `$:` statement expresses the same prop→store sync more idiomatically while preserving the `readonly` guard. `beforeUpdate` is also a deprecrated lifecycle method.