### PR TITLE
feat(tabs)!: replace mobile dropdown with scrollable overflow tabs

### DIFF
--- a/css/_tabs.scss
+++ b/css/_tabs.scss
@@ -45,10 +45,10 @@
 }
 
 /// Icon-only tab styles
-/// At `md` and up, the nav link is a square icon trigger and the label is
-/// surfaced as a portalled tooltip (rendered by `Tab.svelte`). Below `md` the
-/// tabs collapse into the legacy dropdown, where each item keeps its full-width
-/// footprint and shows the icon next to its text label.
+/// The nav link is a square icon trigger at every breakpoint and the label is
+/// surfaced as a portalled tooltip (rendered by `Tab.svelte`). Carbon React v11
+/// keeps icon-only tabs square on narrow viewports rather than collapsing them
+/// into a labeled dropdown, so the trigger size is breakpoint-agnostic.
 /// @access private
 /// @group components
 @mixin tabs-icon-only {
@@ -57,14 +57,19 @@
   // Container tabs are 48px tall, so icon-only container tabs are square at 48px.
   $icon-tab-size-container: $carbon--spacing-09; // 48px
 
-  // Below md (dropdown menu): show the icon beside the label and keep the
-  // full-width item border. The label span is hidden in the desktop row below.
-  // Double class so `display: flex` out-specifies the base `a.bx--tabs__nav-link`
-  // (`display: block`) rule that is imported after this file.
-  a.#{$prefix}--tabs__nav-link.#{$prefix}--tabs__nav-link--icon-only {
+  // Square icon trigger. Double class (and explicit :focus/:active) so these win
+  // over the base `a.bx--tabs__nav-link` rules imported after this file.
+  a.#{$prefix}--tabs__nav-link.#{$prefix}--tabs__nav-link--icon-only,
+  a.#{$prefix}--tabs__nav-link.#{$prefix}--tabs__nav-link--icon-only:focus,
+  a.#{$prefix}--tabs__nav-link.#{$prefix}--tabs__nav-link--icon-only:active {
     display: flex;
     align-items: center;
-    gap: $carbon--spacing-03;
+    justify-content: center;
+    gap: 0;
+    inline-size: $icon-tab-size;
+    min-inline-size: $icon-tab-size;
+    block-size: $icon-tab-size;
+    padding: 0;
   }
 
   // Lift the icon out of its default beside-label spacing so it sits flush.
@@ -76,7 +81,7 @@
   }
 
   // Container type adds an auto inline-start margin to push the icon to the end;
-  // neutralize it so the icon stays beside the label (mobile) / centered (md).
+  // neutralize it so the icon stays centered.
   .#{$prefix}--tabs--container
     .#{$prefix}--tabs__nav-link--icon-only
     .#{$prefix}--tabs__nav-item--icon {
@@ -84,85 +89,277 @@
     padding-inline-start: 0;
   }
 
-  // Mobile dropdown: Carbon's disabled underline (`2px solid $disabled-01`) is
-  // near-invisible, so disabled items look like they are missing a separator.
-  // Restore the same separator the enabled items use.
-  @include carbon--breakpoint-down(md) {
-    .#{$prefix}--tabs__nav-item--disabled
-      a.#{$prefix}--tabs__nav-link.#{$prefix}--tabs__nav-link--icon-only {
-      border-bottom: 1px solid $ui-03;
-    }
+  // The label is the accessible name and tooltip text only; never shown inline.
+  .#{$prefix}--tabs__nav-link--icon-only .#{$prefix}--tabs__nav-item-label {
+    display: none;
   }
 
-  @include carbon--breakpoint(md) {
-    // The icon-only nav is absolutely positioned and overlays the panel; the
-    // `.bx--tabs` container reserves only 40px by default, so the 48px lg row
-    // would cover the panel by 8px. Reserve the full 48px instead.
-    .#{$prefix}--tabs.#{$prefix}--tabs__icon--lg {
-      min-height: $icon-tab-size-lg;
-    }
+  // Container type: contained tabs are 48px tall, so make the icon-only link a
+  // 48px square (instead of the 40px default) so it does not look stretched.
+  .#{$prefix}--tabs--container
+    a.#{$prefix}--tabs__nav-link.#{$prefix}--tabs__nav-link--icon-only,
+  .#{$prefix}--tabs--container
+    a.#{$prefix}--tabs__nav-link.#{$prefix}--tabs__nav-link--icon-only:focus,
+  .#{$prefix}--tabs--container
+    a.#{$prefix}--tabs__nav-link.#{$prefix}--tabs__nav-link--icon-only:active {
+    inline-size: $icon-tab-size-container;
+    min-inline-size: $icon-tab-size-container;
+    block-size: $icon-tab-size-container;
+    padding: 0;
+  }
 
-    // Square icon trigger; double class to out-specify the base
-    // `a.bx--tabs__nav-link` rules, which are imported after this file.
-    a.#{$prefix}--tabs__nav-link.#{$prefix}--tabs__nav-link--icon-only {
-      justify-content: center;
-      gap: 0;
-      width: $icon-tab-size;
-      min-width: $icon-tab-size;
-      height: $icon-tab-size;
-      padding: 0;
+  // Large icon scale: 48px square trigger. The `.bx--tabs__icon--lg` ancestor
+  // raises specificity above the default-scale rules above.
+  .#{$prefix}--tabs__icon--lg {
+    a.#{$prefix}--tabs__nav-link.#{$prefix}--tabs__nav-link--icon-only,
+    &.#{$prefix}--tabs--container
+      a.#{$prefix}--tabs__nav-link.#{$prefix}--tabs__nav-link--icon-only {
+      inline-size: $icon-tab-size-lg;
+      min-inline-size: $icon-tab-size-lg;
+      block-size: $icon-tab-size-lg;
 
       &:focus,
       &:active {
-        width: $icon-tab-size;
-        min-width: $icon-tab-size;
-        padding: 0;
+        inline-size: $icon-tab-size-lg;
+        min-inline-size: $icon-tab-size-lg;
       }
     }
 
