### PR TITLE
chore(user-avatar-group): add stackOrder prop

### DIFF
--- a/css/_user-avatar-group.scss
+++ b/css/_user-avatar-group.scss
@@ -34,10 +34,29 @@
     box-shadow: 0 0 0 $carbon--spacing-01 var(--cds-ui-background, #{$ui-background});
   }
 
-  // Lift the hovered or focused avatar to the front of the stack.
+  // `stackOrder="first"`: reverse the default paint order so earlier avatars
+  // sit above later ones. `--user-avatar-index` is set per avatar in JS;
+  // `--user-avatar-group-count` on the container keeps every index positive.
+  .#{$prefix}--user-avatar-group--stack-first > * {
+    z-index: calc(
+      var(--user-avatar-group-count, 0) - var(--user-avatar-index, 0)
+    );
+  }
+
+  // The "+N" overflow chip opts out of item registration (it isn't a real
+  // avatar), so it never gets a `--user-avatar-index`. Pin it behind every
+  // real avatar instead of letting it fall back to the same z-index as the
+  // first one.
+  .#{$prefix}--user-avatar-group--stack-first
+    > *:has(.#{$prefix}--user-avatar-group__overflow) {
+    z-index: 0;
+  }
+
+  // Lift the hovered or focused avatar to the front of the stack, above the
+  // highest z-index a reversed stack can produce.
   .#{$prefix}--user-avatar-group--overlap > *:hover,
   .#{$prefix}--user-avatar-group--overlap > *:focus-within {
-    z-index: 1;
+    z-index: calc(var(--user-avatar-group-count, 0) + 1);
   }
 }
 

--- a/docs/src/pages/components/UserAvatarGroup.svx
+++ b/docs/src/pages/components/UserAvatarGroup.svx
@@ -86,6 +86,16 @@ Set `gap` to a negative length string to overlap the avatars by that amount, tig
   <UserAvatar backgroundColor="auto" name="Dinesh Chugtai" tooltipText="Dinesh Chugtai" />
 </UserAvatarGroup>
 
+### Stack order
+
+By default, the last avatar paints on top. Set `stackOrder="first"` to keep the first avatar most prominent instead.
+
+<UserAvatarGroup stackOrder="first">
+  <UserAvatar backgroundColor="auto" name="Monica" tooltipText="Monica" />
+  <UserAvatar backgroundColor="auto" name="Richard Hendricks" tooltipText="Richard Hendricks" />
+  <UserAvatar backgroundColor="auto" name="Dinesh Chugtai" tooltipText="Dinesh Chugtai" />
+</UserAvatarGroup>
+
 ## Sizes
 
 Set `size` on the group to resize every avatar at once, including the overflow chip. A child can still override with its own `size`.

--- a/e2e/fixtures/UserAvatarGroupFixture.svelte
+++ b/e2e/fixtures/UserAvatarGroupFixture.svelte
@@ -68,3 +68,19 @@
     {/each}
   </UserAvatarGroup>
 </div>
+
+<div data-testid="stack-first">
+  <UserAvatarGroup stackOrder="first" max={2}>
+    <UserAvatar backgroundColor="auto" name="Monica" tooltipText="Monica" />
+    <UserAvatar
+      backgroundColor="auto"
+      name="Richard Hendricks"
+      tooltipText="Richard Hendricks"
+    />
+    <UserAvatar
+      backgroundColor="auto"
+      name="Dinesh Chugtai"
+      tooltipText="Dinesh Chugtai"
+    />
+  </UserAvatarGroup>
+</div>

--- a/e2e/user-avatar-group.test.ts
+++ b/e2e/user-avatar-group.test.ts
@@ -88,6 +88,31 @@ test.describe("UserAvatarGroup", () => {
     await expect(overflow).toHaveText("99+");
   });
 
