### PR TITLE
feat(ui-shell): `HeaderNavItem` supports icon

### DIFF
--- a/css/_ui-shell.scss
+++ b/css/_ui-shell.scss
@@ -200,6 +200,24 @@
     fill: $icon-secondary;
   }
 
+  // First-class icon support: render an icon after the nav item text.
+  // Gap matches Carbon's label-to-trailing-icon convention ($spacing-03 / 8px),
+  // as used by .bx--header__menu-arrow (mini-units(1)) and .bx--link__icon.
+  a.#{$prefix}--header__menu-item.#{$prefix}--header__menu-item--icon {
+    display: flex;
+    align-items: center;
+    gap: $spacing-03;
+  }
+
+  a.#{$prefix}--header__menu-item.#{$prefix}--header__menu-item--icon > svg,
+  a.#{$prefix}--header__menu-item.#{$prefix}--header__menu-item--icon:hover > svg,
+  a.#{$prefix}--header__menu-item.#{$prefix}--header__menu-item--icon:active > svg,
+  a.#{$prefix}--header__menu-item.#{$prefix}--header__menu-item--icon:focus > svg {
+    flex-shrink: 0;
+    // Track the text color across default/hover/active/focus states.
+    fill: currentColor;
+  }
+
   /** Vertical rule between product name and header nav (Carbon v10 used fixed #393939) */
   .#{$prefix}--header__nav.#{$prefix}--header__nav::before {
     background-color: $border-subtle;
@@ -730,6 +748,8 @@
     left: 1rem; // convert.to-rem(16px)
   }
 
+  // In the side nav, the icon is right-justified to the row's trailing edge by
+  // the space-between rule below, mirroring the HeaderNavMenu expand chevron.
   .#{$prefix}--side-nav.#{$prefix}--side-nav
     a.#{$prefix}--header__menu-item.#{$prefix}--header__menu-item {
     justify-content: space-between;

--- a/docs/src/pages/_module.svelte
+++ b/docs/src/pages/_module.svelte
@@ -177,19 +177,14 @@
         href="https://github.com/carbon-design-system/carbon-icons-svelte"
         target="_blank"
         text="Icons"
-      >
-        <Stack orientation="horizontal" gap={2} align="center">
-          Icons <Launch />
-        </Stack>
-      </HeaderNavItem>
+        icon={Launch}
+      />
       <HeaderNavItem
         href="https://github.com/carbon-design-system/carbon-pictograms-svelte"
         target="_blank"
-      >
-        <Stack orientation="horizontal" gap={2} align="center">
-          Pictograms <Launch />
-        </Stack>
-      </HeaderNavItem>
+        text="Pictograms"
+        icon={Launch}
+      />
     </HeaderNav>
     <HeaderUtilities>
       <HeaderSearch

--- a/docs/src/pages/components/UIShell.svx
+++ b/docs/src/pages/components/UIShell.svx
@@ -28,6 +28,14 @@ Create a basic header with the header component. Open these examples in a new ta
 
 <FileSource src="/framed/UIShell/Header" />
 
+### External links
+
+Set the `icon` prop on `HeaderNavItem` to add a trailing icon after the text. For external links that open in a new tab, set `target="_blank"` and an external `href`. Use `Launch` from [carbon-icons-svelte](https://github.com/carbon-design-system/carbon-icons-svelte). The icon is decorative and inherits the link color on hover, focus, and active.
+
+Duplicate those items in `HeaderSideNavItems` so the links stay in the side nav below the large breakpoint.
+
+<FileSource src="/framed/UIShell/HeaderNavExternalLinks" />
+
 ## Side navigation
 
 Pair the header with a `SideNav`. It collapses behind a hamburger menu by default and also supports responsive, fixed, and rail layouts.

--- a/docs/src/pages/framed/UIShell/HeaderNavExternalLinks.svelte
+++ b/docs/src/pages/framed/UIShell/HeaderNavExternalLinks.svelte
@@ -1,0 +1,70 @@
+<script>
+  import {
+    Column,
+    Content,
+    Grid,
+    Header,
+    HeaderNav,
+    HeaderNavItem,
+    HeaderSideNavItems,
+    Row,
+    SideNav,
+    SideNavItems,
+    SideNavLink,
+    SkipToContent,
+  } from "carbon-components-svelte";
+  import Launch from "carbon-icons-svelte/lib/Launch.svelte";
+
+  let isSideNavOpen = false;
+</script>
+
+<Header companyName="IBM" platformName="Cloud" bind:isSideNavOpen>
+  <svelte:fragment slot="skipToContent"> <SkipToContent /> </svelte:fragment>
+  <HeaderNav>
+    <HeaderNavItem href="/catalog" text="Catalog" />
+    <HeaderNavItem href="/resources" text="Resource list" />
+    <HeaderNavItem
+      href="https://cloud.ibm.com/docs"
+      target="_blank"
+      text="Docs"
+      icon={Launch}
+    />
+    <HeaderNavItem
+      href="https://cloud.ibm.com/status"
+      target="_blank"
+      text="Status"
+      icon={Launch}
+    />
+  </HeaderNav>
+</Header>
+
+<SideNav bind:isOpen={isSideNavOpen}>
+  <SideNavItems>
+    <HeaderSideNavItems hasDivider>
+      <HeaderNavItem href="/catalog" text="Catalog" />
+      <HeaderNavItem href="/resources" text="Resource list" />
+      <HeaderNavItem
+        href="https://cloud.ibm.com/docs"
+        target="_blank"
+        text="Docs"
+        icon={Launch}
+      />
+      <HeaderNavItem
+        href="https://cloud.ibm.com/status"
+        target="_blank"
+        text="Status"
+        icon={Launch}
+      />
+    </HeaderSideNavItems>
+    <SideNavLink href="/dashboard" text="Dashboard" isSelected />
+    <SideNavLink href="/activity" text="Activity tracker" />
+  </SideNavItems>
+</SideNav>
+
+<Content>
+  <Grid>
+    <Row>
+      <Column> <h1>Dashboard</h1> </Column>
+    </Row>
+  </Grid>
+</Content>

--- a/src/UIShell/HeaderNavItem.svelte
+++ b/src/UIShell/HeaderNavItem.svelte
@@ -1,5 +1,9 @@
 <script>
   /**
+   * @template [Icon=any]
+   */
+
+  /**
    * Specify the `href` attribute.
    * @type {string}
    */
@@ -10,6 +14,13 @@
    * @type {string}
    */
   export let text = undefined;
+
+  /**
+   * Specify an icon to render after the text.
+   * Alternatively, use the "icon" slot.
+   * @type {Icon}
+   */
+  export let icon = /** @type {Icon} */ (undefined);
 
   /** Set to `true` to select the item */
   export let isSelected = false;
@@ -61,6 +72,7 @@
     {href}
     rel={$$restProps.target === "_blank" ? "noopener noreferrer" : undefined}
     class:bx--header__menu-item={true}
+    class:bx--header__menu-item--icon={icon || $$slots.icon}
     aria-current={isSelected ? "page" : undefined}
     {...$$restProps}
     on:click
@@ -110,5 +122,10 @@
     }}
   >
     <span class:bx--text-truncate--end={true}><slot>{text}</slot></span>
