### PR TITLE
feat(overflow-menu): add `autoAlign` for edge-aware horizontal placement

### DIFF
--- a/docs/src/pages/components/OverflowMenu.svx
+++ b/docs/src/pages/components/OverflowMenu.svx
@@ -44,6 +44,14 @@ Set `flipped` to `true` to position the menu to the left of the button.
   <OverflowMenuItem danger text="Delete service" />
 </OverflowMenu>
 
+### Auto align
+
+Set `autoAlign` to `true` and the menu aligns itself to the trigger's other edge when the default placement would overflow the viewport. Each trigger below sits at the right edge of its row, so the menu opens inward instead of off-screen. The side is re-evaluated on scroll and resize.
+
+Auto alignment measures the menu in a portal, so `autoAlign` turns on portalling unless you set `portalMenu` to `false`. Use [Flipped](#flipped) to pin the menu to one side yourself.
+
+<FileSource src="/framed/OverflowMenu/OverflowMenuAutoAlign" />
+
 ### Direction
 
 Set `direction` to `"top"` to position the menu above the button.

--- a/docs/src/pages/framed/OverflowMenu/OverflowMenuAutoAlign.svelte
+++ b/docs/src/pages/framed/OverflowMenu/OverflowMenuAutoAlign.svelte
@@ -1,0 +1,31 @@
+<script>
+  import {
+    OverflowMenu,
+    OverflowMenuItem,
+    Stack,
+  } from "carbon-components-svelte";
+
+  const services = ["Load balancer", "Kubernetes cluster", "Object storage"];
+</script>
+
+<Stack gap={3}>
+  {#each services as service (service)}
+    <div class="row">
+      <span>{service}</span>
+      <OverflowMenu autoAlign>
+        <OverflowMenuItem text="Manage credentials" />
+        <OverflowMenuItem text="API documentation" />
+        <OverflowMenuItem danger text="Delete service" />
+      </OverflowMenu>
+    </div>
+  {/each}
+</Stack>
+
+<style>
+  .row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    border-bottom: 1px solid var(--cds-border-subtle);
+  }
+</style>

--- a/src/OverflowMenu/OverflowMenu.svelte
+++ b/src/OverflowMenu/OverflowMenu.svelte
@@ -47,6 +47,13 @@
   export let maxHeight = undefined;
 
   /**
+   * Set to `true` to align the menu to the button's other edge when the
+   * default placement would overflow the right edge of the viewport.
+   * Implies `portalMenu`; ignored when `portalMenu` is explicitly `false`.
+   */
+  export let autoAlign = false;
+
+  /**
    * Specify the menu options class.
    * @type {string}
    */
@@ -95,6 +102,7 @@
     afterUpdate,
     createEventDispatcher,
     getContext,
+    onDestroy,
     setContext,
   } from "svelte";
   import { derived, writable } from "svelte/store";
@@ -104,13 +112,16 @@
   import { dismiss } from "../utils/dismiss.js";
   import { isOutsideClick } from "../utils/isOutsideClick.js";
   import { keyBy } from "../utils/keyBy.js";
+  import { rafThrottle } from "../utils/rafThrottle.js";
   import { rovingFocus } from "../utils/rovingFocus.js";
+  import { shouldFlipHorizontally } from "../utils/shouldFlipHorizontally.js";
 
   const ctxBreadcrumbItem = getContext("carbon:BreadcrumbItem");
   const insideModal = getContext("carbon:Modal");
 
   $: effectivePortalMenu =
-    portalMenu === undefined ? !!insideModal : portalMenu;
+    portalMenu === undefined ? autoAlign || !!insideModal : portalMenu;
+  $: isAutoAligned = autoAlign && effectivePortalMenu;
 
   const dispatch = createEventDispatcher();
   /**
@@ -130,6 +141,35 @@
 
   let buttonWidth = undefined;
   let onMountAfterUpdate = true;
+  let autoFlipped = false;
+
+  $: effectiveFlipped = isAutoAligned ? autoFlipped : flipped;
+
+  /**
+   * Measure the trigger against the viewport and pick the edge the menu aligns
+   * to. Returns the side to use right now: `effectiveFlipped` only catches up
+   * on the next flush, and callers position the menu in the same pass.
+   */
+  function updateAutoAlign() {
+    if (isAutoAligned && buttonRef && menuRef) {
+      const { left, width } = buttonRef.getBoundingClientRect();
+
+      autoFlipped = shouldFlipHorizontally({
+        anchorLeft: left,
+        anchorWidth: width,
+        floatingWidth: menuRef.offsetWidth,
+        viewportWidth: window.innerWidth,
+      });
+    }
+
+    return isAutoAligned ? autoFlipped : flipped;
+  }
+
+  const scheduleAutoAlign = rafThrottle(updateAutoAlign);
+
+  onDestroy(() => {
+    scheduleAutoAlign.cancel();
+  });
 
   $: if (ctxBreadcrumbItem) {
     icon = OverflowMenuHorizontal;
@@ -217,6 +257,8 @@
         menuRef?.focus({ preventScroll: true });
       }
 
