### PR TITLE
feat(code-snippet): support async copy

### DIFF
--- a/docs/src/pages/components/CodeSnippet.svx
+++ b/docs/src/pages/components/CodeSnippet.svx
@@ -23,6 +23,16 @@ In this example, we use the open source module [clipboard-copy](https://github.c
 
 <FileSource src="/framed/CodeSnippet/CodeSnippetOverride" />
 
+## Async copy
+
+Pass an async function to `copy` when clipboard text is not ready at render time, such as a longer install command fetched on click. The copy feedback text appears after `copy()` resolves.
+
+During the request, the copy control sets `aria-busy="true"` and ignores further clicks. A rejected copy skips the success message and emits `copy:error`.
+
+Prefetch on hover with `on:mouseenter:copy-button` on the copy control. The example below shows async copy for each variant (`single`, `inline`, `multi`).
+
+<FileSource src="/framed/CodeSnippet/CodeSnippetAsync" />
+
 ## Preventing copy functionality
 
 Pass a no-op function to the `copy` prop to disable copying.

--- a/docs/src/pages/components/CopyButton.svx
+++ b/docs/src/pages/components/CopyButton.svx
@@ -35,9 +35,9 @@ This example uses the NPM package [clipboard-copy](https://github.com/feross/cli
 
 ## Async copy
 
-Pass an async function to `copy` when the text is not ready at render time, such as markdown fetched on click. **Copied!** appears after `copy()` resolves.
+Pass an async function to `copy` when the text is not ready at render time, such as markdown fetched on click. The copy feedback text appears after `copy()` resolves.
 
-During the request, the button sets `aria-busy="true"` and ignores further clicks. A rejected copy skips the success message and emits `copy:error` with `{ error }`.
+During the request, the button sets `aria-busy="true"` and ignores further clicks. A rejected copy skips the success message and emits `copy:error`.
 
 Prefetch on hover with `on:mouseenter`.
 

--- a/docs/src/pages/framed/CodeSnippet/CodeSnippetAsync.svelte
+++ b/docs/src/pages/framed/CodeSnippet/CodeSnippetAsync.svelte
@@ -1,0 +1,109 @@
+<script>
+  import { CodeSnippet, Stack } from "carbon-components-svelte";
+
+  const displayCode = "npm i carbon-components-svelte";
+  const fullInstallCommand =
+    "npm install --save-dev carbon-components-svelte carbon-icons-svelte";
+
+  const multiDisplayCode = `export function add(a, b) {
+    return a + b;
+  }`;
+
+  const multiFullCode = `export function add(a, b) {
+    return a + b;
+  }
+
+  export function subtract(a, b) {
+    return a - b;
+  }`;
+
+  let cachedSingleCommand = null;
+  let cachedInlineCommand = null;
+  let cachedMultiCommand = null;
+
+  function logEvent(variant, event) {
+    return () => {
+      console.log(event, variant);
+    };
+  }
+
+  async function prefetchSingle() {
+    if (cachedSingleCommand) return;
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    cachedSingleCommand = fullInstallCommand;
+  }
+
+  async function prefetchInline() {
+    if (cachedInlineCommand) return;
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    cachedInlineCommand = "rm -rf node_modules/ && npm install";
+  }
+
+  async function prefetchMulti() {
+    if (cachedMultiCommand) return;
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    cachedMultiCommand = multiFullCode;
+  }
+
+  async function copySingle() {
+    if (!cachedSingleCommand) await prefetchSingle();
+    await navigator.clipboard.writeText(cachedSingleCommand);
+  }
+
+  async function copyInline() {
+    if (!cachedInlineCommand) await prefetchInline();
+    await navigator.clipboard.writeText(cachedInlineCommand);
+  }
+
+  async function copyMulti() {
+    if (!cachedMultiCommand) await prefetchMulti();
+    await navigator.clipboard.writeText(cachedMultiCommand);
+  }
+
+  function onMouseenterCopyButton(variant, prefetch) {
+    return () => {
+      console.log("mouseenter", variant);
+      prefetch();
+    };
+  }
+</script>
+
+<Stack gap={4}>
+  <div>
+    <CodeSnippet
+      type="inline"
+      code="rm -rf node_modules/"
+      copy={copyInline}
+      on:mouseenter:copy-button={onMouseenterCopyButton("inline", prefetchInline)}
+      on:mouseleave:copy-button={logEvent("inline", "mouseleave")}
+      on:copy={logEvent("inline", "copy")}
+      on:copy:error={(e) => {
+        console.error("copy:error",  e.detail.error);
+      }}
+    />
+  </div>
+
+  <CodeSnippet
+    type="single"
+    code={displayCode}
+    copy={copySingle}
+    on:mouseenter:copy-button={onMouseenterCopyButton("single", prefetchSingle)}
+    on:mouseleave:copy-button={logEvent("single", "mouseleave")}
+    on:copy={logEvent("single", "copy")}
+    on:copy:error={(e) => {
+      console.error("copy:error",  e.detail.error);
+    }}
+  />
+
+  <CodeSnippet
+    type="multi"
+    code={multiDisplayCode}
+    copy={copyMulti}
+    on:mouseenter:copy-button={onMouseenterCopyButton("multi", prefetchMulti)}
+    on:mouseleave:copy-button={logEvent("multi", "mouseleave")}
+    on:copy={logEvent("multi", "copy")}
+    on:copy:error={(e) => {
+      console.error("copy:error",  e.detail.error);
+    }}
+  />
+</Stack>

--- a/src/CodeSnippet/CodeSnippet.svelte
+++ b/src/CodeSnippet/CodeSnippet.svelte
@@ -8,6 +8,8 @@
    * @event {null} collapse
    * @event {null} copy
    * @event {{ error: unknown }} copy:error
+   * @event {MouseEvent} mouseenter:copy-button
+   * @event {MouseEvent} mouseleave:copy-button
    * @restProps {button | span} Rest props are spread to the span (inline variant) or the copy button (single/multi).
    */
 
@@ -279,6 +281,8 @@
       on:mouseover
       on:mouseenter
       on:mouseleave
+      on:mouseenter={(event) => dispatch("mouseenter:copy-button", event)}
+      on:mouseleave={(event) => dispatch("mouseleave:copy-button", event)}
     >
       <code {id}> <slot>{code}</slot> </code>
       {#if !effectivePortalTooltip}
@@ -345,6 +349,8 @@
         on:copy
         on:copy:error
         on:animationend
+        on:mouseenter={(event) => dispatch("mouseenter:copy-button", event)}
+        on:mouseleave={(event) => dispatch("mouseleave:copy-button", event)}
       />
     {/if}
     {#if showMoreLess}

--- a/src/CodeSnippet/CodeSnippet.svelte
+++ b/src/CodeSnippet/CodeSnippet.svelte
@@ -7,6 +7,7 @@
    * @event {null} expand
    * @event {null} collapse
    * @event {null} copy
+   * @event {{ error: unknown }} copy:error
    * @restProps {button | span} Rest props are spread to the span (inline variant) or the copy button (single/multi).
    */
 
@@ -342,6 +343,7 @@
         portalTooltip={effectivePortalTooltip}
         on:click
         on:copy
+        on:copy:error
         on:animationend
       />
     {/if}

--- a/src/CodeSnippet/CodeSnippet.svelte
+++ b/src/CodeSnippet/CodeSnippet.svelte
@@ -33,7 +33,7 @@
    * By default, this component uses `navigator.clipboard.writeText` API to copy text to the user's clipboard.
    *
    * Provide a custom function to override this behavior.
-   * @type {(code: string) => void}
+   * @type {(code: string) => void | Promise<void>}
    */
   export let copy = async (code) => {
     try {
@@ -161,12 +161,14 @@
   let animation = undefined;
   let timeout = undefined;
   let feedbackOpen = false;
+  let copyPending = false;
   let prevExpanded = expanded;
 
   function syncCopyFeedback() {
     animation = copyFeedback.animation;
     feedbackOpen = copyFeedback.feedbackOpen;
     timeout = copyFeedback.timeout;
+    copyPending = copyFeedback.copyPending;
   }
 
   function dismissFeedback() {
@@ -245,6 +247,7 @@
       bind:this={inlineButtonRef}
       type="button"
       aria-live="polite"
+      aria-busy={copyPending || undefined}
       class:bx--copy={true}
       class:bx--btn--copy={true}
       class:bx--copy-btn--animating={animation}
@@ -259,14 +262,15 @@
       aria-label={copyLabel}
       {...$$restProps}
       on:click
-      on:click={() => {
-        copyFeedback.onClick(
-          () => {
-            copy(code);
+      on:click={async () => {
+        try {
+          await copyFeedback.onClick(async () => {
+            await copy(code);
             dispatch("copy");
-          },
-          feedbackTimeout,
-        );
+          }, feedbackTimeout);
+        } catch (error) {
+          dispatch("copy:error", { error });
+        }
       }}
       on:animationend={(event) => {
         copyFeedback.onAnimationEnd(event);

--- a/src/CopyButton/CopyButton.svelte
+++ b/src/CopyButton/CopyButton.svelte
@@ -130,10 +130,8 @@
   on:animationend={(event) => {
     copyFeedback.onAnimationEnd(event);
   }}
-  on:mouseover
   on:mouseenter
   on:mouseleave
-  on:mouseout
   on:focus
   on:blur
 >

--- a/tests/CodeSnippet/CodeSnippet.test.ts
+++ b/tests/CodeSnippet/CodeSnippet.test.ts
@@ -3,6 +3,7 @@ import { user } from "../utils/user";
 import CodeSnippetAsync from "./CodeSnippetAsync.test.svelte";
 import CodeSnippetAsyncDoubleClick from "./CodeSnippetAsyncDoubleClick.test.svelte";
 import CodeSnippetCopyButton from "./CodeSnippetCopyButton.test.svelte";
+import CodeSnippetCopyError from "./CodeSnippetCopyError.test.svelte";
 import CodeSnippetCustomEvents from "./CodeSnippetCustomEvents.test.svelte";
 import CodeSnippetDisabled from "./CodeSnippetDisabled.test.svelte";
 import CodeSnippetDoubleClick from "./CodeSnippetDoubleClick.test.svelte";
@@ -124,6 +125,27 @@ yarn -v`,
     expect(button.querySelector(".bx--copy-btn__feedback")).toHaveTextContent(
       "Copied!",
     );
+  });
+
+  it.each(
+    snippetVariants,
+  )("async copy failure does not show feedback ($type)", async ({
+    type,
+    label,
+  }) => {
+    const error = new Error("copy failed");
+    const copy = vi.fn().mockRejectedValue(error);
+    const onCopyError = vi.fn();
+
+    render(CodeSnippetAsync, {
+      props: { type, copy, onCopyError },
+    });
+
+    const button = screen.getByLabelText(label);
+    await user.click(button);
+
+    expect(onCopyError).toHaveBeenCalledWith({ error });
+    expect(button).not.toHaveClass("bx--copy-btn--fade-in");
   });
 
   it.each(
@@ -305,6 +327,28 @@ yarn -v`,
     const copyButton = screen.getByLabelText("Copy to clipboard");
     await user.click(copyButton);
     expect(screen.getByText("Copy events: 1")).toBeInTheDocument();
+  });
+
+  it.each([
+    { type: "single" as const, label: "Copy to clipboard" },
+    { type: "inline" as const, label: "Copy code" },
+    {
+      type: "multi" as const,
+      label: "Copy to clipboard",
+    },
+  ])("forwards copy:error from $type snippet copy control", async ({
+    type,
+    label,
+  }) => {
+    const error = new Error("copy failed");
+    const onCopyError = vi.fn();
+    render(CodeSnippetCopyError, {
+      props: { type, onCopyError },
+    });
+
+    await user.click(screen.getByLabelText(label));
+
+    expect(onCopyError).toHaveBeenCalledWith({ error });
   });
 
   test("should wrap text when wrapText is true", () => {

--- a/tests/CodeSnippet/CodeSnippet.test.ts
+++ b/tests/CodeSnippet/CodeSnippet.test.ts
@@ -1,5 +1,7 @@
-import { render, screen } from "@testing-library/svelte";
+import { fireEvent, render, screen, waitFor } from "@testing-library/svelte";
 import { user } from "../utils/user";
+import CodeSnippetAsync from "./CodeSnippetAsync.test.svelte";
+import CodeSnippetAsyncDoubleClick from "./CodeSnippetAsyncDoubleClick.test.svelte";
 import CodeSnippetCopyButton from "./CodeSnippetCopyButton.test.svelte";
 import CodeSnippetCustomEvents from "./CodeSnippetCustomEvents.test.svelte";
 import CodeSnippetDisabled from "./CodeSnippetDisabled.test.svelte";
@@ -81,6 +83,134 @@ yarn -v`,
 
     expect(copy).toHaveBeenCalledTimes(1);
     expect(screen.getByText("Copy events: 1")).toBeInTheDocument();
+  });
+
+  const snippetVariants = [
+    { type: "single" as const, label: "Copy to clipboard" },
+    { type: "inline" as const, label: "Copy code" },
+    { type: "multi" as const, label: "Copy to clipboard" },
+  ];
+
+  it.each(
+    snippetVariants,
+  )("async copy delays feedback until resolved ($type)", async ({
+    type,
+    label,
+  }) => {
+    let resolveCopy: () => void = () => {};
+    const copy = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveCopy = resolve;
+        }),
+    );
+
+    render(CodeSnippetAsync, { props: { type, copy } });
+
+    const button = screen.getByLabelText(label);
+    fireEvent.click(button);
+    await Promise.resolve();
+
+    expect(copy).toHaveBeenCalledTimes(1);
+    expect(button).toHaveAttribute("aria-busy", "true");
+    expect(button).not.toHaveClass("bx--copy-btn--fade-in");
+
+    resolveCopy();
+    await waitFor(() => {
+      expect(button).toHaveClass("bx--copy-btn--fade-in");
+    });
+
+    expect(button).not.toHaveAttribute("aria-busy");
+    expect(button.querySelector(".bx--copy-btn__feedback")).toHaveTextContent(
+      "Copied!",
+    );
+  });
+
+  it.each(
+    snippetVariants,
+  )("dispatches copy event after async copy resolves ($type)", async ({
+    type,
+    label,
+  }) => {
+    const order: string[] = [];
+    let resolveCopy: () => void = () => {};
+    const copy = vi.fn(async () => {
+      order.push("copyStart");
+      await new Promise<void>((resolve) => {
+        resolveCopy = resolve;
+      });
+      order.push("copyEnd");
+    });
+
+    render(CodeSnippetAsync, {
+      props: {
+        type,
+        copy,
+        onCopy: () => {
+          order.push("copyEvent");
+        },
+      },
+    });
+
+    const button = screen.getByLabelText(label);
+    fireEvent.click(button);
+    await Promise.resolve();
+
+    expect(order).toEqual(["copyStart"]);
+
+    resolveCopy();
+    await waitFor(() => {
+      expect(order).toEqual(["copyStart", "copyEnd", "copyEvent"]);
+    });
+  });
+
+  it.each([
+    {
+      type: "inline" as const,
+      label: "Copy code",
+      code: "npm install -g @carbon/cli",
+    },
+    {
+      type: "single" as const,
+      label: "Copy to clipboard",
+      code: "npm install --save @carbon/icons",
+    },
+    {
+      type: "multi" as const,
+      label: "Copy to clipboard",
+      code: `node -v
+npm -v
+yarn -v`,
+    },
+  ] as const)("should not copy again while async copy is pending ($type)", async ({
+    type,
+    label,
+    code,
+  }) => {
+    let resolveCopy: () => void = () => {};
+    const copy = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveCopy = resolve;
+        }),
+    );
+
+    render(CodeSnippetAsyncDoubleClick, {
+      props: { type, code, copy },
+    });
+
+    const button = screen.getByLabelText(label);
+    fireEvent.click(button);
+    await Promise.resolve();
+    await user.click(button);
+
+    expect(copy).toHaveBeenCalledTimes(1);
+    expect(screen.getByText("Copy events: 0")).toBeInTheDocument();
+
+    resolveCopy();
+    await waitFor(() => {
+      expect(screen.getByText("Copy events: 1")).toBeInTheDocument();
+    });
   });
 
   test("should render multiline variant", () => {

--- a/tests/CodeSnippet/CodeSnippet.test.ts
+++ b/tests/CodeSnippet/CodeSnippet.test.ts
@@ -3,6 +3,8 @@ import { user } from "../utils/user";
 import CodeSnippetAsync from "./CodeSnippetAsync.test.svelte";
 import CodeSnippetAsyncDoubleClick from "./CodeSnippetAsyncDoubleClick.test.svelte";
 import CodeSnippetCopyButton from "./CodeSnippetCopyButton.test.svelte";
+import CodeSnippetCopyButtonMouseEnter from "./CodeSnippetCopyButtonMouseEnter.test.svelte";
+import CodeSnippetCopyButtonMouseLeave from "./CodeSnippetCopyButtonMouseLeave.test.svelte";
 import CodeSnippetCopyError from "./CodeSnippetCopyError.test.svelte";
 import CodeSnippetCustomEvents from "./CodeSnippetCustomEvents.test.svelte";
 import CodeSnippetDisabled from "./CodeSnippetDisabled.test.svelte";
@@ -11,6 +13,7 @@ import CodeSnippetExpandable from "./CodeSnippetExpandable.test.svelte";
 import CodeSnippetExpandedByDefault from "./CodeSnippetExpandedByDefault.svelte";
 import CodeSnippetInitialEvent from "./CodeSnippetInitialEvent.test.svelte";
 import CodeSnippetInline from "./CodeSnippetInline.test.svelte";
+import CodeSnippetMouseEnter from "./CodeSnippetMouseEnter.test.svelte";
 import CodeSnippetMultiline from "./CodeSnippetMultiline.test.svelte";
 import CodeSnippetNullishAriaLabel from "./CodeSnippetNullishAriaLabel.test.svelte";
 import CodeSnippetRestPropsButton from "./CodeSnippetRestPropsButton.test.svelte";
@@ -19,6 +22,7 @@ import CodeSnippetRestPropsSpan from "./CodeSnippetRestPropsSpan.test.svelte";
 import CodeSnippetWithCustomCopyText from "./CodeSnippetWithCustomCopyText.test.svelte";
 import CodeSnippetWithHideShowMore from "./CodeSnippetWithHideShowMore.test.svelte";
 import CodeSnippetWithWrapText from "./CodeSnippetWithWrapText.test.svelte";
+import CodeSnippetWrapperMouseEnter from "./CodeSnippetWrapperMouseEnter.test.svelte";
 
 describe("CodeSnippet", () => {
   // Regression test for initial event dispatch in Svelte 5
@@ -327,6 +331,88 @@ yarn -v`,
     const copyButton = screen.getByLabelText("Copy to clipboard");
     await user.click(copyButton);
     expect(screen.getByText("Copy events: 1")).toBeInTheDocument();
+  });
+
+  it.each([
+    { type: "single" as const, label: "Copy to clipboard" },
+    { type: "inline" as const, label: "Copy code" },
+    { type: "multi" as const, label: "Copy to clipboard" },
+  ])("dispatches mouseenter:copy-button from $type snippet copy control", ({
+    type,
+    label,
+  }) => {
+    const onMouseEnterCopyButton = vi.fn();
+    render(CodeSnippetMouseEnter, {
+      props: { type, onMouseEnterCopyButton },
+    });
+
+    fireEvent.mouseEnter(screen.getByLabelText(label));
+
+    expect(onMouseEnterCopyButton).toHaveBeenCalledTimes(1);
+    expect(onMouseEnterCopyButton.mock.calls[0][0]).toBeInstanceOf(MouseEvent);
+  });
+
+  test("does not dispatch mouseenter:copy-button from single snippet code area", () => {
+    const onMouseEnterCopyButton = vi.fn();
+    const { container } = render(CodeSnippetMouseEnter, {
+      props: { type: "single", onMouseEnterCopyButton },
+    });
+
+    const pre = container.querySelector("pre");
+    assert(pre);
+    fireEvent.mouseEnter(pre);
+
+    expect(onMouseEnterCopyButton).not.toHaveBeenCalled();
+  });
+
+  test("forwards mouseenter on single snippet wrapper", () => {
+    const onMouseEnter = vi.fn();
+    const { container } = render(CodeSnippetWrapperMouseEnter, {
+      props: { onMouseEnter },
+    });
+
+    const snippet = container.querySelector(".bx--snippet");
+    assert(snippet);
+    fireEvent.mouseEnter(snippet);
+
+    expect(onMouseEnter).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    { type: "inline" as const, label: "Copy code" },
+  ])("forwards mouseenter from inline snippet copy control", ({
+    type,
+    label,
+  }) => {
+    const onMouseEnter = vi.fn();
+    render(CodeSnippetCopyButtonMouseEnter, {
+      props: { type, onMouseEnter },
+    });
+
+    fireEvent.mouseEnter(screen.getByLabelText(label));
+
+    expect(onMouseEnter).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    { type: "single" as const, label: "Copy to clipboard" },
+    { type: "inline" as const, label: "Copy code" },
+    { type: "multi" as const, label: "Copy to clipboard" },
+  ])("dispatches mouseleave:copy-button from $type snippet copy control", ({
+    type,
+    label,
+  }) => {
+    const onMouseleaveCopyButton = vi.fn();
+    render(CodeSnippetCopyButtonMouseLeave, {
+      props: { type, onMouseleaveCopyButton },
+    });
+
+    const button = screen.getByLabelText(label);
+    fireEvent.mouseEnter(button);
+    fireEvent.mouseLeave(button);
+
+    expect(onMouseleaveCopyButton).toHaveBeenCalledTimes(1);
+    expect(onMouseleaveCopyButton.mock.calls[0][0]).toBeInstanceOf(MouseEvent);
   });
 
   it.each([

--- a/tests/CodeSnippet/CodeSnippetAsync.test.svelte
+++ b/tests/CodeSnippet/CodeSnippetAsync.test.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  import { CodeSnippet } from "carbon-components-svelte";
+  import type { ComponentProps } from "svelte";
+
+  export let type: ComponentProps<CodeSnippet>["type"];
+  export let copy: (code: string) => void | Promise<void> = async () => {};
+  export let onCopy = () => {};
+  export let onCopyError = (_detail: { error: unknown }) => {};
+</script>
+
+<CodeSnippet
+  {type}
+  code="npm install --save @carbon/icons"
+  {copy}
+  on:copy={onCopy}
+  on:copy:error={(event) => onCopyError(event.detail)}
+/>

--- a/tests/CodeSnippet/CodeSnippetAsyncDoubleClick.test.svelte
+++ b/tests/CodeSnippet/CodeSnippetAsyncDoubleClick.test.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+  import { CodeSnippet } from "carbon-components-svelte";
+  import type { ComponentProps } from "svelte";
+
+  export let type: ComponentProps<CodeSnippet>["type"];
+  export let code: string;
+  export let copy: (code: string) => void | Promise<void>;
+
+  let copyEventCount = 0;
+</script>
+Copy events: {copyEventCount}
+
+<CodeSnippet
+  {type}
+  {code}
+  {copy}
+  on:copy={() => {
+    copyEventCount += 1;
+  }}
+/>

--- a/tests/CodeSnippet/CodeSnippetCopyButtonMouseEnter.test.svelte
+++ b/tests/CodeSnippet/CodeSnippetCopyButtonMouseEnter.test.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+  import { CodeSnippet } from "carbon-components-svelte";
+  import type { ComponentProps } from "svelte";
+
+  export let type: ComponentProps<CodeSnippet>["type"];
+  export let onMouseEnter = (_event: MouseEvent) => {};
+</script>
+
+<CodeSnippet
+  {type}
+  code="npm install --save @carbon/icons"
+  on:mouseenter={onMouseEnter}
+/>

--- a/tests/CodeSnippet/CodeSnippetCopyButtonMouseLeave.test.svelte
+++ b/tests/CodeSnippet/CodeSnippetCopyButtonMouseLeave.test.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+  import { CodeSnippet } from "carbon-components-svelte";
+  import type { ComponentProps } from "svelte";
+
+  export let type: ComponentProps<CodeSnippet>["type"];
+  export let onMouseleaveCopyButton = (_event: MouseEvent) => {};
+</script>
+
+<CodeSnippet
+  {type}
+  code="npm install --save @carbon/icons"
+  on:mouseleave:copy-button={(event) => onMouseleaveCopyButton(event.detail)}
+/>

--- a/tests/CodeSnippet/CodeSnippetCopyError.test.svelte
+++ b/tests/CodeSnippet/CodeSnippetCopyError.test.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+  import { CodeSnippet } from "carbon-components-svelte";
+  import type { ComponentProps } from "svelte";
+
+  export let type: ComponentProps<CodeSnippet>["type"];
+  export let onCopyError = (_detail: { error: unknown }) => {};
+</script>
+
+<CodeSnippet
+  {type}
+  code="npm install --save @carbon/icons"
+  copy={() => Promise.reject(new Error("copy failed"))}
+  on:copy:error={(event) => onCopyError(event.detail)}
+/>

--- a/tests/CodeSnippet/CodeSnippetMouseEnter.test.svelte
+++ b/tests/CodeSnippet/CodeSnippetMouseEnter.test.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+  import { CodeSnippet } from "carbon-components-svelte";
+  import type { ComponentProps } from "svelte";
+
+  export let type: ComponentProps<CodeSnippet>["type"];
+  export let onMouseEnterCopyButton = (_event: MouseEvent) => {};
+</script>
+
+<CodeSnippet
+  {type}
+  code="npm install --save @carbon/icons"
+  on:mouseenter:copy-button={(event) => onMouseEnterCopyButton(event.detail)}
+/>

--- a/tests/CodeSnippet/CodeSnippetWrapperMouseEnter.test.svelte
+++ b/tests/CodeSnippet/CodeSnippetWrapperMouseEnter.test.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+  import { CodeSnippet } from "carbon-components-svelte";
+
+  export let onMouseEnter = (_event: MouseEvent) => {};
+</script>
+
+<CodeSnippet
+  type="single"
+  code="npm install --save @carbon/icons"
+  on:mouseenter={onMouseEnter}
+/>


### PR DESCRIPTION
Follow-up to #3150

`CodeSnippet` composes `CopyButton`, so this forwards newly added mouse events to `CopyButton` (prefetch async use case), and supports async copy for the inline variant.
