### PR TITLE
feat(accordion-item): add `extra` slot for header content

### DIFF
--- a/css/_accordion-extra.scss
+++ b/css/_accordion-extra.scss
@@ -1,0 +1,30 @@
+@import "carbon-components/scss/globals/scss/vars";
+@import "carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/import-once/import-once";
+
+/// Header row for AccordionItem's "extra" slot, which renders secondary
+/// content as a sibling of the heading button instead of inside it.
+/// @access private
+/// @group components
+@mixin accordion-extra {
+  .#{$prefix}--accordion__heading-row {
+    display: flex;
+    align-items: flex-start;
+  }
+
+  .#{$prefix}--accordion__heading-row .#{$prefix}--accordion__heading {
+    flex: 1 1 auto;
+    min-width: 0;
+  }
+
+  .#{$prefix}--accordion__extra {
+    display: flex;
+    flex-shrink: 0;
+    align-items: center;
+    align-self: stretch;
+    padding-left: $carbon--spacing-03;
+  }
+}
+
+@include exports("accordion-extra") {
+  @include accordion-extra;
+}

--- a/css/all.scss
+++ b/css/all.scss
@@ -149,3 +149,4 @@ $css--plex: true;
 @import "./user-avatar-group";
 @import "./disclosure";
 @import "./accordion-flush";
+@import "./accordion-extra";

--- a/css/g10.scss
+++ b/css/g10.scss
@@ -109,3 +109,4 @@ $css--plex: true;
 @import "./user-avatar-group";
 @import "./disclosure";
 @import "./accordion-flush";
+@import "./accordion-extra";

--- a/css/g100.scss
+++ b/css/g100.scss
@@ -109,3 +109,4 @@ $css--plex: true;
 @import "./user-avatar-group";
 @import "./disclosure";
 @import "./accordion-flush";
+@import "./accordion-extra";

--- a/css/g80.scss
+++ b/css/g80.scss
@@ -109,3 +109,4 @@ $css--plex: true;
 @import "./user-avatar-group";
 @import "./disclosure";
 @import "./accordion-flush";
+@import "./accordion-extra";

--- a/css/g90.scss
+++ b/css/g90.scss
@@ -109,3 +109,4 @@ $css--plex: true;
 @import "./user-avatar-group";
 @import "./disclosure";
 @import "./accordion-flush";
+@import "./accordion-extra";

--- a/css/white.scss
+++ b/css/white.scss
@@ -109,3 +109,4 @@ $css--plex: true;
 @import "./user-avatar-group";
 @import "./disclosure";
 @import "./accordion-flush";
+@import "./accordion-extra";

--- a/docs/src/pages/components/Accordion.svx
+++ b/docs/src/pages/components/Accordion.svx
@@ -96,6 +96,14 @@ more complex layouts with multiple elements.
   </AccordionItem>
 </Accordion>
 
+## Header actions
+
+Render secondary header content, such as a status tag or an action menu, with
+the `extra` slot. The content sits beside the heading button instead of inside
+it, which keeps buttons and menus valid HTML and reachable by keyboard.
+
+<FileSource src="/framed/Accordion/AccordionHeaderActions" />
+
 ## First item open
 
 Set `open` on an item to have it expanded by default when the

--- a/docs/src/pages/framed/Accordion/AccordionHeaderActions.svelte
+++ b/docs/src/pages/framed/Accordion/AccordionHeaderActions.svelte
@@ -1,0 +1,53 @@
+<script>
+  import {
+    Accordion,
+    AccordionItem,
+    OverflowMenu,
+    OverflowMenuItem,
+    Tag,
+  } from "carbon-components-svelte";
+
+  let lastAction = "None";
+</script>
+
+<p>Last action: {lastAction}</p>
+
+<Accordion>
+  <AccordionItem title="Natural Language Classifier">
+    <Tag slot="extra" type="red">3 errors</Tag>
+    <p>
+      Natural Language Classifier uses advanced natural language processing and
+      machine learning techniques to create custom classification models. Users
+      train their data and the service predicts the appropriate category for the
+      inputted text.
+    </p>
+  </AccordionItem>
+  <AccordionItem title="Natural Language Understanding">
+    <OverflowMenu slot="extra" flipped>
+      <OverflowMenuItem
+        text="Restart service"
+        on:click={() => {
+          lastAction = "Restart Natural Language Understanding";
+        }}
+      />
+      <OverflowMenuItem
+        danger
+        text="Delete service"
+        on:click={() => {
+          lastAction = "Delete Natural Language Understanding";
+        }}
+      />
+    </OverflowMenu>
+    <p>
+      Analyze text to extract meta-data from content such as concepts, entities,
+      emotion, relations, sentiment and more.
+    </p>
+  </AccordionItem>
+  <AccordionItem title="Language Translator">
+    <p>
+      Translate text, documents, and websites from one language to another.
+      Create industry or region-specific translations via the service's
+      customization capability.
+    </p>
+  </AccordionItem>
+</Accordion>

