### PR TITLE
docs: update number of icons to 2,700+

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Carbon Components Svelte is a [Svelte](https://github.com/sveltejs/svelte) compo
 
 The Carbon Svelte ecosystem also includes:
 
-- **[Carbon Icons Svelte](https://github.com/carbon-design-system/carbon-icons-svelte)**: 2,600+ Carbon icons as Svelte components
+- **[Carbon Icons Svelte](https://github.com/carbon-design-system/carbon-icons-svelte)**: 2,700+ Carbon icons as Svelte components
 - **[Carbon Pictograms Svelte](https://github.com/carbon-design-system/carbon-pictograms-svelte)**: 1,500+ Carbon pictograms as Svelte components
 - **[Carbon Charts Svelte](https://github.com/carbon-design-system/carbon-charts/tree/master/packages/svelte)**: 25+ charts, powered by d3
 - **[Carbon Preprocess Svelte](https://github.com/carbon-design-system/carbon-preprocess-svelte)**: Collection of Svelte preprocessors for Carbon
@@ -304,7 +304,7 @@ The icon and pictogram sets ship as separate packages of individual Svelte compo
 
 ### Icons
 
-2,600+ icons designed for product UI, in four sizes (16, 20, 24, and 32 pixels), set with a single prop.
+2,700+ icons designed for product UI, in four sizes (16, 20, 24, and 32 pixels), set with a single prop.
 
 ```sh
 # npm

--- a/docs/content/overview.md
+++ b/docs/content/overview.md
@@ -216,7 +216,7 @@ The icon and pictogram sets ship as separate packages of individual Svelte compo
 
 ### Icons
 
-2,600+ icons designed for product UI, in four sizes (16, 20, 24, and 32 pixels), set with a single prop.
+2,700+ icons designed for product UI, in four sizes (16, 20, 24, and 32 pixels), set with a single prop.
 
 ```sh
 # npm
@@ -278,7 +278,7 @@ Documentation is available in LLM-friendly plain text for use with coding assist
 The Carbon Svelte collection includes packages for icons, pictograms, and data visualization:
 
 - **Carbon Components Svelte** — 70+ components — [GitHub](https://github.com/carbon-design-system/carbon-components-svelte)
-- **Carbon Icons Svelte** — 2,600+ icons — [GitHub](https://github.com/carbon-design-system/carbon-icons-svelte)
+- **Carbon Icons Svelte** — 2,700+ icons — [GitHub](https://github.com/carbon-design-system/carbon-icons-svelte)
 - **Carbon Pictograms Svelte** — 1,500+ pictograms — [GitHub](https://github.com/carbon-design-system/carbon-pictograms-svelte)
 - **Carbon Charts Svelte** — 25+ charts, powered by d3 — [GitHub](https://github.com/carbon-design-system/carbon-charts/tree/master/packages/svelte)
 - **Carbon Preprocess Svelte** — Collection of Carbon Svelte preprocessors — [GitHub](https://github.com/carbon-design-system/carbon-preprocess-svelte)

--- a/docs/src/pages/component-index.svelte
+++ b/docs/src/pages/component-index.svelte
@@ -300,13 +300,15 @@
                         class="doc-links"
                       >
                         <Link
+                          inline
+                          muted
                           href={sourceRepoUrl(entry.sourcePath)}
                           target="_blank"
                         >
                           Source code
                         </Link>
                         <Stack orientation="horizontal" gap={2} align="center">
-                          <Link href={entry.markdownHref} target="_blank">
+                          <Link inline muted href={entry.markdownHref} target="_blank">
                             Markdown
                           </Link>
                           <CopyMarkdownButton

--- a/docs/src/pages/index.svelte
+++ b/docs/src/pages/index.svelte
@@ -235,7 +235,7 @@
                 <TileCard
                   borderBottom
                   title="Carbon Icons Svelte"
-                  subtitle="2,600+ icons"
+                  subtitle="2,700+ icons"
                   target="_blank"
                   href="https://github.com/carbon-design-system/carbon-icons-svelte"
                 />

--- a/docs/src/pages/quick-start.svelte
+++ b/docs/src/pages/quick-start.svelte
@@ -304,7 +304,7 @@
             <Stack gap={3}>
               <div class="glyph-desc">
                 <Text type="body-long-01" color="secondary" maxWidth="40ch">
-                  2,600+ icons designed for product UI, in four sizes (16, 20,
+                  2,700+ icons designed for product UI, in four sizes (16, 20,
                   24, and 32 pixels), set with a single prop.
                 </Text>
               </div>


### PR DESCRIPTION
The latest minor version of the icons library has surpassed 2700+ icons.