### PR TITLE
fix(checkbox): prevent forwarded `change` event when `readonly`

### DIFF
--- a/src/Checkbox/Checkbox.svelte
+++ b/src/Checkbox/Checkbox.svelte
@@ -146,7 +146,7 @@
       }}
       on:change={(event) => {
         if (readonly) {
-          event.preventDefault();
+          event.stopImmediatePropagation();
           return;
         }
         if (ctxUpdate) {

--- a/tests/Checkbox/Checkbox.readonly.test.svelte
+++ b/tests/Checkbox/Checkbox.readonly.test.svelte
@@ -10,4 +10,5 @@
   {readonly}
   labelText="Readonly checkbox test"
   data-testid="checkbox"
+  on:change={() => console.log("change")}
 />

--- a/tests/Checkbox/Checkbox.test.ts
+++ b/tests/Checkbox/Checkbox.test.ts
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/svelte";
+import { fireEvent, render, screen } from "@testing-library/svelte";
 import type CheckboxComponent from "carbon-components-svelte/Checkbox/Checkbox.svelte";
 import type { ComponentProps } from "svelte";
 import { tick } from "svelte";
@@ -481,6 +481,21 @@ describe("Checkbox", () => {
 
     await user.click(input);
     expect(input).toBeChecked();
+  });
+
+  it("does not forward change event when readonly", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(CheckboxReadonly, { checked: false, readonly: true });
+
+    const input = screen.getByRole("checkbox");
+    consoleLog.mockClear();
+
+    await fireEvent.change(input);
+
+    const changeCalls = consoleLog.mock.calls.filter(
+      (call) => call[0] === "change",
+    );
+    expect(changeCalls).toHaveLength(0);
   });
 
   it("allows state change when not readonly", async () => {


### PR DESCRIPTION
`change` events are not cancelable, so the inline `preventDefault` was a no-op and the forwarded `on:change` still leaked to consumers. Use `stopImmediatePropagation` to block the subsequent forwarded listener.

This achieves parity with `RadioButton`.