### PR TITLE
fix(content-switcher): sync switch order to DOM on conditional render

### DIFF
--- a/docs/src/pages/components/ContentSwitcher.svx
+++ b/docs/src/pages/components/ContentSwitcher.svx
@@ -49,6 +49,12 @@ interactions or application state.
 
 <FileSource src="/framed/ContentSwitcher/ContentSwitcherReactive" />
 
+## Conditional switches
+
+Switches can be conditionally rendered using Svelte's `{#if}` blocks. The component automatically maintains correct indices even when switches are dynamically added or removed.
+
+<FileSource src="/framed/ContentSwitcher/ContentSwitcherConditional" />
+
 ## Custom switch slot
 
 Override the default slot in the switch to customize how each option displays.

--- a/docs/src/pages/framed/ContentSwitcher/ContentSwitcherConditional.svelte
+++ b/docs/src/pages/framed/ContentSwitcher/ContentSwitcherConditional.svelte
@@ -1,0 +1,33 @@
+<script>
+  import {
+    Checkbox,
+    ContentSwitcher,
+    Stack,
+    Switch,
+  } from "carbon-components-svelte";
+
+  let selectedIndex = 0;
+  let showAdmin = true;
+  let showSettings = true;
+</script>
+
+<Stack gap={3}>
+  <div>
+    <Checkbox bind:checked={showAdmin} labelText="Show Admin switch" />
+    <Checkbox bind:checked={showSettings} labelText="Show Settings switch" />
+  </div>
+  <div>
+    <strong>Selected index:</strong>
+    {selectedIndex}
+  </div>
+  <ContentSwitcher bind:selectedIndex>
+    <Switch text="Dashboard" />
+    {#if showAdmin}
+      <Switch text="Admin" />
+    {/if}
+    {#if showSettings}
+      <Switch text="Settings" />
+    {/if}
+    <Switch text="Profile" />
+  </ContentSwitcher>
+</Stack>

--- a/src/ContentSwitcher/ContentSwitcher.svelte
+++ b/src/ContentSwitcher/ContentSwitcher.svelte
@@ -43,6 +43,10 @@
   let currentIndex = -1;
   let focusedIndex = -1;
   let switches = [];
+
+  // Flag to trigger DOM reordering only when switches change.
+  // This is necessary to avoid infinite loops in Svelte 5.
+  let needsDomSync = false;
   $: if (switches[currentIndex]) {
     if (prevIndex > -1 && prevIndex !== currentIndex) {
       dispatch("change", currentIndex);
@@ -63,6 +67,7 @@
       selectedIndex = switches.length;
     }
 
+    needsDomSync = true;
     switches = [...switches, { id, text, selected }];
   };
 
@@ -70,6 +75,7 @@
    * @type {(id: string) => void}
    */
   const remove = (id) => {
+    needsDomSync = true;
     switches = switches.filter((s) => s.id !== id);
   };
 
@@ -159,6 +165,28 @@
   });
 
   afterUpdate(() => {
+    // Sync the switches array with DOM order only when switches are
+    // added/removed. The flag avoids infinite loops in Svelte 5 by not
+    // running on every update. The selected switch is preserved by id so
+    // selection survives reordering. Nested [role='tab'] elements inside
+    // switch slots are dropped because their ids are not in the registry.
+    if (needsDomSync && ref) {
+      needsDomSync = false;
+
+      const selectedId = switches[selectedIndex]?.id;
+      const switchesById = new Map(switches.map((s) => [s.id, s]));
+      switches = Array.from(ref.querySelectorAll("[role='tab']"))
+        .map((el) => switchesById.get(el.id))
+        .filter(Boolean);
+
+      if (selectedId !== undefined) {
+        const nextIndex = switches.findIndex((s) => s.id === selectedId);
+        if (nextIndex > -1) {
+          selectedIndex = nextIndex;
+        }
+      }
+    }
+
     if (selectedIndex !== currentIndex) {
       currentIndex = selectedIndex;
       focusedIndex = -1;

--- a/tests/ContentSwitcher/ContentSwitcher.test.ts
+++ b/tests/ContentSwitcher/ContentSwitcher.test.ts
@@ -320,6 +320,40 @@ describe("ContentSwitcher", () => {
     expect(tabs[1]).toHaveClass("bx--content-switcher--selected");
   });
 
+  it("syncs switch order to the DOM when a middle Switch is re-added", async () => {
+    const { rerender } = render(ContentSwitcherDynamic, {
+      props: { show: false },
+    });
+
+    expect(
+      screen.getAllByRole("tab").map((tab) => tab.textContent?.trim()),
+    ).toEqual(["First", "Last"]);
+
+    // Re-adding the middle Switch mounts it last, so the parent's registry
+    // would append it after "Last" without DOM-order syncing.
+    await rerender({ show: true });
+
+    const tabs = screen.getAllByRole("tab");
+    expect(tabs.map((tab) => tab.textContent?.trim())).toEqual([
+      "First",
+      "Middle",
+      "Last",
+    ]);
+
+    // Arrow navigation must follow visual order, not mount order.
+    await user.tab();
+    expect(document.activeElement).toBe(tabs[0]);
+
+    await user.keyboard("{ArrowRight}");
+    expect(document.activeElement).toBe(tabs[1]);
+    expect(tabs[1]).toHaveTextContent("Middle");
+    expect(tabs[1]).toHaveClass("bx--content-switcher--selected");
+
+    await user.keyboard("{ArrowRight}");
+    expect(document.activeElement).toBe(tabs[2]);
+    expect(tabs[2]).toHaveTextContent("Last");
+  });
+
   it("should bind ref to the tablist element", () => {
     const { component } = render(ContentSwitcher);
 


### PR DESCRIPTION
Similar fix to #2350 (and #2394)

`ContentSwitcher` also uses a component composition pattern, similar to `Tabs`. If a switch is conditionally rendered, the internally managed `selectedIndex` becomes out of sync. This can cause the active switch to be lost completely.

This applies a similar fix to sync the index if a switch is added/removed.