### PR TITLE
feat(tree-view): add `select:change` aggregate selection event

### DIFF
--- a/docs/src/pages/components/TreeView.svx
+++ b/docs/src/pages/components/TreeView.svx
@@ -77,9 +77,9 @@ Use a `contenteditable` element in each tree view node to enable inline editing 
 
 ## Events
 
-Listen for node selection, expansion, and focus with `on:select`, `on:toggle`, and `on:focus`. Each `event.detail` is the affected node after the interaction, with the same expanded, selected, and leaf fields as the slot node (see [Custom (slot)](#custom-slot)). A select reports the node as selected; a toggle that expands a branch reports it as expanded. These per-node events fire only for direct user gestures.
+Use `on:select`, `on:toggle`, and `on:focus` for user-driven selection, expansion, and focus. Each detail is the affected node after the gesture, with the same shape as the [Custom (slot)](#custom-slot) node.
 
-To track expansion from any source, listen for `on:toggle:change`. It fires once for every expansion change, whether it comes from a user gesture, a programmatic method (`expandAll`, `collapseAll`, `expandNodes`, `collapseNodes`, `showNode`, `autoCollapse`), or an external `bind:expandedIds` update. The event detail carries the full new `expandedIds` set plus the delta since the previous event: `added` lists ids newly expanded and `removed` lists ids newly collapsed. Bulk operations like `expandAll` emit a single event.
+Use `on:toggle:change` and `on:select:change` to track every expansion or selection change from any source, including imperative methods and bound ids. Each detail includes the full set plus `added` and `removed` deltas. Aggregate events skip mount and no-op updates; bulk operations emit one event.
 
 <FileSource src="/framed/TreeView/TreeViewEvents" />
 

--- a/docs/src/pages/framed/TreeView/TreeViewEvents.svelte
+++ b/docs/src/pages/framed/TreeView/TreeViewEvents.svelte
@@ -4,6 +4,7 @@
   let treeview = null;
   let lastEvent = null;
   let lastToggleChange = null;
+  let lastSelectChange = null;
   let nodes = [
     { id: 0, text: "AI / Machine learning" },
     {
@@ -50,12 +51,14 @@
   <div>
     <TreeView
       bind:this={treeview}
+      multiselect
       labelText="Cloud Products"
       {nodes}
       on:select={({ detail }) => logEvent("select", detail)}
       on:toggle={({ detail }) => logEvent("toggle", detail)}
       on:focus={({ detail }) => logEvent("focus", detail)}
       on:toggle:change={({ detail }) => (lastToggleChange = detail)}
+      on:select:change={({ detail }) => (lastSelectChange = detail)}
     />
   </div>
   {#if lastEvent}
@@ -72,6 +75,14 @@
       <div>expandedIds: {JSON.stringify(lastToggleChange.expandedIds)}</div>
       <div>added: {JSON.stringify(lastToggleChange.added)}</div>
       <div>removed: {JSON.stringify(lastToggleChange.removed)}</div>
+    </Stack>
+  {/if}
+  {#if lastSelectChange}
+    <Stack gap={4}>
+      <div>Last select:change</div>
+      <div>selectedIds: {JSON.stringify(lastSelectChange.selectedIds)}</div>
+      <div>added: {JSON.stringify(lastSelectChange.added)}</div>
+      <div>removed: {JSON.stringify(lastSelectChange.removed)}</div>
     </Stack>
   {/if}
 </Stack>

--- a/src/TreeView/TreeView.svelte
+++ b/src/TreeView/TreeView.svelte
@@ -196,6 +196,10 @@
    * @property {ReadonlyArray<Id>} expandedIds - The full set of expanded node ids after the change
    * @property {Array<Id>} added - Node ids expanded since the previous change
    * @property {Array<Id>} removed - Node ids collapsed since the previous change
+   * @typedef {object} TreeViewSelectionChange<Id=(string|number)>
+   * @property {ReadonlyArray<Id>} selectedIds - The full set of selected node ids after the change
+   * @property {Array<Id>} added - Node ids selected since the previous change
+   * @property {Array<Id>} removed - Node ids deselected since the previous change
    * @slot {{ node: Node & { expanded: boolean; leaf: boolean; selected: boolean; } }}
    * @event select
    * @type {Node & { expanded: boolean; leaf: boolean; selected: boolean }}
@@ -205,6 +209,8 @@
    * @type {TreeViewExpandedChange<Node["id"]>}
    * @event focus
    * @type {Node & { expanded: boolean; leaf: boolean; selected: boolean }}
+   * @event select:change
+   * @type {TreeViewSelectionChange<Node["id"]>}
    */
 
   /**
@@ -854,9 +860,23 @@
       activeNodeId.set(activeId);
     }
     if (!arrayIdsEqual(selectedIds, lastSelectedIdsPushed)) {
+      const prevSelectedIds = lastSelectedIdsPushed;
       lastSelectedIdsPushed = selectedIds;
       selectedIdsSetStore.set(new Set(selectedIds));
       selectedNodeIds.set(selectedIds);
+
+      const nextSelectedIds = selectedIds.slice();
+      const prevSet = new Set(prevSelectedIds);
+      const nextSet = new Set(nextSelectedIds);
+      const added = nextSelectedIds.filter((id) => !prevSet.has(id));
+      const removed = prevSelectedIds.filter((id) => !nextSet.has(id));
+      tick().then(() => {
+        dispatch("select:change", {
+          selectedIds: nextSelectedIds,
+          added,
+          removed,
+        });
+      });
     }
     if (!arrayIdsEqual(expandedIds, lastExpandedIdsPushed)) {
       const prevExpandedIds = lastExpandedIdsPushed;

--- a/src/TreeView/TreeViewNodeList.svelte
+++ b/src/TreeView/TreeViewNodeList.svelte
@@ -78,7 +78,10 @@
     selected,
   };
   $: {
+    // The root list is a non-selectable wrapper; its default empty `id` would
+    // otherwise match the default empty `activeId` and select a phantom node.
     if (
+      !root &&
       id === $activeNodeId &&
       prevActiveId !== $activeNodeId &&
       !$selectedIdsSetStore.has(id)

--- a/tests/TreeView/TreeViewSelectionChange.test.svelte
+++ b/tests/TreeView/TreeViewSelectionChange.test.svelte
@@ -1,0 +1,92 @@
+<script lang="ts">
+  import Button from "carbon-components-svelte/Button/Button.svelte";
+  import type { TreeNode } from "carbon-components-svelte/TreeView/TreeView.svelte";
+  import TreeView from "carbon-components-svelte/TreeView/TreeView.svelte";
+  import type { ComponentProps } from "svelte";
+
+  type Id = TreeNode["id"];
+
+  export let multiselect: ComponentProps<TreeView>["multiselect"] = false;
+  export let multiselectMode: ComponentProps<TreeView>["multiselectMode"] =
+    "node";
+  export let selectedIds: Id[] = [];
+  export let expandedIds: Id[] = [];
+  /** Spy for the aggregate `select:change` event. */
+  export let onSelectChange: (detail: {
+    selectedIds: ReadonlyArray<Id>;
+    added: Id[];
+    removed: Id[];
+  }) => void = () => {};
+
+  let treeview: TreeView;
+  export let nodes: ComponentProps<TreeView>["nodes"] = [
+    { id: 0, text: "AI / Machine learning" },
+    {
+      id: 1,
+      text: "Analytics",
+      nodes: [
+        {
+          id: 2,
+          text: "IBM Analytics Engine",
+          nodes: [
+            { id: 3, text: "Apache Spark" },
+            { id: 4, text: "Hadoop" },
+          ],
+        },
+        { id: 5, text: "IBM Cloud SQL Query" },
+        { id: 6, text: "IBM Db2 Warehouse on Cloud" },
+      ],
+    },
+    {
+      id: 7,
+      text: "Blockchain",
+      nodes: [{ id: 8, text: "IBM Blockchain Platform" }],
+    },
+    {
+      id: 9,
+      text: "Databases",
+      nodes: [
+        { id: 10, text: "IBM Cloud Databases for Elasticsearch" },
+        { id: 11, text: "IBM Cloud Databases for Enterprise DB" },
+        { id: 12, text: "IBM Cloud Databases for MongoDB" },
+        { id: 13, text: "IBM Cloud Databases for PostgreSQL" },
+      ],
+    },
+    {
+      id: 14,
+      text: "Integration",
+      disabled: true,
+      nodes: [{ id: 15, text: "IBM API Connect", disabled: true }],
+    },
+  ];
+</script>
+
+<TreeView
+  bind:this={treeview}
+  labelText="Cloud Products"
+  {multiselect}
+  {multiselectMode}
+  {nodes}
+  bind:selectedIds
+  bind:expandedIds
+  on:select:change={({ detail }) => onSelectChange(detail)}
+/>
+
+<Button data-testid="set-selected" on:click={() => (selectedIds = [0, 7])}>
+  Set selected
+</Button>
+<Button
+  data-testid="set-same"
+  on:click={() => (selectedIds = [...selectedIds])}
+>
+  Set same
+</Button>
+<Button data-testid="expand-all" on:click={() => treeview.expandAll()}>
+  Expand all
+</Button>
+<Button
+  data-testid="show-node-select"
+  on:click={() => treeview.showNode(8, { select: true })}
+>
+  Show node select
+</Button>

--- a/tests/TreeView/TreeViewSelectionChange.test.ts
+++ b/tests/TreeView/TreeViewSelectionChange.test.ts
@@ -1,0 +1,295 @@
+import { render, screen } from "@testing-library/svelte";
+import type TreeViewComponent from "carbon-components-svelte/TreeView/TreeView.svelte";
+import type {
+  TreeViewSelectionChange as SelectionChangeDetail,
+  TreeNode,
+} from "carbon-components-svelte/TreeView/TreeView.svelte";
+import type { ComponentEvents } from "svelte";
+import { user } from "../utils/user";
+import TreeViewSelectionChange from "./TreeViewSelectionChange.test.svelte";
+
+type Id = string | number;
+type SelectChangeDetail = {
+  selectedIds: ReadonlyArray<Id>;
+  added: Id[];
+  removed: Id[];
+};
+
+function treeItemById(id: Id): HTMLElement {
+  const el = document.getElementById(String(id));
+  expect.assert(el instanceof HTMLElement);
+  return el;
+}
+
+const lastDetail = (spy: ReturnType<typeof vi.fn>): SelectChangeDetail =>
+  spy.mock.calls.at(-1)?.[0] as SelectChangeDetail;
+
+describe("TreeView select:change", () => {
+  it("fires on a plain click with the new selection and delta", async () => {
+    const onSelectChange = vi.fn();
+    render(TreeViewSelectionChange, { onSelectChange });
+
+    await user.click(treeItemById(0));
+
+    await vi.waitFor(() => expect(onSelectChange).toHaveBeenCalledTimes(1));
+    expect(lastDetail(onSelectChange)).toEqual({
+      selectedIds: [0],
+      added: [0],
+      removed: [],
+    });
+  });
+
+  it("does not fire on initial mount", async () => {
+    const onSelectChange = vi.fn();
+    render(TreeViewSelectionChange, {
+      selectedIds: [0, 7],
+      onSelectChange,
+    });
+
+    // Give any deferred dispatch a chance to run.
+    await new Promise((resolve) => setTimeout(resolve));
+    expect(onSelectChange).not.toHaveBeenCalled();
+  });
+
+  it("does not corrupt selectedIds on mount when activeId is unset", async () => {
+    const onSelectChange = vi.fn();
+    render(TreeViewSelectionChange, { selectedIds: [], onSelectChange });
+
+    await new Promise((resolve) => setTimeout(resolve));
+    expect(onSelectChange).not.toHaveBeenCalled();
+    expect(screen.queryAllByRole("treeitem", { selected: true })).toHaveLength(
+      0,
+    );
+  });
+
+  it("flips delta between added and removed on Ctrl+click toggle", async () => {
+    const onSelectChange = vi.fn();
+    render(TreeViewSelectionChange, {
+      multiselect: true,
+      selectedIds: [],
+      onSelectChange,
+    });
+
+    // Plain click selects node 0.
+    await user.click(treeItemById(0));
+    await vi.waitFor(() => expect(onSelectChange).toHaveBeenCalledTimes(1));
+    expect(lastDetail(onSelectChange)).toEqual({
+      selectedIds: [0],
+      added: [0],
+      removed: [],
+    });
+
+    // Ctrl+click adds node 7.
+    await user.keyboard("{Control>}");
+    await user.click(treeItemById(7));
+    await user.keyboard("{/Control}");
+    await vi.waitFor(() => expect(onSelectChange).toHaveBeenCalledTimes(2));
+    expect(lastDetail(onSelectChange)).toEqual({
+      selectedIds: [0, 7],
+      added: [7],
+      removed: [],
+    });
+
+    // Ctrl+click again removes node 7.
+    await user.keyboard("{Control>}");
+    await user.click(treeItemById(7));
+    await user.keyboard("{/Control}");
+    await vi.waitFor(() => expect(onSelectChange).toHaveBeenCalledTimes(3));
+    expect(lastDetail(onSelectChange)).toEqual({
+      selectedIds: [0],
+      added: [],
+      removed: [7],
+    });
+  });
+
+  it("fires for Ctrl+A select-all with every visible non-disabled id added", async () => {
+    const onSelectChange = vi.fn();
+    render(TreeViewSelectionChange, {
+      multiselect: true,
+      selectedIds: [],
+      onSelectChange,
+    });
+
+    treeItemById(0).focus();
+    await user.keyboard("{Control>}a{/Control}");
+
+    await vi.waitFor(() => expect(onSelectChange).toHaveBeenCalledTimes(1));
+    const detail = lastDetail(onSelectChange);
+    // Only top-level rows are visible (children collapsed); node 14 is disabled.
+    expect([...detail.added].sort()).toEqual([0, 1, 7, 9]);
+    expect([...detail.selectedIds].sort()).toEqual([0, 1, 7, 9]);
+    expect(detail.removed).toEqual([]);
+  });
+
+  it("fires for Ctrl+Shift+End range-extend", async () => {
+    const onSelectChange = vi.fn();
+    render(TreeViewSelectionChange, {
+      multiselect: true,
+      selectedIds: [0],
+      onSelectChange,
+    });
+
+    treeItemById(0).focus();
+    await user.keyboard("{Control>}{Shift>}{End}{/Shift}{/Control}");
+
+    await vi.waitFor(() => expect(onSelectChange).toHaveBeenCalledTimes(1));
+    const detail = lastDetail(onSelectChange);
+    // Extends from the focused row through the last visible non-disabled row.
+    expect(detail.added.length).toBeGreaterThan(0);
+    expect(detail.removed).toEqual([]);
+    expect(detail.selectedIds).toContain(0);
+  });
+
+  it("fires for the imperative showNode(id, { select: true })", async () => {
+    const onSelectChange = vi.fn();
+    render(TreeViewSelectionChange, { selectedIds: [], onSelectChange });
+
+    await user.click(screen.getByTestId("show-node-select"));
+
+    await vi.waitFor(() => expect(onSelectChange).toHaveBeenCalledTimes(1));
+    expect(lastDetail(onSelectChange)).toEqual({
+      selectedIds: [8],
+      added: [8],
+      removed: [],
+    });
+  });
+
+  it("fires once for an external bind:selectedIds change", async () => {
+    const onSelectChange = vi.fn();
+    render(TreeViewSelectionChange, { selectedIds: [9], onSelectChange });
+
+    await user.click(screen.getByTestId("set-selected"));
+
+    await vi.waitFor(() => expect(onSelectChange).toHaveBeenCalledTimes(1));
+    expect(lastDetail(onSelectChange)).toEqual({
+      selectedIds: [0, 7],
+      added: [0, 7],
+      removed: [9],
+    });
+  });
+
+  it("does not fire when the same ids are reassigned (no-op set)", async () => {
+    const onSelectChange = vi.fn();
+    render(TreeViewSelectionChange, { selectedIds: [0, 7], onSelectChange });
+
+    await user.click(screen.getByTestId("set-same"));
+
+    await new Promise((resolve) => setTimeout(resolve));
+    expect(onSelectChange).not.toHaveBeenCalled();
+  });
+
+  it("does not fire when only expansion changes (expandAll)", async () => {
+    const onSelectChange = vi.fn();
+    render(TreeViewSelectionChange, { selectedIds: [0], onSelectChange });
+
+    await user.click(screen.getByTestId("expand-all"));
+
+    await new Promise((resolve) => setTimeout(resolve));
+    expect(onSelectChange).not.toHaveBeenCalled();
+  });
+
+  it("a throwing consumer neither wedges the flush nor surfaces a tracked unhandled rejection", async () => {
+    // Deferred dispatch turns a consumer throw into an unhandled rejection.
+    // Swap out the `process` listeners so vitest's collector does not fail the
+    // run, capture it ourselves, then assert the selection still committed.
+    const priorListeners = process.listeners("unhandledRejection");
+    process.removeAllListeners("unhandledRejection");
+
+    const rejections: unknown[] = [];
+    const capture = (reason: unknown) => rejections.push(reason);
+    process.on("unhandledRejection", capture);
+
+    try {
+      const onSelectChange = vi.fn(() => {
+        throw new Error("consumer boom");
+      });
+      render(TreeViewSelectionChange, { selectedIds: [], onSelectChange });
+
+      await user.click(treeItemById(0));
+      await vi.waitFor(() => expect(onSelectChange).toHaveBeenCalledTimes(1));
+
+      // The selection still committed despite the throw.
+      expect(treeItemById(0)).toHaveAttribute("aria-selected", "true");
+
+      // Let Node emit the rejection from the deferred microtask.
+      await new Promise((resolve) => setTimeout(resolve));
+      expect(rejections).toHaveLength(1);
+      expect((rejections[0] as Error).message).toBe("consumer boom");
+    } finally {
+      process.removeListener("unhandledRejection", capture);
+      for (const listener of priorListeners) {
+        process.on("unhandledRejection", listener);
+      }
+    }
+  });
+});
+
+describe("TreeView select:change generics", () => {
+  it("defaults the detail ids to string | number", () => {
+    type Events = ComponentEvents<TreeViewComponent<TreeNode>>;
+    type Detail =
+      Events["select:change"] extends CustomEvent<infer T> ? T : never;
+
+    expectTypeOf<Detail>().toEqualTypeOf<
+      SelectionChangeDetail<string | number>
+    >();
+    expectTypeOf<Detail["selectedIds"]>().toEqualTypeOf<
+      ReadonlyArray<string | number>
+    >();
+    expectTypeOf<Detail["added"]>().toEqualTypeOf<Array<string | number>>();
+    expectTypeOf<Detail["removed"]>().toEqualTypeOf<Array<string | number>>();
+  });
+
+  it("narrows the detail ids to the node id type", () => {
+    type StringNode = { id: string; text: string };
+    type StringDetail =
+      ComponentEvents<
+        TreeViewComponent<StringNode>
+      >["select:change"] extends CustomEvent<infer T>
+        ? T
+        : never;
+    expectTypeOf<StringDetail["selectedIds"]>().toEqualTypeOf<
+      ReadonlyArray<string>
+    >();
+    expectTypeOf<StringDetail["added"]>().toEqualTypeOf<Array<string>>();
+    expectTypeOf<StringDetail["removed"]>().toEqualTypeOf<Array<string>>();
+
+    type NumberNode = { id: number; text: string };
+    type NumberDetail =
+      ComponentEvents<
+        TreeViewComponent<NumberNode>
+      >["select:change"] extends CustomEvent<infer T>
+        ? T
+        : never;
+    expectTypeOf<NumberDetail["selectedIds"]>().toEqualTypeOf<
+      ReadonlyArray<number>
+    >();
+    expectTypeOf<NumberDetail["added"]>().toEqualTypeOf<Array<number>>();
+
+    type UnionId = "a" | "b" | "c";
+    type UnionNode = { id: UnionId; text: string };
+    type UnionDetail =
+      ComponentEvents<
+        TreeViewComponent<UnionNode>
+      >["select:change"] extends CustomEvent<infer T>
+        ? T
+        : never;
+    expectTypeOf<UnionDetail["added"]>().toEqualTypeOf<Array<UnionId>>();
+    expectTypeOf<UnionDetail["removed"]>().toEqualTypeOf<Array<UnionId>>();
+  });
+
+  it("matches the exported TreeViewSelectionChange type", () => {
+    type StringNode = { id: string; text: string };
+    type StringDetail =
+      ComponentEvents<
+        TreeViewComponent<StringNode>
+      >["select:change"] extends CustomEvent<infer T>
+        ? T
+        : never;
+
+    expectTypeOf<StringDetail>().toEqualTypeOf<SelectionChangeDetail<string>>();
+    expectTypeOf<SelectionChangeDetail>().toEqualTypeOf<
+      SelectionChangeDetail<string | number>
+    >();
+  });
+});


### PR DESCRIPTION
Mirrors #3344 and adds a similar aggregate `select:change` events for select events (user-triggered or programmatic).

This makes it actually useful for consumers to know what was selected/deselected without needing to derive the delta themselves.