### PR TITLE
perf: register outside-click listener only while open

### DIFF
--- a/src/ContextMenu/ContextMenu.svelte
+++ b/src/ContextMenu/ContextMenu.svelte
@@ -51,6 +51,7 @@
     setContext,
   } from "svelte";
   import { writable } from "svelte/store";
+  import { dismiss } from "../utils/dismiss.js";
   import { isOutsideClick } from "../utils/isOutsideClick.js";
   import { rovingFocus } from "../utils/rovingFocus.js";
 
@@ -176,6 +177,13 @@
   $: level = ctx ? 2 : 1;
   $: currentIndex.set(focusIndex);
   $: menuAriaLabel = ($$props["aria-label"] ?? labelText) || undefined;
+
+  function handleOutsideClick(event) {
+    if (open && isOutsideClick(event, ref)) close();
+  }
+  function handleEscape(event) {
+    if (open && event.key === "Escape") close();
+  }
 </script>
 
 <svelte:window
@@ -184,12 +192,6 @@
     if (level > 1) return;
     if (!ref) return;
     openMenu(event);
-  }}
-  on:click={(event) => {
-    if (open && isOutsideClick(event, ref)) close();
-  }}
-  on:keydown={(event) => {
-    if (open && event.key === "Escape") close();
   }}
 />
 
@@ -205,6 +207,13 @@
       if ($hasPopup) return;
       focusIndex = index;
     },
+  }}
+  use:dismiss={{
+    enabled: open,
+    listeners: [
+      { type: "click", handler: handleOutsideClick },
+      { type: "keydown", handler: handleEscape },
+    ],
   }}
   role="menu"
   tabindex="-1"

--- a/src/Dropdown/Dropdown.svelte
+++ b/src/Dropdown/Dropdown.svelte
@@ -168,6 +168,7 @@
   } from "../ListBox";
   import { getMenuMaxHeight } from "../ListBox/list-box-utils.js";
   import { debounce } from "../utils/debounce.js";
+  import { dismiss } from "../utils/dismiss.js";
   import { isOutsideClick } from "../utils/isOutsideClick.js";
   import { nextEnabledIndex } from "../utils/moveIndex.js";
   import { typeaheadIndex } from "../utils/typeahead.js";
@@ -391,15 +392,13 @@
   ]
     .filter(Boolean)
     .join(" ");
-</script>
 
-<svelte:window
-  on:click={(event) => {
+  function handleOutsideClick(event) {
     if (open && isOutsideClick(event, [ref, effectivePortalMenu && listRef])) {
       open = false;
     }
-  }}
-/>
+  }
+</script>
 
 <div
   class:bx--dropdown__wrapper={true}
@@ -407,6 +406,7 @@
   class:bx--dropdown__wrapper--inline={inline}
   class:bx--list-box__wrapper--inline={inline}
   class:bx--dropdown__wrapper--inline--invalid={inline && showInvalid}
+  use:dismiss={{ enabled: open, type: "click", handler: handleOutsideClick }}
   {...$$restProps}
 >
   {#if labelText || $$slots.labelChildren}

--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -259,6 +259,7 @@
     ListBoxSelection,
   } from "../ListBox";
   import { getMenuMaxHeight } from "../ListBox/list-box-utils.js";
+  import { dismiss } from "../utils/dismiss.js";
   import { isOutsideClick } from "../utils/isOutsideClick.js";
   import { nextEnabledIndex } from "../utils/moveIndex.js";
   import {
@@ -588,29 +589,24 @@
   ]
     .filter(Boolean)
     .join(" ");
-</script>
 
-<svelte:window
-  on:click={(event) => {
+  function handleOutsideInteraction(event) {
     if (
       open &&
       isOutsideClick(event, [multiSelectRef, effectivePortalMenu && listRef])
     ) {
       open = false;
     }
-  }}
-  on:focusin={(event) => {
-    if (
-      open &&
-      isOutsideClick(event, [multiSelectRef, effectivePortalMenu && listRef])
-    ) {
-      open = false;
-    }
-  }}
-/>
+  }
+</script>
 
 <div
   bind:this={multiSelectRef}
