### PR TITLE
chore: forward native events on ComboButton/MenuButton triggers

### DIFF
--- a/docs/src/pages/components/ComboButton.svx
+++ b/docs/src/pages/components/ComboButton.svx
@@ -11,7 +11,7 @@ description: ComboButton pairs a primary action with a menu of related secondary
 
 ## Basic
 
-Wrap `MenuItem` components in `ComboButton` and set `labelText` for the primary action button. Use the `labelChildren` slot for custom button content. Clicking the label fires `on:click`; clicking the chevron trigger opens the menu and fires the separate `on:click:trigger` event.
+Wrap `MenuItem` components in `ComboButton` and set `labelText` for the primary action button. Use the `labelChildren` slot for custom button content. Clicking the label fires `on:click`; clicking the chevron trigger opens the menu and fires the separate `on:click:trigger` event. The trigger's other native events (`mousedown`, `focus`, `blur`, `mouseover`, `mouseenter`, `mouseleave`) dispatch the same way, each with a `:trigger`-suffixed counterpart alongside the shared, unscoped event.
 
 <ComboButton labelText="Save">
   <MenuItem on:click={() => console.log("Save as")}>Save as</MenuItem>

--- a/docs/src/pages/components/ComboButton.svx
+++ b/docs/src/pages/components/ComboButton.svx
@@ -11,7 +11,7 @@ description: ComboButton pairs a primary action with a menu of related secondary
 
 ## Basic
 
-Wrap `MenuItem` components in `ComboButton` and set `labelText` for the primary action button. Use the `labelChildren` slot for custom button content. Clicking the label fires `on:click`; clicking the chevron trigger opens the menu.
+Wrap `MenuItem` components in `ComboButton` and set `labelText` for the primary action button. Use the `labelChildren` slot for custom button content. Clicking the label fires `on:click`; clicking the chevron trigger opens the menu and fires the separate `on:click:trigger` event.
 
 <ComboButton labelText="Save">
   <MenuItem on:click={() => console.log("Save as")}>Save as</MenuItem>

--- a/src/ComboButton/ComboButton.svelte
+++ b/src/ComboButton/ComboButton.svelte
@@ -1,9 +1,13 @@
 <script>
   /**
    * @event {MouseEvent} click
-   */
-
-  /**
+   * @event {MouseEvent} click:trigger - Fires when the menu trigger button is clicked, separate from the primary action's `click` event.
+   * @event {MouseEvent} mousedown
+   * @event {FocusEvent} focus
+   * @event {FocusEvent} blur
+   * @event {MouseEvent} mouseover
+   * @event {MouseEvent} mouseenter
+   * @event {MouseEvent} mouseleave
    * @event close
    * @type {object}
    * @property {"escape-key" | "outside-click" | "select"} trigger
@@ -73,9 +77,12 @@
    */
   export let ref = null;
 
+  import { createEventDispatcher } from "svelte";
   import Button from "../Button/Button.svelte";
   import ChevronDown from "../icons/ChevronDown.svelte";
   import Menu from "../Menu/Menu.svelte";
