### PR TITLE
feat(menu): add anchored Menu/MenuItem primitive

### DIFF
--- a/docs/src/component-categories.ts
+++ b/docs/src/component-categories.ts
@@ -129,7 +129,7 @@ export const COMPONENT_CATEGORIES: ComponentCategory[] = [
   },
   {
     label: "Misc",
-    components: ["UserAvatar", "UserAvatarGroup"],
+    components: ["UserAvatar", "UserAvatarGroup", "Menu"],
   },
 ];
 

--- a/docs/src/component-since-versions.ts
+++ b/docs/src/component-since-versions.ts
@@ -33,6 +33,7 @@ export const COMPONENT_SINCE_VERSIONS: Record<string, string> = {
   Link: "0.2.0",
   Loading: "0.2.0",
   LocalStorage: "0.30.0",
+  Menu: "0.110.0",
   Modal: "0.2.0",
   MultiSelect: "0.2.0",
   NotificationQueue: "0.94.0",

--- a/docs/src/pages/components/Menu.svx
+++ b/docs/src/pages/components/Menu.svx
@@ -1,0 +1,29 @@
+---
+components: ["Menu", "MenuItem"]
+description: Menu is a low-level primitive that anchors a list of actions to a trigger element, with keyboard navigation and outside-click dismissal built in.
+---
+
+<script>
+</script>
+
+## Basic
+
+Menu positions its content relative to an `anchor` element and does not render a trigger of its own. Bind a reference to the element that opens the menu, then control `open` from that element's event handler. Use `MenuItem` for each action; set `disabled` to make an item non-interactive.
+
+The root element has `role="menu"`. Set `labelText` or `aria-label` on Menu so assistive technologies get a meaningful name, since there is no visible text the menu is otherwise associated with.
+
+<FileSource src="/framed/Menu/MenuBasic" />
+
+## Direction
+
+Set `direction` to `"top"`, `"bottom"`, `"left"`, or `"right"` to control which side of the anchor the menu opens toward. The menu flips to the opposite side automatically when there is not enough space.
+
+<FileSource src="/framed/Menu/MenuDirection" />
+
+## Keyboard interactions
+
+Once open, arrow keys move focus between items without wrapping past the first or last item. <DocKbd label="Home" /> and <DocKbd label="End" /> jump to the first and last enabled item, skipping disabled ones. The menu closes from an item selection, <DocKbd label="Escape" />, or an outside click; <DocKbd label="Escape" /> also returns focus to the anchor.
+
+## Placement
+
+Menu forwards the same placement props as [FloatingPortal](/components/FloatingPortal): `gapTop`, `gapBottom`, `horizontalGapLeft`, `horizontalGapRight`, `verticalAlignOffsetLeft`, `verticalAlignOffsetRight`, `zIndex`, `intrinsicWidth`, `intrinsicAlign`, and `target`. See the FloatingPortal documentation for how each affects positioning.

--- a/docs/src/pages/framed/Menu/MenuBasic.svelte
+++ b/docs/src/pages/framed/Menu/MenuBasic.svelte
@@ -1,0 +1,15 @@
+<script>
+  import { Button, Menu, MenuItem } from "carbon-components-svelte";
+
+  let anchor;
+  let open = false;
+</script>
+
+<Button bind:ref={anchor} on:click={() => (open = !open)}>Actions</Button>
+
+<Menu {anchor} bind:open labelText="Actions menu">
+  <MenuItem on:click={() => console.log("Cut")}>Cut</MenuItem>
+  <MenuItem on:click={() => console.log("Copy")}>Copy</MenuItem>
+  <MenuItem on:click={() => console.log("Paste")}>Paste</MenuItem>
+  <MenuItem disabled>Delete</MenuItem>
+</Menu>

--- a/docs/src/pages/framed/Menu/MenuDirection.svelte
+++ b/docs/src/pages/framed/Menu/MenuDirection.svelte
@@ -1,0 +1,16 @@
+<script>
+  import { Button, Menu, MenuItem } from "carbon-components-svelte";
+
+  let anchor;
+  let open = false;
+</script>
+
+<div style="margin-top: 220px;">
+  <Button bind:ref={anchor} on:click={() => (open = !open)}>Actions</Button>
+</div>
+
+<Menu {anchor} direction="top" bind:open labelText="Actions menu">
+  <MenuItem on:click={() => console.log("Cut")}>Cut</MenuItem>
+  <MenuItem on:click={() => console.log("Copy")}>Copy</MenuItem>
+  <MenuItem on:click={() => console.log("Paste")}>Paste</MenuItem>
+</Menu>

--- a/src/Menu/Menu.svelte
+++ b/src/Menu/Menu.svelte
@@ -1,0 +1,187 @@
+<script>
+  /**
+   * @event {HTMLElement} open
+   */
+
+  /**
+   * @event close
+   * @type {object}
+   * @property {"escape-key" | "outside-click" | "select"} trigger
+   */
+
+  /**
+   * Required. Specify the anchor element to position the menu relative to.
+   * @type {null | HTMLElement}
+   */
+  export let anchor = null;
+
+  /**
+   * Set the preferred direction of the menu.
+   * The menu flips to the opposite direction if there is not enough space.
+   * @type {"bottom" | "top" | "left" | "right"}
+   */
+  export let direction = "bottom";
+
+  /**
+   * Set to `true` to open the menu.
+   * @bindable writable
+   */
+  export let open = false;
+
+  /**
+   * Obtain a reference to the unordered list HTML element.
+   * @bindable readonly
+   */
+  export let ref = null;
+
+  /**
+   * Accessible name for the menu.
+   * Prefer setting this (or `aria-label`) when there is no visible trigger
+   * text for `aria-labelledby`.
+   * @type {string | undefined}
+   */
+  export let labelText = undefined;
+
+  /** Vertical gap in pixels when direction is top. */
+  export let gapTop = 0;
+
+  /** Vertical gap in pixels when direction is bottom. */
+  export let gapBottom = 0;
+
+  /** Horizontal gap in pixels when direction is left. */
+  export let horizontalGapLeft = 0;
+
+  /** Horizontal gap in pixels when direction is right. */
+  export let horizontalGapRight = 0;
+
+  /** Vertical offset in pixels when direction is left. */
+  export let verticalAlignOffsetLeft = 0;
+
+  /** Vertical offset in pixels when direction is right. */
+  export let verticalAlignOffsetRight = 0;
+
+  /** Specify the z-index of the menu. */
+  export let zIndex = 9200;
+
+  /**
+   * Set to `true` to use the menu's intrinsic width instead of matching the anchor width.
+   * @type {boolean}
+   */
+  export let intrinsicWidth = false;
+
+  /**
+   * When `intrinsicWidth` is true, align the menu to the anchor.
+   * @type {"start" | "center" | "end"}
+   */
+  export let intrinsicAlign = "center";
+
+  /**
+   * DOM node to mount the menu into.
+   * When unset, uses the anchor's nearest `<dialog>` or `[popover]`, else `document.body`.
+   * @type {HTMLElement | null}
+   */
+  export let target = null;
+
+  import { createEventDispatcher, setContext, tick } from "svelte";
+  import FloatingPortal from "../Portal/FloatingPortal.svelte";
+  import { dismiss } from "../utils/dismiss.js";
+  import { isOutsideClick } from "../utils/isOutsideClick.js";
+  import { rovingFocus } from "../utils/rovingFocus.js";
+
+  const dispatch = createEventDispatcher();
+
+  let focusIndex = -1;
+  let prevOpen = false;
+
+  /**
+   * @type {(trigger: "escape-key" | "outside-click" | "select") => void}
+   */
+  function close(trigger) {
+    if (!open) return;
+    open = false;
+    if (trigger === "escape-key") anchor?.focus({ preventScroll: true });
+    dispatch("close", { trigger });
+  }
+
+  setContext("carbon:Menu", { close });
+
+  $: {
+    if (open && !prevOpen) {
+      focusIndex = -1;
+      tick().then(() => {
+        if (!open) return;
+        ref?.focus();
+        dispatch("open", anchor);
+      });
+    }
+    prevOpen = open;
+  }
+
+  $: menuAriaLabel = ($$props["aria-label"] ?? labelText) || undefined;
+
+  function handleOutsideClick(event) {
+    if (open && isOutsideClick(event, [anchor, ref])) close("outside-click");
+  }
+  function handleEscape(event) {
+    if (open && event.key === "Escape") close("escape-key");
+  }
+</script>
+
+<FloatingPortal
+  {anchor}
+  {direction}
+  {open}
+  {gapTop}
+  {gapBottom}
+  {horizontalGapLeft}
+  {horizontalGapRight}
+  {verticalAlignOffsetLeft}
+  {verticalAlignOffsetRight}
+  {zIndex}
+  {intrinsicWidth}
+  {intrinsicAlign}
+  {target}
+  let:direction={portalDirection}
+>
+  <!-- svelte-ignore a11y-no-noninteractive-element-to-interactive-role -->
+  <ul
+    bind:this={ref}
+    use:rovingFocus={{
+      selector: "[role='menuitem']:not([aria-disabled='true'])",
+      orientation: "vertical",
+      wrap: false,
+      focusOnMove: true,
+      getActiveIndex: () => focusIndex,
+      onMove: (index) => {
+        focusIndex = index;
+      },
+    }}
+    use:dismiss={{
+      enabled: open,
+      listeners: [
+        { type: "click", handler: handleOutsideClick },
+        { type: "keydown", handler: handleEscape },
+      ],
+    }}
+    role="menu"
+    tabindex="-1"
+    data-floating-menu-direction={portalDirection}
+    style:position="relative"
+    style:top="auto"
+    style:left="auto"
+    class:bx--menu={true}
+    class:bx--menu--open={open}
+    {...$$restProps}
+    aria-label={menuAriaLabel}
+    on:keydown
+    on:keydown={(event) => {
+      if (
+        ["ArrowDown", "ArrowUp", "Home", "End"].includes(event.key)
+      ) {
+        event.preventDefault();
+      }
+    }}
+  >
+    <slot />
+  </ul>
+</FloatingPortal>

--- a/src/Menu/MenuItem.svelte
+++ b/src/Menu/MenuItem.svelte
@@ -1,0 +1,54 @@
+<script>
+  /**
+   * @event {MouseEvent} click
+   */
+
+  /** Set to `true` to disable the item */
+  export let disabled = false;
+
+  /**
+   * Obtain a reference to the list item HTML element.
+   * @bindable readonly
+   */
+  export let ref = null;
+
+  import { createEventDispatcher, getContext } from "svelte";
+
+  const dispatch = createEventDispatcher();
+  const ctx = getContext("carbon:Menu");
+
+  function handleClick(event) {
+    if (disabled) return;
+
+    const shouldContinue = dispatch("click", event, { cancelable: true });
+
+    if (shouldContinue) {
+      ctx.close("select");
+    }
+  }
+</script>
+
+<li
+  bind:this={ref}
+  role="menuitem"
+  tabindex="-1"
+  aria-disabled={disabled}
+  class:bx--menu-option={true}
+  class:bx--menu-option--disabled={disabled}
+  {...$$restProps}
+  on:keydown
+  on:keydown={(event) => {
+    if (disabled) return;
+    if (event.key === " " || event.key === "Enter") handleClick(event);
+  }}
+  on:click={handleClick}
+>
+  <div
+    class:bx--menu-option__content={true}
+    class:bx--menu-option__content--disabled={disabled}
+  >
+    <span class:bx--menu-option__label={true}>
+      <slot />
+    </span>
+  </div>
+</li>

--- a/src/Menu/index.js
+++ b/src/Menu/index.js
@@ -1,0 +1,2 @@
+export { default as Menu } from "./Menu.svelte";
+export { default as MenuItem } from "./MenuItem.svelte";

--- a/src/index.js
+++ b/src/index.js
@@ -87,6 +87,8 @@ export { default as ListBoxSelection } from "./ListBox/ListBoxSelection.svelte";
 export { default as ListItem } from "./ListItem/ListItem.svelte";
 export { default as Loading } from "./Loading/Loading.svelte";
 export { default as LocalStorage } from "./LocalStorage/LocalStorage.svelte";
+export { default as Menu } from "./Menu/Menu.svelte";
+export { default as MenuItem } from "./Menu/MenuItem.svelte";
 export { default as Modal } from "./Modal/Modal.svelte";
 export { default as FluidMultiSelectSkeleton } from "./MultiSelect/FluidMultiSelectSkeleton.svelte";
 export { default as MultiSelect } from "./MultiSelect/MultiSelect.svelte";

--- a/tests/Menu/Menu.test.svelte
+++ b/tests/Menu/Menu.test.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+  import Menu from "carbon-components-svelte/Menu/Menu.svelte";
+  import MenuItem from "carbon-components-svelte/Menu/MenuItem.svelte";
+  import type { ComponentProps } from "svelte";
+
+  export let direction: ComponentProps<Menu>["direction"] = "bottom";
+  export let disabledIndex: number | undefined = undefined;
+
+  let anchor: HTMLButtonElement;
+  let open = false;
+
+  const items = ["First", "Second", "Third"];
+</script>
+
+<button type="button" bind:this={anchor} on:click={() => (open = !open)}>
+  Trigger
+</button>
+
+<Menu
+  {anchor}
+  {direction}
+  bind:open
+  labelText="Example menu"
+  on:open={(e) => console.log("open", e.detail)}
+  on:close={(e) => console.log("close", e.detail)}
+>
+  {#each items as text, index}
+    <MenuItem
+      disabled={index === disabledIndex}
+      on:click={() => console.log("click", text)}
+    >
+      {text}
+    </MenuItem>
+  {/each}
+</Menu>

--- a/tests/Menu/Menu.test.ts
+++ b/tests/Menu/Menu.test.ts
@@ -1,0 +1,171 @@
+import { render, screen } from "@testing-library/svelte";
+import { user } from "../utils/user";
+import MenuFixture from "./Menu.test.svelte";
+
+describe("Menu", () => {
+  it("opens and renders items in a portal, not nested in the anchor", async () => {
+    render(MenuFixture);
+
+    const trigger = screen.getByRole("button", { name: "Trigger" });
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+
+    await user.click(trigger);
+
+    const menu = screen.getByRole("menu");
+    expect(menu).toBeInTheDocument();
+    expect(trigger.contains(menu)).toBe(false);
+
+    const floatingPortal = menu.closest("[data-floating-portal]");
+    expect(floatingPortal).toBeInTheDocument();
+    expect(floatingPortal?.parentElement).toBe(document.body);
+
+    expect(screen.getAllByRole("menuitem")).toHaveLength(3);
+  });
+
+  it("applies the aria-label from labelText", async () => {
+    render(MenuFixture);
+
+    await user.click(screen.getByRole("button", { name: "Trigger" }));
+
+    expect(screen.getByRole("menu")).toHaveAttribute(
+      "aria-label",
+      "Example menu",
+    );
+  });
+
+  it("overrides fixed positioning so FloatingPortal controls placement", async () => {
+    render(MenuFixture);
+
+    await user.click(screen.getByRole("button", { name: "Trigger" }));
+
+    const menu = screen.getByRole("menu");
+    expect(menu.style.position).toBe("relative");
+  });
+
+  it("applies the direction attribute", async () => {
+    render(MenuFixture, { props: { direction: "top" } });
+
+    await user.click(screen.getByRole("button", { name: "Trigger" }));
+
+    expect(screen.getByRole("menu")).toHaveAttribute(
+      "data-floating-menu-direction",
+      "top",
+    );
+  });
+
+  it("focuses the menu on open and dispatches the open event", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(MenuFixture);
+
+    await user.click(screen.getByRole("button", { name: "Trigger" }));
+
+    expect(screen.getByRole("menu")).toHaveFocus();
+    expect(consoleLog).toHaveBeenCalledWith("open", expect.any(HTMLElement));
+  });
+
+  it("navigates items with arrow keys without wrapping", async () => {
+    render(MenuFixture);
+
+    await user.click(screen.getByRole("button", { name: "Trigger" }));
+    const items = screen.getAllByRole("menuitem");
+
+    await user.keyboard("{ArrowDown}");
+    expect(items[0]).toHaveFocus();
+
+    await user.keyboard("{ArrowDown}");
+    expect(items[1]).toHaveFocus();
+
+    await user.keyboard("{ArrowDown}");
+    expect(items[2]).toHaveFocus();
+
+    // Clamps at the last item instead of wrapping.
+    await user.keyboard("{ArrowDown}");
+    expect(items[2]).toHaveFocus();
+
+    await user.keyboard("{ArrowUp}");
+    expect(items[1]).toHaveFocus();
+  });
+
+  it("supports Home and End to jump to the first/last item", async () => {
+    render(MenuFixture);
+
+    await user.click(screen.getByRole("button", { name: "Trigger" }));
+    const items = screen.getAllByRole("menuitem");
+
+    await user.keyboard("{End}");
+    expect(items[2]).toHaveFocus();
+
+    await user.keyboard("{Home}");
+    expect(items[0]).toHaveFocus();
+  });
+
+  it("skips disabled items during keyboard navigation", async () => {
+    render(MenuFixture, { props: { disabledIndex: 1 } });
+
+    await user.click(screen.getByRole("button", { name: "Trigger" }));
+    const items = screen.getAllByRole("menuitem");
+    expect(items[1]).toHaveAttribute("aria-disabled", "true");
+
+    await user.keyboard("{ArrowDown}");
+    expect(items[0]).toHaveFocus();
+
+    await user.keyboard("{ArrowDown}");
+    expect(items[2]).toHaveFocus();
+  });
+
+  it("dispatches click and closes the menu when an item is selected", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(MenuFixture);
+
+    await user.click(screen.getByRole("button", { name: "Trigger" }));
+    const items = screen.getAllByRole("menuitem");
+
+    await user.click(items[0]);
+
+    expect(consoleLog).toHaveBeenCalledWith("click", "First");
+    expect(consoleLog).toHaveBeenCalledWith("close", { trigger: "select" });
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+  });
+
+  it("does not select or close when clicking a disabled item", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(MenuFixture, { props: { disabledIndex: 0 } });
+
+    await user.click(screen.getByRole("button", { name: "Trigger" }));
+    const items = screen.getAllByRole("menuitem");
+
+    await user.click(items[0]);
+
+    expect(consoleLog).not.toHaveBeenCalledWith("click", "First");
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+  });
+
+  it("closes and returns focus to the anchor on Escape", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(MenuFixture);
+
+    const trigger = screen.getByRole("button", { name: "Trigger" });
+    await user.click(trigger);
+
+    await user.keyboard("{Escape}");
+
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    expect(trigger).toHaveFocus();
+    expect(consoleLog).toHaveBeenCalledWith("close", {
+      trigger: "escape-key",
+    });
+  });
+
+  it("closes on outside click without returning focus", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(MenuFixture);
+
+    await user.click(screen.getByRole("button", { name: "Trigger" }));
+    await user.click(document.body);
+
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    expect(consoleLog).toHaveBeenCalledWith("close", {
+      trigger: "outside-click",
+    });
+  });
+});


