### PR TITLE
feat(data-table): support pinned columns

### DIFF
--- a/css/_data-table-pinned-column.scss
+++ b/css/_data-table-pinned-column.scss
@@ -1,0 +1,71 @@
+@import "carbon-components/scss/globals/scss/vars";
+@import "carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/import-once/import-once";
+
+/// Pinned column styling for DataTable headers with `pinned: "start" | "end"`.
+/// The offsets are measured at runtime and applied inline; this partial
+/// supplies the opaque background, the stacking order, and the boundary shadow.
+///
+/// A sticky cell with a transparent background lets the scrolled content show
+/// straight through it. Carbon already paints every `th` and `td` for each row
+/// state — default, zebra, selected, hover — and
+/// `_data-table-highlighted-row.scss` covers the highlighted combinations. The
+/// background rules here are therefore a low-specificity fallback, deliberately
+/// left unscoped: qualifying them with the table selector would outrank those
+/// state rules and flatten hover, zebra, and selection to a single colour.
+///
+/// `data-pinned-columns` is set on the table only when a column is actually
+/// pinned, so a table without pinned columns keeps its default stacking.
+/// @access private
+/// @group components
+@mixin data-table-pinned-column {
+  th.#{$prefix}--table-column--pinned-start,
+  th.#{$prefix}--table-column--pinned-end {
+    background-color: $layer-accent;
+  }
+
+  td.#{$prefix}--table-column--pinned-start,
+  td.#{$prefix}--table-column--pinned-end {
+    background-color: $layer;
+  }
+
+  .#{$prefix}--data-table[data-pinned-columns] {
+    // Confine pinned cells to the table's own stacking context. The toolbar
+    // that precedes the table is `position: relative; z-index: 1` and has to
+    // keep winning, for example when an overflow menu opens over the header.
+    isolation: isolate;
+
+    thead {
+      // Above pinned body cells (z-index 1): in a virtualized table the header
+      // row is sticky and rows scroll underneath it.
+      position: relative;
+      z-index: 2;
+    }
+
+    th.#{$prefix}--table-column--pinned-start,
+    th.#{$prefix}--table-column--pinned-end,
+    td.#{$prefix}--table-column--pinned-start,
+    td.#{$prefix}--table-column--pinned-end {
+      position: sticky;
+      // Above unpinned cells, which are not positioned at all.
+      z-index: 1;
+    }
+
+    // Only the column at each edge of the pinned group casts a shadow, so the
+    // seam between pinned and scrolling content reads as a single edge. The
+    // negative spread keeps the blur off the horizontal cell edges. Negate
+    // through `calc`: in the themable build the tokens are custom properties,
+    // and `-var(…)` is not valid CSS.
+    .#{$prefix}--table-column--pinned-start.#{$prefix}--table-column--pinned-boundary {
+      box-shadow: $spacing-01 0 $spacing-02 calc(-1 * #{$spacing-01}) $shadow;
+    }
+
+    .#{$prefix}--table-column--pinned-end.#{$prefix}--table-column--pinned-boundary {
+      box-shadow: calc(-1 * #{$spacing-01}) 0 $spacing-02
+        calc(-1 * #{$spacing-01}) $shadow;
+    }
+  }
+}
+
+@include exports("data-table-pinned-column") {
+  @include data-table-pinned-column;
+}

--- a/css/all.scss
+++ b/css/all.scss
@@ -99,6 +99,7 @@ $css--plex: true;
 @import "./data-table-sticky-column-menu";
 @import "./data-table-footer";
 @import "./data-table-align";
+@import "./data-table-pinned-column";
 @import "./pagination";
 @import "./structured-list-input-focusable";
 @import "./multiselect";

--- a/css/g10.scss
+++ b/css/g10.scss
@@ -59,6 +59,7 @@ $css--plex: true;
 @import "./data-table-sticky-column-menu";
 @import "./data-table-footer";
 @import "./data-table-align";
+@import "./data-table-pinned-column";
 @import "./pagination";
 @import "./structured-list-input-focusable";
 @import "./multiselect";

--- a/css/g100.scss
+++ b/css/g100.scss
@@ -59,6 +59,7 @@ $css--plex: true;
 @import "./data-table-sticky-column-menu";
 @import "./data-table-footer";
 @import "./data-table-align";
+@import "./data-table-pinned-column";
 @import "./pagination";
 @import "./structured-list-input-focusable";
 @import "./multiselect";

--- a/css/g80.scss
+++ b/css/g80.scss
@@ -59,6 +59,7 @@ $css--plex: true;
 @import "./data-table-sticky-column-menu";
 @import "./data-table-footer";
 @import "./data-table-align";
+@import "./data-table-pinned-column";
 @import "./pagination";
 @import "./structured-list-input-focusable";
 @import "./multiselect";

