### PR TITLE
fix(floating-portal): keep a flipped tooltip side stable across content resize

### DIFF
--- a/docs/src/components/CopyMarkdownButton.svelte
+++ b/docs/src/components/CopyMarkdownButton.svelte
@@ -25,7 +25,6 @@
   kind="ghost"
   {size}
   {tooltipPosition}
-  portalTooltip
   copy={copyMarkdown}
   feedbackIcon={Checkmark}
   iconDescription={formatCopyIconDescription(false, bytes)}

--- a/docs/src/components/CopyMarkdownButton.svelte
+++ b/docs/src/components/CopyMarkdownButton.svelte
@@ -25,6 +25,7 @@
   kind="ghost"
   {size}
   {tooltipPosition}
+  portalTooltip
   copy={copyMarkdown}
   feedbackIcon={Checkmark}
   iconDescription={formatCopyIconDescription(false, bytes)}

--- a/docs/src/pages/components/CodeSnippet.svx
+++ b/docs/src/pages/components/CodeSnippet.svx
@@ -148,21 +148,17 @@ Re-render the component to fix this issue.
 
 ## Portal tooltip
 
-Set `portalTooltip` to `true` to render the feedback tooltip in a floating portal.
-This prevents clipping by parent containers with overflow hidden or z-index
-stacking contexts. The example renders each variant inside a container with hidden
-overflow.
-
-When inside a [Modal](/components/Modal), portalTooltip defaults to `true`
-unless explicitly set to `false`.
+The "Copied!" feedback tooltip is rendered in a floating portal by default, so it
+is never clipped by a parent container with hidden overflow or a z-index stacking
+context. Set `portalTooltip` to `false` to use Carbon's inline feedback caret
+instead. The example renders each variant inside a container with hidden overflow.
 
 <FileSource src="/framed/CodeSnippet/CodeSnippetPortalTooltip" />
 
 ## Inside a modal
 
-When used inside a Modal, the feedback tooltip is automatically portalled to
-prevent clipping by overflow hidden. Set `portalTooltip` to control this
-behavior explicitly.
+Because the feedback tooltip is portalled by default, it is not clipped inside a
+[Modal](/components/Modal). Set `portalTooltip` to `false` to use the inline caret.
 
 <FileSource src="/framed/CodeSnippet/CodeSnippetInModal" />
 

--- a/docs/src/pages/components/CodeSnippet.svx
+++ b/docs/src/pages/components/CodeSnippet.svx
@@ -146,6 +146,19 @@ Re-render the component to fix this issue.
 
 <FileSource src="/framed/CodeSnippet/HiddenCodeSnippet" />
 
+## Tooltip position
+
+Set `tooltipPosition` to place the feedback tooltip relative to the copy button.
+It applies to every variant, including the inline snippet.
+
+<FileSource src="/framed/CodeSnippet/CodeSnippetTooltipPosition" />
+
+## Tooltip alignment
+
+Set `tooltipAlignment` to align the feedback tooltip relative to the copy button.
+
+<FileSource src="/framed/CodeSnippet/CodeSnippetTooltipAlignment" />
+
 ## Portal tooltip
 
 The "Copied!" feedback tooltip is rendered in a floating portal by default, so it

--- a/docs/src/pages/components/CopyButton.svx
+++ b/docs/src/pages/components/CopyButton.svx
@@ -108,12 +108,12 @@ Set `tooltipAlignment` to align the tooltip relative to the button.
 
 ## Portal tooltip
 
-Set `portalTooltip` to render the feedback tooltip in a portal so it is not clipped by `overflow: hidden` containers. It is also portalled automatically inside a [Modal](/components/Modal) or when a non-default `tooltipPosition` or `tooltipAlignment` is set.
+The "Copied!" feedback tooltip is rendered in a floating portal by default, so it shares the same surface as the hover tooltip (the text swaps in place) and is never clipped by an `overflow: hidden` container. Set `portalTooltip` to `false` to use Carbon's inline feedback caret instead. A non-default `tooltipPosition` or `tooltipAlignment` is always portalled because the inline caret only supports the default placement.
 
 <FileSource src="/framed/CopyButton/CopyButtonPortalTooltip" />
 
 ## Inside a modal
 
-When used inside a [Modal](/components/Modal), the feedback tooltip is automatically portalled so it is not clipped. Set `portalTooltip` to override this behavior.
+Because the feedback tooltip is portalled by default, it is not clipped inside a [Modal](/components/Modal). Set `portalTooltip` to `false` to use the inline caret.
 
 <FileSource src="/framed/CopyButton/CopyButtonInModal" />

--- a/docs/src/pages/components/CopyInput.svx
+++ b/docs/src/pages/components/CopyInput.svx
@@ -116,13 +116,13 @@ Set `tooltipAlignment` to align the tooltip relative to the copy button. Accepts
 
 ## Portal tooltip
 
