### PR TITLE
fix(select): re-assert native value when an option unmounts

### DIFF
--- a/e2e/fixtures/ItemsResyncFixture.svelte
+++ b/e2e/fixtures/ItemsResyncFixture.svelte
@@ -22,6 +22,13 @@
     { id: "woolf", text: "Virginia Woolf" },
   ];
 
+  // Drops a non-selected option (austen) while keeping the selected one (orwell).
+  const makeWithoutAusten = () => [
+    { id: "dickens", text: "Charles Dickens" },
+    { id: "orwell", text: "George Orwell" },
+    { id: "woolf", text: "Virginia Woolf" },
+  ];
+
   const cbPreloadItems = make();
   let cbPreloadSelectedId = "orwell";
   let cbPreloadValue = "";
@@ -38,14 +45,24 @@
   let cbRemoveSelectedId = "orwell";
   let cbRemoveValue = "";
 
+  let cbKeepItems = make();
+  let cbKeepSelectedId = "orwell";
+  let cbKeepValue = "George Orwell";
+
   let selFillItems = [];
   let selFillSelected = "orwell";
 
   let selSwapItems = make();
   let selSwapSelected = "orwell";
 
+  let selRemoveItems = make();
+  let selRemoveSelected = "orwell";
+
   let msSwapItems = make();
   let msSwapSelectedIds = ["orwell"];
+
+  let msRemoveItems = make();
+  let msRemoveSelectedIds = ["orwell"];
 
   let msFillItems = [];
   let msFillSelectedIds = ["orwell"];
@@ -70,6 +87,13 @@
     cbRemoveItems = makeWithoutOrwell();
   }
 
+  // Remove a non-selected option from each component while the selection stays present.
+  function removeNonSelected() {
+    selRemoveItems = makeWithoutAusten();
+    cbKeepItems = makeWithoutAusten();
+    msRemoveItems = makeWithoutAusten();
+  }
+
   function clearFill() {
     cbFillItems = [];
     selFillItems = [];
@@ -90,6 +114,13 @@
   on:click={reloadWithoutOrwell}
 >
   Reload without orwell
+</button>
+<button
+  type="button"
+  data-testid="remove-non-selected"
+  on:click={removeNonSelected}
+>
+  Remove non-selected
 </button>
 
 <ComboBox
@@ -128,6 +159,15 @@
 />
 <p data-testid="cb-remove-id">{cbRemoveSelectedId}</p>
 
+<ComboBox
+  data-testid="cb-keep"
+  labelText="ComboBox keep"
+  items={cbKeepItems}
+  bind:selectedId={cbKeepSelectedId}
+  bind:value={cbKeepValue}
+/>
+<p data-testid="cb-keep-id">{cbKeepSelectedId}</p>
+
 <Select
   data-testid="sel-fill"
   labelText="Select fill"
@@ -150,6 +190,17 @@
 </Select>
 <p data-testid="sel-swap-selected">{selSwapSelected}</p>
 
+<Select
+  data-testid="sel-remove"
+  labelText="Select remove non-selected"
+  bind:selected={selRemoveSelected}
+>
+  {#each selRemoveItems as item (item.id)}
+    <SelectItem value={item.id} text={item.text} />
+  {/each}
+</Select>
+<p data-testid="sel-remove-selected">{selRemoveSelected}</p>
+
 <!-- Wrapper carries data-testid; MultiSelect does not spread $$restProps. -->
 <div data-testid="ms-swap">
   <MultiSelect
@@ -160,6 +211,16 @@
   />
 </div>
 <p data-testid="ms-swap-ids">{msSwapSelectedIds.join(",")}</p>
+
+<div data-testid="ms-remove">
+  <MultiSelect
+    labelText="MultiSelect remove non-selected"
+    label="Choose authors"
+    items={msRemoveItems}
+    bind:selectedIds={msRemoveSelectedIds}
+  />
+</div>
+<p data-testid="ms-remove-ids">{msRemoveSelectedIds.join(",")}</p>
 
 <div data-testid="ms-fill">
   <MultiSelect

--- a/e2e/items-resync.test.ts
+++ b/e2e/items-resync.test.ts
@@ -110,6 +110,38 @@ test.describe("Items resync — display derived from value + items", () => {
     await expect(page.getByTestId("ms-fill")).toContainText("1");
   });
 
+  test("Select keeps selection after a non-selected option is removed", async ({
+    page,
+  }) => {
+    // Removing an <option> mutates the native <select> subtree, which can reset
+    // selectedIndex to -1. The unmount cleanup re-asserts ref.value from the store.
+    await expect(page.getByTestId("sel-remove")).toHaveValue("orwell");
+    await page.getByTestId("remove-non-selected").click();
+    await expect(page.getByTestId("sel-remove-selected")).toHaveText("orwell");
+    await expect(page.getByTestId("sel-remove")).toHaveValue("orwell");
+  });
+
+  test("ComboBox keeps selection after a non-selected option is removed", async ({
+    page,
+  }) => {
+    // Display derives from selectedId in JS, so an items change re-resolves it; no
+    // per-option unmount handling is needed.
+    await expect(page.getByTestId("cb-keep")).toHaveValue("George Orwell");
+    await page.getByTestId("remove-non-selected").click();
+    await expect(page.getByTestId("cb-keep-id")).toHaveText("orwell");
+    await expect(page.getByTestId("cb-keep")).toHaveValue("George Orwell");
+  });
+
+  test("MultiSelect keeps selection after a non-selected option is removed", async ({
+    page,
+  }) => {
+    // Selection lives in selectedIds; an items change re-baselines checked counts.
+    await expect(page.getByTestId("ms-remove")).toContainText("1");
+    await page.getByTestId("remove-non-selected").click();
+    await expect(page.getByTestId("ms-remove-ids")).toHaveText("orwell");
+    await expect(page.getByTestId("ms-remove")).toContainText("1");
+  });
+
   test("Dropdown shows selection after async fill (reference)", async ({
     page,
   }) => {

--- a/src/Select/SelectItem.svelte
+++ b/src/Select/SelectItem.svelte
@@ -54,7 +54,10 @@
   });
 
   onMount(() => {
-    return () => unsubscribe();
+    return () => {
+      unsubscribe();
+      ctx?.syncNativeSelectValue?.();
+    };
   });
 </script>
 


### PR DESCRIPTION
_Removing_ an option from a native `<select>` can reset selectedIndex to -1, so SelectItem now re-asserts the native value on unmount the same way 9e60780 does on mount. `ComboBox` and `MultiSelect` track their selection in JS so they don't need this.