### PR TITLE
feat(copy-button, code-snippet): add `feedbackIcon` prop

### DIFF
--- a/docs/src/pages/components/CodeSnippet.svx
+++ b/docs/src/pages/components/CodeSnippet.svx
@@ -1,5 +1,6 @@
 <script>
   import { CodeSnippet } from "carbon-components-svelte";
+  import Checkmark from "carbon-icons-svelte/lib/Checkmark.svelte";
 </script>
 
 Code snippets display and copy code examples. They support single-line, multi-line, and inline formats with customizable copy and expand functionality.
@@ -57,6 +58,12 @@ The multi-line code snippet dispatches "expand" and "collapse" events.
 Set `feedback` to customize the copy button feedback text.
 
 <FileSource src="/framed/CodeSnippet/CodeSnippetFeedback" />
+
+## Custom feedback icon
+
+Set `feedbackIcon` to swap the copy button icon for a different icon during the feedback window. This applies to the `"single"` and `"multi"` types; it has no effect on the `"inline"` variant.
+
+<CodeSnippet code="npm i carbon-components-svelte" feedbackIcon={Checkmark} />
 
 ## Hidden copy button
 

--- a/docs/src/pages/components/CopyButton.svx
+++ b/docs/src/pages/components/CopyButton.svx
@@ -1,5 +1,6 @@
 <script>
   import { CopyButton } from "carbon-components-svelte";
+  import Checkmark from "carbon-icons-svelte/lib/Checkmark.svelte";
 </script>
 
 Copy buttons let users copy text to their clipboard with a single click. Use them to provide quick access to code snippets, links, or other text content.
@@ -17,6 +18,12 @@ Create a copy button with the `text` prop to specify what to copy.
 Set `feedback` to customize the message shown after copying.
 
 <CopyButton text="Carbon svelte" feedback="Copied to clipboard" />
+
+## Custom feedback icon
+
+Set `feedbackIcon` to swap the copy icon for a different icon during the feedback window. The icon reverts to the default copy icon once the feedback dismisses.
+
+<CopyButton text="Carbon svelte" feedbackIcon={Checkmark} />
 
 ## Overriding copy functionality
 

--- a/e2e/code-snippet.test.ts
+++ b/e2e/code-snippet.test.ts
@@ -55,4 +55,18 @@ test.describe("CodeSnippet", () => {
     const expandedHeight = (await codeBlock.boundingBox())?.height ?? 0;
     expect(expandedHeight).toBeGreaterThanOrEqual(collapsedHeight);
   });
+
+  test("copy button swaps to feedback icon during feedback window and reverts", async ({
+    page,
+  }) => {
+    const copyButton = page.getByRole("button", {
+      name: "Copy with feedback icon",
+    });
+    const feedbackIcon = copyButton.getByTestId("feedback-icon");
+
+    await expect(feedbackIcon).toBeHidden();
+    await copyButton.click();
+    await expect(feedbackIcon).toBeVisible();
+    await expect(feedbackIcon).toBeHidden();
+  });
 });

--- a/e2e/copy-button.test.ts
+++ b/e2e/copy-button.test.ts
@@ -28,4 +28,16 @@ test.describe("CopyButton", () => {
       "Hello, World!",
     );
   });
+
+  test("swaps to feedback icon during feedback window and reverts", async ({
+    page,
+  }) => {
+    const button = page.getByTestId("copy-button-feedback-icon");
+    const feedbackIcon = button.getByTestId("feedback-icon");
+
+    await expect(feedbackIcon).toBeHidden();
+    await button.click();
+    await expect(feedbackIcon).toBeVisible();
+    await expect(feedbackIcon).toBeHidden();
+  });
 });

--- a/e2e/fixtures/CheckmarkIcon.svelte
+++ b/e2e/fixtures/CheckmarkIcon.svelte
@@ -1,0 +1,10 @@
+<svg
+  data-testid="feedback-icon"
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 32 32"
+  width="16"
+  height="16"
+  {...$$restProps}
+>
+  <path d="M13 24L4 15 5.414 13.586 13 21.171 26.586 7.586 28 9 13 24z"></path>
+</svg>

--- a/e2e/fixtures/CodeSnippetFixture.svelte
+++ b/e2e/fixtures/CodeSnippetFixture.svelte
@@ -1,5 +1,6 @@
 <script>
   import { CodeSnippet } from "carbon-components-svelte";
+  import CheckmarkIcon from "./CheckmarkIcon.svelte";
 
   const shortCode = "const x = 1;";
   const longCode = Array(20)
@@ -18,5 +19,17 @@
     data-testid="snippet-multi"
     showMoreText="Show more"
     showLessText="Show less"
+  />
+</div>
+
+<div data-testid="feedback-icon-snippet">
+  <CodeSnippet
+    type="single"
+    code={shortCode}
+    data-testid="snippet-feedback-icon"
+    copyButtonDescription="Copy with feedback icon"
+    feedbackIcon={CheckmarkIcon}
+    feedbackTimeout={500}
+    copy={() => {}}
   />
 </div>

