### PR TITLE
fix(local-storage,session-storage): drop stray argument from internal `setItem` calls

### DIFF
--- a/src/LocalStorage/LocalStorage.svelte
+++ b/src/LocalStorage/LocalStorage.svelte
@@ -53,6 +53,7 @@
   let prevKey = key;
   let mounted = false;
 
+  /** @type {() => void} */
   function setItem() {
     if (typeof value === "object") {
       localStorage.setItem(key, JSON.stringify(value));
@@ -65,7 +66,7 @@
     const item = localStorage.getItem(key);
 
     if (item == null) {
-      setItem(value);
+      setItem();
       dispatch("save");
     } else {
       try {
@@ -100,7 +101,7 @@
     const item = localStorage.getItem(key);
 
     if (item == null) {
-      setItem(value);
+      setItem();
     } else {
       try {
         value = JSON.parse(item);
@@ -114,7 +115,7 @@
 
   afterUpdate(() => {
     if (prevValue !== value) {
-      setItem(value);
+      setItem();
       dispatch("update", { prevValue, value });
     }
 

--- a/src/SessionStorage/SessionStorage.svelte
+++ b/src/SessionStorage/SessionStorage.svelte
@@ -53,6 +53,7 @@
   let prevKey = key;
   let mounted = false;
 
+  /** @type {() => void} */
   function setItem() {
     if (typeof value === "object") {
       sessionStorage.setItem(key, JSON.stringify(value));
@@ -65,7 +66,7 @@
     const item = sessionStorage.getItem(key);
 
     if (item == null) {
-      setItem(value);
+      setItem();
       dispatch("save");
     } else {
       try {
@@ -100,7 +101,7 @@
     const item = sessionStorage.getItem(key);
 
     if (item == null) {
-      setItem(value);
+      setItem();
     } else {
       try {
         value = JSON.parse(item);
@@ -114,7 +115,7 @@
 
   afterUpdate(() => {
     if (prevValue !== value) {
-      setItem(value);
+      setItem();
       dispatch("update", { prevValue, value });
     }
 


### PR DESCRIPTION
`setItem` reads `value` from closure and declares no parameters, so the passed argument was silently discarded. Annotate with `() => void` so future call sites with extra args fail type-checking.