### PR TITLE
fix(data-table): associate cells with column headers

### DIFF
--- a/src/DataTable/DataTable.svelte
+++ b/src/DataTable/DataTable.svelte
@@ -962,6 +962,7 @@
                   </td>
                 {:else}
                   <TableCell
+                    headers="{id}-{cell.key}"
                     on:click={(event) => {
                       dispatch("click", { row, cell });
                       dispatch("click:cell", {
@@ -1170,6 +1171,7 @@
                   </td>
                 {:else}
                   <TableCell
+                    headers="{id}-{cell.key}"
                     on:click={(event) => {
                       dispatch("click", { row, cell });
                       dispatch("click:cell", {

--- a/src/DataTable/TableHeader.svelte
+++ b/src/DataTable/TableHeader.svelte
@@ -55,6 +55,7 @@
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
 {#if sortable}
   <th
+    {id}
     aria-sort={active ? sortDirection : "none"}
     {scope}
     data-header={id}
@@ -81,6 +82,7 @@
   </th>
 {:else}
   <th
+    {id}
     {scope}
     data-header={id}
     {...$$restProps}

--- a/tests/DataTable/DataTable.test.ts
+++ b/tests/DataTable/DataTable.test.ts
@@ -101,6 +101,29 @@ describe("DataTable", () => {
     }
   });
 
+  // a11y: each data cell should reference its column header via headers/id
+  it("associates data cells with their column headers", () => {
+    render(DataTable);
+
+    const columnHeaders = screen.getAllByRole("columnheader");
+    headers.forEach((header, i) => {
+      expect(columnHeaders[i]).toHaveAttribute(
+        "id",
+        expect.stringMatching(new RegExp(`-${header.key}$`)),
+      );
+    });
+
+    const bodyRows = screen
+      .getAllByRole("row")
+      .filter((row) => row.closest("tbody") !== null);
+    for (const row of bodyRows) {
+      const cells = within(row).getAllByRole("cell");
+      cells.forEach((cell, i) => {
+        expect(cell).toHaveAttribute("headers", columnHeaders[i].id);
+      });
+    }
+  });
+
   it("renders with title and description", () => {
     render(DataTable, {
       props: {


### PR DESCRIPTION
Ports this fix https://github.com/carbon-design-system/carbon/pull/22169

Associate table cells with their column headers.