### PR TITLE
test: use direct imports for faster individual test runs

### DIFF
--- a/tests/Accordion/Accordion.batch-disable.test.svelte
+++ b/tests/Accordion/Accordion.batch-disable.test.svelte
@@ -1,10 +1,8 @@
 <script lang="ts">
-  import {
-    Accordion,
-    AccordionItem,
-    Button,
-    ButtonSet,
-  } from "carbon-components-svelte";
+  import Accordion from "carbon-components-svelte/Accordion/Accordion.svelte";
+  import AccordionItem from "carbon-components-svelte/Accordion/AccordionItem.svelte";
+  import Button from "carbon-components-svelte/Button/Button.svelte";
+  import ButtonSet from "carbon-components-svelte/Button/ButtonSet.svelte";
 
   export let disabled = false;
 

--- a/tests/Accordion/Accordion.disabled.test.svelte
+++ b/tests/Accordion/Accordion.disabled.test.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { Accordion, AccordionItem } from "carbon-components-svelte";
+  import Accordion from "carbon-components-svelte/Accordion/Accordion.svelte";
+  import AccordionItem from "carbon-components-svelte/Accordion/AccordionItem.svelte";
 </script>
 
 <Accordion disabled>

--- a/tests/Accordion/Accordion.programmatic.test.svelte
+++ b/tests/Accordion/Accordion.programmatic.test.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
-  import { Accordion, AccordionItem, Button } from "carbon-components-svelte";
+  import Accordion from "carbon-components-svelte/Accordion/Accordion.svelte";
+  import AccordionItem from "carbon-components-svelte/Accordion/AccordionItem.svelte";
+  import Button from "carbon-components-svelte/Button/Button.svelte";
 
   const items = [
     {

--- a/tests/Accordion/Accordion.skeleton.test.svelte
+++ b/tests/Accordion/Accordion.skeleton.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Accordion } from "carbon-components-svelte";
+  import Accordion from "carbon-components-svelte/Accordion/Accordion.svelte";
 </script>
 
 <Accordion skeleton />

--- a/tests/Accordion/Accordion.test.svelte
+++ b/tests/Accordion/Accordion.test.svelte
@@ -1,7 +1,8 @@
 <svelte:options accessors />
 
 <script lang="ts">
-  import { Accordion, AccordionItem } from "carbon-components-svelte";
+  import Accordion from "carbon-components-svelte/Accordion/Accordion.svelte";
+  import AccordionItem from "carbon-components-svelte/Accordion/AccordionItem.svelte";
   import type { ComponentProps } from "svelte";
 
   export let align: ComponentProps<Accordion>["align"] = "end";

--- a/tests/AspectRatio/AspectRatio.test.svelte
+++ b/tests/AspectRatio/AspectRatio.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { AspectRatio } from "carbon-components-svelte";
+  import AspectRatio from "carbon-components-svelte/AspectRatio/AspectRatio.svelte";
 </script>
 
 <AspectRatio>2x1</AspectRatio>

--- a/tests/Breadcrumb/Breadcrumb.ariaCurrent.test.svelte
+++ b/tests/Breadcrumb/Breadcrumb.ariaCurrent.test.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { Breadcrumb, BreadcrumbItem } from "carbon-components-svelte";
+  import Breadcrumb from "carbon-components-svelte/Breadcrumb/Breadcrumb.svelte";
+  import BreadcrumbItem from "carbon-components-svelte/Breadcrumb/BreadcrumbItem.svelte";
 </script>
 
 <Breadcrumb>

--- a/tests/Breadcrumb/Breadcrumb.dynamic.test.svelte
+++ b/tests/Breadcrumb/Breadcrumb.dynamic.test.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { Breadcrumb, BreadcrumbItem } from "carbon-components-svelte";
+  import Breadcrumb from "carbon-components-svelte/Breadcrumb/Breadcrumb.svelte";
+  import BreadcrumbItem from "carbon-components-svelte/Breadcrumb/BreadcrumbItem.svelte";
 
   type BreadcrumbItemType = { href?: string; text: string };
 

--- a/tests/Breadcrumb/Breadcrumb.labelText.test.svelte
+++ b/tests/Breadcrumb/Breadcrumb.labelText.test.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { Breadcrumb, BreadcrumbItem } from "carbon-components-svelte";
+  import Breadcrumb from "carbon-components-svelte/Breadcrumb/Breadcrumb.svelte";
+  import BreadcrumbItem from "carbon-components-svelte/Breadcrumb/BreadcrumbItem.svelte";
 </script>
 
 <Breadcrumb labelText="Page navigation">

--- a/tests/Breadcrumb/Breadcrumb.noTrailingSlash.test.svelte
+++ b/tests/Breadcrumb/Breadcrumb.noTrailingSlash.test.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { Breadcrumb, BreadcrumbItem } from "carbon-components-svelte";
+  import Breadcrumb from "carbon-components-svelte/Breadcrumb/Breadcrumb.svelte";
+  import BreadcrumbItem from "carbon-components-svelte/Breadcrumb/BreadcrumbItem.svelte";
 </script>
 
 <Breadcrumb noTrailingSlash>

--- a/tests/Breadcrumb/Breadcrumb.size.test.svelte
+++ b/tests/Breadcrumb/Breadcrumb.size.test.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { Breadcrumb, BreadcrumbItem } from "carbon-components-svelte";
+  import Breadcrumb from "carbon-components-svelte/Breadcrumb/Breadcrumb.svelte";
+  import BreadcrumbItem from "carbon-components-svelte/Breadcrumb/BreadcrumbItem.svelte";
 </script>
 
 <Breadcrumb size="sm">

--- a/tests/Breadcrumb/Breadcrumb.skeleton-sm.test.svelte
+++ b/tests/Breadcrumb/Breadcrumb.skeleton-sm.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Breadcrumb } from "carbon-components-svelte";
+  import Breadcrumb from "carbon-components-svelte/Breadcrumb/Breadcrumb.svelte";
 </script>
 
 <Breadcrumb skeleton size="sm" count={2} />

--- a/tests/Breadcrumb/Breadcrumb.skeleton.test.svelte
+++ b/tests/Breadcrumb/Breadcrumb.skeleton.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Breadcrumb } from "carbon-components-svelte";
+  import Breadcrumb from "carbon-components-svelte/Breadcrumb/Breadcrumb.svelte";
 </script>
 
 <Breadcrumb skeleton count={3} />

--- a/tests/Breadcrumb/Breadcrumb.test.svelte
+++ b/tests/Breadcrumb/Breadcrumb.test.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { Breadcrumb, BreadcrumbItem } from "carbon-components-svelte";
+  import Breadcrumb from "carbon-components-svelte/Breadcrumb/Breadcrumb.svelte";
+  import BreadcrumbItem from "carbon-components-svelte/Breadcrumb/BreadcrumbItem.svelte";
 </script>
 
 <Breadcrumb>

--- a/tests/Breakpoint/Breakpoint.test.svelte
+++ b/tests/Breakpoint/Breakpoint.test.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-  import { Breakpoint } from "carbon-components-svelte";
   import type {
     BreakpointSize,
     BreakpointValue,
   } from "carbon-components-svelte/Breakpoint/Breakpoint.svelte";
+  import Breakpoint from "carbon-components-svelte/Breakpoint/Breakpoint.svelte";
   import type { ComponentProps } from "svelte";
 
   export let size: ComponentProps<Breakpoint>["size"] = undefined;

--- a/tests/Breakpoint/BreakpointObserver.test.svelte
+++ b/tests/Breakpoint/BreakpointObserver.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { breakpointObserver } from "carbon-components-svelte";
+  import breakpointObserver from "carbon-components-svelte/Breakpoint/breakpointObserver";
 
   export let smallerThanMd = false;
   export let largerThanMd = false;

--- a/tests/Breakpoint/Breakpoints.test.svelte
+++ b/tests/Breakpoint/Breakpoints.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { breakpoints } from "carbon-components-svelte";
+  import breakpoints from "carbon-components-svelte/Breakpoint/breakpoints";
 </script>
 
 <div data-testid="sm">{breakpoints.sm}</div>

--- a/tests/Button/Button.test.svelte
+++ b/tests/Button/Button.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Button } from "carbon-components-svelte";
+  import Button from "carbon-components-svelte/Button/Button.svelte";
   import Add from "carbon-icons-svelte/lib/Add.svelte";
 </script>
 

--- a/tests/ButtonSet/ButtonSet.test.svelte
+++ b/tests/ButtonSet/ButtonSet.test.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { Button, ButtonSet } from "carbon-components-svelte";
+  import Button from "carbon-components-svelte/Button/Button.svelte";
+  import ButtonSet from "carbon-components-svelte/Button/ButtonSet.svelte";
 
   export let stacked = false;
 </script>

--- a/tests/Checkbox/Checkbox.group.test.svelte
+++ b/tests/Checkbox/Checkbox.group.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Checkbox } from "carbon-components-svelte";
+  import Checkbox from "carbon-components-svelte/Checkbox/Checkbox.svelte";
 
   export let group = ["option-2"];
 

--- a/tests/Checkbox/Checkbox.readonly.test.svelte
+++ b/tests/Checkbox/Checkbox.readonly.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Checkbox } from "carbon-components-svelte";
+  import Checkbox from "carbon-components-svelte/Checkbox/Checkbox.svelte";
 
   export let checked = false;
   export let readonly = false;

--- a/tests/Checkbox/Checkbox.skeleton.test.svelte
+++ b/tests/Checkbox/Checkbox.skeleton.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Checkbox } from "carbon-components-svelte";
+  import Checkbox from "carbon-components-svelte/Checkbox/Checkbox.svelte";
 </script>
 
 <Checkbox skeleton data-testid="checkbox-skeleton" />

--- a/tests/Checkbox/Checkbox.slot.test.svelte
+++ b/tests/Checkbox/Checkbox.slot.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Checkbox } from "carbon-components-svelte";
+  import Checkbox from "carbon-components-svelte/Checkbox/Checkbox.svelte";
 </script>
 
 <Checkbox data-testid="checkbox-slot">

--- a/tests/Checkbox/Checkbox.test.svelte
+++ b/tests/Checkbox/Checkbox.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Checkbox } from "carbon-components-svelte";
+  import Checkbox from "carbon-components-svelte/Checkbox/Checkbox.svelte";
 
   export let checked = false;
   export let indeterminate = false;

--- a/tests/Checkbox/CheckboxGroup.readonly.test.svelte
+++ b/tests/Checkbox/CheckboxGroup.readonly.test.svelte
@@ -1,7 +1,8 @@
 <svelte:options accessors />
 
 <script lang="ts">
-  import { Checkbox, CheckboxGroup } from "carbon-components-svelte";
+  import Checkbox from "carbon-components-svelte/Checkbox/Checkbox.svelte";
+  import CheckboxGroup from "carbon-components-svelte/Checkbox/CheckboxGroup.svelte";
 
   export let selected: string[] = ["1"];
   export let readonly = false;

--- a/tests/Checkbox/CheckboxGroupComponent.test.svelte
+++ b/tests/Checkbox/CheckboxGroupComponent.test.svelte
@@ -1,7 +1,8 @@
 <svelte:options accessors />
 
 <script lang="ts">
-  import { Checkbox, CheckboxGroup } from "carbon-components-svelte";
+  import Checkbox from "carbon-components-svelte/Checkbox/Checkbox.svelte";
+  import CheckboxGroup from "carbon-components-svelte/Checkbox/CheckboxGroup.svelte";
   import type { ComponentProps } from "svelte";
 
   export let selected: ComponentProps<CheckboxGroup>["selected"] = [];

--- a/tests/Checkbox/CheckboxGroupEvents.test.svelte
+++ b/tests/Checkbox/CheckboxGroupEvents.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Checkbox } from "carbon-components-svelte";
+  import Checkbox from "carbon-components-svelte/Checkbox/Checkbox.svelte";
 
   export let group = ["option-2"];
 

--- a/tests/Checkbox/CheckboxGroupReactive.test.svelte
+++ b/tests/Checkbox/CheckboxGroupReactive.test.svelte
@@ -1,7 +1,7 @@
 <svelte:options accessors />
 
 <script lang="ts">
-  import { Checkbox } from "carbon-components-svelte";
+  import Checkbox from "carbon-components-svelte/Checkbox/Checkbox.svelte";
 
   export let group = ["option-2"];
 </script>

--- a/tests/Checkbox/CheckboxGroupStaticSelected.test.svelte
+++ b/tests/Checkbox/CheckboxGroupStaticSelected.test.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { Checkbox, CheckboxGroup } from "carbon-components-svelte";
+  import Checkbox from "carbon-components-svelte/Checkbox/Checkbox.svelte";
+  import CheckboxGroup from "carbon-components-svelte/Checkbox/CheckboxGroup.svelte";
 </script>
 
 <CheckboxGroup

--- a/tests/Checkbox/CheckboxReactiveBind.test.svelte
+++ b/tests/Checkbox/CheckboxReactiveBind.test.svelte
@@ -1,7 +1,7 @@
 <svelte:options accessors />
 
 <script lang="ts">
-  import { Checkbox } from "carbon-components-svelte";
+  import Checkbox from "carbon-components-svelte/Checkbox/Checkbox.svelte";
 
   export let checked = false;
 </script>

--- a/tests/Checkbox/CheckboxReadonlyChange.test.svelte
+++ b/tests/Checkbox/CheckboxReadonlyChange.test.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { Checkbox, CheckboxGroup } from "carbon-components-svelte";
+  import Checkbox from "carbon-components-svelte/Checkbox/Checkbox.svelte";
+  import CheckboxGroup from "carbon-components-svelte/Checkbox/CheckboxGroup.svelte";
 </script>
 
 <CheckboxGroup legendText="Options" readonly selected={["1"]}>

--- a/tests/Checkbox/MultipleCheckboxes.test.svelte
+++ b/tests/Checkbox/MultipleCheckboxes.test.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { Button, Checkbox } from "carbon-components-svelte";
+  import Button from "carbon-components-svelte/Button/Button.svelte";
+  import Checkbox from "carbon-components-svelte/Checkbox/Checkbox.svelte";
 
   export let values = ["Apple", "Banana", "Coconut"];
   export let group = values.slice(0, 2);