-Set `portalTooltip` to render the copy feedback tooltip in a portal so it is not clipped by `overflow: hidden` containers. Inside a [Modal](/components/Modal), portalling is enabled by default unless you set `portalTooltip` to `false`.
+The copy feedback tooltip is rendered in a floating portal by default, so it shares the same surface as the hover tooltip (the text swaps in place) and is never clipped by an `overflow: hidden` container. Set `portalTooltip` to `false` to use Carbon's inline feedback caret instead. A non-default `tooltipPosition` or `tooltipAlignment` is always portalled because the inline caret only supports the default placement.
 
 <FileSource src="/framed/CopyInput/CopyInputPortalTooltip" />
 
 ## Inside a modal
 
-Inside a modal, the copy feedback tooltip is portalled automatically so it is not clipped. Set `portalTooltip` to control this explicitly.
+Because the feedback tooltip is portalled by default, it is not clipped inside a [Modal](/components/Modal). Set `portalTooltip` to `false` to use the inline caret.
 
 <FileSource src="/framed/CopyInput/CopyInputInModal" />
 

--- a/docs/src/pages/framed/CodeSnippet/CodeSnippetPortalTooltip.svelte
+++ b/docs/src/pages/framed/CodeSnippet/CodeSnippetPortalTooltip.svelte
@@ -5,29 +5,20 @@
     "export function add(a, b) {\n  return a + b;\n}\n\nexport function subtract(a, b) {\n  return a - b;\n}";
 </script>
 
+<!--
+  The feedback tooltip is portalled by default, so it is not clipped even when
+  the snippet sits in an `overflow: hidden` container. Set `portalTooltip` to
+  `false` on any variant to use Carbon's inline feedback caret instead.
+-->
 <Stack
   gap={4}
   style="overflow: hidden; border: 1px dashed var(--cds-border-subtle); padding: 1rem; max-height: 200px;"
 >
   <div>
-    <CodeSnippet
-      type="inline"
-      code="rm -rf node_modules/"
-      feedback="Copied!"
-      portalTooltip={true}
-    />
+    <CodeSnippet type="inline" code="rm -rf node_modules/" feedback="Copied!" />
   </div>
 
-  <CodeSnippet
-    code="npm i carbon-components-svelte"
-    feedback="Copied!"
-    portalTooltip={true}
-  />
+  <CodeSnippet code="npm i carbon-components-svelte" feedback="Copied!" />
 
-  <CodeSnippet
-    type="multi"
-    code={multiCode}
-    feedback="Copied!"
-    portalTooltip={true}
-  />
+  <CodeSnippet type="multi" code={multiCode} feedback="Copied!" />
 </Stack>

--- a/docs/src/pages/framed/CodeSnippet/CodeSnippetTooltipAlignment.svelte
+++ b/docs/src/pages/framed/CodeSnippet/CodeSnippetTooltipAlignment.svelte
@@ -1,0 +1,10 @@
+<script>
+  import { CodeSnippet, Stack } from "carbon-components-svelte";
+</script>
+
+<!-- Alignment positions the tooltip along the copy button edge. -->
+<Stack gap={6}>
+  <CodeSnippet code="alignment: start" tooltipAlignment="start" />
+  <CodeSnippet code="alignment: center" tooltipAlignment="center" />
+  <CodeSnippet code="alignment: end" tooltipAlignment="end" />
+</Stack>

--- a/docs/src/pages/framed/CodeSnippet/CodeSnippetTooltipPosition.svelte
+++ b/docs/src/pages/framed/CodeSnippet/CodeSnippetTooltipPosition.svelte
@@ -1,0 +1,12 @@
+<script>
+  import { CodeSnippet, Stack } from "carbon-components-svelte";
+</script>
+
+<!-- Click a snippet to copy; the "Copied!" feedback tooltip uses tooltipPosition. -->
+<Stack gap={6}>
+  <CodeSnippet code="position: top" tooltipPosition="top" />
+  <CodeSnippet code="position: right" tooltipPosition="right" />
+  <CodeSnippet code="position: bottom" tooltipPosition="bottom" />
+  <CodeSnippet code="position: left" tooltipPosition="left" />
+  <CodeSnippet type="inline" code="inline" tooltipPosition="right" />
+</Stack>

--- a/docs/src/pages/framed/CopyButton/CopyButtonPortalTooltip.svelte
+++ b/docs/src/pages/framed/CopyButton/CopyButtonPortalTooltip.svelte
@@ -2,14 +2,24 @@
   import { CopyButton, Stack } from "carbon-components-svelte";
 </script>
 
+<!--
+  The feedback tooltip is portalled by default, so it is not clipped even when
+  the button sits in an `overflow: hidden` container. Set `portalTooltip` to
+  `false` to use Carbon's inline feedback caret, which is clipped here.
+-->
 <Stack
   gap={4}
   style="overflow: hidden; border: 1px dashed var(--cds-border-subtle); padding: 1rem; max-height: 120px;"
 >
   <CopyButton
     text="Carbon svelte"
-    feedback="Copied!"
-    portalTooltip={true}
+    feedback="Portalled (default)"
+    tooltipAlignment="start"
+  />
+  <CopyButton
+    text="Carbon svelte"
+    feedback="Inline caret"
+    portalTooltip={false}
     tooltipAlignment="start"
   />
 </Stack>

