### PR TITLE
feat(tabs): `TabsVertical` supports sm/md/lg sizes

### DIFF
--- a/css/_tabs.scss
+++ b/css/_tabs.scss
@@ -1,5 +1,6 @@
 @import "carbon-components/scss/globals/scss/vars";
 @import "carbon-components/scss/globals/scss/helper-mixins";
+@import "carbon-components/scss/globals/scss/vendor/@carbon/layout/scss/generated/size";
 @import "carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/import-once/import-once";
 
 /// Tab icon styles
@@ -738,4 +739,66 @@
 
 @include exports('tabs-vertical') {
   @include tabs-vertical;
+}
+
+/// Vertical tabs size variants (Carbon v11 `size` on `TabListVertical`). Maps
+/// the layout size token to each nav item's height. At `md` and up (the column
+/// layout) `xl` equals the default vertical-tab height ($size-xl / spacing-10),
+/// so the unsized default and `size="xl"` match, and `sm` clamps labels to one
+/// line since it is too short for two. Below `md` the column collapses to a
+/// horizontal contained row capped at `lg` height (Carbon React maps `xl` to
+/// `lg` there), where the default row height ($spacing-09) already equals `lg`.
+/// @access private
+/// @group components
+@mixin tabs-vertical-size {
+  @include carbon--breakpoint(md) {
+    .#{$prefix}--tabs.#{$prefix}--tabs--vertical.#{$prefix}--layout--size-sm
+      .#{$prefix}--tabs__nav-item {
+      block-size: $size-sm;
+    }
+
+    .#{$prefix}--tabs.#{$prefix}--tabs--vertical.#{$prefix}--layout--size-md
+      .#{$prefix}--tabs__nav-item {
+      block-size: $size-md;
+    }
+
+    .#{$prefix}--tabs.#{$prefix}--tabs--vertical.#{$prefix}--layout--size-lg
+      .#{$prefix}--tabs__nav-item {
+      block-size: $size-lg;
+    }
+
+    .#{$prefix}--tabs.#{$prefix}--tabs--vertical.#{$prefix}--layout--size-xl
+      .#{$prefix}--tabs__nav-item {
+      block-size: $size-xl;
+    }
+
+    .#{$prefix}--tabs.#{$prefix}--tabs--vertical.#{$prefix}--layout--size-sm
+      .#{$prefix}--tabs__nav-item-label {
+      -webkit-line-clamp: 1;
+    }
+  }
+
+  @include carbon--breakpoint-down(md) {
+    .#{$prefix}--tabs.#{$prefix}--tabs--vertical.#{$prefix}--layout--size-sm
+      .#{$prefix}--tabs__nav-item {
+      block-size: $size-sm;
+    }
+
+    .#{$prefix}--tabs.#{$prefix}--tabs--vertical.#{$prefix}--layout--size-md
+      .#{$prefix}--tabs__nav-item {
+      block-size: $size-md;
+    }
+
+    // `xl` caps at `lg` below `md`; both match the default row height.
+    .#{$prefix}--tabs.#{$prefix}--tabs--vertical.#{$prefix}--layout--size-lg
+      .#{$prefix}--tabs__nav-item,
+    .#{$prefix}--tabs.#{$prefix}--tabs--vertical.#{$prefix}--layout--size-xl
+      .#{$prefix}--tabs__nav-item {
+      block-size: $size-lg;
+    }
+  }
+}
+
+@include exports('tabs-vertical-size') {
+  @include tabs-vertical-size;
 }

--- a/docs/src/pages/components/Tabs.svx
+++ b/docs/src/pages/components/Tabs.svx
@@ -419,9 +419,9 @@ Show a loading state for the container tab variant.
 
 ## Vertical
 
-Use TabsVertical to stack tabs in a column beside the panel on medium breakpoints
-and wider. On smaller viewports the tab list becomes a horizontal, scrollable row.
-Compose it with the same Tab and TabContent components.
+Use TabsVertical for a tab list beside the panel. Compose it with the same Tab and
+TabContent components. From the medium breakpoint up, tabs stack in a vertical column.
+On narrower screens, the list becomes a horizontal row with overflow scrolling.
 
 <TabsVertical>
   <Tab label="Dashboard" />
@@ -433,6 +433,52 @@ Compose it with the same Tab and TabContent components.
     <TabContent>Content 2</TabContent>
     <TabContent>Content 3</TabContent>
     <TabContent>Content 4</TabContent>
