### PR TITLE
docs(pin-code-input): copy pass

### DIFF
--- a/docs/src/pages/components/PinCodeInput.svx
+++ b/docs/src/pages/components/PinCodeInput.svx
@@ -7,10 +7,7 @@ components: ["PinCodeInput", "FluidPinCodeInputSkeleton"]
   import { FluidPinCodeInputSkeleton, Link, PinCodeInput, TooltipIcon } from "carbon-components-svelte";
 </script>
 
-Pin code inputs collect a short verification code (such as a one-time passcode) across a row of single-character segments. Each segment is an independent text field with shared labeling, validation, and keyboard navigation (typing advances focus, <DocKbd label="Backspace" /> moves to the previous segment, <DocKbd label="←" /> and <DocKbd label="→" /> move between segments), plus paste support and optional masking.
-
-> [!WARNING]
-> For OTP/MFA, use this as a capture UI only. Submit the assembled code to a server for verification. Never compare against an expected OTP in the browser.
+Pin code inputs collect a short verification code (such as a one-time passcode) across a row of single-character segments. Each segment is an independent text field with shared labeling, validation, and keyboard navigation (typing advances focus, <DocKbd label="Backspace" /> moves to the previous segment, <DocKbd label="Delete" /> clears the focused segment, <DocKbd label="←" /> and <DocKbd label="→" /> move between segments), plus paste support and optional masking.
 
 ## Default
 


### PR DESCRIPTION
Revise the description and omit the warning; this is already made clear in the UX example.