### PR TITLE
fix(storage): persist object and array value mutations

### DIFF
--- a/docs/src/pages/components/LocalStorage.svx
+++ b/docs/src/pages/components/LocalStorage.svx
@@ -15,6 +15,17 @@ See how the component maintains state across page reloads. Toggle the switch and
 
 <FileSource src="/framed/LocalStorage/LocalStorage" />
 
+## Persisting objects and arrays
+
+`value` can be any JSON-serializable value; objects and arrays are serialized with `JSON.stringify`. The component compares the serialized form to decide when to write, which has two consequences:
+
+- Reassigning `value` to a new object/array with **identical contents** does not trigger a redundant write.
+- **In-place mutations** (for example, `value.theme = "light"`) are persisted only when you signal the change to Svelte. Reassign the value (`value = { ...value, theme: "light" }`) or use the self-assignment idiom (`value = value`); a bare mutation alone will not re-render the component and therefore will not persist.
+
+In this example, the text inputs bind directly to nested properties and the button mutates the object in place. Edit a field and refresh the page to confirm the change is persisted.
+
+<FileSource src="/framed/LocalStorage/LocalStorageObject" />
+
 ## Reactive key
 
 The `key` prop is also reactive, so you can dynamically switch between storage keys — useful for per-user settings or multiple contexts.

--- a/docs/src/pages/components/SessionStorage.svx
+++ b/docs/src/pages/components/SessionStorage.svx
@@ -12,6 +12,17 @@ See how the component maintains state within a session. Toggle the switch and re
 
 <FileSource src="/framed/SessionStorage/SessionStorage" />
 
+## Persisting objects and arrays
+
+`value` can be any JSON-serializable value; objects and arrays are serialized with `JSON.stringify`. The component compares the serialized form to decide when to write, which has two consequences:
+
+- Reassigning `value` to a new object/array with **identical contents** does not trigger a redundant write.
+- **In-place mutations** (for example, `value.theme = "light"`) are persisted only when you signal the change to Svelte. Reassign the value (`value = { ...value, theme: "light" }`) or use the self-assignment idiom (`value = value`); a bare mutation alone will not re-render the component and therefore will not persist.
+
+In this example, the text inputs bind directly to nested properties and the button mutates the object in place. Edit a field and refresh the page to confirm the change is persisted within the session.
+
+<FileSource src="/framed/SessionStorage/SessionStorageObject" />
+
 ## Reactive key
 
 The `key` prop is also reactive, so you can dynamically switch between storage keys — useful for per-user settings or multiple contexts.

--- a/docs/src/pages/framed/LocalStorage/LocalStorageObject.svelte
+++ b/docs/src/pages/framed/LocalStorage/LocalStorageObject.svelte
@@ -1,0 +1,60 @@
+<script>
+  import {
+    Button,
+    LocalStorage,
+    Stack,
+    TextInput,
+  } from "carbon-components-svelte";
+
+  // A nested object value. Editing a nested field — either through a two-way
+  // binding or an explicit in-place mutation signalled with `value = value` —
+  // is persisted because the component compares the serialized form.
+  let settings = { profile: { name: "Ada", role: "Engineer" }, visits: 0 };
+  let events = [];
+</script>
+
+<Stack gap={6}>
+  <LocalStorage
+    key="local-storage-object-example"
+    bind:value={settings}
+    on:update={({ detail }) => {
+      events = [...events, { event: "on:update", detail }];
+    }}
+  />
+
+  <div>
+    Edit the nested fields below, then refresh the page to confirm the changes
+    survive. The two-way bindings mutate <code>settings</code> in place; the
+    component still persists them.
+  </div>
+
+  <TextInput
+    labelText="Name (binds to settings.profile.name)"
+    bind:value={settings.profile.name}
+  />
+
+  <TextInput
+    labelText="Role (binds to settings.profile.role)"
+    bind:value={settings.profile.role}
+  />
+
+  <Button
+    size="small"
+    on:click={() => {
+      settings.visits += 1; // in-place mutation
+      settings = settings; // signal the change to Svelte
+    }}
+  >
+    Increment visits ({settings.visits})
+  </Button>
+
+  <div>
+    <strong>Current value:</strong>
+    <pre>{JSON.stringify(settings, null, 2)}</pre>
+  </div>
+
+  <div>
+    <strong>Updates (note prevValue is a true snapshot):</strong>
+    <pre>{JSON.stringify(events, null, 2)}</pre>
+  </div>
+</Stack>

