### PR TITLE
feat(date-picker): add "month" type

### DIFF
--- a/css/_datepicker.scss
+++ b/css/_datepicker.scss
@@ -65,3 +65,73 @@
 @include exports('datepicker-month-nav-disabled') {
   @include date-picker-month-nav-disabled;
 }
+
+// Carbon ships no styles for flatpickr's monthSelect plugin (used by
+// `datePickerType="month"`), so style its raw classes directly, matching
+// the token usage of the day-cell styles Carbon backports from v11.
+@mixin date-picker-month-select {
+  .flatpickr-monthSelect-months {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    margin: 0.625rem 0.0625rem 0.1875rem;
+  }
+
+  .flatpickr-monthSelect-month {
+    box-sizing: border-box;
+    display: flex;
+    padding: 0.625rem;
+    align-items: center;
+    justify-content: center;
+    border: 0;
+    border-radius: 0;
+    background: none;
+    color: $text-01;
+    cursor: pointer;
+    font-weight: 400;
+    text-align: center;
+
+    &:hover {
+      background: $hover-ui;
+    }
+
+    &:focus {
+      outline: 1px solid $focus;
+      outline-offset: -1px;
+    }
+
+    &.selected {
+      background-color: $interactive-01;
+      color: $text-04;
+    }
+
+    &.disabled {
+      color: $disabled-02;
+      cursor: not-allowed;
+
+      &:hover {
+        background: none;
+      }
+    }
+  }
+}
+
+@include exports('datepicker-month-select') {
+  @include date-picker-month-select;
+}
+
+// The month grid is shorter than the day grid Carbon sizes `.flatpickr-calendar.open`
+// for (21rem), which leaves a large empty gap below the 4x3 month layout.
+// `updateClasses` in createCalendar.js marks the container with
+// `.#{$prefix}--date-picker__calendar--month` so this can scope the shorter
+// height without `:has()` (unsupported at the Svelte 5 browser baseline);
+// the extra class also out-specifies the base `.flatpickr-calendar.open` rule
+// (which loads before this partial).
+@mixin date-picker-month-select-height {
+  .flatpickr-calendar.open.#{$prefix}--date-picker__calendar--month {
+    height: 14rem;
+  }
+}
+
+@include exports('datepicker-month-select-height') {
+  @include date-picker-month-select-height;
+}

--- a/docs/src/pages/components/DatePicker.svx
+++ b/docs/src/pages/components/DatePicker.svx
@@ -26,9 +26,27 @@ Use `bind:valueFrom` and `bind:valueTo` to update the range from outside the com
 
 <FileSource src="/framed/DatePicker/DatePickerProgrammatic" />
 
+## Month calendar
+
+Set `datePickerType` to `"month"` to select a month instead of a day. The calendar shows a 12-month grid for the current year; use the year stepper to change years. Pair it with a `dateFormat` that omits the day, such as `"F Y"` (for example, "January 2026").
+
+<FileSource src="/framed/DatePicker/DatePickerMonth" />
+
+### Custom format
+
+Pass a numeric `dateFormat`, such as `"Y-m"`, along with a matching `placeholder` for a compact "yyyy-mm" input.
+
+<FileSource src="/framed/DatePicker/DatePickerMonthCustomFormat" />
+
+### Programmatic
+
+Use `bind:value` to update the selected month from outside the component, such as a "previous month" button.
+
+<FileSource src="/framed/DatePicker/DatePickerMonthProgrammatic" />
+
 ## Calendar options
 
-Configure constraints and behavior shared by single and range calendars.
+Configure constraints and behavior shared by single, range, and month calendars.
 
 ### Min and max dates
 
@@ -175,6 +193,14 @@ The range date picker renders both inputs inside a single fluid field.
 <DatePicker fluid datePickerType="range">
   <DatePickerInput labelText="Start date" placeholder="mm/dd/yyyy" />
   <DatePickerInput labelText="End date" placeholder="mm/dd/yyyy" />
