### PR TITLE
feat(data-table): empty table header uses discriminated union

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -25,7 +25,7 @@
         "jsdom": "^29.1.1",
         "postcss": "^8.5.5",
         "sass": "^1.100.0",
-        "sveld": "0.32.0",
+        "sveld": "0.32.3",
         "svelte": "^5.55.10",
         "svelte-check": "^4.4.8",
         "typescript": "^6.0.3",
@@ -430,7 +430,7 @@
 
     "postcss-value-parser": ["postcss-value-parser@4.2.0", "", {}, "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="],
 
-    "prettier": ["prettier@3.8.1", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg=="],
+    "prettier": ["prettier@3.8.3", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw=="],
 
     "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
 
@@ -462,7 +462,7 @@
 
     "strip-indent": ["strip-indent@3.0.0", "", { "dependencies": { "min-indent": "^1.0.0" } }, "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ=="],
 
-    "sveld": ["sveld@0.32.0", "", { "dependencies": { "prettier": "^3.8.0" }, "bin": { "sveld": "cli.js" } }, "sha512-X0zdVbydLDlE+NrhxX08KXMVjqOvcPtH9LsDmgVfccL7h2I03KSn/DMYGbBikj6uGhiOKvbbzqRMYAFjo4vUlw=="],
+    "sveld": ["sveld@0.32.3", "", { "dependencies": { "prettier": "^3.8.3" }, "bin": { "sveld": "cli.js" } }, "sha512-slOy8a/R5TqmIOFNauo7yhIDTXzC7tHZkXgJSGHaira8Z9pXQUzqbibehjOzXfSl0F9TkZli3pVok/+CepJUeA=="],
 
     "svelte": ["svelte@5.55.10", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "@jridgewell/sourcemap-codec": "^1.5.0", "@sveltejs/acorn-typescript": "^1.0.10", "@types/estree": "^1.0.5", "@types/trusted-types": "^2.0.7", "acorn": "^8.12.1", "aria-query": "5.3.1", "axobject-query": "^4.1.0", "clsx": "^2.1.1", "devalue": "^5.8.1", "esm-env": "^1.2.1", "esrap": "^2.2.9", "is-reference": "^3.0.3", "locate-character": "^3.0.0", "magic-string": "^0.30.11", "zimmerframe": "^1.1.2" } }, "sha512-v9mFVBY1USosyIWdXE7Cg4AN0ywyKCMcAhONvli8doMowEhFhMdNLKD1j7O/UnsrdVTHaUOk/jv8hD/HClVy+g=="],
 

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "jsdom": "^29.1.1",
     "postcss": "^8.5.5",
     "sass": "^1.100.0",
-    "sveld": "0.32.0",
+    "sveld": "0.32.3",
     "svelte": "^5.55.10",
     "svelte-check": "^4.4.8",
     "typescript": "^6.0.3",

--- a/src/DataTable/DataTable.svelte
+++ b/src/DataTable/DataTable.svelte
@@ -77,12 +77,9 @@
    * @type {object}
    * @property {boolean} selected
    * @property {Row} row
-   * @event sort
-   * @type {object}
+   * @event {{ key: null; direction: "none" } | { key: DataTableKey<Row>; direction: "ascending" | "descending" }} sort - Dispatched when a sortable column header would change the active sort. The event is cancelable: call `preventDefault()` to skip updating `sortKey` / `sortDirection` and skip client side sorting for that click (for example full server side sorting while still reading `detail.key` / `detail.direction` for your API). If not cancelled, the table applies the new sort and sorts the current `rows` client side. Typical uses: server side sorting, URL or query string sync, analytics, and persisting sort preferences.
    * @property {DataTableKey<Row> | null} key - Proposed sort column (`header.key`), or `null` when the proposed `direction` is `none`.
    * @property {"ascending" | "descending" | "none"} direction - Proposed sort direction for this click (applied internally unless the event is cancelled).
-   *
-   * Dispatched when a sortable column header would change the active sort. The event is cancelable: call `preventDefault()` to skip updating `sortKey` / `sortDirection` and skip client-side sorting for that click (for example full server-side sorting while still reading `detail.key` / `detail.direction` for your API). If not cancelled, the table applies the new sort and sorts the current `rows` client-side. Typical uses: server-side sorting, URL or query-string sync, analytics, and persisting sort preferences. The event is cancelable: call `preventDefault()` to skip updating `sortKey` / `sortDirection` and skip client-side sorting for that click (for example full server-side sorting while still reading `detail.key` / `detail.direction` for your API). If not cancelled, the table applies the new sort and sorts the current `rows` client-side. Typical uses: server-side sorting, URL or query-string sync, analytics, and persisting sort preferences.
    * @event click:cell
    * @type {object}
    * @property {DataTableCell<Row>} cell

