### PR TITLE
chore(radio-button): suppress forwarded `on:change` when readonly

### DIFF
--- a/src/RadioButton/RadioButton.svelte
+++ b/src/RadioButton/RadioButton.svelte
@@ -162,13 +162,12 @@
     class:bx--radio-button={true}
     on:focus
     on:blur
-    on:change
     on:click={(e) => {
       if (readonly) e.preventDefault();
     }}
     on:change={(e) => {
       if (readonly) {
-        e.preventDefault();
+        e.stopImmediatePropagation();
         return;
       }
       if (update) {
@@ -183,6 +182,7 @@
         checked = e.currentTarget.checked;
       }
     }}
+    on:change
   >
   <label class:bx--radio-button__label={true} for={id}>
     <span class:bx--radio-button__appearance={true}></span>

--- a/tests/RadioButton/RadioButton.test.ts
+++ b/tests/RadioButton/RadioButton.test.ts
@@ -1,10 +1,11 @@
-import { render, screen } from "@testing-library/svelte";
+import { fireEvent, render, screen } from "@testing-library/svelte";
 import type RadioButtonComponent from "carbon-components-svelte/RadioButton/RadioButton.svelte";
 import type { ComponentProps } from "svelte";
 import { user } from "../utils/user";
 import RadioButton from "./RadioButton.test.svelte";
 import RadioButtonCustom from "./RadioButtonCustom.test.svelte";
 import RadioButtonGroupReadonly from "./RadioButtonGroup.readonly.test.svelte";
+import RadioButtonReadonlyChange from "./RadioButtonReadonlyChange.test.svelte";
 
 describe("RadioButton", () => {
   it("should render with default props", () => {
@@ -161,6 +162,16 @@ describe("RadioButton", () => {
       expect(pro).not.toBeChecked();
       expect(screen.getByRole("radio", { name: "Free" })).toBeChecked();
       expect(consoleLog).not.toHaveBeenCalledWith("change", "2");
+    });
+
+    it("should not forward a child RadioButton's on:change when the group is readonly", async () => {
+      const consoleLog = vi.spyOn(console, "log");
+      render(RadioButtonReadonlyChange);
+
+      const pro = screen.getByRole("radio", { name: "Pro" });
+      await fireEvent.change(pro);
+
+      expect(consoleLog).not.toHaveBeenCalledWith("radio-change", "2");
     });
 
     it("should allow selection when readonly is false", async () => {

--- a/tests/RadioButton/RadioButtonReadonlyChange.test.svelte
+++ b/tests/RadioButton/RadioButtonReadonlyChange.test.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+  import { RadioButton, RadioButtonGroup } from "carbon-components-svelte";
+</script>
+
+<RadioButtonGroup legendText="Plan" readonly selected="1">
+  <RadioButton labelText="Free" value="1" />
+  <RadioButton
+    labelText="Pro"
+    value="2"
+    on:change={() => console.log("radio-change", "2")}
+  />
+</RadioButtonGroup>


### PR DESCRIPTION
Forwarded `on:change` ran before the readonly guard due to source order, and native radio `change` is not cancelable. Reorder so the guard runs first and use `stopImmediatePropagation` to block forward.

This isn't a fix since https://github.com/carbon-design-system/carbon-components-svelte/pull/3019 is not released yet.