### PR TITLE
chore(copy-input): `selectOnFocus` is false by default

### DIFF
--- a/docs/src/pages/components/CopyInput.svx
+++ b/docs/src/pages/components/CopyInput.svx
@@ -9,13 +9,15 @@ Use [CodeSnippet](/components/CodeSnippet) for install commands and code samples
 
 ## Default
 
-Set `value` to the string to show and copy. By default, focusing the field selects the full value.
+Set `value` to the string to show and copy.
 
 <CopyInput labelText="API endpoint" value="https://api.example.com/v1" />
 
-Set `selectOnFocus` to `false` to leave the caret placement unchanged.
+## Select on focus
 
-<CopyInput selectOnFocus={false} labelText="API endpoint" value="https://api.example.com/v1" />
+Set `selectOnFocus` to `true` to select the full value when the field receives focus.
+
+<CopyInput selectOnFocus labelText="API endpoint" value="https://api.example.com/v1" />
 
 ## Async copy
 

--- a/src/CopyInput/CopyInput.svelte
+++ b/src/CopyInput/CopyInput.svelte
@@ -31,10 +31,10 @@
   export let revealMode = undefined;
 
   /**
-   * Set to `false` to skip selecting the full value when the input receives focus.
+   * Set to `true` to select the full value when the input receives focus.
    * @type {boolean}
    */
-  export let selectOnFocus = true;
+  export let selectOnFocus = false;
 
   /**
    * Set the size of the input.

--- a/tests/CopyInput/CopyInput.test.svelte
+++ b/tests/CopyInput/CopyInput.test.svelte
@@ -17,7 +17,7 @@
   {value}
   {type}
   {revealMode}
-  selectOnFocus={selectOnFocus ?? true}
+  {selectOnFocus}
   {labelText}
   {helperText}
   {disabled}

--- a/tests/CopyInput/CopyInput.test.ts
+++ b/tests/CopyInput/CopyInput.test.ts
@@ -32,24 +32,24 @@ describe("CopyInput", () => {
     expect(consoleLog).toHaveBeenCalledWith("copied");
   });
 
-  it("selects the full value on focus by default", async () => {
+  it("does not select the value on focus by default", async () => {
     render(CopyInput);
 
     const input = screen.getByLabelText("API token") as HTMLInputElement;
     const select = vi.spyOn(input, "select");
     await fireEvent.focus(input);
 
-    expect(select).toHaveBeenCalled();
+    expect(select).not.toHaveBeenCalled();
   });
 
-  it("does not select the value on focus when selectOnFocus is false", async () => {
-    render(CopyInput, { props: { selectOnFocus: false } });
+  it("selects the full value on focus when selectOnFocus is true", async () => {
+    render(CopyInput, { props: { selectOnFocus: true } });
 
     const input = screen.getByLabelText("API token") as HTMLInputElement;
     const select = vi.spyOn(input, "select");
     await fireEvent.focus(input);
 
-    expect(select).not.toHaveBeenCalled();
+    expect(select).toHaveBeenCalled();
   });
 
   it("stays obscured on focus when revealMode is unset", async () => {


### PR DESCRIPTION
This is a "chore", not a breaking change, since it's not released yet.
