### PR TITLE
fix(data-table): label row checkboxes and fix expand column headers

### DIFF
--- a/src/DataTable/DataTable.svelte
+++ b/src/DataTable/DataTable.svelte
@@ -801,6 +801,7 @@
           {#if expandable}
             <th
               scope="col"
+              id="{id}-expand"
               class:bx--table-expand={true}
               data-previous-value={expanded ? "collapsed" : undefined}
             >
@@ -830,6 +831,8 @@
                     <ChevronRight {...expandIconProps} />
                   </slot>
                 </button>
+              {:else}
+                <span class:bx--visually-hidden={true}>Expand rows</span>
               {/if}
             </th>
           {/if}
@@ -995,7 +998,7 @@
               {#if expandable}
                 <TableCell
                   class="bx--table-expand"
-                  headers="expand"
+                  headers="{id}-expand"
                   data-previous-value={!nonExpandableRowIdsSet.has(row.id) &&
                   expandedRowIdsSet.has(row.id)
                     ? "collapsed"
@@ -1059,6 +1062,7 @@
                       <InlineCheckbox
                         id={inputId}
                         name={inputName}
+                        aria-label="Select row"
                         checked={selectedRowIdsSet.has(row.id)}
                         value={row.id}
                         on:change={() => {
@@ -1224,7 +1228,7 @@
               {#if expandable}
                 <TableCell
                   class="bx--table-expand"
-                  headers="expand"
+                  headers="{id}-expand"
                   data-previous-value={isExpandable && isExpanded
                     ? "collapsed"
                     : undefined}
@@ -1283,6 +1287,7 @@
                       <InlineCheckbox
                         id={inputId}
                         name={inputName}
+                        aria-label="Select row"
                         checked={isSelected}
                         value={row.id}
                         on:change={() => {

--- a/tests/DataTable/DataTable.test.ts
+++ b/tests/DataTable/DataTable.test.ts
@@ -1093,6 +1093,20 @@ describe("DataTable", () => {
     expect(expandedContent).toBeInTheDocument();
   });
 
+  it("should give the expand column an id referenced by every row's headers attribute", () => {
+    const { container } = render(DataTableExpandIcon);
+
+    const expandHeader = container.querySelector("th.bx--table-expand");
+    expect(expandHeader).toHaveAttribute("id");
+
+    const expandId = expandHeader?.getAttribute("id");
+    const expandCells = container.querySelectorAll("td.bx--table-expand");
+    expect(expandCells.length).toBeGreaterThan(0);
+    for (const cell of expandCells) {
+      expect(cell.getAttribute("headers")).toBe(expandId);
+    }
+  });
+
   // Styling and layout tests
   it("applies zebra stripe styling", () => {
     render(DataTable, {

--- a/tests/DataTable/DataTableBatchSelectionToolbar.test.ts
+++ b/tests/DataTable/DataTableBatchSelectionToolbar.test.ts
@@ -246,6 +246,25 @@ describe("DataTableBatchSelectionToolbar", () => {
     expect(toolbarContent).not.toHaveAttribute("inert");
   });
 
+  it("should label each row selection checkbox", () => {
+    const { container } = render(DataTableBatchSelectionToolbar, {
+      props: { selectedRowIds: [] },
+    });
+
+    const rowCheckboxes = container.querySelectorAll(
+      'td input[type="checkbox"]',
+    );
+    expect(rowCheckboxes.length).toBeGreaterThan(0);
+    for (const checkbox of rowCheckboxes) {
+      const label = container.querySelector(`label[for="${checkbox.id}"]`);
+      const hasAccessibleName =
+        checkbox.getAttribute("aria-label") ||
+        label?.getAttribute("aria-label") ||
+        label?.textContent?.trim();
+      expect(hasAccessibleName).toBeTruthy();
+    }
+  });
+
   it("toggles inert attributes when selection changes", async () => {
     const { container, rerender } = render(DataTableBatchSelectionToolbar, {
       props: {


### PR DESCRIPTION
Accessibility scanning flagged three violations in DataTable: the
per-row batch-selection checkboxes have no accessible name, the
expand column's `<td headers="expand">` references a `<th>` id that
is never actually set, and the expand column header renders with no
text content at all when `batchExpansion` is off.

Add `aria-label="Select row"` to each row checkbox, matching the
existing "Select all rows" label on the header checkbox. Scope the
expand column's `<th>` id to the table's internal id, since a literal
`id="expand"` would collide across multiple `DataTable`s on one page,
and reference it from both the normal and virtual-scroll row render
paths. Always render text in the expand header, visually hidden when
`batchExpansion` is off.

## Risk

Changes are contained to DataTable's expand and batch-selection
columns. Row checkboxes now announce as "Select row" instead of
silently. The expand `<th>` id changes from unset to a table-scoped
value, which could affect external code selecting on that attribute
directly, though that's unlikely since the id was previously blank.