### PR TITLE
fix(multi-select): scope checkbox ids per instance

### DIFF
--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -871,7 +871,7 @@
                 <ListBoxMenuItem
                   id={item.id}
                   role="option"
-                  aria-labelledby="checkbox-{item.id}"
+                  aria-labelledby="checkbox-{id}-{item.id}"
                   aria-selected={item.isSelectAll ? allSelected : item.checked}
                   aria-checked={item.isSelectAll
                     ? selectAllIndeterminate
@@ -903,7 +903,7 @@
                     title={useTitleInItem ? itemToString(item) : undefined}
                     {...itemToInput(item)}
                     tabindex="-1"
-                    id="checkbox-{item.id}"
+                    id="checkbox-{id}-{item.id}"
                     checked={item.isSelectAll ? allSelected : item.checked}
                     indeterminate={item.isSelectAll
                       ? selectAllIndeterminate
@@ -923,7 +923,7 @@
             <ListBoxMenuItem
               id={item.id}
               role="option"
-              aria-labelledby="checkbox-{item.id}"
+              aria-labelledby="checkbox-{id}-{item.id}"
               aria-selected={item.isSelectAll ? allSelected : item.checked}
               aria-checked={item.isSelectAll
                 ? selectAllIndeterminate
@@ -955,7 +955,7 @@
                 title={useTitleInItem ? itemToString(item) : undefined}
                 {...itemToInput(item)}
                 tabindex="-1"
-                id="checkbox-{item.id}"
+                id="checkbox-{id}-{item.id}"
                 checked={item.isSelectAll ? allSelected : item.checked}
                 indeterminate={item.isSelectAll
                   ? selectAllIndeterminate

--- a/tests/MultiSelect/MultiSelect.test.ts
+++ b/tests/MultiSelect/MultiSelect.test.ts
@@ -7,6 +7,7 @@ import { user } from "../utils/user";
 import MultiSelectLabelSlot from "./MultiSelect.slot.test.svelte";
 import MultiSelect from "./MultiSelect.test.svelte";
 import MultiSelectBindValue from "./MultiSelectBindValue.test.svelte";
+import MultiSelectDuplicateIds from "./MultiSelectDuplicateIds.test.svelte";
 import MultiSelectGenerics from "./MultiSelectGenerics.test.svelte";
 import MultiSelectInModal from "./MultiSelectInModal.test.svelte";
 import MultiSelectItemToStringId from "./MultiSelectItemToStringId.test.svelte";
@@ -2577,5 +2578,40 @@ describe("MultiSelect", () => {
         container.querySelectorAll(".bx--tag--filter").length,
       ).toBeGreaterThan(0);
     });
+  });
+
+  // Regression: checkbox ids are scoped by the MultiSelect `id` so that two
+  // instances sharing the same item ids do not emit duplicate DOM ids (which
+  // would make a label click on one instance toggle the other instance's input).
+  it("scopes checkbox ids per instance to avoid clashes between instances", () => {
+    const { container } = render(MultiSelectDuplicateIds);
+
+    const checkboxes = Array.from(
+      container.querySelectorAll<HTMLInputElement>('input[id^="checkbox-"]'),
+    );
+    const ids = checkboxes.map((checkbox) => checkbox.id);
+
+    // Two instances of 3 items each.
+    expect(ids).toHaveLength(6);
+    // Every id is unique across instances.
+    expect(new Set(ids).size).toBe(ids.length);
+    // Ids are scoped by the instance `id` prop.
+    expect(ids).toEqual(
+      expect.arrayContaining([
+        "checkbox-first-0",
+        "checkbox-first-1",
+        "checkbox-first-2",
+        "checkbox-second-0",
+        "checkbox-second-1",
+        "checkbox-second-2",
+      ]),
+    );
+
+    // Each option's aria-labelledby resolves to the checkbox within the same instance.
+    for (const option of container.querySelectorAll('[role="option"]')) {
+      const labelledby = option.getAttribute("aria-labelledby");
+      assert(labelledby);
+      expect(container.querySelector(`#${labelledby}`)).not.toBeNull();
+    }
   });
 });

--- a/tests/MultiSelect/MultiSelectDuplicateIds.test.svelte
+++ b/tests/MultiSelect/MultiSelectDuplicateIds.test.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+  import { MultiSelect } from "carbon-components-svelte";
+
+  const items = [
+    { id: "0", text: "Slack" },
+    { id: "1", text: "Email" },
+    { id: "2", text: "Fax" },
+  ];
+</script>
+
+<MultiSelect id="first" labelText="First" {items} open />
+<MultiSelect id="second" labelText="Second" {items} open />


### PR DESCRIPTION
List items must have an ID scoped to its multi-select instance. Otherwise, it risks clashing with other instances on the page.