### PR TITLE
feat(storage): add `sync` prop to opt out of storage event sync

### DIFF
--- a/docs/src/pages/components/LocalStorage.svx
+++ b/docs/src/pages/components/LocalStorage.svx
@@ -36,6 +36,16 @@ Switching the `key` only hydrates `value` from storage; it does not dispatch an 
 
 <FileSource src="/framed/LocalStorage/LocalStorageReactiveKey" />
 
+## Disabling cross-tab sync
+
+With `sync="on"` (the default), another tab writing the same key updates `value` and fires `on:update`. Set `sync="off"` to ignore those writes. The component still loads storage on mount and saves your own changes.
+
+Use `sync="off"` when each tab should keep separate state: drafts, forms in progress, or a second login tab that should not clobber the first. You can also turn sync off if the app resolves conflicts itself. `sync` is reactive, so you can change it at runtime.
+
+```svelte
+<LocalStorage key="draft" bind:value sync="off" />
+```
+
 ## Clear item, clear all
 
 The component provides methods to manage stored data:

--- a/docs/src/pages/components/SessionStorage.svx
+++ b/docs/src/pages/components/SessionStorage.svx
@@ -33,6 +33,16 @@ Switching the `key` only hydrates `value` from storage; it does not dispatch an 
 
 <FileSource src="/framed/SessionStorage/SessionStorageReactiveKey" />
 
+## Disabling sync
+
+With `sync="on"` (the default), the component listens for the `storage` event and updates `value` when another same-origin document in this tab writes the same key, such as an iframe. Set `sync="off"` to ignore those writes. The component still loads storage on mount and saves your own changes.
+
+`sessionStorage` is already per tab, so this matters mainly when an iframe shares the session. Turn sync off when the host page should not follow iframe writes, or when the app handles conflicts itself. `sync` is reactive, so you can change it at runtime.
+
+```svelte
+<SessionStorage key="draft" bind:value sync="off" />
+```
+
 ## Clear item, clear all
 
 The component provides methods to manage stored data:

--- a/src/LocalStorage/LocalStorage.svelte
+++ b/src/LocalStorage/LocalStorage.svelte
@@ -2,7 +2,7 @@
   /**
    * @template [T=any]
    * @event {null} save
-   * @event update - Fires when the stored value changes, either from a bound value update or when localStorage is modified from another tab/window.
+   * @event update - Fires when the stored value changes, either from a bound value update or when localStorage is modified from another tab or window. Set `sync` to `"off"` to ignore updates from other tabs.
    * @property {T} prevValue
    * @property {T} value
    * @event {{ error: unknown }} error - Fires when a write to localStorage fails (e.g. quota exceeded or access denied).
@@ -19,6 +19,13 @@
    * @bindable writable
    */
   export let value = /** @type {T} */ ("");
+
+  /**
+   * `"off"` ignores storage events from other tabs or windows on the same
+   * origin. `"on"` (default) keeps the previous behavior.
+   * @type {"on" | "off"}
+   */
+  export let sync = "on";
 
   /**
    * Remove the persisted key value from the browser's local storage.
@@ -78,6 +85,24 @@
     });
   }
 
+  function handleStorageChange(event) {
+    if (event.key !== key) return;
+
+    const prevValue = parseStoredValue(prevSerialized);
+
+    if (event.newValue === null) {
+      // Another tab removed the key (or called clear()).
+      // Reset so the next local mutation does not re-persist stale state.
+      value = /** @type {T} */ (undefined);
+      prevSerialized = serializeStoredValue(value);
+    } else {
+      value = parseStoredValue(event.newValue);
+      prevSerialized = event.newValue;
+    }
+
+    dispatch("update", { prevValue, value });
+  }
+
   onMount(() => {
     const item = storage.getItem(key);
 
@@ -91,30 +116,19 @@
     prevSerialized = serializeStoredValue(value);
     mounted = true;
 
-    function handleStorageChange(event) {
-      if (event.key === key) {
-        const prevValue = parseStoredValue(prevSerialized);
-
-        if (event.newValue === null) {
-          // Another tab removed the key (or called clear()).
-          // Reset so the next local mutation does not re-persist stale state.
-          value = /** @type {T} */ (undefined);
-          prevSerialized = serializeStoredValue(value);
-        } else {
-          value = parseStoredValue(event.newValue);
-          prevSerialized = event.newValue;
-        }
-
-        dispatch("update", { prevValue, value });
-      }
-    }
-
-    window.addEventListener("storage", handleStorageChange);
-
     return () => {
       window.removeEventListener("storage", handleStorageChange);
     };
   });
