### PR TITLE
chore(deps-dev): upgrade Biome to 2.5.0

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.0/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",
@@ -18,12 +18,17 @@
     }
   },
   "files": {
-    "includes": ["**", "!!**/.*/**/*", "!!**/docs/src/pages/index.svelte"]
+    "includes": [
+      "**",
+      "!!**/.*/**/*",
+      "!!**/docs/src/pages/index.svelte",
+      "!**/*.svg"
+    ]
   },
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true,
+      "preset": "recommended",
       "performance": {
         "noAccumulatingSpread": "error",
         "noAwaitInLoops": "error",
@@ -54,12 +59,14 @@
         "noUselessUndefinedInitialization": "error",
         "useArrowFunction": "error",
         "useLiteralKeys": "error",
-        "noImportantStyles": "off"
+        "noImportantStyles": "off",
+        "useArrayFind": "error"
       },
       "suspicious": {
         "noExplicitAny": "error",
         "noImportCycles": "error",
-        "useAwait": "error"
+        "useAwait": "error",
+        "noForIn": "error"
       },
       "style": {
         "noImplicitBoolean": "error",
@@ -89,8 +96,6 @@
         "noDescendingSpecificity": "off"
       },
       "nursery": {
-        "useFind": "error",
-        "noForIn": "error",
         "noFloatingPromises": "error"
       }
     }
@@ -111,7 +116,8 @@
       "linter": {
         "rules": {
           "correctness": {
-            "noSelfAssign": "off"
+            "noSelfAssign": "off",
+            "noDuplicateAttributes": "off"
           },
           "complexity": {
             "noUselessUndefinedInitialization": "off"
@@ -125,7 +131,16 @@
             "useAltText": "off",
             "useAnchorContent": "off",
             "useAriaPropsForRole": "off",
-            "useValidAriaRole": "off"
+            "useValidAriaRole": "off",
+            "useValidAriaValues": "off",
+            "noLabelWithoutControl": "off",
+            "useSemanticElements": "off",
+            "useValidAnchor": "off",
+            "noNoninteractiveElementToInteractiveRole": "off",
+            "useAriaPropsSupportedByRole": "off",
+            "useFocusableInteractive": "off",
+            "noNoninteractiveTabindex": "off",
+            "noAmbiguousAnchorText": "off"
           }
         }
       }

