### PR TITLE
feat(ui-shell): add `HeaderSideNavItems` for responsive header navigation

### DIFF
--- a/docs/src/pages/components/UIShell.svx
+++ b/docs/src/pages/components/UIShell.svx
@@ -6,6 +6,7 @@ components: ["Header",
 "HeaderNav",
 "HeaderNavItem",
 "HeaderNavMenu",
+"HeaderSideNavItems",
 "HeaderPanelDivider",
 "HeaderPanelLink",
 "HeaderPanelLinks",
@@ -35,6 +36,16 @@ Create a basic header with the header component.
 The hamburger menu is automatically rendered if the side nav component is used.
 
 <FileSource src="/framed/UIShell/HeaderNav" />
+
+## Header with responsive navigation
+
+On smaller screens, header links belong in the side nav, above the regular side nav items.
+
+Carbon hides the header nav below the large breakpoint (66rem). Duplicate those links with `HeaderSideNavItems`. Its children only show below that breakpoint. Set `hasDivider` to separate them from the side nav items.
+
+Resize the viewport to see the switch.
+
+<FileSource src="/framed/UIShell/HeaderSideNavItems" />
 
 ## Header with custom expansion breakpoint
 

--- a/docs/src/pages/framed/UIShell/HeaderSideNavItems.svelte
+++ b/docs/src/pages/framed/UIShell/HeaderSideNavItems.svelte
@@ -1,0 +1,59 @@
+<script>
+  import {
+    Column,
+    Content,
+    Grid,
+    Header,
+    HeaderNav,
+    HeaderNavItem,
+    HeaderNavMenu,
+    HeaderSideNavItems,
+    Row,
+    SideNav,
+    SideNavItems,
+    SideNavLink,
+    SkipToContent,
+  } from "carbon-components-svelte";
+
+  let isSideNavOpen = false;
+</script>
+
+<Header companyName="IBM" platformName="Cloud" bind:isSideNavOpen>
+  <svelte:fragment slot="skipToContent"> <SkipToContent /> </svelte:fragment>
+  <HeaderNav>
+    <HeaderNavItem href="/catalog" text="Catalog" />
+    <HeaderNavItem href="/docs" text="Docs" />
+    <HeaderNavItem href="/support" text="Support" />
+    <HeaderNavMenu text="Manage">
+      <HeaderNavItem href="/account" text="Account" />
+      <HeaderNavItem href="/iam" text="Access (IAM)" />
+      <HeaderNavItem href="/billing" text="Billing and usage" />
+    </HeaderNavMenu>
+  </HeaderNav>
+</Header>
+
+<SideNav bind:isOpen={isSideNavOpen}>
+  <SideNavItems>
+    <HeaderSideNavItems hasDivider>
+      <HeaderNavItem href="/catalog" text="Catalog" />
+      <HeaderNavItem href="/docs" text="Docs" />
+      <HeaderNavItem href="/support" text="Support" />
+      <HeaderNavMenu text="Manage">
+        <HeaderNavItem href="/account" text="Account" />
+        <HeaderNavItem href="/iam" text="Access (IAM)" />
+        <HeaderNavItem href="/billing" text="Billing and usage" />
+      </HeaderNavMenu>
+    </HeaderSideNavItems>
+    <SideNavLink href="/dashboard" text="Dashboard" isSelected />
+    <SideNavLink href="/resources" text="Resource list" />
+    <SideNavLink href="/activity" text="Activity tracker" />
+  </SideNavItems>
+</SideNav>
+
+<Content>
+  <Grid>
+    <Row>
+      <Column> <h1>Dashboard</h1> </Column>
+    </Row>
+  </Grid>
+</Content>

--- a/src/UIShell/HeaderSideNavItems.svelte
+++ b/src/UIShell/HeaderSideNavItems.svelte
@@ -1,0 +1,15 @@
+<script>
+  /**
+   * Set to `true` to add a divider between the header
+   * navigation items and the side nav items.
+   */
+  export let hasDivider = false;
+</script>
+
+<ul
+  class:bx--side-nav__header-navigation={true}
+  class:bx--side-nav__header-divider={hasDivider}
+  {...$$restProps}
+>
+  <slot />
+</ul>

--- a/src/UIShell/index.js
+++ b/src/UIShell/index.js
@@ -10,6 +10,7 @@ export { default as HeaderPanelDivider } from "./HeaderPanelDivider.svelte";
 export { default as HeaderPanelLink } from "./HeaderPanelLink.svelte";
 export { default as HeaderPanelLinks } from "./HeaderPanelLinks.svelte";
 export { default as HeaderSearch } from "./HeaderSearch.svelte";
+export { default as HeaderSideNavItems } from "./HeaderSideNavItems.svelte";
 export { default as HeaderUtilities } from "./HeaderUtilities.svelte";
 export { default as SideNav } from "./SideNav.svelte";
 export { default as SideNavDivider } from "./SideNavDivider.svelte";

--- a/src/index.js
+++ b/src/index.js
@@ -173,6 +173,7 @@ export { default as HeaderPanelDivider } from "./UIShell/HeaderPanelDivider.svel
 export { default as HeaderPanelLink } from "./UIShell/HeaderPanelLink.svelte";
 export { default as HeaderPanelLinks } from "./UIShell/HeaderPanelLinks.svelte";
 export { default as HeaderSearch } from "./UIShell/HeaderSearch.svelte";
+export { default as HeaderSideNavItems } from "./UIShell/HeaderSideNavItems.svelte";
 export { default as HeaderUtilities } from "./UIShell/HeaderUtilities.svelte";
 export { default as SideNav } from "./UIShell/SideNav.svelte";
 export { default as SideNavDivider } from "./UIShell/SideNavDivider.svelte";

--- a/tests/UIShell/HeaderSideNavItems.test.svelte
+++ b/tests/UIShell/HeaderSideNavItems.test.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+  import Header from "carbon-components-svelte/UIShell/Header.svelte";
+  import HeaderNav from "carbon-components-svelte/UIShell/HeaderNav.svelte";
+  import HeaderNavItem from "carbon-components-svelte/UIShell/HeaderNavItem.svelte";
+  import HeaderSideNavItems from "carbon-components-svelte/UIShell/HeaderSideNavItems.svelte";
+  import SideNav from "carbon-components-svelte/UIShell/SideNav.svelte";
+  import SideNavItems from "carbon-components-svelte/UIShell/SideNavItems.svelte";
+  import SideNavLink from "carbon-components-svelte/UIShell/SideNavLink.svelte";
+
+  export let hasDivider = false;
+
+  let isSideNavOpen = false;
+</script>
+
+<Header companyName="IBM" platformName="Carbon Svelte" bind:isSideNavOpen>
+  <HeaderNav>
+    <HeaderNavItem href="/" text="Link 1" />
+    <HeaderNavItem href="/" text="Link 2" />
+  </HeaderNav>
+</Header>
+
+<SideNav bind:isOpen={isSideNavOpen}>
+  <SideNavItems>
+    <HeaderSideNavItems {hasDivider} data-testid="header-side-nav-items">
+      <HeaderNavItem href="/" text="Link 1" />
+      <HeaderNavItem href="/" text="Link 2" />
+    </HeaderSideNavItems>
+    <SideNavLink text="Side nav link" />
+  </SideNavItems>
+</SideNav>

--- a/tests/UIShell/HeaderSideNavItems.test.ts
+++ b/tests/UIShell/HeaderSideNavItems.test.ts
@@ -1,0 +1,33 @@
+import { render, screen } from "@testing-library/svelte";
+import HeaderSideNavItemsTest from "./HeaderSideNavItems.test.svelte";
+
+describe("HeaderSideNavItems", () => {
+  it("renders a list with the header navigation class", () => {
+    render(HeaderSideNavItemsTest);
+
+    const list = screen.getByTestId("header-side-nav-items");
+    expect(list.tagName).toBe("UL");
+    expect(list).toHaveClass("bx--side-nav__header-navigation");
+    expect(list).not.toHaveClass("bx--side-nav__header-divider");
+  });
+
+  it("adds the divider class when hasDivider is true", () => {
+    render(HeaderSideNavItemsTest, { props: { hasDivider: true } });
+
+    const list = screen.getByTestId("header-side-nav-items");
+    expect(list).toHaveClass(
+      "bx--side-nav__header-navigation",
+      "bx--side-nav__header-divider",
+    );
+  });
+
+  it("renders header nav items inside the side nav", () => {
+    render(HeaderSideNavItemsTest);
+
+    const list = screen.getByTestId("header-side-nav-items");
+    const links = list.querySelectorAll("a.bx--header__menu-item");
+    expect(links).toHaveLength(2);
+    expect(links[0]).toHaveTextContent("Link 1");
+    expect(links[1]).toHaveTextContent("Link 2");
+  });
+});


### PR DESCRIPTION
Closes [#516](https://github.com/carbon-design-system/carbon-components-svelte/issues/516)

Adds the React parity component for the Carbon responsive behavior
spec: header links duplicated inside the side nav are shown only
below the large (66rem) breakpoint, where the header nav is hidden
by the Carbon stylesheets. The supporting CSS
(`bx--side-nav__header-navigation`, `bx--side-nav__header-divider`,
and the side-nav header menu item styles) already ships in every
theme; only the component was missing.

<img width="603" height="436" alt="Screenshot 2026-06-10 at 1 46 53 PM" src="https://github.com/user-attachments/assets/ac03310b-b415-4be1-a63d-308b284bff70" />
