### PR TITLE
feat(tree-view): allow slottable interactive content

### DIFF
--- a/src/TreeView/TreeViewNode.svelte
+++ b/src/TreeView/TreeViewNode.svelte
@@ -52,6 +52,43 @@
     }
     return null;
   }
+
+  const SLOTTED_INTERACTIVE_SELECTOR =
+    'input, button, select, textarea, a[href], label, [contenteditable], [role="checkbox"]';
+
+  /**
+   * Prevents a tree item from taking focus when clicking slotted controls
+   * (e.g. checkboxes, links, contenteditable regions).
+   * @type {(
+   *   event: MouseEvent,
+   *   labelRoot: HTMLElement | null,
+   *   options?: { ignoreToggle?: boolean }
+   * ) => void}
+   */
+  export function preventTreeItemFocusOnSlottedControl(
+    event,
+    labelRoot,
+    options = {},
+  ) {
+    if (
+      !(event.target instanceof Element) ||
+      !labelRoot?.contains(event.target)
+    ) {
+      return;
+    }
+
+    if (
+      options.ignoreToggle &&
+      event.target.closest(".bx--tree-parent-node__toggle")
+    ) {
+      return;
+    }
+
+    const interactive = event.target.closest(SLOTTED_INTERACTIVE_SELECTOR);
+    if (interactive instanceof HTMLElement) {
+      event.preventDefault();
+    }
+  }
 </script>
 
 <script>
@@ -128,6 +165,11 @@
     refLabel.style.marginLeft = `-${offset()}rem`;
     refLabel.style.paddingLeft = `${offset()}rem`;
   }
+
+  /** @param {MouseEvent} event */
+  function handleSlottedControlMouseDown(event) {
+    preventTreeItemFocusOnSlottedControl(event, refLabel);
+  }
 </script>
 
 {#if href}
@@ -153,6 +195,7 @@
         if (disabled) return;
         clickNode(node, event);
       }}
+      on:mousedown={handleSlottedControlMouseDown}
       on:keydown={(event) => {
         if (
           event.key === "ArrowLeft" ||
@@ -203,6 +246,7 @@
       if (disabled) return;
       clickNode(node, event);
     }}
+    on:mousedown={handleSlottedControlMouseDown}
     on:keydown={(event) => {
       if (
         event.key === "ArrowLeft" ||

--- a/src/TreeView/TreeViewNodeList.svelte
+++ b/src/TreeView/TreeViewNodeList.svelte
@@ -25,6 +25,7 @@
   import TreeViewNode, {
     computeTreeLeafDepth,
     findParentTreeNode,
+    preventTreeItemFocusOnSlottedControl,
   } from "./TreeViewNode.svelte";
 
   /**
@@ -91,6 +92,13 @@
     refLabel.style.marginLeft = `-${offset()}rem`;
     refLabel.style.paddingLeft = `${offset()}rem`;
   }
+
+  /** @param {MouseEvent} event */
+  function handleSlottedControlMouseDown(event) {
+    preventTreeItemFocusOnSlottedControl(event, refLabel, {
+      ignoreToggle: true,
+    });
+  }
 </script>
 
 {#if root}
@@ -123,6 +131,7 @@
       if (disabled) return;
       clickNode(node, event);
     }}
+    on:mousedown={handleSlottedControlMouseDown}
     on:keydown={(event) => {
       if (
         event.key === "ArrowLeft" ||


### PR DESCRIPTION
POC: haven't done a11y.

This is meant to better support custom interactive content within tree view nodes. For example, avoiding the "click focus" outline when clicking a checkbox in a tree view node.