### PR TITLE
refactor: extract reusable overflowTitle action; fix Checkbox title

### DIFF
--- a/src/Checkbox/Checkbox.svelte
+++ b/src/Checkbox/Checkbox.svelte
@@ -72,6 +72,7 @@
 
   import { createEventDispatcher, getContext } from "svelte";
   import { readable } from "svelte/store";
+  import { overflowTitle } from "../utils/overflowTitle.js";
   import CheckboxSkeleton from "./CheckboxSkeleton.svelte";
 
   const dispatch = createEventDispatcher();
@@ -112,8 +113,6 @@
 
   let refLabel = null;
 
-  $: isTruncated = refLabel?.offsetWidth < refLabel?.scrollWidth;
-  $: title = !title && isTruncated ? refLabel?.innerText : title;
   $: helperId = `helper-${id}`;
 </script>
 
@@ -179,7 +178,11 @@
       on:focus
       on:blur
     >
-    <label for={id} {title} class:bx--checkbox-label={true}>
+    <label
+      for={id}
+      use:overflowTitle={{ title, measure: refLabel }}
+      class:bx--checkbox-label={true}
+    >
       <span
         bind:this={refLabel}
         class:bx--checkbox-label-text={true}

--- a/src/ListBox/ListBoxMenuItem.svelte
+++ b/src/ListBox/ListBoxMenuItem.svelte
@@ -1,4 +1,6 @@
 <script>
+  import { overflowTitle } from "../utils/overflowTitle.js";
+
   /** Set to `true` to enable the active state */
   export let active = false;
 
@@ -13,8 +15,6 @@
 
   let ref = null;
 
