### PR TITLE
feat(user-avatar): add UserAvatarGroup and auto background color

### DIFF
--- a/css/_user-avatar-group.scss
+++ b/css/_user-avatar-group.scss
@@ -1,0 +1,46 @@
+@import "carbon-components/scss/globals/scss/vars";
+
+/// UserAvatarGroup styles: an overlapping (stacked) or spaced row of avatars
+/// with a "+N" overflow avatar.
+/// @access private
+/// @group components
+@mixin user-avatar-group {
+  .#{$prefix}--user-avatar-group {
+    align-items: center;
+  }
+
+  // Avatars past `max` stay in the DOM but hide; the overflow chip stands in.
+  .#{$prefix}--user-avatar-group [data-overflow="true"] {
+    display: none;
+  }
+
+  //--------------------------------------------------------------------------
+  // Overlapping (stacked) layout
+  //--------------------------------------------------------------------------
+  .#{$prefix}--user-avatar-group--overlap > * {
+    // Stacking context so a hovered avatar can lift above its neighbors.
+    position: relative;
+  }
+
+  // The overlap amount defaults to a spacing token. A negative `gap` overrides
+  // it through the custom property.
+  .#{$prefix}--user-avatar-group--overlap > * + * {
+    margin-left: var(--user-avatar-group-overlap, -#{$carbon--spacing-03});
+  }
+
+  // A ring in the surrounding background color separates overlapping circles.
+  // `box-shadow` is not clipped by the avatar's `overflow: hidden` frame.
+  .#{$prefix}--user-avatar-group--overlap .#{$prefix}--user-avatar {
+    box-shadow: 0 0 0 $carbon--spacing-01 var(--cds-ui-background, #{$ui-background});
+  }
+
+  // Lift the hovered or focused avatar to the front of the stack.
+  .#{$prefix}--user-avatar-group--overlap > *:hover,
+  .#{$prefix}--user-avatar-group--overlap > *:focus-within {
+    z-index: 1;
+  }
+}
+
+@include exports("user-avatar-group") {
+  @include user-avatar-group;
+}

--- a/css/all.scss
+++ b/css/all.scss
@@ -134,3 +134,4 @@ $css--plex: true;
 @import "./link";
 @import "./profile-menu";
 @import "./user-avatar";
+@import "./user-avatar-group";

--- a/css/g10.scss
+++ b/css/g10.scss
@@ -94,3 +94,4 @@ $css--plex: true;
 @import "./link";
 @import "./profile-menu";
 @import "./user-avatar";
+@import "./user-avatar-group";

--- a/css/g100.scss
+++ b/css/g100.scss
@@ -94,3 +94,4 @@ $css--plex: true;
 @import "./link";
 @import "./profile-menu";
 @import "./user-avatar";
+@import "./user-avatar-group";

--- a/css/g80.scss
+++ b/css/g80.scss
@@ -94,3 +94,4 @@ $css--plex: true;
 @import "./link";
 @import "./profile-menu";
 @import "./user-avatar";
+@import "./user-avatar-group";

--- a/css/g90.scss
+++ b/css/g90.scss
@@ -94,3 +94,4 @@ $css--plex: true;
 @import "./link";
 @import "./profile-menu";
 @import "./user-avatar";
+@import "./user-avatar-group";

--- a/css/white.scss
+++ b/css/white.scss
@@ -94,3 +94,4 @@ $css--plex: true;
 @import "./link";
 @import "./profile-menu";
 @import "./user-avatar";
+@import "./user-avatar-group";

--- a/docs/src/component-categories.ts
+++ b/docs/src/component-categories.ts
@@ -127,6 +127,10 @@ export const COMPONENT_CATEGORIES: ComponentCategory[] = [
       "Truncate",
     ],
   },
+  {
+    label: "Misc",
+    components: ["UserAvatar", "UserAvatarGroup"],
+  },
 ];
 
 export const CATEGORY_BY_COMPONENT: Record<string, string> =

--- a/docs/src/component-since-versions.ts
+++ b/docs/src/component-since-versions.ts
@@ -82,4 +82,5 @@ export const COMPONENT_SINCE_VERSIONS: Record<string, string> = {
   UIShell: "0.3.0",
   UnorderedList: "0.2.0",
   UserAvatar: "0.110.0",
+  UserAvatarGroup: "0.110.0",
 };

--- a/docs/src/pages/components/UserAvatar.svx
+++ b/docs/src/pages/components/UserAvatar.svx
@@ -72,6 +72,16 @@ Set `backgroundColor` to choose the color rendered behind the initials or icon. 
 <UserAvatar backgroundColor="cool-gray" name="Richard Hendricks" />
 <UserAvatar backgroundColor="warm-gray" name="Richard Hendricks" />
 
+### Automatic background color
+
+Set `backgroundColor` to `"auto"` to pick a color from `name` (or `initials`). The name is hashed into one of the palette swatches. The same name always gets the same color.
+
+<UserAvatar backgroundColor="auto" name="Monica" />
+<UserAvatar backgroundColor="auto" name="Richard Hendricks" />
+<UserAvatar backgroundColor="auto" name="Dinesh Chugtai" />
+<UserAvatar backgroundColor="auto" name="Bertram Gilfoyle" />
+<UserAvatar backgroundColor="auto" name="Jared Dunn" />
+
 ## Tooltip
 
 Set `tooltipText` to show the display name on hover or focus. Use `align` and `direction` to position the tooltip. The tooltip closes on <DocKbd label="Escape" />.

