### PR TITLE
feat(combo-box): add empty menu slot for loading and no-results UI

### DIFF
--- a/css/_list-box-menu-item.scss
+++ b/css/_list-box-menu-item.scss
@@ -39,3 +39,27 @@
 @include exports('list-box-menu-item-icon') {
   @include list-box-menu-item-icon;
 }
+
+/// Non-interactive empty / loading row for ComboBox and MultiSelect menus.
+/// @access private
+/// @group components
+@mixin list-box-menu-item-empty {
+  .#{$prefix}--list-box__menu-item--empty {
+    color: $text-02;
+    cursor: default;
+    pointer-events: none;
+
+    &:hover {
+      background-color: transparent;
+    }
+
+    .#{$prefix}--list-box__menu-item__option {
+      color: inherit;
+      border-top-color: transparent;
+    }
+  }
+}
+
+@include exports("list-box-menu-item-empty") {
+  @include list-box-menu-item-empty;
+}

--- a/docs/src/pages/components/ComboBox.svx
+++ b/docs/src/pages/components/ComboBox.svx
@@ -248,7 +248,9 @@ The original value is automatically restored if you close the dropdown without m
 
 ### Async
 
-For async (for example, server-side) filtering, bind to `value` and update `items` when input changes. This example simulates async behavior with a debounced input value change.
+For async (for example, server-side) filtering, bind to `value` and update `items` when input changes. Clear `items` while a request is in flight so the menu has no options.
+
+When the open menu has no options, the `empty` slot renders. Put loading UI, an error message, or a no-matches string there. This example simulates async behavior with a debounced input value change.
 
 <FileSource src="/framed/ComboBox/AsyncComboBox" />
 

--- a/docs/src/pages/framed/ComboBox/AsyncComboBox.svelte
+++ b/docs/src/pages/framed/ComboBox/AsyncComboBox.svelte
@@ -1,8 +1,8 @@
 <script>
-  import { ComboBox } from "carbon-components-svelte";
-  import { onMount } from "svelte";
+  import { ComboBox, InlineLoading } from "carbon-components-svelte";
 
   let items = [];
+  let status = "idle";
   let timeoutId;
   let inputValue = "";
 
@@ -32,24 +32,18 @@
     );
   }
 
