### PR TITLE
feat(combo-box): commit typeahead suggestion on Tab, fix fuzzy completion

### DIFF
--- a/docs/src/pages/components/ComboBox.svx
+++ b/docs/src/pages/components/ComboBox.svx
@@ -210,6 +210,8 @@ You can provide a custom `shouldFilterItem` to change the filtering logic. See t
 
 Provide a custom `shouldFilterItem` to override the default prefix matching used by typeahead. This example reuses the built-in `fuzzyMatch` util, exported from `carbon-components-svelte`, as the predicate. It matches items whose text contains the typed characters in order (for example, "bl" matches "Blueberry" and "Blackberry"). Only the `matched` boolean is used here; the `score` and `indices` it also returns are intended for ranked, highlighted search surfaces such as [SearchMenu](/components/SearchMenu).
 
+Inline completion only fills in the input when the top match starts with the typed text, so a fuzzy match like "api" against "Apricot" filters the list without completing the input. Pair the custom filter with `autoHighlight="first-match"` so the matched item is highlighted and <DocKbd label="Enter" /> or <DocKbd label="Tab" /> selects it.
+
 <FileSource src="/framed/ComboBox/TypeaheadCustomFilter" />
 
 ## Filtering

--- a/docs/src/pages/components/ComboBox.svx
+++ b/docs/src/pages/components/ComboBox.svx
@@ -200,7 +200,7 @@ Set `typeahead` to `true` to enable autocomplete. As users type, the input sugge
 
 By default, typeahead uses case-insensitive prefix matching. When a match is found, the suggestion shows the untyped portion highlighted so users can accept it or keep typing.
 
-Pressing <DocKbd label="Enter" /> selects the matching item and closes the dropdown.
+Pressing <DocKbd label="Enter" /> or <DocKbd label="Tab" /> accepts the suggestion: it selects the matching item, normalizes the value to the item's casing, and closes the dropdown. <DocKbd label="Tab" /> still moves focus to the next control. Clicking away accepts the suggestion the same way. When the typed text matches no item, the suggestion is not committed.
 
 You can provide a custom `shouldFilterItem` to change the filtering logic. See the [fuzzy filter](#fuzzy-filter) example below.
 

--- a/docs/src/pages/framed/ComboBox/TypeaheadComboBox.svelte
+++ b/docs/src/pages/framed/ComboBox/TypeaheadComboBox.svelte
@@ -23,6 +23,9 @@
   ]}
 />
 <br>
-<Button on:click={() => (selectedId = undefined)}>
+<Button
+  disabled={selectedId === undefined}
+  on:click={() => (selectedId = undefined)}
+>
   Set to undefined (unselected)
 </Button>

--- a/docs/src/pages/framed/ComboBox/TypeaheadCustomFilter.svelte
+++ b/docs/src/pages/framed/ComboBox/TypeaheadCustomFilter.svelte
@@ -15,6 +15,7 @@
   placeholder="Select an item"
   bind:selectedId
   typeahead
