### PR TITLE
test: baseline coverage for outside click behavior

### DIFF
--- a/tests/ComboBox/ComboBox.test.ts
+++ b/tests/ComboBox/ComboBox.test.ts
@@ -2051,6 +2051,22 @@ describe("ComboBox", () => {
       const floatingPortal = menu.closest("[data-floating-portal]");
       expect(floatingPortal).not.toBeInTheDocument();
     });
+
+    it("should close portaled menu when clicking outside", async () => {
+      render(ComboBox, {
+        props: { portalMenu: true },
+      });
+
+      await user.click(getInput());
+      const menu = screen.getAllByRole("listbox")[1];
+      expect(menu).toBeVisible();
+      expect(menu.closest("[data-floating-portal]")?.parentElement).toBe(
+        document.body,
+      );
+
+      await user.click(document.body);
+      expect(screen.getAllByRole("listbox")).toHaveLength(1);
+    });
   });
 
   it("should not trap focus when tabbing away from an open menu", async () => {

--- a/tests/Dropdown/Dropdown.test.ts
+++ b/tests/Dropdown/Dropdown.test.ts
@@ -382,6 +382,24 @@ describe("Dropdown", () => {
     expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
   });
 
+  it("should stay open when window click has a non-Node target", () => {
+    render(Dropdown, {
+      props: {
+        items,
+        selectedId: "0",
+        open: true,
+      },
+    });
+
+    expect(screen.getByRole("listbox")).toBeVisible();
+
+    const event = new Event("click", { bubbles: true });
+    Object.defineProperty(event, "target", { value: null });
+    window.dispatchEvent(event);
+
+    expect(screen.getByRole("listbox")).toBeVisible();
+  });
+
   it("should handle direction prop", () => {
     render(Dropdown, {
       props: {
@@ -1778,6 +1796,27 @@ describe("Dropdown", () => {
           document.body,
         );
       });
+    });
+
+    it("should close portaled menu when clicking outside", async () => {
+      render(Dropdown, {
+        props: {
+          items,
+          selectedId: "0",
+          portalMenu: true,
+        },
+      });
+
+      const combobox = screen.getByRole("combobox");
+      await user.click(combobox);
+      const menu = screen.getByRole("listbox");
+      expect(menu).toBeInTheDocument();
+      expect(menu.closest("[data-floating-portal]")?.parentElement).toBe(
+        document.body,
+      );
+
+      await user.click(document.body);
+      expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
     });
 
     // Regression test for https://github.com/carbon-design-system/carbon-components-svelte/issues/2699

--- a/tests/MultiSelect/MultiSelect.test.ts
+++ b/tests/MultiSelect/MultiSelect.test.ts
@@ -2358,6 +2358,64 @@ describe("MultiSelect", () => {
       expect(host).toHaveClass("bx--list-box--expanded");
       expect(host?.parentElement).toHaveAttribute("data-floating-portal");
     });
+
+    it("should close portaled menu when clicking outside", async () => {
+      render(MultiSelect, {
+        props: {
+          items: [
+            { id: "0", text: "Slack" },
+            { id: "1", text: "Email" },
+          ],
+          portalMenu: true,
+        },
+      });
+
+      await openMenu();
+      const menu = screen.getByRole("listbox");
+      expect(menu).toBeInTheDocument();
+      expect(menu.closest("[data-floating-portal]")?.parentElement).toBe(
+        document.body,
+      );
+
+      await user.click(document.body);
+      expect(screen.getByRole("combobox")).toHaveAttribute(
+        "aria-expanded",
+        "false",
+      );
+    });
+
+    it("should close portaled menu when focus moves outside", async () => {
+      const externalButton = document.createElement("button");
+      externalButton.textContent = "Outside";
+      document.body.appendChild(externalButton);
+
+      try {
+        render(MultiSelect, {
+          props: {
+            items: [
+              { id: "0", text: "Slack" },
+              { id: "1", text: "Email" },
+            ],
+            portalMenu: true,
+          },
+        });
+
+        await openMenu();
+        const combobox = screen.getByRole("combobox");
+        expect(combobox).toHaveAttribute("aria-expanded", "true");
+        expect(
+          screen.getByRole("listbox").closest("[data-floating-portal]")
+            ?.parentElement,
+        ).toBe(document.body);
+
+        externalButton.focus();
+        await tick();
+
+        expect(combobox).toHaveAttribute("aria-expanded", "false");
+      } finally {
+        externalButton.remove();
+      }
+    });
   });
 
   describe("filterable: Backspace/Delete clears selection", () => {

--- a/tests/MultiSelect/MultiSelect.test.ts
+++ b/tests/MultiSelect/MultiSelect.test.ts
@@ -2402,11 +2402,11 @@ describe("MultiSelect", () => {
 
         await openMenu();
         const combobox = screen.getByRole("combobox");
+        const menu = screen.getByRole("listbox");
         expect(combobox).toHaveAttribute("aria-expanded", "true");
-        expect(
-          screen.getByRole("listbox").closest("[data-floating-portal]")
-            ?.parentElement,
-        ).toBe(document.body);
+        expect(menu.closest("[data-floating-portal]")?.parentElement).toBe(
+          document.body,
+        );
 
         externalButton.focus();
         await tick();

--- a/tests/UIShell/HeaderAction.outsideClick.test.svelte
+++ b/tests/UIShell/HeaderAction.outsideClick.test.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+  import {
+    Header,
+    HeaderAction,
+    HeaderUtilities,
+  } from "carbon-components-svelte";
+
+  export let preventCloseOnClickOutside = false;
+
+  let isOpen = false;
+</script>
+
+<Header companyName="Test" platformName="Test">
+  <HeaderUtilities>
+    <HeaderAction
+      bind:isOpen
+      {preventCloseOnClickOutside}
+      transition={false}
+      iconDescription="Switcher"
+    >
+      <p data-testid="panel-content">Panel content</p>
+    </HeaderAction>
+  </HeaderUtilities>
+</Header>

--- a/tests/UIShell/HeaderAction.test.ts
+++ b/tests/UIShell/HeaderAction.test.ts
@@ -1,6 +1,8 @@
 import { render, screen } from "@testing-library/svelte";
 import type HeaderActionComponent from "carbon-components-svelte/UIShell/HeaderAction.svelte";
 import type { ComponentProps } from "svelte";
+import { user } from "../utils/user";
+import HeaderActionOutsideClick from "./HeaderAction.outsideClick.test.svelte";
 import HeaderActionSlot from "./HeaderAction.slot.test.svelte";
 
 describe("HeaderAction", () => {
@@ -20,6 +22,39 @@ describe("HeaderAction", () => {
 
     const customIcon = screen.getByTestId("custom-icon");
     expect(customIcon).toBeInTheDocument();
+  });
+
+  describe("outside click", () => {
+    const getActionButton = () =>
+      screen.getByRole("button", { name: "Switcher" });
+
+    it("closes when clicking outside", async () => {
+      render(HeaderActionOutsideClick);
+
+      await user.click(getActionButton());
+      expect(getActionButton()).toHaveClass("bx--header__action--active");
+
+      await user.click(document.body);
+      expect(getActionButton()).not.toHaveClass("bx--header__action--active");
+    });
+
+    it("stays open when clicking panel content", async () => {
+      render(HeaderActionOutsideClick);
+
+      await user.click(getActionButton());
+      await user.click(screen.getByTestId("panel-content"));
+      expect(screen.getByTestId("panel-content")).toBeInTheDocument();
+    });
+
+    it("respects preventCloseOnClickOutside", async () => {
+      render(HeaderActionOutsideClick, {
+        props: { preventCloseOnClickOutside: true },
+      });
+
+      await user.click(getActionButton());
+      await user.click(document.body);
+      expect(screen.getByTestId("panel-content")).toBeInTheDocument();
+    });
   });
 
   describe("Generics", () => {

--- a/tests/UIShell/HeaderNav.test.ts
+++ b/tests/UIShell/HeaderNav.test.ts
@@ -60,6 +60,19 @@ describe("HeaderNav keyboard navigation", () => {
       await user.keyboard(" ");
       expect(menuTrigger).toHaveAttribute("aria-expanded", "false");
     });
+
+    it("should collapse when clicking outside", async () => {
+      render(HeaderNavTest);
+
+      const menuTrigger = screen.getByRole("menuitem", { name: "Menu" });
+      menuTrigger.focus();
+
+      await user.keyboard("{ArrowDown}");
+      expect(menuTrigger).toHaveAttribute("aria-expanded", "true");
+
+      await user.click(document.body);
+      expect(menuTrigger).toHaveAttribute("aria-expanded", "false");
+    });
   });
 
   describe("HeaderNavItem within menu", () => {


### PR DESCRIPTION
Add baseline coverage for outside click behavior, to guard against regressions from refactoring (#3138).