-  onMount(() => {
-    // Fetch initial items.
-    fetchItems("")
-      .then((data) => {
-        items = data;
-      })
-      .catch(() => {});
-
-    return () => {
-      clearTimeout(timeoutId);
-    };
-  });
-
-  $: {
+  function handleInput() {
     clearTimeout(timeoutId);
+    status = "loading";
+    items = [];
+
     timeoutId = setTimeout(async () => {
-      items = await fetchItems(inputValue);
-      // Debounce input value changes.
+      try {
+        items = await fetchItems(inputValue);
+        status = items.length ? "idle" : "empty";
+      } catch {
+        status = "error";
+      }
     }, 150);
   }
 </script>
@@ -59,4 +53,15 @@
   placeholder="Type to search..."
   bind:value={inputValue}
   {items}
-/>
+  on:input={handleInput}
+>
+  <svelte:fragment slot="empty">
+    {#if status === "loading"}
+      <InlineLoading status="active" description="Searching…" />
+    {:else if status === "error"}
+      Something went wrong
+    {:else}
+      No contacts found
+    {/if}
+  </svelte:fragment>
+</ComboBox>

--- a/src/ComboBox/ComboBox.svelte
+++ b/src/ComboBox/ComboBox.svelte
@@ -17,6 +17,7 @@
    * @slot {{ item: Item; index: number; selected: boolean; highlighted: boolean; }}
    * @slot {{ item: Item; index: number; selected: boolean; highlighted: boolean; }} icon
    * @slot {{ item: Item; index: number; selected: boolean; highlighted: boolean; }} iconRight
+   * @slot {{}} empty
    */
 
   /**
@@ -860,7 +861,16 @@
             ? `max-height: ${virtualConfig.containerHeight}px; overflow-y: auto;`
             : undefined}
       >
-        {#if virtualData?.isVirtualized}
+        {#if filteredItems.length === 0}
+          <div
+            class:bx--list-box__menu-item={true}
+            class:bx--list-box__menu-item--empty={true}
+          >
+            <div class:bx--list-box__menu-item__option={true}>
+              <slot name="empty">No results</slot>
+            </div>
+          </div>
+        {:else if virtualData?.isVirtualized}
           <div style="height: {virtualData.totalHeight}px; position: relative;">
             <div style="transform: translateY({virtualData.offsetY}px);">
               {#each itemsToRender as item, index (item.id)}

--- a/tests/ComboBox/ComboBox.empty.test.svelte
+++ b/tests/ComboBox/ComboBox.empty.test.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+  import ComboBox from "carbon-components-svelte/ComboBox/ComboBox.svelte";
+  import type { ComponentProps } from "svelte";
+
+  export let items: ComponentProps<ComboBox>["items"] = [
+    { id: "0", text: "Slack" },
+    { id: "1", text: "Email" },
+    { id: "2", text: "Fax" },
+  ];
+  export let value = "";
+  export let open = false;
+  export let emptyContent: "custom" | "loading" | "error" = "custom";
+</script>
+
+<ComboBox
+  {items}
+  {value}
+  {open}
+  labelText="Contact"
+  placeholder="Select contact method"
+  shouldFilterItem={(item, filterValue) =>
+    item.text.toLowerCase().includes(filterValue.toLowerCase())}
+>
+  <svelte:fragment slot="empty">
+    {#if emptyContent === "loading"}
+      <span data-testid="empty-loading">Searching…</span>
+    {:else if emptyContent === "error"}
+      <span data-testid="empty-error">Something went wrong</span>
+    {:else}
+      <span data-testid="empty-custom">Custom empty</span>
+    {/if}
+  </svelte:fragment>
+</ComboBox>

--- a/tests/ComboBox/ComboBox.test.ts
+++ b/tests/ComboBox/ComboBox.test.ts
@@ -6,6 +6,7 @@ import { fuzzyMatch } from "carbon-components-svelte/utils/fuzzyMatch";
 import type { ComponentEvents, ComponentProps } from "svelte";
 import { tick } from "svelte";
 import { user } from "../utils/user";
+import ComboBoxEmpty from "./ComboBox.empty.test.svelte";
 import ComboBoxFluidForm from "./ComboBox.fluidForm.test.svelte";
 import ComboBoxFluidSkeleton from "./ComboBox.fluidSkeleton.test.svelte";
 import ComboBoxFluidSlot from "./ComboBox.fluidSlot.test.svelte";
@@ -564,6 +565,88 @@ describe("ComboBox", () => {
     await user.click(document.body);
     expect(input).not.toHaveFocus();
     expect(screen.queryByRole("option")).not.toBeInTheDocument();
+  });
+
+  describe("empty slot", () => {
+    it("shows default No results when the filtered list is empty", async () => {
+      render(ComboBox);
+
+      const input = getInput();
+      await user.click(input);
+      await user.type(input, "zzz");
+
+      expect(screen.getByText("No results")).toBeInTheDocument();
+      expect(screen.queryByRole("option")).not.toBeInTheDocument();
+      expect(
+        document.querySelector(".bx--list-box__menu-item--empty"),
+      ).toBeInTheDocument();
+    });
+
+    it("does not show the empty slot when options are present", async () => {
+      render(ComboBox);
+
+      await user.click(getInput());
+
+      expect(screen.queryByText("No results")).not.toBeInTheDocument();
+      expect(screen.getAllByRole("option").length).toBeGreaterThan(0);
+      expect(
+        document.querySelector(".bx--list-box__menu-item--empty"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("renders a custom empty slot for loading and error states", () => {
+      const { unmount } = render(ComboBoxEmpty, {
+        props: { items: [], open: true, emptyContent: "loading" },
+      });
+
+      expect(screen.getByTestId("empty-loading")).toHaveTextContent(
+        "Searching…",
+      );
+      expect(screen.queryByText("No results")).not.toBeInTheDocument();
+      expect(screen.queryByRole("option")).not.toBeInTheDocument();
+
+      unmount();
+
+      render(ComboBoxEmpty, {
+        props: { items: [], open: true, emptyContent: "error" },
+      });
+
+      expect(screen.getByTestId("empty-error")).toHaveTextContent(
+        "Something went wrong",
+      );
+      expect(screen.queryByTestId("empty-loading")).not.toBeInTheDocument();
+    });
+
+    it("does not treat the empty row as a selectable option", async () => {
+      render(ComboBox);
+
+      const input = getInput();
+      await user.click(input);
+      await user.type(input, "zzz");
+
+      expect(screen.getByText("No results")).toBeInTheDocument();
+      expect(screen.queryByRole("option")).not.toBeInTheDocument();
+      expect(input.getAttribute("aria-activedescendant")).toBe("");
+
+      await user.keyboard("{ArrowDown}");
+      expect(input.getAttribute("aria-activedescendant")).toBe("");
+      expect(input).toHaveValue("zzz");
+
+      await user.keyboard("{Enter}");
+      expect(input).toHaveValue("zzz");
+      expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    });
+
+    it("opens the menu when typing into an empty items list", async () => {
+      render(ComboBox, { props: { items: [] } });
+
+      const input = getInput();
+      await user.type(input, "a");
+
+      expect(input).toHaveAttribute("aria-expanded", "true");
+      expect(screen.getByText("No results")).toBeInTheDocument();
+      expect(screen.getByRole("listbox")).toBeVisible();
+    });
   });
 
   it("should clear input when clicking clear button", async () => {


### PR DESCRIPTION
When the open menu has no options, an `empty` slot renders so
consumers can show loading, error, or no-match UI. AsyncComboBox
now uses it with InlineLoading during fetch.