+  test("reverses stacking order so the first avatar paints on top, even wrapped in a tooltip", async ({
+    page,
+  }) => {
+    // Every avatar sets `tooltipText`, wrapping the registered element in a
+    // `TooltipDefinition`; the z-index must land on that direct-child
+    // wrapper, not the nested (non-positioned) avatar span.
+    const items = page
+      .getByTestId("stack-first")
+      .locator(".bx--user-avatar-group--overlap > *");
+
+    const zIndex = (el: Element) =>
+      Number.parseInt(getComputedStyle(el).zIndex, 10);
+    const first = await items.nth(0).evaluate(zIndex);
+    const second = await items.nth(1).evaluate(zIndex);
+    const third = await items.nth(2).evaluate(zIndex);
+
+    expect(first).toBeGreaterThan(second);
+    expect(second).toBeGreaterThan(third);
+
+    // The "+N" overflow chip (max={2} hides the third avatar) isn't a
+    // registered item; it should render behind every real avatar.
+    const overflow = await items.nth(3).evaluate(zIndex);
+    expect(overflow).toBeLessThan(third);
+  });
+
   test("spaces avatars apart when a gap is set", async ({ page }) => {
     const list = page.getByTestId("spaced").locator(".bx--user-avatar-group");
     await expect(list).not.toHaveClass(/bx--user-avatar-group--overlap/);

--- a/src/UserAvatarGroup/UserAvatarGroup.svelte
+++ b/src/UserAvatarGroup/UserAvatarGroup.svelte
@@ -37,6 +37,14 @@
   export let size = "md";
 
   /**
+   * Specify which end of the stack renders on top when avatars overlap.
+   * `"last"` matches the default browser paint order (and most avatar
+   * stacks). `"first"` keeps the first avatar most prominent instead.
+   * @type {"last" | "first"}
+   */
+  export let stackOrder = "last";
+
+  /**
    * Specify the tooltip text for the "+N" overflow avatar. Defaults to a
    * comma-separated list of hidden slotted `name` values. Set this when using
    * `total` for people who are not mounted.
@@ -60,6 +68,21 @@
 
   function isNegativeGap(value) {
     return typeof value === "string" && value.trim().startsWith("-");
+  }
+
+  // A `tooltipText` avatar wraps its element in a `TooltipDefinition`, so the
+  // registered node is nested a couple of levels below the direct child that
+  // the group's `> *` overlap/stacking CSS targets. Walk up to that direct
+  // child so the stacking custom property lands where the CSS reads it.
+  function overlapTarget(node) {
+    let el = node;
+    while (
+      el?.parentElement &&
+      !el.parentElement.classList.contains("bx--user-avatar-group")
+    ) {
+      el = el.parentElement;
+    }
+    return el ?? null;
   }
 
   // `max` of 0 (or non-positive) means "no limit"; mirror that as 0 in the
@@ -124,10 +147,30 @@
   // Overlap (stacked) when no gap is set, or when a negative gap tightens the
   // stack; a positive gap switches to a spaced row.
   $: overlap = gap == null || isNegativeGap(gap);
+  // `stackOrder: "first"` reverses which avatar paints on top. The default
+  // paint order already puts the last avatar on top for free, so only the
+  // reversed case needs an explicit per-avatar z-index; it's driven by a
+  // custom property (not `z-index` directly) so the hover/focus rule below
+  // can still win on specificity instead of losing to an inline style.
+  $: if (overlap && stackOrder === "first") {
+    for (const [index, item] of $items.entries()) {
+      overlapTarget(item.node)?.style.setProperty(
+        "--user-avatar-index",
+        String(index),
+      );
+    }
+  } else {
+    for (const item of $items) {
+      overlapTarget(item.node)?.style.removeProperty("--user-avatar-index");
+    }
+  }
   // A negative gap overrides the default overlap amount via a custom property.
   $: groupStyle =
     [
       isNegativeGap(gap) && `--user-avatar-group-overlap: ${gap}`,
+      overlap &&
+        stackOrder === "first" &&
+        `--user-avatar-group-count: ${$items.length}`,
       $$restProps.style,
     ]
       .filter(Boolean)
@@ -136,6 +179,7 @@
   $: groupClass = [
     "bx--user-avatar-group",
     overlap && "bx--user-avatar-group--overlap",
+    overlap && stackOrder === "first" && "bx--user-avatar-group--stack-first",
     $$restProps.class,
   ]
     .filter(Boolean)

--- a/tests/UserAvatarGroup/UserAvatarGroup.test.svelte
+++ b/tests/UserAvatarGroup/UserAvatarGroup.test.svelte
@@ -71,6 +71,14 @@
   </UserAvatarGroup>
 </div>
 
+<div data-testid="stack-first">
+  <UserAvatarGroup stackOrder="first" max={2}>
+    <UserAvatar name="Monica" tooltipText="Monica" />
+    <UserAvatar name="Richard Hendricks" tooltipText="Richard Hendricks" />
+    <UserAvatar name="Dinesh Chugtai" tooltipText="Dinesh Chugtai" />
+  </UserAvatarGroup>
+</div>
+
 <button
   type="button"
   data-testid="toggle-lead"

--- a/tests/UserAvatarGroup/UserAvatarGroup.test.ts
+++ b/tests/UserAvatarGroup/UserAvatarGroup.test.ts
@@ -122,6 +122,38 @@ describe("UserAvatarGroup", () => {
     });
   });
 
+  it("reverses the stacking order so the first avatar paints on top, even when tooltipText wraps it", () => {
+    render(UserAvatarGroup);
+
+    const root = groupRoot("stack-first");
+    expect(root).toHaveClass("bx--user-avatar-group--stack-first");
+    expect(root.style.getPropertyValue("--user-avatar-group-count")).toBe("3");
+
+    // Each avatar sets `tooltipText`, so the registered node is nested inside
+    // a `TooltipDefinition` wrapper. The stacking index must land on that
+    // direct child wrapper (what the CSS `> *` selector targets), not on the
+    // nested avatar span the CSS rule never reaches.
+    const wrappers = Array.from(root.children).filter((child) =>
+      child.classList.contains("bx--user-avatar-tooltip"),
+    ) as HTMLElement[];
+    expect(wrappers[0].style.getPropertyValue("--user-avatar-index")).toBe("0");
+    expect(
+      wrappers[0]
+        .querySelector<HTMLElement>(".bx--user-avatar")
+        ?.style.getPropertyValue("--user-avatar-index"),
+    ).toBe("");
+    expect(wrappers[2].style.getPropertyValue("--user-avatar-index")).toBe("2");
+
+    // The overflow chip (past `max={2}`) opts out of registration, so it
+    // never gets an index; it relies on the `:has()` CSS rule instead.
+    const overflowWrapper = root
+      .querySelector(".bx--user-avatar-group__overflow")
+      ?.closest<HTMLElement>(".bx--user-avatar-tooltip");
+    expect(overflowWrapper?.style.getPropertyValue("--user-avatar-index")).toBe(
+      "",
+    );
+  });
+
   it("re-sorts to DOM order when an avatar is inserted ahead of others", async () => {
     render(UserAvatarGroup);
 


### PR DESCRIPTION
Adds a stackOrder prop to UserAvatarGroup so the first avatar can render on top of the stack instead of the last. The default stays "last" to match the existing behavior, Figma's Auto Layout default, and MUI's AvatarGroup. The fix also resolves the actual overlap-stacking element when tooltipText wraps an avatar in a TooltipDefinition, since the docs example surfaced that the z-index was landing on the wrong node.