### PR TITLE
feat(tree-view): support lazy loading via hasChildren + childNodes slot

### DIFF
--- a/docs/src/pages/components/TreeView.svx
+++ b/docs/src/pages/components/TreeView.svx
@@ -177,6 +177,14 @@ Use `TreeView.getNodes` to resolve multiple ids at once, such as `selectedIds`. 
 
 <FileSource src="/framed/TreeView/TreeViewGetNode" />
 
+## Lazy loading
+
+Set `hasChildren` on a node to render it as an expandable branch before its `nodes` are known. Expanding it fires `toggle` as usual; the handler can fetch and assign `nodes` asynchronously.
+
+While `hasChildren` is `true` and `nodes` is empty, the `childNodes` slot renders in place of the (empty) subtree, receiving the same `node` as the default slot. TreeView has no built-in concept of "loading" or "error" — the slot is generic, so you decide what to render (a spinner, an error message with retry, or nothing) based on whatever fields you put on the node yourself.
+
+<FileSource src="/framed/TreeView/TreeViewLazyLoad" />
+
 ## Flat data
 
 Convert flat data to a hierarchical structure using the `toHierarchy` utility.

--- a/docs/src/pages/framed/TreeView/TreeViewLazyLoad.svelte
+++ b/docs/src/pages/framed/TreeView/TreeViewLazyLoad.svelte
@@ -1,0 +1,54 @@
+<script>
+  import { InlineLoading, TreeView } from "carbon-components-svelte";
+
+  let nodes = [
+    { id: "ai", text: "AI / Machine learning", hasChildren: true },
+    { id: "analytics", text: "Analytics", hasChildren: true },
+    { id: "blockchain", text: "Blockchain", hasChildren: true },
+  ];
+
+  const childrenByParentId = {
+    ai: [
+      { id: "watson-studio", text: "Watson Studio" },
+      { id: "watson-assistant", text: "Watson Assistant" },
+    ],
+    analytics: [
+      { id: "analytics-engine", text: "IBM Analytics Engine" },
+      { id: "cloud-sql-query", text: "IBM Cloud SQL Query" },
+    ],
+    blockchain: [
+      { id: "blockchain-platform", text: "IBM Blockchain Platform" },
+    ],
+  };
+
+  function fetchChildren(id) {
+    return new Promise((resolve) => {
+      setTimeout(() => resolve(childrenByParentId[id] ?? []), 1000);
+    });
+  }
+
+  async function handleToggle(event) {
+    const node = event.detail;
+
+    // Only fetch once: a node with `hasChildren` but no `nodes` yet.
+    if (!node.hasChildren || node.nodes) return;
+
+    const children = await fetchChildren(node.id);
+
+    nodes = nodes.map((n) =>
+      n.id === node.id ? { ...n, nodes: children } : n,
+    );
+  }
+</script>
+
+<TreeView
+  labelText="Cloud Products (lazy-loaded)"
+  {nodes}
+  on:toggle={handleToggle}
+  let:node
+>
+  {node.text}
+  <svelte:fragment slot="childNodes" let:node>
+    <InlineLoading status="active" description="Loading {node.text}…" />
+  </svelte:fragment>
+</TreeView>

--- a/src/TreeView/TreeView.svelte
+++ b/src/TreeView/TreeView.svelte
@@ -203,6 +203,7 @@
    * @property {boolean} [disabled] - Whether the node is disabled
    * @property {string} [href] - Optional URL the node links to
    * @property {string} [target] - Optional link target (e.g., "_blank")
+   * @property {boolean} [hasChildren] - Whether the node has children that have not been loaded yet. Renders an expander even without a `nodes` array; expanding fires `toggle` so children can be loaded lazily.
    * @property {TreeNode<Id>[]} [nodes]
    * @typedef {object} ShowNodeOptions
    * @property {boolean} [expand] - Whether to expand the node and its ancestors (default: true)
@@ -217,6 +218,7 @@
    * @property {Array<Id>} added - Node ids selected since the previous change
    * @property {Array<Id>} removed - Node ids deselected since the previous change
    * @slot {{ node: Node & { expanded: boolean; leaf: boolean; selected: boolean; } }}
+   * @slot {{ node: Node & { expanded: boolean; leaf: boolean; selected: boolean; } }} childNodes
    * @event select
    * @type {Node & { expanded: boolean; leaf: boolean; selected: boolean }}
    * @event toggle
