### PR TITLE
docs(tree-view): fix "Slottable node with inline editing" example

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -174,6 +174,18 @@
           }
         }
       }
+    },
+    {
+      "includes": [
+        "docs/src/pages/framed/TreeView/TreeViewInlineEditing.svelte"
+      ],
+      "linter": {
+        "rules": {
+          "correctness": {
+            "noUnusedVariables": "off"
+          }
+        }
+      }
     }
   ]
 }

--- a/docs/src/pages/framed/TreeView/TreeViewInlineEditing.svelte
+++ b/docs/src/pages/framed/TreeView/TreeViewInlineEditing.svelte
@@ -51,6 +51,17 @@
     findAndUpdate(nodes);
     nodes = nodes;
   }
+
+  function syncContenteditable(element, text) {
+    element.textContent = text;
+    return {
+      update(text) {
+        if (document.activeElement !== element) {
+          element.textContent = text;
+        }
+      },
+    };
+  }
 </script>
 
 <Stack gap={6}>
@@ -64,11 +75,11 @@
           style="align-items: center; outline: none"
         >
           <span
+            use:syncContenteditable={node.text}
             contenteditable={!node.disabled}
-            on:input={(e) => updateNodeText(node.id, e.target.textContent)}
-          >
-            {node.text}
-          </span>
+            on:input={(e) => updateNodeText(node.id, e.currentTarget.textContent)}
+            style:outline="none"
+          ></span>
           <Edit aria-hidden="true" />
         </Stack>
       </div>


### PR DESCRIPTION
Fixes the docs example for contenteditable with TreeView. Somewhere along the way, this regressed, where it "re-focuses" the start of the `span`.

For now, this is a hotfix, but I'd like better support/documentation/a11y for "custom" interactive elements within tree view nodes (e.g., checkboxes, links).