### PR TITLE
feat(popover): dispatch `close` when `closeOnOutsideClick` auto-closes

### DIFF
--- a/src/Popover/Popover.svelte
+++ b/src/Popover/Popover.svelte
@@ -5,6 +5,12 @@
    */
 
   /**
+   * @event close
+   * @type {object}
+   * @property {"outside-click"} trigger
+   */
+
+  /**
    * Set to `true` to display the popover.
    * @bindable writable
    */
@@ -42,7 +48,10 @@
   function handleOutsideClick(event) {
     if (open && isOutsideClick(event, ref)) {
       dispatch("click:outside", { target: event.target });
-      if (closeOnOutsideClick) open = false;
+      if (closeOnOutsideClick) {
+        open = false;
+        dispatch("close", { trigger: "outside-click" });
+      }
     }
   }
 </script>

--- a/tests/Popover/PopoverClose.test.svelte
+++ b/tests/Popover/PopoverClose.test.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+  import Popover from "../../src/Popover/Popover.svelte";
+
+  export let open = false;
+  export let closeOnOutsideClick = false;
+  export let onClose: (e: CustomEvent<{ trigger: string }>) => void = () => {};
+</script>
+
+<div data-testid="parent">
+  Parent
+  <Popover bind:open {closeOnOutsideClick} on:close={onClose}>
+    <div data-testid="content">Content</div>
+  </Popover>
+</div>

--- a/tests/Popover/PopoverClose.test.ts
+++ b/tests/Popover/PopoverClose.test.ts
@@ -1,0 +1,48 @@
+import { render, screen } from "@testing-library/svelte";
+import { user } from "../utils/user";
+import PopoverClose from "./PopoverClose.test.svelte";
+
+describe("Popover close event", () => {
+  it('dispatches close with trigger "outside-click" and flips open', async () => {
+    const onClose = vi.fn();
+    render(PopoverClose, {
+      props: { open: true, closeOnOutsideClick: true, onClose },
+    });
+
+    const popover = screen.getByTestId("parent").firstElementChild;
+    expect(popover).toHaveClass("bx--popover--open");
+
+    await user.click(document.body);
+
+    expect(popover).not.toHaveClass("bx--popover--open");
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onClose.mock.calls[0][0].detail).toEqual({
+      trigger: "outside-click",
+    });
+  });
+
+  it("does not dispatch close when closeOnOutsideClick is false", async () => {
+    const onClose = vi.fn();
+    render(PopoverClose, {
+      props: { open: true, closeOnOutsideClick: false, onClose },
+    });
+
+    const popover = screen.getByTestId("parent").firstElementChild;
+
+    await user.click(document.body);
+
+    expect(popover).toHaveClass("bx--popover--open");
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("does not dispatch close when the popover is already closed", async () => {
+    const onClose = vi.fn();
+    render(PopoverClose, {
+      props: { open: false, closeOnOutsideClick: true, onClose },
+    });
+
+    await user.click(document.body);
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Popover now dispatches a `close` event with `{ trigger: "outside-click" }` when `closeOnOutsideClick` flips `open` to false, letting consumers react to the auto-close by name instead of re-deriving it from `click:outside` plus the prop. `bind:open` stays authoritative and `click:outside` still fires on every outside click. This aligns Popover with the `close`+`trigger` pattern used by Dropdown, ComboBox, and MultiSelect, though the trigger union is single-valued here since Popover has no other dismissal causes.