### PR TITLE
refactor(modal, composed-modal): apply `createOutsideDismiss` util

### DIFF
--- a/src/ComposedModal/ComposedModal.svelte
+++ b/src/ComposedModal/ComposedModal.svelte
@@ -49,6 +49,7 @@
   import { writable } from "svelte/store";
   import { trackModal } from "../Modal/modalStore";
   import { initialFocus, restoreFocus } from "../utils/focus.js";
+  import { createOutsideDismiss } from "../utils/outsideDismiss.js";
   import { trapFocus } from "../utils/trapFocus.js";
 
   const dispatch = createEventDispatcher();
@@ -57,7 +58,6 @@
 
   let buttonRef = null;
   let innerModal = null;
-  let didClickInnerModal = false;
   let closeDispatched = false;
 
   function close(trigger) {
@@ -69,6 +69,10 @@
       closeDispatched = false;
     }
   }
+
+  const outsideDismiss = createOutsideDismiss(() => {
+    if (!preventCloseOnClickOutside) close("outside-click");
+  });
 
   /**
    * @type {() => void}
@@ -171,12 +175,7 @@
     }
   }}
   on:click
-  on:mouseup={() => {
-    if (!didClickInnerModal && !preventCloseOnClickOutside) {
-      close("outside-click");
-    }
-    didClickInnerModal = false;
-  }}
+  on:mouseup={outsideDismiss.release}
   on:mouseover
   on:mouseenter
   on:mouseleave
@@ -206,9 +205,7 @@
     class:bx--modal-container--sm={size === "sm"}
     class:bx--modal-container--lg={size === "lg"}
     class={containerClass}
-    on:mousedown={() => {
-      didClickInnerModal = true;
-    }}
+    on:mousedown={outsideDismiss.pressInside}
   >
     <slot />
   </div>

--- a/src/Modal/Modal.svelte
+++ b/src/Modal/Modal.svelte
@@ -115,6 +115,7 @@
   import Button from "../Button/Button.svelte";
   import Close from "../icons/Close.svelte";
   import { initialFocus, restoreFocus } from "../utils/focus.js";
+  import { createOutsideDismiss } from "../utils/outsideDismiss.js";
   import { trapFocus } from "../utils/trapFocus.js";
   import { trackModal } from "./modalStore";
 
@@ -125,7 +126,6 @@
   let primaryButtonRef = null;
   let innerModal = null;
   let opened = false;
-  let didClickInnerModal = false;
   let closeDispatched = false;
 
   function focus(element) {
@@ -151,6 +151,10 @@
       closeDispatched = false;
     }
   }
+
+  const outsideDismiss = createOutsideDismiss(() => {
+    if (!preventCloseOnClickOutside) close("outside-click");
+  });
 
   const openStore = writable(open);
   $: $openStore = open;
@@ -220,12 +224,7 @@
     }
   }}
   on:click
-  on:mouseup={() => {
-    if (!didClickInnerModal && !preventCloseOnClickOutside) {
-      close("outside-click");
-    }
-    didClickInnerModal = false;
-  }}
+  on:mouseup={outsideDismiss.release}
   on:mouseover
   on:mouseenter
   on:mouseleave
@@ -247,9 +246,7 @@
     class:bx--modal-container--xs={size === "xs"}
     class:bx--modal-container--sm={size === "sm"}
     class:bx--modal-container--lg={size === "lg"}
-    on:mousedown={() => {
-      didClickInnerModal = true;
-    }}
+    on:mousedown={outsideDismiss.pressInside}
   >
     <div class:bx--modal-header={true}>
       {#if passiveModal}

--- a/src/utils/outsideDismiss.d.ts
+++ b/src/utils/outsideDismiss.d.ts
@@ -1,0 +1,6 @@
+export type OutsideDismiss = {
+  pressInside: () => void;
+  release: () => void;
+};
+
+export function createOutsideDismiss(onDismiss: () => void): OutsideDismiss;

--- a/src/utils/outsideDismiss.js
+++ b/src/utils/outsideDismiss.js
@@ -1,0 +1,28 @@
+// @ts-check
+
+/**
+ * Drag-aware outside-click dismissal for dialog surfaces (Modal, ComposedModal).
+ *
+ * A plain `click` handler on the backdrop dismisses the dialog even when a text
+ * selection that *began inside* the dialog is released outside it. To avoid that,
+ * track whether the pointer was pressed inside the dialog on `mousedown` and only
+ * dismiss on `mouseup` when it was not.
+ *
+ * @param {() => void} onDismiss Called on a press-and-release that began outside the dialog.
+ * @returns {{ pressInside: () => void, release: () => void }}
+ */
+export function createOutsideDismiss(onDismiss) {
+  let pressedInside = false;
+
+  return {
+    /** Wire to the dialog container's `on:mousedown`. */
+    pressInside() {
+      pressedInside = true;
+    },
+    /** Wire to the surface's `on:mouseup`; dismisses only if the press began outside. */
+    release() {
+      if (!pressedInside) onDismiss();
+      pressedInside = false;
+    },
+  };
+}

--- a/tests/utils/outsideDismiss.test.ts
+++ b/tests/utils/outsideDismiss.test.ts
@@ -1,0 +1,46 @@
+import { createOutsideDismiss } from "../../src/utils/outsideDismiss.js";
+
+describe("createOutsideDismiss", () => {
+  test("does not dismiss when the press began inside", () => {
+    const onDismiss = vi.fn();
+    const dismiss = createOutsideDismiss(onDismiss);
+
+    dismiss.pressInside();
+    dismiss.release();
+
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  test("dismisses when there was no inside press", () => {
+    const onDismiss = vi.fn();
+    const dismiss = createOutsideDismiss(onDismiss);
+
+    dismiss.release();
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  test("resets the flag after release", () => {
+    const onDismiss = vi.fn();
+    const dismiss = createOutsideDismiss(onDismiss);
+
+    dismiss.pressInside();
+    dismiss.release();
+    expect(onDismiss).not.toHaveBeenCalled();
+
+    dismiss.release();
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  test("suppresses dismissal for each independent inside interaction", () => {
+    const onDismiss = vi.fn();
+    const dismiss = createOutsideDismiss(onDismiss);
+
+    dismiss.pressInside();
+    dismiss.release();
+    dismiss.pressInside();
+    dismiss.release();
+
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Extract and apply this identical util (more testable, reusable).