### PR TITLE
feat(breakpoint): add hideAtBreakpoint action

### DIFF
--- a/docs/src/pages/components/Breakpoint.svx
+++ b/docs/src/pages/components/Breakpoint.svx
@@ -1,6 +1,10 @@
 ---
-description: Breakpoint declaratively reports the current Carbon responsive breakpoint size.
+description: Breakpoint declaratively reports the current Carbon responsive breakpoint size, or hides an element outside a breakpoint range with the hideAtBreakpoint action.
 ---
+
+<script>
+  import { hideAtBreakpoint } from "carbon-components-svelte";
+</script>
 
 ## Breakpoints
 
@@ -29,3 +33,10 @@ Use `breakpointObserver` as an alternative to the component to get the current s
 Access the breakpoints dictionary to map from BreakpointSize to BreakpointValue.
 
 <FileSource src="/framed/Breakpoint/BreakpointObserver" />
+
+## use:hideAtBreakpoint
+
+Use the `hideAtBreakpoint` action to hide an element outside a breakpoint range, without wrapping it in `Breakpoint`. Set `above`, `below`, or both. Resize the browser to see the elements toggle.
+
+<div use:hideAtBreakpoint={{ above: "md" }}>Hidden at md and up</div>
+<div use:hideAtBreakpoint={{ below: "lg" }}>Hidden below lg</div>

--- a/src/Breakpoint/breakpointObserver.d.ts
+++ b/src/Breakpoint/breakpointObserver.d.ts
@@ -2,6 +2,16 @@ import type { Readable, Subscriber, Unsubscriber } from "svelte/store";
 import type { BreakpointSize } from "./breakpoints";
 
 /**
+ * Attaches `matchMedia` listeners for every breakpoint and invokes `callback`
+ * with the current size immediately, then again on every subsequent change.
+ * @param callback - Called with the current breakpoint size.
+ * @returns Cleanup function that removes the listeners.
+ */
+export function observeBreakpoint(
+  callback: (size: BreakpointSize) => void,
+): () => void;
+
+/**
  * Creates a readable store that returns the current breakpoint size.
  * It also provides functions for creating derived stores used to do comparisons.
  */

--- a/src/Breakpoint/breakpointObserver.js
+++ b/src/Breakpoint/breakpointObserver.js
@@ -5,6 +5,59 @@ import { breakpoints } from "./breakpoints";
 /** @typedef {import("./breakpoints").BreakpointSize} BreakpointSize */
 
 /**
+ * Attaches `matchMedia` listeners for every breakpoint and invokes `callback`
+ * with the current size immediately, then again on every subsequent change.
+ * Framework-agnostic (no `onMount`), so it can be called from a Svelte action
+ * as well as from {@link breakpointObserver}.
+ * @param {(size: BreakpointSize) => void} callback
+ * @returns {() => void} Cleanup function that removes the listeners.
+ */
+export function observeBreakpoint(callback) {
+  /** @type {Record<BreakpointSize, MediaQueryList>} */
+  const match = {
+    sm: window.matchMedia(`(max-width: ${breakpoints.md}px)`),
+    md: window.matchMedia(
+      `(min-width: ${breakpoints.md}px) and (max-width: ${breakpoints.lg}px)`,
+    ),
+    lg: window.matchMedia(
+      `(min-width: ${breakpoints.lg}px) and (max-width: ${breakpoints.xlg}px)`,
+    ),
+    xlg: window.matchMedia(
+      `(min-width: ${breakpoints.xlg}px) and (max-width: ${breakpoints.max}px)`,
+    ),
+    max: window.matchMedia(`(min-width: ${breakpoints.max}px)`),
+  };
+  const matchers = Object.entries(match);
+  const sizeByMedia = /** @type {Record<string, BreakpointSize>} */ (
+    Object.fromEntries(
+      matchers.map(([size, queryList]) => [queryList.media, size]),
+    )
+  );
+
+  const entry = matchers.find(([_size, queryList]) => queryList.matches);
+  const size = entry?.[0];
+  if (size !== undefined) callback(/** @type {BreakpointSize} */ (size));
+
+  /** @type {(e: MediaQueryListEvent) => void} */
+  function handleChange({ matches, media }) {
+    const raw = sizeByMedia[media];
+    if (matches && raw !== undefined) {
+      callback(/** @type {BreakpointSize} */ (raw));
+    }
+  }
+
+  for (const [_size, queryList] of matchers) {
+    queryList.addEventListener("change", handleChange, { passive: true });
+  }
+
+  return () => {
+    for (const [_size, queryList] of matchers) {
+      queryList.removeEventListener("change", handleChange);
+    }
+  };
+}
+
+/**
  * Creates a readable store that returns the current breakpoint size.
  * It also provides functions for creating derived stores used to do comparisons.
  */