--- a/docs/src/pages/components/UserAvatarGroup.svx
+++ b/docs/src/pages/components/UserAvatarGroup.svx
@@ -1,0 +1,171 @@
+---
+components: ["UserAvatarGroup"]
+description: A row of overlapping or spaced user avatars. Extras fold into a "+N" overflow avatar.
+---
+
+<script>
+  import { UserAvatar, UserAvatarGroup } from "carbon-components-svelte";
+</script>
+
+## Basic
+
+Put [UserAvatar](/components/UserAvatar) children inside the group. The default layout stacks them with a slight overlap. A ring keeps the circles distinct, and hover brings an avatar to the front. Set `tooltipText` on each avatar to show the name on hover or focus.
+
+<UserAvatarGroup>
+  <UserAvatar backgroundColor="auto" name="Monica" tooltipText="Monica" />
+  <UserAvatar backgroundColor="auto" name="Richard Hendricks" tooltipText="Richard Hendricks" />
+  <UserAvatar backgroundColor="auto" name="Dinesh Chugtai" tooltipText="Dinesh Chugtai" />
+</UserAvatarGroup>
+
+## Overflow
+
+Set `max` to limit how many avatars show. Everyone else goes into a "+N" overflow avatar. Hover it for the hidden names. Counts above 99 show as `99+` so the label fits the circle.
+
+<UserAvatarGroup max={3}>
+  <UserAvatar backgroundColor="auto" name="Monica" tooltipText="Monica" />
+  <UserAvatar backgroundColor="auto" name="Richard Hendricks" tooltipText="Richard Hendricks" />
+  <UserAvatar backgroundColor="auto" name="Dinesh Chugtai" tooltipText="Dinesh Chugtai" />
+  <UserAvatar backgroundColor="auto" name="Bertram Gilfoyle" tooltipText="Bertram Gilfoyle" />
+  <UserAvatar backgroundColor="auto" name="Jared Dunn" tooltipText="Jared Dunn" />
+  <UserAvatar backgroundColor="auto" name="Erlich Bachman" tooltipText="Erlich Bachman" />
+</UserAvatarGroup>
+
+Set `max` to `0` to show every avatar without an overflow.
+
+### Large groups
+
+Every slotted avatar still mounts; CSS hides the ones past `max`. For large lists, render only the faces you need and set `total` to the real headcount so the "+N" chip gets the right number without mounting hundreds of nodes. Set `overflowTooltipText` when the hidden people are not slotted, since the default tooltip only lists mounted `name` values.
+
+<UserAvatarGroup
+  max={3}
+  total={250}
+  overflowTooltipText="Gilfoyle, Jared, Erlich, and 244 others"
+>
+  <UserAvatar backgroundColor="auto" name="Monica" tooltipText="Monica" />
+  <UserAvatar backgroundColor="auto" name="Richard Hendricks" tooltipText="Richard Hendricks" />
+  <UserAvatar backgroundColor="auto" name="Dinesh Chugtai" tooltipText="Dinesh Chugtai" />
+</UserAvatarGroup>
+
+## Spacing
+
+Leave `gap` unset for the default overlapping layout. Set `gap` to a positive value to space the avatars apart, or to a negative length string to tighten the overlap.
+
+### Scale
+
+Set `gap` to a Carbon layout scale from `0` to `13`.
+
+<UserAvatarGroup gap={2}>
+  <UserAvatar backgroundColor="auto" name="Monica" tooltipText="Monica" />
+  <UserAvatar backgroundColor="auto" name="Richard Hendricks" tooltipText="Richard Hendricks" />
+  <UserAvatar backgroundColor="auto" name="Dinesh Chugtai" tooltipText="Dinesh Chugtai" />
+</UserAvatarGroup>
+
+<UserAvatarGroup gap={6}>
+  <UserAvatar backgroundColor="auto" name="Monica" tooltipText="Monica" />
+  <UserAvatar backgroundColor="auto" name="Richard Hendricks" tooltipText="Richard Hendricks" />
+  <UserAvatar backgroundColor="auto" name="Dinesh Chugtai" tooltipText="Dinesh Chugtai" />
+</UserAvatarGroup>
+
+### Custom length
+
+Set `gap` to any CSS length string for spacing off the scale.
+
+<UserAvatarGroup gap="24px">
+  <UserAvatar backgroundColor="auto" name="Monica" tooltipText="Monica" />
+  <UserAvatar backgroundColor="auto" name="Richard Hendricks" tooltipText="Richard Hendricks" />
+  <UserAvatar backgroundColor="auto" name="Dinesh Chugtai" tooltipText="Dinesh Chugtai" />
+</UserAvatarGroup>
+
+### Tighter overlap
+
+Set `gap` to a negative length string to overlap the avatars by that amount, tighter than the default stack.
+
+<UserAvatarGroup gap="-1rem">
+  <UserAvatar backgroundColor="auto" name="Monica" tooltipText="Monica" />
+  <UserAvatar backgroundColor="auto" name="Richard Hendricks" tooltipText="Richard Hendricks" />
+  <UserAvatar backgroundColor="auto" name="Dinesh Chugtai" tooltipText="Dinesh Chugtai" />
+</UserAvatarGroup>
+
+## Sizes
+
+Set `size` on the group to resize every avatar at once, including the overflow chip. A child can still override with its own `size`.
+
+### Small
+
+<UserAvatarGroup size="sm" max={3}>
+  <UserAvatar backgroundColor="auto" name="Monica" tooltipText="Monica" />
+  <UserAvatar backgroundColor="auto" name="Richard Hendricks" tooltipText="Richard Hendricks" />
+  <UserAvatar backgroundColor="auto" name="Dinesh Chugtai" tooltipText="Dinesh Chugtai" />
+  <UserAvatar backgroundColor="auto" name="Bertram Gilfoyle" tooltipText="Bertram Gilfoyle" />
+</UserAvatarGroup>
+
+### Medium
+
+<UserAvatarGroup size="md" max={3}>
+  <UserAvatar backgroundColor="auto" name="Monica" tooltipText="Monica" />
+  <UserAvatar backgroundColor="auto" name="Richard Hendricks" tooltipText="Richard Hendricks" />
+  <UserAvatar backgroundColor="auto" name="Dinesh Chugtai" tooltipText="Dinesh Chugtai" />
+  <UserAvatar backgroundColor="auto" name="Bertram Gilfoyle" tooltipText="Bertram Gilfoyle" />
+</UserAvatarGroup>
+
+### Large
+
+<UserAvatarGroup size="lg" max={3}>
+  <UserAvatar backgroundColor="auto" name="Monica" tooltipText="Monica" />
+  <UserAvatar backgroundColor="auto" name="Richard Hendricks" tooltipText="Richard Hendricks" />
+  <UserAvatar backgroundColor="auto" name="Dinesh Chugtai" tooltipText="Dinesh Chugtai" />
+  <UserAvatar backgroundColor="auto" name="Bertram Gilfoyle" tooltipText="Bertram Gilfoyle" />
+</UserAvatarGroup>
+
+### Extra large
+
+<UserAvatarGroup size="xl" max={3}>
+  <UserAvatar backgroundColor="auto" name="Monica" tooltipText="Monica" />
+  <UserAvatar backgroundColor="auto" name="Richard Hendricks" tooltipText="Richard Hendricks" />
+  <UserAvatar backgroundColor="auto" name="Dinesh Chugtai" tooltipText="Dinesh Chugtai" />
+  <UserAvatar backgroundColor="auto" name="Bertram Gilfoyle" tooltipText="Bertram Gilfoyle" />
+</UserAvatarGroup>
+
+## Images
+
+Photos, icons, and initials work the same as on a lone `UserAvatar`.
+
+### Small
+
+<UserAvatarGroup size="sm" max={3}>
+  <UserAvatar image="https://i.pravatar.cc/150?img=12" imageDescription="Monica" tooltipText="Monica" />
+  <UserAvatar image="https://i.pravatar.cc/150?img=5" imageDescription="Richard Hendricks" tooltipText="Richard Hendricks" />
+  <UserAvatar image="https://i.pravatar.cc/150?img=33" imageDescription="Dinesh Chugtai" tooltipText="Dinesh Chugtai" />
+  <UserAvatar backgroundColor="auto" name="Bertram Gilfoyle" tooltipText="Bertram Gilfoyle" />
+  <UserAvatar backgroundColor="auto" name="Jared Dunn" tooltipText="Jared Dunn" />
+</UserAvatarGroup>
+
+### Medium
+
+<UserAvatarGroup size="md" max={3}>
+  <UserAvatar image="https://i.pravatar.cc/150?img=12" imageDescription="Monica" tooltipText="Monica" />
+  <UserAvatar image="https://i.pravatar.cc/150?img=5" imageDescription="Richard Hendricks" tooltipText="Richard Hendricks" />
+  <UserAvatar image="https://i.pravatar.cc/150?img=33" imageDescription="Dinesh Chugtai" tooltipText="Dinesh Chugtai" />
+  <UserAvatar backgroundColor="auto" name="Bertram Gilfoyle" tooltipText="Bertram Gilfoyle" />
+  <UserAvatar backgroundColor="auto" name="Jared Dunn" tooltipText="Jared Dunn" />
+</UserAvatarGroup>
+
+### Large
+
+<UserAvatarGroup size="lg" max={3}>
+  <UserAvatar image="https://i.pravatar.cc/150?img=12" imageDescription="Monica" tooltipText="Monica" />
+  <UserAvatar image="https://i.pravatar.cc/150?img=5" imageDescription="Richard Hendricks" tooltipText="Richard Hendricks" />
+  <UserAvatar image="https://i.pravatar.cc/150?img=33" imageDescription="Dinesh Chugtai" tooltipText="Dinesh Chugtai" />
+  <UserAvatar backgroundColor="auto" name="Bertram Gilfoyle" tooltipText="Bertram Gilfoyle" />
+  <UserAvatar backgroundColor="auto" name="Jared Dunn" tooltipText="Jared Dunn" />
+</UserAvatarGroup>
+
+### Extra large
+
+<UserAvatarGroup size="xl" max={3}>
+  <UserAvatar image="https://i.pravatar.cc/150?img=12" imageDescription="Monica" tooltipText="Monica" />
+  <UserAvatar image="https://i.pravatar.cc/150?img=5" imageDescription="Richard Hendricks" tooltipText="Richard Hendricks" />
+  <UserAvatar image="https://i.pravatar.cc/150?img=33" imageDescription="Dinesh Chugtai" tooltipText="Dinesh Chugtai" />
+  <UserAvatar backgroundColor="auto" name="Bertram Gilfoyle" tooltipText="Bertram Gilfoyle" />
+  <UserAvatar backgroundColor="auto" name="Jared Dunn" tooltipText="Jared Dunn" />
+</UserAvatarGroup>

