### PR TITLE
feat(menu-button): add `iconOnly` trigger variant

### DIFF
--- a/css/_menu-button.scss
+++ b/css/_menu-button.scss
@@ -23,6 +23,61 @@
     padding-top: 0;
     padding-bottom: 0;
   }
+
+  /// Icon-only MenuButton uses Menu (box-shadow) with an overflow-style
+  /// trigger. OverflowMenu hides the seam with a ::after bridge on the
+  /// options list; Menu has no equivalent, so the menu shadow paints onto
+  /// the open trigger. Mirror that bridge for the attached icon-only case.
+  /// Widths match the overflow-menu trigger sizes (sm/md/xl + our xs).
+  .#{$prefix}--menu[data-carbon-menu-button-icon-only] {
+    &::after {
+      position: absolute;
+      display: block;
+      background-color: $layer;
+      content: "";
+    }
+
+    &[data-floating-menu-direction="bottom"]::after {
+      top: to-rem(-3px);
+      left: 0;
+      width: to-rem(32px);
+      height: to-rem(3px);
+    }
+
+    &[data-floating-menu-direction="top"]::after {
+      bottom: to-rem(-3px);
+      left: 0;
+      width: to-rem(32px);
+      height: to-rem(3px);
+    }
+
+    &.#{$prefix}--menu--xs[data-floating-menu-direction="bottom"]::after,
+    &.#{$prefix}--menu--xs[data-floating-menu-direction="top"]::after {
+      width: to-rem(24px);
+    }
+
+    &.#{$prefix}--menu--md[data-floating-menu-direction="bottom"]::after,
+    &.#{$prefix}--menu--md[data-floating-menu-direction="top"]::after {
+      width: to-rem(40px);
+    }
+
+    &.#{$prefix}--menu--lg[data-floating-menu-direction="bottom"]::after,
+    &.#{$prefix}--menu--lg[data-floating-menu-direction="top"]::after {
+      width: to-rem(48px);
+    }
+
+    &[data-carbon-align="end"][data-floating-menu-direction="bottom"]::after,
+    &[data-carbon-align="end"][data-floating-menu-direction="top"]::after {
+      right: 0;
+      left: auto;
+    }
+
+    &[data-carbon-align="center"][data-floating-menu-direction="bottom"]::after,
+    &[data-carbon-align="center"][data-floating-menu-direction="top"]::after {
+      left: 50%;
+      transform: translateX(-50%);
+    }
+  }
 }
 
 @include exports("menu-button") {

--- a/docs/src/pages/components/MenuButton.svx
+++ b/docs/src/pages/components/MenuButton.svx
@@ -79,6 +79,22 @@ Set `size` to scale the trigger button and each menu item's row height together.
   <MenuItem on:click={() => console.log("Paste")}>Paste</MenuItem>
 </MenuButton>
 
+## Icon-only
+
+Set `iconOnly` for an icon-only trigger. `labelText` is no longer rendered, but it remains the trigger's accessible name. Pass `icon` to swap the glyph. Use this trigger for overflow menus that need submenus, which [OverflowMenu](/components/OverflowMenu) does not support.
+
+<MenuButton iconOnly labelText="Row actions">
+  <MenuItem on:click={() => console.log("Rename")}>Rename</MenuItem>
+  <MenuItem labelText="Export as">
+    <MenuItem on:click={() => console.log("PDF")}>PDF</MenuItem>
+    <MenuItem on:click={() => console.log("CSV")}>CSV</MenuItem>
+  </MenuItem>
+  <MenuDivider />
+  <MenuItem icon={TrashCan} kind="danger" on:click={() => console.log("Delete")}>
+    Delete
+  </MenuItem>
+</MenuButton>
+
 ## Direction
 
 Set `direction` to `"top"` or `"bottom"` (default) for which side of the trigger the menu opens on. The menu flips to the opposite side when there isn't room on the preferred side. See [Menu placement](/components/Menu#placement) for gap and offset props.

--- a/docs/src/pages/components/OverflowMenu.svx
+++ b/docs/src/pages/components/OverflowMenu.svx
@@ -14,7 +14,7 @@ description: Overflow menus present a list of actions in a compact dropdown, ide
 
 ## Basic
 
-Create a basic overflow menu by wrapping overflow menu item components within the overflow menu.
+Create a basic overflow menu by wrapping overflow menu item components within the overflow menu. For menus that need submenus, use [MenuButton](/components/MenuButton#icon-only) instead.
 
 <OverflowMenu>
   <OverflowMenuItem text="Manage credentials" />

--- a/src/MenuButton/MenuButton.svelte
+++ b/src/MenuButton/MenuButton.svelte
@@ -1,5 +1,9 @@
 <script>
   /**
+   * @template [Icon=any]
+   */
+
+  /**
    * @event {MouseEvent} click
    * @event {MouseEvent} mousedown
    * @event {FocusEvent} focus
@@ -16,12 +20,32 @@
    * Required. Specify the trigger button text.
    * Alternatively, use the "labelChildren" slot for custom trigger content;
    * `labelText` is still used as the accessible name in that case.
+   * When `iconOnly` is `true`, the text is not rendered but remains the
+   * trigger's accessible name.
    * @type {string}
    */
   export let labelText;
 
+  /** Set to `true` to render an icon-only trigger */
+  export let iconOnly = false;
+
+  /**
+   * Specify the icon to render in the icon-only trigger.
+   * @type {Icon}
+   */
+  export let icon = /** @type {Icon} */ (OverflowMenuVertical);
+
+  /**
+   * Specify the ARIA label and title for the icon-only trigger's icon.
+   * Defaults to `labelText`.
+   * @type {string}
+   */
+  export let iconDescription = undefined;
+
   /**
    * Specify the kind of button.
+   * Does not apply when `iconOnly` is `true`; the icon-only trigger is
+   * always ghost.
    * @type {"primary" | "tertiary" | "ghost"}
    */
   export let kind = "primary";
@@ -63,6 +87,7 @@
 
   import Button from "../Button/Button.svelte";
   import ChevronDown from "../icons/ChevronDown.svelte";
+  import OverflowMenuVertical from "../icons/OverflowMenuVertical.svelte";
   import Menu from "../Menu/Menu.svelte";
 
   /**
@@ -79,12 +104,27 @@
     lg: "default",
   };
 
+  /**
+   * The overflow menu scale is offset from MenuButton's: its unclassed
+   * default is 40px ("md" here) and its largest, "xl", is 48px ("lg" here).
+   */
+  const ICON_TRIGGER_SIZE_CLASSES = {
+    xs: "bx--overflow-menu--xs",
+    sm: "bx--overflow-menu--sm",
+    md: "",
+    lg: "bx--overflow-menu--xl",
+  };
+
   $: triggerClass = [
     "bx--menu-button__trigger",
     size === "xs" && "bx--menu-button__trigger--xs",
     open && "bx--menu-button__trigger--open",
     $$restProps.class,
   ]
+    .filter(Boolean)
+    .join(" ");
+
+  $: iconTriggerClass = [ICON_TRIGGER_SIZE_CLASSES[size], $$restProps.class]
     .filter(Boolean)
     .join(" ");
 
@@ -104,29 +144,61 @@
   }
 </script>
 
-<Button
-  bind:ref
-  {kind}
-  size={TRIGGER_BUTTON_SIZES[size]}
-  {disabled}
-  icon={ChevronDown}
-  {...$$restProps}
-  class={triggerClass}
-  aria-haspopup="menu"
-  aria-expanded={open}
-  aria-label={$$restProps["aria-label"] ?? labelText}
-  on:mousedown={(event) => event.preventDefault()}
-  on:mousedown
-  on:click
-  on:click={toggle}
-  on:focus
-  on:blur
-  on:mouseover
-  on:mouseenter
-  on:mouseleave
->
-  <slot name="labelChildren">{labelText}</slot>
-</Button>
+{#if iconOnly}
+  <button
+    bind:this={ref}
+    type="button"
+    {disabled}
+    class:bx--overflow-menu={true}
+    class:bx--overflow-menu--open={open}
+    class:bx--menu-button__trigger={true}
+    {...$$restProps}
+    class={iconTriggerClass}
+    aria-haspopup="menu"
+    aria-expanded={open}
+    aria-label={$$restProps["aria-label"] ?? labelText}
+    on:mousedown|preventDefault
+    on:mousedown
+    on:click
+    on:click={toggle}
+    on:focus
+    on:blur
+    on:mouseover
+    on:mouseenter
+    on:mouseleave
+  >
+    <svelte:component
+      this={icon}
+      aria-label={iconDescription ?? labelText}
+      title={iconDescription ?? labelText}
+      class="bx--overflow-menu__icon"
+    />
+  </button>
+{:else}
+  <Button
+    bind:ref
+    {kind}
+    size={TRIGGER_BUTTON_SIZES[size]}
+    {disabled}
+    icon={ChevronDown}
+    {...$$restProps}
+    class={triggerClass}
+    aria-haspopup="menu"
+    aria-expanded={open}
+    aria-label={$$restProps["aria-label"] ?? labelText}
+    on:mousedown={(event) => event.preventDefault()}
+    on:mousedown
+    on:click
+    on:click={toggle}
+    on:focus
+    on:blur
+    on:mouseover
+    on:mouseenter
+    on:mouseleave
+  >
+    <slot name="labelChildren">{labelText}</slot>
+  </Button>
+{/if}
 
 <Menu
   anchor={ref}
@@ -136,6 +208,8 @@
   intrinsicWidth
   bind:open
   {labelText}
+  data-carbon-menu-button-icon-only={iconOnly ? true : undefined}
+  data-carbon-align={iconOnly ? intrinsicAlign : undefined}
   on:close
 >
   <slot />

--- a/tests/MenuButton/MenuButton.iconOnly.test.svelte
+++ b/tests/MenuButton/MenuButton.iconOnly.test.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  import MenuItem from "carbon-components-svelte/Menu/MenuItem.svelte";
+  import MenuButton from "carbon-components-svelte/MenuButton/MenuButton.svelte";
+  import type { ComponentProps } from "svelte";
+
+  export let size: ComponentProps<MenuButton>["size"] = "md";
+  export let disabled = false;
+
+  const items = ["Cut", "Copy", "Paste"];
+</script>
+
+<MenuButton iconOnly labelText="Row actions" {size} {disabled}>
+  {#each items as text}
+    <MenuItem on:click={() => console.log("select", text)}>{text}</MenuItem>
+  {/each}
+</MenuButton>

--- a/tests/MenuButton/MenuButton.test.ts
+++ b/tests/MenuButton/MenuButton.test.ts
@@ -1,5 +1,6 @@
 import { fireEvent, render, screen } from "@testing-library/svelte";
 import { user } from "../utils/user";
+import MenuButtonIconOnly from "./MenuButton.iconOnly.test.svelte";
 import MenuButtonSlot from "./MenuButton.slot.test.svelte";
 import MenuButtonFixture from "./MenuButton.test.svelte";
 
@@ -182,5 +183,52 @@ describe("MenuButton", () => {
     trigger.focus();
     await fireEvent.click(trigger, { detail: 0 });
     expect(trigger).toHaveFocus();
+  });
+
+  describe("icon-only", () => {
+    it("names the trigger from labelText without rendering it as label content", () => {
+      render(MenuButtonIconOnly);
+
+      expect(
+        screen.getByRole("button", { name: "Row actions" }),
+      ).toBeInTheDocument();
+      // The icon's <title> carries the same text; it is not visible content.
+      expect(
+        screen.queryByText("Row actions", { ignore: "title" }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("attaches the menu with the overflow-menu shadow bridge", async () => {
+      render(MenuButtonIconOnly);
+
+      await user.click(screen.getByRole("button", { name: "Row actions" }));
+
+      const menu = screen.getByRole("menu");
+      expect(menu).toHaveAttribute("data-carbon-menu-button-icon-only");
+      expect(menu).toHaveAttribute("data-carbon-align", "start");
+    });
+
+    it.each([
+      { size: "sm", sizeClass: "bx--overflow-menu--sm" },
+      { size: "lg", sizeClass: "bx--overflow-menu--xl" },
+    ] as const)(
+      "renders the overflow menu trigger with the $size size class",
+      ({ size, sizeClass }) => {
+        render(MenuButtonIconOnly, { props: { size } });
+
+        const trigger = screen.getByRole("button", { name: "Row actions" });
+
+        expect(trigger).toHaveClass("bx--overflow-menu");
+        expect(trigger).toHaveClass(sizeClass);
+      },
+    );
+
+    it("renders the disabled state on the trigger", () => {
+      render(MenuButtonIconOnly, { props: { disabled: true } });
+
+      expect(
+        screen.getByRole("button", { name: "Row actions" }),
+      ).toBeDisabled();
+    });
   });
 });


### PR DESCRIPTION
Adds a kebab-style icon-only trigger so MenuButton can host nested
menus from overflow contexts. labelText stays required as the
accessible name; kind does not apply in this mode.