--- a/docs/src/pages/framed/CopyInput/CopyInputPortalTooltip.svelte
+++ b/docs/src/pages/framed/CopyInput/CopyInputPortalTooltip.svelte
@@ -2,13 +2,19 @@
   import { CopyInput, Stack } from "carbon-components-svelte";
 </script>
 
+<!--
+  The feedback tooltip is portalled by default, so it is not clipped even when
+  the input sits in an `overflow: hidden` container. Set `portalTooltip` to
+  `false` to use Carbon's inline feedback caret, which is clipped here.
+-->
 <Stack
   gap={4}
-  style="overflow: hidden; border: 1px dashed var(--cds-border-subtle); padding: 1rem; max-height: 120px;"
+  style="overflow: hidden; border: 1px dashed var(--cds-border-subtle); padding: 1rem; max-height: 160px;"
 >
+  <CopyInput labelText="Portalled (default)" value="sk-1234567890abcdef" />
   <CopyInput
-    labelText="API token"
+    labelText="Inline caret"
     value="sk-1234567890abcdef"
-    portalTooltip={true}
+    portalTooltip={false}
   />
 </Stack>

--- a/src/CodeSnippet/CodeSnippet.svelte
+++ b/src/CodeSnippet/CodeSnippet.svelte
@@ -141,14 +141,15 @@
   export let copyRef = null;
 
   /**
-   * Set to `true` to render the feedback tooltip in a portal,
-   * preventing it from being clipped by `overflow: hidden` containers.
-   * By default, the tooltip is portalled when inside a `Modal`.
+   * Set how the "Copied!" feedback tooltip is rendered.
+   * By default, it is rendered in a portal so it is never clipped by an
+   * `overflow: hidden` container. Set to `false` to use Carbon's inline
+   * feedback caret instead.
    * @type {boolean | undefined}
    */
   export let portalTooltip = undefined;
 
-  import { createEventDispatcher, getContext, onMount } from "svelte";
+  import { createEventDispatcher, onMount } from "svelte";
   import Button from "../Button/Button.svelte";
   import CopyButton from "../CopyButton/CopyButton.svelte";
   import ChevronDown from "../icons/ChevronDown.svelte";
@@ -158,10 +159,11 @@
   import CodeSnippetSkeleton from "./CodeSnippetSkeleton.svelte";
 
   const dispatch = createEventDispatcher();
-  const insideModal = getContext("carbon:Modal");
 
+  // Feedback is portalled by default; only an explicit `portalTooltip={false}`
+  // opts back into Carbon's inline caret.
   $: effectivePortalTooltip =
-    portalTooltip === undefined ? !!insideModal : portalTooltip;
+    portalTooltip === undefined ? true : portalTooltip;
 
   const copyFeedback = createCopyFeedbackState(syncCopyFeedback);
 

--- a/src/CodeSnippet/CodeSnippet.svelte
+++ b/src/CodeSnippet/CodeSnippet.svelte
@@ -149,10 +149,23 @@
    */
   export let portalTooltip = undefined;
 
+  /**
+   * Set the position of the feedback tooltip relative to the copy button.
+   * @type {"top" | "right" | "bottom" | "left"}
+   */
+  export let tooltipPosition = "bottom";
+
+  /**
+   * Set the alignment of the feedback tooltip relative to the copy button.
+   * @type {"start" | "center" | "end"}
+   */
+  export let tooltipAlignment = "center";
+
   import { createEventDispatcher, onMount } from "svelte";
   import Button from "../Button/Button.svelte";
   import CopyButton from "../CopyButton/CopyButton.svelte";
   import ChevronDown from "../icons/ChevronDown.svelte";
+  import { iconTooltipPortalGaps } from "../Portal/iconTooltipPortalGaps.js";
   import PortalTooltip from "../Portal/PortalTooltip.svelte";
   import { observeModalClose } from "../Portal/portal-utils.js";
   import { createCopyFeedbackState } from "../utils/copyFeedback.js";
@@ -164,6 +177,11 @@
   // opts back into Carbon's inline caret.
   $: effectivePortalTooltip =
     portalTooltip === undefined ? true : portalTooltip;
+
+  // Caret spacing + alignment nudges for the inline variant's portalled
+  // feedback. Single/multi variants delegate to CopyButton, which computes
+  // its own from the same util.
+  $: portalGaps = iconTooltipPortalGaps(tooltipPosition, tooltipAlignment);
 
   const copyFeedback = createCopyFeedbackState(syncCopyFeedback);
 
