### PR TITLE
fix(multi-select): fix selection if `portalMenu` is `true`

### DIFF
--- a/e2e/fixtures/ModalWithDropdownsFixture.svelte
+++ b/e2e/fixtures/ModalWithDropdownsFixture.svelte
@@ -9,6 +9,7 @@
   } from "carbon-components-svelte";
 
   let open = false;
+  let notificationIds = [];
 
   const contactItems = [
     { id: "0", text: "Slack" },
@@ -22,6 +23,11 @@
 <button type="button" data-testid="open-modal" on:click={() => (open = true)}>
   Open modal
 </button>
+
+<!-- bind:selectedIds from MultiSelect. Outside the Modal so it stays on screen
+     when the dialog closes; this pair failed to update during the bug. -->
+<p data-testid="notification-ids">{[...notificationIds].sort().join(",")}</p>
+<p data-testid="notification-count">{notificationIds.length}</p>
 
 <Modal
   bind:open
@@ -47,6 +53,7 @@
       labelText="Notification methods"
       label="Select methods..."
       items={contactItems}
+      bind:selectedIds={notificationIds}
     />
   </Stack>
 </Modal>

--- a/e2e/modal-with-dropdowns.test.ts
+++ b/e2e/modal-with-dropdowns.test.ts
@@ -57,6 +57,37 @@ test.describe("Modal with Dropdowns", () => {
     ).toBeChecked();
   });
 
+  // Regression test for https://github.com/carbon-design-system/carbon-components-svelte/issues/3170
+  test("MultiSelect keeps sequential label clicks selected and syncs bind:selectedIds", async ({
+    page,
+  }) => {
+    const trigger = page.getByRole("combobox", { name: "Open menu" });
+    await trigger.click();
+
+    const menu = page.getByRole("listbox", { name: "Choose an item" });
+    await expect(menu).toBeVisible();
+
+    const picks = ["Slack", "Email", "Phone"];
+    for (const name of picks) {
+      const option = menu.getByRole("option", { name });
+      // Click label text, not the checkbox input. That path double-toggled.
+      // biome-ignore lint/performance/noAwaitInLoops: each click must finish before the next
+      await option.getByText(name, { exact: true }).click();
+      await expect(option.getByRole("checkbox")).toBeChecked();
+    }
+
+    await Promise.all(
+      picks.map((name) =>
+        expect(
+          menu.getByRole("option", { name }).getByRole("checkbox"),
+        ).toBeChecked(),
+      ),
+    );
+
+    await expect(page.getByTestId("notification-count")).toHaveText("3");
+    await expect(page.getByTestId("notification-ids")).toHaveText("0,1,4");
+  });
+
   test("Dropdown menu renders outside the dialog (portal)", async ({
     page,
   }) => {

--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -888,6 +888,9 @@
                       event.stopPropagation();
                       return;
                     }
+                    // Label default synthesizes a second click; without this,
+                    // selectItem runs twice and the toggle nets to no change.
+                    event.preventDefault();
                     selectItem(item);
                     if (filterable) {
                       inputRef?.focus();
@@ -940,6 +943,9 @@
                   event.stopPropagation();
                   return;
                 }
+                // Label default synthesizes a second click; without this,
+                // selectItem runs twice and the toggle nets to no change.
+                event.preventDefault();
                 selectItem(item);
                 if (filterable) {
                   inputRef?.focus();


### PR DESCRIPTION
Fixes #3170

If `MultiSelect` is used in a modal, `portalMenu` is automatically set to `true` unless explicitly set to false.

There was a critical bug where selections could not be made in this case. The issue is that the list item row uses a native label + checkbox, so the synthetic click event competed with the native behavior (firing twice).

---

## Before

https://github.com/user-attachments/assets/709247e2-27fa-4580-bee9-8e0ee4a404b5


## After

https://github.com/user-attachments/assets/20d4038c-3365-4422-a080-7a41469a2413

