### PR TITLE
fix(package): include CSS type definitions in `package.json` exports map

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -198,6 +198,8 @@ jobs:
 
       - run: bun run test:src-types
 
+      - run: bun run test:package-exports
+
   deploy-docs:
     needs: [lint, changes, test, types]
     if: |

--- a/css/css.d.ts
+++ b/css/css.d.ts
@@ -1,0 +1,6 @@
+declare module "carbon-components-svelte/css/all.css";
+declare module "carbon-components-svelte/css/g10.css";
+declare module "carbon-components-svelte/css/g100.css";
+declare module "carbon-components-svelte/css/g80.css";
+declare module "carbon-components-svelte/css/g90.css";
+declare module "carbon-components-svelte/css/white.css";

--- a/package.json
+++ b/package.json
@@ -12,7 +12,10 @@
       "types": "./src/index.d.ts",
       "svelte": "./src/index.js"
     },
-    "./css/*": "./css/*",
+    "./css/*.css": {
+      "types": "./css/css.d.ts",
+      "default": "./css/*.css"
+    },
     "./src/*.svelte": {
       "types": "./src/*.svelte.d.ts",
       "import": "./src/*.svelte"

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "setup": "bun ci && bun build:docs && cd docs && bun ci",
     "test": "vitest",
     "test:src-types": "tsgo --project tsconfig.types.json",
+    "test:package-exports": "tsgo --project tsconfig.package-exports.json",
     "test:types": "svelte-check --workspace tests --tsgo --fail-on-warnings",
     "test:svelte3": "cd tests-svelte3 && bunx vitest",
     "test:types:svelte3": "cd tests-svelte3 && bun run test:types",

--- a/scripts/build-css.ts
+++ b/scripts/build-css.ts
@@ -41,4 +41,13 @@ await Promise.all(
     await Bun.write(outFile, prefixed.css);
   }),
 );
+
+const cssTypes = scss
+  .map(
+    ({ name }) => `declare module "carbon-components-svelte/css/${name}.css";`,
+  )
+  .join("\n");
+
+await Bun.write("css/css.d.ts", `${cssTypes}\n`);
+
 console.timeEnd("[build-css]");

--- a/tests/package-exports.test-d.ts
+++ b/tests/package-exports.test-d.ts
@@ -1,0 +1,38 @@
+import type {
+  Button as BarrelButton,
+  DataTable as BarrelDataTable,
+  breakpointObserver,
+  breakpoints,
+} from "carbon-components-svelte";
+import type breakpointObserverDefault from "carbon-components-svelte/src/Breakpoint/breakpointObserver.js";
+import type { BreakpointSize } from "carbon-components-svelte/src/Breakpoint/breakpoints.js";
+import type Button from "carbon-components-svelte/src/Button/Button.svelte";
+import type DataTable from "carbon-components-svelte/src/DataTable/DataTable.svelte";
+import type { DataTableRow } from "carbon-components-svelte/src/DataTable/DataTable.svelte";
+import type {
+  CarbonTheme,
+  ThemeProps,
+  themes,
+} from "carbon-components-svelte/src/Theme/Theme.svelte";
+import type { HeaderSearchResult } from "carbon-components-svelte/src/UIShell/HeaderSearch.svelte";
+
+import "carbon-components-svelte/css/all.css";
+import "carbon-components-svelte/css/g100.css";
+import "carbon-components-svelte/css/g10.css";
+import "carbon-components-svelte/css/g80.css";
+import "carbon-components-svelte/css/g90.css";
+import "carbon-components-svelte/css/white.css";
+
+type _BarrelButton = BarrelButton;
+type _BarrelDataTable = BarrelDataTable;
+type _BreakpointObserver = ReturnType<typeof breakpointObserver>;
+type _BreakpointObserverDefault = typeof breakpointObserverDefault;
+type _BreakpointSize = BreakpointSize;
+type _Breakpoints = typeof breakpoints;
+type _Button = Button;
+type _CarbonTheme = CarbonTheme;
+type _DataTable = DataTable;
+type _DataTableRow = DataTableRow<{ id: string; name: string }>;
+type _HeaderSearchResult = HeaderSearchResult;
+type _ThemeProps = ThemeProps;
+type _Themes = typeof themes;

--- a/tsconfig.package-exports.json
+++ b/tsconfig.package-exports.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "noEmit": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noUncheckedSideEffectImports": true
+  },
+  "include": ["tests/package-exports.test-d.ts"]
+}


### PR DESCRIPTION
Include type defs for imported CSS files; intended to resolve TypeScript errors when importing a Carbon StyleSheet directly in the script block (instead of a TS file).