### PR TITLE
docs: dogfood `carbon-preprocess-svelte`

### DIFF
--- a/docs/bun.lock
+++ b/docs/bun.lock
@@ -8,6 +8,7 @@
         "@sveltejs/vite-plugin-svelte": "^7.1.2",
         "@types/prismjs": "^1.26.5",
         "carbon-icons-svelte": "^13.12.0",
+        "carbon-preprocess-svelte": "^0.11.35",
         "clipboard-copy": "^4.0.1",
         "estree-walker": "^3.0.3",
         "github-slugger": "^2.0.0",
@@ -108,6 +109,8 @@
     "cachewrap": ["cachewrap@0.0.1", "", {}, "sha512-MumTMQ26KmLvWKnECZvoX+7tVGNOplDL4ls1z+xLkpZKCjuvv4t6QvrpqcsCAPfHoqerz0FEfWa6KXVHYylbJA=="],
 
     "carbon-icons-svelte": ["carbon-icons-svelte@13.12.0", "", {}, "sha512-VK/gSvzCEe3tNEHS2xAcih/GBuygHuUenV+EY/44A3nyYjk+MCbgpY20uwID8/81gEUxIkl4rA/EMRWb/3qs0A=="],
+
+    "carbon-preprocess-svelte": ["carbon-preprocess-svelte@0.11.35", "", {}, "sha512-h079aj+v2ErU7FX88fDrPTQ9x1NkUxM7Hz/z2flgWudNuEDm0eOSpHUWrYPFkknxmX+ZrldtQpxnOCoavFmPQA=="],
 
     "cheap-watch": ["cheap-watch@1.0.4", "", {}, "sha512-QR/9FrtRL5fjfUJBhAKCdi0lSRQ3rVRRum3GF9wDKp2TJbEIMGhUEr2yU8lORzm9Isdjx7/k9S0DFDx+z5VGtw=="],
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -17,6 +17,7 @@
     "@sveltejs/vite-plugin-svelte": "^7.1.2",
     "@types/prismjs": "^1.26.5",
     "carbon-icons-svelte": "^13.12.0",
+    "carbon-preprocess-svelte": "^0.11.35",
     "clipboard-copy": "^4.0.1",
     "estree-walker": "^3.0.3",
     "github-slugger": "^2.0.0",

--- a/docs/svelte.config.ts
+++ b/docs/svelte.config.ts
@@ -18,6 +18,7 @@ import "prismjs/components/prism-clike.js";
 import "prismjs/components/prism-javascript.js";
 import "prismjs/components/prism-typescript.js";
 import "prism-svelte";
+import { optimizeImports } from "carbon-preprocess-svelte";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -443,6 +444,7 @@ function carbonify() {
 export default {
   extensions: [".svelte", ".svx"],
   preprocess: [
+    optimizeImports({ optimistic: false }),
     mdsvex({
       smartypants: false,
       highlight: { highlighter: mdsvexPrismHighlighter },

--- a/docs/vite.config.ts
+++ b/docs/vite.config.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import routify from "@roxi/routify/vite-plugin";
 import { svelte } from "@sveltejs/vite-plugin-svelte";
+import { optimizeCss, } from "carbon-preprocess-svelte";
 import { defineConfig } from "vite";
 import pkg from "../package.json" with { type: "json" };
 
@@ -54,6 +55,7 @@ export default defineConfig({
         return { build: { outDir } };
       },
     },
+    optimizeCss({ experimental: { strict: true }})
   ],
   define: {
     __PKG_VERSION: JSON.stringify(pkg.version),


### PR DESCRIPTION
Only for internal reference/testing.

This won't work from a practical standpoint, since new components that have custom CSS won't benefit from `optimizeCss`, which analyzes the structure AOT.