### PR TITLE
ci(e2e): speed up e2e tests

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -122,10 +122,14 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       # Playwright image is minimal; setup-bun extracts a zip and needs unzip.
-      - run: apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y unzip
+      # Try installing first (fast path) and only refresh apt lists if needed.
+      - run: DEBIAN_FRONTEND=noninteractive apt-get install -y unzip || { apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y unzip; }
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-      - run: bun ci
+      # --ignore-scripts skips the ibmtelemetry postinstall (already disabled
+      # via IBM_TELEMETRY_DISABLED) and Playwright's browser download (browsers
+      # are baked into the image at PLAYWRIGHT_BROWSERS_PATH).
+      - run: bun ci --ignore-scripts
 
       - name: E2E tests
         run: bunx playwright test --project=chromium

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -523,6 +523,25 @@ bunx playwright test e2e/breakpoint.test.ts
 bunx playwright test --grep "Breakpoint"
 ```
 
+#### How fixtures are served (local vs CI)
+
+The fixtures are a Vite multi-page app, one `.html` entry per fixture. How they are served depends on the environment, controlled by the `CI` env var in `playwright.config.ts`:
+
+- **Locally**: Playwright starts the Vite **dev server**. It transforms modules on demand, so there is no build step and edits show up immediately.
+- **In CI**: Playwright runs `vite build` once and serves the static output with `vite preview`. Bundled assets load faster and with less run-to-run variance than the dev server, which transforms unbundled modules on demand through a single process that competes with the browser workers for CPU.
+
+Neither path needs a manual build. To reproduce the CI build locally, for example to debug a build-only failure, build the fixtures once:
+
+```sh
+bunx vite build --config e2e/vite.config.ts
+```
+
+The output lands in `e2e/fixtures/dist/` (gitignored). Serve it with `bunx vite preview --config e2e/vite.config.ts`, or run the whole CI path in one command:
+
+```sh
+CI=true bunx playwright test --project=chromium
+```
+
 To add a new E2E test, copy the Breakpoint example. Create these files:
 
 | File                                     | Purpose                                                                                                          |

--- a/e2e/vite.config.ts
+++ b/e2e/vite.config.ts
@@ -1,13 +1,29 @@
+import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { svelte, vitePreprocess } from "@sveltejs/vite-plugin-svelte";
 import { defineConfig } from "vite";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const fixtures = path.resolve(__dirname, "fixtures");
+
+// Every fixture .html is its own entry point so `vite build` emits the full
+// multi-page app. The dev server discovers these automatically, but the
+// production build needs them listed explicitly.
+const input = Object.fromEntries(
+  fs
+    .readdirSync(fixtures)
+    .filter((file) => file.endsWith(".html"))
+    .map((file) => [
+      file.slice(0, -".html".length),
+      path.resolve(fixtures, file),
+    ]),
+);
 
 export default defineConfig({
-  root: path.resolve(__dirname, "fixtures"),
+  root: fixtures,
   plugins: [svelte({ preprocess: [vitePreprocess()] })],
+  build: { rollupOptions: { input } },
   resolve: {
     alias: [
       {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -3,7 +3,7 @@ import { defineConfig, devices } from "@playwright/test";
 export default defineConfig({
   testDir: "./e2e",
   fullyParallel: true,
-  workers: process.env.CI ? 3 : undefined,
+  workers: process.env.CI ? 4 : undefined,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   reporter: process.env.CI ? [["list"], ["github"]] : "list",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -18,7 +18,13 @@ export default defineConfig({
         { name: "webkit", use: { ...devices["Desktop Safari"] } },
       ],
   webServer: {
-    command: "bunx vite --config e2e/vite.config.ts --port 4173",
+    // In CI, serve a production build via `vite preview`: bundled static assets
+    // load far faster and with less variance than the dev server, which
+    // transforms modules on demand through a single process. Locally, keep the
+    // dev server for fast iteration (HMR, no build step).
+    command: process.env.CI
+      ? "bunx vite build --config e2e/vite.config.ts && bunx vite preview --config e2e/vite.config.ts --port 4173 --strictPort"
+      : "bunx vite --config e2e/vite.config.ts --port 4173",
     port: 4173,
     reuseExistingServer: !process.env.CI,
   },


### PR DESCRIPTION
e2e job in CI is expensive. This optimizes it to drastically reduce the wall clock time for a full run.

The trick is to build the Vite entries used by Playwright, instead of dynamically running them per test suite.

---

## Before

<img width="978" height="570" alt="Screenshot 2026-06-07 at 8 39 26 PM" src="https://github.com/user-attachments/assets/a55e2e17-7eda-4fc0-9b8d-2a89992ebf73" />

## After

<img width="993" height="610" alt="Screenshot 2026-06-07 at 8 39 35 PM" src="https://github.com/user-attachments/assets/f5f2225f-160e-4b4b-99e3-453776cf8e84" />
