### PR TITLE
fix: suppress invalid/warn states when disabled or read-only

### DIFF
--- a/src/ComboBox/ComboBox.svelte
+++ b/src/ComboBox/ComboBox.svelte
@@ -477,6 +477,9 @@
   $: helperId = `helper-${id}`;
   $: errorId = `error-${id}`;
   $: warnId = `warn-${id}`;
+  // Invalid/warn states are suppressed when the combo box is disabled or read-only.
+  $: showInvalid = invalid && !disabled && !readonly;
+  $: showWarn = warn && !invalid && !disabled && !readonly;
   $: filteredItems = open ? items.filter((item) => filterFn(item, value)) : [];
   $: highlightedId = filteredItems[highlightedIndex]?.id;
 
@@ -553,7 +556,7 @@
   $: comboBoxListBoxClass = [
     "bx--combo-box",
     direction === "top" && "bx--list-box--up",
-    !invalid && warn && "bx--combo-box--warning",
+    showWarn && "bx--combo-box--warning",
     readonly && "bx--combo-box--readonly",
   ]
     .filter(Boolean)
@@ -590,11 +593,11 @@
     aria-label={ariaLabel}
     aria-disabled={readonly || undefined}
     {disabled}
-    {invalid}
+    invalid={showInvalid}
     {open}
     {light}
     {size}
-    {warn}
+    warn={showWarn}
   >
     <div bind:this={fieldRef} class:bx--list-box__field={true}>
       <input
@@ -612,11 +615,11 @@
         aria-readonly={readonly || undefined}
         aria-controls={open ? menuId : undefined}
         aria-owns={open ? menuId : undefined}
-        aria-describedby={invalid && invalidText
+        aria-describedby={showInvalid && invalidText
           ? errorId
-          : !invalid && warn && warnText
+          : showWarn && warnText
             ? warnId
-            : !invalid && !warn && helperText
+            : !showInvalid && !showWarn && helperText
               ? helperId
               : undefined}
         {disabled}
@@ -710,10 +713,10 @@
         }}
         on:paste
       >
