### PR TITLE
perf(combo-box): register outside-click listener only while open

### DIFF
--- a/e2e/combobox.test.ts
+++ b/e2e/combobox.test.ts
@@ -89,6 +89,41 @@ test.describe("ComboBox", () => {
     await expect(outsideLink).toBeFocused();
   });
 
+  test("closes the menu on an outside mouse click", async ({ page }) => {
+    // Real-browser proof for the `use:dismiss` outside-click listener: jsdom
+    // bubbles synthetic clicks differently, so this guards the actual behavior.
+    const combobox = page.getByTestId("combobox-contact");
+    await combobox.click();
+    const menu = page.locator(".bx--list-box__menu");
+    await expect(menu).toBeVisible();
+
+    await page.getByTestId("outside-target").click();
+    await expect(menu).not.toBeVisible();
+  });
+
+  test("clearing with openOnClear reopens without self-closing", async ({
+    page,
+  }) => {
+    // The click that triggers clear({ open: true }) must not bubble to the
+    // outside-click listener and immediately re-close the menu it just opened.
+    // This is the timing-sensitive path that `skipWindowClick` used to guard;
+    // it now relies on the gated listener being absent while the click bubbles.
+    const wrapper = page.getByTestId("combobox-clear-reopen-wrapper");
+    const combobox = wrapper.getByRole("combobox");
+    const menu = wrapper.locator(".bx--list-box__menu");
+    await expect(combobox).toHaveValue("Email");
+
+    await wrapper.getByRole("button", { name: "Clear selected item" }).click();
+
+    await expect(combobox).toHaveValue("");
+    await expect(menu).toBeVisible();
+    await expect(wrapper.getByRole("option")).toHaveCount(3);
+
+    // A genuine outside click now closes it on the first try.
+    await page.getByTestId("outside-target").click();
+    await expect(menu).not.toBeVisible();
+  });
+
   test("selects all text on focus when selectTextOnFocus is true", async ({
     page,
   }) => {

--- a/e2e/fixtures/ComboBoxFixture.svelte
+++ b/e2e/fixtures/ComboBoxFixture.svelte
@@ -13,6 +13,10 @@
   }
 </script>
 
+<!-- Sits above every ComboBox so a downward-opening menu never overlaps it,
+     keeping it clickable as an outside-click target in any state. -->
+<button type="button" data-testid="outside-target">Outside target</button>
+
 <ComboBox
   data-testid="combobox-contact"
   labelText="Contact"
@@ -32,3 +36,16 @@
   selectedId="1"
   value="Email"
 />
+
+<div data-testid="combobox-clear-reopen-wrapper">
+  <ComboBox
+    data-testid="combobox-clear-reopen"
+    labelText="Clear reopen"
+    placeholder="Select"
+    {items}
+    {shouldFilterItem}
+    openOnClear
+    selectedId="1"
+    value="Email"
+  />
+</div>

--- a/src/ComboBox/ComboBox.svelte
+++ b/src/ComboBox/ComboBox.svelte
@@ -221,6 +221,7 @@
     getMenuItemHeight,
     getMenuMaxHeight,
   } from "../ListBox/list-box-utils.js";
+  import { dismiss } from "../utils/dismiss.js";
   import { isOutsideClick } from "../utils/isOutsideClick.js";
   import { nextEnabledIndex } from "../utils/moveIndex.js";
   import {
@@ -236,7 +237,6 @@
   $: effectivePortalMenu =
     portalMenu === undefined ? !!insideModal : portalMenu;
 
-  let skipWindowClick = false;
   let selectedItem = undefined;
   let prevSelectedId = null;
   let highlightedIndex = -1;
@@ -298,7 +298,6 @@
     selectedItem = undefined;
     open = false;
     value = "";
-    if (options?.open === true) skipWindowClick = true;
     // Ensure binding updates are complete before focusing.
     await tick();
     if (options?.open === true) open = true;
@@ -502,21 +501,18 @@
   ]
     .filter(Boolean)
     .join(" ");
-</script>
 
-<svelte:window
-  on:click={(event) => {
-    if (skipWindowClick) {
-      skipWindowClick = false;
-      return;
-    }
+  function handleOutsideClick(event) {
     if (open && isOutsideClick(event, [ref, effectivePortalMenu && listRef])) {
       open = false;
     }
-  }}
-/>
+  }
+</script>
 
