### PR TITLE
refactor(selectable-tile): standardize context guard idiom

### DIFF
--- a/src/Tile/SelectableTile.svelte
+++ b/src/Tile/SelectableTile.svelte
@@ -54,13 +54,11 @@
 
   const ctx = getContext("carbon:SelectableTileGroup");
   const hasGroup = ctx !== undefined;
-  const {
-    add = () => {},
-    remove = () => {},
-    update = () => {},
-    selectedValues = readable([]),
-    groupName = readable(undefined),
-  } = ctx ?? {};
+  const add = ctx?.add ?? (() => {});
+  const remove = ctx?.remove ?? (() => {});
+  const update = ctx?.update ?? (() => {});
+  const selectedValues = ctx?.selectedValues ?? readable([]);
+  const groupName = ctx?.groupName ?? readable(undefined);
 
   add({ value, selected });
 

--- a/tests/Tile/SelectableTile.test.ts
+++ b/tests/Tile/SelectableTile.test.ts
@@ -1,8 +1,13 @@
 import { render, screen } from "@testing-library/svelte";
 import { user } from "../utils/user";
 import SelectableTileTest from "./SelectableTile.test.svelte";
+import SelectableTileStandalone from "./SelectableTileStandalone.test.svelte";
 
 describe("SelectableTile", () => {
+  it("does not throw when rendered outside a SelectableTileGroup", () => {
+    expect(() => render(SelectableTileStandalone)).not.toThrow();
+  });
+
   it("renders with default props", () => {
     render(SelectableTileTest);
     const tile = screen.getByTestId("selectable-tile");

--- a/tests/Tile/SelectableTileStandalone.test.svelte
+++ b/tests/Tile/SelectableTileStandalone.test.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+  import { SelectableTile } from "carbon-components-svelte";
+</script>
+
+<SelectableTile value="standalone-value" name="solo">Standalone</SelectableTile>


### PR DESCRIPTION
Match the per-field `ctx?.x ?? fallback` pattern from other components that use context.