### PR TITLE
fix(tabs): support Home/End keyboard shortcuts

### DIFF
--- a/src/Tabs/Tab.svelte
+++ b/src/Tabs/Tab.svelte
@@ -61,6 +61,7 @@
     remove,
     update,
     change,
+    changeToEdge,
   } = getContext("carbon:Tabs");
 
   add({
@@ -101,6 +102,12 @@
       change(1);
     } else if (event.key === "ArrowLeft") {
       change(-1);
+    } else if (event.key === "Home") {
+      event.preventDefault();
+      changeToEdge("first");
+    } else if (event.key === "End") {
+      event.preventDefault();
+      changeToEdge("last");
     } else if (!disabled && (event.key === " " || event.key === "Enter")) {
       update(id);
     }

--- a/src/Tabs/Tabs.svelte
+++ b/src/Tabs/Tabs.svelte
@@ -121,6 +121,17 @@
   };
 
   /**
+   * @type {(index: number) => Promise<void>}
+   */
+  const focusTab = async (index) => {
+    currentIndex = index;
+
+    await tick();
+    const activeTab = refTabList?.querySelectorAll("[role='tab']")[index];
+    activeTab?.focus();
+  };
+
+  /**
    * @type {(direction: number) => Promise<void>}
    */
   const change = async (direction) => {
@@ -132,12 +143,29 @@
 
     if (nextIndex === currentIndex) return;
 
-    currentIndex = nextIndex;
+    await focusTab(nextIndex);
+  };
 
-    await tick();
-    const activeTab =
-      refTabList?.querySelectorAll("[role='tab']")[currentIndex];
-    activeTab?.focus();
+  /**
+   * @type {(edge: "first" | "last") => Promise<void>}
+   */
+  const changeToEdge = async (edge) => {
+    const nextIndex = nextEnabledIndex({
+      items: $tabs,
+      index: edge === "first" ? -1 : $tabs.length,
+      step: edge === "first" ? 1 : -1,
+    });
+
+    // nextEnabledIndex leaves index out of range when every tab is disabled.
+    if (
+      nextIndex === currentIndex ||
+      nextIndex < 0 ||
+      nextIndex >= $tabs.length
+    ) {
+      return;
+    }
+
+    await focusTab(nextIndex);
   };
 
   setContext("carbon:Tabs", {
@@ -154,6 +182,7 @@
     removeContent,
     update,
     change,
+    changeToEdge,
   });
 
   afterUpdate(() => {

--- a/tests/Tabs/Tabs.test.ts
+++ b/tests/Tabs/Tabs.test.ts
@@ -101,6 +101,22 @@ describe("Tabs", () => {
     expect(consoleLog).toHaveBeenCalledWith("change event", 0);
   });
 
+  it("should jump to first and last tab with Home and End keys", async () => {
+    render(Tabs);
+
+    const tab1 = screen.getByRole("tab", { name: "Tab 1" });
+    const tab3 = screen.getByRole("tab", { name: "Tab 3" });
+    await user.click(tab1);
+
+    await user.keyboard("{End}");
+    expect(tab3).toHaveFocus();
+    expect(tab3).toHaveAttribute("aria-selected", "true");
+
+    await user.keyboard("{Home}");
+    expect(tab1).toHaveFocus();
+    expect(tab1).toHaveAttribute("aria-selected", "true");
+  });
+
   // Regression: ?? for aria-label so empty string is used (not fallback)
   it("uses empty aria-label when passed (nullish coalescing)", () => {
     render(Tabs, { props: { ariaLabel: "" } });


### PR DESCRIPTION
Similar to #2968, `Tabs` needs to support Home/End keyboard shortcuts. See the upstream implementation.