### PR TITLE
feat(ui-shell): HeaderSearch menu slot with SearchMenu composition

### DIFF
--- a/css/_ui-shell.scss
+++ b/css/_ui-shell.scss
@@ -394,6 +394,58 @@
     color: $text-secondary;
   }
 
+  // Rich results menu hosted by HeaderSearch's `menu` slot. Positioned like the
+  // legacy header menu, but the inner rows render via the SearchMenu
+  // presentation layer (`_search-menu.scss`) for fuzzy highlighting, groups,
+  // and footer actions.
+  .#{$prefix}--header__search-menu-rich {
+    position: absolute;
+    z-index: 10000;
+    left: 0;
+    right: 0;
+    top: 3rem;
+    padding: $carbon--spacing-03 0;
+    max-height: to-rem(360px);
+    overflow-y: auto;
+    background-color: $layer;
+    border: 1px solid $border-subtle;
+    border-top: none;
+    box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.15);
+
+    // Result text, group headers, and the empty state are flush-left with the
+    // header input text (after the 3rem magnifier button), independent of size.
+    .#{$prefix}--search-menu-item,
+    .#{$prefix}--search-menu-group__header,
+    .#{$prefix}--search-menu__no-results {
+      padding-left: 3rem;
+    }
+
+    // Leading icon centered under the header magnifier (centered in the 3rem
+    // button at 1.5rem); a 16px icon at left: 1rem centers at 1.5rem.
+    .#{$prefix}--search-menu-item__icon {
+      left: 1rem;
+    }
+
+    .#{$prefix}--search-menu-item__icon--right {
+      left: auto;
+      right: 1rem;
+    }
+  }
+
+  // Row density per size. Text alignment is fixed (above); only the row height
+  // changes so smaller sizes fit more results.
+  .#{$prefix}--header__search-menu-rich--sm .#{$prefix}--search-menu-item {
+    min-height: 2rem;
+  }
+
+  .#{$prefix}--header__search-menu-rich--lg .#{$prefix}--search-menu-item {
+    min-height: 2.5rem;
+  }
+
+  .#{$prefix}--header__search-menu-rich--xl .#{$prefix}--search-menu-item {
+    min-height: 3rem;
+  }
+
   .#{$prefix}--header-panel-divider {
     margin: 2rem 1rem 0;
     font-size: 0.75rem;

--- a/docs/src/pages/_module.svelte
+++ b/docs/src/pages/_module.svelte
@@ -11,17 +11,23 @@
     HeaderPanelLinks,
     HeaderSearch,
     HeaderUtilities,
+    SearchMenuGroup,
+    SearchMenuItem,
     SideNav,
     SideNavDivider,
     SideNavItems,
     SideNavLink,
     SkipToContent,
-    Stack,
-    Tag,
     Text,
     Theme,
   } from "carbon-components-svelte";
   import type { HeaderSearchResult } from "carbon-components-svelte/src/UIShell/HeaderSearch.svelte";
+  import {
+    fuzzyMatch,
+    highlightSegments,
+  } from "carbon-components-svelte/src/utils/fuzzyMatch.js";
+  import Code from "carbon-icons-svelte/lib/Code.svelte";
+  import Document from "carbon-icons-svelte/lib/Document.svelte";
   import Launch from "carbon-icons-svelte/lib/Launch.svelte";
   import LogoGithub from "carbon-icons-svelte/lib/LogoGithub.svelte";
   import MiniSearch from "minisearch";
@@ -83,6 +89,33 @@
         isComponent: Boolean(r.isComponent),
       }),
     );
