### PR TITLE
perf: apply `dismiss` action to `Slider`, `RangeSlider`, `ContextMenu`

### DIFF
--- a/src/ContextMenu/ContextMenuOption.svelte
+++ b/src/ContextMenu/ContextMenuOption.svelte
@@ -83,6 +83,7 @@
   import CaretRight from "../icons/CaretRight.svelte";
   import Checkmark from "../icons/Checkmark.svelte";
   import { clampIndex } from "../utils/clampIndex.js";
+  import { dismiss } from "../utils/dismiss.js";
   import ContextMenu from "./ContextMenu.svelte";
 
   const dispatch = createEventDispatcher();
@@ -302,10 +303,14 @@
   }
 </script>
 
-<svelte:window on:mousemove|passive={handleGlobalMouseMove} />
-
 <li
   bind:this={ref}
+  use:dismiss={{
+    enabled: !!subOptions && submenuOpen,
+    type: "mousemove",
+    handler: handleGlobalMouseMove,
+    options: { passive: true },
+  }}
   {role}
   tabindex="-1"
   aria-disabled={disabled}

--- a/src/Slider/RangeSlider.svelte
+++ b/src/Slider/RangeSlider.svelte
@@ -109,6 +109,7 @@
   import { createEventDispatcher } from "svelte";
   import WarningAltFilled from "../icons/WarningAltFilled.svelte";
   import WarningFilled from "../icons/WarningFilled.svelte";
+  import { dismiss } from "../utils/dismiss.js";
 
   /** @typedef {{ value: number; valueUpper: number }} RangeSliderChangeDetail */
   /** @typedef {"lower" | "upper"} ActiveHandle */
@@ -264,18 +265,20 @@
   }
 </script>
 
-<svelte:window
-  on:mousemove|passive={move}
-  on:touchmove|passive={move}
-  on:mouseup={stopHolding}
-  on:touchend={stopHolding}
-  on:touchcancel={stopHolding}
-/>
-
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <!-- svelte-ignore a11y-no-static-element-interactions -->
 <div
   class:bx--form-item={true}
+  use:dismiss={{
+    enabled: holding,
+    listeners: [
+      { type: "mousemove", handler: move, options: { passive: true } },
+      { type: "touchmove", handler: move, options: { passive: true } },
+      { type: "mouseup", handler: stopHolding },
+      { type: "touchend", handler: stopHolding },
+      { type: "touchcancel", handler: stopHolding },
+    ],
+  }}
   {...$$restProps}
   on:click
   on:mouseover

--- a/src/Slider/Slider.svelte
+++ b/src/Slider/Slider.svelte
@@ -94,6 +94,7 @@
   import { createEventDispatcher } from "svelte";
   import WarningAltFilled from "../icons/WarningAltFilled.svelte";
   import WarningFilled from "../icons/WarningFilled.svelte";
+  import { dismiss } from "../utils/dismiss.js";
 
   const dispatch = createEventDispatcher();
 
@@ -168,18 +169,20 @@
   }
 </script>
 
-<svelte:window
-  on:mousemove|passive={move}
-  on:touchmove|passive={move}
-  on:mouseup={stopHolding}
-  on:touchend={stopHolding}
-  on:touchcancel={stopHolding}
-/>
-
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <!-- svelte-ignore a11y-no-static-element-interactions -->
 <div
   class:bx--form-item={true}
+  use:dismiss={{
+    enabled: holding,
+    listeners: [
+      { type: "mousemove", handler: move, options: { passive: true } },
+      { type: "touchmove", handler: move, options: { passive: true } },
+      { type: "mouseup", handler: stopHolding },
+      { type: "touchend", handler: stopHolding },
+      { type: "touchcancel", handler: stopHolding },
+    ],
+  }}
   {...$$restProps}
   on:click
   on:mouseover

