### PR TITLE
fix(radio-button-group): associate `helperText` via `aria-describedby`

### DIFF
--- a/src/RadioButton/RadioButton.svelte
+++ b/src/RadioButton/RadioButton.svelte
@@ -59,13 +59,21 @@
 
   const ctx = getContext("carbon:RadioButtonGroup");
 
-  const { add, update, selectedValue, groupName, groupRequired, readonly } =
-    ctx ?? {
-      groupName: readable(undefined),
-      groupRequired: readable(undefined),
-      selectedValue: readable(checked ? value : undefined),
-      readonly: readable(false),
-    };
+  const {
+    add,
+    update,
+    selectedValue,
+    groupName,
+    groupRequired,
+    readonly,
+    helperId,
+  } = ctx ?? {
+    groupName: readable(undefined),
+    groupRequired: readable(undefined),
+    selectedValue: readable(checked ? value : undefined),
+    readonly: readable(false),
+    helperId: readable(undefined),
+  };
 
   // Track if we're in standalone mode (no RadioButtonGroup context)
   const isStandalone = !ctx;
@@ -159,6 +167,7 @@
     {disabled}
     required={$groupRequired ?? required}
     {value}
+    aria-describedby={$helperId}
     class:bx--radio-button={true}
     on:focus
     on:blur

--- a/src/RadioButtonGroup/RadioButtonGroup.svelte
+++ b/src/RadioButtonGroup/RadioButtonGroup.svelte
@@ -85,6 +85,9 @@
   const groupName = writable(name);
   const groupRequired = writable(required);
   const groupReadonly = writable(readonly);
+  const fallbackHelperId = `ccs-${Math.random().toString(36)}`;
+  /** @type {import("svelte/store").Writable<string | undefined>} */
+  const helperId = writable(undefined);
   let isInitialRender = true;
 
   /**
@@ -109,6 +112,7 @@
     groupName: readOnly(groupName),
     groupRequired: readOnly(groupRequired),
     readonly: readOnly(groupReadonly),
+    helperId: readOnly(helperId),
     add,
     update,
   });
@@ -138,6 +142,11 @@
   $: $groupName = name;
   $: $groupRequired = required;
   $: $groupReadonly = readonly;
+  $: $helperId = helperText
+    ? id
+      ? `helper-${id}`
+      : fallbackHelperId
+    : undefined;
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
@@ -168,6 +177,7 @@
   </fieldset>
   {#if helperText}
     <div
+      id={$helperId}
       class:bx--form__helper-text={true}
       class:bx--form__helper-text--disabled={disabled}
     >

--- a/tests/RadioButtonGroup/RadioButtonGroup.test.ts
+++ b/tests/RadioButtonGroup/RadioButtonGroup.test.ts
@@ -170,6 +170,31 @@ describe("RadioButtonGroup", () => {
     expect(helperElement).not.toBeInTheDocument();
   });
 
+  it("should associate helper text with each radio via aria-describedby", () => {
+    render(RadioButtonGroup, {
+      props: { id: "group-1", helperText: "Helper text message" },
+    });
+
+    const helperElement = screen.getByText("Helper text message");
+    const helperId = helperElement.getAttribute("id");
+    expect(helperId).toBe("helper-group-1");
+
+    const radios = screen.getAllByRole("radio");
+    expect(radios.length).toBeGreaterThan(0);
+    for (const radio of radios) {
+      expect(radio).toHaveAttribute("aria-describedby", helperId);
+    }
+  });
+
+  it("should not set aria-describedby on radios when no helper text", () => {
+    render(RadioButtonGroup);
+
+    const radios = screen.getAllByRole("radio");
+    for (const radio of radios) {
+      expect(radio).not.toHaveAttribute("aria-describedby");
+    }
+  });
+
   describe("Generics", () => {
     it("should support custom string literal types with generics", () => {
       type CustomValue = "option1" | "option2" | "option3";


### PR DESCRIPTION
Generate a deterministic `helperId` and expose it through context so each `RadioButton` sets `aria-describedby` on its input, ensuring screen readers announce the helper text on focus.