### PR TITLE
chore(utils): extract `trapFocus` utility

### DIFF
--- a/src/ComposedModal/ComposedModal.svelte
+++ b/src/ComposedModal/ComposedModal.svelte
@@ -48,6 +48,7 @@
   } from "svelte";
   import { writable } from "svelte/store";
   import { trackModal } from "../Modal/modalStore";
+  import { trapFocus } from "../utils/trapFocus.js";
 
   const dispatch = createEventDispatcher();
   const label = writable(undefined);
@@ -170,54 +171,7 @@
       if (event.key === "Escape") {
         close("escape-key");
       } else if (event.key === "Tab") {
-        // taken from github.com/carbon-design-system/carbon/packages/react/src/internal/keyboard/navigation.js
-        const selectorTabbable = `
-  a[href], area[href], input:not([disabled]):not([tabindex='-1']),
-  button:not([disabled]):not([tabindex='-1']),select:not([disabled]):not([tabindex='-1']),
-  textarea:not([disabled]):not([tabindex='-1']),
-  iframe, object, embed, *[tabindex]:not([tabindex='-1']):not([disabled]), *[contenteditable=true]
-`;
-
-        const tabbable = Array.from(
-          ref.querySelectorAll(selectorTabbable)
-        ).filter((el) => {
-          // Filter out elements that are not visible.
-          const style = getComputedStyle(el);
-          if (style.visibility === "hidden" || style.display === "none") {
-            return false;
-          }
-
-          // Check for zero dimensions, but only if the element has been laid out
-          // (offsetParent is null for hidden elements or elements not in the DOM.
-          if (
-            el.offsetParent !== null &&
-            el.offsetWidth === 0 &&
-            el.offsetHeight === 0
-          ) {
-            return false;
-          }
-
-          return true;
-        });
-
-        if (tabbable.length === 0) {
-          event.preventDefault();
-          return;
-        }
-
-        let index = tabbable.indexOf(document.activeElement);
-        if (index === -1) {
-          // Active element not in tabbable list, find closest tabbable element
-          // For forward Tab, start from beginning (-1 + 1 = 0)
-          // For Shift+Tab, start from end (length + -1 = length - 1)
-          index = event.shiftKey ? tabbable.length : -1;
-        }
-
-        index += event.shiftKey ? -1 : 1;
-        index = (index + tabbable.length) % tabbable.length;
-
-        tabbable[index].focus();
-        event.preventDefault();
+        trapFocus({ container: ref, event });
       }
     }
   }}

--- a/src/Modal/Modal.svelte
+++ b/src/Modal/Modal.svelte
@@ -114,6 +114,7 @@
   import { writable } from "svelte/store";
   import Button from "../Button/Button.svelte";
   import Close from "../icons/Close.svelte";
+  import { trapFocus } from "../utils/trapFocus.js";
   import { trackModal } from "./modalStore";
 
   const dispatch = createEventDispatcher();
