### PR TITLE
fix(code-snippet): multi-line variant dynamically shows expand button based on content height

### DIFF
--- a/docs/src/pages/components/CodeSnippet.svx
+++ b/docs/src/pages/components/CodeSnippet.svx
@@ -53,6 +53,14 @@ Set `type="multi"` to display multiple lines of code with expand/collapse functi
 
 <FileSource src="/framed/CodeSnippet/CodeSnippetMultiLine" />
 
+### Overflow detection
+
+The "Show more"/"Show less" button only appears when the multi-line snippet content exceeds the collapsed height. Because the visibility is based on the snippet's measured height, it adapts to the consumer's font size and line height, and updates automatically if the content or layout changes.
+
+Toggle the example below to grow the content past the threshold and reveal the expand button.
+
+<FileSource src="/framed/CodeSnippet/CodeSnippetOverflow" />
+
 ## Expanded by default
 
 Set `expanded` to `true` to show the full multi-line code snippet.

--- a/docs/src/pages/framed/CodeSnippet/CodeSnippetOverflow.svelte
+++ b/docs/src/pages/framed/CodeSnippet/CodeSnippetOverflow.svelte
@@ -1,0 +1,16 @@
+<script>
+  import { CodeSnippet, Stack, Toggle } from "carbon-components-svelte";
+
+  let expandable = false;
+
+  $: length = expandable ? 24 : 4;
+  $: code = Array.from(
+    { length },
+    (_, i) => `const line${i + 1} = ${i + 1};`,
+  ).join("\n");
+</script>
+
+<Stack gap={5}>
+  <Toggle bind:toggled={expandable} size="sm" labelText="Grow content" />
+  <CodeSnippet type="multi" {code} />
+</Stack>

--- a/e2e/code-snippet.test.ts
+++ b/e2e/code-snippet.test.ts
@@ -56,6 +56,54 @@ test.describe("CodeSnippet", () => {
     expect(expandedHeight).toBeGreaterThanOrEqual(collapsedHeight);
   });
 
