### PR TITLE
fix(accordion-item): a11y parities

### DIFF
--- a/src/Accordion/AccordionItem.svelte
+++ b/src/Accordion/AccordionItem.svelte
@@ -87,7 +87,7 @@
       }
     }}
   >
-    <ChevronRight class="bx--accordion__arrow" aria-label={iconDescription} />
+    <ChevronRight class="bx--accordion__arrow" />
     <div class:bx--accordion__title={true}>
       <slot name="title">{title}</slot>
     </div>

--- a/src/Accordion/AccordionItem.svelte
+++ b/src/Accordion/AccordionItem.svelte
@@ -23,8 +23,12 @@
    */
   export let disabled = false;
 
-  /** Specify the ARIA label for the accordion item chevron icon */
-  export let iconDescription = "Expand/Collapse";
+  /**
+   * Specify a custom label for the accordion button.
+   * This is important for accessibility when the accordion has no visible title.
+   * @type {string}
+   */
+  export let ariaLabel = undefined;
 
   /**
    * Obtain a reference to the heading button HTML element.
@@ -69,7 +73,7 @@
     bind:this={ref}
     type="button"
     class:bx--accordion__heading={true}
-    title={iconDescription}
+    aria-label={ariaLabel}
     aria-expanded={open}
     {disabled}
     on:click

--- a/tests/Accordion/Accordion.test.svelte
+++ b/tests/Accordion/Accordion.test.svelte
@@ -9,7 +9,7 @@
   export let customClass = "";
   export let itemClass = "";
   export let useSlot = false;
-  export let iconDescription = "Expand/Collapse";
+  export let ariaLabel: ComponentProps<AccordionItem>["ariaLabel"] = undefined;
   export let ref: ComponentProps<AccordionItem>["ref"] = null;
 </script>
 
@@ -31,7 +31,7 @@
   }}
 >
   {#if useSlot}
-    <AccordionItem class={itemClass} {iconDescription}>
+    <AccordionItem class={itemClass} {ariaLabel}>
       <div slot="title">Custom Title</div>
       Slot content
     </AccordionItem>

--- a/tests/Accordion/Accordion.test.ts
+++ b/tests/Accordion/Accordion.test.ts
@@ -404,12 +404,12 @@ describe("Accordion", () => {
     );
   });
 
-  it("should use custom iconDescription", () => {
+  it("should use custom ariaLabel on the heading button", () => {
     render(Accordion, {
-      props: { useSlot: true, iconDescription: "Custom description" },
+      props: { useSlot: true, ariaLabel: "Custom description" },
     });
 
     const button = screen.getByRole("button");
-    expect(button).toHaveAttribute("title", "Custom description");
+    expect(button).toHaveAttribute("aria-label", "Custom description");
   });
 });


### PR DESCRIPTION
Aligns with the upstream implementation:

- Remove `iconDescription` on decorative chevron icon
- Breaking: rename it to `ariaLabel` and provide it to the heading button (useful for a11y if there is no visible title)