### PR TITLE
fix(tabs): prevent infinite loop when all items are disabled

### DIFF
--- a/src/Tabs/Tab.svelte
+++ b/src/Tabs/Tab.svelte
@@ -97,14 +97,12 @@
   on:mouseenter
   on:mouseleave
   on:keydown={(event) => {
-    if (!disabled) {
-      if (event.key === "ArrowRight") {
-        change(1);
-      } else if (event.key === "ArrowLeft") {
-        change(-1);
-      } else if (event.key === " " || event.key === "Enter") {
-        update(id);
-      }
+    if (event.key === "ArrowRight") {
+      change(1);
+    } else if (event.key === "ArrowLeft") {
+      change(-1);
+    } else if (!disabled && (event.key === " " || event.key === "Enter")) {
+      update(id);
     }
   }}
 >

--- a/src/Tabs/Tabs.svelte
+++ b/src/Tabs/Tabs.svelte
@@ -141,8 +141,9 @@
     }
 
     let disabled = $tabs[index].disabled;
+    let attempts = 0;
 
-    while (disabled) {
+    while (disabled && attempts < $tabs.length) {
       index = index + direction;
 
       if (index < 0) {
@@ -152,7 +153,10 @@
       }
 
       disabled = $tabs[index].disabled;
+      attempts++;
     }
+
+    if (disabled) return;
 
     currentIndex = index;
 

--- a/tests/Tabs/Tabs.test.ts
+++ b/tests/Tabs/Tabs.test.ts
@@ -10,6 +10,7 @@ import TabIconContainer from "./TabIconContainer.test.svelte";
 import TabIconSecondaryLabel from "./TabIconSecondaryLabel.test.svelte";
 import TabSecondaryLabel from "./TabSecondaryLabel.test.svelte";
 import Tabs from "./Tabs.test.svelte";
+import TabsAllDisabled from "./TabsAllDisabled.test.svelte";
 import TabsDynamic from "./TabsDynamic.test.svelte";
 import TabsSkeleton from "./TabsSkeleton.test.svelte";
 
@@ -68,6 +69,21 @@ describe("Tabs", () => {
 
     expect(tab2).toHaveAttribute("aria-selected", "false");
     expect(screen.getByText("Content 1")).toBeVisible();
+  });
+
+  it("does not infinite-loop when all items are disabled", async () => {
+    render(TabsAllDisabled);
+
+    const tab1 = screen.getByRole("tab", { name: "Tab 1" });
+    await user.click(tab1);
+    expect(tab1).toHaveAttribute("aria-selected", "true");
+
+    await user.keyboard("{ArrowRight}");
+    await user.keyboard("{ArrowLeft}");
+    await user.keyboard("{ArrowRight}");
+
+    expect(screen.getByText("Content 1")).toBeVisible();
+    expect(tab1).toHaveAttribute("aria-selected", "true");
   });
 
   it("should support keyboard navigation", async () => {

--- a/tests/Tabs/TabsAllDisabled.test.svelte
+++ b/tests/Tabs/TabsAllDisabled.test.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+  import { Tab, TabContent, Tabs } from "carbon-components-svelte";
+</script>
+
+<Tabs>
+  <Tab label="Tab 1" disabled />
+  <Tab label="Tab 2" disabled />
+  <Tab label="Tab 3" disabled />
+  <svelte:fragment slot="content">
+    <TabContent>Content 1</TabContent>
+    <TabContent>Content 2</TabContent>
+    <TabContent>Content 3</TabContent>
+  </svelte:fragment>
+</Tabs>


### PR DESCRIPTION
Similar to #2984, avoid this edge case if all tab items are disabled.