### PR TITLE
feat(data-table): inherit `Toolbar` size from parent `DataTable`

### DIFF
--- a/docs/src/pages/components/DataTable.svx
+++ b/docs/src/pages/components/DataTable.svx
@@ -453,7 +453,7 @@ Add a toolbar with search, menu, and actions above the table.
 
 ## With toolbar (small size)
 
-Use `size="short"` to create a more compact table with a small toolbar.
+Use `size="short"` for a more compact table. The `Toolbar` inherits a matching size from the parent `DataTable`: `short` uses the small toolbar and `compact` uses the [extra small toolbar](#with-toolbar-compact-size). Set `size` on the `Toolbar` to override the inherited value (see [toolbar size override](#with-toolbar-size-override)).
 
 <DataTable size="short" title="Load balancers" description="Your organization's active load balancers."
   headers="{[
@@ -507,6 +507,54 @@ Use `size="short"` to create a more compact table with a small toolbar.
     },
   ]}"
 >
+  <Toolbar>
+    <ToolbarContent>
+      <ToolbarSearch />
+      <ToolbarMenu>
+        <ToolbarMenuItem primaryFocus>Restart all</ToolbarMenuItem>
+        <ToolbarMenuItem href="https://cloud.ibm.com/docs/loadbalancer-service">API documentation</ToolbarMenuItem>
+        <ToolbarMenuItem hasDivider danger>Stop all</ToolbarMenuItem>
+      </ToolbarMenu>
+      <Button>Create balancer</Button>
+    </ToolbarContent>
+  </Toolbar>
+</DataTable>
+
+## With toolbar (size override)
+
+Set `size` on the `Toolbar` to override the size inherited from the `DataTable`. Here, a `size="tall"` table uses a `size="sm"` toolbar.
+
+<DataTable size="tall" title="Load balancers" description="Your organization's active load balancers."
+  headers="{[
+    { key: "name", value: "Name" },
+    { key: "protocol", value: "Protocol" },
+    { key: "port", value: "Port" },
+    { key: "rule", value: "Rule" }
+  ]}"
+  rows="{[
+    {
+      id: "a",
+      name: "Load Balancer 3",
+      protocol: "HTTP",
+      port: 3000,
+      rule: "Round robin"
+    },
+    {
+      id: "b",
+      name: "Load Balancer 1",
+      protocol: "HTTP",
+      port: 443,
+      rule: "Round robin"
+    },
+    {
+      id: "c",
+      name: "Load Balancer 2",
+      protocol: "HTTP",
+      port: 80,
+      rule: "DNS delegation"
+    },
+  ]}"
+>
   <Toolbar size="sm">
     <ToolbarContent>
       <ToolbarSearch />
@@ -522,7 +570,7 @@ Use `size="short"` to create a more compact table with a small toolbar.
 
 ## With toolbar (compact size)
 
-Use `size="compact"` for the table together with `size="xs"` on the toolbar to align the toolbar with a compact (24px row) table.
+Use `size="compact"` for the table. The `Toolbar` inherits the extra small (`xs`) size to match the compact 24px row height.
 
 <DataTable size="compact" title="Load balancers" description="Your organization's active load balancers."
   headers="{[
@@ -576,7 +624,7 @@ Use `size="compact"` for the table together with `size="xs"` on the toolbar to a
     },
   ]}"
 >
-  <Toolbar size="xs">
+  <Toolbar>
     <ToolbarContent>
       <ToolbarSearch />
       <ToolbarMenu size="sm">
@@ -645,7 +693,7 @@ Set `selectable` to `true` to enable selectable rows. Here, the toolbar is used 
     },
   ]}"
 >
-  <Toolbar size="sm">
+  <Toolbar>
     <ToolbarContent>
       <ToolbarSearch persistent />
       <Button>Action</Button>

--- a/src/DataTable/DataTable.svelte
+++ b/src/DataTable/DataTable.svelte
@@ -315,6 +315,13 @@
    * @type {import("svelte/store").Writable<ReadonlyArray<Row>>}
    */
   const tableRows = writable(rows);
