### PR TITLE
fix(structured-list-row): make selectable rows keyboard-activatable

### DIFF
--- a/src/StructuredList/StructuredListInput.svelte
+++ b/src/StructuredList/StructuredListInput.svelte
@@ -44,6 +44,7 @@
   bind:this={ref}
   type="radio"
   tabindex="-1"
+  aria-hidden={ctx ? "true" : undefined}
   {checked}
   {id}
   {name}

--- a/src/StructuredList/StructuredListRow.svelte
+++ b/src/StructuredList/StructuredListRow.svelte
@@ -10,6 +10,32 @@
    * @type {number | string | undefined}
    */
   export let tabindex = "0";
+
+  import { getContext, onMount } from "svelte";
+  import { writable } from "svelte/store";
+
+  const ctx = getContext("carbon:StructuredListWrapper");
+  const selectedValue = ctx?.selectedValue ?? writable(undefined);
+
+  let labelRef;
+  let inputValue;
+
+  onMount(() => {
+    if (label && labelRef) {
+      const input = labelRef.querySelector('input[type="radio"]');
+      if (input) inputValue = input.value;
+    }
+  });
+
+  $: isRadio = label && inputValue !== undefined;
+  $: ariaChecked = isRadio ? $selectedValue === inputValue : undefined;
+
+  function handleKeydown(event) {
+    if (event.key === " " || event.key === "Enter") {
+      event.preventDefault();
+      event.currentTarget.click();
+    }
+  }
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
@@ -18,6 +44,9 @@
   <!-- svelte-ignore a11y-no-noninteractive-tabindex -->
   <!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
   <label
+    bind:this={labelRef}
+    role={isRadio ? "radio" : undefined}
+    aria-checked={ariaChecked}
     {tabindex}
     class:bx--structured-list-row={true}
     class:bx--structured-list-row--header-row={head}
@@ -27,6 +56,7 @@
     on:mouseenter
     on:mouseleave
     on:keydown
+    on:keydown={handleKeydown}
   >
     <slot />
   </label>

--- a/tests/StructuredList/StructuredList.test.ts
+++ b/tests/StructuredList/StructuredList.test.ts
@@ -80,6 +80,34 @@ describe("StructuredList", () => {
     expect(screen.getByTestId("value").textContent).toBe("row-2-value");
   });
 
+  it("should activate selectable row via Space/Enter keys", async () => {
+    render(StructuredList, { props: { selection: true } });
+
+    const rows = screen.getAllByRole("radio");
+    rows[1].focus();
+    await user.keyboard(" ");
+    expect(screen.getByTestId("value").textContent).toBe("row-2-value");
+
+    rows[2].focus();
+    await user.keyboard("{Enter}");
+    expect(screen.getByTestId("value").textContent).toBe("row-3-value");
+  });
+
+  it("should expose selectable rows as radio with aria-checked", () => {
+    render(StructuredList, {
+      props: { selection: true, selected: "row-2-value" },
+    });
+
+    const rows = screen.getAllByRole("radio");
+    expect(rows).toHaveLength(3);
+    for (const row of rows) {
+      expect(row.tagName).toBe("LABEL");
+    }
+    expect(rows[0]).toHaveAttribute("aria-checked", "false");
+    expect(rows[1]).toHaveAttribute("aria-checked", "true");
+    expect(rows[2]).toHaveAttribute("aria-checked", "false");
+  });
+
   it("should handle custom content", () => {
     render(StructuredListCustom);
 


### PR DESCRIPTION
Selectable rows are focusable `<label>` elements but the nested `<input type="radio">` is `tabindex="-1"`, so Space/Enter on a focused row did nothing. Adds an internal handler plus `role="radio"` and reactive `aria-checked` derived from wrapper context; input is marked `aria-hidden` to avoid duplicate radio announcements.