### PR TITLE
refactor(checkbox-group): replace `beforeUpdate` with reactive statement

### DIFF
--- a/src/Checkbox/CheckboxGroup.svelte
+++ b/src/Checkbox/CheckboxGroup.svelte
@@ -51,13 +51,7 @@
    */
   export let id = undefined;
 
-  import {
-    beforeUpdate,
-    createEventDispatcher,
-    onMount,
-    setContext,
-    tick,
-  } from "svelte";
+  import { createEventDispatcher, onMount, setContext, tick } from "svelte";
   import { readonly, writable } from "svelte/store";
 
   const dispatch = createEventDispatcher();
@@ -70,13 +64,6 @@
   const groupRequired = writable(required);
   const groupDisabled = writable(disabled);
   let isInitialRender = true;
-  let isSyncingSelected = false;
-
-  function syncSelectedValues() {
-    isSyncingSelected = true;
-    $selectedValues = selected;
-    isSyncingSelected = false;
-  }
 
   /**
    * @type {(value: string | number, checked: boolean) => void}
@@ -98,24 +85,21 @@
     update,
   });
 
-  beforeUpdate(() => {
-    syncSelectedValues();
-  });
-
   const unsubscribe = selectedValues.subscribe((value) => {
     selected = value;
-    if (!isInitialRender && !isSyncingSelected) {
+    if (!isInitialRender) {
       dispatch("change", value);
     }
   });
 
   onMount(() => {
-    syncSelectedValues();
     tick().then(() => {
       isInitialRender = false;
     });
     return unsubscribe;
   });
+
+  $: if (selected !== $selectedValues) $selectedValues = selected;
 
   $: $groupName = name;
   $: $groupRequired = required;

--- a/tests/Checkbox/CheckboxGroupComponent.test.ts
+++ b/tests/Checkbox/CheckboxGroupComponent.test.ts
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/svelte";
+import { tick } from "svelte";
 import { user } from "../utils/user";
 import CheckboxGroupComponent from "./CheckboxGroupComponent.test.svelte";
 import CheckboxGroupStaticSelected from "./CheckboxGroupStaticSelected.test.svelte";
@@ -146,6 +147,26 @@ describe("CheckboxGroup", () => {
     const formItem = fieldset.closest(".bx--form-item");
     assert(formItem);
     expect(formItem).toHaveClass("custom-group");
+  });
+
+  it("should propagate external selected updates to child checkboxes", async () => {
+    const { component } = render(CheckboxGroupComponent, {
+      props: { selected: ["1"] },
+    });
+
+    expect(screen.getByRole("checkbox", { name: "Option 1" })).toBeChecked();
+    expect(
+      screen.getByRole("checkbox", { name: "Option 2" }),
+    ).not.toBeChecked();
+
+    component.selected = ["2", "3"];
+    await tick();
+
+    expect(
+      screen.getByRole("checkbox", { name: "Option 1" }),
+    ).not.toBeChecked();
+    expect(screen.getByRole("checkbox", { name: "Option 2" })).toBeChecked();
+    expect(screen.getByRole("checkbox", { name: "Option 3" })).toBeChecked();
   });
 
   it("should update selected value on checkbox clicks", async () => {


### PR DESCRIPTION
The lifecycle hook ran on every render to mirror `selected` into the context store, occasionally clobbering in-flight selections. A guarded `$:` statement syncs only when references differ, preventing duplicate `change` dispatches from array store notifications.