-  $: isTruncated = ref?.offsetWidth < ref?.scrollWidth;
-  $: title = isTruncated ? ref?.innerText : undefined;
   $: if (highlighted && ref && !ref.matches(":hover")) {
     // Scroll highlighted item into view if using keyboard navigation
     ref.scrollIntoView({ block: "nearest" });
@@ -37,7 +37,7 @@
 >
   <div
     bind:this={ref}
-    {title}
+    use:overflowTitle
     class:bx--list-box__menu-item__option={true}
     class:bx--list-box__menu-item__option--icon-left={hasLeftIcon}
   >

--- a/src/utils/overflowTitle.d.ts
+++ b/src/utils/overflowTitle.d.ts
@@ -1,0 +1,15 @@
+/** Params for `overflowTitle`. */
+export interface OverflowTitleParams {
+  /** Fixed `title`; skips overflow detection. */
+  title?: string;
+  /** Element to measure. Defaults to `node`. */
+  measure?: HTMLElement | null;
+}
+
+/** Set `title` from overflow text. Provided `title` wins. */
+export function overflowTitle(
+  node: HTMLElement,
+  params?: OverflowTitleParams,
+): { update: (params?: OverflowTitleParams) => void };
+
+export default overflowTitle;

--- a/src/utils/overflowTitle.js
+++ b/src/utils/overflowTitle.js
@@ -1,0 +1,35 @@
+// @ts-check
+
+/**
+ * Svelte action: set `title` while text overflows horizontally.
+ * `params.title` wins over auto-detection, including `""`.
+ * `params.measure` checks a descendant instead of `node`.
+ *
+ * @param {HTMLElement} node Element that gets the `title` attribute.
+ * @param {import("./overflowTitle.js").OverflowTitleParams} [params]
+ * @returns {{ update: (params?: import("./overflowTitle.js").OverflowTitleParams) => void }}
+ * @example
+ * <div use:overflowTitle>{text}</div>
+ * <label use:overflowTitle={{ title, measure: labelText }}>...</label>
+ */
+export function overflowTitle(node, params = {}) {
+  function update(next = {}) {
+    if (next.title != null) {
+      node.setAttribute("title", next.title);
+      return;
+    }
+
+    const measured = next.measure ?? node;
+    if (measured.offsetWidth < measured.scrollWidth) {
+      node.setAttribute("title", measured.innerText);
+    } else {
+      node.removeAttribute("title");
+    }
+  }
+
+  update(params);
+
+  return { update };
+}
+
+export default overflowTitle;

--- a/tests/Checkbox/Checkbox.test.ts
+++ b/tests/Checkbox/Checkbox.test.ts
@@ -11,6 +11,7 @@ import Checkbox from "./Checkbox.test.svelte";
 import CheckboxGroupEvents from "./CheckboxGroupEvents.test.svelte";
 import CheckboxGroupReactive from "./CheckboxGroupReactive.test.svelte";
 import CheckboxReactiveBind from "./CheckboxReactiveBind.test.svelte";
+import CheckboxTitleTruncation from "./CheckboxTitleTruncation.test.svelte";
 import MultipleCheckboxes from "./MultipleCheckboxes.test.svelte";
 import MultipleCheckboxesObject from "./MultipleCheckboxesObject.test.svelte";
 
@@ -537,6 +538,55 @@ describe("Checkbox", () => {
 
     const input = screen.getByRole("checkbox");
     expect(input).not.toHaveAttribute("aria-describedby");
+  });
+
+  describe("title truncation", () => {
+    let offsetWidthSpy: ReturnType<typeof vi.spyOn>;
+    let scrollWidthSpy: ReturnType<typeof vi.spyOn>;
+
+    function mockTruncated() {
+      offsetWidthSpy = vi
+        .spyOn(HTMLElement.prototype, "offsetWidth", "get")
+        .mockReturnValue(10);
+      scrollWidthSpy = vi
+        .spyOn(HTMLElement.prototype, "scrollWidth", "get")
+        .mockReturnValue(100);
+    }
+
+    afterEach(() => {
+      offsetWidthSpy?.mockRestore();
+      scrollWidthSpy?.mockRestore();
+    });
+
+    function getLabel() {
+      const label = document
+        .querySelector('[data-testid="checkbox-title"]')
+        ?.querySelector("label.bx--checkbox-label");
+      assert(label);
+      return label;
+    }
+
+    it('keeps title="" when the label is truncated', async () => {
+      mockTruncated();
+      render(CheckboxTitleTruncation, {
+        title: "",
+        labelText: "A very long label that should be truncated",
+      });
+      await tick();
+
+      expect(getLabel().getAttribute("title")).toBe("");
+    });
+
+    it("keeps a provided title when truncated", async () => {
+      mockTruncated();
+      render(CheckboxTitleTruncation, {
+        title: "Custom title",
+        labelText: "A very long label that should be truncated",
+      });
+      await tick();
+
+      expect(getLabel().getAttribute("title")).toBe("Custom title");
+    });
   });
 
   describe("Generics", () => {

--- a/tests/Checkbox/CheckboxTitleTruncation.test.svelte
+++ b/tests/Checkbox/CheckboxTitleTruncation.test.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+  import Checkbox from "carbon-components-svelte/Checkbox/Checkbox.svelte";
+
+  export let title: string | undefined = undefined;
+  export let labelText = "Checkbox label";
+</script>
+
+<Checkbox {title} {labelText} data-testid="checkbox-title" />

--- a/tests/utils/overflowTitle.test.ts
+++ b/tests/utils/overflowTitle.test.ts
@@ -1,0 +1,93 @@
+import { overflowTitle } from "../../src/utils/overflowTitle.js";
+
+function mockSize(node: HTMLElement, offsetWidth: number, scrollWidth: number) {
+  Object.defineProperty(node, "offsetWidth", {
+    configurable: true,
+    value: offsetWidth,
+  });
+  Object.defineProperty(node, "scrollWidth", {
+    configurable: true,
+    value: scrollWidth,
+  });
+}
+
+describe("overflowTitle action", () => {
+  let node: HTMLElement;
+
+  beforeEach(() => {
+    node = document.createElement("div");
+    node.textContent = "A very long label";
+    // jsdom lacks innerText; stub from textContent.
+    Object.defineProperty(node, "innerText", {
+      configurable: true,
+      get() {
+        return this.textContent;
+      },
+    });
+    document.body.appendChild(node);
+  });
+
+  afterEach(() => {
+    node.remove();
+  });
+
+  test("sets title to the text content when truncated", () => {
+    mockSize(node, 50, 120);
+    overflowTitle(node);
+    expect(node.getAttribute("title")).toBe("A very long label");
+  });
+
+  test("does not set title when the text fits", () => {
+    mockSize(node, 120, 120);
+    overflowTitle(node);
+    expect(node.hasAttribute("title")).toBe(false);
+  });
+
+  test("removes a stale title once no longer truncated on update", () => {
+    mockSize(node, 50, 120);
+    const { update } = overflowTitle(node);
+    expect(node.getAttribute("title")).toBe("A very long label");
+
+    mockSize(node, 120, 120);
+    update();
+    expect(node.hasAttribute("title")).toBe(false);
+  });
+
+  test("uses a provided title instead of overflow detection", () => {
+    mockSize(node, 120, 120);
+    overflowTitle(node, { title: "Custom title" });
+    expect(node.getAttribute("title")).toBe("Custom title");
+  });
+
+  test('keeps title="" when truncated', () => {
+    mockSize(node, 50, 120);
+    overflowTitle(node, { title: "" });
+    expect(node.getAttribute("title")).toBe("");
+  });
+
+  test("measures a descendant when `measure` is provided", () => {
+    const host = document.createElement("label");
+    const span = document.createElement("span");
+    span.textContent = "A very long label";
+    Object.defineProperty(span, "innerText", {
+      configurable: true,
+      get() {
+        return this.textContent;
+      },
+    });
+    host.appendChild(span);
+    document.body.appendChild(host);
+
+    mockSize(span, 50, 120);
+    overflowTitle(host, { measure: span });
+
+    expect(host.getAttribute("title")).toBe("A very long label");
+    host.remove();
+  });
+
+  test("falls back to measuring the node when `measure` is null", () => {
+    mockSize(node, 50, 120);
+    expect(() => overflowTitle(node, { measure: null })).not.toThrow();
+    expect(node.getAttribute("title")).toBe("A very long label");
+  });
+});


### PR DESCRIPTION
Extracts the truncation title logic into a reusable `overflowTitle` action in `src/utils` and adopts it in ListBoxMenuItem and Checkbox. The Checkbox fix preserves a consumer-provided `title` (including an empty string) and stops mutating the exported prop. Closes #3079.