+</DatePicker>
+
+### Month
+
+The fluid variant also supports the `"month"` date picker type.
+
+<DatePicker fluid datePickerType="month" dateFormat="F Y">
+  <DatePickerInput labelText="Billing month" placeholder="Month Year" />
 </DatePicker>
 
 ### Custom label

--- a/docs/src/pages/framed/DatePicker/DatePickerMonth.svelte
+++ b/docs/src/pages/framed/DatePicker/DatePickerMonth.svelte
@@ -1,0 +1,7 @@
+<script>
+  import { DatePicker, DatePickerInput } from "carbon-components-svelte";
+</script>
+
+<DatePicker datePickerType="month" dateFormat="F Y" on:change>
+  <DatePickerInput labelText="Billing month" placeholder="Month Year" />
+</DatePicker>

--- a/docs/src/pages/framed/DatePicker/DatePickerMonthCustomFormat.svelte
+++ b/docs/src/pages/framed/DatePicker/DatePickerMonthCustomFormat.svelte
@@ -1,0 +1,7 @@
+<script>
+  import { DatePicker, DatePickerInput } from "carbon-components-svelte";
+</script>
+
+<DatePicker datePickerType="month" dateFormat="Y-m" on:change>
+  <DatePickerInput labelText="Billing month" placeholder="yyyy-mm" />
+</DatePicker>

--- a/docs/src/pages/framed/DatePicker/DatePickerMonthProgrammatic.svelte
+++ b/docs/src/pages/framed/DatePicker/DatePickerMonthProgrammatic.svelte
@@ -1,0 +1,24 @@
+<script>
+  import {
+    Button,
+    DatePicker,
+    DatePickerInput,
+    Stack,
+  } from "carbon-components-svelte";
+
+  let value = "03/2026";
+
+  function previousMonth() {
+    var [month, year] = value.split("/").map(Number);
+    var d = new Date(year, month - 2, 1);
+    var mm = String(d.getMonth() + 1).padStart(2, "0");
+    value = `${mm}/${d.getFullYear()}`;
+  }
+</script>
+
+<Stack gap={4}>
+  <DatePicker datePickerType="month" dateFormat="m/Y" bind:value on:change>
+    <DatePickerInput labelText="Billing month" placeholder="mm/yyyy" />
+  </DatePicker>
+  <Button on:click={previousMonth}>Previous month</Button>
+</Stack>

--- a/e2e/date-picker.test.ts
+++ b/e2e/date-picker.test.ts
@@ -473,4 +473,50 @@ test.describe("DatePicker", () => {
       ).toHaveText("select");
     });
   });
+
+  test.describe("month", () => {
+    test("opens a 12-month grid instead of days", async ({ page }) => {
+      const input = page.getByLabel("Billing month");
+      await input.click();
+
+      const calendar = page
+        .getByTestId("date-picker-month")
+        .getByLabel("calendar-container");
+      await expect(calendar).toBeVisible();
+      await expect(
+        calendar.locator(".flatpickr-monthSelect-month"),
+      ).toHaveCount(12);
+      await expect(calendar.locator(".flatpickr-day")).toHaveCount(0);
+    });
+
+    test("selects a month and updates the input", async ({ page }) => {
+      const input = page.getByLabel("Billing month");
+      await input.click();
+
+      const calendar = page
+        .getByTestId("date-picker-month")
+        .getByLabel("calendar-container");
+      await calendar.getByText("Sep", { exact: true }).click();
+
+      await expect(input).toHaveValue("September 2024");
+      await expect(calendar).not.toHaveClass(/open/);
+    });
+
+    test("year stepper changes the displayed year without closing", async ({
+      page,
+    }) => {
+      const input = page.getByLabel("Billing month");
+      await input.click();
+
+      const calendar = page
+        .getByTestId("date-picker-month")
+        .getByLabel("calendar-container");
+      const yearInput = calendar.locator("input.cur-year");
+      await expect(yearInput).toHaveValue("2024");
+
+      await calendar.locator(".flatpickr-next-month").click();
+      await expect(yearInput).toHaveValue("2025");
+      await expect(calendar).toHaveClass(/open/);
+    });
+  });
 });

