### PR TITLE
feat(tree-view): support inline rename via `editable` and `rename`

### DIFF
--- a/css/_treeview.scss
+++ b/css/_treeview.scss
@@ -41,8 +41,35 @@
   }
 }
 
+/// Inline rename input, rendered in place of a node label while editing.
+/// @access private
+/// @group components
+@mixin treeview-rename {
+  .#{$prefix}--tree-node__rename {
+    flex: 1 1 auto;
+    width: 100%;
+    min-width: 0;
+    padding: 0;
+    border: 0;
+    margin: 0;
+    background-color: transparent;
+    color: inherit;
+    font: inherit;
+    letter-spacing: inherit;
+
+    // The row already draws the focus outline on `.bx--tree-node__label`.
+    &:focus {
+      outline: none;
+    }
+  }
+}
+
 @include exports('treeview-hidden') {
   @include treeview-hidden;
+}
+
+@include exports('treeview-rename') {
+  @include treeview-rename;
 }
 
 @include exports('treeview-multiselect') {

--- a/docs/src/pages/components/TreeView.svx
+++ b/docs/src/pages/components/TreeView.svx
@@ -71,9 +71,19 @@ Slot a checkbox component in each tree view node to create a tree with checkable
 
 ### Inline editing
 
-Use a `contenteditable` element in each tree view node to enable inline editing of node names. The editable region is wrapped in a container with `stopPropagation` to prevent tree node selection when editing.
+Set `editable` to rename nodes in place. Press <DocKbd label="F2" /> or double-click a node to start editing. <DocKbd label="Enter" /> commits the new name, as does clicking away from the input; <DocKbd label="Escape" /> restores the original name.
+
+Nodes stay yours to manage: `rename` reports the node id, the committed text, and the previous text, and your handler applies it. An unchanged or empty name reports nothing.
+
+Set `editable` to `false` on a node to opt it out, as the first node here does. Disabled nodes and link nodes are never editable.
 
 <FileSource src="/framed/TreeView/TreeViewInlineEditing" />
+
+### Programmatic rename
+
+Use `TreeView.editNode` to start an edit from elsewhere in the interface, such as a toolbar or context menu. A collapsed target expands into view first.
+
+<FileSource src="/framed/TreeView/TreeViewEditNode" />
 
 ## Events
 

--- a/docs/src/pages/framed/TreeView/TreeViewEditNode.svelte
+++ b/docs/src/pages/framed/TreeView/TreeViewEditNode.svelte
@@ -1,8 +1,10 @@
 <script>
-  import { RecursiveList, Stack, TreeView } from "carbon-components-svelte";
+  import { Button, ButtonSet, Stack, TreeView } from "carbon-components-svelte";
 
+  let treeview = null;
+  let activeId = "";
   let nodes = [
-    { id: 0, text: "AI / Machine learning", editable: false },
+    { id: 0, text: "AI / Machine learning" },
     {
       id: 1,
       text: "Analytics",
@@ -38,8 +40,21 @@
 </script>
 
 <Stack gap={6}>
+  <ButtonSet>
+    <Button
+      disabled={activeId === ""}
+      on:click={() => treeview?.editNode(activeId)}
+    >
+      Rename active node
+    </Button>
+    <Button kind="tertiary" on:click={() => treeview?.editNode(3)}>
+      Rename a collapsed node
+    </Button>
+  </ButtonSet>
   <div>
     <TreeView
+      bind:this={treeview}
+      bind:activeId
       labelText="Cloud Products"
       editable
       {nodes}
@@ -48,5 +63,4 @@
       }}
     />
   </div>
-  <RecursiveList {nodes} />
 </Stack>

--- a/src/TreeView/TreeView.svelte
+++ b/src/TreeView/TreeView.svelte
@@ -204,6 +204,7 @@
    * @property {string} [href] - Optional URL the node links to
    * @property {string} [target] - Optional link target (e.g., "_blank")
    * @property {boolean} [hasChildren] - Whether the node has children that have not been loaded yet. Renders an expander even without a `nodes` array; expanding fires `toggle` so children can be loaded lazily.
+   * @property {boolean} [editable] - Whether the node can be renamed inline. Defaults to the tree-level `editable` value; set `false` to opt a single node out.
    * @property {TreeNode<Id>[]} [nodes]
    * @typedef {object} ShowNodeOptions
    * @property {boolean} [expand] - Whether to expand the node and its ancestors (default: true)
@@ -217,6 +218,10 @@
    * @property {ReadonlyArray<Id>} selectedIds - The full set of selected node ids after the change
    * @property {Array<Id>} added - Node ids selected since the previous change
    * @property {Array<Id>} removed - Node ids deselected since the previous change
+   * @typedef {object} TreeViewRename<Id=(string|number)>
+   * @property {Id} id - Id of the renamed node
+   * @property {string} text - The committed text, trimmed
+   * @property {string} previousText - The text before the edit
    * @slot {{ node: Node & { expanded: boolean; leaf: boolean; selected: boolean; } }}
    * @slot {{ node: Node & { expanded: boolean; leaf: boolean; selected: boolean; } }} childNodes
    * @event select
@@ -229,6 +234,8 @@
    * @type {Node & { expanded: boolean; leaf: boolean; selected: boolean }}
    * @event select:change
    * @type {TreeViewSelectionChange<Node["id"]>}
+   * @event rename
+   * @type {TreeViewRename<Node["id"]>}
    */
 
   /**
@@ -291,6 +298,13 @@
    * @type {'node' | 'shallow' | 'deep'}
    */
   export let multiselectMode = "node";
+
+  /**
+   * Set to `true` to rename nodes inline.
+   * F2 or a double-click starts an edit; Enter and blur commit it, Escape cancels.
+   * Set `editable` to `false` on a node to opt it out.
+   */
+  export let editable = false;
 
   /**
    * Programmatically expand all nodes
@@ -430,6 +444,26 @@
   }
 
   /**
+   * Programmatically start renaming a node by `id`.
+   * Ancestors are expanded first so a collapsed target scrolls into view.
+   * No-op if the node is disabled, links elsewhere, or opts out of `editable`.
+   * @type {(id: Node["id"]) => void}
+   * @example
+   * ```svelte
+   * <TreeView bind:this={treeView} editable {nodes} on:rename={rename} />
+   * <button on:click={() => treeView.editNode('node-123')}>
+   *   Rename Node
+   * </button>
+   * ```
+   */
+  export function editNode(id) {
+    const node = getNode(id);
+    if (!isNodeEditable(node)) return;
+    showNode(id, { focus: false });
+    startEdit(node);
+  }
+
+  /**
    * Look up a node by `id` without re-implementing tree traversal.
    * Returns `null` if no node with the given `id` exists.
    * @type {(id: Node["id"]) => Node | null}
@@ -476,6 +510,13 @@
 
   /** @type {import("svelte/store").Writable<boolean>} */
   const multiselectStore = writable(multiselect);
+
+  /** @type {import("svelte/store").Writable<boolean>} */
+  const editableStore = writable(editable);
+  /** @type {import("svelte/store").Writable<Node["id"] | null>} */
+  const editingNodeId = writable(null);
+  /** @type {import("svelte/store").Writable<string>} */
+  const renameLabel = writable("");
 
   /** @type {import("svelte/store").Writable<Node["id"]>} */
   const activeNodeId = writable(activeId);
@@ -709,6 +750,77 @@
     dispatch("toggle", withLiveState(node));
   }
 
