### PR TITLE
feat(data-table): add per-column filtering with cancelable `filter` event

### DIFF
--- a/docs/src/pages/components/DataTable.svx
+++ b/docs/src/pages/components/DataTable.svx
@@ -867,6 +867,20 @@ Pass a function to `shouldFilterRows` to implement custom filtering logic.
 
 <FileSource src="/framed/DataTable/DataTableFilterCustom" />
 
+### Per-column
+
+Bind to `filters` for per-column filtering. Each entry is keyed by `header.key`; a blank value, `null`, or an empty array leaves that column unfiltered. A string value matches a case-insensitive substring, an array matches any of its members, and a header can supply its own predicate through `filter` to compare values another way.
+
+Column filters combine with the toolbar search, and `filteredRowIds` reflects both. Bind to it on `DataTable` rather than on `ToolbarSearch` when column filters are in play.
+
+<FileSource src="/framed/DataTable/DataTableColumnFilters" />
+
+### Server-side filtering
+
+There is no built-in filter UI, so `filter` fires whenever a column filter value changes. It is cancelable in the same way as the [sort event](#server-side): call `preventDefault()` to take the change and skip local filtering, read `event.detail.filters` as your query parameters, then assign the rows the server returns.
+
+<FileSource src="/framed/DataTable/DataTableFilterPreventDefault" />
+
 ### Strategy
 
 By default (`filterMode="remove"`), filtering unmounts non-matching rows, resetting focus, draft inputs, and open menus. This keeps the DOM small for large tables.
@@ -1255,6 +1269,8 @@ When rows and sort order come from an API, the canonical order is usually define
 Client-side sorting on the same payload can disagree with that behavior or waste work on large datasets. In those cases, call `preventDefault()` on the `sort` event so the table does not reorder rows or apply its own sort for that click. Use event.detail.key and event.detail.direction as your sort parameters (query string, GraphQL variables, RPC args), wait for the response, then assign the new rows. The sort indicators should match what the server applied: bind sortKey and sortDirection from the parent and set them after the response (as in the example), or pass them as one-way props if you do not need child-to-parent sync.
 
 The framed example uses setTimeout to simulate a network request; `preventDefault()` runs first, then simulated sorted rows replace rows and the bound sort props update the header.
+
+The `filter` event works the same way for column filters; see [Server-side filtering](#server-side-filtering).
 
 <FileSource src="/framed/DataTable/DataTableSortPreventDefault" />
 

--- a/docs/src/pages/framed/DataTable/DataTableColumnFilters.svelte
+++ b/docs/src/pages/framed/DataTable/DataTableColumnFilters.svelte
@@ -1,0 +1,68 @@
+<script>
+  import {
+    DataTable,
+    NumberInput,
+    Pagination,
+    Select,
+    SelectItem,
+    Stack,
+    TextInput,
+  } from "carbon-components-svelte";
+
+  const rows = Array.from({ length: 10 }).map((_, i) => ({
+    id: i,
+    name: `Load Balancer ${i + 1}`,
+    protocol: i % 3 ? "HTTP" : "FTP",
+    port: 3000 + i * 10,
+    rule: i % 2 ? "Round robin" : "DNS delegation",
+  }));
+
+  const headers = [
+    { key: "name", value: "Name" },
+    { key: "protocol", value: "Protocol" },
+    {
+      key: "port",
+      value: "Port",
+      filter: (value, filterValue) => value >= filterValue,
+    },
+    { key: "rule", value: "Rule" },
+  ];
+
+  let filters = {};
+  let filteredRowIds = [];
+  let pageSize = 5;
+  let page = 1;
+</script>
+
+<Stack gap={6}>
+  <Select labelText="Protocol" bind:selected={filters.protocol}>
+    <SelectItem value="" text="All" />
+    <SelectItem value="HTTP" text="HTTP" />
+    <SelectItem value="FTP" text="FTP" />
+  </Select>
+  <TextInput
+    labelText="Name"
+    placeholder="Filter by name"
+    bind:value={filters.name}
+  />
+  <NumberInput
+    label="Minimum port"
+    min={3000}
+    step={10}
+    bind:value={filters.port}
+  />
+  <DataTable
+    {headers}
+    {rows}
+    {pageSize}
+    {page}
+    bind:filters
+    bind:filteredRowIds
+  />
+  <Pagination
+    bind:pageSize
+    bind:page
+    totalItems={filteredRowIds.length}
+    pageSizeInputDisabled
+  />
+</Stack>

--- a/docs/src/pages/framed/DataTable/DataTableFilterPreventDefault.svelte
+++ b/docs/src/pages/framed/DataTable/DataTableFilterPreventDefault.svelte
@@ -1,0 +1,52 @@
+<script>
+  import {
+    DataTable,
+    Select,
+    SelectItem,
+    Stack,
+  } from "carbon-components-svelte";
+
+  // Mock data from the server.
+  const allFromServer = [
+    { id: "1", name: "Load Balancer 1", protocol: "HTTP" },
+    { id: "2", name: "Load Balancer 2", protocol: "FTP" },
+    { id: "3", name: "Load Balancer 3", protocol: "HTTP" },
+  ];
+
+  let rows = [...allFromServer];
+  let filters = {};
+
+  // Simulate fetching filtered data from a remote server.
+  function fakeServerFilter(nextFilters) {
+    return new Promise((resolve) => {
+      const { protocol } = nextFilters;
+      setTimeout(() => {
+        resolve(
+          protocol
+            ? allFromServer.filter((row) => row.protocol === protocol)
+            : [...allFromServer],
+        );
+      }, 250);
+    });
+  }
+</script>
+
+<Stack gap={6}>
+  <Select labelText="Protocol" bind:selected={filters.protocol}>
+    <SelectItem value="" text="All" />
+    <SelectItem value="HTTP" text="HTTP" />
+    <SelectItem value="FTP" text="FTP" />
+  </Select>
+  <DataTable
+    headers={[
+      { key: "name", value: "Name" },
+      { key: "protocol", value: "Protocol" },
+    ]}
+    {rows}
+    bind:filters
+    on:filter={async (e) => {
+      e.preventDefault();
+      rows = await fakeServerFilter(e.detail.filters);
+    }}
+  />
+</Stack>

--- a/src/DataTable/DataTable.svelte
+++ b/src/DataTable/DataTable.svelte
@@ -424,71 +424,74 @@
   // Row ids that match the active filter. In "hide" mode this toggles `hidden` on rows
   // instead of shrinking `tableRows`.
   let matchedRowIdsSet = new Set(originalRows.map((row) => row.id));
-  // Last filter applied via `filterRows`, replayed when `rows` changes so
+  // Last search applied via `filterRows`, replayed when `rows` changes so
   // an active search is not silently dropped on row reassignment.
   let lastSearchValue = "";
   let lastCustomFilter = undefined;
 
   /**
+   * Recompute the matched rows from `originalRows` using the stored search state.
+   * "hide" mode keeps every row in `tableRows` and lets `matchedRowIdsSet` carry
+   * the truth; otherwise the rendered set shrinks to the matches.
+   * @type {() => ReadonlyArray<Row["id"]>}
+   */
+  function applyFilters() {
+    const searchValue = String(lastSearchValue ?? "")
+      .trim()
+      .toLowerCase();
+    let filteredRows = originalRows;
+
+    if (searchValue.length > 0) {
+      if (typeof lastCustomFilter === "function") {
+        filteredRows = filteredRows.filter((row) =>
+          lastCustomFilter(row, searchValue),
+        );
+      } else {
+        // Get searchable keys from headers (non-empty headers with keys).
+        // Hidden columns are excluded: matching on a column the user cannot
+        // see produces results they cannot explain.
+        const searchableKeys = visibleHeaders
+          .filter((header) => !header.empty && header.key)
+          .map((header) => header.key);
+
+        // Default filter checks fields defined in headers
+        // for a basic, case-insensitive match (non-fuzzy).
+        // This supports nested keys like "contact.company".
+        filteredRows = filteredRows.filter((row) =>
+          searchableKeys.some((searchKey) => {
+            const cellValue = resolvePath(row, searchKey);
+            if (
+              typeof cellValue === "string" ||
+              typeof cellValue === "number"
+            ) {
+              return `${cellValue}`.toLowerCase().includes(searchValue);
+            }
+            return false;
+          }),
+        );
+      }
+    }
+
+    const ids = filteredRows.map((row) => row.id);
+    matchedRowIdsSet = new Set(ids);
+    tableRows.set(hideMode ? originalRows : filteredRows);
+    return ids;
+  }
+
+  /**
+   * Record the search state from `ToolbarSearch` and recompute the matched rows.
    * @type {(searchValue: string, customFilter?: (row: Row, value: string) => boolean) => ReadonlyArray<Row["id"]>}
    */
   function filterRows(searchValue, customFilter) {
     lastSearchValue = searchValue;
     lastCustomFilter = customFilter;
-    const value = searchValue.trim().toLowerCase();
-
-    if (value.length === 0) {
-      // Reset to original rows.
-      const ids = originalRows.map((row) => row.id);
-      matchedRowIdsSet = new Set(ids);
-      tableRows.set(originalRows);
-      return ids;
-    }
-
-    let filteredRows = [];
-
-    if (typeof customFilter === "function") {
-      // Apply custom filter if provided.
-      filteredRows = originalRows.filter((row) => customFilter(row, value));
-    } else {
-      // Get searchable keys from headers (non-empty headers with keys).
-      // Hidden columns are excluded: matching on a column the user cannot
-      // see produces results they cannot explain.
-      const searchableKeys = visibleHeaders
-        .filter((header) => !header.empty && header.key)
-        .map((header) => header.key);
-
-      // Default filter checks fields defined in headers
-      // for a basic, case-insensitive match (non-fuzzy).
-      // This supports nested keys like "contact.company".
-      filteredRows = originalRows.filter((row) => {
-        return searchableKeys.some((searchKey) => {
-          const cellValue = resolvePath(row, searchKey);
-          if (typeof cellValue === "string" || typeof cellValue === "number") {
-            return `${cellValue}`?.toLowerCase().includes(value);
-          }
-          return false;
-        });
-      });
-    }
-
-    const ids = filteredRows.map((row) => row.id);
-    matchedRowIdsSet = new Set(ids);
-    // "hide" mode keeps every row mounted and drives visibility via `matchedRowIdsSet`;
-    // otherwise shrink the rendered set as before.
-    tableRows.set(hideMode ? originalRows : filteredRows);
-    return ids;
+    return applyFilters();
   }
 
   $: if (rows !== prevRows_ref) {
     originalRows = [...rows];
     prevRows_ref = rows;
-    if (lastSearchValue.trim().length > 0) {
-      filterRows(lastSearchValue, lastCustomFilter);
-    } else {
-      matchedRowIdsSet = new Set(rows.map((row) => row.id));
-      $tableRows = rows;
-    }
+    applyFilters();
   }
 
   // Replay the active filter when the strategy flips so the rendered set and the
@@ -497,9 +500,7 @@
   let prevHideModeRef = hideMode;
   $: if (hideMode !== prevHideModeRef) {
     prevHideModeRef = hideMode;
-    if (lastSearchValue.trim().length > 0) {
-      filterRows(lastSearchValue, lastCustomFilter);
-    }
+    applyFilters();
   }
 
   /**

--- a/src/DataTable/DataTable.svelte
+++ b/src/DataTable/DataTable.svelte
@@ -21,6 +21,7 @@
    * @property {true} empty - Whether the header is empty
    * @property {(item: DataTableValue, row: Row) => DataTableValue} [display]
    * @property {false | ((a: DataTableSortValue<Row>, b: DataTableSortValue<Row>) => number)} [sort]
+   * @property {(value: DataTableValue, filterValue: any, row: Row) => boolean} [filter] - Override the default predicate for this column's entry in `filters`
    * @property {boolean} [sortAlways] - Override table-level sortAlways for this column
    * @property {boolean} [columnMenu] - Whether the column menu is enabled
    * @property {boolean} [columnHidden] - Whether the column is skipped in render while remaining in `headers`
@@ -32,6 +33,7 @@
    * @property {DataTableValue} value
    * @property {(item: DataTableValue, row: Row) => DataTableValue} [display]
    * @property {false | ((a: DataTableSortValue<Row>, b: DataTableSortValue<Row>) => number)} [sort]
+   * @property {(value: DataTableValue, filterValue: any, row: Row) => boolean} [filter] - Override the default predicate for this column's entry in `filters`
    * @property {boolean} [sortAlways] - Override table-level sortAlways for this column
    * @property {boolean} [columnMenu] - Whether the column menu is enabled
    * @property {boolean} [columnHidden] - Whether the column is skipped in render while remaining in `headers`
@@ -84,6 +86,10 @@
    * @event {{ key: null; direction: "none" } | { key: DataTableKey<Row>; direction: "ascending" | "descending" }} sort - Dispatched when a sortable column header would change the active sort. The event is cancelable: call `preventDefault()` to skip updating `sortKey` / `sortDirection` and skip client side sorting for that click (for example full server side sorting while still reading `detail.key` / `detail.direction` for your API). If not cancelled, the table applies the new sort and sorts the current `rows` client side. Typical uses: server side sorting, URL or query string sync, analytics, and persisting sort preferences.
    * @property {DataTableKey<Row> | null} key - Proposed sort column (`header.key`), or `null` when the proposed `direction` is `none`.
    * @property {"ascending" | "descending" | "none"} direction - Proposed sort direction for this click (applied internally unless the event is cancelled).
+   * @event {{ key: null; value: null; filters: Record<string, any> } | { key: DataTableKey<Row>; value: any; filters: Record<string, any> }} filter - Dispatched when the resolved `filters` change. There is no built-in filter UI, so this is not a click handler: it fires whenever a column filter value changes, including from a control bound into `filters`. The event is cancelable: call `preventDefault()` to skip client side filtering for that change (for example server side filtering, where you read `detail.filters` for your API and hand back new `rows`). If not cancelled, the table narrows the current `rows` client side. Typical uses: server side filtering, URL or query string sync, and persisting filter preferences.
+   * @property {DataTableKey<Row> | null} key - Column whose filter value changed (`header.key`), or `null` when more than one entry changed in a single assignment.
+   * @property {any} value - New filter value for `key`, or `null` when `key` is `null`.
+   * @property {Record<string, any>} filters - The whole filter map after the change.
    * @event click:cell
    * @type {object}
    * @property {DataTableCell<Row>} cell
@@ -281,6 +287,33 @@
    */
   export let filterMode = "remove";
 
+  /**
+   * Specify per-column filter values, keyed by `header.key`.
+   *
+   * An entry is skipped when its value is `undefined`, `null`, a blank string, or an
+   * empty array. Active entries combine with `AND` across columns and with the
+   * `ToolbarSearch` value. A column matches on a case-insensitive substring for a
+   * string value, on membership for an array value, and on strict equality otherwise;
+   * set `header.filter` to override the predicate for that column.
+   * @example
+   * ```svelte
+   * <Select bind:selected={filters.status} …/>
+   * <DataTable bind:filters bind:filteredRowIds {headers} {rows} />
+   * ```
+   * @type {Record<string, any>}
+   * @bindable writable
+   */
+  export let filters = {};
+
+  /**
+   * The row ids matching the column filters and the `ToolbarSearch` value.
+   * Bind to this rather than to `ToolbarSearch.filteredRowIds` when column
+   * filters are in play; with no column filters the two agree.
+   * @type {ReadonlyArray<Row["id"]>}
+   * @bindable readonly
+   */
+  export let filteredRowIds = [];
+
   /** Specify the number of items to display in a page */
   export let pageSize = 0;
 
@@ -326,8 +359,10 @@
   import { virtualize as virtualizeUtil } from "../utils/virtualize.js";
   import {
     compareValues,
+    createColumnFilterPredicate,
     formatHeaderWidth,
     getDisplayedRows,
+    isColumnFilterActive,
     resolvePath,
     shouldIgnoreRowClick,
   } from "./data-table-utils.js";
@@ -428,17 +463,90 @@
   // an active search is not silently dropped on row reassignment.
   let lastSearchValue = "";
   let lastCustomFilter = undefined;
+  // Column filters as of the last pass, so that assigning `filters` from within an
+  // `on:filter` handler cannot loop. Compared by value rather than by reference: a
+  // control bound to `filters.someKey` mutates the map in place.
+  let appliedFilters = snapshotFilters(filters);
 
   /**
-   * Recompute the matched rows from `originalRows` using the stored search state.
-   * "hide" mode keeps every row in `tableRows` and lets `matchedRowIdsSet` carry
-   * the truth; otherwise the rendered set shrinks to the matches.
+   * @type {(source: Record<string, DataTableValue>) => Record<string, DataTableValue>}
+   */
+  function snapshotFilters(source) {
+    const snapshot = {};
+    for (const [key, value] of Object.entries(source ?? {})) {
+      snapshot[key] = Array.isArray(value) ? [...value] : value;
+    }
+    return snapshot;
+  }
+
+  /**
+   * @type {(a: DataTableValue, b: DataTableValue) => boolean}
+   */
+  function filterValuesEqual(a, b) {
+    if (Array.isArray(a) && Array.isArray(b)) {
+      return a.length === b.length && a.every((value, i) => value === b[i]);
+    }
+    return a === b;
+  }
+
+  /**
+   * Keys whose filter value differs from the last applied pass.
+   * @type {(next: Record<string, DataTableValue>) => string[]}
+   */
+  function getChangedFilterKeys(next) {
+    const changed = [];
+    const keys = new Set([
+      ...Object.keys(next),
+      ...Object.keys(appliedFilters),
+    ]);
+
+    for (const key of keys) {
+      if (!filterValuesEqual(next[key], appliedFilters[key])) {
+        changed.push(key);
+      }
+    }
+
+    return changed;
+  }
+
+  /**
+   * Active column filters paired with their resolved predicates.
+   * @type {() => Array<{ key: string; predicate: (cellValue: DataTableValue, row: Row) => boolean }>}
+   */
+  function getActiveColumnFilters() {
+    const active = [];
+    /** @type {Map<string, DataTableHeader<Row>> | null} */
+    let headersByKey = null;
+
+    for (const [key, filterValue] of Object.entries(filters ?? {})) {
+      if (!isColumnFilterActive(filterValue)) continue;
+      if (headersByKey === null) {
+        headersByKey = new Map(headers.map((header) => [header.key, header]));
+      }
+      active.push({
+        key,
+        predicate: createColumnFilterPredicate(
+          filterValue,
+          headersByKey.get(key)?.filter,
+        ),
+      });
+    }
+
+    return active;
+  }
+
+  /**
+   * Recompute the matched rows from `originalRows` using the stored search state and
+   * the active column filters, which combine with `AND`. "hide" mode keeps every row
+   * in `tableRows` and lets `matchedRowIdsSet` carry the truth; otherwise the
+   * rendered set shrinks to the matches.
    * @type {() => ReadonlyArray<Row["id"]>}
    */
   function applyFilters() {
     const searchValue = String(lastSearchValue ?? "")
       .trim()
       .toLowerCase();
+    const activeColumnFilters = getActiveColumnFilters();
     let filteredRows = originalRows;
 
     if (searchValue.length > 0) {
@@ -472,8 +580,17 @@
       }
     }
 
+    if (activeColumnFilters.length > 0) {
+      filteredRows = filteredRows.filter((row) =>
+        activeColumnFilters.every(({ key, predicate }) =>
+          predicate(resolvePath(row, key), row),
+        ),
+      );
+    }
+
     const ids = filteredRows.map((row) => row.id);
     matchedRowIdsSet = new Set(ids);
+    filteredRowIds = ids;
     tableRows.set(hideMode ? originalRows : filteredRows);
     return ids;
   }
@@ -487,6 +604,34 @@
     lastCustomFilter = customFilter;
     return applyFilters();
   }
