### PR TITLE
fix(file-uploader): join `accept` array explicitly

### DIFF
--- a/src/FileUploader/FileUploaderButton.svelte
+++ b/src/FileUploader/FileUploaderButton.svelte
@@ -176,7 +176,7 @@
   bind:this={ref}
   type="file"
   tabindex="-1"
-  {accept}
+  accept={typeof accept === "string" ? accept : accept.join(",")}
   {disabled}
   {id}
   {multiple}

--- a/src/FileUploader/FileUploaderDropContainer.svelte
+++ b/src/FileUploader/FileUploaderDropContainer.svelte
@@ -114,7 +114,7 @@
     tabindex="-1"
     {id}
     {disabled}
-    {accept}
+    accept={typeof accept === "string" ? accept : accept.join(",")}
     {name}
     {multiple}
     class:bx--file-input={true}


### PR DESCRIPTION
`FileUploaderButton` and `FileUploaderDropContainer` accept `accept` as a `ReadonlyArray<string>`, but passed it to the native `<input accept>` via `{accept}`, relying on `Array.prototype.toString()` to comma-join the values. This made the contract implicit and dependent on a JS coercion quirk. Both components now join the array explicitly (`typeof accept === "string" ? accept : accept.join(",")`), preserving string inputs while making the array behavior intentional and documented.