### PR TITLE
refactor(list-box): add fluid menu item height constant

### DIFF
--- a/src/ComboBox/ComboBox.svelte
+++ b/src/ComboBox/ComboBox.svelte
@@ -205,7 +205,7 @@
    * Set `virtualize={true}` to explicitly enable virtualization with default settings.
    *
    * Provide an object to customize virtualization behavior:
-   * - `itemHeight` (default: 40 for md, adjusted for size): Height of each item in pixels. Override when custom slots change row height.
+   * - `itemHeight` (default: size-based, or 64px for fluid unless `condensed`): Height of each item in pixels. Override when custom slots change row height.
    * - `containerHeight` (default: 300): The maximum height in pixels of the dropdown container.
    * - `overscan` (default: 3): The number of extra items to render above and below the viewport for smoother scrolling. Higher values may cause more flickering during very fast scrolling.
    * - `threshold` (default: 100): The minimum number of items required before virtualization activates. Lists with fewer items will render all items normally without virtualization.
@@ -469,7 +469,7 @@
     shouldVirtualize,
     virtualize,
     defaults: {
-      itemHeight: hasFluidMenuItems ? 64 : getMenuItemHeight(size),
+      itemHeight: getMenuItemHeight(size, { fluid: hasFluidMenuItems }),
     },
   });
   $: virtualConfig = virtualState.config;

--- a/src/Dropdown/Dropdown.svelte
+++ b/src/Dropdown/Dropdown.svelte
@@ -129,7 +129,7 @@
    * Set `virtualize={true}` to explicitly enable virtualization with default settings.
    *
    * Provide an object to customize virtualization behavior:
-   * - `itemHeight` (default: 40 for md, adjusted for size): Height of each item in pixels. Override when custom slots change row height.
+   * - `itemHeight` (default: size-based, or 64px for fluid unless `condensed`): Height of each item in pixels. Override when custom slots change row height.
    * - `containerHeight` (default: 300): The maximum height in pixels of the dropdown container.
    * - `overscan` (default: 3): The number of extra items to render above and below the viewport for smoother scrolling. Higher values may cause more flickering during very fast scrolling.
    * - `threshold` (default: 100): The minimum number of items required before virtualization activates. Lists with fewer items will render all items normally without virtualization.
@@ -277,7 +277,9 @@
     scrollTop: listScrollTop,
     shouldVirtualize,
     virtualize,
-    defaults: { itemHeight: hasFluidMenuItems ? 64 : getMenuItemHeight(size) },
+    defaults: {
+      itemHeight: getMenuItemHeight(size, { fluid: hasFluidMenuItems }),
+    },
   });
   $: virtualConfig = virtualState.config;
   $: virtualData = virtualState.data;

--- a/src/ListBox/list-box-utils.d.ts
+++ b/src/ListBox/list-box-utils.d.ts
@@ -23,11 +23,16 @@ export declare const MENU_ITEM_HEIGHT: Readonly<{
   xl: number;
 }>;
 
+/** Fluid menu item height (px). Same height for every size. */
+export declare const FLUID_MENU_ITEM_HEIGHT: number;
+
 /**
  * Get the menu item height in pixels for a listbox/dropdown size.
  * @param size - The size variant (defaults to "md" when undefined)
+ * @param options - Pass `fluid: true` for FLUID_MENU_ITEM_HEIGHT
  * @returns The item height in pixels
  */
 export declare function getMenuItemHeight(
   size?: "sm" | "md" | "lg" | "xl",
+  options?: { fluid?: boolean },
 ): number;

