### PR TITLE
feat(overflow-menu): `close` event surfaces dismissal `trigger`

### DIFF
--- a/src/OverflowMenu/OverflowMenu.svelte
+++ b/src/OverflowMenu/OverflowMenu.svelte
@@ -1,9 +1,14 @@
 <script>
   /**
    * @template [Icon=any]
+   */
+
+  /**
    * @event close
-   * @property {number} [index]
-   * @property {string} [text]
+   * @type {object}
+   * @property {"escape-key" | "outside-click" | "toggle" | "item-select"} trigger
+   * @property {number} [index] only present when an item is selected
+   * @property {string} [text] only present when an item is selected
    */
 
   /**
@@ -148,7 +153,7 @@
 
     const shouldContinue = dispatch(
       "close",
-      { index: item.index, text: item.text },
+      { trigger: "item-select", index: item.index, text: item.text },
       { cancelable: true },
     );
     if (shouldContinue) {
@@ -249,7 +254,11 @@
 
   function handleOutsideClick(event) {
     if (menuRef && isOutsideClick(event, [buttonRef, menuRef])) {
-      const shouldContinue = dispatch("close", null, { cancelable: true });
+      const shouldContinue = dispatch(
+        "close",
+        { trigger: "outside-click" },
+        { cancelable: true },
+      );
       if (shouldContinue) {
         open = false;
       }
@@ -279,7 +288,11 @@
   on:click={({ target }) => {
     if (!menuRef?.contains(target)) {
       if (open) {
-        const shouldContinue = dispatch("close", null, { cancelable: true });
+        const shouldContinue = dispatch(
+          "close",
+          { trigger: "toggle" },
+          { cancelable: true },
+        );
         if (shouldContinue) {
           open = false;
         }
@@ -304,7 +317,11 @@
         last();
       } else if (event.key === "Escape") {
         event.stopPropagation();
-        const shouldContinue = dispatch("close", null, { cancelable: true });
+        const shouldContinue = dispatch(
+          "close",
+          { trigger: "escape-key" },
+          { cancelable: true },
+        );
         if (shouldContinue) {
           open = false;
           buttonRef.focus();
@@ -348,7 +365,11 @@
         e.preventDefault();
       } else if (e.key === "Escape") {
         e.stopPropagation();
-        const shouldContinue = dispatch("close", null, { cancelable: true });
+        const shouldContinue = dispatch(
+          "close",
+          { trigger: "escape-key" },
+          { cancelable: true },
+        );
         if (shouldContinue) {
           open = false;
           buttonRef.focus();
@@ -391,7 +412,11 @@
           event.preventDefault();
         } else if (event.key === "Escape") {
           event.stopPropagation();
-          const shouldContinue = dispatch("close", null, { cancelable: true });
+          const shouldContinue = dispatch(
+            "close",
+            { trigger: "escape-key" },
+            { cancelable: true },
+          );
           if (shouldContinue) {
             open = false;
             buttonRef.focus();

--- a/tests/OverflowMenu/OverflowMenu.test.svelte
+++ b/tests/OverflowMenu/OverflowMenu.test.svelte
@@ -31,7 +31,7 @@
   {id}
   {portalMenu}
   on:close={(e) => {
-    console.log("close", e.detail); // { index: number; text: string; }
+    console.log("close", e.detail); // { trigger: string; index?: number; text?: string; }
   }}
 >
   <OverflowMenuItem

--- a/tests/OverflowMenu/OverflowMenu.test.ts
+++ b/tests/OverflowMenu/OverflowMenu.test.ts
@@ -71,6 +71,7 @@ describe("OverflowMenu", () => {
 
     expect(menuButton).toHaveAttribute("aria-expanded", "false");
     expect(spy).toHaveBeenCalledWith("close", {
+      trigger: "item-select",
       index: 0,
       text: "Manage credentials",
     });
@@ -114,7 +115,7 @@ describe("OverflowMenu", () => {
 
     await user.keyboard("{Escape}");
     expect(menuButton).toHaveAttribute("aria-expanded", "false");
-    expect(spy).toHaveBeenCalledWith("close", null);
+    expect(spy).toHaveBeenCalledWith("close", { trigger: "escape-key" });
   });
 
   it("does not infinite-loop when all items are disabled", async () => {
@@ -456,6 +457,7 @@ describe("OverflowMenu", () => {
     await user.click(menuItems[0]);
 
     expect(spy).toHaveBeenCalledWith("close", {
+      trigger: "item-select",
       index: 0,
       text: "Manage credentials",
     });
@@ -470,7 +472,7 @@ describe("OverflowMenu", () => {
 
     await user.keyboard("{Escape}");
 
-    expect(spy).toHaveBeenCalledWith("close", null);
+    expect(spy).toHaveBeenCalledWith("close", { trigger: "escape-key" });
   });
 
   it("handles close event with outside click", async () => {
@@ -482,7 +484,7 @@ describe("OverflowMenu", () => {
 
     await user.click(document.body);
 
-    expect(spy).toHaveBeenCalledWith("close", null);
+    expect(spy).toHaveBeenCalledWith("close", { trigger: "outside-click" });
   });
 
   it("supports preventDefault on item to prevent menu from closing", async () => {
@@ -498,6 +500,7 @@ describe("OverflowMenu", () => {
 
     expect(consoleLog).toHaveBeenCalledWith("click", "Manage credentials");
     expect(consoleLog).not.toHaveBeenCalledWith("close", {
+      trigger: "item-select",
       index: 0,
       text: "Manage credentials",
     });
@@ -533,6 +536,7 @@ describe("OverflowMenu", () => {
     expect(clickEvent.defaultPrevented).toBe(true);
     expect(consoleLog).not.toHaveBeenCalledWith("click", "API documentation");
     expect(consoleLog).not.toHaveBeenCalledWith("close", {
+      trigger: "item-select",
       index: 0,
       text: "API documentation",
     });

--- a/tests/OverflowMenu/OverflowMenuClose.test.svelte
+++ b/tests/OverflowMenu/OverflowMenuClose.test.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  import OverflowMenu from "../../src/OverflowMenu/OverflowMenu.svelte";
+  import OverflowMenuItem from "../../src/OverflowMenu/OverflowMenuItem.svelte";
+
+  export let onClose: (e: CustomEvent<{ trigger: string }>) => void = () => {};
+  export let cancelClose = false;
+</script>
+
+<OverflowMenu
+  on:close={(e) => {
+    if (cancelClose) e.preventDefault();
+    onClose(e);
+  }}
+>
+  <OverflowMenuItem text="Manage credentials" />
+  <OverflowMenuItem text="API documentation" />
+  <OverflowMenuItem danger text="Delete service" />
+</OverflowMenu>

--- a/tests/OverflowMenu/OverflowMenuClose.test.ts
+++ b/tests/OverflowMenu/OverflowMenuClose.test.ts
@@ -1,0 +1,64 @@
+import { render, screen } from "@testing-library/svelte";
+import { user } from "../utils/user";
+import OverflowMenuClose from "./OverflowMenuClose.test.svelte";
+
+describe("OverflowMenu close event trigger", () => {
+  it('dispatches close with trigger "escape-key" from the trigger button', async () => {
+    const onClose = vi.fn();
+    render(OverflowMenuClose, { props: { onClose } });
+
+    const menuButton = screen.getByRole("button");
+    await user.click(menuButton);
+    expect(menuButton).toHaveAttribute("aria-expanded", "true");
+
+    await user.keyboard("{Escape}");
+    expect(menuButton).toHaveAttribute("aria-expanded", "false");
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onClose.mock.calls[0][0].detail).toEqual({ trigger: "escape-key" });
+  });
+
+  it('dispatches close with trigger "outside-click" when clicking outside', async () => {
+    const onClose = vi.fn();
+    render(OverflowMenuClose, { props: { onClose } });
+
+    const menuButton = screen.getByRole("button");
+    await user.click(menuButton);
+    expect(menuButton).toHaveAttribute("aria-expanded", "true");
+
+    await user.click(document.body);
+    expect(menuButton).toHaveAttribute("aria-expanded", "false");
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onClose.mock.calls[0][0].detail).toEqual({
+      trigger: "outside-click",
+    });
+  });
+
+  it('dispatches close with trigger "toggle" when the trigger click closes an open menu', async () => {
+    const onClose = vi.fn();
+    render(OverflowMenuClose, { props: { onClose } });
+
+    const menuButton = screen.getByRole("button");
+    await user.click(menuButton);
+    expect(menuButton).toHaveAttribute("aria-expanded", "true");
+
+    await user.click(menuButton);
+    expect(menuButton).toHaveAttribute("aria-expanded", "false");
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onClose.mock.calls[0][0].detail).toEqual({ trigger: "toggle" });
+  });
+
+  it("preventDefault on the close event cancels the close (cancelable contract)", async () => {
+    const onClose = vi.fn();
+    render(OverflowMenuClose, { props: { onClose, cancelClose: true } });
+
+    const menuButton = screen.getByRole("button");
+    await user.click(menuButton);
+    expect(menuButton).toHaveAttribute("aria-expanded", "true");
+
+    await user.keyboard("{Escape}");
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onClose.mock.calls[0][0].detail).toEqual({ trigger: "escape-key" });
+    // Close was canceled: the menu stays open.
+    expect(menuButton).toHaveAttribute("aria-expanded", "true");
+  });
+});


### PR DESCRIPTION
`OverflowMenu` now stamps every `close` dispatch with a `trigger` (`escape-key`/`outside-click`/`toggle`/`item-select`) so consumers can tell why the menu closed, extending the pattern from #3308 (`HeaderNavMenu`) and `Modal`. Note the JSDoc previously claimed `index`/`text` detail that only the item-select path ever emitted, so this reconciles the docs while keeping `index`/`text` on that path for backward compatibility. Cancelable semantics and `bind:open` are unchanged.