### PR TITLE
fix(date-picker): mark out-of-range calendar days as aria-disabled

### DIFF
--- a/src/DatePicker/createCalendar.js
+++ b/src/DatePicker/createCalendar.js
@@ -87,6 +87,25 @@ function updateClasses(instance, { isMonth = false } = {}) {
 }
 
 /**
+ * Marks flatpickr's own disabled day elements (out-of-range days, and
+ * previous/next-month days that fall outside minDate/maxDate) as
+ * aria-disabled. Without this, axe-core's color-contrast check flags
+ * these days: WCAG 1.4.3 exempts inactive UI component text from the
+ * contrast requirement, but axe only recognizes that exemption via
+ * aria-disabled="true", not the flatpickr-disabled CSS class.
+ *
+ * @param {any} _dObj
+ * @param {any} _dStr
+ * @param {any} _fp
+ * @param {HTMLElement} dayElem
+ */
+function markDisabledDayAriaState(_dObj, _dStr, _fp, dayElem) {
+  if (dayElem.classList.contains("flatpickr-disabled")) {
+    dayElem.setAttribute("aria-disabled", "true");
+  }
+}
+
+/**
  * @param {FlatpickrInstance} instance
  */
 function updateMonthNode(instance) {
@@ -146,6 +165,8 @@ export async function createCalendar({ options, base, input, dispatch }) {
       : false,
   ].filter(Boolean);
 
+  const userOnDayCreate = options.onDayCreate;
+
   const config = {
     allowInput: true,
     disableMobile: true,
@@ -181,6 +202,14 @@ export async function createCalendar({ options, base, input, dispatch }) {
     },
     ...options,
     locale: resolveLocale(options.locale),
+    onDayCreate: [
+      markDisabledDayAriaState,
+      ...(Array.isArray(userOnDayCreate)
+        ? userOnDayCreate
+        : userOnDayCreate
+          ? [userOnDayCreate]
+          : []),
+    ],
   };
   return new /** @type {any} */ (flatpickr)(base, config);
 }

--- a/tests/DatePicker/DatePicker.test.ts
+++ b/tests/DatePicker/DatePicker.test.ts
@@ -510,6 +510,55 @@ describe("DatePicker", () => {
 
       expect(calendar).toHaveClass("open");
     });
+
+    // Regression test: axe-core flags out-of-range calendar days for
+    // insufficient color contrast because they carry no ARIA signal that
+    // they are disabled (only the meaningless flatpickr-disabled CSS class).
+    // WCAG 1.4.3 exempts text belonging to an inactive UI component, and
+    // axe-core's color-contrast check specifically skips aria-disabled="true"
+    // elements, so marking these days closes the gap correctly.
+    it("marks out-of-range calendar days as aria-disabled", async () => {
+      const { container } = render(DatePicker, {
+        datePickerType: "single",
+        value: "03/01/2024",
+        minDate: new Date(2024, 2, 1),
+        maxDate: new Date(2024, 2, 31),
+      });
+
+      await user.click(screen.getByLabelText("Date"));
+      await screen.findByLabelText("calendar-container");
+
+      const disabledDays = container.querySelectorAll(
+        ".flatpickr-day.flatpickr-disabled",
+      );
+      expect(disabledDays.length).toBeGreaterThan(0);
+      for (const day of disabledDays) {
+        expect(day).toHaveAttribute("aria-disabled", "true");
+      }
+    });
+
+    it("composes a consumer-supplied onDayCreate with the default aria-disabled hook", async () => {
+      const onDayCreate = vi.fn();
+      const { container } = render(DatePicker, {
+        datePickerType: "single",
+        value: "03/01/2024",
+        minDate: new Date(2024, 2, 1),
+        maxDate: new Date(2024, 2, 31),
+        flatpickrProps: { onDayCreate },
+      });
+
+      await user.click(screen.getByLabelText("Date"));
+      await screen.findByLabelText("calendar-container");
+
+      expect(onDayCreate).toHaveBeenCalled();
+      const disabledDays = container.querySelectorAll(
+        ".flatpickr-day.flatpickr-disabled",
+      );
+      expect(disabledDays.length).toBeGreaterThan(0);
+      for (const day of disabledDays) {
+        expect(day).toHaveAttribute("aria-disabled", "true");
+      }
+    });
   });
 
   describe("bind:calendar", () => {


### PR DESCRIPTION
Out-of-range calendar days (previous/next-month days, and days
outside minDate/maxDate) render with Carbon's own text-disabled
color, inherited unchanged from carbon-components'
_date-picker.scss. That color pairing fails WCAG 1.4.3 contrast
against the calendar background. The days carried only a
flatpickr-disabled CSS class, which is meaningless to assistive
tech, so axe-core's color-contrast check had no ARIA signal to
recognize them as an inactive UI component and correctly exempt
them, and screen reader users got no indication the day was
unselectable.

createCalendar.js now marks these days aria-disabled="true" via
flatpickr's onDayCreate hook. The hook is composed as an array so
any consumer-supplied flatpickrProps.onDayCreate keeps running
alongside the default one instead of being clobbered.

## Risk

Limited to DatePicker's calendar day rendering. The only behavior
change is a new aria-disabled attribute on days flatpickr already
treats as disabled; visual styling and existing flatpickrProps
usage are unaffected.