### PR TITLE
fix(tooltip): focus and labeling a11y for the interactive tooltip

### DIFF
--- a/src/Tooltip/Tooltip.svelte
+++ b/src/Tooltip/Tooltip.svelte
@@ -333,6 +333,7 @@
         class:bx--tooltip__content={true}
         tabindex="-1"
         role="dialog"
+        aria-labelledby={triggerId}
       >
         <slot />
       </div>

--- a/src/Tooltip/Tooltip.svelte
+++ b/src/Tooltip/Tooltip.svelte
@@ -120,6 +120,13 @@
    * @type {import("svelte/store").Writable<boolean>}
    */
   const tooltipOpen = writable(open);
+  /**
+   * Tracks whether the latest open was triggered by mouse hover. TooltipFooter
+   * reads this to avoid stealing focus on hover; focus only moves into the
+   * footer when the tooltip is opened via keyboard or programmatically.
+   * @type {import("svelte/store").Writable<boolean>}
+   */
+  const openedByHover = writable(false);
 
   let prevOpen = undefined;
   let openTimeout;
@@ -128,7 +135,7 @@
   $: effectivePortalTooltip =
     portalTooltip === undefined ? !!insideModal : portalTooltip;
 
-  setContext("carbon:Tooltip", { tooltipOpen });
+  setContext("carbon:Tooltip", { tooltipOpen, openedByHover });
 
   function setOpenDelayed(value, delay = 0) {
     clearTimeout(openTimeout);
@@ -142,6 +149,7 @@
   }
 
   function onMouseEnter() {
+    openedByHover.set(true);
     setOpenDelayed(true, enterDelayMs);
   }
 
@@ -166,6 +174,7 @@
 
   function onFocus() {
     if (!focusByMouse) {
+      openedByHover.set(false);
       open = true;
     }
   }
@@ -235,6 +244,7 @@
   });
 
   $: tooltipOpen.set(open);
+  $: if (!open) openedByHover.set(false);
   $: {
     if (prevOpen !== undefined) {
       dispatch(open ? "open" : "close");

--- a/src/Tooltip/TooltipFooter.svelte
+++ b/src/Tooltip/TooltipFooter.svelte
@@ -6,19 +6,27 @@
 
   let ref = null;
   let open = false;
+  let openedByHover = false;
 
   const ctx = getContext("carbon:Tooltip") ?? null;
-  const unsubscribe = ctx?.tooltipOpen.subscribe((tooltipOpen) => {
-    open = tooltipOpen;
+  const unsubscribeOpen = ctx?.tooltipOpen.subscribe((value) => {
+    open = value;
+  });
+  const unsubscribeOpenedByHover = ctx?.openedByHover?.subscribe((value) => {
+    openedByHover = value;
   });
 
   onMount(() => {
     return () => {
-      unsubscribe?.();
+      unsubscribeOpen?.();
+      unsubscribeOpenedByHover?.();
     };
   });
 
-  $: if (open && ref) {
+  // Move focus into the footer only when the tooltip was opened via keyboard or
+  // programmatically. Focusing on mouse hover would yank focus away from a user
+  // who is only pointing at the trigger.
+  $: if (open && !openedByHover && ref) {
     const node = ref.querySelector(selectorPrimaryFocus);
     if (node) node.focus();
   }

--- a/tests/Tooltip/Tooltip.test.ts
+++ b/tests/Tooltip/Tooltip.test.ts
@@ -7,6 +7,7 @@ import TooltipCustomIcon from "./TooltipCustomIcon.test.svelte";
 import TooltipDefault from "./TooltipDefault.test.svelte";
 import TooltipDirections from "./TooltipDirections.test.svelte";
 import TooltipEvents from "./TooltipEvents.test.svelte";
+import TooltipFooterFocus from "./TooltipFooterFocus.test.svelte";
 import TooltipFooterStandalone from "./TooltipFooterStandalone.test.svelte";
 import TooltipHideIcon from "./TooltipHideIcon.test.svelte";
 import TooltipOpen from "./TooltipOpen.test.svelte";
@@ -256,6 +257,26 @@ describe("Tooltip", () => {
 
   test("TooltipFooter should not throw when rendered outside a Tooltip", () => {
     expect(() => render(TooltipFooterStandalone)).not.toThrow();
+  });
+
+  test("should move focus into the footer when opened via keyboard", async () => {
+    render(TooltipFooterFocus);
+
+    const trigger = screen.getByRole("button", { name: "Resource list" });
+    await fireEvent.focus(trigger);
+
+    expect(screen.getByRole("link", { name: "Learn more" })).toHaveFocus();
+  });
+
+  test("should not move focus into the footer when opened via mouse hover", async () => {
+    render(TooltipFooterFocus);
+
+    const trigger = screen.getByRole("button", { name: "Resource list" });
+    await fireEvent.mouseEnter(trigger);
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Learn more" })).not.toHaveFocus();
   });
 
   describe("Generics", () => {

--- a/tests/Tooltip/Tooltip.test.ts
+++ b/tests/Tooltip/Tooltip.test.ts
@@ -279,6 +279,16 @@ describe("Tooltip", () => {
     expect(screen.getByRole("link", { name: "Learn more" })).not.toHaveFocus();
   });
 
+  test("should label the interactive dialog with its trigger", () => {
+    render(TooltipOpen);
+
+    const labelledby = screen
+      .getByRole("dialog")
+      .getAttribute("aria-labelledby");
+    expect(labelledby).toBeTruthy();
+    expect(document.getElementById(labelledby ?? "")).toBeInTheDocument();
+  });
+
   describe("Generics", () => {
     it("should support custom Icon types with generics", () => {
       type CustomIcon = new (...args: unknown[]) => unknown;

--- a/tests/Tooltip/TooltipFooterFocus.test.svelte
+++ b/tests/Tooltip/TooltipFooterFocus.test.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+  import Tooltip from "carbon-components-svelte/Tooltip/Tooltip.svelte";
+  import TooltipFooter from "carbon-components-svelte/Tooltip/TooltipFooter.svelte";
+</script>
+
+<Tooltip triggerText="Resource list">
+  <p>Resources are provisioned based on your account's organization.</p>
+  <TooltipFooter>
+    <a href="/">Learn more</a>
+    <button type="button">Manage</button>
+  </TooltipFooter>
+</Tooltip>


### PR DESCRIPTION
The interactive Tooltip had two accessibility gaps that this PR addresses. First, TooltipFooter moved focus to its primary element on every open, so hovering the trigger pulled keyboard focus out of the page for mouse users; focus now moves into the footer only when the tooltip opens via keyboard or programmatically. Second, the role="dialog" content had no accessible name, so it is now labelled by its trigger.