### PR TITLE
feat(data-table): support per-column alignment

### DIFF
--- a/css/_data-table-align.scss
+++ b/css/_data-table-align.scss
@@ -1,0 +1,55 @@
+@import "carbon-components/scss/globals/scss/vars";
+@import "carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/import-once/import-once";
+
+/// Per-column alignment for DataTable `headers[].align`.
+/// Carbon v10 has no column alignment class, so the modifier is net-new.
+/// Values are logical, so an `end` column follows the text direction.
+/// Three layouts have to agree:
+/// 1. Body cells and non-sortable headers, where `text-align` is enough.
+/// 2. Sortable headers, whose label sits in a flex `bx--table-sort` button that
+///    ignores `text-align`.
+/// 3. `stickyHeader`, where Carbon lays out every `th` and `td` as a flex
+///    container and `text-align` stops applying.
+/// @access private
+/// @group components
+@mixin data-table-align {
+  $alignments: (
+    start: flex-start,
+    end: flex-end,
+  );
+
+  @each $align, $justify in $alignments {
+    .#{$prefix}--data-table th.#{$prefix}--table-column--align-#{$align},
+    .#{$prefix}--data-table td.#{$prefix}--table-column--align-#{$align} {
+      text-align: $align;
+    }
+
+    .#{$prefix}--data-table
+      th.#{$prefix}--table-column--align-#{$align}
+      .#{$prefix}--table-sort {
+      text-align: inherit;
+    }
+
+    .#{$prefix}--data-table--sticky-header
+      th.#{$prefix}--table-column--align-#{$align},
+    .#{$prefix}--data-table--sticky-header
+      td.#{$prefix}--table-column--align-#{$align} {
+      justify-content: $justify;
+    }
+  }
+
+  // Reversing the sort button puts the icon at the padding edge, with the
+  // label pushed to the opposite edge by the base `space-between` layout,
+  // rather than wedged between the icon and the edge.
+  .#{$prefix}--data-table
+    th.#{$prefix}--table-column--align-end
+    .#{$prefix}--table-sort {
+    flex-direction: row-reverse;
+    padding-right: $spacing-05;
+    padding-left: 0;
+  }
+}
+
+@include exports("data-table-align") {
+  @include data-table-align;
+}

--- a/css/all.scss
+++ b/css/all.scss
@@ -97,6 +97,7 @@ $css--plex: true;
 @import "./data-table-highlighted-row";
 @import "./data-table-sticky-column-menu";
 @import "./data-table-footer";
+@import "./data-table-align";
 @import "./pagination";
 @import "./structured-list-input-focusable";
 @import "./multiselect";

--- a/css/g10.scss
+++ b/css/g10.scss
@@ -57,6 +57,7 @@ $css--plex: true;
 @import "./data-table-highlighted-row";
 @import "./data-table-sticky-column-menu";
 @import "./data-table-footer";
+@import "./data-table-align";
 @import "./pagination";
 @import "./structured-list-input-focusable";
 @import "./multiselect";

--- a/css/g100.scss
+++ b/css/g100.scss
@@ -57,6 +57,7 @@ $css--plex: true;
 @import "./data-table-highlighted-row";
 @import "./data-table-sticky-column-menu";
 @import "./data-table-footer";
+@import "./data-table-align";
 @import "./pagination";
 @import "./structured-list-input-focusable";
 @import "./multiselect";

--- a/css/g80.scss
+++ b/css/g80.scss
@@ -57,6 +57,7 @@ $css--plex: true;
 @import "./data-table-highlighted-row";
 @import "./data-table-sticky-column-menu";
 @import "./data-table-footer";
+@import "./data-table-align";
 @import "./pagination";
 @import "./structured-list-input-focusable";
 @import "./multiselect";

--- a/css/g90.scss
+++ b/css/g90.scss
@@ -57,6 +57,7 @@ $css--plex: true;
 @import "./data-table-highlighted-row";
 @import "./data-table-sticky-column-menu";
 @import "./data-table-footer";
+@import "./data-table-align";
 @import "./pagination";
 @import "./structured-list-input-focusable";
 @import "./multiselect";

--- a/css/white.scss
+++ b/css/white.scss
@@ -57,6 +57,7 @@ $css--plex: true;
 @import "./data-table-highlighted-row";
 @import "./data-table-sticky-column-menu";
 @import "./data-table-footer";
+@import "./data-table-align";
 @import "./pagination";
 @import "./structured-list-input-focusable";
 @import "./multiselect";

