### PR TITLE
fix(structured-list): move radio/checkbox role off selectable row

### DIFF
--- a/css/_structured-list-input-focusable.scss
+++ b/css/_structured-list-input-focusable.scss
@@ -1,0 +1,27 @@
+@import "carbon-components/scss/globals/scss/vars";
+@import "carbon-components/scss/globals/scss/helper-mixins";
+@import "carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/import-once/import-once";
+
+// Carbon's base `.bx--structured-list-input` is `display: none`, which
+// worked when the row's own <label> carried the radio/checkbox role and
+// tabindex. Now that the label is a plain wrapper (role isn't allowed on
+// <label>) and the native input is the focusable, checkbox/radio-shaped
+// control, it must stay in the tab order and accessibility tree -- visually
+// hidden the same way SelectableTile's input is, instead of display: none.
+@mixin structured-list-input-focusable {
+  .#{$prefix}--structured-list-input {
+    // The base rule sets `display: none`; CSS cascades per-property, so
+    // `@include hidden` alone (which never declares `display`) can't
+    // override it regardless of source order -- reset it explicitly.
+    display: inline-block;
+    @include hidden;
+  }
+
+  .#{$prefix}--structured-list-row:focus-within {
+    @include focus-outline("outline");
+  }
+}
+
+@include exports("structured-list-input-focusable") {
+  @include structured-list-input-focusable;
+}

--- a/css/all.scss
+++ b/css/all.scss
@@ -97,6 +97,7 @@ $css--plex: true;
 @import "./data-table-highlighted-row";
 @import "./data-table-sticky-column-menu";
 @import "./pagination";
+@import "./structured-list-input-focusable";
 @import "./multiselect";
 @import "./treeview";
 @import "./selectable-tag";

--- a/css/g10.scss
+++ b/css/g10.scss
@@ -57,6 +57,7 @@ $css--plex: true;
 @import "./data-table-highlighted-row";
 @import "./data-table-sticky-column-menu";
 @import "./pagination";
+@import "./structured-list-input-focusable";
 @import "./multiselect";
 @import "./treeview";
 @import "./selectable-tag";

--- a/css/g100.scss
+++ b/css/g100.scss
@@ -57,6 +57,7 @@ $css--plex: true;
 @import "./data-table-highlighted-row";
 @import "./data-table-sticky-column-menu";
 @import "./pagination";
+@import "./structured-list-input-focusable";
 @import "./multiselect";
 @import "./treeview";
 @import "./selectable-tag";

--- a/css/g80.scss
+++ b/css/g80.scss
@@ -57,6 +57,7 @@ $css--plex: true;
 @import "./data-table-highlighted-row";
 @import "./data-table-sticky-column-menu";
 @import "./pagination";
+@import "./structured-list-input-focusable";
 @import "./multiselect";
 @import "./treeview";
 @import "./selectable-tag";

--- a/css/g90.scss
+++ b/css/g90.scss
@@ -57,6 +57,7 @@ $css--plex: true;
 @import "./data-table-highlighted-row";
 @import "./data-table-sticky-column-menu";
 @import "./pagination";
+@import "./structured-list-input-focusable";
 @import "./multiselect";
 @import "./treeview";
 @import "./selectable-tag";

--- a/css/white.scss
+++ b/css/white.scss
@@ -57,6 +57,7 @@ $css--plex: true;
 @import "./data-table-highlighted-row";
 @import "./data-table-sticky-column-menu";
 @import "./pagination";
+@import "./structured-list-input-focusable";
 @import "./multiselect";
 @import "./treeview";
 @import "./selectable-tag";

--- a/e2e/structured-list.test.ts
+++ b/e2e/structured-list.test.ts
@@ -19,4 +19,16 @@ test.describe("StructuredList", () => {
 
     await expect(page.getByTestId("selected-value")).toHaveText("a");
   });
+
+  test("selects row via Tab + Space keyboard navigation", async ({ page }) => {
+    await expect(page.getByTestId("selected-value")).toHaveText("none");
+
+    const firstRadio = page.getByRole("radio").first();
+    await firstRadio.focus();
+    await expect(firstRadio).toBeFocused();
+
+    await page.keyboard.press("Space");
+
+    await expect(page.getByTestId("selected-value")).toHaveText("a");
+  });
 });

