### PR TITLE
feat(checkbox-group): add `readonly` prop

### DIFF
--- a/docs/src/pages/components/Checkbox.svx
+++ b/docs/src/pages/components/Checkbox.svx
@@ -135,10 +135,10 @@ Disable all checkboxes in the group.
 
 ## CheckboxGroup (read-only)
 
-Set `readonly` on each checkbox to display selected values without allowing user interaction. Unlike `disabled`, the readonly state keeps labels readable.
+Set `readonly` to `true` on `CheckboxGroup` to display non-editable values. Unlike `disabled`, the readonly state keeps labels readable. You can also set `readonly` on individual checkboxes when needed.
 
-<CheckboxGroup legendText="Notification preferences" name="prefs-readonly" selected={["email", "push"]}>
-<Checkbox value="email" labelText="Email" readonly />
-<Checkbox value="sms" labelText="SMS" readonly />
-<Checkbox value="push" labelText="Push notifications" readonly />
+<CheckboxGroup readonly legendText="Notification preferences" name="prefs-readonly" selected={["email", "push"]}>
+<Checkbox value="email" labelText="Email" />
+<Checkbox value="sms" labelText="SMS" />
+<Checkbox value="push" labelText="Push notifications" />
 </CheckboxGroup>

--- a/src/Checkbox/Checkbox.svelte
+++ b/src/Checkbox/Checkbox.svelte
@@ -77,11 +77,19 @@
   const dispatch = createEventDispatcher();
 
   const ctx = getContext("carbon:CheckboxGroup");
-  const selectedValues = ctx?.selectedValues ?? readable([]);
-  const groupName = ctx?.groupName ?? readable(undefined);
-  const groupRequired = ctx?.groupRequired ?? readable(undefined);
-  const groupReadonly = ctx?.readonly ?? readable(false);
-  const ctxUpdate = ctx?.update;
+
+  const {
+    selectedValues,
+    groupName,
+    groupRequired,
+    readonly: groupReadonly,
+    update: ctxUpdate,
+  } = ctx ?? {
+    selectedValues: readable([]),
+    groupName: readable(undefined),
+    groupRequired: readable(undefined),
+    readonly: readable(false),
+  };
 
   $: useGroup = !ctx && Array.isArray(group);
   $: if (ctx) checked = $selectedValues.includes(value);

--- a/src/Checkbox/Checkbox.svelte
+++ b/src/Checkbox/Checkbox.svelte
@@ -80,6 +80,7 @@
   const selectedValues = ctx?.selectedValues ?? readable([]);
   const groupName = ctx?.groupName ?? readable(undefined);
   const groupRequired = ctx?.groupRequired ?? readable(undefined);
+  const groupReadonly = ctx?.readonly ?? readable(false);
   const ctxUpdate = ctx?.update;
 
   $: useGroup = !ctx && Array.isArray(group);
@@ -88,6 +89,7 @@
 
   $: effectiveName = ctx ? ($groupName ?? name) : name;
   $: effectiveRequired = ctx ? ($groupRequired ?? required) : required;
+  $: effectiveReadonly = $groupReadonly || readonly;
 
   // Track previous checked value to avoid duplicate dispatches in Svelte 5
   // The reactive statement will only dispatch when checked changes externally (e.g., via bind:checked)
@@ -121,7 +123,7 @@
   <div
     class:bx--form-item={true}
     class:bx--checkbox-wrapper={true}
-    class:bx--checkbox-wrapper--readonly={readonly}
+    class:bx--checkbox-wrapper--readonly={effectiveReadonly}
     {...$$restProps}
     on:click
     on:mouseover
@@ -138,16 +140,16 @@
       bind:indeterminate
       name={effectiveName}
       required={effectiveRequired}