--- a/tests/Checkbox/MultipleCheckboxesObject.test.svelte
+++ b/tests/Checkbox/MultipleCheckboxesObject.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Checkbox } from "carbon-components-svelte";
+  import Checkbox from "carbon-components-svelte/Checkbox/Checkbox.svelte";
 
   export let obj = {
     a: false,

--- a/tests/CodeSnippet/CodeSnippetAsync.test.svelte
+++ b/tests/CodeSnippet/CodeSnippetAsync.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { CodeSnippet } from "carbon-components-svelte";
+  import CodeSnippet from "carbon-components-svelte/CodeSnippet/CodeSnippet.svelte";
   import type { ComponentProps } from "svelte";
 
   export let type: ComponentProps<CodeSnippet>["type"];

--- a/tests/CodeSnippet/CodeSnippetAsyncDoubleClick.test.svelte
+++ b/tests/CodeSnippet/CodeSnippetAsyncDoubleClick.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { CodeSnippet } from "carbon-components-svelte";
+  import CodeSnippet from "carbon-components-svelte/CodeSnippet/CodeSnippet.svelte";
   import type { ComponentProps } from "svelte";
 
   export let type: ComponentProps<CodeSnippet>["type"];

--- a/tests/CodeSnippet/CodeSnippetBindShowMoreLess.test.svelte
+++ b/tests/CodeSnippet/CodeSnippetBindShowMoreLess.test.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
-  import { CodeSnippet } from "carbon-components-svelte";
+  import CodeSnippet from "carbon-components-svelte/CodeSnippet/CodeSnippet.svelte";
+  import type { ComponentProps } from "svelte";
 
-  export let type: "single" | "inline" | "multi" = "multi";
+  export let type: ComponentProps<CodeSnippet>["type"] = "multi";
   export let showMoreLess = true;
 </script>
 

--- a/tests/CodeSnippet/CodeSnippetCopyButton.test.svelte
+++ b/tests/CodeSnippet/CodeSnippetCopyButton.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { CodeSnippet } from "carbon-components-svelte";
+  import CodeSnippet from "carbon-components-svelte/CodeSnippet/CodeSnippet.svelte";
   import Checkmark from "carbon-icons-svelte/lib/Checkmark.svelte";
 </script>
 

--- a/tests/CodeSnippet/CodeSnippetCopyButtonMouseEnter.test.svelte
+++ b/tests/CodeSnippet/CodeSnippetCopyButtonMouseEnter.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { CodeSnippet } from "carbon-components-svelte";
+  import CodeSnippet from "carbon-components-svelte/CodeSnippet/CodeSnippet.svelte";
   import type { ComponentProps } from "svelte";
 
   export let type: ComponentProps<CodeSnippet>["type"];

--- a/tests/CodeSnippet/CodeSnippetCopyButtonMouseLeave.test.svelte
+++ b/tests/CodeSnippet/CodeSnippetCopyButtonMouseLeave.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { CodeSnippet } from "carbon-components-svelte";
+  import CodeSnippet from "carbon-components-svelte/CodeSnippet/CodeSnippet.svelte";
   import type { ComponentProps } from "svelte";
 
   export let type: ComponentProps<CodeSnippet>["type"];

--- a/tests/CodeSnippet/CodeSnippetCopyError.test.svelte
+++ b/tests/CodeSnippet/CodeSnippetCopyError.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { CodeSnippet } from "carbon-components-svelte";
+  import CodeSnippet from "carbon-components-svelte/CodeSnippet/CodeSnippet.svelte";
   import type { ComponentProps } from "svelte";
 
   export let type: ComponentProps<CodeSnippet>["type"];

--- a/tests/CodeSnippet/CodeSnippetCopyRef.test.svelte
+++ b/tests/CodeSnippet/CodeSnippetCopyRef.test.svelte
@@ -1,7 +1,7 @@
 <svelte:options accessors />
 
 <script lang="ts">
-  import { CodeSnippet } from "carbon-components-svelte";
+  import CodeSnippet from "carbon-components-svelte/CodeSnippet/CodeSnippet.svelte";
   import type { ComponentProps } from "svelte";
 
   export let type: ComponentProps<CodeSnippet>["type"] = "inline";

--- a/tests/CodeSnippet/CodeSnippetCustomEvents.test.svelte
+++ b/tests/CodeSnippet/CodeSnippetCustomEvents.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { CodeSnippet } from "carbon-components-svelte";
+  import CodeSnippet from "carbon-components-svelte/CodeSnippet/CodeSnippet.svelte";
 
   let copyCount = 0;
 

--- a/tests/CodeSnippet/CodeSnippetDisabled.test.svelte
+++ b/tests/CodeSnippet/CodeSnippetDisabled.test.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
-  import { CodeSnippet } from "carbon-components-svelte";
+  import CodeSnippet from "carbon-components-svelte/CodeSnippet/CodeSnippet.svelte";
+  import type { ComponentProps } from "svelte";
 
-  export let type: "single" | "multi" = "single";
+  export let type: ComponentProps<CodeSnippet>["type"] = "single";
 </script>
 
 <CodeSnippet {type} disabled code="npm install --save @carbon/icons" />

--- a/tests/CodeSnippet/CodeSnippetDoubleClick.test.svelte
+++ b/tests/CodeSnippet/CodeSnippetDoubleClick.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { CodeSnippet } from "carbon-components-svelte";
+  import CodeSnippet from "carbon-components-svelte/CodeSnippet/CodeSnippet.svelte";
   import type { ComponentProps } from "svelte";
 
   export let type: ComponentProps<CodeSnippet>["type"];

--- a/tests/CodeSnippet/CodeSnippetExpandable.test.svelte
+++ b/tests/CodeSnippet/CodeSnippetExpandable.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { CodeSnippet } from "carbon-components-svelte";
+  import CodeSnippet from "carbon-components-svelte/CodeSnippet/CodeSnippet.svelte";
 </script>
 
 <CodeSnippet

--- a/tests/CodeSnippet/CodeSnippetInitialEvent.test.svelte
+++ b/tests/CodeSnippet/CodeSnippetInitialEvent.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { CodeSnippet } from "carbon-components-svelte";
+  import CodeSnippet from "carbon-components-svelte/CodeSnippet/CodeSnippet.svelte";
 
   export let expanded = false;
 

--- a/tests/CodeSnippet/CodeSnippetInline.test.svelte
+++ b/tests/CodeSnippet/CodeSnippetInline.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { CodeSnippet } from "carbon-components-svelte";
+  import CodeSnippet from "carbon-components-svelte/CodeSnippet/CodeSnippet.svelte";
 </script>
 
 <CodeSnippet type="inline" code="npm install -g @carbon/cli" />

--- a/tests/CodeSnippet/CodeSnippetInlineInModal.test.svelte
+++ b/tests/CodeSnippet/CodeSnippetInlineInModal.test.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { CodeSnippet, Modal } from "carbon-components-svelte";
+  import CodeSnippet from "carbon-components-svelte/CodeSnippet/CodeSnippet.svelte";
+  import Modal from "carbon-components-svelte/Modal/Modal.svelte";
   import type { ComponentProps } from "svelte";
 
   export let modalOpen = true;

--- a/tests/CodeSnippet/CodeSnippetMouseEnter.test.svelte
+++ b/tests/CodeSnippet/CodeSnippetMouseEnter.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { CodeSnippet } from "carbon-components-svelte";
+  import CodeSnippet from "carbon-components-svelte/CodeSnippet/CodeSnippet.svelte";
   import type { ComponentProps } from "svelte";
 
   export let type: ComponentProps<CodeSnippet>["type"];

--- a/tests/CodeSnippet/CodeSnippetMultiline.test.svelte
+++ b/tests/CodeSnippet/CodeSnippetMultiline.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { CodeSnippet } from "carbon-components-svelte";
+  import CodeSnippet from "carbon-components-svelte/CodeSnippet/CodeSnippet.svelte";
 </script>
 
 <CodeSnippet

--- a/tests/CodeSnippet/CodeSnippetNullishAriaLabel.test.svelte
+++ b/tests/CodeSnippet/CodeSnippetNullishAriaLabel.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { CodeSnippet } from "carbon-components-svelte";
+  import CodeSnippet from "carbon-components-svelte/CodeSnippet/CodeSnippet.svelte";
   import type { ComponentProps } from "svelte";
 
   export let ariaLabel: ComponentProps<CodeSnippet>["aria-label"] = undefined;

--- a/tests/CodeSnippet/CodeSnippetPortalTooltipTimeout.test.svelte
+++ b/tests/CodeSnippet/CodeSnippetPortalTooltipTimeout.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { CodeSnippet } from "carbon-components-svelte";
+  import CodeSnippet from "carbon-components-svelte/CodeSnippet/CodeSnippet.svelte";
   import type { ComponentProps } from "svelte";
 
   export let portalTooltip: ComponentProps<CodeSnippet>["portalTooltip"] = true;

--- a/tests/CodeSnippet/CodeSnippetRestPropsButton.test.svelte
+++ b/tests/CodeSnippet/CodeSnippetRestPropsButton.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { CodeSnippet } from "carbon-components-svelte";
+  import CodeSnippet from "carbon-components-svelte/CodeSnippet/CodeSnippet.svelte";
   import type { ComponentProps } from "svelte";
 
   const props: ComponentProps<CodeSnippet> = {

--- a/tests/CodeSnippet/CodeSnippetRestPropsSingle.test.svelte
+++ b/tests/CodeSnippet/CodeSnippetRestPropsSingle.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { CodeSnippet } from "carbon-components-svelte";
+  import CodeSnippet from "carbon-components-svelte/CodeSnippet/CodeSnippet.svelte";
   import type { ComponentProps } from "svelte";
 
   const props: ComponentProps<CodeSnippet> = {

--- a/tests/CodeSnippet/CodeSnippetRestPropsSpan.test.svelte
+++ b/tests/CodeSnippet/CodeSnippetRestPropsSpan.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { CodeSnippet } from "carbon-components-svelte";
+  import CodeSnippet from "carbon-components-svelte/CodeSnippet/CodeSnippet.svelte";
   import type { ComponentProps } from "svelte";
 
   const props: ComponentProps<CodeSnippet> = {

--- a/tests/CodeSnippet/CodeSnippetWithCustomCopyText.test.svelte
+++ b/tests/CodeSnippet/CodeSnippetWithCustomCopyText.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { CodeSnippet } from "carbon-components-svelte";
+  import CodeSnippet from "carbon-components-svelte/CodeSnippet/CodeSnippet.svelte";
 </script>
 
 <CodeSnippet

--- a/tests/CodeSnippet/CodeSnippetWithHideShowMore.test.svelte
+++ b/tests/CodeSnippet/CodeSnippetWithHideShowMore.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { CodeSnippet } from "carbon-components-svelte";
+  import CodeSnippet from "carbon-components-svelte/CodeSnippet/CodeSnippet.svelte";
 </script>
 
 <CodeSnippet

--- a/tests/CodeSnippet/CodeSnippetWithWrapText.test.svelte
+++ b/tests/CodeSnippet/CodeSnippetWithWrapText.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { CodeSnippet } from "carbon-components-svelte";
+  import CodeSnippet from "carbon-components-svelte/CodeSnippet/CodeSnippet.svelte";
 </script>
 
 <CodeSnippet

--- a/tests/CodeSnippet/CodeSnippetWrapperMouseEnter.test.svelte
+++ b/tests/CodeSnippet/CodeSnippetWrapperMouseEnter.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { CodeSnippet } from "carbon-components-svelte";
+  import CodeSnippet from "carbon-components-svelte/CodeSnippet/CodeSnippet.svelte";
 
   export let onMouseEnter = (_event: MouseEvent) => {};
 </script>

--- a/tests/Column/Column.test.svelte
+++ b/tests/Column/Column.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Column } from "carbon-components-svelte";
+  import Column from "carbon-components-svelte/Grid/Column.svelte";
   import type { ComponentProps } from "svelte";
 
   export let as = false;

--- a/tests/ComposedModal/ComposedModal.test.svelte
+++ b/tests/ComposedModal/ComposedModal.test.svelte
@@ -1,10 +1,8 @@
 <script lang="ts">
-  import {
-    ComposedModal,
-    ModalBody,
-    ModalFooter,
-    ModalHeader,
-  } from "carbon-components-svelte";
+  import ComposedModal from "carbon-components-svelte/ComposedModal/ComposedModal.svelte";
+  import ModalBody from "carbon-components-svelte/ComposedModal/ModalBody.svelte";
+  import ModalFooter from "carbon-components-svelte/ComposedModal/ModalFooter.svelte";
+  import ModalHeader from "carbon-components-svelte/ComposedModal/ModalHeader.svelte";
   import type { ComponentProps } from "svelte";
 
   export let open: ComponentProps<ComposedModal>["open"] = false;

--- a/tests/ComposedModal/ComposedModalFocusReturn.test.svelte
+++ b/tests/ComposedModal/ComposedModalFocusReturn.test.svelte
@@ -1,10 +1,8 @@
 <script lang="ts">
-  import {
-    ComposedModal,
-    ModalBody,
-    ModalFooter,
-    ModalHeader,
-  } from "carbon-components-svelte";
+  import ComposedModal from "carbon-components-svelte/ComposedModal/ComposedModal.svelte";
+  import ModalBody from "carbon-components-svelte/ComposedModal/ModalBody.svelte";
+  import ModalFooter from "carbon-components-svelte/ComposedModal/ModalFooter.svelte";
+  import ModalHeader from "carbon-components-svelte/ComposedModal/ModalHeader.svelte";
 
   let open = false;
 </script>

--- a/tests/ComposedModal/ComposedModalFocusTrap.test.svelte
+++ b/tests/ComposedModal/ComposedModalFocusTrap.test.svelte
@@ -1,12 +1,10 @@
 <script lang="ts">
-  import {
-    ComposedModal,
-    Dropdown,
-    ModalBody,
-    ModalFooter,
-    ModalHeader,
-    TextInput,
-  } from "carbon-components-svelte";
+  import ComposedModal from "carbon-components-svelte/ComposedModal/ComposedModal.svelte";
+  import ModalBody from "carbon-components-svelte/ComposedModal/ModalBody.svelte";
+  import ModalFooter from "carbon-components-svelte/ComposedModal/ModalFooter.svelte";
+  import ModalHeader from "carbon-components-svelte/ComposedModal/ModalHeader.svelte";
+  import Dropdown from "carbon-components-svelte/Dropdown/Dropdown.svelte";
+  import TextInput from "carbon-components-svelte/TextInput/TextInput.svelte";
 
   export let open = false;
 </script>

--- a/tests/ComposedModal/ModalBody.test.svelte
+++ b/tests/ComposedModal/ModalBody.test.svelte
@@ -1,9 +1,7 @@
 <script lang="ts">
-  import {
-    ComposedModal,
-    ModalBody,
-    ModalHeader,
-  } from "carbon-components-svelte";
+  import ComposedModal from "carbon-components-svelte/ComposedModal/ComposedModal.svelte";
+  import ModalBody from "carbon-components-svelte/ComposedModal/ModalBody.svelte";
+  import ModalHeader from "carbon-components-svelte/ComposedModal/ModalHeader.svelte";
   import type { ComponentProps } from "svelte";
 
   export let open = true;

--- a/tests/ComposedModal/ModalFooter.test.svelte
+++ b/tests/ComposedModal/ModalFooter.test.svelte
@@ -1,10 +1,8 @@
 <script lang="ts">
-  import {
-    ComposedModal,
-    ModalBody,
-    ModalFooter,
-    ModalHeader,
-  } from "carbon-components-svelte";
+  import ComposedModal from "carbon-components-svelte/ComposedModal/ComposedModal.svelte";
+  import ModalBody from "carbon-components-svelte/ComposedModal/ModalBody.svelte";
+  import ModalFooter from "carbon-components-svelte/ComposedModal/ModalFooter.svelte";
+  import ModalHeader from "carbon-components-svelte/ComposedModal/ModalHeader.svelte";
   import type { ComponentProps } from "svelte";
 
   export let open = true;

--- a/tests/ComposedModal/ModalHeader.test.svelte
+++ b/tests/ComposedModal/ModalHeader.test.svelte
@@ -1,9 +1,7 @@
 <script lang="ts">
-  import {
-    ComposedModal,
-    ModalBody,
-    ModalHeader,
-  } from "carbon-components-svelte";
+  import ComposedModal from "carbon-components-svelte/ComposedModal/ComposedModal.svelte";
+  import ModalBody from "carbon-components-svelte/ComposedModal/ModalBody.svelte";
+  import ModalHeader from "carbon-components-svelte/ComposedModal/ModalHeader.svelte";
   import type { ComponentProps } from "svelte";
 
   export let open = true;

--- a/tests/ContainedList/ContainedList.labelChildren.test.svelte
+++ b/tests/ContainedList/ContainedList.labelChildren.test.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { ContainedList, ContainedListItem } from "carbon-components-svelte";
+  import ContainedList from "carbon-components-svelte/ContainedList/ContainedList.svelte";
+  import ContainedListItem from "carbon-components-svelte/ContainedList/ContainedListItem.svelte";
 </script>
 
 <ContainedList>

--- a/tests/ContainedList/ContainedList.test.svelte
+++ b/tests/ContainedList/ContainedList.test.svelte
@@ -1,10 +1,8 @@
 <script lang="ts">
-  import {
-    Button,
-    ContainedList,
-    ContainedListItem,
-    Search,
-  } from "carbon-components-svelte";
+  import Button from "carbon-components-svelte/Button/Button.svelte";
+  import ContainedList from "carbon-components-svelte/ContainedList/ContainedList.svelte";
+  import ContainedListItem from "carbon-components-svelte/ContainedList/ContainedListItem.svelte";
+  import Search from "carbon-components-svelte/Search/Search.svelte";
   import Add from "carbon-icons-svelte/lib/Add.svelte";
   import Close from "carbon-icons-svelte/lib/Close.svelte";
   import type { ComponentProps } from "svelte";

--- a/tests/ContainedList/ContainedListItem.action.test.svelte
+++ b/tests/ContainedList/ContainedListItem.action.test.svelte
@@ -1,9 +1,7 @@
 <script lang="ts">
-  import {
-    Button,
-    ContainedList,
-    ContainedListItem,
-  } from "carbon-components-svelte";
+  import Button from "carbon-components-svelte/Button/Button.svelte";
+  import ContainedList from "carbon-components-svelte/ContainedList/ContainedList.svelte";
+  import ContainedListItem from "carbon-components-svelte/ContainedList/ContainedListItem.svelte";
   import Close from "carbon-icons-svelte/lib/Close.svelte";
 </script>
 

--- a/tests/ContentSwitcher/ContentSwitcher.custom.test.svelte
+++ b/tests/ContentSwitcher/ContentSwitcher.custom.test.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { ContentSwitcher, Switch } from "carbon-components-svelte";
+  import ContentSwitcher from "carbon-components-svelte/ContentSwitcher/ContentSwitcher.svelte";
+  import Switch from "carbon-components-svelte/ContentSwitcher/Switch.svelte";
 </script>
 
 <ContentSwitcher>

--- a/tests/ContentSwitcher/ContentSwitcher.disabled.test.svelte
+++ b/tests/ContentSwitcher/ContentSwitcher.disabled.test.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { ContentSwitcher, Switch } from "carbon-components-svelte";
+  import ContentSwitcher from "carbon-components-svelte/ContentSwitcher/ContentSwitcher.svelte";
+  import Switch from "carbon-components-svelte/ContentSwitcher/Switch.svelte";
 </script>
 
 <ContentSwitcher>

--- a/tests/ContentSwitcher/ContentSwitcher.disabledNav.test.svelte
+++ b/tests/ContentSwitcher/ContentSwitcher.disabledNav.test.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { ContentSwitcher, Switch } from "carbon-components-svelte";
+  import ContentSwitcher from "carbon-components-svelte/ContentSwitcher/ContentSwitcher.svelte";
+  import Switch from "carbon-components-svelte/ContentSwitcher/Switch.svelte";
   import type { ComponentProps } from "svelte";
 
   export let selectionMode: ComponentProps<ContentSwitcher>["selectionMode"] =

--- a/tests/ContentSwitcher/ContentSwitcher.dynamic.test.svelte
+++ b/tests/ContentSwitcher/ContentSwitcher.dynamic.test.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { ContentSwitcher, Switch } from "carbon-components-svelte";
+  import ContentSwitcher from "carbon-components-svelte/ContentSwitcher/ContentSwitcher.svelte";
+  import Switch from "carbon-components-svelte/ContentSwitcher/Switch.svelte";
 
   export let show = true;
 </script>

--- a/tests/ContentSwitcher/ContentSwitcher.nested.test.svelte
+++ b/tests/ContentSwitcher/ContentSwitcher.nested.test.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { ContentSwitcher, Switch } from "carbon-components-svelte";
+  import ContentSwitcher from "carbon-components-svelte/ContentSwitcher/ContentSwitcher.svelte";
+  import Switch from "carbon-components-svelte/ContentSwitcher/Switch.svelte";
 </script>
 
 <ContentSwitcher>

--- a/tests/ContentSwitcher/ContentSwitcher.selectedIndex.test.svelte
+++ b/tests/ContentSwitcher/ContentSwitcher.selectedIndex.test.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { ContentSwitcher, Switch } from "carbon-components-svelte";
+  import ContentSwitcher from "carbon-components-svelte/ContentSwitcher/ContentSwitcher.svelte";
+  import Switch from "carbon-components-svelte/ContentSwitcher/Switch.svelte";
 
   export let selectedIndex = 1;
 </script>

--- a/tests/ContentSwitcher/ContentSwitcher.selectionMode.test.svelte
+++ b/tests/ContentSwitcher/ContentSwitcher.selectionMode.test.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { ContentSwitcher, Switch } from "carbon-components-svelte";
+  import ContentSwitcher from "carbon-components-svelte/ContentSwitcher/ContentSwitcher.svelte";
+  import Switch from "carbon-components-svelte/ContentSwitcher/Switch.svelte";
   import type { ComponentProps } from "svelte";
 
   export let selectionMode: ComponentProps<ContentSwitcher>["selectionMode"] =

--- a/tests/ContentSwitcher/ContentSwitcher.size.test.svelte
+++ b/tests/ContentSwitcher/ContentSwitcher.size.test.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { ContentSwitcher, Switch } from "carbon-components-svelte";
+  import ContentSwitcher from "carbon-components-svelte/ContentSwitcher/ContentSwitcher.svelte";
+  import Switch from "carbon-components-svelte/ContentSwitcher/Switch.svelte";
 </script>
 
 <ContentSwitcher size="sm">

--- a/tests/ContentSwitcher/ContentSwitcher.test.svelte
+++ b/tests/ContentSwitcher/ContentSwitcher.test.svelte
@@ -1,7 +1,8 @@
 <svelte:options accessors />
 
 <script lang="ts">
-  import { ContentSwitcher, Switch } from "carbon-components-svelte";
+  import ContentSwitcher from "carbon-components-svelte/ContentSwitcher/ContentSwitcher.svelte";
+  import Switch from "carbon-components-svelte/ContentSwitcher/Switch.svelte";
   import type { ComponentProps } from "svelte";
 
   export let selectedIndex: ComponentProps<ContentSwitcher>["selectedIndex"] = 0;

--- a/tests/ContextMenu/ContextMenu.preventDefault.test.svelte
+++ b/tests/ContextMenu/ContextMenu.preventDefault.test.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { ContextMenu, ContextMenuOption } from "carbon-components-svelte";
+  import ContextMenu from "carbon-components-svelte/ContextMenu/ContextMenu.svelte";
+  import ContextMenuOption from "carbon-components-svelte/ContextMenu/ContextMenuOption.svelte";
   import type { ComponentProps } from "svelte";
 
   export let open = false;

--- a/tests/ContextMenu/ContextMenu.target.test.svelte
+++ b/tests/ContextMenu/ContextMenu.target.test.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { ContextMenu, ContextMenuOption } from "carbon-components-svelte";
+  import ContextMenu from "carbon-components-svelte/ContextMenu/ContextMenu.svelte";
+  import ContextMenuOption from "carbon-components-svelte/ContextMenu/ContextMenuOption.svelte";
   import { onMount } from "svelte";
 
   let targetA: HTMLElement | null = null;

--- a/tests/ContextMenu/ContextMenu.test.svelte
+++ b/tests/ContextMenu/ContextMenu.test.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { ContextMenu, ContextMenuOption } from "carbon-components-svelte";
+  import ContextMenu from "carbon-components-svelte/ContextMenu/ContextMenu.svelte";
+  import ContextMenuOption from "carbon-components-svelte/ContextMenu/ContextMenuOption.svelte";
   import type { ComponentProps } from "svelte";
 
   export let target: ComponentProps<ContextMenu>["target"] = null;

--- a/tests/ContextMenu/ContextMenuGroup.test.svelte
+++ b/tests/ContextMenu/ContextMenuGroup.test.svelte
@@ -1,9 +1,7 @@
 <script lang="ts">
-  import {
-    ContextMenu,
-    ContextMenuGroup,
-    ContextMenuOption,
-  } from "carbon-components-svelte";
+  import ContextMenu from "carbon-components-svelte/ContextMenu/ContextMenu.svelte";
+  import ContextMenuGroup from "carbon-components-svelte/ContextMenu/ContextMenuGroup.svelte";
+  import ContextMenuOption from "carbon-components-svelte/ContextMenu/ContextMenuOption.svelte";
   import type { ComponentProps } from "svelte";
 
   export let selectedIds: ComponentProps<ContextMenuGroup>["selectedIds"] = [];

--- a/tests/ContextMenu/ContextMenuOption.icon.test.svelte
+++ b/tests/ContextMenu/ContextMenuOption.icon.test.svelte
@@ -1,9 +1,7 @@
 <script lang="ts">
-  import {
-    ContextMenu,
-    ContextMenuDivider,
-    ContextMenuOption,
-  } from "carbon-components-svelte";
+  import ContextMenu from "carbon-components-svelte/ContextMenu/ContextMenu.svelte";
+  import ContextMenuDivider from "carbon-components-svelte/ContextMenu/ContextMenuDivider.svelte";
+  import ContextMenuOption from "carbon-components-svelte/ContextMenu/ContextMenuOption.svelte";
   import CopyFile from "carbon-icons-svelte/lib/CopyFile.svelte";
   import TrashCan from "carbon-icons-svelte/lib/TrashCan.svelte";
 

--- a/tests/ContextMenu/ContextMenuOption.role.test.svelte
+++ b/tests/ContextMenu/ContextMenuOption.role.test.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { ContextMenu, ContextMenuOption } from "carbon-components-svelte";
+  import ContextMenu from "carbon-components-svelte/ContextMenu/ContextMenu.svelte";
+  import ContextMenuOption from "carbon-components-svelte/ContextMenu/ContextMenuOption.svelte";
 
   export let selectable = true;
 </script>

--- a/tests/ContextMenu/ContextMenuOption.slot.test.svelte
+++ b/tests/ContextMenu/ContextMenuOption.slot.test.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { ContextMenu, ContextMenuOption } from "carbon-components-svelte";
+  import ContextMenu from "carbon-components-svelte/ContextMenu/ContextMenu.svelte";
+  import ContextMenuOption from "carbon-components-svelte/ContextMenu/ContextMenuOption.svelte";
 </script>
 
 <ContextMenu open={true} x={0} y={0}>

--- a/tests/CopyButton/CopyButton.test.svelte
+++ b/tests/CopyButton/CopyButton.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { CopyButton } from "carbon-components-svelte";
+  import CopyButton from "carbon-components-svelte/CopyButton/CopyButton.svelte";
   import Checkmark from "carbon-icons-svelte/lib/Checkmark.svelte";
   import type { ComponentProps } from "svelte";
 

--- a/tests/CopyButton/CopyButtonAsync.test.svelte
+++ b/tests/CopyButton/CopyButtonAsync.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { CopyButton } from "carbon-components-svelte";
+  import CopyButton from "carbon-components-svelte/CopyButton/CopyButton.svelte";
 
   export let copy: (text: string) => void | Promise<void> = async () => {};
   export let onCopy = () => {};

--- a/tests/CopyButton/CopyButtonAsyncDoubleClick.test.svelte
+++ b/tests/CopyButton/CopyButtonAsyncDoubleClick.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { CopyButton } from "carbon-components-svelte";
+  import CopyButton from "carbon-components-svelte/CopyButton/CopyButton.svelte";
 
   export let copy: (text: string) => void | Promise<void>;
 

--- a/tests/CopyButton/CopyButtonDoubleClick.test.svelte
+++ b/tests/CopyButton/CopyButtonDoubleClick.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { CopyButton } from "carbon-components-svelte";
+  import CopyButton from "carbon-components-svelte/CopyButton/CopyButton.svelte";
 
   export let copy: (text: string) => void;
 

--- a/tests/CopyButton/CopyButtonInModal.test.svelte
+++ b/tests/CopyButton/CopyButtonInModal.test.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { CopyButton, Modal } from "carbon-components-svelte";
+  import CopyButton from "carbon-components-svelte/CopyButton/CopyButton.svelte";
+  import Modal from "carbon-components-svelte/Modal/Modal.svelte";
   import type { ComponentProps } from "svelte";
 
   export let modalOpen = true;

--- a/tests/CopyButton/CopyButtonMouseEnter.test.svelte
+++ b/tests/CopyButton/CopyButtonMouseEnter.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { CopyButton } from "carbon-components-svelte";
+  import CopyButton from "carbon-components-svelte/CopyButton/CopyButton.svelte";
 
   export let onMouseEnter = () => {};
 </script>

--- a/tests/CopyButton/CopyButtonPortalTooltipTimeout.test.svelte
+++ b/tests/CopyButton/CopyButtonPortalTooltipTimeout.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { CopyButton } from "carbon-components-svelte";
+  import CopyButton from "carbon-components-svelte/CopyButton/CopyButton.svelte";
   import type { ComponentProps } from "svelte";
 
   export let portalTooltip: ComponentProps<CopyButton>["portalTooltip"] = true;

--- a/tests/DataTable/DataTableToolbarSize.test.svelte
+++ b/tests/DataTable/DataTableToolbarSize.test.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
-  import { DataTable, Toolbar, ToolbarContent } from "carbon-components-svelte";
+  import DataTable from "carbon-components-svelte/DataTable/DataTable.svelte";
+  import Toolbar from "carbon-components-svelte/DataTable/Toolbar.svelte";
+  import ToolbarContent from "carbon-components-svelte/DataTable/ToolbarContent.svelte";
   import type { ComponentProps } from "svelte";
 
   export let tableSize: ComponentProps<DataTable>["size"] = undefined;

--- a/tests/DataTable/ToolbarSearchNumericValue.test.svelte
+++ b/tests/DataTable/ToolbarSearchNumericValue.test.svelte
@@ -3,8 +3,9 @@
   import Toolbar from "carbon-components-svelte/DataTable/Toolbar.svelte";
   import ToolbarContent from "carbon-components-svelte/DataTable/ToolbarContent.svelte";
   import ToolbarSearch from "carbon-components-svelte/DataTable/ToolbarSearch.svelte";
+  import type { ComponentProps } from "svelte";
 
-  export let value: number | string = "";
+  export let value: ComponentProps<ToolbarSearch>["value"] = "";
 </script>
 
 <DataTable

--- a/tests/DatePicker/DatePicker.test.svelte
+++ b/tests/DatePicker/DatePicker.test.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { DatePicker, DatePickerInput } from "carbon-components-svelte";
+  import DatePicker from "carbon-components-svelte/DatePicker/DatePicker.svelte";
+  import DatePickerInput from "carbon-components-svelte/DatePicker/DatePickerInput.svelte";
   import type { ComponentProps } from "svelte";
 
   export let datePickerType: ComponentProps<DatePicker>["datePickerType"] =

--- a/tests/DatePicker/DatePickerCalendar.test.svelte
+++ b/tests/DatePicker/DatePickerCalendar.test.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { DatePicker, DatePickerInput } from "carbon-components-svelte";
+  import DatePicker from "carbon-components-svelte/DatePicker/DatePicker.svelte";
+  import DatePickerInput from "carbon-components-svelte/DatePicker/DatePickerInput.svelte";
   import type { ComponentProps } from "svelte";
 
   export let datePickerType: ComponentProps<DatePicker>["datePickerType"] =

--- a/tests/DatePicker/DatePickerInModal.test.svelte
+++ b/tests/DatePicker/DatePickerInModal.test.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
-  import { DatePicker, DatePickerInput, Modal } from "carbon-components-svelte";
+  import DatePicker from "carbon-components-svelte/DatePicker/DatePicker.svelte";
+  import DatePickerInput from "carbon-components-svelte/DatePicker/DatePickerInput.svelte";
+  import Modal from "carbon-components-svelte/Modal/Modal.svelte";
   import type { ComponentProps } from "svelte";
 
   export let modalOpen = true;

--- a/tests/DatePicker/DatePickerInput.slot.test.svelte
+++ b/tests/DatePicker/DatePickerInput.slot.test.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { DatePicker, DatePickerInput } from "carbon-components-svelte";
+  import DatePicker from "carbon-components-svelte/DatePicker/DatePicker.svelte";
+  import DatePickerInput from "carbon-components-svelte/DatePicker/DatePickerInput.svelte";
 </script>
 
 <DatePicker datePickerType="simple">

--- a/tests/DatePicker/DatePickerRange.test.svelte
+++ b/tests/DatePicker/DatePickerRange.test.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { DatePicker, DatePickerInput } from "carbon-components-svelte";
+  import DatePicker from "carbon-components-svelte/DatePicker/DatePicker.svelte";
+  import DatePickerInput from "carbon-components-svelte/DatePicker/DatePickerInput.svelte";
 
   export let valueFrom = "";
   export let valueTo = "";

--- a/tests/DatePicker/DatePickerSkeleton.test.svelte
+++ b/tests/DatePicker/DatePickerSkeleton.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { DatePickerSkeleton } from "carbon-components-svelte";
+  import DatePickerSkeleton from "carbon-components-svelte/DatePicker/DatePickerSkeleton.svelte";
 </script>
 
 <DatePickerSkeleton

--- a/tests/ExpandableTile/ExpandableTile.test.svelte
+++ b/tests/ExpandableTile/ExpandableTile.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { ExpandableTile } from "carbon-components-svelte";
+  import ExpandableTile from "carbon-components-svelte/Tile/ExpandableTile.svelte";
   import type { ComponentProps } from "svelte";
 
   export let expanded: ComponentProps<ExpandableTile>["expanded"] = false;

--- a/tests/ExpandableTile/ExpandableTileCustom.test.svelte
+++ b/tests/ExpandableTile/ExpandableTileCustom.test.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { Button, ExpandableTile } from "carbon-components-svelte";
+  import Button from "carbon-components-svelte/Button/Button.svelte";
+  import ExpandableTile from "carbon-components-svelte/Tile/ExpandableTile.svelte";
 
   export let buttonClicked = false;
   export let linkClicked = false;

--- a/tests/ExpandableTile/ExpandableTileToggle.test.svelte
+++ b/tests/ExpandableTile/ExpandableTileToggle.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { ExpandableTile } from "carbon-components-svelte";
+  import ExpandableTile from "carbon-components-svelte/Tile/ExpandableTile.svelte";
 
   export let interactive = false;
 </script>

--- a/tests/ExpandableTile/ExpandableTileVariants.test.svelte
+++ b/tests/ExpandableTile/ExpandableTileVariants.test.svelte
@@ -1,7 +1,7 @@
 <svelte:options accessors />
 
 <script lang="ts">
-  import { ExpandableTile } from "carbon-components-svelte";
+  import ExpandableTile from "carbon-components-svelte/Tile/ExpandableTile.svelte";
 
   export let tileMaxHeight = 100;
   export let tilePadding = 50;

--- a/tests/FileUploader/FileUploader.test.svelte
+++ b/tests/FileUploader/FileUploader.test.svelte
@@ -1,7 +1,7 @@
 <svelte:options accessors />
 
 <script lang="ts">
-  import { FileUploader } from "carbon-components-svelte";
+  import FileUploader from "carbon-components-svelte/FileUploader/FileUploader.svelte";
   import type { ComponentProps } from "svelte";
 
   export let files: ComponentProps<FileUploader>["files"] = [];

--- a/tests/FileUploader/FileUploaderButton.slot.test.svelte
+++ b/tests/FileUploader/FileUploaderButton.slot.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { FileUploaderButton } from "carbon-components-svelte";
+  import FileUploaderButton from "carbon-components-svelte/FileUploader/FileUploaderButton.svelte";
 </script>
 
 <FileUploaderButton labelText="Default label">

--- a/tests/FileUploader/FileUploaderButton.test.svelte
+++ b/tests/FileUploader/FileUploaderButton.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { FileUploaderButton } from "carbon-components-svelte";
+  import FileUploaderButton from "carbon-components-svelte/FileUploader/FileUploaderButton.svelte";
   import type { ComponentProps } from "svelte";
 
   export let files: ComponentProps<FileUploaderButton>["files"] = [];

--- a/tests/FileUploader/FileUploaderDropContainer.slot.test.svelte
+++ b/tests/FileUploader/FileUploaderDropContainer.slot.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { FileUploaderDropContainer } from "carbon-components-svelte";
+  import FileUploaderDropContainer from "carbon-components-svelte/FileUploader/FileUploaderDropContainer.svelte";
 </script>
 
 <FileUploaderDropContainer labelText="Default label">

--- a/tests/FileUploader/FileUploaderDropContainer.test.svelte
+++ b/tests/FileUploader/FileUploaderDropContainer.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { FileUploaderDropContainer } from "carbon-components-svelte";
+  import FileUploaderDropContainer from "carbon-components-svelte/FileUploader/FileUploaderDropContainer.svelte";
   import type { ComponentProps } from "svelte";
 
   export let files: ComponentProps<FileUploaderDropContainer>["files"] = [];

--- a/tests/FileUploader/FileUploaderItem.test.svelte
+++ b/tests/FileUploader/FileUploaderItem.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { FileUploaderItem } from "carbon-components-svelte";
+  import FileUploaderItem from "carbon-components-svelte/FileUploader/FileUploaderItem.svelte";
 
   export let ondelete: ((e: CustomEvent<string>) => void) | undefined =
     undefined;

--- a/tests/FileUploader/Filename.test.svelte
+++ b/tests/FileUploader/Filename.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Filename } from "carbon-components-svelte";
+  import Filename from "carbon-components-svelte/FileUploader/Filename.svelte";
 
   export let onclick: ((e: MouseEvent) => void) | undefined = undefined;
   export let onkeydown: ((e: KeyboardEvent) => void) | undefined = undefined;

--- a/tests/FluidForm/FluidForm.test.svelte
+++ b/tests/FluidForm/FluidForm.test.svelte
@@ -1,12 +1,10 @@
 <svelte:options accessors />
 
 <script lang="ts">
-  import {
-    Button,
-    Checkbox,
-    FluidForm,
-    FormGroup,
-  } from "carbon-components-svelte";
+  import Button from "carbon-components-svelte/Button/Button.svelte";
+  import Checkbox from "carbon-components-svelte/Checkbox/Checkbox.svelte";
+  import FluidForm from "carbon-components-svelte/FluidForm/FluidForm.svelte";
+  import FormGroup from "carbon-components-svelte/FormGroup/FormGroup.svelte";
 
   export let preventDefault = false;
   export let ref: null | HTMLFormElement = null;

--- a/tests/Form/Form.test.svelte
+++ b/tests/Form/Form.test.svelte
@@ -1,5 +1,8 @@
 <script lang="ts">
-  import { Button, Checkbox, Form, FormGroup } from "carbon-components-svelte";
+  import Button from "carbon-components-svelte/Button/Button.svelte";
+  import Checkbox from "carbon-components-svelte/Checkbox/Checkbox.svelte";
+  import Form from "carbon-components-svelte/Form/Form.svelte";
+  import FormGroup from "carbon-components-svelte/FormGroup/FormGroup.svelte";
 
   export let preventDefault = false;
 </script>

--- a/tests/FormGroup/FormGroup.test.svelte
+++ b/tests/FormGroup/FormGroup.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { FormGroup } from "carbon-components-svelte";
+  import FormGroup from "carbon-components-svelte/FormGroup/FormGroup.svelte";
   import type { ComponentProps } from "svelte";
 
   export let noMargin: ComponentProps<FormGroup>["noMargin"] = false;

--- a/tests/FormItem/FormItem.test.svelte
+++ b/tests/FormItem/FormItem.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { FormItem } from "carbon-components-svelte";
+  import FormItem from "carbon-components-svelte/FormItem/FormItem.svelte";
 
   export let slotContent = "";
 </script>

--- a/tests/FormLabel/FormLabel.test.svelte
+++ b/tests/FormLabel/FormLabel.test.svelte
@@ -1,7 +1,7 @@
 <svelte:options accessors />
 
 <script lang="ts">
-  import { FormLabel } from "carbon-components-svelte";
+  import FormLabel from "carbon-components-svelte/FormLabel/FormLabel.svelte";
   import type { ComponentProps } from "svelte";
 
   export let id: ComponentProps<FormLabel>["id"] = undefined;

--- a/tests/Grid/Grid.test.svelte
+++ b/tests/Grid/Grid.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Grid } from "carbon-components-svelte";
+  import Grid from "carbon-components-svelte/Grid/Grid.svelte";
 
   export let condensed = false;
   export let narrow = false;

--- a/tests/Grid/Row.test.svelte
+++ b/tests/Grid/Row.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Row } from "carbon-components-svelte";
+  import Row from "carbon-components-svelte/Grid/Row.svelte";
   import type { ComponentProps } from "svelte";
 
   export let condensed: ComponentProps<Row>["condensed"] = false;

