### PR TITLE
chore: export `fuzzyMatch` util

### DIFF
--- a/docs/src/pages/components/ComboBox.svx
+++ b/docs/src/pages/components/ComboBox.svx
@@ -208,7 +208,7 @@ You can provide a custom `shouldFilterItem` to change the filtering logic. See t
 
 ### Fuzzy filter
 
-Provide a custom `shouldFilterItem` to override the default prefix matching used by typeahead. In this example, a simple fuzzy filter is used where each typed character must appear in order within the item text (for example, "ba" matches "Banana" and "Blackberry").
+Provide a custom `shouldFilterItem` to override the default prefix matching used by typeahead. This example reuses the built-in `fuzzyMatch` util, exported from `carbon-components-svelte`, as the predicate. It matches items whose text contains the typed characters in order (for example, "bl" matches "Blueberry" and "Blackberry"). Only the `matched` boolean is used here; the `score` and `indices` it also returns are intended for ranked, highlighted search surfaces such as [SearchMenu](/components/SearchMenu).
 
 <FileSource src="/framed/ComboBox/TypeaheadCustomFilter" />
 

--- a/docs/src/pages/components/MultiSelect.svx
+++ b/docs/src/pages/components/MultiSelect.svx
@@ -150,6 +150,12 @@ Enable filtering by setting `filterable` to `true`. This example includes a plac
     {id: "2", text: "Fax"}]}"
   />
 
+### Fuzzy filter
+
+Provide a custom `filterItem` to override the default substring matching. This example reuses the built-in `fuzzyMatch` util, exported from `carbon-components-svelte`, as the predicate. It matches items whose text contains the typed characters in order (for example, "bl" matches "Blueberry" and "Blackberry"). Only the `matched` boolean is used here; the `score` and `indices` it also returns are intended for ranked, highlighted search surfaces such as [SearchMenu](/components/SearchMenu).
+
+<FileSource src="/framed/MultiSelect/MultiSelectFuzzyFilter" />
+
 ## Multiple multi-selects
 
 Manage multiple dropdowns in a form with coordinated state.

--- a/docs/src/pages/components/SearchMenu.svx
+++ b/docs/src/pages/components/SearchMenu.svx
@@ -88,7 +88,7 @@ Fuzzy matching prefers a contiguous substring, ranking a prefix above a word bou
 
 ### Custom fuzzy options
 
-Import `fuzzyMatch` from `carbon-components-svelte/src/utils/fuzzyMatch` to reuse the built-in matcher with custom options. Pass an options object as the third argument to tune sensitivity: set `threshold` to a value between `0` and `1` to require a minimum match quality (`0`, the default, accepts any match; `0.5` requires a contiguous substring; `0.7` a word-boundary substring; and `0.9` a prefix). Set `caseSensitive` to `true` to match the exact case. Pass it to the `match` prop.
+Import `fuzzyMatch` from `carbon-components-svelte` to reuse the built-in matcher with custom options. Pass an options object as the third argument to tune sensitivity: set `threshold` to a value between `0` and `1` to require a minimum match quality (`0`, the default, accepts any match; `0.5` requires a contiguous substring; `0.7` a word-boundary substring; and `0.9` a prefix). Set `caseSensitive` to `true` to match the exact case. Pass it to the `match` prop.
 
 <FileSource src="/framed/SearchMenu/CustomFuzzyOptions" />
 

--- a/docs/src/pages/framed/ComboBox/TypeaheadCustomFilter.svelte
+++ b/docs/src/pages/framed/ComboBox/TypeaheadCustomFilter.svelte
@@ -1,24 +1,13 @@
 <script>
-  import { ComboBox } from "carbon-components-svelte";
+  import { ComboBox, fuzzyMatch } from "carbon-components-svelte";
 
   let selectedId = undefined;
 
-  /**
-   * Simple fuzzy filter: each character in the query
-   * must appear in order within the item text.
-   * e.g., "bl" matches "Blueberry" and "Blackberry".
-   */
-  function shouldFilterItem(item, value) {
-    if (!value) return true;
-    const text = item.text.toLowerCase();
-    let j = 0;
-    for (const char of value.toLowerCase()) {
-      j = text.indexOf(char, j);
-      if (j === -1) return false;
-      j++;
-    }
-    return true;
-  }
+  // Reuse the built-in fuzzy matcher as the filter predicate. Each typed
+  // character must appear in order within the item text, so "bl" matches
+  // "Blueberry" and "Blackberry". Only the `matched` boolean is used here.
+  const shouldFilterItem = (item, value) =>
+    fuzzyMatch(item.text, value).matched;
 </script>
 
 <ComboBox

--- a/docs/src/pages/framed/MultiSelect/MultiSelectFuzzyFilter.svelte
+++ b/docs/src/pages/framed/MultiSelect/MultiSelectFuzzyFilter.svelte
@@ -1,0 +1,27 @@
+<script>
+  import { fuzzyMatch, MultiSelect } from "carbon-components-svelte";
+
+  // Reuse the built-in fuzzy matcher as the filter predicate. Each typed
+  // character must appear in order within the item text, so "bl" matches
+  // "Blueberry" and "Blackberry". Only the `matched` boolean is used here.
+  const filterItem = (item, value) => fuzzyMatch(item.text, value).matched;
+</script>
+
+<MultiSelect
+  filterable
+  {filterItem}
+  labelText="Item"
+  placeholder="Filter items..."
+  items={[
+    { id: "0", text: "Apple" },
+    { id: "1", text: "Apricot" },
+    { id: "2", text: "Banana" },
+    { id: "3", text: "Blueberry" },
+    { id: "4", text: "Blackberry" },
+    { id: "5", text: "Cherry" },
+    { id: "6", text: "Cranberry" },
+    { id: "7", text: "Grape" },
+    { id: "8", text: "Mango" },
+    { id: "9", text: "Pineapple" },
+  ]}
+/>

