### PR TITLE
docs: remove 80-column prose wrap from generated markdown

### DIFF
--- a/docs/scripts/generate-md-docs.ts
+++ b/docs/scripts/generate-md-docs.ts
@@ -673,8 +673,7 @@ async function formatMarkdown(markdown: string) {
   try {
     const formatted = await prettierFormat(markdown, {
       parser: "markdown",
-      proseWrap: "always",
-      printWidth: 80,
+      proseWrap: "never",
     });
     return `${String(formatted).trimEnd()}\n`;
   } catch {


### PR DESCRIPTION
## Summary

Removes the 80-column `proseWrap`/`printWidth` constraint in `formatMarkdown` so generated component docs and `llms-full.txt` no longer hard-wrap prose. This shrinks output size with no loss of content (tables and code fences are unaffected), while still being human-readable.

| Output | Before | After | Saved |
| --- | --- | --- | --- |
| `public/components/*.md` | 1,700,884 B | 1,158,084 B | 31.9% |
| `public/llms-full.txt` | 1,710,758 B | 1,167,944 B | 31.7% |
| `public/llms.txt` | 7,139 B | 7,139 B | 0% |
