### PR TITLE
fix: preserve displayed selection across async items changes

### DIFF
--- a/e2e/fixtures/ItemsResyncFixture.svelte
+++ b/e2e/fixtures/ItemsResyncFixture.svelte
@@ -1,5 +1,11 @@
 <script>
-  import { ComboBox, Select, SelectItem } from "carbon-components-svelte";
+  import {
+    ComboBox,
+    Dropdown,
+    MultiSelect,
+    Select,
+    SelectItem,
+  } from "carbon-components-svelte";
 
   // orwell is not the first option; native <select> would otherwise mask a reset.
   // make() returns a new array reference, like an async refetch.
@@ -28,20 +34,33 @@
   let selSwapItems = make();
   let selSwapSelected = "orwell";
 
+  let msSwapItems = make();
+  let msSwapSelectedIds = ["orwell"];
+
+  let msFillItems = [];
+  let msFillSelectedIds = ["orwell"];
+
+  let dropFillItems = [];
+  let dropFillSelectedId = "orwell";
+
   function load() {
     cbFillItems = make();
     selFillItems = make();
+    msFillItems = make();
+    dropFillItems = make();
   }
 
   function reload() {
     cbSwapItems = make();
     selSwapItems = make();
+    msSwapItems = make();
   }
 
   function clearFill() {
     cbFillItems = [];
     cbFillValue = "";
     selFillItems = [];
+    msFillItems = [];
   }
 </script>
 
@@ -101,3 +120,33 @@
   {/each}
 </Select>
 <p data-testid="sel-swap-selected">{selSwapSelected}</p>
+
+<!-- Wrapper carries data-testid; MultiSelect does not spread $$restProps. -->
+<div data-testid="ms-swap">
+  <MultiSelect
+    labelText="MultiSelect swap"
+    label="Choose authors"
+    items={msSwapItems}
+    bind:selectedIds={msSwapSelectedIds}
+  />
+</div>
+<p data-testid="ms-swap-ids">{msSwapSelectedIds.join(",")}</p>
+
+<div data-testid="ms-fill">
+  <MultiSelect
+    labelText="MultiSelect fill"
+    label="Choose authors"
+    items={msFillItems}
+    bind:selectedIds={msFillSelectedIds}
+  />
+</div>
+<p data-testid="ms-fill-ids">{msFillSelectedIds.join(",")}</p>
+
+<div data-testid="drop-fill">
+  <Dropdown
+    titleText="Dropdown fill"
+    items={dropFillItems}
+    bind:selectedId={dropFillSelectedId}
+  />
+</div>
+<p data-testid="drop-fill-id">{dropFillSelectedId}</p>

--- a/e2e/fixtures/ItemsResyncFixture.svelte
+++ b/e2e/fixtures/ItemsResyncFixture.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { ComboBox } from "carbon-components-svelte";
+  import { ComboBox, Select, SelectItem } from "carbon-components-svelte";
 
   // orwell is not the first option; native <select> would otherwise mask a reset.
   // make() returns a new array reference, like an async refetch.
@@ -22,17 +22,26 @@
   let cbSwapSelectedId = "orwell";
   let cbSwapValue = "George Orwell";
 
+  let selFillItems = [];
+  let selFillSelected = "orwell";
+
+  let selSwapItems = make();
+  let selSwapSelected = "orwell";
+
   function load() {
     cbFillItems = make();
+    selFillItems = make();
   }
 
   function reload() {
     cbSwapItems = make();
+    selSwapItems = make();
   }
 
   function clearFill() {
     cbFillItems = [];
     cbFillValue = "";
+    selFillItems = [];
   }
 </script>
 
@@ -70,3 +79,25 @@
   bind:value={cbSwapValue}
 />
 <p data-testid="cb-swap-id">{cbSwapSelectedId}</p>
