### PR TITLE
perf(dismiss): pool window listeners by type, options

### DIFF
--- a/e2e/data-table-overflow-menu.test.ts
+++ b/e2e/data-table-overflow-menu.test.ts
@@ -1,0 +1,46 @@
+import { expect, test } from "@playwright/test";
+import {
+  installClickListenerCounter,
+  netClickListeners,
+} from "./helpers/window-listeners";
+
+const ROW_COUNT = 50;
+
+test.describe("DataTable overflow menu listener pooling", () => {
+  test.beforeEach(async ({ page }) => {
+    await installClickListenerCounter(page);
+    await page.goto("/data-table-overflow-menu.html");
+    await expect(page.getByTestId("data-table-overflow")).toBeVisible();
+  });
+
+  test("50 closed menus attach no window click listeners", async ({ page }) => {
+    const table = page.getByTestId("data-table-overflow");
+    await expect(table.locator("tbody tr")).toHaveCount(ROW_COUNT);
+    await expect(table.getByRole("button")).toHaveCount(ROW_COUNT);
+    expect(await netClickListeners(page)).toBe(0);
+  });
+
+  test("50 open menus share one window click listener", async ({ page }) => {
+    const baseline = await netClickListeners(page);
+
+    await page.getByTestId("open-all-menus").click();
+    await expect(page.locator(".bx--overflow-menu--open")).toHaveCount(
+      ROW_COUNT,
+    );
+    expect(await netClickListeners(page)).toBe(baseline + 1);
+  });
+
+  test("closing all menus removes the shared listener", async ({ page }) => {
+    const baseline = await netClickListeners(page);
+
+    await page.getByTestId("open-all-menus").click();
+    await expect(page.locator(".bx--overflow-menu--open")).toHaveCount(
+      ROW_COUNT,
+    );
+    expect(await netClickListeners(page)).toBe(baseline + 1);
+
+    await page.getByTestId("close-all-menus").click();
+    await expect(page.locator(".bx--overflow-menu--open")).toHaveCount(0);
+    expect(await netClickListeners(page)).toBe(baseline);
+  });
+});

