### PR TITLE
feat(tree-view): add getNode/getNodes lookup accessors

### DIFF
--- a/docs/src/pages/components/TreeView.svx
+++ b/docs/src/pages/components/TreeView.svx
@@ -169,6 +169,14 @@ Configure `TreeView.showNode` behavior using optional parameters. By default, al
 
 <FileSource src="/framed/TreeView/TreeViewShowNodeOptions" />
 
+## Node lookup
+
+Use `TreeView.getNode` to resolve a node's text or metadata from its id, useful for a breadcrumb or detail pane driven by `activeId`. Unmatched ids return `null`.
+
+Use `TreeView.getNodes` to resolve multiple ids at once, such as `selectedIds`. Unmatched ids are omitted from the result.
+
+<FileSource src="/framed/TreeView/TreeViewGetNode" />
+
 ## Flat data
 
 Convert flat data to a hierarchical structure using the `toHierarchy` utility.

--- a/docs/src/pages/framed/TreeView/TreeViewGetNode.svelte
+++ b/docs/src/pages/framed/TreeView/TreeViewGetNode.svelte
@@ -1,0 +1,55 @@
+<script>
+  import { Stack, TreeView } from "carbon-components-svelte";
+
+  let treeview = null;
+  let activeId = "";
+  let selectedIds = [];
+  let nodes = [
+    { id: 0, text: "AI / Machine learning" },
+    {
+      id: 1,
+      text: "Analytics",
+      nodes: [
+        {
+          id: 2,
+          text: "IBM Analytics Engine",
+          nodes: [
+            { id: 3, text: "Apache Spark" },
+            { id: 4, text: "Hadoop" },
+          ],
+        },
+        { id: 5, text: "IBM Cloud SQL Query" },
+        { id: 6, text: "IBM Db2 Warehouse on Cloud" },
+      ],
+    },
+    {
+      id: 7,
+      text: "Blockchain",
+      nodes: [{ id: 8, text: "IBM Blockchain Platform" }],
+    },
+  ];
+
+  $: activeNode = treeview?.getNode(activeId) ?? null;
+  $: selectedNodes = treeview?.getNodes(selectedIds) ?? [];
+</script>
+
+<Stack gap={6}>
+  <div>
+    <TreeView
+      bind:this={treeview}
+      multiselect
+      labelText="Cloud Products"
+      {nodes}
+      bind:activeId
+      bind:selectedIds
+    />
+  </div>
+  <Stack gap={4}>
+    <div>Active node: {activeNode ? activeNode.text : "(none)"}</div>
+    <div>
+      Selected nodes:
+      {selectedNodes.map((node) => node.text).join(", ") ||
+        "(none)"}
+    </div>
+  </Stack>
+</Stack>

--- a/src/TreeView/TreeView.svelte
+++ b/src/TreeView/TreeView.svelte
@@ -427,6 +427,37 @@
     }
   }
 
+  /**
+   * Look up a node by `id` without re-implementing tree traversal.
+   * Returns `null` if no node with the given `id` exists.
+   * @type {(id: Node["id"]) => Node | null}
+   * @example
+   * ```svelte
+   * <TreeView bind:this={treeView} {nodes} />
+   * <button on:click={() => console.log(treeView.getNode('node-123'))}>
+   *   Log Node
+   * </button>
+   * ```
+   */
+  export function getNode(id) {
+    return cachedNodeMap?.get(id) ?? null;
+  }
+
+  /**
+   * Look up multiple nodes by `id`. Ids without a matching node are omitted.
+   * @type {(ids: ReadonlyArray<Node["id"]>) => Array<Node>}
+   * @example
+   * ```svelte
+   * <TreeView bind:this={treeView} {nodes} />
+   * <button on:click={() => console.log(treeView.getNodes(selectedIds))}>
+   *   Log Selected Nodes
+   * </button>
+   * ```
+   */
+  export function getNodes(ids) {
+    return ids.map((id) => cachedNodeMap?.get(id)).filter((node) => node);
+  }
+
   import {
     afterUpdate,
     createEventDispatcher,
@@ -526,6 +557,8 @@
   let cachedFlattenedNodes = null;
   /** @type {Array<Node["id"]> | null} */
   let cachedNodeIds = null;
+  /** @type {Map<Node["id"], Node> | null} */
+  let cachedNodeMap = null;
 
   /** @type {Node["id"] | null} */
   let anchorId = null;
@@ -898,6 +931,9 @@
     cachedNodes = nodes;
     cachedFlattenedNodes = traverse(nodes);
     cachedNodeIds = cachedFlattenedNodes.map((node) => node.id);
+    cachedNodeMap = new Map(
+      cachedFlattenedNodes.map((node) => [node.id, node]),
+    );
   }
 
   $: multiselectStore.set(multiselect);

