### PR TITLE
docs(preview): remove iframe `sandbox` attribute

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -98,7 +98,6 @@
       },
       "nursery": {
         "useFind": "error",
-        "useIframeSandbox": "error",
         "noForIn": "error",
         "noFloatingPromises": "error"
       }

--- a/docs/src/components/Preview.svelte
+++ b/docs/src/components/Preview.svelte
@@ -42,7 +42,6 @@
         loading="lazy"
         title={src.split("/").pop()}
         src={themedSrcUrl}
-        sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
       ></iframe>
     {:else}
       <slot />


### PR DESCRIPTION
Chrome warns that `allow-scripts` + `allow-same-origin` defeats the sandbox, but `allow-same-origin` is required for examples that touch `localStorage`. Since the iframe loads trusted same-origin content, drop the sandbox entirely.