### PR TITLE
feat(data-table): support editable cells

### DIFF
--- a/docs/src/pages/components/DataTable.svx
+++ b/docs/src/pages/components/DataTable.svx
@@ -159,6 +159,16 @@ When you edit multiple rows in place, call `refreshCells()` once to update deriv
 
 <FileSource src="/framed/DataTable/DataTableEditableCellsRefreshCells" />
 
+## Editable cells with `EditableCell`
+
+The `EditableCell` component wraps a form input in the `"cell"` slot and wires the editing concerns for you. It re-derives the row after each edit (no manual `refreshRow`), reports dirty state, and rolls up validation.
+
+Pass `validate` a function that returns an error message for an invalid value or `undefined` when valid. The message is exposed through `let:invalidText` (and `let:invalid`) so your chosen input renders the error.
+
+Bind `dirty` to know when any cell differs from its initial value, and `valid` to know when every cell passes validation. After persisting edits, call the `resetDirty` method (via `bind:this`) to treat the current values as pristine.
+
+<FileSource src="/framed/DataTable/DataTableEditableCellComponent" />
+
 ## With title, description
 
 Add a title and description to provide context for the table data.

--- a/docs/src/pages/components/DataTable.svx
+++ b/docs/src/pages/components/DataTable.svx
@@ -169,6 +169,14 @@ Bind `dirty` to know when any cell differs from its initial value, and `valid` t
 
 <FileSource src="/framed/DataTable/DataTableEditableCellComponent" />
 
+## Row edit mode
+
+Edit one row at a time with explicit save and cancel. The `"cell"` slot exposes `let:editing`, `let:edit`, `let:save`, and `let:cancel`. Render inputs only when `editing` is `true`; use the callbacks to drive the row.
+
+When a row enters edit mode the table snapshots it, so `cancel` restores the original values without reassigning `rows`. `save` re-derives the row, and both dispatch a `save` / `discard` event with the affected `row`. Bind `editingRowId` to read or set which row is editing; pressing `Enter` commits and `Escape` cancels.
+
+<FileSource src="/framed/DataTable/DataTableEditableRow" />
+
 ## With title, description
 
 Add a title and description to provide context for the table data.

