### PR TITLE
build(scripts): skip sveld when inputs are unchanged

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -25,7 +25,7 @@
         "jsdom": "^29.1.1",
         "lightningcss": "^1.32.0",
         "sass-embedded": "^1.100.0",
-        "sveld": "^0.32.5",
+        "sveld": "^0.32.6",
         "svelte": "^5.56.3",
         "svelte-check": "^4.6.0",
         "typescript": "^6.0.3",
@@ -575,7 +575,7 @@
 
     "supports-color": ["supports-color@8.1.1", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q=="],
 
-    "sveld": ["sveld@0.32.5", "", { "dependencies": { "prettier": "^3.8.3" }, "bin": { "sveld": "cli.js" } }, "sha512-tj7Kxl/xS/+cCFhLXO01gIwqblsS6VY4fWHeDM738s5GX54luE+45QWw3eTxcdmf3Y3l7cZGtHHzmgdSE6LMWg=="],
+    "sveld": ["sveld@0.32.6", "", { "dependencies": { "prettier": "^3.8.3" }, "bin": { "sveld": "cli.js" } }, "sha512-3/E5pKLoe/FDanpfjbExXUqc2AQg5DZdFFbfGolMwJRCiuH+5jJFTFFV+US59u6gy1an+oitzoooGoFPOKluWA=="],
 
     "svelte": ["svelte@5.56.3", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "@jridgewell/sourcemap-codec": "^1.5.0", "@sveltejs/acorn-typescript": "^1.0.10", "@types/estree": "^1.0.5", "@types/trusted-types": "^2.0.7", "acorn": "^8.12.1", "aria-query": "5.3.1", "axobject-query": "^4.1.0", "clsx": "^2.1.1", "devalue": "^5.8.1", "esm-env": "^1.2.1", "esrap": "^2.2.11", "is-reference": "^3.0.3", "locate-character": "^3.0.0", "magic-string": "^0.30.11", "zimmerframe": "^1.1.2" } }, "sha512-w7JvrM5IFl5cmfbY0TLik9o7mjRUJmRMhOR51tBPu708Gr/MjbGs7VnJnr/B0CaXeI4vtnOh7RKxDr0cwhMdDA=="],
 

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "jsdom": "^29.1.1",
     "lightningcss": "^1.32.0",
     "sass-embedded": "^1.100.0",
-    "sveld": "^0.32.5",
+    "sveld": "^0.32.6",
     "svelte": "^5.56.3",
     "svelte-check": "^4.6.0",
     "typescript": "^6.0.3",

--- a/scripts/build-docs.ts
+++ b/scripts/build-docs.ts
@@ -1,10 +1,12 @@
-import { $ } from "bun";
+import { createHash } from "node:crypto";
+import { access, mkdir, readFile, writeFile } from "node:fs/promises";
+import { $, Glob } from "bun";
 import { sveld } from "sveld";
 
-// Clean auto-generated files.
-await $`rm -f src/index.d.ts && find src -name "*.svelte.d.ts" -delete`;
+const CACHE_DIR = ".cache/build-docs";
+const CACHE_FILE = `${CACHE_DIR}/input.hash`;
 
-await sveld({
+const SVELD_OPTIONS = {
   glob: true,
   json: true,
   jsonOptions: {
@@ -13,4 +15,83 @@ await sveld({
   typesOptions: {
     outDir: "src",
   },
-});
+};
+
+function collectInputFiles(): string[] {
+  const files = new Set<string>();
+
+  for (const file of new Glob("**/*.svelte").scanSync({ cwd: "src" })) {
+    files.add(file);
+  }
+
+  for (const file of new Glob("**/*.d.ts").scanSync({ cwd: "src" })) {
+    if (file.endsWith(".svelte.d.ts") || file === "index.d.ts") continue;
+    files.add(file);
+  }
+
+  for (const file of new Glob("**/index.js").scanSync({ cwd: "src" })) {
+    files.add(file);
+  }
+
+  return [...files].sort();
+}
+
+async function sharedInputs(): Promise<string> {
+  const packageJson = JSON.parse(await readFile("package.json", "utf8")) as {
+    devDependencies?: { sveld?: string };
+  };
+
+  return [
+    packageJson.devDependencies?.sveld ?? "",
+    JSON.stringify(SVELD_OPTIONS),
+  ].join("\0");
+}
+
+async function computeInputHash(): Promise<string> {
+  const files = collectInputFiles();
+  const contents = await Promise.all(
+    files.map(async (file) => ({
+      file,
+      contents: await readFile(`src/${file}`, "utf8"),
+    })),
+  );
+  const hash = createHash("sha256");
+
+  for (const { file, contents: fileContents } of contents) {
+    hash.update(file);
+    hash.update("\0");
+    hash.update(fileContents);
+    hash.update("\0");
+  }
+
+  hash.update(await sharedInputs());
+  return hash.digest("hex");
+}
+
+async function isCached(hash: string): Promise<boolean> {
+  try {
+    const cachedHash = (await readFile(CACHE_FILE, "utf8")).trim();
+    if (cachedHash !== hash) return false;
+    await access("docs/src/COMPONENT_API.json");
+    await access("src/index.d.ts");
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+console.time("[build-docs]");
+
+await mkdir(CACHE_DIR, { recursive: true });
+
+const hash = await computeInputHash();
+
+if (await isCached(hash)) {
+  console.log("[build-docs] (cached)");
+} else {
+  await $`rm -f src/index.d.ts && find src -name "*.svelte.d.ts" -delete`;
+  await sveld(SVELD_OPTIONS);
+  await writeFile(CACHE_FILE, `${hash}\n`);
+}
+
+console.timeEnd("[build-docs]");


### PR DESCRIPTION
`bun build:docs` auto-generates TypeScript definitions and component API docs from source code.

This is not ideal, and wasteful. This implements a similar cache that the CSS build script uses (input hash, not content hash). If content has not change, skip the script.

This only speeds up local work; CI should run cold.

| Scenario | Script time | Wall clock | Speedup vs cold | sveld runs? |
| --- | ---: | ---: | ---: | --- |
| Cold (no cache) | ~3.2s | ~3.5s | 1× | Yes |
| Cached (hash hit) | ~60ms | ~0.26s | ~50× script · ~13× wall | No |