### PR TITLE
docs: clarify scoped Biome lint commands

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -348,15 +348,27 @@ This compiles every non-partial `*.scss` (sass, compressed) through autoprefixer
 
 See [Best practices](#best-practices) for scoping. Run checks against what you changed. Full-repo runs are slow and surface unrelated failures.
 
-For format and lint, prefer changed files only:
+For format and lint, scope Biome to what you touched:
 
 ```sh
-# Files changed relative to master
-bunx biome check --write --changed
-
-# Or specific paths
+# Specific paths — always lints the current working tree
 bunx biome check --write src/DataTable
+
+# Staged files only (what a commit would include)
+bunx biome check --write --staged
+
+# Files committed on this branch relative to master
+bunx biome check --write --changed --since=master
 ```
+
+Pick the form that matches your state. `--changed` and `--staged` resolve their file
+list from git, so each sees a different slice:
+
+- Path scoping (`src/DataTable`) lints whatever is on disk now, committed or not. Use it
+  while editing.
+- `--staged` lints the git index. Run it after `git add`.
+- `--changed` diffs commits against the default branch. It does **not** see uncommitted
+  or unstaged edits, so it reports nothing until you commit.
 
 `bun run lint` runs Biome over the entire repository. Reserve it for broad sweeps.
 

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "test:types:svelte4": "cd tests-svelte4 && bun run test:types",
     "test:e2e": "playwright test",
     "lint": "biome check --write .",
+    "lint:changed": "biome check --write --changed --since=master --no-errors-on-unmatched .",
     "build:css": "bun scripts/build-css",
     "build:docs": "bun scripts/build-docs",
     "postinstall": "ibmtelemetry --config=telemetry.yml",


### PR DESCRIPTION
`biome check --changed` only diffs committed work, so it silently linted nothing for uncommitted edits. Document path/`--staged`/ `--changed` semantics and add a `lint:changed` script.

Also add a `bun lint:changed` script for faster local lints/formats.