### PR TITLE
refactor: apply `copyFeedback` util to `CodeSnippet`, `CopyButton`

### DIFF
--- a/src/CodeSnippet/CodeSnippet.svelte
+++ b/src/CodeSnippet/CodeSnippet.svelte
@@ -130,6 +130,7 @@
   import ChevronDown from "../icons/ChevronDown.svelte";
   import PortalTooltip from "../Portal/PortalTooltip.svelte";
   import { observeModalClose } from "../Portal/portal-utils.js";
+  import { createCopyFeedbackState } from "../utils/copyFeedback.js";
   import CodeSnippetSkeleton from "./CodeSnippetSkeleton.svelte";
 
   const dispatch = createEventDispatcher();
@@ -141,16 +142,22 @@
   /** @type {null | HTMLButtonElement} */
   let inlineButtonRef = null;
 
+  const copyFeedback = createCopyFeedbackState(syncCopyFeedback);
+
   /** @type {"fade-in" | "fade-out"} */
   let animation = undefined;
   let timeout = undefined;
   let feedbackOpen = false;
   let prevExpanded = expanded;
 
+  function syncCopyFeedback() {
+    animation = copyFeedback.animation;
+    feedbackOpen = copyFeedback.feedbackOpen;
+    timeout = copyFeedback.timeout;
+  }
+
   function dismissFeedback() {
-    feedbackOpen = false;
-    animation = undefined;
-    clearTimeout(timeout);
+    copyFeedback.dismiss();
   }
 
   function setShowMoreLess() {
@@ -189,8 +196,7 @@
 
   onMount(() => {
     return () => {
-      clearTimeout(timeout);
-      feedbackOpen = false;
+      copyFeedback.cleanup();
       disconnectModalObserver();
     };
   });
@@ -241,20 +247,16 @@
       {...$$restProps}
       on:click
       on:click={() => {
-        copy(code);
-        dispatch("copy");
-        if (animation === "fade-in") return;
-        animation = "fade-in";
-        feedbackOpen = true;
-        timeout = setTimeout(() => {
-          animation = "fade-out";
-        }, feedbackTimeout);
+        copyFeedback.onClick(
+          () => {
+            copy(code);
+            dispatch("copy");
+          },
+          feedbackTimeout,
+        );
       }}
       on:animationend={(event) => {
-        if (event.animationName === "hide-feedback") {
-          animation = undefined;
-          feedbackOpen = false;
-        }
+        copyFeedback.onAnimationEnd(event);
       }}
       on:mouseover
       on:mouseenter

--- a/src/CopyButton/CopyButton.svelte
+++ b/src/CopyButton/CopyButton.svelte
@@ -38,6 +38,7 @@
   import Copy from "../icons/Copy.svelte";
   import PortalTooltip from "../Portal/PortalTooltip.svelte";
   import { observeModalClose } from "../Portal/portal-utils.js";
+  import { createCopyFeedbackState } from "../utils/copyFeedback.js";
 
   const dispatch = createEventDispatcher();
   const insideModal = getContext("carbon:Modal");
@@ -48,15 +49,21 @@
   /** @type {null | HTMLButtonElement} */
   let buttonRef = null;
 
+  const copyFeedback = createCopyFeedbackState(syncCopyFeedback);
+
   /** @type {"fade-in" | "fade-out"} */
   let animation = undefined;
   let timeout = undefined;
   let feedbackOpen = false;
 
+  function syncCopyFeedback() {
+    animation = copyFeedback.animation;
+    feedbackOpen = copyFeedback.feedbackOpen;
+    timeout = copyFeedback.timeout;
+  }
+
   function dismissFeedback() {
-    feedbackOpen = false;
-    animation = undefined;
-    clearTimeout(timeout);
+    copyFeedback.dismiss();
   }
 
   let disconnectModalObserver = () => {};
@@ -71,8 +78,7 @@
 
   onMount(() => {
     return () => {
-      clearTimeout(timeout);
-      feedbackOpen = false;
+      copyFeedback.cleanup();
       disconnectModalObserver();
     };
   });
@@ -93,25 +99,19 @@
   {...$$restProps}
   on:click
   on:click={() => {
-    if (animation === "fade-in") return;
-
-    if (text !== undefined) {
-      copy(text);
-      dispatch("copy");
-    }
-
-    animation = "fade-in";
-    feedbackOpen = true;
-    timeout = setTimeout(() => {
-      animation = "fade-out";
-    }, feedbackTimeout);
+    copyFeedback.onClick(
+      () => {
+        if (text !== undefined) {
+          copy(text);
+          dispatch("copy");
+        }
+      },
+      feedbackTimeout,
+    );
   }}
   on:animationend
   on:animationend={(event) => {
-    if (event.animationName === "hide-feedback") {
-      animation = undefined;
-      feedbackOpen = false;
-    }
+    copyFeedback.onAnimationEnd(event);
   }}
 >
   <Copy class="bx--snippet__icon" />

--- a/src/InlineLoading/InlineLoading.svelte
+++ b/src/InlineLoading/InlineLoading.svelte
@@ -38,6 +38,7 @@
 
   afterUpdate(() => {
     if (status === "finished") {
+      clearTimeout(timeout);
       timeout = setTimeout(() => {
         dispatch("success");
       }, successDelay);

--- a/src/utils/copyFeedback.d.ts
+++ b/src/utils/copyFeedback.d.ts
@@ -1,0 +1,13 @@
+export type CopyFeedbackAnimation = "fade-in" | "fade-out" | undefined;
+
+export type CopyFeedbackState = {
+  readonly animation: CopyFeedbackAnimation;
+  readonly feedbackOpen: boolean;
+  readonly timeout: ReturnType<typeof setTimeout> | undefined;
+  dismiss: () => void;
+  onClick: (performCopy: () => void, feedbackTimeout: number) => void;
+  onAnimationEnd: (event: { animationName: string }) => void;
+  cleanup: () => void;
+};
+
+export function createCopyFeedbackState(onSync?: () => void): CopyFeedbackState;

--- a/src/utils/copyFeedback.js
+++ b/src/utils/copyFeedback.js
@@ -1,0 +1,93 @@
+// @ts-check
+
+/** @typedef {'fade-in' | 'fade-out' | undefined} CopyFeedbackAnimation */
+
+/**
+ * Copy-button "Copied!" feedback (fade-in/out, portal tooltip).
+ * `copyActive` blocks a second click before Svelte assigns `animation`.
+ *
+ * @param {() => void} [onSync] - Run after internal state changes (sync component `let`s).
+ * @returns {{
+ *   get animation(): CopyFeedbackAnimation,
+ *   get feedbackOpen(): boolean,
+ *   get timeout(): ReturnType<typeof setTimeout> | undefined,
+ *   dismiss: () => void,
+ *   onClick: (performCopy: () => void, feedbackTimeout: number) => void,
+ *   onAnimationEnd: (event: { animationName: string }) => void,
+ *   cleanup: () => void,
+ * }}
+ */
+export function createCopyFeedbackState(onSync) {
+  /** @type {CopyFeedbackAnimation} */
+  let animation;
+  let feedbackOpen = false;
+  /** @type {ReturnType<typeof setTimeout> | undefined} */
+  let timeout;
+  let copyActive = false;
+
+  function notify() {
+    onSync?.();
+  }
+
+  function dismiss() {
+    feedbackOpen = false;
+    animation = undefined;
+    copyActive = false;
+    clearTimeout(timeout);
+    timeout = undefined;
+    notify();
+  }
+
+  function cleanup() {
+    feedbackOpen = false;
+    animation = undefined;
+    copyActive = false;
+    clearTimeout(timeout);
+    timeout = undefined;
+  }
+
+  /**
+   * @param {() => void} performCopy
+   * @param {number} feedbackTimeout
+   */
+  function onClick(performCopy, feedbackTimeout) {
+    if (copyActive || animation === "fade-in") return;
+
+    copyActive = true;
+    performCopy();
+    animation = "fade-in";
+    feedbackOpen = true;
+    clearTimeout(timeout);
+    timeout = setTimeout(() => {
+      animation = "fade-out";
+      notify();
+    }, feedbackTimeout);
+    notify();
+  }
+
+  /** @param {{ animationName: string }} event */
+  function onAnimationEnd(event) {
+    if (event.animationName === "hide-feedback") {
+      animation = undefined;
+      feedbackOpen = false;
+      copyActive = false;
+      notify();
+    }
+  }
+
+  return {
+    get animation() {
+      return animation;
+    },
+    get feedbackOpen() {
+      return feedbackOpen;
+    },
+    get timeout() {
+      return timeout;
+    },
+    dismiss,
+    onClick,
+    onAnimationEnd,
+    cleanup,
+  };
+}

--- a/tests/CodeSnippet/CodeSnippet.test.ts
+++ b/tests/CodeSnippet/CodeSnippet.test.ts
@@ -3,6 +3,7 @@ import { user } from "../utils/user";
 import CodeSnippetCopyButton from "./CodeSnippetCopyButton.test.svelte";
 import CodeSnippetCustomEvents from "./CodeSnippetCustomEvents.test.svelte";
 import CodeSnippetDisabled from "./CodeSnippetDisabled.test.svelte";
+import CodeSnippetDoubleClick from "./CodeSnippetDoubleClick.test.svelte";
 import CodeSnippetExpandable from "./CodeSnippetExpandable.test.svelte";
 import CodeSnippetExpandedByDefault from "./CodeSnippetExpandedByDefault.svelte";
 import CodeSnippetInitialEvent from "./CodeSnippetInitialEvent.test.svelte";
@@ -46,6 +47,40 @@ describe("CodeSnippet", () => {
   test("inline copy button has default 'Copy code' aria-label", () => {
     render(CodeSnippetInline);
     expect(screen.getByLabelText("Copy code")).toBeInTheDocument();
+  });
+
+  test.each([
+    {
+      variant: "inline",
+      label: "Copy code",
+      code: "npm install -g @carbon/cli",
+    },
+    {
+      variant: "single",
+      label: "Copy to clipboard",
+      code: "npm install --save @carbon/icons",
+    },
+    {
+      variant: "multi",
+      label: "Copy to clipboard",
+      code: `node -v
+npm -v
+yarn -v`,
+    },
+  ] as const)("should not copy again on $variant snippet while feedback is active", async ({
+    variant,
+    label,
+    code,
+  }) => {
+    const copy = vi.fn();
+    render(CodeSnippetDoubleClick, {
+      props: { type: variant, code, copy },
+    });
+
+    await user.dblClick(screen.getByLabelText(label));
+
+    expect(copy).toHaveBeenCalledTimes(1);
+    expect(screen.getByText("Copy events: 1")).toBeInTheDocument();
   });
 
   test("should render multiline variant", () => {

--- a/tests/CodeSnippet/CodeSnippetDoubleClick.test.svelte
+++ b/tests/CodeSnippet/CodeSnippetDoubleClick.test.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+  import { CodeSnippet } from "carbon-components-svelte";
+  import type { ComponentProps } from "svelte";
+
+  export let type: ComponentProps<CodeSnippet>["type"];
+  export let code: string;
+  export let copy: (code: string) => void;
+
+  let copyEventCount = 0;
+</script>
+Copy events: {copyEventCount}
+
+<CodeSnippet
+  {type}
+  {code}
+  {copy}
+  on:copy={() => {
+    copyEventCount += 1;
+  }}
+/>

--- a/tests/InlineLoading/InlineLoading.test.ts
+++ b/tests/InlineLoading/InlineLoading.test.ts
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/svelte";
 import InlineLoading from "./InlineLoading.test.svelte";
+import InlineLoadingRerender from "./InlineLoadingRerender.test.svelte";
 
 describe("InlineLoading", () => {
   beforeEach(() => {
@@ -98,6 +99,18 @@ describe("InlineLoading", () => {
     ).toBeInTheDocument();
 
     vi.advanceTimersByTime(1500);
+    expect(consoleLog).toHaveBeenCalledWith("success");
+  });
+
+  it("dispatches success once when parent re-renders while finished", () => {
+    const consoleLog = vi.spyOn(console, "log");
+    const { rerender } = render(InlineLoadingRerender, { props: { tick: 0 } });
+
+    rerender({ tick: 1 });
+    rerender({ tick: 2 });
+
+    vi.advanceTimersByTime(1500);
+    expect(consoleLog).toHaveBeenCalledTimes(1);
     expect(consoleLog).toHaveBeenCalledWith("success");
   });
 

--- a/tests/InlineLoading/InlineLoadingRerender.test.svelte
+++ b/tests/InlineLoading/InlineLoadingRerender.test.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  import { InlineLoading } from "carbon-components-svelte";
+
+  export let tick = 0;
+</script>
+
+{tick}
+
+<InlineLoading
+  status="finished"
+  description="Success"
+  on:success={() => {
+    console.log("success");
+  }}
+/>

--- a/tests/utils/copyFeedback.test.ts
+++ b/tests/utils/copyFeedback.test.ts
@@ -1,0 +1,85 @@
+import { createCopyFeedbackState } from "../../src/utils/copyFeedback.js";
+
+describe("createCopyFeedbackState", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("runs performCopy once and starts fade-in feedback", () => {
+    const state = createCopyFeedbackState();
+    const performCopy = vi.fn();
+
+    state.onClick(performCopy, 2000);
+
+    expect(performCopy).toHaveBeenCalledTimes(1);
+    expect(state.animation).toBe("fade-in");
+    expect(state.feedbackOpen).toBe(true);
+  });
+
+  test("ignores a second onClick while feedback is active", () => {
+    const state = createCopyFeedbackState();
+    const performCopy = vi.fn();
+
+    state.onClick(performCopy, 2000);
+    state.onClick(performCopy, 2000);
+
+    expect(performCopy).toHaveBeenCalledTimes(1);
+  });
+
+  test("transitions to fade-out after feedbackTimeout", () => {
+    const state = createCopyFeedbackState();
+    const performCopy = vi.fn();
+
+    state.onClick(performCopy, 100);
+    vi.advanceTimersByTime(100);
+
+    expect(state.animation).toBe("fade-out");
+  });
+
+  test("resets on hide-feedback animation end", () => {
+    const state = createCopyFeedbackState();
+    const performCopy = vi.fn();
+
+    state.onClick(performCopy, 2000);
+    state.onAnimationEnd({ animationName: "hide-feedback" });
+
+    expect(state.animation).toBeUndefined();
+    expect(state.feedbackOpen).toBe(false);
+
+    state.onClick(performCopy, 2000);
+    expect(performCopy).toHaveBeenCalledTimes(2);
+  });
+
+  test("dismiss clears state and allows another copy", () => {
+    const state = createCopyFeedbackState();
+    const performCopy = vi.fn();
+
+    state.onClick(performCopy, 2000);
+    state.dismiss();
+
+    expect(state.animation).toBeUndefined();
+    expect(state.feedbackOpen).toBe(false);
+
+    state.onClick(performCopy, 2000);
+    expect(performCopy).toHaveBeenCalledTimes(2);
+  });
+
+  test("cleanup clears timeout without calling onSync", () => {
+    const onSync = vi.fn();
+    const state = createCopyFeedbackState(onSync);
+
+    state.onClick(vi.fn(), 2000);
+    onSync.mockClear();
+
+    state.cleanup();
+
+    expect(onSync).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(2000);
+    expect(state.animation).toBeUndefined();
+    expect(state.feedbackOpen).toBe(false);
+  });
+});


### PR DESCRIPTION
Extract a common util and apply it to copy flows. Fixes and adds similar tests to `CodeSnippet` (see #3141).

Also first clears the timer in `InlineLoading` before dispatching `success`.