### PR TITLE
feat(copy-button, code-snippet): expose ref for copy button

### DIFF
--- a/src/CodeSnippet/CodeSnippet.svelte
+++ b/src/CodeSnippet/CodeSnippet.svelte
@@ -132,6 +132,9 @@
    */
   export let ref = null;
 
+  /** Obtain a reference to the underlying copy button element. */
+  export let copyRef = null;
+
   /**
    * Set to `true` to render the feedback tooltip in a portal,
    * preventing it from being clipped by `overflow: hidden` containers.
@@ -154,9 +157,6 @@
 
   $: effectivePortalTooltip =
     portalTooltip === undefined ? !!insideModal : portalTooltip;
-
-  /** @type {null | HTMLButtonElement} */
-  let inlineButtonRef = null;
 
   const copyFeedback = createCopyFeedbackState(syncCopyFeedback);
 
@@ -202,7 +202,7 @@
   let disconnectModalObserver = () => {};
 
   $: {
-    const el = inlineButtonRef || ref;
+    const el = copyRef || ref;
     disconnectModalObserver();
     disconnectModalObserver =
       effectivePortalTooltip && el
@@ -245,7 +245,7 @@
     </span>
   {:else}
     <button
-      bind:this={inlineButtonRef}
+      bind:this={copyRef}
       type="button"
       aria-live="polite"
       aria-busy={copyPending || undefined}
@@ -295,11 +295,7 @@
     </button>
 
     {#if effectivePortalTooltip}
-      <PortalTooltip
-        anchor={inlineButtonRef}
-        open={feedbackOpen}
-        text={feedback}
-      />
+      <PortalTooltip anchor={copyRef} open={feedbackOpen} text={feedback} />
     {/if}
   {/if}
 {:else}
@@ -335,6 +331,7 @@
     </div>
     {#if !hideCopyButton}
       <CopyButton
+        bind:ref={copyRef}
         text={code}
         {copy}
         {disabled}

--- a/src/CopyButton/CopyButton.svelte
+++ b/src/CopyButton/CopyButton.svelte
@@ -43,6 +43,9 @@
    */
   export let portalTooltip = undefined;
 
+  /** Obtain a reference to the underlying button element. */
+  export let ref = null;
+
   import { createEventDispatcher, getContext, onMount } from "svelte";
   import Copy from "../icons/Copy.svelte";
   import PortalTooltip from "../Portal/PortalTooltip.svelte";
@@ -54,9 +57,6 @@
 
   $: effectivePortalTooltip =
     portalTooltip === undefined ? !!insideModal : portalTooltip;
-
-  /** @type {null | HTMLButtonElement} */
-  let buttonRef = null;
 
   const copyFeedback = createCopyFeedbackState(syncCopyFeedback);
 
@@ -80,8 +80,8 @@
   $: {
     disconnectModalObserver();
     disconnectModalObserver =
-      effectivePortalTooltip && buttonRef
-        ? observeModalClose(buttonRef, dismissFeedback)
+      effectivePortalTooltip && ref
+        ? observeModalClose(ref, dismissFeedback)
         : () => {};
   }
 
@@ -94,7 +94,7 @@
 </script>
 
 <button
-  bind:this={buttonRef}
+  bind:this={ref}
   type="button"
   aria-live="polite"
   aria-busy={copyPending || undefined}
@@ -146,5 +146,5 @@
 </button>
 
 {#if effectivePortalTooltip}
-  <PortalTooltip anchor={buttonRef} open={feedbackOpen} text={feedback} />
+  <PortalTooltip anchor={ref} open={feedbackOpen} text={feedback} />
 {/if}

--- a/tests/CodeSnippet/CodeSnippet.test.ts
+++ b/tests/CodeSnippet/CodeSnippet.test.ts
@@ -6,6 +6,7 @@ import CodeSnippetCopyButton from "./CodeSnippetCopyButton.test.svelte";
 import CodeSnippetCopyButtonMouseEnter from "./CodeSnippetCopyButtonMouseEnter.test.svelte";
 import CodeSnippetCopyButtonMouseLeave from "./CodeSnippetCopyButtonMouseLeave.test.svelte";
 import CodeSnippetCopyError from "./CodeSnippetCopyError.test.svelte";
+import CodeSnippetCopyRef from "./CodeSnippetCopyRef.test.svelte";
 import CodeSnippetCustomEvents from "./CodeSnippetCustomEvents.test.svelte";
 import CodeSnippetDisabled from "./CodeSnippetDisabled.test.svelte";
 import CodeSnippetDoubleClick from "./CodeSnippetDoubleClick.test.svelte";
@@ -523,6 +524,20 @@ yarn -v`,
     expect(snippet).toHaveAttribute("aria-readonly", "true");
     expect(snippet).toHaveAttribute("aria-multiline", "true");
     expect(snippet).not.toHaveAttribute("tabindex");
+  });
+
+  test.each([
+    { type: "inline" as const, expectedClass: "bx--snippet--inline" },
+    { type: "single" as const, expectedClass: "bx--copy-btn" },
+    { type: "multi" as const, expectedClass: "bx--copy-btn" },
+  ])("binds copyRef to the copy button ($type)", ({ type, expectedClass }) => {
+    const { component } = render(CodeSnippetCopyRef, {
+      props: { type },
+    });
+
+    expect(component.copyRef).toBeInstanceOf(HTMLButtonElement);
+    assert(component.copyRef instanceof HTMLButtonElement);
+    expect(component.copyRef).toHaveClass(expectedClass);
   });
 
   // Regression: ?? for aria-label so empty string is used (not fallback)

--- a/tests/CodeSnippet/CodeSnippetCopyRef.test.svelte
+++ b/tests/CodeSnippet/CodeSnippetCopyRef.test.svelte
@@ -1,0 +1,11 @@
+<svelte:options accessors />
+
+<script lang="ts">
+  import { CodeSnippet } from "carbon-components-svelte";
+  import type { ComponentProps } from "svelte";
+
+  export let type: ComponentProps<CodeSnippet>["type"] = "inline";
+  export let copyRef: ComponentProps<CodeSnippet>["copyRef"] = null;
+</script>
+
+<CodeSnippet {type} code="npm install" bind:copyRef />


### PR DESCRIPTION
Allow programmatic control over the copy button by exporting the element reference.