### PR TITLE
fix(composed-modal): fall back to title for the dialog's accessible name

### DIFF
--- a/src/ComposedModal/ComposedModal.svelte
+++ b/src/ComposedModal/ComposedModal.svelte
@@ -51,6 +51,7 @@
 
   const dispatch = createEventDispatcher();
   const label = writable(undefined);
+  const title = writable(undefined);
   const focusReturn = restoreFocus();
 
   let buttonRef = null;
@@ -100,12 +101,20 @@
     label.set(value);
   }
 
+  /**
+   * @type {(value: string | undefined) => void}
+   */
+  function updateTitle(value) {
+    title.set(value);
+  }
+
   setContext("carbon:Modal", {});
   setContext("carbon:ComposedModal", {
     closeModal,
     submit,
     declareRef,
     updateLabel,
+    updateTitle,
   });
 
   function focus(element) {
@@ -198,7 +207,7 @@
     bind:this={innerModal}
     role="dialog"
     aria-modal="true"
-    aria-label={$$props["aria-label"] ?? $label ?? undefined}
+    aria-label={$$props["aria-label"] ?? ($label || $title || undefined)}
     class:bx--modal-container={true}
     class:bx--modal-container--xs={size === "xs"}
     class:bx--modal-container--sm={size === "sm"}

--- a/src/ComposedModal/ModalHeader.svelte
+++ b/src/ComposedModal/ModalHeader.svelte
@@ -23,9 +23,12 @@
   import { getContext } from "svelte";
   import Close from "../icons/Close.svelte";
 
-  const { closeModal, updateLabel } = getContext("carbon:ComposedModal");
+  const { closeModal, updateLabel, updateTitle } = getContext(
+    "carbon:ComposedModal",
+  );
 
   $: updateLabel(label);
+  $: updateTitle(title);
 </script>
 
 <div class:bx--modal-header={true} {...$$restProps}>

--- a/tests/ComposedModal/ComposedModal.test.ts
+++ b/tests/ComposedModal/ComposedModal.test.ts
@@ -32,6 +32,21 @@ describe("ComposedModal", () => {
     expect(screen.getByText("Test Modal")).toBeInTheDocument();
   });
 
+  it("should have an accessible name when only a title is set", () => {
+    render(ComposedModalTest, {
+      props: { open: true, headerTitle: "Modal title" },
+    });
+
+    const dialog = screen.getByRole("dialog");
+    const accessibleName =
+      dialog.getAttribute("aria-label") ||
+      (dialog.getAttribute("aria-labelledby") &&
+        document
+          .getElementById(dialog.getAttribute("aria-labelledby") ?? "")
+          ?.textContent?.trim());
+    expect(accessibleName).toBeTruthy();
+  });
+
   // Regression: ?? for aria-label so empty string is used (not fallback)
   it("uses empty aria-label when passed (nullish coalescing)", () => {
     render(ComposedModalTest, {


### PR DESCRIPTION
ComposedModal's role="dialog" only got its aria-label from
ModalHeader's `label` prop, a secondary eyebrow string shown above
the heading. `title`, the actual modal heading rendered as an
`<h3>` with no `id`, never fed the accessible name at all. Since
`label` defaults to `""` and the derivation used `??`, a modal with
only `title` set (the common case) ended up with `aria-label=""`
instead of falling through, because nullish coalescing does not
treat an empty string as absent.

`title` is now tracked through the same `carbon:ComposedModal`
context mechanism `label` already uses, and falls back to it (via
`||`, so empty strings are treated as unset) beneath the explicit
`aria-label` prop, which still takes precedence through `??` so an
intentionally empty `aria-label=""` is preserved. This matches how
the simpler Modal component already falls back to `modalHeading`.

## Risk

Change is scoped to ComposedModal/ModalHeader's accessible-name
derivation. Existing precedence (explicit aria-label prop, then
label, then title) is unchanged for consumers already setting
label; only consumers who set title without label gain an
accessible name where they previously had none.