--- a/tests/TreeView/TreeView.getNode.test.svelte
+++ b/tests/TreeView/TreeView.getNode.test.svelte
@@ -1,0 +1,55 @@
+<script lang="ts">
+  import Button from "carbon-components-svelte/Button/Button.svelte";
+  import type { TreeNode } from "carbon-components-svelte/TreeView/TreeView.svelte";
+  import TreeView from "carbon-components-svelte/TreeView/TreeView.svelte";
+  import type { ComponentProps } from "svelte";
+
+  let treeview: TreeView;
+  let selectedIds: TreeNode["id"][] = [];
+  let nodes: ComponentProps<TreeView>["nodes"] = [
+    { id: 0, text: "Level 0" },
+    {
+      id: 1,
+      text: "Level 1",
+      nodes: [
+        {
+          id: 2,
+          text: "Level 2",
+          nodes: [
+            { id: 3, text: "Level 3 - Target" },
+            { id: 4, text: "Level 3 - Other" },
+          ],
+        },
+      ],
+    },
+  ];
+</script>
+
+<TreeView
+  bind:this={treeview}
+  labelText="getNode Test"
+  {nodes}
+  bind:selectedIds
+  let:node
+>
+  {node.text}
+</TreeView>
+
+<Button
+  data-testid="get-node"
+  on:click={() => console.log("getNode", treeview.getNode(3))}
+>
+  Get node
+</Button>
+<Button
+  data-testid="get-missing-node"
+  on:click={() => console.log("getNode", treeview.getNode(999))}
+>
+  Get missing node
+</Button>
+<Button
+  data-testid="get-nodes"
+  on:click={() => console.log("getNodes", treeview.getNodes([3, 999, 0]))}
+>
+  Get nodes
+</Button>

--- a/tests/TreeView/TreeView.getNode.test.ts
+++ b/tests/TreeView/TreeView.getNode.test.ts
@@ -1,0 +1,45 @@
+import { render, screen } from "@testing-library/svelte";
+import { user } from "../utils/user";
+import TreeViewGetNode from "./TreeView.getNode.test.svelte";
+
+describe("TreeView.getNode / getNodes", () => {
+  const getButton = (testId: string) => screen.getByTestId(testId);
+
+  beforeEach(() => {
+    render(TreeViewGetNode);
+  });
+
+  it("returns the matching node for a nested id", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    await user.click(getButton("get-node"));
+
+    expect(consoleLog).toHaveBeenCalledWith(
+      "getNode",
+      expect.objectContaining({ id: 3, text: "Level 3 - Target" }),
+    );
+  });
+
+  it("returns null for an id with no matching node", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    await user.click(getButton("get-missing-node"));
+
+    expect(consoleLog).toHaveBeenCalledWith("getNode", null);
+  });
+
+  it("resolves multiple ids and omits ids with no matching node", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    await user.click(getButton("get-nodes"));
+
+    expect(consoleLog).toHaveBeenCalledWith(
+      "getNodes",
+      expect.arrayContaining([
+        expect.objectContaining({ id: 3 }),
+        expect.objectContaining({ id: 0 }),
+      ]),
+    );
+    const nodes = consoleLog.mock.calls.find(
+      (call) => call[0] === "getNodes",
+    )?.[1];
+    expect(nodes).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
Consumers holding activeId/selectedIds had no way to resolve a
node's text or metadata without re-implementing tree traversal.
getNode(id) and getNodes(ids) resolve against the existing
flattened-node cache, so lookups stay O(1).