### PR TITLE
feat(link): icon scaling, tighter gap, and muted variant

### DIFF
--- a/css/_link.scss
+++ b/css/_link.scss
@@ -1,0 +1,34 @@
+@import "carbon-components/scss/globals/scss/vars";
+@import "carbon-components/scss/globals/scss/helper-mixins";
+@import "carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/import-once/import-once";
+
+/// Scale the Link icon to match the link size.
+/// carbon-components v10 ships no icon scaling — `.bx--link__icon` only sets a
+/// fixed `$spacing-03` gap, so the icon stays 16px at every size and looks
+/// oversized on `sm` links. Size the icon optically to the link text: smaller
+/// for `sm`, larger for `lg`. The default (medium) link keeps the 16px icon.
+/// Also tighten the icon-to-text gap on the smaller sizes, where Carbon's
+/// `$spacing-03` is too wide. Targets the rendered `svg` so the scaling applies
+/// to both the `icon` prop and the `icon` slot.
+/// @access private
+/// @group components
+@mixin link-icon {
+  // Default (md) and sm: narrower than Carbon's fixed $spacing-03. lg keeps it.
+  .#{$prefix}--link:not(.#{$prefix}--link--lg) .#{$prefix}--link__icon {
+    margin-left: $spacing-02;
+  }
+
+  .#{$prefix}--link--sm .#{$prefix}--link__icon svg {
+    width: to-rem(14px);
+    height: to-rem(14px);
+  }
+
+  .#{$prefix}--link--lg .#{$prefix}--link__icon svg {
+    width: to-rem(20px);
+    height: to-rem(20px);
+  }
+}
+
+@include exports("link-icon") {
+  @include link-icon;
+}

--- a/css/_link.scss
+++ b/css/_link.scss
@@ -32,3 +32,26 @@
 @include exports("link-icon") {
   @include link-icon;
 }
+
+/// Muted Link variant: inherit the surrounding text color instead of the
+/// link color, for inline links inside body text. Carbon has no equivalent.
+/// Guard against `disabled` so a disabled link keeps its disabled color. The
+/// `:not()` guard also lifts specificity above Carbon's `:hover`/`:visited`
+/// link rules.
+/// @access private
+/// @group components
+@mixin link-muted {
+  .#{$prefix}--link--muted:not(.#{$prefix}--link--disabled) {
+    &,
+    &:hover,
+    &:active,
+    &:visited,
+    &:visited:hover {
+      color: inherit;
+    }
+  }
+}
+
+@include exports("link-muted") {
+  @include link-muted;
+}

--- a/css/all.scss
+++ b/css/all.scss
@@ -129,3 +129,4 @@ $css--plex: true;
 @import "./content-switcher-low-contrast";
 @import "./modal-full-width";
 @import "./code-snippet";
+@import "./link";

--- a/css/g10.scss
+++ b/css/g10.scss
@@ -89,3 +89,4 @@ $css--plex: true;
 @import "./content-switcher-low-contrast";
 @import "./modal-full-width";
 @import "./code-snippet";
+@import "./link";

--- a/css/g100.scss
+++ b/css/g100.scss
@@ -89,3 +89,4 @@ $css--plex: true;
 @import "./content-switcher-low-contrast";
 @import "./modal-full-width";
 @import "./code-snippet";
+@import "./link";

--- a/css/g80.scss
+++ b/css/g80.scss
@@ -89,3 +89,4 @@ $css--plex: true;
 @import "./content-switcher-low-contrast";
 @import "./modal-full-width";
 @import "./code-snippet";
+@import "./link";

--- a/css/g90.scss
+++ b/css/g90.scss
@@ -89,3 +89,4 @@ $css--plex: true;
 @import "./content-switcher-low-contrast";
 @import "./modal-full-width";
 @import "./code-snippet";
+@import "./link";

