### PR TITLE
chore(copy-input): add `revealMode` prop

### DIFF
--- a/docs/src/pages/components/CopyInput.svx
+++ b/docs/src/pages/components/CopyInput.svx
@@ -29,9 +29,17 @@ Prefetch on hover with `on:mouseenter:copy-button`.
 
 ## Obscured value
 
-Set `type` to `"password"` to obscure the value. The value is revealed while the input is focused. The copy button still copies the full value while obscured.
+Set `type` to `"password"` to obscure the value. By default the value stays obscured; the copy button still copies the full value.
 
 <CopyInput labelText="API token" type="password" value="sk-1234567890abcdef" />
+
+Set `revealMode` to opt into revealing the value on interaction. Use `"focus"` to reveal while the input is focused.
+
+<CopyInput labelText="API token" type="password" revealMode="focus" value="sk-1234567890abcdef" />
+
+Use `"hover-focus"` to reveal while the input is hovered or focused.
+
+<CopyInput labelText="API token" type="password" revealMode="hover-focus" value="sk-1234567890abcdef" />
 
 ## Truncation
 

--- a/src/CopyInput/CopyInput.svelte
+++ b/src/CopyInput/CopyInput.svelte
@@ -15,10 +15,20 @@
 
   /**
    * Set to `"password"` to obscure the value.
-   * The value is revealed while the input is focused.
+   * Use `revealMode` to reveal the value on interaction.
    * @type {"text" | "password"}
    */
   export let type = "text";
+
+  /**
+   * Control when a `type="password"` value is revealed.
+   * Has no effect unless `type` is `"password"`.
+   * - `"focus"`: reveal while the input is focused.
+   * - `"hover-focus"`: reveal while the input is hovered or focused.
+   * When unset, the value stays obscured; the copy button still copies the full value.
+   * @type {"focus" | "hover-focus"}
+   */
+  export let revealMode = undefined;
 
   /**
    * Set to `false` to skip selecting the full value when the input receives focus.
@@ -103,8 +113,14 @@
   const isFluid = !!ctx && ctx.isFluid;
 
   let focused = false;
+  let hovered = false;
 
-  $: revealed = focused;
+  $: revealed =
+    revealMode === "hover-focus"
+      ? focused || hovered
+      : revealMode === "focus"
+        ? focused
+        : false;
   $: inputType = type === "password" && !revealed ? "password" : "text";
   $: helperId = `helper-${id}`;
 
@@ -195,6 +211,8 @@
         on:focus={handleFocus}
         on:blur
         on:blur={handleBlur}
+        on:mouseenter={() => (hovered = true)}
+        on:mouseleave={() => (hovered = false)}
       >
       {#if isFluid}
         <hr class:bx--text-input__divider={true}>

--- a/tests/CopyInput/CopyInput.test.svelte
+++ b/tests/CopyInput/CopyInput.test.svelte
@@ -4,6 +4,7 @@
 
   export let value = "secret-token-123";
   export let type: ComponentProps<CopyInput>["type"] = "text";
+  export let revealMode: ComponentProps<CopyInput>["revealMode"] = undefined;
   export let selectOnFocus: ComponentProps<CopyInput>["selectOnFocus"] =
     undefined;
   export let labelText = "API token";
@@ -15,6 +16,7 @@
 <CopyInput
   {value}
   {type}
+  {revealMode}
   selectOnFocus={selectOnFocus ?? true}
   {labelText}
   {helperText}

--- a/tests/CopyInput/CopyInput.test.ts
+++ b/tests/CopyInput/CopyInput.test.ts
@@ -52,8 +52,18 @@ describe("CopyInput", () => {
     expect(select).not.toHaveBeenCalled();
   });
 
-  it("obscures the value and reveals it on focus", async () => {
+  it("stays obscured on focus when revealMode is unset", async () => {
     render(CopyInput, { props: { type: "password" } });
+
+    const input = screen.getByLabelText("API token") as HTMLInputElement;
+    expect(input).toHaveAttribute("type", "password");
+
+    await fireEvent.focus(input);
+    expect(input).toHaveAttribute("type", "password");
+  });
+
+  it("reveals the value on focus when revealMode is focus", async () => {
+    render(CopyInput, { props: { type: "password", revealMode: "focus" } });
 
     const input = screen.getByLabelText("API token") as HTMLInputElement;
     expect(input).toHaveAttribute("type", "password");
@@ -65,13 +75,44 @@ describe("CopyInput", () => {
     expect(input).toHaveAttribute("type", "password");
   });
 
-  it("does not reveal the obscured value on hover", async () => {
+  it("does not reveal the value on hover when revealMode is focus", async () => {
+    render(CopyInput, { props: { type: "password", revealMode: "focus" } });
+
+    const input = screen.getByLabelText("API token") as HTMLInputElement;
+
+    await fireEvent.mouseEnter(input);
+    expect(input).toHaveAttribute("type", "password");
+  });
+
+  it("reveals the value on hover and focus when revealMode is hover-focus", async () => {
+    render(CopyInput, {
+      props: { type: "password", revealMode: "hover-focus" },
+    });
+
+    const input = screen.getByLabelText("API token") as HTMLInputElement;
+    expect(input).toHaveAttribute("type", "password");
+
+    await fireEvent.mouseEnter(input);
+    expect(input).toHaveAttribute("type", "text");
+
+    await fireEvent.mouseLeave(input);
+    expect(input).toHaveAttribute("type", "password");
+
+    await fireEvent.focus(input);
+    expect(input).toHaveAttribute("type", "text");
+
+    await fireEvent.blur(input);
+    expect(input).toHaveAttribute("type", "password");
+  });
+
+  it("does not reveal the obscured value on hover when revealMode is unset", async () => {
     render(CopyInput, { props: { type: "password" } });
 
     const input = screen.getByLabelText("API token") as HTMLInputElement;
     const fieldWrapper = input.closest(".bx--copy-input__field-wrapper");
     expect(fieldWrapper).toBeInTheDocument();
 
+    await fireEvent.mouseEnter(input);
     await fireEvent.mouseEnter(fieldWrapper as Element);
     expect(input).toHaveAttribute("type", "password");
   });


### PR DESCRIPTION
Not a `feat` since #3218 is not yet released.

The focus-show should not be the default. Add a `revealMode` prop that allows controlling the reveal logic: focus or (hover/focus).