### PR TITLE
feat(data-table): add `toCsv` utility

### DIFF
--- a/docs/src/pages/components/DataTable.svx
+++ b/docs/src/pages/components/DataTable.svx
@@ -778,6 +778,12 @@ Compose [SearchMenu](/components/SearchMenu) in the toolbar for a search typeahe
 
 <FileSource src="/framed/DataTable/DataTableSearchMenu" />
 
+## Export
+
+Serialize headers and rows to a CSV string with `toCsv`. It applies each column's `display` formatting and skips empty columns, so the export matches what the table renders. It returns a string instead of triggering a download; pass the result to [`downloadFile`](/components/Link#download-link) (or wire it into [`LinkDownload`](/components/Link#download-link)) when you want a file. Export the current view by passing the rows matching `filteredRowIds`; values a spreadsheet would read as formulas are prefixed with a single quote unless `escapeFormulas` is `false`.
+
+<FileSource src="/framed/DataTable/DataTableExport" />
+
 ## Filtering
 
 Filter rows with `shouldFilterRows`.

--- a/docs/src/pages/framed/DataTable/DataTableExport.svelte
+++ b/docs/src/pages/framed/DataTable/DataTableExport.svelte
@@ -1,0 +1,47 @@
+<script>
+  import {
+    Button,
+    DataTable,
+    downloadFile,
+    Toolbar,
+    ToolbarContent,
+    ToolbarSearch,
+    toCsv,
+  } from "carbon-components-svelte";
+
+  const headers = [
+    { key: "name", value: "Name" },
+    { key: "protocol", value: "Protocol" },
+    { key: "port", value: "Port" },
+    { key: "rule", value: "Rule" },
+  ];
+
+  const rows = Array.from({ length: 10 }).map((_, i) => ({
+    id: i,
+    name: `Load Balancer ${i + 1}`,
+    protocol: "HTTP",
+    port: 3000 + i * 10,
+    rule: i % 2 ? "Round robin" : "DNS delegation",
+  }));
+
+  let filteredRowIds = [];
+
+  function downloadCsv() {
+    const matchedIds = new Set(filteredRowIds);
+    const csv = toCsv(
+      headers,
+      rows.filter((row) => matchedIds.has(row.id)),
+    );
+
+    downloadFile(csv, "load-balancers.csv", "text/csv;charset=utf-8");
+  }
+</script>
+
+<DataTable {headers} {rows}>
+  <Toolbar>
+    <ToolbarContent>
+      <ToolbarSearch persistent shouldFilterRows bind:filteredRowIds />
+      <Button on:click={downloadCsv}>Export CSV</Button>
+    </ToolbarContent>
+  </Toolbar>
+</DataTable>

--- a/src/DataTable/data-table-utils.d.ts
+++ b/src/DataTable/data-table-utils.d.ts
@@ -60,6 +60,53 @@ export function compareValues<T = unknown>(
   customSort?: ((a: T, b: T) => number) | false | undefined,
 ): number;
 
+export type ToCsvHeader<Row> = {
+  /** Column key. Supports nested paths like `"contact.company"`. */
+  key: string;
+  /** Column label written to the header row. Falls back to `key`. */
+  value?: unknown;
+  /** Whether the column renders no data. Empty columns are skipped. */
+  empty?: boolean;
+  /** Formats the cell value, matching the rendered table. */
+  display?: (item: unknown, row: Row) => unknown;
+};
+
+export type ToCsvOptions = {
+  /**
+   * Field delimiter. Set to `"\t"` for TSV or `";"` for locales where
+   * Excel expects it.
+   * @default ","
+   */
+  delimiter?: string;
+  /**
+   * Emit the header row.
+   * @default true
+   */
+  includeHeaders?: boolean;
+  /**
+   * Prefix a field starting with `=`, `+`, `-`, `@`, tab, or carriage return
+   * with a single quote so spreadsheets do not evaluate it as a formula.
+   * @default true
+   */
+  escapeFormulas?: boolean;
+  /**
+   * Line ending. RFC 4180 specifies `"\r\n"`, which is what Excel expects.
+   * @default "\r\n"
+   */
+  newline?: string;
+};
+
+/**
+ * Serializes data table headers and rows to a CSV string.
+ * Skips empty columns, resolves nested keys, and applies `display` formatting
+ * so the export matches the rendered table.
+ */
+export function toCsv<Row extends Record<string, unknown>>(
+  headers: ReadonlyArray<ToCsvHeader<Row>>,
+  rows: ReadonlyArray<Row>,
+  options?: ToCsvOptions,
+): string;
+
 type PathDepth = [never, 0, 1, 2, ...0[]];
 
 type Join<K, P> = K extends string | number

--- a/src/DataTable/data-table-utils.js
+++ b/src/DataTable/data-table-utils.js
@@ -274,3 +274,113 @@ export function compareValues(itemA, itemB, ascending, customSort) {
   // Reverse result for descending order
   return ascending ? result : -result;
 }
