### PR TITLE
feat(tree-view): add tri-state checkbox selection mode

### DIFF
--- a/css/_treeview-checkbox.scss
+++ b/css/_treeview-checkbox.scss
@@ -1,0 +1,56 @@
+@import "carbon-components/scss/globals/scss/vars";
+@import "carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/import-once/import-once";
+
+/// Tri-state checkbox control rendered in each node label when TreeView runs
+/// in `selectionMode="checkbox"`. Carbon v10's treeview ships no checkbox
+/// styling, so the control is a `bx--checkbox` reshaped to sit in a tree row.
+/// @access private
+/// @group components
+@mixin treeview-checkbox {
+  // Carbon pads leaf rows for a missing caret so text lines up with parents.
+  // The checkbox sits ahead of that pad, so reset it or leaf checkboxes
+  // drift right of their parent siblings.
+  .#{$prefix}--tree--checkbox .#{$prefix}--tree-leaf-node,
+  .#{$prefix}--tree--checkbox
+    .#{$prefix}--tree-leaf-node.#{$prefix}--tree-node--with-icon {
+    padding-left: $carbon--spacing-05;
+  }
+
+  // `bx--form-item` stretches to fill its flex parent and would shove the
+  // node text to the end of the row.
+  .#{$prefix}--tree--checkbox
+    .#{$prefix}--tree-node__label
+    > .#{$prefix}--form-item.#{$prefix}--checkbox-wrapper {
+    position: relative;
+    flex: 0 0 auto;
+    margin-top: 0;
+    // Nudge the checkbox left into the row inset and widen the gap after it
+    // by the same amount so the text column does not move.
+    margin-left: -$carbon--spacing-03;
+    margin-right: $carbon--spacing-04;
+    margin-bottom: 0;
+  }
+
+  // Parents put a caret between checkbox and text. Leaves have no caret,
+  // so widen a leaf's post-checkbox gap by that footprint to keep text aligned.
+  .#{$prefix}--tree--checkbox
+    .#{$prefix}--tree-leaf-node
+    .#{$prefix}--tree-node__label
+    > .#{$prefix}--form-item.#{$prefix}--checkbox-wrapper {
+    margin-right: $carbon--spacing-04 + $carbon--spacing-05 + $carbon--spacing-03;
+  }
+
+  // Carbon pads the label for ascenders of label text. There is none here,
+  // so drop the pad and center the box on the row.
+  .#{$prefix}--tree--checkbox
+    .#{$prefix}--tree-node__label
+    > .#{$prefix}--checkbox-wrapper
+    .#{$prefix}--checkbox-label {
+    min-height: $carbon--spacing-06;
+    padding-top: 0;
+  }
+}
+
+@include exports("treeview-checkbox") {
+  @include treeview-checkbox;
+}

--- a/css/all.scss
+++ b/css/all.scss
@@ -103,6 +103,7 @@ $css--plex: true;
 @import "./structured-list-input-focusable";
 @import "./multiselect";
 @import "./treeview";
+@import "./treeview-checkbox";
 @import "./selectable-tag";
 @import "./tag";
 @import "./tag-set";

--- a/css/g10.scss
+++ b/css/g10.scss
@@ -63,6 +63,7 @@ $css--plex: true;
 @import "./structured-list-input-focusable";
 @import "./multiselect";
 @import "./treeview";
+@import "./treeview-checkbox";
 @import "./selectable-tag";
 @import "./tag";
 @import "./tag-set";

--- a/css/g100.scss
+++ b/css/g100.scss
@@ -63,6 +63,7 @@ $css--plex: true;
 @import "./structured-list-input-focusable";
 @import "./multiselect";
 @import "./treeview";
+@import "./treeview-checkbox";
 @import "./selectable-tag";
 @import "./tag";
 @import "./tag-set";

--- a/css/g80.scss
+++ b/css/g80.scss
@@ -63,6 +63,7 @@ $css--plex: true;
 @import "./structured-list-input-focusable";
 @import "./multiselect";
 @import "./treeview";
+@import "./treeview-checkbox";
 @import "./selectable-tag";
 @import "./tag";
 @import "./tag-set";

--- a/css/g90.scss
+++ b/css/g90.scss
@@ -63,6 +63,7 @@ $css--plex: true;
 @import "./structured-list-input-focusable";
 @import "./multiselect";
 @import "./treeview";
+@import "./treeview-checkbox";
 @import "./selectable-tag";
 @import "./tag";
 @import "./tag-set";

--- a/css/white.scss
+++ b/css/white.scss
@@ -63,6 +63,7 @@ $css--plex: true;
 @import "./structured-list-input-focusable";
 @import "./multiselect";
 @import "./treeview";
+@import "./treeview-checkbox";
 @import "./selectable-tag";
 @import "./tag";
 @import "./tag-set";