+  test("multi snippet hides expand button when content is below the threshold", async ({
+    page,
+  }) => {
+    const snippet = page.getByTestId("snippet-multi-short");
+    await expect(snippet).toBeVisible();
+    await expect(
+      snippet.getByRole("button", { name: /show more/i }),
+    ).toBeHidden();
+  });
+
+  test("expand button appears when content grows past the threshold", async ({
+    page,
+  }) => {
+    const snippet = page.getByTestId("snippet-multi-dynamic");
+    const showMore = snippet.getByRole("button", { name: /show more/i });
+
+    // Starts short: no overflow, no button.
+    await expect(showMore).toBeHidden();
+
+    await page.getByTestId("toggle-content-size").click();
+
+    // Grows past the threshold: button appears.
+    await expect(showMore).toBeVisible();
+  });
+
+  test("resets height when content shrinks below the threshold after expanding", async ({
+    page,
+  }) => {
+    const snippet = page.getByTestId("snippet-multi-dynamic");
+
+    // Grow content, then expand.
+    await page.getByTestId("toggle-content-size").click();
+    await snippet.getByRole("button", { name: /show more/i }).click();
+    await expect(snippet).toHaveClass(/bx--snippet--expand/);
+    const expandedHeight = (await snippet.boundingBox())?.height ?? 0;
+
+    // Shrink content back below the threshold.
+    await page.getByTestId("toggle-content-size").click();
+
+    // Button disappears, expanded state resets, and height collapses back down.
+    await expect(
+      snippet.getByRole("button", { name: /show (more|less)/i }),
+    ).toBeHidden();
+    await expect(snippet).not.toHaveClass(/bx--snippet--expand/);
+    const shrunkHeight = (await snippet.boundingBox())?.height ?? 0;
+    expect(shrunkHeight).toBeLessThan(expandedHeight);
+  });
+
   test("copy button swaps to feedback icon during feedback window and reverts", async ({
     page,
   }) => {

--- a/e2e/fixtures/CodeSnippetFixture.svelte
+++ b/e2e/fixtures/CodeSnippetFixture.svelte
@@ -6,6 +6,13 @@
   const longCode = Array(20)
     .fill("function example() { return 'line'; }")
     .join("\n");
+
+  let dynamicExpanded = false;
+  $: dynamicLines = dynamicExpanded ? 24 : 3;
+  $: dynamicCode = Array.from(
+    { length: dynamicLines },
+    (_, i) => `const line${i + 1} = ${i + 1};`,
+  ).join("\n");
 </script>
 
 <div data-testid="single-snippet">
@@ -19,6 +26,29 @@
     data-testid="snippet-multi"
     showMoreText="Show more"
     showLessText="Show less"
+  />
+</div>
+
+<div data-testid="short-multi-snippet">
+  <CodeSnippet
+    type="multi"
+    code={shortCode}
+    data-testid="snippet-multi-short"
+  />
+</div>
+
+<div data-testid="dynamic-multi-snippet">
+  <button
+    type="button"
+    data-testid="toggle-content-size"
+    on:click={() => (dynamicExpanded = !dynamicExpanded)}
+  >
+    Toggle content size
+  </button>
+  <CodeSnippet
+    type="multi"
+    code={dynamicCode}
+    data-testid="snippet-multi-dynamic"
   />
 </div>
 

--- a/src/CodeSnippet/CodeSnippet.svelte
+++ b/src/CodeSnippet/CodeSnippet.svelte
@@ -148,7 +148,7 @@
    */
   export let portalTooltip = undefined;
 
-  import { createEventDispatcher, getContext, onMount, tick } from "svelte";
+  import { createEventDispatcher, getContext, onMount } from "svelte";
   import Button from "../Button/Button.svelte";
   import CopyButton from "../CopyButton/CopyButton.svelte";
   import ChevronDown from "../icons/ChevronDown.svelte";
@@ -170,7 +170,14 @@
   let feedbackOpen = false;
   let copyPending = false;
   let prevExpanded = expanded;
-  let exceedsThreshold = true;
+  let exceedsThreshold = false;
+  let resizeObserver;
+
+  /**
+   * The collapsed (non-expanded) max-height of the snippet, in px.
+   * The expand button is only relevant when the content exceeds this.
+   */
+  const collapsedHeight = 16 * 15;
 
   function syncCopyFeedback() {
     animation = copyFeedback.animation;
@@ -183,18 +190,32 @@
   }
 
   function measureHeight() {
+    if (!ref) return;
+    // Measure the snippet's full (unclipped) content height. The <pre> is never
+    // the element with a max-height, so its rendered height always reflects the
+    // true content height regardless of expanded state. Comparing the measured
+    // height keeps this correct across any consumer font size or line height.
     const { height } = ref.getBoundingClientRect();
-    if (height > 0) exceedsThreshold = height > 255;
+    if (height === 0) return;
+    exceedsThreshold = height > collapsedHeight;
+    // If the content no longer overflows, collapse so the expanded min-height
+    // doesn't leave the snippet taller than its (now shorter) content.
+    if (!exceedsThreshold && expanded) expanded = false;
   }
 
   $: expandText = expanded ? showLessText : showMoreText;
-  $: minHeight = expanded ? 16 * 15 : 48;
-  $: maxHeight = expanded ? "none" : `${16 * 15}px`;
+  $: minHeight = expanded ? collapsedHeight : 48;
+  $: maxHeight = expanded ? "none" : `${collapsedHeight}px`;
 
-  $: if (type === "multi" && ref && showMoreLess) {
-    // Only measure when the consumer has not opted out
-    if (code === undefined) measureHeight();
-    if (code) tick().then(measureHeight);
+  // Re-measure whenever the snippet resizes (font load, content change, width
+  // change causing reflow), so the expand button only shows on real overflow.
+  $: if (resizeObserver) {
+    resizeObserver.disconnect();
+    if (type === "multi" && showMoreLess && ref) {
+      resizeObserver.observe(ref);
+    } else {
+      exceedsThreshold = false;
+    }
   }
 
   $: showExpandButton = showMoreLess && type === "multi" && exceedsThreshold;
@@ -216,7 +237,10 @@
   }
 
   onMount(() => {
+    resizeObserver = new ResizeObserver(() => measureHeight());
+
     return () => {
+      resizeObserver.disconnect();
       copyFeedback.cleanup();
       disconnectModalObserver();
     };

--- a/tests/CodeSnippet/CodeSnippet.test.ts
+++ b/tests/CodeSnippet/CodeSnippet.test.ts
@@ -1,5 +1,9 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/svelte";
 import CodeSnippet from "carbon-components-svelte/CodeSnippet/CodeSnippet.svelte";
+import {
+  mockSnippetOverflowHeight,
+  waitForSnippetMeasurement,
+} from "../utils/mockSnippetOverflowHeight";
 import { user } from "../utils/user";
 import CodeSnippetAsync from "./CodeSnippetAsync.test.svelte";
 import CodeSnippetAsyncDoubleClick from "./CodeSnippetAsyncDoubleClick.test.svelte";
@@ -249,13 +253,15 @@ yarn -v`,
   });
 
   test("should expand and collapse expandable snippet", async () => {
+    mockSnippetOverflowHeight();
     const { container } = render(CodeSnippetExpandable);
+    await waitForSnippetMeasurement();
 
     expect(
       container.querySelector(".bx--snippet--expand"),
     ).not.toBeInTheDocument();
 
-    const showMoreButton = screen.getByText("Show more");
+    const showMoreButton = await screen.findByText("Show more");
     await user.click(showMoreButton);
 
     expect(container.querySelector(".bx--snippet--expand")).toBeInTheDocument();
@@ -271,8 +277,10 @@ yarn -v`,
   });
 
   // Regression: chevron should not duplicate the button's accessible name
-  test("should not set aria-label on the expand chevron", () => {
+  test("should not set aria-label on the expand chevron", async () => {
+    mockSnippetOverflowHeight();
     const { container } = render(CodeSnippetExpandable);
+    await waitForSnippetMeasurement();
 
     const chevron = container.querySelector(".bx--icon-chevron--down");
     assert(chevron);
@@ -281,10 +289,12 @@ yarn -v`,
   });
 
   test("should render expanded by default", async () => {
+    mockSnippetOverflowHeight();
     const { container } = render(CodeSnippetExpandedByDefault);
+    await waitForSnippetMeasurement();
 
     expect(container.querySelector(".bx--snippet--expand")).toBeInTheDocument();
-    expect(screen.getByText("Show less")).toBeInTheDocument();
+    expect(await screen.findByText("Show less")).toBeInTheDocument();
 
     await user.click(screen.getByText("Show less"));
 

--- a/tests/utils/mockSnippetOverflowHeight.ts
+++ b/tests/utils/mockSnippetOverflowHeight.ts
@@ -1,0 +1,33 @@
+const COLLAPSED_HEIGHT = 16 * 15;
+
+/**
+ * jsdom does not lay out text, so CodeSnippet's overflow measurement always
+ * sees height 0. Mock the `<pre>` height so expand/collapse tests can run.
+ */
+export function mockSnippetOverflowHeight(height = COLLAPSED_HEIGHT + 1) {
+  const original = Element.prototype.getBoundingClientRect;
+
+  return vi
+    .spyOn(Element.prototype, "getBoundingClientRect")
+    .mockImplementation(function (this: Element) {
+      if (this.tagName === "PRE") {
+        return {
+          height,
+          width: 100,
+          top: 0,
+          left: 0,
+          right: 100,
+          bottom: height,
+          x: 0,
+          y: 0,
+          toJSON: () => ({}),
+        } as DOMRect;
+      }
+
+      return original.call(this);
+    });
+}
+
+export async function waitForSnippetMeasurement() {
+  await Promise.resolve();
+}


### PR DESCRIPTION
The expand button should only show if there is actual content below the fold. It doesn't make sense to exhibit the button if it does nothing. The component should intelligently auto-detect actual overflow.