--- a/tests/Heading/Heading.test.svelte
+++ b/tests/Heading/Heading.test.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { Heading, Section } from "carbon-components-svelte";
+  import Heading from "carbon-components-svelte/Heading/Heading.svelte";
+  import Section from "carbon-components-svelte/Heading/Section.svelte";
 </script>
 
 <Section> <Heading>Default Heading 1</Heading> </Section>

--- a/tests/ImageLoader/ImageLoader.test.svelte
+++ b/tests/ImageLoader/ImageLoader.test.svelte
@@ -1,8 +1,9 @@
 <svelte:options accessors />
 
 <script lang="ts">
-  import { ImageLoader, InlineLoading } from "carbon-components-svelte";
   import type ImageLoaderComponent from "carbon-components-svelte/ImageLoader/ImageLoader.svelte";
+  import ImageLoader from "carbon-components-svelte/ImageLoader/ImageLoader.svelte";
+  import InlineLoading from "carbon-components-svelte/InlineLoading/InlineLoading.svelte";
 
   // Valid image URL for testing successful loads
   const validImageSrc =

--- a/tests/InlineLoading/InlineLoading.test.svelte
+++ b/tests/InlineLoading/InlineLoading.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { InlineLoading } from "carbon-components-svelte";
+  import InlineLoading from "carbon-components-svelte/InlineLoading/InlineLoading.svelte";
 </script>
 
 <!-- Default inline loading -->

--- a/tests/InlineLoading/InlineLoadingRerender.test.svelte
+++ b/tests/InlineLoading/InlineLoadingRerender.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { InlineLoading } from "carbon-components-svelte";
+  import InlineLoading from "carbon-components-svelte/InlineLoading/InlineLoading.svelte";
 
   export let tick = 0;
 </script>

--- a/tests/InlineLoading/InlineLoadingTransition.test.svelte
+++ b/tests/InlineLoading/InlineLoadingTransition.test.svelte
@@ -1,9 +1,10 @@
 <svelte:options accessors />
 
 <script lang="ts">