+  /**
+   * Exposes the table size to slotted content (e.g. `Toolbar`)
+   * so it can derive a matching size unless explicitly overridden.
+   * @type {import("svelte/store").Writable<"compact" | "short" | "medium" | "tall" | undefined>}
+   */
+  const tableSize = writable(size);
+  $: $tableSize = size;
 
   /** Default row heights based on size variant */
   const DEFAULT_ROW_HEIGHTS = {
@@ -445,6 +452,7 @@
   setContext("carbon:DataTable", {
     batchSelectedIds,
     tableRows,
+    tableSize,
     resetSelectedRowIds,
     filterRows,
   });

--- a/src/DataTable/Toolbar.svelte
+++ b/src/DataTable/Toolbar.svelte
@@ -1,19 +1,39 @@
 <script>
   /**
    * Specify the toolbar size.
+   * If unset, the size is inherited from the parent `DataTable`
+   * ("xs" for "compact", "sm" for "short", "default" otherwise).
    * @type {"xs" | "sm" | "default"}
    */
-  export let size = "default";
+  export let size = undefined;
 
   /**
    * Specify the ARIA label for the toolbar.
    */
   export let ariaLabel = "data table toolbar";
 
-  import { setContext } from "svelte";
+  import { getContext, setContext } from "svelte";
   import { writable } from "svelte/store";
 
   let ref = null;
+
+  const dataTableCtx = getContext("carbon:DataTable");
+  /** @type {import("svelte/store").Writable<"compact" | "short" | "medium" | "tall" | undefined> | undefined} */
+  const tableSize = dataTableCtx?.tableSize;
+
+  /** @type {Record<"compact" | "short" | "medium" | "tall", "xs" | "sm" | "default">} */
+  const TOOLBAR_SIZE_BY_TABLE_SIZE = {
+    compact: "xs",
+    short: "sm",
+    medium: "default",
+    tall: "default",
+  };
+
+  // `$tableSize` is safe when `tableSize` is undefined: Svelte's auto-subscription no-ops on null/undefined stores.
+  $: inheritedSize = $tableSize
+    ? TOOLBAR_SIZE_BY_TABLE_SIZE[$tableSize]
+    : undefined;
+  $: effectiveSize = size ?? inheritedSize ?? "default";
 
   /**
    * @type {import("svelte/store").Writable<boolean>}
@@ -44,9 +64,9 @@
   bind:this={ref}
   aria-label={ariaLabel}
   class:bx--table-toolbar={true}
-  class:bx--table-toolbar--xs={size === "xs"}
-  class:bx--table-toolbar--small={size === "sm"}
-  class:bx--table-toolbar--normal={size === "default"}
+  class:bx--table-toolbar--xs={effectiveSize === "xs"}
+  class:bx--table-toolbar--small={effectiveSize === "sm"}
+  class:bx--table-toolbar--normal={effectiveSize === "default"}
   style:z-index={1}
   {...$$restProps}
 >

--- a/tests/DataTable/DataTableToolbarSize.test.svelte
+++ b/tests/DataTable/DataTableToolbarSize.test.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+  import { DataTable, Toolbar, ToolbarContent } from "carbon-components-svelte";
+  import type { ComponentProps } from "svelte";
+
+  export let tableSize: ComponentProps<DataTable>["size"] = undefined;
+  export let toolbarSize: ComponentProps<Toolbar>["size"] = undefined;
+  export let standalone = false;
+</script>
+
+{#if standalone}
+  <Toolbar size={toolbarSize}>
+    <ToolbarContent />
+  </Toolbar>
+{:else}
+  <DataTable
+    size={tableSize}
+    headers={[{ key: "name", value: "Name" }]}
+    rows={[{ id: "a", name: "Row A" }]}
+  >
+    <Toolbar size={toolbarSize}>
+      <ToolbarContent />
+    </Toolbar>
+  </DataTable>
+{/if}

--- a/tests/DataTable/DataTableToolbarSize.test.ts
+++ b/tests/DataTable/DataTableToolbarSize.test.ts
@@ -1,0 +1,60 @@
+import { render } from "@testing-library/svelte";
+import DataTableToolbarSize from "./DataTableToolbarSize.test.svelte";
+
+describe("DataTable Toolbar size inheritance", () => {
+  const toolbar = (container: HTMLElement) =>
+    container.querySelector(".bx--table-toolbar");
+
+  it("inherits the small toolbar from a short DataTable", () => {
+    const { container } = render(DataTableToolbarSize, {
+      props: { tableSize: "short" },
+    });
+
+    expect(toolbar(container)).toHaveClass("bx--table-toolbar--small");
+    expect(toolbar(container)).not.toHaveClass("bx--table-toolbar--normal");
+  });
+
+  it("inherits the extra small toolbar from a compact DataTable", () => {
+    const { container } = render(DataTableToolbarSize, {
+      props: { tableSize: "compact" },
+    });
+
+    expect(toolbar(container)).toHaveClass("bx--table-toolbar--xs");
+    expect(toolbar(container)).not.toHaveClass("bx--table-toolbar--small");
+  });
+
+  it("inherits the default toolbar from medium/tall/unset DataTable sizes", () => {
+    for (const tableSize of [undefined, "medium", "tall"] as const) {
+      const { container } = render(DataTableToolbarSize, {
+        props: { tableSize },
+      });
+
+      expect(toolbar(container)).toHaveClass("bx--table-toolbar--normal");
+      expect(toolbar(container)).not.toHaveClass("bx--table-toolbar--small");
+    }
+  });
+
+  it("lets an explicit toolbar size override the inherited size", () => {
+    const { container } = render(DataTableToolbarSize, {
+      props: { tableSize: "tall", toolbarSize: "sm" },
+    });
+
+    expect(toolbar(container)).toHaveClass("bx--table-toolbar--small");
+
+    const { container: container2 } = render(DataTableToolbarSize, {
+      props: { tableSize: "short", toolbarSize: "default" },
+    });
+
+    expect(toolbar(container2)).toHaveClass("bx--table-toolbar--normal");
+    expect(toolbar(container2)).not.toHaveClass("bx--table-toolbar--small");
+  });
+
+  it("defaults to the normal toolbar when used standalone", () => {
+    const { container } = render(DataTableToolbarSize, {
+      props: { standalone: true },
+    });
+
+    expect(toolbar(container)).toHaveClass("bx--table-toolbar--normal");
+    expect(toolbar(container)).not.toHaveClass("bx--table-toolbar--small");
+  });
+});


### PR DESCRIPTION
For DX, the toolbar should inherit the size of its parent data table. Consumer can still override the size to allow mismatched sizes.

Motivation is to:

- Further simplify usage and encourage same-size usage
- Existing size prop names are poorly mismatched/inconsistent (t-shirt sizing vs. "compact" and "tall"). A future breaking release will standardize these names