### PR TITLE
fix(checkbox): preserve consumer-provided `title` and avoid prop mutation

### DIFF
--- a/src/Checkbox/Checkbox.svelte
+++ b/src/Checkbox/Checkbox.svelte
@@ -105,7 +105,7 @@
   let refLabel = null;
 
   $: isTruncated = refLabel?.offsetWidth < refLabel?.scrollWidth;
-  $: title = !title && isTruncated ? refLabel?.innerText : title;
+  $: computedTitle = title ?? (isTruncated ? refLabel?.innerText : undefined);
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
@@ -169,7 +169,7 @@
       on:focus
       on:blur
     >
-    <label for={id} {title} class:bx--checkbox-label={true}>
+    <label for={id} title={computedTitle} class:bx--checkbox-label={true}>
       <span
         bind:this={refLabel}
         class:bx--checkbox-label-text={true}

--- a/tests/Checkbox/Checkbox.test.ts
+++ b/tests/Checkbox/Checkbox.test.ts
@@ -11,6 +11,7 @@ import Checkbox from "./Checkbox.test.svelte";
 import CheckboxGroupEvents from "./CheckboxGroupEvents.test.svelte";
 import CheckboxGroupReactive from "./CheckboxGroupReactive.test.svelte";
 import CheckboxReactiveBind from "./CheckboxReactiveBind.test.svelte";
+import CheckboxTitleTruncation from "./CheckboxTitleTruncation.test.svelte";
 import MultipleCheckboxes from "./MultipleCheckboxes.test.svelte";
 import MultipleCheckboxesObject from "./MultipleCheckboxesObject.test.svelte";
 
@@ -504,6 +505,35 @@ describe("Checkbox", () => {
     render(Checkbox);
     const helperElement = screen.queryByText("Helper text message");
     expect(helperElement).not.toBeInTheDocument();
+  });
+
+  it("does not overwrite an explicitly-empty title when label is truncated", async () => {
+    const offsetWidthSpy = vi
+      .spyOn(HTMLElement.prototype, "offsetWidth", "get")
+      .mockReturnValue(10);
+    const scrollWidthSpy = vi
+      .spyOn(HTMLElement.prototype, "scrollWidth", "get")
+      .mockReturnValue(100);
+
+    try {
+      render(CheckboxTitleTruncation, {
+        title: "",
+        labelText: "A very long label that should be truncated",
+      });
+      await tick();
+
+      const label = document
+        .querySelector('[data-testid="checkbox-title"]')
+        ?.querySelector("label.bx--checkbox-label");
+      assert(label);
+
+      // The consumer passed title="" deliberately — the component must not
+      // replace it with refLabel.innerText just because truncation triggered.
+      expect(label.getAttribute("title")).toBe("");
+    } finally {
+      offsetWidthSpy.mockRestore();
+      scrollWidthSpy.mockRestore();
+    }
   });
 
   describe("Generics", () => {

--- a/tests/Checkbox/CheckboxTitleTruncation.test.svelte
+++ b/tests/Checkbox/CheckboxTitleTruncation.test.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+  import { Checkbox } from "carbon-components-svelte";
+
+  export let title: string | undefined = undefined;
+  export let labelText = "Checkbox label";
+</script>
+
+<Checkbox {title} {labelText} data-testid="checkbox-title" />


### PR DESCRIPTION
Computed `title` via a derived local instead of overwriting the exported prop. Previous reactive overwrote a deliberately-empty `title=""` once truncation triggered and could not refresh later.