### PR TITLE
fix(slider): move keyboard handler to thumb with role="slider"

### DIFF
--- a/src/Slider/Slider.svelte
+++ b/src/Slider/Slider.svelte
@@ -200,29 +200,12 @@
     <span class:bx--slider__range-label={true}>{minLabel ?? min}</span>
     <div
       bind:this={ref}
-      role="presentation"
-      tabindex="-1"
       class:bx--slider={true}
       class:bx--slider--disabled={disabled}
       class:bx--slider--readonly={readonly}
       style:max-width={fullWidth ? "none" : undefined}
       on:mousedown={startInteraction}
       on:touchstart={startInteraction}
-      on:keydown={({ shiftKey, key }) => {
-        if (disabled || readonly) return;
-        const keys = {
-          ArrowDown: -1,
-          ArrowLeft: -1,
-          ArrowRight: 1,
-          ArrowUp: 1,
-        };
-        if (keys[key]) {
-          const delta =
-            step * (shiftKey ? range / step / stepMultiplier : 1) * keys[key];
-          value = Math.round((value + delta) / step) * step;
-          dispatch("input", value);
-        }
-      }}
     >
       <div
         role="slider"
@@ -240,6 +223,21 @@
             : undefined}
         aria-invalid={invalid || undefined}
         {id}
+        on:keydown={({ shiftKey, key }) => {
+          if (disabled || readonly) return;
+          const keys = {
+            ArrowDown: -1,
+            ArrowLeft: -1,
+            ArrowRight: 1,
+            ArrowUp: 1,
+          };
+          if (keys[key]) {
+            const delta =
+              step * (shiftKey ? range / step / stepMultiplier : 1) * keys[key];
+            value = Math.round((value + delta) / step) * step;
+            dispatch("input", value);
+          }
+        }}
       ></div>
       <div bind:this={trackRef} class:bx--slider__track={true}></div>
       <div

--- a/tests/Slider/Slider.test.ts
+++ b/tests/Slider/Slider.test.ts
@@ -168,7 +168,8 @@ describe("Slider", () => {
     const slider = screen.getByRole("slider");
     const initialValue = slider.getAttribute("aria-valuenow");
 
-    const container = screen.getByRole("presentation");
+    const container = slider.parentElement;
+    assert(container);
     await user.click(container);
 
     // Value should not change
@@ -417,7 +418,8 @@ describe("Slider", () => {
   it("should handle mouse dragging without errors", async () => {
     render(Slider);
 
-    const container = screen.getByRole("presentation");
+    const container = screen.getByRole("slider").parentElement;
+    assert(container);
     const { left, width } = container.getBoundingClientRect();
 
     await user.pointer({ target: container, keys: "[MouseLeft]" });
@@ -439,7 +441,8 @@ describe("Slider", () => {
     });
 
     const slider = screen.getByRole("slider");
-    const container = screen.getByRole("presentation");
+    const container = slider.parentElement;
+    assert(container);
 
     await user.pointer({ target: slider, keys: "[MouseLeft]" });
 
@@ -617,6 +620,30 @@ describe("Slider", () => {
     });
     const input = screen.getByRole("spinbutton");
     expect(input).toHaveAttribute("aria-label", "");
+  });
+
+  // Regression: keyboard handling must live on the role="slider" thumb, not a
+  // role="presentation" parent (which strips ARIA semantics from the
+  // keyboard-handling element).
+  it("attaches keyboard handling to the thumb with role=slider", () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(Slider);
+
+    const slider = screen.getByRole("slider");
+    expect(slider).toHaveAttribute("role", "slider");
+
+    // No presentation-role wrapper should swallow the thumb's semantics.
+    expect(screen.queryByRole("presentation")).not.toBeInTheDocument();
+
+    slider.focus();
+    expect(slider).toHaveFocus();
+
+    // Dispatch keydown directly on the thumb (not the parent track) and
+    // confirm the value changes — proves the handler is on the thumb.
+    slider.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }),
+    );
+    expect(consoleLog).toHaveBeenCalledWith("input", 1);
   });
 
   // Regression test for https://github.com/carbon-design-system/carbon-components-svelte/issues/1219


### PR DESCRIPTION
The track wrapper had `role="presentation"` while owning `keydown`, stripping ARIA semantics from the keyboard-handling element. Move `keydown` onto the `role="slider"` thumb so it is both focusable and semantically correct for assistive tech.