### PR TITLE
fix(code-snippet,copy-button): close portalled tooltip after feedback timeout

### DIFF
--- a/src/CodeSnippet/CodeSnippet.svelte
+++ b/src/CodeSnippet/CodeSnippet.svelte
@@ -265,10 +265,14 @@
       on:click
       on:click={async () => {
         try {
-          await copyFeedback.onClick(async () => {
-            await copy(code);
-            dispatch("copy");
-          }, feedbackTimeout);
+          await copyFeedback.onClick(
+            async () => {
+              await copy(code);
+              dispatch("copy");
+            },
+            feedbackTimeout,
+            effectivePortalTooltip,
+          );
         } catch (error) {
           dispatch("copy:error", { error });
         }

--- a/src/CopyButton/CopyButton.svelte
+++ b/src/CopyButton/CopyButton.svelte
@@ -115,7 +115,7 @@
           await copy(text ?? "");
           dispatch("copy");
         }
-      }, feedbackTimeout);
+      }, feedbackTimeout, effectivePortalTooltip);
     } catch (error) {
       dispatch("copy:error", { error });
     }

--- a/src/utils/copyFeedback.d.ts
+++ b/src/utils/copyFeedback.d.ts
@@ -8,6 +8,7 @@ export type CopyFeedbackState = {
   onClick: (
     performCopy: () => void | Promise<void>,
     feedbackTimeout: number,
+    portalled?: boolean,
   ) => Promise<void>;
   onAnimationEnd: (event: { animationName: string }) => void;
   cleanup: () => void;

--- a/src/utils/copyFeedback.js
+++ b/src/utils/copyFeedback.js
@@ -12,7 +12,7 @@
  *   get feedbackOpen(): boolean,
  *   get copyPending(): boolean,
  *   dismiss: () => void,
- *   onClick: (performCopy: () => void | Promise<void>, feedbackTimeout: number) => Promise<void>,
+ *   onClick: (performCopy: () => void | Promise<void>, feedbackTimeout: number, portalled?: boolean) => Promise<void>,
  *   onAnimationEnd: (event: { animationName: string }) => void,
  *   cleanup: () => void,
  * }}
