### PR TITLE
chore(code-snippet): exclude pre padding from expand threshold

### DIFF
--- a/e2e/code-snippet.test.ts
+++ b/e2e/code-snippet.test.ts
@@ -66,6 +66,16 @@ test.describe("CodeSnippet", () => {
     ).toBeHidden();
   });
 
+  test("multi snippet hides expand button when content fits but padding exceeds the threshold", async ({
+    page,
+  }) => {
+    const snippet = page.getByTestId("snippet-multi-boundary");
+    await expect(snippet).toBeVisible();
+    await expect(
+      snippet.getByRole("button", { name: /show more/i }),
+    ).toBeHidden();
+  });
+
   test("expand button appears when content grows past the threshold", async ({
     page,
   }) => {

--- a/e2e/fixtures/CodeSnippetFixture.svelte
+++ b/e2e/fixtures/CodeSnippetFixture.svelte
@@ -6,6 +6,14 @@
   const longCode = Array(20)
     .fill("function example() { return 'line'; }")
     .join("\n");
+  // 14 lines: at the 16px code-01 line-height this is 224px of text, under the
+  // 240px collapsed viewport, so no content is hidden and the expand button
+  // must stay hidden even though the <pre>'s bottom padding pushes its raw
+  // bounding-box height past the threshold.
+  const boundaryCode = Array.from(
+    { length: 14 },
+    (_, i) => `const line${i + 1} = ${i + 1};`,
+  ).join("\n");
 
   let dynamicExpanded = false;
   $: dynamicLines = dynamicExpanded ? 24 : 3;
@@ -34,6 +42,14 @@
     type="multi"
     code={shortCode}
     data-testid="snippet-multi-short"
+  />
+</div>
+
+<div data-testid="boundary-multi-snippet">
+  <CodeSnippet
+    type="multi"
+    code={boundaryCode}
+    data-testid="snippet-multi-boundary"
   />
 </div>
 

--- a/src/CodeSnippet/CodeSnippet.svelte
+++ b/src/CodeSnippet/CodeSnippet.svelte
@@ -195,8 +195,15 @@
     // the element with a max-height, so its rendered height always reflects the
     // true content height regardless of expanded state. Comparing the measured
     // height keeps this correct across any consumer font size or line height.
-    const { height } = ref.getBoundingClientRect();
-    if (height === 0) return;
+    // Subtract the <pre>'s own vertical padding so only the text counts toward
+    // the threshold; otherwise the decorative bottom padding inflates the height
+    // and the expand button appears when only padding, not content, is clipped.
+    const style = getComputedStyle(ref);
+    const padding =
+      Number.parseFloat(style.paddingTop) +
+      Number.parseFloat(style.paddingBottom);
+    const height = ref.getBoundingClientRect().height - padding;
+    if (height <= 0) return;
     exceedsThreshold = height > collapsedHeight;
     // If the content no longer overflows, collapse so the expanded min-height
     // doesn't leave the snippet taller than its (now shorter) content.


### PR DESCRIPTION
Follow-up to #3355. The expand button measured the `<pre>`'s full bounding box, which counts Carbon's 24px bottom padding as content, so snippets that fit the 240px collapsed viewport still showed "Show more" with nothing more to reveal. This subtracts the `<pre>`'s vertical padding so only real content counts toward the threshold, and adds a boundary e2e test covering the case.