### PR TITLE
fix(tag): `SelectableTag` uses `aria-pressed` instead of `aria-checked`

### DIFF
--- a/src/Tag/SelectableTag.svelte
+++ b/src/Tag/SelectableTag.svelte
@@ -46,8 +46,7 @@
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <button
   type="button"
-  role="checkbox"
-  aria-checked={selected}
+  aria-pressed={selected}
   {id}
   {disabled}
   aria-disabled={disabled}

--- a/tests/Tag/SelectableTag.test.svelte
+++ b/tests/Tag/SelectableTag.test.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+  import { SelectableTag } from "carbon-components-svelte";
+</script>
+
+<SelectableTag>Default</SelectableTag>
+
+<SelectableTag selected>Preselected</SelectableTag>
+
+<SelectableTag disabled>Disabled</SelectableTag>

--- a/tests/Tag/SelectableTag.test.ts
+++ b/tests/Tag/SelectableTag.test.ts
@@ -1,0 +1,27 @@
+import { render, screen } from "@testing-library/svelte";
+import { user } from "../utils/user";
+import SelectableTag from "./SelectableTag.test.svelte";
+
+describe("SelectableTag", () => {
+  it("exposes the selected state via aria-pressed and toggles on click", async () => {
+    render(SelectableTag);
+
+    const tag = screen.getByRole("button", { name: "Default" });
+    expect(tag).toHaveAttribute("aria-pressed", "false");
+    expect(tag).not.toHaveAttribute("role", "checkbox");
+    expect(tag).not.toHaveAttribute("aria-checked");
+
+    await user.click(tag);
+    expect(tag).toHaveAttribute("aria-pressed", "true");
+
+    await user.click(tag);
+    expect(tag).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("reflects an initially `selected` prop on aria-pressed", () => {
+    render(SelectableTag);
+
+    const tag = screen.getByRole("button", { name: "Preselected" });
+    expect(tag).toHaveAttribute("aria-pressed", "true");
+  });
+});


### PR DESCRIPTION
For parity with the upstream React version, use `aria-pressed` (toggle button semantics) instead of `aria-checked`.

Also adds tests, for which #2769 did not include any.