### PR TITLE
refactor(radio-tile): standardize context guard idiom

### DIFF
--- a/src/Tile/RadioTile.svelte
+++ b/src/Tile/RadioTile.svelte
@@ -56,14 +56,13 @@
     ),
   );
 
-  const { add, update, selectedValue, groupName, groupRequired } = getContext(
-    "carbon:TileGroup",
-  ) ?? {
-    add: () => {},
-    groupName: readable(undefined),
-    groupRequired: readable(undefined),
-    selectedValue: readable(checked ? value : undefined),
-  };
+  const ctx = getContext("carbon:TileGroup");
+  const add = ctx?.add ?? (() => {});
+  const update = ctx?.update ?? (() => {});
+  const selectedValue =
+    ctx?.selectedValue ?? readable(checked ? value : undefined);
+  const groupName = ctx?.groupName ?? readable(undefined);
+  const groupRequired = ctx?.groupRequired ?? readable(undefined);
 
   add({ value, checked });
 

--- a/tests/Tile/RadioTile.test.ts
+++ b/tests/Tile/RadioTile.test.ts
@@ -1,7 +1,12 @@
 import { render, screen } from "@testing-library/svelte";
 import RadioTileTest from "./RadioTile.test.svelte";
+import RadioTileStandalone from "./RadioTileStandalone.test.svelte";
 
 describe("RadioTile", () => {
+  it("does not throw when rendered outside a TileGroup", () => {
+    expect(() => render(RadioTileStandalone)).not.toThrow();
+  });
+
   describe("aria attributes", () => {
     it("should apply aria-describedby to the input element, not the label", () => {
       render(RadioTileTest, { ariaDescribedBy: "description-id" });

--- a/tests/Tile/RadioTileStandalone.test.svelte
+++ b/tests/Tile/RadioTileStandalone.test.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+  import { RadioTile } from "carbon-components-svelte";
+</script>
+
+<RadioTile value="standalone-value" name="solo">Standalone</RadioTile>


### PR DESCRIPTION
Match the per-field `ctx?.x ?? fallback` pattern from other components that use context.