### PR TITLE
feat(tree-view): add `filterText` with in-place hiding

### DIFF
--- a/css/_treeview.scss
+++ b/css/_treeview.scss
@@ -7,6 +7,22 @@
   }
 }
 
+/// Rows hidden by the `filterText` prop, and the highlighted match within a
+/// visible row's label. `<mark>` carries a UA background, so both colors are
+/// set from theme tokens to keep it legible in every theme.
+/// @access private
+/// @group components
+@mixin treeview-filter {
+  .#{$prefix}--tree-node--filtered-out {
+    display: none;
+  }
+
+  .#{$prefix}--tree-node__match {
+    background-color: $highlight;
+    color: $text-01;
+  }
+}
+
 @mixin treeview-multiselect-overrides {
   .#{$prefix}--tree--multiselect
     .#{$prefix}--tree-node--selected
@@ -43,6 +59,10 @@
 
 @include exports('treeview-hidden') {
   @include treeview-hidden;
+}
+
+@include exports('treeview-filter') {
+  @include treeview-filter;
 }
 
 @include exports('treeview-multiselect') {

--- a/docs/src/pages/components/TreeView.svx
+++ b/docs/src/pages/components/TreeView.svx
@@ -60,6 +60,7 @@ Customize node rendering using the default slot with the `let:node` directive. T
 | leaf     | True when the node does not have child nodes.    |
 | disabled | True when the node is disabled.                  |
 | selected | True when the node is selected.                  |
+| match    | Character offsets of the [Search](#search) match, or null. |
 
 <FileSource src="/framed/TreeView/TreeViewSlot" />
 
@@ -193,11 +194,21 @@ Convert flat data to a hierarchical structure using the `toHierarchy` utility.
 
 ## Filtering
 
-Filter nodes with the built-in helpers.
+Hide rows in place with `filterText`, or derive a filtered data set with the tree helpers.
+
+### Search
+
+Set `filterText` to hide the rows that do not match, matching node text case-insensitively. Rows stay mounted, so a branch keeps its local DOM state while it is hidden and a parent whose children all fail the filter stays a parent.
+
+Ancestors of a match expand automatically and collapse back to their previous state once the filter clears. Any node expanded by hand while filtering stays expanded.
+
+The default label wraps the matched characters in a `<mark>`. To highlight matches in custom node content, read `node.match` from the default slot: it holds the start and end character offsets of the match, or `null` when the row is visible only because a descendant matched.
+
+<FileSource src="/framed/TreeView/TreeViewSearch" />
 
 ### By text
 
-Combine a search input with `filterTreeByText` to create an interactive searchable tree. Type to filter nodes by name (case-insensitive substring matching). By default, matching nodes and their ancestors are included to maintain valid tree structure.
+Combine a search input with `filterTreeByText` to derive a filtered copy of the data. Type to filter nodes by name (case-insensitive substring matching). By default, matching nodes and their ancestors are included to maintain valid tree structure. For live search that keeps the original tree intact, use [Search](#search) instead.
 
 <FileSource src="/framed/TreeView/TreeViewFilter" />
 

--- a/docs/src/pages/framed/TreeView/TreeViewSearch.svelte
+++ b/docs/src/pages/framed/TreeView/TreeViewSearch.svelte
@@ -1,0 +1,52 @@
+<script>
+  import { Search, Stack, TreeView } from "carbon-components-svelte";
+
+  let filterText = "";
+
+  const nodes = [
+    { id: 0, text: "AI / Machine learning" },
+    {
+      id: 1,
+      text: "Analytics",
+      nodes: [
+        {
+          id: 2,
+          text: "IBM Analytics Engine",
+          nodes: [
+            { id: 3, text: "Apache Spark" },
+            { id: 4, text: "Hadoop" },
+          ],
+        },
+        { id: 5, text: "IBM Cloud SQL Query" },
+        { id: 6, text: "IBM Db2 Warehouse on Cloud" },
+      ],
+    },
+    {
+      id: 7,
+      text: "Blockchain",
+      nodes: [{ id: 8, text: "IBM Blockchain Platform" }],
+    },
+    {
+      id: 9,
+      text: "Databases",
+      nodes: [
+        { id: 10, text: "IBM Cloud Databases for Elasticsearch" },
+        { id: 11, text: "IBM Cloud Databases for Enterprise DB" },
+        { id: 12, text: "IBM Cloud Databases for MongoDB" },
+        { id: 13, text: "IBM Cloud Databases for PostgreSQL" },
+      ],
+    },
+  ];
+</script>
+
+<Stack gap={6}>
+  <Search
+    size="sm"
+    labelText="Filter products"
+    placeholder="Filter products..."
+    bind:value={filterText}
+  />
+  <div>
+    <TreeView labelText="Cloud Products" {nodes} {filterText} />
+  </div>
+</Stack>

--- a/src/TreeView/TreeView.svelte
+++ b/src/TreeView/TreeView.svelte
@@ -54,7 +54,8 @@
         if (!(node instanceof Element)) return NodeFilter.FILTER_SKIP;
         if (
           node.classList.contains("bx--tree-node--disabled") ||
-          node.classList.contains("bx--tree-node--hidden")
+          node.classList.contains("bx--tree-node--hidden") ||
+          node.classList.contains("bx--tree-node--filtered-out")
         ) {
           return NodeFilter.FILTER_REJECT;
         }
@@ -169,8 +170,8 @@
    * @property {ReadonlyArray<Id>} selectedIds - The full set of selected node ids after the change
    * @property {Array<Id>} added - Node ids selected since the previous change
    * @property {Array<Id>} removed - Node ids deselected since the previous change
-   * @slot {{ node: Node & { expanded: boolean; leaf: boolean; selected: boolean; } }}
-   * @slot {{ node: Node & { expanded: boolean; leaf: boolean; selected: boolean; } }} childNodes
+   * @slot {{ node: Node & { expanded: boolean; leaf: boolean; selected: boolean; match: [number, number] | null; } }}
+   * @slot {{ node: Node & { expanded: boolean; leaf: boolean; selected: boolean; match: [number, number] | null; } }} childNodes
    * @event select
    * @type {Node & { expanded: boolean; leaf: boolean; selected: boolean }}
    * @event toggle
@@ -243,6 +244,15 @@
    * @type {'node' | 'shallow' | 'deep'}
    */
   export let multiselectMode = "node";
+
+  /**
+   * Filter rows by a case-insensitive substring match on node text.
+   * Non-matching rows are hidden in place instead of unmounted, and the
+   * ancestors of a match expand automatically until the filter clears.
+   * An empty string means no filtering.
+   * @type {string}
+   */
+  export let filterText = "";
 
   /**
    * Programmatically expand all nodes
@@ -422,6 +432,8 @@
     tick,
   } from "svelte";
   import { writable } from "svelte/store";
+  import { matchTreeNodes } from "../utils/matchTreeNodes";
+  import TreeViewLabel from "./TreeViewLabel.svelte";
   import TreeViewNodeList from "./TreeViewNodeList.svelte";
 
   const dispatch = createEventDispatcher();
@@ -441,6 +453,13 @@
   const selectedIdsSetStore = writable(new Set(selectedIds));
   /** @type {import("svelte/store").Writable<Set<Node["id"]>>} */
   const expandedIdsSetStore = writable(new Set(expandedIds));
+  /**
+   * Ids hidden by `filterText`. Empty whenever no filter is active.
+   * @type {import("svelte/store").Writable<Set<Node["id"]>>}
+   */
+  const filteredOutIdsSetStore = writable(new Set());
+  /** @type {import("svelte/store").Writable<Map<Node["id"], [number, number]>>} */
+  const matchesStore = writable(new Map());
 
   /** @type {HTMLElement | null} */
   let ref = null;
@@ -552,6 +571,23 @@
   /** @type {ReadonlyArray<Node["id"]>} */
   let lastExpandedIdsPushed = expandedIds;
 
+  /** @type {ReadonlyArray<Node> | null} */
+  let cachedFilterNodes = null;
+  /** @type {string | null} */
+  let cachedFilterText = null;
+  /**
+   * The consumer's `expandedIds` as of the moment filtering began, restored
+   * when the filter clears. `null` while no filter is active.
+   * @type {Set<Node["id"]> | null}
+   */
+  let preFilterExpandedIds = null;
+  /**
+   * Ids expanded by the filter itself, as opposed to by the consumer or by a
+   * manual expansion made while filtering.
+   * @type {Set<Node["id"]>}
+   */
+  let filterExpandedIds = new Set();
+
   /**
    * @returns {boolean}
    */
@@ -559,6 +595,19 @@
     if (a.length !== b.length) return false;
     for (let i = 0; i < a.length; i++) {
       if (a[i] !== b[i]) return false;
+    }
+    return true;
+  }
+
+  /**
+   * @param {Set<Node["id"]>} a
+   * @param {Set<Node["id"]>} b
+   * @returns {boolean}
+   */
+  function idSetsEqual(a, b) {
+    if (a.size !== b.size) return false;
+    for (const id of a) {
+      if (!b.has(id)) return false;
     }
     return true;
   }
@@ -689,6 +738,77 @@
     lastExpandedIdsRef = expandedIds;
   }
 
+  /**
+   * Expand the ancestors of the current matches, remembering which ids the
+   * filter opened so clearing it can put them back.
+   * @param {Set<Node["id"]>} ancestorIds
+   * @returns {Set<Node["id"]> | null} The next expanded set, or `null` when unchanged.
+   */
+  function expandFilterAncestors(ancestorIds) {
+    if (preFilterExpandedIds === null) {
+      preFilterExpandedIds = new Set(expandedIdsSet);
+    }
+
+    const next = new Set(expandedIdsSet);
+    for (const id of ancestorIds) {
+      if (next.has(id)) continue;
+      next.add(id);
+      filterExpandedIds.add(id);
+    }
+
+    return next.size === expandedIdsSet.size ? null : next;
+  }
+
+  /**
+   * Undo the filter's expansions, keeping any node the consumer expanded by
+   * hand while the filter was active.
+   * @returns {Set<Node["id"]> | null} The next expanded set, or `null` when unchanged.
+   */
+  function restoreFilterExpansion() {
+    if (preFilterExpandedIds === null) return null;
+
+    const next = new Set(preFilterExpandedIds);
+    for (const id of expandedIdsSet) {
+      if (!filterExpandedIds.has(id)) next.add(id);
+    }
+
+    preFilterExpandedIds = null;
+    filterExpandedIds = new Set();
+
+    return idSetsEqual(next, expandedIdsSet) ? null : next;
+  }
+
+  /**
+   * Recompute which rows the filter hides and which matches to highlight.
+   * @param {ReadonlyArray<Node>} sourceNodes
+   * @param {Array<Node>} allNodes - `sourceNodes` flattened.
+   * @param {string} text
+   * @returns {Set<Node["id"]> | null} The next expanded set, or `null` when unchanged.
+   */
+  function resolveFilter(sourceNodes, allNodes, text) {
+    if (text.trim() === "") {
+      filteredOutIdsSetStore.set(new Set());
+      matchesStore.set(new Map());
+      return restoreFilterExpansion();
+    }
+
+    const { visibleIds, ancestorIds, matches } = matchTreeNodes(
+      sourceNodes,
+      text,
+    );
+
+    /** @type {Set<Node["id"]>} */
+    const filteredOutIds = new Set();
+    for (const node of allNodes) {
+      if (!visibleIds.has(node.id)) filteredOutIds.add(node.id);
+    }
+
+    filteredOutIdsSetStore.set(filteredOutIds);
+    matchesStore.set(matches);
+
+    return expandFilterAncestors(ancestorIds);
+  }
+
   /** @type {(node: Node) => void} */
   function focusNode(node) {
     dispatch("focus", withLiveState(node));
@@ -706,6 +826,8 @@
     expandedNodeIds,
     selectedIdsSetStore,
     expandedIdsSetStore,
+    filteredOutIdsSetStore,
+    matchesStore,
     multiselectStore,
     clickNode,
     selectNode,
@@ -868,7 +990,7 @@
         const visibleEls = new Map(
           Array.from(
             ref?.querySelectorAll(
-              '[role="treeitem"]:not(.bx--tree-node--hidden)',
+              '[role="treeitem"]:not(.bx--tree-node--hidden):not(.bx--tree-node--filtered-out)',
             ) ?? [],
           ).map((el) => [el.id, el]),
         );
@@ -894,14 +1016,21 @@
 
   /** @type {ReadonlyArray<Node> | null} */
   let prevNodesForFirstTab = null;
+  let prevFilterTextForFirstTab = filterText;
 
   afterUpdate(() => {
     if (!ref) return;
-    if (nodes === prevNodesForFirstTab) return;
+    const filterChanged = filterText !== prevFilterTextForFirstTab;
+    if (nodes === prevNodesForFirstTab && !filterChanged) return;
     prevNodesForFirstTab = nodes;
+    prevFilterTextForFirstTab = filterText;
+
+    // A filter change can hide the row currently holding the roving tabindex,
+    // so re-seed from scratch rather than leaving a hidden tab stop behind.
+    if (filterChanged) resetNodeTabIndices(ref);
 
     const firstFocusableNode = ref.querySelector(
-      ".bx--tree-node:not(.bx--tree-node--disabled):not(.bx--tree-node--hidden)",
+      ".bx--tree-node:not(.bx--tree-node--disabled):not(.bx--tree-node--hidden):not(.bx--tree-node--filtered-out)",
     );
 
     if (firstFocusableNode instanceof HTMLElement) {
@@ -959,6 +1088,25 @@
   $: multiselectStore.set(multiselect);
   $: flattenedNodes = cachedFlattenedNodes ?? [];
   $: nodeIds = cachedNodeIds ?? [];
+
+  $: {
+    if (nodes !== cachedFilterNodes || filterText !== cachedFilterText) {
+      cachedFilterNodes = nodes;
+      cachedFilterText = filterText;
+
+      const nextExpandedIdsSet = resolveFilter(
+        nodes,
+        flattenedNodes,
+        filterText,
+      );
+
+      if (nextExpandedIdsSet) {
+        expandedIdsSet = nextExpandedIdsSet;
+        expandedIds = Array.from(expandedIdsSet);
+        lastExpandedIdsRef = expandedIds;
+      }
+    }
+  }
 
   let prevActiveIdForAutoCollapse = activeId;
 
@@ -1071,7 +1219,9 @@
   on:keydown|stopPropagation={handleKeyDown}
 >
   <TreeViewNodeList root {nodes} let:node>
-    <slot {node}> {node.text} </slot>
+    <slot {node}>
+      <TreeViewLabel text={node.text} match={node.match} />
+    </slot>
     <svelte:fragment slot="childNodes" let:node>
       <slot name="childNodes" {node} />
     </svelte:fragment>

--- a/src/TreeView/TreeViewLabel.svelte
+++ b/src/TreeView/TreeViewLabel.svelte
@@ -1,0 +1,32 @@
+<script>
+  /**
+   * Default label text for a tree row, with the `filterText` match wrapped in
+   * a `<mark>`. Internal to TreeView; not exported from the package barrel.
+   * @typedef {[number, number]} MatchRange
+   */
+
+  /**
+   * Specify the node text to render.
+   * @type {any}
+   */
+  export let text = "";
+
+  /**
+   * Character offsets of the filter match within `text`.
+   * `null` when the row is visible without matching.
+   * @type {MatchRange | null}
+   */
+  export let match = null;
+
+  $: highlight =
+    match !== null && typeof text === "string"
+      ? {
+          before: text.slice(0, match[0]),
+          matched: text.slice(match[0], match[1]),
+          after: text.slice(match[1]),
+        }
+      : null;
+</script>
+
+<!-- biome-ignore format: the text around <mark> must stay flush; a line break here becomes a rendered space. -->
+{#if highlight}{highlight.before}<mark class:bx--tree-node__match={true}>{highlight.matched}</mark>{highlight.after}{:else}{text}{/if}

--- a/src/TreeView/TreeViewNode.svelte
+++ b/src/TreeView/TreeViewNode.svelte
@@ -58,7 +58,7 @@
   /**
    * @generics {Node extends TreeNode<any> = TreeNode<any>, Icon = any} Node,Icon
    * @typedef {import('./TreeView.svelte').TreeNode<Id>} TreeNode<Id=(string|number)>
-   * @slot {{ node: Node & { expanded: false; leaf: boolean; selected: boolean; } }}
+   * @slot {{ node: Node & { expanded: false; leaf: boolean; selected: boolean; match: [number, number] | null; } }}
    */
 
   export let leaf = false;
@@ -102,6 +102,8 @@
   const {
     activeNodeId,
     selectedIdsSetStore,
+    filteredOutIdsSetStore,
+    matchesStore,
     clickNode,
     selectNode,
     focusNode,
@@ -111,6 +113,8 @@
   }
 
   $: selected = $selectedIdsSetStore.has(id);
+  $: filteredOut = $filteredOutIdsSetStore.has(id);
+  $: match = $matchesStore.get(id) ?? null;
   // Merge all props (including custom properties) with computed properties
   // Explicitly include disabled to ensure it's always present (has default value)
   // `level`/`posinset`/`setsize` are layout-only (drive `aria-*` attributes) and excluded from `node`.
@@ -126,6 +130,7 @@
     expanded: false, // A node cannot be expanded.
     leaf,
     selected,
+    match,
   };
   $: {
     if (
@@ -165,6 +170,7 @@
       class:bx--tree-node--selected={selected}
       class:bx--tree-node--disabled={disabled}
       class:bx--tree-node--with-icon={icon}
+      class:bx--tree-node--filtered-out={filteredOut}
       on:click|stopPropagation={(event) => {
         if (disabled) return;
         clickNode(node, event);
@@ -228,6 +234,7 @@
     class:bx--tree-node--selected={selected}
     class:bx--tree-node--disabled={disabled}
     class:bx--tree-node--with-icon={icon}
+    class:bx--tree-node--filtered-out={filteredOut}
     on:click|stopPropagation={(event) => {
       if (disabled) return;
       clickNode(node, event);

--- a/src/TreeView/TreeViewNodeList.svelte
+++ b/src/TreeView/TreeViewNodeList.svelte
@@ -2,8 +2,8 @@
   /**
    * @generics {Id extends string | number = string | number, Icon = any} Id,Icon
    * @typedef {{ id: Id; text: string; disabled?: boolean; expanded?: boolean; }} TreeNode<Id>
-   * @slot {{ node: TreeNode<Id> & { expanded: boolean; leaf: boolean; selected: boolean; } }}
-   * @slot {{ node: TreeNode<Id> & { expanded: boolean; leaf: boolean; selected: boolean; } }} childNodes
+   * @slot {{ node: TreeNode<Id> & { expanded: boolean; leaf: boolean; selected: boolean; match: [number, number] | null; } }}
+   * @slot {{ node: TreeNode<Id> & { expanded: boolean; leaf: boolean; selected: boolean; match: [number, number] | null; } }} childNodes
    */
 
   /** @type {ReadonlyArray<TreeNode<Id> & { nodes?: TreeNode<Id>[] }>} */
@@ -64,6 +64,8 @@
     activeNodeId,
     selectedIdsSetStore,
     expandedIdsSetStore,
+    filteredOutIdsSetStore,
+    matchesStore,
     clickNode,
     selectNode,
     expandNode,
@@ -82,6 +84,8 @@
   $: parent = Array.isArray(nodes);
   $: expanded = $expandedIdsSetStore.has(id);
   $: selected = $selectedIdsSetStore.has(id);
+  $: filteredOut = $filteredOutIdsSetStore.has(id);
+  $: match = $matchesStore.get(id) ?? null;
   // Merge all props (including custom properties) with computed properties
   // Explicitly reference text and disabled to avoid Svelte warning and ensure they're included
   // `level`/`posinset`/`setsize` are layout-only (drive `aria-*` attributes) and excluded from `node`.
@@ -99,6 +103,7 @@
     expanded,
     leaf: !parent,
     selected,
+    match,
   };
   $: {
     // The root list is a non-selectable wrapper; its default empty `id` would
@@ -163,6 +168,7 @@
     class:bx--tree-node--selected={selected}
     class:bx--tree-node--disabled={disabled}
     class:bx--tree-node--with-icon={icon}
+    class:bx--tree-node--filtered-out={filteredOut}
     aria-expanded={expanded}
     aria-owns="{treeId}-{id}-subtree"
     aria-level={level}

--- a/src/index.js
+++ b/src/index.js
@@ -240,4 +240,5 @@ export {
   filterTreeNodes,
 } from "./utils/filterTreeNodes";
 export { fuzzyMatch, highlightSegments } from "./utils/fuzzyMatch";
+export { matchTreeNodes } from "./utils/matchTreeNodes";
 export { toHierarchy } from "./utils/toHierarchy";

--- a/src/utils/matchTreeNodes.d.ts
+++ b/src/utils/matchTreeNodes.d.ts
@@ -1,0 +1,32 @@
+type NodeLike = {
+  id: string | number;
+  text?: unknown;
+  nodes?: NodeLike[];
+  [key: string]: unknown;
+};
+
+/** Character offsets `[start, end]` of a match within a node's `text`. */
+export type TreeNodeMatchRange = [start: number, end: number];
+
+export type TreeNodeMatches<Id extends string | number = string | number> = {
+  /** Nodes whose own `text` matches. */
+  matchedIds: Set<Id>;
+  /** Nodes visible only because a descendant matched. */
+  ancestorIds: Set<Id>;
+  /** Every node that stays visible: the matches, their ancestors, and the descendants of a matching node. */
+  visibleIds: Set<Id>;
+  /** Matched node id to the character offsets of the match in `text`. */
+  matches: Map<Id, TreeNodeMatchRange>;
+};
+
+/**
+ * Resolve which rows stay visible for a filter term, using the same
+ * case-insensitive substring match on `text` as `filterTreeByText`. An empty or
+ * whitespace-only `filterText` means "no filter" and returns empty sets.
+ */
+export function matchTreeNodes<T extends NodeLike>(
+  nodes: readonly T[],
+  filterText: string,
+): TreeNodeMatches<T["id"]>;
+
+export default matchTreeNodes;

--- a/src/utils/matchTreeNodes.js
+++ b/src/utils/matchTreeNodes.js
@@ -1,0 +1,92 @@
+// @ts-check
+/**
+ * @typedef {Object} TreeNode
+ * @property {string | number} id
+ * @property {any} [text]
+ * @property {TreeNode[]} [nodes]
+ */
+
+/**
+ * @typedef {Object} TreeNodeMatches
+ * @property {Set<string | number>} matchedIds - Nodes whose own `text` matches.
+ * @property {Set<string | number>} ancestorIds - Nodes visible only because a descendant matched.
+ * @property {Set<string | number>} visibleIds - Every node that stays visible: the matches, their ancestors, and the descendants of a matching node.
+ * @property {Map<string | number, [number, number]>} matches - Matched node id to the `[start, end]` character offsets of the match in `text`.
+ */
+
+/**
+ * Character offsets of the first case-insensitive occurrence of `needle`.
+ * Returns `null` when `text` is not a string or does not contain `needle`.
+ * @param {any} text
+ * @param {string} needle - Already lowercased search term.
+ * @returns {[number, number] | null}
+ */
+function matchRange(text, needle) {
+  if (typeof text !== "string") return null;
+  const start = text.toLowerCase().indexOf(needle);
+  if (start === -1) return null;
+  return [start, start + needle.length];
+}
+
+/**
+ * Resolve which rows stay visible for a filter term, without allocating a new
+ * tree. Matching is a case-insensitive substring test on `node.text`, the same
+ * semantics as `filterTreeByText`. Surrounding whitespace in `filterText` is
+ * ignored; an empty or whitespace-only term means "no filter" and returns
+ * empty sets.
+ * @param {TreeNode[]} nodes - Hierarchical tree structure to search
+ * @param {string} filterText - Text to search for (case-insensitive)
+ * @returns {TreeNodeMatches}
+ */
+export function matchTreeNodes(nodes, filterText) {
+  /** @type {TreeNodeMatches} */
+  const result = {
+    matchedIds: new Set(),
+    ancestorIds: new Set(),
+    visibleIds: new Set(),
+    matches: new Map(),
+  };
+
+  const needle = (filterText ?? "").trim().toLowerCase();
+  if (needle === "") return result;
+
+  /**
+   * @param {TreeNode} node
+   * @param {boolean} isUnderMatch - Whether an ancestor of `node` matched.
+   * @returns {boolean} Whether `node` or one of its descendants matched.
+   */
+  function visit(node, isUnderMatch) {
+    const range = matchRange(node.text, needle);
+    const isMatch = range !== null;
+
+    if (range !== null) {
+      result.matchedIds.add(node.id);
+      result.matches.set(node.id, range);
+    }
+
+    let hasMatchInSubtree = isMatch;
+
+    if (Array.isArray(node.nodes)) {
+      for (const child of node.nodes) {
+        if (visit(child, isUnderMatch || isMatch)) hasMatchInSubtree = true;
+      }
+    }
+
+    if (isMatch || isUnderMatch) {
+      result.visibleIds.add(node.id);
+    } else if (hasMatchInSubtree) {
+      result.ancestorIds.add(node.id);
+      result.visibleIds.add(node.id);
+    }
+
+    return hasMatchInSubtree;
+  }
+
+  for (const node of nodes) {
+    visit(node, false);
+  }
+
+  return result;
+}
+
+export default matchTreeNodes;

--- a/tests/TreeView/TreeView.filterText.slot.test.svelte
+++ b/tests/TreeView/TreeView.filterText.slot.test.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+  import TreeView from "carbon-components-svelte/TreeView/TreeView.svelte";
+  import type { ComponentProps } from "svelte";
+
+  export let filterText: ComponentProps<TreeView>["filterText"] = "";
+
+  const nodes: ComponentProps<TreeView>["nodes"] = [
+    {
+      id: "1",
+      text: "Analytics",
+      nodes: [
+        {
+          id: "1-1",
+          text: "Engines",
+          nodes: [{ id: "1-1-1", text: "Apache Spark" }],
+        },
+      ],
+    },
+  ];
+</script>
+
+<TreeView labelText="Cloud Products" {nodes} {filterText} let:node>
+  <span
+    data-testid="label-{node.id}"
+    data-match={node.match === null ? "none" : node.match.join(",")}
+  >
+    {node.text}
+  </span>
+</TreeView>

--- a/tests/TreeView/TreeView.filterText.test.svelte
+++ b/tests/TreeView/TreeView.filterText.test.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+  import TreeView from "carbon-components-svelte/TreeView/TreeView.svelte";
+  import type { ComponentProps } from "svelte";
+
+  export let filterText: ComponentProps<TreeView>["filterText"] = "";
+
+  const nodes: ComponentProps<TreeView>["nodes"] = [
+    {
+      id: "1",
+      text: "Analytics",
+      nodes: [
+        {
+          id: "1-1",
+          text: "Engines",
+          nodes: [{ id: "1-1-1", text: "Apache Spark" }],
+        },
+        {
+          id: "1-2",
+          text: "Warehouse",
+          nodes: [{ id: "1-2-1", text: "Db2 Warehouse" }],
+        },
+      ],
+    },
+    {
+      id: "2",
+      text: "Storage",
+      nodes: [
+        { id: "2-1", text: "Object Storage" },
+        { id: "2-2", text: "Block Volume" },
+      ],
+    },
+  ];
+</script>
+
+<TreeView labelText="Cloud Products" {nodes} {filterText} />

--- a/tests/TreeView/TreeView.filterText.test.ts
+++ b/tests/TreeView/TreeView.filterText.test.ts
@@ -1,0 +1,123 @@
+import { render, screen } from "@testing-library/svelte";
+import { user } from "../utils/user";
+import TreeViewFilterTextSlot from "./TreeView.filterText.slot.test.svelte";
+import TreeViewFilterText from "./TreeView.filterText.test.svelte";
+
+// Filtered-out rows stay mounted — that is the point of the feature — and jsdom
+// never loads the stylesheet that hides them, so accessible-name computation
+// pulls in text from rows the user cannot see. Look rows up by id instead,
+// matching the convention in `TreeView.lazyLoad.test.ts`.
+function treeItemById(id: string): HTMLElement {
+  const el = document.getElementById(id);
+  expect.assert(el instanceof HTMLElement);
+  return el;
+}
+
+/** A parent row wraps its descendants' labels, so scope to its own. */
+function ownLabelText(row: HTMLElement): HTMLElement | null {
+  return row.querySelector(
+    ":scope > .bx--tree-node__label .bx--tree-node__label__text",
+  );
+}
+
+describe("TreeView filterText", () => {
+  it("marks non-matching rows as filtered out and leaves the rest alone", () => {
+    render(TreeViewFilterText, { filterText: "spark" });
+
+    for (const id of ["1", "1-1", "1-1-1"]) {
+      expect(treeItemById(id)).not.toHaveClass("bx--tree-node--filtered-out");
+    }
+    for (const id of ["1-2", "1-2-1", "2", "2-1", "2-2"]) {
+      expect(treeItemById(id)).toHaveClass("bx--tree-node--filtered-out");
+    }
+  });
+
+  it("expands the ancestors of a match and collapses them when the filter clears", async () => {
+    const { rerender } = render(TreeViewFilterText);
+
+    expect(treeItemById("1")).toHaveAttribute("aria-expanded", "false");
+
+    await rerender({ filterText: "spark" });
+    expect(treeItemById("1")).toHaveAttribute("aria-expanded", "true");
+    expect(treeItemById("1-1")).toHaveAttribute("aria-expanded", "true");
+
+    await rerender({ filterText: "" });
+    expect(treeItemById("1")).toHaveAttribute("aria-expanded", "false");
+    expect(treeItemById("1-1")).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("keeps a manual expansion made while filtering after the filter clears", async () => {
+    const { rerender } = render(TreeViewFilterText, { filterText: "storage" });
+
+    const storage = treeItemById("2");
+    expect(storage).toHaveAttribute("aria-expanded", "false");
+
+    const toggle = storage.querySelector(".bx--tree-parent-node__toggle");
+    expect.assert(toggle instanceof HTMLElement);
+    await user.click(toggle);
+    expect(storage).toHaveAttribute("aria-expanded", "true");
+
+    await rerender({ filterText: "" });
+    expect(treeItemById("2")).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("skips filtered-out rows on ArrowDown", async () => {
+    render(TreeViewFilterText, { filterText: "spark" });
+
+    treeItemById("1").focus();
+
+    await user.keyboard("{ArrowDown}");
+    expect(document.activeElement).toBe(treeItemById("1-1"));
+
+    await user.keyboard("{ArrowDown}");
+    expect(document.activeElement).toBe(treeItemById("1-1-1"));
+
+    // Warehouse (1-2) and Storage (2) come next in DOM order but are hidden.
+    await user.keyboard("{ArrowDown}");
+    expect(document.activeElement).toBe(treeItemById("1-1-1"));
+  });
+
+  it("does not select filtered-out rows on Ctrl+A", async () => {
+    render(TreeViewFilterText, { filterText: "spark" });
+
+    treeItemById("1").focus();
+    await user.keyboard("{Control>}a{/Control}");
+
+    const selectedIds = Array.from(
+      document.querySelectorAll("[aria-selected='true']"),
+      (el) => el.id,
+    );
+    expect(selectedIds.sort()).toEqual(["1", "1-1", "1-1-1"]);
+  });
+
+  it("wraps the match in a mark and leaves the rest of the label alone", () => {
+    // A mid-word match: the surrounding characters must stay flush against the
+    // highlight, with no whitespace introduced on either side.
+    render(TreeViewFilterText, { filterText: "hous" });
+
+    const label = ownLabelText(treeItemById("1-2"));
+    expect.assert(label instanceof HTMLElement);
+    expect(label.textContent).toBe("Warehouse");
+
+    const mark = label.querySelector("mark");
+    expect.assert(mark instanceof HTMLElement);
+    expect(mark).toHaveClass("bx--tree-node__match");
+    expect(mark.textContent).toBe("hous");
+
+    // An ancestor row is visible without matching, so it carries no highlight.
+    expect(ownLabelText(treeItemById("1"))?.querySelector("mark")).toBeNull();
+  });
+
+  it("passes node.match to custom slot content with the matched offsets", () => {
+    render(TreeViewFilterTextSlot, { filterText: "spark" });
+
+    expect(screen.getByTestId("label-1-1-1")).toHaveAttribute(
+      "data-match",
+      "7,12",
+    );
+    expect(screen.getByTestId("label-1-1")).toHaveAttribute(
+      "data-match",
+      "none",
+    );
+  });
+});

--- a/tests/TreeView/TreeView.test.ts
+++ b/tests/TreeView/TreeView.test.ts
@@ -91,6 +91,7 @@ describe.each(testCases)("$name", ({ component }) => {
       icon: expect.anything(),
       id: 0,
       leaf: true,
+      match: null,
       // The `select` payload reflects the post-click state: the node is now selected.
       selected: true,
       text: "AI / Machine learning",

--- a/tests/utils/matchTreeNodes.test.ts
+++ b/tests/utils/matchTreeNodes.test.ts
@@ -1,0 +1,112 @@
+import { matchTreeNodes } from "../../src/utils/matchTreeNodes.js";
+
+const nodes = [
+  {
+    id: "1",
+    text: "Analytics",
+    nodes: [
+      {
+        id: "1-1",
+        text: "Engines",
+        nodes: [{ id: "1-1-1", text: "Apache Spark" }],
+      },
+      {
+        id: "1-2",
+        text: "Warehouse",
+        nodes: [{ id: "1-2-1", text: "Db2 Warehouse" }],
+      },
+    ],
+  },
+  {
+    id: "2",
+    text: "Storage",
+    nodes: [
+      { id: "2-1", text: "Object Storage" },
+      { id: "2-2", text: "Block Volume" },
+    ],
+  },
+];
+
+describe("matchTreeNodes", () => {
+  test("matches a substring case-insensitively", () => {
+    const result = matchTreeNodes(nodes, "APACHE");
+
+    expect([...result.matchedIds]).toEqual(["1-1-1"]);
+    expect(result.matches.get("1-1-1")).toEqual([0, 6]);
+  });
+
+  test("reports match offsets into the original text", () => {
+    const result = matchTreeNodes(nodes, "spark");
+
+    expect(result.matches.get("1-1-1")).toEqual([7, 12]);
+  });
+
+  test("returns empty sets for an empty filter", () => {
+    const result = matchTreeNodes(nodes, "");
+
+    expect(result.matchedIds.size).toBe(0);
+    expect(result.ancestorIds.size).toBe(0);
+    expect(result.visibleIds.size).toBe(0);
+    expect(result.matches.size).toBe(0);
+  });
+
+  test("returns empty sets for a whitespace-only filter", () => {
+    const result = matchTreeNodes(nodes, "   ");
+
+    expect(result.visibleIds.size).toBe(0);
+    expect(result.matches.size).toBe(0);
+  });
+
+  test("returns empty sets when nothing matches", () => {
+    const result = matchTreeNodes(nodes, "kubernetes");
+
+    expect(result.matchedIds.size).toBe(0);
+    expect(result.ancestorIds.size).toBe(0);
+    expect(result.visibleIds.size).toBe(0);
+  });
+
+  test("keeps every ancestor of a match visible", () => {
+    const result = matchTreeNodes(nodes, "spark");
+
+    expect([...result.ancestorIds].sort()).toEqual(["1", "1-1"]);
+    expect([...result.visibleIds].sort()).toEqual(["1", "1-1", "1-1-1"]);
+  });
+
+  test("keeps the descendants of a matching branch visible", () => {
+    const result = matchTreeNodes(nodes, "storage");
+
+    // "Block Volume" does not match, but its parent branch does.
+    expect([...result.visibleIds].sort()).toEqual(["2", "2-1", "2-2"]);
+    expect(result.ancestorIds.size).toBe(0);
+  });
+
+  test("matches disabled nodes", () => {
+    const result = matchTreeNodes(
+      [{ id: "a", text: "Archive", disabled: true }],
+      "archive",
+    );
+
+    expect([...result.matchedIds]).toEqual(["a"]);
+    expect([...result.visibleIds]).toEqual(["a"]);
+  });
+
+  test("skips nodes whose text is not a string", () => {
+    const result = matchTreeNodes(
+      [
+        { id: "a", text: undefined },
+        { id: "b", text: 42 },
+        { id: "c", text: "42 apples" },
+      ],
+      "42",
+    );
+
+    expect([...result.matchedIds]).toEqual(["c"]);
+  });
+
+  test("walks the tree in place without mutating it", () => {
+    const snapshot = structuredClone(nodes);
+    matchTreeNodes(nodes, "storage");
+
+    expect(nodes).toEqual(snapshot);
+  });
+});


### PR DESCRIPTION
Hides non-matching rows in place without unmounting them, auto-
expands ancestors of matches, and wraps the match in mark in the
default label. node.match exposes the range for custom slots.