@@ -204,56 +205,7 @@
       if (event.key === "Escape") {
         close("escape-key");
       } else if (event.key === "Tab") {
-        // trap focus
-
-        // taken from github.com/carbon-design-system/carbon/packages/react/src/internal/keyboard/navigation.js
-        const selectorTabbable = `
-  a[href], area[href], input:not([disabled]):not([tabindex='-1']),
-  button:not([disabled]):not([tabindex='-1']),select:not([disabled]):not([tabindex='-1']),
-  textarea:not([disabled]):not([tabindex='-1']),
-  iframe, object, embed, *[tabindex]:not([tabindex='-1']):not([disabled]), *[contenteditable=true]
-`;
-
-        const tabbable = Array.from(
-          ref.querySelectorAll(selectorTabbable)
-        ).filter((el) => {
-          // Filter out elements that are not visible.
-          const style = getComputedStyle(el);
-          if (style.visibility === "hidden" || style.display === "none") {
-            return false;
-          }
-
-          // Check for zero dimensions, but only if the element has been laid out
-          // (offsetParent is null for hidden elements or elements not in the DOM.
-          if (
-            el.offsetParent !== null &&
-            el.offsetWidth === 0 &&
-            el.offsetHeight === 0
-          ) {
-            return false;
-          }
-          
-          return true;
-        });
-
-        if (tabbable.length === 0) {
-          event.preventDefault();
-          return;
-        }
-
-        let index = tabbable.indexOf(document.activeElement);
-        if (index === -1) {
-          // Active element not in tabbable list, find closest tabbable element
-          // For forward Tab, start from beginning (-1 + 1 = 0)
-          // For Shift+Tab, start from end (length + -1 = length - 1)
-          index = event.shiftKey ? tabbable.length : -1;
-        }
-
-        index += event.shiftKey ? -1 : 1;
-        index = (index + tabbable.length) % tabbable.length;
-
-        tabbable[index].focus();
-        event.preventDefault();
+        trapFocus({ container: ref, event });
       } else if (
         shouldSubmitOnEnter &&
         event.key === "Enter" &&

--- a/src/utils/trapFocus.d.ts
+++ b/src/utils/trapFocus.d.ts
@@ -1,0 +1,10 @@
+/**
+ * Trap Tab/Shift+Tab focus within `container`, cycling focus across its
+ * visible tabbable descendants. Always calls `event.preventDefault()`.
+ */
+export function trapFocus(options: {
+  /** Element whose tabbable descendants form the focus loop. */
+  container: Element;
+  /** The Tab keydown event. */
+  event: KeyboardEvent;
+}): void;

--- a/src/utils/trapFocus.js
+++ b/src/utils/trapFocus.js
@@ -1,0 +1,64 @@
+// @ts-check
+
+// taken from github.com/carbon-design-system/carbon/packages/react/src/internal/keyboard/navigation.js
+const selectorTabbable = `
+  a[href], area[href], input:not([disabled]):not([tabindex='-1']),
+  button:not([disabled]):not([tabindex='-1']),select:not([disabled]):not([tabindex='-1']),
+  textarea:not([disabled]):not([tabindex='-1']),
+  iframe, object, embed, *[tabindex]:not([tabindex='-1']):not([disabled]), *[contenteditable=true]
+`;
+
+/**
+ * Trap Tab/Shift+Tab focus within `container`, cycling focus across its
+ * visible tabbable descendants. Call from a `keydown` handler when the
+ * pressed key is `Tab`; always calls `event.preventDefault()`.
+ *
+ * @param {Object} options
+ * @param {Element} options.container - Element whose tabbable descendants form the focus loop.
+ * @param {KeyboardEvent} options.event - The Tab keydown event.
+ * @returns {void}
+ */
+export function trapFocus({ container, event }) {
+  const tabbable = /** @type {HTMLElement[]} */ (
+    Array.from(container.querySelectorAll(selectorTabbable))
+  ).filter((el) => {
+    // Filter out elements that are not visible.
+    const style = getComputedStyle(el);
+    if (style.visibility === "hidden" || style.display === "none") {
+      return false;
+    }
+
+    // Check for zero dimensions, but only if the element has been laid out
+    // (offsetParent is null for hidden elements or elements not in the DOM.
+    if (
+      el.offsetParent !== null &&
+      el.offsetWidth === 0 &&
+      el.offsetHeight === 0
+    ) {
+      return false;
+    }
+
+    return true;
+  });
+
+  if (tabbable.length === 0) {
+    event.preventDefault();
+    return;
+  }
+
+  let index = tabbable.indexOf(
+    /** @type {HTMLElement} */ (document.activeElement),
+  );
+  if (index === -1) {
+    // Active element not in tabbable list, find closest tabbable element
+    // For forward Tab, start from beginning (-1 + 1 = 0)
+    // For Shift+Tab, start from end (length + -1 = length - 1)
+    index = event.shiftKey ? tabbable.length : -1;
+  }
+
+  index += event.shiftKey ? -1 : 1;
+  index = (index + tabbable.length) % tabbable.length;
+
+  tabbable[index].focus();
+  event.preventDefault();
+}

--- a/tests/utils/trapFocus.test.ts
+++ b/tests/utils/trapFocus.test.ts
@@ -1,0 +1,122 @@
+import { trapFocus } from "../../src/utils/trapFocus.js";
+
+/**
+ * Build a container with `count` buttons, append it to the document, and
+ * return the container plus its buttons. jsdom has no layout, so
+ * `offsetParent` is null and the zero-dimension filter branch is skipped —
+ * the buttons count as visible.
+ */
+function setup(count: number) {
+  const container = document.createElement("div");
+  const buttons = Array.from({ length: count }, (_, i) => {
+    const button = document.createElement("button");
+    button.textContent = `Button ${i}`;
+    container.appendChild(button);
+    return button;
+  });
+  document.body.appendChild(container);
+  return { container, buttons };
+}
+
+function tabEvent(shiftKey = false) {
+  const event = new KeyboardEvent("keydown", { key: "Tab", shiftKey });
+  const preventDefault = vi.spyOn(event, "preventDefault");
+  return { event, preventDefault };
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("trapFocus", () => {
+  test("forward Tab from the last element wraps to the first", () => {
+    const { container, buttons } = setup(3);
+    buttons[2].focus();
+    const { event, preventDefault } = tabEvent();
+
+    trapFocus({ container, event });
+
+    expect(document.activeElement).toBe(buttons[0]);
+    expect(preventDefault).toHaveBeenCalledOnce();
+  });
+
+  test("Shift+Tab from the first element wraps to the last", () => {
+    const { container, buttons } = setup(3);
+    buttons[0].focus();
+    const { event, preventDefault } = tabEvent(true);
+
+    trapFocus({ container, event });
+
+    expect(document.activeElement).toBe(buttons[2]);
+    expect(preventDefault).toHaveBeenCalledOnce();
+  });
+
+  test("Tab advances to the next element mid-list", () => {
+    const { container, buttons } = setup(3);
+    buttons[0].focus();
+    const { event } = tabEvent();
+
+    trapFocus({ container, event });
+
+    expect(document.activeElement).toBe(buttons[1]);
+  });
+
+  test("Shift+Tab moves to the previous element mid-list", () => {
+    const { container, buttons } = setup(3);
+    buttons[2].focus();
+    const { event } = tabEvent(true);
+
+    trapFocus({ container, event });
+
+    expect(document.activeElement).toBe(buttons[1]);
+  });
+
+  test("empty container calls preventDefault and focuses nothing", () => {
+    const { container } = setup(0);
+    const outside = document.createElement("button");
+    document.body.appendChild(outside);
+    outside.focus();
+    const { event, preventDefault } = tabEvent();
+
+    trapFocus({ container, event });
+
+    expect(document.activeElement).toBe(outside);
+    expect(preventDefault).toHaveBeenCalledOnce();
+  });
+
+  test("active element outside the list: Tab focuses the first element", () => {
+    const { container, buttons } = setup(3);
+    const outside = document.createElement("button");
+    document.body.appendChild(outside);
+    outside.focus();
+    const { event } = tabEvent();
+
+    trapFocus({ container, event });
+
+    expect(document.activeElement).toBe(buttons[0]);
+  });
+
+  test("active element outside the list: Shift+Tab focuses the last element", () => {
+    const { container, buttons } = setup(3);
+    const outside = document.createElement("button");
+    document.body.appendChild(outside);
+    outside.focus();
+    const { event } = tabEvent(true);
+
+    trapFocus({ container, event });
+
+    expect(document.activeElement).toBe(buttons[2]);
+  });
+
+  test("hidden elements are excluded from the focus loop", () => {
+    const { container, buttons } = setup(3);
+    buttons[1].style.display = "none";
+    buttons[0].focus();
+    const { event } = tabEvent();
+
+    // buttons[1] is skipped, so Tab goes straight to buttons[2].
+    trapFocus({ container, event });
+
+    expect(document.activeElement).toBe(buttons[2]);
+  });
+});


### PR DESCRIPTION
Extract a `trapFocus` utility and apply to the modals, for consistency/re-use.

Will also apply in #3120