+  /** @type {Node["id"] | null} */
+  let editingId = null;
+  /** Text the node carried when the current edit session started. */
+  let editingText = "";
+
+  /** @type {(node: Node | null) => boolean} */
+  function isNodeEditable(node) {
+    if (!editable || node == null) return false;
+    if (node.disabled || node.href) return false;
+    return node.editable !== false;
+  }
+
+  /** @type {(node: Node) => void} */
+  function startEdit(node) {
+    if (!isNodeEditable(node)) return;
+    editingId = node.id;
+    editingText = node.text ?? "";
+    editingNodeId.set(editingId);
+  }
+
+  /** Leaves edit mode and hands focus back to the row the input replaced. */
+  function endEdit() {
+    const id = editingId;
+    editingId = null;
+    editingNodeId.set(null);
+    tick().then(() => {
+      ref?.querySelector(`[id="${CSS.escape(String(id))}"]`)?.focus();
+    });
+  }
+
+  /** @type {(text: string) => void} */
+  function commitEdit(text) {
+    if (editingId === null) return;
+    const id = editingId;
+    const previousText = editingText;
+    const nextText = text.trim();
+    endEdit();
+    if (nextText === "" || nextText === previousText) return;
+    dispatch("rename", { id, text: nextText, previousText });
+  }
+
+  function cancelEdit() {
+    if (editingId === null) return;
+    endEdit();
+  }
+
+  /**
+   * Action for the rename input: typing replaces the current name.
+   * @param {HTMLInputElement} input
+   */
+  function initEditInput(input) {
+    input.focus();
+    input.select();
+  }
+
+  /** @param {KeyboardEvent & { currentTarget: HTMLInputElement }} event */
+  function handleEditKeyDown(event) {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      commitEdit(event.currentTarget.value);
+    } else if (event.key === "Escape") {
+      event.preventDefault();
+      cancelEdit();
+    }
+  }
+
+  /** @param {FocusEvent & { currentTarget: HTMLInputElement }} event */
+  function handleEditBlur(event) {
+    commitEdit(event.currentTarget.value);
+  }
+
   setContext("carbon:TreeView", {
     treeId,
     activeNodeId,
@@ -717,11 +829,19 @@
     selectedIdsSetStore,
     expandedIdsSetStore,
     multiselectStore,
+    editableStore,
+    editingNodeId,
+    renameLabel,
     clickNode,
     selectNode,
     expandNode,
     focusNode,
     toggleNode,
+    isNodeEditable,
+    startEdit,
+    initEditInput,
+    handleEditKeyDown,
+    handleEditBlur,
   });
 
   /** @param {HTMLElement | null} root */
