### PR TITLE
fix(selectable-tile): re-register with group when value changes

### DIFF
--- a/src/Tile/SelectableTile.svelte
+++ b/src/Tile/SelectableTile.svelte
@@ -56,6 +56,7 @@
   const hasGroup = ctx !== undefined;
   const {
     add = () => {},
+    remove = () => {},
     update = () => {},
     selectedValues = readable([]),
     groupName = readable(undefined),
@@ -63,7 +64,14 @@
 
   add({ value, selected });
 
+  let prevValue = value;
+
   $: if (hasGroup) {
+    if (value !== prevValue) {
+      remove(prevValue);
+      add({ value, selected });
+      prevValue = value;
+    }
     selected = $selectedValues.includes(value);
   }
 </script>

--- a/src/Tile/SelectableTileGroup.svelte
+++ b/src/Tile/SelectableTileGroup.svelte
@@ -60,6 +60,15 @@
   };
 
   /**
+   * @type {(value: T) => void}
+   */
+  const remove = (value) => {
+    if ($selectedValues.includes(value)) {
+      selectedValues.update((values) => values.filter((v) => v !== value));
+    }
+  };
+
+  /**
    * @type {(data: { value: T; selected: boolean }) => void}
    */
   const update = ({ value, selected: isSelected }) => {
@@ -80,6 +89,7 @@
     selectedValues,
     groupName: groupNameReadonly,
     add,
+    remove,
     update,
   });
 

--- a/tests/Tile/SelectableTileGroup.test.ts
+++ b/tests/Tile/SelectableTileGroup.test.ts
@@ -1,8 +1,9 @@
 import { render, screen } from "@testing-library/svelte";
 import type SelectableTileGroupComponent from "carbon-components-svelte/Tile/SelectableTileGroup.svelte";
-import type { ComponentEvents, ComponentProps } from "svelte";
+import { type ComponentEvents, type ComponentProps, tick } from "svelte";
 import { user } from "../utils/user";
 import SelectableTileGroup from "./SelectableTileGroup.test.svelte";
+import SelectableTileGroupReactive from "./SelectableTileGroupReactive.test.svelte";
 
 describe("SelectableTileGroup", () => {
   beforeEach(() => {
@@ -192,6 +193,20 @@ describe("SelectableTileGroup", () => {
     await user.click(tiles[2]);
 
     expect(component.selected).toHaveLength(0);
+  });
+
+  it("should re-register with group when tile value changes after mount", async () => {
+    const { component } = render(SelectableTileGroupReactive, {
+      props: { tileValue: "a", tileSelected: true },
+    });
+
+    await tick();
+    expect(component.groupSelected).toEqual(["a"]);
+
+    component.tileValue = "b";
+    await tick();
+
+    expect(component.groupSelected).toEqual(["b"]);
   });
 
   describe("Generics", () => {

--- a/tests/Tile/SelectableTileGroupReactive.test.svelte
+++ b/tests/Tile/SelectableTileGroupReactive.test.svelte
@@ -1,0 +1,18 @@
+<svelte:options accessors />
+
+<script lang="ts">
+  import {
+    SelectableTile,
+    SelectableTileGroup,
+  } from "carbon-components-svelte";
+
+  export let groupSelected: string[] = [];
+  export let tileValue = "a";
+  export let tileSelected = true;
+</script>
+
+<SelectableTileGroup bind:selected={groupSelected}>
+  <SelectableTile value={tileValue} selected={tileSelected}>
+    Dynamic
+  </SelectableTile>
+</SelectableTileGroup>


### PR DESCRIPTION
Reactive `value` updates left the parent `SelectableTileGroup`'s `selectedValues` referencing the stale value. Track `prevValue` and expose a `remove` action on the group context to evict the old value before re-adding under the new one.