### PR TITLE
fix(content-switcher): skip disabled switches during keyboard navigation

### DIFF
--- a/src/ContentSwitcher/ContentSwitcher.svelte
+++ b/src/ContentSwitcher/ContentSwitcher.svelte
@@ -31,7 +31,7 @@
 
   import { afterUpdate, createEventDispatcher, setContext, tick } from "svelte";
   import { writable } from "svelte/store";
-  import { moveIndex } from "../utils/moveIndex.js";
+  import { nextEnabledIndex } from "../utils/moveIndex.js";
   import { syncDomOrder } from "../utils/syncDomOrder.js";
 
   const dispatch = createEventDispatcher();
@@ -58,9 +58,9 @@
   }
 
   /**
-   * @type {(data: { id: string; text: string; selected: boolean }) => void}
+   * @type {(data: { id: string; text: string; selected: boolean; disabled?: boolean }) => void}
    */
-  const add = ({ id, text, selected }) => {
+  const add = ({ id, text, selected, disabled = false }) => {
     if (switches.some((s) => s.id === id)) {
       return;
     }
@@ -70,7 +70,21 @@
     }
 
     needsDomSync = true;
-    switches = [...switches, { id, text, selected }];
+    switches = [...switches, { id, text, selected, disabled }];
+  };
+
+  /**
+   * Keep a switch's disabled state in sync so keyboard navigation skips it.
+   * @type {(id: string, disabled: boolean) => void}
+   */
+  const setDisabled = (id, disabled) => {
+    const index = switches.findIndex((s) => s.id === id);
+    if (index === -1 || switches[index].disabled === disabled) {
+      return;
+    }
+
+    switches[index] = { ...switches[index], disabled };
+    switches = switches;
   };
 
   /**
@@ -92,6 +106,7 @@
    * @type {(index: number) => Promise<void>}
    */
   const changeTo = async (index) => {
+    if (index < 0 || index >= switches.length) return;
     selectedIndex = index;
 
     await tick();
@@ -106,7 +121,13 @@
    * @type {(direction: number) => Promise<void>}
    */
   const change = async (direction) => {
-    await changeTo(moveIndex(currentIndex, direction, switches.length));
+    await changeTo(
+      nextEnabledIndex({
+        items: switches,
+        index: currentIndex,
+        step: direction,
+      }),
+    );
   };
 
   /**
@@ -114,6 +135,7 @@
    * @type {(index: number) => Promise<void>}
    */
   const focusTo = async (index) => {
+    if (index < 0 || index >= switches.length) return;
     focusedIndex = index;
 
     await tick();
@@ -130,7 +152,20 @@
    */
   const focus = async (direction) => {
     const base = focusedIndex >= 0 ? focusedIndex : currentIndex;
-    await focusTo(moveIndex(base, direction, switches.length));
+    await focusTo(
+      nextEnabledIndex({ items: switches, index: base, step: direction }),
+    );
+  };
+
+  /**
+   * Resolve the first or last enabled switch index for Home/End. Returns -1
+   * when every switch is disabled.
+   * @type {(edge: "first" | "last") => number}
+   */
+  const edgeEnabledIndex = (edge) => {
+    const start = edge === "first" ? -1 : switches.length;
+    const step = edge === "first" ? 1 : -1;
+    return nextEnabledIndex({ items: switches, index: start, step });
   };
 
   setContext("carbon:ContentSwitcher", {
@@ -138,10 +173,12 @@
     add,
     remove,
     update,
+    setDisabled,
     change,
     changeTo,
     focus,
     focusTo,
+    edgeEnabledIndex,
     get switchCount() {
       return switches.length;
     },

--- a/src/ContentSwitcher/Switch.svelte
+++ b/src/ContentSwitcher/Switch.svelte
@@ -33,7 +33,11 @@
 
   const ctx = getContext("carbon:ContentSwitcher");
 
-  ctx.add({ id, text, selected });
+  ctx.add({ id, text, selected, disabled });
+
+  // Keep the parent registry in sync when `disabled` changes reactively so
+  // keyboard navigation continues to skip the correct switches.
+  $: ctx.setDisabled?.(id, disabled);
 
   const unsubscribe = ctx.currentId.subscribe((currentId) => {
     selected = currentId === id;
@@ -77,10 +81,11 @@
       ctx.selectionMode === "manual" ? ctx.focus(-1) : ctx.change(-1);
     } else if (event.key === "Home") {
       event.preventDefault();
-      ctx.selectionMode === "manual" ? ctx.focusTo(0) : ctx.changeTo(0);
+      const first = ctx.edgeEnabledIndex("first");
+      ctx.selectionMode === "manual" ? ctx.focusTo(first) : ctx.changeTo(first);
     } else if (event.key === "End") {
       event.preventDefault();
-      const last = ctx.switchCount - 1;
+      const last = ctx.edgeEnabledIndex("last");
       ctx.selectionMode === "manual" ? ctx.focusTo(last) : ctx.changeTo(last);
     }
   }}

--- a/tests/ContentSwitcher/ContentSwitcher.disabledNav.test.svelte
+++ b/tests/ContentSwitcher/ContentSwitcher.disabledNav.test.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+  import { ContentSwitcher, Switch } from "carbon-components-svelte";
+  import type { ComponentProps } from "svelte";
+
+  export let selectionMode: ComponentProps<ContentSwitcher>["selectionMode"] =
+    "automatic";
+</script>
+
+<ContentSwitcher {selectionMode}>
+  <Switch text="A" />
+  <Switch text="B" disabled />
+  <Switch text="C" />
+  <Switch text="D" disabled />
+</ContentSwitcher>

--- a/tests/ContentSwitcher/ContentSwitcher.test.ts
+++ b/tests/ContentSwitcher/ContentSwitcher.test.ts
@@ -2,6 +2,7 @@ import { render, screen, within } from "@testing-library/svelte";
 import { user } from "../utils/user";
 import ContentSwitcherCustom from "./ContentSwitcher.custom.test.svelte";
 import ContentSwitcherDisabled from "./ContentSwitcher.disabled.test.svelte";
+import ContentSwitcherDisabledNav from "./ContentSwitcher.disabledNav.test.svelte";
 import ContentSwitcherDynamic from "./ContentSwitcher.dynamic.test.svelte";
 import ContentSwitcherNested from "./ContentSwitcher.nested.test.svelte";
 import ContentSwitcherSelectedIndex from "./ContentSwitcher.selectedIndex.test.svelte";
@@ -221,6 +222,106 @@ describe("ContentSwitcher", () => {
     await user.click(tabs[2]);
     expect(tabs[0]).not.toHaveClass("bx--content-switcher--selected");
     expect(tabs[2]).toHaveClass("bx--content-switcher--selected");
+  });
+
+  describe("skips disabled switches during keyboard navigation", () => {
+    // Fixture order: A (enabled), B (disabled), C (enabled), D (disabled)
+    it("ArrowRight skips a disabled switch (automatic)", async () => {
+      render(ContentSwitcherDisabledNav);
+
+      const tabs = screen.getAllByRole("tab");
+      await user.tab();
+      expect(document.activeElement).toBe(tabs[0]);
+
+      // A -> (skip B) -> C
+      await user.keyboard("{ArrowRight}");
+      expect(document.activeElement).toBe(tabs[2]);
+      expect(tabs[2]).toHaveClass("bx--content-switcher--selected");
+      expect(tabs[1]).not.toHaveClass("bx--content-switcher--selected");
+    });
+
+    it("ArrowRight wraps past a trailing disabled switch (automatic)", async () => {
+      render(ContentSwitcherDisabledNav);
+
+      const tabs = screen.getAllByRole("tab");
+      await user.tab();
+      await user.keyboard("{ArrowRight}");
+      expect(document.activeElement).toBe(tabs[2]);
+
+      // C -> (skip D, wrap) -> A
+      await user.keyboard("{ArrowRight}");
+      expect(document.activeElement).toBe(tabs[0]);
+      expect(tabs[0]).toHaveClass("bx--content-switcher--selected");
+    });
+
+    it("ArrowLeft skips a disabled switch (automatic)", async () => {
+      render(ContentSwitcherDisabledNav);
+
+      const tabs = screen.getAllByRole("tab");
+      await user.tab();
+      expect(document.activeElement).toBe(tabs[0]);
+
+      // A -> (skip D, skip nothing) wraps left past D to C
+      await user.keyboard("{ArrowLeft}");
+      expect(document.activeElement).toBe(tabs[2]);
+      expect(tabs[2]).toHaveClass("bx--content-switcher--selected");
+    });
+
+    it("End lands on the last enabled switch (automatic)", async () => {
+      render(ContentSwitcherDisabledNav);
+
+      const tabs = screen.getAllByRole("tab");
+      await user.tab();
+
+      // D (last) is disabled, so End should land on C
+      await user.keyboard("{End}");
+      expect(document.activeElement).toBe(tabs[2]);
+      expect(tabs[2]).toHaveClass("bx--content-switcher--selected");
+      expect(tabs[3]).not.toHaveClass("bx--content-switcher--selected");
+    });
+
+    it("Home lands on the first enabled switch (automatic)", async () => {
+      render(ContentSwitcherDisabledNav);
+
+      const tabs = screen.getAllByRole("tab");
+      await user.tab();
+      await user.keyboard("{End}");
+      expect(document.activeElement).toBe(tabs[2]);
+
+      // A (first) is enabled, so Home should land on A
+      await user.keyboard("{Home}");
+      expect(document.activeElement).toBe(tabs[0]);
+      expect(tabs[0]).toHaveClass("bx--content-switcher--selected");
+    });
+
+    it("ArrowRight moves focus past a disabled switch without selecting it (manual)", async () => {
+      render(ContentSwitcherDisabledNav, {
+        props: { selectionMode: "manual" },
+      });
+
+      const tabs = screen.getAllByRole("tab");
+      await user.tab();
+      expect(document.activeElement).toBe(tabs[0]);
+
+      // Focus moves A -> (skip B) -> C; selection stays on A
+      await user.keyboard("{ArrowRight}");
+      expect(document.activeElement).toBe(tabs[2]);
+      expect(tabs[0]).toHaveClass("bx--content-switcher--selected");
+      expect(tabs[2]).not.toHaveClass("bx--content-switcher--selected");
+    });
+
+    it("End moves focus to the last enabled switch (manual)", async () => {
+      render(ContentSwitcherDisabledNav, {
+        props: { selectionMode: "manual" },
+      });
+
+      const tabs = screen.getAllByRole("tab");
+      await user.tab();
+
+      await user.keyboard("{End}");
+      expect(document.activeElement).toBe(tabs[2]);
+      expect(tabs[0]).toHaveClass("bx--content-switcher--selected");
+    });
   });
 
   it("renders custom content", () => {


### PR DESCRIPTION
Arrow/Home/End nav stepped onto disabled switches because the parent registry never tracked `disabled`. Now propagated via `ctx.add`/`setDisabled` and resolved with `nextEnabledIndex`, matching Tabs/Dropdown/ComboBox behavior.