--- a/css/g90.scss
+++ b/css/g90.scss
@@ -59,6 +59,7 @@ $css--plex: true;
 @import "./data-table-sticky-column-menu";
 @import "./data-table-footer";
 @import "./data-table-align";
+@import "./data-table-pinned-column";
 @import "./pagination";
 @import "./structured-list-input-focusable";
 @import "./multiselect";

--- a/css/white.scss
+++ b/css/white.scss
@@ -59,6 +59,7 @@ $css--plex: true;
 @import "./data-table-sticky-column-menu";
 @import "./data-table-footer";
 @import "./data-table-align";
+@import "./data-table-pinned-column";
 @import "./pagination";
 @import "./structured-list-input-focusable";
 @import "./multiselect";

--- a/docs/src/pages/components/DataTable.svx
+++ b/docs/src/pages/components/DataTable.svx
@@ -417,6 +417,14 @@ Flip `columnHidden` on a bound `headers` array from a `ToolbarMenu` to build a c
 
 <FileSource src="/framed/DataTable/DataTableColumnVisibility" />
 
+### Pinned columns
+
+Set `pinned` to `"start"` or `"end"` in `headers` to keep a column visible while the table scrolls horizontally. The selection and expansion columns pin along with the first `start` column. Pinned columns must be contiguous with their edge; a pin separated from the edge by an unpinned column is ignored.
+
+Pinned columns do not work with a [sticky header](#sticky-header).
+
+<FileSource src="/framed/DataTable/DataTablePinnedColumns" />
+
 ## Sticky header
 
 Set `stickyHeader` to fix the header in place while the body scrolls.

--- a/docs/src/pages/framed/DataTable/DataTablePinnedColumns.svelte
+++ b/docs/src/pages/framed/DataTable/DataTablePinnedColumns.svelte
@@ -1,0 +1,39 @@
+<script>
+  import { Button, DataTable } from "carbon-components-svelte";
+
+  const headers = [
+    { key: "name", value: "Name", width: "220px", pinned: "start" },
+    { key: "protocol", value: "Protocol", width: "160px" },
+    { key: "port", value: "Port", width: "140px" },
+    { key: "rule", value: "Rule", width: "200px" },
+    { key: "region", value: "Region", width: "180px" },
+    { key: "status", value: "Status", width: "160px" },
+    { key: "owner", value: "Owner", width: "200px" },
+    { key: "updated", value: "Last updated", width: "200px" },
+    { key: "actions", value: "Actions", width: "140px", pinned: "end" },
+  ];
+
+  const rows = Array.from({ length: 8 }).map((_, i) => ({
+    id: i,
+    name: `Load Balancer ${i + 1}`,
+    protocol: "HTTP",
+    port: i % 3 ? (i % 2 ? 3000 : 80) : 443,
+    rule: i % 3 ? "Round robin" : "DNS delegation",
+    region: i % 2 ? "us-south" : "eu-de",
+    status: i % 4 ? "Active" : "Disabled",
+    owner: i % 2 ? "Platform team" : "Networking team",
+    updated: `2024-0${(i % 9) + 1}-14`,
+  }));
+</script>
+
+<div style="overflow-x: auto">
+  <DataTable style="min-width: 1600px" {headers} {rows}>
+    <svelte:fragment slot="cell" let:cell>
+      {#if cell.key === "actions"}
+        <Button size="small" kind="ghost">Edit</Button>
+      {:else}
+        {cell.value}
+      {/if}
+    </svelte:fragment>
+  </DataTable>
+</div>

--- a/src/DataTable/DataTable.svelte
+++ b/src/DataTable/DataTable.svelte
@@ -24,6 +24,7 @@
    * @property {boolean} [sortAlways] - Override table-level sortAlways for this column
    * @property {boolean} [columnMenu] - Whether the column menu is enabled
    * @property {boolean} [columnHidden] - Whether the column is skipped in render while remaining in `headers`
+   * @property {"start" | "end"} [pinned] - Keep the column visible while the table scrolls horizontally. Pinned columns must be contiguous with their edge. Ignored when `stickyHeader` is `true`.
    * @property {string} [width]
    * @property {string} [minWidth]
    * @typedef {object} DataTableNonEmptyHeader<Row=DataTableRow>
@@ -35,6 +36,7 @@
    * @property {boolean} [sortAlways] - Override table-level sortAlways for this column
    * @property {boolean} [columnMenu] - Whether the column menu is enabled
    * @property {boolean} [columnHidden] - Whether the column is skipped in render while remaining in `headers`
+   * @property {"start" | "end"} [pinned] - Keep the column visible while the table scrolls horizontally. Pinned columns must be contiguous with their edge. Ignored when `stickyHeader` is `true`.
    * @property {string} [width]
    * @property {string} [minWidth]
    * @property {"start" | "end"} [columnAlign] - Horizontal alignment of the column header and cells. Logical, so `end` is the right edge in LTR and the left edge in RTL. Defaults to `"start"`.
@@ -331,6 +333,7 @@
   import { virtualize as virtualizeUtil } from "../utils/virtualize.js";
   import {
     compareValues,
+    computePinnedOffsets,
     formatHeaderWidth,
     getDisplayedRows,
     resolvePath,
@@ -412,6 +415,7 @@
   onMount(() => {
     return () => {
       if (scrollListenerCleanup) scrollListenerCleanup();
+      if (pinnedResizeCleanup) pinnedResizeCleanup();
     };
   });
 
@@ -632,6 +636,7 @@
         empty: header.empty,
         columnMenu: header.columnMenu,
         columnAlign: header.columnAlign,
+        pinned: header.pinned,
       });
     });
 