+      const isFlipped = updateAutoAlign();
+
       if (!effectivePortalMenu) {
         // Menu is a button sibling; position from offsetTop/offsetLeft.
         const { offsetTop, offsetLeft } = buttonRef;
@@ -233,7 +275,7 @@
           menuRef.style.top = `${offsetTop + height}px`;
         }
 
-        if (flipped) {
+        if (isFlipped) {
           menuRef.style.left = `${offsetLeft + width - menuWidth}px`;
         } else {
           menuRef.style.left = `${offsetLeft}px`;
@@ -243,14 +285,19 @@
           menuRef.style.top = `${offsetTop + height + 10}px`;
           menuRef.style.left = `${offsetLeft - 11}px`;
         }
-      } else if (flipped && menuRef) {
-        menuRef.style.marginLeft = `${width - menuRef.offsetWidth}px`;
+      } else if (menuRef) {
+        // Clear rather than skip: `autoAlign` can flip back mid-session.
+        menuRef.style.marginLeft = isFlipped
+          ? `${width - menuRef.offsetWidth}px`
+          : "";
       }
     }
 
     if (!open) {
       currentId.set(undefined);
       currentIndex.set(0);
+      autoFlipped = false;
+      scheduleAutoAlign.cancel();
     }
 
     onMountAfterUpdate = false;
@@ -281,6 +328,11 @@
     }
   }
 </script>
+
+<svelte:window
+  on:scroll|passive={open && isAutoAligned ? scheduleAutoAlign : undefined}
+  on:resize|passive={open && isAutoAligned ? scheduleAutoAlign : undefined}
+/>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <button
@@ -367,7 +419,7 @@
     aria-label={ariaLabel}
     data-floating-menu-direction={direction}
     class:bx--overflow-menu-options={true}
-    class:bx--overflow-menu--flip={flipped}
+    class:bx--overflow-menu--flip={effectiveFlipped}
     class:bx--overflow-menu-options--open={open}
     class:bx--overflow-menu-options--light={light}
     class:bx--overflow-menu-options--xs={size === "xs"}
@@ -416,7 +468,7 @@
       aria-label={ariaLabel}
       data-floating-menu-direction={portalDirection}
       class:bx--overflow-menu-options={true}
-      class:bx--overflow-menu--flip={flipped}
+      class:bx--overflow-menu--flip={effectiveFlipped}
       class:bx--overflow-menu-options--open={open}
       class:bx--overflow-menu-options--light={light}
       class:bx--overflow-menu-options--xs={size === "xs"}

--- a/src/utils/shouldFlipHorizontally.d.ts
+++ b/src/utils/shouldFlipHorizontally.d.ts
@@ -1,0 +1,12 @@
+export interface ShouldFlipHorizontallyOptions {
+  /** Anchor's viewport-relative left edge. */
+  anchorLeft: number;
+  anchorWidth: number;
+  floatingWidth: number;
+  viewportWidth: number;
+}
+
+/** Decide whether a menu should align to the anchor's right edge to stay inside the viewport. */
+export function shouldFlipHorizontally(
+  options: ShouldFlipHorizontallyOptions,
+): boolean;

--- a/src/utils/shouldFlipHorizontally.js
+++ b/src/utils/shouldFlipHorizontally.js
@@ -1,0 +1,29 @@
+// @ts-check
+
+/**
+ * Decide which of an anchor's edges a floating menu aligns to. The menu is
+ * left-aligned to the anchor by default and right-aligned when flipped.
+ *
+ * Flipping only pays off when the default placement runs past the right edge
+ * of the viewport and the flipped placement clears the left edge. A menu wider
+ * than the space on either side stays where it is, since flipping would only
+ * move the clipping to the other end.
+ *
+ * @param {Object} options
+ * @param {number} options.anchorLeft   Anchor's viewport-relative left edge.
+ * @param {number} options.anchorWidth
+ * @param {number} options.floatingWidth
+ * @param {number} options.viewportWidth
+ * @returns {boolean} True when the menu should align to the anchor's right edge.
+ */
+export function shouldFlipHorizontally({
+  anchorLeft,
+  anchorWidth,
+  floatingWidth,
+  viewportWidth,
+}) {
+  const overflowsRight = anchorLeft + floatingWidth > viewportWidth;
+  if (!overflowsRight) return false;
+
+  return anchorLeft + anchorWidth - floatingWidth >= 0;
+}

