### PR TITLE
feat(overflow-menu): add `maxHeight` for scrollable menus

### DIFF
--- a/css/_overflow-menu.scss
+++ b/css/_overflow-menu.scss
@@ -91,3 +91,30 @@
 @include exports('overflow-menu-xs') {
   @include overflow-menu-xs;
 }
+
+/// Scrollable overflow menu, paired with the inline `max-height` the
+/// `maxHeight` prop sets on the options list.
+/// @access private
+/// @group components
+@mixin overflow-menu-scrollable {
+  .#{$prefix}--overflow-menu-options--scrollable {
+    overflow-y: auto;
+
+    // Open menus are `display: flex; flex-direction: column`. Without this,
+    // items shrink to fit `max-height` instead of overflowing into a scroll.
+    .#{$prefix}--overflow-menu-options__option {
+      flex-shrink: 0;
+    }
+
+    // The ::after caret sits outside the list box and bridges the hover gap
+    // between trigger and menu. `overflow-y` clips it, and this menu opens on
+    // click, so the bridge is not needed here.
+    &::after {
+      display: none;
+    }
+  }
+}
+
+@include exports('overflow-menu-scrollable') {
+  @include overflow-menu-scrollable;
+}

--- a/docs/src/pages/components/OverflowMenu.svx
+++ b/docs/src/pages/components/OverflowMenu.svx
@@ -98,6 +98,12 @@ Set `size` to `"xs"` for an extra-small overflow menu.
   <OverflowMenuItem danger text="Delete service" />
 </OverflowMenu>
 
+## Scrollable
+
+Set `maxHeight` to cap the menu height and scroll the remaining items. A number is treated as pixels; a string is used as any CSS length, such as `"20rem"`. Keyboard navigation scrolls the focused item into view.
+
+<FileSource src="/framed/OverflowMenu/OverflowMenuScrollable" />
+
 ## Custom primary focus
 
 Set `primaryFocus` to `true` on a menu item to focus it when opening the dropdown.

