### PR TITLE
feat(structured-list): customizable, auto-rendered selection icon

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -25,7 +25,7 @@
         "jsdom": "^29.1.1",
         "lightningcss": "^1.32.0",
         "sass-embedded": "^1.100.0",
-        "sveld": "^0.32.7",
+        "sveld": "^0.32.8",
         "svelte": "^5.56.3",
         "svelte-check": "^4.6.0",
         "typescript": "^6.0.3",
@@ -533,7 +533,7 @@
 
     "supports-color": ["supports-color@8.1.1", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q=="],
 
-    "sveld": ["sveld@0.32.7", "", { "dependencies": { "prettier": "^3.8.4" }, "bin": { "sveld": "cli.js" } }, "sha512-4a5dNbc5kK4Ce3TSChzOznC2KsM/3KNGDESRZesnWDO3MYNDcI35lGepipo6+zGLU/kVoP9Vu56sa37FsxnttA=="],
+    "sveld": ["sveld@0.32.8", "", { "dependencies": { "prettier": "^3.8.4" }, "bin": { "sveld": "cli.js" } }, "sha512-yIY+I4/RSPsCRDRjbanFdeQNYuOJdNaelc50g1cFyLXnIkyULt7O/93y/msOW3BVlGZkcrl6uNSbN5oOLQs0CA=="],
 
     "svelte": ["svelte@5.56.3", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "@jridgewell/sourcemap-codec": "^1.5.0", "@sveltejs/acorn-typescript": "^1.0.10", "@types/estree": "^1.0.5", "@types/trusted-types": "^2.0.7", "acorn": "^8.12.1", "aria-query": "5.3.1", "axobject-query": "^4.1.0", "clsx": "^2.1.1", "devalue": "^5.8.1", "esm-env": "^1.2.1", "esrap": "^2.2.11", "is-reference": "^3.0.3", "locate-character": "^3.0.0", "magic-string": "^0.30.11", "zimmerframe": "^1.1.2" } }, "sha512-w7JvrM5IFl5cmfbY0TLik9o7mjRUJmRMhOR51tBPu708Gr/MjbGs7VnJnr/B0CaXeI4vtnOh7RKxDr0cwhMdDA=="],
 

--- a/docs/src/pages/components/StructuredList.svx
+++ b/docs/src/pages/components/StructuredList.svx
@@ -5,7 +5,7 @@ description: Structured lists display tabular data with support for row selectio
 
 <script>
   import { StructuredList, StructuredListSkeleton, StructuredListBody, StructuredListHead, StructuredListCell, StructuredListRow, StructuredListInput } from "carbon-components-svelte";
-  import CheckmarkFilled from "carbon-icons-svelte/lib/CheckmarkFilled.svelte";
+  import CheckmarkOutline from "carbon-icons-svelte/lib/CheckmarkOutline.svelte";
 </script>
 
 ## Basic
@@ -120,7 +120,7 @@ Let users select one or more rows.
 
 ### Single
 
-Enable row selection with `selection` and structured list input components.
+Enable row selection with `selection` and structured list input components. The selection icon column is rendered automatically for each selectable row.
 
 <StructuredList selection selected="postgresql-value">
   <StructuredListHead>
@@ -128,7 +128,6 @@ Enable row selection with `selection` and structured list input components.
       <StructuredListCell head>Name</StructuredListCell>
       <StructuredListCell head>Type</StructuredListCell>
       <StructuredListCell head>Description</StructuredListCell>
-      <StructuredListCell head>{''}</StructuredListCell>
     </StructuredListRow>
   </StructuredListHead>
   <StructuredListBody>
@@ -147,13 +146,37 @@ Enable row selection with `selection` and structured list input components.
           title="{db.name} option"
           name="database"
         />