+  </svelte:fragment>
+</TabsVertical>
+
+### Sizes
+
+Size defaults to `"xl"`. Set `size` to change tab height in the vertical column
+layout. At `"sm"`, labels stay on one line. Size classes apply from the medium
+breakpoint up; in the horizontal overflow row below that, `"xl"` uses the large
+height.
+
+#### Small
+
+<TabsVertical size="sm">
+  <Tab label="Dashboard" />
+  <Tab label="Monitoring" />
+  <Tab label="Activity" />
+  <svelte:fragment slot="content">
+    <TabContent>Content 1</TabContent>
+    <TabContent>Content 2</TabContent>
+    <TabContent>Content 3</TabContent>
+  </svelte:fragment>
+</TabsVertical>
+
+#### Medium
+
+<TabsVertical size="md">
+  <Tab label="Dashboard" />
+  <Tab label="Monitoring" />
+  <Tab label="Activity" />
+  <svelte:fragment slot="content">
+    <TabContent>Content 1</TabContent>
+    <TabContent>Content 2</TabContent>
+    <TabContent>Content 3</TabContent>
+  </svelte:fragment>
+</TabsVertical>
+
+#### Large
+
+<TabsVertical size="lg">
+  <Tab label="Dashboard" />
+  <Tab label="Monitoring" />
+  <Tab label="Activity" />
+  <svelte:fragment slot="content">
+    <TabContent>Content 1</TabContent>
+    <TabContent>Content 2</TabContent>
+    <TabContent>Content 3</TabContent>
   </svelte:fragment>
 </TabsVertical>
 

--- a/src/Tabs/TabsVertical.svelte
+++ b/src/Tabs/TabsVertical.svelte
@@ -9,6 +9,13 @@
    */
   export let selected = 0;
 
+  /**
+   * Specify the size of the vertical tabs.
+   * `"xl"` matches the default height.
+   * @type {"sm" | "md" | "lg" | "xl"}
+   */
+  export let size = "xl";
+
   import { afterUpdate, createEventDispatcher, setContext, tick } from "svelte";
   import { derived, writable } from "svelte/store";
   import { breakpointObserver } from "../Breakpoint/breakpointObserver.js";
@@ -204,6 +211,10 @@
     class:bx--tabs={true}
     class:bx--tabs--vertical={true}
     class:bx--tabs--tall={$hasSecondaryLabel}
+    class:bx--layout--size-sm={size === "sm"}
+    class:bx--layout--size-md={size === "md"}
+    class:bx--layout--size-lg={size === "lg"}
+    class:bx--layout--size-xl={size === "xl"}
     {...$$restProps}
   >
     <!-- svelte-ignore a11y-no-noninteractive-element-to-interactive-role -->

--- a/tests/Tabs/TabsVertical.test.svelte
+++ b/tests/Tabs/TabsVertical.test.svelte
@@ -6,10 +6,12 @@
 
   export let selected = 0;
   export let icon: ComponentProps<Tab>["icon"] = undefined;
+  export let size: ComponentProps<TabsVertical>["size"] = undefined;
 </script>
 
 <TabsVertical
   {selected}
+  {size}
   on:change={({ detail }) => {
     console.log("change event", detail);
   }}

--- a/tests/Tabs/TabsVertical.test.ts
+++ b/tests/Tabs/TabsVertical.test.ts
@@ -28,6 +28,20 @@ describe("TabsVertical", () => {
     expect(screen.getByText("Content 2")).not.toBeVisible();
   });
 
+  it("should default to the xl layout size", () => {
+    render(TabsVertical);
+
+    expect(screen.getByRole("navigation")).toHaveClass("bx--layout--size-xl");
+  });
+
+  it("should apply the layout size class for the size prop", () => {
+    render(TabsVertical, { props: { size: "sm" } });
+
+    const nav = screen.getByRole("navigation");
+    expect(nav).toHaveClass("bx--layout--size-sm");
+    expect(nav).not.toHaveClass("bx--layout--size-xl");
+  });
+
   it("should render a vertically-oriented tablist", () => {
     render(TabsVertical);
 


### PR DESCRIPTION
Adds a `size` prop to TabsVertical with sm, md, lg, and xl variants, defaulting to xl to match the existing vertical tab height. SCSS maps layout size tokens at the md breakpoint and up, and caps xl at lg in the horizontal overflow row below md. Docs cover the responsive behavior with sm, md, and lg examples, and unit tests assert the layout size classes.