--- a/css/white.scss
+++ b/css/white.scss
@@ -89,3 +89,4 @@ $css--plex: true;
 @import "./content-switcher-low-contrast";
 @import "./modal-full-width";
 @import "./code-snippet";
+@import "./link";

--- a/docs/src/pages/components/Link.svx
+++ b/docs/src/pages/components/Link.svx
@@ -89,7 +89,7 @@ Set `size` to control link size. The default is medium.
 
 ## Size with icon
 
-Combine size and icon. Inline must be false.
+Combine `size` and `icon`. The icon scales to match the link size. Inline must be false.
 
 ### Large
 

--- a/docs/src/pages/components/Link.svx
+++ b/docs/src/pages/components/Link.svx
@@ -4,7 +4,7 @@ description: Links provide styled hyperlinks with multiple sizes, states, and ic
 ---
 
 <script>
-  import { Link, OutboundLink } from "carbon-components-svelte";
+  import { Link, OutboundLink, Text } from "carbon-components-svelte";
   import Carbon from "carbon-icons-svelte/lib/Carbon.svelte";
 </script>
 
@@ -26,6 +26,18 @@ Create links that flow naturally with surrounding text.
     Carbon Design System
   </Link>.
 </div>
+
+## Muted
+
+Set `muted` to `true` so the link inherits the surrounding text color instead of the link color. Pair it with `inline` for links that sit within body text.
+
+<Text>
+  Read the
+  <Link inline muted href="https://www.carbondesignsystem.com/">
+    Carbon Design System
+  </Link>
+  documentation for usage guidelines and component examples.
+</Text>
 
 ## External links
 

--- a/e2e/fixtures/LinkFixture.svelte
+++ b/e2e/fixtures/LinkFixture.svelte
@@ -1,0 +1,30 @@
+<script>
+  import { Link } from "carbon-components-svelte";
+  import Carbon from "carbon-icons-svelte/lib/Carbon.svelte";
+</script>
+
+<Link
+  data-testid="link-sm"
+  size="sm"
+  href="https://www.carbondesignsystem.com/"
+  icon={Carbon}
+>
+  Small
+</Link>
+
+<Link
+  data-testid="link-md"
+  href="https://www.carbondesignsystem.com/"
+  icon={Carbon}
+>
+  Medium
+</Link>
+
+<Link
+  data-testid="link-lg"
+  size="lg"
+  href="https://www.carbondesignsystem.com/"
+  icon={Carbon}
+>
+  Large
+</Link>

--- a/e2e/fixtures/LinkFixture.svelte
+++ b/e2e/fixtures/LinkFixture.svelte
@@ -28,3 +28,28 @@
 >
   Large
 </Link>
+
+<p style="color: rgb(10, 20, 30);">
+  Read the
+  <Link
+    data-testid="link-muted"
+    muted
+    inline
+    href="https://www.carbondesignsystem.com/"
+  >
+    Carbon Design System
+  </Link>
+  documentation.
+</p>
+
+<p style="color: rgb(10, 20, 30);">
+  Read the
+  <Link
+    data-testid="link-default"
+    inline
+    href="https://www.carbondesignsystem.com/"
+  >
+    Carbon Design System
+  </Link>
+  documentation.
+</p>

--- a/e2e/fixtures/index.html
+++ b/e2e/fixtures/index.html
@@ -71,7 +71,7 @@
       <a href="/code-snippet.html">CodeSnippet</a>
       <a href="/data-table.html">DataTable</a>
       <a href="/data-table-virtual.html">DataTable (virtualized)</a>
-      <a href="/link.html">Link</a>
+      <a href="/link.html">Link (icon scaling)</a>
       <a href="/uishell.html">UIShell</a>
       <a href="/notification-queue.html">NotificationQueue</a>
     </nav>

--- a/e2e/fixtures/index.html
+++ b/e2e/fixtures/index.html
@@ -71,6 +71,7 @@
       <a href="/code-snippet.html">CodeSnippet</a>
       <a href="/data-table.html">DataTable</a>
       <a href="/data-table-virtual.html">DataTable (virtualized)</a>
