### PR TITLE
feat(combo-box,dropdown): pass `selected` and `highlighted` to default slot

### DIFF
--- a/docs/src/pages/components/ComboBox.svx
+++ b/docs/src/pages/components/ComboBox.svx
@@ -22,7 +22,7 @@ items={[
 
 ## Custom slot
 
-Override the default slot to customize how each item displays. Access the item and index through the `let:` directive.
+Override the default slot to customize how each item displays. Use `let:item`, `let:index`, `let:selected`, and `let:highlighted` to style highlighted and selected rows.
 
 <FileSource src="/framed/ComboBox/ComboBoxSlot" />
 

--- a/docs/src/pages/components/Dropdown.svx
+++ b/docs/src/pages/components/Dropdown.svx
@@ -49,8 +49,7 @@ Use the `labelChildren` slot to provide custom label content instead of using th
 
 ## Custom slot
 
-Override the default slot to customize the display of each item. Access the item and
-index through the `let:` directive.
+Override the default slot to customize the display of each item. Use `let:item`, `let:index`, `let:selected`, and `let:highlighted` to style highlighted and selected rows.
 
 <FileSource src="/framed/Dropdown/DropdownSlot" />
 

--- a/docs/src/pages/framed/ComboBox/ComboBoxSlot.svelte
+++ b/docs/src/pages/framed/ComboBox/ComboBoxSlot.svelte
@@ -12,11 +12,16 @@
   ]}
   let:item
   let:index
+  let:selected
+  let:highlighted
 >
   <div>
     <strong>{item.text}</strong>
   </div>
-  <div>id: {item.id} - index:{index}</div>
+  <div>
+    id: {item.id} - index: {index} - selected: {selected} - highlighted:
+    {highlighted}
+  </div>
 </ComboBox>
 
 <style>

--- a/docs/src/pages/framed/Dropdown/DropdownSlot.svelte
+++ b/docs/src/pages/framed/Dropdown/DropdownSlot.svelte
@@ -12,11 +12,16 @@
   ]}
   let:item
   let:index
+  let:selected
+  let:highlighted
 >
   <div>
     <strong>{item.text}</strong>
   </div>
-  <div>id: {item.id} - index:{index}</div>
+  <div>
+    id: {item.id} - index: {index} - selected: {selected} - highlighted:
+    {highlighted}
+  </div>
 </Dropdown>
 
 <style>

--- a/src/ComboBox/ComboBox.svelte
+++ b/src/ComboBox/ComboBox.svelte
@@ -13,7 +13,7 @@
    * @property {Item["id"]} selectedId
    * @property {Item} selectedItem
    * @event {KeyboardEvent | MouseEvent} clear