@@ -337,7 +355,19 @@
     </button>
 
     {#if effectivePortalTooltip}
-      <PortalTooltip anchor={copyRef} open={feedbackOpen} text={feedback} />
+      <PortalTooltip
+        anchor={copyRef}
+        open={feedbackOpen}
+        text={feedback}
+        direction={tooltipPosition}
+        intrinsicAlign={tooltipAlignment}
+        horizontalGapLeft={portalGaps.horizontalGapLeft}
+        horizontalGapRight={portalGaps.horizontalGapRight}
+        gapTop={portalGaps.gapTop}
+        gapBottom={portalGaps.gapBottom}
+        verticalAlignOffsetLeft={portalGaps.verticalAlignOffsetLeft}
+        verticalAlignOffsetRight={portalGaps.verticalAlignOffsetRight}
+      />
     {/if}
   {/if}
 {:else}
@@ -382,6 +412,8 @@
         {feedbackIcon}
         iconDescription={copyButtonDescription}
         portalTooltip={effectivePortalTooltip}
+        {tooltipPosition}
+        {tooltipAlignment}
         on:click
         on:copy
         on:copy:error

--- a/src/CopyButton/CopyButton.svelte
+++ b/src/CopyButton/CopyButton.svelte
@@ -50,10 +50,12 @@
   export let copy = defaultCopy;
 
   /**
-   * Set to `true` to render the feedback tooltip in a portal,
-   * preventing it from being clipped by `overflow: hidden` containers.
-   * By default, the tooltip is portalled when inside a `Modal` or when a
-   * non-default `tooltipPosition`/`tooltipAlignment` is set.
+   * Set how the "Copied!" feedback tooltip is rendered.
+   * By default, it is rendered in a portal so it shares the same surface as the
+   * hover tooltip (the text swaps in place) and is never clipped by an
+   * `overflow: hidden` container. Set to `false` to use Carbon's inline feedback
+   * caret instead; a non-default `tooltipPosition`/`tooltipAlignment` still
+   * portals because the inline caret only supports the default placement.
    * @type {boolean | undefined}
    */
   export let portalTooltip = undefined;
@@ -73,7 +75,7 @@
   /** Obtain a reference to the underlying button element. */
   export let ref = null;
 
-  import { createEventDispatcher, getContext, onMount } from "svelte";
+  import { createEventDispatcher, onMount } from "svelte";
   import { get } from "svelte/store";
   import { activeButtonTooltip } from "../Button/button-tooltip-store.js";
   import Copy from "../icons/Copy.svelte";
@@ -82,10 +84,11 @@
   import { createCopyFeedbackState } from "../utils/copyFeedback.js";
 
   const dispatch = createEventDispatcher();
-  const insideModal = getContext("carbon:Modal");
 
+  // Feedback is portalled by default; only an explicit `portalTooltip={false}`
+  // opts back into Carbon's inline caret.
   $: effectivePortalTooltip =
-    portalTooltip === undefined ? !!insideModal : portalTooltip;
+    portalTooltip === undefined ? true : portalTooltip;
 
   const copyFeedback = createCopyFeedbackState(syncCopyFeedback);
 

--- a/src/CopyButton/CopyButton.svelte
+++ b/src/CopyButton/CopyButton.svelte
@@ -79,6 +79,7 @@
   import { get } from "svelte/store";
   import { activeButtonTooltip } from "../Button/button-tooltip-store.js";
   import Copy from "../icons/Copy.svelte";
+  import { iconTooltipPortalGaps } from "../Portal/iconTooltipPortalGaps.js";
   import PortalTooltip from "../Portal/PortalTooltip.svelte";
   import { observeModalClose } from "../Portal/portal-utils.js";
   import { createCopyFeedbackState } from "../utils/copyFeedback.js";
@@ -185,29 +186,7 @@
   }
 
   // Caret spacing + alignment nudges, mirroring Button's icon tooltip.
