### PR TITLE
docs(session-storage): clarify storage event scope

### DIFF
--- a/docs/src/pages/components/SessionStorage.svx
+++ b/docs/src/pages/components/SessionStorage.svx
@@ -4,7 +4,7 @@ components: ["SessionStorage"]
 
 Session storage provides a reactive wrapper around the [Window.sessionStorage API](https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage). Unlike [LocalStorage](/components/LocalStorage), data is cleared when the browser tab is closed and is isolated per tab—each tab has its own storage. Use session storage for temporary state that should not persist across sessions (e.g., form drafts, wizard progress).
 
-The component listens for the [storage event](https://developer.mozilla.org/en-US/docs/Web/API/Window/storage_event) for consistency with the storage API.
+The component listens for the [storage event](https://developer.mozilla.org/en-US/docs/Web/API/Window/storage_event) so that updates from another same-origin document in the same tab (e.g., an iframe) stay in sync. Note that `sessionStorage` is isolated per tab, so this event does not propagate across tabs or windows.
 
 ## Basic example
 

--- a/src/SessionStorage/SessionStorage.svelte
+++ b/src/SessionStorage/SessionStorage.svelte
@@ -2,7 +2,7 @@
   /**
    * @template [T=any]
    * @event {null} save
-   * @event update - Fires when the stored value changes, either from a bound value update or when sessionStorage is modified from another tab/window.
+   * @event update - Fires when the stored value changes, either from a bound value update or when sessionStorage is modified by another same-origin document in this tab (e.g. an iframe).
    * @property {T} prevValue
    * @property {T} value
    */


### PR DESCRIPTION
`sessionStorage` is isolated per tab, so the `storage` event never fires across tabs/windows: only from same-origin documents (e.g. an iframe) in the same tab. Correct the misleading cross-tab wording.