### PR TITLE
fix(ui-shell): stop `HeaderSearch` referencing non-existent menu id

### DIFF
--- a/src/UIShell/HeaderSearch.svelte
+++ b/src/UIShell/HeaderSearch.svelte
@@ -338,7 +338,7 @@
   >
   <div
     class:bx--header__search-menu={true}
-    aria-owns={menuId}
+    aria-owns={active ? menuId : undefined}
     aria-haspopup="menu"
   >
     <button
@@ -367,9 +367,13 @@
       id={inputId}
       role={richMenu ? "combobox" : undefined}
       aria-autocomplete="list"
-      aria-controls={menuId}
+      aria-controls={active ? menuId : undefined}
       aria-expanded={richMenu ? richMenuVisible : undefined}
-      aria-activedescendant={richMenu ? ($activeId ?? undefined) : selectedId}
+      aria-activedescendant={active
+        ? richMenu
+          ? ($activeId ?? undefined)
+          : selectedId
+        : undefined}
       bind:value
       on:change
       on:input

--- a/tests/UIShell/HeaderSearch.test.ts
+++ b/tests/UIShell/HeaderSearch.test.ts
@@ -162,7 +162,9 @@ describe("HeaderSearch", () => {
         { href: "/2", text: "Result 2" },
         { href: "/3", text: "Result 3" },
       ];
-      render(HeaderSearchTest, { props: { results, selectedResultIndex: 1 } });
+      render(HeaderSearchTest, {
+        props: { active: true, results, selectedResultIndex: 1 },
+      });
 
       const searchInput = screen.getByRole("textbox");
       expect(searchInput.getAttribute("aria-activedescendant")).toMatch(
@@ -488,7 +490,7 @@ describe("HeaderSearch", () => {
 
   describe("Accessibility", () => {
     it("should have proper ARIA attributes", () => {
-      render(HeaderSearchTest);
+      render(HeaderSearchTest, { props: { active: true } });
 
       const searchContainer = screen.getByRole("search");
       expect(searchContainer).toBeInTheDocument();
@@ -498,6 +500,25 @@ describe("HeaderSearch", () => {
       expect(searchInput.getAttribute("aria-controls")).toMatch(
         /^ccs-[a-z0-9.]+-menu$/,
       );
+    });
+
+    it("should not reference a menu id via aria-owns/aria-controls/aria-activedescendant while closed", () => {
+      const { container } = render(HeaderSearchTest, {
+        props: {
+          active: false,
+          results: [
+            { id: "1", text: "Result one" },
+            { id: "2", text: "Result two" },
+          ],
+        },
+      });
+
+      const wrapper = container.querySelector(".bx--header__search-menu");
+      expect(wrapper).not.toHaveAttribute("aria-owns");
+
+      const input = container.querySelector(".bx--header__search-input");
+      expect(input).not.toHaveAttribute("aria-controls");
+      expect(input).not.toHaveAttribute("aria-activedescendant");
     });
 
     it("should have proper tabindex attributes", () => {


### PR DESCRIPTION
HeaderSearch set aria-owns and aria-controls to a fixed menu id
unconditionally, but the element carrying that id only renders once
the field is active (open). aria-activedescendant had the same
problem: selectedId is derived from the results/selectedResultIndex
props alone, with no dependency on active, so it resolved to a
menuitem id that doesn't exist until the field opens. Any consumer
that populates `results` up front, the normal way to use this prop,
ships a closed search field with three dangling ARIA references,
which axe-core flags as aria-valid-attr-value violations.

Gate `aria-owns`, `aria-controls`, and `aria-activedescendant` on
`active` so they're only set once the referenced element actually
exists in the DOM.

Risk is limited to `HeaderSearch`'s ARIA output. Behavior and DOM
structure are unchanged; only the three attributes are now absent
while the field is closed instead of pointing at a nonexistent id.