+
+  // Attach storage listener when sync is on. Re-run when sync changes.
+  $: if (mounted) {
+    window.removeEventListener("storage", handleStorageChange);
+
+    if (sync === "on") {
+      window.addEventListener("storage", handleStorageChange);
+    }
+  }
 
   $: if (mounted && key !== prevKey) {
     const item = storage.getItem(key);

--- a/src/SessionStorage/SessionStorage.svelte
+++ b/src/SessionStorage/SessionStorage.svelte
@@ -2,7 +2,7 @@
   /**
    * @template [T=any]
    * @event {null} save
-   * @event update - Fires when the stored value changes, either from a bound value update or when sessionStorage is modified by another same-origin document in this tab (e.g. an iframe).
+   * @event update - Fires when the stored value changes, either from a bound value update or when sessionStorage is modified by another same origin document in this tab (e.g. an iframe). Set `sync` to `"off"` to ignore those external updates.
    * @property {T} prevValue
    * @property {T} value
    * @event {{ error: unknown }} error - Fires when a write to sessionStorage fails (e.g. quota exceeded or access denied).
@@ -19,6 +19,13 @@
    * @bindable writable
    */
   export let value = /** @type {T} */ ("");
+
+  /**
+   * `"off"` ignores storage events from other documents in this tab (e.g. an
+   * iframe). `"on"` (default) keeps the previous behavior.
+   * @type {"on" | "off"}
+   */
+  export let sync = "on";
 
   /**
    * Remove the persisted key value from the browser's session storage.
@@ -78,6 +85,24 @@
     });
   }
 
+  function handleStorageChange(event) {
+    if (event.key !== key) return;
+
+    const prevValue = parseStoredValue(prevSerialized);
+
+    if (event.newValue === null) {
+      // Another document removed the key (or called clear()).
+      // Reset so the next local mutation does not re-persist stale state.
+      value = /** @type {T} */ (undefined);
+      prevSerialized = serializeStoredValue(value);
+    } else {
+      value = parseStoredValue(event.newValue);
+      prevSerialized = event.newValue;
+    }
+
+    dispatch("update", { prevValue, value });
+  }
+
   onMount(() => {
     const item = storage.getItem(key);
 
@@ -91,30 +116,19 @@
     prevSerialized = serializeStoredValue(value);
     mounted = true;
 
-    function handleStorageChange(event) {
-      if (event.key === key) {
-        const prevValue = parseStoredValue(prevSerialized);
-
-        if (event.newValue === null) {
-          // Another tab removed the key (or called clear()).
-          // Reset so the next local mutation does not re-persist stale state.
-          value = /** @type {T} */ (undefined);
-          prevSerialized = serializeStoredValue(value);
-        } else {
-          value = parseStoredValue(event.newValue);
-          prevSerialized = event.newValue;
-        }
-
-        dispatch("update", { prevValue, value });
-      }
-    }
-
-    window.addEventListener("storage", handleStorageChange);
-
     return () => {
       window.removeEventListener("storage", handleStorageChange);
     };
   });
