### PR TITLE
chore: remove unused `timeout` in copy components, util

### DIFF
--- a/src/CodeSnippet/CodeSnippet.svelte
+++ b/src/CodeSnippet/CodeSnippet.svelte
@@ -162,7 +162,6 @@
 
   /** @type {"fade-in" | "fade-out"} */
   let animation = undefined;
-  let timeout = undefined;
   let feedbackOpen = false;
   let copyPending = false;
   let prevExpanded = expanded;
@@ -170,7 +169,6 @@
   function syncCopyFeedback() {
     animation = copyFeedback.animation;
     feedbackOpen = copyFeedback.feedbackOpen;
-    timeout = copyFeedback.timeout;
     copyPending = copyFeedback.copyPending;
   }
 

--- a/src/CopyButton/CopyButton.svelte
+++ b/src/CopyButton/CopyButton.svelte
@@ -62,14 +62,12 @@
 
   /** @type {"fade-in" | "fade-out"} */
   let animation = undefined;
-  let timeout = undefined;
   let feedbackOpen = false;
   let copyPending = false;
 
   function syncCopyFeedback() {
     animation = copyFeedback.animation;
     feedbackOpen = copyFeedback.feedbackOpen;
-    timeout = copyFeedback.timeout;
     copyPending = copyFeedback.copyPending;
   }
 

--- a/src/utils/copyFeedback.d.ts
+++ b/src/utils/copyFeedback.d.ts
@@ -4,7 +4,6 @@ export type CopyFeedbackState = {
   readonly animation: CopyFeedbackAnimation;
   readonly feedbackOpen: boolean;
   readonly copyPending: boolean;
-  readonly timeout: ReturnType<typeof setTimeout> | undefined;
   dismiss: () => void;
   onClick: (
     performCopy: () => void | Promise<void>,

--- a/src/utils/copyFeedback.js
+++ b/src/utils/copyFeedback.js
@@ -11,7 +11,6 @@
  *   get animation(): CopyFeedbackAnimation,
  *   get feedbackOpen(): boolean,
  *   get copyPending(): boolean,
- *   get timeout(): ReturnType<typeof setTimeout> | undefined,
  *   dismiss: () => void,
  *   onClick: (performCopy: () => void | Promise<void>, feedbackTimeout: number) => Promise<void>,
  *   onAnimationEnd: (event: { animationName: string }) => void,
@@ -101,9 +100,6 @@ export function createCopyFeedbackState(onSync) {
     },
     get copyPending() {
       return copyPending;
-    },
-    get timeout() {
-      return timeout;
     },
     dismiss,
     onClick,


### PR DESCRIPTION
Removes unused/dead code, now that the timeout is managed in the utility.