### PR TITLE
feat(structured-list): support `multiple` selection

### DIFF
--- a/docs/src/pages/components/StructuredList.svx
+++ b/docs/src/pages/components/StructuredList.svx
@@ -152,6 +152,12 @@ Enable row selection with the `selection` prop and structured list input compone
   </StructuredListBody>
 </StructuredList>
 
+## Multi-select rows
+
+Set `multiple` to allow selecting more than one row. `selected` becomes an array of values.
+
+<FileSource src="/framed/StructuredList/StructuredListMultiSelect" />
+
 ## Skeleton
 
 Show a loading state with the skeleton variant.

--- a/docs/src/pages/framed/StructuredList/StructuredListMultiSelect.svelte
+++ b/docs/src/pages/framed/StructuredList/StructuredListMultiSelect.svelte
@@ -1,0 +1,73 @@
+<script>
+  import {
+    StructuredList,
+    StructuredListBody,
+    StructuredListCell,
+    StructuredListHead,
+    StructuredListInput,
+    StructuredListRow,
+  } from "carbon-components-svelte";
+  import CheckmarkFilled from "carbon-icons-svelte/lib/CheckmarkFilled.svelte";
+
+  const databases = [
+    {
+      id: "postgresql",
+      name: "PostgreSQL",
+      type: "Relational",
+      description:
+        "Open-source object-relational database known for reliability, extensibility, and strong SQL standards compliance.",
+    },
+    {
+      id: "mongodb",
+      name: "MongoDB",
+      type: "Document",
+      description:
+        "Document-oriented NoSQL database designed for flexible schemas and horizontal scaling across distributed clusters.",
+    },
+    {
+      id: "redis",
+      name: "Redis",
+      type: "Key-value",
+      description:
+        "In-memory key-value store used as a cache, message broker, and real-time data platform with sub-millisecond latency.",
+    },
+  ];
+
+  let selected = ["postgresql-value", "redis-value"];
+</script>
+
+<StructuredList selection multiple bind:selected>
+  <StructuredListHead>
+    <StructuredListRow head>
+      <StructuredListCell head>Name</StructuredListCell>
+      <StructuredListCell head>Type</StructuredListCell>
+      <StructuredListCell head>Description</StructuredListCell>
+      <StructuredListCell head>{""}</StructuredListCell>
+    </StructuredListRow>
+  </StructuredListHead>
+  <StructuredListBody>
+    {#each databases as db}
+      <StructuredListRow label for="multi-{db.id}">
+        <StructuredListCell>{db.name}</StructuredListCell>
+        <StructuredListCell>{db.type}</StructuredListCell>
+        <StructuredListCell>{db.description}</StructuredListCell>
+        <StructuredListInput
+          id="multi-{db.id}"
+          value="{db.id}-value"
+          title="{db.name} option"
+        />
+        <StructuredListCell>
+          <CheckmarkFilled
+            class="bx--structured-list-svg"
+            aria-label="select an option"
+            title="select an option"
+          />
+        </StructuredListCell>
+      </StructuredListRow>
+    {/each}
+  </StructuredListBody>
+</StructuredList>
+
+<div style="margin-top: 1rem;">
+  Selected: <strong>{selected.join(", ") || "None"}</strong>
+</div>

--- a/src/StructuredList/StructuredList.svelte
+++ b/src/StructuredList/StructuredList.svelte
@@ -1,12 +1,13 @@
 <script>
   /**
    * @template {string} [Value=string]
-   * @event {Value} change
+   * @event {Value | Value[]} change
    */
 
   /**
    * Specify the selected structured list row value.
-   * @type {Value | undefined}
+   * When `multiple` is `true`, this is an array of selected values.
+   * @type {Value | Value[] | undefined}
    * @bindable writable
    */
   export let selected = undefined;
@@ -20,28 +21,43 @@
   /** Set to `true` to use the selection variant */
   export let selection = false;
 
+  /** Set to `true` to allow selecting multiple rows */
+  export let multiple = false;
+
   import { createEventDispatcher, onMount, setContext } from "svelte";
   import { writable } from "svelte/store";
 
   const dispatch = createEventDispatcher();
   /**
-   * @type {import("svelte/store").Writable<Value | undefined>}
+   * @type {import("svelte/store").Writable<Value | Value[] | undefined>}
    */
-  const selectedValue = writable(selected);
+  const selectedValue = writable(
+    multiple ? (Array.isArray(selected) ? selected : []) : selected,
+  );
 
-  let prevSelectedValue = selected;
+  let prevSelectedValue = $selectedValue;
   let isInitialRender = true;
 
   /**
    * @type {(value: Value) => void}
    */
   const update = (value) => {
-    selectedValue.set(value);
+    if (multiple) {
+      selectedValue.update((current) => {
+        const list = Array.isArray(current) ? current : [];
+        return list.includes(value)
+          ? list.filter((v) => v !== value)
+          : [...list, value];
+      });
+    } else {
+      selectedValue.set(value);
+    }
   };
 
   setContext("carbon:StructuredListWrapper", {
     selectedValue,
     update,
+    multiple,
   });
 
   onMount(() => {

--- a/src/StructuredList/StructuredListInput.svelte
+++ b/src/StructuredList/StructuredListInput.svelte
@@ -35,6 +35,8 @@
 
   const initialChecked = checked;
   const ctx = getContext("carbon:StructuredListWrapper");
+  const multiple = ctx?.multiple ?? false;
+  // Standalone (no wrapper context) is always single-select.
   const selectedValue =
     ctx?.selectedValue ?? writable(initialChecked ? value : undefined);
   const update = ctx?.update ?? ((v) => selectedValue.set(v));
@@ -43,12 +45,14 @@
     update(value);
   }
 
-  $: checked = $selectedValue === value;
+  $: checked = multiple
+    ? Array.isArray($selectedValue) && $selectedValue.includes(value)
+    : $selectedValue === value;
 </script>
 
 <input
   bind:this={ref}
-  type="radio"
+  type={multiple ? "checkbox" : "radio"}
   tabindex="-1"
   aria-hidden={ctx ? "true" : undefined}
   {checked}

--- a/src/StructuredList/StructuredListRow.svelte
+++ b/src/StructuredList/StructuredListRow.svelte
@@ -16,19 +16,26 @@
 
   const ctx = getContext("carbon:StructuredListWrapper");
   const selectedValue = ctx?.selectedValue ?? writable(undefined);
+  const multiple = ctx?.multiple ?? false;
 
   let labelRef;
   let inputValue;
 
   onMount(() => {
     if (label && labelRef) {
-      const input = labelRef.querySelector('input[type="radio"]');
+      const input = labelRef.querySelector(
+        'input[type="radio"], input[type="checkbox"]',
+      );
       if (input) inputValue = input.value;
     }
   });
 
-  $: isRadio = label && inputValue !== undefined;
-  $: ariaChecked = isRadio ? $selectedValue === inputValue : undefined;
+  $: isSelectable = label && inputValue !== undefined;
+  $: ariaChecked = isSelectable
+    ? multiple
+      ? Array.isArray($selectedValue) && $selectedValue.includes(inputValue)
+      : $selectedValue === inputValue
+    : undefined;
 
   function handleKeydown(event) {
     if (event.key === " " || event.key === "Enter") {
@@ -45,7 +52,7 @@
   <!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
   <label
     bind:this={labelRef}
-    role={isRadio ? "radio" : undefined}
+    role={isSelectable ? (multiple ? "checkbox" : "radio") : undefined}
     aria-checked={ariaChecked}
     {tabindex}
     class:bx--structured-list-row={true}

--- a/tests/StructuredList/StructuredList.test.ts
+++ b/tests/StructuredList/StructuredList.test.ts
@@ -6,6 +6,7 @@ import StructuredList from "./StructuredList.test.svelte";
 import StructuredListChecked from "./StructuredListChecked.test.svelte";
 import StructuredListCustom from "./StructuredListCustom.test.svelte";
 import StructuredListInputStandalone from "./StructuredListInputStandalone.test.svelte";
+import StructuredListMultiple from "./StructuredListMultiple.test.svelte";
 
 describe("StructuredList", () => {
   it("should render with default props", () => {
@@ -171,6 +172,36 @@ describe("StructuredList", () => {
 
     expect(consoleLog).not.toHaveBeenCalledWith("change", expect.anything());
   });
+
+  it("should support multi-select via the `multiple` prop", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(StructuredListMultiple);
+
+    const checkboxes = screen.getAllByRole("checkbox");
+    expect(checkboxes).toHaveLength(3);
+    expect(screen.queryAllByRole("radio")).toHaveLength(0);
+    expect(screen.getByTestId("value").textContent).toBe("[]");
+    // a11y: each selectable row exposes its checked state to assistive tech.
+    for (const checkbox of checkboxes) {
+      expect(checkbox).toHaveAttribute("aria-checked", "false");
+    }
+
+    await user.click(checkboxes[0]);
+    expect(screen.getByTestId("value").textContent).toBe('["row-1-value"]');
+    expect(consoleLog).toHaveBeenLastCalledWith("change", ["row-1-value"]);
+    expect(checkboxes[0]).toHaveAttribute("aria-checked", "true");
+
+    await user.click(checkboxes[2]);
+    expect(screen.getByTestId("value").textContent).toBe(
+      '["row-1-value","row-3-value"]',
+    );
+    expect(checkboxes[2]).toHaveAttribute("aria-checked", "true");
+
+    // toggling re-selects off
+    await user.click(checkboxes[0]);
+    expect(screen.getByTestId("value").textContent).toBe('["row-3-value"]');
+    expect(checkboxes[0]).toHaveAttribute("aria-checked", "false");
+  });
 });
 
 describe("Generics", () => {
@@ -181,12 +212,16 @@ describe("Generics", () => {
     type Props = ComponentProps<ComponentType>;
     type Events = ComponentEvents<ComponentType>;
 
-    expectTypeOf<Props["selected"]>().toEqualTypeOf<CustomValue | undefined>();
+    expectTypeOf<Props["selected"]>().toEqualTypeOf<
+      CustomValue | CustomValue[] | undefined
+    >();
 
     type ChangeEvent = Events["change"];
     type ChangeEventDetail =
       ChangeEvent extends CustomEvent<infer T> ? T : never;
-    expectTypeOf<ChangeEventDetail>().toEqualTypeOf<CustomValue>();
+    expectTypeOf<ChangeEventDetail>().toEqualTypeOf<
+      CustomValue | CustomValue[]
+    >();
   });
 
   it("should default to string when generic is not specified", () => {
@@ -194,25 +229,24 @@ describe("Generics", () => {
     type Props = ComponentProps<ComponentType>;
     type Events = ComponentEvents<ComponentType>;
 
-    expectTypeOf<Props["selected"]>().toEqualTypeOf<string | undefined>();
+    expectTypeOf<Props["selected"]>().toEqualTypeOf<
+      string | string[] | undefined
+    >();
 
     type ChangeEvent = Events["change"];
     type ChangeEventDetail =
       ChangeEvent extends CustomEvent<infer T> ? T : never;
-    expectTypeOf<ChangeEventDetail>().toEqualTypeOf<string>();
+    expectTypeOf<ChangeEventDetail>().toEqualTypeOf<string | string[]>();
   });
 
   it("should provide type-safe access to custom string literal types in event handlers", () => {
     type Status = "pending" | "approved" | "rejected";
 
-    const handleChange = (value: Status) => {
-      expectTypeOf(value).toEqualTypeOf<Status>();
-      if (value === "pending") {
-        expectTypeOf(value).toEqualTypeOf<"pending">();
-      }
+    const handleChange = (value: Status | Status[]) => {
+      expectTypeOf(value).toEqualTypeOf<Status | Status[]>();
     };
 
-    expectTypeOf(handleChange).parameter(0).toEqualTypeOf<Status>();
+    expectTypeOf(handleChange).parameter(0).toEqualTypeOf<Status | Status[]>();
 
     type ComponentType = StructuredListComponent<Status>;
     type Events = ComponentEvents<ComponentType>;

--- a/tests/StructuredList/StructuredListMultiple.test.svelte
+++ b/tests/StructuredList/StructuredListMultiple.test.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+  import {
+    StructuredList,
+    StructuredListBody,
+    StructuredListCell,
+    StructuredListHead,
+    StructuredListInput,
+    StructuredListRow,
+  } from "carbon-components-svelte";
+  import type { ComponentProps } from "svelte";
+
+  export let selected: ComponentProps<StructuredList>["selected"] = undefined;
+</script>
+
+<StructuredList
+  selection
+  multiple
+  bind:selected
+  on:change={(e) => {
+    console.log("change", e.detail);
+  }}
+>
+  <StructuredListHead>
+    <StructuredListRow head>
+      <StructuredListCell head>Column A</StructuredListCell>
+      <StructuredListCell head>{""}</StructuredListCell>
+    </StructuredListRow>
+  </StructuredListHead>
+  <StructuredListBody>
+    {#each ["1", "2", "3"] as item}
+      <StructuredListRow label for="row-{item}">
+        <StructuredListCell>Row {item}</StructuredListCell>
+        <StructuredListInput
+          id="row-{item}"
+          value="row-{item}-value"
+          title="row-{item}-title"
+        />
+      </StructuredListRow>
+    {/each}
+  </StructuredListBody>
+</StructuredList>
+
+<div data-testid="value">{JSON.stringify(selected)}</div>


### PR DESCRIPTION
`StructuredList` currently supports single selection ("radio" style). This adds the `multiple` prop to allow multi-selection. If `multiple` is enabled, `selected` becomes an array of IDs.

Style/function-wise (a11y), this is similar to `SelectableTile`.

---

https://github.com/user-attachments/assets/1cdc633a-557b-4f24-9fbc-5d5745508949

