### PR TITLE
fix(list-box): clear hover highlight when cursor leaves the menu

### DIFF
--- a/src/ComboBox/ComboBox.svelte
+++ b/src/ComboBox/ComboBox.svelte
@@ -710,6 +710,11 @@
         on:scroll={(event) => {
           listScrollTop = event.target.scrollTop;
         }}
+        on:mouseleave={() => {
+          // Clear the hover highlight when the cursor leaves the menu so the
+          // highlighted state does not linger on the last hovered item.
+          highlightedIndex = -1;
+        }}
         bind:ref={listRef}
         style={effectivePortalMenu
           ? `max-height: ${virtualConfig

--- a/src/Dropdown/Dropdown.svelte
+++ b/src/Dropdown/Dropdown.svelte
@@ -560,6 +560,11 @@
         on:scroll={(event) => {
           listScrollTop = event.target.scrollTop;
         }}
+        on:mouseleave={() => {
+          // Clear the hover highlight when the cursor leaves the menu so the
+          // highlighted state does not linger on the last hovered item.
+          highlightedIndex = -1;
+        }}
         bind:ref={listRef}
         style={effectivePortalMenu
           ? `max-height: ${virtualConfig

--- a/src/ListBox/ListBoxMenu.svelte
+++ b/src/ListBox/ListBoxMenu.svelte
@@ -57,6 +57,7 @@
         style="position: static; {$$restProps.style || ''}"
         {...$$restProps}
         on:scroll
+        on:mouseleave
       >
         <slot />
       </div>
@@ -70,6 +71,7 @@
     class:bx--list-box__menu={true}
     {...$$restProps}
     on:scroll
+    on:mouseleave
   >
     <slot />
   </div>

--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -903,6 +903,11 @@
         on:scroll={(event) => {
           listScrollTop = event.target.scrollTop;
         }}
+        on:mouseleave={() => {
+          // Clear the hover highlight when the cursor leaves the menu so the
+          // highlighted state does not linger on the last hovered item.
+          highlightedIndex = -1;
+        }}
         bind:ref={listRef}
         style={effectivePortalMenu
           ? `max-height: ${virtualConfig

--- a/tests/ComboBox/ComboBox.test.ts
+++ b/tests/ComboBox/ComboBox.test.ts
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/svelte";
+import { fireEvent, render, screen, waitFor } from "@testing-library/svelte";
 import type ComboBoxComponent from "carbon-components-svelte/ComboBox/ComboBox.svelte";
 import type { ComboBoxItem } from "carbon-components-svelte/ComboBox/ComboBox.svelte";
 import ComboBoxReal from "carbon-components-svelte/ComboBox/ComboBox.svelte";
@@ -256,6 +256,19 @@ describe("ComboBox", () => {
     const activeOptions = document.querySelectorAll(`[id="${activeId}"]`);
     expect(activeOptions).toHaveLength(1);
     expect(activeOptions[0]).toHaveAttribute("role", "option");
+  });
+
+  it("should clear the hover highlight when the cursor leaves the menu", async () => {
+    render(ComboBox);
+
+    await user.click(getInput());
+
+    const emailOption = screen.getByRole("option", { name: "Email" });
+    await user.hover(emailOption);
+    expect(emailOption).toHaveClass("bx--list-box__menu-item--highlighted");
+
+    await fireEvent.mouseLeave(screen.getByRole("listbox"));
+    expect(emailOption).not.toHaveClass("bx--list-box__menu-item--highlighted");
   });
 
   it("should set aria-activedescendant only when an item is highlighted", async () => {

--- a/tests/Dropdown/Dropdown.test.ts
+++ b/tests/Dropdown/Dropdown.test.ts
@@ -966,6 +966,20 @@ describe("Dropdown", () => {
     expect(button).toHaveTextContent("Banana");
   });
 
+  it("should clear the hover highlight when the cursor leaves the menu", async () => {
+    render(Dropdown, { props: { items } });
+
+    const button = screen.getByRole("combobox");
+    await user.click(button);
+
+    const emailOption = screen.getByRole("option", { name: "Email" });
+    await user.hover(emailOption);
+    expect(emailOption).toHaveClass("bx--list-box__menu-item--highlighted");
+
+    await fireEvent.mouseLeave(screen.getByRole("listbox"));
+    expect(emailOption).not.toHaveClass("bx--list-box__menu-item--highlighted");
+  });
+
   it("should support typeahead with multiple characters", async () => {
     render(Dropdown, {
       props: {

--- a/tests/MultiSelect/MultiSelect.test.ts
+++ b/tests/MultiSelect/MultiSelect.test.ts
@@ -72,6 +72,19 @@ describe("MultiSelect", () => {
     expect(screen.getByText("0 Slack 2")).toBeInTheDocument();
   });
 
+  it("should clear the hover highlight when the cursor leaves the menu", async () => {
+    render(MultiSelect, { props: { items } });
+
+    await openMenu();
+
+    const emailOption = screen.getByRole("option", { name: "Email" });
+    await user.hover(emailOption);
+    expect(emailOption).toHaveClass("bx--list-box__menu-item--highlighted");
+
+    await fireEvent.mouseLeave(screen.getByRole("listbox"));
+    expect(emailOption).not.toHaveClass("bx--list-box__menu-item--highlighted");
+  });
+
   it("should pass selected and highlighted to the default slot", async () => {
     render(MultiSelectItemSlot, { props: { selectedIds: ["1"] } });
 


### PR DESCRIPTION
Dropdown, ComboBox, and MultiSelect set `highlightedIndex` on item `mouseenter` but never reset it, so the highlighted class lingered on the last hovered item after the cursor left the menu. This forwards `mouseleave` from `ListBoxMenu` and resets the index in each consumer. Handling it at the menu level rather than per item avoids churn when moving between adjacent items, since `mouseleave` skips descendant transitions.