### PR TITLE
feat(list-box): add xs size to dropdown, combo box, and multi-select

### DIFF
--- a/css/_list-box-xs.scss
+++ b/css/_list-box-xs.scss
@@ -1,0 +1,45 @@
+// xs (24px) list-box heights for Dropdown, ComboBox, and MultiSelect.
+// carbon-components v10 stops at sm; backported from
+// https://github.com/carbon-design-system/carbon/pull/22439
+
+@import "carbon-components/scss/globals/scss/vars";
+@import "carbon-components/scss/globals/scss/helper-mixins";
+@import "carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/import-once/import-once";
+
+/// 24px list-box size for Dropdown, ComboBox, and MultiSelect.
+/// Follows the same sm/lg override pattern in carbon-components v10.
+/// @access private
+/// @group components
+@mixin list-box-xs {
+  .#{$prefix}--list-box--xs {
+    block-size: to-rem(24px);
+    max-block-size: to-rem(24px);
+  }
+
+  .#{$prefix}--list-box--expanded.#{$prefix}--list-box--xs
+    .#{$prefix}--list-box__menu {
+    // 24px item height * 5.5 items shown
+    max-block-size: to-rem(132px);
+  }
+
+  .#{$prefix}--list-box--xs .#{$prefix}--list-box__menu-item,
+  .#{$prefix}--list-box--xs .#{$prefix}--list-box__menu-item__option {
+    block-size: to-rem(24px);
+  }
+
+  // 3px padding centers the 1rem line in 24px (same math as sm/lg).
+  .#{$prefix}--list-box--xs .#{$prefix}--list-box__menu-item__option {
+    padding-block: to-rem(3px);
+  }
+
+  .#{$prefix}--list-box--up.#{$prefix}--list-box--xs
+    .#{$prefix}--list-box__menu,
+  .#{$prefix}--list-box--up.#{$prefix}--dropdown--xs
+    .#{$prefix}--list-box__menu {
+    inset-block-end: to-rem(24px);
+  }
+}
+
+@include exports("list-box-xs") {
+  @include list-box-xs;
+}

--- a/css/all.scss
+++ b/css/all.scss
@@ -107,6 +107,7 @@ $css--plex: true;
 @import "./copy-input";
 @import "./overflow-menu";
 @import "./list-box-menu-item";
+@import "./list-box-xs";
 @import "./fluid-list-box";
 @import "./fluid-combo-box";
 @import "./fluid-multiselect";

--- a/css/g10.scss
+++ b/css/g10.scss
@@ -67,6 +67,7 @@ $css--plex: true;
 @import "./copy-input";
 @import "./overflow-menu";
 @import "./list-box-menu-item";
+@import "./list-box-xs";
 @import "./fluid-list-box";
 @import "./fluid-combo-box";
 @import "./fluid-multiselect";

--- a/css/g100.scss
+++ b/css/g100.scss
@@ -67,6 +67,7 @@ $css--plex: true;
 @import "./copy-input";
 @import "./overflow-menu";
 @import "./list-box-menu-item";
+@import "./list-box-xs";
 @import "./fluid-list-box";
 @import "./fluid-combo-box";
 @import "./fluid-multiselect";

--- a/css/g80.scss
+++ b/css/g80.scss
@@ -67,6 +67,7 @@ $css--plex: true;
 @import "./copy-input";
 @import "./overflow-menu";
 @import "./list-box-menu-item";
+@import "./list-box-xs";
 @import "./fluid-list-box";
 @import "./fluid-combo-box";
 @import "./fluid-multiselect";

--- a/css/g90.scss
+++ b/css/g90.scss
@@ -67,6 +67,7 @@ $css--plex: true;
 @import "./copy-input";
 @import "./overflow-menu";
 @import "./list-box-menu-item";
+@import "./list-box-xs";
 @import "./fluid-list-box";
 @import "./fluid-combo-box";
 @import "./fluid-multiselect";

--- a/css/white.scss
+++ b/css/white.scss
@@ -67,6 +67,7 @@ $css--plex: true;
 @import "./copy-input";
 @import "./overflow-menu";
 @import "./list-box-menu-item";
+@import "./list-box-xs";
 @import "./fluid-list-box";
 @import "./fluid-combo-box";
 @import "./fluid-multiselect";

--- a/docs/src/pages/components/ComboBox.svx
+++ b/docs/src/pages/components/ComboBox.svx
@@ -295,7 +295,7 @@ Specify a custom value for `threshold` to control when virtualization activates.
 
 ### Custom item height
 
-By default, item height matches the menu row for each size: 32px (`sm`), 40px (`md`), 48px (`lg`, `xl`). Set `itemHeight` when custom slots change row height.
+By default, item height matches the menu row for each size: 24px (`xs`), 32px (`sm`), 40px (`md`), 48px (`lg`, `xl`). Set `itemHeight` when custom slots change row height.
 
 <FileSource src="/framed/ComboBox/VirtualizeItemHeight" />
 