+
+<Select
+  data-testid="sel-fill"
+  labelText="Select fill"
+  bind:selected={selFillSelected}
+>
+  {#each selFillItems as item (item.id)}
+    <SelectItem value={item.id} text={item.text} />
+  {/each}
+</Select>
+<p data-testid="sel-fill-selected">{selFillSelected}</p>
+
+<Select
+  data-testid="sel-swap"
+  labelText="Select swap"
+  bind:selected={selSwapSelected}
+>
+  {#each selSwapItems as item (item.id)}
+    <SelectItem value={item.id} text={item.text} />
+  {/each}
+</Select>
+<p data-testid="sel-swap-selected">{selSwapSelected}</p>

--- a/e2e/fixtures/ItemsResyncFixture.svelte
+++ b/e2e/fixtures/ItemsResyncFixture.svelte
@@ -1,0 +1,72 @@
+<script>
+  import { ComboBox } from "carbon-components-svelte";
+
+  // orwell is not the first option; native <select> would otherwise mask a reset.
+  // make() returns a new array reference, like an async refetch.
+  const make = () => [
+    { id: "austen", text: "Jane Austen" },
+    { id: "dickens", text: "Charles Dickens" },
+    { id: "orwell", text: "George Orwell" },
+    { id: "woolf", text: "Virginia Woolf" },
+  ];
+
+  const cbPreloadItems = make();
+  let cbPreloadSelectedId = "orwell";
+  let cbPreloadValue = "";
+
+  let cbFillItems = [];
+  let cbFillSelectedId = "orwell";
+  let cbFillValue = "";
+
+  let cbSwapItems = make();
+  let cbSwapSelectedId = "orwell";
+  let cbSwapValue = "George Orwell";
+
+  function load() {
+    cbFillItems = make();
+  }
+
+  function reload() {
+    cbSwapItems = make();
+  }
+
+  function clearFill() {
+    cbFillItems = [];
+    cbFillValue = "";
+  }
+</script>
+
+<button type="button" data-testid="load" on:click={load}>Load options</button>
+<button type="button" data-testid="reload" on:click={reload}>
+  Reload options
+</button>
+<button type="button" data-testid="clear-fill" on:click={clearFill}>
+  Clear fill
+</button>
+
+<ComboBox
+  data-testid="cb-preload"
+  labelText="ComboBox preload"
+  items={cbPreloadItems}
+  bind:selectedId={cbPreloadSelectedId}
+  bind:value={cbPreloadValue}
+/>
+<p data-testid="cb-preload-id">{cbPreloadSelectedId}</p>
+
+<ComboBox
+  data-testid="cb-fill"
+  labelText="ComboBox fill"
+  items={cbFillItems}
+  bind:selectedId={cbFillSelectedId}
+  bind:value={cbFillValue}
+/>
+<p data-testid="cb-fill-id">{cbFillSelectedId}</p>
+
+<ComboBox
+  data-testid="cb-swap"
+  labelText="ComboBox swap"
+  items={cbSwapItems}
+  bind:selectedId={cbSwapSelectedId}
+  bind:value={cbSwapValue}
+/>
+<p data-testid="cb-swap-id">{cbSwapSelectedId}</p>

--- a/e2e/fixtures/index.html
+++ b/e2e/fixtures/index.html
@@ -41,6 +41,7 @@
       <a href="/file-uploader.html">FileUploader</a>
       <a href="/file-uploader-advanced.html">FileUploader (advanced)</a>
       <a href="/time-picker.html">TimePicker</a>
+      <a href="/items-resync.html">Items resync</a>
       <a href="/inline-notification.html">InlineNotification</a>
       <a href="/toast-notification.html">ToastNotification</a>
       <a href="/content-switcher.html">ContentSwitcher</a>

--- a/e2e/fixtures/items-resync.html
+++ b/e2e/fixtures/items-resync.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Items Resync Test</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="./items-resync.ts"></script>
+  </body>
+</html>

--- a/e2e/fixtures/items-resync.ts
+++ b/e2e/fixtures/items-resync.ts
@@ -1,0 +1,4 @@
+import ItemsResyncFixture from "./ItemsResyncFixture.svelte";
+import { mount } from "./mount";
+
+mount(ItemsResyncFixture);

--- a/e2e/items-resync.test.ts
+++ b/e2e/items-resync.test.ts
@@ -24,6 +24,25 @@ test.describe("Items resync — display derived from value + items", () => {
     await expect(page.getByTestId("cb-swap")).toHaveValue("George Orwell");
   });
 
+  test("Select shows selection after async fill", async ({ page }) => {
+    await page.getByTestId("load").click();
+    await expect(page.getByTestId("sel-fill-selected")).toHaveText("orwell");
+    await expect(page.getByTestId("sel-fill")).toHaveValue("orwell");
+  });
+
+  test("Select shows selection after clear + second async fill", async ({
+    page,
+  }) => {
+    // Second load does not change selected; afterUpdate never re-synced the native value.
+    await page.getByTestId("load").click();
+    await expect(page.getByTestId("sel-fill")).toHaveValue("orwell");
+    await page.getByTestId("clear-fill").click();
+    await expect(page.getByTestId("sel-fill")).toHaveValue("");
+    await page.getByTestId("load").click();
+    await expect(page.getByTestId("sel-fill-selected")).toHaveText("orwell");
+    await expect(page.getByTestId("sel-fill")).toHaveValue("orwell");
+  });
+
   test("ComboBox shows selection after clear + second async fill", async ({
     page,
   }) => {
@@ -33,5 +52,12 @@ test.describe("Items resync — display derived from value + items", () => {
     await expect(page.getByTestId("cb-fill-id")).toHaveText("orwell");
     await page.getByTestId("load").click();
     await expect(page.getByTestId("cb-fill")).toHaveValue("George Orwell");
+  });
+
+  test("Select keeps selection after items ref swap", async ({ page }) => {
+    await expect(page.getByTestId("sel-swap")).toHaveValue("orwell");
+    await page.getByTestId("reload").click();
+    await expect(page.getByTestId("sel-swap-selected")).toHaveText("orwell");
+    await expect(page.getByTestId("sel-swap")).toHaveValue("orwell");
   });
 });

--- a/e2e/items-resync.test.ts
+++ b/e2e/items-resync.test.ts
@@ -1,0 +1,37 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("Items resync — display derived from value + items", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/items-resync.html");
+  });
+
+  test("ComboBox shows preloaded selection at mount", async ({ page }) => {
+    await expect(page.getByTestId("cb-preload-id")).toHaveText("orwell");
+    await expect(page.getByTestId("cb-preload")).toHaveValue("George Orwell");
+  });
+
+  test("ComboBox shows selection after async fill", async ({ page }) => {
+    await expect(page.getByTestId("cb-fill")).toHaveValue("");
+    await page.getByTestId("load").click();
+    await expect(page.getByTestId("cb-fill-id")).toHaveText("orwell");
+    await expect(page.getByTestId("cb-fill")).toHaveValue("George Orwell");
+  });
+
+  test("ComboBox keeps selection after items ref swap", async ({ page }) => {
+    await expect(page.getByTestId("cb-swap")).toHaveValue("George Orwell");
+    await page.getByTestId("reload").click();
+    await expect(page.getByTestId("cb-swap-id")).toHaveText("orwell");
+    await expect(page.getByTestId("cb-swap")).toHaveValue("George Orwell");
+  });
+
+  test("ComboBox shows selection after clear + second async fill", async ({
+    page,
+  }) => {
+    await page.getByTestId("load").click();
+    await expect(page.getByTestId("cb-fill")).toHaveValue("George Orwell");
+    await page.getByTestId("clear-fill").click();
+    await expect(page.getByTestId("cb-fill-id")).toHaveText("orwell");
+    await page.getByTestId("load").click();
+    await expect(page.getByTestId("cb-fill")).toHaveValue("George Orwell");
+  });
+});

