### PR TITLE
fix(overflow-menu): dispatch cancelable `close` before flipping `open`

### DIFF
--- a/docs/src/pages/components/OverflowMenu.svx
+++ b/docs/src/pages/components/OverflowMenu.svx
@@ -136,8 +136,14 @@ Set `disabled` to `true` to disable menu items. Use `hasDivider` to add visual s
   <OverflowMenuItem hasDivider danger text="Delete service" />
 </OverflowMenu>
 
-## Prevent menu from closing
+## Prevent an item from closing the menu
 
-Use `preventDefault()` on individual overflow menu item click events to prevent the menu from closing when that item is clicked. Use this to keep the menu open after performing an action.
+Use `e.preventDefault()` on an individual overflow menu item click event to prevent the menu from closing when that item is clicked. Use this to keep the menu open after performing an action.
 
 <FileSource src="/framed/OverflowMenu/OverflowMenuPreventDefault" />
+
+## Cancel the close event
+
+The `close` event is cancelable. Call `e.preventDefault()` on it to keep the menu open when it would otherwise close from the trigger, the `Escape` key, or an outside click. The example below guards against accidentally dismissing unsaved changes: toggle a setting, then try to close the menu without saving.
+
+<FileSource src="/framed/OverflowMenu/OverflowMenuCancelableClose" />

--- a/docs/src/pages/framed/OverflowMenu/OverflowMenuCancelableClose.svelte
+++ b/docs/src/pages/framed/OverflowMenu/OverflowMenuCancelableClose.svelte
@@ -1,0 +1,42 @@
+<script>
+  import { OverflowMenu, OverflowMenuItem } from "carbon-components-svelte";
+
+  let emailEnabled = false;
+  let smsEnabled = false;
+  let saved = true;
+
+  function toggle(setter) {
+    return (e) => {
+      // Keep the menu open while editing settings.
+      e.preventDefault();
+      setter();
+      saved = false;
+    };
+  }
+</script>
+
+<OverflowMenu
+  on:close={(e) => {
+    // Guard against accidentally dismissing unsaved changes.
+    if (!saved && !window.confirm("Discard unsaved notification settings?")) {
+      e.preventDefault();
+    }
+  }}
+>
+  <OverflowMenuItem
+    text="Email alerts: {emailEnabled ? 'On' : 'Off'}"
+    on:click={toggle(() => (emailEnabled = !emailEnabled))}
+  />
+  <OverflowMenuItem
+    text="SMS alerts: {smsEnabled ? 'On' : 'Off'}"
+    on:click={toggle(() => (smsEnabled = !smsEnabled))}
+  />
+  <OverflowMenuItem
+    hasDivider
+    text="Save changes"
+    on:click={() => {
+      // Allow the menu to close after saving.
+      saved = true;
+    }}
+  />
+</OverflowMenu>

--- a/src/OverflowMenu/OverflowMenu.svelte
+++ b/src/OverflowMenu/OverflowMenu.svelte
@@ -277,11 +277,14 @@
   class:bx--overflow-menu--xl={size === "xl"}
   {...$$restProps}
   on:click
-  on:click={() => {
-    open = !open;
-    if (!open) {
-      const shouldContinue = dispatch("close", null, { cancelable: true });
-      if (!shouldContinue) {
+  on:click={({ target }) => {
+    if (!menuRef?.contains(target)) {
+      if (open) {
+        const shouldContinue = dispatch("close", null, { cancelable: true });
+        if (shouldContinue) {
+          open = false;
+        }
+      } else {
         open = true;
       }
     }

--- a/tests/OverflowMenu/OverflowMenu.test.ts
+++ b/tests/OverflowMenu/OverflowMenu.test.ts
@@ -10,6 +10,7 @@ import OverflowMenuDynamicItems from "./OverflowMenu.dynamicItems.test.svelte";
 import OverflowMenuPreventDefault from "./OverflowMenu.preventDefault.test.svelte";
 import OverflowMenuRel from "./OverflowMenu.rel.test.svelte";
 import OverflowMenu from "./OverflowMenu.test.svelte";
+import OverflowMenuTriggerClose from "./OverflowMenu.triggerClose.test.svelte";
 import OverflowMenuInModal from "./OverflowMenuInModal.test.svelte";
 
 describe("OverflowMenu", () => {
@@ -524,6 +525,24 @@ describe("OverflowMenu", () => {
       text: "API documentation",
     });
     expect(menuButton).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("dispatches close before flipping `open` when trigger click closes the menu", async () => {
+    const spy = vi.spyOn(console, "log");
+    render(OverflowMenuTriggerClose);
+
+    const menuButton = screen.getByRole("button");
+    await user.click(menuButton);
+    expect(menuButton).toHaveAttribute("aria-expanded", "true");
+
+    spy.mockClear();
+    await user.click(menuButton);
+    expect(menuButton).toHaveAttribute("aria-expanded", "false");
+
+    // The `close` event must be dispatched while `open` is still `true`
+    // so listeners can preventDefault before any subscriber observes the
+    // transition.
+    expect(spy).toHaveBeenCalledWith("close:open-at-dispatch", true);
   });
 
   it("closes menu normally when preventDefault is not called", async () => {

--- a/tests/OverflowMenu/OverflowMenu.triggerClose.test.svelte
+++ b/tests/OverflowMenu/OverflowMenu.triggerClose.test.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import { OverflowMenu, OverflowMenuItem } from "carbon-components-svelte";
+
+  export let cancelClose = false;
+
+  let open = false;
+</script>
+
+<OverflowMenu
+  bind:open
+  on:close={(e) => {
+    console.log("close:open-at-dispatch", open);
+    if (cancelClose) {
+      e.preventDefault();
+    }
+  }}
+>
+  <OverflowMenuItem text="Manage credentials" />
+  <OverflowMenuItem text="API documentation" />
+  <OverflowMenuItem danger text="Delete service" />
+</OverflowMenu>


### PR DESCRIPTION
The `close` event on `OverflowMenu` is cancelable.

However, when the user clicks the trigger to close an open menu, the close event is dispatched after open has already been flipped to false. Listeners observe open=false at dispatch time instead of the pre-close true state.

This adds an example to differentiate from the "prevent item closing the menu."