### PR TITLE
feat(header-search): add icon, placeholder, labelText, and closeButtonLabelText props

### DIFF
--- a/docs/src/pages/components/UIShell.svx
+++ b/docs/src/pages/components/UIShell.svx
@@ -120,6 +120,12 @@ Override the default slot to customize each result. The slot exposes `let:result
 
 <FileSource src="/framed/UIShell/HeaderSearchSlot" />
 
+### Customization
+
+Set `icon` to render a different trigger icon. Use `placeholder`, `labelText`, and `closeButtonLabelText` to localize the input placeholder, the assistive field label, and the clear button label.
+
+<FileSource src="/framed/UIShell/HeaderSearchCustom" />
+
 ## Utilities
 
 Add utilities to the header with header utilities. Compose [BadgeIndicator](/components/BadgeIndicator) in the badge slot on `HeaderGlobalAction`. Set `iconDescription` for screen readers.

--- a/docs/src/pages/framed/UIShell/HeaderSearchCustom.svelte
+++ b/docs/src/pages/framed/UIShell/HeaderSearchCustom.svelte
@@ -1,0 +1,38 @@
+<script>
+  import {
+    Header,
+    HeaderSearch,
+    HeaderUtilities,
+    SkipToContent,
+  } from "carbon-components-svelte";
+  import ImageSearchAlt from "carbon-icons-svelte/lib/ImageSearchAlt.svelte";
+
+  const data = [
+    { id: "kubernetes-service", href: "/", text: "Kubernetes Service" },
+    { id: "code-engine", href: "/", text: "Code Engine" },
+    { id: "container-registry", href: "/", text: "Container Registry" },
+  ];
+
+  let value = "";
+
+  $: results =
+    value.length > 0
+      ? data.filter((item) =>
+          item.text.toLowerCase().includes(value.toLowerCase()),
+        )
+      : [];
+</script>
+
+<Header companyName="IBM" platformName="Cloud">
+  <svelte:fragment slot="skipToContent"> <SkipToContent /> </svelte:fragment>
+  <HeaderUtilities>
+    <HeaderSearch
+      bind:value
+      icon={ImageSearchAlt}
+      placeholder="Search secure services"
+      labelText="Search secure services"
+      closeButtonLabelText="Clear the search query"
+      {results}
+    />
+  </HeaderUtilities>
+</Header>

--- a/src/UIShell/HeaderSearch.svelte
+++ b/src/UIShell/HeaderSearch.svelte
@@ -67,6 +67,9 @@
   /** Specify the `placeholder` attribute of the search input. */
   export let placeholder = "Search...";
 
+  /** Specify the text for the assistive label associated with the search input. */
+  export let labelText = "Search";
+
   import { createEventDispatcher, tick } from "svelte";
   import Close from "../icons/Close.svelte";
   import IconSearch from "../icons/IconSearch.svelte";
@@ -125,7 +128,7 @@
   class:bx--header__search--active={active}
 >
   <label class:bx--header__search-label={true} for={inputId} id={labelId}
-    >Search</label
+    >{labelText}</label
   >
   <div
     class:bx--header__search-menu={true}

--- a/src/UIShell/HeaderSearch.svelte
+++ b/src/UIShell/HeaderSearch.svelte
@@ -1,6 +1,7 @@
 <script>
   /**
    * @template {HeaderSearchResult} [Result=HeaderSearchResult]
+   * @template [Icon=any]
    */
 
   /**
@@ -56,6 +57,12 @@
    * @bindable readonly
    */
   export let selectedResultIndex = 0;
+
+  /**
+   * Specify the icon to render for the search trigger.
+   * @type {Icon}
+   */
+  export let icon = /** @type {Icon} */ (IconSearch);
 
   import { createEventDispatcher, tick } from "svelte";
   import Close from "../icons/Close.svelte";
@@ -134,7 +141,7 @@
         active = true;
       }}
     >
-      <IconSearch size={20} title="Search" />
+      <svelte:component this={icon} size={20} title="Search" />
     </button>
     <input
       bind:this={ref}

--- a/src/UIShell/HeaderSearch.svelte
+++ b/src/UIShell/HeaderSearch.svelte
@@ -70,6 +70,9 @@
   /** Specify the text for the assistive label associated with the search input. */
   export let labelText = "Search";
 
+  /** Specify the label for the clear button. */
+  export let closeButtonLabelText = "Clear search input";
+
   import { createEventDispatcher, tick } from "svelte";
   import Close from "../icons/Close.svelte";
   import IconSearch from "../icons/IconSearch.svelte";
@@ -208,7 +211,7 @@
     {#if active}
       <button
         type="button"
-        aria-label="Clear search"
+        aria-label={closeButtonLabelText}
         tabindex="0"
         class:bx--header__action={true}
         class:bx--header-search-button={true}
@@ -217,7 +220,7 @@
           dispatch("clear");
         }}
       >
-        <Close size={20} title="Close" />
+        <Close size={20} title={closeButtonLabelText} />
       </button>
     {/if}
   </div>

--- a/src/UIShell/HeaderSearch.svelte
+++ b/src/UIShell/HeaderSearch.svelte
@@ -64,6 +64,9 @@
    */
   export let icon = /** @type {Icon} */ (IconSearch);
 
+  /** Specify the `placeholder` attribute of the search input. */
+  export let placeholder = "Search...";
+
   import { createEventDispatcher, tick } from "svelte";
   import Close from "../icons/Close.svelte";
   import IconSearch from "../icons/IconSearch.svelte";
@@ -147,7 +150,7 @@
       bind:this={ref}
       type="text"
       autocomplete="off"
-      placeholder="Search..."
+      {placeholder}
       tabindex={active ? "0" : "-1"}
       class:bx--header__search-input={true}
       class:bx--header__search--active={active}

--- a/tests/UIShell/HeaderSearch.test.svelte
+++ b/tests/UIShell/HeaderSearch.test.svelte
@@ -39,6 +39,7 @@
   bind:value
   bind:selectedResultIndex
   {results}
+  {...$$restProps}
   on:active={handleActive}
   on:inactive={handleInactive}
   on:clear={handleClear}

--- a/tests/UIShell/HeaderSearch.test.ts
+++ b/tests/UIShell/HeaderSearch.test.ts
@@ -4,6 +4,7 @@ import type { HeaderSearchResult } from "carbon-components-svelte/UIShell/Header
 import type { ComponentProps } from "svelte";
 import { user } from "../utils/user";
 import HeaderSearchTest from "./HeaderSearch.test.svelte";
+import HeaderSearchIconTest from "./HeaderSearchIcon.test.svelte";
 
 describe("HeaderSearch", () => {
   beforeEach(() => {
@@ -80,6 +81,25 @@ describe("HeaderSearch", () => {
       expect(
         screen.queryByRole("button", { name: "Clear search" }),
       ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("Icon", () => {
+    it("should render IconSearch in the trigger by default", () => {
+      render(HeaderSearchTest);
+
+      const searchButton = screen.getByRole("button", { name: "Search" });
+      expect(searchButton.querySelector("svg")).toBeInTheDocument();
+      expect(screen.queryByTestId("custom-icon")).not.toBeInTheDocument();
+    });
+
+    it("should render a custom icon in the trigger", () => {
+      render(HeaderSearchIconTest);
+
+      const searchButton = screen.getByRole("button", { name: "Search" });
+      expect(
+        searchButton.querySelector("[data-testid='custom-icon']"),
+      ).toBeInTheDocument();
     });
   });
 

--- a/tests/UIShell/HeaderSearch.test.ts
+++ b/tests/UIShell/HeaderSearch.test.ts
@@ -97,7 +97,9 @@ describe("HeaderSearch", () => {
     it("should render clear button when active", () => {
       render(HeaderSearchTest, { props: { active: true } });
 
-      const clearButton = screen.getByRole("button", { name: "Clear search" });
+      const clearButton = screen.getByRole("button", {
+        name: "Clear search input",
+      });
       expect(clearButton).toBeInTheDocument();
     });
 
@@ -105,8 +107,18 @@ describe("HeaderSearch", () => {
       render(HeaderSearchTest, { props: { active: false } });
 
       expect(
-        screen.queryByRole("button", { name: "Clear search" }),
+        screen.queryByRole("button", { name: "Clear search input" }),
       ).not.toBeInTheDocument();
+    });
+
+    it("should support a custom closeButtonLabelText", () => {
+      render(HeaderSearchTest, {
+        props: { active: true, closeButtonLabelText: "Reset search" },
+      });
+
+      expect(
+        screen.getByRole("button", { name: "Reset search" }),
+      ).toBeInTheDocument();
     });
   });
 
@@ -268,7 +280,9 @@ describe("HeaderSearch", () => {
     it("should dispatch clear event when clear button is clicked", async () => {
       render(HeaderSearchTest, { props: { active: true, value: "test" } });
 
-      const clearButton = screen.getByRole("button", { name: "Clear search" });
+      const clearButton = screen.getByRole("button", {
+        name: "Clear search input",
+      });
       await user.click(clearButton);
 
       expect(screen.getByTestId("clear-event")).toHaveTextContent("true");
@@ -495,7 +509,9 @@ describe("HeaderSearch", () => {
       const searchInput = screen.getByRole("textbox");
       expect(searchInput).toHaveAttribute("tabindex", "0");
 
-      const clearButton = screen.getByRole("button", { name: "Clear search" });
+      const clearButton = screen.getByRole("button", {
+        name: "Clear search input",
+      });
       expect(clearButton).toHaveAttribute("tabindex", "0");
     });
 

--- a/tests/UIShell/HeaderSearch.test.ts
+++ b/tests/UIShell/HeaderSearch.test.ts
@@ -54,6 +54,23 @@ describe("HeaderSearch", () => {
       );
     });
 
+    it("should label the input with labelText by default", () => {
+      render(HeaderSearchTest);
+
+      const label = screen.getByText("Search", { selector: "label" });
+      const input = screen.getByRole("textbox");
+      expect(label.getAttribute("for")).toBe(input.id);
+    });
+
+    it("should support a custom labelText", () => {
+      render(HeaderSearchTest, { props: { labelText: "Search the catalog" } });
+
+      const label = screen.getByText("Search the catalog", {
+        selector: "label",
+      });
+      expect(label.getAttribute("for")).toBe(screen.getByRole("textbox").id);
+    });
+
     it("should generate unique ids per instance to avoid collisions", () => {
       const { container: a } = render(HeaderSearchTest);
       const { container: b } = render(HeaderSearchTest);

--- a/tests/UIShell/HeaderSearch.test.ts
+++ b/tests/UIShell/HeaderSearch.test.ts
@@ -45,6 +45,15 @@ describe("HeaderSearch", () => {
       expect(searchInput.id).toMatch(/^ccs-[a-z0-9.]+-input$/);
     });
 
+    it("should support a custom placeholder", () => {
+      render(HeaderSearchTest, { props: { placeholder: "Find anything..." } });
+
+      expect(screen.getByRole("textbox")).toHaveAttribute(
+        "placeholder",
+        "Find anything...",
+      );
+    });
+
     it("should generate unique ids per instance to avoid collisions", () => {
       const { container: a } = render(HeaderSearchTest);
       const { container: b } = render(HeaderSearchTest);

--- a/tests/UIShell/HeaderSearchClose.test.ts
+++ b/tests/UIShell/HeaderSearchClose.test.ts
@@ -55,7 +55,9 @@ describe("HeaderSearch close event", () => {
       props: { active: true, value: "query", onClose },
     });
 
-    await user.click(screen.getByRole("button", { name: "Clear search" }));
+    await user.click(
+      screen.getByRole("button", { name: "Clear search input" }),
+    );
 
     expect(onClose).not.toHaveBeenCalled();
   });

--- a/tests/UIShell/HeaderSearchCustomIcon.test.svelte
+++ b/tests/UIShell/HeaderSearchCustomIcon.test.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+  export let size = 16;
+  export let title: string | undefined = undefined;
+</script>
+
+<svg data-testid="custom-icon" width={size} height={size}>
+  {#if title}
+    <title>{title}</title>
+  {/if}
+</svg>

--- a/tests/UIShell/HeaderSearchIcon.test.svelte
+++ b/tests/UIShell/HeaderSearchIcon.test.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+  import HeaderSearch from "carbon-components-svelte/UIShell/HeaderSearch.svelte";
+  import CustomIcon from "./HeaderSearchCustomIcon.test.svelte";
+</script>
+
+<HeaderSearch icon={CustomIcon} />


### PR DESCRIPTION
Adds four customization props to `HeaderSearch` for parity with `Search` and `SearchMenu`: `icon` (default `IconSearch`), `placeholder`, `labelText`, and `closeButtonLabelText`. The label and close-button props are also an accessibility and i18n win, since those strings were previously hardcoded. Note that `closeButtonLabelText` defaults to `"Clear search input"` to match the sibling components, which changes the clear button's accessible name from the prior `"Clear search"`. Each prop ships as its own commit with a unit test, and the docs include a new customization example.

```svelte
<script>
  import { Header, HeaderSearch, HeaderUtilities } from "carbon-components-svelte";
  import Locked from "carbon-icons-svelte/lib/Locked.svelte";

  let value = "";
  const results = [];
</script>

<Header companyName="IBM" platformName="Cloud">
  <HeaderUtilities>
    <HeaderSearch
      bind:value
      icon={Locked}
      placeholder="Search secure services"
      labelText="Search secure services"
      closeButtonLabelText="Clear the search query"
      {results}
    />
  </HeaderUtilities>
</Header>
```
