### PR TITLE
feat(multi-select): dispatch `close` event with dismissal `trigger`

### DIFF
--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -17,6 +17,7 @@
    * @property {Item[]} unselected
    * @event {null} clear
    * @event {FocusEvent | CustomEvent<FocusEvent>} blur
+   * @event {{ trigger: "escape-key" | "outside-click" }} close
    * @slot {{ item: Item; index: number; selected: boolean; highlighted: boolean; }}
    */
 
@@ -626,12 +627,24 @@
     .filter(Boolean)
     .join(" ");
 
+  /**
+   * Dismiss the menu and notify consumers of the cause. Guarded on `open` so a
+   * dismissal gesture fired while already closed does not emit a phantom event.
+   * @type {(trigger: "escape-key" | "outside-click") => void}
+   */
+  function close(trigger) {
+    if (open) {
+      open = false;
+      dispatch("close", { trigger });
+    }
+  }
+
   function handleOutsideInteraction(event) {
     if (
       open &&
       isOutsideClick(event, [multiSelectRef, effectivePortalMenu && listRef])
     ) {
-      open = false;
+      close("outside-click");
     }
   }
 </script>
@@ -765,14 +778,14 @@
                 if (event.key === "ArrowDown" && !open) {
                   open = true;
                 } else if (event.key === "ArrowUp" && open) {
-                  open = false;
+                  close("escape-key");
                 }
               } else {
                 if (!open) open = true;
                 change(step);
               }
             } else if (event.key === "Escape") {
-              open = false;
+              close("escape-key");
             } else if (event.key === " ") {
               if (!open) open = true;
             } else if (event.key === "Backspace" && value === "") {
@@ -895,7 +908,7 @@
               if (event.key === "ArrowDown" && !open) {
                 open = true;
               } else if (event.key === "ArrowUp" && open) {
-                open = false;
+                close("escape-key");
               }
             } else {
               if (!open) open = true;
@@ -909,7 +922,7 @@
               if (item) selectItem(item);
             }
           } else if (event.key === "Escape") {
-            open = false;
+            close("escape-key");
           }
         }}
           on:blur={(event) => {

--- a/tests/MultiSelect/MultiSelectClose.test.svelte
+++ b/tests/MultiSelect/MultiSelectClose.test.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import MultiSelect from "../../src/MultiSelect/MultiSelect.svelte";
+
+  export let filterable = false;
+  export let onClose: (e: CustomEvent<{ trigger: string }>) => void = () => {};
+
+  const items = [
+    { id: "0", text: "Slack" },
+    { id: "1", text: "Email" },
+  ];
+</script>
+
+<button type="button">Outside</button>
+<MultiSelect
+  {filterable}
+  {items}
+  labelText="Contact"
+  label="Select contact methods"
+  placeholder="Filter contacts"
+  on:close={onClose}
+/>

--- a/tests/MultiSelect/MultiSelectClose.test.ts
+++ b/tests/MultiSelect/MultiSelectClose.test.ts
@@ -1,0 +1,70 @@
+import { render, screen } from "@testing-library/svelte";
+import { user } from "../utils/user";
+import MultiSelectClose from "./MultiSelectClose.test.svelte";
+
+describe("MultiSelect close event", () => {
+  it('dispatches close with trigger "escape-key" on Escape', async () => {
+    const onClose = vi.fn();
+    render(MultiSelectClose, { props: { onClose } });
+
+    const combobox = screen.getByRole("combobox");
+    await user.click(combobox);
+    expect(combobox).toHaveAttribute("aria-expanded", "true");
+
+    await user.keyboard("{Escape}");
+    expect(combobox).toHaveAttribute("aria-expanded", "false");
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onClose.mock.calls[0][0].detail).toEqual({ trigger: "escape-key" });
+  });
+
+  it('dispatches close with trigger "escape-key" on Alt+ArrowUp', async () => {
+    const onClose = vi.fn();
+    render(MultiSelectClose, { props: { onClose } });
+
+    const combobox = screen.getByRole("combobox");
+    await user.click(combobox);
+    expect(combobox).toHaveAttribute("aria-expanded", "true");
+
+    await user.keyboard("{Alt>}{ArrowUp}{/Alt}");
+    expect(combobox).toHaveAttribute("aria-expanded", "false");
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onClose.mock.calls[0][0].detail).toEqual({ trigger: "escape-key" });
+  });
+
+  it('dispatches close with trigger "outside-click" when clicking outside', async () => {
+    const onClose = vi.fn();
+    render(MultiSelectClose, { props: { onClose } });
+
+    const combobox = screen.getByRole("combobox");
+    await user.click(combobox);
+    expect(combobox).toHaveAttribute("aria-expanded", "true");
+
+    await user.click(screen.getByRole("button", { name: "Outside" }));
+    expect(combobox).toHaveAttribute("aria-expanded", "false");
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onClose.mock.calls[0][0].detail).toEqual({
+      trigger: "outside-click",
+    });
+  });
+
+  it("does not dispatch close when selecting an item (menu stays open)", async () => {
+    const onClose = vi.fn();
+    render(MultiSelectClose, { props: { onClose } });
+
+    const combobox = screen.getByRole("combobox");
+    await user.click(combobox);
+    expect(combobox).toHaveAttribute("aria-expanded", "true");
+
+    await user.click(screen.getByRole("option", { name: "Email" }));
+    expect(combobox).toHaveAttribute("aria-expanded", "true");
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("does not dispatch close on outside clicks while collapsed", async () => {
+    const onClose = vi.fn();
+    render(MultiSelectClose, { props: { onClose } });
+
+    await user.click(screen.getByRole("button", { name: "Outside" }));
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Adds a `close` event to `MultiSelect` carrying a `trigger` of `"escape-key"` or `"outside-click"`, so consumers can hook off a dismissal. This mirrors the pattern from #3308 (`HeaderNavMenu`) and `Modal`, routing dismissals through a guarded helper that fires only when the menu was open. `bind:open`, selection behavior, and the existing `select`/`clear`/`blur` events are unchanged.