### PR TITLE
feat(toggletip): add `Toggletip`

### DIFF
--- a/css/_toggletip.scss
+++ b/css/_toggletip.scss
@@ -1,0 +1,93 @@
+// Toggletip from @carbon/styles. The floating content reuses the popover
+// styles; this partial adds the toggletip-specific button, label, content,
+// and actions.
+
+@import "carbon-components/scss/globals/scss/vars";
+@import "carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/import-once/import-once";
+
+/// Toggletip component
+/// @access private
+/// @group components
+@mixin toggletip {
+  .#{$prefix}--toggletip-container {
+    display: inline-flex;
+    align-items: center;
+    vertical-align: middle;
+  }
+
+  .#{$prefix}--toggletip {
+    position: relative;
+    display: inline-flex;
+  }
+
+  .#{$prefix}--toggletip-label {
+    @include type-style("label-01");
+
+    margin-right: $spacing-03;
+    color: $text-02;
+  }
+
+  .#{$prefix}--toggletip-button {
+    display: flex;
+    align-items: center;
+    padding: 0;
+    border: 0;
+    margin: 0;
+    background: transparent;
+    cursor: pointer;
+  }
+
+  .#{$prefix}--toggletip-button svg {
+    fill: $icon-02;
+  }
+
+  .#{$prefix}--toggletip-button:hover svg,
+  .#{$prefix}--toggletip--open .#{$prefix}--toggletip-button svg {
+    fill: $icon-01;
+  }
+
+  .#{$prefix}--toggletip-button:focus {
+    outline: 1px solid $focus;
+  }
+
+  .#{$prefix}--toggletip-content {
+    @include type-style("body-short-01");
+
+    display: grid;
+    max-width: rem(288px);
+    padding: $spacing-05;
+    row-gap: $spacing-05;
+  }
+
+  // The content sits on the inverse (dark) popover surface, so links must use
+  // the inverse link color across every state to remain legible. Mirrors the
+  // link treatment Carbon applies inside `.bx--tooltip`.
+  .#{$prefix}--toggletip-content .#{$prefix}--link,
+  .#{$prefix}--toggletip-content .#{$prefix}--link:hover,
+  .#{$prefix}--toggletip-content .#{$prefix}--link:visited,
+  .#{$prefix}--toggletip-content .#{$prefix}--link:visited:hover {
+    color: $inverse-link;
+  }
+
+  .#{$prefix}--toggletip-content .#{$prefix}--link:active,
+  .#{$prefix}--toggletip-content .#{$prefix}--link:active:visited,
+  .#{$prefix}--toggletip-content .#{$prefix}--link:active:visited:hover {
+    color: $inverse-01;
+  }
+
+  .#{$prefix}--toggletip-content .#{$prefix}--link:focus {
+    outline: 1px solid $inverse-focus-ui;
+    outline-offset: 2px;
+  }
+
+  .#{$prefix}--toggletip-actions {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    column-gap: $spacing-05;
+  }
+}
+
+@include exports("toggletip") {
+  @include toggletip;
+}

--- a/css/all.scss
+++ b/css/all.scss
@@ -41,6 +41,7 @@ $css--plex: true;
 @import "./tabs";
 @import "./content-switcher";
 @import "./tooltip";
