### PR TITLE
docs: skip `svelte:*` elements in snippet import injection

### DIFF
--- a/docs/scripts/generate-md-docs.ts
+++ b/docs/scripts/generate-md-docs.ts
@@ -458,6 +458,7 @@ function injectImportsIntoSvelteSnippet(code: string): string {
 
     walkLegacySvelteNode(root, (node) => {
       if (node.type === "InlineComponent" && typeof node.name === "string") {
+        if (node.name.startsWith("svelte:")) return;
         if (isIconName(node.name)) icons.add(node.name);
         else inlineComponents.add(node.name);
       } else if (node.type === "MustacheTag") {

--- a/docs/svelte.config.ts
+++ b/docs/svelte.config.ts
@@ -137,6 +137,7 @@ function createImportsUncached(source: string) {
           usesDocKbd = true;
           return;
         }
+        if (n.name.startsWith("svelte:")) return;
         if (isIcon(n.name)) {
           icons.add(n.name);
         } else {


### PR DESCRIPTION
Doc import scanners treated `<svelte:component>` as a Carbon component, producing invalid `import { …, svelte:component }` and Prettier SyntaxError noise during md-docs and Vite builds.

<img width="676" height="252" alt="Screenshot 2026-06-09 at 5 49 13 PM" src="https://github.com/user-attachments/assets/d0b607d4-48a2-42be-8388-025c21008cd8" />
