### PR TITLE
chore: fix JSDoc type annotations for `filterTreeNodes`, `toHierarchy`

### DIFF
--- a/src/utils/filterTreeNodes.js
+++ b/src/utils/filterTreeNodes.js
@@ -1,20 +1,23 @@
 // @ts-check
 /**
- * Filter tree nodes by a predicate function.
- * Returns a new tree containing only matching nodes and their ancestors.
- *
  * @typedef {Object} TreeNode
  * @property {string | number} id - Unique identifier for the node
  * @property {string} [text] - Optional text/name for the node
  * @property {TreeNode[]} [nodes] - Optional array of child nodes
  * @property {Record<string, unknown>} [additionalProperties] - Any additional properties
- *
+ */
+
+/**
  * @typedef {Object} FilterOptions
  * @property {boolean} [includeChildren=false] - Include all descendants of matching nodes
  * @property {boolean} [includeAncestors=true] - Include all ancestors of matching nodes
- *
+ */
+
+/**
+ * Filter tree nodes by a predicate function.
+ * Returns a new tree containing only matching nodes and their ancestors.
  * @param {TreeNode[]} tree - Hierarchical tree structure to filter
- * @param {function(TreeNode): boolean} predicate - Function to test each node
+ * @param {(node: TreeNode) => boolean} predicate - Function to test each node
  * @param {FilterOptions} [options] - Filtering options
  * @returns {TreeNode[]} Filtered tree structure
  */

--- a/src/utils/toHierarchy.js
+++ b/src/utils/toHierarchy.js
@@ -1,13 +1,15 @@
 // @ts-check
 /**
- * Create a nested array from a flat array.
  * @typedef {Object} NodeLike
  * @property {string | number} id - Unique identifier for the node
  * @property {NodeLike[]} [nodes] - Optional array of child nodes
  * @property {Record<string, unknown>} [additionalProperties] - Any additional properties
- *
+ */
+
+/**
+ * Create a nested array from a flat array.
  * @param {NodeLike[]} flatArray - Array of flat nodes to convert
- * @param {function(NodeLike): (string|number|null)} getParentId - Function to get parent ID for a node
+ * @param {(node: NodeLike) => string | number | null} getParentId - Function to get parent ID for a node
  * @returns {NodeLike[]} Hierarchical tree structure
  */
 export function toHierarchy(flatArray, getParentId) {


### PR DESCRIPTION
Fixes broken `@param` syntax.