### PR TITLE
refactor: apply `numericFormat` utils to `NumberInput`

### DIFF
--- a/src/NumberInput/NumberInput.svelte
+++ b/src/NumberInput/NumberInput.svelte
@@ -166,6 +166,13 @@
   import Subtract from "../icons/Subtract.svelte";
   import WarningAltFilled from "../icons/WarningAltFilled.svelte";
   import WarningFilled from "../icons/WarningFilled.svelte";
+  import {
+    clamp,
+    getDefaultValue,
+    parse,
+    parseLocaleValue,
+    roundToStep,
+  } from "../utils/numericFormat.js";
 
   const defaultTranslations = {
     [translationIds.increment]: "Increment number",
@@ -173,11 +180,6 @@
   };
 
   const dispatch = createEventDispatcher();
-
-  /** Regex to match period/dot characters globally */
-  const RE_DOT = /\./g;
-  /** Regex to match comma and Arabic decimal separator (٫) globally */
-  const RE_COMMA = /[,\u066B]/g;
 
   function updateValue(isIncrementing) {
     // When the input is empty (null) or zero and stepStartValue is set,
@@ -195,24 +197,13 @@
     }
 
     if (useTextMode) {
-      const currentValue = value ?? getDefaultValue();
-      let newValue;
-
-      if (isIncrementing) {
-        newValue = currentValue + step;
-        if (max !== undefined && newValue > max) {
-          newValue = max;
-        }
-      } else {
-        newValue = currentValue - step;
-        if (min !== undefined && newValue < min) {
-          newValue = min;
-        }
-      }
-
-      // Round to avoid floating point precision issues.
-      const decimalPlaces = step.toString().split(".")[1]?.length || 0;
-      newValue = Number(newValue.toFixed(decimalPlaces));
+      const currentValue = value ?? getDefaultValue(stepStartValue, min);
+      const newValue = roundToStep(
+        isIncrementing
+          ? clamp(currentValue + step, undefined, max)
+          : clamp(currentValue - step, min, undefined),
+        step,
+      );
 
       value = newValue;
       inputValue = formatter ? formatter.format(newValue) : newValue.toString();
@@ -222,7 +213,7 @@
     } else {
       // When allowEmpty is false and value is null, set to default value first
       if (!allowEmpty && value === null) {
-        const defaultValue = getDefaultValue();
+        const defaultValue = getDefaultValue(stepStartValue, min);
         if (ref) {
           ref.value = defaultValue.toString();
         }
@@ -293,7 +284,7 @@
     } else if (value != null) {
       const valueStr = formatter ? formatter.format(value) : value.toString();
       const parsedInput = locale
-        ? parseLocaleValue(inputValue)
+        ? parseLocaleValue(inputValue, groupSeparator, decimalSeparator)
         : parse(inputValue);
       // Sync inputValue to value when:
       // - The numeric values differ AND input is valid (preserves "1.0" formatting)
@@ -307,70 +298,12 @@
     }
   }
 
