### PR TITLE
feat(tabs-vertical): add `TabsVertical` component

### DIFF
--- a/css/_tabs.scss
+++ b/css/_tabs.scss
@@ -482,3 +482,260 @@
 @include exports('tabs-dismissible') {
   @include tabs-dismissible;
 }
+
+/// Vertical tabs (Carbon v11 `TabsVertical` parity), authored from the v11 token
+/// map since Carbon v10 ships no vertical variant. At `md` and up the tab list
+/// is a fixed left column with a per-item left indicator; below `md` it is a
+/// horizontal, scrollable row of contained tabs. The component drops
+/// `bx--tabs--container`, so these rules override the default-tab rules and split
+/// by `breakpoint-down(md)` / `breakpoint(md)` so the orientations stay separate.
+/// @access private
+/// @group components
+@mixin tabs-vertical {
+  .#{$prefix}--tabs--vertical-container {
+    display: flex;
+    flex-direction: column;
+
+    @include carbon--breakpoint(md) {
+      flex-direction: row;
+      align-items: stretch;
+    }
+  }
+
+  // `Tab` renders the icon after the label; move it before the label.
+  .#{$prefix}--tabs--vertical .#{$prefix}--tabs__nav-item--icon {
+    order: -1;
+    padding-inline: 0 $carbon--spacing-03;
+  }
+
+  @include carbon--breakpoint-down(md) {
+    // The nav is an absolutely-positioned dropdown overlay by default.
+    .#{$prefix}--tabs--vertical .#{$prefix}--tabs__nav {
+      position: static;
+      z-index: auto;
+      max-height: none;
+      box-shadow: none;
+      flex-direction: row;
+      overflow-x: auto;
+      background-color: $ui-01;
+    }
+
+    // The selected item is hidden by default below `md` (legacy dropdown).
+    .#{$prefix}--tabs--vertical .#{$prefix}--tabs__nav-item,
+    .#{$prefix}--tabs--vertical
+      .#{$prefix}--tabs__nav-item--selected:not(.#{$prefix}--tabs__nav-item--disabled) {
+      display: flex;
+      flex: none;
+      block-size: $carbon--spacing-09;
+      inline-size: auto;
+      margin: 0;
+      background-color: $ui-03;
+    }
+
+    .#{$prefix}--tabs--vertical
+      .#{$prefix}--tabs__nav-item
+      + .#{$prefix}--tabs__nav-item {
+      box-shadow: inset 1px 0 0 0 $ui-04;
+    }
+
+    .#{$prefix}--tabs--vertical
+      .#{$prefix}--tabs__nav-item--selected:not(.#{$prefix}--tabs__nav-item--disabled) {
+      background-color: $ui-01;
+      box-shadow: inset 0 2px 0 0 $interactive-04;
+    }
+
+    .#{$prefix}--tabs--vertical
+      .#{$prefix}--tabs__nav-item:not(.#{$prefix}--tabs__nav-item--selected):not(.#{$prefix}--tabs__nav-item--disabled):hover {
+      background-color: $hover-selected-ui;
+    }
+
+    .#{$prefix}--tabs--vertical .#{$prefix}--tabs__nav-item--disabled,
+    .#{$prefix}--tabs--vertical .#{$prefix}--tabs__nav-item--disabled:hover {
+      background-color: $disabled-02;
+    }
+
+    // The base disabled text token equals the disabled background here.
+    .#{$prefix}--tabs.#{$prefix}--tabs--vertical
+      .#{$prefix}--tabs__nav-item--disabled
+      a.#{$prefix}--tabs__nav-link {
+      color: $disabled-03;
+    }
+
+    .#{$prefix}--tabs.#{$prefix}--tabs--vertical a.#{$prefix}--tabs__nav-link,
+    .#{$prefix}--tabs.#{$prefix}--tabs--vertical a.#{$prefix}--tabs__nav-link:focus,
+    .#{$prefix}--tabs.#{$prefix}--tabs--vertical a.#{$prefix}--tabs__nav-link:active {
+      display: flex;
+      align-items: center;
+      inline-size: auto;
+      block-size: 100%;
+      padding: $carbon--spacing-03 $carbon--spacing-05;
+      border: none;
+      margin: 0;
+      line-height: inherit;
+    }
+
+    // Remove the base hover-link bottom border, which would shift the label.
+    .#{$prefix}--tabs.#{$prefix}--tabs--vertical
+      .#{$prefix}--tabs__nav-item:hover:not(.#{$prefix}--tabs__nav-item--disabled)
+      a.#{$prefix}--tabs__nav-link {
+      border: none;
+    }
+
+    .#{$prefix}--tabs.#{$prefix}--tabs--vertical
+      .#{$prefix}--tabs__nav-item--selected:not(.#{$prefix}--tabs__nav-item--disabled)
+      a.#{$prefix}--tabs__nav-link {
+      @include carbon--type-style("productive-heading-01");
+
+      border: none;
+      color: $text-01;
+    }
+
+    .#{$prefix}--tabs--vertical .#{$prefix}--tabs__nav-item-label {
+      overflow: hidden;
+      max-inline-size: to-rem(160px);
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .#{$prefix}--tabs--vertical ~ .#{$prefix}--tab-content {
+      background-color: $ui-01;
+    }
+  }
+
+  @include carbon--breakpoint(md) {
+    .#{$prefix}--tabs.#{$prefix}--tabs--vertical {
+      flex: 0 0 auto;
+      inline-size: to-rem(160px);
+      min-height: 0;
+      background-color: $ui-01;
+    }
+
+    // The nav is an absolutely-positioned dropdown overlay by default.
+    .#{$prefix}--tabs--vertical .#{$prefix}--tabs__nav {
+      position: static;
+      z-index: auto;
+      max-height: none;
+      box-shadow: none;
+      flex-direction: column;
+      inline-size: 100%;
+      max-width: none;
+      overflow: visible;
+    }
+
+    .#{$prefix}--tabs--vertical .#{$prefix}--tabs__nav-item {
+      flex: none;
+      block-size: $carbon--spacing-10;
+      inline-size: 100%;
+      margin: 0;
+      background-color: $ui-01;
+      border-block-end: 1px solid $ui-03;
+      border-inline-end: 1px solid $ui-03;
+    }
+
+    .#{$prefix}--tabs--vertical
+      .#{$prefix}--tabs__nav-item
+      + .#{$prefix}--tabs__nav-item {
+      margin: 0;
+    }
+
+    // Specificity (0,5,0) keeps the base hover rule
+    // (`item:hover + item { box-shadow: none }`) from stripping the indicator.
+    .#{$prefix}--tabs.#{$prefix}--tabs--vertical
+      .#{$prefix}--tabs__nav-item:not(.#{$prefix}--tabs__nav-item--selected):not(.#{$prefix}--tabs__nav-item--disabled) {
+      box-shadow: inset 3px 0 0 0 $ui-03;
+    }
+
+    // Re-assert the bottom separator that the base `--selected { border: none }`
+    // strips. The right divider is transparent so the tab merges into the panel.
+    .#{$prefix}--tabs.#{$prefix}--tabs--vertical
+      .#{$prefix}--tabs__nav-item--selected:not(.#{$prefix}--tabs__nav-item--disabled) {
+      border-block-end: 1px solid $ui-03;
+      border-inline-end: 1px solid transparent;
+      box-shadow: inset 3px 0 0 0 $interactive-04;
+    }
+
+    .#{$prefix}--tabs.#{$prefix}--tabs--vertical
+      .#{$prefix}--tabs__nav-item:not(.#{$prefix}--tabs__nav-item--selected):not(.#{$prefix}--tabs__nav-item--disabled):hover {
+      background-color: $hover-ui;
+      box-shadow: inset 3px 0 0 0 $ui-04;
+    }
+
+    .#{$prefix}--tabs.#{$prefix}--tabs--vertical
+      .#{$prefix}--tabs__nav-item--disabled,
+    .#{$prefix}--tabs.#{$prefix}--tabs--vertical
+      .#{$prefix}--tabs__nav-item--disabled:hover {
+      background-color: $ui-01;
+      box-shadow: inset 3px 0 0 0 $ui-03;
+    }
+
+    // The last tab closes against the panel edge. The second selector
+    // out-specifies the selected rule above (0,6,0 > 0,5,0).
+    .#{$prefix}--tabs.#{$prefix}--tabs--vertical
+      .#{$prefix}--tabs__nav-item:last-child,
+    .#{$prefix}--tabs.#{$prefix}--tabs--vertical
+      .#{$prefix}--tabs__nav-item--selected:not(.#{$prefix}--tabs__nav-item--disabled):last-child {
+      border-block-end: none;
+    }
+
+    .#{$prefix}--tabs.#{$prefix}--tabs--vertical a.#{$prefix}--tabs__nav-link,
+    .#{$prefix}--tabs.#{$prefix}--tabs--vertical a.#{$prefix}--tabs__nav-link:focus,
+    .#{$prefix}--tabs.#{$prefix}--tabs--vertical a.#{$prefix}--tabs__nav-link:active {
+      display: flex;
+      align-items: center;
+      inline-size: 100%;
+      block-size: 100%;
+      padding: $carbon--spacing-04 $carbon--spacing-05;
+      border: none;
+      margin: 0;
+      line-height: inherit;
+    }
+
+    // Top-align so the icon tracks the first line when the label wraps.
+    .#{$prefix}--tabs.#{$prefix}--tabs--vertical
+      a.#{$prefix}--tabs__nav-link.#{$prefix}--tabs__nav-link--icon {
+      align-items: flex-start;
+    }
+
+    // One line tall so the centered icon lands on the label's first line.
+    .#{$prefix}--tabs--vertical
+      .#{$prefix}--tabs__nav-link--icon
+      .#{$prefix}--tabs__nav-item--icon {
+      block-size: to-rem(18px);
+    }
+
+    // Remove the base hover-link bottom border, which would shift the label.
+    .#{$prefix}--tabs.#{$prefix}--tabs--vertical
+      .#{$prefix}--tabs__nav-item:hover:not(.#{$prefix}--tabs__nav-item--disabled)
+      a.#{$prefix}--tabs__nav-link {
+      border: none;
+    }
+
+    .#{$prefix}--tabs.#{$prefix}--tabs--vertical
+      .#{$prefix}--tabs__nav-item--selected:not(.#{$prefix}--tabs__nav-item--disabled)
+      a.#{$prefix}--tabs__nav-link {
+      @include carbon--type-style("productive-heading-01");
+
+      border: none;
+      color: $text-01;
+    }
+
+    .#{$prefix}--tabs--vertical .#{$prefix}--tabs__nav-item-label {
+      display: -webkit-box;
+      overflow: hidden;
+      -webkit-box-orient: vertical;
+      -webkit-line-clamp: 2;
+      text-overflow: ellipsis;
+      white-space: normal;
+    }
+
+    .#{$prefix}--tabs--vertical ~ .#{$prefix}--tab-content {
+      flex: 1 1 auto;
+      background-color: $ui-01;
+      overflow-y: auto;
+    }
+  }
+}
+
+@include exports('tabs-vertical') {
+  @include tabs-vertical;
+}