--- a/biome.json
+++ b/biome.json
@@ -146,6 +146,16 @@
       }
     },
     {
+      "includes": ["src/**/*.svelte"],
+      "linter": {
+        "rules": {
+          "nursery": {
+            "useSvelteRequireEachKey": "error"
+          }
+        }
+      }
+    },
+    {
       "includes": ["**/*.test.ts"],
       "linter": {
         "rules": {

--- a/bun.lock
+++ b/bun.lock
@@ -9,7 +9,7 @@
         "flatpickr": "4.6.9",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.4.16",
+        "@biomejs/biome": "2.5.0",
         "@playwright/test": "^1.59.0",
         "@sveltejs/vite-plugin-svelte": "^7.1.2",
         "@testing-library/jest-dom": "^6.9.1",
@@ -51,23 +51,23 @@
 
     "@babel/runtime": ["@babel/runtime@7.28.2", "", {}, "sha512-KHp2IflsnGywDjBWDkR9iEqiWSpc8GIi0lgTT3mOElT0PP1tG26P4tmFI2YvAdzgq9RGyoHZQEIEdZy6Ec5xCA=="],
 
-    "@biomejs/biome": ["@biomejs/biome@2.4.16", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.16", "@biomejs/cli-darwin-x64": "2.4.16", "@biomejs/cli-linux-arm64": "2.4.16", "@biomejs/cli-linux-arm64-musl": "2.4.16", "@biomejs/cli-linux-x64": "2.4.16", "@biomejs/cli-linux-x64-musl": "2.4.16", "@biomejs/cli-win32-arm64": "2.4.16", "@biomejs/cli-win32-x64": "2.4.16" }, "bin": { "biome": "bin/biome" } }, "sha512-x9ajFh1zChVybCiM3TN6OD4phAqLgtPZjFrZF+aTMYCPjwBO+k529TX7PPsAqtGNLeV4UgzwQnowEgS7bGmzcA=="],
+    "@biomejs/biome": ["@biomejs/biome@2.5.0", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.5.0", "@biomejs/cli-darwin-x64": "2.5.0", "@biomejs/cli-linux-arm64": "2.5.0", "@biomejs/cli-linux-arm64-musl": "2.5.0", "@biomejs/cli-linux-x64": "2.5.0", "@biomejs/cli-linux-x64-musl": "2.5.0", "@biomejs/cli-win32-arm64": "2.5.0", "@biomejs/cli-win32-x64": "2.5.0" }, "bin": { "biome": "bin/biome" } }, "sha512-4kURkd9hAPrdDM3C9n82ycYgx8hvQcW6MjKTEejruj8rK0N8P3OPpdy8BvI8kt3KWY4ycF5XtDOrktetEfhfuw=="],
 
-    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.16", "", { "os": "darwin", "cpu": "arm64" }, "sha512-wxPvu4XOA85YJk9ixSWUmq/QBHbid85BISbOAqqBM/5xQpPk9ayjk5375tOlSC0BeCwNSbPFafQBm+vBumXq0A=="],
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.5.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Mn3Fwi3SA5fgmfCPqmzpWF2DLZnms3BVAhM088nTnGrTZmHS3wwIjcoZPqpXeNgd3DrrLH6xp8vTLIBuJoZiXw=="],
 
-    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.16", "", { "os": "darwin", "cpu": "x64" }, "sha512-xFCqGPwYusQJp4N4NJLi1XJiZqjwFdjhT+KqtNy+Ug3qgfczqnTa6MSDvxJF6TkuDLoYJItMapz6tAf7kCekFw=="],
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.5.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-rg3VPL5P8mYro6pqlXYXuJWph21slVp3SZtAqWSrkZs40d2gTzYmHF8E/X1iTID25btmNKltNDJ926sqVBp7DQ=="],
 
-    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.4.16", "", { "os": "linux", "cpu": "arm64" }, "sha512-2kFb4//jxfZaP6D+Rj5VkHkxgyD9EoRAVBEQb8PKRv+s4NO2zYNJKXFaJmK1CmhufJOWEfpHKaRbOja7qjmdhQ=="],
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.5.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-tl+LW8fdD96/xdeWtWwc82LIOc5CoY7N2AsogLTp5R4ECErYt+8Jl/N68ezN9vzSiqPTxw6vjcihoLPYKZHrlw=="],
 
-    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.4.16", "", { "os": "linux", "cpu": "arm64" }, "sha512-oYxnW0ARfJkr72ezzF2OR8N/rtkgLUQeYtF8cFhVswbknHxtTcmzSsanVJP8yQKnGpGpc2ck6c5zLvHahL6Cbg=="],
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.5.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-vQdM4oSGaf7ZNeGO9w5+Y8SBtyser9M6znxYbm7Ec8wInxJu1WiKxFYZW5Auj2d80bcVvefuGGRxoFOE0eee8g=="],
 
-    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.4.16", "", { "os": "linux", "cpu": "x64" }, "sha512-NbcBbi/nJqn5baae6wqRXdS7Gadf2uRpehSh6vMSYpG8OhkXl/Xg8aorWrJ+9VWqAT5ml90alLvorkpMW0nBwQ=="],
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.5.0", "", { "os": "linux", "cpu": "x64" }, "sha512-zpEGf4RQbFEh8Vt7OmavLyyOzRbtcE9osCqrS1kfvt8jDvxwhKXLSf7n0ebr/ov0RJ9ssP+lhs6C8a9WwFvrQA=="],
 
-    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.4.16", "", { "os": "linux", "cpu": "x64" }, "sha512-iHDS+MCM65DPqWGu+ECC3uoALyj2H7F4nVUPxIPjz/PIl94EUu+EDfGZDzFP+NY1EOPVt9NQvwFqq7HdMmowdg=="],
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.5.0", "", { "os": "linux", "cpu": "x64" }, "sha512-+9hIcMngJ+yGUahXqZuZ8CoWKJE9SAZsFsM3QDvXpNsLbXZ9lqVzgBhOk/jTSYkOA0GLP9eu3teukqpLUojHMg=="],
 
-    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.16", "", { "os": "win32", "cpu": "arm64" }, "sha512-0rgImMsNb5v/chhkIFe3wu7PEFClS6RBAYUijGL9UsYN3PanSaoK24HSSuSJb1pYbYYVjzAyZTl3gtjJ84BM8A=="],
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.5.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-jB0wAvTLI4itx5VidqVUejPQFhRUxiZ9l9FvZ26D5fl6t3qme+ZB4PD3bTSeL1vZ8NI2Rx/zj6H9zcESuGHKGw=="],
 
-    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.16", "", { "os": "win32", "cpu": "x64" }, "sha512-Kp85jgoBHa05gix6UIRjfCDiUV3w/8VIdZ247VyyO2gEjaw12WEVhdIjlxp/AMzXxqxQwbxNTDVZ3Mwd2RG5rw=="],
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.0", "", { "os": "win32", "cpu": "x64" }, "sha512-VT/lF+GId+67j8aDfLkxdxNoVApsPSTbyAtB3jJq0IWTrY77WXfbPfpngxq0bA6JCEv/7k8C9qWjDRKRznDlyw=="],
 
     "@bramus/specificity": ["@bramus/specificity@2.4.2", "", { "dependencies": { "css-tree": "^3.0.0" }, "bin": { "specificity": "bin/cli.js" } }, "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw=="],
 

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "flatpickr": "4.6.9"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.4.16",
+    "@biomejs/biome": "2.5.0",
     "@playwright/test": "^1.59.0",
     "@sveltejs/vite-plugin-svelte": "^7.1.2",
     "@testing-library/jest-dom": "^6.9.1",

--- a/src/ComposedModal/ModalFooter.svelte
+++ b/src/ComposedModal/ModalFooter.svelte
@@ -55,7 +55,7 @@
   {...$$restProps}
 >
   {#if secondaryButtons.length > 0}
-    {#each secondaryButtons as button}
+    {#each secondaryButtons as button (button.text)}
       <Button
         kind="secondary"
         on:click={() => {

--- a/src/Modal/Modal.svelte
+++ b/src/Modal/Modal.svelte
@@ -313,7 +313,7 @@
         class:bx--modal-footer--three-button={secondaryButtons.length === 2}
       >
         {#if secondaryButtons.length > 0}
-          {#each secondaryButtons as button}
+          {#each secondaryButtons as button (button.text)}
             <Button
               kind="secondary"
               on:click={() => {

--- a/src/PaginationNav/PaginationNav.svelte
+++ b/src/PaginationNav/PaginationNav.svelte
@@ -127,7 +127,7 @@
         dispatch("change", { page });
       }}
     />
-    {#each items as item}
+    {#each items as item (item)}
       <PaginationItem
         page={item + 1}
         active={page === item + 1}

--- a/src/PaginationNav/PaginationOverflow.svelte
+++ b/src/PaginationNav/PaginationOverflow.svelte
@@ -33,7 +33,7 @@
         }}
       >
         <option value="" hidden></option>
-        {#each Array.from({ length: count }, (_, index) => index) as pageOffset}
+        {#each Array.from({ length: count }, (_, index) => index) as pageOffset (pageOffset)}
           <option
             value={fromIndex + pageOffset + 1}
             data-page={fromIndex + pageOffset + 1}

--- a/src/SkeletonText/SkeletonText.svelte
+++ b/src/SkeletonText/SkeletonText.svelte
@@ -27,7 +27,7 @@
       const rand = `${Math.floor(RANDOM[i % 3] * (max - min + 1)) + min}px`;
 
       return widthPx ? rand : `calc(${width} - ${rand})`;
-    }) as width}
+    }) as width, i (i)}
       <p
         class:bx--skeleton__text={true}
         class:bx--skeleton__heading={heading}

--- a/src/Tabs/TabsSkeleton.svelte
+++ b/src/Tabs/TabsSkeleton.svelte
@@ -23,7 +23,7 @@
   on:mouseleave
 >
   <ul class:bx--tabs--scrollable__nav={true}>
-    {#each Array.from({ length: count }, (_, i) => i) as item}
+    {#each Array.from({ length: count }, (_, i) => i) as item (item)}
       <li class:bx--tabs--scrollable__nav-item={true}>
         <div class:bx--tabs__nav-link={true}><span></span></div>
       </li>


### PR DESCRIPTION
Upgrades Biome to 2.5.0 and applies its config changes (preset rename, rule moves, svg exclude, expanded docs test overrides). Enables useSvelteRequireEachKey for src Svelte files and adds keys to each blocks that were missing them.

Keyed each gives Svelte a stable identity per item when a list updates. Without a key, Svelte diffs by position, which is fine for static lists but wrong when items reorder or when child state must stay with a specific item.

Skeleton and pagination placeholders use index as identity: slot 0 is the first line or tab, not the computed width string (which can collide). Pagination page numbers use the number itself since that is the item.

Modal secondary buttons use button.text as the key. Duplicate labels are unlikely in a two-button modal and the list does not reorder. If two buttons did share text, Svelte warns in dev; with a static non-sorting list both still render on mount and the mismatch only surfaces if the list is later reconciled with duplicate keys, which this API does not do.

Test plan: run biome check on src Svelte files; spot-check modal footer, pagination nav, skeleton text, and tabs skeleton in docs.