@@ -52,9 +52,13 @@ export function createCopyFeedbackState(onSync) {
   /**
    * @param {() => void | Promise<void>} performCopy
    * @param {number} feedbackTimeout
+   * @param {boolean} [portalled] - When `true`, close feedback directly on
+   *   timeout instead of awaiting the `hide-feedback` animation. The portalled
+   *   tooltip hides the feedback element, so that animation (and its
+   *   `animationend`) never fires and the tooltip would otherwise stay open.
    * @returns {Promise<void>}
    */
-  async function onClick(performCopy, feedbackTimeout) {
+  async function onClick(performCopy, feedbackTimeout, portalled = false) {
     if (copyActive || animation === "fade-in") return;
 
     copyActive = true;
@@ -75,7 +79,13 @@ export function createCopyFeedbackState(onSync) {
     feedbackOpen = true;
     clearTimeout(timeout);
     timeout = setTimeout(() => {
-      animation = "fade-out";
+      if (portalled) {
+        feedbackOpen = false;
+        animation = undefined;
+        copyActive = false;
+      } else {
+        animation = "fade-out";
+      }
       notify();
     }, feedbackTimeout);
     notify();

--- a/tests/CodeSnippet/CodeSnippetPortalTooltip.test.ts
+++ b/tests/CodeSnippet/CodeSnippetPortalTooltip.test.ts
@@ -1,6 +1,7 @@
-import { render, screen } from "@testing-library/svelte";
+import { fireEvent, render, screen } from "@testing-library/svelte";
 import { user } from "../utils/user";
 import CodeSnippetInlineInModal from "./CodeSnippetInlineInModal.test.svelte";
+import CodeSnippetPortalTooltipTimeout from "./CodeSnippetPortalTooltipTimeout.test.svelte";
 
 describe("CodeSnippet portal tooltip", () => {
   beforeEach(() => {
@@ -45,6 +46,43 @@ describe("CodeSnippet portal tooltip", () => {
       expect(
         button.querySelector(".bx--copy-btn__feedback"),
       ).toBeInTheDocument();
+    });
+
+    describe("feedback timeout", () => {
+      beforeEach(() => {
+        vi.useFakeTimers();
+      });
+
+      afterEach(() => {
+        vi.useRealTimers();
+      });
+
+      // Regression: portalled feedback hides the inline element, so the
+      // hide-feedback animation (and animationend) never runs; feedbackTimeout
+      // must close the portal directly or the tooltip stays open.
+      it("should dismiss portal feedback after feedbackTimeout", async () => {
+        render(CodeSnippetPortalTooltipTimeout);
+
+        const button = screen.getByRole("button", { name: "Copy code" });
+        await fireEvent.click(button);
+        await Promise.resolve();
+
+        expect(
+          document.querySelector("[data-floating-portal]"),
+        ).toBeInTheDocument();
+
+        await vi.advanceTimersByTimeAsync(100);
+
+        expect(
+          document.querySelector("[data-floating-portal]"),
+        ).not.toBeInTheDocument();
+
+        await fireEvent.click(button);
+        await Promise.resolve();
+        expect(
+          document.querySelector("[data-floating-portal]"),
+        ).toBeInTheDocument();
+      });
     });
 
     // Regression: observer must re-attach when portalTooltip flips after mount.

--- a/tests/CodeSnippet/CodeSnippetPortalTooltipTimeout.test.svelte
+++ b/tests/CodeSnippet/CodeSnippetPortalTooltipTimeout.test.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  import { CodeSnippet } from "carbon-components-svelte";
+  import type { ComponentProps } from "svelte";
+
+  export let portalTooltip: ComponentProps<CodeSnippet>["portalTooltip"] = true;
+  export let feedbackTimeout = 100;
+</script>
+
+<CodeSnippet
+  type="inline"
+  code="npm install"
+  copyLabel="Copy code"
+  {portalTooltip}
+  {feedbackTimeout}
+/>

--- a/tests/CopyButton/CopyButton.test.ts
+++ b/tests/CopyButton/CopyButton.test.ts
@@ -6,6 +6,7 @@ import CopyButtonAsyncDoubleClick from "./CopyButtonAsyncDoubleClick.test.svelte
 import CopyButtonDoubleClick from "./CopyButtonDoubleClick.test.svelte";
 import CopyButtonInModal from "./CopyButtonInModal.test.svelte";
 import CopyButtonMouseEnter from "./CopyButtonMouseEnter.test.svelte";
+import CopyButtonPortalTooltipTimeout from "./CopyButtonPortalTooltipTimeout.test.svelte";
 
 describe("CopyButton", () => {
   const getCopyButton = (label: string) =>
@@ -276,6 +277,43 @@ describe("CopyButton", () => {
       expect(
         button.querySelector(".bx--copy-btn__feedback"),
       ).toBeInTheDocument();
+    });
+
+    describe("feedback timeout", () => {
+      beforeEach(() => {
+        vi.useFakeTimers();
+      });
+
+      afterEach(() => {
+        vi.useRealTimers();
+      });
+
+      // Regression: portalled feedback hides the inline element, so the
+      // hide-feedback animation (and animationend) never runs; feedbackTimeout
+      // must close the portal directly or the tooltip stays open.
+      it("should dismiss portal feedback after feedbackTimeout", async () => {
+        render(CopyButtonPortalTooltipTimeout);
+
+        const button = getCopyButton("Copy");
+        await fireEvent.click(button);
+        await Promise.resolve();
+
+        expect(
+          document.querySelector("[data-floating-portal]"),
+        ).toBeInTheDocument();
+
+        await vi.advanceTimersByTimeAsync(100);
+
+        expect(
+          document.querySelector("[data-floating-portal]"),
+        ).not.toBeInTheDocument();
+
+        await fireEvent.click(button);
+        await Promise.resolve();
+        expect(
+          document.querySelector("[data-floating-portal]"),
+        ).toBeInTheDocument();
+      });
     });
 
     // Regression: observer must re-attach when portalTooltip flips after mount.

--- a/tests/CopyButton/CopyButtonPortalTooltipTimeout.test.svelte
+++ b/tests/CopyButton/CopyButtonPortalTooltipTimeout.test.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+  import { CopyButton } from "carbon-components-svelte";
+  import type { ComponentProps } from "svelte";
+
+  export let portalTooltip: ComponentProps<CopyButton>["portalTooltip"] = true;
+  export let feedbackTimeout = 100;
+</script>
+
+<CopyButton
+  text="text"
+  iconDescription="Copy"
+  {portalTooltip}
+  {feedbackTimeout}
+/>

--- a/tests/utils/copyFeedback.test.ts
+++ b/tests/utils/copyFeedback.test.ts
@@ -41,6 +41,25 @@ describe("createCopyFeedbackState", () => {
     expect(state.animation).toBe("fade-out");
   });
 
+  test("portalled closes feedback directly after feedbackTimeout", async () => {
+    const state = createCopyFeedbackState();
+    const performCopy = vi.fn();
+
+    await state.onClick(performCopy, 100, true);
+    expect(state.feedbackOpen).toBe(true);
+
+    vi.advanceTimersByTime(100);
+
+    // No hide-feedback animationend fires when portalled, so the timeout must
+    // close the tooltip itself.
+    expect(state.feedbackOpen).toBe(false);
+    expect(state.animation).toBeUndefined();
+
+    // copyActive is also cleared, so a subsequent copy works.
+    await state.onClick(performCopy, 100, true);
+    expect(performCopy).toHaveBeenCalledTimes(2);
+  });
+
   test("resets on hide-feedback animation end", async () => {
     const state = createCopyFeedbackState();
     const performCopy = vi.fn();


### PR DESCRIPTION
The portalled feedback tooltip is shown/hidden purely by the `feedbackOpen` flag (`<PortalTooltip open={feedbackOpen} … />`). After `feedbackTimeout`, `createCopyFeedbackState`'s timer only set `animation = "fade-out"` and depended on the CSS `hide-feedback` animation to emit an `animationend` event, which `onAnimationEnd` uses to set `feedbackOpen = false`.

This fixes it so the portalled tooltip use case is not dependent on the `animationend` event.