-    // Hide the text label in the desktop icon-only row (kept for the dropdown).
-    .#{$prefix}--tabs__nav-link--icon-only .#{$prefix}--tabs__nav-item-label {
-      display: none;
-    }
-
-    // Container type: contained tabs are 48px tall, so make the icon-only link a
-    // 48px square (instead of the 40px default) so it does not look stretched.
-    .#{$prefix}--tabs--container
-      a.#{$prefix}--tabs__nav-link.#{$prefix}--tabs__nav-link--icon-only {
-      width: $icon-tab-size-container;
-      min-width: $icon-tab-size-container;
-      height: $icon-tab-size-container;
-      padding: 0;
-    }
-
-    // Large icon scale: 48px square trigger. The `.bx--tabs__icon--lg` ancestor
-    // raises specificity above the default-scale rules above.
-    .#{$prefix}--tabs__icon--lg {
-      a.#{$prefix}--tabs__nav-link.#{$prefix}--tabs__nav-link--icon-only,
-      &.#{$prefix}--tabs--container
-        a.#{$prefix}--tabs__nav-link.#{$prefix}--tabs__nav-link--icon-only {
-        width: $icon-tab-size-lg;
-        min-width: $icon-tab-size-lg;
-        height: $icon-tab-size-lg;
-
-        &:focus,
-        &:active {
-          width: $icon-tab-size-lg;
-          min-width: $icon-tab-size-lg;
-        }
-      }
-
-      // 20px icon at lg scale (Carbon React); default scale stays 16px.
-      .#{$prefix}--tabs__nav-link--icon-only .#{$prefix}--tabs__nav-item--icon svg {
-        block-size: to-rem(20px);
-        inline-size: to-rem(20px);
-      }
+    // 20px icon at lg scale (Carbon React); default scale stays 16px.
+    .#{$prefix}--tabs__nav-link--icon-only .#{$prefix}--tabs__nav-item--icon svg {
+      block-size: to-rem(20px);
+      inline-size: to-rem(20px);
     }
   }
 }
 
 @include exports('tabs-icon-only') {
   @include tabs-icon-only;
+}
+
+/// Overflow / scrollable tab list (Carbon React v11 parity).
+/// Carbon v10 collapses tabs into a dropdown menu on narrow viewports, which is
+/// unexpected and not fully accessible. Instead, keep the tab list inline at
+/// every breakpoint and make it horizontally scrollable, surfacing scroll
+/// buttons + edge fades only when the list overflows its container.
+///
+/// Carbon v10.58 already ships the scrollable-tabs CSS (`bx--tabs--scrollable`,
+/// `bx--tab--overflow-nav-button`, `bx--tabs__overflow-indicator--*`), so the
+/// component reuses those classes and this partial only fills two gaps the
+/// shipped CSS leaves for the legacy `bx--tabs__nav*` structure:
+///   1. take the nav out of the mobile dropdown overlay (static + scrollable);
+///   2. render the desktop tab appearance below `md`, since Carbon is
+///      mobile-first and its default tab styling lives under `min-width: 42rem`.
+/// @access private
+/// @group components
+@mixin tabs-overflow {
+  // (1) The legacy nav is an absolutely-positioned dropdown overlay by default;
+  // keep it in flow and horizontally scrollable at every breakpoint.
+  .#{$prefix}--tabs .#{$prefix}--tabs__nav {
+    position: static;
+    z-index: auto;
+    display: flex;
+    flex-direction: row;
+    max-block-size: none;
+    overflow-x: auto;
+    // The mobile dropdown overlay paints the nav `$ui-01`; drop it so line tabs
+    // are transparent and container cells provide their own background.
+    background: transparent;
+    box-shadow: none;
+    transition: none;
+    // Keyboard navigation scrolls the focused tab into view by adjusting
+    // scrollLeft; keep that instant so reads stay consistent (the overflow
+    // buttons request smooth scrolling explicitly via `scrollBy`).
+    scroll-behavior: auto;
+    // Hide the native scrollbar; scrolling is driven by the overflow buttons,
+    // touch drag, and trackpad gestures.
+    scrollbar-width: none;
+  }
+
+  .#{$prefix}--tabs .#{$prefix}--tabs__nav::-webkit-scrollbar {
+    display: none;
+  }
+
+  // Size every tab to its content instead of the legacy `width: 100%` dropdown
+  // row, so tabs sit close together and the list scrolls (Carbon's
+  // `bx--tabs--scrollable .bx--tabs__nav-item { flex: none }` pins the width).
+  .#{$prefix}--tabs .#{$prefix}--tabs__nav-item {
+    inline-size: auto;
+  }
+
+  // Line (non-container) tabs are content-width at every breakpoint (Carbon
+  // React v11), replacing the legacy fixed 10rem tab width that left them spread
+  // out. Container, dismissible, and icon-only tabs carry their own widths.
+  .#{$prefix}--tabs:not(.#{$prefix}--tabs--container):not(.#{$prefix}--tabs--vertical):not(.#{$prefix}--tabs--dismissible):not(.#{$prefix}--tabs--icon-only)
+    a.#{$prefix}--tabs__nav-link,
+  .#{$prefix}--tabs:not(.#{$prefix}--tabs--container):not(.#{$prefix}--tabs--vertical):not(.#{$prefix}--tabs--dismissible):not(.#{$prefix}--tabs--icon-only)
+    a.#{$prefix}--tabs__nav-link:focus,
+  .#{$prefix}--tabs:not(.#{$prefix}--tabs--container):not(.#{$prefix}--tabs--vertical):not(.#{$prefix}--tabs--dismissible):not(.#{$prefix}--tabs--icon-only)
+    a.#{$prefix}--tabs__nav-link:active {
+    inline-size: auto;
+  }
+
+  // (2) Below `md`, render the inline desktop tab appearance instead of Carbon's
+  // mobile-first dropdown rows. Values mirror Carbon's own `min-width: 42rem`
+  // tab rules so the tabs look identical above and below the breakpoint.
+  // Override partials emit before Carbon base, so every rule here carries a
+  // leading `.bx--tabs` (and `.bx--tabs--container`) ancestor to out-specify the
+  // equal-specificity mobile-first defaults that load afterward.
+  @include carbon--breakpoint-down(md) {
+    // Drop the mobile dropdown-row side margin (`0 16px`) on every variant so
+    // tabs sit flush instead of spaced apart (line, container, icon-only,
+    // dismissible all inherit this legacy margin below `md`).
+    .#{$prefix}--tabs a.#{$prefix}--tabs__nav-link {
+      margin: 0;
+    }
+
+    // Reveal the selected tab (the dropdown hides it to show it in the trigger).
+    .#{$prefix}--tabs
+      .#{$prefix}--tabs__nav-item--selected:not(.#{$prefix}--tabs__nav-item--disabled) {
+      display: flex;
+    }
+
+    .#{$prefix}--tabs .#{$prefix}--tabs__nav-item {
+      background: transparent;
+      block-size: auto;
+    }
+
+    .#{$prefix}--tabs
+      .#{$prefix}--tabs__nav-item
+      + .#{$prefix}--tabs__nav-item {
+      margin-inline-start: to-rem(1px);
+    }
+
+    .#{$prefix}--tabs
+      .#{$prefix}--tabs__nav-item:hover:not(.#{$prefix}--tabs__nav-item--disabled) {
+      background-color: transparent;
+      box-shadow: none;
+    }
+
+    .#{$prefix}--tabs
+      .#{$prefix}--tabs__nav-item:hover:not(.#{$prefix}--tabs__nav-item--disabled)
+      + .#{$prefix}--tabs__nav-item {
+      box-shadow: none;
+    }
+
+    // Line (non-container) link: content-width inline tab with the bottom
+    // selection border. Width comes from the unconditional rule above; here we
+    // restore the desktop padding/border the mobile dropdown rows override.
+    // Scoped away from container / dismissible / icon-only.
+    .#{$prefix}--tabs:not(.#{$prefix}--tabs--container):not(.#{$prefix}--tabs--vertical):not(.#{$prefix}--tabs--dismissible):not(.#{$prefix}--tabs--icon-only)
+      a.#{$prefix}--tabs__nav-link,
+    .#{$prefix}--tabs:not(.#{$prefix}--tabs--container):not(.#{$prefix}--tabs--vertical):not(.#{$prefix}--tabs--dismissible):not(.#{$prefix}--tabs--icon-only)
+      a.#{$prefix}--tabs__nav-link:focus,
+    .#{$prefix}--tabs:not(.#{$prefix}--tabs--container):not(.#{$prefix}--tabs--vertical):not(.#{$prefix}--tabs--dismissible):not(.#{$prefix}--tabs--icon-only)
+      a.#{$prefix}--tabs__nav-link:active {
+      block-size: auto;
+      padding: $carbon--spacing-04 $carbon--spacing-05 $carbon--spacing-03;
+      border-block-end: 2px solid $ui-03;
+      line-height: inherit;
+    }
+
+    // Selected emphasis (bold + color) applies to every non-container tab,
+    // including dismissible.
+    .#{$prefix}--tabs:not(.#{$prefix}--tabs--container):not(.#{$prefix}--tabs--vertical)
+      .#{$prefix}--tabs__nav-item--selected:not(.#{$prefix}--tabs__nav-item--disabled)
+      a.#{$prefix}--tabs__nav-link {
+      @include carbon--type-style("productive-heading-01");
+
+      color: $text-01;
+    }
+
+    // The link bottom border (selected / hover / disabled indicator) is excluded
+    // from dismissible, whose underline is moved to the nav item by the
+    // dismissible mixin — a link border here would double it up.
+    .#{$prefix}--tabs:not(.#{$prefix}--tabs--container):not(.#{$prefix}--tabs--vertical):not(.#{$prefix}--tabs--dismissible)
+      .#{$prefix}--tabs__nav-item--selected:not(.#{$prefix}--tabs__nav-item--disabled)
+      a.#{$prefix}--tabs__nav-link {
+      border-block-end: 2px solid $interactive-04;
+    }
+
+    .#{$prefix}--tabs:not(.#{$prefix}--tabs--container):not(.#{$prefix}--tabs--vertical):not(.#{$prefix}--tabs--dismissible)
+      .#{$prefix}--tabs__nav-item:hover:not(.#{$prefix}--tabs__nav-item--selected):not(.#{$prefix}--tabs__nav-item--disabled)
+      a.#{$prefix}--tabs__nav-link {
+      border-block-end: 2px solid $ui-04;
+      color: $text-01;
+    }
+
+    .#{$prefix}--tabs:not(.#{$prefix}--tabs--container):not(.#{$prefix}--tabs--vertical):not(.#{$prefix}--tabs--dismissible)
+      .#{$prefix}--tabs__nav-item--disabled
+      a.#{$prefix}--tabs__nav-link {
+      border-block-end: 2px solid $disabled-01;
+      color: $disabled-02;
+    }
+
+    // Container type below `md`: gray cells, vertical dividers, and a top inset
+    // selection indicator on the active tab.
+    .#{$prefix}--tabs.#{$prefix}--tabs--container .#{$prefix}--tabs__nav-item {
+      background-color: $ui-03;
+    }
+
+    .#{$prefix}--tabs.#{$prefix}--tabs--container
+      .#{$prefix}--tabs__nav-item
+      + .#{$prefix}--tabs__nav-item {
+      box-shadow: to-rem(-1px) 0 0 0 $ui-04;
+      margin-inline-start: 0;
+    }
+
+    .#{$prefix}--tabs.#{$prefix}--tabs--container
+      .#{$prefix}--tabs__nav-item:hover:not(.#{$prefix}--tabs__nav-item--disabled) {
+      background-color: $hover-selected-ui;
+    }
+
+    .#{$prefix}--tabs.#{$prefix}--tabs--container .#{$prefix}--tabs__nav-item--disabled,
+    .#{$prefix}--tabs.#{$prefix}--tabs--container
+      .#{$prefix}--tabs__nav-item--disabled:hover {
+      background-color: $disabled-02;
+    }
+
+    .#{$prefix}--tabs.#{$prefix}--tabs--container a.#{$prefix}--tabs__nav-link {
+      block-size: $carbon--spacing-09;
+      inline-size: auto;
+      padding: $carbon--spacing-03 $carbon--spacing-05;
+      border-block-end: none;
+      line-height: calc(#{$carbon--spacing-09} - #{$carbon--spacing-03} * 2);
+    }
+
+    .#{$prefix}--tabs.#{$prefix}--tabs--container
+      .#{$prefix}--tabs__nav-item--selected:not(.#{$prefix}--tabs__nav-item--disabled),
+    .#{$prefix}--tabs.#{$prefix}--tabs--container
+      .#{$prefix}--tabs__nav-item--selected:hover:not(.#{$prefix}--tabs__nav-item--disabled) {
+      background-color: $ui-01;
+    }
+
+    .#{$prefix}--tabs.#{$prefix}--tabs--container
+      .#{$prefix}--tabs__nav-item--selected:not(.#{$prefix}--tabs__nav-item--disabled)
+      a.#{$prefix}--tabs__nav-link {
+      @include carbon--type-style("productive-heading-01");
+
+      // Re-assert the cell line-height the heading type style overwrites, so the
+      // bold selected label stays vertically aligned with the other tabs.
+      box-shadow: inset 0 2px 0 0 $interactive-04;
+      border-block-end: none;
+      line-height: calc(#{$carbon--spacing-09} - #{$carbon--spacing-03} * 2);
+      color: $text-01;
+    }
+
+    .#{$prefix}--tabs.#{$prefix}--tabs--container
+      .#{$prefix}--tabs__nav-item--disabled
+      a.#{$prefix}--tabs__nav-link {
+      border-block-end: none;
+      color: $disabled-03;
+    }
+
+    .#{$prefix}--tabs.#{$prefix}--tabs--container
+      .#{$prefix}--tabs__nav-item:hover:not(.#{$prefix}--tabs__nav-item--selected):not(.#{$prefix}--tabs__nav-item--disabled)
+      a.#{$prefix}--tabs__nav-link {
+      border-block-end: none;
+    }
+  }
+}
+
+@include exports('tabs-overflow') {
+  @include tabs-overflow;
 }
 
 /// Tab full-width styles
