### PR TITLE
refactor: apply `rovingFocus` util to `Tabs`, `ContentSwitcher`, `ContextMenu`, `OverflowMenu`

### DIFF
--- a/src/ContentSwitcher/ContentSwitcher.svelte
+++ b/src/ContentSwitcher/ContentSwitcher.svelte
@@ -31,7 +31,7 @@
 
   import { afterUpdate, createEventDispatcher, setContext, tick } from "svelte";
   import { writable } from "svelte/store";
-  import { nextEnabledIndex } from "../utils/moveIndex.js";
+  import { rovingFocus } from "../utils/rovingFocus.js";
   import { syncDomOrder } from "../utils/syncDomOrder.js";
 
   const dispatch = createEventDispatcher();
@@ -58,9 +58,9 @@
   }
 
   /**
-   * @type {(data: { id: string; text: string; selected: boolean; disabled?: boolean }) => void}
+   * @type {(data: { id: string; text: string; selected: boolean }) => void}
    */
-  const add = ({ id, text, selected, disabled = false }) => {
+  const add = ({ id, text, selected }) => {
     if (switches.some((s) => s.id === id)) {
       return;
     }
@@ -70,21 +70,7 @@
     }
 
     needsDomSync = true;
-    switches = [...switches, { id, text, selected, disabled }];
-  };
-
-  /**
-   * Keep a switch's disabled state in sync so keyboard navigation skips it.
-   * @type {(id: string, disabled: boolean) => void}
-   */
-  const setDisabled = (id, disabled) => {
-    const index = switches.findIndex((s) => s.id === id);
-    if (index === -1 || switches[index].disabled === disabled) {
-      return;
-    }
-
-    switches[index] = { ...switches[index], disabled };
-    switches = switches;
+    switches = [...switches, { id, text, selected }];
   };
 
   /**
@@ -118,19 +104,6 @@
   };
 
   /**
-   * @type {(direction: number) => Promise<void>}
-   */
-  const change = async (direction) => {
-    await changeTo(
-      nextEnabledIndex({
-        items: switches,
-        index: currentIndex,
-        step: direction,
-      }),
-    );
-  };
-
-  /**
    * Move focus to a switch at an absolute index without changing selection.
    * @type {(index: number) => Promise<void>}
    */
@@ -146,45 +119,11 @@
     }
   };
 
