### PR TITLE
fix(progress-bar): associate label via `aria-labelledby`

### DIFF
--- a/src/ProgressBar/ProgressBar.svelte
+++ b/src/ProgressBar/ProgressBar.svelte
@@ -72,8 +72,8 @@
   class:bx--progress-bar--finished={status === "finished"}
   {...$$restProps}
 >
-  <label
-    for={id}
+  <div
+    id="{id}-label"
     class:bx--progress-bar__label={true}
     class:bx--visually-hidden={hideLabel}
   >
@@ -84,12 +84,13 @@
         class="bx--progress-bar__status-icon"
       />
     {/if}
-  </label>
+  </div>
   <div
     role="progressbar"
     {id}
     class:bx--progress-bar__track={true}
     aria-busy={status === "active"}
+    aria-labelledby="{id}-label"
     aria-valuemin={indeterminate ? undefined : 0}
     aria-valuemax={indeterminate ? undefined : max}
     aria-valuenow={indeterminate ? undefined : capped}

--- a/tests/ProgressBar/ProgressBar.test.ts
+++ b/tests/ProgressBar/ProgressBar.test.ts
@@ -84,6 +84,18 @@ describe("ProgressBar", () => {
     expect(underZero).toHaveAttribute("aria-valuenow", "0");
   });
 
+  it("associates the label with the progressbar via aria-labelledby", () => {
+    render(ProgressBar);
+
+    const progressBar = within(screen.getByTestId("progress-40%")).getByRole(
+      "progressbar",
+    );
+    const label = screen.getByText("Progress 40%");
+    expect(progressBar).toHaveAttribute("aria-labelledby", label.id);
+    expect(label).toHaveClass("bx--progress-bar__label");
+    expect(progressBar).not.toHaveAttribute("for");
+  });
+
   it("supports custom label slot", () => {
     render(ProgressBarSlot);
 


### PR DESCRIPTION
`<label for>` only binds to native form controls, so the `<div role="progressbar">` was effectively unlabeled for assistive tech. Switch the label to a `<div>` and reference it from the track via `aria-labelledby`, matching the React Carbon markup.