### PR TITLE
feat(disclosure): add Disclosure component

### DIFF
--- a/css/_disclosure.scss
+++ b/css/_disclosure.scss
@@ -1,0 +1,132 @@
+@import "carbon-components/scss/globals/scss/vars";
+@import "carbon-components/scss/globals/scss/helper-mixins";
+@import "carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/import-once/import-once";
+
+/// Disclosure styles
+/// @access private
+/// @group components
+@mixin disclosure {
+  .#{$prefix}--disclosure {
+    width: 100%;
+  }
+
+  .#{$prefix}--disclosure__control {
+    @include button-reset;
+
+    position: relative;
+    display: flex;
+    width: 100%;
+    min-height: to-rem(40px);
+    flex-direction: $accordion-flex-direction;
+    align-items: flex-start;
+    justify-content: $accordion-justify-content;
+    padding: to-rem(10px) 0;
+    margin: 0;
+    color: $text-01;
+    cursor: pointer;
+    transition: background-color motion(standard, productive) $duration--fast-02;
+
+    &:hover::before,
+    &:focus::before {
+      position: absolute;
+      top: -1px;
+      left: 0;
+      width: 100%;
+      height: calc(100% + 2px);
+      content: "";
+    }
+
+    &:hover::before {
+      background-color: $hover-ui;
+    }
+
+    &:focus {
+      outline: none;
+    }
+
+    &:focus::before {
+      @include focus-outline("outline-compat");
+    }
+  }
+
+  .#{$prefix}--disclosure__arrow {
+    @include focus-outline("reset");
+
+    width: 1rem;
+    height: 1rem;
+    flex: 0 0 1rem;
+    margin: $accordion-arrow-margin;
+    fill: $ui-05;
+    transform: rotate(-270deg) #{"/*rtl:ignore*/"};
+    transition: all $duration--fast-02 motion(standard, productive);
+  }
+
+  .#{$prefix}--disclosure__summary {
+    @include type-style("body-long-01");
+
+    z-index: 1;
+    width: 100%;
+    margin: $accordion-title-margin;
+    text-align: left;
+  }
+
+  .#{$prefix}--disclosure--start .#{$prefix}--disclosure__control {
+    // Reverse `$accordion-flex-direction` token:
+    flex-direction: row;
+  }
+
+  .#{$prefix}--disclosure--start .#{$prefix}--disclosure__arrow {
+    // Alters `$accordion-arrow-margin` token:
+    margin: 2px 0 0 $carbon--spacing-05;
+  }
+
+  .#{$prefix}--disclosure--start .#{$prefix}--disclosure__summary {
+    margin-right: $carbon--spacing-05;
+  }
+
+  .#{$prefix}--disclosure--start .#{$prefix}--disclosure__content {
+    margin-left: $carbon--spacing-07;
+  }
+
+  .#{$prefix}--disclosure__content {
+    display: none;
+    padding-right: $carbon--spacing-05;
+    padding-left: $carbon--spacing-05;
+    // Transition property for when the disclosure closes
+    transition: padding motion(standard, productive) $duration--fast-02;
+  }
+
+  .#{$prefix}--disclosure--collapsing .#{$prefix}--disclosure__content,
+  .#{$prefix}--disclosure--expanding .#{$prefix}--disclosure__content {
+    display: block;
+  }
+
+  .#{$prefix}--disclosure--collapsing .#{$prefix}--disclosure__content {
+    animation: $duration--fast-02 motion(standard, productive)
+      collapse-accordion;
+  }
+
+  .#{$prefix}--disclosure--expanding .#{$prefix}--disclosure__content {
+    animation: $duration--fast-02 motion(standard, productive) expand-accordion;
+  }
+
+  .#{$prefix}--disclosure--open {
+    .#{$prefix}--disclosure__content {
+      display: block;
+      padding-top: $carbon--spacing-03;
+      padding-bottom: $carbon--spacing-05;
+      // Transition property for when the disclosure opens
+      transition: padding-top motion(entrance, productive) $duration--fast-02,
+        padding-bottom motion(entrance, productive) $duration--fast-02;
+    }
+
+    .#{$prefix}--disclosure__arrow {
+      fill: $ui-05;
+      transform: rotate(-90deg) #{"/*rtl:ignore*/"};
+    }
+  }
+}
+
+@include exports("disclosure") {
+  @include disclosure;
+}

--- a/css/all.scss
+++ b/css/all.scss
@@ -139,3 +139,4 @@ $css--plex: true;
 @import "./profile-menu";
 @import "./user-avatar";
 @import "./user-avatar-group";
