### PR TITLE
docs: revise copy markdown metadata design

### DIFF
--- a/docs/src/layouts/ComponentLayout.svelte
+++ b/docs/src/layouts/ComponentLayout.svelte
@@ -21,15 +21,18 @@
   } from "carbon-components-svelte";
   import type { CarbonTheme } from "carbon-components-svelte/src/Theme/Theme.svelte";
   import { themes as themeLabels } from "carbon-components-svelte/src/Theme/Theme.svelte";
+  import Checkmark from "carbon-icons-svelte/lib/Checkmark.svelte";
   import Copy from "carbon-icons-svelte/lib/Copy.svelte";
   import OverflowMenuVertical from "carbon-icons-svelte/lib/OverflowMenuVertical.svelte";
   import { onMount } from "svelte";
   import COMPONENT_API from "../COMPONENT_API.json";
-  import COMPONENT_MD_SIZES from "../COMPONENT_MD_SIZES.json";
+  import COMPONENT_MD_SIZES_JSON from "../COMPONENT_MD_SIZES.json";
   import ComponentApi from "../components/ComponentApi.svelte";
   import { theme } from "../store";
 
   type DocComponent = (typeof COMPONENT_API.components)[number];
+
+  const COMPONENT_MD_SIZES: Record<string, number> = COMPONENT_MD_SIZES_JSON;
 
   const URL_THEMES: readonly CarbonTheme[] = [
     "white",
@@ -62,8 +65,10 @@
     return `~${rounded}k tokens`;
   }
 
-  function formatMarkdownMetadata(bytes: number): string {
-    return `${formatFileSize(bytes)} (${formatTokenEstimate(bytes)})`;
+  function formatCopyIconDescription(copied: boolean, bytes: number): string {
+    if (copied) return "Copied!";
+    if (bytes <= 0) return "Copy Markdown";
+    return `Copy Markdown\n${formatFileSize(bytes)} (${formatTokenEstimate(bytes)})`;
   }
 
   const REPO_URL = __PKG_REPO;
@@ -115,14 +120,13 @@
 
   $: sourceCode = `${REPO_URL}/tree/master/${formatSourceURL(multiple)}`;
   $: markdownUrl = `/components/${component}.md`;
-  $: markdownMetadata = COMPONENT_MD_SIZES[component]
-    ? formatMarkdownMetadata(COMPONENT_MD_SIZES[component])
-    : "";
+  $: markdownBytes = COMPONENT_MD_SIZES[component] ?? 0;
 
   let copying = false;
   let copied = false;
 
-  $: copyIconDescription = copied ? "Copied!" : "Copy page";
+  $: copyIcon = copied ? Checkmark : Copy;
+  $: copyIconDescription = formatCopyIconDescription(copied, markdownBytes);
 
   let copyTimeout: ReturnType<typeof setTimeout> | null = null;
 
@@ -181,13 +185,11 @@
             }}
           />
           <Stack orientation="horizontal" align="center" gap={2}>
-            {#if markdownMetadata}
-              <span class="markdown-metadata">{markdownMetadata}</span>
-            {/if}
             <Button
+              class="copy-markdown-btn"
               kind="ghost"
               size="field"
-              icon={Copy}
+              icon={copyIcon}
               iconDescription={copyIconDescription}
               tooltipPosition="bottom"
               on:click={copyMarkdown}
@@ -274,14 +276,9 @@
     min-width: 8rem;
   }
 
-  .markdown-metadata {
-    color: var(--cds-text-02);
-    font-size: var(--cds-helper-text-01-font-size);
-    font-weight: var(--cds-helper-text-01-font-weight);
-    letter-spacing: var(--cds-helper-text-01-letter-spacing);
-    line-height: var(--cds-helper-text-01-line-height);
-    user-select: none;
-    white-space: nowrap;
+  .bar :global(.copy-markdown-btn .bx--assistive-text) {
+    white-space: pre-line;
+    text-align: center;
   }
 
   :global(.toc h5) {


### PR DESCRIPTION
Revises design of #3152

- Don't show metadata inline. This is potentially confusing: is this the size of the component or the page?
- Instead, fold the metadata into the tooltip. The metadata is neat, but it should be progressively disclosed. This still improves on the previous iteration (before #3152) where the "Copy page [icon]" took up a lot of space.

With this revised design, there should be no ambiguity that the thing you are copying is the Markdown representation of the docs. It's also reduces visual clutter (both the text and the gap between the metadata and the hovered ghost icon).

---

## Before
<img width="929" height="213" alt="Screenshot 2026-06-04 at 6 52 35 PM" src="https://github.com/user-attachments/assets/6cd392fb-d122-4794-847a-4967278fefad" />

## After
<img width="927" height="213" alt="Screenshot 2026-06-04 at 6 57 30 PM" src="https://github.com/user-attachments/assets/5b7c3264-e8b9-4ed4-8f73-92680cc25849" />
