### PR TITLE
feat(combo-box): add create option row and create event

### DIFF
--- a/docs/src/pages/components/ComboBox.svx
+++ b/docs/src/pages/components/ComboBox.svx
@@ -271,6 +271,14 @@ Set `allowCustomValue` to `true` to let users enter custom text that is not in t
 
 <FileSource src="/framed/ComboBox/AllowCustomValue" />
 
+### Create option
+
+Set `allowCustomValue` to `true` and listen to `create` to persist a new option. `allowCustomValue` keeps typed text when the menu closes; the menu also shows a trailing create row whenever the query is novel (no case-insensitive `itemToString` match), even if partial matches remain. Handle `create` to append to `items` and set `value` / `selectedId`. The combobox does not mutate `items` on its own.
+
+Override the row label with `createOptionText` — a string, or a function of the current query. The default label is `Create "…"` with the query inserted.
+
+<FileSource src="/framed/ComboBox/CreateOption" />
+
 ### Select text on focus
 
 Set `selectTextOnFocus` to `true` to select all text in the input when it receives focus (for example, on tab or click). Users can replace the value by typing without manually selecting first.

--- a/docs/src/pages/framed/ComboBox/CreateOption.svelte
+++ b/docs/src/pages/framed/ComboBox/CreateOption.svelte
@@ -1,0 +1,41 @@
+<script>
+  import { ComboBox, Stack } from "carbon-components-svelte";
+
+  let items = [
+    { id: "0", text: "Apple" },
+    { id: "1", text: "Banana" },
+    { id: "2", text: "Orange" },
+    { id: "3", text: "Strawberry" },
+  ];
+  let selectedId = undefined;
+  let value = "";
+</script>
+
+<Stack gap={2}>
+  <ComboBox
+    allowCustomValue
+    labelText="Favorite fruit"
+    placeholder="Select or create a fruit"
+    helperText="Type a new name and choose Create to add it to the list"
+    bind:selectedId
+    bind:value
+    {items}
+    shouldFilterItem={(item, query) => {
+      if (!query) return true;
+      return item.text.toLowerCase().includes(query.toLowerCase());
+    }}
+    on:create={(e) => {
+      const text = e.detail;
+      items = [...items, { id: text, text }];
+      value = text;
+      selectedId = text;
+    }}
+  />
+  <div>
+    <div><strong>Selected ID:</strong> {selectedId ?? "none"}</div>
+    <div><strong>Current value:</strong> {value || "empty"}</div>
+    <div>
+      <strong>Items:</strong> {items.map((item) => item.text).join(", ")}
+    </div>
+  </div>
+</Stack>

--- a/src/ComboBox/ComboBox.svelte
+++ b/src/ComboBox/ComboBox.svelte
@@ -23,6 +23,7 @@
    * @event close
    * @type {object}
    * @property {"escape-key" | "outside-click" | "select"} trigger
+   * @event {string} create
    */
 
   /**
@@ -124,9 +125,25 @@
   /**
    * Set to `true` to allow custom values that are not in the items list.
    * By default, user-entered text is cleared when the combobox loses focus without selecting an item.
-   * When enabled, custom text is preserved.
+   * When enabled, custom text is preserved. A trailing "Create …" menu row is also shown for novel
+   * queries (case-insensitive `itemToString` match); listen to `create` to append a new option.
    */
   export let allowCustomValue = false;
+
+  /**
+   * @param {string} query
+   * @returns {string}
+   */
+  function defaultCreateOptionText(query) {
+    return `Create "${query}"`;
+  }
+
+  /**
+   * Label for the synthetic create-option menu row when `allowCustomValue` is enabled.
+   * Pass a string for a fixed label, or a function of the current query.
+   * @type {string | ((query: string) => string)}
+   */
+  export let createOptionText = defaultCreateOptionText;
 
   /**
    * Set to `true` to clear the input value when opening the dropdown.
@@ -262,6 +279,9 @@
   const insideModal = getContext("carbon:Modal");
   const formContext = getContext("carbon:Form");
 
+  /** Stable sentinel so the create row never collides with a real item id. */
+  const CREATE_OPTION_ID = "__ccs-combo-box-create-option__";
+
   $: effectivePortalMenu =
     portalMenu === undefined ? !!insideModal : portalMenu;
 
@@ -321,9 +341,27 @@
     // "Focusability of disabled controls") so assistive-tech users can
     // discover them; the Enter handler and the option click handlers refuse
     // the actual selection.
