### PR TITLE
chore(menu): safe-triangle hover intent + MenuItem feature parity prep

### DIFF
--- a/src/Menu/MenuItem.svelte
+++ b/src/Menu/MenuItem.svelte
@@ -19,6 +19,7 @@
   /**
    * Specify the icon to render.
    * Icon is rendered to the left of the label text.
+   * Alternatively, use the "icon" slot for custom icon markup.
    * @type {Icon}
    */
   export let icon = /** @type {Icon} */ (undefined);
@@ -34,6 +35,43 @@
   export let labelText = undefined;
 
   /**
+   * Set to `true` to render the item as a checkbox (`role="menuitemcheckbox"`).
+   * Selecting the item toggles `selected` and keeps the menu open.
+   * @bindable writable
+   */
+  export let selectable = false;
+
+  /**
+   * Set to `true` to mark a `selectable` item (or a radio item inside a
+   * `MenuItemRadioGroup`) as selected.
+   * @bindable writable
+   */
+  export let selected = false;
+
+  /**
+   * Set to `true` to reserve the icon gutter even without an icon.
+   * Automatically set to `true` when `icon` is provided, or when the item
+   * is `selectable` or part of a `MenuItemRadioGroup`.
+   * @bindable writable
+   */
+  export let indented = false;
+
+  /**
+   * Specify the shortcut text, rendered at the trailing edge of the item.
+   * Alternatively, use the "shortcutText" slot.
+   * Ignored for an item with a submenu.
+   * @type {string | undefined}
+   */
+  export let shortcutText = undefined;
+
+  /**
+   * Specify the id.
+   * It's recommended to provide an id as a value to bind to within a
+   * `MenuItemRadioGroup`.
+   */
+  export let id = `ccs-${Math.random().toString(36)}`;
+
+  /**
    * Obtain a reference to the list item HTML element.
    * @bindable readonly
    */
@@ -41,78 +79,101 @@
 
   import { createEventDispatcher, getContext, onMount } from "svelte";
   import CaretRight from "../icons/CaretRight.svelte";
+  import Checkmark from "../icons/Checkmark.svelte";
+  import { createSubmenuHoverController } from "../utils/submenuHoverController.js";
+  import { dismiss } from "../utils/dismiss.js";
   import Menu from "./Menu.svelte";
-
-  // "moderate-01" duration (ms) from Carbon motion recommended for small
-  // expansion, short distance movements - matches the delay used for
-  // ContextMenuOption's own submenu hover.
-  const HOVER_DELAY_MS = 150;
 
   const dispatch = createEventDispatcher();
   const ctx = getContext("carbon:Menu");
+  const ctxRadioGroup = getContext("carbon:MenuRadioGroup");
 
   let submenuOpen = false;
-  let hoverTimeout;
-  let closeTimeout;
+  let submenuRef = null;
+  let unsubCurrentId;
+  let role = "menuitem";
+
+  const hover = createSubmenuHoverController({
+    isDisabled: () => disabled,
+    setOpen: (open) => {
+      submenuOpen = open;
+    },
+    getTrigger: () => ref,
+    getSubmenu: () => submenuRef,
+  });
 
   $: hasSubmenu = labelText !== undefined && $$slots.default;
+  $: isRadio = !!ctxRadioGroup;
+
+  $: {
+    if (icon || $$slots.icon) indented = true;
+    if (selectable || isRadio) indented = true;
+
+    let nextRole = "menuitem";
+    if (selectable) nextRole = "menuitemcheckbox";
+    if (isRadio) nextRole = "menuitemradio";
+    role = nextRole;
+
+    if (selectable) icon = selected ? Checkmark : undefined;
+    if (isRadio) icon = selected ? Checkmark : undefined;
+  }
 
   function handleClick(event) {
     if (disabled) return;
 
     const shouldContinue = dispatch("click", event, { cancelable: true });
+    if (!shouldContinue) return;
 
-    if (shouldContinue) {
+    if (isRadio) {
+      ctxRadioGroup.setOption({ id });
+      ctx.close("select");
+    } else if (selectable) {
+      selected = !selected;
+    } else {
       ctx.close("select");
     }
   }
 
-  function openSubmenu() {
-    if (disabled) return;
-    clearTimeout(hoverTimeout);
-    clearTimeout(closeTimeout);
-    submenuOpen = true;
-  }
-
-  function scheduleOpenSubmenu() {
-    if (disabled) return;
-    clearTimeout(closeTimeout);
-    clearTimeout(hoverTimeout);
-    hoverTimeout = setTimeout(openSubmenu, HOVER_DELAY_MS);
-  }
-
-  function scheduleCloseSubmenu() {
-    clearTimeout(hoverTimeout);
-    clearTimeout(closeTimeout);
-    closeTimeout = setTimeout(() => {
-      submenuOpen = false;
-    }, HOVER_DELAY_MS);
-  }
-
-  function cancelCloseSubmenu() {
-    clearTimeout(closeTimeout);
+  function handleGlobalMouseMove(event) {
+    if (!hasSubmenu || !submenuOpen) return;
+    hover.trackPointer(event.clientX, event.clientY);
   }
 
   onMount(() => {
+    if (ctxRadioGroup) {
+      unsubCurrentId = ctxRadioGroup.currentId.subscribe((currentId) => {
+        selected = id === currentId;
+      });
+      ctxRadioGroup.addOption({ id });
+    }
+
     return () => {
-      clearTimeout(hoverTimeout);
-      clearTimeout(closeTimeout);
+      unsubCurrentId?.();
+      hover.destroy();
     };
   });
 </script>
 
 <li
   bind:this={ref}
-  role="menuitem"
+  {role}
   tabindex="-1"
   aria-disabled={disabled}
   aria-haspopup={hasSubmenu ? true : undefined}
   aria-expanded={hasSubmenu ? submenuOpen : undefined}
+  aria-checked={selectable || isRadio ? selected : undefined}
   class:bx--menu-option={true}
   class:bx--menu-option--disabled={disabled}
   class:bx--menu-option--active={hasSubmenu && submenuOpen}
   class:bx--menu-option--danger={!hasSubmenu && kind === "danger"}
+  {indented}
   {...$$restProps}
+  use:dismiss={{
+    enabled: hasSubmenu && submenuOpen,
+    type: "mousemove",
+    handler: handleGlobalMouseMove,
+    options: { passive: true },
+  }}
   on:keydown
   on:keydown={(event) => {
     if (disabled) return;
@@ -124,7 +185,7 @@
         event.key === "Enter"
       ) {
         event.preventDefault();
-        openSubmenu();
+        hover.open();
       }
       return;
     }
@@ -141,25 +202,32 @@
     if (hasSubmenu) {
       event.stopPropagation();
       if (disabled) return;
-      openSubmenu();
+      hover.open();
       return;
     }
     handleClick(event);
   }}
   on:mouseenter={() => {
-    if (hasSubmenu) scheduleOpenSubmenu();
+    if (hasSubmenu) hover.scheduleOpen();
+  }}
+  on:mousemove={(event) => {
+    if (hasSubmenu && submenuOpen) {
+      hover.trackPointer(event.clientX, event.clientY);
+    }
   }}
   on:mouseleave={() => {
-    if (hasSubmenu) scheduleCloseSubmenu();
+    if (hasSubmenu) hover.scheduleClose();
   }}
 >
   <div
     class:bx--menu-option__content={true}
     class:bx--menu-option__content--disabled={disabled}
   >