@@ -691,7 +696,8 @@
             a.display === b.display &&
             a.empty === b.empty &&
             a.columnMenu === b.columnMenu &&
-            a.columnAlign === b.columnAlign
+            a.columnAlign === b.columnAlign &&
+            a.pinned === b.pinned
           ) {
             newCells[i] = a;
           } else {
@@ -818,8 +824,134 @@
   );
 
   // Calculate total columns for spacer rows and expanded row cells
-  $: totalColumns =
-    (expandable ? 1 : 0) + (isSelectionEnabled ? 1 : 0) + visibleHeaders.length;
+  $: leadingColumns = (expandable ? 1 : 0) + (isSelectionEnabled ? 1 : 0);
+  $: totalColumns = leadingColumns + visibleHeaders.length;
+
+  /**
+   * `stickyHeader` lays the table out with `display: flex` rows in two
+   * independently scrolling containers, where `position: sticky` cannot pin a
+   * column. Pinning opts out of that mode instead of half-supporting it.
+   */
+  $: isPinned = !stickyHeader && visibleHeaders.some((header) => header.pinned);
+
+  // The selection and expansion columns pin with the first `start` column;
+  // leaving them floating beside a pinned identifier column looks broken.
+  $: pinnedFlags = isPinned
+    ? [
+        ...Array(leadingColumns).fill(
+          visibleHeaders[0]?.pinned === "start" ? "start" : undefined,
+        ),
+        ...visibleHeaders.map((header) => header.pinned),
+      ]
+    : [];
+
+  /** @type {Array<number>} */
+  let columnWidths = [];
+  /** @type {null | (() => void)} */
+  let pinnedResizeCleanup = null;
+
+  /**
+   * Sticky offsets are the summed widths of the pinned cells before a column.
+   * Those widths are not knowable from `headers` (the selection and expansion
+   * columns are content-sized and `width` is optional), so read them off the
+   * rendered header row.
+   * @param {HTMLElement} table
+   */
+  function measureColumnWidths(table) {
+    const headerRow = table.querySelector("thead tr");
+    if (!headerRow) return;
+    const next = Array.from(
+      headerRow.children,
+      (cell) => cell.getBoundingClientRect().width,
+    );
+    if (
+      next.length === columnWidths.length &&
+      next.every((width, index) => width === columnWidths[index])
+    ) {
+      return;
+    }
+    columnWidths = next;
+  }
+
+  $: if (pinnedResizeCleanup && !(isPinned && tableRef)) {
+    pinnedResizeCleanup();
+    pinnedResizeCleanup = null;
+    columnWidths = [];
+  }
+
+  // Re-measure on every column change, and on layout changes via the observer.
+  $: if (isPinned && tableRef && pinnedFlags.length > 0) {
+    if (pinnedResizeCleanup) {
+      pinnedResizeCleanup();
+      pinnedResizeCleanup = null;
+    }
+    const table = tableRef;
+    tick().then(() => measureColumnWidths(table));
+    if (typeof ResizeObserver !== "undefined") {
+      const observer = new ResizeObserver(() => measureColumnWidths(table));
+      observer.observe(table);
+      pinnedResizeCleanup = () => observer.disconnect();
+    }
+  }
+
+  $: pinnedOffsets = computePinnedOffsets(columnWidths, pinnedFlags);
+
+  /**
+   * Everything the markup needs for one pinned column: `class:` and `style:`
+   * directives for plain cells, plus class and style strings for `TableHeader`
+   * and `TableCell`, which forward them to their inner `th` / `td`.
+   * @param {"start" | "end"} side
+   * @param {number} offset
+   * @param {boolean} isBoundary
+   */
+  function createPinnedColumn(side, offset, isBoundary) {
+    const inset = `${offset}px`;
+    const className = `bx--table-column--pinned-${side}`;
+    return {
+      side,
+      isBoundary,
+      className: isBoundary
+        ? `${className} bx--table-column--pinned-boundary`
+        : className,
+      style: `inset-inline-${side}: ${inset}`,
+      insetStart: side === "start" ? inset : undefined,
+      insetEnd: side === "end" ? inset : undefined,
+    };
+  }
+
+  /**
+   * Resolved pin per column, in rendered cell order (leading columns first).
+   * `null` for columns that are not pinned.
+   */
+  $: pinnedColumns = pinnedFlags.map((_, index) => {
+    const endIndex = pinnedFlags.length - pinnedOffsets.end.length;
+    if (index < pinnedOffsets.start.length) {
+      return createPinnedColumn(
+        "start",
+        pinnedOffsets.start[index],
+        index === pinnedOffsets.start.length - 1,
+      );
+    }
+    if (index >= endIndex) {
+      return createPinnedColumn(
+        "end",
+        pinnedOffsets.end[index - endIndex],
+        index === endIndex,
+      );
+    }
+    return null;
+  });
+
+  /**
+   * @param {{ width?: string; minWidth?: string }} header
+   * @param {null | { style: string }} pinned
+   */
+  function formatHeaderStyle(header, pinned) {
+    return (
+      [formatHeaderWidth(header), pinned?.style].filter(Boolean).join(";") ||
+      undefined
+    );
+  }
 </script>
 
 <TableContainer {useStaticWidth} {...$$restProps}>