--- a/tests/OverflowMenu/OverflowMenu.autoAlign.test.svelte
+++ b/tests/OverflowMenu/OverflowMenu.autoAlign.test.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+  import OverflowMenu from "carbon-components-svelte/OverflowMenu/OverflowMenu.svelte";
+  import OverflowMenuItem from "carbon-components-svelte/OverflowMenu/OverflowMenuItem.svelte";
+  import type { ComponentProps } from "svelte";
+
+  export let autoAlign: ComponentProps<OverflowMenu>["autoAlign"] = true;
+  export let portalMenu: ComponentProps<OverflowMenu>["portalMenu"] = undefined;
+</script>
+
+<OverflowMenu {autoAlign} {portalMenu}>
+  <OverflowMenuItem text="Manage credentials" />
+  <OverflowMenuItem text="API documentation" />
+  <OverflowMenuItem danger text="Delete service" />
+</OverflowMenu>

--- a/tests/OverflowMenu/OverflowMenu.test.ts
+++ b/tests/OverflowMenu/OverflowMenu.test.ts
@@ -4,6 +4,7 @@ import type { ComponentProps } from "svelte";
 import { tick } from "svelte";
 import { user } from "../utils/user";
 import OverflowMenuAllDisabled from "./OverflowMenu.allDisabled.test.svelte";
+import OverflowMenuAutoAlign from "./OverflowMenu.autoAlign.test.svelte";
 import OverflowMenuDisabled from "./OverflowMenu.disabled.test.svelte";
 import OverflowMenuDisabledLink from "./OverflowMenu.disabledLink.test.svelte";
 import OverflowMenuDynamicItems from "./OverflowMenu.dynamicItems.test.svelte";
@@ -844,6 +845,148 @@ describe("OverflowMenu", () => {
         expect(portal).toHaveAttribute("data-floating-direction", "bottom");
       } finally {
         Element.prototype.getBoundingClientRect = original;
+      }
+    });
+  });
+
+  describe("autoAlign", () => {
+    const VIEWPORT_WIDTH = 1000;
+    const MENU_WIDTH = 200;
+    const TRIGGER_WIDTH = 40;
+
+    /**
+     * jsdom has no layout, so place the trigger and size the menu by hand.
+     * Returns a teardown that restores the real getters.
+     */
+    function stubLayout(triggerLeft: number) {
+      const originalRect = Element.prototype.getBoundingClientRect;
+
+      Element.prototype.getBoundingClientRect = function () {
+        if (this.classList?.contains("bx--overflow-menu")) {
+          return {
+            x: triggerLeft,
+            y: 100,
+            width: TRIGGER_WIDTH,
+            height: 32,
+            top: 100,
+            right: triggerLeft + TRIGGER_WIDTH,
+            bottom: 132,
+            left: triggerLeft,
+            toJSON() {
+              return this;
+            },
+          } as DOMRect;
+        }
+        return originalRect.call(this);
+      };
+
+      const offsetWidth = vi
+        .spyOn(HTMLElement.prototype, "offsetWidth", "get")
+        .mockImplementation(function (this: HTMLElement) {
+          return this.getAttribute("role") === "menu"
+            ? MENU_WIDTH
+            : TRIGGER_WIDTH;
+        });
+
+      Object.defineProperty(window, "innerWidth", {
+        writable: true,
+        configurable: true,
+        value: VIEWPORT_WIDTH,
+      });
+
+      return () => {
+        Element.prototype.getBoundingClientRect = originalRect;
+        offsetWidth.mockRestore();
+      };
+    }
+
+    afterEach(() => {
+      for (const portal of document.querySelectorAll(
+        "[data-floating-portal]",
+      )) {
+        portal.remove();
+      }
+    });
+
+    it("flips the menu when the trigger sits near the right edge", async () => {
+      const restore = stubLayout(VIEWPORT_WIDTH - 60);
+
+      try {
+        render(OverflowMenuAutoAlign);
+
+        await user.click(screen.getByRole("button"));
+
+        const menu = screen.getByRole("menu");
+        await waitFor(() => {
+          expect(menu).toHaveClass("bx--overflow-menu--flip");
+        });
+      } finally {
+        restore();
+      }
+    });
+
+    it("leaves the menu unflipped when there is room to the right", async () => {
+      const restore = stubLayout(100);
+
+      try {
+        render(OverflowMenuAutoAlign);
+
+        await user.click(screen.getByRole("button"));
+        await tick();
+
+        const menu = screen.getByRole("menu");
+        expect(menu).not.toHaveClass("bx--overflow-menu--flip");
+      } finally {
+        restore();
+      }
+    });
+
+    it("ignores autoAlign when portalMenu is explicitly false", async () => {
+      const restore = stubLayout(VIEWPORT_WIDTH - 60);
+
+      try {
+        render(OverflowMenuAutoAlign, { props: { portalMenu: false } });
+
+        await user.click(screen.getByRole("button"));
+        await tick();
+
+        const menu = screen.getByRole("menu");
+        expect(menu.closest("[data-floating-portal]")).not.toBeInTheDocument();
+        expect(menu).not.toHaveClass("bx--overflow-menu--flip");
+      } finally {
+        restore();
+      }
+    });
+
+    it("stops re-measuring on scroll and resize once the menu closes", async () => {
+      const restore = stubLayout(VIEWPORT_WIDTH - 60);
+      // `svelte:window` keeps its listeners attached and calls through to an
+      // `undefined` handler when closed, so assert on the scheduled work
+      // rather than on listener counts.
+      const raf = vi.spyOn(window, "requestAnimationFrame");
+
+      try {
+        render(OverflowMenuAutoAlign);
+
+        raf.mockClear();
+        window.dispatchEvent(new Event("scroll"));
+        expect(raf).not.toHaveBeenCalled();
+
+        await user.click(screen.getByRole("button"));
+
+        raf.mockClear();
+        window.dispatchEvent(new Event("scroll"));
+        expect(raf).toHaveBeenCalled();
+
+        await user.keyboard("{Escape}");
+
+        raf.mockClear();
+        window.dispatchEvent(new Event("scroll"));
+        window.dispatchEvent(new Event("resize"));
+        expect(raf).not.toHaveBeenCalled();
+      } finally {
+        raf.mockRestore();
+        restore();
       }
     });
   });