+      <a href="/link.html">Link</a>
       <a href="/uishell.html">UIShell</a>
       <a href="/notification-queue.html">NotificationQueue</a>
     </nav>

--- a/e2e/fixtures/link.html
+++ b/e2e/fixtures/link.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Link Test</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="./link.ts"></script>
+  </body>
+</html>

--- a/e2e/fixtures/link.ts
+++ b/e2e/fixtures/link.ts
@@ -1,0 +1,4 @@
+import LinkFixture from "./LinkFixture.svelte";
+import { mount } from "./mount";
+
+mount(LinkFixture);

--- a/e2e/link.test.ts
+++ b/e2e/link.test.ts
@@ -1,0 +1,43 @@
+import type { Page } from "@playwright/test";
+import { expect, test } from "@playwright/test";
+
+test.describe("Link icon scaling", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/link.html");
+  });
+
+  function iconWidth(page: Page, testId: string) {
+    return page
+      .getByTestId(testId)
+      .locator(".bx--link__icon svg")
+      .evaluate((svg) => svg.getBoundingClientRect().width);
+  }
+
+  function iconGap(page: Page, testId: string) {
+    return page
+      .getByTestId(testId)
+      .locator(".bx--link__icon")
+      .evaluate((el) => Number.parseFloat(getComputedStyle(el).marginLeft));
+  }
+
+  test("scales the icon to match the link size", async ({ page }) => {
+    const sm = await iconWidth(page, "link-sm");
+    const md = await iconWidth(page, "link-md");
+    const lg = await iconWidth(page, "link-lg");
+
+    // sm: 0.875rem, md: 16px (Carbon default), lg: 1.25rem
+    expect(sm).toBeCloseTo(14, 0);
+    expect(md).toBeCloseTo(16, 0);
+    expect(lg).toBeCloseTo(20, 0);
+
+    expect(sm).toBeLessThan(md);
+    expect(md).toBeLessThan(lg);
+  });
+
+  test("tightens the icon-to-text gap on non-large sizes", async ({ page }) => {
+    // sm and md: 0.25rem (4px); lg keeps Carbon's 0.5rem (8px).
+    expect(await iconGap(page, "link-sm")).toBeCloseTo(4, 0);
+    expect(await iconGap(page, "link-md")).toBeCloseTo(4, 0);
+    expect(await iconGap(page, "link-lg")).toBeCloseTo(8, 0);
+  });
+});

--- a/e2e/link.test.ts
+++ b/e2e/link.test.ts
@@ -40,4 +40,17 @@ test.describe("Link icon scaling", () => {
     expect(await iconGap(page, "link-md")).toBeCloseTo(4, 0);
     expect(await iconGap(page, "link-lg")).toBeCloseTo(8, 0);
   });
+
+  function color(page: Page, testId: string) {
+    return page
+      .getByTestId(testId)
+      .evaluate((el) => getComputedStyle(el).color);
+  }
+
+  test("muted link inherits the parent text color", async ({ page }) => {
+    // Parent paragraph sets color: rgb(10, 20, 30).
+    expect(await color(page, "link-muted")).toBe("rgb(10, 20, 30)");
+    // A non-muted link keeps Carbon's link color.
+    expect(await color(page, "link-default")).not.toBe("rgb(10, 20, 30)");
+  });
 });

--- a/src/Link/Link.svelte
+++ b/src/Link/Link.svelte
@@ -32,6 +32,12 @@
   export let visited = false;
 
   /**
+   * Set to `true` to inherit the surrounding text color instead of the
+   * link color. Use for inline links within body text.
+   */
+  export let muted = false;
+
+  /**
    * Obtain a reference to the top-level HTML element.
    * @bindable readonly
    */
@@ -52,6 +58,7 @@
     class:bx--link--disabled={disabled}
     class:bx--link--inline={inline}
     class:bx--link--visited={visited}