@@ -12,51 +65,7 @@ export function breakpointObserver() {
   /** @type {import("svelte/store").Writable<BreakpointSize | undefined>} */
   const store = writable(undefined);
 
-  onMount(() => {
-    /** @type {Record<BreakpointSize, MediaQueryList>} */
-    const match = {
-      sm: window.matchMedia(`(max-width: ${breakpoints.md}px)`),
-      md: window.matchMedia(
-        `(min-width: ${breakpoints.md}px) and (max-width: ${breakpoints.lg}px)`,
-      ),
-      lg: window.matchMedia(
-        `(min-width: ${breakpoints.lg}px) and (max-width: ${breakpoints.xlg}px)`,
-      ),
-      xlg: window.matchMedia(
-        `(min-width: ${breakpoints.xlg}px) and (max-width: ${breakpoints.max}px)`,
-      ),
-      max: window.matchMedia(`(min-width: ${breakpoints.max}px)`),
-    };
-    const matchers = Object.entries(match);
-    const sizeByMedia = /** @type {Record<string, BreakpointSize>} */ (
-      Object.fromEntries(
-        matchers.map(([size, queryList]) => [queryList.media, size]),
-      )
-    );
-
-    const entry = matchers.find(([_size, queryList]) => queryList.matches);
-    const size = entry?.[0];
-    if (size !== undefined) store.set(/** @type {BreakpointSize} */ (size));
-
-    /** @type {(e: MediaQueryListEvent) => void} */
-    function handleChange({ matches, media }) {
-      const raw = sizeByMedia[media];
-      if (matches && raw !== undefined) {
-        const size = /** @type {BreakpointSize} */ (raw);
-        store.set(size);
-      }
-    }
-
-    for (const [_size, queryList] of matchers) {
-      queryList.addEventListener("change", handleChange, { passive: true });
-    }
-
-    return () => {
-      for (const [_size, queryList] of matchers) {
-        queryList.removeEventListener("change", handleChange);
-      }
-    };
-  });
+  onMount(() => observeBreakpoint((size) => store.set(size)));
 
   return {
     subscribe: store.subscribe,

--- a/src/Breakpoint/hideAtBreakpoint.d.ts
+++ b/src/Breakpoint/hideAtBreakpoint.d.ts
@@ -1,0 +1,24 @@
+import type { BreakpointSize } from "./breakpoints";
+
+export interface HideAtBreakpointOptions {
+  /** Hide the element when the current breakpoint is larger than this size. */
+  above?: BreakpointSize;
+  /** Hide the element when the current breakpoint is smaller than this size. */
+  below?: BreakpointSize;
+}
+
+/**
+ * Svelte action that hides the element when the current breakpoint is
+ * larger than `above` or smaller than `below`.
+ * @param node - The element to toggle visibility on
+ * @param options - Upper/lower breakpoint bounds
+ */
+export function hideAtBreakpoint(
+  node: HTMLElement,
+  options?: HideAtBreakpointOptions,
+): {
+  update: (options?: HideAtBreakpointOptions) => void;
+  destroy: () => void;
+};
+
+export default hideAtBreakpoint;

--- a/src/Breakpoint/hideAtBreakpoint.js
+++ b/src/Breakpoint/hideAtBreakpoint.js
@@ -1,0 +1,46 @@
+// @ts-check
+
+import { observeBreakpoint } from "./breakpointObserver";
+import { breakpoints } from "./breakpoints";
+
+/** @typedef {import("./breakpoints").BreakpointSize} BreakpointSize */
+
+/**
+ * Svelte action that hides the element when the current breakpoint is
+ * larger than `above` or smaller than `below`.
+ * @typedef {{ above?: BreakpointSize; below?: BreakpointSize }} HideAtBreakpointOptions
+ * @type {(node: HTMLElement, options?: HideAtBreakpointOptions) => { update: (options?: HideAtBreakpointOptions) => void; destroy: () => void }}
+ * @example
+ * <div use:hideAtBreakpoint={{ above: "md" }}>Hidden at md and up</div>
+ * <div use:hideAtBreakpoint={{ below: "lg" }}>Hidden below lg</div>
+ */
+export function hideAtBreakpoint(node, options = {}) {
+  let { above, below } = options;
+
+  /** @type {BreakpointSize | undefined} */
+  let size;
+
+  function updateVisibility() {
+    if (size === undefined) return;
+    const hidden =
+      (above !== undefined && breakpoints[size] > breakpoints[above]) ||
+      (below !== undefined && breakpoints[size] < breakpoints[below]);
+    node.style.display = hidden ? "none" : "";
+  }
+
+  const cleanup = observeBreakpoint((newSize) => {
+    size = newSize;
+    updateVisibility();
+  });
+
+  return {
+    update(newOptions = {}) {
+      above = newOptions.above;
+      below = newOptions.below;
+      updateVisibility();
+    },
+    destroy: cleanup,
+  };
+}
+
+export default hideAtBreakpoint;

--- a/src/Breakpoint/index.d.ts
+++ b/src/Breakpoint/index.d.ts
@@ -2,3 +2,4 @@
 export { default as Breakpoint } from "./Breakpoint.svelte";
 export { breakpointObserver } from "./breakpointObserver";
 export { breakpoints } from "./breakpoints";
+export { hideAtBreakpoint } from "./hideAtBreakpoint";

--- a/src/Breakpoint/index.js
+++ b/src/Breakpoint/index.js
@@ -1,3 +1,4 @@
 export { default as Breakpoint } from "./Breakpoint.svelte";
 export { breakpointObserver } from "./breakpointObserver";
 export { breakpoints } from "./breakpoints";
+export { hideAtBreakpoint } from "./hideAtBreakpoint";

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ export { default as BreadcrumbSkeleton } from "./Breadcrumb/BreadcrumbSkeleton.s
 export { default as Breakpoint } from "./Breakpoint/Breakpoint.svelte";
 export { default as breakpointObserver } from "./Breakpoint/breakpointObserver";
 export { default as breakpoints } from "./Breakpoint/breakpoints";
+export { hideAtBreakpoint } from "./Breakpoint/hideAtBreakpoint";
 export { default as Button } from "./Button/Button.svelte";
 export { default as ButtonSet } from "./Button/ButtonSet.svelte";
 export { default as ButtonSkeleton } from "./Button/ButtonSkeleton.svelte";

--- a/tests/Breakpoint/HideAtBreakpoint.test.svelte
+++ b/tests/Breakpoint/HideAtBreakpoint.test.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+  import type { HideAtBreakpointOptions } from "carbon-components-svelte/Breakpoint/hideAtBreakpoint";
+  import { hideAtBreakpoint } from "carbon-components-svelte/Breakpoint/hideAtBreakpoint";
+
+  export let options: HideAtBreakpointOptions = {};
+</script>
+
+<div data-testid="target" use:hideAtBreakpoint={options}>Content</div>

--- a/tests/Breakpoint/HideAtBreakpoint.test.ts
+++ b/tests/Breakpoint/HideAtBreakpoint.test.ts
@@ -1,0 +1,90 @@
+import { render, screen } from "@testing-library/svelte";
+import { hideAtBreakpoint } from "../../src/Breakpoint/hideAtBreakpoint.js";
+import HideAtBreakpoint from "./HideAtBreakpoint.test.svelte";
+
+type Size = "sm" | "md" | "lg" | "xlg" | "max";
+
+function stubMatchMediaForSize(size: Size) {
+  const isMatch: Record<Size, (query: string) => boolean> = {
+    sm: (query) => query.includes("(max-width: 672px)"),
+    md: (query) => query.includes("(min-width: 672px) and (max-width: 1056px)"),
+    lg: (query) =>
+      query.includes("(min-width: 1056px) and (max-width: 1312px)"),
+    xlg: (query) =>
+      query.includes("(min-width: 1312px) and (max-width: 1584px)"),
+    max: (query) => query.includes("(min-width: 1584px)"),
+  };
+
+  vi.stubGlobal("matchMedia", (query: string) => ({
+    matches: isMatch[size](query),
+    media: query,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  }));
+}
+
+describe("hideAtBreakpoint", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("renders children when outside the hidden range", () => {
+    stubMatchMediaForSize("lg");
+
+    render(HideAtBreakpoint, { props: { options: { above: "xlg" } } });
+
+    expect(screen.getByTestId("target")).not.toHaveStyle({
+      display: "none",
+    });
+  });
+
+  it("hides content above the `above` bound", () => {
+    stubMatchMediaForSize("xlg");
+
+    render(HideAtBreakpoint, { props: { options: { above: "lg" } } });
+
+    expect(screen.getByTestId("target")).toHaveStyle({ display: "none" });
+  });
+
+  it("does not hide at the `above` boundary itself", () => {
+    stubMatchMediaForSize("lg");
+
+    render(HideAtBreakpoint, { props: { options: { above: "lg" } } });
+
+    expect(screen.getByTestId("target")).not.toHaveStyle({
+      display: "none",
+    });
+  });
+
+  it("hides content below the `below` bound", () => {
+    stubMatchMediaForSize("sm");
+
+    render(HideAtBreakpoint, { props: { options: { below: "md" } } });
+
+    expect(screen.getByTestId("target")).toHaveStyle({ display: "none" });
+  });
+
+  it("does not hide at the `below` boundary itself", () => {
+    stubMatchMediaForSize("md");
+
+    render(HideAtBreakpoint, { props: { options: { below: "md" } } });
+
+    expect(screen.getByTestId("target")).not.toHaveStyle({
+      display: "none",
+    });
+  });
+
+  it("supports direct import and updates visibility on option change", () => {
+    stubMatchMediaForSize("xlg");
+
+    const node = document.createElement("div");
+    const { update, destroy } = hideAtBreakpoint(node, { above: "lg" });
+
+    expect(node.style.display).toBe("none");
+
+    update({ above: "xlg" });
+    expect(node.style.display).toBe("");
+
+    destroy();
+  });
+});


### PR DESCRIPTION
- Adds a `use:hideAtBreakpoint` action instead of a `HideAtBreakpoint` component, since #2764 already established that Breakpoint's slot API covers reading the current size idiomatically for Svelte.
- Extracts a framework-agnostic `observeBreakpoint` helper out of `breakpointObserver` so the action can reuse the same matchMedia logic without depending on `onMount`.
- Documents the action on the existing Breakpoint page with a new `## use:hideAtBreakpoint` section.
