### PR TITLE
refactor(context-menu): apply `clampIndex` util

### DIFF
--- a/src/ContextMenu/ContextMenu.svelte
+++ b/src/ContextMenu/ContextMenu.svelte
@@ -51,6 +51,7 @@
     setContext,
   } from "svelte";
   import { writable } from "svelte/store";
+  import { clampIndex } from "../utils/clampIndex.js";
 
   const dispatch = createEventDispatcher();
   /**
@@ -223,13 +224,9 @@
     if ($hasPopup) return;
 
     if (event.key === "ArrowDown") {
-      if (focusIndex < options.length - 1) focusIndex++;
+      focusIndex = clampIndex(focusIndex, 1, options.length);
     } else if (event.key === "ArrowUp") {
-      if (focusIndex === -1) {
-        focusIndex = options.length - 1;
-      } else {
-        if (focusIndex > 0) focusIndex--;
-      }
+      focusIndex = clampIndex(focusIndex, -1, options.length);
     } else if (event.key === "Home") {
       if (options.length > 0) focusIndex = 0;
     } else if (event.key === "End" && options.length > 0) {

--- a/src/ContextMenu/ContextMenuOption.svelte
+++ b/src/ContextMenu/ContextMenuOption.svelte
@@ -82,6 +82,7 @@
   import { createEventDispatcher, getContext, onMount, tick } from "svelte";
   import CaretRight from "../icons/CaretRight.svelte";
   import Checkmark from "../icons/Checkmark.svelte";
+  import { clampIndex } from "../utils/clampIndex.js";
   import ContextMenu from "./ContextMenu.svelte";
 
   const dispatch = createEventDispatcher();
@@ -343,13 +344,9 @@
       }
 
       if (event.key === "ArrowDown") {
-        if (focusIndex < options.length - 1) focusIndex++;
+        focusIndex = clampIndex(focusIndex, 1, options.length);
       } else if (event.key === "ArrowUp") {
-        if (focusIndex === -1) {
-          focusIndex = options.length - 1;
-        } else {
-          if (focusIndex > 0) focusIndex--;
-        }
+        focusIndex = clampIndex(focusIndex, -1, options.length);
       } else if (event.key === "Home") {
         if (options.length > 0) focusIndex = 0;
       } else if (event.key === "End" && options.length > 0) {

--- a/src/utils/clampIndex.d.ts
+++ b/src/utils/clampIndex.d.ts
@@ -1,0 +1,9 @@
+/**
+ * Clamped index movement for keyboard navigation. Stops at the ends instead of wrapping.
+ */
+
+/**
+ * Move `index` by `step` and clamp to `[0, length - 1]`. Returns -1 for an empty range.
+ * From `index` of -1, moving up enters at the last item and moving down at the first.
+ */
+export function clampIndex(index: number, step: number, length: number): number;

--- a/src/utils/clampIndex.js
+++ b/src/utils/clampIndex.js
@@ -1,0 +1,18 @@
+// @ts-check
+// Clamped index movement for keyboard navigation. Stops at the ends instead of wrapping.
+
+/**
+ * Move `index` by `step` and clamp to `[0, length - 1]`. Returns -1 for an empty range.
+ * From `index` of -1, moving up enters at the last item and moving down at the first.
+ *
+ * @param {number} index
+ * @param {number} step
+ * @param {number} length
+ * @returns {number}
+ */
+export function clampIndex(index, step, length) {
+  if (length <= 0) return -1;
+  if (index < 0) return step < 0 ? length - 1 : 0;
+  const next = index + step;
+  return Math.min(Math.max(next, 0), length - 1);
+}

--- a/tests/utils/clampIndex.test.ts
+++ b/tests/utils/clampIndex.test.ts
@@ -1,0 +1,23 @@
+import { clampIndex } from "../../src/utils/clampIndex.js";
+
+describe("clampIndex", () => {
+  test("moves forward and backward within range", () => {
+    expect(clampIndex(0, 1, 3)).toBe(1);
+    expect(clampIndex(2, -1, 3)).toBe(1);
+  });
+
+  test("clamps at the ends instead of wrapping", () => {
+    expect(clampIndex(2, 1, 3)).toBe(2);
+    expect(clampIndex(0, -1, 3)).toBe(0);
+  });
+
+  test("treats -1 as 'nothing selected': step up lands on last, down on first", () => {
+    expect(clampIndex(-1, 1, 3)).toBe(0);
+    expect(clampIndex(-1, -1, 3)).toBe(2);
+  });
+
+  test("returns -1 for an empty range", () => {
+    expect(clampIndex(0, 1, 0)).toBe(-1);
+    expect(clampIndex(-1, -1, 0)).toBe(-1);
+  });
+});


### PR DESCRIPTION
Extract the util; unlike `moveIndex` (#3128), the `ContextMenu` keyboard behavior is clamped to the beginning and end.