### PR TITLE
feat(date-picker): `close` event surfaces dismissal `trigger`

### DIFF
--- a/e2e/date-picker.test.ts
+++ b/e2e/date-picker.test.ts
@@ -336,4 +336,141 @@ test.describe("DatePicker", () => {
     await page.getByTestId("outside-date-picker").click();
     await expect(calendar).not.toHaveClass(/open/);
   });
+
+  test.describe("close event trigger", () => {
+    test("single: outside-click when dismissing without changing value", async ({
+      page,
+    }) => {
+      const input = page.getByLabel("Meeting date");
+      await input.click();
+      const calendar = page
+        .getByTestId("date-picker-single")
+        .getByLabel("calendar-container");
+      await expect(calendar).toHaveClass(/open/);
+
+      await page.getByTestId("outside-date-picker").click();
+
+      await expect(calendar).not.toHaveClass(/open/);
+      await expect(
+        page.getByTestId("date-picker-single-close-triggers"),
+      ).toHaveText("outside-click");
+    });
+
+    test("single: outside-click on viewport mousedown before click handler", async ({
+      page,
+    }) => {
+      const input = page.getByLabel("Meeting date");
+      await input.click();
+      const calendar = page
+        .getByTestId("date-picker-single")
+        .getByLabel("calendar-container");
+      await expect(calendar).toHaveClass(/open/);
+
+      const viewport = page.viewportSize();
+      if (!viewport) throw new Error("expected viewport size");
+      await page.mouse.click(viewport.width - 5, viewport.height - 5);
+
+      await expect(calendar).not.toHaveClass(/open/);
+      await expect(
+        page.getByTestId("date-picker-single-close-triggers"),
+      ).toHaveText("outside-click");
+    });
+
+    test("single: outside-click when opened via calendar icon", async ({
+      page,
+    }) => {
+      const calendarIcon = page
+        .getByTestId("date-picker-single")
+        .locator(".bx--date-picker__icon");
+      await calendarIcon.click({ force: true });
+      const calendar = page
+        .getByTestId("date-picker-single")
+        .getByLabel("calendar-container");
+      await expect(calendar).toHaveClass(/open/);
+
+      await page.getByTestId("outside-date-picker").click();
+
+      await expect(calendar).not.toHaveClass(/open/);
+      await expect(
+        page.getByTestId("date-picker-single-close-triggers"),
+      ).toHaveText("outside-click");
+    });
+
+    test("single: select when choosing a day", async ({ page }) => {
+      const input = page.getByLabel("Meeting date");
+      await input.click();
+      const calendar = page
+        .getByTestId("date-picker-single")
+        .getByLabel("calendar-container");
+      await expect(calendar).toHaveClass(/open/);
+
+      const day20 = calendar
+        .locator(".flatpickr-day:not(.prev-month):not(.next-month)")
+        .filter({ hasText: /^20$/ });
+      await day20.click();
+
+      await expect(calendar).not.toHaveClass(/open/);
+      await expect(
+        page.getByTestId("date-picker-single-close-triggers"),
+      ).toHaveText("select");
+    });
+
+    test("single: escape-key on Escape", async ({ page }) => {
+      const input = page.getByLabel("Meeting date");
+      await input.click();
+      const calendar = page
+        .getByTestId("date-picker-single")
+        .getByLabel("calendar-container");
+      await expect(calendar).toHaveClass(/open/);
+
+      await input.focus();
+      await page.keyboard.press("Escape");
+
+      await expect(calendar).not.toHaveClass(/open/);
+      await expect(
+        page.getByTestId("date-picker-single-close-triggers"),
+      ).toHaveText("escape-key");
+    });
+
+    test("range: outside-click after partial selection", async ({ page }) => {
+      await page.getByTestId("date-picker-range-start").click();
+      const calendar = page
+        .getByTestId("date-picker-range")
+        .getByLabel("calendar-container");
+      await expect(calendar).toHaveClass(/open/);
+
+      const day10 = calendar
+        .locator(".flatpickr-day:not(.prev-month):not(.next-month)")
+        .filter({ hasText: /^10$/ });
+      await day10.click();
+      await page.getByTestId("outside-date-picker").click();
+
+      await expect(calendar).not.toHaveClass(/open/);
+      await expect(
+        page.getByTestId("date-picker-range-close-triggers"),
+      ).toHaveText("outside-click");
+    });
+
+    test("range: select when both dates are chosen", async ({ page }) => {
+      await page.getByTestId("date-picker-range-start").click();
+      const calendar = page
+        .getByTestId("date-picker-range")
+        .getByLabel("calendar-container");
+      await expect(calendar).toHaveClass(/open/);
+
+      const day10 = calendar
+        .locator(".flatpickr-day:not(.prev-month):not(.next-month)")
+        .filter({ hasText: /^10$/ });
+      const day20 = calendar
+        .locator(".flatpickr-day:not(.prev-month):not(.next-month)")
+        .filter({ hasText: /^20$/ });
+      await day10.click();
+      await day20.click();
+
+      await expect(calendar).not.toHaveClass(/open/);
+      await expect(
+        page.getByTestId("date-picker-range-close-triggers"),
+      ).toHaveText("select");
+    });
+  });
 });

