### PR TITLE
docs: replace Prism with Shiki for syntax highlighting

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -10,4 +10,3 @@ src/COMPONENT_MD_SIZES.json
 src/component-api/components/
 src/component-api/highlighted-primitives.json
 src/component-api/module-names.json
-src/preview-snippets/

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -7,3 +7,7 @@
 /.routify
 src/SEARCH_INDEX.json
 src/COMPONENT_MD_SIZES.json
+src/component-api/components/
+src/component-api/highlighted-primitives.json
+src/component-api/module-names.json
+src/preview-snippets/

--- a/docs/bun.lock
+++ b/docs/bun.lock
@@ -1,12 +1,11 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
+  "configVersion": 1,
   "workspaces": {
     "": {
       "devDependencies": {
         "@roxi/routify": "^3.6.4",
         "@sveltejs/vite-plugin-svelte": "^7.1.2",
-        "@types/prismjs": "^1.26.5",
         "carbon-icons-svelte": "^13.12.0",
         "clipboard-copy": "^4.0.1",
         "estree-walker": "^3.0.3",
@@ -16,9 +15,8 @@
         "minisearch": "^7.1.0",
         "prettier": "^3.8.3",
         "prettier-plugin-svelte": "^4.1.0",
-        "prism-svelte": "^0.5.0",
-        "prismjs": "^1.30.0",
         "rehype-slug": "^6.0.0",
+        "shiki": "^4.1.0",
         "svelte": "^5.56.3",
         "vite": "^8.0.16",
       },
@@ -77,27 +75,43 @@
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.1", "", {}, "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw=="],
 
-    "@roxi/routify": ["@roxi/routify@3.6.4", "", { "dependencies": { "cachewrap": "^0.0.1", "cheap-watch": "^1.0.4", "cheerio": "^1.0.0", "commander": "^7.2.0", "configent": "^3.0.0", "consolite": "^0.3.12", "dotenv-expand": "^12.0.2", "fs-extra": "^10.0.0", "hookar": "^0.0.7", "kleur": "^4.1.4", "node-fetch": "^3.3.0", "persistable": "^0.1.2", "prompts": "^2.4.2", "scroll-into-view-if-needed": "^3.1.0" }, "peerDependencies": { "@roxi/routify": "^3.0.0-next.0", "@sveltejs/vite-plugin-svelte": "^2.4.6 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0", "dotenv-expand": "^8.0.0 || ^9.0.0 || ^10.0.0", "spank": "^2.0.0", "svelte": "^3.0.0 || ^4.0.0 || ^5.0.0", "vite": "^3.2.4 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" }, "optionalPeers": ["spank"], "bin": { "routify": "lib/cli/index.js", "routify3": "lib/cli/index.js" } }, "sha512-cLx0gyUjbdUfQnNCVRi8Itabze/SFQSn7mvF6w/OGZkJRC89sscwMop7CT0hEc+yTZsj5l6RMK6JD5xHS6E9pg=="],
+    "@roxi/routify": ["@roxi/routify@3.6.4", "", { "dependencies": { "cachewrap": "^0.0.1", "cheap-watch": "^1.0.4", "cheerio": "^1.0.0", "commander": "^7.2.0", "configent": "^3.0.0", "consolite": "^0.3.12", "dotenv-expand": "^12.0.2", "fs-extra": "^10.0.0", "hookar": "^0.0.7", "kleur": "^4.1.4", "node-fetch": "^3.3.0", "persistable": "^0.1.2", "prompts": "^2.4.2", "scroll-into-view-if-needed": "^3.1.0" }, "peerDependencies": { "@roxi/routify": "^3.0.0-next.0", "@sveltejs/vite-plugin-svelte": "^2.4.6 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0", "spank": "^2.0.0", "svelte": "^3.0.0 || ^4.0.0 || ^5.0.0", "vite": "^3.2.4 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" }, "optionalPeers": ["@roxi/routify", "@sveltejs/vite-plugin-svelte", "spank", "vite"], "bin": { "routify": "lib/cli/index.js", "routify3": "lib/cli/index.js" } }, "sha512-cLx0gyUjbdUfQnNCVRi8Itabze/SFQSn7mvF6w/OGZkJRC89sscwMop7CT0hEc+yTZsj5l6RMK6JD5xHS6E9pg=="],
+
+    "@shikijs/core": ["@shikijs/core@4.2.0", "", { "dependencies": { "@shikijs/primitive": "4.2.0", "@shikijs/types": "4.2.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-Hc87Ab1Ld/vEbZRCbwx344I5v+4RU8CVToUTRkqXL1+TjbuOp9U5Xa0M23V4GEWHxVn+yO5otb+HkQVm3ptWQQ=="],
+
+    "@shikijs/engine-javascript": ["@shikijs/engine-javascript@4.2.0", "", { "dependencies": { "@shikijs/types": "4.2.0", "@shikijs/vscode-textmate": "^10.0.2", "oniguruma-to-es": "^4.3.6" } }, "sha512-fjETeq1k5ffyXqRgS6+3hpvqseLalp1kjNfRbXpUgWR8FpZ1CmQfiNHovc5lncYjt/Vg5JK/WJEmLahjwMa0og=="],
+
+    "@shikijs/engine-oniguruma": ["@shikijs/engine-oniguruma@4.2.0", "", { "dependencies": { "@shikijs/types": "4.2.0", "@shikijs/vscode-textmate": "^10.0.2" } }, "sha512-hTorK1dffPkpbMUk6Z+828PgRo7d07HbnizoP0hNPFjhxMHctj0Px/qoHeGMYafc6ju+u9iMldN4JbVzNQM++g=="],
+
+    "@shikijs/langs": ["@shikijs/langs@4.2.0", "", { "dependencies": { "@shikijs/types": "4.2.0" } }, "sha512-bwrVRlJ0wUhZxAbVdvBbv2TTC9yLsh4C/IO5Ofz0T8MQntgDvyVnkbjw9vi50r1kx7RCIJdnJnjZAwmAsXFLZQ=="],
+
+    "@shikijs/primitive": ["@shikijs/primitive@4.2.0", "", { "dependencies": { "@shikijs/types": "4.2.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-NOq+DtUkVBJtZMVXL5A0vI0Xk8nvDYaXetFHSJFlOqjDZIVhIPRYFdGkSoElDqNuegikcc3A76SNUa8dTqtAYA=="],
+
+    "@shikijs/themes": ["@shikijs/themes@4.2.0", "", { "dependencies": { "@shikijs/types": "4.2.0" } }, "sha512-RX8IHYeLv8Cu2W6ruc3RxUqWn0IYCqSrMBzi/uRGAmfyDNOnNO5BF/Px7o97n4XTpmFTo5GbRaazuOWj+2ak2w=="],
+
+    "@shikijs/types": ["@shikijs/types@4.2.0", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-VT/MKtlpOhEPZloSH3Pb9WCZEBDoQVMa9jedp5UAwmJOar1DVc9DRODAxmYPW9M93IK4ryuqRejFfmlvlVDemw=="],
+
+    "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
 
     "@sveltejs/acorn-typescript": ["@sveltejs/acorn-typescript@1.0.10", "", { "peerDependencies": { "acorn": "^8.9.0" } }, "sha512-4WfKk68eTih+MiJD4fSbxN7E8kVBmTMPWHUPYjvl2N0rMs53YLTT8/YjKU5Dtnz5LqDjl7LEw4U7lXR2W3J5WA=="],
 
     "@sveltejs/vite-plugin-svelte": ["@sveltejs/vite-plugin-svelte@7.1.2", "", { "dependencies": { "deepmerge": "^4.3.1", "magic-string": "^0.30.21", "obug": "^2.1.0", "vitefu": "^1.1.2" }, "peerDependencies": { "svelte": "^5.46.4", "vite": "^8.0.0-beta.7 || ^8.0.0" } }, "sha512-DrUBA2UXRfDmUX/ZTiEopd3X40yavsJF1FX2RygcuIScHL7o5YX1fMvoYnDhjeJQC4weCOklirpNWlcb2NiSeA=="],
 
-    "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
+    "@tybys/wasm-util": ["@tybys/wasm-util@0.10.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg=="],
 
-    "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
+    "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
 
     "@types/hast": ["@types/hast@3.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ=="],
 
     "@types/mdast": ["@types/mdast@4.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA=="],
 
-    "@types/prismjs": ["@types/prismjs@1.26.6", "", {}, "sha512-vqlvI7qlMvcCBbVe0AKAb4f97//Hy0EBTaiW8AalRnG/xAN5zOiWWyrNqNXeq8+KAuvRewjCVY1+IPxk4RdNYw=="],
-
     "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
 
     "@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
-    "acorn": ["acorn@8.16.0", "", { "bin": "bin/acorn" }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
+    "@ungap/structured-clone": ["@ungap/structured-clone@1.3.1", "", {}, "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ=="],
+
+    "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
     "aria-query": ["aria-query@5.3.1", "", {}, "sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g=="],
 
@@ -109,6 +123,12 @@
 
     "carbon-icons-svelte": ["carbon-icons-svelte@13.12.0", "", {}, "sha512-VK/gSvzCEe3tNEHS2xAcih/GBuygHuUenV+EY/44A3nyYjk+MCbgpY20uwID8/81gEUxIkl4rA/EMRWb/3qs0A=="],
 
+    "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
+
+    "character-entities-html4": ["character-entities-html4@2.1.0", "", {}, "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA=="],
+
+    "character-entities-legacy": ["character-entities-legacy@3.0.0", "", {}, "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ=="],
+
     "cheap-watch": ["cheap-watch@1.0.4", "", {}, "sha512-QR/9FrtRL5fjfUJBhAKCdi0lSRQ3rVRRum3GF9wDKp2TJbEIMGhUEr2yU8lORzm9Isdjx7/k9S0DFDx+z5VGtw=="],
 
     "cheerio": ["cheerio@1.2.0", "", { "dependencies": { "cheerio-select": "^2.1.0", "dom-serializer": "^2.0.0", "domhandler": "^5.0.3", "domutils": "^3.2.2", "encoding-sniffer": "^0.2.1", "htmlparser2": "^10.1.0", "parse5": "^7.3.0", "parse5-htmlparser2-tree-adapter": "^7.1.0", "parse5-parser-stream": "^7.1.2", "undici": "^7.19.0", "whatwg-mimetype": "^4.0.0" } }, "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg=="],
@@ -118,6 +138,8 @@
     "clipboard-copy": ["clipboard-copy@4.0.1", "", {}, "sha512-wOlqdqziE/NNTUJsfSgXmBMIrYmfd5V0HCGsR8uAKHcg+h9NENWINcfRjtWGU77wDHC8B8ijV4hMTGYbrKovng=="],
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
+
+    "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
 
     "commander": ["commander@7.2.0", "", {}, "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="],
 
@@ -135,9 +157,13 @@
 
     "deepmerge": ["deepmerge@4.3.1", "", {}, "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="],
 
+    "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
+
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
     "devalue": ["devalue@5.8.1", "", {}, "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw=="],
+
+    "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
 
     "dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
 
@@ -163,7 +189,7 @@
 
     "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
-    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" } }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
     "fetch-blob": ["fetch-blob@3.2.0", "", { "dependencies": { "node-domexception": "^1.0.0", "web-streams-polyfill": "^3.0.3" } }, "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ=="],
 
@@ -179,9 +205,15 @@
 
     "hast-util-heading-rank": ["hast-util-heading-rank@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-EJKb8oMUXVHcWZTDepnr+WNbfnXKFNf9duMesmr4S8SXTJBJ9M4Yok08pu9vxdJwdlGRhVumk9mEhkEvKGifwA=="],
 
+    "hast-util-to-html": ["hast-util-to-html@9.0.5", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "ccount": "^2.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-whitespace": "^3.0.0", "html-void-elements": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "stringify-entities": "^4.0.0", "zwitch": "^2.0.4" } }, "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw=="],
+
     "hast-util-to-string": ["hast-util-to-string@3.0.1", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-XelQVTDWvqcl3axRfI0xSeoVKzyIFPwsAGSLIsKdJKQMXDYJS4WYrBNF/8J7RdhIcFI2BOHgAifggsvsxp/3+A=="],
 
+    "hast-util-whitespace": ["hast-util-whitespace@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw=="],
+
     "hookar": ["hookar@0.0.7", "", {}, "sha512-4qiFw9WIMM6ft82CalpWaEkBAzoL3Dw7xB7eLlC9P64Mx/SaHTLqWQTfLkGe6r5ERE4iTbVDCTsKLQuK1YTr3A=="],
+
+    "html-void-elements": ["html-void-elements@3.0.0", "", {}, "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="],
 
     "htmlparser2": ["htmlparser2@10.1.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.2.2", "entities": "^7.0.1" } }, "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ=="],
 
@@ -189,7 +221,7 @@
 
     "is-reference": ["is-reference@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.6" } }, "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw=="],
 
-    "jsonfile": ["jsonfile@6.2.0", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg=="],
+    "jsonfile": ["jsonfile@6.2.1", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q=="],
 
     "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
 
@@ -223,7 +255,19 @@
 
     "mdast": ["mdast@3.0.0", "", {}, "sha512-xySmf8g4fPKMeC07jXGz971EkLbWAJ83s4US2Tj9lEdnZ142UP5grN73H1Xd3HzrdbU5o9GYYP/y8F9ZSwLE9g=="],
 
+    "mdast-util-to-hast": ["mdast-util-to-hast@13.2.1", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "@ungap/structured-clone": "^1.0.0", "devlop": "^1.0.0", "micromark-util-sanitize-uri": "^2.0.0", "trim-lines": "^3.0.0", "unist-util-position": "^5.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA=="],
+
     "mdsvex": ["mdsvex@0.12.7", "", { "dependencies": { "@types/mdast": "^4.0.4", "@types/unist": "^2.0.3", "prism-svelte": "^0.4.7", "prismjs": "^1.17.1", "unist-util-visit": "^2.0.1", "vfile-message": "^2.0.4" }, "peerDependencies": { "svelte": "^3.56.0 || ^4.0.0 || ^5.0.0-next.120" } }, "sha512-gx4bReLCUvq+MPErHXYeyX+TEq1hsS2KfiZtEOMNTcbibSouFy8AHc5h04KbGCl+g5tLuo4/lbgRVYRnc7bJZw=="],
+
+    "micromark-util-character": ["micromark-util-character@2.1.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q=="],
+
+    "micromark-util-encode": ["micromark-util-encode@2.0.1", "", {}, "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw=="],
+
+    "micromark-util-sanitize-uri": ["micromark-util-sanitize-uri@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-symbol": "^2.0.0" } }, "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ=="],
+
+    "micromark-util-symbol": ["micromark-util-symbol@2.0.1", "", {}, "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q=="],
+
+    "micromark-util-types": ["micromark-util-types@2.0.2", "", {}, "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA=="],
 
     "minisearch": ["minisearch@7.2.0", "", {}, "sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg=="],
 
@@ -235,7 +279,11 @@
 
     "nth-check": ["nth-check@2.1.1", "", { "dependencies": { "boolbase": "^1.0.0" } }, "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w=="],
 
-    "obug": ["obug@2.1.1", "", {}, "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ=="],
+    "obug": ["obug@2.1.2", "", {}, "sha512-AWGB9WFcRXOQs48Z/udjI5ZcZMHXwX8XPByNpOydgcGsDLIzjGizhoMWJyKAWze7AVW/2W1i+/gPX4YtKe5cyg=="],
+
+    "oniguruma-parser": ["oniguruma-parser@0.12.2", "", {}, "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw=="],
+
+    "oniguruma-to-es": ["oniguruma-to-es@4.3.6", "", { "dependencies": { "oniguruma-parser": "^0.12.2", "regex": "^6.1.0", "regex-recursion": "^6.0.2" } }, "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA=="],
 
     "parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
 
@@ -255,11 +303,19 @@
 
     "prettier-plugin-svelte": ["prettier-plugin-svelte@4.1.0", "", { "peerDependencies": { "prettier": "^3.0.0", "svelte": "^5.0.0" } }, "sha512-YZkhA2Q9oOerFFG9tq+2f98WYT7Z2JgrybJrAyrB78jpsH9i/DdgplXemehuFPgsldetFNCcR/yCcYlDjPy94Q=="],
 
-    "prism-svelte": ["prism-svelte@0.5.0", "", {}, "sha512-db91Bf3pRGKDPz1lAqLFSJXeW13mulUJxhycysFpfXV5MIK7RgWWK2E5aPAa71s8TCzQUXxF5JOV42/iOs6QkA=="],
+    "prism-svelte": ["prism-svelte@0.4.7", "", {}, "sha512-yABh19CYbM24V7aS7TuPYRNMqthxwbvx6FF/Rw920YbyBWO3tnyPIqRMgHuSVsLmuHkkBS1Akyof463FVdkeDQ=="],
 
     "prismjs": ["prismjs@1.30.0", "", {}, "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw=="],
 
     "prompts": ["prompts@2.4.2", "", { "dependencies": { "kleur": "^3.0.3", "sisteransi": "^1.0.5" } }, "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q=="],
+
+    "property-information": ["property-information@7.2.0", "", {}, "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg=="],
+
+    "regex": ["regex@6.1.0", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg=="],
+
+    "regex-recursion": ["regex-recursion@6.0.2", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg=="],
+
+    "regex-utilities": ["regex-utilities@2.3.0", "", {}, "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng=="],
 
     "rehype-slug": ["rehype-slug@6.0.0", "", { "dependencies": { "@types/hast": "^3.0.0", "github-slugger": "^2.0.0", "hast-util-heading-rank": "^3.0.0", "hast-util-to-string": "^3.0.0", "unist-util-visit": "^5.0.0" } }, "sha512-lWyvf/jwu+oS5+hL5eClVd3hNdmwM1kAC0BUvEGD19pajQMIzcNUd/k9GsfQ+FfECvX+JE+e9/btsKH0EjJT6A=="],
 
@@ -269,19 +325,29 @@
 
     "scroll-into-view-if-needed": ["scroll-into-view-if-needed@3.1.0", "", { "dependencies": { "compute-scroll-into-view": "^3.0.2" } }, "sha512-49oNpRjWRvnU8NyGVmUaYG4jtTkNonFZI86MmGRDqBphEK2EXT9gdEUoQPZhuBM8yWHxCWbobltqYO5M4XrUvQ=="],
 
+    "shiki": ["shiki@4.2.0", "", { "dependencies": { "@shikijs/core": "4.2.0", "@shikijs/engine-javascript": "4.2.0", "@shikijs/engine-oniguruma": "4.2.0", "@shikijs/langs": "4.2.0", "@shikijs/themes": "4.2.0", "@shikijs/types": "4.2.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-hjNax6o/ylDy9lefQEaSDtzaT3iVNtZ3WmpQnbuQNoG4xvnSKf2kSKbihZVO4JRG1TTMejs7CmNRYlWgAL66pQ=="],
+
     "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
+
+    "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
 
     "svelte": ["svelte@5.56.3", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "@jridgewell/sourcemap-codec": "^1.5.0", "@sveltejs/acorn-typescript": "^1.0.10", "@types/estree": "^1.0.5", "@types/trusted-types": "^2.0.7", "acorn": "^8.12.1", "aria-query": "5.3.1", "axobject-query": "^4.1.0", "clsx": "^2.1.1", "devalue": "^5.8.1", "esm-env": "^1.2.1", "esrap": "^2.2.11", "is-reference": "^3.0.3", "locate-character": "^3.0.0", "magic-string": "^0.30.11", "zimmerframe": "^1.1.2" } }, "sha512-w7JvrM5IFl5cmfbY0TLik9o7mjRUJmRMhOR51tBPu708Gr/MjbGs7VnJnr/B0CaXeI4vtnOh7RKxDr0cwhMdDA=="],
 
     "tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
 
+    "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
+
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
-    "undici": ["undici@7.24.5", "", {}, "sha512-3IWdCpjgxp15CbJnsi/Y9TCDE7HWVN19j1hmzVhoAkY/+CJx449tVxT5wZc1Gwg8J+P0LWvzlBzxYRnHJ+1i7Q=="],
+    "undici": ["undici@7.27.2", "", {}, "sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA=="],
 
     "unist-util-is": ["unist-util-is@4.1.0", "", {}, "sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg=="],
+
+    "unist-util-position": ["unist-util-position@5.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA=="],
 
     "unist-util-stringify-position": ["unist-util-stringify-position@2.0.3", "", { "dependencies": { "@types/unist": "^2.0.2" } }, "sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g=="],
 
@@ -291,11 +357,13 @@
 
     "universalify": ["universalify@2.0.1", "", {}, "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="],
 
+    "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
+
     "vfile-message": ["vfile-message@2.0.4", "", { "dependencies": { "@types/unist": "^2.0.0", "unist-util-stringify-position": "^2.0.0" } }, "sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ=="],
 
     "vite": ["vite@8.0.16", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.15", "rolldown": "1.0.3", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.18", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw=="],
 
-    "vitefu": ["vitefu@1.1.2", "", { "peerDependencies": { "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-beta.0" } }, "sha512-zpKATdUbzbsycPFBN71nS2uzBUQiVnFoOrr2rvqv34S1lcAgMKKkjWleLGeiJlZ8lwCXvtWaRn7R3ZC16SYRuw=="],
+    "vitefu": ["vitefu@1.1.3", "", { "peerDependencies": { "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["vite"] }, "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg=="],
 
     "web-streams-polyfill": ["web-streams-polyfill@3.3.3", "", {}, "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="],
 
@@ -305,9 +373,15 @@
 
     "zimmerframe": ["zimmerframe@1.1.4", "", {}, "sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ=="],
 
+    "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
+
+    "@types/hast/@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
+
+    "hast-util-to-html/@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
+
     "htmlparser2/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
-    "mdsvex/prism-svelte": ["prism-svelte@0.4.7", "", {}, "sha512-yABh19CYbM24V7aS7TuPYRNMqthxwbvx6FF/Rw920YbyBWO3tnyPIqRMgHuSVsLmuHkkBS1Akyof463FVdkeDQ=="],
+    "mdast-util-to-hast/unist-util-visit": ["unist-util-visit@5.1.0", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg=="],
 
     "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
@@ -315,10 +389,24 @@
 
     "rehype-slug/unist-util-visit": ["unist-util-visit@5.1.0", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg=="],
 
+    "unist-util-position/@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
+
+    "vfile/@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
+
+    "vfile/vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
+
+    "mdast-util-to-hast/unist-util-visit/@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
+
+    "mdast-util-to-hast/unist-util-visit/unist-util-is": ["unist-util-is@6.0.1", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g=="],
+
+    "mdast-util-to-hast/unist-util-visit/unist-util-visit-parents": ["unist-util-visit-parents@6.0.2", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0" } }, "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ=="],
+
     "rehype-slug/unist-util-visit/@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
     "rehype-slug/unist-util-visit/unist-util-is": ["unist-util-is@6.0.1", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g=="],
 
     "rehype-slug/unist-util-visit/unist-util-visit-parents": ["unist-util-visit-parents@6.0.2", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0" } }, "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ=="],
+
+    "vfile/vfile-message/unist-util-stringify-position": ["unist-util-stringify-position@4.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ=="],
   }
 }

--- a/docs/package.json
+++ b/docs/package.json
@@ -15,7 +15,6 @@
   "devDependencies": {
     "@roxi/routify": "^3.6.4",
     "@sveltejs/vite-plugin-svelte": "^7.1.2",
-    "@types/prismjs": "^1.26.5",
     "carbon-icons-svelte": "^13.12.0",
     "clipboard-copy": "^4.0.1",
     "estree-walker": "^3.0.3",
@@ -25,9 +24,8 @@
     "minisearch": "^7.1.0",
     "prettier": "^3.8.3",
     "prettier-plugin-svelte": "^4.1.0",
-    "prism-svelte": "^0.5.0",
-    "prismjs": "^1.30.0",
     "rehype-slug": "^6.0.0",
+    "shiki": "^4.1.0",
     "svelte": "^5.56.3",
     "vite": "^8.0.16"
   },

--- a/docs/scripts/format-component-api.ts
+++ b/docs/scripts/format-component-api.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from "node:url";
 import { format } from "prettier";
 import plugin from "prettier/plugins/typescript";
 import componentApi from "../src/COMPONENT_API.json" with { type: "json" };
+import { extractExampleCode, highlightCode } from "./shiki-highlighter.ts";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const outFile = path.join(__dirname, "../src/COMPONENT_API.json");
@@ -12,6 +13,14 @@ const WHITESPACE_REGEX = /\s{2,}/;
 const TRAILING_SEMICOLON_REGEX = /;\s*$/;
 const EVENT_DETAIL_PREFIX_REGEX = /type EventDetail = /;
 const SLOT_PROPS_PREFIX_REGEX = /type SlotProps = /;
+
+const PRIMITIVE_TYPES = [
+  "string",
+  "boolean",
+  "number",
+  "null",
+  "Date",
+] as const;
 
 /** Avoid `type EventDetail = type EventDetail = …` when re-running the formatter. */
 const stripLeadingTypeAlias = (
@@ -37,35 +46,79 @@ const formatTypeScript = async (value: string) => {
   });
 };
 
+async function highlightTypeScriptFragment(code: string) {
+  if (!code) return "";
+  return await highlightCode(code, "typescript", { fragment: true });
+}
+
+async function highlightSvelteFragment(code: string) {
+  if (!code) return "";
+  return await highlightCode(code, "svelte", { fragment: true });
+}
+
 console.time("formatComponentApi");
+
+const highlightedPrimitives = Object.fromEntries(
+  await Promise.all(
+    PRIMITIVE_TYPES.map(async (type) => {
+      const display = type === "Date" ? "JavaScript Date" : type;
+      return [type, await highlightTypeScriptFragment(display)] as const;
+    }),
+  ),
+);
 
 const modified = {
   ...componentApi,
+  highlightedPrimitives,
   components: await Promise.all(
     componentApi.components.map(async (component) => {
       const props = await Promise.all(
         component.props.map(async (prop) => {
-          if (!prop.value || !WHITESPACE_REGEX.test(prop.value)) {
-            return prop;
+          let nextProp = { ...prop };
+
+          if (prop.value && WHITESPACE_REGEX.test(prop.value)) {
+            let normalizedValue = prop.value;
+            const prefix = `const ${prop.name} = `;
+
+            if (prop.isFunction || prop.value.startsWith("{")) {
+              normalizedValue = prefix + prop.value;
+            }
+
+            const formatted = (await formatTypeScript(normalizedValue))
+              .replace(new RegExp(`^${prefix}`), "")
+              .replace(TRAILING_SEMICOLON_REGEX, "");
+
+            nextProp = { ...nextProp, value: formatted };
           }
 
-          let normalizedValue = prop.value;
-          const prefix = `const ${prop.name} = `;
+          const typeSegments = (prop.type || "").split(" | ").filter(Boolean);
+          const typesHighlighted = await Promise.all(
+            typeSegments.map((type) => {
+              if (type.startsWith("HTML") || type in highlightedPrimitives) {
+                return Promise.resolve("");
+              }
+              return highlightTypeScriptFragment(type);
+            }),
+          );
 
-          if (prop.isFunction || prop.value.startsWith("{")) {
-            normalizedValue = prefix + prop.value;
-          }
+          const exampleCode = prop.description
+            ? extractExampleCode(prop.description)
+            : null;
 
-          const formatted = (await formatTypeScript(normalizedValue))
-            // Remove prefix needed for formatting.
-            .replace(new RegExp(`^${prefix}`), "")
-            // Remove trailing semi-colon.
-            .replace(TRAILING_SEMICOLON_REGEX, "");
-
-          return {
-            ...prop,
-            value: formatted,
+          nextProp = {
+            ...nextProp,
+            typesHighlighted,
+            valueHighlighted:
+              nextProp.value === undefined
+                ? undefined
+                : await highlightTypeScriptFragment(nextProp.value),
+            exampleCode: exampleCode ?? undefined,
+            exampleCodeHighlighted: exampleCode
+              ? await highlightSvelteFragment(exampleCode)
+              : undefined,
           };
+
+          return nextProp;
         }),
       );
 
@@ -75,9 +128,11 @@ const modified = {
             return typedef;
           }
 
+          const ts = await formatTypeScript(typedef.ts);
           return {
             ...typedef,
-            ts: await formatTypeScript(typedef.ts),
+            ts,
+            tsHighlighted: await highlightTypeScriptFragment(ts),
           };
         }),
       );
@@ -100,14 +155,13 @@ const modified = {
           const normalizedValue = `type EventDetail = ${detailBody}`;
 
           const formatted = (await formatTypeScript(normalizedValue))
-            // Remove prefix needed for formatting.
             .replace(EVENT_DETAIL_PREFIX_REGEX, "")
-            // Remove trailing semi-colon.
             .replace(TRAILING_SEMICOLON_REGEX, "");
 
           return {
             ...event,
             detail: formatted,
+            detailHighlighted: await highlightTypeScriptFragment(formatted),
           };
         }),
       );
@@ -128,22 +182,27 @@ const modified = {
           }
 
           const formatted = (await formatTypeScript(normalizedValue))
-            // Remove prefix needed for formatting.
             .replace(SLOT_PROPS_PREFIX_REGEX, "")
-            // Remove trailing semi-colon.
             .replace(TRAILING_SEMICOLON_REGEX, "");
 
           return {
             ...slot,
             slot_props: formatted,
+            slot_propsHighlighted: await highlightTypeScriptFragment(formatted),
           };
         }),
       );
+
+      const typedefTs = typedefs.map((t) => t.ts ?? "").join("\n");
 
       return {
         ...component,
         props,
         typedefs,
+        typedefsHighlighted:
+          typedefTs.length > 0
+            ? await highlightTypeScriptFragment(typedefTs)
+            : undefined,
         events,
         slots,
       };

--- a/docs/scripts/format-component-api.ts
+++ b/docs/scripts/format-component-api.ts
@@ -8,6 +8,8 @@ import { extractExampleCode, highlightCode } from "./shiki-highlighter.ts";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const outFile = path.join(__dirname, "../src/COMPONENT_API.json");
+const componentApiDir = path.join(__dirname, "../src/component-api");
+const componentApiComponentsDir = path.join(componentApiDir, "components");
 
 const WHITESPACE_REGEX = /\s{2,}/;
 const TRAILING_SEMICOLON_REGEX = /;\s*$/;
@@ -211,5 +213,21 @@ const modified = {
 };
 
 fs.writeFileSync(outFile, JSON.stringify(modified, null, 2));
+
+fs.mkdirSync(componentApiComponentsDir, { recursive: true });
+for (const component of modified.components) {
+  fs.writeFileSync(
+    path.join(componentApiComponentsDir, `${component.moduleName}.json`),
+    JSON.stringify(component),
+  );
+}
+fs.writeFileSync(
+  path.join(componentApiDir, "highlighted-primitives.json"),
+  JSON.stringify(highlightedPrimitives),
+);
+fs.writeFileSync(
+  path.join(componentApiDir, "module-names.json"),
+  JSON.stringify(modified.components.map((component) => component.moduleName)),
+);
 
 console.timeEnd("formatComponentApi");

--- a/docs/scripts/shiki-highlighter.ts
+++ b/docs/scripts/shiki-highlighter.ts
@@ -37,6 +37,13 @@ const EMBEDDED_LITERAL_PROPERTY_SCOPES = [
   "meta.objectliteral.js",
 ] as const;
 
+const IMPORT_BINDING_SCOPES = [
+  "meta.import variable.other.readwrite",
+  "meta.import variable.other.readwrite.js",
+  "meta.import variable.other.readwrite.ts",
+  "meta.import variable.other.readwrite.tsx",
+] as const;
+
 const carbonDark = {
   name: CARBON_DARK_THEME,
   colors: {
@@ -83,14 +90,27 @@ const carbonDark = {
       settings: { foreground: "#3ddbd9" },
     },
     {
-      scope: ["entity.name.function", "support.function", "meta.function-call"],
+      scope: [
+        "variable",
+        "variable.other",
+        "variable.other.readwrite",
+        "variable.other.object",
+        "variable.other.constant",
+      ],
+      settings: { foreground: "#f4f4f4" },
+    },
+    {
+      scope: [...IMPORT_BINDING_SCOPES],
+      settings: { foreground: "#d4bbff" },
+    },
+    {
+      scope: ["entity.name.function", "support.function"],
       settings: { foreground: "#9ef0f0" },
     },
     {
       scope: [
         "string.quoted.attribute-value",
         "meta.embedded.line.js",
-        "source.js",
         ...EMBEDDED_LITERAL_PROPERTY_SCOPES,
       ],
       settings: { foreground: "#d4bbff" },
@@ -149,14 +169,27 @@ const carbonLight = {
       settings: { foreground: "#005d5d" },
     },
     {
-      scope: ["entity.name.function", "support.function", "meta.function-call"],
+      scope: [
+        "variable",
+        "variable.other",
+        "variable.other.readwrite",
+        "variable.other.object",
+        "variable.other.constant",
+      ],
+      settings: { foreground: "#161616" },
+    },
+    {
+      scope: [...IMPORT_BINDING_SCOPES],
+      settings: { foreground: "#8a3ffc" },
+    },
+    {
+      scope: ["entity.name.function", "support.function"],
       settings: { foreground: "#007d79" },
     },
     {
       scope: [
         "string.quoted.attribute-value",
         "meta.embedded.line.js",
-        "source.js",
         ...EMBEDDED_LITERAL_PROPERTY_SCOPES,
       ],
       settings: { foreground: "#8a3ffc" },

--- a/docs/scripts/shiki-highlighter.ts
+++ b/docs/scripts/shiki-highlighter.ts
@@ -1,0 +1,261 @@
+import html from "@shikijs/langs/html";
+import javascript from "@shikijs/langs/javascript";
+import svelte from "@shikijs/langs/svelte";
+import typescript from "@shikijs/langs/typescript";
+import type { LanguageRegistration, ThemeRegistration } from "@shikijs/types";
+import { createHighlighterCore, type HighlighterCore } from "shiki/core";
+import { createJavaScriptRegexEngine } from "shiki/engine/javascript";
+
+export const CARBON_LIGHT_THEME = "carbon-light" as const;
+export const CARBON_DARK_THEME = "carbon-dark" as const;
+
+const LANG_ALIASES = {
+  js: "javascript",
+  ts: "typescript",
+  html: "html",
+  svg: "html",
+  markup: "html",
+} as const;
+
+const LITERAL_STRUCTURE_SCOPES = [
+  "meta.brace.square.ts",
+  "meta.brace.curly.ts",
+  "meta.brace.round.ts",
+  "meta.array.literal.ts",
+  "meta.brace.square.js",
+  "meta.brace.curly.js",
+  "meta.brace.round.js",
+  "meta.array.literal.js",
+] as const;
+
+const EMBEDDED_LITERAL_PROPERTY_SCOPES = [
+  "meta.object-literal.key.ts",
+  "meta.object.member.ts",
+  "meta.objectliteral.ts",
+  "meta.object-literal.key.js",
+  "meta.object.member.js",
+  "meta.objectliteral.js",
+] as const;
+
+const carbonDark = {
+  name: CARBON_DARK_THEME,
+  colors: {
+    "editor.background": "#00000000",
+    "editor.foreground": "#f4f4f4",
+  },
+  tokenColors: [
+    {
+      scope: ["comment", "punctuation.definition.comment"],
+      settings: { foreground: "#bebebe" },
+    },
+    { scope: ["string", "string.quoted"], settings: { foreground: "#fa75a6" } },
+    {
+      scope: ["constant.numeric", "constant.language.numeric"],
+      settings: { foreground: "#a7f0ba" },
+    },
+    {
+      scope: [
+        "keyword",
+        "storage.type",
+        "storage.modifier",
+        "constant.language.boolean",
+      ],
+      settings: { foreground: "#bb8eff" },
+    },
+    {
+      scope: [
+        "entity.name.tag",
+        "entity.name.tag.svelte",
+        "keyword.control.svelte",
+        "support.class",
+        "punctuation.definition.tag",
+        "keyword.operator",
+        "punctuation.separator",
+      ],
+      settings: { foreground: "#6ea6ff" },
+    },
+    {
+      scope: [
+        "entity.other.attribute-name",
+        "support.type",
+        "variable.language",
+      ],
+      settings: { foreground: "#3ddbd9" },
+    },
+    {
+      scope: ["entity.name.function", "support.function", "meta.function-call"],
+      settings: { foreground: "#9ef0f0" },
+    },
+    {
+      scope: [
+        "string.quoted.attribute-value",
+        "meta.embedded.line.js",
+        "source.js",
+        ...EMBEDDED_LITERAL_PROPERTY_SCOPES,
+      ],
+      settings: { foreground: "#d4bbff" },
+    },
+    {
+      scope: [...LITERAL_STRUCTURE_SCOPES],
+      settings: { foreground: "#a8a8a8" },
+    },
+    { scope: ["punctuation"], settings: { foreground: "#a8a8a8" } },
+  ],
+} satisfies ThemeRegistration;
+
+const carbonLight = {
+  name: CARBON_LIGHT_THEME,
+  colors: {
+    "editor.background": "#00000000",
+    "editor.foreground": "#161616",
+  },
+  tokenColors: [
+    {
+      scope: ["comment", "punctuation.definition.comment"],
+      settings: { foreground: "#6f6f6f" },
+    },
+    { scope: ["string", "string.quoted"], settings: { foreground: "#9f1853" } },
+    {
+      scope: ["constant.numeric", "constant.language.numeric"],
+      settings: { foreground: "#0e6027" },
+    },
+    {
+      scope: [
+        "keyword",
+        "storage.type",
+        "storage.modifier",
+        "constant.language.boolean",
+      ],
+      settings: { foreground: "#6929c4" },
+    },
+    {
+      scope: [
+        "entity.name.tag",
+        "entity.name.tag.svelte",
+        "keyword.control.svelte",
+        "support.class",
+        "punctuation.definition.tag",
+        "keyword.operator",
+        "punctuation.separator",
+      ],
+      settings: { foreground: "#0043ce" },
+    },
+    {
+      scope: [
+        "entity.other.attribute-name",
+        "support.type",
+        "variable.language",
+      ],
+      settings: { foreground: "#005d5d" },
+    },
+    {
+      scope: ["entity.name.function", "support.function", "meta.function-call"],
+      settings: { foreground: "#007d79" },
+    },
+    {
+      scope: [
+        "string.quoted.attribute-value",
+        "meta.embedded.line.js",
+        "source.js",
+        ...EMBEDDED_LITERAL_PROPERTY_SCOPES,
+      ],
+      settings: { foreground: "#8a3ffc" },
+    },
+    {
+      scope: [...LITERAL_STRUCTURE_SCOPES],
+      settings: { foreground: "#525252" },
+    },
+    { scope: ["punctuation"], settings: { foreground: "#525252" } },
+  ],
+} satisfies ThemeRegistration;
+
+const langs = [
+  ...svelte,
+  ...typescript,
+  ...javascript,
+  ...html,
+] satisfies LanguageRegistration[];
+
+const SHIKI_THEMES = {
+  light: CARBON_LIGHT_THEME,
+  dark: CARBON_DARK_THEME,
+} as const;
+
+const PRE_CODE_RE = /^<pre[^>]*><code[^>]*>([\s\S]*)<\/code><\/pre>$/;
+const SHIKI_FRAGMENT_CLASS =
+  `shiki shiki-themes ${CARBON_LIGHT_THEME} ${CARBON_DARK_THEME}` as const;
+
+const EXAMPLE_CODE_BLOCK_REGEX = /```svelte\s*\n([\s\S]*?)```/;
+
+let highlighterPromise: Promise<HighlighterCore> | null = null;
+
+export function getHighlighter(): Promise<HighlighterCore> {
+  highlighterPromise ??= createHighlighterCore({
+    themes: [carbonDark, carbonLight],
+    langs,
+    engine: createJavaScriptRegexEngine(),
+  });
+  return highlighterPromise;
+}
+
+export function normalizeLang(lang: string | null | undefined): string {
+  const raw = lang?.toLowerCase().trim() ?? "";
+  if (!raw) return "text";
+  return LANG_ALIASES[raw as keyof typeof LANG_ALIASES] ?? raw;
+}
+
+function escapeHtmlText(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+export function stripPreCodeWrapper(html: string): string {
+  const match = html.match(PRE_CODE_RE);
+  return match ? match[1] : html;
+}
+
+export function wrapShikiFragment(innerHtml: string): string {
+  return `<span class="${SHIKI_FRAGMENT_CLASS}">${innerHtml}</span>`;
+}
+
+export async function highlightCode(
+  code: string,
+  lang: string | null | undefined,
+  options: { fragment?: boolean } = {},
+): Promise<string> {
+  const normalized = normalizeLang(lang);
+  if (normalized === "text" || !code) {
+    return options.fragment
+      ? escapeHtmlText(code)
+      : `<pre><code>${escapeHtmlText(code)}</code></pre>`;
+  }
+
+  const highlighter = await getHighlighter();
+  if (!highlighter.getLoadedLanguages().includes(normalized)) {
+    const escaped = escapeHtmlText(code);
+    return options.fragment ? escaped : `<pre><code>${escaped}</code></pre>`;
+  }
+
+  const htmlOutput = highlighter.codeToHtml(code, {
+    lang: normalized,
+    themes: SHIKI_THEMES,
+    defaultColor: false,
+  });
+
+  if (options.fragment) {
+    return wrapShikiFragment(stripPreCodeWrapper(htmlOutput));
+  }
+
+  return htmlOutput;
+}
+
+export function extractExampleCode(description: string): string | null {
+  const exampleIndex = description.indexOf("@example");
+  if (exampleIndex === -1) return null;
+  const exampleSection = description.slice(exampleIndex);
+  const match = exampleSection.match(EXAMPLE_CODE_BLOCK_REGEX);
+  return match ? match[1].trim() : null;
+}

--- a/docs/src/component-api/types.ts
+++ b/docs/src/component-api/types.ts
@@ -1,0 +1,50 @@
+export type ComponentApiProp = {
+  name: string;
+  description?: string;
+  type?: string;
+  typesHighlighted?: string[];
+  value?: string;
+  valueHighlighted?: string;
+  exampleCode?: string;
+  exampleCodeHighlighted?: string;
+  isRequired?: boolean;
+  reactive?: boolean;
+};
+
+export type ComponentApiTypedef = {
+  ts?: string;
+  tsHighlighted?: string;
+};
+
+export type ComponentApiSlot = {
+  default?: boolean;
+  name?: string | null;
+  slot_props?: string;
+  slot_propsHighlighted?: string;
+};
+
+export type ComponentApiEvent = {
+  type?: string;
+  name?: string;
+  detail?: string;
+  detailHighlighted?: string;
+  description?: string;
+};
+
+export type ComponentApiRestProps = {
+  type: string;
+  name: string;
+};
+
+export type ComponentApiEntry = {
+  moduleName: string;
+  filePath: string;
+  props: ComponentApiProp[];
+  slots: ComponentApiSlot[];
+  events: ComponentApiEvent[];
+  typedefs: ComponentApiTypedef[];
+  typedefsHighlighted?: string;
+  rest_props?: ComponentApiRestProps;
+};
+
+export type HighlightedPrimitives = Record<string, string>;

--- a/docs/src/components/ComponentApi.svelte
+++ b/docs/src/components/ComponentApi.svelte
@@ -3,25 +3,32 @@
     name: string;
     description?: string;
     type?: string;
+    typesHighlighted?: string[];
     value?: string;
+    valueHighlighted?: string;
+    exampleCode?: string;
+    exampleCodeHighlighted?: string;
     isRequired?: boolean;
     reactive?: boolean;
   };
 
   type ComponentApiTypedef = {
     ts?: string;
+    tsHighlighted?: string;
   };
 
   type ComponentApiSlot = {
     default?: boolean;
     name?: string | null;
     slot_props?: string;
+    slot_propsHighlighted?: string;
   };
 
   type ComponentApiEvent = {
     type?: string;
     name?: string;
     detail?: string;
+    detailHighlighted?: string;
     description?: string;
   };
 
@@ -37,6 +44,7 @@
     slots: ComponentApiSlot[];
     events: ComponentApiEvent[];
     typedefs: ComponentApiTypedef[];
+    typedefsHighlighted?: string;
     rest_props?: ComponentApiRestProps;
   };
 
@@ -50,6 +58,8 @@
     rest_props: undefined,
   };
 
+  export let highlightedPrimitives: Record<string, string> = {};
+
   import {
     ListItem,
     OutboundLink,
@@ -61,17 +71,8 @@
     Tag,
     UnorderedList,
   } from "carbon-components-svelte";
-  import { onMount } from "svelte";
+  import HighlightedCodeSnippet from "./HighlightedCodeSnippet.svelte";
   import InlineSnippet from "./InlineSnippet.svelte";
-
-  let AsyncPreviewTypeScript:
-    | typeof import("./PreviewTypeScript.svelte").default
-    | undefined;
-
-  onMount(async () => {
-    AsyncPreviewTypeScript = (await import("./PreviewTypeScript.svelte"))
-      .default;
-  });
 
   const mdn_api = "https://developer.mozilla.org/en-US/docs/Web/API/";
   const typeMap: Record<string, string> = {
@@ -82,29 +83,20 @@
     Date: "JavaScript Date",
   };
 
-  // Regex to extract code blocks from @example annotations
-  // Pattern: ```svelte\n...code...\n``` or ```svelte\n...code...```
-  // The regex uses [\s\S]*? to match any character including newlines (non-greedy)
-  const EXAMPLE_CODE_BLOCK_REGEX = /```svelte\s*\n([\s\S]*?)```/;
-
   function parseDescription(description: string) {
     if (!description) {
-      return { mainDescription: "", exampleCode: null };
+      return { mainDescription: "", hasExample: false };
     }
 
     const exampleIndex = description.indexOf("@example");
     if (exampleIndex === -1) {
-      return { mainDescription: description, exampleCode: null };
+      return { mainDescription: description, hasExample: false };
     }
 
-    const mainDescription = description.slice(0, exampleIndex).trim();
-    const exampleSection = description.slice(exampleIndex);
-
-    // Extract code block from example section
-    const codeBlockMatch = exampleSection.match(EXAMPLE_CODE_BLOCK_REGEX);
-    const exampleCode = codeBlockMatch ? codeBlockMatch[1].trim() : null;
-
-    return { mainDescription, exampleCode };
+    return {
+      mainDescription: description.slice(0, exampleIndex).trim(),
+      hasExample: true,
+    };
   }
 
   $: source = `https://github.com/carbon-design-system/carbon-components-svelte/tree/master/${component.filePath}`;
@@ -180,25 +172,25 @@
                     >
                       {type}
                     </OutboundLink>
-                  {:else if type in typeMap}
+                  {:else if type in typeMap && highlightedPrimitives[type]}
                     <div
                       style="display: inline-flex; max-width: 220px; white-space: nowrap;"
                     >
-                      <svelte:component
-                        this={AsyncPreviewTypeScript}
+                      <HighlightedCodeSnippet
                         type="inline"
                         code={typeMap[type] ?? type}
+                        highlighted={highlightedPrimitives[type]}
                         portalTooltip
                       />
                     </div>
-                  {:else}
+                  {:else if prop.typesHighlighted?.[i]}
                     <div
                       style="display: inline-flex; max-width: 220px; word-break: break-word;"
                     >
-                      <svelte:component
-                        this={AsyncPreviewTypeScript}
+                      <HighlightedCodeSnippet
                         type="inline"
                         code={type}
+                        highlighted={prop.typesHighlighted[i]}
                         portalTooltip
                       />
                     </div>
@@ -222,7 +214,7 @@
                       })}
                   </div>
                 {/if}
-                {#if parsed.exampleCode}
+                {#if prop.exampleCode && prop.exampleCodeHighlighted}
                   <div
                     style:margin-top="var(--cds-layout-02)"
                     style:margin-bottom="var(--cds-spacing-03)"
@@ -233,10 +225,10 @@
                     style:margin-bottom="var(--cds-layout-02)"
                     style:max-width="85%"
                   >
-                    <svelte:component
-                      this={AsyncPreviewTypeScript}
+                    <HighlightedCodeSnippet
                       type="multi"
-                      code={parsed.exampleCode}
+                      code={prop.exampleCode}
+                      highlighted={prop.exampleCodeHighlighted}
                       portalTooltip
                     />
                   </div>
@@ -254,11 +246,11 @@
               >
                 {#if prop.value === undefined}
                   <em>undefined</em>
-                {:else}
-                  <svelte:component
-                    this={AsyncPreviewTypeScript}
+                {:else if prop.valueHighlighted}
+                  <HighlightedCodeSnippet
                     type={/\n/.test(prop.value ?? "") ? "multi" : "inline"}
                     code={prop.value ?? ""}
+                    highlighted={prop.valueHighlighted}
                     portalTooltip
                   />
                 {/if}
@@ -275,11 +267,11 @@
 
 <h2 id="typedefs">Typedefs</h2>
 
-{#if component.typedefs.length > 0}
+{#if component.typedefs.length > 0 && component.typedefsHighlighted}
   <div class="my-layout-01-03">
-    <svelte:component
-      this={AsyncPreviewTypeScript}
+    <HighlightedCodeSnippet
       code={component.typedefs.map((t) => t.ts ?? "").join("\n")}
+      highlighted={component.typedefsHighlighted}
     />
   </div>
 {:else}
@@ -302,12 +294,14 @@
             <strong>{slot.default ? "default" : slot.name}</strong>
           </StructuredListCell>
           <StructuredListCell>
-            <svelte:component
-              this={AsyncPreviewTypeScript}
-              type={/\n/.test(slot.slot_props ?? "") ? "multi" : "inline"}
-              code={slot.slot_props ?? ""}
-              portalTooltip
-            />
+            {#if slot.slot_props && slot.slot_propsHighlighted}
+              <HighlightedCodeSnippet
+                type={/\n/.test(slot.slot_props ?? "") ? "multi" : "inline"}
+                code={slot.slot_props ?? ""}
+                highlighted={slot.slot_propsHighlighted}
+                portalTooltip
+              />
+            {/if}
           </StructuredListCell>
         </StructuredListRow>
       {/each}
@@ -349,12 +343,16 @@
             <strong>on:{dispatched_event.name}</strong>
           </StructuredListCell>
           <StructuredListCell>
-            <svelte:component
-              this={AsyncPreviewTypeScript}
-              type={/\n/.test(dispatched_event.detail ?? "") ? "multi" : "inline"}
-              code={dispatched_event.detail ?? ""}
-              portalTooltip
-            />
+            {#if dispatched_event.detailHighlighted}
+              <HighlightedCodeSnippet
+                type={/\n/.test(dispatched_event.detail ?? "")
+                  ? "multi"
+                  : "inline"}
+                code={dispatched_event.detail ?? ""}
+                highlighted={dispatched_event.detailHighlighted}
+                portalTooltip
+              />
+            {/if}
           </StructuredListCell>
           <StructuredListCell>
             {dispatched_event.description ?? ""}

--- a/docs/src/components/HighlightedCodeSnippet.svelte
+++ b/docs/src/components/HighlightedCodeSnippet.svelte
@@ -1,29 +1,20 @@
 <script lang="ts">
   export let code = "";
-  export let type = "multi";
+  export let highlighted = "";
+  export let type: "multi" | "inline" = "multi";
   export let portalTooltip: boolean | undefined = undefined;
 
   import { CodeSnippet } from "carbon-components-svelte";
-  import Prism, { highlight } from "prismjs";
-  import "prismjs/components/prism-typescript";
   import copy from "clipboard-copy";
-
-  $: highlightedCode = highlight(
-    code,
-    Prism.languages.typescript,
-    "typescript",
-  );
 </script>
 
 {#if type === "multi"}
   <div class="code-override">
     <CodeSnippet type="multi" {code} {copy} {portalTooltip}>
-      {@html highlightedCode}
+      {@html highlighted}
     </CodeSnippet>
   </div>
-{/if}
-
-{#if type === "inline"}
+{:else}
   <CodeSnippet
     type="inline"
     class="code-override-inline"
@@ -31,6 +22,6 @@
     {copy}
     {portalTooltip}
   >
-    {@html highlightedCode}
+    {@html highlighted}
   </CodeSnippet>
 {/if}

--- a/docs/src/components/Preview.svelte
+++ b/docs/src/components/Preview.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  export let codeId = "";
   export let codeRaw = "";
+  export let codeHighlighted = "";
   export let src = "";
   export let framed = false;
 
@@ -8,38 +8,13 @@
   import { Button, CodeSnippet } from "carbon-components-svelte";
   import Launch from "carbon-icons-svelte/lib/Launch.svelte";
   import copy from "clipboard-copy";
-  import { onMount } from "svelte";
   import { theme } from "../store";
-
-  let highlightedHtml = "";
-  let previewEl: HTMLDivElement | undefined;
 
   $: resolvedSrc = src ? $url(src) : "";
   $: themedSrcUrl = resolvedSrc ? `${resolvedSrc}?theme=${$theme}` : "";
-
-  onMount(() => {
-    if (!codeId || !previewEl) return;
-
-    const observer = new IntersectionObserver(
-      (entries) => {
-        const entry = entries[0];
-        if (!entry?.isIntersecting || highlightedHtml) return;
-
-        observer.disconnect();
-        void import(`../preview-snippets/${codeId}.json`).then((module) => {
-          highlightedHtml = module.default.html;
-        });
-      },
-      { rootMargin: "200px" },
-    );
-
-    observer.observe(previewEl);
-
-    return () => observer.disconnect();
-  });
 </script>
 
-<div class="preview" bind:this={previewEl}>
+<div class="preview">
   {#if framed}
     <div class="framed-header">
       <div
@@ -74,11 +49,7 @@
   </div>
   <div class="code-override">
     <CodeSnippet type="multi" code={codeRaw} copy={(text) => copy(text)}>
-      {#if highlightedHtml}
-        {@html highlightedHtml}
-      {:else}
-        <pre class="language-svelte"><code>{codeRaw}</code></pre>
-      {/if}
+      {@html codeHighlighted}
     </CodeSnippet>
   </div>
 </div>

--- a/docs/src/components/Preview.svelte
+++ b/docs/src/components/Preview.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  export let code = "";
+  export let codeId = "";
   export let codeRaw = "";
   export let src = "";
   export let framed = false;
@@ -8,13 +8,38 @@
   import { Button, CodeSnippet } from "carbon-components-svelte";
   import Launch from "carbon-icons-svelte/lib/Launch.svelte";
   import copy from "clipboard-copy";
+  import { onMount } from "svelte";
   import { theme } from "../store";
+
+  let highlightedHtml = "";
+  let previewEl: HTMLDivElement | undefined;
 
   $: resolvedSrc = src ? $url(src) : "";
   $: themedSrcUrl = resolvedSrc ? `${resolvedSrc}?theme=${$theme}` : "";
+
+  onMount(() => {
+    if (!codeId || !previewEl) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const entry = entries[0];
+        if (!entry?.isIntersecting || highlightedHtml) return;
+
+        observer.disconnect();
+        void import(`../preview-snippets/${codeId}.json`).then((module) => {
+          highlightedHtml = module.default.html;
+        });
+      },
+      { rootMargin: "200px" },
+    );
+
+    observer.observe(previewEl);
+
+    return () => observer.disconnect();
+  });
 </script>
 
-<div class="preview">
+<div class="preview" bind:this={previewEl}>
   {#if framed}
     <div class="framed-header">
       <div
@@ -49,7 +74,11 @@
   </div>
   <div class="code-override">
     <CodeSnippet type="multi" code={codeRaw} copy={(text) => copy(text)}>
-      {@html code}
+      {#if highlightedHtml}
+        {@html highlightedHtml}
+      {:else}
+        <pre class="language-svelte"><code>{codeRaw}</code></pre>
+      {/if}
     </CodeSnippet>
   </div>
 </div>

--- a/docs/src/global.css
+++ b/docs/src/global.css
@@ -3,6 +3,7 @@ html {
 }
 
 .prose > pre,
+.prose > pre.shiki,
 .code-override .bx--snippet {
   color-scheme: dark;
   max-width: none;
@@ -11,12 +12,15 @@ html {
 /* Light themes use light color scheme */
 [theme="white"] .prose > pre,
 [theme="g10"] .prose > pre,
+[theme="white"] .prose > pre.shiki,
+[theme="g10"] .prose > pre.shiki,
 [theme="white"] .code-override .bx--snippet,
 [theme="g10"] .code-override .bx--snippet {
   color-scheme: light;
 }
 
-.prose > pre {
+.prose > pre,
+.prose > pre.shiki {
   padding: 1rem;
   margin-bottom: 1rem;
   overflow: auto;
@@ -29,6 +33,7 @@ html {
 
 /* Dark theme code block styles (default for g80, g90, g100) */
 .prose > pre,
+.prose > pre.shiki,
 .code-override .bx--copy-btn,
 .code-override .bx--snippet,
 .code-override button.bx--btn.bx--snippet-btn--expand {
@@ -48,6 +53,8 @@ html {
 /* Light theme code block styles (white, g10) */
 [theme="white"] .prose > pre,
 [theme="g10"] .prose > pre,
+[theme="white"] .prose > pre.shiki,
+[theme="g10"] .prose > pre.shiki,
 [theme="white"] .code-override .bx--copy-btn,
 [theme="g10"] .code-override .bx--copy-btn,
 [theme="white"] .code-override .bx--snippet,
@@ -71,6 +78,7 @@ html {
 }
 
 .prose > pre,
+.prose > pre.shiki,
 .code-override .bx--snippet-container pre {
   font-size: var(--cds-code-01-font-size);
   line-height: var(--cds-code-01-line-height);
@@ -87,9 +95,38 @@ html {
   min-width: 0;
 }
 
-.token.tag,
-.token.operator {
-  color: #6ea6ff;
+/* Shiki dual-theme syntax highlighting (Carbon palette) */
+[theme="white"] .shiki span,
+[theme="g10"] .shiki span {
+  color: var(--shiki-light) !important;
+  background-color: var(--shiki-light-bg) !important;
+  font-style: var(--shiki-light-font-style) !important;
+  font-weight: var(--shiki-light-font-weight) !important;
+  text-decoration: var(--shiki-light-text-decoration) !important;
+}
+
+[theme="g80"] .shiki span,
+[theme="g90"] .shiki span,
+[theme="g100"] .shiki span,
+html:not([theme="white"]):not([theme="g10"]) .shiki span {
+  color: var(--shiki-dark) !important;
+  background-color: var(--shiki-dark-bg) !important;
+  font-style: var(--shiki-dark-font-style) !important;
+  font-weight: var(--shiki-dark-font-weight) !important;
+  text-decoration: var(--shiki-dark-text-decoration) !important;
+}
+
+.shiki {
+  background-color: transparent !important;
+}
+
+.prose > pre.shiki {
+  background-color: var(--cds-ui-background);
+}
+
+[theme="white"] .prose > pre.shiki,
+[theme="g10"] .prose > pre.shiki {
+  background-color: var(--cds-ui-background);
 }
 
 /* Light theme inline code background */
@@ -102,110 +139,6 @@ html {
 [theme="g80"] .code-override,
 [theme="g80"] .code-override-inline {
   background-color: var(--cds-ui-background);
-}
-
-.token.builtin,
-.token.attr-name {
-  color: #3ddbd9; /* teal 30 */
-}
-
-.token.function {
-  color: #9ef0f0;
-}
-
-.token.token.language-javascript,
-.token.attr-value {
-  color: #d4bbff; /* purple 30 */
-}
-
-.token.keyword {
-  color: #bb8eff;
-}
-
-.token.punctuation {
-  color: #a8a8a8; /* gray 40 */
-}
-
-.token.script .token.language-javascript {
-  color: #3ddbd9; /* teal 30 */
-}
-
-.token.string {
-  color: #fa75a6;
-}
-
-.token.boolean {
-  color: #bb8eff;
-}
-
-.token.number {
-  color: #a7f0ba;
-}
-
-.token.comment {
-  color: #bebebe;
-}
-
-/* Light theme syntax highlighting (white, g10) */
-[theme="white"] .token.tag,
-[theme="g10"] .token.tag,
-[theme="white"] .token.operator,
-[theme="g10"] .token.operator {
-  color: #0043ce; /* blue 70 */
-}
-
-[theme="white"] .token.builtin,
-[theme="g10"] .token.builtin,
-[theme="white"] .token.attr-name,
-[theme="g10"] .token.attr-name {
-  color: #005d5d; /* teal 70 */
-}
-
-[theme="white"] .token.function,
-[theme="g10"] .token.function {
-  color: #007d79; /* teal 60 */
-}
-
-[theme="white"] .token.token.language-javascript,
-[theme="g10"] .token.token.language-javascript,
-[theme="white"] .token.attr-value,
-[theme="g10"] .token.attr-value {
-  color: #8a3ffc; /* purple 60 */
-}
-
-[theme="white"] .token.keyword,
-[theme="g10"] .token.keyword {
-  color: #6929c4; /* purple 70 */
-}
-
-[theme="white"] .token.punctuation,
-[theme="g10"] .token.punctuation {
-  color: #525252; /* gray 70 */
-}
-
-[theme="white"] .token.script .token.language-javascript,
-[theme="g10"] .token.script .token.language-javascript {
-  color: #005d5d; /* teal 70 */
-}
-
-[theme="white"] .token.string,
-[theme="g10"] .token.string {
-  color: #9f1853; /* magenta 70 */
-}
-
-[theme="white"] .token.boolean,
-[theme="g10"] .token.boolean {
-  color: #6929c4; /* purple 70 */
-}
-
-[theme="white"] .token.number,
-[theme="g10"] .token.number {
-  color: #0e6027; /* green 70 */
-}
-
-[theme="white"] .token.comment,
-[theme="g10"] .token.comment {
-  color: #6f6f6f; /* gray 60 */
 }
 
 .override-tabs a.bx--tabs__nav-link,

--- a/docs/src/layouts/ComponentLayout.svelte
+++ b/docs/src/layouts/ComponentLayout.svelte
@@ -27,12 +27,12 @@
   import Document from "carbon-icons-svelte/lib/Document.svelte";
   import OverflowMenuVertical from "carbon-icons-svelte/lib/OverflowMenuVertical.svelte";
   import { onMount } from "svelte";
-  import COMPONENT_API from "../COMPONENT_API.json";
   import COMPONENT_MD_SIZES_JSON from "../COMPONENT_MD_SIZES.json";
-  import ComponentApi from "../components/ComponentApi.svelte";
+  import type {
+    ComponentApiEntry,
+    HighlightedPrimitives,
+  } from "../component-api/types";
   import { theme } from "../store";
-
-  type DocComponent = (typeof COMPONENT_API.components)[number];
 
   const COMPONENT_MD_SIZES: Record<string, number> = COMPONENT_MD_SIZES_JSON;
 
@@ -78,14 +78,56 @@
   export let component = $activeRoute?.leaf?.node?.name ?? "";
   export let components = [component];
 
-  const componentMap = new Map(
-    COMPONENT_API.components.map((c) => [c.moduleName, c]),
-  );
+  type ComponentApiComponent =
+    typeof import("../components/ComponentApi.svelte").default;
 
-  $: api_components = components
-    .map((i) => componentMap.get(i))
-    .filter((c): c is DocComponent => c != null);
+  function loadComponentApiEntry(
+    moduleName: string,
+  ): Promise<ComponentApiEntry> {
+    return import(
+      `../component-api/components/${moduleName}.json`
+    ) as Promise<ComponentApiEntry>;
+  }
+
+  let AsyncComponentApi: ComponentApiComponent | undefined;
+  let highlightedPrimitives: HighlightedPrimitives = {};
+  let api_components: ComponentApiEntry[] = [];
+  let apiLoading = true;
+  let apiRequestId = 0;
+
   $: multiple = api_components.length > 1;
+
+  async function loadApiDocs(moduleNames: string[]) {
+    const requestId = ++apiRequestId;
+    apiLoading = true;
+
+    try {
+      const [componentApiModule, primitivesModule, ...entries] =
+        await Promise.all([
+          AsyncComponentApi
+            ? Promise.resolve(AsyncComponentApi)
+            : import("../components/ComponentApi.svelte").then(
+                (module) => module.default,
+              ),
+          import("../component-api/highlighted-primitives.json").then(
+            (module) => module.default,
+          ),
+          ...moduleNames.map((moduleName) => loadComponentApiEntry(moduleName)),
+        ]);
+
+      if (requestId !== apiRequestId) return;
+
+      AsyncComponentApi = componentApiModule;
+      highlightedPrimitives = primitivesModule;
+      api_components = entries;
+    } finally {
+      if (requestId === apiRequestId) {
+        apiLoading = false;
+      }
+    }
+  }
+
+  $: loadApiDocs(components);
 
   onMount(() => {
     const searchParams = new URLSearchParams(window.location.search);
@@ -102,10 +144,10 @@
     };
   });
 
-  function formatSourceURL(multiple: boolean) {
+  function formatSourceURL(multipleComponents: boolean) {
     const filePath = api_components[0]?.filePath ?? "";
 
-    if (multiple) {
+    if (multipleComponents) {
       /**
        * Link to folder for doc with multiple components.
        * @example "src/Breadcrumb"
@@ -243,27 +285,33 @@
 
     <Row>
       <Column class="prose" noGutter={multiple}>
-        {#if multiple}
-          <Tabs class="override-tabs">
-            {#each api_components as component (component.moduleName)}
-              <Tab label={component.moduleName} />
-            {/each}
-            <div slot="content" class="tab-content-spacing">
-              {#each api_components as component (component.moduleName)}
-                <TabContent
-                  ><ComponentApi
-                    {component}
-                    highlightedPrimitives={COMPONENT_API.highlightedPrimitives ?? {}}
-                  /></TabContent
-                >
+        {#if apiLoading}
+          <p class="api-loading">Loading component API…</p>
+        {:else if AsyncComponentApi && api_components.length > 0}
+          {#if multiple}
+            <Tabs class="override-tabs">
+              {#each api_components as apiComponent (apiComponent.moduleName)}
+                <Tab label={apiComponent.moduleName} />
               {/each}
-            </div>
-          </Tabs>
-        {:else}
-          <ComponentApi
-            component={api_components[0]}
-            highlightedPrimitives={COMPONENT_API.highlightedPrimitives ?? {}}
-          />
+              <div slot="content" class="tab-content-spacing">
+                {#each api_components as apiComponent (apiComponent.moduleName)}
+                  <TabContent>
+                    <svelte:component
+                      this={AsyncComponentApi}
+                      component={apiComponent}
+                      {highlightedPrimitives}
+                    />
+                  </TabContent>
+                {/each}
+              </div>
+            </Tabs>
+          {:else}
+            <svelte:component
+              this={AsyncComponentApi}
+              component={api_components[0]}
+              {highlightedPrimitives}
+            />
+          {/if}
         {/if}
       </Column>
     </Row>
@@ -296,6 +344,12 @@
   .bar :global(.copy-markdown-btn .bx--assistive-text) {
     white-space: pre-line;
     text-align: center;
+  }
+
+  .api-loading {
+    margin-top: var(--cds-layout-01);
+    margin-bottom: var(--cds-layout-03);
+    color: var(--cds-text-02);
   }
 
   :global(.toc h5) {

--- a/docs/src/layouts/ComponentLayout.svelte
+++ b/docs/src/layouts/ComponentLayout.svelte
@@ -250,12 +250,20 @@
             {/each}
             <div slot="content" class="tab-content-spacing">
               {#each api_components as component (component.moduleName)}
-                <TabContent><ComponentApi {component} /></TabContent>
+                <TabContent
+                  ><ComponentApi
+                    {component}
+                    highlightedPrimitives={COMPONENT_API.highlightedPrimitives ?? {}}
+                  /></TabContent
+                >
               {/each}
             </div>
           </Tabs>
         {:else}
-          <ComponentApi component={api_components[0]} />
+          <ComponentApi
+            component={api_components[0]}
+            highlightedPrimitives={COMPONENT_API.highlightedPrimitives ?? {}}
+          />
         {/if}
       </Column>
     </Row>

--- a/docs/src/pages/components/Theme.svx
+++ b/docs/src/pages/components/Theme.svx
@@ -11,7 +11,7 @@ The component can persist theme preferences using [window.localStorage](https://
 
 You must use the `all.css` StyleSheet for dynamic theming, which uses [CSS variables](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties).
 
-```css
+```js
 import "carbon-components-svelte/css/all.css";
 ```
 

--- a/docs/src/pages/components/UIShell.svx
+++ b/docs/src/pages/components/UIShell.svx
@@ -121,7 +121,7 @@ Set `theme="classic"` on both `Header` and `SideNav` for the classic look: **Gra
 > [!NOTE]
 > The classic theme requires **carbon-components-svelte/css/all.css** because it uses CSS custom properties.
 
-```css
+```js
 import "carbon-components-svelte/css/all.css";
 ```
 

--- a/docs/svelte.config.ts
+++ b/docs/svelte.config.ts
@@ -7,17 +7,11 @@ import type { Blockquote, List, Paragraph, PhrasingContent } from "mdast";
 import { escapeSvelte, mdsvex } from "mdsvex";
 import { format } from "prettier";
 import prettierPluginSvelte from "prettier-plugin-svelte";
-import Prism from "prismjs";
 import rehypeSlug from "rehype-slug";
 import { parse } from "svelte/compiler";
 import visit from "unist-util-visit";
+import { highlightCode, normalizeLang } from "./scripts/shiki-highlighter.ts";
 import componentApi from "./src/COMPONENT_API.json" with { type: "json" };
-import "prismjs/components/prism-markup.js";
-import "prismjs/components/prism-css.js";
-import "prismjs/components/prism-clike.js";
-import "prismjs/components/prism-javascript.js";
-import "prismjs/components/prism-typescript.js";
-import "prism-svelte";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -43,13 +37,6 @@ const SNIPPET_ICON_MUSTACHE_RE = /\{\s*[A-Z][A-Za-z0-9]*\s*[},]/;
 const SNIPPET_TAG_RE = /<[a-zA-Z]/;
 const SNIPPET_MUSTACHE_ANY_RE = /\{/;
 
-const MDSVEX_LANG_ALIASES = {
-  js: "javascript",
-  ts: "typescript",
-  html: "markup",
-  svg: "markup",
-} as const;
-
 const SKIP_MDSVEX_PRETTIER = process.env.NODE_ENV === "development";
 
 const previewCodeCache = new Map<
@@ -70,32 +57,24 @@ function escapeHtmlText(str: string): string {
     .replace(/"/g, "&quot;");
 }
 
-function mdsvexPrismHighlighter(
+async function mdsvexShikiHighlighter(
   code: string,
   lang: string | null | undefined,
   _meta: string | null | undefined,
   _filename?: string,
   optimize = true,
-): string {
-  const raw = lang?.toLowerCase().trim() ?? "";
-  const classLang = raw || "text";
+): Promise<string> {
+  const classLang = lang?.toLowerCase().trim() || "text";
+  const normalized = normalizeLang(lang);
 
-  const grammarKey = raw
-    ? (MDSVEX_LANG_ALIASES[raw as keyof typeof MDSVEX_LANG_ALIASES] ?? raw)
-    : "";
-  const grammar =
-    grammarKey && Prism.languages[grammarKey as keyof typeof Prism.languages]
-      ? Prism.languages[grammarKey as keyof typeof Prism.languages]
-      : null;
+  const html =
+    normalized === "text"
+      ? `<pre class="language-${classLang}"><code>${escapeHtmlText(code)}</code></pre>`
+      : await highlightCode(code, lang);
 
-  const inner = grammar
-    ? Prism.highlight(code, grammar, grammarKey)
-    : escapeHtmlText(code);
-  const highlighted = escapeSvelte(inner);
+  if (!optimize) return html;
 
-  return optimize
-    ? `<pre class="language-${classLang}">{@html \`<code class="language-${classLang}">${highlighted}</code>\`}</pre>`
-    : `<pre class="language-${classLang}"><code class="language-${classLang}">${highlighted}</code></pre>`;
+  return `{@html \`${escapeSvelte(html)}\`}`;
 }
 
 const prettierSvelte = {
@@ -207,11 +186,9 @@ async function formatAndHighlightPreviewSvelte(combinedSource: string) {
   const formattedCode = SKIP_MDSVEX_PRETTIER
     ? combinedSource
     : await format(combinedSource, prettierSvelte);
-  const highlightedCode = Prism.highlight(
-    formattedCode,
-    Prism.languages.svelte,
-    "svelte",
-  );
+  const highlightedCode = await highlightCode(formattedCode, "svelte", {
+    fragment: true,
+  });
   const out = { formattedCode, highlightedCode };
   previewCodeCache.set(cacheKey, out);
   return out;
@@ -230,11 +207,9 @@ async function formatAndHighlightFileSourceSvelte(
   const formattedCode = SKIP_MDSVEX_PRETTIER
     ? sourceCode
     : await format(sourceCode, prettierSvelte);
-  const highlightedCode = Prism.highlight(
-    formattedCode,
-    Prism.languages.svelte,
-    "svelte",
-  );
+  const highlightedCode = await highlightCode(formattedCode, "svelte", {
+    fragment: true,
+  });
   const out = { formattedCode, highlightedCode };
   previewCodeCache.set(cacheKey, out);
   return out;
@@ -445,7 +420,7 @@ export default {
   preprocess: [
     mdsvex({
       smartypants: false,
-      highlight: { highlighter: mdsvexPrismHighlighter },
+      highlight: { highlighter: mdsvexShikiHighlighter },
       remarkPlugins: [plugin, carbonify],
       rehypePlugins: [rehypeSlug],
       layout: {

--- a/docs/svelte.config.ts
+++ b/docs/svelte.config.ts
@@ -11,13 +11,13 @@ import rehypeSlug from "rehype-slug";
 import { parse } from "svelte/compiler";
 import visit from "unist-util-visit";
 import { highlightCode, normalizeLang } from "./scripts/shiki-highlighter.ts";
-import componentApi from "./src/COMPONENT_API.json" with { type: "json" };
+import componentApi from "./src/component-api/module-names.json" with {
+  type: "json",
+};
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-const componentApiByName = new Set(
-  componentApi.components.map((c) => c.moduleName),
-);
+const componentApiByName = new Set(componentApi);
 
 const ICON_NAME_REGEX = /[A-Z][a-z]*/;
 const NODE_MODULES_REGEX = /node_modules/;
@@ -39,14 +39,27 @@ const SNIPPET_MUSTACHE_ANY_RE = /\{/;
 
 const SKIP_MDSVEX_PRETTIER = process.env.NODE_ENV === "development";
 
+const PREVIEW_SNIPPETS_DIR = path.join(__dirname, "src/preview-snippets");
+
 const previewCodeCache = new Map<
   string,
-  { formattedCode: string; highlightedCode: string }
+  { formattedCode: string; codeId: string }
 >();
 const createImportsCache = new Map<string, string>();
 
 function hashKey(s: string): string {
   return createHash("sha256").update(s, "utf8").digest("hex").slice(0, 32);
+}
+
+function writePreviewSnippet(codeId: string, highlightedCode: string) {
+  fs.mkdirSync(PREVIEW_SNIPPETS_DIR, { recursive: true });
+  const filePath = path.join(PREVIEW_SNIPPETS_DIR, `${codeId}.json`);
+
+  fs.writeFileSync(
+    filePath,
+    JSON.stringify({ html: highlightedCode }),
+    "utf-8",
+  );
 }
 
 function escapeHtmlText(str: string): string {
@@ -189,7 +202,9 @@ async function formatAndHighlightPreviewSvelte(combinedSource: string) {
   const highlightedCode = await highlightCode(formattedCode, "svelte", {
     fragment: true,
   });
-  const out = { formattedCode, highlightedCode };
+  const codeId = hashKey(formattedCode);
+  writePreviewSnippet(codeId, highlightedCode);
+  const out = { formattedCode, codeId };
   previewCodeCache.set(cacheKey, out);
   return out;
 }
@@ -210,7 +225,9 @@ async function formatAndHighlightFileSourceSvelte(
   const highlightedCode = await highlightCode(formattedCode, "svelte", {
     fragment: true,
   });
-  const out = { formattedCode, highlightedCode };
+  const codeId = hashKey(formattedCode);
+  writePreviewSnippet(codeId, highlightedCode);
+  const out = { formattedCode, codeId };
   previewCodeCache.set(cacheKey, out);
   return out;
 }
@@ -227,10 +244,11 @@ function plugin() {
       !NO_PREVIEW_HTML_RE.test(node.value)
     ) {
       const scriptBlock = createImports(node.value);
-      const { formattedCode, highlightedCode } =
-        await formatAndHighlightPreviewSvelte(scriptBlock + node.value);
+      const { formattedCode, codeId } = await formatAndHighlightPreviewSvelte(
+        scriptBlock + node.value,
+      );
 
-      node.value = `<Preview codeRaw={${JSON.stringify(formattedCode)}} code={${JSON.stringify(highlightedCode)}}>${node.value}</Preview>`;
+      node.value = `<Preview codeRaw={${JSON.stringify(formattedCode)}} codeId="${codeId}">${node.value}</Preview>`;
     }
 
     if (node.value.startsWith("<FileSource")) {
@@ -240,10 +258,10 @@ function plugin() {
       const filePath = path.join(__dirname, "src/pages", `${src}.svelte`);
       const sourceCode = fs.readFileSync(filePath, "utf-8");
       const mtimeMs = fs.statSync(filePath).mtimeMs;
-      const { formattedCode, highlightedCode } =
+      const { formattedCode, codeId } =
         await formatAndHighlightFileSourceSvelte(src, sourceCode, mtimeMs);
 
-      node.value = `<Preview framed src="${src}" codeRaw={${JSON.stringify(formattedCode)}} code={${JSON.stringify(highlightedCode)}} />`;
+      node.value = `<Preview framed src="${src}" codeRaw={${JSON.stringify(formattedCode)}} codeId="${codeId}" />`;
     }
   }
 

--- a/docs/svelte.config.ts
+++ b/docs/svelte.config.ts
@@ -39,27 +39,14 @@ const SNIPPET_MUSTACHE_ANY_RE = /\{/;
 
 const SKIP_MDSVEX_PRETTIER = process.env.NODE_ENV === "development";
 
-const PREVIEW_SNIPPETS_DIR = path.join(__dirname, "src/preview-snippets");
-
 const previewCodeCache = new Map<
   string,
-  { formattedCode: string; codeId: string }
+  { formattedCode: string; highlightedCode: string }
 >();
 const createImportsCache = new Map<string, string>();
 
 function hashKey(s: string): string {
   return createHash("sha256").update(s, "utf8").digest("hex").slice(0, 32);
-}
-
-function writePreviewSnippet(codeId: string, highlightedCode: string) {
-  fs.mkdirSync(PREVIEW_SNIPPETS_DIR, { recursive: true });
-  const filePath = path.join(PREVIEW_SNIPPETS_DIR, `${codeId}.json`);
-
-  fs.writeFileSync(
-    filePath,
-    JSON.stringify({ html: highlightedCode }),
-    "utf-8",
-  );
 }
 
 function escapeHtmlText(str: string): string {
@@ -202,9 +189,7 @@ async function formatAndHighlightPreviewSvelte(combinedSource: string) {
   const highlightedCode = await highlightCode(formattedCode, "svelte", {
     fragment: true,
   });
-  const codeId = hashKey(formattedCode);
-  writePreviewSnippet(codeId, highlightedCode);
-  const out = { formattedCode, codeId };
+  const out = { formattedCode, highlightedCode };
   previewCodeCache.set(cacheKey, out);
   return out;
 }
@@ -225,9 +210,7 @@ async function formatAndHighlightFileSourceSvelte(
   const highlightedCode = await highlightCode(formattedCode, "svelte", {
     fragment: true,
   });
-  const codeId = hashKey(formattedCode);
-  writePreviewSnippet(codeId, highlightedCode);
-  const out = { formattedCode, codeId };
+  const out = { formattedCode, highlightedCode };
   previewCodeCache.set(cacheKey, out);
   return out;
 }
@@ -244,11 +227,10 @@ function plugin() {
       !NO_PREVIEW_HTML_RE.test(node.value)
     ) {
       const scriptBlock = createImports(node.value);
-      const { formattedCode, codeId } = await formatAndHighlightPreviewSvelte(
-        scriptBlock + node.value,
-      );
+      const { formattedCode, highlightedCode } =
+        await formatAndHighlightPreviewSvelte(scriptBlock + node.value);
 
-      node.value = `<Preview codeRaw={${JSON.stringify(formattedCode)}} codeId="${codeId}">${node.value}</Preview>`;
+      node.value = `<Preview codeRaw={${JSON.stringify(formattedCode)}} codeHighlighted={${JSON.stringify(highlightedCode)}}>${node.value}</Preview>`;
     }
 
     if (node.value.startsWith("<FileSource")) {
@@ -258,10 +240,10 @@ function plugin() {
       const filePath = path.join(__dirname, "src/pages", `${src}.svelte`);
       const sourceCode = fs.readFileSync(filePath, "utf-8");
       const mtimeMs = fs.statSync(filePath).mtimeMs;
-      const { formattedCode, codeId } =
+      const { formattedCode, highlightedCode } =
         await formatAndHighlightFileSourceSvelte(src, sourceCode, mtimeMs);
 
-      node.value = `<Preview framed src="${src}" codeRaw={${JSON.stringify(formattedCode)}} codeId="${codeId}" />`;
+      node.value = `<Preview framed src="${src}" codeRaw={${JSON.stringify(formattedCode)}} codeHighlighted={${JSON.stringify(highlightedCode)}} />`;
     }
   }
 


### PR DESCRIPTION
Replace Prism with Shiki for syntax highlighting:

- More precise, customizable tokens
- Highlighting is done AOT, not client-side
- Because most docs pages have grown giant (e.g., DataTable, TreeView), load highlighted bits on demand.
  - This increases the time to build the docs, but should dramatically decrease the amount of client-side JS (especially for larger pages), since the code snippets are bundled in the app anyway
  - Each individual highlighted bit is hashed based on the formatted source code, so caching should work between builds. This is the key piece; this would not work if assets are not hashed properly.

TODO:

- Needs refinement on colors
- Split out `.svx` content changes