### PR TITLE
feat(link): make disabled links inert

### DIFF
--- a/docs/src/pages/components/Link.svx
+++ b/docs/src/pages/components/Link.svx
@@ -121,7 +121,7 @@ Reflect interaction and navigation history.
 
 ### Disabled
 
-Disabled links render as plain text while remaining accessible.
+Disabled links render as plain text while remaining accessible. They are inert: removed from the tab order and they do not navigate or dispatch click events.
 
 <Link disabled href="https://www.carbondesignsystem.com/">
   Disabled link

--- a/src/Link/Link.svelte
+++ b/src/Link/Link.svelte
@@ -42,6 +42,12 @@
    * @bindable readonly
    */
   export let ref = null;
+
+  /** @param {Event} event */
+  function preventDisabledActivation(event) {
+    event.preventDefault();
+    event.stopPropagation();
+  }
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
@@ -54,19 +60,20 @@
     bind:this={ref}
     role="link"
     aria-disabled="true"
+    tabindex="-1"
     class:bx--link={true}
     class:bx--link--disabled={disabled}
     class:bx--link--inline={inline}
     class:bx--link--visited={visited}
     class:bx--link--muted={muted}
     {...$$restProps}
-    on:click
+    on:click={preventDisabledActivation}
+    on:keydown={preventDisabledActivation}
     on:mouseover
     on:mouseenter
     on:mouseleave
     on:focus
     on:blur
-    on:keydown
     on:keyup
   >
     <slot />

--- a/tests/Link/Link.test.svelte
+++ b/tests/Link/Link.test.svelte
@@ -86,7 +86,13 @@
 
 <!-- Disabled link -->
 <div data-testid="link-disabled">
-  <Link disabled href="https://www.carbondesignsystem.com/">
+  <Link
+    disabled
+    href="https://www.carbondesignsystem.com/"
+    on:click={() => {
+      console.log("disabled-click");
+    }}
+  >
     Carbon Design System
   </Link>
 </div>

--- a/tests/Link/Link.test.ts
+++ b/tests/Link/Link.test.ts
@@ -124,6 +124,26 @@ describe("Link", () => {
     expect(link).toHaveAttribute("role", "link");
   });
 
+  it("removes a disabled link from the tab order", () => {
+    render(Link);
+    const links = screen.getAllByRole("link", { name: "Carbon Design System" });
+    const link = links.find((l) => l.getAttribute("aria-disabled") === "true");
+    assert(link);
+
+    expect(link).toHaveAttribute("tabindex", "-1");
+  });
+
+  it("does not dispatch click to consumers when disabled", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(Link);
+    const links = screen.getAllByRole("link", { name: "Carbon Design System" });
+    const link = links.find((l) => l.getAttribute("aria-disabled") === "true");
+    assert(link);
+
+    await user.click(link);
+    expect(consoleLog).not.toHaveBeenCalledWith("disabled-click");
+  });
+
   it("supports muted variant", () => {
     render(Link);
     const links = screen.getAllByRole("link", { name: "Carbon Design System" });


### PR DESCRIPTION
Disabled links rendered `<a role="link" aria-disabled="true">` but still forwarded `on:click`/`on:keydown` and stayed focusable, so a consumer's click handler fired on a disabled link and the element remained in the tab order. This makes the disabled state genuinely inert by adding `tabindex="-1"`, dropping the bare click/keydown forwards, and guarding activation with a named handler, while keeping `role="link"` and `aria-disabled="true"` so it stays announced to assistive tech. Adds unit tests for tab-order removal and click suppression.