### PR TITLE
refactor: migrate `afterUpdate` to reactive statements

### DIFF
--- a/src/ComposedModal/ComposedModal.svelte
+++ b/src/ComposedModal/ComposedModal.svelte
@@ -39,13 +39,7 @@
    */
   export let ref = null;
 
-  import {
-    afterUpdate,
-    createEventDispatcher,
-    onMount,
-    setContext,
-    tick,
-  } from "svelte";
+  import { createEventDispatcher, onMount, setContext, tick } from "svelte";
   import { writable } from "svelte/store";
   import { trackModal } from "../Modal/modalStore";
   import { initialFocus, restoreFocus } from "../utils/focus.js";
@@ -139,7 +133,7 @@
     });
   });
 
-  afterUpdate(() => {
+  $: {
     if (opened) {
       if (!open) {
         opened = false;
@@ -152,7 +146,7 @@
       opened = true;
       dispatch("open");
     }
-  });
+  }
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->

--- a/src/FileUploader/FileUploader.svelte
+++ b/src/FileUploader/FileUploader.svelte
@@ -131,7 +131,7 @@
    */
   export let ref = null;
 
-  import { afterUpdate, createEventDispatcher } from "svelte";
+  import { createEventDispatcher } from "svelte";
   import Filename from "./Filename.svelte";
   import FileUploaderButton from "./FileUploaderButton.svelte";
 
@@ -170,22 +170,24 @@
   /** Stable keys for `{#each}` (and Biome-safe: no commas in the each header). */
   $: filesWithKeys = keyFiles(files);
 
-  afterUpdate(() => {
+  $: {
     const prevSet = new Set(prevFiles);
     const currentSet = new Set(files);
     const added = files.filter((f) => !prevSet.has(f));
     const removed = prevFiles.filter((f) => !currentSet.has(f));
 
-    if (added.length > 0) dispatch("add", added);
-    if (removed.length > 0) dispatch("remove", removed);
+    if (added.length > 0 || removed.length > 0) {
+      if (added.length > 0) dispatch("add", added);
+      if (removed.length > 0) dispatch("remove", removed);
 
-    if (prevFiles.length > 0 && files.length === 0) {
-      dispatch("change", []);
-      dispatch("clear");
+      if (prevFiles.length > 0 && files.length === 0) {
+        dispatch("change", []);
+        dispatch("clear");
+      }
+
+      prevFiles = [...files];
     }
-
-    prevFiles = [...files];
-  });
+  }
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->

--- a/src/InlineLoading/InlineLoading.svelte
+++ b/src/InlineLoading/InlineLoading.svelte
@@ -21,7 +21,7 @@
   /** Specify the timeout delay (ms) after `status` is set to "success" */
   export let successDelay = 1500;
 
-  import { afterUpdate, createEventDispatcher, onMount } from "svelte";
+  import { createEventDispatcher, onMount } from "svelte";
   import CheckmarkFilled from "../icons/CheckmarkFilled.svelte";
   import ErrorFilled from "../icons/ErrorFilled.svelte";
   import Loading from "../Loading/Loading.svelte";
@@ -36,14 +36,12 @@
     };
   });
 
-  afterUpdate(() => {
-    if (status === "finished") {
-      clearTimeout(timeout);
-      timeout = setTimeout(() => {
-        dispatch("success");
-      }, successDelay);
-    }
-  });
+  $: if (status === "finished") {
+    clearTimeout(timeout);
+    timeout = setTimeout(() => {
+      dispatch("success");
+    }, successDelay);
+  }
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->

--- a/src/LocalStorage/LocalStorage.svelte
+++ b/src/LocalStorage/LocalStorage.svelte
@@ -52,7 +52,7 @@
     storage.clear();
   }
 
-  import { afterUpdate, createEventDispatcher, onMount } from "svelte";
+  import { createEventDispatcher, onMount } from "svelte";
   import {
     parseStoredValue,
     safeBrowserStorage,
@@ -129,7 +129,7 @@
     prevSerialized = serializeStoredValue(value);
   }
 
-  afterUpdate(() => {
+  $: if (mounted) {
     const serialized = serializeStoredValue(value);
 
     if (serialized !== prevSerialized) {
@@ -138,5 +138,5 @@
       dispatch("update", { prevValue, value });
       prevSerialized = serialized;
     }
-  });
+  }
 </script>

--- a/src/RadioButtonGroup/RadioButtonGroup.svelte
+++ b/src/RadioButtonGroup/RadioButtonGroup.svelte
@@ -68,12 +68,7 @@
    */
   export let id = undefined;
 
-  import {
-    afterUpdate,
-    createEventDispatcher,
-    onMount,
-    setContext,
-  } from "svelte";
+  import { createEventDispatcher, onMount, setContext } from "svelte";
   import { readonly as readOnly, writable } from "svelte/store";
 
   const dispatch = createEventDispatcher();
@@ -128,11 +123,8 @@
 
   onMount(() => {
     $selectedValue = selected;
-    return unsubscribe;
-  });
-
-  afterUpdate(() => {
     isInitialRender = false;
+    return unsubscribe;
   });
 
   $: $groupName = name;

