### PR TITLE
docs(code-snippet): ensure multi-line examples overflow expand threshold

### DIFF
--- a/docs/src/pages/framed/CodeSnippet/CodeSnippetCustomText.svelte
+++ b/docs/src/pages/framed/CodeSnippet/CodeSnippetCustomText.svelte
@@ -2,7 +2,7 @@
   import { CodeSnippet } from "carbon-components-svelte";
 
   let code =
-    "export function multiply(a: number, b: number) {\n  return a * b;\n}\n\nexport function divide(a: number, b: number) {\n  return a / b;\n}\n\nexport function add(a: number, b: number) {\n  return a + b;\n}\n\nexport function subtract(a: number, b: number) {\n  return a - b;\n}";
+    "export function add(a: number, b: number) {\n  return a + b;\n}\n\nexport function subtract(a: number, b: number) {\n  return a - b;\n}\n\nexport function multiply(a: number, b: number) {\n  return a * b;\n}\n\nexport function divide(a: number, b: number) {\n  return a / b;\n}\n\nexport function modulo(a: number, b: number) {\n  return a % b;\n}\n\nexport function power(a: number, b: number) {\n  return a ** b;\n}\n\nexport function negate(a: number) {\n  return -a;\n}";
 </script>
 
 <CodeSnippet

--- a/docs/src/pages/framed/CodeSnippet/CodeSnippetExpanded.svelte
+++ b/docs/src/pages/framed/CodeSnippet/CodeSnippetExpanded.svelte
@@ -2,7 +2,7 @@
   import { CodeSnippet } from "carbon-components-svelte";
 
   let code =
-    "export function multiply(a: number, b: number) {\n  return a * b;\n}\n\nexport function divide(a: number, b: number) {\n  return a / b;\n}\n\nexport function add(a: number, b: number) {\n  return a + b;\n}\n\nexport function subtract(a: number, b: number) {\n  return a - b;\n}";
+    "export function add(a: number, b: number) {\n  return a + b;\n}\n\nexport function subtract(a: number, b: number) {\n  return a - b;\n}\n\nexport function multiply(a: number, b: number) {\n  return a * b;\n}\n\nexport function divide(a: number, b: number) {\n  return a / b;\n}\n\nexport function modulo(a: number, b: number) {\n  return a % b;\n}\n\nexport function power(a: number, b: number) {\n  return a ** b;\n}\n\nexport function negate(a: number) {\n  return -a;\n}";
 </script>
 
 <CodeSnippet type="multi" {code} expanded />

--- a/docs/src/pages/framed/CodeSnippet/CodeSnippetHideButtons.svelte
+++ b/docs/src/pages/framed/CodeSnippet/CodeSnippetHideButtons.svelte
@@ -2,7 +2,7 @@
   import { CodeSnippet } from "carbon-components-svelte";
 
   let code =
-    "export function multiply(a: number, b: number) {\n  return a * b;\n}\n\nexport function divide(a: number, b: number) {\n  return a / b;\n}\n\nexport function add(a: number, b: number) {\n  return a + b;\n}\n\nexport function subtract(a: number, b: number) {\n  return a - b;\n}";
+    "export function add(a: number, b: number) {\n  return a + b;\n}\n\nexport function subtract(a: number, b: number) {\n  return a - b;\n}\n\nexport function multiply(a: number, b: number) {\n  return a * b;\n}\n\nexport function divide(a: number, b: number) {\n  return a / b;\n}\n\nexport function modulo(a: number, b: number) {\n  return a % b;\n}\n\nexport function power(a: number, b: number) {\n  return a ** b;\n}\n\nexport function negate(a: number) {\n  return -a;\n}";
 </script>
 
 <CodeSnippet type="multi" {code} hideCopyButton showMoreLess={false} />

--- a/docs/src/pages/framed/CodeSnippet/CodeSnippetHideCopyButton.svelte
+++ b/docs/src/pages/framed/CodeSnippet/CodeSnippetHideCopyButton.svelte
@@ -2,7 +2,7 @@
   import { CodeSnippet } from "carbon-components-svelte";
 
   let code =
-    "export function multiply(a: number, b: number) {\n  return a * b;\n}\n\nexport function divide(a: number, b: number) {\n  return a / b;\n}\n\nexport function add(a: number, b: number) {\n  return a + b;\n}\n\nexport function subtract(a: number, b: number) {\n  return a - b;\n}";
+    "export function add(a: number, b: number) {\n  return a + b;\n}\n\nexport function subtract(a: number, b: number) {\n  return a - b;\n}\n\nexport function multiply(a: number, b: number) {\n  return a * b;\n}\n\nexport function divide(a: number, b: number) {\n  return a / b;\n}\n\nexport function modulo(a: number, b: number) {\n  return a % b;\n}\n\nexport function power(a: number, b: number) {\n  return a ** b;\n}\n\nexport function negate(a: number) {\n  return -a;\n}";
 </script>
 
 <CodeSnippet type="multi" {code} hideCopyButton />

--- a/docs/src/pages/framed/CodeSnippet/CodeSnippetHideShowMore.svelte
+++ b/docs/src/pages/framed/CodeSnippet/CodeSnippetHideShowMore.svelte
@@ -2,7 +2,7 @@
   import { CodeSnippet } from "carbon-components-svelte";
 
   let code =
-    "export function multiply(a: number, b: number) {\n  return a * b;\n}\n\nexport function divide(a: number, b: number) {\n  return a / b;\n}\n\nexport function add(a: number, b: number) {\n  return a + b;\n}\n\nexport function subtract(a: number, b: number) {\n  return a - b;\n}";
+    "export function add(a: number, b: number) {\n  return a + b;\n}\n\nexport function subtract(a: number, b: number) {\n  return a - b;\n}\n\nexport function multiply(a: number, b: number) {\n  return a * b;\n}\n\nexport function divide(a: number, b: number) {\n  return a / b;\n}\n\nexport function modulo(a: number, b: number) {\n  return a % b;\n}\n\nexport function power(a: number, b: number) {\n  return a ** b;\n}\n\nexport function negate(a: number) {\n  return -a;\n}";
 </script>
 
 <CodeSnippet type="multi" {code} showMoreLess={false} />

--- a/docs/src/pages/framed/CodeSnippet/CodeSnippetMultiLine.svelte
+++ b/docs/src/pages/framed/CodeSnippet/CodeSnippetMultiLine.svelte
@@ -2,7 +2,7 @@
   import { CodeSnippet } from "carbon-components-svelte";
 
   let code =
-    "export function multiply(a: number, b: number) {\n  return a * b;\n}\n\nexport function divide(a: number, b: number) {\n  return a / b;\n}\n\nexport function add(a: number, b: number) {\n  return a + b;\n}\n\nexport function subtract(a: number, b: number) {\n  return a - b;\n}";
+    "export function add(a: number, b: number) {\n  return a + b;\n}\n\nexport function subtract(a: number, b: number) {\n  return a - b;\n}\n\nexport function multiply(a: number, b: number) {\n  return a * b;\n}\n\nexport function divide(a: number, b: number) {\n  return a / b;\n}\n\nexport function modulo(a: number, b: number) {\n  return a % b;\n}\n\nexport function power(a: number, b: number) {\n  return a ** b;\n}\n\nexport function negate(a: number) {\n  return -a;\n}";
 </script>
 
 <CodeSnippet type="multi" {code} />


### PR DESCRIPTION
The 15-line sample measured exactly 240px, the collapsed-height cutoff, so the dynamically-gated expand button never rendered and `expanded` silently auto-collapsed. Bump to 27 lines to clear it.