### PR TITLE
feat(copy-button): support async `copy`

### DIFF
--- a/docs/src/pages/components/CopyButton.svx
+++ b/docs/src/pages/components/CopyButton.svx
@@ -33,6 +33,16 @@ This example uses the NPM package [clipboard-copy](https://github.com/feross/cli
 
 <FileSource src="/framed/CopyButton/CopyButtonOverride" />
 
+## Async copy
+
+Pass an async function to `copy` when the text is not ready at render time, such as markdown fetched on click. **Copied!** appears after `copy()` resolves.
+
+During the request, the button sets `aria-busy="true"` and ignores further clicks. A rejected copy skips the success message and emits `copy:error` with `{ error }`.
+
+Prefetch on hover with `on:mouseenter`.
+
+<FileSource src="/framed/CopyButton/CopyButtonAsync" />
+
 ## Preventing copy functionality
 
 Pass a no-op function to the `copy` prop to disable copying.

--- a/docs/src/pages/framed/CopyButton/CopyButtonAsync.svelte
+++ b/docs/src/pages/framed/CopyButton/CopyButtonAsync.svelte
@@ -1,0 +1,31 @@
+<script>
+  import { CopyButton } from "carbon-components-svelte";
+
+  const content = "Text fetched on demand";
+  let cachedContent = null;
+
+  async function prefetchContent() {
+    if (cachedContent) return;
+
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    cachedContent = content;
+  }
+
+  async function copyContent() {
+    if (!cachedContent) {
+      await prefetchContent();
+    }
+
+    await navigator.clipboard.writeText(cachedContent);
+  }
+</script>
+
+<CopyButton
+  iconDescription="Copy fetched content"
+  feedback="Copied!"
+  copy={copyContent}
+  on:mouseenter={prefetchContent}
+  on:copy:error={(e) => {
+    console.error("Copy failed", e.detail.error);
+  }}
+/>

--- a/src/CopyButton/CopyButton.svelte
+++ b/src/CopyButton/CopyButton.svelte
@@ -130,6 +130,12 @@
   on:animationend={(event) => {
     copyFeedback.onAnimationEnd(event);
   }}
+  on:mouseover
+  on:mouseenter
+  on:mouseleave
+  on:mouseout
+  on:focus
+  on:blur
 >
   {#if feedbackIcon && feedbackOpen}
     <svelte:component this={feedbackIcon} class="bx--snippet__icon" />

--- a/src/CopyButton/CopyButton.svelte
+++ b/src/CopyButton/CopyButton.svelte
@@ -23,19 +23,21 @@
    * Specify the text to copy.
    * @type {string}
    */
-  export let text;
+  export let text = undefined;
 
   /**
    * Override the default copy behavior of using the navigator.clipboard.writeText API to copy text.
-   * @type {(text: string) => void}
+   * @type {(text: string) => void | Promise<void>}
    */
-  export let copy = async (text) => {
-    try {
-      await navigator.clipboard.writeText(text);
-    } catch (error) {
-      console.log(error);
-    }
+  const defaultCopy = async (text) => {
+    await navigator.clipboard.writeText(text);
   };
+
+  /**
+   * Override the default copy behavior of using the navigator.clipboard.writeText API to copy text.
+   * @type {(text: string) => void | Promise<void>}
+   */
+  export let copy = defaultCopy;
 
   /**
    * Set to `true` to render the feedback tooltip in a portal,
@@ -66,11 +68,13 @@
   let animation = undefined;
   let timeout = undefined;
   let feedbackOpen = false;
+  let copyPending = false;
 
   function syncCopyFeedback() {
     animation = copyFeedback.animation;
     feedbackOpen = copyFeedback.feedbackOpen;
     timeout = copyFeedback.timeout;
+    copyPending = copyFeedback.copyPending;
   }
 
   function dismissFeedback() {
@@ -99,6 +103,7 @@
   bind:this={buttonRef}
   type="button"
   aria-live="polite"
+  aria-busy={copyPending || undefined}
   class:bx--copy-btn={true}
   class:bx--copy={true}
   class:bx--copy-btn--animating={animation}
@@ -109,16 +114,17 @@
   title={iconDescription}
   {...$$restProps}
   on:click
-  on:click={() => {
-    copyFeedback.onClick(
-      () => {
-        if (text !== undefined) {
-          copy(text);
+  on:click={async () => {
+    try {
+      await copyFeedback.onClick(async () => {
+        if (copy === defaultCopy ? text !== undefined : true) {
+          await copy(text ?? "");
           dispatch("copy");
         }
-      },
-      feedbackTimeout,
-    );
+      }, feedbackTimeout);
+    } catch (error) {
+      dispatch("copy:error", { error });
+    }
   }}
   on:animationend
   on:animationend={(event) => {

--- a/src/utils/copyFeedback.d.ts
+++ b/src/utils/copyFeedback.d.ts
@@ -3,9 +3,13 @@ export type CopyFeedbackAnimation = "fade-in" | "fade-out" | undefined;
 export type CopyFeedbackState = {
   readonly animation: CopyFeedbackAnimation;
   readonly feedbackOpen: boolean;
+  readonly copyPending: boolean;
   readonly timeout: ReturnType<typeof setTimeout> | undefined;
   dismiss: () => void;
-  onClick: (performCopy: () => void, feedbackTimeout: number) => void;
+  onClick: (
+    performCopy: () => void | Promise<void>,
+    feedbackTimeout: number,
+  ) => Promise<void>;
   onAnimationEnd: (event: { animationName: string }) => void;
   cleanup: () => void;
 };

--- a/src/utils/copyFeedback.js
+++ b/src/utils/copyFeedback.js
@@ -10,9 +10,10 @@
  * @returns {{
  *   get animation(): CopyFeedbackAnimation,
  *   get feedbackOpen(): boolean,
+ *   get copyPending(): boolean,
  *   get timeout(): ReturnType<typeof setTimeout> | undefined,
  *   dismiss: () => void,
- *   onClick: (performCopy: () => void, feedbackTimeout: number) => void,
+ *   onClick: (performCopy: () => void | Promise<void>, feedbackTimeout: number) => Promise<void>,
  *   onAnimationEnd: (event: { animationName: string }) => void,
  *   cleanup: () => void,
  * }}
@@ -24,6 +25,7 @@ export function createCopyFeedbackState(onSync) {
   /** @type {ReturnType<typeof setTimeout> | undefined} */
   let timeout;
   let copyActive = false;
+  let copyPending = false;
 
   function notify() {
     onSync?.();
@@ -33,6 +35,7 @@ export function createCopyFeedbackState(onSync) {
     feedbackOpen = false;
     animation = undefined;
     copyActive = false;
+    copyPending = false;
     clearTimeout(timeout);
     timeout = undefined;
     notify();
@@ -42,19 +45,33 @@ export function createCopyFeedbackState(onSync) {
     feedbackOpen = false;
     animation = undefined;
     copyActive = false;
+    copyPending = false;
     clearTimeout(timeout);
     timeout = undefined;
   }
 
   /**
-   * @param {() => void} performCopy
+   * @param {() => void | Promise<void>} performCopy
    * @param {number} feedbackTimeout
+   * @returns {Promise<void>}
    */
-  function onClick(performCopy, feedbackTimeout) {
+  async function onClick(performCopy, feedbackTimeout) {
     if (copyActive || animation === "fade-in") return;
 
     copyActive = true;
-    performCopy();
+    copyPending = true;
+    notify();
+
+    try {
+      await performCopy();
+    } catch (error) {
+      copyActive = false;
+      copyPending = false;
+      notify();
+      throw error;
+    }
+
+    copyPending = false;
     animation = "fade-in";
     feedbackOpen = true;
     clearTimeout(timeout);
@@ -81,6 +98,9 @@ export function createCopyFeedbackState(onSync) {
     },
     get feedbackOpen() {
       return feedbackOpen;
+    },
+    get copyPending() {
+      return copyPending;
     },
     get timeout() {
       return timeout;

--- a/tests/CopyButton/CopyButton.test.svelte
+++ b/tests/CopyButton/CopyButton.test.svelte
@@ -5,6 +5,7 @@
 
   export let portalTooltip: ComponentProps<CopyButton>["portalTooltip"] =
     undefined;
+  export let onCopyError = (_detail: { error: unknown }) => {};
 </script>
 
 <CopyButton
@@ -14,6 +15,7 @@
   on:copy={() => {
     console.log("copied");
   }}
+  on:copy:error={(event) => onCopyError(event.detail)}
 />
 
 <CopyButton

--- a/tests/CopyButton/CopyButton.test.ts
+++ b/tests/CopyButton/CopyButton.test.ts
@@ -5,6 +5,7 @@ import CopyButtonAsync from "./CopyButtonAsync.test.svelte";
 import CopyButtonAsyncDoubleClick from "./CopyButtonAsyncDoubleClick.test.svelte";
 import CopyButtonDoubleClick from "./CopyButtonDoubleClick.test.svelte";
 import CopyButtonInModal from "./CopyButtonInModal.test.svelte";
+import CopyButtonMouseEnter from "./CopyButtonMouseEnter.test.svelte";
 
 describe("CopyButton", () => {
   const getCopyButton = (label: string) =>
@@ -154,6 +155,16 @@ describe("CopyButton", () => {
     await waitFor(() => {
       expect(order).toEqual(["copyStart", "copyEnd", "copyEvent"]);
     });
+  });
+
+  it("forwards mouseenter events to parent handlers", () => {
+    const onMouseEnter = vi.fn();
+    render(CopyButtonMouseEnter, { props: { onMouseEnter } });
+
+    const button = getCopyButton("Hover test");
+    fireEvent.mouseEnter(button);
+
+    expect(onMouseEnter).toHaveBeenCalledTimes(1);
   });
 
   it("should not copy again while feedback is active", async () => {

--- a/tests/CopyButton/CopyButton.test.ts
+++ b/tests/CopyButton/CopyButton.test.ts
@@ -1,6 +1,8 @@
-import { render, screen } from "@testing-library/svelte";
+import { fireEvent, render, screen, waitFor } from "@testing-library/svelte";
 import { user } from "../utils/user";
 import CopyButton from "./CopyButton.test.svelte";
+import CopyButtonAsync from "./CopyButtonAsync.test.svelte";
+import CopyButtonAsyncDoubleClick from "./CopyButtonAsyncDoubleClick.test.svelte";
 import CopyButtonDoubleClick from "./CopyButtonDoubleClick.test.svelte";
 import CopyButtonInModal from "./CopyButtonInModal.test.svelte";
 
@@ -56,17 +58,102 @@ describe("CopyButton", () => {
   });
 
   it("handles clipboard API errors", async () => {
-    const consoleLog = vi.spyOn(console, "log");
+    const onCopyError = vi.fn();
     Object.defineProperty(navigator, "clipboard", {
       value: { writeText: () => Promise.reject("Clipboard error") },
       writable: true,
     });
 
-    render(CopyButton);
+    render(CopyButton, { props: { onCopyError } });
 
     const button = getCopyButton("Basic");
     await user.click(button);
-    expect(consoleLog).toHaveBeenCalledWith("Clipboard error");
+    expect(onCopyError).toHaveBeenCalledWith({ error: "Clipboard error" });
+    expect(button).not.toHaveClass("bx--copy-btn--fade-in");
+    expect(button.querySelector(".bx--copy-btn__feedback")).not.toHaveClass(
+      "bx--copy-btn--fade-in",
+    );
+  });
+
+  it("async copy delays feedback until resolved", async () => {
+    let resolveCopy: () => void = () => {};
+    const copy = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveCopy = resolve;
+        }),
+    );
+
+    render(CopyButtonAsync, { props: { copy } });
+
+    const button = getCopyButton("Async copy");
+    fireEvent.click(button);
+    await Promise.resolve();
+
+    expect(copy).toHaveBeenCalledTimes(1);
+    expect(button).toHaveAttribute("aria-busy", "true");
+    expect(button).not.toHaveClass("bx--copy-btn--fade-in");
+
+    resolveCopy();
+    await waitFor(() => {
+      expect(button).toHaveClass("bx--copy-btn--fade-in");
+    });
+
+    expect(button).not.toHaveAttribute("aria-busy");
+    expect(button.querySelector(".bx--copy-btn__feedback")).toHaveTextContent(
+      "Copied!",
+    );
+  });
+
+  it("async copy failure does not show feedback and dispatches copy:error", async () => {
+    const error = new Error("copy failed");
+    const copy = vi.fn().mockRejectedValue(error);
+    const onCopyError = vi.fn();
+
+    render(CopyButtonAsync, {
+      props: { copy, onCopyError },
+    });
+
+    const button = getCopyButton("Async copy");
+    await user.click(button);
+
+    expect(onCopyError).toHaveBeenCalledWith({ error });
+    expect(button).not.toHaveClass("bx--copy-btn--fade-in");
+
+    await user.click(button);
+    expect(copy).toHaveBeenCalledTimes(2);
+  });
+
+  it("dispatches copy event after async copy resolves", async () => {
+    const order: string[] = [];
+    let resolveCopy: () => void = () => {};
+    const copy = vi.fn(async () => {
+      order.push("copyStart");
+      await new Promise<void>((resolve) => {
+        resolveCopy = resolve;
+      });
+      order.push("copyEnd");
+    });
+
+    render(CopyButtonAsync, {
+      props: {
+        copy,
+        onCopy: () => {
+          order.push("copyEvent");
+        },
+      },
+    });
+
+    const button = getCopyButton("Async copy");
+    fireEvent.click(button);
+    await Promise.resolve();
+
+    expect(order).toEqual(["copyStart"]);
+
+    resolveCopy();
+    await waitFor(() => {
+      expect(order).toEqual(["copyStart", "copyEnd", "copyEvent"]);
+    });
   });
 
   it("should not copy again while feedback is active", async () => {
@@ -80,6 +167,31 @@ describe("CopyButton", () => {
 
     expect(copy).toHaveBeenCalledTimes(1);
     expect(screen.getByText("Copy events: 1")).toBeInTheDocument();
+  });
+
+  it("should not copy again while async copy is in flight", async () => {
+    let resolveCopy: () => void = () => {};
+    const copy = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveCopy = resolve;
+        }),
+    );
+
+    render(CopyButtonAsyncDoubleClick, { props: { copy } });
+
+    const button = getCopyButton("Async double click");
+    fireEvent.click(button);
+    await Promise.resolve();
+    fireEvent.click(button);
+
+    expect(copy).toHaveBeenCalledTimes(1);
+    expect(screen.getByText("Copy events: 0")).toBeInTheDocument();
+
+    resolveCopy();
+    await waitFor(() => {
+      expect(screen.getByText("Copy events: 1")).toBeInTheDocument();
+    });
   });
 
   describe("Portal tooltip", () => {

--- a/tests/CopyButton/CopyButtonAsync.test.svelte
+++ b/tests/CopyButton/CopyButtonAsync.test.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+  import { CopyButton } from "carbon-components-svelte";
+
+  export let copy: (text: string) => void | Promise<void> = async () => {};
+  export let onCopy = () => {};
+  export let onCopyError = (_detail: { error: unknown }) => {};
+</script>
+
+<CopyButton
+  iconDescription="Async copy"
+  {copy}
+  on:copy={onCopy}
+  on:copy:error={(event) => onCopyError(event.detail)}
+/>

--- a/tests/CopyButton/CopyButtonAsyncDoubleClick.test.svelte
+++ b/tests/CopyButton/CopyButtonAsyncDoubleClick.test.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  import { CopyButton } from "carbon-components-svelte";
+
+  export let copy: (text: string) => void | Promise<void>;
+
+  let copyEventCount = 0;
+</script>
+Copy events: {copyEventCount}
+
+<CopyButton
+  text="text"
+  iconDescription="Async double click"
+  {copy}
+  on:copy={() => {
+    copyEventCount += 1;
+  }}
+/>

--- a/tests/CopyButton/CopyButtonMouseEnter.test.svelte
+++ b/tests/CopyButton/CopyButtonMouseEnter.test.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+  import { CopyButton } from "carbon-components-svelte";
+
+  export let onMouseEnter = () => {};
+</script>
+
+<CopyButton
+  text="hover me"
+  iconDescription="Hover test"
+  on:mouseenter={onMouseEnter}
+/>

--- a/tests/utils/copyFeedback.test.ts
+++ b/tests/utils/copyFeedback.test.ts
@@ -9,70 +9,71 @@ describe("createCopyFeedbackState", () => {
     vi.useRealTimers();
   });
 
-  test("runs performCopy once and starts fade-in feedback", () => {
+  test("runs performCopy once and starts fade-in feedback", async () => {
     const state = createCopyFeedbackState();
     const performCopy = vi.fn();
 
-    state.onClick(performCopy, 2000);
+    await state.onClick(performCopy, 2000);
 
     expect(performCopy).toHaveBeenCalledTimes(1);
     expect(state.animation).toBe("fade-in");
     expect(state.feedbackOpen).toBe(true);
+    expect(state.copyPending).toBe(false);
   });
 
-  test("ignores a second onClick while feedback is active", () => {
+  test("ignores a second onClick while feedback is active", async () => {
     const state = createCopyFeedbackState();
     const performCopy = vi.fn();
 
-    state.onClick(performCopy, 2000);
-    state.onClick(performCopy, 2000);
+    await state.onClick(performCopy, 2000);
+    await state.onClick(performCopy, 2000);
 
     expect(performCopy).toHaveBeenCalledTimes(1);
   });
 
-  test("transitions to fade-out after feedbackTimeout", () => {
+  test("transitions to fade-out after feedbackTimeout", async () => {
     const state = createCopyFeedbackState();
     const performCopy = vi.fn();
 
-    state.onClick(performCopy, 100);
+    await state.onClick(performCopy, 100);
     vi.advanceTimersByTime(100);
 
     expect(state.animation).toBe("fade-out");
   });
 
-  test("resets on hide-feedback animation end", () => {
+  test("resets on hide-feedback animation end", async () => {
     const state = createCopyFeedbackState();
     const performCopy = vi.fn();
 
-    state.onClick(performCopy, 2000);
+    await state.onClick(performCopy, 2000);
     state.onAnimationEnd({ animationName: "hide-feedback" });
 
     expect(state.animation).toBeUndefined();
     expect(state.feedbackOpen).toBe(false);
 
-    state.onClick(performCopy, 2000);
+    await state.onClick(performCopy, 2000);
     expect(performCopy).toHaveBeenCalledTimes(2);
   });
 
-  test("dismiss clears state and allows another copy", () => {
+  test("dismiss clears state and allows another copy", async () => {
     const state = createCopyFeedbackState();
     const performCopy = vi.fn();
 
-    state.onClick(performCopy, 2000);
+    await state.onClick(performCopy, 2000);
     state.dismiss();
 
     expect(state.animation).toBeUndefined();
     expect(state.feedbackOpen).toBe(false);
 
-    state.onClick(performCopy, 2000);
+    await state.onClick(performCopy, 2000);
     expect(performCopy).toHaveBeenCalledTimes(2);
   });
 
-  test("cleanup clears timeout without calling onSync", () => {
+  test("cleanup clears timeout without calling onSync", async () => {
     const onSync = vi.fn();
     const state = createCopyFeedbackState(onSync);
 
-    state.onClick(vi.fn(), 2000);
+    await state.onClick(vi.fn(), 2000);
     onSync.mockClear();
 
     state.cleanup();
@@ -81,5 +82,51 @@ describe("createCopyFeedbackState", () => {
     vi.advanceTimersByTime(2000);
     expect(state.animation).toBeUndefined();
     expect(state.feedbackOpen).toBe(false);
+  });
+
+  test("async performCopy delays feedback until resolved", async () => {
+    const state = createCopyFeedbackState();
+    let resolveCopy: () => void = () => {};
+    const performCopy = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveCopy = resolve;
+        }),
+    );
+
+    const pending = state.onClick(performCopy, 2000);
+
+    expect(performCopy).toHaveBeenCalledTimes(1);
+    expect(state.copyPending).toBe(true);
+    expect(state.animation).toBeUndefined();
+    expect(state.feedbackOpen).toBe(false);
+
+    resolveCopy();
+    await pending;
+
+    expect(state.copyPending).toBe(false);
+    expect(state.animation).toBe("fade-in");
+    expect(state.feedbackOpen).toBe(true);
+  });
+
+  test("rejected performCopy resets state and allows retry", async () => {
+    const state = createCopyFeedbackState();
+    const performCopy = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("copy failed"))
+      .mockResolvedValueOnce(undefined);
+
+    await expect(state.onClick(performCopy, 2000)).rejects.toThrow(
+      "copy failed",
+    );
+
+    expect(state.animation).toBeUndefined();
+    expect(state.feedbackOpen).toBe(false);
+    expect(state.copyPending).toBe(false);
+
+    await state.onClick(performCopy, 2000);
+
+    expect(performCopy).toHaveBeenCalledTimes(2);
+    expect(state.animation).toBe("fade-in");
   });
 });


### PR DESCRIPTION
Couple of enhancements for `CopyButton`. This actually supports a basic use case, fetching + copying content on demand instead of synchronously. The docs site currently has this behavior for the "Copy page" button.

- `CopyButton` supports async `copy`
- Forward more events to the button (e.g., allowing prefetch-on-hover)

One slight change is that this requires making `text` optional, for the async case. In the future, I'd want to leverage discriminated unions to type this (e.g., if `text` is omitted, require the `copy` prop), but this is slightly more opinionated and beyond scope.

Will port similar behavior to `CodeSnippet` (which uses `CopyButton` as a follow-up).