### PR TITLE
fix: derive virtualized item height from size

### DIFF
--- a/docs/src/pages/components/ComboBox.svx
+++ b/docs/src/pages/components/ComboBox.svx
@@ -377,6 +377,6 @@ Specify a custom value for `threshold` to control when virtualization activates.
 
 ## Virtualized items (custom item height)
 
-The default item height for virtualization is 40 pixels. When using custom slots to render items with different heights (for example, multi-line items with descriptions), specify a custom `itemHeight` value to match your item's actual height.
+By default, item height matches the menu row for each size: 32px (`sm`), 40px (`md`), 48px (`lg`, `xl`). Set `itemHeight` when custom slots change row height.
 
 <FileSource src="/framed/ComboBox/VirtualizeItemHeight" />

--- a/docs/src/pages/components/Dropdown.svx
+++ b/docs/src/pages/components/Dropdown.svx
@@ -228,7 +228,7 @@ Specify a custom value for `threshold` to control when virtualization activates.
 
 ## Virtualized items (custom item height)
 
-The default item height for virtualization is 40 pixels. When using custom slots to render items with different heights (for example, multi-line items with descriptions), specify a custom `itemHeight` value to match your item's actual height.
+By default, item height matches the menu row for each size: 32px (`sm`), 40px (`md`), 48px (`lg`, `xl`). Set `itemHeight` when custom slots change row height.
 
 <FileSource src="/framed/Dropdown/VirtualizeItemHeight" />
 

--- a/docs/src/pages/components/MultiSelect.svx
+++ b/docs/src/pages/components/MultiSelect.svx
@@ -319,6 +319,6 @@ Specify a custom value for `threshold` to control when virtualization activates.
 
 ## Virtualized items (custom item height)
 
-The default item height for virtualization is 40 pixels. When using custom slots to render items with different heights (for example, multi-line items with descriptions), specify a custom `itemHeight` value to match your item's actual height.
+By default, item height matches the menu row for each size: 32px (`sm`), 40px (`md`), 48px (`lg`, `xl`). Set `itemHeight` when custom slots change row height.
 
 <FileSource src="/framed/MultiSelect/VirtualizeItemHeight" />

--- a/src/ComboBox/ComboBox.svelte
+++ b/src/ComboBox/ComboBox.svelte
@@ -188,7 +188,7 @@
    * Set `virtualize={true}` to explicitly enable virtualization with default settings.
    *
    * Provide an object to customize virtualization behavior:
-   * - `itemHeight` (default: 40): The height in pixels of each item. Specify a custom value when using custom slots with multi-line items or different heights.
+   * - `itemHeight` (default: 40 for md, adjusted for size): Height of each item in pixels. Override when custom slots change row height.
    * - `containerHeight` (default: 300): The maximum height in pixels of the dropdown container.
    * - `overscan` (default: 3): The number of extra items to render above and below the viewport for smoother scrolling. Higher values may cause more flickering during very fast scrolling.
    * - `threshold` (default: 100): The minimum number of items required before virtualization activates. Lists with fewer items will render all items normally without virtualization.
@@ -214,7 +214,10 @@
   import ListBoxMenuIcon from "../ListBox/ListBoxMenuIcon.svelte";
   import ListBoxMenuItem from "../ListBox/ListBoxMenuItem.svelte";
   import ListBoxSelection from "../ListBox/ListBoxSelection.svelte";
-  import { getMenuMaxHeight } from "../ListBox/list-box-utils.js";
+  import {
+    getMenuItemHeight,
+    getMenuMaxHeight,
+  } from "../ListBox/list-box-utils.js";
   import { isOutsideClick } from "../utils/isOutsideClick.js";
   import { nextEnabledIndex } from "../utils/moveIndex.js";
   import {
@@ -441,6 +444,7 @@
     scrollTop: listScrollTop,
     shouldVirtualize,
     virtualize,
+    defaults: { itemHeight: getMenuItemHeight(size) },
   });
   $: virtualConfig = virtualState.config;
   $: virtualData = virtualState.data;

