### PR TITLE
feat(selectable-tile-group): add `hideLegend` prop

### DIFF
--- a/docs/src/pages/components/SelectableTile.svx
+++ b/docs/src/pages/components/SelectableTile.svx
@@ -36,6 +36,22 @@ Bind to the `selected` prop for simpler state management.
 
 <FileSource src="/framed/SelectableTile/SelectableTileReactive" />
 
+## Hidden legend
+
+Visually hide the legend while maintaining accessibility.
+
+<SelectableTileGroup hideLegend legendText="Select options" name="options-hidden-legend" selected={["option1"]}>
+  <SelectableTile value="option1">
+    Multi-select Tile
+  </SelectableTile>
+  <SelectableTile value="option2">
+    Multi-select Tile
+  </SelectableTile>
+  <SelectableTile value="option3">
+    Multi-select Tile
+  </SelectableTile>
+</SelectableTileGroup>
+
 ## Light variant
 
 Use the light variant for light backgrounds.

--- a/src/Tile/SelectableTileGroup.svelte
+++ b/src/Tile/SelectableTileGroup.svelte
@@ -33,6 +33,9 @@
    */
   export let legendText = "";
 
+  /** Set to `true` to visually hide the legend */
+  export let hideLegend = false;
+
   import { createEventDispatcher, setContext } from "svelte";
   import { readonly, writable } from "svelte/store";
 
@@ -90,7 +93,7 @@
 
 <fieldset {disabled} class:bx--tile-group={true} {...$$restProps}>
   {#if legendText || $$slots.legendChildren}
-    <legend class:bx--label={true}>
+    <legend class:bx--label={true} class:bx--visually-hidden={hideLegend}>
       <slot name="legendChildren">{legendText}</slot>
     </legend>
   {/if}

--- a/tests/Tile/SelectableTileGroup.test.svelte
+++ b/tests/Tile/SelectableTileGroup.test.svelte
@@ -11,6 +11,7 @@
   export let disabled: ComponentProps<SelectableTileGroup>["disabled"] = false;
   export let name: ComponentProps<SelectableTileGroup>["name"] = undefined;
   export let legendText: ComponentProps<SelectableTileGroup>["legendText"] = "";
+  export let hideLegend: ComponentProps<SelectableTileGroup>["hideLegend"] = false;
   export let customClass = "";
 </script>
 
@@ -19,6 +20,7 @@
   {disabled}
   {name}
   {legendText}
+  {hideLegend}
   class={customClass}
   on:select={(e) => {
     console.log("select", e.detail);

--- a/tests/Tile/SelectableTileGroup.test.ts
+++ b/tests/Tile/SelectableTileGroup.test.ts
@@ -27,6 +27,15 @@ describe("SelectableTileGroup", () => {
     expect(screen.getByText("Select options")).toHaveClass("bx--label");
   });
 
+  it("should hide legend visually", () => {
+    render(SelectableTileGroup, {
+      props: { legendText: "Legend", hideLegend: true },
+    });
+
+    const legend = screen.getByText("Legend");
+    expect(legend).toHaveClass("bx--visually-hidden");
+  });
+
   it("should handle disabled state", () => {
     render(SelectableTileGroup, { props: { disabled: true } });
 


### PR DESCRIPTION
For parity with CheckboxGroup, RadioButtonGroup, add a prop to visually hide the label.