-    const navigableItems = filteredItems?.length ? filteredItems : items;
+    const baseItems = filteredItems?.length ? filteredItems : items;
+    const navigableItems = showCreateOption
+      ? [...filteredItems, { id: CREATE_OPTION_ID, disabled: false }]
+      : baseItems;
     highlightedIndex = moveIndex(highlightedIndex, step, navigableItems.length);
     highlightOrigin = "keyboard";
+  }
+
+  /**
+   * Dispatch `create` for the current query and close the menu.
+   * Does not mutate `items`; the consumer owns appending the new option.
+   * @param {string} query
+   * @param {boolean} [wasOpen]
+   */
+  function commitCreate(query, wasOpen = open) {
+    valueBeforeOpen = "";
+    dispatch("create", query);
+    open = false;
+    highlightedIndex = -1;
+    highlightOrigin = null;
+    if (wasOpen) dispatch("close", { trigger: "select" });
   }
 
   /**
@@ -492,13 +530,34 @@
   $: hasFluidMenuItems = isFluid && !condensed && !effectivePortalMenu;
   $: filteredItems = open ? items.filter((item) => filterFn(item, value)) : [];
   $: scrollEndTracker.noteItemCount(filteredItems.length);
+  $: trimmedQuery = typeof value === "string" ? value.trim() : "";
+  // Novel when no item's display string equals the query (case-insensitive),
+  // matching Enter selection equality. Trailing create row shows whenever the
+  // query is novel so users can create even if partial matches remain.
+  $: isNovelQuery =
+    allowCustomValue &&
+    trimmedQuery.length > 0 &&
+    !items.some(
+      (item) => itemToString(item).toLowerCase() === trimmedQuery.toLowerCase(),
+    );
+  $: showCreateOption = open && isNovelQuery;
+  $: createOptionIndex = showCreateOption ? filteredItems.length : -1;
+  $: createOptionLabel =
+    typeof createOptionText === "function"
+      ? createOptionText(trimmedQuery)
+      : createOptionText;
   $: highlightedId =
-    filteredItems[highlightedIndex] == null
-      ? undefined
-      : `${id}-${filteredItems[highlightedIndex].id}`;
+    showCreateOption && highlightedIndex === createOptionIndex
+      ? `${id}-${CREATE_OPTION_ID}`
+      : filteredItems[highlightedIndex] == null
+        ? undefined
+        : `${id}-${filteredItems[highlightedIndex].id}`;
 
-  $: shouldVirtualize =
-    virtualize === false
+  // Prefer a non-virtualized path when the create row is shown so the trailing
+  // row is always present without adjusting virtual height maps.
+  $: shouldVirtualize = showCreateOption
+    ? false
+    : virtualize === false
       ? false
       : virtualize !== undefined || items.length > 100;
 
@@ -733,39 +792,57 @@
               return;
             }
             const wasOpen = open;
-            open = !open;
-            if (
-              highlightOrigin === "keyboard" &&
-              highlightedIndex > -1 &&
-              filteredItems[highlightedIndex]?.id !== selectedId
-            ) {
-              open = false;
-              valueBeforeOpen = "";
-              if (filteredItems[highlightedIndex]) {
-                value = itemToString(filteredItems[highlightedIndex]);
-                selectedItem = filteredItems[highlightedIndex];
-                selectedId = filteredItems[highlightedIndex].id;
-                if (wasOpen) dispatch("close", { trigger: "select" });
-              }
+            const inputValue = ref?.value ?? value;
+            const query =
+              typeof inputValue === "string" ? inputValue.trim() : "";
+            const isCreateHighlighted =
+              showCreateOption && highlightedIndex === createOptionIndex;
+
+            if (isCreateHighlighted) {
+              commitCreate(query, wasOpen);
             } else {
-              // Match typed value case-insensitively against item text
-              const inputValue = ref?.value ?? value;
-              const matchedItem = filteredItems.find(
-                (item) =>
-                  item.text.toLowerCase() === inputValue?.toLowerCase() &&
-                  !item.disabled,
-              );
-              if (matchedItem) {
+              open = !open;
+              if (
+                highlightOrigin === "keyboard" &&
+                highlightedIndex > -1 &&
+                filteredItems[highlightedIndex]?.id !== selectedId
+              ) {
                 open = false;
                 valueBeforeOpen = "";
-                selectedItem = matchedItem;
-                value = itemToString(selectedItem);
-                selectedId = selectedItem.id;
-                if (wasOpen) dispatch("close", { trigger: "select" });
+                if (filteredItems[highlightedIndex]) {
+                  value = itemToString(filteredItems[highlightedIndex]);
+                  selectedItem = filteredItems[highlightedIndex];
+                  selectedId = filteredItems[highlightedIndex].id;
+                  if (wasOpen) dispatch("close", { trigger: "select" });
+                }
+              } else {
+                // Match typed value case-insensitively against item text
+                const matchedItem = filteredItems.find(
+                  (item) =>
+                    item.text.toLowerCase() === inputValue?.toLowerCase() &&
+                    !item.disabled,
+                );
+                if (matchedItem) {
+                  open = false;
+                  valueBeforeOpen = "";
+                  selectedItem = matchedItem;
+                  value = itemToString(selectedItem);
+                  selectedId = selectedItem.id;
+                  if (wasOpen) dispatch("close", { trigger: "select" });
+                } else if (
+                  wasOpen &&
+                  allowCustomValue &&
+                  query.length > 0 &&
+                  isNovelQuery
+                ) {
+                  // Novel custom text with no highlight: signal create while
+                  // preserving today's allowCustomValue close behavior.
+                  dispatch("create", query);
+                }
               }
+              highlightedIndex = -1;
+              highlightOrigin = null;
             }
-            highlightedIndex = -1;
-            highlightOrigin = null;
           } else if (event.key === "Tab") {
             // Accept the inline suggestion before focus moves to the next
             // control. Tab is not prevented, so focus still advances normally.
@@ -1036,6 +1113,21 @@
               {/if}
             </ListBoxMenuItem>
           {/each}
+          {#if showCreateOption}
+            <ListBoxMenuItem
+              id="{id}-{CREATE_OPTION_ID}"
+              highlighted={highlightedIndex === createOptionIndex}
+              on:click={() => {
+                commitCreate(trimmedQuery);
+              }}
+              on:mouseenter={() => {
+                highlightedIndex = createOptionIndex;
+                highlightOrigin = "pointer";
+              }}
+            >
+              {createOptionLabel}
+            </ListBoxMenuItem>
+          {/if}
         {/if}
       </ListBoxMenu>
     {/if}

--- a/tests/ComboBox/ComboBox.test.svelte
+++ b/tests/ComboBox/ComboBox.test.svelte
@@ -36,6 +36,10 @@
   export let translateWithIdSelection: ComponentProps<ComboBox>["translateWithIdSelection"] =
     undefined;
   export let allowCustomValue = false;
+  export let createOptionText:
+    | string
+    | ((query: string) => string)
+    | undefined = undefined;
   export let clearFilterOnOpen = false;
   export let selectTextOnFocus = false;
   export let openOnClear = false;
@@ -73,6 +77,7 @@
   {shouldFilterItem}
   {translateWithIdSelection}
   {allowCustomValue}
+  {createOptionText}
   {clearFilterOnOpen}
   {selectTextOnFocus}
   {openOnClear}

--- a/tests/ComboBox/ComboBoxCreateOption.test.svelte
+++ b/tests/ComboBox/ComboBoxCreateOption.test.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+  import ComboBox from "carbon-components-svelte/ComboBox/ComboBox.svelte";
+
+  type Item = { id: string; text: string };
+
+  export let items: Item[] = [
+    { id: "0", text: "Slack" },
+    { id: "1", text: "Email" },
+    { id: "2", text: "Fax" },
+  ];
+  export let value = "";
+  export let selectedId: string | undefined = undefined;
+  export let allowCustomValue = true;
+  export let createOptionText:
+    | string
+    | ((query: string) => string)
+    | undefined = undefined;
+  export let appendOnCreate = false;
+  export let onCreate: (e: CustomEvent<string>) => void = () => {};
+
+  function handleCreate(event: CustomEvent<string>) {
+    onCreate(event);
+    if (appendOnCreate) {
+      const text = event.detail;
+      items = [...items, { id: text, text }];
+      value = text;
+      selectedId = text;
+    }
+  }
+</script>
+
+<ComboBox
+  {items}
+  bind:value
+  bind:selectedId
+  {allowCustomValue}
+  {createOptionText}
+  labelText="Contact"
+  placeholder="Select contact method"
+  shouldFilterItem={(item, query) =>
+    !query || item.text.toLowerCase().includes(query.toLowerCase())}
+  on:create={handleCreate}
+/>

--- a/tests/ComboBox/ComboBoxCreateOption.test.ts
+++ b/tests/ComboBox/ComboBoxCreateOption.test.ts
@@ -1,0 +1,148 @@
+import { render, screen } from "@testing-library/svelte";
+import { user } from "../utils/user";
+import ComboBox from "./ComboBox.test.svelte";
+import ComboBoxCreateOption from "./ComboBoxCreateOption.test.svelte";
+
+describe("ComboBox create option", () => {
+  const getInput = () => {
+    const input = screen.getByRole("combobox");
+    assert(input instanceof HTMLInputElement);
+    return input;
+  };
+
+  it("shows a trailing create row for a novel query", async () => {
+    render(ComboBox, { props: { allowCustomValue: true } });
+
+    const input = getInput();
+    await user.click(input);
+    await user.type(input, "e");
+
+    // Partial matches remain; create row trails because "e" is not an exact match.
+    expect(screen.getByRole("option", { name: "Email" })).toBeVisible();
+    expect(screen.getByRole("option", { name: 'Create "e"' })).toBeVisible();
+  });
+
+  it("shows the create row when filtered results are empty", async () => {
+    render(ComboBox, { props: { allowCustomValue: true } });
+
+    const input = getInput();
+    await user.click(input);
+    await user.type(input, "Teams");
+
+    expect(
+      screen.getByRole("option", { name: 'Create "Teams"' }),
+    ).toBeVisible();
+    expect(
+      screen.queryByRole("option", { name: "Slack" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not show the create row for an exact case-insensitive match", async () => {
+    render(ComboBox, { props: { allowCustomValue: true } });
+
+    const input = getInput();
+    await user.click(input);
+    await user.type(input, "email");
+
+    expect(
+      screen.queryByRole("option", { name: /Create/ }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Email" })).toBeVisible();
+  });
+
+  it("does not show the create row when allowCustomValue is false", async () => {
+    render(ComboBox);
+
+    const input = getInput();
+    await user.click(input);
+    await user.type(input, "Teams");
+
+    expect(
+      screen.queryByRole("option", { name: /Create/ }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("dispatches create with the query when the create row is clicked", async () => {
+    const onCreate = vi.fn();
+    render(ComboBoxCreateOption, { props: { onCreate } });
+
+    const input = getInput();
+    await user.click(input);
+    await user.type(input, "Teams");
+    await user.click(screen.getByRole("option", { name: 'Create "Teams"' }));
+
+    expect(onCreate).toHaveBeenCalledTimes(1);
+    expect(onCreate.mock.calls[0][0].detail).toBe("Teams");
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+  });
+
+  it("dispatches create on Enter with a novel query and no highlight", async () => {
+    const onCreate = vi.fn();
+    render(ComboBoxCreateOption, { props: { onCreate } });
+
+    const input = getInput();
+    await user.click(input);
+    await user.type(input, "Teams");
+    await user.keyboard("{Enter}");
+
+    expect(onCreate).toHaveBeenCalledTimes(1);
+    expect(onCreate.mock.calls[0][0].detail).toBe("Teams");
+    expect(input).toHaveValue("Teams");
+  });
+
+  it("dispatches create on Enter when the create row is highlighted", async () => {
+    const onCreate = vi.fn();
+    render(ComboBoxCreateOption, { props: { onCreate } });
+
+    const input = getInput();
+    await user.click(input);
+    await user.type(input, "zzz");
+    // No filtered matches: ArrowDown lands on the create row.
+    await user.keyboard("{ArrowDown}{Enter}");
+
+    expect(onCreate).toHaveBeenCalledTimes(1);
+    expect(onCreate.mock.calls[0][0].detail).toBe("zzz");
+  });
+
+  it("lets the consumer append the created option to items", async () => {
+    render(ComboBoxCreateOption, { props: { appendOnCreate: true } });
+
+    const input = getInput();
+    await user.click(input);
+    await user.type(input, "Teams");
+    await user.click(screen.getByRole("option", { name: 'Create "Teams"' }));
+
+    expect(input).toHaveValue("Teams");
+
+    await user.click(input);
+    expect(screen.getByRole("option", { name: "Teams" })).toBeVisible();
+    expect(
+      screen.queryByRole("option", { name: /Create/ }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("preserves custom value on close without requiring a create handler", async () => {
+    render(ComboBox, { props: { allowCustomValue: true } });
+
+    const input = getInput();
+    await user.click(input);
+    await user.type(input, "Custom Value");
+    await user.click(document.body);
+    expect(input).toHaveValue("Custom Value");
+  });
+
+  it("uses createOptionText for the create row label", async () => {
+    render(ComboBox, {
+      props: {
+        allowCustomValue: true,
+        createOptionText: (q: string) => `Add ${q}`,
+      },
+    });
+
+    const input = getInput();
+    await user.click(input);
+    await user.type(input, "Teams");
+
+    expect(screen.getByRole("option", { name: "Add Teams" })).toBeVisible();
+  });
+});


### PR DESCRIPTION
With `allowCustomValue`, a trailing create row appears for novel
queries and dispatches `create` so consumers can append to
`items`. Does not mutate `items` itself.