--- a/tests/utils/shouldFlipHorizontally.test.ts
+++ b/tests/utils/shouldFlipHorizontally.test.ts
@@ -1,0 +1,94 @@
+import { shouldFlipHorizontally } from "../../src/utils/shouldFlipHorizontally.js";
+
+const viewportWidth = 1000;
+
+describe("shouldFlipHorizontally", () => {
+  test("keeps the default alignment when the menu fits", () => {
+    expect(
+      shouldFlipHorizontally({
+        anchorLeft: 100,
+        anchorWidth: 40,
+        floatingWidth: 200,
+        viewportWidth,
+      }),
+    ).toBe(false);
+  });
+
+  test("flips when the menu overflows right and fits on the other side", () => {
+    expect(
+      shouldFlipHorizontally({
+        anchorLeft: 940,
+        anchorWidth: 40,
+        floatingWidth: 200,
+        viewportWidth,
+      }),
+    ).toBe(true);
+  });
+
+  test("does not flip when the menu ends exactly on the right edge", () => {
+    // anchorLeft (800) + floatingWidth (200) === viewportWidth (1000).
+    expect(
+      shouldFlipHorizontally({
+        anchorLeft: 800,
+        anchorWidth: 40,
+        floatingWidth: 200,
+        viewportWidth,
+      }),
+    ).toBe(false);
+  });
+
+  test("does not flip when the menu is wider than the viewport", () => {
+    expect(
+      shouldFlipHorizontally({
+        anchorLeft: 900,
+        anchorWidth: 40,
+        floatingWidth: 1200,
+        viewportWidth,
+      }),
+    ).toBe(false);
+  });
+
+  test("does not flip when the flipped placement would clip the left edge", () => {
+    // Overflows right (940 + 200 > 1000) but flipping lands at -160.
+    expect(
+      shouldFlipHorizontally({
+        anchorLeft: 40,
+        anchorWidth: 40,
+        floatingWidth: 1200,
+        viewportWidth,
+      }),
+    ).toBe(false);
+  });
+
+  test("does not flip an anchor at the left edge", () => {
+    expect(
+      shouldFlipHorizontally({
+        anchorLeft: 0,
+        anchorWidth: 40,
+        floatingWidth: 200,
+        viewportWidth,
+      }),
+    ).toBe(false);
+  });
+
+  test("falls back to the default alignment for zero-size inputs", () => {
+    expect(
+      shouldFlipHorizontally({
+        anchorLeft: 0,
+        anchorWidth: 0,
+        floatingWidth: 0,
+        viewportWidth: 0,
+      }),
+    ).toBe(false);
+
+    // A measured-but-unlaid-out menu (width 0) never overflows.
+    expect(
+      shouldFlipHorizontally({
+        anchorLeft: 990,
+        anchorWidth: 0,
+        floatingWidth: 0,
+        viewportWidth,
+      }),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
When a menu would overflow the right edge of the viewport and there
is room on the other side, autoAlign flips it to the trigger's
right edge. Implies a portalled menu; ignored when portalMenu is
explicitly false. Never writes back into flipped.