### PR TITLE
test: add baseline coverage for `afterUpdate` migrations

### DIFF
--- a/tests/ComposedModal/ComposedModal.test.ts
+++ b/tests/ComposedModal/ComposedModal.test.ts
@@ -71,6 +71,23 @@ describe("ComposedModal", () => {
     expect(closeHandler).toHaveBeenCalledTimes(1);
   });
 
+  it("does not dispatch open or close when mounted closed", async () => {
+    const openHandler = vi.fn();
+    const closeHandler = vi.fn();
+    render(ComposedModalTest, {
+      props: {
+        open: false,
+        headerTitle: "Test Modal",
+        onopen: openHandler,
+        onclose: closeHandler,
+      },
+    });
+
+    await tick();
+    expect(openHandler).not.toHaveBeenCalled();
+    expect(closeHandler).not.toHaveBeenCalled();
+  });
+
   it("should handle size variants", () => {
     const sizes = ["xs", "sm", "lg"] as const;
 

--- a/tests/FileUploader/FileUploader.test.ts
+++ b/tests/FileUploader/FileUploader.test.ts
@@ -314,6 +314,26 @@ describe("FileUploader", () => {
     expect(event.detail[1].name).toBe("file2.txt");
   });
 
+  it("dispatches add when files are set programmatically via two-way binding", async () => {
+    const addHandler = vi.fn();
+    const { component } = render(FileUploader, {
+      props: { onAdd: addHandler, multiple: true },
+    });
+
+    const file1 = new File(["content1"], "file1.txt", { type: "text/plain" });
+    const file2 = new File(["content2"], "file2.txt", { type: "text/plain" });
+    component.files = [file1, file2];
+
+    await vi.waitFor(() => {
+      expect(addHandler).toHaveBeenCalled();
+    });
+
+    const added = addHandler.mock.calls[0][0].detail;
+    expect(added).toHaveLength(2);
+    expect(added[0].name).toBe("file1.txt");
+    expect(added[1].name).toBe("file2.txt");
+  });
+
   it("should dispatch change event when files change", async () => {
     const changeHandler = vi.fn();
     const { component } = render(FileUploader, {

--- a/tests/InlineLoading/InlineLoading.test.ts
+++ b/tests/InlineLoading/InlineLoading.test.ts
@@ -1,6 +1,8 @@
 import { render, screen } from "@testing-library/svelte";
+import { tick } from "svelte";
 import InlineLoading from "./InlineLoading.test.svelte";
 import InlineLoadingRerender from "./InlineLoadingRerender.test.svelte";
+import InlineLoadingTransition from "./InlineLoadingTransition.test.svelte";
 
 describe("InlineLoading", () => {
   beforeEach(() => {
@@ -110,6 +112,23 @@ describe("InlineLoading", () => {
     rerender({ tick: 2 });
 
     vi.advanceTimersByTime(1500);
+    expect(consoleLog).toHaveBeenCalledTimes(1);
+    expect(consoleLog).toHaveBeenCalledWith("success");
+  });
+
+  it("dispatches success when status transitions to finished after mount", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    const { component } = render(InlineLoadingTransition, {
+      props: { status: "active" },
+    });
+
+    vi.advanceTimersByTime(1500);
+    expect(consoleLog).not.toHaveBeenCalled();
+
+    component.status = "finished";
+    await tick();
+    vi.advanceTimersByTime(1500);
+
     expect(consoleLog).toHaveBeenCalledTimes(1);
     expect(consoleLog).toHaveBeenCalledWith("success");
   });

--- a/tests/InlineLoading/InlineLoadingTransition.test.svelte
+++ b/tests/InlineLoading/InlineLoadingTransition.test.svelte
@@ -1,0 +1,15 @@
+<svelte:options accessors />
+
+<script lang="ts">
+  import { InlineLoading } from "carbon-components-svelte";
+
+  export let status: "active" | "finished" = "active";
+</script>
+
+<InlineLoading
+  {status}
+  description="Working"
+  on:success={() => {
+    console.log("success");
+  }}
+/>

--- a/tests/LocalStorage/LocalStoragePrimitive.test.ts
+++ b/tests/LocalStorage/LocalStoragePrimitive.test.ts
@@ -29,4 +29,25 @@ describe("LocalStorage - Primitive Values", () => {
     render(LocalStoragePrimitive);
     expect(consoleLog).toHaveBeenCalledWith("save event");
   });
+
+  it("does not dispatch update event on initial render", () => {
+    render(LocalStoragePrimitive);
+    expect(consoleLog).not.toHaveBeenCalledWith(
+      "update event",
+      expect.anything(),
+    );
+  });
+
+  it("dispatches update event and persists when value changes after mount", async () => {
+    const { component } = render(LocalStoragePrimitive);
+
+    component.value = "next-value";
+    await tick();
+
+    expect(consoleLog).toHaveBeenCalledWith("update event", {
+      prevValue: "test-value",
+      value: "next-value",
+    });
+    expect(localStorage.setItem).toHaveBeenCalledWith("test-key", "next-value");
+  });
 });

--- a/tests/RadioButtonGroup/RadioButtonGroup.test.ts
+++ b/tests/RadioButtonGroup/RadioButtonGroup.test.ts
@@ -38,6 +38,22 @@ describe("RadioButtonGroup", () => {
     );
   });
 
+  it("dispatches change when selected is set programmatically after mount", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    const { component } = render(RadioButtonGroup, {
+      props: { selected: "1" },
+    });
+
+    expect(consoleLog.mock.calls.some(([event]) => event === "change")).toBe(
+      false,
+    );
+
+    component.selected = "3";
+    await tick();
+
+    expect(consoleLog).toHaveBeenCalledWith("change", "3");
+  });
+
   it("should handle disabled state", () => {
     render(RadioButtonGroup, { props: { disabled: true } });
 

--- a/tests/SessionStorage/SessionStoragePrimitive.test.ts
+++ b/tests/SessionStorage/SessionStoragePrimitive.test.ts
@@ -32,4 +32,28 @@ describe("SessionStorage - Primitive Values", () => {
     render(SessionStoragePrimitive);
     expect(consoleLog).toHaveBeenCalledWith("save event");
   });
+
+  it("does not dispatch update event on initial render", () => {
+    render(SessionStoragePrimitive);
+    expect(consoleLog).not.toHaveBeenCalledWith(
+      "update event",
+      expect.anything(),
+    );
+  });
+
+  it("dispatches update event and persists when value changes after mount", async () => {
+    const { component } = render(SessionStoragePrimitive);
+
+    component.value = "next-value";
+    await tick();
+
+    expect(consoleLog).toHaveBeenCalledWith("update event", {
+      prevValue: "test-value",
+      value: "next-value",
+    });
+    expect(sessionStorage.setItem).toHaveBeenCalledWith(
+      "test-key",
+      "next-value",
+    );
+  });
 });

--- a/tests/Theme/Theme.test.ts
+++ b/tests/Theme/Theme.test.ts
@@ -161,6 +161,16 @@ describe("Theme", () => {
     expect(documentMock.setAttribute).toHaveBeenCalledWith("theme", "g90");
   });
 
+  it("does not fire update event when loading a persisted theme on mount", async () => {
+    localStorageMock.theme = "g90";
+
+    render(Theme, { props: { persist: true } });
+    await tick();
+
+    expect(documentMock.setAttribute).toHaveBeenCalledWith("theme", "g90");
+    expect(consoleLog).not.toHaveBeenCalledWith("update", expect.anything());
+  });
+
   it("should warn on invalid theme", async () => {
     const consoleWarn = vi.spyOn(console, "warn");
     const { rerender } = render(Theme);

--- a/tests/TreeView/TreeView.test.ts
+++ b/tests/TreeView/TreeView.test.ts
@@ -95,6 +95,19 @@ describe.each(testCases)("$name", ({ component }) => {
     });
   });
 
+  it("moves selection to the newly active node", async () => {
+    render(component);
+
+    const firstItem = treeItemById(0);
+    await user.click(firstItem);
+    expect(firstItem).toHaveAttribute("aria-selected", "true");
+
+    const secondItem = treeItemById(1);
+    await user.click(secondItem);
+    expect(secondItem).toHaveAttribute("aria-selected", "true");
+    expect(firstItem).toHaveAttribute("aria-selected", "false");
+  });
+
   it("can expand all nodes", async () => {
     render(component);
 


### PR DESCRIPTION
Cherry-picked from #3173 

Ensure sufficient baseline test coverage before refactoring `afterUpdate` usage.