### PR TITLE
feat(combo-button): add ComboButton component

### DIFF
--- a/css/_combo-button.scss
+++ b/css/_combo-button.scss
@@ -1,0 +1,50 @@
+@import "carbon-components/scss/globals/scss/vars";
+@import "carbon-components/scss/globals/scss/helper-mixins";
+@import "carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/import-once/import-once";
+
+/// Groups a `ComboButton`'s primary action and icon-only trigger button into
+/// a single visual unit. The divider mirrors v10's own `.bx--btn-set`
+/// technique (a box-shadow on the trigger, since adjacent buttons have no
+/// margin between them); the chevron rotates on open.
+/// @access private
+/// @group components
+@mixin combo-button {
+  .#{$prefix}--combo-button {
+    display: inline-flex;
+  }
+
+  .#{$prefix}--combo-button .#{$prefix}--combo-button__trigger:not(:focus) {
+    box-shadow: to-rem(-1px) 0 0 0 $button-separator;
+  }
+
+  .#{$prefix}--combo-button
+    .#{$prefix}--combo-button__trigger.#{$prefix}--btn--disabled {
+    box-shadow: to-rem(-1px) 0 0 0 $disabled-03;
+  }
+
+  .#{$prefix}--combo-button__trigger .#{$prefix}--btn__icon {
+    transition: transform $duration--fast-01 motion(standard, productive);
+  }
+
+  .#{$prefix}--combo-button__trigger--open .#{$prefix}--btn__icon {
+    transform: rotate(180deg);
+  }
+
+  // Extra-small (Carbon React size="xs", 24px). Neither Button's "small"
+  // class (32px) nor any other Button size lands on 24px, so shrink further
+  // on top of the "small" size already passed to both buttons.
+  .#{$prefix}--combo-button--xs .#{$prefix}--btn {
+    min-height: to-rem(24px);
+    padding-top: 0;
+    padding-bottom: 0;
+  }
+
+  .#{$prefix}--combo-button--xs .#{$prefix}--btn--icon-only {
+    padding-right: to-rem(4px);
+    padding-left: to-rem(4px);
+  }
+}
+
+@include exports("combo-button") {
+  @include combo-button;
+}

--- a/css/_menu-button.scss
+++ b/css/_menu-button.scss
@@ -14,6 +14,15 @@
   .#{$prefix}--menu-button__trigger--open .#{$prefix}--btn__icon {
     transform: rotate(180deg);
   }
+
+  // Extra-small (Carbon React size="xs", 24px). Neither Button's "small"
+  // class (32px) nor any other Button size lands on 24px, so shrink further
+  // on top of the "small" size already passed to the trigger.
+  .#{$prefix}--menu-button__trigger--xs {
+    min-height: to-rem(24px);
+    padding-top: 0;
+    padding-bottom: 0;
+  }
 }
 
 @include exports("menu-button") {

--- a/css/_menu-xs.scss
+++ b/css/_menu-xs.scss
@@ -1,0 +1,17 @@
+@import "carbon-components/scss/globals/scss/vars";
+@import "carbon-components/scss/globals/scss/helper-mixins";
+@import "carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/import-once/import-once";
+
+/// Extra-small menu (Carbon React size="xs", 24px). v10 only ships sm/md/lg
+/// for `.bx--menu`; mirrors the same v10-lacks-xs situation as OverflowMenu.
+/// @access private
+/// @group components
+@mixin menu-xs {
+  .#{$prefix}--menu--xs .#{$prefix}--menu-option {
+    height: to-rem(24px);
+  }
+}
+
+@include exports("menu-xs") {
+  @include menu-xs;
+}

--- a/css/all.scss
+++ b/css/all.scss
@@ -109,6 +109,7 @@ $css--plex: true;
 @import "./copy-input";
 @import "./overflow-menu";
 @import "./menu-xs";
+@import "./combo-button";
 @import "./list-box-menu-item";
 @import "./list-box-xs";
 @import "./fluid-list-box";

--- a/css/all.scss
+++ b/css/all.scss
@@ -108,6 +108,7 @@ $css--plex: true;
 @import "./copy-button";
 @import "./copy-input";
 @import "./overflow-menu";
+@import "./menu-xs";
 @import "./list-box-menu-item";
 @import "./list-box-xs";
 @import "./fluid-list-box";

--- a/css/g10.scss
+++ b/css/g10.scss
@@ -68,6 +68,7 @@ $css--plex: true;
 @import "./copy-button";
 @import "./copy-input";
 @import "./overflow-menu";
+@import "./menu-xs";
 @import "./list-box-menu-item";
 @import "./list-box-xs";
 @import "./fluid-list-box";

--- a/css/g10.scss
+++ b/css/g10.scss
@@ -69,6 +69,7 @@ $css--plex: true;
 @import "./copy-input";
 @import "./overflow-menu";
 @import "./menu-xs";
+@import "./combo-button";
 @import "./list-box-menu-item";
 @import "./list-box-xs";
 @import "./fluid-list-box";

--- a/css/g100.scss
+++ b/css/g100.scss
@@ -68,6 +68,7 @@ $css--plex: true;
 @import "./copy-button";
 @import "./copy-input";
 @import "./overflow-menu";
+@import "./menu-xs";
 @import "./list-box-menu-item";
 @import "./list-box-xs";
 @import "./fluid-list-box";

--- a/css/g100.scss
+++ b/css/g100.scss
@@ -69,6 +69,7 @@ $css--plex: true;
 @import "./copy-input";
 @import "./overflow-menu";
 @import "./menu-xs";
+@import "./combo-button";
 @import "./list-box-menu-item";
 @import "./list-box-xs";
 @import "./fluid-list-box";

--- a/css/g80.scss
+++ b/css/g80.scss
@@ -68,6 +68,7 @@ $css--plex: true;
 @import "./copy-button";
 @import "./copy-input";
 @import "./overflow-menu";
+@import "./menu-xs";
 @import "./list-box-menu-item";
 @import "./list-box-xs";
 @import "./fluid-list-box";

--- a/css/g80.scss
+++ b/css/g80.scss
@@ -69,6 +69,7 @@ $css--plex: true;
 @import "./copy-input";
 @import "./overflow-menu";
 @import "./menu-xs";
+@import "./combo-button";
 @import "./list-box-menu-item";
 @import "./list-box-xs";
 @import "./fluid-list-box";

--- a/css/g90.scss
+++ b/css/g90.scss
@@ -68,6 +68,7 @@ $css--plex: true;
 @import "./copy-button";
 @import "./copy-input";
 @import "./overflow-menu";
+@import "./menu-xs";
 @import "./list-box-menu-item";
 @import "./list-box-xs";
 @import "./fluid-list-box";

--- a/css/g90.scss
+++ b/css/g90.scss
@@ -69,6 +69,7 @@ $css--plex: true;
 @import "./copy-input";
 @import "./overflow-menu";
 @import "./menu-xs";
+@import "./combo-button";
 @import "./list-box-menu-item";
 @import "./list-box-xs";
 @import "./fluid-list-box";

--- a/css/white.scss
+++ b/css/white.scss
@@ -68,6 +68,7 @@ $css--plex: true;
 @import "./copy-button";
 @import "./copy-input";
 @import "./overflow-menu";
