### PR TITLE
feat(tree-view): support virtualization

### DIFF
--- a/docs/src/pages/components/TreeView.svx
+++ b/docs/src/pages/components/TreeView.svx
@@ -1,5 +1,5 @@
 ---
-description: A tree view displays hierarchical data in a collapsible tree structure. It supports node selection, expansion, icons, and programmatic control of the tree state.
+description: A tree view displays hierarchical data in a collapsible tree structure. It supports node selection, expansion, icons, programmatic control of the tree state, and virtualization for large trees.
 ---
 
 ## Basic
@@ -67,7 +67,7 @@ Customize node rendering using the default slot with the `let:node` directive. T
 
 ### Checkbox
 
-Set `selectionMode` to `"checkbox"` to render a checkbox on every node. Checking a branch checks its descendants, and a branch whose descendants are only partly checked renders indeterminate.
+Set `selectionMode` to `"checkbox"` to render a checkbox on every node. Checking a branch checks its descendants, and a branch whose descendants are only partly checked renders indeterminate. Checkbox mode also works with [Virtualization](#virtualization).
 
 Bind to `checkedIds` to read and set which nodes are checked. That is separate from `selectedIds`, which tracks row highlighting and is unused in checkbox mode. Bind to `indeterminateIds` to read which nodes are partially checked; it is derived from `checkedIds` and read-only, so writes are overwritten. Checkbox mode carries its own multi-selection, so [Multi-select](#multi-select) is ignored. Link nodes navigate instead of checking and render no checkbox.
 
@@ -202,6 +202,28 @@ Set `hasChildren` on a node to render it as an expandable branch before its `nod
 While `hasChildren` is `true` and `nodes` is empty, the `childNodes` slot renders in place of the (empty) subtree, receiving the same `node` as the default slot. TreeView has no built-in concept of "loading" or "error" — the slot is generic, so you decide what to render (a spinner, an error message with retry, or nothing) based on whatever fields you put on the node yourself.
 
 <FileSource src="/framed/TreeView/TreeViewLazyLoad" />
+
+## Virtualization
+
+Virtualization renders only the rows currently visible in the scroll viewport, improving performance for large trees (for example, file trees and log explorers). Set `virtualize` to enable it. The tree still tracks the full `nodes` dataset; only the on-screen slice is mounted in the DOM.
+
+Row height is fixed and comes from `size` (32px default, 24px compact). Rows do not grow to fit their content, so keep slot content to a single line. Pass `true` for defaults, or an object to customize:
+
+| Field             | Default                       | Description                                                                 |
+| ----------------- | ----------------------------- | --------------------------------------------------------------------------- |
+| `containerHeight` | `maxVisibleRows * itemHeight` | Scroll viewport height. Pass a number (pixels) or a CSS string (`"80%"`, `"100%"`, `"calc(...)"`) when the parent sets height. |
+| `maxVisibleRows`  | `10`                          | Rows visible at once when `containerHeight` is not set.                     |
+| `overscan`        | `3`                           | Extra rows rendered above and below the viewport during scroll.             |
+
+`expandAll` and `expandedIds` only need expandable nodes (those with loaded `nodes` or `hasChildren: true`). Leaf ids in `expandedIds` are ignored for expansion.
+
+<FileSource src="/framed/TreeView/TreeViewVirtualize" />
+
+### With lazy loading
+
+Combine `virtualize` with `hasChildren` to fetch children on expand. This example starts with the same project-folder roots as [Virtualization](#virtualization), but each subtree loads on demand (including nested folders). The virtualized path does not render the `childNodes` slot, so the demo inserts a temporary disabled "Loading…" child while the request is in flight, then replaces it with the fetched nodes.
+
+<FileSource src="/framed/TreeView/TreeViewVirtualizeLazy" />
 
 ## Flat data
 

--- a/docs/src/pages/framed/TreeView/TreeViewVirtualize.svelte
+++ b/docs/src/pages/framed/TreeView/TreeViewVirtualize.svelte
@@ -1,0 +1,307 @@
+<script>
+  import {
+    Button,
+    ButtonSet,
+    filterTreeByText,
+    Search,
+    Stack,
+    Toggle,
+    TreeView,
+  } from "carbon-components-svelte";
+  import Code from "carbon-icons-svelte/lib/Code.svelte";
+  import Document from "carbon-icons-svelte/lib/Document.svelte";
+  import DocumentBlank from "carbon-icons-svelte/lib/DocumentBlank.svelte";
+  import Folder from "carbon-icons-svelte/lib/Folder.svelte";
+  import Html from "carbon-icons-svelte/lib/Html.svelte";
+  import Image from "carbon-icons-svelte/lib/Image.svelte";
+  import Json from "carbon-icons-svelte/lib/Json.svelte";
+  import { onMount, tick } from "svelte";
+
+  function iconFor(name) {
+    const ext = name.slice(name.lastIndexOf(".") + 1).toLowerCase();
+    if (ext === "ts" || ext === "tsx" || ext === "js" || ext === "jsx") {
+      return Code;
+    }
+    if (ext === "json") return Json;
+    if (ext === "html") return Html;
+    if (ext === "png" || ext === "jpg" || ext === "svg" || ext === "gif") {
+      return Image;
+    }
+    if (ext === "md" || ext === "txt") return Document;
+    return DocumentBlank;
+  }
+
+  const fileNames = [
+    "index.ts",
+    "utils.ts",
+    "config.json",
+    "package.json",
+    "styles.scss",
+    "theme.css",
+    "logo.svg",
+    "hero.png",
+    "README.md",
+    "CHANGELOG.md",
+    "App.tsx",
+    "Header.tsx",
+    "index.html",
+    "404.html",
+    "robots.txt",
+  ];
+
+  const rootNames = [
+    "src",
+    "tests",
+    "docs",
+    "examples",
+    "scripts",
+    "node_modules",
+    "dist",
+    "build",
+    "public",
+    "static",
+    "assets",
+    "fixtures",
+    "e2e",
+    "lib",
+    "packages",
+    "apps",
+    "types",
+    "config",
+    "tools",
+    "plugins",
+    "themes",
+    "locales",
+    "components",
+    "hooks",
+    "utils",
+    "services",
+    "pages",
+    "layouts",
+    "store",
+    "api",
+    "db",
+    "migrations",
+    "seeds",
+    "internal",
+    "integrations",
+    "cli",
+    "server",
+    "client",
+    "vendor",
+    "workers",
+  ];
+
+  let nextId = 0;
+  const id = () => nextId++;
+
+  /** A leaf at the deepest level, used as a `showNode` target. */
+  let deepFile = null;
+
+  function makeFolder(name, depth, fanout) {
+    const node = { id: id(), text: name, icon: Folder, nodes: [] };
+    for (let i = 0; i < fanout.files; i++) {
+      const fname = fileNames[(i + depth) % fileNames.length];
+      const file = { id: id(), text: fname, icon: iconFor(fname) };
+      node.nodes.push(file);
+      if (depth === fanout.maxDepth) {
+        deepFile = { id: file.id, path: `${name}/${fname}` };
+      }
+    }
+    if (depth < fanout.maxDepth) {
+      for (let i = 0; i < fanout.folders; i++) {
+        node.nodes.push(
+          makeFolder(`${name}/subfolder-${i}`, depth + 1, fanout),
+        );
+      }
+    }
+    return node;
+  }
+
+  function countNodes(list) {
+    let n = 0;
+    for (const node of list) {
+      n++;
+      if (node.nodes) n += countNodes(node.nodes);
+    }
+    return n;
+  }
+
+  /** Expandable ids only — leaves are no-ops for TreeView expansion. */
+  function expandableIds(list) {
+    const ids = [];
+    for (const node of list) {
+      const hasLoadedChildren =
+        Array.isArray(node.nodes) && node.nodes.length > 0;
+      if (hasLoadedChildren || node.hasChildren === true) {
+        ids.push(node.id);
+      }
+      if (hasLoadedChildren) ids.push(...expandableIds(node.nodes));
+    }
+    return ids;
+  }
+
+  // Defer ~100k+ node allocation so the framed preview shell can paint first
+  // (avoids Vite/Svelte DEV OOMing on module eval).
+  let nodes = [];
+  let totalNodes = 0;
+  let ready = false;
+
+  onMount(() => {
+    nodes = rootNames.map((name) =>
+      makeFolder(name, 0, { files: 8, folders: 4, maxDepth: 4 }),
+    );
+    totalNodes = countNodes(nodes);
+    ready = true;
+    return () => observer?.disconnect();
+  });
+
+  let treeview = null;
+  let searchValue = "";
+  let compact = false;
+  let dynamicHeight = false;
+
+  $: size = compact ? "compact" : "default";
+
+  $: filteredNodes =
+    searchValue.trim() === "" ? nodes : filterTreeByText(nodes, searchValue);
+
+  let expandedIds = [];
+
+  // A new filter resets the view: expand every match and jump back to the top.
+  // Gate on the text actually changing. Reactive statements also run on
+  // unrelated passes, and resetting unconditionally would fight anything else
+  // that scrolls or expands -- `showNode`, or the user's own caret clicks.
+  let lastSearchValue = searchValue;
+  $: if (searchValue !== lastSearchValue) {
+    lastSearchValue = searchValue;
+    expandedIds = searchValue.trim() === "" ? [] : expandableIds(filteredNodes);
+    tick().then(() => scrollContainerRef?.scrollTo({ top: 0 }));
+  }
+
+  let scrollContainerRef = null;
+  let domRowCount = 0;
+  let observer = null;
+
+  function attachObserver(el) {
+    observer?.disconnect();
+    observer = null;
+    if (!el) {
+      domRowCount = 0;
+      return;
+    }
+    const recount = () => {
+      domRowCount = el.querySelectorAll('[role="treeitem"]').length;
+    };
+    observer = new MutationObserver(recount);
+    observer.observe(el, { childList: true });
+    recount();
+  }
+
+  $: attachObserver(scrollContainerRef);
+</script>
+
+<Stack gap={5}>
+  <ButtonSet>
+    <Button
+      kind="tertiary"
+      size="small"
+      disabled={!ready}
+      on:click={() => treeview?.expandAll()}
+    >
+      Expand all
+    </Button>
+    <Button
+      kind="tertiary"
+      size="small"
+      disabled={!ready}
+      on:click={() => {
+        treeview?.collapseAll();
+        expandedIds = [];
+      }}
+    >
+      Collapse all
+    </Button>
+    <Button
+      kind="tertiary"
+      size="small"
+      disabled={!ready || searchValue.trim() !== ""}
+      on:click={() => treeview?.showNode(deepFile.id)}
+    >
+      Jump to a deep file
+    </Button>
+  </ButtonSet>
+
+  <Search
+    size="sm"
+    placeholder="Filter by file or folder name"
+    bind:value={searchValue}
+    disabled={!ready}
+  />
+
+  <Stack gap={3} orientation="horizontal">
+    <Toggle
+      size="sm"
+      labelText="Compact size"
+      labelA="Default (32px rows)"
+      labelB="Compact (24px rows)"
+      bind:toggled={compact}
+    />
+    <Toggle
+      size="sm"
+      labelText="Container height"
+      labelA="Fixed (480px)"
+      labelB="Dynamic (60vh, resize window)"
+      bind:toggled={dynamicHeight}
+    />
+  </Stack>
+
+  {#if !ready}
+    <p style:margin="0">Building demo tree…</p>
+  {:else}
+    <p style:margin="0">
+      Total nodes: <strong>{totalNodes.toLocaleString()}</strong>
+      {#if searchValue.trim() !== ""}
+        &middot; matching filter:
+        <strong>{countNodes(filteredNodes).toLocaleString()}</strong>
+      {/if}
+      &middot; rendered in DOM: <strong>{domRowCount.toLocaleString()}</strong>
+    </p>
+
+    {#if filteredNodes.length > 0}
+      {#if dynamicHeight}
+        <!-- A constrained parent gives `containerHeight: "100%"` something to
+             resolve against. Resize the browser to watch the DOM count change. -->
+        <div style="height: 60vh; min-height: 240px;">
+          <TreeView
+            bind:this={treeview}
+            bind:scrollContainerRef
+            labelText="Project files"
+            nodes={filteredNodes}
+            bind:expandedIds
+            {size}
+            virtualize={{ containerHeight: "100%" }}
+            let:node
+          >
+            {node.text}
+          </TreeView>
+        </div>
+      {:else}
+        <TreeView
+          bind:this={treeview}
+          bind:scrollContainerRef
+          labelText="Project files"
+          nodes={filteredNodes}
+          bind:expandedIds
+          {size}
+          virtualize={{ containerHeight: 480 }}
+          let:node
+        >
+          {node.text}
+        </TreeView>
+      {/if}
+    {:else}
+      <p>No files match "{searchValue}".</p>
+    {/if}
+  {/if}
+</Stack>

--- a/docs/src/pages/framed/TreeView/TreeViewVirtualizeLazy.svelte
+++ b/docs/src/pages/framed/TreeView/TreeViewVirtualizeLazy.svelte
@@ -1,0 +1,184 @@
+<script>
+  import { TreeView } from "carbon-components-svelte";
+  import Code from "carbon-icons-svelte/lib/Code.svelte";
+  import Document from "carbon-icons-svelte/lib/Document.svelte";
+  import DocumentBlank from "carbon-icons-svelte/lib/DocumentBlank.svelte";
+  import Folder from "carbon-icons-svelte/lib/Folder.svelte";
+  import Html from "carbon-icons-svelte/lib/Html.svelte";
+  import Image from "carbon-icons-svelte/lib/Image.svelte";
+  import Json from "carbon-icons-svelte/lib/Json.svelte";
+
+  function iconFor(name) {
+    const ext = name.slice(name.lastIndexOf(".") + 1).toLowerCase();
+    if (ext === "ts" || ext === "tsx" || ext === "js" || ext === "jsx") {
+      return Code;
+    }
+    if (ext === "json") return Json;
+    if (ext === "html") return Html;
+    if (ext === "png" || ext === "jpg" || ext === "svg" || ext === "gif") {
+      return Image;
+    }
+    if (ext === "md" || ext === "txt") return Document;
+    return DocumentBlank;
+  }
+
+  const fileNames = [
+    "index.ts",
+    "utils.ts",
+    "config.json",
+    "package.json",
+    "styles.scss",
+    "theme.css",
+    "logo.svg",
+    "hero.png",
+    "README.md",
+    "CHANGELOG.md",
+    "App.tsx",
+    "Header.tsx",
+    "index.html",
+    "404.html",
+    "robots.txt",
+  ];
+
+  const rootNames = [
+    "src",
+    "tests",
+    "docs",
+    "examples",
+    "scripts",
+    "node_modules",
+    "dist",
+    "build",
+    "public",
+    "static",
+    "assets",
+    "fixtures",
+    "e2e",
+    "lib",
+    "packages",
+    "apps",
+    "types",
+    "config",
+    "tools",
+    "plugins",
+    "themes",
+    "locales",
+    "components",
+    "hooks",
+    "utils",
+    "services",
+    "pages",
+    "layouts",
+    "store",
+    "api",
+    "db",
+    "migrations",
+    "seeds",
+    "internal",
+    "integrations",
+    "cli",
+    "server",
+    "client",
+    "vendor",
+    "workers",
+  ];
+
+  const MAX_DEPTH = 4;
+  const FETCH_MS = 500;
+  const fanout = { files: 8, folders: 4 };
+
+  let nextId = 0;
+  const id = () => nextId++;
+
+  // Roots are unloaded folders; children are fetched on expand.
+  let nodes = rootNames.map((name) => ({
+    id: id(),
+    text: name,
+    icon: Folder,
+    depth: 0,
+    path: name,
+    hasChildren: true,
+  }));
+
+  function updateNode(list, nodeId, updater) {
+    return list.map((node) => {
+      if (node.id === nodeId) return updater(node);
+      if (node.nodes) {
+        return { ...node, nodes: updateNode(node.nodes, nodeId, updater) };
+      }
+      return node;
+    });
+  }
+
+  function makeChildren(parentPath, depth) {
+    const children = [];
+    for (let i = 0; i < fanout.files; i++) {
+      const fname = fileNames[(i + depth) % fileNames.length];
+      children.push({
+        id: id(),
+        text: fname,
+        icon: iconFor(fname),
+        depth: depth + 1,
+        path: `${parentPath}/${fname}`,
+      });
+    }
+    if (depth < MAX_DEPTH) {
+      for (let i = 0; i < fanout.folders; i++) {
+        const name = `subfolder-${i}`;
+        children.push({
+          id: id(),
+          text: name,
+          icon: Folder,
+          depth: depth + 1,
+          path: `${parentPath}/${name}`,
+          hasChildren: true,
+        });
+      }
+    }
+    return children;
+  }
+
+  async function fetchChildren(parentPath, depth) {
+    await new Promise((resolve) => setTimeout(resolve, FETCH_MS));
+    return makeChildren(parentPath, depth);
+  }
+
+  async function handleToggle(event) {
+    const node = event.detail;
+
+    // Only fetch once: expandable and not yet loaded (placeholder or real).
+    if (!node.hasChildren || node.nodes) return;
+
+    // Virtualized trees do not render the `childNodes` slot. Put a temporary
+    // disabled row under the parent so the expand still shows progress.
+    nodes = updateNode(nodes, node.id, (n) => ({
+      ...n,
+      nodes: [
+        {
+          id: `${n.id}__loading`,
+          text: "Loading…",
+          disabled: true,
+        },
+      ],
+    }));
+
+    const children = await fetchChildren(
+      node.path ?? node.text,
+      node.depth ?? 0,
+    );
+    nodes = updateNode(nodes, node.id, (n) => ({
+      ...n,
+      nodes: children,
+    }));
+  }
+</script>
+
+<TreeView
+  labelText="Project files"
+  {nodes}
+  virtualize={{ containerHeight: 480 }}
+  on:toggle={handleToggle}
+  let:node
+>
+  {node.text}
+</TreeView>

--- a/e2e/fixtures/TreeViewVirtualizeFixture.svelte
+++ b/e2e/fixtures/TreeViewVirtualizeFixture.svelte
@@ -1,0 +1,53 @@
+<script>
+  import { Button, TreeView } from "carbon-components-svelte";
+
+  let nextId = 0;
+  const id = () => nextId++;
+
+  /** Leaf at the deepest level, used as a `showNode` target. */
+  let deepFile = null;
+
+  function makeFolder(name, depth, fanout) {
+    const node = { id: id(), text: name, nodes: [] };
+    for (let i = 0; i < fanout.files; i++) {
+      const file = { id: id(), text: `${name}/file-${i}` };
+      node.nodes.push(file);
+      if (depth === fanout.maxDepth) deepFile = file.id;
+    }
+    if (depth < fanout.maxDepth) {
+      for (let i = 0; i < fanout.folders; i++) {
+        node.nodes.push(makeFolder(`${name}/sub-${i}`, depth + 1, fanout));
+      }
+    }
+    return node;
+  }
+
+  const nodes = Array.from({ length: 40 }, (_, i) =>
+    makeFolder(`root-${i}`, 0, { files: 8, folders: 4, maxDepth: 4 }),
+  );
+
+  let treeview = null;
+  let expandedIds = [];
+  let scrollContainerRef = null;
+</script>
+
+<Button
+  size="small"
+  data-testid="jump-deep"
+  on:click={() => treeview?.showNode(deepFile)}
+>
+  Jump to a deep file
+</Button>
+
+<TreeView
+  bind:this={treeview}
+  bind:scrollContainerRef
+  data-testid="tree-view-virtualize"
+  labelText="Project files"
+  {nodes}
+  bind:expandedIds
+  virtualize={{ containerHeight: 480 }}
+  let:node
+>
+  {node.text}
+</TreeView>

--- a/e2e/fixtures/tree-view-virtualize.html
+++ b/e2e/fixtures/tree-view-virtualize.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>TreeView Virtualize Fixture</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="./tree-view-virtualize.ts"></script>
+  </body>
+</html>

--- a/e2e/fixtures/tree-view-virtualize.ts
+++ b/e2e/fixtures/tree-view-virtualize.ts
@@ -1,0 +1,4 @@
+import { mount } from "./mount";
+import TreeViewVirtualizeFixture from "./TreeViewVirtualizeFixture.svelte";
+
+mount(TreeViewVirtualizeFixture);

--- a/e2e/tree-view-virtualize.test.ts
+++ b/e2e/tree-view-virtualize.test.ts
@@ -1,0 +1,52 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("TreeView virtualization", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/tree-view-virtualize.html");
+  });
+
+  test("showNode scrolls the deep row into view and focuses it", async ({
+    page,
+  }) => {
+    const tree = page.getByTestId("tree-view-virtualize");
+    await expect(tree).toBeVisible();
+    expect(await tree.evaluate((el) => el.scrollTop)).toBe(0);
+
+    await page.getByTestId("jump-deep").click();
+
+    // The focused row must be the deep target, and it must be inside the
+    // scroll viewport rather than merely mounted in the DOM.
+    const focused = page.locator("[data-tree-row-id]:focus");
+    await expect(focused).toBeVisible();
+
+    const inView = await tree.evaluate((el) => {
+      const row = el.querySelector("[data-tree-row-id]:focus");
+      if (!row) return null;
+      const treeBox = el.getBoundingClientRect();
+      const rowBox = row.getBoundingClientRect();
+      return {
+        scrollTop: el.scrollTop,
+        fullyVisible:
+          rowBox.top >= treeBox.top && rowBox.bottom <= treeBox.bottom,
+      };
+    });
+
+    expect(inView).not.toBeNull();
+    expect(inView?.scrollTop).toBeGreaterThan(0);
+    expect(inView?.fullyVisible).toBe(true);
+  });
+
+  test("scroll container is height-limited and scrollable", async ({
+    page,
+  }) => {
+    const metrics = await page
+      .getByTestId("tree-view-virtualize")
+      .evaluate((el) => ({
+        clientHeight: el.clientHeight,
+        scrollHeight: el.scrollHeight,
+      }));
+
+    expect(metrics.clientHeight).toBe(480);
+    expect(metrics.scrollHeight).toBeGreaterThan(metrics.clientHeight);
+  });
+});

--- a/src/TreeView/TreeView.svelte
+++ b/src/TreeView/TreeView.svelte
@@ -353,6 +353,35 @@
   export let indeterminateIds = [];
 
   /**
+   * Enable virtualization for large trees. Virtualization renders only the
+   * rows currently visible in the viewport, improving performance for large
+   * datasets.
+   *
+   * Virtualization is opt-in. TreeView cannot tell from `nodes` alone whether
+   * the tree will stay small or grow through expansion, so it does not
+   * auto-enable based on row count. Set `virtualize={true}` to enable with
+   * default settings, or pass a configuration object to customize. Leave
+   * `undefined` for the default recursive rendering.
+   *
+   * Row height is derived from `size` (32px default, 24px compact).
+   *
+   * @type {undefined | boolean | {
+   *   maxVisibleRows?: number,
+   *   containerHeight?: number | string,
+   *   overscan?: number,
+   * }}
+   */
+  export let virtualize = undefined;
+
+  /**
+   * Reference to the scrollable container when `virtualize` is enabled.
+   * `null` otherwise.
+   * @type {null | HTMLElement}
+   * @bindable readonly
+   */
+  export let scrollContainerRef = null;
+
+  /**
    * Programmatically expand all expandable nodes (those with loaded children
    * or `hasChildren: true`). Leaf ids are omitted — they do not affect
    * expansion.
@@ -478,9 +507,11 @@
     if (select) {
       activeId = id;
       if (selectionMode === "checkbox") {
-        checkedIds = toggleCheckboxNode(nodes, checkedIds, id, true, {
-          cascade: checkMode !== "node",
-        });
+        setCheckedIds(
+          toggleCheckboxNode(nodes, checkedIds, id, true, {
+            cascade: checkMode !== "node",
+          }),
+        );
       } else if (isMultiselect && multiselectMode !== "node") {
         setSelectedIds(multiselectExpansionIds(targetNode, multiselectMode));
       } else {
@@ -490,6 +521,10 @@
 
     if (focus) {
       tick().then(() => {
+        if (virtualConfig && scrollContainerRef) {
+          focusVirtualRowById(id);
+          return;
+        }
         ref?.querySelector(`[id="${CSS.escape(String(id))}"]`)?.focus();
       });
     }
@@ -534,12 +569,20 @@
     tick,
   } from "svelte";
   import { writable } from "svelte/store";
-  import { isExpandableNode } from "../utils/isExpandableNode.js";
   import {
     resolveCheckboxState,
     toggleCheckboxNode,
   } from "../utils/treeCheckboxState.js";
+  import {
+    createTreeVirtualIndex,
+    isExpandableNode,
+  } from "../utils/treeVirtualIndex.js";
+  import {
+    getVisibleRange,
+    scrollHighlightedIntoView,
+  } from "../utils/virtualize.js";
   import TreeViewNodeList from "./TreeViewNodeList.svelte";
+  import TreeViewNodeVirtual from "./TreeViewNodeVirtual.svelte";
 
   const dispatch = createEventDispatcher();
   const labelId = `label-${Math.random().toString(36)}`;
@@ -679,6 +722,14 @@
   let selectedIdsSet = new Set(selectedIds);
   /** @type {ReadonlyArray<Node["id"]>} */
   let lastSelectedIdsRef = selectedIds;
+  /** @type {Set<Node["id"]>} */
+  let checkedIdsSet = new Set(checkedIds);
+  /** @type {ReadonlyArray<Node["id"]>} */
+  let lastCheckedIdsRef = checkedIds;
+  /** @type {Set<Node["id"]>} */
+  let indeterminateIdsSet = new Set(indeterminateIds);
+  /** @type {ReadonlyArray<Node["id"]>} */
+  let lastIndeterminateIdsRef = indeterminateIds;
   /** @type {Node["id"]} */
   let lastActiveIdPushed = activeId;
   /** @type {ReadonlyArray<Node["id"]>} */
@@ -710,8 +761,8 @@
       ...node,
       expanded: expandedIdsSet.has(node.id),
       selected: selectedIdsSet.has(node.id),
-      checked: checkedIds.includes(node.id),
-      indeterminate: indeterminateIds.includes(node.id),
+      checked: checkedIdsSet.has(node.id),
+      indeterminate: indeterminateIdsSet.has(node.id),
     };
   }
 
@@ -727,6 +778,16 @@
     selectedIds = next;
     selectedIdsSet = new Set(next);
     lastSelectedIdsRef = next;
+  }
+
+  /**
+   * Same sync-mirror pattern as `setSelectedIds` for checkbox state.
+   * @type {(next: ReadonlyArray<Node["id"]>) => void}
+   */
+  function setCheckedIds(next) {
+    checkedIds = next;
+    checkedIdsSet = new Set(next);
+    lastCheckedIdsRef = next;
   }
 
   /** @type {(node: Node, event?: Event) => void} */
@@ -757,12 +818,14 @@
 
       if (!clickedCheckbox) return;
 
-      checkedIds = toggleCheckboxNode(
-        nodes,
-        checkedIds,
-        node.id,
-        !checkedIds.includes(node.id),
-        { cascade: checkMode !== "node" },
+      setCheckedIds(
+        toggleCheckboxNode(
+          nodes,
+          checkedIds,
+          node.id,
+          !checkedIdsSet.has(node.id),
+          { cascade: checkMode !== "node" },
+        ),
       );
       dispatch("check", withLiveState(node));
       return;
@@ -874,6 +937,7 @@
 
   /** @type {(node: Node) => void} */
   function focusNode(node) {
+    if (virtualConfig) virtualFocusedId = node.id;
     dispatch("focus", withLiveState(node));
   }
 
@@ -1104,6 +1168,7 @@
     return () => {
       setMultiselectKeyListeners(false);
       if (typeAheadTimeoutId) clearTimeout(typeAheadTimeoutId);
+      resizeObserver?.disconnect();
     };
   });
 
@@ -1137,13 +1202,28 @@
         },
       );
       if (!arrayIdsEqual(checkboxState.checkedIds, checkedIds)) {
-        checkedIds = checkboxState.checkedIds;
+        setCheckedIds(checkboxState.checkedIds);
       }
       if (!arrayIdsEqual(checkboxState.indeterminateIds, indeterminateIds)) {
         indeterminateIds = checkboxState.indeterminateIds;
+        indeterminateIdsSet = new Set(indeterminateIds);
+        lastIndeterminateIdsRef = indeterminateIds;
       }
     } else if (indeterminateIds.length > 0) {
       indeterminateIds = [];
+      indeterminateIdsSet = new Set();
+      lastIndeterminateIdsRef = indeterminateIds;
+    }
+
+    // External `bind:checkedIds` / `bind:indeterminateIds` updates that
+    // bypass `setCheckedIds` still need the sync mirrors refreshed.
+    if (checkedIds !== lastCheckedIdsRef) {
+      checkedIdsSet = new Set(checkedIds);
+      lastCheckedIdsRef = checkedIds;
+    }
+    if (indeterminateIds !== lastIndeterminateIdsRef) {
+      indeterminateIdsSet = new Set(indeterminateIds);
+      lastIndeterminateIdsRef = indeterminateIds;
     }
 
     if (!arrayIdsEqual(indeterminateIds, lastIndeterminateIdsPushed)) {
@@ -1170,6 +1250,466 @@
           indeterminateIds: nextIndeterminateIds,
         });
       });
+    }
+  }
+
+  let scrollTop = 0;
+
+  /** Row id that currently owns keyboard focus in the virtual path.
+   * Kept separate from `activeId` so arrow moves match non-virtual
+   * (focus only) while still anchoring tabindex across remounts. */
+  let virtualFocusedId = undefined;
+
+  /** Pixel height of the scroll container, measured from the DOM when
+   * `containerHeight` is set to a non-numeric value (e.g. `"80%"`).
+   * Falls back to a derived px value otherwise. */
+  let measuredContainerHeight = 0;
+
+  $: virtualConfig = virtualize
+    ? {
+        maxVisibleRows: 10,
+        containerHeight: undefined,
+        overscan: 3,
+        ...(typeof virtualize === "object" ? virtualize : {}),
+        itemHeight: size === "compact" ? 24 : 32,
+      }
+    : null;
+
+  // Derive from `expandedIds` (reassigned synchronously at every mutation
+  // site) rather than `$expandedIdsSetStore`. The store is only `.set()` from
+  // inside a reactive block, which Svelte 3/4 doesn't track as an assignment
+  // for reactive ordering — so subscribers re-run a flush late and the
+  // rendered window lags one `tick()` behind expand/collapse. Reading
+  // `expandedIds` keeps the index in the same flush as the change.
+  //
+  // Prefer the live `expandedIdsSet` mirror when it is already in sync with
+  // `expandedIds` (expandNode / expandAll). Fall back to a temporary Set when
+  // an external `bind:expandedIds` update has not been mirrored yet (this
+  // reactive block runs before the sync block later in the file).
+  $: virtualIndex = virtualConfig
+    ? createTreeVirtualIndex(
+        nodes,
+        expandedIds === lastExpandedIdsRef
+          ? expandedIdsSet
+          : new Set(expandedIds),
+      )
+    : null;
+
+  /** CSS height value applied to the scroll container. Strings pass through;
+   * numbers/undefined become px. */
+  $: containerHeightStyle = virtualConfig
+    ? typeof virtualConfig.containerHeight === "string"
+      ? virtualConfig.containerHeight
+      : `${virtualConfig.containerHeight ?? virtualConfig.maxVisibleRows * virtualConfig.itemHeight}px`
+    : undefined;
+
+  /** Pixel height used for windowing math. */
+  function getVirtualContainerHeight() {
+    if (!virtualConfig) return 0;
+    if (typeof virtualConfig.containerHeight === "number") {
+      return virtualConfig.containerHeight;
+    }
+    if (typeof virtualConfig.containerHeight === "string") {
+      return (
+        measuredContainerHeight ||
+        virtualConfig.maxVisibleRows * virtualConfig.itemHeight
+      );
+    }
+    return virtualConfig.maxVisibleRows * virtualConfig.itemHeight;
+  }
+
+  // If the visible list shrinks (e.g. filter removed rows the user had
+  // scrolled past, or many parents collapsed), the previous scrollTop can
+  // exceed the new max — leaving the windowing math with `startIndex` past
+  // the end of the list and the tree appearing blank. Clamp back to the
+  // last valid scroll position.
+  $: if (virtualConfig && virtualIndex && scrollContainerRef) {
+    const containerHeight = getVirtualContainerHeight();
+    const maxTop = Math.max(
+      0,
+      virtualIndex.totalCount * virtualConfig.itemHeight - containerHeight,
+    );
+    if (scrollTop > maxTop) {
+      scrollTop = maxTop;
+      scrollContainerRef.scrollTop = maxTop;
+    }
+  }
+
+  $: virtualData = (() => {
+    if (!virtualConfig || !virtualIndex) return null;
+    const itemHeight = virtualConfig.itemHeight;
+    const containerHeight = getVirtualContainerHeight();
+    const totalHeight = virtualIndex.totalCount * itemHeight;
+    const maxScroll = Math.max(0, totalHeight - containerHeight);
+    const clampedScrollTop = Math.min(Math.max(0, scrollTop), maxScroll);
+    const { startIndex, endIndex } = getVisibleRange({
+      scrollTop: clampedScrollTop,
+      itemHeight,
+      containerHeight,
+      itemCount: virtualIndex.totalCount,
+      overscan: virtualConfig.overscan,
+    });
+    return {
+      visibleItems: virtualIndex.collectRows(startIndex, endIndex),
+      startIndex,
+      endIndex,
+      offsetY: startIndex * itemHeight,
+      totalHeight,
+    };
+  })();
+
+  /** Observe the scroll container so percentage / relative heights
+   * (`containerHeight: "80%"`) translate into a usable pixel value for
+   * windowing math. Disconnect when virtualization is off or height is
+   * no longer a relative string. */
+  let resizeObserver = null;
+  $: if (
+    virtualConfig &&
+    typeof virtualConfig.containerHeight === "string" &&
+    scrollContainerRef
+  ) {
+    if (typeof ResizeObserver === "undefined") {
+      measuredContainerHeight = scrollContainerRef.clientHeight;
+    } else {
+      resizeObserver?.disconnect();
+      resizeObserver = new ResizeObserver((entries) => {
+        const entry = entries[0];
+        if (entry) measuredContainerHeight = entry.contentRect.height;
+      });
+      resizeObserver.observe(scrollContainerRef);
+    }
+  } else {
+    resizeObserver?.disconnect();
+    resizeObserver = null;
+    if (!virtualConfig) measuredContainerHeight = 0;
+  }
+
+  /** Tabindex anchor: prefer the focused row when it is currently mounted
+   * and enabled; otherwise the first enabled row in the window. */
+  $: virtualTabAnchorId = (() => {
+    if (!virtualConfig || !virtualIndex || !virtualData) return undefined;
+    const visible = virtualData.visibleItems;
+    if (
+      virtualFocusedId !== undefined &&
+      virtualFocusedId !== "" &&
+      virtualFocusedId != null
+    ) {
+      for (const row of visible) {
+        if (row.node.id === virtualFocusedId && !row.node.disabled) {
+          return virtualFocusedId;
+        }
+      }
+    }
+    for (const row of visible) {
+      if (!row.node.disabled) return row.node.id;
+    }
+    return undefined;
+  })();
+
+  /**
+   * Set both the DOM scrollTop and the reactive mirror so the windowed
+   * slice updates synchronously (the browser's scroll event is async, and
+   * jsdom doesn't fire one at all on programmatic assignment).
+   * @param {number} top
+   */
+  function virtualSetScrollTop(top) {
+    if (!scrollContainerRef) return;
+    scrollContainerRef.scrollTop = top;
+    scrollTop = top;
+  }
+
+  /**
+   * If the focused virtual row unmounted (mouse/scrollbar scroll), park
+   * focus on the scroll container so the next Arrow key still works.
+   */
+  function preserveVirtualFocusAfterScroll() {
+    if (!scrollContainerRef) return;
+    const active = document.activeElement;
+    if (!(active instanceof HTMLElement)) return;
+    if (!scrollContainerRef.contains(active)) {
+      // Focus already left the tree (e.g. body after unmount).
+      if (
+        active === document.body ||
+        !document.body.contains(active) ||
+        !active.isConnected
+      ) {
+        scrollContainerRef.focus({ preventScroll: true });
+      }
+      return;
+    }
+    // Still inside the tree but might be a detached orphan in some envs.
+    if (!active.isConnected) {
+      scrollContainerRef.focus({ preventScroll: true });
+    }
+  }
+
+  /** @param {Event & { currentTarget: HTMLElement }} e */
+  function handleVirtualScroll(e) {
+    scrollTop = e.currentTarget.scrollTop;
+    // Only recover focus when the tree already owned it at scroll start.
+    // Otherwise incidental wheel scroll would steal focus from body / elsewhere.
+    const active = document.activeElement;
+    const hadTreeFocus =
+      active instanceof HTMLElement &&
+      scrollContainerRef != null &&
+      (active === scrollContainerRef || scrollContainerRef.contains(active));
+    if (!hadTreeFocus) return;
+    // Wait a microtask so Svelte can unmount off-window rows first.
+    tick().then(preserveVirtualFocusAfterScroll);
+  }
+
+  /**
+   * Scroll a virtual row into view and focus it. Callers schedule this on a
+   * `tick`, so the virtual index already reflects the ancestors `showNode` expanded.
+   * @param {string | number} targetId
+   */
+  function focusVirtualRowById(targetId) {
+    if (!virtualConfig || !virtualIndex || !scrollContainerRef) return;
+
+    const index = virtualIndex.findIndexById(targetId);
+    if (index < 0) return;
+
+    virtualFocusedId = targetId;
+
+    const nextScrollTop = scrollHighlightedIntoView({
+      highlightedIndex: index,
+      currentScrollTop: scrollTop,
+      itemCount: virtualIndex.totalCount,
+      itemHeight: virtualConfig.itemHeight,
+      containerHeight: getVirtualContainerHeight(),
+      // Overscan rows are mounted but offscreen, so require true visibility.
+      overscan: 0,
+    });
+    if (nextScrollTop !== null) virtualSetScrollTop(nextScrollTop);
+
+    tick().then(() => {
+      scrollContainerRef
+        ?.querySelector(`[data-tree-row-id="${CSS.escape(String(targetId))}"]`)
+        ?.focus();
+    });
+  }
+
+  /** Cancels stale focus from overlapping async `virtualMoveTo` calls
+   * (e.g. multi-character type-ahead). */
+  let virtualMoveGen = 0;
+
+  /** @param {number} idx */
+  async function virtualMoveTo(idx) {
+    if (
+      !virtualConfig ||
+      !virtualIndex ||
+      idx < 0 ||
+      idx >= virtualIndex.totalCount
+    )
+      return;
+    const target = virtualIndex.getRowAt(idx);
+    if (!target) return;
+    const gen = ++virtualMoveGen;
+    // Match non-virtual arrows: move focus only, do not mutate activeId.
+    virtualFocusedId = target.node.id;
+    const top = idx * virtualConfig.itemHeight;
+    if (top < scrollTop) {
+      virtualSetScrollTop(top);
+    } else if (
+      top + virtualConfig.itemHeight >
+      scrollTop + getVirtualContainerHeight()
+    ) {
+      virtualSetScrollTop(
+        top + virtualConfig.itemHeight - getVirtualContainerHeight(),
+      );
+    }
+    await tick();
+    if (gen !== virtualMoveGen) return;
+    scrollContainerRef
+      ?.querySelector(
+        `[data-tree-row-id="${CSS.escape(String(target.node.id))}"]`,
+      )
+      ?.focus();
+  }
+
+  /**
+   * Type-ahead against the virtual index. Off-window rows match on
+   * `node.text` (DOM textContent is unavailable when unmounted).
+   * @param {KeyboardEvent} event
+   * @param {number} activeIdx
+   * @returns {boolean}
+   */
+  function handleVirtualTypeAhead(event, activeIdx) {
+    if (!virtualIndex || !isTypeAheadKey(event)) return false;
+
+    if (typeAheadTimeoutId) clearTimeout(typeAheadTimeoutId);
+    typeAheadBuffer += event.key.toLowerCase();
+    typeAheadTimeoutId = setTimeout(() => {
+      typeAheadBuffer = "";
+    }, typeAheadTimeoutMs);
+
+    const isRepeatedChar =
+      typeAheadBuffer.length > 1 &&
+      [...typeAheadBuffer].every((c) => c === typeAheadBuffer[0]);
+    const query = isRepeatedChar ? typeAheadBuffer[0] : typeAheadBuffer;
+    const count = virtualIndex.totalCount;
+    if (count === 0) return true;
+
+    const startIndex = Math.max(activeIdx, 0);
+    for (let offset = 1; offset <= count; offset++) {
+      const idx = (startIndex + offset) % count;
+      const row = virtualIndex.getRowAt(idx);
+      if (!row || row.node.disabled) continue;
+      const label = String(row.node.text ?? "")
+        .trim()
+        .toLowerCase();
+      if (label.startsWith(query)) {
+        virtualMoveTo(idx);
+        break;
+      }
+    }
+    return true;
+  }
+
+  /** @param {KeyboardEvent} e */
+  function handleVirtualKeyDown(e) {
+    if (!virtualConfig || !virtualIndex) return;
+
+    // When focus sits on the scroll container after a row unmounted, resume
+    // from virtualFocusedId / first enabled row.
+    let rowEl =
+      e.target instanceof Element
+        ? e.target.closest("[data-tree-row-id]")
+        : null;
+    let activeIdx = -1;
+    if (rowEl) {
+      const id = rowEl.getAttribute("data-tree-row-id");
+      activeIdx = virtualIndex.findIndexById(/** @type {string} */ (id));
+    } else if (e.target === scrollContainerRef) {
+      if (virtualFocusedId != null && virtualFocusedId !== "") {
+        activeIdx = virtualIndex.findIndexById(virtualFocusedId);
+      }
+      if (activeIdx < 0) {
+        for (let i = 0; i < virtualIndex.totalCount; i++) {
+          const row = virtualIndex.getRowAt(i);
+          if (row && !row.node.disabled) {
+            activeIdx = i;
+            break;
+          }
+        }
+      }
+    }
+    if (activeIdx < 0) return;
+    const item = virtualIndex.getRowAt(activeIdx);
+    if (!item) return;
+
+    if (handleVirtualTypeAhead(e, activeIdx)) {
+      e.preventDefault();
+      e.stopPropagation();
+      return;
+    }
+
+    /** @param {number} from @param {1 | -1} dir */
+    const nextEnabled = (from, dir) => {
+      let i = from;
+      while (i >= 0 && i < virtualIndex.totalCount) {
+        const row = virtualIndex.getRowAt(i);
+        if (row && !row.node.disabled) return i;
+        i += dir;
+      }
+      return -1;
+    };
+
+    const isHomeOrEnd = e.key === "Home" || e.key === "End";
+    const isSelectAll =
+      (e.code === "KeyA" || e.key === "a" || e.key === "A") && e.ctrlKey;
+
+    if (isHomeOrEnd || isSelectAll) {
+      /** @type {Array<string | number>} */
+      const nodeIds = [];
+
+      if (isHomeOrEnd) {
+        e.preventDefault();
+        e.stopPropagation();
+        const targetIdx =
+          e.key === "Home"
+            ? nextEnabled(0, 1)
+            : nextEnabled(virtualIndex.totalCount - 1, -1);
+        if (isMultiselect && e.shiftKey && e.ctrlKey && targetIdx >= 0) {
+          const from = Math.min(activeIdx, targetIdx);
+          const to = Math.max(activeIdx, targetIdx);
+          for (let i = from; i <= to; i++) {
+            const row = virtualIndex.getRowAt(i);
+            if (row && !row.node.disabled) nodeIds.push(row.node.id);
+          }
+          setSelectedIds([...new Set(selectedIds.concat(nodeIds))]);
+        }
+        if (targetIdx >= 0) virtualMoveTo(targetIdx);
+        return;
+      }
+
+      if (isSelectAll) {
+        e.preventDefault();
+        e.stopPropagation();
+        for (let i = 0; i < virtualIndex.totalCount; i++) {
+          const row = virtualIndex.getRowAt(i);
+          if (row && !row.node.disabled) nodeIds.push(row.node.id);
+        }
+        setSelectedIds([...new Set(selectedIds.concat(nodeIds))]);
+        return;
+      }
+    }
+
+    switch (e.key) {
+      case "ArrowDown": {
+        e.preventDefault();
+        e.stopPropagation();
+        const next = nextEnabled(activeIdx + 1, 1);
+        if (next >= 0) virtualMoveTo(next);
+        break;
+      }
+      case "ArrowUp": {
+        e.preventDefault();
+        e.stopPropagation();
+        const prev = nextEnabled(activeIdx - 1, -1);
+        if (prev >= 0) virtualMoveTo(prev);
+        break;
+      }
+      case "ArrowRight": {
+        if (!item.hasChildren) break;
+        e.preventDefault();
+        e.stopPropagation();
+        if ($expandedIdsSetStore.has(item.node.id)) {
+          // Already expanded: focus first child (next row).
+          const next = nextEnabled(activeIdx + 1, 1);
+          if (next >= 0) virtualMoveTo(next);
+        } else {
+          expandNode(item.node, true);
+          toggleNode(item.node);
+        }
+        break;
+      }
+      case "ArrowLeft": {
+        e.preventDefault();
+        e.stopPropagation();
+        if (item.hasChildren && $expandedIdsSetStore.has(item.node.id)) {
+          expandNode(item.node, false);
+          toggleNode(item.node);
+        } else if (item.parentId != null) {
+          const parentIdx = virtualIndex.findIndexById(item.parentId);
+          if (parentIdx >= 0) virtualMoveTo(parentIdx);
+        }
+        break;
+      }
+      case "Enter":
+      case " ": {
+        if (item.node.disabled) break;
+        e.preventDefault();
+        e.stopPropagation();
+        // Match recursive TreeViewNodeList: Space only activates (check /
+        // select); Enter also toggles expansion on parents.
+        if (e.key === "Enter" && item.hasChildren) {
+          expandNode(item.node, !$expandedIdsSetStore.has(item.node.id));
+          toggleNode(item.node);
+        }
+        clickNode(item.node, e);
+        break;
+      }
     }
   }
 
@@ -1261,30 +1801,77 @@
   </label>
 {/if}
 
-<!-- svelte-ignore a11y-no-noninteractive-element-to-interactive-role -->
-<ul
-  {...$$restProps}
-  role="tree"
-  bind:this={ref}
-  class:bx--tree={true}
-  class:bx--tree--default={size === "default"}
-  class:bx--tree--compact={size === "compact"}
-  class:bx--tree--multiselect={isMultiselect}
-  class:bx--tree--checkbox={isCheckboxMode}
-  class:bx--tree--multiselect-modifier={isMultiselect &&
-    multiselectModifierActive}
-  aria-label={hideLabel ? labelText : undefined}
-  aria-labelledby={hideLabel ? undefined : labelId}
-  aria-multiselectable={isMultiselect || isCheckboxMode || undefined}
-  on:mousedown|capture={syncModifierFromTreeMouseDown}
-  on:selectstart|capture={handleMultiselectSelectStart}
-  on:keydown
-  on:keydown|stopPropagation={handleKeyDown}
->
-  <TreeViewNodeList root {nodes} let:node>
-    <slot {node}> {node.text} </slot>
-    <svelte:fragment slot="childNodes" let:node>
-      <slot name="childNodes" {node} />
-    </svelte:fragment>
-  </TreeViewNodeList>
-</ul>
+{#if virtualConfig}
+  <!-- svelte-ignore a11y-no-noninteractive-element-to-interactive-role -->
+  <ul
+    {...$$restProps}
+    role="tree"
+    bind:this={scrollContainerRef}
+    tabindex="-1"
+    class:bx--tree={true}
+    class:bx--tree--default={size === "default"}
+    class:bx--tree--compact={size === "compact"}
+    class:bx--tree--multiselect={isMultiselect}
+    class:bx--tree--checkbox={isCheckboxMode}
+    class:bx--tree--multiselect-modifier={isMultiselect &&
+      multiselectModifierActive}
+    style="height: {containerHeightStyle}; overflow-y: auto;"
+    aria-label={hideLabel ? labelText : undefined}
+    aria-labelledby={hideLabel ? undefined : labelId}
+    aria-multiselectable={isMultiselect || isCheckboxMode || undefined}
+    on:mousedown|capture={syncModifierFromTreeMouseDown}
+    on:selectstart|capture={handleMultiselectSelectStart}
+    on:scroll={handleVirtualScroll}
+    on:keydown
+    on:keydown|stopPropagation={handleVirtualKeyDown}
+  >
+    {#if virtualData.offsetY > 0}
+      <li aria-hidden="true" style:height="{virtualData.offsetY}px"></li>
+    {/if}
+    {#each virtualData.visibleItems as row (row.node.id)}
+      <TreeViewNodeVirtual
+        item={row}
+        itemHeight={virtualConfig.itemHeight}
+        isTabAnchor={row.node.id === virtualTabAnchorId}
+        let:node
+      >
+        <slot {node}>{node.text}</slot>
+      </TreeViewNodeVirtual>
+    {/each}
+    {#if virtualData.endIndex < virtualIndex.totalCount}
+      <li
+        aria-hidden="true"
+        style:height="{virtualData.totalHeight -
+          virtualData.endIndex * virtualConfig.itemHeight}px"
+      ></li>
+    {/if}
+  </ul>
+{:else}
+  <!-- svelte-ignore a11y-no-noninteractive-element-to-interactive-role -->
+  <ul
+    {...$$restProps}
+    role="tree"
+    bind:this={ref}
+    class:bx--tree={true}
+    class:bx--tree--default={size === "default"}
+    class:bx--tree--compact={size === "compact"}
+    class:bx--tree--multiselect={isMultiselect}
+    class:bx--tree--checkbox={isCheckboxMode}
+    class:bx--tree--multiselect-modifier={isMultiselect &&
+      multiselectModifierActive}
+    aria-label={hideLabel ? labelText : undefined}
+    aria-labelledby={hideLabel ? undefined : labelId}
+    aria-multiselectable={isMultiselect || isCheckboxMode || undefined}
+    on:mousedown|capture={syncModifierFromTreeMouseDown}
+    on:selectstart|capture={handleMultiselectSelectStart}
+    on:keydown
+    on:keydown|stopPropagation={handleKeyDown}
+  >
+    <TreeViewNodeList root {nodes} let:node>
+      <slot {node}> {node.text} </slot>
+      <svelte:fragment slot="childNodes" let:node>
+        <slot name="childNodes" {node} />
+      </svelte:fragment>
+    </TreeViewNodeList>
+  </ul>
+{/if}

--- a/src/TreeView/TreeViewNodeVirtual.svelte
+++ b/src/TreeView/TreeViewNodeVirtual.svelte
@@ -1,0 +1,223 @@
+<script>
+  /**
+   * Flat-row renderer used by `<TreeView virtualize>`. Consumes the same
+   * `carbon:TreeView` context as TreeViewNode / TreeViewNodeList so all
+   * selection / expansion / focus / checkbox callbacks behave identically.
+   *
+   * @typedef {object} Row
+   * @property {{ id: string | number; text?: any; icon?: any; disabled?: boolean; href?: string; target?: string; nodes?: any[] }} node
+   * @property {number} depth
+   * @property {string | number | null} parentId
+   * @property {number} posInSet
+   * @property {number} setSize
+   * @property {boolean} hasChildren
+   */
+
+  /** @type {Row} */
+  export let item;
+
+  /** @type {number} */
+  export let itemHeight;
+
+  /** Whether this row owns tabindex=0 (one focusable row at a time). */
+  export let isTabAnchor = false;
+
+  import { getContext } from "svelte";
+  import Checkbox from "../Checkbox/Checkbox.svelte";
+  import CaretDown from "../icons/CaretDown.svelte";
+
+  const {
+    activeNodeId,
+    selectedIdsSetStore,
+    checkedIdsSetStore,
+    expandedIdsSetStore,
+    indeterminateIdsSetStore,
+    selectionModeStore,
+    clickNode,
+    selectNode,
+    expandNode,
+    focusNode,
+    toggleNode,
+  } = getContext("carbon:TreeView");
+
+  /**
+   * Tri-state value for `aria-checked` on the row.
+   * @returns {"true" | "false" | "mixed"}
+   */
+  function toAriaChecked(isSelected, isIndeterminate) {
+    if (isIndeterminate) return "mixed";
+    return isSelected ? "true" : "false";
+  }
+
+  let prevActiveId = undefined;
+
+  $: ({ node, depth, posInSet, setSize, hasChildren } = item);
+  $: id = node.id;
+  $: disabled = node.disabled === true;
+  $: href = node.href;
+  $: target = node.target;
+  $: expanded = hasChildren && $expandedIdsSetStore.has(id);
+  $: selected = $selectedIdsSetStore.has(id);
+  $: checked = $checkedIdsSetStore.has(id);
+  // Link rows navigate; they render no checkbox (same as TreeViewNode).
+  $: isCheckboxMode =
+    $selectionModeStore === "checkbox" && node.href === undefined;
+  $: indeterminate = isCheckboxMode && $indeterminateIdsSetStore.has(id);
+  $: icon = node.icon;
+  $: isLinkLeaf = href !== undefined && !hasChildren;
+
+  // Flattened-row indent that matches what the recursive TreeViewNodeList
+  // produces visually. In the recursive tree, each ancestor `<li>` contributes
+  // its `.bx--tree-node` `padding-left: $spacing-05` (1rem) through nesting.
+  // The leaf class adds `padding-left: $spacing-08` (2.5rem) or `$spacing-07`
+  // (2rem) with an icon. Checkbox mode uses one inset per depth so the
+  // leading control lines up across parents and leaves.
+  $: leafBase = icon ? 2 : 2.5;
+  $: indentRem = isCheckboxMode || hasChildren ? depth + 1 : depth + leafBase;
+
+  $: mergedNode = {
+    ...node,
+    expanded: hasChildren ? expanded : false,
+    leaf: !hasChildren,
+    selected,
+    checked,
+    indeterminate,
+  };
+
+  // Match TreeViewNode: externally-set activeId auto-selects the row.
+  $: {
+    if (
+      id === $activeNodeId &&
+      prevActiveId !== $activeNodeId &&
+      !$selectedIdsSetStore.has(id)
+    )
+      selectNode(mergedNode);
+
+    prevActiveId = $activeNodeId;
+  }
+</script>
+
+{#if isLinkLeaf}
+  <li role="none" style:height="{itemHeight}px">
+    <!-- svelte-ignore a11y-no-noninteractive-element-to-interactive-role a11y-role-has-required-aria-props -->
+    <a
+      data-tree-row-id={id}
+      role="treeitem"
+      {id}
+      href={disabled ? undefined : href}
+      target={disabled ? undefined : target}
+      rel={target === "_blank" ? "noopener noreferrer" : undefined}
+      style:padding-left="{indentRem}rem"
+      tabindex={disabled ? undefined : isTabAnchor ? 0 : -1}
+      aria-level={depth + 1}
+      aria-posinset={posInSet}
+      aria-setsize={setSize}
+      aria-current={id === $activeNodeId ? "page" : undefined}
+      aria-selected={disabled ? undefined : selected}
+      aria-disabled={disabled}
+      class:bx--tree-node={true}
+      class:bx--tree-leaf-node={true}
+      class:bx--tree-node--active={id === $activeNodeId}
+      class:bx--tree-node--selected={selected}
+      class:bx--tree-node--disabled={disabled}
+      class:bx--tree-node--with-icon={icon}
+      on:click|stopPropagation={(e) => {
+        if (disabled) return;
+        clickNode(mergedNode, e);
+      }}
+      on:focus={() => focusNode(mergedNode)}
+    >
+      <div
+        class:bx--tree-node__label={true}
+        style:margin-left="-{indentRem}rem"
+        style:padding-left="{indentRem}rem"
+      >
+        <svelte:component this={icon} class="bx--tree-node__icon" />
+        <slot node={mergedNode}>{node.text}</slot>
+      </div>
+    </a>
+  </li>
+{:else}
+  <!-- svelte-ignore a11y-no-noninteractive-element-to-interactive-role -->
+  <!-- svelte-ignore a11y-click-events-have-key-events -->
+  <li
+    data-tree-row-id={id}
+    role="treeitem"
+    {id}
+    style:height="{itemHeight}px"
+    style:padding-left="{indentRem}rem"
+    tabindex={disabled ? undefined : isTabAnchor ? 0 : -1}
+    aria-level={depth + 1}
+    aria-posinset={posInSet}
+    aria-setsize={setSize}
+    aria-expanded={hasChildren ? expanded : undefined}
+    aria-current={id === $activeNodeId || undefined}
+    aria-selected={isCheckboxMode || disabled ? undefined : selected}
+    aria-checked={isCheckboxMode
+      ? toAriaChecked(checked, indeterminate)
+      : undefined}
+    aria-disabled={disabled}
+    class:bx--tree-node={true}
+    class:bx--tree-parent-node={hasChildren}
+    class:bx--tree-leaf-node={!hasChildren}
+    class:bx--tree-node--active={id === $activeNodeId}
+    class:bx--tree-node--selected={isCheckboxMode ? checked : selected}
+    class:bx--tree-node--disabled={disabled}
+    class:bx--tree-node--with-icon={icon}
+    on:click|stopPropagation={(e) => {
+      if (disabled) return;
+      // Stop the label from toggling the decorative input; `clickNode`
+      // owns checked state.
+      if (isCheckboxMode) e.preventDefault();
+      clickNode(mergedNode, e);
+    }}
+    on:focus={() => focusNode(mergedNode)}
+  >
+    <div
+      class:bx--tree-node__label={true}
+      style:margin-left="-{indentRem}rem"
+      style:padding-left="{indentRem}rem"
+    >
+      {#if isCheckboxMode}
+        <!-- Decorative input; empty label keeps row textContent stable for type-ahead. -->
+        <Checkbox
+          decorative
+          hideLabel
+          labelText=""
+          {disabled}
+          {indeterminate}
+          {checked}
+        />
+      {/if}
+      {#if hasChildren}
+        <!-- svelte-ignore a11y-click-events-have-key-events -->
+        <!-- svelte-ignore a11y-no-static-element-interactions -->
+        <span
+          class:bx--tree-parent-node__toggle={true}
+          {disabled}
+          on:click={() => {
+            if (disabled) return;
+            expandNode(mergedNode, !expanded);
+            toggleNode(mergedNode);
+          }}
+        >
+          <CaretDown
+            class={[
+              "bx--tree-parent-node__toggle-icon",
+              expanded && "bx--tree-parent-node__toggle-icon--expanded",
+            ]
+              .filter(Boolean)
+              .join(" ")}
+          />
+        </span>
+        <span class:bx--tree-node__label__details={true}>
+          <svelte:component this={icon} class="bx--tree-node__icon" />
+          <slot node={mergedNode}>{node.text}</slot>
+        </span>
+      {:else}
+        <svelte:component this={icon} class="bx--tree-node__icon" />
+        <slot node={mergedNode}>{node.text}</slot>
+      {/if}
+    </div>
+  </li>
+{/if}

--- a/src/utils/treeVirtualIndex.d.ts
+++ b/src/utils/treeVirtualIndex.d.ts
@@ -1,0 +1,47 @@
+import { isExpandableNode } from "./isExpandableNode.js";
+
+type TreeNodeLike = {
+  id: string | number;
+  nodes?: TreeNodeLike[];
+  disabled?: boolean;
+  hasChildren?: boolean;
+  [key: string]: unknown;
+};
+
+export type VisibleTreeRow<T extends TreeNodeLike = TreeNodeLike> = {
+  node: T;
+  depth: number;
+  parentId: string | number | null;
+  posInSet: number;
+  setSize: number;
+  hasChildren: boolean;
+};
+
+export type TreeVirtualIndex<T extends TreeNodeLike = TreeNodeLike> = {
+  totalCount: number;
+  getRowAt: (index: number) => VisibleTreeRow<T> | null;
+  collectRows: (startIndex: number, endIndex: number) => VisibleTreeRow<T>[];
+  findIndexById: (id: string | number) => number;
+};
+
+export { isExpandableNode };
+
+/**
+ * Flatten visible (expanded-only) nodes into annotated rows.
+ * Iterative — one output array, no recursive spread.
+ */
+export function flattenVisibleRows<T extends TreeNodeLike>(
+  nodes: readonly T[],
+  expandedIdsSet: Set<string | number>,
+): VisibleTreeRow<T>[];
+
+/**
+ * Size cache + row lookup for virtualized trees.
+ * Allocates one number per node, not a row object per visible line.
+ * `getRowAt` is O(siblings on path); `collectRows` is one cursor walk
+ * O(path-to-start + window).
+ */
+export function createTreeVirtualIndex<T extends TreeNodeLike>(
+  nodes: readonly T[],
+  expandedIdsSet: Set<string | number>,
+): TreeVirtualIndex<T>;

--- a/src/utils/treeVirtualIndex.js
+++ b/src/utils/treeVirtualIndex.js
@@ -1,0 +1,277 @@
+/**
+ * Virtualization helpers for TreeView: iterative visible flatten (oracle /
+ * small trees), and a size-cache index that avoids materializing a full
+ * visible row array.
+ *
+ * Complexity (after build):
+ * - build: O(n) time and one size entry per node
+ * - getRowAt / findIndexById: O(siblings along the path) — flat/wide lists
+ *   are O(index), not O(depth)
+ * - collectRows: one cursor walk — O(path-to-start + window), not
+ *   O(width × window) from independent getRowAt calls
+ */
+
+export { isExpandableNode } from "./isExpandableNode.js";
+
+/**
+ * @template {{ id: string | number; nodes?: T[]; hasChildren?: boolean }} T
+ * @param {T} node
+ * @returns {boolean}
+ */
+function hasLoadedChildren(node) {
+  return Array.isArray(node.nodes) && node.nodes.length > 0;
+}
+
+/**
+ * Flatten visible (expanded-only) nodes into annotated rows.
+ * Iterative walk — one output array, no recursive `push(...spread)`.
+ *
+ * @template {{ id: string | number; nodes?: T[]; disabled?: boolean; hasChildren?: boolean }} T
+ * @param {ReadonlyArray<T>} nodes
+ * @param {Set<string | number>} expandedIdsSet
+ * @returns {Array<{ node: T; depth: number; parentId: string | number | null; posInSet: number; setSize: number; hasChildren: boolean }>}
+ */
+export function flattenVisibleRows(nodes, expandedIdsSet) {
+  /** @type {Array<{ node: T; depth: number; parentId: string | number | null; posInSet: number; setSize: number; hasChildren: boolean }>} */
+  const out = [];
+  /** @type {Array<{ list: ReadonlyArray<T>; depth: number; parentId: string | number | null; index: number }>} */
+  const stack = [{ list: nodes, depth: 0, parentId: null, index: 0 }];
+
+  while (stack.length > 0) {
+    const frame = stack[stack.length - 1];
+    if (frame.index >= frame.list.length) {
+      stack.pop();
+      continue;
+    }
+
+    const i = frame.index++;
+    const node = frame.list[i];
+    const loaded = hasLoadedChildren(node);
+    const hasChildren = loaded || node.hasChildren === true;
+    out.push({
+      node,
+      depth: frame.depth,
+      parentId: frame.parentId,
+      posInSet: i + 1,
+      setSize: frame.list.length,
+      hasChildren,
+    });
+
+    if (loaded && expandedIdsSet.has(node.id)) {
+      stack.push({
+        list: node.nodes,
+        depth: frame.depth + 1,
+        parentId: node.id,
+        index: 0,
+      });
+    }
+  }
+
+  return out;
+}
+
+/**
+ * Build a size cache and row lookup for virtualized trees.
+ * Allocates one number per node (visible subtree size), not a row object
+ * per visible line — so expand-all on 100k+ nodes stays cheap.
+ *
+ * @template {{ id: string | number; nodes?: T[]; disabled?: boolean; hasChildren?: boolean }} T
+ * @param {ReadonlyArray<T>} nodes
+ * @param {Set<string | number>} expandedIdsSet
+ * @returns {{
+ *   totalCount: number,
+ *   getRowAt: (index: number) => { node: T; depth: number; parentId: string | number | null; posInSet: number; setSize: number; hasChildren: boolean } | null,
+ *   collectRows: (startIndex: number, endIndex: number) => Array<{ node: T; depth: number; parentId: string | number | null; posInSet: number; setSize: number; hasChildren: boolean }>,
+ *   findIndexById: (id: string | number) => number,
+ * }}
+ */
+export function createTreeVirtualIndex(nodes, expandedIdsSet) {
+  /** @type {Map<string | number, number>} */
+  const sizeById = new Map();
+
+  /**
+   * Visible row count for `node` including itself.
+   * @param {T} node
+   * @returns {number}
+   */
+  function visibleSize(node) {
+    const cached = sizeById.get(node.id);
+    if (cached != null) return cached;
+
+    let size = 1;
+    if (hasLoadedChildren(node) && expandedIdsSet.has(node.id)) {
+      for (const child of node.nodes) {
+        size += visibleSize(child);
+      }
+    }
+    sizeById.set(node.id, size);
+    return size;
+  }
+
+  let totalCount = 0;
+  for (const node of nodes) {
+    totalCount += visibleSize(node);
+  }
+
+  /**
+   * @param {ReadonlyArray<T>} list
+   * @param {number} depth
+   * @param {string | number | null} parentId
+   * @param {number} targetIndex
+   * @param {number} indexOffset
+   * @returns {{ node: T; depth: number; parentId: string | number | null; posInSet: number; setSize: number; hasChildren: boolean } | null}
+   */
+  function rowAtInList(list, depth, parentId, targetIndex, indexOffset) {
+    let offset = indexOffset;
+    const setSize = list.length;
+    for (let i = 0; i < list.length; i++) {
+      const node = list[i];
+      const size = sizeById.get(node.id) ?? 1;
+      if (targetIndex < offset + size) {
+        const loaded = hasLoadedChildren(node);
+        const hasChildren = loaded || node.hasChildren === true;
+        if (targetIndex === offset) {
+          return {
+            node,
+            depth,
+            parentId,
+            posInSet: i + 1,
+            setSize,
+            hasChildren,
+          };
+        }
+        if (loaded && expandedIdsSet.has(node.id)) {
+          return rowAtInList(
+            node.nodes,
+            depth + 1,
+            node.id,
+            targetIndex,
+            offset + 1,
+          );
+        }
+        return null;
+      }
+      offset += size;
+    }
+    return null;
+  }
+
+  /**
+   * @param {number} index
+   */
+  function getRowAt(index) {
+    if (index < 0 || index >= totalCount) return null;
+    return rowAtInList(nodes, 0, null, index, 0);
+  }
+
+  /**
+   * Collect `[startIndex, endIndex)` in one cursor walk: skip whole
+   * subtrees via `sizeById` until `start`, then emit until `end`.
+   * @param {number} startIndex
+   * @param {number} endIndex
+   */
+  function collectRows(startIndex, endIndex) {
+    const start = Math.max(0, startIndex);
+    const end = Math.min(totalCount, endIndex);
+    /** @type {Array<{ node: T; depth: number; parentId: string | number | null; posInSet: number; setSize: number; hasChildren: boolean }>} */
+    const rows = [];
+    if (start >= end) return rows;
+
+    /** @type {Array<{ list: ReadonlyArray<T>; depth: number; parentId: string | number | null; index: number; offset: number }>} */
+    const stack = [
+      { list: nodes, depth: 0, parentId: null, index: 0, offset: 0 },
+    ];
+
+    while (stack.length > 0 && rows.length < end - start) {
+      const frame = stack[stack.length - 1];
+      if (frame.index >= frame.list.length) {
+        stack.pop();
+        continue;
+      }
+
+      const i = frame.index;
+      const node = frame.list[i];
+      const size = sizeById.get(node.id) ?? 1;
+      const nodeStart = frame.offset;
+      const nodeEnd = nodeStart + size;
+
+      if (nodeEnd <= start) {
+        // Entire subtree is before the window — skip it.
+        frame.index++;
+        frame.offset = nodeEnd;
+        continue;
+      }
+
+      if (nodeStart >= end) break;
+
+      const loaded = hasLoadedChildren(node);
+      const hasChildren = loaded || node.hasChildren === true;
+
+      if (nodeStart >= start && nodeStart < end) {
+        rows.push({
+          node,
+          depth: frame.depth,
+          parentId: frame.parentId,
+          posInSet: i + 1,
+          setSize: frame.list.length,
+          hasChildren,
+        });
+      }
+
+      frame.index++;
+      frame.offset = nodeEnd;
+
+      // Descend when the window still needs rows inside this expanded subtree.
+      if (
+        loaded &&
+        expandedIdsSet.has(node.id) &&
+        nodeStart + 1 < end &&
+        nodeEnd > start
+      ) {
+        stack.push({
+          list: node.nodes,
+          depth: frame.depth + 1,
+          parentId: node.id,
+          index: 0,
+          offset: nodeStart + 1,
+        });
+      }
+    }
+
+    return rows;
+  }
+
+  /**
+   * @param {string | number} id
+   * @returns {number} visible index, or -1 if not currently visible
+   */
+  function findIndexById(id) {
+    const needle = String(id);
+    /**
+     * @param {ReadonlyArray<T>} list
+     * @param {number} indexOffset
+     * @returns {number}
+     */
+    function findInList(list, indexOffset) {
+      let offset = indexOffset;
+      for (let i = 0; i < list.length; i++) {
+        const node = list[i];
+        if (String(node.id) === needle) return offset;
+        const size = sizeById.get(node.id) ?? 1;
+        if (
+          hasLoadedChildren(node) &&
+          expandedIdsSet.has(node.id) &&
+          size > 1
+        ) {
+          const found = findInList(node.nodes, offset + 1);
+          if (found >= 0) return found;
+        }
+        offset += size;
+      }
+      return -1;
+    }
+    return findInList(nodes, 0);
+  }
+
+  return { totalCount, getRowAt, collectRows, findIndexById };
+}

--- a/tests/TreeView/TreeView.virtualize.checkbox.test.svelte
+++ b/tests/TreeView/TreeView.virtualize.checkbox.test.svelte
@@ -1,0 +1,58 @@
+<script lang="ts">
+  import type { TreeNode } from "carbon-components-svelte/TreeView/TreeView.svelte";
+  import TreeView from "carbon-components-svelte/TreeView/TreeView.svelte";
+  import type { ComponentProps } from "svelte";
+
+  type Id = TreeNode["id"];
+
+  export let checkMode: ComponentProps<TreeView>["checkMode"] = "deep";
+  export let checkedIds: Id[] = [];
+  export let indeterminateIds: ReadonlyArray<Id> = [];
+  /** Spy for the aggregate `check:change` event. */
+  export let onCheckChange: (detail: {
+    checkedIds: ReadonlyArray<Id>;
+    added: Id[];
+    removed: Id[];
+    indeterminateIds: ReadonlyArray<Id>;
+  }) => void = () => {};
+
+  export let nodes: NonNullable<ComponentProps<TreeView>["nodes"]> = [
+    {
+      id: "analytics",
+      text: "Analytics",
+      nodes: [
+        { id: "spark", text: "Apache Spark" },
+        { id: "hadoop", text: "Hadoop" },
+        { id: "legacy", text: "Legacy warehouse", disabled: true },
+      ],
+    },
+    {
+      id: "blockchain",
+      text: "Blockchain",
+      nodes: [{ id: "platform", text: "IBM Blockchain Platform" }],
+    },
+    { id: "docs", text: "Documentation", href: "/docs" },
+  ];
+
+  // Pad with enough collapsed roots that windowing is active, while keeping
+  // the interactive subtree near the top of the viewport.
+  const paddingRoots: TreeNode[] = Array.from({ length: 80 }, (_, i) => ({
+    id: `pad-${i}`,
+    text: `Padding ${i}`,
+    nodes: [{ id: `pad-${i}-child`, text: `Padding ${i} child` }],
+  }));
+
+  $: allNodes = [...nodes, ...paddingRoots];
+</script>
+
+<TreeView
+  labelText="Permissions"
+  nodes={allNodes}
+  selectionMode="checkbox"
+  {checkMode}
+  expandedIds={["analytics", "blockchain"]}
+  virtualize={{ maxVisibleRows: 10 }}
+  bind:checkedIds
+  bind:indeterminateIds
+  on:check:change={({ detail }) => onCheckChange(detail)}
+/>

--- a/tests/TreeView/TreeView.virtualize.checkbox.test.ts
+++ b/tests/TreeView/TreeView.virtualize.checkbox.test.ts
@@ -1,0 +1,124 @@
+import { render, screen } from "@testing-library/svelte";
+import { tick } from "svelte";
+import { user } from "../utils/user";
+import TreeViewVirtualizeCheckbox from "./TreeView.virtualize.checkbox.test.svelte";
+
+function treeItemById(id: string): HTMLElement {
+  const el = document.getElementById(id);
+  expect.assert(el instanceof HTMLElement);
+  return el;
+}
+
+function checkboxFor(id: string): HTMLElement {
+  const el = treeItemById(id).querySelector(".bx--checkbox-wrapper");
+  expect.assert(el instanceof HTMLElement);
+  return el;
+}
+
+describe("TreeView virtualize + selectionMode=checkbox", () => {
+  it("renders checkboxes on windowed rows with correct ARIA", () => {
+    render(TreeViewVirtualizeCheckbox);
+
+    expect(
+      treeItemById("analytics").querySelector(".bx--checkbox"),
+    ).not.toBeNull();
+    expect(treeItemById("spark").querySelector(".bx--checkbox")).not.toBeNull();
+    expect(treeItemById("analytics")).toHaveAttribute("aria-checked", "false");
+    expect(treeItemById("analytics")).not.toHaveAttribute("aria-selected");
+    // Link rows still skip the checkbox in the virtual path.
+    expect(treeItemById("docs").querySelector(".bx--checkbox")).toBeNull();
+  });
+
+  it("checks every descendant when a branch checkbox is clicked", async () => {
+    render(TreeViewVirtualizeCheckbox);
+
+    await user.click(checkboxFor("analytics"));
+
+    expect(treeItemById("analytics")).toHaveAttribute("aria-checked", "true");
+    expect(treeItemById("spark")).toHaveAttribute("aria-checked", "true");
+    expect(treeItemById("hadoop")).toHaveAttribute("aria-checked", "true");
+    expect(treeItemById("legacy")).toHaveAttribute("aria-checked", "false");
+  });
+
+  it("does not toggle when the row body is clicked", async () => {
+    render(TreeViewVirtualizeCheckbox);
+
+    await user.click(treeItemById("spark"));
+
+    expect(treeItemById("spark")).toHaveAttribute("aria-checked", "false");
+  });
+
+  it("flips the branch to mixed when one child is unchecked", async () => {
+    render(TreeViewVirtualizeCheckbox);
+
+    await user.click(checkboxFor("analytics"));
+    await user.click(checkboxFor("spark"));
+
+    expect(treeItemById("analytics")).toHaveAttribute("aria-checked", "mixed");
+    expect(treeItemById("spark")).toHaveAttribute("aria-checked", "false");
+    expect(treeItemById("hadoop")).toHaveAttribute("aria-checked", "true");
+  });
+
+  it('leaves ancestors untouched with checkMode="node"', async () => {
+    render(TreeViewVirtualizeCheckbox, { checkMode: "node" });
+
+    await user.click(checkboxFor("spark"));
+
+    expect(treeItemById("spark")).toHaveAttribute("aria-checked", "true");
+    expect(treeItemById("hadoop")).toHaveAttribute("aria-checked", "false");
+    expect(treeItemById("analytics")).toHaveAttribute("aria-checked", "false");
+  });
+
+  it("toggles with Space without expanding, and Enter expands parents", async () => {
+    render(TreeViewVirtualizeCheckbox);
+
+    const analytics = treeItemById("analytics");
+    analytics.focus();
+    expect(analytics).toHaveAttribute("aria-expanded", "true");
+
+    await user.keyboard(" ");
+    expect(analytics).toHaveAttribute("aria-checked", "true");
+    expect(analytics).toHaveAttribute("aria-expanded", "true");
+
+    await user.keyboard("{Enter}");
+    expect(analytics).toHaveAttribute("aria-expanded", "false");
+    expect(analytics).toHaveAttribute("aria-checked", "false");
+  });
+
+  it("preserves checked state when the row scrolls out and back in", async () => {
+    render(TreeViewVirtualizeCheckbox);
+
+    await user.click(checkboxFor("spark"));
+    expect(treeItemById("spark")).toHaveAttribute("aria-checked", "true");
+
+    const tree = screen.getByRole("tree");
+    // Scroll far enough that the interactive subtree leaves the window.
+    tree.scrollTop = 2000;
+    tree.dispatchEvent(new Event("scroll"));
+    await tick();
+
+    expect(document.getElementById("spark")).toBeNull();
+
+    tree.scrollTop = 0;
+    tree.dispatchEvent(new Event("scroll"));
+    await tick();
+
+    expect(treeItemById("spark")).toHaveAttribute("aria-checked", "true");
+    expect(treeItemById("analytics")).toHaveAttribute("aria-checked", "mixed");
+  });
+
+  it("fires check:change once per gesture with the derived state", async () => {
+    const onCheckChange = vi.fn();
+    render(TreeViewVirtualizeCheckbox, { onCheckChange });
+
+    await user.click(checkboxFor("spark"));
+
+    await vi.waitFor(() => expect(onCheckChange).toHaveBeenCalledTimes(1));
+    expect(onCheckChange).toHaveBeenLastCalledWith({
+      checkedIds: ["spark"],
+      added: ["spark"],
+      removed: [],
+      indeterminateIds: ["analytics"],
+    });
+  });
+});

--- a/tests/TreeView/TreeView.virtualize.href.test.svelte
+++ b/tests/TreeView/TreeView.virtualize.href.test.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+  import TreeView from "carbon-components-svelte/TreeView/TreeView.svelte";
+  import type { ComponentProps } from "svelte";
+
+  export let nodes: NonNullable<ComponentProps<TreeView>["nodes"]> = [
+    { id: "link-1", text: "Link Node", href: "/page-1" },
+    { id: "plain-1", text: "Plain Node" },
+    {
+      id: "link-disabled",
+      text: "Disabled Link",
+      href: "/disabled",
+      disabled: true,
+    },
+    {
+      id: "link-blank",
+      text: "Blank Target",
+      href: "/external",
+      target: "_blank",
+    },
+    {
+      id: "link-self",
+      text: "Self Target",
+      href: "/internal",
+      target: "_self",
+    },
+    // Pad so virtualization stays active.
+    ...Array.from({ length: 80 }, (_, i) => ({
+      id: `pad-${i}`,
+      text: `Padding ${i}`,
+    })),
+  ];
+  export let activeId: ComponentProps<TreeView>["activeId"] = "";
+  export let selectedIds: ComponentProps<TreeView>["selectedIds"] = [];
+</script>
+
+<TreeView
+  {nodes}
+  bind:activeId
+  bind:selectedIds
+  labelText="Link Tree"
+  virtualize={{ maxVisibleRows: 10 }}
+/>

--- a/tests/TreeView/TreeView.virtualize.href.test.ts
+++ b/tests/TreeView/TreeView.virtualize.href.test.ts
@@ -1,0 +1,55 @@
+import { render, screen } from "@testing-library/svelte";
+import TreeViewVirtualizeHref from "./TreeView.virtualize.href.test.svelte";
+
+describe("TreeView virtualize + href", () => {
+  it("renders an anchor with role=treeitem when href is set", () => {
+    render(TreeViewVirtualizeHref);
+
+    const linkNode = screen.getByRole("treeitem", { name: /Link Node/ });
+    expect(linkNode.tagName).toBe("A");
+    expect(linkNode).toHaveAttribute("href", "/page-1");
+    expect(linkNode).toHaveAttribute("data-tree-row-id", "link-1");
+  });
+
+  it("wraps the anchor in a li with role=none", () => {
+    render(TreeViewVirtualizeHref);
+
+    const linkNode = screen.getByRole("treeitem", { name: /Link Node/ });
+    expect(linkNode.closest("li")).toHaveAttribute("role", "none");
+  });
+
+  it("renders a regular li when href is not set", () => {
+    render(TreeViewVirtualizeHref);
+
+    const plainNode = screen.getByRole("treeitem", { name: /Plain Node/ });
+    expect(plainNode.tagName).toBe("LI");
+    expect(plainNode).not.toHaveAttribute("href");
+  });
+
+  it("does not set href or target on disabled link nodes", () => {
+    render(TreeViewVirtualizeHref);
+
+    const disabledLink = screen.getByRole("treeitem", {
+      name: /Disabled Link/,
+    });
+    expect(disabledLink.tagName).toBe("A");
+    expect(disabledLink).not.toHaveAttribute("href");
+    expect(disabledLink).not.toHaveAttribute("target");
+  });
+
+  it("sets target and rel=noopener noreferrer for _blank", () => {
+    render(TreeViewVirtualizeHref);
+
+    const blankLink = screen.getByRole("treeitem", { name: /Blank Target/ });
+    expect(blankLink).toHaveAttribute("target", "_blank");
+    expect(blankLink).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
+  it("does not add rel when target is not _blank", () => {
+    render(TreeViewVirtualizeHref);
+
+    const selfLink = screen.getByRole("treeitem", { name: /Self Target/ });
+    expect(selfLink).toHaveAttribute("target", "_self");
+    expect(selfLink).not.toHaveAttribute("rel");
+  });
+});

--- a/tests/TreeView/TreeView.virtualize.lazy.test.svelte
+++ b/tests/TreeView/TreeView.virtualize.lazy.test.svelte
@@ -1,0 +1,69 @@
+<script lang="ts">
+  import type { TreeNode } from "carbon-components-svelte/TreeView/TreeView.svelte";
+  import TreeView from "carbon-components-svelte/TreeView/TreeView.svelte";
+  import type { ComponentProps } from "svelte";
+
+  type LazyNode = TreeNode & { hasChildren?: boolean };
+
+  export let nodes: NonNullable<ComponentProps<TreeView>["nodes"]> = [
+    { id: "root-a", text: "Folder A", hasChildren: true },
+    { id: "root-b", text: "Folder B", hasChildren: true },
+    ...Array.from({ length: 80 }, (_, i) => ({
+      id: `pad-${i}`,
+      text: `Padding ${i}`,
+      hasChildren: true,
+    })),
+  ];
+
+  let resolveFetch: (() => void) | undefined;
+
+  export function resolveLoad() {
+    resolveFetch?.();
+  }
+
+  function updateNode(
+    list: LazyNode[],
+    id: LazyNode["id"],
+    updater: (n: LazyNode) => LazyNode,
+  ): LazyNode[] {
+    return list.map((n) => {
+      if (n.id === id) return updater(n);
+      if (n.nodes) {
+        return {
+          ...n,
+          nodes: updateNode(n.nodes as LazyNode[], id, updater),
+        };
+      }
+      return n;
+    });
+  }
+
+  function handleToggle(event: CustomEvent<LazyNode>) {
+    const node = event.detail;
+    if (!node.hasChildren || node.nodes) return;
+
+    nodes = updateNode(nodes as LazyNode[], node.id, (n) => ({
+      ...n,
+      nodes: [{ id: `${n.id}__loading`, text: "Loading…", disabled: true }],
+    }));
+
+    new Promise<void>((resolve) => {
+      resolveFetch = resolve;
+    }).then(() => {
+      nodes = updateNode(nodes as LazyNode[], node.id, (n) => ({
+        ...n,
+        nodes: [
+          { id: `${n.id}-child-1`, text: `${n.text} child 1` },
+          { id: `${n.id}-child-2`, text: `${n.text} child 2` },
+        ],
+      }));
+    });
+  }
+</script>
+
+<TreeView
+  {nodes}
+  labelText="Lazy virtual tree"
+  virtualize={{ maxVisibleRows: 10 }}
+  on:toggle={handleToggle}
+/>

--- a/tests/TreeView/TreeView.virtualize.lazy.test.ts
+++ b/tests/TreeView/TreeView.virtualize.lazy.test.ts
@@ -1,0 +1,47 @@
+import { render, waitFor } from "@testing-library/svelte";
+import { tick } from "svelte";
+import { user } from "../utils/user";
+import TreeViewVirtualizeLazy from "./TreeView.virtualize.lazy.test.svelte";
+
+const findRowById = (id: string) =>
+  document.querySelector(
+    `[data-tree-row-id="${CSS.escape(id)}"]`,
+  ) as HTMLElement | null;
+
+describe("TreeView virtualize + hasChildren lazy load", () => {
+  it("renders an expander for unloaded hasChildren parents", () => {
+    render(TreeViewVirtualizeLazy);
+
+    const root = findRowById("root-a");
+    expect(root).not.toBeNull();
+    expect(root).toHaveAttribute("aria-expanded", "false");
+    expect(root?.querySelector(".bx--tree-parent-node__toggle")).not.toBeNull();
+    expect(findRowById("root-a-child-1")).toBeNull();
+  });
+
+  it("mounts fetched children as virtual rows after expand resolves", async () => {
+    const { component } = render(TreeViewVirtualizeLazy);
+
+    const root = findRowById("root-a");
+    expect.assert(root instanceof HTMLElement);
+    const caret = root.querySelector(
+      ".bx--tree-parent-node__toggle",
+    ) as HTMLElement;
+    await user.click(caret);
+    await tick();
+
+    expect(findRowById("root-a__loading")).not.toBeNull();
+    expect(findRowById("root-a__loading")).toHaveAttribute(
+      "aria-disabled",
+      "true",
+    );
+
+    component.resolveLoad();
+    await waitFor(() => {
+      expect(findRowById("root-a__loading")).toBeNull();
+      expect(findRowById("root-a-child-1")).not.toBeNull();
+      expect(findRowById("root-a-child-2")).not.toBeNull();
+    });
+    expect(findRowById("root-a-child-1")).toHaveAttribute("aria-level", "2");
+  });
+});

--- a/tests/TreeView/TreeView.virtualize.test.svelte
+++ b/tests/TreeView/TreeView.virtualize.test.svelte
@@ -1,0 +1,85 @@
+<svelte:options accessors />
+
+<script lang="ts">
+  import type { TreeNode } from "carbon-components-svelte/TreeView/TreeView.svelte";
+  import TreeView from "carbon-components-svelte/TreeView/TreeView.svelte";
+  import type { ComponentProps } from "svelte";
+
+  export let totalRoots = 500;
+  export let childrenPerRoot = 3;
+
+  // Large enough that windowing matters: totalRoots visible rows when collapsed.
+  function buildTree(roots: number, perRoot: number): TreeNode[] {
+    const out: TreeNode[] = [];
+    let next = 0;
+    for (let r = 0; r < roots; r++) {
+      const rootId = next++;
+      const children: TreeNode[] = [];
+      for (let c = 0; c < perRoot; c++) {
+        children.push({ id: next++, text: `root-${rootId}-child-${c}` });
+      }
+      out.push({ id: rootId, text: `root-${rootId}`, nodes: children });
+    }
+    return out;
+  }
+
+  export let showNodeId: TreeNode["id"] = 0;
+  export let expandBeforeShowId: TreeNode["id"] = 0;
+  export let virtualize: ComponentProps<TreeView>["virtualize"] = {
+    maxVisibleRows: 10,
+  };
+  export let multiselect = false;
+
+  let treeview: TreeView;
+  export let activeId: TreeNode["id"] = "";
+  export let selectedIds: TreeNode["id"][] = [];
+  let expandedIds: TreeNode["id"][] = [];
+  let scrollContainerRef: ComponentProps<TreeView>["scrollContainerRef"] = null;
+  $: nodes = buildTree(totalRoots, childrenPerRoot);
+</script>
+
+<TreeView
+  bind:this={treeview}
+  bind:scrollContainerRef
+  labelText="Virtualized tree"
+  {virtualize}
+  {multiselect}
+  {nodes}
+  bind:activeId
+  bind:selectedIds
+  bind:expandedIds
+  let:node
+>
+  {node.text}
+</TreeView>
+
+<button
+  type="button"
+  data-testid="set-active"
+  on:click={() => {
+    activeId = showNodeId;
+  }}
+>
+  Set active
+</button>
+
+<button
+  type="button"
+  data-testid="show-node"
+  on:click={() => treeview.showNode(showNodeId)}
+>
+  Show node
+</button>
+
+<!-- Mirrors the docs example, without awaiting a flush in between: `showNode`
+     runs while the rendered window still reflects the collapsed tree. -->
+<button
+  type="button"
+  data-testid="expand-and-show-node"
+  on:click={() => {
+    expandedIds = [expandBeforeShowId];
+    treeview.showNode(showNodeId);
+  }}
+>
+  Expand and show node
+</button>

--- a/tests/TreeView/TreeView.virtualize.test.ts
+++ b/tests/TreeView/TreeView.virtualize.test.ts
@@ -1,0 +1,356 @@
+import { render, screen, waitFor } from "@testing-library/svelte";
+import { tick } from "svelte";
+import { user } from "../utils/user";
+import TreeViewVirtualize from "./TreeView.virtualize.test.svelte";
+
+const countRows = () => screen.queryAllByRole("treeitem").length;
+
+const findRowById = (id: number | string) =>
+  document.querySelector(
+    `[data-tree-row-id="${CSS.escape(String(id))}"]`,
+  ) as HTMLElement | null;
+
+describe("TreeView (virtualize)", () => {
+  it("windows the DOM to the overscan-bounded slice of a large tree", () => {
+    // 500 collapsed roots. itemHeight=32, container=320 (maxVisibleRows=10),
+    // overscan=3 → endIndex = ceil(320/32)+3 = 13 at scrollTop=0.
+    render(TreeViewVirtualize, { totalRoots: 500, childrenPerRoot: 3 });
+
+    expect(countRows()).toBe(13);
+    expect(findRowById(0)).not.toBeNull();
+    // Root ids advance by 4 (1 root + 3 children). Row 12 is root #12 → id 48.
+    expect(findRowById(48)).not.toBeNull();
+    // Row 13 (root #13, id 52) is past the window.
+    expect(findRowById(52)).toBeNull();
+  });
+
+  it("renders spacer <li>s above/below the visible window", () => {
+    render(TreeViewVirtualize, { totalRoots: 500, childrenPerRoot: 3 });
+
+    const ul = screen.getByRole("tree");
+    const spacers = ul.querySelectorAll(':scope > li[aria-hidden="true"]');
+    // At scrollTop=0 there's no leading spacer, only a trailing one.
+    expect(spacers.length).toBe(1);
+    const trailing = spacers[0] as HTMLElement;
+    const trailingHeight = Number.parseFloat(trailing.style.height);
+    expect(trailingHeight).toBeGreaterThan(0);
+  });
+
+  it("renders rows with the expected ARIA tree metadata", () => {
+    render(TreeViewVirtualize, { totalRoots: 500, childrenPerRoot: 3 });
+
+    const firstRow = findRowById(0);
+    expect(firstRow).not.toBeNull();
+    if (!firstRow) throw new Error("expected first row");
+    expect(firstRow).toHaveAttribute("aria-level", "1");
+    expect(firstRow).toHaveAttribute("aria-posinset", "1");
+    expect(firstRow).toHaveAttribute("aria-setsize", "500");
+    // Roots are parents (have children) → aria-expanded is present.
+    expect(firstRow.getAttribute("aria-expanded")).toBe("false");
+  });
+
+  it("shifts the windowed slice when the container is scrolled", async () => {
+    render(TreeViewVirtualize, { totalRoots: 500, childrenPerRoot: 3 });
+
+    // Initially: row 0 mounted, row ~200 not mounted.
+    expect(findRowById(0)).not.toBeNull();
+    expect(findRowById(200)).toBeNull();
+
+    const ul = screen.getByRole("tree");
+    // Each root id is `next++` and root 0 takes ids 0..3 (1 root + 3 leaves).
+    // Roots are collapsed so visible row index === root index. Scroll to put
+    // root #100 in the window (row 100 * 32 = 3200px).
+    ul.scrollTop = 3200;
+    ul.dispatchEvent(new Event("scroll"));
+    await tick();
+
+    expect(findRowById(0)).toBeNull(); // scrolled out
+    // root #100's id = 100 * (1 + 3) = 400.
+    expect(findRowById(400)).not.toBeNull();
+  });
+
+  it("expand/collapse refilters the visible flat list", async () => {
+    render(TreeViewVirtualize, { totalRoots: 500, childrenPerRoot: 3 });
+
+    // Root #0 has id=0; its children have ids 1, 2, 3. Children should not
+    // be mounted while their parent is collapsed.
+    expect(findRowById(1)).toBeNull();
+    expect(findRowById(2)).toBeNull();
+
+    // Click the caret on the root row to toggle expansion (matches the
+    // non-virtualized behavior where row-body click only selects).
+    const root = findRowById(0);
+    if (!root) throw new Error("expected root row");
+    const caret = root.querySelector(
+      ".bx--tree-parent-node__toggle",
+    ) as HTMLElement;
+    await user.click(caret);
+    await tick();
+
+    expect(findRowById(0)).toHaveAttribute("aria-expanded", "true");
+    expect(findRowById(1)).not.toBeNull();
+    expect(findRowById(2)).not.toBeNull();
+    expect(findRowById(3)).not.toBeNull();
+
+    // Children show aria-level=2.
+    expect(findRowById(1)).toHaveAttribute("aria-level", "2");
+  });
+
+  it("ArrowDown moves focus across the window without mutating activeId", async () => {
+    const { component } = render(TreeViewVirtualize, {
+      totalRoots: 500,
+      childrenPerRoot: 3,
+    });
+
+    const first = findRowById(0);
+    if (!first) throw new Error("expected first row");
+    first.focus();
+    expect(first).toHaveFocus();
+    expect(component.activeId).toBe("");
+
+    // Press ArrowDown 20 times — crosses past the initial window (~13 rows).
+    for (let i = 0; i < 20; i++) {
+      // biome-ignore lint/performance/noAwaitInLoops: sequential focus ops
+      await user.keyboard("{ArrowDown}");
+    }
+
+    // Active row should now be id of root #20 = 20 * 4 = 80.
+    const expected = findRowById(80);
+    expect(expected).not.toBeNull();
+    expect(expected).toHaveFocus();
+    // Non-virtual arrows do not mutate activeId; virtual matches that.
+    expect(component.activeId).toBe("");
+  });
+
+  it("setting activeId externally selects the matching virtual row", async () => {
+    render(TreeViewVirtualize, {
+      totalRoots: 500,
+      childrenPerRoot: 3,
+      showNodeId: 4,
+    });
+
+    await user.click(screen.getByTestId("set-active"));
+    await tick();
+
+    const row = findRowById(4);
+    expect(row).not.toBeNull();
+    expect(row).toHaveAttribute("aria-selected", "true");
+    expect(row).toHaveClass("bx--tree-node--selected");
+  });
+
+  it("keeps keyboard navigation after the focused row scrolls out of the window", async () => {
+    render(TreeViewVirtualize, { totalRoots: 500, childrenPerRoot: 3 });
+
+    const first = findRowById(0);
+    if (!first) throw new Error("expected first row");
+    first.focus();
+    expect(first).toHaveFocus();
+
+    const ul = screen.getByRole("tree");
+    ul.scrollTop = 3200;
+    ul.dispatchEvent(new Event("scroll"));
+    await tick();
+    await tick();
+
+    expect(findRowById(0)).toBeNull();
+    expect(document.activeElement).not.toBe(document.body);
+    expect(ul.contains(document.activeElement)).toBe(true);
+
+    await user.keyboard("{ArrowDown}");
+    const focused = document.activeElement as HTMLElement | null;
+    expect(focused?.getAttribute("data-tree-row-id")).toBeTruthy();
+  });
+
+  it("does not steal focus when scrolling a never-focused virtualized tree", async () => {
+    render(TreeViewVirtualize, { totalRoots: 500, childrenPerRoot: 3 });
+
+    expect(document.activeElement).toBe(document.body);
+
+    const ul = screen.getByRole("tree");
+    ul.scrollTop = 3200;
+    ul.dispatchEvent(new Event("scroll"));
+    await tick();
+    await tick();
+
+    expect(document.activeElement).toBe(document.body);
+  });
+
+  it("type-ahead jumps to a matching off-window row", async () => {
+    // Flat roots: id N has text `root-N`. Id 100 is past the initial window.
+    render(TreeViewVirtualize, { totalRoots: 500, childrenPerRoot: 0 });
+
+    const first = findRowById(0);
+    if (!first) throw new Error("expected first row");
+    first.focus();
+
+    await user.keyboard("root-100");
+    await waitFor(() => {
+      expect(findRowById(100)).toHaveFocus();
+    });
+  });
+
+  it("Ctrl+A selects all currently visible (expanded) non-disabled rows", async () => {
+    const { component } = render(TreeViewVirtualize, {
+      totalRoots: 40,
+      childrenPerRoot: 0,
+      multiselect: true,
+      selectedIds: [],
+    });
+
+    const first = findRowById(0);
+    if (!first) throw new Error("expected first row");
+    first.focus();
+
+    await user.keyboard("{Control>}a{/Control}");
+    await tick();
+
+    expect(component.selectedIds).toEqual(
+      Array.from({ length: 40 }, (_, i) => i),
+    );
+  });
+
+  it("Shift+Ctrl+End extends selection toward the end of the visible list", async () => {
+    const { component } = render(TreeViewVirtualize, {
+      totalRoots: 40,
+      childrenPerRoot: 0,
+      multiselect: true,
+      selectedIds: [],
+    });
+
+    const first = findRowById(0);
+    if (!first) throw new Error("expected first row");
+    first.focus();
+
+    await user.keyboard("{Control>}{Shift>}{End}{/Shift}{/Control}");
+    await tick();
+
+    expect(component.selectedIds).toEqual(
+      Array.from({ length: 40 }, (_, i) => i),
+    );
+  });
+
+  it("disconnects ResizeObserver when virtualize is turned off", async () => {
+    const disconnect = vi.fn();
+    class MockResizeObserver {
+      observe = vi.fn();
+      unobserve = vi.fn();
+      disconnect = disconnect;
+      constructor(cb: ResizeObserverCallback) {
+        void cb;
+      }
+    }
+    vi.stubGlobal("ResizeObserver", MockResizeObserver);
+
+    const { rerender } = render(TreeViewVirtualize, {
+      totalRoots: 20,
+      childrenPerRoot: 0,
+      virtualize: { containerHeight: "100%" },
+    });
+    await tick();
+
+    const callsAfterMount = disconnect.mock.calls.length;
+    await rerender({
+      totalRoots: 20,
+      childrenPerRoot: 0,
+      virtualize: undefined,
+    });
+    await tick();
+
+    expect(disconnect.mock.calls.length).toBeGreaterThan(callsAfterMount);
+    vi.unstubAllGlobals();
+  });
+
+  it("clamps scrollTop when the visible list shrinks past the current scroll position", async () => {
+    const { rerender } = render(TreeViewVirtualize, {
+      totalRoots: 500,
+      childrenPerRoot: 3,
+    });
+
+    // Scroll near the end of the original 500-row list.
+    const ul = screen.getByRole("tree");
+    ul.scrollTop = 14000;
+    ul.dispatchEvent(new Event("scroll"));
+    await tick();
+
+    // Re-render with a much smaller tree — the prior scrollTop is far past
+    // the new max. Without clamping, the visible window would slice past
+    // the end of the array and the tree would render blank.
+    await rerender({ totalRoots: 5, childrenPerRoot: 3 });
+    await tick();
+
+    expect(countRows()).toBeGreaterThan(0);
+    // The first root of the new tree should be mounted.
+    expect(findRowById(0)).not.toBeNull();
+  });
+
+  it("showNode focuses a row at the very end of the list, clamping the scroll position", async () => {
+    // Last root (#499) has id 1996; its last child is 1999. Reaching it
+    // requires expanding the branch and scrolling past the clamped maximum.
+    render(TreeViewVirtualize, {
+      totalRoots: 500,
+      childrenPerRoot: 3,
+      showNodeId: 1999,
+    });
+
+    await user.click(screen.getByTestId("show-node"));
+
+    await waitFor(() => {
+      expect(findRowById(1999)).not.toBeNull();
+      expect(findRowById(1999)).toHaveFocus();
+    });
+
+    // 503 visible rows * 32px - 320px container = 15776px max scroll.
+    expect(screen.getByRole("tree").scrollTop).toBe(15776);
+  });
+
+  it("showNode focuses the target when the consumer expands a branch in the same pass", async () => {
+    render(TreeViewVirtualize, {
+      totalRoots: 500,
+      childrenPerRoot: 3,
+      expandBeforeShowId: 1996,
+      showNodeId: 1999,
+    });
+
+    // Scroll somewhere unrelated first so the target starts far offscreen.
+    const ul = screen.getByRole("tree");
+    ul.scrollTop = 3200;
+    ul.dispatchEvent(new Event("scroll"));
+    await tick();
+
+    await user.click(screen.getByTestId("expand-and-show-node"));
+
+    await waitFor(() => {
+      expect(findRowById(1999)).not.toBeNull();
+      expect(findRowById(1999)).toHaveFocus();
+    });
+  });
+
+  it("showNode leaves the scroll position alone when the row is already visible", async () => {
+    render(TreeViewVirtualize, {
+      totalRoots: 500,
+      childrenPerRoot: 3,
+      showNodeId: 4, // root #1, within the initial window
+    });
+
+    await user.click(screen.getByTestId("show-node"));
+
+    await waitFor(() => expect(findRowById(4)).toHaveFocus());
+    expect(screen.getByRole("tree").scrollTop).toBe(0);
+  });
+
+  it("showNode scrolls a deep, offscreen node into view and focuses it", async () => {
+    // root #300's id = 1200; target one of its children (id 1201).
+    render(TreeViewVirtualize, {
+      totalRoots: 500,
+      childrenPerRoot: 3,
+      showNodeId: 1201,
+    });
+
+    await user.click(screen.getByTestId("show-node"));
+
+    await waitFor(() => {
+      expect(findRowById(1201)).not.toBeNull();
+      expect(findRowById(1201)).toHaveFocus();
+    });
+  });
+});

--- a/tests/utils/treeVirtualIndex.test.ts
+++ b/tests/utils/treeVirtualIndex.test.ts
@@ -1,0 +1,123 @@
+import {
+  createTreeVirtualIndex,
+  flattenVisibleRows,
+  isExpandableNode,
+} from "../../src/utils/treeVirtualIndex.js";
+
+describe("treeVirtualIndex", () => {
+  const nodes = [
+    { id: 0, text: "leaf-root" },
+    {
+      id: 1,
+      text: "branch",
+      nodes: [
+        {
+          id: 2,
+          text: "nested",
+          nodes: [
+            { id: 3, text: "a" },
+            { id: 4, text: "b" },
+          ],
+        },
+        { id: 5, text: "sibling" },
+      ],
+    },
+    {
+      id: 6,
+      text: "lazy",
+      hasChildren: true,
+      nodes: [],
+    },
+  ];
+
+  it("isExpandableNode matches loaded children and lazy hasChildren", () => {
+    expect(isExpandableNode(nodes[0])).toBe(false);
+    expect(isExpandableNode(nodes[1])).toBe(true);
+    expect(isExpandableNode(nodes[2])).toBe(true);
+    expect(isExpandableNode({ id: 9, nodes: [] })).toBe(false);
+  });
+
+  it("flattenVisibleRows with empty expand is only roots", () => {
+    const rows = flattenVisibleRows(nodes, new Set());
+    expect(rows.map((r) => r.node.id)).toEqual([0, 1, 6]);
+    expect(rows.map((r) => r.depth)).toEqual([0, 0, 0]);
+    expect(rows[1].hasChildren).toBe(true);
+    expect(rows[2].hasChildren).toBe(true);
+  });
+
+  it("flattenVisibleRows expands only loaded children when id is expanded", () => {
+    const rows = flattenVisibleRows(nodes, new Set([1, 2]));
+    expect(rows.map((r) => r.node.id)).toEqual([0, 1, 2, 3, 4, 5, 6]);
+    expect(rows.find((r) => r.node.id === 3)).toMatchObject({
+      depth: 2,
+      parentId: 2,
+      posInSet: 1,
+      setSize: 2,
+      hasChildren: false,
+    });
+  });
+
+  it("lazy hasChildren parents stay leaves in flatten until nodes load", () => {
+    const rows = flattenVisibleRows(nodes, new Set([6]));
+    expect(rows.map((r) => r.node.id)).toEqual([0, 1, 6]);
+  });
+
+  it("createTreeVirtualIndex totalCount matches flatten length", () => {
+    const expanded = new Set([1, 2]);
+    const flat = flattenVisibleRows(nodes, expanded);
+    const index = createTreeVirtualIndex(nodes, expanded);
+    expect(index.totalCount).toBe(flat.length);
+  });
+
+  it("getRowAt matches flattenVisibleRows for every index", () => {
+    const expanded = new Set([1, 2]);
+    const flat = flattenVisibleRows(nodes, expanded);
+    const index = createTreeVirtualIndex(nodes, expanded);
+    for (let i = 0; i < flat.length; i++) {
+      expect(index.getRowAt(i)).toEqual(flat[i]);
+    }
+    expect(index.getRowAt(-1)).toBeNull();
+    expect(index.getRowAt(flat.length)).toBeNull();
+  });
+
+  it("collectRows returns only the window", () => {
+    const expanded = new Set([1, 2]);
+    const flat = flattenVisibleRows(nodes, expanded);
+    const index = createTreeVirtualIndex(nodes, expanded);
+    expect(index.collectRows(2, 5)).toEqual(flat.slice(2, 5));
+  });
+
+  it("collectRows matches flatten for every window on a wide flat tree", () => {
+    const wide = Array.from({ length: 2000 }, (_, i) => ({
+      id: i,
+      text: `item-${i}`,
+    }));
+    const flat = flattenVisibleRows(wide, new Set());
+    const index = createTreeVirtualIndex(wide, new Set());
+    expect(index.totalCount).toBe(2000);
+    expect(index.collectRows(1980, 2000).map((r) => r.node.id)).toEqual(
+      flat.slice(1980, 2000).map((r) => r.node.id),
+    );
+    expect(index.collectRows(0, 10).map((r) => r.node.id)).toEqual(
+      flat.slice(0, 10).map((r) => r.node.id),
+    );
+    expect(index.collectRows(500, 520)).toEqual(flat.slice(500, 520));
+  });
+
+  it("findIndexById returns visible index or -1", () => {
+    const collapsed = createTreeVirtualIndex(nodes, new Set());
+    expect(collapsed.findIndexById(1)).toBe(1);
+    expect(collapsed.findIndexById(3)).toBe(-1);
+
+    const expanded = createTreeVirtualIndex(nodes, new Set([1, 2]));
+    expect(expanded.findIndexById(3)).toBe(3);
+    expect(expanded.findIndexById(5)).toBe(5);
+    expect(expanded.findIndexById(99)).toBe(-1);
+  });
+
+  it("empty expandAll-shaped set still lists roots only until parents expand", () => {
+    const index = createTreeVirtualIndex(nodes, new Set());
+    expect(index.totalCount).toBe(3);
+    expect(index.getRowAt(0)?.node.id).toBe(0);
+  });
+});


### PR DESCRIPTION
Opt-in via `virtualize` (boolean or config). Only the viewport
slice is mounted, with a size-cache index so expand-all on large
trees stays cheap. Docs cover the full tree demo plus lazy
`hasChildren` fetching; checkbox mode works on the same path.

---


https://github.com/user-attachments/assets/4145f987-2161-4797-a087-bd370d067fbe

