### PR TITLE
chore: improve/standardize internal code style

### DIFF
--- a/src/Accordion/AccordionItem.svelte
+++ b/src/Accordion/AccordionItem.svelte
@@ -81,8 +81,8 @@
     on:mouseenter
     on:mouseleave
     on:keydown
-    on:keydown={({ key }) => {
-      if (open && key === "Escape") {
+    on:keydown={(event) => {
+      if (open && event.key === "Escape") {
         open = false;
       }
     }}

--- a/src/Checkbox/Checkbox.svelte
+++ b/src/Checkbox/Checkbox.svelte
@@ -139,14 +139,14 @@
       required={effectiveRequired}
       aria-readonly={readonly || undefined}
       class:bx--checkbox={true}
-      on:click={(e) => {
+      on:click={(event) => {
         if (readonly) {
-          e.preventDefault();
+          event.preventDefault();
         }
       }}
-      on:change={(e) => {
+      on:change={(event) => {
         if (readonly) {
-          e.preventDefault();
+          event.preventDefault();
           return;
         }
         if (ctxUpdate) {

--- a/src/CodeSnippet/CodeSnippet.svelte
+++ b/src/CodeSnippet/CodeSnippet.svelte
@@ -34,8 +34,8 @@
   export let copy = async (code) => {
     try {
       await navigator.clipboard.writeText(code);
-    } catch (e) {
-      console.log(e);
+    } catch (error) {
+      console.log(error);
     }
   };
 

--- a/src/CodeSnippet/CodeSnippet.svelte
+++ b/src/CodeSnippet/CodeSnippet.svelte
@@ -250,8 +250,8 @@
           animation = "fade-out";
         }, feedbackTimeout);
       }}
-      on:animationend={({ animationName }) => {
-        if (animationName === "hide-feedback") {
+      on:animationend={(event) => {
+        if (event.animationName === "hide-feedback") {
           animation = undefined;
           feedbackOpen = false;
         }

--- a/src/ComboBox/ComboBox.svelte
+++ b/src/ComboBox/ComboBox.svelte
@@ -257,32 +257,32 @@
       : shouldFilterItem
     : shouldFilterItem;
 
-  function change(dir) {
-    let index = highlightedIndex + dir;
-    let _items = filteredItems?.length ? filteredItems : items;
-    if (_items.length === 0) return;
-    if (index < 0) {
-      index = _items.length - 1;
-    } else if (index >= _items.length) {
-      index = 0;
+  function change(step) {
+    let candidateIndex = highlightedIndex + step;
+    const navigableItems = filteredItems?.length ? filteredItems : items;
+    if (navigableItems.length === 0) return;
+    if (candidateIndex < 0) {
+      candidateIndex = navigableItems.length - 1;
+    } else if (candidateIndex >= navigableItems.length) {
+      candidateIndex = 0;
     }
-    let disabled = _items[index].disabled;
+    let itemDisabled = navigableItems[candidateIndex].disabled;
     let attempts = 0;
 
-    while (disabled && attempts < _items.length) {
-      index = index + dir;
+    while (itemDisabled && attempts < navigableItems.length) {
+      candidateIndex = candidateIndex + step;
 
-      if (index < 0) {
-        index = _items.length - 1;
-      } else if (index >= _items.length) {
-        index = 0;
+      if (candidateIndex < 0) {
+        candidateIndex = navigableItems.length - 1;
+      } else if (candidateIndex >= navigableItems.length) {
+        candidateIndex = 0;
       }
 
-      disabled = _items[index].disabled;
+      itemDisabled = navigableItems[candidateIndex].disabled;
       attempts++;
     }
 
-    if (!disabled) highlightedIndex = index;
+    if (!itemDisabled) highlightedIndex = candidateIndex;
   }
 
   /**
@@ -448,7 +448,6 @@
         if (!ref.contains(document.activeElement) && !allowCustomValue) {
           value = "";
         }
-        highlightedIndex = -1;
       }
     }
   });
@@ -668,15 +667,14 @@
                 selectedId = filteredItems[highlightedIndex].id;
               }
             } else {
-              // searching typed value in text list with lowercase
+              // Match typed value case-insensitively against item text
               const inputValue = ref?.value ?? value;
               const matchedItem = filteredItems.find(
-                (e) =>
-                  e.text.toLowerCase() === inputValue?.toLowerCase() &&
-                  !e.disabled,
+                (item) =>
+                  item.text.toLowerCase() === inputValue?.toLowerCase() &&
+                  !item.disabled,
               );
               if (matchedItem) {
-                // typed value has matched
                 open = false;
                 valueBeforeOpen = "";
                 selectedItem = matchedItem;
@@ -767,8 +765,8 @@
         {#if virtualData?.isVirtualized}
           <div style="height: {virtualData.totalHeight}px; position: relative;">
             <div style="transform: translateY({virtualData.offsetY}px);">
-              {#each itemsToRender as item, i (item.id)}
-                {@const actualIndex = virtualData.startIndex + i}
+              {#each itemsToRender as item, index (item.id)}
+                {@const actualIndex = virtualData.startIndex + index}
                 <ListBoxMenuItem
                   id={item.id}
                   active={selectedId === item.id}
@@ -801,11 +799,11 @@
             </div>
           </div>
         {:else}
-          {#each itemsToRender as item, i (item.id)}
+          {#each itemsToRender as item, index (item.id)}
             <ListBoxMenuItem
               id={item.id}
               active={selectedId === item.id}
-              highlighted={highlightedIndex === i}
+              highlighted={highlightedIndex === index}
               disabled={item.disabled}
               on:click={(event) => {
                 if (item.disabled) {
@@ -816,16 +814,16 @@
                 open = false;
                 valueBeforeOpen = "";
 
-                if (filteredItems[i]) {
-                  value = itemToString(filteredItems[i]);
+                if (filteredItems[index]) {
+                  value = itemToString(filteredItems[index]);
                 }
               }}
               on:mouseenter={() => {
                 if (item.disabled) return;
-                highlightedIndex = i;
+                highlightedIndex = index;
               }}
             >
-              <slot {item} index={i}> {itemToString(item)} </slot>
+              <slot {item} {index}> {itemToString(item)} </slot>
               {#if selectedItem && selectedItem.id === item.id}
                 <Checkmark class="bx--list-box__menu-item__selected-icon" />
               {/if}

--- a/src/ComboBox/ComboBox.svelte
+++ b/src/ComboBox/ComboBox.svelte
@@ -238,8 +238,6 @@
   let fieldRef = null;
 
   /**
-   * @param {Item} item
-   * @param {string} inputValue
    * @returns {boolean}
    */
   function autocompleteCustomFilter(item, inputValue) {
@@ -564,13 +562,13 @@
 </script>
 
 <svelte:window
-  on:click={({ target }) => {
+  on:click={(event) => {
     if (skipWindowClick) {
       skipWindowClick = false;
       return;
     }
-    if (open && ref && !ref.contains(target)) {
-      if (effectivePortalMenu && listRef?.contains(target)) return;
+    if (open && ref && !ref.contains(event.target)) {
+      if (effectivePortalMenu && listRef?.contains(event.target)) return;
       open = false;
     }
   }}
@@ -636,8 +634,8 @@
           open = true;
         }}
         on:input
-        on:input={({ target }) => {
-          if (!open && target.value.length > 0) {
+        on:input={(event) => {
+          if (!open && event.target.value.length > 0) {
             open = true;
           }
 
@@ -647,13 +645,16 @@
           }
         }}
         on:keydown
-        on:keydown|stopPropagation={(e) => {
+        on:keydown|stopPropagation={(event) => {
           if (readonly) return;
-          const { key } = e;
-          if (key === "Enter" || key === "ArrowDown" || key === "ArrowUp") {
-            e.preventDefault();
+          if (
+            event.key === "Enter" ||
+            event.key === "ArrowDown" ||
+            event.key === "ArrowUp"
+          ) {
+            event.preventDefault();
           }
-          if (key === "Enter") {
+          if (event.key === "Enter") {
             open = !open;
             if (
               highlightedIndex > -1 &&
@@ -684,13 +685,13 @@
               }
             }
             highlightedIndex = -1;
-          } else if (key === "Tab") {
+          } else if (event.key === "Tab") {
             open = false;
-          } else if (key === "ArrowDown") {
+          } else if (event.key === "ArrowDown") {
             change(1);
-          } else if (key === "ArrowUp") {
+          } else if (event.key === "ArrowUp") {
             change(-1);
-          } else if (key === "Escape") {
+          } else if (event.key === "Escape") {
             clear();
           }
         }}
@@ -702,11 +703,11 @@
           }
         }}
         on:blur
-        on:blur={({ relatedTarget }) => {
-          if (!open || !relatedTarget) return;
+        on:blur={(event) => {
+          if (!open || !event.relatedTarget) return;
           if (
-            fieldRef?.contains(relatedTarget) ||
-            listRef?.contains(relatedTarget)
+            fieldRef?.contains(event.relatedTarget) ||
+            listRef?.contains(event.relatedTarget)
           ) {
             ref.focus();
           }
@@ -733,9 +734,9 @@
       {/if}
       <ListBoxMenuIcon
         aria-hidden={readonly || undefined}
-        on:click={(e) => {
+        on:click={(event) => {
           if (disabled || readonly) return;
-          e.stopPropagation();
+          event.stopPropagation();
           open = !open;
         }}
         {translateWithId}
@@ -751,8 +752,8 @@
         anchor={fieldRef}
         {direction}
         on:scroll
-        on:scroll={(e) => {
-          listScrollTop = e.target.scrollTop;
+        on:scroll={(event) => {
+          listScrollTop = event.target.scrollTop;
         }}
         bind:ref={listRef}
         style={effectivePortalMenu
@@ -773,9 +774,9 @@
                   active={selectedId === item.id}
                   highlighted={highlightedIndex === actualIndex}
                   disabled={item.disabled}
-                  on:click={(e) => {
+                  on:click={(event) => {
                     if (item.disabled) {
-                      e.stopPropagation();
+                      event.stopPropagation();
                       return;
                     }
                     selectedId = item.id;
@@ -806,9 +807,9 @@
               active={selectedId === item.id}
               highlighted={highlightedIndex === i}
               disabled={item.disabled}
-              on:click={(e) => {
+              on:click={(event) => {
                 if (item.disabled) {
-                  e.stopPropagation();
+                  event.stopPropagation();
                   return;
                 }
                 selectedId = item.id;

--- a/src/ComposedModal/ComposedModal.svelte
+++ b/src/ComposedModal/ComposedModal.svelte
@@ -165,11 +165,11 @@
   inert={open ? undefined : true}
   {...$$restProps}
   on:keydown
-  on:keydown={(e) => {
+  on:keydown={(event) => {
     if (open) {
-      if (e.key === "Escape") {
+      if (event.key === "Escape") {
         close("escape-key");
-      } else if (e.key === "Tab") {
+      } else if (event.key === "Tab") {
         // taken from github.com/carbon-design-system/carbon/packages/react/src/internal/keyboard/navigation.js
         const selectorTabbable = `
   a[href], area[href], input:not([disabled]):not([tabindex='-1']),
@@ -201,7 +201,7 @@
         });
 
         if (tabbable.length === 0) {
-          e.preventDefault();
+          event.preventDefault();
           return;
         }
 
@@ -210,14 +210,14 @@
           // Active element not in tabbable list, find closest tabbable element
           // For forward Tab, start from beginning (-1 + 1 = 0)
           // For Shift+Tab, start from end (length + -1 = length - 1)
-          index = e.shiftKey ? tabbable.length : -1;
+          index = event.shiftKey ? tabbable.length : -1;
         }
 
-        index += e.shiftKey ? -1 : 1;
+        index += event.shiftKey ? -1 : 1;
         index = (index + tabbable.length) % tabbable.length;
 
         tabbable[index].focus();
-        e.preventDefault();
+        event.preventDefault();
       }
     }
   }}
@@ -231,8 +231,8 @@
   on:mouseover
   on:mouseenter
   on:mouseleave
-  on:transitionend={({ propertyName, currentTarget }) => {
-    if (propertyName === "transform") {
+  on:transitionend={(event) => {
+    if (event.propertyName === "transform") {
       dispatch("transitionend", { open });
       if (!open && previouslyFocusedElement?.isConnected) {
         previouslyFocusedElement.focus();
@@ -245,7 +245,7 @@
         document.activeElement instanceof HTMLElement
           ? document.activeElement
           : null;
-      focus(currentTarget);
+      focus(event.currentTarget);
       didOpen = false;
     }
   }}

--- a/src/ContentSwitcher/Switch.svelte
+++ b/src/ContentSwitcher/Switch.svelte
@@ -70,16 +70,16 @@
   on:blur
   on:keyup
   on:keydown
-  on:keydown={(e) => {
-    if (e.key === "ArrowRight") {
+  on:keydown={(event) => {
+    if (event.key === "ArrowRight") {
       ctx.selectionMode === "manual" ? ctx.focus(1) : ctx.change(1);
-    } else if (e.key === "ArrowLeft") {
+    } else if (event.key === "ArrowLeft") {
       ctx.selectionMode === "manual" ? ctx.focus(-1) : ctx.change(-1);
-    } else if (e.key === "Home") {
-      e.preventDefault();
+    } else if (event.key === "Home") {
+      event.preventDefault();
       ctx.selectionMode === "manual" ? ctx.focusTo(0) : ctx.changeTo(0);
-    } else if (e.key === "End") {
-      e.preventDefault();
+    } else if (event.key === "End") {
+      event.preventDefault();
       const last = ctx.switchCount - 1;
       ctx.selectionMode === "manual" ? ctx.focusTo(last) : ctx.changeTo(last);
     }

--- a/src/ContextMenu/ContextMenu.svelte
+++ b/src/ContextMenu/ContextMenu.svelte
@@ -89,30 +89,30 @@
   }
 
   /** @type {(e: MouseEvent) => void} */
-  function openMenu(e) {
-    e.preventDefault();
+  function openMenu(event) {
+    event.preventDefault();
     const { height, width } = ref.getBoundingClientRect();
 
     if (open || x === 0) {
-      if (window.innerWidth - width < e.x) {
-        x = e.x - width;
+      if (window.innerWidth - width < event.x) {
+        x = event.x - width;
       } else {
-        x = e.x;
+        x = event.x;
       }
     }
 
     if (open || y === 0) {
-      menuOffsetX.set(e.x);
+      menuOffsetX.set(event.x);
 
-      if (window.innerHeight - height < e.y) {
-        y = e.y - height;
+      if (window.innerHeight - height < event.y) {
+        y = event.y - height;
       } else {
-        y = e.y;
+        y = event.y;
       }
     }
     position.set([x, y]);
     open = true;
-    openDetail = e.target;
+    openDetail = event.target;
   }
 
   /** @type {Array<HTMLElement | null>} */
@@ -177,20 +177,20 @@
 </script>
 
 <svelte:window
-  on:contextmenu={(e) => {
+  on:contextmenu={(event) => {
     if (target != null) return;
     if (level > 1) return;
     if (!ref) return;
-    openMenu(e);
+    openMenu(event);
   }}
-  on:click={(e) => {
+  on:click={(event) => {
     if (!open) return;
-    if (ref && !ref.contains(e.target)) {
+    if (ref && !ref.contains(event.target)) {
       close();
     }
   }}
-  on:keydown={(e) => {
-    if (open && e.key === "Escape") close();
+  on:keydown={(event) => {
+    if (open && event.key === "Escape") close();
   }}
 />
 
@@ -210,29 +210,29 @@
   {...$$restProps}
   aria-label={menuAriaLabel}
   on:click
-  on:click={({ target }) => {
-    const closestOption = target.closest("[tabindex]");
+  on:click={(event) => {
+    const closestOption = event.target.closest("[tabindex]");
 
     if (closestOption && closestOption.getAttribute("role") !== "menuitem") {
       close();
     }
   }}
   on:keydown
-  on:keydown={(e) => {
-    if (open) e.preventDefault();
+  on:keydown={(event) => {
+    if (open) event.preventDefault();
     if ($hasPopup) return;
 
-    if (e.key === "ArrowDown") {
+    if (event.key === "ArrowDown") {
       if (focusIndex < options.length - 1) focusIndex++;
-    } else if (e.key === "ArrowUp") {
+    } else if (event.key === "ArrowUp") {
       if (focusIndex === -1) {
         focusIndex = options.length - 1;
       } else {
         if (focusIndex > 0) focusIndex--;
       }
-    } else if (e.key === "Home") {
+    } else if (event.key === "Home") {
       if (options.length > 0) focusIndex = 0;
-    } else if (e.key === "End" && options.length > 0) {
+    } else if (event.key === "End" && options.length > 0) {
       focusIndex = options.length - 1;
     }
   }}

--- a/src/ContextMenu/ContextMenuOption.svelte
+++ b/src/ContextMenu/ContextMenuOption.svelte
@@ -183,11 +183,11 @@
     return inTopTriangle || inBottomTriangle;
   }
 
-  function handleClick(e, opts = {}) {
+  function handleClick(event, opts = {}) {
     if (disabled) return;
     if (subOptions) return;
 
-    const shouldContinue = dispatch("click", e, { cancelable: true });
+    const shouldContinue = dispatch("click", event, { cancelable: true });
 
     if (shouldContinue) {
       if (ctxGroup) {
@@ -206,12 +206,12 @@
     }
   }
 
-  function handleGlobalMouseMove(e) {
+  function handleGlobalMouseMove(event) {
     if (subOptions && submenuOpen) {
-      mousePosition = { x: e.clientX, y: e.clientY };
+      mousePosition = { x: event.clientX, y: event.clientY };
 
       if (
-        isInSafeTriangle(e.clientX, e.clientY) &&
+        isInSafeTriangle(event.clientX, event.clientY) &&
         typeof timeoutClose === "number"
       ) {
         clearTimeout(timeoutClose);
@@ -322,11 +322,10 @@
   data-id={id}
   {...$$restProps}
   on:keydown
-  on:keydown={async (e) => {
-    const { key, target } = e;
+  on:keydown={async (event) => {
     if (
       subOptions &&
-      (key === "ArrowRight" || key === " " || key === "Enter")
+      (event.key === "ArrowRight" || event.key === " " || event.key === "Enter")
     ) {
       if (disabled) return;
       submenuOpen = true;
@@ -337,31 +336,34 @@
     }
 
     if (submenuOpen) {
-      if (key === "ArrowLeft") {
+      if (event.key === "ArrowLeft") {
         submenuOpen = false;
         focusIndex = 0;
         return;
       }
 
-      if (key === "ArrowDown") {
+      if (event.key === "ArrowDown") {
         if (focusIndex < options.length - 1) focusIndex++;
-      } else if (key === "ArrowUp") {
+      } else if (event.key === "ArrowUp") {
         if (focusIndex === -1) {
           focusIndex = options.length - 1;
         } else {
           if (focusIndex > 0) focusIndex--;
         }
-      } else if (key === "Home") {
+      } else if (event.key === "Home") {
         if (options.length > 0) focusIndex = 0;
-      } else if (key === "End" && options.length > 0) {
+      } else if (event.key === "End" && options.length > 0) {
         focusIndex = options.length - 1;
       }
 
       if (options[focusIndex]) options[focusIndex].focus();
     }
 
-    if (key === " " || key === "Enter") {
-      handleClick(e, { fromKeyboard: true, id: target.getAttribute("data-id") });
+    if (event.key === " " || event.key === "Enter") {
+      handleClick(event, {
+        fromKeyboard: true,
+        id: event.target.getAttribute("data-id"),
+      });
     }
   }}
   on:mouseenter
@@ -377,9 +379,9 @@
       }, moderate01);
     }
   }}
-  on:mousemove={(e) => {
+  on:mousemove={(event) => {
     if (subOptions && submenuOpen) {
-      mousePosition = { x: e.clientX, y: e.clientY };
+      mousePosition = { x: event.clientX, y: event.clientY };
     }
   }}
   on:mouseleave
@@ -394,14 +396,14 @@
       }, closeDelay);
     }
   }}
-  on:click={(e) => {
+  on:click={(event) => {
     if (subOptions) {
-      e.stopPropagation();
+      event.stopPropagation();
       if (disabled) return;
       submenuOpen = true;
       return;
     }
-    handleClick(e);
+    handleClick(event);
   }}
 >
   {#if subOptions}

--- a/src/CopyButton/CopyButton.svelte
+++ b/src/CopyButton/CopyButton.svelte
@@ -21,8 +21,8 @@
   export let copy = async (text) => {
     try {
       await navigator.clipboard.writeText(text);
-    } catch (e) {
-      console.log(e);
+    } catch (error) {
+      console.log(error);
     }
   };
 

--- a/src/CopyButton/CopyButton.svelte
+++ b/src/CopyButton/CopyButton.svelte
@@ -106,8 +106,8 @@
     }, feedbackTimeout);
   }}
   on:animationend
-  on:animationend={({ animationName }) => {
-    if (animationName === "hide-feedback") {
+  on:animationend={(event) => {
+    if (event.animationName === "hide-feedback") {
       animation = undefined;
       feedbackOpen = false;
     }

--- a/src/DataTable/DataTable.svelte
+++ b/src/DataTable/DataTable.svelte
@@ -653,7 +653,7 @@
       : undefined}
     style:overflow-y={virtualScrollContainer ? "auto" : undefined}
     on:scroll={virtualScrollContainer
-      ? (e) => { tableBodyScrollTop = e.target.scrollTop || 0; }
+      ? (event) => { tableBodyScrollTop = event.target.scrollTop || 0; }
       : undefined}
   >
     <Table
@@ -717,20 +717,20 @@
                 value="all"
                 checked={selectAll}
                 {indeterminate}
-                on:change={(e) => {
+                on:change={(event) => {
                   dispatch("click:header--select", {
                     indeterminate,
-                    selected: !indeterminate && e.target.checked,
+                    selected: !indeterminate && event.target.checked,
                   });
 
                   if (indeterminate) {
-                    e.target.checked = false;
+                    event.target.checked = false;
                     selectAll = false;
                     selectedRowIds = [];
                     return;
                   }
 
-                  if (e.target.checked) {
+                  if (event.target.checked) {
                     selectedRowIds = selectableRowIds;
                   } else {
                     selectedRowIds = [];
@@ -752,14 +752,14 @@
                 {...(tableHeaderTranslateWithId
                   ? { translateWithId: tableHeaderTranslateWithId }
                   : {})}
-                on:click={(e) => {
+                on:click={(event) => {
                   dispatch("click", { header });
 
                   if (header.sort === false) {
                     dispatch("click:header", {
                       header,
-                      target: e.target,
-                      currentTarget: e.currentTarget,
+                      target: event.target,
+                      currentTarget: event.currentTarget,
                     });
                   } else {
                     const currentSortDirection =
@@ -795,8 +795,8 @@
                     dispatch("click:header", {
                       header,
                       sortDirection: nextSortDirection,
-                      target: e.target,
-                      currentTarget: e.currentTarget,
+                      target: event.target,
+                      currentTarget: event.currentTarget,
                     });
                   }
                 }}
@@ -834,17 +834,17 @@
               parentRowId === row.id
                 ? 'bx--expandable-row--hover'
                 : ''} {rowClassValue ?? ''}"
-              on:click={(e) => {
+              on:click={(event) => {
                 // forgo "click", "click:row" events if target
                 // resembles an overflow menu, a checkbox, or radio button
-                if (shouldIgnoreRowClick(e.target)) {
+                if (shouldIgnoreRowClick(event.target)) {
                   return;
                 }
                 dispatch("click", { row });
                 dispatch("click:row", {
                   row,
-                  target: e.target,
-                  currentTarget: e.currentTarget,
+                  target: event.target,
+                  currentTarget: event.currentTarget,
                 });
               }}
               on:mouseenter={() => {
@@ -964,12 +964,12 @@
                   </td>
                 {:else}
                   <TableCell
-                    on:click={(e) => {
+                    on:click={(event) => {
                       dispatch("click", { row, cell });
                       dispatch("click:cell", {
                         cell,
-                        target: e.target,
-                        currentTarget: e.currentTarget,
+                        target: event.target,
+                        currentTarget: event.currentTarget,
                       });
                     }}
                   >
@@ -1054,17 +1054,17 @@
                 : ''} {expandable && parentRowId === row.id
                 ? 'bx--expandable-row--hover'
                 : ''} {rowClassValue ?? ''}"
-              on:click={(e) => {
+              on:click={(event) => {
                 // forgo "click", "click:row" events if target
                 // resembles an overflow menu, a checkbox, or radio button
-                if (shouldIgnoreRowClick(e.target)) {
+                if (shouldIgnoreRowClick(event.target)) {
                   return;
                 }
                 dispatch("click", { row });
                 dispatch("click:row", {
                   row,
-                  target: e.target,
-                  currentTarget: e.currentTarget,
+                  target: event.target,
+                  currentTarget: event.currentTarget,
                 });
               }}
               on:mouseenter={() => {
@@ -1172,12 +1172,12 @@
                   </td>
                 {:else}
                   <TableCell
-                    on:click={(e) => {
+                    on:click={(event) => {
                       dispatch("click", { row, cell });
                       dispatch("click:cell", {
                         cell,
-                        target: e.target,
-                        currentTarget: e.currentTarget,
+                        target: event.target,
+                        currentTarget: event.currentTarget,
                       });
                     }}
                   >

--- a/src/DataTable/DataTable.svelte
+++ b/src/DataTable/DataTable.svelte
@@ -412,10 +412,10 @@
       // for a basic, case-insensitive match (non-fuzzy).
       // This supports nested keys like "contact.company".
       filteredRows = originalRows.filter((row) => {
-        return searchableKeys.some((key) => {
-          const _value = resolvePath(row, key);
-          if (typeof _value === "string" || typeof _value === "number") {
-            return `${_value}`?.toLowerCase().includes(value);
+        return searchableKeys.some((searchKey) => {
+          const cellValue = resolvePath(row, searchKey);
+          if (typeof cellValue === "string" || typeof cellValue === "number") {
+            return `${cellValue}`?.toLowerCase().includes(value);
           }
           return false;
         });
@@ -817,8 +817,8 @@
           {/if}
 
           <!-- Visible rows -->
-          {#each rowsToRender as row, i (row.id)}
-            {@const actualIndex = virtualData.startIndex + i}
+          {#each rowsToRender as row, index (row.id)}
+            {@const actualIndex = virtualData.startIndex + index}
             {@const isSelected = selectedRowIdsSet.has(row.id)}
             {@const isExpanded = !!expandedRows[row.id]}
             {@const rowClassValue =
@@ -1035,14 +1035,14 @@
           {/if}
         {:else}
           <!-- Non-virtualized: render all rows normally -->
-          {#each rowsToRender as row, i (row.id)}
+          {#each rowsToRender as row, index (row.id)}
             {@const isSelected = selectedRowIdsSet.has(row.id)}
             {@const isExpanded = !!expandedRows[row.id]}
             {@const isExpandable = !nonExpandableRowIdsSet.has(row.id)}
             {@const isSelectable = !nonSelectableRowIdsSet.has(row.id)}
             {@const rowClassValue =
               typeof rowClass === "function"
-                ? rowClass({ row, rowIndex: i, selected: isSelected, expanded: isExpanded })
+                ? rowClass({ row, rowIndex: index, selected: isSelected, expanded: isExpanded })
                 : rowClass}
             <TableRow
               data-row={row.id}
@@ -1162,7 +1162,7 @@
                       name="cell"
                       {row}
                       {cell}
-                      rowIndex={i}
+                      rowIndex={index}
                       cellIndex={j}
                       rowSelected={isSelected}
                       rowExpanded={isExpanded}
@@ -1185,7 +1185,7 @@
                       name="cell"
                       {row}
                       {cell}
-                      rowIndex={i}
+                      rowIndex={index}
                       cellIndex={j}
                       rowSelected={isSelected}
                       rowExpanded={isExpanded}

--- a/src/DatePicker/DatePicker.svelte
+++ b/src/DatePicker/DatePicker.svelte
@@ -280,10 +280,10 @@
     focusCalendar,
   });
 
-  function applyOptionIfChanged(key, value, appliedValue = value) {
-    if (lastAppliedOptions[key] !== value) {
-      calendar.set(key, appliedValue);
-      lastAppliedOptions[key] = value;
+  function applyOptionIfChanged(optionKey, value, appliedValue = value) {
+    if (lastAppliedOptions[optionKey] !== value) {
+      calendar.set(optionKey, appliedValue);
+      lastAppliedOptions[optionKey] = value;
     }
   }
 

--- a/src/DatePicker/DatePicker.svelte
+++ b/src/DatePicker/DatePicker.svelte
@@ -422,13 +422,13 @@
 </script>
 
 <svelte:window
-  on:click={({ target }) => {
+  on:click={(event) => {
     if (!calendar?.isOpen) return;
     if (
       isEventTargetInsidePortaledCalendar(
         datePickerRef,
         calendar.calendarContainer,
-        target,
+        event.target,
       )
     ) {
       return;
@@ -459,9 +459,9 @@
     class:bx--date-picker--range={datePickerType === "range"}
     class:bx--date-picker--nolabel={datePickerType === "range" &&
       $labelTextEmpty}
-    on:keydown={(e) => {
-      if (calendar?.isOpen && e.key === "Escape") {
-        e.stopPropagation();
+    on:keydown={(event) => {
+      if (calendar?.isOpen && event.key === "Escape") {
+        event.stopPropagation();
         calendar.close();
       }
     }}

--- a/src/DatePicker/DatePickerInput.svelte
+++ b/src/DatePicker/DatePickerInput.svelte
@@ -169,23 +169,23 @@
       class:bx--date-picker__input--sm={size === "sm"}
       class:bx--date-picker__input--xl={size === "xl"}
       on:input
-      on:input={({ target }) => {
-        updateValue({ type: "input", value: target.value });
+      on:input={(event) => {
+        updateValue({ type: "input", value: event.target.value });
       }}
-      on:change={({ target }) => {
-        updateValue({ type: "change", value: target.value });
+      on:change={(event) => {
+        updateValue({ type: "change", value: event.target.value });
       }}
       on:keydown
-      on:keydown={({ key }) => {
-        if (!readonly && key === "ArrowDown") {
+      on:keydown={(event) => {
+        if (!readonly && event.key === "ArrowDown") {
           focusCalendar();
         }
       }}
       on:keyup
       on:focus
       on:blur
-      on:blur={({ relatedTarget }) => {
-        blurInput(relatedTarget);
+      on:blur={(event) => {
+        blurInput(event.relatedTarget);
       }}
       on:paste
     >

--- a/src/Dropdown/Dropdown.svelte
+++ b/src/Dropdown/Dropdown.svelte
@@ -201,8 +201,8 @@
   $: inline = type === "inline";
   $: {
     itemsById = new Map();
-    for (let i = 0; i < items.length; i++) {
-      itemsById.set(items[i].id, items[i]);
+    for (let index = 0; index < items.length; index++) {
+      itemsById.set(items[index].id, items[index]);
     }
   }
   $: menuId = `menu-${id}`;
@@ -379,43 +379,43 @@
     }
   });
 
-  function change(dir) {
-    let index = highlightedIndex + dir;
+  function change(step) {
+    let candidateIndex = highlightedIndex + step;
 
     if (items.length === 0) return;
-    if (index < 0) {
-      index = items.length - 1;
-    } else if (index >= items.length) {
-      index = 0;
+    if (candidateIndex < 0) {
+      candidateIndex = items.length - 1;
+    } else if (candidateIndex >= items.length) {
+      candidateIndex = 0;
     }
 
-    let disabled = items[i].disabled;
+    let itemDisabled = items[candidateIndex].disabled;
     let attempts = 0;
 
-    while (disabled && attempts < items.length) {
-      index = index + dir;
+    while (itemDisabled && attempts < items.length) {
+      candidateIndex = candidateIndex + step;
 
-      if (index < 0) {
-        index = items.length - 1;
-      } else if (index >= items.length) {
-        index = 0;
+      if (candidateIndex < 0) {
+        candidateIndex = items.length - 1;
+      } else if (candidateIndex >= items.length) {
+        candidateIndex = 0;
       }
 
-      disabled = items[i].disabled;
+      itemDisabled = items[candidateIndex].disabled;
       attempts++;
     }
 
-    if (!disabled) highlightedIndex = index;
+    if (!itemDisabled) highlightedIndex = candidateIndex;
   }
 
-  function typeaheadSearch(char) {
+  function typeaheadSearch(character) {
     if (items.length === 0) return;
 
     if (typeaheadTimeout) {
       clearTimeout(typeaheadTimeout);
     }
 
-    typeaheadBuffer += char.toLowerCase();
+    typeaheadBuffer += character.toLowerCase();
 
     typeaheadTimeout = setTimeout(() => {
       typeaheadBuffer = "";
@@ -425,19 +425,19 @@
     // Start search from the next index after current highlight, or from 0 if none highlighted.
     const startIndex = highlightedIndex >= 0 ? highlightedIndex + 1 : 0;
 
-    for (let i = startIndex; i < items.length; i++) {
-      const itemText = itemToString(items[i]).toLowerCase();
-      if (itemText.startsWith(typeaheadBuffer) && !items[i].disabled) {
-        highlightedIndex = i;
+    for (let index = startIndex; index < items.length; index++) {
+      const itemText = itemToString(items[index]).toLowerCase();
+      if (itemText.startsWith(typeaheadBuffer) && !items[index].disabled) {
+        highlightedIndex = index;
         return;
       }
     }
 
     // Wrap around: search from beginning to startIndex.
-    for (let i = 0; i < startIndex; i++) {
-      const itemText = itemToString(items[i]).toLowerCase();
-      if (itemText.startsWith(typeaheadBuffer) && !items[i].disabled) {
-        highlightedIndex = i;
+    for (let index = 0; index < startIndex; index++) {
+      const itemText = itemToString(items[index]).toLowerCase();
+      if (itemText.startsWith(typeaheadBuffer) && !items[index].disabled) {
+        highlightedIndex = index;
         return;
       }
     }
@@ -634,8 +634,8 @@
         {#if virtualData?.isVirtualized}
           <div style="height: {virtualData.totalHeight}px; position: relative;">
             <div style="transform: translateY({virtualData.offsetY}px);">
-              {#each itemsToRender as item, i (item.id)}
-                {@const actualIndex = virtualData.startIndex + i}
+              {#each itemsToRender as item, index (item.id)}
+                {@const actualIndex = virtualData.startIndex + index}
                 <ListBoxMenuItem
                   id={item.id}
                   active={selectedId === item.id}
@@ -665,11 +665,11 @@
             </div>
           </div>
         {:else}
-          {#each itemsToRender as item, i (item.id)}
+          {#each itemsToRender as item, index (item.id)}
             <ListBoxMenuItem
               id={item.id}
               active={selectedId === item.id}
-              highlighted={highlightedIndex === i}
+              highlighted={highlightedIndex === index}
               disabled={item.disabled}
               on:click={(event) => {
                 if (item.disabled) {
@@ -683,10 +683,10 @@
               }}
               on:mouseenter={() => {
                 if (item.disabled) return;
-                highlightedIndex = i;
+                highlightedIndex = index;
               }}
             >
-              <slot {item} index={i}> {itemToString(item)} </slot>
+              <slot {item} {index}> {itemToString(item)} </slot>
               {#if selectedId === item.id}
                 <Checkmark class="bx--list-box__menu-item__selected-icon" />
               {/if}

--- a/src/Dropdown/Dropdown.svelte
+++ b/src/Dropdown/Dropdown.svelte
@@ -389,7 +389,7 @@
       index = 0;
     }
 
-    let disabled = items[index].disabled;
+    let disabled = items[i].disabled;
     let attempts = 0;
 
     while (disabled && attempts < items.length) {
@@ -401,7 +401,7 @@
         index = 0;
       }
 
-      disabled = items[index].disabled;
+      disabled = items[i].disabled;
       attempts++;
     }
 
@@ -477,9 +477,9 @@
 </script>
 
 <svelte:window
-  on:click={(e) => {
-    if (open && ref && !ref.contains(e.target)) {
-      if (effectivePortalMenu && listRef?.contains(e.target)) return;
+  on:click={(event) => {
+    if (open && ref && !ref.contains(event.target)) {
+      if (effectivePortalMenu && listRef?.contains(event.target)) return;
       open = false;
     }
   }}
@@ -510,9 +510,9 @@
     {name}
     aria-label={$$props["aria-label"]}
     class={dropdownListBoxClass}
-    on:click={({ target }) => {
+    on:click={(event) => {
       if (disabled || readonly) return;
-      open = ref.contains(target) ? !open : false;
+      open = ref.contains(event.target) ? !open : false;
     }}
     {disabled}
     {open}
@@ -547,40 +547,44 @@
           : !inline && !showInvalid && !showWarn && helperText
             ? helperId
             : undefined}
-      on:keydown={(e) => {
-        if (e.key === "Enter" || e.key === "ArrowDown" || e.key === "ArrowUp") {
-          e.preventDefault();
+      on:keydown={(event) => {
+        if (
+          event.key === "Enter" ||
+          event.key === "ArrowDown" ||
+          event.key === "ArrowUp"
+        ) {
+          event.preventDefault();
         }
 
         if (readonly) return;
 
-        if (e.key === "Enter") {
+        if (event.key === "Enter") {
           selectHighlighted();
-        } else if (e.key === "Tab") {
+        } else if (event.key === "Tab") {
           open = false;
-        } else if (e.key === "ArrowDown") {
+        } else if (event.key === "ArrowDown") {
           if (!open) open = true;
           change(1);
-        } else if (e.key === "ArrowUp") {
+        } else if (event.key === "ArrowUp") {
           if (!open) open = true;
           change(-1);
-        } else if (e.key === "Escape") {
+        } else if (event.key === "Escape") {
           open = false;
         } else if (
           open &&
-          e.key.length === 1 &&
-          e.key !== " " &&
-          !e.ctrlKey &&
-          !e.metaKey &&
-          !e.altKey
+          event.key.length === 1 &&
+          event.key !== " " &&
+          !event.ctrlKey &&
+          !event.metaKey &&
+          !event.altKey
         ) {
-          e.preventDefault();
-          typeaheadSearch(e.key);
+          event.preventDefault();
+          typeaheadSearch(event.key);
         }
       }}
-      on:keyup={(e) => {
-        if (e.key === " ") {
-          e.preventDefault();
+      on:keyup={(event) => {
+        if (event.key === " ") {
+          event.preventDefault();
         } else {
           return;
         }
@@ -597,8 +601,8 @@
         {/if}
       </span>
       <ListBoxMenuIcon
-        on:click={(e) => {
-          e.stopPropagation();
+        on:click={(event) => {
+          event.stopPropagation();
           if (disabled || readonly) return;
           open = !open;
         }}
@@ -615,8 +619,8 @@
         anchor={ref}
         {direction}
         on:scroll
-        on:scroll={(e) => {
-          listScrollTop = e.target.scrollTop;
+        on:scroll={(event) => {
+          listScrollTop = event.target.scrollTop;
         }}
         bind:ref={listRef}
         style={effectivePortalMenu
@@ -637,9 +641,9 @@
                   active={selectedId === item.id}
                   highlighted={highlightedIndex === actualIndex}
                   disabled={item.disabled}
-                  on:click={(e) => {
+                  on:click={(event) => {
                     if (item.disabled) {
-                      e.stopPropagation();
+                      event.stopPropagation();
                       return;
                     }
                     selectedId = item.id;
@@ -667,9 +671,9 @@
               active={selectedId === item.id}
               highlighted={highlightedIndex === i}
               disabled={item.disabled}
-              on:click={(e) => {
+              on:click={(event) => {
                 if (item.disabled) {
-                  e.stopPropagation();
+                  event.stopPropagation();
                   return;
                 }
                 selectedId = item.id;

--- a/src/FileUploader/FileUploader.svelte
+++ b/src/FileUploader/FileUploader.svelte
@@ -212,8 +212,8 @@
     {kind}
     {size}
     bind:files
-    on:change={(e) => {
-      let newFiles = e.detail;
+    on:change={(event) => {
+      let newFiles = event.detail;
       const allRejected = [];
       const existingRefs = new Set(prevFiles);
 
@@ -277,8 +277,8 @@
             {iconDescription}
             {status}
             on:keydown
-            on:keydown={(e) => {
-              if (e.key === " " || e.key === "Enter") {
+            on:keydown={(event) => {
+              if (event.key === " " || event.key === "Enter") {
                 files = files.filter((f) => f !== file);
               }
             }}

--- a/src/FileUploader/FileUploaderButton.svelte
+++ b/src/FileUploader/FileUploaderButton.svelte
@@ -199,9 +199,9 @@
   aria-label={hasIconOnly ? iconDescription : labelText}
   class:bx--visually-hidden={true}
   {...$$restProps}
-  on:change|stopPropagation={({ target }) => {
+  on:change|stopPropagation={(event) => {
     if (multiple) {
-      let incoming = [...target.files];
+      let incoming = [...event.target.files];
       if (preventDuplicate) {
         const existingKeys = new Set(
           files.map((f) => `${f.name}\0${f.size}\0${f.lastModified}`),
@@ -212,7 +212,7 @@
       }
       files = [...files, ...incoming];
     } else {
-      files = [...target.files];
+      files = [...event.target.files];
     }
 
     if (files && files.length > 0 && !disableLabelChanges) {
@@ -222,7 +222,7 @@
     dispatch("change", files);
   }}
   on:click
-  on:click={({ target }) => {
-    target.value = "";
+  on:click={(event) => {
+    event.target.value = "";
   }}
 >

--- a/src/FileUploader/FileUploaderDropContainer.svelte
+++ b/src/FileUploader/FileUploaderDropContainer.svelte
@@ -66,24 +66,24 @@
   class:bx--file={true}
   {...$$restProps}
   on:dragover
-  on:dragover|preventDefault|stopPropagation={({ dataTransfer }) => {
+  on:dragover|preventDefault|stopPropagation={(event) => {
     if (!disabled) {
       over = true;
-      dataTransfer.dropEffect = "copy";
+      event.dataTransfer.dropEffect = "copy";
     }
   }}
   on:dragleave
-  on:dragleave|preventDefault|stopPropagation={({ dataTransfer }) => {
+  on:dragleave|preventDefault|stopPropagation={(event) => {
     if (!disabled) {
       over = false;
-      dataTransfer.dropEffect = "move";
+      event.dataTransfer.dropEffect = "move";
     }
   }}
   on:drop
-  on:drop|preventDefault|stopPropagation={({ dataTransfer }) => {
+  on:drop|preventDefault|stopPropagation={(event) => {
     if (!disabled) {
       over = false;
-      const newFiles = validateFiles([...dataTransfer.files]);
+      const newFiles = validateFiles([...event.dataTransfer.files]);
       files = multiple ? [...files, ...newFiles] : newFiles;
       dispatch("add", files);
       dispatch("change", files);
@@ -98,8 +98,8 @@
     class:bx--file-browse-btn={true}
     class:bx--file-browse-btn--disabled={disabled}
     on:keydown
-    on:keydown={({ key }) => {
-      if (key === " " || key === "Enter") {
+    on:keydown={(event) => {
+      if (event.key === " " || event.key === "Enter") {
         ref.click();
       }
     }}
@@ -122,15 +122,15 @@
     {name}
     {multiple}
     class:bx--file-input={true}
-    on:change={({ target }) => {
-      const newFiles = validateFiles([...target.files]);
+    on:change={(event) => {
+      const newFiles = validateFiles([...event.target.files]);
       files = multiple ? [...files, ...newFiles] : newFiles;
       dispatch("add", files);
       dispatch("change", files);
     }}
     on:click
-    on:click={({ target }) => {
-      target.value = null;
+    on:click={(event) => {
+      event.target.value = null;
     }}
   >
 </div>

--- a/src/FileUploader/FileUploaderItem.svelte
+++ b/src/FileUploader/FileUploaderItem.svelte
@@ -61,8 +61,8 @@
   <span class:bx--file__state-container={true}>
     <Filename
       fileName={name}
-      on:keydown={({ key }) => {
-        if (key === " " || key === "Enter") {
+      on:keydown={(event) => {
+        if (event.key === " " || event.key === "Enter") {
           dispatch("delete", id);
         }
       }}

--- a/src/ListBox/ListBox.svelte
+++ b/src/ListBox/ListBox.svelte
@@ -48,9 +48,9 @@
   class:bx--list-box--warning={!invalid && warn}
   {...$$restProps}
   on:keydown
-  on:keydown={(e) => {
-    if (e.key === "Escape") {
-      e.stopPropagation();
+  on:keydown={(event) => {
+    if (event.key === "Escape") {
+      event.stopPropagation();
     }
   }}
   on:click|preventDefault

--- a/src/ListBox/ListBoxSelection.svelte
+++ b/src/ListBox/ListBoxSelection.svelte
@@ -79,14 +79,14 @@
       role="button"
       tabindex="-1"
       class:bx--tag__close-icon={true}
-      on:click|preventDefault|stopPropagation={(e) => {
+      on:click|preventDefault|stopPropagation={(event) => {
         if (!disabled && !readonly) {
-          dispatch("clear", e);
+          dispatch("clear", event);
         }
       }}
-      on:keydown|stopPropagation={(e) => {
-        if (!disabled && !readonly && (e.key === "Enter" || e.key === " ")) {
-          dispatch("clear", e);
+      on:keydown|stopPropagation={(event) => {
+        if (!disabled && !readonly && (event.key === "Enter" || event.key === " ")) {
+          dispatch("clear", event);
         }
       }}
       {disabled}
@@ -110,14 +110,14 @@
     class:bx--list-box__selection--multi={selectionCount}
     aria-disabled={readonly || undefined}
     {...$$restProps}
-    on:click|preventDefault|stopPropagation={(e) => {
+    on:click|preventDefault|stopPropagation={(event) => {
       if (!disabled && !readonly) {
-        dispatch("clear", e);
+        dispatch("clear", event);
       }
     }}
-    on:keydown|stopPropagation={(e) => {
-      if (!disabled && !readonly && (e.key === "Enter" || e.key === " ")) {
-        dispatch("clear", e);
+    on:keydown|stopPropagation={(event) => {
+      if (!disabled && !readonly && (event.key === "Enter" || event.key === " ")) {
+        dispatch("clear", event);
       }
     }}
   >

--- a/src/Modal/Modal.svelte
+++ b/src/Modal/Modal.svelte
@@ -199,11 +199,11 @@
   inert={open ? undefined : true}
   {...$$restProps}
   on:keydown
-  on:keydown={(e) => {
+  on:keydown={(event) => {
     if (open) {
-      if (e.key === "Escape") {
+      if (event.key === "Escape") {
         close("escape-key");
-      } else if (e.key === "Tab") {
+      } else if (event.key === "Tab") {
         // trap focus
 
         // taken from github.com/carbon-design-system/carbon/packages/react/src/internal/keyboard/navigation.js
@@ -237,7 +237,7 @@
         });
 
         if (tabbable.length === 0) {
-          e.preventDefault();
+          event.preventDefault();
           return;
         }
 
@@ -246,20 +246,20 @@
           // Active element not in tabbable list, find closest tabbable element
           // For forward Tab, start from beginning (-1 + 1 = 0)
           // For Shift+Tab, start from end (length + -1 = length - 1)
-          index = e.shiftKey ? tabbable.length : -1;
+          index = event.shiftKey ? tabbable.length : -1;
         }
 
-        index += e.shiftKey ? -1 : 1;
+        index += event.shiftKey ? -1 : 1;
         index = (index + tabbable.length) % tabbable.length;
 
         tabbable[index].focus();
-        e.preventDefault();
+        event.preventDefault();
       } else if (
         shouldSubmitOnEnter &&
-        e.key === "Enter" &&
+        event.key === "Enter" &&
         !primaryButtonDisabled
       ) {
-        const target = e.target;
+        const target = event.target;
         const tag = target?.tagName;
         if (tag === "TEXTAREA" || tag === "SELECT" || target?.isContentEditable) {
           return;
@@ -283,8 +283,8 @@
   on:mouseover
   on:mouseenter
   on:mouseleave
-  on:transitionend={(e) => {
-    if (e.propertyName === "transform") {
+  on:transitionend={(event) => {
+    if (event.propertyName === "transform") {
       dispatch("transitionend", { open });
       if (!open && previouslyFocusedElement?.isConnected) {
         previouslyFocusedElement.focus();

--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -317,9 +317,8 @@
     if (!disabled) highlightedIndex = index;
   }
 
-  /**
+    /**
    * Handle selection of an item, including isSelectAll logic.
-   * @param {Item} item
    */
   function selectItem(item) {
     if (item.disabled) return;
@@ -597,16 +596,16 @@
 </script>
 
 <svelte:window
-  on:click={({ target }) => {
-    if (open && multiSelectRef && !multiSelectRef.contains(target)) {
-      if (effectivePortalMenu && listRef?.contains(target)) return;
+  on:click={(event) => {
+    if (open && multiSelectRef && !multiSelectRef.contains(event.target)) {
+      if (effectivePortalMenu && listRef?.contains(event.target)) return;
       open = false;
     }
   }}
-  on:focusin={({ target }) => {
+  on:focusin={(event) => {
     if (!open) return;
-    if (multiSelectRef?.contains(target)) return;
-    if (effectivePortalMenu && listRef?.contains(target)) return;
+    if (multiSelectRef?.contains(event.target)) return;
+    if (effectivePortalMenu && listRef?.contains(event.target)) return;
     open = false;
   }}
 />
@@ -693,34 +692,34 @@
             open = true;
           }}
           on:keydown
-          on:keydown|stopPropagation={({ key }) => {
+          on:keydown|stopPropagation={(event) => {
             if (readonly) return;
-            if (key === "Enter") {
+            if (event.key === "Enter") {
               if (highlightedId) {
                 const highlightedItem = sortedItems.find(
                   (item) => item.id === highlightedId,
                 );
                 if (highlightedItem) selectItem(highlightedItem);
               }
-            } else if (key === "Tab") {
+            } else if (event.key === "Tab") {
               open = false;
-            } else if (key === "ArrowDown") {
+            } else if (event.key === "ArrowDown") {
               if (!open) open = true;
               change(1);
-            } else if (key === "ArrowUp") {
+            } else if (event.key === "ArrowUp") {
               if (!open) open = true;
               change(-1);
-            } else if (key === "Escape") {
+            } else if (event.key === "Escape") {
               open = false;
-            } else if (key === " ") {
+            } else if (event.key === " ") {
               if (!open) open = true;
-            } else if (key === "Backspace" && value === "") {
+            } else if (event.key === "Backspace" && value === "") {
               selectedIds = [];
               sortedItems = sortedItems.map((item) => ({
                 ...item,
                 checked: false,
               }));
-            } else if (key === "Delete") {
+            } else if (event.key === "Delete") {
               if (open) {
                 value = "";
               } else {
@@ -761,9 +760,9 @@
         {/if}
         <ListBoxMenuIcon
           aria-hidden={readonly || undefined}
-          on:click={(e) => {
+          on:click={(event) => {
             if (disabled || readonly) return;
-            e.stopPropagation();
+            event.stopPropagation();
             open = !open;
           }}
           {translateWithId}
@@ -782,35 +781,38 @@
           if (disabled || readonly) return;
           open = !open;
         }}
-        on:keydown={(e) => {
-          const key = e.key;
-          if (key === " " || key === "ArrowUp" || key === "ArrowDown") {
-            e.preventDefault();
+        on:keydown={(event) => {
+          if (
+            event.key === " " ||
+            event.key === "ArrowUp" ||
+            event.key === "ArrowDown"
+          ) {
+            event.preventDefault();
           }
           if (readonly) return;
-          if (key === " ") {
+          if (event.key === " ") {
             open = !open;
-          } else if (key === "Tab") {
+          } else if (event.key === "Tab") {
             open = false;
-          } else if (key === "ArrowDown") {
+          } else if (event.key === "ArrowDown") {
             if (!open) open = true;
             change(1);
-          } else if (key === "ArrowUp") {
+          } else if (event.key === "ArrowUp") {
             if (!open) open = true;
             change(-1);
-          } else if (key === "Enter") {
+          } else if (event.key === "Enter") {
             if (highlightedIndex > -1) {
               const item = (filterable ? filteredItems : sortedItems)[
                 highlightedIndex
               ];
               if (item) selectItem(item);
             }
-          } else if (key === "Escape") {
+          } else if (event.key === "Escape") {
             open = false;
           }
         }}
-        on:blur={(e) => {
-          dispatch("blur", e);
+        on:blur={(event) => {
+          dispatch("blur", event);
         }}
         {id}
         {disabled}
@@ -852,8 +854,8 @@
         {direction}
         aria-multiselectable="true"
         on:scroll
-        on:scroll={(e) => {
-          listScrollTop = e.target.scrollTop;
+        on:scroll={(event) => {
+          listScrollTop = event.target.scrollTop;
         }}
         bind:ref={listRef}
         style={effectivePortalMenu
@@ -882,9 +884,9 @@
                   active={item.isSelectAll ? false : item.checked}
                   highlighted={highlightedIndex === actualIndex}
                   disabled={item.disabled}
-                  on:click={(e) => {
+                  on:click={(event) => {
                     if (item.disabled) {
-                      e.stopPropagation();
+                      event.stopPropagation();
                       return;
                     }
                     selectItem(item);
@@ -934,9 +936,9 @@
               active={item.isSelectAll ? false : item.checked}
               highlighted={highlightedIndex === i}
               disabled={item.disabled}
-              on:click={(e) => {
+              on:click={(event) => {
                 if (item.disabled) {
-                  e.stopPropagation();
+                  event.stopPropagation();
                   return;
                 }
                 selectItem(item);

--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -287,67 +287,72 @@
     declareRef,
   });
 
-  function change(direction) {
-    let index = highlightedIndex + direction;
-    const itemsToUse = filterable ? filteredItems : sortedItems;
-    const length = itemsToUse.length;
+  function change(step) {
+    let candidateIndex = highlightedIndex + step;
+    const navigableItems = filterable ? filteredItems : sortedItems;
+    const length = navigableItems.length;
     if (length === 0) return;
-    if (index < 0) {
-      index = length - 1;
-    } else if (index >= length) {
-      index = 0;
+    if (candidateIndex < 0) {
+      candidateIndex = length - 1;
+    } else if (candidateIndex >= length) {
+      candidateIndex = 0;
     }
 
-    let disabled = itemsToUse[index].disabled;
+    let itemDisabled = navigableItems[candidateIndex].disabled;
     let attempts = 0;
 
-    while (disabled && attempts < length) {
-      index = index + direction;
+    while (itemDisabled && attempts < length) {
+      candidateIndex = candidateIndex + step;
 
-      if (index < 0) {
-        index = length - 1;
-      } else if (index >= length) {
-        index = 0;
+      if (candidateIndex < 0) {
+        candidateIndex = length - 1;
+      } else if (candidateIndex >= length) {
+        candidateIndex = 0;
       }
 
-      disabled = itemsToUse[index].disabled;
+      itemDisabled = navigableItems[candidateIndex].disabled;
       attempts++;
     }
 
-    if (!disabled) highlightedIndex = index;
+    if (!itemDisabled) highlightedIndex = candidateIndex;
   }
 
-    /**
-   * Handle selection of an item, including isSelectAll logic.
-   */
+  /** Handle selection of an item, including isSelectAll logic. */
   function selectItem(item) {
     if (item.disabled) return;
 
     if (item.isSelectAll) {
       const target = !allSelected;
-      sortedItems = sortedItems.map((si) =>
-        si.disabled || si.checked === target ? si : { ...si, checked: target },
+      sortedItems = sortedItems.map((sortedItem) =>
+        sortedItem.disabled || sortedItem.checked === target
+          ? sortedItem
+          : { ...sortedItem, checked: target },
       );
     } else {
-      const idx = sortedItems.indexOf(item);
-      if (idx !== -1) {
-        sortedItems[idx] = { ...item, checked: !item.checked };
+      const itemIndex = sortedItems.indexOf(item);
+      if (itemIndex !== -1) {
+        sortedItems[itemIndex] = { ...item, checked: !item.checked };
       }
 
       if (hasSelectAll) {
         const newSelectableChecked = sortedItems.filter(
-          (si) => !si.disabled && !si.isSelectAll && si.checked,
+          (sortedItem) =>
+            !sortedItem.disabled &&
+            !sortedItem.isSelectAll &&
+            sortedItem.checked,
         ).length;
         const newAllSelected =
           selectableItems.length > 0 &&
           newSelectableChecked === selectableItems.length;
-        const selectAllIdx = sortedItems.findIndex((si) => si.isSelectAll);
+        const selectAllIndex = sortedItems.findIndex(
+          (sortedItem) => sortedItem.isSelectAll,
+        );
         if (
-          selectAllIdx !== -1 &&
-          sortedItems[selectAllIdx].checked !== newAllSelected
+          selectAllIndex !== -1 &&
+          sortedItems[selectAllIndex].checked !== newAllSelected
         ) {
-          sortedItems[selectAllIdx] = {
-            ...sortedItems[selectAllIdx],
+          sortedItems[selectAllIndex] = {
+            ...sortedItems[selectAllIndex],
             checked: newAllSelected,
           };
         }
@@ -358,8 +363,8 @@
 
     if (selectionFeedback === "top") {
       selectedIds = sortedItems
-        .filter((si) => si.checked && !si.isSelectAll)
-        .map((si) => si.id);
+        .filter((sortedItem) => sortedItem.checked && !sortedItem.isSelectAll)
+        .map((sortedItem) => sortedItem.id);
       internalSelectedIdsRef = selectedIds;
       sortedItems = sort();
     }
@@ -375,7 +380,7 @@
       prevChecked = checked;
       selectedIds = checked
         .filter((item) => !item.isSelectAll)
-        .map(({ id }) => id);
+        .map((item) => item.id);
       internalSelectedIdsRef = selectedIds;
       if (!isInitialRender) {
         dispatch("select", {
@@ -523,8 +528,8 @@
     sortedItems = sort();
   }
   $: hasSelectAll = items.some((item) => item.isSelectAll);
-  $: checked = sortedItems.filter(({ checked }) => checked);
-  $: unchecked = sortedItems.filter(({ checked }) => !checked);
+  $: checked = sortedItems.filter((item) => item.checked);
+  $: unchecked = sortedItems.filter((item) => !item.checked);
   $: selectableItems = sortedItems.filter(
     (item) => !item.disabled && !item.isSelectAll,
   );
@@ -869,8 +874,8 @@
         {#if virtualData?.isVirtualized}
           <div style="height: {virtualData.totalHeight}px; position: relative;">
             <div style="transform: translateY({virtualData.offsetY}px);">
-              {#each itemsToRender as item, i (item.id)}
-                {@const actualIndex = virtualData.startIndex + i}
+              {#each itemsToRender as item, index (item.id)}
+                {@const actualIndex = virtualData.startIndex + index}
                 <ListBoxMenuItem
                   id={item.id}
                   role="option"
@@ -922,7 +927,7 @@
             </div>
           </div>
         {:else}
-          {#each itemsToRender as item, i (item.id)}
+          {#each itemsToRender as item, index (item.id)}
             <ListBoxMenuItem
               id={item.id}
               role="option"
@@ -934,7 +939,7 @@
                   : allSelected
                 : item.checked}
               active={item.isSelectAll ? false : item.checked}
-              highlighted={highlightedIndex === i}
+              highlighted={highlightedIndex === index}
               disabled={item.disabled}
               on:click={(event) => {
                 if (item.disabled) {
@@ -950,7 +955,7 @@
               }}
               on:mouseenter={() => {
                 if (item.disabled) return;
-                highlightedIndex = i;
+                highlightedIndex = index;
               }}
             >
               <Checkbox
@@ -965,7 +970,7 @@
                   : false}
                 disabled={item.disabled}
               >
-                <slot slot="labelChildren" {item} index={i}>
+                <slot slot="labelChildren" {item} {index}>
                   {itemToString(item)}
                 </slot>
               </Checkbox>

--- a/src/NumberInput/NumberInput.svelte
+++ b/src/NumberInput/NumberInput.svelte
@@ -365,34 +365,38 @@
     return min === undefined ? 0 : min;
   }
 
-  function onInput({ target }) {
+  function onInput(event) {
     if (useTextMode) {
       userInputActive = true;
-      inputValue = target.value;
+      inputValue = event.target.value;
       const parsed = locale
-        ? parseLocaleValue(target.value)
-        : parse(target.value);
+        ? parseLocaleValue(event.target.value)
+        : parse(event.target.value);
       // Preserve last valid value when input is invalid (e.g., "1.5." with two decimals).
       // This provides better UX by letting users see and correct typos without losing data.
-      if (parsed !== null || target.value === "" || target.value === "-") {
+      if (
+        parsed !== null ||
+        event.target.value === "" ||
+        event.target.value === "-"
+      ) {
         value = parsed;
       }
     } else {
-      value = parse(target.value);
+      value = parse(event.target.value);
     }
 
     dispatch("input", value);
   }
 
-  function onChange({ target }) {
+  function onChange(event) {
     userInputActive = false;
     let parsedValue = locale
-      ? parseLocaleValue(target.value)
-      : parse(target.value, useTextMode);
+      ? parseLocaleValue(event.target.value)
+      : parse(event.target.value, useTextMode);
 
     // If allowEmpty is false and value would be null, use default value
     // This prevents the input from staying empty when allowEmpty is false
-    if (!allowEmpty && parsedValue === null && target.value === "") {
+    if (!allowEmpty && parsedValue === null && event.target.value === "") {
       parsedValue = getDefaultValue();
       // Update the input to show the default value
       if (useTextMode) {
@@ -407,7 +411,7 @@
     } else if (
       useTextMode &&
       parsedValue === null &&
-      target.value !== "" &&
+      event.target.value !== "" &&
       value !== null
     ) {
       // In text mode, normalize invalid input (e.g., "1.5.") back to
@@ -432,12 +436,12 @@
     }
   }
 
-  function handleBlur(e) {
-    dispatch("blur", { event: e, value });
+  function handleBlur(event) {
+    dispatch("blur", { event: event, value });
   }
 
-  function handleStepperBlur(e, direction) {
-    dispatch("blur:stepper", { event: e, value, direction });
+  function handleStepperBlur(event, direction) {
+    dispatch("blur:stepper", { event: event, value, direction });
   }
 </script>
 
@@ -510,8 +514,8 @@
           on:focus
           on:blur={handleBlur}
           on:paste
-          on:wheel|nonpassive={(e) => {
-            if (disableWheel) e.preventDefault();
+          on:wheel|nonpassive={(event) => {
+            if (disableWheel) event.preventDefault();
           }}
         >
       {:else}
@@ -546,8 +550,8 @@
           on:focus
           on:blur={handleBlur}
           on:paste
-          on:wheel|nonpassive={(e) => {
-            if (disableWheel) e.preventDefault();
+          on:wheel|nonpassive={(event) => {
+            if (disableWheel) event.preventDefault();
           }}
         >
       {/if}
@@ -576,7 +580,7 @@
               updateValue(false);
               dispatch("click:stepper", { value, direction: "down" });
             }}
-            on:blur={(e) => handleStepperBlur(e, "down")}
+            on:blur={(event) => handleStepperBlur(event, "down")}
             {disabled}
           >
             <Subtract class="down-icon" />
@@ -593,7 +597,7 @@
               updateValue(true);
               dispatch("click:stepper", { value, direction: "up" });
             }}
-            on:blur={(e) => handleStepperBlur(e, "up")}
+            on:blur={(event) => handleStepperBlur(event, "up")}
             {disabled}
           >
             <Add class="up-icon" />

--- a/src/NumberInput/NumberInput.svelte
+++ b/src/NumberInput/NumberInput.svelte
@@ -437,11 +437,11 @@
   }
 
   function handleBlur(event) {
-    dispatch("blur", { event: event, value });
+    dispatch("blur", { event, value });
   }
 
   function handleStepperBlur(event, direction) {
-    dispatch("blur:stepper", { event: event, value, direction });
+    dispatch("blur:stepper", { event, value, direction });
   }
 </script>
 

--- a/src/OverflowMenu/OverflowMenu.svelte
+++ b/src/OverflowMenu/OverflowMenu.svelte
@@ -258,10 +258,10 @@
 </script>
 
 <svelte:window
-  on:click={({ target }) => {
-    if (buttonRef?.contains(target)) return;
-    if (effectivePortalMenu && menuRef?.contains(target)) return;
-    if (menuRef && !menuRef.contains(target)) {
+  on:click={(event) => {
+    if (buttonRef?.contains(event.target)) return;
+    if (effectivePortalMenu && menuRef?.contains(event.target)) return;
+    if (menuRef && !menuRef.contains(event.target)) {
       const shouldContinue = dispatch("close", null, { cancelable: true });
       if (shouldContinue) {
         open = false;
@@ -287,8 +287,8 @@
   class:bx--overflow-menu--xl={size === "xl"}
   {...$$restProps}
   on:click
-  on:click={({ target }) => {
-    if (!menuRef?.contains(target)) {
+  on:click={(event) => {
+    if (!menuRef?.contains(event.target)) {
       open = !open;
       if (!open) {
         const shouldContinue = dispatch("close", null, { cancelable: true });
@@ -302,18 +302,18 @@
   on:mouseenter
   on:mouseleave
   on:keydown
-  on:keydown={(e) => {
+  on:keydown={(event) => {
     if (open) {
-      if (["ArrowDown", "ArrowLeft", "ArrowRight", "ArrowUp"].includes(e.key)) {
-        e.preventDefault();
-      } else if (e.key === "Home") {
-        e.preventDefault();
+      if (["ArrowDown", "ArrowLeft", "ArrowRight", "ArrowUp"].includes(event.key)) {
+        event.preventDefault();
+      } else if (event.key === "Home") {
+        event.preventDefault();
         first();
-      } else if (e.key === "End") {
-        e.preventDefault();
+      } else if (event.key === "End") {
+        event.preventDefault();
         last();
-      } else if (e.key === "Escape") {
-        e.stopPropagation();
+      } else if (event.key === "Escape") {
+        event.stopPropagation();
         const shouldContinue = dispatch("close", null, { cancelable: true });
         if (shouldContinue) {
           open = false;
@@ -379,17 +379,17 @@
       class:bx--breadcrumb-menu-options={!!ctxBreadcrumbItem}
       class={menuOptionsClass}
       style="position: relative; top: auto; left: auto; --overflow-menu-options-after-width: {overflowMenuOptionsAfterWidth}"
-      on:keydown={(e) => {
-        if (["ArrowDown", "ArrowLeft", "ArrowRight", "ArrowUp"].includes(e.key)) {
-          e.preventDefault();
-        } else if (e.key === "Home") {
-          e.preventDefault();
+      on:keydown={(event) => {
+        if (["ArrowDown", "ArrowLeft", "ArrowRight", "ArrowUp"].includes(event.key)) {
+          event.preventDefault();
+        } else if (event.key === "Home") {
+          event.preventDefault();
           first();
-        } else if (e.key === "End") {
-          e.preventDefault();
+        } else if (event.key === "End") {
+          event.preventDefault();
           last();
-        } else if (e.key === "Escape") {
-          e.stopPropagation();
+        } else if (event.key === "Escape") {
+          event.stopPropagation();
           const shouldContinue = dispatch("close", null, { cancelable: true });
           if (shouldContinue) {
             open = false;

--- a/src/OverflowMenu/OverflowMenuItem.svelte
+++ b/src/OverflowMenu/OverflowMenuItem.svelte
@@ -99,15 +99,15 @@
     title: requireTitle ? ($$slots.default ? undefined : text) : undefined,
   };
 
-  function handleClick(e) {
-    e.stopPropagation();
+  function handleClick(event) {
+    event.stopPropagation();
 
     if (disabled) {
-      e.preventDefault();
+      event.preventDefault();
       return;
     }
 
-    const shouldContinue = dispatch("click", e, { cancelable: true });
+    const shouldContinue = dispatch("click", event, { cancelable: true });
 
     // Only update (close menu) if preventDefault was not called.
     if (shouldContinue) {
@@ -133,16 +133,16 @@
       {...buttonProps}
       on:click={handleClick}
       on:keydown
-      on:keydown={(e) => {
-        if (e.key === "ArrowDown") {
+      on:keydown={(event) => {
+        if (event.key === "ArrowDown") {
           change(1);
-        } else if (e.key === "ArrowUp") {
+        } else if (event.key === "ArrowUp") {
           change(-1);
-        } else if (e.key === "Home") {
-          e.preventDefault();
+        } else if (event.key === "Home") {
+          event.preventDefault();
           first();
-        } else if (e.key === "End") {
-          e.preventDefault();
+        } else if (event.key === "End") {
+          event.preventDefault();
           last();
         }
       }}
@@ -158,16 +158,16 @@
       {...buttonProps}
       on:click={handleClick}
       on:keydown
-      on:keydown={(e) => {
-        if (e.key === "ArrowDown") {
+      on:keydown={(event) => {
+        if (event.key === "ArrowDown") {
           change(1);
-        } else if (e.key === "ArrowUp") {
+        } else if (event.key === "ArrowUp") {
           change(-1);
-        } else if (e.key === "Home") {
-          e.preventDefault();
+        } else if (event.key === "Home") {
+          event.preventDefault();
           first();
-        } else if (e.key === "End") {
-          e.preventDefault();
+        } else if (event.key === "End") {
+          event.preventDefault();
           last();
         }
       }}

--- a/src/Pagination/Pagination.svelte
+++ b/src/Pagination/Pagination.svelte
@@ -186,7 +186,7 @@
         }}
         bind:selected={pageSize}
       >
-        {#each effectivePageSizes as size, i (size)}
+        {#each effectivePageSizes as size, index (size)}
           <SelectItem value={size} text={size.toString()} />
         {/each}
       </Select>
@@ -216,7 +216,7 @@
         }}
         bind:selected={page}
       >
-        {#each selectItems as size, i (size)}
+        {#each selectItems as size, index (size)}
           <SelectItem value={size} text={size.toString()} />
         {/each}
       </Select>

--- a/src/Pagination/Pagination.svelte
+++ b/src/Pagination/Pagination.svelte
@@ -127,9 +127,6 @@
    * Returns a subset of page numbers centered around the current page to prevent
    * performance issues with large datasets. Creates a capped window of pages
    * instead of potentially thousands, improving render speed and memory usage.
-   * @param {number} currentPage - The current page number.
-   * @param {number} totalPages - Total number of pages.
-   * @param {number} window - How many pages to show before/after current page.
    * @returns {number[]} Array of page numbers to display.
    */
   function getWindowedPages(currentPage, totalPages, window) {
@@ -141,8 +138,6 @@
   /**
    * Filters page sizes to remove redundant options based on total items.
    * Keeps all sizes up to and including the first one >= totalItems.
-   * @param {ReadonlyArray<number>} sizes - Available page sizes.
-   * @param {number} total - Total number of items.
    * @returns {number[]} Filtered array of page sizes.
    */
   function getFilteredPageSizes(sizes, total) {

--- a/src/PaginationNav/PaginationNav.svelte
+++ b/src/PaginationNav/PaginationNav.svelte
@@ -122,8 +122,8 @@
     <PaginationOverflow
       fromIndex={startOffset}
       count={front}
-      on:select={({ detail }) => {
-        page = detail.index;
+      on:select={(event) => {
+        page = event.detail.index;
         dispatch("change", { page });
       }}
     />
@@ -142,8 +142,8 @@
     <PaginationOverflow
       fromIndex={total - back - 1}
       count={back}
-      on:select={({ detail }) => {
-        page = detail.index;
+      on:select={(event) => {
+        page = event.detail.index;
         dispatch("change", { page });
       }}
     />

--- a/src/PaginationNav/PaginationOverflow.svelte
+++ b/src/PaginationNav/PaginationOverflow.svelte
@@ -27,14 +27,17 @@
         {value}
         class:bx--pagination-nav__page={true}
         class:bx--pagination-nav__page--select={true}
-        on:change={({ target }) => {
+        on:change={(event) => {
           value = "";
-          dispatch("select", { index: Number(target.value) });
+          dispatch("select", { index: Number(event.target.value) });
         }}
       >
         <option value="" hidden></option>
         {#each Array.from({ length: count }, (_, i) => i) as i}
-          <option value={fromIndex + i + 1} data-page={fromIndex + i + 1}>
+          <option
+            value={fromIndex + i + 1}
+            data-page={fromIndex + i + 1}
+          >
             {fromIndex + i + 1}
           </option>
         {/each}

--- a/src/PaginationNav/PaginationOverflow.svelte
+++ b/src/PaginationNav/PaginationOverflow.svelte
@@ -33,12 +33,12 @@
         }}
       >
         <option value="" hidden></option>
-        {#each Array.from({ length: count }, (_, i) => i) as i}
+        {#each Array.from({ length: count }, (_, index) => index) as pageOffset}
           <option
-            value={fromIndex + i + 1}
-            data-page={fromIndex + i + 1}
+            value={fromIndex + pageOffset + 1}
+            data-page={fromIndex + pageOffset + 1}
           >
-            {fromIndex + i + 1}
+            {fromIndex + pageOffset + 1}
           </option>
         {/each}
       </select>

--- a/src/Popover/Popover.svelte
+++ b/src/Popover/Popover.svelte
@@ -39,10 +39,10 @@
 </script>
 
 <svelte:window
-  on:click={(e) => {
+  on:click={(event) => {
     if (!open) return;
-    if (!ref.contains(e.target)) {
-      dispatch("click:outside", { target: e.target });
+    if (!ref.contains(event.target)) {
+      dispatch("click:outside", { target: event.target });
       if (closeOnOutsideClick) open = false;
     }
   }}

--- a/src/Portal/FloatingPortal.svelte
+++ b/src/Portal/FloatingPortal.svelte
@@ -114,7 +114,6 @@
   /**
    * Walk up from the anchor element and collect every
    * scrollable ancestor so we can listen for their scroll events.
-   * @param {HTMLElement} node
    * @returns {Array<HTMLElement | Document>}
    */
   function getScrollableAncestors(node) {

--- a/src/ProgressIndicator/ProgressIndicatorSkeleton.svelte
+++ b/src/ProgressIndicator/ProgressIndicatorSkeleton.svelte
@@ -22,7 +22,7 @@
   on:mouseenter
   on:mouseleave
 >
-  {#each Array.from({ length: count }, (_, i) => i) as item, i (item)}
+  {#each Array.from({ length: count }, (_, i) => i) as item, index (item)}
     <li
       class:bx--progress-step={true}
       class:bx--progress-step--incomplete={true}

--- a/src/RadioButton/RadioButton.svelte
+++ b/src/RadioButton/RadioButton.svelte
@@ -94,7 +94,6 @@
 
   /**
    * Initialize registry for standalone mode with name.
-   * @param {string | undefined} radioName
    */
   function initRegistry(radioName) {
     // Clean up previous registration if any
@@ -171,12 +170,12 @@
     class:bx--radio-button={true}
     on:focus
     on:blur
-    on:click={(e) => {
-      if ($readonly) e.preventDefault();
+    on:click={(event) => {
+      if ($readonly) event.preventDefault();
     }}
-    on:change={(e) => {
+    on:change={(event) => {
       if ($readonly) {
-        e.stopImmediatePropagation();
+        event.stopImmediatePropagation();
         return;
       }
       if (update) {
@@ -184,11 +183,11 @@
         update(value);
       } else if (name && registryStore) {
         // Standalone with name - update local checked and notify siblings via registry
-        checked = e.currentTarget.checked;
+        checked = event.currentTarget.checked;
         updateGroupSelection(name, instanceKey);
       } else {
         // Standalone without name - just update local checked
-        checked = e.currentTarget.checked;
+        checked = event.currentTarget.checked;
       }
     }}
     on:change

--- a/src/Search/Search.svelte
+++ b/src/Search/Search.svelte
@@ -155,8 +155,8 @@
         }
       }}
       on:keydown
-      on:keydown={({ key }) => {
-        if (key === "Escape") {
+      on:keydown={(event) => {
+        if (event.key === "Escape") {
           value = "";
           dispatch("clear");
         }

--- a/src/Select/Select.svelte
+++ b/src/Select/Select.svelte
@@ -112,8 +112,8 @@
     setDefaultValue,
   });
 
-  const handleChange = ({ target }) => {
-    let value = target.value;
+  const handleChange = (event) => {
+    let value = event.target.value;
 
     if ($itemTypesByValue[value] === "number") {
       value = Number(value);
@@ -125,17 +125,17 @@
   const selectReadOnlyKeys = ["ArrowDown", "ArrowUp", " "];
 
   /** @type {(e: MouseEvent) => void} */
-  const onMouseDown = (e) => {
+  const onMouseDown = (event) => {
     if (readonly) {
-      e.preventDefault();
-      e.currentTarget.focus();
+      event.preventDefault();
+      event.currentTarget.focus();
     }
   };
 
   /** @type {(e: KeyboardEvent) => void} */
-  const onKeyDown = (e) => {
-    if (readonly && selectReadOnlyKeys.includes(e.key)) {
-      e.preventDefault();
+  const onKeyDown = (event) => {
+    if (readonly && selectReadOnlyKeys.includes(event.key)) {
+      event.preventDefault();
     }
   };
 

--- a/src/Slider/RangeSlider.svelte
+++ b/src/Slider/RangeSlider.svelte
@@ -131,16 +131,16 @@
   let currentEvent = null;
 
   /** @type {(e: PointerLikeEvent) => number | null} */
-  function getClientX(e) {
-    if ("touches" in e) return e.touches[0]?.clientX ?? null;
-    return e.clientX;
+  function getClientX(event) {
+    if ("touches" in event) return event.touches[0]?.clientX ?? null;
+    return event.clientX;
   }
 
   /** @type {(e: PointerLikeEvent) => ActiveHandle} */
-  function pickHandle(e) {
-    if (e.target === lowerThumbRef) return "lower";
-    if (e.target === upperThumbRef) return "upper";
-    const clientX = getClientX(e);
+  function pickHandle(event) {
+    if (event.target === lowerThumbRef) return "lower";
+    if (event.target === upperThumbRef) return "upper";
+    const clientX = getClientX(event);
     if (clientX == null) return activeHandle;
     const lowerRect = lowerThumbRef?.getBoundingClientRect();
     const upperRect = upperThumbRef?.getBoundingClientRect();
@@ -154,15 +154,15 @@
   }
 
   /** @type {(e: MouseEvent | TouchEvent) => void} */
-  function startInteraction(e) {
+  function startInteraction(event) {
     if (disabled || readonly) return;
-    activeHandle = pickHandle(e);
+    activeHandle = pickHandle(event);
     if (activeHandle === "lower") {
       lowerThumbRef?.focus({ preventScroll: true });
     } else {
       upperThumbRef?.focus({ preventScroll: true });
     }
-    currentEvent = e;
+    currentEvent = event;
     holding = true;
     dragging = true;
   }
@@ -175,18 +175,18 @@
   }
 
   /** @type {(e: PointerLikeEvent) => void} */
-  function move(e) {
+  function move(event) {
     if (holding) {
-      currentEvent = e;
+      currentEvent = event;
       dragging = true;
     }
   }
 
   /** @type {(e: PointerLikeEvent | null) => void} */
-  function calcValue(e) {
-    if (disabled || readonly || !e || !trackRef) return;
+  function calcValue(event) {
+    if (disabled || readonly || !event || !trackRef) return;
 
-    const offsetX = getClientX(e);
+    const offsetX = getClientX(event);
     if (offsetX == null) return;
     const { left, width } = trackRef.getBoundingClientRect();
     let nextValue =
@@ -210,7 +210,7 @@
   }
 
   /** @type {(e: KeyboardEvent) => void} */
-  function onKeyDown(e) {
+  function onKeyDown(event) {
     if (disabled || readonly) return;
     /** @type {Record<string, number>} */
     const keys = {
@@ -219,10 +219,11 @@
       ArrowRight: 1,
       ArrowUp: 1,
     };
-    const dir = keys[e.key];
+    const dir = keys[event.key];
     if (!dir) return;
     const range = max - min;
-    const delta = step * (e.shiftKey ? range / step / stepMultiplier : 1) * dir;
+    const delta =
+      step * (event.shiftKey ? range / step / stepMultiplier : 1) * dir;
     if (activeHandle === "lower") {
       let next = Math.round((value + delta) / step) * step;
       if (next < min) next = min;

--- a/src/Slider/Slider.svelte
+++ b/src/Slider/Slider.svelte
@@ -102,9 +102,9 @@
   let holding = false;
   let currentEvent = null;
 
-  function startInteraction(e) {
+  function startInteraction(event) {
     if (disabled || readonly) return;
-    currentEvent = e;
+    currentEvent = event;
     holding = true;
     dragging = true;
   }
@@ -115,17 +115,17 @@
     currentEvent = null;
   }
 
-  function move(e) {
+  function move(event) {
     if (holding) {
-      currentEvent = e;
+      currentEvent = event;
       dragging = true;
     }
   }
 
-  function calcValue(e) {
-    if (disabled || readonly || !e) return;
+  function calcValue(event) {
+    if (disabled || readonly || !event) return;
 
-    const offsetX = e.touches ? e.touches[0].clientX : e.clientX;
+    const offsetX = event.touches ? event.touches[0].clientX : event.clientX;
     const { left, width } = trackRef.getBoundingClientRect();
     let nextValue =
       min +
@@ -226,7 +226,7 @@
             : undefined}
         aria-invalid={showInvalid || undefined}
         {id}
-        on:keydown={({ shiftKey, key }) => {
+        on:keydown={(event) => {
           if (disabled || readonly) return;
           const keys = {
             ArrowDown: -1,
@@ -234,9 +234,11 @@
             ArrowRight: 1,
             ArrowUp: 1,
           };
-          if (keys[key]) {
+          if (keys[event.key]) {
             const delta =
-              step * (shiftKey ? range / step / stepMultiplier : 1) * keys[key];
+              step *
+              (event.shiftKey ? range / step / stepMultiplier : 1) *
+              keys[event.key];
             value = Math.round((value + delta) / step) * step;
             dispatch("input", value);
           }
@@ -275,9 +277,9 @@
         {min}
         {max}
         {step}
-        on:change={({ target }) => {
+        on:change={(event) => {
           if (!readonly) {
-            value = Number(target.value);
+            value = Number(event.target.value);
           }
         }}
         data-invalid={showInvalid || null}

--- a/src/StructuredList/StructuredListSkeleton.svelte
+++ b/src/StructuredList/StructuredListSkeleton.svelte
@@ -30,7 +30,7 @@
     </div>
   </div>
   <div class:bx--structured-list-tbody={true}>
-    {#each Array.from({ length: rows }, (_, i) => i) as row, i (row)}
+    {#each Array.from({ length: rows }, (_, i) => i) as row, index (row)}
       <div class:bx--structured-list-row={true}>
         {#each cols as col (col)}
           <div class:bx--structured-list-td={true}></div>

--- a/src/Tabs/Tab.svelte
+++ b/src/Tabs/Tab.svelte
@@ -96,13 +96,13 @@
   on:mouseover
   on:mouseenter
   on:mouseleave
-  on:keydown={({ key }) => {
+  on:keydown={(event) => {
     if (!disabled) {
-      if (key === "ArrowRight") {
+      if (event.key === "ArrowRight") {
         change(1);
-      } else if (key === "ArrowLeft") {
+      } else if (event.key === "ArrowLeft") {
         change(-1);
-      } else if (key === " " || key === "Enter") {
+      } else if (event.key === " " || event.key === "Enter") {
         update(id);
       }
     }

--- a/src/TextInput/PasswordInput.svelte
+++ b/src/TextInput/PasswordInput.svelte
@@ -212,8 +212,8 @@
         {...$$restProps}
         on:change
         on:input
-        on:input={({ target }) => {
-          value = target.value;
+        on:input={(event) => {
+          value = event.target.value;
         }}
         on:keydown
         on:keyup

--- a/src/TextInput/TextInput.svelte
+++ b/src/TextInput/TextInput.svelte
@@ -87,14 +87,14 @@
   }
 
   /** @type {(e: Event) => void} */
-  const onInput = (e) => {
-    value = parse(e.target.value);
+  const onInput = (event) => {
+    value = parse(event.target.value);
     dispatch("input", value);
   };
 
   /** @type {(e: Event) => void} */
-  const onChange = (e) => {
-    dispatch("change", parse(e.target.value));
+  const onChange = (event) => {
+    dispatch("change", parse(event.target.value));
   };
 
   const isFluid = !!ctx && ctx.isFluid;

--- a/src/Theme/Theme.svelte
+++ b/src/Theme/Theme.svelte
@@ -140,8 +140,8 @@
   <Toggle
     {...toggleProps}
     toggled={theme === toggleThemes[1]}
-    on:toggle={({ detail }) => {
-      theme = detail.toggled ? toggleThemes[1] : toggleThemes[0];
+    on:toggle={(event) => {
+      theme = event.detail.toggled ? toggleThemes[1] : toggleThemes[0];
     }}
   />
 {:else if render === "select"}
@@ -157,8 +157,8 @@
     {...dropdownProps}
     items={dropdownThemes.map((t) => ({ id: t, text: themes[t] }))}
     selectedId={theme}
-    on:select={({ detail }) => {
-      theme = detail.selectedId;
+    on:select={(event) => {
+      theme = event.detail.selectedId;
     }}
   />
 {/if}

--- a/src/Tile/ClickableTile.svelte
+++ b/src/Tile/ClickableTile.svelte
@@ -50,9 +50,9 @@
     clicked = !clicked;
   }}
   on:keydown
-  on:keydown={({ key }) => {
+  on:keydown={(event) => {
     if (disabled) return;
-    if (key === " " || key === "Enter") {
+    if (event.key === " " || event.key === "Enter") {
       clicked = !clicked;
     }
   }}

--- a/src/Tile/RadioTile.svelte
+++ b/src/Tile/RadioTile.svelte
@@ -52,7 +52,8 @@
   $: ariaLabelledBy = $$restProps["aria-labelledby"];
   $: labelRestProps = Object.fromEntries(
     Object.entries($$restProps).filter(
-      ([key]) => key !== "aria-describedby" && propKey !== "aria-labelledby",
+      ([propKey]) =>
+        propKey !== "aria-describedby" && propKey !== "aria-labelledby",
     ),
   );
 

--- a/src/Tile/RadioTile.svelte
+++ b/src/Tile/RadioTile.svelte
@@ -52,7 +52,7 @@
   $: ariaLabelledBy = $$restProps["aria-labelledby"];
   $: labelRestProps = Object.fromEntries(
     Object.entries($$restProps).filter(
-      ([key]) => key !== "aria-describedby" && key !== "aria-labelledby",
+      ([key]) => key !== "aria-describedby" && propKey !== "aria-labelledby",
     ),
   );
 
@@ -87,10 +87,10 @@
     update(value);
   }}
   on:keydown
-  on:keydown={(e) => {
+  on:keydown={(event) => {
     if (disabled) return;
-    if (e.key === " " || e.key === "Enter") {
-      e.preventDefault();
+    if (event.key === " " || event.key === "Enter") {
+      event.preventDefault();
       update(value);
     }
   }}

--- a/src/Tile/SelectableTile.svelte
+++ b/src/Tile/SelectableTile.svelte
@@ -140,10 +140,10 @@
   on:mouseenter
   on:mouseleave
   on:keydown
-  on:keydown={(e) => {
+  on:keydown={(event) => {
     if (disabled) return;
-    if (e.key === " " || e.key === "Enter") {
-      e.preventDefault();
+    if (event.key === " " || event.key === "Enter") {
+      event.preventDefault();
       if (ref) {
         ref.click();
       }

--- a/src/TimePicker/TimePickerSelect.svelte
+++ b/src/TimePicker/TimePickerSelect.svelte
@@ -74,27 +74,27 @@
     {value}
     aria-readonly={readonly || undefined}
     class:bx--select-input={true}
-    on:change={({ target }) => {
-      selectedValue.set(target.value);
+    on:change={(event) => {
+      selectedValue.set(event.target.value);
     }}
     on:change
     on:input
     on:focus
     on:blur
-    on:mousedown={(e) => {
+    on:mousedown={(event) => {
       if (readonly) {
-        e.preventDefault();
-        e.currentTarget.focus();
+        event.preventDefault();
+        event.currentTarget.focus();
       }
     }}
-    on:keydown={(e) => {
+    on:keydown={(event) => {
       if (
         readonly &&
-        e.key !== "Tab" &&
-        e.key !== "Shift" &&
-        !(e.altKey && e.key === "ArrowDown")
+        event.key !== "Tab" &&
+        event.key !== "Shift" &&
+        !(event.altKey && event.key === "ArrowDown")
       ) {
-        e.preventDefault();
+        event.preventDefault();
       }
     }}
   >

--- a/src/Toggle/Toggle.svelte
+++ b/src/Toggle/Toggle.svelte
@@ -75,8 +75,8 @@
     checked={toggled}
     aria-disabled={readonly || undefined}
     aria-readonly={readonly || undefined}
-    on:click={(e) => {
-      if (readonly) e.preventDefault();
+    on:click={(event) => {
+      if (readonly) event.preventDefault();
     }}
     on:change={() => {
       if (readonly) return;
@@ -84,9 +84,9 @@
       dispatch("toggle", { toggled });
     }}
     on:change
-    on:keydown={(e) => {
-      if (e.key === "Enter") {
-        e.preventDefault();
+    on:keydown={(event) => {
+      if (event.key === "Enter") {
+        event.preventDefault();
         if (!readonly) ref?.click();
       }
     }}

--- a/src/Tooltip/Tooltip.svelte
+++ b/src/Tooltip/Tooltip.svelte
@@ -149,16 +149,16 @@
     setOpenDelayed(false, leaveDelayMs);
   }
 
-  function onKeydown(e) {
-    if (e.key === "Escape") {
-      e.stopPropagation();
+  function onKeydown(event) {
+    if (event.key === "Escape") {
+      event.stopPropagation();
       refIcon?.focus();
       open = false;
     }
   }
 
-  function onBlur({ relatedTarget }) {
-    if (refTooltip && !refTooltip.contains(relatedTarget)) {
+  function onBlur(event) {
+    if (refTooltip && !refTooltip.contains(event.relatedTarget)) {
       open = false;
     }
     focusByMouse = false;

--- a/src/TooltipDefinition/TooltipDefinition.svelte
+++ b/src/TooltipDefinition/TooltipDefinition.svelte
@@ -110,8 +110,8 @@
 </script>
 
 <svelte:window
-  on:keydown={({ key }) => {
-    if (key === "Escape") hide();
+  on:keydown={(event) => {
+    if (event.key === "Escape") hide();
   }}
 />
 

--- a/src/TooltipIcon/TooltipIcon.svelte
+++ b/src/TooltipIcon/TooltipIcon.svelte
@@ -193,8 +193,8 @@
 </script>
 
 <svelte:window
-  on:keydown={({ key }) => {
-    if (key === "Escape") {
+  on:keydown={(event) => {
+    if (event.key === "Escape") {
       hide();
     }
   }}

--- a/src/TreeView/TreeView.svelte
+++ b/src/TreeView/TreeView.svelte
@@ -3,8 +3,6 @@
    * Depth-first search to find a node by id; returns an array
    * of nodes from the initial node to the matching leaf.
    * @template {{ id: string | number; nodes?: TNode[] }} TNode
-   * @param {TNode | null} node
-   * @param {string | number} id
    * @returns {null | TNode[]}
    */
   function findNodeById(node, id) {
@@ -32,7 +30,6 @@
 
   /**
    * Creates a TreeWalker instance for keyboard navigation.
-   * @param {HTMLElement} root - The root element to traverse
    * @returns {TreeWalker} A TreeWalker configured to navigate tree nodes
    */
   function createTreeWalkerInstance(root) {
@@ -61,7 +58,6 @@
   /**
    * Recursively flattens a tree of nodes into a single array
    * @template {object} Node
-   * @param {ReadonlyArray<Node & { nodes?: Node[] }>} nodes
    * @returns {Array<Node>}
    */
   function traverse(nodes) {
@@ -78,8 +74,6 @@
    * Like `traverse` but only descends into expanded nodes.
    * Used for Shift+Click range selection (only visible nodes).
    * @template {object} Node
-   * @param {ReadonlyArray<Node & { id: string | number; nodes?: Node[] }>} nodes
-   * @param {Set<string | number>} expandedIdsSet
    * @returns {Array<Node>}
    */
   function traverseVisible(nodes, expandedIdsSet) {
@@ -99,8 +93,6 @@
   /**
    * Finds sibling node IDs for a given node ID within a tree structure.
    * @template {{ id: string | number; nodes?: TNode[] }} TNode
-   * @param {ReadonlyArray<TNode>} nodes - The tree nodes to search
-   * @param {string | number} id - The ID of the node to find siblings for
    * @returns {Array<string | number>} Array of sibling IDs (excluding the node itself)
    */
   function findSiblingIds(nodes, id) {
@@ -143,8 +135,6 @@
   /**
    * Finds a node by id across top-level tree roots.
    * @template {{ id: string | number; disabled?: boolean; nodes?: TNode[] }} TNode
-   * @param {ReadonlyArray<TNode>} roots
-   * @param {string | number} id
    * @returns {TNode | null}
    */
   function findForestNodeById(roots, id) {
@@ -159,8 +149,6 @@
    * IDs to select for multiselect expansion from `node` (non-disabled only).
    * Disabled nodes are omitted; subtrees under a disabled node are not traversed.
    * @template {{ id: string | number; disabled?: boolean; nodes?: TNode[] }} TNode
-   * @param {TNode} node
-   * @param {'node' | 'shallow' | 'deep'} mode
    * @returns {Array<string | number>}
    */
   function multiselectExpansionIds(node, mode) {
@@ -445,9 +433,10 @@
   let multiselectModifierActive = false;
 
   /** @param {KeyboardEvent} e */
-  function syncModifierFromKeyboard(e) {
+  function syncModifierFromKeyboard(event) {
     if (!multiselect) return;
-    multiselectModifierActive = e.ctrlKey || e.metaKey || e.shiftKey;
+    multiselectModifierActive =
+      event.ctrlKey || event.metaKey || event.shiftKey;
   }
 
   function clearMultiselectModifierKeys() {
@@ -455,15 +444,16 @@
   }
 
   /** @param {MouseEvent} e */
-  function syncModifierFromTreeMouseDown(e) {
+  function syncModifierFromTreeMouseDown(event) {
     if (!multiselect) return;
-    multiselectModifierActive = e.ctrlKey || e.metaKey || e.shiftKey;
+    multiselectModifierActive =
+      event.ctrlKey || event.metaKey || event.shiftKey;
   }
 
   /** @param {Event} e */
-  function handleMultiselectSelectStart(e) {
+  function handleMultiselectSelectStart(event) {
     if (multiselect && multiselectModifierActive) {
-      e.preventDefault();
+      event.preventDefault();
     }
   }
 
@@ -523,8 +513,6 @@
   let lastExpandedIdsPushed = expandedIds;
 
   /**
-   * @param {ReadonlyArray<Node["id"]>} a
-   * @param {ReadonlyArray<Node["id"]>} b
    * @returns {boolean}
    */
   function arrayIdsEqual(a, b) {
@@ -662,28 +650,27 @@
     }
   }
 
-  /** @param {EventTarget | null} target */
   function getTreeItemFromTarget(target) {
     if (!(target instanceof Element)) return null;
     if (target.classList.contains("bx--tree-node")) return target;
     return target.closest(".bx--tree-node");
   }
 
-  function handleKeyDown(e) {
-    e.stopPropagation();
+  function handleKeyDown(event) {
+    event.stopPropagation();
 
     if (
-      e.key === "ArrowUp" ||
-      e.key === "ArrowDown" ||
-      e.key === "Home" ||
-      e.key === "End"
+      event.key === "ArrowUp" ||
+      event.key === "ArrowDown" ||
+      event.key === "Home" ||
+      event.key === "End"
     ) {
-      e.preventDefault();
+      event.preventDefault();
     }
 
     if (!treeWalker || !ref) return;
 
-    const treeItem = getTreeItemFromTarget(e.target);
+    const treeItem = getTreeItemFromTarget(event.target);
     if (!treeItem) return;
 
     treeWalker.currentNode = treeItem;
@@ -691,16 +678,17 @@
     /** @type {Node | null} */
     let nextFocusNode = null;
 
-    if (e.key === "ArrowUp") {
+    if (event.key === "ArrowUp") {
       nextFocusNode = treeWalker.previousNode();
     }
-    if (e.key === "ArrowDown") {
+    if (event.key === "ArrowDown") {
       nextFocusNode = treeWalker.nextNode();
     }
 
-    const isHomeOrEnd = e.key === "Home" || e.key === "End";
+    const isHomeOrEnd = event.key === "Home" || event.key === "End";
     const isSelectAll =
-      (e.code === "KeyA" || e.key === "a" || e.key === "A") && e.ctrlKey;
+      (event.code === "KeyA" || event.key === "a" || event.key === "A") &&
+      event.ctrlKey;
 
     if (isHomeOrEnd || isSelectAll) {
       /** @type {Array<string | number>} */
@@ -709,21 +697,23 @@
       if (isHomeOrEnd) {
         if (
           multiselect &&
-          e.shiftKey &&
-          e.ctrlKey &&
+          event.shiftKey &&
+          event.ctrlKey &&
           treeItem instanceof HTMLElement
         ) {
           const hid = treeItem.id;
           if (hid) nodeIds.push(hid);
         }
         while (
-          e.key === "Home" ? treeWalker.previousNode() : treeWalker.nextNode()
+          event.key === "Home"
+            ? treeWalker.previousNode()
+            : treeWalker.nextNode()
         ) {
           nextFocusNode = treeWalker.currentNode;
           if (
             multiselect &&
-            e.shiftKey &&
-            e.ctrlKey &&
+            event.shiftKey &&
+            event.ctrlKey &&
             nextFocusNode instanceof Element
           ) {
             const nid = nextFocusNode.id;
@@ -733,7 +723,7 @@
       }
 
       if (isSelectAll) {
-        e.preventDefault();
+        event.preventDefault();
         for (const n of flattenedNodes) {
           if (n.disabled) continue;
           const el = ref?.querySelector(`[id="${CSS.escape(String(n.id))}"]`);

--- a/src/TreeView/TreeViewNode.svelte
+++ b/src/TreeView/TreeViewNode.svelte
@@ -149,28 +149,28 @@
       class:bx--tree-node--selected={selected}
       class:bx--tree-node--disabled={disabled}
       class:bx--tree-node--with-icon={icon}
-      on:click|stopPropagation={(e) => {
+      on:click|stopPropagation={(event) => {
         if (disabled) return;
-        clickNode(node, e);
+        clickNode(node, event);
       }}
-      on:keydown={(e) => {
+      on:keydown={(event) => {
         if (
-          e.key === "ArrowLeft" ||
-          e.key === "ArrowRight" ||
-          e.key === "Enter"
+          event.key === "ArrowLeft" ||
+          event.key === "ArrowRight" ||
+          event.key === "Enter"
         ) {
-          e.stopPropagation();
+          event.stopPropagation();
         }
 
-        if (e.key === "ArrowLeft") {
+        if (event.key === "ArrowLeft") {
           const parentNode = findParentTreeNode(ref.parentNode?.parentNode);
           if (parentNode) parentNode.focus();
         }
 
-        if (e.key === "Enter" || e.key === " ") {
-          e.preventDefault();
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
           if (disabled) return;
-          clickNode(node, e);
+          clickNode(node, event);
         }
       }}
       on:focus={() => {
@@ -199,28 +199,28 @@
     class:bx--tree-node--selected={selected}
     class:bx--tree-node--disabled={disabled}
     class:bx--tree-node--with-icon={icon}
-    on:click|stopPropagation={(e) => {
+    on:click|stopPropagation={(event) => {
       if (disabled) return;
-      clickNode(node, e);
+      clickNode(node, event);
     }}
-    on:keydown={(e) => {
+    on:keydown={(event) => {
       if (
-        e.key === "ArrowLeft" ||
-        e.key === "ArrowRight" ||
-        e.key === "Enter"
+        event.key === "ArrowLeft" ||
+        event.key === "ArrowRight" ||
+        event.key === "Enter"
       ) {
-        e.stopPropagation();
+        event.stopPropagation();
       }
 
-      if (e.key === "ArrowLeft") {
+      if (event.key === "ArrowLeft") {
         const parentNode = findParentTreeNode(ref.parentNode);
         if (parentNode) parentNode.focus();
       }
 
-      if (e.key === "Enter" || e.key === " ") {
-        e.preventDefault();
+      if (event.key === "Enter" || event.key === " ") {
+        event.preventDefault();
         if (disabled) return;
-        clickNode(node, e);
+        clickNode(node, event);
       }
     }}
     on:focus={() => {

--- a/src/TreeView/TreeViewNode.svelte
+++ b/src/TreeView/TreeViewNode.svelte
@@ -38,8 +38,7 @@
 
   /**
    * Finds the nearest parent tree node
-   * @param {HTMLElement | null} node
-   * @returns {null | HTMLElement}
+   * @type {(node: HTMLElement | null) => null | HTMLElement}
    */
   export function findParentTreeNode(node) {
     if (node == null || !(node instanceof HTMLElement)) return null;

--- a/src/TreeView/TreeViewNodeList.svelte
+++ b/src/TreeView/TreeViewNodeList.svelte
@@ -30,7 +30,6 @@
   /**
    * First focusable tree item in a subtree `ul` — handles both bare
    * `li.bx--tree-node` rows and the link variant (`li[role="none"] > a`).
-   * @param {HTMLElement} groupUl
    * @returns {HTMLElement | null}
    */
   function firstTreeItemInGroup(groupUl) {
@@ -120,20 +119,20 @@
     class:bx--tree-node--with-icon={icon}
     aria-expanded={expanded}
     aria-owns={`${id}-subtree`}
-    on:click|stopPropagation={(e) => {
+    on:click|stopPropagation={(event) => {
       if (disabled) return;
-      clickNode(node, e);
+      clickNode(node, event);
     }}
-    on:keydown={(e) => {
+    on:keydown={(event) => {
       if (
-        e.key === "ArrowLeft" ||
-        e.key === "ArrowRight" ||
-        e.key === "Enter"
+        event.key === "ArrowLeft" ||
+        event.key === "ArrowRight" ||
+        event.key === "Enter"
       ) {
-        e.stopPropagation();
+        event.stopPropagation();
       }
 
-      if (parent && e.key === "ArrowLeft") {
+      if (parent && event.key === "ArrowLeft") {
         if (expanded) {
           expandNode(node, false);
           toggleNode(node);
@@ -143,7 +142,7 @@
         }
       }
 
-      if (parent && e.key === "ArrowRight") {
+      if (parent && event.key === "ArrowRight") {
         if (expanded) {
           const groupUl = ref.lastElementChild;
           if (groupUl instanceof HTMLElement) {
@@ -156,15 +155,15 @@
         }
       }
 
-      if (e.key === "Enter" || e.key === " ") {
-        e.preventDefault();
+      if (event.key === "Enter" || event.key === " ") {
+        event.preventDefault();
         if (disabled) return;
-        if (e.key === "Enter" && parent) {
+        if (event.key === "Enter" && parent) {
           const nextExpanded = !expanded;
           expandNode(node, nextExpanded);
           toggleNode(node);
         }
-        clickNode(node, e);
+        clickNode(node, event);
         ref.focus();
       }
     }}

--- a/src/UIShell/HeaderAction.svelte
+++ b/src/UIShell/HeaderAction.svelte
@@ -57,7 +57,7 @@
   export let ref = null;
 
   /**
-   * Customize the panel transition (i.e., `transition:slide`).
+   * Customize the panel transition (i.event., `transition:slide`).
    * Set to `false` to disable the transition.
    * @type {false | import("svelte/transition").SlideParams}
    */
@@ -88,11 +88,11 @@
 </script>
 
 <svelte:window
-  on:click={({ target }) => {
+  on:click={(event) => {
     if (
       isOpen &&
-      !ref.contains(target) &&
-      !refPanel.contains(target) &&
+      !ref.contains(event.target) &&
+      !refPanel.contains(event.target) &&
       !preventCloseOnClickOutside
     ) {
       isOpen = false;

--- a/src/UIShell/HeaderNavItem.svelte
+++ b/src/UIShell/HeaderNavItem.svelte
@@ -68,44 +68,44 @@
     on:mouseleave
     on:keyup
     on:keydown
-    on:keydown={(e) => {
+    on:keydown={(event) => {
       if (!ctx) return;
 
       const currentIndex = menuItems.indexOf(ref);
       if (currentIndex === -1) return;
 
-      if (e.key === "ArrowDown") {
-        e.preventDefault();
+      if (event.key === "ArrowDown") {
+        event.preventDefault();
         // Move to next item, wrap to first
         const nextIndex = (currentIndex + 1) % menuItems.length;
         menuItems[nextIndex]?.focus();
-      } else if (e.key === "ArrowUp") {
-        e.preventDefault();
+      } else if (event.key === "ArrowUp") {
+        event.preventDefault();
         // Move to previous item, wrap to last
         const prevIndex =
           (currentIndex - 1 + menuItems.length) % menuItems.length;
         menuItems[prevIndex]?.focus();
-      } else if (e.key === "Home") {
-        e.preventDefault();
+      } else if (event.key === "Home") {
+        event.preventDefault();
         // Focus first item
         menuItems[0]?.focus();
-      } else if (e.key === "End") {
-        e.preventDefault();
+      } else if (event.key === "End") {
+        event.preventDefault();
         // Focus last item
         menuItems[menuItems.length - 1]?.focus();
-      } else if (e.key === "Escape") {
-        e.preventDefault();
+      } else if (event.key === "Escape") {
+        event.preventDefault();
         ctx.closeMenu();
       }
     }}
     on:focus
     on:blur
-    on:blur={(e) => {
+    on:blur={(event) => {
       // Only close menu if blur is moving focus outside the menu
       // (not when navigating between menu items with arrow keys)
       if (
         selectedItemIds.indexOf(id) === selectedItemIds.length - 1 &&
-        (!e.relatedTarget || !menuItems.includes(e.relatedTarget))
+        (!event.relatedTarget || !menuItems.includes(event.relatedTarget))
       ) {
         ctx?.closeMenu();
       }

--- a/src/UIShell/HeaderNavMenu.svelte
+++ b/src/UIShell/HeaderNavMenu.svelte
@@ -83,8 +83,8 @@
 </script>
 
 <svelte:window
-  on:click={({ target }) => {
-    if (!ref?.contains(target)) {
+  on:click={(event) => {
+    if (!ref?.contains(event.target)) {
       expanded = false;
     }
   }}
@@ -94,15 +94,15 @@
   role="none"
   class:bx--header__submenu={true}
   class:bx--header__submenu--current={isCurrentSubmenu}
-  on:click={(e) => {
-    if (!menuRef.contains(e.target)) {
-      e.preventDefault();
+  on:click={(event) => {
+    if (!menuRef.contains(event.target)) {
+      event.preventDefault();
     }
     expanded = !expanded;
   }}
-  on:keydown={(e) => {
-    if (e.key === "Enter") {
-      e.stopPropagation();
+  on:keydown={(event) => {
+    if (event.key === "Enter") {
+      event.stopPropagation();
       expanded = !expanded;
     }
   }}
@@ -120,10 +120,10 @@
     style:z-index={1}
     {...$$restProps}
     on:keydown
-    on:keydown={async (e) => {
-      if (e.key === " ") {
-        e.preventDefault();
-        e.stopPropagation();
+    on:keydown={async (event) => {
+      if (event.key === " ") {
+        event.preventDefault();
+        event.stopPropagation();
         const wasExpanded = expanded;
         expanded = !expanded;
         if (!wasExpanded && expanded && $menuItems.length > 0) {
@@ -131,32 +131,32 @@
           await tick();
           $menuItems[0]?.focus();
         }
-      } else if (e.key === "Enter") {
-        e.preventDefault();
+      } else if (event.key === "Enter") {
+        event.preventDefault();
         // Let the li handler toggle the expanded state
         // Just focus the first item if opening
         if (!expanded && $menuItems.length > 0) {
           await tick();
           $menuItems[0]?.focus();
         }
-      } else if (e.key === "ArrowDown") {
-        e.preventDefault();
+      } else if (event.key === "ArrowDown") {
+        event.preventDefault();
         if (!expanded) {
           expanded = true;
         }
         // Focus first item
         await tick();
         $menuItems[0]?.focus();
-      } else if (e.key === "ArrowUp") {
-        e.preventDefault();
+      } else if (event.key === "ArrowUp") {
+        event.preventDefault();
         if (!expanded) {
           expanded = true;
         }
         // Focus last item
         await tick();
         $menuItems[$menuItems.length - 1]?.focus();
-      } else if (e.key === "Escape") {
-        e.preventDefault();
+      } else if (event.key === "Escape") {
+        event.preventDefault();
         expanded = false;
         await tick();
         ref?.focus();

--- a/src/UIShell/HeaderSearch.svelte
+++ b/src/UIShell/HeaderSearch.svelte
@@ -92,8 +92,8 @@
 </script>
 
 <svelte:window
-  on:mouseup={({ target }) => {
-    if (active && !refSearch?.contains(target)) active = false;
+  on:mouseup={(event) => {
+    if (active && !refSearch?.contains(event.target)) active = false;
   }}
 />
 
@@ -144,13 +144,13 @@
       on:focus
       on:blur
       on:keydown
-      on:keydown={(e) => {
-        switch (e.key) {
+      on:keydown={(event) => {
+        switch (event.key) {
           case "Enter":
             selectResult();
             break;
           case "ArrowDown":
-            e.preventDefault();
+            event.preventDefault();
             if (selectedResultIndex === results.length - 1) {
               selectedResultIndex = 0;
             } else {
@@ -158,7 +158,7 @@
             }
             break;
           case "ArrowUp":
-            e.preventDefault();
+            event.preventDefault();
             if (selectedResultIndex === 0) {
               selectedResultIndex = results.length - 1;
             } else {

--- a/src/UIShell/HeaderSearch.svelte
+++ b/src/UIShell/HeaderSearch.svelte
@@ -205,23 +205,23 @@
       id={menuId}
       class:bx--header-search-menu={true}
     >
-      {#each results as result, i (result.id ?? i)}
+      {#each results as result, index (result.id ?? index)}
         <li role="none">
           <a
             tabindex="-1"
-            id="{id}-menuitem-{result.id ?? i}"
+            id="{id}-menuitem-{result.id ?? index}"
             role="menuitem"
             href={result.href}
             class:bx--header-search-menu-item={true}
             class:bx--header-search-menu-item--selected={selectedId ===
-              `${id}-menuitem-${result.id ?? i}`}
+              `${id}-menuitem-${result.id ?? index}`}
             on:click|preventDefault={async () => {
-              selectedResultIndex = i;
+              selectedResultIndex = index;
               await tick();
               selectResult();
             }}
           >
-            <slot {result} index={i}>
+            <slot {result} {index}>
               {result.text}
               {#if result.description}
                 <span class:bx--header-search-menu-description={true}


### PR DESCRIPTION
Pass at improving/standardizing internal variable names.

- Use better variable names, period.
- Use `event` instead of `(e)` or destructured handler params so DOM events read unambiguously in templates and dispatch sites.
- Rename loop indices to `index` and locals like `step`/`candidateIndex` to avoid clashing with props and abbreviated names.
- Avoid "_" prefix unless intentionally unused.