+
+// Leading characters a spreadsheet interprets as the start of a formula.
+const FORMULA_PREFIX_REGEX = /^[=+\-@\t\r]/;
+
+/**
+ * Stringifies a cell value for CSV output.
+ * @param {unknown} value - The resolved cell value
+ * @returns {string} The value as a string; empty for null and undefined
+ */
+function stringifyCsvValue(value) {
+  if (value === null || value === undefined) return "";
+  if (value instanceof Date) return value.toISOString();
+  if (typeof value === "object") return JSON.stringify(value);
+  return String(value);
+}
+
+/**
+ * Quotes and escapes a single CSV field per RFC 4180.
+ * @param {string} field - The stringified field value
+ * @param {string} delimiter - The field delimiter
+ * @param {boolean} escapeFormulas - Whether to neutralize spreadsheet formulas
+ * @returns {string} The escaped field
+ */
+function escapeCsvField(field, delimiter, escapeFormulas) {
+  const value =
+    escapeFormulas && FORMULA_PREFIX_REGEX.test(field) ? `'${field}` : field;
+
+  if (
+    value.includes(delimiter) ||
+    value.includes('"') ||
+    value.includes("\r") ||
+    value.includes("\n")
+  ) {
+    return `"${value.replaceAll('"', '""')}"`;
+  }
+
+  return value;
+}
+
+/**
+ * @typedef {object} ToCsvHeader
+ * @property {string} key - Column key; supports nested paths like "contact.company"
+ * @property {unknown} [value] - Column label; falls back to the key
+ * @property {boolean} [empty] - Whether the column renders no data
+ * @property {(item: unknown, row: Record<string, unknown>) => unknown} [display] - Formats the cell value
+ */
+
+/**
+ * @typedef {object} ToCsvOptions
+ * @property {string} [delimiter] - Field delimiter. Defaults to ","
+ * @property {boolean} [includeHeaders] - Whether to emit the header row. Defaults to true
+ * @property {boolean} [escapeFormulas] - Whether to prefix fields starting with "=", "+", "-", "@", tab, or carriage return with a single quote. Defaults to true
+ * @property {string} [newline] - Line ending. Defaults to "\r\n"
+ */
+
+/**
+ * Serializes data table headers and rows to a CSV string.
+ * Skips empty columns, resolves nested keys, and applies `display` formatting
+ * so the export matches the rendered table.
+ * @template {Record<string, unknown>} Row
+ * @param {ReadonlyArray<ToCsvHeader>} headers - The data table headers
+ * @param {ReadonlyArray<Row>} rows - The rows to serialize
+ * @param {ToCsvOptions} [options] - Serialization options
+ * @returns {string} The CSV string
+ */
+export function toCsv(headers, rows, options = {}) {
+  const {
+    delimiter = ",",
+    includeHeaders = true,
+    escapeFormulas = true,
+    newline = "\r\n",
+  } = options;
+
+  const columns = headers.filter((header) => !header.empty);
+  /** @type {string[]} */
+  const lines = [];
+
+  if (includeHeaders) {
+    lines.push(
+      columns
+        .map((header) =>
+          escapeCsvField(
+            stringifyCsvValue(header.value ?? header.key),
+            delimiter,
+            escapeFormulas,
+          ),
+        )
+        .join(delimiter),
+    );
+  }
+
+  for (const row of rows) {
+    lines.push(
+      columns
+        .map((header) => {
+          const value = resolvePath(row, header.key);
+          return escapeCsvField(
+            stringifyCsvValue(
+              header.display ? header.display(value, row) : value,
+            ),
+            delimiter,
+            escapeFormulas,
+          );
+        })
+        .join(delimiter),
+    );
+  }
+
+  return lines.join(newline);
+}

--- a/src/index.js
+++ b/src/index.js
@@ -40,6 +40,7 @@ export { default as CopyInputSkeleton } from "./CopyInput/CopyInputSkeleton.svel
 export { default as FluidCopyInputSkeleton } from "./CopyInput/FluidCopyInputSkeleton.svelte";
 export { default as DataTable } from "./DataTable/DataTable.svelte";
 export { default as DataTableSkeleton } from "./DataTable/DataTableSkeleton.svelte";
+export { toCsv } from "./DataTable/data-table-utils";
 export { default as Table } from "./DataTable/Table.svelte";
 export { default as TableBody } from "./DataTable/TableBody.svelte";
 export { default as TableCell } from "./DataTable/TableCell.svelte";