--- a/e2e/fixtures/UserAvatarGroupFixture.svelte
+++ b/e2e/fixtures/UserAvatarGroupFixture.svelte
@@ -1,0 +1,70 @@
+<script>
+  import { UserAvatar, UserAvatarGroup } from "carbon-components-svelte";
+</script>
+
+<div data-testid="overlap">
+  <UserAvatarGroup max={3}>
+    <UserAvatar backgroundColor="auto" name="Monica" tooltipText="Monica" />
+    <UserAvatar
+      backgroundColor="auto"
+      name="Richard Hendricks"
+      tooltipText="Richard Hendricks"
+    />
+    <UserAvatar
+      backgroundColor="auto"
+      name="Dinesh Chugtai"
+      tooltipText="Dinesh Chugtai"
+    />
+    <UserAvatar
+      backgroundColor="auto"
+      name="Bertram Gilfoyle"
+      tooltipText="Bertram Gilfoyle"
+    />
+    <UserAvatar
+      backgroundColor="auto"
+      name="Jared Dunn"
+      tooltipText="Jared Dunn"
+    />
+  </UserAvatarGroup>
+</div>
+
+<div data-testid="spaced">
+  <UserAvatarGroup gap={3} max={0}>
+    <UserAvatar backgroundColor="auto" name="Monica" />
+    <UserAvatar backgroundColor="auto" name="Richard Hendricks" />
+  </UserAvatarGroup>
+</div>
+
+<div data-testid="cascade">
+  <UserAvatarGroup size="lg" max={0}>
+    <UserAvatar backgroundColor="auto" name="Monica" tooltipText="Monica" />
+    <UserAvatar
+      backgroundColor="auto"
+      name="Richard Hendricks"
+      size="sm"
+      tooltipText="Richard Hendricks"
+    />
+  </UserAvatarGroup>
+</div>
+
+<div data-testid="coord">
+  <UserAvatarGroup gap={5} max={0}>
+    <UserAvatar backgroundColor="auto" name="Alpha" tooltipText="Alpha" />
+    <UserAvatar backgroundColor="auto" name="Beta" tooltipText="Beta" />
+  </UserAvatarGroup>
+</div>
+
+<div data-testid="tighter">
+  <UserAvatarGroup gap="-1rem" max={0}>
+    <UserAvatar backgroundColor="auto" name="Monica" />
+    <UserAvatar backgroundColor="auto" name="Richard Hendricks" />
+  </UserAvatarGroup>
+</div>
+
+<div data-testid="big">
+  <UserAvatarGroup max={1}>
+    {#each Array.from({ length: 101 }) as _, index (index)}
+      <UserAvatar backgroundColor="auto" name={`User ${index}`} />
+    {/each}
+  </UserAvatarGroup>
+</div>

--- a/e2e/fixtures/index.html
+++ b/e2e/fixtures/index.html
@@ -73,6 +73,7 @@
       <a href="/data-table-virtual.html">DataTable (virtualized)</a>
       <a href="/link.html">Link (icon scaling)</a>
       <a href="/uishell.html">UIShell</a>
+      <a href="/user-avatar-group.html">UserAvatarGroup</a>
       <a href="/notification-queue.html">NotificationQueue</a>
     </nav>
   </body>

--- a/e2e/fixtures/user-avatar-group.html
+++ b/e2e/fixtures/user-avatar-group.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>UserAvatarGroup Test</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="./user-avatar-group.ts"></script>
+  </body>
+</html>

--- a/e2e/fixtures/user-avatar-group.ts
+++ b/e2e/fixtures/user-avatar-group.ts
@@ -1,0 +1,4 @@
+import { mount } from "./mount";
+import UserAvatarGroupFixture from "./UserAvatarGroupFixture.svelte";
+
+mount(UserAvatarGroupFixture);

--- a/e2e/user-avatar-group.test.ts
+++ b/e2e/user-avatar-group.test.ts
@@ -1,0 +1,110 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("UserAvatarGroup", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/user-avatar-group.html");
+  });
+
+  test("renders visible avatars and a +N overflow avatar", async ({ page }) => {
+    const list = page.getByTestId("overlap").locator(".bx--user-avatar-group");
+    await expect(list).toBeVisible();
+
+    // Five slotted avatars + one overflow avatar are in the DOM.
+    await expect(list.locator(".bx--user-avatar")).toHaveCount(6);
+    // Two avatars past `max` of 3 are hidden as overflow.
+    await expect(list.locator('[data-overflow="true"]')).toHaveCount(2);
+    await expect(page.getByText("+2")).toBeVisible();
+  });
+
+  test("overflow avatar tooltip lists the hidden names", async ({ page }) => {
+    await page
+      .getByTestId("overlap")
+      .locator(".bx--user-avatar-group__overflow")
+      .hover();
+
+    await expect(page.getByRole("tooltip")).toHaveText(
+      "Bertram Gilfoyle, Jared Dunn",
+    );
+  });
+
+  test("overlaps avatars with a negative margin and a ring", async ({
+    page,
+  }) => {
+    const second = page.locator(".bx--user-avatar-group--overlap > *").nth(1);
+    const marginLeft = await second.evaluate((el) =>
+      Number.parseFloat(getComputedStyle(el).marginLeft),
+    );
+    expect(marginLeft).toBeLessThan(0);
+
+    // A separation ring is drawn with box-shadow on the avatar circle.
+    const boxShadow = await page
+      .getByTestId("overlap")
+      .locator(".bx--user-avatar")
+      .first()
+      .evaluate((el) => getComputedStyle(el).boxShadow);
+    expect(boxShadow).not.toBe("none");
+  });
+
+  test("tightens the overlap with a negative gap", async ({ page }) => {
+    const second = page
+      .getByTestId("tighter")
+      .locator(".bx--user-avatar-group--overlap > *")
+      .nth(1);
+    const marginLeft = await second.evaluate((el) =>
+      Number.parseFloat(getComputedStyle(el).marginLeft),
+    );
+    // gap="-1rem" overlaps by 16px, tighter than the default 8px stack.
+    expect(marginLeft).toBeCloseTo(-16, 0);
+  });
+
+  test("cascades the group size to avatars that do not set their own", async ({
+    page,
+  }) => {
+    const avatars = page.getByTestId("cascade").locator(".bx--user-avatar");
+    const width = (el: Element) => el.getBoundingClientRect().width;
+
+    // First avatar inherits lg (2.5rem = 40px); the second keeps sm (1.5rem = 24px).
+    expect(await avatars.nth(0).evaluate(width)).toBeCloseTo(40, 0);
+    expect(await avatars.nth(1).evaluate(width)).toBeCloseTo(24, 0);
+  });
+
+  test("shows only one avatar tooltip at a time", async ({ page }) => {
+    const avatars = page.getByTestId("coord").locator(".bx--user-avatar");
+
+    await avatars.nth(0).hover();
+    await expect(page.getByRole("tooltip")).toHaveText("Alpha");
+
+    // Hovering a different avatar replaces the open tooltip rather than
+    // stacking a second one.
+    await avatars.nth(1).hover();
+    await expect(page.getByRole("tooltip")).toHaveText("Beta");
+    await expect(page.getByRole("tooltip")).toHaveCount(1);
+  });
+
+  test("caps the overflow label at 99+", async ({ page }) => {
+    const overflow = page
+      .getByTestId("big")
+      .locator(".bx--user-avatar-group__overflow");
+    await expect(overflow).toHaveText("99+");
+  });
+
+  test("spaces avatars apart when a gap is set", async ({ page }) => {
+    const list = page.getByTestId("spaced").locator(".bx--user-avatar-group");
+    await expect(list).not.toHaveClass(/bx--user-avatar-group--overlap/);
+
+    // No overflow avatar when max is 0.
+    await expect(list.locator(".bx--user-avatar")).toHaveCount(2);
+
+    // The gap comes from the Stack scale, not a negative margin.
+    const gap = await list.evaluate((el) =>
+      Number.parseFloat(getComputedStyle(el).columnGap),
+    );
+    expect(gap).toBeGreaterThan(0);
+
+    const boxShadow = await list
+      .locator(".bx--user-avatar")
+      .first()
+      .evaluate((el) => getComputedStyle(el).boxShadow);
+    expect(boxShadow).toBe("none");
+  });
+});

