### PR TITLE
fix(session-storage): sync `prevValue` after hydration and reactive key change

### DIFF
--- a/docs/src/pages/components/SessionStorage.svx
+++ b/docs/src/pages/components/SessionStorage.svx
@@ -18,6 +18,8 @@ The `key` prop is also reactive, allowing you to dynamically switch between diff
 
 In this example, each user has their own theme preference stored under a separate key. When you switch users, the component automatically loads that user's saved preference.
 
+Switching the `key` only hydrates `value` from storage; it does not dispatch an `on:update` event. The event log below should remain empty when you change users and only record entries when you change the theme.
+
 <FileSource src="/framed/SessionStorage/SessionStorageReactiveKey" />
 
 ## Clear item, clear all

--- a/docs/src/pages/framed/SessionStorage/SessionStorageReactiveKey.svelte
+++ b/docs/src/pages/framed/SessionStorage/SessionStorageReactiveKey.svelte
@@ -3,47 +3,50 @@
     RadioButton,
     RadioButtonGroup,
     SessionStorage,
+    Stack,
   } from "carbon-components-svelte";
 
   let selectedUser = "user-1";
   let theme = "white";
+  let events = [];
 
   $: storageKey = `session-storage-reactive-example-${selectedUser}`;
 </script>
 
-<div style:margin-bottom="var(--cds-layout-01)">
-  Try selecting different users and changing their theme preferences. Each
-  user's preference is stored separately and persists within the session.
-</div>
-
-<SessionStorage key={storageKey} bind:value={theme} />
-
-<RadioButtonGroup legendText="Select user" bind:selected={selectedUser}>
-  <RadioButton labelText="User 1" value="user-1" />
-  <RadioButton labelText="User 2" value="user-2" />
-  <RadioButton labelText="User 3" value="user-3" />
-</RadioButtonGroup>
-
-<br>
-
-<RadioButtonGroup legendText="Theme preference" bind:selected={theme}>
-  <RadioButton labelText="White" value="white" />
-  <RadioButton labelText="Gray 10" value="g10" />
-  <RadioButton labelText="Gray 80" value="g80" />
-  <RadioButton labelText="Gray 90" value="g90" />
-  <RadioButton labelText="Gray 100" value="g100" />
-</RadioButtonGroup>
-
-<div
-  style="margin-top: var(--cds-layout-01)"
-  style:margin-bottom="var(--cds-layout-01)"
->
+<Stack gap={6}>
   <div>
-    <strong>Current key:</strong>
-    {storageKey}
+    Try selecting different users and changing their theme preferences. Each
+    user's preference is stored separately and persists within the session.
   </div>
-  <div>
-    <strong>Current theme:</strong>
-    {theme}
-  </div>
-</div>
+  <SessionStorage
+    key={storageKey}
+    bind:value={theme}
+    on:update={({ detail }) => {
+      events = [...events, { event: "on:update", detail }];
+    }}
+  />
+  <RadioButtonGroup legendText="Select user" bind:selected={selectedUser}>
+    <RadioButton labelText="User 1" value="user-1" />
+    <RadioButton labelText="User 2" value="user-2" />
+    <RadioButton labelText="User 3" value="user-3" />
+  </RadioButtonGroup>
+  <RadioButtonGroup legendText="Theme preference" bind:selected={theme}>
+    <RadioButton labelText="White" value="white" />
+    <RadioButton labelText="Gray 10" value="g10" />
+    <RadioButton labelText="Gray 80" value="g80" />
+    <RadioButton labelText="Gray 90" value="g90" />
+    <RadioButton labelText="Gray 100" value="g100" />
+  </RadioButtonGroup>
+  <Stack gap={2}>
+    <div>
+      <strong>Current key:</strong>
+      {storageKey}
+    </div>
+    <div>
+      <strong>Current theme:</strong>
+      {theme}
+    </div>
+  </Stack>
+  <strong> Updates: </strong>
+  <pre>{JSON.stringify(events, null, 2)}</pre>
+</Stack>

--- a/src/SessionStorage/SessionStorage.svelte
+++ b/src/SessionStorage/SessionStorage.svelte
@@ -82,6 +82,7 @@
       }
     }
 