--- a/src/StructuredList/StructuredListInput.svelte
+++ b/src/StructuredList/StructuredListInput.svelte
@@ -25,6 +25,12 @@
   export let name = "";
 
   /**
+   * Specify the tabindex
+   * @type {number | string | undefined}
+   */
+  export let tabindex = "0";
+
+  /**
    * Obtain a reference to the input HTML element.
    * @bindable readonly
    */
@@ -53,8 +59,7 @@
 <input
   bind:this={ref}
   type={multiple ? "checkbox" : "radio"}
-  tabindex="-1"
-  aria-hidden={ctx ? "true" : undefined}
+  {tabindex}
   {checked}
   {id}
   {name}
@@ -64,5 +69,11 @@
   {...$$restProps}
   on:change={() => {
     update(value);
+  }}
+  on:keydown={(event) => {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      ref.click();
+    }
   }}
 >

--- a/src/StructuredList/StructuredListRow.svelte
+++ b/src/StructuredList/StructuredListRow.svelte
@@ -6,59 +6,28 @@
   export let label = false;
 
   /**
-   * Specify the tabindex
+   * Specify the tabindex.
+   * @deprecated no longer applied here -- the row's own `<label>` isn't
+   * a tab stop anymore. Set `tabindex` on `StructuredListInput` instead,
+   * which now owns focus for the selectable row.
    * @type {number | string | undefined}
    */
   export let tabindex = "0";
 
   import CheckmarkFilled from "carbon-icons-svelte/lib/CheckmarkFilled.svelte";
-  import { getContext, onMount } from "svelte";
-  import { writable } from "svelte/store";
+  import { getContext } from "svelte";
   import StructuredListCell from "./StructuredListCell.svelte";
 
   const ctx = getContext("carbon:StructuredListWrapper");
-  const selectedValue = ctx?.selectedValue ?? writable(undefined);
-  const multiple = ctx?.multiple ?? false;
   const selection = ctx?.selection ?? false;
   const icon = ctx?.icon ?? CheckmarkFilled;
