### PR TITLE
docs: language style pass

### DIFF
--- a/docs/src/pages/components/Accordion.svx
+++ b/docs/src/pages/components/Accordion.svx
@@ -9,7 +9,7 @@ components: ["Accordion", "AccordionItem", "AccordionSkeleton"]
   } from "carbon-components-svelte";
 </script>
 
-Accordions create a vertically stacked list of expandable sections that show or hide content. They support custom titles, different sizes, and various states including disabled and skeleton loading.
+Accordions stack expandable sections vertically to show or hide content. They support custom titles, multiple sizes, and states like disabled and skeleton loading.
 
 ## Default
 
@@ -33,9 +33,8 @@ By default, the chevron icon is on the right side of the accordion item.
 
 ## Left-aligned chevron
 
-The chevron icon can be aligned to the left side of the accordion item by setting
-the `align` prop to "start". This provides an alternative visual style while
-maintaining the same functionality.
+Align the chevron icon to the left side of the accordion item by setting the
+`align` prop to "start".
 
 <Accordion align="start">
   <AccordionItem title="Natural Language Classifier">
@@ -52,8 +51,8 @@ maintaining the same functionality.
 
 ## Custom title slot
 
-Customize the title content by using the `title` slot instead of the `title` prop.
-This allows for more complex title layouts with multiple elements.
+Customize the title content with the `title` slot instead of the `title` prop for
+more complex layouts with multiple elements.
 
 <Accordion>
   <AccordionItem>
@@ -100,17 +99,14 @@ accordion is first rendered.
 
 ## Programmatic example
 
-This example demonstrates how to programmatically control the accordion items using
-the `bind:open` directive. Expand and collapse items based on user
-interactions or application state.
+Programmatically control the accordion items with the `bind:open` directive,
+expanding and collapsing items based on user interactions or application state.
 
 <FileSource src="/framed/Accordion/ExpandableAccordion" />
 
 ## Extra-large size
 
-The accordion can be displayed in an extra-large size by setting the `size` prop to
-"xl". This provides more visual emphasis and is suitable for prominent content
-sections.
+Display the accordion in an extra-large size by setting the `size` prop to "xl".
 
 <Accordion size="xl">
   <AccordionItem title="Natural Language Classifier">
@@ -127,9 +123,8 @@ sections.
 
 ## Small size
 
-For more compact layouts, set the `size` prop to "sm" to display the accordion in a
-smaller size. This is useful when space is limited or when the accordion is used as
-a secondary UI element.
+Set the `size` prop to "sm" for a smaller accordion. Use it in compact layouts or
+when space is limited.
 
 <Accordion size="sm">
   <AccordionItem title="Natural Language Classifier">
@@ -146,8 +141,8 @@ a secondary UI element.
 
 ## Disabled state
 
-Set the `disabled` prop on the accordion to disable all items at once.
-This prevents users from expanding or collapsing any items in the accordion.
+Set the `disabled` prop on the accordion to disable all items at once. Users can no
+longer expand or collapse any item.
 
 <Accordion disabled>
   <AccordionItem title="Natural Language Classifier">
