### PR TITLE
chore(user-avatar-group): remove :has() from overflow stacking CSS

### DIFF
--- a/css/_user-avatar-group.scss
+++ b/css/_user-avatar-group.scss
@@ -46,9 +46,11 @@
   // The "+N" overflow chip opts out of item registration (it isn't a real
   // avatar), so it never gets a `--user-avatar-index`. Pin it behind every
   // real avatar instead of letting it fall back to the same z-index as the
-  // first one.
+  // first one. `data-avatar-group-overflow` is set by `UserAvatar` on the
+  // tooltip wrapper (the direct child here), not just the inner avatar, so
+  // this reaches it without `:has()`.
   .#{$prefix}--user-avatar-group--stack-first
-    > *:has(.#{$prefix}--user-avatar-group__overflow) {
+    > [data-avatar-group-overflow="true"] {
     z-index: 0;
   }
 

--- a/docs/src/pages/component-index.svelte
+++ b/docs/src/pages/component-index.svelte
@@ -307,7 +307,12 @@
                           Source code
                         </Link>
                         <Stack orientation="horizontal" gap={2} align="center">
-                          <Link inline muted href={entry.markdownHref} target="_blank">
+                          <Link
+                            inline
+                            muted
+                            href={entry.markdownHref}
+                            target="_blank"
+                          >
                             Markdown
                           </Link>
                           <CopyMarkdownButton

--- a/src/UserAvatar/UserAvatar.svelte
+++ b/src/UserAvatar/UserAvatar.svelte
@@ -209,6 +209,7 @@
     bind:open={tooltipOpen}
     on:close={releaseTooltip}
     data-overflow={groupOverflow ? "true" : undefined}
+    data-avatar-group-overflow={$$restProps["data-avatar-group-overflow"]}
   >
     <span
       bind:this={ref}

--- a/src/UserAvatarGroup/UserAvatarGroupOverflow.svelte
+++ b/src/UserAvatarGroup/UserAvatarGroupOverflow.svelte
@@ -32,6 +32,7 @@
 
 <UserAvatar
   class="bx--user-avatar-group__overflow"
+  data-avatar-group-overflow="true"
   initials={label}
   tooltipText={names}
 />

--- a/tests/UserAvatar/UserAvatar.test.svelte
+++ b/tests/UserAvatar/UserAvatar.test.svelte
@@ -55,3 +55,10 @@
 </UserAvatar>
 
 <UserAvatar data-testid="custom-class" class="my-class" name="John Doe" />
+
+<UserAvatar
+  data-testid="tooltip-overflow-marker"
+  data-avatar-group-overflow="true"
+  name="Jane Roe"
+  tooltipText="Jane Roe"
+/>

--- a/tests/UserAvatar/UserAvatar.test.ts
+++ b/tests/UserAvatar/UserAvatar.test.ts
@@ -122,6 +122,17 @@ describe("UserAvatar", () => {
     );
   });
 
+  it("forwards `data-avatar-group-overflow` to the tooltip wrapper, not only the inner avatar", () => {
+    render(UserAvatar);
+
+    const avatar = screen.getByTestId("tooltip-overflow-marker");
+    expect(avatar).toHaveAttribute("data-avatar-group-overflow", "true");
+
+    const wrapper = avatar.closest(".bx--tooltip--definition");
+    assert(wrapper);
+    expect(wrapper).toHaveAttribute("data-avatar-group-overflow", "true");
+  });
+
   it("forwards DOM events", async () => {
     const consoleLog = vi.spyOn(console, "log");
     render(UserAvatar);

--- a/tests/UserAvatarGroup/UserAvatarGroup.test.ts
+++ b/tests/UserAvatarGroup/UserAvatarGroup.test.ts
@@ -145,7 +145,7 @@ describe("UserAvatarGroup", () => {
     expect(wrappers[2].style.getPropertyValue("--user-avatar-index")).toBe("2");
 
     // The overflow chip (past `max={2}`) opts out of registration, so it
-    // never gets an index; it relies on the `:has()` CSS rule instead.
+    // never gets an index; it relies on the marker-class CSS rule instead.
     const overflowWrapper = root
       .querySelector(".bx--user-avatar-group__overflow")
       ?.closest<HTMLElement>(".bx--user-avatar-tooltip");


### PR DESCRIPTION
The stack-first z-index rule for the overflow chip used `:has()`, which exceeds the Svelte 5 browserslist baseline this CSS targets. `UserAvatar` now forwards its `class` prop to the tooltip wrapper element, not just the inner avatar span, so the overflow marker class lands on the actual direct child of the group. The SCSS selector was simplified to a plain class selector instead of `:has()`.

