### PR TITLE
ci(e2e): use preinstalled Chrome instead of Playwright's bundled Chromium

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -108,26 +108,15 @@ jobs:
       (needs.test.result == 'success' || needs.test.result == 'skipped') &&
       (github.event_name == 'workflow_dispatch' || needs.changes.outputs.e2e == 'true')
     runs-on: ubuntu-latest
-    # Official image includes Chromium/Firefox/WebKit + system deps
-    # Bump tag with @playwright/test in bun.lock.
-    container:
-      image: mcr.microsoft.com/playwright:v1.61.0-noble
-      options: --ipc=host --init
     timeout-minutes: 15
-    env:
-      PLAYWRIGHT_BROWSERS_PATH: /ms-playwright
-      HOME: /root
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      # Playwright image is minimal; setup-bun extracts a zip and needs unzip.
-      # Try installing first (fast path) and only refresh apt lists if needed.
-      - run: DEBIAN_FRONTEND=noninteractive apt-get install -y unzip || { apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y unzip; }
-
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
       # --ignore-scripts skips the ibmtelemetry postinstall (already disabled
-      # via IBM_TELEMETRY_DISABLED) and Playwright's browser download (browsers
-      # are baked into the image at PLAYWRIGHT_BROWSERS_PATH).
+      # via IBM_TELEMETRY_DISABLED) and Playwright's browser download: the
+      # chromium project uses channel: "chrome", reusing the Google Chrome
+      # preinstalled on GitHub-hosted runners instead.
       - run: bun ci --ignore-scripts
 
       - name: Build CSS

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -11,7 +11,14 @@ export default defineConfig({
     baseURL: "http://localhost:4173",
   },
   projects: process.env.CI
-    ? [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }]
+    ? [
+        {
+          // Reuse the Chrome preinstalled on GitHub-hosted runners instead of
+          // downloading Playwright's bundled Chromium.
+          name: "chromium",
+          use: { ...devices["Desktop Chrome"], channel: "chrome" },
+        },
+      ]
     : [
         { name: "chromium", use: { ...devices["Desktop Chrome"] } },
         { name: "firefox", use: { ...devices["Desktop Firefox"] } },


### PR DESCRIPTION
The e2e job ran inside the mcr.microsoft.com/playwright container
just to get a Chromium binary + system deps for a single chromium
project. GitHub-hosted runners already ship Google Chrome, so the
container and its unzip workaround are unnecessary.

The chromium project now sets `channel: "chrome"` in CI, and the job
runs directly on bare `ubuntu-latest`. Local dev is unaffected; it
still uses Playwright's bundled Chromium/Firefox/WebKit.

## Risk

CI Chrome now tracks the runner image's version instead of being
pinned to `@playwright/test` in `bun.lock`. A runner image bump could
occasionally drift from the locally tested browser version.