@@ -170,9 +165,8 @@ Programmatically toggle the disabled state of all accordion items using the `dis
 
 ## Disabled (item)
 
-Individual accordion items can be disabled by setting the `disabled` prop on
-specific accordion item components. This allows for more granular control over
-which items are interactive.
+Disable an individual item by setting the `disabled` prop on a specific accordion
+item component for finer control over which items are interactive.
 
 <Accordion>
   <AccordionItem disabled title="Natural Language Classifier">

--- a/docs/src/pages/components/Breakpoint.svx
+++ b/docs/src/pages/components/Breakpoint.svx
@@ -14,7 +14,7 @@ This utility component uses the [Window.matchMedia API](https://developer.mozill
 
 Bind to the `size` prop to determine the current breakpoint size. Possible values include: `"sm" | "md" | "lg" | "xlg" | "max"`.
 
-The `"on:change"` event will fire when the size is initially determined and when a breakpoint change event occurs (e.g., the browser width is resized).
+The `"on:change"` event fires when the size is initially determined and when a breakpoint change occurs (for example, when the browser is resized).
 
 <FileSource src="/framed/Breakpoint/Breakpoint" />
 

--- a/docs/src/pages/components/Checkbox.svx
+++ b/docs/src/pages/components/Checkbox.svx
@@ -26,7 +26,7 @@ Set `indeterminate` to `true` to show a mixed state, typically used in parent ch
 
 ## Hidden label
 
-Set `hideLabel` to `true` to visually hide the label while keeping it accessible to screen readers.
+Hide the label visually by setting `hideLabel` to `true`. The label remains available to screen readers.
 
 <Checkbox labelText="Label text" hideLabel />
 
@@ -87,7 +87,7 @@ Use two-way binding with `bind:selected` to track and update the selected values
 
 ## CheckboxGroup (hidden legend)
 
-Visually hide the legend while maintaining accessibility.
+Hide the legend visually by setting `hideLegend` to `true`. The legend remains available to screen readers.
 
 <CheckboxGroup hideLegend legendText="Notification preferences" name="prefs-hidden" selected={["email"]}>
 <Checkbox value="email" labelText="Email" />

--- a/docs/src/pages/components/CodeSnippet.svx
+++ b/docs/src/pages/components/CodeSnippet.svx
@@ -19,7 +19,7 @@ Display a single-line code snippet by default.
 
 Pass a custom function to the `copy` prop to override the default copy behavior.
 
-In this example, we use the open source module [clipboard-copy](https://github.com/feross/clipboard-copy) to copy the text instead of the default Clipboard API.
+This example uses the open source module [clipboard-copy](https://github.com/feross/clipboard-copy) to copy the text instead of the default Clipboard API.
 
 <FileSource src="/framed/CodeSnippet/CodeSnippetOverride" />
 

--- a/docs/src/pages/components/ComboBox.svx
+++ b/docs/src/pages/components/ComboBox.svx
@@ -4,7 +4,7 @@
 
 Combo boxes combine a text input with a dropdown menu to let users select from predefined options or enter custom values. They support filtering, custom item rendering, and various states.
 
-Combo boxes are keyed for performance reasons.
+Combo boxes are keyed for performance.
 
 > [!NOTE]
 > Every `items` object must have a unique "id" property.
@@ -28,7 +28,7 @@ Override the default slot to customize how each item displays. Access the item a
 
 ## Hidden label
 
-Set `hideLabel` to `true` to visually hide the label while keeping it accessible to screen readers.
+Hide the label visually by setting `hideLabel` to `true`. The label remains available to screen readers.
 
 <ComboBox hideLabel labelText="Hidden Label" placeholder="Select contact method"
 items={[
@@ -70,9 +70,9 @@ See how the combobox responds to user input and selection changes.
 
 By default, no item is automatically highlighted when typing.
 
-Set `autoHighlight` to `"first-match"` to automatically highlight the first matching item as you type. This makes it easy to select by pressing <DocKbd label="Enter" /> without using arrow keys.
+Set `autoHighlight` to `"first-match"` to automatically highlight the first matching item as you type. Select it by pressing <DocKbd label="Enter" /> without using arrow keys.
 
-The default filter is case-insensitive substring matching (e.g., "app" matches "Apple").
+The default filter is case-insensitive substring matching (for example, "app" matches "Apple").
 
 <ComboBox autoHighlight="first-match"
 labelText="Item"
@@ -127,7 +127,7 @@ You can provide a custom `shouldFilterItem` to change the filtering logic. See [
 
 ## Typeahead with custom filter
 
-Provide a custom `shouldFilterItem` to override the default prefix matching used by typeahead. In this example, a simple fuzzy filter is used where each typed character must appear in order within the item text (e.g., "ba" matches "Banana" and "Blackberry").
+Provide a custom `shouldFilterItem` to override the default prefix matching used by typeahead. In this example, a simple fuzzy filter is used where each typed character must appear in order within the item text (for example, "ba" matches "Banana" and "Blackberry").
 
 <FileSource src="/framed/ComboBox/TypeaheadCustomFilter" />
 
@@ -192,7 +192,7 @@ Set `itemToString` to customize how items display in the filterable combobox.
 
 ## Clear filter on open
 
-When using a filterable combobox, reopening the dropdown after making a selection will normally show only the filtered results matching the selected item. Set `clearFilterOnOpen` to `true` to temporarily clear the filter when opening, showing all available items. This makes it easier to browse and change selections.
+When using a filterable combobox, reopening the dropdown after making a selection will normally show only the filtered results matching the selected item. Set `clearFilterOnOpen` to `true` to temporarily clear the filter when opening, showing all available items so you can browse and change selections.
 
 The original value is automatically restored if you close the dropdown without making a new selection.
 
@@ -202,7 +202,7 @@ The original value is automatically restored if you close the dropdown without m
 
 By default, combobox filtering is synchronous and client-side.
 
-For async (e.g., server-side) filtering, bind to `value` and update `items` when input changes. This example simulates async/await behavior with a debounced input value change.
+For async (for example, server-side) filtering, bind to `value` and update `items` when input changes. This example simulates async/await behavior with a debounced input value change.
 
 <FileSource src="/framed/ComboBox/AsyncComboBox" />
 
@@ -214,7 +214,7 @@ Set `allowCustomValue` to `true` to let users enter custom text that isn't in th
 
 ## Select text on focus
 
-Set `selectTextOnFocus` to `true` to select all text in the input when it receives focus (e.g. on tab or click). This lets users replace the value by typing without manually selecting first.
+Set `selectTextOnFocus` to `true` to select all text in the input when it receives focus (for example, on tab or click). Users can replace the value by typing without manually selecting first.
 
 An alternative is [clear filter on open](#clear-filter-on-open), which clears the filter when opening so all options are visible.
 
@@ -346,7 +346,7 @@ Set `readonly` to `true` to display a non-editable value.
 
 ## Virtualized items (large lists)
 
-Virtualization is a technique that allows only the items currently visible in the viewport to be rendered in the DOM, improving performance for large lists.
+Virtualization renders only the items currently visible in the viewport, improving performance for large lists.
 
 By default, the combo box will virtualize lists with more than 100 items.
 
@@ -377,6 +377,6 @@ Specify a custom value for `threshold` to control when virtualization activates.
 
 ## Virtualized items (custom item height)
 
-The default item height for virtualization is 40 pixels. When using custom slots to render items with different heights (e.g., multi-line items with descriptions), specify a custom `itemHeight` value to match your item's actual height.
+The default item height for virtualization is 40 pixels. When using custom slots to render items with different heights (for example, multi-line items with descriptions), specify a custom `itemHeight` value to match your item's actual height.
 
 <FileSource src="/framed/ComboBox/VirtualizeItemHeight" />

--- a/docs/src/pages/components/ComposedModal.svx
+++ b/docs/src/pages/components/ComposedModal.svx
@@ -25,7 +25,7 @@ Wrap the composed modal in a portal to ensure it renders above all z-index stack
 
 ## Prevent default close behavior
 
-The modal dispatches a cancelable `close` event, allowing you to prevent the modal from closing using `e.preventDefault()`. The event includes a `trigger` property indicating what triggered the close attempt: `"escape-key"` (<DocKbd label="Escape" />), `"outside-click"`, or `"close-button"`.
+The modal dispatches a cancelable `close` event. Call `e.preventDefault()` to keep the modal open. The event includes a `trigger` property indicating what triggered the close attempt: `"escape-key"` (<DocKbd label="Escape" />), `"outside-click"`, or `"close-button"`.
 
 <FileSource src="/framed/Modal/ComposedModalPreventClose" />
 

--- a/docs/src/pages/components/ContainedList.svx
+++ b/docs/src/pages/components/ContainedList.svx
@@ -8,7 +8,7 @@ components: ["ContainedList", "ContainedListItem"]
   import Close from "carbon-icons-svelte/lib/Close.svelte";
 </script>
 
-Contained lists provide a structured way to display a list of items within a container. They support various sizes, interactive items, icons, actions, and search functionality. They are useful for displaying hierarchical or grouped content with consistent spacing and styling.
+Contained lists display a list of items within a container. They support multiple sizes, interactive items, icons, actions, and search — useful for hierarchical or grouped content with consistent spacing and styling.
 
 ## Default
 
@@ -73,7 +73,7 @@ Set the `inset` prop to `true` to make the divider lines between list items inse
 
 ## Disclosed variant
 
-Set `kind="disclosed"` to use a more compact header style with sticky positioning. When scrolling, the list header will stick to the top of the container, making it useful for long lists where you want to keep the context visible. The header in the disclosed variant has a fixed height.
+Set `kind="disclosed"` to use a more compact header style with sticky positioning. When scrolling, the list header sticks to the top of the container, keeping context visible in long lists. The header in the disclosed variant has a fixed height.
 
 <div style:height="200px" style:overflow-y="auto">
   <ContainedList labelText="List title 1" kind="disclosed">
@@ -129,7 +129,7 @@ Set the `interactive` prop to `true` on a contained list item to render the item
 
 ## Interactive items with actions
 
-Add interactive elements to individual list items using the `action` slot on a contained list item. This is useful for adding buttons, icons, or other controls that appear on the right side of each item. Actions are positioned absolutely and don't interfere with the item's clickable area.
+Add interactive elements to individual list items using the `action` slot on a contained list item, such as buttons, icons, or other controls that appear on the trailing side of each item. Actions are positioned absolutely and don't interfere with the item's clickable area.
 
 <ContainedList labelText="List title">
   <ContainedListItem interactive on:click={() => console.log('click')}>

--- a/docs/src/pages/components/ContentSwitcher.svx
+++ b/docs/src/pages/components/ContentSwitcher.svx
@@ -31,7 +31,7 @@ Set `selectedIndex` to pre-select a switch when the content switcher loads.
 
 ## Manual selection mode
 
-By default, the content switcher will change the selection when the user uses the arrow keys to move focus.
+By default, the content switcher changes the selection when the user moves focus with the arrow keys.
 
 Set `selectionMode` to `"manual"` so that arrow keys only move focus without changing the selection. The user must press <DocKbd label="Enter" /> or <DocKbd label="Space" /> to select a switch.
 
@@ -43,9 +43,9 @@ Set `selectionMode` to `"manual"` so that arrow keys only move focus without cha
 
 ## Reactive example
 
-This example demonstrates how to programmatically control the content switcher using
-the `bind:selectedIndex` directive. Update the selected index based on user
-interactions or application state.
+Programmatically control the content switcher with the `bind:selectedIndex`
+directive, updating the selected index based on user interactions or application
+state.
 
 <FileSource src="/framed/ContentSwitcher/ContentSwitcherReactive" />
 

--- a/docs/src/pages/components/ContextMenu.svx
+++ b/docs/src/pages/components/ContextMenu.svx
@@ -52,7 +52,7 @@ Toggling a checkbox or radio item in a nested submenu leaves that flyout open so
 
 ## Custom target
 
-By default, the context menu will trigger when right clicking anywhere in the `window`.
+By default, the context menu triggers when you right-click anywhere in the `window`.
 
 Set `target` to specify which element triggers the context menu.
 
@@ -90,6 +90,6 @@ Put `ContextMenuRadioGroup` inside a parent `ContextMenuOption` to show the radi
 
 ## Prevent menu from closing
 
-Use `preventDefault()` on individual context menu option click events to prevent the menu from closing when that option is clicked. This is useful for scenarios where you want to keep the menu open after performing an action.
+Use `preventDefault()` on individual context menu option click events to prevent the menu from closing when that option is clicked. Use this to keep the menu open after performing an action.
 
 <FileSource src="/framed/ContextMenu/ContextMenuPreventDefault" />

--- a/docs/src/pages/components/DatePicker.svx
+++ b/docs/src/pages/components/DatePicker.svx
@@ -58,7 +58,7 @@ Use the `dateFormat` prop to customize the date format (default: `"m/d/Y"`). The
 
 The `locale` prop accepts either a [flatpickr locale key](https://github.com/flatpickr/flatpickr/tree/master/src/l10n) or a [CustomLocale](https://github.com/flatpickr/flatpickr/blob/master/src/types/locale.ts) object. It defaults to `"en"`, which renders Carbon-spec single-letter weekday abbreviations (`S, M, T, W, Th, F, S`).
 
-To customize the weekday labels (e.g., to restore flatpickr's default English `Sun, Mon, Tue, ...` shorthands), pass a `CustomLocale` object.
+To customize the weekday labels (for example, to restore flatpickr's default English `Sun, Mon, Tue, ...` shorthands), pass a `CustomLocale` object.
 
 <FileSource src="/framed/DatePicker/DatePickerLocale" />
 
@@ -116,7 +116,7 @@ Add helper text to provide additional context or formatting instructions.
 
 ## Hidden label
 
-Hide the label while maintaining accessibility.
+Hide the label visually by setting `hideLabel` to `true`. The label remains available to screen readers.
 
 <DatePicker>
   <DatePickerInput hideLabel labelText="Date of birth" placeholder="mm/dd/yyyy" />

--- a/docs/src/pages/components/Dropdown.svx
+++ b/docs/src/pages/components/Dropdown.svx
@@ -7,8 +7,7 @@ components: ["Dropdown", "DropdownSkeleton"]
 </script>
 
 Dropdowns provide a select input with a dropdown menu. They support
-various states, sizes, and customization options. Each item in the dropdown must
-have a unique `id` property for proper functionality.
+multiple states, sizes, and customization options.
 
 > [!NOTE]
 > Every `items` object must have a unique "id" property.
@@ -65,8 +64,8 @@ Add descriptive text below the dropdown using the `helperText` prop.
 
 ## Hidden label
 
-Hide the label while maintaining accessibility by setting the `hideLabel` prop to
-`true`. The label will still be available to screen readers.
+Hide the label visually by setting `hideLabel` to `true`. The label remains
+available to screen readers.
 
 <Dropdown hideLabel labelText="Contact" selectedId="0" items="{[{id: "0", text: "Slack"},
   {id: "1", text: "Email"},
@@ -85,8 +84,7 @@ receives the item object and returns the formatted string.
 
 ## Multiple dropdowns
 
-Create multiple dropdowns that work together. This example demonstrates how to
-manage the state of multiple dropdowns.
+Create multiple dropdowns that work together.
 
 <FileSource src="/framed/Dropdown/MultipleDropdown" />
 
@@ -127,8 +125,7 @@ Display the dropdown inline with other content by setting the `type` prop to
 
 ## Extra-large size
 
-Increase the size of the dropdown by setting the `size` prop to `"xl"`. This
-provides more visual emphasis for important selections.
+Increase the size of the dropdown by setting the `size` prop to `"xl"`.
 
 <Dropdown size="xl" labelText="Contact" selectedId="0" items="{[{id: "0", text: "Slack"},
   {id: "1", text: "Email"},
@@ -163,8 +160,7 @@ context with the `warnText` prop.
 
 ## Disabled state
 
-Disable the entire dropdown by setting the `disabled` prop to `true`. This prevents
-user interaction with the component.
+Disable the entire dropdown by setting the `disabled` prop to `true`.
 
 <Dropdown disabled labelText="Contact" selectedId="0" items="{[{id: "0", text: "Slack"},
   {id: "1", text: "Email"},
@@ -173,8 +169,7 @@ user interaction with the component.
 ## Disabled items
 
 Disable specific items in the dropdown by setting the `disabled` property to
-`true` in the item object. This allows for more granular control over available
-selections.
+`true` in the item object for finer control over available selections.
 
 <Dropdown
   selectedId="0"
@@ -203,9 +198,9 @@ Set `readonly` to `true` to display a non-editable value.
 
 ## Virtualized items (large lists)
 
-Virtualization is a technique that allows only the items currently visible in the viewport to be rendered in the DOM, improving performance for large lists.
+Virtualization renders only the items currently visible in the viewport, improving performance for large lists.
 
-By default, the dropdown will virtualize lists with more than 100 items.
+By default, the dropdown virtualizes lists with more than 100 items.
 
 In the example below, 10,000 items are provided to the dropdown but only 11 items (8 visible items + 3 overscan items) are rendered in the DOM.
 
@@ -234,13 +229,12 @@ Specify a custom value for `threshold` to control when virtualization activates.
 
 ## Virtualized items (custom item height)
 
-The default item height for virtualization is 40 pixels. When using custom slots to render items with different heights (e.g., multi-line items with descriptions), specify a custom `itemHeight` value to match your item's actual height.
+The default item height for virtualization is 40 pixels. When using custom slots to render items with different heights (for example, multi-line items with descriptions), specify a custom `itemHeight` value to match your item's actual height.
 
 <FileSource src="/framed/Dropdown/VirtualizeItemHeight" />
 
 ## Skeleton
 
-Display a loading state using the dropdown skeleton. This provides
-visual feedback while the dropdown content is being loaded.
+Display a loading state using the dropdown skeleton.
 
 <DropdownSkeleton />

--- a/docs/src/pages/components/ExpandableTile.svx
+++ b/docs/src/pages/components/ExpandableTile.svx
@@ -2,10 +2,9 @@
   import { ExpandableTile, Button, Stack, OutboundLink } from "carbon-components-svelte";
 </script>
 
-Expandable tiles create a collapsible content container that can
-show and hide content with a smooth animation. They are ideal for managing content
-overflow and progressive disclosure of information. They automatically
-measure content height using a resize observer.
+Expandable tiles show and hide content with a smooth animation. They suit content
+overflow and progressive disclosure, and automatically measure content height with
+a resize observer.
 
 ## Default
 
@@ -32,8 +31,8 @@ content that appears before and after expansion.
 
 ## Custom tile heights
 
-Set custom heights for the tile content using CSS. This is useful when you need to
-control the exact dimensions of the visible and hidden content.
+Set custom heights for the tile content using CSS to control the exact dimensions
+of the visible and hidden content.
 
 <ExpandableTile>
   <div slot="above" style="height: 10rem">Above the fold content here</div>
@@ -74,9 +73,9 @@ Customize the expand/collapse button labels using the `tileExpandedLabel` and
 
 By default, the tile uses a `<button>` element to toggle the expand/collapse state.
 
-If you need to use interactive content inside the tile, set the `hasInteractiveContent` prop to `true`. This will render the tile as a `<div>` element to avoid invalid HTML nesting. 
+If you need to use interactive content inside the tile, set the `hasInteractiveContent` prop to `true`. This renders the tile as a `<div>` element to avoid invalid HTML nesting.
 
-Only the expand/collapse toggle with affect the tile's expand/collapse state.
+Only the expand/collapse toggle affects the tile's expand/collapse state.
 
 <ExpandableTile hasInteractiveContent tileExpandedLabel="View less" tileCollapsedLabel="View more">
   <Stack slot="above" gap={4} inline>

--- a/docs/src/pages/components/FileUploader.svx
+++ b/docs/src/pages/components/FileUploader.svx
@@ -21,8 +21,7 @@ accepts a single file. Set `multiple` to `true` to allow multiple file selection
 
 ## Multiple files
 
-Enable multiple file selection by setting the `multiple` prop to `true`. This
-allows users to select multiple files at once.
+Enable multiple file selection by setting the `multiple` prop to `true`.
 
 <FileUploaderButton multiple labelText="Add files" />
 
@@ -125,7 +124,7 @@ programmatically.
 ## Maximum file size
 
 Limit the size of uploaded files using the `maxFileSize` prop. Files exceeding the
-limit (in bytes) will be automatically filtered out.
+limit (in bytes) are automatically filtered out.
 
 The `maxFileSize` prop accepts values in bytes. File sizes use binary (base 2)
 units, where 1024 bytes = 1 KiB (kibibyte), not 1000 bytes. This matches how
@@ -159,8 +158,7 @@ Set `preventDuplicate` to `true` to reject files that match an already-selected 
 
 ## File uploader (disabled state)
 
-Disable the file uploader by setting the `disabled` prop to `true`. This prevents
-user interaction with the component.
+Disable the file uploader by setting the `disabled` prop to `true`.
 
 <FileUploader disabled multiple labelTitle="Upload files" buttonLabel="Add files" labelDescription="Only JPEG files are accepted." accept="{['.jpg', '.jpeg']}" status="complete" />
 
@@ -239,7 +237,6 @@ console.
 
 ## Skeleton
 
-Display a loading state using the file uploader skeleton. This provides
-visual feedback while the file uploader content is being loaded.
+Display a loading state using the file uploader skeleton.
 
 <FileUploaderSkeleton />

--- a/docs/src/pages/components/FloatingPortal.svx
+++ b/docs/src/pages/components/FloatingPortal.svx
@@ -16,7 +16,7 @@ Position floating content below an anchor element.
 
 ## Direction
 
-Set the `direction` prop to `"top"`, `"bottom"`, `"left"`, or `"right"` to control the preferred direction. The component will flip to the opposite direction if there is not enough space (e.g. `"top"` flips to `"bottom"`, `"right"` flips to `"left"`).
+Set the `direction` prop to `"top"`, `"bottom"`, `"left"`, or `"right"` to control the preferred direction. The component flips to the opposite direction if there is not enough space (for example, `"top"` flips to `"bottom"`, `"right"` flips to `"left"`).
 
 The default direction is `"bottom"`.
 
@@ -47,11 +47,11 @@ Use these props to fine-tune spacing and nudge side-positioned content:
 
 | Prop                      | Type (default)   | Description                                                                                                                                                    |
 | ------------------------- | ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `gapTop`                  | number (`0`)     | Vertical gap in pixels between the anchor and the floating content when direction is `"top"`. Useful for caret clearance (e.g. tooltips).                        |
+| `gapTop`                  | number (`0`)     | Vertical gap in pixels between the anchor and the floating content when direction is `"top"`. Useful for caret clearance (for example, tooltips).                        |
 | `gapBottom`               | number (`0`)     | Vertical gap when direction is `"bottom"`.                                                                                                                     |
 | `horizontalGapLeft`       | number (`0`)     | Horizontal gap in pixels when the content is to the left of the anchor (space between anchor left edge and content right edge).                                |
 | `horizontalGapRight`      | number (`0`)     | Horizontal gap when the content is to the right of the anchor.                                                                                               |
-| `verticalAlignOffsetLeft` | number (`0`)     | Vertical offset in pixels when direction is `"left"` (e.g. negative to nudge content up).                                                                        |
+| `verticalAlignOffsetLeft` | number (`0`)     | Vertical offset in pixels when direction is `"left"` (for example, negative to nudge content up).                                                                        |
 | `verticalAlignOffsetRight` | number (`0`)     | Vertical offset when direction is `"right"`.                                                                                                                  |
 
 These are optional; omit them to use defaults. [Tooltip](/components/Tooltip) uses them when `portalTooltip` is true; [TooltipIcon](/components/TooltipIcon) and [TooltipDefinition](/components/TooltipDefinition) apply small built-in gaps when portalled so spacing matches the non-portal Carbon tooltips.
@@ -64,7 +64,7 @@ Because the floating content is rendered into `document.body`, it escapes parent
 
 ## Slot direction
 
-By default, the floating content is rendered below the anchor element. However, if there is not enough space below the anchor element, the component will automatically flip to the opposite direction.
+By default, the floating content is rendered below the anchor element. However, if there is not enough space below the anchor element, the component automatically flips to the opposite direction.
 
 Use the `direction` slot prop to read the actual rendered direction after auto-flipping for conditional logic, like styles.
 

--- a/docs/src/pages/components/FluidForm.svx
+++ b/docs/src/pages/components/FluidForm.svx
@@ -29,7 +29,6 @@ shows a basic login form with required fields.
 ## Invalid state
 
 Handle form validation and display error states using the `invalid` and
-`invalidText` props on form inputs. This example demonstrates how to show
-validation errors in a fluid form.
+`invalidText` props on form inputs.
 
 <FileSource src="/framed/FluidForm/FluidFormInvalid" />

--- a/docs/src/pages/components/Grid.svx
+++ b/docs/src/pages/components/Grid.svx
@@ -23,8 +23,7 @@ same value across all breakpoints.
 
 ## Default
 
-Create a basic grid layout with equal-width columns. This example demonstrates the
-default grid behavior.
+Create a basic grid layout with equal-width columns.
 
 <FileSource src="/framed/Grid/Grid" />
 
@@ -81,8 +80,8 @@ you need to scale your column spans proportionally. Here are common patterns:
 
 ## Offset columns
 
-Create space between columns using the offset feature. This allows for more
-flexible layouts without empty columns.
+Create space between columns using the offset feature for more flexible layouts
+without empty columns.
 
 <FileSource src="/framed/Grid/OffsetColumns" />
 

--- a/docs/src/pages/components/Heading.svx
+++ b/docs/src/pages/components/Heading.svx
@@ -10,7 +10,7 @@ Heading and section components work together to automatically manage semantic he
 
 ## Default
 
-A top-level heading inside a section renders as an `h1` element. This provides a semantic starting point for your document structure.
+A top-level heading inside a section renders as an `h1` element, a semantic starting point for your document structure.
 
 <Section>
   <Heading>Heading 1</Heading>

--- a/docs/src/pages/components/ImageLoader.svx
+++ b/docs/src/pages/components/ImageLoader.svx
@@ -18,8 +18,7 @@ process automatically.
 
 ## Slots
 
-Customize the loading and error states using named slots. This example shows how
-to display a loading indicator and error message.
+Customize the loading and error states using named slots.
 
 <ImageLoader src="https://upload.wikimedia.org/wikipedia/commons/5/51/IBM_logo.svg">
     <svelte:fragment slot="loading">
@@ -42,22 +41,20 @@ Supported aspect ratios include `"2x1"`, `"2x3"`, `"16x9"`, `"4x3"`, `"1x1"`,
 
 ## Fade in
 
-Enable a smooth fade-in animation when the image loads successfully. This provides
-a better user experience for image loading.
+Enable a smooth fade-in animation when the image loads successfully.
 
 <Button kind="ghost" on:click="{() => { key++;}}">Reload image</Button>
 {#key key}<ImageLoader fadeIn ratio="16x9" src="https://upload.wikimedia.org/wikipedia/commons/5/51/IBM_logo.svg" />{/key}
 
 ## Programmatic usage
 
-Control image loading programmatically using component references. This example
-demonstrates how to trigger image loading manually.
+Control image loading programmatically using component references.
 
 <FileSource src="/framed/ImageLoader/ProgrammaticImageLoader" />
 
 ## Dynamic image source
 
-Update the image source dynamically using the same image loader instance. This
-allows for smooth transitions between different images.
+Update the image source dynamically using the same image loader instance for
+smooth transitions between images.
 
 <FileSource src="/framed/ImageLoader/DynamicImageLoader" />

--- a/docs/src/pages/components/InlineNotification.svx
+++ b/docs/src/pages/components/InlineNotification.svx
@@ -19,7 +19,7 @@ Display a basic error notification with title and subtitle by default.
 
 ## Prevent default close behavior
 
-The component is controlled, allowing you to prevent the default close behavior using `e.preventDefault()`.
+The component is controlled, so you can prevent the default close behavior with `e.preventDefault()`.
 
 <InlineNotification title="Error" subtitle="An internal server error occurred." on:close={(e) => {
   e.preventDefault();
@@ -28,7 +28,7 @@ The component is controlled, allowing you to prevent the default close behavior 
 
 ## Reusable notification
 
-Control the notification visibility by binding to the `open` prop. This allows you to show, hide, and reuse the same notification component with different messages. The `open` prop defaults to `true`.
+Control the notification visibility by binding to the `open` prop to show, hide, and reuse the same notification component with different messages. The `open` prop defaults to `true`.
 
 <FileSource src="/framed/InlineNotification/InlineNotificationReusable" />
 

--- a/docs/src/pages/components/Link.svx
+++ b/docs/src/pages/components/Link.svx
@@ -84,7 +84,7 @@ The component supports different sizes to match your design needs:
 
 ## Disabled state
 
-Disabled links render as plain text while maintaining accessibility.
+Disabled links render as plain text while remaining accessible.
 
 <Link disabled href="https://www.carbondesignsystem.com/">
   Disabled link

--- a/docs/src/pages/components/LocalStorage.svx
+++ b/docs/src/pages/components/LocalStorage.svx
@@ -17,7 +17,7 @@ See how the component maintains state across page reloads. Toggle the switch and
 
 ## Reactive key
 
-The `key` prop is also reactive, allowing you to dynamically switch between different storage keys. This is useful for managing per-user settings or multiple contexts.
+The `key` prop is also reactive, so you can dynamically switch between storage keys — useful for per-user settings or multiple contexts.
 
 In this example, each user has their own theme preference stored under a separate key. When you switch users, the component automatically loads that user's saved preference.
 

--- a/docs/src/pages/components/Modal.svx
+++ b/docs/src/pages/components/Modal.svx
@@ -77,7 +77,7 @@ Stack multiple modals for complex workflows. Each modal maintains its own state 
 
 ## Multiple secondary buttons
 
-Add up to two secondary actions using the `secondaryButtons` prop. This provides more flexibility than the single `secondaryButtonText` option.
+Add up to two secondary actions using the `secondaryButtons` prop, which replaces the single `secondaryButtonText` option.
 
 <FileSource src="/framed/Modal/3ButtonModal" />
 
@@ -89,19 +89,19 @@ Use the extra-small size for compact notifications by setting `size` to `"xs"`. 
 
 ## Small size
 
-Use the small size for simple confirmations by setting `size` to `"sm"`. This provides a more focused dialog.
+Use the small size for simple confirmations by setting `size` to `"sm"`.
 
 <FileSource src="/framed/Modal/ModalSmall" />
 
 ## Large size
 
-Use the large size for complex content by setting `size` to `"lg"`. This provides more space for detailed information.
+Use the large size for complex content by setting `size` to `"lg"`.
 
 <FileSource src="/framed/Modal/ModalLarge" />
 
 ## Prevent default close behavior
 
-The modal dispatches a cancelable `close` event, allowing you to prevent the modal from closing using `e.preventDefault()`. The event includes a `trigger` property indicating what triggered the close attempt: `"escape-key"` (<DocKbd label="Escape" />), `"outside-click"`, or `"close-button"`.
+The modal dispatches a cancelable `close` event. Call `e.preventDefault()` to keep the modal open. The event includes a `trigger` property indicating what triggered the close attempt: `"escape-key"` (<DocKbd label="Escape" />), `"outside-click"`, or `"close-button"`.
 
 <FileSource src="/framed/Modal/ModalPreventClose" />
 
@@ -113,6 +113,6 @@ Disable closing the modal when clicking outside by setting `preventCloseOnClickO
 
 ## Button with icon
 
