### PR TITLE
feat(list-box): emit scrollend near menu bottom

### DIFF
--- a/docs/src/pages/components/ComboBox.svx
+++ b/docs/src/pages/components/ComboBox.svx
@@ -252,6 +252,18 @@ For async (for example, server-side) filtering, bind to `value` and update `item
 
 <FileSource src="/framed/ComboBox/AsyncComboBox" />
 
+### Load more
+
+`scrollend` fires when the menu is scrolled near the bottom. Use it to append the next page of `items`. The component does not fetch or mutate `items` for you.
+
+This is a library load-more signal, named like Modal's lowercase `transitionend`. It is not the browser's native `scrollend` (scroll stopped).
+
+Keep prior items visible while the next page loads. Track in-flight status in local state, or surface it with the `empty` slot when the list is temporarily empty.
+
+`scrollend` fires once per approach to the bottom. It re-arms after the user scrolls away, and when `items` grows so another page can be requested. Holding the scrollbar at the bottom does not spam the handler. The raw DOM `scroll` event is still forwarded via `on:scroll`.
+
+<FileSource src="/framed/ComboBox/ScrollEndComboBox" />
+
 ### Allow custom value
 
 Set `allowCustomValue` to `true` to let users enter custom text that is not in the predefined list. By default, user-entered text is cleared when the combobox loses focus without selecting an item. With allowCustomValue enabled, custom text is preserved.

--- a/docs/src/pages/components/Dropdown.svx
+++ b/docs/src/pages/components/Dropdown.svx
@@ -125,6 +125,17 @@ Set `virtualize={false}` to explicitly disable virtualization, even for large li
 
 <FileSource src="/framed/Dropdown/VirtualizedDropdown" />
 
+### Load more
+
+`scrollend` fires when the menu is scrolled near the bottom so you can append the next page of `items`. Same pattern as [ComboBox load more](/components/ComboBox#load-more): handle `on:scrollend`, keep prior items visible while loading, and track in-flight status locally (or with the `empty` slot when appropriate). The event is a near-bottom load-more signal, not the browser's native `scrollend`.
+
+```svelte
+<Dropdown
+  {items}
+  on:scrollend={() => loadNextPage()}
+/>
+```
+
 ### Custom overscan
 
 Overscanning is the process of rendering extra items above and below the viewport to ensure smooth scrolling. The default overscan value is 3.

--- a/docs/src/pages/components/MultiSelect.svx
+++ b/docs/src/pages/components/MultiSelect.svx
@@ -180,6 +180,17 @@ Set `virtualize={false}` to explicitly disable virtualization, even for large li
 
 <FileSource src="/framed/MultiSelect/VirtualizedMultiSelect" />
 
+### Load more
+
+`scrollend` fires when the menu is scrolled near the bottom so you can append the next page of `items`. Same pattern as [ComboBox load more](/components/ComboBox#load-more): handle `on:scrollend`, keep prior items visible while loading, and track in-flight status locally (or with the `empty` slot when appropriate). The event is a near-bottom load-more signal, not the browser's native `scrollend`.
+
+```svelte
+<MultiSelect
+  {items}
+  on:scrollend={() => loadNextPage()}
+/>
+```
+
 ### Custom overscan
 
 Overscanning is the process of rendering extra items above and below the viewport to ensure smooth scrolling. The default overscan value is 3.

--- a/docs/src/pages/framed/ComboBox/ScrollEndComboBox.svelte
+++ b/docs/src/pages/framed/ComboBox/ScrollEndComboBox.svelte
@@ -1,0 +1,50 @@
+<script>
+  import { ComboBox, InlineLoading, Stack } from "carbon-components-svelte";
+
+  const PAGE_SIZE = 40;
+  const TOTAL = 200;
+
+  let items = [];
+  let loading = false;
+  let hasMore = true;
+
+  function makePage(offset) {
+    return Array.from({ length: PAGE_SIZE }, (_, i) => {
+      const n = offset + i;
+      return { id: String(n), text: `Item ${n + 1}` };
+    }).filter((item) => Number(item.id) < TOTAL);
+  }
+
+  async function loadMore() {
+    if (loading || !hasMore) return;
+    loading = true;
+    await new Promise((resolve) => setTimeout(resolve, 400));
+    const next = makePage(items.length);
+    items = [...items, ...next];
+    hasMore = items.length < TOTAL;
+    loading = false;
+  }
+
+  loadMore();
+</script>
+
+<Stack gap={4}>
+  <ComboBox
+    labelText="Load more on scroll"
+    placeholder="Open and scroll to the bottom…"
+    {items}
+    shouldFilterItem={() => true}
+    virtualize={{ containerHeight: 240, threshold: 1 }}
+    on:scrollend={loadMore}
+  />
+  {#if loading}
+    <InlineLoading description="Loading more…" />
+  {:else if !hasMore}
+    <p>Loaded all {TOTAL} items.</p>
+  {:else}
+    <p>
+      {items.length}
+      of {TOTAL} loaded. Scroll the menu to fetch the next page.
+    </p>
+  {/if}
+</Stack>

--- a/src/ComboBox/ComboBox.svelte
+++ b/src/ComboBox/ComboBox.svelte
@@ -26,6 +26,12 @@
    */
 
   /**
+   * Dispatched when the menu is scrolled near the bottom (load-more signal).
+   * Not the browser's native `scrollend` (scroll stopped).
+   * @event {{ scrollTop: number; scrollHeight: number; clientHeight: number }} scrollend
+   */
+
+  /**
    * Set the combobox items.
    * @type {ReadonlyArray<Item>}
    */
@@ -243,6 +249,7 @@
   } from "../ListBox/list-box-utils.js";
   import { dismiss } from "../utils/dismiss.js";
   import { isOutsideClick } from "../utils/isOutsideClick.js";
+  import { createScrollEndTracker } from "../utils/isScrollNearEnd.js";
   import { nextEnabledIndex } from "../utils/moveIndex.js";
   import {
     resetVirtualScrollOnClose,
@@ -252,6 +259,7 @@
   } from "../utils/virtualize.js";
 
   const dispatch = createEventDispatcher();
+  const scrollEndTracker = createScrollEndTracker();
   const insideModal = getContext("carbon:Modal");
   const formContext = getContext("carbon:Form");
 
@@ -291,6 +299,23 @@
       ? autocompleteCustomFilter
       : shouldFilterItem
     : shouldFilterItem;
+
+  /**
+   * @param {Event} event
+   */
+  function handleMenuScroll(event) {
+    const target = /** @type {HTMLElement} */ (event.target);
+    listScrollTop = target.scrollTop;
+    const detail = scrollEndTracker.observe({
+      scrollTop: target.scrollTop,
+      scrollHeight: target.scrollHeight,
+      clientHeight: target.clientHeight,
+      itemCount: filteredItems.length,
+    });
+    if (detail) {
+      dispatch("scrollend", detail);
+    }
+  }
 
   function change(step) {
     const navigableItems = filteredItems?.length ? filteredItems : items;
@@ -408,6 +433,7 @@
       if (shouldVirtualize) {
         listScrollTop = resetVirtualScrollOnClose();
       }
+      scrollEndTracker.reset();
       highlightedIndex = -1;
       highlightOrigin = null;
       prevHighlightedIndex = -1;
@@ -466,6 +492,7 @@
   // Portaled menus render outside the fluid wrapper, so they keep default heights.
   $: hasFluidMenuItems = isFluid && !condensed && !effectivePortalMenu;
   $: filteredItems = open ? items.filter((item) => filterFn(item, value)) : [];
+  $: scrollEndTracker.noteItemCount(filteredItems.length);
   $: highlightedId =
     filteredItems[highlightedIndex] == null
       ? undefined
@@ -842,9 +869,7 @@
         anchor={fieldRef}
         {direction}
         on:scroll
-        on:scroll={(event) => {
-          listScrollTop = event.target.scrollTop;
-        }}
+        on:scroll={handleMenuScroll}
         on:mouseleave={() => {
           // Clear the hover highlight when the cursor leaves the menu so the
           // highlighted state does not linger on the last hovered item.

--- a/src/Dropdown/Dropdown.svelte
+++ b/src/Dropdown/Dropdown.svelte
@@ -25,6 +25,12 @@
    */
 
   /**
+   * Dispatched when the menu is scrolled near the bottom (load-more signal).
+   * Not the browser's native `scrollend` (scroll stopped).
+   * @event {{ scrollTop: number; scrollHeight: number; clientHeight: number }} scrollend
+   */
+
+  /**
    * Set the dropdown items.
    * @type {ReadonlyArray<Item>}
    */
@@ -197,6 +203,7 @@
   import { debounce } from "../utils/debounce.js";
   import { dismiss } from "../utils/dismiss.js";
   import { isOutsideClick } from "../utils/isOutsideClick.js";
+  import { createScrollEndTracker } from "../utils/isScrollNearEnd.js";
   import { nextEnabledIndex } from "../utils/moveIndex.js";
   import { typeaheadIndex } from "../utils/typeahead.js";
   import {
@@ -207,6 +214,7 @@
   } from "../utils/virtualize.js";
 
   const dispatch = createEventDispatcher();
+  const scrollEndTracker = createScrollEndTracker();
   const insideModal = getContext("carbon:Modal");
   const formContext = getContext("carbon:Form");
 
@@ -292,6 +300,7 @@
   $: virtualConfig = virtualState.config;
   $: virtualData = virtualState.data;
   $: itemsToRender = virtualState.itemsToRender;
+  $: scrollEndTracker.noteItemCount(items.length);
 
   afterUpdate(() => {
     // Scroll to highlighted item when it changes via keyboard navigation
@@ -379,7 +388,27 @@
     if (!open && shouldVirtualize) {
       listScrollTop = resetVirtualScrollOnClose();
     }
+    if (!open) {
+      scrollEndTracker.reset();
+    }
   });
+
+  /**
+   * @param {Event} event
+   */
+  function handleMenuScroll(event) {
+    const target = /** @type {HTMLElement} */ (event.target);
+    listScrollTop = target.scrollTop;
+    const detail = scrollEndTracker.observe({
+      scrollTop: target.scrollTop,
+      scrollHeight: target.scrollHeight,
+      clientHeight: target.clientHeight,
+      itemCount: items.length,
+    });
+    if (detail) {
+      dispatch("scrollend", detail);
+    }
+  }
 
   function change(step) {
     highlightedIndex = nextEnabledIndex({
@@ -640,9 +669,7 @@
         anchor={ref}
         {direction}
         on:scroll
-        on:scroll={(event) => {
-          listScrollTop = event.target.scrollTop;
-        }}
+        on:scroll={handleMenuScroll}
         on:mouseleave={() => {
           // Clear the hover highlight when the cursor leaves the menu so the
           // highlighted state does not linger on the last hovered item.

--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -18,6 +18,7 @@
    * @event {null} clear
    * @event {FocusEvent | CustomEvent<FocusEvent>} blur
    * @event {{ trigger: "escape-key" | "outside-click" }} close
+   * @event {{ scrollTop: number; scrollHeight: number; clientHeight: number }} scrollend
    * @slot {{ item: Item; index: number; selected: boolean; highlighted: boolean; }}
    */
 
@@ -286,6 +287,7 @@
   } from "../ListBox/list-box-utils.js";
   import { dismiss } from "../utils/dismiss.js";
   import { isOutsideClick } from "../utils/isOutsideClick.js";
+  import { createScrollEndTracker } from "../utils/isScrollNearEnd.js";
   import { nextEnabledIndex } from "../utils/moveIndex.js";
   import {
     resetVirtualScrollOnClose,
@@ -295,6 +297,7 @@
   } from "../utils/virtualize.js";
 
   const dispatch = createEventDispatcher();
+  const scrollEndTracker = createScrollEndTracker();
   const formContext = getContext("carbon:Form");
   const insideModal = getContext("carbon:Modal");
 
@@ -493,7 +496,27 @@
         listRef.scrollTop = listScrollTop;
       }
     }
+    if (!open) {
+      scrollEndTracker.reset();
+    }
   });
+
+  /**
+   * @param {Event} event
+   */
+  function handleMenuScroll(event) {
+    const target = /** @type {HTMLElement} */ (event.target);
+    listScrollTop = target.scrollTop;
+    const detail = scrollEndTracker.observe({
+      scrollTop: target.scrollTop,
+      scrollHeight: target.scrollHeight,
+      clientHeight: target.clientHeight,
+      itemCount: itemsToUse.length,
+    });
+    if (detail) {
+      dispatch("scrollend", detail);
+    }
+  }
 
   function sort() {
     const selectedIdsSet = new Set(selectedIds);
@@ -634,6 +657,7 @@
       : virtualize !== undefined || items.length > 100;
 
   $: itemsToUse = filterable ? filteredItems : sortedItems;
+  $: scrollEndTracker.noteItemCount(itemsToUse.length);
 
   $: menuMaxHeight = getMenuMaxHeight(size);
 
@@ -997,9 +1021,7 @@
         aria-multiselectable="true"
         aria-readonly={readonly || undefined}
         on:scroll
-        on:scroll={(event) => {
-          listScrollTop = event.target.scrollTop;
-        }}
+        on:scroll={handleMenuScroll}
         on:mouseleave={() => {
           // Clear the hover highlight when the cursor leaves the menu so the
           // highlighted state does not linger on the last hovered item.

--- a/src/utils/isScrollNearEnd.d.ts
+++ b/src/utils/isScrollNearEnd.d.ts
@@ -1,0 +1,36 @@
+/** Default distance from the bottom (px) that counts as near end. */
+export const DEFAULT_SCROLL_END_THRESHOLD: 32;
+
+export type ScrollEndDetail = {
+  scrollTop: number;
+  scrollHeight: number;
+  clientHeight: number;
+};
+
+/**
+ * True when the scroll position is within `threshold` px of the bottom.
+ * Returns false when the content does not overflow.
+ */
+export function isScrollNearEnd(options: {
+  scrollTop: number;
+  scrollHeight: number;
+  clientHeight: number;
+  threshold?: number;
+}): boolean;
+
+export type ScrollEndTracker = {
+  noteItemCount: (itemCount: number) => void;
+  observe: (
+    metrics: ScrollEndDetail & { itemCount?: number },
+  ) => ScrollEndDetail | null;
+  reset: () => void;
+};
+
+/**
+ * Fire-once-per-approach tracker for listbox near-bottom `scrollend`.
+ * Re-arms after the user scrolls away from the bottom, and when the item
+ * count grows so another page can be requested.
+ */
+export function createScrollEndTracker(options?: {
+  threshold?: number;
+}): ScrollEndTracker;

--- a/src/utils/isScrollNearEnd.js
+++ b/src/utils/isScrollNearEnd.js
@@ -1,0 +1,105 @@
+// @ts-check
+
+/** Default distance from the bottom (px) that counts as near end. */
+export const DEFAULT_SCROLL_END_THRESHOLD = 32;
+
+/**
+ * True when the scroll position is within `threshold` px of the bottom.
+ * Returns false when the content does not overflow.
+ *
+ * @param {Object} options
+ * @param {number} options.scrollTop
+ * @param {number} options.scrollHeight
+ * @param {number} options.clientHeight
+ * @param {number} [options.threshold=DEFAULT_SCROLL_END_THRESHOLD]
+ * @returns {boolean}
+ */
+export function isScrollNearEnd({
+  scrollTop,
+  scrollHeight,
+  clientHeight,
+  threshold = DEFAULT_SCROLL_END_THRESHOLD,
+}) {
+  if (scrollHeight <= clientHeight) return false;
+  return scrollTop + clientHeight >= scrollHeight - threshold;
+}
+
+/**
+ * @typedef {Object} ScrollEndDetail
+ * @property {number} scrollTop
+ * @property {number} scrollHeight
+ * @property {number} clientHeight
+ */
+
+/**
+ * Fire-once-per-approach tracker for listbox near-bottom `scrollend`.
+ * Re-arms after the user scrolls away from the bottom, and when the item
+ * count grows so another page can be requested.
+ *
+ * @param {Object} [options]
+ * @param {number} [options.threshold=DEFAULT_SCROLL_END_THRESHOLD]
+ * @returns {{
+ *   noteItemCount: (itemCount: number) => void,
+ *   observe: (metrics: ScrollEndDetail & { itemCount?: number }) => ScrollEndDetail | null,
+ *   reset: () => void,
+ * }}
+ */
+export function createScrollEndTracker({
+  threshold = DEFAULT_SCROLL_END_THRESHOLD,
+} = {}) {
+  let armed = true;
+  /** @type {number | undefined} */
+  let lastItemCount;
+
+  /**
+   * Re-arm when the rendered list grows.
+   * @param {number} itemCount
+   */
+  function noteItemCount(itemCount) {
+    if (lastItemCount !== undefined && itemCount > lastItemCount) {
+      armed = true;
+    }
+    lastItemCount = itemCount;
+  }
+
+  return {
+    noteItemCount,
+
+    /**
+     * @param {ScrollEndDetail & { itemCount?: number }} metrics
+     * @returns {ScrollEndDetail | null}
+     */
+    observe(metrics) {
+      if (typeof metrics.itemCount === "number") {
+        noteItemCount(metrics.itemCount);
+      }
+
+      const nearEnd = isScrollNearEnd({
+        scrollTop: metrics.scrollTop,
+        scrollHeight: metrics.scrollHeight,
+        clientHeight: metrics.clientHeight,
+        threshold,
+      });
+
+      if (!nearEnd) {
+        if (metrics.scrollHeight > metrics.clientHeight) {
+          armed = true;
+        }
+        return null;
+      }
+
+      if (!armed) return null;
+      armed = false;
+      return {
+        scrollTop: metrics.scrollTop,
+        scrollHeight: metrics.scrollHeight,
+        clientHeight: metrics.clientHeight,
+      };
+    },
+
+    reset() {
+      armed = true;
+      lastItemCount = undefined;
+    },
+  };
+}

--- a/tests/ComboBox/ComboBoxScrollend.test.svelte
+++ b/tests/ComboBox/ComboBoxScrollend.test.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+  import ComboBox from "carbon-components-svelte/ComboBox/ComboBox.svelte";
+  import type { ComponentProps } from "svelte";
+
+  export let items: ComponentProps<ComboBox>["items"] = [];
+  export let open: ComponentProps<ComboBox>["open"] = false;
+  export let virtualize: ComponentProps<ComboBox>["virtualize"] = {
+    containerHeight: 200,
+    threshold: 1,
+  };
+  export let shouldFilterItem: ComponentProps<ComboBox>["shouldFilterItem"] =
+    () => true;
+  export let onScrollend: (
+    e: CustomEvent<{
+      scrollTop: number;
+      scrollHeight: number;
+      clientHeight: number;
+    }>,
+  ) => void = () => {};
+  export let onScroll: (e: Event) => void = () => {};
+</script>
+
+<ComboBox
+  {items}
+  bind:open
+  {virtualize}
+  {shouldFilterItem}
+  labelText="Contact"
+  placeholder="Select…"
+  portalMenu={false}
+  on:scrollend={onScrollend}
+  on:scroll={onScroll}
+/>

--- a/tests/ComboBox/ComboBoxScrollend.test.ts
+++ b/tests/ComboBox/ComboBoxScrollend.test.ts
@@ -1,0 +1,206 @@
+import { fireEvent, render, screen } from "@testing-library/svelte";
+import { tick } from "svelte";
+import { user } from "../utils/user";
+import ComboBoxScrollend from "./ComboBoxScrollend.test.svelte";
+
+function createItems(count: number) {
+  return Array.from({ length: count }, (_, i) => ({
+    id: String(i),
+    text: `Item ${i + 1}`,
+  }));
+}
+
+function setMenuMetrics(
+  menu: HTMLElement,
+  {
+    scrollTop,
+    scrollHeight,
+    clientHeight,
+  }: { scrollTop: number; scrollHeight: number; clientHeight: number },
+) {
+  Object.defineProperty(menu, "scrollHeight", {
+    value: scrollHeight,
+    configurable: true,
+  });
+  Object.defineProperty(menu, "clientHeight", {
+    value: clientHeight,
+    configurable: true,
+  });
+  menu.scrollTop = scrollTop;
+}
+
+describe("ComboBox scrollend", () => {
+  it("dispatches scrollend when scrolled near the bottom", async () => {
+    const onScrollend = vi.fn();
+    render(ComboBoxScrollend, {
+      props: {
+        items: createItems(40),
+        open: true,
+        onScrollend,
+      },
+    });
+
+    const menu = screen.getByRole("listbox");
+    setMenuMetrics(menu, {
+      scrollTop: 800,
+      scrollHeight: 1000,
+      clientHeight: 200,
+    });
+    await fireEvent.scroll(menu);
+
+    expect(onScrollend).toHaveBeenCalledTimes(1);
+    expect(onScrollend.mock.calls[0][0].detail).toEqual({
+      scrollTop: 800,
+      scrollHeight: 1000,
+      clientHeight: 200,
+    });
+  });
+
+  it("does not dispatch scrollend on open or for non-overflowing lists", async () => {
+    const onScrollend = vi.fn();
+    render(ComboBoxScrollend, {
+      props: {
+        items: createItems(3),
+        open: true,
+        onScrollend,
+      },
+    });
+
+    await tick();
+    expect(onScrollend).not.toHaveBeenCalled();
+
+    const menu = screen.getByRole("listbox");
+    setMenuMetrics(menu, {
+      scrollTop: 0,
+      scrollHeight: 100,
+      clientHeight: 200,
+    });
+    await fireEvent.scroll(menu);
+
+    expect(onScrollend).not.toHaveBeenCalled();
+  });
+
+  it("does not spam while held at the bottom; re-arms after scroll-away", async () => {
+    const onScrollend = vi.fn();
+    render(ComboBoxScrollend, {
+      props: {
+        items: createItems(40),
+        open: true,
+        onScrollend,
+      },
+    });
+
+    const menu = screen.getByRole("listbox");
+    setMenuMetrics(menu, {
+      scrollTop: 800,
+      scrollHeight: 1000,
+      clientHeight: 200,
+    });
+    await fireEvent.scroll(menu);
+    await fireEvent.scroll(menu);
+    expect(onScrollend).toHaveBeenCalledTimes(1);
+
+    setMenuMetrics(menu, {
+      scrollTop: 0,
+      scrollHeight: 1000,
+      clientHeight: 200,
+    });
+    await fireEvent.scroll(menu);
+
+    setMenuMetrics(menu, {
+      scrollTop: 800,
+      scrollHeight: 1000,
+      clientHeight: 200,
+    });
+    await fireEvent.scroll(menu);
+    expect(onScrollend).toHaveBeenCalledTimes(2);
+  });
+
+  it("re-arms when items grow", async () => {
+    const onScrollend = vi.fn();
+    const { rerender } = render(ComboBoxScrollend, {
+      props: {
+        items: createItems(20),
+        open: true,
+        onScrollend,
+      },
+    });
+
+    const menu = screen.getByRole("listbox");
+    setMenuMetrics(menu, {
+      scrollTop: 800,
+      scrollHeight: 1000,
+      clientHeight: 200,
+    });
+    await fireEvent.scroll(menu);
+    expect(onScrollend).toHaveBeenCalledTimes(1);
+
+    const spacerBefore = menu.querySelector<HTMLElement>(":scope > div");
+    const heightBefore = spacerBefore?.style.height;
+
+    await rerender({
+      items: createItems(40),
+      open: true,
+      onScrollend,
+      virtualize: { containerHeight: 200, threshold: 1 },
+      shouldFilterItem: () => true,
+    });
+    await tick();
+
+    const menuAfter = screen.getByRole("listbox");
+    const spacerAfter = menuAfter.querySelector<HTMLElement>(":scope > div");
+    // 40 items * 40px default itemHeight
+    expect(spacerAfter?.style.height).toBe("1600px");
+    expect(heightBefore).toBe("800px");
+
+    setMenuMetrics(menuAfter, {
+      scrollTop: 1400,
+      scrollHeight: 1600,
+      clientHeight: 200,
+    });
+    await fireEvent.scroll(menuAfter);
+    expect(onScrollend).toHaveBeenCalledTimes(2);
+  });
+
+  it("still forwards the raw DOM scroll event", async () => {
+    const onScroll = vi.fn();
+    render(ComboBoxScrollend, {
+      props: {
+        items: createItems(40),
+        open: true,
+        onScroll,
+      },
+    });
+
+    const menu = screen.getByRole("listbox");
+    setMenuMetrics(menu, {
+      scrollTop: 100,
+      scrollHeight: 1000,
+      clientHeight: 200,
+    });
+    await fireEvent.scroll(menu);
+
+    expect(onScroll).toHaveBeenCalled();
+  });
+
+  it("works when opened via user interaction", async () => {
+    const onScrollend = vi.fn();
+    render(ComboBoxScrollend, {
+      props: {
+        items: createItems(40),
+        onScrollend,
+      },
+    });
+
+    await user.click(screen.getByRole("combobox"));
+    const menu = screen.getByRole("listbox");
+    setMenuMetrics(menu, {
+      scrollTop: 800,
+      scrollHeight: 1000,
+      clientHeight: 200,
+    });
+    await fireEvent.scroll(menu);
+
+    expect(onScrollend).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/Dropdown/DropdownScrollend.test.svelte
+++ b/tests/Dropdown/DropdownScrollend.test.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+  import Dropdown from "carbon-components-svelte/Dropdown/Dropdown.svelte";
+  import type { ComponentProps } from "svelte";
+
+  export let items: ComponentProps<Dropdown>["items"] = [];
+  export let open: ComponentProps<Dropdown>["open"] = false;
+  export let virtualize: ComponentProps<Dropdown>["virtualize"] = {
+    containerHeight: 200,
+    threshold: 1,
+  };
+  export let onScrollend: (
+    e: CustomEvent<{
+      scrollTop: number;
+      scrollHeight: number;
+      clientHeight: number;
+    }>,
+  ) => void = () => {};
+  export let onScroll: (e: Event) => void = () => {};
+</script>
+
+<Dropdown
+  {items}
+  bind:open
+  {virtualize}
+  labelText="Contact"
+  portalMenu={false}
+  on:scrollend={onScrollend}
+  on:scroll={onScroll}
+/>

--- a/tests/Dropdown/DropdownScrollend.test.ts
+++ b/tests/Dropdown/DropdownScrollend.test.ts
@@ -1,0 +1,152 @@
+import { fireEvent, render, screen } from "@testing-library/svelte";
+import { tick } from "svelte";
+import DropdownScrollend from "./DropdownScrollend.test.svelte";
+
+function createItems(count: number) {
+  return Array.from({ length: count }, (_, i) => ({
+    id: String(i),
+    text: `Item ${i + 1}`,
+  }));
+}
+
+function setMenuMetrics(
+  menu: HTMLElement,
+  {
+    scrollTop,
+    scrollHeight,
+    clientHeight,
+  }: { scrollTop: number; scrollHeight: number; clientHeight: number },
+) {
+  Object.defineProperty(menu, "scrollHeight", {
+    value: scrollHeight,
+    configurable: true,
+  });
+  Object.defineProperty(menu, "clientHeight", {
+    value: clientHeight,
+    configurable: true,
+  });
+  menu.scrollTop = scrollTop;
+}
+
+describe("Dropdown scrollend", () => {
+  it("dispatches scrollend when scrolled near the bottom", async () => {
+    const onScrollend = vi.fn();
+    render(DropdownScrollend, {
+      props: {
+        items: createItems(40),
+        open: true,
+        onScrollend,
+      },
+    });
+
+    const menu = screen.getByRole("listbox");
+    setMenuMetrics(menu, {
+      scrollTop: 800,
+      scrollHeight: 1000,
+      clientHeight: 200,
+    });
+    await fireEvent.scroll(menu);
+
+    expect(onScrollend).toHaveBeenCalledTimes(1);
+    expect(onScrollend.mock.calls[0][0].detail).toEqual({
+      scrollTop: 800,
+      scrollHeight: 1000,
+      clientHeight: 200,
+    });
+  });
+
+  it("does not dispatch scrollend on open or for non-overflowing lists", async () => {
+    const onScrollend = vi.fn();
+    render(DropdownScrollend, {
+      props: {
+        items: createItems(3),
+        open: true,
+        onScrollend,
+      },
+    });
+
+    await tick();
+    expect(onScrollend).not.toHaveBeenCalled();
+
+    const menu = screen.getByRole("listbox");
+    setMenuMetrics(menu, {
+      scrollTop: 0,
+      scrollHeight: 100,
+      clientHeight: 200,
+    });
+    await fireEvent.scroll(menu);
+
+    expect(onScrollend).not.toHaveBeenCalled();
+  });
+
+  it("re-arms after scroll-away and when items grow", async () => {
+    const onScrollend = vi.fn();
+    const { rerender } = render(DropdownScrollend, {
+      props: {
+        items: createItems(20),
+        open: true,
+        onScrollend,
+      },
+    });
+
+    const menu = screen.getByRole("listbox");
+    setMenuMetrics(menu, {
+      scrollTop: 800,
+      scrollHeight: 1000,
+      clientHeight: 200,
+    });
+    await fireEvent.scroll(menu);
+    expect(onScrollend).toHaveBeenCalledTimes(1);
+
+    setMenuMetrics(menu, {
+      scrollTop: 0,
+      scrollHeight: 1000,
+      clientHeight: 200,
+    });
+    await fireEvent.scroll(menu);
+    setMenuMetrics(menu, {
+      scrollTop: 800,
+      scrollHeight: 1000,
+      clientHeight: 200,
+    });
+    await fireEvent.scroll(menu);
+    expect(onScrollend).toHaveBeenCalledTimes(2);
+
+    await rerender({
+      items: createItems(40),
+      open: true,
+      onScrollend,
+    });
+    await tick();
+
+    const menuAfter = screen.getByRole("listbox");
+    setMenuMetrics(menuAfter, {
+      scrollTop: 1400,
+      scrollHeight: 1600,
+      clientHeight: 200,
+    });
+    await fireEvent.scroll(menuAfter);
+    expect(onScrollend).toHaveBeenCalledTimes(3);
+  });
+
+  it("still forwards the raw DOM scroll event", async () => {
+    const onScroll = vi.fn();
+    render(DropdownScrollend, {
+      props: {
+        items: createItems(40),
+        open: true,
+        onScroll,
+      },
+    });
+
+    const menu = screen.getByRole("listbox");
+    setMenuMetrics(menu, {
+      scrollTop: 100,
+      scrollHeight: 1000,
+      clientHeight: 200,
+    });
+    await fireEvent.scroll(menu);
+
+    expect(onScroll).toHaveBeenCalled();
+  });
+});

--- a/tests/utils/isScrollNearEnd.test.ts
+++ b/tests/utils/isScrollNearEnd.test.ts
@@ -1,0 +1,172 @@
+import {
+  createScrollEndTracker,
+  DEFAULT_SCROLL_END_THRESHOLD,
+  isScrollNearEnd,
+} from "../../src/utils/isScrollNearEnd.js";
+
+describe("isScrollNearEnd", () => {
+  test("false when content does not overflow", () => {
+    expect(
+      isScrollNearEnd({
+        scrollTop: 0,
+        scrollHeight: 200,
+        clientHeight: 200,
+      }),
+    ).toBe(false);
+    expect(
+      isScrollNearEnd({
+        scrollTop: 0,
+        scrollHeight: 100,
+        clientHeight: 200,
+      }),
+    ).toBe(false);
+  });
+
+  test("false when scrolled away from the bottom", () => {
+    expect(
+      isScrollNearEnd({
+        scrollTop: 0,
+        scrollHeight: 1000,
+        clientHeight: 200,
+      }),
+    ).toBe(false);
+    expect(
+      isScrollNearEnd({
+        scrollTop: 700,
+        scrollHeight: 1000,
+        clientHeight: 200,
+        threshold: 32,
+      }),
+    ).toBe(false);
+  });
+
+  test("true at and within the default threshold of the bottom", () => {
+    // Distance from bottom: 1000 - (768 + 200) = 32
+    expect(
+      isScrollNearEnd({
+        scrollTop: 768,
+        scrollHeight: 1000,
+        clientHeight: 200,
+      }),
+    ).toBe(true);
+    expect(
+      isScrollNearEnd({
+        scrollTop: 800,
+        scrollHeight: 1000,
+        clientHeight: 200,
+      }),
+    ).toBe(true);
+  });
+
+  test("respects a custom threshold", () => {
+    expect(
+      isScrollNearEnd({
+        scrollTop: 750,
+        scrollHeight: 1000,
+        clientHeight: 200,
+        threshold: 50,
+      }),
+    ).toBe(true);
+    expect(
+      isScrollNearEnd({
+        scrollTop: 750,
+        scrollHeight: 1000,
+        clientHeight: 200,
+        threshold: 49,
+      }),
+    ).toBe(false);
+  });
+
+  test("exports the default threshold constant", () => {
+    expect(DEFAULT_SCROLL_END_THRESHOLD).toBe(32);
+  });
+});
+
+describe("createScrollEndTracker", () => {
+  const nearBottom = {
+    scrollTop: 800,
+    scrollHeight: 1000,
+    clientHeight: 200,
+  };
+  const awayFromBottom = {
+    scrollTop: 0,
+    scrollHeight: 1000,
+    clientHeight: 200,
+  };
+
+  test("fires once when approaching the bottom", () => {
+    const tracker = createScrollEndTracker();
+
+    expect(tracker.observe(nearBottom)).toEqual(nearBottom);
+    expect(tracker.observe(nearBottom)).toBeNull();
+    expect(tracker.observe({ ...nearBottom, scrollTop: 850 })).toBeNull();
+  });
+
+  test("re-arms after scrolling away from the bottom", () => {
+    const tracker = createScrollEndTracker();
+
+    expect(tracker.observe(nearBottom)).toEqual(nearBottom);
+    expect(tracker.observe(awayFromBottom)).toBeNull();
+    expect(tracker.observe(nearBottom)).toEqual(nearBottom);
+  });
+
+  test("re-arms when the item count grows", () => {
+    const tracker = createScrollEndTracker();
+
+    expect(tracker.observe({ ...nearBottom, itemCount: 20 })).toEqual(
+      nearBottom,
+    );
+
+    expect(tracker.observe({ ...nearBottom, itemCount: 40 })).toEqual(
+      nearBottom,
+    );
+  });
+
+  test("re-arms via noteItemCount when the item count grows", () => {
+    const tracker = createScrollEndTracker();
+
+    tracker.noteItemCount(20);
+    expect(tracker.observe(nearBottom)).toEqual(nearBottom);
+
+    tracker.noteItemCount(40);
+    expect(tracker.observe(nearBottom)).toEqual(nearBottom);
+  });
+
+  test("does not re-arm when the item count stays the same or shrinks", () => {
+    const tracker = createScrollEndTracker();
+
+    tracker.noteItemCount(40);
+    expect(tracker.observe(nearBottom)).toEqual(nearBottom);
+
+    tracker.noteItemCount(40);
+    expect(tracker.observe(nearBottom)).toBeNull();
+
+    tracker.noteItemCount(30);
+    expect(tracker.observe(nearBottom)).toBeNull();
+  });
+
+  test("reset re-arms and clears the item count baseline", () => {
+    const tracker = createScrollEndTracker();
+
+    tracker.noteItemCount(20);
+    expect(tracker.observe(nearBottom)).toEqual(nearBottom);
+
+    tracker.reset();
+    expect(tracker.observe(nearBottom)).toEqual(nearBottom);
+  });
+
+  test("does not re-arm when leaving a non-overflowing list", () => {
+    const tracker = createScrollEndTracker();
+
+    expect(tracker.observe(nearBottom)).toEqual(nearBottom);
+    expect(
+      tracker.observe({
+        scrollTop: 0,
+        scrollHeight: 100,
+        clientHeight: 200,
+      }),
+    ).toBeNull();
+    // Still disarmed until overflow scroll-away or item growth / reset.
+    expect(tracker.observe(nearBottom)).toBeNull();
+  });
+});


### PR DESCRIPTION
ComboBox, Dropdown, and MultiSelect emit lowercase `scrollend`
when the menu is scrolled near the bottom (load-more signal),
via a shared util. Bare `on:scroll` is unchanged.