### PR TITLE
feat(combo-box): dispatch `close` event with dismissal `trigger`

### DIFF
--- a/src/ComboBox/ComboBox.svelte
+++ b/src/ComboBox/ComboBox.svelte
@@ -20,6 +20,12 @@
    */
 
   /**
+   * @event close
+   * @type {object}
+   * @property {"escape-key" | "outside-click" | "select"} trigger
+   */
+
+  /**
    * Set the combobox items.
    * @type {ReadonlyArray<Item>}
    */
@@ -525,9 +531,21 @@
     .filter(Boolean)
     .join(" ");
 
+  /**
+   * Close the dropdown and surface the dismissal cause.
+   * Guarded on `open` so redundant assignments don't double-fire the event.
+   * @param {"escape-key" | "outside-click" | "select"} trigger
+   */
+  function close(trigger) {
+    if (open) {
+      open = false;
+      dispatch("close", { trigger });
+    }
+  }
+
   function handleOutsideClick(event) {
     if (open && isOutsideClick(event, [ref, effectivePortalMenu && listRef])) {
-      open = false;
+      close("outside-click");
     }
   }
 </script>
@@ -628,6 +646,7 @@
             event.preventDefault();
           }
           if (event.key === "Enter") {
+            const wasOpen = open;
             open = !open;
             if (
               highlightedIndex > -1 &&
@@ -639,6 +658,7 @@
                 value = itemToString(filteredItems[highlightedIndex]);
                 selectedItem = filteredItems[highlightedIndex];
                 selectedId = filteredItems[highlightedIndex].id;
+                if (wasOpen) dispatch("close", { trigger: "select" });
               }
             } else {
               // Match typed value case-insensitively against item text
@@ -654,11 +674,12 @@
                 selectedItem = matchedItem;
                 value = itemToString(selectedItem);
                 selectedId = selectedItem.id;
+                if (wasOpen) dispatch("close", { trigger: "select" });
               }
             }
             highlightedIndex = -1;
           } else if (event.key === "Tab") {
-            open = false;
+            close("escape-key");
           } else if (event.key === "ArrowDown" || event.key === "ArrowUp") {
             const step = event.key === "ArrowDown" ? 1 : -1;
             if (event.altKey) {
@@ -667,7 +688,7 @@
               if (event.key === "ArrowDown" && !open) {
                 open = true;
               } else if (event.key === "ArrowUp" && open) {
-                open = false;
+                close("escape-key");
               }
             } else if (open) {
               change(step);
@@ -682,6 +703,8 @@
               });
             }
           } else if (event.key === "Escape") {
+            // Dispatch before `clear()` flips `open`, so the guard still sees it open.
+            close("escape-key");
             clear();
           }
         }}
@@ -781,7 +804,7 @@
                       return;
                     }
                     selectedId = item.id;
-                    open = false;
+                    close("select");
                     valueBeforeOpen = "";
 
                     if (filteredItems[actualIndex]) {
@@ -848,7 +871,7 @@
                   return;
                 }
                 selectedId = item.id;
