### PR TITLE
feat(tree-view): add `toggle:change` aggregate expansion event

### DIFF
--- a/docs/src/pages/components/TreeView.svx
+++ b/docs/src/pages/components/TreeView.svx
@@ -77,7 +77,9 @@ Use a `contenteditable` element in each tree view node to enable inline editing 
 
 ## Events
 
-Listen for node selection, expansion, and focus with `on:select`, `on:toggle`, and `on:focus`. Each `event.detail` is the affected node after the interaction, with the same expanded, selected, and leaf fields as the slot node (see [Custom (slot)](#custom-slot)). A select reports the node as selected; a toggle that expands a branch reports it as expanded.
+Listen for node selection, expansion, and focus with `on:select`, `on:toggle`, and `on:focus`. Each `event.detail` is the affected node after the interaction, with the same expanded, selected, and leaf fields as the slot node (see [Custom (slot)](#custom-slot)). A select reports the node as selected; a toggle that expands a branch reports it as expanded. These per-node events fire only for direct user gestures.
+
+To track expansion from any source, listen for `on:toggle:change`. It fires once for every expansion change, whether it comes from a user gesture, a programmatic method (`expandAll`, `collapseAll`, `expandNodes`, `collapseNodes`, `showNode`, `autoCollapse`), or an external `bind:expandedIds` update. The event detail carries the full new `expandedIds` set plus the delta since the previous event: `added` lists ids newly expanded and `removed` lists ids newly collapsed. Bulk operations like `expandAll` emit a single event.
 
 <FileSource src="/framed/TreeView/TreeViewEvents" />
 

--- a/docs/src/pages/framed/TreeView/TreeViewEvents.svelte
+++ b/docs/src/pages/framed/TreeView/TreeViewEvents.svelte
@@ -1,7 +1,9 @@
 <script>
-  import { Stack, TreeView } from "carbon-components-svelte";
+  import { Button, Stack, TreeView } from "carbon-components-svelte";
 
+  let treeview = null;
   let lastEvent = null;
+  let lastToggleChange = null;
   let nodes = [
     { id: 0, text: "AI / Machine learning" },
     {
@@ -40,20 +42,36 @@
 
 <Stack gap={6}>
   <div>
+    <Button on:click={() => treeview?.expandAll()}>Expand all</Button>
+    <Button kind="secondary" on:click={() => treeview?.collapseAll()}>
+      Collapse all
+    </Button>
+  </div>
+  <div>
     <TreeView
+      bind:this={treeview}
       labelText="Cloud Products"
       {nodes}
       on:select={({ detail }) => logEvent("select", detail)}
       on:toggle={({ detail }) => logEvent("toggle", detail)}
       on:focus={({ detail }) => logEvent("focus", detail)}
+      on:toggle:change={({ detail }) => (lastToggleChange = detail)}
     />
   </div>
   {#if lastEvent}
     <Stack gap={4}>
-      <div>Last event: {lastEvent.type}</div>
+      <div>Last node event: {lastEvent.type}</div>
       <div>Node: {lastEvent.text} (id: {lastEvent.id})</div>
       <div>detail.expanded: {lastEvent.expanded}</div>
       <div>detail.selected: {lastEvent.selected}</div>
+    </Stack>
+  {/if}
+  {#if lastToggleChange}
+    <Stack gap={4}>
+      <div>Last toggle:change</div>
+      <div>expandedIds: {JSON.stringify(lastToggleChange.expandedIds)}</div>
+      <div>added: {JSON.stringify(lastToggleChange.added)}</div>
+      <div>removed: {JSON.stringify(lastToggleChange.removed)}</div>
     </Stack>
   {/if}
 </Stack>

--- a/src/TreeView/TreeView.svelte
+++ b/src/TreeView/TreeView.svelte
@@ -192,11 +192,17 @@
    * @property {boolean} [expand] - Whether to expand the node and its ancestors (default: true)
    * @property {boolean} [select] - Whether to select the node (default: true)
    * @property {boolean} [focus] - Whether to focus the node (default: true)
+   * @typedef {object} TreeViewExpandedChange<Id=(string|number)>
+   * @property {ReadonlyArray<Id>} expandedIds - The full set of expanded node ids after the change
+   * @property {Array<Id>} added - Node ids expanded since the previous change
+   * @property {Array<Id>} removed - Node ids collapsed since the previous change
    * @slot {{ node: Node & { expanded: boolean; leaf: boolean; selected: boolean; } }}
    * @event select
    * @type {Node & { expanded: boolean; leaf: boolean; selected: boolean }}
    * @event toggle
    * @type {Node & { expanded: boolean; leaf: boolean; selected: boolean }}
+   * @event toggle:change
+   * @type {TreeViewExpandedChange<Node["id"]>}
    * @event focus
    * @type {Node & { expanded: boolean; leaf: boolean; selected: boolean }}
    */
@@ -853,9 +859,23 @@
       selectedNodeIds.set(selectedIds);
     }
     if (!arrayIdsEqual(expandedIds, lastExpandedIdsPushed)) {
+      const prevExpandedIds = lastExpandedIdsPushed;
       lastExpandedIdsPushed = expandedIds;
       expandedIdsSetStore.set(expandedIdsSet);
       expandedNodeIds.set(expandedIds);
+
+      const nextExpandedIds = expandedIds.slice();
+      const prevSet = new Set(prevExpandedIds);
+      const nextSet = new Set(nextExpandedIds);
+      const added = nextExpandedIds.filter((id) => !prevSet.has(id));
+      const removed = prevExpandedIds.filter((id) => !nextSet.has(id));
+      tick().then(() => {
+        dispatch("toggle:change", {
+          expandedIds: nextExpandedIds,
+          added,
+          removed,
+        });
+      });
     }
   }
 </script>

--- a/tests/TreeView/TreeView.expandedChange.test.svelte
+++ b/tests/TreeView/TreeView.expandedChange.test.svelte
@@ -1,0 +1,108 @@
+<script lang="ts">
+  import Button from "carbon-components-svelte/Button/Button.svelte";
+  import TreeView from "carbon-components-svelte/TreeView/TreeView.svelte";
+  import type { ComponentProps } from "svelte";
+
+  export let autoCollapse = false;
+  export let expandedIds: ComponentProps<TreeView>["expandedIds"] = [];
+
+  /** Spy for the aggregate `toggle:change` event. */
+  export let onToggleChange: (detail: {
+    expandedIds: ReadonlyArray<string | number>;
+    added: Array<string | number>;
+    removed: Array<string | number>;
+  }) => void = () => {};
+  /** Spy for the per-node `toggle` event. */
+  export let onToggle: (detail: unknown) => void = () => {};
+
+  let treeview: TreeView;
+  let activeId: ComponentProps<TreeView>["activeId"] = "";
+  let selectedIds: ComponentProps<TreeView>["selectedIds"] = [];
+  let nodes: ComponentProps<TreeView>["nodes"] = [
+    { id: 0, text: "AI / Machine learning" },
+    {
+      id: 1,
+      text: "Analytics",
+      nodes: [
+        {
+          id: 2,
+          text: "IBM Analytics Engine",
+          nodes: [
+            { id: 3, text: "Apache Spark" },
+            { id: 4, text: "Hadoop" },
+          ],
+        },
+        { id: 5, text: "IBM Cloud SQL Query" },
+        { id: 6, text: "IBM Db2 Warehouse on Cloud" },
+      ],
+    },
+    {
+      id: 7,
+      text: "Blockchain",
+      nodes: [{ id: 8, text: "IBM Blockchain Platform" }],
+    },
+    {
+      id: 9,
+      text: "Databases",
+      nodes: [
+        { id: 10, text: "IBM Cloud Databases for Elasticsearch" },
+        { id: 11, text: "IBM Cloud Databases for Enterprise DB" },
+      ],
+    },
+  ];
+</script>
+
+<TreeView
+  bind:this={treeview}
+  {autoCollapse}
+  labelText="Expanded change"
+  {nodes}
+  bind:activeId
+  bind:selectedIds
+  bind:expandedIds
+  on:toggle={({ detail }) => onToggle(detail)}
+  on:toggle:change={({ detail }) => onToggleChange(detail)}
+  let:node
+>
+  {node.text}
+</TreeView>
+
+<Button data-testid="expand-all" on:click={() => treeview.expandAll()}>
+  Expand all
+</Button>
+<Button data-testid="collapse-all" on:click={() => treeview.collapseAll()}>
+  Collapse all
+</Button>
+<Button
+  data-testid="expand-nodes"
+  on:click={() => treeview.expandNodes((node) => node.id === 1)}
+>
+  Expand Analytics
+</Button>
+<Button
+  data-testid="collapse-nodes"
+  on:click={() => treeview.collapseNodes((node) => node.id === 1)}
+>
+  Collapse Analytics
+</Button>
+<Button
+  data-testid="show-node"
+  on:click={() => treeview.showNode(3, { focus: false })}
+>
+  Show Apache Spark
+</Button>
+<Button data-testid="set-prop" on:click={() => (expandedIds = [1])}>
+  Set expanded via prop
+</Button>
+<Button
+  data-testid="noop-set"
+  on:click={() => (expandedIds = (expandedIds ?? []).slice())}
+>
+  No-op set
+</Button>
+<Button data-testid="select-only" on:click={() => (activeId = 0)}>
+  Select only
+</Button>
+<Button data-testid="auto-collapse" on:click={() => (activeId = 2)}>
+  Activate nested node
+</Button>

--- a/tests/TreeView/TreeView.expandedChange.test.ts
+++ b/tests/TreeView/TreeView.expandedChange.test.ts
@@ -1,0 +1,308 @@
+import { render, screen, waitFor } from "@testing-library/svelte";
+import type TreeViewComponent from "carbon-components-svelte/TreeView/TreeView.svelte";
+import type {
+  TreeViewExpandedChange as ExpandedChangeDetail,
+  TreeNode,
+} from "carbon-components-svelte/TreeView/TreeView.svelte";
+import type { ComponentEvents } from "svelte";
+import { tick } from "svelte";
+import { user } from "../utils/user";
+import TreeViewExpandedChange from "./TreeView.expandedChange.test.svelte";
+
+type ToggleChangeDetail = {
+  expandedIds: ReadonlyArray<string | number>;
+  added: Array<string | number>;
+  removed: Array<string | number>;
+};
+
+function lastDetail(spy: ReturnType<typeof vi.fn>): ToggleChangeDetail {
+  return spy.mock.calls.at(-1)?.[0] as ToggleChangeDetail;
+}
+
+describe("TreeView toggle:change", () => {
+  it("fires on caret-click expand and collapse with single-id delta", async () => {
+    const onToggleChange = vi.fn();
+    const onToggle = vi.fn();
+    render(TreeViewExpandedChange, { onToggleChange, onToggle });
+
+    const analytics = document.getElementById("1");
+    expect.assert(analytics instanceof HTMLElement);
+    const toggle = analytics.querySelector(".bx--tree-parent-node__toggle");
+    expect.assert(toggle instanceof HTMLElement);
+
+    await user.click(toggle);
+    await waitFor(() => expect(onToggleChange).toHaveBeenCalledTimes(1));
+    expect(lastDetail(onToggleChange)).toEqual({
+      expandedIds: [1],
+      added: [1],
+      removed: [],
+    });
+    // Per-node `toggle` still fires (no regression).
+    expect(onToggle).toHaveBeenCalledTimes(1);
+
+    await user.click(toggle);
+    await waitFor(() => expect(onToggleChange).toHaveBeenCalledTimes(2));
+    expect(lastDetail(onToggleChange)).toEqual({
+      expandedIds: [],
+      added: [],
+      removed: [1],
+    });
+    expect(onToggle).toHaveBeenCalledTimes(2);
+  });
+
+  it("expandAll() emits exactly once with every id added", async () => {
+    const onToggleChange = vi.fn();
+    render(TreeViewExpandedChange, { onToggleChange });
+
+    await user.click(screen.getByTestId("expand-all"));
+    await waitFor(() => expect(onToggleChange).toHaveBeenCalledTimes(1));
+
+    const detail = lastDetail(onToggleChange);
+    // `expandAll` marks every node id (parents and leaves) as expanded.
+    const allIds = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
+    expect(
+      [...detail.expandedIds].sort((a, b) => Number(a) - Number(b)),
+    ).toEqual(allIds);
+    expect([...detail.added].sort((a, b) => Number(a) - Number(b))).toEqual(
+      allIds,
+    );
+    expect(detail.removed).toEqual([]);
+  });
+
+  it("collapseAll() emits once with all ids removed", async () => {
+    const onToggleChange = vi.fn();
+    render(TreeViewExpandedChange, {
+      onToggleChange,
+      expandedIds: [1, 2, 7, 9],
+    });
+
+    await user.click(screen.getByTestId("collapse-all"));
+    await waitFor(() => expect(onToggleChange).toHaveBeenCalledTimes(1));
+
+    const detail = lastDetail(onToggleChange);
+    expect(detail.expandedIds).toEqual([]);
+    expect(detail.added).toEqual([]);
+    expect([...detail.removed].sort()).toEqual([1, 2, 7, 9]);
+  });
+
+  it("expandNodes(filter) emits the matched added ids", async () => {
+    const onToggleChange = vi.fn();
+    render(TreeViewExpandedChange, { onToggleChange });
+
+    await user.click(screen.getByTestId("expand-nodes"));
+    await waitFor(() => expect(onToggleChange).toHaveBeenCalledTimes(1));
+
+    const detail = lastDetail(onToggleChange);
+    expect(detail.added).toContain(1);
+    expect(detail.expandedIds).toContain(1);
+    expect(detail.removed).toEqual([]);
+  });
+
+  it("collapseNodes(filter) emits the matched removed ids", async () => {
+    const onToggleChange = vi.fn();
+    render(TreeViewExpandedChange, {
+      onToggleChange,
+      expandedIds: [1, 7],
+    });
+
+    await user.click(screen.getByTestId("collapse-nodes"));
+    await waitFor(() => expect(onToggleChange).toHaveBeenCalledTimes(1));
+
+    const detail = lastDetail(onToggleChange);
+    expect(detail.removed).toEqual([1]);
+    expect(detail.expandedIds).toEqual([7]);
+    expect(detail.added).toEqual([]);
+  });
+
+  it("showNode(id, { expand: true }) emits the ancestor ids added", async () => {
+    const onToggleChange = vi.fn();
+    render(TreeViewExpandedChange, { onToggleChange });
+
+    await user.click(screen.getByTestId("show-node"));
+    await waitFor(() => expect(onToggleChange).toHaveBeenCalledTimes(1));
+
+    const detail = lastDetail(onToggleChange);
+    // Apache Spark (id 3) ancestors: Analytics (1) and IBM Analytics Engine (2).
+    expect([...detail.added].sort()).toEqual([1, 2]);
+    expect([...detail.expandedIds].sort()).toEqual([1, 2]);
+    expect(detail.removed).toEqual([]);
+  });
+
+  it("autoCollapse sibling collapse includes the sibling in removed", async () => {
+    const onToggleChange = vi.fn();
+    render(TreeViewExpandedChange, {
+      onToggleChange,
+      autoCollapse: true,
+      expandedIds: [1, 7],
+    });
+
+    // Activating a node under Analytics (1) collapses its sibling Blockchain (7).
+    await user.click(screen.getByTestId("auto-collapse"));
+    await waitFor(() => expect(onToggleChange).toHaveBeenCalledTimes(1));
+
+    const detail = lastDetail(onToggleChange);
+    expect(detail.removed).toContain(7);
+    expect(detail.expandedIds).not.toContain(7);
+  });
+
+  it("external prop change emits once", async () => {
+    const onToggleChange = vi.fn();
+    render(TreeViewExpandedChange, { onToggleChange });
+
+    await user.click(screen.getByTestId("set-prop"));
+    await waitFor(() => expect(onToggleChange).toHaveBeenCalledTimes(1));
+
+    expect(lastDetail(onToggleChange)).toEqual({
+      expandedIds: [1],
+      added: [1],
+      removed: [],
+    });
+  });
+
+  it("does not fire on a no-op set", async () => {
+    const onToggleChange = vi.fn();
+    render(TreeViewExpandedChange, {
+      onToggleChange,
+      expandedIds: [1],
+    });
+
+    await user.click(screen.getByTestId("noop-set"));
+    await tick();
+    await tick();
+
+    expect(onToggleChange).not.toHaveBeenCalled();
+  });
+
+  it("does not fire for selection-only changes", async () => {
+    const onToggleChange = vi.fn();
+    render(TreeViewExpandedChange, { onToggleChange });
+
+    await user.click(screen.getByTestId("select-only"));
+    await tick();
+    await tick();
+
+    expect(onToggleChange).not.toHaveBeenCalled();
+  });
+
+  it("does not fire on initial mount", async () => {
+    const onToggleChange = vi.fn();
+    render(TreeViewExpandedChange, {
+      onToggleChange,
+      expandedIds: [1, 2],
+    });
+
+    await tick();
+    await tick();
+
+    expect(onToggleChange).not.toHaveBeenCalled();
+  });
+
+  it("a throwing consumer neither wedges the flush nor surfaces a tracked unhandled rejection", async () => {
+    // Deferred dispatch turns a consumer throw into an unhandled rejection.
+    // Swap out the `process` listeners so vitest's collector does not fail the
+    // run, capture it ourselves, then assert the tree still updated.
+    const priorListeners = process.listeners("unhandledRejection");
+    process.removeAllListeners("unhandledRejection");
+
+    const rejections: unknown[] = [];
+    const capture = (reason: unknown) => rejections.push(reason);
+    process.on("unhandledRejection", capture);
+
+    try {
+      const onToggleChange = vi.fn(() => {
+        throw new Error("consumer boom");
+      });
+      render(TreeViewExpandedChange, { onToggleChange });
+
+      await user.click(screen.getByTestId("expand-all"));
+      await waitFor(() => expect(onToggleChange).toHaveBeenCalledTimes(1));
+
+      // The expansion still committed despite the throw.
+      expect(screen.getAllByRole("treeitem", { expanded: true }).length).toBe(
+        4,
+      );
+
+      // Let Node emit the rejection from the deferred microtask.
+      await new Promise((resolve) => setTimeout(resolve));
+      expect(rejections).toHaveLength(1);
+      expect((rejections[0] as Error).message).toBe("consumer boom");
+    } finally {
+      process.removeListener("unhandledRejection", capture);
+      for (const listener of priorListeners) {
+        process.on("unhandledRejection", listener);
+      }
+    }
+  });
+});
+
+describe("TreeView toggle:change generics", () => {
+  it("defaults the detail ids to string | number", () => {
+    type Events = ComponentEvents<TreeViewComponent<TreeNode>>;
+    type Detail =
+      Events["toggle:change"] extends CustomEvent<infer T> ? T : never;
+
+    expectTypeOf<Detail>().toEqualTypeOf<
+      ExpandedChangeDetail<string | number>
+    >();
+    expectTypeOf<Detail["expandedIds"]>().toEqualTypeOf<
+      ReadonlyArray<string | number>
+    >();
+    expectTypeOf<Detail["added"]>().toEqualTypeOf<Array<string | number>>();
+    expectTypeOf<Detail["removed"]>().toEqualTypeOf<Array<string | number>>();
+  });
+
+  it("narrows the detail ids to the node id type", () => {
+    type StringNode = { id: string; text: string };
+    type StringDetail =
+      ComponentEvents<
+        TreeViewComponent<StringNode>
+      >["toggle:change"] extends CustomEvent<infer T>
+        ? T
+        : never;
+    expectTypeOf<StringDetail["expandedIds"]>().toEqualTypeOf<
+      ReadonlyArray<string>
+    >();
+    expectTypeOf<StringDetail["added"]>().toEqualTypeOf<Array<string>>();
+    expectTypeOf<StringDetail["removed"]>().toEqualTypeOf<Array<string>>();
+
+    type NumberNode = { id: number; text: string };
+    type NumberDetail =
+      ComponentEvents<
+        TreeViewComponent<NumberNode>
+      >["toggle:change"] extends CustomEvent<infer T>
+        ? T
+        : never;
+    expectTypeOf<NumberDetail["expandedIds"]>().toEqualTypeOf<
+      ReadonlyArray<number>
+    >();
+    expectTypeOf<NumberDetail["added"]>().toEqualTypeOf<Array<number>>();
+
+    type UnionId = "a" | "b" | "c";
+    type UnionNode = { id: UnionId; text: string };
+    type UnionDetail =
+      ComponentEvents<
+        TreeViewComponent<UnionNode>
+      >["toggle:change"] extends CustomEvent<infer T>
+        ? T
+        : never;
+    expectTypeOf<UnionDetail["added"]>().toEqualTypeOf<Array<UnionId>>();
+    expectTypeOf<UnionDetail["removed"]>().toEqualTypeOf<Array<UnionId>>();
+  });
+
+  it("matches the exported TreeViewExpandedChange type", () => {
+    type StringNode = { id: string; text: string };
+    type StringDetail =
+      ComponentEvents<
+        TreeViewComponent<StringNode>
+      >["toggle:change"] extends CustomEvent<infer T>
+        ? T
+        : never;
+
+    // The event detail is exactly the public, reusable typedef.
+    expectTypeOf<StringDetail>().toEqualTypeOf<ExpandedChangeDetail<string>>();
+    // The exported type defaults its Id parameter to string | number.
+    expectTypeOf<ExpandedChangeDetail>().toEqualTypeOf<
+      ExpandedChangeDetail<string | number>
+    >();
+  });
+});


### PR DESCRIPTION
Builds on the example in #3342

Add a toggle:change aggregate event for expansion (can be click/keyboard or programmatic). This is useful for knowing the exact IDs that were expanded/collapsed without needing to diff the IDs yourself.