--- a/e2e/fixtures/DatePickerFixture.svelte
+++ b/e2e/fixtures/DatePickerFixture.svelte
@@ -1,5 +1,10 @@
 <script>
   import { DatePicker, DatePickerInput } from "carbon-components-svelte";
+
+  /** @type {string[]} */
+  let singleCloseTriggers = [];
+  /** @type {string[]} */
+  let rangeCloseTriggers = [];
 </script>
 
 <div data-testid="date-picker-single">
@@ -12,6 +17,11 @@
       maxDate: "03/31/2024",
     }}
     on:change
+    on:close={(e) =>
+      (singleCloseTriggers = [
+        ...singleCloseTriggers,
+        e.detail?.trigger ?? "null",
+      ])}
   >
     <DatePickerInput
       data-testid="date-picker-meeting"
@@ -19,6 +29,9 @@
       placeholder="mm/dd/yyyy"
     />
   </DatePicker>
+  <p data-testid="date-picker-single-close-triggers">
+    {singleCloseTriggers.join(",")}
+  </p>
 </div>
 
 <div data-testid="outside-date-picker" style="margin-top: 1rem; padding: 1rem;">
@@ -34,6 +47,11 @@
       maxDate: "03/31/2024",
     }}
     on:change
+    on:close={(e) =>
+      (rangeCloseTriggers = [
+        ...rangeCloseTriggers,
+        e.detail?.trigger ?? "null",
+      ])}
   >
     <DatePickerInput
       data-testid="date-picker-range-start"
@@ -46,4 +64,7 @@
       placeholder="mm/dd/yyyy"
     />
   </DatePicker>
+  <p data-testid="date-picker-range-close-triggers">
+    {rangeCloseTriggers.join(",")}
+  </p>
 </div>

--- a/src/DatePicker/DatePicker.svelte
+++ b/src/DatePicker/DatePicker.svelte
@@ -4,6 +4,12 @@
    */
 
   /**
+   * @event close
+   * @type {object}
+   * @property {"escape-key" | "outside-click" | "select"} trigger
+   */
+
+  /**
    * Specify the date picker type.
    * @type {"simple" | "single" | "range"}
    */
@@ -173,6 +179,97 @@
   let topLayerAncestor = null;
   // Set from onOpen/onClose. Outside-click listener attaches only while open.
   let calendarOpen = false;