@@ -332,6 +332,18 @@ items={[
 ## Sizes
 
 The `size` prop sets the height. The default is `medium`.
+
+### Extra-small
+
+Set `size` to `"xs"` for an extra-small combobox.
+
+<ComboBox labelText="Contact" placeholder="Select contact method"
+size="xs"
+items={[
+  {id: "0", text: "Slack"},
+  {id: "1", text: "Email"},
+  {id: "2", text: "Fax"}
+  ]}  />
 
 ### Small
 

--- a/docs/src/pages/components/Dropdown.svx
+++ b/docs/src/pages/components/Dropdown.svx
@@ -145,7 +145,7 @@ Specify a custom value for `threshold` to control when virtualization activates.
 
 ### Custom item height
 
-By default, item height matches the menu row for each size: 32px (`sm`), 40px (`md`), 48px (`lg`, `xl`). Set `itemHeight` when custom slots change row height.
+By default, item height matches the menu row for each size: 24px (`xs`), 32px (`sm`), 40px (`md`), 48px (`lg`, `xl`). Set `itemHeight` when custom slots change row height.
 
 <FileSource src="/framed/Dropdown/VirtualizeItemHeight" />
 
@@ -172,6 +172,14 @@ Set `size` to adjust the height of the dropdown. The default is medium.
 Set `size` to `"xl"` for an extra-large dropdown.
 
 <Dropdown size="xl" labelText="Contact" selectedId="0" items="{[{id: "0", text: "Slack"},
+  {id: "1", text: "Email"},
+  {id: "2", text: "Fax"}]}" />
+
+### Extra-small
+
+Set `size` to `"xs"` for an extra-small dropdown.
+
+<Dropdown size="xs" labelText="Contact" selectedId="0" items="{[{id: "0", text: "Slack"},
   {id: "1", text: "Email"},
   {id: "2", text: "Fax"}]}" />
 

--- a/docs/src/pages/components/MultiSelect.svx
+++ b/docs/src/pages/components/MultiSelect.svx
@@ -188,13 +188,23 @@ Specify a custom value for `threshold` to control when virtualization activates.
 
 ### Custom item height
 
-By default, item height matches the menu row for each size: 32px (sm), 40px (md), 48px (lg, xl). Set `itemHeight` when custom slots change row height.
+By default, item height matches the menu row for each size: 24px (xs), 32px (sm), 40px (md), 48px (lg, xl). Set `itemHeight` when custom slots change row height.
 
 <FileSource src="/framed/MultiSelect/VirtualizeItemHeight" />
 
 ## Sizes
 
 The `size` prop sets the field height. The default is medium.
+
+### Extra-small
+
+Set `size` to `"xs"` for an extra-small multiselect.
+
+<MultiSelect size="xs" labelText="Contact" label="Select contact methods..."
+    items="{[{id: "0", text: "Slack"},
+    {id: "1", text: "Email"},
+    {id: "2", text: "Fax"}]}"
+  />
 
 ### Small
 

--- a/src/ComboBox/ComboBox.svelte
+++ b/src/ComboBox/ComboBox.svelte
@@ -58,7 +58,7 @@
 
   /**
    * Set the size of the combobox.
-   * @type {"sm" | "lg" | "xl"}
+   * @type {"xs" | "sm" | "lg" | "xl"}
    */
   export let size = undefined;
 

--- a/src/Dropdown/Dropdown.svelte
+++ b/src/Dropdown/Dropdown.svelte
@@ -57,7 +57,7 @@
 
   /**
    * Specify the size of the dropdown field.
-   * @type {"sm" | "lg" | "xl"}
+   * @type {"xs" | "sm" | "lg" | "xl"}
    */
   export let size = undefined;
 
@@ -442,6 +442,7 @@
     showInvalid && "bx--dropdown--invalid",
     showWarn && "bx--dropdown--warning",
     open && "bx--dropdown--open",
+    size === "xs" && "bx--dropdown--xs",
     size === "sm" && "bx--dropdown--sm",
     size === "xl" && "bx--dropdown--xl",
     inline && "bx--dropdown--inline",

--- a/src/ListBox/ListBox.svelte
+++ b/src/ListBox/ListBox.svelte
@@ -1,7 +1,7 @@
 <script>
   /**
    * Set the size of the list box.
-   * @type {"sm" | "lg" | "xl"}
+   * @type {"xs" | "sm" | "lg" | "xl"}
    */
   export let size = undefined;
 
@@ -37,6 +37,7 @@
   tabindex="-1"
   data-invalid={invalid || undefined}
   class:bx--list-box={true}
+  class:bx--list-box--xs={size === "xs"}
   class:bx--list-box--sm={size === "sm"}
   class:bx--list-box--lg={size === "lg"}
   class:bx--list-box--xl={size === "xl"}