+
+  // Split MiniSearch hits into two groups. MiniSearch already ranks and filters,
+  // so pass shouldFilter={false} and let the default matcher highlight labels.
+  $: componentHits = results.filter((r) => r.isComponent);
+  $: sectionHits = results.filter((r) => !r.isComponent);
+
+  /** Build highlighted label HTML from `segments`. */
+  function toHtml(segments: { text: string; match: boolean }[]) {
+    return segments
+      .map((s) => {
+        const escaped = s.text
+          .replace(/&/g, "&amp;")
+          .replace(/</g, "&lt;")
+          .replace(/>/g, "&gt;");
+        return s.match
+          ? `<strong class="bx--search-menu-item__highlight">${escaped}</strong>`
+          : escaped;
+      })
+      .join("");
+  }
+
+  /** Highlight the current query in arbitrary text (e.g. a description). */
+  function highlightHtml(text: string | undefined) {
+    if (!text) return "";
+    const { matched, indices } = fuzzyMatch(text, value);
+    return toHtml(highlightSegments(text, matched ? (indices ?? []) : []));
+  }
 
   let isOpen = false;
   let isSideNavOpen = true;
@@ -192,10 +225,12 @@
         bind:active
         placeholder="Search"
         spellcheck="false"
-        {results}
-        let:result
+        shouldFilter={false}
         on:select={(e) => {
-          const href = e.detail.selectedResult.href;
+          // Selecting a link item would navigate natively; intercept it and
+          // route through Routify for SPA navigation instead.
+          e.detail.event?.preventDefault();
+          const href = e.detail.item.href;
           // Hash must not be part of the path: getChainTo treats "/" segments literally,
           // so "Toolbar#slug" would not match the Toolbar route node.
           const u = new URL(href, window.location.origin);
@@ -204,22 +239,39 @@
           routifyNav.getNavigate()?.(path, hash ? { "#": hash } : undefined);
         }}
       >
