### PR TITLE
fix(expandable-tile): add aria-label to chevron toggle button

### DIFF
--- a/src/Tile/ExpandableTile.svelte
+++ b/src/Tile/ExpandableTile.svelte
@@ -137,6 +137,7 @@
       type={hasInteractiveContent ? "button" : undefined}
       class:bx--tile__chevron={true}
       aria-expanded={hasInteractiveContent ? expanded : undefined}
+      aria-label={hasInteractiveContent ? (expanded ? tileExpandedIconText : tileCollapsedIconText) : undefined}
       title={hasInteractiveContent ? (expanded ? tileExpandedIconText : tileCollapsedIconText) : undefined}
       on:click={() => {
         if (hasInteractiveContent) expanded = !expanded;

--- a/tests/ExpandableTile/ExpandableTile.test.ts
+++ b/tests/ExpandableTile/ExpandableTile.test.ts
@@ -159,6 +159,19 @@ describe("ExpandableTile", () => {
       expect(tile.tagName).not.toBe("BUTTON");
     });
 
+    it("should give the chevron button an accessible name when no labels are provided", () => {
+      render(ExpandableTileVariants);
+
+      const tile = screen.getByTestId("interactive");
+      const chevronButton = tile.querySelector("button.bx--tile__chevron");
+      expect.assert(chevronButton);
+
+      expect(chevronButton).toHaveAttribute(
+        "aria-label",
+        "Interact to expand Tile",
+      );
+    });
+
     it("should not toggle when clicking interactive button or link", async () => {
       render(ExpandableTileCustom);
 


### PR DESCRIPTION
The chevron `<button>` exposed `title` but no accessible name, so screen readers announced a bare "button". Mirror the title text via `aria-label` so the expand/collapse purpose is conveyed.