+
+  // Attach storage listener when sync is on. Re-run when sync changes.
+  $: if (mounted) {
+    window.removeEventListener("storage", handleStorageChange);
+
+    if (sync === "on") {
+      window.addEventListener("storage", handleStorageChange);
+    }
+  }
 
   $: if (mounted && key !== prevKey) {
     const item = storage.getItem(key);

--- a/tests/LocalStorage/LocalStorageSync.test.svelte
+++ b/tests/LocalStorage/LocalStorageSync.test.svelte
@@ -1,0 +1,20 @@
+<svelte:options accessors />
+
+<script lang="ts">
+  import LocalStorage from "carbon-components-svelte/LocalStorage/LocalStorage.svelte";
+
+  export let value: unknown = "initial-value";
+  export let key = "sync-key";
+  export let sync: "on" | "off" = "off";
+  export let onUpdate: (detail: {
+    prevValue: unknown;
+    value: unknown;
+  }) => void = () => undefined;
+</script>
+
+<LocalStorage
+  {key}
+  {sync}
+  bind:value
+  on:update={({ detail }) => onUpdate(detail)}
+/>

--- a/tests/LocalStorage/LocalStorageSync.test.ts
+++ b/tests/LocalStorage/LocalStorageSync.test.ts
@@ -1,0 +1,59 @@
+import { render } from "@testing-library/svelte";
+import { tick } from "svelte";
+import { setupStorageEventMock } from "../utils/storage-mocks";
+import LocalStorageSync from "./LocalStorageSync.test.svelte";
+
+describe("LocalStorage sync opt-out", () => {
+  const { dispatchStorageEvent, getMockItem } = setupStorageEventMock();
+
+  it("does not register a storage listener when sync is off", async () => {
+    render(LocalStorageSync, { props: { sync: "off" } });
+    await tick();
+
+    expect(window.addEventListener).not.toHaveBeenCalledWith(
+      "storage",
+      expect.any(Function),
+    );
+  });
+
+  it("ignores external storage events when sync is off", async () => {
+    const onUpdate = vi.fn();
+    const { component } = render(LocalStorageSync, {
+      props: { key: "k", value: "initial", sync: "off", onUpdate },
+    });
+    await tick();
+
+    dispatchStorageEvent("k", "from-another-tab");
+    await tick();
+
+    expect(component.value).toBe("initial");
+    expect(onUpdate).not.toHaveBeenCalled();
+  });
+
+  it("still persists local value changes when sync is off", async () => {
+    const { component } = render(LocalStorageSync, {
+      props: { key: "k", value: "initial", sync: "off" },
+    });
+    await tick();
+
+    component.value = "updated-locally";
+    await tick();
+
+    expect(getMockItem("k")).toBe("updated-locally");
+  });
+
+  it("starts syncing when sync flips from off to on", async () => {
+    const { component } = render(LocalStorageSync, {
+      props: { key: "k", value: "initial", sync: "off" },
+    });
+    await tick();
+
+    component.sync = "on";
+    await tick();
+
+    dispatchStorageEvent("k", "now-synced");
+    await tick();
+
+    expect(component.value).toBe("now-synced");
+  });
+});

--- a/tests/SessionStorage/SessionStorageSync.test.svelte
+++ b/tests/SessionStorage/SessionStorageSync.test.svelte
@@ -1,0 +1,20 @@
+<svelte:options accessors />
+
+<script lang="ts">
+  import SessionStorage from "carbon-components-svelte/SessionStorage/SessionStorage.svelte";
+
+  export let value: unknown = "initial-value";
+  export let key = "sync-key";
+  export let sync: "on" | "off" = "off";
+  export let onUpdate: (detail: {
+    prevValue: unknown;
+    value: unknown;
+  }) => void = () => undefined;
+</script>
+
+<SessionStorage
+  {key}
+  {sync}
+  bind:value
+  on:update={({ detail }) => onUpdate(detail)}
+/>

--- a/tests/SessionStorage/SessionStorageSync.test.ts
+++ b/tests/SessionStorage/SessionStorageSync.test.ts
@@ -1,0 +1,59 @@
+import { render } from "@testing-library/svelte";
+import { tick } from "svelte";
+import { setupSessionStorageEventMock } from "../utils/storage-mocks";
+import SessionStorageSync from "./SessionStorageSync.test.svelte";
+
+describe("SessionStorage sync opt-out", () => {
+  const { dispatchStorageEvent, getMockItem } = setupSessionStorageEventMock();
+
+  it("does not register a storage listener when sync is off", async () => {
+    render(SessionStorageSync, { props: { sync: "off" } });
+    await tick();
+
+    expect(window.addEventListener).not.toHaveBeenCalledWith(
+      "storage",
+      expect.any(Function),
+    );
+  });
+
+  it("ignores external storage events when sync is off", async () => {
+    const onUpdate = vi.fn();
+    const { component } = render(SessionStorageSync, {
+      props: { key: "k", value: "initial", sync: "off", onUpdate },
+    });
+    await tick();
+
+    dispatchStorageEvent("k", "from-an-iframe");
+    await tick();
+
+    expect(component.value).toBe("initial");
+    expect(onUpdate).not.toHaveBeenCalled();
+  });
+
+  it("still persists local value changes when sync is off", async () => {
+    const { component } = render(SessionStorageSync, {
+      props: { key: "k", value: "initial", sync: "off" },
+    });
+    await tick();
+
+    component.value = "updated-locally";
+    await tick();
+
+    expect(getMockItem("k")).toBe("updated-locally");
+  });
+
+  it("starts syncing when sync flips from off to on", async () => {
+    const { component } = render(SessionStorageSync, {
+      props: { key: "k", value: "initial", sync: "off" },
+    });
+    await tick();
+
+    component.sync = "on";
+    await tick();
+
+    dispatchStorageEvent("k", "now-synced");
+    await tick();
+
+    expect(component.value).toBe("now-synced");
+  });
+});


### PR DESCRIPTION
Cross-tab sync is a reasonable default for the storage utilities. However, there are some cases where this is not desired.

Add the ability to opt-out of sync.