### PR TITLE
refactor: apply `syncDomOrder` utility to `Tabs` and `ContentSwitcher`

### DIFF
--- a/src/ContentSwitcher/ContentSwitcher.svelte
+++ b/src/ContentSwitcher/ContentSwitcher.svelte
@@ -31,6 +31,7 @@
 
   import { afterUpdate, createEventDispatcher, setContext, tick } from "svelte";
   import { writable } from "svelte/store";
+  import { syncDomOrder } from "../utils/syncDomOrder.js";
 
   const dispatch = createEventDispatcher();
   /**
@@ -174,10 +175,11 @@
       needsDomSync = false;
 
       const selectedId = switches[selectedIndex]?.id;
-      const switchesById = new Map(switches.map((s) => [s.id, s]));
-      switches = Array.from(ref.querySelectorAll("[role='tab']"))
-        .map((el) => switchesById.get(el.id))
-        .filter(Boolean);
+      switches = syncDomOrder({
+        root: ref,
+        selector: "[role='tab']",
+        items: switches,
+      });
 
       if (selectedId !== undefined) {
         const nextIndex = switches.findIndex((s) => s.id === selectedId);

--- a/src/Tabs/Tabs.svelte
+++ b/src/Tabs/Tabs.svelte
@@ -33,6 +33,7 @@
   import { afterUpdate, createEventDispatcher, setContext, tick } from "svelte";
   import { derived, writable } from "svelte/store";
   import ChevronDown from "../icons/ChevronDown.svelte";
+  import { syncDomOrder } from "../utils/syncDomOrder.js";
 
   const dispatch = createEventDispatcher();
 
@@ -183,35 +184,23 @@
     if (needsDomSync && refTabList) {
       needsDomSync = false;
 
-      const domTabs = Array.from(refTabList.querySelectorAll("[role='tab']"));
-      const domTabIds = domTabs.map((el) => el.id);
+      tabs.update((currentTabs) =>
+        syncDomOrder({
+          root: refTabList,
+          selector: "[role='tab']",
+          items: currentTabs,
+        }),
+      );
 
-      tabs.update((currentTabs) => {
-        const tabsMap = new Map(currentTabs.map((tab) => [tab.id, tab]));
-        return domTabIds
-          .map((id, index) => {
-            const tab = tabsMap.get(id);
-            return tab ? { ...tab, index } : undefined;
-          })
-          .filter(Boolean);
-      });
-
-      const contentElements = refRoot?.parentElement
-        ? Array.from(
-            refRoot.parentElement.querySelectorAll("[role='tabpanel']"),
-          )
-        : [];
-      const contentIds = contentElements.map((el) => el.id);
-
-      content.update((currentContent) => {
-        const contentMap = new Map(currentContent.map((c) => [c.id, c]));
-        return contentIds
-          .map((id, index) => {
-            const c = contentMap.get(id);
-            return c ? { ...c, index } : undefined;
-          })
-          .filter(Boolean);
-      });
+      if (refRoot?.parentElement) {
+        content.update((currentContent) =>
+          syncDomOrder({
+            root: refRoot.parentElement,
+            selector: "[role='tabpanel']",
+            items: currentContent,
+          }),
+        );
+      }
     }
 
     if (selected !== currentIndex) {

--- a/src/utils/syncDomOrder.d.ts
+++ b/src/utils/syncDomOrder.d.ts
@@ -1,0 +1,13 @@
+/**
+ * Reorder a collection of id-bearing items to match the DOM order of the
+ * elements matching `selector` within `root`, reassigning a contiguous `index`.
+ * Items with no matching DOM element are dropped.
+ */
+export function syncDomOrder<T extends { id: string }>(options: {
+  /** Element to query within. */
+  root: Element;
+  /** CSS selector for the ordered child elements. */
+  selector: string;
+  /** Items to reorder, keyed by `id`. */
+  items: readonly T[];
+}): (T & { index: number })[];

--- a/src/utils/syncDomOrder.js
+++ b/src/utils/syncDomOrder.js
@@ -1,0 +1,31 @@
+// @ts-check
+/**
+ * Reorder a collection of id-bearing items to match the DOM order of the
+ * elements matching `selector` within `root`.
+ *
+ * Slotted children register with their parent in mount order, which can
+ * diverge from visual DOM order when children are conditionally rendered or
+ * reordered. This re-sorts the collection to the DOM and reassigns a
+ * contiguous `index` to each item. Items with no matching DOM element (e.g.
+ * removed mid-update) are dropped.
+ *
+ * @template {{ id: string }} T
+ * @param {Object} options
+ * @param {Element} options.root - Element to query within.
+ * @param {string} options.selector - CSS selector for the ordered child elements.
+ * @param {ReadonlyArray<T>} options.items - Items to reorder, keyed by `id`.
+ * @returns {Array<T & { index: number }>} Items in DOM order with reassigned `index`.
+ */
+export function syncDomOrder({ root, selector, items }) {
+  const itemsById = new Map(items.map((item) => [item.id, item]));
+  /** @type {Array<T & { index: number }>} */
+  const ordered = [];
+  const elements = root.querySelectorAll(selector);
+
+  for (let index = 0; index < elements.length; index++) {
+    const item = itemsById.get(elements[index].id);
+    if (item) ordered.push({ ...item, index });
+  }
+
+  return ordered;
+}


### PR DESCRIPTION
Both `Tabs` and `ContentSwitcher` have internal logic to re-sync the index if items are conditionally added or removed.

This extracts an internal utility and applies it, for readability and code reuse.