### PR TITLE
chore(code-snippet): keep focus outline above edge fade

### DIFF
--- a/css/_code-snippet.scss
+++ b/css/_code-snippet.scss
@@ -13,6 +13,12 @@
       $black-100 calc(100% - #{$carbon--spacing-07}),
       transparent 100%
     );
+
+    // The focus outline is drawn on this same element, so the edge fade would
+    // clip the ring. Drop the mask while focused so the outline is unbroken.
+    &:focus {
+      mask-image: none;
+    }
   }
 
   // Expanded multi-line adds padding-bottom: $spacing-05, so the bottom fade
@@ -28,6 +34,10 @@
         transparent 100%
       );
     mask-composite: intersect;
+
+    &:focus {
+      mask-image: none;
+    }
   }
 }
 


### PR DESCRIPTION
The single and multi code snippet edge-fade applied `mask-image` to the same element that draws the focus outline, so the gradient clipped the right edge of the focus ring. This drops the mask while the snippet container is focused so the outline renders unbroken above where the fade was. Scoped as `chore` because the edge fade has not shipped in a release yet.