### PR TITLE
fix(selectable-tile): `SelectableTile` does not use incorrect `role="checkbox"`

### DIFF
--- a/src/Tile/SelectableTile.svelte
+++ b/src/Tile/SelectableTile.svelte
@@ -77,7 +77,7 @@
 <input
   bind:this={ref}
   type="checkbox"
-  tabindex="-1"
+  tabindex={disabled ? undefined : tabindex}
   class:bx--tile-input={true}
   checked={selected}
   {id}
@@ -100,16 +100,19 @@
       }
     }
   }}
+  on:keydown
+  on:keydown={(event) => {
+    if (disabled) return;
+    if (event.key === "Enter") {
+      event.preventDefault();
+      ref.click();
+    }
+  }}
 >
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
-<!-- svelte-ignore a11y-no-noninteractive-tabindex -->
 <!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
 <label
   for={id}
-  tabindex={disabled ? undefined : tabindex}
-  role="checkbox"
-  aria-checked={selected}
-  aria-disabled={disabled || undefined}
   class:bx--tile={true}
   class:bx--tile--selectable={true}
   class:bx--tile--is-selected={selected}
@@ -117,38 +120,9 @@
   class:bx--tile--disabled={disabled}
   {...$$restProps}
   on:click
-  on:click|preventDefault={() => {
-    if (disabled) return;
-    const newSelected = !selected;
-    selected = newSelected;
-
-    if (ref) {
-      ref.checked = newSelected;
-    }
-
-    if (hasGroup) {
-      update({ value, selected: newSelected });
-    } else {
-      if (newSelected) {
-        dispatch("select", id);
-      } else {
-        dispatch("deselect", id);
-      }
-    }
-  }}
   on:mouseover
   on:mouseenter
   on:mouseleave
-  on:keydown
-  on:keydown={(event) => {
-    if (disabled) return;
-    if (event.key === " " || event.key === "Enter") {
-      event.preventDefault();
-      if (ref) {
-        ref.click();
-      }
-    }
-  }}
 >
   <span aria-hidden="true" class:bx--tile__checkmark={true}>
     <CheckmarkFilled aria-label={iconDescription} title={iconDescription} />

--- a/tests/Tile/SelectableTile.test.ts
+++ b/tests/Tile/SelectableTile.test.ts
@@ -28,17 +28,29 @@ describe("SelectableTile", () => {
   });
 
   it("renders with disabled state", () => {
-    render(SelectableTileTest, { disabled: true });
+    const { container } = render(SelectableTileTest, { disabled: true });
     const tile = screen.getByTestId("selectable-tile");
     expect(tile).toHaveClass("bx--tile--disabled");
-    expect(tile).toHaveAttribute("aria-disabled", "true");
-    expect(tile).not.toHaveAttribute("tabindex");
+
+    const input = container.querySelector('input[type="checkbox"]');
+    expect(input).toBeDisabled();
+    expect(input).not.toHaveAttribute("tabindex");
   });
 
-  it("omits aria-disabled when enabled", () => {
+  it("keeps the input focusable when enabled", () => {
+    const { container } = render(SelectableTileTest);
+    const input = container.querySelector('input[type="checkbox"]');
+    expect(input).not.toBeDisabled();
+    expect(input).toHaveAttribute("tabindex", "0");
+  });
+
+  it('should not put role="checkbox" on the <label> element', () => {
     render(SelectableTileTest);
     const tile = screen.getByTestId("selectable-tile");
-    expect(tile).not.toHaveAttribute("aria-disabled");
+
+    if (tile.tagName === "LABEL") {
+      expect(tile).not.toHaveAttribute("role", "checkbox");
+    }
   });
 
   it("renders with custom title and value", () => {
@@ -64,19 +76,24 @@ describe("SelectableTile", () => {
     expect(icon).toHaveAttribute("aria-label", "Custom checkmark");
   });
 
-  it("exposes checkbox semantics on the focusable label", () => {
-    render(SelectableTileTest);
+  it("exposes checkbox semantics via the native input, not the label", () => {
+    const { container } = render(SelectableTileTest);
+    const input = container.querySelector('input[type="checkbox"]');
+    expect(input).not.toBeChecked();
+
     const tile = screen.getByTestId("selectable-tile");
-    expect(tile).toHaveAttribute("role", "checkbox");
-    expect(tile).toHaveAttribute("aria-checked", "false");
-    expect(tile).not.toHaveAttribute("aria-disabled");
+    expect(tile).not.toHaveAttribute("role");
+    expect(tile).not.toHaveAttribute("aria-checked");
   });
 
-  it("reflects selected and disabled state in ARIA attributes", () => {
-    render(SelectableTileTest, { selected: true, disabled: true });
-    const tile = screen.getByTestId("selectable-tile");
-    expect(tile).toHaveAttribute("aria-checked", "true");
-    expect(tile).toHaveAttribute("aria-disabled", "true");
+  it("reflects selected and disabled state on the input", () => {
+    const { container } = render(SelectableTileTest, {
+      selected: true,
+      disabled: true,
+    });
+    const input = container.querySelector('input[type="checkbox"]');
+    expect(input).toBeChecked();
+    expect(input).toBeDisabled();
   });
 
   it("hides the checkmark icon from assistive technology", () => {


### PR DESCRIPTION
SelectableTile put role="checkbox" and aria-checked directly on the
<label> wrapping each tile, while the actual <input
type="checkbox"> was removed from the tab order (tabindex="-1").
role="checkbox" isn't an ARIA-in-HTML-allowed role for <label>
elements, which axe-core flags as an aria-allowed-role violation.

Fixed by mirroring RadioTile's existing pattern: the native <input>
is now the focusable, checkbox-shaped element (its tabindex is
driven by the component's own tabindex prop, and the change/keydown
handlers moved onto it), while the <label> goes back to being a
plain native label with no role, aria-checked, or tabindex of its
own. The label still wraps the tile content and forwards clicks to
the input, so the click hit area and Tab/Enter/Space behavior are
unchanged.

Risk is limited to SelectableTile and SelectableTileGroup. Anything
relying on the label itself being the focus target (rather than the
input) or the label's ARIA attributes would need to change, but
existing tests for click, keyboard, and group selection all still
pass.