### PR TITLE
ContextMenu: position via FloatingPortal and share Menu primitives

### DIFF
--- a/src/ContextMenu/ContextMenu.svelte
+++ b/src/ContextMenu/ContextMenu.svelte
@@ -49,6 +49,32 @@
    */
   export let labelText = undefined;
 
+  /**
+   * Specify the size of the menu, which controls each item's row height.
+   * @type {"xs" | "sm" | "md" | "lg"}
+   */
+  export let size = "sm";
+
+  /**
+   * Specify the z-index of the menu.
+   */
+  export let zIndex = 9200;
+
+  /**
+   * Anchor to a real element instead of the `x`/`y` point - used internally
+   * by `ContextMenuOption` for nested submenus, which (like a `MenuItem`
+   * submenu) should open relative to their trigger `<li>`, not a click point.
+   * @type {null | HTMLElement}
+   */
+  export let anchor = null;
+
+  /**
+   * Preferred direction to open in. The root, click-triggered menu opens
+   * `"bottom"`; a `ContextMenuOption` submenu opens `"right"`.
+   * @type {"bottom" | "top" | "left" | "right"}
+   */
+  export let direction = "bottom";
+
   import {
     afterUpdate,
     createEventDispatcher,
@@ -57,28 +83,28 @@
     setContext,
   } from "svelte";
   import { writable } from "svelte/store";
+  import FloatingPortal from "../Portal/FloatingPortal.svelte";
   import { dismiss } from "../utils/dismiss.js";
   import { isOutsideClick } from "../utils/isOutsideClick.js";
   import { rovingFocus } from "../utils/rovingFocus.js";
 
   const dispatch = createEventDispatcher();
   /**
-   * @type {import("svelte/store").Writable<[number, number]>}
-   */
-  const position = writable([x, y]);
-  /**
    * @type {import("svelte/store").Writable<number>}
    */
   const currentIndex = writable(-1);
   const hasPopup = writable(false);
-  /**
-   * @type {import("svelte/store").Writable<number>}
-   */
-  const menuOffsetX = writable(0);
   const ctx = getContext("carbon:ContextMenu");
 
+  /** Real, zero-size, in-document element positioned at (x, y) - lets
+   * FloatingPortal anchor to an arbitrary point instead of a real trigger
+   * element, when `anchor` isn't given. FloatingPortal watches the anchor's
+   * `style` attribute via MutationObserver, so updating x/y while open
+   * repositions the menu. */
+  let pointAnchor;
+  $: effectiveAnchor = anchor ?? pointAnchor;
+
   let options = [];
-  let direction = 1;
   let prevX = 0;
   let prevY = 0;
   let prevOpen = false;
@@ -102,26 +128,8 @@
   /** @type {(e: MouseEvent) => void} */
   function openMenu(event) {
     event.preventDefault();
-    const { height, width } = ref.getBoundingClientRect();
-
-    if (open || x === 0) {
-      if (window.innerWidth - width < event.x) {
-        x = event.x - width;
-      } else {
-        x = event.x;
-      }
-    }
-
-    if (open || y === 0) {
-      menuOffsetX.set(event.x);
-
-      if (window.innerHeight - height < event.y) {
-        y = event.y - height;
-      } else {
-        y = event.y;
-      }
-    }
-    position.set([x, y]);
+    x = event.x;
+    y = event.y;
     open = true;
     openDetail = event.target;
   }
