### PR TITLE
fix(expandable-tile): link `aria-controls` to below-the-fold content

### DIFF
--- a/src/Tile/ExpandableTile.svelte
+++ b/src/Tile/ExpandableTile.svelte
@@ -138,6 +138,7 @@
       class:bx--tile__chevron={true}
       aria-expanded={hasInteractiveContent ? expanded : undefined}
       aria-label={hasInteractiveContent ? (expanded ? tileExpandedIconText : tileCollapsedIconText) : undefined}
+      aria-controls={hasInteractiveContent ? `${id}-content` : undefined}
       title={hasInteractiveContent ? (expanded ? tileExpandedIconText : tileCollapsedIconText) : undefined}
       on:click={() => {
         if (hasInteractiveContent) expanded = !expanded;
@@ -147,7 +148,7 @@
       <ChevronDown />
     </svelte:element>
     <div class:bx--tile-content={true}>
-      <span class:bx--tile-content__below-the-fold={true}>
+      <span id="{id}-content" class:bx--tile-content__below-the-fold={true}>
         <slot name="below" />
       </span>
     </div>

--- a/tests/ExpandableTile/ExpandableTile.test.ts
+++ b/tests/ExpandableTile/ExpandableTile.test.ts
@@ -152,6 +152,21 @@ describe("ExpandableTile", () => {
       expect(chevronButton).toHaveAttribute("aria-expanded", "false");
     });
 
+    it("should link the chevron button to the below-the-fold region via aria-controls", () => {
+      render(ExpandableTileVariants);
+
+      const tile = screen.getByTestId("interactive");
+      const chevronButton = tile.querySelector("button.bx--tile__chevron");
+      expect.assert(chevronButton);
+      expect(chevronButton).toHaveAttribute(
+        "aria-controls",
+        "interactive-tile-content",
+      );
+
+      const belowFold = tile.querySelector(".bx--tile-content__below-the-fold");
+      expect(belowFold).toHaveAttribute("id", "interactive-tile-content");
+    });
+
     it("should render as a div (not button) when it contains interactive content", () => {
       render(ExpandableTileVariants);
 

--- a/tests/ExpandableTile/ExpandableTileVariants.test.svelte
+++ b/tests/ExpandableTile/ExpandableTileVariants.test.svelte
@@ -19,7 +19,11 @@
 </ExpandableTile>
 
 <!-- Expandable tile with interactive content (link) in "above" slot -->
-<ExpandableTile data-testid="interactive" hasInteractiveContent>
+<ExpandableTile
+  data-testid="interactive"
+  id="interactive-tile"
+  hasInteractiveContent
+>
   <div slot="above">
     <a href="https://example.com" data-testid="inner-link">Learn more</a>
   </div>


### PR DESCRIPTION
Per the WAI-ARIA disclosure pattern, the toggling control must
reference the region it expands. Derive the region `id` from the
component `id` so AT users can navigate to the controlled content.