### PR TITLE
fix(progress-step): do not throw if rendered outside context

### DIFF
--- a/src/ProgressIndicator/ProgressStep.svelte
+++ b/src/ProgressIndicator/ProgressStep.svelte
@@ -27,6 +27,7 @@
   export let id = `ccs-${Math.random().toString(36)}`;
 
   import { getContext, onMount } from "svelte";
+  import { writable } from "svelte/store";
   import CheckmarkOutline from "../icons/CheckmarkOutline.svelte";
   import CircleDash from "../icons/CircleDash.svelte";
   import Incomplete from "../icons/Incomplete.svelte";
@@ -34,9 +35,12 @@
 
   let step = {};
 
-  const { stepsById, add, remove, change, preventChangeOnClick } = getContext(
-    "carbon:ProgressIndicator",
-  );
+  const ctx = getContext("carbon:ProgressIndicator");
+  const stepsById = ctx?.stepsById ?? writable({});
+  const add = ctx?.add ?? (() => {});
+  const remove = ctx?.remove ?? (() => {});
+  const change = ctx?.change ?? (() => {});
+  const preventChangeOnClick = ctx?.preventChangeOnClick ?? writable(false);
 
   $: add({ id, complete, disabled });
 

--- a/tests/ProgressIndicator/ProgressIndicator.test.ts
+++ b/tests/ProgressIndicator/ProgressIndicator.test.ts
@@ -4,6 +4,7 @@ import ProgressIndicator from "./ProgressIndicator.test.svelte";
 import ProgressIndicatorConditional from "./ProgressIndicatorConditional.test.svelte";
 import ProgressIndicatorIssue1249 from "./ProgressIndicatorIssue1249.test.svelte";
 import ProgressIndicatorReactive from "./ProgressIndicatorReactive.test.svelte";
+import ProgressStepStandalone from "./ProgressStepStandalone.test.svelte";
 
 describe("ProgressIndicator", () => {
   describe("Default (horizontal)", () => {
@@ -291,6 +292,11 @@ describe("ProgressIndicator", () => {
       await user.click(screen.getByText("Step 3"));
       expect(consoleLog).toHaveBeenLastCalledWith("change", 1);
     });
+  });
+
+  it("should not throw when ProgressStep is rendered outside a ProgressIndicator", () => {
+    expect(() => render(ProgressStepStandalone)).not.toThrow();
+    expect(screen.getByText("Standalone step")).toBeInTheDocument();
   });
 
   describe("Reactive complete prop (#1249)", () => {

--- a/tests/ProgressIndicator/ProgressStepStandalone.test.svelte
+++ b/tests/ProgressIndicator/ProgressStepStandalone.test.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+  import { ProgressStep } from "carbon-components-svelte";
+</script>
+
+<ProgressStep label="Standalone step" secondaryLabel="Optional" />


### PR DESCRIPTION
`getContext` returns `undefined` when no `ProgressIndicator` ancestor exists; fall back to no-op `add`/`change` and empty writable stores so the `<li>` renders passively instead of throwing on destructure.