### PR TITLE
refactor(dropdown): use `typeahead` util

### DIFF
--- a/src/Dropdown/Dropdown.svelte
+++ b/src/Dropdown/Dropdown.svelte
@@ -170,6 +170,7 @@
   import { debounce } from "../utils/debounce.js";
   import { isOutsideClick } from "../utils/isOutsideClick.js";
   import { nextEnabledIndex } from "../utils/moveIndex.js";
+  import { typeaheadIndex } from "../utils/typeahead.js";
   import {
     resetVirtualScrollOnClose,
     scrollHighlightedIntoView,
@@ -351,25 +352,12 @@
     typeaheadBuffer += character.toLowerCase();
     resetTypeaheadBuffer();
 
-    // Start search from the next index after current highlight, or from 0 if none highlighted.
-    const startIndex = highlightedIndex >= 0 ? highlightedIndex + 1 : 0;
-
-    for (let index = startIndex; index < items.length; index++) {
-      const itemText = itemToString(items[index]).toLowerCase();
-      if (itemText.startsWith(typeaheadBuffer) && !items[index].disabled) {
-        highlightedIndex = index;
-        return;
-      }
-    }
-
-    // Wrap around: search from beginning to startIndex.
-    for (let index = 0; index < startIndex; index++) {
-      const itemText = itemToString(items[index]).toLowerCase();
-      if (itemText.startsWith(typeaheadBuffer) && !items[index].disabled) {
-        highlightedIndex = index;
-        return;
-      }
-    }
+    highlightedIndex = typeaheadIndex({
+      items,
+      query: typeaheadBuffer,
+      itemToString,
+      index: highlightedIndex,
+    });
   }
 
   function dispatchSelect() {

--- a/src/utils/typeahead.d.ts
+++ b/src/utils/typeahead.d.ts
@@ -1,0 +1,13 @@
+/**
+ * Typeahead matching for listbox keyboard navigation.
+ */
+
+/** Next enabled item whose text starts with `query`, or `index` if none. */
+export function typeaheadIndex<T>(options: {
+  items: ReadonlyArray<T>;
+  query: string;
+  itemToString: (item: T) => string;
+  index: number;
+  /** @default item => item.disabled */
+  isDisabled?: (item: T) => boolean;
+}): number;

--- a/src/utils/typeahead.js
+++ b/src/utils/typeahead.js
@@ -1,0 +1,37 @@
+// @ts-check
+
+/**
+ * Next enabled item whose text starts with `query`, searching forward from
+ * `index` and wrapping once. Returns `index` if nothing matches.
+ *
+ * @template T
+ * @param {object} options
+ * @param {ReadonlyArray<T>} options.items
+ * @param {string} options.query
+ * @param {(item: T) => string} options.itemToString
+ * @param {number} options.index - May be -1 when nothing is highlighted.
+ * @param {(item: T) => boolean} [options.isDisabled] - Defaults to `item.disabled`.
+ * @returns {number}
+ */
+export function typeaheadIndex({
+  items,
+  query,
+  itemToString,
+  index,
+  isDisabled,
+}) {
+  if (items.length === 0 || query === "") return index;
+  const disabled = isDisabled ?? ((item) => Boolean(item?.disabled));
+  const needle = query.toLowerCase();
+  const start = index >= 0 ? index + 1 : 0;
+  for (let offset = 0; offset < items.length; offset++) {
+    const i = (start + offset) % items.length;
+    if (
+      !disabled(items[i]) &&
+      itemToString(items[i]).toLowerCase().startsWith(needle)
+    ) {
+      return i;
+    }
+  }
+  return index;
+}

--- a/tests/utils/typeahead.test.ts
+++ b/tests/utils/typeahead.test.ts
@@ -1,0 +1,84 @@
+import { typeaheadIndex } from "../../src/utils/typeahead.js";
+
+describe("typeaheadIndex", () => {
+  const fruits = ["Apple", "Apricot", "Banana", "Cherry"].map((text, id) => ({
+    id,
+    text,
+    disabled: false,
+  }));
+  const itemToString = (item: { text: string }) => item.text;
+
+  test("finds the next prefix match after the current index", () => {
+    expect(
+      typeaheadIndex({ items: fruits, query: "a", itemToString, index: 0 }),
+    ).toBe(1);
+  });
+
+  test("finds a match from the start when index is -1", () => {
+    expect(
+      typeaheadIndex({ items: fruits, query: "b", itemToString, index: -1 }),
+    ).toBe(2);
+  });
+
+  test("wraps to the first prefix match after the end", () => {
+    expect(
+      typeaheadIndex({ items: fruits, query: "a", itemToString, index: 3 }),
+    ).toBe(0);
+  });
+
+  test("matches a multi-character prefix", () => {
+    expect(
+      typeaheadIndex({ items: fruits, query: "apr", itemToString, index: -1 }),
+    ).toBe(1);
+  });
+
+  test("is case-insensitive", () => {
+    expect(
+      typeaheadIndex({ items: fruits, query: "B", itemToString, index: -1 }),
+    ).toBe(2);
+  });
+
+  test("skips disabled items", () => {
+    const items = [
+      { text: "Banana", disabled: true },
+      { text: "Blueberry", disabled: false },
+    ];
+    expect(typeaheadIndex({ items, query: "b", itemToString, index: -1 })).toBe(
+      1,
+    );
+  });
+
+  test("returns the original index when nothing matches", () => {
+    expect(
+      typeaheadIndex({ items: fruits, query: "z", itemToString, index: 2 }),
+    ).toBe(2);
+  });
+
+  test("returns the original index for an empty query", () => {
+    expect(
+      typeaheadIndex({ items: fruits, query: "", itemToString, index: 1 }),
+    ).toBe(1);
+  });
+
+  test("returns the original index for empty items", () => {
+    expect(
+      typeaheadIndex({ items: [], query: "a", itemToString, index: -1 }),
+    ).toBe(-1);
+  });
+
+  test("supports a custom isDisabled predicate", () => {
+    const items = [
+      { label: "Alpha", ok: false },
+      { label: "Apex", ok: true },
+    ];
+    expect(
+      typeaheadIndex({
+        items,
+        query: "a",
+        itemToString: (item) => item.label,
+        index: -1,
+        isDisabled: (item) => !item.ok,
+      }),
+    ).toBe(1);
+  });
+});


### PR DESCRIPTION
Extract the typeahead-highlight util for easier testing and reuse.