-Enhance modal buttons with icons for better visual context and clarity. This example shows how to add icons to modal actions.
+Enhance modal buttons with icons for better visual context and clarity.
 
 <FileSource src="/framed/Modal/ModalButtonWithIcon" />

--- a/docs/src/pages/components/MultiSelect.svx
+++ b/docs/src/pages/components/MultiSelect.svx
@@ -2,7 +2,7 @@
   import { MultiSelect } from "carbon-components-svelte";
 </script>
 
-Multi-selects provide a dropdown interface for selecting multiple options using checkboxes. They support filtering, custom formatting, and various states. Each item must have a unique `id` property for proper functionality.
+Multi-selects provide a dropdown interface for selecting multiple options using checkboxes. They support filtering, custom formatting, and multiple states.
 
 > [!NOTE]
 > Every `items` object must have a unique "id" property.
@@ -85,7 +85,7 @@ Bind to `sortedItems` to read the resolved list after sorting and selection feed
 
 ## Multiple multi-select dropdowns
 
-This example demonstrates how to manage multiple dropdowns in a form with coordinated state.
+Manage multiple dropdowns in a form with coordinated state.
 
 <FileSource src="/framed/MultiSelect/MultipleMultiSelect" />
 
@@ -142,7 +142,7 @@ Add descriptive text below the multi-select using the `helperText` prop.
 
 ## Hidden label
 
