### PR TITLE
docs(expandable-tile): add "Reactive (two-way binding)" example

### DIFF
--- a/docs/src/pages/components/ExpandableTile.svx
+++ b/docs/src/pages/components/ExpandableTile.svx
@@ -29,6 +29,14 @@ content that appears before and after expansion.
   <div slot="below">Below the fold content here</div>
 </ExpandableTile>
 
+## Reactive (two-way binding)
+
+Bind to the `expanded` prop to control and read the tile state outside the component.
+Grow the above-the-fold content while collapsed to see the resize observer remeasure
+and update the tile height.
+
+<FileSource src="/framed/ExpandableTile/ExpandableTileReactive" />
+
 ## Custom tile heights
 
 Set custom heights for the tile content using CSS to control the exact dimensions

--- a/docs/src/pages/framed/ExpandableTile/ExpandableTileReactive.svelte
+++ b/docs/src/pages/framed/ExpandableTile/ExpandableTileReactive.svelte
@@ -1,0 +1,35 @@
+<script>
+  import {
+    Button,
+    ButtonSet,
+    ExpandableTile,
+    Stack,
+  } from "carbon-components-svelte";
+
+  let expanded = false;
+  let grow = false;
+</script>
+
+<Stack gap={5}>
+  <ButtonSet>
+    <Button size="small" on:click={() => (expanded = !expanded)}>
+      {expanded ? "Collapse" : "Expand"}
+      tile
+    </Button>
+    <Button size="small" kind="secondary" on:click={() => (grow = !grow)}>
+      {grow ? "Shrink" : "Grow"}
+      content
+    </Button>
+  </ButtonSet>
+  <div>Expanded: <strong>{expanded}</strong></div>
+  <ExpandableTile bind:expanded>
+    <div slot="above">
+      <div>Above the fold content here</div>
+      {#if grow}
+        <div>Extra line added dynamically.</div>
+        <div>The resize observer remeasures the collapsed height.</div>
+      {/if}
+    </div>
+    <div slot="below">Below the fold content here</div>
+  </ExpandableTile>
+</Stack>


### PR DESCRIPTION
Add a more realistic example for expandable tile (two-way binding).

This also simulates growing/shrinking content in the tile, for which [#3180](https://github.com/carbon-design-system/carbon-components-svelte/issues/3180) fixed.