### PR TITLE
fix(multi-select): scope option ids per instance

### DIFF
--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -553,6 +553,8 @@
       ? ((filterable ? filteredItems : sortedItems)[highlightedIndex]?.id ??
         null)
       : null;
+  $: activeDescendantId =
+    highlightedId == null ? null : `${id}-${highlightedId}`;
 
   $: shouldVirtualize =
     virtualize === false
@@ -676,7 +678,7 @@
           aria-autocomplete="list"
           aria-haspopup="listbox"
           aria-expanded={open}
-          aria-activedescendant={highlightedId}
+          aria-activedescendant={activeDescendantId}
           aria-disabled={disabled || readonly}
           aria-readonly={readonly || undefined}
           aria-controls={open ? menuId : undefined}
@@ -771,7 +773,7 @@
         role="combobox"
         tabindex="0"
         aria-expanded={open}
-        aria-activedescendant={highlightedId}
+        aria-activedescendant={activeDescendantId}
         aria-controls={open ? menuId : undefined}
         aria-owns={open ? menuId : undefined}
         on:click={() => {
@@ -869,7 +871,7 @@
               {#each itemsToRender as item, index (item.id)}
                 {@const actualIndex = virtualData.startIndex + index}
                 <ListBoxMenuItem
-                  id={item.id}
+                  id={`${id}-${item.id}`}
                   role="option"
                   aria-labelledby="checkbox-{id}-{item.id}"
                   aria-selected={item.isSelectAll ? allSelected : item.checked}
@@ -921,7 +923,7 @@
         {:else}
           {#each itemsToRender as item, index (item.id)}
             <ListBoxMenuItem
-              id={item.id}
+              id={`${id}-${item.id}`}
               role="option"
               aria-labelledby="checkbox-{id}-{item.id}"
               aria-selected={item.isSelectAll ? allSelected : item.checked}

--- a/tests/MultiSelect/MultiSelect.test.ts
+++ b/tests/MultiSelect/MultiSelect.test.ts
@@ -2613,5 +2613,57 @@ describe("MultiSelect", () => {
       assert(labelledby);
       expect(container.querySelector(`#${labelledby}`)).not.toBeNull();
     }
+
+    // Every option id is globally unique and prefixed by its instance id,
+    // even though both instances share the same raw item ids.
+    const optionIds = Array.from(
+      container.querySelectorAll('[role="option"]'),
+    ).map((option) => option.id);
+    expect(optionIds).toHaveLength(6);
+    expect(new Set(optionIds).size).toBe(optionIds.length);
+    expect(optionIds).toEqual(
+      expect.arrayContaining([
+        "first-0",
+        "first-1",
+        "first-2",
+        "second-0",
+        "second-1",
+        "second-2",
+      ]),
+    );
+  });
+
+  it("scopes aria-activedescendant to options within the same instance", async () => {
+    const { container } = render(MultiSelectDuplicateIds);
+
+    const comboboxes = Array.from(
+      container.querySelectorAll<HTMLElement>('[role="combobox"]'),
+    );
+    expect(comboboxes).toHaveLength(2);
+
+    // Highlight the first item of an instance and verify the active descendant
+    // resolves to an option belonging to that same instance.
+    const expectScopedActiveDescendant = async (
+      combobox: HTMLElement,
+      prefix: string,
+    ) => {
+      combobox.focus();
+      await user.keyboard("{ArrowDown}");
+
+      const activeDescendant = combobox.getAttribute("aria-activedescendant");
+      assert(activeDescendant);
+      expect(activeDescendant.startsWith(`${prefix}-`)).toBe(true);
+
+      const active = container.querySelector(`#${activeDescendant}`);
+      expect(active).not.toBeNull();
+      expect(active?.getAttribute("role")).toBe("option");
+      // The resolved option lives inside the same instance's list box.
+      expect(combobox.closest(".bx--list-box")).toBe(
+        active?.closest(".bx--list-box"),
+      );
+    };
+
+    await expectScopedActiveDescendant(comboboxes[0], "first");
+    await expectScopedActiveDescendant(comboboxes[1], "second");
   });
 });


### PR DESCRIPTION
Similar to https://github.com/carbon-design-system/carbon-components-svelte/pull/3175, https://github.com/carbon-design-system/carbon-components-svelte/pull/3176, https://github.com/carbon-design-system/carbon-components-svelte/pull/3177, 

Two `MultiSelect` instances with overlapping item ids rendered duplicate `role="option"` ids, making `aria-activedescendant` ambiguous across instances. Prefix the option DOM id with the instance `id` and resolve `aria-activedescendant` against it, keeping the bindable `highlightedId` raw to preserve its API.