-  const PORTAL_HORIZONTAL_GAP_PX = 2;
-  const PORTAL_VERTICAL_GAP_PX = 1;
-  const PORTAL_VERTICAL_ALIGN_OFFSET_LEFT_START_PX = -3;
-  const PORTAL_VERTICAL_ALIGN_OFFSET_RIGHT_END_PX = 1;
-
-  $: tooltipHorizontal =
-    tooltipPosition === "left" || tooltipPosition === "right";
-  $: tooltipVertical =
-    tooltipPosition === "top" || tooltipPosition === "bottom";
-  $: portalHorizontalGapLeft = tooltipHorizontal ? PORTAL_HORIZONTAL_GAP_PX : 0;
-  $: portalHorizontalGapRight = tooltipHorizontal
-    ? PORTAL_HORIZONTAL_GAP_PX
-    : 0;
-  $: portalGapTop = tooltipVertical ? PORTAL_VERTICAL_GAP_PX : 0;
-  $: portalGapBottom = tooltipVertical ? PORTAL_VERTICAL_GAP_PX : 0;
-  $: portalVerticalAlignOffsetLeft =
-    tooltipPosition === "left" && tooltipAlignment === "start"
-      ? PORTAL_VERTICAL_ALIGN_OFFSET_LEFT_START_PX
-      : 0;
-  $: portalVerticalAlignOffsetRight =
-    tooltipPosition === "right" && tooltipAlignment === "end"
-      ? PORTAL_VERTICAL_ALIGN_OFFSET_RIGHT_END_PX
-      : 0;
+  $: portalGaps = iconTooltipPortalGaps(tooltipPosition, tooltipAlignment);
 
   function dismissFeedback() {
     copyFeedback.dismiss();
@@ -300,11 +279,11 @@
     tooltipType="icon"
     direction={tooltipPosition}
     intrinsicAlign={tooltipAlignment}
-    horizontalGapLeft={portalHorizontalGapLeft}
-    horizontalGapRight={portalHorizontalGapRight}
-    gapTop={portalGapTop}
-    gapBottom={portalGapBottom}
-    verticalAlignOffsetLeft={portalVerticalAlignOffsetLeft}
-    verticalAlignOffsetRight={portalVerticalAlignOffsetRight}
+    horizontalGapLeft={portalGaps.horizontalGapLeft}
+    horizontalGapRight={portalGaps.horizontalGapRight}
+    gapTop={portalGaps.gapTop}
+    gapBottom={portalGaps.gapBottom}
+    verticalAlignOffsetLeft={portalGaps.verticalAlignOffsetLeft}
+    verticalAlignOffsetRight={portalGaps.verticalAlignOffsetRight}
   />
 {/if}

--- a/src/Portal/FloatingPortal.svelte
+++ b/src/Portal/FloatingPortal.svelte
@@ -85,6 +85,16 @@
   export let intrinsicAlign = "center";
 
   /**
+   * Set to `true` to keep a flipped side stable for the duration of an open
+   * session. Once the content flips away from `direction` (because the preferred
+   * side does not fit), that side is reused even if the content later resizes,
+   * so a floating element whose content swaps (e.g. a tooltip whose text changes
+   * to something narrower) does not snap back to the preferred side mid-session.
+   * @type {boolean}
+   */
+  export let lockDirection = false;
+
+  /**
    * Obtain a reference to the floating portal element.
    * @type {null | HTMLElement}
    * @bindable readonly
@@ -195,6 +205,11 @@
     typeof document !== "undefined" &&
     effectiveTarget !== document.body;
 
+  // The side chosen on open; reused on subsequent updates when `lockDirection`
+  // is set so content resizes do not re-trigger a flip. Reset each open session.
+  /** @type {"bottom" | "top" | "left" | "right" | null} */
+  let lockedDirection = null;
+
   function updatePosition() {
     if (!mounted || !anchor || !ref) return;
 
@@ -208,6 +223,9 @@
         scrollY: window.scrollY,
       },
       direction,
+      lockedDirection: lockDirection
+        ? (lockedDirection ?? undefined)
+        : undefined,
       useFixedPosition,
       intrinsicWidth,
       intrinsicAlign,
@@ -218,6 +236,20 @@
       verticalAlignOffsetLeft,
       verticalAlignOffsetRight,
     });
+
+    // Latch the side only once it actually flips away from the preferred
+    // direction. Until then keep recomputing, so the initial layout passes
+    // (which run before the content's final width is known for side placements)
+    // can still flip. Once flipped, stay flipped for the session so a content
+    // resize — e.g. a tooltip whose text swaps to something narrower — does not
+    // snap the box back to the preferred side.
+    if (
+      lockDirection &&
+      lockedDirection === null &&
+      pos.actualDirection !== direction
+    ) {
+      lockedDirection = pos.actualDirection;
+    }
   }
 
   const scheduleUpdate = rafThrottle(updatePosition);
@@ -258,6 +290,8 @@
     removeScrollListeners();
     scrollableAncestors = [];
     scheduleUpdate.cancel();