--- a/tests/ContextMenu/ContextMenuWindowListeners.test.ts
+++ b/tests/ContextMenu/ContextMenuWindowListeners.test.ts
@@ -1,4 +1,5 @@
-import { render } from "@testing-library/svelte";
+import { fireEvent, render, screen } from "@testing-library/svelte";
+import { tick } from "svelte";
 import ContextMenu from "./ContextMenu.test.svelte";
 
 const net = (
@@ -32,6 +33,22 @@ describe("ContextMenu window listeners", () => {
     render(ContextMenu, { props: { open: true } });
     expect(net(add, remove, "click")).toBe(1);
     expect(net(add, remove, "keydown")).toBe(1);
+
+    add.mockRestore();
+    remove.mockRestore();
+  });
+
+  test("submenu options register the hover mousemove listener only while open", async () => {
+    const add = vi.spyOn(window, "addEventListener");
+    const remove = vi.spyOn(window, "removeEventListener");
+
+    render(ContextMenu, { props: { open: true, withSubmenu: true } });
+    // The parent option's global mousemove handler is idle until its submenu opens.
+    expect(net(add, remove, "mousemove")).toBe(0);
+
+    await fireEvent.click(screen.getByText("Option with submenu"));
+    await tick();
+    expect(net(add, remove, "mousemove")).toBe(1);
 
     add.mockRestore();
     remove.mockRestore();

--- a/tests/Slider/RangeSliderWindowListeners.test.ts
+++ b/tests/Slider/RangeSliderWindowListeners.test.ts
@@ -1,0 +1,53 @@
+import { fireEvent, render } from "@testing-library/svelte";
+import { tick } from "svelte";
+import RangeSlider from "./RangeSlider.test.svelte";
+
+const net = (
+  add: ReturnType<typeof vi.spyOn>,
+  remove: ReturnType<typeof vi.spyOn>,
+  type: string,
+) =>
+  add.mock.calls.filter((c: unknown[]) => c[0] === type).length -
+  remove.mock.calls.filter((c: unknown[]) => c[0] === type).length;
+
+describe("RangeSlider window listeners", () => {
+  test("idle range sliders register no drag listeners", () => {
+    const add = vi.spyOn(window, "addEventListener");
+    const remove = vi.spyOn(window, "removeEventListener");
+
+    for (let i = 0; i < 5; i++) render(RangeSlider);
+
+    for (const type of ["mousemove", "touchmove", "mouseup", "touchend"]) {
+      expect(net(add, remove, type)).toBe(0);
+    }
+
+    add.mockRestore();
+    remove.mockRestore();
+  });
+
+  test("a drag adds exactly one shared listener per type; releasing removes it", async () => {
+    const add = vi.spyOn(window, "addEventListener");
+    const remove = vi.spyOn(window, "removeEventListener");
+
+    const { container } = render(RangeSlider);
+    expect(net(add, remove, "mousemove")).toBe(0);
+
+    const slider = container.querySelector(".bx--slider");
+    assert(slider instanceof HTMLElement);
+    await fireEvent.mouseDown(slider);
+    await tick();
+
+    expect(net(add, remove, "mousemove")).toBe(1);
+    expect(net(add, remove, "touchmove")).toBe(1);
+    expect(net(add, remove, "mouseup")).toBe(1);
+
+    await fireEvent.mouseUp(window);
+    await tick();
+    for (const type of ["mousemove", "touchmove", "mouseup", "touchend"]) {
+      expect(net(add, remove, type)).toBe(0);
+    }
+
+    add.mockRestore();
+    remove.mockRestore();
+  });
+});

--- a/tests/Slider/SliderWindowListeners.test.ts
+++ b/tests/Slider/SliderWindowListeners.test.ts
@@ -1,0 +1,85 @@
+import { fireEvent, render } from "@testing-library/svelte";
+import { tick } from "svelte";
+import Slider from "./Slider.test.svelte";
+
+const net = (
+  add: ReturnType<typeof vi.spyOn>,
+  remove: ReturnType<typeof vi.spyOn>,
+  type: string,
+) =>
+  add.mock.calls.filter((c: unknown[]) => c[0] === type).length -
+  remove.mock.calls.filter((c: unknown[]) => c[0] === type).length;
+
+describe("Slider window listeners", () => {
+  test("idle sliders register no drag listeners", () => {
+    const add = vi.spyOn(window, "addEventListener");
+    const remove = vi.spyOn(window, "removeEventListener");
+
+    for (let i = 0; i < 5; i++) render(Slider);
+
+    for (const type of ["mousemove", "touchmove", "mouseup", "touchend"]) {
+      expect(net(add, remove, type)).toBe(0);
+    }
+
+    add.mockRestore();
+    remove.mockRestore();
+  });
+
+  test("a drag adds exactly one shared listener per type; releasing removes it", async () => {
+    const add = vi.spyOn(window, "addEventListener");
+    const remove = vi.spyOn(window, "removeEventListener");
+
+    const containers = Array.from(
+      { length: 5 },
+      () => render(Slider).container,
+    );
+    for (const type of ["mousemove", "mouseup"]) {
+      expect(net(add, remove, type)).toBe(0);
+    }
+
+    // Begin a drag on one slider.
+    const sliderA = containers[0].querySelector(".bx--slider");
+    assert(sliderA instanceof HTMLElement);
+    await fireEvent.mouseDown(sliderA);
+    await tick();
+
+    expect(net(add, remove, "mousemove")).toBe(1);
+    expect(net(add, remove, "touchmove")).toBe(1);
+    expect(net(add, remove, "mouseup")).toBe(1);
+
+    // A second concurrent drag still shares the single pooled listener.
+    const sliderB = containers[1].querySelector(".bx--slider");
+    assert(sliderB instanceof HTMLElement);
+    await fireEvent.mouseDown(sliderB);
+    await tick();
+    expect(net(add, remove, "mousemove")).toBe(1);
+
+    // Releasing both ends the drag and tears the shared listeners down.
+    await fireEvent.mouseUp(window);
+    await tick();
+    for (const type of ["mousemove", "touchmove", "mouseup", "touchend"]) {
+      expect(net(add, remove, type)).toBe(0);
+    }
+
+    add.mockRestore();
+    remove.mockRestore();
+  });
+
+  test("move listeners stay passive (scrolling is never blocked)", async () => {
+    const add = vi.spyOn(window, "addEventListener");
+
+    const { container } = render(Slider);
+    const slider = container.querySelector(".bx--slider");
+    assert(slider instanceof HTMLElement);
+    await fireEvent.mouseDown(slider);
+    await tick();
+
+    const moveCall = add.mock.calls.find(
+      (c: unknown[]) => c[0] === "mousemove",
+    );
+    assert(moveCall);
+    expect(moveCall[2]).toMatchObject({ passive: true });
+
+    add.mockRestore();
+  });
+});


### PR DESCRIPTION
Follow-up to #3215 and #3231

Ensure that window event listeners (click outside detection, dragging slider) only register when active/interacted with.