--- a/docs/src/pages/framed/DataTable/DataTableEditSaveDiscard.svelte
+++ b/docs/src/pages/framed/DataTable/DataTableEditSaveDiscard.svelte
@@ -1,0 +1,129 @@
+<script>
+  import {
+    Button,
+    DataTable,
+    EditableCell,
+    NumberInput,
+    Select,
+    SelectItem,
+    TextInput,
+    Toolbar,
+    ToolbarContent,
+  } from "carbon-components-svelte";
+  import Save from "carbon-icons-svelte/lib/Save.svelte";
+  import Undo from "carbon-icons-svelte/lib/Undo.svelte";
+
+  // BASELINE (hand-rolled). Demonstrates a full edit -> save | discard flow
+  // built only with today's primitives (EditableCell + bind:dirty/valid +
+  // resetDirty). Highlights what is still manual: the snapshot, the discard
+  // restore, and the rows reassignment needed to push restored values back
+  // into the bound inputs.
+
+  const protocols = ["HTTP", "HTTPS", "TCP", "UDP"];
+
+  const headers = [
+    { key: "name", value: "Name" },
+    { key: "protocol", value: "Protocol" },
+    { key: "port", value: "Port" },
+  ];
+
+  const seed = [
+    { id: "a", name: "Rule 1", protocol: "HTTP", port: 80 },
+    { id: "b", name: "Rule 2", protocol: "HTTPS", port: 443 },
+    { id: "c", name: "Rule 3", protocol: "TCP", port: 3000 },
+  ];
+
+  let dataTable;
+  let dirty = false;
+  let valid = true;
+
+  // Manual deep snapshot of the last-saved state, used to discard edits.
+  const clone = (list) => list.map((row) => ({ ...row }));
+  let rows = clone(seed);
+  let saved = clone(seed);
+
+  const portRange = (value) =>
+    value >= 1 && value <= 65535 ? undefined : "Port must be 1-65535";
+  const required = (value) =>
+    value && `${value}`.trim() ? undefined : "Required";
+
+  function save() {
+    // Persist to your backend here, then mark the new baseline.
+    saved = clone(rows);
+    dataTable.resetDirty();
+  }
+
+  function discard() {
+    // Restoring in place would NOT update the bound inputs (Svelte does not
+    // track row.field deeply), so we must rebuild rows with fresh objects to
+    // force the inputs to rebind. This is the boilerplate `editable` should remove.
+    rows = clone(saved);
+    dataTable.resetDirty();
+  }
+</script>
+
+<DataTable bind:this={dataTable} bind:dirty bind:valid {headers} {rows}>
+  <Toolbar>
+    <ToolbarContent>
+      <Button kind="secondary" icon={Undo} disabled={!dirty} on:click={discard}>
+        Discard
+      </Button>
+      <Button icon={Save} disabled={!dirty || !valid} on:click={save}>
+        Save changes
+      </Button>
+    </ToolbarContent>
+  </Toolbar>
+
+  <svelte:fragment slot="cell" let:row let:cell>
+    {#if cell.key === "name"}
+      <EditableCell
+        {row}
+        {cell}
+        validate={required}
+        let:invalid
+        let:invalidText
+      >
+        <TextInput
+          size="sm"
+          hideLabel
+          labelText="Name"
+          bind:value={row.name}
+          {invalid}
+          {invalidText}
+        />
+      </EditableCell>
+    {:else if cell.key === "protocol"}
+      <EditableCell {row} {cell}>
+        <Select
+          size="sm"
+          hideLabel
+          labelText="Protocol"
+          bind:selected={row.protocol}
+        >
+          {#each protocols as protocol}
+            <SelectItem value={protocol} text={protocol} />
+          {/each}
+        </Select>
+      </EditableCell>
+    {:else if cell.key === "port"}
+      <EditableCell
+        {row}
+        {cell}
+        validate={portRange}
+        let:invalid
+        let:invalidText
+      >
+        <NumberInput
+          size="sm"
+          hideLabel
+          label="Port"
+          bind:value={row.port}
+          {invalid}
+          {invalidText}
+        />
+      </EditableCell>
+    {:else}
+      {cell.value}
+    {/if}
+  </svelte:fragment>
+</DataTable>

--- a/docs/src/pages/framed/DataTable/DataTableEditToolbar.svelte
+++ b/docs/src/pages/framed/DataTable/DataTableEditToolbar.svelte
@@ -1,0 +1,111 @@
+<script>
+  import {
+    Button,
+    DataTable,
+    EditableCell,
+    NumberInput,
+    TextInput,
+    Toolbar,
+    ToolbarBatchActions,
+    ToolbarContent,
+  } from "carbon-components-svelte";
+  import Add from "carbon-icons-svelte/lib/Add.svelte";
+  import Save from "carbon-icons-svelte/lib/Save.svelte";
+  import TrashCan from "carbon-icons-svelte/lib/TrashCan.svelte";
+
+  // BASELINE (hand-rolled). Bulk entry with a toolbar: add a blank row, remove
+  // selected rows, save. The toolbar wiring is all manual: id generation, the
+  // rows array reassignment for add/remove, and clearing the selection. An
+  // `edit-toolbar` slot with `let:addRow` / `let:removeRow` should remove this.
+
+  const headers = [
+    { key: "name", value: "Name" },
+    { key: "qty", value: "Quantity" },
+  ];
+
+  let rows = [
+    { id: "a", name: "Widget", qty: 3 },
+    { id: "b", name: "Gadget", qty: 1 },
+  ];
+
+  let dataTable;
+  let dirty = false;
+  let valid = true;
+  let selectedRowIds = [];
+
+  let nextId = rows.length;
+  const required = (value) =>
+    value && `${value}`.trim() ? undefined : "Required";
+
+  function addRow() {
+    // Manual id bookkeeping + array reassignment.
+    const id = `row-${nextId++}`;
+    rows = [...rows, { id, name: "", qty: 1 }];
+  }
+
+  function removeSelected() {
+    const remove = new Set(selectedRowIds);
+    rows = rows.filter((row) => !remove.has(row.id));
+    selectedRowIds = [];
+  }
+
+  function save() {
+    // Persist rows here.
+    dataTable.resetDirty();
+  }
+</script>
+
+<DataTable
+  bind:this={dataTable}
+  bind:dirty
+  bind:valid
+  bind:selectedRowIds
+  batchSelection
+  {headers}
+  {rows}
+>
+  <Toolbar>
+    <ToolbarBatchActions>
+      <Button icon={TrashCan} on:click={removeSelected}>Delete</Button>
+    </ToolbarBatchActions>
+    <ToolbarContent>
+      <Button kind="ghost" icon={Add} on:click={addRow}>Add row</Button>
+      <Button icon={Save} disabled={!dirty || !valid} on:click={save}>
+        Save changes
+      </Button>
+    </ToolbarContent>
+  </Toolbar>
+
+  <svelte:fragment slot="cell" let:row let:cell>
+    {#if cell.key === "name"}
+      <EditableCell
+        {row}
+        {cell}
+        validate={required}
+        let:invalid
+        let:invalidText
+      >
+        <TextInput
+          size="sm"
+          hideLabel
+          labelText="Name"
+          bind:value={row.name}
+          {invalid}
+          {invalidText}
+        />
+      </EditableCell>
+    {:else if cell.key === "qty"}
+      <EditableCell {row} {cell}>
+        <NumberInput
+          size="sm"
+          hideLabel
+          label="Quantity"
+          min={0}
+          bind:value={row.qty}
+        />
+      </EditableCell>
+    {:else}
+      {cell.value}
+    {/if}
+  </svelte:fragment>
+</DataTable>

--- a/docs/src/pages/framed/DataTable/DataTableEditableCellComponent.svelte
+++ b/docs/src/pages/framed/DataTable/DataTableEditableCellComponent.svelte
@@ -1,0 +1,77 @@
+<script>
+  import {
+    DataTable,
+    EditableCell,
+    TextInput,
+    NumberInput,
+    Button,
+  } from "carbon-components-svelte";
+
+  let dataTable;
+  let dirty = false;
+  let valid = true;
+
+  let rows = [
+    { id: "a", item: "Widget", qty: 3, unitPrice: 10 },
+    { id: "b", item: "Gadget", qty: 1, unitPrice: 25 },
+  ];
+
+  const required = (value) =>
+    value && `${value}`.trim() ? undefined : "Required";
+  const positive = (value) => (value > 0 ? undefined : "Must be greater than 0");
+</script>
+
+<DataTable
+  bind:this={dataTable}
+  {rows}
+  bind:dirty
+  bind:valid
+  headers={[
+    { key: "item", value: "Item" },
+    { key: "qty", value: "Quantity" },
+    {
+      key: "total",
+      value: "Total",
+      display: (_value, row) => `$${row.qty * row.unitPrice}`,
+    },
+  ]}
+>
+  <svelte:fragment slot="cell" let:row let:cell>
+    {#if cell.key === "item"}
+      <EditableCell {row} {cell} validate={required} let:invalid let:invalidText>
+        <TextInput
+          size="sm"
+          hideLabel
+          labelText="Item"
+          bind:value={row.item}
+          {invalid}
+          {invalidText}
+        />
+      </EditableCell>
+    {:else if cell.key === "qty"}
+      <EditableCell {row} {cell} validate={positive} let:invalid let:invalidText>
+        <NumberInput
+          size="sm"
+          hideLabel
+          label="Quantity"
+          bind:value={row.qty}
+          {invalid}
+          {invalidText}
+        />
+      </EditableCell>
+    {:else}
+      {cell.display ? cell.display(cell.value, row) : cell.value}
+    {/if}
+  </svelte:fragment>
+</DataTable>
+
+<Button
+  style="margin-top: var(--cds-spacing-05)"
+  disabled={!dirty || !valid}
+  on:click={() => {
+    // Persist `rows`, then mark the current values as pristine.
+    dataTable.resetDirty();
+  }}
+>
+  Save changes
+</Button>

--- a/docs/src/pages/framed/DataTable/DataTableEditableCellComponent.svelte
+++ b/docs/src/pages/framed/DataTable/DataTableEditableCellComponent.svelte
@@ -1,10 +1,10 @@
 <script>
   import {
+    Button,
     DataTable,
     EditableCell,
-    TextInput,
     NumberInput,
-    Button,
+    TextInput,
   } from "carbon-components-svelte";
 
   let dataTable;
@@ -18,7 +18,8 @@
 
   const required = (value) =>
     value && `${value}`.trim() ? undefined : "Required";
-  const positive = (value) => (value > 0 ? undefined : "Must be greater than 0");
+  const positive = (value) =>
+    value > 0 ? undefined : "Must be greater than 0";
 </script>
 
 <DataTable
@@ -38,7 +39,13 @@
 >
   <svelte:fragment slot="cell" let:row let:cell>
     {#if cell.key === "item"}
-      <EditableCell {row} {cell} validate={required} let:invalid let:invalidText>
+      <EditableCell
+        {row}
+        {cell}
+        validate={required}
+        let:invalid
+        let:invalidText
+      >
         <TextInput
           size="sm"
           hideLabel
@@ -49,7 +56,13 @@
         />
       </EditableCell>
     {:else if cell.key === "qty"}
-      <EditableCell {row} {cell} validate={positive} let:invalid let:invalidText>
+      <EditableCell
+        {row}
+        {cell}
+        validate={positive}
+        let:invalid
+        let:invalidText
+      >
         <NumberInput
           size="sm"
           hideLabel

--- a/docs/src/pages/framed/DataTable/DataTableEditableRow.svelte
+++ b/docs/src/pages/framed/DataTable/DataTableEditableRow.svelte
@@ -1,0 +1,110 @@
+<script>
+  import {
+    Button,
+    DataTable,
+    EditableCell,
+    NumberInput,
+    TextInput,
+  } from "carbon-components-svelte";
+  import Checkmark from "carbon-icons-svelte/lib/Checkmark.svelte";
+  import Close from "carbon-icons-svelte/lib/Close.svelte";
+  import Edit from "carbon-icons-svelte/lib/Edit.svelte";
+
+  let editingRowId = null;
+  let valid = true;
+
+  let rows = [
+    { id: "a", name: "Widget", qty: 3 },
+    { id: "b", name: "Gadget", qty: 1 },
+    { id: "c", name: "Gizmo", qty: 5 },
+  ];
+
+  const required = (value) =>
+    value && `${value}`.trim() ? undefined : "Required";
+</script>
+
+<DataTable
+  bind:editingRowId
+  bind:valid
+  headers={[
+    { key: "name", value: "Name" },
+    { key: "qty", value: "Quantity" },
+    {
+      key: "total",
+      value: "Total",
+      display: (_value, row) => `$${row.qty * 10}`,
+    },
+    { key: "actions", empty: true },
+  ]}
+  {rows}
+  on:save={(e) => console.log("save", e.detail.row)}
+  on:discard={(e) => console.log("discard", e.detail.row)}
+>
+  <svelte:fragment
+    slot="cell"
+    let:row
+    let:cell
+    let:editing
+    let:edit
+    let:save
+    let:cancel
+  >
+    {#if cell.key === "actions"}
+      {#if editing}
+        <Button
+          size="small"
+          kind="ghost"
+          icon={Checkmark}
+          iconDescription="Save"
+          disabled={!valid}
+          on:click={save}
+        />
+        <Button
+          size="small"
+          kind="ghost"
+          icon={Close}
+          iconDescription="Cancel"
+          on:click={cancel}
+        />
+      {:else}
+        <Button
+          size="small"
+          kind="ghost"
+          icon={Edit}
+          iconDescription="Edit row"
+          disabled={editingRowId !== null}
+          on:click={edit}
+        />
+      {/if}
+    {:else if editing && cell.key === "name"}
+      <EditableCell
+        {row}
+        {cell}
+        validate={required}
+        let:invalid
+        let:invalidText
+      >
+        <TextInput
+          size="sm"
+          hideLabel
+          labelText="Name"
+          bind:value={row.name}
+          {invalid}
+          {invalidText}
+        />
+      </EditableCell>
+    {:else if editing && cell.key === "qty"}
+      <EditableCell {row} {cell}>
+        <NumberInput
+          size="sm"
+          hideLabel
+          label="Quantity"
+          min={0}
+          bind:value={row.qty}
+        />
+      </EditableCell>
+    {:else}
+      {cell.display ? cell.display(cell.value, row) : cell.value}
+    {/if}
+  </svelte:fragment>
+</DataTable>

--- a/docs/src/pages/framed/DataTable/DataTableRowEditMode.svelte
+++ b/docs/src/pages/framed/DataTable/DataTableRowEditMode.svelte
@@ -1,0 +1,90 @@
+<script>
+  import {
+    Button,
+    DataTable,
+    NumberInput,
+    TextInput,
+  } from "carbon-components-svelte";
+  import Checkmark from "carbon-icons-svelte/lib/Checkmark.svelte";
+  import Close from "carbon-icons-svelte/lib/Close.svelte";
+  import Edit from "carbon-icons-svelte/lib/Edit.svelte";
+
+  // BASELINE (hand-rolled). Row-level edit mode: one row enters edit at a
+  // time with Save/Cancel, all other rows stay read-only. Everything here is
+  // manual state that `editable="row"` should own: which row is editing, the
+  // per-row snapshot for cancel, swapping value vs input, and (missing here)
+  // Enter-to-commit / Esc-to-cancel and focus management.
+
+  const headers = [
+    { key: "name", value: "Name" },
+    { key: "qty", value: "Quantity" },
+    { key: "actions", value: "", empty: true },
+  ];
+
+  let rows = [
+    { id: "a", name: "Widget", qty: 3 },
+    { id: "b", name: "Gadget", qty: 1 },
+    { id: "c", name: "Gizmo", qty: 5 },
+  ];
+
+  let editingId = null;
+  let snapshot = null;
+
+  function startEdit(row) {
+    editingId = row.id;
+    snapshot = { ...row };
+  }
+
+  function saveEdit() {
+    // Persist row here. Reassign rows so the now-static cells re-derive and
+    // reflect the in-place edits (another manual step `editable="row"` removes).
+    rows = [...rows];
+    editingId = null;
+    snapshot = null;
+  }
+
+  function cancelEdit() {
+    // Restore the snapshot. New object references force the inputs to rebind.
+    rows = rows.map((row) => (row.id === editingId ? { ...snapshot } : row));
+    editingId = null;
+    snapshot = null;
+  }
+</script>
+
+<DataTable {headers} {rows}>
+  <svelte:fragment slot="cell" let:row let:cell>
+    {#if cell.key === "actions"}
+      {#if editingId === row.id}
+        <Button
+          kind="ghost"
+          size="small"
+          iconDescription="Save"
+          icon={Checkmark}
+          on:click={saveEdit}
+        />
+        <Button
+          kind="ghost"
+          size="small"
+          iconDescription="Cancel"
+          icon={Close}
+          on:click={cancelEdit}
+        />
+      {:else}
+        <Button
+          kind="ghost"
+          size="small"
+          iconDescription="Edit row"
+          icon={Edit}
+          disabled={editingId !== null && editingId !== row.id}
+          on:click={() => startEdit(row)}
+        />
+      {/if}
+    {:else if editingId === row.id && cell.key === "name"}
+      <TextInput size="sm" hideLabel labelText="Name" bind:value={row.name} />
+    {:else if editingId === row.id && cell.key === "qty"}
+      <NumberInput size="sm" hideLabel label="Quantity" bind:value={row.qty} />
+    {:else}
+      {cell.value}
+    {/if}
+  </svelte:fragment>
+</DataTable>

--- a/docs/src/pages/framed/DataTable/DataTableVirtualizedEdit.svelte
+++ b/docs/src/pages/framed/DataTable/DataTableVirtualizedEdit.svelte
@@ -1,0 +1,67 @@
+<script>
+  import {
+    DataTable,
+    EditableCell,
+    NumberInput,
+    TextInput,
+  } from "carbon-components-svelte";
+
+  // BASELINE (hand-rolled, EXPLORATORY). Editing inside a virtualized table.
+  // Virtualization recycles DOM: rows scrolled out of view are unmounted and
+  // their EditableCells destroyed. Bound values survive (they live on the row
+  // objects), but try this to see the rough edges:
+  //   - focus is lost when the focused row scrolls out of the viewport
+  //   - row height is fixed (itemHeight), so taller inputs can clip
+  //   - an open Select/menu inside a cell is destroyed mid-interaction
+  // This is the case the proposal flags as ambiguous; the goal of recording
+  // it is to decide whether to support it or document it as unsupported.
+
+  const headers = [
+    { key: "name", value: "Name" },
+    { key: "qty", value: "Quantity" },
+    {
+      key: "total",
+      value: "Total",
+      display: (_value, row) => `$${row.qty * 10}`,
+    },
+  ];
+
+  let rows = Array.from({ length: 500 }, (_, index) => ({
+    id: `row-${index}`,
+    name: `Item ${index}`,
+    qty: (index % 9) + 1,
+  }));
+
+  let dirty = false;
+  let valid = true;
+</script>
+
+<DataTable
+  bind:dirty
+  bind:valid
+  {headers}
+  {rows}
+  virtualize
+  stickyHeader
+  size="short"
+>
+  <svelte:fragment slot="cell" let:row let:cell>
+    {#if cell.key === "name"}
+      <EditableCell {row} {cell}>
+        <TextInput size="sm" hideLabel labelText="Name" bind:value={row.name} />
+      </EditableCell>
+    {:else if cell.key === "qty"}
+      <EditableCell {row} {cell}>
+        <NumberInput
+          size="sm"
+          hideLabel
+          label="Quantity"
+          min={0}
+          bind:value={row.qty}
+        />
+      </EditableCell>
+    {:else}
+      {cell.display ? cell.display(cell.value, row) : cell.value}
+    {/if}
+  </svelte:fragment>
+</DataTable>

--- a/src/DataTable/DataTable.svelte
+++ b/src/DataTable/DataTable.svelte
@@ -43,7 +43,9 @@
    * @slot {{ expanded: boolean; row: Row | undefined; props: { "aria-hidden": "true" | "false"; class: string; }; }} expandIcon
    * @slot {{ row: Row; rowSelected: boolean; }} expandedRow
    * @slot {{ header: DataTableNonEmptyHeader; }} cellHeader
-   * @slot {{ row: Row; cell: DataTableCell<Row>; rowIndex: number; cellIndex: number; rowSelected: boolean; rowExpanded: boolean; }} cell
+   * @slot {{ row: Row; cell: DataTableCell<Row>; rowIndex: number; cellIndex: number; rowSelected: boolean; rowExpanded: boolean; editing: boolean; edit: () => void; save: () => void; cancel: () => void; }} cell
+   * @event {{ row: Row }} save
+   * @event {{ row: Row }} discard
    * @event click
    * @type {object}
    * @property {DataTableHeader<Row>} [header]
@@ -119,6 +121,16 @@
    * @bindable readonly
    */
   export let valid = true;
+
+  /**
+   * Id of the row currently in row edit mode, or `null`.
+   * The `cell` slot exposes `let:editing` / `let:edit` / `let:save` / `let:cancel`
+   * to drive row editing; set this directly to enter edit mode programmatically.
+   * Entering edit snapshots the row so `cancel` can restore it.
+   * @type {Row["id"] | null}
+   * @bindable writable
+   */
+  export let editingRowId = null;
 
   /**
    * Set the size of the data table.
@@ -422,6 +434,92 @@
 
   $: dirty = Object.values($editableCells).some((cell) => cell.dirty);
   $: valid = Object.values($editableCells).every((cell) => !cell.invalidText);
+
+  // Row edit mode. The table owns a shallow snapshot of the row being edited so
+  // `cancel` can restore it without the consumer reassigning `rows`. Entering
+  // edit (including programmatically via `editingRowId`) takes the snapshot and
+  // focuses the row's first field.
+  let prevEditingRowId = null;
+  /** @type {Record<string, any> | null} */
+  let editSnapshot = null;
+  $: if (editingRowId !== prevEditingRowId) {
+    prevEditingRowId = editingRowId;
+    if (editingRowId == null) {
+      editSnapshot = null;
+    } else {
+      const row = rows.find((row) => row.id === editingRowId);
+      editSnapshot = row ? { ...row } : null;
+      focusFirstField(editingRowId);
+    }
+  }
+
+  /**
+   * Enter row edit mode for the given row id.
+   * @type {(id: Row["id"]) => void}
+   */
+  export function editRow(id) {
+    editingRowId = id;
+  }
+
+  /**
+   * Commit the row currently in edit mode: re-derive its cells, dispatch
+   * `save`, clear dirty, and exit edit mode.
+   * @type {() => void}
+   */
+  export function saveRow() {
+    const id = editingRowId;
+    if (id == null) return;
+    const row = rows.find((row) => row.id === id);
+    refreshRow(id);
+    if (row) dispatch("save", { row });
+    resetDirty();
+    editingRowId = null;
+  }
+
+  /**
+   * Cancel the row currently in edit mode: restore the snapshot taken when
+   * editing began, dispatch `discard`, clear dirty, and exit edit mode.
+   * @type {() => void}
+   */
+  export function cancelRow() {
+    const id = editingRowId;
+    if (id == null) return;
+    const row = rows.find((row) => row.id === id);
+    if (row && editSnapshot) {
+      Object.assign(row, editSnapshot);
+      refreshRow(id);
+      dispatch("discard", { row });
+    }
+    resetDirty();
+    editingRowId = null;
+  }
+
+  function focusFirstField(id) {
+    tick().then(() => {
+      const root = tableRef ?? scrollContainerRef;
+      if (!root) return;
+      let rowEl = null;
+      try {
+        rowEl = root.querySelector(`[data-row="${String(id)}"]`);
+      } catch {
+        return;
+      }
+      rowEl?.querySelector("input, select, textarea")?.focus();
+    });
+  }
+
+  function handleRowKeydown(event, row) {
+    if (editingRowId !== row.id) return;
+    if (event.key === "Enter") {
+      // Allow newlines in a textarea; commit on Enter elsewhere.
+      if (event.target instanceof HTMLTextAreaElement) return;
+      event.preventDefault();
+      saveRow();
+    } else if (event.key === "Escape") {
+      event.preventDefault();
+      cancelRow();
+    }
+  }
 
   /** Default row heights based on size variant */
   const DEFAULT_ROW_HEIGHTS = {
@@ -1039,6 +1137,8 @@
             {@const isSelected = selectedRowIdsSet.has(row.id)}
             {@const isExpanded = !!expandedRows[row.id]}
             {@const isHighlighted = highlightedRowIdsSet.has(row.id)}
+            {@const isEditing = editingRowId === row.id}
+            {@const editThisRow = () => editRow(row.id)}
             {@const rowClassValue =
               typeof rowClass === "function"
                 ? rowClass({ row, rowIndex: actualIndex, selected: isSelected, expanded: isExpanded })
@@ -1071,6 +1171,7 @@
               on:mouseleave={() => {
                 dispatch("mouseleave:row", row);
               }}
+              on:keydown={(event) => handleRowKeydown(event, row)}
             >
               {#if expandable}
                 <TableCell
@@ -1174,6 +1275,10 @@
                       cellIndex={j}
                       rowSelected={isSelected}
                       rowExpanded={isExpanded}
+                      editing={isEditing}
+                      edit={editThisRow}
+                      save={saveRow}
+                      cancel={cancelRow}
                     >
                       {cell.display
                         ? cell.display(cell.value, row)
@@ -1200,6 +1305,10 @@
                       cellIndex={j}
                       rowSelected={isSelected}
                       rowExpanded={isExpanded}
+                      editing={isEditing}
+                      edit={editThisRow}
+                      save={saveRow}
+                      cancel={cancelRow}
                     >
                       {cell.display
                         ? cell.display(cell.value, row)
@@ -1259,6 +1368,8 @@
             {@const isExpanded = !!expandedRows[row.id]}
             {@const isExpandable = !nonExpandableRowIdsSet.has(row.id)}
             {@const isSelectable = !nonSelectableRowIdsSet.has(row.id)}
+            {@const isEditing = editingRowId === row.id}
+            {@const editThisRow = () => editRow(row.id)}
             {@const isHighlighted = highlightedRowIdsSet.has(row.id)}
             {@const rowClassValue =
               typeof rowClass === "function"
@@ -1299,6 +1410,7 @@
               on:mouseleave={() => {
                 dispatch("mouseleave:row", row);
               }}
+              on:keydown={(event) => handleRowKeydown(event, row)}
             >
               {#if expandable}
                 <TableCell
@@ -1392,6 +1504,10 @@
                       cellIndex={j}
                       rowSelected={isSelected}
                       rowExpanded={isExpanded}
+                      editing={isEditing}
+                      edit={editThisRow}
+                      save={saveRow}
+                      cancel={cancelRow}
                     >
                       {cell.display ? cell.display(cell.value, row) : cell.value}
                     </slot>
@@ -1416,6 +1532,10 @@
                       cellIndex={j}
                       rowSelected={isSelected}
                       rowExpanded={isExpanded}
+                      editing={isEditing}
+                      edit={editThisRow}
+                      save={saveRow}
+                      cancel={cancelRow}
                     >
                       {cell.display ? cell.display(cell.value, row) : cell.value}
                     </slot>

--- a/src/DataTable/DataTable.svelte
+++ b/src/DataTable/DataTable.svelte
@@ -106,6 +106,21 @@
   export let rows = [];
 
   /**
+   * `true` when at least one `EditableCell` holds a value
+   * that differs from its value when first rendered.
+   * Resets are the consumer's responsibility (e.g. after a save).
+   * @bindable readonly
+   */
+  export let dirty = false;
+
+  /**
+   * `true` when every `EditableCell` passes its `validate` function.
+   * `true` when there are no editable cells.
+   * @bindable readonly
+   */
+  export let valid = true;
+
+  /**
    * Set the size of the data table.
    * @type {"compact" | "short" | "medium" | "tall"}
    */
@@ -351,6 +366,63 @@
   const tableSize = writable(size);
   $: $tableSize = size;
 
+  /**
+   * Registry of editable cells keyed by `${rowId}:${cellKey}`. Each
+   * `EditableCell` registers on mount and reports its dirty/validity
+   * state here; `dirty` and `valid` are rolled up from it. The store
+   * stays empty (and the rollups stay at their defaults) for tables
+   * with no editable cells, so non-editing tables pay nothing.
+   * @type {import("svelte/store").Writable<Record<string, { dirty: boolean; invalidText: string | undefined }>>}
+   */
+  const editableCells = writable({});
+
+  /**
+   * Monotonic counter bumped by `resetDirty`. Each `EditableCell` watches
+   * it and re-snapshots its baseline value when it changes, so the dirty
+   * rollup can return to `false` after the consumer persists edits.
+   * @type {import("svelte/store").Writable<number>}
+   */
+  const editableBaseline = writable(0);
+
+  /**
+   * Treat the current editable cell values as pristine, clearing `dirty`.
+   * Call this after persisting edits (for example in an `on:save` handler).
+   * @type {() => void}
+   */
+  export function resetDirty() {
+    editableBaseline.update((n) => n + 1);
+  }
+
+  /** @type {(id: string) => void} */
+  function editableRegister(id) {
+    editableCells.update((cells) =>
+      id in cells
+        ? cells
+        : { ...cells, [id]: { dirty: false, invalidText: undefined } },
+    );
+  }
+
+  /** @type {(id: string, state: { dirty: boolean; invalidText: string | undefined }) => void} */
+  function editableUpdate(id, state) {
+    editableCells.update((cells) => ({
+      ...cells,
+      [id]: { ...cells[id], ...state },
+    }));
+  }
+
+  /** @type {(id: string) => void} */
+  function editableUnregister(id) {
+    editableCells.update((cells) => {
+      if (!(id in cells)) return cells;
+      const next = { ...cells };
+      delete next[id];
+      return next;
+    });
+  }
+
+  $: dirty = Object.values($editableCells).some((cell) => cell.dirty);
+  $: valid = Object.values($editableCells).every((cell) => !cell.invalidText);
+
   /** Default row heights based on size variant */
   const DEFAULT_ROW_HEIGHTS = {
     compact: 24,
@@ -506,6 +578,11 @@
     filterRows,
     refreshRow,
     refreshCells,
+    editableRegister,
+    editableUpdate,
+    editableUnregister,
+    editableBaseline,
+    resetDirty,
   });
 
   let expanded = false;

--- a/src/DataTable/EditableCell.svelte
+++ b/src/DataTable/EditableCell.svelte
@@ -1,0 +1,121 @@
+<script>
+  /**
+   * @template {import("./DataTable.svelte").DataTableRow} [Row=import("./DataTable.svelte").DataTableRow]
+   */
+
+  /**
+   * @restProps {div}
+   * @slot {{ invalid: boolean; invalidText: string | undefined; }}
+   */
+
+  /**
+   * Specify the row this cell belongs to.
+   * Provided by the `cell` slot as `let:row`.
+   * @type {Row}
+   */
+  export let row;
+
+  /**
+   * Specify the cell being edited.
+   * Provided by the `cell` slot as `let:cell`.
+   * @type {import("./DataTable.svelte").DataTableCell<Row>}
+   */
+  export let cell;
+
+  /**
+   * Provide a validation function for the bound value.
+   * Return an error message to mark the cell invalid, or
+   * `undefined` (or an empty string) when the value is valid.
+   * The returned message is exposed via `let:invalidText`.
+   * @type {(value: any, row: Row) => string | undefined}
+   */
+  export let validate = undefined;
+
+  import { getContext, onDestroy, onMount } from "svelte";
+  import { resolvePath } from "./data-table-utils.js";
+
+  const ctx = getContext("carbon:DataTable") ?? {};
+  const cellId = `${row?.id}:${cell?.key}`;
+  const baseline = ctx.editableBaseline;
+
+  let initialValue;
+  let mounted = false;
+  let seenBaseline = 0;
+  let dirty = false;
+  /** @type {string | undefined} */
+  let invalidText = undefined;
+
+  $: invalid = invalidText !== undefined && invalidText !== "";
+
+  // `resetDirty()` on the table bumps the baseline; re-snapshot the current
+  // value as pristine so an edited-then-saved cell stops reporting dirty.
+  $: if (mounted && baseline && $baseline !== seenBaseline) {
+    seenBaseline = $baseline;
+    initialValue = resolvePath(row, cell.key);
+    dirty = false;
+    ctx.editableUpdate?.(cellId, { dirty, invalidText });
+  }
+
+  function report(value, markDirty) {
+    if (markDirty) dirty = !Object.is(value, initialValue);
+    invalidText = validate ? validate(value, row) : undefined;
+    ctx.editableUpdate?.(cellId, { dirty, invalidText });
+  }
+
+  // A bound Carbon input writes `row[cell.key]` before this bubbled event
+  // reaches the wrapper, so the row already holds the edited value here.
+  function handleEdit() {
+    const value = resolvePath(row, cell.key);
+    // Re-derive `display` columns and sort keys that read this row,
+    // so the consumer never has to call `refreshRow` by hand.
+    ctx.refreshRow?.(row.id);
+    report(value, true);
+  }
+
+  onMount(() => {
+    initialValue = resolvePath(row, cell.key);
+    mounted = true;
+    ctx.editableRegister?.(cellId);
+    // Seed the validity rollup from the initial value (e.g. a required
+    // field that starts empty should make the table invalid immediately).
+    report(initialValue, false);
+  });
+
+  onDestroy(() => {
+    ctx.editableUnregister?.(cellId);
+  });
+</script>
+
+<!-- svelte-ignore a11y-no-static-element-interactions -->
+<div
+  class:bx--editable-cell={true}
+  class:bx--editable-cell--dirty={dirty}
+  class:bx--editable-cell--invalid={invalid}
+  on:input={handleEdit}
+  on:change={handleEdit}
+  {...$$restProps}
+>
+  <slot {invalid} {invalidText} />
+</div>
+
+<style>
+  .bx--editable-cell {
+    position: relative;
+  }
+
+  /* Compact in-cell inputs: drop the form-item top margin so the row
+     height stays tight when an input is always rendered in the cell. */
+  .bx--editable-cell :global(.bx--form-item) {
+    margin: 0;
+  }
+
+  /* Dirty marker: a subtle accent on the leading edge of the cell. */
+  .bx--editable-cell--dirty::before {
+    content: "";
+    position: absolute;
+    inset-block: 0;
+    inset-inline-start: 0;
+    inline-size: 2px;
+    background-color: var(--cds-interactive-04, #0f62fe);
+  }
+</style>

--- a/src/DataTable/EditableCell.svelte
+++ b/src/DataTable/EditableCell.svelte
@@ -104,7 +104,7 @@
   }
 
   /* Compact in-cell inputs: drop the form-item top margin so the row
-     height stays tight when an input is always rendered in the cell. */
+         height stays tight when an input is always rendered in the cell. */
   .bx--editable-cell :global(.bx--form-item) {
     margin: 0;
   }

--- a/src/DataTable/TableRow.svelte
+++ b/src/DataTable/TableRow.svelte
@@ -1,4 +1,11 @@
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
-<tr {...$$restProps} on:click on:mouseover on:mouseenter on:mouseleave>
+<tr
+  {...$$restProps}
+  on:click
+  on:keydown
+  on:mouseover
+  on:mouseenter
+  on:mouseleave
+>
   <slot />
 </tr>

--- a/src/index.js
+++ b/src/index.js
@@ -38,6 +38,7 @@ export { default as CopyInputSkeleton } from "./CopyInput/CopyInputSkeleton.svel
 export { default as FluidCopyInputSkeleton } from "./CopyInput/FluidCopyInputSkeleton.svelte";
 export { default as DataTable } from "./DataTable/DataTable.svelte";
 export { default as DataTableSkeleton } from "./DataTable/DataTableSkeleton.svelte";
+export { default as EditableCell } from "./DataTable/EditableCell.svelte";
 export { default as Table } from "./DataTable/Table.svelte";
 export { default as TableBody } from "./DataTable/TableBody.svelte";
 export { default as TableCell } from "./DataTable/TableCell.svelte";

--- a/tests/DataTable/DataTableEditableCell.test.svelte
+++ b/tests/DataTable/DataTableEditableCell.test.svelte
@@ -1,0 +1,58 @@
+<script lang="ts">
+  import DataTable from "carbon-components-svelte/DataTable/DataTable.svelte";
+  import EditableCell from "carbon-components-svelte/DataTable/EditableCell.svelte";
+  import NumberInput from "carbon-components-svelte/NumberInput/NumberInput.svelte";
+  import TextInput from "carbon-components-svelte/TextInput/TextInput.svelte";
+
+  type Row = { id: string; name: string; qty: number };
+
+  let table: DataTable;
+
+  export let dirty = false;
+  export let valid = true;
+
+  export let rows: Row[] = [{ id: "a", name: "alpha", qty: 2 }];
+
+  export function resetDirty() {
+    table.resetDirty();
+  }
+
+  // `total` reads `qty` via display(); it goes stale on an in-place edit
+  // unless the cell is re-derived. EditableCell does that automatically.
+  const headers = [
+    { key: "name", value: "Name" },
+    { key: "qty", value: "Qty" },
+    {
+      key: "total",
+      value: "Total",
+      display: (_value: unknown, row: Row) => row.qty * 10,
+    },
+  ];
+
+  const required = (value: string) => (value ? undefined : "Required");
+</script>
+
+<DataTable bind:this={table} {headers} {rows} bind:dirty bind:valid>
+  <svelte:fragment slot="cell" let:row let:cell>
+    {#if cell.key === "name"}
+      <EditableCell {row} {cell} validate={required} let:invalid let:invalidText>
+        <TextInput
+          bind:value={row.name}
+          {invalid}
+          {invalidText}
+          hideLabel
+          labelText="Name"
+        />
+      </EditableCell>
+    {:else if cell.key === "qty"}
+      <EditableCell {row} {cell}>
+        <NumberInput bind:value={row.qty} hideLabel label="Qty" />
+      </EditableCell>
+    {:else}
+      {cell.display ? cell.display(cell.value, row) : cell.value}
+    {/if}
+  </svelte:fragment>
+</DataTable>
+
+<div data-testid="dirty">{dirty}</div>
+<div data-testid="valid">{valid}</div>

--- a/tests/DataTable/DataTableEditableCell.test.svelte
+++ b/tests/DataTable/DataTableEditableCell.test.svelte
@@ -35,7 +35,13 @@
 <DataTable bind:this={table} {headers} {rows} bind:dirty bind:valid>
   <svelte:fragment slot="cell" let:row let:cell>
     {#if cell.key === "name"}
-      <EditableCell {row} {cell} validate={required} let:invalid let:invalidText>
+      <EditableCell
+        {row}
+        {cell}
+        validate={required}
+        let:invalid
+        let:invalidText
+      >
         <TextInput
           bind:value={row.name}
           {invalid}

--- a/tests/DataTable/DataTableEditableCell.test.ts
+++ b/tests/DataTable/DataTableEditableCell.test.ts
@@ -1,0 +1,78 @@
+import { fireEvent, render, screen, within } from "@testing-library/svelte";
+import { tick } from "svelte";
+import DataTableEditableCell from "./DataTableEditableCell.test.svelte";
+
+const dirty = () => screen.getByTestId("dirty").textContent;
+const valid = () => screen.getByTestId("valid").textContent;
+
+function getFirstBodyRow(): HTMLElement {
+  const rows = screen
+    .getAllByRole("row")
+    .filter((r) => r.closest("tbody") !== null);
+  expect(rows.length).toBeGreaterThan(0);
+  return rows[0];
+}
+
+describe("EditableCell", () => {
+  it("starts clean and valid for non-empty initial values", () => {
+    render(DataTableEditableCell);
+    expect(dirty()).toBe("false");
+    expect(valid()).toBe("true");
+  });
+
+  it("marks the table dirty when a cell value changes", async () => {
+    render(DataTableEditableCell);
+    const input = screen.getByLabelText("Name") as HTMLInputElement;
+
+    await fireEvent.input(input, { target: { value: "beta" } });
+    await tick();
+
+    expect(dirty()).toBe("true");
+  });
+
+  it("rolls up validity from the cell's validate function", async () => {
+    render(DataTableEditableCell);
+    const input = screen.getByLabelText("Name") as HTMLInputElement;
+
+    await fireEvent.input(input, { target: { value: "" } });
+    await tick();
+    expect(valid()).toBe("false");
+
+    await fireEvent.input(input, { target: { value: "gamma" } });
+    await tick();
+    expect(valid()).toBe("true");
+  });
+
+  it("clears dirty after resetDirty re-snapshots the baseline", async () => {
+    const { component } = render(DataTableEditableCell);
+    const input = screen.getByLabelText("Name") as HTMLInputElement;
+
+    await fireEvent.input(input, { target: { value: "beta" } });
+    await tick();
+    expect(dirty()).toBe("true");
+
+    component.resetDirty();
+    await tick();
+    expect(dirty()).toBe("false");
+
+    // A further edit (away from the new baseline) marks dirty again.
+    await fireEvent.input(input, { target: { value: "gamma" } });
+    await tick();
+    expect(dirty()).toBe("true");
+  });
+
+  it("re-derives a display column after an edit without a manual refresh", async () => {
+    render(DataTableEditableCell);
+    expect(
+      within(getFirstBodyRow()).queryByRole("cell", { name: "20" }),
+    ).not.toBeNull();
+
+    const qty = screen.getByRole("spinbutton") as HTMLInputElement;
+    await fireEvent.input(qty, { target: { value: "5" } });
+    await tick();
+
+    const row = getFirstBodyRow();
+    expect(within(row).queryByRole("cell", { name: "50" })).not.toBeNull();
+    expect(within(row).queryByRole("cell", { name: "20" })).toBeNull();
+  });
+});

--- a/tests/DataTable/DataTableRowEdit.test.svelte
+++ b/tests/DataTable/DataTableRowEdit.test.svelte
@@ -1,0 +1,69 @@
+<script lang="ts">
+  import DataTable from "carbon-components-svelte/DataTable/DataTable.svelte";
+  import TextInput from "carbon-components-svelte/TextInput/TextInput.svelte";
+
+  type Row = { id: string; name: string };
+
+  export let editingRowId: string | null = null;
+  export let saved: string[] = [];
+  export let discarded: string[] = [];
+
+  export let rows: Row[] = [
+    { id: "a", name: "alpha" },
+    { id: "b", name: "beta" },
+  ];
+
+  const headers = [
+    { key: "name", value: "Name" },
+    { key: "actions", value: "", empty: true },
+  ];
+</script>
+
+<DataTable
+  {headers}
+  {rows}
+  bind:editingRowId
+  on:save={(event) => (saved = [...saved, event.detail.row.name])}
+  on:discard={(event) => (discarded = [...discarded, event.detail.row.name])}
+>
+  <svelte:fragment
+    slot="cell"
+    let:row
+    let:cell
+    let:editing
+    let:edit
+    let:save
+    let:cancel
+  >
+    {#if cell.key === "actions"}
+      {#if editing}
+        <button type="button" data-testid="save-{row.id}" on:click={save}>
+          Save
+        </button>
+        <button type="button" data-testid="cancel-{row.id}" on:click={cancel}>
+          Cancel
+        </button>
+      {:else}
+        <button type="button" data-testid="edit-{row.id}" on:click={edit}>
+          Edit
+        </button>
+      {/if}
+    {:else if editing}
+      <TextInput size="sm" hideLabel labelText="Name" bind:value={row.name} />
+    {:else}
+      {cell.value}
+    {/if}
+  </svelte:fragment>
+</DataTable>
+
+<button
+  type="button"
+  data-testid="program-edit-b"
+  on:click={() => (editingRowId = "b")}
+>
+  Edit b programmatically
+</button>
+
+<div data-testid="editing">{editingRowId ?? ""}</div>
+<div data-testid="saved">{saved.join(",")}</div>
+<div data-testid="discarded">{discarded.join(",")}</div>

--- a/tests/DataTable/DataTableRowEdit.test.ts
+++ b/tests/DataTable/DataTableRowEdit.test.ts
@@ -1,0 +1,110 @@
+import { fireEvent, render, screen, within } from "@testing-library/svelte";
+import { tick } from "svelte";
+import DataTableRowEdit from "./DataTableRowEdit.test.svelte";
+
+const editing = () => screen.getByTestId("editing").textContent;
+const saved = () => screen.getByTestId("saved").textContent;
+const discarded = () => screen.getByTestId("discarded").textContent;
+
+function bodyRow(id: string): HTMLElement {
+  const row = document.querySelector(`[data-row="${id}"]`);
+  expect(row).not.toBeNull();
+  return row as HTMLElement;
+}
+
+describe("DataTable row edit mode", () => {
+  it("enters edit mode for one row, leaving others read-only", async () => {
+    render(DataTableRowEdit);
+    expect(editing()).toBe("");
+
+    await fireEvent.click(screen.getByTestId("edit-a"));
+    await tick();
+
+    expect(editing()).toBe("a");
+    // Row a shows an input; row b stays as static text.
+    expect(within(bodyRow("a")).getByLabelText("Name")).toBeInTheDocument();
+    expect(within(bodyRow("b")).queryByLabelText("Name")).toBeNull();
+    expect(
+      within(bodyRow("b")).queryByRole("cell", { name: "beta" }),
+    ).not.toBeNull();
+  });
+
+  it("commits the edit and dispatches save", async () => {
+    render(DataTableRowEdit);
+    await fireEvent.click(screen.getByTestId("edit-a"));
+    await tick();
+
+    const input = within(bodyRow("a")).getByLabelText(
+      "Name",
+    ) as HTMLInputElement;
+    await fireEvent.input(input, { target: { value: "ALPHA" } });
+    await fireEvent.click(screen.getByTestId("save-a"));
+    await tick();
+
+    expect(editing()).toBe("");
+    expect(saved()).toBe("ALPHA");
+    expect(
+      within(bodyRow("a")).queryByRole("cell", { name: "ALPHA" }),
+    ).not.toBeNull();
+  });
+
+  it("restores the snapshot on cancel and dispatches discard", async () => {
+    render(DataTableRowEdit);
+    await fireEvent.click(screen.getByTestId("edit-a"));
+    await tick();
+
+    const input = within(bodyRow("a")).getByLabelText(
+      "Name",
+    ) as HTMLInputElement;
+    await fireEvent.input(input, { target: { value: "zzz" } });
+    await fireEvent.click(screen.getByTestId("cancel-a"));
+    await tick();
+
+    expect(editing()).toBe("");
+    expect(discarded()).toBe("alpha");
+    // Reverted to the pre-edit value.
+    expect(
+      within(bodyRow("a")).queryByRole("cell", { name: "alpha" }),
+    ).not.toBeNull();
+    expect(
+      within(bodyRow("a")).queryByRole("cell", { name: "zzz" }),
+    ).toBeNull();
+  });
+
+  it("commits on Enter and cancels on Escape", async () => {
+    render(DataTableRowEdit);
+
+    // Enter commits.
+    await fireEvent.click(screen.getByTestId("edit-a"));
+    await tick();
+    let input = within(bodyRow("a")).getByLabelText("Name") as HTMLInputElement;
+    await fireEvent.input(input, { target: { value: "ENTERED" } });
+    await fireEvent.keyDown(input, { key: "Enter" });
+    await tick();
+    expect(editing()).toBe("");
+    expect(saved()).toBe("ENTERED");
+
+    // Escape cancels.
+    await fireEvent.click(screen.getByTestId("edit-b"));
+    await tick();
+    input = within(bodyRow("b")).getByLabelText("Name") as HTMLInputElement;
+    await fireEvent.input(input, { target: { value: "nope" } });
+    await fireEvent.keyDown(input, { key: "Escape" });
+    await tick();
+    expect(editing()).toBe("");
+    expect(discarded()).toBe("beta");
+    expect(
+      within(bodyRow("b")).queryByRole("cell", { name: "beta" }),
+    ).not.toBeNull();
+  });
+
+  it("enters edit mode when editingRowId is set programmatically", async () => {
+    render(DataTableRowEdit);
+
+    await fireEvent.click(screen.getByTestId("program-edit-b"));
+    await tick();
+
+    expect(editing()).toBe("b");
+    expect(within(bodyRow("b")).getByLabelText("Name")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Follow-up to #3320

Closes https://github.com/carbon-design-system/carbon-components-svelte/issues/574

This explores adding first class support for an editable `DataTable` experience, while prioritizing performance, DX etc..

- Composable `EditableCell` wires the accessors
- Consumer can bind to dirty/valid given a custom validate function

TODO:

- Need to broaden design scenarios, e.g., combo input + buttons