### PR TITLE
chore(ui-shell): `Header` auto-expands side nav on desktop after mobile toggle

### DIFF
--- a/src/UIShell/Header.svelte
+++ b/src/UIShell/Header.svelte
@@ -121,10 +121,16 @@
       // Initial mount: set based on current viewport
       isSideNavOpen = shouldAutoExpand;
     } else if (wasAboveBreakpoint !== isAboveBreakpoint) {
-      // Crossed breakpoint threshold: skip auto-write if the user just
-      // toggled the nav so their choice isn't clobbered by the resize.
+      // Crossed breakpoint threshold: apply the responsive default for the
+      // new viewport. In `persistentHamburgerMenu` mode there is no responsive
+      // default (the hamburger is always shown and the nav is fully
+      // user-controlled), so preserve a state the user just toggled. In the
+      // default mode the hamburger only appears on mobile, so a mobile toggle
+      // must NOT suppress auto-expand when returning to desktop.
       // The flag is one-shot — reset so subsequent crossings auto-expand.
-      if (!userExplicitlySet) isSideNavOpen = shouldAutoExpand;
+      if (!(persistentHamburgerMenu && userExplicitlySet)) {
+        isSideNavOpen = shouldAutoExpand;
+      }
       userExplicitlySet = false;
     }
 

--- a/tests/UIShell/UIShell.test.ts
+++ b/tests/UIShell/UIShell.test.ts
@@ -219,6 +219,38 @@ describe("UIShell", () => {
         expect(component.isSideNavOpen).toBe(true);
       });
 
+      it("auto-expands on desktop after toggling the mobile hamburger (open then close)", async () => {
+        // Regression: in the default (non-persistent) mode the hamburger
+        // appears only on mobile, so clicking it set `userExplicitlySet`,
+        // which then suppressed the desktop auto-expand. Repro: desktop ->
+        // mobile -> open + close menu -> desktop must re-expand the side nav.
+        setViewportWidth(1200); // Desktop
+        const { container, component } = render(UiShell, {
+          props: { isSideNavOpen: true },
+        });
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        expect(component.isSideNavOpen).toBe(true);
+
+        // Desktop -> mobile: auto-collapses, hamburger appears.
+        setViewportWidth(500);
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        expect(component.isSideNavOpen).toBe(false);
+
+        const hamburgerButton = container.querySelector(
+          ".bx--header__menu-trigger",
+        );
+        assert(hamburgerButton);
+        await user.click(hamburgerButton); // open
+        expect(component.isSideNavOpen).toBe(true);
+        await user.click(hamburgerButton); // close
+        expect(component.isSideNavOpen).toBe(false);
+
+        // Mobile -> desktop: should auto-expand again.
+        setViewportWidth(1200);
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        expect(component.isSideNavOpen).toBe(true);
+      });
+
       it("should auto-expand when crossing breakpoint to desktop", async () => {
         setViewportWidth(500); // Start on mobile
 


### PR DESCRIPTION
Gate PR #3013's user-toggle preservation on `persistentHamburgerMenu`. That guard only applies to persistent mode; in default mode the hamburger is mobile-only, so a mobile toggle was wrongly suppressing the desktop auto-expand on the next breakpoint crossing.

This commit is marked as "chore" and not a fix, since #3013 has not been released yet.