### PR TITLE
fix(tabs): remove tabindex from the presentational <li> wrapper

### DIFF
--- a/src/Tabs/Tab.svelte
+++ b/src/Tabs/Tab.svelte
@@ -160,7 +160,6 @@
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <li
-  tabindex="-1"
   role="presentation"
   class:bx--tabs__nav-item={true}
   class:bx--tabs__nav-item--disabled={disabled}

--- a/tests/Tabs/Tabs.test.ts
+++ b/tests/Tabs/Tabs.test.ts
@@ -40,6 +40,18 @@ describe("Tabs", () => {
     expect(tabsContainer).not.toHaveClass("bx--tabs--full-width");
   });
 
+  it("should not put a tabindex on the presentational <li> wrapper", () => {
+    const { container } = render(Tabs);
+
+    const presentationalItems = container.querySelectorAll(
+      'li[role="presentation"]',
+    );
+    expect(presentationalItems.length).toBeGreaterThan(0);
+    for (const li of presentationalItems) {
+      expect(li).not.toHaveAttribute("tabindex");
+    }
+  });
+
   it("should pass selected to the Tab default slot", async () => {
     render(TabSlot);
 


### PR DESCRIPTION
Closes #2200

Accessibility scans of Tabs surface aria-required-children,
aria-required-parent, and presentation-role-conflict violations. The
cause is `Tab.svelte`'s `<li role="presentation">`, which also
carries `tabindex="-1"`. Per HTML-AAM role-conflict resolution, a
presentational element that is focusable is not flattened out of the
accessibility tree, so browsers keep the `<li>` as a list item
between the tablist and its tabs, breaking the required direct
tablist -> tab relationship.