### PR TITLE
feat(multi-select): add empty menu slot for loading and no-results UI

### DIFF
--- a/css/_list-box-menu-item.scss
+++ b/css/_list-box-menu-item.scss
@@ -1,5 +1,6 @@
 @import "carbon-components/scss/globals/scss/vars";
 @import "carbon-components/scss/globals/scss/helper-mixins";
+@import "carbon-components/scss/globals/scss/typography";
 @import "carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/import-once/import-once";
 
 /// Left/right icons for list box menu items (Dropdown, ComboBox).
@@ -36,6 +37,23 @@
   }
 }
 
-@include exports('list-box-menu-item-icon') {
+/// Non-option empty/placeholder row for ComboBox and MultiSelect menus.
+/// @access private
+/// @group components
+@mixin list-box-menu-item-empty {
+  .#{$prefix}--list-box__menu-item--empty {
+    @include type-style("body-short-01");
+
+    padding: to-rem(11px) $carbon--spacing-05;
+    color: $text-02;
+    cursor: default;
+  }
+}
+
+@include exports("list-box-menu-item-icon") {
   @include list-box-menu-item-icon;
+}
+
+@include exports("list-box-menu-item-empty") {
+  @include list-box-menu-item-empty;
 }

--- a/docs/src/pages/components/MultiSelect.svx
+++ b/docs/src/pages/components/MultiSelect.svx
@@ -459,3 +459,11 @@ Set `readonly` to `true` to display non-editable values. The menu can still be o
     { id: "2", text: "Fax" },
   ]}
 />
+
+## Async results
+
+For async (for example, server-side) filtering, clear and replace `items` from an `on:input` handler. Debounce the fetch, then swap in the returned options. Set `filterItem` to always return `true` when the server already filtered the list.
+
+When the open menu has no options, the `empty` slot renders. Put loading, error, or "no matches" content there — MultiSelect does not model those states itself. Clear `items` while fetching so the slot appears. The default slot content is "No results".
+
+<FileSource src="/framed/MultiSelect/AsyncMultiSelect" />