-        <StructuredListCell>
-          <CheckmarkFilled
-            class="bx--structured-list-svg"
-            aria-label="select an option"
-            title="select an option"
-          />
-        </StructuredListCell>
+      </StructuredListRow>
+    {/each}
+  </StructuredListBody>
+</StructuredList>
+
+### Custom selection icon
+
+Customize the selection icon with the `icon` prop on `StructuredList`.
+
+<StructuredList selection selected="postgresql-value" icon={CheckmarkOutline}>
+  <StructuredListHead>
+    <StructuredListRow head>
+      <StructuredListCell head>Name</StructuredListCell>
+      <StructuredListCell head>Type</StructuredListCell>
+    </StructuredListRow>
+  </StructuredListHead>
+  <StructuredListBody>
+    {#each [
+      { id: "postgresql", name: "PostgreSQL", type: "Relational" },
+      { id: "mongodb", name: "MongoDB", type: "Document" },
+      { id: "redis", name: "Redis", type: "Key-value" },
+    ] as db}
+      <StructuredListRow label for="icon-{db.id}">
+        <StructuredListCell>{db.name}</StructuredListCell>
+        <StructuredListCell>{db.type}</StructuredListCell>
+        <StructuredListInput
+          id="icon-{db.id}"
+          value="{db.id}-value"
+          title="{db.name} option"
+          name="database-icon"
+        />
       </StructuredListRow>
     {/each}
   </StructuredListBody>

--- a/docs/src/pages/framed/StructuredList/StructuredListMultiSelect.svelte
+++ b/docs/src/pages/framed/StructuredList/StructuredListMultiSelect.svelte
@@ -7,7 +7,6 @@
     StructuredListInput,
     StructuredListRow,
   } from "carbon-components-svelte";
