### PR TITLE
docs: add Markdown page size and token estimates

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -6,3 +6,4 @@
 /public/llms-full.txt
 /.routify
 src/SEARCH_INDEX.json
+src/COMPONENT_MD_SIZES.json

--- a/docs/scripts/constants.ts
+++ b/docs/scripts/constants.ts
@@ -1,4 +1,5 @@
 export const BASE_URL = "https://svelte.carbondesignsystem.com";
 export const COMPONENTS_PATH = "./src/pages/components";
 export const RAW_COMPONENTS_OUT_DIR = "./public/components";
+export const COMPONENT_MD_SIZES_PATH = "./src/COMPONENT_MD_SIZES.json";
 export const SITEMAP_PATH = "./public/sitemap.xml";

--- a/docs/scripts/generate-md-docs.ts
+++ b/docs/scripts/generate-md-docs.ts
@@ -3,7 +3,12 @@ import path from "node:path";
 import { format as prettierFormat } from "prettier";
 import prettierPluginSvelte from "prettier-plugin-svelte";
 import { parse } from "svelte/compiler";
-import { BASE_URL, COMPONENTS_PATH, RAW_COMPONENTS_OUT_DIR } from "./constants";
+import {
+  BASE_URL,
+  COMPONENT_MD_SIZES_PATH,
+  COMPONENTS_PATH,
+  RAW_COMPONENTS_OUT_DIR,
+} from "./constants";
 import { getComponentNames } from "./utils";
 
 type ComponentApiProp = {
@@ -772,6 +777,8 @@ for (const componentName of getComponentNames()) {
   generatedMdByComponent.push({ componentName, md: generatedMd });
 }
 
+const componentMdSizes: Record<string, number> = {};
+
 await Promise.all(
   generatedMdByComponent.map(async ({ componentName, md }) => {
     const svelteFormatted = await formatSvelteFences(md);
@@ -782,7 +789,14 @@ await Promise.all(
       docOut,
       "utf8",
     );
+    componentMdSizes[componentName] = Buffer.byteLength(docOut, "utf8");
   }),
+);
+
+fs.writeFileSync(
+  COMPONENT_MD_SIZES_PATH,
+  `${JSON.stringify(componentMdSizes, null, 2)}\n`,
+  "utf8",
 );
 
 // Generate llms.txt file

--- a/docs/src/env.d.ts
+++ b/docs/src/env.d.ts
@@ -2,3 +2,8 @@
 
 declare const __PKG_VERSION: string;
 declare const __PKG_REPO: string;
+
+declare module "*/COMPONENT_MD_SIZES.json" {
+  const sizes: Record<string, number>;
+  export default sizes;
+}

--- a/docs/src/layouts/ComponentLayout.svelte
+++ b/docs/src/layouts/ComponentLayout.svelte
@@ -171,6 +171,7 @@
         <h1>{component}</h1>
         <div class="bar">
           <Dropdown
+            class="theme-dropdown"
             type="inline"
             labelText="Theme"
             items={themeItems}
@@ -179,7 +180,7 @@
               theme.set(detail.selectedId);
             }}
           />