--- a/src/UserAvatar/UserAvatar.svelte
+++ b/src/UserAvatar/UserAvatar.svelte
@@ -14,7 +14,8 @@
 
   /**
    * Specify the background color rendered behind the initials or icon.
-   * @type {"red" | "magenta" | "purple" | "blue" | "cyan" | "teal" | "green" | "gray" | "cool-gray" | "warm-gray"}
+   * Set to `"auto"` to pick a stable color from `name` (or `initials`).
+   * @type {"auto" | "red" | "magenta" | "purple" | "blue" | "cyan" | "teal" | "green" | "gray" | "cool-gray" | "warm-gray"}
    */
   export let backgroundColor = "gray";
 
@@ -84,6 +85,7 @@
 
   import User from "../icons/User.svelte";
   import TooltipDefinition from "../TooltipDefinition/TooltipDefinition.svelte";
+  import { getAvatarBackgroundColor } from "../utils/avatarColor.js";
 
   const glyphSize = { sm: 16, md: 20, lg: 24, xl: 32 };
   const WHITESPACE = /\s+/;
@@ -101,10 +103,14 @@
   }
 
   $: avatarInitials = initials ?? formatInitials(name);
+  $: resolvedBackgroundColor =
+    backgroundColor === "auto"
+      ? getAvatarBackgroundColor(name ?? initials ?? "")
+      : backgroundColor;
   $: avatarClass = [
     "bx--user-avatar",
     `bx--user-avatar--${size}`,
-    `bx--user-avatar--${backgroundColor}`,
+    `bx--user-avatar--${resolvedBackgroundColor}`,
     $$restProps.class,
   ]
     .filter(Boolean)

--- a/src/UserAvatar/UserAvatar.svelte
+++ b/src/UserAvatar/UserAvatar.svelte
@@ -8,9 +8,10 @@
 
   /**
    * Specify the size of the avatar.
+   * Defaults to `"md"`, or to the `size` of a parent `UserAvatarGroup`.
    * @type {"sm" | "md" | "lg" | "xl"}
    */
-  export let size = "md";
+  export let size = undefined;
 
   /**
    * Specify the background color rendered behind the initials or icon.
@@ -83,9 +84,90 @@
    */
   export let ref = null;
 
+  import { getContext, onMount } from "svelte";
+  import { get, readable } from "svelte/store";
   import User from "../icons/User.svelte";
   import TooltipDefinition from "../TooltipDefinition/TooltipDefinition.svelte";
   import { getAvatarBackgroundColor } from "../utils/avatarColor.js";