+  use:dismiss={{
+    enabled: open,
+    type: ["click", "focusin"],
+    handler: handleOutsideInteraction,
+  }}
   class:bx--multi-select__wrapper={true}
   class:bx--list-box__wrapper={true}
   class:bx--multi-select__wrapper--inline={inline}

--- a/src/OverflowMenu/OverflowMenu.svelte
+++ b/src/OverflowMenu/OverflowMenu.svelte
@@ -88,6 +88,7 @@
   import OverflowMenuHorizontal from "../icons/OverflowMenuHorizontal.svelte";
   import OverflowMenuVertical from "../icons/OverflowMenuVertical.svelte";
   import FloatingPortal from "../Portal/FloatingPortal.svelte";
+  import { dismiss } from "../utils/dismiss.js";
   import { isOutsideClick } from "../utils/isOutsideClick.js";
   import { keyBy } from "../utils/keyBy.js";
   import { rovingFocus } from "../utils/rovingFocus.js";
@@ -245,22 +246,21 @@
   // performance. The previous approach created individual `style` tags per
   // instance, causing overhead when many OverflowMenu components are rendered.
   $: overflowMenuOptionsAfterWidth = buttonWidth ? `${buttonWidth}px` : "2rem";
-</script>
 
-<svelte:window
-  on:click={(event) => {
+  function handleOutsideClick(event) {
     if (menuRef && isOutsideClick(event, [buttonRef, menuRef])) {
       const shouldContinue = dispatch("close", null, { cancelable: true });
       if (shouldContinue) {
         open = false;
       }
     }
-  }}
-/>
+  }
+</script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <button
   bind:this={buttonRef}
+  use:dismiss={{ enabled: open, type: "click", handler: handleOutsideClick }}
   type="button"
   {disabled}
   aria-haspopup="menu"

--- a/src/Popover/Popover.svelte
+++ b/src/Popover/Popover.svelte
@@ -32,24 +32,24 @@
   export let relative = false;
 
   import { createEventDispatcher } from "svelte";
+  import { dismiss } from "../utils/dismiss.js";
   import { isOutsideClick } from "../utils/isOutsideClick.js";
 
   const dispatch = createEventDispatcher();
 
   let ref = null;
-</script>
 
-<svelte:window
-  on:click={(event) => {
+  function handleOutsideClick(event) {
     if (open && isOutsideClick(event, ref)) {
       dispatch("click:outside", { target: event.target });
       if (closeOnOutsideClick) open = false;
     }
-  }}
-/>
+  }
+</script>
 
 <div
   bind:this={ref}
+  use:dismiss={{ enabled: open, type: "click", handler: handleOutsideClick }}
   class:bx--popover={true}
   class:bx--popover--caret={caret}
   class:bx--popover--light={light}

--- a/src/TooltipDefinition/TooltipDefinition.svelte
+++ b/src/TooltipDefinition/TooltipDefinition.svelte
@@ -63,6 +63,7 @@
 
   import { createEventDispatcher, getContext, onMount } from "svelte";
   import FloatingPortal from "../Portal/FloatingPortal.svelte";
+  import { dismiss } from "../utils/dismiss.js";
 
   const insideModal = getContext("carbon:Modal");
 
@@ -113,16 +114,14 @@
       clearTimeout(openTimeout);
     };
   });
-</script>
-
-<svelte:window
-  on:keydown={(event) => {
+  function handleEscape(event) {
     if (event.key === "Escape") hide();
-  }}
-/>
+  }
+</script>
 
 <!-- svelte-ignore a11y-no-static-element-interactions -->
 <span
+  use:dismiss={{ enabled: open, type: "keydown", handler: handleEscape }}
   class:bx--tooltip--definition={true}
   class:bx--tooltip--a11y={true}
   {...$$restProps}

--- a/src/TooltipIcon/TooltipIcon.svelte
+++ b/src/TooltipIcon/TooltipIcon.svelte
@@ -8,6 +8,7 @@
   import { createEventDispatcher, getContext, onMount } from "svelte";
   import { get } from "svelte/store";
   import PortalTooltip from "../Portal/PortalTooltip.svelte";
