### PR TITLE
fix(ui-shell): keep HeaderSearch menu scrollable on short viewports

### DIFF
--- a/css/_ui-shell.scss
+++ b/css/_ui-shell.scss
@@ -405,7 +405,10 @@
     right: 0;
     top: 3rem;
     padding: $carbon--spacing-03 0;
-    max-height: to-rem(360px);
+    // Cap at 360px, but never taller than the space below the header (which
+    // sits at `top: 3rem`) so short viewports scroll the menu internally
+    // instead of overflowing off-screen with no way to reach the lower rows.
+    max-height: min(to-rem(360px), calc(100vh - 3rem));
     overflow-y: auto;
     background-color: $layer;
     border: 1px solid $border-subtle;


### PR DESCRIPTION
The HeaderSearch `menu`-slot dropdown added in #3363 capped its `max-height` at a fixed 360px, so on viewports shorter than the header offset plus that height the menu ran off-screen and only the page body scrolled, leaving the lower rows unreachable. This caps the height against the space below the header with `min(360px, calc(100vh - 3rem))` so the existing `overflow-y: auto` scrolls the menu internally. Only the SCSS source changes; the built `css/*.css` files are gitignored and regenerated in CI.

Not a "fix" since the previous feature is not released yet.