### PR TITLE
feat(data-table): add `stickyHeaderMaxHeight` prop for sticky header

### DIFF
--- a/docs/src/pages/components/DataTable.svx
+++ b/docs/src/pages/components/DataTable.svx
@@ -388,6 +388,12 @@ An `empty: true` header has no label, but its body cells can still render conten
   </svelte:fragment>
 </DataTable>
 
+## Sticky header max height
+
+By default, `stickyHeader` caps the table height at `300px`. Override the cap with `stickyHeaderMaxHeight`. Pass a number (interpreted as `px`) or a CSS length string (e.g. `"24rem"`).
+
+<FileSource src="/framed/DataTable/StickyHeaderMaxHeight" />
+
 ## Virtualized rows (large datasets)
 
 Virtualization renders only the rows currently visible in the viewport, improving performance for large datasets. Set `virtualize={true}` to enable. The header stays visible while scrolling (sticky positioning is applied automatically). Use `stickyHeader={true}` for the intended layout, if necessary. Container height defaults to 10 rows (`itemHeight * maxVisibleRows`).

--- a/docs/src/pages/framed/DataTable/StickyHeaderMaxHeight.svelte
+++ b/docs/src/pages/framed/DataTable/StickyHeaderMaxHeight.svelte
@@ -1,0 +1,25 @@
+<script>
+  import { DataTable } from "carbon-components-svelte";
+
+  const rows = Array.from({ length: 20 }).map((_, i) => ({
+    id: i,
+    name: `Load Balancer ${i + 1}`,
+    protocol: "HTTP",
+    port: i % 3 ? (i % 2 ? 3000 : 80) : 443,
+    rule: i % 3 ? "Round robin" : "DNS delegation",
+  }));
+</script>
+
+<DataTable
+  title="Load balancers"
+  description="Your organization's active load balancers."
+  stickyHeader
+  stickyHeaderMaxHeight={500}
+  headers={[
+    { key: "name", value: "Name" },
+    { key: "protocol", value: "Protocol" },
+    { key: "port", value: "Port" },
+    { key: "rule", value: "Rule" },
+  ]}
+  {rows}
+/>

--- a/src/DataTable/DataTable.svelte
+++ b/src/DataTable/DataTable.svelte
@@ -253,6 +253,14 @@
   /** Set to `true` to enable a sticky header */
   export let stickyHeader = false;
 
+  /**
+   * Override the maximum height of the sticky header table, replacing the
+   * default `300px`. Only applies when `stickyHeader` is `true`. Pass a number
+   * (interpreted as `px`) or a CSS length string (e.g. `"100%"`, `"24rem"`).
+   * @type {number | string}
+   */
+  export let stickyHeaderMaxHeight = undefined;
+
   /** Set to `true` to use static width */
   export let useStaticWidth = false;
 
@@ -738,7 +746,14 @@
       {stickyHeader}
       {sortable}
       {useStaticWidth}
-      tableStyle={hasCustomHeaderWidth && "table-layout: fixed"}
+      tableStyle={[
+        hasCustomHeaderWidth && "table-layout: fixed",
+        stickyHeader &&
+          stickyHeaderMaxHeight != null &&
+          `max-height: ${typeof stickyHeaderMaxHeight === "number" ? `${stickyHeaderMaxHeight}px` : stickyHeaderMaxHeight}`,
+      ]
+        .filter(Boolean)
+        .join("; ") || undefined}
     >
       <TableHead
         style={virtualScrollContainer

--- a/tests/DataTable/DataTable.test.svelte
+++ b/tests/DataTable/DataTable.test.svelte
@@ -63,6 +63,8 @@
   export let sortAlways = false;
   export let sort: ComponentProps<DataTable>["sort"] = undefined;
   export let stickyHeader = false;
+  export let stickyHeaderMaxHeight: ComponentProps<DataTable>["stickyHeaderMaxHeight"] =
+    undefined;
   export let useStaticWidth = false;
   export let expandable = false;
   export let batchExpansion = false;
@@ -101,6 +103,7 @@
   {sortAlways}
   {sort}
   {stickyHeader}
+  {stickyHeaderMaxHeight}
   {useStaticWidth}
   {expandable}
   {batchExpansion}

--- a/tests/DataTable/DataTable.test.ts
+++ b/tests/DataTable/DataTable.test.ts
@@ -1213,6 +1213,50 @@ describe("DataTable", () => {
     expect(table).toHaveClass("bx--data-table--sticky-header");
   });
 
+  describe("stickyHeaderMaxHeight", () => {
+    it("applies a pixel max-height when stickyHeader is enabled", () => {
+      render(DataTable, {
+        props: {
+          headers,
+          rows,
+          stickyHeader: true,
+          stickyHeaderMaxHeight: 500,
+        },
+      });
+
+      const table = screen.getByRole("table");
+      expect(table).toHaveStyle({ "max-height": "500px" });
+    });
+
+    it("applies a CSS length string when stickyHeader is enabled", () => {
+      render(DataTable, {
+        props: {
+          headers,
+          rows,
+          stickyHeader: true,
+          stickyHeaderMaxHeight: "24rem",
+        },
+      });
+
+      const table = screen.getByRole("table");
+      expect(table).toHaveStyle({ "max-height": "24rem" });
+    });
+
+    it("ignores stickyHeaderMaxHeight when stickyHeader is disabled", () => {
+      render(DataTable, {
+        props: {
+          headers,
+          rows,
+          stickyHeader: false,
+          stickyHeaderMaxHeight: 500,
+        },
+      });
+
+      const table = screen.getByRole("table");
+      expect(table).not.toHaveStyle({ "max-height": "500px" });
+    });
+  });
+
   it("handles static width", () => {
     const { container } = render(DataTable, {
       props: {


### PR DESCRIPTION
Closes [#1697](https://github.com/carbon-design-system/carbon-components-svelte/issues/1697)

The sticky header's `300px` cap is hardcoded in Carbon's SCSS, so
content slightly taller than it produces a sliver of scroll that
tucks the first row under the pinned header.

The `stickyHeaderMaxHeight` prop overrides the cap inline (number as `px`,
or any CSS length); unset preserves the existing default.

This allows for a custom table body height with use of the sticky header.

---

<img width="1547" height="630" alt="Screenshot 2026-06-13 at 12 47 05 PM" src="https://github.com/user-attachments/assets/6985cc74-4c19-47df-b324-840d18eb6e68" />
