### PR TITLE
perf(data-table): use Set for O(1) lookups for expanded rows

### DIFF
--- a/e2e/data-table.test.ts
+++ b/e2e/data-table.test.ts
@@ -54,6 +54,22 @@ test.describe("DataTable", () => {
     );
   });
 
+  test("expandable: supports row ids matching object prototype properties", async ({
+    page,
+  }) => {
+    const table = page.getByTestId("data-table-prototype-id");
+    const detail = table.getByTestId("prototype-id-detail");
+
+    await expect(table).toBeVisible();
+    await expect(detail).toBeHidden();
+
+    await table.getByRole("button", { name: "Expand current row" }).click();
+    await expect(detail).toHaveText("Extra row: Prototype ID");
+
+    await table.getByRole("button", { name: "Collapse current row" }).click();
+    await expect(detail).toBeHidden();
+  });
+
   test("batch selection: select all checks every row", async ({ page }) => {
     const batch = page.getByTestId("data-table-batch");
     await batch

--- a/e2e/fixtures/DataTableFixture.svelte
+++ b/e2e/fixtures/DataTableFixture.svelte
@@ -28,7 +28,11 @@
   const expandRows = [
     { id: "e1", name: "First" },
     { id: "e2", name: "Second" },
+    { id: "e3", name: "Third" },
+    { id: "e4", name: "Fourth" },
   ];
+
+  const prototypeIdRows = [{ id: "toString", name: "Prototype ID" }];
 
   const batchHeaders = [{ key: "name", value: "Product" }];
 
@@ -50,6 +54,14 @@
   <DataTable expandable headers={expandHeaders} rows={expandRows}>
     <svelte:fragment slot="expandedRow" let:row>
       <p data-testid="expanded-detail">Extra row: {row.name}</p>
+    </svelte:fragment>
+  </DataTable>
+</div>
+
+<div data-testid="data-table-prototype-id">
+  <DataTable expandable headers={expandHeaders} rows={prototypeIdRows}>
+    <svelte:fragment slot="expandedRow" let:row>
+      <p data-testid="prototype-id-detail">Extra row: {row.name}</p>
     </svelte:fragment>
   </DataTable>
 </div>

--- a/src/DataTable/DataTable.svelte
+++ b/src/DataTable/DataTable.svelte
@@ -511,10 +511,7 @@
   let expanded = false;
   let parentRowId = null;
 
-  $: expandedRows = expandedRowIds.reduce((a, id) => {
-    a[id] = true;
-    return a;
-  }, {});
+  $: expandedRowIdsSet = new Set(expandedRowIds);
 
   let prevBatchSelected = [];
   $: if (
@@ -960,7 +957,7 @@
           {#each rowsToRender as row, index (row.id)}
             {@const actualIndex = virtualData.startIndex + index}
             {@const isSelected = selectedRowIdsSet.has(row.id)}
-            {@const isExpanded = !!expandedRows[row.id]}
+            {@const isExpanded = expandedRowIdsSet.has(row.id)}
             {@const isHighlighted = highlightedRowIdsSet.has(row.id)}
             {@const rowClassValue =
               typeof rowClass === "function"
@@ -1000,7 +997,7 @@
                   class="bx--table-expand"
                   headers="expand"
                   data-previous-value={!nonExpandableRowIdsSet.has(row.id) &&
-                  expandedRows[row.id]
+                  expandedRowIdsSet.has(row.id)
                     ? "collapsed"
                     : undefined}
                 >
@@ -1009,11 +1006,11 @@
                       type="button"
                       class:bx--table-expand__button={true}
                       aria-controls="{id}-expandable-row-{row.id}"
-                      aria-label={expandedRows[row.id]
+                      aria-label={expandedRowIdsSet.has(row.id)
                         ? "Collapse current row"
                         : "Expand current row"}
                       on:click|stopPropagation={() => {
-                        const rowExpanded = !!expandedRows[row.id];
+                        const rowExpanded = expandedRowIdsSet.has(row.id);
 
                         expandedRowIds = rowExpanded
                           ? expandedRowIds.filter((id) => id !== row.id)
@@ -1027,7 +1024,7 @@
                     >
                       <slot
                         name="expandIcon"
-                        expanded={!!expandedRows[row.id]}
+                        expanded={expandedRowIdsSet.has(row.id)}
                         {row}
                         props={expandIconProps}
                       >
@@ -1147,7 +1144,8 @@
                   parentRowId = null;
                 }}
               >
-                {#if expandedRows[row.id] && !nonExpandableRowIdsSet.has(row.id)}
+                {#if expandedRowIdsSet.has(row.id) &&
+                !nonExpandableRowIdsSet.has(row.id)}
                   <TableCell
                     colspan={selectable
                       ? headers.length + 2
@@ -1179,7 +1177,7 @@
           <!-- Non-virtualized: render all rows normally -->
           {#each rowsToRender as row, index (row.id)}
             {@const isSelected = selectedRowIdsSet.has(row.id)}
-            {@const isExpanded = !!expandedRows[row.id]}
+            {@const isExpanded = expandedRowIdsSet.has(row.id)}
             {@const isExpandable = !nonExpandableRowIdsSet.has(row.id)}
             {@const isSelectable = !nonSelectableRowIdsSet.has(row.id)}
             {@const isHighlighted = highlightedRowIdsSet.has(row.id)}


### PR DESCRIPTION
Optimized datatable variable `expandedRowIdsSet` to use a Set instead of a plain object. Increasing performance from linear O(n) to constant O(1) lookup time. This change enhances readability and cleaness for the use case needed for this variable, since a set is more appropiate than a plain object.

Included a new E2E test to verify this new functionality.

## Verification

1. Expand all rows

<img width="1272" height="295" alt="image" src="https://github.com/user-attachments/assets/ccdb35b0-853d-4986-82cb-f1a50930284e" />

2. Contract them

<img width="1273" height="167" alt="image" src="https://github.com/user-attachments/assets/2555b7e7-61a0-45d9-b7b0-2c5c234587dd" />

3. Expand a few rows

<img width="1271" height="232" alt="image" src="https://github.com/user-attachments/assets/4ff9522c-6b58-49f5-a8b8-eb46ddb23770" />

4. Contract them

<img width="1268" height="164" alt="image" src="https://github.com/user-attachments/assets/dab6a199-c12d-48d1-9a76-3ea65341c344" />


 