--- a/docs/src/pages/framed/SearchMenu/CustomFuzzyOptions.svelte
+++ b/docs/src/pages/framed/SearchMenu/CustomFuzzyOptions.svelte
@@ -1,6 +1,9 @@
 <script>
-  import { SearchMenu, SearchMenuItem } from "carbon-components-svelte";
-  import { fuzzyMatch } from "carbon-components-svelte/src/utils/fuzzyMatch";
+  import {
+    fuzzyMatch,
+    SearchMenu,
+    SearchMenuItem,
+  } from "carbon-components-svelte";
 
   let value = "Data";
 

--- a/src/index.js
+++ b/src/index.js
@@ -212,4 +212,5 @@ export {
   filterTreeByText,
   filterTreeNodes,
 } from "./utils/filterTreeNodes";
+export { fuzzyMatch } from "./utils/fuzzyMatch";
 export { toHierarchy } from "./utils/toHierarchy";

--- a/tests/ComboBox/ComboBox.test.ts
+++ b/tests/ComboBox/ComboBox.test.ts
@@ -2,6 +2,7 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/svelte";
 import type ComboBoxComponent from "carbon-components-svelte/ComboBox/ComboBox.svelte";
 import type { ComboBoxItem } from "carbon-components-svelte/ComboBox/ComboBox.svelte";
 import ComboBoxReal from "carbon-components-svelte/ComboBox/ComboBox.svelte";
+import { fuzzyMatch } from "carbon-components-svelte/utils/fuzzyMatch";
 import type { ComponentEvents, ComponentProps } from "svelte";
 import { tick } from "svelte";
 import { user } from "../utils/user";
@@ -784,6 +785,27 @@ describe("ComboBox", () => {
     const options = screen.getAllByRole("option");
     expect(options).toHaveLength(1);
     expect(options[0]).toHaveTextContent("Banana");
+  });
+
+  it("should support fuzzyMatch as shouldFilterItem", async () => {
+    render(ComboBoxCustom, {
+      props: {
+        items: [
+          { id: "1", text: "Apple" },
+          { id: "2", text: "Blueberry" },
+          { id: "3", text: "Blackberry" },
+        ],
+        shouldFilterItem: (item: { text: string }, value: string) =>
+          fuzzyMatch(item.text, value).matched,
+      },
+    });
+    const input = getInput();
+    await user.click(input);
+    await user.type(input, "b");
+    const options = screen.getAllByRole("option");
+    expect(options).toHaveLength(2);
+    expect(options[0]).toHaveTextContent("Blueberry");
+    expect(options[1]).toHaveTextContent("Blackberry");
   });
 
   it("should use custom itemToString function", async () => {

--- a/tests/MultiSelect/MultiSelect.test.ts
+++ b/tests/MultiSelect/MultiSelect.test.ts
@@ -7,6 +7,7 @@ import {
 } from "@testing-library/svelte";
 import type MultiSelectComponent from "carbon-components-svelte/MultiSelect/MultiSelect.svelte";
 import type { MultiSelectItem } from "carbon-components-svelte/MultiSelect/MultiSelect.svelte";
+import { fuzzyMatch } from "carbon-components-svelte/utils/fuzzyMatch";
 import type { ComponentEvents, ComponentProps } from "svelte";
 import { tick } from "svelte";
 import { user } from "../utils/user";
@@ -596,6 +597,26 @@ describe("MultiSelect", () => {
           { id: "0", text: "Slack", checked: false },
         ],
       });
+    });
+
+    it("supports fuzzyMatch as filterItem", async () => {
+      render(MultiSelect, {
+        props: {
+          items,
+          filterable: true,
+          filterItem: (item: MultiSelectItem, value: string) =>
+            fuzzyMatch(item.text, value).matched,
+        },
+      });
+
+      const input = screen.getByRole("combobox");
+      await user.click(input);
+      // Subsequence match: "sk" matches "Slack" but no substring would.
+      await user.type(input, "sk");
+
+      expect(screen.getByText("Slack")).toBeInTheDocument();
+      expect(screen.queryByText("Email")).not.toBeInTheDocument();
+      expect(screen.queryByText("Fax")).not.toBeInTheDocument();
     });
 
     it("does not clear bound `value` on initial render when not filterable", async () => {

--- a/tests/package-exports.test-d.ts
+++ b/tests/package-exports.test-d.ts
@@ -3,6 +3,7 @@ import type {
   DataTable as BarrelDataTable,
   breakpointObserver,
   breakpoints,
+  fuzzyMatch,
 } from "carbon-components-svelte";
 import type breakpointObserverDefault from "carbon-components-svelte/src/Breakpoint/breakpointObserver.js";
 import type { BreakpointSize } from "carbon-components-svelte/src/Breakpoint/breakpoints.js";
@@ -33,6 +34,7 @@ type _Button = Button;
 type _CarbonTheme = CarbonTheme;
 type _DataTable = DataTable;
 type _DataTableRow = DataTableRow<{ id: string; name: string }>;
+type _FuzzyMatch = ReturnType<typeof fuzzyMatch>;
 type _HeaderSearchResult = HeaderSearchResult;
 type _ThemeProps = ThemeProps;
 type _Themes = typeof themes;


### PR DESCRIPTION
Export the utility added for `SearchMenu`. Allow it to be used for customizing fuzzy search for `SearchMenu`, `ComboBox`, and `Dropdown`.

Future work: support a similar character highlighting API for list box.