--- a/src/Dropdown/Dropdown.svelte
+++ b/src/Dropdown/Dropdown.svelte
@@ -111,7 +111,7 @@
    * Set `virtualize={true}` to explicitly enable virtualization with default settings.
    *
    * Provide an object to customize virtualization behavior:
-   * - `itemHeight` (default: 40): The height in pixels of each item. Specify a custom value when using custom slots with multi-line items or different heights.
+   * - `itemHeight` (default: 40 for md, adjusted for size): Height of each item in pixels. Override when custom slots change row height.
    * - `containerHeight` (default: 300): The maximum height in pixels of the dropdown container.
    * - `overscan` (default: 3): The number of extra items to render above and below the viewport for smoother scrolling. Higher values may cause more flickering during very fast scrolling.
    * - `threshold` (default: 100): The minimum number of items required before virtualization activates. Lists with fewer items will render all items normally without virtualization.
@@ -166,7 +166,10 @@
     ListBoxMenuIcon,
     ListBoxMenuItem,
   } from "../ListBox";
-  import { getMenuMaxHeight } from "../ListBox/list-box-utils.js";
+  import {
+    getMenuItemHeight,
+    getMenuMaxHeight,
+  } from "../ListBox/list-box-utils.js";
   import { debounce } from "../utils/debounce.js";
   import { dismiss } from "../utils/dismiss.js";
   import { isOutsideClick } from "../utils/isOutsideClick.js";
@@ -248,6 +251,7 @@
     scrollTop: listScrollTop,
     shouldVirtualize,
     virtualize,
+    defaults: { itemHeight: getMenuItemHeight(size) },
   });
   $: virtualConfig = virtualState.config;
   $: virtualData = virtualState.data;

--- a/src/ListBox/list-box-utils.d.ts
+++ b/src/ListBox/list-box-utils.d.ts
@@ -14,3 +14,20 @@ export declare const MENU_MAX_HEIGHT: Readonly<{
 export declare function getMenuMaxHeight(
   size?: "sm" | "md" | "lg" | "xl",
 ): string;
+
+/** Menu item heights (px) by size */
+export declare const MENU_ITEM_HEIGHT: Readonly<{
+  sm: number;
+  md: number;
+  lg: number;
+  xl: number;
+}>;
+
+/**
+ * Get the menu item height in pixels for a listbox/dropdown size.
+ * @param size - The size variant (defaults to "md" when undefined)
+ * @returns The item height in pixels
+ */
+export declare function getMenuItemHeight(
+  size?: "sm" | "md" | "lg" | "xl",
+): number;

--- a/src/ListBox/list-box-utils.js
+++ b/src/ListBox/list-box-utils.js
@@ -17,3 +17,24 @@ export const MENU_MAX_HEIGHT = Object.freeze({
 export function getMenuMaxHeight(size = "md") {
   return MENU_MAX_HEIGHT[size];
 }
+
+/**
+ * Menu item heights (px) by size. Matches `.bx--list-box__menu-item` in
+ * carbon-components (sm 2rem, md 2.5rem, lg/xl 3rem).
+ * @type {Readonly<{ sm: number; md: number; lg: number; xl: number }>}
+ */
+export const MENU_ITEM_HEIGHT = Object.freeze({
+  sm: 32,
+  md: 40,
+  lg: 48,
+  xl: 48,
+});
+
+/**
+ * Get the menu item height in pixels for a listbox/dropdown size.
+ * @param {"sm" | "md" | "lg" | "xl"} [size] - The size variant
+ * @returns {number} The item height in pixels
+ */
+export function getMenuItemHeight(size = "md") {
+  return MENU_ITEM_HEIGHT[size] ?? MENU_ITEM_HEIGHT.md;
+}

--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -216,7 +216,7 @@
    * Set `virtualize={true}` to explicitly enable virtualization with default settings.
    *
    * Provide an object to customize virtualization behavior:
-   * - `itemHeight` (default: 40): The height in pixels of each item. Specify a custom value when using custom slots with multi-line items or different heights.
+   * - `itemHeight` (default: 40 for md, adjusted for size): Height of each item in pixels. Override when custom slots change row height.
    * - `containerHeight` (default: 300): The maximum height in pixels of the dropdown container.
    * - `overscan` (default: 3): The number of extra items to render above and below the viewport for smoother scrolling. Higher values may cause more flickering during very fast scrolling.
    * - `threshold` (default: 100): The minimum number of items required before virtualization activates. Lists with fewer items will render all items normally without virtualization.
@@ -258,7 +258,10 @@
     ListBoxMenuItem,
     ListBoxSelection,
   } from "../ListBox";
-  import { getMenuMaxHeight } from "../ListBox/list-box-utils.js";
+  import {
+    getMenuItemHeight,
+    getMenuMaxHeight,
+  } from "../ListBox/list-box-utils.js";
   import { dismiss } from "../utils/dismiss.js";
   import { isOutsideClick } from "../utils/isOutsideClick.js";
   import { nextEnabledIndex } from "../utils/moveIndex.js";
@@ -571,6 +574,7 @@
     scrollTop: listScrollTop,
     shouldVirtualize,
     virtualize,
+    defaults: { itemHeight: getMenuItemHeight(size) },
   });
   $: virtualConfig = virtualState.config;
   $: virtualData = virtualState.data;