@@ -867,6 +999,7 @@
       {useStaticWidth}
       labelledBy={hasTitle ? titleId : undefined}
       describedBy={hasDescription ? descriptionId : undefined}
+      data-pinned-columns={isPinned ? "" : undefined}
       tableStyle={[
         hasCustomHeaderWidth && "table-layout: fixed",
         stickyHeader &&
@@ -883,10 +1016,16 @@
       >
         <TableRow>
           {#if expandable}
+            {@const pinned = pinnedColumns[0]}
             <th
               scope="col"
               id="{id}-expand"
               class:bx--table-expand={true}
+              class:bx--table-column--pinned-start={pinned?.side === "start"}
+              class:bx--table-column--pinned-end={pinned?.side === "end"}
+              class:bx--table-column--pinned-boundary={pinned?.isBoundary}
+              style:inset-inline-start={pinned?.insetStart}
+              style:inset-inline-end={pinned?.insetEnd}
               data-previous-value={expanded ? "collapsed" : undefined}
             >
               {#if batchExpansion}
@@ -922,12 +1061,29 @@
             </th>
           {/if}
           {#if isSelectionEnabled && !batchSelection}
-            <th scope="col">
+            {@const pinned = pinnedColumns[expandable ? 1 : 0]}
+            <th
+              scope="col"
+              class:bx--table-column--pinned-start={pinned?.side === "start"}
+              class:bx--table-column--pinned-end={pinned?.side === "end"}
+              class:bx--table-column--pinned-boundary={pinned?.isBoundary}
+              style:inset-inline-start={pinned?.insetStart}
+              style:inset-inline-end={pinned?.insetEnd}
+            >
               <span class:bx--visually-hidden={true}>Select row</span>
             </th>
           {/if}
           {#if batchSelection && !radio}
-            <th scope="col" class:bx--table-column-checkbox={true}>
+            {@const pinned = pinnedColumns[expandable ? 1 : 0]}
+            <th
+              scope="col"
+              class:bx--table-column-checkbox={true}
+              class:bx--table-column--pinned-start={pinned?.side === "start"}
+              class:bx--table-column--pinned-end={pinned?.side === "end"}
+              class:bx--table-column--pinned-boundary={pinned?.isBoundary}
+              style:inset-inline-start={pinned?.insetStart}
+              style:inset-inline-end={pinned?.insetEnd}
+            >
               <InlineCheckbox
                 aria-label="Select all rows"
                 name="{id}-select-all"
@@ -956,24 +1112,40 @@
               />
             </th>
           {/if}
-          {#each visibleHeaders as header (header.key)}
+          {#each visibleHeaders as header, columnIndex (header.key)}
+            {@const pinned = pinnedColumns[leadingColumns + columnIndex]}
             {#if header.empty}
               {#if header.columnMenu}
                 <th
                   scope="col"
                   class:bx--table-column-menu={true}
+                  class:bx--table-column--pinned-start={pinned?.side === "start"}
+                  class:bx--table-column--pinned-end={pinned?.side === "end"}
+                  class:bx--table-column--pinned-boundary={pinned?.isBoundary}
+                  style:inset-inline-start={pinned?.insetStart}
+                  style:inset-inline-end={pinned?.insetEnd}
                   style={formatHeaderWidth(header)}
                 ></th>
               {:else}
-                <th scope="col" style={formatHeaderWidth(header)}>
+                <th
+                  scope="col"
+                  class:bx--table-column--pinned-start={pinned?.side === "start"}
+                  class:bx--table-column--pinned-end={pinned?.side === "end"}
+                  class:bx--table-column--pinned-boundary={pinned?.isBoundary}
+                  style:inset-inline-start={pinned?.insetStart}
+                  style:inset-inline-end={pinned?.insetEnd}
+                  style={formatHeaderWidth(header)}
+                >
                   <div class:bx--table-header-label={true}></div>
                 </th>
               {/if}
             {:else}
               <TableHeader
                 id="{id}-{header.key}"
-                class={formatAlignClass(header.columnAlign)}
-                style={formatHeaderWidth(header)}
+                class={[formatAlignClass(header.columnAlign), pinned?.className]
+                  .filter(Boolean)
+                  .join(" ")}
+                style={formatHeaderStyle(header, pinned)}
                 sortable={sortable && header.sort !== false}
                 sortDirection={sortKey === header.key ? sortDirection : "none"}
                 active={sortKey === header.key}
@@ -1084,8 +1256,10 @@
               }}
             >
               {#if expandable}
+                {@const pinned = pinnedColumns[0]}
                 <TableCell
-                  class="bx--table-expand"
+                  class="bx--table-expand {pinned?.className ?? ''}"
+                  style={pinned?.style}
                   headers="{id}-expand"
                   data-previous-value={!nonExpandableRowIdsSet.has(row.id) &&
                   expandedRowIdsSet.has(row.id)
@@ -1127,9 +1301,15 @@
                 </TableCell>
               {/if}
               {#if isSelectionEnabled}
+                {@const pinned = pinnedColumns[expandable ? 1 : 0]}
                 <td
                   class:bx--table-column-checkbox={true}
                   class:bx--table-column-radio={radio}
+                  class:bx--table-column--pinned-start={pinned?.side === "start"}
+                  class:bx--table-column--pinned-end={pinned?.side === "end"}
+                  class:bx--table-column--pinned-boundary={pinned?.isBoundary}
+                  style:inset-inline-start={pinned?.insetStart}
+                  style:inset-inline-end={pinned?.insetEnd}
                 >
                   {#if !nonSelectableRowIdsSet.has(row.id)}
                     {@const inputId = `${id}-${row.id}`}
@@ -1180,10 +1360,17 @@
                 </td>
               {/if}
               {#each tableCellsByRowId[row.id] as cell, j (cell.key)}
+                {@const pinned = pinnedColumns[leadingColumns + j]}
                 {#if cell.empty}
                   <td
                     class={formatAlignClass(cell.columnAlign)}
                     class:bx--table-column-menu={cell.columnMenu}
+                    class:bx--table-column--pinned-start={pinned?.side ===
+                      "start"}
+                    class:bx--table-column--pinned-end={pinned?.side === "end"}
+                    class:bx--table-column--pinned-boundary={pinned?.isBoundary}
+                    style:inset-inline-start={pinned?.insetStart}
+                    style:inset-inline-end={pinned?.insetEnd}
                   >
                     <slot
                       name="cell"
@@ -1201,8 +1388,11 @@
                   </td>
                 {:else}
                   <TableCell
-                    class={formatAlignClass(cell.columnAlign)}
+                    class={[formatAlignClass(cell.columnAlign), pinned?.className]
+                      .filter(Boolean)
+                      .join(" ")}
                     headers="{id}-{cell.key}"
+                    style={pinned?.style}
                     on:click={(event) => {
                       dispatch("click", { row, cell });
                       dispatch("click:cell", {
@@ -1318,8 +1508,10 @@
               }}
             >
               {#if expandable}
+                {@const pinned = pinnedColumns[0]}
                 <TableCell
-                  class="bx--table-expand"
+                  class="bx--table-expand {pinned?.className ?? ''}"
+                  style={pinned?.style}
                   headers="{id}-expand"
                   data-previous-value={isExpandable && isExpanded
                     ? "collapsed"
@@ -1359,9 +1551,15 @@
                 </TableCell>
               {/if}
               {#if isSelectionEnabled}
+                {@const pinned = pinnedColumns[expandable ? 1 : 0]}
                 <td
                   class:bx--table-column-checkbox={true}
                   class:bx--table-column-radio={radio}
+                  class:bx--table-column--pinned-start={pinned?.side === "start"}
+                  class:bx--table-column--pinned-end={pinned?.side === "end"}
+                  class:bx--table-column--pinned-boundary={pinned?.isBoundary}
+                  style:inset-inline-start={pinned?.insetStart}
+                  style:inset-inline-end={pinned?.insetEnd}
                 >
                   {#if isSelectable}
                     {@const inputId = `${id}-${row.id}`}
@@ -1409,10 +1607,17 @@
                 </td>
               {/if}
               {#each tableCellsByRowId[row.id] as cell, j (cell.key)}
+                {@const pinned = pinnedColumns[leadingColumns + j]}
                 {#if cell.empty}
                   <td
                     class={formatAlignClass(cell.columnAlign)}
                     class:bx--table-column-menu={cell.columnMenu}
+                    class:bx--table-column--pinned-start={pinned?.side ===
+                      "start"}
+                    class:bx--table-column--pinned-end={pinned?.side === "end"}
+                    class:bx--table-column--pinned-boundary={pinned?.isBoundary}
+                    style:inset-inline-start={pinned?.insetStart}
+                    style:inset-inline-end={pinned?.insetEnd}
                   >
                     <slot
                       name="cell"
@@ -1428,8 +1633,11 @@
                   </td>
                 {:else}
                   <TableCell
-                    class={formatAlignClass(cell.columnAlign)}
+                    class={[formatAlignClass(cell.columnAlign), pinned?.className]
+                      .filter(Boolean)
+                      .join(" ")}
                     headers="{id}-{cell.key}"
+                    style={pinned?.style}
                     on:click={(event) => {
                       dispatch("click", { row, cell });
                       dispatch("click:cell", {

--- a/src/DataTable/data-table-utils.d.ts
+++ b/src/DataTable/data-table-utils.d.ts
@@ -49,6 +49,18 @@ export function formatHeaderWidth<
 >(header: Header): string | undefined;
 
 /**
+ * Sticky offsets for pinned columns, in source order.
+ *
+ * `start` covers columns `0..start.length - 1` and `end` covers the final
+ * `end.length` columns. Pins that are not contiguous with their edge are
+ * dropped; missing widths count as `0`.
+ */
+export function computePinnedOffsets(
+  columnWidths: ReadonlyArray<number>,
+  pinnedFlags: ReadonlyArray<"start" | "end" | undefined>,
+): { start: Array<number>; end: Array<number> };
+
+/**
  * Compares two values for sorting in a data table.
  * Handles numbers, strings, null/undefined values, and custom sort functions.
  * @returns {number} Negative if a < b (ascending) or a > b (descending), positive if a > b (ascending) or a < b (descending), 0 if equal

--- a/src/DataTable/data-table-utils.js
+++ b/src/DataTable/data-table-utils.js
@@ -226,6 +226,48 @@ export function formatHeaderWidth(header) {
 }
 
 /**
+ * Sticky offsets for pinned columns, in source order.
+ *
+ * A pinned column must be contiguous with its edge: `start` pins run from the
+ * first column, `end` pins run from the last. A pin that is separated from its
+ * edge by an unpinned column is dropped rather than accommodated, since sticky
+ * offsets can only be stacked against an edge.
+ *
+ * `start` covers columns `0..start.length - 1` and `end` covers the final
+ * `end.length` columns, so each offset maps back to a column by position.
+ * Missing widths count as `0`, which keeps the pinned set stable before the
+ * first measurement.
+ * @param {ReadonlyArray<number>} columnWidths - Rendered width of each column, in source order
+ * @param {ReadonlyArray<"start" | "end" | undefined>} pinnedFlags - Requested pin side of each column, in source order
+ * @returns {{ start: Array<number>, end: Array<number> }}
+ */
+export function computePinnedOffsets(columnWidths, pinnedFlags) {
+  const flags = Array.isArray(pinnedFlags) ? pinnedFlags : [];
+  const widths = Array.isArray(columnWidths) ? columnWidths : [];
+
+  /** @type {Array<number>} */
+  const start = [];
+  /** @type {Array<number>} */
+  const end = [];
+
+  let offset = 0;
+  for (let i = 0; i < flags.length; i++) {
+    if (flags[i] !== "start") break;
+    start.push(offset);
+    offset += widths[i] || 0;
+  }
+
+  offset = 0;
+  for (let i = flags.length - 1; i >= start.length; i--) {
+    if (flags[i] !== "end") break;
+    end.unshift(offset);
+    offset += widths[i] || 0;
+  }
+
+  return { start, end };
+}
+
+/**
  * Compares two values for sorting in a data table.
  * Handles numbers, strings, null/undefined values, and custom sort functions.
  * @template T

--- a/tests/DataTable/DataTable.test.svelte
+++ b/tests/DataTable/DataTable.test.svelte
@@ -12,6 +12,7 @@
   type DataTableHeader = {
     key: string;
     value: string;
+    pinned?: "start" | "end";
     width?: string;
     minWidth?: string;
     columnAlign?: "start" | "end";

--- a/tests/DataTable/DataTable.test.ts
+++ b/tests/DataTable/DataTable.test.ts
@@ -2823,6 +2823,160 @@ describe("DataTable", () => {
     expect(overlap).toHaveLength(0);
   });
 
+  describe("pinned columns", () => {
+    const PINNED_START = "bx--table-column--pinned-start";
+    const PINNED_BOUNDARY = "bx--table-column--pinned-boundary";
+
+    const pinnedHeaders = [
+      { key: "name", value: "Name", pinned: "start" },
+      { key: "protocol", value: "Protocol" },
+      { key: "port", value: "Port" },
+      { key: "rule", value: "Rule" },
+    ] as const;
+
+    /** Body rows, excluding virtualization spacer rows. */
+    const getDataRows = () =>
+      screen
+        .getAllByRole("row")
+        .filter((row) => row.closest("tbody") !== null)
+        .filter((row) => !row.getAttribute("style")?.includes("height:"));
+
+    it("pins the header cell and every body cell in that column", () => {
+      render(DataTable, { props: { headers: pinnedHeaders, rows } });
+
+      const columnHeaders = screen.getAllByRole("columnheader");
+      expect(columnHeaders[0]).toHaveClass(PINNED_START);
+      expect(columnHeaders[0].getAttribute("style")).toContain(
+        "inset-inline-start",
+      );
+      for (const columnHeader of columnHeaders.slice(1)) {
+        expect(columnHeader).not.toHaveClass(PINNED_START);
+      }
+
+      const dataRows = getDataRows();
+      expect(dataRows).toHaveLength(rows.length);
+      for (const row of dataRows) {
+        const cells = within(row).getAllByRole("cell");
+        expect(cells[0]).toHaveClass(PINNED_START);
+        expect(cells[0].getAttribute("style")).toContain("inset-inline-start");
+        for (const cell of cells.slice(1)) {
+          expect(cell).not.toHaveClass(PINNED_START);
+        }
+      }
+    });
+
+    it("pins the selection column alongside the first start column", () => {
+      render(DataTable, {
+        props: { headers: pinnedHeaders, rows, selectable: true },
+      });
+
+      const [selectionHeader, nameHeader] = screen.getAllByRole("columnheader");
+      expect(selectionHeader).toHaveClass(PINNED_START);
+      expect(selectionHeader.getAttribute("style")).toContain(
+        "inset-inline-start",
+      );
+      expect(nameHeader).toHaveClass(PINNED_START);
+
+      for (const row of getDataRows()) {
+        const [selectionCell, nameCell] = within(row).getAllByRole("cell");
+        expect(selectionCell).toHaveClass(PINNED_START);
+        expect(nameCell).toHaveClass(PINNED_START);
+      }
+    });
+
+    it("ignores a pin that is not contiguous with its edge", () => {
+      const { container } = render(DataTable, {
+        props: {
+          headers: [
+            { key: "name", value: "Name" },
+            { key: "protocol", value: "Protocol", pinned: "start" },
+            { key: "port", value: "Port" },
+            { key: "rule", value: "Rule" },
+          ],
+          rows,
+        },
+      });
+
+      expect(container.querySelectorAll(`.${PINNED_START}`)).toHaveLength(0);
+    });
+
+    it("marks only the last start column as the boundary", () => {
+      render(DataTable, {
+        props: {
+          headers: [
+            { key: "name", value: "Name", pinned: "start" },
+            { key: "protocol", value: "Protocol", pinned: "start" },
+            { key: "port", value: "Port" },
+            { key: "rule", value: "Rule" },
+          ],
+          rows,
+        },
+      });
+
+      const columnHeaders = screen.getAllByRole("columnheader");
+      expect(columnHeaders[0]).not.toHaveClass(PINNED_BOUNDARY);
+      expect(columnHeaders[1]).toHaveClass(PINNED_BOUNDARY);
+
+      for (const row of getDataRows()) {
+        const cells = within(row).getAllByRole("cell");
+        expect(cells[0]).not.toHaveClass(PINNED_BOUNDARY);
+        expect(cells[1]).toHaveClass(PINNED_BOUNDARY);
+      }
+    });
+
+    it("ignores pinned columns when stickyHeader is set", () => {
+      const { container } = render(DataTable, {
+        props: { headers: pinnedHeaders, rows, stickyHeader: true },
+      });
+
+      expect(container.querySelectorAll(`.${PINNED_START}`)).toHaveLength(0);
+      expect(
+        container.querySelector("table")?.hasAttribute("data-pinned-columns"),
+      ).toBe(false);
+    });
+
+    it("pins rendered rows but not spacer rows when virtualized", () => {
+      const virtualizedRows = Array.from({ length: 500 }, (_, i) => ({
+        id: String(i),
+        name: `Load Balancer ${i + 1}`,
+        protocol: "HTTP",
+        port: 3000 + i,
+        rule: "Round robin",
+      }));
+
+      render(DataTable, {
+        props: {
+          headers: pinnedHeaders,
+          rows: virtualizedRows,
+          virtualize: true,
+        },
+      });
+
+      const bodyRows = screen
+        .getAllByRole("row")
+        .filter((row) => row.closest("tbody") !== null);
+      const spacerRows = bodyRows.filter((row) =>
+        row.getAttribute("style")?.includes("height:"),
+      );
+      const dataRows = bodyRows.filter(
+        (row) => !row.getAttribute("style")?.includes("height:"),
+      );
+
+      expect(spacerRows.length).toBeGreaterThan(0);
+      expect(dataRows.length).toBeGreaterThan(0);
+      expect(dataRows.length).toBeLessThan(virtualizedRows.length);
+
+      for (const row of dataRows) {
+        expect(within(row).getAllByRole("cell")[0]).toHaveClass(PINNED_START);
+      }
+      for (const row of spacerRows) {
+        for (const cell of within(row).getAllByRole("cell")) {
+          expect(cell).not.toHaveClass(PINNED_START);
+        }
+      }
+    });
+  });
+
   describe("virtualization", () => {
     const createLargeRowList = (count: number) => {
       return Array.from({ length: count }, (_, i) => ({

--- a/tests/DataTable/data-table-utils.test.ts
+++ b/tests/DataTable/data-table-utils.test.ts
@@ -1,5 +1,6 @@
 import {
   compareValues,
+  computePinnedOffsets,
   formatHeaderWidth,
   getDisplayedRows,
   resolvePath,
@@ -1314,5 +1315,86 @@ describe("toCsv", () => {
 
   it("emits only the header row when there are no rows", () => {
     expect(toCsv(headers, [])).toBe("Name,Port");
+  });
+});
+
+describe("computePinnedOffsets", () => {
+  it("returns empty arrays when no column is pinned", () => {
+    expect(
+      computePinnedOffsets([100, 200, 300], [undefined, undefined, undefined]),
+    ).toEqual({ start: [], end: [] });
+  });
+
+  it("returns empty arrays for empty input", () => {
+    expect(computePinnedOffsets([], [])).toEqual({ start: [], end: [] });
+  });
+
+  it("gives the first start column an offset of zero", () => {
+    expect(
+      computePinnedOffsets([100, 200, 300], ["start", undefined, undefined]),
+    ).toEqual({ start: [0], end: [] });
+  });
+
+  it("accumulates start offsets from the preceding widths", () => {
+    expect(
+      computePinnedOffsets([100, 200, 300], ["start", "start", "start"]),
+    ).toEqual({ start: [0, 100, 300], end: [] });
+  });
+
+  it("accumulates end offsets from the right, in reverse", () => {
+    expect(
+      computePinnedOffsets([100, 200, 300], [undefined, "end", "end"]),
+    ).toEqual({ start: [], end: [300, 0] });
+  });
+
+  it("pins both edges of the same table", () => {
+    expect(
+      computePinnedOffsets(
+        [100, 200, 300, 400],
+        ["start", undefined, "end", "end"],
+      ),
+    ).toEqual({ start: [0], end: [400, 0] });
+  });
+
+  it("drops a start pin that is not contiguous with the leading edge", () => {
+    expect(
+      computePinnedOffsets([100, 200, 300], [undefined, "start", undefined]),
+    ).toEqual({ start: [], end: [] });
+  });
+
+  it("drops an end pin that is not contiguous with the trailing edge", () => {
+    expect(
+      computePinnedOffsets([100, 200, 300], [undefined, "end", undefined]),
+    ).toEqual({ start: [], end: [] });
+  });
+
+  it("keeps the contiguous run and drops the pin beyond the gap", () => {
+    expect(
+      computePinnedOffsets(
+        [100, 200, 300, 400],
+        ["start", "start", undefined, "start"],
+      ),
+    ).toEqual({ start: [0, 100], end: [] });
+  });
+
+  it("treats missing widths as zero", () => {
+    expect(computePinnedOffsets([], ["start", "start"])).toEqual({
+      start: [0, 0],
+      end: [],
+    });
+  });
+
+  it("never counts one column as both a start and an end pin", () => {
+    expect(computePinnedOffsets([100], ["start"])).toEqual({
+      start: [0],
+      end: [],
+    });
+  });
+
+  it("returns empty arrays for non-array input", () => {
+    expect(
+      // @ts-expect-error
+      computePinnedOffsets(undefined, undefined),
+    ).toEqual({ start: [], end: [] });
   });
 });


### PR DESCRIPTION
Keeps start or end columns visible during horizontal scroll.
Selection and expansion columns pin with the first start column.
Pinned columns must be contiguous from their edge; pinning is
ignored when stickyHeader is set.