### PR TITLE
feat(menu): add selectable and radio menu items

### DIFF
--- a/docs/src/pages/components/Menu.svx
+++ b/docs/src/pages/components/Menu.svx
@@ -28,7 +28,7 @@ Set `size` to control each item's row height. The default is `"sm"`.
 
 ## Menu items
 
-`MenuItem` takes an `icon`, `kind="danger"` for destructive rows, and nested children for submenus. Use `MenuDivider` between groups.
+`MenuItem` takes an `icon`, `kind="danger"` for destructive rows, and nested children for submenus. Use `MenuDivider` between groups. Items can also hold checkbox or radio state; see [MenuButton selectable](/components/MenuButton#selectable).
 
 ### Icons
 

--- a/docs/src/pages/components/MenuButton.svx
+++ b/docs/src/pages/components/MenuButton.svx
@@ -1,5 +1,5 @@
 ---
-components: ["MenuButton", "MenuItem", "MenuDivider"]
+components: ["MenuButton", "MenuItem", "MenuDivider", "MenuItemGroup", "MenuItemRadioGroup"]
 description: MenuButton is a labeled button that opens a dropdown of actions, including nested submenus.
 ---
 
@@ -181,6 +181,20 @@ Put a `MenuDivider` between groups.
   <MenuDivider />
   <MenuItem kind="danger" on:click={() => console.log("Delete")}>Delete</MenuItem>
 </MenuButton>
+
+### Selectable
+
+Wrap items in `MenuItemGroup` to make them checkboxes that hold state, such as which table columns are visible. Give every item an id, then bind `selectedIds` for the chosen ones. Set `selected` on an item to check it when the menu first opens, or set `selectable` on a single item outside a group for a standalone toggle.
+
+Choosing an item closes the menu. Call `event.preventDefault()` in an item's `on:click` handler to keep it open for a multi-select flow, then update the bound value yourself.
+
+<FileSource src="/framed/MenuButton/MenuButtonSelectable" />
+
+### Radio group
+
+Wrap items in `MenuItemRadioGroup` for a set where one choice is active at a time, such as row density. Bind `selectedId` for the active id; picking another item clears the previous one.
+
+<FileSource src="/framed/MenuButton/MenuButtonRadioGroup" />
 
 ### Nested
 

--- a/docs/src/pages/framed/MenuButton/MenuButtonRadioGroup.svelte
+++ b/docs/src/pages/framed/MenuButton/MenuButtonRadioGroup.svelte
@@ -1,0 +1,25 @@
+<script>
+  import {
+    MenuButton,
+    MenuDivider,
+    MenuItem,
+    MenuItemRadioGroup,
+    Stack,
+  } from "carbon-components-svelte";
+
+  let selectedId = "comfortable";
+</script>
+
+<Stack gap={5}>
+  <MenuButton labelText="View">
+    <MenuItem on:click={() => console.log("Reset")}>Reset</MenuItem>
+    <MenuDivider />
+    <MenuItemRadioGroup labelText="Density" bind:selectedId>
+      <MenuItem id="compact" labelText="Compact" />
+      <MenuItem id="comfortable" labelText="Comfortable" />
+      <MenuItem id="spacious" labelText="Spacious" />
+    </MenuItemRadioGroup>
+  </MenuButton>
+
+  <p>Density: {selectedId}</p>
+</Stack>

--- a/docs/src/pages/framed/MenuButton/MenuButtonSelectable.svelte
+++ b/docs/src/pages/framed/MenuButton/MenuButtonSelectable.svelte
@@ -1,0 +1,24 @@
+<script>
+  import {
+    MenuButton,
+    MenuItem,
+    MenuItemGroup,
+    Stack,
+  } from "carbon-components-svelte";
+
+  let selectedIds = ["name"];
+
+  $: visibleColumns = selectedIds.join(", ") || "None";
+</script>
+
+<Stack gap={5}>
+  <MenuButton labelText="View">
+    <MenuItemGroup labelText="Columns" bind:selectedIds>
+      <MenuItem id="name" labelText="Name" />
+      <MenuItem id="size" labelText="Size" />
+      <MenuItem id="modified" labelText="Last modified" />
+    </MenuItemGroup>
+  </MenuButton>
+
+  <p>Visible columns: {visibleColumns}</p>
+</Stack>

--- a/src/Menu/Menu.svelte
+++ b/src/Menu/Menu.svelte
@@ -95,8 +95,15 @@
   import { isOutsideClick } from "../utils/isOutsideClick.js";
   import { rovingFocus } from "../utils/rovingFocus.js";
 
-  const NON_DISABLED_MENUITEM_SELECTOR =
-    "[role='menuitem']:not([aria-disabled='true'])";
+  // Selectable and radio items carry their own roles, so navigation and
+  // initial focus must match all three.
+  const NON_DISABLED_MENUITEM_SELECTOR = [
+    "menuitem",
+    "menuitemcheckbox",
+    "menuitemradio",
+  ]
+    .map((role) => `[role='${role}']:not([aria-disabled='true'])`)
+    .join(",");
 
   const dispatch = createEventDispatcher();
 

--- a/src/Menu/MenuItem.svelte
+++ b/src/Menu/MenuItem.svelte
@@ -47,6 +47,29 @@
   export let shortcutText = "";
 
   /**
+   * Set to `true` to select the item.
+   * Only applies to a selectable item or one inside
+   * `MenuItemGroup` or `MenuItemRadioGroup`.
+   * @bindable writable
+   */
+  export let selected = false;
+
+  /**
+   * Set to `true` to make the item a standalone checkbox.
+   * Automatically enabled when `selected` is `true` or when the item
+   * is inside `MenuItemGroup`.
+   * @bindable writable
+   */
+  export let selectable = false;
+
+  /**
+   * Specify the id.
+   * It's recommended to provide an id as a value to bind to
+   * within a selectable or radio menu group.
+   */
+  export let id = `ccs-${Math.random().toString(36)}`;
+
+  /**
    * Obtain a reference to the list item HTML element.
    * @bindable readonly
    */
@@ -54,6 +77,7 @@
 
   import { createEventDispatcher, getContext, onMount } from "svelte";
   import CaretRight from "../icons/CaretRight.svelte";
+  import Checkmark from "../icons/Checkmark.svelte";
   import Menu from "./Menu.svelte";
 
   // "moderate-01" duration (ms) from Carbon motion recommended for small
@@ -63,12 +87,27 @@
 
   const dispatch = createEventDispatcher();
   const ctx = getContext("carbon:Menu");
+  const ctxGroup = getContext("carbon:MenuItemGroup");
+  const ctxRadioGroup = getContext("carbon:MenuItemRadioGroup");
 
   let submenuOpen = false;
   let hoverTimeout;
   let closeTimeout;
+  // `selected` implies the checkbox variant. Latch it instead of writing back
+  // to `selectable` so deselecting the item keeps its role and indentation.
+  let hasBeenSelected = false;
 
   $: hasSubmenu = labelText !== undefined && $$slots.default;
+  $: if (selected) hasBeenSelected = true;
+  $: isSelectable = !!ctxGroup || selectable || hasBeenSelected;
+  $: isRadio = !!ctxRadioGroup;
+  $: isIndented = isSelectable || isRadio;
+  $: role = isRadio
+    ? "menuitemradio"
+    : isSelectable
+      ? "menuitemcheckbox"
+      : "menuitem";
+  $: displayIcon = isIndented ? (selected ? Checkmark : undefined) : icon;
 
   function handleClick(event) {
     if (disabled) return;
@@ -76,6 +115,14 @@
     const shouldContinue = dispatch("click", event, { cancelable: true });
 
     if (shouldContinue) {
+      if (ctxGroup) {
+        ctxGroup.toggleOption({ id });
+      } else if (ctxRadioGroup) {
+        ctxRadioGroup.setOption({ id });
+      } else if (isSelectable) {
+        selected = !selected;
+      }
+
       ctx.close("select");
     }
   }
@@ -107,18 +154,34 @@
   }
 
   onMount(() => {
+    let unsubscribe;
+
+    if (ctxGroup) {
+      if (selected) ctxGroup.addOption({ id });
+      unsubscribe = ctxGroup.currentIds.subscribe((currentIds) => {
+        selected = currentIds.includes(id);
+      });
+    } else if (ctxRadioGroup) {
+      if (selected) ctxRadioGroup.addOption({ id });
+      unsubscribe = ctxRadioGroup.currentId.subscribe((currentId) => {
+        selected = id === currentId;
+      });
+    }
+
     return () => {
       clearTimeout(hoverTimeout);
       clearTimeout(closeTimeout);
+      unsubscribe?.();
     };
   });
 </script>
 
 <li
   bind:this={ref}
