### PR TITLE
chore(deps-dev): bump @playwright/test to 1.61

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -111,7 +111,7 @@ jobs:
     # Official image includes Chromium/Firefox/WebKit + system deps
     # Bump tag with @playwright/test in bun.lock.
     container:
-      image: mcr.microsoft.com/playwright:v1.59.0-noble
+      image: mcr.microsoft.com/playwright:v1.61.0-noble
       options: --ipc=host --init
     timeout-minutes: 15
     env:

--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "2.5.0",
-        "@playwright/test": "^1.59.0",
+        "@playwright/test": "^1.61.0",
         "@sveltejs/vite-plugin-svelte": "^7.1.2",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/svelte": "^5.3.1",
@@ -191,7 +191,7 @@
 
     "@parcel/watcher-win32-x64": ["@parcel/watcher-win32-x64@2.5.1", "", { "os": "win32", "cpu": "x64" }, "sha512-9lHBdJITeNR++EvSQVUcaZoWupyHfXe1jZvGZ06O/5MflPcuPLtEphScIBL+AiCWBO46tDSHzWyD0uDmmZqsgA=="],
 
-    "@playwright/test": ["@playwright/test@1.59.0", "", { "dependencies": { "playwright": "1.59.0" }, "bin": { "playwright": "cli.js" } }, "sha512-TOA5sTLd49rTDaZpYpvCQ9hGefHQq/OYOyCVnGqS2mjMfX+lGZv2iddIJd0I48cfxqSPttS9S3OuLKyylHcO1w=="],
+    "@playwright/test": ["@playwright/test@1.61.0", "", { "dependencies": { "playwright": "1.61.0" }, "bin": { "playwright": "cli.js" } }, "sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA=="],
 
     "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.3", "", { "os": "android", "cpu": "arm64" }, "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw=="],
 
@@ -453,9 +453,9 @@
 
     "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
