### PR TITLE
fix(multi-select): make read-only reviewable, drop disabled semantics

### DIFF
--- a/docs/src/pages/components/MultiSelect.svx
+++ b/docs/src/pages/components/MultiSelect.svx
@@ -434,7 +434,7 @@ Disable specific items using the disabled property in the items array. This exam
 
 ### Read-only
 
-Set `readonly` to `true` to display non-editable values. Selected items remain visible but cannot be cleared.
+Set `readonly` to `true` to display non-editable values. The menu can still be opened and navigated to review the selected values, but the selection cannot be changed or cleared.
 
 <MultiSelect
   readonly

--- a/src/ListBox/ListBoxSelection.svelte
+++ b/src/ListBox/ListBoxSelection.svelte
@@ -66,6 +66,7 @@
     class:bx--tag--filter={true}
     class:bx--tag--high-contrast={true}
     class:bx--tag--disabled={disabled}
+    aria-hidden={readonly || undefined}
   >
     <span
       class:bx--tag__label={true}

--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -976,10 +976,7 @@
             />
           {/if}
           <span class:bx--list-box__label={true}>{label}</span>
-          <ListBoxMenuIcon
-            {open}
-            {translateWithId}
-          />
+          <ListBoxMenuIcon {open} {translateWithId} />
         </ListBoxField>
       </div>
     {/if}

--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -176,6 +176,12 @@
   export let readonly = false;
 
   /**
+   * Specify the assistive text announced to screen readers when read-only.
+   * Exposed because VoiceOver does not announce `aria-readonly`.
+   */
+  export let readonlyText = "Read-only";
+
+  /**
    * Specify a name attribute for the select.
    * @type {string}
    */