+  // flatpickr onClose has no reason; explicit handlers set closeTrigger, else
+  // infer from session baseline. Close dispatch is deferred for range sync.
+  /** @type {"escape-key" | "outside-click" | undefined} */
+  let closeTrigger;
+  /** @type {string | { from: string; to: string }} */
+  let dateStrAtOpen;
+  /** @type {number[]} */
+  let selectedDatesAtOpen = [];
+
+  /**
+   * @param {string | { from: string; to: string }} atOpen
+   * @param {string | { from: string; to: string }} atClose
+   */
+  function dateStrChanged(atOpen, atClose) {
+    if (typeof atClose === "object") {
+      return atOpen.from !== atClose.from || atOpen.to !== atClose.to;
+    }
+    return atOpen !== atClose;
+  }
+
+  /**
+   * @param {number[]} atOpen
+   * @param {Date[]} selectedDates
+   */
+  function selectedDatesChanged(atOpen, selectedDates) {
+    const atClose = (selectedDates || []).map((date) => date.getTime());
+    return (
+      atClose.length !== atOpen.length ||
+      atClose.some((time, index) => time !== atOpen[index])
+    );
+  }
+
+  function snapshotCloseBaseline() {
+    dateStrAtOpen = $range
+      ? { from: inputRef.value, to: inputRefTo.value }
+      : inputRef.value;
+    selectedDatesAtOpen = (calendar?.selectedDates || []).map((date) =>
+      date.getTime(),
+    );
+  }
+
+  function refreshCloseBaselineOnOpen() {
+    if (
+      selectedDatesChanged(selectedDatesAtOpen, calendar?.selectedDates || [])
+    ) {
+      dateStrAtOpen = $range
+        ? { from: inputRef.value, to: inputRefTo.value }
+        : inputRef.value;
+    } else {
+      snapshotCloseBaseline();
+    }
+  }
+
+  /**
+   * @param {{ copySelectedDates?: boolean }} [options]
+   */
+  function buildCalendarDetail({ copySelectedDates = false } = {}) {
+    const dates = calendar?.selectedDates || [];
+    const detail = {
+      selectedDates: copySelectedDates ? [...dates] : dates,
+    };
+
+    if ($range) {
+      const from = inputRef.value;
+      const to = inputRefTo.value;
+      detail.dateStr = { from, to };
+    } else {
+      detail.dateStr = inputRef.value;
+    }
+
+    return detail;
+  }
+
+  function dispatchDeferredClose() {
+    if (!calendar) return;
+
+    const detail = buildCalendarDetail({ copySelectedDates: true });
+
+    if ($range) {
+      valueFrom = inputRef.value;
+      valueTo = inputRefTo.value;
+    }
+
+    const selectionChanged =
+      selectedDatesChanged(selectedDatesAtOpen, detail.selectedDates) ||
+      dateStrChanged(dateStrAtOpen, detail.dateStr);
+    const trigger =
+      closeTrigger ?? (selectionChanged ? "select" : "outside-click");
+    closeTrigger = undefined;
+    dispatch("close", { ...detail, trigger });
+  }
 
   function attachFixedRepositionListeners() {
     if (!calendar || onCalendarReposition) return;
@@ -237,22 +334,17 @@
 
     if (type === "change") {
       if (calendar) {
-        const detail = { selectedDates: calendar.selectedDates || [] };
-
-        if ($range) {
-          detail.dateStr = {
-            from: inputRef?.value || "",
-            to: inputRefTo?.value || "",
-          };
-        } else {
-          detail.dateStr = inputRef?.value || "";
-        }
-
-        dispatch("change", detail);
+        dispatch("change", buildCalendarDetail());
       } else {
         dispatch("change", value);
       }
     }
+  }
+
+  function dismissCalendar(trigger) {
+    if (!calendarOpen) return;
+    closeTrigger = trigger;
+    if (calendar?.isOpen) calendar.close();
   }
 
   /**
@@ -261,8 +353,7 @@
   function blurInput(relatedTarget) {
     if (!calendar) return;
     // No relatedTarget means focus left the document (e.g. switching browser
-    // tabs); refocusing would replay the open animation. Outside clicks close
-    // via handleOutsideClick on datePickerRef.
+    // tabs); refocusing would replay the open animation.
     if (relatedTarget == null) return;
     // In range mode, focus moves between the two inputs while the calendar
     // stays open; closing here would replay the open animation on every switch.
@@ -271,7 +362,7 @@
       calendar.calendarContainer.contains(/** @type {Node} */ (relatedTarget))
     )
       return;
