### PR TITLE
fix(tooltip): default `iconDescription` is "Show information"

### DIFF
--- a/src/Tooltip/Tooltip.svelte
+++ b/src/Tooltip/Tooltip.svelte
@@ -38,7 +38,7 @@
   export let icon = /** @type {Icon} */ (Information);
 
   /** Specify the ARIA label for the tooltip button */
-  export let iconDescription = "";
+  export let iconDescription = "Show information";
 
   /** Specify the icon name attribute */
   export let iconName = "";

--- a/tests/Tooltip/Tooltip.test.ts
+++ b/tests/Tooltip/Tooltip.test.ts
@@ -10,6 +10,7 @@ import TooltipEvents from "./TooltipEvents.test.svelte";
 import TooltipFooterFocus from "./TooltipFooterFocus.test.svelte";
 import TooltipFooterStandalone from "./TooltipFooterStandalone.test.svelte";
 import TooltipHideIcon from "./TooltipHideIcon.test.svelte";
+import TooltipNoLabel from "./TooltipNoLabel.test.svelte";
 import TooltipOpen from "./TooltipOpen.test.svelte";
 import TooltipPortalDirections from "./TooltipPortalDirections.test.svelte";
 
@@ -277,6 +278,13 @@ describe("Tooltip", () => {
 
     expect(screen.getByRole("dialog")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Learn more" })).not.toHaveFocus();
+  });
+
+  test("should have a non-empty accessible name with no props set", () => {
+    render(TooltipNoLabel);
+
+    const trigger = screen.getByRole("button");
+    expect(trigger.getAttribute("aria-label")).toBeTruthy();
   });
 
   test("should label the interactive dialog with its trigger", () => {

--- a/tests/Tooltip/TooltipNoLabel.test.svelte
+++ b/tests/Tooltip/TooltipNoLabel.test.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+  import Tooltip from "carbon-components-svelte/Tooltip/Tooltip.svelte";
+</script>
+
+<Tooltip />


### PR DESCRIPTION
Mounting a bare `<Tooltip />` with no `iconDescription` or
`triggerText` rendered an icon-only trigger with `aria-label=""`, an
explicit empty label that is worse than no label at all since it
suppresses any other accessible-name computation. Every other
icon-only trigger in this codebase (`OverflowMenu`, `CopyButton`)
defaults its description prop to a real string; `Tooltip` was the
outlier, so its most minimal usage shipped with zero accessible name.

`iconDescription` now defaults to `"Show information"` instead of
`""`, matching the existing convention so the default tooltip trigger
has a non-empty accessible name out of the box.

## Note

This changes a default string value, not a prop signature or type.
Consumers who mount `<Tooltip>` without setting `iconDescription` or
`triggerText` will now get `aria-label="Show information"` instead of
`aria-label=""`. Nothing renders visually differently since
`aria-label` isn't visible, but accessible-name output changes.

## Risk

Limited to consumers relying on the prior empty-label default; no
prop or type signature changes, no visual output changes.