+  autoHighlight="first-match"
   {shouldFilterItem}
   items={[
     { id: "0", text: "Apple" },

--- a/src/ComboBox/ComboBox.svelte
+++ b/src/ComboBox/ComboBox.svelte
@@ -487,13 +487,23 @@
   $: itemsToRender = virtualState.itemsToRender;
 
   $: if (typeahead) {
+    const topItemText = filteredItems[0] ? itemToString(filteredItems[0]) : "";
+    // Inline completion only makes sense when the top match starts with the
+    // typed text. A custom (fuzzy/contains) filter can surface items that do
+    // not, where appending the untyped tail would produce a nonsense value
+    // (typing "api" against "Apricot" yields "apiicot"). Skip it in that case.
+    const isPrefixMatch = topItemText
+      .toLowerCase()
+      .startsWith(value.toLowerCase());
     const showNewSuggestion =
-      value.length > prevInputLength && filteredItems.length > 0;
+      value.length > prevInputLength &&
+      filteredItems.length > 0 &&
+      isPrefixMatch;
 
     prevInputLength = value.length;
 
     if (ref && showNewSuggestion) {
-      const suggestion = itemToString(filteredItems[0]).slice(value.length);
+      const suggestion = topItemText.slice(value.length);
       const selectionStart = value.length;
       const selectionEnd = selectionStart + suggestion.length;
 

--- a/src/ComboBox/ComboBox.svelte
+++ b/src/ComboBox/ComboBox.svelte
@@ -536,6 +536,33 @@
     .join(" ");
 
   /**
+   * Commit the active typeahead suggestion when focus leaves the field.
+   * Mirrors the inline completion shown in the input: the highlighted item, or
+   * an exact case-insensitive match of the autocompleted value. Selecting
+   * normalizes the value to the item's casing and fires `select` reactively.
+   * Returns `true` when an item was committed.
+   * @returns {boolean}
+   */
+  function acceptTypeaheadSuggestion() {
+    if (!typeahead) return false;
+    let item =
+      highlightedIndex > -1 ? filteredItems[highlightedIndex] : undefined;
+    if (!item) {
+      const inputValue = ref?.value ?? value;
+      item = filteredItems.find(
+        (candidate) =>
+          candidate.text.toLowerCase() === inputValue?.toLowerCase() &&
+          !candidate.disabled,
+      );
+    }
+    if (!item || item.disabled) return false;
+    valueBeforeOpen = "";
+    value = itemToString(item);
+    selectedId = item.id;
+    return true;
+  }
+
+  /**
    * Close the dropdown and surface the dismissal cause.
    * Guarded on `open` so redundant assignments don't double-fire the event.
    * @param {"escape-key" | "outside-click" | "select"} trigger
@@ -549,6 +576,9 @@
 
   function handleOutsideClick(event) {
     if (open && isOutsideClick(event, [ref, effectivePortalMenu && listRef])) {
+      // Commit the inline suggestion on click-away so it matches Tab. The
+      // dismissal cause is still the outside click; `select` fires reactively.
+      acceptTypeaheadSuggestion();
       close("outside-click");
     }
   }
@@ -683,7 +713,10 @@
             }
             highlightedIndex = -1;
           } else if (event.key === "Tab") {
-            close("escape-key");
+            // Accept the inline suggestion before focus moves to the next
+            // control. Tab is not prevented, so focus still advances normally.
+            const accepted = acceptTypeaheadSuggestion();
+            close(accepted ? "select" : "escape-key");
           } else if (event.key === "ArrowDown" || event.key === "ArrowUp") {
             const step = event.key === "ArrowDown" ? 1 : -1;
             if (event.altKey) {

--- a/src/ComboBox/ComboBox.svelte
+++ b/src/ComboBox/ComboBox.svelte
@@ -630,7 +630,7 @@
           role="combobox"
           tabindex="0"
           autocomplete="off"
-          aria-autocomplete="list"
+          aria-autocomplete={typeahead ? "both" : "list"}
           aria-haspopup="listbox"
           aria-expanded={open}
           aria-activedescendant={highlightedId ?? ""}

--- a/tests/ComboBox/ComboBox.test.ts
+++ b/tests/ComboBox/ComboBox.test.ts
@@ -1588,6 +1588,28 @@ describe("ComboBox", () => {
       expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
     });
 
+    it("should not inline-complete when the top match is not a prefix", async () => {
+      render(ComboBox, {
+        props: {
+          typeahead: true,
+          // The default fixture uses a contains filter, so "ri" matches
+          // "Apricot" even though it is not a prefix of the typed text.
+          items: [
+            { id: "1", text: "Apricot", price: 100 },
+            { id: "2", text: "Banana", price: 200 },
+          ],
+        },
+      });
+
+      const input = getInput();
+      await user.click(input);
+      await user.type(input, "ri");
+
+      // No nonsense completion ("riricot"); the dropdown still filters.
+      expect(input).toHaveValue("ri");
+      expect(screen.getByRole("option")).toHaveTextContent("Apricot");
+    });
+
     it('should set aria-autocomplete to "list" without typeahead', () => {
       render(ComboBox, { props: { typeahead: false } });
       expect(getInput()).toHaveAttribute("aria-autocomplete", "list");

--- a/tests/ComboBox/ComboBox.test.ts
+++ b/tests/ComboBox/ComboBox.test.ts
@@ -1588,6 +1588,16 @@ describe("ComboBox", () => {
       expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
     });
 
+    it('should set aria-autocomplete to "list" without typeahead', () => {
+      render(ComboBox, { props: { typeahead: false } });
+      expect(getInput()).toHaveAttribute("aria-autocomplete", "list");
+    });
+
+    it('should set aria-autocomplete to "both" when typeahead is enabled', () => {
+      render(ComboBox, { props: { typeahead: true } });
+      expect(getInput()).toHaveAttribute("aria-autocomplete", "both");
+    });
+
     it("should keep a custom value on Tab when no suggestion matches", async () => {
       render(ComboBox, {
         props: {

--- a/tests/ComboBox/ComboBox.test.ts
+++ b/tests/ComboBox/ComboBox.test.ts
@@ -1532,6 +1532,78 @@ describe("ComboBox", () => {
 
       expect(input).toHaveValue("Apricot");
     });
+
+    it("should accept the suggestion on Tab and normalize casing", async () => {
+      const consoleLog = vi.spyOn(console, "log");
+      render(ComboBox, {
+        props: {
+          typeahead: true,
+          items: [
+            { id: "1", text: "Apple", price: 100 },
+            { id: "2", text: "Banana", price: 200 },
+          ],
+        },
+      });
+
+      const input = getInput();
+      await user.click(input);
+      await user.type(input, "ap");
+      // Inline suggestion shows the lowercased typed text plus the completion.
+      expect(input).toHaveValue("apple");
+
+      await user.keyboard("{Tab}");
+
+      // Tab commits the suggestion with the item's casing and closes the menu.
+      expect(input).toHaveValue("Apple");
+      expect(consoleLog).toHaveBeenCalledWith("select", {
+        selectedId: "1",
+        selectedItem: { id: "1", text: "Apple", price: 100 },
+      });
+      expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    });
+
+    it("should accept the suggestion when clicking away", async () => {
+      const consoleLog = vi.spyOn(console, "log");
+      render(ComboBox, {
+        props: {
+          typeahead: true,
+          items: [
+            { id: "1", text: "Apple", price: 100 },
+            { id: "2", text: "Banana", price: 200 },
+          ],
+        },
+      });
+
+      const input = getInput();
+      await user.click(input);
+      await user.type(input, "ap");
+
+      await user.click(document.body);
+
+      expect(input).toHaveValue("Apple");
+      expect(consoleLog).toHaveBeenCalledWith("select", {
+        selectedId: "1",
+        selectedItem: { id: "1", text: "Apple", price: 100 },
+      });
+      expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    });
+
+    it("should keep a custom value on Tab when no suggestion matches", async () => {
+      render(ComboBox, {
+        props: {
+          typeahead: true,
+          allowCustomValue: true,
+          items: [{ id: "1", text: "Apple", price: 100 }],
+        },
+      });
+
+      const input = getInput();
+      await user.click(input);
+      await user.type(input, "xyz");
+      await user.keyboard("{Tab}");
+
+      expect(input).toHaveValue("xyz");
+    });
   });
 
   describe("Generics", () => {


### PR DESCRIPTION
Tab and clicking away now commit the active typeahead suggestion, selecting the highlighted or exact case-insensitive match, normalizing the value to the item's casing, and firing select while still letting Tab move focus to the next control.

The typeahead input now sets `aria-autocomplete="both"` instead of `"list"` so it matches the ARIA list-and-inline autocomplete pattern it actually implements. Inline completion is now skipped unless the top match is a true prefix of the typed text, which stops a fuzzy or contains filter from producing a nonsense value such as "apiicot" when typing "api" against "Apricot".

No breaking changes. The typeahead Tab and click-away interaction changes (it now commits a selection), but this is scoped to `typeahead` and adds no API changes.