+
+  // When rendered inside a `UserAvatarGroup`, register with the group so it can
+  // count avatars and hide those beyond its `max`. The group context is absent
+  // for a standalone avatar, in which case none of this applies.
+  const userAvatarGroup = getContext("carbon:UserAvatarGroup");
+  const groupItemId = userAvatarGroup
+    ? `cua-${Math.random().toString(36).slice(2)}`
+    : undefined;
+  const groupItems = userAvatarGroup?.items ?? readable([]);
+  const groupMax = userAvatarGroup?.max ?? readable(0);
+  const groupSize = userAvatarGroup?.size ?? readable(undefined);
+  const groupActiveTooltip = userAvatarGroup?.activeTooltip ?? readable(null);
+
+  // In a group, only one avatar tooltip shows at a time. Hovering an avatar
+  // claims a shared store on pointer enter (before the tooltip's open delay);
+  // any other open tooltip closes immediately when a neighbor claims it (same
+  // approach as ContentSwitcher's icon-only tooltips).
+  let tooltipOpen = false;
+  let releaseTimeout;
+  $: if (
+    userAvatarGroup &&
+    tooltipOpen &&
+    $groupActiveTooltip !== null &&
+    $groupActiveTooltip !== groupItemId
+  ) {
+    tooltipOpen = false;
+  }
+
+  function claimTooltip() {
+    if (!userAvatarGroup) return;
+    clearTimeout(releaseTimeout);
+    const previous = get(groupActiveTooltip);
+    userAvatarGroup.activeTooltip.set(groupItemId);
+    // Warm handoff: if another avatar already has its tooltip open, skip the
+    // enter delay (same pattern as ContentSwitcher's icon-only tooltips).
+    if (previous !== null && previous !== groupItemId) {
+      tooltipOpen = true;
+    }
+  }
+
+  function releaseTooltip() {
+    if (userAvatarGroup && get(groupActiveTooltip) === groupItemId) {
+      userAvatarGroup.activeTooltip.set(null);
+    }
+  }
+
+  // Defer release so moving between neighbors within 300ms skips the next
+  // enter delay.
+  function scheduleRelease() {
+    clearTimeout(releaseTimeout);
+    releaseTimeout = setTimeout(releaseTooltip, 300);
+  }
+
+  if (userAvatarGroup) {
+    // Register once mounted so the group can sort registrations into DOM order
+    // via the element reference (mount order can differ from DOM order when
+    // avatars are conditionally rendered).
+    onMount(() => {
+      userAvatarGroup.register({ id: groupItemId, name, node: ref });
+      return () => {
+        clearTimeout(releaseTimeout);
+        userAvatarGroup.unregister(groupItemId);
+      };
+    });
+  }
+
+  $: if (userAvatarGroup) userAvatarGroup.updateName(groupItemId, name);
+  $: groupIndex = userAvatarGroup
+    ? $groupItems.findIndex((item) => item.id === groupItemId)
+    : -1;
+  // Avatars past the group's `max` are hidden (the group renders a "+N" overflow
+  // avatar in their place). `$groupMax` of 0 means "no limit."
+  $: groupOverflow =
+    userAvatarGroup &&
+    $groupMax > 0 &&
+    groupIndex >= 0 &&
+    groupIndex >= $groupMax;
+  // Fall back to the group's size, then to "md".
+  $: resolvedSize = size ?? $groupSize ?? "md";
 
   const glyphSize = { sm: 16, md: 20, lg: 24, xl: 32 };
   const WHITESPACE = /\s+/;
@@ -109,7 +191,7 @@
       : backgroundColor;
   $: avatarClass = [
     "bx--user-avatar",
-    `bx--user-avatar--${size}`,
+    `bx--user-avatar--${resolvedSize}`,
     `bx--user-avatar--${resolvedBackgroundColor}`,
     $$restProps.class,
   ]
@@ -124,6 +206,9 @@
     {align}
     {direction}
     {portalTooltip}
+    bind:open={tooltipOpen}
+    on:close={releaseTooltip}
+    data-overflow={groupOverflow ? "true" : undefined}
   >
     <span
       bind:this={ref}
@@ -132,18 +217,20 @@
       on:click
       on:mouseover
       on:mouseenter
+      on:mouseenter={claimTooltip}
       on:mouseleave
