### PR TITLE
chore: remove duplicate JSDoc annotations for aliased function declaration props

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -25,7 +25,7 @@
         "jsdom": "^29.1.1",
         "postcss": "^8.5.5",
         "sass": "^1.100.0",
-        "sveld": "0.32.3",
+        "sveld": "^0.32.5",
         "svelte": "^5.55.10",
         "svelte-check": "^4.4.8",
         "typescript": "^6.0.3",
@@ -462,7 +462,7 @@
 
     "strip-indent": ["strip-indent@3.0.0", "", { "dependencies": { "min-indent": "^1.0.0" } }, "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ=="],
 
-    "sveld": ["sveld@0.32.3", "", { "dependencies": { "prettier": "^3.8.3" }, "bin": { "sveld": "cli.js" } }, "sha512-slOy8a/R5TqmIOFNauo7yhIDTXzC7tHZkXgJSGHaira8Z9pXQUzqbibehjOzXfSl0F9TkZli3pVok/+CepJUeA=="],
+    "sveld": ["sveld@0.32.5", "", { "dependencies": { "prettier": "^3.8.3" }, "bin": { "sveld": "cli.js" } }, "sha512-tj7Kxl/xS/+cCFhLXO01gIwqblsS6VY4fWHeDM738s5GX54luE+45QWw3eTxcdmf3Y3l7cZGtHHzmgdSE6LMWg=="],
 
     "svelte": ["svelte@5.55.10", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "@jridgewell/sourcemap-codec": "^1.5.0", "@sveltejs/acorn-typescript": "^1.0.10", "@types/estree": "^1.0.5", "@types/trusted-types": "^2.0.7", "acorn": "^8.12.1", "aria-query": "5.3.1", "axobject-query": "^4.1.0", "clsx": "^2.1.1", "devalue": "^5.8.1", "esm-env": "^1.2.1", "esrap": "^2.2.9", "is-reference": "^3.0.3", "locate-character": "^3.0.0", "magic-string": "^0.30.11", "zimmerframe": "^1.1.2" } }, "sha512-v9mFVBY1USosyIWdXE7Cg4AN0ywyKCMcAhONvli8doMowEhFhMdNLKD1j7O/UnsrdVTHaUOk/jv8hD/HClVy+g=="],
 

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "jsdom": "^29.1.1",
     "postcss": "^8.5.5",
     "sass": "^1.100.0",
-    "sveld": "0.32.3",
+    "sveld": "^0.32.5",
     "svelte": "^5.55.10",
     "svelte-check": "^4.4.8",
     "typescript": "^6.0.3",

--- a/src/ComboBox/ComboBox.svelte
+++ b/src/ComboBox/ComboBox.svelte
@@ -128,10 +128,6 @@
    */
   export let autoHighlight = "none";
 
-  function defaultShouldFilter() {
-    return true;
-  }
-
   /**
    * Determine if an item should be filtered given the current combobox value.
    * When `typeahead` is enabled and no custom function is provided,
@@ -140,6 +136,10 @@
    * @default () => true
    * @type {(item: Item, value: string) => boolean}
    */
+  function defaultShouldFilter() {
+    return true;
+  }
+
   export let shouldFilterItem = defaultShouldFilter;
 
   /**

--- a/src/CopyButton/CopyButton.svelte
+++ b/src/CopyButton/CopyButton.svelte
@@ -26,17 +26,13 @@
   export let text = undefined;
 
   /**
-   * Override the default copy behavior of using the navigator.clipboard.writeText API to copy text.
+   * Override the default copy behavior (navigator.clipboard.writeText).
    * @type {(text: string) => void | Promise<void>}
    */
   const defaultCopy = async (text) => {
     await navigator.clipboard.writeText(text);
   };
 
-  /**
-   * Override the default copy behavior of using the navigator.clipboard.writeText API to copy text.
-   * @type {(text: string) => void | Promise<void>}
-   */
   export let copy = defaultCopy;
 
   /**


### PR DESCRIPTION
Upgrade sveld, which now supports annotated prop aliases for function declarations. Previously, duplicate JSDoc comments were needed.