--- a/tests/DataTable/data-table-utils.test.ts
+++ b/tests/DataTable/data-table-utils.test.ts
@@ -5,6 +5,7 @@ import {
   resolvePath,
   rowsEqual,
   shouldIgnoreRowClick,
+  toCsv,
 } from "../../src/DataTable/data-table-utils.js";
 
 describe("shouldIgnoreRowClick", () => {
@@ -1182,5 +1183,136 @@ describe("formatHeaderWidth", () => {
     const header = { width: null, minWidth: null };
     // null is falsy, so it won't be included
     expect(formatHeaderWidth(header)).toBeUndefined();
+  });
+});
+
+describe("toCsv", () => {
+  const headers = [
+    { key: "name", value: "Name" },
+    { key: "port", value: "Port" },
+  ];
+  const rows = [
+    { id: "a", name: "Load Balancer 1", port: 3000 },
+    { id: "b", name: "Load Balancer 2", port: 443 },
+  ];
+
+  it("serializes headers and rows with CRLF line endings", () => {
+    expect(toCsv(headers, rows)).toBe(
+      "Name,Port\r\nLoad Balancer 1,3000\r\nLoad Balancer 2,443",
+    );
+  });
+
+  it("omits the header row when includeHeaders is false", () => {
+    expect(toCsv(headers, rows, { includeHeaders: false })).toBe(
+      "Load Balancer 1,3000\r\nLoad Balancer 2,443",
+    );
+  });
+
+  it("quotes fields containing the delimiter, quotes, or newlines", () => {
+    const csv = toCsv(
+      [{ key: "name", value: "Name" }],
+      [
+        { id: "a", name: "Round robin, DNS delegation" },
+        { id: "b", name: 'Rule "primary"' },
+        { id: "c", name: "Line 1\nLine 2" },
+      ],
+    );
+
+    expect(csv).toBe(
+      [
+        "Name",
+        '"Round robin, DNS delegation"',
+        '"Rule ""primary"""',
+        '"Line 1\nLine 2"',
+      ].join("\r\n"),
+    );
+  });
+
+  it("applies display formatting instead of the raw value", () => {
+    const csv = toCsv(
+      [
+        {
+          key: "port",
+          value: "Port",
+          display: (item: unknown) => `Port ${item}`,
+        },
+      ],
+      rows,
+    );
+
+    expect(csv).toBe("Port\r\nPort 3000\r\nPort 443");
+  });
+
+  it("resolves nested dot-notation keys", () => {
+    const csv = toCsv(
+      [{ key: "contact.company", value: "Company" }],
+      [{ id: "a", contact: { company: "IBM" } }],
+    );
+
+    expect(csv).toBe("Company\r\nIBM");
+  });
+
+  it("skips empty headers", () => {
+    const csv = toCsv(
+      [
+        { key: "name", value: "Name" },
+        { key: "overflow", empty: true },
+      ],
+      rows,
+    );
+
+    expect(csv).toBe("Name\r\nLoad Balancer 1\r\nLoad Balancer 2");
+  });
+
+  it("falls back to the header key when value is absent", () => {
+    expect(toCsv([{ key: "name" }], rows)).toBe(
+      "name\r\nLoad Balancer 1\r\nLoad Balancer 2",
+    );
+  });
+
+  it("stringifies null, undefined, and Date values", () => {
+    const csv = toCsv(
+      [
+        { key: "name", value: "Name" },
+        { key: "port", value: "Port" },
+        { key: "created", value: "Created" },
+      ],
+      [
+        {
+          id: "a",
+          name: null,
+          port: undefined,
+          created: new Date("2024-01-15T10:30:00.000Z"),
+        },
+      ],
+    );
+
+    expect(csv).toBe("Name,Port,Created\r\n,,2024-01-15T10:30:00.000Z");
+  });
+
+  it("prefixes formula values unless escapeFormulas is false", () => {
+    const formulaHeaders = [{ key: "name", value: "Name" }];
+    const formulaRows = [{ id: "a", name: "=1+1" }];
+
+    expect(toCsv(formulaHeaders, formulaRows)).toBe("Name\r\n'=1+1");
+    expect(toCsv(formulaHeaders, formulaRows, { escapeFormulas: false })).toBe(
+      "Name\r\n=1+1",
+    );
+  });
+
+  it("uses a custom delimiter for both separation and quoting", () => {
+    const csv = toCsv(
+      headers,
+      [{ id: "a", name: "Round robin, DNS delegation; fallback", port: 3000 }],
+      { delimiter: ";" },
+    );
+
+    expect(csv).toBe(
+      'Name;Port\r\n"Round robin, DNS delegation; fallback";3000',
+    );
+  });
+
+  it("emits only the header row when there are no rows", () => {
+    expect(toCsv(headers, [])).toBe("Name,Port");
   });
 });


### PR DESCRIPTION
## Summary
- Add public `toCsv` util that serializes DataTable headers/rows to a CSV string (display formatting, empty-column skip, nested keys, RFC 4180 quoting, formula escaping)
- Keep download consumer-side; docs example uses `downloadFile` for the file trigger
- Document Export example that exports the current filtered view via `filteredRowIds`

