### PR TITLE
feat(tree-view): add type-ahead search and aria-level/posinset/setsize

### DIFF
--- a/src/TreeView/TreeView.svelte
+++ b/src/TreeView/TreeView.svelte
@@ -29,6 +29,22 @@
   }
 
   /**
+   * Whether a keydown event should feed the type-ahead search buffer:
+   * a single printable character with no modifier (excludes Space, which
+   * is reserved for selection).
+   * @param {KeyboardEvent} event
+   */
+  function isTypeAheadKey(event) {
+    return (
+      event.key.length === 1 &&
+      event.key !== " " &&
+      !event.ctrlKey &&
+      !event.metaKey &&
+      !event.altKey
+    );
+  }
+
+  /**
    * Creates a TreeWalker instance for keyboard navigation.
    * @returns {TreeWalker} A TreeWalker configured to navigate tree nodes
    */
@@ -689,6 +705,69 @@
     return target.closest(".bx--tree-node");
   }
 
+  /** Type-ahead search buffer, reset after `typeAheadTimeoutMs` of inactivity. */
+  let typeAheadBuffer = "";
+  let typeAheadTimeoutId = null;
+  const typeAheadTimeoutMs = 500;
+
+  /** @returns {Element[]} Visible (non-disabled, non-hidden) tree items in document order. */
+  function collectVisibleTreeItems() {
+    if (!treeWalker || !ref) return [];
+    treeWalker.currentNode = ref;
+    /** @type {Element[]} */
+    const items = [];
+    let n = treeWalker.nextNode();
+    while (n) {
+      items.push(n);
+      n = treeWalker.nextNode();
+    }
+    return items;
+  }
+
+  /**
+   * Moves focus to the next visible node whose label starts with the
+   * typed search string, cycling from the current item. Repeating the
+   * same character (e.g. "bbb") cycles through matches for that letter,
+   * matching native `<select>`-style type-ahead.
+   * @param {KeyboardEvent} event
+   * @param {Element} treeItem
+   * @returns {boolean} Whether the event was handled as type-ahead input.
+   */
+  function handleTypeAhead(event, treeItem) {
+    if (!isTypeAheadKey(event)) return false;
+
+    if (typeAheadTimeoutId) clearTimeout(typeAheadTimeoutId);
+    typeAheadBuffer += event.key.toLowerCase();
+    typeAheadTimeoutId = setTimeout(() => {
+      typeAheadBuffer = "";
+    }, typeAheadTimeoutMs);
+
+    const isRepeatedChar =
+      typeAheadBuffer.length > 1 &&
+      [...typeAheadBuffer].every((c) => c === typeAheadBuffer[0]);
+    const query = isRepeatedChar ? typeAheadBuffer[0] : typeAheadBuffer;
+
+    const items = collectVisibleTreeItems();
+    if (items.length === 0) return true;
+
+    const startIndex = Math.max(items.indexOf(treeItem), 0);
+
+    for (let offset = 1; offset <= items.length; offset++) {
+      const candidate = items[(startIndex + offset) % items.length];
+      const label = (candidate.textContent ?? "").trim().toLowerCase();
+      if (label.startsWith(query)) {
+        resetNodeTabIndices(ref);
+        if (candidate instanceof HTMLElement) {
+          candidate.tabIndex = 0;
+          candidate.focus();
+        }
+        break;
+      }
+    }
+
+    return true;
+  }
+
   function handleKeyDown(event) {
     event.stopPropagation();
 
@@ -707,6 +786,8 @@
 
     const treeItem = getTreeItemFromTarget(event.target);
     if (!treeItem) return;
+
+    if (handleTypeAhead(event, treeItem)) return;
 
     treeWalker.currentNode = treeItem;
 
@@ -809,6 +890,7 @@
 
     return () => {
       setMultiselectKeyListeners(false);
+      if (typeAheadTimeoutId) clearTimeout(typeAheadTimeoutId);
     };
   });
 

--- a/src/TreeView/TreeViewNode.svelte
+++ b/src/TreeView/TreeViewNode.svelte
@@ -68,6 +68,13 @@
   export let text = "";
   export let disabled = false;
 