--- a/src/ListBox/list-box-utils.js
+++ b/src/ListBox/list-box-utils.js
@@ -31,10 +31,19 @@ export const MENU_ITEM_HEIGHT = Object.freeze({
 });
 
 /**
- * Get the menu item height in pixels for a listbox/dropdown size.
+ * Fluid menu item height (px). Matches `$spacing-10` (4rem) on
+ * `.bx--list-box__menu-item` in css/_fluid-list-box.scss. Same height for every
+ * size; condensed fluid uses the size-based heights in MENU_ITEM_HEIGHT.
+ */
+export const FLUID_MENU_ITEM_HEIGHT = 64;
+
+/**
+ * Get the menu item height in pixels for a listbox/dropdown.
  * @param {"sm" | "md" | "lg" | "xl"} [size] - The size variant
+ * @param {{ fluid?: boolean }} [options] - Pass `fluid: true` for FLUID_MENU_ITEM_HEIGHT
  * @returns {number} The item height in pixels
  */
-export function getMenuItemHeight(size = "md") {
+export function getMenuItemHeight(size = "md", { fluid = false } = {}) {
+  if (fluid) return FLUID_MENU_ITEM_HEIGHT;
   return MENU_ITEM_HEIGHT[size] ?? MENU_ITEM_HEIGHT.md;
 }

--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -231,7 +231,7 @@
    * Set `virtualize={true}` to explicitly enable virtualization with default settings.
    *
    * Provide an object to customize virtualization behavior:
-   * - `itemHeight` (default: 40 for md, adjusted for size): Height of each item in pixels. Override when custom slots change row height.
+   * - `itemHeight` (default: size-based, or 64px for fluid unless `condensed`): Height of each item in pixels. Override when custom slots change row height.
    * - `containerHeight` (default: 300): The maximum height in pixels of the dropdown container.
    * - `overscan` (default: 3): The number of extra items to render above and below the viewport for smoother scrolling. Higher values may cause more flickering during very fast scrolling.
    * - `threshold` (default: 100): The minimum number of items required before virtualization activates. Lists with fewer items will render all items normally without virtualization.
@@ -605,7 +605,7 @@
     shouldVirtualize,
     virtualize,
     defaults: {
-      itemHeight: hasFluidMenuItems ? 64 : getMenuItemHeight(size),
+      itemHeight: getMenuItemHeight(size, { fluid: hasFluidMenuItems }),
     },
   });
   $: virtualConfig = virtualState.config;

--- a/tests/ListBox/list-box-utils.test.ts
+++ b/tests/ListBox/list-box-utils.test.ts
@@ -1,4 +1,5 @@
 import {
+  FLUID_MENU_ITEM_HEIGHT,
   getMenuItemHeight,
   getMenuMaxHeight,
   MENU_ITEM_HEIGHT,
@@ -41,5 +42,25 @@ describe("getMenuItemHeight", () => {
   it("returns default for an unknown size", () => {
     // @ts-expect-error - exercising the runtime fallback
     expect(getMenuItemHeight("xxl")).toBe(MENU_ITEM_HEIGHT.md);
+  });
+
+  it("returns 64px for every size when fluid is true", () => {
+    expect(getMenuItemHeight("sm", { fluid: true })).toBe(
+      FLUID_MENU_ITEM_HEIGHT,
+    );
+    expect(getMenuItemHeight("md", { fluid: true })).toBe(
+      FLUID_MENU_ITEM_HEIGHT,
+    );
+    expect(getMenuItemHeight("lg", { fluid: true })).toBe(
+      FLUID_MENU_ITEM_HEIGHT,
+    );
+    expect(getMenuItemHeight("xl", { fluid: true })).toBe(
+      FLUID_MENU_ITEM_HEIGHT,
+    );
+  });
+
+  it("uses size-based heights when fluid is false", () => {
+    expect(getMenuItemHeight("sm", { fluid: false })).toBe(32);
+    expect(getMenuItemHeight("lg", { fluid: false })).toBe(48);
   });
 });


### PR DESCRIPTION
Centralizes the hardcoded fluid virtualization item height (64px) into a `FLUID_MENU_ITEM_HEIGHT` constant and a `fluid` option on `getMenuItemHeight` in `list-box-utils`. ComboBox, Dropdown, and MultiSelect now derive their fluid item height from that helper instead of an inline literal. Condensed fluid menus continue to use the size-based heights, and the util gains unit coverage for both paths.