### PR TITLE
fix(multi-select): stop option checkboxes from being independently focusable

### DIFF
--- a/src/Checkbox/Checkbox.svelte
+++ b/src/Checkbox/Checkbox.svelte
@@ -65,6 +65,12 @@
   export let id = `ccs-${Math.random().toString(36)}`;
 
   /**
+   * Set the tabindex for the input element.
+   * @type {number | string | undefined}
+   */
+  export let tabindex = undefined;
+
+  /**
    * Obtain a reference to the input HTML element.
    * @bindable readonly
    */
@@ -144,6 +150,7 @@
       {checked}
       {disabled}
       {id}
+      {tabindex}
       bind:indeterminate
       name={effectiveName}
       required={effectiveRequired}

--- a/tests/MultiSelect/MultiSelect.test.ts
+++ b/tests/MultiSelect/MultiSelect.test.ts
@@ -104,6 +104,15 @@ describe("MultiSelect", () => {
     expect(screen.getByRole("listbox")).toBeInTheDocument();
   });
 
+  it("should not leave the option checkbox independently focusable", async () => {
+    render(MultiSelect, { props: { items } });
+    await openMenu();
+
+    const option = screen.getByRole("option", { name: "Slack" });
+    const checkbox = option.querySelector('input[type="checkbox"]');
+    expect(checkbox).toHaveAttribute("tabindex", "-1");
+  });
+
   it("should pass selected and highlighted to the default slot", async () => {
     render(MultiSelectItemSlot, { props: { selectedIds: ["1"] } });
 


### PR DESCRIPTION
MultiSelect renders each option as a `role="option"` div using a roving-tabindex pattern, with `tabindex="-1"` passed to the inner `Checkbox` so the visual checkbox itself never enters the tab order. That `tabindex` never reached the actual `<input>`: `Checkbox.svelte`'s `$$restProps` is documented and spread onto the wrapper `<div>`, not the input, so the attribute landed on an inert element. The checkbox kept its native default tabbable state, leaving every option with a focusable descendant. axe-core's `nested-interactive` check flags this as a WCAG 4.1.2 violation, and it lets keyboard and screen-reader users tab directly into a checkbox nested inside an already-focusable listbox option.