--- a/e2e/fixtures/DatePickerFixture.svelte
+++ b/e2e/fixtures/DatePickerFixture.svelte
@@ -68,3 +68,19 @@
     {rangeCloseTriggers.join(",")}
   </p>
 </div>
+
+<div data-testid="date-picker-month">
+  <DatePicker
+    datePickerType="month"
+    dateFormat="F Y"
+    value="March 2024"
+    flatpickrProps={{ static: true }}
+    on:change
+  >
+    <DatePickerInput
+      data-testid="date-picker-billing-month"
+      labelText="Billing month"
+      placeholder="Month Year"
+    />
+  </DatePicker>
+</div>

--- a/src/DatePicker/DatePicker.svelte
+++ b/src/DatePicker/DatePicker.svelte
@@ -11,7 +11,7 @@
 
   /**
    * Specify the date picker type.
-   * @type {"simple" | "single" | "range"}
+   * @type {"simple" | "single" | "range" | "month"}
    */
   export let datePickerType = "simple";
 
@@ -164,7 +164,10 @@
   /**
    * @type {import("svelte/store").Readable<boolean>}
    */
-  const hasCalendar = derived(mode, (_) => _ === "single" || _ === "range");
+  const hasCalendar = derived(
+    mode,
+    (_) => _ === "single" || _ === "range" || _ === "month",
+  );
 
   let datePickerRef = null;
   let inputRef = null;
@@ -612,7 +615,8 @@
     class:bx--date-picker--short={short}
     class:bx--date-picker--light={light}
     class:bx--date-picker--simple={datePickerType === "simple"}
-    class:bx--date-picker--single={datePickerType === "single"}
+    class:bx--date-picker--single={datePickerType === "single" ||
+      datePickerType === "month"}
     class:bx--date-picker--range={datePickerType === "range"}
     class:bx--date-picker--nolabel={datePickerType === "range" &&
       $labelTextEmpty}