@@ -333,7 +339,10 @@
 
   /** Handle selection of an item, including isSelectAll logic. */
   function selectItem(item) {
-    if (item.disabled) return;
+    // Read-only allows opening and navigating the menu to review values, but
+    // never changing them. Guarding here covers every path (click, Enter,
+    // label click, select-all) so callers don't each need a readonly check.
+    if (readonly || item.disabled) return;
 
     if (item.isSelectAll) {
       const target = !allSelected;
@@ -537,6 +546,30 @@
   $: helperId = `helper-${id}`;
   $: errorId = `error-${id}`;
   $: warnId = `warn-${id}`;
+  $: readonlyId = `readonly-${id}`;
+  // `aria-readonly` on a combobox/listbox does not reliably surface read-only state,
+  // so the read-only state is also exposed as a visually-hidden description. The
+  // single status/help id is combined with the read-only id (a describedby
+  // may reference multiple ids) so it works in every state.
+  $: statusDescribedById =
+    showInvalid && invalidText
+      ? errorId
+      : showWarn && warnText
+        ? warnId
+        : !isFluid && !showInvalid && !showWarn && helperText
+          ? helperId
+          : undefined;
+  $: fieldDescribedById =
+    [readonly ? readonlyId : null, statusDescribedById]
+      .filter(Boolean)
+      .join(" ") || undefined;
+  // The selection count badge is hidden from assistive tech in read-only.
+  // Fold the count into the read-only description so the
+  // collapsed field still announces how much there is to review.
+  $: readonlyDescription =
+    selectionCount > 0
+      ? `${readonlyText}, ${selectionCount} selected`
+      : readonlyText;
   $: inline = type === "inline";
   $: isFluid = !inline && (fluid || !!formContext?.isFluid);
   // Keep the focus outline on the field while the menu is open, not just while
@@ -683,7 +716,6 @@
   <ListBox
     id={comboId}
     aria-label={ariaLabel}
-    aria-disabled={readonly || undefined}
     {disabled}
     invalid={showInvalid}
     invalidText={isFluid ? "" : invalidText}
@@ -740,27 +772,26 @@
             aria-haspopup="listbox"
             aria-expanded={open}
             aria-activedescendant={activeDescendantId}
-            aria-disabled={disabled || readonly}
+            aria-disabled={disabled || undefined}
             aria-readonly={readonly || undefined}
             aria-controls={open ? menuId : undefined}
             aria-owns={open ? menuId : undefined}
-            aria-describedby={showInvalid && invalidText
-            ? errorId
-            : showWarn && warnText
-              ? warnId
-              : !isFluid && !showInvalid && !showWarn && helperText
-                ? helperId
-                : undefined}
+            aria-describedby={fieldDescribedById}
             class:bx--text-input={true}
             class:bx--text-input--empty={value === ""}
             class:bx--text-input--light={light}
             on:click={() => {
-            if (disabled || readonly) return;
+            if (disabled) return;
             open = true;
           }}
             on:keydown
             on:keydown|stopPropagation={(event) => {
-            if (readonly) return;
+            // Read-only opens and navigates the menu to review values, but the
+            // keys that clear the selection are blocked; selectItem guards the
+            // rest (Enter/option toggle).
+            if (readonly && (event.key === "Backspace" || event.key === "Delete")) {
+              return;
+            }
             if (event.key === "Enter") {
               if (highlightedId) {
                 const highlightedItem = sortedItems.find(
@@ -840,9 +871,8 @@
             />
           {/if}
           <ListBoxMenuIcon
-            aria-hidden={readonly || undefined}
             on:click={(event) => {
-            if (disabled || readonly) return;
+            if (disabled) return;
             event.stopPropagation();
             open = !open;
           }}
@@ -870,18 +900,12 @@
           aria-activedescendant={activeDescendantId}
           aria-controls={open ? menuId : undefined}
           aria-owns={open ? menuId : undefined}
-          aria-describedby={showInvalid && invalidText
-            ? errorId
-            : showWarn && warnText
-              ? warnId
-              : !isFluid && !showInvalid && !showWarn && helperText
-                ? helperId
-                : undefined}
+          aria-describedby={fieldDescribedById}
           on:focus={() => {
           fieldFocused = true;
         }}
           on:click={() => {
-          if (disabled || readonly) return;
+          if (disabled) return;
           open = !open;
         }}
           on:keydown={(event) => {
@@ -895,7 +919,8 @@
             // toggle the menu) so these keys are handled solely below.
             event.preventDefault();
           }
-          if (readonly) return;
+          // Read-only still opens and navigates the menu; selectItem is the
+          // single guard that blocks the actual selection change.
           if (event.key === " ") {
             open = !open;
           } else if (event.key === "Tab") {
@@ -952,7 +977,6 @@
           {/if}
           <span class:bx--list-box__label={true}>{label}</span>
           <ListBoxMenuIcon
-            aria-hidden={readonly || undefined}
             {open}
             {translateWithId}
           />
@@ -969,6 +993,7 @@
         anchor={fieldRef}
         {direction}
         aria-multiselectable="true"
+        aria-readonly={readonly || undefined}
         on:scroll
         on:scroll={(event) => {
           listScrollTop = event.target.scrollTop;
@@ -1036,6 +1061,7 @@
                       ? selectAllIndeterminate
                       : false}
                     disabled={item.disabled}
+                    {readonly}
                   >
                     <slot
                       slot="labelChildren"
@@ -1097,6 +1123,7 @@
                   ? selectAllIndeterminate
                   : false}
                 disabled={item.disabled}
+                {readonly}
               >
                 <slot
                   slot="labelChildren"
@@ -1131,5 +1158,10 @@
     >
       {helperText}
     </div>
+  {/if}
+  {#if readonly}
+    <span id={readonlyId} class:bx--visually-hidden={true}
+      >{readonlyDescription}</span
+    >
   {/if}
 </div>

--- a/tests/MultiSelect/MultiSelect.test.svelte
+++ b/tests/MultiSelect/MultiSelect.test.svelte
@@ -20,6 +20,8 @@
   export let warnText = "";
   export let disabled = false;
   export let readonly = false;
+  export let readonlyText: ComponentProps<MultiSelect>["readonlyText"] =
+    undefined;
   export let selectionFeedback: ComponentProps<MultiSelect>["selectionFeedback"] =
     "top-after-reopen";
   export let translateWithIdSelection: ComponentProps<MultiSelect>["translateWithIdSelection"] =
@@ -60,6 +62,7 @@
   {warnText}
   {disabled}
   {readonly}
+  {readonlyText}
   {selectionFeedback}
   {translateWithIdSelection}
   {itemToString}

--- a/tests/MultiSelect/MultiSelect.test.ts
+++ b/tests/MultiSelect/MultiSelect.test.ts
@@ -2775,18 +2775,27 @@ describe("MultiSelect", () => {
       ).toBeTruthy();
     });
 
-    it("should not open menu on click when readonly (default)", async () => {
-      render(MultiSelect, {
+    it("opens the menu for review on click when readonly (default)", async () => {
+      const { container } = render(MultiSelect, {
         props: { items, labelText: "Contact", readonly: true },
       });
 
       const trigger = await screen.findByRole("combobox");
+      // Read-only conveys read-only semantics, not disabled/unavailable.
+      expect(trigger).toHaveAttribute("aria-readonly", "true");
+      expect(trigger).not.toHaveAttribute("aria-disabled", "true");
+      expect(container.querySelector(".bx--list-box")).not.toHaveAttribute(
+        "aria-disabled",
+      );
+
       await user.click(trigger);
 
-      expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+      // The menu opens so the selected values can be reviewed/navigated.
+      expect(screen.getByRole("listbox")).toBeInTheDocument();
+      expect(screen.getAllByRole("option")).toHaveLength(items.length);
     });
 
-    it("should not open menu on click when readonly + filterable", async () => {
+    it("opens the menu for review on click when readonly + filterable", async () => {
       render(MultiSelect, {
         props: {
           items,
@@ -2799,11 +2808,146 @@ describe("MultiSelect", () => {
 
       const input = screen.getByRole("combobox");
       assert(input instanceof HTMLInputElement);
-      await user.click(input);
 
+      // Read-only, not disabled: the input stays non-editable but reviewable.
       expect(input).toHaveAttribute("readonly");
       expect(input).toHaveAttribute("aria-readonly", "true");
-      expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+      expect(input).not.toHaveAttribute("aria-disabled", "true");
+
+      await user.click(input);
+
+      expect(screen.getByRole("listbox")).toBeInTheDocument();
+    });
+
+    it("does not toggle a selection when an option is clicked while readonly", async () => {
+      render(MultiSelect, {
+        props: {
+          items,
+          labelText: "Contact",
+          readonly: true,
+          selectedIds: ["0"],
+        },
+      });
+
+      const trigger = await screen.findByRole("combobox");
+      await user.click(trigger);
+
+      const options = screen.getAllByRole("option");
+      expect(options[0]).toHaveAttribute("aria-selected", "true");
+      expect(options[1]).toHaveAttribute("aria-selected", "false");
+
+      // Clicking an option must not change the selection in read-only.
+      await user.click(options[1]);
+      expect(options[0]).toHaveAttribute("aria-selected", "true");
+      expect(options[1]).toHaveAttribute("aria-selected", "false");
+
+      // Nor may clicking a selected option clear it.
+      await user.click(options[0]);
+      expect(options[0]).toHaveAttribute("aria-selected", "true");
+    });
+
+    it("marks the open menu and its checkboxes as read-only", async () => {
+      const { container } = render(MultiSelect, {
+        props: {
+          items,
+          labelText: "Contact",
+          readonly: true,
+          selectedIds: ["0"],
+        },
+      });
+
+      const trigger = await screen.findByRole("combobox");
+      await user.click(trigger);
+
+      // The listbox itself advertises that it cannot be modified.
+      expect(screen.getByRole("listbox")).toHaveAttribute(
+        "aria-readonly",
+        "true",
+      );
+
+      // Each option's checkbox is read-only so a browse-mode toggle is blocked.
+      const checkboxes = container.querySelectorAll<HTMLInputElement>(
+        'input[type="checkbox"]',
+      );
+      expect(checkboxes.length).toBe(items.length);
+      checkboxes.forEach((checkbox) => {
+        expect(checkbox).toHaveAttribute("aria-readonly", "true");
+      });
+    });
+
+    it("describes the field as read-only for screen readers that ignore aria-readonly", () => {
+      const { container } = render(MultiSelect, {
+        props: {
+          id: "test-multiselect",
+          items,
+          labelText: "Contact",
+          readonly: true,
+        },
+      });
+
+      // VoiceOver does not surface aria-readonly, so the state is also exposed
+      // as a visually-hidden description referenced by the combobox.
+      const combobox = screen.getByRole("combobox");
+      expect(combobox).toHaveAttribute(
+        "aria-describedby",
+        "readonly-test-multiselect",
+      );
+
+      const description = container.querySelector("#readonly-test-multiselect");
+      expect(description).toHaveTextContent("Read-only");
+      expect(description).toHaveClass("bx--visually-hidden");
+    });
+
+    it("supports overriding the read-only assistive text", () => {
+      const { container } = render(MultiSelect, {
+        props: {
+          id: "test-multiselect",
+          items,
+          labelText: "Contact",
+          readonly: true,
+          readonlyText: "Schreibgeschützt",
+        },
+      });
+
+      expect(
+        container.querySelector("#readonly-test-multiselect"),
+      ).toHaveTextContent("Schreibgeschützt");
+    });
+
+    it("includes the selected count in the read-only description", () => {
+      const { container } = render(MultiSelect, {
+        props: {
+          id: "test-multiselect",
+          items,
+          labelText: "Contact",
+          readonly: true,
+          selectedIds: ["0", "1"],
+        },
+      });
+
+      // The count badge is hidden from AT in read-only, so the count is folded
+      // into the description to keep the collapsed field reviewable.
+      expect(
+        container.querySelector("#readonly-test-multiselect"),
+      ).toHaveTextContent("Read-only, 2 selected");
+    });
+
+    it("appends the read-only description to existing helper text", () => {
+      render(MultiSelect, {
+        props: {
+          id: "test-multiselect",
+          items,
+          labelText: "Contact",
+          helperText: "Helper text",
+          readonly: true,
+        },
+      });
+
+      // Both ids are referenced so the help text is not lost in read-only.
+      expect(screen.getByRole("combobox")).toHaveAttribute(
+        "aria-describedby",
+        "readonly-test-multiselect helper-test-multiselect",
+      );
     });
 
     it("should not clear selection when readonly", async () => {

--- a/tests/MultiSelect/MultiSelect.test.ts
+++ b/tests/MultiSelect/MultiSelect.test.ts
@@ -2870,9 +2870,9 @@ describe("MultiSelect", () => {
         'input[type="checkbox"]',
       );
       expect(checkboxes.length).toBe(items.length);
-      checkboxes.forEach((checkbox) => {
+      for (const checkbox of checkboxes) {
         expect(checkbox).toHaveAttribute("aria-readonly", "true");
-      });
+      }
     });
 
     it("describes the field as read-only for screen readers that ignore aria-readonly", () => {


### PR DESCRIPTION
**Make read-only MultiSelect reviewable instead of disabled**

Read-only MultiSelect can't behave like a disabled field: the menu won't open providing no way to see what was selected, and screen readers announced it as disabled/unavailable.

This edit makes read-only reviewable:

- The menu opens and you can navigate the options to review what's selected, but you can't change or
clear the selection.
- Dropped aria-disabled in favor of aria-readonly on the combobox and listbox (both valid per ARIA
1.2).
- All selection changes funnel through one guard in selectItem, so every path (click, Enter, label
click, select-all, clear) is blocked consistently in read-only.
- AT doesn't reliably surface aria-readonly, so the state is also exposed as visually-hidden text
referenced by the field. The number of selected items is folded into that text ("Read-only, 3
selected") since the count badge is hidden from assistive tech in read-only.
- The read-only text is overridable via a new readonlyText prop.