-   * @slot {{ item: Item; index: number }}
+   * @slot {{ item: Item; index: number; selected: boolean; highlighted: boolean; }}
    */
 
   /**
@@ -725,7 +725,14 @@
                     highlightedIndex = actualIndex;
                   }}
                 >
-                  <slot {item} index={actualIndex}> {itemToString(item)} </slot>
+                  <slot
+                    {item}
+                    index={actualIndex}
+                    selected={selectedId === item.id}
+                    highlighted={highlightedIndex === actualIndex}
+                  >
+                    {itemToString(item)}
+                  </slot>
                   {#if selectedItem && selectedItem.id === item.id}
                     <Checkmark class="bx--list-box__menu-item__selected-icon" />
                   {/if}
@@ -758,7 +765,14 @@
                 highlightedIndex = index;
               }}
             >
-              <slot {item} {index}> {itemToString(item)} </slot>
+              <slot
+                {item}
+                {index}
+                selected={selectedId === item.id}
+                highlighted={highlightedIndex === index}
+              >
+                {itemToString(item)}
+              </slot>
               {#if selectedItem && selectedItem.id === item.id}
                 <Checkmark class="bx--list-box__menu-item__selected-icon" />
               {/if}

--- a/src/Dropdown/Dropdown.svelte
+++ b/src/Dropdown/Dropdown.svelte
@@ -12,7 +12,7 @@
    * @type {object}
    * @property {Item["id"]} selectedId
    * @property {Item} selectedItem
-   * @slot {{ item: Item; index: number; }}
+   * @slot {{ item: Item; index: number; selected: boolean; highlighted: boolean; }}
    */
 
   /**
@@ -572,7 +572,14 @@
                     highlightedIndex = actualIndex;
                   }}
                 >
-                  <slot {item} index={actualIndex}> {itemToString(item)} </slot>
+                  <slot
+                    {item}
+                    index={actualIndex}
+                    selected={selectedId === item.id}
+                    highlighted={highlightedIndex === actualIndex}
+                  >
+                    {itemToString(item)}
+                  </slot>
                   {#if selectedId === item.id}
                     <Checkmark class="bx--list-box__menu-item__selected-icon" />
                   {/if}
@@ -602,7 +609,14 @@
                 highlightedIndex = index;
               }}
             >
-              <slot {item} {index}> {itemToString(item)} </slot>
+              <slot
+                {item}
+                {index}
+                selected={selectedId === item.id}
+                highlighted={highlightedIndex === index}
+              >
+                {itemToString(item)}
+              </slot>
               {#if selectedId === item.id}
                 <Checkmark class="bx--list-box__menu-item__selected-icon" />
               {/if}

--- a/tests/ComboBox/ComboBox.test.ts
+++ b/tests/ComboBox/ComboBox.test.ts
@@ -11,6 +11,7 @@ import ComboBoxCustom from "./ComboBoxCustom.test.svelte";
 import ComboBoxDuplicateIds from "./ComboBoxDuplicateIds.test.svelte";
 import ComboBoxGenerics from "./ComboBoxGenerics.test.svelte";
 import ComboBoxInModal from "./ComboBoxInModal.test.svelte";
+import ComboBoxItemSlot from "./ComboBoxItemSlot.test.svelte";
 
 describe("ComboBox", () => {
   const getInput = () => {
@@ -1519,6 +1520,23 @@ describe("ComboBox", () => {
 
     const customLabel = screen.getByText("Custom label content");
     expect(customLabel).toBeInTheDocument();
+  });
+
+  it("should pass selected and highlighted to the default slot", async () => {
+    render(ComboBoxItemSlot, { props: { selectedId: "1" } });
+
+    await user.click(getInput());
+
+    const customItems = screen.getAllByTestId("custom-item");
+
+    // selectedId "1" is the second item, not index 1.
+    expect(customItems[0]).toHaveAttribute("data-selected", "false");
+    expect(customItems[1]).toHaveAttribute("data-selected", "true");
+    expect(customItems[2]).toHaveAttribute("data-selected", "false");
+
+    await user.hover(customItems[2]);
+    expect(customItems[2]).toHaveAttribute("data-highlighted", "true");
+    expect(customItems[0]).toHaveAttribute("data-highlighted", "false");
   });
 
   describe("virtualization", () => {

--- a/tests/ComboBox/ComboBoxItemSlot.test.svelte
+++ b/tests/ComboBox/ComboBoxItemSlot.test.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+  import ComboBox from "carbon-components-svelte/ComboBox/ComboBox.svelte";
+  import type { ComponentProps } from "svelte";
+
+  export let items: ComponentProps<ComboBox>["items"] = [
+    { id: "0", text: "Option 1" },
+    { id: "1", text: "Option 2" },
+    { id: "2", text: "Option 3" },
+  ];
+  export let selectedId: ComponentProps<ComboBox>["selectedId"] = undefined;
+</script>
+
+<ComboBox
+  {items}
+  {selectedId}
+  labelText="Custom slot combobox"
+  let:item
+  let:index
+  let:selected
+  let:highlighted
+>
+  <span
+    data-testid="custom-item"
+    data-selected={selected}
+    data-highlighted={highlighted}
+  >
+    Item {index + 1}: {item.text}
+  </span>
+</ComboBox>

--- a/tests/Dropdown/Dropdown.test.ts
+++ b/tests/Dropdown/Dropdown.test.ts
@@ -361,6 +361,23 @@ describe("Dropdown", () => {
     expect(customItems[2]).toHaveTextContent("Item 3: Option 3");
   });
 
+  it("should pass selected and highlighted to the default slot", async () => {
+    render(DropdownSlot, { props: { selectedId: "1" } });
+
+    await user.click(screen.getByLabelText("Custom slot dropdown"));
+
+    const customItems = screen.getAllByTestId("custom-item");
+
+    // selectedId "1" is the second item, not index 1.
+    expect(customItems[0]).toHaveAttribute("data-selected", "false");
+    expect(customItems[1]).toHaveAttribute("data-selected", "true");
+    expect(customItems[2]).toHaveAttribute("data-selected", "false");
+
+    await user.hover(customItems[2]);
+    expect(customItems[2]).toHaveAttribute("data-highlighted", "true");
+    expect(customItems[0]).toHaveAttribute("data-highlighted", "false");
+  });
+
   it("supports custom label slot", () => {
     render(DropdownLabelChildren);
 

--- a/tests/Dropdown/DropdownSlot.test.svelte
+++ b/tests/Dropdown/DropdownSlot.test.svelte
@@ -18,6 +18,14 @@
   labelText="Custom slot dropdown"
   let:item
   let:index
+  let:selected
+  let:highlighted
 >
-  <span data-testid="custom-item"> Item {index + 1}: {item.text} </span>
+  <span
+    data-testid="custom-item"
+    data-selected={selected}
+    data-highlighted={highlighted}
+  >
+    Item {index + 1}: {item.text}
+  </span>
 </Dropdown>


### PR DESCRIPTION
Pass derived `selected` and `highlighted` states to the default slot, to allow consumers to conditionally render logic, markup, styles.