### PR TITLE
fix(checkbox): associate `helperText` with input via `aria-describedby`

### DIFF
--- a/src/Checkbox/Checkbox.svelte
+++ b/src/Checkbox/Checkbox.svelte
@@ -104,6 +104,7 @@
 
   $: isTruncated = refLabel?.offsetWidth < refLabel?.scrollWidth;
   $: title = !title && isTruncated ? refLabel?.innerText : title;
+  $: helperId = `helper-${id}`;
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
@@ -138,6 +139,7 @@
       name={effectiveName}
       required={effectiveRequired}
       aria-readonly={readonly || undefined}
+      aria-describedby={helperText ? helperId : undefined}
       class:bx--checkbox={true}
       on:click={(e) => {
         if (readonly) {
@@ -178,6 +180,7 @@
     </label>
     {#if helperText}
       <div
+        id={helperId}
         class:bx--form__helper-text={true}
         class:bx--form__helper-text--disabled={disabled}
       >

--- a/src/Checkbox/CheckboxGroup.svelte
+++ b/src/Checkbox/CheckboxGroup.svelte
@@ -101,6 +101,9 @@
 
   $: $groupName = name;
   $: $groupRequired = required;
+
+  const fallbackHelperId = `ccs-${Math.random().toString(36)}`;
+  $: helperId = id ? `helper-${id}` : fallbackHelperId;
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
@@ -114,7 +117,11 @@
   on:mouseenter
   on:mouseleave
 >
-  <fieldset class:bx--checkbox-group={true} {disabled}>
+  <fieldset
+    class:bx--checkbox-group={true}
+    {disabled}
+    aria-describedby={helperText ? helperId : undefined}
+  >
     {#if legendText || $$slots.legendChildren}
       <legend class:bx--label={true} class:bx--visually-hidden={hideLegend}>
         <slot name="legendChildren">{legendText}</slot>
@@ -124,6 +131,7 @@
   </fieldset>
   {#if helperText}
     <div
+      id={helperId}
       class:bx--form__helper-text={true}
       class:bx--form__helper-text--disabled={disabled}
     >

--- a/tests/Checkbox/Checkbox.test.ts
+++ b/tests/Checkbox/Checkbox.test.ts
@@ -506,6 +506,24 @@ describe("Checkbox", () => {
     expect(helperElement).not.toBeInTheDocument();
   });
 
+  it("associates helper text with the input via aria-describedby", () => {
+    render(Checkbox, { helperText: "Helper text message" });
+
+    const input = screen.getByRole("checkbox");
+    const helperId = input.getAttribute("aria-describedby");
+    assert(helperId);
+
+    const helper = document.getElementById(helperId);
+    expect(helper).toHaveTextContent("Helper text message");
+  });
+
+  it("does not set aria-describedby when helper text is absent", () => {
+    render(Checkbox);
+
+    const input = screen.getByRole("checkbox");
+    expect(input).not.toHaveAttribute("aria-describedby");
+  });
+
   describe("Generics", () => {
     it("should support custom types with generics", () => {
       type CustomValue = "option1" | "option2" | "option3";

--- a/tests/Checkbox/CheckboxGroupComponent.test.ts
+++ b/tests/Checkbox/CheckboxGroupComponent.test.ts
@@ -207,6 +207,26 @@ describe("CheckboxGroup", () => {
     expect(helperElement).not.toBeInTheDocument();
   });
 
+  it("associates helper text with the fieldset via aria-describedby", () => {
+    render(CheckboxGroupComponent, {
+      props: { helperText: "Helper text message" },
+    });
+
+    const fieldset = screen.getByRole("group");
+    const helperId = fieldset.getAttribute("aria-describedby");
+    assert(helperId);
+
+    const helper = document.getElementById(helperId);
+    expect(helper).toHaveTextContent("Helper text message");
+  });
+
+  it("does not set aria-describedby on the fieldset when helper text is absent", () => {
+    render(CheckboxGroupComponent);
+
+    const fieldset = screen.getByRole("group");
+    expect(fieldset).not.toHaveAttribute("aria-describedby");
+  });
+
   it("should support multiple selections", async () => {
     const consoleLog = vi.spyOn(console, "log");
     render(CheckboxGroupComponent);


### PR DESCRIPTION
`helperText` rendered without an id meant screen readers never announced it on focus. Wire it on `Checkbox`'s `<input>` and on `CheckboxGroup`'s `<fieldset>` so all nested checkboxes inherit the description.