### PR TITLE
fix(storage): sync cross-tab key removal for LocalStorage and SessionStorage

### DIFF
--- a/docs/src/pages/components/LocalStorage.svx
+++ b/docs/src/pages/components/LocalStorage.svx
@@ -7,7 +7,7 @@ components: ["LocalStorage"]
 
 Local storage provides a reactive wrapper around the [Window.localStorage API](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage). Unlike [SessionStorage](/components/SessionStorage), data persists indefinitely until explicitly cleared and is shared across all tabs of the same origin. Use local storage for user preferences and application state that should survive page reloads and browser restarts.
 
-The component listens for the [storage event](https://developer.mozilla.org/en-US/docs/Web/API/Window/storage_event), so changes made in one browser tab are automatically synchronized to other tabs with the same key.
+The component listens for the [storage event](https://developer.mozilla.org/en-US/docs/Web/API/Window/storage_event), so changes made in one browser tab are automatically synchronized to other tabs with the same key. Updates from other tabs dispatch `on:update` with `{ prevValue, value }`. When another tab removes the key (for example, via `localStorage.removeItem()` or `localStorage.clear()`), the bound `value` resets to `undefined` so the next local mutation does not re-persist stale data.
 
 ## Basic example
 
@@ -45,6 +45,8 @@ The component provides methods to manage stored data:
 | `clearItem`  | Remove a specific key-value pair.   |
 | `clearAll`   | Remove all stored data.             |
 
-Use `bind:this` to access these methods. In this example, try toggling the switch, refreshing the page, then clearing the storage.
+Use `bind:this` to access these methods. These methods only clear browser storage in the current tab; they do not reset the bound `value`. Other tabs with the same key will reset their bound `value` to `undefined` when they receive the storage event. If you want to clear both storage and the bound value in the current tab, reset `value` yourself after calling `clearItem` or `clearAll`.
+
+In this example, try toggling the switch, refreshing the page, then clearing the storage.
 
 <FileSource src="/framed/LocalStorage/LocalStorageClear" />

--- a/docs/src/pages/components/SessionStorage.svx
+++ b/docs/src/pages/components/SessionStorage.svx
@@ -4,7 +4,7 @@ components: ["SessionStorage"]
 
 Session storage provides a reactive wrapper around the [Window.sessionStorage API](https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage). Unlike [LocalStorage](/components/LocalStorage), data is cleared when the browser tab is closed and is isolated per tab—each tab has its own storage. Use session storage for temporary state that should not persist across sessions (for example, form drafts or wizard progress).
 
-The component listens for the [storage event](https://developer.mozilla.org/en-US/docs/Web/API/Window/storage_event) so that updates from another same-origin document in the same tab (e.g., an iframe) stay in sync. Note that `sessionStorage` is isolated per tab, so this event does not propagate across tabs or windows.
+The component listens for the [storage event](https://developer.mozilla.org/en-US/docs/Web/API/Window/storage_event) so that updates from another same-origin document in the same tab (e.g., an iframe) stay in sync. Note that `sessionStorage` is isolated per tab, so this event does not propagate across tabs or windows. Received storage updates dispatch `on:update` with `{ prevValue, value }`. When the key is removed from a context sharing the session (for example, via `sessionStorage.removeItem()` or `sessionStorage.clear()`), the bound `value` resets to `undefined` so the next local mutation does not re-persist stale data.
 
 ## Basic example
 
@@ -42,6 +42,8 @@ The component provides methods to manage stored data:
 | `clearItem`  | Remove a specific key-value pair.   |
 | `clearAll`   | Remove all stored data.             |
 
-Use `bind:this` to access these methods. In this example, try toggling the switch, refreshing the page, then clearing the storage.
+Use `bind:this` to access these methods. These methods only clear browser storage in the current tab; they do not reset the bound `value`. If you want to clear both storage and the bound value, reset `value` yourself after calling `clearItem` or `clearAll`.
+
+In this example, try toggling the switch, refreshing the page, then clearing the storage.
 
 <FileSource src="/framed/SessionStorage/SessionStorageClear" />

--- a/src/LocalStorage/LocalStorage.svelte
+++ b/src/LocalStorage/LocalStorage.svelte
@@ -92,11 +92,20 @@
     mounted = true;
 
     function handleStorageChange(event) {
-      if (event.key === key && event.newValue !== null) {
+      if (event.key === key) {
         const prevValue = parseStoredValue(prevSerialized);
-        value = parseStoredValue(event.newValue);
+
+        if (event.newValue === null) {
+          // Another tab removed the key (or called clear()).
+          // Reset so the next local mutation does not re-persist stale state.
+          value = /** @type {T} */ (undefined);
+          prevSerialized = serializeStoredValue(value);
+        } else {
+          value = parseStoredValue(event.newValue);
+          prevSerialized = event.newValue;
+        }
+
         dispatch("update", { prevValue, value });
-        prevSerialized = event.newValue;
       }
     }
 

--- a/src/SessionStorage/SessionStorage.svelte
+++ b/src/SessionStorage/SessionStorage.svelte
@@ -92,11 +92,20 @@
     mounted = true;
 
     function handleStorageChange(event) {
-      if (event.key === key && event.newValue !== null) {
+      if (event.key === key) {
         const prevValue = parseStoredValue(prevSerialized);
-        value = parseStoredValue(event.newValue);
+
+        if (event.newValue === null) {
+          // Another tab removed the key (or called clear()).
+          // Reset so the next local mutation does not re-persist stale state.
+          value = /** @type {T} */ (undefined);
+          prevSerialized = serializeStoredValue(value);
+        } else {
+          value = parseStoredValue(event.newValue);
+          prevSerialized = event.newValue;
+        }
+
         dispatch("update", { prevValue, value });
-        prevSerialized = event.newValue;
       }
     }
 

--- a/tests/LocalStorage/LocalStorageCrossTab.test.svelte
+++ b/tests/LocalStorage/LocalStorageCrossTab.test.svelte
@@ -3,10 +3,12 @@
 <script lang="ts">
   import { LocalStorage } from "carbon-components-svelte";
 
-  export let value = "initial-value";
+  export let value: unknown = "initial-value";
   export let key = "cross-tab-key";
-  export let onUpdate: (e: CustomEvent) => void = () => {};
-  export let onSave: () => void = () => {};
+  export let onUpdate: (detail: {
+    prevValue: unknown;
+    value: unknown;
+  }) => void = () => undefined;
 </script>
 
-<LocalStorage {key} bind:value on:update={onUpdate} on:save={onSave} />
+<LocalStorage {key} bind:value on:update={({ detail }) => onUpdate(detail)} />

--- a/tests/LocalStorage/LocalStorageCrossTab.test.ts
+++ b/tests/LocalStorage/LocalStorageCrossTab.test.ts
@@ -68,17 +68,37 @@ describe("LocalStorage cross-tab sync", () => {
     expect(component.value).toBe("initial");
   });
 
-  it("ignores storage events with null newValue", async () => {
+  it("resets value when another tab removes the key", async () => {
     const { component } = render(LocalStorageCrossTab, {
       props: { key: "test-key", value: "initial" },
     });
     await tick();
 
-    // Simulate a storage event with null (key was removed)
+    // Another tab calls localStorage.removeItem("test-key"),
+    // which fires a storage event with newValue === null.
     dispatchStorageEvent("test-key", null);
     await tick();
 
-    expect(component.value).toBe("initial");
+    // The in-memory value should not silently retain the stale data;
+    // otherwise the next local mutation re-persists it and defeats
+    // the cross-tab delete.
+    expect(component.value).toBeUndefined();
+  });
+
+  it("dispatches update with prevValue when another tab removes the key", async () => {
+    const handleUpdate = vi.fn();
+    render(LocalStorageCrossTab, {
+      props: { key: "test-key", value: "initial", onUpdate: handleUpdate },
+    });
+    await tick();
+
+    dispatchStorageEvent("test-key", null);
+    await tick();
+
+    expect(handleUpdate).toHaveBeenCalledWith({
+      prevValue: "initial",
+      value: undefined,
+    });
   });
 
   it("does not dispatch update when key changes to an existing entry", async () => {

--- a/tests/SessionStorage/SessionStorageCrossTab.test.svelte
+++ b/tests/SessionStorage/SessionStorageCrossTab.test.svelte
@@ -3,10 +3,12 @@
 <script lang="ts">
   import { SessionStorage } from "carbon-components-svelte";
 
-  export let value = "initial-value";
+  export let value: unknown = "initial-value";
   export let key = "cross-tab-key";
-  export let onUpdate: (e: CustomEvent) => void = () => {};
-  export let onSave: () => void = () => {};
+  export let onUpdate: (detail: {
+    prevValue: unknown;
+    value: unknown;
+  }) => void = () => undefined;
 </script>
 
-<SessionStorage {key} bind:value on:update={onUpdate} on:save={onSave} />
+<SessionStorage {key} bind:value on:update={({ detail }) => onUpdate(detail)} />

--- a/tests/SessionStorage/SessionStorageCrossTab.test.ts
+++ b/tests/SessionStorage/SessionStorageCrossTab.test.ts
@@ -65,16 +65,37 @@ describe("SessionStorage cross-tab sync", () => {
     expect(component.value).toBe("initial");
   });
 
-  it("ignores storage events with null newValue", async () => {
+  it("resets value when another tab removes the key", async () => {
     const { component } = render(SessionStorageCrossTab, {
       props: { key: "test-key", value: "initial" },
+    });
+    await tick();
+
+    // Another context calls sessionStorage.removeItem("test-key"),
+    // which fires a storage event with newValue === null.
+    dispatchStorageEvent("test-key", null);
+    await tick();
+
+    // The in-memory value should not silently retain the stale data;
+    // otherwise the next local mutation re-persists it and defeats
+    // the removal.
+    expect(component.value).toBeUndefined();
+  });
+
+  it("dispatches update with prevValue when another tab removes the key", async () => {
+    const handleUpdate = vi.fn();
+    render(SessionStorageCrossTab, {
+      props: { key: "test-key", value: "initial", onUpdate: handleUpdate },
     });
     await tick();
 
     dispatchStorageEvent("test-key", null);
     await tick();
 
-    expect(component.value).toBe("initial");
+    expect(handleUpdate).toHaveBeenCalledWith({
+      prevValue: "initial",
+      value: undefined,
+    });
   });
 
   it("does not dispatch update when key changes to an existing entry", async () => {


### PR DESCRIPTION
A `storage` event fired when another browsing context removes a key via `removeItem()`/`clear()` carries `newValue === null`, which the previous guard skipped: leaving the stale in-memory `value`, which the next local mutation then re-persisted, defeating the cross-tab delete.

Both `LocalStorage` and `SessionStorage` now reset the bound `value` to `undefined` on that event and dispatch `update` with `{ prevValue, value }` so consumers observe the removal. Cross-tab tests are updated (the old test that codified the buggy behavior is replaced) and docs note the reset behavior and that `clearItem`/`clearAll` only clear browser storage, not the bound `value`.