--- a/docs/src/pages/framed/SessionStorage/SessionStorageObject.svelte
+++ b/docs/src/pages/framed/SessionStorage/SessionStorageObject.svelte
@@ -1,0 +1,61 @@
+<script>
+  import {
+    Button,
+    SessionStorage,
+    Stack,
+    TextInput,
+  } from "carbon-components-svelte";
+
+  // A nested object value. Editing a nested field — either through a two-way
+  // binding or an explicit in-place mutation signalled with `value = value` —
+  // is persisted because the component compares the serialized form.
+  let settings = { profile: { name: "Ada", role: "Engineer" }, visits: 0 };
+  let events = [];
+</script>
+
+<Stack gap={6}>
+  <SessionStorage
+    key="session-storage-object-example"
+    bind:value={settings}
+    on:update={({ detail }) => {
+      events = [...events, { event: "on:update", detail }];
+    }}
+  />
+
+  <div>
+    Edit the nested fields below, then refresh the page to confirm the changes
+    survive within the session. The two-way bindings mutate
+    <code>settings</code>
+    in place; the component still persists them.
+  </div>
+
+  <TextInput
+    labelText="Name (binds to settings.profile.name)"
+    bind:value={settings.profile.name}
+  />
+
+  <TextInput
+    labelText="Role (binds to settings.profile.role)"
+    bind:value={settings.profile.role}
+  />
+
+  <Button
+    size="small"
+    on:click={() => {
+      settings.visits += 1; // in-place mutation
+      settings = settings; // signal the change to Svelte
+    }}
+  >
+    Increment visits ({settings.visits})
+  </Button>
+
+  <div>
+    <strong>Current value:</strong>
+    <pre>{JSON.stringify(settings, null, 2)}</pre>
+  </div>
+
+  <div>
+    <strong>Updates (note prevValue is a true snapshot):</strong>
+    <pre>{JSON.stringify(events, null, 2)}</pre>
+  </div>
+</Stack>

--- a/src/LocalStorage/LocalStorage.svelte
+++ b/src/LocalStorage/LocalStorage.svelte
@@ -62,13 +62,18 @@
   const dispatch = createEventDispatcher();
   const storage = safeBrowserStorage("localStorage");
 
-  let prevValue = value;
+  // Change detection compares the serialized form (what actually lands in
+  // storage) rather than the raw `value` reference. This persists in-place
+  // mutations signalled via the Svelte `value = value` idiom — a referential
+  // `prevValue !== value` check cannot, since `prevValue` would alias `value` —
+  // and skips redundant writes when a new reference serializes identically.
+  let prevSerialized = serializeStoredValue(value);
   let prevKey = key;
   let mounted = false;
 
-  /** @type {() => void} */
-  function setItem() {
-    storage.setItem(key, serializeStoredValue(value), (error) => {
+  /** @param {string} [serialized] */
+  function setItem(serialized = serializeStoredValue(value)) {
+    storage.setItem(key, serialized, (error) => {
       dispatch("error", { error });
     });
   }
@@ -83,14 +88,15 @@
       value = parseStoredValue(item);
     }
 
-    prevValue = value;
+    prevSerialized = serializeStoredValue(value);
     mounted = true;
 
     function handleStorageChange(event) {
       if (event.key === key && event.newValue !== null) {
+        const prevValue = parseStoredValue(prevSerialized);
         value = parseStoredValue(event.newValue);
         dispatch("update", { prevValue, value });
-        prevValue = value;
+        prevSerialized = event.newValue;
       }
     }
 
@@ -111,15 +117,17 @@
     }
 
     prevKey = key;
-    prevValue = value;
+    prevSerialized = serializeStoredValue(value);
   }
 
   afterUpdate(() => {
-    if (prevValue !== value) {
-      setItem();
-      dispatch("update", { prevValue, value });
-    }
+    const serialized = serializeStoredValue(value);
 
-    prevValue = value;
+    if (serialized !== prevSerialized) {
+      const prevValue = parseStoredValue(prevSerialized);
+      setItem(serialized);
+      dispatch("update", { prevValue, value });
+      prevSerialized = serialized;
+    }
   });
 </script>

--- a/src/SessionStorage/SessionStorage.svelte
+++ b/src/SessionStorage/SessionStorage.svelte
@@ -62,13 +62,18 @@
   const dispatch = createEventDispatcher();
   const storage = safeBrowserStorage("sessionStorage");
 
-  let prevValue = value;
+  // Change detection compares the serialized form (what actually lands in
+  // storage) rather than the raw `value` reference. This persists in-place
+  // mutations signalled via the Svelte `value = value` idiom — a referential
+  // `prevValue !== value` check cannot, since `prevValue` would alias `value` —
+  // and skips redundant writes when a new reference serializes identically.
+  let prevSerialized = serializeStoredValue(value);
   let prevKey = key;
   let mounted = false;
 
