### PR TITLE
perf(date-picker): register outside-click listener only while calendar is open

### DIFF
--- a/e2e/date-picker-top-layer.test.ts
+++ b/e2e/date-picker-top-layer.test.ts
@@ -67,6 +67,22 @@ test.describe("DatePicker inside native dialog", () => {
       expect(Math.min(distanceBelow, distanceAbove)).toBeLessThan(32);
     }
   });
+
+  test("clicking inside the portaled calendar keeps it open", async ({
+    page,
+  }) => {
+    await page.getByTestId("dialog-date-picker-portal-input").click();
+
+    const calendar = page
+      .getByTestId("native-dialog")
+      .locator(".flatpickr-calendar.open");
+    await expect(calendar).toBeVisible();
+
+    // Calendar is portaled outside the input tree. Month nav click should not
+    // close it. Modal dialogs have no outside-click target; Escape closes.
+    await calendar.locator(".flatpickr-months").click();
+    await expect(calendar).toHaveClass(/open/);
+  });
 });
 
 test.describe("DatePicker inside native [popover]", () => {
@@ -130,5 +146,38 @@ test.describe("DatePicker inside native [popover]", () => {
       );
       expect(Math.min(distanceBelow, distanceAbove)).toBeLessThan(32);
     }
+  });
+
+  test("clicking inside the portaled calendar keeps it open", async ({
+    page,
+  }) => {
+    await page.getByTestId("popover-date-picker-portal-input").focus();
+
+    const calendar = page
+      .getByTestId("native-popover")
+      .locator(".flatpickr-calendar.open");
+    await expect(calendar).toBeVisible();
+
+    await calendar.locator(".flatpickr-months").click();
+    await expect(calendar).toHaveClass(/open/);
+  });
+
+  test("clicking the page outside the popover closes the calendar", async ({
+    page,
+  }) => {
+    await page.getByTestId("popover-date-picker-portal-input").focus();
+
+    // No `.open` filter: locator must still resolve after the calendar closes.
+    const calendar = page
+      .getByTestId("native-popover")
+      .locator(".flatpickr-calendar");
+    await expect(calendar).toHaveClass(/open/);
+
+    // Non-modal popover: click a viewport corner, away from the popover and
+    // page triggers.
+    const viewport = page.viewportSize();
+    if (!viewport) throw new Error("expected a viewport size");
+    await page.mouse.click(viewport.width - 5, viewport.height - 5);
+    await expect(calendar).not.toHaveClass(/open/);
   });
 });

--- a/e2e/date-picker.test.ts
+++ b/e2e/date-picker.test.ts
@@ -128,6 +128,18 @@ test.describe("DatePicker", () => {
     await expect(calendar).not.toHaveClass(/open/);
   });
 
+  test("click inside the calendar keeps it open", async ({ page }) => {
+    const input = page.getByLabel("Meeting date");
+    await input.click();
+    const calendar = page
+      .getByTestId("date-picker-single")
+      .getByLabel("calendar-container");
+    await expect(calendar).toHaveClass(/open/);
+    // Month nav doesn't pick a date; the calendar should stay open.
+    await calendar.locator(".flatpickr-months").click();
+    await expect(calendar).toHaveClass(/open/);
+  });
+
   test("min/max: disabled days not selectable", async ({ page }) => {
     const input = page.getByLabel("Meeting date");
     await input.click();
@@ -281,6 +293,47 @@ test.describe("DatePicker", () => {
     await expect(calendar).toHaveClass(/open/);
     await page.getByTestId("date-picker-range-start").focus();
     await page.keyboard.press("Escape");
+    await expect(calendar).not.toHaveClass(/open/);
+  });
+
+  test("range: click outside closes calendar", async ({ page }) => {
+    await page.getByTestId("date-picker-range-start").click();
+    const calendar = page
+      .getByTestId("date-picker-range")
+      .getByLabel("calendar-container");
+    await expect(calendar).toHaveClass(/open/);
+    await page.getByTestId("outside-date-picker").click();
+    await expect(calendar).not.toHaveClass(/open/);
+  });
+
+  test("range: click inside the calendar keeps it open", async ({ page }) => {
+    await page.getByTestId("date-picker-range-start").click();
+    const calendar = page
+      .getByTestId("date-picker-range")
+      .getByLabel("calendar-container");
+    await expect(calendar).toHaveClass(/open/);
+    // Month nav doesn't pick a date; the calendar should stay open.
+    await calendar.locator(".flatpickr-months").click();
+    await expect(calendar).toHaveClass(/open/);
+  });
+
+  test("range: closing the calendar lets it reopen from either input", async ({
+    page,
+  }) => {
+    const calendar = page
+      .getByTestId("date-picker-range")
+      .getByLabel("calendar-container");
+
+    // Open from start, close with outside click, reopen from end. calendarOpen
+    // should flip correctly for both inputs.
+    await page.getByTestId("date-picker-range-start").click();
+    await expect(calendar).toHaveClass(/open/);
+    await page.getByTestId("outside-date-picker").click();
+    await expect(calendar).not.toHaveClass(/open/);
+
+    await page.getByTestId("date-picker-range-end").click();
+    await expect(calendar).toHaveClass(/open/);
+    await page.getByTestId("outside-date-picker").click();
     await expect(calendar).not.toHaveClass(/open/);
   });
 });

