### PR TITLE
feat(combo-box): accept inline typeahead suggestion in place on Right/End

### DIFF
--- a/docs/src/pages/components/ComboBox.svx
+++ b/docs/src/pages/components/ComboBox.svx
@@ -202,6 +202,8 @@ By default, typeahead uses case-insensitive prefix matching. When a match is fou
 
 Pressing <DocKbd label="Enter" /> or <DocKbd label="Tab" /> accepts the suggestion: it selects the matching item, normalizes the value to the item's casing, and closes the dropdown. <DocKbd label="Tab" /> still moves focus to the next control. Clicking away accepts the suggestion the same way. When the typed text matches no item, the suggestion is not committed.
 
+Pressing <DocKbd label="→" /> or <DocKbd label="End" /> accepts the inline suggestion in place: it commits the completed text into the value (keeping your casing) and collapses the cursor to the end, but keeps focus in the input and leaves the dropdown open so you can continue editing. Unlike <DocKbd label="Enter" /> and <DocKbd label="Tab" />, it does not select an item or close the menu.
+
 You can provide a custom `shouldFilterItem` to change the filtering logic. See the [fuzzy filter](#fuzzy-filter) example below.
 
 <FileSource src="/framed/ComboBox/TypeaheadComboBox" />

--- a/src/ComboBox/ComboBox.svelte
+++ b/src/ComboBox/ComboBox.svelte
@@ -727,6 +727,24 @@
             // control. Tab is not prevented, so focus still advances normally.
             const accepted = acceptTypeaheadSuggestion();
             close(accepted ? "select" : "escape-key");
+          } else if (
+            typeahead &&
+            (event.key === "ArrowRight" || event.key === "End") &&
+            ref &&
+            ref.selectionStart !== ref.selectionEnd &&
+            ref.selectionEnd === ref.value.length
+          ) {
+            // APG inline-both "accept in place": when the ghost completion is
+            // shown (a trailing selection extends to the end of the input),
+            // ArrowRight/End commits the displayed text into the editable value
+            // and collapses the cursor to the end, keeping focus and the open
+            // menu. Unlike Enter/Tab it does not select an item or close, and it
+            // preserves the user's casing so continued typing still filters.
+            event.preventDefault();
+            value = ref.value;
+            tick().then(() => {
+              ref.setSelectionRange(value.length, value.length);
+            });
           } else if (event.key === "ArrowDown" || event.key === "ArrowUp") {
             const step = event.key === "ArrowDown" ? 1 : -1;
             if (event.altKey) {

--- a/tests/ComboBox/ComboBox.test.ts
+++ b/tests/ComboBox/ComboBox.test.ts
@@ -1588,6 +1588,115 @@ describe("ComboBox", () => {
       expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
     });
 
+    it("should accept the inline suggestion in place on ArrowRight", async () => {
+      const consoleLog = vi.spyOn(console, "log");
+      render(ComboBox, {
+        props: {
+          typeahead: true,
+          items: [
+            { id: "1", text: "Apple", price: 100 },
+            { id: "2", text: "Banana", price: 200 },
+          ],
+        },
+      });
+
+      const input = getInput();
+      await user.click(input);
+      await user.type(input, "ap");
+      // Inline ghost: typed casing plus the completed tail, selected.
+      expect(input).toHaveValue("apple");
+      expect(input.selectionStart).toBe(2);
+      expect(input.selectionEnd).toBe(5);
+
+      await user.keyboard("{ArrowRight}");
+
+      // Accept in place: the displayed text is committed (cursor collapsed to
+      // the end), focus stays, the menu stays open, and no item is selected.
+      expect(input).toHaveValue("apple");
+      expect(input.selectionStart).toBe(5);
+      expect(input.selectionEnd).toBe(5);
+      expect(input).toHaveFocus();
+      expect(screen.getByRole("listbox")).toBeInTheDocument();
+      expect(consoleLog).not.toHaveBeenCalledWith("select", expect.anything());
+    });
+
+    it("should accept the inline suggestion in place on End", async () => {
+      const consoleLog = vi.spyOn(console, "log");
+      render(ComboBox, {
+        props: {
+          typeahead: true,
+          items: [
+            { id: "1", text: "Apple", price: 100 },
+            { id: "2", text: "Banana", price: 200 },
+          ],
+        },
+      });
+
+      const input = getInput();
+      await user.click(input);
+      await user.type(input, "ap");
+      expect(input).toHaveValue("apple");
+
+      await user.keyboard("{End}");
+
+      expect(input).toHaveValue("apple");
+      expect(input.selectionStart).toBe(5);
+      expect(input.selectionEnd).toBe(5);
+      expect(input).toHaveFocus();
+      expect(screen.getByRole("listbox")).toBeInTheDocument();
+      expect(consoleLog).not.toHaveBeenCalledWith("select", expect.anything());
+    });
+
+    it("should still commit and normalize after accepting in place", async () => {
+      const consoleLog = vi.spyOn(console, "log");
+      render(ComboBox, {
+        props: {
+          typeahead: true,
+          items: [
+            { id: "1", text: "Apple", price: 100 },
+            { id: "2", text: "Banana", price: 200 },
+          ],
+        },
+      });
+
+      const input = getInput();
+      await user.click(input);
+      await user.type(input, "ap");
+      await user.keyboard("{ArrowRight}");
+      expect(input).toHaveValue("apple");
+
+      // Enter still selects the item and normalizes to the item's casing.
+      await user.keyboard("{Enter}");
+      expect(input).toHaveValue("Apple");
+      expect(consoleLog).toHaveBeenCalledWith("select", {
+        selectedId: "1",
+        selectedItem: { id: "1", text: "Apple", price: 100 },
+      });
+    });
+
+    it("should not intercept ArrowRight when there is no ghost", async () => {
+      render(ComboBox, {
+        props: {
+          typeahead: true,
+          items: [
+            { id: "1", text: "Apple", price: 100 },
+            { id: "2", text: "Banana", price: 200 },
+          ],
+        },
+      });
+
+      const input = getInput();
+      await user.click(input);
+      await user.type(input, "ap");
+      // Collapse the selection to the end so no ghost remains.
+      await user.keyboard("{ArrowRight}");
+      expect(input.selectionStart).toBe(input.selectionEnd);
+
+      // A second ArrowRight has no ghost to accept; value is unchanged.
+      await user.keyboard("{ArrowRight}");
+      expect(input).toHaveValue("apple");
+    });
+
     it("should not inline-complete when the top match is not a prefix", async () => {
       render(ComboBox, {
         props: {


### PR DESCRIPTION
When `typeahead` is enabled and the inline ghost is shown, ArrowRight and End now commit the completed text into the editable value and collapse the cursor to the end, keeping focus and the open menu so users can keep editing — distinct from Enter/Tab, which select the item and close. This follows the [ARIA APG editable combobox with both list and inline autocomplete](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/examples/combobox-autocomplete-both/) pattern, where Right Arrow / End is the standard gesture to accept an inline completion without leaving the field.