### PR TITLE
fix: decouple hover highlight from Enter selection in listbox components

### DIFF
--- a/src/ComboBox/ComboBox.svelte
+++ b/src/ComboBox/ComboBox.svelte
@@ -262,6 +262,7 @@
   let selectedItem = undefined;
   let prevSelectedId = null;
   let highlightedIndex = -1;
+  let highlightOrigin = /** @type {"keyboard" | "pointer" | null} */ (null);
   let prevHighlightedIndex = -1;
   let valueBeforeOpen = "";
   let prevInputLength = 0;
@@ -298,6 +299,7 @@
       index: highlightedIndex,
       step,
     });
+    highlightOrigin = "keyboard";
   }
 
   /**
@@ -316,6 +318,7 @@
     if (readonly) return;
     prevSelectedId = null;
     highlightedIndex = -1;
+    highlightOrigin = null;
     selectedId = undefined;
     selectedItem = undefined;
     open = false;
@@ -366,6 +369,7 @@
       if (selectedIndex >= 0) {
         // Set highlighted index to selected item so keyboard nav starts there
         highlightedIndex = selectedIndex;
+        highlightOrigin = "keyboard";
         prevHighlightedIndex = selectedIndex;
       }
     }
@@ -405,6 +409,7 @@
         listScrollTop = resetVirtualScrollOnClose();
       }
       highlightedIndex = -1;
+      highlightOrigin = null;
       prevHighlightedIndex = -1;
       if (selectedItem) {
         // Restore the value if clearFilterOnOpen was used and no new selection was made.
@@ -528,12 +533,14 @@
           itemToString(item).toLowerCase().includes(lowerValue)),
     );
     highlightedIndex = firstEnabledIndex >= 0 ? firstEnabledIndex : -1;
+    highlightOrigin = firstEnabledIndex >= 0 ? "keyboard" : null;
   } else if (
     autoHighlight === "first-match" &&
     open &&
     (value.length === 0 || filteredItems.length === 0)
   ) {
     highlightedIndex = -1;
+    highlightOrigin = null;
   }
 
   $: comboBoxListBoxClass = [
@@ -693,6 +700,7 @@
             const wasOpen = open;
             open = !open;
             if (
+              highlightOrigin === "keyboard" &&
               highlightedIndex > -1 &&
               filteredItems[highlightedIndex]?.id !== selectedId
             ) {
@@ -722,6 +730,7 @@
               }
             }
             highlightedIndex = -1;
+            highlightOrigin = null;
           } else if (event.key === "Tab") {
             // Accept the inline suggestion before focus moves to the next
             // control. Tab is not prevented, so focus still advances normally.
@@ -840,6 +849,7 @@
           // Clear the hover highlight when the cursor leaves the menu so the
           // highlighted state does not linger on the last hovered item.
           highlightedIndex = -1;
+          highlightOrigin = null;
         }}
         bind:ref={listRef}
         style={effectivePortalMenu
@@ -879,6 +889,7 @@
                   on:mouseenter={() => {
                     if (item.disabled) return;
                     highlightedIndex = actualIndex;
+                    highlightOrigin = "pointer";
                   }}
                 >
                   {#if $$slots.icon || item.icon}
@@ -946,6 +957,7 @@
               on:mouseenter={() => {
                 if (item.disabled) return;
                 highlightedIndex = index;
+                highlightOrigin = "pointer";
               }}
             >
               {#if $$slots.icon || item.icon}

--- a/src/Dropdown/Dropdown.svelte
+++ b/src/Dropdown/Dropdown.svelte
@@ -216,6 +216,7 @@
   $: menuAriaLabel = $$props["aria-label"] ?? (labelText || "Choose an item");
 
   let highlightedIndex = -1;
+  let highlightOrigin = /** @type {"keyboard" | "pointer" | null} */ (null);
   let prevHighlightedIndex = -1;
   let typeaheadBuffer = "";
   let listScrollTop = 0;