+    class:bx--link--muted={muted}
     {...$$restProps}
     on:click
     on:mouseover
@@ -76,6 +83,7 @@
     class:bx--link--disabled={disabled}
     class:bx--link--inline={inline}
     class:bx--link--visited={visited}
+    class:bx--link--muted={muted}
     class:bx--link--sm={size === "sm"}
     class:bx--link--lg={size === "lg"}
     rel={$$restProps.target === "_blank" ? "noopener noreferrer" : undefined}

--- a/tests/Link/Link.test.svelte
+++ b/tests/Link/Link.test.svelte
@@ -70,6 +70,20 @@
   </Link>
 </div>
 
+<!-- Small link with icon -->
+<div data-testid="link-small-icon">
+  <Link size="sm" href="https://www.carbondesignsystem.com/" icon={Carbon}>
+    Carbon Design System
+  </Link>
+</div>
+
+<!-- Large link with icon -->
+<div data-testid="link-large-icon">
+  <Link size="lg" href="https://www.carbondesignsystem.com/" icon={Carbon}>
+    Carbon Design System
+  </Link>
+</div>
+
 <!-- Disabled link -->
 <div data-testid="link-disabled">
   <Link disabled href="https://www.carbondesignsystem.com/">

--- a/tests/Link/Link.test.svelte
+++ b/tests/Link/Link.test.svelte
@@ -91,6 +91,13 @@
   </Link>
 </div>
 
+<!-- Muted link -->
+<div data-testid="link-muted">
+  <Link muted inline href="https://www.carbondesignsystem.com/">
+    Carbon Design System
+  </Link>
+</div>
+
 <!-- Visited link -->
 <div data-testid="link-visited">
   <Link visited href="https://www.carbondesignsystem.com/">

--- a/tests/Link/Link.test.ts
+++ b/tests/Link/Link.test.ts
@@ -92,6 +92,27 @@ describe("Link", () => {
     expect(link).toHaveClass("bx--link--sm");
   });
 
+  it("renders the icon at every non-inline size", () => {
+    render(Link);
+    const links = screen.getAllByRole("link", { name: "Carbon Design System" });
+
+    const smIconLink = links.find(
+      (l) =>
+        l.classList.contains("bx--link--sm") &&
+        l.querySelector(".bx--link__icon"),
+    );
+    assert(smIconLink);
+    expect(smIconLink.querySelector(".bx--link__icon svg")).toBeInTheDocument();
+
+    const lgIconLink = links.find(
+      (l) =>
+        l.classList.contains("bx--link--lg") &&
+        l.querySelector(".bx--link__icon"),
+    );
+    assert(lgIconLink);
+    expect(lgIconLink.querySelector(".bx--link__icon svg")).toBeInTheDocument();
+  });
+
   it("supports disabled state", () => {
     render(Link);
     const links = screen.getAllByRole("link", { name: "Carbon Design System" });

--- a/tests/Link/Link.test.ts
+++ b/tests/Link/Link.test.ts
@@ -124,6 +124,15 @@ describe("Link", () => {
     expect(link).toHaveAttribute("role", "link");
   });
 
+  it("supports muted variant", () => {
+    render(Link);
+    const links = screen.getAllByRole("link", { name: "Carbon Design System" });
+    const link = links.find((l) => l.classList.contains("bx--link--muted"));
+    assert(link);
+
+    expect(link).toHaveClass("bx--link--muted");
+  });
+
   it("supports visited state", () => {
     render(Link);
     const links = screen.getAllByRole("link", { name: "Carbon Design System" });


### PR DESCRIPTION
Link now scales its icon to match the link size (smaller for sm, larger for lg) and tightens the icon-to-text gap on the non-large sizes. A new muted prop renders a link that inherits the surrounding text color instead of the Carbon link color, intended for inline links within body paragraphs. No breaking changes; all additions are opt-in and the default link appearance is unchanged.