--- a/docs/src/pages/components/DataTable.svx
+++ b/docs/src/pages/components/DataTable.svx
@@ -352,6 +352,25 @@ Custom column widths do not work with a [sticky header](#sticky-header).
 
 <FileSource src="/framed/DataTable/DataTableHeaderWidth" />
 
+### Alignment
+
+Set `columnAlign` in `headers` to align a column's header and cells. Values are logical: `end` is the right edge in left-to-right text and the left edge in right-to-left text; the default, `start`, is the left edge. Sortable columns keep their sort affordance.
+
+<DataTable
+  sortable
+  headers={[
+    { key: "name", value: "Name" },
+    { key: "protocol", value: "Protocol" },
+    { key: "port", value: "Port" },
+    { key: "cost", value: "Monthly cost", columnAlign: "end", display: (cost) => "$" + cost },
+  ]}
+  rows={[
+    { id: "a", name: "Load Balancer 3", protocol: "HTTP", port: 3000, cost: 1240 },
+    { id: "b", name: "Load Balancer 1", protocol: "HTTP", port: 443, cost: 865 },
+    { id: "c", name: "Load Balancer 2", protocol: "HTTP", port: 80, cost: 310 },
+  ]}
+/>
+
 ## Column visibility
 
 Control which columns render without editing the `headers` definition.

--- a/src/DataTable/DataTable.svelte
+++ b/src/DataTable/DataTable.svelte
@@ -37,6 +37,7 @@
    * @property {boolean} [columnHidden] - Whether the column is skipped in render while remaining in `headers`
    * @property {string} [width]
    * @property {string} [minWidth]
+   * @property {"start" | "end"} [columnAlign] - Horizontal alignment of the column header and cells. Logical, so `end` is the right edge in LTR and the left edge in RTL. Defaults to `"start"`.
    * @typedef {DataTableNonEmptyHeader<Row> | DataTableEmptyHeader<Row>} DataTableHeader<Row=DataTableRow>
    * @typedef {object} DataTableCell<Row=DataTableRow>
    * @property {DataTableKey<Row> | (string & {})} key
@@ -594,6 +595,15 @@
   let prevRows;
   let prevVisibleHeaders;
 
+  const alignClasses = {
+    start: "bx--table-column--align-start",
+    end: "bx--table-column--align-end",
+  };
+
+  function formatAlignClass(columnAlign) {
+    return alignClasses[columnAlign];
+  }
+
   /** Build cell objects for one row. Always new objects so `display` columns re-run. */
   function computeRowCells(row) {
     const cells = [];
@@ -608,6 +618,7 @@
         display: header.display,
         empty: header.empty,
         columnMenu: header.columnMenu,
+        columnAlign: header.columnAlign,
       });
     });
 
@@ -666,7 +677,8 @@
             a.value === b.value &&
             a.display === b.display &&
             a.empty === b.empty &&