-        {@const hit = result as ModuleSearchResult}
-        <Stack
-          gap={3}
-          orientation="horizontal"
-          style="display: flex; align-items: center;"
-        >
-          {hit.text}
-          {#if hit.description && !hit.isComponent}
-            <span class="bx--header-search-menu-description">
-              {hit.description}
-            </span>
+        <svelte:fragment slot="menu">
+          {#if componentHits.length}
+            <SearchMenuGroup label="Components">
+              {#each componentHits as hit (hit.id)}
+                <SearchMenuItem text={hit.text} href={hit.href} icon={Code} />
+              {/each}
+            </SearchMenuGroup>
           {/if}
-          {#if hit.isComponent}
-            <Tag size="sm" type="blue" style="margin: 0">Component</Tag>
+
+          {#if sectionHits.length}
+            <SearchMenuGroup label="Sections">
+              {#each sectionHits as hit (hit.id)}
+                <SearchMenuItem
+                  text={hit.text}
+                  href={hit.href}
+                  icon={Document}
+                  let:segments
+                >
+                  <span class="docs-search-hit"
+                    ><span>{@html toHtml(segments)}</span>
+                    {#if hit.description}
+                      <span class="bx--header-search-menu-description"
+                        >{@html highlightHtml(hit.description)}</span
+                      >
+                    {/if}</span
+                  >
+                </SearchMenuItem>
+              {/each}
+            </SearchMenuGroup>
           {/if}
-        </Stack>
+        </svelte:fragment>
+
+        <svelte:fragment slot="noResults">No results</svelte:fragment>
       </HeaderSearch>
       <HeaderActionLink
         icon={LogoGithub}
@@ -369,6 +421,19 @@
     .platform-name-full {
       display: none;
     }
+  }
+
+  :global(.docs-search-hit) {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    min-width: 0;
+  }
+
+  :global(.docs-search-hit > span) {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   :global(.bx--side-nav__items .bx--side-nav__divider) {

--- a/docs/src/pages/components/UIShell.svx
+++ b/docs/src/pages/components/UIShell.svx
@@ -126,6 +126,16 @@ Set `icon` to render a different trigger icon. Use `placeholder`, `labelText`, a
 
 <FileSource src="/framed/UIShell/HeaderSearchCustom" />
 
+### Menu slot
+
+Use the `menu` slot to render [SearchMenu](/components/SearchMenu) items in the header. Compose `SearchMenuGroup` and `SearchMenuItem` for grouped, fuzzy-highlighted results with icons, persistent footer actions, and a `loading` skeleton state.
+
+When the `menu` slot is present, it replaces the `results` prop. Keyboard navigation uses `role="option"`. Press Enter with no selection to dispatch `submit`. Use the `noResults` slot when nothing matches. The `results` prop still works if you do not use `menu`.
+
+Set `size` to `"sm"` (default), `"lg"`, or `"xl"` to control row density. Result text stays flush with the header input at every size. Pass `icon` or `iconRight` to each `SearchMenuItem`, or use the default slot with `let:segments` to highlight the query in secondary text like a description.
+
+<FileSource src="/framed/UIShell/HeaderSearchMenu" />
+
 ## Utilities
 
 Add utilities to the header with header utilities. Compose [BadgeIndicator](/components/BadgeIndicator) in the badge slot on `HeaderGlobalAction`. Set `iconDescription` for screen readers.

--- a/docs/src/pages/framed/UIShell/HeaderSearchMenu.svelte
+++ b/docs/src/pages/framed/UIShell/HeaderSearchMenu.svelte
@@ -1,0 +1,83 @@
+<script>
+  import {
+    Content,
+    FormGroup,
+    Header,
+    HeaderSearch,
+    HeaderUtilities,
+    RadioButton,
+    RadioButtonGroup,
+    SearchMenuGroup,
+    SearchMenuItem,
+    SkipToContent,
+  } from "carbon-components-svelte";
+  import Document from "carbon-icons-svelte/lib/Document.svelte";
+  import Launch from "carbon-icons-svelte/lib/Launch.svelte";
+
+  const docs = [
+    { id: "accordion", text: "Accordion", href: "/components/Accordion" },
+    { id: "button", text: "Button", href: "/components/Button" },
+    { id: "data-table", text: "DataTable", href: "/components/DataTable" },
+    { id: "dropdown", text: "Dropdown", href: "/components/Dropdown" },
+    { id: "search-menu", text: "SearchMenu", href: "/components/SearchMenu" },
+    { id: "header-search", text: "HeaderSearch", href: "/components/UIShell" },
+  ];
+
+  let value = "";
+  let active = false;
+  let size = "sm";
+  let events = [];
+</script>
+
+<Header companyName="Carbon" platformName="Svelte">
+  <svelte:fragment slot="skipToContent"><SkipToContent /></svelte:fragment>
+  <HeaderUtilities>
+    <HeaderSearch
+      bind:value
+      bind:active
+      {size}
+      placeholder="Search..."
+      on:select={(e) => (events = [{ type: "select", ...e.detail }, ...events])}
+      on:submit={(e) => (events = [{ type: "submit", ...e.detail }, ...events])}
+      on:close={(e) => (events = [{ type: "close", ...e.detail }, ...events])}
+    >
+      <svelte:fragment slot="menu">
+        <SearchMenuGroup label="Docs">
+          {#each docs as doc (doc.id)}
+            <SearchMenuItem text={doc.text} href={doc.href} icon={Document} />
+          {/each}
+        </SearchMenuGroup>
+
+        <SearchMenuGroup divider>
+          <SearchMenuItem
+            persistent
+            iconRight={Launch}
+            href="https://www.google.com/search?q={encodeURIComponent(value)}"
+          >
+            Search "{value}" in <strong>Docs</strong>
+          </SearchMenuItem>
+        </SearchMenuGroup>
+      </svelte:fragment>
+
+      <svelte:fragment slot="noResults">No matching components</svelte:fragment>
+    </HeaderSearch>
+  </HeaderUtilities>
+</Header>
+
+<Content>
+  <h1>HeaderSearch (menu slot)</h1>
+  <p>
+    Open search and type a component name (e.g. "data"). Results fuzzy-match and
+    highlight, grouped under a header, with a persistent footer action.
+  </p>
+
+  <FormGroup legendText="Menu size">
+    <RadioButtonGroup bind:selected={size}>
+      <RadioButton value="sm" labelText="Small" />
+      <RadioButton value="lg" labelText="Large" />
+      <RadioButton value="xl" labelText="Extra large" />
+    </RadioButtonGroup>
+  </FormGroup>
+
+  <pre>{JSON.stringify(events.slice(0, 5), null, 2)}</pre>
+</Content>

--- a/src/UIShell/HeaderSearch.svelte
+++ b/src/UIShell/HeaderSearch.svelte
@@ -24,7 +24,11 @@
    * @property {string} value
    * @property {number} selectedResultIndex
    * @property {Result} selectedResult
+   * @event {{ value: string }} submit
    * @slot {{ result: Result; index: number; selected: boolean; }}
+   * @slot {{}} menu
+   * @slot {{}} noResults
+   * @slot {{}} loading
    */
 
   /**
@@ -73,10 +77,45 @@
   /** Specify the label for the clear button. */
   export let closeButtonLabelText = "Clear search input";
 
-  import { createEventDispatcher, tick } from "svelte";
+  /**
+   * Set to `true` to filter `menu`-slot items by the search value using fuzzy
+   * matching. Requires the `menu` slot; ignored when using the `results` prop.
+   */
+  export let shouldFilter = true;
+
+  /**
+   * Override how the search value is matched against each `menu`-slot item's
+   * `text`. Receives the item `text` and the current search value, and returns
+   * whether the item `matched` along with the `indices` of characters to
+   * highlight. Defaults to fuzzy matching. Requires the `menu` slot.
+   * @type {(text: string, query: string) => { matched: boolean; indices?: number[] }}
+   */
+  export let match = fuzzyMatch;
+
+  /**
+   * Set to `true` to render a skeleton menu while results are loading.
+   * Override the placeholder rows with the `loading` slot. Requires the
+   * `menu` slot.
+   */
+  export let loading = false;
+
+  /** Number of skeleton rows while `loading`. Requires the `menu` slot. */
+  export let skeletonCount = 4;
+
+  /**
+   * Row density for the `menu` slot. Result text stays flush with the header
+   * input; smaller sizes shorten rows to fit more results.
+   * @type {"sm" | "lg" | "xl"}
+   */
+  export let size = "sm";
+
+  import { createEventDispatcher, setContext, tick } from "svelte";
+  import { writable } from "svelte/store";
   import Close from "../icons/Close.svelte";
   import IconSearch from "../icons/IconSearch.svelte";
+  import SkeletonText from "../SkeletonText/SkeletonText.svelte";
   import { dismiss } from "../utils/dismiss.js";
+  import { fuzzyMatch } from "../utils/fuzzyMatch.js";
   import { isOutsideClick } from "../utils/isOutsideClick.js";
 
   const dispatch = createEventDispatcher();
@@ -88,12 +127,168 @@
 
   /** @type {null | HTMLDivElement} */
   let refSearch = null;
+  /** @type {null | HTMLElement} */
+  let menuRef = null;
   let prevActive;
+  // Escape closes the menu but leaves the search bar open.
+  let menuDismissed = false;
+
+  // `menu` slot shares SearchMenu context with SearchMenuItem/SearchMenuGroup.
+  $: richMenu = Boolean($$slots.menu);
+
+  const queryStore = writable("");
+  const shouldFilterStore = writable(shouldFilter);
+  const matchStore = writable(match);
+  const activeId = writable(/** @type {string | null} */ (null));
+  const hasPrimaryItemsStore = writable(false);
+
+  let itemIds = new Set();
+  let filterableIds = new Set();
+  let primaryItemIds = new Set();
+
+  $: queryStore.set(String(value ?? ""));
+  $: shouldFilterStore.set(shouldFilter);
+  $: matchStore.set(match);
+  $: hasPrimaryItemsStore.set(primaryItemIds.size > 0);
+
+  const SKELETON_WIDTHS = ["75%", "90%", "65%", "80%"];
+  $: skeletonWidths = Array.from(
+    { length: Math.max(0, skeletonCount) },
+    (_, i) => SKELETON_WIDTHS[i % SKELETON_WIDTHS.length],
+  );
+
+  $: itemCount = itemIds.size;
+  $: hasQuery = String(value ?? "").length > 0;
+  $: showNoResults =
+    richMenu &&
+    !loading &&
+    hasQuery &&
+    filterableIds.size === 0 &&
+    itemCount === 0 &&
+    $$slots.noResults;
+  $: richMenuVisible =
+    richMenu &&
+    active &&
+    !menuDismissed &&
+    (loading || itemCount > 0 || showNoResults);
+
+  setContext("carbon:SearchMenu", {
+    query: queryStore,
+    shouldFilter: shouldFilterStore,
+    match: matchStore,
+    activeId,
+    setActiveId(next) {
+      activeId.set(next);
+    },
+    selectItem(detail) {
+      value = detail.value ?? value;
+      dispatch("select", detail);
+      reset();
+      dispatch("close", { trigger: "select" });
+    },
+    hasPrimaryItems: hasPrimaryItemsStore,
+    registerItem(itemId, filterable, inDividerGroup = false) {
+      itemIds.add(itemId);
+      if (filterable) filterableIds.add(itemId);
+      else filterableIds.delete(itemId);
+      if (inDividerGroup) primaryItemIds.delete(itemId);
+      else primaryItemIds.add(itemId);
+      itemIds = itemIds;
+      filterableIds = filterableIds;
+      primaryItemIds = primaryItemIds;
+    },
+    unregisterItem(itemId) {
+      itemIds.delete(itemId);
+      filterableIds.delete(itemId);
+      primaryItemIds.delete(itemId);
+      itemIds = itemIds;
+      filterableIds = filterableIds;
+      primaryItemIds = primaryItemIds;
+    },
+  });
+
+  function getOptionElements() {
+    if (!menuRef) return [];
+    return Array.from(menuRef.querySelectorAll('[role="option"]')).filter(
+      (el) => el.getAttribute("aria-disabled") !== "true",
+    );
+  }
+
+  function moveActive(step) {
+    const els = getOptionElements();
+    if (els.length === 0) {
+      activeId.set(null);
+      return;
+    }
+    const current = els.findIndex((el) => el.id === $activeId);
+    let next = current + step;
+    if (next < 0) next = els.length - 1;
+    else if (next >= els.length) next = 0;
+    activeId.set(els[next].id);
+  }
+
+  function setActiveEdge(edge) {
+    const els = getOptionElements();
+    if (els.length === 0) return;
+    activeId.set(els[edge === "first" ? 0 : els.length - 1].id);
+  }
+
+  /** Keyboard navigation for the `menu` slot (`role="option"`). */
+  function handleRichKeydown(event) {
+    switch (event.key) {
+      case "ArrowDown":
+        event.preventDefault();
+        menuDismissed = false;
+        if (richMenuVisible) moveActive(1);
+        break;
+      case "ArrowUp":
+        if (!richMenuVisible) return;
+        event.preventDefault();
+        moveActive(-1);
+        break;
+      case "Home":
+        if (!richMenuVisible) return;
+        event.preventDefault();
+        setActiveEdge("first");
+        break;
+      case "End":
+        if (!richMenuVisible) return;
+        event.preventDefault();
+        setActiveEdge("last");
+        break;
+      case "Enter": {
+        const active = $activeId
+          ? getOptionElements().find((el) => el.id === $activeId)
+          : null;
+        if (richMenuVisible && active) {
+          event.preventDefault();
+          active.click();
+        } else {
+          dispatch("submit", { value });
+        }
+        break;
+      }
+      case "Escape":
+        if (richMenuVisible) {
+          // Close the menu but keep the bar active and the value intact.
+          menuDismissed = true;
+          activeId.set(null);
+        } else if (value === "") {
+          active = false;
+          dispatch("close", { trigger: "escape-key" });
+        } else {
+          value = "";
+        }
+        break;
+    }
+  }
 
   function reset() {
     active = false;
     value = "";
     selectedResultIndex = 0;
+    menuDismissed = false;
+    activeId.set(null);
   }
 
   function selectResult() {
@@ -118,8 +313,16 @@
   function handleOutsideMouseup(event) {
     if (active && isOutsideClick(event, refSearch)) {
       active = false;
+      activeId.set(null);
+      menuDismissed = false;
       dispatch("close", { trigger: "outside-click" });
     }
+  }
+
+  // Clicks on group headers or padding blur the input; refocus so only item
+  // selection closes the menu.
+  function handleMenuPointerDown() {
+    ref?.focus();
   }
 </script>
 
@@ -162,16 +365,25 @@
       class:bx--header__search--active={active}
       {...$$restProps}
       id={inputId}
+      role={richMenu ? "combobox" : undefined}
       aria-autocomplete="list"
       aria-controls={menuId}
-      aria-activedescendant={selectedId}
+      aria-expanded={richMenu ? richMenuVisible : undefined}
+      aria-activedescendant={richMenu ? ($activeId ?? undefined) : selectedId}
       bind:value
       on:change
       on:input
+      on:input={() => {
+        if (richMenu) menuDismissed = false;
+      }}
       on:focus
       on:blur
       on:keydown
       on:keydown={(event) => {
+        if (richMenu) {
+          handleRichKeydown(event);
+          return;
+        }
         switch (event.key) {
           case "Enter":
             selectResult();
@@ -225,7 +437,37 @@
     {/if}
   </div>
 
-  {#if active && results.length > 0}
+  {#if richMenu && active}
+    <!-- svelte-ignore a11y-no-static-element-interactions -->
+    <div
+      bind:this={menuRef}
+      id={menuId}
+      role="listbox"
+      tabindex="-1"
+      aria-label="Search"
+      aria-busy={loading || undefined}
+      hidden={!richMenuVisible}
+      class="bx--header__search-menu-rich bx--header__search-menu-rich--{size}"
+      on:mousedown={handleMenuPointerDown}
+    >
+      {#if loading}
+        <slot name="loading">
+          {#each skeletonWidths as width, i (i)}
+            <div class="bx--search-menu-item bx--search-menu-item--skeleton">
+              <SkeletonText {width} />
+            </div>
+          {/each}
+        </slot>
+      {:else}
+        <slot name="menu" />
+        {#if showNoResults}
+          <div class="bx--search-menu__no-results">
+            <slot name="noResults" />
+          </div>
+        {/if}
+      {/if}
+    </div>
+  {:else if active && results.length > 0}
     <!-- svelte-ignore a11y-no-noninteractive-element-to-interactive-role -->
     <ul
       aria-labelledby={labelId}

--- a/tests/UIShell/HeaderSearchMenu.test.svelte
+++ b/tests/UIShell/HeaderSearchMenu.test.svelte
@@ -1,0 +1,53 @@
+<svelte:options accessors />
+
+<script lang="ts">
+  import SearchMenuGroup from "carbon-components-svelte/SearchMenu/SearchMenuGroup.svelte";
+  import SearchMenuItem from "carbon-components-svelte/SearchMenu/SearchMenuItem.svelte";
+  import HeaderSearch from "carbon-components-svelte/UIShell/HeaderSearch.svelte";
+  import type { ComponentProps } from "svelte";
+
+  export let active = true;
+  export let value = "";
+  export let size: ComponentProps<HeaderSearch>["size"] = undefined;
+
+  export let selected: { value: string; submitted: boolean } = {
+    value: "",
+    submitted: false,
+  };
+  export let closeTrigger = "";
+
+  const items = [
+    "Databases for TestSQL",
+    "AT&T IoT Data Plans",
+    "Data Store for Memcache",
+    "HazardHub Property Risk Data API",
+  ];
+</script>
+
+<HeaderSearch
+  bind:active
+  bind:value
+  {size}
+  on:select={(e) => (selected = { value: e.detail.value, submitted: false })}
+  on:submit={(e) => (selected = { value: e.detail.value, submitted: true })}
+  on:close={(e) => (closeTrigger = e.detail.trigger)}
+>
+  <svelte:fragment slot="menu">
+    <SearchMenuGroup label="Results">
+      {#each items as text (text)}
+        <SearchMenuItem {text} />
+      {/each}
+    </SearchMenuGroup>
+
+    <SearchMenuGroup divider>
+      <SearchMenuItem persistent value="__all__" text="Search everywhere" />
+    </SearchMenuGroup>
+  </svelte:fragment>
+
+  <svelte:fragment slot="noResults">No results</svelte:fragment>
+</HeaderSearch>
+
+<div data-testid="result">
+  {selected.submitted ? "submit:" : ""}{selected.value}
+</div>
+<div data-testid="close">{closeTrigger}</div>

--- a/tests/UIShell/HeaderSearchMenu.test.ts
+++ b/tests/UIShell/HeaderSearchMenu.test.ts
@@ -1,0 +1,127 @@
+import { render, screen } from "@testing-library/svelte";
+import { user } from "../utils/user";
+import HeaderSearchMenu from "./HeaderSearchMenu.test.svelte";
+
+describe("HeaderSearch (menu slot)", () => {
+  it("renders a listbox when active instead of the results menu", async () => {
+    render(HeaderSearchMenu, { props: { active: true } });
+
+    const listbox = await screen.findByRole("listbox");
+    expect(listbox).toBeInTheDocument();
+    // role="menu" is not used when the menu slot is present.
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    // Four filterable items + one persistent footer item.
+    expect(screen.getAllByRole("option")).toHaveLength(5);
+    expect(screen.getByText("Results")).toBeInTheDocument();
+  });
+
+  it("does not render the menu when inactive", () => {
+    render(HeaderSearchMenu, { props: { active: false } });
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+  });
+
+  it("fuzzy-filters items while keeping persistent items visible", async () => {
+    render(HeaderSearchMenu, { props: { active: true } });
+    const input = screen.getByRole("combobox");
+    await user.type(input, "memcache");
+
+    const options = screen.getAllByRole("option");
+    expect(options).toHaveLength(2);
+    expect(options[0]).toHaveTextContent("Data Store for Memcache");
+    // Persistent footer item stays visible when other items match.
+    expect(options[1]).toHaveTextContent("Search everywhere");
+  });
+
+  it("keeps only persistent items for a no-match query", async () => {
+    render(HeaderSearchMenu, { props: { active: true } });
+    const input = screen.getByRole("combobox");
+    await user.type(input, "zzzznomatch");
+
+    const options = screen.getAllByRole("option");
+    expect(options).toHaveLength(1);
+    expect(options[0]).toHaveTextContent("Search everywhere");
+  });
+
+  it("highlights the matched portion of each item", async () => {
+    const { container } = render(HeaderSearchMenu, { props: { active: true } });
+    const input = screen.getByRole("combobox");
+    await user.type(input, "Data");
+
+    const highlights = container.querySelectorAll(
+      ".bx--search-menu-item__highlight",
+    );
+    expect(highlights.length).toBeGreaterThan(0);
+    expect(highlights[0]).toHaveTextContent("Data");
+  });
+
+  it("navigates with the arrow keys and selects with Enter", async () => {
+    render(HeaderSearchMenu, { props: { active: true } });
+    const input = screen.getByRole("combobox");
+    await user.click(input);
+    await user.keyboard("{ArrowDown}");
+
+    const firstOption = screen.getAllByRole("option")[0];
+    expect(firstOption).toHaveAttribute("aria-selected", "true");
+    expect(input).toHaveAttribute("aria-activedescendant", firstOption.id);
+
+    await user.keyboard("{Enter}");
+
+    expect(screen.getByTestId("result")).toHaveTextContent(
+      "Databases for TestSQL",
+    );
+    // Selecting an item closes the menu (the bar collapses).
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+  });
+
+  it("dispatches submit when Enter is pressed with no active item", async () => {
+    render(HeaderSearchMenu, { props: { active: true } });
+    const input = screen.getByRole("combobox");
+    await user.type(input, "free text");
+    await user.keyboard("{Enter}");
+
+    expect(screen.getByTestId("result")).toHaveTextContent("submit:free text");
+  });
+
+  it("closes the menu on Escape but preserves the value and active state", async () => {
+    render(HeaderSearchMenu, { props: { active: true } });
+    const input = screen.getByRole("combobox");
+    await user.type(input, "Data");
+    expect(await screen.findByRole("listbox")).toBeInTheDocument();
+
+    await user.keyboard("{Escape}");
+
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    expect(input).toHaveValue("Data");
+    expect(screen.getByRole("search")).toHaveClass(
+      "bx--header__search--active",
+    );
+    expect(screen.getByTestId("close")).toHaveTextContent("");
+  });
+
+  it("sets aria-expanded and aria-controls on the input", async () => {
+    render(HeaderSearchMenu, { props: { active: true } });
+    const input = screen.getByRole("combobox");
+    const listbox = await screen.findByRole("listbox");
+
+    expect(input).toHaveAttribute("aria-expanded", "true");
+    expect(input).toHaveAttribute("aria-controls", listbox.id);
+  });
+
+  it("defaults to the small (compact) size", async () => {
+    const { container } = render(HeaderSearchMenu, { props: { active: true } });
+    await screen.findByRole("listbox");
+
+    const menu = container.querySelector(".bx--header__search-menu-rich");
+    expect(menu).toHaveClass("bx--header__search-menu-rich--sm");
+  });
+
+  it("applies the requested size", async () => {
+    const { container } = render(HeaderSearchMenu, {
+      props: { active: true, size: "xl" },
+    });
+    await screen.findByRole("listbox");
+
+    const menu = container.querySelector(".bx--header__search-menu-rich");
+    expect(menu).toHaveClass("bx--header__search-menu-rich--xl");
+  });
+});


### PR DESCRIPTION
## Summary

`HeaderSearch` gains an optional `menu` slot that composes existing `SearchMenuGroup` and `SearchMenuItem` components through the shared `carbon:SearchMenu` context. Fuzzy filtering, highlighting, persistent footer actions, loading skeletons, and keyboard navigation reuse the same APIs as standalone `SearchMenu`, so header search stays consistent without duplicating logic. The change is fully backwards compatible: the `results` prop and default result slot continue to work when `menu` is not provided. The docs site search now uses this pattern, with grouped component and section hits.

```svelte
<HeaderSearch bind:value bind:active size="sm">
  <svelte:fragment slot="menu">
    <SearchMenuGroup label="Docs">
      {#each docs as doc (doc.id)}
        <SearchMenuItem text={doc.text} href={doc.href} icon={Document} />
      {/each}
    </SearchMenuGroup>

    <SearchMenuGroup divider>
      <SearchMenuItem persistent iconRight={Launch} href={searchUrl}>
        Search "{value}" in Docs
      </SearchMenuItem>
    </SearchMenuGroup>
  </svelte:fragment>

  <svelte:fragment slot="noResults">No matching results</svelte:fragment>
</HeaderSearch>
```

<img width="733" height="453" alt="Screenshot 2026-06-26 at 1 51 47 PM" src="https://github.com/user-attachments/assets/5b72e72a-6b00-4c44-9625-ddc347fdc594" />
