### PR TITLE
fix(date-picker): keep calendar portalled after reactive re-run

### DIFF
--- a/src/DatePicker/DatePicker.svelte
+++ b/src/DatePicker/DatePicker.svelte
@@ -420,6 +420,10 @@
       applyOptionIfChanged("locale", locale, resolveLocale(locale));
       applyOptionIfChanged("dateFormat", dateFormat);
       for (const [option, value] of Object.entries(flatpickrProps)) {
+        // `static` is decided by `effectivePortalMenu` at creation time
+        // (see below); re-applying the default `flatpickrProps.static`
+        // here would clobber that on every reactive re-run.
+        if (option === "static" && effectivePortalMenu) continue;
         applyOptionIfChanged(option, value);
       }
       return;

--- a/tests/DatePicker/DatePicker.test.ts
+++ b/tests/DatePicker/DatePicker.test.ts
@@ -731,6 +731,33 @@ describe("DatePicker", () => {
       expect(wrapper?.contains(calendar)).toBe(true);
       expect(calendar.classList.contains("static")).toBe(true);
     });
+
+    it("does not reapply static:true on a reactive re-run (#3444)", async () => {
+      const { rerender } = render(DatePicker, {
+        datePickerType: "single",
+        portalMenu: true,
+      });
+
+      const input = screen.getByLabelText("Date") as HTMLInputElement;
+      await user.click(input);
+      await screen.findByLabelText("calendar-container");
+
+      const fp = (
+        input as unknown as { _flatpickr: { config: { static: boolean } } }
+      )._flatpickr;
+      expect(fp.config.static).toBe(false);
+
+      // Trigger the `initCalendar` reactive statement to re-run (e.g. a
+      // minDate update) without touching `portalMenu` or `flatpickrProps`.
+      await rerender({
+        datePickerType: "single",
+        portalMenu: true,
+        minDate: "01/01/2024",
+      });
+      await tick();
+
+      expect(fp.config.static).toBe(false);
+    });
   });
 
   describe("month mode", () => {


### PR DESCRIPTION
Fixes #3444 

The initCalendar reactive block reapplied flatpickrProps' default
static: true on every re-run, clobbering the static: false that
`portalMenu` sets at creation, so the calendar drifted out of the
portal (and could get clipped inside a Modal) after any unrelated
prop update.