--- a/src/SessionStorage/SessionStorage.svelte
+++ b/src/SessionStorage/SessionStorage.svelte
@@ -52,7 +52,7 @@
     storage.clear();
   }
 
-  import { afterUpdate, createEventDispatcher, onMount } from "svelte";
+  import { createEventDispatcher, onMount } from "svelte";
   import {
     parseStoredValue,
     safeBrowserStorage,
@@ -129,7 +129,7 @@
     prevSerialized = serializeStoredValue(value);
   }
 
-  afterUpdate(() => {
+  $: if (mounted) {
     const serialized = serializeStoredValue(value);
 
     if (serialized !== prevSerialized) {
@@ -138,5 +138,5 @@
       dispatch("update", { prevValue, value });
       prevSerialized = serialized;
     }
-  });
+  }
 </script>

--- a/src/Theme/Theme.svelte
+++ b/src/Theme/Theme.svelte
@@ -88,7 +88,7 @@
     hideLabel: false,
   };
 
-  import { afterUpdate, createEventDispatcher } from "svelte";
+  import { createEventDispatcher, onMount } from "svelte";
   import Dropdown from "../Dropdown/Dropdown.svelte";
   import LocalStorage from "../LocalStorage/LocalStorage.svelte";
   import Select from "../Select/Select.svelte";
@@ -98,17 +98,17 @@
   const dispatch = createEventDispatcher();
 
   let prevTheme = theme;
-  let isInitialRender = true;
+  let mounted = false;
 
-  afterUpdate(() => {
-    if (prevTheme !== theme) {
-      prevTheme = theme;
-      if (!isInitialRender) {
-        dispatch("update", { theme });
-      }
-    }
-    isInitialRender = false;
+  onMount(() => {
+    prevTheme = theme;
+    mounted = true;
   });
+
+  $: if (mounted && theme !== prevTheme) {
+    prevTheme = theme;
+    dispatch("update", { theme });
+  }
 
   $: if (typeof window !== "undefined") {
     for (const [token, value] of Object.entries(tokens)) {

--- a/src/TreeView/TreeViewNode.svelte
+++ b/src/TreeView/TreeViewNode.svelte
@@ -86,7 +86,7 @@
    */
   export let icon = /** @type {Icon} */ (undefined);
 
-  import { afterUpdate, getContext } from "svelte";
+  import { getContext } from "svelte";
 
   let ref = null;
   let refLabel = null;
@@ -103,17 +103,6 @@
     return computeTreeLeafDepth(refLabel) - 1 + (leaf && icon ? 2 : 2.5);
   }
 
-  afterUpdate(() => {
-    if (
-      id === $activeNodeId &&
-      prevActiveId !== $activeNodeId &&
-      !$selectedIdsSetStore.has(id)
-    )
-      selectNode(node);
-
-    prevActiveId = $activeNodeId;
-  });
-
   $: selected = $selectedIdsSetStore.has(id);
   // Merge all props (including custom properties) with computed properties
   // Explicitly include disabled to ensure it's always present (has default value)
@@ -124,6 +113,16 @@
     leaf,
     selected,
   };
+  $: {
+    if (
+      id === $activeNodeId &&
+      prevActiveId !== $activeNodeId &&
+      !$selectedIdsSetStore.has(id)
+    )
+      selectNode(node);
+
+    prevActiveId = $activeNodeId;
+  }
   $: if (refLabel) {
     refLabel.style.marginLeft = `-${offset()}rem`;
     refLabel.style.paddingLeft = `${offset()}rem`;

--- a/src/TreeView/TreeViewNodeList.svelte
+++ b/src/TreeView/TreeViewNodeList.svelte
@@ -20,7 +20,7 @@
    */
   export let icon = /** @type {Icon} */ (undefined);
 
-  import { afterUpdate, getContext } from "svelte";
+  import { getContext } from "svelte";
   import CaretDown from "../icons/CaretDown.svelte";
   import TreeViewNode, {
     computeTreeLeafDepth,
@@ -63,17 +63,6 @@
     return depth + 2.5;
   }
 
-  afterUpdate(() => {
-    if (
-      id === $activeNodeId &&
-      prevActiveId !== $activeNodeId &&
-      !$selectedIdsSetStore.has(id)
-    )
-      selectNode(node);
-
-    prevActiveId = $activeNodeId;
-  });
-
   $: parent = Array.isArray(nodes);
   $: expanded = $expandedIdsSetStore.has(id);
   $: selected = $selectedIdsSetStore.has(id);
@@ -87,6 +76,16 @@
     leaf: !parent,
     selected,
   };
+  $: {
+    if (
+      id === $activeNodeId &&
+      prevActiveId !== $activeNodeId &&
+      !$selectedIdsSetStore.has(id)
+    )
+      selectNode(node);
+
+    prevActiveId = $activeNodeId;
+  }
   $: if (refLabel) {
     refLabel.style.marginLeft = `-${offset()}rem`;
     refLabel.style.paddingLeft = `${offset()}rem`;


### PR DESCRIPTION
- afterUpdate is deprecated
- Main goal, however, is to avoid re-updating (e.g., calling functions, allocations) on any reactive update within a component. Only re-fire based on dependencies

The first commit adds additional (non-dupe) baseline test coverage to guard against regressions.