### PR TITLE
fix(pagination-nav): label active middle page with "Active, Page"

### DIFF
--- a/src/PaginationNav/PaginationNav.svelte
+++ b/src/PaginationNav/PaginationNav.svelte
@@ -136,7 +136,7 @@
           dispatch("change", { page });
         }}
       >
-        {page === item ? "Active, Page" : "Page"}
+        {page === item + 1 ? "Active, Page" : "Page"}
       </PaginationItem>
     {/each}
     <PaginationOverflow

--- a/tests/PaginationNav/PaginationNav.test.ts
+++ b/tests/PaginationNav/PaginationNav.test.ts
@@ -151,6 +151,16 @@ describe("PaginationNav", () => {
     expect(screen.getByText("Page 1 of 10")).toBeInTheDocument();
   });
 
+  it("should announce active middle page with 'Active, Page' label", () => {
+    render(PaginationNav, {
+      props: { page: 3, total: 5 },
+    });
+
+    const activeButton = screen.getByRole("button", { current: "page" });
+    expect(activeButton).toHaveAttribute("data-page", "3");
+    expect(within(activeButton).getByText("Active, Page")).toBeInTheDocument();
+  });
+
   it("should handle overflow selection", async () => {
     const consoleLog = vi.spyOn(console, "log");
     render(PaginationNav, {


### PR DESCRIPTION
Similar fix to #3070; the slot compared `page === item` while sibling props use `item + 1`, so the active middle item never matched and announced only "Page".