-          <Stack orientation="horizontal" align="center" gap={3}>
+          <Stack orientation="horizontal" align="center" gap={2}>
             {#if markdownMetadata}
               <span class="markdown-metadata">{markdownMetadata}</span>
             {/if}
@@ -267,6 +268,10 @@
     justify-content: space-between;
     margin-bottom: var(--cds-layout-02);
     border-bottom: 1px solid var(--cds-ui-03);
+  }
+
+  .bar :global(.theme-dropdown .bx--list-box__menu) {
+    min-width: 8rem;
   }
 
   .markdown-metadata {

--- a/docs/src/layouts/ComponentLayout.svelte
+++ b/docs/src/layouts/ComponentLayout.svelte
@@ -25,6 +25,7 @@
   import OverflowMenuVertical from "carbon-icons-svelte/lib/OverflowMenuVertical.svelte";
   import { onMount } from "svelte";
   import COMPONENT_API from "../COMPONENT_API.json";
+  import COMPONENT_MD_SIZES from "../COMPONENT_MD_SIZES.json";
   import ComponentApi from "../components/ComponentApi.svelte";
   import { theme } from "../store";
 
@@ -42,6 +43,27 @@
 
   function isCarbonTheme(value: string | null): value is CarbonTheme {
     return value !== null && URL_THEMES.includes(value as CarbonTheme);
+  }
+
+  /** 1 token ≈ 4 characters; 1 kB (1,000 bytes) ≈ 250 tokens. */
+  const BYTES_PER_TOKEN = 4;
+
+  function formatFileSize(bytes: number): string {
+    if (bytes < 1000) return `${bytes} B`;
+    if (bytes < 1_000_000) return `${Math.round(bytes / 1000)} kB`;
+    return `${(bytes / 1_000_000).toFixed(1)} MB`;
+  }
+
+  function formatTokenEstimate(bytes: number): string {
+    const tokens = bytes / BYTES_PER_TOKEN;
+    if (tokens < 1000) return `~${Math.round(tokens)} tokens`;
+    const k = tokens / 1000;
+    const rounded = k >= 10 ? Math.round(k) : Math.round(k * 10) / 10;
+    return `~${rounded}k tokens`;
+  }
+
+  function formatMarkdownMetadata(bytes: number): string {
+    return `${formatFileSize(bytes)} (${formatTokenEstimate(bytes)})`;
   }
 
   const REPO_URL = __PKG_REPO;
@@ -93,9 +115,14 @@
 
   $: sourceCode = `${REPO_URL}/tree/master/${formatSourceURL(multiple)}`;
   $: markdownUrl = `/components/${component}.md`;
+  $: markdownMetadata = COMPONENT_MD_SIZES[component]
+    ? formatMarkdownMetadata(COMPONENT_MD_SIZES[component])
+    : "";
 
   let copying = false;
   let copied = false;
+
+  $: copyIconDescription = copied ? "Copied!" : "Copy page";
 
   let copyTimeout: ReturnType<typeof setTimeout> | null = null;
 
@@ -152,15 +179,18 @@
               theme.set(detail.selectedId);
             }}
           />
-          <Stack orientation="horizontal">
+          <Stack orientation="horizontal" align="center" gap={3}>
+            {#if markdownMetadata}
+              <span class="markdown-metadata">{markdownMetadata}</span>
+            {/if}
             <Button
               kind="ghost"
               size="field"
               icon={Copy}
+              iconDescription={copyIconDescription}
+              tooltipPosition="bottom"
               on:click={copyMarkdown}
-            >
-              {copied ? "Copied!" : "Copy page"}
-            </Button>
+            />
             <OverflowMenu flipped icon={OverflowMenuVertical}>
               <OverflowMenuItem
                 text="Source code"
@@ -237,6 +267,16 @@
     justify-content: space-between;
     margin-bottom: var(--cds-layout-02);
     border-bottom: 1px solid var(--cds-ui-03);
+  }
+
+  .markdown-metadata {
+    color: var(--cds-text-02);
+    font-size: var(--cds-helper-text-01-font-size);
+    font-weight: var(--cds-helper-text-01-font-weight);
+    letter-spacing: var(--cds-helper-text-01-letter-spacing);
+    line-height: var(--cds-helper-text-01-line-height);
+    user-select: none;
+    white-space: nowrap;
   }
 
   :global(.toc h5) {

--- a/docs/vite.config.ts
+++ b/docs/vite.config.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import routify from "@roxi/routify/vite-plugin";
@@ -8,6 +9,11 @@ import pkg from "../package.json" with { type: "json" };
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const carbonRoot = path.resolve(__dirname, "..");
 const outDir = path.resolve(__dirname, "dist");
+const componentMdSizesPath = path.resolve(
+  __dirname,
+  "src/COMPONENT_MD_SIZES.json",
+);
+const componentMdSizesId = "\0component-md-sizes";
 
 export default defineConfig({
   resolve: {
@@ -16,6 +22,23 @@ export default defineConfig({
     },
   },
   plugins: [
+    {
+      name: "component-md-sizes",
+      resolveId(source) {
+        if (source.endsWith("COMPONENT_MD_SIZES.json")) {
+          return componentMdSizesId;
+        }
+      },
+      load(id) {
+        if (id !== componentMdSizesId) return;
+
+        const json = fs.existsSync(componentMdSizesPath)
+          ? fs.readFileSync(componentMdSizesPath, "utf8")
+          : "{}";
+
+        return `export default ${JSON.stringify(JSON.parse(json))}`;
+      },
+    },
     routify({
       routesDir: { default: "src/pages" },
       extensions: [".svelte", ".svx"],


### PR DESCRIPTION
Redesign the "Copy page" UX by displaying the Markdown size in kB, along with the estimated token cost. This is friendlier UX for the token conscious. For example, the `DataTable` Markdown is huge.

```sh
# Common formula
1 token ≈ 4 characters; 1 kB (1,000 bytes) ≈ 250 tokens
```



---

<img width="808" height="214" alt="Screenshot 2026-06-03 at 9 02 52 PM" src="https://github.com/user-attachments/assets/003114c5-2ab6-49e3-a526-cffe926355bf" />