--- a/docs/src/pages/framed/OverflowMenu/OverflowMenuScrollable.svelte
+++ b/docs/src/pages/framed/OverflowMenu/OverflowMenuScrollable.svelte
@@ -1,0 +1,15 @@
+<script>
+  import { OverflowMenu, OverflowMenuItem } from "carbon-components-svelte";
+
+  const workspaces = Array.from(
+    { length: 20 },
+    (_, index) => `Workspace ${index + 1}`,
+  );
+</script>
+
+<OverflowMenu maxHeight={240}>
+  {#each workspaces as workspace (workspace)}
+    <OverflowMenuItem text={workspace} />
+  {/each}
+  <OverflowMenuItem hasDivider danger text="Delete service" />
+</OverflowMenu>

--- a/src/OverflowMenu/OverflowMenu.svelte
+++ b/src/OverflowMenu/OverflowMenu.svelte
@@ -39,6 +39,14 @@
   export let flipped = false;
 
   /**
+   * Specify the maximum height of the menu.
+   * A number is treated as pixels; a string is used as a CSS length.
+   * The menu scrolls once its items exceed the height.
+   * @type {number | string}
+   */
+  export let maxHeight = undefined;
+
+  /**
    * Specify the menu options class.
    * @type {string}
    */
@@ -251,6 +259,8 @@
   // performance. The previous approach created individual `style` tags per
   // instance, causing overhead when many OverflowMenu components are rendered.
   $: overflowMenuOptionsAfterWidth = buttonWidth ? `${buttonWidth}px` : "2rem";
+  $: maxHeightStyle =
+    typeof maxHeight === "number" ? `${maxHeight}px` : maxHeight;
 
   function handleOutsideClick(event) {
     if (menuRef && isOutsideClick(event, [buttonRef, menuRef])) {
@@ -357,9 +367,11 @@
     class:bx--overflow-menu-options--xs={size === "xs"}
     class:bx--overflow-menu-options--sm={size === "sm"}
     class:bx--overflow-menu-options--xl={size === "xl"}
+    class:bx--overflow-menu-options--scrollable={!!maxHeight}
     class:bx--breadcrumb-menu-options={!!ctxBreadcrumbItem}
     class={menuOptionsClass}
     style="--overflow-menu-options-after-width: {overflowMenuOptionsAfterWidth}"
+    style:max-height={maxHeightStyle}
     on:keydown={(e) => {
       if (["ArrowDown", "ArrowLeft", "ArrowRight", "ArrowUp"].includes(e.key)) {
         e.preventDefault();
@@ -404,9 +416,11 @@
       class:bx--overflow-menu-options--xs={size === "xs"}
       class:bx--overflow-menu-options--sm={size === "sm"}
       class:bx--overflow-menu-options--xl={size === "xl"}
+      class:bx--overflow-menu-options--scrollable={!!maxHeight}
       class:bx--breadcrumb-menu-options={!!ctxBreadcrumbItem}
       class={menuOptionsClass}
       style="position: relative; top: auto; left: auto; --overflow-menu-options-after-width: {overflowMenuOptionsAfterWidth}"
+      style:max-height={maxHeightStyle}
       on:keydown={(event) => {
         if (["ArrowDown", "ArrowLeft", "ArrowRight", "ArrowUp"].includes(event.key)) {
           event.preventDefault();

--- a/src/OverflowMenu/OverflowMenuItem.svelte
+++ b/src/OverflowMenu/OverflowMenuItem.svelte
@@ -94,6 +94,7 @@
     getContext,
     onMount,
   } from "svelte";
+  import { scrollIntoViewWithinMenu } from "../utils/scrollIntoViewWithinMenu.js";
 
   const dispatch = createEventDispatcher();
   const { focusedId, add, remove, update, itemsById } = getContext(
@@ -110,7 +111,10 @@
 
   afterUpdate(() => {
     if (ref && focused) {
+      // `preventScroll` keeps a portaled menu from scrolling the document;
+      // scroll the item into view within the menu's own scroll container.
       ref.focus({ preventScroll: true });
+      scrollIntoViewWithinMenu(ref, '[role="menu"]');
     }
   });
 

--- a/src/utils/scrollIntoViewWithinMenu.d.ts
+++ b/src/utils/scrollIntoViewWithinMenu.d.ts
@@ -9,7 +9,11 @@
  * not scrollable.
  */
 /**
- * Scroll `el` into view within its nearest `role="listbox"` scroll container
- * using `block: "nearest"` semantics. Never scrolls the document.
+ * Scroll `el` into view within its nearest scroll container matching
+ * `containerSelector` using `block: "nearest"` semantics. Never scrolls the
+ * document.
  */
-export function scrollIntoViewWithinMenu(el: HTMLElement): void;
+export function scrollIntoViewWithinMenu(
+  el: HTMLElement,
+  containerSelector?: string,
+): void;

--- a/src/utils/scrollIntoViewWithinMenu.js
+++ b/src/utils/scrollIntoViewWithinMenu.js
@@ -9,14 +9,19 @@
 // not scrollable.
 
 /**
- * Scroll `el` into view within its nearest `role="listbox"` scroll container
- * using `block: "nearest"` semantics. Never scrolls the document.
+ * Scroll `el` into view within its nearest scroll container matching
+ * `containerSelector` using `block: "nearest"` semantics. Never scrolls the
+ * document.
  *
  * @param {HTMLElement} el
+ * @param {string} [containerSelector] defaults to `[role="listbox"]`
  * @returns {void}
  */
-export function scrollIntoViewWithinMenu(el) {
-  const container = el.closest('[role="listbox"]');
+export function scrollIntoViewWithinMenu(
+  el,
+  containerSelector = '[role="listbox"]',
+) {
+  const container = el.closest(containerSelector);
   if (!(container instanceof HTMLElement)) return;
   if (container.scrollHeight <= container.clientHeight) return;
 

--- a/tests/OverflowMenu/OverflowMenu.maxHeight.test.svelte
+++ b/tests/OverflowMenu/OverflowMenu.maxHeight.test.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  import OverflowMenu from "carbon-components-svelte/OverflowMenu/OverflowMenu.svelte";
+  import OverflowMenuItem from "carbon-components-svelte/OverflowMenu/OverflowMenuItem.svelte";
+  import type { ComponentProps } from "svelte";
+
+  export let maxHeight: ComponentProps<OverflowMenu>["maxHeight"] = undefined;
+  export let portalMenu: ComponentProps<OverflowMenu>["portalMenu"] = false;
+</script>
+
+<OverflowMenu {maxHeight} {portalMenu}>
+  <OverflowMenuItem text="Manage credentials" />
+  <OverflowMenuItem
+    href="https://cloud.ibm.com/docs/api-gateway/"
+    target="_blank"
+    text="API documentation"
+  />
+  <OverflowMenuItem danger text="Delete service" />
+</OverflowMenu>

--- a/tests/OverflowMenu/OverflowMenu.test.ts
+++ b/tests/OverflowMenu/OverflowMenu.test.ts
@@ -7,6 +7,7 @@ import OverflowMenuAllDisabled from "./OverflowMenu.allDisabled.test.svelte";
 import OverflowMenuDisabled from "./OverflowMenu.disabled.test.svelte";
 import OverflowMenuDisabledLink from "./OverflowMenu.disabledLink.test.svelte";
 import OverflowMenuDynamicItems from "./OverflowMenu.dynamicItems.test.svelte";
+import OverflowMenuMaxHeight from "./OverflowMenu.maxHeight.test.svelte";
 import OverflowMenuPreventDefault from "./OverflowMenu.preventDefault.test.svelte";
 import OverflowMenuRel from "./OverflowMenu.rel.test.svelte";
 import OverflowMenu from "./OverflowMenu.test.svelte";
@@ -880,6 +881,70 @@ describe("OverflowMenu", () => {
       expect(
         noIcons.querySelector(".bx--overflow-menu-options__option-icon"),
       ).toBeNull();
+    });
+  });
+
+  describe("maxHeight", () => {
+    afterEach(() => {
+      const existingPortals = document.querySelectorAll(
+        "[data-floating-portal]",
+      );
+      for (const portal of existingPortals) {
+        portal.remove();
+      }
+    });
+
+    it("caps the menu height in pixels when given a number", async () => {
+      render(OverflowMenuMaxHeight, { props: { maxHeight: 240 } });
+
+      await user.click(screen.getByRole("button"));
+
+      const menu = screen.getByRole("menu");
+      expect(menu).toHaveClass("bx--overflow-menu-options--scrollable");
+      expect(menu).toHaveStyle("max-height: 240px");
+    });
+
+    it("passes a string maxHeight through verbatim", async () => {
+      render(OverflowMenuMaxHeight, { props: { maxHeight: "20rem" } });
+
+      await user.click(screen.getByRole("button"));
+
+      const menu = screen.getByRole("menu");
+      expect(menu).toHaveClass("bx--overflow-menu-options--scrollable");
+      expect(menu.style.maxHeight).toBe("20rem");
+    });
+
+    it("renders neither the class nor the style when maxHeight is unset", async () => {
+      render(OverflowMenuMaxHeight);
+
+      await user.click(screen.getByRole("button"));
+
+      const menu = screen.getByRole("menu");
+      expect(menu).not.toHaveClass("bx--overflow-menu-options--scrollable");
+      expect(menu.style.maxHeight).toBe("");
+    });
+
+    it("caps the height of a portalled menu", async () => {
+      render(OverflowMenuMaxHeight, {
+        props: { maxHeight: 240, portalMenu: true },
+      });
+
+      await user.click(screen.getByRole("button"));
+
+      const menu = screen.getByRole("menu");
+      expect(menu.closest("[data-floating-portal]")).toBeInTheDocument();
+      expect(menu).toHaveClass("bx--overflow-menu-options--scrollable");
+      expect(menu).toHaveStyle("max-height: 240px");
+    });
+
+    it("leaves a portalled menu unscrollable when maxHeight is unset", async () => {
+      render(OverflowMenuMaxHeight, { props: { portalMenu: true } });
+
+      await user.click(screen.getByRole("button"));
+
+      const menu = screen.getByRole("menu");
+      expect(menu).not.toHaveClass("bx--overflow-menu-options--scrollable");
+      expect(menu.style.maxHeight).toBe("");
     });
   });
 

--- a/tests/utils/scrollIntoViewWithinMenu.test.ts
+++ b/tests/utils/scrollIntoViewWithinMenu.test.ts
@@ -1,9 +1,8 @@
 import { scrollIntoViewWithinMenu } from "../../src/utils/scrollIntoViewWithinMenu.js";
 
 /**
- * Build a `role="listbox"` container with a single item, stubbing the layout
- * jsdom does not compute: the container's scrollability and both elements'
- * bounding rects.
+ * Build a container with a single item, stubbing the layout jsdom does not
+ * compute: the container's scrollability and both elements' bounding rects.
  */
 function buildMenu(options: {
   scrollable: boolean;
@@ -11,9 +10,10 @@ function buildMenu(options: {
   containerBottom: number;
   itemTop: number;
   itemBottom: number;
+  role?: string;
 }) {
   const container = document.createElement("div");
-  container.setAttribute("role", "listbox");
+  container.setAttribute("role", options.role ?? "listbox");
   Object.defineProperty(container, "clientHeight", { value: 100 });
   Object.defineProperty(container, "scrollHeight", {
     value: options.scrollable ? 300 : 100,
@@ -100,5 +100,66 @@ describe("scrollIntoViewWithinMenu", () => {
     scrollIntoViewWithinMenu(item);
 
     expect(container.scrollTop).toBe(50);
+  });
+
+  describe("container selector", () => {
+    test("resolves a listbox container by default", () => {
+      const { container, item } = buildMenu({
+        scrollable: true,
+        containerTop: 0,
+        containerBottom: 100,
+        itemTop: 110,
+        itemBottom: 130,
+      });
+
+      scrollIntoViewWithinMenu(item);
+
+      expect(container.scrollTop).toBe(80);
+    });
+
+    test("ignores a menu container under the default selector", () => {
+      const { container, item } = buildMenu({
+        scrollable: true,
+        containerTop: 0,
+        containerBottom: 100,
+        itemTop: 110,
+        itemBottom: 130,
+        role: "menu",
+      });
+
+      scrollIntoViewWithinMenu(item);
+
+      expect(container.scrollTop).toBe(50);
+    });
+
+    test("resolves a menu container when the selector is passed", () => {
+      const { container, item } = buildMenu({
+        scrollable: true,
+        containerTop: 0,
+        containerBottom: 100,
+        itemTop: 110,
+        itemBottom: 130,
+        role: "menu",
+      });
+
+      scrollIntoViewWithinMenu(item, '[role="menu"]');
+
+      expect(container.scrollTop).toBe(80);
+    });
+
+    test("does not scroll a non-scrollable menu container", () => {
+      const { container, item } = buildMenu({
+        scrollable: false,
+        containerTop: 0,
+        containerBottom: 100,
+        itemTop: 110,
+        itemBottom: 130,
+        role: "menu",
+      });
+
+      scrollIntoViewWithinMenu(item, '[role="menu"]');
+
+      expect(container.scrollTop).toBe(50);
+    });
   });
 });


### PR DESCRIPTION
Caps long overflow menus with an opt-in max height so leftover
items scroll inside the list instead of running off-screen.
Keyboard focus still scrolls within the menu only, including when
portalled.