### PR TITLE
fix(dropdown): prevent page scroll when opening menu with Space

### DIFF
--- a/src/Dropdown/Dropdown.svelte
+++ b/src/Dropdown/Dropdown.svelte
@@ -541,6 +541,7 @@
         }}
         on:keydown={(event) => {
         if (
+          event.key === " " ||
           event.key === "Enter" ||
           event.key === "ArrowDown" ||
           event.key === "ArrowUp"

--- a/tests/Dropdown/Dropdown.test.ts
+++ b/tests/Dropdown/Dropdown.test.ts
@@ -331,6 +331,31 @@ describe("Dropdown", () => {
     expect(button).toHaveTextContent("Email");
   });
 
+  // Regression: the Space keydown must cancel its default action so the
+  // browser does not scroll the page (and does not synthesize a click)
+  // before the keyup handler opens the menu.
+  it("should prevent the default page scroll when opening with Space", async () => {
+    render(Dropdown, { props: { items, selectedId: "0" } });
+
+    const button = screen.getByRole("combobox");
+    button.focus();
+    expect(button).toHaveAttribute("aria-expanded", "false");
+
+    const keydown = new KeyboardEvent("keydown", {
+      key: " ",
+      bubbles: true,
+      cancelable: true,
+    });
+    button.dispatchEvent(keydown);
+    expect(keydown.defaultPrevented).toBe(true);
+
+    // Space opens on keyup.
+    await fireEvent.keyUp(button, { key: " " });
+    await tick();
+    expect(button).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByRole("listbox")).toBeVisible();
+  });
+
   it("should open the menu on ArrowDown and highlight the first enabled item", async () => {
     render(Dropdown, { props: { items } });
 


### PR DESCRIPTION
The button's keydown handler called preventDefault for Enter, ArrowDown, and ArrowUp but not Space.

Space's open/select logic runs on keyup, so the keydown default was never canceled: opening the dropdown with the spacebar let the browser perform its native Space action (scrolling the page) and synthesize a click.

Other components, like MultiSelect, already do this.