-    {#if icon}
+    {#if indented}
       <div class:bx--menu-option__icon={true}>
-        <svelte:component this={icon} />
+        <slot name="icon">
+          {#if icon}<svelte:component this={icon} />{/if}
+        </slot>
       </div>
     {/if}
     <span
@@ -176,11 +244,16 @@
       <div class:bx--menu-option__info={true}>
         <CaretRight />
       </div>
+    {:else if shortcutText !== undefined || $$slots.shortcutText}
+      <div class:bx--menu-option__info={true}>
+        <slot name="shortcutText">{shortcutText}</slot>
+      </div>
     {/if}
   </div>
 
   {#if hasSubmenu}
     <Menu
+      bind:ref={submenuRef}
       anchor={ref}
       direction="right"
       intrinsicWidth
@@ -194,8 +267,8 @@
           ref?.focus({ preventScroll: true });
         }
       }}
-      on:mouseenter={cancelCloseSubmenu}
-      on:mouseleave={scheduleCloseSubmenu}
+      on:mouseenter={hover.cancelClose}
+      on:mouseleave={hover.scheduleClose}
       on:close={(event) => {
         if (event.detail.trigger === "select") ctx.close("select");
       }}

--- a/src/Menu/MenuItemRadioGroup.svelte
+++ b/src/Menu/MenuItemRadioGroup.svelte
@@ -1,0 +1,53 @@
+<script>
+  /**
+   * Set the selected radio group id.
+   * @bindable writable
+   */
+  export let selectedId = "";
+
+  /** Specify the label text */
+  export let labelText = "";
+
+  import { setContext } from "svelte";
+  import { writable } from "svelte/store";
+
+  /**
+   * @type {import("svelte/store").Writable<string>}
+   */
+  const currentId = writable("");
+  /**
+   * @type {import("svelte/store").Writable<ReadonlyArray<string>>}
+   */
+  const radioIds = writable([]);
+
+  /**
+   * @type {(data: { id: string }) => void}
+   */
+  function addOption({ id }) {
+    if (!$radioIds.includes(id)) {
+      radioIds.update((_) => [..._, id]);
+    }
+  }
+
+  /**
+   * @type {(data: { id: string }) => void}
+   */
+  function setOption({ id }) {
+    selectedId = id;
+  }
+
+  setContext("carbon:MenuRadioGroup", {
+    currentId,
+    radioIds,
+    addOption,
+    setOption,
+  });
+
+  $: currentId.set(selectedId);
+</script>
+
+<li role="none">
+  <ul role="group" aria-label={labelText}>
+    <slot />
+  </ul>
+</li>

--- a/src/Menu/index.js
+++ b/src/Menu/index.js
@@ -1,3 +1,4 @@
 export { default as Menu } from "./Menu.svelte";
 export { default as MenuDivider } from "./MenuDivider.svelte";
 export { default as MenuItem } from "./MenuItem.svelte";
+export { default as MenuItemRadioGroup } from "./MenuItemRadioGroup.svelte";

--- a/src/index.js
+++ b/src/index.js
@@ -95,6 +95,7 @@ export { default as LocalStorage } from "./LocalStorage/LocalStorage.svelte";
 export { default as Menu } from "./Menu/Menu.svelte";
 export { default as MenuDivider } from "./Menu/MenuDivider.svelte";
 export { default as MenuItem } from "./Menu/MenuItem.svelte";
+export { default as MenuItemRadioGroup } from "./Menu/MenuItemRadioGroup.svelte";
 export { default as MenuButton } from "./MenuButton/MenuButton.svelte";
 export { default as Modal } from "./Modal/Modal.svelte";
 export { default as FluidMultiSelectSkeleton } from "./MultiSelect/FluidMultiSelectSkeleton.svelte";

--- a/src/utils/floatingPosition.js
+++ b/src/utils/floatingPosition.js
@@ -6,7 +6,12 @@
 
 /**
  * Place a floating element next to an anchor. Caller passes both rects and the
- * viewport. Flips direction when the preferred side does not fit.
+ * viewport. Flips direction when the preferred side does not fit, then shifts
+ * (clamps) the box to stay within the viewport on the cross axis - there is
+ * no "other side" to flip to there, so this is a shift rather than a flip,
+ * same as Floating UI's `shift`. For `left`/`right`, the primary axis also
+ * gets a final clamp as a fallback for when content is too wide for either
+ * side to fully fit.
  *
  * @param {Object} options
  * @param {RectLike} options.anchorRect - The anchor's `getBoundingClientRect()`.
@@ -192,6 +197,55 @@ export function floatingPosition({
     // changes — no recompute, no bounce. The CSS applies it from the matching
     // edge per alignment.
     caretNudgePx = rect.width / 2;
+  }
+
+  if (actualDirection === "top" || actualDirection === "bottom") {
+    const finalWidth = posWidth ?? floatingRect.width;
+
+    // `posLeft` is the box's own left edge for `start` alignment (or when
+    // matching the anchor width), but for `center`/`end` it is an
+    // anchor-relative coordinate that FloatingPortal shifts into place with a
+    // CSS `translateX` — account for that offset to find the true rendered
+    // left edge before clamping it to the viewport.
+    let trueLeft = posLeft;
+    if (intrinsicWidth && intrinsicAlign === "center") {
+      trueLeft = posLeft - finalWidth / 2;
+    } else if (intrinsicWidth && intrinsicAlign === "end") {
+      trueLeft = posLeft - finalWidth;
+    }
+
+    const minLeft = scrollXOffset;
+    const maxLeft = scrollXOffset + viewport.innerWidth - finalWidth;
+    // Content wider than the viewport: prefer the left edge over the right.
+    const clampedTrueLeft =
+      maxLeft >= minLeft
+        ? Math.min(Math.max(trueLeft, minLeft), maxLeft)
+        : minLeft;
+
+    const delta = clampedTrueLeft - trueLeft;
+    if (delta !== 0) {
+      posLeft += delta;
+      // Keep the caret pointing at the (unmoved) anchor center after the
+      // box itself shifted to stay within the viewport.
+      if (caretNudgePx !== undefined) caretNudgePx -= delta;
+    }
+  } else {
+    // `left`/`right`: clamp both axes. `top` is the cross axis (mirrors the
+    // top/bottom case's horizontal shift; no CSS transform involved here, so
+    // no extra offset accounting is needed). `left` is the primary axis -
+    // the flip above already tries the preferred side, but if the content is
+    // too wide for either side to fully fit, this is a final fallback so it
+    // stays on-screen rather than overflowing whichever side it landed on.
+    const minTop = scrollYOffset;
+    const maxTop = scrollYOffset + viewport.innerHeight - floatingRect.height;
+    top = maxTop >= minTop ? Math.min(Math.max(top, minTop), maxTop) : minTop;
+
+    const minLeft = scrollXOffset;
+    const maxLeft = scrollXOffset + viewport.innerWidth - floatingRect.width;
+    posLeft =
+      maxLeft >= minLeft
+        ? Math.min(Math.max(posLeft, minLeft), maxLeft)
+        : minLeft;
   }
 
   return {

--- a/src/utils/isInSafeTriangle.js
+++ b/src/utils/isInSafeTriangle.js
@@ -1,0 +1,89 @@
+// @ts-check
+
+/**
+ * @param {number} px
+ * @param {number} py
+ * @param {number} x1
+ * @param {number} y1
+ * @param {number} x2
+ * @param {number} y2
+ * @param {number} x3
+ * @param {number} y3
+ * @returns {boolean}
+ */
+function isPointInTriangle(px, py, x1, y1, x2, y2, x3, y3) {
+  const denominator = (y2 - y3) * (x1 - x3) + (x3 - x2) * (y1 - y3);
+  const a = ((y2 - y3) * (px - x3) + (x3 - x2) * (py - y3)) / denominator;
+  const b = ((y3 - y1) * (px - x3) + (x1 - x3) * (py - y3)) / denominator;
+  const c = 1 - a - b;
+
+  return a >= 0 && a <= 1 && b >= 0 && b <= 1 && c >= 0 && c <= 1;
+}
+
+/**
+ * Check whether `(mouseX, mouseY)` sits in the "safe triangle" between two
+ * adjacent rects (e.g. a menu item and the submenu it opens) - the wedge
+ * connecting the near edge of `fromRect` to the near corner of `toRect` -
+ * so diagonal mouse movement toward the submenu doesn't cause it to close
+ * prematurely.
+ *
+ * @param {number} mouseX
+ * @param {number} mouseY
+ * @param {{ top: number, left: number, right: number, bottom: number, height: number }} fromRect
+ * @param {{ top: number, left: number, right: number, bottom: number, height: number }} toRect
+ * @param {number} [buffer] Padding added to the wedge on the `fromRect` side. Default `12`.
+ * @returns {boolean}
+ */
+export function isInSafeTriangle(mouseX, mouseY, fromRect, toRect, buffer = 12) {
+  const isToOnRight = toRect.left >= fromRect.right;
+
+  // Submenus commonly render flush against the trigger rect (zero gap), which
+  // would otherwise make x1/x2/x3 identical - a zero-area triangle that never
+  // contains any point. Give the wedge a minimum depth so it stays usable even
+  // with no gap; a wider real gap still wins via the Math.max/min below.
+  const MIN_WEDGE_DEPTH = 24;
+  let trianglePoints;
+  if (isToOnRight) {
+    trianglePoints = {
+      x1: fromRect.right,
+      y1: fromRect.top - buffer,
+      x2: fromRect.right,
+      y2: fromRect.bottom + buffer,
+      x3: Math.max(toRect.left, fromRect.right + MIN_WEDGE_DEPTH),
+      y3: toRect.top + toRect.height / 2,
+    };
+  } else {
+    trianglePoints = {
+      x1: fromRect.left,
+      y1: fromRect.top - buffer,
+      x2: fromRect.left,
+      y2: fromRect.bottom + buffer,
+      x3: Math.min(toRect.right, fromRect.left - MIN_WEDGE_DEPTH),
+      y3: toRect.top + toRect.height / 2,
+    };
+  }
+
+  const inTopTriangle = isPointInTriangle(
+    mouseX,
+    mouseY,
+    trianglePoints.x1,
+    trianglePoints.y1,
+    isToOnRight ? trianglePoints.x3 : trianglePoints.x2,
+    toRect.top,
+    trianglePoints.x3,
+    trianglePoints.y3,
+  );
+
+  const inBottomTriangle = isPointInTriangle(
+    mouseX,
+    mouseY,
+    trianglePoints.x2,
+    trianglePoints.y2,
+    trianglePoints.x3,
+    trianglePoints.y3,
+    isToOnRight ? trianglePoints.x3 : trianglePoints.x1,
+    toRect.bottom,
+  );
+
+  return inTopTriangle || inBottomTriangle;
+}

--- a/src/utils/submenuHoverController.js
+++ b/src/utils/submenuHoverController.js
@@ -1,0 +1,98 @@
+// @ts-check
+
+import { isInSafeTriangle } from "./isInSafeTriangle.js";
+
+/**
+ * @typedef {Object} SubmenuHoverController
+ * @property {() => void} open - Cancel any pending timers and open immediately (click/keyboard activation).
+ * @property {() => void} scheduleOpen - Open after the hover delay.
+ * @property {() => void} scheduleClose - Close after the hover delay, unless the pointer is in the safe triangle when it fires.
+ * @property {() => void} cancelClose - Cancel a pending close (e.g. the pointer entered the submenu itself).
+ * @property {(x: number, y: number) => void} trackPointer - Record the latest pointer position; cancels a pending close early if it's now safe.
+ * @property {() => void} destroy - Clear any pending timers (call from onDestroy).
+ */
+
+/**
+ * Shared hover-intent scheduling for a menu item's submenu: open after the
+ * "moderate-01" Carbon motion delay, and on leave, close after the same
+ * delay unless the pointer is moving through the "safe triangle" toward the
+ * submenu. `MenuItem` and `ContextMenuOption` each own their own DOM and
+ * submenu-instantiation (a nested `Menu` vs. a nested `ContextMenu`), but
+ * this exact timing/geometry logic is identical between them.
+ *
+ * @param {Object} options
+ * @param {() => boolean} options.isDisabled
+ * @param {(open: boolean) => void} options.setOpen
+ * @param {() => Element | null} options.getTrigger - The item's own element, anchoring the near edge of the wedge.
+ * @param {() => Element | null} options.getSubmenu - The submenu's own element, anchoring the far side of the wedge.
+ * @param {number} [options.delayMs] Default `150`.
+ * @returns {SubmenuHoverController}
+ */
+export function createSubmenuHoverController({
+  isDisabled,
+  setOpen,
+  getTrigger,
+  getSubmenu,
+  delayMs = 150,
+}) {
+  /** @type {ReturnType<typeof setTimeout> | undefined} */
+  let hoverTimeout;
+  /** @type {ReturnType<typeof setTimeout> | undefined} */
+  let closeTimeout;
+  let mousePosition = { x: 0, y: 0 };
+
+  function isSafe() {
+    const trigger = getTrigger();
+    const submenu = getSubmenu();
+    if (!trigger || !submenu) return false;
+    return isInSafeTriangle(
+      mousePosition.x,
+      mousePosition.y,
+      trigger.getBoundingClientRect(),
+      submenu.getBoundingClientRect(),
+    );
+  }
+
+  function open() {
+    if (isDisabled()) return;
+    clearTimeout(hoverTimeout);
+    clearTimeout(closeTimeout);
+    setOpen(true);
+  }
+
+  function scheduleOpen() {
+    if (isDisabled()) return;
+    clearTimeout(closeTimeout);
+    clearTimeout(hoverTimeout);
+    hoverTimeout = setTimeout(open, delayMs);
+  }
+
+  function scheduleClose() {
+    clearTimeout(hoverTimeout);
+    clearTimeout(closeTimeout);
+    closeTimeout = setTimeout(() => {
+      if (isSafe()) return;
+      setOpen(false);
+    }, delayMs);
+  }
+
+  function cancelClose() {
+    clearTimeout(closeTimeout);
+  }
+
+  /** @type {(x: number, y: number) => void} */
+  function trackPointer(x, y) {
+    mousePosition = { x, y };
+    if (closeTimeout !== undefined && isSafe()) {
+      clearTimeout(closeTimeout);
+      closeTimeout = undefined;
+    }
+  }
+
+  function destroy() {
+    clearTimeout(hoverTimeout);
+    clearTimeout(closeTimeout);
+  }
+
+  return { open, scheduleOpen, scheduleClose, cancelClose, trackPointer, destroy };
+}

--- a/tests/Menu/MenuItem.preventDefault.test.svelte
+++ b/tests/Menu/MenuItem.preventDefault.test.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+  import Menu from "carbon-components-svelte/Menu/Menu.svelte";
+  import MenuItem from "carbon-components-svelte/Menu/MenuItem.svelte";
+
+  let anchor: HTMLButtonElement;
+  export let open = true;
+</script>
+
+<button type="button" bind:this={anchor} on:click={() => (open = !open)}>
+  Trigger
+</button>
+
+<Menu
+  {anchor}
+  bind:open
+  labelText="Example menu"
+  on:close={() => console.log("close")}
+>
+  <MenuItem
+    on:click={(event) => {
+      console.log("click", "Stay open");
+      event.preventDefault();
+    }}
+  >
+    Stay open
+  </MenuItem>
+  <MenuItem on:click={() => console.log("click", "Close menu")}>
+    Close menu
+  </MenuItem>
+</Menu>

--- a/tests/Menu/MenuItem.radio.test.svelte
+++ b/tests/Menu/MenuItem.radio.test.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import Menu from "carbon-components-svelte/Menu/Menu.svelte";
+  import MenuItem from "carbon-components-svelte/Menu/MenuItem.svelte";
+  import MenuItemRadioGroup from "carbon-components-svelte/Menu/MenuItemRadioGroup.svelte";
+
+  let anchor: HTMLButtonElement;
+  let open = false;
+  export let selectedId = "";
+</script>
+
+<button type="button" bind:this={anchor} on:click={() => (open = !open)}>
+  Trigger
+</button>
+
+<Menu {anchor} bind:open labelText="Example menu">
+  <MenuItemRadioGroup labelText="Alignment" bind:selectedId>
+    <MenuItem id="left" labelText="Left" />
+    <MenuItem id="center" labelText="Center" />
+    <MenuItem id="right" labelText="Right" />
+  </MenuItemRadioGroup>
+</Menu>

--- a/tests/Menu/MenuItem.selectable.test.svelte
+++ b/tests/Menu/MenuItem.selectable.test.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+  import Menu from "carbon-components-svelte/Menu/Menu.svelte";
+  import MenuItem from "carbon-components-svelte/Menu/MenuItem.svelte";
+
+  let anchor: HTMLButtonElement;
+  let open = false;
+  export let selected = false;
+</script>
+
+<button type="button" bind:this={anchor} on:click={() => (open = !open)}>
+  Trigger
+</button>
+
+<Menu {anchor} bind:open labelText="Example menu">
+  <MenuItem
+    selectable
+    bind:selected
+    labelText="Show grid"
+    on:click={() => console.log("click", "Show grid")}
+  />
+  <MenuItem labelText="Plain" />
+</Menu>

--- a/tests/Menu/MenuItem.shortcut.test.svelte
+++ b/tests/Menu/MenuItem.shortcut.test.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import Menu from "carbon-components-svelte/Menu/Menu.svelte";
+  import MenuItem from "carbon-components-svelte/Menu/MenuItem.svelte";
+  import Star from "carbon-icons-svelte/lib/Star.svelte";
+
+  let anchor: HTMLButtonElement;
+  let open = false;
+</script>
+
+<button type="button" bind:this={anchor} on:click={() => (open = !open)}>
+  Trigger
+</button>
+
+<Menu {anchor} bind:open labelText="Example menu">
+  <MenuItem labelText="Save" shortcutText="Ctrl+S" />
+  <MenuItem labelText="Custom icon">
+    <svelte:fragment slot="icon">
+      <Star data-testid="custom-icon" />
+    </svelte:fragment>
+  </MenuItem>
+</Menu>

--- a/tests/Menu/MenuItem.test.ts
+++ b/tests/Menu/MenuItem.test.ts
@@ -1,5 +1,9 @@
 import { fireEvent, render, screen } from "@testing-library/svelte";
 import { user } from "../utils/user";
+import MenuItemPreventDefault from "./MenuItem.preventDefault.test.svelte";
+import MenuItemRadio from "./MenuItem.radio.test.svelte";
+import MenuItemSelectable from "./MenuItem.selectable.test.svelte";
+import MenuItemShortcut from "./MenuItem.shortcut.test.svelte";
 import MenuItemSlot from "./MenuItem.slot.test.svelte";
 import MenuItemFixture from "./MenuItem.test.svelte";
 
@@ -202,6 +206,161 @@ describe("MenuItem", () => {
         "title",
         "Export as",
       );
+    });
+
+    it("does not close the submenu when the pointer crosses through the safe triangle", async () => {
+      vi.useFakeTimers();
+      try {
+        render(MenuItemFixture);
+
+        await fireEvent.click(screen.getByRole("button", { name: "Trigger" }));
+        const parent = screen.getByRole("menuitem", { name: "Export as" });
+        await fireEvent.mouseEnter(parent);
+        await vi.advanceTimersByTimeAsync(HOVER_DELAY_MS);
+
+        const submenu = screen.getByRole("menu", { name: "Export as" });
+        parent.getBoundingClientRect = () =>
+          ({ top: 100, left: 0, right: 100, bottom: 120, height: 20 }) as DOMRect;
+        submenu.getBoundingClientRect = () =>
+          ({ top: 100, left: 100, right: 300, bottom: 300, height: 200 }) as DOMRect;
+
+        await fireEvent.mouseLeave(parent);
+        // Inside the wedge between the trigger and the submenu's vertical center.
+        await fireEvent.mouseMove(parent, { clientX: 110, clientY: 200 });
+        await vi.advanceTimersByTimeAsync(HOVER_DELAY_MS);
+
+        expect(
+          screen.getByRole("menuitem", { name: "PDF" }),
+        ).toBeInTheDocument();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("closes the submenu when the pointer moves away from the safe triangle", async () => {
+      vi.useFakeTimers();
+      try {
+        render(MenuItemFixture);
+
+        await fireEvent.click(screen.getByRole("button", { name: "Trigger" }));
+        const parent = screen.getByRole("menuitem", { name: "Export as" });
+        await fireEvent.mouseEnter(parent);
+        await vi.advanceTimersByTimeAsync(HOVER_DELAY_MS);
+
+        const submenu = screen.getByRole("menu", { name: "Export as" });
+        parent.getBoundingClientRect = () =>
+          ({ top: 100, left: 0, right: 100, bottom: 120, height: 20 }) as DOMRect;
+        submenu.getBoundingClientRect = () =>
+          ({ top: 100, left: 100, right: 300, bottom: 300, height: 200 }) as DOMRect;
+
+        await fireEvent.mouseLeave(parent);
+        // Far outside the wedge.
+        await fireEvent.mouseMove(parent, { clientX: 105, clientY: 400 });
+        await vi.advanceTimersByTimeAsync(HOVER_DELAY_MS);
+
+        expect(
+          screen.queryByRole("menuitem", { name: "PDF" }),
+        ).not.toBeInTheDocument();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
+  describe("selectable", () => {
+    it("renders role menuitemcheckbox and toggles selected on click without closing the menu", async () => {
+      render(MenuItemSelectable);
+
+      await user.click(screen.getByRole("button", { name: "Trigger" }));
+      const item = screen.getByRole("menuitemcheckbox", { name: "Show grid" });
+      expect(item).toHaveAttribute("aria-checked", "false");
+
+      await user.click(item);
+
+      expect(item).toHaveAttribute("aria-checked", "true");
+      expect(
+        item.querySelector(".bx--menu-option__icon svg"),
+      ).toBeInTheDocument();
+      // Selecting a checkbox item keeps the menu open.
+      expect(screen.getByRole("menu")).toBeInTheDocument();
+    });
+
+    it("does not render a checkmark when unselected", async () => {
+      render(MenuItemSelectable, { props: { selected: false } });
+
+      await user.click(screen.getByRole("button", { name: "Trigger" }));
+      const item = screen.getByRole("menuitemcheckbox", { name: "Show grid" });
+
+      expect(item.querySelector(".bx--menu-option__icon svg")).toBeNull();
+      // The icon gutter is still reserved so the label stays aligned.
+      expect(item.querySelector(".bx--menu-option__icon")).toBeInTheDocument();
+    });
+  });
+
+  describe("shortcutText and icon slot", () => {
+    it("renders shortcut text at the trailing edge of the item", async () => {
+      render(MenuItemShortcut);
+
+      await user.click(screen.getByRole("button", { name: "Trigger" }));
+      const item = screen.getByRole("menuitem", { name: /^Save/ });
+
+      expect(item.querySelector(".bx--menu-option__info")).toHaveTextContent(
+        "Ctrl+S",
+      );
+    });
+
+    it("renders custom markup from the icon slot", async () => {
+      render(MenuItemShortcut);
+
+      await user.click(screen.getByRole("button", { name: "Trigger" }));
+
+      expect(screen.getByTestId("custom-icon")).toBeInTheDocument();
+    });
+  });
+
+  describe("radio", () => {
+    it("renders role menuitemradio and only checks the selected option", async () => {
+      render(MenuItemRadio, { props: { selectedId: "center" } });
+
+      await user.click(screen.getByRole("button", { name: "Trigger" }));
+
+      const left = screen.getByRole("menuitemradio", { name: "Left" });
+      const center = screen.getByRole("menuitemradio", { name: "Center" });
+      expect(left).toHaveAttribute("aria-checked", "false");
+      expect(center).toHaveAttribute("aria-checked", "true");
+    });
+
+    it("selecting an option updates the group and closes the menu", async () => {
+      render(MenuItemRadio, { props: { selectedId: "left" } });
+
+      await user.click(screen.getByRole("button", { name: "Trigger" }));
+      await user.click(screen.getByRole("menuitemradio", { name: "Right" }));
+
+      expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("preventDefault", () => {
+    it("keeps the menu open when a click handler calls preventDefault", async () => {
+      const consoleLog = vi.spyOn(console, "log");
+      render(MenuItemPreventDefault);
+
+      await user.click(screen.getByRole("menuitem", { name: "Stay open" }));
+
+      expect(consoleLog).toHaveBeenCalledWith("click", "Stay open");
+      expect(consoleLog).not.toHaveBeenCalledWith("close");
+      expect(screen.getByRole("menu")).toBeInTheDocument();
+    });
+
+    it("closes the menu normally when preventDefault is not called", async () => {
+      const consoleLog = vi.spyOn(console, "log");
+      render(MenuItemPreventDefault);
+
+      await user.click(screen.getByRole("menuitem", { name: "Close menu" }));
+
+      expect(consoleLog).toHaveBeenCalledWith("click", "Close menu");
+      expect(consoleLog).toHaveBeenCalledWith("close");
+      expect(screen.queryByRole("menu")).not.toBeInTheDocument();
     });
   });
 });

--- a/tests/utils/floatingPosition.test.ts
+++ b/tests/utils/floatingPosition.test.ts
@@ -84,6 +84,54 @@ describe("floatingPosition", () => {
     });
   });
 
+  describe("vertical viewport clamping (left/right direction)", () => {
+    test("shifts up when a bottom-anchored right placement would overflow the bottom edge", () => {
+      const result = floatingPosition({
+        anchorRect: rect(100, 780, 100, 20), // near the bottom of an 800px viewport
+        floatingRect: rect(0, 0, 150, 200),
+        viewport,
+        direction: "right",
+      });
+
+      expect(result.actualDirection).toBe("right");
+      expect(result.top).toBe(600); // clamped so top + height (200) === innerHeight (800)
+    });
+
+    test("does not shift when the content already fits", () => {
+      const result = floatingPosition({
+        anchorRect: rect(100, 200, 100, 20),
+        floatingRect: rect(0, 0, 150, 200),
+        viewport,
+        direction: "right",
+      });
+
+      expect(result.top).toBe(110); // centered: 200 + 20/2 - 200/2
+    });
+
+    test("prefers the top viewport edge when content is taller than the viewport", () => {
+      const result = floatingPosition({
+        anchorRect: rect(100, 400, 100, 20),
+        floatingRect: rect(0, 0, 150, 1200),
+        viewport,
+        direction: "left",
+      });
+
+      expect(result.top).toBe(0);
+    });
+
+    test("clamps the primary axis too when content fits on neither side", () => {
+      const narrowViewport = { ...viewport, innerWidth: 200 };
+      const result = floatingPosition({
+        anchorRect: rect(50, 100, 100, 20),
+        floatingRect: rect(0, 0, 250, 200), // wider than the 200px viewport
+        viewport: narrowViewport,
+        direction: "right",
+      });
+
+      expect(result.left).toBe(0);
+    });
+  });
+
   describe("auto-flip", () => {
     test("bottom flips to top when there is more room above", () => {
       const result = floatingPosition({
@@ -231,6 +279,123 @@ describe("floatingPosition", () => {
       // the CSS, so the caret stays centered on the trigger regardless of the
       // floating width.
       expect(result.caretNudgePx).toBe(75);
+    });
+  });
+
+  describe("horizontal viewport clamping (intrinsic width, vertical direction)", () => {
+    test("shifts left when start-aligned content would overflow the right edge", () => {
+      const result = floatingPosition({
+        anchorRect: rect(950, 200, 0, 20), // zero-width point anchor near right edge
+        floatingRect: rect(0, 0, 200, 150),
+        viewport,
+        direction: "bottom",
+        intrinsicWidth: true,
+        intrinsicAlign: "start",
+      });
+
+      expect(result.left).toBe(800); // clamped so left + width (200) === innerWidth (1000)
+    });
+
+    test("does not shift when the content already fits", () => {
+      const result = floatingPosition({
+        anchorRect: rect(300, 200, 0, 20),
+        floatingRect: rect(0, 0, 200, 150),
+        viewport,
+        direction: "bottom",
+        intrinsicWidth: true,
+        intrinsicAlign: "start",
+      });
+
+      expect(result.left).toBe(300);
+    });
+
+    test("shifts right when the content would overflow the left edge", () => {
+      const result = floatingPosition({
+        anchorRect: rect(-50, 200, 0, 20),
+        floatingRect: rect(0, 0, 200, 150),
+        viewport,
+        direction: "bottom",
+        intrinsicWidth: true,
+        intrinsicAlign: "start",
+      });
+
+      expect(result.left).toBe(0);
+    });
+
+    test("accounts for the CSS translateX(-50%) applied to center-aligned content", () => {
+      const result = floatingPosition({
+        anchorRect: rect(950, 200, 0, 20), // anchor center = 950
+        floatingRect: rect(0, 0, 200, 150),
+        viewport,
+        direction: "bottom",
+        intrinsicWidth: true,
+        intrinsicAlign: "center",
+      });
+
+      // True left edge after translateX(-50%) is (left - 100); clamp that to
+      // maxLeft (800), so the returned anchor-relative left is 800 + 100.
+      expect(result.left).toBe(900);
+    });
+
+    test("accounts for the CSS translateX(-100%) applied to end-aligned content", () => {
+      const result = floatingPosition({
+        anchorRect: rect(50, 200, 0, 20), // anchor right edge = 50
+        floatingRect: rect(0, 0, 200, 150),
+        viewport,
+        direction: "bottom",
+        intrinsicWidth: true,
+        intrinsicAlign: "end",
+      });
+
+      // True left edge after translateX(-100%) is (left - 200); clamp that to
+      // minLeft (0), so the returned anchor-relative left is 0 + 200.
+      expect(result.left).toBe(200);
+    });
+
+    test("shifts the caret nudge to keep pointing at the anchor after clamping", () => {
+      const result = floatingPosition({
+        anchorRect: rect(950, 200, 100, 20), // anchor width 100, center at 1000
+        floatingRect: rect(0, 0, 200, 150),
+        viewport,
+        direction: "bottom",
+        intrinsicWidth: true,
+        intrinsicAlign: "start",
+      });
+
+      // Box shifted left by 150 (950 -> 800) to fit, but the anchor (and its
+      // center) didn't move - the caret nudge grows by the same 150 so it
+      // still points at the anchor center instead of drifting with the box.
+      expect(result.left).toBe(800);
+      expect(result.caretNudgePx).toBe(200);
+    });
+
+    test("prefers the left viewport edge when content is wider than the viewport", () => {
+      const result = floatingPosition({
+        anchorRect: rect(500, 200, 0, 20),
+        floatingRect: rect(0, 0, 1200, 150),
+        viewport,
+        direction: "bottom",
+        intrinsicWidth: true,
+        intrinsicAlign: "start",
+      });
+
+      expect(result.left).toBe(0);
+    });
+
+    test("clamps using scroll offset when not using fixed position", () => {
+      const scrolled = { ...viewport, scrollX: 100 };
+      const result = floatingPosition({
+        anchorRect: rect(950, 200, 0, 20),
+        floatingRect: rect(0, 0, 200, 150),
+        viewport: scrolled,
+        direction: "bottom",
+        intrinsicWidth: true,
+        intrinsicAlign: "start",
+        useFixedPosition: false,
+      });
+
+      // maxLeft = scrollX (100) + innerWidth (1000) - width (200) = 900
+      expect(result.left).toBe(900);
     });
   });
 

--- a/tests/utils/isInSafeTriangle.test.ts
+++ b/tests/utils/isInSafeTriangle.test.ts
@@ -1,0 +1,43 @@
+import { isInSafeTriangle } from "../../src/utils/isInSafeTriangle.js";
+
+describe("isInSafeTriangle", () => {
+  // Trigger row (fromRect) flush against a taller submenu (toRect) opening to
+  // the right - the common case where a Menu submenu renders with zero gap.
+  const fromRect = { top: 100, left: 0, right: 100, bottom: 120, height: 20 };
+  const toRect = { top: 100, left: 100, right: 300, bottom: 300, height: 200 };
+
+  it("returns true just past the trigger's edge, near the trigger's own row", () => {
+    expect(isInSafeTriangle(105, 110, fromRect, toRect)).toBe(true);
+  });
+
+  it("returns true near the submenu's vertical center, further from the edge", () => {
+    expect(isInSafeTriangle(110, 200, fromRect, toRect)).toBe(true);
+  });
+
+  it("returns false for a point outside the wedge (mid-height, away from the edge)", () => {
+    expect(isInSafeTriangle(110, 150, fromRect, toRect)).toBe(false);
+  });
+
+  it("returns false for a point far past the submenu's bottom", () => {
+    expect(isInSafeTriangle(105, 400, fromRect, toRect)).toBe(false);
+  });
+
+  it("returns false for a point still inside the trigger, left of the wedge", () => {
+    expect(isInSafeTriangle(50, 110, fromRect, toRect)).toBe(false);
+  });
+
+  it("mirrors the wedge when the submenu opens to the left", () => {
+    const leftToRect = { top: 100, left: -300, right: -100, bottom: 300, height: 200 };
+    const leftFromRect = { top: 100, left: -100, right: 0, bottom: 120, height: 20 };
+    expect(isInSafeTriangle(-105, 200, leftFromRect, leftToRect)).toBe(true);
+    expect(isInSafeTriangle(-105, 400, leftFromRect, leftToRect)).toBe(false);
+  });
+
+  it("shifts the safe zone once a real gap separates the two rects", () => {
+    const gappedToRect = { top: 100, left: 140, right: 340, bottom: 300, height: 200 };
+    // A point that succeeds against the flush toRect can fall outside the
+    // wedge once a real gap pushes the near edge further from the trigger.
+    expect(isInSafeTriangle(110, 150, fromRect, gappedToRect)).toBe(true);
+    expect(isInSafeTriangle(115, 150, fromRect, gappedToRect)).toBe(false);
+  });
+});

--- a/tests/utils/submenuHoverController.test.ts
+++ b/tests/utils/submenuHoverController.test.ts
@@ -1,0 +1,161 @@
+import { createSubmenuHoverController } from "../../src/utils/submenuHoverController.js";
+
+const DELAY_MS = 150;
+
+/** Minimal DOM-like stand-in with a stubbed rect. */
+function fakeElement(rect: {
+  top: number;
+  left: number;
+  right: number;
+  bottom: number;
+  height: number;
+}) {
+  return { getBoundingClientRect: () => rect as DOMRect };
+}
+
+describe("createSubmenuHoverController", () => {
+  // Trigger flush against a submenu opening to the right (matches the
+  // isInSafeTriangle fixture already validated elsewhere).
+  const trigger = fakeElement({ top: 100, left: 0, right: 100, bottom: 120, height: 20 });
+  const submenu = fakeElement({ top: 100, left: 100, right: 300, bottom: 300, height: 200 });
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("opens after the hover delay", async () => {
+    const setOpen = vi.fn();
+    const controller = createSubmenuHoverController({
+      isDisabled: () => false,
+      setOpen,
+      getTrigger: () => trigger,
+      getSubmenu: () => submenu,
+      delayMs: DELAY_MS,
+    });
+
+    controller.scheduleOpen();
+    expect(setOpen).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(DELAY_MS);
+    expect(setOpen).toHaveBeenCalledWith(true);
+  });
+
+  it("does not schedule an open when disabled", async () => {
+    const setOpen = vi.fn();
+    const controller = createSubmenuHoverController({
+      isDisabled: () => true,
+      setOpen,
+      getTrigger: () => trigger,
+      getSubmenu: () => submenu,
+      delayMs: DELAY_MS,
+    });
+
+    controller.scheduleOpen();
+    await vi.advanceTimersByTimeAsync(DELAY_MS);
+    expect(setOpen).not.toHaveBeenCalled();
+  });
+
+  it("open() opens immediately regardless of pending timers", () => {
+    const setOpen = vi.fn();
+    const controller = createSubmenuHoverController({
+      isDisabled: () => false,
+      setOpen,
+      getTrigger: () => trigger,
+      getSubmenu: () => submenu,
+      delayMs: DELAY_MS,
+    });
+
+    controller.open();
+    expect(setOpen).toHaveBeenCalledWith(true);
+  });
+
+  it("closes after the delay when the pointer is not in the safe triangle", async () => {
+    const setOpen = vi.fn();
+    const controller = createSubmenuHoverController({
+      isDisabled: () => false,
+      setOpen,
+      getTrigger: () => trigger,
+      getSubmenu: () => submenu,
+      delayMs: DELAY_MS,
+    });
+
+    controller.trackPointer(105, 400); // far outside the wedge
+    controller.scheduleClose();
+    await vi.advanceTimersByTimeAsync(DELAY_MS);
+
+    expect(setOpen).toHaveBeenCalledWith(false);
+  });
+
+  it("does not close when the pointer is in the safe triangle at fire time", async () => {
+    const setOpen = vi.fn();
+    const controller = createSubmenuHoverController({
+      isDisabled: () => false,
+      setOpen,
+      getTrigger: () => trigger,
+      getSubmenu: () => submenu,
+      delayMs: DELAY_MS,
+    });
+
+    controller.trackPointer(110, 200); // inside the wedge toward the submenu's vertical center
+    controller.scheduleClose();
+    await vi.advanceTimersByTimeAsync(DELAY_MS);
+
+    expect(setOpen).not.toHaveBeenCalled();
+  });
+
+  it("cancelClose prevents a pending close from firing", async () => {
+    const setOpen = vi.fn();
+    const controller = createSubmenuHoverController({
+      isDisabled: () => false,
+      setOpen,
+      getTrigger: () => trigger,
+      getSubmenu: () => submenu,
+      delayMs: DELAY_MS,
+    });
+
+    controller.scheduleClose();
+    controller.cancelClose();
+    await vi.advanceTimersByTimeAsync(DELAY_MS);
+
+    expect(setOpen).not.toHaveBeenCalled();
+  });
+
+  it("trackPointer cancels a pending close early once the pointer becomes safe", async () => {
+    const setOpen = vi.fn();
+    const controller = createSubmenuHoverController({
+      isDisabled: () => false,
+      setOpen,
+      getTrigger: () => trigger,
+      getSubmenu: () => submenu,
+      delayMs: DELAY_MS,
+    });
+
+    controller.trackPointer(105, 400); // starts unsafe
+    controller.scheduleClose();
+    controller.trackPointer(110, 200); // moves into the wedge before the delay elapses
+    await vi.advanceTimersByTimeAsync(DELAY_MS);
+
+    expect(setOpen).not.toHaveBeenCalled();
+  });
+
+  it("destroy clears pending open and close timers", async () => {
+    const setOpen = vi.fn();
+    const controller = createSubmenuHoverController({
+      isDisabled: () => false,
+      setOpen,
+      getTrigger: () => trigger,
+      getSubmenu: () => submenu,
+      delayMs: DELAY_MS,
+    });
+
+    controller.scheduleOpen();
+    controller.destroy();
+    await vi.advanceTimersByTimeAsync(DELAY_MS);
+
+    expect(setOpen).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
- Extracts `isInSafeTriangle` and `submenuHoverController` as standalone utils for diagonal-hover submenu intent.
- Brings `MenuItem` to feature parity with `ContextMenuOption`: selectable (checkbox) variant, radio variant via new `MenuItemRadioGroup`, indented/shortcutText/named icon slot props, and safe-triangle hover intent for submenus.
- Fixes `floatingPosition` to clamp to the viewport on all four directions (top/bottom now account for horizontal overflow, left/right for vertical overflow and primary-axis fallback). Affects Tooltip, Toggletip, TooltipDefinition, the ListBox family, OverflowMenu, and SearchMenu.

Cherry-picked from `metonym/contextmenu-menu-primitive-refactor`, which also attempted to port `ContextMenu` onto these `Menu`/`MenuItem` primitives — that part didn't land cleanly and is intentionally excluded here. This PR contains only the safe, self-contained prep work (utils + Menu/MenuItem).
