### PR TITLE
fix(copy-button): avoid dispatching "copy" event if already clicked

### DIFF
--- a/src/CopyButton/CopyButton.svelte
+++ b/src/CopyButton/CopyButton.svelte
@@ -93,12 +93,13 @@
   {...$$restProps}
   on:click
   on:click={() => {
+    if (animation === "fade-in") return;
+
     if (text !== undefined) {
       copy(text);
       dispatch("copy");
     }
 
-    if (animation === "fade-in") return;
     animation = "fade-in";
     feedbackOpen = true;
     timeout = setTimeout(() => {

--- a/tests/CopyButton/CopyButton.test.ts
+++ b/tests/CopyButton/CopyButton.test.ts
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/svelte";
 import { user } from "../utils/user";
 import CopyButton from "./CopyButton.test.svelte";
+import CopyButtonDoubleClick from "./CopyButtonDoubleClick.test.svelte";
 import CopyButtonInModal from "./CopyButtonInModal.test.svelte";
 
 describe("CopyButton", () => {
@@ -66,6 +67,19 @@ describe("CopyButton", () => {
     const button = getCopyButton("Basic");
     await user.click(button);
     expect(consoleLog).toHaveBeenCalledWith("Clipboard error");
+  });
+
+  it("should not copy again while feedback is active", async () => {
+    const copy = vi.fn();
+    render(CopyButtonDoubleClick, {
+      props: { copy },
+    });
+
+    const button = getCopyButton("Copy");
+    await user.dblClick(button);
+
+    expect(copy).toHaveBeenCalledTimes(1);
+    expect(screen.getByText("Copy events: 1")).toBeInTheDocument();
   });
 
   describe("Portal tooltip", () => {

--- a/tests/CopyButton/CopyButtonDoubleClick.test.svelte
+++ b/tests/CopyButton/CopyButtonDoubleClick.test.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  import { CopyButton } from "carbon-components-svelte";
+
+  export let copy: (text: string) => void;
+
+  let copyEventCount = 0;
+</script>
+Copy events: {copyEventCount}
+
+<CopyButton
+  text="text"
+  iconDescription="Copy"
+  {copy}
+  on:copy={() => {
+    copyEventCount += 1;
+  }}
+/>


### PR DESCRIPTION
Fixes a UX papercut; if the copy button is clicked, do not dispatch repeated copy events (especially since these may be async, like is used by the docs).