+  import { dismiss } from "../utils/dismiss.js";
   import { activeTooltipIcon } from "./tooltip-icon-store.js";
 
   /**
@@ -190,18 +191,17 @@
       }
     };
   });
-</script>
 
-<svelte:window
-  on:keydown={(event) => {
+  function handleEscape(event) {
     if (event.key === "Escape") {
       hide();
     }
-  }}
-/>
+  }
+</script>
 
 <button
   bind:this={ref}
+  use:dismiss={{ enabled: open, type: "keydown", handler: handleEscape }}
   {disabled}
   type="button"
   aria-describedby={id}

--- a/src/UIShell/HeaderAction.svelte
+++ b/src/UIShell/HeaderAction.svelte
@@ -70,6 +70,7 @@
   import { slide } from "svelte/transition";
   import Close from "../icons/Close.svelte";
   import Switcher from "../icons/Switcher.svelte";
+  import { dismiss } from "../utils/dismiss.js";
   import { isOutsideClick } from "../utils/isOutsideClick.js";
 
   const dispatch = createEventDispatcher();
@@ -86,10 +87,8 @@
   ]
     .filter(Boolean)
     .join(" ");
-</script>
 
-<svelte:window
-  on:click={(event) => {
+  function handleOutsideClick(event) {
     if (
       isOpen &&
       !preventCloseOnClickOutside &&
@@ -98,11 +97,12 @@
       isOpen = false;
       dispatch("close");
     }
-  }}
-/>
+  }
+</script>
 
 <button
   bind:this={ref}
+  use:dismiss={{ enabled: isOpen, type: "click", handler: handleOutsideClick }}
   type="button"
   class:bx--header__action={true}
   class:bx--header__action--active={isOpen}

--- a/src/UIShell/HeaderNavMenu.svelte
+++ b/src/UIShell/HeaderNavMenu.svelte
@@ -24,6 +24,7 @@
   import { setContext, tick } from "svelte";
   import { writable } from "svelte/store";
   import ChevronDown from "../icons/ChevronDown.svelte";
+  import { dismiss } from "../utils/dismiss.js";
   import { isOutsideClick } from "../utils/isOutsideClick.js";
 
   /**
@@ -81,16 +82,15 @@
 
   $: isCurrentSubmenu =
     Object.values($selectedItems).filter(Boolean).length > 0;
-</script>
 
-<svelte:window
-  on:click={(event) => {
+  function handleOutsideClick(event) {
     if (isOutsideClick(event, ref)) expanded = false;
-  }}
-/>
+  }
+</script>
 
 <li
   role="none"
+  use:dismiss={{ enabled: expanded, type: "click", handler: handleOutsideClick }}
   class:bx--header__submenu={true}
   class:bx--header__submenu--current={isCurrentSubmenu}
   on:click={(event) => {

--- a/src/UIShell/HeaderSearch.svelte
+++ b/src/UIShell/HeaderSearch.svelte
@@ -54,6 +54,7 @@
   import { createEventDispatcher, tick } from "svelte";
   import Close from "../icons/Close.svelte";
   import IconSearch from "../icons/IconSearch.svelte";
+  import { dismiss } from "../utils/dismiss.js";
   import { isOutsideClick } from "../utils/isOutsideClick.js";
 
   const dispatch = createEventDispatcher();
@@ -90,16 +91,15 @@
   $: selectedId = selectedResult
     ? `${id}-menuitem-${selectedResult.id ?? selectedResultIndex}`
     : undefined;
-</script>
 
-<svelte:window
-  on:mouseup={(event) => {
+  function handleOutsideMouseup(event) {
     if (active && isOutsideClick(event, refSearch)) active = false;
-  }}
-/>
+  }
+</script>
 
 <div
   bind:this={refSearch}
+  use:dismiss={{ enabled: active, type: "mouseup", handler: handleOutsideMouseup }}
   class:bx--header__search={true}
   role="search"
   class:bx--header__search--active={active}

--- a/src/utils/dismiss.d.ts
+++ b/src/utils/dismiss.d.ts
@@ -1,0 +1,21 @@
+/** A single window listener managed by the `dismiss` action. */
+export interface DismissListener {
+  type: string;
+  handler: (event: Event) => void;
+  options?: boolean | AddEventListenerOptions;
+}
+
+/** Params for `dismiss`. Use `listeners` or the `type` + `handler` shorthand. */
+export interface DismissParams {
+  enabled: boolean;
+  listeners?: DismissListener[];
+  type?: string | string[];
+  handler?: (event: Event) => void;
+  options?: boolean | AddEventListenerOptions;
+}
+
+/** Adds `window` listeners only while `enabled` is true. SSR-safe. */
+export function dismiss(
+  node: unknown,
+  params: DismissParams,
+): { update: (params: DismissParams) => void; destroy: () => void };

