### PR TITLE
docs: hide tooltip after copying

### DIFF
--- a/docs/src/layouts/ComponentLayout.svelte
+++ b/docs/src/layouts/ComponentLayout.svelte
@@ -22,7 +22,9 @@
   import type { CarbonTheme } from "carbon-components-svelte/src/Theme/Theme.svelte";
   import { themes as themeLabels } from "carbon-components-svelte/src/Theme/Theme.svelte";
   import Checkmark from "carbon-icons-svelte/lib/Checkmark.svelte";
+  import Code from "carbon-icons-svelte/lib/Code.svelte";
   import Copy from "carbon-icons-svelte/lib/Copy.svelte";
+  import Document from "carbon-icons-svelte/lib/Document.svelte";
   import OverflowMenuVertical from "carbon-icons-svelte/lib/OverflowMenuVertical.svelte";
   import { onMount } from "svelte";
   import COMPONENT_API from "../COMPONENT_API.json";
@@ -201,12 +203,14 @@
             />
             <OverflowMenu flipped icon={OverflowMenuVertical}>
               <OverflowMenuItem
+                icon={Code}
                 text="Source code"
                 href={sourceCode}
                 target="_blank"
               />
               <OverflowMenuItem
-                text="View as Markdown"
+                icon={Document}
+                text="View Markdown"
                 href={markdownUrl}
                 target="_blank"
               />

--- a/docs/src/layouts/ComponentLayout.svelte
+++ b/docs/src/layouts/ComponentLayout.svelte
@@ -124,6 +124,7 @@
 
   let copying = false;
   let copied = false;
+  let copyButtonRef: HTMLElement | null = null;
 
   $: copyIcon = copied ? Checkmark : Copy;
   $: copyIconDescription = formatCopyIconDescription(copied, markdownBytes);
@@ -152,6 +153,9 @@
         copyTimeout = setTimeout(() => {
           copied = false;
           copyTimeout = null;
+          // Blur the button so the icon-only tooltip closes; it otherwise
+          // stays open while the button retains focus after the click.
+          copyButtonRef?.blur();
         }, 2000);
       }
     }
@@ -186,6 +190,7 @@
           />
           <Stack orientation="horizontal" align="center" gap={2}>
             <Button
+              bind:ref={copyButtonRef}
               class="copy-markdown-btn"
               kind="ghost"
               size="field"


### PR DESCRIPTION
Running PR for meta improvements to docs:

- hide tooltip after copying
- use icons in overflow menu
- customize menu width
- ideal: copy button supports ghost/light variant