### PR TITLE
chore(structured-list): stop hidden input from opening a table-layout gap

### DIFF
--- a/css/_structured-list-input-focusable.scss
+++ b/css/_structured-list-input-focusable.scss
@@ -8,17 +8,50 @@
 // <label>) and the native input is the focusable, checkbox/radio-shaped
 // control, it must stay in the tab order and accessibility tree -- visually
 // hidden the same way SelectableTile's input is, instead of display: none.
+//
+// The input renders as a sibling of the row's `.bx--structured-list-td`
+// cells (inside the CSS-table `.bx--structured-list-row`). Any non-`none`
+// display value on that raw sibling -- regardless of position -- makes the
+// browser's table auto-layout allocate it an oversized anonymous column,
+// opening a visible gap between cells. Giving the wrapper an explicit
+// `display: table-cell` makes it a real, correctly-sized column instead of
+// an anonymous one. Native radio/checkbox inputs can't take `table-cell`
+// display themselves (browsers force them back to `inline-block`), so the
+// wrapper carries the table-cell display; the clipping that hides the input
+// stays on the input itself, since a table-cell box is stretched to the
+// row's height regardless of its own `height`, which would defeat a 1px
+// clip applied to the wrapper.
 @mixin structured-list-input-focusable {
+  .#{$prefix}--structured-list-input-wrapper {
+    display: table-cell;
+    position: relative;
+    width: 1px;
+  }
+
   .#{$prefix}--structured-list-input {
-    // The base rule sets `display: none`; CSS cascades per-property, so
-    // `@include hidden` alone (which never declares `display`) can't
-    // override it regardless of source order -- reset it explicitly.
     display: inline-block;
     @include hidden;
   }
 
   .#{$prefix}--structured-list-row:focus-within {
     @include focus-outline("outline");
+  }
+
+  // Carbon's base CSS fills the selection icon via
+  // `.bx--structured-list-input:checked + .bx--structured-list-td`, an
+  // adjacent-sibling selector that requires the input to be a direct
+  // sibling of the cell. Wrapping the input for the table-layout fix above
+  // breaks that adjacency. `:has()` would restore it, but it's unsupported
+  // at the Svelte 5 browser baseline (Safari 14, Chrome 87 -- see
+  // _datepicker.scss), so instead StructuredListInput mirrors `checked`
+  // onto the wrapper itself, keeping the same adjacent-sibling shape.
+  .#{$prefix}--structured-list-input-wrapper--checked
+    + .#{$prefix}--structured-list-row
+    .#{$prefix}--structured-list-svg,
+  .#{$prefix}--structured-list-input-wrapper--checked
+    + .#{$prefix}--structured-list-td
+    .#{$prefix}--structured-list-svg {
+    fill: $icon-01;
   }
 }
 

--- a/css/_structured-list-input-focusable.scss
+++ b/css/_structured-list-input-focusable.scss
@@ -26,6 +26,7 @@
     display: table-cell;
     position: relative;
     width: 1px;
+    box-sizing: border-box;
   }
 
   .#{$prefix}--structured-list-input {
@@ -35,6 +36,20 @@
 
   .#{$prefix}--structured-list-row:focus-within {
     @include focus-outline("outline");
+  }
+
+  // Under `border-collapse: collapse`, every column's top border is
+  // resolved independently against the column above it. Carbon's hover
+  // rule below only adds `border-top` to `.bx--structured-list-td`
+  // cells, so the wrapper's column -- lacking that border -- resolves
+  // to a different edge than its neighbors, showing as a 1px seam right
+  // where the wrapper sits. Giving the wrapper the identical
+  // conditional border keeps every column's top edge resolving the same
+  // way, hover or not.
+  .#{$prefix}--structured-list--selection
+    .#{$prefix}--structured-list-row:hover:not(.#{$prefix}--structured-list-row--header-row)
+    > .#{$prefix}--structured-list-input-wrapper {
+    border-top: 1px solid $ui-01;
   }
 
   // Carbon's base CSS fills the selection icon via

--- a/src/StructuredList/StructuredListInput.svelte
+++ b/src/StructuredList/StructuredListInput.svelte
@@ -56,24 +56,29 @@
     : $selectedValue === value;
 </script>
 
