### PR TITLE
refactor: apply `debounce` utility to `Dropdown` typeahead

### DIFF
--- a/src/Dropdown/Dropdown.svelte
+++ b/src/Dropdown/Dropdown.svelte
@@ -167,6 +167,7 @@
     ListBoxMenuItem,
   } from "../ListBox";
   import { getMenuMaxHeight } from "../ListBox/list-box-utils.js";
+  import { debounce } from "../utils/debounce.js";
   import { virtualize as virtualizeUtil } from "../utils/virtualize.js";
 
   const dispatch = createEventDispatcher();
@@ -183,18 +184,20 @@
   let highlightedIndex = -1;
   let prevHighlightedIndex = -1;
   let typeaheadBuffer = "";
-  let typeaheadTimeout = null;
   let listScrollTop = 0;
   let prevOpen = false;
   let itemsById = new Map();
 
   const TYPEAHEAD_DELAY = 500;
 
+  // Clear the typeahead buffer once the user stops typing for TYPEAHEAD_DELAY ms.
+  const resetTypeaheadBuffer = debounce(() => {
+    typeaheadBuffer = "";
+  }, TYPEAHEAD_DELAY);
+
   onMount(() => {
     return () => {
-      if (typeaheadTimeout) {
-        clearTimeout(typeaheadTimeout);
-      }
+      resetTypeaheadBuffer.cancel();
     };
   });
 
@@ -221,10 +224,7 @@
     highlightedIndex = -1;
     prevHighlightedIndex = -1;
     typeaheadBuffer = "";
-    if (typeaheadTimeout) {
-      clearTimeout(typeaheadTimeout);
-      typeaheadTimeout = null;
-    }
+    resetTypeaheadBuffer.cancel();
   }
 
   $: shouldVirtualize =
