### PR TITLE
feat(multi-select): add maxSelectedItems selection cap

### DIFF
--- a/docs/src/pages/components/MultiSelect.svx
+++ b/docs/src/pages/components/MultiSelect.svx
@@ -115,6 +115,17 @@ Move selected items to the top of the list immediately after selection by settin
     {id: "2", text: "Fax"}]}"
   />
 
+### Maximum selection
+
+Limit how many items a user can select by setting `maxSelectedItems`. Once the cap is reached, remaining unchecked items are disabled until a selection is cleared. Select-all is unavailable when a cap is set.
+
+<MultiSelect maxSelectedItems="{3}" labelText="Preferences" label="Select preferences..."
+    items="{[{id: "0", text: "Email"},
+    {id: "1", text: "Slack"},
+    {id: "2", text: "SMS"},
+    {id: "3", text: "Push"}]}"
+  />
+
 ### Select all
 
 Add a "select all" item by setting isSelectAll to true on an item. Clicking this item selects or deselects all non-disabled items. Disabled items are not affected by "select all".

--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -76,6 +76,14 @@
    */
   export let selectionFeedback = "top-after-reopen";
 
+  /**
+   * Cap how many items can be selected at once.
+   * Unset or a non-positive value means unlimited.
+   * When set, select-all is unavailable and unchecked items disable once the cap is reached.
+   * @type {number | undefined}
+   */
+  export let maxSelectedItems = undefined;
+
   /** Set to `true` to disable the dropdown */
   export let disabled = false;
 
@@ -329,12 +337,25 @@
     declareRef,
   });
 
+  /**
+   * Whether an item should be treated as disabled for selection and keyboard nav.
+   * Checked items stay enabled at the cap so they can be cleared.
+   * @param {Item & { checked?: boolean }} item
+   */
+  function isItemDisabled(item) {
+    if (item.disabled) return true;
+    if (hasMaxSelectedItems && item.isSelectAll) return true;
+    if (isAtSelectionCap && !item.checked) return true;
+    return false;
+  }
+
   function change(step) {
     const navigableItems = filterable ? filteredItems : sortedItems;
     highlightedIndex = nextEnabledIndex({
       items: navigableItems,
       index: highlightedIndex,
       step,
+      isDisabled: isItemDisabled,
     });
     highlightOrigin = "keyboard";
   }
@@ -344,7 +365,7 @@
     // Read-only allows opening and navigating the menu to review values, but
     // never changing them. Guarding here covers every path (click, Enter,
     // label click, select-all) so callers don't each need a readonly check.
