### PR TITLE
feat(overflow-menu-item): support `icon` and `iconRight`

### DIFF
--- a/css/_overflow-menu.scss
+++ b/css/_overflow-menu.scss
@@ -23,3 +23,39 @@
 @include exports('overflow-menu-disabled') {
   @include overflow-menu-disabled;
 }
+
+/// Left/right icon support for overflow menu items (non-standard Carbon layout).
+/// @access private
+/// @group components
+@mixin overflow-menu-option-icons {
+  .#{$prefix}--overflow-menu-options__option-icon {
+    display: flex;
+    flex-shrink: 0;
+    align-items: center;
+
+    // Follow the button text color across hover, danger, and disabled states.
+    svg {
+      fill: currentColor;
+    }
+  }
+
+  .#{$prefix}--overflow-menu-options__option-icon--left {
+    margin-right: $carbon--spacing-03;
+  }
+
+  .#{$prefix}--overflow-menu-options__option-icon--right {
+    margin-left: auto;
+    padding-left: $carbon--spacing-05;
+  }
+
+  // Let the text region grow so the right icon pins to the edge while the text truncates.
+  .#{$prefix}--overflow-menu-options__btn
+    .#{$prefix}--overflow-menu-options__option-content:not(:only-child) {
+    flex: 1;
+    min-width: 0;
+  }
+}
+
+@include exports('overflow-menu-option-icons') {
+  @include overflow-menu-option-icons;
+}

--- a/docs/src/pages/components/OverflowMenu.svx
+++ b/docs/src/pages/components/OverflowMenu.svx
@@ -5,6 +5,10 @@ components: ["OverflowMenu", "OverflowMenuItem"]
 <script>
   import { OverflowMenu, OverflowMenuItem } from "carbon-components-svelte";
   import Add from "carbon-icons-svelte/lib/Add.svelte";
+  import Document from "carbon-icons-svelte/lib/Document.svelte";
+  import Edit from "carbon-icons-svelte/lib/Edit.svelte";
+  import Launch from "carbon-icons-svelte/lib/Launch.svelte";
+  import TrashCan from "carbon-icons-svelte/lib/TrashCan.svelte";
 </script>
 
 Overflow menus provide a compact way to display a list of actions or options. They render as a button that opens a dropdown menu when clicked, making them ideal for secondary actions or overflow content.
@@ -85,6 +89,22 @@ Set `primaryFocus` to `true` on a menu item to focus it when opening the dropdow
   <OverflowMenuItem text="Manage credentials" />
   <OverflowMenuItem href="https://cloud.ibm.com/docs/api-gateway/" target="_blank" text="API documentation" />
   <OverflowMenuItem primaryFocus danger text="Delete service" />
+</OverflowMenu>
+
+## Item icons
+
+Set `icon` for a left icon or `iconRight` for a right icon. The label fills the space between them. Use the `icon` and `iconRight` slots for custom markup.
+
+<OverflowMenu>
+  <OverflowMenuItem icon={Edit} text="Rename" />
+  <OverflowMenuItem
+    icon={Document}
+    iconRight={Launch}
+    text="Open docs"
+    href="https://www.ibm.com/docs"
+    target="_blank"
+  />
+  <OverflowMenuItem hasDivider danger icon={TrashCan} text="Delete" />
 </OverflowMenu>
 
 ## Custom trigger icon

--- a/src/OverflowMenu/OverflowMenuItem.svelte
+++ b/src/OverflowMenu/OverflowMenuItem.svelte
@@ -1,6 +1,12 @@
 <script>
   /**
+   * @template [Icon=any]
+   */
+
+  /**
    * @event {MouseEvent} click
+   * @slot {{}} icon
+   * @slot {{}} iconRight
    */
 
   /**
@@ -14,6 +20,32 @@
    * ```
    */
   export let text = "Provide text";
