### PR TITLE
fix(select): keep the placeholder when options change with nothing selected

### DIFF
--- a/e2e/fixtures/ItemsResyncFixture.svelte
+++ b/e2e/fixtures/ItemsResyncFixture.svelte
@@ -58,6 +58,8 @@
   let selRemoveItems = make();
   let selRemoveSelected = "orwell";
 
+  let selNoSelectionExtra = false;
+
   let msSwapItems = make();
   let msSwapSelectedIds = ["orwell"];
 
@@ -99,6 +101,10 @@
     selFillItems = [];
     msFillItems = [];
   }
+
+  function toggleNoSelectionOption() {
+    selNoSelectionExtra = !selNoSelectionExtra;
+  }
 </script>
 
 <button type="button" data-testid="load" on:click={load}>Load options</button>
@@ -121,6 +127,13 @@
   on:click={removeNonSelected}
 >
   Remove non-selected
+</button>
+<button
+  type="button"
+  data-testid="toggle-no-selection-option"
+  on:click={toggleNoSelectionOption}
+>
+  Toggle no-selection option
 </button>
 
 <ComboBox
@@ -200,6 +213,15 @@
   {/each}
 </Select>
 <p data-testid="sel-remove-selected">{selRemoveSelected}</p>
+
+<!-- No `selected` prop: the empty-valued placeholder is the effective selection. -->
+<Select data-testid="sel-no-selection" labelText="Select no selection">
+  <SelectItem value="" text="Choose an option" />
+  <SelectItem value="austen" text="Jane Austen" />
+  {#if selNoSelectionExtra}
+    <SelectItem value="dickens" text="Charles Dickens" />
+  {/if}
+</Select>
 
 <!-- Wrapper carries data-testid; MultiSelect does not spread $$restProps. -->
 <div data-testid="ms-swap">

--- a/e2e/items-resync.test.ts
+++ b/e2e/items-resync.test.ts
@@ -142,6 +142,28 @@ test.describe("Items resync — display derived from value + items", () => {
     await expect(page.getByTestId("ms-remove")).toContainText("1");
   });
 
+  test("Select keeps the placeholder when the option list changes with nothing selected", async ({
+    page,
+  }) => {
+    // On the Svelte 5 runtime a spread <select> gets a MutationObserver that
+    // re-asserts select.__value (undefined here, since Select never spreads a
+    // value) on every option add/remove, resetting selectedIndex to -1.
+    // `value` reads "" both when the placeholder is selected and when
+    // selectedIndex is -1, so only selectedIndex distinguishes the two.
+    const select = page.getByTestId("sel-no-selection");
+    const selectedIndex = () =>
+      select.evaluate((node: HTMLSelectElement) => node.selectedIndex);
+
+    await expect(select).toHaveValue("");
+    await expect.poll(selectedIndex).toBe(0);
+
+    await page.getByTestId("toggle-no-selection-option").click();
+    await expect.poll(selectedIndex).toBe(0);
+
+    await page.getByTestId("toggle-no-selection-option").click();
+    await expect.poll(selectedIndex).toBe(0);
+  });
+
   test("Dropdown shows selection after async fill (reference)", async ({
     page,
   }) => {

--- a/src/Select/Select.svelte
+++ b/src/Select/Select.svelte
@@ -170,11 +170,15 @@
   });
 
   // Options mounted after selected is set do not update the native value.
+  // selectedIndex -1 comes back as value "", indistinguishable from an
+  // empty-valued option being selected, so it must be re-asserted explicitly.
   function syncNativeSelectValue() {
     tick().then(() => {
       if (!ref) return;
       const nextValue = $selectedValue == null ? "" : String($selectedValue);
-      if (ref.value !== nextValue) ref.value = nextValue;
+      if (ref.selectedIndex === -1 || ref.value !== nextValue) {
+        ref.value = nextValue;
+      }
     });
   }
 


### PR DESCRIPTION
A `Select` with **no selection** loses its placeholder when the option list changes on the Svelte 5 runtime. Render a `Select` whose first option is an empty-valued placeholder, select nothing, then mount/unmount any option: the input goes blank and `select.selectedIndex` sticks at `-1`. 

Svelte 4 consumers are unaffected.

Also filed an issue with [svelte](https://github.com/sveltejs/svelte/issues/18557) as this isn't just a carbon issue. 