--- a/src/ListBox/list-box-utils.d.ts
+++ b/src/ListBox/list-box-utils.d.ts
@@ -1,5 +1,6 @@
 /** Max height values for listbox/dropdown menus by size */
 export declare const MENU_MAX_HEIGHT: Readonly<{
+  xs: string;
   sm: string;
   md: string;
   lg: string;
@@ -12,11 +13,12 @@ export declare const MENU_MAX_HEIGHT: Readonly<{
  * @returns The max height in rem units
  */
 export declare function getMenuMaxHeight(
-  size?: "sm" | "md" | "lg" | "xl",
+  size?: "xs" | "sm" | "md" | "lg" | "xl",
 ): string;
 
 /** Menu item heights (px) by size */
 export declare const MENU_ITEM_HEIGHT: Readonly<{
+  xs: number;
   sm: number;
   md: number;
   lg: number;
@@ -33,6 +35,6 @@ export declare const FLUID_MENU_ITEM_HEIGHT: number;
  * @returns The item height in pixels
  */
 export declare function getMenuItemHeight(
-  size?: "sm" | "md" | "lg" | "xl",
+  size?: "xs" | "sm" | "md" | "lg" | "xl",
   options?: { fluid?: boolean },
 ): number;

--- a/src/ListBox/list-box-utils.js
+++ b/src/ListBox/list-box-utils.js
@@ -1,8 +1,9 @@
 /**
  * Max height values for listbox/dropdown menus by size.
- * @type {Readonly<{ sm: string; md: string; lg: string; xl: string }>}
+ * @type {Readonly<{ xs: string; sm: string; md: string; lg: string; xl: string }>}
  */
 export const MENU_MAX_HEIGHT = Object.freeze({
+  xs: "8.25rem",
   sm: "11rem",
   md: "13.75rem",
   lg: "16.5rem",
@@ -11,7 +12,7 @@ export const MENU_MAX_HEIGHT = Object.freeze({
 
 /**
  * Get the max height for a listbox/dropdown menu based on size.
- * @param {"sm" | "md" | "lg" | "xl"} [size] - The size variant
+ * @param {"xs" | "sm" | "md" | "lg" | "xl"} [size] - The size variant
  * @returns {string} The max height in rem units
  */
 export function getMenuMaxHeight(size = "md") {
@@ -20,10 +21,11 @@ export function getMenuMaxHeight(size = "md") {
 
 /**
  * Menu item heights (px) by size. Matches `.bx--list-box__menu-item` in
- * carbon-components (sm 2rem, md 2.5rem, lg/xl 3rem).
- * @type {Readonly<{ sm: number; md: number; lg: number; xl: number }>}
+ * carbon-components (xs 1.5rem, sm 2rem, md 2.5rem, lg/xl 3rem).
+ * @type {Readonly<{ xs: number; sm: number; md: number; lg: number; xl: number }>}
  */
 export const MENU_ITEM_HEIGHT = Object.freeze({
+  xs: 24,
   sm: 32,
   md: 40,
   lg: 48,
@@ -39,7 +41,7 @@ export const FLUID_MENU_ITEM_HEIGHT = 64;
 
 /**
  * Get the menu item height in pixels for a listbox/dropdown.
- * @param {"sm" | "md" | "lg" | "xl"} [size] - The size variant
+ * @param {"xs" | "sm" | "md" | "lg" | "xl"} [size] - The size variant
  * @param {{ fluid?: boolean }} [options] - Pass `fluid: true` for FLUID_MENU_ITEM_HEIGHT
  * @returns {number} The item height in pixels
  */

--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -54,7 +54,7 @@
 
   /**
    * Set the size of the multiselect.
-   * @type {"sm" | "lg" | "xl"}
+   * @type {"xs" | "sm" | "lg" | "xl"}
    */
   export let size = undefined;
 

--- a/tests/ListBox/list-box-utils.test.ts
+++ b/tests/ListBox/list-box-utils.test.ts
@@ -16,6 +16,7 @@ describe("getMenuMaxHeight", () => {
   });
 
   it("returns correct value for each size", () => {
+    expect(getMenuMaxHeight("xs")).toBe("8.25rem");
     expect(getMenuMaxHeight("sm")).toBe("11rem");
     expect(getMenuMaxHeight("md")).toBe("13.75rem");
     expect(getMenuMaxHeight("lg")).toBe("16.5rem");
@@ -33,6 +34,7 @@ describe("getMenuItemHeight", () => {
   });
 
   it("returns correct value for each size", () => {
+    expect(getMenuItemHeight("xs")).toBe(24);
     expect(getMenuItemHeight("sm")).toBe(32);
     expect(getMenuItemHeight("md")).toBe(40);
     expect(getMenuItemHeight("lg")).toBe(48);


### PR DESCRIPTION
This PR adds extra-small (24px) size support to Dropdown, ComboBox, and MultiSelect. Carbon v11 introduced xs for list box components, but carbon-components v10 only goes down to sm, so this backports the 24px heights via a new SCSS partial and updated menu height constants. Each component accepts `size="xs"` on its public API. Docs examples cover the new size for all three components.