-  import { InlineLoading } from "carbon-components-svelte";
+  import InlineLoading from "carbon-components-svelte/InlineLoading/InlineLoading.svelte";
+  import type { ComponentProps } from "svelte";
 
-  export let status: "active" | "finished" = "active";
+  export let status: ComponentProps<InlineLoading>["status"] = "active";
 </script>
 
 <InlineLoading

--- a/tests/InlineNotification/InlineNotification.test.svelte
+++ b/tests/InlineNotification/InlineNotification.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { InlineNotification } from "carbon-components-svelte";
+  import InlineNotification from "carbon-components-svelte/Notification/InlineNotification.svelte";
   import type { ComponentProps } from "svelte";
 
   export let kind: ComponentProps<InlineNotification>["kind"] = "error";

--- a/tests/InlineNotification/InlineNotificationActionHref.test.svelte
+++ b/tests/InlineNotification/InlineNotificationActionHref.test.svelte
@@ -1,8 +1,6 @@
 <script lang="ts">
-  import {
-    InlineNotification,
-    NotificationActionButton,
-  } from "carbon-components-svelte";
+  import InlineNotification from "carbon-components-svelte/Notification/InlineNotification.svelte";
+  import NotificationActionButton from "carbon-components-svelte/Notification/NotificationActionButton.svelte";
 </script>
 
 <InlineNotification

--- a/tests/InlineNotification/InlineNotificationCustom.test.svelte
+++ b/tests/InlineNotification/InlineNotificationCustom.test.svelte
@@ -1,8 +1,6 @@
 <script lang="ts">
-  import {
-    InlineNotification,
-    NotificationActionButton,
-  } from "carbon-components-svelte";
+  import InlineNotification from "carbon-components-svelte/Notification/InlineNotification.svelte";
+  import NotificationActionButton from "carbon-components-svelte/Notification/NotificationActionButton.svelte";
 </script>
 
 <InlineNotification kind="warning">

--- a/tests/InlineNotification/InlineNotificationReusable.test.svelte
+++ b/tests/InlineNotification/InlineNotificationReusable.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { InlineNotification } from "carbon-components-svelte";
+  import InlineNotification from "carbon-components-svelte/Notification/InlineNotification.svelte";
   import type { ComponentProps } from "svelte";
 
   export let open = false;

--- a/tests/InlineNotification/InlineNotificationSubtitleSlot.test.svelte
+++ b/tests/InlineNotification/InlineNotificationSubtitleSlot.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { InlineNotification } from "carbon-components-svelte";
+  import InlineNotification from "carbon-components-svelte/Notification/InlineNotification.svelte";
 </script>
 
 <InlineNotification on:close on:click>

--- a/tests/InlineNotification/InlineNotificationTitleSlot.test.svelte
+++ b/tests/InlineNotification/InlineNotificationTitleSlot.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { InlineNotification } from "carbon-components-svelte";
+  import InlineNotification from "carbon-components-svelte/Notification/InlineNotification.svelte";
 </script>
 
 <InlineNotification on:close on:click>

--- a/tests/Link/Link.test.svelte
+++ b/tests/Link/Link.test.svelte
@@ -1,7 +1,7 @@
 <svelte:options accessors />
 
 <script lang="ts">
-  import { Link } from "carbon-components-svelte";
+  import Link from "carbon-components-svelte/Link/Link.svelte";
   import Carbon from "carbon-icons-svelte/lib/Carbon.svelte";
 </script>
 

--- a/tests/Link/OutboundLink.test.svelte
+++ b/tests/Link/OutboundLink.test.svelte
@@ -1,7 +1,7 @@
 <svelte:options accessors />
 
 <script lang="ts">
-  import { OutboundLink } from "carbon-components-svelte";
+  import OutboundLink from "carbon-components-svelte/Link/OutboundLink.svelte";
 </script>
 
 <!-- Default outbound link -->

--- a/tests/ListBox/ListBox.test.svelte
+++ b/tests/ListBox/ListBox.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { ListBox } from "carbon-components-svelte";
+  import ListBox from "carbon-components-svelte/ListBox/ListBox.svelte";
   import type { ComponentProps } from "svelte";
 
   export let size: ComponentProps<ListBox>["size"] = undefined;

--- a/tests/ListBox/ListBoxField.test.svelte
+++ b/tests/ListBox/ListBoxField.test.svelte
@@ -1,7 +1,7 @@
 <svelte:options accessors />
 
 <script lang="ts">
-  import { ListBoxField } from "carbon-components-svelte";
+  import ListBoxField from "carbon-components-svelte/ListBox/ListBoxField.svelte";
   import type { ComponentProps } from "svelte";
 
   export let disabled: ComponentProps<ListBoxField>["disabled"] = false;

--- a/tests/ListBox/ListBoxMenu.test.svelte
+++ b/tests/ListBox/ListBoxMenu.test.svelte
@@ -1,7 +1,7 @@
 <svelte:options accessors />
 
 <script lang="ts">
-  import { ListBoxMenu } from "carbon-components-svelte";
+  import ListBoxMenu from "carbon-components-svelte/ListBox/ListBoxMenu.svelte";
   import type { ComponentProps } from "svelte";
 
   export let id: ComponentProps<ListBoxMenu>["id"] = undefined;

--- a/tests/ListBox/ListBoxMenuIcon.test.svelte
+++ b/tests/ListBox/ListBoxMenuIcon.test.svelte
@@ -1,7 +1,7 @@
 <svelte:options accessors />
 
 <script lang="ts">
-  import { ListBoxMenuIcon } from "carbon-components-svelte";
+  import ListBoxMenuIcon from "carbon-components-svelte/ListBox/ListBoxMenuIcon.svelte";
   import type { ComponentProps } from "svelte";
 
   export let open: ComponentProps<ListBoxMenuIcon>["open"] = false;

--- a/tests/ListBox/ListBoxMenuItem.test.svelte
+++ b/tests/ListBox/ListBoxMenuItem.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { ListBoxMenuItem } from "carbon-components-svelte";
+  import ListBoxMenuItem from "carbon-components-svelte/ListBox/ListBoxMenuItem.svelte";
   import type { ComponentProps } from "svelte";
 
   export let active: ComponentProps<ListBoxMenuItem>["active"] = false;

--- a/tests/ListBox/ListBoxSelection.test.svelte
+++ b/tests/ListBox/ListBoxSelection.test.svelte
@@ -1,7 +1,7 @@
 <svelte:options accessors />
 
 <script lang="ts">
-  import { ListBoxSelection } from "carbon-components-svelte";
+  import ListBoxSelection from "carbon-components-svelte/ListBox/ListBoxSelection.svelte";
   import type { ComponentProps } from "svelte";
 
   export let selectionCount: ComponentProps<ListBoxSelection>["selectionCount"] =

--- a/tests/ListItem/ListItem.test.svelte
+++ b/tests/ListItem/ListItem.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { ListItem } from "carbon-components-svelte";
+  import ListItem from "carbon-components-svelte/ListItem/ListItem.svelte";
 
   export let slotContent = "";
 </script>

--- a/tests/Loading/Loading.test.svelte
+++ b/tests/Loading/Loading.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Loading } from "carbon-components-svelte";
+  import Loading from "carbon-components-svelte/Loading/Loading.svelte";
 </script>
 
 <!-- Default loading (with overlay) -->

--- a/tests/LocalStorage/LocalStorage.test.svelte
+++ b/tests/LocalStorage/LocalStorage.test.svelte
@@ -1,7 +1,7 @@
 <svelte:options accessors />
 
 <script lang="ts">
-  import { LocalStorage } from "carbon-components-svelte";
+  import LocalStorage from "carbon-components-svelte/LocalStorage/LocalStorage.svelte";
 
   // Example values for testing
   const primitiveValue = "test-value";

--- a/tests/LocalStorage/LocalStorageCrossTab.test.svelte
+++ b/tests/LocalStorage/LocalStorageCrossTab.test.svelte
@@ -1,7 +1,7 @@
 <svelte:options accessors />
 
 <script lang="ts">
-  import { LocalStorage } from "carbon-components-svelte";
+  import LocalStorage from "carbon-components-svelte/LocalStorage/LocalStorage.svelte";
 
   export let value: unknown = "initial-value";
   export let key = "cross-tab-key";

--- a/tests/LocalStorage/LocalStorageHardening.test.svelte
+++ b/tests/LocalStorage/LocalStorageHardening.test.svelte
@@ -1,8 +1,8 @@
 <svelte:options accessors />
 
 <script lang="ts">
-  import { LocalStorage } from "carbon-components-svelte";
   import type LocalStorageComponent from "carbon-components-svelte/LocalStorage/LocalStorage.svelte";
+  import LocalStorage from "carbon-components-svelte/LocalStorage/LocalStorage.svelte";
 
   export let value: unknown = "initial";
   export let key = "hardening-key";

--- a/tests/LocalStorage/LocalStorageObject.test.svelte
+++ b/tests/LocalStorage/LocalStorageObject.test.svelte
@@ -1,7 +1,7 @@
 <svelte:options accessors />
 
 <script lang="ts">
-  import { LocalStorage } from "carbon-components-svelte";
+  import LocalStorage from "carbon-components-svelte/LocalStorage/LocalStorage.svelte";
 
   export let value: { theme: string; fontSize: number } = {
     theme: "dark",

--- a/tests/LocalStorage/LocalStoragePrimitive.test.svelte
+++ b/tests/LocalStorage/LocalStoragePrimitive.test.svelte
@@ -1,7 +1,7 @@
 <svelte:options accessors />
 
 <script lang="ts">
-  import { LocalStorage } from "carbon-components-svelte";
+  import LocalStorage from "carbon-components-svelte/LocalStorage/LocalStorage.svelte";
 
   export let value = "test-value";
 </script>

--- a/tests/LocalStorage/LocalStorageReactiveKey.test.svelte
+++ b/tests/LocalStorage/LocalStorageReactiveKey.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { LocalStorage } from "carbon-components-svelte";
+  import LocalStorage from "carbon-components-svelte/LocalStorage/LocalStorage.svelte";
   import type { ComponentProps } from "svelte";
 
   export let storageKey: ComponentProps<LocalStorage>["key"] = "key-a";

--- a/tests/LocalStorage/LocalStorageWriteError.test.svelte
+++ b/tests/LocalStorage/LocalStorageWriteError.test.svelte
@@ -1,7 +1,7 @@
 <svelte:options accessors />
 
 <script lang="ts">
-  import { LocalStorage } from "carbon-components-svelte";
+  import LocalStorage from "carbon-components-svelte/LocalStorage/LocalStorage.svelte";
 
   export let value = "test-value";
   export let key = "test-key";

--- a/tests/Modal/Modal.test.svelte
+++ b/tests/Modal/Modal.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Modal } from "carbon-components-svelte";
+  import Modal from "carbon-components-svelte/Modal/Modal.svelte";
   import type { ComponentProps } from "svelte";
 
   export let open = false;

--- a/tests/Modal/ModalFocusReturn.test.svelte
+++ b/tests/Modal/ModalFocusReturn.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Modal } from "carbon-components-svelte";
+  import Modal from "carbon-components-svelte/Modal/Modal.svelte";
 
   let open = false;
 </script>

--- a/tests/Modal/ModalFocusTrap.test.svelte
+++ b/tests/Modal/ModalFocusTrap.test.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
-  import { Dropdown, Modal, TextInput } from "carbon-components-svelte";
+  import Dropdown from "carbon-components-svelte/Dropdown/Dropdown.svelte";
+  import Modal from "carbon-components-svelte/Modal/Modal.svelte";
+  import TextInput from "carbon-components-svelte/TextInput/TextInput.svelte";
 
   export let open = false;
 </script>

--- a/tests/Modal/ModalFormId.test.svelte
+++ b/tests/Modal/ModalFormId.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Modal } from "carbon-components-svelte";
+  import Modal from "carbon-components-svelte/Modal/Modal.svelte";
   import type { ComponentProps } from "svelte";
 
   export let open = false;

--- a/tests/Modal/ModalNullishAriaLabel.test.svelte
+++ b/tests/Modal/ModalNullishAriaLabel.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Modal } from "carbon-components-svelte";
+  import Modal from "carbon-components-svelte/Modal/Modal.svelte";
 
   export let open = false;
   export let ariaLabel = "";

--- a/tests/Modal/ModalSideNavBodyLock.test.svelte
+++ b/tests/Modal/ModalSideNavBodyLock.test.svelte
@@ -1,12 +1,10 @@
 <svelte:options accessors />
 
 <script lang="ts">
-  import {
-    Modal,
-    SideNav,
-    SideNavItems,
-    SideNavLink,
-  } from "carbon-components-svelte";
+  import Modal from "carbon-components-svelte/Modal/Modal.svelte";
+  import SideNav from "carbon-components-svelte/UIShell/SideNav.svelte";
+  import SideNavItems from "carbon-components-svelte/UIShell/SideNavItems.svelte";
+  import SideNavLink from "carbon-components-svelte/UIShell/SideNavLink.svelte";
 
   export let modalOpen = false;
   export let sideNavOpen = false;

--- a/tests/Modal/ModalTextareaEnter.test.svelte
+++ b/tests/Modal/ModalTextareaEnter.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Modal } from "carbon-components-svelte";
+  import Modal from "carbon-components-svelte/Modal/Modal.svelte";
 
   export let open = true;
   export let shouldSubmitOnEnter = true;

--- a/tests/MultiSelect/MultiSelect.slot.test.svelte
+++ b/tests/MultiSelect/MultiSelect.slot.test.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  import { MultiSelect } from "carbon-components-svelte";
   import type { MultiSelectItem } from "carbon-components-svelte/MultiSelect/MultiSelect.svelte";