-Hide the label visually while maintaining accessibility by setting `hideLabel` to `true`. The label is still available to screen readers.
+Hide the label visually by setting `hideLabel` to `true`. The label remains available to screen readers.
 
 <MultiSelect labelText="Contact" label="Select contact methods..." hideLabel
     items="{[{id: "0", text: "Slack"},
@@ -152,7 +152,7 @@ Hide the label visually while maintaining accessibility by setting `hideLabel` t
 
 ## Light variant
 
-Use the light variant for dark backgrounds by setting `light` to `true`. This provides better contrast in dark themes.
+Use the light variant for dark backgrounds by setting `light` to `true`.
 
 <MultiSelect light labelText="Contact" label="Select contact methods..."
     items="{[{id: "0", text: "Slack"},
@@ -180,7 +180,7 @@ Display the dropdown inline with other content by setting `type` to `"inline"`. 
 
 ## Extra-large size
 
-Use the extra-large size for prominent selections by setting `size` to `"xl"`. This provides more visual emphasis.
+Use the extra-large size for prominent selections by setting `size` to `"xl"`.
 
 <MultiSelect size="xl" labelText="Contact" label="Select contact methods..."
     items="{[{id: "0", text: "Slack"},
@@ -288,9 +288,9 @@ The select-all option is styled differently from regular options (with a separat
 
 ## Virtualized items (large lists)
 
-Virtualization is a technique that allows only the items currently visible in the viewport to be rendered in the DOM, improving performance for large lists.
+Virtualization renders only the items currently visible in the viewport, improving performance for large lists.
 
-By default, the multi-select will virtualize lists with more than 100 items.
+By default, the multi-select virtualizes lists with more than 100 items.
 
 In the example below, 10,000 items are provided to the multi-select but only 11 items (8 visible items + 3 overscan items) are rendered in the DOM.
 
@@ -319,6 +319,6 @@ Specify a custom value for `threshold` to control when virtualization activates.
 
 ## Virtualized items (custom item height)
 
-The default item height for virtualization is 40 pixels. When using custom slots to render items with different heights (e.g., multi-line items with descriptions), specify a custom `itemHeight` value to match your item's actual height.
+The default item height for virtualization is 40 pixels. When using custom slots to render items with different heights (for example, multi-line items with descriptions), specify a custom `itemHeight` value to match your item's actual height.
 
 <FileSource src="/framed/MultiSelect/VirtualizeItemHeight" />

--- a/docs/src/pages/components/NotificationQueue.svx
+++ b/docs/src/pages/components/NotificationQueue.svx
@@ -6,7 +6,7 @@ components: ["NotificationQueue"]
   import { NotificationQueue } from "carbon-components-svelte";
 </script>
 
-Notification queues provide an imperative API for managing toast notifications. They handle positioning, deduplication, and overflow management, making it easy to display notifications from anywhere in your application.
+Notification queues provide an imperative API for managing toast notifications. They handle positioning, deduplication, and overflow management, so you can display notifications from anywhere in your application.
 
 The queue uses the underlying [ToastNotification](ToastNotification) to display notifications.
 
@@ -26,7 +26,7 @@ The `top-right` position assumes usage of the [UIShell](/components/UIShell) com
 
 ## Deduplication
 
-By default, the `id` prop is optional; a unique id will be generated for the notification. The queue [keys](https://svelte.dev/docs/svelte/each#Keyed-each-blocks) notifications by `id` for performance reasons.
+By default, the `id` prop is optional; a unique id will be generated for the notification. The queue [keys](https://svelte.dev/docs/svelte/each#Keyed-each-blocks) notifications by `id` for performance.
 
 Notifications are deduplicated by `id`. If you add a notification with an `id` that already exists in the queue, the call is ignored. This prevents duplicate notifications from appearing. To change an existing notification in place, use [update](#update).
 

--- a/docs/src/pages/components/NumberInput.svx
+++ b/docs/src/pages/components/NumberInput.svx
@@ -42,7 +42,7 @@ Control the increment/decrement step size using the `step` prop. This example us
 
 Configure a starting point for stepping when the input is empty or zero using `stepStartValue`. When the user clicks increment or decrement, the value jumps directly to `stepStartValue` instead of stepping from zero.
 
-This is useful when zero is not within the `min`/`max` range, or when there is a more sensible default (e.g., the current year when asking for a year). Combined with `allowEmpty`, it ensures the user must interact with the input before submitting a value.
+This is useful when zero is not within the `min`/`max` range, or when there is a more sensible default (for example, the current year when asking for a year). Combined with `allowEmpty`, it ensures the user must interact with the input before submitting a value.
 
 <NumberInput stepStartValue={2026} allowEmpty min={2026} max={2100} labelText="Year" />
 
@@ -110,13 +110,13 @@ Use `on:blur:stepper` to listen for when a stepper button loses focus. The event
 
 ## Hidden label
 
-Hide the label visually while maintaining accessibility by setting `hideLabel` to `true`. The label is still available to screen readers.
+Hide the label visually by setting `hideLabel` to `true`. The label remains available to screen readers.
 
 <NumberInput hideLabel labelText="Clusters" value={0} />
 
 ## Extra-large size
 
-Use the extra-large size for prominent inputs by setting `size` to `"xl"`. This provides more visual emphasis.
+Use the extra-large size for prominent inputs by setting `size` to `"xl"`.
 
 <NumberInput size="xl" labelText="Clusters" value={0} />
 
@@ -128,7 +128,7 @@ Use the small size for compact layouts by setting `size` to `"sm"`. This is idea
 
 ## Light variant
 
-Use the light variant for dark backgrounds by setting `light` to `true`. This provides better contrast in dark themes.
+Use the light variant for dark backgrounds by setting `light` to `true`.
 
 <NumberInput light labelText="Clusters" value={0} />
 
@@ -146,7 +146,7 @@ Indicate a warning state by setting `warn` to `true`. This example shows a warni
 
 ## Disabled state
 
-Disable the input by setting `disabled` to `true`. This prevents all user interaction.
+Disable the input by setting `disabled` to `true`.
 
 <NumberInput disabled labelText="Clusters" value={0} />
 
@@ -158,7 +158,7 @@ Make the input read-only by setting `readonly` to `true`. This allows viewing bu
 
 ## Hidden steppers
 
-Hide the increment/decrement controls by setting `hideSteppers` to `true`. This provides a simpler input interface.
+Hide the increment/decrement controls by setting `hideSteppers` to `true`.
 
 <NumberInput hideSteppers labelText="Clusters" value={0} />
 
@@ -176,6 +176,6 @@ Show a loading state using the number input skeleton. This is useful while data 
 
 ## Skeleton without label
 
-Show a loading state without a label by setting `hideLabel` to `true`. This maintains layout consistency.
+Show a loading state without a label by setting `hideLabel` to `true`.
 
 <NumberInputSkeleton hideLabel />

--- a/docs/src/pages/components/OverflowMenu.svx
+++ b/docs/src/pages/components/OverflowMenu.svx
@@ -138,6 +138,6 @@ Set `disabled` to `true` to disable menu items. Use `hasDivider` to add visual s
 
 ## Prevent menu from closing
 
-Use `preventDefault()` on individual overflow menu item click events to prevent the menu from closing when that item is clicked. This is useful for scenarios where you want to keep the menu open after performing an action.
+Use `preventDefault()` on individual overflow menu item click events to prevent the menu from closing when that item is clicked. Use this to keep the menu open after performing an action.
 
 <FileSource src="/framed/OverflowMenu/OverflowMenuPreventDefault" />

--- a/docs/src/pages/components/Pagination.svx
+++ b/docs/src/pages/components/Pagination.svx
@@ -6,7 +6,7 @@ components: ["Pagination", "PaginationSkeleton"]
   import { Pagination, PaginationSkeleton } from "carbon-components-svelte";
 </script>
 
-Pagination provides navigation controls for large data sets. It displays the current page, total items, and allows users to change page size and navigate between pages.
+Pagination provides navigation controls for large data sets. It shows the current page and total items, and supports changing page size and navigating between pages.
 
 ## Default
 

--- a/docs/src/pages/components/PasswordInput.svx
+++ b/docs/src/pages/components/PasswordInput.svx
@@ -24,7 +24,7 @@ Set prop `type` to `"text"` to toggle password visibility.
 
 ## Hidden label
 
-Visually hide the label while maintaining accessibility.
+Hide the label visually by setting `hideLabel` to `true`. The label remains available to screen readers.
 
 <PasswordInput hideLabel labelText="Password" placeholder="Enter password..." />
 

--- a/docs/src/pages/components/Portal.svx
+++ b/docs/src/pages/components/Portal.svx
@@ -2,9 +2,9 @@
   import { Portal } from "carbon-components-svelte";
 </script>
 
-Portals render their content directly into `document.body`, allowing you to escape parent overflow constraints and z-index stacking contexts.
+Portals render their content directly into `document.body` to escape parent overflow constraints and z-index stacking contexts.
 
-For anchored, positioned content (e.g., dropdowns, popovers, overflow menus), use [FloatingPortal](/components/FloatingPortal) instead.
+For anchored, positioned content (for example, dropdowns, popovers, overflow menus), use [FloatingPortal](/components/FloatingPortal) instead.
 
 ## Default Portal
 

--- a/docs/src/pages/components/ProgressBar.svx
+++ b/docs/src/pages/components/ProgressBar.svx
@@ -42,7 +42,7 @@ Set a custom maximum value for the progress bar.
 
 ## Hidden label
 
-Visually hide the label while maintaining accessibility.
+Hide the label visually by setting `hideLabel` to `true`. The label remains available to screen readers.
 
 <ProgressBar hideLabel value={40} labelText="Upload status" helperText="40 MB of 100 MB" />
 

--- a/docs/src/pages/components/RadioButton.svx
+++ b/docs/src/pages/components/RadioButton.svx
@@ -6,7 +6,7 @@ components: ["RadioButtonGroup", "RadioButton", "RadioButtonSkeleton"]
   import { RadioButton, RadioButtonSkeleton, RadioButtonGroup, Tooltip, Stack } from "carbon-components-svelte";
 </script>
 
-Radio buttons provide a selection control that allows users to choose a single option from a set. They support both individual and grouped usage, with options for horizontal and vertical layouts.
+Radio buttons are a selection control for choosing a single option from a set. They support both individual and grouped usage, with options for horizontal and vertical layouts.
 
 ## Default
 
@@ -28,13 +28,13 @@ Use a radio button individually with a bindable `checked` prop for simple use ca
 
 ## Implicit grouping
 
-Multiple standalone radio button components sharing the same `name` attribute automatically form a group and synchronize their checked state. This allows you to create radio button groups without using a radio button group.
+Multiple standalone radio button components sharing the same `name` attribute automatically form a group and synchronize their checked state — no radio button group component required.
 
 <FileSource src="/framed/RadioButton/RadioButtonImplicitGroup" />
 
 ## Hidden legend
 
-Visually hide the legend while maintaining accessibility.
+Hide the legend visually by setting `hideLegend` to `true`. The legend remains available to screen readers.
 
 <RadioButtonGroup hideLegend legendText="Storage tier (disk)" name="plan-legend" selected="standard">
   <RadioButton labelText="Free (1 GB)" value="free" />

--- a/docs/src/pages/components/Select.svx
+++ b/docs/src/pages/components/Select.svx
@@ -64,7 +64,7 @@ Add descriptive text below the select menu.
 
 ## Hidden label
 
-Visually hide the label while maintaining accessibility.
+Hide the label visually by setting `hideLabel` to `true`. The label remains available to screen readers.
 
 <Select hideLabel labelText="Carbon theme" selected="g10" >
   <SelectItem value="white" text="White" />
@@ -177,7 +177,7 @@ Disable the select menu to prevent interaction.
 
 ## Read-only state
 
-Use the read-only state to display the selected value without allowing changes.
+Use the read-only state to display the selected value while preventing changes.
 
 <Select readonly labelText="Carbon theme" selected="g10" >
   <SelectItem value="white" text="White" />

--- a/docs/src/pages/components/SelectableTile.svx
+++ b/docs/src/pages/components/SelectableTile.svx
@@ -6,7 +6,7 @@ components: ["SelectableTileGroup", "SelectableTile"]
   import { SelectableTileGroup, SelectableTile } from "carbon-components-svelte";
 </script>
 
-Selectable tiles provide a tile-based selection interface that allows users to select multiple options. They support various states and include built-in keyboard navigation and accessibility features.
+Selectable tiles provide a tile-based selection interface for choosing multiple options. They support multiple states and include built-in keyboard navigation and accessibility features.
 
 ## Multi-selectable tiles
 
@@ -38,7 +38,7 @@ Bind to the `selected` prop for simpler state management.
 
 ## Hidden legend
 
-Visually hide the legend while maintaining accessibility.
+Hide the legend visually by setting `hideLegend` to `true`. The legend remains available to screen readers.
 
 <SelectableTileGroup hideLegend legendText="Select options" name="options-hidden-legend" selected={["option1"]}>
   <SelectableTile value="option1">

--- a/docs/src/pages/components/SessionStorage.svx
+++ b/docs/src/pages/components/SessionStorage.svx
@@ -2,7 +2,7 @@
 components: ["SessionStorage"]
 ---
 
-Session storage provides a reactive wrapper around the [Window.sessionStorage API](https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage). Unlike [LocalStorage](/components/LocalStorage), data is cleared when the browser tab is closed and is isolated per tab—each tab has its own storage. Use session storage for temporary state that should not persist across sessions (e.g., form drafts, wizard progress).
+Session storage provides a reactive wrapper around the [Window.sessionStorage API](https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage). Unlike [LocalStorage](/components/LocalStorage), data is cleared when the browser tab is closed and is isolated per tab—each tab has its own storage. Use session storage for temporary state that should not persist across sessions (for example, form drafts or wizard progress).
 
 The component listens for the [storage event](https://developer.mozilla.org/en-US/docs/Web/API/Window/storage_event) for consistency with the storage API.
 
@@ -14,7 +14,7 @@ See how the component maintains state within a session. Toggle the switch and re
 
 ## Reactive key
 
-The `key` prop is also reactive, allowing you to dynamically switch between different storage keys. This is useful for managing per-user settings or multiple contexts.
+The `key` prop is also reactive, so you can dynamically switch between storage keys — useful for per-user settings or multiple contexts.
 
 In this example, each user has their own theme preference stored under a separate key. When you switch users, the component automatically loads that user's saved preference.
 

--- a/docs/src/pages/components/Slider.svx
+++ b/docs/src/pages/components/Slider.svx
@@ -22,7 +22,7 @@ Set `fullWidth` to `true` for the slider to span the full width of its containin
 
 ## Hidden label
 
-Visually hide the label while maintaining accessibility.
+Hide the label visually by setting `hideLabel` to `true`. The label remains available to screen readers.
 
 <Slider labelText="Instances" hideLabel value={0} />
 
@@ -70,7 +70,7 @@ Disable the slider to prevent interaction.
 
 ## Read-only state
 
-Set the slider to read-only to display a value without allowing changes.
+Set the slider to read-only to display a value while preventing changes.
 
 <Slider readonly labelText="Runtime memory (MB)" min={10} max={990} maxLabel="990 MB" value={100} step={10} />
 
@@ -118,7 +118,7 @@ Disable the range slider to prevent interaction.
 
 ## Range slider (read-only)
 
-Set the range slider to read-only to display values without allowing changes.
+Set the range slider to read-only to display values while preventing changes.
 
 <RangeSlider readonly labelText="Range" value={10} valueUpper={90} />
 

--- a/docs/src/pages/components/Stack.svx
+++ b/docs/src/pages/components/Stack.svx
@@ -25,7 +25,7 @@ The `gap` scale can be set from `0` to `13`:
 | **12** | 6rem (96px)       |
 | **13** | 10rem (160px)     |
 
-Alternatively, you can specify an arbitrary `gap` value (e.g., `200px`). You can also set `gap` to `0` to omit any gap class.
+Alternatively, you can specify an arbitrary `gap` value (for example, `200px`). You can also set `gap` to `0` to omit any gap class.
 
 ## Vertical (gap 0)
 
@@ -179,7 +179,7 @@ Set `inline` to `true` to use `display: inline-flex` instead of `display: flex`.
 
 ## Vertical (custom value)
 
-Use an arbitrary gap value (e.g., 22px) instead of the scale.
+Use an arbitrary gap value (for example, 22px) instead of the scale.
 
 <Stack gap="22px">
   <div>Item 1</div>
@@ -339,7 +339,7 @@ Gap scale of `13` (160px).
 
 ## Horizontal (custom value)
 
-Use an arbitrary gap value (e.g., 22px) instead of the scale.
+Use an arbitrary gap value (for example, 22px) instead of the scale.
 
 <Stack orientation="horizontal" gap="22px">
   <div>Item 1</div>

--- a/docs/src/pages/components/Tabs.svx
+++ b/docs/src/pages/components/Tabs.svx
@@ -58,7 +58,7 @@ Set `fullWidth` to `true` for tabs to evenly span the full width of the containe
 
 ## Reactive example
 
-Use `bind:selected` to create a two-way binding with the selected tab index. This allows you to programmatically control the selected tab and react to tab changes.
+Use `bind:selected` for a two-way binding with the selected tab index, so you can programmatically control the selected tab and react to tab changes.
 
 <FileSource src="/framed/Tabs/TabsReactive" />
 
@@ -66,7 +66,7 @@ Use `bind:selected` to create a two-way binding with the selected tab index. Thi
 
 Tabs can be conditionally rendered using Svelte's `{#if}` blocks. The component automatically maintains correct indices even when tabs are dynamically added or removed.
 
-If the current selected tab is removed, the next tab will be selected.
+If the current selected tab is removed, the next tab is selected.
 
 <FileSource src="/framed/Tabs/TabsConditional" />
 
@@ -200,7 +200,7 @@ When only some tabs use `secondaryLabel`, the container still applies the taller
 
 ## Container type (secondaryChildren slot)
 
-Use the `secondaryChildren` slot to customize the secondary label with custom markup (e.g. `<strong>` for emphasis).
+Use the `secondaryChildren` slot to customize the secondary label with custom markup (for example, `<strong>` for emphasis).
 
 <Tabs type="container">
   <Tab label="Engage">
@@ -221,7 +221,7 @@ Use the `secondaryChildren` slot to customize the secondary label with custom ma
 
 ## Container type with icons and secondary label
 
-Container type tabs can use both `icon` and `secondaryLabel` for a primary label, icon, and optional secondary line (e.g. counts or status).
+Container type tabs can use both `icon` and `secondaryLabel` for a primary label, icon, and optional secondary line (for example, counts or status).
 
 <Tabs type="container">
   <Tab label="Calendar" icon={Calendar} secondaryLabel="(12 events)" />

--- a/docs/src/pages/components/Tag.svx
+++ b/docs/src/pages/components/Tag.svx
@@ -88,7 +88,7 @@ Add a custom icon to the tag. Note: custom icons cannot be used with the filtera
 
 ## Interactive variant
 
-Set `interactive` to `true` to render a `button` element instead of a `div`. This is useful for clickable tags.
+Set `interactive` to `true` to render a `button` element instead of a `div` for clickable tags.
 
 <Tag interactive>Machine learning</Tag>
 

--- a/docs/src/pages/components/TextArea.svx
+++ b/docs/src/pages/components/TextArea.svx
@@ -28,7 +28,7 @@ Add helper text below the textarea to provide additional context or instructions
 
 ## Hidden label
 
-Visually hide the label while maintaining accessibility by setting `hideLabel` to `true`.
+Hide the label visually by setting `hideLabel` to `true`. The label remains available to screen readers.
 
 <TextArea hideLabel labelText="App description" placeholder="Enter a description..." />
 

--- a/docs/src/pages/components/TextInput.svx
+++ b/docs/src/pages/components/TextInput.svx
@@ -22,7 +22,7 @@ Add helper text below the input to provide additional context or instructions.
 
 ## Hidden label
 
-Visually hide the label while maintaining accessibility by setting `hideLabel` to `true`.
+Hide the label visually by setting `hideLabel` to `true`. The label remains available to screen readers.
 
 <TextInput hideLabel labelText="User name" placeholder="Enter user name..." />
 

--- a/docs/src/pages/components/Theme.svx
+++ b/docs/src/pages/components/Theme.svx
@@ -5,7 +5,7 @@ components: ["Theme"]
 <script>
 </script>
 
-Theme provides dynamic client-side theming using CSS variables. It supports five themes: `white`, `g10`, `g80`, `g90`, and `g100`, and allows for custom theme token overrides.
+Theme provides dynamic client-side theming using CSS variables. It supports five themes: `white`, `g10`, `g80`, `g90`, and `g100`, and supports custom theme token overrides.
 
 The component can persist theme preferences using [window.localStorage](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage) and provides built-in toggle and select controls for theme switching.
 
@@ -25,7 +25,7 @@ Create a basic theme component that can be controlled programmatically.
 
 Set `persist` to `true` to save the theme preference in [localStorage](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage). Use `persistKey` to specify a custom storage key.
 
-When `persist` is enabled, theme changes are automatically synchronized across browser tabs. When the theme is changed in one tab, all other tabs with the same `persistKey` will update immediately.
+When `persist` is enabled, theme changes are automatically synchronized across browser tabs. When the theme is changed in one tab, all other tabs with the same `persistKey` update immediately.
 
 <FileSource src="/framed/Theme/ThemePersist" />
 

--- a/docs/src/pages/components/TimePicker.svx
+++ b/docs/src/pages/components/TimePicker.svx
@@ -85,7 +85,7 @@ Add helper text to provide additional context or formatting instructions.
 
 ## Hidden label
 
-Hide the label while maintaining accessibility.
+Hide the label visually by setting `hideLabel` to `true`. The label remains available to screen readers.
 
 <TimePicker hideLabel labelText="Cron job" placeholder="hh:mm">
   <TimePickerSelect value="pm">

--- a/docs/src/pages/components/ToastNotification.svx
+++ b/docs/src/pages/components/ToastNotification.svx
@@ -36,7 +36,7 @@ Prevent the default close behavior using `e.preventDefault()` in the `on:close` 
 
 ## Reusable notification
 
-Control the notification visibility by binding to the `open` prop. This allows you to show, hide, and reuse the same notification component with different messages. The `open` prop defaults to `true`.
+Control the notification visibility by binding to the `open` prop to show, hide, and reuse the same notification component with different messages. The `open` prop defaults to `true`.
 
 <FileSource src="/framed/ToastNotification/ToastNotificationReusable" />
 

--- a/docs/src/pages/components/Toggle.svx
+++ b/docs/src/pages/components/Toggle.svx
@@ -6,7 +6,7 @@ components: ["Toggle", "ToggleSkeleton"]
   import { Toggle, ToggleSkeleton } from "carbon-components-svelte";
 </script>
 
-Toggles provide a switch-like control that allows users to turn options on or off. They support custom labels, different sizes, and various states to match your application's needs.
+Toggles are a switch-like control for turning options on or off. They support custom labels, different sizes, and multiple states to match your application's needs.
 
 ## Default
 
@@ -34,7 +34,7 @@ Listen for toggle state changes using the `on:toggle` event.
 
 ## Hidden label text
 
-Set `hideLabel` to `true` to visually hide the label while maintaining accessibility.
+Hide the label visually by setting `hideLabel` to `true`. The label remains available to screen readers.
 
 <Toggle labelText="Push notifications" hideLabel />
 

--- a/docs/src/pages/components/TreeView.svx
+++ b/docs/src/pages/components/TreeView.svx
@@ -144,7 +144,7 @@ Configure `TreeView.showNode` behavior using optional parameters. By default, al
 
 ## Performance with large and deep trees
 
-The tree view is optimized to handle large datasets efficiently. This example demonstrates performance with both a large tree (1000+ nodes) and a deeply nested tree (100 levels deep).
+The tree view is optimized to handle large datasets efficiently, as shown here with a large tree (1000+ nodes) and a deeply nested tree (100 levels deep).
 
 <FileSource src="/framed/TreeView/TreeViewPerformance" />
 

--- a/docs/src/pages/components/UIShell.svx
+++ b/docs/src/pages/components/UIShell.svx
@@ -32,7 +32,7 @@ Create a basic header with the header component.
 
 ## Header with side navigation
 
-The hamburger menu will automatically be rendered if the side nav component is used.
+The hamburger menu is automatically rendered if the side nav component is used.
 
 <FileSource src="/framed/UIShell/HeaderNav" />
 
@@ -108,7 +108,7 @@ Integrate toasts with the UI Shell. This example triggers a toast, which appears
 
 ## Classic theme
 
-Before version 0.105.0, the UI Shell defaulted to a mixed theme: **Gray 100** header and **White** side navigation. Now, the UI Shell respects the current theme (e.g., `white`, `g10`, `g80`, `g90`, `g100`).
+Before version 0.105.0, the UI Shell defaulted to a mixed theme: **Gray 100** header and **White** side navigation. Now, the UI Shell respects the current theme (for example, `white`, `g10`, `g80`, `g90`, `g100`).
 
 Set `theme="classic"` on both `Header` and `SideNav` for the classic look: **Gray 100** header and **White** side navigation, independent of the global theme.
 


### PR DESCRIPTION
This does a comprehensive pass at applying Carbon's [writing style](https://carbondesignsystem.com/guidelines/content/writing-style/) to the docs:

- **Removed trivializers**: "easy/easily", "makes it easier to", "for performance reasons"
- **Replaced Latin abbreviations**: every `e.g.` / `e.g` → "for example", `i.e.` cleared
- **Rewrote indirect "allows you to / allowing you to / allows for"** into direct phrasing
- **Cut pure-filler tails**: "This provides more visual emphasis.", "This provides better contrast in dark themes.", "This prevents user interaction with the component." while keeping genuine *when-to-use* guidance
- **Standardized the hideLabel/hideLegend boilerplate** to one consistent line: *"Hide the label visually by setting `hideLabel` to `true`. The label remains available to screen readers."*
- **Tightened wordy intros** and converted passive future tense to present