-  import CheckmarkFilled from "carbon-icons-svelte/lib/CheckmarkFilled.svelte";
 
   const databases = [
     {
@@ -42,7 +41,6 @@
       <StructuredListCell head>Name</StructuredListCell>
       <StructuredListCell head>Type</StructuredListCell>
       <StructuredListCell head>Description</StructuredListCell>
-      <StructuredListCell head>{""}</StructuredListCell>
     </StructuredListRow>
   </StructuredListHead>
   <StructuredListBody>
@@ -56,13 +54,6 @@
           value="{db.id}-value"
           title="{db.name} option"
         />
-        <StructuredListCell>
-          <CheckmarkFilled
-            class="bx--structured-list-svg"
-            aria-label="select an option"
-            title="select an option"
-          />
-        </StructuredListCell>
       </StructuredListRow>
     {/each}
   </StructuredListBody>

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "jsdom": "^29.1.1",
     "lightningcss": "^1.32.0",
     "sass-embedded": "^1.100.0",
-    "sveld": "^0.32.7",
+    "sveld": "^0.32.8",
     "svelte": "^5.56.3",
     "svelte-check": "^4.6.0",
     "typescript": "^6.0.3",

--- a/src/StructuredList/StructuredList.svelte
+++ b/src/StructuredList/StructuredList.svelte
@@ -1,6 +1,7 @@
 <script>
   /**
    * @template {string} [Value=string]
+   * @template [Icon=any]
    * @event {Value | Value[]} change
    */
 
@@ -24,6 +25,15 @@
   /** Set to `true` to allow selecting multiple rows */
   export let multiple = false;
 
+  /**
+   * Specify the icon rendered in the selection column of selectable rows.
+   * Only used when `selection` is `true`.
+   * The icon is decorative; selection state is conveyed by each row's `aria-checked`.
+   * @type {Icon}
+   */
+  export let icon = CheckmarkFilled;
+
+  import CheckmarkFilled from "carbon-icons-svelte/lib/CheckmarkFilled.svelte";
   import { createEventDispatcher, onMount, setContext } from "svelte";
   import { writable } from "svelte/store";
 
@@ -58,6 +68,8 @@
     selectedValue,
     update,
     multiple,
+    selection,
+    icon,
   });
 
   onMount(() => {

--- a/src/StructuredList/StructuredListRow.svelte
+++ b/src/StructuredList/StructuredListRow.svelte
@@ -11,12 +11,16 @@
    */
   export let tabindex = "0";
 
+  import CheckmarkFilled from "carbon-icons-svelte/lib/CheckmarkFilled.svelte";
   import { getContext, onMount } from "svelte";
   import { writable } from "svelte/store";
+  import StructuredListCell from "./StructuredListCell.svelte";
 
   const ctx = getContext("carbon:StructuredListWrapper");
   const selectedValue = ctx?.selectedValue ?? writable(undefined);
   const multiple = ctx?.multiple ?? false;
+  const selection = ctx?.selection ?? false;
+  const icon = ctx?.icon ?? CheckmarkFilled;
 
   let labelRef;
   let inputValue;
@@ -66,6 +70,11 @@
     on:keydown={handleKeydown}
   >
     <slot />
+    {#if selection}
+      <StructuredListCell style="width: 1px; white-space: nowrap;">
+        <svelte:component this={icon} class="bx--structured-list-svg" />
+      </StructuredListCell>
+    {/if}
   </label>
 {:else}
   <!-- svelte-ignore a11y-interactive-supports-focus -->
@@ -80,5 +89,8 @@
     on:mouseleave
   >
     <slot />
+    {#if selection && head}
+      <StructuredListCell head style="width: 1px;">{""}</StructuredListCell>
+    {/if}
   </div>
 {/if}

--- a/tests/StructuredList/StructuredList.test.svelte
+++ b/tests/StructuredList/StructuredList.test.svelte
@@ -5,7 +5,6 @@
   import StructuredListHead from "carbon-components-svelte/StructuredList/StructuredListHead.svelte";
   import StructuredListInput from "carbon-components-svelte/StructuredList/StructuredListInput.svelte";
   import StructuredListRow from "carbon-components-svelte/StructuredList/StructuredListRow.svelte";
-  import CheckmarkFilled from "carbon-icons-svelte/lib/CheckmarkFilled.svelte";
   import type { ComponentProps } from "svelte";
 
   export let selected: ComponentProps<StructuredList>["selected"] = undefined;
@@ -40,9 +39,6 @@
       <StructuredListCell head>Column A</StructuredListCell>
       <StructuredListCell head>Column B</StructuredListCell>
       <StructuredListCell head>Column C</StructuredListCell>
-      {#if selection}
-        <StructuredListCell head>{""}</StructuredListCell>
-      {/if}
     </StructuredListRow>
   </StructuredListHead>
   <StructuredListBody>
@@ -61,13 +57,6 @@
             title="row-{item}-title"
             name="row-{item}-name"
           />
-          <StructuredListCell>
-            <CheckmarkFilled
-              class="bx--structured-list-svg"
-              aria-label="select an option"
-              title="select an option"
-            />
-          </StructuredListCell>
         {/if}
       </StructuredListRow>
     {/each}

--- a/tests/StructuredList/StructuredList.test.ts
+++ b/tests/StructuredList/StructuredList.test.ts
@@ -5,6 +5,7 @@ import { user } from "../utils/user";
 import StructuredList from "./StructuredList.test.svelte";
 import StructuredListChecked from "./StructuredListChecked.test.svelte";
 import StructuredListCustom from "./StructuredListCustom.test.svelte";
+import StructuredListCustomIcon from "./StructuredListCustomIcon.test.svelte";
 import StructuredListInputStandalone from "./StructuredListInputStandalone.test.svelte";
 import StructuredListMultiple from "./StructuredListMultiple.test.svelte";
 
@@ -46,7 +47,9 @@ describe("StructuredList", () => {
   });
 
   it("should handle selection variant", () => {
-    render(StructuredList, { props: { selection: true } });
+    const { container } = render(StructuredList, {
+      props: { selection: true },
+    });
 
     const list = screen.getByRole("table");
     expect(list).toHaveClass("bx--structured-list--selection");
@@ -54,8 +57,30 @@ describe("StructuredList", () => {
     const inputs = screen.getAllByRole("radio");
     expect(inputs).toHaveLength(3);
 
-    const checkmarks = screen.getAllByTitle("select an option");
+    const checkmarks = container.querySelectorAll(
+      "svg.bx--structured-list-svg",
+    );
     expect(checkmarks).toHaveLength(3);
+
+    for (const checkmark of checkmarks) {
+      // The checkmark is decorative; selection state is conveyed by the row.
+      expect(checkmark).toHaveAttribute("aria-hidden", "true");
+      // The selection icon column shrinks to the icon so it sits flush right.
+      expect(checkmark.closest(".bx--structured-list-td")).toHaveStyle({
+        width: "1px",
+      });
+    }
+  });
+
+  it("should render a custom selection icon via the `icon` prop", () => {
+    const { container } = render(StructuredListCustomIcon);
+
+    // One auto-rendered, decorative icon per selectable row.
+    const icons = container.querySelectorAll("svg.bx--structured-list-svg");
+    expect(icons).toHaveLength(3);
+    for (const icon of icons) {
+      expect(icon).toHaveAttribute("aria-hidden", "true");
+    }
   });
 
   it("should handle selected state", async () => {

--- a/tests/StructuredList/StructuredListCustomIcon.test.svelte
+++ b/tests/StructuredList/StructuredListCustomIcon.test.svelte
@@ -5,19 +5,10 @@
   import StructuredListHead from "carbon-components-svelte/StructuredList/StructuredListHead.svelte";
   import StructuredListInput from "carbon-components-svelte/StructuredList/StructuredListInput.svelte";
   import StructuredListRow from "carbon-components-svelte/StructuredList/StructuredListRow.svelte";
-  import type { ComponentProps } from "svelte";
-
-  export let selected: ComponentProps<StructuredList>["selected"] = undefined;
+  import CheckmarkOutline from "carbon-icons-svelte/lib/CheckmarkOutline.svelte";
 </script>
 
-<StructuredList
-  selection
-  multiple
-  bind:selected
-  on:change={(e) => {
-    console.log("change", e.detail);
-  }}
->
+<StructuredList selection icon={CheckmarkOutline}>
   <StructuredListHead>
     <StructuredListRow head>
       <StructuredListCell head>Column A</StructuredListCell>
@@ -27,14 +18,8 @@
     {#each ["1", "2", "3"] as item}
       <StructuredListRow label for="row-{item}">
         <StructuredListCell>Row {item}</StructuredListCell>
-        <StructuredListInput
-          id="row-{item}"
-          value="row-{item}-value"
-          title="row-{item}-title"
-        />
+        <StructuredListInput id="row-{item}" value="row-{item}-value" />
       </StructuredListRow>
     {/each}
   </StructuredListBody>
 </StructuredList>
-
-<div data-testid="value">{JSON.stringify(selected)}</div>


### PR DESCRIPTION
Add an `icon` prop to `StructuredList` so the selection checkmark is customizable, and have selectable rows auto-render it in a narrow, right-aligned column. This saves consumers from hand-placing a checkmark cell in every row while still allowing a custom icon, and the icon stays `aria-hidden` since selection state is conveyed by each row's `aria-checked`.

## Sample usage

```svelte
<script>
  import { StructuredList, StructuredListHead, StructuredListBody, StructuredListRow, StructuredListCell, StructuredListInput } from "carbon-components-svelte";
  import CheckmarkOutline from "carbon-icons-svelte/lib/CheckmarkOutline.svelte";
</script>

<StructuredList selection icon={CheckmarkOutline}>
  <StructuredListHead>
    <StructuredListRow head>
      <StructuredListCell head>Name</StructuredListCell>
      <StructuredListCell head>Type</StructuredListCell>
    </StructuredListRow>
  </StructuredListHead>
  <StructuredListBody>
    <StructuredListRow label for="postgresql">
      <StructuredListCell>PostgreSQL</StructuredListCell>
      <StructuredListCell>Relational</StructuredListCell>
      <StructuredListInput id="postgresql" value="postgresql" title="PostgreSQL" />
    </StructuredListRow>
  </StructuredListBody>
</StructuredList>
```

> [!WARNING]
> Breaking: selection rows now render the icon column automatically, so remove any manually placed checkmark cell to avoid a duplicate.