--- a/src/DataTable/DataTable.svelte
+++ b/src/DataTable/DataTable.svelte
@@ -18,7 +18,7 @@
    * @typedef {import('./data-table-utils.d.ts').DataTableSortValue<Row>} DataTableSortValue<Row=DataTableRow>
    * @typedef {object} DataTableEmptyHeader<Row=DataTableRow>
    * @property {DataTableKey<Row> | (string & {})} key
-   * @property {boolean} empty - Whether the header is empty
+   * @property {true} empty - Whether the header is empty
    * @property {(item: DataTableValue, row: Row) => DataTableValue} [display]
    * @property {false | ((a: DataTableSortValue<Row>, b: DataTableSortValue<Row>) => number)} [sort]
    * @property {boolean} [sortAlways] - Override table-level sortAlways for this column
@@ -27,6 +27,7 @@
    * @property {string} [minWidth]
    * @typedef {object} DataTableNonEmptyHeader<Row=DataTableRow>
    * @property {DataTableKey<Row>} key
+   * @property {false} [empty]
    * @property {DataTableValue} value
    * @property {(item: DataTableValue, row: Row) => DataTableValue} [display]
    * @property {false | ((a: DataTableSortValue<Row>, b: DataTableSortValue<Row>) => number)} [sort]
@@ -81,7 +82,7 @@
    * @property {DataTableKey<Row> | null} key - Proposed sort column (`header.key`), or `null` when the proposed `direction` is `none`.
    * @property {"ascending" | "descending" | "none"} direction - Proposed sort direction for this click (applied internally unless the event is cancelled).
    *
-   * Dispatched when a sortable column header would change the active sort. The event is cancelable: call `preventDefault()` to skip updating `sortKey` / `sortDirection` and skip client-side sorting for that click (for example full server-side sorting while still reading `detail.key` / `detail.direction` for your API). If not cancelled, the table applies the new sort and sorts the current `rows` client-side. Typical uses: server-side sorting, URL or query-string sync, analytics, and persisting sort preferences.
+   * Dispatched when a sortable column header would change the active sort. The event is cancelable: call `preventDefault()` to skip updating `sortKey` / `sortDirection` and skip client-side sorting for that click (for example full server-side sorting while still reading `detail.key` / `detail.direction` for your API). If not cancelled, the table applies the new sort and sorts the current `rows` client-side. Typical uses: server-side sorting, URL or query-string sync, analytics, and persisting sort preferences. The event is cancelable: call `preventDefault()` to skip updating `sortKey` / `sortDirection` and skip client-side sorting for that click (for example full server-side sorting while still reading `detail.key` / `detail.direction` for your API). If not cancelled, the table applies the new sort and sorts the current `rows` client-side. Typical uses: server-side sorting, URL or query-string sync, analytics, and persisting sort preferences.
    * @event click:cell
    * @type {object}
    * @property {DataTableCell<Row>} cell

--- a/tests/DataTable/DataTableGenerics.test.svelte
+++ b/tests/DataTable/DataTableGenerics.test.svelte
@@ -2,6 +2,7 @@
   import type {
     DataTableEmptyHeader,
     DataTableHeader,
+    DataTableKey,
     DataTableNonEmptyHeader,
     DataTableRow,
   } from "carbon-components-svelte/DataTable/DataTable.svelte";
@@ -77,6 +78,25 @@
   // @ts-expect-error
   const _badEmpty: DataTableEmptyHeader<Row> = { key: "x", empty: false };
   void _badEmpty;
+
+  type ProductSortDetail =
+    | { key: null; direction: "none" }
+    | {
+        key: DataTableKey<ProductRow>;
+        direction: "ascending" | "descending";
+      };
+
+  function readSortDetail(detail: ProductSortDetail) {
+    if (detail.direction === "none") {
+      return detail.key;
+    }
+    return detail.key;
+  }
+  void readSortDetail;
+
+  export let onProductSort:
+    | ((e: CustomEvent<ProductSortDetail>) => void)
+    | undefined = undefined;
 </script>
 
 <DataTable
@@ -108,6 +128,7 @@
 <DataTable
   headers={productHeaders}
   rows={productRows}