--- a/e2e/fixtures/CopyButtonFixture.svelte
+++ b/e2e/fixtures/CopyButtonFixture.svelte
@@ -1,5 +1,6 @@
 <script>
   import { CopyButton } from "carbon-components-svelte";
+  import CheckmarkIcon from "./CheckmarkIcon.svelte";
 
   let copiedText = null;
 </script>
@@ -16,3 +17,13 @@
 {#if copiedText}
   <p data-testid="copied-value">Copied: {copiedText}</p>
 {/if}
+
+<CopyButton
+  data-testid="copy-button-feedback-icon"
+  text="Hello, World!"
+  iconDescription="Copy with feedback icon"
+  feedback="Copied with icon!"
+  feedbackIcon={CheckmarkIcon}
+  feedbackTimeout={500}
+  copy={() => {}}
+/>

--- a/src/CodeSnippet/CodeSnippet.svelte
+++ b/src/CodeSnippet/CodeSnippet.svelte
@@ -1,5 +1,9 @@
 <script>
   /**
+   * @template [Icon=any]
+   */
+
+  /**
    * @event {null} expand
    * @event {null} collapse
    * @event {null} copy
@@ -84,6 +88,15 @@
 
   /** Set the timeout duration (ms) to display feedback text */
   export let feedbackTimeout = 2000;
+
+  /**
+   * Specify an icon to render on the copy button during the feedback window
+   * (e.g. after copying). When unset, the copy icon is always shown.
+   *
+   * NOTE: this prop does not apply to the `type="inline"` variant.
+   * @type {Icon}
+   */
+  export let feedbackIcon = /** @type {Icon} */ (undefined);
 
   /**
    * Specify the show less text.
@@ -320,6 +333,7 @@
         {disabled}
         {feedback}
         {feedbackTimeout}
+        {feedbackIcon}
         iconDescription={copyButtonDescription}
         portalTooltip={effectivePortalTooltip}
         on:click

--- a/src/CopyButton/CopyButton.svelte
+++ b/src/CopyButton/CopyButton.svelte
@@ -1,9 +1,20 @@
 <script>
+  /**
+   * @template [Icon=any]
+   */
+
   /** Set the feedback text shown after clicking the button */
   export let feedback = "Copied!";
 
   /** Set the timeout duration (ms) to display feedback text */
   export let feedbackTimeout = 2000;
+
+  /**
+   * Specify an icon to render during the feedback window (e.g. after copying).
+   * When unset, the copy icon is always shown.
+   * @type {Icon}
+   */
+  export let feedbackIcon = /** @type {Icon} */ (undefined);
 
   /** Set the title and ARIA label for the copy button */
   export let iconDescription = "Copy to clipboard";
@@ -114,7 +125,11 @@
     copyFeedback.onAnimationEnd(event);
   }}
 >
-  <Copy class="bx--snippet__icon" />
+  {#if feedbackIcon && feedbackOpen}
+    <svelte:component this={feedbackIcon} class="bx--snippet__icon" />
+  {:else}
+    <Copy class="bx--snippet__icon" />
+  {/if}
   {#if !effectivePortalTooltip}
     <span
       aria-hidden="true"

--- a/tests/CodeSnippet/CodeSnippetCopyButton.test.svelte
+++ b/tests/CodeSnippet/CodeSnippetCopyButton.test.svelte
@@ -1,5 +1,10 @@
 <script lang="ts">
   import { CodeSnippet } from "carbon-components-svelte";
+  import Checkmark from "carbon-icons-svelte/lib/Checkmark.svelte";
 </script>
 
-<CodeSnippet type="single" code="npm install --save @carbon/icons" />
+<CodeSnippet
+  type="single"
+  code="npm install --save @carbon/icons"
+  feedbackIcon={Checkmark}
+/>

--- a/tests/CopyButton/CopyButton.test.svelte
+++ b/tests/CopyButton/CopyButton.test.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { CopyButton } from "carbon-components-svelte";
+  import Checkmark from "carbon-icons-svelte/lib/Checkmark.svelte";
   import type { ComponentProps } from "svelte";
 
   export let portalTooltip: ComponentProps<CopyButton>["portalTooltip"] =
@@ -29,5 +30,12 @@
   copy={(text) => {
     console.log(`Custom copy: ${text}`);
   }}
+  {portalTooltip}
+/>
+
+<CopyButton
+  text="text"
+  iconDescription="Custom feedback icon"
+  feedbackIcon={Checkmark}
   {portalTooltip}
 />


### PR DESCRIPTION
Similar to `feedbackText`, I would like a simple way to customize the feedback icon when the copy button is clicked.

This adds a `feedbackIcon` prop to both `CodeSnippet` and `CopyButton`.

---


https://github.com/user-attachments/assets/7e1512d8-8de8-4a71-b32e-98ede9c467f9

