### PR TITLE
refactor: apply `moveIndex` / `nextEnabledIndex` utils to navigation

### DIFF
--- a/src/ComboBox/ComboBox.svelte
+++ b/src/ComboBox/ComboBox.svelte
@@ -213,6 +213,7 @@
   import ListBoxMenuItem from "../ListBox/ListBoxMenuItem.svelte";
   import ListBoxSelection from "../ListBox/ListBoxSelection.svelte";
   import { getMenuMaxHeight } from "../ListBox/list-box-utils.js";
+  import { nextEnabledIndex } from "../utils/moveIndex.js";
   import {
     resetVirtualScrollOnClose,
     scrollHighlightedIntoView,
@@ -260,31 +261,12 @@
     : shouldFilterItem;
 
   function change(step) {
-    let candidateIndex = highlightedIndex + step;
     const navigableItems = filteredItems?.length ? filteredItems : items;
-    if (navigableItems.length === 0) return;
-    if (candidateIndex < 0) {
-      candidateIndex = navigableItems.length - 1;
-    } else if (candidateIndex >= navigableItems.length) {
-      candidateIndex = 0;
-    }
-    let itemDisabled = navigableItems[candidateIndex].disabled;
-    let attempts = 0;
-
-    while (itemDisabled && attempts < navigableItems.length) {
-      candidateIndex = candidateIndex + step;
-
-      if (candidateIndex < 0) {
-        candidateIndex = navigableItems.length - 1;
-      } else if (candidateIndex >= navigableItems.length) {
-        candidateIndex = 0;
-      }
-
-      itemDisabled = navigableItems[candidateIndex].disabled;
-      attempts++;
-    }
-
-    if (!itemDisabled) highlightedIndex = candidateIndex;
+    highlightedIndex = nextEnabledIndex({
+      items: navigableItems,
+      index: highlightedIndex,
+      step,
+    });
   }
 
   /**

--- a/src/ContentSwitcher/ContentSwitcher.svelte
+++ b/src/ContentSwitcher/ContentSwitcher.svelte
@@ -31,6 +31,7 @@
 
   import { afterUpdate, createEventDispatcher, setContext, tick } from "svelte";
   import { writable } from "svelte/store";
+  import { moveIndex } from "../utils/moveIndex.js";
   import { syncDomOrder } from "../utils/syncDomOrder.js";
 
   const dispatch = createEventDispatcher();
@@ -105,15 +106,7 @@
    * @type {(direction: number) => Promise<void>}
    */
   const change = async (direction) => {
-    let index = currentIndex + direction;
-
-    if (index < 0) {
-      index = switches.length - 1;
-    } else if (index >= switches.length) {
-      index = 0;
-    }
-
-    await changeTo(index);
+    await changeTo(moveIndex(currentIndex, direction, switches.length));
   };
 
   /**
@@ -137,15 +130,7 @@
    */
   const focus = async (direction) => {
     const base = focusedIndex >= 0 ? focusedIndex : currentIndex;
-    let index = base + direction;
-
-    if (index < 0) {
-      index = switches.length - 1;
-    } else if (index >= switches.length) {
-      index = 0;
-    }
-
-    await focusTo(index);
+    await focusTo(moveIndex(base, direction, switches.length));
   };
 
   setContext("carbon:ContentSwitcher", {

--- a/src/Dropdown/Dropdown.svelte
+++ b/src/Dropdown/Dropdown.svelte
@@ -168,6 +168,7 @@
   } from "../ListBox";
   import { getMenuMaxHeight } from "../ListBox/list-box-utils.js";
   import { debounce } from "../utils/debounce.js";
+  import { nextEnabledIndex } from "../utils/moveIndex.js";
   import {
     resetVirtualScrollOnClose,
     scrollHighlightedIntoView,
@@ -333,32 +334,11 @@
   });
 
   function change(step) {
-    let candidateIndex = highlightedIndex + step;
-
-    if (items.length === 0) return;
-    if (candidateIndex < 0) {
-      candidateIndex = items.length - 1;
-    } else if (candidateIndex >= items.length) {
-      candidateIndex = 0;
-    }
-
-    let itemDisabled = items[candidateIndex].disabled;
-    let attempts = 0;
-
-    while (itemDisabled && attempts < items.length) {
-      candidateIndex = candidateIndex + step;
-
-      if (candidateIndex < 0) {
-        candidateIndex = items.length - 1;
-      } else if (candidateIndex >= items.length) {
-        candidateIndex = 0;
-      }
-
-      itemDisabled = items[candidateIndex].disabled;
-      attempts++;
-    }
-
-    if (!itemDisabled) highlightedIndex = candidateIndex;
+    highlightedIndex = nextEnabledIndex({
+      items,
+      index: highlightedIndex,
+      step,
+    });
   }
 
   function typeaheadSearch(character) {

--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -259,6 +259,7 @@
     ListBoxSelection,
   } from "../ListBox";
   import { getMenuMaxHeight } from "../ListBox/list-box-utils.js";
+  import { nextEnabledIndex } from "../utils/moveIndex.js";
   import {
     resetVirtualScrollOnClose,
     scrollHighlightedIntoView,
@@ -299,33 +300,12 @@
   });
 
   function change(step) {
-    let candidateIndex = highlightedIndex + step;
     const navigableItems = filterable ? filteredItems : sortedItems;
-    const length = navigableItems.length;
-    if (length === 0) return;
-    if (candidateIndex < 0) {
-      candidateIndex = length - 1;
-    } else if (candidateIndex >= length) {
-      candidateIndex = 0;
-    }
-
-    let itemDisabled = navigableItems[candidateIndex].disabled;
-    let attempts = 0;
-
-    while (itemDisabled && attempts < length) {
-      candidateIndex = candidateIndex + step;
-
-      if (candidateIndex < 0) {
-        candidateIndex = length - 1;
-      } else if (candidateIndex >= length) {
-        candidateIndex = 0;
-      }
-
-      itemDisabled = navigableItems[candidateIndex].disabled;
-      attempts++;
-    }
-
-    if (!itemDisabled) highlightedIndex = candidateIndex;
+    highlightedIndex = nextEnabledIndex({
+      items: navigableItems,
+      index: highlightedIndex,
+      step,
+    });
   }
 
   /** Handle selection of an item, including isSelectAll logic. */

