### PR TITLE
feat(pagination): add `size` prop

### DIFF
--- a/docs/src/pages/components/DataTable.svx
+++ b/docs/src/pages/components/DataTable.svx
@@ -1163,6 +1163,42 @@ Bind to `pageSize` and `page` props of the pagination component and pass them to
 
 <FileSource src="/framed/DataTable/DataTablePagination" />
 
+## Matching pagination size
+
+Match the `Pagination` `size` to the `DataTable` `size` for consistent heights. Pair a `short` table with a small (`sm`) pagination.
+
+<DataTable size="short" title="Load balancers" description="Your organization's active load balancers."
+  headers="{[
+    { key: "name", value: "Name" },
+    { key: "protocol", value: "Protocol" },
+    { key: "port", value: "Port" },
+    { key: "rule", value: "Rule" }
+  ]}"
+  rows="{[
+    { id: "a", name: "Load Balancer 3", protocol: "HTTP", port: 3000, rule: "Round robin" },
+    { id: "b", name: "Load Balancer 1", protocol: "HTTP", port: 443, rule: "Round robin" },
+    { id: "c", name: "Load Balancer 2", protocol: "HTTP", port: 80, rule: "DNS delegation" },
+  ]}"
+/>
+<Pagination size="sm" totalItems={3} pageSizes={[10, 15, 20]} />
+
+Pair a `tall` table with a large (`lg`) pagination.
+
+<DataTable size="tall" title="Load balancers" description="Your organization's active load balancers."
+  headers="{[
+    { key: "name", value: "Name" },
+    { key: "protocol", value: "Protocol" },
+    { key: "port", value: "Port" },
+    { key: "rule", value: "Rule" }
+  ]}"
+  rows="{[
+    { id: "a", name: "Load Balancer 3", protocol: "HTTP", port: 3000, rule: "Round robin" },
+    { id: "b", name: "Load Balancer 1", protocol: "HTTP", port: 443, rule: "Round robin" },
+    { id: "c", name: "Load Balancer 2", protocol: "HTTP", port: 80, rule: "DNS delegation" },
+  ]}"
+/>
+<Pagination size="lg" totalItems={3} pageSizes={[10, 15, 20]} />
+
 ## Sortable with custom display and sort methods
 
 Use `display` and `sort` functions in header objects to customize cell rendering and sorting.

--- a/docs/src/pages/components/Pagination.svx
+++ b/docs/src/pages/components/Pagination.svx
@@ -58,8 +58,28 @@ Disable the page size selector by setting `pageSizeInputDisabled` to `true`.
 
 <Pagination totalItems={102} pageSizeInputDisabled />
 
+## Small size
+
+Set `size` to `"sm"` for a small pagination.
+
+<Pagination size="sm" totalItems={102} pageSizes={[10, 15, 20]} />
+
+## Large size
+
+Set `size` to `"lg"` for a large pagination.
+
+<Pagination size="lg" totalItems={102} pageSizes={[10, 15, 20]} />
+
 ## Skeleton
 
 Use the pagination skeleton to show a loading state.
 
 <PaginationSkeleton />
+
+## Skeleton sizes
+
+The skeleton accepts the same `size` prop as `Pagination`.
+
+<PaginationSkeleton size="sm" />
+<PaginationSkeleton />
+<PaginationSkeleton size="lg" />

--- a/src/Pagination/Pagination.svelte
+++ b/src/Pagination/Pagination.svelte
@@ -111,6 +111,12 @@
   /** Set an id for the top-level element */
   export let id = `ccs-${Math.random().toString(36)}`;
 
+  /**
+   * Specify the size of the pagination.
+   * @type {"sm" | "md" | "lg"}
+   */
+  export let size = "md";
+
   import { createEventDispatcher } from "svelte";
   import Button from "../Button/Button.svelte";
   import CaretLeft from "../icons/CaretLeft.svelte";
@@ -165,7 +171,13 @@
   $: forwardButtonDisabled = disabled || page === totalPages;
 </script>
 
