### PR TITLE
fix(list-box): scope highlighted-item scroll to the menu, not the page

### DIFF
--- a/src/ListBox/ListBoxMenuItem.svelte
+++ b/src/ListBox/ListBoxMenuItem.svelte
@@ -1,5 +1,6 @@
 <script>
   import { overflowTitle } from "../utils/overflowTitle.js";
+  import { scrollIntoViewWithinMenu } from "../utils/scrollIntoViewWithinMenu.js";
 
   /** Set to `true` to enable the active state */
   export let active = false;
@@ -16,8 +17,10 @@
   let ref = null;
 
   $: if (highlighted && ref && !ref.matches(":hover")) {
-    // Scroll highlighted item into view if using keyboard navigation
-    ref.scrollIntoView({ block: "nearest" });
+    // Scroll highlighted item into view if using keyboard navigation.
+    // Scoped to the menu's own scroll container so a portaled menu (whose
+    // nearest scrollable ancestor is the document) does not scroll the page.
+    scrollIntoViewWithinMenu(ref);
   }
 </script>
 

--- a/src/utils/scrollIntoViewWithinMenu.d.ts
+++ b/src/utils/scrollIntoViewWithinMenu.d.ts
@@ -1,0 +1,15 @@
+/**
+ * Scroll a highlighted option into view without scrolling the document.
+ *
+ * `Element.scrollIntoView` scrolls every scrollable ancestor up to the
+ * viewport. When the list box menu is portaled to `document.body` (or has no
+ * internal scroll container), the nearest scrollable ancestor is the document
+ * itself, so calling it on highlight would jump the whole page. This scopes the
+ * adjustment to the menu's own scroll container and is a no-op when the menu is
+ * not scrollable.
+ */
+/**
+ * Scroll `el` into view within its nearest `role="listbox"` scroll container
+ * using `block: "nearest"` semantics. Never scrolls the document.
+ */
+export function scrollIntoViewWithinMenu(el: HTMLElement): void;

--- a/src/utils/scrollIntoViewWithinMenu.js
+++ b/src/utils/scrollIntoViewWithinMenu.js
@@ -1,0 +1,31 @@
+// @ts-check
+// Scroll a highlighted option into view without scrolling the document.
+//
+// `Element.scrollIntoView` scrolls every scrollable ancestor up to the
+// viewport. When the list box menu is portaled to `document.body` (or has no
+// internal scroll container), the nearest scrollable ancestor is the document
+// itself, so calling it on highlight would jump the whole page. This scopes the
+// adjustment to the menu's own scroll container and is a no-op when the menu is
+// not scrollable.
+
+/**
+ * Scroll `el` into view within its nearest `role="listbox"` scroll container
+ * using `block: "nearest"` semantics. Never scrolls the document.
+ *
+ * @param {HTMLElement} el
+ * @returns {void}
+ */
+export function scrollIntoViewWithinMenu(el) {
+  const container = el.closest('[role="listbox"]');
+  if (!(container instanceof HTMLElement)) return;
+  if (container.scrollHeight <= container.clientHeight) return;
+
+  const itemRect = el.getBoundingClientRect();
+  const containerRect = container.getBoundingClientRect();
+
+  if (itemRect.top < containerRect.top) {
+    container.scrollTop -= containerRect.top - itemRect.top;
+  } else if (itemRect.bottom > containerRect.bottom) {
+    container.scrollTop += itemRect.bottom - containerRect.bottom;
+  }
+}

--- a/tests/utils/scrollIntoViewWithinMenu.test.ts
+++ b/tests/utils/scrollIntoViewWithinMenu.test.ts
@@ -1,0 +1,104 @@
+import { scrollIntoViewWithinMenu } from "../../src/utils/scrollIntoViewWithinMenu.js";
+
+/**
+ * Build a `role="listbox"` container with a single item, stubbing the layout
+ * jsdom does not compute: the container's scrollability and both elements'
+ * bounding rects.
+ */
+function buildMenu(options: {
+  scrollable: boolean;
+  containerTop: number;
+  containerBottom: number;
+  itemTop: number;
+  itemBottom: number;
+}) {
+  const container = document.createElement("div");
+  container.setAttribute("role", "listbox");
+  Object.defineProperty(container, "clientHeight", { value: 100 });
+  Object.defineProperty(container, "scrollHeight", {
+    value: options.scrollable ? 300 : 100,
+  });
+  container.scrollTop = 50;
+  container.getBoundingClientRect = () =>
+    ({ top: options.containerTop, bottom: options.containerBottom }) as DOMRect;
+
+  const item = document.createElement("div");
+  item.getBoundingClientRect = () =>
+    ({ top: options.itemTop, bottom: options.itemBottom }) as DOMRect;
+
+  container.appendChild(item);
+  document.body.appendChild(container);
+  return { container, item };
+}
+
+describe("scrollIntoViewWithinMenu", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  test("is a no-op when the element has no listbox ancestor", () => {
+    const item = document.createElement("div");
+    item.getBoundingClientRect = () => ({ top: -100, bottom: -80 }) as DOMRect;
+    document.body.appendChild(item);
+
+    expect(() => scrollIntoViewWithinMenu(item)).not.toThrow();
+  });
+
+  test("does not scroll when the menu is not scrollable", () => {
+    const { container, item } = buildMenu({
+      scrollable: false,
+      containerTop: 0,
+      containerBottom: 100,
+      itemTop: -50,
+      itemBottom: -30,
+    });
+
+    scrollIntoViewWithinMenu(item);
+
+    expect(container.scrollTop).toBe(50);
+  });
+
+  test("scrolls the container up when the item is above the viewport", () => {
+    const { container, item } = buildMenu({
+      scrollable: true,
+      containerTop: 0,
+      containerBottom: 100,
+      itemTop: -20,
+      itemBottom: 0,
+    });
+
+    scrollIntoViewWithinMenu(item);
+
+    // scrollTop -= containerTop(0) - itemTop(-20) => 50 - 20 = 30
+    expect(container.scrollTop).toBe(30);
+  });
+
+  test("scrolls the container down when the item is below the viewport", () => {
+    const { container, item } = buildMenu({
+      scrollable: true,
+      containerTop: 0,
+      containerBottom: 100,
+      itemTop: 110,
+      itemBottom: 130,
+    });
+
+    scrollIntoViewWithinMenu(item);
+
+    // scrollTop += itemBottom(130) - containerBottom(100) => 50 + 30 = 80
+    expect(container.scrollTop).toBe(80);
+  });
+
+  test("does not scroll when the item is already fully visible", () => {
+    const { container, item } = buildMenu({
+      scrollable: true,
+      containerTop: 0,
+      containerBottom: 100,
+      itemTop: 40,
+      itemBottom: 60,
+    });
+
+    scrollIntoViewWithinMenu(item);
+
+    expect(container.scrollTop).toBe(50);
+  });
+});


### PR DESCRIPTION
`ListBoxMenuItem` called `scrollIntoView` whenever an item became highlighted, which scrolls every scrollable ancestor up to the viewport. For a portaled menu the nearest scrollable ancestor is the document, so opening a `Dropdown`/`ComboBox`/`MultiSelect` with a pre-selected item (or arrow-navigating) jumped the whole page. This scopes the scroll to the menu's own `role="listbox"` container and makes it a no-op when the menu is not scrollable.

Follow-up to #3346, which only suppressed the native spacebar page-scroll and did not cover the open-on-click path.