-    "playwright": ["playwright@1.59.0", "", { "dependencies": { "playwright-core": "1.59.0" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-wihGScriusvATUxmhfENxg0tj1vHEFeIwxlnPFKQTOQVd7aG08mUfvvniRP/PtQOC+2Bs52kBOC/Up1jTXeIbw=="],
+    "playwright": ["playwright@1.61.0", "", { "dependencies": { "playwright-core": "1.61.0" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ=="],
 
-    "playwright-core": ["playwright-core@1.59.0", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-PW/X/IoZ6BMUUy8rpwHEZ8Kc0IiLIkgKYGNFaMs5KmQhcfLILNx9yCQD0rnWeWfz1PNeqcFP1BsihQhDOBCwZw=="],
+    "playwright-core": ["playwright-core@1.61.0", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA=="],
 
     "postcss": ["postcss@8.5.15", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A=="],
 

--- a/e2e/local-storage.test.ts
+++ b/e2e/local-storage.test.ts
@@ -12,19 +12,12 @@ test.describe("LocalStorage", () => {
   }) => {
     await expect(page.getByTestId("display-value")).toHaveText("initial");
 
-    const stored = await page.evaluate(
-      (key) => localStorage.getItem(key),
-      STORAGE_KEY,
-    );
-    expect(stored).toBe("initial");
+    expect(await page.localStorage.getItem(STORAGE_KEY)).toBe("initial");
   });
 
   test("loads existing value from localStorage on mount", async ({ page }) => {
     await page.goto("/local-storage.html");
-    await page.evaluate(({ key, value }) => localStorage.setItem(key, value), {
-      key: STORAGE_KEY,
-      value: "pre-loaded",
-    });
+    await page.localStorage.setItem(STORAGE_KEY, "pre-loaded");
     await page.reload();
 
     await expect(page.getByTestId("display-value")).toHaveText("pre-loaded");
@@ -34,11 +27,7 @@ test.describe("LocalStorage", () => {
     await page.getByTestId("value-input").fill("user-edited");
     await expect(page.getByTestId("display-value")).toHaveText("user-edited");
 
-    const stored = await page.evaluate(
-      (key) => localStorage.getItem(key),
-      STORAGE_KEY,
-    );
-    expect(stored).toBe("user-edited");
+    expect(await page.localStorage.getItem(STORAGE_KEY)).toBe("user-edited");
   });
 
   test("persists across page reload", async ({ page }) => {
@@ -54,26 +43,15 @@ test.describe("LocalStorage", () => {
     await page.getByTestId("value-input").fill("to-be-cleared");
     await page.getByTestId("clear-item").click();
 
-    const stored = await page.evaluate(
-      (key) => localStorage.getItem(key),
-      STORAGE_KEY,
-    );
-    expect(stored).toBeNull();
+    expect(await page.localStorage.getItem(STORAGE_KEY)).toBeNull();
   });
 
   test("clearAll removes all localStorage", async ({ page }) => {
     await page.getByTestId("value-input").fill("to-be-cleared");
-    await page.evaluate(() => localStorage.setItem("other-key", "other"));
+    await page.localStorage.setItem("other-key", "other");
     await page.getByTestId("clear-all").click();
 
-    const ourStored = await page.evaluate(
-      (key) => localStorage.getItem(key),
-      STORAGE_KEY,
-    );
-    const otherStored = await page.evaluate(() =>
-      localStorage.getItem("other-key"),
-    );
-    expect(ourStored).toBeNull();
-    expect(otherStored).toBeNull();
+    expect(await page.localStorage.getItem(STORAGE_KEY)).toBeNull();
+    expect(await page.localStorage.getItem("other-key")).toBeNull();
   });
 });

--- a/e2e/session-storage.test.ts
+++ b/e2e/session-storage.test.ts
@@ -12,21 +12,14 @@ test.describe("SessionStorage", () => {
   }) => {
     await expect(page.getByTestId("display-value")).toHaveText("initial");
 
-    const stored = await page.evaluate(
-      (key) => sessionStorage.getItem(key),
-      STORAGE_KEY,
-    );
-    expect(stored).toBe("initial");
+    expect(await page.sessionStorage.getItem(STORAGE_KEY)).toBe("initial");
   });
 
   test("loads existing value from sessionStorage on mount", async ({
     page,
   }) => {
     await page.goto("/session-storage.html");
-    await page.evaluate(
-      ({ key, value }) => sessionStorage.setItem(key, value),
-      { key: STORAGE_KEY, value: "pre-loaded" },
-    );
+    await page.sessionStorage.setItem(STORAGE_KEY, "pre-loaded");
     await page.reload();
 
     await expect(page.getByTestId("display-value")).toHaveText("pre-loaded");
@@ -36,11 +29,7 @@ test.describe("SessionStorage", () => {
     await page.getByTestId("value-input").fill("user-edited");
     await expect(page.getByTestId("display-value")).toHaveText("user-edited");
 
-    const stored = await page.evaluate(
-      (key) => sessionStorage.getItem(key),
-      STORAGE_KEY,
-    );
-    expect(stored).toBe("user-edited");
+    expect(await page.sessionStorage.getItem(STORAGE_KEY)).toBe("user-edited");
   });
 
   test("persists across page reload", async ({ page }) => {
@@ -56,26 +45,15 @@ test.describe("SessionStorage", () => {
     await page.getByTestId("value-input").fill("to-be-cleared");
     await page.getByTestId("clear-item").click();
 
-    const stored = await page.evaluate(
-      (key) => sessionStorage.getItem(key),
-      STORAGE_KEY,
-    );
-    expect(stored).toBeNull();
+    expect(await page.sessionStorage.getItem(STORAGE_KEY)).toBeNull();
   });
 
   test("clearAll removes all sessionStorage", async ({ page }) => {
     await page.getByTestId("value-input").fill("to-be-cleared");
-    await page.evaluate(() => sessionStorage.setItem("other-key", "other"));
+    await page.sessionStorage.setItem("other-key", "other");
     await page.getByTestId("clear-all").click();
 
-    const ourStored = await page.evaluate(
-      (key) => sessionStorage.getItem(key),
-      STORAGE_KEY,
-    );
-    const otherStored = await page.evaluate(() =>
-      sessionStorage.getItem("other-key"),
-    );
-    expect(ourStored).toBeNull();
-    expect(otherStored).toBeNull();
+    expect(await page.sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+    expect(await page.sessionStorage.getItem("other-key")).toBeNull();
   });
 });

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.5.0",
-    "@playwright/test": "^1.59.0",
+    "@playwright/test": "^1.61.0",
     "@sveltejs/vite-plugin-svelte": "^7.1.2",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/svelte": "^5.3.1",


### PR DESCRIPTION
Bumps `@playwright/test` to 1.61 and the CI Playwright container image to `v1.61.0-noble` to match.

Refactors the localStorage and sessionStorage e2e tests to use the native `page.localStorage` and `page.sessionStorage` methods added in 1.61, replacing the previous `page.evaluate` closures.

Verified locally: both storage suites pass across chromium, firefox, and webkit (36 passed).