--- a/e2e/items-resync.test.ts
+++ b/e2e/items-resync.test.ts
@@ -60,4 +60,42 @@ test.describe("Items resync — display derived from value + items", () => {
     await expect(page.getByTestId("sel-swap-selected")).toHaveText("orwell");
     await expect(page.getByTestId("sel-swap")).toHaveValue("orwell");
   });
+
+  test("MultiSelect keeps selection after items ref swap (control)", async ({
+    page,
+  }) => {
+    await expect(page.getByTestId("ms-swap")).toContainText("1");
+    await page.getByTestId("reload").click();
+    await expect(page.getByTestId("ms-swap-ids")).toHaveText("orwell");
+    await expect(page.getByTestId("ms-swap")).toContainText("1");
+  });
+
+  test("MultiSelect keeps selection through clear + reload cycle", async ({
+    page,
+  }) => {
+    // Items clear dropped checked to 0; afterUpdate wrote selectedIds = [] every other cycle.
+    await page.getByTestId("load").click();
+    await expect(page.getByTestId("ms-fill-ids")).toHaveText("orwell");
+    await expect(page.getByTestId("ms-fill")).toContainText("1");
+
+    await page.getByTestId("clear-fill").click();
+    await expect(page.getByTestId("ms-fill-ids")).toHaveText("orwell");
+
+    await page.getByTestId("load").click();
+    await expect(page.getByTestId("ms-fill-ids")).toHaveText("orwell");
+    await expect(page.getByTestId("ms-fill")).toContainText("1");
+
+    await page.getByTestId("clear-fill").click();
+    await page.getByTestId("load").click();
+    await expect(page.getByTestId("ms-fill-ids")).toHaveText("orwell");
+    await expect(page.getByTestId("ms-fill")).toContainText("1");
+  });
+
+  test("Dropdown shows selection after async fill (reference)", async ({
+    page,
+  }) => {
+    await page.getByTestId("load").click();
+    await expect(page.getByTestId("drop-fill-id")).toHaveText("orwell");
+    await expect(page.getByTestId("drop-fill")).toContainText("George Orwell");
+  });
 });

