### PR TITLE
fix(tree-view): scope internal node ids per instance

### DIFF
--- a/src/TreeView/TreeView.svelte
+++ b/src/TreeView/TreeView.svelte
@@ -411,6 +411,7 @@
 
   const dispatch = createEventDispatcher();
   const labelId = `label-${Math.random().toString(36)}`;
+  const treeId = `tree-${Math.random().toString(36)}`;
 
   /** @type {import("svelte/store").Writable<boolean>} */
   const multiselectStore = writable(multiselect);
@@ -627,6 +628,7 @@
   const toggleNode = (node) => dispatch("toggle", node);
 
   setContext("carbon:TreeView", {
+    treeId,
     activeNodeId,
     selectedNodeIds,
     expandedNodeIds,

--- a/src/TreeView/TreeViewNodeList.svelte
+++ b/src/TreeView/TreeViewNodeList.svelte
@@ -45,6 +45,7 @@
   let prevActiveId = undefined;
 
   const {
+    treeId,
     activeNodeId,
     selectedIdsSetStore,
     expandedIdsSetStore,
@@ -118,7 +119,7 @@
     class:bx--tree-node--disabled={disabled}
     class:bx--tree-node--with-icon={icon}
     aria-expanded={expanded}
-    aria-owns={`${id}-subtree`}
+    aria-owns={`${treeId}-${id}-subtree`}
     on:click|stopPropagation={(event) => {
       if (disabled) return;
       clickNode(node, event);
@@ -205,15 +206,18 @@
       </span>
       <span class:bx--tree-node__label__details={true}>
         <svelte:component this={icon} class="bx--tree-node__icon" />
-        <span id={`${id}__label`} class:bx--tree-node__label__text={true}>
+        <span
+          id={`${treeId}-${id}__label`}
+          class:bx--tree-node__label__text={true}
+        >
           <slot {node} />
         </span>
       </span>
     </div>
     <ul
-      id={`${id}-subtree`}
+      id={`${treeId}-${id}-subtree`}
       role="group"
-      aria-labelledby={`${id}__label`}
+      aria-labelledby={`${treeId}-${id}__label`}
       class:bx--tree-node__children={true}
       class:bx--tree-node--hidden={!expanded}
     >

--- a/tests/TreeView/TreeView.test.ts
+++ b/tests/TreeView/TreeView.test.ts
@@ -17,6 +17,7 @@ import TreeViewMultiselect from "./TreeView.multiselect.test.svelte";
 import TreeViewProps from "./TreeView.props.test.svelte";
 import TreeViewSlot from "./TreeView.slot.test.svelte";
 import TreeView from "./TreeView.test.svelte";
+import TreeViewDuplicateIds from "./TreeViewDuplicateIds.test.svelte";
 import TreeViewGenerics from "./TreeViewGenerics.test.svelte";
 
 function treeItemById(id: string | number): HTMLElement {
@@ -1812,15 +1813,15 @@ describe("TreeView autoCollapse", () => {
 
     const parent = container.querySelector("#parent");
     const subtreeId = parent?.getAttribute("aria-owns");
-    expect(subtreeId).toBe("parent-subtree");
+    expect(subtreeId).toMatch(/^tree-.+-parent-subtree$/);
 
-    const subtree = container.querySelector(`#${subtreeId}`);
+    const subtree = document.getElementById(subtreeId as string);
     expect(subtree?.getAttribute("role")).toBe("group");
 
     const labelledBy = subtree?.getAttribute("aria-labelledby");
-    expect(labelledBy).toBe("parent__label");
+    expect(labelledBy).toMatch(/^tree-.+-parent__label$/);
 
-    const labelEl = container.querySelector(`#${labelledBy}`);
+    const labelEl = document.getElementById(labelledBy as string);
     expect(labelEl?.textContent?.trim()).toBe("Top Parent");
   });
 
@@ -1897,5 +1898,38 @@ describe("TreeView autoCollapse", () => {
       // biome-ignore lint/suspicious/noExplicitAny: Testing default any type
       expectTypeOf<Props["icon"]>().toEqualTypeOf<any>();
     });
+  });
+});
+
+describe("TreeView duplicate ids", () => {
+  it("keeps internal ids unique when two trees share node ids", () => {
+    const { container } = render(TreeViewDuplicateIds);
+
+    const labels = Array.from(
+      container.querySelectorAll<HTMLElement>(
+        ".bx--tree-node__label__text[id]",
+      ),
+    );
+    const labelIds = labels.map((label) => label.id);
+
+    expect(labelIds).toHaveLength(2);
+    expect(new Set(labelIds).size).toBe(labelIds.length);
+
+    const trees = Array.from(
+      container.querySelectorAll<HTMLElement>('[role="tree"]'),
+    );
+    expect(trees).toHaveLength(2);
+
+    for (const tree of trees) {
+      const subtree = tree.querySelector<HTMLElement>('[role="group"]');
+      expect(subtree).not.toBeNull();
+
+      const labelledby = subtree?.getAttribute("aria-labelledby");
+      expect(labelledby).toBeTruthy();
+
+      const referenced = document.getElementById(labelledby as string);
+      expect(referenced).not.toBeNull();
+      expect(tree.contains(referenced)).toBe(true);
+    }
   });
 });

--- a/tests/TreeView/TreeViewDuplicateIds.test.svelte
+++ b/tests/TreeView/TreeViewDuplicateIds.test.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+  import { TreeView } from "carbon-components-svelte";
+  import type { TreeNode } from "carbon-components-svelte/TreeView/TreeView.svelte";
+
+  const nodes: TreeNode[] = [
+    {
+      id: 0,
+      text: "Parent",
+      nodes: [
+        { id: 1, text: "Child A" },
+        { id: 2, text: "Child B" },
+      ],
+    },
+  ];
+</script>
+
+<TreeView labelText="First" {nodes} expandedIds={[0]} let:node>
+  {node.text}
+</TreeView>
+<TreeView labelText="Second" {nodes} expandedIds={[0]} let:node>
+  {node.text}
+</TreeView>


### PR DESCRIPTION
Same class of error as https://github.com/carbon-design-system/carbon-components-svelte/pull/3175 etc..

Generate a per-instance ID for `TreeView` to avoid internal node IDs having clashing values in the DOM.