-                open = false;
+                close("select");
                 valueBeforeOpen = "";
 
                 if (filteredItems[index]) {

--- a/tests/ComboBox/ComboBoxClose.test.svelte
+++ b/tests/ComboBox/ComboBoxClose.test.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+  import ComboBox from "carbon-components-svelte/ComboBox/ComboBox.svelte";
+  import type { ComponentProps } from "svelte";
+
+  type TestItem = { id: string; text: string };
+
+  export let items: TestItem[] = [
+    { id: "0", text: "Slack" },
+    { id: "1", text: "Email" },
+    { id: "2", text: "Fax" },
+  ];
+  export let selectedId: ComponentProps<ComboBox>["selectedId"] = undefined;
+  export let value = "";
+  export let clearFilterOnOpen = false;
+  export let onClose: (e: CustomEvent<{ trigger: string }>) => void = () => {};
+</script>
+
+<button type="button">Outside</button>
+<ComboBox
+  {items}
+  bind:selectedId
+  bind:value
+  {clearFilterOnOpen}
+  labelText="Contact"
+  on:close={onClose}
+/>

--- a/tests/ComboBox/ComboBoxClose.test.ts
+++ b/tests/ComboBox/ComboBoxClose.test.ts
@@ -1,0 +1,103 @@
+import { render, screen } from "@testing-library/svelte";
+import { user } from "../utils/user";
+import ComboBoxClose from "./ComboBoxClose.test.svelte";
+
+describe("ComboBox close event", () => {
+  const getInput = () => {
+    const input = screen.getByRole("combobox");
+    assert(input instanceof HTMLInputElement);
+    return input;
+  };
+
+  it('dispatches close with trigger "escape-key" on Escape', async () => {
+    const onClose = vi.fn();
+    render(ComboBoxClose, { props: { onClose } });
+
+    await user.click(getInput());
+    expect(screen.getByRole("listbox")).toBeVisible();
+
+    await user.keyboard("{Escape}");
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onClose.mock.calls[0][0].detail).toEqual({ trigger: "escape-key" });
+  });
+
+  it('dispatches close with trigger "outside-click" when clicking outside', async () => {
+    const onClose = vi.fn();
+    render(ComboBoxClose, { props: { onClose } });
+
+    await user.click(getInput());
+    expect(screen.getByRole("listbox")).toBeVisible();
+
+    await user.click(screen.getByText("Outside"));
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onClose.mock.calls[0][0].detail).toEqual({
+      trigger: "outside-click",
+    });
+  });
+
+  it('dispatches close with trigger "select" when clicking an item', async () => {
+    const onClose = vi.fn();
+    render(ComboBoxClose, { props: { onClose } });
+
+    await user.click(getInput());
+    await user.click(screen.getByText("Email"));
+
+    expect(getInput()).toHaveValue("Email");
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onClose.mock.calls[0][0].detail).toEqual({ trigger: "select" });
+  });
+
+  it('dispatches close with trigger "select" when selecting via Enter', async () => {
+    const onClose = vi.fn();
+    render(ComboBoxClose, { props: { onClose } });
+
+    const input = getInput();
+    await user.click(input);
+    await user.keyboard("{ArrowDown}{Enter}");
+
+    expect(input).toHaveValue("Slack");
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onClose.mock.calls[0][0].detail).toEqual({ trigger: "select" });
+  });
+
+  it("does not dispatch close when the menu is already closed", async () => {
+    const onClose = vi.fn();
+    render(ComboBoxClose, { props: { onClose } });
+
+    // Escape while collapsed clears state but must not surface a close.
+    getInput().focus();
+    await user.keyboard("{Escape}");
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("restores the value on close without a selection and still dispatches close", async () => {
+    const onClose = vi.fn();
+    render(ComboBoxClose, {
+      props: {
+        onClose,
+        clearFilterOnOpen: true,
+        selectedId: "1",
+        value: "Email",
+      },
+    });
+
+    const input = getInput();
+    expect(input).toHaveValue("Email");
+
+    // Opening with clearFilterOnOpen blanks the filter to show all items.
+    await user.click(input);
+    expect(input).toHaveValue("");
+
+    // Closing without a new selection restores the previous value.
+    await user.click(screen.getByText("Outside"));
+    expect(input).toHaveValue("Email");
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onClose.mock.calls[0][0].detail).toEqual({
+      trigger: "outside-click",
+    });
+  });
+});


### PR DESCRIPTION
`ComboBox` now dispatches a non-cancelable `close` event carrying a `trigger` (`escape-key` / `outside-click` / `select`) so consumers can hook analytics or animations off a dismissal, following the same pattern as `HeaderNavMenu` in #3308. Every `open = false` site is routed through a guarded `close(trigger)` helper that fires only when the menu was open, so it never double-fires or fires while collapsed. Value-restore-on-close and `bind:open` are unchanged; the event is purely additive.