### PR TITLE
fix(code-snippet): avoid overwriting consumer-controlled `showMoreLess` prop

### DIFF
--- a/src/CodeSnippet/CodeSnippet.svelte
+++ b/src/CodeSnippet/CodeSnippet.svelte
@@ -165,6 +165,7 @@
   let feedbackOpen = false;
   let copyPending = false;
   let prevExpanded = expanded;
+  let exceedsThreshold = true;
 
   function syncCopyFeedback() {
     animation = copyFeedback.animation;
@@ -176,23 +177,22 @@
     copyFeedback.dismiss();
   }
 
-  function setShowMoreLess() {
+  function measureHeight() {
     const { height } = ref.getBoundingClientRect();
-    if (height > 0) showMoreLess = ref.getBoundingClientRect().height > 255;
+    if (height > 0) exceedsThreshold = height > 255;
   }
 
   $: expandText = expanded ? showLessText : showMoreText;
   $: minHeight = expanded ? 16 * 15 : 48;
   $: maxHeight = expanded ? "none" : `${16 * 15}px`;
 
-  // Show more/less only applies to multi-line code snippets
-  $: if (type !== "multi") showMoreLess = false;
-
   $: if (type === "multi" && ref && showMoreLess) {
-    // Only compute the show more/less button if the consumer has not opted out
-    if (code === undefined) setShowMoreLess();
-    if (code) tick().then(setShowMoreLess);
+    // Only measure when the consumer has not opted out
+    if (code === undefined) measureHeight();
+    if (code) tick().then(measureHeight);
   }
+
+  $: showExpandButton = showMoreLess && type === "multi" && exceedsThreshold;
 
   $: if (type === "multi" && prevExpanded !== expanded) {
     dispatch(expanded ? "expand" : "collapse");
@@ -355,7 +355,7 @@
         on:mouseleave={(event) => dispatch("mouseleave:copy-button", event)}
       />
     {/if}
-    {#if showMoreLess}
+    {#if showExpandButton}
       <Button
         kind="ghost"
         size="small"

--- a/tests/CodeSnippet/CodeSnippet.test.ts
+++ b/tests/CodeSnippet/CodeSnippet.test.ts
@@ -2,6 +2,7 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/svelte";
 import { user } from "../utils/user";
 import CodeSnippetAsync from "./CodeSnippetAsync.test.svelte";
 import CodeSnippetAsyncDoubleClick from "./CodeSnippetAsyncDoubleClick.test.svelte";
+import CodeSnippetBindShowMoreLess from "./CodeSnippetBindShowMoreLess.test.svelte";
 import CodeSnippetCopyButton from "./CodeSnippetCopyButton.test.svelte";
 import CodeSnippetCopyButtonMouseEnter from "./CodeSnippetCopyButtonMouseEnter.test.svelte";
 import CodeSnippetCopyButtonMouseLeave from "./CodeSnippetCopyButtonMouseLeave.test.svelte";
@@ -447,6 +448,22 @@ yarn -v`,
   test("should hide show more button when hideShowMore is true", () => {
     render(CodeSnippetWithHideShowMore);
     expect(screen.queryByText("Show more")).not.toBeInTheDocument();
+  });
+
+  // Regression: the exported `showMoreLess` prop is consumer-controlled and
+  // must not be silently overwritten by the component's internal logic.
+  test("does not overwrite bound showMoreLess prop", async () => {
+    const { rerender } = render(CodeSnippetBindShowMoreLess, {
+      props: { type: "multi", showMoreLess: true },
+    });
+
+    // Content is short and type is "multi"; the component's auto-hide must
+    // not flip the consumer's bound value to false.
+    expect(screen.getByTestId("bound-value")).toHaveTextContent("true");
+
+    // Switching type away from "multi" must also not mutate the bound prop.
+    await rerender({ type: "single", showMoreLess: true });
+    expect(screen.getByTestId("bound-value")).toHaveTextContent("true");
   });
 
   test("should display custom copy text", async () => {

--- a/tests/CodeSnippet/CodeSnippetBindShowMoreLess.test.svelte
+++ b/tests/CodeSnippet/CodeSnippetBindShowMoreLess.test.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  import { CodeSnippet } from "carbon-components-svelte";
+
+  export let type: "single" | "inline" | "multi" = "multi";
+  export let showMoreLess = true;
+</script>
+
+<div data-testid="bound-value">{showMoreLess}</div>
+
+<CodeSnippet
+  {type}
+  bind:showMoreLess
+  code={`node -v
+npm -v
+yarn -v`}
+/>


### PR DESCRIPTION
The exported `showMoreLess` prop was mutated by internal reactive logic, so `bind:showMoreLess` got silently flipped and became unsettable to `true` once auto-hide fired.