### PR TITLE
chore(deps-dev): upgrade `sveld` to 0.35.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -25,7 +25,7 @@
         "jsdom": "^29.1.1",
         "lightningcss": "^1.32.0",
         "sass-embedded": "^1.100.0",
-        "sveld": "^0.34.1",
+        "sveld": "^0.35.0",
         "svelte": "^5.56.3",
         "svelte-check": "^4.6.0",
         "typescript": "^6.0.3",
@@ -459,8 +459,6 @@
 
     "postcss": ["postcss@8.5.15", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A=="],
 
-    "prettier": ["prettier@3.8.4", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q=="],
-
     "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
@@ -533,7 +531,7 @@
 
     "supports-color": ["supports-color@8.1.1", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q=="],
 
-    "sveld": ["sveld@0.34.1", "", { "dependencies": { "prettier": "^3.8.4" }, "bin": { "sveld": "cli.js" } }, "sha512-xmxN3/kG5kfIdBi4iCQ8PGneAbnD1nxddIaeL1C9ihQTkdw4WEmaVrS9dHFjsyFkEUvxsR0UQHh9NKqG77GyBQ=="],
+    "sveld": ["sveld@0.35.0", "", { "bin": { "sveld": "cli.js" } }, "sha512-Sey7hqf661/fr26aRu45ED7WMM40g/HzzEJK9wrL7jTNbOJ5aSumdq3R4OAehkxegGIVMrijEPYOokgTecLvAQ=="],
 
     "svelte": ["svelte@5.56.3", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "@jridgewell/sourcemap-codec": "^1.5.0", "@sveltejs/acorn-typescript": "^1.0.10", "@types/estree": "^1.0.5", "@types/trusted-types": "^2.0.7", "acorn": "^8.12.1", "aria-query": "5.3.1", "axobject-query": "^4.1.0", "clsx": "^2.1.1", "devalue": "^5.8.1", "esm-env": "^1.2.1", "esrap": "^2.2.11", "is-reference": "^3.0.3", "locate-character": "^3.0.0", "magic-string": "^0.30.11", "zimmerframe": "^1.1.2" } }, "sha512-w7JvrM5IFl5cmfbY0TLik9o7mjRUJmRMhOR51tBPu708Gr/MjbGs7VnJnr/B0CaXeI4vtnOh7RKxDr0cwhMdDA=="],
 

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "jsdom": "^29.1.1",
     "lightningcss": "^1.32.0",
     "sass-embedded": "^1.100.0",
-    "sveld": "^0.34.1",
+    "sveld": "^0.35.0",
     "svelte": "^5.56.3",
     "svelte-check": "^4.6.0",
     "typescript": "^6.0.3",

--- a/scripts/build-docs.ts
+++ b/scripts/build-docs.ts
@@ -1,10 +1,5 @@
-import { createHash } from "node:crypto";
-import { access, mkdir, readFile, writeFile } from "node:fs/promises";
-import { $, Glob } from "bun";
+import { $ } from "bun";
 import { sveld } from "sveld";
-
-const CACHE_DIR = ".cache/build-docs";
-const CACHE_FILE = `${CACHE_DIR}/input.hash`;
 
 const SVELD_OPTIONS = {
   glob: true,
@@ -17,81 +12,9 @@ const SVELD_OPTIONS = {
   },
 };
 
-function collectInputFiles(): string[] {
-  const files = new Set<string>();
-
-  for (const file of new Glob("**/*.svelte").scanSync({ cwd: "src" })) {
-    files.add(file);
-  }
-
-  for (const file of new Glob("**/*.d.ts").scanSync({ cwd: "src" })) {
-    if (file.endsWith(".svelte.d.ts") || file === "index.d.ts") continue;
-    files.add(file);
-  }
-
-  for (const file of new Glob("**/index.js").scanSync({ cwd: "src" })) {
-    files.add(file);
-  }
-
-  return [...files].sort();
-}
-
-async function sharedInputs(): Promise<string> {
-  const packageJson = JSON.parse(await readFile("package.json", "utf8")) as {
-    devDependencies?: { sveld?: string };
-  };
-
-  return [
-    packageJson.devDependencies?.sveld ?? "",
-    JSON.stringify(SVELD_OPTIONS),
-  ].join("\0");
-}
-
-async function computeInputHash(): Promise<string> {
-  const files = collectInputFiles();
-  const contents = await Promise.all(
-    files.map(async (file) => ({
-      file,
-      contents: await readFile(`src/${file}`, "utf8"),
-    })),
-  );
-  const hash = createHash("sha256");
-
-  for (const { file, contents: fileContents } of contents) {
-    hash.update(file);
-    hash.update("\0");
-    hash.update(fileContents);
-    hash.update("\0");
-  }
-
-  hash.update(await sharedInputs());
-  return hash.digest("hex");
-}
-
-async function isCached(hash: string): Promise<boolean> {
-  try {
-    const cachedHash = (await readFile(CACHE_FILE, "utf8")).trim();
-    if (cachedHash !== hash) return false;
-    await access("docs/src/COMPONENT_API.json");
-    await access("src/index.d.ts");
-    return true;
-  } catch {
-    return false;
-  }
-}
-
 console.time("[build-docs]");
 
-await mkdir(CACHE_DIR, { recursive: true });
-
-const hash = await computeInputHash();
-
-if (await isCached(hash)) {
-  console.log("[build-docs] (cached)");
-} else {
-  await $`rm -f src/index.d.ts && find src -name "*.svelte.d.ts" -delete`;
-  await sveld(SVELD_OPTIONS);
-  await writeFile(CACHE_FILE, `${hash}\n`);
-}
+await $`rm -f src/index.d.ts && find src -name "*.svelte.d.ts" -delete`;
+await sveld(SVELD_OPTIONS);
 
 console.timeEnd("[build-docs]");


### PR DESCRIPTION
Upgrades `sveld` to [0.35.0](https://github.com/carbon-design-system/sveld/releases/tag/v0.35.0), which has caching enabled by default, ~16x faster output writes (Prettier removed).