-<div class:bx--list-box__wrapper={true}>
+<div
+  class:bx--list-box__wrapper={true}
+  use:dismiss={{ enabled: open, type: "click", handler: handleOutsideClick }}
+>
   {#if labelText || $$slots.labelChildren}
     <label
       for={id}

--- a/tests/ComboBox/ComboBox.test.ts
+++ b/tests/ComboBox/ComboBox.test.ts
@@ -468,6 +468,38 @@ describe("ComboBox", () => {
     expect(options.length).toBe(3);
   });
 
+  it("should close on the first outside click after clearing and reopening from a closed box", async () => {
+    // closed -> open via clear({ open: true }): the gated outside-click
+    // listener is absent while the triggering click bubbles, so it cannot
+    // self-close. The next genuine outside click must close on the first try.
+    render(ComboBoxCustom, { props: { selectedId: "1" } });
+
+    const input = getInput();
+    expect(input).toHaveValue("Email");
+    expect(screen.queryByRole("option")).not.toBeInTheDocument();
+
+    await user.click(screen.getByText("Clear (reopen)"));
+    expect(screen.getAllByRole("option").length).toBe(3);
+
+    await user.click(document.body);
+    expect(screen.queryByRole("option")).not.toBeInTheDocument();
+  });
+
+  it("should keep the menu open when clearing and reopening from an already-open box", async () => {
+    // open -> open via clear({ open: true }): the triggering click must not
+    // close the box that clear() just reopened.
+    render(ComboBoxCustom, { props: { selectedId: "1" } });
+
+    const input = getInput();
+    await user.click(input);
+    // Open with the current selection: the filter narrows to the one match.
+    expect(screen.getByRole("option")).toHaveTextContent("Email");
+
+    await user.click(screen.getByText("Clear (reopen)"));
+    expect(input).toHaveValue("");
+    expect(screen.getAllByRole("option").length).toBe(3);
+  });
+
   it("should not re-focus textbox if clearOptions.focus is false", async () => {
     render(ComboBoxCustom, {
       props: {

--- a/tests/ComboBox/ComboBoxWindowListeners.test.ts
+++ b/tests/ComboBox/ComboBoxWindowListeners.test.ts
@@ -1,0 +1,49 @@
+import { render } from "@testing-library/svelte";
+import { user } from "../utils/user";
+import ComboBox from "./ComboBox.test.svelte";
+
+const netClick = (
+  add: ReturnType<typeof vi.spyOn>,
+  remove: ReturnType<typeof vi.spyOn>,
+) =>
+  add.mock.calls.filter((c: unknown[]) => c[0] === "click").length -
+  remove.mock.calls.filter((c: unknown[]) => c[0] === "click").length;
+
+describe("ComboBox window listeners", () => {
+  test("closed combo boxes register no window click listener", () => {
+    const add = vi.spyOn(window, "addEventListener");
+    const remove = vi.spyOn(window, "removeEventListener");
+
+    for (let i = 0; i < 5; i++) render(ComboBox, { props: { open: false } });
+    expect(netClick(add, remove)).toBe(0);
+
+    add.mockRestore();
+    remove.mockRestore();
+  });
+
+  test("an open combo box registers exactly one window click listener", () => {
+    const add = vi.spyOn(window, "addEventListener");
+    const remove = vi.spyOn(window, "removeEventListener");
+
+    render(ComboBox, { props: { open: true } });
+    expect(netClick(add, remove)).toBe(1);
+
+    add.mockRestore();
+    remove.mockRestore();
+  });
+
+  test("closing a combo box removes the window click listener", async () => {
+    const add = vi.spyOn(window, "addEventListener");
+    const remove = vi.spyOn(window, "removeEventListener");
+
+    render(ComboBox, { props: { open: true } });
+    expect(netClick(add, remove)).toBe(1);
+
+    // An outside click closes the menu, which must tear down the listener.
+    await user.click(document.body);
+    expect(netClick(add, remove)).toBe(0);
+
+    add.mockRestore();
+    remove.mockRestore();
+  });
+});


### PR DESCRIPTION
Related #3215, #3231, #3245

Apply similar event listener optimization to `ComboBox`; only register to the listener if the combo box is actually open. Adds an e2e test since the click behavior is slightly more complex in `ComboBox`.

For example, https://svelte.carbondesignsystem.com/components/ComboBox goes from 20 click event listeners to 0.