### PR TITLE
fix(multi-select): prevent page scroll on Space in filterable read-only mode

### DIFF
--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -822,6 +822,7 @@
             } else if (event.key === "Escape") {
               close("escape-key");
             } else if (event.key === " ") {
+              if (readonly) event.preventDefault();
               if (!open) open = true;
             } else if (event.key === "Backspace" && value === "") {
               selectedIds = [];

--- a/tests/MultiSelect/MultiSelect.test.ts
+++ b/tests/MultiSelect/MultiSelect.test.ts
@@ -2882,6 +2882,34 @@ describe("MultiSelect", () => {
       expect(screen.getByRole("listbox")).toBeInTheDocument();
     });
 
+    it("prevents the browser default (page scroll) on Space when readonly + filterable", async () => {
+      render(MultiSelect, {
+        props: {
+          items,
+          labelText: "Contact",
+          readonly: true,
+          filterable: true,
+          placeholder: "Select",
+        },
+      });
+
+      const input = screen.getByRole("combobox");
+
+      // A readonly input cannot insert a space, so an un-prevented Space falls
+      // through to the browser's default page scroll. The handler must
+      // preventDefault while still opening the menu for review.
+      const event = new KeyboardEvent("keydown", {
+        key: " ",
+        bubbles: true,
+        cancelable: true,
+      });
+      input.dispatchEvent(event);
+      await tick();
+
+      expect(event.defaultPrevented).toBe(true);
+      expect(screen.getByRole("listbox")).toBeInTheDocument();
+    });
+
     it("does not toggle a selection when an option is clicked while readonly", async () => {
       render(MultiSelect, {
         props: {


### PR DESCRIPTION
When MultiSelect is in `filterable` mode and is also set to `readonly`, if someone uses SPACE to open the menu, the event falls through and scrolls the page.

This adds a readonly check and corresponding `preventDefault` 