-  /**
-   * Move focus to the next/previous switch without changing selection.
-   * @type {(direction: number) => Promise<void>}
-   */
-  const focus = async (direction) => {
-    const base = focusedIndex >= 0 ? focusedIndex : currentIndex;
-    await focusTo(
-      nextEnabledIndex({ items: switches, index: base, step: direction }),
-    );
-  };
-
-  /**
-   * Resolve the first or last enabled switch index for Home/End. Returns -1
-   * when every switch is disabled.
-   * @type {(edge: "first" | "last") => number}
-   */
-  const edgeEnabledIndex = (edge) => {
-    const start = edge === "first" ? -1 : switches.length;
-    const step = edge === "first" ? 1 : -1;
-    return nextEnabledIndex({ items: switches, index: start, step });
-  };
-
   setContext("carbon:ContentSwitcher", {
     currentId,
     add,
     remove,
     update,
-    setDisabled,
-    change,
-    changeTo,
-    focus,
-    focusTo,
-    edgeEnabledIndex,
-    get switchCount() {
-      return switches.length;
-    },
-    get selectionMode() {
-      return selectionMode;
-    },
   });
 
   afterUpdate(() => {
@@ -223,6 +162,17 @@
 <div
   bind:this={ref}
   role="tablist"
+  use:rovingFocus={{
+    selector: "[role='tab']",
+    skipDisabled: true,
+    getItems: () =>
+      switches
+        .map((s) => document.getElementById(s.id))
+        .filter((el) => el instanceof HTMLElement),
+    getActiveIndex: () => (focusedIndex >= 0 ? focusedIndex : currentIndex),
+    onMove: (index) =>
+      selectionMode === "manual" ? focusTo(index) : changeTo(index),
+  }}
   class:bx--content-switcher={true}
   class:bx--content-switcher--sm={size === "sm"}
   class:bx--content-switcher--xl={size === "xl"}

--- a/src/ContentSwitcher/Switch.svelte
+++ b/src/ContentSwitcher/Switch.svelte
@@ -33,11 +33,7 @@
 
   const ctx = getContext("carbon:ContentSwitcher");
 
-  ctx.add({ id, text, selected, disabled });
-
-  // Keep the parent registry in sync when `disabled` changes reactively so
-  // keyboard navigation continues to skip the correct switches.
-  $: ctx.setDisabled?.(id, disabled);
+  ctx.add({ id, text, selected });
 
   const unsubscribe = ctx.currentId.subscribe((currentId) => {
     selected = currentId === id;
@@ -74,21 +70,6 @@
   on:blur
   on:keyup
   on:keydown
-  on:keydown={(event) => {
-    if (event.key === "ArrowRight") {
-      ctx.selectionMode === "manual" ? ctx.focus(1) : ctx.change(1);
-    } else if (event.key === "ArrowLeft") {
-      ctx.selectionMode === "manual" ? ctx.focus(-1) : ctx.change(-1);
-    } else if (event.key === "Home") {
-      event.preventDefault();
-      const first = ctx.edgeEnabledIndex("first");
-      ctx.selectionMode === "manual" ? ctx.focusTo(first) : ctx.changeTo(first);
-    } else if (event.key === "End") {
-      event.preventDefault();
-      const last = ctx.edgeEnabledIndex("last");
-      ctx.selectionMode === "manual" ? ctx.focusTo(last) : ctx.changeTo(last);
-    }
-  }}
 >
   <span class:bx--content-switcher__label={true}> <slot>{text}</slot> </span>
 </button>

--- a/src/ContextMenu/ContextMenu.svelte
+++ b/src/ContextMenu/ContextMenu.svelte
@@ -51,8 +51,8 @@
     setContext,
   } from "svelte";
   import { writable } from "svelte/store";
-  import { clampIndex } from "../utils/clampIndex.js";
   import { isOutsideClick } from "../utils/isOutsideClick.js";
+  import { rovingFocus } from "../utils/rovingFocus.js";
 
   const dispatch = createEventDispatcher();
   /**
@@ -196,6 +196,16 @@
 <!-- svelte-ignore a11y-no-noninteractive-element-to-interactive-role -->
 <ul
   bind:this={ref}
+  use:rovingFocus={{
+    selector: "li[data-nested='false']",
+    orientation: "vertical",
+    wrap: false,
+    getActiveIndex: () => focusIndex,
+    onMove: (index) => {
+      if ($hasPopup) return;
+      focusIndex = index;
+    },
+  }}
   role="menu"
   tabindex="-1"
   data-direction={direction}
@@ -219,17 +229,6 @@
   on:keydown
   on:keydown={(event) => {
     if (open) event.preventDefault();
-    if ($hasPopup) return;
-
-    if (event.key === "ArrowDown") {
-      focusIndex = clampIndex(focusIndex, 1, options.length);
-    } else if (event.key === "ArrowUp") {
-      focusIndex = clampIndex(focusIndex, -1, options.length);
-    } else if (event.key === "Home") {
-      if (options.length > 0) focusIndex = 0;
-    } else if (event.key === "End" && options.length > 0) {
-      focusIndex = options.length - 1;
-    }
   }}
 >
   <slot />

--- a/src/OverflowMenu/OverflowMenu.svelte
+++ b/src/OverflowMenu/OverflowMenu.svelte
@@ -90,7 +90,7 @@
   import FloatingPortal from "../Portal/FloatingPortal.svelte";
   import { isOutsideClick } from "../utils/isOutsideClick.js";
   import { keyBy } from "../utils/keyBy.js";
-  import { nextEnabledIndex } from "../utils/moveIndex.js";
+  import { rovingFocus } from "../utils/rovingFocus.js";
 
   const ctxBreadcrumbItem = getContext("carbon:BreadcrumbItem");
   const insideModal = getContext("carbon:Modal");
@@ -155,19 +155,6 @@
     }
   };
 
-  /**
-   * @type {(direction: number) => void}
-   */
-  const change = (direction) => {
-    currentIndex.set(
-      nextEnabledIndex({
-        items: $items,
-        index: $currentIndex,
-        step: direction,
-      }),
-    );
-  };
-
   const first = () => {
     const index = $items.findIndex((_) => !_.disabled);
     if (index >= 0) currentIndex.set(index);
@@ -189,10 +176,21 @@
     add,
     remove,
     update,
-    change,
     first,
     last,
   });
+
+  // Roving focus over the registry (`$items`), not the DOM: the focused item
+  // is the one whose id matches `focusedId`, set reactively from `currentIndex`.
+  const menuRovingFocus = {
+    selector: "[role='menuitem']",
+    orientation: /** @type {const} */ ("vertical"),
+    skipDisabled: true,
+    getItems: () => $items,
+    isDisabled: (item) => item.disabled,
+    getActiveIndex: () => $currentIndex,
+    onMove: (index) => currentIndex.set(index),
+  };
 
   afterUpdate(() => {
     if (open) {
@@ -328,6 +326,7 @@
   <!-- svelte-ignore a11y-no-noninteractive-element-to-interactive-role -->
   <ul
     bind:this={menuRef}
+    use:rovingFocus={menuRovingFocus}
     role="menu"
     tabindex="-1"
     id={menuId}
@@ -369,6 +368,7 @@
     <!-- svelte-ignore a11y-no-noninteractive-element-to-interactive-role -->
     <ul
       bind:this={menuRef}
+      use:rovingFocus={menuRovingFocus}
       role="menu"
       tabindex="-1"
       id={menuId}
@@ -386,12 +386,6 @@
       on:keydown={(event) => {
         if (["ArrowDown", "ArrowLeft", "ArrowRight", "ArrowUp"].includes(event.key)) {
           event.preventDefault();
-        } else if (event.key === "Home") {
-          event.preventDefault();
-          first();
-        } else if (event.key === "End") {
-          event.preventDefault();
-          last();
         } else if (event.key === "Escape") {
           event.stopPropagation();
           const shouldContinue = dispatch("close", null, { cancelable: true });

--- a/src/OverflowMenu/OverflowMenuItem.svelte
+++ b/src/OverflowMenu/OverflowMenuItem.svelte
@@ -64,8 +64,9 @@
   } from "svelte";
 
   const dispatch = createEventDispatcher();
-  const { focusedId, add, remove, update, change, first, last, itemsById } =
-    getContext("carbon:OverflowMenu");
+  const { focusedId, add, remove, update, itemsById } = getContext(
+    "carbon:OverflowMenu",
+  );
 
   $: item = $itemsById[id];
 
@@ -128,25 +129,7 @@
   {#if href}
     <!-- svelte-ignore a11y-missing-attribute -->
     <!-- svelte-ignore a11y-no-static-element-interactions -->
-    <a
-      bind:this={ref}
-      {...buttonProps}
-      on:click={handleClick}
-      on:keydown
-      on:keydown={(event) => {
-        if (event.key === "ArrowDown") {
-          change(1);
-        } else if (event.key === "ArrowUp") {
-          change(-1);
-        } else if (event.key === "Home") {
-          event.preventDefault();
-          first();
-        } else if (event.key === "End") {
-          event.preventDefault();
-          last();
-        }
-      }}
-    >
+    <a bind:this={ref} {...buttonProps} on:click={handleClick} on:keydown>
       <slot>
         <div class:bx--overflow-menu-options__option-content={true}>{text}</div>
       </slot>
@@ -158,19 +141,6 @@
       {...buttonProps}
       on:click={handleClick}
       on:keydown
-      on:keydown={(event) => {
-        if (event.key === "ArrowDown") {
-          change(1);
-        } else if (event.key === "ArrowUp") {
-          change(-1);
-        } else if (event.key === "Home") {
-          event.preventDefault();
-          first();
-        } else if (event.key === "End") {
-          event.preventDefault();
-          last();
-        }
-      }}
     >
       <slot>
         <div class:bx--overflow-menu-options__option-content={true}>{text}</div>

--- a/src/Tabs/Tab.svelte
+++ b/src/Tabs/Tab.svelte
@@ -60,8 +60,6 @@
     add,
     remove,
     update,
-    change,
-    changeToEdge,
   } = getContext("carbon:Tabs");
 
   add({
@@ -98,17 +96,7 @@
   on:mouseenter
   on:mouseleave
   on:keydown={(event) => {
-    if (event.key === "ArrowRight") {
-      change(1);
-    } else if (event.key === "ArrowLeft") {
-      change(-1);
-    } else if (event.key === "Home") {
-      event.preventDefault();
-      changeToEdge("first");
-    } else if (event.key === "End") {
-      event.preventDefault();
-      changeToEdge("last");
-    } else if (!disabled && (event.key === " " || event.key === "Enter")) {
+    if (!disabled && (event.key === " " || event.key === "Enter")) {
       update(id);
     }
   }}

--- a/src/Tabs/Tabs.svelte
+++ b/src/Tabs/Tabs.svelte
@@ -34,7 +34,7 @@
   import { derived, writable } from "svelte/store";
   import ChevronDown from "../icons/ChevronDown.svelte";
   import { keyBy } from "../utils/keyBy.js";
-  import { nextEnabledIndex } from "../utils/moveIndex.js";
+  import { rovingFocus } from "../utils/rovingFocus.js";
   import { syncDomOrder } from "../utils/syncDomOrder.js";
 
   const dispatch = createEventDispatcher();
@@ -121,51 +121,18 @@
   };
 
   /**
+   * Move selection/focus to a tab at an absolute index. Roving focus resolves
+   * the index (skipping disabled, wrapping); selection follows focus.
    * @type {(index: number) => Promise<void>}
    */
-  const focusTab = async (index) => {
+  const selectTab = async (index) => {
+    if (index === currentIndex) return;
+
     currentIndex = index;
 
     await tick();
     const activeTab = refTabList?.querySelectorAll("[role='tab']")[index];
     activeTab?.focus();
-  };
-
-  /**
-   * @type {(direction: number) => Promise<void>}
-   */
-  const change = async (direction) => {
-    const nextIndex = nextEnabledIndex({
-      items: $tabs,
-      index: currentIndex,
-      step: direction,
-    });
-
-    if (nextIndex === currentIndex) return;
-
-    await focusTab(nextIndex);
-  };
-
-  /**
-   * @type {(edge: "first" | "last") => Promise<void>}
-   */
-  const changeToEdge = async (edge) => {
-    const nextIndex = nextEnabledIndex({
-      items: $tabs,
-      index: edge === "first" ? -1 : $tabs.length,
-      step: edge === "first" ? 1 : -1,
-    });
-
-    // nextEnabledIndex leaves index out of range when every tab is disabled.
-    if (
-      nextIndex === currentIndex ||
-      nextIndex < 0 ||
-      nextIndex >= $tabs.length
-    ) {
-      return;
-    }
-
-    await focusTab(nextIndex);
   };
 
   setContext("carbon:Tabs", {
@@ -181,8 +148,6 @@
     addContent,
     removeContent,
     update,
-    change,
-    changeToEdge,
   });
 
   afterUpdate(() => {
@@ -285,6 +250,13 @@
   <ul
     bind:this={refTabList}
     role="tablist"
+    use:rovingFocus={{
+      selector: "[role='tab']",
+      orientation: "horizontal",
+      skipDisabled: true,
+      getActiveIndex: () => currentIndex,
+      onMove: (index) => selectTab(index),
+    }}
     class:bx--tabs__nav={true}
     class:bx--tabs__nav--hidden={dropdownHidden}
   >

--- a/src/utils/rovingFocus.d.ts
+++ b/src/utils/rovingFocus.d.ts
@@ -1,0 +1,35 @@
+/** Svelte action for arrow-key roving focus. */
+
+export type RovingFocusOrientation = "horizontal" | "vertical" | "both";
+
+export type RovingFocusOptions = {
+  /** Items inside `node`. Also filters which keydown events count. */
+  selector: string;
+  /** Item list in tab order. Default: `node.querySelectorAll(selector)`. */
+  getItems?: () => HTMLElement[];
+  /** @default "horizontal" */
+  orientation?: RovingFocusOrientation;
+  /** Wrap at the ends. @default true */
+  wrap?: boolean;
+  /** @default false */
+  skipDisabled?: boolean;
+  /** @default true */
+  home?: boolean;
+  /** @default true */
+  end?: boolean;
+  /** @default el => el.disabled || aria-disabled */
+  isDisabled?: (item: HTMLElement) => boolean;
+  getActiveIndex: () => number;
+  onMove?: (index: number, event: KeyboardEvent) => void;
+  /** Call `.focus()` on the new item. @default false */
+  focusOnMove?: boolean;
+};
+
+/** Arrow/Home/End keydown on `node` calls `onMove` with the next index. */
+export function rovingFocus(
+  node: HTMLElement,
+  options: RovingFocusOptions,
+): {
+  update: (options: RovingFocusOptions) => void;
+  destroy: () => void;
+};

--- a/src/utils/rovingFocus.js
+++ b/src/utils/rovingFocus.js
@@ -1,0 +1,126 @@
+// @ts-check
+
+import { clampIndex } from "./clampIndex.js";
+import { moveIndex, nextEnabledIndex } from "./moveIndex.js";
+
+/**
+ * @typedef {"horizontal" | "vertical" | "both"} RovingFocusOrientation
+ */
+
+/**
+ * @typedef {Object} RovingFocusOptions
+ * @property {string} selector - Items inside `node`. Also filters which keydown events count.
+ * @property {() => HTMLElement[]} [getItems] - Item list in tab order. Default: `node.querySelectorAll(selector)`.
+ * @property {RovingFocusOrientation} [orientation] - "horizontal" = Left/Right, "vertical" = Up/Down, "both" = all four. Default "horizontal".
+ * @property {boolean} [wrap] - Wrap at the ends. Default `true`; `false` clamps.
+ * @property {boolean} [skipDisabled] - Skip disabled items. Default `false`.
+ * @property {boolean} [home] - Home jumps to the first item. Default `true`.
+ * @property {boolean} [end] - End jumps to the last item. Default `true`.
+ * @property {(item: HTMLElement) => boolean} [isDisabled] - Default: `disabled` or `aria-disabled="true"`.
+ * @property {() => number} getActiveIndex - Index to move from.
+ * @property {(index: number, event: KeyboardEvent) => void} [onMove] - New index after a navigation key.
+ * @property {boolean} [focusOnMove] - Call `.focus()` on the new item. Default `false`.
+ */
+
+/**
+ * Svelte action for arrow-key roving focus inside `node`.
+ * Listens for keydown on matching items and on `node` when the list holds focus.
+ * Calls `onMove(index, event)`. Index math uses moveIndex, clampIndex, and
+ * nextEnabledIndex. Only Home/End call `preventDefault`.
+ *
+ * @param {HTMLElement} node
+ * @param {RovingFocusOptions} options
+ */
+export function rovingFocus(node, options) {
+  let opts = options;
+
+  /** @param {HTMLElement} el */
+  const defaultIsDisabled = (el) =>
+    el.hasAttribute("disabled") || el.getAttribute("aria-disabled") === "true";
+
+  function getItems() {
+    if (opts.getItems) return opts.getItems();
+    return /** @type {HTMLElement[]} */ (
+      Array.from(node.querySelectorAll(opts.selector))
+    );
+  }
+
+  /**
+   * @param {HTMLElement[]} items
+   * @param {number} direction
+   */
+  function moveBy(items, direction) {
+    const index = opts.getActiveIndex();
+    if (opts.skipDisabled) {
+      const isDisabled = opts.isDisabled ?? defaultIsDisabled;
+      return nextEnabledIndex({ items, index, step: direction, isDisabled });
+    }
+    return opts.wrap === false
+      ? clampIndex(index, direction, items.length)
+      : moveIndex(index, direction, items.length);
+  }
+
+  /**
+   * @param {HTMLElement[]} items
+   * @param {1 | -1} direction - 1 for the first item, -1 for the last.
+   */
+  function edge(items, direction) {
+    if (!opts.skipDisabled) {
+      return direction === 1 ? 0 : items.length - 1;
+    }
+    const isDisabled = opts.isDisabled ?? defaultIsDisabled;
+    return nextEnabledIndex({ items, index: -1, step: direction, isDisabled });
+  }
+
+  /** @param {KeyboardEvent} event */
+  function handleKeydown(event) {
+    const target = event.target;
+    if (!(target instanceof Element)) return;
+    // Item keydown, or keydown on `node` when the list itself is focused.
+    if (target !== node && !target.closest(opts.selector)) return;
+
+    const orientation = opts.orientation ?? "horizontal";
+    const horizontal = orientation === "horizontal" || orientation === "both";
+    const vertical = orientation === "vertical" || orientation === "both";
+
+    const items = getItems();
+    if (items.length === 0) return;
+
+    let index = -1;
+    if (
+      (horizontal && event.key === "ArrowRight") ||
+      (vertical && event.key === "ArrowDown")
+    ) {
+      index = moveBy(items, 1);
+    } else if (
+      (horizontal && event.key === "ArrowLeft") ||
+      (vertical && event.key === "ArrowUp")
+    ) {
+      index = moveBy(items, -1);
+    } else if (opts.home !== false && event.key === "Home") {
+      event.preventDefault();
+      index = edge(items, 1);
+    } else if (opts.end !== false && event.key === "End") {
+      event.preventDefault();
+      index = edge(items, -1);
+    } else {
+      return;
+    }
+
+    if (index < 0) return;
+    opts.onMove?.(index, event);
+    if (opts.focusOnMove) items[index]?.focus();
+  }
+
+  node.addEventListener("keydown", handleKeydown);
+
+  return {
+    /** @param {RovingFocusOptions} update */
+    update(update) {
+      opts = update;
+    },
+    destroy() {
+      node.removeEventListener("keydown", handleKeydown);
+    },
+  };
+}

--- a/tests/ContextMenu/ContextMenu.test.ts
+++ b/tests/ContextMenu/ContextMenu.test.ts
@@ -132,23 +132,23 @@ describe("ContextMenu", () => {
     const menu = screen.getAllByRole("menu")[0];
     menu.focus();
 
-    // Arrow down
-    await user.keyboard("{ArrowDown}");
     const options = screen.getAllByRole("menuitem");
-    expect(options[0].parentElement).toHaveFocus();
 
-    // Arrow up wraps to the last option from the initial position.
-    // After ArrowDown, focusIndex is 0, so ArrowUp stays at 0.
+    // ArrowDown from the focused menu moves to the first option.
+    await user.keyboard("{ArrowDown}");
+    expect(options[0]).toHaveFocus();
+
+    // ArrowUp clamps at the first option (no wrap).
     await user.keyboard("{ArrowUp}");
-    expect(options[0].parentElement).toHaveFocus();
+    expect(options[0]).toHaveFocus();
 
     // End jumps to the last option.
     await user.keyboard("{End}");
-    expect(options[options.length - 1].parentElement).toHaveFocus();
+    expect(options[options.length - 1]).toHaveFocus();
 
     // Home jumps back to the first option.
     await user.keyboard("{Home}");
-    expect(options[0].parentElement).toHaveFocus();
+    expect(options[0]).toHaveFocus();
   });
 
   it("should handle custom target", async () => {

--- a/tests/Tabs/Tabs.test.ts
+++ b/tests/Tabs/Tabs.test.ts
@@ -101,7 +101,7 @@ describe("Tabs", () => {
     expect(consoleLog).toHaveBeenCalledWith("change event", 0);
   });
 
-  it("should jump to first and last tab with Home and End keys", async () => {
+  it("supports Home/End keyboard navigation", async () => {
     render(Tabs);
 
     const tab1 = screen.getByRole("tab", { name: "Tab 1" });
@@ -111,10 +111,12 @@ describe("Tabs", () => {
     await user.keyboard("{End}");
     expect(tab3).toHaveFocus();
     expect(tab3).toHaveAttribute("aria-selected", "true");
+    expect(consoleLog).toHaveBeenCalledWith("change event", 2);
 
     await user.keyboard("{Home}");
     expect(tab1).toHaveFocus();
     expect(tab1).toHaveAttribute("aria-selected", "true");
+    expect(consoleLog).toHaveBeenCalledWith("change event", 0);
   });
 
   // Regression: ?? for aria-label so empty string is used (not fallback)

--- a/tests/utils/rovingFocus.test.ts
+++ b/tests/utils/rovingFocus.test.ts
@@ -1,0 +1,176 @@
+import { rovingFocus } from "../../src/utils/rovingFocus.js";
+
+type Options = Parameters<typeof rovingFocus>[1];
+
+function setup(count: number, options: Partial<Options> = {}) {
+  const container = document.createElement("div");
+  const items = Array.from({ length: count }, (_, i) => {
+    const button = document.createElement("button");
+    button.setAttribute("role", "option");
+    button.textContent = `Item ${i}`;
+    container.appendChild(button);
+    return button;
+  });
+  document.body.appendChild(container);
+
+  let active = 0;
+  const onMove = vi.fn((index: number) => {
+    active = index;
+  });
+
+  const action = rovingFocus(container, {
+    selector: "[role='option']",
+    getActiveIndex: () => active,
+    onMove,
+    ...options,
+  });
+
+  return {
+    container,
+    items,
+    onMove,
+    action,
+    setActive: (index: number) => {
+      active = index;
+    },
+  };
+}
+
+function keydown(target: Element, key: string) {
+  const event = new KeyboardEvent("keydown", { key, bubbles: true });
+  const preventDefault = vi.spyOn(event, "preventDefault");
+  target.dispatchEvent(event);
+  return { event, preventDefault };
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("rovingFocus", () => {
+  test("ArrowRight moves to the next index", () => {
+    const { items, onMove } = setup(3);
+    keydown(items[0], "ArrowRight");
+    expect(onMove).toHaveBeenCalledWith(1, expect.any(KeyboardEvent));
+  });
+
+  test("ArrowLeft wraps from the first item to the last", () => {
+    const { items, onMove } = setup(3);
+    keydown(items[0], "ArrowLeft");
+    expect(onMove).toHaveBeenCalledWith(2, expect.any(KeyboardEvent));
+  });
+
+  test("ArrowRight wraps from the last item to the first", () => {
+    const { items, onMove, setActive } = setup(3);
+    setActive(2);
+    keydown(items[2], "ArrowRight");
+    expect(onMove).toHaveBeenCalledWith(0, expect.any(KeyboardEvent));
+  });
+
+  test("horizontal orientation ignores ArrowUp/ArrowDown", () => {
+    const { items, onMove } = setup(3);
+    keydown(items[0], "ArrowDown");
+    keydown(items[0], "ArrowUp");
+    expect(onMove).not.toHaveBeenCalled();
+  });
+
+  test("vertical orientation uses ArrowDown/ArrowUp, not Left/Right", () => {
+    const { items, onMove } = setup(3, { orientation: "vertical" });
+    keydown(items[0], "ArrowDown");
+    expect(onMove).toHaveBeenCalledWith(1, expect.any(KeyboardEvent));
+
+    onMove.mockClear();
+    keydown(items[0], "ArrowRight");
+    expect(onMove).not.toHaveBeenCalled();
+  });
+
+  test("both orientation handles all four arrow keys", () => {
+    const { items, onMove } = setup(3, { orientation: "both" });
+    keydown(items[0], "ArrowRight");
+    keydown(items[0], "ArrowDown");
+    expect(onMove).toHaveBeenCalledTimes(2);
+  });
+
+  test("Home jumps to the first item and calls preventDefault", () => {
+    const { items, onMove, setActive } = setup(3);
+    setActive(2);
+    const { preventDefault } = keydown(items[2], "Home");
+    expect(onMove).toHaveBeenCalledWith(0, expect.any(KeyboardEvent));
+    expect(preventDefault).toHaveBeenCalledOnce();
+  });
+
+  test("End jumps to the last item and calls preventDefault", () => {
+    const { items, onMove } = setup(3);
+    const { preventDefault } = keydown(items[0], "End");
+    expect(onMove).toHaveBeenCalledWith(2, expect.any(KeyboardEvent));
+    expect(preventDefault).toHaveBeenCalledOnce();
+  });
+
+  test("arrow keys do not call preventDefault", () => {
+    const { items } = setup(3);
+    const { preventDefault } = keydown(items[0], "ArrowRight");
+    expect(preventDefault).not.toHaveBeenCalled();
+  });
+
+  test("skipDisabled skips disabled items", () => {
+    const { items, onMove } = setup(3, { skipDisabled: true });
+    items[1].disabled = true;
+    keydown(items[0], "ArrowRight");
+    expect(onMove).toHaveBeenCalledWith(2, expect.any(KeyboardEvent));
+  });
+
+  test("without skipDisabled, navigation lands on a disabled item", () => {
+    const { items, onMove } = setup(3);
+    items[1].disabled = true;
+    keydown(items[0], "ArrowRight");
+    expect(onMove).toHaveBeenCalledWith(1, expect.any(KeyboardEvent));
+  });
+
+  test("ignores keydown outside the selector", () => {
+    const { container, onMove } = setup(3);
+    const stray = document.createElement("input");
+    container.appendChild(stray);
+    keydown(stray, "ArrowRight");
+    expect(onMove).not.toHaveBeenCalled();
+  });
+
+  test("ArrowRight on the container moves to the next index", () => {
+    const { container, onMove } = setup(3);
+    keydown(container, "ArrowRight");
+    expect(onMove).toHaveBeenCalledWith(1, expect.any(KeyboardEvent));
+  });
+
+  test("wrap: false clamps at the ends instead of wrapping", () => {
+    const { items, onMove, setActive } = setup(3, { wrap: false });
+    setActive(2);
+    keydown(items[2], "ArrowRight");
+    expect(onMove).toHaveBeenCalledWith(2, expect.any(KeyboardEvent));
+  });
+
+  test("focusOnMove focuses the resolved item", () => {
+    const { items } = setup(3, { focusOnMove: true });
+    keydown(items[0], "ArrowRight");
+    expect(document.activeElement).toBe(items[1]);
+  });
+
+  test("getItems sets the item list and count", () => {
+    const { items, onMove, setActive } = setup(4, {
+      getItems: () => {
+        const all = Array.from(
+          document.querySelectorAll<HTMLElement>("[role='option']"),
+        );
+        return all.slice(0, 3);
+      },
+    });
+    setActive(2);
+    keydown(items[2], "ArrowRight");
+    expect(onMove).toHaveBeenCalledWith(0, expect.any(KeyboardEvent));
+  });
+
+  test("destroy removes the keydown listener", () => {
+    const { items, onMove, action } = setup(3);
+    action.destroy();
+    keydown(items[0], "ArrowRight");
+    expect(onMove).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Extract this util for more testing and reuse. Codifies this pattern more broadly.