--- a/src/DatePicker/createCalendar.d.ts
+++ b/src/DatePicker/createCalendar.d.ts
@@ -14,7 +14,7 @@ export interface FlatpickrInstance {
 }
 
 export interface CreateCalendarArgs {
-  options: { locale?: string; mode?: string };
+  options: { locale?: string; mode?: string; dateFormat?: string };
   base: HTMLElement;
   input: HTMLInputElement;
   dispatch: (event: string) => void;

--- a/src/DatePicker/createCalendar.js
+++ b/src/DatePicker/createCalendar.js
@@ -47,8 +47,9 @@ export function resolveLocale(locale) {
 
 /**
  * @param {FlatpickrInstance} instance
+ * @param {{ isMonth?: boolean }} [modifiers]
  */
-function updateClasses(instance) {
+function updateClasses(instance, { isMonth = false } = {}) {
   const {
     calendarContainer,
     days,
@@ -58,6 +59,11 @@ function updateClasses(instance) {
   } = instance;
 
   calendarContainer.classList.add("bx--date-picker__calendar");
+  // Marker class so SCSS can target the shorter month grid without `:has()`.
+  calendarContainer.classList.toggle(
+    "bx--date-picker__calendar--month",
+    isMonth,
+  );
   calendarContainer
     .querySelector(".flatpickr-month")
     ?.classList.add("bx--date-picker__month");
@@ -114,15 +120,29 @@ function updateMonthNode(instance) {
 export async function createCalendar({ options, base, input, dispatch }) {
   /** @type {((new (config: { position: string; input: HTMLInputElement }) => unknown) | undefined)} */
   let RangePlugin;
+  /** @type {((config?: { shorthand?: boolean; dateFormat?: string; altFormat?: string }) => unknown) | undefined} */
+  let monthSelectPlugin;
 
   if (options.mode === "range") {
     const importee = await import("flatpickr/dist/esm/plugins/rangePlugin");
     RangePlugin = importee.default;
   }
 
+  if (options.mode === "month") {
+    const importee = await import("flatpickr/dist/esm/plugins/monthSelect");
+    monthSelectPlugin = importee.default;
+  }
+
   const plugins = [
     options.mode === "range" && RangePlugin
       ? new RangePlugin({ position: "left", input })
+      : false,
+    options.mode === "month" && monthSelectPlugin
+      ? monthSelectPlugin({
+          shorthand: true,
+          dateFormat: options.dateFormat,
+          altFormat: options.dateFormat,
+        })
       : false,
   ].filter(Boolean);
 
@@ -146,7 +166,9 @@ export async function createCalendar({ options, base, input, dispatch }) {
       /** @type {any} */ _d,
       /** @type {FlatpickrInstance} */ instance,
     ) => {
-      updateMonthNode(instance);
+      // The monthSelect plugin removes the month-label node in favor of a
+      // year-only stepper, so there is nothing for updateMonthNode to patch.
+      if (options.mode !== "month") updateMonthNode(instance);
     },
     onOpen: (
       /** @type {any} */ _s,
@@ -154,8 +176,8 @@ export async function createCalendar({ options, base, input, dispatch }) {
       /** @type {FlatpickrInstance} */ instance,
     ) => {
       dispatch("open");
-      updateClasses(instance);
-      updateMonthNode(instance);
+      updateClasses(instance, { isMonth: options.mode === "month" });
+      if (options.mode !== "month") updateMonthNode(instance);
     },
     ...options,
     locale: resolveLocale(options.locale),

--- a/src/DatePicker/flatpickr-monthSelectPlugin.d.ts
+++ b/src/DatePicker/flatpickr-monthSelectPlugin.d.ts
@@ -1,0 +1,11 @@
+declare module "flatpickr/dist/esm/plugins/monthSelect" {
+  interface MonthSelectPluginConfig {
+    shorthand?: boolean;
+    dateFormat?: string;
+    altFormat?: string;
+    theme?: string;
+  }
+
+  const monthSelectPlugin: (config?: MonthSelectPluginConfig) => unknown;
+  export default monthSelectPlugin;
+}

--- a/tests/DatePicker/DatePicker.test.ts
+++ b/tests/DatePicker/DatePicker.test.ts
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/svelte";
+import { render, screen, within } from "@testing-library/svelte";
 import type { Instance } from "flatpickr/dist/types/instance";
 import { tick } from "svelte";
 import { user } from "../utils/user";
@@ -51,9 +51,9 @@ describe("DatePicker", () => {
       screen.queryByLabelText("calendar-container"),
     ).not.toBeInTheDocument();
     await user.click(input);
-    expect(
-      await screen.findByLabelText("calendar-container"),
-    ).toBeInTheDocument();
+    const calendar = await screen.findByLabelText("calendar-container");
+    expect(calendar).toBeInTheDocument();
+    expect(calendar).not.toHaveClass("bx--date-picker__calendar--month");
   });
 
   it("renders single-letter weekday shorthands for locale='en'", async () => {
@@ -672,6 +672,85 @@ describe("DatePicker", () => {
       const wrapper = container.querySelector(".bx--date-picker");
       expect(wrapper?.contains(calendar)).toBe(true);
       expect(calendar.classList.contains("static")).toBe(true);
+    });
+  });
+
+  describe("month mode", () => {
+    it("renders month mode", async () => {
+      const { container } = render(DatePicker, {
+        datePickerType: "month",
+        dateFormat: "F Y",
+      });
+
+      const input = screen.getByLabelText("Date");
+
+      const wrapper = container.querySelector(".bx--date-picker");
+      // Month mode reuses the single-mode input width styling.
+      expect(wrapper).toHaveClass("bx--date-picker--single");
+
+      expect(
+        screen.queryByLabelText("calendar-container"),
+      ).not.toBeInTheDocument();
+      await user.click(input);
+      expect(
+        await screen.findByLabelText("calendar-container"),
+      ).toBeInTheDocument();
+    });
+
+    it("renders a 12-month grid instead of days", async () => {
+      render(DatePicker, { datePickerType: "month", dateFormat: "F Y" });
+
+      await user.click(screen.getByLabelText("Date"));
+      const calendar = await screen.findByLabelText("calendar-container");
+
+      expect(
+        calendar.querySelectorAll(".flatpickr-monthSelect-month"),
+      ).toHaveLength(12);
+      expect(calendar.querySelectorAll(".flatpickr-day")).toHaveLength(0);
+    });
+
+    // Regression test: SCSS scopes the shorter calendar height to month mode
+    // via this marker class instead of `:has()` (unsupported at the Svelte 5
+    // browser baseline).
+    it("marks the calendar container for month-specific height styling", async () => {
+      render(DatePicker, { datePickerType: "month", dateFormat: "F Y" });
+
+      await user.click(screen.getByLabelText("Date"));
+      const calendar = await screen.findByLabelText("calendar-container");
+
+      expect(calendar).toHaveClass("bx--date-picker__calendar--month");
+    });
+
+    it("selects a month and dispatches change with the formatted date", async () => {
+      const changeHandler = vi.fn();
+      render(DatePicker, {
+        datePickerType: "month",
+        dateFormat: "F Y",
+        onchange: changeHandler,
+      });
+
+      await user.click(screen.getByLabelText("Date"));
+      const calendar = await screen.findByLabelText("calendar-container");
+
+      await user.click(within(calendar).getByText("Mar"));
+
+      const input = screen.getByLabelText("Date") as HTMLInputElement;
+      expect(input.value).toMatch(/^March \d{4}$/);
+      expect(changeHandler).toHaveBeenCalled();
+      expect(changeHandler.mock.lastCall?.[0]?.detail).toMatchObject({
+        dateStr: input.value,
+      });
+    });
+
+    it("closes the calendar after selecting a month", async () => {
+      render(DatePicker, { datePickerType: "month", dateFormat: "F Y" });
+
+      await user.click(screen.getByLabelText("Date"));
+      const calendar = await screen.findByLabelText("calendar-container");
+      expect(calendar).toHaveClass("open");
+
+      await user.click(within(calendar).getByText("Jun"));
+      expect(calendar).not.toHaveClass("open");
     });
   });
 

--- a/tests/DatePicker/createCalendar.test.ts
+++ b/tests/DatePicker/createCalendar.test.ts
@@ -23,4 +23,45 @@ describe("createCalendar", () => {
       }),
     ).resolves.toBeDefined();
   });
+
+  it("loads the monthSelect plugin when mode is month", async () => {
+    const { createCalendar } = await import(
+      "../../src/DatePicker/createCalendar.js"
+    );
+    const base = document.createElement("div");
+    const input = document.createElement("input");
+    const dispatch = vi.fn();
+
+    await createCalendar({
+      options: { mode: "month", dateFormat: "F Y" },
+      base,
+      input,
+      dispatch,
+    });
+
+    const flatpickr = vi.mocked((await import("flatpickr")).default);
+    const config = flatpickr.mock.calls.at(-1)?.[1];
+    expect(config?.plugins).toHaveLength(1);
+    expect(typeof config?.plugins?.[0]).toBe("function");
+  });
+
+  it("does not load a plugin when mode is single", async () => {
+    const { createCalendar } = await import(
+      "../../src/DatePicker/createCalendar.js"
+    );
+    const base = document.createElement("div");
+    const input = document.createElement("input");
+    const dispatch = vi.fn();
+
+    await createCalendar({
+      options: { mode: "single" },
+      base,
+      input,
+      dispatch,
+    });
+
+    const flatpickr = vi.mocked((await import("flatpickr")).default);
+    const config = flatpickr.mock.calls.at(-1)?.[1];
+    expect(config?.plugins).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
Closes #976

Adds datePickerType="month" using flatpickr's bundled monthSelect plugin, so consumers can pick a month instead of a day without pulling in an extra dependency. Includes doc examples and unit and e2e tests.

Similar to the range plugin, the month plugin is dynamically loaded for performance.

---

<img width="419" height="318" alt="Screenshot 2026-07-03 at 12 48 32 PM" src="https://github.com/user-attachments/assets/f5686fd1-232a-4ae0-9109-f04e2643955e" />
