### PR TITLE
fix(selectable-tile): hide checkmark icon from assistive technology

### DIFF
--- a/src/Tile/SelectableTile.svelte
+++ b/src/Tile/SelectableTile.svelte
@@ -150,7 +150,7 @@
     }
   }}
 >
-  <span class:bx--tile__checkmark={true}>
+  <span aria-hidden="true" class:bx--tile__checkmark={true}>
     <CheckmarkFilled aria-label={iconDescription} title={iconDescription} />
   </span>
   <span class:bx--tile-content={true}> <slot /> </span>

--- a/tests/Tile/SelectableTile.test.ts
+++ b/tests/Tile/SelectableTile.test.ts
@@ -79,6 +79,15 @@ describe("SelectableTile", () => {
     expect(tile).toHaveAttribute("aria-disabled", "true");
   });
 
+  it("hides the checkmark icon from assistive technology", () => {
+    render(SelectableTileTest);
+
+    const checkmark = screen
+      .getByTestId("selectable-tile")
+      .querySelector(".bx--tile__checkmark");
+    expect(checkmark).toHaveAttribute("aria-hidden", "true");
+  });
+
   describe("interaction", () => {
     it("handles click selection", async () => {
       const consoleLog = vi.spyOn(console, "log");


### PR DESCRIPTION
The checkmark `aria-label` was announced regardless of selected state. Mark the icon `aria-hidden` so screen readers rely on the underlying checkbox for state instead of reading it out of context.