-  role="menuitem"
+  {role}
   tabindex="-1"
   aria-disabled={disabled}
+  aria-checked={isIndented ? selected : undefined}
   aria-haspopup={hasSubmenu ? true : undefined}
   aria-expanded={hasSubmenu ? submenuOpen : undefined}
   class:bx--menu-option={true}
@@ -170,9 +233,9 @@
     class:bx--menu-option__content={true}
     class:bx--menu-option__content--disabled={disabled}
   >
-    {#if icon}
+    {#if isIndented || icon}
       <div class:bx--menu-option__icon={true}>
-        <svelte:component this={icon} />
+        <svelte:component this={displayIcon} />
       </div>
     {/if}
     <span

--- a/src/Menu/MenuItemGroup.svelte
+++ b/src/Menu/MenuItemGroup.svelte
@@ -1,0 +1,60 @@
+<script>
+  /**
+   * Specify the selected ids.
+   * @type {ReadonlyArray<string>}
+   * @bindable writable
+   */
+  export let selectedIds = [];
+
+  /** Specify the label text */
+  export let labelText = "";
+
+  import { setContext } from "svelte";
+  import { writable } from "svelte/store";
+
+  /**
+   * @type {import("svelte/store").Writable<ReadonlyArray<string>>}
+   */
+  const currentIds = writable([]);
+
+  // A menu unmounts its items when it closes, so items re-seed on every open.
+  // Only honor a `selected` item when the group opens without a selection,
+  // otherwise reopening the menu would restore the initial selection.
+  const isSeedable = selectedIds.length === 0;
+
+  /**
+   * @type {(data: { id: string }) => void}
+   */
+  function addOption({ id }) {
+    if (!isSeedable) return;
+
+    if (!selectedIds.includes(id)) {
+      selectedIds = [...selectedIds, id];
+    }
+  }
+
+  /**
+   * @type {(data: { id: string }) => void}
+   */
+  function toggleOption({ id }) {
+    if (selectedIds.includes(id)) {
+      selectedIds = selectedIds.filter((selectedId) => selectedId !== id);
+    } else {
+      selectedIds = [...selectedIds, id];
+    }
+  }
+
+  setContext("carbon:MenuItemGroup", {
+    currentIds,
+    addOption,
+    toggleOption,
+  });
+
+  $: currentIds.set(selectedIds);
+</script>
+
+<li role="none">
+  <ul role="group" aria-label={labelText}>
+    <slot />
+  </ul>
+</li>

--- a/src/Menu/MenuItemRadioGroup.svelte
+++ b/src/Menu/MenuItemRadioGroup.svelte
@@ -1,0 +1,52 @@
+<script>
+  /**
+   * Set the selected radio group id.
+   * @bindable writable
+   */
+  export let selectedId = "";
+
+  /** Specify the label text */
+  export let labelText = "";
+
+  import { setContext } from "svelte";
+  import { writable } from "svelte/store";
+
+  /**
+   * @type {import("svelte/store").Writable<string>}
+   */
+  const currentId = writable("");
+
+  // A menu unmounts its items when it closes, so items re-seed on every open.
+  // Only honor a `selected` item when the group opens without a selection,
+  // otherwise reopening the menu would restore the initial selection.
+  const isSeedable = selectedId === "";
+
+  /**
+   * @type {(data: { id: string }) => void}
+   */
+  function addOption({ id }) {
+    if (!isSeedable || selectedId !== "") return;
+    selectedId = id;
+  }
+
+  /**
+   * @type {(data: { id: string }) => void}
+   */
+  function setOption({ id }) {
+    selectedId = id;
+  }
+
+  setContext("carbon:MenuItemRadioGroup", {
+    currentId,
+    addOption,
+    setOption,
+  });
+
+  $: currentId.set(selectedId);
+</script>
+
+<li role="none">
+  <ul role="group" aria-label={labelText}>
+    <slot />
+  </ul>
+</li>

--- a/src/Menu/index.js
+++ b/src/Menu/index.js
@@ -1,3 +1,5 @@
 export { default as Menu } from "./Menu.svelte";
 export { default as MenuDivider } from "./MenuDivider.svelte";
 export { default as MenuItem } from "./MenuItem.svelte";
+export { default as MenuItemGroup } from "./MenuItemGroup.svelte";
+export { default as MenuItemRadioGroup } from "./MenuItemRadioGroup.svelte";

--- a/src/index.js
+++ b/src/index.js
@@ -98,6 +98,8 @@ export { default as LocalStorage } from "./LocalStorage/LocalStorage.svelte";
 export { default as Menu } from "./Menu/Menu.svelte";
 export { default as MenuDivider } from "./Menu/MenuDivider.svelte";
 export { default as MenuItem } from "./Menu/MenuItem.svelte";
+export { default as MenuItemGroup } from "./Menu/MenuItemGroup.svelte";
+export { default as MenuItemRadioGroup } from "./Menu/MenuItemRadioGroup.svelte";
 export { default as MenuButton } from "./MenuButton/MenuButton.svelte";
 export { default as Modal } from "./Modal/Modal.svelte";
 export { default as FluidMultiSelectSkeleton } from "./MultiSelect/FluidMultiSelectSkeleton.svelte";

--- a/tests/Menu/MenuItem.radioGroup.test.svelte
+++ b/tests/Menu/MenuItem.radioGroup.test.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+  import Menu from "carbon-components-svelte/Menu/Menu.svelte";
+  import MenuItem from "carbon-components-svelte/Menu/MenuItem.svelte";
+  import MenuItemRadioGroup from "carbon-components-svelte/Menu/MenuItemRadioGroup.svelte";
+  import type { ComponentProps } from "svelte";
+
+  export let selectedId: ComponentProps<MenuItemRadioGroup>["selectedId"] = "";
+
+  let anchor: HTMLButtonElement;
+  let open = false;
+</script>
+
+<button type="button" bind:this={anchor} on:click={() => (open = !open)}>
+  Trigger
+</button>
+
+<Menu {anchor} bind:open labelText="Example menu">
+  <MenuItem>Plain</MenuItem>
+  <MenuItemRadioGroup labelText="Density" bind:selectedId>
+    <MenuItem id="compact" labelText="Compact" />
+    <MenuItem id="comfortable" labelText="Comfortable" selected />
+  </MenuItemRadioGroup>
+</Menu>
+
+<div data-testid="selected-id">{selectedId}</div>

--- a/tests/Menu/MenuItem.selectable.test.svelte
+++ b/tests/Menu/MenuItem.selectable.test.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+  import Menu from "carbon-components-svelte/Menu/Menu.svelte";
+  import MenuItem from "carbon-components-svelte/Menu/MenuItem.svelte";
+  import MenuItemGroup from "carbon-components-svelte/Menu/MenuItemGroup.svelte";
+  import type { ComponentProps } from "svelte";
+
+  export let selectedIds: ComponentProps<MenuItemGroup>["selectedIds"] = [];
+
+  let anchor: HTMLButtonElement;
+  let open = false;
+</script>
+
+<button type="button" bind:this={anchor} on:click={() => (open = !open)}>
+  Trigger
+</button>
+
+<Menu {anchor} bind:open labelText="Example menu">
+  <MenuItem>Plain</MenuItem>
+  <MenuItemGroup labelText="Columns" bind:selectedIds>
+    <MenuItem id="name" labelText="Name" />
+    <MenuItem id="size" labelText="Size" selected />
+    <MenuItem id="date" labelText="Date" on:click={(e) => e.preventDefault()} />
+  </MenuItemGroup>
+</Menu>
+
+<div data-testid="selected-ids">{JSON.stringify(selectedIds)}</div>

--- a/tests/Menu/MenuItem.test.ts
+++ b/tests/Menu/MenuItem.test.ts
@@ -1,5 +1,7 @@
 import { fireEvent, render, screen } from "@testing-library/svelte";
 import { user } from "../utils/user";
+import MenuItemRadioGroupFixture from "./MenuItem.radioGroup.test.svelte";
+import MenuItemSelectableFixture from "./MenuItem.selectable.test.svelte";
 import MenuItemSlot from "./MenuItem.slot.test.svelte";
 import MenuItemFixture from "./MenuItem.test.svelte";
 
@@ -235,6 +237,142 @@ describe("MenuItem", () => {
         "title",
         "Export as",
       );
+    });
+  });
+
+  describe("selectable", () => {
+    const getSelectedIds = () =>
+      JSON.parse(screen.getByTestId("selected-ids").textContent || "[]");
+
+    it("renders checkbox items and seeds the bound value from a selected item", async () => {
+      render(MenuItemSelectableFixture);
+
+      await user.click(screen.getByRole("button", { name: "Trigger" }));
+
+      expect(
+        screen.getByRole("group", { name: "Columns" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("menuitemcheckbox", { name: "Name" }),
+      ).toHaveAttribute("aria-checked", "false");
+      expect(
+        screen.getByRole("menuitemcheckbox", { name: "Size" }),
+      ).toHaveAttribute("aria-checked", "true");
+      expect(getSelectedIds()).toEqual(["size"]);
+    });
+
+    it("toggles aria-checked and the bound selectedIds on click", async () => {
+      render(MenuItemSelectableFixture);
+
+      await user.click(screen.getByRole("button", { name: "Trigger" }));
+      await user.click(screen.getByRole("menuitemcheckbox", { name: "Name" }));
+
+      expect(getSelectedIds()).toEqual(["size", "name"]);
+
+      // Selecting closes the menu, so reopen it to toggle the item back off.
+      await user.click(screen.getByRole("button", { name: "Trigger" }));
+      expect(
+        screen.getByRole("menuitemcheckbox", { name: "Name" }),
+      ).toHaveAttribute("aria-checked", "true");
+
+      await user.click(screen.getByRole("menuitemcheckbox", { name: "Name" }));
+      expect(getSelectedIds()).toEqual(["size"]);
+    });
+
+    it("selects with Enter", async () => {
+      render(MenuItemSelectableFixture);
+
+      await user.click(screen.getByRole("button", { name: "Trigger" }));
+      screen.getByRole("menuitemcheckbox", { name: "Name" }).focus();
+      await user.keyboard("{Enter}");
+
+      expect(getSelectedIds()).toEqual(["size", "name"]);
+    });
+
+    it("moves focus onto checkbox items with arrow keys", async () => {
+      render(MenuItemSelectableFixture);
+
+      await user.click(screen.getByRole("button", { name: "Trigger" }));
+      expect(screen.getByRole("menuitem", { name: "Plain" })).toHaveFocus();
+
+      await user.keyboard("{ArrowDown}");
+      expect(
+        screen.getByRole("menuitemcheckbox", { name: "Name" }),
+      ).toHaveFocus();
+
+      await user.keyboard("{ArrowDown}");
+      expect(
+        screen.getByRole("menuitemcheckbox", { name: "Size" }),
+      ).toHaveFocus();
+    });
+
+    it("keeps the menu open when the click event is prevented", async () => {
+      render(MenuItemSelectableFixture);
+
+      await user.click(screen.getByRole("button", { name: "Trigger" }));
+      await user.click(screen.getByRole("menuitemcheckbox", { name: "Date" }));
+
+      expect(screen.getByRole("menu")).toBeInTheDocument();
+      expect(getSelectedIds()).toEqual(["size"]);
+    });
+  });
+
+  describe("radio group", () => {
+    const getSelectedId = () => screen.getByTestId("selected-id").textContent;
+
+    it("renders radio items and seeds the bound value from a selected item", async () => {
+      render(MenuItemRadioGroupFixture);
+
+      await user.click(screen.getByRole("button", { name: "Trigger" }));
+
+      expect(
+        screen.getByRole("group", { name: "Density" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("menuitemradio", { name: "Compact" }),
+      ).toHaveAttribute("aria-checked", "false");
+      expect(
+        screen.getByRole("menuitemradio", { name: "Comfortable" }),
+      ).toHaveAttribute("aria-checked", "true");
+      expect(getSelectedId()).toBe("comfortable");
+    });
+
+    it("unchecks the previous item when another one is selected", async () => {
+      render(MenuItemRadioGroupFixture);
+
+      await user.click(screen.getByRole("button", { name: "Trigger" }));
+      await user.click(screen.getByRole("menuitemradio", { name: "Compact" }));
+
+      expect(getSelectedId()).toBe("compact");
+
+      await user.click(screen.getByRole("button", { name: "Trigger" }));
+      expect(
+        screen.getByRole("menuitemradio", { name: "Compact" }),
+      ).toHaveAttribute("aria-checked", "true");
+      expect(
+        screen.getByRole("menuitemradio", { name: "Comfortable" }),
+      ).toHaveAttribute("aria-checked", "false");
+    });
+
+    it("selects with Space", async () => {
+      render(MenuItemRadioGroupFixture);
+
+      await user.click(screen.getByRole("button", { name: "Trigger" }));
+      screen.getByRole("menuitemradio", { name: "Compact" }).focus();
+      await user.keyboard(" ");
+
+      expect(getSelectedId()).toBe("compact");
+    });
+
+    it("moves focus onto radio items with arrow keys", async () => {
+      render(MenuItemRadioGroupFixture);
+
+      await user.click(screen.getByRole("button", { name: "Trigger" }));
+      await user.keyboard("{ArrowDown}");
+
+      expect(
+        screen.getByRole("menuitemradio", { name: "Compact" }),
+      ).toHaveFocus();
     });
   });
 });


### PR DESCRIPTION
Adds MenuItemGroup and MenuItemRadioGroup, plus selected and
selectable on MenuItem, so menus can hold checkbox and radio
state. Selection closes the menu; preventDefault on click keeps
it open for multi-select flows.