+  sortable
   selectable
   expandable
   batchSelection
@@ -125,10 +146,16 @@
     console.log("Expanded:", row.id);
   }}
   on:sort={(e) => {
-    // e.detail.key is DataTableKey<ProductRow> | null (`null` when direction is `none`, e.g. third header click without sortAlways)
-    const key = e.detail.key;
-    const direction = e.detail.direction;
-    console.log("Sort:", key, direction);
+    readSortDetail(e.detail);
+    onProductSort?.(e);
+    const detail = e.detail;
+
+    if (detail.direction === "none") {
+      console.log("Clear sort", detail.key);
+      return;
+    }
+
+    console.log("Sort:", detail.key, detail.direction);
   }}
 >
   <svelte:fragment slot="expandedRow" let:row>

--- a/tests/DataTable/DataTableGenerics.test.svelte
+++ b/tests/DataTable/DataTableGenerics.test.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import type {
+    DataTableEmptyHeader,
     DataTableHeader,
+    DataTableNonEmptyHeader,
     DataTableRow,
   } from "carbon-components-svelte/DataTable/DataTable.svelte";
   import DataTable from "carbon-components-svelte/DataTable/DataTable.svelte";
@@ -56,6 +58,25 @@
 
   let productSelectedRowIds: ReadonlyArray<ProductRow["id"]> = ["prod-1"];
   let productExpandedRowIds: ReadonlyArray<ProductRow["id"]> = [];
+
+  const discriminantHeaders = [
+    { key: "name", value: "Name" },
+    { key: "overflow", empty: true },
+  ] as const satisfies ReadonlyArray<DataTableHeader<Row>>;
+
+  function readHeader(h: DataTableHeader<Row>) {
+    if (h.empty === true) {
+      const _empty: DataTableEmptyHeader<Row> = h;
+      return _empty.key;
+    }
+    const _nonEmpty: DataTableNonEmptyHeader<Row> = h;
+    return _nonEmpty.value;
+  }
+  void readHeader;
+
+  // @ts-expect-error
+  const _badEmpty: DataTableEmptyHeader<Row> = { key: "x", empty: false };
+  void _badEmpty;
 </script>
 
 <DataTable
@@ -114,3 +135,8 @@
     <p>Expanded content for {row.name}</p>
   </svelte:fragment>
 </DataTable>
+
+<DataTable
+  headers={discriminantHeaders}
+  rows={[{ id: "row-1", name: "Item" }]}
+/>

--- a/tests/DataTable/DataTableGenerics.test.ts
+++ b/tests/DataTable/DataTableGenerics.test.ts
@@ -346,7 +346,7 @@ describe("DataTable Generics", () => {
 
       // Verify all three tables render independently
       const tables = container.querySelectorAll("table.bx--data-table");
-      expect(tables.length).toBe(3);
+      expect(tables.length).toBe(4);
 
       // Verify each table has its own rows
       const firstTableRows = getTableRows(container, 0);
@@ -370,7 +370,7 @@ describe("DataTable Generics", () => {
       const { container } = render(DataTableGenerics);
 
       const tables = container.querySelectorAll("table.bx--data-table");
-      expect(tables.length).toBe(3);
+      expect(tables.length).toBe(4);
 
       // Each table should have its own selection state
       // TypeScript prevents assigning wrong ID types at compile time
@@ -382,6 +382,22 @@ describe("DataTable Generics", () => {
       expect(firstTable).toBeInTheDocument();
       expect(secondTable).toBeInTheDocument();
       expect(thirdTable).toBeInTheDocument();
+    });
+  });
+
+  describe("Header empty discriminant", () => {
+    it("renders an empty header alongside a non-empty header", () => {
+      const { container } = render(DataTableGenerics);
+
+      const tables = container.querySelectorAll("table.bx--data-table");
+      expect(tables.length).toBeGreaterThanOrEqual(4);
+
+      const fourthTable = tables[3];
+      expect.assert(fourthTable instanceof HTMLElement);
+      const headerCells = fourthTable.querySelectorAll("thead th");
+      expect(headerCells).toHaveLength(2);
+      expect(headerCells[0]?.textContent?.trim()).toBe("Name");
+      expect(headerCells[1]?.textContent?.trim()).toBe("");
     });
   });
 


### PR DESCRIPTION
This upgrades to sveld@0.32.3, which properly supports discriminated union types.

It then applies a discriminated union type to the empty data table header object for stricter typing.