@@ -156,15 +164,13 @@
   }
 
   setContext("carbon:ContextMenu", {
-    menuOffsetX,
     currentIndex,
-    position,
     close,
     setPopup,
   });
 
   afterUpdate(() => {
-    if (open) {
+    if (open && ref) {
       options = [...ref.querySelectorAll("li[data-nested='false']")];
 
       if (level === 1) {
@@ -185,7 +191,7 @@
   $: menuAriaLabel = ($$props["aria-label"] ?? labelText) || undefined;
 
   function handleOutsideClick(event) {
-    if (open && isOutsideClick(event, ref)) close("outside-click");
+    if (open && ref && isOutsideClick(event, ref)) close("outside-click");
   }
   function handleEscape(event) {
     if (open && event.key === "Escape") close("escape-key");
@@ -196,55 +202,81 @@
   on:contextmenu={(event) => {
     if (target != null) return;
     if (level > 1) return;
-    if (!ref) return;
     openMenu(event);
   }}
 />
 
-<!-- svelte-ignore a11y-no-noninteractive-element-to-interactive-role -->
-<ul
-  bind:this={ref}
-  use:rovingFocus={{
-    selector: "li[data-nested='false']",
-    orientation: "vertical",
-    wrap: false,
-    getActiveIndex: () => focusIndex,
-    onMove: (index) => {
-      if ($hasPopup) return;
-      focusIndex = index;
-    },
-  }}
-  use:dismiss={{
-    enabled: open,
-    listeners: [
-      { type: "click", handler: handleOutsideClick },
-      { type: "keydown", handler: handleEscape },
-    ],
-  }}
-  role="menu"
-  tabindex="-1"
-  data-direction={direction}
-  data-level={level}
-  class:bx--menu={true}
-  class:bx--menu--open={open}
-  class:bx--menu--invisible={open && x === 0 && y === 0}
-  class:bx--menu--root={level === 1}
-  style:left="{x}px"
+<div
+  bind:this={pointAnchor}
+  data-context-menu-point-anchor
+  aria-hidden="true"
+  style:position="fixed"
   style:top="{y}px"
-  {...$$restProps}
-  aria-label={menuAriaLabel}
-  on:click
-  on:click={(event) => {
-    const closestOption = event.target.closest("[tabindex]");
+  style:left="{x}px"
+  style:width="0"
+  style:height="0"
+  style:pointer-events="none"
+></div>
 
-    if (closestOption && closestOption.getAttribute("role") !== "menuitem") {
-      close("select");
-    }
-  }}
-  on:keydown
-  on:keydown={(event) => {
-    if (open) event.preventDefault();
-  }}
+<FloatingPortal
+  anchor={effectiveAnchor}
+  {direction}
+  {open}
+  intrinsicWidth
+  intrinsicAlign="start"
+  {zIndex}
+  let:direction={portalDirection}
 >
-  <slot />
-</ul>
+  <!-- svelte-ignore a11y-no-noninteractive-element-to-interactive-role -->
+  <ul
+    bind:this={ref}
+    use:rovingFocus={{
+      selector: "li[data-nested='false']",
+      orientation: "vertical",
+      wrap: false,
+      getActiveIndex: () => focusIndex,
+      onMove: (index) => {
+        if ($hasPopup) return;
+        focusIndex = index;
+      },
+    }}
+    use:dismiss={{
+      enabled: open,
+      listeners: [
+        { type: "click", handler: handleOutsideClick },
+        { type: "keydown", handler: handleEscape },
+      ],
+    }}
+    role="menu"
+    tabindex="-1"
+    data-direction={portalDirection}
+    data-level={level}
+    style:position="relative"
+    style:top="auto"
+    style:left="auto"
+    class:bx--menu={true}
+    class:bx--menu--open={open}
+    class:bx--menu--root={level === 1}
+    class:bx--menu--xs={size === "xs"}
+    class:bx--menu--md={size === "md"}
+    class:bx--menu--lg={size === "lg"}
+    {...$$restProps}
+    aria-label={menuAriaLabel}
+    on:click
+    on:click={(event) => {
+      const closestOption = event.target.closest("[tabindex]");
+
+      if (closestOption && closestOption.getAttribute("role") !== "menuitem") {
+        close("select");
+      }
+    }}
+    on:keydown
+    on:keydown={(event) => {
+      if (open) event.preventDefault();
+    }}
+    on:mouseenter
+    on:mouseleave
+  >
+    <slot />
+  </ul>
+</FloatingPortal>

--- a/src/ContextMenu/ContextMenuOption.svelte
+++ b/src/ContextMenu/ContextMenuOption.svelte
@@ -84,6 +84,7 @@
   import Checkmark from "../icons/Checkmark.svelte";
   import { clampIndex } from "../utils/clampIndex.js";
   import { dismiss } from "../utils/dismiss.js";
+  import { createSubmenuHoverController } from "../utils/submenuHoverController.js";
   import ContextMenu from "./ContextMenu.svelte";
 
   const dispatch = createEventDispatcher();
@@ -91,99 +92,23 @@
   const ctxGroup = getContext("carbon:ContextMenuGroup");
   const ctxRadioGroup = getContext("carbon:ContextMenuRadioGroup");
 
-  // "moderate-01" duration (ms) from Carbon motion recommended for small expansion, short distance movements
-  const moderate01 = 150;
-  const closeDelay = moderate01;
-
   let unsubCurrentIds = undefined;
   let unsubCurrentId = undefined;
-  let timeoutHover = undefined;
-  let timeoutClose = undefined;
-  let rootMenuPosition = [0, 0];
   let focusIndex = 0;
   let options = [];
   let role = "menuitem";
   let submenuOpen = false;
-  let submenuPosition = [0, 0];
-  let menuOffsetX = 0;
-  let mousePosition = { x: 0, y: 0 };
   /** @type {HTMLUListElement | null} */
   let submenuRef = null;
 
-  const unsubPosition = ctx.position.subscribe((position) => {
-    rootMenuPosition = position;
+  const hover = createSubmenuHoverController({
+    isDisabled: () => disabled,
+    setOpen: (open) => {
+      submenuOpen = open;
+    },
+    getTrigger: () => ref,
+    getSubmenu: () => submenuRef,
   });
-
-  const unsubMenuOffsetX = ctx.menuOffsetX.subscribe((_menuOffsetX) => {
-    menuOffsetX = _menuOffsetX;
-  });
-
-  function isPointInTriangle(px, py, x1, y1, x2, y2, x3, y3) {
-    const denominator = (y2 - y3) * (x1 - x3) + (x3 - x2) * (y1 - y3);
-    const a = ((y2 - y3) * (px - x3) + (x3 - x2) * (py - y3)) / denominator;
-    const b = ((y3 - y1) * (px - x3) + (x1 - x3) * (py - y3)) / denominator;
-    const c = 1 - a - b;
-
-    return a >= 0 && a <= 1 && b >= 0 && b <= 1 && c >= 0 && c <= 1;
-  }
-
-  // Utility function to check if mouse is in the
-  // safe triangle when transferring to the submenu.
-  function isInSafeTriangle(mouseX, mouseY) {
-    if (!submenuOpen || !ref || !submenuRef) return false;
-
-    const parentRect = ref.getBoundingClientRect();
-    const submenuRect = submenuRef.getBoundingClientRect();
-
-    // Magic number to make the triangle slightly larger
-    const buffer = 12;
-    const isSubmenuOnRight = submenuRect.left >= parentRect.right;
-
-    let trianglePoints;
-    if (isSubmenuOnRight) {
-      trianglePoints = {
-        x1: parentRect.right,
-        y1: parentRect.top - buffer,
-        x2: parentRect.right,
-        y2: parentRect.bottom + buffer,
-        x3: submenuRect.left,
-        y3: submenuRect.top + submenuRect.height / 2,
-      };
-    } else {
-      trianglePoints = {
-        x1: parentRect.left,
-        y1: parentRect.top - buffer,
-        x2: parentRect.left,
-        y2: parentRect.bottom + buffer,
-        x3: submenuRect.right,
-        y3: submenuRect.top + submenuRect.height / 2,
-      };
-    }
-
-    const inTopTriangle = isPointInTriangle(
-      mouseX,
-      mouseY,
-      trianglePoints.x1,
-      trianglePoints.y1,
-      isSubmenuOnRight ? trianglePoints.x3 : trianglePoints.x2,
-      submenuRect.top,
-      trianglePoints.x3,
-      trianglePoints.y3,
-    );
-
-    const inBottomTriangle = isPointInTriangle(
-      mouseX,
-      mouseY,
-      trianglePoints.x2,
-      trianglePoints.y2,
-      trianglePoints.x3,
-      trianglePoints.y3,
-      isSubmenuOnRight ? trianglePoints.x3 : trianglePoints.x1,
-      submenuRect.bottom,
-    );
-
-    return inTopTriangle || inBottomTriangle;
-  }
 
   function handleClick(event, opts = {}) {
     if (disabled) return;
@@ -210,15 +135,7 @@
 
   function handleGlobalMouseMove(event) {
     if (subOptions && submenuOpen) {
-      mousePosition = { x: event.clientX, y: event.clientY };
-
-      if (
-        isInSafeTriangle(event.clientX, event.clientY) &&
-        typeof timeoutClose === "number"
-      ) {
-        clearTimeout(timeoutClose);
-        timeoutClose = undefined;
-      }
+      hover.trackPointer(event.clientX, event.clientY);
     }
   }
 
@@ -238,12 +155,9 @@
     }
 
     return () => {
-      unsubPosition();
-      unsubMenuOffsetX();
       if (unsubCurrentIds) unsubCurrentIds();
       if (unsubCurrentId) unsubCurrentId();
-      if (typeof timeoutHover === "number") clearTimeout(timeoutHover);
-      if (typeof timeoutClose === "number") clearTimeout(timeoutClose);
+      hover.destroy();
     };
   });
 
@@ -251,23 +165,6 @@
   $: isRadio = !!ctxRadioGroup;
   $: subOptions = $$slots.default;
   $: ctx.setPopup(submenuOpen);
-  $: if (submenuOpen) {
-    const { width, y } = ref.getBoundingClientRect();
-    let x = rootMenuPosition[0] + width;
-
-    const submenuWidth = submenuRef?.getBoundingClientRect().width ?? width;
-
-    if (x + submenuWidth > window.innerWidth) {
-      x = rootMenuPosition[0] - submenuWidth;
-
-      // On narrow screens, position submenu at edge to avoid clipping.
-      if (x < 0) {
-        x = Math.max(0, window.innerWidth - submenuWidth);
-      }
-    }
-
-    submenuPosition = [x, y];
-  }
   $: {
     if (icon) {
       indented = true;
@@ -334,7 +231,7 @@
       (event.key === "ArrowRight" || event.key === " " || event.key === "Enter")
     ) {
       if (disabled) return;
-      submenuOpen = true;
+      hover.open();
       await tick();
       options = [...ref.querySelectorAll("li[tabindex]")];
       if (options[focusIndex]) options[focusIndex].focus();
@@ -370,39 +267,22 @@
   }}
   on:mouseenter
   on:mouseenter={() => {
-    if (subOptions && !disabled) {
-      if (typeof timeoutClose === "number") {
-        clearTimeout(timeoutClose);
-        timeoutClose = undefined;
-      }
-
-      timeoutHover = setTimeout(() => {
-        submenuOpen = true;
-      }, moderate01);
-    }
+    if (subOptions) hover.scheduleOpen();
   }}
   on:mousemove={(event) => {
     if (subOptions && submenuOpen) {
-      mousePosition = { x: event.clientX, y: event.clientY };
+      hover.trackPointer(event.clientX, event.clientY);
     }
   }}
   on:mouseleave
   on:mouseleave={() => {
-    if (subOptions) {
-      if (typeof timeoutHover === "number") clearTimeout(timeoutHover);
-
-      timeoutClose = setTimeout(() => {
-        if (!isInSafeTriangle(mousePosition.x, mousePosition.y)) {
-          submenuOpen = false;
-        }
-      }, closeDelay);
-    }
+    if (subOptions) hover.scheduleClose();
   }}
   on:click={(event) => {
     if (subOptions) {
       event.stopPropagation();
       if (disabled) return;
-      submenuOpen = true;
+      hover.open();
       return;
     }
     handleClick(event);
@@ -426,9 +306,11 @@
 
     <ContextMenu
       bind:ref={submenuRef}
+      anchor={ref}
+      direction="right"
       open={submenuOpen}
-      x={submenuPosition[0]}
-      y={submenuPosition[1]}
+      on:mouseenter={hover.cancelClose}
+      on:mouseleave={hover.scheduleClose}
     >
       <slot />
     </ContextMenu>

--- a/src/Portal/FloatingPortal.svelte
+++ b/src/Portal/FloatingPortal.svelte
@@ -219,12 +219,31 @@
   function updatePosition() {
     if (!mounted || !anchor || !ref) return;
 
+    // window.innerWidth/innerHeight can disagree with the document's actual
+    // rendered box in some hosting pages (observed with a carbon-components-
+    // svelte docs page, cause not fully isolated - some interaction between
+    // scrollbar accounting and the page's own CSS). Clamping to the smaller
+    // of the two avoids positioning content past the edge that's actually
+    // safe to render in, at no cost when they already agree. A zero rect
+    // (jsdom, or any environment that hasn't laid out the document) means
+    // this measurement isn't meaningful, so fall back to window.innerWidth/
+    // innerHeight unchanged rather than clamping everything to zero.
+    const docRect = document.documentElement.getBoundingClientRect();
+    const safeInnerWidth =
+      docRect.width > 0
+        ? Math.min(window.innerWidth, docRect.width)
+        : window.innerWidth;
+    const safeInnerHeight =
+      docRect.height > 0
+        ? Math.min(window.innerHeight, docRect.height)
+        : window.innerHeight;
+
     pos = floatingPosition({
       anchorRect: anchor.getBoundingClientRect(),
       floatingRect: ref.getBoundingClientRect(),
       viewport: {
-        innerWidth: window.innerWidth,
-        innerHeight: window.innerHeight,
+        innerWidth: safeInnerWidth,
+        innerHeight: safeInnerHeight,
         scrollX: window.scrollX,
         scrollY: window.scrollY,
       },

--- a/src/utils/floatingPosition.js
+++ b/src/utils/floatingPosition.js
@@ -6,7 +6,12 @@
 
 /**
  * Place a floating element next to an anchor. Caller passes both rects and the
- * viewport. Flips direction when the preferred side does not fit.
+ * viewport. Flips direction when the preferred side does not fit, then shifts
+ * (clamps) the box to stay within the viewport on the cross axis - there is
+ * no "other side" to flip to there, so this is a shift rather than a flip,
+ * same as Floating UI's `shift`. For `left`/`right`, the primary axis also
+ * gets a final clamp as a fallback for when content is too wide for either
+ * side to fully fit.
  *
  * @param {Object} options
  * @param {RectLike} options.anchorRect - The anchor's `getBoundingClientRect()`.
@@ -192,6 +197,55 @@ export function floatingPosition({
     // changes — no recompute, no bounce. The CSS applies it from the matching
     // edge per alignment.
     caretNudgePx = rect.width / 2;
+  }
+
+  if (actualDirection === "top" || actualDirection === "bottom") {
+    const finalWidth = posWidth ?? floatingRect.width;
+
+    // `posLeft` is the box's own left edge for `start` alignment (or when
+    // matching the anchor width), but for `center`/`end` it is an
+    // anchor-relative coordinate that FloatingPortal shifts into place with a
+    // CSS `translateX` — account for that offset to find the true rendered
+    // left edge before clamping it to the viewport.
+    let trueLeft = posLeft;
+    if (intrinsicWidth && intrinsicAlign === "center") {
+      trueLeft = posLeft - finalWidth / 2;
+    } else if (intrinsicWidth && intrinsicAlign === "end") {
+      trueLeft = posLeft - finalWidth;
+    }
+
+    const minLeft = scrollXOffset;
+    const maxLeft = scrollXOffset + viewport.innerWidth - finalWidth;
+    // Content wider than the viewport: prefer the left edge over the right.
+    const clampedTrueLeft =
+      maxLeft >= minLeft
+        ? Math.min(Math.max(trueLeft, minLeft), maxLeft)
+        : minLeft;
+
+    const delta = clampedTrueLeft - trueLeft;
+    if (delta !== 0) {
+      posLeft += delta;
+      // Keep the caret pointing at the (unmoved) anchor center after the
+      // box itself shifted to stay within the viewport.
+      if (caretNudgePx !== undefined) caretNudgePx -= delta;
+    }
+  } else {
+    // `left`/`right`: clamp both axes. `top` is the cross axis (mirrors the
+    // top/bottom case's horizontal shift; no CSS transform involved here, so
+    // no extra offset accounting is needed). `left` is the primary axis -
+    // the flip above already tries the preferred side, but if the content is
+    // too wide for either side to fully fit, this is a final fallback so it
+    // stays on-screen rather than overflowing whichever side it landed on.
+    const minTop = scrollYOffset;
+    const maxTop = scrollYOffset + viewport.innerHeight - floatingRect.height;
+    top = maxTop >= minTop ? Math.min(Math.max(top, minTop), maxTop) : minTop;
+
+    const minLeft = scrollXOffset;
+    const maxLeft = scrollXOffset + viewport.innerWidth - floatingRect.width;
+    posLeft =
+      maxLeft >= minLeft
+        ? Math.min(Math.max(posLeft, minLeft), maxLeft)
+        : minLeft;
   }
 
   return {

--- a/src/utils/isInSafeTriangle.js
+++ b/src/utils/isInSafeTriangle.js
@@ -1,0 +1,95 @@
+// @ts-check
+
+/**
+ * @param {number} px
+ * @param {number} py
+ * @param {number} x1
+ * @param {number} y1
+ * @param {number} x2
+ * @param {number} y2
+ * @param {number} x3
+ * @param {number} y3
+ * @returns {boolean}
+ */
+function isPointInTriangle(px, py, x1, y1, x2, y2, x3, y3) {
+  const denominator = (y2 - y3) * (x1 - x3) + (x3 - x2) * (y1 - y3);
+  const a = ((y2 - y3) * (px - x3) + (x3 - x2) * (py - y3)) / denominator;
+  const b = ((y3 - y1) * (px - x3) + (x1 - x3) * (py - y3)) / denominator;
+  const c = 1 - a - b;
+
+  return a >= 0 && a <= 1 && b >= 0 && b <= 1 && c >= 0 && c <= 1;
+}
+
+/**
+ * Check whether `(mouseX, mouseY)` sits in the "safe triangle" between two
+ * adjacent rects (e.g. a menu item and the submenu it opens) - the wedge
+ * connecting the near edge of `fromRect` to the near corner of `toRect` -
+ * so diagonal mouse movement toward the submenu doesn't cause it to close
+ * prematurely.
+ *
+ * @param {number} mouseX
+ * @param {number} mouseY
+ * @param {{ top: number, left: number, right: number, bottom: number, height: number }} fromRect
+ * @param {{ top: number, left: number, right: number, bottom: number, height: number }} toRect
+ * @param {number} [buffer] Padding added to the wedge on the `fromRect` side. Default `12`.
+ * @returns {boolean}
+ */
+export function isInSafeTriangle(
+  mouseX,
+  mouseY,
+  fromRect,
+  toRect,
+  buffer = 12,
+) {
+  const isToOnRight = toRect.left >= fromRect.right;
+
+  // Submenus commonly render flush against the trigger rect (zero gap), which
+  // would otherwise make x1/x2/x3 identical - a zero-area triangle that never
+  // contains any point. Give the wedge a minimum depth so it stays usable even
+  // with no gap; a wider real gap still wins via the Math.max/min below.
+  const MIN_WEDGE_DEPTH = 24;
+  let trianglePoints;
+  if (isToOnRight) {
+    trianglePoints = {
+      x1: fromRect.right,
+      y1: fromRect.top - buffer,
+      x2: fromRect.right,
+      y2: fromRect.bottom + buffer,
+      x3: Math.max(toRect.left, fromRect.right + MIN_WEDGE_DEPTH),
+      y3: toRect.top + toRect.height / 2,
+    };
+  } else {
+    trianglePoints = {
+      x1: fromRect.left,
+      y1: fromRect.top - buffer,
+      x2: fromRect.left,
+      y2: fromRect.bottom + buffer,
+      x3: Math.min(toRect.right, fromRect.left - MIN_WEDGE_DEPTH),
+      y3: toRect.top + toRect.height / 2,
+    };
+  }
+
+  const inTopTriangle = isPointInTriangle(
+    mouseX,
+    mouseY,
+    trianglePoints.x1,
+    trianglePoints.y1,
+    isToOnRight ? trianglePoints.x3 : trianglePoints.x2,
+    toRect.top,
+    trianglePoints.x3,
+    trianglePoints.y3,
+  );
+
+  const inBottomTriangle = isPointInTriangle(
+    mouseX,
+    mouseY,
+    trianglePoints.x2,
+    trianglePoints.y2,
+    trianglePoints.x3,
+    trianglePoints.y3,
+    isToOnRight ? trianglePoints.x3 : trianglePoints.x1,
+    toRect.bottom,
+  );
+
+  return inTopTriangle || inBottomTriangle;
+}

--- a/src/utils/submenuHoverController.js
+++ b/src/utils/submenuHoverController.js
@@ -1,0 +1,105 @@
+// @ts-check
+
+import { isInSafeTriangle } from "./isInSafeTriangle.js";
+
+/**
+ * @typedef {Object} SubmenuHoverController
+ * @property {() => void} open - Cancel any pending timers and open immediately (click/keyboard activation).
+ * @property {() => void} scheduleOpen - Open after the hover delay.
+ * @property {() => void} scheduleClose - Close after the hover delay, unless the pointer is in the safe triangle when it fires.
+ * @property {() => void} cancelClose - Cancel a pending close (e.g. the pointer entered the submenu itself).
+ * @property {(x: number, y: number) => void} trackPointer - Record the latest pointer position; cancels a pending close early if it's now safe.
+ * @property {() => void} destroy - Clear any pending timers (call from onDestroy).
+ */
+
+/**
+ * Shared hover-intent scheduling for a menu item's submenu: open after the
+ * "moderate-01" Carbon motion delay, and on leave, close after the same
+ * delay unless the pointer is moving through the "safe triangle" toward the
+ * submenu. `MenuItem` and `ContextMenuOption` each own their own DOM and
+ * submenu-instantiation (a nested `Menu` vs. a nested `ContextMenu`), but
+ * this exact timing/geometry logic is identical between them.
+ *
+ * @param {Object} options
+ * @param {() => boolean} options.isDisabled
+ * @param {(open: boolean) => void} options.setOpen
+ * @param {() => Element | null} options.getTrigger - The item's own element, anchoring the near edge of the wedge.
+ * @param {() => Element | null} options.getSubmenu - The submenu's own element, anchoring the far side of the wedge.
+ * @param {number} [options.delayMs] Default `150`.
+ * @returns {SubmenuHoverController}
+ */
+export function createSubmenuHoverController({
+  isDisabled,
+  setOpen,
+  getTrigger,
+  getSubmenu,
+  delayMs = 150,
+}) {
+  /** @type {ReturnType<typeof setTimeout> | undefined} */
+  let hoverTimeout;
+  /** @type {ReturnType<typeof setTimeout> | undefined} */
+  let closeTimeout;
+  let mousePosition = { x: 0, y: 0 };
+
+  function isSafe() {
+    const trigger = getTrigger();
+    const submenu = getSubmenu();
+    if (!trigger || !submenu) return false;
+    return isInSafeTriangle(
+      mousePosition.x,
+      mousePosition.y,
+      trigger.getBoundingClientRect(),
+      submenu.getBoundingClientRect(),
+    );
+  }
+
+  function open() {
+    if (isDisabled()) return;
+    clearTimeout(hoverTimeout);
+    clearTimeout(closeTimeout);
+    setOpen(true);
+  }
+
+  function scheduleOpen() {
+    if (isDisabled()) return;
+    clearTimeout(closeTimeout);
+    clearTimeout(hoverTimeout);
+    hoverTimeout = setTimeout(open, delayMs);
+  }
+
+  function scheduleClose() {
+    clearTimeout(hoverTimeout);
+    clearTimeout(closeTimeout);
+    closeTimeout = setTimeout(() => {
+      if (isSafe()) return;
+      setOpen(false);
+    }, delayMs);
+  }
+
+  function cancelClose() {
+    clearTimeout(closeTimeout);
+  }
+
+  /** @type {(x: number, y: number) => void} */
+  function trackPointer(x, y) {
+    mousePosition = { x, y };
+    if (closeTimeout !== undefined && isSafe()) {
+      clearTimeout(closeTimeout);
+      closeTimeout = undefined;
+    }
+  }
+
+  function destroy() {
+    clearTimeout(hoverTimeout);
+    clearTimeout(closeTimeout);
+  }
+
+  return {
+    open,
+    scheduleOpen,
+    scheduleClose,
+    cancelClose,
+    trackPointer,
+    destroy,
+  };
+}

--- a/tests/ContextMenu/ContextMenu.test.ts
+++ b/tests/ContextMenu/ContextMenu.test.ts
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/svelte";
+import { fireEvent, render, screen } from "@testing-library/svelte";
 import type ContextMenuOptionComponent from "carbon-components-svelte/ContextMenu/ContextMenuOption.svelte";
 import type { ComponentProps } from "svelte";
 import { user } from "../utils/user";
@@ -9,13 +9,41 @@ import ContextMenuOptionIcon from "./ContextMenuOption.icon.test.svelte";
 import ContextMenuOptionRole from "./ContextMenuOption.role.test.svelte";
 import ContextMenuOptionSlot from "./ContextMenuOption.slot.test.svelte";
 
+/** ContextMenuOption's hover-open/close delay for a submenu ("moderate-01"). */
+const HOVER_DELAY_MS = 150;
+
+/**
+ * Stub an element's `getBoundingClientRect()` (jsdom never computes real
+ * layout) and force FloatingPortal to recompute against it, matching the
+ * pattern FloatingPortal's own tests use for reposition assertions. Accepts
+ * either a CSS selector or an already-resolved element.
+ */
+async function stubRectAndReposition(
+  target: string | Element,
+  rect: {
+    top: number;
+    left: number;
+    right: number;
+    bottom: number;
+    width: number;
+    height: number;
+  },
+) {
+  const element =
+    typeof target === "string" ? document.querySelector(target) : target;
+  assert(element);
+  (element as HTMLElement).getBoundingClientRect = () => rect as DOMRect;
+  window.dispatchEvent(new Event("resize"));
+  await new Promise((resolve) => requestAnimationFrame(resolve));
+}
+
 describe("ContextMenu", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
   it("should render with default props", () => {
-    render(ContextMenu);
+    render(ContextMenu, { props: { open: true } });
 
     const target = screen.getByTestId("target");
     expect(target).toBeInTheDocument();
@@ -58,7 +86,7 @@ describe("ContextMenu", () => {
   });
 
   it("should render menu options", () => {
-    render(ContextMenu);
+    render(ContextMenu, { props: { open: true } });
 
     const options = screen.getAllByRole("menuitem");
     expect(options).toHaveLength(3);
@@ -181,7 +209,7 @@ describe("ContextMenu", () => {
     expect(openCalls).toHaveLength(0);
   });
 
-  it("should handle custom position", () => {
+  it("should handle custom position", async () => {
     render(ContextMenu, {
       props: {
         open: true,
@@ -190,8 +218,21 @@ describe("ContextMenu", () => {
       },
     });
 
-    const menu = screen.getAllByRole("menu")[0];
-    expect(menu).toHaveStyle({
+    // jsdom never computes real layout, so the internal point-anchor's
+    // getBoundingClientRect() is zero regardless of its inline x/y style -
+    // stub it to reflect (100, 200), then force a reposition.
+    await stubRectAndReposition("[data-context-menu-point-anchor]", {
+      top: 200,
+      left: 100,
+      right: 100,
+      bottom: 200,
+      width: 0,
+      height: 0,
+    });
+
+    const portal = document.querySelector("[data-floating-portal]");
+    assert(portal);
+    expect(portal).toHaveStyle({
       left: "100px",
       top: "200px",
     });
@@ -217,6 +258,7 @@ describe("ContextMenu", () => {
   });
 
   it("should set level to 2 when ctx exists (nested menu)", async () => {
+    vi.useFakeTimers();
     render(ContextMenu, {
       props: {
         open: true,
@@ -227,7 +269,9 @@ describe("ContextMenu", () => {
     });
 
     const submenuTrigger = screen.getByText("Option with submenu");
-    await user.hover(submenuTrigger);
+    await fireEvent.mouseEnter(submenuTrigger.closest("li"));
+    await vi.advanceTimersByTimeAsync(HOVER_DELAY_MS);
+    vi.useRealTimers();
 
     const submenu = screen
       .getAllByRole("menu")
@@ -320,19 +364,51 @@ describe("ContextMenu", () => {
       },
     });
 
-    const submenuTrigger = screen.getByText("Option with submenu");
-    await user.hover(submenuTrigger);
+    const submenuTrigger = screen
+      .getByText("Option with submenu")
+      .closest("li");
+    assert(submenuTrigger);
+    // Trigger sits flush against the right edge of a 400px-wide viewport.
+    submenuTrigger.getBoundingClientRect = () =>
+      ({
+        top: 100,
+        left: 300,
+        right: 400,
+        bottom: 120,
+        width: 100,
+        height: 20,
+      }) as DOMRect;
+
+    vi.useFakeTimers();
+    try {
+      await fireEvent.mouseEnter(submenuTrigger);
+      await vi.advanceTimersByTimeAsync(HOVER_DELAY_MS);
+    } finally {
+      vi.useRealTimers();
+    }
 
     const submenu = screen
       .getAllByRole("menu")
       .find((menu) => menu.getAttribute("data-level") === "2");
     assert(submenu);
+    const portal = submenu.closest("[data-floating-portal]");
+    assert(portal);
+    // FloatingPortal measures its own wrapper (not the <ul>) for the
+    // flip/clamp decision.
+    await stubRectAndReposition(portal, {
+      top: 100,
+      left: 0,
+      right: 200,
+      bottom: 300,
+      width: 200,
+      height: 200,
+    });
 
-    const submenuX = Number.parseInt(submenu.style.left, 10);
-    const submenuWidth = submenu.getBoundingClientRect().width;
+    expect(portal).toHaveAttribute("data-floating-direction", "left");
 
-    // Submenu should not overflow the right edge of viewport
-    expect(submenuX + submenuWidth).toBeLessThanOrEqual(400);
+    const submenuX = Number.parseInt((portal as HTMLElement).style.left, 10);
+    // Submenu should not overflow the right edge of viewport.
+    expect(submenuX + 200).toBeLessThanOrEqual(400);
   });
 
   // Regression test for https://github.com/carbon-design-system/carbon-components-svelte/issues/1847
@@ -352,26 +428,47 @@ describe("ContextMenu", () => {
       },
     });
 
-    const submenuTrigger = screen.getByText("Option with submenu");
-    await user.hover(submenuTrigger);
-    await new Promise((resolve) => setTimeout(resolve, 150));
+    const submenuTrigger = screen
+      .getByText("Option with submenu")
+      .closest("li");
+    assert(submenuTrigger);
+    // Trigger has plenty of room to either side.
+    submenuTrigger.getBoundingClientRect = () =>
+      ({
+        top: 100,
+        left: 100,
+        right: 300,
+        bottom: 120,
+        width: 200,
+        height: 20,
+      }) as DOMRect;
+
+    vi.useFakeTimers();
+    try {
+      await fireEvent.mouseEnter(submenuTrigger);
+      await vi.advanceTimersByTimeAsync(HOVER_DELAY_MS);
+    } finally {
+      vi.useRealTimers();
+    }
 
     const submenu = screen
       .getAllByRole("menu")
       .find((menu) => menu.getAttribute("data-level") === "2");
     assert(submenu);
+    const portal = submenu.closest("[data-floating-portal]");
+    assert(portal);
+    await stubRectAndReposition(portal, {
+      top: 100,
+      left: 0,
+      right: 200,
+      bottom: 300,
+      width: 200,
+      height: 200,
+    });
 
-    const rootMenu = screen
-      .getAllByRole("menu")
-      .find((menu) => menu.getAttribute("data-level") === "1");
-    assert(rootMenu);
-
-    const rootX = Number.parseInt(rootMenu.style.left, 10);
-    const rootWidth = rootMenu.getBoundingClientRect().width;
-    const submenuX = Number.parseInt(submenu.style.left, 10);
-
-    // Submenu should be positioned to the right of the parent menu.
-    expect(submenuX).toBeGreaterThanOrEqual(rootX + rootWidth);
+    // Submenu should be positioned to the right of the parent (trigger) option.
+    expect(portal).toHaveAttribute("data-floating-direction", "right");
+    expect(Number.parseInt((portal as HTMLElement).style.left, 10)).toBe(300);
   });
 
   // Regression test for https://github.com/carbon-design-system/carbon-components-svelte/issues/1847
@@ -391,17 +488,47 @@ describe("ContextMenu", () => {
       },
     });
 
-    const submenuTrigger = screen.getByText("Option with submenu");
-    await user.hover(submenuTrigger);
+    const submenuTrigger = screen
+      .getByText("Option with submenu")
+      .closest("li");
+    assert(submenuTrigger);
+    // Neither side of a 200px-wide viewport has room for a 250px-wide submenu.
+    submenuTrigger.getBoundingClientRect = () =>
+      ({
+        top: 100,
+        left: 50,
+        right: 150,
+        bottom: 120,
+        width: 100,
+        height: 20,
+      }) as DOMRect;
+
+    vi.useFakeTimers();
+    try {
+      await fireEvent.mouseEnter(submenuTrigger);
+      await vi.advanceTimersByTimeAsync(HOVER_DELAY_MS);
+    } finally {
+      vi.useRealTimers();
+    }
 
     const submenu = screen
       .getAllByRole("menu")
       .find((menu) => menu.getAttribute("data-level") === "2");
     assert(submenu);
+    const portal = submenu.closest("[data-floating-portal]");
+    assert(portal);
+    await stubRectAndReposition(portal, {
+      top: 100,
+      left: 0,
+      right: 250,
+      bottom: 300,
+      width: 250,
+      height: 200,
+    });
 
-    const submenuX = Number.parseInt(submenu.style.left, 10);
-    // Submenu should be positioned at or near 0 (left edge of viewport).
-    expect(submenuX).toBeGreaterThanOrEqual(0);
+    // Content wider than the viewport itself: clamped to the left edge
+    // rather than overflowing whichever side it lands on.
+    expect(Number.parseInt((portal as HTMLElement).style.left, 10)).toBe(0);
   });
 
   // Regression test: a disabled submenu trigger should expose
@@ -449,7 +576,7 @@ describe("ContextMenu", () => {
       const submenu = screen
         .getAllByRole("menu")
         .find((menu) => menu.getAttribute("data-level") === "2");
-      expect(submenu).not.toHaveClass("bx--menu--open");
+      expect(submenu).toBeUndefined();
     });
 
     it("should not open submenu on hover when disabled", async () => {
@@ -474,7 +601,7 @@ describe("ContextMenu", () => {
       const submenu = screen
         .getAllByRole("menu")
         .find((menu) => menu.getAttribute("data-level") === "2");
-      expect(submenu).not.toHaveClass("bx--menu--open");
+      expect(submenu).toBeUndefined();
     });
 
     it("should not open submenu on click when disabled", async () => {
@@ -498,7 +625,7 @@ describe("ContextMenu", () => {
       const submenu = screen
         .getAllByRole("menu")
         .find((menu) => menu.getAttribute("data-level") === "2");
-      expect(submenu).not.toHaveClass("bx--menu--open");
+      expect(submenu).toBeUndefined();
     });
   });
 
@@ -662,6 +789,126 @@ describe("ContextMenu", () => {
 
       // biome-ignore lint/suspicious/noExplicitAny: Testing default any type
       expectTypeOf<Props["icon"]>().toEqualTypeOf<any>();
+    });
+  });
+
+  describe("ContextMenuOption submenu safe triangle", () => {
+    it("does not close the submenu when the pointer moves into it before the close delay elapses", async () => {
+      vi.useFakeTimers();
+      try {
+        render(ContextMenu, {
+          props: { open: true, withSubmenu: true, x: 100, y: 100 },
+        });
+
+        const parent = screen.getByText("Option with submenu").closest("li");
+        assert(parent);
+        await fireEvent.mouseEnter(parent);
+        await vi.advanceTimersByTimeAsync(HOVER_DELAY_MS);
+        expect(screen.getByText("Submenu option 1")).toBeInTheDocument();
+
+        await fireEvent.mouseLeave(parent);
+        const submenu = screen
+          .getAllByRole("menu")
+          .find((menu) => menu.getAttribute("data-level") === "2");
+        assert(submenu);
+        await fireEvent.mouseEnter(submenu);
+        await vi.advanceTimersByTimeAsync(HOVER_DELAY_MS);
+
+        expect(screen.getByText("Submenu option 1")).toBeInTheDocument();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("does not close the submenu when the pointer crosses through the safe triangle", async () => {
+      vi.useFakeTimers();
+      try {
+        render(ContextMenu, {
+          props: { open: true, withSubmenu: true, x: 100, y: 100 },
+        });
+
+        const parent = screen.getByText("Option with submenu").closest("li");
+        assert(parent);
+        await fireEvent.mouseEnter(parent);
+        await vi.advanceTimersByTimeAsync(HOVER_DELAY_MS);
+
+        const submenu = screen
+          .getAllByRole("menu")
+          .find((menu) => menu.getAttribute("data-level") === "2");
+        assert(submenu);
+        parent.getBoundingClientRect = () =>
+          ({
+            top: 100,
+            left: 0,
+            right: 100,
+            bottom: 120,
+            height: 20,
+          }) as DOMRect;
+        submenu.getBoundingClientRect = () =>
+          ({
+            top: 100,
+            left: 100,
+            right: 300,
+            bottom: 300,
+            height: 200,
+          }) as DOMRect;
+
+        await fireEvent.mouseLeave(parent);
+        // Inside the wedge between the trigger and the submenu's vertical center.
+        await fireEvent.mouseMove(parent, { clientX: 110, clientY: 200 });
+        await vi.advanceTimersByTimeAsync(HOVER_DELAY_MS);
+
+        expect(screen.getByText("Submenu option 1")).toBeInTheDocument();
+        expect(submenu).toHaveClass("bx--menu--open");
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("closes the submenu when the pointer moves away from the safe triangle", async () => {
+      vi.useFakeTimers();
+      try {
+        render(ContextMenu, {
+          props: { open: true, withSubmenu: true, x: 100, y: 100 },
+        });
+
+        const parent = screen.getByText("Option with submenu").closest("li");
+        assert(parent);
+        await fireEvent.mouseEnter(parent);
+        await vi.advanceTimersByTimeAsync(HOVER_DELAY_MS);
+
+        const submenu = screen
+          .getAllByRole("menu")
+          .find((menu) => menu.getAttribute("data-level") === "2");
+        assert(submenu);
+        parent.getBoundingClientRect = () =>
+          ({
+            top: 100,
+            left: 0,
+            right: 100,
+            bottom: 120,
+            height: 20,
+          }) as DOMRect;
+        submenu.getBoundingClientRect = () =>
+          ({
+            top: 100,
+            left: 100,
+            right: 300,
+            bottom: 300,
+            height: 200,
+          }) as DOMRect;
+
+        await fireEvent.mouseLeave(parent);
+        // Far outside the wedge.
+        await fireEvent.mouseMove(parent, { clientX: 105, clientY: 400 });
+        await vi.advanceTimersByTimeAsync(HOVER_DELAY_MS);
+
+        // The submenu unmounts (rather than just losing a CSS class) once
+        // ContextMenuOption's own `submenuOpen` flips to false.
+        expect(submenu).not.toBeInTheDocument();
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 });

--- a/tests/Portal/FloatingPortal.test.ts
+++ b/tests/Portal/FloatingPortal.test.ts
@@ -394,6 +394,116 @@ describe("FloatingPortal", () => {
     });
   });
 
+  describe("viewport measurement fallback", () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    // Regression test: on a page where window.innerWidth disagrees with
+    // document.documentElement's actual rendered box (observed on this
+    // project's own docs site - cause not fully isolated), clamping only to
+    // window.innerWidth positioned a ContextMenu partially outside the
+    // visually rendered area.
+    it("clamps to the narrower of window.innerWidth and the document's rendered width", async () => {
+      Object.defineProperty(window, "innerWidth", {
+        writable: true,
+        configurable: true,
+        value: 1000,
+      });
+      vi.spyOn(
+        document.documentElement,
+        "getBoundingClientRect",
+      ).mockReturnValue({ width: 800, height: 800 } as DOMRect);
+
+      render(FloatingPortalTest, {
+        props: {
+          open: true,
+          direction: "bottom",
+          intrinsicWidth: true,
+          intrinsicAlign: "start",
+        },
+      });
+
+      const content = await screen.findByText("Floating content");
+      const portalElement = content.closest(
+        "[data-floating-portal]",
+      ) as HTMLElement;
+      const anchor = screen.getByTestId("anchor");
+
+      vi.spyOn(anchor, "getBoundingClientRect").mockReturnValue({
+        top: 100,
+        bottom: 120,
+        left: 950,
+        right: 1050,
+        width: 100,
+        height: 20,
+      } as DOMRect);
+      vi.spyOn(portalElement, "getBoundingClientRect").mockReturnValue({
+        top: 0,
+        bottom: 113,
+        left: 0,
+        right: 208,
+        width: 208,
+        height: 113,
+      } as DOMRect);
+
+      window.dispatchEvent(new Event("resize"));
+      await new Promise((resolve) => requestAnimationFrame(resolve));
+
+      // Clamped against the narrower 800px document width (800 - 208 = 592),
+      // not the wider 1000px window.innerWidth (which would give 792).
+      expect(portalElement).toHaveStyle({ left: "592px" });
+    });
+
+    it("falls back to window.innerWidth when the document rect is zero (no real layout, e.g. jsdom by default)", async () => {
+      Object.defineProperty(window, "innerWidth", {
+        writable: true,
+        configurable: true,
+        value: 1000,
+      });
+
+      render(FloatingPortalTest, {
+        props: {
+          open: true,
+          direction: "bottom",
+          intrinsicWidth: true,
+          intrinsicAlign: "start",
+        },
+      });
+
+      const content = await screen.findByText("Floating content");
+      const portalElement = content.closest(
+        "[data-floating-portal]",
+      ) as HTMLElement;
+      const anchor = screen.getByTestId("anchor");
+
+      vi.spyOn(anchor, "getBoundingClientRect").mockReturnValue({
+        top: 100,
+        bottom: 120,
+        left: 950,
+        right: 1050,
+        width: 100,
+        height: 20,
+      } as DOMRect);
+      vi.spyOn(portalElement, "getBoundingClientRect").mockReturnValue({
+        top: 0,
+        bottom: 113,
+        left: 0,
+        right: 208,
+        width: 208,
+        height: 113,
+      } as DOMRect);
+
+      window.dispatchEvent(new Event("resize"));
+      await new Promise((resolve) => requestAnimationFrame(resolve));
+
+      // document.documentElement.getBoundingClientRect() is jsdom's default
+      // zero rect here (unmocked) - clamps against window.innerWidth (792),
+      // not zero.
+      expect(portalElement).toHaveStyle({ left: "792px" });
+    });
+  });
+
   it("binds ref to the floating portal element", async () => {
     const { component } = render(FloatingPortalTest, {
       props: { open: true },

--- a/tests/utils/floatingPosition.test.ts
+++ b/tests/utils/floatingPosition.test.ts
@@ -84,6 +84,54 @@ describe("floatingPosition", () => {
     });
   });
 
+  describe("vertical viewport clamping (left/right direction)", () => {
+    test("shifts up when a bottom-anchored right placement would overflow the bottom edge", () => {
+      const result = floatingPosition({
+        anchorRect: rect(100, 780, 100, 20), // near the bottom of an 800px viewport
+        floatingRect: rect(0, 0, 150, 200),
+        viewport,
+        direction: "right",
+      });
+
+      expect(result.actualDirection).toBe("right");
+      expect(result.top).toBe(600); // clamped so top + height (200) === innerHeight (800)
+    });
+
+    test("does not shift when the content already fits", () => {
+      const result = floatingPosition({
+        anchorRect: rect(100, 200, 100, 20),
+        floatingRect: rect(0, 0, 150, 200),
+        viewport,
+        direction: "right",
+      });
+
+      expect(result.top).toBe(110); // centered: 200 + 20/2 - 200/2
+    });
+
+    test("prefers the top viewport edge when content is taller than the viewport", () => {
+      const result = floatingPosition({
+        anchorRect: rect(100, 400, 100, 20),
+        floatingRect: rect(0, 0, 150, 1200),
+        viewport,
+        direction: "left",
+      });
+
+      expect(result.top).toBe(0);
+    });
+
+    test("clamps the primary axis too when content fits on neither side", () => {
+      const narrowViewport = { ...viewport, innerWidth: 200 };
+      const result = floatingPosition({
+        anchorRect: rect(50, 100, 100, 20),
+        floatingRect: rect(0, 0, 250, 200), // wider than the 200px viewport
+        viewport: narrowViewport,
+        direction: "right",
+      });
+
+      expect(result.left).toBe(0);
+    });
+  });
+
   describe("auto-flip", () => {
     test("bottom flips to top when there is more room above", () => {
       const result = floatingPosition({
@@ -231,6 +279,123 @@ describe("floatingPosition", () => {
       // the CSS, so the caret stays centered on the trigger regardless of the
       // floating width.
       expect(result.caretNudgePx).toBe(75);
+    });
+  });
+
+  describe("horizontal viewport clamping (intrinsic width, vertical direction)", () => {
+    test("shifts left when start-aligned content would overflow the right edge", () => {
+      const result = floatingPosition({
+        anchorRect: rect(950, 200, 0, 20), // zero-width point anchor near right edge
+        floatingRect: rect(0, 0, 200, 150),
+        viewport,
+        direction: "bottom",
+        intrinsicWidth: true,
+        intrinsicAlign: "start",
+      });
+
+      expect(result.left).toBe(800); // clamped so left + width (200) === innerWidth (1000)
+    });
+
+    test("does not shift when the content already fits", () => {
+      const result = floatingPosition({
+        anchorRect: rect(300, 200, 0, 20),
+        floatingRect: rect(0, 0, 200, 150),
+        viewport,
+        direction: "bottom",
+        intrinsicWidth: true,
+        intrinsicAlign: "start",
+      });
+
+      expect(result.left).toBe(300);
+    });
+
+    test("shifts right when the content would overflow the left edge", () => {
+      const result = floatingPosition({
+        anchorRect: rect(-50, 200, 0, 20),
+        floatingRect: rect(0, 0, 200, 150),
+        viewport,
+        direction: "bottom",
+        intrinsicWidth: true,
+        intrinsicAlign: "start",
+      });
+
+      expect(result.left).toBe(0);
+    });
+
+    test("accounts for the CSS translateX(-50%) applied to center-aligned content", () => {
+      const result = floatingPosition({
+        anchorRect: rect(950, 200, 0, 20), // anchor center = 950
+        floatingRect: rect(0, 0, 200, 150),
+        viewport,
+        direction: "bottom",
+        intrinsicWidth: true,
+        intrinsicAlign: "center",
+      });
+
+      // True left edge after translateX(-50%) is (left - 100); clamp that to
+      // maxLeft (800), so the returned anchor-relative left is 800 + 100.
+      expect(result.left).toBe(900);
+    });
+
+    test("accounts for the CSS translateX(-100%) applied to end-aligned content", () => {
+      const result = floatingPosition({
+        anchorRect: rect(50, 200, 0, 20), // anchor right edge = 50
+        floatingRect: rect(0, 0, 200, 150),
+        viewport,
+        direction: "bottom",
+        intrinsicWidth: true,
+        intrinsicAlign: "end",
+      });
+
+      // True left edge after translateX(-100%) is (left - 200); clamp that to
+      // minLeft (0), so the returned anchor-relative left is 0 + 200.
+      expect(result.left).toBe(200);
+    });
+
+    test("shifts the caret nudge to keep pointing at the anchor after clamping", () => {
+      const result = floatingPosition({
+        anchorRect: rect(950, 200, 100, 20), // anchor width 100, center at 1000
+        floatingRect: rect(0, 0, 200, 150),
+        viewport,
+        direction: "bottom",
+        intrinsicWidth: true,
+        intrinsicAlign: "start",
+      });
+
+      // Box shifted left by 150 (950 -> 800) to fit, but the anchor (and its
+      // center) didn't move - the caret nudge grows by the same 150 so it
+      // still points at the anchor center instead of drifting with the box.
+      expect(result.left).toBe(800);
+      expect(result.caretNudgePx).toBe(200);
+    });
+
+    test("prefers the left viewport edge when content is wider than the viewport", () => {
+      const result = floatingPosition({
+        anchorRect: rect(500, 200, 0, 20),
+        floatingRect: rect(0, 0, 1200, 150),
+        viewport,
+        direction: "bottom",
+        intrinsicWidth: true,
+        intrinsicAlign: "start",
+      });
+
+      expect(result.left).toBe(0);
+    });
+
+    test("clamps using scroll offset when not using fixed position", () => {
+      const scrolled = { ...viewport, scrollX: 100 };
+      const result = floatingPosition({
+        anchorRect: rect(950, 200, 0, 20),
+        floatingRect: rect(0, 0, 200, 150),
+        viewport: scrolled,
+        direction: "bottom",
+        intrinsicWidth: true,
+        intrinsicAlign: "start",
+        useFixedPosition: false,
+      });
+
+      // maxLeft = scrollX (100) + innerWidth (1000) - width (200) = 900
+      expect(result.left).toBe(900);
     });
   });
 

--- a/tests/utils/isInSafeTriangle.test.ts
+++ b/tests/utils/isInSafeTriangle.test.ts
@@ -1,0 +1,61 @@
+import { isInSafeTriangle } from "../../src/utils/isInSafeTriangle.js";
+
+describe("isInSafeTriangle", () => {
+  // Trigger row (fromRect) flush against a taller submenu (toRect) opening to
+  // the right - the common case where a Menu submenu renders with zero gap.
+  const fromRect = { top: 100, left: 0, right: 100, bottom: 120, height: 20 };
+  const toRect = { top: 100, left: 100, right: 300, bottom: 300, height: 200 };
+
+  it("returns true just past the trigger's edge, near the trigger's own row", () => {
+    expect(isInSafeTriangle(105, 110, fromRect, toRect)).toBe(true);
+  });
+
+  it("returns true near the submenu's vertical center, further from the edge", () => {
+    expect(isInSafeTriangle(110, 200, fromRect, toRect)).toBe(true);
+  });
+
+  it("returns false for a point outside the wedge (mid-height, away from the edge)", () => {
+    expect(isInSafeTriangle(110, 150, fromRect, toRect)).toBe(false);
+  });
+
+  it("returns false for a point far past the submenu's bottom", () => {
+    expect(isInSafeTriangle(105, 400, fromRect, toRect)).toBe(false);
+  });
+
+  it("returns false for a point still inside the trigger, left of the wedge", () => {
+    expect(isInSafeTriangle(50, 110, fromRect, toRect)).toBe(false);
+  });
+
+  it("mirrors the wedge when the submenu opens to the left", () => {
+    const leftToRect = {
+      top: 100,
+      left: -300,
+      right: -100,
+      bottom: 300,
+      height: 200,
+    };
+    const leftFromRect = {
+      top: 100,
+      left: -100,
+      right: 0,
+      bottom: 120,
+      height: 20,
+    };
+    expect(isInSafeTriangle(-105, 200, leftFromRect, leftToRect)).toBe(true);
+    expect(isInSafeTriangle(-105, 400, leftFromRect, leftToRect)).toBe(false);
+  });
+
+  it("shifts the safe zone once a real gap separates the two rects", () => {
+    const gappedToRect = {
+      top: 100,
+      left: 140,
+      right: 340,
+      bottom: 300,
+      height: 200,
+    };
+    // A point that succeeds against the flush toRect can fall outside the
+    // wedge once a real gap pushes the near edge further from the trigger.
+    expect(isInSafeTriangle(110, 150, fromRect, gappedToRect)).toBe(true);
+    expect(isInSafeTriangle(115, 150, fromRect, gappedToRect)).toBe(false);
+  });
+});

--- a/tests/utils/submenuHoverController.test.ts
+++ b/tests/utils/submenuHoverController.test.ts
@@ -1,0 +1,173 @@
+import { createSubmenuHoverController } from "../../src/utils/submenuHoverController.js";
+
+const DELAY_MS = 150;
+
+/** Minimal DOM-like stand-in with a stubbed rect. */
+function fakeElement(rect: {
+  top: number;
+  left: number;
+  right: number;
+  bottom: number;
+  height: number;
+}) {
+  return { getBoundingClientRect: () => rect as DOMRect };
+}
+
+describe("createSubmenuHoverController", () => {
+  // Trigger flush against a submenu opening to the right (matches the
+  // isInSafeTriangle fixture already validated elsewhere).
+  const trigger = fakeElement({
+    top: 100,
+    left: 0,
+    right: 100,
+    bottom: 120,
+    height: 20,
+  });
+  const submenu = fakeElement({
+    top: 100,
+    left: 100,
+    right: 300,
+    bottom: 300,
+    height: 200,
+  });
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("opens after the hover delay", async () => {
+    const setOpen = vi.fn();
+    const controller = createSubmenuHoverController({
+      isDisabled: () => false,
+      setOpen,
+      getTrigger: () => trigger,
+      getSubmenu: () => submenu,
+      delayMs: DELAY_MS,
+    });
+
+    controller.scheduleOpen();
+    expect(setOpen).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(DELAY_MS);
+    expect(setOpen).toHaveBeenCalledWith(true);
+  });
+
+  it("does not schedule an open when disabled", async () => {
+    const setOpen = vi.fn();
+    const controller = createSubmenuHoverController({
+      isDisabled: () => true,
+      setOpen,
+      getTrigger: () => trigger,
+      getSubmenu: () => submenu,
+      delayMs: DELAY_MS,
+    });
+
+    controller.scheduleOpen();
+    await vi.advanceTimersByTimeAsync(DELAY_MS);
+    expect(setOpen).not.toHaveBeenCalled();
+  });
+
+  it("open() opens immediately regardless of pending timers", () => {
+    const setOpen = vi.fn();
+    const controller = createSubmenuHoverController({
+      isDisabled: () => false,
+      setOpen,
+      getTrigger: () => trigger,
+      getSubmenu: () => submenu,
+      delayMs: DELAY_MS,
+    });
+
+    controller.open();
+    expect(setOpen).toHaveBeenCalledWith(true);
+  });
+
+  it("closes after the delay when the pointer is not in the safe triangle", async () => {
+    const setOpen = vi.fn();
+    const controller = createSubmenuHoverController({
+      isDisabled: () => false,
+      setOpen,
+      getTrigger: () => trigger,
+      getSubmenu: () => submenu,
+      delayMs: DELAY_MS,
+    });
+
+    controller.trackPointer(105, 400); // far outside the wedge
+    controller.scheduleClose();
+    await vi.advanceTimersByTimeAsync(DELAY_MS);
+
+    expect(setOpen).toHaveBeenCalledWith(false);
+  });
+
+  it("does not close when the pointer is in the safe triangle at fire time", async () => {
+    const setOpen = vi.fn();
+    const controller = createSubmenuHoverController({
+      isDisabled: () => false,
+      setOpen,
+      getTrigger: () => trigger,
+      getSubmenu: () => submenu,
+      delayMs: DELAY_MS,
+    });
+
+    controller.trackPointer(110, 200); // inside the wedge toward the submenu's vertical center
+    controller.scheduleClose();
+    await vi.advanceTimersByTimeAsync(DELAY_MS);
+
+    expect(setOpen).not.toHaveBeenCalled();
+  });
+
+  it("cancelClose prevents a pending close from firing", async () => {
+    const setOpen = vi.fn();
+    const controller = createSubmenuHoverController({
+      isDisabled: () => false,
+      setOpen,
+      getTrigger: () => trigger,
+      getSubmenu: () => submenu,
+      delayMs: DELAY_MS,
+    });
+
+    controller.scheduleClose();
+    controller.cancelClose();
+    await vi.advanceTimersByTimeAsync(DELAY_MS);
+
+    expect(setOpen).not.toHaveBeenCalled();
+  });
+
+  it("trackPointer cancels a pending close early once the pointer becomes safe", async () => {
+    const setOpen = vi.fn();
+    const controller = createSubmenuHoverController({
+      isDisabled: () => false,
+      setOpen,
+      getTrigger: () => trigger,
+      getSubmenu: () => submenu,
+      delayMs: DELAY_MS,
+    });
+
+    controller.trackPointer(105, 400); // starts unsafe
+    controller.scheduleClose();
+    controller.trackPointer(110, 200); // moves into the wedge before the delay elapses
+    await vi.advanceTimersByTimeAsync(DELAY_MS);
+
+    expect(setOpen).not.toHaveBeenCalled();
+  });
+
+  it("destroy clears pending open and close timers", async () => {
+    const setOpen = vi.fn();
+    const controller = createSubmenuHoverController({
+      isDisabled: () => false,
+      setOpen,
+      getTrigger: () => trigger,
+      getSubmenu: () => submenu,
+      delayMs: DELAY_MS,
+    });
+
+    controller.scheduleOpen();
+    controller.destroy();
+    await vi.advanceTimersByTimeAsync(DELAY_MS);
+
+    expect(setOpen).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Brings ContextMenu onto the same positioning and hover-intent primitives as Menu/MenuItem, and gives MenuItem full parity with ContextMenuOption's feature set as prep work for that.

MenuItem gains a selectable checkbox variant, a radio variant via MenuItemRadioGroup, indented/shortcutText/icon slot props, and safe-triangle hover intent for submenus. Grouped as a chore since Menu is not yet released.

floatingPosition now clamps to the viewport on all four directions. The top/bottom branches never accounted for horizontal overflow, and left/right never accounted for vertical overflow or a fallback when content fits on neither side. This affects every consumer: Tooltip, Toggletip, TooltipDefinition, the ListBox family (Dropdown, ComboBox, MultiSelect, Select), OverflowMenu, and SearchMenu.

ContextMenu now anchors a point (or a real element, for ContextMenuOption's nested submenus) to FloatingPortal instead of computing position with one-shot manual math. This fixes the z-index tie with Modal (was 9000, now 9200 like the rest of the Menu family), adds proper flip-to-fit and scroll/resize repositioning, and adds size and zIndex props. ContextMenuOption and ContextMenu also now share isInSafeTriangle and createSubmenuHoverController with MenuItem instead of carrying their own copies, fixing two bugs along the way: the safe-triangle check divided by zero whenever the submenu rendered flush against its trigger (the common case, silently disabling the hover-intent protection), and the hover handler could double-schedule on a rapid re-hover.

Menu content now only mounts while open, matching Menu/MenuButton/ComboButton, instead of always rendering hidden in the DOM.