### PR TITLE
fix(pagination-nav): announce current page as 1-based in live region

### DIFF
--- a/src/PaginationNav/PaginationNav.svelte
+++ b/src/PaginationNav/PaginationNav.svelte
@@ -188,6 +188,6 @@
     aria-atomic="true"
     class:bx--pagination-nav__accessibility-label={true}
   >
-    Page {page + 1}{" of "}{total}
+    Page {page}{" of "}{total}
   </div>
 </nav>

--- a/tests/PaginationNav/PaginationNav.test.ts
+++ b/tests/PaginationNav/PaginationNav.test.ts
@@ -138,6 +138,19 @@ describe("PaginationNav", () => {
     expect(consoleLog).toHaveBeenCalledWith("change", { page: 2 });
   });
 
+  it("should announce current 1-based page in the live region", async () => {
+    render(PaginationNav, { props: { page: 1, total: 10 } });
+    expect(screen.getByText("Page 1 of 10")).toBeInTheDocument();
+
+    const nextButton = screen.getByRole("button", { name: "Next page" });
+    await user.click(nextButton);
+    expect(screen.getByText("Page 2 of 10")).toBeInTheDocument();
+
+    const prevButton = screen.getByRole("button", { name: "Previous page" });
+    await user.click(prevButton);
+    expect(screen.getByText("Page 1 of 10")).toBeInTheDocument();
+  });
+
   it("should handle overflow selection", async () => {
     const consoleLog = vi.spyOn(console, "log");
     render(PaginationNav, {


### PR DESCRIPTION
Fixes an off-by-1 error; the `aria-live` label rendered `page + 1`, but `page` is already 1-based everywhere else in the component, so screen readers announced "Page 2 of 10" when on page 1.