### PR TITLE
fix(expandable-tile): stop measurements clobbering bound props

### DIFF
--- a/src/Tile/ExpandableTile.svelte
+++ b/src/Tile/ExpandableTile.svelte
@@ -61,9 +61,17 @@
   let refAbove = null;
   let resizeObserver;
 
+  /**
+   * Internal, measured fallbacks. These are only used when the consumer has
+   * not explicitly set the corresponding public prop, so that `bind:` values
+   * used to *control* the layout are never clobbered by measurements.
+   */
+  let measuredMaxHeight = 0;
+  let measuredPadding = 0;
+
   onMount(() => {
     resizeObserver = new ResizeObserver(([elem]) => {
-      tileMaxHeight = elem.contentRect.height;
+      measuredMaxHeight = elem.contentRect.height;
     });
 
     return () => {
@@ -79,15 +87,15 @@
   afterUpdate(() => {
     if (!ref) return;
 
-    if (tileMaxHeight === 0 && refAbove) {
-      tileMaxHeight = refAbove.getBoundingClientRect().height;
+    if (measuredMaxHeight === 0 && refAbove) {
+      measuredMaxHeight = refAbove.getBoundingClientRect().height;
     }
 
     const style = getComputedStyle(ref);
 
-    tilePadding =
-      Number.parseInt(style.getPropertyValue("padding-top"), 10) +
-      Number.parseInt(style.getPropertyValue("padding-bottom"), 10);
+    measuredPadding =
+      (Number.parseInt(style.getPropertyValue("padding-top"), 10) || 0) +
+      (Number.parseInt(style.getPropertyValue("padding-bottom"), 10) || 0);
   });
 </script>
 
@@ -105,7 +113,7 @@
   class:bx--tile--expandable={true}
   class:bx--tile--is-expanded={expanded}
   class:bx--tile--light={light}
-  style:max-height={expanded || tileMaxHeight <= 0 ? "none" : `${tileMaxHeight + tilePadding}px`}
+  style:max-height={expanded || (tileMaxHeight > 0 ? tileMaxHeight : measuredMaxHeight) <= 0 ? "none" : `${(tileMaxHeight > 0 ? tileMaxHeight : measuredMaxHeight) + (tilePadding > 0 ? tilePadding : measuredPadding)}px`}
   {...$$restProps}
   on:click
   on:click={() => {

--- a/tests/ExpandableTile/ExpandableTile.test.ts
+++ b/tests/ExpandableTile/ExpandableTile.test.ts
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/svelte";
+import { tick } from "svelte";
 import { user } from "../utils/user";
 import ExpandableTile from "./ExpandableTile.test.svelte";
 import ExpandableTileCustom from "./ExpandableTileCustom.test.svelte";
@@ -193,7 +194,7 @@ describe("ExpandableTile", () => {
     });
 
     const tile = screen.getByRole("button");
-    expect(tile.getAttribute("style")).toBe("max-height: 200px;");
+    expect(tile.getAttribute("style")).toBe("max-height: 220px;");
 
     await user.click(tile);
     expect(tile.getAttribute("style")).toBe("max-height: none;");
@@ -209,6 +210,27 @@ describe("ExpandableTile", () => {
 
     const tile = screen.getByRole("button");
     expect(tile.getAttribute("style")).toBe("max-height: none;");
+  });
+
+  it("should not overwrite consumer-bound tilePadding after afterUpdate runs", async () => {
+    const { component } = render(ExpandableTileVariants, {
+      props: { tilePadding: 50, tileMaxHeight: 300 },
+    });
+
+    await tick();
+
+    expect(component.tilePadding).toBe(50);
+  });
+
+  it("should not overwrite consumer-bound tileMaxHeight after the ResizeObserver measures", async () => {
+    const { component } = render(ExpandableTileVariants, {
+      props: { tilePadding: 50, tileMaxHeight: 300 },
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await tick();
+
+    expect(component.tileMaxHeight).toBe(300);
   });
 
   it("should re-observe the above-the-fold element when hasInteractiveContent toggles", async () => {

--- a/tests/ExpandableTile/ExpandableTileVariants.test.svelte
+++ b/tests/ExpandableTile/ExpandableTileVariants.test.svelte
@@ -1,6 +1,16 @@
+<svelte:options accessors />
+
 <script lang="ts">
   import { ExpandableTile } from "carbon-components-svelte";
+
+  export let tileMaxHeight = 100;
+  export let tilePadding = 50;
 </script>
+
+<ExpandableTile data-testid="bound" bind:tileMaxHeight bind:tilePadding>
+  <div slot="above">Above bound</div>
+  <div slot="below">Below bound</div>
+</ExpandableTile>
 
 <!-- Basic expandable tile (no interactive content) -->
 <ExpandableTile data-testid="basic">


### PR DESCRIPTION
Similar to #3191

The `ResizeObserver` and `afterUpdate` wrote measured height/padding back into the exported `tileMaxHeight`/`tilePadding` props, clobbering any `bind:` value a consumer set to control the layout. These are now measured into internal fallbacks, so an explicitly set public prop always wins and is never overwritten. Includes regression tests for both props plus an NaN guard on the padding parse.