### PR TITLE
feat(ui-shell): `HeaderNavMenu` dispatches `close` event

### DIFF
--- a/src/UIShell/HeaderNavItem.svelte
+++ b/src/UIShell/HeaderNavItem.svelte
@@ -93,7 +93,7 @@
         menuItems[menuItems.length - 1]?.focus();
       } else if (event.key === "Escape") {
         event.preventDefault();
-        ctx.closeMenu();
+        ctx.closeMenu("escape-key");
       }
     }}
     on:focus
@@ -105,7 +105,7 @@
         selectedItemIds.indexOf(id) === selectedItemIds.length - 1 &&
         (!event.relatedTarget || !menuItems.includes(event.relatedTarget))
       ) {
-        ctx?.closeMenu();
+        ctx?.closeMenu("blur");
       }
     }}
   >

--- a/src/UIShell/HeaderNavMenu.svelte
+++ b/src/UIShell/HeaderNavMenu.svelte
@@ -1,5 +1,11 @@
 <script>
   /**
+   * @event close
+   * @type {object}
+   * @property {"escape-key" | "outside-click" | "blur"} trigger
+   */
+
+  /**
    * Set to `true` to toggle the expanded state.
    * @bindable writable
    */
@@ -21,11 +27,13 @@
    */
   export let ref = null;
 
-  import { setContext, tick } from "svelte";
+  import { createEventDispatcher, setContext, tick } from "svelte";
   import { writable } from "svelte/store";
   import ChevronDown from "../icons/ChevronDown.svelte";
   import { dismiss } from "../utils/dismiss.js";
   import { isOutsideClick } from "../utils/isOutsideClick.js";
+
+  const dispatch = createEventDispatcher();
 
   /**
    * @type {import("svelte/store").Writable<Record<string, boolean>>}
@@ -63,12 +71,15 @@
   }
 
   /**
-   * @type {() => Promise<void>}
+   * @type {(trigger?: "escape-key" | "blur") => Promise<void>}
    */
-  async function closeMenu() {
-    expanded = false;
-    await tick();
-    ref?.focus();
+  async function closeMenu(trigger) {
+    if (expanded) {
+      expanded = false;
+      if (trigger) dispatch("close", { trigger });
+      await tick();
+      ref?.focus();
+    }
   }
 
   setContext("carbon:HeaderNavMenu", {
@@ -84,7 +95,10 @@
     Object.values($selectedItems).filter(Boolean).length > 0;
 
   function handleOutsideClick(event) {
-    if (isOutsideClick(event, ref)) expanded = false;
+    if (expanded && isOutsideClick(event, ref)) {
+      expanded = false;
+      dispatch("close", { trigger: "outside-click" });
+    }
   }
 </script>
 
@@ -156,9 +170,7 @@
         $menuItems[$menuItems.length - 1]?.focus();
       } else if (event.key === "Escape") {
         event.preventDefault();
-        expanded = false;
-        await tick();
-        ref?.focus();
+        await closeMenu("escape-key");
       }
     }}
     on:click|preventDefault

--- a/tests/UIShell/HeaderNavMenuClose.test.svelte
+++ b/tests/UIShell/HeaderNavMenuClose.test.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  import Header from "../../src/UIShell/Header.svelte";
+  import HeaderNav from "../../src/UIShell/HeaderNav.svelte";
+  import HeaderNavItem from "../../src/UIShell/HeaderNavItem.svelte";
+  import HeaderNavMenu from "../../src/UIShell/HeaderNavMenu.svelte";
+
+  export let onClose: (e: CustomEvent<{ trigger: string }>) => void = () => {};
+</script>
+
+<Header companyName="Test" platformName="Test">
+  <HeaderNav>
+    <HeaderNavItem href="/outside" text="Outside Link" />
+    <HeaderNavMenu text="Menu" on:close={onClose}>
+      <HeaderNavItem href="/item1" text="Menu Item 1" />
+      <HeaderNavItem href="/item2" text="Menu Item 2" />
+    </HeaderNavMenu>
+  </HeaderNav>
+</Header>

--- a/tests/UIShell/HeaderNavMenuClose.test.ts
+++ b/tests/UIShell/HeaderNavMenuClose.test.ts
@@ -1,0 +1,60 @@
+import { render, screen } from "@testing-library/svelte";
+import { user } from "../utils/user";
+import HeaderNavMenuClose from "./HeaderNavMenuClose.test.svelte";
+
+describe("HeaderNavMenu close event", () => {
+  it('dispatches close with trigger "escape-key" from the trigger', async () => {
+    const onClose = vi.fn();
+    render(HeaderNavMenuClose, { props: { onClose } });
+
+    const menuTrigger = screen.getByRole("menuitem", { name: "Menu" });
+    menuTrigger.focus();
+    await user.keyboard(" ");
+    expect(menuTrigger).toHaveAttribute("aria-expanded", "true");
+
+    await user.keyboard("{Escape}");
+    expect(menuTrigger).toHaveAttribute("aria-expanded", "false");
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onClose.mock.calls[0][0].detail).toEqual({ trigger: "escape-key" });
+  });
+
+  it('dispatches close with trigger "escape-key" from a menu item', async () => {
+    const onClose = vi.fn();
+    render(HeaderNavMenuClose, { props: { onClose } });
+
+    const menuTrigger = screen.getByRole("menuitem", { name: "Menu" });
+    menuTrigger.focus();
+    await user.keyboard("{ArrowDown}");
+    expect(screen.getByRole("menuitem", { name: "Menu Item 1" })).toHaveFocus();
+
+    await user.keyboard("{Escape}");
+    expect(menuTrigger).toHaveAttribute("aria-expanded", "false");
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onClose.mock.calls[0][0].detail).toEqual({ trigger: "escape-key" });
+  });
+
+  it('dispatches close with trigger "outside-click" when clicking outside', async () => {
+    const onClose = vi.fn();
+    render(HeaderNavMenuClose, { props: { onClose } });
+
+    const menuTrigger = screen.getByRole("menuitem", { name: "Menu" });
+    menuTrigger.focus();
+    await user.keyboard(" ");
+    expect(menuTrigger).toHaveAttribute("aria-expanded", "true");
+
+    await user.click(screen.getByRole("menuitem", { name: "Outside Link" }));
+    expect(menuTrigger).toHaveAttribute("aria-expanded", "false");
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onClose.mock.calls[0][0].detail).toEqual({
+      trigger: "outside-click",
+    });
+  });
+
+  it("does not dispatch close on outside clicks while collapsed", async () => {
+    const onClose = vi.fn();
+    render(HeaderNavMenuClose, { props: { onClose } });
+
+    await user.click(screen.getByRole("menuitem", { name: "Outside Link" }));
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Mirror the UX of other menu/dialog components by dispatching a close event, with the trigger.