-    calendar.close();
+    dismissCalendar("outside-click");
   }
 
   /**
@@ -355,32 +446,31 @@
       base: inputRef,
       input: inputRefTo,
       dispatch: (event) => {
-        if (event === "open") calendarOpen = true;
-        else if (event === "close") calendarOpen = false;
-        if (calendarUsesFixedPositioning) {
-          if (event === "open") attachFixedRepositionListeners();
-          else if (event === "close") detachFixedRepositionListeners();
+        if (event === "open") {
+          calendarOpen = true;
+          closeTrigger = undefined;
+          refreshCloseBaselineOnOpen();
+        } else if (event === "close") {
+          calendarOpen = false;
+          if (calendarUsesFixedPositioning) {
+            detachFixedRepositionListeners();
+          }
+          queueMicrotask(dispatchDeferredClose);
+          return;
         }
-        const detail = { selectedDates: calendar?.selectedDates || [] };
+        if (calendarUsesFixedPositioning && event === "open")
+          attachFixedRepositionListeners();
+        const detail = buildCalendarDetail();
 
         if ($range) {
-          const from = inputRef.value;
-          const to = inputRefTo.value;
-
-          detail.dateStr = {
-            from: inputRef.value,
-            to: inputRefTo.value,
-          };
-
-          valueFrom = from;
-          valueTo = to;
-        } else {
-          detail.dateStr = inputRef.value;
+          valueFrom = inputRef.value;
+          valueTo = inputRefTo.value;
         }
 
         return dispatch(event, detail);
       },
     });
+    snapshotCloseBaseline();
     calendar?.calendarContainer?.setAttribute("role", "application");
     calendar?.calendarContainer?.setAttribute(
       "aria-label",
@@ -455,21 +545,37 @@
   }
 
   /**
+   * Returns true when `event.target` is outside both the date-picker element
+   * and the (possibly portalled) calendar container.
+   *
+   * @param {Event} event
+   */
+  function isOutsideCalendarTarget(event) {
+    if (!calendarOpen || !calendar) return false;
+    return !isEventTargetInsidePortaledCalendar(
+      datePickerRef,
+      calendar.calendarContainer,
+      event.target,
+      topLayerAncestor,
+    );
+  }
+
+  /**
+   * flatpickr closes on document `mousedown` before our `click` handler runs.
+   * Set `closeTrigger` in capture phase so single-mode outside dismiss is not
+   * inferred as select when selectedDates differ from the session baseline.
+   *
+   * @type {(event: Event) => void}
+   */
+  function handleOutsidePointerDown(event) {
+    if (isOutsideCalendarTarget(event)) closeTrigger = "outside-click";
+  }
+
+  /**
    * @type {(event: Event) => void}
    */
   function handleOutsideClick(event) {
-    if (!calendar?.isOpen) return;
-    if (
-      isEventTargetInsidePortaledCalendar(
-        datePickerRef,
-        calendar.calendarContainer,
-        event.target,
-        topLayerAncestor,
-      )
-    ) {
-      return;
-    }
-    calendar.close();
+    if (isOutsideCalendarTarget(event)) dismissCalendar("outside-click");
   }
 </script>
 
@@ -492,8 +598,14 @@
     bind:this={datePickerRef}
     use:dismiss={{
       enabled: calendarOpen,
-      type: "click",
-      handler: handleOutsideClick,
+      listeners: [
+        {
+          type: "pointerdown",
+          handler: handleOutsidePointerDown,
+          options: { capture: true },
+        },
+        { type: "click", handler: handleOutsideClick },
+      ],
     }}
     {id}
     class:bx--date-picker={true}
@@ -507,7 +619,7 @@
     on:keydown={(event) => {
       if (calendar?.isOpen && event.key === "Escape") {
         event.stopPropagation();
-        calendar.close();
+        dismissCalendar("escape-key");
       }
     }}
   >

--- a/src/DatePicker/DatePicker.svelte
+++ b/src/DatePicker/DatePicker.svelte
@@ -169,6 +169,8 @@
   let lastAppliedOptions = {};
   let calendarUsesFixedPositioning = false;
   let onCalendarReposition = null;
+  /** @type {HTMLElement | null} */
+  let topLayerAncestor = null;
   // Set from onOpen/onClose. Outside-click listener attaches only while open.
   let calendarOpen = false;
 
@@ -332,7 +334,7 @@
     // Auto-detect a top-layer ancestor (native dialog or open popover) so the
     // calendar can participate in its top layer instead of being clipped behind
     // the backdrop. Computed at creation time — appendTo cannot change after.
