### PR TITLE
fix(multi-select): open menu when the field label is clicked

### DIFF
--- a/src/ListBox/ListBoxField.svelte
+++ b/src/ListBox/ListBoxField.svelte
@@ -52,9 +52,10 @@
   $: menuId = `menu-${id}`;
 </script>
 
-<!-- svelte-ignore a11y-no-noninteractive-tabindex -->
-<div
+<button
   bind:this={ref}
+  type="button"
+  {id}
   {role}
   aria-expanded={ariaExpanded}
   aria-owns={(ariaExpanded && menuId) || undefined}
@@ -74,4 +75,4 @@
   on:blur
 >
   <slot />
-</div>
+</button>

--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -179,7 +179,7 @@
 
   /**
    * Obtain a reference to the field box element.
-   * @type {null | HTMLDivElement}
+   * @type {null | HTMLButtonElement}
    * @bindable readonly
    */
   export let fieldRef = null;
@@ -287,7 +287,7 @@
   let internalSelectedIdsRef = selectedIds;
 
   /**
-   * @type {(data: { key: "field" | "selection"; ref: HTMLDivElement }) => void}
+   * @type {(data: { key: "field" | "selection"; ref: HTMLDivElement | HTMLButtonElement }) => void}
    */
   function declareRef({ key, ref }) {
     switch (key) {
@@ -792,9 +792,12 @@
         on:keydown={(event) => {
           if (
             event.key === " " ||
+            event.key === "Enter" ||
             event.key === "ArrowUp" ||
             event.key === "ArrowDown"
           ) {
+            // Prevent the native button from synthesizing a click (which would
+            // toggle the menu) so these keys are handled solely below.
             event.preventDefault();
           }
           if (readonly) return;

--- a/tests/ListBox/ListBoxField.test.ts
+++ b/tests/ListBox/ListBoxField.test.ts
@@ -263,7 +263,7 @@ describe("ListBoxField", () => {
       props: { slotContent: "Ref field" },
     });
 
-    expect(component.ref).toBeInstanceOf(HTMLDivElement);
+    expect(component.ref).toBeInstanceOf(HTMLButtonElement);
   });
 
   it("should set aria-readonly when readonly is true", () => {

--- a/tests/MultiSelect/MultiSelect.test.ts
+++ b/tests/MultiSelect/MultiSelect.test.ts
@@ -1001,6 +1001,23 @@ describe("MultiSelect", () => {
       expect(screen.getByRole("listbox")).toHaveAttribute("id", menuId);
     });
 
+    it("clicking the label opens the menu and focuses the field (non-filterable)", async () => {
+      render(MultiSelect, {
+        props: {
+          items,
+          labelText: "Contact methods",
+        },
+      });
+
+      const combobox = screen.getByRole("combobox");
+      expect(combobox).toHaveAttribute("aria-expanded", "false");
+
+      await user.click(screen.getByText("Contact methods"));
+
+      expect(combobox).toHaveAttribute("aria-expanded", "true");
+      expect(combobox).toHaveFocus();
+    });
+
     it("filterable variant has correct ARIA attributes", () => {
       render(MultiSelect, {
         props: {


### PR DESCRIPTION
The default MultiSelect should focus/open the menu when clicking the label. This does not affect the filterable variant.

This also changes to the `button` element, which is more semantic and mirrors the upstream React implementation. It also fixes an a11y warning about `label` not being appropriate for the div.