-            a.columnMenu === b.columnMenu
+            a.columnMenu === b.columnMenu &&
+            a.columnAlign === b.columnAlign
           ) {
             newCells[i] = a;
           } else {
@@ -940,6 +952,7 @@
             {:else}
               <TableHeader
                 id="{id}-{header.key}"
+                class={formatAlignClass(header.columnAlign)}
                 style={formatHeaderWidth(header)}
                 sortable={sortable && header.sort !== false}
                 sortDirection={sortKey === header.key ? sortDirection : "none"}
@@ -1147,7 +1160,10 @@
               {/if}
               {#each tableCellsByRowId[row.id] as cell, j (cell.key)}
                 {#if cell.empty}
-                  <td class:bx--table-column-menu={cell.columnMenu}>
+                  <td
+                    class={formatAlignClass(cell.columnAlign)}
+                    class:bx--table-column-menu={cell.columnMenu}
+                  >
                     <slot
                       name="cell"
                       {row}
@@ -1164,6 +1180,7 @@
                   </td>
                 {:else}
                   <TableCell
+                    class={formatAlignClass(cell.columnAlign)}
                     headers="{id}-{cell.key}"
                     on:click={(event) => {
                       dispatch("click", { row, cell });
@@ -1371,7 +1388,10 @@
               {/if}
               {#each tableCellsByRowId[row.id] as cell, j (cell.key)}
                 {#if cell.empty}
-                  <td class:bx--table-column-menu={cell.columnMenu}>
+                  <td
+                    class={formatAlignClass(cell.columnAlign)}
+                    class:bx--table-column-menu={cell.columnMenu}
+                  >
                     <slot
                       name="cell"
                       {row}
@@ -1386,6 +1406,7 @@
                   </td>
                 {:else}
                   <TableCell
+                    class={formatAlignClass(cell.columnAlign)}
                     headers="{id}-{cell.key}"
                     on:click={(event) => {
                       dispatch("click", { row, cell });

--- a/tests/DataTable/DataTable.test.svelte
+++ b/tests/DataTable/DataTable.test.svelte
@@ -14,6 +14,7 @@
     value: string;
     width?: string;
     minWidth?: string;
+    columnAlign?: "start" | "end";
     display?: (value: string | number | boolean) => string;
     sort?:
       | false

--- a/tests/DataTable/DataTable.test.ts
+++ b/tests/DataTable/DataTable.test.ts
@@ -1272,6 +1272,98 @@ describe("DataTable", () => {
     expect(protocolHeader).toHaveStyle({ "min-width": "100px" });
   });
 
+  describe("column alignment", () => {
+    const alignedHeaders = [
+      { key: "name", value: "Name" },
+      { key: "protocol", value: "Protocol", columnAlign: "start" },
+      { key: "port", value: "Port", columnAlign: "end" },
+      { key: "rule", value: "Rule" },
+    ] as const;
+
+    const getBodyRows = () =>
+      screen.getAllByRole("row").filter((row) => row.closest("tbody") !== null);
+
+    it("aligns the header and every cell of an aligned column only", () => {
+      render(DataTable, { props: { headers: alignedHeaders, rows } });
+
+      const columnHeaders = screen.getAllByRole("columnheader");
+      expect(columnHeaders[1]).toHaveClass("bx--table-column--align-start");
+      expect(columnHeaders[2]).toHaveClass("bx--table-column--align-end");
+      expect(columnHeaders[0].className).not.toMatch(/align/);
+      expect(columnHeaders[3].className).not.toMatch(/align/);
+
+      const bodyRows = getBodyRows();
+      expect(bodyRows).toHaveLength(rows.length);
+
+      for (const row of bodyRows) {
+        const cells = within(row).getAllByRole("cell");
+        expect(cells[1]).toHaveClass("bx--table-column--align-start");
+        expect(cells[2]).toHaveClass("bx--table-column--align-end");
+        expect(cells[0].className).not.toMatch(/align/);
+        expect(cells[3].className).not.toMatch(/align/);
+      }
+    });
+
+    it("renders no alignment class when headers omit align", () => {
+      const { container } = render(DataTable, { props: { headers, rows } });
+
+      expect(
+        container.querySelectorAll("[class*='bx--table-column--align']"),
+      ).toHaveLength(0);
+    });
+
+    it("keeps the sort affordance on an aligned sortable header", async () => {
+      render(DataTable, {
+        props: { headers: alignedHeaders, rows, sortable: true },
+      });
+
+      const portHeader = screen.getAllByRole("columnheader")[2];
+      expect(portHeader).toHaveClass("bx--table-column--align-end");
+      expect(portHeader).toHaveAttribute("aria-sort", "none");
+
+      const sortButton = within(portHeader).getByRole("button");
+      expect(sortButton).toHaveClass("bx--table-sort");
+
+      await user.click(sortButton);
+      expect(portHeader).toHaveAttribute("aria-sort", "ascending");
+    });
+
+    it("aligns virtualized rows but not spacer rows", () => {
+      const largeRows = Array.from({ length: 500 }, (_, i) => ({
+        id: String(i),
+        name: `Load Balancer ${i + 1}`,
+        protocol: "HTTP",
+        port: 3000 + i,
+        rule: "Round robin",
+      }));
+
+      render(DataTable, {
+        props: { headers: alignedHeaders, rows: largeRows, virtualize: true },
+      });
+
+      const isSpacer = (row: HTMLElement) =>
+        row.getAttribute("style")?.includes("height:") ?? false;
+      const bodyRows = getBodyRows();
+      const dataRows = bodyRows.filter((row) => !isSpacer(row));
+      const spacerRows = bodyRows.filter(isSpacer);
+
+      expect(dataRows.length).toBeGreaterThan(0);
+      expect(spacerRows.length).toBeGreaterThan(0);
+
+      for (const row of dataRows) {
+        const cells = within(row).getAllByRole("cell");
+        expect(cells[1]).toHaveClass("bx--table-column--align-start");
+        expect(cells[2]).toHaveClass("bx--table-column--align-end");
+      }
+
+      for (const row of spacerRows) {
+        for (const cell of within(row).getAllByRole("cell")) {
+          expect(cell.className).not.toMatch(/align/);
+        }
+      }
+    });
+  });
+
   it("applies sticky header", () => {
     render(DataTable, {
       props: {


### PR DESCRIPTION
Optional align on headers (start, end) applies to the
column's th and tds, including sortable headers and sticky-header
flex layout. Omitting align leaves the DOM unchanged.

---

<img width="1098" height="272" alt="Screenshot 2026-08-03 at 8 06 57 AM" src="https://github.com/user-attachments/assets/6212ceb6-e754-4e9f-8211-93418a256554" />
