### PR TITLE
feat: CopyButton ghost kind, sizes, and tooltip placement

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,9 +149,9 @@ Reference [`ComboBox.svelte`](src/ComboBox/ComboBox.svelte) for `@template`, `@t
 ```js
 /**
  * Specify the size of the component
- * @type {"sm" | "default" | "lg"}
+ * @type {"sm" | "md" | "lg"}
  */
-export let size = "default";
+export let size = "md";
 ```
 
 #### After changing a component's API

--- a/css/_copy-button.scss
+++ b/css/_copy-button.scss
@@ -1,0 +1,68 @@
+// CopyButton variants: a `ghost` kind and a set of square sizes that mirror
+// `Button`. Carbon ships a single, fixed-size `bx--copy-btn` (a 2.5rem square
+// with a `$layer` fill), so these modifiers extend it to match the `Button`
+// API. The ghost kind reuses Button's ghost theme (transparent fill, subtle
+// hover) so a CopyButton can sit beside a ghost Button without a seam; the
+// sizes scale the square to Button's small/lg/xl heights.
+//
+// Loaded after Carbon's base styles (see all.scss), so each modifier is
+// double-classed to win at equal specificity against the base `bx--copy-btn`
+// declarations it overrides.
+
+@import "carbon-components/scss/globals/scss/vars";
+@import "carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/import-once/import-once";
+
+/// CopyButton ghost kind and square sizes.
+/// @access private
+/// @group copy-button
+@mixin copy-button {
+  //--------------------------------------------------------------------------
+  // Ghost kind (mirrors Button's ghost theme)
+  //--------------------------------------------------------------------------
+  .#{$prefix}--copy-btn.#{$prefix}--copy-btn--ghost {
+    background-color: transparent;
+  }
+
+  .#{$prefix}--copy-btn.#{$prefix}--copy-btn--ghost:hover {
+    background-color: $hover-ui;
+  }
+
+  .#{$prefix}--copy-btn.#{$prefix}--copy-btn--ghost:active {
+    background-color: $active-ui;
+  }
+
+  .#{$prefix}--copy-btn.#{$prefix}--copy-btn--ghost .#{$prefix}--snippet__icon {
+    fill: $icon-01;
+  }
+
+  //--------------------------------------------------------------------------
+  // Sizes (square dimensions matching Button's small/lg/xl heights;
+  // `default` keeps Carbon's native 2.5rem)
+  //--------------------------------------------------------------------------
+  .#{$prefix}--copy-btn.#{$prefix}--copy-btn--sm {
+    width: 2rem;
+    height: 2rem;
+  }
+
+  .#{$prefix}--copy-btn.#{$prefix}--copy-btn--lg {
+    width: 3rem;
+    height: 3rem;
+  }
+
+  .#{$prefix}--copy-btn.#{$prefix}--copy-btn--xl {
+    width: 4rem;
+    height: 4rem;
+  }
+
+  // Grow the icon on the larger squares so it stays visually centered rather
+  // than marooned in whitespace.
+  .#{$prefix}--copy-btn.#{$prefix}--copy-btn--lg .#{$prefix}--snippet__icon,
+  .#{$prefix}--copy-btn.#{$prefix}--copy-btn--xl .#{$prefix}--snippet__icon {
+    width: 1.25rem;
+    height: 1.25rem;
+  }
+}
+
+@include exports("copy-button-variants") {
+  @include copy-button;
+}

--- a/css/_tooltip.scss
+++ b/css/_tooltip.scss
@@ -40,15 +40,23 @@
     align-self: flex-end;
   }
 
+  // `start`: offset the caret from the box's left edge.
   [data-floating-portal][data-floating-direction='top'][data-floating-intrinsic-align='start']
     .#{$prefix}--tooltip-portal__caret,
   [data-floating-portal][data-floating-direction='bottom'][data-floating-intrinsic-align='start']
-    .#{$prefix}--tooltip-portal__caret,
+    .#{$prefix}--tooltip-portal__caret {
+    margin-left: calc(var(--ccs-tooltip-caret-nudge) - 0.3125rem);
+  }
+
+  // `end`: offset the caret from the box's right edge. The nudge is the anchor
+  // half-width, so the caret stays centered on the trigger regardless of the
+  // tooltip width (no movement when the text swaps to the copy feedback).
   [data-floating-portal][data-floating-direction='top'][data-floating-intrinsic-align='end']
     .#{$prefix}--tooltip-portal__caret,
   [data-floating-portal][data-floating-direction='bottom'][data-floating-intrinsic-align='end']
     .#{$prefix}--tooltip-portal__caret {
-    margin-left: calc(var(--ccs-tooltip-caret-nudge) - 0.3125rem);
+    align-self: flex-end;
+    margin-right: calc(var(--ccs-tooltip-caret-nudge) - 0.3125rem);
   }
 
   [data-floating-portal][data-floating-direction='right'] .#{$prefix}--tooltip-portal {

--- a/css/all.scss
+++ b/css/all.scss
@@ -105,6 +105,7 @@ $css--plex: true;
 @import "./fluid-date-picker";
 @import "./time-picker";
 @import "./copy-button-portal";
+@import "./copy-button";
 @import "./copy-input";
 @import "./overflow-menu";
 @import "./list-box-menu-item";

--- a/css/g10.scss
+++ b/css/g10.scss
@@ -65,6 +65,7 @@ $css--plex: true;
 @import "./fluid-date-picker";
 @import "./time-picker";
 @import "./copy-button-portal";
+@import "./copy-button";
 @import "./copy-input";
 @import "./overflow-menu";
 @import "./list-box-menu-item";

--- a/css/g100.scss
+++ b/css/g100.scss
@@ -65,6 +65,7 @@ $css--plex: true;
 @import "./fluid-date-picker";
 @import "./time-picker";
 @import "./copy-button-portal";
+@import "./copy-button";
 @import "./copy-input";
 @import "./overflow-menu";
 @import "./list-box-menu-item";

--- a/css/g80.scss
+++ b/css/g80.scss
@@ -65,6 +65,7 @@ $css--plex: true;
 @import "./fluid-date-picker";
 @import "./time-picker";
 @import "./copy-button-portal";
+@import "./copy-button";
 @import "./copy-input";
 @import "./overflow-menu";
 @import "./list-box-menu-item";

--- a/css/g90.scss
+++ b/css/g90.scss
@@ -65,6 +65,7 @@ $css--plex: true;
 @import "./fluid-date-picker";
 @import "./time-picker";
 @import "./copy-button-portal";
+@import "./copy-button";
 @import "./copy-input";
 @import "./overflow-menu";
 @import "./list-box-menu-item";

--- a/css/white.scss
+++ b/css/white.scss
@@ -65,6 +65,7 @@ $css--plex: true;
 @import "./fluid-date-picker";
 @import "./time-picker";
 @import "./copy-button-portal";
+@import "./copy-button";
 @import "./copy-input";
 @import "./overflow-menu";
 @import "./list-box-menu-item";

--- a/docs/src/components/ComponentDocBarActions.svelte
+++ b/docs/src/components/ComponentDocBarActions.svelte
@@ -56,12 +56,12 @@
     <Link icon={ArrowUpRight} href={markdownUrl} target="_blank">
       Markdown
     </Link>
-    <div>
+    <div class="bar-actions__group">
       <CopyMarkdownButton
         name={component}
         href={markdownUrl}
         bytes={markdownBytes}
-        size="small"
+        size="sm"
         tooltipPosition="bottom"
       />
       <Button
@@ -101,6 +101,11 @@
 </div>
 
 <style>
+  .bar-actions__group {
+    display: flex;
+    align-items: center;
+  }
+
   .bar-actions--mobile {
     display: none;
   }

--- a/docs/src/components/CopyMarkdownButton.svelte
+++ b/docs/src/components/CopyMarkdownButton.svelte
@@ -1,9 +1,6 @@
 <script lang="ts">
-  import { Button } from "carbon-components-svelte";
-  import { createCopyFeedbackState } from "carbon-components-svelte/src/utils/copyFeedback.js";
+  import { CopyButton } from "carbon-components-svelte";
   import Checkmark from "carbon-icons-svelte/lib/Checkmark.svelte";
-  import Copy from "carbon-icons-svelte/lib/Copy.svelte";
-  import { onMount } from "svelte";
   import {
     copyComponentMarkdown,
     formatCopyIconDescription,
@@ -15,57 +12,27 @@
   export let href: string;
   /** Markdown size in bytes; shown as size/token estimate in the tooltip. */
   export let bytes = 0;
-  export let size: "default" | "field" | "small" | "lg" | "xl" = "field";
+  export let size: "sm" | "md" | "lg" | "xl" = "md";
   export let tooltipPosition: "top" | "right" | "bottom" | "left" = "bottom";
-  /** Portalled tooltips avoid clipping and support multi-line copy labels. */
-  export let portalTooltip = true;
-
-  let copied = false;
-  let copying = false;
-  let buttonRef: HTMLButtonElement | null = null;
-
-  const copyFeedback = createCopyFeedbackState(() => {
-    const wasCopied = copied;
-    copied = copyFeedback.feedbackOpen;
-    copying = copyFeedback.copyPending;
-    if (wasCopied && !copied) buttonRef?.blur();
-  });
 
   async function copyMarkdown() {
-    await copyFeedback.onClick(
-      async () => {
-        const ok = await copyComponentMarkdown(name, href);
-        if (!ok) throw new Error("Failed to copy markdown");
-      },
-      2000,
-      portalTooltip,
-    );
+    const ok = await copyComponentMarkdown(name, href);
+    if (!ok) throw new Error("Failed to copy markdown");
   }
-
-  onMount(() => copyFeedback.cleanup);
 </script>
 
-<Button
-  bind:ref={buttonRef}
-  class="copy-markdown-btn"
+<CopyButton
   kind="ghost"
   {size}
-  {portalTooltip}
   {tooltipPosition}
-  icon={copied ? Checkmark : Copy}
-  iconDescription={formatCopyIconDescription(copied, bytes)}
-  disabled={copying}
-  on:click={copyMarkdown}
+  copy={copyMarkdown}
+  feedbackIcon={Checkmark}
+  iconDescription={formatCopyIconDescription(false, bytes)}
 />
 
 <style>
-  /* iconDescription embeds a newline (size/token estimate on its own line). */
-  :global(.copy-markdown-btn.bx--tooltip__trigger .bx--assistive-text) {
-    display: block;
-    white-space: pre-line;
-    text-align: center;
-  }
-
+  /* iconDescription embeds a newline (size/token estimate on its own line);
+       applies to the proactive hover tooltip rendered in the floating portal. */
   :global(
     [data-floating-portal]
       .bx--tooltip-portal[data-tooltip-type="icon"]

--- a/docs/src/pages/component-index.svelte
+++ b/docs/src/pages/component-index.svelte
@@ -313,9 +313,8 @@
                             name={entry.name}
                             href={entry.markdownHref}
                             bytes={markdownBytesFor(entry.name)}
-                            size="small"
+                            size="sm"
                             tooltipPosition="right"
-                            portalTooltip
                           />
                         </Stack>
                       </Stack>

--- a/docs/src/pages/components/CopyButton.svx
+++ b/docs/src/pages/components/CopyButton.svx
@@ -23,6 +23,34 @@ Prefetch on hover with `on:mouseenter`.
 
 <FileSource src="/framed/CopyButton/CopyButtonAsync" />
 
+## Ghost kind
+
+Set `kind` to `"ghost"` to render a transparent button that matches a [Button](/components/Button) with `kind="ghost"`. The default `kind` (`"primary"`) keeps Carbon's filled square.
+
+<CopyButton text="Carbon svelte" kind="ghost" />
+
+## Sizes
+
+Set `size` to scale the square. Sizes align with the heights used by [Button](/components/Button).
+
+### Small
+
+<CopyButton text="Carbon svelte" size="sm" />
+
+### Medium
+
+The default size (`md`) matches Carbon's native copy button.
+
+<CopyButton text="Carbon svelte" />
+
+### Large
+
+<CopyButton text="Carbon svelte" size="lg" />
+
+### Extra large
+
+<CopyButton text="Carbon svelte" size="xl" />
+
 ## Custom feedback
 
 Customize the message and icon shown after copying.
@@ -57,14 +85,35 @@ Set `copy` to a no-op function to disable copying.
 
 <CopyButton text="This text should not be copied" copy={() => {}} />
 
+## Hover tooltip
+
+On hover or focus, the button shows a proactive tooltip with the `iconDescription`. It renders in a floating portal so it is never clipped and flips when space is tight.
+
+### Directions
+
+Set `tooltipPosition` to place the tooltip relative to the button.
+
+<CopyButton text="Carbon svelte" iconDescription="Top" tooltipPosition="top" />
+<CopyButton text="Carbon svelte" iconDescription="Right" tooltipPosition="right" />
+<CopyButton text="Carbon svelte" iconDescription="Bottom" tooltipPosition="bottom" />
+<CopyButton text="Carbon svelte" iconDescription="Left" tooltipPosition="left" />
+
+### Alignment
+
+Set `tooltipAlignment` to align the tooltip relative to the button.
+
+<CopyButton text="Carbon svelte" iconDescription="Start" tooltipAlignment="start" />
+<CopyButton text="Carbon svelte" iconDescription="Center" tooltipAlignment="center" />
+<CopyButton text="Carbon svelte" iconDescription="End" tooltipAlignment="end" />
+
 ## Portal tooltip
 
-Set `portalTooltip` to render the feedback tooltip in a portal so it is not clipped by overflow containers. Inside a [Modal](/components/Modal), portalling is enabled by default unless you set `portalTooltip` to false.
+Set `portalTooltip` to render the feedback tooltip in a portal so it is not clipped by `overflow: hidden` containers. It is also portalled automatically inside a [Modal](/components/Modal) or when a non-default `tooltipPosition` or `tooltipAlignment` is set.
 
 <FileSource src="/framed/CopyButton/CopyButtonPortalTooltip" />
 
 ## Inside a modal
 
-When used inside a Modal, the feedback tooltip is automatically portalled so it is not clipped by overflow. Set `portalTooltip` to override this behavior.
+When used inside a [Modal](/components/Modal), the feedback tooltip is automatically portalled so it is not clipped. Set `portalTooltip` to override this behavior.
 
 <FileSource src="/framed/CopyButton/CopyButtonInModal" />

--- a/docs/src/pages/components/CopyInput.svx
+++ b/docs/src/pages/components/CopyInput.svx
@@ -98,6 +98,22 @@ Set `feedbackIcon` to show a different icon while feedback is visible. The copy 
 
 <CopyInput light labelText="API endpoint" value="https://api.example.com/v1" />
 
+## Tooltip
+
+On hover or focus, the copy button shows a tooltip with `iconDescription`. It renders in a floating portal so it is not clipped and flips when space is tight.
+
+### Direction
+
+Set `tooltipPosition` to place the tooltip relative to the copy button. Accepts `"top"`, `"right"`, `"bottom"` (default), and `"left"`.
+
+<CopyInput labelText="API endpoint" value="https://api.example.com/v1" tooltipPosition="left" />
+
+### Alignment
+
+Set `tooltipAlignment` to align the tooltip relative to the copy button. Accepts `"start"`, `"center"` (default), and `"end"`.
+
+<CopyInput labelText="API endpoint" value="https://api.example.com/v1" tooltipAlignment="end" />
+
 ## Portal tooltip
 
 Set `portalTooltip` to render the copy feedback tooltip in a portal so it is not clipped by `overflow: hidden` containers. Inside a [Modal](/components/Modal), portalling is enabled by default unless you set `portalTooltip` to `false`.

--- a/docs/src/pages/framed/CopyButton/CopyButtonOverride.svelte
+++ b/docs/src/pages/framed/CopyButton/CopyButtonOverride.svelte
@@ -3,4 +3,8 @@
   import copy from "clipboard-copy";
 </script>
 
-<CopyButton text="Carbon svelte" copy={(text) => copy(text)} />
+<CopyButton
+  text="Carbon svelte"
+  copy={(text) => copy(text)}
+  tooltipAlignment="start"
+/>

--- a/docs/src/pages/framed/CopyButton/CopyButtonPortalTooltip.svelte
+++ b/docs/src/pages/framed/CopyButton/CopyButtonPortalTooltip.svelte
@@ -6,5 +6,10 @@
   gap={4}
   style="overflow: hidden; border: 1px dashed var(--cds-border-subtle); padding: 1rem; max-height: 120px;"
 >
-  <CopyButton text="Carbon svelte" feedback="Copied!" portalTooltip={true} />
+  <CopyButton
+    text="Carbon svelte"
+    feedback="Copied!"
+    portalTooltip={true}
+    tooltipAlignment="start"
+  />
 </Stack>

--- a/src/CopyButton/CopyButton.svelte
+++ b/src/CopyButton/CopyButton.svelte
@@ -20,6 +20,20 @@
   export let iconDescription = "Copy to clipboard";
 
   /**
+   * Specify the kind of copy button.
+   * Use `"ghost"` to match a `Button` with `kind="ghost"`.
+   * @type {"primary" | "ghost"}
+   */
+  export let kind = "primary";
+
+  /**
+   * Specify the size of the copy button.
+   * `"md"` keeps Carbon's native 2.5rem square; the other sizes match `Button`.
+   * @type {"sm" | "md" | "lg" | "xl"}
+   */
+  export let size = "md";
+
+  /**
    * Specify the text to copy.
    * @type {string}
    */
@@ -38,15 +52,30 @@
   /**
    * Set to `true` to render the feedback tooltip in a portal,
    * preventing it from being clipped by `overflow: hidden` containers.
-   * By default, the tooltip is portalled when inside a `Modal`.
+   * By default, the tooltip is portalled when inside a `Modal` or when a
+   * non-default `tooltipPosition`/`tooltipAlignment` is set.
    * @type {boolean | undefined}
    */
   export let portalTooltip = undefined;
+
+  /**
+   * Set the position of the tooltip relative to the button.
+   * @type {"top" | "right" | "bottom" | "left"}
+   */
+  export let tooltipPosition = "bottom";
+
+  /**
+   * Set the alignment of the tooltip relative to the button.
+   * @type {"start" | "center" | "end"}
+   */
+  export let tooltipAlignment = "center";
 
   /** Obtain a reference to the underlying button element. */
   export let ref = null;
 
   import { createEventDispatcher, getContext, onMount } from "svelte";
+  import { get } from "svelte/store";
+  import { activeButtonTooltip } from "../Button/button-tooltip-store.js";
   import Copy from "../icons/Copy.svelte";
   import PortalTooltip from "../Portal/PortalTooltip.svelte";
   import { observeModalClose } from "../Portal/portal-utils.js";
@@ -71,24 +100,132 @@
     copyPending = copyFeedback.copyPending;
   }
 
+  // Proactive hover/focus tooltip. Reuses the floating-portal `PortalTooltip`
+  // and the shared `activeButtonTooltip` store, so a CopyButton coordinates
+  // with adjacent icon-only Buttons (warm handoff, no overlapping tooltips).
+  // Mirrors Button's portal-tooltip timing.
+  const tooltipId = {};
+  const ENTER_DELAY_MS = 100;
+  const LEAVE_DELAY_MS = 300;
+  let hovered = false;
+  let focused = false;
+  let tooltipTimeout;
+
+  // Feedback shares the proactive tooltip's portal surface whenever the tooltip
+  // is portalled OR a non-default position/alignment is set, so the "Copied!"
+  // state appears in the same place as the hover description (text swaps in
+  // place, no flash). Only the plain default (bottom/center, non-portalled)
+  // keeps Carbon's inline feedback caret.
+  $: tooltipCustomized =
+    tooltipPosition !== "bottom" || tooltipAlignment !== "center";
+  $: feedbackPortalled = effectivePortalTooltip || tooltipCustomized;
+
+  $: showingInlineFeedback =
+    !feedbackPortalled && (feedbackOpen || copyPending);
+  $: tooltipHoverActive =
+    !showingInlineFeedback &&
+    (hovered || focused) &&
+    $activeButtonTooltip === tooltipId;
+  $: feedbackInPortal = feedbackPortalled && feedbackOpen;
+  $: tooltipOpen = tooltipHoverActive || feedbackInPortal;
+  $: tooltipText = feedbackOpen ? feedback : iconDescription;
+
+  function claimTooltip() {
+    activeButtonTooltip.set(tooltipId);
+  }
+
+  function releaseTooltip() {
+    if (get(activeButtonTooltip) === tooltipId) {
+      activeButtonTooltip.set(null);
+    }
+  }
+
+  function handleTooltipMouseEnter() {
+    clearTimeout(tooltipTimeout);
+    // Skip the enter delay when another icon tooltip is already open so moving
+    // between adjacent buttons feels instant.
+    const warmHandoff =
+      get(activeButtonTooltip) !== null &&
+      get(activeButtonTooltip) !== tooltipId;
+    tooltipTimeout = setTimeout(
+      () => {
+        hovered = true;
+        claimTooltip();
+      },
+      warmHandoff ? 0 : ENTER_DELAY_MS,
+    );
+  }
+
+  function handleTooltipMouseLeave() {
+    clearTimeout(tooltipTimeout);
+    tooltipTimeout = setTimeout(() => {
+      hovered = false;
+      if (!focused) releaseTooltip();
+    }, LEAVE_DELAY_MS);
+  }
+
+  function handleTooltipFocus() {
+    focused = true;
+    claimTooltip();
+  }
+
+  function handleTooltipBlur() {
+    focused = false;
+    if (!hovered) releaseTooltip();
+  }
+
+  function dismissTooltip() {
+    clearTimeout(tooltipTimeout);
+    hovered = false;
+    focused = false;
+    releaseTooltip();
+  }
+
+  // Caret spacing + alignment nudges, mirroring Button's icon tooltip.
+  const PORTAL_HORIZONTAL_GAP_PX = 2;
+  const PORTAL_VERTICAL_GAP_PX = 1;
+  const PORTAL_VERTICAL_ALIGN_OFFSET_LEFT_START_PX = -3;
+  const PORTAL_VERTICAL_ALIGN_OFFSET_RIGHT_END_PX = 1;
+
+  $: tooltipHorizontal =
+    tooltipPosition === "left" || tooltipPosition === "right";
+  $: tooltipVertical =
+    tooltipPosition === "top" || tooltipPosition === "bottom";
+  $: portalHorizontalGapLeft = tooltipHorizontal ? PORTAL_HORIZONTAL_GAP_PX : 0;
+  $: portalHorizontalGapRight = tooltipHorizontal
+    ? PORTAL_HORIZONTAL_GAP_PX
+    : 0;
+  $: portalGapTop = tooltipVertical ? PORTAL_VERTICAL_GAP_PX : 0;
+  $: portalGapBottom = tooltipVertical ? PORTAL_VERTICAL_GAP_PX : 0;
+  $: portalVerticalAlignOffsetLeft =
+    tooltipPosition === "left" && tooltipAlignment === "start"
+      ? PORTAL_VERTICAL_ALIGN_OFFSET_LEFT_START_PX
+      : 0;
+  $: portalVerticalAlignOffsetRight =
+    tooltipPosition === "right" && tooltipAlignment === "end"
+      ? PORTAL_VERTICAL_ALIGN_OFFSET_RIGHT_END_PX
+      : 0;
+
   function dismissFeedback() {
     copyFeedback.dismiss();
+    dismissTooltip();
   }
 
   let disconnectModalObserver = () => {};
 
   $: {
     disconnectModalObserver();
-    disconnectModalObserver =
-      effectivePortalTooltip && ref
-        ? observeModalClose(ref, dismissFeedback)
-        : () => {};
+    disconnectModalObserver = ref
+      ? observeModalClose(ref, dismissFeedback)
+      : () => {};
   }
 
   onMount(() => {
     return () => {
       copyFeedback.cleanup();
       disconnectModalObserver();
+      clearTimeout(tooltipTimeout);
+      releaseTooltip();
     };
   });
 </script>
@@ -103,9 +240,12 @@
   class:bx--copy-btn--animating={animation}
   class:bx--copy-btn--fade-in={animation === "fade-in"}
   class:bx--copy-btn--fade-out={animation === "fade-out"}
-  class:bx--copy-btn--portal-active={effectivePortalTooltip}
+  class:bx--copy-btn--portal-active={feedbackPortalled}
+  class:bx--copy-btn--ghost={kind === "ghost"}
+  class:bx--copy-btn--sm={size === "sm"}
+  class:bx--copy-btn--lg={size === "lg"}
+  class:bx--copy-btn--xl={size === "xl"}
   aria-label={iconDescription}
-  title={iconDescription}
   {...$$restProps}
   on:click
   on:click={async () => {
@@ -115,7 +255,7 @@
           await copy(text ?? "");
           dispatch("copy");
         }
-      }, feedbackTimeout, effectivePortalTooltip);
+      }, feedbackTimeout, feedbackPortalled);
     } catch (error) {
       dispatch("copy:error", { error });
     }
@@ -125,16 +265,20 @@
     copyFeedback.onAnimationEnd(event);
   }}
   on:mouseenter
+  on:mouseenter={handleTooltipMouseEnter}
   on:mouseleave
+  on:mouseleave={handleTooltipMouseLeave}
   on:focus
+  on:focus={handleTooltipFocus}
   on:blur
+  on:blur={handleTooltipBlur}
 >
   {#if feedbackIcon && feedbackOpen}
     <svelte:component this={feedbackIcon} class="bx--snippet__icon" />
   {:else}
     <Copy class="bx--snippet__icon" />
   {/if}
-  {#if !effectivePortalTooltip}
+  {#if !feedbackPortalled}
     <span
       aria-hidden="true"
       class:bx--assistive-text={true}
@@ -145,6 +289,19 @@
   {/if}
 </button>
 
-{#if effectivePortalTooltip}
-  <PortalTooltip anchor={ref} open={feedbackOpen} text={feedback} />
+{#if ref}
+  <PortalTooltip
+    anchor={ref}
+    open={tooltipOpen}
+    text={tooltipText}
+    tooltipType="icon"
+    direction={tooltipPosition}
+    intrinsicAlign={tooltipAlignment}
+    horizontalGapLeft={portalHorizontalGapLeft}
+    horizontalGapRight={portalHorizontalGapRight}
+    gapTop={portalGapTop}
+    gapBottom={portalGapBottom}
+    verticalAlignOffsetLeft={portalVerticalAlignOffsetLeft}
+    verticalAlignOffsetRight={portalVerticalAlignOffsetRight}
+  />
 {/if}

--- a/src/CopyInput/CopyInput.svelte
+++ b/src/CopyInput/CopyInput.svelte
@@ -113,6 +113,18 @@
    */
   export let portalTooltip = undefined;
 
+  /**
+   * Set the position of the copy button's tooltip.
+   * @type {"top" | "right" | "bottom" | "left"}
+   */
+  export let tooltipPosition = "bottom";
+
+  /**
+   * Set the alignment of the copy button's tooltip.
+   * @type {"start" | "center" | "end"}
+   */
+  export let tooltipAlignment = "center";
+
   import { createEventDispatcher, getContext } from "svelte";
   import CopyButton from "../CopyButton/CopyButton.svelte";
 
@@ -235,6 +247,8 @@
         {feedbackTimeout}
         {iconDescription}
         {portalTooltip}
+        {tooltipPosition}
+        {tooltipAlignment}
         {disabled}
         {copy}
         on:copy

--- a/src/Portal/FloatingPortal.svelte
+++ b/src/Portal/FloatingPortal.svelte
@@ -125,6 +125,7 @@
     return () => {
       mounted = false;
       unobserveAnchor();
+      unobserveFloating();
       removeScrollListeners();
       scheduleUpdate.cancel();
     };
@@ -157,6 +158,30 @@
     if (anchorObserver && anchor) {
       anchorObserver.disconnect();
       anchorObserver = null;
+    }
+  }
+
+  /** @type {ResizeObserver | null} */
+  let floatingObserver = null;
+
+  // Reposition when the floating content itself resizes (e.g. a tooltip whose
+  // text swaps). Caret nudge for intrinsic `start`/`end` alignment depends on
+  // the floating width, so a stale width leaves the caret off the anchor.
+  function observeFloating() {
+    if (!ref || floatingObserver || typeof ResizeObserver === "undefined") {
+      return;
+    }
+    // Reposition synchronously (not rAF-throttled). ResizeObserver fires after
+    // layout but before paint, so updating here applies the corrected position
+    // in the same frame the content resized — no one-frame caret drift.
+    floatingObserver = new ResizeObserver(() => updatePosition());
+    floatingObserver.observe(ref);
+  }
+
+  function unobserveFloating() {
+    if (floatingObserver) {
+      floatingObserver.disconnect();
+      floatingObserver = null;
     }
   }
 
@@ -229,6 +254,7 @@
 
   $: if (!open) {
     unobserveAnchor();
+    unobserveFloating();
     removeScrollListeners();
     scrollableAncestors = [];
     scheduleUpdate.cancel();
@@ -236,10 +262,12 @@
 
   $: if (open && anchor && ref) {
     unobserveAnchor();
+    unobserveFloating();
     removeScrollListeners();
     scrollableAncestors = getScrollableAncestors(anchor);
     addScrollListeners();
     observeAnchor();
+    observeFloating();
     tick().then(() => {
       updatePosition();
       // Second pass after layout: side placements need width; intrinsic caret needs stable rect.

--- a/src/utils/floatingPosition.js
+++ b/src/utils/floatingPosition.js
@@ -178,13 +178,13 @@ export function floatingPosition({
     (actualDirection === "top" || actualDirection === "bottom") &&
     (intrinsicAlign === "start" || intrinsicAlign === "end")
   ) {
-    const anchorCx = rect.left + rect.width / 2;
-    // end + translateX(-100%): use anchor.right - width; floatingRect.left can lag styles
-    const portalLeftViewport =
-      intrinsicAlign === "end" && floatingRect.width > 0
-        ? rect.right - floatingRect.width
-        : floatingRect.left;
-    caretNudgePx = anchorCx - portalLeftViewport;
+    // Distance from the box edge that sits on the anchor (left edge for
+    // `start`, right edge for `end`) to the anchor center. This is half the
+    // anchor width and does NOT depend on the floating width, so the caret
+    // stays centered on the trigger when the tooltip text (and thus width)
+    // changes — no recompute, no bounce. The CSS applies it from the matching
+    // edge per alignment.
+    caretNudgePx = rect.width / 2;
   }
 
   return {

--- a/tests/utils/floatingPosition.test.ts
+++ b/tests/utils/floatingPosition.test.ts
@@ -170,14 +170,14 @@ describe("floatingPosition", () => {
       });
 
       expect(result.left).toBe(100);
-      // anchorCx (175) - measured floating left (100)
+      // Half the anchor width (150 / 2), applied from the box's left edge.
       expect(result.caretNudgePx).toBe(75);
     });
 
-    test("end intrinsic align uses anchor right; caret uses width not measured left", () => {
+    test("end intrinsic align uses anchor right; caret offset is anchor half-width", () => {
       const result = floatingPosition({
         anchorRect, // right = 250
-        floatingRect: rect(999, 0, 80, 30), // stale left ignored; width=80 used
+        floatingRect: rect(999, 0, 80, 30), // left and width are ignored for the caret
         viewport,
         direction: "bottom",
         intrinsicWidth: true,
@@ -185,8 +185,10 @@ describe("floatingPosition", () => {
       });
 
       expect(result.left).toBe(250); // anchor.right
-      // anchorCx (175) - (anchor.right (250) - width (80)) = 175 - 170
-      expect(result.caretNudgePx).toBe(5);
+      // Half the anchor width (150 / 2), applied from the box's right edge by
+      // the CSS, so the caret stays centered on the trigger regardless of the
+      // floating width.
+      expect(result.caretNudgePx).toBe(75);
     });
   });
 

--- a/tests/utils/mockSnippetOverflowHeight.ts
+++ b/tests/utils/mockSnippetOverflowHeight.ts
@@ -1,12 +1,16 @@
 const COLLAPSED_HEIGHT = 16 * 15;
 
+// Capture the native implementation at module load. `vi.spyOn` on an
+// already-spied method returns the same spy, so reading it inside the function
+// could capture the spy itself and recurse infinitely when the fallback runs
+// (e.g. a portal tooltip measuring a non-`<pre>` element).
+const nativeGetBoundingClientRect = Element.prototype.getBoundingClientRect;
+
 /**
  * jsdom does not lay out text, so CodeSnippet's overflow measurement always
  * sees height 0. Mock the `<pre>` height so expand/collapse tests can run.
  */
 export function mockSnippetOverflowHeight(height = COLLAPSED_HEIGHT + 1) {
-  const original = Element.prototype.getBoundingClientRect;
-
   return vi
     .spyOn(Element.prototype, "getBoundingClientRect")
     .mockImplementation(function (this: Element) {
@@ -24,7 +28,7 @@ export function mockSnippetOverflowHeight(height = COLLAPSED_HEIGHT + 1) {
         } as DOMRect;
       }
 
-      return original.call(this);
+      return nativeGetBoundingClientRect.call(this);
     });
 }
 


### PR DESCRIPTION
Adds a `ghost` kind and `sm`/`md`/`lg`/`xl` sizes to `CopyButton` so it can sit next to a ghost `Button`, and gives both `CopyButton` and `CopyInput` a proactive hover and focus tooltip controlled by `tooltipPosition` and `tooltipAlignment`. The hover description and the copy feedback share one floating portal surface when the tooltip is portalled, so the transition stays smooth and the caret stays centered on the trigger when the text width changes. The component docs site dogfoods the new button for its copy markdown action. These changes are additive and backward compatible: `portalTooltip` still behaves as before.

## Usage

```svelte
<script>
  import { CopyButton, CopyInput } from "carbon-components-svelte";
</script>

<CopyButton text="Carbon svelte" kind="ghost" size="sm" />

<CopyInput
  labelText="API endpoint"
  value="https://api.example.com/v1"
  tooltipPosition="left"
  tooltipAlignment="start"
/>
```