+  import MultiSelect from "carbon-components-svelte/MultiSelect/MultiSelect.svelte";
 
   const items: MultiSelectItem[] = [
     { id: "0", text: "Option 1" },

--- a/tests/MultiSelect/MultiSelect.test.svelte
+++ b/tests/MultiSelect/MultiSelect.test.svelte
@@ -1,7 +1,7 @@
 <svelte:options accessors />
 
 <script lang="ts">
-  import { MultiSelect } from "carbon-components-svelte";
+  import MultiSelect from "carbon-components-svelte/MultiSelect/MultiSelect.svelte";
   import type { ComponentProps } from "svelte";
 
   export let items: ComponentProps<MultiSelect>["items"] = [];

--- a/tests/MultiSelect/MultiSelectBindValue.test.svelte
+++ b/tests/MultiSelect/MultiSelectBindValue.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { MultiSelect } from "carbon-components-svelte";
+  import MultiSelect from "carbon-components-svelte/MultiSelect/MultiSelect.svelte";
   import type { ComponentProps } from "svelte";
 
   export let items: ComponentProps<MultiSelect>["items"] = [];

--- a/tests/MultiSelect/MultiSelectDuplicateIds.test.svelte
+++ b/tests/MultiSelect/MultiSelectDuplicateIds.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { MultiSelect } from "carbon-components-svelte";
+  import MultiSelect from "carbon-components-svelte/MultiSelect/MultiSelect.svelte";
 
   const items = [
     { id: "0", text: "Slack" },

--- a/tests/MultiSelect/MultiSelectGenerics.test.svelte
+++ b/tests/MultiSelect/MultiSelectGenerics.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { MultiSelect } from "carbon-components-svelte";
+  import MultiSelect from "carbon-components-svelte/MultiSelect/MultiSelect.svelte";
 
   const items = [
     { id: "1", text: "Laptop", price: 999, category: "Electronics" },

--- a/tests/MultiSelect/MultiSelectInModal.test.svelte
+++ b/tests/MultiSelect/MultiSelectInModal.test.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { Modal, MultiSelect } from "carbon-components-svelte";
+  import Modal from "carbon-components-svelte/Modal/Modal.svelte";
+  import MultiSelect from "carbon-components-svelte/MultiSelect/MultiSelect.svelte";
   import type { ComponentProps } from "svelte";
 
   export let modalOpen = true;

--- a/tests/MultiSelect/MultiSelectItemToStringId.test.svelte
+++ b/tests/MultiSelect/MultiSelectItemToStringId.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { MultiSelect } from "carbon-components-svelte";
+  import MultiSelect from "carbon-components-svelte/MultiSelect/MultiSelect.svelte";
 
   /** itemToString may return Item["id"] (e.g. number), matching default `text ?? id`. */
   const items = [

--- a/tests/MultiSelect/MultiSelectSlot.test.svelte
+++ b/tests/MultiSelect/MultiSelectSlot.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { MultiSelect } from "carbon-components-svelte";
+  import MultiSelect from "carbon-components-svelte/MultiSelect/MultiSelect.svelte";
   import type { ComponentProps } from "svelte";
 
   export let items: ComponentProps<MultiSelect>["items"] = [];

--- a/tests/Notification/NotificationQueue.test.svelte
+++ b/tests/Notification/NotificationQueue.test.svelte
@@ -1,8 +1,8 @@
 <svelte:options accessors />
 
 <script lang="ts">
-  import { NotificationQueue } from "carbon-components-svelte";
   import type NotificationQueueComponent from "carbon-components-svelte/Notification/NotificationQueue.svelte";
+  import NotificationQueue from "carbon-components-svelte/Notification/NotificationQueue.svelte";
   import type { ComponentProps } from "svelte";
 
   export let position: ComponentProps<NotificationQueue>["position"] =

--- a/tests/NumberInput/NumberInput.test.svelte
+++ b/tests/NumberInput/NumberInput.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { NumberInput } from "carbon-components-svelte";
+  import NumberInput from "carbon-components-svelte/NumberInput/NumberInput.svelte";
   import type { ComponentProps } from "svelte";
 
   export let value: ComponentProps<NumberInput>["value"] = 0;

--- a/tests/NumberInput/NumberInputCustom.test.svelte
+++ b/tests/NumberInput/NumberInputCustom.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { NumberInput } from "carbon-components-svelte";
+  import NumberInput from "carbon-components-svelte/NumberInput/NumberInput.svelte";
 </script>
 
 <NumberInput labelText="Custom label" value={0}>

--- a/tests/OrderedList/OrderedList.test.svelte
+++ b/tests/OrderedList/OrderedList.test.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { ListItem, OrderedList } from "carbon-components-svelte";
+  import ListItem from "carbon-components-svelte/ListItem/ListItem.svelte";
+  import OrderedList from "carbon-components-svelte/OrderedList/OrderedList.svelte";
 
   export let nested = false;
   export let native = false;

--- a/tests/OverflowMenu/OverflowMenu.allDisabled.test.svelte
+++ b/tests/OverflowMenu/OverflowMenu.allDisabled.test.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { OverflowMenu, OverflowMenuItem } from "carbon-components-svelte";
+  import OverflowMenu from "carbon-components-svelte/OverflowMenu/OverflowMenu.svelte";
+  import OverflowMenuItem from "carbon-components-svelte/OverflowMenu/OverflowMenuItem.svelte";
 </script>
 
 <OverflowMenu>

--- a/tests/OverflowMenu/OverflowMenu.disabled.test.svelte
+++ b/tests/OverflowMenu/OverflowMenu.disabled.test.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { OverflowMenu, OverflowMenuItem } from "carbon-components-svelte";
+  import OverflowMenu from "carbon-components-svelte/OverflowMenu/OverflowMenu.svelte";
+  import OverflowMenuItem from "carbon-components-svelte/OverflowMenu/OverflowMenuItem.svelte";
 </script>
 
 <OverflowMenu>

--- a/tests/OverflowMenu/OverflowMenu.disabledLink.test.svelte
+++ b/tests/OverflowMenu/OverflowMenu.disabledLink.test.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { OverflowMenu, OverflowMenuItem } from "carbon-components-svelte";
+  import OverflowMenu from "carbon-components-svelte/OverflowMenu/OverflowMenu.svelte";
+  import OverflowMenuItem from "carbon-components-svelte/OverflowMenu/OverflowMenuItem.svelte";
 </script>
 
 <OverflowMenu

--- a/tests/OverflowMenu/OverflowMenu.dynamicItems.test.svelte
+++ b/tests/OverflowMenu/OverflowMenu.dynamicItems.test.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { OverflowMenu, OverflowMenuItem } from "carbon-components-svelte";
+  import OverflowMenu from "carbon-components-svelte/OverflowMenu/OverflowMenu.svelte";
+  import OverflowMenuItem from "carbon-components-svelte/OverflowMenu/OverflowMenuItem.svelte";
 
   export let showMiddle = true;
 </script>

--- a/tests/OverflowMenu/OverflowMenu.preventDefault.test.svelte
+++ b/tests/OverflowMenu/OverflowMenu.preventDefault.test.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { OverflowMenu, OverflowMenuItem } from "carbon-components-svelte";
+  import OverflowMenu from "carbon-components-svelte/OverflowMenu/OverflowMenu.svelte";
+  import OverflowMenuItem from "carbon-components-svelte/OverflowMenu/OverflowMenuItem.svelte";
 </script>
 
 <OverflowMenu

--- a/tests/OverflowMenu/OverflowMenu.rel.test.svelte
+++ b/tests/OverflowMenu/OverflowMenu.rel.test.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { OverflowMenu, OverflowMenuItem } from "carbon-components-svelte";
+  import OverflowMenu from "carbon-components-svelte/OverflowMenu/OverflowMenu.svelte";
+  import OverflowMenuItem from "carbon-components-svelte/OverflowMenu/OverflowMenuItem.svelte";
 
   export let testCase:
     | "default"

--- a/tests/OverflowMenu/OverflowMenu.test.svelte
+++ b/tests/OverflowMenu/OverflowMenu.test.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { OverflowMenu, OverflowMenuItem } from "carbon-components-svelte";
+  import OverflowMenu from "carbon-components-svelte/OverflowMenu/OverflowMenu.svelte";
+  import OverflowMenuItem from "carbon-components-svelte/OverflowMenu/OverflowMenuItem.svelte";
   import type { ComponentProps } from "svelte";
 
   export let size: ComponentProps<OverflowMenu>["size"] = undefined;

--- a/tests/OverflowMenu/OverflowMenu.triggerClose.test.svelte
+++ b/tests/OverflowMenu/OverflowMenu.triggerClose.test.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { OverflowMenu, OverflowMenuItem } from "carbon-components-svelte";
+  import OverflowMenu from "carbon-components-svelte/OverflowMenu/OverflowMenu.svelte";
+  import OverflowMenuItem from "carbon-components-svelte/OverflowMenu/OverflowMenuItem.svelte";
 
   export let cancelClose = false;
 

--- a/tests/OverflowMenu/OverflowMenuInModal.test.svelte
+++ b/tests/OverflowMenu/OverflowMenuInModal.test.svelte
@@ -1,9 +1,7 @@
 <script lang="ts">
-  import {
-    Modal,
-    OverflowMenu,
-    OverflowMenuItem,
-  } from "carbon-components-svelte";
+  import Modal from "carbon-components-svelte/Modal/Modal.svelte";
+  import OverflowMenu from "carbon-components-svelte/OverflowMenu/OverflowMenu.svelte";
+  import OverflowMenuItem from "carbon-components-svelte/OverflowMenu/OverflowMenuItem.svelte";
   import type { ComponentProps } from "svelte";
 
   export let modalOpen = true;

--- a/tests/Pagination/Pagination.test.svelte
+++ b/tests/Pagination/Pagination.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Pagination } from "carbon-components-svelte";
+  import Pagination from "carbon-components-svelte/Pagination/Pagination.svelte";
   import type { ComponentProps } from "svelte";
 
   export let page = 1;

--- a/tests/PaginationNav/PaginationNav.test.svelte
+++ b/tests/PaginationNav/PaginationNav.test.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { PaginationNav } from "carbon-components-svelte";
+  import PaginationNav from "carbon-components-svelte/PaginationNav/PaginationNav.svelte";
+  import type { ComponentProps } from "svelte";
 
   export let page = 1;
   export let total = 10;
@@ -7,13 +8,8 @@
   export let loop = false;
   export let forwardText = "Next page";
   export let backwardText = "Previous page";
-  export let tooltipPosition:
-    | "top"
-    | "right"
-    | "bottom"
-    | "left"
-    | "outside"
-    | "inside" = "bottom";
+  export let tooltipPosition: ComponentProps<PaginationNav>["tooltipPosition"] =
+    "bottom";
 </script>
 
 <PaginationNav

--- a/tests/PasswordInput/PasswordInput.slot.test.svelte
+++ b/tests/PasswordInput/PasswordInput.slot.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { PasswordInput } from "carbon-components-svelte";
+  import PasswordInput from "carbon-components-svelte/TextInput/PasswordInput.svelte";
 </script>
 
 <PasswordInput labelText="Default label">

--- a/tests/PasswordInput/PasswordInput.test.svelte
+++ b/tests/PasswordInput/PasswordInput.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { PasswordInput } from "carbon-components-svelte";
+  import PasswordInput from "carbon-components-svelte/TextInput/PasswordInput.svelte";
   import type { ComponentProps } from "svelte";
 
   export let size: ComponentProps<PasswordInput>["size"] = undefined;

--- a/tests/PasswordInput/PasswordInputInModal.test.svelte
+++ b/tests/PasswordInput/PasswordInputInModal.test.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { Modal, PasswordInput } from "carbon-components-svelte";
+  import Modal from "carbon-components-svelte/Modal/Modal.svelte";
+  import PasswordInput from "carbon-components-svelte/TextInput/PasswordInput.svelte";
   import type { ComponentProps } from "svelte";
 
   export let modalOpen = true;

--- a/tests/Popover/Popover.test.svelte
+++ b/tests/Popover/Popover.test.svelte
@@ -1,20 +1,9 @@
 <script lang="ts">
-  import { Popover } from "carbon-components-svelte";
+  import Popover from "carbon-components-svelte/Popover/Popover.svelte";
+  import type { ComponentProps } from "svelte";
 
   export let open = false;
-  export let align:
-    | "top"
-    | "top-left"
-    | "top-right"
-    | "bottom"
-    | "bottom-left"
-    | "bottom-right"
-    | "left"
-    | "left-bottom"
-    | "left-top"
-    | "right"
-    | "right-bottom"
-    | "right-top" = "top";
+  export let align: ComponentProps<Popover>["align"] = "top";
   export let caret = false;
   export let light = false;
   export let highContrast = false;

--- a/tests/Portal/FloatingPortal.test.svelte
+++ b/tests/Portal/FloatingPortal.test.svelte
@@ -1,7 +1,7 @@
 <svelte:options accessors />
 
 <script lang="ts">
-  import { FloatingPortal } from "carbon-components-svelte";
+  import FloatingPortal from "carbon-components-svelte/Portal/FloatingPortal.svelte";
   import type { ComponentProps } from "svelte";
 
   export let open = false;

--- a/tests/Portal/Portal.focus.test.svelte
+++ b/tests/Portal/Portal.focus.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Portal } from "carbon-components-svelte";
+  import Portal from "carbon-components-svelte/Portal/Portal.svelte";
 
   export let showPortal = true;
 </script>

--- a/tests/Portal/Portal.multiple.test.svelte
+++ b/tests/Portal/Portal.multiple.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Portal } from "carbon-components-svelte";
+  import Portal from "carbon-components-svelte/Portal/Portal.svelte";
 </script>
 
 <Portal> Portal content 1 </Portal>

--- a/tests/Portal/Portal.test.svelte
+++ b/tests/Portal/Portal.test.svelte
@@ -1,7 +1,7 @@
 <svelte:options accessors />
 
 <script lang="ts">
-  import { Portal } from "carbon-components-svelte";
+  import Portal from "carbon-components-svelte/Portal/Portal.svelte";
   import type { ComponentProps } from "svelte";
 
   export let showPortal = true;

--- a/tests/ProgressBar/ProgressBar.slot.test.svelte
+++ b/tests/ProgressBar/ProgressBar.slot.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { ProgressBar } from "carbon-components-svelte";
+  import ProgressBar from "carbon-components-svelte/ProgressBar/ProgressBar.svelte";
 </script>
 
 <ProgressBar labelText="Default label">

--- a/tests/ProgressBar/ProgressBar.test.svelte
+++ b/tests/ProgressBar/ProgressBar.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { ProgressBar } from "carbon-components-svelte";
+  import ProgressBar from "carbon-components-svelte/ProgressBar/ProgressBar.svelte";
 </script>
 
 <ProgressBar status="active" data-testid="indeterminate-progress" />

--- a/tests/ProgressIndicator/ProgressIndicator.test.svelte
+++ b/tests/ProgressIndicator/ProgressIndicator.test.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { ProgressIndicator, ProgressStep } from "carbon-components-svelte";
+  import ProgressIndicator from "carbon-components-svelte/ProgressIndicator/ProgressIndicator.svelte";
+  import ProgressStep from "carbon-components-svelte/ProgressIndicator/ProgressStep.svelte";
 
   export let currentIndex = 0;
   export let vertical = false;

--- a/tests/ProgressIndicator/ProgressIndicatorConditional.test.svelte
+++ b/tests/ProgressIndicator/ProgressIndicatorConditional.test.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { ProgressIndicator, ProgressStep } from "carbon-components-svelte";
+  import ProgressIndicator from "carbon-components-svelte/ProgressIndicator/ProgressIndicator.svelte";
+  import ProgressStep from "carbon-components-svelte/ProgressIndicator/ProgressStep.svelte";
 
   export let showOptional = true;
   export let currentIndex = 0;

--- a/tests/ProgressIndicator/ProgressIndicatorIssue1249.test.svelte
+++ b/tests/ProgressIndicator/ProgressIndicatorIssue1249.test.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { ProgressIndicator, ProgressStep } from "carbon-components-svelte";
+  import ProgressIndicator from "carbon-components-svelte/ProgressIndicator/ProgressIndicator.svelte";
+  import ProgressStep from "carbon-components-svelte/ProgressIndicator/ProgressStep.svelte";
   import { onMount } from "svelte";
 
   export let stepsCompleted = [false, false, false];

--- a/tests/ProgressIndicator/ProgressIndicatorReactive.test.svelte
+++ b/tests/ProgressIndicator/ProgressIndicatorReactive.test.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { ProgressIndicator, ProgressStep } from "carbon-components-svelte";
+  import ProgressIndicator from "carbon-components-svelte/ProgressIndicator/ProgressIndicator.svelte";
+  import ProgressStep from "carbon-components-svelte/ProgressIndicator/ProgressStep.svelte";
 
   export let step1Complete = false;
   export let step2Complete = false;

--- a/tests/ProgressIndicator/ProgressStepIconSlot.test.svelte
+++ b/tests/ProgressIndicator/ProgressStepIconSlot.test.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { ProgressIndicator, ProgressStep } from "carbon-components-svelte";
+  import ProgressIndicator from "carbon-components-svelte/ProgressIndicator/ProgressIndicator.svelte";
+  import ProgressStep from "carbon-components-svelte/ProgressIndicator/ProgressStep.svelte";
 </script>
 
 <ProgressIndicator currentIndex={1}>

--- a/tests/ProgressIndicator/ProgressStepStandalone.test.svelte
+++ b/tests/ProgressIndicator/ProgressStepStandalone.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { ProgressStep } from "carbon-components-svelte";
+  import ProgressStep from "carbon-components-svelte/ProgressIndicator/ProgressStep.svelte";
 </script>
 
 <ProgressStep label="Standalone step" secondaryLabel="Optional" />

--- a/tests/RadioButton/RadioButton.test.svelte
+++ b/tests/RadioButton/RadioButton.test.svelte
@@ -1,7 +1,7 @@
 <svelte:options accessors />
 
 <script lang="ts">
-  import { RadioButton } from "carbon-components-svelte";
+  import RadioButton from "carbon-components-svelte/RadioButton/RadioButton.svelte";
   import type { ComponentProps } from "svelte";
 
   export let value: ComponentProps<RadioButton>["value"] = "";

--- a/tests/RadioButton/RadioButtonCustom.test.svelte
+++ b/tests/RadioButton/RadioButtonCustom.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { RadioButton } from "carbon-components-svelte";
+  import RadioButton from "carbon-components-svelte/RadioButton/RadioButton.svelte";
 </script>
 
 <RadioButton labelText="Custom label" value="custom" name="test-group">

--- a/tests/RadioButton/RadioButtonGroup.readonly.test.svelte
+++ b/tests/RadioButton/RadioButtonGroup.readonly.test.svelte
@@ -1,9 +1,11 @@
 <svelte:options accessors />
 
 <script lang="ts">
-  import { RadioButton, RadioButtonGroup } from "carbon-components-svelte";
+  import RadioButton from "carbon-components-svelte/RadioButton/RadioButton.svelte";
+  import RadioButtonGroup from "carbon-components-svelte/RadioButtonGroup/RadioButtonGroup.svelte";
+  import type { ComponentProps } from "svelte";
 
-  export let selected: string | undefined = "1";
+  export let selected: ComponentProps<RadioButtonGroup>["selected"] = "1";
   export let readonly = false;
 </script>
 

--- a/tests/RadioButton/RadioButtonImplicitGroup.test.svelte
+++ b/tests/RadioButton/RadioButtonImplicitGroup.test.svelte
@@ -1,7 +1,7 @@
 <svelte:options accessors />
 
 <script lang="ts">
-  import { RadioButton } from "carbon-components-svelte";
+  import RadioButton from "carbon-components-svelte/RadioButton/RadioButton.svelte";
 
   export let checked1 = false;
   export let checked2 = false;

--- a/tests/RadioButton/RadioButtonReadonlyChange.test.svelte
+++ b/tests/RadioButton/RadioButtonReadonlyChange.test.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { RadioButton, RadioButtonGroup } from "carbon-components-svelte";
+  import RadioButton from "carbon-components-svelte/RadioButton/RadioButton.svelte";
+  import RadioButtonGroup from "carbon-components-svelte/RadioButtonGroup/RadioButtonGroup.svelte";
 </script>
 
 <RadioButtonGroup legendText="Plan" readonly selected="1">

--- a/tests/RadioButton/RadioButtonStandalone.test.svelte
+++ b/tests/RadioButton/RadioButtonStandalone.test.svelte
@@ -1,7 +1,7 @@
 <svelte:options accessors />
 
 <script lang="ts">
-  import { RadioButton } from "carbon-components-svelte";
+  import RadioButton from "carbon-components-svelte/RadioButton/RadioButton.svelte";
 
   export let checked = false;
 </script>

--- a/tests/RadioButtonGroup/RadioButtonGroup.test.svelte
+++ b/tests/RadioButtonGroup/RadioButtonGroup.test.svelte
@@ -1,7 +1,8 @@
 <svelte:options accessors />
 
 <script lang="ts">
-  import { RadioButton, RadioButtonGroup } from "carbon-components-svelte";
+  import RadioButton from "carbon-components-svelte/RadioButton/RadioButton.svelte";
+  import RadioButtonGroup from "carbon-components-svelte/RadioButtonGroup/RadioButtonGroup.svelte";
   import type { ComponentProps } from "svelte";
 
   export let selected: ComponentProps<RadioButtonGroup>["selected"] = undefined;

--- a/tests/RadioTile/RadioTile.group.test.svelte
+++ b/tests/RadioTile/RadioTile.group.test.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
-  import { Button, RadioTile, TileGroup } from "carbon-components-svelte";
+  import Button from "carbon-components-svelte/Button/Button.svelte";
+  import RadioTile from "carbon-components-svelte/Tile/RadioTile.svelte";
+  import TileGroup from "carbon-components-svelte/Tile/TileGroup.svelte";
 
   const values = ["Lite plan", "Standard plan", "Plus plan"];
 

--- a/tests/RadioTile/RadioTile.single.test.svelte
+++ b/tests/RadioTile/RadioTile.single.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { RadioTile } from "carbon-components-svelte";
+  import RadioTile from "carbon-components-svelte/Tile/RadioTile.svelte";
 </script>
 
 <RadioTile name="custom-name" value="test">

--- a/tests/RadioTile/RadioTile.test.svelte
+++ b/tests/RadioTile/RadioTile.test.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { RadioTile, TileGroup } from "carbon-components-svelte";
+  import RadioTile from "carbon-components-svelte/Tile/RadioTile.svelte";
+  import TileGroup from "carbon-components-svelte/Tile/TileGroup.svelte";
   import type { ComponentProps } from "svelte";
 
   export let checked: ComponentProps<RadioTile>["checked"] = false;

--- a/tests/RadioTile/RadioTileAria.test.svelte
+++ b/tests/RadioTile/RadioTileAria.test.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { RadioTile, TileGroup } from "carbon-components-svelte";
+  import RadioTile from "carbon-components-svelte/Tile/RadioTile.svelte";
+  import TileGroup from "carbon-components-svelte/Tile/TileGroup.svelte";
   import type { ComponentProps } from "svelte";
 
   export let selected: ComponentProps<TileGroup>["selected"] = undefined;

--- a/tests/RadioTile/RadioTileCustom.test.svelte
+++ b/tests/RadioTile/RadioTileCustom.test.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { RadioTile, TileGroup } from "carbon-components-svelte";
+  import RadioTile from "carbon-components-svelte/Tile/RadioTile.svelte";
+  import TileGroup from "carbon-components-svelte/Tile/TileGroup.svelte";
 </script>
 
 <TileGroup legendText="Test group" name="test-group" selected="test">

--- a/tests/RecursiveList/RecursiveList.hierarchy.test.svelte
+++ b/tests/RecursiveList/RecursiveList.hierarchy.test.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { RecursiveList, toHierarchy } from "carbon-components-svelte";
+  import RecursiveList from "carbon-components-svelte/RecursiveList/RecursiveList.svelte";
+  import { toHierarchy } from "carbon-components-svelte/utils/toHierarchy";
 
   let nodes = toHierarchy(
     [

--- a/tests/RecursiveList/RecursiveList.id.test.svelte
+++ b/tests/RecursiveList/RecursiveList.id.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { RecursiveList } from "carbon-components-svelte";
+  import RecursiveList from "carbon-components-svelte/RecursiveList/RecursiveList.svelte";
 
   type TestNode = {
     id?: string | number;

--- a/tests/RecursiveList/RecursiveList.test.svelte
+++ b/tests/RecursiveList/RecursiveList.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { RecursiveList } from "carbon-components-svelte";
+  import RecursiveList from "carbon-components-svelte/RecursiveList/RecursiveList.svelte";
   import type { RecursiveListNode } from "../../src/RecursiveList/RecursiveList.svelte";
 
   const nodes: RecursiveListNode[] = [

--- a/tests/Search/Search.slot.test.svelte
+++ b/tests/Search/Search.slot.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Search } from "carbon-components-svelte";
+  import Search from "carbon-components-svelte/Search/Search.svelte";
 </script>
 
 <Search labelText="Default label">

--- a/tests/Search/Search.test.svelte
+++ b/tests/Search/Search.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Search } from "carbon-components-svelte";
+  import Search from "carbon-components-svelte/Search/Search.svelte";
 
   let value = "";
 </script>

--- a/tests/Search/SearchExpandable.test.svelte
+++ b/tests/Search/SearchExpandable.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Search } from "carbon-components-svelte";
+  import Search from "carbon-components-svelte/Search/Search.svelte";
 
   let expanded = false;
   let value = "";

--- a/tests/Search/SearchInitialEvent.test.svelte
+++ b/tests/Search/SearchInitialEvent.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Search } from "carbon-components-svelte";
+  import Search from "carbon-components-svelte/Search/Search.svelte";
 
   export let expanded = false;
 

--- a/tests/Search/SearchSkeleton.test.svelte
+++ b/tests/Search/SearchSkeleton.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Search } from "carbon-components-svelte";
+  import Search from "carbon-components-svelte/Search/Search.svelte";
 </script>
 
 <Search skeleton labelText="Default skeleton" />