+@import "./disclosure";

--- a/css/g10.scss
+++ b/css/g10.scss
@@ -99,3 +99,4 @@ $css--plex: true;
 @import "./profile-menu";
 @import "./user-avatar";
 @import "./user-avatar-group";
+@import "./disclosure";

--- a/css/g100.scss
+++ b/css/g100.scss
@@ -99,3 +99,4 @@ $css--plex: true;
 @import "./profile-menu";
 @import "./user-avatar";
 @import "./user-avatar-group";
+@import "./disclosure";

--- a/css/g80.scss
+++ b/css/g80.scss
@@ -99,3 +99,4 @@ $css--plex: true;
 @import "./profile-menu";
 @import "./user-avatar";
 @import "./user-avatar-group";
+@import "./disclosure";

--- a/css/g90.scss
+++ b/css/g90.scss
@@ -99,3 +99,4 @@ $css--plex: true;
 @import "./profile-menu";
 @import "./user-avatar";
 @import "./user-avatar-group";
+@import "./disclosure";

--- a/css/white.scss
+++ b/css/white.scss
@@ -99,3 +99,4 @@ $css--plex: true;
 @import "./profile-menu";
 @import "./user-avatar";
 @import "./user-avatar-group";
+@import "./disclosure";

--- a/docs/src/component-categories.ts
+++ b/docs/src/component-categories.ts
@@ -22,7 +22,14 @@ export const COMPONENT_CATEGORIES: ComponentCategory[] = [
   },
   {
     label: "Layout",
-    components: ["Grid", "Stack", "Box", "AspectRatio", "Accordion"],
+    components: [
+      "Grid",
+      "Stack",
+      "Box",
+      "AspectRatio",
+      "Accordion",
+      "Disclosure",
+    ],
   },
   {
     label: "Actions",

--- a/docs/src/component-since-versions.ts
+++ b/docs/src/component-since-versions.ts
@@ -20,6 +20,7 @@ export const COMPONENT_SINCE_VERSIONS: Record<string, string> = {
   DataTable: "0.5.0",
   DatePicker: "0.2.0",
   Dialog: "0.110.0",
+  Disclosure: "0.110.0",
   Dropdown: "0.2.0",
   ExpandableTile: "0.2.0",
   FileUploader: "0.2.0",

--- a/docs/src/pages/components/Disclosure.svx
+++ b/docs/src/pages/components/Disclosure.svx
@@ -1,0 +1,54 @@
+---
+description: Disclosures show and hide a section of content from a single, always-visible trigger.
+---
+
+<script>
+  import { Disclosure } from "carbon-components-svelte";
+</script>
+
+## Basic
+
+Create a disclosure with `summary` for the always-visible trigger text and a
+default slot for the content it shows or hides.
+
+<Disclosure summary="Show shipping details">
+  <p>Orders ship within 2 business days and arrive in 3-5 business days.</p>
+</Disclosure>
+
+## Left-aligned chevron
+
+Align the chevron icon to the left side of the trigger by setting `align` to
+`"start"`. The default is `"end"`.
+
+<Disclosure align="start" summary="Show shipping details">
+  <p>Orders ship within 2 business days and arrive in 3-5 business days.</p>
+</Disclosure>
+
+## Custom summary slot
+
+Customize the trigger content with the summary slot instead of `summary`
+for more complex layouts with multiple elements.
+
+<Disclosure>
+  <svelte:fragment slot="summary">
+    <strong>Shipping details</strong>
+    <span>Ships in 2 days</span>
+  </svelte:fragment>
+  <p>Orders ship within 2 business days and arrive in 3-5 business days.</p>
+</Disclosure>
+
+## Open by default
+
+Set `open` to `true` to render the disclosure expanded.
+
+<Disclosure open summary="Show shipping details">
+  <p>Orders ship within 2 business days and arrive in 3-5 business days.</p>
+</Disclosure>
+
+## Reactive (two-way binding)
+
+Bind to `open` to control and read the disclosure state outside the component.
+Listen for `toggle` to react to state changes, such as when the trigger is
+activated with a click or the keyboard.
+
+<FileSource src="/framed/Disclosure/ReactiveDisclosure" />

--- a/docs/src/pages/framed/Disclosure/ReactiveDisclosure.svelte
+++ b/docs/src/pages/framed/Disclosure/ReactiveDisclosure.svelte
@@ -1,0 +1,16 @@
+<script>
+  import { Disclosure, Stack } from "carbon-components-svelte";
+
+  let open = false;
+</script>
+
+<Stack gap={5}>
+  <div>Open: <strong>{open}</strong></div>
+  <Disclosure
+    bind:open
+    summary="Show shipping details"
+    on:toggle={(e) => console.log("toggle", e.detail)}
+  >
+    <p>Orders ship within 2 business days and arrive in 3-5 business days.</p>
+  </Disclosure>
+</Stack>

--- a/src/Disclosure/Disclosure.svelte
+++ b/src/Disclosure/Disclosure.svelte
@@ -1,0 +1,84 @@
+<script>
+  /**
+   * @restProps {div}
+   * @slot {{}} summary - Content for the always-visible trigger.
+   * @slot {{}}
+   * @event {boolean} toggle - Dispatched with the new open state.
+   */
+
+  /**
+   * Specify the summary content of the trigger.
+   * Alternatively, use the "summary" slot.
+   * @example
+   * ```svelte
+   * <Disclosure>
+   *   <div slot="summary">Custom summary</div>
+   * </Disclosure>
+   * ```
+   */
+  export let summary = "";
+
+  /**
+   * Specify alignment of the chevron icon.
+   * @type {"start" | "end"}
+   */
+  export let align = "end";
+
+  /**
+   * Set to `true` to open the disclosure.
+   * @bindable writable
+   */
+  export let open = false;
+
+  import { createEventDispatcher } from "svelte";
+  import ChevronRight from "../icons/ChevronRight.svelte";
+
+  const dispatch = createEventDispatcher();
+
+  const contentId = `ccs-${Math.random().toString(36)}`;
+
+  let animation = undefined;
+
+  function toggle() {
+    open = !open;
+    animation = open ? "expanding" : "collapsing";
+    dispatch("toggle", open);
+  }
+</script>
+
+<div
+  class:bx--disclosure={true}
+  class:bx--disclosure--start={align === "start"}
+  class:bx--disclosure--end={align === "end"}
+  class:bx--disclosure--open={open}
+  class:bx--disclosure--expanding={animation === "expanding"}
+  class:bx--disclosure--collapsing={animation === "collapsing"}
+  {...$$restProps}
+  on:animationend
+  on:animationend={() => {
+    animation = undefined;
+  }}
+>
+  <button
+    type="button"
+    class:bx--disclosure__control={true}
+    aria-expanded={open}
+    aria-controls={contentId}
+    on:click
+    on:click={toggle}
+    on:mouseover
+    on:mouseenter
+    on:mouseleave
+    on:keydown
+    on:focus
+    on:blur
+  >
+    <ChevronRight class="bx--disclosure__arrow" />
+    <span class:bx--disclosure__summary={true}>
+      <slot name="summary">{summary}</slot>
+    </span>
+  </button>
+  <div id={contentId} class:bx--disclosure__content={true}>
+    <slot />
+  </div>
+</div>

--- a/src/Disclosure/index.js
+++ b/src/Disclosure/index.js
@@ -1,0 +1,1 @@
+export { default as Disclosure } from "./Disclosure.svelte";

--- a/src/index.js
+++ b/src/index.js
@@ -56,6 +56,7 @@ export { default as DatePickerInput } from "./DatePicker/DatePickerInput.svelte"
 export { default as DatePickerSkeleton } from "./DatePicker/DatePickerSkeleton.svelte";
 export { default as FluidDatePickerSkeleton } from "./DatePicker/FluidDatePickerSkeleton.svelte";
 export { default as Dialog } from "./Dialog/Dialog.svelte";
+export { default as Disclosure } from "./Disclosure/Disclosure.svelte";
 export { default as Dropdown } from "./Dropdown/Dropdown.svelte";
 export { default as DropdownSkeleton } from "./Dropdown/DropdownSkeleton.svelte";
 export { default as FluidDropdownSkeleton } from "./Dropdown/FluidDropdownSkeleton.svelte";

--- a/tests/Disclosure/Disclosure.test.svelte
+++ b/tests/Disclosure/Disclosure.test.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+  import Disclosure from "carbon-components-svelte/Disclosure/Disclosure.svelte";
+  import type { ComponentProps } from "svelte";
+
+  export let open: ComponentProps<Disclosure>["open"] = false;
+  export let align: ComponentProps<Disclosure>["align"] = "end";
+</script>
+
+<Disclosure
+  bind:open
+  {align}
+  on:toggle={(e) => {
+    console.log("toggle:", e.detail);
+  }}
+  on:click
+  on:keydown
+  on:mouseover
+  on:mouseenter
+  on:mouseleave
+  on:focus
+  on:blur
+>
+  <span slot="summary">Show details</span>
+  <p>Hidden content</p>
+</Disclosure>

--- a/tests/Disclosure/Disclosure.test.ts
+++ b/tests/Disclosure/Disclosure.test.ts
@@ -1,0 +1,102 @@
+import { render, screen } from "@testing-library/svelte";
+import { user } from "../utils/user";
+import Disclosure from "./Disclosure.test.svelte";
+import DisclosureSummaryProp from "./DisclosureSummaryProp.test.svelte";
+
+describe("Disclosure", () => {
+  it("should render the summary prop when no summary slot is provided", () => {
+    render(DisclosureSummaryProp);
+
+    expect(
+      screen.getByRole("button", { name: "Show details" }),
+    ).toBeInTheDocument();
+  });
+
+  it("should render with default props", () => {
+    render(Disclosure);
+
+    const control = screen.getByRole("button", { name: "Show details" });
+    expect(control).toHaveAttribute("aria-expanded", "false");
+    expect(control.closest(".bx--disclosure")).toHaveClass(
+      "bx--disclosure--end",
+    );
+
+    const content = screen.getByText("Hidden content");
+    expect(content.closest(".bx--disclosure__content")).not.toHaveClass(
+      "bx--disclosure--open",
+    );
+  });
+
+  it("should align the chevron to the start", () => {
+    render(Disclosure, { props: { align: "start" } });
+
+    const control = screen.getByRole("button", { name: "Show details" });
+    const wrapper = control.closest(".bx--disclosure");
+    expect(wrapper).toHaveClass("bx--disclosure--start");
+    expect(wrapper).not.toHaveClass("bx--disclosure--end");
+  });
+
+  it("should toggle open state on click", async () => {
+    render(Disclosure);
+
+    const control = screen.getByRole("button", { name: "Show details" });
+    expect(control).toHaveAttribute("aria-expanded", "false");
+
+    await user.click(control);
+    expect(control).toHaveAttribute("aria-expanded", "true");
+
+    await user.click(control);
+    expect(control).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("should dispatch a toggle event with the new open state", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(Disclosure);
+
+    const control = screen.getByRole("button", { name: "Show details" });
+
+    await user.click(control);
+    expect(consoleLog).toHaveBeenCalledWith("toggle:", true);
+
+    await user.click(control);
+    expect(consoleLog).toHaveBeenCalledWith("toggle:", false);
+  });
+
+  it("should render open when bound to true", () => {
+    render(Disclosure, { props: { open: true } });
+
+    const control = screen.getByRole("button", { name: "Show details" });
+    expect(control).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("should associate the control with its content via aria-controls", () => {
+    render(Disclosure);
+
+    const control = screen.getByRole("button", { name: "Show details" });
+    const contentId = control.getAttribute("aria-controls");
+    expect(contentId).toBeTruthy();
+
+    const content = screen.getByText("Hidden content").closest("div");
+    expect(content).toHaveAttribute("id", contentId);
+  });
+
+  it("should toggle on Enter key", async () => {
+    render(Disclosure);
+
+    const control = screen.getByRole("button", { name: "Show details" });
+    control.focus();
+
+    await user.keyboard("{Enter}");
+    expect(control).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("should toggle on Space key", async () => {
+    render(Disclosure);
+
+    const control = screen.getByRole("button", { name: "Show details" });
+    control.focus();
+
+    await user.keyboard(" ");
+    expect(control).toHaveAttribute("aria-expanded", "true");
+  });
+});

--- a/tests/Disclosure/DisclosureSummaryProp.test.svelte
+++ b/tests/Disclosure/DisclosureSummaryProp.test.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  import Disclosure from "carbon-components-svelte/Disclosure/Disclosure.svelte";
+</script>
+
+<Disclosure summary="Show details">
+  <p>Hidden content</p>
+</Disclosure>


### PR DESCRIPTION
Adds a new Disclosure component, a standalone expand/collapse trigger for a single section of content. It supports a summary prop or slot for the trigger text, an align prop to place the chevron on either side, and a bindable open prop with a toggle event. Styling reuses AccordionItem's layout tokens and animation keyframes for visual consistency.

<img width="921" height="152" alt="Screenshot 2026-07-03 at 1 11 46 PM" src="https://github.com/user-attachments/assets/925c5e35-1a09-406c-9ad8-18a4fd2402b6" />
