### PR TITLE
feat(data-table): add refreshRow/refreshCells to re-derive cells after in-place edits

### DIFF
--- a/docs/src/pages/components/DataTable.svx
+++ b/docs/src/pages/components/DataTable.svx
@@ -151,9 +151,13 @@ The `"cell"` slot provides `rowSelected` and `rowExpanded` props to conditionall
 
 Use the `"cell"` slot to render form inputs that edit row values inline. Bind the input to the row field, for example `bind:value={row.qty}`, to update `rows`.
 
-The table rebuilds cells only when the `rows` array reference changes. After an in-place edit, call `refreshRow(id)` to update columns whose `display` reads other fields on the same row. Use `bind:this` to obtain a reference to the component instance. Call `refreshCells()` to refresh every row after batch edits.
+The table rebuilds cells only when the `rows` array reference changes. After an in-place edit, call `refreshRow(id)` to update columns whose `display` reads other fields on the same row. Use `bind:this` to obtain a reference to the component instance.
 
 <FileSource src="/framed/DataTable/DataTableEditableCells" />
+
+When you edit multiple rows in place, call `refreshCells()` once to update derived columns for every row.
+
+<FileSource src="/framed/DataTable/DataTableEditableCellsRefreshCells" />
 
 ## With title, description
 

--- a/docs/src/pages/components/DataTable.svx
+++ b/docs/src/pages/components/DataTable.svx
@@ -147,6 +147,14 @@ The `"cell"` slot provides `rowSelected` and `rowExpanded` props to conditionall
 
 <FileSource src="/framed/DataTable/DataTableCustomCellRowState" />
 
+## Editable cells
+
+Use the `"cell"` slot to render form inputs that edit row values inline. Bind the input to the row field, for example `bind:value={row.qty}`, to update `rows`.
+
+The table rebuilds cells only when the `rows` array reference changes. After an in-place edit, call `refreshRow(id)` to update columns whose `display` reads other fields on the same row. Use `bind:this` to obtain a reference to the component instance. Call `refreshCells()` to refresh every row after batch edits.
+
+<FileSource src="/framed/DataTable/DataTableEditableCells" />
+
 ## With title, description
 
 Add a title and description to provide context for the table data.

--- a/docs/src/pages/framed/DataTable/DataTableEditableCells.svelte
+++ b/docs/src/pages/framed/DataTable/DataTableEditableCells.svelte
@@ -1,0 +1,44 @@
+<script>
+  import { DataTable, NumberInput } from "carbon-components-svelte";
+
+  let dataTable;
+
+  let rows = [
+    { id: "a", item: "Widget", unitPrice: 10, qty: 3 },
+    { id: "b", item: "Gadget", unitPrice: 25, qty: 1 },
+    { id: "c", item: "Gizmo", unitPrice: 8, qty: 5 },
+  ];
+</script>
+
+<DataTable
+  bind:this={dataTable}
+  headers={[
+    { key: "item", value: "Item" },
+    { key: "unitPrice", value: "Unit price" },
+    { key: "qty", value: "Quantity" },
+    {
+      key: "total",
+      value: "Total",
+      display: (_value, row) => `$${row.unitPrice * row.qty}`,
+    },
+  ]}
+  {rows}
+>
+  <svelte:fragment slot="cell" let:row let:cell>
+    {#if cell.key === "qty"}
+      <NumberInput
+        size="sm"
+        hideLabel
+        label="Quantity"
+        min={0}
+        bind:value={row.qty}
+        on:input={() => {
+          // Rebuild cells so the Total column picks up the new qty.
+          dataTable.refreshRow(row.id);
+        }}
+      />
+    {:else}
+      {cell.display ? cell.display(cell.value, row) : cell.value}
+    {/if}
+  </svelte:fragment>
+</DataTable>

--- a/docs/src/pages/framed/DataTable/DataTableEditableCellsRefreshCells.svelte
+++ b/docs/src/pages/framed/DataTable/DataTableEditableCellsRefreshCells.svelte
@@ -1,0 +1,74 @@
+<script>
+  import {
+    Button,
+    DataTable,
+    NumberInput,
+    Stack,
+  } from "carbon-components-svelte";
+
+  let dataTable;
+
+  let rows = [
+    { id: "a", item: "Widget", unitPrice: 10, qty: 3 },
+    { id: "b", item: "Gadget", unitPrice: 25, qty: 1 },
+    { id: "c", item: "Gizmo", unitPrice: 8, qty: 5 },
+  ];
+
+  function snapshotQty() {
+    return Object.fromEntries(rows.map((row) => [row.id, row.qty]));
+  }
+
+  let savedQtyById = snapshotQty();
+  let hasEdits = false;
+
+  function syncHasEdits() {
+    hasEdits = rows.some((row) => row.qty !== savedQtyById[row.id]);
+  }
+
+  function updateTotals() {
+    dataTable.refreshCells();
+    savedQtyById = snapshotQty();
+    hasEdits = false;
+  }
+</script>
+
+<Stack gap={5}>
+  <Button
+    kind="secondary"
+    size="sm"
+    disabled={!hasEdits}
+    on:click={updateTotals}
+  >
+    Update totals
+  </Button>
+
+  <DataTable
+    bind:this={dataTable}
+    headers={[
+      { key: "item", value: "Item" },
+      { key: "unitPrice", value: "Unit price" },
+      { key: "qty", value: "Quantity" },
+      {
+        key: "total",
+        value: "Total",
+        display: (_value, row) => `$${row.unitPrice * row.qty}`,
+      },
+    ]}
+    {rows}
+  >
+    <svelte:fragment slot="cell" let:row let:cell>
+      {#if cell.key === "qty"}
+        <NumberInput
+          size="sm"
+          hideLabel
+          label="Quantity"
+          min={0}
+          bind:value={row.qty}
+          on:input={syncHasEdits}
+        />
+      {:else}
+        {cell.display ? cell.display(cell.value, row) : cell.value}
+      {/if}
+    </svelte:fragment>
+  </DataTable>
+</Stack>

--- a/src/DataTable/DataTable.svelte
+++ b/src/DataTable/DataTable.svelte
@@ -496,6 +496,8 @@
     tableSize,
     resetSelectedRowIds,
     filterRows,
+    refreshRow,
+    refreshCells,
   });
 
   let expanded = false;
