### PR TITLE
feat(accordion): add single-open type

### DIFF
--- a/docs/src/pages/components/Accordion.svx
+++ b/docs/src/pages/components/Accordion.svx
@@ -95,6 +95,26 @@ accordion is first rendered.
   </AccordionItem>
 </Accordion>
 
+## Single-open
+
+Set `type` to `"single"` so that opening an item automatically closes any
+other open item. This is useful for FAQs, step-by-step wizards, or settings
+panels where only one section should be expanded at a time. The default is
+`"multiple"`, which allows any number of items to be open simultaneously.
+
+<Accordion type="single">
+  <AccordionItem open title="Natural Language Classifier">
+   <p>Natural Language Classifier uses advanced natural language processing and machine learning techniques to create custom classification models. Users train their data and the service predicts the appropriate category for the inputted text.
+   </p>
+  </AccordionItem>
+  <AccordionItem title="Natural Language Understanding">
+    <p>Analyze text to extract meta-data from content such as concepts, entities, emotion, relations, sentiment and more.</p>
+  </AccordionItem>
+  <AccordionItem title="Language Translator">
+    <p>Translate text, documents, and websites from one language to another. Create industry or region-specific translations via the service's customization capability.</p>
+  </AccordionItem>
+</Accordion>
+
 ## Programmatic example
 
 Programmatically control the accordion items with the `bind:open` directive,

--- a/src/Accordion/Accordion.svelte
+++ b/src/Accordion/Accordion.svelte
@@ -19,6 +19,13 @@
   /** Set to `true` to display the skeleton state */
   export let skeleton = false;
 
+  /**
+   * Specify the expansion behavior of the accordion.
+   * Set to `"single"` so that opening an item closes all other items.
+   * @type {"single" | "multiple"}
+   */
+  export let type = "multiple";
+
   import { setContext } from "svelte";
   import { writable } from "svelte/store";
   import AccordionSkeleton from "./AccordionSkeleton.svelte";
@@ -30,7 +37,19 @@
 
   $: disableItems.set(disabled);
 
-  setContext("carbon:Accordion", { disableItems });
+  /**
+   * Tracks the identity of the currently open item when `type` is `"single"`.
+   * @type {import("svelte/store").Writable<object | null>}
+   */
+  const openId = writable(null);
+
+  function notifyOpen(id) {
+    if (type === "single") {
+      openId.set(id);
+    }
+  }
+
+  setContext("carbon:Accordion", { disableItems, openId, notifyOpen });
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->

--- a/src/Accordion/AccordionItem.svelte
+++ b/src/Accordion/AccordionItem.svelte
@@ -42,16 +42,29 @@
   let initialDisabled = disabled;
 
   const ctx = getContext("carbon:Accordion");
-  const unsubscribe = ctx.disableItems.subscribe((value) => {
+  const unsubscribeDisableItems = ctx.disableItems.subscribe((value) => {
     if (!value && initialDisabled) return;
     disabled = value;
   });
+
+  const id = {};
+
+  const unsubscribeOpenId = ctx.openId.subscribe((openItemId) => {
+    if (openItemId !== null && openItemId !== id) {
+      open = false;
+    }
+  });
+
+  $: if (open) {
+    ctx.notifyOpen(id);
+  }
 
   let animation = undefined;
 
   onMount(() => {
     return () => {
-      unsubscribe();
+      unsubscribeDisableItems();
+      unsubscribeOpenId();
     };
   });
 </script>

--- a/tests/Accordion/Accordion.single.test.svelte
+++ b/tests/Accordion/Accordion.single.test.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+  import Accordion from "carbon-components-svelte/Accordion/Accordion.svelte";
+  import AccordionItem from "carbon-components-svelte/Accordion/AccordionItem.svelte";
+
+  const items = [
+    {
+      title: "Natural Language Classifier",
+      description:
+        "Natural Language Classifier uses advanced natural language processing and machine learning techniques to create custom classification models.",
+    },
+    {
+      title: "Natural Language Understanding",
+      description:
+        "Analyze text to extract meta-data from content such as concepts, entities, emotion, relations, sentiment and more.",
+    },
+    {
+      title: "Language Translator",
+      description:
+        "Translate text, documents, and websites from one language to another.",
+    },
+  ];
+</script>
+
+<Accordion type="single">
+  {#each items as item}
+    <AccordionItem title={item.title}>
+      <p>{item.description}</p>
+    </AccordionItem>
+  {/each}
+</Accordion>

--- a/tests/Accordion/Accordion.test.ts
+++ b/tests/Accordion/Accordion.test.ts
@@ -3,6 +3,7 @@ import { user } from "../utils/user";
 import AccordionBatchDisable from "./Accordion.batch-disable.test.svelte";
 import AccordionDisabled from "./Accordion.disabled.test.svelte";
 import AccordionProgrammatic from "./Accordion.programmatic.test.svelte";
+import AccordionSingle from "./Accordion.single.test.svelte";
 import AccordionSkeleton from "./Accordion.skeleton.test.svelte";
 import Accordion from "./Accordion.test.svelte";
 
@@ -411,5 +412,23 @@ describe("Accordion", () => {
 
     const button = screen.getByRole("button");
     expect(button).toHaveAttribute("aria-label", "Custom description");
+  });
+
+  it('closes other items when type is "single"', async () => {
+    render(AccordionSingle);
+
+    const firstItem = screen.getByText("Natural Language Classifier");
+    const lastItem = screen.getByText("Language Translator");
+
+    await user.click(firstItem);
+    itemIsExpanded(/Natural Language Classifier/);
+
+    await user.click(lastItem);
+    itemIsExpanded(/Language Translator/);
+    itemIsCollapsed(/Natural Language Classifier/);
+
+    // Clicking the open item again just collapses it.
+    await user.click(lastItem);
+    itemIsCollapsed(/Language Translator/);
   });
 });


### PR DESCRIPTION
Closes the gap from discussion #1543, where users hand-rolled
single-open behavior by looping over sibling item state. Setting
`type="single"` now coordinates open state through a context store,
so opening one item automatically collapses the rest, with
`"multiple"` (today's behavior) staying the default.

---


https://github.com/user-attachments/assets/e5a2e7fa-b807-4e5c-9848-6b06f1eae0f2

