### PR TITLE
fix(toggle): do not render empty label span when no label provided

### DIFF
--- a/src/Toggle/Toggle.svelte
+++ b/src/Toggle/Toggle.svelte
@@ -96,9 +96,11 @@
     for={id}
     class:bx--toggle-input__label={true}
   >
-    <span class:bx--visually-hidden={hideLabel}>
-      <slot name="labelChildren"> {labelText} </slot>
-    </span>
+    {#if labelText || $$slots.labelChildren}
+      <span class:bx--visually-hidden={hideLabel}>
+        <slot name="labelChildren"> {labelText} </slot>
+      </span>
+    {/if}
     <span
       class:bx--toggle__switch={true}
       style:margin-top={hideLabel ? 0 : undefined}

--- a/tests/Toggle/Toggle.test.ts
+++ b/tests/Toggle/Toggle.test.ts
@@ -330,6 +330,18 @@ describe("Toggle", () => {
     });
   });
 
+  it("does not render label text span when labelText is empty and no labelChildren slot", () => {
+    const { container } = render(ToggleNullishAriaLabel, {
+      props: { ariaLabel: "Toggle" },
+    });
+    const label = container.querySelector("label.bx--toggle-input__label");
+    expect(label).toBeInTheDocument();
+    // Only the switch span should be a direct child of the label.
+    const directSpans = label?.querySelectorAll(":scope > span") ?? [];
+    expect(directSpans).toHaveLength(1);
+    expect(directSpans[0]).toHaveClass("bx--toggle__switch");
+  });
+
   // Regression: ?? for aria-label so empty string is used (not fallback)
   it("ToggleSkeleton uses empty aria-label when passed (nullish coalescing)", () => {
     render(ToggleSkeletonNullishAriaLabel, { props: { ariaLabel: "" } });


### PR DESCRIPTION
Similar to other components that have labelText/labelChildren, guard it so an empty label is not rendered if a value is not provided.