+      on:mouseleave={scheduleRelease}
     >
       {#if $$slots.default}
         <slot />
       {:else if image}
         <img src={image} alt={imageDescription}>
       {:else if icon}
-        <svelte:component this={icon} size={glyphSize[size]} />
+        <svelte:component this={icon} size={glyphSize[resolvedSize]} />
       {:else if avatarInitials}
         <span class:bx--user-avatar__text={true}>{avatarInitials}</span>
       {:else}
-        <User size={glyphSize[size]} />
+        <User size={glyphSize[resolvedSize]} />
       {/if}
     </span>
   </TooltipDefinition>
@@ -153,6 +240,7 @@
     bind:this={ref}
     {...$$restProps}
     class={avatarClass}
+    data-overflow={groupOverflow ? "true" : undefined}
     on:click
     on:mouseover
     on:mouseenter
@@ -163,11 +251,11 @@
     {:else if image}
       <img src={image} alt={imageDescription}>
     {:else if icon}
-      <svelte:component this={icon} size={glyphSize[size]} />
+      <svelte:component this={icon} size={glyphSize[resolvedSize]} />
     {:else if avatarInitials}
       <span class:bx--user-avatar__text={true}>{avatarInitials}</span>
     {:else}
-      <User size={glyphSize[size]} />
+      <User size={glyphSize[resolvedSize]} />
     {/if}
   </span>
 {/if}

--- a/src/UserAvatarGroup/UserAvatarGroup.svelte
+++ b/src/UserAvatarGroup/UserAvatarGroup.svelte
@@ -1,0 +1,156 @@
+<script>
+  /**
+   * Render a row of `UserAvatar` children. The group adds the "+N" overflow chip.
+   * @restProps {div}
+   */
+
+  /**
+   * Specify the maximum number of avatars to show before collapsing the rest
+   * into a "+N" overflow avatar. Set to `0` to show every avatar.
+   * @type {number}
+   */
+  export let max = 5;
+
+  /**
+   * Specify the total number of people represented. Defaults to the number of
+   * slotted avatars. Set this when you render only a subset (large groups) so
+   * the overflow count stays right without mounting every avatar.
+   * @type {number}
+   */
+  export let total = undefined;
+
+  /**
+   * Specify the spacing between avatars. Leave unset for the default
+   * overlapping (stacked) layout. A positive value spaces the avatars apart,
+   * accepting a Carbon layout scale (`0`–`13`) or a CSS length string. A
+   * negative length string (for example `"-1rem"`) overlaps them by that
+   * amount.
+   * @type {import("../Stack/Stack.svelte").StackScale | string}
+   */
+  export let gap = undefined;
+
+  /**
+   * Specify the size of the avatars. Applies to slotted avatars without their
+   * own `size`, and to the "+N" overflow chip.
+   * @type {"sm" | "md" | "lg" | "xl"}
+   */
+  export let size = "md";
+
+  /**
+   * Specify the tooltip text for the "+N" overflow avatar. Defaults to a
+   * comma-separated list of hidden slotted `name` values. Set this when using
+   * `total` for people who are not mounted.
+   * @type {string}
+   */
+  export let overflowTooltipText = undefined;
+
+  import { setContext } from "svelte";
+  import { writable } from "svelte/store";
+  import Stack from "../Stack/Stack.svelte";
+  import UserAvatarGroupOverflow from "./UserAvatarGroupOverflow.svelte";
+
+  /** @type {import("svelte/store").Writable<Array<{ id: string; name: string; node?: HTMLElement }>>} */
+  const items = writable([]);
+  const maxStore = writable(0);
+  const sizeStore = writable(size);
+  // Tracks which avatar's tooltip is open so only one shows at a time. Scoped
+  // per group instance.
+  /** @type {import("svelte/store").Writable<string | null>} */
+  const activeTooltip = writable(null);
+
+  function isNegativeGap(value) {
+    return typeof value === "string" && value.trim().startsWith("-");
+  }
+
+  // `max` of 0 (or non-positive) means "no limit"; mirror that as 0 in the
+  // store so registered avatars never mark themselves as overflow.
+  $: hasLimit = Number.isFinite(max) && max > 0;
+  $: maxStore.set(hasLimit ? max : 0);
+  $: sizeStore.set(size);
+
+  // Avatars register in mount order, which differs from DOM order when they are
+  // conditionally rendered. Each registers from its own `onMount`, so its node
+  // is already in the DOM; sort the registry by document position right then to
+  // keep the visible avatars and overflow names tracking the rendered layout.
+  // This stays synchronous (no `afterUpdate`) so the order is correct in the
+  // same flush, across Svelte versions.
+  function sortByDomOrder(list) {
+    return [...list].sort((a, b) => {
+      if (!a.node || !b.node) return 0;
+      const position = a.node.compareDocumentPosition(b.node);
+      if (position & Node.DOCUMENT_POSITION_FOLLOWING) return -1;
+      if (position & Node.DOCUMENT_POSITION_PRECEDING) return 1;
+      return 0;
+    });
+  }
+
+  setContext("carbon:UserAvatarGroup", {
+    items,
+    max: maxStore,
+    size: sizeStore,
+    activeTooltip,
+    register: ({ id, name, node }) => {
+      items.update((current) =>
+        current.some((item) => item.id === id)
+          ? current
+          : sortByDomOrder([...current, { id, name, node }]),
+      );
+    },
+    unregister: (id) => {
+      items.update((current) => current.filter((item) => item.id !== id));
+    },
+    updateName: (id, name) => {
+      items.update((current) =>
+        current.map((item) => (item.id === id ? { ...item, name } : item)),
+      );
+    },
+  });
+
+  // Number of avatars actually shown: capped at `max` unless `max` is 0.
+  $: visibleCount = hasLimit ? Math.min($items.length, max) : $items.length;
+  // The total represented; defaults to the slotted count. Overflow is everyone
+  // past the visible slots, including people not rendered when `total` is set.
+  $: effectiveTotal = total ?? $items.length;
+  $: overflowCount = Math.max(0, effectiveTotal - visibleCount);
+  // Cap the label so it always fits the circle; counts above 99 read as "99+".
+  $: overflowLabel = overflowCount > 99 ? "99+" : `+${overflowCount}`;
+  // Names are known only for the slotted avatars past the visible ones.
+  $: hiddenNames = $items
+    .slice(visibleCount)
+    .map((item) => item.name)
+    .filter(Boolean);
+  $: overflowTooltip = overflowTooltipText ?? hiddenNames.join(", ");
+
+  // Overlap (stacked) when no gap is set, or when a negative gap tightens the
+  // stack; a positive gap switches to a spaced row.
+  $: overlap = gap == null || isNegativeGap(gap);
+  // A negative gap overrides the default overlap amount via a custom property.
+  $: groupStyle =
+    [
+      isNegativeGap(gap) && `--user-avatar-group-overlap: ${gap}`,
+      $$restProps.style,
+    ]
+      .filter(Boolean)
+      .join("; ") || undefined;
+
+  $: groupClass = [
+    "bx--user-avatar-group",
+    overlap && "bx--user-avatar-group--overlap",
+    $$restProps.class,
+  ]
+    .filter(Boolean)
+    .join(" ");
+</script>
+
+<Stack
+  orientation="horizontal"
+  gap={overlap ? 0 : gap}
+  {...$$restProps}
+  class={groupClass}
+  style={groupStyle}
+>
+  <slot />
+  {#if overflowCount > 0}
+    <UserAvatarGroupOverflow label={overflowLabel} names={overflowTooltip} />
+  {/if}
+</Stack>

--- a/src/UserAvatarGroup/UserAvatarGroupOverflow.svelte
+++ b/src/UserAvatarGroup/UserAvatarGroupOverflow.svelte
@@ -1,0 +1,37 @@
+<script>
+  /**
+   * Internal "+N" overflow avatar for `UserAvatarGroup`. Shadows the group
+   * context so the inner `UserAvatar` does not register as a group item.
+   */
+
+  /** @type {string} */
+  export let label;
+
+  /** @type {string} */
+  export let names = "";
+
+  import { getContext, setContext } from "svelte";
+  import { readable } from "svelte/store";
+  import UserAvatar from "../UserAvatar/UserAvatar.svelte";
+
+  const parent = getContext("carbon:UserAvatarGroup");
+
+  // Opt out of registration and overflow (empty items/max, no-op register) so
+  // the chip is never counted or hidden, but keep sharing the parent's
+  // `activeTooltip` and `size` so the chip coordinates with the avatars.
+  setContext("carbon:UserAvatarGroup", {
+    items: readable([]),
+    max: readable(0),
+    size: parent?.size ?? readable(undefined),
+    activeTooltip: parent?.activeTooltip ?? readable(null),
+    register: () => {},
+    unregister: () => {},
+    updateName: () => {},
+  });
+</script>
+
+<UserAvatar
+  class="bx--user-avatar-group__overflow"
+  initials={label}
+  tooltipText={names}
+/>

--- a/src/UserAvatarGroup/index.js
+++ b/src/UserAvatarGroup/index.js
@@ -1,0 +1,1 @@
+export { default as UserAvatarGroup } from "./UserAvatarGroup.svelte";

--- a/src/index.js
+++ b/src/index.js
@@ -216,6 +216,7 @@ export { default as SideNavMenuItem } from "./UIShell/SideNavMenuItem.svelte";
 export { default as SkipToContent } from "./UIShell/SkipToContent.svelte";
 export { default as UnorderedList } from "./UnorderedList/UnorderedList.svelte";
 export { default as UserAvatar } from "./UserAvatar/UserAvatar.svelte";
+export { default as UserAvatarGroup } from "./UserAvatarGroup/UserAvatarGroup.svelte";
 export {
   filterTreeById,
   filterTreeByText,

--- a/src/utils/avatarColor.d.ts
+++ b/src/utils/avatarColor.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Chromatic `UserAvatar` background colors for auto mode. Grays are left out.
+ */
+export const AVATAR_BACKGROUND_COLORS: ReadonlyArray<
+  "red" | "magenta" | "purple" | "blue" | "cyan" | "teal" | "green"
+>;
+
+/**
+ * Hash a string to a non-negative 32-bit integer (djb2). Same string in, same hash out.
+ */
+export function hashString(value: string): number;
+
+/**
+ * Pick a stable avatar background color from a string. Empty or falsy input
+ * returns the first palette entry.
+ */
+export function getAvatarBackgroundColor<
+  T extends string = (typeof AVATAR_BACKGROUND_COLORS)[number],
+>(value: string | null | undefined, palette?: ReadonlyArray<T>): T;

--- a/src/utils/avatarColor.js
+++ b/src/utils/avatarColor.js
@@ -1,0 +1,50 @@
+// @ts-check
+// Pick a stable avatar background color from a name or id. Same string, same color.
+
+/**
+ * Chromatic `UserAvatar` background colors for auto mode. Grays are left out.
+ * Each entry is a valid `UserAvatar` `backgroundColor` value.
+ * @type {ReadonlyArray<"red" | "magenta" | "purple" | "blue" | "cyan" | "teal" | "green">}
+ */
+export const AVATAR_BACKGROUND_COLORS = [
+  "red",
+  "magenta",
+  "purple",
+  "blue",
+  "cyan",
+  "teal",
+  "green",
+];
+
+/**
+ * Hash a string to a non-negative 32-bit integer (djb2). Same string in, same hash out.
+ *
+ * @param {string} value
+ * @returns {number}
+ */
+export function hashString(value) {
+  let hash = 5381;
+  for (let i = 0; i < value.length; i++) {
+    // hash * 33 + charCode, kept within 32-bit range via `| 0`.
+    hash = (hash * 33) ^ value.charCodeAt(i);
+  }
+  // Coerce to an unsigned 32-bit integer.
+  return hash >>> 0;
+}
+
+/**
+ * Pick a stable avatar background color from a string. Empty or falsy input
+ * returns the first palette entry.
+ *
+ * @template {string} [T=AVATAR_BACKGROUND_COLORS[number]]
+ * @param {string | null | undefined} value
+ * @param {ReadonlyArray<T>} [palette]
+ * @returns {T}
+ */
+export function getAvatarBackgroundColor(
+  value,
+  palette = /** @type {ReadonlyArray<T>} */ (AVATAR_BACKGROUND_COLORS),
+) {
+  if (!value || palette.length === 0) return palette[0];
+  return palette[hashString(value) % palette.length];
+}

--- a/tests/UserAvatar/UserAvatar.test.svelte
+++ b/tests/UserAvatar/UserAvatar.test.svelte
@@ -30,6 +30,10 @@
   name="John Doe"
 />
 
+<UserAvatar data-testid="color-auto" backgroundColor="auto" name="John Doe" />
+
+<UserAvatar data-testid="color-auto-2" backgroundColor="auto" name="John Doe" />
+
 <UserAvatar data-testid="tooltip" name="Jane Roe" tooltipText="Jane Roe" />
 
 <UserAvatar

--- a/tests/UserAvatar/UserAvatar.test.ts
+++ b/tests/UserAvatar/UserAvatar.test.ts
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/svelte";
 import type UserAvatarComponent from "carbon-components-svelte/UserAvatar/UserAvatar.svelte";
 import type { ComponentProps } from "svelte";
+import { getAvatarBackgroundColor } from "../../src/utils/avatarColor.js";
 import { user } from "../utils/user";
 import UserAvatar from "./UserAvatar.test.svelte";
 
@@ -73,6 +74,15 @@ describe("UserAvatar", () => {
     expect(screen.getByTestId("color-cool-gray")).toHaveClass(
       "bx--user-avatar--cool-gray",
     );
+  });
+
+  it('picks a stable background color when backgroundColor is "auto"', () => {
+    render(UserAvatar);
+
+    const expected = `bx--user-avatar--${getAvatarBackgroundColor("John Doe")}`;
+    expect(screen.getByTestId("color-auto")).toHaveClass(expected);
+    // Same name resolves to the same color.
+    expect(screen.getByTestId("color-auto-2")).toHaveClass(expected);
   });
 
   it("wraps the avatar in a floating-portal tooltip by default", () => {

--- a/tests/UserAvatarGroup/UserAvatarGroup.test.svelte
+++ b/tests/UserAvatarGroup/UserAvatarGroup.test.svelte
@@ -1,0 +1,89 @@
+<script lang="ts">
+  import UserAvatar from "carbon-components-svelte/UserAvatar/UserAvatar.svelte";
+  import UserAvatarGroup from "carbon-components-svelte/UserAvatarGroup/UserAvatarGroup.svelte";
+
+  // Toggles a leading avatar to exercise DOM-order resync: the avatar mounts
+  // last but renders first.
+  let showLead = false;
+</script>
+
+<div data-testid="under-max">
+  <UserAvatarGroup max={5}>
+    <UserAvatar name="Monica" />
+    <UserAvatar name="Richard Hendricks" />
+    <UserAvatar name="Dinesh Chugtai" />
+  </UserAvatarGroup>
+</div>
+
+<div data-testid="overflow">
+  <UserAvatarGroup max={2}>
+    <UserAvatar name="Monica" />
+    <UserAvatar name="Richard Hendricks" />
+    <UserAvatar name="Dinesh Chugtai" />
+    <UserAvatar name="Bertram Gilfoyle" />
+  </UserAvatarGroup>
+</div>
+
+<div data-testid="no-limit">
+  <UserAvatarGroup max={0}>
+    <UserAvatar name="Monica" />
+    <UserAvatar name="Richard Hendricks" />
+    <UserAvatar name="Dinesh Chugtai" />
+  </UserAvatarGroup>
+</div>
+
+<div data-testid="spaced">
+  <UserAvatarGroup gap={3}>
+    <UserAvatar name="Monica" />
+    <UserAvatar name="Richard Hendricks" />
+  </UserAvatarGroup>
+</div>
+
+<div data-testid="tighter">
+  <UserAvatarGroup gap="-1rem">
+    <UserAvatar name="Monica" />
+    <UserAvatar name="Richard Hendricks" />
+  </UserAvatarGroup>
+</div>
+
+<div data-testid="total">
+  <UserAvatarGroup max={3} total={250}>
+    <UserAvatar name="Monica" />
+    <UserAvatar name="Richard Hendricks" />
+    <UserAvatar name="Dinesh Chugtai" />
+  </UserAvatarGroup>
+</div>
+
+<div data-testid="overflow-tooltip">
+  <UserAvatarGroup
+    max={1}
+    total={10}
+    overflowTooltipText="Gilfoyle, Jared, and 8 others"
+  >
+    <UserAvatar name="Monica" />
+  </UserAvatarGroup>
+</div>
+
+<div data-testid="cascade">
+  <UserAvatarGroup size="lg" max={1}>
+    <UserAvatar name="Monica" />
+    <UserAvatar name="Richard Hendricks" size="sm" />
+  </UserAvatarGroup>
+</div>
+
+<button
+  type="button"
+  data-testid="toggle-lead"
+  on:click={() => (showLead = !showLead)}
+>
+  toggle
+</button>
+<div data-testid="resync">
+  <UserAvatarGroup max={1}>
+    {#if showLead}
+      <UserAvatar name="Alice" initials="A1" />
+    {/if}
+    <UserAvatar name="Bob" initials="B2" />
+    <UserAvatar name="Cara" initials="C3" />
+  </UserAvatarGroup>
+</div>

--- a/tests/UserAvatarGroup/UserAvatarGroup.test.ts
+++ b/tests/UserAvatarGroup/UserAvatarGroup.test.ts
@@ -1,0 +1,142 @@
+import { render, screen, waitFor } from "@testing-library/svelte";
+import { user } from "../utils/user";
+import UserAvatarGroup from "./UserAvatarGroup.test.svelte";
+
+function groupRoot(testId: string): HTMLElement {
+  const root = screen
+    .getByTestId(testId)
+    .querySelector<HTMLElement>(".bx--user-avatar-group");
+  assert(root);
+  return root;
+}
+
+// The single visible (non-overflow, non-chip) avatar in a `max={1}` group.
+function visibleAvatar(root: HTMLElement): HTMLElement {
+  const avatar = root.querySelector<HTMLElement>(
+    '.bx--user-avatar:not([data-overflow="true"]):not(.bx--user-avatar-group__overflow)',
+  );
+  assert(avatar);
+  return avatar;
+}
+
+describe("UserAvatarGroup", () => {
+  it("renders every avatar and no overflow when under max", () => {
+    render(UserAvatarGroup);
+
+    const root = groupRoot("under-max");
+    expect(root.querySelectorAll(".bx--user-avatar")).toHaveLength(3);
+    expect(root.querySelectorAll('[data-overflow="true"]')).toHaveLength(0);
+    expect(root).not.toHaveTextContent("+");
+  });
+
+  it("applies the overlap modifier by default", () => {
+    render(UserAvatarGroup);
+
+    expect(groupRoot("under-max")).toHaveClass(
+      "bx--user-avatar-group--overlap",
+    );
+  });
+
+  it("hides avatars past max and renders a +N overflow avatar", () => {
+    render(UserAvatarGroup);
+
+    const root = groupRoot("overflow");
+    // Two of the four slotted avatars are hidden as overflow.
+    expect(root.querySelectorAll('[data-overflow="true"]')).toHaveLength(2);
+    // The overflow avatar shows the hidden count.
+    expect(root).toHaveTextContent("+2");
+    expect(
+      root.querySelector(".bx--user-avatar-group__overflow"),
+    ).toBeInTheDocument();
+  });
+
+  it("treats max of 0 as no limit", () => {
+    render(UserAvatarGroup);
+
+    const root = groupRoot("no-limit");
+    expect(root.querySelectorAll('[data-overflow="true"]')).toHaveLength(0);
+    expect(root).not.toHaveTextContent("+");
+  });
+
+  it("spaces avatars apart when a gap is set", () => {
+    render(UserAvatarGroup);
+
+    const root = groupRoot("spaced");
+    expect(root).not.toHaveClass("bx--user-avatar-group--overlap");
+    expect(root).toHaveClass("bx--stack-scale-3");
+  });
+
+  it("tightens the overlap with a negative gap", () => {
+    render(UserAvatarGroup);
+
+    const root = groupRoot("tighter");
+    expect(root).toHaveClass("bx--user-avatar-group--overlap");
+    expect(root.style.getPropertyValue("--user-avatar-group-overlap")).toBe(
+      "-1rem",
+    );
+  });
+
+  it("uses total for the overflow without rendering the hidden avatars", () => {
+    render(UserAvatarGroup);
+
+    const root = groupRoot("total");
+    // Only the three slotted avatars render (plus the overflow avatar); the
+    // other 247 are never created.
+    expect(root.querySelectorAll(".bx--user-avatar")).toHaveLength(4);
+    expect(root.querySelectorAll('[data-overflow="true"]')).toHaveLength(0);
+    // 250 total - 3 shown = 247, capped at 99+.
+    expect(
+      root.querySelector(".bx--user-avatar-group__overflow"),
+    ).toHaveTextContent("99+");
+  });
+
+  it("cascades its size to avatars that do not set their own", () => {
+    render(UserAvatarGroup);
+
+    const root = groupRoot("cascade");
+    // First avatar inherits the group size; the second keeps its own.
+    expect(visibleAvatar(root)).toHaveClass("bx--user-avatar--lg");
+    expect(root.querySelector('[data-overflow="true"]')).toHaveClass(
+      "bx--user-avatar--sm",
+    );
+    // The overflow avatar is sized by the group too.
+    expect(root.querySelector(".bx--user-avatar-group__overflow")).toHaveClass(
+      "bx--user-avatar--lg",
+    );
+  });
+
+  it("uses overflowTooltipText for the overflow chip tooltip", async () => {
+    render(UserAvatarGroup);
+
+    const overflow = groupRoot("overflow-tooltip").querySelector(
+      ".bx--user-avatar-group__overflow",
+    );
+    assert(overflow);
+
+    await user.hover(overflow);
+
+    await waitFor(() => {
+      expect(screen.getByRole("tooltip")).toHaveTextContent(
+        "Gilfoyle, Jared, and 8 others",
+      );
+    });
+  });
+
+  it("re-sorts to DOM order when an avatar is inserted ahead of others", async () => {
+    render(UserAvatarGroup);
+
+    const root = groupRoot("resync");
+    // Only Bob and Cara are mounted; Bob is the single visible avatar.
+    expect(visibleAvatar(root)).toHaveTextContent("B2");
+    expect(root).toHaveTextContent("+1");
+
+    // Insert Alice ahead of Bob. She mounts last but renders first, so the
+    // group must re-sort to keep her visible instead of Bob.
+    await user.click(screen.getByTestId("toggle-lead"));
+
+    await waitFor(() => {
+      expect(visibleAvatar(root)).toHaveTextContent("A1");
+    });
+    expect(root).toHaveTextContent("+2");
+  });
+});

--- a/tests/utils/avatarColor.test.ts
+++ b/tests/utils/avatarColor.test.ts
@@ -1,0 +1,66 @@
+import {
+  AVATAR_BACKGROUND_COLORS,
+  getAvatarBackgroundColor,
+  hashString,
+} from "../../src/utils/avatarColor.js";
+
+describe("hashString", () => {
+  test("is deterministic for the same input", () => {
+    expect(hashString("Richard Hendricks")).toBe(
+      hashString("Richard Hendricks"),
+    );
+  });
+
+  test("returns a non-negative integer", () => {
+    for (const value of ["", "a", "Jane Roe", "🚀"]) {
+      const hash = hashString(value);
+      expect(Number.isInteger(hash)).toBe(true);
+      expect(hash).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  test("differs for different inputs", () => {
+    expect(hashString("Monica")).not.toBe(hashString("Richard"));
+  });
+});
+
+describe("getAvatarBackgroundColor", () => {
+  test("maps the same input to the same color", () => {
+    expect(getAvatarBackgroundColor("Jane Roe")).toBe(
+      getAvatarBackgroundColor("Jane Roe"),
+    );
+  });
+
+  test("returns a color from the default palette", () => {
+    expect(AVATAR_BACKGROUND_COLORS).toContain(
+      getAvatarBackgroundColor("Richard Hendricks"),
+    );
+  });
+
+  test("distributes varied inputs across more than one color", () => {
+    const names = [
+      "Monica",
+      "Richard",
+      "Dinesh",
+      "Gilfoyle",
+      "Jared",
+      "Erlich",
+    ];
+    const colors = new Set(names.map((name) => getAvatarBackgroundColor(name)));
+    expect(colors.size).toBeGreaterThan(1);
+  });
+
+  test("returns the first palette entry for empty or nullish input", () => {
+    expect(getAvatarBackgroundColor("")).toBe(AVATAR_BACKGROUND_COLORS[0]);
+    expect(getAvatarBackgroundColor(null)).toBe(AVATAR_BACKGROUND_COLORS[0]);
+    expect(getAvatarBackgroundColor(undefined)).toBe(
+      AVATAR_BACKGROUND_COLORS[0],
+    );
+  });
+
+  test("supports a custom palette", () => {
+    const palette = ["one", "two"] as const;
+    const color = getAvatarBackgroundColor("anything", palette);
+    expect(palette).toContain(color);
+  });
+});


### PR DESCRIPTION
Adds `UserAvatarGroup` for overlapping or spaced avatar rows with a "+N" overflow chip, plus `backgroundColor="auto"` on `UserAvatar` to pick a stable color from a name via the internal `avatarColor` hash util. Use it for project members on a card, assignee stacks on work items, or comment threads where you render three faces and set `total` for everyone on the issue. Large groups can pass `total` without mounting every avatar; tooltips hand off as you move across the stack.

<img width="738" height="423" alt="Screenshot 2026-06-28 at 3 25 33 PM" src="https://github.com/user-attachments/assets/39e5bd44-087a-40a4-8ce8-10051333dd1f" />
