### PR TITLE
ci: bump `dorny/paths-filter` to v4.0.1 for node24

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
           filters: |


### PR DESCRIPTION
Updates the `dorny/paths-filter` pin from v3.0.3 to v4.0.1.

v3.0.3 runs on the deprecated node20 runtime. v4.0.1 runs on node24; the major bump only swaps the runtime, so the `filters` config is unchanged.