### PR TITLE
docs: portal inline code tooltips

### DIFF
--- a/docs/src/components/ComponentApi.svelte
+++ b/docs/src/components/ComponentApi.svelte
@@ -151,7 +151,7 @@
         }) as prop (prop.name)}
           <StructuredListRow>
             <StructuredListCell noWrap>
-              <InlineSnippet code={prop.name} />
+              <InlineSnippet code={prop.name} portalTooltip />
               {#if prop.reactive}
                 <div
                   style="white-space: nowrap; margin-top: var(--cds-spacing-03); margin-bottom: var(--cds-spacing-{prop.isRequired
@@ -188,6 +188,7 @@
                         this={AsyncPreviewTypeScript}
                         type="inline"
                         code={typeMap[type] ?? type}
+                        portalTooltip
                       />
                     </div>
                   {:else}
@@ -198,6 +199,7 @@
                         this={AsyncPreviewTypeScript}
                         type="inline"
                         code={type}
+                        portalTooltip
                       />
                     </div>
                   {/if}
@@ -235,6 +237,7 @@
                       this={AsyncPreviewTypeScript}
                       type="multi"
                       code={parsed.exampleCode}
+                      portalTooltip
                     />
                   </div>
                 {/if}
@@ -256,6 +259,7 @@
                     this={AsyncPreviewTypeScript}
                     type={/\n/.test(prop.value ?? "") ? "multi" : "inline"}
                     code={prop.value ?? ""}
+                    portalTooltip
                   />
                 {/if}
               </div>
@@ -302,6 +306,7 @@
               this={AsyncPreviewTypeScript}
               type={/\n/.test(slot.slot_props ?? "") ? "multi" : "inline"}
               code={slot.slot_props ?? ""}
+              portalTooltip
             />
           </StructuredListCell>
         </StructuredListRow>
@@ -348,6 +353,7 @@
               this={AsyncPreviewTypeScript}
               type={/\n/.test(dispatched_event.detail ?? "") ? "multi" : "inline"}
               code={dispatched_event.detail ?? ""}
+              portalTooltip
             />
           </StructuredListCell>
           <StructuredListCell>

--- a/docs/src/components/InlineSnippet.svelte
+++ b/docs/src/components/InlineSnippet.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
   export let code = "";
+  export let portalTooltip: boolean | undefined = undefined;
 
   import { CodeSnippet } from "carbon-components-svelte";
   import copy from "clipboard-copy";
 </script>
 
-<CodeSnippet {code} type="inline" {copy} />
+<CodeSnippet {code} type="inline" {copy} {portalTooltip} />

--- a/docs/src/components/PreviewTypeScript.svelte
+++ b/docs/src/components/PreviewTypeScript.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   export let code = "";
   export let type = "multi";
+  export let portalTooltip: boolean | undefined = undefined;
 
   import { CodeSnippet } from "carbon-components-svelte";
   import Prism, { highlight } from "prismjs";
@@ -16,14 +17,20 @@
 
 {#if type === "multi"}
   <div class="code-override">
-    <CodeSnippet type="multi" {code} {copy}>
+    <CodeSnippet type="multi" {code} {copy} {portalTooltip}>
       {@html highlightedCode}
     </CodeSnippet>
   </div>
 {/if}
 
 {#if type === "inline"}
-  <CodeSnippet type="inline" class="code-override-inline" {code} {copy}>
+  <CodeSnippet
+    type="inline"
+    class="code-override-inline"
+    {code}
+    {copy}
+    {portalTooltip}
+  >
     {@html highlightedCode}
   </CodeSnippet>
 {/if}

--- a/docs/src/layouts/ComponentLayout.svelte
+++ b/docs/src/layouts/ComponentLayout.svelte
@@ -66,9 +66,9 @@
   }
 
   function formatCopyIconDescription(copied: boolean, bytes: number): string {
-    if (copied) return "Copied!";
-    if (bytes <= 0) return "Copy Markdown";
-    return `Copy Markdown\n${formatFileSize(bytes)} (${formatTokenEstimate(bytes)})`;
+    const label = copied ? "Copied!" : "Copy Markdown";
+    if (bytes <= 0) return label;
+    return `${label}\n${formatFileSize(bytes)} (${formatTokenEstimate(bytes)})`;
   }
 
   const REPO_URL = __PKG_REPO;


### PR DESCRIPTION
Portal the inline snippets used in component docs. Also, refine the Copy Markdown feedback text to retain the metadata.