### PR TITLE
fix(utils): harden virtualization range math and edge cases

### DIFF
--- a/src/ComboBox/ComboBox.svelte
+++ b/src/ComboBox/ComboBox.svelte
@@ -323,6 +323,7 @@
             itemHeight: virtualConfig.itemHeight,
             containerHeight: virtualConfig.containerHeight,
             overscan: virtualConfig.overscan ?? 3,
+            maxItems: virtualConfig.maxItems,
           });
           if (nextScrollTop !== null) {
             listScrollTop = nextScrollTop;

--- a/src/Dropdown/Dropdown.svelte
+++ b/src/Dropdown/Dropdown.svelte
@@ -277,6 +277,7 @@
             itemHeight: virtualConfig.itemHeight,
             containerHeight: virtualConfig.containerHeight,
             overscan: virtualConfig.overscan ?? 3,
+            maxItems: virtualConfig.maxItems,
           });
           if (nextScrollTop !== null) {
             listScrollTop = nextScrollTop;

--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -415,6 +415,7 @@
             itemHeight: virtualConfig.itemHeight,
             containerHeight: virtualConfig.containerHeight,
             overscan: virtualConfig.overscan ?? 3,
+            maxItems: virtualConfig.maxItems,
           });
           if (nextScrollTop !== null) {
             listScrollTop = nextScrollTop;

--- a/src/utils/virtualize.d.ts
+++ b/src/utils/virtualize.d.ts
@@ -98,6 +98,7 @@ export type ScrollHighlightedIntoViewOptions = {
   containerHeight: number;
   /** @default 3 */
   overscan?: number;
+  maxItems?: number;
 };
 
 /**

--- a/src/utils/virtualize.d.ts
+++ b/src/utils/virtualize.d.ts
@@ -23,6 +23,22 @@ export type VirtualizeResult<
   isVirtualized: boolean;
 };
 
+export type GetVisibleRangeOptions = {
+  scrollTop: number;
+  itemHeight: number;
+  containerHeight: number;
+  itemCount: number;
+  /** @default 3 */
+  overscan?: number;
+  maxItems?: number;
+};
+
+/** Compute the `[startIndex, endIndex)` slice of items to render. */
+export function getVisibleRange(options: GetVisibleRangeOptions): {
+  startIndex: number;
+  endIndex: number;
+};
+
 /** Render only the visible slice of a fixed-height list. */
 export function virtualize<
   Item extends Record<string, unknown> = Record<string, unknown>,

