### PR TITLE
fix(structured-list): silence unused export warning on deprecated tabindex

### DIFF
--- a/src/StructuredList/StructuredListRow.svelte
+++ b/src/StructuredList/StructuredListRow.svelte
@@ -12,7 +12,7 @@
    * which now owns focus for the selectable row.
    * @type {number | string | undefined}
    */
-  export let tabindex = "0";
+  export const tabindex = "0";
 
   import { getContext } from "svelte";
   import CheckmarkFilled from "../icons/CheckmarkFilled.svelte";


### PR DESCRIPTION
Switches the deprecated tabindex prop on StructuredListRow from
export let to export const, since it's kept only for backward-
compatible external reference and is no longer applied in the
template.