+    // Recompute the side fresh on the next open.
+    lockedDirection = null;
   }
 
   $: if (open && anchor && ref) {

--- a/src/Portal/PortalTooltip.svelte
+++ b/src/Portal/PortalTooltip.svelte
@@ -94,6 +94,7 @@
   {verticalAlignOffsetRight}
   {intrinsicAlign}
   intrinsicWidth={true}
+  lockDirection={true}
   let:direction={actualDirection}
 >
   <div

--- a/src/Portal/iconTooltipPortalGaps.d.ts
+++ b/src/Portal/iconTooltipPortalGaps.d.ts
@@ -1,0 +1,14 @@
+export interface IconTooltipPortalGaps {
+  horizontalGapLeft: number;
+  horizontalGapRight: number;
+  gapTop: number;
+  gapBottom: number;
+  verticalAlignOffsetLeft: number;
+  verticalAlignOffsetRight: number;
+}
+
+/** Caret spacing + alignment nudges for an icon tooltip rendered through `PortalTooltip`. */
+export function iconTooltipPortalGaps(
+  tooltipPosition: "top" | "right" | "bottom" | "left",
+  tooltipAlignment: "start" | "center" | "end",
+): IconTooltipPortalGaps;

--- a/src/Portal/iconTooltipPortalGaps.js
+++ b/src/Portal/iconTooltipPortalGaps.js
@@ -1,0 +1,41 @@
+// @ts-check
+
+// Caret spacing + alignment nudges for an icon tooltip rendered through
+// `PortalTooltip`. Shared by `CopyButton` and `CodeSnippet`'s inline copy
+// feedback so the portalled caret sits the same distance from the trigger
+// across components. Mirrors Button's icon tooltip.
+const PORTAL_HORIZONTAL_GAP_PX = 2;
+const PORTAL_VERTICAL_GAP_PX = 1;
+const PORTAL_VERTICAL_ALIGN_OFFSET_LEFT_START_PX = -3;
+const PORTAL_VERTICAL_ALIGN_OFFSET_RIGHT_END_PX = 1;
+
+/**
+ * @param {"top" | "right" | "bottom" | "left"} tooltipPosition
+ * @param {"start" | "center" | "end"} tooltipAlignment
+ * @returns {{
+ *   horizontalGapLeft: number,
+ *   horizontalGapRight: number,
+ *   gapTop: number,
+ *   gapBottom: number,
+ *   verticalAlignOffsetLeft: number,
+ *   verticalAlignOffsetRight: number,
+ * }}
+ */
+export function iconTooltipPortalGaps(tooltipPosition, tooltipAlignment) {
+  const horizontal = tooltipPosition === "left" || tooltipPosition === "right";
+  const vertical = tooltipPosition === "top" || tooltipPosition === "bottom";
+  return {
+    horizontalGapLeft: horizontal ? PORTAL_HORIZONTAL_GAP_PX : 0,
+    horizontalGapRight: horizontal ? PORTAL_HORIZONTAL_GAP_PX : 0,
+    gapTop: vertical ? PORTAL_VERTICAL_GAP_PX : 0,
+    gapBottom: vertical ? PORTAL_VERTICAL_GAP_PX : 0,
+    verticalAlignOffsetLeft:
+      tooltipPosition === "left" && tooltipAlignment === "start"
+        ? PORTAL_VERTICAL_ALIGN_OFFSET_LEFT_START_PX
+        : 0,
+    verticalAlignOffsetRight:
+      tooltipPosition === "right" && tooltipAlignment === "end"
+        ? PORTAL_VERTICAL_ALIGN_OFFSET_RIGHT_END_PX
+        : 0,
+  };
+}

--- a/src/utils/floatingPosition.d.ts
+++ b/src/utils/floatingPosition.d.ts
@@ -22,6 +22,8 @@ export interface FloatingPositionOptions {
   };
   /** Preferred direction. */
   direction: FloatingDirection;
+  /** When set, skip flip detection and place on this side. Keeps a side stable across content changes while the floating element stays open. */
+  lockedDirection?: FloatingDirection;
   /** When true, scroll offsets are zeroed (caller uses `position: fixed`). */
   useFixedPosition?: boolean;
   /** Use the floating element's own width instead of matching the anchor. */

--- a/src/utils/floatingPosition.js
+++ b/src/utils/floatingPosition.js
@@ -13,6 +13,7 @@
  * @param {RectLike} options.floatingRect - The floating element's `getBoundingClientRect()`.
  * @param {{ innerWidth: number, innerHeight: number, scrollX: number, scrollY: number }} options.viewport
  * @param {"bottom" | "top" | "left" | "right"} options.direction - Preferred direction.
+ * @param {"bottom" | "top" | "left" | "right"} [options.lockedDirection] - When set, skip flip detection and place on this side. Used to keep a side stable across content (width/height) changes while the floating element stays open.
  * @param {boolean} [options.useFixedPosition=false] - When true, scroll offsets are zeroed (the caller positions with `position: fixed`).
  * @param {boolean} [options.intrinsicWidth=false] - Use the floating element's own width instead of matching the anchor.
  * @param {"start" | "center" | "end"} [options.intrinsicAlign="center"] - Alignment along the anchor edge when `intrinsicWidth` is true.
@@ -29,6 +30,7 @@ export function floatingPosition({
   floatingRect,
   viewport,
   direction,
+  lockedDirection,
   useFixedPosition = false,
   intrinsicWidth = false,
   intrinsicAlign = "center",
@@ -45,7 +47,12 @@ export function floatingPosition({
   const isVertical = direction === "top" || direction === "bottom";
   let actualDirection = direction;
 
-  if (isVertical) {
+  if (lockedDirection) {
+    // Caller is keeping a previously-chosen side stable (e.g. a tooltip whose
+    // text — and thus width/height — swaps while open). Skip flip detection so
+    // the floating element does not jump to the opposite side mid-session.
+    actualDirection = lockedDirection;
+  } else if (isVertical) {
     const spaceBelow = viewport.innerHeight - rect.bottom;
     const spaceAbove = rect.top;
 

--- a/tests/CodeSnippet/CodeSnippet.test.ts
+++ b/tests/CodeSnippet/CodeSnippet.test.ts
@@ -148,6 +148,25 @@ yarn -v`,
 
   it.each(
     snippetVariants,
+  )("forwards tooltipPosition to the portalled feedback tooltip ($type)", async ({
+    type,
+    label,
+  }) => {
+    render(CodeSnippetAsync, {
+      props: { type, copy: () => Promise.resolve(), tooltipPosition: "right" },
+    });
+
+    const button = screen.getByLabelText(label);
+    await user.click(button);
+
+    await waitFor(() => {
+      const portal = document.querySelector("[data-floating-portal]");
+      expect(portal).toHaveAttribute("data-floating-direction", "right");
+    });
+  });
+
+  it.each(
+    snippetVariants,
   )("async copy failure does not show feedback ($type)", async ({
     type,
     label,

--- a/tests/CodeSnippet/CodeSnippet.test.ts
+++ b/tests/CodeSnippet/CodeSnippet.test.ts
@@ -32,6 +32,12 @@ import CodeSnippetWithWrapText from "./CodeSnippetWithWrapText.test.svelte";
 import CodeSnippetWrapperMouseEnter from "./CodeSnippetWrapperMouseEnter.test.svelte";
 
 describe("CodeSnippet", () => {
+  afterEach(() => {
+    for (const portal of document.querySelectorAll("[data-floating-portal]")) {
+      portal.remove();
+    }
+  });
+
   // Regression test for initial event dispatch in Svelte 5
   // https://github.com/carbon-design-system/carbon-components-svelte/issues/2527
   test("does not fire expand/collapse event on initial render", () => {
@@ -133,9 +139,11 @@ yarn -v`,
     });
 
     expect(button).not.toHaveAttribute("aria-busy");
-    expect(button.querySelector(".bx--copy-btn__feedback")).toHaveTextContent(
-      "Copied!",
-    );
+    // Feedback is portalled by default.
+    const portal = document.querySelector("[data-floating-portal]");
+    expect(
+      portal?.querySelector(".bx--tooltip-portal__content"),
+    ).toHaveTextContent("Copied!");
   });
 
   it.each(

--- a/tests/CodeSnippet/CodeSnippetAsync.test.svelte
+++ b/tests/CodeSnippet/CodeSnippetAsync.test.svelte
@@ -6,12 +6,15 @@
   export let copy: (code: string) => void | Promise<void> = async () => {};
   export let onCopy = () => {};
   export let onCopyError = (_detail: { error: unknown }) => {};
+  export let tooltipPosition: ComponentProps<CodeSnippet>["tooltipPosition"] =
+    "bottom";
 </script>
 
 <CodeSnippet
   {type}
   code="npm install --save @carbon/icons"
   {copy}
+  {tooltipPosition}
   on:copy={onCopy}
   on:copy:error={(event) => onCopyError(event.detail)}
 />

--- a/tests/CopyButton/CopyButton.test.ts
+++ b/tests/CopyButton/CopyButton.test.ts
@@ -19,6 +19,12 @@ describe("CopyButton", () => {
     });
   });
 
+  afterEach(() => {
+    for (const portal of document.querySelectorAll("[data-floating-portal]")) {
+      portal.remove();
+    }
+  });
+
   it("renders and functions correctly", async () => {
     const consoleLog = vi.spyOn(console, "log");
     render(CopyButton);
@@ -29,12 +35,17 @@ describe("CopyButton", () => {
     await user.click(button);
     expect(consoleLog).toHaveBeenCalledWith("copied");
 
-    const feedback = button.querySelector(".bx--copy-btn__feedback");
-    expect(feedback).toHaveTextContent("Copied!");
+    // Feedback is portalled by default; it shares the hover tooltip surface.
+    const portal = document.querySelector("[data-floating-portal]");
+    expect(
+      portal?.querySelector(".bx--tooltip-portal__content"),
+    ).toHaveTextContent("Copied!");
   });
 
-  it("supports custom feedback text and timeout", async () => {
-    render(CopyButton);
+  it("supports custom feedback text and timeout (inline caret)", async () => {
+    // The fade-out animation is specific to the inline caret; portalled
+    // feedback closes the tooltip directly on timeout.
+    render(CopyButton, { props: { portalTooltip: false } });
 
     const button = getCopyButton("Custom feedback");
     await user.click(button);
@@ -72,9 +83,10 @@ describe("CopyButton", () => {
     await user.click(button);
     expect(onCopyError).toHaveBeenCalledWith({ error: "Clipboard error" });
     expect(button).not.toHaveClass("bx--copy-btn--fade-in");
-    expect(button.querySelector(".bx--copy-btn__feedback")).not.toHaveClass(
-      "bx--copy-btn--fade-in",
-    );
+    // No "Copied!" feedback on error. (A hover/focus description tooltip may
+    // still portal because clicking focuses the button — that is not feedback.)
+    expect(button.querySelector(".bx--copy-btn__feedback")).toBeNull();
+    expect(screen.queryByText("Copied!")).toBeNull();
   });
 
   it("async copy delays feedback until resolved", async () => {
@@ -102,9 +114,10 @@ describe("CopyButton", () => {
     });
 
     expect(button).not.toHaveAttribute("aria-busy");
-    expect(button.querySelector(".bx--copy-btn__feedback")).toHaveTextContent(
-      "Copied!",
-    );
+    const portal = document.querySelector("[data-floating-portal]");
+    expect(
+      portal?.querySelector(".bx--tooltip-portal__content"),
+    ).toHaveTextContent("Copied!");
   });
 
   it("async copy failure does not show feedback and dispatches copy:error", async () => {
@@ -207,15 +220,6 @@ describe("CopyButton", () => {
   });
 
   describe("Portal tooltip", () => {
-    afterEach(() => {
-      const existingPortals = document.querySelectorAll(
-        "[data-floating-portal]",
-      );
-      for (const portal of existingPortals) {
-        portal.remove();
-      }
-    });
-
     it("should add portal-active class when portalTooltip is true", () => {
       render(CopyButton, {
         props: { portalTooltip: true },

--- a/tests/CopyInput/CopyInput.test.ts
+++ b/tests/CopyInput/CopyInput.test.ts
@@ -17,6 +17,12 @@ describe("CopyInput", () => {
     });
   });
 
+  afterEach(() => {
+    for (const portal of document.querySelectorAll("[data-floating-portal]")) {
+      portal.remove();
+    }
+  });
+
   it("renders a read-only field with the value", () => {
     render(CopyInput);
 
@@ -147,9 +153,11 @@ describe("CopyInput", () => {
     });
 
     expect(button).not.toHaveAttribute("aria-busy");
-    expect(button.querySelector(".bx--copy-btn__feedback")).toHaveTextContent(
-      "Copied!",
-    );
+    // Feedback is portalled by default.
+    const portal = document.querySelector("[data-floating-portal]");
+    expect(
+      portal?.querySelector(".bx--tooltip-portal__content"),
+    ).toHaveTextContent("Copied!");
   });
 
   it("async copy failure does not show feedback and dispatches copy:error", async () => {

--- a/tests/Portal/iconTooltipPortalGaps.test.ts
+++ b/tests/Portal/iconTooltipPortalGaps.test.ts
@@ -1,0 +1,40 @@
+import { iconTooltipPortalGaps } from "carbon-components-svelte/Portal/iconTooltipPortalGaps.js";
+
+describe("iconTooltipPortalGaps", () => {
+  test("vertical placements only add a top/bottom gap", () => {
+    expect(iconTooltipPortalGaps("bottom", "center")).toEqual({
+      horizontalGapLeft: 0,
+      horizontalGapRight: 0,
+      gapTop: 1,
+      gapBottom: 1,
+      verticalAlignOffsetLeft: 0,
+      verticalAlignOffsetRight: 0,
+    });
+    expect(iconTooltipPortalGaps("top", "center").gapTop).toBe(1);
+    expect(iconTooltipPortalGaps("top", "center").horizontalGapLeft).toBe(0);
+  });
+
+  test("horizontal placements only add a left/right gap", () => {
+    const gaps = iconTooltipPortalGaps("right", "center");
+    expect(gaps.horizontalGapLeft).toBe(2);
+    expect(gaps.horizontalGapRight).toBe(2);
+    expect(gaps.gapTop).toBe(0);
+    expect(gaps.gapBottom).toBe(0);
+  });
+
+  test("nudges the caret only for left/start and right/end", () => {
+    expect(iconTooltipPortalGaps("left", "start").verticalAlignOffsetLeft).toBe(
+      -3,
+    );
+    expect(iconTooltipPortalGaps("right", "end").verticalAlignOffsetRight).toBe(
+      1,
+    );
+    // No nudge for other alignment combinations.
+    expect(iconTooltipPortalGaps("left", "end").verticalAlignOffsetLeft).toBe(
+      0,
+    );
+    expect(
+      iconTooltipPortalGaps("right", "center").verticalAlignOffsetRight,
+    ).toBe(0);
+  });
+});

--- a/tests/utils/floatingPosition.test.ts
+++ b/tests/utils/floatingPosition.test.ts
@@ -141,6 +141,35 @@ describe("floatingPosition", () => {
     });
   });
 
+  describe("lockedDirection", () => {
+    test("keeps the locked side even when the preferred side would overflow", () => {
+      // Narrow content fits on the right (no flip), but it stays on the locked
+      // left side — e.g. a wide tooltip flipped left, then its text shrank.
+      const result = floatingPosition({
+        anchorRect: rect(880, 200, 100, 40),
+        floatingRect: rect(0, 0, 60, 40),
+        viewport,
+        direction: "right",
+        lockedDirection: "left",
+      });
+
+      expect(result.actualDirection).toBe("left");
+      expect(result.left).toBe(820); // anchor.left (880) - floating width (60)
+    });
+
+    test("ignores the preferred direction when locked to the opposite side", () => {
+      const result = floatingPosition({
+        anchorRect: rect(100, 200, 150, 40),
+        floatingRect: rect(0, 0, 150, 60),
+        viewport,
+        direction: "bottom",
+        lockedDirection: "top",
+      });
+
+      expect(result.actualDirection).toBe("top");
+    });
+  });
+
   describe("intrinsic width (vertical)", () => {
     const anchorRect = rect(100, 200, 150, 40); // center x = 175
 


### PR DESCRIPTION
Fixes a UX issue.

Especially for a feedback tooltip (CopyButton), floating portal needs an opt-in prop to lock the direction, so it doesn't use inconsistent directions.