### PR TITLE
feat(data-table): support hiding columns via `columnHidden` header flag

### DIFF
--- a/docs/src/pages/components/DataTable.svx
+++ b/docs/src/pages/components/DataTable.svx
@@ -352,6 +352,52 @@ Custom column widths do not work with a [sticky header](#sticky-header).
 
 <FileSource src="/framed/DataTable/DataTableHeaderWidth" />
 
+## Column visibility
+
+Control which columns render without editing the `headers` definition.
+
+### Hidden columns
+
+Set `columnHidden` to `true` on a header to skip that column in render while keeping it in `headers`. A single canonical header list keeps column order and definitions stable across toggles. Hidden columns are excluded from toolbar search, since a match the reader cannot see is a result they cannot explain. An active sort on a hidden column still applies, because hiding is presentational.
+
+<DataTable
+  headers={[
+    { key: "name", value: "Name" },
+    { key: "protocol", value: "Protocol" },
+    { key: "port", value: "Port" },
+    { key: "rule", value: "Rule", columnHidden: true },
+  ]}
+  rows={[
+    {
+      id: "a",
+      name: "Load Balancer 3",
+      protocol: "HTTP",
+      port: 3000,
+      rule: "Round robin",
+    },
+    {
+      id: "b",
+      name: "Load Balancer 1",
+      protocol: "HTTP",
+      port: 443,
+      rule: "Round robin",
+    },
+    {
+      id: "c",
+      name: "Load Balancer 2",
+      protocol: "HTTP",
+      port: 80,
+      rule: "DNS delegation",
+    },
+  ]}
+/>
+
+### Toggling columns
+
+Flip `columnHidden` on a bound `headers` array from a `ToolbarMenu` to build a column picker.
+
+<FileSource src="/framed/DataTable/DataTableColumnVisibility" />
+
 ## Sticky header
 
 Set `stickyHeader` to fix the header in place while the body scrolls.

--- a/docs/src/pages/framed/DataTable/DataTableColumnVisibility.svelte
+++ b/docs/src/pages/framed/DataTable/DataTableColumnVisibility.svelte
@@ -1,0 +1,89 @@
+<script>
+  import {
+    DataTable,
+    Toolbar,
+    ToolbarContent,
+    ToolbarMenu,
+    ToolbarMenuItem,
+  } from "carbon-components-svelte";
+
+  let headers = [
+    { key: "name", value: "Name" },
+    { key: "protocol", value: "Protocol" },
+    { key: "port", value: "Port" },
+    { key: "rule", value: "Rule", columnHidden: true },
+  ];
+
+  const rows = [
+    {
+      id: "a",
+      name: "Load Balancer 3",
+      protocol: "HTTP",
+      port: 3000,
+      rule: "Round robin",
+    },
+    {
+      id: "b",
+      name: "Load Balancer 1",
+      protocol: "HTTP",
+      port: 443,
+      rule: "Round robin",
+    },
+    {
+      id: "c",
+      name: "Load Balancer 2",
+      protocol: "HTTP",
+      port: 80,
+      rule: "DNS delegation",
+    },
+    {
+      id: "d",
+      name: "Load Balancer 6",
+      protocol: "HTTP",
+      port: 3000,
+      rule: "Round robin",
+    },
+    {
+      id: "e",
+      name: "Load Balancer 4",
+      protocol: "HTTP",
+      port: 443,
+      rule: "Round robin",
+    },
+    {
+      id: "f",
+      name: "Load Balancer 5",
+      protocol: "HTTP",
+      port: 80,
+      rule: "DNS delegation",
+    },
+  ];
+
+  function toggleColumn(key) {
+    headers = headers.map((header) =>
+      header.key === key
+        ? { ...header, columnHidden: !header.columnHidden }
+        : header,
+    );
+  }
+</script>
+
+<DataTable
+  title="Load balancers"
+  description="Your organization's active load balancers."
+  {headers}
+  {rows}
+>
+  <Toolbar>
+    <ToolbarContent>
+      <ToolbarMenu>
+        {#each headers as header (header.key)}
+          <ToolbarMenuItem on:click={() => toggleColumn(header.key)}>
+            {header.columnHidden ? "Show" : "Hide"}
+            {header.value}
+          </ToolbarMenuItem>
+        {/each}
+      </ToolbarMenu>
+    </ToolbarContent>
+  </Toolbar>
+</DataTable>

--- a/src/DataTable/DataTable.svelte
+++ b/src/DataTable/DataTable.svelte
@@ -23,6 +23,7 @@
    * @property {false | ((a: DataTableSortValue<Row>, b: DataTableSortValue<Row>) => number)} [sort]
    * @property {boolean} [sortAlways] - Override table-level sortAlways for this column
    * @property {boolean} [columnMenu] - Whether the column menu is enabled
+   * @property {boolean} [columnHidden] - Whether the column is skipped in render while remaining in `headers`
    * @property {string} [width]
    * @property {string} [minWidth]
    * @typedef {object} DataTableNonEmptyHeader<Row=DataTableRow>
@@ -33,6 +34,7 @@
    * @property {false | ((a: DataTableSortValue<Row>, b: DataTableSortValue<Row>) => number)} [sort]
    * @property {boolean} [sortAlways] - Override table-level sortAlways for this column
    * @property {boolean} [columnMenu] - Whether the column menu is enabled
+   * @property {boolean} [columnHidden] - Whether the column is skipped in render while remaining in `headers`
    * @property {string} [width]
    * @property {string} [minWidth]
    * @typedef {DataTableNonEmptyHeader<Row> | DataTableEmptyHeader<Row>} DataTableHeader<Row=DataTableRow>
@@ -411,6 +413,10 @@
   // since there may be multiple `DataTable` instances that have overlapping row ids.
   const id = `ccs-${Math.random().toString(36)}`;
 
+  // A columnHidden header stays in `headers`, the column definition, and is
+  // skipped everywhere the rendered column set is meant.
+  $: visibleHeaders = headers.filter((header) => !header.columnHidden);
+
   // Store a copy of the original rows for filter restoration.
   let prevRows_ref = rows;
   let originalRows = [...rows];
@@ -445,7 +451,9 @@
       filteredRows = originalRows.filter((row) => customFilter(row, value));
     } else {
       // Get searchable keys from headers (non-empty headers with keys).
-      const searchableKeys = headers
+      // Hidden columns are excluded: matching on a column the user cannot
+      // see produces results they cannot explain.
+      const searchableKeys = visibleHeaders
         .filter((header) => !header.empty && header.key)
         .map((header) => header.key);
 
@@ -584,17 +592,26 @@
 
   let tableCellsByRowId = {};
   let prevRows;
-  let prevHeaders;
+  let prevVisibleHeaders;
 
   /** Build cell objects for one row. Always new objects so `display` columns re-run. */
   function computeRowCells(row) {
-    return headers.map((header, index) => ({
-      key: header.key ?? `key-${index}`,
-      value: header.key ? resolvePath(row, header.key) : undefined,
-      display: header.display,
-      empty: header.empty,
-      columnMenu: header.columnMenu,
-    }));
+    const cells = [];
+
+    // Index into `headers` rather than the visible subset so hiding a preceding
+    // column does not renumber the generated keys the `{#each}` blocks key on.
+    headers.forEach((header, index) => {
+      if (header.columnHidden) return;
+      cells.push({
+        key: header.key ?? `key-${index}`,
+        value: header.key ? resolvePath(row, header.key) : undefined,
+        display: header.display,
+        empty: header.empty,
+        columnMenu: header.columnMenu,
+      });
+    });
+
+    return cells;
   }
 
   /**
@@ -630,7 +647,9 @@
     tableCellsByRowId = next;
   }
 
-  $: if (rows !== prevRows || headers !== prevHeaders) {
+  // Compare against `visibleHeaders`, not `headers`: it is a fresh array on every
+  // `headers` invalidation, so toggling `columnHidden` in place still rebuilds the cells.
+  $: if (rows !== prevRows || visibleHeaders !== prevVisibleHeaders) {
     const next = {};
 
     for (const row of rows) {
@@ -662,7 +681,7 @@
 
     tableCellsByRowId = next;
     prevRows = rows;
-    prevHeaders = headers;
+    prevVisibleHeaders = visibleHeaders;
   }
 
   $: ascending = sortDirection === "ascending";
@@ -769,13 +788,13 @@
         })()
       : null;
 
-  $: hasCustomHeaderWidth = headers.some(
+  $: hasCustomHeaderWidth = visibleHeaders.some(
     (header) => header.width ?? header.minWidth,
   );
 
-  // Calculate total columns for spacer rows
+  // Calculate total columns for spacer rows and expanded row cells
   $: totalColumns =
-    (expandable ? 1 : 0) + (selectable ? 1 : 0) + headers.length;
+    (expandable ? 1 : 0) + (selectable ? 1 : 0) + visibleHeaders.length;
 </script>
 
 <TableContainer {useStaticWidth} {...$$restProps}>
@@ -905,7 +924,7 @@
               />
             </th>
           {/if}
-          {#each headers as header (header.key)}
+          {#each visibleHeaders as header (header.key)}
             {#if header.empty}
               {#if header.columnMenu}
                 <th
@@ -1189,11 +1208,7 @@
               >
                 {#if expandedRowIdsSet.has(row.id) &&
                 !nonExpandableRowIdsSet.has(row.id)}
-                  <TableCell
-                    colspan={selectable
-                      ? headers.length + 2
-                      : headers.length + 1}
-                  >
+                  <TableCell colspan={totalColumns}>
                     <div class:bx--child-row-inner-container={true}>
                       <slot
                         name="expandedRow"
@@ -1415,9 +1430,7 @@
                 }}
               >
                 {#if isExpanded && isExpandable}
-                  <TableCell
-                    colspan={selectable ? headers.length + 2 : headers.length + 1}
-                  >
+                  <TableCell colspan={totalColumns}>
                     <div class:bx--child-row-inner-container={true}>
                       <slot name="expandedRow" {row} rowSelected={isSelected} />
                     </div>

--- a/tests/DataTable/DataTable.test.svelte
+++ b/tests/DataTable/DataTable.test.svelte
@@ -22,6 +22,7 @@
           b: DataTableSortValue<BaseRow>,
         ) => number);
     sortAlways?: boolean;
+    columnHidden?: boolean;
   };
 
   export let headers: readonly DataTableHeader[] = [

--- a/tests/DataTable/DataTable.test.ts
+++ b/tests/DataTable/DataTable.test.ts
@@ -21,6 +21,7 @@ import DataTableCustomDescription from "./DataTableCustomDescription.test.svelte
 import DataTableCustomSlots from "./DataTableCustomSlots.test.svelte";
 import DataTableExpandIcon from "./DataTableExpandIcon.test.svelte";
 import DataTableFooter from "./DataTableFooter.test.svelte";
+import DataTableHiddenColumnSearch from "./DataTableHiddenColumnSearch.test.svelte";
 
 describe("DataTable", () => {
   beforeEach(() => {
@@ -3136,6 +3137,171 @@ describe("DataTable", () => {
       const cells = container.querySelectorAll("tfoot td");
       expect(cells).toHaveLength(footerHeaders.length);
       expect(cells[2]).toHaveTextContent(String(largeRows.length));
+    });
+  });
+
+  describe("hidden columns", () => {
+    const headersWithHiddenProtocol = [
+      { key: "name", value: "Name" },
+      { key: "protocol", value: "Protocol", columnHidden: true },
+      { key: "port", value: "Port" },
+      { key: "rule", value: "Rule" },
+    ];
+
+    const getColumnHeaderText = () =>
+      screen
+        .getAllByRole("columnheader")
+        .map((columnHeader) => columnHeader.textContent?.trim());
+
+    const getBodyRows = () =>
+      screen.getAllByRole("row").filter((row) => row.closest("tbody") !== null);
+
+    const getRowText = (row: HTMLElement) =>
+      within(row)
+        .getAllByRole("cell")
+        .map((cell) => cell.textContent?.trim());
+
+    it("renders no header or body cells for a hidden column", () => {
+      render(DataTable, {
+        props: { headers: headersWithHiddenProtocol, rows },
+      });
+
+      expect(getColumnHeaderText()).toEqual(["Name", "Port", "Rule"]);
+      expect(screen.queryByText("Protocol")).not.toBeInTheDocument();
+      expect(screen.queryByText("HTTP")).not.toBeInTheDocument();
+
+      const bodyRows = getBodyRows();
+      expect(bodyRows).toHaveLength(3);
+      bodyRows.forEach((row, index) => {
+        expect(getRowText(row)).toEqual([
+          rows[index].name,
+          String(rows[index].port),
+          rows[index].rule,
+        ]);
+      });
+    });
+
+    it("sizes the expanded row to the visible column count", async () => {
+      const { container, rerender } = render(DataTable, {
+        props: {
+          headers: headersWithHiddenProtocol,
+          rows,
+          expandable: true,
+          expandedRowIds: ["a"],
+        },
+      });
+
+      const getExpandedCell = () =>
+        container.querySelector("tr[data-child-row] td");
+
+      // 3 visible columns + the expand column.
+      expect(getExpandedCell()).toHaveAttribute("colspan", "4");
+
+      await rerender({ selectable: true });
+      await tick();
+
+      expect(getExpandedCell()).toHaveAttribute("colspan", "5");
+    });
+
+    it("excludes hidden columns from toolbar search", async () => {
+      render(DataTableHiddenColumnSearch);
+
+      const searchInput = screen.getByRole("searchbox");
+
+      await user.type(searchInput, "load balancer 1");
+      expect(getBodyRows()).toHaveLength(1);
+
+      await user.clear(searchInput);
+      await user.type(searchInput, "dns");
+      expect(getBodyRows()).toHaveLength(0);
+    });
+
+    it("sorts by a hidden column key", () => {
+      render(DataTable, {
+        props: {
+          headers: [
+            { key: "name", value: "Name" },
+            { key: "protocol", value: "Protocol" },
+            { key: "port", value: "Port", columnHidden: true },
+            { key: "rule", value: "Rule" },
+          ],
+          rows,
+          sortable: true,
+          sortKey: "port",
+          sortDirection: "ascending",
+        },
+      });
+
+      // Ports 80, 443, and 3000 belong to rows "c", "b", and "a".
+      expect(getBodyRows().map((row) => getRowText(row)[0])).toEqual([
+        "Load Balancer 2",
+        "Load Balancer 1",
+        "Load Balancer 3",
+      ]);
+    });
+
+    it("adds and removes the column when hidden is toggled", async () => {
+      const { rerender } = render(DataTable, { props: { headers, rows } });
+
+      expect(getColumnHeaderText()).toEqual([
+        "Name",
+        "Protocol",
+        "Port",
+        "Rule",
+      ]);
+
+      await rerender({ headers: headersWithHiddenProtocol });
+      await tick();
+
+      expect(getColumnHeaderText()).toEqual(["Name", "Port", "Rule"]);
+      expect(getRowText(getBodyRows()[0])).toEqual([
+        "Load Balancer 3",
+        "3000",
+        "Round robin",
+      ]);
+
+      await rerender({ headers });
+      await tick();
+
+      expect(getColumnHeaderText()).toEqual([
+        "Name",
+        "Protocol",
+        "Port",
+        "Rule",
+      ]);
+      expect(getRowText(getBodyRows()[0])).toEqual([
+        "Load Balancer 3",
+        "HTTP",
+        "3000",
+        "Round robin",
+      ]);
+    });
+
+    it("sizes virtualization spacer rows to the visible column count", () => {
+      const largeRows = Array.from({ length: 500 }, (_, i) => ({
+        id: String(i),
+        name: `Load Balancer ${i + 1}`,
+        protocol: "HTTP",
+        port: 3000 + i * 10,
+        rule: "Round robin",
+      }));
+
+      render(DataTable, {
+        props: {
+          headers: headersWithHiddenProtocol,
+          rows: largeRows,
+          virtualize: true,
+        },
+      });
+
+      // Spacer rows are the only rows with an inline height.
+      const spacerRows = getBodyRows().filter((row) =>
+        row.getAttribute("style")?.includes("height:"),
+      );
+      expect(spacerRows.length).toBeGreaterThan(0);
+      for (const row of spacerRows) {
+        expect(within(row).getByRole("cell")).toHaveAttribute("colspan", "3");
+      }
     });
   });
 });

--- a/tests/DataTable/DataTableHiddenColumnSearch.test.svelte
+++ b/tests/DataTable/DataTableHiddenColumnSearch.test.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+  import DataTable from "carbon-components-svelte/DataTable/DataTable.svelte";
+  import Toolbar from "carbon-components-svelte/DataTable/Toolbar.svelte";
+  import ToolbarContent from "carbon-components-svelte/DataTable/ToolbarContent.svelte";
+  import ToolbarSearch from "carbon-components-svelte/DataTable/ToolbarSearch.svelte";
+</script>
+
+<DataTable
+  headers={[
+    { key: "name", value: "Name" },
+    { key: "protocol", value: "Protocol" },
+    { key: "rule", value: "Rule", columnHidden: true },
+  ]}
+  rows={[
+    { id: "a", name: "Load Balancer 3", protocol: "HTTP", rule: "Round robin" },
+    {
+      id: "b",
+      name: "Load Balancer 1",
+      protocol: "HTTP",
+      rule: "DNS delegation",
+    },
+  ]}
+>
+  <Toolbar>
+    <ToolbarContent>
+      <ToolbarSearch shouldFilterRows />
+    </ToolbarContent>
+  </Toolbar>
+</DataTable>


### PR DESCRIPTION
Skips a column in render while keeping it in `headers`, so column
order and definitions stay stable across toggles. Hidden columns
are left out of toolbar search; an active sort on a hidden column
still applies.

```svelte
<DataTable
  headers={[
    { key: "name", value: "Name" },
    { key: "protocol", value: "Protocol" },
    { key: "port", value: "Port" },
    { key: "rule", value: "Rule", columnHidden: true },
  ]}
  {rows}
/>
```
