### PR TITLE
fix(dropdown): add Alt+Arrow support for opening/closing the menu

### DIFF
--- a/e2e/dropdown.test.ts
+++ b/e2e/dropdown.test.ts
@@ -61,6 +61,30 @@ test.describe("Dropdown", () => {
     await expect(trigger).toContainText("Email");
   });
 
+  test("opens closed menu with Alt+ArrowDown without moving the highlight", async ({
+    page,
+  }) => {
+    const trigger = page.getByTestId("dropdown-contact").getByRole("combobox");
+    await trigger.focus();
+    await expect(page.locator(".bx--list-box__menu")).not.toBeVisible();
+
+    await page.keyboard.press("Alt+ArrowDown");
+
+    await expect(page.locator(".bx--list-box__menu")).toBeVisible();
+    await expect(trigger).toHaveAttribute("aria-activedescendant", "");
+  });
+
+  test("closes open menu with Alt+ArrowUp", async ({ page }) => {
+    const trigger = page.getByTestId("dropdown-contact").getByRole("combobox");
+    await trigger.click();
+    await expect(page.locator(".bx--list-box__menu")).toBeVisible();
+
+    await page.keyboard.press("Alt+ArrowUp");
+
+    await expect(page.locator(".bx--list-box__menu")).not.toBeVisible();
+    await expect(trigger).toBeFocused();
+  });
+
   test("closes menu with Escape", async ({ page }) => {
     const trigger = page.getByTestId("dropdown-contact").getByRole("combobox");
     await trigger.click();

--- a/src/Dropdown/Dropdown.svelte
+++ b/src/Dropdown/Dropdown.svelte
@@ -486,12 +486,27 @@
           selectHighlighted();
         } else if (event.key === "Tab") {
           open = false;
-        } else if (event.key === "ArrowDown") {
-          if (!open) open = true;
-          change(1);
-        } else if (event.key === "ArrowUp") {
-          if (!open) open = true;
-          change(-1);
+        } else if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+          const step = event.key === "ArrowDown" ? 1 : -1;
+          if (event.altKey) {
+            // APG combobox pattern: Alt+ArrowDown opens a closed menu without
+            // moving the highlight; Alt+ArrowUp closes an open one.
+            if (event.key === "ArrowDown" && !open) {
+              open = true;
+            } else if (event.key === "ArrowUp" && open) {
+              open = false;
+            }
+          } else if (open) {
+            change(step);
+          } else {
+            open = true;
+            // `afterUpdate` highlights any selected item only after the open
+            // state flushes; if nothing is highlighted by then, start at the
+            // first (ArrowDown) or last (ArrowUp) enabled item.
+            tick().then(() => {
+              if (highlightedIndex === -1) change(step);
+            });
+          }
         } else if (event.key === "Escape") {
           open = false;
         } else if (

--- a/tests/Dropdown/Dropdown.test.ts
+++ b/tests/Dropdown/Dropdown.test.ts
@@ -328,6 +328,97 @@ describe("Dropdown", () => {
     expect(button).toHaveTextContent("Email");
   });
 
+  it("should open the menu on ArrowDown and highlight the first enabled item", async () => {
+    render(Dropdown, { props: { items } });
+
+    const button = screen.getByRole("combobox");
+    button.focus();
+    expect(button).toHaveAttribute("aria-expanded", "false");
+
+    await user.keyboard("{ArrowDown}");
+    await tick();
+
+    expect(button).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByRole("listbox")).toBeVisible();
+    // Slack (id="0") is the first enabled item.
+    expect(button.getAttribute("aria-activedescendant")).toMatch(/-0$/);
+  });
+
+  it("should open the menu on ArrowUp and highlight the last enabled item", async () => {
+    render(Dropdown, { props: { items } });
+
+    const button = screen.getByRole("combobox");
+    button.focus();
+
+    await user.keyboard("{ArrowUp}");
+    await tick();
+
+    expect(button).toHaveAttribute("aria-expanded", "true");
+    // Fax (id="2") is the last enabled item.
+    expect(button.getAttribute("aria-activedescendant")).toMatch(/-2$/);
+  });
+
+  it("should open the menu on Alt+ArrowDown without moving the highlight", async () => {
+    render(Dropdown, { props: { items } });
+
+    const button = screen.getByRole("combobox");
+    button.focus();
+
+    await user.keyboard("{Alt>}{ArrowDown}{/Alt}");
+    await tick();
+
+    expect(button).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByRole("listbox")).toBeVisible();
+    expect(button).toHaveAttribute("aria-activedescendant", "");
+  });
+
+  it("should highlight the selected item when opening the menu on Alt+ArrowDown", async () => {
+    render(Dropdown, { props: { items, selectedId: "1" } });
+
+    const button = screen.getByRole("combobox");
+    button.focus();
+
+    await user.keyboard("{Alt>}{ArrowDown}{/Alt}");
+    await tick();
+
+    expect(button).toHaveAttribute("aria-expanded", "true");
+    // Email (id="1") is the selected item.
+    expect(button.getAttribute("aria-activedescendant")).toMatch(/-1$/);
+  });
+
+  it("should close the menu on Alt+ArrowUp", async () => {
+    render(Dropdown, { props: { items } });
+
+    const button = screen.getByRole("combobox");
+    await user.click(button);
+    expect(button).toHaveAttribute("aria-expanded", "true");
+
+    await user.keyboard("{Alt>}{ArrowUp}{/Alt}");
+
+    expect(button).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    expect(button).toHaveFocus();
+  });
+
+  it("should treat Alt+ArrowUp on a closed menu and Alt+ArrowDown on an open menu as no-ops", async () => {
+    render(Dropdown, { props: { items } });
+
+    const button = screen.getByRole("combobox");
+    button.focus();
+
+    await user.keyboard("{Alt>}{ArrowUp}{/Alt}");
+    expect(button).toHaveAttribute("aria-expanded", "false");
+
+    await user.keyboard("{ArrowDown}");
+    await tick();
+    expect(button.getAttribute("aria-activedescendant")).toMatch(/-0$/);
+
+    await user.keyboard("{Alt>}{ArrowDown}{/Alt}");
+    expect(button).toHaveAttribute("aria-expanded", "true");
+    // The highlight does not move.
+    expect(button.getAttribute("aria-activedescendant")).toMatch(/-0$/);
+  });
+
   it("should handle disabled items", async () => {
     const itemsWithDisabled = [
       { id: "0", text: "Slack" },


### PR DESCRIPTION
Brings Dropdown to parity with the ComboBox keyboard fix in #3254. Alt+ArrowDown opens a closed menu without moving the highlight, and Alt+ArrowUp closes an open one, following the WAI-ARIA APG combobox pattern. Adds unit and e2e coverage for the new shortcuts.