### PR TITLE
feat(code-snippet): add mask gradient for single/multi-line variants

### DIFF
--- a/css/_code-snippet.scss
+++ b/css/_code-snippet.scss
@@ -1,0 +1,36 @@
+@import "carbon-components/scss/globals/scss/vars";
+
+/// Edge fade for code snippets (Carbon React v11 parity). v10 uses
+/// `--overflow-indicator` gradient elements that this library's markup does not
+/// render. v11 masks the scroll container instead, which is background-agnostic
+/// and works across themes, the light variant, and skeleton state.
+/// @access private
+/// @group components
+@mixin code-snippet-fade {
+  .#{$prefix}--snippet--single .#{$prefix}--snippet-container {
+    mask-image: linear-gradient(
+      90deg,
+      $black-100 calc(100% - #{$carbon--spacing-07}),
+      transparent 100%
+    );
+  }
+
+  // Expanded multi-line adds padding-bottom: $spacing-05, so the bottom fade
+  // offset matches that padding when content no longer scrolls.
+  .#{$prefix}--snippet--multi .#{$prefix}--snippet-container {
+    mask-image: linear-gradient(
+        90deg,
+        $black-100 calc(100% - #{$carbon--spacing-07}),
+        transparent 100%
+      ),
+      linear-gradient(
+        $black-100 calc(100% - #{$spacing-05}),
+        transparent 100%
+      );
+    mask-composite: intersect;
+  }
+}
+
+@include exports("code-snippet-fade") {
+  @include code-snippet-fade;
+}

--- a/css/all.scss
+++ b/css/all.scss
@@ -126,3 +126,4 @@ $css--plex: true;
 @import "./box";
 @import "./content-switcher-low-contrast";
 @import "./modal-full-width";
+@import "./code-snippet";

--- a/css/g10.scss
+++ b/css/g10.scss
@@ -86,3 +86,4 @@ $css--plex: true;
 @import "./box";
 @import "./content-switcher-low-contrast";
 @import "./modal-full-width";
+@import "./code-snippet";

--- a/css/g100.scss
+++ b/css/g100.scss
@@ -86,3 +86,4 @@ $css--plex: true;
 @import "./box";
 @import "./content-switcher-low-contrast";
 @import "./modal-full-width";
+@import "./code-snippet";

--- a/css/g80.scss
+++ b/css/g80.scss
@@ -86,3 +86,4 @@ $css--plex: true;
 @import "./box";
 @import "./content-switcher-low-contrast";
 @import "./modal-full-width";
+@import "./code-snippet";

--- a/css/g90.scss
+++ b/css/g90.scss
@@ -86,3 +86,4 @@ $css--plex: true;
 @import "./box";
 @import "./content-switcher-low-contrast";
 @import "./modal-full-width";
+@import "./code-snippet";

--- a/css/white.scss
+++ b/css/white.scss
@@ -86,3 +86,4 @@ $css--plex: true;
 @import "./box";
 @import "./content-switcher-low-contrast";
 @import "./modal-full-width";
+@import "./code-snippet";


### PR DESCRIPTION
Upstream v11 parity: add a subtle gradient for single/multi-line code snippets.

<img width="499" height="306" alt="Screenshot 2026-06-15 at 6 04 41 PM" src="https://github.com/user-attachments/assets/9d2715ad-62bf-453a-90c2-6e0262c2bd89" />
