### PR TITLE
feat(dropdown): dispatch `close` event with dismissal `trigger`

### DIFF
--- a/src/Dropdown/Dropdown.svelte
+++ b/src/Dropdown/Dropdown.svelte
@@ -19,6 +19,12 @@
    */
 
   /**
+   * @event close
+   * @type {object}
+   * @property {"escape-key" | "outside-click" | "select"} trigger
+   */
+
+  /**
    * Set the dropdown items.
    * @type {ReadonlyArray<Item>}
    */
@@ -401,11 +407,31 @@
     });
   }
 
+  /**
+   * Close the menu and notify consumers of the dismissal cause.
+   * Only dispatches when transitioning from open to closed so redundant
+   * `open = false` assignments do not double-fire.
+   * @param {"escape-key" | "outside-click" | "select"} trigger
+   */
+  function close(trigger) {
+    if (open) {
+      open = false;
+      dispatch("close", { trigger });
+    }
+  }
+
   function selectHighlighted() {
-    open = !open;
+    if (!open) {
+      open = true;
+      return;
+    }
     if (highlightedIndex > -1 && items[highlightedIndex].id !== selectedId) {
       selectedId = items[highlightedIndex].id;
       dispatchSelect();
+      close("select");
+    } else {
+      // Toggling closed via Enter/Space without picking a (new) item is not a
+      // meaningful dismissal trigger, so close silently.
       open = false;
     }
   }
@@ -428,7 +454,7 @@
 
   function handleOutsideClick(event) {
     if (open && isOutsideClick(event, [ref, effectivePortalMenu && listRef])) {
-      open = false;
+      close("outside-click");
     }
   }
 </script>
@@ -536,7 +562,9 @@
             if (event.key === "ArrowDown" && !open) {
               open = true;
             } else if (event.key === "ArrowUp" && open) {
-              open = false;
+              // APG combobox: Alt+ArrowUp dismisses an open menu without
+              // selecting, so it shares the keyboard-dismissal trigger.
+              close("escape-key");
             }
           } else if (open) {
             change(step);
@@ -550,7 +578,7 @@
             });
           }
         } else if (event.key === "Escape") {
-          open = false;
+          close("escape-key");
         } else if (
           open &&
           event.key.length === 1 &&
@@ -638,7 +666,7 @@
                     }
                     selectedId = item.id;
                     dispatchSelect();
-                    open = false;
+                    close("select");
                     ref.focus();
                   }}
                   on:mouseenter={() => {
@@ -702,7 +730,7 @@
                 }
                 selectedId = item.id;
                 dispatchSelect();
-                open = false;
+                close("select");
                 ref.focus();
               }}
               on:mouseenter={() => {

--- a/tests/Dropdown/DropdownClose.test.svelte
+++ b/tests/Dropdown/DropdownClose.test.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import type { ComponentProps } from "svelte";
+  import Dropdown from "../../src/Dropdown/Dropdown.svelte";
+
+  export let items: ComponentProps<Dropdown>["items"] = [
+    { id: "0", text: "Slack" },
+    { id: "1", text: "Email" },
+    { id: "2", text: "Fax" },
+  ];
+  export let selectedId: ComponentProps<Dropdown>["selectedId"] = "0";
+  export let open: ComponentProps<Dropdown>["open"] = false;
+  export let onClose: (e: CustomEvent<{ trigger: string }>) => void = () => {};
+</script>
+
+<Dropdown
+  {items}
+  bind:selectedId
+  bind:open
+  labelText="Contact"
+  on:close={onClose}
+/>

--- a/tests/Dropdown/DropdownClose.test.ts
+++ b/tests/Dropdown/DropdownClose.test.ts
@@ -1,0 +1,64 @@
+import { render, screen } from "@testing-library/svelte";
+import { user } from "../utils/user";
+import DropdownClose from "./DropdownClose.test.svelte";
+
+describe("Dropdown close event", () => {
+  it('dispatches close with trigger "escape-key" on Escape', async () => {
+    const onClose = vi.fn();
+    render(DropdownClose, { props: { onClose } });
+
+    const button = screen.getByRole("combobox");
+    await user.click(button);
+    expect(screen.getByRole("listbox")).toBeVisible();
+
+    await user.keyboard("{Escape}");
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onClose.mock.calls[0][0].detail).toEqual({ trigger: "escape-key" });
+  });
+
+  it('dispatches close with trigger "outside-click" when clicking outside', async () => {
+    const onClose = vi.fn();
+    render(DropdownClose, { props: { onClose } });
+
+    await user.click(screen.getByRole("combobox"));
+    expect(screen.getByRole("listbox")).toBeVisible();
+
+    await user.click(document.body);
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onClose.mock.calls[0][0].detail).toEqual({
+      trigger: "outside-click",
+    });
+  });
+
+  it('dispatches close with trigger "select" when selecting an item', async () => {
+    const onClose = vi.fn();
+    render(DropdownClose, { props: { onClose } });
+
+    await user.click(screen.getByRole("combobox"));
+
+    const menuItem = screen
+      .getByText("Email")
+      .closest(".bx--list-box__menu-item");
+    expect(menuItem).not.toBeNull();
+    await user.click(menuItem as Element);
+
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onClose.mock.calls[0][0].detail).toEqual({ trigger: "select" });
+  });
+
+  it("does not dispatch close when the menu is already closed", async () => {
+    const onClose = vi.fn();
+    render(DropdownClose, { props: { onClose } });
+
+    // Menu starts closed; Escape and outside clicks must be no-ops.
+    const button = screen.getByRole("combobox");
+    button.focus();
+    await user.keyboard("{Escape}");
+    await user.click(document.body);
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
`Dropdown` now dispatches a `close` event carrying a `trigger` of `escape-key`, `outside-click`, or `select` so consumers can hook analytics or animations off a dismissal, mirroring `HeaderNavMenu` (#3308) and `Modal`. It only fires on a true open to closed transition, and `bind:open` plus the existing `select` event stay authoritative. Keyboard toggles and Tab focus-out are left as silent closes since they have no meaningful trigger value.