### PR TITLE
feat(file-uploader-drop-container): dispatch `rejected` event

### DIFF
--- a/src/FileUploader/FileUploaderDropContainer.svelte
+++ b/src/FileUploader/FileUploaderDropContainer.svelte
@@ -2,6 +2,7 @@
   /**
    * @event {ReadonlyArray<File>} add
    * @event {ReadonlyArray<File>} change
+   * @event {Array<{ file: File; reason: string }>} rejected
    */
 
   /**
@@ -83,7 +84,13 @@
   on:drop|preventDefault|stopPropagation={(event) => {
     if (!disabled) {
       over = false;
-      const newFiles = validateFiles([...event.dataTransfer.files]);
+      const incoming = [...event.dataTransfer.files];
+      const newFiles = validateFiles(incoming);
+      const accepted = new Set(newFiles);
+      const rejected = incoming
+        .filter((file) => !accepted.has(file))
+        .map((file) => ({ file, reason: "invalid" }));
+      if (rejected.length > 0) dispatch("rejected", rejected);
       files = multiple ? [...files, ...newFiles] : newFiles;
       dispatch("add", files);
       dispatch("change", files);
@@ -122,8 +129,14 @@
     {name}
     {multiple}
     class:bx--file-input={true}
-    on:change={(event) => {
-      const newFiles = validateFiles([...event.target.files]);
+    on:change={({ target }) => {
+      const incoming = [...target.files];
+      const newFiles = validateFiles(incoming);
+      const accepted = new Set(newFiles);
+      const rejected = incoming
+        .filter((file) => !accepted.has(file))
+        .map((file) => ({ file, reason: "invalid" }));
+      if (rejected.length > 0) dispatch("rejected", rejected);
       files = multiple ? [...files, ...newFiles] : newFiles;
       dispatch("add", files);
       dispatch("change", files);

--- a/tests/FileUploader/FileUploaderDropContainer.test.svelte
+++ b/tests/FileUploader/FileUploaderDropContainer.test.svelte
@@ -9,11 +9,15 @@
   export let onchange:
     | ((e: CustomEvent<ReadonlyArray<File>>) => void)
     | undefined = undefined;
+  export let onrejected:
+    | ((e: CustomEvent<Array<{ file: File; reason: string }>>) => void)
+    | undefined = undefined;
 </script>
 
 <FileUploaderDropContainer
   bind:files
   on:add={(e) => onadd?.(e)}
   on:change={(e) => onchange?.(e)}
+  on:rejected={(e) => onrejected?.(e)}
   {...$$restProps}
 />

--- a/tests/FileUploader/FileUploaderDropContainer.test.ts
+++ b/tests/FileUploader/FileUploaderDropContainer.test.ts
@@ -269,6 +269,102 @@ describe("FileUploaderDropContainer", () => {
     expect(event.detail[0].name).toBe("small.txt");
   });
 
+  it("should dispatch rejected event on drop when validateFiles filters files", async () => {
+    const validateFiles = vi.fn((files: File[]) =>
+      files.filter((f: File) => f.size < 1000),
+    );
+    const rejectedHandler = vi.fn();
+    const changeHandler = vi.fn();
+    const { container } = render(FileUploaderDropContainer, {
+      props: {
+        validateFiles,
+        onrejected: rejectedHandler,
+        onchange: changeHandler,
+      },
+    });
+
+    const dropDiv = container.querySelector(".bx--file");
+    assert(dropDiv instanceof HTMLElement);
+
+    const smallFile = new File(["x".repeat(500)], "small.txt", {
+      type: "text/plain",
+    });
+    const largeFile = new File(["x".repeat(2000)], "large.txt", {
+      type: "text/plain",
+    });
+    const dropEvent = createDragEvent("drop", [smallFile, largeFile]);
+
+    dropDiv.dispatchEvent(dropEvent);
+
+    await vi.waitFor(() => {
+      expect(rejectedHandler).toHaveBeenCalled();
+    });
+
+    const event = rejectedHandler.mock.calls[0][0];
+    expect(event.detail).toHaveLength(1);
+    expect(event.detail[0].file.name).toBe("large.txt");
+    expect(event.detail[0].reason).toBe("invalid");
+  });
+
+  it("should not dispatch rejected event when validateFiles accepts all files", async () => {
+    const validateFiles = vi.fn((files: File[]) => files);
+    const rejectedHandler = vi.fn();
+    const changeHandler = vi.fn();
+    const { container } = render(FileUploaderDropContainer, {
+      props: {
+        validateFiles,
+        onrejected: rejectedHandler,
+        onchange: changeHandler,
+      },
+    });
+
+    const dropDiv = container.querySelector(".bx--file");
+    assert(dropDiv instanceof HTMLElement);
+
+    const file = new File(["content"], "ok.txt", { type: "text/plain" });
+    dropDiv.dispatchEvent(createDragEvent("drop", [file]));
+
+    await vi.waitFor(() => {
+      expect(changeHandler).toHaveBeenCalled();
+    });
+
+    expect(rejectedHandler).not.toHaveBeenCalled();
+  });
+
+  it("should dispatch rejected event from input change when validateFiles filters files", async () => {
+    const validateFiles = vi.fn((files: File[]) =>
+      files.filter((f: File) => f.size < 1000),
+    );
+    const rejectedHandler = vi.fn();
+    const { container } = render(FileUploaderDropContainer, {
+      props: {
+        multiple: true,
+        validateFiles,
+        onrejected: rejectedHandler,
+      },
+    });
+
+    const input = container.querySelector('input[type="file"]');
+    assert(input instanceof HTMLInputElement);
+
+    const smallFile = new File(["x".repeat(500)], "small.txt", {
+      type: "text/plain",
+    });
+    const largeFile = new File(["x".repeat(2000)], "large.txt", {
+      type: "text/plain",
+    });
+    simulateFileSelection(input, [smallFile, largeFile]);
+
+    await vi.waitFor(() => {
+      expect(rejectedHandler).toHaveBeenCalled();
+    });
+
+    const event = rejectedHandler.mock.calls[0][0];
+    expect(event.detail).toHaveLength(1);
+    expect(event.detail[0].file.name).toBe("large.txt");
+    expect(event.detail[0].reason).toBe("invalid");
+  });
+
   it("should handle file input change event", async () => {
     const changeHandler = vi.fn();
     const { container } = render(FileUploaderDropContainer, {


### PR DESCRIPTION
Similar to `FileUploader` (https://github.com/carbon-design-system/carbon-components-svelte/pull/2774), add parity by dispatching a `rejected` event.