### PR TITLE
fix(date-picker): resync flatpickr `allowInput` on readonly toggle

### DIFF
--- a/src/DatePicker/DatePicker.svelte
+++ b/src/DatePicker/DatePicker.svelte
@@ -548,6 +548,7 @@
   }
   $: if (calendar) {
     calendar.set("clickOpens", !$readonlyAny);
+    calendar.set("allowInput", !$readonlyAny);
     if ($readonlyAny && calendar.isOpen) calendar.close();
   }
 

--- a/tests/DatePicker/DatePicker.test.ts
+++ b/tests/DatePicker/DatePicker.test.ts
@@ -137,6 +137,30 @@ describe("DatePicker", () => {
       expect(start).toHaveAttribute("readonly");
       expect(end).toHaveAttribute("readonly");
     });
+
+    it("keeps flatpickr's allowInput option in sync when readonly toggles after mount", async () => {
+      const { rerender } = render(DatePicker, {
+        datePickerType: "single",
+        readonly: false,
+      });
+
+      const input = screen.getByLabelText("Date") as HTMLInputElement;
+      await user.click(input);
+      await screen.findByLabelText("calendar-container");
+
+      const fp = (
+        input as unknown as { _flatpickr: { config: { allowInput: boolean } } }
+      )._flatpickr;
+      expect(fp.config.allowInput).toBe(true);
+
+      await rerender({
+        datePickerType: "single",
+        readonly: true,
+      });
+      await tick();
+
+      expect(fp.config.allowInput).toBe(false);
+    });
   });
 
   it("handles invalid state", () => {


### PR DESCRIPTION
`allowInput` was only ever set from `!readonlyAny` at flatpickr
creation time, unlike the sibling `clickOpens` option, which is
kept in sync on every readonly change. Toggling `readonly` after
the calendar mounted left `allowInput` stale, contradicting the
option's own stated purpose.

The reactive block that already resyncs `clickOpens` now also
resyncs `allowInput`. Added a regression test and a docs example
showing readonly toggled at runtime.