@@ -411,16 +411,8 @@
   function typeaheadSearch(character) {
     if (items.length === 0) return;
 
-    if (typeaheadTimeout) {
-      clearTimeout(typeaheadTimeout);
-    }
-
     typeaheadBuffer += character.toLowerCase();
-
-    typeaheadTimeout = setTimeout(() => {
-      typeaheadBuffer = "";
-      typeaheadTimeout = null;
-    }, TYPEAHEAD_DELAY);
+    resetTypeaheadBuffer();
 
     // Start search from the next index after current highlight, or from 0 if none highlighted.
     const startIndex = highlightedIndex >= 0 ? highlightedIndex + 1 : 0;

--- a/src/utils/debounce.d.ts
+++ b/src/utils/debounce.d.ts
@@ -1,0 +1,19 @@
+export type Debounced<Fn extends (...args: unknown[]) => void> = ((
+  ...args: Parameters<Fn>
+) => void) & {
+  /** Discard a pending invocation without calling `fn`. */
+  cancel: () => void;
+  /** Invoke a pending call immediately, if one is scheduled. */
+  flush: () => void;
+};
+
+/**
+ * Create a debounced version of `fn` that postpones invocation until `delay`
+ * milliseconds have elapsed since the last call. Repeated calls within that
+ * window reset the timer, so `fn` runs once after activity settles, using the
+ * arguments from the most recent call.
+ */
+export function debounce<Fn extends (...args: unknown[]) => void>(
+  fn: Fn,
+  delay: number,
+): Debounced<Fn>;

--- a/src/utils/debounce.js
+++ b/src/utils/debounce.js
@@ -1,0 +1,51 @@
+// @ts-check
+/**
+ * Create a debounced version of `fn` that postpones invocation until `delay`
+ * milliseconds have elapsed since the last call. Repeated calls within that
+ * window reset the timer, so `fn` runs once after activity settles, using the
+ * arguments from the most recent call.
+ *
+ * The returned function exposes `cancel()` to discard a pending invocation
+ * (e.g. on component teardown) and `flush()` to invoke a pending call
+ * immediately.
+ *
+ * @template {(...args: any[]) => void} Fn
+ * @param {Fn} fn - Function to debounce.
+ * @param {number} delay - Quiet period in milliseconds before `fn` runs.
+ * @returns {((...args: Parameters<Fn>) => void) & { cancel: () => void; flush: () => void }}
+ */
+export function debounce(fn, delay) {
+  /** @type {ReturnType<typeof setTimeout> | undefined} */
+  let timeoutId;
+  /** @type {Parameters<Fn> | undefined} */
+  let pendingArgs;
+
+  /** @param {Parameters<Fn>} args */
+  function debounced(...args) {
+    pendingArgs = args;
+    clearTimeout(timeoutId);
+    timeoutId = setTimeout(() => {
+      timeoutId = undefined;
+      const args = pendingArgs;
+      pendingArgs = undefined;
+      if (args) fn(...args);
+    }, delay);
+  }
+
+  debounced.cancel = () => {
+    clearTimeout(timeoutId);
+    timeoutId = undefined;
+    pendingArgs = undefined;
+  };
+
+  debounced.flush = () => {
+    if (timeoutId === undefined) return;
+    clearTimeout(timeoutId);
+    timeoutId = undefined;
+    const args = pendingArgs;
+    pendingArgs = undefined;
+    if (args) fn(...args);
+  };
+
+  return debounced;
+}

--- a/tests/Dropdown/Dropdown.test.ts
+++ b/tests/Dropdown/Dropdown.test.ts
@@ -859,6 +859,48 @@ describe("Dropdown", () => {
     expect(apricotOption).toHaveClass("bx--list-box__menu-item--highlighted");
   });
 
+  // The typeahead buffer must reset after a delay of inactivity so a
+  // later keystroke starts a fresh search instead of appending to a
+  // stale buffer. Without the reset, typing "b" then (after a delay) "c"
+  // would search "bc" (no match) and leave Banana highlighted instead of
+  // moving to Cherry. The selected item (Apple) is intentionally excluded
+  // from the assertions because it always carries the highlighted class
+  // regardless of typeahead state.
+  it("should reset the typeahead buffer after the delay", async () => {
+    render(Dropdown, {
+      props: {
+        items: [
+          { id: "0", text: "Apple" },
+          { id: "1", text: "Banana" },
+          { id: "2", text: "Cherry" },
+        ],
+        selectedId: "0",
+      },
+    });
+
+    const button = screen.getByRole("combobox");
+    await user.click(button);
+
+    // Fire keydown only (no keyup) so the menu stays open between keystrokes.
+    await fireEvent.keyDown(button, { key: "b" });
+    expect(screen.getByRole("option", { name: "Banana" })).toHaveClass(
+      "bx--list-box__menu-item--highlighted",
+    );
+
+    // Wait past the delay so the buffer clears.
+    await new Promise((resolve) => setTimeout(resolve, 600));
+
+    // A fresh keystroke starts a new search ("c" -> Cherry) rather than
+    // appending to the stale buffer ("bc" -> no match -> Banana highlighted).
+    await fireEvent.keyDown(button, { key: "c" });
+    expect(screen.getByRole("option", { name: "Cherry" })).toHaveClass(
+      "bx--list-box__menu-item--highlighted",
+    );
+    expect(screen.getByRole("option", { name: "Banana" })).not.toHaveClass(
+      "bx--list-box__menu-item--highlighted",
+    );
+  });
+
   it("should skip disabled items in typeahead search", async () => {
     render(Dropdown, {
       props: {

--- a/tests/utils/debounce.test.ts
+++ b/tests/utils/debounce.test.ts
@@ -1,0 +1,83 @@
+import { debounce } from "../../src/utils/debounce.js";
+
+describe("debounce", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("invokes once after the quiet period", () => {
+    const fn = vi.fn();
+    const debounced = debounce(fn, 100);
+
+    debounced();
+    debounced();
+    debounced();
+    expect(fn).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(100);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  test("repeated calls reset the timer", () => {
+    const fn = vi.fn();
+    const debounced = debounce(fn, 100);
+
+    debounced();
+    vi.advanceTimersByTime(60);
+    debounced();
+    vi.advanceTimersByTime(60);
+    expect(fn).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(40);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  test("invokes with the most recent arguments", () => {
+    const fn = vi.fn();
+    const debounced = debounce(fn, 100);
+
+    debounced("a");
+    debounced("b");
+    vi.advanceTimersByTime(100);
+
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn).toHaveBeenCalledWith("b");
+  });
+
+  test("cancel discards a pending invocation", () => {
+    const fn = vi.fn();
+    const debounced = debounce(fn, 100);
+
+    debounced();
+    debounced.cancel();
+    vi.advanceTimersByTime(100);
+
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  test("flush invokes a pending call immediately", () => {
+    const fn = vi.fn();
+    const debounced = debounce(fn, 100);
+
+    debounced("x");
+    debounced.flush();
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn).toHaveBeenCalledWith("x");
+
+    // No double-invoke once the timer would have fired.
+    vi.advanceTimersByTime(100);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  test("flush is a no-op when nothing is pending", () => {
+    const fn = vi.fn();
+    const debounced = debounce(fn, 100);
+
+    debounced.flush();
+    expect(fn).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Extract a `debounce` utility, which can also be applied to `Search`, `CommandPalette` down the line.