### PR DESCRIPTION
Adds a generic `Menu`/`MenuItem` primitive, ported from Carbon React v11's `menu/` package (the shared building block behind `MenuButton`, `ComboButton`, and the newer `OverflowMenu`). It anchors to a trigger element via `FloatingPortal` and reuses `ContextMenu`'s existing `rovingFocus`/`dismiss` utils for keyboard nav, so it only supports anchor-relative floating positioning, not `ContextMenu`'s right-click x/y coordinates — that positioning model already exists and doesn't need duplicating here. This unblocks the dedicated `MenuButton` (#2489) and `ComboButton` (#2488) efforts, which can now compose this primitive instead of hand-rolling their own anchored menu.

```svelte
<script>
  import { Button, Menu, MenuItem } from "carbon-components-svelte";
  let anchor;
  let open = false;
</script>

<Button bind:ref={anchor} on:click={() => (open = !open)}>Actions</Button>
<Menu {anchor} bind:open labelText="Actions menu">
  <MenuItem on:click={() => console.log("Cut")}>Cut</MenuItem>
  <MenuItem disabled>Delete</MenuItem>
</Menu>
```
<img width="518" height="285" alt="Screenshot 2026-07-02 at 3 09 46 PM" src="https://github.com/user-attachments/assets/ad7ce7f8-77d5-4038-bbf2-1abd5d0f1f98" />
