### PR TITLE
test(date-picker): compute expected day labels from current date

### DIFF
--- a/tests/DatePicker/DatePickerClose.test.ts
+++ b/tests/DatePicker/DatePickerClose.test.ts
@@ -7,6 +7,14 @@ afterEach(() => {
   cleanup();
 });
 
+function ariaLabelForDayInCurrentMonth(day: number) {
+  const now = new Date();
+  return new Date(now.getFullYear(), now.getMonth(), day).toLocaleDateString(
+    "en-US",
+    { month: "long", day: "numeric", year: "numeric" },
+  );
+}
+
 describe("DatePicker close event", () => {
   it('dispatches close with trigger "select" when a date is chosen', async () => {
     const onClose = vi.fn();
@@ -127,7 +135,7 @@ describe("DatePicker close event", () => {
       return openCalendar;
     });
     const startDay = calendar.querySelector<HTMLElement>(
-      '[aria-label="June 1, 2026"]',
+      `[aria-label="${ariaLabelForDayInCurrentMonth(1)}"]`,
     );
     if (!startDay) throw new Error("expected a start day");
 
@@ -161,7 +169,7 @@ describe("DatePicker close event", () => {
       return openCalendar;
     });
     const startDay = calendar.querySelector<HTMLElement>(
-      '[aria-label="June 1, 2026"]',
+      `[aria-label="${ariaLabelForDayInCurrentMonth(1)}"]`,
     );
     if (!startDay) throw new Error("expected a start day");
 
@@ -169,7 +177,7 @@ describe("DatePicker close event", () => {
     await tick();
 
     const endDay = calendar.querySelector<HTMLElement>(
-      '[aria-label="June 15, 2026"]',
+      `[aria-label="${ariaLabelForDayInCurrentMonth(15)}"]`,
     );
     if (!endDay) throw new Error("expected an end day");
 


### PR DESCRIPTION
Hardcoded "June 1/15, 2026" aria-labels only matched the calendar's
default month while today happened to fall in June 2026; deriving
the label from `new Date()` keeps the test correct going forward.