--- a/src/OverflowMenu/OverflowMenu.svelte
+++ b/src/OverflowMenu/OverflowMenu.svelte
@@ -88,6 +88,7 @@
   import OverflowMenuHorizontal from "../icons/OverflowMenuHorizontal.svelte";
   import OverflowMenuVertical from "../icons/OverflowMenuVertical.svelte";
   import FloatingPortal from "../Portal/FloatingPortal.svelte";
+  import { nextEnabledIndex } from "../utils/moveIndex.js";
 
   const ctxBreadcrumbItem = getContext("carbon:BreadcrumbItem");
   const insideModal = getContext("carbon:Modal");
@@ -152,32 +153,13 @@
    * @type {(direction: number) => void}
    */
   const change = (direction) => {
-    let index = $currentIndex + direction;
-
-    if (index < 0) {
-      index = $items.length - 1;
-    } else if (index >= $items.length) {
-      index = 0;
-    }
-
-    const start = index;
-    let disabled = $items[index].disabled;
-
-    while (disabled) {
-      index = index + direction;
-
-      if (index < 0) {
-        index = $items.length - 1;
-      } else if (index >= $items.length) {
-        index = 0;
-      }
-
-      if (index === start) return;
-
-      disabled = $items[index].disabled;
-    }
-
-    currentIndex.set(index);
+    currentIndex.set(
+      nextEnabledIndex({
+        items: $items,
+        index: $currentIndex,
+        step: direction,
+      }),
+    );
   };
 
   const first = () => {

--- a/src/Tabs/Tabs.svelte
+++ b/src/Tabs/Tabs.svelte
@@ -33,6 +33,7 @@
   import { afterUpdate, createEventDispatcher, setContext, tick } from "svelte";
   import { derived, writable } from "svelte/store";
   import ChevronDown from "../icons/ChevronDown.svelte";
+  import { nextEnabledIndex } from "../utils/moveIndex.js";
   import { syncDomOrder } from "../utils/syncDomOrder.js";
 
   const dispatch = createEventDispatcher();
@@ -132,33 +133,15 @@
    * @type {(direction: number) => Promise<void>}
    */
   const change = async (direction) => {
-    let index = currentIndex + direction;
+    const nextIndex = nextEnabledIndex({
+      items: $tabs,
+      index: currentIndex,
+      step: direction,
+    });
 
-    if (index < 0) {
-      index = $tabs.length - 1;
-    } else if (index >= $tabs.length) {
-      index = 0;
-    }
+    if (nextIndex === currentIndex) return;
 
-    let disabled = $tabs[index].disabled;
-    let attempts = 0;
-
-    while (disabled && attempts < $tabs.length) {
-      index = index + direction;
-
-      if (index < 0) {
-        index = $tabs.length - 1;
-      } else if (index >= $tabs.length) {
-        index = 0;
-      }
-
-      disabled = $tabs[index].disabled;
-      attempts++;
-    }
-
-    if (disabled) return;
-
-    currentIndex = index;
+    currentIndex = nextIndex;
 
     await tick();
     const activeTab =

--- a/src/utils/moveIndex.d.ts
+++ b/src/utils/moveIndex.d.ts
@@ -1,0 +1,24 @@
+/**
+ * Cyclic index movement for keyboard navigation. `moveIndex` is the wrap-only
+ * primitive; `nextEnabledIndex` layers disabled-skipping on top.
+ */
+
+/**
+ * Move `index` by `step` and wrap once at either end: a result past the end
+ * becomes the first item and a result before the start becomes the last item.
+ * Returns -1 for an empty range. Designed for single-step moves (`step` ±1).
+ */
+export function moveIndex(index: number, step: number, length: number): number;
+
+/**
+ * From `index`, move by `step` cyclically and return the first index whose item
+ * is enabled. Returns the original `index` when no enabled item exists, so
+ * callers can leave selection unchanged.
+ */
+export function nextEnabledIndex<T>(options: {
+  items: ReadonlyArray<T>;
+  index: number;
+  step: number;
+  /** Defaults to `item.disabled`. */
+  isDisabled?: (item: T) => boolean;
+}): number;

--- a/src/utils/moveIndex.js
+++ b/src/utils/moveIndex.js
@@ -1,0 +1,54 @@
+// @ts-check
+// Cyclic index movement for keyboard navigation. Components like Dropdown,
+// ComboBox, MultiSelect, Tabs, OverflowMenu, and ContentSwitcher move a
+// highlighted/selected index by a step, wrap at the ends, and (for most) skip
+// disabled items. `moveIndex` is the wrap-only primitive; `nextEnabledIndex`
+// layers disabled-skipping on top.
+
+/**
+ * Move `index` by `step` and wrap once at either end: a result past the end
+ * becomes the first item and a result before the start becomes the last item.
+ * Returns -1 for an empty range. Designed for single-step moves (`step` ±1), so
+ * stepping up from -1 ("nothing selected") lands on the last item and stepping
+ * down from -1 lands on the first.
+ *
+ * @param {number} index - Current index (may be -1 when nothing is selected).
+ * @param {number} step - Amount/direction to move (e.g. 1 or -1).
+ * @param {number} length - Number of items.
+ * @returns {number}
+ */
+export function moveIndex(index, step, length) {
+  if (length <= 0) return -1;
+  const next = index + step;
+  if (next < 0) return length - 1;
+  if (next >= length) return 0;
+  return next;
+}
+
+/**
+ * From `index`, move by `step` cyclically and return the first index whose item
+ * is enabled. Returns the original `index` when no enabled item exists (e.g. all
+ * items disabled), so callers can leave selection unchanged. `index` may be -1
+ * (nothing selected) — `moveIndex(-1, 1, n)` → 0 and `moveIndex(-1, -1, n)` →
+ * n-1, landing on the first/last item respectively.
+ *
+ * @template T
+ * @param {object} options
+ * @param {ReadonlyArray<T>} options.items
+ * @param {number} options.index - Current index (may be -1).
+ * @param {number} options.step - Direction/magnitude to move (e.g. 1 or -1).
+ * @param {(item: T) => boolean} [options.isDisabled] - Defaults to `item.disabled`.
+ * @returns {number}
+ */
+export function nextEnabledIndex({ items, index, step, isDisabled }) {
+  const length = items.length;
+  if (length === 0) return index;
+  const disabled = isDisabled ?? ((item) => Boolean(item?.disabled));
+  let candidate = moveIndex(index, step, length);
+  let attempts = 0;
+  while (disabled(items[candidate]) && attempts < length) {
+    candidate = moveIndex(candidate, step, length);
+    attempts++;
+  }
+  return disabled(items[candidate]) ? index : candidate;
+}

--- a/tests/utils/moveIndex.test.ts
+++ b/tests/utils/moveIndex.test.ts
@@ -1,0 +1,115 @@
+import { moveIndex, nextEnabledIndex } from "../../src/utils/moveIndex.js";
+
+describe("moveIndex", () => {
+  test("moves forward and backward within range", () => {
+    expect(moveIndex(0, 1, 3)).toBe(1);
+    expect(moveIndex(2, -1, 3)).toBe(1);
+  });
+
+  test("wraps from last to first and first to last", () => {
+    expect(moveIndex(2, 1, 3)).toBe(0);
+    expect(moveIndex(0, -1, 3)).toBe(2);
+  });
+
+  test("treats -1 as 'nothing selected': step up lands on last, down on first", () => {
+    expect(moveIndex(-1, 1, 3)).toBe(0);
+    expect(moveIndex(-1, -1, 3)).toBe(2);
+  });
+
+  test("returns -1 for an empty range", () => {
+    expect(moveIndex(0, 1, 0)).toBe(-1);
+    expect(moveIndex(0, -1, 0)).toBe(-1);
+  });
+});
+
+describe("nextEnabledIndex", () => {
+  const items = (...disabled: boolean[]) =>
+    disabled.map((d, i) => ({ id: i, disabled: d }));
+
+  test("moves to the next enabled neighbor", () => {
+    const result = nextEnabledIndex({
+      items: items(false, false, false),
+      index: 0,
+      step: 1,
+    });
+    expect(result).toBe(1);
+  });
+
+  test("skips a single disabled neighbor", () => {
+    const result = nextEnabledIndex({
+      items: items(false, true, false),
+      index: 0,
+      step: 1,
+    });
+    expect(result).toBe(2);
+  });
+
+  test("skips a run of disabled items", () => {
+    const result = nextEnabledIndex({
+      items: items(false, true, true, false),
+      index: 0,
+      step: 1,
+    });
+    expect(result).toBe(3);
+  });
+
+  test("wraps past the end, skipping disabled", () => {
+    const result = nextEnabledIndex({
+      items: items(false, false, true),
+      index: 1,
+      step: 1,
+    });
+    expect(result).toBe(0);
+  });
+
+  test("wraps backward past the start", () => {
+    const result = nextEnabledIndex({
+      items: items(true, false, false),
+      index: 1,
+      step: -1,
+    });
+    expect(result).toBe(2);
+  });
+
+  test("returns the original index when every item is disabled", () => {
+    const result = nextEnabledIndex({
+      items: items(true, true, true),
+      index: 1,
+      step: 1,
+    });
+    expect(result).toBe(1);
+  });
+
+  test("lands on the first enabled item when starting from -1", () => {
+    const result = nextEnabledIndex({
+      items: items(true, false, false),
+      index: -1,
+      step: 1,
+    });
+    expect(result).toBe(1);
+  });
+
+  test("lands on the last enabled item when starting from -1 going backward", () => {
+    const result = nextEnabledIndex({
+      items: items(false, false, true),
+      index: -1,
+      step: -1,
+    });
+    expect(result).toBe(1);
+  });
+
+  test("supports a custom isDisabled predicate", () => {
+    const data = [{ ok: true }, { ok: false }, { ok: true }];
+    const result = nextEnabledIndex({
+      items: data,
+      index: 0,
+      step: 1,
+      isDisabled: (item) => !item.ok,
+    });
+    expect(result).toBe(2);
+  });
+
+  test("returns the original index for an empty items array", () => {
+    expect(nextEnabledIndex({ items: [], index: -1, step: 1 })).toBe(-1);
+  });
+});


### PR DESCRIPTION
Replace hand-rolled cyclic index movement in Dropdown, ComboBox, MultiSelect, Tabs, and OverflowMenu with `nextEnabledIndex`, and in ContentSwitcher (no disabled-skip) with `moveIndex`.