-<input
-  bind:this={ref}
-  type={multiple ? "checkbox" : "radio"}
-  {tabindex}
-  {checked}
-  {id}
-  {name}
-  {title}
-  {value}
-  class:bx--structured-list-input={true}
-  {...$$restProps}
-  on:change={() => {
-    update(value);
-  }}
-  on:keydown={(event) => {
-    if (event.key === "Enter") {
-      event.preventDefault();
-      ref.click();
-    }
-  }}
+<span
+  class:bx--structured-list-input-wrapper={true}
+  class:bx--structured-list-input-wrapper--checked={checked}
 >
+  <input
+    bind:this={ref}
+    type={multiple ? "checkbox" : "radio"}
+    {tabindex}
+    {checked}
+    {id}
+    {name}
+    {title}
+    {value}
+    class:bx--structured-list-input={true}
+    {...$$restProps}
+    on:change={() => {
+      update(value);
+    }}
+    on:keydown={(event) => {
+      if (event.key === "Enter") {
+        event.preventDefault();
+        ref.click();
+      }
+    }}
+  >
+</span>

--- a/tests/StructuredList/StructuredList.test.ts
+++ b/tests/StructuredList/StructuredList.test.ts
@@ -159,6 +159,45 @@ describe("StructuredList", () => {
     expect(rows[2]).not.toBeChecked();
   });
 
+  it("should wrap the native input in a table-cell so it doesn't leave a stray anonymous column", () => {
+    // Regression: an unwrapped, visually-hidden input sitting directly
+    // between two `.bx--structured-list-td` cells makes the browser's CSS
+    // table auto-layout allocate it an oversized anonymous column, opening
+    // a visible gap between cells. The wrapper must be a real table cell.
+    const { container } = render(StructuredList, {
+      props: { selection: true, selected: "row-2-value" },
+    });
+
+    const wrappers = container.querySelectorAll(
+      ".bx--structured-list-input-wrapper",
+    );
+    expect(wrappers.length).toBeGreaterThan(0);
+    for (const wrapper of wrappers) {
+      expect(wrapper.tagName).toBe("SPAN");
+      expect(wrapper.querySelector('input[type="radio"]')).not.toBeNull();
+      expect(
+        wrapper.parentElement?.classList.contains("bx--structured-list-row"),
+      ).toBe(true);
+    }
+
+    const checkedWrapper = screen
+      .getByRole("radio", { checked: true })
+      .closest(".bx--structured-list-input-wrapper");
+    expect(checkedWrapper).toHaveClass(
+      "bx--structured-list-input-wrapper--checked",
+    );
+
+    const uncheckedWrappers = [...wrappers].filter(
+      (wrapper) => wrapper !== checkedWrapper,
+    );
+    expect(uncheckedWrappers.length).toBeGreaterThan(0);
+    for (const wrapper of uncheckedWrappers) {
+      expect(wrapper).not.toHaveClass(
+        "bx--structured-list-input-wrapper--checked",
+      );
+    }
+  });
+
   it('should not put role="radio"/"checkbox" on the <label> element', () => {
     const { container } = render(StructuredList, {
       props: { selection: true },


### PR DESCRIPTION
Scoping as a "chore" and not a "fix" since this visual regression
is not yet released.

The focusable, visually-hidden `<input>` added in #3431 (so a11y
selection state stays in the tab order) renders as a raw sibling of a
row's `.bx--structured-list-td` cells inside the CSS-table
`.bx--structured-list-row`. Any non-`none` display value on that raw
sibling, regardless of position, makes the browser's table
auto-layout allocate it an oversized anonymous column, which shows up
as a stray border/highlight on row hover or selection.

The fix wraps the input in a `span` with `display: table-cell` so it
becomes a real, correctly-sized column instead of an anonymous one.
Native radio/checkbox inputs can't take `table-cell` display
themselves (browsers force them back to `inline-block`), so the
wrapper carries the layout fix while the visual-hiding clip stays on
the input. Wrapping also breaks Carbon's adjacent-sibling selector
that fills the selection checkmark on `:checked`; `:has()` would
restore it but is unsupported at this project's browser baseline
(Chrome 87, Safari 14), so `checked` is mirrored onto the wrapper as
a modifier class instead, keeping the same adjacent-sibling shape.
