### PR TITLE
feat(context-menu): `close` event surfaces dismissal `trigger`

### DIFF
--- a/src/ContextMenu/ContextMenu.svelte
+++ b/src/ContextMenu/ContextMenu.svelte
@@ -4,6 +4,12 @@
    */
 
   /**
+   * @event close
+   * @type {object}
+   * @property {"escape-key" | "outside-click" | "select"} trigger
+   */
+
+  /**
    * Specify an element or list of elements to trigger the context menu.
    * If no element is specified, the context menu applies to the entire window.
    * @type {null | ReadonlyArray<null | HTMLElement>}
@@ -80,15 +86,17 @@
   let openDetail = null;
 
   /**
-   * @type {() => void}
+   * @type {(trigger: "escape-key" | "outside-click" | "select") => void}
    */
-  function close() {
+  function close(trigger) {
+    if (!open) return;
     open = false;
     x = 0;
     y = 0;
     prevX = 0;
     prevY = 0;
     focusIndex = -1;
+    dispatch("close", { trigger });
   }
 
   /** @type {(e: MouseEvent) => void} */
@@ -166,8 +174,6 @@
       }
 
       if (!prevOpen) dispatch("open", openDetail);
-    } else if (prevOpen) {
-      dispatch("close");
     }
     prevOpen = open;
 
@@ -179,10 +185,10 @@
   $: menuAriaLabel = ($$props["aria-label"] ?? labelText) || undefined;
 
   function handleOutsideClick(event) {
-    if (open && isOutsideClick(event, ref)) close();
+    if (open && isOutsideClick(event, ref)) close("outside-click");
   }
   function handleEscape(event) {
-    if (open && event.key === "Escape") close();
+    if (open && event.key === "Escape") close("escape-key");
   }
 </script>
 
@@ -232,7 +238,7 @@
     const closestOption = event.target.closest("[tabindex]");
 
     if (closestOption && closestOption.getAttribute("role") !== "menuitem") {
-      close();
+      close("select");
     }
   }}
   on:keydown

--- a/src/ContextMenu/ContextMenuOption.svelte
+++ b/src/ContextMenu/ContextMenuOption.svelte
@@ -204,7 +204,7 @@
         selected = !selected;
       }
 
-      ctx.close();
+      ctx.close("select");
     }
   }
 

--- a/tests/ContextMenu/ContextMenuClose.test.svelte
+++ b/tests/ContextMenu/ContextMenuClose.test.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+  import ContextMenu from "carbon-components-svelte/ContextMenu/ContextMenu.svelte";
+  import ContextMenuOption from "carbon-components-svelte/ContextMenu/ContextMenuOption.svelte";
+
+  export let open = false;
+  export let x = 0;
+  export let y = 0;
+</script>
+
+<ContextMenu
+  bind:open
+  {x}
+  {y}
+  on:close={(e) => {
+    console.log("close", e.detail.trigger);
+  }}
+>
+  <ContextMenuOption labelText="Option 1" />
+  <ContextMenuOption labelText="Option 2" />
+</ContextMenu>

--- a/tests/ContextMenu/ContextMenuClose.test.ts
+++ b/tests/ContextMenu/ContextMenuClose.test.ts
@@ -1,0 +1,33 @@
+import { render, screen } from "@testing-library/svelte";
+import { user } from "../utils/user";
+import ContextMenuClose from "./ContextMenuClose.test.svelte";
+
+describe("ContextMenu close trigger", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should surface 'escape-key' when closed via Escape", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(ContextMenuClose, { props: { open: true, x: 100, y: 100 } });
+
+    await user.keyboard("{Escape}");
+    expect(consoleLog).toHaveBeenCalledWith("close", "escape-key");
+  });
+
+  it("should surface 'outside-click' when closed via clicking outside", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(ContextMenuClose, { props: { open: true, x: 100, y: 100 } });
+
+    await user.click(document.body);
+    expect(consoleLog).toHaveBeenCalledWith("close", "outside-click");
+  });
+
+  it("should surface 'select' when closed by selecting an option", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(ContextMenuClose, { props: { open: true, x: 100, y: 100 } });
+
+    await user.click(screen.getByText("Option 1"));
+    expect(consoleLog).toHaveBeenCalledWith("close", "select");
+  });
+});


### PR DESCRIPTION
`ContextMenu` now dispatches `close` with a `trigger` of `escape-key`, `outside-click`, or `select`, so consumers can tell a dismissal from a selection-driven close. This follows the same prior art as `HeaderNavMenu` (#3308) and `Modal`. The trigger is routed through `close()` and dispatched directly to avoid losing the cause across the reactive open-watcher.