### PR TITLE
fix(file-uploader): expose `aria-disabled` on drop container

### DIFF
--- a/src/FileUploader/FileUploaderDropContainer.svelte
+++ b/src/FileUploader/FileUploaderDropContainer.svelte
@@ -94,7 +94,7 @@
   <!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
   <label
     for={id}
-    {tabindex}
+    tabindex={disabled ? -1 : tabindex}
     class:bx--file-browse-btn={true}
     class:bx--file-browse-btn--disabled={disabled}
     on:keydown
@@ -106,6 +106,7 @@
   >
     <div
       {role}
+      aria-disabled={disabled || undefined}
       class:bx--file__drop-container={true}
       class:bx--file__drop-container--drag-over={over}
     >

--- a/tests/FileUploader/FileUploaderDropContainer.test.ts
+++ b/tests/FileUploader/FileUploaderDropContainer.test.ts
@@ -80,6 +80,28 @@ describe("FileUploaderDropContainer", () => {
     expect(label).toHaveClass("bx--file-browse-btn--disabled");
   });
 
+  it("should expose aria-disabled and remove from tab order when disabled", () => {
+    const { container } = render(FileUploaderDropContainer, {
+      props: { disabled: true },
+    });
+
+    const dropContainer = container.querySelector(".bx--file__drop-container");
+    assert(dropContainer instanceof HTMLElement);
+    expect(dropContainer).toHaveAttribute("aria-disabled", "true");
+
+    const label = container.querySelector("label");
+    assert(label instanceof HTMLElement);
+    expect(label).toHaveAttribute("tabindex", "-1");
+  });
+
+  it("should not expose aria-disabled when not disabled", () => {
+    const { container } = render(FileUploaderDropContainer);
+
+    const dropContainer = container.querySelector(".bx--file__drop-container");
+    assert(dropContainer instanceof HTMLElement);
+    expect(dropContainer).not.toHaveAttribute("aria-disabled");
+  });
+
   it("should respect accept prop", () => {
     const { container } = render(FileUploaderDropContainer, {
       props: { accept: [".pdf", ".doc"] },


### PR DESCRIPTION
A disabled `FileUploaderDropContainer` only changed visually and no-op'd its handlers, but stayed focusable and announced as a normal button. Set `aria-disabled` and `tabindex="-1"` so AT and keyboard users perceive the disabled state.