-    if (readonly || item.disabled) return;
+    if (readonly || isItemDisabled(item)) return;
 
     if (item.isSelectAll) {
       const target = !allSelected;
@@ -617,6 +638,10 @@
   $: selectionCount = hasSelectAll
     ? checked.filter((item) => !item.isSelectAll).length
     : checked.length;
+  $: hasMaxSelectedItems =
+    typeof maxSelectedItems === "number" && maxSelectedItems > 0;
+  $: isAtSelectionCap =
+    hasMaxSelectedItems && selectionCount >= maxSelectedItems;
   $: filteredItems = sortedItems.filter(
     (item) => item.isSelectAll || filterItem(item, value),
   );
@@ -1020,6 +1045,10 @@
             <div style="transform: translateY({virtualData.offsetY}px);">
               {#each itemsToRender as item, index (item.id)}
                 {@const actualIndex = virtualData.startIndex + index}
+                {@const itemDisabled =
+                  item.disabled ||
+                  (hasMaxSelectedItems && !!item.isSelectAll) ||
+                  (isAtSelectionCap && !item.checked)}
                 <ListBoxMenuItem
                   id="{id}-{item.id}"
                   role="option"
@@ -1032,9 +1061,9 @@
                     : item.checked}
                   active={item.isSelectAll ? false : item.checked}
                   highlighted={highlightedIndex === actualIndex}
-                  disabled={item.disabled}
+                  disabled={itemDisabled}
                   on:click={(event) => {
-                    if (item.disabled) {
+                    if (itemDisabled) {
                       event.stopPropagation();
                       return;
                     }
@@ -1049,7 +1078,7 @@
                     }
                   }}
                   on:mouseenter={() => {
-                    if (item.disabled) return;
+                    if (itemDisabled) return;
                     highlightedIndex = actualIndex;
                     highlightOrigin = "pointer";
                   }}
@@ -1065,7 +1094,7 @@
                     indeterminate={item.isSelectAll
                       ? selectAllIndeterminate
                       : false}
-                    disabled={item.disabled}
+                    disabled={itemDisabled}
                     {readonly}
                   >
                     <slot
@@ -1084,6 +1113,10 @@
           </div>
         {:else}
           {#each itemsToRender as item, index (item.id)}
+            {@const itemDisabled =
+              item.disabled ||
+              (hasMaxSelectedItems && !!item.isSelectAll) ||
+              (isAtSelectionCap && !item.checked)}
             <ListBoxMenuItem
               id="{id}-{item.id}"
               role="option"
@@ -1096,9 +1129,9 @@
                 : item.checked}
               active={item.isSelectAll ? false : item.checked}
               highlighted={highlightedIndex === index}
-              disabled={item.disabled}
+              disabled={itemDisabled}
               on:click={(event) => {
-                if (item.disabled) {
+                if (itemDisabled) {
                   event.stopPropagation();
                   return;
                 }
@@ -1113,7 +1146,7 @@
                 }
               }}
               on:mouseenter={() => {
-                if (item.disabled) return;
+                if (itemDisabled) return;
                 highlightedIndex = index;
                 highlightOrigin = "pointer";
               }}
@@ -1129,7 +1162,7 @@
                 indeterminate={item.isSelectAll
                   ? selectAllIndeterminate
                   : false}
-                disabled={item.disabled}
+                disabled={itemDisabled}
                 {readonly}
               >
                 <slot

--- a/tests/MultiSelect/MultiSelect.test.svelte
+++ b/tests/MultiSelect/MultiSelect.test.svelte
@@ -24,6 +24,8 @@
     undefined;
   export let selectionFeedback: ComponentProps<MultiSelect>["selectionFeedback"] =
     "top-after-reopen";
+  export let maxSelectedItems: ComponentProps<MultiSelect>["maxSelectedItems"] =
+    undefined;
   export let translateWithIdSelection: ComponentProps<MultiSelect>["translateWithIdSelection"] =
     undefined;
   export let itemToString: ComponentProps<MultiSelect>["itemToString"] = (
@@ -64,6 +66,7 @@
   {readonly}
   {readonlyText}
   {selectionFeedback}
+  {maxSelectedItems}
   {translateWithIdSelection}
   {itemToString}
   {itemToInput}

--- a/tests/MultiSelect/MultiSelect.test.ts
+++ b/tests/MultiSelect/MultiSelect.test.ts
@@ -571,6 +571,131 @@ describe("MultiSelect", () => {
     });
   });
 