--- a/docs/src/pages/framed/MultiSelect/AsyncMultiSelect.svelte
+++ b/docs/src/pages/framed/MultiSelect/AsyncMultiSelect.svelte
@@ -1,0 +1,61 @@
+<script>
+  import { InlineLoading, MultiSelect } from "carbon-components-svelte";
+
+  let items = [];
+  let status = "idle";
+  let timeoutId;
+
+  const allRoles = [
+    { id: "0", text: "Admin" },
+    { id: "1", text: "Editor" },
+    { id: "2", text: "Viewer" },
+    { id: "3", text: "Approver" },
+    { id: "4", text: "Auditor" },
+  ];
+
+  async function fetchRoles(query) {
+    await new Promise((resolve) => setTimeout(resolve, 300));
+
+    if (!query) {
+      return allRoles;
+    }
+
+    return allRoles.filter((item) =>
+      item.text.toLowerCase().includes(query.toLowerCase()),
+    );
+  }
+
+  function handleInput(event) {
+    const query = event.currentTarget.value;
+    status = "loading";
+    items = [];
+    clearTimeout(timeoutId);
+    timeoutId = setTimeout(async () => {
+      try {
+        items = await fetchRoles(query);
+        status = items.length ? "idle" : "empty";
+      } catch {
+        status = "error";
+      }
+    }, 150);
+  }
+</script>
+
+<MultiSelect
+  filterable
+  filterItem={() => true}
+  {items}
+  labelText="Role"
+  placeholder="Search roles..."
+  on:input={handleInput}
+>
+  <svelte:fragment slot="empty">
+    {#if status === "loading"}
+      <InlineLoading status="active" description="Loading…" />
+    {:else if status === "error"}
+      Something went wrong
+    {:else}
+      No matching roles
+    {/if}
+  </svelte:fragment>
+</MultiSelect>

--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -19,6 +19,7 @@
    * @event {FocusEvent | CustomEvent<FocusEvent>} blur
    * @event {{ trigger: "escape-key" | "outside-click" }} close
    * @slot {{ item: Item; index: number; selected: boolean; highlighted: boolean; }}
+   * @slot {{}} empty
    */
 
   /**
@@ -1015,7 +1016,11 @@
             ? `max-height: ${virtualConfig.containerHeight}px; overflow-y: auto;`
             : undefined}
       >
-        {#if virtualData?.isVirtualized}
+        {#if itemsToRender.length === 0}
+          <div role="presentation" class:bx--list-box__menu-item--empty={true}>
+            <slot name="empty">No results</slot>
+          </div>
+        {:else if virtualData?.isVirtualized}
           <div style="height: {virtualData.totalHeight}px; position: relative;">
             <div style="transform: translateY({virtualData.offsetY}px);">
               {#each itemsToRender as item, index (item.id)}

--- a/tests/MultiSelect/MultiSelect.test.ts
+++ b/tests/MultiSelect/MultiSelect.test.ts
@@ -18,6 +18,7 @@ import MultiSelectLabelSlot from "./MultiSelect.slot.test.svelte";
 import MultiSelect from "./MultiSelect.test.svelte";
 import MultiSelectBindValue from "./MultiSelectBindValue.test.svelte";
 import MultiSelectDuplicateIds from "./MultiSelectDuplicateIds.test.svelte";
+import MultiSelectEmptySlot from "./MultiSelectEmptySlot.test.svelte";
 import MultiSelectGenerics from "./MultiSelectGenerics.test.svelte";
 import MultiSelectInModal from "./MultiSelectInModal.test.svelte";
 import MultiSelectItemSlot from "./MultiSelectItemSlot.test.svelte";
@@ -3436,5 +3437,78 @@ describe("MultiSelect", () => {
     expect(listBox.children).toHaveLength(2);
     expect(listBox.children[0]).toHaveClass("bx--list-box__label");
     expect(listBox.children[1]).toHaveClass("bx--list-box__field");
+  });
+
+  describe("empty slot", () => {
+    it("shows the default empty content when the open menu has no items", () => {
+      render(MultiSelect, { props: { items: [], open: true } });
+
+      expect(screen.getByText("No results")).toBeInTheDocument();
+      expect(screen.queryByRole("option")).not.toBeInTheDocument();
+      expect(
+        document.querySelector(".bx--list-box__menu-item--empty"),
+      ).toBeInTheDocument();
+    });
+
+    it("shows the default empty content when a filter matches nothing", async () => {
+      render(MultiSelect, {
+        props: {
+          items,
+          filterable: true,
+          placeholder: "Filter...",
+        },
+      });
+
+      const input = screen.getByPlaceholderText("Filter...");
+      await user.click(input);
+      await user.type(input, "zzz");
+
+      expect(screen.getByText("No results")).toBeInTheDocument();
+      expect(screen.queryByRole("option")).not.toBeInTheDocument();
+    });
+
+    it("renders a custom empty slot instead of the default", () => {
+      render(MultiSelectEmptySlot, {
+        props: {
+          items: [],
+          open: true,
+          emptyContent: "Something went wrong",
+        },
+      });
+
+      expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+      expect(screen.queryByText("No results")).not.toBeInTheDocument();
+    });
+
+    it("does not treat the empty row as a selectable option", async () => {
+      render(MultiSelect, {
+        props: {
+          items: [],
+          open: true,
+          labelText: "Roles",
+        },
+      });
+
+      const combobox = screen.getByRole("combobox");
+      combobox.focus();
+      await user.keyboard("{ArrowDown}");
+      await tick();
+
+      expect(combobox).not.toHaveAttribute("aria-activedescendant");
+      expect(screen.queryByRole("option")).not.toBeInTheDocument();
+
+      await user.click(screen.getByText("No results"));
+      expect(screen.queryByRole("option")).not.toBeInTheDocument();
+    });
+
+    it("does not show the empty slot when the menu has items", () => {
+      render(MultiSelect, { props: { items, open: true } });
+
+      expect(screen.queryByText("No results")).not.toBeInTheDocument();
+      expect(screen.getAllByRole("option")).toHaveLength(3);
+      expect(
+        document.querySelector(".bx--list-box__menu-item--empty"),
+      ).not.toBeInTheDocument();
+    });
   });
 });

--- a/tests/MultiSelect/MultiSelectEmptySlot.test.svelte
+++ b/tests/MultiSelect/MultiSelectEmptySlot.test.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+  import MultiSelect from "carbon-components-svelte/MultiSelect/MultiSelect.svelte";
+  import type { ComponentProps } from "svelte";
+
+  export let items: ComponentProps<MultiSelect>["items"] = [];
+  export let filterable = false;
+  export let open = false;
+  export let placeholder = "Filter...";
+  export let emptyContent = "Loading…";
+</script>
+
+<MultiSelect {items} {filterable} {open} {placeholder} labelText="Roles">
+  <svelte:fragment slot="empty">{emptyContent}</svelte:fragment>
+</MultiSelect>


### PR DESCRIPTION
When the open menu has no options, an `empty` slot renders so
consumers can show loading, error, or no-match UI without a
built-in `loading` prop. Same pattern as TreeView `childNodes`.