### PR TITLE
perf(multi-select): drop per-keystroke index Map for `findIndex`

### DIFF
--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -520,7 +520,6 @@
     internalSelectedIdsRef = selectedIds;
     sortedItems = sort();
   }
-  $: sortedItemsById = new Map(sortedItems.map((item) => [item.id, item]));
   $: hasSelectAll = items.some((item) => item.isSelectAll);
   $: checked = sortedItems.filter(({ checked }) => checked);
   $: unchecked = sortedItems.filter(({ checked }) => !checked);
@@ -695,7 +694,9 @@
             if (readonly) return;
             if (key === "Enter") {
               if (highlightedId) {
-                const highlightedItem = sortedItemsById.get(highlightedId);
+                const highlightedItem = sortedItems.find(
+                  (item) => item.id === highlightedId,
+                );
                 if (highlightedItem) selectItem(highlightedItem);
               }
             } else if (key === "Tab") {


### PR DESCRIPTION
https://github.com/carbon-design-system/carbon-components-svelte/pull/2825 applied Set/Map for look-ups, but the `filteredItemIndexById` Map was rebuilt on every keystroke but read once per menu-open. A `findIndex` at the single call site avoids the allocation.

Related #3088 