### PR TITLE
feat(multi-select,tabs,header-search): pass more state to default slots

### DIFF
--- a/docs/src/pages/components/MultiSelect.svx
+++ b/docs/src/pages/components/MultiSelect.svx
@@ -32,7 +32,7 @@ Format the display text of items using the `itemToString` prop. This example app
 
 ## Custom slot
 
-Override the default slot to customize item rendering. This example shows how to access and use the item and index values.
+Override the default slot to customize item rendering. Use `let:item`, `let:index`, `let:selected`, and `let:highlighted` to access each item's data and its derived selected and highlighted state.
 
 <FileSource src="/framed/MultiSelect/MultiSelectSlot" />
 

--- a/docs/src/pages/components/Tabs.svx
+++ b/docs/src/pages/components/Tabs.svx
@@ -219,6 +219,27 @@ Use the `secondaryChildren` slot to customize the secondary label with custom ma
   </svelte:fragment>
 </Tabs>
 
+## Custom label slot
+
+Override the default slot to customize the tab label. Use `let:selected` to render custom content based on whether the tab is selected.
+
+<Tabs>
+  <Tab label="Tab label 1" let:selected>
+    Tab label 1 {#if selected}(selected){/if}
+  </Tab>
+  <Tab label="Tab label 2" let:selected>
+    Tab label 2 {#if selected}(selected){/if}
+  </Tab>
+  <Tab label="Tab label 3" let:selected>
+    Tab label 3 {#if selected}(selected){/if}
+  </Tab>
+  <svelte:fragment slot="content">
+    <TabContent>Content 1</TabContent>
+    <TabContent>Content 2</TabContent>
+    <TabContent>Content 3</TabContent>
+  </svelte:fragment>
+</Tabs>
+
 ## Container type with icons and secondary label
 
 Container type tabs can use both `icon` and `secondaryLabel` for a primary label, icon, and optional secondary line (for example, counts or status).

--- a/docs/src/pages/components/UIShell.svx
+++ b/docs/src/pages/components/UIShell.svx
@@ -82,6 +82,12 @@ Add a global search component to the header.
 
 <FileSource src="/framed/UIShell/HeaderSearch" />
 
+## Header with custom search results
+
+Override the default slot to customize how each result displays. Use `let:result`, `let:index`, and `let:selected` to style the highlighted result.
+
+<FileSource src="/framed/UIShell/HeaderSearchSlot" />
+
 ## Header with utilities
 
 Include utility components in the header using header utilities.

--- a/docs/src/pages/framed/MultiSelect/MultiSelectSlot.svelte
+++ b/docs/src/pages/framed/MultiSelect/MultiSelectSlot.svelte
@@ -12,11 +12,16 @@
   ]}
   let:item
   let:index
+  let:selected
+  let:highlighted
 >
   <div>
     <strong>{item.text}</strong>
   </div>
-  <div>id: {item.id} - index:{index}</div>
+  <div>
+    id: {item.id} - index: {index} - selected: {selected} - highlighted:
+    {highlighted}
+  </div>
 </MultiSelect>
 
 <style>

--- a/docs/src/pages/framed/UIShell/HeaderSearchSlot.svelte
+++ b/docs/src/pages/framed/UIShell/HeaderSearchSlot.svelte
@@ -1,0 +1,67 @@
+<script>
+  import {
+    Content,
+    Header,
+    HeaderSearch,
+    HeaderUtilities,
+    SkipToContent,
+  } from "carbon-components-svelte";
+
+  const data = [
+    {
+      id: "kubernetes-service",
+      href: "/",
+      text: "Kubernetes Service",
+      description: "Deploy secure, highly available apps.",
+    },
+    {
+      id: "red-hat-openshift",
+      href: "/",
+      text: "Red Hat OpenShift on IBM Cloud",
+      description: "Deploy and secure enterprise workloads.",
+    },
+    {
+      id: "container-registry",
+      href: "/",
+      text: "Container Registry",
+      description: "Securely store container images.",
+    },
+  ];
+
+  let active = false;
+  let value = "";
+  let selectedResultIndex = 0;
+
+  $: lowerCaseValue = value.toLowerCase();
+  $: results =
+    value.length > 0
+      ? data.filter((item) => item.text.toLowerCase().includes(lowerCaseValue))
+      : [];
+</script>
+
+<Header companyName="IBM" platformName="Carbon Svelte">
+  <svelte:fragment slot="skipToContent"> <SkipToContent /> </svelte:fragment>
+  <HeaderUtilities>
+    <HeaderSearch
+      bind:active
+      bind:value
+      bind:selectedResultIndex
+      placeholder="Search services"
+      {results}
+      let:result
+      let:selected
+    >
+      <div>
+        <strong>{result.text}</strong>
+        {#if selected}
+          <span>&nbsp;(selected)</span>
+        {/if}
+      </div>
+      <div>{result.description}</div>
+    </HeaderSearch>
+  </HeaderUtilities>
+</Header>
+
+<Content>
+  <p>Activate the search bar and type "service" to see custom results.</p>
+</Content>

--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -17,7 +17,7 @@
    * @property {Item[]} unselected
    * @event {null} clear
    * @event {FocusEvent | CustomEvent<FocusEvent>} blur
-   * @slot {{ item: Item; index: number }}
+   * @slot {{ item: Item; index: number; selected: boolean; highlighted: boolean; }}
    */
 
   /**
@@ -911,7 +911,13 @@
                       : false}
                     disabled={item.disabled}
                   >
-                    <slot slot="labelChildren" {item} index={actualIndex}>
+                    <slot
+                      slot="labelChildren"
+                      {item}
+                      index={actualIndex}
+                      selected={item.isSelectAll ? allSelected : item.checked}
+                      highlighted={highlightedIndex === actualIndex}
+                    >
                       {itemToString(item)}
                     </slot>
                   </Checkbox>
@@ -966,7 +972,13 @@
                   : false}
                 disabled={item.disabled}
               >
-                <slot slot="labelChildren" {item} {index}>
+                <slot
+                  slot="labelChildren"
+                  {item}
+                  {index}
+                  selected={item.isSelectAll ? allSelected : item.checked}
+                  highlighted={highlightedIndex === index}
+                >
                   {itemToString(item)}
                 </slot>
               </Checkbox>

--- a/src/Tabs/Tab.svelte
+++ b/src/Tabs/Tab.svelte
@@ -4,6 +4,10 @@
    */
 
   /**
+   * @slot {{ selected: boolean; }}
+   */
+
+  /**
    * Specify the tab label.
    * Alternatively, use the default slot.
    * @example
@@ -115,7 +119,7 @@
     {#if $hasSecondaryLabel}
       <div class:bx--tabs__nav-item-label-wrapper={true}>
         <span class:bx--tabs__nav-item-label={true}>
-          <slot>{label}</slot>
+          <slot {selected}>{label}</slot>
         </span>
         {#if icon}
           <div class:bx--tabs__nav-item--icon={true}>
@@ -137,7 +141,9 @@
         ></div>
       {/if}
     {:else}
-      <span class:bx--tabs__nav-item-label={true}> <slot>{label}</slot> </span>
+      <span class:bx--tabs__nav-item-label={true}>
+        <slot {selected}>{label}</slot>
+      </span>
       {#if icon}
         <div class:bx--tabs__nav-item--icon={true}>
           <svelte:component this={icon} />

--- a/src/UIShell/HeaderSearch.svelte
+++ b/src/UIShell/HeaderSearch.svelte
@@ -17,7 +17,7 @@
    * @property {string} value
    * @property {number} selectedResultIndex
    * @property {Result} selectedResult
-   * @slot {{ result: Result; index: number }}
+   * @slot {{ result: Result; index: number; selected: boolean; }}
    */
 
   /**
@@ -222,7 +222,7 @@
               selectResult();
             }}
           >
-            <slot {result} {index}>
+            <slot {result} {index} selected={selectedResultIndex === index}>
               {result.text}
               {#if result.description}
                 <span class:bx--header-search-menu-description={true}

--- a/tests/MultiSelect/MultiSelect.test.ts
+++ b/tests/MultiSelect/MultiSelect.test.ts
@@ -10,6 +10,7 @@ import MultiSelectBindValue from "./MultiSelectBindValue.test.svelte";
 import MultiSelectDuplicateIds from "./MultiSelectDuplicateIds.test.svelte";
 import MultiSelectGenerics from "./MultiSelectGenerics.test.svelte";
 import MultiSelectInModal from "./MultiSelectInModal.test.svelte";
+import MultiSelectItemSlot from "./MultiSelectItemSlot.test.svelte";
 import MultiSelectItemToStringId from "./MultiSelectItemToStringId.test.svelte";
 import MultiSelectSlot from "./MultiSelectSlot.test.svelte";
 
@@ -63,6 +64,29 @@ describe("MultiSelect", () => {
     expect(screen.getByText("1 Email 0")).toBeInTheDocument();
     expect(screen.getByText("2 Fax 1")).toBeInTheDocument();
     expect(screen.getByText("0 Slack 2")).toBeInTheDocument();
+  });
+
+  it("should pass selected and highlighted to the default slot", async () => {
+    render(MultiSelectItemSlot, { props: { selectedIds: ["1"] } });
+
+    await openMenu();
+
+    const customItems = screen.getAllByTestId("custom-item");
+    const byText = (text: string) => {
+      const el = customItems.find((item) => item.textContent?.includes(text));
+      if (!el) throw new Error(`No custom item matching "${text}"`);
+      return el;
+    };
+
+    // selectedIds ["1"] is "Option 2". Items may be sorted selected-to-top,
+    // so assert by content rather than position.
+    expect(byText("Option 2")).toHaveAttribute("data-selected", "true");
+    expect(byText("Option 1")).toHaveAttribute("data-selected", "false");
+    expect(byText("Option 3")).toHaveAttribute("data-selected", "false");
+
+    await user.hover(byText("Option 3"));
+    expect(byText("Option 3")).toHaveAttribute("data-highlighted", "true");
+    expect(byText("Option 1")).toHaveAttribute("data-highlighted", "false");
   });
 
   // Regression: ?? for itemToString so item.text "" is used (not id)

--- a/tests/MultiSelect/MultiSelectItemSlot.test.svelte
+++ b/tests/MultiSelect/MultiSelectItemSlot.test.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+  import MultiSelect from "carbon-components-svelte/MultiSelect/MultiSelect.svelte";
+  import type { ComponentProps } from "svelte";
+
+  export let items: ComponentProps<MultiSelect>["items"] = [
+    { id: "0", text: "Option 1" },
+    { id: "1", text: "Option 2" },
+    { id: "2", text: "Option 3" },
+  ];
+  export let selectedIds: ComponentProps<MultiSelect>["selectedIds"] = [];
+</script>
+
+<MultiSelect
+  {items}
+  {selectedIds}
+  labelText="Custom slot multiselect"
+  label="Select items"
+  let:item
+  let:index
+  let:selected
+  let:highlighted
+>
+  <span
+    data-testid="custom-item"
+    data-selected={selected}
+    data-highlighted={highlighted}
+  >
+    Item {index + 1}: {item.text}
+  </span>
+</MultiSelect>

--- a/tests/Tabs/TabSlot.test.svelte
+++ b/tests/Tabs/TabSlot.test.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+  import Tab from "carbon-components-svelte/Tabs/Tab.svelte";
+  import TabContent from "carbon-components-svelte/Tabs/TabContent.svelte";
+  import Tabs from "carbon-components-svelte/Tabs/Tabs.svelte";
+  import type { ComponentProps } from "svelte";
+
+  export let selected: ComponentProps<Tabs>["selected"] = 0;
+</script>
+
+<Tabs {selected}>
+  <Tab label="Tab 1" let:selected>
+    <span data-testid="tab-0" data-selected={selected}>Tab 1</span>
+  </Tab>
+  <Tab label="Tab 2" let:selected>
+    <span data-testid="tab-1" data-selected={selected}>Tab 2</span>
+  </Tab>
+  <Tab label="Tab 3" let:selected>
+    <span data-testid="tab-2" data-selected={selected}>Tab 3</span>
+  </Tab>
+  <svelte:fragment slot="content">
+    <TabContent>Content 1</TabContent>
+    <TabContent>Content 2</TabContent>
+    <TabContent>Content 3</TabContent>
+  </svelte:fragment>
+</Tabs>

--- a/tests/Tabs/Tabs.test.ts
+++ b/tests/Tabs/Tabs.test.ts
@@ -9,6 +9,7 @@ import TabIcon from "./TabIcon.test.svelte";
 import TabIconContainer from "./TabIconContainer.test.svelte";
 import TabIconSecondaryLabel from "./TabIconSecondaryLabel.test.svelte";
 import TabSecondaryLabel from "./TabSecondaryLabel.test.svelte";
+import TabSlot from "./TabSlot.test.svelte";
 import Tabs from "./Tabs.test.svelte";
 import TabsAllDisabled from "./TabsAllDisabled.test.svelte";
 import TabsDynamic from "./TabsDynamic.test.svelte";
@@ -37,6 +38,30 @@ describe("Tabs", () => {
 
     const tabsContainer = screen.getByRole("navigation");
     expect(tabsContainer).not.toHaveClass("bx--tabs--full-width");
+  });
+
+  it("should pass selected to the Tab default slot", async () => {
+    render(TabSlot);
+
+    expect(screen.getByTestId("tab-0")).toHaveAttribute(
+      "data-selected",
+      "true",
+    );
+    expect(screen.getByTestId("tab-1")).toHaveAttribute(
+      "data-selected",
+      "false",
+    );
+
+    await user.click(screen.getByRole("tab", { name: "Tab 2" }));
+
+    expect(screen.getByTestId("tab-0")).toHaveAttribute(
+      "data-selected",
+      "false",
+    );
+    expect(screen.getByTestId("tab-1")).toHaveAttribute(
+      "data-selected",
+      "true",
+    );
   });
 
   it("should select initial tab based on selected prop", () => {

--- a/tests/UIShell/HeaderSearch.test.svelte
+++ b/tests/UIShell/HeaderSearch.test.svelte
@@ -45,8 +45,9 @@
   on:select={handleSelect}
   let:result
   let:index
+  let:selected
 >
-  <div data-testid="result-{index}">{result.text}</div>
+  <div data-testid="result-{index}" data-selected={selected}>{result.text}</div>
 </HeaderSearch>
 
 <div data-testid="active-event">{activeEvent}</div>

--- a/tests/UIShell/HeaderSearch.test.ts
+++ b/tests/UIShell/HeaderSearch.test.ts
@@ -112,6 +112,37 @@ describe("HeaderSearch", () => {
       );
     });
 
+    it("should pass selected to the result slot", async () => {
+      const results = [
+        { href: "/1", text: "Result 1" },
+        { href: "/2", text: "Result 2" },
+        { href: "/3", text: "Result 3" },
+      ];
+      render(HeaderSearchTest, {
+        props: { active: true, results, selectedResultIndex: 0 },
+      });
+
+      expect(screen.getByTestId("result-0")).toHaveAttribute(
+        "data-selected",
+        "true",
+      );
+      expect(screen.getByTestId("result-1")).toHaveAttribute(
+        "data-selected",
+        "false",
+      );
+
+      await user.keyboard("{ArrowDown}");
+
+      expect(screen.getByTestId("result-0")).toHaveAttribute(
+        "data-selected",
+        "false",
+      );
+      expect(screen.getByTestId("result-1")).toHaveAttribute(
+        "data-selected",
+        "true",
+      );
+    });
+
     it("should use result id for selected menu item id when provided", () => {
       const results = [
         { id: "result-a", href: "/1", text: "Result 1" },


### PR DESCRIPTION
Similar to #3224, pass more state to default slots for convenience (conditional rendering, styling etc..).