### PR TITLE
test(e2e): add automated a11y testing using axe

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -9,6 +9,7 @@
         "flatpickr": "4.6.9",
       },
       "devDependencies": {
+        "@axe-core/playwright": "^4.12.1",
         "@biomejs/biome": "2.5.3",
         "@playwright/test": "^1.61.0",
         "@sveltejs/vite-plugin-svelte": "^7.1.2",
@@ -44,6 +45,8 @@
     "@asamuzakjp/generational-cache": ["@asamuzakjp/generational-cache@1.0.1", "", {}, "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg=="],
 
     "@asamuzakjp/nwsapi": ["@asamuzakjp/nwsapi@2.3.9", "", {}, "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q=="],
+
+    "@axe-core/playwright": ["@axe-core/playwright@4.12.1", "", { "dependencies": { "axe-core": "~4.12.1" }, "peerDependencies": { "playwright-core": ">= 1.0.0" } }, "sha512-rMd7xriptqKpP+w5265i4Hdkv2X5kbu6uiBi/B2I7uf3hieRBM3qDCfaKPtxfiYb2mKXfF+yLODJwIx+Jv1GDw=="],
 
     "@babel/code-frame": ["@babel/code-frame@7.27.1", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.27.1", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg=="],
 
@@ -296,6 +299,8 @@
     "ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 
     "aria-query": ["aria-query@5.3.2", "", {}, "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw=="],
+
+    "axe-core": ["axe-core@4.12.1", "", {}, "sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA=="],
 
     "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
 

--- a/e2e/a11y-accordion.test.ts
+++ b/e2e/a11y-accordion.test.ts
@@ -6,20 +6,17 @@ test.describe("Accordion a11y", () => {
     await page.goto("/accordion.html");
     await expect(page.getByTestId("accordion")).toBeVisible();
 
-    const results = await new AxeBuilder({ page }).include("#app").analyze();
+    const staticResults = await new AxeBuilder({ page })
+      .include("#app")
+      .analyze();
+    expect(staticResults.violations).toEqual([]);
 
-    expect(results.violations).toEqual([]);
-  });
-
-  test("has no detectable accessibility violations with a section expanded", async ({
-    page,
-  }) => {
-    await page.goto("/accordion.html");
     await page.getByRole("button", { name: "Section 1" }).click();
     await expect(page.getByText("Content for section 1")).toBeVisible();
 
-    const results = await new AxeBuilder({ page }).include("#app").analyze();
-
-    expect(results.violations).toEqual([]);
+    const expandedResults = await new AxeBuilder({ page })
+      .include("#app")
+      .analyze();
+    expect(expandedResults.violations).toEqual([]);
   });
 });