--- a/src/utils/dismiss.js
+++ b/src/utils/dismiss.js
@@ -1,0 +1,92 @@
+// @ts-check
+
+/**
+ * Svelte action that adds `window` listeners only while `enabled` is true.
+ * Handlers refresh in place on update without re-registering listeners.
+ * SSR-safe.
+ *
+ * @param {unknown} _node Host element (unused; listeners attach to `window`).
+ * @param {import("./dismiss.js").DismissParams} params
+ * @returns {{ update: (params: import("./dismiss.js").DismissParams) => void, destroy: () => void }}
+ */
+export function dismiss(_node, params) {
+  let specs = normalize(params);
+  let enabled = !!params.enabled;
+
+  /**
+   * @type {Array<{ type: string, options: boolean | AddEventListenerOptions | undefined, listener: (event: Event) => void, ref: { handler: (event: Event) => void } }>}
+   */
+  let registered = [];
+
+  function add() {
+    if (typeof window === "undefined") return;
+    registered = specs.map((spec) => {
+      const ref = { handler: spec.handler };
+      const listener = (/** @type {Event} */ event) => ref.handler(event);
+      window.addEventListener(spec.type, listener, spec.options);
+      return { type: spec.type, options: spec.options, listener, ref };
+    });
+  }
+
+  function remove() {
+    for (const r of registered) {
+      window.removeEventListener(r.type, r.listener, r.options);
+    }
+    registered = [];
+  }
+
+  if (enabled) add();
+
+  return {
+    /** @param {import("./dismiss.js").DismissParams} next */
+    update(next) {
+      const nextSpecs = normalize(next);
+      const nextEnabled = !!next.enabled;
+      const sameShape =
+        registered.length === nextSpecs.length &&
+        nextSpecs.every(
+          (s, i) => registered[i] && registered[i].type === s.type,
+        );
+
+      if (enabled && nextEnabled && sameShape) {
+        nextSpecs.forEach((s, i) => {
+          registered[i].ref.handler = s.handler;
+        });
+        specs = nextSpecs;
+        return;
+      }
+
+      remove();
+      specs = nextSpecs;
+      enabled = nextEnabled;
+      if (enabled) add();
+    },
+    destroy() {
+      remove();
+    },
+  };
+}
+
+/**
+ * @param {import("./dismiss.js").DismissParams} params
+ * @returns {Array<{ type: string, handler: (event: Event) => void, options: boolean | AddEventListenerOptions | undefined }>}
+ */
+function normalize(params) {
+  if (params.listeners) {
+    return params.listeners.map((l) => ({
+      type: l.type,
+      handler: l.handler,
+      options: l.options,
+    }));
+  }
+  const types = Array.isArray(params.type)
+    ? params.type
+    : params.type == null
+      ? []
+      : [params.type];
+  return types.map((type) => ({
+    type,
+    handler: /** @type {(event: Event) => void} */ (params.handler),
+    options: params.options,
+  }));
+}

