### PR TITLE
fix(local-storage): sync `prevValue` after reactive key change

### DIFF
--- a/docs/src/pages/components/LocalStorage.svx
+++ b/docs/src/pages/components/LocalStorage.svx
@@ -21,6 +21,8 @@ The `key` prop is also reactive, allowing you to dynamically switch between diff
 
 In this example, each user has their own theme preference stored under a separate key. When you switch users, the component automatically loads that user's saved preference.
 
+Switching the `key` only hydrates `value` from storage; it does not dispatch an `on:update` event. The event log below should remain empty when you change users and only record entries when you change the theme.
+
 <FileSource src="/framed/LocalStorage/LocalStorageReactiveKey" />
 
 ## Clear item, clear all

--- a/docs/src/pages/framed/LocalStorage/LocalStorageReactiveKey.svelte
+++ b/docs/src/pages/framed/LocalStorage/LocalStorageReactiveKey.svelte
@@ -8,6 +8,7 @@
 
   let selectedUser = "user-1";
   let theme = "white";
+  let events = [];
 
   $: storageKey = `local-storage-reactive-example-${selectedUser}`;
 </script>
@@ -17,7 +18,13 @@
     Try selecting different users and changing their theme preferences. Each
     user's preference is stored separately and persists across page reloads.
   </div>
-  <LocalStorage key={storageKey} bind:value={theme} />
+  <LocalStorage
+    key={storageKey}
+    bind:value={theme}
+    on:update={({ detail }) => {
+      events = [...events, { event: "on:update", detail }];
+    }}
+  />
   <RadioButtonGroup legendText="Select user" bind:selected={selectedUser}>
     <RadioButton labelText="User 1" value="user-1" />
     <RadioButton labelText="User 2" value="user-2" />
@@ -40,4 +47,6 @@
       {theme}
     </div>
   </Stack>
+  <strong> Updates: </strong>
+  <pre>{JSON.stringify(events, null, 2)}</pre>
 </Stack>

--- a/src/LocalStorage/LocalStorage.svelte
+++ b/src/LocalStorage/LocalStorage.svelte
@@ -82,6 +82,7 @@
       }
     }
 
+    prevValue = value;
     mounted = true;
 
     function handleStorageChange(event) {
@@ -117,6 +118,7 @@
     }
 
     prevKey = key;
+    prevValue = value;
   }
 
   afterUpdate(() => {

--- a/tests/LocalStorage/LocalStorageCrossTab.test.svelte
+++ b/tests/LocalStorage/LocalStorageCrossTab.test.svelte
@@ -5,6 +5,8 @@
 
   export let value = "initial-value";
   export let key = "cross-tab-key";
+  export let onUpdate: (e: CustomEvent) => void = () => {};
+  export let onSave: () => void = () => {};
 </script>
 
-<LocalStorage {key} bind:value on:update />
+<LocalStorage {key} bind:value on:update={onUpdate} on:save={onSave} />

--- a/tests/LocalStorage/LocalStorageCrossTab.test.ts
+++ b/tests/LocalStorage/LocalStorageCrossTab.test.ts
@@ -4,7 +4,20 @@ import { setupStorageEventMock } from "../utils/storage-mocks";
 import LocalStorageCrossTab from "./LocalStorageCrossTab.test.svelte";
 
 describe("LocalStorage cross-tab sync", () => {
-  const { dispatchStorageEvent } = setupStorageEventMock();
+  const { dispatchStorageEvent, setMockItem } = setupStorageEventMock();
+
+  it("does not dispatch update on mount when hydrating from existing storage", async () => {
+    setMockItem("hydrate-key", JSON.stringify("persisted-value"));
+
+    const onUpdate = vi.fn();
+    const { component } = render(LocalStorageCrossTab, {
+      props: { key: "hydrate-key", value: "initial", onUpdate },
+    });
+    await tick();
+
+    expect(component.value).toBe("persisted-value");
+    expect(onUpdate).not.toHaveBeenCalled();
+  });
 
   it("registers a storage event listener on mount", async () => {
     render(LocalStorageCrossTab);
@@ -66,6 +79,23 @@ describe("LocalStorage cross-tab sync", () => {
     await tick();
 
     expect(component.value).toBe("initial");
+  });
+
+  it("does not dispatch update when key changes to an existing entry", async () => {
+    setMockItem("key-b", JSON.stringify("b-value"));
+
+    const onUpdate = vi.fn();
+    const { component } = render(LocalStorageCrossTab, {
+      props: { key: "key-a", value: "a-value", onUpdate },
+    });
+    await tick();
+    onUpdate.mockClear();
+
+    component.key = "key-b";
+    await tick();
+
+    expect(component.value).toBe("b-value");
+    expect(onUpdate).not.toHaveBeenCalled();
   });
 
   it("handles invalid JSON gracefully by using raw string", async () => {

--- a/tests/LocalStorage/LocalStorageReactiveKey.test.ts
+++ b/tests/LocalStorage/LocalStorageReactiveKey.test.ts
@@ -5,7 +5,7 @@ import LocalStorageReactiveKey from "./LocalStorageReactiveKey.test.svelte";
 
 // Regression tests for https://github.com/carbon-design-system/carbon-components-svelte/issues/1204
 describe("LocalStorage - reactive key", () => {
-  const { setMockItem } = setupLocalStorageMock();
+  const { setMockItem, getMockItem } = setupLocalStorageMock();
 
   it("should update value when key prop changes", async () => {
     setMockItem("key-a", "value-a");
@@ -48,9 +48,12 @@ describe("LocalStorage - reactive key", () => {
     expect(JSON.parse(valueDisplay?.textContent || "{}")).toEqual({
       theme: "light",
     });
-    expect(localStorage.setItem).toHaveBeenLastCalledWith(
-      "user-2-settings",
+    expect(getMockItem("user-2-settings")).toBe(
       JSON.stringify({ theme: "light" }),
+    );
+    expect(localStorage.setItem).not.toHaveBeenCalledWith(
+      "user-2-settings",
+      JSON.stringify({ theme: "dark" }),
     );
   });
 


### PR DESCRIPTION
The `key !== prevKey` block rehydrates `value` from storage but left `prevValue` stale, so the next `afterUpdate` dispatched a spurious `update` event carrying the previous key's `prevValue`.

Updated the docs "Reactive key" example to illustrate this. It should not dispatch an update event on mount.