-
-  let labelRef;
-  let inputValue;
-
-  onMount(() => {
-    if (label && labelRef) {
-      const input = labelRef.querySelector(
-        'input[type="radio"], input[type="checkbox"]',
-      );
-      if (input) inputValue = input.value;
-    }
-  });
-
-  $: isSelectable = label && inputValue !== undefined;
-  $: ariaChecked = isSelectable
-    ? multiple
-      ? Array.isArray($selectedValue) && $selectedValue.includes(inputValue)
-      : $selectedValue === inputValue
-    : undefined;
-
-  function handleKeydown(event) {
-    if (event.key === " " || event.key === "Enter") {
-      event.preventDefault();
-      event.currentTarget.click();
-    }
-  }
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
 {#if label}
   <!-- svelte-ignore a11y-label-has-associated-control -->
-  <!-- svelte-ignore a11y-no-noninteractive-tabindex -->
   <!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
   <label
-    bind:this={labelRef}
-    role={isSelectable ? (multiple ? "checkbox" : "radio") : undefined}
-    aria-checked={ariaChecked}
-    {tabindex}
     class:bx--structured-list-row={true}
     class:bx--structured-list-row--header-row={head}
     {...$$restProps}
@@ -66,8 +35,6 @@
     on:mouseover
     on:mouseenter
     on:mouseleave
-    on:keydown
-    on:keydown={handleKeydown}
   >
     <slot />
     {#if selection}

--- a/tests/StructuredList/StructuredList.test.ts
+++ b/tests/StructuredList/StructuredList.test.ts
@@ -79,7 +79,7 @@ describe("StructuredList", () => {
     });
 
     const options = container.querySelectorAll(
-      '[role="radio"], [role="checkbox"]',
+      'input[type="radio"], input[type="checkbox"]',
     );
     expect(options.length).toBeGreaterThan(0);
     for (const option of options) {
@@ -144,7 +144,7 @@ describe("StructuredList", () => {
     expect(screen.getByTestId("value").textContent).toBe("row-3-value");
   });
 
-  it("should expose selectable rows as radio with aria-checked", () => {
+  it("should expose selectable rows as native radio inputs with correct checked state", () => {
     render(StructuredList, {
       props: { selection: true, selected: "row-2-value" },
     });
@@ -152,11 +152,38 @@ describe("StructuredList", () => {
     const rows = screen.getAllByRole("radio");
     expect(rows).toHaveLength(3);
     for (const row of rows) {
-      expect(row.tagName).toBe("LABEL");
+      expect(row.tagName).toBe("INPUT");
     }
-    expect(rows[0]).toHaveAttribute("aria-checked", "false");
-    expect(rows[1]).toHaveAttribute("aria-checked", "true");
-    expect(rows[2]).toHaveAttribute("aria-checked", "false");
+    expect(rows[0]).not.toBeChecked();
+    expect(rows[1]).toBeChecked();
+    expect(rows[2]).not.toBeChecked();
+  });
+
+  it('should not put role="radio"/"checkbox" on the <label> element', () => {
+    const { container } = render(StructuredList, {
+      props: { selection: true },
+    });
+
+    const labels = container.querySelectorAll("label.bx--structured-list-row");
+    expect(labels.length).toBeGreaterThan(0);
+    for (const label of labels) {
+      expect(label).not.toHaveAttribute("role");
+      expect(label).not.toHaveAttribute("aria-checked");
+    }
+  });
+
+  it("should keep the native input focusable and keyboard-toggleable", () => {
+    const { container } = render(StructuredList, {
+      props: { selection: true },
+    });
+
+    const inputs = container.querySelectorAll(
+      'input[type="radio"], input[type="checkbox"]',
+    );
+    expect(inputs.length).toBeGreaterThan(0);
+    for (const input of inputs) {
+      expect(input).toHaveAttribute("tabindex", "0");
+    }
   });
 
   it("should handle custom content", () => {
@@ -231,26 +258,26 @@ describe("StructuredList", () => {
     expect(checkboxes).toHaveLength(3);
     expect(screen.queryAllByRole("radio")).toHaveLength(0);
     expect(screen.getByTestId("value").textContent).toBe("[]");
-    // a11y: each selectable row exposes its checked state to assistive tech.
+    // a11y: each selectable row's native input exposes its checked state.
     for (const checkbox of checkboxes) {
-      expect(checkbox).toHaveAttribute("aria-checked", "false");
+      expect(checkbox).not.toBeChecked();
     }
 
     await user.click(checkboxes[0]);
     expect(screen.getByTestId("value").textContent).toBe('["row-1-value"]');
     expect(consoleLog).toHaveBeenLastCalledWith("change", ["row-1-value"]);
-    expect(checkboxes[0]).toHaveAttribute("aria-checked", "true");
+    expect(checkboxes[0]).toBeChecked();
 
     await user.click(checkboxes[2]);
     expect(screen.getByTestId("value").textContent).toBe(
       '["row-1-value","row-3-value"]',
     );
-    expect(checkboxes[2]).toHaveAttribute("aria-checked", "true");
+    expect(checkboxes[2]).toBeChecked();
 
     // toggling re-selects off
     await user.click(checkboxes[0]);
     expect(screen.getByTestId("value").textContent).toBe('["row-3-value"]');
-    expect(checkboxes[0]).toHaveAttribute("aria-checked", "false");
+    expect(checkboxes[0]).not.toBeChecked();
   });
 });
 


### PR DESCRIPTION
StructuredListRow put role="radio"/"checkbox" and aria-checked
directly on the <label> wrapping each selectable row, with the
associated <input> hardcoded to tabindex="-1" and aria-hidden.
role="radio"/"checkbox" isn't an ARIA-in-HTML-allowed role for
<label> elements, which axe-core flags as aria-allowed-role. This is
independent of the table/rowgroup gating landed in 881d19dbe.

The fix mirrors SelectableTile's (e5a9c2c9e): StructuredListInput's
native <input> becomes the real focusable, checkbox/radio-shaped
element (own tabindex prop, Enter-to-toggle keydown handler, no more
aria-hidden/tabindex="-1"), and StructuredListRow's <label> goes
back to a plain wrapper with no role/aria-checked/tabindex of its
own. Carbon's base CSS sets `.bx--structured-list-input { display:
none }`, which would leave the newly-focusable input untabbable and
hidden from assistive tech in real browsers, even though it passes
in jsdom (no stylesheet loaded) and axe (which skips display:none
elements). Added a CSS override so the input is visually hidden the
same way SelectableTile's is, with a focus-within outline on the
row.

<img width="815" height="384" alt="Screenshot 2026-07-12 at 5 00 29 PM" src="https://github.com/user-attachments/assets/c44b7c6a-8a6b-414b-a07d-768cc71326e1" />