--- a/tests/ContextMenu/ContextMenuWindowListeners.test.ts
+++ b/tests/ContextMenu/ContextMenuWindowListeners.test.ts
@@ -1,0 +1,39 @@
+import { render } from "@testing-library/svelte";
+import ContextMenu from "./ContextMenu.test.svelte";
+
+const net = (
+  add: ReturnType<typeof vi.spyOn>,
+  remove: ReturnType<typeof vi.spyOn>,
+  type: string,
+) =>
+  add.mock.calls.filter((c: unknown[]) => c[0] === type).length -
+  remove.mock.calls.filter((c: unknown[]) => c[0] === type).length;
+
+describe("ContextMenu window listeners", () => {
+  test("closed menus register no click/keydown listeners", () => {
+    const add = vi.spyOn(window, "addEventListener");
+    const remove = vi.spyOn(window, "removeEventListener");
+
+    const N = 50;
+    for (let i = 0; i < N; i++) render(ContextMenu, { props: { open: false } });
+
+    expect(net(add, remove, "click")).toBe(0);
+    expect(net(add, remove, "keydown")).toBe(0);
+    expect(net(add, remove, "contextmenu")).toBe(N);
+
+    add.mockRestore();
+    remove.mockRestore();
+  });
+
+  test("an open menu registers one click and one keydown listener", () => {
+    const add = vi.spyOn(window, "addEventListener");
+    const remove = vi.spyOn(window, "removeEventListener");
+
+    render(ContextMenu, { props: { open: true } });
+    expect(net(add, remove, "click")).toBe(1);
+    expect(net(add, remove, "keydown")).toBe(1);
+
+    add.mockRestore();
+    remove.mockRestore();
+  });
+});

--- a/tests/Dropdown/DropdownWindowListeners.test.ts
+++ b/tests/Dropdown/DropdownWindowListeners.test.ts
@@ -1,0 +1,33 @@
+import { render } from "@testing-library/svelte";
+import Dropdown from "./Dropdown.test.svelte";
+
+const netClick = (
+  add: ReturnType<typeof vi.spyOn>,
+  remove: ReturnType<typeof vi.spyOn>,
+) =>
+  add.mock.calls.filter((c: unknown[]) => c[0] === "click").length -
+  remove.mock.calls.filter((c: unknown[]) => c[0] === "click").length;
+
+describe("Dropdown window listeners", () => {
+  test("closed dropdowns register no window click listener", () => {
+    const add = vi.spyOn(window, "addEventListener");
+    const remove = vi.spyOn(window, "removeEventListener");
+
+    for (let i = 0; i < 100; i++) render(Dropdown, { props: { open: false } });
+    expect(netClick(add, remove)).toBe(0);
+
+    add.mockRestore();
+    remove.mockRestore();
+  });
+
+  test("an open dropdown registers exactly one window click listener", () => {
+    const add = vi.spyOn(window, "addEventListener");
+    const remove = vi.spyOn(window, "removeEventListener");
+
+    render(Dropdown, { props: { open: true } });
+    expect(netClick(add, remove)).toBe(1);
+
+    add.mockRestore();
+    remove.mockRestore();
+  });
+});

--- a/tests/MultiSelect/MultiSelectWindowListeners.test.ts
+++ b/tests/MultiSelect/MultiSelectWindowListeners.test.ts
@@ -1,0 +1,39 @@
+import { render } from "@testing-library/svelte";
+import MultiSelect from "./MultiSelect.test.svelte";
+
+const net = (
+  add: ReturnType<typeof vi.spyOn>,
+  remove: ReturnType<typeof vi.spyOn>,
+  type: string,
+) =>
+  add.mock.calls.filter((c: unknown[]) => c[0] === type).length -
+  remove.mock.calls.filter((c: unknown[]) => c[0] === type).length;
+
+describe("MultiSelect window listeners", () => {
+  test("closed MultiSelects register no window click/focusin listeners", () => {
+    const add = vi.spyOn(window, "addEventListener");
+    const remove = vi.spyOn(window, "removeEventListener");
+
+    for (let i = 0; i < 100; i++) {
+      render(MultiSelect, { props: { open: false } });
+    }
+
+    expect(net(add, remove, "click")).toBe(0);
+    expect(net(add, remove, "focusin")).toBe(0);
+
+    add.mockRestore();
+    remove.mockRestore();
+  });
+
+  test("an open MultiSelect registers one click and one focusin listener", () => {
+    const add = vi.spyOn(window, "addEventListener");
+    const remove = vi.spyOn(window, "removeEventListener");
+
+    render(MultiSelect, { props: { open: true } });
+    expect(net(add, remove, "click")).toBe(1);
+    expect(net(add, remove, "focusin")).toBe(1);
+
+    add.mockRestore();
+    remove.mockRestore();
+  });
+});