+
+  const dispatch = createEventDispatcher();
 
   /**
    * Button's own "default"/"lg" naming is offset from the v11 size scale:
@@ -99,6 +106,7 @@
   function toggleOpen(event) {
     const wasOpen = open;
     open = !open;
+    dispatch("click:trigger", event);
     // A keyboard-activated click (Enter/Space) reports detail 0; a real mouse
     // click reports 1+. Blur only after a mouse-driven close, so the trigger
     // doesn't linger with a visible focus ring and pop its own tooltip -
@@ -122,6 +130,12 @@
     class="bx--combo-button__primary-action"
     aria-label={$$restProps["aria-label"] ?? labelText}
     on:click
+    on:mousedown
+    on:focus
+    on:blur
+    on:mouseover
+    on:mouseenter
+    on:mouseleave
   >
     <slot name="labelChildren">{labelText}</slot>
   </Button>
@@ -140,7 +154,13 @@
     aria-haspopup="menu"
     aria-expanded={open}
     on:mousedown={(event) => event.preventDefault()}
+    on:mousedown
     on:click={toggleOpen}
+    on:focus
+    on:blur
+    on:mouseover
+    on:mouseenter
+    on:mouseleave
   />
   <Menu
     anchor={triggerRef}

--- a/src/ComboButton/ComboButton.svelte
+++ b/src/ComboButton/ComboButton.svelte
@@ -3,11 +3,17 @@
    * @event {MouseEvent} click
    * @event {MouseEvent} click:trigger - Fires when the menu trigger button is clicked, separate from the primary action's `click` event.
    * @event {MouseEvent} mousedown
+   * @event {MouseEvent} mousedown:trigger
    * @event {FocusEvent} focus
+   * @event {FocusEvent} focus:trigger
    * @event {FocusEvent} blur
+   * @event {FocusEvent} blur:trigger
    * @event {MouseEvent} mouseover
+   * @event {MouseEvent} mouseover:trigger
    * @event {MouseEvent} mouseenter
+   * @event {MouseEvent} mouseenter:trigger
    * @event {MouseEvent} mouseleave
+   * @event {MouseEvent} mouseleave:trigger
    * @event close
    * @type {object}
    * @property {"escape-key" | "outside-click" | "select"} trigger
@@ -101,6 +107,13 @@
   let triggerRef = null;
 
   /**
+   * @type {(name: string) => (event: Event) => void}
+   */
+  function dispatchTriggerEvent(name) {
+    return (event) => dispatch(`${name}:trigger`, event);
+  }
+
+  /**
    * @type {(event: MouseEvent) => void}
    */
   function toggleOpen(event) {
@@ -155,12 +168,18 @@
     aria-expanded={open}
     on:mousedown={(event) => event.preventDefault()}
     on:mousedown
+    on:mousedown={dispatchTriggerEvent("mousedown")}
     on:click={toggleOpen}
     on:focus
+    on:focus={dispatchTriggerEvent("focus")}
     on:blur
+    on:blur={dispatchTriggerEvent("blur")}
     on:mouseover
+    on:mouseover={dispatchTriggerEvent("mouseover")}
     on:mouseenter
+    on:mouseenter={dispatchTriggerEvent("mouseenter")}
     on:mouseleave
+    on:mouseleave={dispatchTriggerEvent("mouseleave")}
   />
   <Menu
     anchor={triggerRef}

--- a/src/MenuButton/MenuButton.svelte
+++ b/src/MenuButton/MenuButton.svelte
@@ -1,9 +1,12 @@
 <script>
   /**
    * @event {MouseEvent} click
-   */
-
-  /**
+   * @event {MouseEvent} mousedown
+   * @event {FocusEvent} focus
+   * @event {FocusEvent} blur
+   * @event {MouseEvent} mouseover
+   * @event {MouseEvent} mouseenter
+   * @event {MouseEvent} mouseleave
    * @event close
    * @type {object}
    * @property {"escape-key" | "outside-click" | "select"} trigger
@@ -113,8 +116,14 @@
   aria-expanded={open}
   aria-label={$$restProps["aria-label"] ?? labelText}
   on:mousedown={(event) => event.preventDefault()}
+  on:mousedown
   on:click
   on:click={toggle}
+  on:focus
+  on:blur
+  on:mouseover
+  on:mouseenter
+  on:mouseleave
 >
   <slot name="labelChildren">{labelText}</slot>
 </Button>

--- a/tests/ComboButton/ComboButton.test.svelte
+++ b/tests/ComboButton/ComboButton.test.svelte
@@ -25,6 +25,8 @@
   {iconDescription}
   bind:open
   on:click={() => console.log("click")}
+  on:click:trigger={() => console.log("click:trigger")}
+  on:mouseenter={() => console.log("mouseenter")}
   on:close={(e) => console.log("close", e.detail)}
 >
   {#each items as text}

--- a/tests/ComboButton/ComboButton.test.svelte
+++ b/tests/ComboButton/ComboButton.test.svelte
@@ -27,6 +27,7 @@
   on:click={() => console.log("click")}
   on:click:trigger={() => console.log("click:trigger")}
   on:mouseenter={() => console.log("mouseenter")}
+  on:mouseenter:trigger={() => console.log("mouseenter:trigger")}
   on:close={(e) => console.log("close", e.detail)}
 >
   {#each items as text}

--- a/tests/ComboButton/ComboButton.test.ts
+++ b/tests/ComboButton/ComboButton.test.ts
@@ -41,6 +41,20 @@ describe("ComboButton", () => {
     expect(consoleLog).toHaveBeenCalledWith("mouseenter");
   });
 
+  it("dispatches mouseenter:trigger only from the trigger, not the primary action", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(ComboButtonFixture);
+
+    const primaryAction = screen.getByRole("button", { name: "Save" });
+    const trigger = screen.getByRole("button", { name: "Additional actions" });
+
+    await fireEvent.mouseEnter(primaryAction);
+    expect(consoleLog).not.toHaveBeenCalledWith("mouseenter:trigger");
+
+    await fireEvent.mouseEnter(trigger);
+    expect(consoleLog).toHaveBeenCalledWith("mouseenter:trigger");
+  });
+
   it("opens and closes the menu from the icon-only trigger", async () => {
     render(ComboButtonFixture);
 

--- a/tests/ComboButton/ComboButton.test.ts
+++ b/tests/ComboButton/ComboButton.test.ts
@@ -14,6 +14,33 @@ describe("ComboButton", () => {
     expect(screen.queryByRole("menu")).not.toBeInTheDocument();
   });
 
+  it("dispatches click:trigger when the menu trigger is clicked, independent of click", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(ComboButtonFixture);
+
+    await user.click(
+      screen.getByRole("button", { name: "Additional actions" }),
+    );
+
+    expect(consoleLog).toHaveBeenCalledWith("click:trigger");
+    expect(consoleLog).not.toHaveBeenCalledWith("click");
+  });
+
+  it("forwards mouseenter from both the primary action and the trigger", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(ComboButtonFixture);
+
+    const primaryAction = screen.getByRole("button", { name: "Save" });
+    const trigger = screen.getByRole("button", { name: "Additional actions" });
+
+    await fireEvent.mouseEnter(primaryAction);
+    expect(consoleLog).toHaveBeenCalledWith("mouseenter");
+
+    consoleLog.mockClear();
+    await fireEvent.mouseEnter(trigger);
+    expect(consoleLog).toHaveBeenCalledWith("mouseenter");
+  });
+
   it("opens and closes the menu from the icon-only trigger", async () => {
     render(ComboButtonFixture);
 

--- a/tests/MenuButton/MenuButton.test.svelte
+++ b/tests/MenuButton/MenuButton.test.svelte
@@ -18,6 +18,7 @@
   {disabled}
   bind:open
   on:click={() => console.log("click")}
+  on:mouseenter={() => console.log("mouseenter")}
   on:close={(e) => console.log("close", e.detail)}
 >
   {#each items as text}

--- a/tests/MenuButton/MenuButton.test.ts
+++ b/tests/MenuButton/MenuButton.test.ts
@@ -19,6 +19,15 @@ describe("MenuButton", () => {
     expect(trigger).toHaveAttribute("aria-expanded", "false");
   });
 
+  it("forwards mouseenter from the trigger", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(MenuButtonFixture);
+
+    await fireEvent.mouseEnter(screen.getByRole("button", { name: "Actions" }));
+
+    expect(consoleLog).toHaveBeenCalledWith("mouseenter");
+  });
+
   it("renders the disabled state on the trigger", () => {
     render(MenuButtonFixture, { props: { disabled: true } });
 


### PR DESCRIPTION
## Summary

- `ComboButton`'s primary action and trigger buttons now forward `mousedown`/`focus`/`blur`/`mouseover`/`mouseenter`/`mouseleave`, matching `Button`'s own forwarded set. The trigger's click was previously unobservable from outside; it now dispatches a separate `click:trigger` event so consumers can react to it without conflating it with the primary action's `click`.
- `MenuButton`'s trigger button gets the same native event forwarding, for parity. It has only one button, so plain `click` already unambiguously identifies the trigger and needs no separate scoped event.