### PR TITLE
fix(tree-view): arrow keys work with link rows

### DIFF
--- a/src/TreeView/TreeView.svelte
+++ b/src/TreeView/TreeView.svelte
@@ -45,7 +45,9 @@
         ) {
           return NodeFilter.FILTER_REJECT;
         }
-        if (node.matches("li.bx--tree-node")) {
+        // Link rows render `role="treeitem"` on `<a class="bx--tree-node">`
+        // inside `<li role="none">`, so we can't constrain by tag name.
+        if (node.matches(".bx--tree-node")) {
           // Children stay mounted under a hidden subtree `ul`; skip so Arrow keys
           // follow visible rows only (same as when branches were unmounted).
           if (isUnderCollapsedSubtree(node)) return NodeFilter.FILTER_REJECT;

--- a/tests/TreeView/TreeView.test.ts
+++ b/tests/TreeView/TreeView.test.ts
@@ -1538,6 +1538,22 @@ describe("TreeViewNode href", () => {
     });
     expect(disabledLink).not.toHaveAttribute("target");
   });
+
+  it("ArrowDown/ArrowUp navigate between link rows", async () => {
+    render(TreeViewHref);
+
+    const first = screen.getByRole("treeitem", { name: /Link Node/ });
+    const second = screen.getByRole("treeitem", { name: /Another Link/ });
+    expect(first.tagName).toBe("A");
+    expect(second.tagName).toBe("A");
+
+    first.focus();
+    await user.keyboard("{ArrowDown}");
+    expect(second).toHaveFocus();
+
+    await user.keyboard("{ArrowUp}");
+    expect(first).toHaveFocus();
+  });
 });
 
 describe("TreeView autoCollapse", () => {


### PR DESCRIPTION
`TreeView` supports link rows, but keyboard navigation never worked with it. This fixes the selector.