### PR TITLE
fix(multi-select): add Alt+Arrow support for opening/closing the menu

### DIFF
--- a/e2e/multiselect.test.ts
+++ b/e2e/multiselect.test.ts
@@ -66,6 +66,32 @@ test.describe("MultiSelect", () => {
     await expect(page.getByTestId("selected-count")).toContainText("1");
   });
 
+  test("opens with Alt+ArrowDown without moving the highlight", async ({
+    page,
+  }) => {
+    const trigger = page.getByTestId("multiselect-fruits");
+    await trigger.focus();
+    await expect(page.getByRole("option", { name: "Apple" })).not.toBeVisible();
+
+    await page.keyboard.press("Alt+ArrowDown");
+
+    await expect(page.getByRole("option", { name: "Apple" })).toBeVisible();
+    expect(await trigger.getAttribute("aria-activedescendant")).toBeNull();
+  });
+
+  test("closes open menu with Alt+ArrowUp and keeps focus", async ({
+    page,
+  }) => {
+    const trigger = page.getByTestId("multiselect-fruits");
+    await trigger.click();
+    await expect(page.getByRole("option", { name: "Apple" })).toBeVisible();
+
+    await page.keyboard.press("Alt+ArrowUp");
+
+    await expect(page.getByRole("option", { name: "Apple" })).not.toBeVisible();
+    await expect(trigger).toBeFocused();
+  });
+
   test.describe("isSelectAll", () => {
     test("renders select-all option first and applies selectall class", async ({
       page,

--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -703,12 +703,20 @@
               }
             } else if (event.key === "Tab") {
               open = false;
-            } else if (event.key === "ArrowDown") {
-              if (!open) open = true;
-              change(1);
-            } else if (event.key === "ArrowUp") {
-              if (!open) open = true;
-              change(-1);
+            } else if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+              const step = event.key === "ArrowDown" ? 1 : -1;
+              if (event.altKey) {
+                // APG combobox pattern: Alt+ArrowDown opens a closed menu
+                // without moving the highlight; Alt+ArrowUp closes an open one.
+                if (event.key === "ArrowDown" && !open) {
+                  open = true;
+                } else if (event.key === "ArrowUp" && open) {
+                  open = false;
+                }
+              } else {
+                if (!open) open = true;
+                change(step);
+              }
             } else if (event.key === "Escape") {
               open = false;
             } else if (event.key === " ") {
@@ -794,12 +802,20 @@
             open = !open;
           } else if (event.key === "Tab") {
             open = false;
-          } else if (event.key === "ArrowDown") {
-            if (!open) open = true;
-            change(1);
-          } else if (event.key === "ArrowUp") {
-            if (!open) open = true;
-            change(-1);
+          } else if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+            const step = event.key === "ArrowDown" ? 1 : -1;
+            if (event.altKey) {
+              // APG combobox pattern: Alt+ArrowDown opens a closed menu
+              // without moving the highlight; Alt+ArrowUp closes an open one.
+              if (event.key === "ArrowDown" && !open) {
+                open = true;
+              } else if (event.key === "ArrowUp" && open) {
+                open = false;
+              }
+            } else {
+              if (!open) open = true;
+              change(step);
+            }
           } else if (event.key === "Enter") {
             if (highlightedIndex > -1) {
               const item = (filterable ? filteredItems : sortedItems)[

--- a/tests/MultiSelect/MultiSelect.test.ts
+++ b/tests/MultiSelect/MultiSelect.test.ts
@@ -1376,6 +1376,108 @@ describe("MultiSelect", () => {
       expect(options[0]).toHaveAttribute("aria-selected", "false");
       expect(options[1]).toHaveAttribute("aria-selected", "false");
     });
+
+    it("non-filterable: ArrowDown opens the menu and highlights the first item", async () => {
+      render(MultiSelect, { props: { items } });
+
+      const combobox = screen.getByRole("combobox");
+      combobox.focus();
+      expect(combobox).toHaveAttribute("aria-expanded", "false");
+
+      await user.keyboard("{ArrowDown}");
+      await tick();
+
+      expect(combobox).toHaveAttribute("aria-expanded", "true");
+      // The first rendered (sorted) item is highlighted.
+      expect(combobox).toHaveAttribute(
+        "aria-activedescendant",
+        screen.getAllByRole("option")[0].id,
+      );
+    });
+
+    it("filterable: ArrowDown opens the menu and highlights the first filtered item", async () => {
+      render(MultiSelect, {
+        props: { items, filterable: true, placeholder: "Filter..." },
+      });
+
+      const input = screen.getByPlaceholderText("Filter...");
+      input.focus();
+
+      await user.keyboard("{ArrowDown}");
+      await tick();
+
+      expect(input).toHaveAttribute("aria-expanded", "true");
+      expect(input).toHaveAttribute(
+        "aria-activedescendant",
+        screen.getAllByRole("option")[0].id,
+      );
+    });
+
+    it("non-filterable: opens the menu on Alt+ArrowDown without moving the highlight", async () => {
+      render(MultiSelect, { props: { items } });
+
+      const combobox = screen.getByRole("combobox");
+      combobox.focus();
+
+      await user.keyboard("{Alt>}{ArrowDown}{/Alt}");
+      await tick();
+
+      expect(combobox).toHaveAttribute("aria-expanded", "true");
+      expect(screen.getByRole("listbox")).toBeVisible();
+      expect(combobox).not.toHaveAttribute("aria-activedescendant");
+    });
+
+    it("non-filterable: closes the menu on Alt+ArrowUp and keeps focus", async () => {
+      render(MultiSelect, { props: { items } });
+
+      const combobox = screen.getByRole("combobox");
+      await user.click(combobox);
+      expect(combobox).toHaveAttribute("aria-expanded", "true");
+
+      await user.keyboard("{Alt>}{ArrowUp}{/Alt}");
+
+      expect(combobox).toHaveAttribute("aria-expanded", "false");
+      expect(combobox).toHaveFocus();
+    });
+
+    it("treats Alt+ArrowDown on an open menu and Alt+ArrowUp on a closed menu as no-ops", async () => {
+      render(MultiSelect, { props: { items } });
+
+      const combobox = screen.getByRole("combobox");
+      combobox.focus();
+
+      // Alt+ArrowUp while closed does nothing.
+      await user.keyboard("{Alt>}{ArrowUp}{/Alt}");
+      expect(combobox).toHaveAttribute("aria-expanded", "false");
+
+      // Plain ArrowDown opens and highlights the first item.
+      await user.keyboard("{ArrowDown}");
+      await tick();
+      const firstOptionId = screen.getAllByRole("option")[0].id;
+      expect(combobox).toHaveAttribute("aria-activedescendant", firstOptionId);
+
+      // Alt+ArrowDown while open keeps the menu open without moving the highlight.
+      await user.keyboard("{Alt>}{ArrowDown}{/Alt}");
+      expect(combobox).toHaveAttribute("aria-expanded", "true");
+      expect(combobox).toHaveAttribute("aria-activedescendant", firstOptionId);
+    });
+
+    it("filterable: opens on Alt+ArrowDown and closes on Alt+ArrowUp", async () => {
+      render(MultiSelect, {
+        props: { items, filterable: true, placeholder: "Filter..." },
+      });
+
+      const input = screen.getByPlaceholderText("Filter...");
+      input.focus();
+
+      await user.keyboard("{Alt>}{ArrowDown}{/Alt}");
+      await tick();
+      expect(input).toHaveAttribute("aria-expanded", "true");
+      expect(input).not.toHaveAttribute("aria-activedescendant");
+
+      await user.keyboard("{Alt>}{ArrowUp}{/Alt}");
+      expect(input).toHaveAttribute("aria-expanded", "false");
+    });
   });
 
   describe("Generics", () => {


### PR DESCRIPTION
Adds the Alt+Arrow keyboard behavior from the APG combobox pattern to MultiSelect, matching the recent ComboBox change (#3254). Alt+ArrowDown opens a closed menu without moving the highlight and Alt+ArrowUp closes an open one. Plain arrow keys already opened the menu, so this only fills the Alt+Arrow gap.