+    {#if icon || $$slots.icon}
+      <slot name="icon">
+        <svelte:component this={icon} size={16} />
+      </slot>
+    {/if}
   </a>
 </li>

--- a/tests/UIShell/HeaderNavItemIcon.test.svelte
+++ b/tests/UIShell/HeaderNavItemIcon.test.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+  import Header from "carbon-components-svelte/UIShell/Header.svelte";
+  import HeaderNav from "carbon-components-svelte/UIShell/HeaderNav.svelte";
+  import HeaderNavItem from "carbon-components-svelte/UIShell/HeaderNavItem.svelte";
+  import Launch from "carbon-icons-svelte/lib/Launch.svelte";
+</script>
+
+<Header companyName="Test" platformName="Test">
+  <HeaderNav>
+    <HeaderNavItem href="/catalog" text="Catalog" />
+    <HeaderNavItem
+      href="https://example.com/docs"
+      target="_blank"
+      text="Docs"
+      icon={Launch}
+    />
+    <HeaderNavItem
+      href="https://example.com/status"
+      target="_blank"
+      text="Status"
+    >
+      <span slot="icon" data-testid="slot-icon" aria-hidden="true">↗</span>
+    </HeaderNavItem>
+  </HeaderNav>
+</Header>

--- a/tests/UIShell/HeaderNavItemIcon.test.ts
+++ b/tests/UIShell/HeaderNavItemIcon.test.ts
@@ -1,0 +1,34 @@
+import { render, screen } from "@testing-library/svelte";
+import Fixture from "./HeaderNavItemIcon.test.svelte";
+
+describe("HeaderNavItem icon", () => {
+  it("renders the icon prop after the text with the icon marker class", () => {
+    render(Fixture);
+
+    const docs = screen.getByRole("menuitem", { name: "Docs" });
+    expect(docs).toHaveClass("bx--header__menu-item--icon");
+
+    const icon = docs.querySelector("svg");
+    expect(icon).toBeInTheDocument();
+    // Carbon icons are decorative by default; the label provides the name.
+    expect(icon).toHaveAttribute("aria-hidden", "true");
+    // The icon is the last child so it trails the text.
+    expect(docs.lastElementChild).toBe(icon);
+  });
+
+  it("omits the icon marker class when no icon is provided", () => {
+    render(Fixture);
+
+    const catalog = screen.getByRole("menuitem", { name: "Catalog" });
+    expect(catalog).not.toHaveClass("bx--header__menu-item--icon");
+    expect(catalog.querySelector("svg")).toBeNull();
+  });
+
+  it("supports a custom icon slot", () => {
+    render(Fixture);
+
+    const status = screen.getByRole("menuitem", { name: /Status/ });
+    expect(status).toHaveClass("bx--header__menu-item--icon");
+    expect(screen.getByTestId("slot-icon")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Adds a first-class `icon` prop and `icon` slot to `HeaderNavItem`, bringing it in line with `HeaderActionLink`, `SideNavLink`, and `SideNavMenu`. The icon renders after the label with an 8px gap (`$spacing-03`) on desktop, matching Carbon's menu-arrow and link-icon spacing, and right-justifies in the side nav to mirror the `HeaderNavMenu` chevron. Includes a UIShell docs example for external links and unit tests.