### PR TITLE
fix(structured-list): stop mixing table and radio/checkbox ARIA roles

### DIFF
--- a/e2e/structured-list.test.ts
+++ b/e2e/structured-list.test.ts
@@ -7,7 +7,7 @@ test.describe("StructuredList", () => {
 
   test("renders structured list", async ({ page }) => {
     await expect(page.getByTestId("structured-list")).toBeVisible();
-    await expect(page.getByRole("table")).toBeVisible();
+    await expect(page.getByRole("radiogroup")).toBeVisible();
     await expect(page.getByText("Row A")).toBeVisible();
     await expect(page.getByText("Row B")).toBeVisible();
   });

--- a/src/StructuredList/StructuredList.svelte
+++ b/src/StructuredList/StructuredList.svelte
@@ -88,7 +88,7 @@
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
 <div
-  role="table"
+  role={selection ? undefined : "table"}
   class:bx--structured-list={true}
   class:bx--structured-list--selection={selection}
   class:bx--structured-list--condensed={condensed}

--- a/src/StructuredList/StructuredListBody.svelte
+++ b/src/StructuredList/StructuredListBody.svelte
@@ -1,7 +1,15 @@
+<script>
+  import { getContext } from "svelte";
+
+  const ctx = getContext("carbon:StructuredListWrapper");
+  const selection = ctx?.selection ?? false;
+  const multiple = ctx?.multiple ?? false;
+</script>
+
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
 <div
-  role="rowgroup"
+  role={selection ? (multiple ? "group" : "radiogroup") : "rowgroup"}
   class:bx--structured-list-tbody={true}
   {...$$restProps}
   on:click

--- a/src/StructuredList/StructuredListCell.svelte
+++ b/src/StructuredList/StructuredListCell.svelte
@@ -4,11 +4,16 @@
 
   /** Set to `true` to prevent wrapping */
   export let noWrap = false;
+
+  import { getContext } from "svelte";
+
+  const ctx = getContext("carbon:StructuredListWrapper");
+  const selection = ctx?.selection ?? false;
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <div
-  role={head ? "columnheader" : "cell"}
+  role={selection ? undefined : head ? "columnheader" : "cell"}
   class:bx--structured-list-th={head}
   class:bx--structured-list-td={!head}
   class:bx--structured-list-content--nowrap={noWrap}

--- a/src/StructuredList/StructuredListHead.svelte
+++ b/src/StructuredList/StructuredListHead.svelte
@@ -1,7 +1,14 @@
+<script>
+  import { getContext } from "svelte";
+
+  const ctx = getContext("carbon:StructuredListWrapper");
+  const selection = ctx?.selection ?? false;
+</script>
+
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
 <div
-  role="rowgroup"
+  role={selection ? undefined : "rowgroup"}
   class:bx--structured-list-thead={true}
   {...$$restProps}
   on:click

--- a/src/StructuredList/StructuredListRow.svelte
+++ b/src/StructuredList/StructuredListRow.svelte
@@ -79,7 +79,7 @@
 {:else}
   <!-- svelte-ignore a11y-interactive-supports-focus -->
   <div
-    role="row"
+    role={selection ? undefined : "row"}
     class:bx--structured-list-row={true}
     class:bx--structured-list-row--header-row={head}
     {...$$restProps}
@@ -90,7 +90,9 @@
   >
     <slot />
     {#if selection && head}
-      <StructuredListCell head style="width: 1px;">{""}</StructuredListCell>
+      <StructuredListCell head style="width: 1px;">
+        <span class:bx--visually-hidden={true}>Select row</span>
+      </StructuredListCell>
     {/if}
   </div>
 {/if}

--- a/tests/StructuredList/StructuredList.test.ts
+++ b/tests/StructuredList/StructuredList.test.ts
@@ -51,8 +51,9 @@ describe("StructuredList", () => {
       props: { selection: true },
     });
 
-    const list = screen.getByRole("table");
+    const list = container.querySelector(".bx--structured-list");
     expect(list).toHaveClass("bx--structured-list--selection");
+    expect(screen.getByRole("radiogroup")).toBeInTheDocument();
 
     const inputs = screen.getAllByRole("radio");
     expect(inputs).toHaveLength(3);
@@ -70,6 +71,30 @@ describe("StructuredList", () => {
         width: "1px",
       });
     }
+  });
+
+  it("should not place a radio/checkbox role under a table or rowgroup role", () => {
+    const { container } = render(StructuredList, {
+      props: { selection: true },
+    });
+
+    const options = container.querySelectorAll(
+      '[role="radio"], [role="checkbox"]',
+    );
+    expect(options.length).toBeGreaterThan(0);
+    for (const option of options) {
+      expect(option.closest('[role="table"], [role="rowgroup"]')).toBeNull();
+    }
+  });
+
+  it("should give the selection-icon header cell accessible text", () => {
+    const { container } = render(StructuredList, {
+      props: { selection: true },
+    });
+
+    const headerCells = container.querySelectorAll(".bx--structured-list-th");
+    const selectionHeaderCell = headerCells[headerCells.length - 1];
+    expect(selectionHeaderCell.textContent?.trim()).not.toBe("");
   });
 
   it("should render a custom selection icon via the `icon` prop", () => {


### PR DESCRIPTION
Fixes a11y issues in `StructuredList`, using AXE + Playwright.

- Selectable `StructuredList` rows render as `<label role="radio">` (or `role="checkbox"` when `multiple`), but the wrapper/head/body/cell components still unconditionally applied `role="table"`/`"rowgroup"`/`"cell"`/`"columnheader"`, producing an invalid ARIA ancestor chain (`table` → `rowgroup` → `radio` → `cell`) that axe-core flags via `aria-required-children`, `aria-required-parent`, and `aria-allowed-role`.
- Gate those table-ish roles off entirely when `selection` is `true`, and give `StructuredListBody` a `radiogroup` (single-select) or `group` (multi-select) role instead — this matches vanilla Carbon's own selectable structured-list markup, which never used table roles for this variant either.
- Give the auto-generated selection-icon header cell a visually-hidden "Select row" label instead of empty text (previously flagged by axe as an empty table header).