@@ -295,11 +492,14 @@
   }
 
   // Default: size the link to its content so the close button sits next to the
-  // label with a fixed gap, instead of growing to the full tab width.
+  // label with a fixed gap, instead of growing to the full tab width. The
+  // asymmetric vertical padding mirrors Carbon's desktop tab link at every
+  // breakpoint so the close-button nudge below lands consistently.
   .#{$prefix}--tabs--dismissible:not(.#{$prefix}--tabs--container)
     .#{$prefix}--tabs__nav-link {
     flex: 0 1 auto;
-    padding-inline-end: $carbon--spacing-03;
+    padding: $carbon--spacing-04 $carbon--spacing-03 $carbon--spacing-03
+      $carbon--spacing-05;
   }
 
   // Container: fill the cell so the close button aligns to the trailing edge.
@@ -328,16 +528,13 @@
     align-items: center;
   }
 
-  // Default: at md the link's asymmetric vertical padding ($spacing-04 top /
+  // Default: the link's asymmetric vertical padding ($spacing-04 top /
   // $spacing-03 bottom) drops the label below the nav-item center, so nudge the
-  // close button down to share the text's optical baseline. Below md the link
-  // padding is symmetric (dropdown rows), so the nudge must not apply there.
-  @include carbon--breakpoint(md) {
-    .#{$prefix}--tabs--dismissible:not(.#{$prefix}--tabs--container)
-      .#{$prefix}--tabs__nav-item--close {
-      position: relative;
-      inset-block-start: $carbon--spacing-01;
-    }
+  // close button down to share the text's optical baseline.
+  .#{$prefix}--tabs--dismissible:not(.#{$prefix}--tabs--container)
+    .#{$prefix}--tabs__nav-item--close {
+    position: relative;
+    inset-block-start: $carbon--spacing-01;
   }
 
   // Container: nudge the close button off the label.
@@ -363,64 +560,62 @@
     outline: none;
   }
 
-  @include carbon--breakpoint(md) {
-    // Default variant: drop Carbon's fixed 10rem link width (including the
-    // focus/active width reset) so the tab sizes to its content.
-    .#{$prefix}--tabs--dismissible:not(.#{$prefix}--tabs--container)
-      a.#{$prefix}--tabs__nav-link,
-    .#{$prefix}--tabs--dismissible:not(.#{$prefix}--tabs--container)
-      a.#{$prefix}--tabs__nav-link:focus,
-    .#{$prefix}--tabs--dismissible:not(.#{$prefix}--tabs--container)
-      a.#{$prefix}--tabs__nav-link:active {
-      inline-size: auto;
-    }
+  // Default variant: drop Carbon's fixed 10rem link width (including the
+  // focus/active width reset) so the tab sizes to its content.
+  .#{$prefix}--tabs--dismissible:not(.#{$prefix}--tabs--container)
+    a.#{$prefix}--tabs__nav-link,
+  .#{$prefix}--tabs--dismissible:not(.#{$prefix}--tabs--container)
+    a.#{$prefix}--tabs__nav-link:focus,
+  .#{$prefix}--tabs--dismissible:not(.#{$prefix}--tabs--container)
+    a.#{$prefix}--tabs__nav-link:active {
+    inline-size: auto;
+  }
 
-    // Default variant: move the bottom underline from the link to the item.
-    .#{$prefix}--tabs--dismissible:not(.#{$prefix}--tabs--container)
-      .#{$prefix}--tabs__nav-item {
-      border-block-end: 2px solid $ui-03;
-    }
+  // Default variant: move the bottom underline from the link to the item.
+  .#{$prefix}--tabs--dismissible:not(.#{$prefix}--tabs--container)
+    .#{$prefix}--tabs__nav-item {
+    border-block-end: 2px solid $ui-03;
+  }
 
-    .#{$prefix}--tabs--dismissible:not(.#{$prefix}--tabs--container)
-      .#{$prefix}--tabs__nav-item:hover:not(.#{$prefix}--tabs__nav-item--selected):not(.#{$prefix}--tabs__nav-item--disabled) {
-      border-block-end-color: $ui-04;
-    }
+  .#{$prefix}--tabs--dismissible:not(.#{$prefix}--tabs--container)
+    .#{$prefix}--tabs__nav-item:hover:not(.#{$prefix}--tabs__nav-item--selected):not(.#{$prefix}--tabs__nav-item--disabled) {
+    border-block-end-color: $ui-04;
+  }
 
-    .#{$prefix}--tabs--dismissible:not(.#{$prefix}--tabs--container)
-      .#{$prefix}--tabs__nav-item--selected:not(.#{$prefix}--tabs__nav-item--disabled) {
-      border-block-end-color: $interactive-04;
-    }
+  .#{$prefix}--tabs--dismissible:not(.#{$prefix}--tabs--container)
+    .#{$prefix}--tabs__nav-item--selected:not(.#{$prefix}--tabs__nav-item--disabled) {
+    border-block-end-color: $interactive-04;
+  }
 