--- a/tests/OverflowMenu/OverflowMenuWindowListeners.test.ts
+++ b/tests/OverflowMenu/OverflowMenuWindowListeners.test.ts
@@ -1,0 +1,52 @@
+import { render, screen } from "@testing-library/svelte";
+import { user } from "../utils/user";
+import OverflowMenu from "./OverflowMenu.test.svelte";
+
+describe("OverflowMenu window listeners", () => {
+  function netClickListeners(
+    addSpy: ReturnType<typeof vi.spyOn>,
+    removeSpy: ReturnType<typeof vi.spyOn>,
+  ) {
+    const adds = addSpy.mock.calls.filter(
+      (c: unknown[]) => c[0] === "click",
+    ).length;
+    const removes = removeSpy.mock.calls.filter(
+      (c: unknown[]) => c[0] === "click",
+    ).length;
+    return adds - removes;
+  }
+
+  test("rendering many closed menus adds no window click listeners", () => {
+    const addSpy = vi.spyOn(window, "addEventListener");
+    const removeSpy = vi.spyOn(window, "removeEventListener");
+
+    for (let i = 0; i < 1000; i++) {
+      render(OverflowMenu, { props: { id: `menu-${i}` } });
+    }
+
+    expect(netClickListeners(addSpy, removeSpy)).toBe(0);
+
+    addSpy.mockRestore();
+    removeSpy.mockRestore();
+  }, 30_000);
+
+  test("opening adds one window click listener, closing removes it", async () => {
+    const addSpy = vi.spyOn(window, "addEventListener");
+    const removeSpy = vi.spyOn(window, "removeEventListener");
+
+    for (let i = 0; i < 5; i++) {
+      render(OverflowMenu, { props: { id: `menu-${i}` } });
+    }
+    expect(netClickListeners(addSpy, removeSpy)).toBe(0);
+
+    const buttons = screen.getAllByRole("button");
+    await user.click(buttons[0]);
+    expect(netClickListeners(addSpy, removeSpy)).toBe(1);
+
+    await user.keyboard("{Escape}");
+    expect(netClickListeners(addSpy, removeSpy)).toBe(0);
+
+    addSpy.mockRestore();
+    removeSpy.mockRestore();
+  });
+});

--- a/tests/Popover/PopoverWindowListeners.test.ts
+++ b/tests/Popover/PopoverWindowListeners.test.ts
@@ -1,0 +1,33 @@
+import { render } from "@testing-library/svelte";
+import Popover from "./Popover.test.svelte";
+
+const netClick = (
+  add: ReturnType<typeof vi.spyOn>,
+  remove: ReturnType<typeof vi.spyOn>,
+) =>
+  add.mock.calls.filter((c: unknown[]) => c[0] === "click").length -
+  remove.mock.calls.filter((c: unknown[]) => c[0] === "click").length;
+
+describe("Popover window listeners", () => {
+  test("closed popovers register no window click listener", () => {
+    const add = vi.spyOn(window, "addEventListener");
+    const remove = vi.spyOn(window, "removeEventListener");
+
+    for (let i = 0; i < 100; i++) render(Popover, { props: { open: false } });
+    expect(netClick(add, remove)).toBe(0);
+
+    add.mockRestore();
+    remove.mockRestore();
+  });
+
+  test("an open popover registers exactly one window click listener", () => {
+    const add = vi.spyOn(window, "addEventListener");
+    const remove = vi.spyOn(window, "removeEventListener");
+
+    render(Popover, { props: { open: true } });
+    expect(netClick(add, remove)).toBe(1);
+
+    add.mockRestore();
+    remove.mockRestore();
+  });
+});

