### PR TITLE
feat(copy-input): add FluidCopyInputSkeleton component

### DIFF
--- a/docs/src/pages/components/CopyInput.svx
+++ b/docs/src/pages/components/CopyInput.svx
@@ -1,5 +1,9 @@
+---
+components: ["CopyInput", "CopyInputSkeleton", "FluidCopyInputSkeleton"]
+---
+
 <script>
-  import { CopyInput, TooltipIcon } from "carbon-components-svelte";
+  import { CopyInput, CopyInputSkeleton, FluidCopyInputSkeleton, TooltipIcon } from "carbon-components-svelte";
   import Checkmark from "carbon-icons-svelte/lib/Checkmark.svelte";
   import Information from "carbon-icons-svelte/lib/Information.svelte";
 </script>
@@ -129,3 +133,21 @@ tooltip icon.
 ## Fluid variant (disabled)
 
 <CopyInput fluid disabled labelText="API token" value="sk-1234567890abcdef" />
+
+## Fluid skeleton
+
+Display a loading skeleton for the fluid copy input variant.
+
+<FluidCopyInputSkeleton />
+
+## Skeleton
+
+Show a loading state with the default skeleton variant.
+
+<CopyInputSkeleton />
+
+## Skeleton without label
+
+Set `hideLabel` to `true` to hide the skeleton label.
+
+<CopyInputSkeleton hideLabel />

--- a/src/CopyInput/CopyInputSkeleton.svelte
+++ b/src/CopyInput/CopyInputSkeleton.svelte
@@ -1,0 +1,20 @@
+<script>
+  /** Set to `true` to hide the label text */
+  export let hideLabel = false;
+</script>
+
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
+<!-- svelte-ignore a11y-no-static-element-interactions -->
+<div
+  class:bx--form-item={true}
+  {...$$restProps}
+  on:click
+  on:mouseover
+  on:mouseenter
+  on:mouseleave
+>
+  {#if !hideLabel}
+    <span class:bx--label={true} class:bx--skeleton={true}></span>
+  {/if}
+  <div class:bx--skeleton={true} class:bx--text-input={true}></div>
+</div>

--- a/src/CopyInput/FluidCopyInputSkeleton.svelte
+++ b/src/CopyInput/FluidCopyInputSkeleton.svelte
@@ -1,0 +1,14 @@
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
+<!-- svelte-ignore a11y-no-static-element-interactions -->
+<div
+  class:bx--form-item={true}
+  class:bx--text-input--fluid__skeleton={true}
+  {...$$restProps}
+  on:click
+  on:mouseover
+  on:mouseenter
+  on:mouseleave
+>
+  <span class:bx--label={true} class:bx--skeleton={true}></span>
+  <div class:bx--skeleton={true} class:bx--text-input={true}></div>
+</div>

--- a/src/CopyInput/index.js
+++ b/src/CopyInput/index.js
@@ -1,1 +1,3 @@
 export { default as CopyInput } from "./CopyInput.svelte";
+export { default as CopyInputSkeleton } from "./CopyInputSkeleton.svelte";
+export { default as FluidCopyInputSkeleton } from "./FluidCopyInputSkeleton.svelte";

--- a/src/index.js
+++ b/src/index.js
@@ -34,6 +34,8 @@ export { default as ContextMenuOption } from "./ContextMenu/ContextMenuOption.sv
 export { default as ContextMenuRadioGroup } from "./ContextMenu/ContextMenuRadioGroup.svelte";
 export { default as CopyButton } from "./CopyButton/CopyButton.svelte";
 export { default as CopyInput } from "./CopyInput/CopyInput.svelte";
+export { default as CopyInputSkeleton } from "./CopyInput/CopyInputSkeleton.svelte";
+export { default as FluidCopyInputSkeleton } from "./CopyInput/FluidCopyInputSkeleton.svelte";
 export { default as DataTable } from "./DataTable/DataTable.svelte";
 export { default as DataTableSkeleton } from "./DataTable/DataTableSkeleton.svelte";
 export { default as Table } from "./DataTable/Table.svelte";

--- a/tests/CopyInput/CopyInput.fluidSkeleton.test.svelte
+++ b/tests/CopyInput/CopyInput.fluidSkeleton.test.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+  import FluidCopyInputSkeleton from "carbon-components-svelte/CopyInput/FluidCopyInputSkeleton.svelte";
+</script>
+
+<FluidCopyInputSkeleton data-testid="fluid-copy-input-skeleton" />

--- a/tests/CopyInput/CopyInput.skeleton.test.svelte
+++ b/tests/CopyInput/CopyInput.skeleton.test.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  import CopyInputSkeleton from "carbon-components-svelte/CopyInput/CopyInputSkeleton.svelte";
+
+  export let hideLabel = false;
+</script>
+
+<CopyInputSkeleton data-testid="copy-input-skeleton" {hideLabel} />

--- a/tests/CopyInput/CopyInput.test.ts
+++ b/tests/CopyInput/CopyInput.test.ts
@@ -1,7 +1,9 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/svelte";
 import { user } from "../utils/user";
 import CopyInputFluidForm from "./CopyInput.fluidForm.test.svelte";
+import CopyInputFluidSkeleton from "./CopyInput.fluidSkeleton.test.svelte";
 import CopyInputFluidSlot from "./CopyInput.fluidSlot.test.svelte";
+import CopyInputSkeleton from "./CopyInput.skeleton.test.svelte";
 import CopyInput from "./CopyInput.test.svelte";
 import CopyInputAsync from "./CopyInputAsync.test.svelte";
 import CopyInputAsyncDoubleClick from "./CopyInputAsyncDoubleClick.test.svelte";
@@ -278,6 +280,50 @@ describe("CopyInput", () => {
 
       expect(fieldWrapper).not.toBeNull();
       expect(fieldWrapper?.closest(".bx--text-input--fluid")).not.toBeNull();
+    });
+  });
+
+  describe("skeleton", () => {
+    it("renders skeleton state", () => {
+      render(CopyInputSkeleton);
+
+      const skeleton = screen.getByTestId("copy-input-skeleton");
+      expect(skeleton).toBeInTheDocument();
+      expect(skeleton).toHaveClass("bx--form-item");
+      expect(skeleton.children).toHaveLength(2);
+      expect(skeleton.children[0]).toHaveClass("bx--label", "bx--skeleton");
+      expect(skeleton.children[1]).toHaveClass(
+        "bx--skeleton",
+        "bx--text-input",
+      );
+    });
+
+    it("hides the skeleton label when hideLabel is true", () => {
+      render(CopyInputSkeleton, { props: { hideLabel: true } });
+
+      const skeleton = screen.getByTestId("copy-input-skeleton");
+      expect(skeleton.children).toHaveLength(1);
+      expect(skeleton.children[0]).toHaveClass(
+        "bx--skeleton",
+        "bx--text-input",
+      );
+    });
+
+    it("renders fluid skeleton state", () => {
+      render(CopyInputFluidSkeleton);
+
+      const skeleton = screen.getByTestId("fluid-copy-input-skeleton");
+      expect(skeleton).toBeInTheDocument();
+      expect(skeleton).toHaveClass(
+        "bx--form-item",
+        "bx--text-input--fluid__skeleton",
+      );
+      expect(skeleton.children).toHaveLength(2);
+      expect(skeleton.children[0]).toHaveClass("bx--label", "bx--skeleton");
+      expect(skeleton.children[1]).toHaveClass(
+        "bx--skeleton",
+        "bx--text-input",
+      );
     });
   });
 });


### PR DESCRIPTION
#3283

Ensure `CopyInput` has a fluid skeleton, for parity.