### PR TITLE
chore(biome): restrict barrel imports in tests

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -73,9 +73,6 @@
               "svelte": {
                 "importNames": ["onDestroy"],
                 "message": "Use the return function from onMount instead of onDestroy."
-              },
-              "vitest": {
-                "message": "Vitest functions are automatically imported."
               }
             }
           }
@@ -184,6 +181,28 @@
         "rules": {
           "correctness": {
             "noUnusedVariables": "off"
+          }
+        }
+      }
+    },
+    {
+      "includes": ["tests/**", "!tests/package-exports.test-d.ts"],
+      "linter": {
+        "rules": {
+          "style": {
+            "noRestrictedImports": {
+              "level": "error",
+              "options": {
+                "paths": {
+                  "carbon-components-svelte": {
+                    "message": "Avoid the barrel import in tests; import directly (e.g. \"carbon-components-svelte/Button/Button.svelte\") to keep Vitest transforms fast."
+                  },
+                  "vitest": {
+                    "message": "Vitest functions are automatically imported."
+                  }
+                }
+              }
+            }
           }
         }
       }

--- a/tests/CodeSnippet/CodeSnippet.test.ts
+++ b/tests/CodeSnippet/CodeSnippet.test.ts
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/svelte";
-import { CodeSnippet } from "carbon-components-svelte";
+import CodeSnippet from "carbon-components-svelte/CodeSnippet/CodeSnippet.svelte";
 import { user } from "../utils/user";
 import CodeSnippetAsync from "./CodeSnippetAsync.test.svelte";
 import CodeSnippetAsyncDoubleClick from "./CodeSnippetAsyncDoubleClick.test.svelte";

--- a/tests/CodeSnippet/CodeSnippetExpandedByDefault.svelte
+++ b/tests/CodeSnippet/CodeSnippetExpandedByDefault.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { CodeSnippet } from "carbon-components-svelte";
+  import CodeSnippet from "carbon-components-svelte/CodeSnippet/CodeSnippet.svelte";
 </script>
 
 <CodeSnippet

--- a/tests/CopyInput/CopyInput.test.svelte
+++ b/tests/CopyInput/CopyInput.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { CopyInput } from "carbon-components-svelte";
+  import CopyInput from "carbon-components-svelte/CopyInput/CopyInput.svelte";
   import type { ComponentProps } from "svelte";
 
   export let value = "secret-token-123";

--- a/tests/CopyInput/CopyInputAsync.test.svelte
+++ b/tests/CopyInput/CopyInputAsync.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { CopyInput } from "carbon-components-svelte";
+  import CopyInput from "carbon-components-svelte/CopyInput/CopyInput.svelte";
 
   export let copy: (text: string) => void | Promise<void> = async () => {};
   export let onCopy = () => {};

--- a/tests/CopyInput/CopyInputAsyncDoubleClick.test.svelte
+++ b/tests/CopyInput/CopyInputAsyncDoubleClick.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { CopyInput } from "carbon-components-svelte";
+  import CopyInput from "carbon-components-svelte/CopyInput/CopyInput.svelte";
 
   export let copy: (text: string) => void | Promise<void>;
 

--- a/tests/CopyInput/CopyInputMouseEnter.test.svelte
+++ b/tests/CopyInput/CopyInputMouseEnter.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { CopyInput } from "carbon-components-svelte";
+  import CopyInput from "carbon-components-svelte/CopyInput/CopyInput.svelte";
 
   export let onMouseEnterCopyButton = (_event: MouseEvent) => {};
 </script>

--- a/tests/OverflowMenu/OverflowMenuItem.icons.test.svelte
+++ b/tests/OverflowMenu/OverflowMenuItem.icons.test.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { OverflowMenu, OverflowMenuItem } from "carbon-components-svelte";
+  import OverflowMenu from "carbon-components-svelte/OverflowMenu/OverflowMenu.svelte";
+  import OverflowMenuItem from "carbon-components-svelte/OverflowMenu/OverflowMenuItem.svelte";
   import Edit from "carbon-icons-svelte/lib/Edit.svelte";
   import Launch from "carbon-icons-svelte/lib/Launch.svelte";
 </script>

--- a/tests/ProgressIndicator/ProgressIndicatorSkeleton.test.ts
+++ b/tests/ProgressIndicator/ProgressIndicatorSkeleton.test.ts
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/svelte";
-import { ProgressIndicatorSkeleton } from "carbon-components-svelte";
+import ProgressIndicatorSkeleton from "carbon-components-svelte/ProgressIndicator/ProgressIndicatorSkeleton.svelte";
 
 describe("ProgressIndicatorSkeleton", () => {
   it("applies space-equal class when spaceEqually is true", () => {

--- a/tests/Theme/ThemeSelectExported.svelte
+++ b/tests/Theme/ThemeSelectExported.svelte
@@ -8,7 +8,7 @@
 </script>
 
 <script lang="ts">
-  import { Theme } from "carbon-components-svelte";
+  import Theme from "carbon-components-svelte/Theme/Theme.svelte";
 </script>
 
 <Theme

--- a/tests/TooltipIcon/TooltipIcon.test.ts
+++ b/tests/TooltipIcon/TooltipIcon.test.ts
@@ -1,5 +1,4 @@
 import { fireEvent, render, screen } from "@testing-library/svelte";
-import type { TooltipIcon as TooltipIconSource } from "carbon-components-svelte";
 import type TooltipIconComponent from "carbon-components-svelte/TooltipIcon/TooltipIcon.svelte";
 import type { ComponentProps } from "svelte";
 import { user } from "../utils/user";
@@ -9,7 +8,7 @@ import TooltipIconMultiple from "./TooltipIconMultiple.test.svelte";
 import TooltipIconPortal from "./TooltipIconPortal.test.svelte";
 import TooltipIconReactive from "./TooltipIconReactive.test.svelte";
 
-type Props = ComponentProps<TooltipIconSource>;
+type Props = ComponentProps<TooltipIconComponent>;
 
 describe("TooltipIcon", () => {
   let consoleLog: Console["log"];

--- a/tests/TreeView/filterTreeNodes.test.ts
+++ b/tests/TreeView/filterTreeNodes.test.ts
@@ -2,7 +2,7 @@ import {
   filterTreeById,
   filterTreeByText,
   filterTreeNodes,
-} from "carbon-components-svelte";
+} from "carbon-components-svelte/utils/filterTreeNodes";
 
 describe("filterTreeNodes", () => {
   const sampleTree = [

--- a/tests/TreeView/toHierarchy.test.ts
+++ b/tests/TreeView/toHierarchy.test.ts
@@ -1,4 +1,4 @@
-import { toHierarchy } from "carbon-components-svelte";
+import { toHierarchy } from "carbon-components-svelte/utils/toHierarchy";
 
 describe("toHierarchy", () => {
   test("should create a flat hierarchy when no items have parents", () => {


### PR DESCRIPTION
Enforce this as a rule. Use direct imports to make Vitest transforms fast.