+
+  /**
+   * Specify an icon to render to the left of the item text.
+   * Alternatively, use the "icon" slot.
+   * @type {Icon}
+   * @example
+   * ```svelte
+   * <OverflowMenuItem>
+   *   <Icon slot="icon" />
+   * </OverflowMenuItem>
+   * ```
+   */
+  export let icon = /** @type {Icon} */ (undefined);
+
+  /**
+   * Specify an icon to render pinned to the right edge of the item.
+   * Alternatively, use the "iconRight" slot.
+   * @type {Icon}
+   * @example
+   * ```svelte
+   * <OverflowMenuItem>
+   *   <Icon slot="iconRight" />
+   * </OverflowMenuItem>
+   * ```
+   */
+  export let iconRight = /** @type {Icon} */ (undefined);
 
   /** Specify the `href` attribute if the item is a link */
   export let href = "";
@@ -130,9 +162,25 @@
     <!-- svelte-ignore a11y-missing-attribute -->
     <!-- svelte-ignore a11y-no-static-element-interactions -->
     <a bind:this={ref} {...buttonProps} on:click={handleClick} on:keydown>
+      {#if $$slots.icon || icon}
+        <div
+          class:bx--overflow-menu-options__option-icon={true}
+          class:bx--overflow-menu-options__option-icon--left={true}
+        >
+          <slot name="icon"><svelte:component this={icon} /></slot>
+        </div>
+      {/if}
       <slot>
         <div class:bx--overflow-menu-options__option-content={true}>{text}</div>
       </slot>
+      {#if $$slots.iconRight || iconRight}
+        <div
+          class:bx--overflow-menu-options__option-icon={true}
+          class:bx--overflow-menu-options__option-icon--right={true}
+        >
+          <slot name="iconRight"><svelte:component this={iconRight} /></slot>
+        </div>
+      {/if}
     </a>
   {:else}
     <button
@@ -142,9 +190,25 @@
       on:click={handleClick}
       on:keydown
     >
+      {#if $$slots.icon || icon}
+        <div
+          class:bx--overflow-menu-options__option-icon={true}
+          class:bx--overflow-menu-options__option-icon--left={true}
+        >
+          <slot name="icon"><svelte:component this={icon} /></slot>
+        </div>
+      {/if}
       <slot>
         <div class:bx--overflow-menu-options__option-content={true}>{text}</div>
       </slot>
+      {#if $$slots.iconRight || iconRight}
+        <div
+          class:bx--overflow-menu-options__option-icon={true}
+          class:bx--overflow-menu-options__option-icon--right={true}
+        >
+          <slot name="iconRight"><svelte:component this={iconRight} /></slot>
+        </div>
+      {/if}
     </button>
   {/if}
 </li>

--- a/tests/OverflowMenu/OverflowMenu.test.ts
+++ b/tests/OverflowMenu/OverflowMenu.test.ts
@@ -12,6 +12,7 @@ import OverflowMenuRel from "./OverflowMenu.rel.test.svelte";
 import OverflowMenu from "./OverflowMenu.test.svelte";
 import OverflowMenuTriggerClose from "./OverflowMenu.triggerClose.test.svelte";
 import OverflowMenuInModal from "./OverflowMenuInModal.test.svelte";
+import OverflowMenuItemIcons from "./OverflowMenuItem.icons.test.svelte";
 
 describe("OverflowMenu", () => {
   // Regression: ?? for aria-label so empty string is used (not fallback)
@@ -309,11 +310,8 @@ describe("OverflowMenu", () => {
     const menuButton = screen.getByRole("button");
     await user.click(menuButton);
 
-    const menuItems = screen.getAllByRole("menuitem");
-    const dangerItem = menuItems.find(
-      (item) => item.textContent === "Delete service",
-    );
-    expect(dangerItem?.parentElement).toHaveClass(
+    const dangerItem = screen.getByRole("menuitem", { name: "Delete service" });
+    expect(dangerItem.parentElement).toHaveClass(
       "bx--overflow-menu-options__option--danger",
     );
   });
@@ -324,11 +322,10 @@ describe("OverflowMenu", () => {
     const menuButton = screen.getByRole("button");
     await user.click(menuButton);
 
-    const menuItems = screen.getAllByRole("menuitem");
-    const buttonItem = menuItems.find(
-      (item) => item.textContent === "Manage credentials",
-    );
-    expect(buttonItem?.tagName).toBe("BUTTON");
+    const buttonItem = screen.getByRole("menuitem", {
+      name: "Manage credentials",
+    });
+    expect(buttonItem.tagName).toBe("BUTTON");
     expect(buttonItem).toHaveAttribute("type", "button");
   });
 
@@ -338,10 +335,9 @@ describe("OverflowMenu", () => {
     const menuButton = screen.getByRole("button");
     await user.click(menuButton);
 
-    const menuItems = screen.getAllByRole("menuitem");
-    const linkItem = menuItems.find(
-      (item) => item.textContent === "API documentation",
-    );
+    const linkItem = screen.getByRole("menuitem", {
+      name: "API documentation",
+    });
     expect(linkItem).toHaveAttribute(
       "href",
       "https://cloud.ibm.com/docs/api-gateway/",
@@ -355,10 +351,9 @@ describe("OverflowMenu", () => {
     const menuButton = screen.getByRole("button");
     await user.click(menuButton);
 
-    const menuItems = screen.getAllByRole("menuitem");
-    const linkItem = menuItems.find(
-      (item) => item.textContent === "API documentation",
-    );
+    const linkItem = screen.getByRole("menuitem", {
+      name: "API documentation",
+    });
     expect(linkItem).toHaveAttribute("target", "_blank");
     expect(linkItem).toHaveAttribute("rel", "noopener noreferrer");
   });
@@ -501,14 +496,13 @@ describe("OverflowMenu", () => {
     await user.click(menuButton);
     expect(menuButton).toHaveAttribute("aria-expanded", "true");
 
-    const menuItems = screen.getAllByRole("menuitem");
-    const disabledLink = menuItems.find(
-      (item) => item.textContent === "API documentation",
-    );
-    expect(disabledLink?.tagName).toBe("A");
+    const disabledLink = screen.getByRole("menuitem", {
+      name: "API documentation",
+    });
+    expect(disabledLink.tagName).toBe("A");
     expect(disabledLink).toHaveAttribute("aria-disabled", "true");
     expect(disabledLink).toHaveAttribute("tabindex", "-1");
-    expect(disabledLink?.parentElement).toHaveClass(
+    expect(disabledLink.parentElement).toHaveClass(
       "bx--overflow-menu-options__option--disabled",
     );
 
@@ -516,7 +510,7 @@ describe("OverflowMenu", () => {
       bubbles: true,
       cancelable: true,
     });
-    disabledLink?.dispatchEvent(clickEvent);
+    disabledLink.dispatchEvent(clickEvent);
 
     expect(clickEvent.defaultPrevented).toBe(true);
     expect(consoleLog).not.toHaveBeenCalledWith("click", "API documentation");
@@ -801,6 +795,42 @@ describe("OverflowMenu", () => {
       } finally {
         Element.prototype.getBoundingClientRect = original;
       }
+    });
+  });
+
+  describe("item icons", () => {
+    it("renders left and right icon wrappers from the icon/iconRight props", () => {
+      render(OverflowMenuItemIcons);
+
+      const bothIcons = screen.getByRole("menuitem", { name: "Both icons" });
+      expect(
+        bothIcons.querySelector(
+          ".bx--overflow-menu-options__option-icon--left",
+        ),
+      ).toBeInTheDocument();
+      expect(
+        bothIcons.querySelector(
+          ".bx--overflow-menu-options__option-icon--right",
+        ),
+      ).toBeInTheDocument();
+    });
+
+    it("renders the iconRight slot content", () => {
+      render(OverflowMenuItemIcons);
+
+      const slotIcon = screen.getByTestId("slot-icon-right");
+      expect(
+        slotIcon.closest(".bx--overflow-menu-options__option-icon--right"),
+      ).toBeInTheDocument();
+    });
+
+    it("omits icon wrappers when neither prop nor slot is provided", () => {
+      render(OverflowMenuItemIcons);
+
+      const noIcons = screen.getByRole("menuitem", { name: "No icons" });
+      expect(
+        noIcons.querySelector(".bx--overflow-menu-options__option-icon"),
+      ).toBeNull();
     });
   });
 

--- a/tests/OverflowMenu/OverflowMenuItem.icons.test.svelte
+++ b/tests/OverflowMenu/OverflowMenuItem.icons.test.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+  import { OverflowMenu, OverflowMenuItem } from "carbon-components-svelte";
+  import Edit from "carbon-icons-svelte/lib/Edit.svelte";
+  import Launch from "carbon-icons-svelte/lib/Launch.svelte";
+</script>
+
+<OverflowMenu open>
+  <OverflowMenuItem icon={Edit} iconRight={Launch} text="Both icons" />
+  <OverflowMenuItem text="Slot icon">
+    <svg slot="iconRight" data-testid="slot-icon-right" />
+  </OverflowMenuItem>
+  <OverflowMenuItem text="No icons" />
+</OverflowMenu>

--- a/tests/Snippets/Snippets.test.svelte
+++ b/tests/Snippets/Snippets.test.svelte
@@ -3,6 +3,8 @@
   import ComboBox from "carbon-components-svelte/ComboBox/ComboBox.svelte";
   import DataTable from "carbon-components-svelte/DataTable/DataTable.svelte";
   import Dropdown from "carbon-components-svelte/Dropdown/Dropdown.svelte";
+  import OverflowMenu from "carbon-components-svelte/OverflowMenu/OverflowMenu.svelte";
+  import OverflowMenuItem from "carbon-components-svelte/OverflowMenu/OverflowMenuItem.svelte";
   import ProgressIndicator from "carbon-components-svelte/ProgressIndicator/ProgressIndicator.svelte";
   import ProgressStep from "carbon-components-svelte/ProgressIndicator/ProgressStep.svelte";
   import Tab from "carbon-components-svelte/Tabs/Tab.svelte";
@@ -62,6 +64,17 @@
     <span data-testid="combobox-item-{index}">{item.text} - index {index}</span>
   {/snippet}
 </ComboBox>
+
+<OverflowMenu data-testid="overflow-menu-snippet" open>
+  <OverflowMenuItem text="Edit">
+    {#snippet icon()}
+      <span data-testid="overflow-item-icon-left">L</span>
+    {/snippet}
+    {#snippet iconRight()}
+      <span data-testid="overflow-item-icon-right">R</span>
+    {/snippet}
+  </OverflowMenuItem>
+</OverflowMenu>
 
 <Button data-testid="button-snippet" as let:props>
   <div {...props} data-testid="custom-button">Custom Button Element</div>

--- a/tests/Snippets/Snippets.test.ts
+++ b/tests/Snippets/Snippets.test.ts
@@ -86,6 +86,24 @@ describe("Svelte 5 Snippets", () => {
     });
   });
 
+  describe("OverflowMenuItem icon/iconRight", () => {
+    it("should render icon and iconRight slots as snippets", () => {
+      render(Snippets);
+
+      const leftIcon = screen.getByTestId("overflow-item-icon-left");
+      expect(leftIcon).toBeInTheDocument();
+      expect(
+        leftIcon.closest(".bx--overflow-menu-options__option-icon--left"),
+      ).toBeInTheDocument();
+
+      const rightIcon = screen.getByTestId("overflow-item-icon-right");
+      expect(rightIcon).toBeInTheDocument();
+      expect(
+        rightIcon.closest(".bx--overflow-menu-options__option-icon--right"),
+      ).toBeInTheDocument();
+    });
+  });
+
   describe("Button", () => {
     it("should render default slot props when using 'as' prop", () => {
       render(Snippets);


### PR DESCRIPTION
Mirroring context menu, support left/right icons for overflow menu items, which aids the visual UX.

---

<img width="830" height="367" alt="Screenshot 2026-06-08 at 7 11 02 PM" src="https://github.com/user-attachments/assets/c3f586ec-ab74-4dc9-828d-ba72e2816568" />