@@ -804,6 +924,10 @@
   }
 
   function handleKeyDown(event) {
+    // Type-ahead consumes every printable key, so it would hijack typing in a
+    // rename input that let its keydown bubble this far.
+    if (editingId !== null) return;
+
     event.stopPropagation();
 
     if (
@@ -939,6 +1063,8 @@
   }
 
   $: multiselectStore.set(multiselect);
+  $: editableStore.set(editable);
+  $: renameLabel.set(labelText ? `Rename ${labelText}` : "Rename");
   $: flattenedNodes = cachedFlattenedNodes ?? [];
   $: nodeIds = cachedNodeIds ?? [];
 

--- a/src/TreeView/TreeViewNode.svelte
+++ b/src/TreeView/TreeViewNode.svelte
@@ -102,9 +102,17 @@
   const {
     activeNodeId,
     selectedIdsSetStore,
+    editableStore,
+    editingNodeId,
+    renameLabel,
     clickNode,
     selectNode,
     focusNode,
+    isNodeEditable,
+    startEdit,
+    initEditInput,
+    handleEditKeyDown,
+    handleEditBlur,
   } = getContext("carbon:TreeView");
   function offset() {
     return computeTreeLeafDepth(refLabel) - 1 + (leaf && icon ? 2 : 2.5);
@@ -137,6 +145,8 @@
 
     prevActiveId = $activeNodeId;
   }
+  $: canEdit = $editableStore && isNodeEditable(node);
+  $: isEditing = $editingNodeId === id;
   $: if (refLabel) {
     refLabel.style.marginLeft = `-${offset()}rem`;
     refLabel.style.paddingLeft = `${offset()}rem`;
@@ -233,6 +243,12 @@
       clickNode(node, event);
     }}
     on:keydown={(event) => {
+      if (event.key === "F2") {
+        event.preventDefault();
+        if (canEdit) startEdit(node);
+        return;
+      }
+
       if (
         event.key === "ArrowUp" ||
         event.key === "ArrowDown" ||
@@ -266,9 +282,29 @@
       focusNode(node);
     }}
   >
-    <div bind:this={refLabel} class:bx--tree-node__label={true}>
+    <!-- svelte-ignore a11y-no-static-element-interactions -->
+    <div
+      bind:this={refLabel}
+      class:bx--tree-node__label={true}
+      on:dblclick={() => {
+        if (canEdit) startEdit(node);
+      }}
+    >
       <svelte:component this={icon} class="bx--tree-node__icon" />
-      <slot {node}> {text} </slot>
+      {#if isEditing}
+        <input
+          class:bx--tree-node__rename={true}
+          aria-label={$renameLabel}
+          value={text}
+          use:initEditInput
+          on:click|stopPropagation
+          on:dblclick|stopPropagation
+          on:keydown|stopPropagation={handleEditKeyDown}
+          on:blur={handleEditBlur}
+        >
+      {:else}
+        <slot {node}> {text} </slot>
+      {/if}
     </div>
   </li>
 {/if}

--- a/src/TreeView/TreeViewNodeList.svelte
+++ b/src/TreeView/TreeViewNodeList.svelte
@@ -64,11 +64,19 @@
     activeNodeId,
     selectedIdsSetStore,
     expandedIdsSetStore,
+    editableStore,
+    editingNodeId,
+    renameLabel,
     clickNode,
     selectNode,
     expandNode,
     focusNode,
     toggleNode,
+    isNodeEditable,
+    startEdit,
+    initEditInput,
+    handleEditKeyDown,
+    handleEditBlur,
   } = getContext("carbon:TreeView");
 
   function offset() {
@@ -113,6 +121,8 @@
 
     prevActiveId = $activeNodeId;
   }
+  $: canEdit = $editableStore && isNodeEditable(node);
+  $: isEditing = $editingNodeId === id;
   $: if (refLabel) {
     refLabel.style.marginLeft = `-${offset()}rem`;
     refLabel.style.paddingLeft = `${offset()}rem`;
@@ -173,6 +183,12 @@
       clickNode(node, event);
     }}
     on:keydown={(event) => {
+      if (event.key === "F2") {
+        event.preventDefault();
+        if (canEdit) startEdit(node);
+        return;
+      }
+
       if (
         event.key === "ArrowUp" ||
         event.key === "ArrowDown" ||
@@ -254,8 +270,28 @@
       </span>
       <span class:bx--tree-node__label__details={true}>
         <svelte:component this={icon} class="bx--tree-node__icon" />
-        <span id="{treeId}-{id}__label" class:bx--tree-node__label__text={true}>
-          <slot {node} />
+        <!-- svelte-ignore a11y-no-static-element-interactions -->
+        <span
+          id="{treeId}-{id}__label"
+          class:bx--tree-node__label__text={true}
+          on:dblclick={() => {
+            if (canEdit) startEdit(node);
+          }}
+        >
+          {#if isEditing}
+            <input
+              class:bx--tree-node__rename={true}
+              aria-label={$renameLabel}
+              value={text}
+              use:initEditInput
+              on:click|stopPropagation
+              on:dblclick|stopPropagation
+              on:keydown|stopPropagation={handleEditKeyDown}
+              on:blur={handleEditBlur}
+            >
+          {:else}
+            <slot {node} />
+          {/if}
         </span>
       </span>
     </div>

--- a/tests/TreeView/TreeView.rename.test.svelte
+++ b/tests/TreeView/TreeView.rename.test.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+  import type { TreeNode } from "carbon-components-svelte/TreeView/TreeView.svelte";
+  import TreeView from "carbon-components-svelte/TreeView/TreeView.svelte";
+  import type { ComponentProps } from "svelte";
+
+  export let nodes: ComponentProps<TreeView>["nodes"] = [
+    {
+      id: "root",
+      text: "Root",
+      nodes: [
+        { id: "child", text: "Child" },
+        { id: "locked", text: "Locked", editable: false },
+      ],
+    },
+    { id: "leaf", text: "Leaf" },
+    { id: "blocked", text: "Blocked", disabled: true },
+    { id: "link", text: "Link", href: "#link" },
+  ];
+
+  let treeview: TreeView;
+
+  // Drives the `editNode` accessor from the spec.
+  export function edit(id: TreeNode["id"]) {
+    treeview.editNode(id);
+  }
+</script>
+
+<TreeView
+  bind:this={treeview}
+  labelText="Files"
+  editable
+  {nodes}
+  on:rename={({ detail }) => console.log("rename", detail)}
+/>

--- a/tests/TreeView/TreeView.rename.test.ts
+++ b/tests/TreeView/TreeView.rename.test.ts
@@ -1,0 +1,186 @@
+import { render, screen, waitFor } from "@testing-library/svelte";
+import { user } from "../utils/user";
+import TreeViewRename from "./TreeView.rename.test.svelte";
+
+// Collapsed subtrees stay mounted, and no stylesheet applies
+// `.bx--tree-node--hidden` in jsdom, so their labels pollute accessible-name
+// computation. Look rows up by id instead, as the lazy-loading suite does.
+function treeItemById(id: string): HTMLElement {
+  const el = document.getElementById(id);
+  expect.assert(el instanceof HTMLElement);
+  return el;
+}
+
+/** The element carrying the double-click-to-rename handler for a row. */
+function labelOf(id: string): HTMLElement {
+  const row = treeItemById(id);
+  const el =
+    row.querySelector(".bx--tree-node__label__text") ??
+    row.querySelector(".bx--tree-node__label");
+  expect.assert(el instanceof HTMLElement);
+  return el;
+}
+
+async function findRenameInput(): Promise<HTMLInputElement> {
+  const input = await screen.findByRole("textbox");
+  expect.assert(input instanceof HTMLInputElement);
+  return input;
+}
+
+describe("TreeView inline rename", () => {
+  it("swaps in an input with the node text selected on F2", async () => {
+    render(TreeViewRename);
+
+    treeItemById("leaf").focus();
+    await user.keyboard("{F2}");
+
+    const input = await findRenameInput();
+    expect(input).toHaveValue("Leaf");
+    expect(input).toHaveFocus();
+    expect(input.selectionStart).toBe(0);
+    expect(input.selectionEnd).toBe("Leaf".length);
+  });
+
+  it("swaps in an input with the node text selected on double-click", async () => {
+    render(TreeViewRename);
+
+    await user.dblClick(labelOf("root"));
+
+    const input = await findRenameInput();
+    expect(input).toHaveValue("Root");
+    expect(input).toHaveFocus();
+    expect(input.selectionStart).toBe(0);
+    expect(input.selectionEnd).toBe("Root".length);
+  });
+
+  it("commits on Enter and reports the change", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(TreeViewRename);
+
+    treeItemById("leaf").focus();
+    await user.keyboard("{F2}");
+    await findRenameInput();
+    await user.keyboard("Renamed{Enter}");
+
+    expect(consoleLog).toHaveBeenCalledWith("rename", {
+      id: "leaf",
+      text: "Renamed",
+      previousText: "Leaf",
+    });
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+  });
+
+  it("commits on blur", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(TreeViewRename);
+
+    treeItemById("leaf").focus();
+    await user.keyboard("{F2}");
+    await findRenameInput();
+    await user.keyboard("Renamed");
+    await user.click(document.body);
+
+    expect(consoleLog).toHaveBeenCalledWith("rename", {
+      id: "leaf",
+      text: "Renamed",
+      previousText: "Leaf",
+    });
+  });
+
+  it("cancels on Escape and returns focus to the row", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(TreeViewRename);
+
+    const leaf = treeItemById("leaf");
+    leaf.focus();
+    await user.keyboard("{F2}");
+    await findRenameInput();
+    await user.keyboard("Renamed{Escape}");
+
+    await waitFor(() => expect(leaf).toHaveFocus());
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+    expect(leaf).toHaveTextContent("Leaf");
+    expect(consoleLog).not.toHaveBeenCalledWith("rename", expect.anything());
+  });
+
+  it("reports nothing when the committed text is unchanged", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(TreeViewRename);
+
+    treeItemById("leaf").focus();
+    await user.keyboard("{F2}");
+    await findRenameInput();
+    await user.keyboard("{Enter}");
+
+    expect(consoleLog).not.toHaveBeenCalledWith("rename", expect.anything());
+  });
+
+  it("reports nothing when the committed text is whitespace-only", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(TreeViewRename);
+
+    treeItemById("leaf").focus();
+    await user.keyboard("{F2}");
+    await findRenameInput();
+    await user.keyboard("   {Enter}");
+
+    expect(consoleLog).not.toHaveBeenCalledWith("rename", expect.anything());
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+  });
+
+  it("types a space without triggering type-ahead or selection", async () => {
+    render(TreeViewRename);
+
+    const leaf = treeItemById("leaf");
+    leaf.focus();
+    await user.keyboard("{F2}");
+    const input = await findRenameInput();
+    await user.keyboard(" x");
+
+    expect(input).toHaveFocus();
+    expect(input).toHaveValue(" x");
+    expect(leaf).toHaveAttribute("aria-selected", "false");
+  });
+
+  it("never edits disabled or link nodes", async () => {
+    const { component } = render(TreeViewRename);
+
+    await user.dblClick(labelOf("blocked"));
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+
+    await user.dblClick(labelOf("link"));
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+
+    component.edit("blocked");
+    component.edit("link");
+    await waitFor(() =>
+      expect(screen.queryByRole("textbox")).not.toBeInTheDocument(),
+    );
+  });
+
+  it("opts a node out with node.editable set to false", async () => {
+    const { component } = render(TreeViewRename);
+
+    await user.dblClick(labelOf("locked"));
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+
+    component.edit("locked");
+    await waitFor(() =>
+      expect(screen.queryByRole("textbox")).not.toBeInTheDocument(),
+    );
+  });
+
+  it("expands ancestors when editNode targets a collapsed node", async () => {
+    const { component } = render(TreeViewRename);
+
+    const root = treeItemById("root");
+    expect(root).toHaveAttribute("aria-expanded", "false");
+
+    component.edit("child");
+
+    const input = await findRenameInput();
+    expect(root).toHaveAttribute("aria-expanded", "true");
+    expect(input).toHaveValue("Child");
+    expect(input).toHaveFocus();
+  });
+});


### PR DESCRIPTION
First-class rename via F2, double-click, or editNode(id). Enter
and blur commit; Escape cancels. The rename event reports the
change so the consumer can update nodes; the component never
mutates them.