### PR TITLE
feat(ui-shell): `HeaderSearch` supports optional `id` as key

### DIFF
--- a/docs/src/pages/_module.svelte
+++ b/docs/src/pages/_module.svelte
@@ -72,6 +72,7 @@
     .slice(0, 10)
     .map(
       (r): ModuleSearchResult => ({
+        id: String(r.id),
         href: String(r.href),
         text: String(r.text),
         description: r.description == null ? undefined : String(r.description),

--- a/docs/src/pages/framed/UIShell/HeaderSearch.svelte
+++ b/docs/src/pages/framed/UIShell/HeaderSearch.svelte
@@ -14,24 +14,28 @@
 
   const data = [
     {
+      id: "kubernetes-service",
       href: "/",
       text: "Kubernetes Service",
       description:
         "Deploy secure, highly available apps in a native Kubernetes experience. IBM Cloud Kubernetes Service creates a cluster of compute hosts and deploys highly available containers.",
     },
     {
+      id: "red-hat-openshift",
       href: "/",
       text: "Red Hat OpenShift on IBM Cloud",
       description:
         "Deploy and secure enterprise workloads on native OpenShift with developer focused tools to run highly available apps. OpenShift clusters build on Kubernetes container orchestration that offers consistency and flexibility in operations.",
     },
     {
+      id: "container-registry",
       href: "/",
       text: "Container Registry",
       description:
         "Securely store container images and monitor their vulnerabilities in a private registry.",
     },
     {
+      id: "code-engine",
       href: "/",
       text: "Code Engine",
       description:

--- a/src/UIShell/HeaderSearch.svelte
+++ b/src/UIShell/HeaderSearch.svelte
@@ -5,6 +5,7 @@
 
   /**
    * @typedef {object} HeaderSearchResult
+   * @property {string | number} [id] - Unique result identifier; used as the each-block key when provided
    * @property {string} href
    * @property {string} text
    * @property {string} [description]
@@ -86,7 +87,7 @@
   }
   $: selectedResult = results[selectedResultIndex];
   $: selectedId = selectedResult
-    ? `${id}-menuitem-${selectedResultIndex}`
+    ? `${id}-menuitem-${selectedResult.id ?? selectedResultIndex}`
     : undefined;
 </script>
 
@@ -204,16 +205,16 @@
       id={menuId}
       class:bx--header-search-menu={true}
     >
-      {#each results as result, i}
+      {#each results as result, i (result.id ?? i)}
         <li role="none">
           <a
             tabindex="-1"
-            id="{id}-menuitem-{i}"
+            id="{id}-menuitem-{result.id ?? i}"
             role="menuitem"
             href={result.href}
             class:bx--header-search-menu-item={true}
             class:bx--header-search-menu-item--selected={selectedId ===
-              `${id}-menuitem-${i}`}
+              `${id}-menuitem-${result.id ?? i}`}
             on:click|preventDefault={async () => {
               selectedResultIndex = i;
               await tick();

--- a/tests/UIShell/HeaderSearch.test.ts
+++ b/tests/UIShell/HeaderSearch.test.ts
@@ -112,6 +112,27 @@ describe("HeaderSearch", () => {
       );
     });
 
+    it("should use result id for selected menu item id when provided", () => {
+      const results = [
+        { id: "result-a", href: "/1", text: "Result 1" },
+        { id: 2, href: "/2", text: "Result 2" },
+      ];
+      render(HeaderSearchTest, {
+        props: { active: true, results, selectedResultIndex: 1 },
+      });
+
+      const searchInput = screen.getByRole("textbox");
+      expect(searchInput.getAttribute("aria-activedescendant")).toMatch(
+        /^ccs-[a-z0-9.]+-menuitem-2$/,
+      );
+      expect(
+        screen.getByRole("menuitem", { name: "Result 2" }),
+      ).toHaveAttribute(
+        "id",
+        searchInput.getAttribute("aria-activedescendant"),
+      );
+    });
+
     it("should render results when active and results exist", () => {
       const results = [
         { href: "/1", text: "Result 1", description: "Description 1" },
@@ -601,6 +622,24 @@ describe("HeaderSearch Generics", () => {
     expectTypeOf<ResultsPropType>().toEqualTypeOf<
       ReadonlyArray<MinimalResult> | undefined
     >();
+  });
+
+  it("should accept an optional id field on HeaderSearchResult", () => {
+    const withStringId: HeaderSearchResult = {
+      id: "result-a",
+      href: "/1",
+      text: "Result",
+    };
+    const withNumberId: HeaderSearchResult = {
+      id: 1,
+      href: "/1",
+      text: "Result",
+    };
+    const withoutId: HeaderSearchResult = { href: "/1", text: "Result" };
+
+    expectTypeOf(withStringId.id).toEqualTypeOf<string | number | undefined>();
+    expectTypeOf(withNumberId.id).toEqualTypeOf<string | number | undefined>();
+    expectTypeOf(withoutId.id).toEqualTypeOf<string | number | undefined>();
   });
 
   it("should provide type-safe access in slot props", () => {


### PR DESCRIPTION
Allow the result to accept an `id` to key the array.