### PR TITLE
feat(ui-shell): `HeaderSearch` dispatches `close` event

### DIFF
--- a/src/UIShell/HeaderSearch.svelte
+++ b/src/UIShell/HeaderSearch.svelte
@@ -4,6 +4,12 @@
    */
 
   /**
+   * @event close
+   * @type {object}
+   * @property {"escape-key" | "outside-click" | "select"} trigger
+   */
+
+  /**
    * @typedef {object} HeaderSearchResult
    * @property {string | number} [id] - Unique result identifier; used as the each-block key when provided
    * @property {string} href
@@ -77,6 +83,7 @@
   function selectResult() {
     dispatch("select", { value, selectedResultIndex, selectedResult });
     reset();
+    dispatch("close", { trigger: "select" });
   }
 
   $: if (active && ref) ref.focus();
@@ -93,7 +100,10 @@
     : undefined;
 
   function handleOutsideMouseup(event) {
-    if (active && isOutsideClick(event, refSearch)) active = false;
+    if (active && isOutsideClick(event, refSearch)) {
+      active = false;
+      dispatch("close", { trigger: "outside-click" });
+    }
   }
 </script>
 
@@ -170,6 +180,7 @@
             if (value === "") {
               // If the search bar is empty, deactivate the input.
               active = false;
+              dispatch("close", { trigger: "escape-key" });
             }
 
             // Reset the search query but keep the search bar active.

--- a/tests/UIShell/HeaderSearchClose.test.svelte
+++ b/tests/UIShell/HeaderSearchClose.test.svelte
@@ -1,0 +1,22 @@
+<svelte:options accessors />
+
+<script lang="ts">
+  import type { ComponentProps } from "svelte";
+  import HeaderSearch from "../../src/UIShell/HeaderSearch.svelte";
+
+  export let active = false;
+  export let value = "";
+  export let results: ComponentProps<HeaderSearch>["results"] = [];
+  export let onClose: (e: CustomEvent<{ trigger: string }>) => void = () => {};
+</script>
+
+<HeaderSearch
+  bind:active
+  bind:value
+  {results}
+  on:close={onClose}
+  let:result
+  let:index
+>
+  <div data-testid="result-{index}">{result.text}</div>
+</HeaderSearch>

--- a/tests/UIShell/HeaderSearchClose.test.ts
+++ b/tests/UIShell/HeaderSearchClose.test.ts
@@ -1,0 +1,105 @@
+import { fireEvent, render, screen } from "@testing-library/svelte";
+import { user } from "../utils/user";
+import HeaderSearchClose from "./HeaderSearchClose.test.svelte";
+
+describe("HeaderSearch close event", () => {
+  it('dispatches close with trigger "escape-key" when Escape collapses an empty search', async () => {
+    const onClose = vi.fn();
+    render(HeaderSearchClose, { props: { active: true, onClose } });
+
+    await user.click(screen.getByRole("textbox"));
+    await user.keyboard("{Escape}");
+
+    expect(screen.getByRole("search")).not.toHaveClass(
+      "bx--header__search--active",
+    );
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onClose.mock.calls[0][0].detail).toEqual({ trigger: "escape-key" });
+  });
+
+  it('dispatches close with trigger "outside-click" when clicking outside', async () => {
+    const onClose = vi.fn();
+    render(HeaderSearchClose, { props: { active: true, onClose } });
+
+    const outside = document.createElement("div");
+    document.body.appendChild(outside);
+    fireEvent.mouseUp(outside);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onClose.mock.calls[0][0].detail).toEqual({
+      trigger: "outside-click",
+    });
+
+    document.body.removeChild(outside);
+  });
+
+  it("does not dispatch close on Escape while a query is present (stays active)", async () => {
+    const onClose = vi.fn();
+    render(HeaderSearchClose, {
+      props: { active: true, value: "query", onClose },
+    });
+
+    await user.click(screen.getByRole("textbox"));
+    await user.keyboard("{Escape}");
+
+    expect(screen.getByRole("search")).toHaveClass(
+      "bx--header__search--active",
+    );
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("does not dispatch close when the clear button collapses the search", async () => {
+    const onClose = vi.fn();
+    render(HeaderSearchClose, {
+      props: { active: true, value: "query", onClose },
+    });
+
+    await user.click(screen.getByRole("button", { name: "Clear search" }));
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('dispatches close with trigger "select" when a result is chosen', async () => {
+    const onClose = vi.fn();
+    render(HeaderSearchClose, {
+      props: {
+        active: true,
+        value: "query",
+        results: [{ href: "/1", text: "Result 1" }],
+        onClose,
+      },
+    });
+
+    await user.click(screen.getByRole("menuitem", { name: "Result 1" }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onClose.mock.calls[0][0].detail).toEqual({ trigger: "select" });
+  });
+
+  it("does not dispatch close when bind:active is set to false externally", async () => {
+    const onClose = vi.fn();
+    const { component } = render(HeaderSearchClose, {
+      props: { active: true, onClose },
+    });
+
+    component.active = false;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("does not dispatch close on an outside click while already collapsed", async () => {
+    const onClose = vi.fn();
+    render(HeaderSearchClose, { props: { active: false, onClose } });
+
+    const outside = document.createElement("div");
+    document.body.appendChild(outside);
+    fireEvent.mouseUp(outside);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(onClose).not.toHaveBeenCalled();
+
+    document.body.removeChild(outside);
+  });
+});


### PR DESCRIPTION
Adds a new `close` event that fires on user dismissal gestures with a `trigger` of `escape-key`, `outside-click`, or `select`, matching `Dropdown`/`ComboBox`/`HeaderNavMenu`. The `clear` event stays separate and programmatic `bind:active` changes do not fire `close`, so the existing `inactive` payload is unchanged. Tests cover all three triggers plus negative cases.