-      aria-readonly={readonly || undefined}
+      aria-readonly={effectiveReadonly || undefined}
       aria-describedby={helperText ? helperId : undefined}
       class:bx--checkbox={true}
       on:click={(event) => {
-        if (readonly) {
+        if (effectiveReadonly) {
           event.preventDefault();
         }
       }}
       on:change={(event) => {
-        if (readonly) {
+        if (effectiveReadonly) {
           event.stopImmediatePropagation();
           return;
         }

--- a/src/Checkbox/CheckboxGroup.svelte
+++ b/src/Checkbox/CheckboxGroup.svelte
@@ -45,6 +45,9 @@
   /** Specify the helper text */
   export let helperText = "";
 
+  /** Set to `true` to use the read-only variant */
+  export let readonly = false;
+
   /**
    * Set an id for the container div element.
    * @type {string}
@@ -52,7 +55,7 @@
   export let id = undefined;
 
   import { createEventDispatcher, onMount, setContext, tick } from "svelte";
-  import { readonly, writable } from "svelte/store";
+  import { readonly as readOnly, writable } from "svelte/store";
 
   const dispatch = createEventDispatcher();
 
@@ -62,12 +65,14 @@
   const selectedValues = writable(selected);
   const groupName = writable(name);
   const groupRequired = writable(required);
+  const groupReadonly = writable(readonly);
   let isInitialRender = true;
 
   /**
    * @type {(value: string | number, checked: boolean) => void}
    */
   const update = (value, checked) => {
+    if (readonly) return;
     selectedValues.update((prev) => {
       if (checked) {
         return prev.includes(value) ? prev : [...prev, value];
@@ -78,12 +83,14 @@
 
   setContext("carbon:CheckboxGroup", {
     selectedValues,
-    groupName: readonly(groupName),
-    groupRequired: readonly(groupRequired),
+    groupName: readOnly(groupName),
+    groupRequired: readOnly(groupRequired),
+    readonly: readOnly(groupReadonly),
     update,
   });
 
   const unsubscribe = selectedValues.subscribe((value) => {
+    if (readonly) return;
     selected = value;
     if (!isInitialRender) {
       dispatch("change", value);
@@ -97,10 +104,11 @@
     return unsubscribe;
   });
 
-  $: if (selected !== $selectedValues) $selectedValues = selected;
+  $: if (!readonly && selected !== $selectedValues) $selectedValues = selected;
 
   $: $groupName = name;
   $: $groupRequired = required;
+  $: $groupReadonly = readonly;
 
   const fallbackHelperId = `ccs-${Math.random().toString(36)}`;
   $: helperId = id ? `helper-${id}` : fallbackHelperId;
@@ -119,6 +127,7 @@
 >
   <fieldset
     class:bx--checkbox-group={true}
+    class:bx--checkbox-group--readonly={readonly}
     {disabled}
     aria-describedby={helperText ? helperId : undefined}
   >

--- a/src/Checkbox/CheckboxGroup.svelte
+++ b/src/Checkbox/CheckboxGroup.svelte
@@ -58,7 +58,6 @@
   import { readonly as readOnly, writable } from "svelte/store";
 
   const dispatch = createEventDispatcher();
-
   /**
    * @type {import("svelte/store").Writable<ReadonlyArray<string | number>>}
    */
@@ -89,6 +88,8 @@
     update,
   });
 
+  $: if (!readonly && selected !== $selectedValues) $selectedValues = selected;
+
   const unsubscribe = selectedValues.subscribe((value) => {
     if (readonly) return;
     selected = value;
@@ -103,8 +104,6 @@
     });
     return unsubscribe;
   });
-
-  $: if (!readonly && selected !== $selectedValues) $selectedValues = selected;
 
   $: $groupName = name;
   $: $groupRequired = required;

--- a/tests/Checkbox/CheckboxGroup.readonly.test.svelte
+++ b/tests/Checkbox/CheckboxGroup.readonly.test.svelte
@@ -1,0 +1,19 @@
+<svelte:options accessors />
+
+<script lang="ts">
+  import { Checkbox, CheckboxGroup } from "carbon-components-svelte";
+
+  export let selected: string[] = ["1"];
+  export let readonly = false;
+</script>
+
+<CheckboxGroup
+  legendText="Options"
+  {readonly}
+  bind:selected
+  on:change={(e) => console.log("change", e.detail)}
+>
+  <Checkbox labelText="Option 1" value="1" />
+  <Checkbox labelText="Option 2" value="2" />
+  <Checkbox labelText="Option 3" value="3" />
+</CheckboxGroup>

--- a/tests/Checkbox/CheckboxGroupComponent.test.svelte
+++ b/tests/Checkbox/CheckboxGroupComponent.test.svelte
@@ -12,6 +12,7 @@
   export let hideLegend: ComponentProps<CheckboxGroup>["hideLegend"] = false;
   export let helperText: ComponentProps<CheckboxGroup>["helperText"] = "";
   export let id: ComponentProps<CheckboxGroup>["id"] = undefined;
+  export let readonly: ComponentProps<CheckboxGroup>["readonly"] = false;
   export let customClass = "";
   export let useSlot = false;
 </script>
@@ -25,6 +26,7 @@
     {hideLegend}
     {id}
     {helperText}
+    {readonly}
     class={customClass}
     on:change={(e) => {
       console.log("change", e.detail);
@@ -45,6 +47,7 @@
     {hideLegend}
     {id}
     {helperText}
+    {readonly}
     class={customClass}
     on:change={(e) => {
       console.log("change", e.detail);

--- a/tests/Checkbox/CheckboxGroupComponent.test.ts
+++ b/tests/Checkbox/CheckboxGroupComponent.test.ts
@@ -1,8 +1,10 @@
-import { render, screen } from "@testing-library/svelte";
+import { fireEvent, render, screen } from "@testing-library/svelte";
 import { tick } from "svelte";
 import { user } from "../utils/user";
+import CheckboxGroupReadonly from "./CheckboxGroup.readonly.test.svelte";
 import CheckboxGroupComponent from "./CheckboxGroupComponent.test.svelte";
 import CheckboxGroupStaticSelected from "./CheckboxGroupStaticSelected.test.svelte";
+import CheckboxReadonlyChange from "./CheckboxReadonlyChange.test.svelte";
 
 describe("CheckboxGroup", () => {
   it("should render with default props", () => {
@@ -270,5 +272,93 @@ describe("CheckboxGroup", () => {
     expect(
       screen.getByRole("checkbox", { name: "Option 3" }),
     ).not.toBeChecked();
+  });
+
+  describe("readonly (group)", () => {
+    it("should apply readonly class on the fieldset", () => {
+      const { container } = render(CheckboxGroupReadonly, {
+        readonly: true,
+      });
+
+      expect(
+        container.querySelector(".bx--checkbox-group--readonly"),
+      ).toBeTruthy();
+    });
+
+    it("should not change selection when clicking another checkbox", async () => {
+      const consoleLog = vi.spyOn(console, "log");
+      render(CheckboxGroupReadonly, { selected: ["1"], readonly: true });
+
+      const option2 = screen.getByRole("checkbox", { name: "Option 2" });
+      await user.click(option2);
+
+      expect(option2).not.toBeChecked();
+      expect(screen.getByRole("checkbox", { name: "Option 1" })).toBeChecked();
+      expect(consoleLog).not.toHaveBeenCalledWith("change", ["1", "2"]);
+    });
+
+    it("should not forward a child Checkbox's on:change when the group is readonly", async () => {
+      const consoleLog = vi.spyOn(console, "log");
+      render(CheckboxReadonlyChange);
+
+      const option2 = screen.getByRole("checkbox", { name: "Option 2" });
+      await fireEvent.change(option2);
+
+      expect(consoleLog).not.toHaveBeenCalledWith("checkbox-change", "2");
+    });
+
+    it("should allow selection when readonly is false", async () => {
+      const consoleLog = vi.spyOn(console, "log");
+      render(CheckboxGroupReadonly, { selected: ["1"], readonly: false });
+
+      const option2 = screen.getByRole("checkbox", { name: "Option 2" });
+      await user.click(option2);
+
+      expect(option2).toBeChecked();
+      expect(consoleLog).toHaveBeenCalledWith("change", ["1", "2"]);
+    });
+
+    it("should not change selection when readonly flips to true after mount", async () => {
+      const consoleLog = vi.spyOn(console, "log");
+      const { rerender } = render(CheckboxGroupReadonly, {
+        selected: ["1"],
+        readonly: false,
+      });
+
+      await rerender({ selected: ["1"], readonly: true });
+      await tick();
+
+      const option2 = screen.getByRole("checkbox", { name: "Option 2" });
+      await user.click(option2);
+
+      expect(screen.getByRole("checkbox", { name: "Option 1" })).toBeChecked();
+      expect(option2).not.toBeChecked();
+      expect(consoleLog).not.toHaveBeenCalledWith("change", ["1", "2"]);
+    });
+
+    it("should not propagate external selected updates to children when readonly", async () => {
+      const { component } = render(CheckboxGroupReadonly, {
+        selected: ["1"],
+        readonly: true,
+      });
+
+      expect(screen.getByRole("checkbox", { name: "Option 1" })).toBeChecked();
+
+      component.selected = ["2"];
+      await tick();
+
+      expect(screen.getByRole("checkbox", { name: "Option 1" })).toBeChecked();
+      expect(
+        screen.getByRole("checkbox", { name: "Option 2" }),
+      ).not.toBeChecked();
+    });
+
+    it("should set aria-readonly on children when the group is readonly", () => {
+      render(CheckboxGroupReadonly, { selected: ["1"], readonly: true });
+
+      for (const checkbox of screen.getAllByRole("checkbox")) {
+        expect(checkbox).toHaveAttribute("aria-readonly", "true");
+      }
+    });
   });
 });

--- a/tests/Checkbox/CheckboxReadonlyChange.test.svelte
+++ b/tests/Checkbox/CheckboxReadonlyChange.test.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+  import { Checkbox, CheckboxGroup } from "carbon-components-svelte";
+</script>
+
+<CheckboxGroup legendText="Options" readonly selected={["1"]}>
+  <Checkbox labelText="Option 1" value="1" />
+  <Checkbox
+    labelText="Option 2"
+    value="2"
+    on:change={() => console.log("checkbox-change", "2")}
+  />
+</CheckboxGroup>


### PR DESCRIPTION
For parity with `RadioButtonGroup`, add a `readonly` prop to `CheckboxGroup` to apply the state to all checkboxes, instead of needing to individually specify the state.