### PR TITLE
docs(link): mute inline prose links

### DIFF
--- a/docs/svelte.config.ts
+++ b/docs/svelte.config.ts
@@ -330,7 +330,7 @@ function serializeInlineNodes(nodes: PhrasingContent[]): string {
         case "emphasis":
           return `<em>${serializeInlineNodes(node.children)}</em>`;
         case "link":
-          return `<a class="bx--link" href="${node.url}">${serializeInlineNodes(node.children)}</a>`;
+          return `<a class="bx--link bx--link--muted" href="${node.url}">${serializeInlineNodes(node.children)}</a>`;
         case "break":
           return "<br/>";
         default:
@@ -456,7 +456,7 @@ function carbonify() {
     visit(tree, (node, index, parent) => {
       switch (node.type) {
         case "link":
-          node.data = { hProperties: { class: "bx--link" } };
+          node.data = { hProperties: { class: "bx--link bx--link--muted" } };
           return;
         case "list": {
           const list = node as List;


### PR DESCRIPTION
Inline `[text](url)` links and hero/admonition prose links now render the `bx--link--muted` variant so they inherit body text color instead of competing with surrounding copy.