--- a/src/ComboBox/ComboBox.svelte
+++ b/src/ComboBox/ComboBox.svelte
@@ -416,12 +416,12 @@
           // Only set value programmatically if the input is not focused
           value = itemToString(selectedItem);
         }
-      } else {
-        selectedId = undefined;
-        // Only reset value if the input is not focused and allowCustomValue is false
-        if (!ref.contains(document.activeElement) && !allowCustomValue) {
-          value = "";
-        }
+      } else if (
+        selectedId === undefined &&
+        !ref.contains(document.activeElement) &&
+        !allowCustomValue
+      ) {
+        value = "";
       }
     }
   });
@@ -430,14 +430,18 @@
     prevSelectedId = selectedId;
     selectedItem = undefined;
   } else {
+    // Re-resolve selectedItem when items changes but selectedId does not.
+    const resolvedItem = itemsById.get(selectedId);
     if (prevSelectedId !== selectedId) {
       // Only dispatch select event if not initial render (prevSelectedId was not null)
       const isInitialRender = prevSelectedId === null;
       prevSelectedId = selectedId;
-      selectedItem = itemsById.get(selectedId);
+      selectedItem = resolvedItem;
       if (!isInitialRender) {
         dispatch("select", { selectedId, selectedItem });
       }
+    } else if (resolvedItem !== undefined && resolvedItem !== selectedItem) {
+      selectedItem = resolvedItem;
     }
   }
 

--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -587,6 +587,7 @@
   $: if (items !== prevItemsRef) {
     prevItemsRef = items;
     sortedItems = sort();
+    prevChecked = sortedItems.filter((item) => item.checked);
   }
   $: if (
     selectedIds &&

--- a/src/Select/Select.svelte
+++ b/src/Select/Select.svelte
@@ -84,6 +84,7 @@
     createEventDispatcher,
     getContext,
     setContext,
+    tick,
   } from "svelte";
   import { writable } from "svelte/store";
   import ChevronDown from "../icons/ChevronDown.svelte";
@@ -124,6 +125,7 @@
   setContext("carbon:Select", {
     selectedValue,
     setDefaultValue,
+    syncNativeSelectValue,
   });
 
   function handleChange(event) {
@@ -167,10 +169,22 @@
     prevSelected = selected;
   });
 
+  // Options mounted after selected is set do not update the native value.
+  function syncNativeSelectValue() {
+    tick().then(() => {
+      if (!ref) return;
+      const nextValue = $selectedValue == null ? "" : String($selectedValue);
+      if (ref.value !== nextValue) ref.value = nextValue;
+    });
+  }
+
   $: errorId = `error-${id}`;
   $: warnId = `warn-${id}`;
   $: helperId = `helper-${id}`;
-  $: selectedValue.set(selected ?? $defaultValue);
+  $: {
+    selectedValue.set(selected ?? $defaultValue);
+    syncNativeSelectValue();
+  }
   // Invalid/warn states are suppressed when the select is disabled or read-only.
   $: showInvalid = invalid && !disabled && !readonly;
   $: showWarn = warn && !invalid && !disabled && !readonly;

--- a/src/Select/SelectItem.svelte
+++ b/src/Select/SelectItem.svelte
@@ -42,7 +42,10 @@
   const ctx =
     getContext("carbon:Select") || getContext("carbon:TimePickerSelect");
 
-  $: ctx?.setDefaultValue?.(id, value);
+  $: {
+    ctx?.setDefaultValue?.(id, value);
+    ctx?.syncNativeSelectValue?.();
+  }
 
   let selected = false;
 


### PR DESCRIPTION
I ran into an issue where `ComboBox`, `Select`, and `MultiSelect` would lose their **displayed** selection whenever `items` changes asynchronously, for example when an async fetch fills an empty list, or when a list gets cleared and then repopulated. The retained value/id stays correct the whole time, and it's only the rendered selection that blanks out. `Dropdown` isn't affected here, since it derives its display purely from the items.

## Fix

- **ComboBox**: stopped it from nulling a set `selectedId` while the matching item is simply unresolved (the async items just haven't loaded yet). It now also re-resolves `selectedItem` on every items change, instead of only when the id changes. 
- **Select**: re-assert the native `<select>` value after the DOM updates. The `<option selected>` attribute only maps to the live selection at insert or reset time, so any options added later leave the element sitting at `selectedIndex = -1`.
- **MultiSelect**: update the `prevChecked` snapshot whenever items changes, so an items-driven count change isn't mistaken for the user deselecting something, which was resetting `selectedIds` to `[]`.