-<div {id} class:bx--pagination={true} {...$$restProps}>
+<div
+  {id}
+  class:bx--pagination={true}
+  class:bx--pagination--sm={size === "sm"}
+  class:bx--pagination--lg={size === "lg"}
+  {...$$restProps}
+>
   <div class:bx--pagination__left={true}>
     {#if !pageSizeInputDisabled}
       <label

--- a/src/Pagination/PaginationSkeleton.svelte
+++ b/src/Pagination/PaginationSkeleton.svelte
@@ -1,4 +1,10 @@
 <script>
+  /**
+   * Specify the size of the pagination.
+   * @type {"sm" | "md" | "lg"}
+   */
+  export let size = "md";
+
   import SkeletonText from "../SkeletonText/SkeletonText.svelte";
 </script>
 
@@ -6,6 +12,8 @@
 <!-- svelte-ignore a11y-no-static-element-interactions -->
 <div
   class:bx--pagination={true}
+  class:bx--pagination--sm={size === "sm"}
+  class:bx--pagination--lg={size === "lg"}
   class:bx--skeleton={true}
   {...$$restProps}
   on:click

--- a/tests/Pagination/Pagination.test.svelte
+++ b/tests/Pagination/Pagination.test.svelte
@@ -21,6 +21,7 @@
   export let itemRangeText: ComponentProps<Pagination>["itemRangeText"] =
     undefined;
   export let id: ComponentProps<Pagination>["id"] = undefined;
+  export let size: ComponentProps<Pagination>["size"] = undefined;
   export let customClass = "";
 </script>
 
@@ -42,6 +43,7 @@
   {pageRangeText}
   {itemRangeText}
   {id}
+  {size}
   class={customClass}
   on:change={(e) => {
     console.log("change", e.detail);

--- a/tests/Pagination/Pagination.test.ts
+++ b/tests/Pagination/Pagination.test.ts
@@ -337,6 +337,35 @@ describe("Pagination", () => {
     expect(pagination).toHaveClass("custom-pagination");
   });
 
+  describe("size", () => {
+    function getRoot() {
+      const nextButton = screen.getByRole("button", { name: "Next page" });
+      const pagination = nextButton.closest(".bx--pagination");
+      assert(pagination);
+      return pagination;
+    }
+
+    it("does not apply a size modifier class by default (md)", () => {
+      render(Pagination);
+
+      const pagination = getRoot();
+      expect(pagination).not.toHaveClass("bx--pagination--sm");
+      expect(pagination).not.toHaveClass("bx--pagination--lg");
+    });
+
+    it("applies the small size modifier class", () => {
+      render(Pagination, { props: { size: "sm" } });
+
+      expect(getRoot()).toHaveClass("bx--pagination--sm");
+    });
+
+    it("applies the large size modifier class", () => {
+      render(Pagination, { props: { size: "lg" } });
+
+      expect(getRoot()).toHaveClass("bx--pagination--lg");
+    });
+  });
+
   describe("dynamicPageSizes", () => {
     it("should show all page sizes when dynamicPageSizes is false (default)", () => {
       render(Pagination, {

--- a/tests/Pagination/PaginationSkeleton.test.ts
+++ b/tests/Pagination/PaginationSkeleton.test.ts
@@ -1,0 +1,30 @@
+import { render } from "@testing-library/svelte";
+import PaginationSkeleton from "carbon-components-svelte/Pagination/PaginationSkeleton.svelte";
+
+describe("PaginationSkeleton", () => {
+  function getRoot(container: HTMLElement) {
+    const pagination = container.querySelector(".bx--pagination");
+    assert(pagination);
+    return pagination;
+  }
+
+  it("does not apply a size modifier class by default (md)", () => {
+    const { container } = render(PaginationSkeleton);
+
+    const pagination = getRoot(container);
+    expect(pagination).not.toHaveClass("bx--pagination--sm");
+    expect(pagination).not.toHaveClass("bx--pagination--lg");
+  });
+
+  it("applies the small size modifier class", () => {
+    const { container } = render(PaginationSkeleton, { props: { size: "sm" } });
+
+    expect(getRoot(container)).toHaveClass("bx--pagination--sm");
+  });
+
+  it("applies the large size modifier class", () => {
+    const { container } = render(PaginationSkeleton, { props: { size: "lg" } });
+
+    expect(getRoot(container)).toHaveClass("bx--pagination--lg");
+  });
+});


### PR DESCRIPTION
It turns out that after all these years, `Pagination` has always supported various sizes, but it just wasn't exposed to the consumer.

This adds a `size` prop.

---

<img width="890" height="351" alt="Screenshot 2026-06-09 at 7 19 04 AM" src="https://github.com/user-attachments/assets/5741dccf-a898-483b-b0dc-64fca7c25461" />
