### PR TITLE
docs: language pass, consistency

### DIFF
--- a/docs/src/pages/components/Accordion.svx
+++ b/docs/src/pages/components/Accordion.svx
@@ -183,45 +183,40 @@ item component for finer control over which items are interactive.
 
 ## Skeleton
 
-The skeleton state provides a loading placeholder for the accordion. It displays a
-simplified version of the component while content is being loaded.
+Set the `skeleton` prop to show a loading placeholder while content loads.
 
 <Accordion skeleton />
 
 ## Skeleton (left-aligned chevron)
 
-The skeleton state can be combined with the left-aligned chevron style by setting
-both the `skeleton` and `align="start"` props.
+Combine the skeleton state with the left-aligned chevron style by setting both the
+`skeleton` and `align="start"` props.
 
 <Accordion skeleton align="start" />
 
 ## Skeleton (custom count)
 
-By default, the skeleton state displays 4 items.
-
-Specify the number of skeleton items to display using the `count` prop. This is
-useful when you know the exact number of items that will be loaded.
+By default, the skeleton state displays 4 items. Set the `count` prop to specify
+the number of skeleton items to display.
 
 <Accordion skeleton count={3} />
 
 ## Skeleton (closed)
 
-By default, the first skeleton item is open. The skeleton state can be displayed
-in a collapsed state by setting `open={false}`.
+By default, the first skeleton item is open. Set `open={false}` to render the
+skeleton collapsed.
 
 <Accordion skeleton open={false} />
 
 ## Skeleton (extra-large)
 
-The skeleton state supports the extra-large size variant, maintaining visual
-consistency with the active component states.
+Set `size` to `"xl"` for an extra-large skeleton.
 
 <Accordion skeleton size="xl" />
 
 ## Skeleton (small)
 
-The skeleton state also supports the small size variant, providing a compact
-loading placeholder for space-constrained layouts.
+Set `size` to `"sm"` for a small skeleton.
 
 <Accordion skeleton size="sm" />
 

--- a/docs/src/pages/components/Breakpoint.svx
+++ b/docs/src/pages/components/Breakpoint.svx
@@ -18,7 +18,7 @@ The `"on:change"` event fires when the size is initially determined and when a b
 
 <FileSource src="/framed/Breakpoint/Breakpoint" />
 
-## Store and Breakpoint Values
+## Store and breakpoint values
 
 Use `breakpointObserver` as an alternative to the component to get the current size as a Svelte store. The store provides two additional functions that create derived stores returning a `boolean` indicating whether the size is smaller/larger than a certain breakpoint.
 

--- a/docs/src/pages/components/Button.svx
+++ b/docs/src/pages/components/Button.svx
@@ -9,7 +9,7 @@ Buttons trigger actions in the interface. Use them to submit forms, navigate bet
 
 ## Primary button
 
-The default button style is primary. This should be used for primary actions.
+The default button style is primary. Use it for the main action on a page.
 
 <Button>Primary button</Button>
 

--- a/docs/src/pages/components/CodeSnippet.svx
+++ b/docs/src/pages/components/CodeSnippet.svx
@@ -125,7 +125,7 @@ Re-render the component to fix this issue.
 
 ## Portal tooltip
 
-Set `portalTooltip` to `true` to render the feedback tooltip in a floating portal. This prevents the tooltip from being clipped by parent containers with `overflow: hidden` or z-index stacking contexts. The example below demonstrates `portalTooltip` for each variant (`inline`, `single`, `multi`) inside a container with hidden overflow; with `portalTooltip`, the tooltip breaks out of the container.
+Set `portalTooltip` to `true` to render the feedback tooltip in a floating portal. This prevents the tooltip from being clipped by parent containers with `overflow: hidden` or z-index stacking contexts. The example renders each variant (`inline`, `single`, `multi`) inside a container with hidden overflow.
 
 When inside a [Modal](/components/Modal), `portalTooltip` defaults to `true` unless explicitly set to `false`.
 

