### PR TITLE
fix(ui-shell)!: do not animate `HeaderAction` panel by default

### DIFF
--- a/docs/src/pages/components/UIShell.svx
+++ b/docs/src/pages/components/UIShell.svx
@@ -86,13 +86,11 @@ Create a header with a persistent hamburger menu state.
 
 ## Switcher
 
-A `HeaderAction` reveals a panel from the right edge using a slide transition.
+A `HeaderAction` reveals a panel from the right edge.
 
 ### App switcher
 
-The header action uses the [transition:slide API](https://svelte.dev/docs#slide). Customize duration, delay, and easing with `transition`.
-
-Disable the slide transition by setting `transition` to `false`.
+The panel does not animate by default. Enable a slide transition by passing [transition:slide params](https://svelte.dev/docs#slide) to `transition` (e.g., `{ duration: 200 }`) to customize duration, delay, and easing.
 
 <FileSource src="/framed/UIShell/HeaderSwitcher" />
 

--- a/docs/src/pages/framed/UIShell/HeaderSwitcher.svelte
+++ b/docs/src/pages/framed/UIShell/HeaderSwitcher.svelte
@@ -26,16 +26,16 @@
   let selected = "0";
   let transitions = {
     0: {
-      text: "Default (duration: 200ms)",
-      value: { duration: 200 },
+      text: "None (default)",
+      value: false,
     },
     1: {
-      text: "Custom (duration: 600ms, delay: 50ms, easing: expoIn)",
-      value: { duration: 600, delay: 50, easing: expoIn },
+      text: "Slide (duration: 200ms)",
+      value: { duration: 200 },
     },
     2: {
-      text: "Disabled",
-      value: false,
+      text: "Custom (duration: 600ms, delay: 50ms, easing: expoIn)",
+      value: { duration: 600, delay: 50, easing: expoIn },
     },
   };
 </script>

--- a/src/UIShell/HeaderAction.svelte
+++ b/src/UIShell/HeaderAction.svelte
@@ -61,11 +61,12 @@
   export let ref = null;
 
   /**
-   * Customize the panel transition (i.event., `transition:slide`).
-   * Set to `false` to disable the transition.
+   * Customize the panel transition (e.g., `transition:slide`).
+   * The panel does not animate by default; provide slide
+   * params (e.g., `{ duration: 200 }`) to enable the transition.
    * @type {false | import("svelte/transition").SlideParams}
    */
-  export let transition = { duration: 200 };
+  export let transition = false;
 
   /** Set to `true` to prevent the panel from closing when clicking outside */
   export let preventCloseOnClickOutside = false;


### PR DESCRIPTION
Animation/transition should not be the default. Additionally, `transition={false}` feels awkward. This will be the standard going forward. Future work: expand upon the animation/transition story (e.g., notifications) in a way that does not punish the baseline usage.