### PR TITLE
fix(tree-view): dispatch select/toggle/focus with correct state

### DIFF
--- a/docs/src/pages/components/TreeView.svx
+++ b/docs/src/pages/components/TreeView.svx
@@ -75,6 +75,12 @@ Use a `contenteditable` element in each tree view node to enable inline editing 
 
 <FileSource src="/framed/TreeView/TreeViewInlineEditing" />
 
+## Events
+
+Listen for node selection, expansion, and focus with `on:select`, `on:toggle`, and `on:focus`. Each `event.detail` is the affected node after the interaction, with the same expanded, selected, and leaf fields as the slot node (see [Custom (slot)](#custom-slot)). A select reports the node as selected; a toggle that expands a branch reports it as expanded.
+
+<FileSource src="/framed/TreeView/TreeViewEvents" />
+
 ## Multi-select
 
 Set `multiselect` to allow more than one selected row; `multiselectMode` controls the unit each gesture applies to.

--- a/docs/src/pages/framed/TreeView/TreeViewEvents.svelte
+++ b/docs/src/pages/framed/TreeView/TreeViewEvents.svelte
@@ -1,0 +1,59 @@
+<script>
+  import { Stack, TreeView } from "carbon-components-svelte";
+
+  let lastEvent = null;
+  let nodes = [
+    { id: 0, text: "AI / Machine learning" },
+    {
+      id: 1,
+      text: "Analytics",
+      nodes: [
+        {
+          id: 2,
+          text: "IBM Analytics Engine",
+          nodes: [
+            { id: 3, text: "Apache Spark" },
+            { id: 4, text: "Hadoop" },
+          ],
+        },
+        { id: 5, text: "IBM Cloud SQL Query" },
+        { id: 6, text: "IBM Db2 Warehouse on Cloud" },
+      ],
+    },
+    {
+      id: 7,
+      text: "Blockchain",
+      nodes: [{ id: 8, text: "IBM Blockchain Platform" }],
+    },
+  ];
+
+  function logEvent(type, detail) {
+    lastEvent = {
+      type,
+      id: detail.id,
+      text: detail.text,
+      expanded: detail.expanded,
+      selected: detail.selected,
+    };
+  }
+</script>
+
+<Stack gap={6}>
+  <div>
+    <TreeView
+      labelText="Cloud Products"
+      {nodes}
+      on:select={({ detail }) => logEvent("select", detail)}
+      on:toggle={({ detail }) => logEvent("toggle", detail)}
+      on:focus={({ detail }) => logEvent("focus", detail)}
+    />
+  </div>
+  {#if lastEvent}
+    <Stack gap={4}>
+      <div>Last event: {lastEvent.type}</div>
+      <div>Node: {lastEvent.text} (id: {lastEvent.id})</div>
+      <div>detail.expanded: {lastEvent.expanded}</div>
+      <div>detail.selected: {lastEvent.selected}</div>
+    </Stack>
+  {/if}
+</Stack>

--- a/src/TreeView/TreeView.svelte
+++ b/src/TreeView/TreeView.svelte
@@ -524,6 +524,21 @@
     return true;
   }
 
+  /**
+   * Re-derive the `expanded`/`selected` flags from the source-of-truth state
+   * at dispatch time. The `node` object passed by the child components is
+   * computed reactively, so its flags still reflect the pre-action state when a
+   * handler mutates `selectedIds`/`expandedIds` and then dispatches synchronously.
+   * @type {(node: Node) => Node & { expanded: boolean; selected: boolean }}
+   */
+  function withLiveState(node) {
+    return {
+      ...node,
+      expanded: expandedIdsSet.has(node.id),
+      selected: selectedIds.includes(node.id),
+    };
+  }
+
   /** @type {(node: Node, event?: Event) => void} */
   function clickNode(node, event) {
     activeId = node.id;
@@ -588,7 +603,7 @@
       selectedIds = [node.id];
     }
 
-    dispatch("select", node);
+    dispatch("select", withLiveState(node));
   }
 
   /** @type {(node: Node) => void} */
@@ -623,12 +638,12 @@
 
   /** @type {(node: Node) => void} */
   function focusNode(node) {
-    dispatch("focus", node);
+    dispatch("focus", withLiveState(node));
   }
 
   /** @type {(node: Node) => void} */
   function toggleNode(node) {
-    dispatch("toggle", node);
+    dispatch("toggle", withLiveState(node));
   }
 
   setContext("carbon:TreeView", {

--- a/tests/TreeView/TreeView.test.ts
+++ b/tests/TreeView/TreeView.test.ts
@@ -91,7 +91,8 @@ describe.each(testCases)("$name", ({ component }) => {
       icon: expect.anything(),
       id: 0,
       leaf: true,
-      selected: false,
+      // The `select` payload reflects the post-click state: the node is now selected.
+      selected: true,
       text: "AI / Machine learning",
     });
   });
@@ -194,16 +195,34 @@ describe.each(testCases)("$name", ({ component }) => {
     expect(toggleButton).toBeInTheDocument();
 
     expect.assert(toggleButton instanceof HTMLElement);
+
+    const lastToggleDetail = () =>
+      consoleLog.mock.calls.filter((call) => call[0] === "toggle").at(-1)?.[1];
+
     await user.click(toggleButton);
 
-    expect(consoleLog).toHaveBeenCalledWith(
-      "toggle",
+    // Expanding reports the post-toggle state: `expanded: true`.
+    expect(lastToggleDetail()).toEqual(
       expect.objectContaining({
         id: 1,
         text: "Analytics",
         leaf: false,
+        expanded: true,
       }),
     );
+    expect(analyticsNode).toHaveAttribute("aria-expanded", "true");
+
+    // Collapsing reports `expanded: false`.
+    await user.click(toggleButton);
+    expect(lastToggleDetail()).toEqual(
+      expect.objectContaining({
+        id: 1,
+        text: "Analytics",
+        leaf: false,
+        expanded: false,
+      }),
+    );
+    expect(analyticsNode).toHaveAttribute("aria-expanded", "false");
   });
 
   it("dispatches focus event when node receives focus", () => {
@@ -610,6 +629,35 @@ describe("TreeView Props", () => {
 
     expect(aiItem).toHaveAttribute("aria-selected", "true");
     expect(blockchainItem).toHaveAttribute("aria-selected", "false");
+  });
+
+  it("select payload reports the post-click selected state when toggling in multiselect", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+
+    render(TreeViewMultiselect, {
+      multiselect: true,
+      selectedIds: [],
+    });
+
+    const blockchainItem = treeItemById(7);
+
+    // Ctrl+click to select: payload reports `selected: true`.
+    await user.keyboard("{Control>}");
+    await user.click(blockchainItem);
+    await user.keyboard("{/Control}");
+    expect(consoleLog).toHaveBeenLastCalledWith(
+      "select",
+      expect.objectContaining({ id: 7, selected: true }),
+    );
+
+    // Ctrl+click again to deselect: payload reports `selected: false`.
+    await user.keyboard("{Control>}");
+    await user.click(blockchainItem);
+    await user.keyboard("{/Control}");
+    expect(consoleLog).toHaveBeenLastCalledWith(
+      "select",
+      expect.objectContaining({ id: 7, selected: false }),
+    );
   });
 
   it("plain click replaces selection in multiselect mode", async () => {


### PR DESCRIPTION
The `select`/`toggle`/`focus` detail re-used the child's reactively
computed `node`, whose `expanded`/`selected` flags only update on
the next tick, so handlers that mutate then dispatch leaked pre-action
state. Re-derive both flags from the source sets at dispatch time.

Added an example that illustrates this (without the fix).