--- a/docs/src/component-since-versions.ts
+++ b/docs/src/component-since-versions.ts
@@ -61,6 +61,7 @@ export const COMPONENT_SINCE_VERSIONS: Record<string, string> = {
   Stack: "0.93.0",
   StructuredList: "0.2.0",
   Tabs: "0.2.0",
+  TabsVertical: "0.110.0",
   Tag: "0.2.0",
   Text: "0.109.0",
   TextArea: "0.2.0",

--- a/docs/src/pages/components/Tabs.svx
+++ b/docs/src/pages/components/Tabs.svx
@@ -244,6 +244,34 @@ Set `type="container"` and `dismissible` to `true` for dismissible container tab
 
 <FileSource src="/framed/Tabs/TabsDismissibleContainer" />
 
+## Custom label
+
+Use the default slot with `let:selected` to customize the tab label based on
+whether the tab is selected.
+
+<Tabs>
+  <Tab label="Tab label 1" let:selected>
+    Tab label 1 {#if selected}(selected){/if}
+  </Tab>
+  <Tab label="Tab label 2" let:selected>
+    Tab label 2 {#if selected}(selected){/if}
+  </Tab>
+  <Tab label="Tab label 3" let:selected>
+    Tab label 3 {#if selected}(selected){/if}
+  </Tab>
+  <svelte:fragment slot="content">
+    <TabContent>Content 1</TabContent>
+    <TabContent>Content 2</TabContent>
+    <TabContent>Content 3</TabContent>
+  </svelte:fragment>
+</Tabs>
+
+## Skeleton
+
+Show a loading state while tabs load.
+
+<TabsSkeleton count={3} />
+
 ## Container
 
 Use the container type for a more prominent tab interface. By default, container types have an auto-width.
@@ -383,9 +411,17 @@ and optional secondary line (for example, counts or status).
   </svelte:fragment>
 </Tabs>
 
+### Skeleton
+
+Show a loading state for the container tab variant.
+
+<TabsSkeleton type="container" count={3} />
+
 ## Vertical
 
-`TabsVertical` stacks the tabs in a column to the left of the panel on `md` and wider screens, then switches to a horizontal, scrollable row below `md`. Compose it with the same `Tab` and `TabContent` building blocks.
+Use TabsVertical to stack tabs in a column beside the panel on medium breakpoints
+and wider. On smaller viewports the tab list becomes a horizontal, scrollable row.
+Compose it with the same Tab and TabContent components.
 
 <TabsVertical>
   <Tab label="Dashboard" />
@@ -402,7 +438,8 @@ and optional secondary line (for example, counts or status).
 
 ### Selected
 
-Set `selected` to control the selected tab index. Bind to `selected` for a two-way binding that updates as the user switches tabs.
+Set selected to control the active tab index. Bind to selected to update the
+index as users switch tabs.
 
 <TabsVertical selected={1}>
   <Tab label="Dashboard" />
@@ -417,7 +454,8 @@ Set `selected` to control the selected tab index. Bind to `selected` for a two-w
 
 ### Disabled
 
-Set `disabled` on a tab to prevent interaction. Keyboard navigation skips disabled tabs.
+Set disabled on a tab to prevent interaction. Keyboard navigation skips disabled
+tabs.
 
 <TabsVertical>
   <Tab label="Dashboard" />
@@ -434,7 +472,7 @@ Set `disabled` on a tab to prevent interaction. Keyboard navigation skips disabl
 
 ### Truncated labels
 
-Long labels wrap to two lines before truncating with an ellipsis.
+Long labels wrap to two lines, then truncate with an ellipsis.
 
 <TabsVertical>
   <Tab label="Dashboard" />
@@ -449,7 +487,8 @@ Long labels wrap to two lines before truncating with an ellipsis.
 
 ### Icons
 
-Set `icon` on a tab to render an icon before the label. The icon stays aligned to the first line when the label truncates to two lines.
+Set icon on a tab to show an icon before the label. The icon stays aligned to
+the first line when the label wraps or truncates.
 
 <TabsVertical>
   <Tab label="Dashboard" icon={Dashboard} />
@@ -466,44 +505,7 @@ Set `icon` on a tab to render an icon before the label. The icon stays aligned t
 
 ### Skeleton
 
-Render `TabsVerticalSkeleton` as a loading state. Set `count` for the number of skeleton tabs.
+Show a loading state with TabsVerticalSkeleton. Set count to control how many
+placeholder tabs render.
 
 <TabsVerticalSkeleton count={4} />
-
-## Custom label slot
-
-Override the default slot to customize the tab label. Use `let:selected` to render
-custom content based on whether the tab is selected.
-
-<Tabs>
-  <Tab label="Tab label 1" let:selected>
-    Tab label 1 {#if selected}(selected){/if}
-  </Tab>
-  <Tab label="Tab label 2" let:selected>
-    Tab label 2 {#if selected}(selected){/if}
-  </Tab>
-  <Tab label="Tab label 3" let:selected>
-    Tab label 3 {#if selected}(selected){/if}
-  </Tab>
-  <svelte:fragment slot="content">
-    <TabContent>Content 1</TabContent>
-    <TabContent>Content 2</TabContent>
-    <TabContent>Content 3</TabContent>
-  </svelte:fragment>
-</Tabs>
-
-## Skeleton
-
-Show a loading state while tabs are being prepared.
-
-### Basic
-
-Render the default skeleton variant.
-
-<TabsSkeleton count={3} />
-
-### Container
-
-Render the container skeleton variant.
-
-<TabsSkeleton type="container" count={3} />

--- a/docs/src/pages/components/Tabs.svx
+++ b/docs/src/pages/components/Tabs.svx
@@ -1,10 +1,10 @@
 ---
-components: ["Tabs", "Tab", "TabContent", "TabsSkeleton"]
+components: ["Tabs", "Tab", "TabContent", "TabsVertical", "TabsSkeleton", "TabsVerticalSkeleton"]
 description: Tabs organize content into separate views that can be switched between, with keyboard navigation, disabled states, and layout options.
 ---
 
 <script>
-  import { Tabs, Tab, TabContent, TabsSkeleton } from "carbon-components-svelte";
+  import { Tabs, Tab, TabContent, TabsVertical, TabsSkeleton, TabsVerticalSkeleton } from "carbon-components-svelte";
   import Calendar from "carbon-icons-svelte/lib/Calendar.svelte";
   import Information from "carbon-icons-svelte/lib/Information.svelte";
   import Settings from "carbon-icons-svelte/lib/Settings.svelte";
@@ -12,6 +12,8 @@ description: Tabs organize content into separate views that can be switched betw
   import Activity from "carbon-icons-svelte/lib/Activity.svelte";
   import Notification from "carbon-icons-svelte/lib/Notification.svelte";
   import Chat from "carbon-icons-svelte/lib/Chat.svelte";
+  import Dashboard from "carbon-icons-svelte/lib/Dashboard.svelte";
+  import Analytics from "carbon-icons-svelte/lib/Analytics.svelte";
 </script>
 
 ## Basic
@@ -380,6 +382,93 @@ and optional secondary line (for example, counts or status).
     <TabContent>Settings content</TabContent>
   </svelte:fragment>
 </Tabs>
+
+## Vertical
+
+`TabsVertical` stacks the tabs in a column to the left of the panel on `md` and wider screens, then switches to a horizontal, scrollable row below `md`. Compose it with the same `Tab` and `TabContent` building blocks.
+
+<TabsVertical>
+  <Tab label="Dashboard" />
+  <Tab label="Monitoring" />
+  <Tab label="Activity" />
+  <Tab label="Settings" />
+  <svelte:fragment slot="content">
+    <TabContent>Content 1</TabContent>
+    <TabContent>Content 2</TabContent>
+    <TabContent>Content 3</TabContent>
+    <TabContent>Content 4</TabContent>
+  </svelte:fragment>
+</TabsVertical>
+
+### Selected
+
+Set `selected` to control the selected tab index. Bind to `selected` for a two-way binding that updates as the user switches tabs.
+
+<TabsVertical selected={1}>
+  <Tab label="Dashboard" />
+  <Tab label="Monitoring" />
+  <Tab label="Activity" />
+  <svelte:fragment slot="content">
+    <TabContent>Content 1</TabContent>
+    <TabContent>Content 2</TabContent>
+    <TabContent>Content 3</TabContent>
+  </svelte:fragment>
+</TabsVertical>
+
+### Disabled
+
+Set `disabled` on a tab to prevent interaction. Keyboard navigation skips disabled tabs.
+
+<TabsVertical>
+  <Tab label="Dashboard" />
+  <Tab label="Monitoring" disabled />
+  <Tab label="Activity" />
+  <Tab label="Settings" disabled />
+  <svelte:fragment slot="content">
+    <TabContent>Content 1</TabContent>
+    <TabContent>Content 2</TabContent>
+    <TabContent>Content 3</TabContent>
+    <TabContent>Content 4</TabContent>
+  </svelte:fragment>
+</TabsVertical>
+
+### Truncated labels
+
+Long labels wrap to two lines before truncating with an ellipsis.
+
+<TabsVertical>
+  <Tab label="Dashboard" />
+  <Tab label="Extra long label that will go two lines then truncate when it gets too long" />
+  <Tab label="Activity" />
+  <svelte:fragment slot="content">
+    <TabContent>Content 1</TabContent>
+    <TabContent>Content 2</TabContent>
+    <TabContent>Content 3</TabContent>
+  </svelte:fragment>
+</TabsVertical>
+
+### Icons
+
+Set `icon` on a tab to render an icon before the label. The icon stays aligned to the first line when the label truncates to two lines.
+
+<TabsVertical>
+  <Tab label="Dashboard" icon={Dashboard} />
+  <Tab label="Activity" icon={Activity} />
+  <Tab label="Analyze trends across every region and team" icon={Analytics} />
+  <Tab label="Settings" icon={Settings} />
+  <svelte:fragment slot="content">
+    <TabContent>Content 1</TabContent>
+    <TabContent>Content 2</TabContent>
+    <TabContent>Content 3</TabContent>
+    <TabContent>Content 4</TabContent>
+  </svelte:fragment>
+</TabsVertical>
+
+### Skeleton
+
+Render `TabsVerticalSkeleton` as a loading state. Set `count` for the number of skeleton tabs.
+
+<TabsVerticalSkeleton count={4} />
 
 ## Custom label slot
 

--- a/src/Tabs/TabsVertical.svelte
+++ b/src/Tabs/TabsVertical.svelte
@@ -1,0 +1,231 @@
+<script>
+  /**
+   * @event {number} change
+   */
+
+  /**
+   * Specify the selected tab index.
+   * @bindable writable
+   */
+  export let selected = 0;
+
+  import { afterUpdate, createEventDispatcher, setContext, tick } from "svelte";
+  import { derived, writable } from "svelte/store";
+  import { breakpointObserver } from "../Breakpoint/breakpointObserver.js";
+  import { keyBy } from "../utils/keyBy.js";
+  import { rovingFocus } from "../utils/rovingFocus.js";
+  import { syncDomOrder } from "../utils/syncDomOrder.js";
+
+  const dispatch = createEventDispatcher();
+
+  /**
+   * @type {import("svelte/store").Writable<ReadonlyArray<{ id: string; label: string; disabled: boolean; hasSecondaryLabel: boolean; index: number }>>}
+   */
+  const tabs = writable([]);
+  const tabsById = derived(tabs, (_) => keyBy(_));
+  /**
+   * @type {import("svelte/store").Writable<string | undefined>}
+   */
+  const selectedTab = writable(undefined);
+  /**
+   * @type {import("svelte/store").Writable<ReadonlyArray<{ id: string; index: number }>>}
+   */
+  const content = writable([]);
+  /**
+   * @type {import("svelte/store").Readable<Record<string, { id: string; index: number }>>}
+   */
+  const contentById = derived(content, (_) => keyBy(_));
+  /**
+   * @type {import("svelte/store").Writable<string | undefined>}
+   */
+  const selectedContent = writable(undefined);
+
+  // Vertical tabs are always the contained type, so a secondary label renders
+  // whenever any tab provides one.
+  const hasSecondaryLabel = derived(tabs, (_) =>
+    _.some((tab) => tab.hasSecondaryLabel),
+  );
+
+  // Below `md` the tabs switch from a vertical column to a horizontal,
+  // scrollable row (Carbon React vertical-tabs responsive design).
+  const belowMd = breakpointObserver().smallerThan("md");
+
+  // Vertical tabs do not support the auto-width, full-width, dismissible, or
+  // icon-only variants. These stores satisfy the shared `Tab` context contract.
+  const useAutoWidth = writable(false);
+  const useFullWidth = writable(false);
+  const useDismissible = writable(false);
+  const useIconOnly = writable(false);
+  const activeTooltip = writable(undefined);
+
+  let refTabList = null;
+  let refRoot = null;
+
+  // Flag to trigger DOM reordering only when tabs change.
+  // This is necessary to avoid infinite loops in Svelte 5.
+  let needsDomSync = false;
+
+  /**
+   * @type {(data: { id: string; label: string; disabled: boolean; hasSecondaryLabel: boolean }) => void}
+   */
+  function add(data) {
+    needsDomSync = true;
+    tabs.update((_) => [..._, { ...data, index: _.length }]);
+  }
+
+  /**
+   * @type {(id: string) => void}
+   */
+  function remove(id) {
+    needsDomSync = true;
+    tabs.update((_) => _.filter((tab) => tab.id !== id));
+  }
+
+  /**
+   * @type {(data: { id: string }) => void}
+   */
+  function addContent(data) {
+    needsDomSync = true;
+    content.update((_) => [..._, { ...data, index: _.length }]);
+  }
+
+  /**
+   * @type {(id: string) => void}
+   */
+  function removeContent(id) {
+    needsDomSync = true;
+    content.update((_) => _.filter((item) => item.id !== id));
+  }
+
+  /**
+   * @type {(id: string) => void}
+   */
+  function update(id) {
+    currentIndex = $tabsById[id].index;
+  }
+
+  // Vertical tabs are never dismissible; this no-op satisfies the `Tab` context.
+  function dismiss() {}
+
+  /**
+   * Move selection/focus to a tab at an absolute index. Roving focus resolves
+   * the index (skipping disabled, wrapping); selection follows focus.
+   * @type {(index: number) => Promise<void>}
+   */
+  async function selectTab(index) {
+    if (index === currentIndex) return;
+
+    currentIndex = index;
+
+    await tick();
+    const activeTab = refTabList?.querySelectorAll("[role='tab']")[index];
+    activeTab?.focus();
+  }
+
+  setContext("carbon:Tabs", {
+    tabs,
+    contentById,
+    selectedTab,
+    selectedContent,
+    activeTooltip,
+    iconOnly: useIconOnly,
+    belowMd,
+    useAutoWidth,
+    useFullWidth,
+    useDismissible,
+    hasSecondaryLabel,
+    add,
+    remove,
+    addContent,
+    removeContent,
+    update,
+    dismiss,
+  });
+
+  afterUpdate(() => {
+    // Sync DOM order with stores only when tabs are added/removed.
+    // This avoids infinite loops in Svelte 5 by not running on every update.
+    if (needsDomSync && refTabList) {
+      needsDomSync = false;
+
+      tabs.update((currentTabs) =>
+        syncDomOrder({
+          root: refTabList,
+          selector: "[role='tab']",
+          items: currentTabs,
+        }),
+      );
+
+      if (refRoot) {
+        content.update((currentContent) =>
+          syncDomOrder({
+            root: refRoot,
+            selector: "[role='tabpanel']",
+            items: currentContent,
+          }),
+        );
+      }
+    }
+
+    if (selected !== currentIndex) {
+      selected = currentIndex;
+    }
+
+    if (prevIndex > -1 && prevIndex !== currentIndex) {
+      dispatch("change", currentIndex);
+    }
+
+    prevIndex = currentIndex;
+  });
+
+  let currentIndex = selected;
+  let prevIndex = -1;
+
+  $: currentIndex = selected;
+  $: currentTab = $tabs[currentIndex] || undefined;
+  $: currentContent = $content[currentIndex] || undefined;
+  $: {
+    if (currentTab) {
+      selectedTab.set(currentTab.id);
+    }
+
+    if (currentContent) {
+      selectedContent.set(currentContent.id);
+    }
+  }
+  // Roving focus follows the visual orientation: arrow Up/Down in the vertical
+  // column, arrow Left/Right in the horizontal row below `md`.
+  $: orientation = $belowMd ? "horizontal" : "vertical";
+</script>
+
+<div bind:this={refRoot} class:bx--tabs--vertical-container={true}>
+  <div
+    role="navigation"
+    class:bx--tabs={true}
+    class:bx--tabs--vertical={true}
+    class:bx--tabs--tall={$hasSecondaryLabel}
+    {...$$restProps}
+  >
+    <!-- svelte-ignore a11y-no-noninteractive-element-to-interactive-role -->
+    <ul
+      bind:this={refTabList}
+      role="tablist"
+      aria-orientation={orientation}
+      use:rovingFocus={{
+        selector: "[role='tab']",
+        orientation,
+        skipDisabled: true,
+        getActiveIndex: () => currentIndex,
+        onMove: (index, event) => {
+          // Prevent the arrow keys from also scrolling the page.
+          event.preventDefault();
+          selectTab(index);
+        },
+      }}
+      class:bx--tabs__nav={true}
+    >
+      <slot />
+    </ul>
+  </div>
+  <slot name="content" />
+</div>

--- a/src/Tabs/TabsVerticalSkeleton.svelte
+++ b/src/Tabs/TabsVerticalSkeleton.svelte
@@ -1,0 +1,27 @@
+<script>
+  /** Specify the number of tabs to render */
+  export let count = 4;
+</script>
+
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
+<!-- svelte-ignore a11y-no-static-element-interactions -->
+<div class:bx--tabs--vertical-container={true}>
+  <div
+    class:bx--tabs={true}
+    class:bx--tabs--vertical={true}
+    class:bx--skeleton={true}
+    {...$$restProps}
+    on:click
+    on:mouseover
+    on:mouseenter
+    on:mouseleave
+  >
+    <ul class:bx--tabs__nav={true}>
+      {#each Array.from({ length: count }, (_, i) => i) as item (item)}
+        <li class:bx--tabs__nav-item={true}>
+          <div class:bx--tabs__nav-link={true}><span></span></div>
+        </li>
+      {/each}
+    </ul>
+  </div>
+</div>

--- a/src/Tabs/index.js
+++ b/src/Tabs/index.js
@@ -2,3 +2,4 @@ export { default as Tab } from "./Tab.svelte";
 export { default as TabContent } from "./TabContent.svelte";
 export { default as Tabs } from "./Tabs.svelte";
 export { default as TabsSkeleton } from "./TabsSkeleton.svelte";
+export { default as TabsVertical } from "./TabsVertical.svelte";

--- a/src/Tabs/index.js
+++ b/src/Tabs/index.js
@@ -3,3 +3,4 @@ export { default as TabContent } from "./TabContent.svelte";
 export { default as Tabs } from "./Tabs.svelte";
 export { default as TabsSkeleton } from "./TabsSkeleton.svelte";
 export { default as TabsVertical } from "./TabsVertical.svelte";
+export { default as TabsVerticalSkeleton } from "./TabsVerticalSkeleton.svelte";

--- a/src/index.js
+++ b/src/index.js
@@ -147,6 +147,7 @@ export { default as Tab } from "./Tabs/Tab.svelte";
 export { default as TabContent } from "./Tabs/TabContent.svelte";
 export { default as Tabs } from "./Tabs/Tabs.svelte";
 export { default as TabsSkeleton } from "./Tabs/TabsSkeleton.svelte";
+export { default as TabsVertical } from "./Tabs/TabsVertical.svelte";
 export { default as SelectableTag } from "./Tag/SelectableTag.svelte";
 export { default as Tag } from "./Tag/Tag.svelte";
 export { default as TagSkeleton } from "./Tag/TagSkeleton.svelte";

--- a/src/index.js
+++ b/src/index.js
@@ -148,6 +148,7 @@ export { default as TabContent } from "./Tabs/TabContent.svelte";
 export { default as Tabs } from "./Tabs/Tabs.svelte";
 export { default as TabsSkeleton } from "./Tabs/TabsSkeleton.svelte";
 export { default as TabsVertical } from "./Tabs/TabsVertical.svelte";
+export { default as TabsVerticalSkeleton } from "./Tabs/TabsVerticalSkeleton.svelte";
 export { default as SelectableTag } from "./Tag/SelectableTag.svelte";
 export { default as Tag } from "./Tag/Tag.svelte";
 export { default as TagSkeleton } from "./Tag/TagSkeleton.svelte";

--- a/tests/Tabs/TabsVertical.test.svelte
+++ b/tests/Tabs/TabsVertical.test.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+  import Tab from "carbon-components-svelte/Tabs/Tab.svelte";
+  import TabContent from "carbon-components-svelte/Tabs/TabContent.svelte";
+  import TabsVertical from "carbon-components-svelte/Tabs/TabsVertical.svelte";
+  import type { ComponentProps } from "svelte";
+
+  export let selected = 0;
+  export let icon: ComponentProps<Tab>["icon"] = undefined;
+</script>
+
+<TabsVertical
+  {selected}
+  on:change={({ detail }) => {
+    console.log("change event", detail);
+  }}
+>
+  <Tab label="Tab 1" {icon} />
+  <Tab label="Tab 2" disabled />
+  <Tab label="Tab 3" />
+  <Tab label="Tab 4" />
+  <svelte:fragment slot="content">
+    <TabContent>Content 1</TabContent>
+    <TabContent>Content 2</TabContent>
+    <TabContent>Content 3</TabContent>
+    <TabContent>Content 4</TabContent>
+  </svelte:fragment>
+</TabsVertical>

--- a/tests/Tabs/TabsVertical.test.ts
+++ b/tests/Tabs/TabsVertical.test.ts
@@ -2,6 +2,7 @@ import { fireEvent, render, screen } from "@testing-library/svelte";
 import Calendar from "../../src/icons/Calendar.svelte";
 import { user } from "../utils/user";
 import TabsVertical from "./TabsVertical.test.svelte";
+import TabsVerticalSkeleton from "./TabsVerticalSkeleton.test.svelte";
 
 describe("TabsVertical", () => {
   let consoleLog: Console["log"];
@@ -100,5 +101,28 @@ describe("TabsVertical", () => {
     expect(
       navLink?.querySelector(".bx--tabs__nav-item--icon svg"),
     ).toBeInTheDocument();
+  });
+});
+
+describe("TabsVerticalSkeleton", () => {
+  it("should render the vertical skeleton with the default count", () => {
+    const { container } = render(TabsVerticalSkeleton);
+
+    const skeleton = container.querySelector(".bx--tabs--vertical");
+    expect(skeleton).toBeInTheDocument();
+    expect(skeleton).toHaveClass("bx--skeleton");
+    expect(container.querySelectorAll(".bx--tabs__nav-item")).toHaveLength(4);
+  });
+
+  it("should render a custom count", () => {
+    const { container } = render(TabsVerticalSkeleton, { props: { count: 6 } });
+
+    expect(container.querySelectorAll(".bx--tabs__nav-item")).toHaveLength(6);
+  });
+
+  it("should handle a zero count", () => {
+    const { container } = render(TabsVerticalSkeleton, { props: { count: 0 } });
+
+    expect(container.querySelectorAll(".bx--tabs__nav-item")).toHaveLength(0);
   });
 });

--- a/tests/Tabs/TabsVertical.test.ts
+++ b/tests/Tabs/TabsVertical.test.ts
@@ -1,0 +1,104 @@
+import { fireEvent, render, screen } from "@testing-library/svelte";
+import Calendar from "../../src/icons/Calendar.svelte";
+import { user } from "../utils/user";
+import TabsVertical from "./TabsVertical.test.svelte";
+
+describe("TabsVertical", () => {
+  let consoleLog: Console["log"];
+
+  beforeEach(() => {
+    consoleLog = vi.spyOn(console, "log");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should render with default props", () => {
+    render(TabsVertical);
+
+    expect(screen.getByRole("navigation")).toHaveClass("bx--tabs--vertical");
+
+    expect(screen.getByRole("tab", { name: "Tab 1" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(screen.getByText("Content 1")).toBeVisible();
+    expect(screen.getByText("Content 2")).not.toBeVisible();
+  });
+
+  it("should render a vertically-oriented tablist", () => {
+    render(TabsVertical);
+
+    expect(screen.getByRole("tablist")).toHaveAttribute(
+      "aria-orientation",
+      "vertical",
+    );
+  });
+
+  it("should select the initial tab from the selected prop", () => {
+    render(TabsVertical, { props: { selected: 2 } });
+
+    expect(screen.getByRole("tab", { name: "Tab 3" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(screen.getByText("Content 3")).toBeVisible();
+  });
+
+  it("should change tab on click and dispatch change", async () => {
+    render(TabsVertical);
+
+    const tab3 = screen.getByRole("tab", { name: "Tab 3" });
+    await user.click(tab3);
+
+    expect(tab3).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByText("Content 3")).toBeVisible();
+    expect(consoleLog).toHaveBeenCalledWith("change event", 2);
+  });
+
+  it("should not select disabled tabs", async () => {
+    render(TabsVertical);
+
+    const tab2 = screen.getByRole("tab", { name: "Tab 2" });
+    expect(tab2).toHaveAttribute("aria-disabled", "true");
+    await user.click(tab2);
+
+    expect(tab2).toHaveAttribute("aria-selected", "false");
+    expect(screen.getByText("Content 1")).toBeVisible();
+  });
+
+  it("should navigate with arrow up/down keys, skipping disabled tabs", async () => {
+    render(TabsVertical);
+
+    const tab1 = screen.getByRole("tab", { name: "Tab 1" });
+    await user.click(tab1);
+
+    // Tab 2 is disabled, so ArrowDown moves to Tab 3.
+    await user.keyboard("{ArrowDown}");
+    expect(screen.getByRole("tab", { name: "Tab 3" })).toHaveFocus();
+    expect(consoleLog).toHaveBeenCalledWith("change event", 2);
+
+    await user.keyboard("{ArrowUp}");
+    expect(tab1).toHaveFocus();
+    expect(consoleLog).toHaveBeenCalledWith("change event", 0);
+  });
+
+  it("should prevent the default scroll on arrow navigation", async () => {
+    render(TabsVertical);
+
+    const tab1 = screen.getByRole("tab", { name: "Tab 1" });
+    expect(await fireEvent.keyDown(tab1, { key: "ArrowDown" })).toBe(false);
+    expect(await fireEvent.keyDown(tab1, { key: "ArrowUp" })).toBe(false);
+  });
+
+  it("should render an icon for the tab", () => {
+    const { container } = render(TabsVertical, { props: { icon: Calendar } });
+
+    const navLink = container.querySelector(".bx--tabs__nav-link--icon");
+    expect(navLink).toBeInTheDocument();
+    expect(
+      navLink?.querySelector(".bx--tabs__nav-item--icon svg"),
+    ).toBeInTheDocument();
+  });
+});

--- a/tests/Tabs/TabsVerticalSkeleton.test.svelte
+++ b/tests/Tabs/TabsVerticalSkeleton.test.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  import TabsVerticalSkeleton from "carbon-components-svelte/Tabs/TabsVerticalSkeleton.svelte";
+
+  export let count = 4;
+</script>
+
+<TabsVerticalSkeleton {count} />


### PR DESCRIPTION
Closes #2726 

Adds the vertical variant, with support for icons.

---

<img width="959" height="292" alt="Screenshot 2026-06-15 at 8 56 55 PM" src="https://github.com/user-attachments/assets/fc7ed307-ae0c-40e9-bc14-abbff0bbe5c1" />
