### PR TITLE
docs(combo-box, multi-select): fuzzy match highlighting examples

### DIFF
--- a/docs/src/pages/components/ComboBox.svx
+++ b/docs/src/pages/components/ComboBox.svx
@@ -208,9 +208,15 @@ You can provide a custom `shouldFilterItem` to change the filtering logic. See t
 
 ### Fuzzy filter
 
-Provide a custom `shouldFilterItem` to override the default prefix matching used by typeahead. This example reuses the built-in `fuzzyMatch` util, exported from `carbon-components-svelte`, as the predicate. It matches items whose text contains the typed characters in order (for example, "bl" matches "Blueberry" and "Blackberry"). Only the `matched` boolean is used here; the `score` and `indices` it also returns are intended for ranked, highlighted search surfaces such as [SearchMenu](/components/SearchMenu).
+Provide a custom `shouldFilterItem` to override the default prefix matching used by typeahead. This example reuses the built-in `fuzzyMatch` utility, exported from `carbon-components-svelte`, as the predicate. It matches items whose text contains the typed characters in order (for example, "bl" matches "Blueberry" and "Blackberry"). Only the `matched` boolean is used here; the `score` and `indices` it also returns rank and highlight matches, as shown in [Highlight matches](#highlight-matches) below.
 
 <FileSource src="/framed/ComboBox/TypeaheadCustomFilter" />
+
+### Highlight matches
+
+Besides `matched`, `fuzzyMatch` returns the `indices` of the characters that matched. Pass them to the `highlightSegments` utility (also exported from `carbon-components-svelte`) to split the item text into matched and unmatched runs, then bold the matched runs in the default slot. Bind `value` to read the typed query inside the slot.
+
+<FileSource src="/framed/ComboBox/ComboBoxHighlightMatch" />
 
 ## Filtering
 

--- a/docs/src/pages/components/MultiSelect.svx
+++ b/docs/src/pages/components/MultiSelect.svx
@@ -152,9 +152,15 @@ Enable filtering by setting `filterable` to `true`. This example includes a plac
 
 ### Fuzzy filter
 
-Provide a custom `filterItem` to override the default substring matching. This example reuses the built-in `fuzzyMatch` util, exported from `carbon-components-svelte`, as the predicate. It matches items whose text contains the typed characters in order (for example, "bl" matches "Blueberry" and "Blackberry"). Only the `matched` boolean is used here; the `score` and `indices` it also returns are intended for ranked, highlighted search surfaces such as [SearchMenu](/components/SearchMenu).
+Provide a custom `filterItem` to override the default substring matching. This example reuses the built-in `fuzzyMatch` utility, exported from `carbon-components-svelte`, as the predicate. It matches items whose text contains the typed characters in order (for example, "bl" matches "Blueberry" and "Blackberry"). Only the `matched` boolean is used here; the `score` and `indices` it also returns rank and highlight matches, as shown in [Highlight matches](#highlight-matches) below.
 
 <FileSource src="/framed/MultiSelect/MultiSelectFuzzyFilter" />
+
+### Highlight matches
+
+Besides `matched`, `fuzzyMatch` returns the `indices` of the characters that matched. Pass them to the `highlightSegments` utility (also exported from `carbon-components-svelte`) to split the item text into matched and unmatched runs, then bold the matched runs in the default slot. Bind `value` to read the filter text inside the slot.
+
+<FileSource src="/framed/MultiSelect/MultiSelectHighlightMatch" />
 
 ## Multiple multi-selects
 

--- a/docs/src/pages/framed/ComboBox/ComboBoxHighlightMatch.svelte
+++ b/docs/src/pages/framed/ComboBox/ComboBoxHighlightMatch.svelte
@@ -1,0 +1,46 @@
+<script>
+  import {
+    ComboBox,
+    fuzzyMatch,
+    highlightSegments,
+  } from "carbon-components-svelte";
+
+  let value = "";
+
+  const items = [
+    { id: "0", text: "Apple" },
+    { id: "1", text: "Apricot" },
+    { id: "2", text: "Banana" },
+    { id: "3", text: "Blueberry" },
+    { id: "4", text: "Blackberry" },
+    { id: "5", text: "Cherry" },
+    { id: "6", text: "Cranberry" },
+    { id: "7", text: "Grape" },
+    { id: "8", text: "Mango" },
+    { id: "9", text: "Pineapple" },
+  ];
+
+  // One matcher drives filtering and highlighting. `shouldFilterItem` keeps
+  // the items whose text fuzzy-matches the typed value; the default slot
+  // reuses the same match and bolds the characters that matched. Bind `value`
+  // to read the typed query inside the slot.
+  const shouldFilterItem = (item, value) =>
+    fuzzyMatch(item.text, value).matched;
+</script>
+
+<ComboBox
+  bind:value
+  labelText="Item"
+  placeholder="Search for an item"
+  {shouldFilterItem}
+  {items}
+  let:item
+>
+  {#each highlightSegments(item.text, fuzzyMatch(item.text, value).indices) as segment}
+    {#if segment.match}
+      <strong>{segment.text}</strong>
+    {:else}
+      {segment.text}
+    {/if}
+  {/each}
+</ComboBox>

--- a/docs/src/pages/framed/MultiSelect/MultiSelectHighlightMatch.svelte
+++ b/docs/src/pages/framed/MultiSelect/MultiSelectHighlightMatch.svelte
@@ -1,0 +1,46 @@
+<script>
+  import {
+    fuzzyMatch,
+    highlightSegments,
+    MultiSelect,
+  } from "carbon-components-svelte";
+
+  let value = "";
+
+  const items = [
+    { id: "0", text: "Apple" },
+    { id: "1", text: "Apricot" },
+    { id: "2", text: "Banana" },
+    { id: "3", text: "Blueberry" },
+    { id: "4", text: "Blackberry" },
+    { id: "5", text: "Cherry" },
+    { id: "6", text: "Cranberry" },
+    { id: "7", text: "Grape" },
+    { id: "8", text: "Mango" },
+    { id: "9", text: "Pineapple" },
+  ];
+
+  // One matcher drives filtering and highlighting. `filterItem` keeps the
+  // items whose text fuzzy-matches the filter value; the default slot reuses
+  // the same match and bolds the characters that matched. Bind `value` to read
+  // the filter text inside the slot.
+  const filterItem = (item, value) => fuzzyMatch(item.text, value).matched;
+</script>
+
+<MultiSelect
+  bind:value
+  filterable
+  {filterItem}
+  labelText="Item"
+  placeholder="Filter items..."
+  {items}
+  let:item
+>
+  {#each highlightSegments(item.text, fuzzyMatch(item.text, value).indices) as segment}
+    {#if segment.match}
+      <strong>{segment.text}</strong>
+    {:else}
+      {segment.text}
+    {/if}
+  {/each}
+</MultiSelect>

--- a/src/index.js
+++ b/src/index.js
@@ -212,5 +212,5 @@ export {
   filterTreeByText,
   filterTreeNodes,
 } from "./utils/filterTreeNodes";
-export { fuzzyMatch } from "./utils/fuzzyMatch";
+export { fuzzyMatch, highlightSegments } from "./utils/fuzzyMatch";
 export { toHierarchy } from "./utils/toHierarchy";


### PR DESCRIPTION
Add ComboBox and MultiSelect docs examples that highlight the characters matched by a fuzzy filter. They reuse the built-in `fuzzyMatch` and `highlightSegments` utilities to split each item label into matched and unmatched runs, bolding the matches in the default slot. This also exports `highlightSegments` from the package so the pattern is reproducible by consumers.