--- a/docs/src/pages/components/TreeView.svx
+++ b/docs/src/pages/components/TreeView.svx
@@ -52,22 +52,38 @@ Add links to leaf nodes by defining an `href` property. Link nodes render as `<a
 
 Customize node rendering using the default slot with the `let:node` directive. The node object provides:
 
-| Property | Description                                      |
-| -------- | ------------------------------------------------ |
-| id       | The node id.                                     |
-| text     | The node text.                                   |
-| expanded | True when the node is expanded.                  |
-| leaf     | True when the node does not have child nodes.    |
-| disabled | True when the node is disabled.                  |
-| selected | True when the node is selected.                  |
+| Property     | Description                                          |
+| ------------ | ----------------------------------------------------- |
+| id           | The node id.                                           |
+| text         | The node text.                                         |
+| expanded     | True when the node is expanded.                        |
+| leaf         | True when the node does not have child nodes.          |
+| disabled     | True when the node is disabled.                        |
+| selected     | True when the node is selected.                        |
+| checked      | True when the node is checked (`selectionMode="checkbox"`). |
+| indeterminate | True when the node is partially checked (`selectionMode="checkbox"`). |
 
 <FileSource src="/framed/TreeView/TreeViewSlot" />
 
 ### Checkbox
 
-Slot a checkbox component in each tree view node to create a tree with checkable items. The checkbox is wrapped in a container with `stopPropagation` to prevent tree node selection when checking items.
+Set `selectionMode` to `"checkbox"` to render a checkbox on every node. Checking a branch checks its descendants, and a branch whose descendants are only partly checked renders indeterminate.
+
+Bind to `checkedIds` to read and set which nodes are checked. That is separate from `selectedIds`, which tracks row highlighting and is unused in checkbox mode. Bind to `indeterminateIds` to read which nodes are partially checked; it is derived from `checkedIds` and read-only, so writes are overwritten. Checkbox mode carries its own multi-selection, so [Multi-select](#multi-select) is ignored. Link nodes navigate instead of checking and render no checkbox.
 
 <FileSource src="/framed/TreeView/TreeViewCheckbox" />
+
+### Checkbox (independent)
+
+Set `checkMode` to `"node"` to check each node on its own. Parents and children no longer follow each other, and no node is indeterminate.
+
+<FileSource src="/framed/TreeView/TreeViewCheckboxIndependent" />
+
+### Checkbox (compact)
+
+Combine `size="compact"` with `selectionMode="checkbox"`.
+
+<FileSource src="/framed/TreeView/TreeViewCheckboxCompact" />
 
 ### Inline editing
 
@@ -77,15 +93,17 @@ Use a `contenteditable` element in each tree view node to enable inline editing 
 
 ## Events
 
-Use `on:select`, `on:toggle`, and `on:focus` for user-driven selection, expansion, and focus. Each detail is the affected node after the gesture, with the same shape as the [Custom (slot)](#custom-slot) node.
+Use `on:select`, `on:toggle`, `on:check`, and `on:focus` for user-driven selection, expansion, checking, and focus. Each detail is the affected node after the gesture, with the same shape as the [Custom (slot)](#custom-slot) node. `on:check` fires only in `selectionMode="checkbox"`, when the checkbox itself is toggled; link nodes (which render no checkbox) fire `on:select` instead.
 
-Use `on:toggle:change` and `on:select:change` to track every expansion or selection change from any source, including imperative methods and bound ids. Each detail includes the full set plus `added` and `removed` deltas. Aggregate events skip mount and no-op updates; bulk operations emit one event.
+Use `on:toggle:change`, `on:select:change`, and `on:check:change` to track every expansion, selection, or check change from any source, including imperative methods and bound ids. Each detail includes the full set plus `added` and `removed` deltas (`on:check:change` also includes `indeterminateIds`). Aggregate events skip mount and no-op updates; bulk operations emit one event.
 
 <FileSource src="/framed/TreeView/TreeViewEvents" />
 
 ## Multi-select
 
 Set `multiselect` to allow more than one selected row; `multiselectMode` controls the unit each gesture applies to.
+
+For a selection that persists parent and child state instead of highlighting rows, see [Checkbox](#checkbox).
 
 ### Node
 

--- a/docs/src/pages/framed/TreeView/TreeViewCheckboxCompact.svelte
+++ b/docs/src/pages/framed/TreeView/TreeViewCheckboxCompact.svelte
@@ -33,6 +33,7 @@
 <Stack gap={6}>
   <div>
     <TreeView
+      size="compact"
       selectionMode="checkbox"
       labelText="Cloud Products"
       {nodes}

--- a/docs/src/pages/framed/TreeView/TreeViewCheckboxIndependent.svelte
+++ b/docs/src/pages/framed/TreeView/TreeViewCheckboxIndependent.svelte
@@ -1,7 +1,7 @@
 <script>
   import { Stack, TreeView } from "carbon-components-svelte";
 
-  let checkedIds = [3];
+  let checkedIds = [1, 3];
   let indeterminateIds = [];
   let expandedIds = [1, 2, 7];
   let nodes = [
@@ -34,7 +34,8 @@
   <div>
     <TreeView
       selectionMode="checkbox"
-      labelText="Cloud Products"
+      checkMode="node"
+      labelText="Cloud Products (independent)"
       {nodes}
       bind:checkedIds
       bind:indeterminateIds

--- a/src/TreeView/TreeView.svelte
+++ b/src/TreeView/TreeView.svelte
@@ -169,18 +169,27 @@
    * @property {ReadonlyArray<Id>} selectedIds - The full set of selected node ids after the change
    * @property {Array<Id>} added - Node ids selected since the previous change
    * @property {Array<Id>} removed - Node ids deselected since the previous change
-   * @slot {{ node: Node & { expanded: boolean; leaf: boolean; selected: boolean; } }}
-   * @slot {{ node: Node & { expanded: boolean; leaf: boolean; selected: boolean; } }} childNodes
+   * @typedef {object} TreeViewCheckChange<Id=(string|number)>
+   * @property {ReadonlyArray<Id>} checkedIds - The full set of checked node ids after the change
+   * @property {Array<Id>} added - Node ids checked since the previous change
+   * @property {Array<Id>} removed - Node ids unchecked since the previous change
+   * @property {ReadonlyArray<Id>} indeterminateIds - The partially checked node ids after the change
+   * @slot {{ node: Node & { expanded: boolean; leaf: boolean; selected: boolean; checked: boolean; indeterminate: boolean; } }}
+   * @slot {{ node: Node & { expanded: boolean; leaf: boolean; selected: boolean; checked: boolean; indeterminate: boolean; } }} childNodes
    * @event select
-   * @type {Node & { expanded: boolean; leaf: boolean; selected: boolean }}
+   * @type {Node & { expanded: boolean; leaf: boolean; selected: boolean; checked: boolean; indeterminate: boolean }}
    * @event toggle
-   * @type {Node & { expanded: boolean; leaf: boolean; selected: boolean }}
+   * @type {Node & { expanded: boolean; leaf: boolean; selected: boolean; checked: boolean; indeterminate: boolean }}
    * @event toggle:change
    * @type {TreeViewExpandedChange<Node["id"]>}
    * @event focus
-   * @type {Node & { expanded: boolean; leaf: boolean; selected: boolean }}
+   * @type {Node & { expanded: boolean; leaf: boolean; selected: boolean; checked: boolean; indeterminate: boolean }}
    * @event select:change
    * @type {TreeViewSelectionChange<Node["id"]>}
+   * @event check
+   * @type {Node & { expanded: boolean; leaf: boolean; selected: boolean; checked: boolean; indeterminate: boolean }}
+   * @event check:change
+   * @type {TreeViewCheckChange<Node["id"]>}
    */
 
   /**
@@ -243,6 +252,39 @@
    * @type {'node' | 'shallow' | 'deep'}
    */
   export let multiselectMode = "node";
+
+  /**
+   * Specify how a selection is presented.
+   * `"checkbox"` renders a tri-state checkbox on every node and implies
+   * multi-selection; `multiselect` and `multiselectMode` are ignored in that mode.
+   * @type {"highlight" | "checkbox"}
+   */
+  export let selectionMode = "highlight";
+
+  /**
+   * In `selectionMode="checkbox"`, `checkMode` controls how far a check propagates:
+   * - `'node'`: only the clicked node; parents and children never follow each other
+   * - `'deep'`: the node plus all non-disabled descendants, with ancestors deriving
+   *   an indeterminate state (default)
+   * @type {'node' | 'deep'}
+   */
+  export let checkMode = "deep";
+
+  /**
+   * The node ids that are checked in `selectionMode="checkbox"`. Distinct from
+   * `selectedIds`, which tracks row highlighting and is unused in checkbox mode.
+   * @type {ReadonlyArray<Node["id"]>}
+   * @bindable writable
+   */
+  export let checkedIds = [];
+
+  /**
+   * The node ids that are partially checked in `selectionMode="checkbox"`.
+   * Derived from `checkedIds`; writes to this prop are overwritten.
+   * @type {ReadonlyArray<Node["id"]>}
+   * @bindable readonly
+   */
+  export let indeterminateIds = [];
 
   /**
    * Programmatically expand all nodes
@@ -363,7 +405,11 @@
         if (select) {
           activeId = lastId;
           const targetNode = path[path.length - 1];
-          if (multiselect && multiselectMode !== "node") {
+          if (selectionMode === "checkbox") {
+            checkedIds = toggleCheckboxNode(nodes, checkedIds, lastId, true, {
+              cascade: checkMode !== "node",
+            });
+          } else if (isMultiselect && multiselectMode !== "node") {
             setSelectedIds(
               multiselectExpansionIds(targetNode, multiselectMode),
             );
@@ -422,6 +468,10 @@
     tick,
   } from "svelte";
   import { writable } from "svelte/store";
+  import {
+    resolveCheckboxState,
+    toggleCheckboxNode,
+  } from "../utils/treeCheckboxState.js";
   import TreeViewNodeList from "./TreeViewNodeList.svelte";
 
   const dispatch = createEventDispatcher();
@@ -430,6 +480,8 @@
 
   /** @type {import("svelte/store").Writable<boolean>} */
   const multiselectStore = writable(multiselect);
+  /** @type {import("svelte/store").Writable<"highlight" | "checkbox">} */
+  const selectionModeStore = writable(selectionMode);
 
   /** @type {import("svelte/store").Writable<Node["id"]>} */
   const activeNodeId = writable(activeId);
@@ -440,17 +492,25 @@
   /** @type {import("svelte/store").Writable<Set<Node["id"]>>} */
   const selectedIdsSetStore = writable(new Set(selectedIds));
   /** @type {import("svelte/store").Writable<Set<Node["id"]>>} */
+  const checkedIdsSetStore = writable(new Set(checkedIds));
+  /** @type {import("svelte/store").Writable<Set<Node["id"]>>} */
   const expandedIdsSetStore = writable(new Set(expandedIds));
+  /** @type {import("svelte/store").Writable<Set<Node["id"]>>} */
+  const indeterminateIdsSetStore = writable(new Set(indeterminateIds));
 
   /** @type {HTMLElement | null} */
   let ref = null;
+
+  $: isCheckboxMode = selectionMode === "checkbox";
+  // Checkbox mode is already multi-select; ignore highlight multiselect.
+  $: isMultiselect = multiselect && !isCheckboxMode;
 
   /** While true (Ctrl/Cmd/Shift held), node labels use user-select: none for multiselect clicks. */
   let multiselectModifierActive = false;
 
   /** @param {KeyboardEvent} e */
   function syncModifierFromKeyboard(event) {
-    if (!multiselect) return;
+    if (!isMultiselect) return;
     multiselectModifierActive =
       event.ctrlKey || event.metaKey || event.shiftKey;
   }
@@ -461,14 +521,14 @@
 
   /** @param {MouseEvent} e */
   function syncModifierFromTreeMouseDown(event) {
-    if (!multiselect) return;
+    if (!isMultiselect) return;
     multiselectModifierActive =
       event.ctrlKey || event.metaKey || event.shiftKey;
   }
 
   /** @param {Event} e */
   function handleMultiselectSelectStart(event) {
-    if (multiselect && multiselectModifierActive) {
+    if (isMultiselect && multiselectModifierActive) {
       event.preventDefault();
     }
   }
@@ -502,7 +562,7 @@
     }
   }
 
-  $: setMultiselectKeyListeners(multiselect);
+  $: setMultiselectKeyListeners(isMultiselect);
 
   /** @type {TreeWalker | null} */
   let treeWalker = null;
@@ -564,17 +624,20 @@
   }
 
   /**
-   * Re-derive the `expanded`/`selected` flags from the source-of-truth state
-   * at dispatch time. The `node` object passed by the child components is
-   * computed reactively, so its flags still reflect the pre-action state when a
-   * handler mutates `selectedIds`/`expandedIds` and then dispatches synchronously.
-   * @type {(node: Node) => Node & { expanded: boolean; selected: boolean }}
+   * Re-derive the `expanded`/`selected`/`checked`/`indeterminate` flags from
+   * the source-of-truth state at dispatch time. The `node` object passed by
+   * the child components is computed reactively, so its flags still reflect
+   * the pre-action state when a handler mutates
+   * `selectedIds`/`checkedIds`/`expandedIds` and then dispatches synchronously.
+   * @type {(node: Node) => Node & { expanded: boolean; selected: boolean; checked: boolean; indeterminate: boolean }}
    */
   function withLiveState(node) {
     return {
       ...node,
       expanded: expandedIdsSet.has(node.id),
       selected: selectedIdsSet.has(node.id),
+      checked: checkedIds.includes(node.id),
+      indeterminate: indeterminateIds.includes(node.id),
     };
   }
 
@@ -596,10 +659,45 @@
   function clickNode(node, event) {
     activeId = node.id;
 
-    const mode =
-      multiselect && multiselectMode !== "node" ? multiselectMode : "node";
+    // Link nodes have no checkbox; they fire `select` like highlight mode.
+    if (selectionMode === "checkbox") {
+      if (node.href !== undefined) {
+        dispatch("select", withLiveState(node));
+        return;
+      }
 
-    if (multiselect && event) {
+      // The checkbox label synthesizes a second click on the hidden input
+      // with `detail: 0`. Real pointer clicks have `detail >= 1`, so skip
+      // the forwarded one to avoid toggling twice.
+      const isForwardedLabelClick =
+        event?.target instanceof HTMLInputElement && event.detail === 0;
+
+      if (isForwardedLabelClick) return;
+
+      // Enter/Space always toggles. Pointer clicks only toggle when they
+      // hit the checkbox, not the rest of the row.
+      const isKeyboardActivation = event?.type === "keydown";
+      const clickedCheckbox =
+        isKeyboardActivation ||
+        event?.target?.closest?.(".bx--checkbox-wrapper") != null;
+
+      if (!clickedCheckbox) return;
+
+      checkedIds = toggleCheckboxNode(
+        nodes,
+        checkedIds,
+        node.id,
+        !checkedIds.includes(node.id),
+        { cascade: checkMode !== "node" },
+      );
+      dispatch("check", withLiveState(node));
+      return;
+    }
+
+    const mode =
+      isMultiselect && multiselectMode !== "node" ? multiselectMode : "node";
+
+    if (isMultiselect && event) {
       const isMeta =
         /** @type {MouseEvent | KeyboardEvent} */ (event).metaKey ||
         /** @type {MouseEvent | KeyboardEvent} */ (event).ctrlKey;
@@ -661,7 +759,10 @@
 
   /** @type {(node: Node) => void} */
   function selectNode(node) {
-    if (multiselect) {
+    // Focus movement must not check the node in checkbox mode.
+    if (selectionMode === "checkbox") return;
+
+    if (isMultiselect) {
       const mode = multiselectMode === "node" ? "node" : multiselectMode;
       const expansion = multiselectExpansionIds(node, mode);
       const set = new Set(selectedIds);
@@ -705,8 +806,11 @@
     selectedNodeIds,
     expandedNodeIds,
     selectedIdsSetStore,
+    checkedIdsSetStore,
     expandedIdsSetStore,
+    indeterminateIdsSetStore,
     multiselectStore,
+    selectionModeStore,
     clickNode,
     selectNode,
     expandNode,
@@ -837,7 +941,7 @@
 
       if (isHomeOrEnd) {
         if (
-          multiselect &&
+          isMultiselect &&
           event.shiftKey &&
           event.ctrlKey &&
           treeItem instanceof HTMLElement
@@ -852,7 +956,7 @@
         ) {
           nextFocusNode = treeWalker.currentNode;
           if (
-            multiselect &&
+            isMultiselect &&
             event.shiftKey &&
             event.ctrlKey &&
             nextFocusNode instanceof Element
@@ -956,9 +1060,63 @@
     cachedChildIdsByParentId = childIdsByParentId;
   }
 
-  $: multiselectStore.set(multiselect);
+  $: multiselectStore.set(isMultiselect);
+  $: selectionModeStore.set(selectionMode);
   $: flattenedNodes = cachedFlattenedNodes ?? [];
   $: nodeIds = cachedNodeIds ?? [];
+
+  /** @type {ReadonlyArray<Node["id"]>} */
+  let lastIndeterminateIdsPushed = indeterminateIds;
+  /** @type {ReadonlyArray<Node["id"]>} */
+  let lastCheckedIdsPushed = checkedIds;
+
+  // Depend on `cachedNodes` so this runs after the cache refresh, and write
+  // `checkedIds` so the sync block below sees the settled state.
+  $: {
+    if (selectionMode === "checkbox") {
+      const checkboxState = resolveCheckboxState(
+        cachedNodes ?? nodes,
+        checkedIds,
+        {
+          cascade: checkMode !== "node",
+        },
+      );
+      if (!arrayIdsEqual(checkboxState.checkedIds, checkedIds)) {
+        checkedIds = checkboxState.checkedIds;
+      }
+      if (!arrayIdsEqual(checkboxState.indeterminateIds, indeterminateIds)) {
+        indeterminateIds = checkboxState.indeterminateIds;
+      }
+    } else if (indeterminateIds.length > 0) {
+      indeterminateIds = [];
+    }
+
+    if (!arrayIdsEqual(indeterminateIds, lastIndeterminateIdsPushed)) {
+      lastIndeterminateIdsPushed = indeterminateIds;
+      indeterminateIdsSetStore.set(new Set(indeterminateIds));
+    }
+
+    if (!arrayIdsEqual(checkedIds, lastCheckedIdsPushed)) {
+      const prevCheckedIds = lastCheckedIdsPushed;
+      lastCheckedIdsPushed = checkedIds;
+      checkedIdsSetStore.set(new Set(checkedIds));
+
+      const nextCheckedIds = checkedIds.slice();
+      const nextIndeterminateIds = indeterminateIds.slice();
+      const prevSet = new Set(prevCheckedIds);
+      const nextSet = new Set(nextCheckedIds);
+      const added = nextCheckedIds.filter((id) => !prevSet.has(id));
+      const removed = prevCheckedIds.filter((id) => !nextSet.has(id));
+      tick().then(() => {
+        dispatch("check:change", {
+          checkedIds: nextCheckedIds,
+          added,
+          removed,
+          indeterminateIds: nextIndeterminateIds,
+        });
+      });
+    }
+  }
 
   let prevActiveIdForAutoCollapse = activeId;
 
@@ -1060,11 +1218,13 @@
   class:bx--tree={true}
   class:bx--tree--default={size === "default"}
   class:bx--tree--compact={size === "compact"}
-  class:bx--tree--multiselect={multiselect}
-  class:bx--tree--multiselect-modifier={multiselect && multiselectModifierActive}
+  class:bx--tree--multiselect={isMultiselect}
+  class:bx--tree--checkbox={isCheckboxMode}
+  class:bx--tree--multiselect-modifier={isMultiselect &&
+    multiselectModifierActive}
   aria-label={hideLabel ? labelText : undefined}
   aria-labelledby={hideLabel ? undefined : labelId}
-  aria-multiselectable={multiselect || undefined}
+  aria-multiselectable={isMultiselect || isCheckboxMode || undefined}
   on:mousedown|capture={syncModifierFromTreeMouseDown}
   on:selectstart|capture={handleMultiselectSelectStart}
   on:keydown

--- a/src/TreeView/TreeViewNode.svelte
+++ b/src/TreeView/TreeViewNode.svelte
@@ -58,7 +58,7 @@
   /**
    * @generics {Node extends TreeNode<any> = TreeNode<any>, Icon = any} Node,Icon
    * @typedef {import('./TreeView.svelte').TreeNode<Id>} TreeNode<Id=(string|number)>
-   * @slot {{ node: Node & { expanded: false; leaf: boolean; selected: boolean; } }}
+   * @slot {{ node: Node & { expanded: false; leaf: boolean; selected: boolean; checked: boolean; indeterminate: boolean; } }}
    */
 
   export let leaf = false;
@@ -94,6 +94,7 @@
   export let icon = /** @type {Icon} */ (undefined);
 
   import { getContext } from "svelte";
+  import Checkbox from "../Checkbox/Checkbox.svelte";
 
   let ref = null;
   let refLabel = null;
@@ -102,15 +103,37 @@
   const {
     activeNodeId,
     selectedIdsSetStore,
+    checkedIdsSetStore,
+    indeterminateIdsSetStore,
+    selectionModeStore,
     clickNode,
     selectNode,
     focusNode,
   } = getContext("carbon:TreeView");
+
+  /**
+   * Tri-state value for `aria-checked` on the row.
+   * @returns {"true" | "false" | "mixed"}
+   */
+  function toAriaChecked(isSelected, isIndeterminate) {
+    if (isIndeterminate) return "mixed";
+    return isSelected ? "true" : "false";
+  }
+
   function offset() {
-    return computeTreeLeafDepth(refLabel) - 1 + (leaf && icon ? 2 : 2.5);
+    const depth = computeTreeLeafDepth(refLabel) - 1;
+    // Checkbox is the leading element; use one inset per depth. The
+    // leaf/icon offsets below align text with a parent's caret and would
+    // shift the checkboxes instead.
+    if (isCheckboxMode) return depth + 1;
+    return depth + (leaf && icon ? 2 : 2.5);
   }
 
   $: selected = $selectedIdsSetStore.has(id);
+  $: checked = $checkedIdsSetStore.has(id);
+  // Link rows navigate; they render no checkbox.
+  $: isCheckboxMode = $selectionModeStore === "checkbox" && href === undefined;
+  $: indeterminate = isCheckboxMode && $indeterminateIdsSetStore.has(id);
   // Merge all props (including custom properties) with computed properties
   // Explicitly include disabled to ensure it's always present (has default value)
   // `level`/`posinset`/`setsize` are layout-only (drive `aria-*` attributes) and excluded from `node`.
@@ -126,6 +149,8 @@
     expanded: false, // A node cannot be expanded.
     leaf,
     selected,
+    checked,
+    indeterminate,
   };
   $: {
     if (
@@ -217,7 +242,10 @@
     {id}
     tabindex={disabled ? undefined : -1}
     aria-current={id === $activeNodeId || undefined}
-    aria-selected={disabled ? undefined : selected}
+    aria-selected={isCheckboxMode || disabled ? undefined : selected}
+    aria-checked={isCheckboxMode
+      ? toAriaChecked(checked, indeterminate)
+      : undefined}
     aria-disabled={disabled}
     aria-level={level}
     aria-posinset={posinset}
@@ -225,11 +253,14 @@
     class:bx--tree-node={true}
     class:bx--tree-leaf-node={true}
     class:bx--tree-node--active={id === $activeNodeId}
-    class:bx--tree-node--selected={selected}
+    class:bx--tree-node--selected={isCheckboxMode ? checked : selected}
     class:bx--tree-node--disabled={disabled}
     class:bx--tree-node--with-icon={icon}
     on:click|stopPropagation={(event) => {
       if (disabled) return;
+      // Stop the label from toggling the decorative input; `clickNode`
+      // owns checked state.
+      if (isCheckboxMode) event.preventDefault();
       clickNode(node, event);
     }}
     on:keydown={(event) => {
@@ -267,6 +298,17 @@
     }}
   >
     <div bind:this={refLabel} class:bx--tree-node__label={true}>
+      {#if isCheckboxMode}
+        <!-- Decorative input; empty label keeps row textContent stable for type-ahead. -->
+        <Checkbox
+          decorative
+          hideLabel
+          labelText=""
+          {disabled}
+          {indeterminate}
+          {checked}
+        />
+      {/if}
       <svelte:component this={icon} class="bx--tree-node__icon" />
       <slot {node}> {text} </slot>
     </div>

--- a/src/TreeView/TreeViewNodeList.svelte
+++ b/src/TreeView/TreeViewNodeList.svelte
@@ -2,8 +2,8 @@
   /**
    * @generics {Id extends string | number = string | number, Icon = any} Id,Icon
    * @typedef {{ id: Id; text: string; disabled?: boolean; expanded?: boolean; }} TreeNode<Id>
-   * @slot {{ node: TreeNode<Id> & { expanded: boolean; leaf: boolean; selected: boolean; } }}
-   * @slot {{ node: TreeNode<Id> & { expanded: boolean; leaf: boolean; selected: boolean; } }} childNodes
+   * @slot {{ node: TreeNode<Id> & { expanded: boolean; leaf: boolean; selected: boolean; checked: boolean; indeterminate: boolean; } }}
+   * @slot {{ node: TreeNode<Id> & { expanded: boolean; leaf: boolean; selected: boolean; checked: boolean; indeterminate: boolean; } }} childNodes
    */
 
   /** @type {ReadonlyArray<TreeNode<Id> & { nodes?: TreeNode<Id>[] }>} */
@@ -32,6 +32,7 @@
   export let icon = /** @type {Icon} */ (undefined);
 
   import { getContext } from "svelte";
+  import Checkbox from "../Checkbox/Checkbox.svelte";
   import CaretDown from "../icons/CaretDown.svelte";
   import TreeViewNode, {
     computeTreeLeafDepth,
@@ -63,7 +64,10 @@
     treeId,
     activeNodeId,
     selectedIdsSetStore,
+    checkedIdsSetStore,
     expandedIdsSetStore,
+    indeterminateIdsSetStore,
+    selectionModeStore,
     clickNode,
     selectNode,
     expandNode,
@@ -71,9 +75,22 @@
     toggleNode,
   } = getContext("carbon:TreeView");
 
+  /**
+   * Tri-state value for `aria-checked` on the row.
+   * @returns {"true" | "false" | "mixed"}
+   */
+  function toAriaChecked(isSelected, isIndeterminate) {
+    if (isIndeterminate) return "mixed";
+    return isSelected ? "true" : "false";
+  }
+
   function offset() {
     const depth = computeTreeLeafDepth(refLabel) - 1;
 
+    // Checkbox is the leading element; use one inset per depth. The
+    // leaf/icon offsets below align text with a parent's caret and would
+    // shift the checkboxes instead.
+    if (isCheckboxMode) return depth + 1;
     if (parent) return depth + 1;
     if (icon) return depth + 2;
     return depth + 2.5;
@@ -82,6 +99,9 @@
   $: parent = Array.isArray(nodes);
   $: expanded = $expandedIdsSetStore.has(id);
   $: selected = $selectedIdsSetStore.has(id);
+  $: checked = $checkedIdsSetStore.has(id);
+  $: isCheckboxMode = $selectionModeStore === "checkbox";
+  $: indeterminate = isCheckboxMode && $indeterminateIdsSetStore.has(id);
   // Merge all props (including custom properties) with computed properties
   // Explicitly reference text and disabled to avoid Svelte warning and ensure they're included
   // `level`/`posinset`/`setsize` are layout-only (drive `aria-*` attributes) and excluded from `node`.
@@ -99,6 +119,8 @@
     expanded,
     leaf: !parent,
     selected,
+    checked,
+    indeterminate,
   };
   $: {
     // The root list is a non-selectable wrapper; its default empty `id` would
@@ -155,12 +177,15 @@
     {id}
     tabindex={disabled ? undefined : -1}
     aria-current={id === $activeNodeId || undefined}
-    aria-selected={disabled ? undefined : selected}
+    aria-selected={isCheckboxMode || disabled ? undefined : selected}
+    aria-checked={isCheckboxMode
+      ? toAriaChecked(checked, indeterminate)
+      : undefined}
     aria-disabled={disabled}
     class:bx--tree-node={true}
     class:bx--tree-parent-node={true}
     class:bx--tree-node--active={id === $activeNodeId}
-    class:bx--tree-node--selected={selected}
+    class:bx--tree-node--selected={isCheckboxMode ? checked : selected}
     class:bx--tree-node--disabled={disabled}
     class:bx--tree-node--with-icon={icon}
     aria-expanded={expanded}
@@ -170,6 +195,9 @@
     aria-setsize={setsize}
     on:click|stopPropagation={(event) => {
       if (disabled) return;
+      // Stop the label from toggling the decorative input; `clickNode`
+      // owns checked state.
+      if (isCheckboxMode) event.preventDefault();
       clickNode(node, event);
     }}
     on:keydown={(event) => {
@@ -231,6 +259,17 @@
     }}
   >
     <div class:bx--tree-node__label={true} bind:this={refLabel}>
+      {#if isCheckboxMode}
+        <!-- Decorative input; empty label keeps row textContent stable for type-ahead. -->
+        <Checkbox
+          decorative
+          hideLabel
+          labelText=""
+          {disabled}
+          {indeterminate}
+          {checked}
+        />
+      {/if}
       <!-- svelte-ignore a11y-click-events-have-key-events -->
       <!-- svelte-ignore a11y-no-static-element-interactions -->
       <span

--- a/src/index.js
+++ b/src/index.js
@@ -241,3 +241,7 @@ export {
 } from "./utils/filterTreeNodes";
 export { fuzzyMatch, highlightSegments } from "./utils/fuzzyMatch";
 export { toHierarchy } from "./utils/toHierarchy";
+export {
+  resolveCheckboxState,
+  toggleCheckboxNode,
+} from "./utils/treeCheckboxState";

--- a/src/utils/treeCheckboxState.d.ts
+++ b/src/utils/treeCheckboxState.d.ts
@@ -1,0 +1,39 @@
+type NodeLike = {
+  id: string | number;
+  disabled?: boolean;
+  nodes?: NodeLike[];
+  [key: string]: unknown;
+};
+
+type TreeCheckboxOptions = {
+  /**
+   * Propagate checks to descendants and derive ancestor state.
+   * @default true
+   */
+  cascade?: boolean;
+};
+
+type TreeCheckboxState<Id extends string | number> = {
+  checkedIds: Id[];
+  indeterminateIds: Id[];
+};
+
+/** Derive the checked and indeterminate ids of a tree from a set of checked ids. */
+export function resolveCheckboxState<T extends NodeLike>(
+  nodes: readonly T[],
+  checkedIds: readonly T["id"][],
+  options?: TreeCheckboxOptions,
+): TreeCheckboxState<T["id"]>;
+
+/**
+ * Next seed of checked ids after toggling one node.
+ * Pass through `resolveCheckboxState` before use; this does not derive
+ * ancestor checked or indeterminate state.
+ */
+export function toggleCheckboxNode<T extends NodeLike>(
+  nodes: readonly T[],
+  checkedIds: readonly T["id"][],
+  id: T["id"],
+  checked: boolean,
+  options?: TreeCheckboxOptions,
+): T["id"][];

--- a/src/utils/treeCheckboxState.js
+++ b/src/utils/treeCheckboxState.js
@@ -1,0 +1,248 @@
+// @ts-check
+/**
+ * @typedef {string | number} TreeCheckboxNodeId
+ */
+
+/**
+ * @typedef {Object} TreeCheckboxNode
+ * @property {TreeCheckboxNodeId} id
+ * @property {boolean} [disabled]
+ * @property {TreeCheckboxNode[]} [nodes]
+ */
+
+/**
+ * @typedef {Object} TreeCheckboxOptions
+ * @property {boolean} [cascade] - Propagate checks to descendants and derive ancestor state
+ */
+
+/**
+ * @typedef {Object} TreeCheckboxState
+ * @property {Array<TreeCheckboxNodeId>} checkedIds
+ * @property {Array<TreeCheckboxNodeId>} indeterminateIds
+ */
+
+/**
+ * Visit every node in document (depth-first, pre-order) order.
+ * @param {ReadonlyArray<TreeCheckboxNode>} nodes
+ * @param {(node: TreeCheckboxNode) => void} visitor
+ * @returns {void}
+ */
+function visit(nodes, visitor) {
+  for (const node of nodes) {
+    visitor(node);
+    if (Array.isArray(node.nodes)) visit(node.nodes, visitor);
+  }
+}
+
+/**
+ * Ids of `node` and every non-disabled descendant. A disabled node prunes its
+ * whole subtree, matching how a disabled node blocks multiselect expansion.
+ * @param {TreeCheckboxNode} node
+ * @returns {Array<TreeCheckboxNodeId>}
+ */
+function cascadableIds(node) {
+  /** @type {Array<TreeCheckboxNodeId>} */
+  const ids = [];
+
+  /** @param {TreeCheckboxNode} current */
+  function walk(current) {
+    if (current.disabled) return;
+    ids.push(current.id);
+    if (!Array.isArray(current.nodes)) return;
+    for (const child of current.nodes) walk(child);
+  }
+
+  walk(node);
+  return ids;
+}
+
+/**
+ * Ids of `node` and every descendant, disabled ones included.
+ * @param {TreeCheckboxNode} node
+ * @returns {Array<TreeCheckboxNodeId>}
+ */
+function subtreeIds(node) {
+  /** @type {Array<TreeCheckboxNodeId>} */
+  const ids = [];
+  visit([node], (current) => ids.push(current.id));
+  return ids;
+}
+
+/**
+ * Nodes from a root down to the node matching `id`, or `null` if no node matches.
+ * @param {ReadonlyArray<TreeCheckboxNode>} nodes
+ * @param {TreeCheckboxNodeId} id
+ * @returns {Array<TreeCheckboxNode> | null}
+ */
+function findPath(nodes, id) {
+  for (const node of nodes) {
+    if (node.id === id) return [node];
+    if (!Array.isArray(node.nodes)) continue;
+    const path = findPath(node.nodes, id);
+    if (path) {
+      path.unshift(node);
+      return path;
+    }
+  }
+  return null;
+}
+
+/**
+ * Ids the consumer set, minus duplicates and ids with no matching node.
+ * @param {ReadonlyArray<TreeCheckboxNode>} nodes
+ * @param {ReadonlyArray<TreeCheckboxNodeId>} checkedIds
+ * @returns {Array<TreeCheckboxNodeId>}
+ */
+function retainKnownIds(nodes, checkedIds) {
+  /** @type {Set<TreeCheckboxNodeId>} */
+  const knownIds = new Set();
+  visit(nodes, (node) => knownIds.add(node.id));
+
+  /** @type {Array<TreeCheckboxNodeId>} */
+  const retained = [];
+  /** @type {Set<TreeCheckboxNodeId>} */
+  const seen = new Set();
+  for (const id of checkedIds) {
+    if (knownIds.has(id) && !seen.has(id)) {
+      seen.add(id);
+      retained.push(id);
+    }
+  }
+  return retained;
+}
+
+/**
+ * Derive the full check state of a tree from a set of checked ids.
+ *
+ * With `cascade`, a checked node checks every non-disabled descendant, a node
+ * is checked when all of its cascadable children are, and indeterminate when
+ * only some are. Disabled nodes and their subtrees are excluded from the result
+ * and from their ancestors' state. Ids with no matching node are dropped.
+ *
+ * With `cascade: false`, the checked set is passed through untouched and nothing
+ * is indeterminate.
+ * @param {ReadonlyArray<TreeCheckboxNode>} nodes
+ * @param {ReadonlyArray<TreeCheckboxNodeId>} checkedIds
+ * @param {TreeCheckboxOptions} [options]
+ * @returns {TreeCheckboxState} Checked and indeterminate ids, in document order
+ */
+export function resolveCheckboxState(nodes, checkedIds, options = {}) {
+  const { cascade = true } = options;
+
+  if (!cascade) {
+    return {
+      checkedIds: retainKnownIds(nodes, checkedIds),
+      indeterminateIds: [],
+    };
+  }
+
+  const seed = new Set(checkedIds);
+  /** @type {Set<TreeCheckboxNodeId>} */
+  const checked = new Set();
+  /** @type {Set<TreeCheckboxNodeId>} */
+  const indeterminate = new Set();
+
+  /**
+   * @param {TreeCheckboxNode} node
+   * @param {boolean} inherited - Whether an ancestor cascaded a check down to `node`
+   * @returns {{ checked: boolean; indeterminate: boolean } | null} `null` when the node is pruned
+   */
+  function walk(node, inherited) {
+    if (node.disabled) return null;
+
+    const isChecked = inherited || seed.has(node.id);
+    const children = Array.isArray(node.nodes) ? node.nodes : [];
+    /** @type {Array<{ checked: boolean; indeterminate: boolean }>} */
+    const results = [];
+
+    for (const child of children) {
+      const result = walk(child, isChecked);
+      if (result) results.push(result);
+    }
+
+    // A node with no cascadable children resolves on its own, so a parent
+    // whose children are all disabled behaves like a leaf.
+    if (results.length === 0) {
+      if (isChecked) checked.add(node.id);
+      return { checked: isChecked, indeterminate: false };
+    }
+
+    if (results.every((result) => result.checked)) {
+      checked.add(node.id);
+      return { checked: true, indeterminate: false };
+    }
+
+    if (results.some((result) => result.checked || result.indeterminate)) {
+      indeterminate.add(node.id);
+      return { checked: false, indeterminate: true };
+    }
+
+    return { checked: false, indeterminate: false };
+  }
+
+  for (const node of nodes) walk(node, false);
+
+  /** @type {Array<TreeCheckboxNodeId>} */
+  const nextCheckedIds = [];
+  /** @type {Array<TreeCheckboxNodeId>} */
+  const nextIndeterminateIds = [];
+  visit(nodes, (node) => {
+    if (checked.has(node.id)) nextCheckedIds.push(node.id);
+    if (indeterminate.has(node.id)) nextIndeterminateIds.push(node.id);
+  });
+
+  return {
+    checkedIds: nextCheckedIds,
+    indeterminateIds: nextIndeterminateIds,
+  };
+}
+
+/**
+ * Next seed of checked ids after toggling one node.
+ * Does not derive ancestor checked/indeterminate state; pass the result
+ * through `resolveCheckboxState` first. TreeView does that on every
+ * `checkedIds` change.
+ *
+ * With `cascade`, checking adds non-disabled descendants and unchecking
+ * clears the subtree plus ancestors so resolve can mark them indeterminate.
+ * Without cascade, only `id` changes.
+ * @param {ReadonlyArray<TreeCheckboxNode>} nodes
+ * @param {ReadonlyArray<TreeCheckboxNodeId>} checkedIds
+ * @param {TreeCheckboxNodeId} id - The node the user checked or unchecked
+ * @param {boolean} checked - The node's state after the gesture
+ * @param {TreeCheckboxOptions} [options]
+ * @returns {Array<TreeCheckboxNodeId>}
+ */
+export function toggleCheckboxNode(
+  nodes,
+  checkedIds,
+  id,
+  checked,
+  options = {},
+) {
+  const { cascade = true } = options;
+  const next = new Set(checkedIds);
+
+  if (!cascade) {
+    if (checked) {
+      next.add(id);
+    } else {
+      next.delete(id);
+    }
+    return Array.from(next);
+  }
+
+  const path = findPath(nodes, id);
+  const node = path?.[path.length - 1];
+
+  if (node && !node.disabled) {
+    if (checked) {
+      for (const descendantId of cascadableIds(node)) next.add(descendantId);
+    } else {
+      for (const descendantId of subtreeIds(node)) next.delete(descendantId);
+      for (const ancestor of path.slice(0, -1)) next.delete(ancestor.id);
+    }
+  }
+
+  return Array.from(next);
+}

--- a/tests/TreeView/TreeView.checkbox.test.svelte
+++ b/tests/TreeView/TreeView.checkbox.test.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+  import type { TreeNode } from "carbon-components-svelte/TreeView/TreeView.svelte";
+  import TreeView from "carbon-components-svelte/TreeView/TreeView.svelte";
+  import type { ComponentProps } from "svelte";
+
+  type Id = TreeNode["id"];
+
+  export let selectionMode: ComponentProps<TreeView>["selectionMode"] =
+    "checkbox";
+  export let checkMode: ComponentProps<TreeView>["checkMode"] = "deep";
+  export let multiselect: ComponentProps<TreeView>["multiselect"] = false;
+  export let checkedIds: Id[] = [];
+  export let indeterminateIds: ReadonlyArray<Id> = [];
+  /** Spy for the aggregate `check:change` event. */
+  export let onCheckChange: (detail: {
+    checkedIds: ReadonlyArray<Id>;
+    added: Id[];
+    removed: Id[];
+    indeterminateIds: ReadonlyArray<Id>;
+  }) => void = () => {};
+
+  export let nodes: ComponentProps<TreeView>["nodes"] = [
+    {
+      id: "analytics",
+      text: "Analytics",
+      nodes: [
+        { id: "spark", text: "Apache Spark" },
+        { id: "hadoop", text: "Hadoop" },
+        { id: "legacy", text: "Legacy warehouse", disabled: true },
+      ],
+    },
+    {
+      id: "blockchain",
+      text: "Blockchain",
+      nodes: [{ id: "platform", text: "IBM Blockchain Platform" }],
+    },
+    { id: "docs", text: "Documentation", href: "/docs" },
+  ];
+</script>
+
+<TreeView
+  labelText="Permissions"
+  {nodes}
+  {selectionMode}
+  {checkMode}
+  {multiselect}
+  expandedIds={["analytics", "blockchain"]}
+  bind:checkedIds
+  bind:indeterminateIds
+  on:check:change={({ detail }) => onCheckChange(detail)}
+/>

--- a/tests/TreeView/TreeView.checkbox.test.ts
+++ b/tests/TreeView/TreeView.checkbox.test.ts
@@ -1,0 +1,125 @@
+import { render } from "@testing-library/svelte";
+import { user } from "../utils/user";
+import TreeViewCheckbox from "./TreeView.checkbox.test.svelte";
+
+// Collapsed subtrees stay mounted, so accessible-name computation in jsdom
+// picks up descendant text. Look rows up by id instead, matching the
+// convention documented in TreeView.lazyLoad.test.ts.
+function treeItemById(id: string): HTMLElement {
+  const el = document.getElementById(id);
+  expect.assert(el instanceof HTMLElement);
+  return el;
+}
+
+// Click the checkbox wrapper; row clicks outside it do not toggle.
+function checkboxFor(id: string): HTMLElement {
+  const el = treeItemById(id).querySelector(".bx--checkbox-wrapper");
+  expect.assert(el instanceof HTMLElement);
+  return el;
+}
+
+// The checkbox label contributes empty text nodes, so compare the words the
+// tree renders rather than the exact whitespace. Type-ahead trims before it
+// matches, so this is the property it depends on.
+function normalizeText(text: string | null): string {
+  return (text ?? "").replace(/\s+/g, " ").trim();
+}
+
+describe("TreeView selectionMode=checkbox", () => {
+  it("checks every descendant when a branch is checked", async () => {
+    render(TreeViewCheckbox);
+
+    await user.click(checkboxFor("analytics"));
+
+    expect(treeItemById("analytics")).toHaveAttribute("aria-checked", "true");
+    expect(treeItemById("spark")).toHaveAttribute("aria-checked", "true");
+    expect(treeItemById("hadoop")).toHaveAttribute("aria-checked", "true");
+    expect(treeItemById("analytics")).not.toHaveAttribute("aria-selected");
+  });
+
+  it("flips the branch to mixed when one child is unchecked", async () => {
+    render(TreeViewCheckbox);
+
+    await user.click(checkboxFor("analytics"));
+    await user.click(checkboxFor("spark"));
+
+    expect(treeItemById("analytics")).toHaveAttribute("aria-checked", "mixed");
+    expect(treeItemById("spark")).toHaveAttribute("aria-checked", "false");
+    expect(treeItemById("hadoop")).toHaveAttribute("aria-checked", "true");
+  });
+
+  it("skips disabled descendants without blocking the branch", async () => {
+    render(TreeViewCheckbox);
+
+    await user.click(checkboxFor("analytics"));
+
+    expect(treeItemById("legacy")).toHaveAttribute("aria-checked", "false");
+    expect(treeItemById("analytics")).toHaveAttribute("aria-checked", "true");
+  });
+
+  it('leaves ancestors untouched with checkMode="node"', async () => {
+    render(TreeViewCheckbox, { checkMode: "node" });
+
+    await user.click(checkboxFor("spark"));
+
+    expect(treeItemById("spark")).toHaveAttribute("aria-checked", "true");
+    expect(treeItemById("hadoop")).toHaveAttribute("aria-checked", "false");
+    expect(treeItemById("analytics")).toHaveAttribute("aria-checked", "false");
+  });
+
+  it("renders no checkbox on a link node", () => {
+    render(TreeViewCheckbox);
+
+    expect(treeItemById("docs").querySelector(".bx--checkbox")).toBeNull();
+    expect(treeItemById("spark").querySelector(".bx--checkbox")).not.toBeNull();
+  });
+
+  it("keeps row text unchanged so type-ahead still matches", async () => {
+    const highlight = render(TreeViewCheckbox, { selectionMode: "highlight" });
+    const highlightText = normalizeText(highlight.container.textContent);
+    highlight.unmount();
+
+    const checkbox = render(TreeViewCheckbox);
+    expect(normalizeText(checkbox.container.textContent)).toBe(highlightText);
+
+    treeItemById("analytics").focus();
+    await user.keyboard("h");
+
+    expect(treeItemById("hadoop")).toHaveFocus();
+  });
+
+  it("ignores multiselect gestures in favor of per-node checks", async () => {
+    render(TreeViewCheckbox, { multiselect: true });
+
+    await user.click(checkboxFor("spark"));
+    await user.click(checkboxFor("hadoop"));
+
+    expect(treeItemById("spark")).toHaveAttribute("aria-checked", "true");
+    expect(treeItemById("hadoop")).toHaveAttribute("aria-checked", "true");
+  });
+
+  it("fires check:change once per gesture with the derived state", async () => {
+    const onCheckChange = vi.fn();
+    render(TreeViewCheckbox, { onCheckChange });
+
+    await user.click(checkboxFor("spark"));
+
+    await vi.waitFor(() => expect(onCheckChange).toHaveBeenCalledTimes(1));
+    expect(onCheckChange).toHaveBeenLastCalledWith({
+      checkedIds: ["spark"],
+      added: ["spark"],
+      removed: [],
+      indeterminateIds: ["analytics"],
+    });
+
+    await user.click(checkboxFor("hadoop"));
+
+    await vi.waitFor(() => expect(onCheckChange).toHaveBeenCalledTimes(2));
+    expect(onCheckChange).toHaveBeenLastCalledWith({
+      checkedIds: ["analytics", "spark", "hadoop"],
+      added: ["analytics", "hadoop"],
+      removed: [],
+      indeterminateIds: [],
+    });
+  });
+});

--- a/tests/TreeView/TreeView.test.ts
+++ b/tests/TreeView/TreeView.test.ts
@@ -86,10 +86,12 @@ describe.each(testCases)("$name", ({ component }) => {
     expect(firstItem).toHaveAttribute("aria-selected", "true");
     expect(consoleLog).toBeCalledWith("selectedIds", [0]);
     expect(consoleLog).toBeCalledWith("select", {
+      checked: false,
       disabled: false,
       expanded: false,
       icon: expect.anything(),
       id: 0,
+      indeterminate: false,
       leaf: true,
       // The `select` payload reflects the post-click state: the node is now selected.
       selected: true,
@@ -1382,7 +1384,13 @@ describe("TreeView Generics", () => {
       type SelectEventDetail =
         SelectEvent extends CustomEvent<infer T> ? T : never;
       expectTypeOf<SelectEventDetail>().toEqualTypeOf<
-        TreeNode & { expanded: boolean; leaf: boolean; selected: boolean }
+        TreeNode & {
+          expanded: boolean;
+          leaf: boolean;
+          selected: boolean;
+          checked: boolean;
+          indeterminate: boolean;
+        }
       >();
     });
 
@@ -1407,7 +1415,13 @@ describe("TreeView Generics", () => {
       type StringSelectDetail =
         StringSelectEvent extends CustomEvent<infer T> ? T : never;
       expectTypeOf<StringSelectDetail>().toEqualTypeOf<
-        StringNode & { expanded: boolean; leaf: boolean; selected: boolean }
+        StringNode & {
+          expanded: boolean;
+          leaf: boolean;
+          selected: boolean;
+          checked: boolean;
+          indeterminate: boolean;
+        }
       >();
 
       // Number ID
@@ -1446,7 +1460,13 @@ describe("TreeView Generics", () => {
       type UnionSelectDetail =
         UnionSelectEvent extends CustomEvent<infer T> ? T : never;
       expectTypeOf<UnionSelectDetail>().toEqualTypeOf<
-        UnionNode & { expanded: boolean; leaf: boolean; selected: boolean }
+        UnionNode & {
+          expanded: boolean;
+          leaf: boolean;
+          selected: boolean;
+          checked: boolean;
+          indeterminate: boolean;
+        }
       >();
     });
 
@@ -1478,7 +1498,13 @@ describe("TreeView Generics", () => {
       type SelectEventDetail =
         SelectEvent extends CustomEvent<infer T> ? T : never;
       expectTypeOf<SelectEventDetail>().toEqualTypeOf<
-        InferredNode & { expanded: boolean; leaf: boolean; selected: boolean }
+        InferredNode & {
+          expanded: boolean;
+          leaf: boolean;
+          selected: boolean;
+          checked: boolean;
+          indeterminate: boolean;
+        }
       >();
       expectTypeOf<SelectEventDetail["id"]>().toEqualTypeOf<InferredId>();
     });
@@ -1539,7 +1565,13 @@ describe("TreeView Generics", () => {
       type SelectDetail = SelectEvent extends CustomEvent<infer T> ? T : never;
       expectTypeOf<SelectDetail["id"]>().toEqualTypeOf<number>();
       expectTypeOf<SelectDetail>().toEqualTypeOf<
-        CustomNode & { expanded: boolean; leaf: boolean; selected: boolean }
+        CustomNode & {
+          expanded: boolean;
+          leaf: boolean;
+          selected: boolean;
+          checked: boolean;
+          indeterminate: boolean;
+        }
       >();
 
       type ToggleEvent = Events["toggle"];

--- a/tests/utils/treeCheckboxState.test.ts
+++ b/tests/utils/treeCheckboxState.test.ts
@@ -1,0 +1,235 @@
+import {
+  resolveCheckboxState,
+  toggleCheckboxNode,
+} from "../../src/utils/treeCheckboxState.js";
+
+type Node = {
+  id: string;
+  disabled?: boolean;
+  nodes?: Node[];
+};
+
+const tree: Node[] = [
+  {
+    id: "analytics",
+    nodes: [
+      {
+        id: "engine",
+        nodes: [{ id: "spark" }, { id: "hadoop" }],
+      },
+      { id: "sql-query" },
+    ],
+  },
+  {
+    id: "blockchain",
+    nodes: [{ id: "platform" }],
+  },
+];
+
+describe("resolveCheckboxState", () => {
+  test("checks every descendant of a selected branch", () => {
+    expect(resolveCheckboxState(tree, ["analytics"])).toEqual({
+      checkedIds: ["analytics", "engine", "spark", "hadoop", "sql-query"],
+      indeterminateIds: [],
+    });
+  });
+
+  test("marks a partially selected branch indeterminate", () => {
+    expect(resolveCheckboxState(tree, ["spark"])).toEqual({
+      checkedIds: ["spark"],
+      indeterminateIds: ["analytics", "engine"],
+    });
+  });
+
+  test("selects a branch once every child is selected", () => {
+    expect(resolveCheckboxState(tree, ["spark", "hadoop"]).checkedIds).toEqual([
+      "engine",
+      "spark",
+      "hadoop",
+    ]);
+  });
+
+  test("treats a branch with no children as a leaf", () => {
+    const empty: Node[] = [{ id: "branch", nodes: [] }];
+    expect(resolveCheckboxState(empty, ["branch"])).toEqual({
+      checkedIds: ["branch"],
+      indeterminateIds: [],
+    });
+  });
+
+  test("prunes a disabled subtree from the selection", () => {
+    const withDisabled: Node[] = [
+      {
+        id: "root",
+        nodes: [
+          { id: "enabled" },
+          { id: "disabled", disabled: true, nodes: [{ id: "buried" }] },
+        ],
+      },
+    ];
+
+    expect(resolveCheckboxState(withDisabled, ["root"])).toEqual({
+      checkedIds: ["root", "enabled"],
+      indeterminateIds: [],
+    });
+  });
+
+  test("reaches a fully selected branch across mixed disabled siblings", () => {
+    const mixed: Node[] = [
+      {
+        id: "root",
+        nodes: [
+          { id: "one" },
+          { id: "two", disabled: true },
+          { id: "three" },
+          { id: "four", disabled: true },
+        ],
+      },
+    ];
+
+    expect(resolveCheckboxState(mixed, ["one", "three"]).checkedIds).toEqual([
+      "root",
+      "one",
+      "three",
+    ]);
+  });
+
+  test("propagates indeterminate state up a deeply nested tree", () => {
+    const deep: Node[] = [
+      {
+        id: "l1",
+        nodes: [
+          {
+            id: "l2",
+            nodes: [
+              {
+                id: "l3",
+                nodes: [{ id: "l4-a" }, { id: "l4-b" }],
+              },
+            ],
+          },
+        ],
+      },
+    ];
+
+    expect(resolveCheckboxState(deep, ["l4-a"])).toEqual({
+      checkedIds: ["l4-a"],
+      indeterminateIds: ["l1", "l2", "l3"],
+    });
+
+    expect(resolveCheckboxState(deep, ["l4-a", "l4-b"])).toEqual({
+      checkedIds: ["l1", "l2", "l3", "l4-a", "l4-b"],
+      indeterminateIds: [],
+    });
+  });
+
+  test("drops ids with no matching node", () => {
+    expect(resolveCheckboxState(tree, ["spark", "ghost"]).checkedIds).toEqual([
+      "spark",
+    ]);
+    expect(
+      resolveCheckboxState(tree, ["spark", "ghost"], { cascade: false })
+        .checkedIds,
+    ).toEqual(["spark"]);
+  });
+
+  test("returns an empty state for an empty tree", () => {
+    const empty: Node[] = [];
+    expect(resolveCheckboxState(empty, ["spark"])).toEqual({
+      checkedIds: [],
+      indeterminateIds: [],
+    });
+  });
+
+  test("passes the selection through unchanged without cascade", () => {
+    expect(
+      resolveCheckboxState(tree, ["analytics", "spark"], { cascade: false }),
+    ).toEqual({
+      checkedIds: ["analytics", "spark"],
+      indeterminateIds: [],
+    });
+  });
+});
+
+describe("toggleCheckboxNode", () => {
+  // Returns a raw seed. Resolve with `resolveCheckboxState` when the
+  // assertion needs derived ancestor checked/indeterminate state.
+  test("checking a branch checks its descendants", () => {
+    expect(toggleCheckboxNode(tree, [], "engine", true)).toEqual([
+      "engine",
+      "spark",
+      "hadoop",
+    ]);
+  });
+
+  test("unchecking one child leaves its ancestors indeterminate", () => {
+    const checkedIds = toggleCheckboxNode(tree, [], "analytics", true);
+    const next = toggleCheckboxNode(tree, checkedIds, "spark", false);
+
+    expect(next).toEqual(["hadoop", "sql-query"]);
+    expect(resolveCheckboxState(tree, next).indeterminateIds).toEqual([
+      "analytics",
+      "engine",
+    ]);
+  });
+
+  test("unchecking a branch clears its whole subtree", () => {
+    const checkedIds = toggleCheckboxNode(tree, [], "analytics", true);
+    expect(toggleCheckboxNode(tree, checkedIds, "engine", false)).toEqual([
+      "sql-query",
+    ]);
+  });
+
+  test("checking the last sibling selects the parent", () => {
+    const checkedIds = toggleCheckboxNode(tree, [], "spark", true);
+    const next = toggleCheckboxNode(tree, checkedIds, "hadoop", true);
+    expect(resolveCheckboxState(tree, next).checkedIds).toEqual([
+      "engine",
+      "spark",
+      "hadoop",
+    ]);
+  });
+
+  test("skips disabled descendants when checking a branch", () => {
+    const withDisabled: Node[] = [
+      {
+        id: "root",
+        nodes: [
+          { id: "enabled" },
+          { id: "disabled", disabled: true, nodes: [{ id: "buried" }] },
+        ],
+      },
+    ];
+
+    expect(toggleCheckboxNode(withDisabled, [], "root", true)).toEqual([
+      "root",
+      "enabled",
+    ]);
+  });
+
+  test("ignores a disabled node", () => {
+    const withDisabled: Node[] = [
+      { id: "root", nodes: [{ id: "off", disabled: true }] },
+    ];
+    expect(toggleCheckboxNode(withDisabled, [], "off", true)).toEqual([]);
+  });
+
+  test("ignores an id with no matching node", () => {
+    expect(toggleCheckboxNode(tree, ["spark"], "ghost", true)).toEqual([
+      "spark",
+    ]);
+  });
+
+  test("leaves ancestors untouched without cascade", () => {
+    const options = { cascade: false };
+    const checkedIds = toggleCheckboxNode(tree, [], "spark", true, options);
+
+    expect(checkedIds).toEqual(["spark"]);
+    expect(
+      toggleCheckboxNode(tree, checkedIds, "hadoop", true, options),
+    ).toEqual(["spark", "hadoop"]);
+    expect(
+      toggleCheckboxNode(tree, ["analytics"], "analytics", false, options),
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Opt-in selectionMode=checkbox with parent/child conduction and
derived indeterminateIds. conduct={false} decouples parents from
children. Tri-state math lives in a DOM-free util so edge cases
stay unit-testable.