### PR TITLE
feat(ui-shell): `HeaderAction` close event surfaces dismissal `trigger`

### DIFF
--- a/src/UIShell/HeaderAction.svelte
+++ b/src/UIShell/HeaderAction.svelte
@@ -1,8 +1,12 @@
 <script>
   /**
    * @template [Icon=any]
-   * @event {null} open
-   * @event {null} close
+   * @event open
+   * @type {object}
+   * @property {"toggle"} trigger
+   * @event close
+   * @type {object}
+   * @property {"outside-click" | "toggle"} trigger
    */
 
   /**
@@ -95,7 +99,7 @@
       isOutsideClick(event, [ref, refPanel])
     ) {
       isOpen = false;
-      dispatch("close");
+      dispatch("close", { trigger: "outside-click" });
     }
   }
 </script>
@@ -112,7 +116,7 @@
   on:click
   on:click|stopPropagation={() => {
     isOpen = !isOpen;
-    dispatch(isOpen ? "open" : "close");
+    dispatch(isOpen ? "open" : "close", { trigger: "toggle" });
   }}
 >
   {#if hasIconOnly}

--- a/tests/UIShell/HeaderActionClose.test.svelte
+++ b/tests/UIShell/HeaderActionClose.test.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+  import Header from "../../src/UIShell/Header.svelte";
+  import HeaderAction from "../../src/UIShell/HeaderAction.svelte";
+  import HeaderUtilities from "../../src/UIShell/HeaderUtilities.svelte";
+
+  export let preventCloseOnClickOutside = false;
+  export let onClose: (e: CustomEvent<{ trigger: string }>) => void = () => {};
+  export let onOpen: (e: CustomEvent<{ trigger: string }>) => void = () => {};
+</script>
+
+<button type="button" data-testid="outside">Outside</button>
+<Header companyName="Test" platformName="Test">
+  <HeaderUtilities>
+    <HeaderAction
+      {preventCloseOnClickOutside}
+      transition={false}
+      iconDescription="Switcher"
+      on:open={onOpen}
+      on:close={onClose}
+    >
+      <p data-testid="panel-content">Panel content</p>
+    </HeaderAction>
+  </HeaderUtilities>
+</Header>

--- a/tests/UIShell/HeaderActionClose.test.ts
+++ b/tests/UIShell/HeaderActionClose.test.ts
@@ -1,0 +1,53 @@
+import { render, screen } from "@testing-library/svelte";
+import { user } from "../utils/user";
+import HeaderActionClose from "./HeaderActionClose.test.svelte";
+
+describe("HeaderAction close event", () => {
+  const getActionButton = () =>
+    screen.getByRole("button", { name: "Switcher" });
+
+  it('dispatches close with trigger "toggle" when the button closes the panel', async () => {
+    const onOpen = vi.fn();
+    const onClose = vi.fn();
+    render(HeaderActionClose, { props: { onOpen, onClose } });
+
+    await user.click(getActionButton());
+    expect(getActionButton()).toHaveClass("bx--header__action--active");
+    expect(onOpen).toHaveBeenCalledTimes(1);
+    expect(onOpen.mock.calls[0][0].detail).toEqual({ trigger: "toggle" });
+
+    await user.click(getActionButton());
+    expect(getActionButton()).not.toHaveClass("bx--header__action--active");
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onClose.mock.calls[0][0].detail).toEqual({ trigger: "toggle" });
+  });
+
+  it('dispatches close with trigger "outside-click" when clicking outside', async () => {
+    const onClose = vi.fn();
+    render(HeaderActionClose, { props: { onClose } });
+
+    await user.click(getActionButton());
+    expect(getActionButton()).toHaveClass("bx--header__action--active");
+
+    await user.click(screen.getByTestId("outside"));
+    expect(getActionButton()).not.toHaveClass("bx--header__action--active");
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onClose.mock.calls[0][0].detail).toEqual({
+      trigger: "outside-click",
+    });
+  });
+
+  it("does not dispatch close on outside click when preventCloseOnClickOutside is set", async () => {
+    const onClose = vi.fn();
+    render(HeaderActionClose, {
+      props: { onClose, preventCloseOnClickOutside: true },
+    });
+
+    await user.click(getActionButton());
+    expect(getActionButton()).toHaveClass("bx--header__action--active");
+
+    await user.click(screen.getByTestId("outside"));
+    expect(getActionButton()).toHaveClass("bx--header__action--active");
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
`HeaderAction`'s `open` and `close` events now carry a `trigger` property so consumers can distinguish an `outside-click` dismissal from a deliberate `toggle`. This follows the prior art in #3308 (`HeaderNavMenu`) and `Modal`, and `bind:isOpen` stays authoritative.