--- a/tests/Select/Select.falsy.test.svelte
+++ b/tests/Select/Select.falsy.test.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { Select, SelectItem } from "carbon-components-svelte";
+  import Select from "carbon-components-svelte/Select/Select.svelte";
+  import SelectItem from "carbon-components-svelte/Select/SelectItem.svelte";
 </script>
 
 <Select labelText="Falsy text">

--- a/tests/Select/Select.group.test.svelte
+++ b/tests/Select/Select.group.test.svelte
@@ -1,9 +1,7 @@
 <script lang="ts">
-  import {
-    Select,
-    SelectItem,
-    SelectItemGroup,
-  } from "carbon-components-svelte";
+  import Select from "carbon-components-svelte/Select/Select.svelte";
+  import SelectItem from "carbon-components-svelte/Select/SelectItem.svelte";
+  import SelectItemGroup from "carbon-components-svelte/Select/SelectItemGroup.svelte";
   import type { ComponentProps } from "svelte";
 
   export let selected: ComponentProps<Select>["selected"] = undefined;

--- a/tests/Select/Select.skeleton.test.svelte
+++ b/tests/Select/Select.skeleton.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { SelectSkeleton } from "carbon-components-svelte";
+  import SelectSkeleton from "carbon-components-svelte/Select/SelectSkeleton.svelte";
 </script>
 
 <SelectSkeleton data-testid="select-skeleton" />

--- a/tests/Select/Select.slot.test.svelte
+++ b/tests/Select/Select.slot.test.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { Select, SelectItem } from "carbon-components-svelte";
+  import Select from "carbon-components-svelte/Select/Select.svelte";
+  import SelectItem from "carbon-components-svelte/Select/SelectItem.svelte";
 </script>
 
 <Select labelText="Default label">

--- a/tests/Select/Select.test.svelte
+++ b/tests/Select/Select.test.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { Select, SelectItem } from "carbon-components-svelte";
+  import Select from "carbon-components-svelte/Select/Select.svelte";
+  import SelectItem from "carbon-components-svelte/Select/SelectItem.svelte";
   import type { ComponentProps } from "svelte";
 
   export let selected: ComponentProps<Select>["selected"] = undefined;

--- a/tests/Select/Select.toggle.test.svelte
+++ b/tests/Select/Select.toggle.test.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { Select, SelectItem } from "carbon-components-svelte";
+  import Select from "carbon-components-svelte/Select/Select.svelte";
+  import SelectItem from "carbon-components-svelte/Select/SelectItem.svelte";
 
   export let open = false;
 </script>

--- a/tests/SessionStorage/SessionStorage.test.svelte
+++ b/tests/SessionStorage/SessionStorage.test.svelte
@@ -1,7 +1,7 @@
 <svelte:options accessors />
 
 <script lang="ts">
-  import { SessionStorage } from "carbon-components-svelte";
+  import SessionStorage from "carbon-components-svelte/SessionStorage/SessionStorage.svelte";
 
   // Example values for testing
   const primitiveValue = "test-value";

--- a/tests/SessionStorage/SessionStorageCrossTab.test.svelte
+++ b/tests/SessionStorage/SessionStorageCrossTab.test.svelte
@@ -1,7 +1,7 @@
 <svelte:options accessors />
 
 <script lang="ts">
-  import { SessionStorage } from "carbon-components-svelte";
+  import SessionStorage from "carbon-components-svelte/SessionStorage/SessionStorage.svelte";
 
   export let value: unknown = "initial-value";
   export let key = "cross-tab-key";

--- a/tests/SessionStorage/SessionStorageHardening.test.svelte
+++ b/tests/SessionStorage/SessionStorageHardening.test.svelte
@@ -1,8 +1,8 @@
 <svelte:options accessors />
 
 <script lang="ts">
-  import { SessionStorage } from "carbon-components-svelte";
   import type SessionStorageComponent from "carbon-components-svelte/SessionStorage/SessionStorage.svelte";
+  import SessionStorage from "carbon-components-svelte/SessionStorage/SessionStorage.svelte";
 
   export let value: unknown = "initial";
   export let key = "hardening-key";

--- a/tests/SessionStorage/SessionStorageObject.test.svelte
+++ b/tests/SessionStorage/SessionStorageObject.test.svelte
@@ -1,7 +1,7 @@
 <svelte:options accessors />
 
 <script lang="ts">
-  import { SessionStorage } from "carbon-components-svelte";
+  import SessionStorage from "carbon-components-svelte/SessionStorage/SessionStorage.svelte";
 
   export let value: { theme: string; fontSize: number } = {
     theme: "dark",

--- a/tests/SessionStorage/SessionStoragePrimitive.test.svelte
+++ b/tests/SessionStorage/SessionStoragePrimitive.test.svelte
@@ -1,7 +1,7 @@
 <svelte:options accessors />
 
 <script lang="ts">
-  import { SessionStorage } from "carbon-components-svelte";
+  import SessionStorage from "carbon-components-svelte/SessionStorage/SessionStorage.svelte";
 
   export let value = "test-value";
 </script>

--- a/tests/SessionStorage/SessionStorageReactiveKey.test.svelte
+++ b/tests/SessionStorage/SessionStorageReactiveKey.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { SessionStorage } from "carbon-components-svelte";
+  import SessionStorage from "carbon-components-svelte/SessionStorage/SessionStorage.svelte";
   import type { ComponentProps } from "svelte";
 
   export let storageKey: ComponentProps<SessionStorage>["key"] = "key-a";

--- a/tests/SessionStorage/SessionStorageWriteError.test.svelte
+++ b/tests/SessionStorage/SessionStorageWriteError.test.svelte
@@ -1,7 +1,7 @@
 <svelte:options accessors />
 
 <script lang="ts">
-  import { SessionStorage } from "carbon-components-svelte";
+  import SessionStorage from "carbon-components-svelte/SessionStorage/SessionStorage.svelte";
 
   export let value = "test-value";
   export let key = "test-key";

--- a/tests/SideNavMenu/SideNavMenu.rail.test.svelte
+++ b/tests/SideNavMenu/SideNavMenu.rail.test.svelte
@@ -1,11 +1,9 @@
 <script lang="ts">
-  import {
-    SideNav,
-    SideNavItems,
-    SideNavLink,
-    SideNavMenu,
-    SideNavMenuItem,
-  } from "carbon-components-svelte";
+  import SideNav from "carbon-components-svelte/UIShell/SideNav.svelte";
+  import SideNavItems from "carbon-components-svelte/UIShell/SideNavItems.svelte";
+  import SideNavLink from "carbon-components-svelte/UIShell/SideNavLink.svelte";
+  import SideNavMenu from "carbon-components-svelte/UIShell/SideNavMenu.svelte";
+  import SideNavMenuItem from "carbon-components-svelte/UIShell/SideNavMenuItem.svelte";
 
   export let rail = true;
   export let isOpen = false;

--- a/tests/SkeletonIcon/SkeletonIcon.test.svelte
+++ b/tests/SkeletonIcon/SkeletonIcon.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { SkeletonIcon } from "carbon-components-svelte";
+  import SkeletonIcon from "carbon-components-svelte/SkeletonIcon/SkeletonIcon.svelte";
 </script>
 
 <SkeletonIcon

--- a/tests/SkeletonPlaceholder/SkeletonPlaceholder.test.svelte
+++ b/tests/SkeletonPlaceholder/SkeletonPlaceholder.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { SkeletonPlaceholder } from "carbon-components-svelte";
+  import SkeletonPlaceholder from "carbon-components-svelte/SkeletonPlaceholder/SkeletonPlaceholder.svelte";
 </script>
 
 <SkeletonPlaceholder

--- a/tests/SkeletonText/SkeletonText.test.svelte
+++ b/tests/SkeletonText/SkeletonText.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { SkeletonText } from "carbon-components-svelte";
+  import SkeletonText from "carbon-components-svelte/SkeletonText/SkeletonText.svelte";
 
   export let lines = 3;
   export let heading = false;

--- a/tests/Slider/RangeSlider.test.svelte
+++ b/tests/Slider/RangeSlider.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { RangeSlider } from "carbon-components-svelte";
+  import RangeSlider from "carbon-components-svelte/Slider/RangeSlider.svelte";
 
   export let value = 0;
   export let valueUpper = 100;

--- a/tests/Slider/Slider.test.svelte
+++ b/tests/Slider/Slider.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Slider } from "carbon-components-svelte";
+  import Slider from "carbon-components-svelte/Slider/Slider.svelte";
   import type { ComponentProps } from "svelte";
 
   export let value = 0;

--- a/tests/Snippets/Snippets.test.svelte
+++ b/tests/Snippets/Snippets.test.svelte
@@ -1,16 +1,14 @@
 <script lang="ts">
-  import {
-    Button,
-    ComboBox,
-    DataTable,
-    Dropdown,
-    ProgressIndicator,
-    ProgressStep,
-    Tab,
-    TabContent,
-    Tabs,
-    Theme,
-  } from "carbon-components-svelte";
+  import Button from "carbon-components-svelte/Button/Button.svelte";
+  import ComboBox from "carbon-components-svelte/ComboBox/ComboBox.svelte";
+  import DataTable from "carbon-components-svelte/DataTable/DataTable.svelte";
+  import Dropdown from "carbon-components-svelte/Dropdown/Dropdown.svelte";
+  import ProgressIndicator from "carbon-components-svelte/ProgressIndicator/ProgressIndicator.svelte";
+  import ProgressStep from "carbon-components-svelte/ProgressIndicator/ProgressStep.svelte";
+  import Tab from "carbon-components-svelte/Tabs/Tab.svelte";
+  import TabContent from "carbon-components-svelte/Tabs/TabContent.svelte";
+  import Tabs from "carbon-components-svelte/Tabs/Tabs.svelte";
+  import Theme from "carbon-components-svelte/Theme/Theme.svelte";
 
   const items = [
     { id: "1", text: "Option 1" },

--- a/tests/Stack/Stack.test.svelte
+++ b/tests/Stack/Stack.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Stack } from "carbon-components-svelte";
+  import Stack from "carbon-components-svelte/Stack/Stack.svelte";
   import type { ComponentProps } from "svelte";
 
   const gaps: ComponentProps<Stack>["gap"][] = [

--- a/tests/StructuredList/StructuredList.test.svelte
+++ b/tests/StructuredList/StructuredList.test.svelte
@@ -1,12 +1,10 @@
 <script lang="ts">
-  import {
-    StructuredList,
-    StructuredListBody,
-    StructuredListCell,
-    StructuredListHead,
-    StructuredListInput,
-    StructuredListRow,
-  } from "carbon-components-svelte";
+  import StructuredList from "carbon-components-svelte/StructuredList/StructuredList.svelte";
+  import StructuredListBody from "carbon-components-svelte/StructuredList/StructuredListBody.svelte";
+  import StructuredListCell from "carbon-components-svelte/StructuredList/StructuredListCell.svelte";
+  import StructuredListHead from "carbon-components-svelte/StructuredList/StructuredListHead.svelte";
+  import StructuredListInput from "carbon-components-svelte/StructuredList/StructuredListInput.svelte";
+  import StructuredListRow from "carbon-components-svelte/StructuredList/StructuredListRow.svelte";
   import CheckmarkFilled from "carbon-icons-svelte/lib/CheckmarkFilled.svelte";
   import type { ComponentProps } from "svelte";
 

--- a/tests/StructuredList/StructuredListChecked.test.svelte
+++ b/tests/StructuredList/StructuredListChecked.test.svelte
@@ -1,12 +1,10 @@
 <script lang="ts">
-  import {
-    StructuredList,
-    StructuredListBody,
-    StructuredListCell,
-    StructuredListHead,
-    StructuredListInput,
-    StructuredListRow,
-  } from "carbon-components-svelte";
+  import StructuredList from "carbon-components-svelte/StructuredList/StructuredList.svelte";
+  import StructuredListBody from "carbon-components-svelte/StructuredList/StructuredListBody.svelte";
+  import StructuredListCell from "carbon-components-svelte/StructuredList/StructuredListCell.svelte";
+  import StructuredListHead from "carbon-components-svelte/StructuredList/StructuredListHead.svelte";
+  import StructuredListInput from "carbon-components-svelte/StructuredList/StructuredListInput.svelte";
+  import StructuredListRow from "carbon-components-svelte/StructuredList/StructuredListRow.svelte";
   import type { ComponentProps } from "svelte";
 
   export let selected: ComponentProps<StructuredList>["selected"] = undefined;

--- a/tests/StructuredList/StructuredListCustom.test.svelte
+++ b/tests/StructuredList/StructuredListCustom.test.svelte
@@ -1,11 +1,9 @@
 <script lang="ts">
-  import {
-    StructuredList,
-    StructuredListBody,
-    StructuredListCell,
-    StructuredListHead,
-    StructuredListRow,
-  } from "carbon-components-svelte";
+  import StructuredList from "carbon-components-svelte/StructuredList/StructuredList.svelte";
+  import StructuredListBody from "carbon-components-svelte/StructuredList/StructuredListBody.svelte";
+  import StructuredListCell from "carbon-components-svelte/StructuredList/StructuredListCell.svelte";
+  import StructuredListHead from "carbon-components-svelte/StructuredList/StructuredListHead.svelte";
+  import StructuredListRow from "carbon-components-svelte/StructuredList/StructuredListRow.svelte";
 </script>
 
 <StructuredList>

--- a/tests/StructuredList/StructuredListInputStandalone.test.svelte
+++ b/tests/StructuredList/StructuredListInputStandalone.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { StructuredListInput } from "carbon-components-svelte";
+  import StructuredListInput from "carbon-components-svelte/StructuredList/StructuredListInput.svelte";
 </script>
 
 <StructuredListInput id="standalone" value="standalone-value" name="solo" />

--- a/tests/StructuredList/StructuredListMultiple.test.svelte
+++ b/tests/StructuredList/StructuredListMultiple.test.svelte
@@ -1,12 +1,10 @@
 <script lang="ts">
-  import {
-    StructuredList,
-    StructuredListBody,
-    StructuredListCell,
-    StructuredListHead,
-    StructuredListInput,
-    StructuredListRow,
-  } from "carbon-components-svelte";
+  import StructuredList from "carbon-components-svelte/StructuredList/StructuredList.svelte";
+  import StructuredListBody from "carbon-components-svelte/StructuredList/StructuredListBody.svelte";
+  import StructuredListCell from "carbon-components-svelte/StructuredList/StructuredListCell.svelte";
+  import StructuredListHead from "carbon-components-svelte/StructuredList/StructuredListHead.svelte";
+  import StructuredListInput from "carbon-components-svelte/StructuredList/StructuredListInput.svelte";
+  import StructuredListRow from "carbon-components-svelte/StructuredList/StructuredListRow.svelte";
   import type { ComponentProps } from "svelte";
 
   export let selected: ComponentProps<StructuredList>["selected"] = undefined;

--- a/tests/StructuredList/StructuredListSkeleton.test.svelte
+++ b/tests/StructuredList/StructuredListSkeleton.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { StructuredListSkeleton } from "carbon-components-svelte";
+  import StructuredListSkeleton from "carbon-components-svelte/StructuredList/StructuredListSkeleton.svelte";
 </script>
 
 <StructuredListSkeleton {...$$props} />

--- a/tests/Tabs/Tab.test.svelte
+++ b/tests/Tabs/Tab.test.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { Tab, Tabs } from "carbon-components-svelte";
+  import Tab from "carbon-components-svelte/Tabs/Tab.svelte";
+  import Tabs from "carbon-components-svelte/Tabs/Tabs.svelte";
 
   export let label = "Test Tab";
   export let href = "#test";

--- a/tests/Tabs/TabIcon.test.svelte
+++ b/tests/Tabs/TabIcon.test.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
-  import { Tab, TabContent, Tabs } from "carbon-components-svelte";
+  import Tab from "carbon-components-svelte/Tabs/Tab.svelte";
+  import TabContent from "carbon-components-svelte/Tabs/TabContent.svelte";
+  import Tabs from "carbon-components-svelte/Tabs/Tabs.svelte";
   import Calendar from "../../src/icons/Calendar.svelte";
 
   export let icon = Calendar;

--- a/tests/Tabs/TabIconContainer.test.svelte
+++ b/tests/Tabs/TabIconContainer.test.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
-  import { Tab, TabContent, Tabs } from "carbon-components-svelte";
+  import Tab from "carbon-components-svelte/Tabs/Tab.svelte";
+  import TabContent from "carbon-components-svelte/Tabs/TabContent.svelte";
+  import Tabs from "carbon-components-svelte/Tabs/Tabs.svelte";
   import Calendar from "../../src/icons/Calendar.svelte";
 
   export let icon = Calendar;

--- a/tests/Tabs/TabIconSecondaryLabel.test.svelte
+++ b/tests/Tabs/TabIconSecondaryLabel.test.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
-  import { Tab, TabContent, Tabs } from "carbon-components-svelte";
+  import Tab from "carbon-components-svelte/Tabs/Tab.svelte";
+  import TabContent from "carbon-components-svelte/Tabs/TabContent.svelte";
+  import Tabs from "carbon-components-svelte/Tabs/Tabs.svelte";
   import Calendar from "../../src/icons/Calendar.svelte";
   import Information from "../../src/icons/Information.svelte";
   import Settings from "../../src/icons/Settings.svelte";

--- a/tests/Tabs/TabSecondaryLabel.test.svelte
+++ b/tests/Tabs/TabSecondaryLabel.test.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
-  import { Tab, TabContent, Tabs } from "carbon-components-svelte";
+  import Tab from "carbon-components-svelte/Tabs/Tab.svelte";
+  import TabContent from "carbon-components-svelte/Tabs/TabContent.svelte";
+  import Tabs from "carbon-components-svelte/Tabs/Tabs.svelte";
 </script>
 
 <Tabs type="container">

--- a/tests/Tabs/Tabs.test.svelte
+++ b/tests/Tabs/Tabs.test.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
-  import { Tab, TabContent, Tabs } from "carbon-components-svelte";
+  import Tab from "carbon-components-svelte/Tabs/Tab.svelte";
+  import TabContent from "carbon-components-svelte/Tabs/TabContent.svelte";
+  import Tabs from "carbon-components-svelte/Tabs/Tabs.svelte";
   import type { ComponentProps } from "svelte";
 
   export let selected = 0;

--- a/tests/Tabs/TabsAllDisabled.test.svelte
+++ b/tests/Tabs/TabsAllDisabled.test.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
-  import { Tab, TabContent, Tabs } from "carbon-components-svelte";
+  import Tab from "carbon-components-svelte/Tabs/Tab.svelte";
+  import TabContent from "carbon-components-svelte/Tabs/TabContent.svelte";
+  import Tabs from "carbon-components-svelte/Tabs/Tabs.svelte";
 </script>
 
 <Tabs>

--- a/tests/Tabs/TabsDynamic.test.svelte
+++ b/tests/Tabs/TabsDynamic.test.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
-  import { Tab, TabContent, Tabs } from "carbon-components-svelte";
+  import Tab from "carbon-components-svelte/Tabs/Tab.svelte";
+  import TabContent from "carbon-components-svelte/Tabs/TabContent.svelte";
+  import Tabs from "carbon-components-svelte/Tabs/Tabs.svelte";
 
   export let selected = 0;
   export let showTab1 = true;

--- a/tests/Tabs/TabsSkeleton.test.svelte
+++ b/tests/Tabs/TabsSkeleton.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { TabsSkeleton } from "carbon-components-svelte";
+  import TabsSkeleton from "carbon-components-svelte/Tabs/TabsSkeleton.svelte";
   import type { ComponentProps } from "svelte";
 
   export let count = 4;

--- a/tests/Tag/SelectableTag.test.svelte
+++ b/tests/Tag/SelectableTag.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { SelectableTag } from "carbon-components-svelte";
+  import SelectableTag from "carbon-components-svelte/Tag/SelectableTag.svelte";
 </script>
 
 <SelectableTag>Default</SelectableTag>

--- a/tests/Tag/Tag.test.svelte
+++ b/tests/Tag/Tag.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Tag } from "carbon-components-svelte";
+  import Tag from "carbon-components-svelte/Tag/Tag.svelte";
   import Add from "carbon-icons-svelte/lib/Add.svelte";
 </script>
 

