### PR TITLE
fix(tabs): user-provided `href` should navigate

### DIFF
--- a/docs/src/pages/components/Tabs.svx
+++ b/docs/src/pages/components/Tabs.svx
@@ -70,6 +70,29 @@ If the current selected tab is removed, the next tab is selected.
 
 <FileSource src="/framed/Tabs/TabsConditional" />
 
+## Navigation
+
+By default, a `Tab` uses `"#"` as a placeholder `href` and behaves purely as an in-page selection control. Provide a real `href` to make the tab act like a link: activating it by mouse or keyboard navigates to the URL (in addition to selecting the tab). This is useful for routing each tab to a separate page.
+
+The tabs below link to other component pages, so selecting one navigates there.
+
+<Tabs>
+  <Tab label="Accordion" href="/components/Accordion" />
+  <Tab label="Breadcrumb" href="/components/Breadcrumb" />
+  <Tab label="Button" href="/components/Button" />
+  <svelte:fragment slot="content">
+    <TabContent>Accordion content</TabContent>
+    <TabContent>Breadcrumb content</TabContent>
+    <TabContent>Button content</TabContent>
+  </svelte:fragment>
+</Tabs>
+
+## Navigation (intercept default)
+
+In a single-page app, you typically intercept the navigation to route on the client instead of triggering a full page load. Listen to the forwarded `click` event, call `event.preventDefault()`, and hand the URL to your router. The example below logs the route to the console instead of navigating.
+
+<FileSource src="/framed/Tabs/TabsNavigation" />
+
 ## Disabled tabs
 
 Set `disabled` to `true` on a tab component to prevent interaction. Keyboard navigation will skip disabled tabs.

--- a/docs/src/pages/framed/Tabs/TabsNavigation.svelte
+++ b/docs/src/pages/framed/Tabs/TabsNavigation.svelte
@@ -1,0 +1,29 @@
+<script>
+  import { Tab, TabContent, Tabs } from "carbon-components-svelte";
+
+  const routes = [
+    { label: "Accordion", href: "/components/Accordion" },
+    { label: "Breadcrumb", href: "/components/Breadcrumb" },
+    { label: "Button", href: "/components/Button" },
+  ];
+
+  function interceptNavigation(e, href) {
+    e.preventDefault();
+    console.log("Navigate to:", href);
+  }
+</script>
+
+<Tabs>
+  {#each routes as route}
+    <Tab
+      label={route.label}
+      href={route.href}
+      on:click={(e) => interceptNavigation(e, route.href)}
+    />
+  {/each}
+  <svelte:fragment slot="content">
+    {#each routes as route}
+      <TabContent>{route.label} content</TabContent>
+    {/each}
+  </svelte:fragment>
+</Tabs>

--- a/src/Tabs/Tab.svelte
+++ b/src/Tabs/Tab.svelte
@@ -84,6 +84,9 @@
   });
 
   $: selected = $selectedTab === id;
+  // Default href is the "#" placeholder, so tabs behave as selection controls.
+  // Any other href is user-provided and should navigate like a link.
+  $: isLink = !!href && href !== "#";
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
@@ -94,11 +97,14 @@
   class:bx--tabs__nav-item--disabled={disabled}
   class:bx--tabs__nav-item--selected={selected}
   {...$$restProps}
-  on:click|preventDefault
-  on:click|preventDefault={() => {
-    if (!disabled) {
-      update(id);
+  on:click
+  on:click={(event) => {
+    if (disabled) {
+      event.preventDefault();
+      return;
     }
+    if (!isLink) event.preventDefault();
+    update(id);
   }}
   on:mouseover
   on:mouseenter
@@ -108,7 +114,11 @@
 
     if ($useDismissible && event.key === "Delete") {
       dismiss(id);
-    } else if (event.key === " " || event.key === "Enter") {
+    } else if (event.key === " ") {
+      event.preventDefault();
+      update(id);
+    } else if (event.key === "Enter") {
+      if (!isLink) event.preventDefault();
       update(id);
     }
   }}

--- a/tests/Tabs/Tabs.test.ts
+++ b/tests/Tabs/Tabs.test.ts
@@ -1,4 +1,4 @@
-import { render, screen, within } from "@testing-library/svelte";
+import { fireEvent, render, screen, within } from "@testing-library/svelte";
 import type TabComponent from "carbon-components-svelte/Tabs/Tab.svelte";
 import type { ComponentProps } from "svelte";
 import Calendar from "../../src/icons/Calendar.svelte";
@@ -363,6 +363,30 @@ describe("Tab", () => {
 
     const tab = screen.getByRole("tab");
     expect(tab).toHaveAttribute("href", "/custom");
+  });
+
+  // A user-provided href should navigate like a link: activation must not be
+  // preventDefault-ed (regression for #2165). fireEvent returns false when a
+  // handler canceled the event.
+  it("should not prevent default activation when a real href is provided", async () => {
+    render(Tab, { props: { href: "#custom" } });
+
+    const tab = screen.getByRole("tab");
+    expect(await fireEvent.click(tab)).toBe(true);
+    expect(await fireEvent.keyDown(tab, { key: "Enter" })).toBe(true);
+    // selection still happens alongside navigation
+    expect(tab).toHaveAttribute("aria-selected", "true");
+  });
+
+  // The default "#" href is a placeholder: tabs act as selection controls, so
+  // navigation must be suppressed (including Enter, the original concern).
+  it("should prevent default activation for the placeholder href", async () => {
+    render(Tab, { props: { href: "#" } });
+
+    const tab = screen.getByRole("tab");
+    expect(await fireEvent.click(tab)).toBe(false);
+    expect(await fireEvent.keyDown(tab, { key: "Enter" })).toBe(false);
+    expect(tab).toHaveAttribute("aria-selected", "true");
   });
 
   it("should handle disabled state", () => {


### PR DESCRIPTION
Fixes #2165

Tabs unconditionally called `preventDefault` on activation, so a user-provided `href` never navigated. Now only the default `"#"` placeholder is treated as selection-only; any other `href` navigates on click or keyboard (Enter), in addition to selecting the tab. Disabled tabs still suppress navigation.

Adds two docs examples (real navigation, and intercepting to route on the client) plus regression tests.

Again linking #3325 (it shouldn't affect it, just be retained for mobile).