+@import "./menu-xs";
 @import "./list-box-menu-item";
 @import "./list-box-xs";
 @import "./fluid-list-box";

--- a/css/white.scss
+++ b/css/white.scss
@@ -69,6 +69,7 @@ $css--plex: true;
 @import "./copy-input";
 @import "./overflow-menu";
 @import "./menu-xs";
+@import "./combo-button";
 @import "./list-box-menu-item";
 @import "./list-box-xs";
 @import "./fluid-list-box";

--- a/docs/src/component-categories.ts
+++ b/docs/src/component-categories.ts
@@ -41,6 +41,7 @@ export const COMPONENT_CATEGORIES: ComponentCategory[] = [
       "OverflowMenu",
       "ContextMenu",
       "MenuButton",
+      "ComboButton",
     ],
   },
   {

--- a/docs/src/component-since-versions.ts
+++ b/docs/src/component-since-versions.ts
@@ -11,6 +11,7 @@ export const COMPONENT_SINCE_VERSIONS: Record<string, string> = {
   ClickableTile: "0.2.0",
   CodeSnippet: "0.2.0",
   ComboBox: "0.2.0",
+  ComboButton: "0.110.0",
   ComposedModal: "0.2.0",
   ContainedList: "0.98.0",
   ContentSwitcher: "0.2.0",

--- a/docs/src/pages/components/Button.svx
+++ b/docs/src/pages/components/Button.svx
@@ -77,6 +77,12 @@ Omit the label and provide an **iconDescription** for accessibility. This text i
 
 <Button iconDescription="Tooltip text" icon={Add} />
 
+### Icon-only without iconDescription
+
+If you omit `iconDescription`, the button renders without Carbon's tooltip instead of an empty one. Supply your own `aria-label` (or `aria-labelledby`) so the button stays accessible.
+
+<Button icon={Add} aria-label="Custom accessible name" />
+
 ### Icon-only link
 
 Set `href` to create an icon-only link button.

--- a/docs/src/pages/components/ComboButton.svx
+++ b/docs/src/pages/components/ComboButton.svx
@@ -1,0 +1,148 @@
+---
+components: ["ComboButton", "MenuItem", "MenuDivider"]
+description: ComboButton pairs a primary action with a menu of related secondary actions, so the most common action stays one click away.
+---
+
+<script>
+  import { ComboButton, MenuDivider, MenuItem } from "carbon-components-svelte";
+  import Copy from "carbon-icons-svelte/lib/Copy.svelte";
+  import TrashCan from "carbon-icons-svelte/lib/TrashCan.svelte";
+</script>
+
+## Basic
+
+Wrap `MenuItem` components in `ComboButton` and set `labelText` for the primary action button. Use the `labelChildren` slot for custom button content. Clicking the label fires `on:click`; clicking the chevron trigger opens the menu.
+
+<ComboButton labelText="Save">
+  <MenuItem on:click={() => console.log("Save as")}>Save as</MenuItem>
+  <MenuItem on:click={() => console.log("Save a copy")}>Save a copy</MenuItem>
+  <MenuItem on:click={() => console.log("Save and close")}>Save and close</MenuItem>
+</ComboButton>
+
+## Icon description
+
+The icon-only trigger needs its own accessible label, since it has no visible text. Override `iconDescription` to change it; the default is `"Additional actions"`.
+
+<ComboButton labelText="Save" iconDescription="More save options">
+  <MenuItem on:click={() => console.log("Save as")}>Save as</MenuItem>
+  <MenuItem on:click={() => console.log("Save a copy")}>Save a copy</MenuItem>
+</ComboButton>
+
+### Tooltip position
+
+Set `tooltipPosition` to control where the trigger's tooltip appears. This is independent of `direction`, which controls where the menu opens - the two are separate concerns and can point different ways.
+
+<ComboButton labelText="Save" tooltipPosition="right">
+  <MenuItem on:click={() => console.log("Save as")}>Save as</MenuItem>
+  <MenuItem on:click={() => console.log("Save a copy")}>Save a copy</MenuItem>
+</ComboButton>
+
+### No tooltip
+
+Set `iconDescription` to an empty string to render the trigger without Carbon's tooltip, the same way [Button](/components/Button#icons) handles an empty `iconDescription`. The trigger then has no accessible name of its own, so only do this when something else in the surrounding context labels it.
+
+<ComboButton labelText="Save" iconDescription="">
+  <MenuItem on:click={() => console.log("Save as")}>Save as</MenuItem>
+  <MenuItem on:click={() => console.log("Save a copy")}>Save a copy</MenuItem>
+</ComboButton>
+
+## Size
+
+Set `size` to scale both buttons and each menu item's row height together. The default is `"md"`. `ComboButton` only supports the `"primary"` kind, matching Carbon React.
+
+### Extra small
+
+<ComboButton labelText="Save" size="xs">
+  <MenuItem on:click={() => console.log("Save as")}>Save as</MenuItem>
+  <MenuItem on:click={() => console.log("Save a copy")}>Save a copy</MenuItem>
+</ComboButton>
+
+### Small
+
+<ComboButton labelText="Save" size="sm">
+  <MenuItem on:click={() => console.log("Save as")}>Save as</MenuItem>
+  <MenuItem on:click={() => console.log("Save a copy")}>Save a copy</MenuItem>
+</ComboButton>
+
+### Large
+
+<ComboButton labelText="Save" size="lg">
+  <MenuItem on:click={() => console.log("Save as")}>Save as</MenuItem>
+  <MenuItem on:click={() => console.log("Save a copy")}>Save a copy</MenuItem>
+</ComboButton>
+
+## Direction
+
+Set `direction` to `"top"` or `"bottom"` (default) for which side of the trigger the menu opens on. The menu flips to the opposite side when there isn't room on the preferred side. See [Menu placement](/components/Menu#placement) for gap and offset props.
+
+### Top
+
+<ComboButton labelText="Save" direction="top">
+  <MenuItem on:click={() => console.log("Save as")}>Save as</MenuItem>
+  <MenuItem on:click={() => console.log("Save a copy")}>Save a copy</MenuItem>
+</ComboButton>
+
+### Alignment
+
+Set `intrinsicAlign` to `"start"`, `"center"`, or `"end"` (default) to align the menu edge with the trigger.
+
+<ComboButton labelText="Save" intrinsicAlign="start">
+  <MenuItem on:click={() => console.log("Save as")}>Save as</MenuItem>
+  <MenuItem on:click={() => console.log("Save a copy")}>Save a copy</MenuItem>
+</ComboButton>
+
+## Disabled
+
+Set `disabled` to `true` to disable both the primary action and trigger buttons.
+
+<ComboButton labelText="Save" disabled>
+  <MenuItem on:click={() => console.log("Save as")}>Save as</MenuItem>
+</ComboButton>
+
+## Menu items
+
+`MenuItem` takes `disabled`, an `icon`, `kind="danger"` for destructive rows, and nested children for submenus. Use `MenuDivider` between groups. See [MenuButton](/components/MenuButton#menu-items) for the full set of examples and keyboard/hover behavior for submenus.
+
+### Disabled
+
+Set `disabled` on a `MenuItem` to make it non-interactive.
+
+<ComboButton labelText="Save">
+  <MenuItem on:click={() => console.log("Save as")}>Save as</MenuItem>
+  <MenuItem disabled on:click={() => console.log("Save a copy")}>Save a copy</MenuItem>
+</ComboButton>
+
+### Icons
+
+Pass a Carbon icon to `icon`.
+
+<ComboButton labelText="Save">
+  <MenuItem icon={Copy} on:click={() => console.log("Save a copy")}>Save a copy</MenuItem>
+  <MenuItem on:click={() => console.log("Save as")}>Save as</MenuItem>
+</ComboButton>
+
+### Danger
+
+Set `kind="danger"` on `MenuItem` for a destructive action.
+
+<ComboButton labelText="Save">
+  <MenuItem on:click={() => console.log("Save as")}>Save as</MenuItem>
+  <MenuItem on:click={() => console.log("Save a copy")}>Save a copy</MenuItem>
+  <MenuDivider />
+  <MenuItem icon={TrashCan} kind="danger" on:click={() => console.log("Delete draft")}>
+    Delete draft
+  </MenuItem>
+</ComboButton>
+
+### Nested
+
+Set `labelText` on a `MenuItem` and nest child `MenuItem` rows to get a submenu.
+
+<ComboButton labelText="Save">
+  <MenuItem on:click={() => console.log("Save as")}>Save as</MenuItem>
+  <MenuItem labelText="Export as">
+    <MenuItem on:click={() => console.log("PDF")}>PDF</MenuItem>
+    <MenuItem on:click={() => console.log("JPG")}>JPG</MenuItem>
+    <MenuItem on:click={() => console.log("PNG")}>PNG</MenuItem>
+  </MenuItem>
+</ComboButton>

--- a/docs/src/pages/components/MenuButton.svx
+++ b/docs/src/pages/components/MenuButton.svx
@@ -55,6 +55,14 @@ The default kind is `"primary"`.
 
 Set `size` to scale the trigger button and each menu item's row height together. The default is `"md"`.
 
+### Extra small
+
+<MenuButton labelText="Actions" size="xs">
+  <MenuItem on:click={() => console.log("Cut")}>Cut</MenuItem>
+  <MenuItem on:click={() => console.log("Copy")}>Copy</MenuItem>
+  <MenuItem on:click={() => console.log("Paste")}>Paste</MenuItem>
+</MenuButton>
+
 ### Small
 
 <MenuButton labelText="Actions" size="sm">
@@ -73,9 +81,21 @@ Set `size` to scale the trigger button and each menu item's row height together.
 
 ## Direction
 
-Set `direction` to `"top"` or `"bottom"` (default) for which side of the trigger the menu opens on. Set `intrinsicAlign` to `"start"` (default), `"center"`, or `"end"` to align the menu edge with the trigger. The menu flips when there isn't room on the preferred side. See [Menu placement](/components/Menu#placement) for gap and offset props.
+Set `direction` to `"top"` or `"bottom"` (default) for which side of the trigger the menu opens on. The menu flips to the opposite side when there isn't room on the preferred side. See [Menu placement](/components/Menu#placement) for gap and offset props.
 
-<MenuButton labelText="Actions" direction="top" intrinsicAlign="end">
+### Top
+
+<MenuButton labelText="Actions" direction="top">
+  <MenuItem on:click={() => console.log("Cut")}>Cut</MenuItem>
+  <MenuItem on:click={() => console.log("Copy")}>Copy</MenuItem>
+  <MenuItem on:click={() => console.log("Paste")}>Paste</MenuItem>
+</MenuButton>
+
+### Alignment
+
+Set `intrinsicAlign` to `"start"` (default), `"center"`, or `"end"` to align the menu edge with the trigger.
+
+<MenuButton labelText="Actions" intrinsicAlign="end">
   <MenuItem on:click={() => console.log("Cut")}>Cut</MenuItem>
   <MenuItem on:click={() => console.log("Copy")}>Copy</MenuItem>
   <MenuItem on:click={() => console.log("Paste")}>Paste</MenuItem>
@@ -91,7 +111,16 @@ Set `disabled` to `true` to disable the trigger button.
 
 ## Menu items
 
-`MenuItem` takes an `icon`, `kind="danger"` for destructive rows, and nested children for submenus. Use `MenuDivider` between groups.
+`MenuItem` takes `disabled`, an `icon`, `kind="danger"` for destructive rows, and nested children for submenus. Use `MenuDivider` between groups.
+
+### Disabled
+
+Set `disabled` on a `MenuItem` to make it non-interactive.
+
+<MenuButton labelText="Actions">
+  <MenuItem on:click={() => console.log("Cut")}>Cut</MenuItem>
+  <MenuItem disabled on:click={() => console.log("Copy")}>Copy</MenuItem>
+</MenuButton>
 
 ### Icons
 

--- a/e2e/combo-button.test.ts
+++ b/e2e/combo-button.test.ts
@@ -1,0 +1,76 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("ComboButton", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/combo-button.html");
+  });
+
+  test("fires the primary action independently of the menu trigger", async ({
+    page,
+  }) => {
+    await page.getByRole("button", { name: "Save" }).click();
+
+    await expect(page.getByTestId("primary-clicks")).toContainText("1");
+    await expect(page.getByRole("menu")).not.toBeVisible();
+  });
+
+  test("opens the menu from the trigger and focuses the first item", async ({
+    page,
+  }) => {
+    await page.getByRole("button", { name: "Additional actions" }).click();
+
+    await expect(page.getByRole("menuitem", { name: "Save as" })).toBeFocused();
+  });
+
+  test("selects a menu item", async ({ page }) => {
+    await page.getByRole("button", { name: "Additional actions" }).click();
+    await page.getByRole("menuitem", { name: "Save a copy" }).click();
+
+    await expect(page.getByTestId("selected-action")).toContainText(
+      "Save a copy",
+    );
+    await expect(page.getByRole("menu")).not.toBeVisible();
+  });
+
+  test("aligns the menu to the right edge of the trigger group", async ({
+    page,
+  }) => {
+    await page.getByRole("button", { name: "Additional actions" }).click();
+
+    const triggerBox = await page
+      .getByRole("button", { name: "Additional actions" })
+      .boundingBox();
+    const menuBox = await page.getByRole("menu").boundingBox();
+
+    expect(Math.round(menuBox.x + menuBox.width)).toBe(
+      Math.round(triggerBox.x + triggerBox.width),
+    );
+  });
+
+  test("does not leave the trigger focused after closing it with a mouse click", async ({
+    page,
+  }) => {
+    const trigger = page.getByRole("button", { name: "Additional actions" });
+    await trigger.click();
+    await trigger.click();
+
+    await expect(trigger).not.toBeFocused();
+  });
+
+  test("keeps the trigger focused after closing it with the keyboard", async ({
+    page,
+  }) => {
+    const trigger = page.getByRole("button", { name: "Additional actions" });
+    await trigger.focus();
+    await page.keyboard.press("Enter");
+    // dismiss.js defers registering its window listeners (including this
+    // Escape handler) past the enabling keypress by a macrotask (setTimeout),
+    // so the menu already being visible isn't enough - that happens
+    // synchronously, before the deferred registration runs. Wait past that
+    // macrotask boundary, or Escape can race the registration and be dropped.
+    await page.waitForTimeout(50);
+    await page.keyboard.press("Escape");
+
+    await expect(trigger).toBeFocused();
+  });
+});