--- a/src/Accordion/AccordionItem.svelte
+++ b/src/Accordion/AccordionItem.svelte
@@ -1,5 +1,9 @@
 <script>
   /**
+   * @slot {{}} extra
+   */
+
+  /**
    * Specify the title of the accordion item heading.
    * Alternatively, use the "title" slot.
    * @example
@@ -77,6 +81,8 @@
       unsubscribeOpenId();
     };
   });
+
+  $: hasExtra = $$slots.extra;
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
@@ -92,34 +98,44 @@
     animation = undefined;
   }}
 >
-  <button
-    bind:this={ref}
-    type="button"
-    class:bx--accordion__heading={true}
-    aria-label={ariaLabel}
-    aria-expanded={open}
-    aria-controls={contentId}
-    {disabled}
-    on:click
-    on:click={() => {
-      open = !open;
-      animation = open ? "expanding" : "collapsing";
-    }}
-    on:mouseover
-    on:mouseenter
-    on:mouseleave
-    on:keydown
-    on:keydown={(event) => {
-      if (open && event.key === "Escape") {
-        open = false;
-      }
-    }}
+  <div
+    class:bx--accordion__heading-row={hasExtra}
+    style:display={hasExtra ? undefined : "contents"}
   >
-    <ChevronRight class="bx--accordion__arrow" />
-    <div class:bx--accordion__title={true}>
-      <slot name="title">{title}</slot>
-    </div>
-  </button>
+    <button
+      bind:this={ref}
+      type="button"
+      class:bx--accordion__heading={true}
+      aria-label={ariaLabel}
+      aria-expanded={open}
+      aria-controls={contentId}
+      {disabled}
+      on:click
+      on:click={() => {
+        open = !open;
+        animation = open ? "expanding" : "collapsing";
+      }}
+      on:mouseover
+      on:mouseenter
+      on:mouseleave
+      on:keydown
+      on:keydown={(event) => {
+        if (open && event.key === "Escape") {
+          open = false;
+        }
+      }}
+    >
+      <ChevronRight class="bx--accordion__arrow" />
+      <div class:bx--accordion__title={true}>
+        <slot name="title">{title}</slot>
+      </div>
+    </button>
+    {#if hasExtra}
+      <div class:bx--accordion__extra={true}>
+        <slot name="extra" />
+      </div>
+    {/if}
+  </div>
   <div id={contentId} class:bx--accordion__content={true}>
     {#if !lazy || hasOpened}
       <slot />

--- a/tests/Accordion/Accordion.test.ts
+++ b/tests/Accordion/Accordion.test.ts
@@ -7,6 +7,7 @@ import AccordionProgrammatic from "./Accordion.programmatic.test.svelte";
 import AccordionSingle from "./Accordion.single.test.svelte";
 import AccordionSkeleton from "./Accordion.skeleton.test.svelte";
 import Accordion from "./Accordion.test.svelte";
+import AccordionItemExtra from "./AccordionItem.extra.test.svelte";
 
 describe("Accordion", () => {
   const itemIsDisabled = (name: string | RegExp) => {
@@ -506,5 +507,57 @@ describe("Accordion", () => {
     render(AccordionLazy, { props: { lazy: true, open: true } });
 
     expect(screen.getByText("Lazy panel content")).toBeInTheDocument();
+  });
+
+  describe("extra slot", () => {
+    it("renders extra content outside the heading button", () => {
+      render(AccordionItemExtra);
+
+      const heading = screen.getByRole("button", {
+        name: /Natural Language Classifier/,
+      });
+      const extra = screen.getByText("3 errors");
+
+      expect(extra).toBeInTheDocument();
+      expect(heading).not.toContainElement(extra);
+      expect(extra.closest(".bx--accordion__extra")).toBeInTheDocument();
+    });
+
+    it("does not toggle the item when extra content is clicked", async () => {
+      render(AccordionItemExtra);
+
+      itemIsCollapsed(/Natural Language Classifier/);
+
+      await user.click(screen.getByRole("button", { name: "Manage" }));
+
+      itemIsCollapsed(/Natural Language Classifier/);
+    });
+
+    it("still toggles the item from the heading button", async () => {
+      render(AccordionItemExtra);
+
+      const heading = screen.getByRole("button", {
+        name: /Natural Language Classifier/,
+      });
+
+      await user.click(heading);
+      itemIsExpanded(/Natural Language Classifier/);
+
+      await user.click(heading);
+      itemIsCollapsed(/Natural Language Classifier/);
+    });
+
+    it("does not render the header row without the slot", () => {
+      const { container } = render(AccordionItemExtra, {
+        props: { withExtra: false },
+      });
+
+      expect(
+        container.querySelector(".bx--accordion__heading-row"),
+      ).not.toBeInTheDocument();
+      expect(
+        container.querySelector(".bx--accordion__extra"),
+      ).not.toBeInTheDocument();
+    });
   });
 });

--- a/tests/Accordion/AccordionItem.extra.test.svelte
+++ b/tests/Accordion/AccordionItem.extra.test.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+  import Accordion from "carbon-components-svelte/Accordion/Accordion.svelte";
+  import AccordionItem from "carbon-components-svelte/Accordion/AccordionItem.svelte";
+
+  export let withExtra = true;
+</script>
+
+<Accordion>
+  {#if withExtra}
+    <AccordionItem title="Natural Language Classifier">
+      <svelte:fragment slot="extra">
+        <span>3 errors</span>
+        <button type="button">Manage</button>
+      </svelte:fragment>
+      <p>Natural Language Classifier</p>
+    </AccordionItem>
+  {:else}
+    <AccordionItem title="Natural Language Classifier">
+      <p>Natural Language Classifier</p>
+    </AccordionItem>
+  {/if}
+</Accordion>


### PR DESCRIPTION
Renders secondary header content as a sibling of the heading
button, so tags, menus, and actions in the header stay valid and
keyboard-reachable. Unused, the wrapper collapses with display
contents so existing consumers are unchanged.