### PR TITLE
feat(link): make medium size explicit ("md")

### DIFF
--- a/docs/src/pages/components/Link.svx
+++ b/docs/src/pages/components/Link.svx
@@ -85,7 +85,13 @@ Add an icon with the `icon` prop. Inline must be false when using icons.
 
 ## Sizes
 
-Set `size` to control link size. The default is medium.
+Set `size` to control link size. The default is medium (`"md"`).
+
+### Medium
+
+<Link size="md" href="https://www.carbondesignsystem.com/">
+  Medium link
+</Link>
 
 ### Large
 

--- a/src/Link/Link.svelte
+++ b/src/Link/Link.svelte
@@ -5,9 +5,9 @@
 
   /**
    * Specify the size of the link.
-   * @type {"sm" | "lg"}
+   * @type {"sm" | "md" | "lg"}
    */
-  export let size = undefined;
+  export let size = "md";
 
   /**
    * Specify the href value.

--- a/tests/Link/Link.test.ts
+++ b/tests/Link/Link.test.ts
@@ -192,5 +192,13 @@ describe("Link", () => {
       // biome-ignore lint/suspicious/noExplicitAny: Testing default any type
       expectTypeOf<Props["icon"]>().toEqualTypeOf<any>();
     });
+
+    it("should expose all three size values", () => {
+      type Props = ComponentProps<LinkComponent>;
+
+      expectTypeOf<Props["size"]>().toEqualTypeOf<
+        "sm" | "md" | "lg" | undefined
+      >();
+    });
   });
 });


### PR DESCRIPTION
The `size` prop was typed `"sm" | "lg"` with a default of `undefined`, leaving the most common value (medium) undocumented and unsettable. This adds `"md"` to the union and defaults to it, with the class logic unchanged so `"md"` emits no modifier and rendered output stays identical for existing consumers. Note that `Button` uses `"default"` for its size scale; `"md"` is chosen here for a coherent sm/md/lg triad matching Carbon link size naming.