-  /** @type {() => void} */
-  function setItem() {
-    storage.setItem(key, serializeStoredValue(value), (error) => {
+  /** @param {string} [serialized] */
+  function setItem(serialized = serializeStoredValue(value)) {
+    storage.setItem(key, serialized, (error) => {
       dispatch("error", { error });
     });
   }
@@ -83,14 +88,15 @@
       value = parseStoredValue(item);
     }
 
-    prevValue = value;
+    prevSerialized = serializeStoredValue(value);
     mounted = true;
 
     function handleStorageChange(event) {
       if (event.key === key && event.newValue !== null) {
+        const prevValue = parseStoredValue(prevSerialized);
         value = parseStoredValue(event.newValue);
         dispatch("update", { prevValue, value });
-        prevValue = value;
+        prevSerialized = event.newValue;
       }
     }
 
@@ -111,15 +117,17 @@
     }
 
     prevKey = key;
-    prevValue = value;
+    prevSerialized = serializeStoredValue(value);
   }
 
   afterUpdate(() => {
-    if (prevValue !== value) {
-      setItem();
-      dispatch("update", { prevValue, value });
-    }
+    const serialized = serializeStoredValue(value);
 
-    prevValue = value;
+    if (serialized !== prevSerialized) {
+      const prevValue = parseStoredValue(prevSerialized);
+      setItem(serialized);
+      dispatch("update", { prevValue, value });
+      prevSerialized = serialized;
+    }
   });
 </script>

--- a/tests/LocalStorage/LocalStorageObject.test.ts
+++ b/tests/LocalStorage/LocalStorageObject.test.ts
@@ -51,4 +51,40 @@ describe("LocalStorage - Object Values", () => {
 
     expect(component.value).toEqual(existingSettings);
   });
+
+  // Change detection compares the serialized form, so an in-place mutation
+  // signalled via the Svelte `value = value` idiom is persisted. A referential
+  // `prevValue !== value` check could not detect this, because `prevValue`
+  // aliases `value` (same object reference) after each cycle.
+  it("persists an in-place mutation of an object value", async () => {
+    const { component } = render(LocalStorageObject);
+    await tick();
+
+    vi.mocked(localStorage.setItem).mockClear();
+
+    // Mutate in place, then self-assign to trigger Svelte reactivity.
+    component.value.theme = "light";
+    // biome-ignore lint/correctness/noSelfAssign: the `value = value` idiom is the behavior under test
+    component.value = component.value;
+    await tick();
+
+    expect(localStorage.setItem).toHaveBeenCalledWith(
+      "theme-settings",
+      JSON.stringify({ theme: "light", fontSize: 16 }),
+    );
+  });
+
+  // The inverse: reassigning to a new object with identical content serializes
+  // the same, so no redundant write is issued.
+  it("does not write when a new reference has identical content", async () => {
+    const { component } = render(LocalStorageObject);
+    await tick();
+
+    vi.mocked(localStorage.setItem).mockClear();
+
+    component.value = { ...component.value };
+    await tick();
+
+    expect(localStorage.setItem).not.toHaveBeenCalled();
+  });
 });

--- a/tests/SessionStorage/SessionStorageObject.test.ts
+++ b/tests/SessionStorage/SessionStorageObject.test.ts
@@ -51,4 +51,40 @@ describe("SessionStorage - Object Values", () => {
 
     expect(component.value).toEqual(existingSettings);
   });
+
+  // Change detection compares the serialized form, so an in-place mutation
+  // signalled via the Svelte `value = value` idiom is persisted. A referential
+  // `prevValue !== value` check could not detect this, because `prevValue`
+  // aliases `value` (same object reference) after each cycle.
+  it("persists an in-place mutation of an object value", async () => {
+    const { component } = render(SessionStorageObject);
+    await tick();
+
+    vi.mocked(sessionStorage.setItem).mockClear();
+
+    // Mutate in place, then self-assign to trigger Svelte reactivity.
+    component.value.theme = "light";
+    // biome-ignore lint/correctness/noSelfAssign: the `value = value` idiom is the behavior under test
+    component.value = component.value;
+    await tick();
+
+    expect(sessionStorage.setItem).toHaveBeenCalledWith(
+      "theme-settings",
+      JSON.stringify({ theme: "light", fontSize: 16 }),
+    );
+  });
+
+  // The inverse: reassigning to a new object with identical content serializes
+  // the same, so no redundant write is issued.
+  it("does not write when a new reference has identical content", async () => {
+    const { component } = render(SessionStorageObject);
+    await tick();
+
+    vi.mocked(sessionStorage.setItem).mockClear();
+
+    component.value = { ...component.value };
+    await tick();
+
+    expect(sessionStorage.setItem).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
`LocalStorage` and `SessionStorage` detected changes with a referential `prevValue !== value` check, but `prevValue = value` aliased the same object, so in-place object/array mutations, including two-way bindings to nested properties, were silently dropped.

Both components now compare the **serialized** form (what actually lands in storage), which persists mutations signalled via the `value = value` idiom, reconstructs a true `prevValue` snapshot for the `update` event, and skips redundant writes when a new reference serializes identically.

**Changes**

- Serialized-snapshot change detection in `src/LocalStorage/LocalStorage.svelte` and `src/SessionStorage/SessionStorage.svelte` (public API unchanged).
- Unit tests covering in-place-mutation-persists and identical-content-no-write for both components.
- Docs: a "Persisting objects and arrays" section plus a new framed example on each component page.