### PR TITLE
feat(data-table): add `footerCell` slot and `TableFoot`

### DIFF
--- a/css/_data-table-footer.scss
+++ b/css/_data-table-footer.scss
@@ -1,0 +1,72 @@
+@import "carbon-components/scss/globals/scss/vars";
+@import "carbon-components/scss/globals/scss/typography";
+@import "carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/import-once/import-once";
+
+/// Summary row (`tfoot`) rendered by the DataTable `footerCell` slot.
+/// Carbon v10 has no `tfoot` styling, so the row is banded like the header and
+/// given the body cell padding of each size variant. In sticky-header mode
+/// Carbon lays out `thead`, `tbody`, and their rows as flex containers and pairs
+/// the leading column widths between them; `tfoot` is left out of both, so the
+/// footer needs the same treatment or every column drifts from the one above it.
+/// @access private
+/// @group components
+@mixin data-table-footer {
+  .#{$prefix}--data-table tfoot {
+    @include type-style("productive-heading-01");
+
+    background-color: $layer-accent;
+  }
+
+  .#{$prefix}--data-table tfoot td {
+    border-top: 1px solid $layer-active;
+    border-bottom: 0;
+    background-color: $layer-accent;
+    color: $text-primary;
+  }
+
+  .#{$prefix}--data-table--compact tfoot td,
+  .#{$prefix}--data-table--xs tfoot td {
+    padding-top: to-rem(2px);
+    padding-bottom: to-rem(2px);
+  }
+
+  .#{$prefix}--data-table--short tfoot td,
+  .#{$prefix}--data-table--sm tfoot td,
+  .#{$prefix}--data-table--md tfoot td {
+    padding-top: to-rem(7px);
+    padding-bottom: to-rem(6px);
+  }
+
+  .#{$prefix}--data-table--tall tfoot td,
+  .#{$prefix}--data-table--xl tfoot td {
+    padding-top: $spacing-05;
+    vertical-align: top;
+  }
+
+  .#{$prefix}--data-table--sticky-header tfoot,
+  .#{$prefix}--data-table--sticky-header tfoot tr,
+  .#{$prefix}--data-table--sticky-header tfoot td {
+    display: flex;
+  }
+
+  .#{$prefix}--data-table--sticky-header tfoot {
+    width: 100%;
+    flex-direction: column;
+  }
+
+  .#{$prefix}--data-table--sticky-header tfoot td.#{$prefix}--table-expand {
+    max-width: to-rem(48px);
+  }
+
+  .#{$prefix}--data-table--sticky-header
+    tfoot
+    td.#{$prefix}--table-column-checkbox {
+    width: to-rem(36px);
+    min-width: to-rem(36px);
+    align-items: center;
+  }
+}
+
+@include exports("data-table-footer") {
+  @include data-table-footer;
+}

--- a/css/all.scss
+++ b/css/all.scss
@@ -96,6 +96,7 @@ $css--plex: true;
 @import "./data-table-zebra-hidden";
 @import "./data-table-highlighted-row";
 @import "./data-table-sticky-column-menu";
+@import "./data-table-footer";
 @import "./pagination";
 @import "./structured-list-input-focusable";
 @import "./multiselect";

--- a/css/g10.scss
+++ b/css/g10.scss
@@ -56,6 +56,7 @@ $css--plex: true;
 @import "./data-table-zebra-hidden";
 @import "./data-table-highlighted-row";
 @import "./data-table-sticky-column-menu";
+@import "./data-table-footer";
 @import "./pagination";
 @import "./structured-list-input-focusable";
 @import "./multiselect";

--- a/css/g100.scss
+++ b/css/g100.scss
@@ -56,6 +56,7 @@ $css--plex: true;
 @import "./data-table-zebra-hidden";
 @import "./data-table-highlighted-row";
 @import "./data-table-sticky-column-menu";
+@import "./data-table-footer";
 @import "./pagination";
 @import "./structured-list-input-focusable";
 @import "./multiselect";