--- a/tests/ComboBox/ComboBox.test.ts
+++ b/tests/ComboBox/ComboBox.test.ts
@@ -1781,6 +1781,41 @@ describe("ComboBox", () => {
       expect(options.length).toBeLessThan(15);
     });
 
+    it("should default itemHeight to the size row height", async () => {
+      const largeItems = createLargeItemList(500);
+      render(ComboBox, {
+        props: {
+          items: largeItems,
+          size: "sm",
+          virtualize: true,
+        },
+      });
+
+      await user.click(getInput());
+
+      const menu = screen.getAllByRole("listbox")[1];
+      // 500 items at 32px (sm), spacer height 16000px
+      const spacer = menu.querySelector<HTMLElement>(":scope > div");
+      expect(spacer?.style.height).toBe("16000px");
+    });
+
+    it("should use explicit itemHeight instead of the size default", async () => {
+      const largeItems = createLargeItemList(500);
+      render(ComboBox, {
+        props: {
+          items: largeItems,
+          size: "sm",
+          virtualize: { itemHeight: 50 },
+        },
+      });
+
+      await user.click(getInput());
+
+      const menu = screen.getAllByRole("listbox")[1];
+      const spacer = menu.querySelector<HTMLElement>(":scope > div");
+      expect(spacer?.style.height).toBe("25000px");
+    });
+
     it("should maintain selection when virtualized", async () => {
       const largeItems = createLargeItemList(500);
       render(ComboBox, {

--- a/tests/Dropdown/Dropdown.test.ts
+++ b/tests/Dropdown/Dropdown.test.ts
@@ -1274,6 +1274,25 @@ describe("Dropdown", () => {
       });
     });
 
+    it("should default itemHeight to the size row height", async () => {
+      const largeItems = createLargeItemList(500);
+      render(Dropdown, {
+        props: {
+          items: largeItems,
+          selectedId: "0",
+          size: "sm",
+          virtualize: true,
+        },
+      });
+
+      await user.click(screen.getByRole("combobox"));
+
+      const menu = screen.getByRole("listbox");
+      // 500 items at 32px (sm), spacer height 16000px
+      const spacer = menu.querySelector<HTMLElement>(":scope > div");
+      expect(spacer?.style.height).toBe("16000px");
+    });
+
     it("should accept virtualization configuration object", async () => {
       const largeItems = createLargeItemList(500);
       render(Dropdown, {

--- a/tests/ListBox/list-box-utils.test.ts
+++ b/tests/ListBox/list-box-utils.test.ts
@@ -1,5 +1,7 @@
 import {
+  getMenuItemHeight,
   getMenuMaxHeight,
+  MENU_ITEM_HEIGHT,
   MENU_MAX_HEIGHT,
 } from "../../src/ListBox/list-box-utils.js";
 
@@ -17,5 +19,27 @@ describe("getMenuMaxHeight", () => {
     expect(getMenuMaxHeight("md")).toBe("13.75rem");
     expect(getMenuMaxHeight("lg")).toBe("16.5rem");
     expect(getMenuMaxHeight("xl")).toBe("16.5rem");
+  });
+});
+
+describe("getMenuItemHeight", () => {
+  it("returns default when size is undefined (optional size guard)", () => {
+    expect(getMenuItemHeight(undefined)).toBe(MENU_ITEM_HEIGHT.md);
+  });
+
+  it("returns default when called with no args", () => {
+    expect(getMenuItemHeight()).toBe(MENU_ITEM_HEIGHT.md);
+  });
+
+  it("returns correct value for each size", () => {
+    expect(getMenuItemHeight("sm")).toBe(32);
+    expect(getMenuItemHeight("md")).toBe(40);
+    expect(getMenuItemHeight("lg")).toBe(48);
+    expect(getMenuItemHeight("xl")).toBe(48);
+  });
+
+  it("returns default for an unknown size", () => {
+    // @ts-expect-error - exercising the runtime fallback
+    expect(getMenuItemHeight("xxl")).toBe(MENU_ITEM_HEIGHT.md);
   });
 });

--- a/tests/MultiSelect/MultiSelect.test.svelte
+++ b/tests/MultiSelect/MultiSelect.test.svelte
@@ -12,6 +12,7 @@
   export let labelText = "";
   export let hideLabel = false;
   export let light = false;
+  export let size: ComponentProps<MultiSelect>["size"] = undefined;
   export let type: ComponentProps<MultiSelect>["type"] = "default";
   export let invalid = false;
   export let invalidText = "";
@@ -47,6 +48,7 @@
   {labelText}
   {hideLabel}
   {light}
+  {size}
   {type}
   {invalid}
   {invalidText}

--- a/tests/MultiSelect/MultiSelect.test.ts
+++ b/tests/MultiSelect/MultiSelect.test.ts
@@ -1741,6 +1741,24 @@ describe("MultiSelect", () => {
       expect(options.length).toBeGreaterThan(0);
     });
 
+    it("should default itemHeight to the size row height", async () => {
+      const largeItems = createLargeItemList(500);
+      render(MultiSelect, {
+        props: {
+          items: largeItems,
+          size: "sm",
+          virtualize: true,
+        },
+      });
+
+      await openMenu();
+
+      const menu = screen.getByRole("listbox");
+      // 500 items at 32px (sm), spacer height 16000px
+      const spacer = menu.querySelector<HTMLElement>(":scope > div");
+      expect(spacer?.style.height).toBe("16000px");
+    });
+
     it.each([
       { virtualize: true, description: "with explicit virtualization" },
       {


### PR DESCRIPTION
Virtualized `ComboBox`, `Dropdown`, and `MultiSelect` menus now derive their default item height from `size`.

The virtualization helper hardcoded `itemHeight` to 40px, which only matches Carbon's `md` row. With `size="sm"` (32px) or `size="lg"`/`"xl"` (48px), every height calculation drifted. The spacer (`totalHeight`) and `offsetY` were computed from 40px while real rows rendered at a different height, so rows overlapped or left gaps, and scroll-into-view (on open and on keyboard navigation) landed on the wrong row. `getMenuMaxHeight(size)` was already size-aware in the non-virtualized path, but `itemHeight` never was.

Note: `DataTable` is unaffected. It already derives row height from `size` via its own `DEFAULT_ROW_HEIGHTS` map and does not use the shared listbox helper.
