### PR TITLE
fix(select)!: isolate chevron position from user-supplied margin

### DIFF
--- a/src/Select/Select.svelte
+++ b/src/Select/Select.svelte
@@ -2,6 +2,7 @@
   /**
    * @template {string | number} [Value=string | number]
    * @event {Value} update The selected value.
+   * @restProps {div}
    */
 
   /**
@@ -191,7 +192,11 @@
   $: isFluid = !inline && (fluid || !!formContext?.isFluid);
 </script>
 
-<div class:bx--form-item={true} class:bx--select--fluid={isFluid}>
+<div
+  class:bx--form-item={true}
+  class:bx--select--fluid={isFluid}
+  {...$$restProps}
+>
   <div
     class:bx--select={true}
     class:bx--select--inline={inline}
@@ -229,6 +234,8 @@
                   : undefined}
             aria-invalid={showInvalid || undefined}
             aria-readonly={readonly || undefined}
+            aria-label={$$props["aria-label"]}
+            aria-labelledby={$$props["aria-labelledby"]}
             disabled={disabled || undefined}
             required={required || undefined}
             {id}
@@ -237,7 +244,6 @@
             class:bx--select-input--xs={size === "xs"}
             class:bx--select-input--sm={size === "sm"}
             class:bx--select-input--xl={size === "xl"}
-            {...$$restProps}
             on:change={handleChange}
             on:change
             on:input
@@ -299,11 +305,12 @@
           required={required || undefined}
           aria-invalid={showInvalid || undefined}
           aria-readonly={readonly || undefined}
+          aria-label={$$props["aria-label"]}
+          aria-labelledby={$$props["aria-labelledby"]}
           class:bx--select-input={true}
           class:bx--select-input--xs={size === "xs"}
           class:bx--select-input--sm={size === "sm"}
           class:bx--select-input--xl={size === "xl"}
-          {...$$restProps}
           on:change={handleChange}
           on:change
           on:input

--- a/tests/Select/Select.test.svelte
+++ b/tests/Select/Select.test.svelte
@@ -36,6 +36,7 @@
   {light}
   {readonly}
   {fluid}
+  {...$$restProps}
   on:change={() => console.log("change")}
   on:input={() => console.log("input")}
   on:update={(e) => console.log("update", e.detail)}

--- a/tests/Select/Select.test.ts
+++ b/tests/Select/Select.test.ts
@@ -472,6 +472,32 @@ describe("Select", () => {
     expect(label).toHaveClass("bx--visually-hidden");
   });
 
+  // Regression test for https://github.com/carbon-design-system/carbon-components-svelte/issues/3136
+  it("applies a user-supplied class to the outer wrapper, not the select or chevron", () => {
+    render(Select, { class: "mb32" });
+
+    const selectElement = screen.getByLabelText("Select label");
+    const wrapper = selectElement.closest(".bx--form-item");
+    assert(wrapper);
+
+    expect(wrapper).toHaveClass("mb32");
+    expect(selectElement).not.toHaveClass("mb32");
+
+    const chevron = wrapper.querySelector(".bx--select__arrow");
+    assert(chevron);
+    expect(chevron.closest(".bx--select-input__wrapper")).not.toHaveClass(
+      "mb32",
+    );
+  });
+
+  // Regression test for https://github.com/carbon-design-system/carbon-components-svelte/issues/3136
+  it("forwards aria-label to the select element despite restProps moving to the wrapper", () => {
+    render(Select, { "aria-label": "Custom label" });
+
+    const selectElement = screen.getByLabelText("Select label");
+    expect(selectElement).toHaveAttribute("aria-label", "Custom label");
+  });
+
   it("renders with SelectItemGroup", () => {
     render(SelectGroup);
 


### PR DESCRIPTION

Fixes #3136

- A margin applied to `<select>` (via `class` or inline `style`) grew the auto-height flex wrapper the chevron icon sizes against (`height: 100%`), shifting the chevron off the visible field.
- `$$restProps` now spreads onto the outer `.bx--form-item` wrapper instead of the `<select>` element, so consumer-supplied layout props no longer participate in the chevron's positioning context.
- `aria-label`/`aria-labelledby` are forwarded explicitly to the `<select>` element(s) so the `noLabel` + `aria-label` accessible-naming pattern keeps working now that `$$restProps` moved.

### Breaking change

`$$restProps` attributes other than `class`/`style` (for example `data-testid`, `autofocus`, `form`) now land on the wrapper `<div>` instead of `<select>`. There was no documented `@restProps` contract prior to this change; `@restProps {div}` is now documented.