-  /**
-   * Simple normalization: treat comma/٫ as decimal separator.
-   * Used during typing to avoid mid-keystroke value jumps.
-   */
-  function normalize(raw) {
-    return raw.replace(RE_COMMA, ".");
-  }
-
-  /**
-   * Locale-aware normalization for completed input (on blur).
-   * When both period and comma/٫ are present, the last separator
-   * is the decimal mark; earlier ones are thousands separators.
-   * e.g., "1.000,5" → 1000.5, "1,000.5" → 1000.5
-   */
-  function normalizeLocale(raw) {
-    const lastComma = Math.max(raw.lastIndexOf(","), raw.lastIndexOf("\u066B"));
-    const lastDot = raw.lastIndexOf(".");
-
-    if (lastComma !== -1 && lastDot !== -1) {
-      if (lastComma > lastDot) {
-        return raw.replace(RE_DOT, "").replace(RE_COMMA, ".");
-      }
-      return raw.replace(RE_COMMA, "");
-    }
-
-    return normalize(raw);
-  }
-
-  function parse(raw, useLocaleNormalize = false) {
-    if (raw === "" || raw === "-") return null;
-    const num = Number(
-      useLocaleNormalize ? normalizeLocale(raw) : normalize(raw),
-    );
-    return Number.isNaN(num) ? null : num;
-  }
-
-  /**
-   * Parse a locale-formatted number string back to a number.
-   * Uses Intl.NumberFormat to detect the locale's grouping/decimal separators.
-   */
-  function parseLocaleValue(raw) {
-    if (raw === "" || raw === "-") return null;
-    let normalized = raw;
-    if (groupSeparator) {
-      normalized = normalized.split(groupSeparator).join("");
-    }
-    if (decimalSeparator !== ".") {
-      normalized = normalized.replace(decimalSeparator, ".");
-    }
-    const num = Number(normalized);
-    return Number.isNaN(num) ? null : num;
-  }
-
-  function getDefaultValue() {
-    if (stepStartValue !== undefined) return stepStartValue;
-    return min === undefined ? 0 : min;
-  }
-
   function onInput(event) {
     if (useTextMode) {
       userInputActive = true;
       inputValue = event.target.value;
       const parsed = locale
-        ? parseLocaleValue(event.target.value)
+        ? parseLocaleValue(event.target.value, groupSeparator, decimalSeparator)
         : parse(event.target.value);
       // Preserve last valid value when input is invalid (e.g., "1.5." with two decimals).
       // This provides better UX by letting users see and correct typos without losing data.
@@ -391,13 +324,13 @@
   function onChange(event) {
     userInputActive = false;
     let parsedValue = locale
-      ? parseLocaleValue(event.target.value)
+      ? parseLocaleValue(event.target.value, groupSeparator, decimalSeparator)
       : parse(event.target.value, useTextMode);
 
     // If allowEmpty is false and value would be null, use default value
     // This prevents the input from staying empty when allowEmpty is false
     if (!allowEmpty && parsedValue === null && event.target.value === "") {
-      parsedValue = getDefaultValue();
+      parsedValue = getDefaultValue(stepStartValue, min);
       // Update the input to show the default value
       if (useTextMode) {
         inputValue = formatter

--- a/src/utils/numericFormat.d.ts
+++ b/src/utils/numericFormat.d.ts
@@ -1,0 +1,29 @@
+/**
+ * Number input string parsing and clamping.
+ */
+
+/** Parse a raw string; `null` for `""`, `"-"`, or NaN. */
+export function parse(raw: string, useLocaleNormalize?: boolean): number | null;
+
+/** Parse with explicit group and decimal separators; `null` for empty or NaN. */
+export function parseLocaleValue(
+  raw: string,
+  groupSeparator: string,
+  decimalSeparator: string,
+): number | null;
+
+/** First step when empty: `stepStartValue`, else `min`, else 0. */
+export function getDefaultValue(
+  stepStartValue: number | undefined,
+  min: number | undefined,
+): number;
+
+/** Clamp to `[min, max]`; undefined bounds are ignored. */
+export function clamp(
+  value: number,
+  min: number | undefined,
+  max: number | undefined,
+): number;
+
+/** Round to the decimal places in `step`. */
+export function roundToStep(value: number, step: number): number;

--- a/src/utils/numericFormat.js
+++ b/src/utils/numericFormat.js
@@ -1,0 +1,115 @@
+// @ts-check
+// Number input string parsing and clamping.
+
+/** Period/dot characters. */
+const RE_DOT = /\./g;
+/** Comma and Arabic decimal separator (٫). */
+const RE_COMMA = /[,٫]/g;
+
+/**
+ * Replace comma and ٫ with `.`. Use while the user is still typing, before blur.
+ *
+ * @param {string} raw
+ * @returns {string}
+ */
+function replaceDecimalSeparators(raw) {
+  return raw.replace(RE_COMMA, ".");
+}
+
+/**
+ * Normalize on blur when both `.` and `,`/`٫` appear. The last separator is
+ * decimal; strip the others as thousands grouping ("1.000,5" → "1000.5",
+ * "1,000.5" → "1000.5").
+ *
+ * @param {string} raw
+ * @returns {string}
+ */
+function normalizeLocale(raw) {
+  const lastComma = Math.max(raw.lastIndexOf(","), raw.lastIndexOf("٫"));
+  const lastDot = raw.lastIndexOf(".");
+
+  if (lastComma !== -1 && lastDot !== -1) {
+    if (lastComma > lastDot) {
+      return raw.replace(RE_DOT, "").replace(RE_COMMA, ".");
+    }
+    return raw.replace(RE_COMMA, "");
+  }
+
+  return replaceDecimalSeparators(raw);
+}
+
+/**
+ * Parse a raw string to a number. Returns `null` for `""`, `"-"`, or NaN.
+ *
+ * @param {string} raw
+ * @param {boolean} [useLocaleNormalize] - On blur, disambiguate thousands vs decimal separators.
+ * @returns {number | null}
+ */
+export function parse(raw, useLocaleNormalize = false) {
+  if (raw === "" || raw === "-") return null;
+  const num = Number(
+    useLocaleNormalize ? normalizeLocale(raw) : replaceDecimalSeparators(raw),
+  );
+  return Number.isNaN(num) ? null : num;
+}
+
+/**
+ * Parse a display string with explicit group and decimal separators. Returns
+ * `null` for `""`, `"-"`, or NaN.
+ *
+ * @param {string} raw
+ * @param {string} groupSeparator - Thousands separator (may be empty).
+ * @param {string} decimalSeparator - Decimal separator.
+ * @returns {number | null}
+ */
+export function parseLocaleValue(raw, groupSeparator, decimalSeparator) {
+  if (raw === "" || raw === "-") return null;
+  let normalized = raw;
+  if (groupSeparator) {
+    normalized = normalized.split(groupSeparator).join("");
+  }
+  if (decimalSeparator !== ".") {
+    normalized = normalized.replace(decimalSeparator, ".");
+  }
+  const num = Number(normalized);
+  return Number.isNaN(num) ? null : num;
+}
+
+/**
+ * First step value when the field is empty: `stepStartValue` if set, else `min`,
+ * else 0.
+ *
+ * @param {number | undefined} stepStartValue
+ * @param {number | undefined} min
+ * @returns {number}
+ */
+export function getDefaultValue(stepStartValue, min) {
+  if (stepStartValue !== undefined) return stepStartValue;
+  return min === undefined ? 0 : min;
+}
+
+/**
+ * Clamp `value` to `[min, max]`. Skip `min` or `max` when undefined.
+ *
+ * @param {number} value
+ * @param {number | undefined} min
+ * @param {number | undefined} max
+ * @returns {number}
+ */
+export function clamp(value, min, max) {
+  if (max !== undefined && value > max) return max;
+  if (min !== undefined && value < min) return min;
+  return value;
+}
+
+/**
+ * Round `value` to the decimal places in `step` (fixes 0.1 + 0.2 drift).
+ *
+ * @param {number} value
+ * @param {number} step
+ * @returns {number}
+ */
+export function roundToStep(value, step) {
+  const decimalPlaces = step.toString().split(".")[1]?.length || 0;
+  return Number(value.toFixed(decimalPlaces));
+}

--- a/tests/utils/numericFormat.test.ts
+++ b/tests/utils/numericFormat.test.ts
@@ -1,0 +1,83 @@
+import {
+  clamp,
+  getDefaultValue,
+  parse,
+  parseLocaleValue,
+  roundToStep,
+} from "../../src/utils/numericFormat.js";
+
+describe("parse", () => {
+  test("returns null for empty or partial input", () => {
+    expect(parse("")).toBe(null);
+    expect(parse("-")).toBe(null);
+  });
+
+  test("treats comma and ٫ as a decimal separator while typing", () => {
+    expect(parse("1,5")).toBe(1.5);
+    expect(parse("1٫5")).toBe(1.5);
+    expect(parse("1.5")).toBe(1.5);
+    expect(parse("42")).toBe(42);
+  });
+
+  test("disambiguates thousands and decimal separators on blur", () => {
+    expect(parse("1.000,5", true)).toBe(1000.5);
+    expect(parse("1,000.5", true)).toBe(1000.5);
+  });
+
+  test("falls back to simple separator rules with one separator type", () => {
+    expect(parse("1,5", true)).toBe(1.5);
+    expect(parse("1.5", true)).toBe(1.5);
+  });
+
+  test("returns null for non-numeric input", () => {
+    expect(parse("abc")).toBe(null);
+  });
+});
+
+describe("parseLocaleValue", () => {
+  test("strips the group separator and rewrites the decimal separator", () => {
+    expect(parseLocaleValue("1.234,5", ".", ",")).toBe(1234.5);
+    expect(parseLocaleValue("1,234.5", ",", ".")).toBe(1234.5);
+  });
+
+  test("handles an empty group separator", () => {
+    expect(parseLocaleValue("1234.5", "", ".")).toBe(1234.5);
+  });
+
+  test("returns null for empty or partial input", () => {
+    expect(parseLocaleValue("", ".", ",")).toBe(null);
+    expect(parseLocaleValue("-", ".", ",")).toBe(null);
+  });
+});
+
+describe("getDefaultValue", () => {
+  test("prefers stepStartValue, then min, then 0", () => {
+    expect(getDefaultValue(5, 0)).toBe(5);
+    expect(getDefaultValue(undefined, 2)).toBe(2);
+    expect(getDefaultValue(undefined, undefined)).toBe(0);
+  });
+
+  test("treats a stepStartValue of 0 as set", () => {
+    expect(getDefaultValue(0, 10)).toBe(0);
+  });
+});
+
+describe("clamp", () => {
+  test("enforces each defined bound", () => {
+    expect(clamp(5, undefined, 3)).toBe(3);
+    expect(clamp(1, 2, undefined)).toBe(2);
+    expect(clamp(5, 0, 10)).toBe(5);
+  });
+
+  test("ignores undefined bounds", () => {
+    expect(clamp(5, undefined, undefined)).toBe(5);
+  });
+});
+
+describe("roundToStep", () => {
+  test("rounds to the decimal places implied by step", () => {
+    expect(roundToStep(0.1 + 0.2, 0.1)).toBe(0.3);
+    expect(roundToStep(1.23456, 1)).toBe(1);
+    expect(roundToStep(1.23456, 0.01)).toBe(1.23);
+  });
+});


### PR DESCRIPTION
Extract utils for testing and a more readable component.