--- a/tests/TextArea/TextArea.test.svelte
+++ b/tests/TextArea/TextArea.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { TextArea } from "carbon-components-svelte";
+  import TextArea from "carbon-components-svelte/TextArea/TextArea.svelte";
   import type { ComponentProps } from "svelte";
 
   export let value: ComponentProps<TextArea>["value"] = "";

--- a/tests/TextArea/TextAreaCustom.test.svelte
+++ b/tests/TextArea/TextAreaCustom.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { TextArea } from "carbon-components-svelte";
+  import TextArea from "carbon-components-svelte/TextArea/TextArea.svelte";
 </script>
 
 <TextArea labelText="Custom label">

--- a/tests/TextInput/TextInput.test.svelte
+++ b/tests/TextInput/TextInput.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { TextInput } from "carbon-components-svelte";
+  import TextInput from "carbon-components-svelte/TextInput/TextInput.svelte";
   import type { ComponentProps } from "svelte";
 
   export let value: ComponentProps<TextInput>["value"] = "";

--- a/tests/TextInput/TextInputCustom.test.svelte
+++ b/tests/TextInput/TextInputCustom.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { TextInput } from "carbon-components-svelte";
+  import TextInput from "carbon-components-svelte/TextInput/TextInput.svelte";
 </script>
 
 <TextInput labelText="Custom label">

--- a/tests/TextInput/TextInputFluid.test.svelte
+++ b/tests/TextInput/TextInputFluid.test.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { FluidForm, TextInput } from "carbon-components-svelte";
+  import FluidForm from "carbon-components-svelte/FluidForm/FluidForm.svelte";
+  import TextInput from "carbon-components-svelte/TextInput/TextInput.svelte";
   import type { ComponentProps } from "svelte";
 
   export let value: ComponentProps<TextInput>["value"] = "";

--- a/tests/TextInput/TextInputInlineLabelChildren.test.svelte
+++ b/tests/TextInput/TextInputInlineLabelChildren.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { TextInput } from "carbon-components-svelte";
+  import TextInput from "carbon-components-svelte/TextInput/TextInput.svelte";
 </script>
 
 <TextInput inline labelText="">

--- a/tests/Theme/Theme.test.svelte
+++ b/tests/Theme/Theme.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Theme } from "carbon-components-svelte";
+  import Theme from "carbon-components-svelte/Theme/Theme.svelte";
   import type { ComponentProps } from "svelte";
 
   export let theme: ComponentProps<Theme>["theme"] = "white";

--- a/tests/Theme/ThemeCrossTab.test.svelte
+++ b/tests/Theme/ThemeCrossTab.test.svelte
@@ -1,7 +1,7 @@
 <svelte:options accessors />
 
 <script lang="ts">
-  import { Theme } from "carbon-components-svelte";
+  import Theme from "carbon-components-svelte/Theme/Theme.svelte";
   import type { ComponentProps } from "svelte";
 
   export let theme: ComponentProps<Theme>["theme"] = "white";

--- a/tests/Theme/ThemeDropdown.test.svelte
+++ b/tests/Theme/ThemeDropdown.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Theme } from "carbon-components-svelte";
+  import Theme from "carbon-components-svelte/Theme/Theme.svelte";
 </script>
 
 <Theme

--- a/tests/Theme/ThemeDropdownCustom.test.svelte
+++ b/tests/Theme/ThemeDropdownCustom.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Theme } from "carbon-components-svelte";
+  import Theme from "carbon-components-svelte/Theme/Theme.svelte";
 </script>
 
 <Theme

--- a/tests/Theme/ThemeSelect.test.svelte
+++ b/tests/Theme/ThemeSelect.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Theme } from "carbon-components-svelte";
+  import Theme from "carbon-components-svelte/Theme/Theme.svelte";
 </script>
 
 <Theme

--- a/tests/Theme/ThemeSelectCustom.test.svelte
+++ b/tests/Theme/ThemeSelectCustom.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Theme } from "carbon-components-svelte";
+  import Theme from "carbon-components-svelte/Theme/Theme.svelte";
 </script>
 
 <Theme

--- a/tests/Theme/ThemeSelectDynamic.test.svelte
+++ b/tests/Theme/ThemeSelectDynamic.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Theme } from "carbon-components-svelte";
+  import Theme from "carbon-components-svelte/Theme/Theme.svelte";
   import type { ComponentProps } from "svelte";
 
   export let themes: NonNullable<ComponentProps<Theme>["select"]>["themes"] =

--- a/tests/Theme/ThemeToggle.test.svelte
+++ b/tests/Theme/ThemeToggle.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Theme } from "carbon-components-svelte";
+  import Theme from "carbon-components-svelte/Theme/Theme.svelte";
 </script>
 
 <Theme

--- a/tests/Theme/ThemeToggleCustom.test.svelte
+++ b/tests/Theme/ThemeToggleCustom.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Theme } from "carbon-components-svelte";
+  import Theme from "carbon-components-svelte/Theme/Theme.svelte";
 </script>
 
 <Theme

--- a/tests/Tile/ClickableTile.test.svelte
+++ b/tests/Tile/ClickableTile.test.svelte
@@ -1,7 +1,7 @@
 <svelte:options accessors />
 
 <script lang="ts">
-  import { ClickableTile } from "carbon-components-svelte";
+  import ClickableTile from "carbon-components-svelte/Tile/ClickableTile.svelte";
   import type { ComponentProps } from "svelte";
 
   export let ref: ComponentProps<ClickableTile>["ref"] = undefined;

--- a/tests/Tile/RadioTileStandalone.test.svelte
+++ b/tests/Tile/RadioTileStandalone.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { RadioTile } from "carbon-components-svelte";
+  import RadioTile from "carbon-components-svelte/Tile/RadioTile.svelte";
 </script>
 
 <RadioTile value="standalone-value" name="solo">Standalone</RadioTile>

--- a/tests/Tile/SelectableTile.test.svelte
+++ b/tests/Tile/SelectableTile.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { SelectableTile } from "carbon-components-svelte";
+  import SelectableTile from "carbon-components-svelte/Tile/SelectableTile.svelte";
 
   export let selected = false;
   export let light = false;

--- a/tests/Tile/SelectableTileGroup.slot.test.svelte
+++ b/tests/Tile/SelectableTileGroup.slot.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { SelectableTileGroup } from "carbon-components-svelte";
+  import SelectableTileGroup from "carbon-components-svelte/Tile/SelectableTileGroup.svelte";
 </script>
 
 <SelectableTileGroup legendText="Default legend">

--- a/tests/Tile/SelectableTileGroup.test.svelte
+++ b/tests/Tile/SelectableTileGroup.test.svelte
@@ -1,10 +1,8 @@
 <svelte:options accessors />
 
 <script lang="ts">
-  import {
-    SelectableTile,
-    SelectableTileGroup,
-  } from "carbon-components-svelte";
+  import SelectableTile from "carbon-components-svelte/Tile/SelectableTile.svelte";
+  import SelectableTileGroup from "carbon-components-svelte/Tile/SelectableTileGroup.svelte";
   import type { ComponentProps } from "svelte";
 
   export let selected: ComponentProps<SelectableTileGroup>["selected"] = [];

--- a/tests/Tile/SelectableTileGroupReactive.test.svelte
+++ b/tests/Tile/SelectableTileGroupReactive.test.svelte
@@ -1,10 +1,8 @@
 <svelte:options accessors />
 
 <script lang="ts">
-  import {
-    SelectableTile,
-    SelectableTileGroup,
-  } from "carbon-components-svelte";
+  import SelectableTile from "carbon-components-svelte/Tile/SelectableTile.svelte";
+  import SelectableTileGroup from "carbon-components-svelte/Tile/SelectableTileGroup.svelte";
 
   export let groupSelected: string[] = [];
   export let tileValue = "a";

--- a/tests/Tile/SelectableTileStandalone.test.svelte
+++ b/tests/Tile/SelectableTileStandalone.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { SelectableTile } from "carbon-components-svelte";
+  import SelectableTile from "carbon-components-svelte/Tile/SelectableTile.svelte";
 </script>
 
 <SelectableTile value="standalone-value" name="solo">Standalone</SelectableTile>

--- a/tests/Tile/Tile.test.svelte
+++ b/tests/Tile/Tile.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Tile } from "carbon-components-svelte";
+  import Tile from "carbon-components-svelte/Tile/Tile.svelte";
 </script>
 
 <Tile>Default tile</Tile>

--- a/tests/Tile/TileGroup.slot.test.svelte
+++ b/tests/Tile/TileGroup.slot.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { TileGroup } from "carbon-components-svelte";
+  import TileGroup from "carbon-components-svelte/Tile/TileGroup.svelte";
 </script>
 
 <TileGroup legendText="Default legend">

--- a/tests/Tile/TileGroup.test.svelte
+++ b/tests/Tile/TileGroup.test.svelte
@@ -1,7 +1,8 @@
 <svelte:options accessors />
 
 <script lang="ts">
-  import { RadioTile, TileGroup } from "carbon-components-svelte";
+  import RadioTile from "carbon-components-svelte/Tile/RadioTile.svelte";
+  import TileGroup from "carbon-components-svelte/Tile/TileGroup.svelte";
   import type { ComponentProps } from "svelte";
 
   export let selected: ComponentProps<TileGroup>["selected"] = undefined;

--- a/tests/TimePicker/TimePicker.test.svelte
+++ b/tests/TimePicker/TimePicker.test.svelte
@@ -1,9 +1,7 @@
 <script lang="ts">
-  import {
-    SelectItem,
-    TimePicker,
-    TimePickerSelect,
-  } from "carbon-components-svelte";
+  import SelectItem from "carbon-components-svelte/Select/SelectItem.svelte";
+  import TimePicker from "carbon-components-svelte/TimePicker/TimePicker.svelte";
+  import TimePickerSelect from "carbon-components-svelte/TimePicker/TimePickerSelect.svelte";
   import type { ComponentProps } from "svelte";
 
   export let size: ComponentProps<TimePicker>["size"] = undefined;

--- a/tests/TimePicker/TimePickerCustom.test.svelte
+++ b/tests/TimePicker/TimePickerCustom.test.svelte
@@ -1,9 +1,7 @@
 <script lang="ts">
-  import {
-    SelectItem,
-    TimePicker,
-    TimePickerSelect,
-  } from "carbon-components-svelte";
+  import SelectItem from "carbon-components-svelte/Select/SelectItem.svelte";
+  import TimePicker from "carbon-components-svelte/TimePicker/TimePicker.svelte";
+  import TimePickerSelect from "carbon-components-svelte/TimePicker/TimePickerSelect.svelte";
 
   export let selectReadonly = false;
 </script>

--- a/tests/TimePicker/TimePickerSelect.slot.test.svelte
+++ b/tests/TimePicker/TimePickerSelect.slot.test.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { SelectItem, TimePickerSelect } from "carbon-components-svelte";
+  import SelectItem from "carbon-components-svelte/Select/SelectItem.svelte";
+  import TimePickerSelect from "carbon-components-svelte/TimePicker/TimePickerSelect.svelte";
 </script>
 
 <TimePickerSelect labelText="Default label">

--- a/tests/TimePicker/TimePickerSelectEvents.test.svelte
+++ b/tests/TimePicker/TimePickerSelectEvents.test.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { SelectItem, TimePickerSelect } from "carbon-components-svelte";
+  import SelectItem from "carbon-components-svelte/Select/SelectItem.svelte";
+  import TimePickerSelect from "carbon-components-svelte/TimePicker/TimePickerSelect.svelte";
 
   export let selectChange: () => void = () => {};
   export let selectInput: () => void = () => {};

--- a/tests/ToastNotification/ToastNotification.test.svelte
+++ b/tests/ToastNotification/ToastNotification.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { ToastNotification } from "carbon-components-svelte";
+  import ToastNotification from "carbon-components-svelte/Notification/ToastNotification.svelte";
   import type { ComponentProps } from "svelte";
 
   export let kind: ComponentProps<ToastNotification>["kind"] = "error";

--- a/tests/ToastNotification/ToastNotificationCaptionSlot.test.svelte
+++ b/tests/ToastNotification/ToastNotificationCaptionSlot.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { ToastNotification } from "carbon-components-svelte";
+  import ToastNotification from "carbon-components-svelte/Notification/ToastNotification.svelte";
 </script>
 
 <ToastNotification on:close on:click>

--- a/tests/ToastNotification/ToastNotificationCustom.test.svelte
+++ b/tests/ToastNotification/ToastNotificationCustom.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { ToastNotification } from "carbon-components-svelte";
+  import ToastNotification from "carbon-components-svelte/Notification/ToastNotification.svelte";
 </script>
 
 <ToastNotification kind="warning">

--- a/tests/ToastNotification/ToastNotificationReusable.test.svelte
+++ b/tests/ToastNotification/ToastNotificationReusable.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { ToastNotification } from "carbon-components-svelte";
+  import ToastNotification from "carbon-components-svelte/Notification/ToastNotification.svelte";
   import type { ComponentProps } from "svelte";
 
   export let open = false;

--- a/tests/ToastNotification/ToastNotificationSubtitleSlot.test.svelte
+++ b/tests/ToastNotification/ToastNotificationSubtitleSlot.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { ToastNotification } from "carbon-components-svelte";
+  import ToastNotification from "carbon-components-svelte/Notification/ToastNotification.svelte";
 </script>
 
 <ToastNotification on:close on:click>

--- a/tests/ToastNotification/ToastNotificationTitleSlot.test.svelte
+++ b/tests/ToastNotification/ToastNotificationTitleSlot.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { ToastNotification } from "carbon-components-svelte";
+  import ToastNotification from "carbon-components-svelte/Notification/ToastNotification.svelte";
 </script>
 
 <ToastNotification on:close on:click>

--- a/tests/Toggle/Toggle.readonly.test.svelte
+++ b/tests/Toggle/Toggle.readonly.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Toggle } from "carbon-components-svelte";
+  import Toggle from "carbon-components-svelte/Toggle/Toggle.svelte";
 
   export let toggled = false;
   export let readonly = false;

--- a/tests/Toggle/Toggle.test.svelte
+++ b/tests/Toggle/Toggle.test.svelte
@@ -1,7 +1,7 @@
 <svelte:options accessors />
 
 <script lang="ts">
-  import { Toggle } from "carbon-components-svelte";
+  import Toggle from "carbon-components-svelte/Toggle/Toggle.svelte";
   import type { ComponentProps } from "svelte";
 
   let toggled = false;

--- a/tests/Toggle/ToggleNullishAriaLabel.test.svelte
+++ b/tests/Toggle/ToggleNullishAriaLabel.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Toggle } from "carbon-components-svelte";
+  import Toggle from "carbon-components-svelte/Toggle/Toggle.svelte";
   import type { ComponentProps } from "svelte";
 
   export let ariaLabel: NonNullable<ComponentProps<Toggle>["aria-label"]> = "";

--- a/tests/Toggle/ToggleSkeleton.slot.test.svelte
+++ b/tests/Toggle/ToggleSkeleton.slot.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { ToggleSkeleton } from "carbon-components-svelte";
+  import ToggleSkeleton from "carbon-components-svelte/Toggle/ToggleSkeleton.svelte";
 </script>
 
 <ToggleSkeleton labelText="Default label">

--- a/tests/Toggle/ToggleSkeletonNullishAriaLabel.test.svelte
+++ b/tests/Toggle/ToggleSkeletonNullishAriaLabel.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { ToggleSkeleton } from "carbon-components-svelte";
+  import ToggleSkeleton from "carbon-components-svelte/Toggle/ToggleSkeleton.svelte";
   import type { ComponentProps } from "svelte";
 
   export let ariaLabel: NonNullable<

--- a/tests/Tooltip/TooltipAlignments.test.svelte
+++ b/tests/Tooltip/TooltipAlignments.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Tooltip } from "carbon-components-svelte";
+  import Tooltip from "carbon-components-svelte/Tooltip/Tooltip.svelte";
 
   const alignments = ["start", "center", "end"] as const;
 </script>

--- a/tests/Tooltip/TooltipCustomContent.test.svelte
+++ b/tests/Tooltip/TooltipCustomContent.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Tooltip } from "carbon-components-svelte";
+  import Tooltip from "carbon-components-svelte/Tooltip/Tooltip.svelte";
 </script>
 
 <Tooltip open={true} iconDescription="Information">

--- a/tests/Tooltip/TooltipCustomIcon.test.svelte
+++ b/tests/Tooltip/TooltipCustomIcon.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Tooltip } from "carbon-components-svelte";
+  import Tooltip from "carbon-components-svelte/Tooltip/Tooltip.svelte";
 </script>
 
 <Tooltip iconDescription="Information">

--- a/tests/Tooltip/TooltipDefault.test.svelte
+++ b/tests/Tooltip/TooltipDefault.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Tooltip } from "carbon-components-svelte";
+  import Tooltip from "carbon-components-svelte/Tooltip/Tooltip.svelte";
 </script>
 
 <Tooltip iconDescription="Information" />