--- a/src/DatePicker/DatePicker.svelte
+++ b/src/DatePicker/DatePicker.svelte
@@ -98,6 +98,7 @@
     setContext,
   } from "svelte";
   import { derived, writable } from "svelte/store";
+  import { dismiss } from "../utils/dismiss.js";
   import { createCalendar, resolveLocale } from "./createCalendar";
   import {
     getTopLayerAncestor,
@@ -155,6 +156,8 @@
   let lastAppliedOptions = {};
   let calendarUsesFixedPositioning = false;
   let onCalendarReposition = null;
+  // Set from onOpen/onClose. Outside-click listener attaches only while open.
+  let calendarOpen = false;
 
   function attachFixedRepositionListeners() {
     if (!calendar || onCalendarReposition) return;
@@ -231,8 +234,8 @@
   function blurInput(relatedTarget) {
     if (!calendar) return;
     // No relatedTarget means focus left the document (e.g. switching browser
-    // tabs); refocusing would replay the open animation. Outside clicks are
-    // handled separately by the window click handler below.
+    // tabs); refocusing would replay the open animation. Outside clicks close
+    // via handleOutsideClick on datePickerRef.
     if (relatedTarget == null) return;
     // In range mode, focus moves between the two inputs while the calendar
     // stays open; closing here would replay the open animation on every switch.
@@ -323,6 +326,8 @@
       base: inputRef,
       input: inputRefTo,
       dispatch: (event) => {
+        if (event === "open") calendarOpen = true;
+        else if (event === "close") calendarOpen = false;
         if (calendarUsesFixedPositioning) {
           if (event === "open") attachFixedRepositionListeners();
           else if (event === "close") detachFixedRepositionListeners();
@@ -419,10 +424,11 @@
     calendar.set("clickOpens", !$readonlyAny);
     if ($readonlyAny && calendar.isOpen) calendar.close();
   }
-</script>
 
-<svelte:window
-  on:click={(event) => {
+  /**
+   * @type {(event: Event) => void}
+   */
+  function handleOutsideClick(event) {
     if (!calendar?.isOpen) return;
     if (
       isEventTargetInsidePortaledCalendar(
@@ -434,8 +440,8 @@
       return;
     }
     calendar.close();
-  }}
-/>
+  }
+</script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <!-- svelte-ignore a11y-no-static-element-interactions -->
@@ -450,6 +456,11 @@
   <!-- svelte-ignore a11y-no-static-element-interactions -->
   <div
     bind:this={datePickerRef}
+    use:dismiss={{
+      enabled: calendarOpen,
+      type: "click",
+      handler: handleOutsideClick,
+    }}
     {id}
     class:bx--date-picker={true}
     class:bx--date-picker--short={short}

--- a/tests/DatePicker/DatePickerWindowListeners.test.ts
+++ b/tests/DatePicker/DatePickerWindowListeners.test.ts
@@ -1,0 +1,109 @@
+import { render, screen } from "@testing-library/svelte";
+import type { Instance } from "flatpickr/dist/types/instance";
+import { tick } from "svelte";
+import { user } from "../utils/user";
+import DatePicker from "./DatePicker.test.svelte";
+import DatePickerCalendar from "./DatePickerCalendar.test.svelte";
+
+const net = (
+  add: ReturnType<typeof vi.spyOn>,
+  remove: ReturnType<typeof vi.spyOn>,
+  type: string,
+) =>
+  add.mock.calls.filter((c: unknown[]) => c[0] === type).length -
+  remove.mock.calls.filter((c: unknown[]) => c[0] === type).length;
+
+const openCalendar = async (oncalendar: () => void): Promise<Instance> => {
+  let captured: Instance | null = null;
+  render(DatePickerCalendar, {
+    props: {
+      datePickerType: "single",
+      oncalendar: (cal: Instance | null | undefined) => {
+        captured = cal ?? null;
+        oncalendar();
+      },
+    },
+  });
+
+  const instance = await vi.waitFor(() => {
+    if (!captured) throw new Error("calendar not set");
+    return captured as Instance;
+  });
+
+  instance.open();
+  await tick();
+  return instance;
+};
+
+describe("DatePicker window listeners", () => {
+  test("closed date pickers register no click listeners", async () => {
+    const add = vi.spyOn(window, "addEventListener");
+    const remove = vi.spyOn(window, "removeEventListener");
+
+    const N = 5;
+    for (let i = 0; i < N; i++) {
+      render(DatePicker, { props: { datePickerType: "single" } });
+    }
+    await tick();
+
+    expect(net(add, remove, "click")).toBe(0);
+
+    add.mockRestore();
+    remove.mockRestore();
+  });
+
+  test("an open calendar registers one shared click listener", async () => {
+    const add = vi.spyOn(window, "addEventListener");
+    const remove = vi.spyOn(window, "removeEventListener");
+
+    const instance = await openCalendar(() => {});
+    expect(instance.isOpen).toBe(true);
+    expect(net(add, remove, "click")).toBe(1);
+
+    add.mockRestore();
+    remove.mockRestore();
+  });
+
+  test("closing the calendar removes the click listener", async () => {
+    const add = vi.spyOn(window, "addEventListener");
+    const remove = vi.spyOn(window, "removeEventListener");
+
+    const instance = await openCalendar(() => {});
+    expect(net(add, remove, "click")).toBe(1);
+
+    instance.close();
+    await tick();
+    expect(instance.isOpen).toBe(false);
+    expect(net(add, remove, "click")).toBe(0);
+
+    add.mockRestore();
+    remove.mockRestore();
+  });
+
+  test("an outside click dismisses an open calendar", async () => {
+    render(DatePicker, { props: { datePickerType: "single" } });
+
+    const input = screen.getByLabelText("Date");
+    await user.click(input);
+    const calendar = await screen.findByLabelText("calendar-container");
+    expect(calendar).toHaveClass("open");
+
+    await user.click(document.body);
+    expect(calendar).not.toHaveClass("open");
+  });
+
+  test("a click inside the calendar does not dismiss it", async () => {
+    render(DatePicker, { props: { datePickerType: "single" } });
+
+    const input = screen.getByLabelText("Date");
+    await user.click(input);
+    const calendar = await screen.findByLabelText("calendar-container");
+    expect(calendar).toHaveClass("open");
+
+    // Month nav doesn't pick a date; it shouldn't close the calendar.
+    const inside =
+      calendar.querySelector<HTMLElement>(".flatpickr-months") ?? calendar;
+    await user.click(inside);
+    expect(calendar).toHaveClass("open");
+  });
+});


### PR DESCRIPTION
Related https://github.com/carbon-design-system/carbon-components-svelte/pull/3215, https://github.com/carbon-design-system/carbon-components-svelte/pull/3231, https://github.com/carbon-design-system/carbon-components-svelte/pull/3245, #3246

Apply similar event listener optimization to `DatePicker`; only register to the listener if the combo box is actually open. Adds an e2e test since the click behavior is slightly more nuanced (open state wraps `flatpickr`).

For example, https://svelte.carbondesignsystem.com/components/DatePicker goes from 16 click event listeners to 0.