### PR TITLE
chore: replace template literals with Svelte attribute syntax

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,7 @@ Patterns:
 - Avoid `afterUpdate`. It runs after every DOM update and is easy to loop in Svelte 5. Prefer `$:` reactive statements with guards, event handlers, `onMount`, or `tick()` for DOM reads. Legacy code may still use `afterUpdate` for scroll-sync or measurement; do not add new uses without a strong reason.
 - Put the JSDoc block first, then `export let`, then imports. See [`Button.svelte`](src/Button/Button.svelte) and [`ComboBox.svelte`](src/ComboBox/ComboBox.svelte).
 - Forward DOM events with bare `on:click` / `on:focus` (no handler) on the underlying element ([`Button.svelte`](src/Button/Button.svelte)).
+- Interpolate attribute values with Svelte's attribute syntax, not template literals: `id="{treeId}-{id}-subtree"`, not ``id={`${treeId}-${id}-subtree`}``. Keep template literals only when a value needs nested quotes or logic the shorthand can't express (see `aria-label` in [`PinCodeInput.svelte`](src/PinCodeInput/PinCodeInput.svelte)).
 - Compound components use `setContext` / `getContext` with `carbon:` keys ([`CheckboxGroup.svelte`](src/Checkbox/CheckboxGroup.svelte)).
 - Default element IDs use `ccs-${Math.random().toString(36)}`.
 - Key `{#each}` blocks, for example `(item.id ?? index)` (see [`RecursiveList.svelte`](src/RecursiveList/RecursiveList.svelte)).

--- a/src/ComboBox/ComboBox.svelte
+++ b/src/ComboBox/ComboBox.svelte
@@ -703,7 +703,7 @@
               {#each itemsToRender as item, index (item.id)}
                 {@const actualIndex = virtualData.startIndex + index}
                 <ListBoxMenuItem
-                  id={`${id}-${item.id}`}
+                  id="{id}-{item.id}"
                   active={selectedId === item.id}
                   highlighted={highlightedIndex === actualIndex}
                   disabled={item.disabled}
@@ -743,7 +743,7 @@
         {:else}
           {#each itemsToRender as item, index (item.id)}
             <ListBoxMenuItem
-              id={`${id}-${item.id}`}
+              id="{id}-{item.id}"
               active={selectedId === item.id}
               highlighted={highlightedIndex === index}
               disabled={item.disabled}

--- a/src/DataTable/DataTable.svelte
+++ b/src/DataTable/DataTable.svelte
@@ -873,7 +873,7 @@
                     <button
                       type="button"
                       class:bx--table-expand__button={true}
-                      aria-controls={`${id}-expandable-row-${row.id}`}
+                      aria-controls="{id}-expandable-row-{row.id}"
                       aria-label={expandedRows[row.id]
                         ? "Collapse current row"
                         : "Expand current row"}
@@ -1000,7 +1000,7 @@
 
             {#if expandable}
               <tr
-                id={`${id}-expandable-row-${row.id}`}
+                id="{id}-expandable-row-{row.id}"
                 data-child-row
                 class:bx--expandable-row={true}
                 on:mouseenter={() => {
@@ -1093,7 +1093,7 @@
                     <button
                       type="button"
                       class:bx--table-expand__button={true}
-                      aria-controls={`${id}-expandable-row-${row.id}`}
+                      aria-controls="{id}-expandable-row-{row.id}"
                       aria-label={isExpanded
                         ? "Collapse current row"
                         : "Expand current row"}
@@ -1207,7 +1207,7 @@
 
             {#if expandable}
               <tr
-                id={`${id}-expandable-row-${row.id}`}
+                id="{id}-expandable-row-{row.id}"
                 data-child-row
                 class:bx--expandable-row={true}
                 on:mouseenter={() => {

--- a/src/Dropdown/Dropdown.svelte
+++ b/src/Dropdown/Dropdown.svelte
@@ -553,7 +553,7 @@
               {#each itemsToRender as item, index (item.id)}
                 {@const actualIndex = virtualData.startIndex + index}
                 <ListBoxMenuItem
-                  id={`${id}-${item.id}`}
+                  id="{id}-{item.id}"
                   active={selectedId === item.id}
                   highlighted={highlightedIndex === actualIndex}
                   disabled={item.disabled}
@@ -590,7 +590,7 @@
         {:else}
           {#each itemsToRender as item, index (item.id)}
             <ListBoxMenuItem
-              id={`${id}-${item.id}`}
+              id="{id}-{item.id}"
               active={selectedId === item.id}
               highlighted={highlightedIndex === index}
               disabled={item.disabled}

--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -867,7 +867,7 @@
               {#each itemsToRender as item, index (item.id)}
                 {@const actualIndex = virtualData.startIndex + index}
                 <ListBoxMenuItem
-                  id={`${id}-${item.id}`}
+                  id="{id}-{item.id}"
                   role="option"
                   aria-labelledby="checkbox-{id}-{item.id}"
                   aria-selected={item.isSelectAll ? allSelected : item.checked}
@@ -928,7 +928,7 @@
         {:else}
           {#each itemsToRender as item, index (item.id)}
             <ListBoxMenuItem
-              id={`${id}-${item.id}`}
+              id="{id}-{item.id}"
               role="option"
               aria-labelledby="checkbox-{id}-{item.id}"
               aria-selected={item.isSelectAll ? allSelected : item.checked}

--- a/src/TreeView/TreeViewNodeList.svelte
+++ b/src/TreeView/TreeViewNodeList.svelte
@@ -118,7 +118,7 @@
     class:bx--tree-node--disabled={disabled}
     class:bx--tree-node--with-icon={icon}
     aria-expanded={expanded}
-    aria-owns={`${treeId}-${id}-subtree`}
+    aria-owns="{treeId}-{id}-subtree"
     on:click|stopPropagation={(event) => {
       if (disabled) return;
       clickNode(node, event);
@@ -205,18 +205,15 @@
       </span>
       <span class:bx--tree-node__label__details={true}>
         <svelte:component this={icon} class="bx--tree-node__icon" />
-        <span
-          id={`${treeId}-${id}__label`}
-          class:bx--tree-node__label__text={true}
-        >
+        <span id="{treeId}-{id}__label" class:bx--tree-node__label__text={true}>
           <slot {node} />
         </span>
       </span>
     </div>
     <ul
-      id={`${treeId}-${id}-subtree`}
+      id="{treeId}-{id}-subtree"
       role="group"
-      aria-labelledby={`${treeId}-${id}__label`}
+      aria-labelledby="{treeId}-{id}__label"
       class:bx--tree-node__children={true}
       class:bx--tree-node--hidden={!expanded}
     >


### PR DESCRIPTION
Use Svelte's attribute syntax instead of template literals. Update the code style guidelines.