--- a/e2e/a11y-accordion.test.ts
+++ b/e2e/a11y-accordion.test.ts
@@ -1,0 +1,25 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+test.describe("Accordion a11y", () => {
+  test("has no detectable accessibility violations", async ({ page }) => {
+    await page.goto("/accordion.html");
+    await expect(page.getByTestId("accordion")).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+
+  test("has no detectable accessibility violations with a section expanded", async ({
+    page,
+  }) => {
+    await page.goto("/accordion.html");
+    await page.getByRole("button", { name: "Section 1" }).click();
+    await expect(page.getByText("Content for section 1")).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+});

--- a/e2e/a11y-breadcrumb.test.ts
+++ b/e2e/a11y-breadcrumb.test.ts
@@ -1,0 +1,13 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+test.describe("Breadcrumb a11y", () => {
+  test("has no detectable accessibility violations", async ({ page }) => {
+    await page.goto("/breadcrumb.html");
+    await expect(page.getByTestId("breadcrumb")).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+});

--- a/e2e/a11y-button.test.ts
+++ b/e2e/a11y-button.test.ts
@@ -1,0 +1,13 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+test.describe("Button a11y", () => {
+  test("has no detectable accessibility violations", async ({ page }) => {
+    await page.goto("/button.html");
+    await expect(page.getByRole("button", { name: "Primary" })).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+});

--- a/e2e/a11y-checkbox-group.test.ts
+++ b/e2e/a11y-checkbox-group.test.ts
@@ -6,22 +6,19 @@ test.describe("CheckboxGroup a11y", () => {
     await page.goto("/checkbox-group.html");
     await expect(page.getByTestId("checkbox-group-options")).toBeVisible();
 
-    const results = await new AxeBuilder({ page }).include("#app").analyze();
+    const staticResults = await new AxeBuilder({ page })
+      .include("#app")
+      .analyze();
+    expect(staticResults.violations).toEqual([]);
 
-    expect(results.violations).toEqual([]);
-  });
-
-  test("has no detectable accessibility violations after checking an option", async ({
-    page,
-  }) => {
-    await page.goto("/checkbox-group.html");
     await page.getByRole("checkbox", { name: "Option A" }).click({
       force: true,
     });
     await expect(page.getByTestId("selected-values")).toHaveText("Selected: a");
 
-    const results = await new AxeBuilder({ page }).include("#app").analyze();
-
-    expect(results.violations).toEqual([]);
+    const checkedResults = await new AxeBuilder({ page })
+      .include("#app")
+      .analyze();
+    expect(checkedResults.violations).toEqual([]);
   });
 });

--- a/e2e/a11y-checkbox-group.test.ts
+++ b/e2e/a11y-checkbox-group.test.ts
@@ -1,0 +1,27 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+test.describe("CheckboxGroup a11y", () => {
+  test("has no detectable accessibility violations", async ({ page }) => {
+    await page.goto("/checkbox-group.html");
+    await expect(page.getByTestId("checkbox-group-options")).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+
+  test("has no detectable accessibility violations after checking an option", async ({
+    page,
+  }) => {
+    await page.goto("/checkbox-group.html");
+    await page.getByRole("checkbox", { name: "Option A" }).click({
+      force: true,
+    });
+    await expect(page.getByTestId("selected-values")).toHaveText("Selected: a");
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+});

--- a/e2e/a11y-checkbox.test.ts
+++ b/e2e/a11y-checkbox.test.ts
@@ -1,0 +1,13 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+test.describe("Checkbox a11y", () => {
+  test("has no detectable accessibility violations", async ({ page }) => {
+    await page.goto("/checkbox.html");
+    await expect(page.getByTestId("checkbox-agree")).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+});

--- a/e2e/a11y-clickable-tile.test.ts
+++ b/e2e/a11y-clickable-tile.test.ts
@@ -1,0 +1,25 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+test.describe("ClickableTile a11y", () => {
+  test("has no detectable accessibility violations", async ({ page }) => {
+    await page.goto("/clickable-tile.html");
+    await expect(page.getByTestId("clickable-tile")).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+
+  test("has no detectable accessibility violations after clicking", async ({
+    page,
+  }) => {
+    await page.goto("/clickable-tile.html");
+    await page.getByTestId("clickable-tile").click();
+    await expect(page.getByTestId("clicked-state")).toHaveText("true");
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+});

--- a/e2e/a11y-clickable-tile.test.ts
+++ b/e2e/a11y-clickable-tile.test.ts
@@ -6,20 +6,17 @@ test.describe("ClickableTile a11y", () => {
     await page.goto("/clickable-tile.html");
     await expect(page.getByTestId("clickable-tile")).toBeVisible();
 
-    const results = await new AxeBuilder({ page }).include("#app").analyze();
+    const staticResults = await new AxeBuilder({ page })
+      .include("#app")
+      .analyze();
+    expect(staticResults.violations).toEqual([]);
 
-    expect(results.violations).toEqual([]);
-  });
-
-  test("has no detectable accessibility violations after clicking", async ({
-    page,
-  }) => {
-    await page.goto("/clickable-tile.html");
     await page.getByTestId("clickable-tile").click();
     await expect(page.getByTestId("clicked-state")).toHaveText("true");
 
-    const results = await new AxeBuilder({ page }).include("#app").analyze();
-
-    expect(results.violations).toEqual([]);
+    const clickedResults = await new AxeBuilder({ page })
+      .include("#app")
+      .analyze();
+    expect(clickedResults.violations).toEqual([]);
   });
 });

--- a/e2e/a11y-code-snippet.test.ts
+++ b/e2e/a11y-code-snippet.test.ts
@@ -6,15 +6,11 @@ test.describe("CodeSnippet a11y", () => {
     await page.goto("/code-snippet.html");
     await expect(page.getByTestId("snippet-single")).toBeVisible();
 
-    const results = await new AxeBuilder({ page }).include("#app").analyze();
+    const staticResults = await new AxeBuilder({ page })
+      .include("#app")
+      .analyze();
+    expect(staticResults.violations).toEqual([]);
 
-    expect(results.violations).toEqual([]);
-  });
-
-  test("has no detectable accessibility violations when expanded", async ({
-    page,
-  }) => {
-    await page.goto("/code-snippet.html");
     await page
       .getByTestId("multi-snippet")
       .getByRole("button", { name: "Show more" })
@@ -25,8 +21,9 @@ test.describe("CodeSnippet a11y", () => {
       }),
     ).toBeVisible();
 
-    const results = await new AxeBuilder({ page }).include("#app").analyze();
-
-    expect(results.violations).toEqual([]);
+    const expandedResults = await new AxeBuilder({ page })
+      .include("#app")
+      .analyze();
+    expect(expandedResults.violations).toEqual([]);
   });
 });

--- a/e2e/a11y-code-snippet.test.ts
+++ b/e2e/a11y-code-snippet.test.ts
@@ -1,0 +1,32 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+test.describe("CodeSnippet a11y", () => {
+  test("has no detectable accessibility violations", async ({ page }) => {
+    await page.goto("/code-snippet.html");
+    await expect(page.getByTestId("snippet-single")).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+
+  test("has no detectable accessibility violations when expanded", async ({
+    page,
+  }) => {
+    await page.goto("/code-snippet.html");
+    await page
+      .getByTestId("multi-snippet")
+      .getByRole("button", { name: "Show more" })
+      .click();
+    await expect(
+      page.getByTestId("multi-snippet").getByRole("button", {
+        name: "Show less",
+      }),
+    ).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+});

--- a/e2e/a11y-combo-button.test.ts
+++ b/e2e/a11y-combo-button.test.ts
@@ -6,21 +6,18 @@ test.describe("ComboButton a11y", () => {
     await page.goto("/combo-button.html");
     await expect(page.getByRole("button", { name: "Save" })).toBeVisible();
 
-    const results = await new AxeBuilder({ page }).include("#app").analyze();
+    const staticResults = await new AxeBuilder({ page })
+      .include("#app")
+      .analyze();
+    expect(staticResults.violations).toEqual([]);
 
-    expect(results.violations).toEqual([]);
-  });
-
-  test("has no detectable accessibility violations with the menu open", async ({
-    page,
-  }) => {
-    await page.goto("/combo-button.html");
     await page.getByRole("button", { name: "Additional actions" }).click();
     await expect(page.getByRole("menu")).toBeVisible();
     await expect(page.getByRole("menuitem", { name: "Save as" })).toBeVisible();
 
-    const results = await new AxeBuilder({ page }).include("#app").analyze();
-
-    expect(results.violations).toEqual([]);
+    const openResults = await new AxeBuilder({ page })
+      .include("#app")
+      .analyze();
+    expect(openResults.violations).toEqual([]);
   });
 });

--- a/e2e/a11y-combo-button.test.ts
+++ b/e2e/a11y-combo-button.test.ts
@@ -1,0 +1,26 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+test.describe("ComboButton a11y", () => {
+  test("has no detectable accessibility violations", async ({ page }) => {
+    await page.goto("/combo-button.html");
+    await expect(page.getByRole("button", { name: "Save" })).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+
+  test("has no detectable accessibility violations with the menu open", async ({
+    page,
+  }) => {
+    await page.goto("/combo-button.html");
+    await page.getByRole("button", { name: "Additional actions" }).click();
+    await expect(page.getByRole("menu")).toBeVisible();
+    await expect(page.getByRole("menuitem", { name: "Save as" })).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+});

--- a/e2e/a11y-combobox.test.ts
+++ b/e2e/a11y-combobox.test.ts
@@ -1,0 +1,26 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+test.describe("ComboBox a11y", () => {
+  test("has no detectable accessibility violations", async ({ page }) => {
+    await page.goto("/combobox.html");
+    await expect(page.getByTestId("combobox-contact")).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+
+  test("has no detectable accessibility violations with the menu open", async ({
+    page,
+  }) => {
+    await page.goto("/combobox.html");
+    await page.getByRole("combobox", { name: "Contact" }).click();
+    await expect(page.getByRole("listbox")).toBeVisible();
+    await expect(page.getByRole("option", { name: "Slack" })).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+});

--- a/e2e/a11y-combobox.test.ts
+++ b/e2e/a11y-combobox.test.ts
@@ -6,21 +6,18 @@ test.describe("ComboBox a11y", () => {
     await page.goto("/combobox.html");
     await expect(page.getByTestId("combobox-contact")).toBeVisible();
 
-    const results = await new AxeBuilder({ page }).include("#app").analyze();
+    const staticResults = await new AxeBuilder({ page })
+      .include("#app")
+      .analyze();
+    expect(staticResults.violations).toEqual([]);
 
-    expect(results.violations).toEqual([]);
-  });
-
-  test("has no detectable accessibility violations with the menu open", async ({
-    page,
-  }) => {
-    await page.goto("/combobox.html");
     await page.getByRole("combobox", { name: "Contact" }).click();
     await expect(page.getByRole("listbox")).toBeVisible();
     await expect(page.getByRole("option", { name: "Slack" })).toBeVisible();
 
-    const results = await new AxeBuilder({ page }).include("#app").analyze();
-
-    expect(results.violations).toEqual([]);
+    const openResults = await new AxeBuilder({ page })
+      .include("#app")
+      .analyze();
+    expect(openResults.violations).toEqual([]);
   });
 });

--- a/e2e/a11y-composed-modal.test.ts
+++ b/e2e/a11y-composed-modal.test.ts
@@ -1,0 +1,16 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+test.describe("ComposedModal a11y", () => {
+  test("has no detectable accessibility violations when open", async ({
+    page,
+  }) => {
+    await page.goto("/composed-modal.html");
+    await page.getByTestId("open-modal").click();
+    await expect(page.getByTestId("modal-body")).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+});

--- a/e2e/a11y-contained-list.test.ts
+++ b/e2e/a11y-contained-list.test.ts
@@ -6,20 +6,17 @@ test.describe("ContainedList a11y", () => {
     await page.goto("/contained-list.html");
     await expect(page.getByTestId("contained-list")).toBeVisible();
 
-    const results = await new AxeBuilder({ page }).include("#app").analyze();
+    const staticResults = await new AxeBuilder({ page })
+      .include("#app")
+      .analyze();
+    expect(staticResults.violations).toEqual([]);
 
-    expect(results.violations).toEqual([]);
-  });
-
-  test("has no detectable accessibility violations after clicking an item", async ({
-    page,
-  }) => {
-    await page.goto("/contained-list.html");
     await page.getByText("Item 1").click();
     await expect(page.getByTestId("clicked-item")).toHaveText("1");
 
-    const results = await new AxeBuilder({ page }).include("#app").analyze();
-
-    expect(results.violations).toEqual([]);
+    const clickedResults = await new AxeBuilder({ page })
+      .include("#app")
+      .analyze();
+    expect(clickedResults.violations).toEqual([]);
   });
 });

--- a/e2e/a11y-contained-list.test.ts
+++ b/e2e/a11y-contained-list.test.ts
@@ -1,0 +1,25 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+test.describe("ContainedList a11y", () => {
+  test("has no detectable accessibility violations", async ({ page }) => {
+    await page.goto("/contained-list.html");
+    await expect(page.getByTestId("contained-list")).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+
+  test("has no detectable accessibility violations after clicking an item", async ({
+    page,
+  }) => {
+    await page.goto("/contained-list.html");
+    await page.getByText("Item 1").click();
+    await expect(page.getByTestId("clicked-item")).toHaveText("1");
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+});

--- a/e2e/a11y-content-switcher.test.ts
+++ b/e2e/a11y-content-switcher.test.ts
@@ -1,0 +1,25 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+test.describe("ContentSwitcher a11y", () => {
+  test("has no detectable accessibility violations", async ({ page }) => {
+    await page.goto("/content-switcher.html");
+    await expect(page.getByTestId("content-switcher")).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+
+  test("has no detectable accessibility violations after switching", async ({
+    page,
+  }) => {
+    await page.goto("/content-switcher.html");
+    await page.getByRole("tab", { name: "Second" }).click();
+    await expect(page.getByTestId("selected-index")).toHaveText("Selected: 1");
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+});

--- a/e2e/a11y-content-switcher.test.ts
+++ b/e2e/a11y-content-switcher.test.ts
@@ -6,20 +6,17 @@ test.describe("ContentSwitcher a11y", () => {
     await page.goto("/content-switcher.html");
     await expect(page.getByTestId("content-switcher")).toBeVisible();
 
-    const results = await new AxeBuilder({ page }).include("#app").analyze();
+    const staticResults = await new AxeBuilder({ page })
+      .include("#app")
+      .analyze();
+    expect(staticResults.violations).toEqual([]);
 
-    expect(results.violations).toEqual([]);
-  });
-
-  test("has no detectable accessibility violations after switching", async ({
-    page,
-  }) => {
-    await page.goto("/content-switcher.html");
     await page.getByRole("tab", { name: "Second" }).click();
     await expect(page.getByTestId("selected-index")).toHaveText("Selected: 1");
 
-    const results = await new AxeBuilder({ page }).include("#app").analyze();
-
-    expect(results.violations).toEqual([]);
+    const switchedResults = await new AxeBuilder({ page })
+      .include("#app")
+      .analyze();
+    expect(switchedResults.violations).toEqual([]);
   });
 });

--- a/e2e/a11y-context-menu.test.ts
+++ b/e2e/a11y-context-menu.test.ts
@@ -1,0 +1,19 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+test.describe("ContextMenu a11y", () => {
+  test("has no detectable accessibility violations when open", async ({
+    page,
+  }) => {
+    await page.goto("/context-menu.html");
+    await page.getByTestId("context-target").click({ button: "right" });
+    await expect(page.getByRole("menu")).toBeVisible();
+    await expect(
+      page.getByRole("menuitem", { name: "Option 1" }),
+    ).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+});

--- a/e2e/a11y-copy-button.test.ts
+++ b/e2e/a11y-copy-button.test.ts
@@ -1,0 +1,25 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+test.describe("CopyButton a11y", () => {
+  test("has no detectable accessibility violations", async ({ page }) => {
+    await page.goto("/copy-button.html");
+    await expect(page.getByTestId("copy-button")).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+
+  test("has no detectable accessibility violations after copying", async ({
+    page,
+  }) => {
+    await page.goto("/copy-button.html");
+    await page.getByRole("button", { name: "Copy to clipboard" }).click();
+    await expect(page.getByTestId("copied-value")).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+});

--- a/e2e/a11y-copy-button.test.ts
+++ b/e2e/a11y-copy-button.test.ts
@@ -6,20 +6,17 @@ test.describe("CopyButton a11y", () => {
     await page.goto("/copy-button.html");
     await expect(page.getByTestId("copy-button")).toBeVisible();
 
-    const results = await new AxeBuilder({ page }).include("#app").analyze();
+    const staticResults = await new AxeBuilder({ page })
+      .include("#app")
+      .analyze();
+    expect(staticResults.violations).toEqual([]);
 
-    expect(results.violations).toEqual([]);
-  });
-
-  test("has no detectable accessibility violations after copying", async ({
-    page,
-  }) => {
-    await page.goto("/copy-button.html");
     await page.getByRole("button", { name: "Copy to clipboard" }).click();
     await expect(page.getByTestId("copied-value")).toBeVisible();
 
-    const results = await new AxeBuilder({ page }).include("#app").analyze();
-
-    expect(results.violations).toEqual([]);
+    const copiedResults = await new AxeBuilder({ page })
+      .include("#app")
+      .analyze();
+    expect(copiedResults.violations).toEqual([]);
   });
 });

--- a/e2e/a11y-data-table-overflow-menu.test.ts
+++ b/e2e/a11y-data-table-overflow-menu.test.ts
@@ -1,0 +1,43 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+test.describe("DataTable OverflowMenu a11y", () => {
+  test("has no detectable accessibility violations", async ({ page }) => {
+    await page.goto("/data-table-overflow-menu.html");
+    await expect(page.getByTestId("data-table-overflow")).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    // The empty overflow-menu column header is a known, deferred gap: DataTable's
+    // `{ empty: true }` header has no way for a consumer to supply accessible
+    // (even visually-hidden) text. See the "Related" section in
+    // .context/bugs/datatable-batch-selection-a11y.md — needs a new header API,
+    // not a one-line fix, so it's intentionally excluded here rather than fixed.
+    const violations = results.violations.filter(
+      (v) => v.id !== "empty-table-header",
+    );
+    expect(violations).toEqual([]);
+  });
+
+  test("has no detectable accessibility violations with a row menu open", async ({
+    page,
+  }) => {
+    await page.goto("/data-table-overflow-menu.html");
+    await page.getByRole("button", { name: "menu" }).first().click();
+    await expect(
+      page.getByRole("menuitem", { name: "Edit" }).first(),
+    ).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    // The empty overflow-menu column header is a known, deferred gap: DataTable's
+    // `{ empty: true }` header has no way for a consumer to supply accessible
+    // (even visually-hidden) text. See the "Related" section in
+    // .context/bugs/datatable-batch-selection-a11y.md — needs a new header API,
+    // not a one-line fix, so it's intentionally excluded here rather than fixed.
+    const violations = results.violations.filter(
+      (v) => v.id !== "empty-table-header",
+    );
+    expect(violations).toEqual([]);
+  });
+});

--- a/e2e/a11y-data-table-overflow-menu.test.ts
+++ b/e2e/a11y-data-table-overflow-menu.test.ts
@@ -1,43 +1,33 @@
 import AxeBuilder from "@axe-core/playwright";
 import { expect, test } from "@playwright/test";
 
+// The empty overflow-menu column header is a known, deferred gap: DataTable's
+// `{ empty: true }` header has no way for a consumer to supply accessible
+// (even visually-hidden) text. See the "Related" section in
+// .context/bugs/datatable-batch-selection-a11y.md — needs a new header API,
+// not a one-line fix, so it's intentionally excluded here rather than fixed.
+function withoutKnownGaps(violations) {
+  return violations.filter((v) => v.id !== "empty-table-header");
+}
+
 test.describe("DataTable OverflowMenu a11y", () => {
   test("has no detectable accessibility violations", async ({ page }) => {
     await page.goto("/data-table-overflow-menu.html");
     await expect(page.getByTestId("data-table-overflow")).toBeVisible();
 
-    const results = await new AxeBuilder({ page }).include("#app").analyze();
+    const staticResults = await new AxeBuilder({ page })
+      .include("#app")
+      .analyze();
+    expect(withoutKnownGaps(staticResults.violations)).toEqual([]);
 
-    // The empty overflow-menu column header is a known, deferred gap: DataTable's
-    // `{ empty: true }` header has no way for a consumer to supply accessible
-    // (even visually-hidden) text. See the "Related" section in
-    // .context/bugs/datatable-batch-selection-a11y.md — needs a new header API,
-    // not a one-line fix, so it's intentionally excluded here rather than fixed.
-    const violations = results.violations.filter(
-      (v) => v.id !== "empty-table-header",
-    );
-    expect(violations).toEqual([]);
-  });
-
-  test("has no detectable accessibility violations with a row menu open", async ({
-    page,
-  }) => {
-    await page.goto("/data-table-overflow-menu.html");
     await page.getByRole("button", { name: "menu" }).first().click();
     await expect(
       page.getByRole("menuitem", { name: "Edit" }).first(),
     ).toBeVisible();
 
-    const results = await new AxeBuilder({ page }).include("#app").analyze();
-
-    // The empty overflow-menu column header is a known, deferred gap: DataTable's
-    // `{ empty: true }` header has no way for a consumer to supply accessible
-    // (even visually-hidden) text. See the "Related" section in
-    // .context/bugs/datatable-batch-selection-a11y.md — needs a new header API,
-    // not a one-line fix, so it's intentionally excluded here rather than fixed.
-    const violations = results.violations.filter(
-      (v) => v.id !== "empty-table-header",
-    );
-    expect(violations).toEqual([]);
+    const openResults = await new AxeBuilder({ page })
+      .include("#app")
+      .analyze();
+    expect(withoutKnownGaps(openResults.violations)).toEqual([]);
   });
 });

--- a/e2e/a11y-data-table.test.ts
+++ b/e2e/a11y-data-table.test.ts
@@ -1,0 +1,44 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+test.describe("DataTable a11y", () => {
+  test("has no detectable accessibility violations", async ({ page }) => {
+    await page.goto("/data-table.html");
+    await expect(page.getByTestId("data-table-basic")).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+
+  test("has no detectable accessibility violations after sorting a column", async ({
+    page,
+  }) => {
+    await page.goto("/data-table.html");
+    const sortTable = page.getByTestId("data-table-sort");
+    await sortTable.getByRole("button", { name: /Name/ }).click();
+    await expect(
+      sortTable.locator("th[aria-sort]").filter({ hasText: "Name" }),
+    ).toHaveAttribute("aria-sort", "ascending");
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+
+  test("has no detectable accessibility violations with a row expanded", async ({
+    page,
+  }) => {
+    await page.goto("/data-table.html");
+    const expandTable = page.getByTestId("data-table-expand");
+    await expandTable
+      .getByRole("button", { name: "Expand current row" })
+      .first()
+      .click();
+    await expect(page.getByTestId("expanded-detail").first()).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+});

--- a/e2e/a11y-data-table.test.ts
+++ b/e2e/a11y-data-table.test.ts
@@ -6,30 +6,22 @@ test.describe("DataTable a11y", () => {
     await page.goto("/data-table.html");
     await expect(page.getByTestId("data-table-basic")).toBeVisible();
 
-    const results = await new AxeBuilder({ page }).include("#app").analyze();
+    const staticResults = await new AxeBuilder({ page })
+      .include("#app")
+      .analyze();
+    expect(staticResults.violations).toEqual([]);
 
-    expect(results.violations).toEqual([]);
-  });
-
-  test("has no detectable accessibility violations after sorting a column", async ({
-    page,
-  }) => {
-    await page.goto("/data-table.html");
     const sortTable = page.getByTestId("data-table-sort");
     await sortTable.getByRole("button", { name: /Name/ }).click();
     await expect(
       sortTable.locator("th[aria-sort]").filter({ hasText: "Name" }),
     ).toHaveAttribute("aria-sort", "ascending");
 
-    const results = await new AxeBuilder({ page }).include("#app").analyze();
+    const sortedResults = await new AxeBuilder({ page })
+      .include("#app")
+      .analyze();
+    expect(sortedResults.violations).toEqual([]);
 
-    expect(results.violations).toEqual([]);
-  });
-
-  test("has no detectable accessibility violations with a row expanded", async ({
-    page,
-  }) => {
-    await page.goto("/data-table.html");
     const expandTable = page.getByTestId("data-table-expand");
     await expandTable
       .getByRole("button", { name: "Expand current row" })
@@ -37,8 +29,9 @@ test.describe("DataTable a11y", () => {
       .click();
     await expect(page.getByTestId("expanded-detail").first()).toBeVisible();
 
-    const results = await new AxeBuilder({ page }).include("#app").analyze();
-
-    expect(results.violations).toEqual([]);
+    const expandedResults = await new AxeBuilder({ page })
+      .include("#app")
+      .analyze();
+    expect(expandedResults.violations).toEqual([]);
   });
 });

--- a/e2e/a11y-date-picker.test.ts
+++ b/e2e/a11y-date-picker.test.ts
@@ -6,20 +6,17 @@ test.describe("DatePicker a11y", () => {
     await page.goto("/date-picker.html");
     await expect(page.getByTestId("date-picker-meeting")).toBeVisible();
 
-    const results = await new AxeBuilder({ page }).include("#app").analyze();
+    const staticResults = await new AxeBuilder({ page })
+      .include("#app")
+      .analyze();
+    expect(staticResults.violations).toEqual([]);
 
-    expect(results.violations).toEqual([]);
-  });
-
-  test("has no detectable accessibility violations with the calendar open", async ({
-    page,
-  }) => {
-    await page.goto("/date-picker.html");
     await page.getByTestId("date-picker-meeting").click();
     await expect(page.locator(".flatpickr-calendar.open")).toBeVisible();
 
-    const results = await new AxeBuilder({ page }).include("#app").analyze();
-
-    expect(results.violations).toEqual([]);
+    const openResults = await new AxeBuilder({ page })
+      .include("#app")
+      .analyze();
+    expect(openResults.violations).toEqual([]);
   });
 });

--- a/e2e/a11y-date-picker.test.ts
+++ b/e2e/a11y-date-picker.test.ts
@@ -1,0 +1,25 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+test.describe("DatePicker a11y", () => {
+  test("has no detectable accessibility violations", async ({ page }) => {
+    await page.goto("/date-picker.html");
+    await expect(page.getByTestId("date-picker-meeting")).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+
+  test("has no detectable accessibility violations with the calendar open", async ({
+    page,
+  }) => {
+    await page.goto("/date-picker.html");
+    await page.getByTestId("date-picker-meeting").click();
+    await expect(page.locator(".flatpickr-calendar.open")).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+});

--- a/e2e/a11y-dialog.test.ts
+++ b/e2e/a11y-dialog.test.ts
@@ -1,0 +1,28 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+test.describe("Dialog a11y", () => {
+  test("has no detectable accessibility violations with a modal dialog open", async ({
+    page,
+  }) => {
+    await page.goto("/dialog.html");
+    await page.getByTestId("open-modal").click();
+    await expect(page.getByTestId("modal-focus-target")).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+
+  test("has no detectable accessibility violations with a non-modal dialog open", async ({
+    page,
+  }) => {
+    await page.goto("/dialog.html");
+    await page.getByTestId("open-non-modal").click();
+    await expect(page.getByText("Non-modal content")).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+});

--- a/e2e/a11y-dialog.test.ts
+++ b/e2e/a11y-dialog.test.ts
@@ -2,27 +2,29 @@ import AxeBuilder from "@axe-core/playwright";
 import { expect, test } from "@playwright/test";
 
 test.describe("Dialog a11y", () => {
-  test("has no detectable accessibility violations with a modal dialog open", async ({
-    page,
-  }) => {
+  test("has no detectable accessibility violations", async ({ page }) => {
     await page.goto("/dialog.html");
+
     await page.getByTestId("open-modal").click();
     await expect(page.getByTestId("modal-focus-target")).toBeVisible();
 
-    const results = await new AxeBuilder({ page }).include("#app").analyze();
+    const modalResults = await new AxeBuilder({ page })
+      .include("#app")
+      .analyze();
+    expect(modalResults.violations).toEqual([]);
 
-    expect(results.violations).toEqual([]);
-  });
+    // Native <dialog> closes on Escape by default; close the modal before
+    // opening the non-modal one, since a modal dialog blocks interaction
+    // with everything outside it.
+    await page.keyboard.press("Escape");
+    await expect(page.getByTestId("modal-focus-target")).toBeHidden();
 
-  test("has no detectable accessibility violations with a non-modal dialog open", async ({
-    page,
-  }) => {
-    await page.goto("/dialog.html");
     await page.getByTestId("open-non-modal").click();
     await expect(page.getByText("Non-modal content")).toBeVisible();
 
-    const results = await new AxeBuilder({ page }).include("#app").analyze();
-
-    expect(results.violations).toEqual([]);
+    const nonModalResults = await new AxeBuilder({ page })
+      .include("#app")
+      .analyze();
+    expect(nonModalResults.violations).toEqual([]);
   });
 });

--- a/e2e/a11y-dropdown-scroll-to-selected.test.ts
+++ b/e2e/a11y-dropdown-scroll-to-selected.test.ts
@@ -1,0 +1,16 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+test.describe("Dropdown scroll-to-selected a11y", () => {
+  test("has no detectable accessibility violations with the menu open", async ({
+    page,
+  }) => {
+    await page.goto("/dropdown-scroll-to-selected.html");
+    await page.getByRole("combobox", { name: "Items" }).click();
+    await expect(page.getByRole("option", { name: "Item 43" })).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+});

--- a/e2e/a11y-dropdown.test.ts
+++ b/e2e/a11y-dropdown.test.ts
@@ -6,21 +6,18 @@ test.describe("Dropdown a11y", () => {
     await page.goto("/dropdown.html");
     await expect(page.getByTestId("dropdown-contact")).toBeVisible();
 
-    const results = await new AxeBuilder({ page }).include("#app").analyze();
+    const staticResults = await new AxeBuilder({ page })
+      .include("#app")
+      .analyze();
+    expect(staticResults.violations).toEqual([]);
 
-    expect(results.violations).toEqual([]);
-  });
-
-  test("has no detectable accessibility violations with the menu open", async ({
-    page,
-  }) => {
-    await page.goto("/dropdown.html");
     await page.getByRole("combobox", { name: "Contact" }).click();
     await expect(page.getByRole("listbox")).toBeVisible();
     await expect(page.getByRole("option", { name: "Slack" })).toBeVisible();
 
-    const results = await new AxeBuilder({ page }).include("#app").analyze();
-
-    expect(results.violations).toEqual([]);
+    const openResults = await new AxeBuilder({ page })
+      .include("#app")
+      .analyze();
+    expect(openResults.violations).toEqual([]);
   });
 });

--- a/e2e/a11y-dropdown.test.ts
+++ b/e2e/a11y-dropdown.test.ts
@@ -1,0 +1,26 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+test.describe("Dropdown a11y", () => {
+  test("has no detectable accessibility violations", async ({ page }) => {
+    await page.goto("/dropdown.html");
+    await expect(page.getByTestId("dropdown-contact")).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+
+  test("has no detectable accessibility violations with the menu open", async ({
+    page,
+  }) => {
+    await page.goto("/dropdown.html");
+    await page.getByRole("combobox", { name: "Contact" }).click();
+    await expect(page.getByRole("listbox")).toBeVisible();
+    await expect(page.getByRole("option", { name: "Slack" })).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+});

--- a/e2e/a11y-expandable-tile.test.ts
+++ b/e2e/a11y-expandable-tile.test.ts
@@ -1,0 +1,28 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+test.describe("ExpandableTile a11y", () => {
+  test("has no detectable accessibility violations", async ({ page }) => {
+    await page.goto("/expandable-tile.html");
+    await expect(page.getByTestId("expandable-tile")).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+
+  test("has no detectable accessibility violations when expanded", async ({
+    page,
+  }) => {
+    await page.goto("/expandable-tile.html");
+    await page.getByTestId("expandable-tile").click();
+    await expect(page.getByTestId("expandable-tile")).toHaveAttribute(
+      "aria-expanded",
+      "true",
+    );
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+});

--- a/e2e/a11y-expandable-tile.test.ts
+++ b/e2e/a11y-expandable-tile.test.ts
@@ -6,23 +6,20 @@ test.describe("ExpandableTile a11y", () => {
     await page.goto("/expandable-tile.html");
     await expect(page.getByTestId("expandable-tile")).toBeVisible();
 
-    const results = await new AxeBuilder({ page }).include("#app").analyze();
+    const staticResults = await new AxeBuilder({ page })
+      .include("#app")
+      .analyze();
+    expect(staticResults.violations).toEqual([]);
 
-    expect(results.violations).toEqual([]);
-  });
-
-  test("has no detectable accessibility violations when expanded", async ({
-    page,
-  }) => {
-    await page.goto("/expandable-tile.html");
     await page.getByTestId("expandable-tile").click();
     await expect(page.getByTestId("expandable-tile")).toHaveAttribute(
       "aria-expanded",
       "true",
     );
 
-    const results = await new AxeBuilder({ page }).include("#app").analyze();
-
-    expect(results.violations).toEqual([]);
+    const expandedResults = await new AxeBuilder({ page })
+      .include("#app")
+      .analyze();
+    expect(expandedResults.violations).toEqual([]);
   });
 });

--- a/e2e/a11y-file-uploader.test.ts
+++ b/e2e/a11y-file-uploader.test.ts
@@ -1,0 +1,13 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+test.describe("FileUploader a11y", () => {
+  test("has no detectable accessibility violations", async ({ page }) => {
+    await page.goto("/file-uploader.html");
+    await expect(page.getByTestId("file-uploader")).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+});

--- a/e2e/a11y-inline-notification.test.ts
+++ b/e2e/a11y-inline-notification.test.ts
@@ -1,0 +1,13 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+test.describe("InlineNotification a11y", () => {
+  test("has no detectable accessibility violations", async ({ page }) => {
+    await page.goto("/inline-notification.html");
+    await expect(page.getByTestId("inline-notification")).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+});

--- a/e2e/a11y-link.test.ts
+++ b/e2e/a11y-link.test.ts
@@ -1,0 +1,13 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+test.describe("Link a11y", () => {
+  test("has no detectable accessibility violations", async ({ page }) => {
+    await page.goto("/link.html");
+    await expect(page.getByTestId("link-md")).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+});

--- a/e2e/a11y-menu-button.test.ts
+++ b/e2e/a11y-menu-button.test.ts
@@ -6,21 +6,18 @@ test.describe("MenuButton a11y", () => {
     await page.goto("/menu-button.html");
     await expect(page.getByRole("button", { name: "Actions" })).toBeVisible();
 
-    const results = await new AxeBuilder({ page }).include("#app").analyze();
+    const staticResults = await new AxeBuilder({ page })
+      .include("#app")
+      .analyze();
+    expect(staticResults.violations).toEqual([]);
 
-    expect(results.violations).toEqual([]);
-  });
-
-  test("has no detectable accessibility violations with the menu open", async ({
-    page,
-  }) => {
-    await page.goto("/menu-button.html");
     await page.getByRole("button", { name: "Actions" }).click();
     await expect(page.getByRole("menu")).toBeVisible();
     await expect(page.getByRole("menuitem", { name: "Cut" })).toBeVisible();
 
-    const results = await new AxeBuilder({ page }).include("#app").analyze();
-
-    expect(results.violations).toEqual([]);
+    const openResults = await new AxeBuilder({ page })
+      .include("#app")
+      .analyze();
+    expect(openResults.violations).toEqual([]);
   });
 });

--- a/e2e/a11y-menu-button.test.ts
+++ b/e2e/a11y-menu-button.test.ts
@@ -1,0 +1,26 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+test.describe("MenuButton a11y", () => {
+  test("has no detectable accessibility violations", async ({ page }) => {
+    await page.goto("/menu-button.html");
+    await expect(page.getByRole("button", { name: "Actions" })).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+
+  test("has no detectable accessibility violations with the menu open", async ({
+    page,
+  }) => {
+    await page.goto("/menu-button.html");
+    await page.getByRole("button", { name: "Actions" }).click();
+    await expect(page.getByRole("menu")).toBeVisible();
+    await expect(page.getByRole("menuitem", { name: "Cut" })).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+});

--- a/e2e/a11y-modal.test.ts
+++ b/e2e/a11y-modal.test.ts
@@ -1,0 +1,16 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+test.describe("Modal a11y", () => {
+  test("has no detectable accessibility violations when open", async ({
+    page,
+  }) => {
+    await page.goto("/modal.html");
+    await page.getByTestId("open-modal").click();
+    await expect(page.getByTestId("modal-body")).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+});

--- a/e2e/a11y-multiselect.test.ts
+++ b/e2e/a11y-multiselect.test.ts
@@ -6,21 +6,18 @@ test.describe("MultiSelect a11y", () => {
     await page.goto("/multiselect.html");
     await expect(page.getByTestId("multiselect-fruits")).toBeVisible();
 
-    const results = await new AxeBuilder({ page }).include("#app").analyze();
+    const staticResults = await new AxeBuilder({ page })
+      .include("#app")
+      .analyze();
+    expect(staticResults.violations).toEqual([]);
 
-    expect(results.violations).toEqual([]);
-  });
-
-  test("has no detectable accessibility violations with the menu open", async ({
-    page,
-  }) => {
-    await page.goto("/multiselect.html");
     await page.getByRole("combobox", { name: "Fruits" }).click();
     await expect(page.getByRole("listbox").first()).toBeVisible();
     await expect(page.getByRole("option", { name: "Apple" })).toBeVisible();
 
-    const results = await new AxeBuilder({ page }).include("#app").analyze();
-
-    expect(results.violations).toEqual([]);
+    const openResults = await new AxeBuilder({ page })
+      .include("#app")
+      .analyze();
+    expect(openResults.violations).toEqual([]);
   });
 });

--- a/e2e/a11y-multiselect.test.ts
+++ b/e2e/a11y-multiselect.test.ts
@@ -1,0 +1,26 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+test.describe("MultiSelect a11y", () => {
+  test("has no detectable accessibility violations", async ({ page }) => {
+    await page.goto("/multiselect.html");
+    await expect(page.getByTestId("multiselect-fruits")).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+
+  test("has no detectable accessibility violations with the menu open", async ({
+    page,
+  }) => {
+    await page.goto("/multiselect.html");
+    await page.getByRole("combobox", { name: "Fruits" }).click();
+    await expect(page.getByRole("listbox").first()).toBeVisible();
+    await expect(page.getByRole("option", { name: "Apple" })).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+});

--- a/e2e/a11y-notification-queue.test.ts
+++ b/e2e/a11y-notification-queue.test.ts
@@ -6,20 +6,17 @@ test.describe("NotificationQueue a11y", () => {
     await page.goto("/notification-queue.html");
     await expect(page.getByTestId("notification-queue-root")).toBeVisible();
 
-    const results = await new AxeBuilder({ page }).include("#app").analyze();
+    const staticResults = await new AxeBuilder({ page })
+      .include("#app")
+      .analyze();
+    expect(staticResults.violations).toEqual([]);
 
-    expect(results.violations).toEqual([]);
-  });
-
-  test("has no detectable accessibility violations with a toast visible", async ({
-    page,
-  }) => {
-    await page.goto("/notification-queue.html");
     await page.getByTestId("nq-add").click();
     await expect(page.getByText("Toast A")).toBeVisible();
 
-    const results = await new AxeBuilder({ page }).include("#app").analyze();
-
-    expect(results.violations).toEqual([]);
+    const toastResults = await new AxeBuilder({ page })
+      .include("#app")
+      .analyze();
+    expect(toastResults.violations).toEqual([]);
   });
 });

--- a/e2e/a11y-notification-queue.test.ts
+++ b/e2e/a11y-notification-queue.test.ts
@@ -1,0 +1,25 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+test.describe("NotificationQueue a11y", () => {
+  test("has no detectable accessibility violations", async ({ page }) => {
+    await page.goto("/notification-queue.html");
+    await expect(page.getByTestId("notification-queue-root")).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+
+  test("has no detectable accessibility violations with a toast visible", async ({
+    page,
+  }) => {
+    await page.goto("/notification-queue.html");
+    await page.getByTestId("nq-add").click();
+    await expect(page.getByText("Toast A")).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+});

--- a/e2e/a11y-number-input.test.ts
+++ b/e2e/a11y-number-input.test.ts
@@ -1,0 +1,27 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+test.describe("NumberInput a11y", () => {
+  test("has no detectable accessibility violations", async ({ page }) => {
+    await page.goto("/number-input.html");
+    await expect(page.getByTestId("number-input-quantity")).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+
+  test("has no detectable accessibility violations after incrementing", async ({
+    page,
+  }) => {
+    await page.goto("/number-input.html");
+    await page
+      .getByRole("button", { name: "Increment number" })
+      .first()
+      .click();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+});

--- a/e2e/a11y-number-input.test.ts
+++ b/e2e/a11y-number-input.test.ts
@@ -6,22 +6,19 @@ test.describe("NumberInput a11y", () => {
     await page.goto("/number-input.html");
     await expect(page.getByTestId("number-input-quantity")).toBeVisible();
 
-    const results = await new AxeBuilder({ page }).include("#app").analyze();
+    const staticResults = await new AxeBuilder({ page })
+      .include("#app")
+      .analyze();
+    expect(staticResults.violations).toEqual([]);
 
-    expect(results.violations).toEqual([]);
-  });
-
-  test("has no detectable accessibility violations after incrementing", async ({
-    page,
-  }) => {
-    await page.goto("/number-input.html");
     await page
       .getByRole("button", { name: "Increment number" })
       .first()
       .click();
 
-    const results = await new AxeBuilder({ page }).include("#app").analyze();
-
-    expect(results.violations).toEqual([]);
+    const incrementedResults = await new AxeBuilder({ page })
+      .include("#app")
+      .analyze();
+    expect(incrementedResults.violations).toEqual([]);
   });
 });

--- a/e2e/a11y-overflow-menu.test.ts
+++ b/e2e/a11y-overflow-menu.test.ts
@@ -6,23 +6,20 @@ test.describe("OverflowMenu a11y", () => {
     await page.goto("/overflow-menu.html");
     await expect(page.getByTestId("overflow-menu")).toBeVisible();
 
-    const results = await new AxeBuilder({ page }).include("#app").analyze();
+    const staticResults = await new AxeBuilder({ page })
+      .include("#app")
+      .analyze();
+    expect(staticResults.violations).toEqual([]);
 
-    expect(results.violations).toEqual([]);
-  });
-
-  test("has no detectable accessibility violations with the menu open", async ({
-    page,
-  }) => {
-    await page.goto("/overflow-menu.html");
     await page.getByRole("button", { name: "Actions" }).click();
     await expect(page.getByRole("menu")).toBeVisible();
     await expect(
       page.getByRole("menuitem", { name: "Action 1" }),
     ).toBeVisible();
 
-    const results = await new AxeBuilder({ page }).include("#app").analyze();
-
-    expect(results.violations).toEqual([]);
+    const openResults = await new AxeBuilder({ page })
+      .include("#app")
+      .analyze();
+    expect(openResults.violations).toEqual([]);
   });
 });

--- a/e2e/a11y-overflow-menu.test.ts
+++ b/e2e/a11y-overflow-menu.test.ts
@@ -1,0 +1,28 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+test.describe("OverflowMenu a11y", () => {
+  test("has no detectable accessibility violations", async ({ page }) => {
+    await page.goto("/overflow-menu.html");
+    await expect(page.getByTestId("overflow-menu")).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+
+  test("has no detectable accessibility violations with the menu open", async ({
+    page,
+  }) => {
+    await page.goto("/overflow-menu.html");
+    await page.getByRole("button", { name: "Actions" }).click();
+    await expect(page.getByRole("menu")).toBeVisible();
+    await expect(
+      page.getByRole("menuitem", { name: "Action 1" }),
+    ).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+});

--- a/e2e/a11y-pagination-nav.test.ts
+++ b/e2e/a11y-pagination-nav.test.ts
@@ -1,0 +1,28 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+test.describe("PaginationNav a11y", () => {
+  test("has no detectable accessibility violations", async ({ page }) => {
+    await page.goto("/pagination-nav.html");
+    await expect(page.getByTestId("pagination-nav")).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+
+  test("has no detectable accessibility violations after navigating to a page", async ({
+    page,
+  }) => {
+    await page.goto("/pagination-nav.html");
+    await page.locator('button[data-page="3"]').click();
+    await expect(page.locator('button[data-page="3"]')).toHaveAttribute(
+      "aria-current",
+      "page",
+    );
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+});

--- a/e2e/a11y-pagination-nav.test.ts
+++ b/e2e/a11y-pagination-nav.test.ts
@@ -6,23 +6,20 @@ test.describe("PaginationNav a11y", () => {
     await page.goto("/pagination-nav.html");
     await expect(page.getByTestId("pagination-nav")).toBeVisible();
 
-    const results = await new AxeBuilder({ page }).include("#app").analyze();
+    const staticResults = await new AxeBuilder({ page })
+      .include("#app")
+      .analyze();
+    expect(staticResults.violations).toEqual([]);
 
-    expect(results.violations).toEqual([]);
-  });
-
-  test("has no detectable accessibility violations after navigating to a page", async ({
-    page,
-  }) => {
-    await page.goto("/pagination-nav.html");
     await page.locator('button[data-page="3"]').click();
     await expect(page.locator('button[data-page="3"]')).toHaveAttribute(
       "aria-current",
       "page",
     );
 
-    const results = await new AxeBuilder({ page }).include("#app").analyze();
-
-    expect(results.violations).toEqual([]);
+    const navigatedResults = await new AxeBuilder({ page })
+      .include("#app")
+      .analyze();
+    expect(navigatedResults.violations).toEqual([]);
   });
 });

--- a/e2e/a11y-pagination.test.ts
+++ b/e2e/a11y-pagination.test.ts
@@ -1,0 +1,13 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+test.describe("Pagination a11y", () => {
+  test("has no detectable accessibility violations", async ({ page }) => {
+    await page.goto("/pagination.html");
+    await expect(page.getByTestId("pagination")).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+});

--- a/e2e/a11y-password-input.test.ts
+++ b/e2e/a11y-password-input.test.ts
@@ -1,0 +1,28 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+test.describe("PasswordInput a11y", () => {
+  test("has no detectable accessibility violations", async ({ page }) => {
+    await page.goto("/password-input.html");
+    await expect(page.getByTestId("password-input")).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+
+  test("has no detectable accessibility violations after revealing the password", async ({
+    page,
+  }) => {
+    await page.goto("/password-input.html");
+    await page.getByRole("button", { name: "Show password" }).click();
+    await expect(page.getByTestId("password-input")).toHaveAttribute(
+      "type",
+      "text",
+    );
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+});

--- a/e2e/a11y-password-input.test.ts
+++ b/e2e/a11y-password-input.test.ts
@@ -6,23 +6,20 @@ test.describe("PasswordInput a11y", () => {
     await page.goto("/password-input.html");
     await expect(page.getByTestId("password-input")).toBeVisible();
 
-    const results = await new AxeBuilder({ page }).include("#app").analyze();
+    const staticResults = await new AxeBuilder({ page })
+      .include("#app")
+      .analyze();
+    expect(staticResults.violations).toEqual([]);
 
-    expect(results.violations).toEqual([]);
-  });
-
-  test("has no detectable accessibility violations after revealing the password", async ({
-    page,
-  }) => {
-    await page.goto("/password-input.html");
     await page.getByRole("button", { name: "Show password" }).click();
     await expect(page.getByTestId("password-input")).toHaveAttribute(
       "type",
       "text",
     );
 
-    const results = await new AxeBuilder({ page }).include("#app").analyze();
-
-    expect(results.violations).toEqual([]);
+    const revealedResults = await new AxeBuilder({ page })
+      .include("#app")
+      .analyze();
+    expect(revealedResults.violations).toEqual([]);
   });
 });

--- a/e2e/a11y-pin-code-input.test.ts
+++ b/e2e/a11y-pin-code-input.test.ts
@@ -1,0 +1,13 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+test.describe("PinCodeInput a11y", () => {
+  test("has no detectable accessibility violations", async ({ page }) => {
+    await page.goto("/pin-code-input.html");
+    await expect(page.getByTestId("pin-code-input-default")).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+});

--- a/e2e/a11y-popover.test.ts
+++ b/e2e/a11y-popover.test.ts
@@ -1,0 +1,25 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+test.describe("Popover a11y", () => {
+  test("has no detectable accessibility violations", async ({ page }) => {
+    await page.goto("/popover.html");
+    await expect(page.getByTestId("open-popover")).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+
+  test("has no detectable accessibility violations when open", async ({
+    page,
+  }) => {
+    await page.goto("/popover.html");
+    await page.getByTestId("open-popover").click();
+    await expect(page.getByTestId("popover-content")).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+});

--- a/e2e/a11y-popover.test.ts
+++ b/e2e/a11y-popover.test.ts
@@ -6,20 +6,17 @@ test.describe("Popover a11y", () => {
     await page.goto("/popover.html");
     await expect(page.getByTestId("open-popover")).toBeVisible();
 
-    const results = await new AxeBuilder({ page }).include("#app").analyze();
+    const staticResults = await new AxeBuilder({ page })
+      .include("#app")
+      .analyze();
+    expect(staticResults.violations).toEqual([]);
 
-    expect(results.violations).toEqual([]);
-  });
-
-  test("has no detectable accessibility violations when open", async ({
-    page,
-  }) => {
-    await page.goto("/popover.html");
     await page.getByTestId("open-popover").click();
     await expect(page.getByTestId("popover-content")).toBeVisible();
 
-    const results = await new AxeBuilder({ page }).include("#app").analyze();
-
-    expect(results.violations).toEqual([]);
+    const openResults = await new AxeBuilder({ page })
+      .include("#app")
+      .analyze();
+    expect(openResults.violations).toEqual([]);
   });
 });

--- a/e2e/a11y-progress-indicator.test.ts
+++ b/e2e/a11y-progress-indicator.test.ts
@@ -1,0 +1,13 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+test.describe("ProgressIndicator a11y", () => {
+  test("has no detectable accessibility violations", async ({ page }) => {
+    await page.goto("/progress-indicator.html");
+    await expect(page.getByTestId("progress-indicator")).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+});

--- a/e2e/a11y-radio-button-group.test.ts
+++ b/e2e/a11y-radio-button-group.test.ts
@@ -6,15 +6,11 @@ test.describe("RadioButtonGroup a11y", () => {
     await page.goto("/radio-button-group.html");
     await expect(page.getByTestId("radio-group-choice")).toBeVisible();
 
-    const results = await new AxeBuilder({ page }).include("#app").analyze();
+    const staticResults = await new AxeBuilder({ page })
+      .include("#app")
+      .analyze();
+    expect(staticResults.violations).toEqual([]);
 
-    expect(results.violations).toEqual([]);
-  });
-
-  test("has no detectable accessibility violations after selecting a different option", async ({
-    page,
-  }) => {
-    await page.goto("/radio-button-group.html");
     await page.getByRole("radio", { name: "Option Two" }).click({
       force: true,
     });
@@ -22,8 +18,9 @@ test.describe("RadioButtonGroup a11y", () => {
       "Selected: two",
     );
 
-    const results = await new AxeBuilder({ page }).include("#app").analyze();
-
-    expect(results.violations).toEqual([]);
+    const selectedResults = await new AxeBuilder({ page })
+      .include("#app")
+      .analyze();
+    expect(selectedResults.violations).toEqual([]);
   });
 });

--- a/e2e/a11y-radio-button-group.test.ts
+++ b/e2e/a11y-radio-button-group.test.ts
@@ -1,0 +1,29 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+test.describe("RadioButtonGroup a11y", () => {
+  test("has no detectable accessibility violations", async ({ page }) => {
+    await page.goto("/radio-button-group.html");
+    await expect(page.getByTestId("radio-group-choice")).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+
+  test("has no detectable accessibility violations after selecting a different option", async ({
+    page,
+  }) => {
+    await page.goto("/radio-button-group.html");
+    await page.getByRole("radio", { name: "Option Two" }).click({
+      force: true,
+    });
+    await expect(page.getByTestId("selected-value")).toHaveText(
+      "Selected: two",
+    );
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+});

--- a/e2e/a11y-radio-tile.test.ts
+++ b/e2e/a11y-radio-tile.test.ts
@@ -6,20 +6,17 @@ test.describe("RadioTile a11y", () => {
     await page.goto("/radio-tile.html");
     await expect(page.getByTestId("radio-tile-group")).toBeVisible();
 
-    const results = await new AxeBuilder({ page }).include("#app").analyze();
+    const staticResults = await new AxeBuilder({ page })
+      .include("#app")
+      .analyze();
+    expect(staticResults.violations).toEqual([]);
 
-    expect(results.violations).toEqual([]);
-  });
-
-  test("has no detectable accessibility violations after selecting a tile", async ({
-    page,
-  }) => {
-    await page.goto("/radio-tile.html");
     await page.getByTestId("radio-tile-a").click();
     await expect(page.getByTestId("selected-value")).toHaveText("a");
 
-    const results = await new AxeBuilder({ page }).include("#app").analyze();
-
-    expect(results.violations).toEqual([]);
+    const selectedResults = await new AxeBuilder({ page })
+      .include("#app")
+      .analyze();
+    expect(selectedResults.violations).toEqual([]);
   });
 });

--- a/e2e/a11y-radio-tile.test.ts
+++ b/e2e/a11y-radio-tile.test.ts
@@ -1,0 +1,25 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+test.describe("RadioTile a11y", () => {
+  test("has no detectable accessibility violations", async ({ page }) => {
+    await page.goto("/radio-tile.html");
+    await expect(page.getByTestId("radio-tile-group")).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+
+  test("has no detectable accessibility violations after selecting a tile", async ({
+    page,
+  }) => {
+    await page.goto("/radio-tile.html");
+    await page.getByTestId("radio-tile-a").click();
+    await expect(page.getByTestId("selected-value")).toHaveText("a");
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+});

--- a/e2e/a11y-range-slider.test.ts
+++ b/e2e/a11y-range-slider.test.ts
@@ -1,0 +1,26 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+test.describe("RangeSlider a11y", () => {
+  test("has no detectable accessibility violations", async ({ page }) => {
+    await page.goto("/range-slider.html");
+    await expect(page.getByTestId("range-slider")).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+
+  test("has no detectable accessibility violations after changing the lower bound", async ({
+    page,
+  }) => {
+    await page.goto("/range-slider.html");
+    await page.getByRole("slider", { name: "Lower bound" }).focus();
+    await page.keyboard.press("ArrowRight");
+    await expect(page.getByTestId("value-display")).toHaveText("21");
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+});

--- a/e2e/a11y-range-slider.test.ts
+++ b/e2e/a11y-range-slider.test.ts
@@ -6,21 +6,18 @@ test.describe("RangeSlider a11y", () => {
     await page.goto("/range-slider.html");
     await expect(page.getByTestId("range-slider")).toBeVisible();
 
-    const results = await new AxeBuilder({ page }).include("#app").analyze();
+    const staticResults = await new AxeBuilder({ page })
+      .include("#app")
+      .analyze();
+    expect(staticResults.violations).toEqual([]);
 
-    expect(results.violations).toEqual([]);
-  });
-
-  test("has no detectable accessibility violations after changing the lower bound", async ({
-    page,
-  }) => {
-    await page.goto("/range-slider.html");
     await page.getByRole("slider", { name: "Lower bound" }).focus();
     await page.keyboard.press("ArrowRight");
     await expect(page.getByTestId("value-display")).toHaveText("21");
 
-    const results = await new AxeBuilder({ page }).include("#app").analyze();
-
-    expect(results.violations).toEqual([]);
+    const changedResults = await new AxeBuilder({ page })
+      .include("#app")
+      .analyze();
+    expect(changedResults.violations).toEqual([]);
   });
 });

--- a/e2e/a11y-search-menu.test.ts
+++ b/e2e/a11y-search-menu.test.ts
@@ -6,23 +6,20 @@ test.describe("SearchMenu a11y", () => {
     await page.goto("/search-menu.html");
     await expect(page.getByTestId("search-input")).toBeVisible();
 
-    const results = await new AxeBuilder({ page }).include("#app").analyze();
+    const staticResults = await new AxeBuilder({ page })
+      .include("#app")
+      .analyze();
+    expect(staticResults.violations).toEqual([]);
 
-    expect(results.violations).toEqual([]);
-  });
-
-  test("has no detectable accessibility violations with results open", async ({
-    page,
-  }) => {
-    await page.goto("/search-menu.html");
     await page.getByRole("combobox", { name: "Search" }).click();
     await expect(page.getByRole("listbox").first()).toBeVisible();
     await expect(
       page.getByRole("option", { name: "recent vpc" }),
     ).toBeVisible();
 
-    const results = await new AxeBuilder({ page }).include("#app").analyze();
-
-    expect(results.violations).toEqual([]);
+    const openResults = await new AxeBuilder({ page })
+      .include("#app")
+      .analyze();
+    expect(openResults.violations).toEqual([]);
   });
 });

--- a/e2e/a11y-search-menu.test.ts
+++ b/e2e/a11y-search-menu.test.ts
@@ -1,0 +1,28 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+test.describe("SearchMenu a11y", () => {
+  test("has no detectable accessibility violations", async ({ page }) => {
+    await page.goto("/search-menu.html");
+    await expect(page.getByTestId("search-input")).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+
+  test("has no detectable accessibility violations with results open", async ({
+    page,
+  }) => {
+    await page.goto("/search-menu.html");
+    await page.getByRole("combobox", { name: "Search" }).click();
+    await expect(page.getByRole("listbox").first()).toBeVisible();
+    await expect(
+      page.getByRole("option", { name: "recent vpc" }),
+    ).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+});

--- a/e2e/a11y-search.test.ts
+++ b/e2e/a11y-search.test.ts
@@ -1,0 +1,39 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+test.describe("Search a11y", () => {
+  test("has no detectable accessibility violations", async ({ page }) => {
+    await page.goto("/search.html");
+    await expect(page.getByTestId("search-query")).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+
+  test("has no detectable accessibility violations with a value and the clear button visible", async ({
+    page,
+  }) => {
+    await page.goto("/search.html");
+    await page.getByTestId("search-query").fill("carbon");
+    await expect(
+      page.getByRole("button", { name: "Clear search input" }),
+    ).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+
+  test("has no detectable accessibility violations when expanded", async ({
+    page,
+  }) => {
+    await page.goto("/search.html");
+    await page.getByTestId("search-expandable").focus();
+    await expect(page.getByTestId("search-expandable")).toBeFocused();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+});

--- a/e2e/a11y-search.test.ts
+++ b/e2e/a11y-search.test.ts
@@ -6,34 +6,27 @@ test.describe("Search a11y", () => {
     await page.goto("/search.html");
     await expect(page.getByTestId("search-query")).toBeVisible();
 
-    const results = await new AxeBuilder({ page }).include("#app").analyze();
+    const staticResults = await new AxeBuilder({ page })
+      .include("#app")
+      .analyze();
+    expect(staticResults.violations).toEqual([]);
 
-    expect(results.violations).toEqual([]);
-  });
-
-  test("has no detectable accessibility violations with a value and the clear button visible", async ({
-    page,
-  }) => {
-    await page.goto("/search.html");
     await page.getByTestId("search-query").fill("carbon");
     await expect(
       page.getByRole("button", { name: "Clear search input" }),
     ).toBeVisible();
 
-    const results = await new AxeBuilder({ page }).include("#app").analyze();
+    const withValueResults = await new AxeBuilder({ page })
+      .include("#app")
+      .analyze();
+    expect(withValueResults.violations).toEqual([]);
 
-    expect(results.violations).toEqual([]);
-  });
-
-  test("has no detectable accessibility violations when expanded", async ({
-    page,
-  }) => {
-    await page.goto("/search.html");
     await page.getByTestId("search-expandable").focus();
     await expect(page.getByTestId("search-expandable")).toBeFocused();
 
-    const results = await new AxeBuilder({ page }).include("#app").analyze();
-
-    expect(results.violations).toEqual([]);
+    const expandedResults = await new AxeBuilder({ page })
+      .include("#app")
+      .analyze();
+    expect(expandedResults.violations).toEqual([]);
   });
 });

--- a/e2e/a11y-select.test.ts
+++ b/e2e/a11y-select.test.ts
@@ -1,0 +1,13 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+test.describe("Select a11y", () => {
+  test("has no detectable accessibility violations", async ({ page }) => {
+    await page.goto("/select.html");
+    await expect(page.getByTestId("select-country")).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+});

--- a/e2e/a11y-selectable-tile.test.ts
+++ b/e2e/a11y-selectable-tile.test.ts
@@ -1,0 +1,25 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+test.describe("SelectableTile a11y", () => {
+  test("has no detectable accessibility violations", async ({ page }) => {
+    await page.goto("/selectable-tile.html");
+    await expect(page.getByTestId("selectable-tile-group")).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+
+  test("has no detectable accessibility violations after selecting a tile", async ({
+    page,
+  }) => {
+    await page.goto("/selectable-tile.html");
+    await page.getByTestId("selectable-tile-x").click();
+    await expect(page.getByTestId("selected-values")).toHaveText("x");
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+});

--- a/e2e/a11y-selectable-tile.test.ts
+++ b/e2e/a11y-selectable-tile.test.ts
@@ -6,20 +6,17 @@ test.describe("SelectableTile a11y", () => {
     await page.goto("/selectable-tile.html");
     await expect(page.getByTestId("selectable-tile-group")).toBeVisible();
 
-    const results = await new AxeBuilder({ page }).include("#app").analyze();
+    const staticResults = await new AxeBuilder({ page })
+      .include("#app")
+      .analyze();
+    expect(staticResults.violations).toEqual([]);
 
-    expect(results.violations).toEqual([]);
-  });
-
-  test("has no detectable accessibility violations after selecting a tile", async ({
-    page,
-  }) => {
-    await page.goto("/selectable-tile.html");
     await page.getByTestId("selectable-tile-x").click();
     await expect(page.getByTestId("selected-values")).toHaveText("x");
 
-    const results = await new AxeBuilder({ page }).include("#app").analyze();
-
-    expect(results.violations).toEqual([]);
+    const selectedResults = await new AxeBuilder({ page })
+      .include("#app")
+      .analyze();
+    expect(selectedResults.violations).toEqual([]);
   });
 });

--- a/e2e/a11y-slider.test.ts
+++ b/e2e/a11y-slider.test.ts
@@ -1,0 +1,26 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+test.describe("Slider a11y", () => {
+  test("has no detectable accessibility violations", async ({ page }) => {
+    await page.goto("/slider.html");
+    await expect(page.getByTestId("slider")).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+
+  test("has no detectable accessibility violations after changing the value", async ({
+    page,
+  }) => {
+    await page.goto("/slider.html");
+    await page.getByRole("slider", { name: "Slider" }).focus();
+    await page.keyboard.press("ArrowRight");
+    await expect(page.getByTestId("value-display")).toHaveText("51");
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+});

--- a/e2e/a11y-slider.test.ts
+++ b/e2e/a11y-slider.test.ts
@@ -6,21 +6,18 @@ test.describe("Slider a11y", () => {
     await page.goto("/slider.html");
     await expect(page.getByTestId("slider")).toBeVisible();
 
-    const results = await new AxeBuilder({ page }).include("#app").analyze();
+    const staticResults = await new AxeBuilder({ page })
+      .include("#app")
+      .analyze();
+    expect(staticResults.violations).toEqual([]);
 
-    expect(results.violations).toEqual([]);
-  });
-
-  test("has no detectable accessibility violations after changing the value", async ({
-    page,
-  }) => {
-    await page.goto("/slider.html");
     await page.getByRole("slider", { name: "Slider" }).focus();
     await page.keyboard.press("ArrowRight");
     await expect(page.getByTestId("value-display")).toHaveText("51");
 
-    const results = await new AxeBuilder({ page }).include("#app").analyze();
-
-    expect(results.violations).toEqual([]);
+    const changedResults = await new AxeBuilder({ page })
+      .include("#app")
+      .analyze();
+    expect(changedResults.violations).toEqual([]);
   });
 });

--- a/e2e/a11y-structured-list.test.ts
+++ b/e2e/a11y-structured-list.test.ts
@@ -6,20 +6,17 @@ test.describe("StructuredList a11y", () => {
     await page.goto("/structured-list.html");
     await expect(page.getByTestId("structured-list")).toBeVisible();
 
-    const results = await new AxeBuilder({ page }).include("#app").analyze();
+    const staticResults = await new AxeBuilder({ page })
+      .include("#app")
+      .analyze();
+    expect(staticResults.violations).toEqual([]);
 
-    expect(results.violations).toEqual([]);
-  });
-
-  test("has no detectable accessibility violations after selecting a row", async ({
-    page,
-  }) => {
-    await page.goto("/structured-list.html");
     await page.getByText("Row A").click();
     await expect(page.getByTestId("selected-value")).toHaveText("a");
 
-    const results = await new AxeBuilder({ page }).include("#app").analyze();
-
-    expect(results.violations).toEqual([]);
+    const selectedResults = await new AxeBuilder({ page })
+      .include("#app")
+      .analyze();
+    expect(selectedResults.violations).toEqual([]);
   });
 });

--- a/e2e/a11y-structured-list.test.ts
+++ b/e2e/a11y-structured-list.test.ts
@@ -1,0 +1,25 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+test.describe("StructuredList a11y", () => {
+  test("has no detectable accessibility violations", async ({ page }) => {
+    await page.goto("/structured-list.html");
+    await expect(page.getByTestId("structured-list")).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+
+  test("has no detectable accessibility violations after selecting a row", async ({
+    page,
+  }) => {
+    await page.goto("/structured-list.html");
+    await page.getByText("Row A").click();
+    await expect(page.getByTestId("selected-value")).toHaveText("a");
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+});

--- a/e2e/a11y-tabs-overflow.test.ts
+++ b/e2e/a11y-tabs-overflow.test.ts
@@ -1,0 +1,13 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+test.describe("Tabs overflow a11y", () => {
+  test("has no detectable accessibility violations", async ({ page }) => {
+    await page.goto("/tabs-overflow.html");
+    await expect(page.getByTestId("tabs-overflow")).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+});

--- a/e2e/a11y-tabs.test.ts
+++ b/e2e/a11y-tabs.test.ts
@@ -1,0 +1,25 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+test.describe("Tabs a11y", () => {
+  test("has no detectable accessibility violations", async ({ page }) => {
+    await page.goto("/tabs.html");
+    await expect(page.getByTestId("tab-content-1")).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+
+  test("has no detectable accessibility violations after switching tabs", async ({
+    page,
+  }) => {
+    await page.goto("/tabs.html");
+    await page.getByRole("tab", { name: "Tab 2" }).click();
+    await expect(page.getByTestId("tab-content-2")).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+});

--- a/e2e/a11y-tabs.test.ts
+++ b/e2e/a11y-tabs.test.ts
@@ -6,20 +6,17 @@ test.describe("Tabs a11y", () => {
     await page.goto("/tabs.html");
     await expect(page.getByTestId("tab-content-1")).toBeVisible();
 
-    const results = await new AxeBuilder({ page }).include("#app").analyze();
+    const staticResults = await new AxeBuilder({ page })
+      .include("#app")
+      .analyze();
+    expect(staticResults.violations).toEqual([]);
 
-    expect(results.violations).toEqual([]);
-  });
-
-  test("has no detectable accessibility violations after switching tabs", async ({
-    page,
-  }) => {
-    await page.goto("/tabs.html");
     await page.getByRole("tab", { name: "Tab 2" }).click();
     await expect(page.getByTestId("tab-content-2")).toBeVisible();
 
-    const results = await new AxeBuilder({ page }).include("#app").analyze();
-
-    expect(results.violations).toEqual([]);
+    const switchedResults = await new AxeBuilder({ page })
+      .include("#app")
+      .analyze();
+    expect(switchedResults.violations).toEqual([]);
   });
 });

--- a/e2e/a11y-tag.test.ts
+++ b/e2e/a11y-tag.test.ts
@@ -1,0 +1,14 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+test.describe("Tag a11y", () => {
+  test("has no detectable accessibility violations", async ({ page }) => {
+    await page.goto("/tag.html");
+    await expect(page.getByTestId("tag-filter")).toBeVisible();
+    await expect(page.getByTestId("tag-static")).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+});

--- a/e2e/a11y-text-area.test.ts
+++ b/e2e/a11y-text-area.test.ts
@@ -1,0 +1,13 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+test.describe("TextArea a11y", () => {
+  test("has no detectable accessibility violations", async ({ page }) => {
+    await page.goto("/text-area.html");
+    await expect(page.getByTestId("text-area-comment")).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+});

--- a/e2e/a11y-text-input.test.ts
+++ b/e2e/a11y-text-input.test.ts
@@ -1,0 +1,13 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+test.describe("TextInput a11y", () => {
+  test("has no detectable accessibility violations", async ({ page }) => {
+    await page.goto("/text-input.html");
+    await expect(page.getByTestId("text-input-username")).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+});

--- a/e2e/a11y-time-picker.test.ts
+++ b/e2e/a11y-time-picker.test.ts
@@ -1,0 +1,13 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+test.describe("TimePicker a11y", () => {
+  test("has no detectable accessibility violations", async ({ page }) => {
+    await page.goto("/time-picker.html");
+    await expect(page.getByTestId("time-picker")).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+});

--- a/e2e/a11y-toast-notification.test.ts
+++ b/e2e/a11y-toast-notification.test.ts
@@ -1,0 +1,13 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+test.describe("ToastNotification a11y", () => {
+  test("has no detectable accessibility violations", async ({ page }) => {
+    await page.goto("/toast-notification.html");
+    await expect(page.getByTestId("toast-notification")).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+});

--- a/e2e/a11y-toggle.test.ts
+++ b/e2e/a11y-toggle.test.ts
@@ -1,0 +1,27 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+test.describe("Toggle a11y", () => {
+  test("has no detectable accessibility violations", async ({ page }) => {
+    await page.goto("/toggle.html");
+    await expect(page.getByTestId("toggle-notifications")).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+
+  test("has no detectable accessibility violations after toggling on", async ({
+    page,
+  }) => {
+    await page.goto("/toggle.html");
+    await page.getByTestId("toggle-notifications").locator("label").click();
+    await expect(
+      page.getByRole("switch", { name: "Enable notifications" }),
+    ).toBeChecked();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+});

--- a/e2e/a11y-toggle.test.ts
+++ b/e2e/a11y-toggle.test.ts
@@ -6,22 +6,19 @@ test.describe("Toggle a11y", () => {
     await page.goto("/toggle.html");
     await expect(page.getByTestId("toggle-notifications")).toBeVisible();
 
-    const results = await new AxeBuilder({ page }).include("#app").analyze();
+    const staticResults = await new AxeBuilder({ page })
+      .include("#app")
+      .analyze();
+    expect(staticResults.violations).toEqual([]);
 
-    expect(results.violations).toEqual([]);
-  });
-
-  test("has no detectable accessibility violations after toggling on", async ({
-    page,
-  }) => {
-    await page.goto("/toggle.html");
     await page.getByTestId("toggle-notifications").locator("label").click();
     await expect(
       page.getByRole("switch", { name: "Enable notifications" }),
     ).toBeChecked();
 
-    const results = await new AxeBuilder({ page }).include("#app").analyze();
-
-    expect(results.violations).toEqual([]);
+    const toggledResults = await new AxeBuilder({ page })
+      .include("#app")
+      .analyze();
+    expect(toggledResults.violations).toEqual([]);
   });
 });

--- a/e2e/a11y-tooltip-definition.test.ts
+++ b/e2e/a11y-tooltip-definition.test.ts
@@ -6,20 +6,17 @@ test.describe("TooltipDefinition a11y", () => {
     await page.goto("/tooltip-definition.html");
     await expect(page.getByTestId("tooltip-definition")).toBeVisible();
 
-    const results = await new AxeBuilder({ page }).include("#app").analyze();
+    const staticResults = await new AxeBuilder({ page })
+      .include("#app")
+      .analyze();
+    expect(staticResults.violations).toEqual([]);
 
-    expect(results.violations).toEqual([]);
-  });
-
-  test("has no detectable accessibility violations when open", async ({
-    page,
-  }) => {
-    await page.goto("/tooltip-definition.html");
     await page.getByRole("button", { name: "Definition trigger" }).focus();
     await expect(page.getByText("Definition tooltip text")).toBeVisible();
 
-    const results = await new AxeBuilder({ page }).include("#app").analyze();
-
-    expect(results.violations).toEqual([]);
+    const openResults = await new AxeBuilder({ page })
+      .include("#app")
+      .analyze();
+    expect(openResults.violations).toEqual([]);
   });
 });

--- a/e2e/a11y-tooltip-definition.test.ts
+++ b/e2e/a11y-tooltip-definition.test.ts
@@ -1,0 +1,25 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+test.describe("TooltipDefinition a11y", () => {
+  test("has no detectable accessibility violations", async ({ page }) => {
+    await page.goto("/tooltip-definition.html");
+    await expect(page.getByTestId("tooltip-definition")).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+
+  test("has no detectable accessibility violations when open", async ({
+    page,
+  }) => {
+    await page.goto("/tooltip-definition.html");
+    await page.getByRole("button", { name: "Definition trigger" }).focus();
+    await expect(page.getByText("Definition tooltip text")).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+});

--- a/e2e/a11y-tooltip-icon.test.ts
+++ b/e2e/a11y-tooltip-icon.test.ts
@@ -1,0 +1,25 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+test.describe("TooltipIcon a11y", () => {
+  test("has no detectable accessibility violations", async ({ page }) => {
+    await page.goto("/tooltip-icon.html");
+    await expect(page.getByTestId("tooltip-icon")).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+
+  test("has no detectable accessibility violations when open", async ({
+    page,
+  }) => {
+    await page.goto("/tooltip-icon.html");
+    await page.getByRole("button", { name: "Icon tooltip text" }).focus();
+    await expect(page.getByText("Icon tooltip text")).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+});

--- a/e2e/a11y-tooltip-icon.test.ts
+++ b/e2e/a11y-tooltip-icon.test.ts
@@ -6,20 +6,17 @@ test.describe("TooltipIcon a11y", () => {
     await page.goto("/tooltip-icon.html");
     await expect(page.getByTestId("tooltip-icon")).toBeVisible();
 
-    const results = await new AxeBuilder({ page }).include("#app").analyze();
+    const staticResults = await new AxeBuilder({ page })
+      .include("#app")
+      .analyze();
+    expect(staticResults.violations).toEqual([]);
 
-    expect(results.violations).toEqual([]);
-  });
-
-  test("has no detectable accessibility violations when open", async ({
-    page,
-  }) => {
-    await page.goto("/tooltip-icon.html");
     await page.getByRole("button", { name: "Icon tooltip text" }).focus();
     await expect(page.getByText("Icon tooltip text")).toBeVisible();
 
-    const results = await new AxeBuilder({ page }).include("#app").analyze();
-
-    expect(results.violations).toEqual([]);
+    const openResults = await new AxeBuilder({ page })
+      .include("#app")
+      .analyze();
+    expect(openResults.violations).toEqual([]);
   });
 });

--- a/e2e/a11y-tooltip.test.ts
+++ b/e2e/a11y-tooltip.test.ts
@@ -1,0 +1,16 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+test.describe("Tooltip a11y", () => {
+  test("has no detectable accessibility violations when open", async ({
+    page,
+  }) => {
+    await page.goto("/tooltip.html");
+    await page.getByTestId("toggle").click();
+    await expect(page.getByTestId("tooltip-content")).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+});

--- a/e2e/a11y-tree-view-multiselect.test.ts
+++ b/e2e/a11y-tree-view-multiselect.test.ts
@@ -6,20 +6,17 @@ test.describe("TreeView multiselect a11y", () => {
     await page.goto("/tree-view-multiselect.html");
     await expect(page.getByTestId("tree-view")).toBeVisible();
 
-    const results = await new AxeBuilder({ page }).include("#app").analyze();
+    const staticResults = await new AxeBuilder({ page })
+      .include("#app")
+      .analyze();
+    expect(staticResults.violations).toEqual([]);
 
-    expect(results.violations).toEqual([]);
-  });
-
-  test("has no detectable accessibility violations after selecting an additional node", async ({
-    page,
-  }) => {
-    await page.goto("/tree-view-multiselect.html");
     await page.getByRole("treeitem", { name: "IBM Analytics Engine" }).click();
     await expect(page.getByTestId("selected-ids")).toContainText("2");
 
-    const results = await new AxeBuilder({ page }).include("#app").analyze();
-
-    expect(results.violations).toEqual([]);
+    const selectedResults = await new AxeBuilder({ page })
+      .include("#app")
+      .analyze();
+    expect(selectedResults.violations).toEqual([]);
   });
 });

--- a/e2e/a11y-tree-view-multiselect.test.ts
+++ b/e2e/a11y-tree-view-multiselect.test.ts
@@ -1,0 +1,25 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+test.describe("TreeView multiselect a11y", () => {
+  test("has no detectable accessibility violations", async ({ page }) => {
+    await page.goto("/tree-view-multiselect.html");
+    await expect(page.getByTestId("tree-view")).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+
+  test("has no detectable accessibility violations after selecting an additional node", async ({
+    page,
+  }) => {
+    await page.goto("/tree-view-multiselect.html");
+    await page.getByRole("treeitem", { name: "IBM Analytics Engine" }).click();
+    await expect(page.getByTestId("selected-ids")).toContainText("2");
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+});

--- a/e2e/a11y-tree-view.test.ts
+++ b/e2e/a11y-tree-view.test.ts
@@ -1,0 +1,30 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+test.describe("TreeView a11y", () => {
+  test("has no detectable accessibility violations", async ({ page }) => {
+    await page.goto("/tree-view.html");
+    await expect(page.getByTestId("tree-view")).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+
+  test("has no detectable accessibility violations with a node expanded", async ({
+    page,
+  }) => {
+    await page.goto("/tree-view.html");
+    await page
+      .getByRole("treeitem", { name: "Parent 1" })
+      .locator(".bx--tree-parent-node__toggle")
+      .click();
+    await expect(
+      page.getByRole("treeitem", { name: "Child 1-1" }),
+    ).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+});

--- a/e2e/a11y-tree-view.test.ts
+++ b/e2e/a11y-tree-view.test.ts
@@ -6,15 +6,11 @@ test.describe("TreeView a11y", () => {
     await page.goto("/tree-view.html");
     await expect(page.getByTestId("tree-view")).toBeVisible();
 
-    const results = await new AxeBuilder({ page }).include("#app").analyze();
+    const staticResults = await new AxeBuilder({ page })
+      .include("#app")
+      .analyze();
+    expect(staticResults.violations).toEqual([]);
 
-    expect(results.violations).toEqual([]);
-  });
-
-  test("has no detectable accessibility violations with a node expanded", async ({
-    page,
-  }) => {
-    await page.goto("/tree-view.html");
     await page
       .getByRole("treeitem", { name: "Parent 1" })
       .locator(".bx--tree-parent-node__toggle")
@@ -23,8 +19,9 @@ test.describe("TreeView a11y", () => {
       page.getByRole("treeitem", { name: "Child 1-1" }),
     ).toBeVisible();
 
-    const results = await new AxeBuilder({ page }).include("#app").analyze();
-
-    expect(results.violations).toEqual([]);
+    const expandedResults = await new AxeBuilder({ page })
+      .include("#app")
+      .analyze();
+    expect(expandedResults.violations).toEqual([]);
   });
 });

--- a/e2e/a11y-uishell.test.ts
+++ b/e2e/a11y-uishell.test.ts
@@ -1,0 +1,39 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+test.describe("UIShell a11y", () => {
+  test("has no detectable accessibility violations", async ({ page }) => {
+    await page.goto("/uishell.html");
+    await expect(page.getByTestId("main-paragraph")).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+
+  test("has no detectable accessibility violations with the profile menu open", async ({
+    page,
+  }) => {
+    await page.goto("/uishell.html");
+    await page.getByRole("button", { name: "Profile" }).click();
+    await expect(page.getByRole("link", { name: "Settings" })).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+
+  test("has no detectable accessibility violations with a header nav submenu open", async ({
+    page,
+  }) => {
+    await page.goto("/uishell.html");
+    await page.getByRole("menuitem", { name: "Submenu" }).click();
+    await expect(
+      page.getByRole("menuitem", { name: "Sub link one" }),
+    ).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+});

--- a/e2e/a11y-uishell.test.ts
+++ b/e2e/a11y-uishell.test.ts
@@ -6,34 +6,27 @@ test.describe("UIShell a11y", () => {
     await page.goto("/uishell.html");
     await expect(page.getByTestId("main-paragraph")).toBeVisible();
 
-    const results = await new AxeBuilder({ page }).include("#app").analyze();
+    const staticResults = await new AxeBuilder({ page })
+      .include("#app")
+      .analyze();
+    expect(staticResults.violations).toEqual([]);
 
-    expect(results.violations).toEqual([]);
-  });
-
-  test("has no detectable accessibility violations with the profile menu open", async ({
-    page,
-  }) => {
-    await page.goto("/uishell.html");
     await page.getByRole("button", { name: "Profile" }).click();
     await expect(page.getByRole("link", { name: "Settings" })).toBeVisible();
 
-    const results = await new AxeBuilder({ page }).include("#app").analyze();
+    const profileMenuResults = await new AxeBuilder({ page })
+      .include("#app")
+      .analyze();
+    expect(profileMenuResults.violations).toEqual([]);
 
-    expect(results.violations).toEqual([]);
-  });
-
-  test("has no detectable accessibility violations with a header nav submenu open", async ({
-    page,
-  }) => {
-    await page.goto("/uishell.html");
     await page.getByRole("menuitem", { name: "Submenu" }).click();
     await expect(
       page.getByRole("menuitem", { name: "Sub link one" }),
     ).toBeVisible();
 
-    const results = await new AxeBuilder({ page }).include("#app").analyze();
-
-    expect(results.violations).toEqual([]);
+    const headerNavResults = await new AxeBuilder({ page })
+      .include("#app")
+      .analyze();
+    expect(headerNavResults.violations).toEqual([]);
   });
 });

--- a/e2e/a11y-user-avatar-group.test.ts
+++ b/e2e/a11y-user-avatar-group.test.ts
@@ -1,0 +1,13 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+test.describe("UserAvatarGroup a11y", () => {
+  test("has no detectable accessibility violations", async ({ page }) => {
+    await page.goto("/user-avatar-group.html");
+    await expect(page.getByTestId("overlap")).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("#app").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+});

--- a/e2e/fixtures/TabsFixture.svelte
+++ b/e2e/fixtures/TabsFixture.svelte
@@ -10,13 +10,15 @@
   <Tab label="Tab 2" />
   <Tab label="Tab 3" />
 
-  <TabContent>
-    <p data-testid="tab-content-1">Content for tab 1</p>
-  </TabContent>
-  <TabContent>
-    <p data-testid="tab-content-2">Content for tab 2</p>
-  </TabContent>
-  <TabContent>
-    <p data-testid="tab-content-3">Content for tab 3</p>
-  </TabContent>
+  <svelte:fragment slot="content">
+    <TabContent>
+      <p data-testid="tab-content-1">Content for tab 1</p>
+    </TabContent>
+    <TabContent>
+      <p data-testid="tab-content-2">Content for tab 2</p>
+    </TabContent>
+    <TabContent>
+      <p data-testid="tab-content-3">Content for tab 3</p>
+    </TabContent>
+  </svelte:fragment>
 </Tabs>

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "flatpickr": "4.6.9"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.12.1",
     "@biomejs/biome": "2.5.3",
     "@playwright/test": "^1.61.0",
     "@sveltejs/vite-plugin-svelte": "^7.1.2",


### PR DESCRIPTION
This adds automated Playwright tests for accessibility using the hardened `axe-core` package, and following this guide: https://playwright.dev/docs/accessibility-testing

Reusing existing e2e scaffolding, it's identified these bugs:

- https://github.com/carbon-design-system/carbon-components-svelte/pull/3428
- https://github.com/carbon-design-system/carbon-components-svelte/pull/3427
- https://github.com/carbon-design-system/carbon-components-svelte/pull/3426
- https://github.com/carbon-design-system/carbon-components-svelte/pull/3425
- https://github.com/carbon-design-system/carbon-components-svelte/pull/3423
- https://github.com/carbon-design-system/carbon-components-svelte/pull/3422
- https://github.com/carbon-design-system/carbon-components-svelte/pull/3424
- https://github.com/carbon-design-system/carbon-components-svelte/pull/3421
- https://github.com/carbon-design-system/carbon-components-svelte/pull/3420