### PR TITLE
fix(multi-select): restore focus outline on the field

### DIFF
--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -278,6 +278,7 @@
   $: effectivePortalMenu =
     portalMenu === undefined ? !!insideModal : portalMenu;
 
+  let fieldFocused = false;
   let highlightedIndex = -1;
   let prevHighlightedIndex = -1;
   let prevChecked = [];
@@ -517,6 +518,10 @@
   $: menuId = `menu-${id}`;
   $: comboId = `combo-${id}`;
   $: inline = type === "inline";
+  // Keep the focus outline on the field while the menu is open, not just while
+  // the field itself is focused: selecting an item bounces focus to the option
+  // and back, which would otherwise drop the outline mid-interaction.
+  $: showFieldFocus = fieldFocused || open;
   // Invalid/warn states are suppressed when the multi-select is disabled or read-only.
   $: showInvalid = invalid && !disabled && !readonly;
   $: showWarn = warn && !invalid && !disabled && !readonly;
@@ -652,7 +657,10 @@
       />
     {/if}
     {#if filterable}
-      <div class:bx--list-box__field={true}>
+      <div
+        class:bx--list-box__field={true}
+        class:bx--list-box__field--wrapper--input-focused={showFieldFocus}
+      >
         {#if selectionCount > 0}
           <ListBoxSelection
             {selectionCount}
@@ -738,7 +746,13 @@
           }}
           on:keyup
           on:focus
+          on:focus={() => {
+            fieldFocused = true;
+          }}
           on:blur
+          on:blur={() => {
+            fieldFocused = false;
+          }}
           on:paste
           {disabled}
           {readonly}
@@ -770,18 +784,30 @@
         />
       </div>
     {:else}
