### PR TITLE
chore(combo-box): clear stale display when items no longer resolve selectedId

### DIFF
--- a/e2e/fixtures/ItemsResyncFixture.svelte
+++ b/e2e/fixtures/ItemsResyncFixture.svelte
@@ -16,6 +16,12 @@
     { id: "woolf", text: "Virginia Woolf" },
   ];
 
+  const makeWithoutOrwell = () => [
+    { id: "austen", text: "Jane Austen" },
+    { id: "dickens", text: "Charles Dickens" },
+    { id: "woolf", text: "Virginia Woolf" },
+  ];
+
   const cbPreloadItems = make();
   let cbPreloadSelectedId = "orwell";
   let cbPreloadValue = "";
@@ -27,6 +33,10 @@
   let cbSwapItems = make();
   let cbSwapSelectedId = "orwell";
   let cbSwapValue = "George Orwell";
+
+  let cbRemoveItems = make();
+  let cbRemoveSelectedId = "orwell";
+  let cbRemoveValue = "";
 
   let selFillItems = [];
   let selFillSelected = "orwell";
@@ -56,9 +66,12 @@
     msSwapItems = make();
   }
 
+  function reloadWithoutOrwell() {
+    cbRemoveItems = makeWithoutOrwell();
+  }
+
   function clearFill() {
     cbFillItems = [];
-    cbFillValue = "";
     selFillItems = [];
     msFillItems = [];
   }
@@ -70,6 +83,13 @@
 </button>
 <button type="button" data-testid="clear-fill" on:click={clearFill}>
   Clear fill
+</button>
+<button
+  type="button"
+  data-testid="reload-without-orwell"
+  on:click={reloadWithoutOrwell}
+>
+  Reload without orwell
 </button>
 
 <ComboBox
@@ -98,6 +118,15 @@
   bind:value={cbSwapValue}
 />
 <p data-testid="cb-swap-id">{cbSwapSelectedId}</p>
+
+<ComboBox
+  data-testid="cb-remove"
+  labelText="ComboBox remove"
+  items={cbRemoveItems}
+  bind:selectedId={cbRemoveSelectedId}
+  bind:value={cbRemoveValue}
+/>
+<p data-testid="cb-remove-id">{cbRemoveSelectedId}</p>
 
 <Select
   data-testid="sel-fill"

--- a/e2e/items-resync.test.ts
+++ b/e2e/items-resync.test.ts
@@ -54,6 +54,25 @@ test.describe("Items resync — display derived from value + items", () => {
     await expect(page.getByTestId("cb-fill")).toHaveValue("George Orwell");
   });
 
+  test("ComboBox clears input when fill items clear but selectedId is preserved", async ({
+    page,
+  }) => {
+    await page.getByTestId("load").click();
+    await expect(page.getByTestId("cb-fill")).toHaveValue("George Orwell");
+    await page.getByTestId("clear-fill").click();
+    await expect(page.getByTestId("cb-fill-id")).toHaveText("orwell");
+    await expect(page.getByTestId("cb-fill")).toHaveValue("");
+  });
+
+  test("ComboBox clears input when selected id is removed from items", async ({
+    page,
+  }) => {
+    await expect(page.getByTestId("cb-remove")).toHaveValue("George Orwell");
+    await page.getByTestId("reload-without-orwell").click();
+    await expect(page.getByTestId("cb-remove-id")).toHaveText("orwell");
+    await expect(page.getByTestId("cb-remove")).toHaveValue("");
+  });
+
   test("Select keeps selection after items ref swap", async ({ page }) => {
     await expect(page.getByTestId("sel-swap")).toHaveValue("orwell");
     await page.getByTestId("reload").click();

--- a/src/ComboBox/ComboBox.svelte
+++ b/src/ComboBox/ComboBox.svelte
@@ -417,7 +417,7 @@
           value = itemToString(selectedItem);
         }
       } else if (
-        selectedId === undefined &&
+        !selectedItem &&
         !ref.contains(document.activeElement) &&
         !allowCustomValue
       ) {
@@ -440,7 +440,7 @@
       if (!isInitialRender) {
         dispatch("select", { selectedId, selectedItem });
       }
-    } else if (resolvedItem !== undefined && resolvedItem !== selectedItem) {
+    } else if (resolvedItem !== selectedItem) {
       selectedItem = resolvedItem;
     }
   }

--- a/tests/ComboBox/ComboBox.test.ts
+++ b/tests/ComboBox/ComboBox.test.ts
@@ -1214,6 +1214,28 @@ describe("ComboBox", () => {
     expect(input).toHaveValue("");
   });
 
+  it("should clear input display when items clear but selectedId is preserved", async () => {
+    const items = [
+      { id: "0", text: "Slack", price: 100 },
+      { id: "1", text: "Email", price: 200 },
+    ];
+    const { rerender } = render(ComboBox, {
+      props: {
+        items,
+        selectedId: "1",
+        value: "Email",
+      },
+    });
+
+    const input = getInput();
+    expect(input).toHaveValue("Email");
+
+    rerender({ items: [], selectedId: "1" });
+    await tick();
+
+    expect(input).toHaveValue("");
+  });
+
   it("should select all text on focus when selectTextOnFocus is true", async () => {
     render(ComboBox, {
       props: {


### PR DESCRIPTION
Follow-up to #3362

Follow-up to the async items resync fix: preserving `selectedId` left
a stale `selectedItem` and ghost input text when `items` cleared or
the id was removed. Re-resolve including `undefined` and clear `value`
when `selectedItem` is unset without resetting the bound id.