### PR TITLE
perf(combo-box): drop per-keystroke index Map for `findIndex`

### DIFF
--- a/src/ComboBox/ComboBox.svelte
+++ b/src/ComboBox/ComboBox.svelte
@@ -371,7 +371,9 @@
     // Set highlighted index to selected item when menu opens
     if (wasJustOpened) {
       if (selectedId !== undefined && selectedItem) {
-        const selectedIndex = filteredItemIndexById.get(selectedId) ?? -1;
+        const selectedIndex = filteredItems.findIndex(
+          (item) => item.id === selectedId,
+        );
         if (selectedIndex >= 0) {
           // Set highlighted index to selected item so keyboard nav starts there
           highlightedIndex = selectedIndex;
@@ -479,9 +481,6 @@
   $: warnId = `warn-${id}`;
   $: filteredItems = open ? items.filter((item) => filterFn(item, value)) : [];
   $: highlightedId = filteredItems[highlightedIndex]?.id;
-  $: filteredItemIndexById = new Map(
-    filteredItems.map((item, i) => [item.id, i]),
-  );
 
   $: shouldVirtualize =
     virtualize === false


### PR DESCRIPTION
https://github.com/carbon-design-system/carbon-components-svelte/pull/2825 applied Set/Map for look-ups, but the `filteredItemIndexById` Map was rebuilt on every keystroke but read once per menu-open. A `findIndex` at the single call site avoids the allocation.