### PR TITLE
fix(checkbox-group, toolbar-content): unsubscribe from stores on destroy

### DIFF
--- a/src/Checkbox/CheckboxGroup.svelte
+++ b/src/Checkbox/CheckboxGroup.svelte
@@ -98,22 +98,23 @@
     update,
   });
 
+  beforeUpdate(() => {
+    syncSelectedValues();
+  });
+
+  const unsubscribe = selectedValues.subscribe((value) => {
+    selected = value;
+    if (!isInitialRender && !isSyncingSelected) {
+      dispatch("change", value);
+    }
+  });
+
   onMount(() => {
     syncSelectedValues();
     tick().then(() => {
       isInitialRender = false;
     });
-  });
-
-  beforeUpdate(() => {
-    syncSelectedValues();
-  });
-
-  selectedValues.subscribe((value) => {
-    selected = value;
-    if (!isInitialRender && !isSyncingSelected) {
-      dispatch("change", value);
-    }
+    return unsubscribe;
   });
 
   $: $groupName = name;

--- a/src/DataTable/ToolbarContent.svelte
+++ b/src/DataTable/ToolbarContent.svelte
@@ -1,15 +1,22 @@
 <script>
-  import { getContext } from "svelte";
+  import { getContext, onMount } from "svelte";
 
   const ctx = getContext("carbon:Toolbar") ?? {};
 
   let batchActionsActive = false;
 
+  let unsubscribe;
   if (ctx?.batchActionsActive) {
-    ctx.batchActionsActive.subscribe((value) => {
+    unsubscribe = ctx.batchActionsActive.subscribe((value) => {
       batchActionsActive = value;
     });
   }
+
+  onMount(() => {
+    return () => {
+      unsubscribe?.();
+    };
+  });
 
   $: inertProps = batchActionsActive ? { inert: true } : {};
 </script>


### PR DESCRIPTION
Similar to #3061, audit the library for more cases where a subscription isn't torn down when the component is destroyed.