### PR TITLE
feat(outbound-link): add `assistiveText` prop for screen readers

### DIFF
--- a/docs/src/pages/components/Link.svx
+++ b/docs/src/pages/components/Link.svx
@@ -27,9 +27,20 @@ For external links that open in a new tab, the component automatically adds secu
 
 ## Outbound link
 
-Use the outbound link as a convenient alternative for external links.
+Use the outbound link as a convenient alternative for external links. Because it opens in a new tab (`target="_blank"`), it adds visually-hidden text ("(opens in a new tab)") so screen readers announce the behavior.
 
 <OutboundLink href="https://www.carbondesignsystem.com/">
+  Carbon Design System
+</OutboundLink>
+
+## Customize the new tab announcement
+
+External links open in a new tab and append `assistiveText` automatically for screen readers. You can override the `assistiveText` prop if needed, and set it to an empty string to opt out.
+
+<OutboundLink
+  href="https://www.carbondesignsystem.com/"
+  assistiveText="(opens in a new window)"
+>
   Carbon Design System
 </OutboundLink>
 

--- a/src/Link/OutboundLink.svelte
+++ b/src/Link/OutboundLink.svelte
@@ -3,6 +3,13 @@
 
   import Launch from "../icons/Launch.svelte";
   import Link from "./Link.svelte";
+
+  /**
+   * Specify the assistive text announced to screen readers to
+   * indicate that the link opens in a new tab.
+   * Set to an empty string to opt out of the announcement.
+   */
+  export let assistiveText = "(opens in a new tab)";
 </script>
 
 <Link
@@ -19,4 +26,7 @@
   icon={Launch}
 >
   <slot />
+  {#if assistiveText}
+    <span class:bx--visually-hidden={true}>{assistiveText}</span>
+  {/if}
 </Link>

--- a/tests/Link/OutboundLink.test.svelte
+++ b/tests/Link/OutboundLink.test.svelte
@@ -1,0 +1,29 @@
+<svelte:options accessors />
+
+<script lang="ts">
+  import { OutboundLink } from "carbon-components-svelte";
+</script>
+
+<!-- Default outbound link -->
+<div data-testid="default">
+  <OutboundLink href="https://www.carbondesignsystem.com/">
+    Carbon Design System
+  </OutboundLink>
+</div>
+
+<!-- Custom assistive text -->
+<div data-testid="custom">
+  <OutboundLink
+    href="https://www.carbondesignsystem.com/"
+    assistiveText="(opens in a new window)"
+  >
+    Carbon Design System
+  </OutboundLink>
+</div>
+
+<!-- Announcement opted out -->
+<div data-testid="empty">
+  <OutboundLink href="https://www.carbondesignsystem.com/" assistiveText="">
+    Carbon Design System
+  </OutboundLink>
+</div>

--- a/tests/Link/OutboundLink.test.ts
+++ b/tests/Link/OutboundLink.test.ts
@@ -1,0 +1,66 @@
+import { render, screen, within } from "@testing-library/svelte";
+import OutboundLink from "./OutboundLink.test.svelte";
+
+describe("OutboundLink", () => {
+  it("opens in a new tab with secure rel attributes", () => {
+    render(OutboundLink);
+    const link = within(screen.getByTestId("default")).getByRole("link");
+
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
+  it("announces that the link opens in a new tab", () => {
+    render(OutboundLink);
+    const container = screen.getByTestId("default");
+
+    // The announcement is part of the link's accessible name.
+    expect(
+      within(container).getByRole("link", {
+        name: "Carbon Design System (opens in a new tab)",
+      }),
+    ).toBeInTheDocument();
+
+    // It is conveyed via visually-hidden text, so it is not shown visually.
+    const assistiveText = within(container)
+      .getByText("(opens in a new tab)")
+      .closest("span");
+    assert(assistiveText);
+    expect(assistiveText).toHaveClass("bx--visually-hidden");
+  });
+
+  it("keeps the launch icon decorative (hidden from screen readers)", () => {
+    render(OutboundLink);
+    const link = within(screen.getByTestId("default")).getByRole("link");
+
+    const icon = link.querySelector(".bx--link__icon svg");
+    assert(icon);
+    expect(icon).toHaveAttribute("aria-hidden", "true");
+  });
+
+  it("supports customizing the assistive text", () => {
+    render(OutboundLink);
+    const container = screen.getByTestId("custom");
+
+    expect(
+      within(container).getByRole("link", {
+        name: "Carbon Design System (opens in a new window)",
+      }),
+    ).toBeInTheDocument();
+    expect(
+      within(container).queryByText("(opens in a new tab)"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("can opt out of the announcement with an empty string", () => {
+    render(OutboundLink);
+    const container = screen.getByTestId("empty");
+
+    expect(
+      within(container).getByRole("link", { name: "Carbon Design System" }),
+    ).toBeInTheDocument();
+    expect(
+      container.querySelector(".bx--visually-hidden"),
+    ).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
OutboundLink opens in a new tab but only signaled this visually (via the aria-hidden launch icon). This adds visually-hidden text with a new assistiveText prop defaulting to "(opens in a new tab)" so screen readers announce the behavior. It can be customized or set to "" to opt out.