--- a/src/utils/virtualize.js
+++ b/src/utils/virtualize.js
@@ -62,13 +62,15 @@ export function virtualize({
   maxItems = undefined,
   threshold = 100,
 }) {
-  if (items.length < threshold) {
+  // A non-positive itemHeight can't be virtualized (the math divides by it and
+  // yields NaN indices), so render the full list unvirtualized.
+  if (items.length < threshold || itemHeight <= 0) {
     return {
       visibleItems: items,
       startIndex: 0,
       endIndex: items.length,
       offsetY: 0,
-      totalHeight: items.length * itemHeight,
+      totalHeight: itemHeight > 0 ? items.length * itemHeight : 0,
       isVirtualized: false,
     };
   }

--- a/src/utils/virtualize.js
+++ b/src/utils/virtualize.js
@@ -1,4 +1,38 @@
 /**
+ * Compute the `[startIndex, endIndex)` slice of items to render for a given
+ * scroll position, including `overscan` padding and an optional `maxItems` cap.
+ *
+ * @param {Object} options
+ * @param {number} options.scrollTop
+ * @param {number} options.itemHeight
+ * @param {number} options.containerHeight
+ * @param {number} options.itemCount
+ * @param {number} [options.overscan=3]
+ * @param {number} [options.maxItems]
+ * @returns {{ startIndex: number, endIndex: number }}
+ */
+export function getVisibleRange({
+  scrollTop,
+  itemHeight,
+  containerHeight,
+  itemCount,
+  overscan = 3,
+  maxItems = undefined,
+}) {
+  const startIndex = Math.max(0, Math.floor(scrollTop / itemHeight) - overscan);
+  let endIndex = Math.min(
+    itemCount,
+    Math.ceil((scrollTop + containerHeight) / itemHeight) + overscan,
+  );
+
+  if (maxItems && endIndex - startIndex > maxItems) {
+    endIndex = startIndex + maxItems;
+  }
+
+  return { startIndex, endIndex };
+}
+
+/**
  * Render only the visible slice of a fixed-height list.
  *
  * @template {Record<string, unknown>} Item
@@ -48,18 +82,14 @@ export function virtualize({
   const maxScroll = Math.max(0, totalHeight - containerHeight);
   const clampedScrollTop = Math.min(Math.max(0, scrollTop), maxScroll);
 
-  const startIndex = Math.max(
-    0,
-    Math.floor(clampedScrollTop / itemHeight) - overscan,
-  );
-  let endIndex = Math.min(
-    items.length,
-    Math.ceil((clampedScrollTop + containerHeight) / itemHeight) + overscan,
-  );
-
-  if (maxItems && endIndex - startIndex > maxItems) {
-    endIndex = startIndex + maxItems;
-  }
+  const { startIndex, endIndex } = getVisibleRange({
+    scrollTop: clampedScrollTop,
+    itemHeight,
+    containerHeight,
+    itemCount: items.length,
+    overscan,
+    maxItems,
+  });
 
   const offsetY = startIndex * itemHeight;
 
@@ -163,14 +193,14 @@ export function scrollHighlightedIntoView({
   containerHeight,
   overscan = 3,
 }) {
-  const visibleStartIndex = Math.max(
-    0,
-    Math.floor(currentScrollTop / itemHeight) - overscan,
-  );
-  const visibleEndIndex = Math.min(
-    itemCount,
-    Math.ceil((currentScrollTop + containerHeight) / itemHeight) + overscan,
-  );
+  const { startIndex: visibleStartIndex, endIndex: visibleEndIndex } =
+    getVisibleRange({
+      scrollTop: currentScrollTop,
+      itemHeight,
+      containerHeight,
+      itemCount,
+      overscan,
+    });
 
   if (
     highlightedIndex < visibleStartIndex ||

--- a/src/utils/virtualize.js
+++ b/src/utils/virtualize.js
@@ -183,6 +183,7 @@ export function getBoundedScrollTop({
  * @param {number} options.itemHeight
  * @param {number} options.containerHeight
  * @param {number} [options.overscan=3]
+ * @param {number} [options.maxItems]
  * @returns {number | null}
  */
 export function scrollHighlightedIntoView({
@@ -192,6 +193,7 @@ export function scrollHighlightedIntoView({
   itemHeight,
   containerHeight,
   overscan = 3,
+  maxItems = undefined,
 }) {
   const { startIndex: visibleStartIndex, endIndex: visibleEndIndex } =
     getVisibleRange({
@@ -200,6 +202,7 @@ export function scrollHighlightedIntoView({
       containerHeight,
       itemCount,
       overscan,
+      maxItems,
     });
 
   if (

--- a/tests/utils/virtualize.test.ts
+++ b/tests/utils/virtualize.test.ts
@@ -618,6 +618,27 @@ describe("scrollHighlightedIntoView", () => {
       }),
     ).toBeNull();
   });
+
+  test("scrolls to an item inside the raw viewport but beyond the maxItems cap", () => {
+    // scrollTop 0 raw range is [0, 11), but maxItems caps the rendered window
+    // to [0, 5). Item 7 looks visible to the raw formula yet is not rendered.
+    expect(
+      scrollHighlightedIntoView({
+        ...base,
+        highlightedIndex: 7,
+        currentScrollTop: 0,
+        maxItems: 5,
+      }),
+    ).toBe(280);
+    // Without the cap the same item is treated as already visible.
+    expect(
+      scrollHighlightedIntoView({
+        ...base,
+        highlightedIndex: 7,
+        currentScrollTop: 0,
+      }),
+    ).toBeNull();
+  });
 });
 
 describe("scrollSelectedIntoView", () => {

--- a/tests/utils/virtualize.test.ts
+++ b/tests/utils/virtualize.test.ts
@@ -361,7 +361,7 @@ describe("virtualize", () => {
     expect(result.isVirtualized).toBe(true);
   });
 
-  test("should handle zero item height", () => {
+  test("falls back to unvirtualized for a non-positive item height", () => {
     const items = Array.from({ length: 500 }, (_, i) => ({
       id: i,
       name: `Item ${i}`,
@@ -374,11 +374,14 @@ describe("virtualize", () => {
       threshold: 100,
     });
 
+    // A zero height can't be virtualized, so render every item with no offset
+    // rather than producing NaN indices and a blank slice.
+    expect(result.isVirtualized).toBe(false);
+    expect(result.visibleItems).toBe(items);
+    expect(result.startIndex).toBe(0);
+    expect(result.endIndex).toBe(500);
+    expect(result.offsetY).toBe(0);
     expect(result.totalHeight).toBe(0);
-    // Division by zero results in NaN for offsetY (0/0 = NaN)
-    expect(Number.isNaN(result.offsetY) || result.offsetY >= 0).toBe(true);
-    // With zero height, calculation produces NaN but function still returns
-    expect(result.isVirtualized).toBe(true);
   });
 
   test("should handle zero container height", () => {

--- a/tests/utils/virtualize.test.ts
+++ b/tests/utils/virtualize.test.ts
@@ -1,5 +1,6 @@
 import {
   getBoundedScrollTop,
+  getVisibleRange,
   resetVirtualScrollOnClose,
   scrollHighlightedIntoView,
   scrollSelectedIntoView,
@@ -469,6 +470,46 @@ describe("virtualListState", () => {
 
     expect(result.data?.isVirtualized).toBe(false);
     expect(result.itemsToRender).toBe(items);
+  });
+});
+
+describe("getVisibleRange", () => {
+  const base = {
+    itemHeight: 40,
+    containerHeight: 300,
+    itemCount: 500,
+  };
+
+  test("clamps startIndex to 0 with overscan at the top", () => {
+    expect(getVisibleRange({ ...base, scrollTop: 0 })).toEqual({
+      startIndex: 0,
+      endIndex: Math.ceil(300 / 40) + 3,
+    });
+  });
+
+  test("offsets the range by scroll position", () => {
+    // scrollTop 2000 => floor(50) - 3 = 47 start.
+    const { startIndex, endIndex } = getVisibleRange({
+      ...base,
+      scrollTop: 2000,
+    });
+    expect(startIndex).toBe(47);
+    expect(endIndex).toBe(Math.ceil((2000 + 300) / 40) + 3);
+  });
+
+  test("clamps endIndex to itemCount", () => {
+    const { endIndex } = getVisibleRange({
+      ...base,
+      scrollTop: 500 * 40,
+    });
+    expect(endIndex).toBe(500);
+  });
+
+  test("caps the window to maxItems", () => {
+    expect(getVisibleRange({ ...base, scrollTop: 0, maxItems: 5 })).toEqual({
+      startIndex: 0,
+      endIndex: 5,
+    });
   });
 });
 


### PR DESCRIPTION
Hardens the shared list-virtualization utilities behind ComboBox, Dropdown, and MultiSelect.

- Extracts a single `getVisibleRange` helper so `virtualize()` and `scrollHighlightedIntoView()` compute the rendered window from one place instead of two drifting copies. 
- scrollHighlightedIntoView()` now applies the same `maxItems` cap that `virtualize()` renders, so keyboard navigation no longer treats a capped-out item as already visible and fails to scroll.
- `virtualize()` falls back to rendering the full list unvirtualized when `itemHeight` is non-positive, instead of dividing by it and producing `NaN` indices and a blank menu.