### PR TITLE
feat(code-snippet): add `codeLabel` prop for container aria-label

### DIFF
--- a/src/CodeSnippet/CodeSnippet.svelte
+++ b/src/CodeSnippet/CodeSnippet.svelte
@@ -86,6 +86,11 @@
    */
   export let copyLabel = "Copy code";
 
+  /**
+   * Specify the ARIA label of the code snippet container (single/multi variants).
+   */
+  export let codeLabel = "Code snippet";
+
   /** Specify the feedback text displayed when clicking the snippet */
   export let feedback = "Copied!";
 
@@ -329,7 +334,7 @@
       tabindex={disabled ? undefined : "0"}
       aria-readonly="true"
       aria-multiline={type === "multi" ? "true" : undefined}
-      aria-label={$$restProps["aria-label"] ?? copyLabel ?? "code-snippet"}
+      aria-label={$$restProps["aria-label"] ?? codeLabel}
       class:bx--snippet-container={true}
       style:width="100%"
       style:min-height="{minHeight}px"

--- a/tests/CodeSnippet/CodeSnippet.test.ts
+++ b/tests/CodeSnippet/CodeSnippet.test.ts
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/svelte";
+import { CodeSnippet } from "carbon-components-svelte";
 import { user } from "../utils/user";
 import CodeSnippetAsync from "./CodeSnippetAsync.test.svelte";
 import CodeSnippetAsyncDoubleClick from "./CodeSnippetAsyncDoubleClick.test.svelte";
@@ -532,5 +533,50 @@ yarn -v`,
     });
     const snippet = container.querySelector(".bx--snippet-container");
     expect(snippet).toHaveAttribute("aria-label", "");
+  });
+
+  test("uses default codeLabel for container aria-label", () => {
+    const { container } = render(CodeSnippet, {
+      props: { type: "single", code: "test" },
+    });
+    const snippet = container.querySelector(".bx--snippet-container");
+    expect(snippet).toHaveAttribute("aria-label", "Code snippet");
+  });
+
+  test("uses custom codeLabel for container aria-label", () => {
+    const { container } = render(CodeSnippet, {
+      props: {
+        type: "multi",
+        code: "test",
+        codeLabel: "Install command",
+      },
+    });
+    const snippet = container.querySelector(".bx--snippet-container");
+    expect(snippet).toHaveAttribute("aria-label", "Install command");
+  });
+
+  test("aria-label rest prop takes precedence over codeLabel", () => {
+    const { container } = render(CodeSnippet, {
+      props: {
+        type: "single",
+        code: "test",
+        codeLabel: "Install command",
+        "aria-label": "Custom label",
+      },
+    });
+    const snippet = container.querySelector(".bx--snippet-container");
+    expect(snippet).toHaveAttribute("aria-label", "Custom label");
+  });
+
+  test("copyLabel does not affect container aria-label", () => {
+    const { container } = render(CodeSnippet, {
+      props: {
+        type: "single",
+        code: "test",
+        copyLabel: "Copy code",
+      },
+    });
+    const snippet = container.querySelector(".bx--snippet-container");
+    expect(snippet).toHaveAttribute("aria-label", "Code snippet");
   });
 });


### PR DESCRIPTION
Separates the snippet container label from `copyLabel`, which only labels the copy button. Change the default to "Code snippet".

This allows consumers to actually label the code snippet.

This *could* be categorized as a fix, technically, but will include as a feature (the default changes, but is now customizable).