-    .#{$prefix}--tabs--dismissible:not(.#{$prefix}--tabs--container)
-      .#{$prefix}--tabs__nav-item--disabled {
-      border-block-end-color: $disabled-01;
-    }
+  .#{$prefix}--tabs--dismissible:not(.#{$prefix}--tabs--container)
+    .#{$prefix}--tabs__nav-item--disabled {
+    border-block-end-color: $disabled-01;
+  }
 
-    // Remove the link border in every state so only the item border shows.
-    // Carbon's hover/selected link rules outrank a plain link selector, so each
-    // state is matched explicitly to win on specificity.
-    .#{$prefix}--tabs--dismissible:not(.#{$prefix}--tabs--container)
-      a.#{$prefix}--tabs__nav-link,
-    .#{$prefix}--tabs--dismissible:not(.#{$prefix}--tabs--container)
-      .#{$prefix}--tabs__nav-item:hover:not(.#{$prefix}--tabs__nav-item--selected):not(.#{$prefix}--tabs__nav-item--disabled)
-      .#{$prefix}--tabs__nav-link,
-    .#{$prefix}--tabs--dismissible:not(.#{$prefix}--tabs--container)
-      .#{$prefix}--tabs__nav-item--selected:not(.#{$prefix}--tabs__nav-item--disabled)
-      .#{$prefix}--tabs__nav-link {
-      border-block-end: none;
-    }
+  // Remove the link border in every state so only the item border shows.
+  // Carbon's hover/selected link rules outrank a plain link selector, so each
+  // state is matched explicitly to win on specificity.
+  .#{$prefix}--tabs--dismissible:not(.#{$prefix}--tabs--container)
+    a.#{$prefix}--tabs__nav-link,
+  .#{$prefix}--tabs--dismissible:not(.#{$prefix}--tabs--container)
+    .#{$prefix}--tabs__nav-item:hover:not(.#{$prefix}--tabs__nav-item--selected):not(.#{$prefix}--tabs__nav-item--disabled)
+    .#{$prefix}--tabs__nav-link,
+  .#{$prefix}--tabs--dismissible:not(.#{$prefix}--tabs--container)
+    .#{$prefix}--tabs__nav-item--selected:not(.#{$prefix}--tabs__nav-item--disabled)
+    .#{$prefix}--tabs__nav-link {
+    border-block-end: none;
+  }
 
-    // Container variant: move the inset top indicator from the link to the item.
-    .#{$prefix}--tabs--dismissible.#{$prefix}--tabs--container
-      .#{$prefix}--tabs__nav-item--selected:not(.#{$prefix}--tabs__nav-item--disabled) {
-      box-shadow: inset 0 2px 0 0 $interactive-04;
-    }
+  // Container variant: move the inset top indicator from the link to the item.
+  .#{$prefix}--tabs--dismissible.#{$prefix}--tabs--container
+    .#{$prefix}--tabs__nav-item--selected:not(.#{$prefix}--tabs__nav-item--disabled) {
+    box-shadow: inset 0 2px 0 0 $interactive-04;
+  }
 
-    .#{$prefix}--tabs--dismissible.#{$prefix}--tabs--container
-      .#{$prefix}--tabs__nav-item--selected:not(.#{$prefix}--tabs__nav-item--disabled)
-      .#{$prefix}--tabs__nav-link {
-      box-shadow: none;
-    }
+  .#{$prefix}--tabs--dismissible.#{$prefix}--tabs--container
+    .#{$prefix}--tabs__nav-item--selected:not(.#{$prefix}--tabs__nav-item--disabled)
+    .#{$prefix}--tabs__nav-link {
+    box-shadow: none;
   }
 
   // The close button is not in the tab order (keyboard dismissal uses Delete on

--- a/docs/src/pages/components/Tabs.svx
+++ b/docs/src/pages/components/Tabs.svx
@@ -37,6 +37,36 @@ Use `bind:selected` for a two-way binding with the selected tab index, so you ca
 
 <FileSource src="/framed/Tabs/TabsReactive" />
 
+## Overflow
+
+When the tabs exceed the available width, the list scrolls horizontally and backward/forward buttons appear at each end. Scroll by dragging, using the buttons, or moving focus with the arrow keys. Resize the viewport to see the buttons appear and hide.
+
+### Line
+
+<FileSource src="/framed/Tabs/TabsOverflow" />
+
+### Container
+
+<FileSource src="/framed/Tabs/TabsOverflowContainer" />
+
+### Tall
+
+<FileSource src="/framed/Tabs/TabsOverflowTall" />
+
+### Dismissible
+
+<FileSource src="/framed/Tabs/TabsOverflowDismissible" />
+
+### Icon-only
+
+<FileSource src="/framed/Tabs/TabsOverflowIconOnly" />
+
+### Vertical
+
+Below the medium breakpoint, vertical tabs collapse into the same horizontal, scrollable row with overflow buttons. Resize the viewport to see them.
+
+<FileSource src="/framed/Tabs/TabsVerticalOverflow" />
+
 ## Disabled tabs
 
 Set `disabled` on a tab to prevent interaction. Keyboard navigation skips disabled