--- a/tests/Tooltip/TooltipDirections.test.svelte
+++ b/tests/Tooltip/TooltipDirections.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Tooltip } from "carbon-components-svelte";
+  import Tooltip from "carbon-components-svelte/Tooltip/Tooltip.svelte";
 
   const directions = ["top", "right", "bottom", "left"] as const;
 </script>

--- a/tests/Tooltip/TooltipEvents.test.svelte
+++ b/tests/Tooltip/TooltipEvents.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Tooltip } from "carbon-components-svelte";
+  import Tooltip from "carbon-components-svelte/Tooltip/Tooltip.svelte";
 
   let openCount = 0;
   let closeCount = 0;

--- a/tests/Tooltip/TooltipFooterStandalone.test.svelte
+++ b/tests/Tooltip/TooltipFooterStandalone.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { TooltipFooter } from "carbon-components-svelte";
+  import TooltipFooter from "carbon-components-svelte/Tooltip/TooltipFooter.svelte";
 </script>
 
 <TooltipFooter />

--- a/tests/Tooltip/TooltipHideIcon.test.svelte
+++ b/tests/Tooltip/TooltipHideIcon.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Tooltip } from "carbon-components-svelte";
+  import Tooltip from "carbon-components-svelte/Tooltip/Tooltip.svelte";
 </script>
 
 <Tooltip

--- a/tests/Tooltip/TooltipOpen.test.svelte
+++ b/tests/Tooltip/TooltipOpen.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Tooltip } from "carbon-components-svelte";
+  import Tooltip from "carbon-components-svelte/Tooltip/Tooltip.svelte";
 </script>
 
 <Tooltip open={true} iconDescription="Information">

--- a/tests/Tooltip/TooltipPortalDirections.test.svelte
+++ b/tests/Tooltip/TooltipPortalDirections.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Tooltip } from "carbon-components-svelte";
+  import Tooltip from "carbon-components-svelte/Tooltip/Tooltip.svelte";
 
   const directions = ["top", "right", "bottom", "left"] as const;
 </script>

--- a/tests/TooltipDefinition/TooltipDefinition.test.svelte
+++ b/tests/TooltipDefinition/TooltipDefinition.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { TooltipDefinition } from "carbon-components-svelte";
+  import TooltipDefinition from "carbon-components-svelte/TooltipDefinition/TooltipDefinition.svelte";
   import type { ComponentProps } from "svelte";
 
   export let tooltipText = "Test tooltip text";

--- a/tests/TooltipDefinition/TooltipDefinitionPortal.test.svelte
+++ b/tests/TooltipDefinition/TooltipDefinitionPortal.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { TooltipDefinition } from "carbon-components-svelte";
+  import TooltipDefinition from "carbon-components-svelte/TooltipDefinition/TooltipDefinition.svelte";
 
   const directions = ["top", "bottom"] as const;
 </script>

--- a/tests/TooltipIcon/TooltipIcon.size.test.svelte
+++ b/tests/TooltipIcon/TooltipIcon.size.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { TooltipIcon } from "carbon-components-svelte";
+  import TooltipIcon from "carbon-components-svelte/TooltipIcon/TooltipIcon.svelte";
   import MockIcon from "./MockIcon.svelte";
 
   export let size = 16;

--- a/tests/TooltipIcon/TooltipIcon.test.svelte
+++ b/tests/TooltipIcon/TooltipIcon.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { TooltipIcon } from "carbon-components-svelte";
+  import TooltipIcon from "carbon-components-svelte/TooltipIcon/TooltipIcon.svelte";
   import Carbon from "carbon-icons-svelte/lib/Carbon.svelte";
   import type { ComponentProps } from "svelte";
 

--- a/tests/TooltipIcon/TooltipIconMultiple.test.svelte
+++ b/tests/TooltipIcon/TooltipIconMultiple.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { TooltipIcon } from "carbon-components-svelte";
+  import TooltipIcon from "carbon-components-svelte/TooltipIcon/TooltipIcon.svelte";
   import Carbon from "carbon-icons-svelte/lib/Carbon.svelte";
 
   export let enterDelayMs = 0;

--- a/tests/TooltipIcon/TooltipIconPortal.test.svelte
+++ b/tests/TooltipIcon/TooltipIconPortal.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { TooltipIcon } from "carbon-components-svelte";
+  import TooltipIcon from "carbon-components-svelte/TooltipIcon/TooltipIcon.svelte";
   import Carbon from "carbon-icons-svelte/lib/Carbon.svelte";
 
   const directions = ["top", "right", "bottom", "left"] as const;

--- a/tests/TooltipIcon/TooltipIconReactive.test.svelte
+++ b/tests/TooltipIcon/TooltipIconReactive.test.svelte
@@ -1,7 +1,7 @@
 <svelte:options accessors />
 
 <script lang="ts">
-  import { TooltipIcon } from "carbon-components-svelte";
+  import TooltipIcon from "carbon-components-svelte/TooltipIcon/TooltipIcon.svelte";
   import Carbon from "carbon-icons-svelte/lib/Carbon.svelte";
 
   export let open = true;

--- a/tests/TreeView/TreeView.autoCollapse.test.svelte
+++ b/tests/TreeView/TreeView.autoCollapse.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { TreeView } from "carbon-components-svelte";
+  import TreeView from "carbon-components-svelte/TreeView/TreeView.svelte";
   import type { ComponentProps } from "svelte";
 
   export let autoCollapse = true;

--- a/tests/TreeView/TreeView.hierarchy.test.svelte
+++ b/tests/TreeView/TreeView.hierarchy.test.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
-  import { Button, TreeView, toHierarchy } from "carbon-components-svelte";
+  import Button from "carbon-components-svelte/Button/Button.svelte";
   import type { TreeNode } from "carbon-components-svelte/TreeView/TreeView.svelte";
+  import TreeView from "carbon-components-svelte/TreeView/TreeView.svelte";
+  import { toHierarchy } from "carbon-components-svelte/utils/toHierarchy";
   import Analytics from "carbon-icons-svelte/lib/Analytics.svelte";
 
   type HierarchyNode = TreeNode<number> & { pid?: number };

--- a/tests/TreeView/TreeView.href.test.svelte
+++ b/tests/TreeView/TreeView.href.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { TreeView } from "carbon-components-svelte";
+  import TreeView from "carbon-components-svelte/TreeView/TreeView.svelte";
   import type { ComponentProps } from "svelte";
 
   export let nodes: ComponentProps<TreeView>["nodes"] = [

--- a/tests/TreeView/TreeView.multiselect.test.svelte
+++ b/tests/TreeView/TreeView.multiselect.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { TreeView } from "carbon-components-svelte";
+  import TreeView from "carbon-components-svelte/TreeView/TreeView.svelte";
   import type { ComponentProps } from "svelte";
 
   export let multiselect: ComponentProps<TreeView>["multiselect"] = true;

--- a/tests/TreeView/TreeView.performance.test.svelte
+++ b/tests/TreeView/TreeView.performance.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { TreeView } from "carbon-components-svelte";
+  import TreeView from "carbon-components-svelte/TreeView/TreeView.svelte";
   import type { ComponentProps } from "svelte";
 
   export let nodes: ComponentProps<TreeView>["nodes"] = [

--- a/tests/TreeView/TreeView.props.test.svelte
+++ b/tests/TreeView/TreeView.props.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { TreeView } from "carbon-components-svelte";
+  import TreeView from "carbon-components-svelte/TreeView/TreeView.svelte";
   import type { ComponentProps } from "svelte";
 
   export let nodes: ComponentProps<TreeView>["nodes"] = [

--- a/tests/TreeView/TreeView.showNode.idEscape.test.svelte
+++ b/tests/TreeView/TreeView.showNode.idEscape.test.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { Button, TreeView } from "carbon-components-svelte";
+  import Button from "carbon-components-svelte/Button/Button.svelte";
+  import TreeView from "carbon-components-svelte/TreeView/TreeView.svelte";
   import type { ComponentProps } from "svelte";
 
   /** Id contains `"`, which breaks a naive `[id="..."]` selector without CSS.escape */

--- a/tests/TreeView/TreeView.showNode.test.svelte
+++ b/tests/TreeView/TreeView.showNode.test.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
-  import { Button, TreeView } from "carbon-components-svelte";
+  import Button from "carbon-components-svelte/Button/Button.svelte";
   import type { TreeNode } from "carbon-components-svelte/TreeView/TreeView.svelte";
+  import TreeView from "carbon-components-svelte/TreeView/TreeView.svelte";
   import type { ComponentProps } from "svelte";
 
   let treeview: TreeView;

--- a/tests/TreeView/TreeView.slot.test.svelte
+++ b/tests/TreeView/TreeView.slot.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { TreeView } from "carbon-components-svelte";
+  import TreeView from "carbon-components-svelte/TreeView/TreeView.svelte";
   import type { ComponentProps } from "svelte";
 
   const nodes: ComponentProps<TreeView>["nodes"] = [

--- a/tests/TreeView/TreeView.test.svelte
+++ b/tests/TreeView/TreeView.test.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { Button, TreeView } from "carbon-components-svelte";
+  import Button from "carbon-components-svelte/Button/Button.svelte";
+  import TreeView from "carbon-components-svelte/TreeView/TreeView.svelte";
   import Analytics from "carbon-icons-svelte/lib/Analytics.svelte";
   import type { ComponentProps } from "svelte";
 

--- a/tests/TreeView/TreeViewDuplicateIds.test.svelte
+++ b/tests/TreeView/TreeViewDuplicateIds.test.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  import { TreeView } from "carbon-components-svelte";
   import type { TreeNode } from "carbon-components-svelte/TreeView/TreeView.svelte";
+  import TreeView from "carbon-components-svelte/TreeView/TreeView.svelte";
 
   const nodes: TreeNode[] = [
     {

--- a/tests/TreeView/TreeViewGenerics.test.svelte
+++ b/tests/TreeView/TreeViewGenerics.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { TreeView } from "carbon-components-svelte";
+  import TreeView from "carbon-components-svelte/TreeView/TreeView.svelte";
 
   type CategoryNode = {
     id: string;

--- a/tests/Truncate/Truncate.test.svelte
+++ b/tests/Truncate/Truncate.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Truncate } from "carbon-components-svelte";
+  import Truncate from "carbon-components-svelte/Truncate/Truncate.svelte";
   import type { ComponentProps } from "svelte";
 
   export let clamp: ComponentProps<Truncate>["clamp"] = "end";

--- a/tests/Truncate/TruncateAction.test.svelte
+++ b/tests/Truncate/TruncateAction.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { truncate } from "carbon-components-svelte";
+  import { truncate } from "carbon-components-svelte/Truncate/truncate";
 
   export let clamp: "end" | "front" = "end";
   export let text =

--- a/tests/UIShell/Header.slot.test.svelte
+++ b/tests/UIShell/Header.slot.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Header } from "carbon-components-svelte";
+  import Header from "carbon-components-svelte/UIShell/Header.svelte";
 </script>
 
 <Header companyName="Default company">

--- a/tests/UIShell/HeaderAction.outsideClick.test.svelte
+++ b/tests/UIShell/HeaderAction.outsideClick.test.svelte
@@ -1,9 +1,7 @@
 <script lang="ts">
-  import {
-    Header,
-    HeaderAction,
-    HeaderUtilities,
-  } from "carbon-components-svelte";
+  import Header from "carbon-components-svelte/UIShell/Header.svelte";
+  import HeaderAction from "carbon-components-svelte/UIShell/HeaderAction.svelte";
+  import HeaderUtilities from "carbon-components-svelte/UIShell/HeaderUtilities.svelte";
 
   export let preventCloseOnClickOutside = false;
 

--- a/tests/UIShell/HeaderAction.slot.test.svelte
+++ b/tests/UIShell/HeaderAction.slot.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { HeaderAction } from "carbon-components-svelte";
+  import HeaderAction from "carbon-components-svelte/UIShell/HeaderAction.svelte";
 </script>
 
 <HeaderAction text="Default text">

--- a/tests/UIShell/HeaderNavKeyboard.test.svelte
+++ b/tests/UIShell/HeaderNavKeyboard.test.svelte
@@ -1,10 +1,8 @@
 <script lang="ts">
-  import {
-    Header,
-    HeaderNav,
-    HeaderNavItem,
-    HeaderNavMenu,
-  } from "carbon-components-svelte";
+  import Header from "carbon-components-svelte/UIShell/Header.svelte";
+  import HeaderNav from "carbon-components-svelte/UIShell/HeaderNav.svelte";
+  import HeaderNavItem from "carbon-components-svelte/UIShell/HeaderNavItem.svelte";
+  import HeaderNavMenu from "carbon-components-svelte/UIShell/HeaderNavMenu.svelte";
 </script>
 
 <Header companyName="Test" platformName="Test">

--- a/tests/UIShell/HeaderSearch.test.svelte
+++ b/tests/UIShell/HeaderSearch.test.svelte
@@ -1,7 +1,7 @@
 <svelte:options accessors />
 
 <script lang="ts">
-  import { HeaderSearch } from "carbon-components-svelte";
+  import HeaderSearch from "carbon-components-svelte/UIShell/HeaderSearch.svelte";
   import type { ComponentEvents, ComponentProps } from "svelte";
 
   export let active = false;

--- a/tests/UIShell/HeaderSwitcher.test.svelte
+++ b/tests/UIShell/HeaderSwitcher.test.svelte
@@ -1,22 +1,20 @@
 <script lang="ts">
-  import {
-    Column,
-    Content,
-    Grid,
-    Header,
-    HeaderAction,
-    HeaderPanelDivider,
-    HeaderPanelLink,
-    HeaderPanelLinks,
-    HeaderUtilities,
-    Row,
-    SideNav,
-    SideNavItems,
-    SideNavLink,
-    SideNavMenu,
-    SideNavMenuItem,
-    SkipToContent,
-  } from "carbon-components-svelte";
+  import Column from "carbon-components-svelte/Grid/Column.svelte";
+  import Grid from "carbon-components-svelte/Grid/Grid.svelte";
+  import Row from "carbon-components-svelte/Grid/Row.svelte";
+  import Content from "carbon-components-svelte/UIShell/Content.svelte";
+  import Header from "carbon-components-svelte/UIShell/Header.svelte";
+  import HeaderAction from "carbon-components-svelte/UIShell/HeaderAction.svelte";
+  import HeaderPanelDivider from "carbon-components-svelte/UIShell/HeaderPanelDivider.svelte";
+  import HeaderPanelLink from "carbon-components-svelte/UIShell/HeaderPanelLink.svelte";
+  import HeaderPanelLinks from "carbon-components-svelte/UIShell/HeaderPanelLinks.svelte";
+  import HeaderUtilities from "carbon-components-svelte/UIShell/HeaderUtilities.svelte";
+  import SideNav from "carbon-components-svelte/UIShell/SideNav.svelte";
+  import SideNavItems from "carbon-components-svelte/UIShell/SideNavItems.svelte";
+  import SideNavLink from "carbon-components-svelte/UIShell/SideNavLink.svelte";
+  import SideNavMenu from "carbon-components-svelte/UIShell/SideNavMenu.svelte";
+  import SideNavMenuItem from "carbon-components-svelte/UIShell/SideNavMenuItem.svelte";
+  import SkipToContent from "carbon-components-svelte/UIShell/SkipToContent.svelte";
 
   let isSideNavOpen = false;
   let isOpen = false;

--- a/tests/UIShell/HeaderUtilities.test.svelte
+++ b/tests/UIShell/HeaderUtilities.test.svelte
@@ -1,23 +1,21 @@
 <script lang="ts">
-  import {
-    Column,
-    Content,
-    Grid,
-    Header,
-    HeaderAction,
-    HeaderGlobalAction,
-    HeaderPanelDivider,
-    HeaderPanelLink,
-    HeaderPanelLinks,
-    HeaderUtilities,
-    Row,
-    SideNav,
-    SideNavItems,
-    SideNavLink,
-    SideNavMenu,
-    SideNavMenuItem,
-    SkipToContent,
-  } from "carbon-components-svelte";
+  import Column from "carbon-components-svelte/Grid/Column.svelte";
+  import Grid from "carbon-components-svelte/Grid/Grid.svelte";
+  import Row from "carbon-components-svelte/Grid/Row.svelte";
+  import Content from "carbon-components-svelte/UIShell/Content.svelte";
+  import Header from "carbon-components-svelte/UIShell/Header.svelte";
+  import HeaderAction from "carbon-components-svelte/UIShell/HeaderAction.svelte";
+  import HeaderGlobalAction from "carbon-components-svelte/UIShell/HeaderGlobalAction.svelte";
+  import HeaderPanelDivider from "carbon-components-svelte/UIShell/HeaderPanelDivider.svelte";
+  import HeaderPanelLink from "carbon-components-svelte/UIShell/HeaderPanelLink.svelte";
+  import HeaderPanelLinks from "carbon-components-svelte/UIShell/HeaderPanelLinks.svelte";
+  import HeaderUtilities from "carbon-components-svelte/UIShell/HeaderUtilities.svelte";
+  import SideNav from "carbon-components-svelte/UIShell/SideNav.svelte";
+  import SideNavItems from "carbon-components-svelte/UIShell/SideNavItems.svelte";
+  import SideNavLink from "carbon-components-svelte/UIShell/SideNavLink.svelte";
+  import SideNavMenu from "carbon-components-svelte/UIShell/SideNavMenu.svelte";
+  import SideNavMenuItem from "carbon-components-svelte/UIShell/SideNavMenuItem.svelte";
+  import SkipToContent from "carbon-components-svelte/UIShell/SkipToContent.svelte";
   import SettingsAdjust from "carbon-icons-svelte/lib/SettingsAdjust.svelte";
   import { quintOut } from "svelte/easing";
 

--- a/tests/UIShell/UIShell.test.svelte
+++ b/tests/UIShell/UIShell.test.svelte
@@ -1,15 +1,13 @@
 <svelte:options accessors />
 
 <script lang="ts">
-  import {
-    Content,
-    Header,
-    HeaderNav,
-    HeaderNavItem,
-    SideNav,
-    SideNavItems,
-    SideNavLink,
-  } from "carbon-components-svelte";
+  import Content from "carbon-components-svelte/UIShell/Content.svelte";
+  import Header from "carbon-components-svelte/UIShell/Header.svelte";
+  import HeaderNav from "carbon-components-svelte/UIShell/HeaderNav.svelte";
+  import HeaderNavItem from "carbon-components-svelte/UIShell/HeaderNavItem.svelte";
+  import SideNav from "carbon-components-svelte/UIShell/SideNav.svelte";
+  import SideNavItems from "carbon-components-svelte/UIShell/SideNavItems.svelte";
+  import SideNavLink from "carbon-components-svelte/UIShell/SideNavLink.svelte";
   import type { ComponentProps } from "svelte";
 
   export let headerHref: ComponentProps<Header>["href"] = undefined;

--- a/tests/UnorderedList/UnorderedList.test.svelte
+++ b/tests/UnorderedList/UnorderedList.test.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { ListItem, UnorderedList } from "carbon-components-svelte";
+  import ListItem from "carbon-components-svelte/ListItem/ListItem.svelte";
+  import UnorderedList from "carbon-components-svelte/UnorderedList/UnorderedList.svelte";
 
   export let nested = false;
   export let expressive = false;


### PR DESCRIPTION
Use direct imports for faster individual test runs (Vitest transform/imports). Should not make the full test suite faster.

Also, use `ComponentProps` instead of "re-typing" props in the fixtures.