--- a/tests/TooltipDefinition/TooltipDefinitionWindowListeners.test.ts
+++ b/tests/TooltipDefinition/TooltipDefinitionWindowListeners.test.ts
@@ -1,0 +1,35 @@
+import { render } from "@testing-library/svelte";
+import TooltipDefinition from "./TooltipDefinition.test.svelte";
+
+const net = (
+  add: ReturnType<typeof vi.spyOn>,
+  remove: ReturnType<typeof vi.spyOn>,
+  type: string,
+) =>
+  add.mock.calls.filter((c: unknown[]) => c[0] === type).length -
+  remove.mock.calls.filter((c: unknown[]) => c[0] === type).length;
+
+describe("TooltipDefinition window listeners", () => {
+  test("closed tooltips register no window keydown listener", () => {
+    const add = vi.spyOn(window, "addEventListener");
+    const remove = vi.spyOn(window, "removeEventListener");
+
+    for (let i = 0; i < 100; i++)
+      render(TooltipDefinition, { props: { open: false } });
+    expect(net(add, remove, "keydown")).toBe(0);
+
+    add.mockRestore();
+    remove.mockRestore();
+  });
+
+  test("an open tooltip registers exactly one window keydown listener", () => {
+    const add = vi.spyOn(window, "addEventListener");
+    const remove = vi.spyOn(window, "removeEventListener");
+
+    render(TooltipDefinition, { props: { open: true } });
+    expect(net(add, remove, "keydown")).toBe(1);
+
+    add.mockRestore();
+    remove.mockRestore();
+  });
+});

--- a/tests/TooltipIcon/TooltipIconWindowListeners.test.ts
+++ b/tests/TooltipIcon/TooltipIconWindowListeners.test.ts
@@ -1,0 +1,35 @@
+import { render } from "@testing-library/svelte";
+import TooltipIcon from "./TooltipIcon.test.svelte";
+
+const net = (
+  add: ReturnType<typeof vi.spyOn>,
+  remove: ReturnType<typeof vi.spyOn>,
+  type: string,
+) =>
+  add.mock.calls.filter((c: unknown[]) => c[0] === type).length -
+  remove.mock.calls.filter((c: unknown[]) => c[0] === type).length;
+
+describe("TooltipIcon window listeners", () => {
+  test("closed icon tooltips register no window keydown listener", () => {
+    const add = vi.spyOn(window, "addEventListener");
+    const remove = vi.spyOn(window, "removeEventListener");
+
+    for (let i = 0; i < 100; i++)
+      render(TooltipIcon, { props: { open: false } });
+    expect(net(add, remove, "keydown")).toBe(0);
+
+    add.mockRestore();
+    remove.mockRestore();
+  });
+
+  test("an open icon tooltip registers exactly one window keydown listener", () => {
+    const add = vi.spyOn(window, "addEventListener");
+    const remove = vi.spyOn(window, "removeEventListener");
+
+    render(TooltipIcon, { props: { open: true } });
+    expect(net(add, remove, "keydown")).toBe(1);
+
+    add.mockRestore();
+    remove.mockRestore();
+  });
+});

