### PR TITLE
WIP: header search prevent default

### DIFF
--- a/docs/src/pages/components/UIShell.svx
+++ b/docs/src/pages/components/UIShell.svx
@@ -82,6 +82,18 @@ Add a global search component to the header.
 
 <FileSource src="/framed/UIShell/HeaderSearch" />
 
+The search button dispatches a cancelable `click` event. Call `preventDefault()` to skip activating the inline search bar, for example to open a command palette instead:
+
+```svelte
+<HeaderSearch
+  on:click={(e) => {
+    e.preventDefault();
+    openCommandPalette();
+  }}
+  ...
+/>
+```
+
 ## Header with utilities
 
 Include utility components in the header using header utilities.

--- a/src/UIShell/HeaderSearch.svelte
+++ b/src/UIShell/HeaderSearch.svelte
@@ -9,6 +9,7 @@
    * @property {string} href
    * @property {string} text
    * @property {string} [description]
+   * @event {MouseEvent} click - Dispatched when the search button is clicked. Cancelable: call `preventDefault()` to skip activating the inline search bar (e.g. open a command palette instead).
    * @event {null} active
    * @event {null} inactive
    * @event {null} clear
@@ -120,8 +121,11 @@
       class:bx--header-search-button={true}
       class:bx--header__action={true}
       class:bx--header-search-button--disabled={active}
-      on:click={() => {
-        active = true;
+      on:click={(event) => {
+        const shouldContinue = dispatch("click", event, { cancelable: true });
+        if (shouldContinue) {
+          active = true;
+        }
       }}
     >
       <IconSearch size={20} title="Search" />

--- a/tests/UIShell/HeaderSearch.test.svelte
+++ b/tests/UIShell/HeaderSearch.test.svelte
@@ -10,6 +10,7 @@
   export let results: ComponentProps<HeaderSearch>["results"] = [];
 
   export let ref: ComponentProps<HeaderSearch>["ref"] = null;
+  export let onclick: ((event: MouseEvent) => void) | undefined = undefined;
   let activeEvent = false;
   let inactiveEvent = false;
   let clearEvent = false;
@@ -43,6 +44,7 @@
   on:inactive={handleInactive}
   on:clear={handleClear}
   on:select={handleSelect}
+  on:click={(e) => onclick?.(e)}
   let:result
   let:index
 >

--- a/tests/UIShell/HeaderSearch.test.ts
+++ b/tests/UIShell/HeaderSearch.test.ts
@@ -178,6 +178,23 @@ describe("HeaderSearch", () => {
       expect(screen.getByTestId("active-event")).toHaveTextContent("true");
     });
 
+    it("should prevent activation when click event is cancelled", async () => {
+      const clickHandler = vi.fn((e: MouseEvent) => {
+        e.preventDefault();
+      });
+      render(HeaderSearchTest, { props: { onclick: clickHandler } });
+
+      const searchButton = screen.getByRole("button", { name: "Search" });
+      await user.click(searchButton);
+
+      expect(clickHandler).toHaveBeenCalledTimes(1);
+      expect(searchButton).toHaveAttribute("aria-expanded", "false");
+      expect(screen.getByRole("search")).not.toHaveClass(
+        "bx--header__search--active",
+      );
+      expect(screen.getByTestId("active-event")).toHaveTextContent("false");
+    });
+
     it("should dispatch inactive event when deactivated", async () => {
       render(HeaderSearchTest, { props: { active: true } });
 


### PR DESCRIPTION
Allow canceling the default open for the header search icon. Mostly to support the use case of triggering an alternative mode of search, like a command palette.