### PR TITLE
feat(file-uploader-skeleton): add `hideLabelTitle` and `hideLabelDescription` props

### DIFF
--- a/docs/src/pages/components/FileUploader.svx
+++ b/docs/src/pages/components/FileUploader.svx
@@ -240,3 +240,11 @@ console.
 Display a loading state using the file uploader skeleton.
 
 <FileUploaderSkeleton />
+
+## Skeleton without labels
+
+Set `hideLabelTitle` or `hideLabelDescription` to hide the corresponding
+skeleton line. This is useful when the live component is configured without
+those labels, preventing layout shift when toggling between the two.
+
+<FileUploaderSkeleton hideLabelTitle hideLabelDescription />

--- a/src/FileUploader/FileUploaderSkeleton.svelte
+++ b/src/FileUploader/FileUploaderSkeleton.svelte
@@ -1,6 +1,12 @@
 <script>
   import ButtonSkeleton from "../Button/ButtonSkeleton.svelte";
   import SkeletonText from "../SkeletonText/SkeletonText.svelte";
+
+  /** Set to `true` to hide the label title skeleton line */
+  export let hideLabelTitle = false;
+
+  /** Set to `true` to hide the label description skeleton line */
+  export let hideLabelDescription = false;
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
@@ -13,7 +19,11 @@
   on:mouseenter
   on:mouseleave
 >
-  <SkeletonText heading width="100px" />
-  <SkeletonText width="225px" class="bx--label-description" />
+  {#if !hideLabelTitle}
+    <SkeletonText heading width="100px" />
+  {/if}
+  {#if !hideLabelDescription}
+    <SkeletonText width="225px" class="bx--label-description" />
+  {/if}
   <ButtonSkeleton />
 </div>


### PR DESCRIPTION
Add the ability to hide the label title/description for the file uploader skeleton (button).