@@ -262,6 +263,7 @@
   $: selectedItem = itemsById.get(selectedId);
   $: if (!open) {
     highlightedIndex = -1;
+    highlightOrigin = null;
     prevHighlightedIndex = -1;
     typeaheadBuffer = "";
     resetTypeaheadBuffer.cancel();
@@ -331,6 +333,7 @@
     if (wasJustOpened && selectedIndex >= 0) {
       // Set highlighted index to selected item so keyboard nav starts there
       highlightedIndex = selectedIndex;
+      highlightOrigin = "keyboard";
       prevHighlightedIndex = selectedIndex;
     }
 
@@ -384,6 +387,7 @@
       index: highlightedIndex,
       step,
     });
+    highlightOrigin = "keyboard";
   }
 
   function typeaheadSearch(character) {
@@ -398,6 +402,7 @@
       itemToString,
       index: highlightedIndex,
     });
+    highlightOrigin = "keyboard";
   }
 
   function dispatchSelect() {
@@ -425,7 +430,11 @@
       open = true;
       return;
     }
-    if (highlightedIndex > -1 && items[highlightedIndex].id !== selectedId) {
+    if (
+      highlightOrigin === "keyboard" &&
+      highlightedIndex > -1 &&
+      items[highlightedIndex].id !== selectedId
+    ) {
       selectedId = items[highlightedIndex].id;
       dispatchSelect();
       close("select");
@@ -638,6 +647,7 @@
           // Clear the hover highlight when the cursor leaves the menu so the
           // highlighted state does not linger on the last hovered item.
           highlightedIndex = -1;
+          highlightOrigin = null;
         }}
         bind:ref={listRef}
         style={effectivePortalMenu
@@ -674,6 +684,7 @@
                   on:mouseenter={() => {
                     if (item.disabled) return;
                     highlightedIndex = actualIndex;
+                    highlightOrigin = "pointer";
                   }}
                 >
                   {#if $$slots.icon || item.icon}
@@ -738,6 +749,7 @@
               on:mouseenter={() => {
                 if (item.disabled) return;
                 highlightedIndex = index;
+                highlightOrigin = "pointer";
               }}
             >
               {#if $$slots.icon || item.icon}

--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -303,6 +303,7 @@
 
   let fieldFocused = false;
   let highlightedIndex = -1;
+  let highlightOrigin = /** @type {"keyboard" | "pointer" | null} */ (null);
   let prevHighlightedIndex = -1;
   let prevChecked = [];
   let isInitialRender = true;
@@ -335,6 +336,7 @@
       index: highlightedIndex,
       step,
     });
+    highlightOrigin = "keyboard";
   }
 
   /** Handle selection of an item, including isSelectAll logic. */
