### PR TITLE
fix(selectable-tile): announce label as checkbox to screen readers

### DIFF
--- a/src/Tile/SelectableTile.svelte
+++ b/src/Tile/SelectableTile.svelte
@@ -101,6 +101,8 @@
 <label
   for={id}
   tabindex={disabled ? undefined : tabindex}
+  role="checkbox"
+  aria-checked={selected}
   aria-disabled={disabled || undefined}
   class:bx--tile={true}
   class:bx--tile--selectable={true}

--- a/tests/Tile/SelectableTile.test.ts
+++ b/tests/Tile/SelectableTile.test.ts
@@ -37,26 +37,41 @@ describe("SelectableTile", () => {
   });
 
   it("renders with custom title and value", () => {
-    render(SelectableTileTest, {
+    const { container } = render(SelectableTileTest, {
       title: "Custom Title",
       value: "custom-value",
     });
-    const input = screen.getByRole("checkbox");
+    const input = container.querySelector('input[type="checkbox"]');
     expect(input).toHaveAttribute("title", "Custom Title");
     expect(input).toHaveAttribute("value", "custom-value");
   });
 
   it("renders with custom name and icon description", () => {
-    render(SelectableTileTest, {
+    const { container } = render(SelectableTileTest, {
       name: "custom-name",
       iconDescription: "Custom checkmark",
     });
 
-    const input = screen.getByRole("checkbox");
+    const input = container.querySelector('input[type="checkbox"]');
     expect(input).toHaveAttribute("name", "custom-name");
 
     const icon = screen.getByTestId("selectable-tile").querySelector("svg");
     expect(icon).toHaveAttribute("aria-label", "Custom checkmark");
+  });
+
+  it("exposes checkbox semantics on the focusable label", () => {
+    render(SelectableTileTest);
+    const tile = screen.getByTestId("selectable-tile");
+    expect(tile).toHaveAttribute("role", "checkbox");
+    expect(tile).toHaveAttribute("aria-checked", "false");
+    expect(tile).not.toHaveAttribute("aria-disabled");
+  });
+
+  it("reflects selected and disabled state in ARIA attributes", () => {
+    render(SelectableTileTest, { selected: true, disabled: true });
+    const tile = screen.getByTestId("selectable-tile");
+    expect(tile).toHaveAttribute("aria-checked", "true");
+    expect(tile).toHaveAttribute("aria-disabled", "true");
   });
 
   describe("interaction", () => {

--- a/tests/Tile/SelectableTileGroup.test.ts
+++ b/tests/Tile/SelectableTileGroup.test.ts
@@ -10,13 +10,13 @@ describe("SelectableTileGroup", () => {
   });
 
   it("should render with default props", () => {
-    render(SelectableTileGroup);
+    const { container } = render(SelectableTileGroup);
 
     const fieldset = screen.getByRole("group");
     expect(fieldset).toHaveClass("bx--tile-group");
     expect(fieldset).not.toBeDisabled();
 
-    const checkboxes = screen.getAllByRole("checkbox");
+    const checkboxes = container.querySelectorAll('input[type="checkbox"]');
     expect(checkboxes).toHaveLength(3);
   });
 
@@ -37,32 +37,36 @@ describe("SelectableTileGroup", () => {
   });
 
   it("should handle disabled state", () => {
-    render(SelectableTileGroup, { props: { disabled: true } });
+    const { container } = render(SelectableTileGroup, {
+      props: { disabled: true },
+    });
 
     const fieldset = screen.getByRole("group");
     expect(fieldset).toBeDisabled();
 
-    const checkboxes = screen.getAllByRole("checkbox");
+    const checkboxes = container.querySelectorAll('input[type="checkbox"]');
     for (const checkbox of checkboxes) {
       expect(checkbox).toBeDisabled();
     }
   });
 
   it("should handle custom name", () => {
-    render(SelectableTileGroup, { props: { name: "custom-group" } });
+    const { container } = render(SelectableTileGroup, {
+      props: { name: "custom-group" },
+    });
 
-    const checkboxes = screen.getAllByRole("checkbox");
+    const checkboxes = container.querySelectorAll('input[type="checkbox"]');
     for (const checkbox of checkboxes) {
       expect(checkbox).toHaveAttribute("name", "custom-group");
     }
   });
 
   it("should handle initial selected values", () => {
-    render(SelectableTileGroup, {
+    const { container } = render(SelectableTileGroup, {
       props: { selected: ["option1", "option3"] },
     });
 
-    const checkboxes = screen.getAllByRole("checkbox");
+    const checkboxes = container.querySelectorAll('input[type="checkbox"]');
     expect(checkboxes[0]).toBeChecked();
     expect(checkboxes[1]).not.toBeChecked();
     expect(checkboxes[2]).toBeChecked();
@@ -130,12 +134,12 @@ describe("SelectableTileGroup", () => {
   });
 
   it("should handle programmatic selected value changes", async () => {
-    const { component } = render(SelectableTileGroup);
+    const { component, container } = render(SelectableTileGroup);
 
     component.selected = ["option2"];
     await new Promise((resolve) => setTimeout(resolve, 0));
 
-    const checkboxes = screen.getAllByRole("checkbox");
+    const checkboxes = container.querySelectorAll('input[type="checkbox"]');
     expect(checkboxes[0]).not.toBeChecked();
     expect(checkboxes[1]).toBeChecked();
     expect(checkboxes[2]).not.toBeChecked();
@@ -181,9 +185,11 @@ describe("SelectableTileGroup", () => {
   });
 
   it("should handle empty selected array", () => {
-    render(SelectableTileGroup, { props: { selected: [] } });
+    const { container } = render(SelectableTileGroup, {
+      props: { selected: [] },
+    });
 
-    const checkboxes = screen.getAllByRole("checkbox");
+    const checkboxes = container.querySelectorAll('input[type="checkbox"]');
     for (const checkbox of checkboxes) {
       expect(checkbox).not.toBeChecked();
     }


### PR DESCRIPTION
Aligns `SelectableTile` a11y closer to the upstream React implementation. The focusable `<label>` had no checkbox semantics, so assistive tech announced it as plain text. Add `role="checkbox"`, `aria-checked`, and `aria-disabled` so the focused element exposes its state.