+  describe("maxSelectedItems", () => {
+    const preferenceItems = [
+      { id: "0", text: "Email" },
+      { id: "1", text: "Slack" },
+      { id: "2", text: "SMS" },
+      { id: "3", text: "Push" },
+    ];
+
+    it("stops checking items once the cap is reached and still allows unchecking", async () => {
+      const consoleLog = vi.spyOn(console, "log");
+      render(MultiSelect, {
+        props: {
+          items: preferenceItems,
+          maxSelectedItems: 2,
+          labelText: "Preferences",
+        },
+      });
+
+      await openMenu();
+      await toggleOption("Email");
+      await toggleOption("Slack");
+
+      expect(consoleLog).toHaveBeenLastCalledWith(
+        "select",
+        expect.objectContaining({
+          selectedIds: expect.arrayContaining(["0", "1"]),
+        }),
+      );
+      expect(consoleLog.mock.calls.at(-1)?.[1].selectedIds).toHaveLength(2);
+
+      const smsOption = screen.getByRole("option", { name: "SMS" });
+      expect(smsOption).toHaveAttribute("aria-disabled", "true");
+
+      await user.click(smsOption);
+      expect(smsOption).toHaveAttribute("aria-selected", "false");
+      expect(consoleLog.mock.calls.at(-1)?.[1].selectedIds).toHaveLength(2);
+
+      await toggleOption("Email");
+      expect(consoleLog.mock.calls.at(-1)?.[1].selectedIds).toEqual(["1"]);
+
+      expect(smsOption).not.toHaveAttribute("aria-disabled");
+      await toggleOption("SMS");
+      expect(consoleLog.mock.calls.at(-1)?.[1].selectedIds).toEqual(
+        expect.arrayContaining(["1", "2"]),
+      );
+    });
+
+    it("skips unchecked items at the cap during keyboard navigation", async () => {
+      render(MultiSelect, {
+        props: {
+          items: preferenceItems,
+          maxSelectedItems: 1,
+          selectedIds: ["0"],
+          sortItem: () => 0,
+          labelText: "Preferences",
+        },
+      });
+
+      await openMenu();
+
+      const emailOption = screen.getByRole("option", { name: "Email" });
+      const slackOption = screen.getByRole("option", { name: "Slack" });
+      expect(slackOption).toHaveAttribute("aria-disabled", "true");
+
+      await user.keyboard("{ArrowDown}");
+      expect(emailOption).toHaveClass("bx--list-box__menu-item--highlighted");
+
+      await user.keyboard("{ArrowDown}");
+      expect(emailOption).toHaveClass("bx--list-box__menu-item--highlighted");
+      expect(slackOption).not.toHaveClass(
+        "bx--list-box__menu-item--highlighted",
+      );
+
+      await user.keyboard("{Enter}");
+      expect(emailOption).toHaveAttribute("aria-selected", "false");
+      expect(slackOption).not.toHaveAttribute("aria-disabled");
+    });
+
+    it("disables select-all when a cap is set", async () => {
+      const consoleLog = vi.spyOn(console, "log");
+      render(MultiSelect, {
+        props: {
+          items: [
+            { id: "select-all", text: "All roles", isSelectAll: true },
+            { id: "editor", text: "Editor" },
+            { id: "owner", text: "Owner" },
+            { id: "uploader", text: "Uploader" },
+          ],
+          maxSelectedItems: 2,
+          labelText: "Roles",
+        },
+      });
+
+      await openMenu();
+      const selectAllOption = screen.getByRole("option", { name: "All roles" });
+      expect(selectAllOption).toHaveAttribute("aria-disabled", "true");
+
+      await user.click(selectAllOption);
+      expect(consoleLog).not.toHaveBeenCalledWith("select", expect.anything());
+    });
+
+    it("preserves unlimited selection when maxSelectedItems is omitted", async () => {
+      const consoleLog = vi.spyOn(console, "log");
+      render(MultiSelect, {
+        props: {
+          items: preferenceItems,
+          labelText: "Preferences",
+        },
+      });
+
+      await openMenu();
+      await toggleOption("Email");
+      await toggleOption("Slack");
+      await toggleOption("SMS");
+      await toggleOption("Push");
+
+      expect(consoleLog.mock.calls.at(-1)?.[1].selectedIds).toHaveLength(4);
+      for (const name of ["Email", "Slack", "SMS", "Push"]) {
+        expect(screen.getByRole("option", { name })).not.toHaveAttribute(
+          "aria-disabled",
+        );
+      }
+    });
+  });
+
   describe("filtering behavior", () => {
     it("filters items based on input", async () => {
       const consoleLog = vi.spyOn(console, "log");


### PR DESCRIPTION
Caps how many items can be checked. Unchecking always works;
remaining items disable at the cap. Select-all is unavailable
when a cap is set.