@@ -417,6 +419,7 @@
 
     if (!open) {
       highlightedIndex = -1;
+      highlightOrigin = null;
       prevHighlightedIndex = -1;
       if (prevOpen && filterable) {
         value = "";
@@ -794,7 +797,7 @@
               return;
             }
             if (event.key === "Enter") {
-              if (highlightedId) {
+              if (highlightOrigin === "keyboard" && highlightedId) {
                 const highlightedItem = sortedItems.find(
                   (item) => item.id === highlightedId,
                 );
@@ -941,7 +944,7 @@
               change(step);
             }
           } else if (event.key === "Enter") {
-            if (highlightedIndex > -1) {
+            if (highlightOrigin === "keyboard" && highlightedIndex > -1) {
               const item = (filterable ? filteredItems : sortedItems)[
                 highlightedIndex
               ];
@@ -1000,6 +1003,7 @@
           // Clear the hover highlight when the cursor leaves the menu so the
           // highlighted state does not linger on the last hovered item.
           highlightedIndex = -1;
+          highlightOrigin = null;
         }}
         bind:ref={listRef}
         style={effectivePortalMenu
@@ -1046,6 +1050,7 @@
                   on:mouseenter={() => {
                     if (item.disabled) return;
                     highlightedIndex = actualIndex;
+                    highlightOrigin = "pointer";
                   }}
                 >
                   <Checkbox
@@ -1108,6 +1113,7 @@
               on:mouseenter={() => {
                 if (item.disabled) return;
                 highlightedIndex = index;
+                highlightOrigin = "pointer";
               }}
             >
               <Checkbox

--- a/tests/ComboBox/ComboBox.test.ts
+++ b/tests/ComboBox/ComboBox.test.ts
@@ -275,6 +275,23 @@ describe("ComboBox", () => {
     expect(emailOption).not.toHaveClass("bx--list-box__menu-item--highlighted");
   });
 
+  it("does not select a hover-highlighted item on Enter; closes without selecting", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(ComboBox);
+
+    const input = getInput();
+    await user.click(input);
+
+    const emailOption = screen.getByRole("option", { name: "Email" });
+    await user.hover(emailOption);
+    expect(emailOption).toHaveClass("bx--list-box__menu-item--highlighted");
+
+    await user.keyboard("{Enter}");
+    expect(consoleLog).not.toHaveBeenCalledWith("select", expect.anything());
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    expect(input).toHaveValue("");
+  });
+
   it("should set aria-activedescendant only when an item is highlighted", async () => {
     render(ComboBox, { props: { shouldFilterItem: () => true } });
 

--- a/tests/Dropdown/Dropdown.test.ts
+++ b/tests/Dropdown/Dropdown.test.ts
@@ -331,6 +331,27 @@ describe("Dropdown", () => {
     expect(button).toHaveTextContent("Email");
   });
 
+  it("does not select a hover-highlighted item on Enter; closes without selecting", async () => {
+    const selectHandler = vi.fn();
+    render(Dropdown, {
+      props: { items, selectedId: "0", onselect: selectHandler },
+    });
+
+    const button = screen.getByRole("combobox");
+    await user.click(button);
+    expect(screen.getByRole("listbox")).toBeVisible();
+
+    const fax = screen.getByText("Fax").closest(".bx--list-box__menu-item");
+    assert(fax);
+    await user.hover(fax);
+    expect(fax).toHaveClass("bx--list-box__menu-item--highlighted");
+
+    await user.keyboard("{Enter}");
+    expect(selectHandler).not.toHaveBeenCalled();
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    expect(button).toHaveTextContent("Slack");
+  });
+
   // Regression: the Space keydown must cancel its default action so the
   // browser does not scroll the page (and does not synthesize a click)
   // before the keyup handler opens the menu.

--- a/tests/MultiSelect/MultiSelect.test.ts
+++ b/tests/MultiSelect/MultiSelect.test.ts
@@ -89,6 +89,21 @@ describe("MultiSelect", () => {
     expect(emailOption).not.toHaveClass("bx--list-box__menu-item--highlighted");
   });
 
+  it("does not toggle a hover-highlighted item on Enter", async () => {
+    render(MultiSelect, { props: { items } });
+
+    await openMenu();
+
+    const emailOption = screen.getByRole("option", { name: "Email" });
+    await user.hover(emailOption);
+    expect(emailOption).toHaveClass("bx--list-box__menu-item--highlighted");
+    expect(emailOption).toHaveAttribute("aria-checked", "false");
+
+    await user.keyboard("{Enter}");
+    expect(emailOption).toHaveAttribute("aria-checked", "false");
+    expect(screen.getByRole("listbox")).toBeInTheDocument();
+  });
+
   it("should pass selected and highlighted to the default slot", async () => {
     render(MultiSelectItemSlot, { props: { selectedIds: ["1"] } });
 


### PR DESCRIPTION
Decouples hover highlighting from keyboard Enter selection in Dropdown, ComboBox, and MultiSelect so a mouse hover no longer changes what Enter commits. Enter now acts only on a keyboard-set highlight (arrow keys, typeahead, or auto-highlight), while a hover-set highlight falls through to each component's existing behavior, matching Carbon React. Each fix ships a focused regression test, and SearchMenu/HeaderSearch are intentionally left for a follow-up.