### PR TITLE
refactor(checkbox-group): dedupe `disabled` propagation

### DIFF
--- a/src/Checkbox/Checkbox.svelte
+++ b/src/Checkbox/Checkbox.svelte
@@ -80,14 +80,12 @@
   const selectedValues = ctx?.selectedValues ?? readable([]);
   const groupName = ctx?.groupName ?? readable(undefined);
   const groupRequired = ctx?.groupRequired ?? readable(undefined);
-  const groupDisabled = ctx?.groupDisabled ?? readable(false);
   const ctxUpdate = ctx?.update;
 
   $: useGroup = !ctx && Array.isArray(group);
   $: if (ctx) checked = $selectedValues.includes(value);
   $: if (useGroup) checked = group.includes(value);
 
-  $: effectiveDisabled = ctx ? $groupDisabled || disabled : disabled;
   $: effectiveName = ctx ? ($groupName ?? name) : name;
   $: effectiveRequired = ctx ? ($groupRequired ?? required) : required;
 
@@ -134,7 +132,7 @@
       type="checkbox"
       {value}
       {checked}
-      disabled={effectiveDisabled}
+      {disabled}
       {id}
       bind:indeterminate
       name={effectiveName}

--- a/src/Checkbox/CheckboxGroup.svelte
+++ b/src/Checkbox/CheckboxGroup.svelte
@@ -68,7 +68,6 @@
   const selectedValues = writable(selected);
   const groupName = writable(name);
   const groupRequired = writable(required);
-  const groupDisabled = writable(disabled);
   let isInitialRender = true;
   let isSyncingSelected = false;
 
@@ -94,7 +93,6 @@
     selectedValues,
     groupName: readonly(groupName),
     groupRequired: readonly(groupRequired),
-    groupDisabled: readonly(groupDisabled),
     update,
   });
 
@@ -118,7 +116,6 @@
 
   $: $groupName = name;
   $: $groupRequired = required;
-  $: $groupDisabled = disabled;
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->

--- a/tests/Checkbox/CheckboxGroupComponent.test.ts
+++ b/tests/Checkbox/CheckboxGroupComponent.test.ts
@@ -74,6 +74,13 @@ describe("CheckboxGroup", () => {
 
     const fieldset = screen.getByRole("group");
     expect(fieldset).toBeDisabled();
+
+    // Native `<fieldset disabled>` propagates to nested inputs; individual
+    // checkboxes should not carry their own `disabled` attribute.
+    for (const checkbox of screen.getAllByRole("checkbox")) {
+      expect(checkbox).toBeDisabled();
+      expect(checkbox).not.toHaveAttribute("disabled");
+    }
   });
 
   it("should handle required state", () => {


### PR DESCRIPTION
Drop the redundant `groupDisabled` context store; `<fieldset disabled>` already propagates to nested inputs natively, matching the existing `RadioButtonGroup` convention.