### PR TITLE
fix(selectable-tile): set `aria-disabled` for disabled state

### DIFF
--- a/src/Tile/SelectableTile.svelte
+++ b/src/Tile/SelectableTile.svelte
@@ -101,6 +101,7 @@
 <label
   for={id}
   tabindex={disabled ? undefined : tabindex}
+  aria-disabled={disabled || undefined}
   class:bx--tile={true}
   class:bx--tile--selectable={true}
   class:bx--tile--is-selected={selected}

--- a/tests/Tile/SelectableTile.test.ts
+++ b/tests/Tile/SelectableTile.test.ts
@@ -26,6 +26,14 @@ describe("SelectableTile", () => {
     render(SelectableTileTest, { disabled: true });
     const tile = screen.getByTestId("selectable-tile");
     expect(tile).toHaveClass("bx--tile--disabled");
+    expect(tile).toHaveAttribute("aria-disabled", "true");
+    expect(tile).not.toHaveAttribute("tabindex");
+  });
+
+  it("omits aria-disabled when enabled", () => {
+    render(SelectableTileTest);
+    const tile = screen.getByTestId("selectable-tile");
+    expect(tile).not.toHaveAttribute("aria-disabled");
   });
 
   it("renders with custom title and value", () => {


### PR DESCRIPTION
The focusable `<label>` had no disabled signal for assistive tech, so screen readers announced the visible control as enabled even though the underlying `<input>` was disabled.