@@ -1045,5 +1047,8 @@
 >
   <TreeViewNodeList root {nodes} let:node>
     <slot {node}> {node.text} </slot>
+    <svelte:fragment slot="childNodes" let:node>
+      <slot name="childNodes" {node} />
+    </svelte:fragment>
   </TreeViewNodeList>
 </ul>

--- a/src/TreeView/TreeViewNodeList.svelte
+++ b/src/TreeView/TreeViewNodeList.svelte
@@ -3,6 +3,7 @@
    * @generics {Id extends string | number = string | number, Icon = any} Id,Icon
    * @typedef {{ id: Id; text: string; disabled?: boolean; expanded?: boolean; }} TreeNode<Id>
    * @slot {{ node: TreeNode<Id> & { expanded: boolean; leaf: boolean; selected: boolean; } }}
+   * @slot {{ node: TreeNode<Id> & { expanded: boolean; leaf: boolean; selected: boolean; } }} childNodes
    */
 
   /** @type {ReadonlyArray<TreeNode<Id> & { nodes?: TreeNode<Id>[] }>} */
@@ -21,6 +22,9 @@
   /** `aria-setsize` — the number of siblings (including this node). */
   export let setsize = 1;
 
+  /** Whether this node has children that have not been loaded yet. */
+  export let hasChildren = false;
+
   /**
    * Specify the icon to render.
    * @type {Icon}
@@ -33,6 +37,10 @@
     computeTreeLeafDepth,
     findParentTreeNode,
   } from "./TreeViewNode.svelte";
+  // `<svelte:fragment>` (used to forward the `childNodes` slot without adding
+  // a DOM wrapper) can only target a `Component`, not `<svelte:self>` — so
+  // this recurses via a self-import instead.
+  import Self from "./TreeViewNodeList.svelte";
 
   /**
    * First focusable tree item in a subtree `ul` — handles both bare
@@ -87,6 +95,7 @@
     ...restProps,
     text, // Ensure text is included and marked as used
     disabled, // Ensure disabled is always included (has default value)
+    hasChildren, // Ensure hasChildren is always included (has default value)
     expanded,
     leaf: !parent,
     selected,
@@ -112,8 +121,8 @@
 
 {#if root}
   {#each nodes as child, index (child.id)}
-    {#if Array.isArray(child.nodes)}
-      <svelte:self
+    {#if Array.isArray(child.nodes) || child.hasChildren}
+      <Self
         {...child}
         level={1}
         posinset={index + 1}
@@ -121,7 +130,10 @@
         let:node
       >
         <slot {node} />
-      </svelte:self>
+        <svelte:fragment slot="childNodes" let:node>
+          <slot name="childNodes" {node} />
+        </svelte:fragment>
+      </Self>
     {:else}
       <TreeViewNode
         leaf
@@ -254,30 +266,37 @@
       class:bx--tree-node__children={true}
       class:bx--tree-node--hidden={!expanded}
     >
-      {#each nodes as child, index (child.id)}
-        {#if Array.isArray(child.nodes)}
-          <svelte:self
-            {...child}
-            level={level + 1}
-            posinset={index + 1}
-            setsize={nodes.length}
-            let:node
-          >
-            <slot {node} />
-          </svelte:self>
-        {:else}
-          <TreeViewNode
-            leaf
-            {...child}
-            level={level + 1}
-            posinset={index + 1}
-            setsize={nodes.length}
-            let:node
-          >
-            <slot {node}>{node.text}</slot>
-          </TreeViewNode>
-        {/if}
-      {/each}
+      {#if hasChildren && nodes.length === 0}
+        <slot name="childNodes" {node} />
+      {:else}
+        {#each nodes as child, index (child.id)}
+          {#if Array.isArray(child.nodes) || child.hasChildren}
+            <Self
+              {...child}
+              level={level + 1}
+              posinset={index + 1}
+              setsize={nodes.length}
+              let:node
+            >
+              <slot {node} />
+              <svelte:fragment slot="childNodes" let:node>
+                <slot name="childNodes" {node} />
+              </svelte:fragment>
+            </Self>
+          {:else}
+            <TreeViewNode
+              leaf
+              {...child}
+              level={level + 1}
+              posinset={index + 1}
+              setsize={nodes.length}
+              let:node
+            >
+              <slot {node}>{node.text}</slot>
+            </TreeViewNode>
+          {/if}
+        {/each}
+      {/if}
     </ul>
   </li>
 {/if}

--- a/tests/TreeView/TreeView.lazyLoad.test.svelte
+++ b/tests/TreeView/TreeView.lazyLoad.test.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+  import InlineLoading from "carbon-components-svelte/InlineLoading/InlineLoading.svelte";
+  import type { TreeNode } from "carbon-components-svelte/TreeView/TreeView.svelte";
+  import TreeView from "carbon-components-svelte/TreeView/TreeView.svelte";
+  import type { ComponentProps } from "svelte";
+
+  type LazyNode = TreeNode & { hasChildren?: boolean };
+
+  export let nodes: NonNullable<ComponentProps<TreeView>["nodes"]> = [
+    { id: "root", text: "Root", hasChildren: true },
+  ];
+
+  let resolveFetch: (() => void) | undefined;
+
+  // Simulates resolving the consumer's async fetch (e.g. after an API call).
+  export function resolveLoad() {
+    resolveFetch?.();
+  }
+
+  function handleToggle(event: CustomEvent<LazyNode>) {
+    const node = event.detail;
+    if (node.hasChildren && !node.nodes) {
+      new Promise<void>((resolve) => {
+        resolveFetch = resolve;
+      }).then(() => {
+        nodes = nodes.map((n) =>
+          n.id === node.id
+            ? { ...n, nodes: [{ id: "child", text: "Child" }] }
+            : n,
+        );
+      });
+    }
+  }
+</script>
+
+<TreeView {nodes} labelText="Lazy Load Test" on:toggle={handleToggle} let:node>
+  {node.text}
+  <svelte:fragment slot="childNodes" let:node>
+    <InlineLoading status="active" description="Loading {node.text}…" />
+  </svelte:fragment>
+</TreeView>

--- a/tests/TreeView/TreeView.lazyLoad.test.ts
+++ b/tests/TreeView/TreeView.lazyLoad.test.ts
@@ -1,0 +1,46 @@
+import { render, screen } from "@testing-library/svelte";
+import { user } from "../utils/user";
+import TreeViewLazyLoad from "./TreeView.lazyLoad.test.svelte";
+
+// The root row's `aria-owns`-referenced subtree contains the `children` slot
+// content once expanded, which pollutes accessible-name computation in jsdom
+// (no real stylesheet applies `.bx--tree-node--hidden`). Look it up by id
+// instead, matching this suite's existing convention for parent rows.
+function treeItemById(id: string): HTMLElement {
+  const el = document.getElementById(id);
+  expect.assert(el instanceof HTMLElement);
+  return el;
+}
+
+describe("TreeView lazy loading (hasChildren + children slot)", () => {
+  it("renders an expander for a hasChildren node with no nodes yet", () => {
+    render(TreeViewLazyLoad);
+
+    const root = treeItemById("root");
+    expect(root).toHaveAttribute("aria-expanded", "false");
+    expect(
+      root.querySelector(".bx--tree-parent-node__toggle"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the children slot while unresolved, then swaps in loaded children", async () => {
+    const { component } = render(TreeViewLazyLoad);
+
+    const root = treeItemById("root");
+    const toggle = root.querySelector(".bx--tree-parent-node__toggle");
+    expect.assert(toggle instanceof HTMLElement);
+
+    await user.click(toggle);
+
+    expect(root).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByText(/Loading Root/)).toBeInTheDocument();
+    expect(
+      screen.queryByRole("treeitem", { name: "Child" }),
+    ).not.toBeInTheDocument();
+
+    component.resolveLoad();
+    await screen.findByRole("treeitem", { name: "Child" });
+
+    expect(screen.queryByText(/Loading Root/)).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Set hasChildren on a node to render an expander before its nodes
are known. Expanding it fires the existing toggle event, so a
consumer can fetch and assign children asynchronously. While
hasChildren is true and nodes is empty, the new childNodes slot
renders in place of the subtree, letting consumers show a spinner,
error, or retry UI without TreeView knowing anything about loading
or error states.


https://github.com/user-attachments/assets/85c7d9a7-4421-432e-8e8f-a7f50f97632d