-      {#if invalid}
+      {#if showInvalid}
         <WarningFilled class="bx--list-box__invalid-icon" />
       {/if}
-      {#if !invalid && warn}
+      {#if showWarn}
         <WarningAltFilled
           class="bx--list-box__invalid-icon bx--list-box__invalid-icon--warning"
         />
@@ -831,13 +834,13 @@
       </ListBoxMenu>
     {/if}
   </ListBox>
-  {#if invalid && invalidText}
+  {#if showInvalid && invalidText}
     <div id={errorId} class:bx--form-requirement={true}>{invalidText}</div>
   {/if}
-  {#if !invalid && warn && warnText}
+  {#if showWarn && warnText}
     <div id={warnId} class:bx--form-requirement={true}>{warnText}</div>
   {/if}
-  {#if !invalid && !warn && helperText}
+  {#if !showInvalid && !showWarn && helperText}
     <div
       id={helperId}
       class:bx--form__helper-text={true}

--- a/src/DatePicker/DatePickerInput.svelte
+++ b/src/DatePicker/DatePickerInput.svelte
@@ -121,6 +121,9 @@
   $: actualPattern = pattern ?? dateFormatToPattern($dateFormat ?? "m/d/Y");
   $: if (ref) declareRef({ id, ref });
   $: setReadonly(id, readonly);
+  // Invalid/warn states are suppressed when the input is disabled or read-only.
+  $: showInvalid = invalid && !disabled && !readonly;
+  $: showWarn = warn && !invalid && !disabled && !readonly;
 </script>
 
 <div
@@ -140,14 +143,14 @@
   {/if}
   <div
     class:bx--date-picker-input__wrapper={true}
-    class:bx--date-picker-input__wrapper--invalid={invalid}
-    class:bx--date-picker-input__wrapper--warn={warn}
+    class:bx--date-picker-input__wrapper--invalid={showInvalid}
+    class:bx--date-picker-input__wrapper--warn={showWarn}
     class:bx--date-picker-input__wrapper--readonly={readonly}
     class:bx--date-picker-input__wrapper--disabled={disabled}
   >
     <input
       bind:this={ref}
-      data-invalid={invalid || undefined}
+      data-invalid={showInvalid || undefined}
       {id}
       {name}
       {placeholder}
@@ -162,7 +165,7 @@
           : $inputValueTo
         : $inputValue}
       class:bx--date-picker__input={true}
-      class:bx--date-picker__input--invalid={invalid}
+      class:bx--date-picker__input--invalid={showInvalid}
       class:bx--date-picker__input--sm={size === "sm"}
       class:bx--date-picker__input--xl={size === "xl"}
       on:input
@@ -186,17 +189,17 @@
       }}
       on:paste
     >
-    {#if invalid}
+    {#if showInvalid}
       <WarningFilled
         class="bx--date-picker__icon bx--date-picker__icon--invalid"
       />
     {/if}
-    {#if !invalid && warn}
+    {#if showWarn}
       <WarningAltFilled
         class="bx--date-picker__icon bx--date-picker__icon--warn"
       />
     {/if}
-    {#if $hasCalendar && !invalid && !warn}
+    {#if $hasCalendar && !showInvalid && !showWarn}
       <Calendar
         class="bx--date-picker__icon"
         aria-label={iconDescription}
@@ -204,13 +207,13 @@
       />
     {/if}
   </div>
-  {#if invalid}
+  {#if showInvalid}
     <div class:bx--form-requirement={true}>{invalidText}</div>
   {/if}
-  {#if !invalid && warn}
+  {#if showWarn}
     <div class:bx--form-requirement={true}>{warnText}</div>
   {/if}
-  {#if !invalid && !warn && helperText}
+  {#if !showInvalid && !showWarn && helperText}
     <div
       class:bx--form__helper-text={true}
       class:bx--form__helper-text--disabled={disabled}

--- a/src/Dropdown/Dropdown.svelte
+++ b/src/Dropdown/Dropdown.svelte
@@ -209,6 +209,9 @@
   $: helperId = `helper-${id}`;
   $: errorId = `error-${id}`;
   $: warnId = `warn-${id}`;
+  // Invalid/warn states are suppressed when the dropdown is disabled or read-only.
+  $: showInvalid = invalid && !disabled && !readonly;
+  $: showWarn = warn && !invalid && !disabled && !readonly;
   $: highlightedId =
     highlightedIndex > -1 && items[highlightedIndex]
       ? items[highlightedIndex].id
@@ -459,8 +462,8 @@
   $: dropdownListBoxClass = [
     "bx--dropdown",
     direction === "top" && "bx--list-box--up",
-    invalid && "bx--dropdown--invalid",
-    !invalid && warn && "bx--dropdown--warning",
+    showInvalid && "bx--dropdown--invalid",
+    showWarn && "bx--dropdown--warning",
     open && "bx--dropdown--open",
     size === "sm" && "bx--dropdown--sm",
     size === "xl" && "bx--dropdown--xl",
@@ -487,7 +490,7 @@
   class:bx--list-box__wrapper={true}
   class:bx--dropdown__wrapper--inline={inline}
   class:bx--list-box__wrapper--inline={inline}
-  class:bx--dropdown__wrapper--inline--invalid={inline && invalid}
+  class:bx--dropdown__wrapper--inline--invalid={inline && showInvalid}
   {...$$restProps}
 >
   {#if labelText || $$slots.labelChildren}
@@ -513,14 +516,14 @@
     }}
     {disabled}
     {open}
-    {invalid}
+    invalid={showInvalid}
     {light}
-    {warn}
+    warn={showWarn}
   >
-    {#if invalid}
+    {#if showInvalid}
       <WarningFilled class="bx--list-box__invalid-icon" />
     {/if}
-    {#if !invalid && warn}
+    {#if showWarn}
       <WarningAltFilled
         class="bx--list-box__invalid-icon bx--list-box__invalid-icon--warning"
       />
@@ -537,11 +540,11 @@
       aria-haspopup="listbox"
       aria-activedescendant={highlightedId ?? ""}
       aria-controls={open ? menuId : undefined}
-      aria-describedby={invalid && invalidText
+      aria-describedby={showInvalid && invalidText
         ? errorId
-        : !invalid && warn && warnText
+        : showWarn && warnText
           ? warnId
-          : !inline && !invalid && !warn && helperText
+          : !inline && !showInvalid && !showWarn && helperText
             ? helperId
             : undefined}
       on:keydown={(e) => {
@@ -689,13 +692,13 @@
       </ListBoxMenu>
     {/if}
   </ListBox>
-  {#if invalid && invalidText}
+  {#if showInvalid && invalidText}
     <div id={errorId} class:bx--form-requirement={true}>{invalidText}</div>
   {/if}
-  {#if !invalid && warn && warnText}
+  {#if showWarn && warnText}
     <div id={warnId} class:bx--form-requirement={true}>{warnText}</div>
   {/if}
-  {#if !inline && !invalid && !warn && helperText}
+  {#if !inline && !showInvalid && !showWarn && helperText}
     <div
       id={helperId}
       class:bx--form__helper-text={true}

--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -507,6 +507,9 @@
   $: menuId = `menu-${id}`;
   $: comboId = `combo-${id}`;
   $: inline = type === "inline";
+  // Invalid/warn states are suppressed when the multi-select is disabled or read-only.
+  $: showInvalid = invalid && !disabled && !readonly;
+  $: showWarn = warn && !invalid && !disabled && !readonly;
   $: ariaLabel = $$props["aria-label"] ?? "Choose an item";
   $: if (items !== prevItemsRef) {
     prevItemsRef = items;
@@ -583,7 +586,7 @@
     direction === "top" && "bx--list-box--up",
     filterable && "bx--combo-box",
     filterable && "bx--multi-select--filterable",
-    invalid && "bx--multi-select--invalid",
+    showInvalid && "bx--multi-select--invalid",
     inline && "bx--multi-select--inline",
     readonly && "bx--multi-select--readonly",
     selectionCount > 0 && "bx--multi-select--selected",
@@ -614,7 +617,7 @@
   class:bx--list-box__wrapper={true}
   class:bx--multi-select__wrapper--inline={inline}
   class:bx--list-box__wrapper--inline={inline}
-  class:bx--multi-select__wrapper--inline--invalid={inline && invalid}
+  class:bx--multi-select__wrapper--inline--invalid={inline && showInvalid}
 >
   {#if labelText || $$slots.labelChildren}
     <label
@@ -632,19 +635,19 @@
     aria-label={ariaLabel}
     aria-disabled={readonly || undefined}
     {disabled}
-    {invalid}
+    invalid={showInvalid}
     {invalidText}
     {open}
     {light}
     {size}
-    {warn}
+    warn={showWarn}
     {warnText}
     class={multiSelectListBoxClass}
   >
-    {#if invalid}
+    {#if showInvalid}
       <WarningFilled class="bx--list-box__invalid-icon" />
     {/if}
-    {#if !invalid && warn}
+    {#if showWarn}
       <WarningAltFilled
         class="bx--list-box__invalid-icon bx--list-box__invalid-icon--warning"
       />
@@ -970,7 +973,7 @@
       </ListBoxMenu>
     </div>
   </ListBox>
-  {#if !inline && !invalid && !warn && helperText}
+  {#if !inline && !showInvalid && !showWarn && helperText}
     <div
       class:bx--form__helper-text={true}
       class:bx--form__helper-text--disabled={disabled}

--- a/src/Select/Select.svelte
+++ b/src/Select/Select.svelte
@@ -157,6 +157,9 @@
   $: warnId = `warn-${id}`;
   $: helperId = `helper-${id}`;
   $: selectedValue.set(selected ?? $defaultValue);
+  // Invalid/warn states are suppressed when the select is disabled or read-only.
+  $: showInvalid = invalid && !disabled && !readonly;
+  $: showWarn = warn && !invalid && !disabled && !readonly;
 </script>
 
 <div class:bx--form-item={true}>
@@ -164,9 +167,9 @@
     class:bx--select={true}
     class:bx--select--inline={inline}
     class:bx--select--light={light}
-    class:bx--select--invalid={invalid && !readonly}
+    class:bx--select--invalid={showInvalid}
     class:bx--select--disabled={disabled}
-    class:bx--select--warning={warn && !readonly}
+    class:bx--select--warning={showWarn}
     class:bx--select--readonly={readonly}
   >
     {#if !noLabel && (labelText || $$slots.labelChildren)}
@@ -183,18 +186,18 @@
       <div class:bx--select-input--inline__wrapper={true}>
         <div
           class:bx--select-input__wrapper={true}
-          data-invalid={(invalid && !readonly) || undefined}
+          data-invalid={showInvalid || undefined}
         >
           <select
             bind:this={ref}
-            aria-describedby={invalid && !readonly
+            aria-describedby={showInvalid
               ? errorId
-              : warn && !readonly
+              : showWarn
                 ? warnId
                 : helperText
                   ? helperId
                   : undefined}
-            aria-invalid={(invalid && !readonly) || undefined}
+            aria-invalid={showInvalid || undefined}
             aria-readonly={readonly || undefined}
             disabled={disabled || undefined}
             required={required || undefined}
@@ -215,27 +218,27 @@
             <slot />
           </select>
           <ChevronDown class="bx--select__arrow" />
-          {#if invalid && !readonly}
+          {#if showInvalid}
             <WarningFilled class="bx--select__invalid-icon" />
           {/if}
-          {#if !invalid && warn && !readonly}
+          {#if showWarn}
             <WarningAltFilled
               class="bx--select__invalid-icon bx--select__invalid-icon--warning"
             />
           {/if}
         </div>
-        {#if invalid && !readonly}
+        {#if showInvalid}
           <div class:bx--form-requirement={true} id={errorId}>
             {invalidText}
           </div>
         {/if}
-        {#if !invalid && warn && !readonly}
+        {#if showWarn}
           <div class:bx--form-requirement={true} id={warnId}>
             {warnText}
           </div>
         {/if}
       </div>
-      {#if (!invalid && !warn && helperText) || (readonly && helperText)}
+      {#if helperText && !showInvalid && !showWarn}
         <div
           id={helperId}
           class:bx--form__helper-text={true}
@@ -248,22 +251,22 @@
     {#if !inline}
       <div
         class:bx--select-input__wrapper={true}
-        data-invalid={(invalid && !readonly) || undefined}
+        data-invalid={showInvalid || undefined}
       >
         <select
           bind:this={ref}
           {id}
           {name}
-          aria-describedby={invalid && !readonly
+          aria-describedby={showInvalid
             ? errorId
-            : warn && !readonly
+            : showWarn
               ? warnId
               : helperText
                 ? helperId
                 : undefined}
           disabled={disabled || undefined}
           required={required || undefined}
-          aria-invalid={(invalid && !readonly) || undefined}
+          aria-invalid={showInvalid || undefined}
           aria-readonly={readonly || undefined}
           class:bx--select-input={true}
           class:bx--select-input--sm={size === "sm"}
@@ -280,16 +283,16 @@
           <slot />
         </select>
         <ChevronDown class="bx--select__arrow" />
-        {#if invalid && !readonly}
+        {#if showInvalid}
           <WarningFilled class="bx--select__invalid-icon" />
         {/if}
-        {#if !invalid && warn && !readonly}
+        {#if showWarn}
           <WarningAltFilled
             class="bx--select__invalid-icon bx--select__invalid-icon--warning"
           />
         {/if}
       </div>
-      {#if (!invalid && !warn && helperText) || (readonly && helperText)}
+      {#if helperText && !showInvalid && !showWarn}
         <div
           id={helperId}
           class:bx--form__helper-text={true}
@@ -298,10 +301,10 @@
           {helperText}
         </div>
       {/if}
-      {#if invalid && !readonly}
+      {#if showInvalid}
         <div id={errorId} class:bx--form-requirement={true}>{invalidText}</div>
       {/if}
-      {#if !invalid && warn && !readonly}
+      {#if showWarn}
         <div id={warnId} class:bx--form-requirement={true}>{warnText}</div>
       {/if}
     {/if}

--- a/src/Slider/Slider.svelte
+++ b/src/Slider/Slider.svelte
@@ -145,6 +145,9 @@
   $: errorId = `error-${id}`;
   $: warnId = `warn-${id}`;
   $: inputId = `input-${id}`;
+  // Invalid/warn states are suppressed when the slider is disabled or read-only.
+  $: showInvalid = invalid && !disabled && !readonly;
+  $: showWarn = warn && !invalid && !disabled && !readonly;
   $: range = max - min;
   $: left = ((value - min) / range) * 100;
   $: {
@@ -216,12 +219,12 @@
         aria-valuemin={min}
         aria-valuenow={value}
         aria-labelledby={labelId}
-        aria-describedby={invalid
+        aria-describedby={showInvalid
           ? errorId
-          : warn
+          : showWarn
             ? warnId
             : undefined}
-        aria-invalid={invalid || undefined}
+        aria-invalid={showInvalid || undefined}
         {id}
         on:keydown={({ shiftKey, key }) => {
           if (disabled || readonly) return;
@@ -247,9 +250,9 @@
     </div>
     <span class:bx--slider__range-label={true}>{maxLabel ?? max}</span>
     <div class:bx--slider-text-input-wrapper={true}>
-      {#if invalid}
+      {#if showInvalid}
         <WarningFilled class="bx--slider__invalid-icon" />
-      {:else if warn}
+      {:else if showWarn}
         <WarningAltFilled
           class="bx--slider__invalid-icon bx--slider__invalid-icon--warning"
         />
@@ -261,8 +264,8 @@
         class:bx--text-input={true}
         class:bx--slider-text-input={true}
         class:bx--text-input--light={light}
-        class:bx--text-input--invalid={invalid}
-        class:bx--slider-text-input--warn={warn}
+        class:bx--text-input--invalid={showInvalid}
+        class:bx--slider-text-input--warn={showWarn}
         {value}
         aria-labelledby={$$props["aria-label"] ? undefined : labelId}
         aria-label={$$props["aria-label"] ?? "Slider number input"}
@@ -277,18 +280,18 @@
             value = Number(target.value);
           }
         }}
-        data-invalid={invalid || null}
-        data-warn={warn && !invalid || null}
-        aria-invalid={invalid || null}
-        aria-describedby={invalid
+        data-invalid={showInvalid || null}
+        data-warn={showWarn || null}
+        aria-invalid={showInvalid || null}
+        aria-describedby={showInvalid
           ? errorId
-          : warn
+          : showWarn
             ? warnId
             : undefined}
       >
     </div>
   </div>
-  {#if invalid}
+  {#if showInvalid}
     <div
       id={errorId}
       class:bx--slider__validation-msg={true}
@@ -298,7 +301,7 @@
       {invalidText}
     </div>
   {/if}
-  {#if warn && !invalid}
+  {#if showWarn}
     <div
       id={warnId}
       class:bx--slider__validation-msg={true}

--- a/tests/ComboBox/ComboBox.test.ts
+++ b/tests/ComboBox/ComboBox.test.ts
@@ -235,6 +235,26 @@ describe("ComboBox", () => {
     expect(screen.getByText("Warning message")).toBeInTheDocument();
   });
 
+  it.each([
+    "disabled",
+    "readonly",
+  ] as const)("should suppress invalid and warn states when %s", (state) => {
+    const { container } = render(ComboBox, {
+      props: {
+        [state]: true,
+        invalid: true,
+        invalidText: "Invalid selection",
+        warn: true,
+        warnText: "Warning message",
+      },
+    });
+
+    expect(screen.getByRole("listbox")).not.toHaveAttribute("data-invalid");
+    expect(container.querySelector(".bx--list-box__invalid-icon")).toBeNull();
+    expect(screen.queryByText("Invalid selection")).not.toBeInTheDocument();
+    expect(screen.queryByText("Warning message")).not.toBeInTheDocument();
+  });
+
   it("should handle helper text", () => {
     render(ComboBox, { props: { helperText: "Helper message" } });
 

--- a/tests/DatePicker/DatePicker.test.ts
+++ b/tests/DatePicker/DatePicker.test.ts
@@ -157,6 +157,29 @@ describe("DatePicker", () => {
     expect(wrapper).toHaveClass("bx--date-picker-input__wrapper--warn");
   });
 
+  it.each([
+    "disabled",
+    "readonly",
+  ] as const)("suppresses invalid and warn states when %s", (state) => {
+    const { container } = render(DatePicker, {
+      [state]: true,
+      invalid: true,
+      invalidText: "Invalid date",
+      warn: true,
+      warnText: "Warning message",
+    });
+
+    const wrapper = container.querySelector(".bx--date-picker-input__wrapper");
+    expect(wrapper).not.toHaveClass("bx--date-picker-input__wrapper--invalid");
+    expect(wrapper).not.toHaveClass("bx--date-picker-input__wrapper--warn");
+    expect(
+      container.querySelector(".bx--date-picker__icon--invalid"),
+    ).toBeNull();
+    expect(container.querySelector(".bx--date-picker__icon--warn")).toBeNull();
+    expect(screen.queryByText("Invalid date")).not.toBeInTheDocument();
+    expect(screen.queryByText("Warning message")).not.toBeInTheDocument();
+  });
+
   it("handles helper text", () => {
     render(DatePicker, { helperText: "Helper message" });
     expect(screen.getByText("Helper message")).toBeInTheDocument();

--- a/tests/Dropdown/Dropdown.test.ts
+++ b/tests/Dropdown/Dropdown.test.ts
@@ -196,6 +196,31 @@ describe("Dropdown", () => {
     expect(screen.getByRole("combobox")).toHaveTextContent("Slack");
   });
 
+  it.each([
+    "disabled",
+    "readonly",
+  ] as const)("should suppress invalid and warn states when %s", (state) => {
+    const { container } = render(Dropdown, {
+      props: {
+        items,
+        selectedId: "0",
+        [state]: true,
+        invalid: true,
+        invalidText: "Invalid selection",
+        warn: true,
+        warnText: "Warning message",
+      },
+    });
+
+    const listbox = container.querySelector(".bx--dropdown");
+    expect(listbox).not.toHaveAttribute("data-invalid");
+    expect(listbox).not.toHaveClass("bx--dropdown--invalid");
+    expect(listbox).not.toHaveClass("bx--dropdown--warning");
+    expect(container.querySelector(".bx--list-box__invalid-icon")).toBeNull();
+    expect(screen.queryByText("Invalid selection")).not.toBeInTheDocument();
+    expect(screen.queryByText("Warning message")).not.toBeInTheDocument();
+  });
+
   it("should handle helper text", () => {
     render(Dropdown, {
       props: {

--- a/tests/MultiSelect/MultiSelect.test.ts
+++ b/tests/MultiSelect/MultiSelect.test.ts
@@ -834,6 +834,30 @@ describe("MultiSelect", () => {
       expect(wrapper).toHaveClass("bx--list-box--warning");
     });
 
+    it.each([
+      "disabled",
+      "readonly",
+    ] as const)("suppresses invalid and warn states when %s", (state) => {
+      const { container } = render(MultiSelect, {
+        props: {
+          items,
+          [state]: true,
+          invalid: true,
+          invalidText: "Invalid selection",
+          warn: true,
+          warnText: "Warning message",
+        },
+      });
+
+      const wrapper = screen.getByRole("combobox").closest(".bx--list-box");
+      expect(wrapper).not.toHaveClass("bx--multi-select--invalid");
+      expect(wrapper).not.toHaveClass("bx--list-box--warning");
+      expect(wrapper).not.toHaveAttribute("data-invalid");
+      expect(container.querySelector(".bx--list-box__invalid-icon")).toBeNull();
+      expect(screen.queryByText("Invalid selection")).not.toBeInTheDocument();
+      expect(screen.queryByText("Warning message")).not.toBeInTheDocument();
+    });
+
     it("handles disabled state", () => {
       render(MultiSelect, {
         props: {

--- a/tests/Select/Select.test.ts
+++ b/tests/Select/Select.test.ts
@@ -167,6 +167,27 @@ describe("Select", () => {
     expect(screen.queryByText("Warning message")).not.toBeInTheDocument();
   });
 
+  it("suppresses invalid and warn states when disabled", () => {
+    render(Select, {
+      disabled: true,
+      invalid: true,
+      invalidText: "Invalid selection",
+      warn: true,
+      warnText: "Warning message",
+    });
+
+    const selectElement = screen.getByLabelText("Select label");
+    const selectWrapper = selectElement.closest(".bx--select");
+    assert(selectWrapper);
+
+    expect(selectWrapper).not.toHaveClass("bx--select--invalid");
+    expect(selectWrapper).not.toHaveClass("bx--select--warning");
+    expect(selectElement).not.toHaveAttribute("aria-invalid");
+    expect(selectWrapper.querySelector(".bx--select__invalid-icon")).toBeNull();
+    expect(screen.queryByText("Invalid selection")).not.toBeInTheDocument();
+    expect(screen.queryByText("Warning message")).not.toBeInTheDocument();
+  });
+
   it.each([
     "ArrowDown",
     "ArrowUp",

--- a/tests/Slider/Slider.test.ts
+++ b/tests/Slider/Slider.test.ts
@@ -364,6 +364,60 @@ describe("Slider", () => {
     expect(warnIcon).not.toBeInTheDocument();
   });
 
+  it("should suppress invalid state when disabled", () => {
+    const { container } = render(Slider, {
+      props: {
+        disabled: true,
+        invalid: true,
+        invalidText: "Error message",
+        warn: true,
+        warnText: "Warning message",
+      },
+    });
+
+    expect(container.querySelector(".bx--slider__invalid-icon")).toBeNull();
+    expect(screen.queryByText("Error message")).not.toBeInTheDocument();
+    expect(screen.queryByText("Warning message")).not.toBeInTheDocument();
+
+    const slider = container.querySelector('[role="slider"]');
+    const input = container.querySelector("input.bx--slider-text-input");
+    expect(slider).not.toHaveAttribute("aria-invalid");
+    expect(slider).not.toHaveAttribute("aria-describedby");
+    expect(input).not.toHaveClass("bx--text-input--invalid");
+    expect(input).not.toHaveAttribute("data-invalid");
+  });
+
+  it("should suppress invalid/warn state when readonly", () => {
+    const { container } = render(Slider, {
+      props: {
+        readonly: true,
+        invalid: true,
+        invalidText: "Error message",
+        warn: true,
+        warnText: "Warning message",
+      },
+    });
+
+    expect(container.querySelector(".bx--slider__invalid-icon")).toBeNull();
+    expect(screen.queryByText("Error message")).not.toBeInTheDocument();
+    expect(screen.queryByText("Warning message")).not.toBeInTheDocument();
+
+    const slider = container.querySelector('[role="slider"]');
+    expect(slider).not.toHaveAttribute("aria-invalid");
+    expect(slider).not.toHaveAttribute("aria-describedby");
+  });
+
+  it("should suppress warn state when disabled", () => {
+    const { container } = render(Slider, {
+      props: { disabled: true, warn: true, warnText: "Warning message" },
+    });
+
+    expect(
+      container.querySelector(".bx--slider__invalid-icon--warning"),
+    ).toBeNull();
+    expect(screen.queryByText("Warning message")).not.toBeInTheDocument();
+  });
+
   it("should handle custom labels", () => {
     render(Slider, {
       props: {


### PR DESCRIPTION
This aligns with Carbon React. Invalid/warn states are meant to be used with interactivity (making a fix to an input value). They should not be displayed if read-only/disabled, when the user cannot actively fix or address the issues.