--- a/css/g80.scss
+++ b/css/g80.scss
@@ -56,6 +56,7 @@ $css--plex: true;
 @import "./data-table-zebra-hidden";
 @import "./data-table-highlighted-row";
 @import "./data-table-sticky-column-menu";
+@import "./data-table-footer";
 @import "./pagination";
 @import "./structured-list-input-focusable";
 @import "./multiselect";

--- a/css/g90.scss
+++ b/css/g90.scss
@@ -56,6 +56,7 @@ $css--plex: true;
 @import "./data-table-zebra-hidden";
 @import "./data-table-highlighted-row";
 @import "./data-table-sticky-column-menu";
+@import "./data-table-footer";
 @import "./pagination";
 @import "./structured-list-input-focusable";
 @import "./multiselect";

--- a/css/white.scss
+++ b/css/white.scss
@@ -56,6 +56,7 @@ $css--plex: true;
 @import "./data-table-zebra-hidden";
 @import "./data-table-highlighted-row";
 @import "./data-table-sticky-column-menu";
+@import "./data-table-footer";
 @import "./pagination";
 @import "./structured-list-input-focusable";
 @import "./multiselect";

--- a/docs/src/pages/components/DataTable.svx
+++ b/docs/src/pages/components/DataTable.svx
@@ -873,6 +873,14 @@ Use `rowClass` to apply custom CSS classes to rows. Pass a string for a static c
 
 <FileSource src="/framed/DataTable/DataTableRowClass" />
 
+## Footer
+
+Use the `footerCell` slot to render a summary row aligned to the table columns. The slot receives each header, so it can decide what to render per column and leave the rest blank.
+
+Compute totals, averages, and counts yourself; the table does not aggregate. The footer renders once for the whole table rather than once per page, and it stays in place while virtualized rows scroll.
+
+<FileSource src="/framed/DataTable/DataTableFooter" />
+
 ## Sizes
 
 Set `size` to control row height. The default is medium.

