### PR TITLE
fix(overflow-menu): prevent scroll jump when opening portalled menu

### DIFF
--- a/src/OverflowMenu/OverflowMenu.svelte
+++ b/src/OverflowMenu/OverflowMenu.svelte
@@ -206,7 +206,7 @@
       buttonWidth = width;
 
       if (!onMountAfterUpdate && $currentIndex < 0) {
-        menuRef?.focus();
+        menuRef?.focus({ preventScroll: true });
       }
 
       if (!effectivePortalMenu) {
@@ -324,7 +324,7 @@
         );
         if (shouldContinue) {
           open = false;
-          buttonRef.focus();
+          buttonRef.focus({ preventScroll: true });
         }
       }
     }
@@ -372,7 +372,7 @@
         );
         if (shouldContinue) {
           open = false;
-          buttonRef.focus();
+          buttonRef.focus({ preventScroll: true });
         }
       }
     }}
@@ -419,7 +419,7 @@
           );
           if (shouldContinue) {
             open = false;
-            buttonRef.focus();
+            buttonRef.focus({ preventScroll: true });
           }
         }
       }}

--- a/src/OverflowMenu/OverflowMenuItem.svelte
+++ b/src/OverflowMenu/OverflowMenuItem.svelte
@@ -110,7 +110,7 @@
 
   afterUpdate(() => {
     if (ref && focused) {
-      ref.focus();
+      ref.focus({ preventScroll: true });
     }
   });
 

--- a/tests/OverflowMenu/OverflowMenu.test.ts
+++ b/tests/OverflowMenu/OverflowMenu.test.ts
@@ -754,6 +754,30 @@ describe("OverflowMenu", () => {
       expect(menuButton).toHaveFocus();
     });
 
+    it("focuses items and trigger with preventScroll so the page does not jump", async () => {
+      // Regression: a portalled menu briefly sits at (0,0) before
+      // FloatingPortal positions it. Focusing without `preventScroll`
+      // scrolls that initial position into view, jumping the page to top.
+      const focusSpy = vi.spyOn(HTMLElement.prototype, "focus");
+      render(OverflowMenu, { props: { portalMenu: true } });
+
+      const menuButton = screen.getByRole("button");
+      await user.click(menuButton);
+
+      // First item is focused programmatically on open.
+      const menuItems = screen.getAllByRole("menuitem");
+      expect(menuItems[0]).toHaveFocus();
+      expect(focusSpy).toHaveBeenCalledWith({ preventScroll: true });
+
+      // Escape returns focus to the trigger, also without scrolling.
+      focusSpy.mockClear();
+      await user.keyboard("{Escape}");
+      expect(menuButton).toHaveFocus();
+      expect(focusSpy).toHaveBeenCalledWith({ preventScroll: true });
+
+      focusSpy.mockRestore();
+    });
+
     it("should reflect auto-flipped direction in data-floating-menu-direction", async () => {
       // Mock getBoundingClientRect to simulate anchor near top of viewport
       // so that direction="top" will auto-flip to "bottom".


### PR DESCRIPTION
Opening an OverflowMenu with `portalMenu` jumped the page to the top because the menu briefly renders at (0,0) before `FloatingPortal` positions it, and focusing it scrolled that initial position into view. This passes `preventScroll: true` to all programmatic focus calls (menu, items, and Escape return-focus) so the scroll position stays put. Adds a regression test asserting `preventScroll` is used on open and on Escape.