-    const topLayerAncestor = getTopLayerAncestor(datePickerRef);
+    topLayerAncestor = getTopLayerAncestor(datePickerRef);
     calendarUsesFixedPositioning = effectivePortalMenu && !!topLayerAncestor;
 
     calendar = await createCalendar({
@@ -462,6 +464,7 @@
         datePickerRef,
         calendar.calendarContainer,
         event.target,
+        topLayerAncestor,
       )
     ) {
       return;

--- a/src/DatePicker/datePickerTopLayer.d.ts
+++ b/src/DatePicker/datePickerTopLayer.d.ts
@@ -22,4 +22,5 @@ export function isEventTargetInsidePortaledCalendar(
   datePickerRef: HTMLElement | null | undefined,
   calendarContainer: HTMLElement,
   target: EventTarget | null,
+  cachedTopLayer?: HTMLElement | null,
 ): boolean;

--- a/src/DatePicker/datePickerTopLayer.js
+++ b/src/DatePicker/datePickerTopLayer.js
@@ -74,15 +74,20 @@ export function positionFlatpickrCalendarFixed(
  * @param {HTMLElement | null | undefined} datePickerRef
  * @param {HTMLElement} calendarContainer
  * @param {EventTarget | null} target
+ * @param {HTMLElement | null} [cachedTopLayer] Pre-computed ancestor; avoids a `.closest()` query per event.
  */
 export function isEventTargetInsidePortaledCalendar(
   datePickerRef,
   calendarContainer,
   target,
+  cachedTopLayer,
 ) {
   if (!(target instanceof Node)) return false;
   if (datePickerRef?.contains(target)) return true;
   if (calendarContainer.contains(target)) return true;
-  const topLayer = getTopLayerAncestor(datePickerRef);
+  const topLayer =
+    cachedTopLayer === undefined
+      ? getTopLayerAncestor(datePickerRef)
+      : cachedTopLayer;
   return !!topLayer?.contains(target);
 }

--- a/tests/DatePicker/DatePickerClose.test.svelte
+++ b/tests/DatePicker/DatePickerClose.test.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  import DatePicker from "carbon-components-svelte/DatePicker/DatePicker.svelte";
+  import DatePickerInput from "carbon-components-svelte/DatePicker/DatePickerInput.svelte";
+
+  export let onClose: (e: CustomEvent<{ trigger: string }>) => void = () => {};
+  export let datePickerType: "single" | "range" = "single";
+  export let value = "";
+  export let valueFrom = "";
+  export let valueTo = "";
+</script>
+
+<DatePicker {datePickerType} {value} {valueFrom} {valueTo} on:close={onClose}>
+  {#if datePickerType === "range"}
+    <DatePickerInput labelText="Start date" placeholder="mm/dd/yyyy" />
+    <DatePickerInput labelText="End date" placeholder="mm/dd/yyyy" />
+  {:else}
+    <DatePickerInput labelText="Date" placeholder="mm/dd/yyyy" />
+  {/if}
+</DatePicker>

--- a/tests/DatePicker/DatePickerClose.test.ts
+++ b/tests/DatePicker/DatePickerClose.test.ts
@@ -1,0 +1,204 @@
+import { cleanup, render, screen, waitFor } from "@testing-library/svelte";
+import { tick } from "svelte";
+import { user } from "../utils/user";
+import DatePickerClose from "./DatePickerClose.test.svelte";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("DatePicker close event", () => {
+  it('dispatches close with trigger "select" when a date is chosen', async () => {
+    const onClose = vi.fn();
+    render(DatePickerClose, { props: { onClose } });
+
+    await user.click(screen.getByLabelText("Date"));
+    const calendar = await screen.findByLabelText("calendar-container");
+    const day = calendar.querySelector<HTMLElement>(
+      ".flatpickr-day:not(.prevMonthDay):not(.nextMonthDay)",
+    );
+    if (!day) throw new Error("expected a selectable day");
+
+    await user.click(day);
+
+    expect(calendar).not.toHaveClass("open");
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onClose.mock.calls[0][0].detail.trigger).toBe("select");
+  });
+
+  it('dispatches close with trigger "escape-key" when Escape is pressed', async () => {
+    const onClose = vi.fn();
+    render(DatePickerClose, { props: { onClose } });
+
+    const input = screen.getByLabelText("Date");
+    await user.click(input);
+    const calendar = await screen.findByLabelText("calendar-container");
+    expect(calendar).toHaveClass("open");
+
+    input.focus();
+    await user.keyboard("{Escape}");
+    await tick();
+
+    expect(calendar).not.toHaveClass("open");
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onClose.mock.calls[0][0].detail.trigger).toBe("escape-key");
+  });
+
+  it('dispatches close with trigger "outside-click" when clicking outside', async () => {
+    const onClose = vi.fn();
+    render(DatePickerClose, { props: { onClose } });
+
+    await user.click(screen.getByLabelText("Date"));
+    const calendar = await screen.findByLabelText("calendar-container");
+    expect(calendar).toHaveClass("open");
+
+    await user.click(document.body);
+
+    expect(calendar).not.toHaveClass("open");
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onClose.mock.calls[0][0].detail.trigger).toBe("outside-click");
+  });
+
+  it('dispatches close with trigger "outside-click" when dismissing without changing an existing value', async () => {
+    const onClose = vi.fn();
+    render(DatePickerClose, {
+      props: { onClose, value: "01/15/1990" },
+    });
+
+    await user.click(screen.getByLabelText("Date"));
+    const calendar = await screen.findByLabelText("calendar-container");
+    expect(calendar).toHaveClass("open");
+
+    await user.click(document.body);
+
+    expect(calendar).not.toHaveClass("open");
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onClose.mock.calls[0][0].detail.trigger).toBe("outside-click");
+  });
+
+  it('dispatches close with trigger "outside-click" when dismissing a range without changing values', async () => {
+    const onClose = vi.fn();
+    render(DatePickerClose, {
+      props: {
+        onClose,
+        datePickerType: "range",
+        valueFrom: "01/01/2025",
+        valueTo: "01/31/2025",
+      },
+    });
+
+    await user.click(screen.getByLabelText("Start date"));
+    const calendar = await waitFor(() => {
+      const openCalendar = document.querySelector<HTMLElement>(
+        ".flatpickr-calendar.open[aria-label='calendar-container']",
+      );
+      if (!openCalendar) {
+        throw new Error("expected an open calendar");
+      }
+      return openCalendar;
+    });
+
+    await user.click(document.body);
+
+    expect(calendar).not.toHaveClass("open");
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onClose.mock.calls[0][0].detail.trigger).toBe("outside-click");
+  });
+
+  it('dispatches close with trigger "outside-click" when dismissing a partial range selection', async () => {
+    const onClose = vi.fn();
+    render(DatePickerClose, {
+      props: {
+        onClose,
+        datePickerType: "range",
+      },
+    });
+
+    await user.click(screen.getByLabelText("Start date"));
+    const calendar = await waitFor(() => {
+      const openCalendar = document.querySelector<HTMLElement>(
+        ".flatpickr-calendar.open[aria-label='calendar-container']",
+      );
+      if (!openCalendar) {
+        throw new Error("expected an open calendar");
+      }
+      return openCalendar;
+    });
+    const startDay = calendar.querySelector<HTMLElement>(
+      '[aria-label="June 1, 2026"]',
+    );
+    if (!startDay) throw new Error("expected a start day");
+
+    await user.click(startDay);
+    await user.click(document.body);
+    await tick();
+
+    expect(calendar).not.toHaveClass("open");
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onClose.mock.calls[0][0].detail.trigger).toBe("outside-click");
+  });
+
+  it('dispatches close with trigger "select" when a range is chosen', async () => {
+    const onClose = vi.fn();
+    render(DatePickerClose, {
+      props: {
+        onClose,
+        datePickerType: "range",
+      },
+    });
+
+    await user.click(screen.getByLabelText("Start date"));
+    const calendar = await waitFor(() => {
+      const openCalendar = document.querySelector<HTMLElement>(
+        ".flatpickr-calendar.open[aria-label='calendar-container']",
+      );
+      if (!openCalendar) {
+        throw new Error("expected an open calendar");
+      }
+      return openCalendar;
+    });
+    const startDay = calendar.querySelector<HTMLElement>(
+      '[aria-label="June 1, 2026"]',
+    );
+    if (!startDay) throw new Error("expected a start day");
+
+    await user.click(startDay);
+    await tick();
+
+    const endDay = calendar.querySelector<HTMLElement>(
+      '[aria-label="June 15, 2026"]',
+    );
+    if (!endDay) throw new Error("expected an end day");
+
+    await user.click(endDay);
+
+    await waitFor(() => expect(calendar).not.toHaveClass("open"));
+    await tick();
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onClose.mock.calls[0][0].detail.selectedDates).toHaveLength(2);
+    expect(onClose.mock.calls[0][0].detail.trigger).toBe("select");
+  });
+
+  it('dispatches close with trigger "select" when changing an existing single value', async () => {
+    const onClose = vi.fn();
+    render(DatePickerClose, {
+      props: {
+        onClose,
+        value: "01/01/2025",
+      },
+    });
+
+    await user.click(screen.getByLabelText("Date"));
+    const calendar = await screen.findByLabelText("calendar-container");
+    const day = calendar.querySelector<HTMLElement>(
+      ".flatpickr-day:not(.prevMonthDay):not(.nextMonthDay):not(.selected)",
+    );
+    if (!day) throw new Error("expected a selectable day");
+
+    await user.click(day);
+
+    expect(calendar).not.toHaveClass("open");
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onClose.mock.calls[0][0].detail.trigger).toBe("select");
+  });
+});


### PR DESCRIPTION
Adds a `trigger` discriminator (`"escape-key" | "outside-click" | "select"`) to the `DatePicker` `close` event, inferred from the Escape handler, a captured day click, and an outside-click residual since flatpickr's `onClose` carries no reason. This mirrors the `HeaderNavMenu` `close` event from #3308 (commit a6bdc582) and matches `Modal`. Value binding and calendar lifecycle are unchanged; the event is purely additive.