### PR TITLE
fix(structured-list): import inline `CheckmarkFilled` icon

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -235,6 +235,26 @@
           }
         }
       }
+    },
+    {
+      "includes": ["src/**"],
+      "linter": {
+        "rules": {
+          "style": {
+            "noRestrictedImports": {
+              "level": "error",
+              "options": {
+                "patterns": [
+                  {
+                    "group": ["carbon-icons-svelte", "carbon-icons-svelte/**"],
+                    "message": "Use the local icon in src/icons instead of importing from carbon-icons-svelte."
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
     }
   ]
 }

--- a/src/StructuredList/StructuredList.svelte
+++ b/src/StructuredList/StructuredList.svelte
@@ -33,9 +33,9 @@
    */
   export let icon = CheckmarkFilled;
 
-  import CheckmarkFilled from "carbon-icons-svelte/lib/CheckmarkFilled.svelte";
   import { createEventDispatcher, onMount, setContext } from "svelte";
   import { writable } from "svelte/store";
+  import CheckmarkFilled from "../icons/CheckmarkFilled.svelte";
 
   const dispatch = createEventDispatcher();
   /**

--- a/src/StructuredList/StructuredListRow.svelte
+++ b/src/StructuredList/StructuredListRow.svelte
@@ -14,8 +14,8 @@
    */
   export let tabindex = "0";
 
-  import CheckmarkFilled from "carbon-icons-svelte/lib/CheckmarkFilled.svelte";
   import { getContext } from "svelte";
+  import CheckmarkFilled from "../icons/CheckmarkFilled.svelte";
   import StructuredListCell from "./StructuredListCell.svelte";
 
   const ctx = getContext("carbon:StructuredListWrapper");


### PR DESCRIPTION
Fixes #3434 

https://github.com/carbon-design-system/carbon-components-svelte/commit/9785256010e7ffc55903f33154fb3c50435d5df6 imported the checkmark icon automatically for the structured list item.

**The impact** is that the consume would see a dependency error if they don't have `carbon-icons-svelte`.

However, it imported it from `carbon-icons-svelte` instead of the inlined icon source. This is a problem because:

- `carbon-icons-svelte` is another dependency; core icons are intentionally inlined in this library. It's a devDependency of this library, not a direct.
- `carbon-icons-svelte` has two major versions to support TypeScript for Svelte 3/4/5; so even if the consumer has the icon library installed, it may not work as intended.

As a remediation, I added a Biome rule to ban `carbon-icons-svelte/**` imports in `./src/**`.