### PR TITLE
docs: fix virtualization custom height examples

### DIFF
--- a/docs/src/pages/framed/ComboBox/VirtualizeItemHeight.svelte
+++ b/docs/src/pages/framed/ComboBox/VirtualizeItemHeight.svelte
@@ -27,3 +27,9 @@
     <span>{item.description}</span>
   </Stack>
 </ComboBox>
+
+<style>
+  :global(.bx--list-box__menu-item, .bx--list-box__menu-item__option) {
+    height: auto;
+  }
+</style>

--- a/docs/src/pages/framed/Dropdown/VirtualizeItemHeight.svelte
+++ b/docs/src/pages/framed/Dropdown/VirtualizeItemHeight.svelte
@@ -22,3 +22,9 @@
     <span>{item.description}</span>
   </Stack>
 </Dropdown>
+
+<style>
+  :global(.bx--list-box__menu-item, .bx--list-box__menu-item__option) {
+    height: auto;
+  }
+</style>

--- a/docs/src/pages/framed/MultiSelect/VirtualizeItemHeight.svelte
+++ b/docs/src/pages/framed/MultiSelect/VirtualizeItemHeight.svelte
@@ -23,3 +23,13 @@
     <span>{item.description}</span>
   </Stack>
 </MultiSelect>
+
+<style>
+  :global(.bx--list-box__menu-item, .bx--list-box__menu-item__option) {
+    height: auto;
+  }
+
+  :global(.bx--checkbox-label-text) {
+    display: block;
+  }
+</style>


### PR DESCRIPTION
The examples need to unset the 40px height.