### PR TITLE
fix(modal): prevent Enter on Cancel from also firing the primary action

### DIFF
--- a/e2e/fixtures/ModalFixture.svelte
+++ b/e2e/fixtures/ModalFixture.svelte
@@ -2,11 +2,14 @@
   import { Button, Modal } from "carbon-components-svelte";
 
   let open = false;
+  let events = [];
 </script>
 
 <button type="button" data-testid="open-modal" on:click={() => (open = true)}>
   Open modal
 </button>
+
+<p data-testid="events">{events.join(",")}</p>
 
 <Modal
   data-testid="modal"
@@ -14,6 +17,8 @@
   modalHeading="Modal title"
   primaryButtonText="Save"
   secondaryButtonText="Cancel"
+  on:click:button--primary={() => (events = [...events, "primary"])}
+  on:click:button--secondary={() => (events = [...events, "secondary"])}
 >
   <p data-testid="modal-body">Modal content</p>
 </Modal>

--- a/e2e/modal.test.ts
+++ b/e2e/modal.test.ts
@@ -54,6 +54,21 @@ test.describe("Modal", () => {
     await expect(modal).toHaveClass(/is-visible/);
   });
 
+  test("fires the secondary event when pressing Enter on the focused secondary button", async ({
+    page,
+  }) => {
+    await page.getByTestId("open-modal").click();
+    await expect(page.locator(".bx--modal")).toHaveClass(/is-visible/);
+
+    // Focus the secondary "Cancel" button and press Enter to cancel.
+    await page.getByRole("button", { name: "Cancel" }).focus();
+    await page.keyboard.press("Enter");
+
+    // Pressing Enter on the secondary button should cancel, not confirm.
+    // The primary (confirm) event must not fire — only the secondary event.
+    await expect(page.getByTestId("events")).toHaveText("secondary");
+  });
+
   test("closes when clicking directly on the backdrop", async ({ page }) => {
     await page.getByTestId("open-modal").click();
     const modal = page.locator(".bx--modal");

--- a/src/Modal/Modal.svelte
+++ b/src/Modal/Modal.svelte
@@ -211,7 +211,14 @@
       ) {
         const target = event.target;
         const tag = target?.tagName;
-        if (tag === "TEXTAREA" || tag === "SELECT" || target?.isContentEditable) {
+        if (
+          tag === "BUTTON" ||
+          tag === "TEXTAREA" ||
+          tag === "SELECT" ||
+          target?.isContentEditable
+        ) {
+          // Let the focused button (e.g. the secondary/cancel button) handle
+          // Enter via its native activation instead of submitting the form.
           return;
         }
         if (formId && primaryButtonRef) {


### PR DESCRIPTION
It actually fires both primary and secondary events. This is a critical issue as users think they are canceling but we go ahead and carry out the action. I included a test that fails without the fix.