+  /** 1-based `aria-level` of this node within the tree. */
+  export let level = 1;
+  /** 1-based `aria-posinset` of this node among its siblings. */
+  export let posinset = 1;
+  /** `aria-setsize` — the number of siblings (including this node). */
+  export let setsize = 1;
+
   /**
    * Specify the URL the TreeNode links to.
    * @type {string | undefined}
@@ -106,8 +113,15 @@
   $: selected = $selectedIdsSetStore.has(id);
   // Merge all props (including custom properties) with computed properties
   // Explicitly include disabled to ensure it's always present (has default value)
+  // `level`/`posinset`/`setsize` are layout-only (drive `aria-*` attributes) and excluded from `node`.
+  $: ({
+    level: _level,
+    posinset: _posinset,
+    setsize: _setsize,
+    ...restProps
+  } = $$props);
   $: node = {
-    ...$$props,
+    ...restProps,
     disabled, // Ensure disabled is always included (has default value)
     expanded: false, // A node cannot be expanded.
     leaf,
@@ -142,6 +156,9 @@
       tabindex={disabled ? undefined : -1}
       aria-current={id === $activeNodeId ? "page" : undefined}
       aria-disabled={disabled}
+      aria-level={level}
+      aria-posinset={posinset}
+      aria-setsize={setsize}
       class:bx--tree-node={true}
       class:bx--tree-leaf-node={true}
       class:bx--tree-node--active={id === $activeNodeId}
@@ -202,6 +219,9 @@
     aria-current={id === $activeNodeId || undefined}
     aria-selected={disabled ? undefined : selected}
     aria-disabled={disabled}
+    aria-level={level}
+    aria-posinset={posinset}
+    aria-setsize={setsize}
     class:bx--tree-node={true}
     class:bx--tree-leaf-node={true}
     class:bx--tree-node--active={id === $activeNodeId}

--- a/src/TreeView/TreeViewNodeList.svelte
+++ b/src/TreeView/TreeViewNodeList.svelte
@@ -14,6 +14,13 @@
   export let text = "";
   export let disabled = false;
 
+  /** 1-based `aria-level` of this node within the tree. */
+  export let level = 1;
+  /** 1-based `aria-posinset` of this node among its siblings. */
+  export let posinset = 1;
+  /** `aria-setsize` — the number of siblings (including this node). */
+  export let setsize = 1;
+
   /**
    * Specify the icon to render.
    * @type {Icon}
@@ -69,8 +76,15 @@
   $: selected = $selectedIdsSetStore.has(id);
   // Merge all props (including custom properties) with computed properties
   // Explicitly reference text and disabled to avoid Svelte warning and ensure they're included
+  // `level`/`posinset`/`setsize` are layout-only (drive `aria-*` attributes) and excluded from `node`.
+  $: ({
+    level: _level,
+    posinset: _posinset,
+    setsize: _setsize,
+    ...restProps
+  } = $$props);
   $: node = {
-    ...$$props,
+    ...restProps,
     text, // Ensure text is included and marked as used
     disabled, // Ensure disabled is always included (has default value)
     expanded,
@@ -97,11 +111,28 @@
 </script>
 
 {#if root}
-  {#each nodes as child (child.id)}
+  {#each nodes as child, index (child.id)}
     {#if Array.isArray(child.nodes)}
-      <svelte:self {...child} let:node> <slot {node} /> </svelte:self>
+      <svelte:self
+        {...child}
+        level={1}
+        posinset={index + 1}
+        setsize={nodes.length}
+        let:node
+      >
+        <slot {node} />
+      </svelte:self>
     {:else}
-      <TreeViewNode leaf {...child} let:node> <slot {node} /> </TreeViewNode>
+      <TreeViewNode
+        leaf
+        {...child}
+        level={1}
+        posinset={index + 1}
+        setsize={nodes.length}
+        let:node
+      >
+        <slot {node} />
+      </TreeViewNode>
     {/if}
   {/each}
 {:else}
@@ -122,6 +153,9 @@
     class:bx--tree-node--with-icon={icon}
     aria-expanded={expanded}
     aria-owns="{treeId}-{id}-subtree"
+    aria-level={level}
+    aria-posinset={posinset}
+    aria-setsize={setsize}
     on:click|stopPropagation={(event) => {
       if (disabled) return;
       clickNode(node, event);
@@ -220,11 +254,26 @@
       class:bx--tree-node__children={true}
       class:bx--tree-node--hidden={!expanded}
     >
-      {#each nodes as child (child.id)}
+      {#each nodes as child, index (child.id)}
         {#if Array.isArray(child.nodes)}
-          <svelte:self {...child} let:node> <slot {node} /> </svelte:self>
+          <svelte:self
+            {...child}
+            level={level + 1}
+            posinset={index + 1}
+            setsize={nodes.length}
+            let:node
+          >
+            <slot {node} />
+          </svelte:self>
         {:else}
-          <TreeViewNode leaf {...child} let:node>
+          <TreeViewNode
+            leaf
+            {...child}
+            level={level + 1}
+            posinset={index + 1}
+            setsize={nodes.length}
+            let:node
+          >
             <slot {node}>{node.text}</slot>
           </TreeViewNode>
         {/if}

--- a/tests/TreeView/TreeView.aria.test.ts
+++ b/tests/TreeView/TreeView.aria.test.ts
@@ -1,0 +1,90 @@
+import { render } from "@testing-library/svelte";
+import { user } from "../utils/user";
+import TreeView from "./TreeView.test.svelte";
+
+function treeItemById(id: string | number): HTMLElement {
+  const el = document.getElementById(String(id));
+  expect.assert(el instanceof HTMLElement);
+  return el;
+}
+
+describe("TreeView WAI-ARIA completeness", () => {
+  it("sets aria-level, aria-posinset, and aria-setsize on root-level nodes", () => {
+    render(TreeView);
+
+    // Top-level nodes: AI/ML(0), Analytics(1), Blockchain(7), Databases(9), Integration(14)
+    const aiItem = treeItemById(0);
+    expect(aiItem).toHaveAttribute("aria-level", "1");
+    expect(aiItem).toHaveAttribute("aria-posinset", "1");
+    expect(aiItem).toHaveAttribute("aria-setsize", "5");
+
+    const analyticsItem = treeItemById(1);
+    expect(analyticsItem).toHaveAttribute("aria-level", "1");
+    expect(analyticsItem).toHaveAttribute("aria-posinset", "2");
+    expect(analyticsItem).toHaveAttribute("aria-setsize", "5");
+  });
+
+  it("sets aria-level, aria-posinset, and aria-setsize on nested nodes", async () => {
+    render(TreeView);
+
+    const analyticsToggle = treeItemById(1).querySelector(
+      ".bx--tree-parent-node__toggle",
+    );
+    expect.assert(analyticsToggle instanceof HTMLElement);
+    await user.click(analyticsToggle);
+
+    // Analytics' children: IBM Analytics Engine(2), IBM Cloud SQL Query(5), IBM Db2 Warehouse(6)
+    const engineItem = treeItemById(2);
+    expect(engineItem).toHaveAttribute("aria-level", "2");
+    expect(engineItem).toHaveAttribute("aria-posinset", "1");
+    expect(engineItem).toHaveAttribute("aria-setsize", "3");
+
+    const db2Item = treeItemById(6);
+    expect(db2Item).toHaveAttribute("aria-level", "2");
+    expect(db2Item).toHaveAttribute("aria-posinset", "3");
+    expect(db2Item).toHaveAttribute("aria-setsize", "3");
+  });
+});
+
+describe("TreeView type-ahead", () => {
+  it("moves focus to the next visible node whose label starts with the typed character", async () => {
+    render(TreeView);
+
+    const aiItem = treeItemById(0);
+    aiItem.focus();
+
+    await user.keyboard("b");
+
+    const blockchainItem = treeItemById(7);
+    expect(blockchainItem).toHaveFocus();
+  });
+
+  it("cycles through repeated-character matches like native <select> type-ahead", async () => {
+    render(TreeView);
+
+    const aiItem = treeItemById(0);
+    aiItem.focus();
+
+    // First "a" moves from AI/ML(0) to the next match, Analytics(1).
+    await user.keyboard("a");
+    const analyticsItem = treeItemById(1);
+    expect(analyticsItem).toHaveFocus();
+
+    // Second "a" cycles back around to AI/ML(0).
+    await user.keyboard("a");
+    expect(aiItem).toHaveFocus();
+  });
+
+  it("ignores the Space key so it does not interfere with selection", async () => {
+    render(TreeView);
+
+    const aiItem = treeItemById(0);
+    aiItem.focus();
+
+    await user.keyboard(" ");
+
+    // Space selects the focused node rather than performing a type-ahead search.
+    expect(aiItem).toHaveAttribute("aria-selected", "true");
+    expect(aiItem).toHaveFocus();
+  });
+});


### PR DESCRIPTION
Buffers printable keystrokes to jump focus to the next visible node
whose label matches, cycling through matches on repeated characters
like native `<select>` elements. Every treeitem now also reports its
level, sibling position, and set size so screen readers can announce
depth and position in large trees.