--- a/docs/src/pages/framed/Tabs/TabsOverflow.svelte
+++ b/docs/src/pages/framed/Tabs/TabsOverflow.svelte
@@ -1,0 +1,16 @@
+<script>
+  import { Tab, TabContent, Tabs } from "carbon-components-svelte";
+
+  const items = Array.from({ length: 12 }, (_, i) => `Tab label ${i + 1}`);
+</script>
+
+<Tabs>
+  {#each items as item}
+    <Tab label={item} />
+  {/each}
+  <svelte:fragment slot="content">
+    {#each items as item}
+      <TabContent>{item} content</TabContent>
+    {/each}
+  </svelte:fragment>
+</Tabs>

--- a/docs/src/pages/framed/Tabs/TabsOverflowContainer.svelte
+++ b/docs/src/pages/framed/Tabs/TabsOverflowContainer.svelte
@@ -1,0 +1,16 @@
+<script>
+  import { Tab, TabContent, Tabs } from "carbon-components-svelte";
+
+  const items = Array.from({ length: 12 }, (_, i) => `Tab label ${i + 1}`);
+</script>
+
+<Tabs type="container">
+  {#each items as item}
+    <Tab label={item} />
+  {/each}
+  <svelte:fragment slot="content">
+    {#each items as item}
+      <TabContent>{item} content</TabContent>
+    {/each}
+  </svelte:fragment>
+</Tabs>

--- a/docs/src/pages/framed/Tabs/TabsOverflowDismissible.svelte
+++ b/docs/src/pages/framed/Tabs/TabsOverflowDismissible.svelte
@@ -1,0 +1,30 @@
+<script>
+  import { Tab, TabContent, Tabs } from "carbon-components-svelte";
+
+  let selected = 0;
+  let tabs = Array.from({ length: 12 }, (_, i) => ({
+    id: `tab-${i + 1}`,
+    label: `Tab label ${i + 1}`,
+  }));
+
+  function handleDismiss({ detail }) {
+    tabs = tabs.filter((tab) => tab.id !== detail.id);
+
+    if (selected > detail.index) {
+      selected -= 1;
+    } else if (selected >= tabs.length) {
+      selected = Math.max(tabs.length - 1, 0);
+    }
+  }
+</script>
+
+<Tabs bind:selected dismissible on:dismiss={handleDismiss}>
+  {#each tabs as tab (tab.id)}
+    <Tab id={tab.id} label={tab.label} />
+  {/each}
+  <svelte:fragment slot="content">
+    {#each tabs as tab (tab.id)}
+      <TabContent>{tab.label} content</TabContent>
+    {/each}
+  </svelte:fragment>
+</Tabs>

--- a/docs/src/pages/framed/Tabs/TabsOverflowIconOnly.svelte
+++ b/docs/src/pages/framed/Tabs/TabsOverflowIconOnly.svelte
@@ -1,0 +1,41 @@
+<script>
+  import { Tab, TabContent, Tabs } from "carbon-components-svelte";
+  import Activity from "carbon-icons-svelte/lib/Activity.svelte";
+  import Add from "carbon-icons-svelte/lib/Add.svelte";
+  import Analytics from "carbon-icons-svelte/lib/Analytics.svelte";
+  import Calendar from "carbon-icons-svelte/lib/Calendar.svelte";
+  import Chat from "carbon-icons-svelte/lib/Chat.svelte";
+  import Dashboard from "carbon-icons-svelte/lib/Dashboard.svelte";
+  import Document from "carbon-icons-svelte/lib/Document.svelte";
+  import Email from "carbon-icons-svelte/lib/Email.svelte";
+  import Folder from "carbon-icons-svelte/lib/Folder.svelte";
+  import Information from "carbon-icons-svelte/lib/Information.svelte";
+  import Notification from "carbon-icons-svelte/lib/Notification.svelte";
+  import Search from "carbon-icons-svelte/lib/Search.svelte";
+
+  const items = [
+    { label: "Dashboard", icon: Dashboard },
+    { label: "Activity", icon: Activity },
+    { label: "Analytics", icon: Analytics },
+    { label: "Calendar", icon: Calendar },
+    { label: "Chat", icon: Chat },
+    { label: "Documents", icon: Document },
+    { label: "Email", icon: Email },
+    { label: "Files", icon: Folder },
+    { label: "Information", icon: Information },
+    { label: "Notifications", icon: Notification },
+    { label: "Search", icon: Search },
+    { label: "Add", icon: Add },
+  ];
+</script>
+
+<Tabs iconOnly>
+  {#each items as item}
+    <Tab label={item.label} icon={item.icon} />
+  {/each}
+  <svelte:fragment slot="content">
+    {#each items as item}
+      <TabContent>{item.label} content</TabContent>
+    {/each}
+  </svelte:fragment>
+</Tabs>

--- a/docs/src/pages/framed/Tabs/TabsOverflowTall.svelte
+++ b/docs/src/pages/framed/Tabs/TabsOverflowTall.svelte
@@ -1,0 +1,19 @@
+<script>
+  import { Tab, TabContent, Tabs } from "carbon-components-svelte";
+
+  const items = Array.from({ length: 12 }, (_, i) => ({
+    label: `Tab label ${i + 1}`,
+    secondaryLabel: `(${i + 1}/12)`,
+  }));
+</script>
+
+<Tabs type="container">
+  {#each items as item}
+    <Tab label={item.label} secondaryLabel={item.secondaryLabel} />
+  {/each}
+  <svelte:fragment slot="content">
+    {#each items as item}
+      <TabContent>{item.label} content</TabContent>
+    {/each}
+  </svelte:fragment>
+</Tabs>

--- a/docs/src/pages/framed/Tabs/TabsVerticalOverflow.svelte
+++ b/docs/src/pages/framed/Tabs/TabsVerticalOverflow.svelte
@@ -1,0 +1,16 @@
+<script>
+  import { Tab, TabContent, TabsVertical } from "carbon-components-svelte";
+
+  const items = Array.from({ length: 12 }, (_, i) => `Tab label ${i + 1}`);
+</script>
+
+<TabsVertical>
+  {#each items as item}
+    <Tab label={item} />
+  {/each}
+  <svelte:fragment slot="content">
+    {#each items as item}
+      <TabContent>{item} content</TabContent>
+    {/each}
+  </svelte:fragment>
+</TabsVertical>

--- a/e2e/fixtures/TabsOverflowFixture.svelte
+++ b/e2e/fixtures/TabsOverflowFixture.svelte
@@ -1,0 +1,19 @@
+<script>
+  import { Tab, TabContent, Tabs } from "carbon-components-svelte";
+
+  const items = Array.from({ length: 10 }, (_, i) => `Tab label ${i + 1}`);
+</script>
+
+<!-- Constrain the width so the list overflows regardless of the viewport. -->
+<div style="inline-size: 320px;" data-testid="tabs-overflow">
+  <Tabs>
+    {#each items as item}
+      <Tab label={item} />
+    {/each}
+    <svelte:fragment slot="content">
+      {#each items as item}
+        <TabContent>{item} content</TabContent>
+      {/each}
+    </svelte:fragment>
+  </Tabs>
+</div>

--- a/e2e/fixtures/index.html
+++ b/e2e/fixtures/index.html
@@ -33,6 +33,7 @@
       <a href="/checkbox-group.html">CheckboxGroup</a>
       <a href="/radio-button-group.html">RadioButtonGroup</a>
       <a href="/tabs.html">Tabs</a>
+      <a href="/tabs-overflow.html">Tabs (overflow)</a>
       <a href="/tag.html">Tag</a>
       <a href="/pagination.html">Pagination</a>
       <a href="/pagination-nav.html">PaginationNav</a>

--- a/e2e/fixtures/tabs-overflow.html
+++ b/e2e/fixtures/tabs-overflow.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Tabs Overflow Test</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="./tabs-overflow.ts"></script>
+  </body>
+</html>

--- a/e2e/fixtures/tabs-overflow.ts
+++ b/e2e/fixtures/tabs-overflow.ts
@@ -1,0 +1,4 @@
+import { mount } from "./mount";
+import TabsOverflowFixture from "./TabsOverflowFixture.svelte";
+
+mount(TabsOverflowFixture);

--- a/e2e/tabs-overflow.test.ts
+++ b/e2e/tabs-overflow.test.ts
@@ -1,0 +1,57 @@
+import { expect, test } from "@playwright/test";
+
+const NEXT = ".bx--tab--overflow-nav-button--next";
+const PREV = ".bx--tab--overflow-nav-button--previous";
+const HIDDEN = "bx--tab--overflow-nav-button--hidden";
+
+test.describe("Tabs overflow", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/tabs-overflow.html");
+  });
+
+  test("shows scroll buttons when the tab list overflows", async ({ page }) => {
+    // At the start, the forward button is visible and the backward one hidden.
+    await expect(page.locator(NEXT)).not.toHaveClass(new RegExp(HIDDEN));
+    await expect(page.locator(PREV)).toHaveClass(new RegExp(HIDDEN));
+  });
+
+  test("forward button scrolls the list and reveals the backward button", async ({
+    page,
+  }) => {
+    const nav = page.getByRole("tablist");
+    expect(await nav.evaluate((n) => n.scrollLeft)).toBe(0);
+
+    await page.locator(NEXT).click();
+
+    await expect
+      .poll(async () => nav.evaluate((n) => n.scrollLeft))
+      .toBeGreaterThan(0);
+    await expect(page.locator(PREV)).not.toHaveClass(new RegExp(HIDDEN));
+  });
+
+  test("keyboard navigation keeps the focused tab visible", async ({
+    page,
+  }) => {
+    await page.getByRole("tab", { name: "Tab label 1", exact: true }).focus();
+
+    // Arrow through several variable-width tabs; the focused tab must stay
+    // within the scroll viewport rather than drifting off-screen.
+    for (let i = 0; i < 6; i++) {
+      // biome-ignore lint/performance/noAwaitInLoops: arrow presses are sequential
+      await page.keyboard.press("ArrowRight");
+    }
+
+    const focused = page.locator("[role=tab]:focus");
+    await expect(focused).toHaveAttribute("aria-selected", "true");
+
+    const visible = await focused.evaluate((tab) => {
+      const nav = tab.closest(".bx--tabs__nav") as HTMLElement;
+      const navRect = nav.getBoundingClientRect();
+      const tabRect = tab.getBoundingClientRect();
+      return (
+        tabRect.left >= navRect.left - 1 && tabRect.right <= navRect.right + 1
+      );
+    });
+    expect(visible).toBe(true);
+  });
+});

--- a/src/Tabs/Tab.svelte
+++ b/src/Tabs/Tab.svelte
@@ -80,7 +80,6 @@
     selectedTab,
     activeTooltip,
     iconOnly,
-    belowMd,
     useAutoWidth,
     useFullWidth,
     useDismissible,
@@ -103,11 +102,7 @@
   // Gate on `activeTooltip` so only one tab tooltip shows at a time. When a
   // neighbor claims the active slot, this one closes even while still hovered.
   $: tooltipOpen =
-    $iconOnly &&
-    !$belowMd &&
-    !disabled &&
-    (hovered || focused) &&
-    $activeTooltip === id;
+    $iconOnly && !disabled && (hovered || focused) && $activeTooltip === id;
 
   function claim() {
     activeTooltip.set(id);

--- a/src/Tabs/Tabs.svelte
+++ b/src/Tabs/Tabs.svelte
@@ -26,15 +26,6 @@
   export let fullWidth = false;
 
   /**
-   * Specify the ARIA label for the chevron icon.
-   * @type {string}
-   */
-  export let iconDescription = "Show menu options";
-
-  /** Specify the tab trigger href attribute */
-  export let triggerHref = "#";
-
-  /**
    * Set to `true` to render icon-only tabs.
    * Each `Tab` displays only its `icon`; the `label` is used as the accessible
    * name and the tooltip shown on hover and focus.
@@ -50,10 +41,16 @@
    */
   export let iconSize = "default";
 
-  import { afterUpdate, createEventDispatcher, setContext, tick } from "svelte";
+  import {
+    afterUpdate,
+    createEventDispatcher,
+    onMount,
+    setContext,
+    tick,
+  } from "svelte";
   import { derived, get, writable } from "svelte/store";
-  import { breakpointObserver } from "../Breakpoint/breakpointObserver.js";
-  import ChevronDown from "../icons/ChevronDown.svelte";
+  import ChevronLeft from "../icons/ChevronLeft.svelte";
+  import ChevronRight from "../icons/ChevronRight.svelte";
   import { keyBy } from "../utils/keyBy.js";
   import { rovingFocus } from "../utils/rovingFocus.js";
   import { syncDomOrder } from "../utils/syncDomOrder.js";
@@ -99,12 +96,37 @@
    * @type {import("svelte/store").Writable<string | undefined>}
    */
   const activeTooltip = writable(undefined);
-  // Below `md` the tabs collapse into the dropdown menu, where the label is
-  // visible inline; the icon-only tooltip is redundant there, so it is suppressed.
-  const belowMd = breakpointObserver().smallerThan("md");
 
   let refTabList = null;
   let refRoot = null;
+
+  // Carbon React v11 replaces the legacy mobile dropdown with a horizontally
+  // scrollable tab list plus overflow navigation buttons. The buttons appear
+  // only when the list overflows, and each one hides once that edge is reached.
+  let canScrollBackward = false;
+  let canScrollForward = false;
+  $: isOverflow = canScrollBackward || canScrollForward;
+
+  function updateOverflow() {
+    if (!refTabList) return;
+    const { scrollLeft, scrollWidth, clientWidth } = refTabList;
+    canScrollBackward = scrollLeft > 0;
+    // Round up to absorb sub-pixel widths so the forward button hides cleanly
+    // when the list is scrolled to the end.
+    canScrollForward = Math.ceil(scrollLeft + clientWidth) < scrollWidth;
+  }
+
+  /**
+   * Scroll the tab list by roughly a viewport width in the given direction.
+   * @type {(direction: 1 | -1) => void}
+   */
+  function scrollTabs(direction) {
+    if (!refTabList) return;
+    refTabList.scrollBy({
+      left: direction * refTabList.clientWidth * 0.75,
+      behavior: "smooth",
+    });
+  }
 
   // Flag to trigger DOM reordering only when tabs change.
   // This is necessary to avoid infinite loops in Svelte 5.
@@ -172,6 +194,36 @@
   }
 
   /**
+   * Keep a focused tab clear of the overflow chevrons / edge fades.
+   * @type {number}
+   */
+  const SCROLL_INTO_VIEW_MARGIN = 48;
+
+  /**
+   * Scroll the tab list so `tab` is fully visible, inset from each edge so it is
+   * not tucked under an overflow button. The browser's native focus scroll moves
+   * a fixed step that lags variable-width tabs, eventually pushing the focused
+   * tab off-screen, so selection is scrolled explicitly instead.
+   * @type {(tab: HTMLElement | undefined) => void}
+   */
+  function scrollTabIntoView(tab) {
+    if (!tab || !refTabList) return;
+
+    const navRect = refTabList.getBoundingClientRect();
+    const tabRect = tab.getBoundingClientRect();
+    const leftOverflow =
+      tabRect.left - (navRect.left + SCROLL_INTO_VIEW_MARGIN);
+    const rightOverflow =
+      tabRect.right - (navRect.right - SCROLL_INTO_VIEW_MARGIN);
+
+    if (leftOverflow < 0) {
+      refTabList.scrollLeft += leftOverflow;
+    } else if (rightOverflow > 0) {
+      refTabList.scrollLeft += rightOverflow;
+    }
+  }
+
+  /**
    * Move selection/focus to a tab at an absolute index. Roving focus resolves
    * the index (skipping disabled, wrapping); selection follows focus.
    * @type {(index: number) => Promise<void>}
@@ -182,8 +234,11 @@
     currentIndex = index;
 
     await tick();
-    const activeTab = refTabList?.querySelectorAll("[role='tab']")[index];
-    activeTab?.focus();
+    const activeTab = /** @type {HTMLElement | undefined} */ (
+      refTabList?.querySelectorAll("[role='tab']")[index]
+    );
+    activeTab?.focus({ preventScroll: true });
+    scrollTabIntoView(activeTab);
   }
 
   setContext("carbon:Tabs", {
@@ -193,7 +248,6 @@
     selectedContent,
     activeTooltip,
     iconOnly: useIconOnly,
-    belowMd,
     useAutoWidth,
     useFullWidth,
     useDismissible,
@@ -242,7 +296,13 @@
     prevIndex = currentIndex;
   });
 
-  let dropdownHidden = true;
+  onMount(() => {
+    updateOverflow();
+    const observer = new ResizeObserver(updateOverflow);
+    if (refTabList) observer.observe(refTabList);
+    return () => observer.disconnect();
+  });
+
   let currentIndex = selected;
   let prevIndex = -1;
 
@@ -258,8 +318,9 @@
       selectedContent.set(currentContent.id);
     }
   }
-  $: if ($selectedTab) {
-    dropdownHidden = true;
+  // Recompute overflow when the set of tabs changes (added/removed/relabeled).
+  $: if ($tabs) {
+    tick().then(updateOverflow);
   }
   $: useAutoWidth.set(autoWidth);
   $: useFullWidth.set(fullWidth);
@@ -277,36 +338,27 @@
   class:bx--tabs--dismissible={dismissible}
   class:bx--tabs--icon-only={iconOnly}
   class:bx--tabs__icon--lg={iconOnly && iconSize === "lg"}
+  class:bx--tabs--scrollable={isOverflow}
+  class:bx--tabs--scrollable--container={isOverflow && type === "container"}
   {...$$restProps}
 >
-  <div
-    role="listbox"
-    tabindex="0"
-    class:bx--tabs-trigger={true}
-    aria-label={$$props["aria-label"] ?? "listbox"}
-    on:click={() => {
-      dropdownHidden = !dropdownHidden;
-    }}
-    on:keypress
-    on:keypress={() => {
-      dropdownHidden = !dropdownHidden;
-    }}
-  >
-    <a
+  {#if isOverflow}
+    <button
+      type="button"
       tabindex="-1"
-      class:bx--tabs-trigger-text={true}
-      href={triggerHref}
-      on:click|preventDefault
-      on:click|preventDefault|stopPropagation={() => {
-        dropdownHidden = !dropdownHidden;
-      }}
+      aria-hidden="true"
+      class:bx--tab--overflow-nav-button={true}
+      class:bx--tab--overflow-nav-button--previous={true}
+      class:bx--tab--overflow-nav-button--hidden={!canScrollBackward}
+      on:click={() => scrollTabs(-1)}
     >
-      {#if currentTab}
-        {currentTab.label}
-      {/if}
-    </a>
-    <ChevronDown aria-hidden="true" title={iconDescription} />
-  </div>
+      <ChevronLeft />
+    </button>
+    <div
+      class:bx--tabs__overflow-indicator--left={true}
+      class:bx--tab--overflow-nav-button--hidden={!canScrollBackward}
+    ></div>
+  {/if}
   <!-- svelte-ignore a11y-no-noninteractive-element-to-interactive-role -->
   <ul
     bind:this={refTabList}
@@ -319,9 +371,26 @@
       onMove: (index) => selectTab(index),
     }}
     class:bx--tabs__nav={true}
-    class:bx--tabs__nav--hidden={dropdownHidden}
+    on:scroll={updateOverflow}
   >
     <slot />
   </ul>
+  {#if isOverflow}
+    <div
+      class:bx--tabs__overflow-indicator--right={true}
+      class:bx--tab--overflow-nav-button--hidden={!canScrollForward}
+    ></div>
+    <button
+      type="button"
+      tabindex="-1"
+      aria-hidden="true"
+      class:bx--tab--overflow-nav-button={true}
+      class:bx--tab--overflow-nav-button--next={true}
+      class:bx--tab--overflow-nav-button--hidden={!canScrollForward}
+      on:click={() => scrollTabs(1)}
+    >
+      <ChevronRight />
+    </button>
+  {/if}
 </div>
 <slot name="content" />

--- a/src/Tabs/TabsVertical.svelte
+++ b/src/Tabs/TabsVertical.svelte
@@ -16,9 +16,17 @@
    */
   export let size = "xl";
 
-  import { afterUpdate, createEventDispatcher, setContext, tick } from "svelte";
+  import {
+    afterUpdate,
+    createEventDispatcher,
+    onMount,
+    setContext,
+    tick,
+  } from "svelte";
   import { derived, writable } from "svelte/store";
   import { breakpointObserver } from "../Breakpoint/breakpointObserver.js";
+  import ChevronLeft from "../icons/ChevronLeft.svelte";
+  import ChevronRight from "../icons/ChevronRight.svelte";
   import { keyBy } from "../utils/keyBy.js";
   import { rovingFocus } from "../utils/rovingFocus.js";
   import { syncDomOrder } from "../utils/syncDomOrder.js";
@@ -67,6 +75,60 @@
 
   let refTabList = null;
   let refRoot = null;
+
+  // Below `md` the tab column collapses into a horizontal, scrollable row that
+  // reuses the same overflow scroll buttons as the horizontal `Tabs`. The
+  // buttons only apply there (a `md`+ column has no horizontal overflow).
+  let canScrollBackward = false;
+  let canScrollForward = false;
+  $: isOverflow = $belowMd && (canScrollBackward || canScrollForward);
+
+  function updateOverflow() {
+    if (!refTabList) return;
+    const { scrollLeft, scrollWidth, clientWidth } = refTabList;
+    canScrollBackward = scrollLeft > 0;
+    canScrollForward = Math.ceil(scrollLeft + clientWidth) < scrollWidth;
+  }
+
+  /**
+   * Scroll the tab list by roughly a viewport width in the given direction.
+   * @type {(direction: 1 | -1) => void}
+   */
+  function scrollTabs(direction) {
+    if (!refTabList) return;
+    refTabList.scrollBy({
+      left: direction * refTabList.clientWidth * 0.75,
+      behavior: "smooth",
+    });
+  }
+
+  /**
+   * Keep a focused tab clear of the overflow chevrons / edge fades.
+   * @type {number}
+   */
+  const SCROLL_INTO_VIEW_MARGIN = 48;
+
+  /**
+   * Scroll the horizontal tab row so `tab` is fully visible, inset from each
+   * edge so it is not tucked under an overflow button.
+   * @type {(tab: HTMLElement | undefined) => void}
+   */
+  function scrollTabIntoView(tab) {
+    if (!tab || !refTabList) return;
+
+    const navRect = refTabList.getBoundingClientRect();
+    const tabRect = tab.getBoundingClientRect();
+    const leftOverflow =
+      tabRect.left - (navRect.left + SCROLL_INTO_VIEW_MARGIN);
+    const rightOverflow =
+      tabRect.right - (navRect.right - SCROLL_INTO_VIEW_MARGIN);
+
+    if (leftOverflow < 0) {
+      refTabList.scrollLeft += leftOverflow;
+    } else if (rightOverflow > 0) {
+      refTabList.scrollLeft += rightOverflow;
+    }
+  }
 
   // Flag to trigger DOM reordering only when tabs change.
   // This is necessary to avoid infinite loops in Svelte 5.
@@ -125,8 +187,14 @@
     currentIndex = index;
 
     await tick();
-    const activeTab = refTabList?.querySelectorAll("[role='tab']")[index];
-    activeTab?.focus();
+    const activeTab = /** @type {HTMLElement | undefined} */ (
+      refTabList?.querySelectorAll("[role='tab']")[index]
+    );
+    // Below `md` the row scrolls horizontally; disable the native focus scroll
+    // (a fixed step that lags variable-width tabs) and scroll explicitly. At
+    // `md`+ the column relies on the browser scrolling the page to the tab.
+    activeTab?.focus({ preventScroll: $belowMd });
+    if ($belowMd) scrollTabIntoView(activeTab);
   }
 
   setContext("carbon:Tabs", {
@@ -136,7 +204,6 @@
     selectedContent,
     activeTooltip,
     iconOnly: useIconOnly,
-    belowMd,
     useAutoWidth,
     useFullWidth,
     useDismissible,
@@ -185,6 +252,13 @@
     prevIndex = currentIndex;
   });
 
+  onMount(() => {
+    updateOverflow();
+    const observer = new ResizeObserver(updateOverflow);
+    if (refTabList) observer.observe(refTabList);
+    return () => observer.disconnect();
+  });
+
   let currentIndex = selected;
   let prevIndex = -1;
 
@@ -203,6 +277,10 @@
   // Roving focus follows the visual orientation: arrow Up/Down in the vertical
   // column, arrow Left/Right in the horizontal row below `md`.
   $: orientation = $belowMd ? "horizontal" : "vertical";
+  // Recompute overflow when the tabs change or the layout flips at `md`.
+  $: if ($tabs || $belowMd) {
+    tick().then(updateOverflow);
+  }
 </script>
 
 <div bind:this={refRoot} class:bx--tabs--vertical-container={true}>
@@ -211,12 +289,31 @@
     class:bx--tabs={true}
     class:bx--tabs--vertical={true}
     class:bx--tabs--tall={$hasSecondaryLabel}
+    class:bx--tabs--scrollable={isOverflow}
+    class:bx--tabs--scrollable--container={isOverflow}
     class:bx--layout--size-sm={size === "sm"}
     class:bx--layout--size-md={size === "md"}
     class:bx--layout--size-lg={size === "lg"}
     class:bx--layout--size-xl={size === "xl"}
     {...$$restProps}
   >
+    {#if isOverflow}
+      <button
+        type="button"
+        tabindex="-1"
+        aria-hidden="true"
+        class:bx--tab--overflow-nav-button={true}
+        class:bx--tab--overflow-nav-button--previous={true}
+        class:bx--tab--overflow-nav-button--hidden={!canScrollBackward}
+        on:click={() => scrollTabs(-1)}
+      >
+        <ChevronLeft />
+      </button>
+      <div
+        class:bx--tabs__overflow-indicator--left={true}
+        class:bx--tab--overflow-nav-button--hidden={!canScrollBackward}
+      ></div>
+    {/if}
     <!-- svelte-ignore a11y-no-noninteractive-element-to-interactive-role -->
     <ul
       bind:this={refTabList}
@@ -234,9 +331,27 @@
         },
       }}
       class:bx--tabs__nav={true}
+      on:scroll={updateOverflow}
     >
       <slot />
     </ul>
+    {#if isOverflow}
+      <div
+        class:bx--tabs__overflow-indicator--right={true}
+        class:bx--tab--overflow-nav-button--hidden={!canScrollForward}
+      ></div>
+      <button
+        type="button"
+        tabindex="-1"
+        aria-hidden="true"
+        class:bx--tab--overflow-nav-button={true}
+        class:bx--tab--overflow-nav-button--next={true}
+        class:bx--tab--overflow-nav-button--hidden={!canScrollForward}
+        on:click={() => scrollTabs(1)}
+      >
+        <ChevronRight />
+      </button>
+    {/if}
   </div>
   <slot name="content" />
 </div>

--- a/src/icons/ChevronLeft.svelte
+++ b/src/icons/ChevronLeft.svelte
@@ -1,0 +1,28 @@
+<script>
+  export let size = 16;
+
+  export let title = undefined;
+
+  $: labelled = $$props["aria-label"] || $$props["aria-labelledby"] || title;
+  $: attributes = {
+    "aria-hidden": labelled ? undefined : true,
+    role: labelled ? "img" : undefined,
+    focusable: Number($$props.tabindex) === 0 ? true : undefined,
+  };
+</script>
+
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 32 32"
+  fill="currentColor"
+  preserveAspectRatio="xMidYMid meet"
+  width={size}
+  height={size}
+  {...attributes}
+  {...$$restProps}
+>
+  {#if title}
+    <title>{title}</title>
+  {/if}
+  <path d="M20 26L10 16 20 6 21.4 7.4 12.8 16 21.4 24.6z"></path>
+</svg>

--- a/tests/Tabs/Tabs.test.svelte
+++ b/tests/Tabs/Tabs.test.svelte
@@ -8,8 +8,6 @@
   export let type: ComponentProps<Tabs>["type"] = "default";
   export let autoWidth = false;
   export let fullWidth = false;
-  export let iconDescription = "Show menu options";
-  export let triggerHref = "#";
   export let customClass = "";
   export let ariaLabel = "";
 </script>
@@ -19,8 +17,6 @@
   {type}
   {autoWidth}
   {fullWidth}
-  {iconDescription}
-  {triggerHref}
   class={customClass}
   aria-label={ariaLabel === undefined ? undefined : ariaLabel}
   on:change={({ detail }) => {

--- a/tests/Tabs/Tabs.test.ts
+++ b/tests/Tabs/Tabs.test.ts
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, within } from "@testing-library/svelte";
+import { fireEvent, render, screen } from "@testing-library/svelte";
 import type TabComponent from "carbon-components-svelte/Tabs/Tab.svelte";
 import type { ComponentProps } from "svelte";
 import Calendar from "../../src/icons/Calendar.svelte";
@@ -144,11 +144,10 @@ describe("Tabs", () => {
     expect(consoleLog).toHaveBeenCalledWith("change event", 0);
   });
 
-  // Regression: ?? for aria-label so empty string is used (not fallback)
-  it("uses empty aria-label when passed (nullish coalescing)", () => {
+  it("uses an empty aria-label when passed an empty string", () => {
     render(Tabs, { props: { ariaLabel: "" } });
-    const listbox = screen.getByRole("listbox");
-    expect(listbox).toHaveAttribute("aria-label", "");
+    const nav = screen.getByRole("navigation");
+    expect(nav).toHaveAttribute("aria-label", "");
   });
 
   it("should render container type tabs", () => {
@@ -181,42 +180,62 @@ describe("Tabs", () => {
     expect(tabsContainer).toHaveClass("bx--tabs--full-width");
   });
 
-  it("should show dropdown on trigger click", async () => {
+  // The v11 redesign drops the legacy mobile dropdown: there is no longer a
+  // listbox trigger, and the tab list is always inline (never `--hidden`).
+  it("does not render a dropdown trigger and keeps the tab list inline", () => {
     render(Tabs);
 
-    const trigger = screen.getByRole("listbox");
-    await user.click(trigger);
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+
     const tablist = screen.getByRole("tablist");
     expect(tablist).not.toHaveClass("bx--tabs__nav--hidden");
+    expect(tablist).toBeVisible();
   });
 
-  it("should update trigger text when tab changes", async () => {
-    render(Tabs);
+  // jsdom does no layout, so the overflow geometry is mocked on the nav element
+  // to drive `updateOverflow`. The buttons only render while the list overflows,
+  // and each hides once that edge is reached.
+  it("renders overflow scroll buttons that toggle at the start and end", async () => {
+    const { container } = render(Tabs);
 
-    const tab3 = screen.getByText("Tab 3");
-    await user.click(tab3);
+    expect(
+      container.querySelector(".bx--tab--overflow-nav-button"),
+    ).not.toBeInTheDocument();
 
-    const trigger = screen.getByRole("listbox");
-    const triggerText = within(trigger).getByRole("link");
-    expect(triggerText).toHaveTextContent("Tab 3");
-  });
-
-  it("should support custom trigger href", () => {
-    render(Tabs, {
-      props: { triggerHref: "#custom" },
+    const nav = screen.getByRole("tablist");
+    Object.defineProperty(nav, "scrollWidth", {
+      configurable: true,
+      value: 600,
     });
-
-    const trigger = screen.getByRole("listbox");
-    const triggerLink = within(trigger).getByRole("link");
-    expect(triggerLink).toHaveAttribute("href", "#custom");
-  });
-
-  it("should support custom icon description", () => {
-    render(Tabs, {
-      props: { iconDescription: "Custom description" },
+    Object.defineProperty(nav, "clientWidth", {
+      configurable: true,
+      value: 200,
     });
+    Object.defineProperty(nav, "scrollLeft", {
+      configurable: true,
+      writable: true,
+      value: 0,
+    });
+    await fireEvent.scroll(nav);
 
-    expect(screen.getByTitle("Custom description")).toBeInTheDocument();
+    const prev = container.querySelector(
+      ".bx--tab--overflow-nav-button--previous",
+    );
+    const next = container.querySelector(".bx--tab--overflow-nav-button--next");
+
+    // Decorative: out of the tab order and hidden from assistive tech.
+    expect(next).toHaveAttribute("aria-hidden", "true");
+    expect(next).toHaveAttribute("tabindex", "-1");
+
+    // At the start: forward shown, backward hidden.
+    expect(prev).toHaveClass("bx--tab--overflow-nav-button--hidden");
+    expect(next).not.toHaveClass("bx--tab--overflow-nav-button--hidden");
+
+    // Scrolled to the end: backward shown, forward hidden.
+    (nav as HTMLElement).scrollLeft = 400;
+    await fireEvent.scroll(nav);
+    expect(prev).not.toHaveClass("bx--tab--overflow-nav-button--hidden");
+    expect(next).toHaveClass("bx--tab--overflow-nav-button--hidden");
   });
 
   it("should apply custom class", () => {
@@ -233,18 +252,8 @@ describe("Tabs", () => {
       props: { ariaLabel: "Custom label" },
     });
 
-    const trigger = screen.getByRole("listbox", { name: "Custom label" });
-    expect(trigger).toHaveAttribute("aria-label", "Custom label");
-  });
-
-  it("should handle keypress on dropdown trigger", async () => {
-    render(Tabs);
-
-    const trigger = screen.getByRole("listbox");
-    trigger.focus();
-    await user.keyboard("{Enter}");
-    const tablist = screen.getByRole("tablist");
-    expect(tablist).not.toHaveClass("bx--tabs__nav--hidden");
+    const nav = screen.getByRole("navigation", { name: "Custom label" });
+    expect(nav).toHaveAttribute("aria-label", "Custom label");
   });
 
   it("should maintain correct indices when tabs are dynamically removed and re-added", async () => {

--- a/tests/Tabs/TabsIconOnly.test.ts
+++ b/tests/Tabs/TabsIconOnly.test.ts
@@ -68,8 +68,10 @@ describe("Tabs (icon-only)", () => {
     expect(openTooltips()).toHaveLength(0);
   });
 
-  it("suppresses the tooltip below the `md` breakpoint (dropdown menu)", async () => {
-    // Simulate the small (dropdown) breakpoint.
+  // The v11 redesign keeps icon-only tabs square at every breakpoint (no more
+  // mobile dropdown that surfaced the label inline), so the tooltip is shown
+  // below `md` as well rather than suppressed.
+  it("still opens the tooltip below the `md` breakpoint", async () => {
     vi.stubGlobal("matchMedia", (query: string) => ({
       matches: query === "(max-width: 672px)",
       media: query,
@@ -85,7 +87,7 @@ describe("Tabs (icon-only)", () => {
       const settings = screen.getByRole("tab", { name: "Settings" });
       await fireEvent.focus(settings);
       await tick();
-      expect(openTooltips()).toHaveLength(0);
+      expect(openTooltips()).toHaveLength(1);
     } finally {
       vi.unstubAllGlobals();
     }


### PR DESCRIPTION
Closes #3325

Replaces the legacy mobile dropdown for Tabs with an inline, horizontally scrollable tab list and backward/forward scroll buttons that appear only on overflow, matching Carbon React v11.

Vertical tabs reuse the same behavior in their below-md horizontal row, and icon-only tabs stay square at every breakpoint with their tooltip always available. This is a breaking change: the dropdown-only `triggerHref` and `iconDescription` props are removed, so set `href` on each `Tab` for link navigation.

---

<img width="764" height="149" alt="Screenshot 2026-06-26 at 8 50 30 PM" src="https://github.com/user-attachments/assets/8208ab82-df90-4ce0-8930-e5187784bcf8" />
