### PR TITLE
feat(search-skeleton): add `hideLabel` prop

### DIFF
--- a/docs/src/pages/components/Search.svx
+++ b/docs/src/pages/components/Search.svx
@@ -1,6 +1,6 @@
 <script>
   import Query from "carbon-icons-svelte/lib/Query.svelte";
-  import { Search } from "carbon-components-svelte";
+  import { Search, SearchSkeleton } from "carbon-components-svelte";
 </script>
 
 Search provides a flexible search input with support for expandable variants, different sizes, and custom icons. It includes built-in functionality for clearing input and handling keyboard events.
@@ -94,3 +94,9 @@ Display a loading state for the small search variant.
 Display a loading state for the extra-small search variant.
 
 <Search size="xs" skeleton />
+
+## Skeleton without label
+
+Show a loading state without a label by setting `hideLabel` to `true`.
+
+<SearchSkeleton hideLabel />

--- a/src/Search/SearchSkeleton.svelte
+++ b/src/Search/SearchSkeleton.svelte
@@ -4,6 +4,9 @@
    * @type {"xs" | "sm" | "lg" | "xl"}
    */
   export let size = "xl";
+
+  /** Set to `true` to hide the label text */
+  export let hideLabel = false;
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
@@ -20,6 +23,8 @@
   on:mouseenter
   on:mouseleave
 >
-  <span class:bx--label={true}></span>
+  {#if !hideLabel}
+    <span class:bx--label={true}></span>
+  {/if}
   <div class:bx--search-input={true}></div>
 </div>

--- a/tests/Search/Search.test.ts
+++ b/tests/Search/Search.test.ts
@@ -97,7 +97,7 @@ describe("Search", () => {
     render(SearchSkeleton);
 
     const skeletons = document.querySelectorAll(".bx--skeleton");
-    expect(skeletons).toHaveLength(3);
+    expect(skeletons).toHaveLength(4);
 
     // Default (xl) skeleton
     expect(skeletons[0]).toHaveClass("bx--search--xl");
@@ -107,6 +107,10 @@ describe("Search", () => {
 
     // Small (sm) skeleton
     expect(skeletons[2]).toHaveClass("bx--search--sm");
+
+    // Skeleton with hidden label has no label element
+    const hideLabelSkeleton = screen.getByTestId("skeleton-hide-label");
+    expect(hideLabelSkeleton.querySelector(".bx--label")).toBeNull();
   });
 
   it("supports custom label slot", () => {

--- a/tests/Search/SearchSkeleton.test.svelte
+++ b/tests/Search/SearchSkeleton.test.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import Search from "carbon-components-svelte/Search/Search.svelte";
+  import SearchSkeleton from "carbon-components-svelte/Search/SearchSkeleton.svelte";
 </script>
 
 <Search skeleton labelText="Default skeleton" />
@@ -7,3 +8,5 @@
 <Search size="lg" skeleton labelText="Large skeleton" />
 
 <Search size="sm" skeleton labelText="Small skeleton" />
+
+<SearchSkeleton hideLabel data-testid="skeleton-hide-label" />


### PR DESCRIPTION
Add ability to hide the label for the skeleton state, so it matches the height.