--- a/docs/src/pages/components/ComboBox.svx
+++ b/docs/src/pages/components/ComboBox.svx
@@ -367,7 +367,7 @@ items={[
 
 ## Portal menu
 
-Set `portalMenu` to `true` to render the dropdown menu in a floating portal. This prevents the menu from being clipped by parent containers with `overflow: hidden` or z-index stacking contexts. The example below shows a container with hidden overflow. Without `portalMenu`, the dropdown would be clipped.
+Set `portalMenu` to `true` to render the dropdown menu in a floating portal. This prevents the menu from being clipped by parent containers with `overflow: hidden` or z-index stacking contexts. Without `portalMenu`, the dropdown in the example below would be clipped by its container's hidden overflow.
 
 When inside a [Modal](/components/Modal#modal-with-dropdowns), `portalMenu` defaults to `true` unless explicitly set to `false`.
 

--- a/docs/src/pages/components/ComboBox.svx
+++ b/docs/src/pages/components/ComboBox.svx
@@ -221,7 +221,7 @@ Set `itemToString` to customize how items display in the filterable combobox.
 
 ## Clear filter on open
 
-When using a filterable combobox, reopening the dropdown after making a selection will normally show only the filtered results matching the selected item. Set `clearFilterOnOpen` to `true` to temporarily clear the filter when opening, showing all available items so you can browse and change selections.
+After selecting an item in a filterable combobox, reopening the dropdown normally shows only the results matching that selection. Set `clearFilterOnOpen` to `true` to clear the filter on open, showing all items so you can browse and change the selection.
 
 The original value is automatically restored if you close the dropdown without making a new selection.
 

--- a/docs/src/pages/components/ComposedModal.svx
+++ b/docs/src/pages/components/ComposedModal.svx
@@ -17,7 +17,7 @@ Create a modal with a header, body, and footer. Each section can be customized i
 
 <FileSource src="/framed/Modal/ComposedModal" />
 
-## With Portal
+## With portal
 
 Wrap the composed modal in a portal to ensure it renders above all z-index stacking contexts and parent overflow constraints, preventing visual clipping and layering issues.
 

--- a/docs/src/pages/components/ContextMenu.svx
+++ b/docs/src/pages/components/ContextMenu.svx
@@ -66,7 +66,7 @@ Set `target` to an array of elements to trigger the context menu from multiple s
 
 ## Selectable
 
-Use `selectable` for a single toggle item, or wrap options in `ContextMenuGroup` with `bind:selectedIds` for a checkbox-style group. Provide an `id` on each option in the group. Multiple items can be selected at once: the standalone toggle and each item in the group are independent, and the group keeps every chosen option in `selectedIds`.
+Use `selectable` for a single toggle item, or wrap options in `ContextMenuGroup` with `bind:selectedIds` for a checkbox-style group. Provide an `id` on each option in the group. The standalone toggle and the group items are independent, and the group tracks every chosen option in `selectedIds`.
 
 <FileSource src="/framed/ContextMenu/ContextMenuSelectable" />
 

--- a/docs/src/pages/components/DataTable.svx
+++ b/docs/src/pages/components/DataTable.svx
@@ -570,7 +570,7 @@ Set `size` on the `Toolbar` to override the size inherited from the `DataTable`.
 
 ## With toolbar (compact size)
 
-Use `size="compact"` for the table. The `Toolbar` inherits the extra small (`xs`) size to match the compact 24px row height.
+Use `size="compact"` for the table. The `Toolbar` inherits the extra small (`xs`) size to match the compact row height.
 
 <DataTable size="compact" title="Load balancers" description="Your organization's active load balancers."
   headers="{[

--- a/docs/src/pages/components/Dropdown.svx
+++ b/docs/src/pages/components/Dropdown.svx
@@ -202,7 +202,7 @@ Invalid and warning states are not displayed while the dropdown is read-only.
 
 ## Portal menu
 
-Set `portalMenu` to `true` to render the dropdown menu in a floating portal. This prevents the menu from being clipped by parent containers with `overflow: hidden` or z-index stacking contexts. The example below shows a container with hidden overflow. Without `portalMenu`, the dropdown would be clipped.
+Set `portalMenu` to `true` to render the dropdown menu in a floating portal. This prevents the menu from being clipped by parent containers with `overflow: hidden` or z-index stacking contexts. Without `portalMenu`, the dropdown in the example below would be clipped by its container's hidden overflow.
 
 When inside a [Modal](/components/Modal#modal-with-dropdowns), `portalMenu` defaults to `true` unless explicitly set to `false`.
 

--- a/docs/src/pages/components/Grid.svx
+++ b/docs/src/pages/components/Grid.svx
@@ -100,7 +100,7 @@ of content. This is useful for creating vertical rhythm without manually adding 
 
 <FileSource src="/framed/Grid/PaddedGrid" />
 
-## Breakpoints Reference
+## Breakpoints reference
 
 Understanding [breakpoints](/components/Breakpoint) is critical for creating responsive layouts. Each breakpoint
 has specific pixel ranges and column counts:

--- a/docs/src/pages/components/Heading.svx
+++ b/docs/src/pages/components/Heading.svx
@@ -44,7 +44,7 @@ As you nest section components, the heading levels automatically increment to ma
 
 ## Custom level
 
-Use the `level` prop on the section to specify a custom starting heading level. This is useful when you need to start a section at a specific level, such as when embedding content that should begin at a higher heading level. Child sections will continue to increment from this custom level.
+Use the `level` prop on the section to specify a custom starting heading level. Child sections continue to increment from this custom level.
 
 <Section level={5}>
   <Heading>Starts at Heading 5</Heading>
@@ -55,7 +55,7 @@ Use the `level` prop on the section to specify a custom starting heading level. 
 
 ## Custom section element
 
-By default, the section renders a semantic `<section>` element. Use the `tag` prop to render a different HTML element while maintaining the heading level context functionality. This is useful when you need to use a different semantic element (like `<div>`, `<article>`, or `<aside>`) but still want automatic heading level management.
+By default, the section renders a semantic `<section>` element. Use the `tag` prop to render a different element (such as `<div>`, `<article>`, or `<aside>`) while keeping automatic heading level management.
 
 <Section tag="div">
   <Heading>Heading 1</Heading>

--- a/docs/src/pages/components/Modal.svx
+++ b/docs/src/pages/components/Modal.svx
@@ -23,7 +23,7 @@ Create a basic modal dialog with primary and secondary actions. This variant is 
 
 <FileSource src="/framed/Modal/Modal" />
 
-## With Portal
+## With portal
 
 Wrap the modal in a portal to escape parent containers with `overflow: hidden` or z-index stacking contexts. This ensures the modal appears above all content and isn't clipped by parent boundaries.
 

--- a/docs/src/pages/components/Modal.svx
+++ b/docs/src/pages/components/Modal.svx
@@ -31,7 +31,7 @@ Wrap the modal in a portal to escape parent containers with `overflow: hidden` o
 
 ## Modal with dropdowns
 
-When components with menus are used inside a modal, such as a combo box, dropdown, multi-select, date picker, or overflow menu, these components automatically render their menus in a floating portal when inside a modal, so menus are positioned relative to their trigger and are not clipped by the modal's overflow or z-index stacking.
+Components with menus — such as a combo box, dropdown, multi-select, date picker, or overflow menu — automatically render their menus in a floating portal when used inside a modal. The menus are positioned relative to their trigger and are not clipped by the modal's overflow or z-index stacking.
 
 Set `portalMenu={false}` on these components to opt out. In this example, the modal itself is wrapped in a portal.
 

--- a/docs/src/pages/components/MultiSelect.svx
+++ b/docs/src/pages/components/MultiSelect.svx
@@ -253,7 +253,7 @@ Invalid and warning states are not displayed while the multi-select is read-only
 
 ## Portal menu
 
-Set `portalMenu` to `true` to render the dropdown menu in a floating portal. This prevents the menu from being clipped by parent containers with `overflow: hidden` or z-index stacking contexts. The example below shows a container with hidden overflow. Without `portalMenu`, the dropdown would be clipped.
+Set `portalMenu` to `true` to render the dropdown menu in a floating portal. This prevents the menu from being clipped by parent containers with `overflow: hidden` or z-index stacking contexts. Without `portalMenu`, the dropdown in the example below would be clipped by its container's hidden overflow.
 
 When inside a [Modal](/components/Modal#modal-with-dropdowns), `portalMenu` defaults to `true` unless explicitly set to `false`.
 

--- a/docs/src/pages/components/OverflowMenu.svx
+++ b/docs/src/pages/components/OverflowMenu.svx
@@ -25,7 +25,7 @@ Create a basic overflow menu by wrapping overflow menu item components within th
 
 ## Portal menu
 
-Set `portalMenu` to `true` to render the menu in a floating portal. This prevents the menu from being clipped by parent containers with `overflow: hidden` or z-index stacking contexts. The example below shows a container with hidden overflow. Without `portalMenu`, the menu would be clipped.
+Set `portalMenu` to `true` to render the menu in a floating portal. This prevents the menu from being clipped by parent containers with `overflow: hidden` or z-index stacking contexts. Without `portalMenu`, the menu in the example below would be clipped by its container's hidden overflow.
 
  When inside a [Modal](/components/Modal), `portalMenu` defaults to `true` unless explicitly set to `false`. 
 

--- a/docs/src/pages/components/Pagination.svx
+++ b/docs/src/pages/components/Pagination.svx
@@ -10,25 +10,25 @@ Pagination provides navigation controls for large data sets. It shows the curren
 
 ## Default
 
-Create a basic pagination component with default page size options. The default size is `"md"` (40px).
+Create a basic pagination component with default page size options. The default size is `"md"`.
 
 <Pagination totalItems={102} pageSizes={[10, 15, 20]} />
 
-## Extra small size
+## Extra-small size
 
-Set `size` to `"xs"` (24px) to pair pagination with a compact (`size="compact"`) data table.
+Set `size` to `"xs"` to pair pagination with a compact (`size="compact"`) data table.
 
 <Pagination size="xs" totalItems={102} pageSizes={[10, 15, 20]} />
 
 ## Small size
 
-Set `size` to `"sm"` (32px) for a small pagination.
+Set `size` to `"sm"` for a small pagination.
 
 <Pagination size="sm" totalItems={102} pageSizes={[10, 15, 20]} />
 
 ## Large size
 
-Set `size` to `"lg"` (48px) for a large pagination.
+Set `size` to `"lg"` for a large pagination.
 
 <Pagination size="lg" totalItems={102} pageSizes={[10, 15, 20]} />
 

--- a/docs/src/pages/components/Portal.svx
+++ b/docs/src/pages/components/Portal.svx
@@ -6,25 +6,25 @@ Portals render their content directly into `document.body` to escape parent over
 
 For anchored, positioned content (for example, dropdowns, popovers, overflow menus), use [FloatingPortal](/components/FloatingPortal) instead.
 
-## Default Portal
+## Default portal
 
 Render content in a portal. This is useful for modals, tooltips, and menus that need to escape parent containers.
 
 <FileSource src="/framed/Portal/BasicPortal" />
 
-## Multiple Portals
+## Multiple portals
 
 Each portal instance is independent and creates its own element in `document.body`. Each portal is automatically cleaned up when it is removed.
 
 <FileSource src="/framed/Portal/MultiplePortals" />
 
-## Custom Tag
+## Custom tag
 
 Use the `tag` prop to specify a custom HTML element. By default, the portal uses a `div` element.
 
 <FileSource src="/framed/Portal/CustomTagPortal" />
 
-## Modal with Portal
+## Modal with portal
 
 Wrap the modal in a portal to escape parent containers with `overflow: hidden` or z-index stacking contexts. This ensures the modal appears above all content and isn't clipped by parent boundaries.
 

--- a/docs/src/pages/components/Toolbar.svx
+++ b/docs/src/pages/components/Toolbar.svx
@@ -28,7 +28,7 @@ Set `size="sm"` for a compact toolbar.
   </ToolbarContent>
 </Toolbar>
 
-## Extra small size
+## Extra-small size
 
 Set `size="xs"` for an extra small toolbar, intended to pair with a compact `DataTable`.
 


### PR DESCRIPTION
Follow CONTRIBUTING.md guidelines on docs voice/tone:

- Use consistent grammar
- Use imperative voice
- Tighten descriptions
- Don't mention exact pixels for sizes; consumer should only need to think in term of size, not exact pixel value