### PR TITLE
fix(multi-select): hide decorative option checkbox via CSS

### DIFF
--- a/e2e/modal-with-dropdowns.test.ts
+++ b/e2e/modal-with-dropdowns.test.ts
@@ -47,11 +47,17 @@ test.describe("Modal with Dropdowns", () => {
     await menu.getByRole("option", { name: "Slack" }).click();
     await menu.getByRole("option", { name: "Email" }).click();
 
+    // The option checkbox is decorative (hidden from the accessibility
+    // tree), so query the underlying <input> directly rather than by role.
     await expect(
-      menu.getByRole("option", { name: "Slack" }).getByRole("checkbox"),
+      menu
+        .getByRole("option", { name: "Slack" })
+        .locator('input[type="checkbox"]'),
     ).toBeChecked();
     await expect(
-      menu.getByRole("option", { name: "Email" }).getByRole("checkbox"),
+      menu
+        .getByRole("option", { name: "Email" })
+        .locator('input[type="checkbox"]'),
     ).toBeChecked();
   });
 
@@ -71,13 +77,15 @@ test.describe("Modal with Dropdowns", () => {
       // Click label text, not the checkbox input. That path double-toggled.
       // biome-ignore lint/performance/noAwaitInLoops: each click must finish before the next
       await option.getByText(name, { exact: true }).click();
-      await expect(option.getByRole("checkbox")).toBeChecked();
+      // The option checkbox is decorative (hidden from the accessibility
+      // tree), so query the underlying <input> directly rather than by role.
+      await expect(option.locator('input[type="checkbox"]')).toBeChecked();
     }
 
     await Promise.all(
       picks.map((name) =>
         expect(
-          menu.getByRole("option", { name }).getByRole("checkbox"),
+          menu.getByRole("option", { name }).locator('input[type="checkbox"]'),
         ).toBeChecked(),
       ),
     );

--- a/src/Checkbox/Checkbox.svelte
+++ b/src/Checkbox/Checkbox.svelte
@@ -71,6 +71,16 @@
   export let tabindex = undefined;
 
   /**
+   * Set to `true` to hide the input from the accessibility tree via CSS
+   * (not just tabindex/aria-hidden, which axe-core's nested-interactive
+   * check does not treat as sufficient). Use when this Checkbox is
+   * nested inside another interactive/widget-role element that already
+   * owns the checked-state semantics (e.g. a listbox option) and the
+   * checkbox itself is purely decorative.
+   */
+  export let decorative = false;
+
+  /**
    * Obtain a reference to the input HTML element.
    * @bindable readonly
    */
@@ -151,6 +161,7 @@
       {disabled}
       {id}
       {tabindex}
+      style:display={decorative ? "none" : undefined}
       bind:indeterminate
       name={effectiveName}
       required={effectiveRequired}

--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -1058,6 +1058,7 @@
                     title={useTitleInItem ? itemToString(item) : undefined}
                     {...itemToInput(item)}
                     tabindex="-1"
+                    decorative
                     id="checkbox-{id}-{item.id}"
                     checked={item.isSelectAll ? allSelected : item.checked}
                     indeterminate={item.isSelectAll
@@ -1121,6 +1122,7 @@
                 title={useTitleInItem ? itemToString(item) : undefined}
                 {...itemToInput(item)}
                 tabindex="-1"
+                decorative
                 id="checkbox-{id}-{item.id}"
                 checked={item.isSelectAll ? allSelected : item.checked}
                 indeterminate={item.isSelectAll

--- a/tests/MultiSelect/MultiSelect.test.ts
+++ b/tests/MultiSelect/MultiSelect.test.ts
@@ -113,6 +113,15 @@ describe("MultiSelect", () => {
     expect(checkbox).toHaveAttribute("tabindex", "-1");
   });
 
+  it("should hide the decorative option checkbox from the accessibility tree", async () => {
+    render(MultiSelect, { props: { items } });
+    await openMenu();
+
+    const option = screen.getByRole("option", { name: "Slack" });
+    const checkbox = option.querySelector('input[type="checkbox"]');
+    expect(checkbox).toHaveStyle({ display: "none" });
+  });
+
   it("should pass selected and highlighted to the default slot", async () => {
     render(MultiSelectItemSlot, { props: { selectedIds: ["1"] } });
 
@@ -1256,7 +1265,8 @@ describe("MultiSelect", () => {
       render(MultiSelect, { props });
 
       await openMenu();
-      const checkbox = screen.getByRole("checkbox", { name: "Slack" });
+      const option = screen.getByRole("option", { name: "Slack" });
+      const checkbox = option.querySelector('input[type="checkbox"]');
       expect(checkbox).toHaveAttribute("name", "contact_0");
       expect(checkbox).toHaveAttribute("value", "slack");
     });
@@ -2277,26 +2287,27 @@ describe("MultiSelect", () => {
       const optionsAfterScroll = screen.getAllByRole("option");
       expect(optionsAfterScroll.length).toBeGreaterThan(0);
 
-      // Click on the checkbox directly (more reliable than clicking the option)
-      const checkboxes = screen.getAllByRole("checkbox");
-      const firstCheckbox = checkboxes[0];
-      expect(firstCheckbox).toBeDefined();
+      // Click on the option (the option's own checkbox is decorative and
+      // hidden from the accessibility tree; the option owns selection).
+      const firstOption = optionsAfterScroll[0];
+      const firstCheckbox = firstOption.querySelector('input[type="checkbox"]');
 
       // Get the current checked state
       expect.assert(firstCheckbox instanceof HTMLInputElement);
       const wasChecked = firstCheckbox.checked;
 
-      // Click the checkbox to toggle it
-      await user.click(firstCheckbox);
+      // Click the option to toggle it
+      await user.click(firstOption);
       await tick();
       await new Promise((resolve) => setTimeout(resolve, 100));
 
       // Verify selection works - the checkbox should have toggled
       await waitFor(() => {
-        const updatedCheckboxes = screen.getAllByRole("checkbox");
-        const firstUpdatedCheckbox = updatedCheckboxes[0];
-        expect.assert(firstUpdatedCheckbox instanceof HTMLInputElement);
-        expect(firstUpdatedCheckbox.checked).toBe(!wasChecked);
+        const updatedCheckbox = firstOption.querySelector(
+          'input[type="checkbox"]',
+        );
+        expect.assert(updatedCheckbox instanceof HTMLInputElement);
+        expect(updatedCheckbox.checked).toBe(!wasChecked);
       });
     });
 
@@ -2367,9 +2378,16 @@ describe("MultiSelect", () => {
       await new Promise((resolve) => setTimeout(resolve, 100));
 
       // ArrowDown twice selects index 1, which is "Item 2" (items are 0-indexed)
-      // Verify the item is selected - check if any checkbox is checked
+      // Verify the item is selected - check if any checkbox is checked.
+      // The option checkboxes are decorative (hidden from the accessibility
+      // tree), so query the underlying <input> elements directly rather than
+      // via role.
       await waitFor(() => {
-        const checkboxes = screen.getAllByRole("checkbox");
+        const checkboxes = Array.from(
+          screen
+            .getAllByRole("option")
+            .map((option) => option.querySelector('input[type="checkbox"]')),
+        );
         const checkedCheckboxes = checkboxes.filter((cb) => {
           expect.assert(cb instanceof HTMLInputElement);
           return cb.checked;
@@ -2378,8 +2396,8 @@ describe("MultiSelect", () => {
 
         // Also verify we can find Item 2 if it's visible
         const item2Checkbox = checkboxes.find((cb) => {
-          const label = cb.closest("label");
-          return label?.textContent?.trim() === "Item 2";
+          const label = cb?.closest(".bx--checkbox-wrapper")?.textContent;
+          return label?.trim() === "Item 2";
         });
         if (item2Checkbox) {
           expect.assert(item2Checkbox instanceof HTMLInputElement);


### PR DESCRIPTION
The tabindex="-1" fix in 113ed03cd (#3421) stopped MultiSelect's
option checkboxes from being independently focusable, but an
axe-core scan of an open MultiSelect menu still flags them under
nested-interactive/no-focusable-content. Reading axe-core's rule
source shows it treats a negative tabindex as an "unreliable hiding
strategy" specifically because assistive tech can still reach the
element; aria-hidden doesn't satisfy it either. Only genuine CSS
hiding (display/visibility/content-visibility) does.

Checkbox gains a new decorative prop, independent of tabindex, that
sets display: none on the input. MultiSelect passes it on its option
checkboxes, since the option's own aria-checked already owns the
checked-state semantics and the nested input is purely decorative.
The :checked sibling-selector styling Carbon uses for the visual
checkmark still applies to a display:none input, so nothing changes
visually.