+
+  /**
+   * Dispatch the cancelable `filter` event, then filter client side unless the
+   * consumer cancelled. Mirrors the `sort` dispatch: compute the next state, dispatch,
+   * and only apply when the dispatch returns truthy.
+   * @type {(next: Record<string, DataTableValue>) => void}
+   */
+  function syncColumnFilters(next) {
+    const changedKeys = getChangedFilterKeys(next);
+    if (changedKeys.length === 0) return;
+
+    // Record the change before dispatching so a handler that assigns `filters`
+    // is treated as a new change instead of re-entering this one.
+    appliedFilters = snapshotFilters(next);
+    const key = changedKeys.length === 1 ? changedKeys[0] : null;
+    const applyFilter = dispatch(
+      "filter",
+      { key, value: key === null ? null : next[key], filters: next },
+      { cancelable: true },
+    );
+
+    if (applyFilter) applyFilters();
+  }
+
+  // Seed `filteredRowIds` and apply any column filters passed at mount.
+  applyFilters();
+
+  $: syncColumnFilters(filters ?? {});
 
   $: if (rows !== prevRows_ref) {
     originalRows = [...rows];

--- a/src/DataTable/data-table-utils.d.ts
+++ b/src/DataTable/data-table-utils.d.ts
@@ -49,6 +49,29 @@ export function formatHeaderWidth<
 >(header: Header): string | undefined;
 
 /**
+ * Returns true when a column filter value should narrow the rows.
+ * `undefined`, `null`, a blank string, and an empty array leave the column unfiltered.
+ */
+export function isColumnFilterActive(filterValue: unknown): boolean;
+
+/**
+ * Builds the predicate for one active column filter. Called once per filter pass so
+ * per-value work (lowercasing a needle, building a membership set) stays out of the
+ * row loop.
+ *
+ * `headerFilter` wins when the column defines one. Otherwise an array `filterValue`
+ * matches cell values that are members of it, a string matches a case-insensitive
+ * substring of a string or number cell value (what the toolbar search does), and any
+ * other value matches by strict equality.
+ */
+export function createColumnFilterPredicate<
+  Row extends Record<string, unknown> = Record<string, unknown>,
+>(
+  filterValue: unknown,
+  headerFilter?: (value: unknown, filterValue: unknown, row: Row) => boolean,
+): (cellValue: unknown, row: Row) => boolean;
+
+/**
  * Compares two values for sorting in a data table.
  * Handles numbers, strings, null/undefined values, and custom sort functions.
  * @returns {number} Negative if a < b (ascending) or a > b (descending), positive if a > b (ascending) or a < b (descending), 0 if equal

--- a/src/DataTable/data-table-utils.js
+++ b/src/DataTable/data-table-utils.js
@@ -226,6 +226,56 @@ export function formatHeaderWidth(header) {
 }
 
 /**
+ * Returns true when a column filter value should narrow the rows.
+ * `undefined`, `null`, a blank string, and an empty array leave the column unfiltered.
+ * @param {unknown} filterValue - A value from the `filters` map
+ * @returns {boolean}
+ */
+export function isColumnFilterActive(filterValue) {
+  if (filterValue == null) return false;
+  if (Array.isArray(filterValue)) return filterValue.length > 0;
+  if (typeof filterValue === "string") return filterValue.trim().length > 0;
+  return true;
+}
+
+/**
+ * Builds the predicate for one active column filter. Called once per filter pass so
+ * per-value work (lowercasing a needle, building a membership set) stays out of the
+ * row loop.
+ *
+ * `headerFilter` wins when the column defines one. Otherwise an array `filterValue`
+ * matches cell values that are members of it, a string matches a case-insensitive
+ * substring of a string or number cell value (what the toolbar search does), and any
+ * other value matches by strict equality.
+ * @template {Record<string, unknown>} Row
+ * @param {unknown} filterValue - A value from the `filters` map
+ * @param {(value: any, filterValue: any, row: Row) => boolean} [headerFilter] - Per-column predicate override
+ * @returns {(cellValue: unknown, row: Row) => boolean}
+ */
+export function createColumnFilterPredicate(filterValue, headerFilter) {
+  if (typeof headerFilter === "function") {
+    return (cellValue, row) => !!headerFilter(cellValue, filterValue, row);
+  }
+
+  if (Array.isArray(filterValue)) {
+    const allowed = new Set(filterValue);
+    return (cellValue) => allowed.has(cellValue);
+  }
+
+  if (typeof filterValue === "string") {
+    const value = filterValue.trim().toLowerCase();
+    return (cellValue) => {
+      if (typeof cellValue !== "string" && typeof cellValue !== "number") {
+        return false;
+      }
+      return `${cellValue}`.toLowerCase().includes(value);
+    };
+  }
+
+  return (cellValue) => cellValue === filterValue;
+}
+
+/**
  * Compares two values for sorting in a data table.
  * Handles numbers, strings, null/undefined values, and custom sort functions.
  * @template T

--- a/tests/DataTable/DataTableColumnFilters.preventDefault.test.svelte
+++ b/tests/DataTable/DataTableColumnFilters.preventDefault.test.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+  import DataTable from "carbon-components-svelte/DataTable/DataTable.svelte";
+
+  const headers = [
+    { key: "name", value: "Name" },
+    { key: "protocol", value: "Protocol" },
+  ] as const;
+
+  const rows = [
+    { id: "a", name: "Zebra", protocol: "HTTP" },
+    { id: "b", name: "Alpha", protocol: "FTP" },
+  ] as const;
+
+  export let filters: Record<string, unknown> = {};
+
+  /** When true, `on:filter` calls preventDefault() so the table does not filter client-side. */
+  export let preventFilterDefault = false;
+
+  export let onfilter:
+    | ((
+        e: CustomEvent<{
+          key: string | null;
+          value: unknown;
+          filters: Record<string, unknown>;
+        }>,
+      ) => void)
+    | undefined = undefined;
+</script>
+
+<DataTable
+  {headers}
+  {rows}
+  {filters}
+  on:filter={(e) => {
+    onfilter?.(e);
+    if (preventFilterDefault) e.preventDefault();
+  }}
+/>

--- a/tests/DataTable/DataTableColumnFilters.test.svelte
+++ b/tests/DataTable/DataTableColumnFilters.test.svelte
@@ -1,0 +1,78 @@
+<script lang="ts">
+  import type { DataTableHeader } from "carbon-components-svelte/DataTable/DataTable.svelte";
+  import DataTable from "carbon-components-svelte/DataTable/DataTable.svelte";
+  import Toolbar from "carbon-components-svelte/DataTable/Toolbar.svelte";
+  import ToolbarContent from "carbon-components-svelte/DataTable/ToolbarContent.svelte";
+  import ToolbarSearch from "carbon-components-svelte/DataTable/ToolbarSearch.svelte";
+
+  export let filters: Record<string, unknown> = {};
+  export let filterMode: "remove" | "hide" = "remove";
+  export let batchSelection = false;
+  export let selectedRowIds: string[] = [];
+  export let sortable = false;
+  export let search = false;
+  export let showControls = false;
+  /** Match `status` exactly instead of the default case-insensitive substring. */
+  export let exactStatus = false;
+  export let filteredRowIds: readonly string[] = [];
+
+  type Row = { id: string; name: string; protocol: string; status: string };
+
+  const initialRows: Row[] = [
+    { id: "a", name: "Zebra", protocol: "HTTP", status: "active" },
+    { id: "b", name: "Alpha", protocol: "HTTP", status: "inactive" },
+    { id: "c", name: "Mango", protocol: "FTP", status: "active" },
+    { id: "d", name: "Bravo", protocol: "HTTP", status: "disabled" },
+  ];
+
+  const toggledRows: Row[] = [
+    { id: "e", name: "Kilo", protocol: "HTTP", status: "active" },
+    { id: "f", name: "Lima", protocol: "FTP", status: "active" },
+  ];
+
+  let rows = initialRows;
+
+  const headers: DataTableHeader<Row>[] = [
+    { key: "name", value: "Name" },
+    { key: "protocol", value: "Protocol" },
+    {
+      key: "status",
+      value: "Status",
+      filter: exactStatus
+        ? (value, filterValue) => value === filterValue
+        : undefined,
+    },
+  ];
+</script>
+
+<button type="button" on:click={() => (rows = toggledRows)}>Toggle rows</button>
+
+{#if showControls}
+  <select aria-label="Protocol filter" bind:value={filters.protocol}>
+    <option value="">All</option>
+    <option value="HTTP">HTTP</option>
+    <option value="FTP">FTP</option>
+  </select>
+{/if}
+
+<DataTable
+  {headers}
+  {rows}
+  {filterMode}
+  {batchSelection}
+  {sortable}
+  bind:filters
+  bind:filteredRowIds
+  bind:selectedRowIds
+>
+  {#if search}
+    <Toolbar>
+      <ToolbarContent>
+        <ToolbarSearch persistent shouldFilterRows />
+      </ToolbarContent>
+    </Toolbar>
+  {/if}
+</DataTable>
+
+<span data-testid="filtered-row-ids">{filteredRowIds.join(",")}</span>
+<span data-testid="selected-count">{selectedRowIds.length}</span>

--- a/tests/DataTable/DataTableColumnFilters.test.ts
+++ b/tests/DataTable/DataTableColumnFilters.test.ts
@@ -1,0 +1,199 @@
+import { render, screen, within } from "@testing-library/svelte";
+import { user } from "../utils/user";
+import DataTableColumnFiltersPreventDefault from "./DataTableColumnFilters.preventDefault.test.svelte";
+import DataTableColumnFilters from "./DataTableColumnFilters.test.svelte";
+
+describe("DataTable column filters", () => {
+  const getBodyRows = () =>
+    screen.getAllByRole("row").filter((row) => row.closest("tbody") !== null);
+  const getRowNames = () =>
+    getBodyRows().map((row) => within(row).getAllByRole("cell")[0].textContent);
+  const filteredRowIds = () =>
+    screen.getByTestId("filtered-row-ids").textContent;
+
+  it("narrows the rendered rows and restores them when the filter clears", async () => {
+    const { rerender } = render(DataTableColumnFilters, {
+      props: { filters: { protocol: "FTP" } },
+    });
+
+    expect(getRowNames()).toEqual(["Mango"]);
+
+    await rerender({ filters: {} });
+
+    expect(getRowNames()).toEqual(["Zebra", "Alpha", "Mango", "Bravo"]);
+  });
+
+  it("combines two active filters with AND", async () => {
+    const { rerender } = render(DataTableColumnFilters, {
+      props: { filters: { protocol: "HTTP" } },
+    });
+
+    expect(getRowNames()).toEqual(["Zebra", "Alpha", "Bravo"]);
+
+    await rerender({ filters: { protocol: "HTTP", status: "disabled" } });
+
+    expect(getRowNames()).toEqual(["Bravo"]);
+  });
+
+  it("combines a column filter with the toolbar search using AND", async () => {
+    const { rerender } = render(DataTableColumnFilters, {
+      props: { search: true, filters: { protocol: "HTTP" } },
+    });
+
+    await user.type(screen.getByRole("searchbox"), "zebra");
+    expect(getRowNames()).toEqual(["Zebra"]);
+
+    await rerender({ filters: { protocol: "FTP" } });
+    expect(getBodyRows()).toHaveLength(0);
+  });
+
+  it("matches a substring for a string filter value", () => {
+    render(DataTableColumnFilters, {
+      props: { filters: { status: "active" } },
+    });
+
+    // "inactive" contains "active", so the default predicate matches it.
+    expect(getRowNames()).toEqual(["Zebra", "Alpha", "Mango"]);
+  });
+
+  it("uses header.filter in place of the default predicate", () => {
+    render(DataTableColumnFilters, {
+      props: { exactStatus: true, filters: { status: "active" } },
+    });
+
+    expect(getRowNames()).toEqual(["Zebra", "Mango"]);
+  });
+
+  it("treats an empty string, null, and an empty array as inactive", async () => {
+    const { rerender } = render(DataTableColumnFilters, {
+      props: { filters: { protocol: "" } },
+    });
+
+    expect(getBodyRows()).toHaveLength(4);
+
+    await rerender({ filters: { protocol: null } });
+    expect(getBodyRows()).toHaveLength(4);
+
+    await rerender({ filters: { protocol: [] } });
+    expect(getBodyRows()).toHaveLength(4);
+
+    await rerender({ filters: { protocol: ["FTP"] } });
+    expect(getRowNames()).toEqual(["Mango"]);
+  });
+
+  it("reports the combined result in filteredRowIds and keeps it in sync with rows", async () => {
+    render(DataTableColumnFilters, {
+      props: { search: true, filters: { status: "active" } },
+    });
+
+    expect(filteredRowIds()).toBe("a,b,c");
+
+    await user.type(screen.getByRole("searchbox"), "mango");
+    expect(filteredRowIds()).toBe("c");
+
+    await user.clear(screen.getByRole("searchbox"));
+    await user.click(screen.getByRole("button", { name: "Toggle rows" }));
+    expect(filteredRowIds()).toBe("e,f");
+  });
+
+  it("applies a filter set through a control bound into filters", async () => {
+    render(DataTableColumnFilters, {
+      props: { showControls: true, filters: { protocol: "" } },
+    });
+
+    expect(getBodyRows()).toHaveLength(4);
+
+    await user.selectOptions(
+      screen.getByRole("combobox", { name: "Protocol filter" }),
+      "FTP",
+    );
+
+    expect(getRowNames()).toEqual(["Mango"]);
+  });
+
+  it("sorts only the matching rows", async () => {
+    render(DataTableColumnFilters, {
+      props: { sortable: true, filters: { protocol: "HTTP" } },
+    });
+
+    await user.click(screen.getByText("Name"));
+
+    expect(getRowNames()).toEqual(["Alpha", "Bravo", "Zebra"]);
+  });
+
+  describe('filterMode="hide"', () => {
+    it("keeps non-matching rows mounted with the hidden attribute", async () => {
+      const { rerender } = render(DataTableColumnFilters, {
+        props: { filterMode: "hide" },
+      });
+
+      await rerender({ filters: { protocol: "FTP" } });
+
+      expect(document.querySelector('[data-row="a"]')).toHaveAttribute(
+        "hidden",
+      );
+      expect(document.querySelector('[data-row="c"]')).not.toHaveAttribute(
+        "hidden",
+      );
+    });
+
+    it('"select all" selects only matching rows', async () => {
+      const { rerender } = render(DataTableColumnFilters, {
+        props: { filterMode: "hide", batchSelection: true },
+      });
+
+      await rerender({ filters: { protocol: "FTP" } });
+      await user.click(
+        screen.getByRole("checkbox", { name: "Select all rows" }),
+      );
+
+      expect(screen.getByTestId("selected-count")).toHaveTextContent("1");
+    });
+  });
+
+  describe("preventDefault", () => {
+    it("skips client-side filtering but still reports key, value, and filters", async () => {
+      const onfilter = vi.fn();
+      const { rerender } = render(DataTableColumnFiltersPreventDefault, {
+        props: { preventFilterDefault: true, onfilter },
+      });
+
+      await rerender({ filters: { protocol: "FTP" } });
+
+      expect(onfilter).toHaveBeenCalledTimes(1);
+      expect(onfilter.mock.calls[0][0].detail).toEqual({
+        key: "protocol",
+        value: "FTP",
+        filters: { protocol: "FTP" },
+      });
+      expect(getBodyRows()).toHaveLength(2);
+    });
+
+    it("filters client-side when the event is not cancelled", async () => {
+      const onfilter = vi.fn();
+      const { rerender } = render(DataTableColumnFiltersPreventDefault, {
+        props: { onfilter },
+      });
+
+      await rerender({ filters: { protocol: "FTP" } });
+
+      expect(onfilter).toHaveBeenCalledTimes(1);
+      expect(getBodyRows()).toHaveLength(1);
+    });
+
+    it("reports a null key when more than one entry changes at once", async () => {
+      const onfilter = vi.fn();
+      const { rerender } = render(DataTableColumnFiltersPreventDefault, {
+        props: { onfilter },
+      });
+
+      await rerender({ filters: { protocol: "FTP", name: "Alpha" } });
+
+      expect(onfilter.mock.calls[0][0].detail).toEqual({
+        key: null,
+        value: null,
+        filters: { protocol: "FTP", name: "Alpha" },
+      });
+    });
+  });
+});

--- a/tests/DataTable/data-table-utils.test.ts
+++ b/tests/DataTable/data-table-utils.test.ts
@@ -1,7 +1,9 @@
 import {
   compareValues,
+  createColumnFilterPredicate,
   formatHeaderWidth,
   getDisplayedRows,
+  isColumnFilterActive,
   resolvePath,
   rowsEqual,
   shouldIgnoreRowClick,
@@ -1127,6 +1129,80 @@ describe("getDisplayedRows", () => {
     const result = getDisplayedRows(rows, 1, 5);
     expect(result[0]).toBe(rows[0]);
     expect(result[4]).toBe(rows[4]);
+  });
+});
+
+describe("column filters", () => {
+  const row = { id: "a", name: "Zebra", status: "active" };
+
+  describe("isColumnFilterActive", () => {
+    it("treats undefined, null, blank strings, and empty arrays as inactive", () => {
+      expect(isColumnFilterActive(undefined)).toBe(false);
+      expect(isColumnFilterActive(null)).toBe(false);
+      expect(isColumnFilterActive("")).toBe(false);
+      expect(isColumnFilterActive("   ")).toBe(false);
+      expect(isColumnFilterActive([])).toBe(false);
+    });
+
+    it("treats any other value as active", () => {
+      expect(isColumnFilterActive("active")).toBe(true);
+      expect(isColumnFilterActive(["HTTP"])).toBe(true);
+      expect(isColumnFilterActive(0)).toBe(true);
+      expect(isColumnFilterActive(false)).toBe(true);
+    });
+  });
+
+  describe("createColumnFilterPredicate", () => {
+    it("matches a trimmed, case-insensitive substring for a string value", () => {
+      const predicate = createColumnFilterPredicate("  ZEB  ");
+      expect(predicate("Zebra", row)).toBe(true);
+      expect(predicate("Alpha", row)).toBe(false);
+    });
+
+    it("stringifies number cell values for a string value", () => {
+      const predicate = createColumnFilterPredicate("30");
+      expect(predicate(3000, row)).toBe(true);
+      expect(predicate(80, row)).toBe(false);
+    });
+
+    it("does not match cell values that are neither strings nor numbers", () => {
+      const predicate = createColumnFilterPredicate("true");
+      expect(predicate(true, row)).toBe(false);
+      expect(predicate(null, row)).toBe(false);
+      expect(predicate(undefined, row)).toBe(false);
+    });
+
+    it("matches membership for an array value", () => {
+      const predicate = createColumnFilterPredicate(["HTTP", "FTP"]);
+      expect(predicate("FTP", row)).toBe(true);
+      expect(predicate("HTTPS", row)).toBe(false);
+    });
+
+    it("matches strict equality for any other value", () => {
+      expect(createColumnFilterPredicate(3000)(3000, row)).toBe(true);
+      expect(createColumnFilterPredicate(3000)("3000", row)).toBe(false);
+      expect(createColumnFilterPredicate(false)(false, row)).toBe(true);
+      expect(createColumnFilterPredicate(false)(0, row)).toBe(false);
+    });
+
+    it("prefers the header predicate and passes it the cell value, filter value, and row", () => {
+      const headerFilter = vi.fn(() => true);
+      const predicate = createColumnFilterPredicate("active", headerFilter);
+
+      expect(predicate("inactive", row)).toBe(true);
+      expect(headerFilter).toHaveBeenCalledWith("inactive", "active", row);
+    });
+
+    it("coerces a truthy header predicate result to a boolean", () => {
+      const predicate = createColumnFilterPredicate(
+        "active",
+        // biome-ignore lint/suspicious/noExplicitAny: predicate returning a non-boolean
+        ((value: unknown) => value) as any,
+      );
+
+      expect(predicate("active", row)).toBe(true);
+      expect(predicate("", row)).toBe(false);
+    });
   });
 });
 


### PR DESCRIPTION
Bindable filters map keyed by header.key, optional per-header
predicate, and a cancelable filter event mirroring on:sort for
server-side consumers. Column filters combine with toolbar search;
filteredRowIds reflects both.