+    prevValue = value;
     mounted = true;
 
     function handleStorageChange(event) {
@@ -117,6 +118,7 @@
     }
 
     prevKey = key;
+    prevValue = value;
   }
 
   afterUpdate(() => {

--- a/tests/SessionStorage/SessionStorageCrossTab.test.svelte
+++ b/tests/SessionStorage/SessionStorageCrossTab.test.svelte
@@ -5,6 +5,8 @@
 
   export let value = "initial-value";
   export let key = "cross-tab-key";
+  export let onUpdate: (e: CustomEvent) => void = () => {};
+  export let onSave: () => void = () => {};
 </script>
 
-<SessionStorage {key} bind:value on:update />
+<SessionStorage {key} bind:value on:update={onUpdate} on:save={onSave} />

--- a/tests/SessionStorage/SessionStorageCrossTab.test.ts
+++ b/tests/SessionStorage/SessionStorageCrossTab.test.ts
@@ -4,7 +4,20 @@ import { setupSessionStorageEventMock } from "../utils/storage-mocks";
 import SessionStorageCrossTab from "./SessionStorageCrossTab.test.svelte";
 
 describe("SessionStorage cross-tab sync", () => {
-  const { dispatchStorageEvent } = setupSessionStorageEventMock();
+  const { dispatchStorageEvent, setMockItem } = setupSessionStorageEventMock();
+
+  it("does not dispatch update on mount when hydrating from existing storage", async () => {
+    setMockItem("hydrate-key", JSON.stringify("persisted-value"));
+
+    const onUpdate = vi.fn();
+    const { component } = render(SessionStorageCrossTab, {
+      props: { key: "hydrate-key", value: "initial", onUpdate },
+    });
+    await tick();
+
+    expect(component.value).toBe("persisted-value");
+    expect(onUpdate).not.toHaveBeenCalled();
+  });
 
   it("registers a storage event listener on mount", async () => {
     render(SessionStorageCrossTab);
@@ -62,6 +75,23 @@ describe("SessionStorage cross-tab sync", () => {
     await tick();
 
     expect(component.value).toBe("initial");
+  });
+
+  it("does not dispatch update when key changes to an existing entry", async () => {
+    setMockItem("key-b", JSON.stringify("b-value"));
+
+    const onUpdate = vi.fn();
+    const { component } = render(SessionStorageCrossTab, {
+      props: { key: "key-a", value: "a-value", onUpdate },
+    });
+    await tick();
+    onUpdate.mockClear();
+
+    component.key = "key-b";
+    await tick();
+
+    expect(component.value).toBe("b-value");
+    expect(onUpdate).not.toHaveBeenCalled();
   });
 
   it("handles invalid JSON gracefully by using raw string", async () => {

--- a/tests/SessionStorage/SessionStorageReactiveKey.test.ts
+++ b/tests/SessionStorage/SessionStorageReactiveKey.test.ts
@@ -4,7 +4,7 @@ import { setupSessionStorageMock } from "../utils/storage-mocks";
 import SessionStorageReactiveKey from "./SessionStorageReactiveKey.test.svelte";
 
 describe("SessionStorage - reactive key", () => {
-  const { setMockItem } = setupSessionStorageMock();
+  const { setMockItem, getMockItem } = setupSessionStorageMock();
 
   it("should update value when key prop changes", async () => {
     setMockItem("key-a", "value-a");
@@ -47,9 +47,12 @@ describe("SessionStorage - reactive key", () => {
     expect(JSON.parse(valueDisplay?.textContent || "{}")).toEqual({
       theme: "light",
     });
-    expect(sessionStorage.setItem).toHaveBeenLastCalledWith(
-      "user-2-settings",
+    expect(getMockItem("user-2-settings")).toBe(
       JSON.stringify({ theme: "light" }),
+    );
+    expect(sessionStorage.setItem).not.toHaveBeenCalledWith(
+      "user-2-settings",
+      JSON.stringify({ theme: "dark" }),
     );
   });
 


### PR DESCRIPTION
Similar to #3113, avoid dispatching an "update" event on mount for `SessionStorage`.