--- a/e2e/fixtures/ComboButtonFixture.svelte
+++ b/e2e/fixtures/ComboButtonFixture.svelte
@@ -1,0 +1,18 @@
+<script>
+  import { ComboButton, MenuItem } from "carbon-components-svelte";
+
+  let primaryClicks = 0;
+  let selectedAction = "";
+</script>
+
+<ComboButton labelText="Save" on:click={() => primaryClicks++}>
+  <MenuItem on:click={() => (selectedAction = "Save as")}>Save as</MenuItem>
+  <MenuItem on:click={() => (selectedAction = "Save a copy")}>
+    Save a copy
+  </MenuItem>
+</ComboButton>
+
+<p data-testid="primary-clicks">Primary clicks: {primaryClicks}</p>
+{#if selectedAction}
+  <p data-testid="selected-action">Selected: {selectedAction}</p>
+{/if}

--- a/e2e/fixtures/combo-button.html
+++ b/e2e/fixtures/combo-button.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ComboButton Test</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="./combo-button.ts"></script>
+  </body>
+</html>

--- a/e2e/fixtures/combo-button.ts
+++ b/e2e/fixtures/combo-button.ts
@@ -1,0 +1,4 @@
+import ComboButtonFixture from "./ComboButtonFixture.svelte";
+import { mount } from "./mount";
+
+mount(ComboButtonFixture);

--- a/e2e/fixtures/index.html
+++ b/e2e/fixtures/index.html
@@ -24,6 +24,7 @@
       <a href="/context-menu.html">ContextMenu</a>
       <a href="/overflow-menu.html">OverflowMenu</a>
       <a href="/menu-button.html">MenuButton</a>
+      <a href="/combo-button.html">ComboButton</a>
       <a href="/multiselect.html">MultiSelect</a>
       <a href="/select.html">Select</a>
       <a href="/text-input.html">TextInput</a>

--- a/e2e/menu-button.test.ts
+++ b/e2e/menu-button.test.ts
@@ -41,6 +41,33 @@ test.describe("MenuButton", () => {
     await expect(page.getByRole("menu")).not.toBeVisible();
   });
 
+  test("does not leave the trigger focused after closing it with a mouse click", async ({
+    page,
+  }) => {
+    const trigger = page.getByRole("button", { name: "Actions" });
+    await trigger.click();
+    await trigger.click();
+
+    await expect(trigger).not.toBeFocused();
+  });
+
+  test("keeps the trigger focused after closing it with the keyboard", async ({
+    page,
+  }) => {
+    const trigger = page.getByRole("button", { name: "Actions" });
+    await trigger.focus();
+    await page.keyboard.press("Enter");
+    // dismiss.js defers registering its window listeners (including this
+    // Escape handler) past the enabling keypress by a macrotask (setTimeout),
+    // so the menu already being visible isn't enough - that happens
+    // synchronously, before the deferred registration runs. Wait past that
+    // macrotask boundary, or Escape can race the registration and be dropped.
+    await page.waitForTimeout(50);
+    await page.keyboard.press("Escape");
+
+    await expect(trigger).toBeFocused();
+  });
+
   test.describe("submenu", () => {
     test("opens on click without closing the root menu", async ({ page }) => {
       await page.getByRole("button", { name: "Actions" }).click();

--- a/src/Button/Button.svelte
+++ b/src/Button/Button.svelte
@@ -48,6 +48,9 @@
 
   /**
    * Specify the ARIA label for the button icon.
+   * On an icon-only button, this also drives Carbon's tooltip. If omitted,
+   * the icon-only button renders without a tooltip; supply your own
+   * `aria-label` or `aria-labelledby` for accessibility in that case.
    * @type {string}
    */
   export let iconDescription = undefined;
@@ -134,9 +137,15 @@
     ctx.declareRef(ref);
   }
   $: hasIconOnly = (icon || $$slots.icon) && !$$slots.default;
+  // Without an iconDescription there is nothing to show in a tooltip or
+  // announce as the accessible name via the assistive-text span; skip the
+  // whole tooltip apparatus and let the consumer's own aria-label/
+  // aria-labelledby (passed through $$restProps) carry accessibility instead.
+  $: hasTooltipContent = hasIconOnly && Boolean(iconDescription);
   $: effectivePortalTooltip =
     portalTooltip === undefined ? !!insideModal : portalTooltip;
-  $: usePortal = hasIconOnly && !hideTooltip && effectivePortalTooltip;
+  $: usePortal = hasTooltipContent && !hideTooltip && effectivePortalTooltip;
+  $: hasTooltip = hasTooltipContent && !hideTooltip && !usePortal;
 
   const tooltipId = {};
 
@@ -187,13 +196,13 @@
   }
 
   $: tooltipHidden =
-    hasIconOnly &&
+    hasTooltipContent &&
     !hideTooltip &&
     $activeButtonTooltip !== null &&
     $activeButtonTooltip !== tooltipId;
 
   function handleMouseEnter() {
-    if (hasIconOnly && !hideTooltip && !usePortal) {
+    if (hasTooltip) {
       claimActiveTooltip();
     }
   }
@@ -311,23 +320,13 @@
       kind && `bx--btn--${kind}`,
       isDisabled && "bx--btn--disabled",
       hasIconOnly && "bx--btn--icon-only",
-      hasIconOnly && !hideTooltip && !usePortal && "bx--tooltip__trigger",
-      hasIconOnly && !hideTooltip && !usePortal && "bx--tooltip--a11y",
-      hasIconOnly &&
-        !hideTooltip &&
-        !usePortal &&
-        tooltipPosition &&
-        `bx--btn--icon-only--${tooltipPosition}`,
-      hasIconOnly &&
-        !hideTooltip &&
-        !usePortal &&
+      hasTooltip && "bx--tooltip__trigger",
+      hasTooltip && "bx--tooltip--a11y",
+      hasTooltip && tooltipPosition && `bx--btn--icon-only--${tooltipPosition}`,
+      hasTooltip &&
         tooltipAlignment &&
         `bx--tooltip--align-${tooltipAlignment}`,
-      hasIconOnly &&
-        !hideTooltip &&
-        !usePortal &&
-        tooltipHidden &&
-        "bx--tooltip--hidden",
+      hasTooltip && tooltipHidden && "bx--tooltip--hidden",
       hasIconOnly && isSelected && kind === "ghost" && "bx--btn--selected",
       $$restProps.class,
     ]
@@ -361,6 +360,7 @@
         bind:this={ref}
         {...buttonProps}
         on:click
+        on:mousedown
         on:focus
         on:focus={handlePortalFocus}
         on:blur
@@ -373,7 +373,7 @@
         on:mouseleave={handleMouseLeave}
         on:mouseleave={handlePortalMouseLeave}
       >
-        {#if hasIconOnly}
+        {#if hasIconOnly && iconDescription}
           <span class:bx--assistive-text={true} style:pointer-events="none">
             {iconDescription}
           </span>
@@ -402,6 +402,7 @@
       bind:this={ref}
       {...buttonProps}
       on:click
+      on:mousedown
       on:focus
       on:focus={handlePortalFocus}
       on:blur
@@ -414,7 +415,7 @@
       on:mouseleave={handleMouseLeave}
       on:mouseleave={handlePortalMouseLeave}
     >
-      {#if hasIconOnly}
+      {#if hasIconOnly && iconDescription}
         <span class:bx--assistive-text={true} style:pointer-events="none">
           {iconDescription}
         </span>
@@ -442,6 +443,7 @@
       bind:this={ref}
       {...buttonProps}
       on:click
+      on:mousedown
       on:focus
       on:focus={handlePortalFocus}
       on:blur
@@ -454,7 +456,7 @@
       on:mouseleave={handleMouseLeave}
       on:mouseleave={handlePortalMouseLeave}
     >
-      {#if hasIconOnly}
+      {#if hasIconOnly && iconDescription}
         <span class:bx--assistive-text={true} style:pointer-events="none">
           {iconDescription}
         </span>
@@ -482,6 +484,7 @@
     bind:this={ref}
     {...buttonProps}
     on:click
+    on:mousedown
     on:focus
     on:focus={handlePortalFocus}
     on:blur
@@ -494,7 +497,7 @@
     on:mouseleave={handleMouseLeave}
     on:mouseleave={handlePortalMouseLeave}
   >
-    {#if hasIconOnly}
+    {#if hasIconOnly && iconDescription}
       <span class:bx--assistive-text={true} style:pointer-events="none">
         {iconDescription}
       </span>

--- a/src/ComboButton/ComboButton.svelte
+++ b/src/ComboButton/ComboButton.svelte
@@ -1,0 +1,157 @@
+<script>
+  /**
+   * @event {MouseEvent} click
+   */
+
+  /**
+   * @event close
+   * @type {object}
+   * @property {"escape-key" | "outside-click" | "select"} trigger
+   */
+
+  /**
+   * @restProps {div}
+   * @slot {{}}
+   * @slot {{}} labelChildren - Custom content for the primary action button. `labelText` remains the accessible name.
+   */
+
+  /**
+   * Required. Specify the primary action button text.
+   * Alternatively, use the "labelChildren" slot for custom button content;
+   * `labelText` is still used as the accessible name in that case.
+   * @type {string}
+   */
+  export let labelText;
+
+  /** Set to `true` to disable both the primary action and trigger buttons. */
+  export let disabled = false;
+
+  /**
+   * Specify the size of both buttons and the menu row height.
+   * @type {"xs" | "sm" | "md" | "lg"}
+   */
+  export let size = "md";
+
+  /**
+   * Set the preferred direction the menu opens toward.
+   * The menu flips to the opposite direction if there is not enough space.
+   * @type {"top" | "bottom"}
+   */
+  export let direction = "bottom";
+
+  /**
+   * Align the menu to the trigger button's intrinsic width.
+   * @type {"start" | "center" | "end"}
+   */
+  export let intrinsicAlign = "end";
+
+  /**
+   * Set to `true` to open the menu.
+   * @bindable writable
+   */
+  export let open = false;
+
+  /**
+   * Specify the accessible label for the icon-only trigger button.
+   * Set to an empty string to render the trigger without a tooltip, the
+   * same way `Button` handles an empty `iconDescription` - the trigger then
+   * has no accessible name of its own, so only do this when something else
+   * in the surrounding context labels it.
+   */
+  export let iconDescription = "Additional actions";
+
+  /**
+   * Set the position of the icon-only trigger's tooltip.
+   * Independent of `direction`, which controls where the menu opens.
+   * @type {"top" | "right" | "bottom" | "left"}
+   */
+  export let tooltipPosition = "bottom";
+
+  /**
+   * Obtain a reference to the outer HTML element.
+   * @bindable readonly
+   */
+  export let ref = null;
+
+  import Button from "../Button/Button.svelte";
+  import ChevronDown from "../icons/ChevronDown.svelte";
+  import Menu from "../Menu/Menu.svelte";
+
+  /**
+   * Button's own "default"/"lg" naming is offset from the v11 size scale:
+   * unclassed "default" renders at 48px (v11 "lg"), while Button's "lg"
+   * class renders at 64px with baseline-aligned text (v11's "xl"/"2xl"
+   * tier). Remap so ComboButton never touches Button's "lg"/"xl" classes.
+   * "xs" has no Button equivalent; combo-button.scss shrinks it further.
+   */
+  const TRIGGER_BUTTON_SIZES = {
+    xs: "small",
+    sm: "small",
+    md: "field",
+    lg: "default",
+  };
+
+  let triggerRef = null;
+
+  /**
+   * @type {(event: MouseEvent) => void}
+   */
+  function toggleOpen(event) {
+    const wasOpen = open;
+    open = !open;
+    // A keyboard-activated click (Enter/Space) reports detail 0; a real mouse
+    // click reports 1+. Blur only after a mouse-driven close, so the trigger
+    // doesn't linger with a visible focus ring and pop its own tooltip -
+    // keyboard users still see focus stay put, as they should.
+    if (wasOpen && event.detail !== 0) {
+      triggerRef?.blur();
+    }
+  }
+</script>
+
+<div
+  bind:this={ref}
+  class:bx--combo-button={true}
+  class:bx--combo-button--xs={size === "xs"}
+  {...$$restProps}
+>
+  <Button
+    kind="primary"
+    size={TRIGGER_BUTTON_SIZES[size]}
+    {disabled}
+    class="bx--combo-button__primary-action"
+    aria-label={$$restProps["aria-label"] ?? labelText}
+    on:click
+  >
+    <slot name="labelChildren">{labelText}</slot>
+  </Button>
+  <Button
+    bind:ref={triggerRef}
+    icon={ChevronDown}
+    {iconDescription}
+    kind="primary"
+    size={TRIGGER_BUTTON_SIZES[size]}
+    {disabled}
+    hideTooltip={open}
+    {tooltipPosition}
+    class="bx--combo-button__trigger {open
+      ? 'bx--combo-button__trigger--open'
+      : ''}"
+    aria-haspopup="menu"
+    aria-expanded={open}
+    on:mousedown={(event) => event.preventDefault()}
+    on:click={toggleOpen}
+  />
+  <Menu
+    anchor={triggerRef}
+    bind:open
+    {direction}
+    {intrinsicAlign}
+    intrinsicWidth={true}
+    {size}
+    {labelText}
+    on:close
+  >
+    <slot />
+  </Menu>
+</div>

--- a/src/ComboButton/index.js
+++ b/src/ComboButton/index.js
@@ -1,0 +1,1 @@
+export { default as ComboButton } from "./ComboButton.svelte";

--- a/src/Menu/Menu.svelte
+++ b/src/Menu/Menu.svelte
@@ -65,7 +65,8 @@
 
   /**
    * Specify the size of the menu, which controls each item's row height.
-   * @type {"sm" | "md" | "lg"}
+   * `"xs"` has no Carbon v10 equivalent and is hand-authored (see `css/_menu-xs.scss`).
+   * @type {"xs" | "sm" | "md" | "lg"}
    */
   export let size = "sm";
 
@@ -193,6 +194,7 @@
     style:left="auto"
     class:bx--menu={true}
     class:bx--menu--open={open}
+    class:bx--menu--xs={size === "xs"}
     class:bx--menu--md={size === "md"}
     class:bx--menu--lg={size === "lg"}
     {...$$restProps}

--- a/src/MenuButton/MenuButton.svelte
+++ b/src/MenuButton/MenuButton.svelte
@@ -25,7 +25,7 @@
 
   /**
    * Specify the size of the trigger button and the menu's row height.
-   * @type {"sm" | "md" | "lg"}
+   * @type {"xs" | "sm" | "md" | "lg"}
    */
   export let size = "md";
 
@@ -62,19 +62,42 @@
   import ChevronDown from "../icons/ChevronDown.svelte";
   import Menu from "../Menu/Menu.svelte";
 
-  /** Button has no "xs" size and no "md"/"sm" names; remap to its closest matching row heights. */
-  const TRIGGER_BUTTON_SIZES = { sm: "small", md: "default", lg: "lg" };
+  /**
+   * Button's own "default"/"lg" naming is offset from the v11 size scale:
+   * unclassed "default" renders at 48px (v11 "lg"), while Button's "lg"
+   * class renders at 64px with baseline-aligned text (v11's "xl"/"2xl"
+   * tier). Remap so MenuButton never touches Button's "lg"/"xl" classes.
+   * "xs" has no Button equivalent; menu-button.scss shrinks it further.
+   */
+  const TRIGGER_BUTTON_SIZES = {
+    xs: "small",
+    sm: "small",
+    md: "field",
+    lg: "default",
+  };
 
   $: triggerClass = [
     "bx--menu-button__trigger",
+    size === "xs" && "bx--menu-button__trigger--xs",
     open && "bx--menu-button__trigger--open",
     $$restProps.class,
   ]
     .filter(Boolean)
     .join(" ");
 
-  function toggle() {
+  /**
+   * @type {(event: MouseEvent) => void}
+   */
+  function toggle(event) {
+    const wasOpen = open;
     open = !open;
+    // A keyboard-activated click (Enter/Space) reports detail 0; a real mouse
+    // click reports 1+. Blur only after a mouse-driven close, so the trigger
+    // doesn't linger with a visible focus ring - keyboard users still see
+    // focus stay put, as they should.
+    if (wasOpen && event.detail !== 0) {
+      ref?.blur();
+    }
   }
 </script>
 
@@ -89,6 +112,7 @@
   aria-haspopup="menu"
   aria-expanded={open}
   aria-label={$$restProps["aria-label"] ?? labelText}
+  on:mousedown={(event) => event.preventDefault()}
   on:click
   on:click={toggle}
 >

--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,7 @@ export { default as CodeSnippet } from "./CodeSnippet/CodeSnippet.svelte";
 export { default as CodeSnippetSkeleton } from "./CodeSnippet/CodeSnippetSkeleton.svelte";
 export { default as ComboBox } from "./ComboBox/ComboBox.svelte";
 export { default as FluidComboBoxSkeleton } from "./ComboBox/FluidComboBoxSkeleton.svelte";
+export { default as ComboButton } from "./ComboButton/ComboButton.svelte";
 export { default as ComposedModal } from "./ComposedModal/ComposedModal.svelte";
 export { default as ModalBody } from "./ComposedModal/ModalBody.svelte";
 export { default as ModalFooter } from "./ComposedModal/ModalFooter.svelte";

--- a/tests/Button/Button.test.svelte
+++ b/tests/Button/Button.test.svelte
@@ -38,6 +38,12 @@
   iconDescription="Portal tooltip text"
 />
 
+<Button
+  data-testid="btn-icon-no-description"
+  icon={Add}
+  aria-label="Custom accessible name"
+/>
+
 <Button href="#">Link button</Button>
 
 <Button href="https://example.com" target="_blank">External link</Button>

--- a/tests/Button/Button.test.ts
+++ b/tests/Button/Button.test.ts
@@ -206,6 +206,26 @@ describe("Button", () => {
     expect(assistiveText).toHaveTextContent("Add item");
   });
 
+  it("should render an icon-only button with no tooltip when iconDescription is omitted", () => {
+    render(Button);
+
+    const button = screen.getByTestId("btn-icon-no-description");
+    expect(button).toHaveClass("bx--btn--icon-only");
+
+    // No tooltip apparatus without a description to show or announce.
+    expect(button).not.toHaveClass("bx--tooltip__trigger");
+    expect(button).not.toHaveClass("bx--tooltip--a11y");
+    expect(button).not.toHaveClass("bx--btn--icon-only--bottom");
+    expect(button).not.toHaveClass("bx--tooltip--align-center");
+    expect(button.querySelector(".bx--assistive-text")).not.toBeInTheDocument();
+
+    // Still accessible via a consumer-supplied aria-label.
+    expect(button).toHaveAttribute("aria-label", "Custom accessible name");
+    expect(screen.getByRole("button", { name: "Custom accessible name" })).toBe(
+      button,
+    );
+  });
+
   describe("portalTooltip", () => {
     beforeEach(() => {
       vi.useFakeTimers();

--- a/tests/ComboButton/ComboButton.slot.test.svelte
+++ b/tests/ComboButton/ComboButton.slot.test.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+  import ComboButton from "carbon-components-svelte/ComboButton/ComboButton.svelte";
+  import MenuItem from "carbon-components-svelte/Menu/MenuItem.svelte";
+</script>
+
+<ComboButton labelText="Save">
+  <svelte:fragment slot="labelChildren">
+    <strong>Custom label content</strong>
+  </svelte:fragment>
+  <MenuItem>Save as</MenuItem>
+</ComboButton>

--- a/tests/ComboButton/ComboButton.test.svelte
+++ b/tests/ComboButton/ComboButton.test.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+  import ComboButton from "carbon-components-svelte/ComboButton/ComboButton.svelte";
+  import MenuItem from "carbon-components-svelte/Menu/MenuItem.svelte";
+  import type { ComponentProps } from "svelte";
+
+  export let disabled: ComponentProps<ComboButton>["disabled"] = false;
+  export let size: ComponentProps<ComboButton>["size"] = undefined;
+  export let direction: ComponentProps<ComboButton>["direction"] = undefined;
+  export let tooltipPosition: ComponentProps<ComboButton>["tooltipPosition"] =
+    undefined;
+  export let iconDescription: ComponentProps<ComboButton>["iconDescription"] =
+    undefined;
+
+  export let open = false;
+
+  const items = ["Save as", "Save a copy"];
+</script>
+
+<ComboButton
+  labelText="Save"
+  {disabled}
+  {size}
+  {direction}
+  {tooltipPosition}
+  {iconDescription}
+  bind:open
+  on:click={() => console.log("click")}
+  on:close={(e) => console.log("close", e.detail)}
+>
+  {#each items as text}
+    <MenuItem on:click={() => console.log("select", text)}>{text}</MenuItem>
+  {/each}
+</ComboButton>

--- a/tests/ComboButton/ComboButton.test.ts
+++ b/tests/ComboButton/ComboButton.test.ts
@@ -1,0 +1,216 @@
+import { fireEvent, render, screen } from "@testing-library/svelte";
+import { user } from "../utils/user";
+import ComboButtonSlot from "./ComboButton.slot.test.svelte";
+import ComboButtonFixture from "./ComboButton.test.svelte";
+
+describe("ComboButton", () => {
+  it("fires the primary action click independently of the menu trigger", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(ComboButtonFixture);
+
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(consoleLog).toHaveBeenCalledWith("click");
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+  });
+
+  it("opens and closes the menu from the icon-only trigger", async () => {
+    render(ComboButtonFixture);
+
+    const trigger = screen.getByRole("button", { name: "Additional actions" });
+    expect(trigger).toHaveAttribute("aria-haspopup", "menu");
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+
+    await user.click(trigger);
+
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+    expect(screen.getAllByRole("menuitem")).toHaveLength(2);
+
+    await user.click(trigger);
+
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+  });
+
+  it("opens and focuses the first item from the trigger", async () => {
+    render(ComboButtonFixture);
+
+    await user.click(
+      screen.getByRole("button", { name: "Additional actions" }),
+    );
+
+    expect(screen.getByRole("menuitem", { name: "Save as" })).toHaveFocus();
+  });
+
+  it("dispatches close and forwards the trigger reason when an item is selected", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(ComboButtonFixture);
+
+    await user.click(
+      screen.getByRole("button", { name: "Additional actions" }),
+    );
+    await user.click(screen.getByRole("menuitem", { name: "Save as" }));
+
+    expect(consoleLog).toHaveBeenCalledWith("select", "Save as");
+    expect(consoleLog).toHaveBeenCalledWith("close", { trigger: "select" });
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+  });
+
+  it("disables both the primary action and trigger buttons", () => {
+    render(ComboButtonFixture, { props: { disabled: true } });
+
+    expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: "Additional actions" }),
+    ).toBeDisabled();
+  });
+
+  it.each([
+    { size: "xs", buttonClass: "bx--btn--sm", menuClass: "bx--menu--xs" },
+    { size: "sm", buttonClass: "bx--btn--sm", menuClass: undefined },
+    { size: "md", buttonClass: "bx--btn--field", menuClass: "bx--menu--md" },
+    { size: "lg", buttonClass: undefined, menuClass: "bx--menu--lg" },
+  ] as const)("propagates size $size to both buttons and the menu row height", async ({
+    size,
+    buttonClass,
+    menuClass,
+  }) => {
+    render(ComboButtonFixture, { props: { size } });
+
+    const primaryAction = screen.getByRole("button", { name: "Save" });
+    const trigger = screen.getByRole("button", {
+      name: "Additional actions",
+    });
+
+    for (const unwanted of [
+      "bx--btn--sm",
+      "bx--btn--field",
+      "bx--btn--lg",
+      "bx--btn--xl",
+    ]) {
+      if (unwanted !== buttonClass) {
+        expect(primaryAction).not.toHaveClass(unwanted);
+        expect(trigger).not.toHaveClass(unwanted);
+      }
+    }
+    if (buttonClass) {
+      expect(primaryAction).toHaveClass(buttonClass);
+      expect(trigger).toHaveClass(buttonClass);
+    }
+
+    await user.click(trigger);
+
+    const menu = screen.getByRole("menu");
+    for (const unwanted of ["bx--menu--xs", "bx--menu--md", "bx--menu--lg"]) {
+      if (unwanted !== menuClass) expect(menu).not.toHaveClass(unwanted);
+    }
+    if (menuClass) expect(menu).toHaveClass(menuClass);
+  });
+
+  it("keeps both buttons the same height at every size (no Button `lg`/`xl` baseline misalignment)", () => {
+    render(ComboButtonFixture, { props: { size: "lg" } });
+
+    const primaryAction = screen.getByRole("button", { name: "Save" });
+    const trigger = screen.getByRole("button", { name: "Additional actions" });
+
+    // Button's own "lg"/"xl" classes render at 64px/80px for labeled buttons
+    // but are ignored for icon-only buttons, and apply baseline (not center)
+    // alignment - ComboButton must never reach for them.
+    expect(primaryAction).not.toHaveClass("bx--btn--lg");
+    expect(trigger).not.toHaveClass("bx--btn--lg");
+  });
+
+  it("defaults to the md size", async () => {
+    render(ComboButtonFixture);
+
+    expect(screen.getByRole("button", { name: "Save" })).toHaveClass(
+      "bx--btn--field",
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: "Additional actions" }),
+    );
+
+    expect(screen.getByRole("menu")).toHaveClass("bx--menu--md");
+  });
+
+  it("hides the trigger tooltip once the menu is open", async () => {
+    render(ComboButtonFixture);
+
+    const trigger = screen.getByRole("button", { name: "Additional actions" });
+    expect(trigger).toHaveClass("bx--tooltip__trigger");
+
+    await user.click(trigger);
+
+    expect(trigger).not.toHaveClass("bx--tooltip__trigger");
+  });
+
+  it("renders the labelChildren slot instead of labelText, using labelText as the accessible name", () => {
+    render(ComboButtonSlot);
+
+    expect(screen.getByText("Custom label content")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
+  });
+
+  it("renders the trigger without a tooltip when iconDescription is an empty string", () => {
+    render(ComboButtonFixture, { props: { iconDescription: "" } });
+
+    const [, trigger] = screen.getAllByRole("button");
+    expect(trigger).toHaveClass("bx--btn--icon-only");
+    expect(trigger).not.toHaveClass("bx--tooltip__trigger");
+    expect(trigger).not.toHaveClass("bx--tooltip--a11y");
+    expect(
+      trigger.querySelector(".bx--assistive-text"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("keeps the tooltip position independent of the menu direction", () => {
+    render(ComboButtonFixture, {
+      props: { direction: "top", tooltipPosition: "right" },
+    });
+
+    const trigger = screen.getByRole("button", { name: "Additional actions" });
+    expect(trigger).toHaveClass("bx--btn--icon-only--right");
+    expect(trigger).not.toHaveClass("bx--btn--icon-only--top");
+  });
+
+  it("never focuses the trigger via a real mouse click, only via keyboard", async () => {
+    render(ComboButtonFixture);
+
+    const trigger = screen.getByRole("button", { name: "Additional actions" });
+
+    // Open: mousedown's default focus behavior is suppressed, so focus goes
+    // straight to the first menu item instead of landing on the trigger.
+    await user.click(trigger);
+    expect(trigger).not.toHaveFocus();
+
+    // Close: same story - the trigger was never focused, so there's nothing
+    // to show a lingering focus ring.
+    await user.click(trigger);
+    expect(trigger).not.toHaveFocus();
+
+    // Keyboard users still get normal focus via Tab.
+    await user.tab();
+    await user.tab();
+    expect(trigger).toHaveFocus();
+  });
+
+  it("blurs the trigger after a mouse-driven close, but not a keyboard-driven one", async () => {
+    // A real click reports event.detail 1+; a keyboard-activated (Enter/
+    // Space) one reports 0. Start each case already open so the closing
+    // click is what's under test, independent of how it was opened.
+    const { unmount } = render(ComboButtonFixture, { props: { open: true } });
+    let trigger = screen.getByRole("button", { name: "Additional actions" });
+    trigger.focus();
+    await fireEvent.click(trigger, { detail: 1 });
+    expect(trigger).not.toHaveFocus();
+    unmount();
+
+    render(ComboButtonFixture, { props: { open: true } });
+    trigger = screen.getByRole("button", { name: "Additional actions" });
+    trigger.focus();
+    await fireEvent.click(trigger, { detail: 0 });
+    expect(trigger).toHaveFocus();
+  });
+});

--- a/tests/Menu/Menu.test.ts
+++ b/tests/Menu/Menu.test.ts
@@ -48,8 +48,17 @@ describe("Menu", () => {
     await user.click(screen.getByRole("button", { name: "Trigger" }));
 
     const menu = screen.getByRole("menu");
+    expect(menu).not.toHaveClass("bx--menu--xs");
     expect(menu).not.toHaveClass("bx--menu--md");
     expect(menu).not.toHaveClass("bx--menu--lg");
+  });
+
+  it("applies the xs size modifier class", async () => {
+    render(MenuFixture, { props: { size: "xs" } });
+
+    await user.click(screen.getByRole("button", { name: "Trigger" }));
+
+    expect(screen.getByRole("menu")).toHaveClass("bx--menu--xs");
   });
 
   it("applies the size modifier class", async () => {

--- a/tests/MenuButton/MenuButton.test.ts
+++ b/tests/MenuButton/MenuButton.test.ts
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/svelte";
+import { fireEvent, render, screen } from "@testing-library/svelte";
 import { user } from "../utils/user";
 import MenuButtonSlot from "./MenuButton.slot.test.svelte";
 import MenuButtonFixture from "./MenuButton.test.svelte";
@@ -25,12 +25,53 @@ describe("MenuButton", () => {
     expect(screen.getByRole("button", { name: "Actions" })).toBeDisabled();
   });
 
-  it("applies the kind and size classes to the trigger", () => {
-    render(MenuButtonFixture, { props: { kind: "ghost", size: "lg" } });
+  it("applies the kind class to the trigger", () => {
+    render(MenuButtonFixture, { props: { kind: "ghost" } });
+
+    expect(screen.getByRole("button", { name: "Actions" })).toHaveClass(
+      "bx--btn--ghost",
+    );
+  });
+
+  it.each([
+    { size: "xs", buttonClass: "bx--btn--sm", menuClass: "bx--menu--xs" },
+    { size: "sm", buttonClass: "bx--btn--sm", menuClass: undefined },
+    { size: "md", buttonClass: "bx--btn--field", menuClass: "bx--menu--md" },
+    { size: "lg", buttonClass: undefined, menuClass: "bx--menu--lg" },
+  ] as const)("propagates size $size to the trigger and the menu row height", async ({
+    size,
+    buttonClass,
+    menuClass,
+  }) => {
+    render(MenuButtonFixture, { props: { size } });
 
     const trigger = screen.getByRole("button", { name: "Actions" });
-    expect(trigger).toHaveClass("bx--btn--ghost");
-    expect(trigger).toHaveClass("bx--btn--lg");
+
+    for (const unwanted of [
+      "bx--btn--sm",
+      "bx--btn--field",
+      "bx--btn--lg",
+      "bx--btn--xl",
+    ]) {
+      if (unwanted !== buttonClass) expect(trigger).not.toHaveClass(unwanted);
+    }
+    if (buttonClass) expect(trigger).toHaveClass(buttonClass);
+
+    await user.click(trigger);
+
+    const menu = screen.getByRole("menu");
+    for (const unwanted of ["bx--menu--xs", "bx--menu--md", "bx--menu--lg"]) {
+      if (unwanted !== menuClass) expect(menu).not.toHaveClass(unwanted);
+    }
+    if (menuClass) expect(menu).toHaveClass(menuClass);
+  });
+
+  it("keeps the trigger off Button's baseline-aligned `lg`/`xl` classes", () => {
+    render(MenuButtonFixture, { props: { size: "lg" } });
+
+    expect(screen.getByRole("button", { name: "Actions" })).not.toHaveClass(
+      "bx--btn--lg",
+    );
   });
 
   it("rotates the trigger's chevron by toggling the open modifier class", async () => {
@@ -100,5 +141,38 @@ describe("MenuButton", () => {
 
     expect(screen.getByText("Custom trigger content")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Actions" })).toBeInTheDocument();
+  });
+
+  it("never focuses the trigger via a real mouse click, only via keyboard", async () => {
+    render(MenuButtonFixture);
+
+    const trigger = screen.getByRole("button", { name: "Actions" });
+
+    await user.click(trigger);
+    expect(trigger).not.toHaveFocus();
+
+    await user.click(trigger);
+    expect(trigger).not.toHaveFocus();
+
+    await user.tab();
+    expect(trigger).toHaveFocus();
+  });
+
+  it("blurs the trigger after a mouse-driven close, but not a keyboard-driven one", async () => {
+    // A real click reports event.detail 1+; a keyboard-activated (Enter/
+    // Space) one reports 0. Start each case already open so the closing
+    // click is what's under test, independent of how it was opened.
+    const { unmount } = render(MenuButtonFixture, { props: { open: true } });
+    let trigger = screen.getByRole("button", { name: "Actions" });
+    trigger.focus();
+    await fireEvent.click(trigger, { detail: 1 });
+    expect(trigger).not.toHaveFocus();
+    unmount();
+
+    render(MenuButtonFixture, { props: { open: true } });
+    trigger = screen.getByRole("button", { name: "Actions" });
+    trigger.focus();
+    await fireEvent.click(trigger, { detail: 0 });
+    expect(trigger).toHaveFocus();
   });
 });


### PR DESCRIPTION
Closes #2488.

Adds ComboButton, pairing a primary action button with an icon-only trigger that opens a Menu of secondary actions, composed from the existing Button and Menu/MenuItem primitives. Along the way it fixes a size-mapping bug and a mouse-click focus-ring flash shared with MenuButton, and teaches Button to skip its tooltip cleanly when iconDescription is empty. 

---
<img width="1280" height="450" alt="button-icon-only-no-description" src="https://github.com/user-attachments/assets/83bee0f7-8bc1-4c01-88e2-46e06e762897" />
<img width="1280" height="10778" alt="combo-button" src="https://github.com/user-attachments/assets/3809568a-137e-4bc8-a6ba-4d3244a9cf33" />
<img width="720" height="380" alt="menu-button-disabled-item" src="https://github.com/user-attachments/assets/223b92d7-b3e3-49d8-9490-41d07e6a58d6" />
<img width="720" height="380" alt="menu-button-xs" src="https://github.com/user-attachments/assets/96228b53-b8aa-4c48-a561-0ca8ddec053f" />