--- a/e2e/fixtures/DataTableOverflowMenuFixture.svelte
+++ b/e2e/fixtures/DataTableOverflowMenuFixture.svelte
@@ -1,0 +1,75 @@
+<script>
+  import {
+    DataTable,
+    OverflowMenu,
+    OverflowMenuItem,
+  } from "carbon-components-svelte";
+  import { tick } from "svelte";
+
+  const ROW_COUNT = 50;
+
+  const headers = [
+    { key: "name", value: "Name" },
+    { key: "overflow", empty: true, width: "72px" },
+  ];
+
+  const rows = Array.from({ length: ROW_COUNT }, (_, i) => ({
+    id: `row-${i}`,
+    name: `Row ${i}`,
+  }));
+
+  /** @type {boolean[]} */
+  let openStates = rows.map(() => false);
+
+  async function setAllOpen(open) {
+    for (let i = 0; i < ROW_COUNT; i++) openStates[i] = open;
+    openStates = openStates;
+    await tick();
+  }
+</script>
+
+<div class="controls">
+  <button
+    type="button"
+    data-testid="open-all-menus"
+    on:click={(event) => {
+      event.stopPropagation();
+      setAllOpen(true);
+    }}
+  >
+    Open all menus
+  </button>
+  <button
+    type="button"
+    data-testid="close-all-menus"
+    on:click={(event) => {
+      event.stopPropagation();
+      setAllOpen(false);
+    }}
+  >
+    Close all menus
+  </button>
+</div>
+
+<div data-testid="data-table-overflow">
+  <DataTable {headers} {rows}>
+    <svelte:fragment slot="cell" let:cell let:rowIndex>
+      {#if cell.key === "overflow"}
+        <OverflowMenu bind:open={openStates[rowIndex]} portalMenu flipped>
+          <OverflowMenuItem text="Edit" />
+          <OverflowMenuItem text="Delete" danger />
+        </OverflowMenu>
+      {:else}
+        {cell.value}
+      {/if}
+    </svelte:fragment>
+  </DataTable>
+</div>
+
+<style>
+  .controls {
+    display: flex;
+    gap: 0.5rem;
+    margin-bottom: 1rem;
+  }
+</style>

--- a/e2e/fixtures/data-table-overflow-menu.html
+++ b/e2e/fixtures/data-table-overflow-menu.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>DataTable Overflow Menu Fixture</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="./data-table-overflow-menu.ts"></script>
+  </body>
+</html>

--- a/e2e/fixtures/data-table-overflow-menu.ts
+++ b/e2e/fixtures/data-table-overflow-menu.ts
@@ -1,0 +1,4 @@
+import DataTableOverflowMenuFixture from "./DataTableOverflowMenuFixture.svelte";
+import { mount } from "./mount";
+
+mount(DataTableOverflowMenuFixture);

--- a/e2e/helpers/window-listeners.ts
+++ b/e2e/helpers/window-listeners.ts
@@ -1,0 +1,28 @@
+import type { Page } from "@playwright/test";
+
+type WindowWithListenerCounter = Window & {
+  __netClickListeners: () => number;
+};
+
+export async function installClickListenerCounter(page: Page) {
+  await page.addInitScript(() => {
+    const net = { click: 0 };
+    const add = window.addEventListener.bind(window);
+    const remove = window.removeEventListener.bind(window);
+    window.addEventListener = (type, listener, options) => {
+      if (type === "click") net.click++;
+      return add(type, listener, options);
+    };
+    window.removeEventListener = (type, listener, options) => {
+      if (type === "click") net.click--;
+      return remove(type, listener, options);
+    };
+    (window as WindowWithListenerCounter).__netClickListeners = () => net.click;
+  });
+}
+
+export function netClickListeners(page: Page) {
+  return page.evaluate(() =>
+    (window as WindowWithListenerCounter).__netClickListeners(),
+  );
+}

--- a/src/utils/dismiss.js
+++ b/src/utils/dismiss.js
@@ -1,9 +1,87 @@
 // @ts-check
 
 /**
- * Svelte action that adds `window` listeners only while `enabled` is true.
- * Handlers refresh in place on update without re-registering listeners.
- * SSR-safe.
+ * One `window` listener per `(type, options)`. Handlers register as consumers;
+ * the first consumer calls `addEventListener`, the last calls `removeEventListener`.
+ *
+ * @typedef {{ handler: (event: Event) => void }} Consumer
+ * @typedef {{
+ *   type: string,
+ *   options: boolean | AddEventListenerOptions | undefined,
+ *   listener: (event: Event) => void,
+ *   consumers: Set<Consumer>,
+ * }} Pool
+ *
+ * @type {Map<string, Pool>}
+ */
+const pools = new Map();
+
+/**
+ * Pool key from type plus `capture`, `passive`, and `once`. Those are the only
+ * options that change how the listener runs.
+ *
+ * @param {string} type
+ * @param {boolean | AddEventListenerOptions | undefined} options
+ * @returns {string}
+ */
+function poolKey(type, options) {
+  let capture = false;
+  let passive = false;
+  let once = false;
+  if (typeof options === "boolean") {
+    capture = options;
+  } else if (options) {
+    capture = !!options.capture;
+    passive = !!options.passive;
+    once = !!options.once;
+  }
+  return `${type} ${capture ? 1 : 0}${passive ? 1 : 0}${once ? 1 : 0}`;
+}
+
+/**
+ * Add a consumer to the pool for `(type, options)`. Creates the pool on first use.
+ *
+ * @param {{ type: string, handler: (event: Event) => void, options: boolean | AddEventListenerOptions | undefined }} spec
+ * @returns {{ key: string, pool: Pool, consumer: Consumer }}
+ */
+function registerConsumer(spec) {
+  const key = poolKey(spec.type, spec.options);
+  let pool = pools.get(key);
+  if (!pool) {
+    const consumers = /** @type {Set<Consumer>} */ (new Set());
+    const listener = (/** @type {Event} */ event) => {
+      // Copy before iterating. Handlers may add or remove consumers mid-dispatch;
+      // removed consumers should not run, same as native listeners.
+      for (const consumer of [...consumers]) {
+        if (consumers.has(consumer)) consumer.handler(event);
+      }
+    };
+    pool = { type: spec.type, options: spec.options, listener, consumers };
+    pools.set(key, pool);
+    window.addEventListener(spec.type, listener, spec.options);
+  }
+  const consumer = { handler: spec.handler };
+  pool.consumers.add(consumer);
+  return { key, pool, consumer };
+}
+
+/**
+ * Remove a consumer. Drops the window listener when the pool is empty.
+ *
+ * @param {{ key: string, pool: Pool, consumer: Consumer }} entry
+ */
+function unregisterConsumer({ key, pool, consumer }) {
+  pool.consumers.delete(consumer);
+  if (pool.consumers.size === 0) {
+    window.removeEventListener(pool.type, pool.listener, pool.options);
+    pools.delete(key);
+  }
+}
+
+/**
+ * Svelte action: `window` listeners while `enabled` is true.
+ * Controls with the same `(type, options)` share one listener.
+ * Handler updates in place without re-registering. SSR-safe.
  *
  * @param {unknown} _node Host element (unused; listeners attach to `window`).
  * @param {import("./dismiss.js").DismissParams} params
@@ -14,24 +92,17 @@ export function dismiss(_node, params) {
   let enabled = !!params.enabled;
 
   /**
-   * @type {Array<{ type: string, options: boolean | AddEventListenerOptions | undefined, listener: (event: Event) => void, ref: { handler: (event: Event) => void } }>}
+   * @type {Array<{ key: string, pool: Pool, consumer: Consumer }>}
    */
   let registered = [];
 
   function add() {
     if (typeof window === "undefined") return;
-    registered = specs.map((spec) => {
-      const ref = { handler: spec.handler };
-      const listener = (/** @type {Event} */ event) => ref.handler(event);
-      window.addEventListener(spec.type, listener, spec.options);
-      return { type: spec.type, options: spec.options, listener, ref };
-    });
+    registered = specs.map((spec) => registerConsumer(spec));
   }
 
   function remove() {
-    for (const r of registered) {
-      window.removeEventListener(r.type, r.listener, r.options);
-    }
+    for (const entry of registered) unregisterConsumer(entry);
     registered = [];
   }
 
@@ -45,12 +116,13 @@ export function dismiss(_node, params) {
       const sameShape =
         registered.length === nextSpecs.length &&
         nextSpecs.every(
-          (s, i) => registered[i] && registered[i].type === s.type,
+          (s, i) =>
+            registered[i] && registered[i].key === poolKey(s.type, s.options),
         );
 
       if (enabled && nextEnabled && sameShape) {
         nextSpecs.forEach((s, i) => {
-          registered[i].ref.handler = s.handler;
+          registered[i].consumer.handler = s.handler;
         });
         specs = nextSpecs;
         return;

--- a/tests/ContextMenu/ContextMenuWindowListeners.test.ts
+++ b/tests/ContextMenu/ContextMenuWindowListeners.test.ts
@@ -14,7 +14,7 @@ describe("ContextMenu window listeners", () => {
     const add = vi.spyOn(window, "addEventListener");
     const remove = vi.spyOn(window, "removeEventListener");
 
-    const N = 50;
+    const N = 5;
     for (let i = 0; i < N; i++) render(ContextMenu, { props: { open: false } });
 
     expect(net(add, remove, "click")).toBe(0);

--- a/tests/Dropdown/DropdownWindowListeners.test.ts
+++ b/tests/Dropdown/DropdownWindowListeners.test.ts
@@ -13,7 +13,7 @@ describe("Dropdown window listeners", () => {
     const add = vi.spyOn(window, "addEventListener");
     const remove = vi.spyOn(window, "removeEventListener");
 
-    for (let i = 0; i < 100; i++) render(Dropdown, { props: { open: false } });
+    for (let i = 0; i < 5; i++) render(Dropdown, { props: { open: false } });
     expect(netClick(add, remove)).toBe(0);
 
     add.mockRestore();

--- a/tests/MultiSelect/MultiSelectWindowListeners.test.ts
+++ b/tests/MultiSelect/MultiSelectWindowListeners.test.ts
@@ -14,7 +14,7 @@ describe("MultiSelect window listeners", () => {
     const add = vi.spyOn(window, "addEventListener");
     const remove = vi.spyOn(window, "removeEventListener");
 
-    for (let i = 0; i < 100; i++) {
+    for (let i = 0; i < 5; i++) {
       render(MultiSelect, { props: { open: false } });
     }
 

--- a/tests/OverflowMenu/OverflowMenuWindowListeners.test.ts
+++ b/tests/OverflowMenu/OverflowMenuWindowListeners.test.ts
@@ -20,7 +20,7 @@ describe("OverflowMenu window listeners", () => {
     const addSpy = vi.spyOn(window, "addEventListener");
     const removeSpy = vi.spyOn(window, "removeEventListener");
 
-    for (let i = 0; i < 1000; i++) {
+    for (let i = 0; i < 5; i++) {
       render(OverflowMenu, { props: { id: `menu-${i}` } });
     }
 
@@ -28,7 +28,7 @@ describe("OverflowMenu window listeners", () => {
 
     addSpy.mockRestore();
     removeSpy.mockRestore();
-  }, 30_000);
+  });
 
   test("opening adds one window click listener, closing removes it", async () => {
     const addSpy = vi.spyOn(window, "addEventListener");

--- a/tests/Popover/PopoverWindowListeners.test.ts
+++ b/tests/Popover/PopoverWindowListeners.test.ts
@@ -13,7 +13,7 @@ describe("Popover window listeners", () => {
     const add = vi.spyOn(window, "addEventListener");
     const remove = vi.spyOn(window, "removeEventListener");
 
-    for (let i = 0; i < 100; i++) render(Popover, { props: { open: false } });
+    for (let i = 0; i < 5; i++) render(Popover, { props: { open: false } });
     expect(netClick(add, remove)).toBe(0);
 
     add.mockRestore();

--- a/tests/TooltipDefinition/TooltipDefinitionWindowListeners.test.ts
+++ b/tests/TooltipDefinition/TooltipDefinitionWindowListeners.test.ts
@@ -14,7 +14,7 @@ describe("TooltipDefinition window listeners", () => {
     const add = vi.spyOn(window, "addEventListener");
     const remove = vi.spyOn(window, "removeEventListener");
 
-    for (let i = 0; i < 100; i++)
+    for (let i = 0; i < 5; i++)
       render(TooltipDefinition, { props: { open: false } });
     expect(net(add, remove, "keydown")).toBe(0);
 

--- a/tests/TooltipIcon/TooltipIconWindowListeners.test.ts
+++ b/tests/TooltipIcon/TooltipIconWindowListeners.test.ts
@@ -14,8 +14,7 @@ describe("TooltipIcon window listeners", () => {
     const add = vi.spyOn(window, "addEventListener");
     const remove = vi.spyOn(window, "removeEventListener");
 
-    for (let i = 0; i < 100; i++)
-      render(TooltipIcon, { props: { open: false } });
+    for (let i = 0; i < 5; i++) render(TooltipIcon, { props: { open: false } });
     expect(net(add, remove, "keydown")).toBe(0);
 
     add.mockRestore();

--- a/tests/utils/dismiss.test.ts
+++ b/tests/utils/dismiss.test.ts
@@ -156,3 +156,137 @@ describe("dismiss action", () => {
     action.destroy();
   });
 });
+
+describe("dismiss listener pooling", () => {
+  const clickAdds = (spy: ReturnType<typeof vi.spyOn>) =>
+    spy.mock.calls.filter((c: unknown[]) => c[0] === "click").length;
+
+  test("many open consumers share one window listener", () => {
+    const addSpy = vi.spyOn(window, "addEventListener");
+    const removeSpy = vi.spyOn(window, "removeEventListener");
+
+    const handlers = Array.from({ length: 5 }, () => vi.fn());
+    const actions = handlers.map((handler) =>
+      dismiss(document.createElement("div"), {
+        enabled: true,
+        type: "click",
+        handler,
+      }),
+    );
+
+    expect(clickAdds(addSpy)).toBe(1);
+
+    window.dispatchEvent(new MouseEvent("click"));
+    for (const h of handlers) expect(h).toHaveBeenCalledTimes(1);
+
+    // Listener stays until the last consumer is destroyed.
+    for (const a of actions.slice(0, -1)) a.destroy();
+    expect(removeSpy.mock.calls.filter((c) => c[0] === "click").length).toBe(0);
+    actions[actions.length - 1].destroy();
+    expect(removeSpy.mock.calls.filter((c) => c[0] === "click").length).toBe(1);
+
+    addSpy.mockRestore();
+    removeSpy.mockRestore();
+  });
+
+  test("calls consumers in registration order", () => {
+    const order: number[] = [];
+    const a = dismiss(document.createElement("div"), {
+      enabled: true,
+      type: "click",
+      handler: () => order.push(1),
+    });
+    const b = dismiss(document.createElement("div"), {
+      enabled: true,
+      type: "click",
+      handler: () => order.push(2),
+    });
+    const c = dismiss(document.createElement("div"), {
+      enabled: true,
+      type: "click",
+      handler: () => order.push(3),
+    });
+
+    window.dispatchEvent(new MouseEvent("click"));
+    expect(order).toEqual([1, 2, 3]);
+
+    a.destroy();
+    b.destroy();
+    c.destroy();
+  });
+
+  test("unregister during dispatch skips removed consumer", () => {
+    const calls: string[] = [];
+    let inner: ReturnType<typeof dismiss>;
+    const outer = dismiss(document.createElement("div"), {
+      enabled: true,
+      type: "click",
+      handler: () => {
+        calls.push("outer");
+        inner.destroy();
+      },
+    });
+    inner = dismiss(document.createElement("div"), {
+      enabled: true,
+      type: "click",
+      handler: () => calls.push("inner"),
+    });
+
+    window.dispatchEvent(new MouseEvent("click"));
+    expect(calls).toEqual(["outer"]);
+
+    outer.destroy();
+  });
+
+  test("consumer added mid-dispatch waits for the next event", () => {
+    const calls: string[] = [];
+    let added: ReturnType<typeof dismiss> | undefined;
+
+    const first = dismiss(document.createElement("div"), {
+      enabled: true,
+      type: "click",
+      handler: () => {
+        calls.push("first");
+        if (added) return;
+        added = dismiss(document.createElement("div"), {
+          enabled: true,
+          type: "click",
+          handler: () => calls.push("added"),
+        });
+      },
+    });
+
+    window.dispatchEvent(new MouseEvent("click"));
+    expect(calls).toEqual(["first"]);
+
+    window.dispatchEvent(new MouseEvent("click"));
+    expect(calls).toEqual(["first", "first", "added"]);
+
+    first.destroy();
+    added?.destroy();
+  });
+
+  test("capture and bubble get separate listeners", () => {
+    const addSpy = vi.spyOn(window, "addEventListener");
+    const bubble = vi.fn();
+    const capture = vi.fn();
+
+    const a = dismiss(document.createElement("div"), {
+      enabled: true,
+      type: "click",
+      handler: bubble,
+    });
+    const b = dismiss(document.createElement("div"), {
+      enabled: true,
+      type: "click",
+      handler: capture,
+      options: { capture: true },
+    });
+
+    expect(clickAdds(addSpy)).toBe(2);
+
+    a.destroy();
+    b.destroy();
+    addSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
Follow-up optimization to #3215, which avoids registering an event listener per component instance that needs "click outside" logic.

`use:dismiss` powers outside-click and Escape dismissal for OverflowMenu, Popover,
Dropdown, MultiSelect, the Tooltips, ContextMenu, and the UIShell Header menus. It
used to attach one real window listener per open control. This PR swaps the
internals for a shared dispatcher: one window listener per distinct (type, options)
key, fanning out to a registry of active consumers.

This is a fairly standard pattern for UI libraries: delegating to a single high-level listener ("many widgets,
one global event.")

## Performance gain

| Scenario | Before | After |
|---|---|---|
| 500 closed menus in a table | 0 listeners | 0 listeners |
| 50 open menus on a page | 50 listeners | 1 |


