### PR TITLE
docs(radio-button): add "Disabled group" example

### DIFF
--- a/docs/src/pages/components/RadioButton.svx
+++ b/docs/src/pages/components/RadioButton.svx
@@ -86,6 +86,16 @@ Disable specific radio buttons to prevent selection.
   <RadioButton disabled labelText="Pro (128 GB)" value="pro" />
 </RadioButtonGroup>
 
+## Disabled group
+
+Set `disabled` to `true` on `RadioButtonGroup` to disable all radio buttons in the group. Their labels are also visually muted.
+
+<RadioButtonGroup disabled legendText="Storage tier (disk)" name="plan-disabled-group" selected="standard">
+  <RadioButton labelText="Free (1 GB)" value="free" />
+  <RadioButton labelText="Standard (10 GB)" value="standard" />
+  <RadioButton labelText="Pro (128 GB)" value="pro" />
+</RadioButtonGroup>
+
 ## Read-only state
 
 Set `readonly` to `true` on `RadioButtonGroup` to display non-editable values.

--- a/tests/RadioButtonGroup/RadioButtonGroup.test.ts
+++ b/tests/RadioButtonGroup/RadioButtonGroup.test.ts
@@ -41,8 +41,10 @@ describe("RadioButtonGroup", () => {
   it("should handle disabled state", () => {
     render(RadioButtonGroup, { props: { disabled: true } });
 
-    const fieldset = screen.getByRole("group");
-    expect(fieldset).toBeDisabled();
+    expect(screen.getByRole("group")).toBeDisabled();
+    for (const radio of screen.getAllByRole("radio")) {
+      expect(radio).toBeDisabled();
+    }
   });
 
   it("should handle required state", () => {


### PR DESCRIPTION
For parity, add an example that disables all radio buttons.