### PR TITLE
docs: restore usage of "New" component tags

### DIFF
--- a/docs/src/global.css
+++ b/docs/src/global.css
@@ -318,6 +318,17 @@ html {
   margin-bottom: var(--cds-layout-01);
 }
 
+.bx--col > h1.component-title-with-badge {
+  display: flex;
+  align-items: center;
+  gap: var(--cds-spacing-04);
+}
+
+.bx--tag .bx--tooltip__trigger--definition {
+  color: inherit;
+  border-bottom-color: currentColor;
+}
+
 .big-paragraph {
   font-size: var(--cds-expressive-heading-03-font-size);
   font-weight: var(--cds-expressive-heading-03-font-weight);

--- a/docs/src/layouts/ComponentLayout.svelte
+++ b/docs/src/layouts/ComponentLayout.svelte
@@ -18,6 +18,8 @@
     Tab,
     TabContent,
     Tabs,
+    Tag,
+    TooltipDefinition,
   } from "carbon-components-svelte";
   import type { CarbonTheme } from "carbon-components-svelte/src/Theme/Theme.svelte";
   import { themes as themeLabels } from "carbon-components-svelte/src/Theme/Theme.svelte";
@@ -30,6 +32,7 @@
   import COMPONENT_API from "../COMPONENT_API.json";
   import COMPONENT_MD_SIZES_JSON from "../COMPONENT_MD_SIZES.json";
   import ComponentApi from "../components/ComponentApi.svelte";
+  import { NEW_COMPONENTS } from "../new-components";
   import { theme } from "../store";
 
   type DocComponent = (typeof COMPONENT_API.components)[number];
@@ -86,6 +89,7 @@
     .map((i) => componentMap.get(i))
     .filter((c): c is DocComponent => c != null);
   $: multiple = api_components.length > 1;
+  $: newVersion = NEW_COMPONENTS[component];
 
   onMount(() => {
     const searchParams = new URLSearchParams(window.location.search);
@@ -178,7 +182,18 @@
   <Grid class="fix-overflow">
     <Row>
       <Column>
-        <h1>{component}</h1>
+        <h1 class:component-title-with-badge={!!newVersion}>
+          {#if newVersion}
+            {component}
+            <Tag size="sm" type="blue" style="margin: 0">
+              <TooltipDefinition tooltipText="Available in v{newVersion}">
+                New
+              </TooltipDefinition>
+            </Tag>
+          {:else}
+            {component}
+          {/if}
+        </h1>
         <div class="bar">
           <Dropdown
             class="theme-dropdown"

--- a/docs/src/new-components.ts
+++ b/docs/src/new-components.ts
@@ -1,0 +1,5 @@
+export const NEW_COMPONENTS: Record<string, string> = {
+  PinCodeInput: "0.109.0",
+  CopyInput: "0.109.0",
+  BadgeIndicator: "0.109.0",
+};

--- a/docs/src/pages/_module.svelte
+++ b/docs/src/pages/_module.svelte
@@ -22,6 +22,7 @@
   import MiniSearch from "minisearch";
   import { onMount, tick } from "svelte";
   import SEARCH_INDEX from "../SEARCH_INDEX.json";
+  import { NEW_COMPONENTS } from "../new-components";
   import { theme } from "../store";
 
   type ModuleSearchResult = HeaderSearchResult & { isComponent: boolean };
@@ -62,7 +63,6 @@
   });
 
   const deprecated: string[] = [];
-  const new_components: string[] = ["PinCodeInput", "CopyInput"];
 
   let value = "";
   let active = false;
@@ -214,7 +214,7 @@
           href={$url(child.path)}
           isSelected={$isActive($url(child.path))}
         >
-          {#if deprecated.includes(child.name) || new_components.includes(child.name)}
+          {#if deprecated.includes(child.name) || child.name in NEW_COMPONENTS}
             <Stack gap={2} orientation="horizontal" align="center">
               {child.name}
               {#if deprecated.includes(child.name)}
@@ -226,7 +226,7 @@
                   Deprecated
                 </Tag>
               {/if}
-              {#if new_components.includes(child.name)}
+              {#if child.name in NEW_COMPONENTS}
                 <Tag
                   size="sm"
                   type="blue"

--- a/docs/src/pages/_module.svelte
+++ b/docs/src/pages/_module.svelte
@@ -62,7 +62,7 @@
   });
 
   const deprecated: string[] = [];
-  const new_components: string[] = [];
+  const new_components: string[] = ["PinCodeInput", "CopyInput"];
 
   let value = "";
   let active = false;
@@ -214,24 +214,30 @@
           href={$url(child.path)}
           isSelected={$isActive($url(child.path))}
         >
-          {child.name}
-          {#if deprecated.includes(child.name)}
-            <Tag
-              size="sm"
-              type="red"
-              style="margin-top: 0; margin-bottom: 0; cursor: inherit"
-            >
-              Deprecated
-            </Tag>
-          {/if}
-          {#if new_components.includes(child.name)}
-            <Tag
-              size="sm"
-              type="green"
-              style="margin-top: 0; margin-bottom: 0; cursor: inherit"
-            >
-              New
-            </Tag>
+          {#if deprecated.includes(child.name) || new_components.includes(child.name)}
+            <Stack gap={2} orientation="horizontal" align="center">
+              {child.name}
+              {#if deprecated.includes(child.name)}
+                <Tag
+                  size="sm"
+                  type="red"
+                  style="margin-top: 0; margin-bottom: 0; cursor: inherit"
+                >
+                  Deprecated
+                </Tag>
+              {/if}
+              {#if new_components.includes(child.name)}
+                <Tag
+                  size="sm"
+                  type="blue"
+                  style="margin-top: 0; margin-bottom: 0; cursor: inherit"
+                >
+                  New
+                </Tag>
+              {/if}
+            </Stack>
+          {:else}
+            {child.name}
           {/if}
         </SideNavMenuItem>
       {/each}


### PR DESCRIPTION
Restore the practice of labeling new components, to help visually distinguish them.

This time, also denote what version they are available in.

<img width="1126" height="623" alt="Screenshot 2026-06-11 at 11 44 14 PM" src="https://github.com/user-attachments/assets/326d3b70-8782-439b-a883-e62e3a8146ac" />