-      <ListBoxField
-        role="combobox"
-        tabindex="0"
-        aria-expanded={open}
-        aria-activedescendant={activeDescendantId}
-        aria-controls={open ? menuId : undefined}
-        aria-owns={open ? menuId : undefined}
-        on:click={() => {
+      <!-- The visible focus outline renders on this wrapper, not the field
+           itself: Carbon resets `.bx--list-box__field:focus` to a transparent
+           outline, which outranks the `--input-focused` rule when both target
+           the focused field. Placing `--input-focused` on the (unfocused)
+           wrapper avoids that `:focus` specificity bump. -->
+      <div
+        class:bx--list-box__field--wrapper={true}
+        class:bx--list-box__field--wrapper--input-focused={showFieldFocus}
+      >
+        <ListBoxField
+          role="combobox"
+          tabindex="0"
+          aria-expanded={open}
+          aria-activedescendant={activeDescendantId}
+          aria-controls={open ? menuId : undefined}
+          aria-owns={open ? menuId : undefined}
+          on:focus={() => {
+          fieldFocused = true;
+        }}
+          on:click={() => {
           if (disabled || readonly) return;
           open = !open;
         }}
-        on:keydown={(event) => {
+          on:keydown={(event) => {
           if (
             event.key === " " ||
             event.key === "ArrowUp" ||
@@ -811,37 +837,39 @@
             open = false;
           }
         }}
-        on:blur={(event) => {
+          on:blur={(event) => {
+          fieldFocused = false;
           dispatch("blur", event);
         }}
-        {id}
-        {disabled}
-        {readonly}
-        {translateWithId}
-      >
-        {#if selectionCount > 0}
-          <ListBoxSelection
-            {selectionCount}
-            on:clear
-            on:clear={() => {
+          {id}
+          {disabled}
+          {readonly}
+          {translateWithId}
+        >
+          {#if selectionCount > 0}
+            <ListBoxSelection
+              {selectionCount}
+              on:clear
+              on:clear={() => {
               selectedIds = [];
               sortedItems = sortedItems.map((item) => ({
                 ...item,
                 checked: false,
               }));
             }}
-            translateWithId={translateWithIdSelection}
-            {disabled}
-            {readonly}
+              translateWithId={translateWithIdSelection}
+              {disabled}
+              {readonly}
+            />
+          {/if}
+          <span class:bx--list-box__label={true}>{label}</span>
+          <ListBoxMenuIcon
+            aria-hidden={readonly || undefined}
+            {open}
+            {translateWithId}
           />
-        {/if}
-        <span class:bx--list-box__label={true}>{label}</span>
-        <ListBoxMenuIcon
-          aria-hidden={readonly || undefined}
-          {open}
-          {translateWithId}
-        />
-      </ListBoxField>
+        </ListBoxField>
+      </div>
     {/if}
     <div style:display={open || effectivePortalMenu ? "block" : "none"}>
       <ListBoxMenu

--- a/tests/MultiSelect/MultiSelect.test.ts
+++ b/tests/MultiSelect/MultiSelect.test.ts
@@ -1,4 +1,10 @@
-import { render, screen, waitFor, within } from "@testing-library/svelte";
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/svelte";
 import type MultiSelectComponent from "carbon-components-svelte/MultiSelect/MultiSelect.svelte";
 import type { MultiSelectItem } from "carbon-components-svelte/MultiSelect/MultiSelect.svelte";
 import type { ComponentEvents, ComponentProps } from "svelte";
@@ -950,6 +956,69 @@ describe("MultiSelect", () => {
       await openMenu();
       const emailOption = screen.getByRole("option", { name: "Email" });
       expect(emailOption).toHaveAttribute("disabled");
+    });
+  });
+
+  describe("focus outline", () => {
+    // Carbon resets the field's own `:focus` outline to transparent and relies
+    // on a `--input-focused` class to render the visible, theme-aware outline.
+    it("toggles the input-focused class on the default field wrapper", async () => {
+      render(MultiSelect, { props: { items, labelText: "Contact methods" } });
+
+      // The outline renders on the field wrapper, not the focusable field
+      // itself, so Carbon's transparent `:focus` reset cannot win by specificity.
+      const field = screen.getByRole("combobox");
+      const wrapper = field.closest(".bx--list-box__field--wrapper");
+      expect(wrapper).not.toHaveClass(
+        "bx--list-box__field--wrapper--input-focused",
+      );
+
+      fireEvent.focus(field);
+      await tick();
+      expect(wrapper).toHaveClass(
+        "bx--list-box__field--wrapper--input-focused",
+      );
+
+      fireEvent.blur(field);
+      await tick();
+      expect(wrapper).not.toHaveClass(
+        "bx--list-box__field--wrapper--input-focused",
+      );
+    });
+
+    it("keeps the input-focused class while the menu is open", () => {
+      // Selecting an item bounces focus to the option and back; tying the
+      // outline to `open` (not just focus) keeps it stable mid-interaction.
+      render(MultiSelect, { props: { items, open: true } });
+
+      const wrapper = screen
+        .getByRole("combobox")
+        .closest(".bx--list-box__field--wrapper");
+      expect(wrapper).toHaveClass(
+        "bx--list-box__field--wrapper--input-focused",
+      );
+    });
+
+    it("toggles the input-focused class on the filterable field", async () => {
+      render(MultiSelect, {
+        props: { items, filterable: true, placeholder: "Filter..." },
+      });
+
+      const input = screen.getByRole("combobox");
+      const field = input.closest(".bx--list-box__field");
+      expect(field).not.toHaveClass(
+        "bx--list-box__field--wrapper--input-focused",
+      );
+
+      fireEvent.focus(input);
+      await tick();
+      expect(field).toHaveClass("bx--list-box__field--wrapper--input-focused");
+
+      fireEvent.blur(input);
+      await tick();
+      expect(field).not.toHaveClass(
+        "bx--list-box__field--wrapper--input-focused",
+      );
     });
   });
 


### PR DESCRIPTION
Carbon resets the field's own `:focus` outline to transparent; the visible one needs an `--input-focused` class on a non-focused wrapper (else `:focus` wins by specificity). Tie it to `open` so selecting an item keeps the outline through the focus-bounce.

<img width="836" height="249" alt="Screenshot 2026-06-10 at 9 26 30 AM" src="https://github.com/user-attachments/assets/0fd6557b-645e-4b08-9da7-d7911fef1054" />
<img width="881" height="268" alt="Screenshot 2026-06-10 at 9 18 39 AM" src="https://github.com/user-attachments/assets/ed8c0ef4-9a98-417d-8605-472f28f0bd01" />