--- a/docs/src/pages/framed/DataTable/DataTableFooter.svelte
+++ b/docs/src/pages/framed/DataTable/DataTableFooter.svelte
@@ -1,0 +1,29 @@
+<script>
+  import { DataTable } from "carbon-components-svelte";
+
+  const rows = [
+    { id: "a", name: "Load Balancer 3", protocol: "HTTP", requests: 12_480 },
+    { id: "b", name: "Load Balancer 1", protocol: "HTTPS", requests: 8_112 },
+    { id: "c", name: "Load Balancer 2", protocol: "HTTP", requests: 3_907 },
+    { id: "d", name: "Load Balancer 6", protocol: "HTTPS", requests: 21_650 },
+  ];
+
+  const totalRequests = rows.reduce((total, row) => total + row.requests, 0);
+</script>
+
+<DataTable
+  headers={[
+    { key: "name", value: "Name" },
+    { key: "protocol", value: "Protocol" },
+    { key: "requests", value: "Requests" },
+  ]}
+  {rows}
+>
+  <svelte:fragment slot="footerCell" let:header let:index>
+    {#if header.key === "requests"}
+      {totalRequests.toLocaleString()}
+    {:else if index === 0}
+      Total
+    {/if}
+  </svelte:fragment>
+</DataTable>

--- a/src/DataTable/DataTable.svelte
+++ b/src/DataTable/DataTable.svelte
@@ -44,6 +44,7 @@
    * @slot {{ row: Row; rowSelected: boolean; }} expandedRow
    * @slot {{ header: DataTableNonEmptyHeader; }} cellHeader
    * @slot {{ row: Row; cell: DataTableCell<Row>; rowIndex: number; cellIndex: number; rowSelected: boolean; rowExpanded: boolean; }} cell
+   * @slot {{ header: DataTableNonEmptyHeader; index: number; }} footerCell
    * @event click
    * @type {object}
    * @property {DataTableHeader<Row>} [header]
@@ -330,6 +331,7 @@
   import TableBody from "./TableBody.svelte";
   import TableCell from "./TableCell.svelte";
   import TableContainer from "./TableContainer.svelte";
+  import TableFoot from "./TableFoot.svelte";
   import TableHead from "./TableHead.svelte";
   import TableHeader from "./TableHeader.svelte";
   import TableRow from "./TableRow.svelte";
@@ -1381,6 +1383,27 @@
           {/each}
         {/if}
       </TableBody>
+      {#if $$slots.footerCell}
+        <TableFoot>
+          <TableRow>
+            {#if expandable}
+              <td aria-hidden="true" class:bx--table-expand={true}></td>
+            {/if}
+            {#if selectable}
+              <td
+                aria-hidden="true"
+                class:bx--table-column-checkbox={true}
+                class:bx--table-column-radio={radio}
+              ></td>
+            {/if}
+            {#each headers as header, index (header.key)}
+              <td>
+                <slot name="footerCell" {header} {index} />
+              </td>
+            {/each}
+          </TableRow>
+        </TableFoot>
+      {/if}
     </Table>
   </div>
 </TableContainer>

--- a/src/DataTable/TableFoot.svelte
+++ b/src/DataTable/TableFoot.svelte
@@ -1,0 +1,5 @@
+<!-- svelte-ignore a11y-mouse-events-have-key-events -->
+<!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
+<tfoot {...$$restProps} on:click on:mouseover on:mouseenter on:mouseleave>
+  <slot />
+</tfoot>

--- a/src/DataTable/index.js
+++ b/src/DataTable/index.js
@@ -4,6 +4,7 @@ export { default as Table } from "./Table.svelte";
 export { default as TableBody } from "./TableBody.svelte";
 export { default as TableCell } from "./TableCell.svelte";
 export { default as TableContainer } from "./TableContainer.svelte";
+export { default as TableFoot } from "./TableFoot.svelte";
 export { default as TableHead } from "./TableHead.svelte";
 export { default as TableHeader } from "./TableHeader.svelte";
 export { default as TableRow } from "./TableRow.svelte";

--- a/src/index.js
+++ b/src/index.js
@@ -44,6 +44,7 @@ export { default as Table } from "./DataTable/Table.svelte";
 export { default as TableBody } from "./DataTable/TableBody.svelte";
 export { default as TableCell } from "./DataTable/TableCell.svelte";
 export { default as TableContainer } from "./DataTable/TableContainer.svelte";
+export { default as TableFoot } from "./DataTable/TableFoot.svelte";
 export { default as TableHead } from "./DataTable/TableHead.svelte";
 export { default as TableHeader } from "./DataTable/TableHeader.svelte";
 export { default as TableRow } from "./DataTable/TableRow.svelte";

--- a/tests/DataTable/DataTable.test.ts
+++ b/tests/DataTable/DataTable.test.ts
@@ -19,6 +19,7 @@ import DataTableCustomBoth from "./DataTableCustomBoth.test.svelte";
 import DataTableCustomDescription from "./DataTableCustomDescription.test.svelte";
 import DataTableCustomSlots from "./DataTableCustomSlots.test.svelte";
 import DataTableExpandIcon from "./DataTableExpandIcon.test.svelte";
+import DataTableFooter from "./DataTableFooter.test.svelte";
 
 describe("DataTable", () => {
   beforeEach(() => {
@@ -2987,6 +2988,98 @@ describe("DataTable", () => {
       expect.assert(scrollContainer instanceof HTMLElement);
       scrollContainer.scrollTop = 100;
       expect(scrollContainer.scrollTop).toBe(100);
+    });
+  });
+
+  describe("footer", () => {
+    const footerHeaders = [
+      { key: "name", value: "Name" },
+      { key: "protocol", value: "Protocol" },
+      { key: "port", value: "Port" },
+    ] as const;
+
+    it("should not render a tfoot without the footerCell slot", () => {
+      const { container } = render(DataTableFooter, {
+        props: { withFooter: false },
+      });
+
+      expect(container.querySelector("tfoot")).not.toBeInTheDocument();
+    });
+
+    it("should render one footer cell per column, in header order", () => {
+      const { container } = render(DataTableFooter);
+
+      const tfoot = container.querySelector("tfoot");
+      assert(tfoot);
+
+      const cells = tfoot.querySelectorAll("td");
+      expect(cells).toHaveLength(footerHeaders.length);
+      expect(within(tfoot).getByText("Total")).toBeInTheDocument();
+      expect(cells[0]).toHaveTextContent("Total");
+      expect(cells[1]).toHaveTextContent("");
+      expect(cells[2]).toHaveTextContent("3523");
+    });
+
+    it("should pass each header to the slot", () => {
+      const { container } = render(DataTableFooter, {
+        props: {
+          headers: [
+            { key: "port", value: "Port" },
+            { key: "name", value: "Name" },
+            { key: "protocol", value: "Protocol" },
+          ],
+        },
+      });
+
+      const cells = container.querySelectorAll("tfoot td");
+      // "port" moved first, so the total follows it rather than the column index.
+      expect(cells[0]).toHaveTextContent("3523");
+      expect(cells[1]).toHaveTextContent("");
+      expect(cells[2]).toHaveTextContent("");
+    });
+
+    it("should emit leading cells matching the header row", () => {
+      const { container } = render(DataTableFooter, {
+        props: { expandable: true, selectable: true },
+      });
+
+      const headerCells = container.querySelectorAll("thead tr th");
+      const footerCells = container.querySelectorAll("tfoot td");
+      expect(footerCells).toHaveLength(headerCells.length);
+      expect(footerCells).toHaveLength(footerHeaders.length + 2);
+
+      expect(footerCells[0]).toHaveClass("bx--table-expand");
+      expect(footerCells[0]).toHaveAttribute("aria-hidden", "true");
+      expect(footerCells[1]).toHaveClass("bx--table-column-checkbox");
+      expect(footerCells[1]).toHaveAttribute("aria-hidden", "true");
+    });
+
+    it("should render once while virtualized rows scroll", () => {
+      const largeRows = Array.from({ length: 500 }, (_, i) => ({
+        id: String(i),
+        name: `Load Balancer ${i + 1}`,
+        protocol: "HTTP",
+        port: 1,
+      }));
+
+      const { container } = render(DataTableFooter, {
+        props: { rows: largeRows, virtualize: true },
+      });
+
+      const footers = container.querySelectorAll("tfoot");
+      expect(footers).toHaveLength(1);
+
+      const spacerRows = [...container.querySelectorAll("tbody tr")].filter(
+        (row) => row.getAttribute("style")?.includes("height:"),
+      );
+      expect(spacerRows.length).toBeGreaterThan(0);
+      for (const spacerRow of spacerRows) {
+        expect(spacerRow.closest("tfoot")).toBeNull();
+      }
+
+      const cells = container.querySelectorAll("tfoot td");
+      expect(cells).toHaveLength(footerHeaders.length);
+      expect(cells[2]).toHaveTextContent(String(largeRows.length));
     });
   });
 });

--- a/tests/DataTable/DataTableFooter.test.svelte
+++ b/tests/DataTable/DataTableFooter.test.svelte
@@ -1,0 +1,65 @@
+<script lang="ts">
+  import DataTable from "carbon-components-svelte/DataTable/DataTable.svelte";
+  import type { ComponentProps } from "svelte";
+
+  type Row = {
+    id: string;
+    name: string;
+    protocol: string;
+    port: number;
+  };
+
+  export let headers: readonly {
+    key: keyof Omit<Row, "id">;
+    value: string;
+  }[] = [
+    { key: "name", value: "Name" },
+    { key: "protocol", value: "Protocol" },
+    { key: "port", value: "Port" },
+  ];
+
+  export let rows: readonly Row[] = [
+    { id: "a", name: "Load Balancer 3", protocol: "HTTP", port: 3000 },
+    { id: "b", name: "Load Balancer 1", protocol: "HTTP", port: 443 },
+    { id: "c", name: "Load Balancer 2", protocol: "HTTP", port: 80 },
+  ];
+
+  export let expandable = false;
+  export let selectable = false;
+  export let pageSize = 0;
+  export let page = 0;
+  export let virtualize: ComponentProps<DataTable>["virtualize"] = undefined;
+  export let withFooter = true;
+
+  $: totalPort = rows.reduce((total, row) => total + row.port, 0);
+</script>
+
+{#if withFooter}
+  <DataTable
+    {headers}
+    {rows}
+    {expandable}
+    {selectable}
+    {pageSize}
+    {page}
+    {virtualize}
+  >
+    <svelte:fragment slot="footerCell" let:header let:index>
+      {#if header.key === "port"}
+        {totalPort}
+      {:else if index === 0}
+        Total
+      {/if}
+    </svelte:fragment>
+  </DataTable>
+{:else}
+  <DataTable
+    {headers}
+    {rows}
+    {expandable}
+    {selectable}
+    {pageSize}
+    {page}
+    {virtualize}
+  />
+{/if}

--- a/tests/DataTable/TableSubComponents.test.svelte
+++ b/tests/DataTable/TableSubComponents.test.svelte
@@ -3,6 +3,7 @@
   import TableBody from "carbon-components-svelte/DataTable/TableBody.svelte";
   import TableCell from "carbon-components-svelte/DataTable/TableCell.svelte";
   import TableContainer from "carbon-components-svelte/DataTable/TableContainer.svelte";
+  import TableFoot from "carbon-components-svelte/DataTable/TableFoot.svelte";
   import TableHead from "carbon-components-svelte/DataTable/TableHead.svelte";
   import TableRow from "carbon-components-svelte/DataTable/TableRow.svelte";
   import type { ComponentProps } from "svelte";
@@ -13,6 +14,7 @@
     | "TableCell"
     | "TableRow"
     | "TableHead"
+    | "TableFoot"
     | "TableContainer" = "Table";
 
   // Table props
@@ -91,6 +93,19 @@
     {/if}
     <slot />
   </TableHead>
+{:else if testComponent === "TableFoot"}
+  <TableFoot
+    on:click={() => console.log("click")}
+    on:mouseover={() => console.log("mouseover")}
+    on:mouseenter={() => console.log("mouseenter")}
+    on:mouseleave={() => console.log("mouseleave")}
+    {...$$restProps}
+  >
+    {#if slotContent}
+      {slotContent}
+    {/if}
+    <slot />
+  </TableFoot>
 {:else if testComponent === "TableContainer"}
   <TableContainer
     {title}

--- a/tests/DataTable/TableSubComponents.test.ts
+++ b/tests/DataTable/TableSubComponents.test.ts
@@ -221,6 +221,32 @@ describe("Table Sub-Components", () => {
     });
   });
 
+  describe("TableFoot", () => {
+    it("should render as tfoot element", () => {
+      const { container } = render(TableSubComponents, {
+        props: { testComponent: "TableFoot", slotContent: "Foot content" },
+      });
+
+      const tfoot = container.querySelector("tfoot");
+      expect(tfoot).toBeInTheDocument();
+      expect(screen.getByText("Foot content")).toBeInTheDocument();
+    });
+
+    it("should apply custom attributes", () => {
+      const { container } = render(TableSubComponents, {
+        props: {
+          testComponent: "TableFoot",
+          "data-testid": "custom-tfoot",
+        },
+      });
+
+      const tfoot = container.querySelector(
+        "tfoot[data-testid='custom-tfoot']",
+      );
+      expect(tfoot).toBeInTheDocument();
+    });
+  });
+
   describe("TableContainer", () => {
     it("should render with default props", () => {
       const { container } = render(TableSubComponents, {


### PR DESCRIPTION
Opt-in tfoot summary row aligned to columns, including leading
cells for expansion and selection. Aggregation stays consumer-
side. TableFoot is also exported for raw Table composition.

<img width="1491" height="371" alt="Screenshot 2026-08-02 at 7 57 22 AM" src="https://github.com/user-attachments/assets/d0297493-1dbe-4e93-81ca-d06b242813eb" />