+@import "./toggletip";
 
 // Default: white
 :root {

--- a/css/g10.scss
+++ b/css/g10.scss
@@ -41,6 +41,7 @@ $css--plex: true;
 @import "./tabs";
 @import "./content-switcher";
 @import "./tooltip";
+@import "./toggletip";
 
 @import "carbon-components/scss/globals/scss/_css--reset";
 @import "carbon-components/scss/globals/scss/_css--font-face";

--- a/css/g100.scss
+++ b/css/g100.scss
@@ -41,6 +41,7 @@ $css--plex: true;
 @import "./tabs";
 @import "./content-switcher";
 @import "./tooltip";
+@import "./toggletip";
 
 @import "carbon-components/scss/globals/scss/_css--reset";
 @import "carbon-components/scss/globals/scss/_css--font-face";

--- a/css/g80.scss
+++ b/css/g80.scss
@@ -41,6 +41,7 @@ $css--plex: true;
 @import "./tabs";
 @import "./content-switcher";
 @import "./tooltip";
+@import "./toggletip";
 
 @import "carbon-components/scss/globals/scss/_css--reset";
 @import "carbon-components/scss/globals/scss/_css--font-face";

--- a/css/g90.scss
+++ b/css/g90.scss
@@ -41,6 +41,7 @@ $css--plex: true;
 @import "./tabs";
 @import "./content-switcher";
 @import "./tooltip";
+@import "./toggletip";
 
 @import "carbon-components/scss/globals/scss/_css--reset";
 @import "carbon-components/scss/globals/scss/_css--font-face";

--- a/css/white.scss
+++ b/css/white.scss
@@ -41,6 +41,7 @@ $css--plex: true;
 @import "./tabs";
 @import "./content-switcher";
 @import "./tooltip";
+@import "./toggletip";
 
 @import "carbon-components/scss/globals/scss/_css--reset";
 @import "carbon-components/scss/globals/scss/_css--font-face";

--- a/docs/src/component-categories.ts
+++ b/docs/src/component-categories.ts
@@ -77,6 +77,7 @@ export const COMPONENT_CATEGORIES: ComponentCategory[] = [
       "Modal",
       "ComposedModal",
       "Popover",
+      "Toggletip",
       "Tooltip",
       "TooltipDefinition",
       "TooltipIcon",

--- a/docs/src/component-since-versions.ts
+++ b/docs/src/component-since-versions.ts
@@ -72,6 +72,7 @@ export const COMPONENT_SINCE_VERSIONS: Record<string, string> = {
   TimePicker: "0.2.0",
   ToastNotification: "0.2.0",
   Toggle: "0.2.0",
+  Toggletip: "0.110.0",
   Toolbar: "0.2.0",
   Tooltip: "0.2.0",
   TooltipDefinition: "0.2.0",

--- a/docs/src/pages/components/Toggletip.svx
+++ b/docs/src/pages/components/Toggletip.svx
@@ -1,0 +1,141 @@
+---
+components: ["Toggletip", "ToggletipFooter"]
+description: Toggletips display contextual content in a popover that is toggled open and closed by clicking the trigger button.
+---
+
+<script>
+  import { Toggletip, ToggletipFooter, Box, Button, Link, Stack } from "carbon-components-svelte";
+  import { Add } from "carbon-icons-svelte";
+</script>
+
+## Basic
+
+Unlike a tooltip, a toggletip opens and closes on click. Click the button to toggle the content. Press `Escape` or click outside to close it.
+
+<Toggletip>
+  Custom toggletip content with a longer description that wraps onto multiple lines.
+</Toggletip>
+
+## Reactive example
+
+Control the toggletip state programmatically by binding to `open`.
+
+<FileSource src="/framed/Toggletip/ToggletipReactive" />
+
+## Label
+
+Render an inline label beside the button.
+
+### Prop
+
+Use the `labelText` prop.
+
+<Toggletip labelText="Setting">
+  This setting controls how items are displayed.
+</Toggletip>
+
+### Slot
+
+Alternatively, use the `"labelText"` slot for custom markup.
+
+<Toggletip>
+  <span slot="labelText"><strong>Setting</strong></span>
+  This setting controls how items are displayed.
+</Toggletip>
+
+## Actions
+
+Use `ToggletipFooter` to render one or two actions at the base of the content.
+
+<Toggletip>
+  Custom toggletip content with actions.
+  <ToggletipFooter>
+    <Link href="#">Link action</Link>
+    <Button size="small">Button</Button>
+  </ToggletipFooter>
+</Toggletip>
+
+## Custom icon
+
+### Component
+
+Pass an icon component to the `icon` prop.
+
+<Toggletip icon={Add} iconDescription="Add">
+  The button renders a custom icon.
+</Toggletip>
+
+### Slot
+
+Alternatively, use the `"icon"` slot.
+
+<Toggletip iconDescription="Add">
+  <Add slot="icon" />
+  The button renders a custom icon.
+</Toggletip>
+
+## Accessible label
+
+Set the button's ARIA label with `iconDescription`. It defaults to `"Show information"`.
+
+<Toggletip iconDescription="Additional information">
+  The button has a custom ARIA label.
+</Toggletip>
+
+## Placement
+
+Position the content with `direction` (`"top"`, `"right"`, `"bottom"`, `"left"`) and `align` (`"start"`, `"center"`, `"end"`). The defaults are `direction="bottom"` and `align="center"`.
+
+### Directions
+
+<Stack orientation="horizontal" gap={10}>
+  <Toggletip direction="top">top</Toggletip>
+  <Toggletip direction="right">right</Toggletip>
+  <Toggletip direction="bottom">bottom</Toggletip>
+  <Toggletip direction="left">left</Toggletip>
+</Stack>
+
+### Alignment
+
+<Stack orientation="horizontal" gap={10}>
+  <Toggletip direction="bottom" align="start">start</Toggletip>
+  <Toggletip direction="bottom" align="center">center</Toggletip>
+  <Toggletip direction="bottom" align="end">end</Toggletip>
+</Stack>
+
+## Portal
+
+Set `portalTooltip` to render the content in a portal so it is not clipped by `overflow: hidden` containers.
+
+<Box padding={5} border="subtle" maxWidth="8rem" style="overflow: hidden;">
+  <Toggletip portalTooltip>
+    This content escapes the clipping container via a portal.
+  </Toggletip>
+</Box>
+
+### Directions
+
+Portalled content supports every `direction`. The portal flips to the opposite side when there is not enough space.
+
+<Stack orientation="horizontal" gap={10}>
+  <Toggletip portalTooltip direction="top">top</Toggletip>
+  <Toggletip portalTooltip direction="right">right</Toggletip>
+  <Toggletip portalTooltip direction="bottom">bottom</Toggletip>
+  <Toggletip portalTooltip direction="left">left</Toggletip>
+</Stack>
+
+### Alignment
+
+Portalled content supports every `align` value.
+
+<Stack orientation="horizontal" gap={10}>
+  <Toggletip portalTooltip direction="bottom" align="start">start</Toggletip>
+  <Toggletip portalTooltip direction="bottom" align="center">center</Toggletip>
+  <Toggletip portalTooltip direction="bottom" align="end">end</Toggletip>
+</Stack>
+
+## Inside a modal
+
+When a toggletip is used inside a [Modal](/components/Modal), the content is portalled by default so it is not clipped by the modal overflow or z-index stacking. There is no need to set `portalTooltip`.
+
+<FileSource src="/framed/Toggletip/ToggletipModal" />

--- a/docs/src/pages/framed/Toggletip/ToggletipModal.svelte
+++ b/docs/src/pages/framed/Toggletip/ToggletipModal.svelte
@@ -1,0 +1,35 @@
+<script>
+  import {
+    Button,
+    Link,
+    Modal,
+    Portal,
+    Stack,
+    Toggletip,
+    ToggletipFooter,
+  } from "carbon-components-svelte";
+
+  let open = false;
+</script>
+
+<Button on:click={() => (open = true)}>Open modal</Button>
+
+<Portal>
+  <Modal
+    bind:open
+    passiveModal
+    modalHeading="Toggletip in modal"
+    on:close={() => (open = false)}
+  >
+    <Stack orientation="horizontal" align="center" gap={3}>
+      Resource list
+      <Toggletip>
+        Resources are provisioned based on your account's organization.
+        <ToggletipFooter>
+          <Link href="#">Learn more</Link>
+          <Button size="small">Manage</Button>
+        </ToggletipFooter>
+      </Toggletip>
+    </Stack>
+  </Modal>
+</Portal>

--- a/docs/src/pages/framed/Toggletip/ToggletipReactive.svelte
+++ b/docs/src/pages/framed/Toggletip/ToggletipReactive.svelte
@@ -1,0 +1,14 @@
+<script>
+  import { Button, Stack, Toggletip } from "carbon-components-svelte";
+
+  let open = true;
+</script>
+
+<Stack gap={12} align="start">
+  <Toggletip bind:open labelText="Resource list" align="start">
+    Resources are provisioned based on your account's organization.
+  </Toggletip>
+  <Button kind="tertiary" size="small" on:click={() => (open = !open)}>
+    {open ? "Close toggletip" : "Open toggletip"}
+  </Button>
+</Stack>

--- a/src/Toggletip/Toggletip.svelte
+++ b/src/Toggletip/Toggletip.svelte
@@ -1,0 +1,294 @@
+<script>
+  /**
+   * @template [Icon=any]
+   */
+
+  /**
+   * @event {null} open
+   * @event {null} close
+   * @slot {{}} labelText - Set the toggletip label, rendered beside the button.
+   * @slot {{}} icon - Override the button icon.
+   */
+
+  /**
+   * Set the alignment of the content relative to the button.
+   * @type {"start" | "center" | "end"}
+   */
+  export let align = "center";
+
+  /**
+   * Set the direction of the content relative to the button.
+   * @type {"top" | "right" | "bottom" | "left"}
+   */
+  export let direction = "bottom";
+
+  /**
+   * Set to `true` to open the toggletip.
+   * @bindable writable
+   */
+  export let open = false;
+
+  /**
+   * Specify the icon to render for the toggletip button.
+   * Defaults to `<Information />`.
+   * @type {Icon}
+   */
+  export let icon = /** @type {Icon} */ (Information);
+
+  /** Specify the icon name attribute */
+  export let iconName = "";
+
+  /** Specify the ARIA label for the toggletip button */
+  export let iconDescription = "Show information";
+
+  /**
+   * Set the toggletip label text.
+   * Alternatively, use the "labelText" slot.
+   */
+  export let labelText = "";
+
+  /**
+   * Obtain a reference to the button HTML element.
+   * @bindable readonly
+   */
+  export let ref = null;
+
+  /**
+   * Set to `true` to render the content in a portal,
+   * preventing it from being clipped by `overflow: hidden` containers.
+   * By default, the content is portalled when inside a `Modal`.
+   * @type {boolean | undefined}
+   */
+  export let portalTooltip = undefined;
+
+  import { createEventDispatcher, getContext, onMount } from "svelte";
+  import Information from "../icons/Information.svelte";
+  import Popover from "../Popover/Popover.svelte";
+  import FloatingPortal from "../Portal/FloatingPortal.svelte";
+  import { observeModalClose } from "../Portal/portal-utils.js";
+  import { dismiss } from "../utils/dismiss.js";
+  import { isOutsideClick } from "../utils/isOutsideClick.js";
+
+  const dispatch = createEventDispatcher();
+  const contentId = `ccs-${Math.random().toString(36)}`;
+  const insideModal = getContext("carbon:Modal");
+
+  // Space (px) reserved for the caret between the anchor and the content.
+  const PORTAL_GAP = 10;
+  // Caret offset from the popover corner. 0.5rem keeps the caret clear of the
+  // rounded corner (the popover's default 1rem assumes a wider trigger). The
+  // popover is then nudged outward so this caret still points at the button
+  // center for start/end alignment.
+  const CARET_OFFSET_STYLE = "--cds-popover-caret-offset: 0.5rem;";
+  // Nudge the popover past the trigger so the caret lands on the button center:
+  // caretCenterFromCorner (0.5rem + caretHalfWidth = 12px) - buttonHalfWidth (8px) = 4px.
+  const CARET_NUDGE_PX = 4;
+  // Neutralizes the popover alignment transforms so the portal places it. The
+  // popover is rendered `relative` (in-flow) so the portal sizes to it.
+  const PORTAL_NEUTRALIZE_STYLE = "inset: auto; transform: none;";
+
+  /**
+   * Margin that nudges the popover outward so its caret points at the button
+   * center for start/end alignment. Center alignment needs no nudge.
+   */
+  function caretNudgeStyle(pAlign) {
+    if (pAlign.endsWith("-left")) return `margin-left: -${CARET_NUDGE_PX}px;`;
+    if (pAlign.endsWith("-right")) return `margin-right: -${CARET_NUDGE_PX}px;`;
+    if (pAlign.endsWith("-top")) return `margin-top: -${CARET_NUDGE_PX}px;`;
+    if (pAlign.endsWith("-bottom"))
+      return `margin-bottom: -${CARET_NUDGE_PX}px;`;
+    return "";
+  }
+
+  /** Inline style for the underlying popover (caret offset + nudge). */
+  function popoverStyleFor(pAlign) {
+    return `${CARET_OFFSET_STYLE} ${caretNudgeStyle(pAlign)}`.trim();
+  }
+
+  let toggletipRef = null;
+  let portalRef = null;
+  let prevOpen = undefined;
+  let disconnectModalObserver = () => {};
+
+  $: effectivePortalTooltip =
+    portalTooltip === undefined ? !!insideModal : portalTooltip;
+
+  // Translate the Carbon `direction` + `align` pair into the underlying
+  // popover's combined alignment modifier (e.g. "bottom" + "start" -> "bottom-left").
+  function toPopoverAlign(dir, intrinsic) {
+    if (intrinsic === "center") return dir;
+    if (dir === "top" || dir === "bottom") {
+      return `${dir}-${intrinsic === "start" ? "left" : "right"}`;
+    }
+    return `${dir}-${intrinsic === "start" ? "top" : "bottom"}`;
+  }
+
+  $: popoverAlign = toPopoverAlign(direction, align);
+  $: popoverStyle = popoverStyleFor(popoverAlign);
+  // Window listeners are enabled on the animation frame after opening. Svelte
+  // flushes the open state synchronously while the triggering click is still
+  // propagating, so enabling them immediately would let the click that opened
+  // the toggletip (e.g. from an external trigger) bubble to the window handler
+  // and close it again. Deferring past the current event mirrors the
+  // post-render effect in the upstream component.
+  let listenersEnabled = false;
+  let enableFrame;
+
+  function toggle() {
+    open = !open;
+  }
+
+  function close() {
+    open = false;
+  }
+
+  function onKeydown(event) {
+    if (open && event.key === "Escape") {
+      event.stopPropagation();
+      close();
+      ref?.focus();
+    }
+  }
+
+  // The portalled content lives outside `toggletipRef`, so treat it as "inside"
+  // for focus and outside-click handling.
+  $: insideElements = [toggletipRef, portalRef];
+
+  function containsTarget(target) {
+    return insideElements.some((el) => el?.contains(target));
+  }
+
+  function onFocusOut(event) {
+    // Keep open when focus moves to the toggletip content itself (relatedTarget
+    // is null on some browsers when clicking non-focusable content).
+    if (open && event.relatedTarget === null) return;
+    if (!containsTarget(event.relatedTarget)) close();
+  }
+
+  function handleOutsideClick(event) {
+    if (open && isOutsideClick(event, insideElements)) close();
+  }
+
+  function handleWindowBlur() {
+    if (open) close();
+  }
+
+  // Close when an ancestor modal closes so the portalled content does not linger.
+  $: {
+    disconnectModalObserver();
+    disconnectModalObserver =
+      effectivePortalTooltip && ref ? observeModalClose(ref, close) : () => {};
+  }
+
+  $: if (typeof requestAnimationFrame !== "undefined") {
+    if (open) {
+      cancelAnimationFrame(enableFrame);
+      enableFrame = requestAnimationFrame(() => {
+        if (open) listenersEnabled = true;
+      });
+    } else {
+      cancelAnimationFrame(enableFrame);
+      listenersEnabled = false;
+    }
+  }
+  $: {
+    if (prevOpen !== undefined) dispatch(open ? "open" : "close");
+    prevOpen = open;
+  }
+
+  onMount(() => {
+    return () => {
+      cancelAnimationFrame(enableFrame);
+      disconnectModalObserver();
+    };
+  });
+</script>
+
+<!-- Flex wrapper so the label and button align without an inter-element
+whitespace gap; the label's `margin-right` is then the only spacing. -->
+<span class:bx--toggletip-container={true}>
+  {#if labelText || $$slots.labelText}
+    <span class:bx--toggletip-label={true}>
+      <slot name="labelText">{labelText}</slot>
+    </span>
+  {/if}
+
+  <!-- svelte-ignore a11y-no-static-element-interactions -->
+  <span
+    bind:this={toggletipRef}
+    class:bx--toggletip={true}
+    class:bx--toggletip--open={open}
+    use:dismiss={{
+      enabled: listenersEnabled,
+      listeners: [
+        { type: "click", handler: handleOutsideClick },
+        { type: "blur", handler: handleWindowBlur },
+      ],
+    }}
+    on:keydown={onKeydown}
+    on:focusout={onFocusOut}
+    {...$$restProps}
+  >
+    <button
+      bind:this={ref}
+      type="button"
+      class:bx--toggletip-button={true}
+      aria-label={iconDescription}
+      aria-expanded={open}
+      aria-controls={contentId}
+      aria-describedby={open ? contentId : undefined}
+      on:click={toggle}
+    >
+      <slot name="icon">
+        <svelte:component this={icon} name={iconName} />
+      </slot>
+    </button>
+    {#if !effectivePortalTooltip}
+      <Popover
+        {open}
+        align={popoverAlign}
+        id={contentId}
+        caret
+        highContrast
+        style={popoverStyle}
+      >
+        <div class:bx--toggletip-content={true}>
+          <slot />
+        </div>
+      </Popover>
+    {/if}
+  </span>
+</span>
+
+{#if effectivePortalTooltip}
+  <FloatingPortal
+    anchor={ref}
+    {direction}
+    {open}
+    intrinsicWidth
+    intrinsicAlign={align}
+    gapTop={PORTAL_GAP}
+    gapBottom={PORTAL_GAP}
+    horizontalGapLeft={PORTAL_GAP}
+    horizontalGapRight={PORTAL_GAP}
+    bind:ref={portalRef}
+    let:direction={actualDirection}
+  >
+    <Popover
+      open
+      relative
+      align={toPopoverAlign(actualDirection ?? direction, align)}
+      id={contentId}
+      caret
+      highContrast
+      style="{PORTAL_NEUTRALIZE_STYLE} {popoverStyleFor(
+        toPopoverAlign(actualDirection ?? direction, align),
+      )}"
+    >
+      <!-- svelte-ignore a11y-no-static-element-interactions -->
+      <div class:bx--toggletip-content={true} on:keydown={onKeydown}>
+        <slot />
+      </div>
+    </Popover>
+  </FloatingPortal>
+{/if}

--- a/src/Toggletip/ToggletipFooter.svelte
+++ b/src/Toggletip/ToggletipFooter.svelte
@@ -1,0 +1,3 @@
+<div class:bx--toggletip-actions={true} {...$$restProps}>
+  <slot />
+</div>

--- a/src/Toggletip/index.js
+++ b/src/Toggletip/index.js
@@ -1,0 +1,2 @@
+export { default as Toggletip } from "./Toggletip.svelte";
+export { default as ToggletipFooter } from "./ToggletipFooter.svelte";

--- a/src/index.js
+++ b/src/index.js
@@ -178,6 +178,8 @@ export { default as TimePicker } from "./TimePicker/TimePicker.svelte";
 export { default as TimePickerSelect } from "./TimePicker/TimePickerSelect.svelte";
 export { default as Toggle } from "./Toggle/Toggle.svelte";
 export { default as ToggleSkeleton } from "./Toggle/ToggleSkeleton.svelte";
+export { default as Toggletip } from "./Toggletip/Toggletip.svelte";
+export { default as ToggletipFooter } from "./Toggletip/ToggletipFooter.svelte";
 export { default as Tooltip } from "./Tooltip/Tooltip.svelte";
 export { default as TooltipFooter } from "./Tooltip/TooltipFooter.svelte";
 export { default as TooltipDefinition } from "./TooltipDefinition/TooltipDefinition.svelte";


### PR DESCRIPTION
Closes [#3371](https://github.com/carbon-design-system/carbon-components-svelte/issues/3371)

A Toggletip differs from a conventional tooltip in that it's *only* triggered on click, not hover. Component API-wise, this mirrors Tooltip and other components in this library.

---

<img width="475" height="185" alt="Screenshot 2026-06-27 at 8 40 23 PM" src="https://github.com/user-attachments/assets/433755f2-776f-494d-bd60-5663f4fd2ed8" />