--- a/tests/utils/dismiss.test.ts
+++ b/tests/utils/dismiss.test.ts
@@ -1,0 +1,158 @@
+import { dismiss } from "../../src/utils/dismiss.js";
+
+describe("dismiss action", () => {
+  let node: HTMLElement;
+
+  beforeEach(() => {
+    node = document.createElement("div");
+    document.body.appendChild(node);
+  });
+
+  afterEach(() => {
+    node.remove();
+  });
+
+  test("registers a window listener only while enabled", () => {
+    const handler = vi.fn();
+    const action = dismiss(node, { enabled: true, type: "click", handler });
+
+    window.dispatchEvent(new MouseEvent("click"));
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    action.destroy();
+  });
+
+  test("does not register while disabled", () => {
+    const handler = vi.fn();
+    const action = dismiss(node, { enabled: false, type: "click", handler });
+
+    window.dispatchEvent(new MouseEvent("click"));
+    expect(handler).not.toHaveBeenCalled();
+
+    action.destroy();
+  });
+
+  test("toggles the listener as enabled flips", () => {
+    const handler = vi.fn();
+    const action = dismiss(node, { enabled: false, type: "click", handler });
+
+    window.dispatchEvent(new MouseEvent("click"));
+    expect(handler).not.toHaveBeenCalled();
+
+    action.update({ enabled: true, type: "click", handler });
+    window.dispatchEvent(new MouseEvent("click"));
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    action.update({ enabled: false, type: "click", handler });
+    window.dispatchEvent(new MouseEvent("click"));
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    action.destroy();
+  });
+
+  test("removes the listener on destroy", () => {
+    const handler = vi.fn();
+    const action = dismiss(node, { enabled: true, type: "click", handler });
+
+    action.destroy();
+    window.dispatchEvent(new MouseEvent("click"));
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  test("shares one handler across multiple event types", () => {
+    const handler = vi.fn();
+    const action = dismiss(node, {
+      enabled: true,
+      type: ["click", "focusin"],
+      handler,
+    });
+
+    window.dispatchEvent(new MouseEvent("click"));
+    window.dispatchEvent(new FocusEvent("focusin"));
+    expect(handler).toHaveBeenCalledTimes(2);
+
+    action.destroy();
+  });
+
+  test("supports distinct handlers per type via listeners", () => {
+    const onClick = vi.fn();
+    const onKeydown = vi.fn();
+    const action = dismiss(node, {
+      enabled: true,
+      listeners: [
+        { type: "click", handler: onClick },
+        { type: "keydown", handler: onKeydown },
+      ],
+    });
+
+    window.dispatchEvent(new MouseEvent("click"));
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(onKeydown).toHaveBeenCalledTimes(1);
+
+    action.destroy();
+  });
+
+  test("refreshes the handler in place without re-adding the listener", () => {
+    const addSpy = vi.spyOn(window, "addEventListener");
+    const first = vi.fn();
+    const second = vi.fn();
+
+    const action = dismiss(node, {
+      enabled: true,
+      type: "click",
+      handler: first,
+    });
+    const addsAfterInit = addSpy.mock.calls.filter(
+      (c) => c[0] === "click",
+    ).length;
+
+    action.update({ enabled: true, type: "click", handler: second });
+
+    const addsAfterUpdate = addSpy.mock.calls.filter(
+      (c) => c[0] === "click",
+    ).length;
+    expect(addsAfterUpdate).toBe(addsAfterInit);
+
+    window.dispatchEvent(new MouseEvent("click"));
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledTimes(1);
+
+    action.destroy();
+    addSpy.mockRestore();
+  });
+
+  test("passes the passive flag through to addEventListener", () => {
+    const addSpy = vi.spyOn(window, "addEventListener");
+    const handler = vi.fn();
+    const action = dismiss(node, {
+      enabled: true,
+      type: "touchmove",
+      handler,
+      options: { passive: true },
+    });
+
+    const call = addSpy.mock.calls.find((c) => c[0] === "touchmove");
+    expect(call?.[2]).toEqual({ passive: true });
+
+    action.destroy();
+    addSpy.mockRestore();
+  });
+
+  test("forwards the real event to the handler", () => {
+    let received: Event | undefined;
+    const action = dismiss(node, {
+      enabled: true,
+      type: "click",
+      handler: (event) => {
+        received = event;
+      },
+    });
+
+    const event = new MouseEvent("click");
+    window.dispatchEvent(event);
+    expect(received).toBe(event);
+
+    action.destroy();
+  });
+});


### PR DESCRIPTION
Many components (menus) have the pattern where an event listener detects when to close the menu.

The issue here is two-fold:

- `svelte:window` pattern immediately registers the event listener, even if not open
- multiple instances of the component instantiates individual event listeners

For performance, only register event listeners when needed, and reuse the event listener. For example, a datatable may have an overflow menu per row. A table with many rows/menus would generate an event listener per row, which is not ideal.