### PR TITLE
docs: widen TOC scroll-spy offset to absorb sub-pixel rounding

### DIFF
--- a/docs/src/toc-scroll-spy.ts
+++ b/docs/src/toc-scroll-spy.ts
@@ -41,7 +41,14 @@ export function setupTocScrollSpy(page: ParentNode): () => void {
     }
   }
 
-  const OFFSET = 48;
+  // Height of the fixed UI shell header. Sections snap to this offset on click
+  // via `scroll-margin-top: 3rem`, so the active threshold must match it.
+  const HEADER_HEIGHT = 48;
+  // Sub-pixel rounding from getBoundingClientRect() can land a clicked section a
+  // fraction below HEADER_HEIGHT (e.g. 48.3), which would fail a strict `<=`
+  // check and let the previous section steal the active state. A 1px tolerance
+  // absorbs that rounding.
+  const OFFSET = HEADER_HEIGHT + 1;
   let raf = 0;
 
   function update() {


### PR DESCRIPTION
The TOC scroll-spy used a hard 48px offset matching the header height, but `getBoundingClientRect()` rounding can land a clicked section a fraction below that and let the previous section steal the active state. This widens the offset to 49px so a 1px tolerance absorbs the sub-pixel rounding. The constant is now derived from a named `HEADER_HEIGHT` with explanatory comments.