@@ -545,18 +547,56 @@
   let prevRows;
   let prevHeaders;
 
+  /** Build cell objects for one row. Always new objects so `display` columns re-run. */
+  function computeRowCells(row) {
+    return headers.map((header, index) => ({
+      key: header.key ?? `key-${index}`,
+      value: header.key ? resolvePath(row, header.key) : undefined,
+      display: header.display,
+      empty: header.empty,
+      columnMenu: header.columnMenu,
+    }));
+  }
+
+  /**
+   * Rebuild cells for a single row after an in-place edit to `rows`.
+   * @type {(id: Row["id"]) => void}
+   * @example
+   * ```svelte
+   * <DataTable bind:this={dataTable} {headers} {rows} />
+   * <NumberInput min={0} bind:value={row.qty} on:input={() => dataTable.refreshRow(row.id)} />
+   * ```
+   */
+  export function refreshRow(id) {
+    const row = rows.find((row) => row.id === id);
+    if (!row) return;
+    tableCellsByRowId = {
+      ...tableCellsByRowId,
+      [id]: computeRowCells(row),
+    };
+  }
+
+  /**
+   * Rebuild cells for every row after batch in-place edits to `rows`.
+   * @type {() => void}
+   * @example
+   * ```svelte
+   * <DataTable bind:this={dataTable} {headers} {rows} />
+   * <button on:click={() => dataTable.refreshCells()}>Refresh table</button>
+   * ```
+   */
+  export function refreshCells() {
+    const next = {};
+    for (const row of rows) next[row.id] = computeRowCells(row);
+    tableCellsByRowId = next;
+  }
+
   $: if (rows !== prevRows || headers !== prevHeaders) {
     const next = {};
 
     for (const row of rows) {
       const prevCells = tableCellsByRowId[row.id];
-      const newCells = headers.map((header, index) => ({
-        key: header.key ?? `key-${index}`,
-        value: header.key ? resolvePath(row, header.key) : undefined,
-        display: header.display,
-        empty: header.empty,
-        columnMenu: header.columnMenu,
-      }));
+      const newCells = computeRowCells(row);
 
       if (prevCells && prevCells.length === newCells.length) {
         let allEqual = true;

--- a/tests/DataTable/DataTableRefreshRow.test.svelte
+++ b/tests/DataTable/DataTableRefreshRow.test.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+  import DataTable from "carbon-components-svelte/DataTable/DataTable.svelte";
+  import type { ComponentProps } from "svelte";
+
+  type Row = { id: string; name: string };
+
+  let table: DataTable;
+
+  // `upper` uses display(row); its cell value does not change when name does.
+  export let headers: ComponentProps<DataTable>["headers"] = [
+    { key: "name", value: "Name" },
+    {
+      key: "upper",
+      value: "Upper",
+      display: (_value, row) => (row as Row).name.toUpperCase(),
+    },
+  ];
+
+  export let rows: Row[] = [{ id: "a", name: "alpha" }];
+
+  // In-place edit, then refreshRow.
+  export function mutateAndRefreshRow() {
+    rows[0].name = "beta";
+    table.refreshRow("a");
+  }
+
+  // In-place edit, no refresh. Should stay stale.
+  export function mutateNoRefresh() {
+    rows[0].name = "gamma";
+  }
+
+  export function mutateAndRefreshCells() {
+    rows[0].name = "delta";
+    table.refreshCells();
+  }
+</script>
+
+<DataTable bind:this={table} {headers} {rows} />

--- a/tests/DataTable/DataTableRefreshRow.test.ts
+++ b/tests/DataTable/DataTableRefreshRow.test.ts
@@ -1,0 +1,66 @@
+import { render, screen, within } from "@testing-library/svelte";
+import { tick } from "svelte";
+import DataTableRefreshRow from "./DataTableRefreshRow.test.svelte";
+
+function getFirstBodyRow(): HTMLElement {
+  const rows = screen
+    .getAllByRole("row")
+    .filter((r) => r.closest("tbody") !== null);
+  expect(rows.length).toBeGreaterThan(0);
+  return rows[0];
+}
+
+describe("DataTable refreshRow / refreshCells", () => {
+  it("updates a row after in-place edit when refreshRow is called", async () => {
+    const { component } = render(DataTableRefreshRow);
+    const row = getFirstBodyRow();
+
+    expect(within(row).queryByRole("cell", { name: "alpha" })).not.toBeNull();
+    expect(within(row).queryByRole("cell", { name: "ALPHA" })).not.toBeNull();
+
+    component.mutateAndRefreshRow();
+    await tick();
+
+    const refreshed = getFirstBodyRow();
+    expect(
+      within(refreshed).queryByRole("cell", { name: "beta" }),
+    ).not.toBeNull();
+    expect(within(refreshed).queryByRole("cell", { name: "alpha" })).toBeNull();
+    expect(
+      within(refreshed).queryByRole("cell", { name: "BETA" }),
+    ).not.toBeNull();
+    expect(within(refreshed).queryByRole("cell", { name: "ALPHA" })).toBeNull();
+  });
+
+  it("does not update cells after in-place edit without refresh", async () => {
+    const { component } = render(DataTableRefreshRow);
+    const row = getFirstBodyRow();
+
+    expect(within(row).queryByRole("cell", { name: "alpha" })).not.toBeNull();
+
+    component.mutateNoRefresh();
+    await tick();
+
+    const stale = getFirstBodyRow();
+    expect(within(stale).queryByRole("cell", { name: "alpha" })).not.toBeNull();
+    expect(within(stale).queryByRole("cell", { name: "gamma" })).toBeNull();
+  });
+
+  it("updates all rows when refreshCells is called", async () => {
+    const { component } = render(DataTableRefreshRow);
+    expect(
+      within(getFirstBodyRow()).queryByRole("cell", { name: "alpha" }),
+    ).not.toBeNull();
+
+    component.mutateAndRefreshCells();
+    await tick();
+
+    const refreshed = getFirstBodyRow();
+    expect(
+      within(refreshed).queryByRole("cell", { name: "delta" }),
+    ).not.toBeNull();
+    expect(
+      within(refreshed).queryByRole("cell", { name: "DELTA" }),
+    ).not.toBeNull();
+  });
+});


### PR DESCRIPTION
Closes [#574](https://github.com/carbon-design-system/carbon-components-svelte/issues/574)

This is the first step to better support editable data tables.

**Problem**

`DataTable` rebuilds its internal cell model only when the `rows` **array reference** changes. This is intentional and keeps re-renders cheap, but it makes inline editing more difficult.

When a consumer renders an input in the `"cell"` slot and binds it to a row field (`bind:value={row.qty}`), the edit mutates the existing row object in place. The array reference is unchanged, so the table never re-derives. The bound value updates, but any **derived column**, one whose `display` reads other fields of the same row (a total, a computed status, a sort key), goes stale. There was no way to ask the table to re-derive a row without reassigning the whole `rows` array, which is awkward and easy to forget.

**Solution**

Add two accessors, exposed both as component methods (via `bind:this`) and on the `carbon:DataTable` context:

- `refreshRow(id)` re-derives the cells for a single row from its current values and reassigns the internal cell map, so the table re-renders without the consumer reassigning `rows`.
- `refreshCells()` does the same for every row, for batch edits.

A consumer now calls `dataTable.refreshRow(row.id)` after an edit and the derived columns stay in sync.

---

**Baseline (non-edit) performance is preserved**

The reactive block that builds cells on a `rows`/`headers` reference change is unchanged in behavior. It keeps its per-cell diff that reuses existing cell objects when their values are equal, so unrelated rows do not re-render. Tables that never edit pay nothing: the new code paths run only when `refreshRow`/`refreshCells` is explicitly invoked.

The refresh path deliberately produces **fresh** cell objects rather than reusing equal ones. This is required for derived columns, whose own cell `value` can be unchanged (often `undefined`) even though their `display` output depends on a mutated sibling field. Reusing the object there would skip the re-render. This trade only applies to the edited row at the moment of refresh, not to normal rendering.

---


https://github.com/user-attachments/assets/20cff522-93a5-485b-b20b-d1ffc9a3107e

