### PR TITLE
fix(tree-view): prevent arrow keys from scrolling the page

### DIFF
--- a/src/TreeView/TreeView.svelte
+++ b/src/TreeView/TreeView.svelte
@@ -662,6 +662,8 @@
     if (
       event.key === "ArrowUp" ||
       event.key === "ArrowDown" ||
+      event.key === "ArrowLeft" ||
+      event.key === "ArrowRight" ||
       event.key === "Home" ||
       event.key === "End"
     ) {

--- a/src/TreeView/TreeViewNode.svelte
+++ b/src/TreeView/TreeViewNode.svelte
@@ -155,10 +155,20 @@
       }}
       on:keydown={(event) => {
         if (
+          event.key === "ArrowUp" ||
+          event.key === "ArrowDown" ||
+          event.key === "Home" ||
+          event.key === "End"
+        ) {
+          event.preventDefault();
+        }
+
+        if (
           event.key === "ArrowLeft" ||
           event.key === "ArrowRight" ||
           event.key === "Enter"
         ) {
+          event.preventDefault();
           event.stopPropagation();
         }
 
@@ -205,10 +215,20 @@
     }}
     on:keydown={(event) => {
       if (
+        event.key === "ArrowUp" ||
+        event.key === "ArrowDown" ||
+        event.key === "Home" ||
+        event.key === "End"
+      ) {
+        event.preventDefault();
+      }
+
+      if (
         event.key === "ArrowLeft" ||
         event.key === "ArrowRight" ||
         event.key === "Enter"
       ) {
+        event.preventDefault();
         event.stopPropagation();
       }
 

--- a/src/TreeView/TreeViewNodeList.svelte
+++ b/src/TreeView/TreeViewNodeList.svelte
@@ -125,10 +125,20 @@
     }}
     on:keydown={(event) => {
       if (
+        event.key === "ArrowUp" ||
+        event.key === "ArrowDown" ||
+        event.key === "Home" ||
+        event.key === "End"
+      ) {
+        event.preventDefault();
+      }
+
+      if (
         event.key === "ArrowLeft" ||
         event.key === "ArrowRight" ||
         event.key === "Enter"
       ) {
+        event.preventDefault();
         event.stopPropagation();
       }
 


### PR DESCRIPTION
This has always been a bug since the `TreeView` implementation in this library.

Easily reproduce this with page overflow: the arrow keys navigating the tree view should not also move the page scroll.

---

<img width="732" height="319" alt="Screenshot 2026-06-06 at 11 13 16 AM" src="https://github.com/user-attachments/assets/fac167d2-a968-41ac-a98f-dbdf57113560" />
