### PR TITLE
feat(accordion-item): add lazy prop to defer panel content mounting

### DIFF
--- a/docs/src/pages/components/Accordion.svx
+++ b/docs/src/pages/components/Accordion.svx
@@ -245,3 +245,23 @@ Set `size` to `"sm"` for a small skeleton.
 
 <Accordion skeleton size="sm" />
 
+## Lazy loading
+
+Set `lazy` on an accordion item to defer mounting its panel content until the
+item first opens. Use it for panels with heavy content, such as API-fetched
+data or charts, so they mount only when needed. The content stays mounted
+after the item collapses.
+
+<Accordion>
+  <AccordionItem lazy title="Natural Language Classifier">
+   <p>Natural Language Classifier uses advanced natural language processing and machine learning techniques to create custom classification models. Users train their data and the service predicts the appropriate category for the inputted text.
+   </p>
+  </AccordionItem>
+  <AccordionItem lazy title="Natural Language Understanding">
+    <p>Analyze text to extract meta-data from content such as concepts, entities, emotion, relations, sentiment and more.</p>
+  </AccordionItem>
+  <AccordionItem lazy title="Language Translator">
+    <p>Translate text, documents, and websites from one language to another. Create industry or region-specific translations via the service's customization capability.</p>
+  </AccordionItem>
+</Accordion>
+

--- a/src/Accordion/AccordionItem.svelte
+++ b/src/Accordion/AccordionItem.svelte
@@ -36,6 +36,12 @@
    */
   export let ref = null;
 
+  /**
+   * Set to `true` to defer mounting the panel content until the item is first opened.
+   * Once mounted, the content stays mounted for subsequent collapses.
+   */
+  export let lazy = false;
+
   import { getContext, onMount } from "svelte";
   import ChevronRight from "../icons/ChevronRight.svelte";
 
@@ -60,6 +66,9 @@
   }
 
   let animation = undefined;
+  let hasOpened = open;
+
+  $: if (open) hasOpened = true;
 
   onMount(() => {
     return () => {
@@ -109,5 +118,9 @@
       <slot name="title">{title}</slot>
     </div>
   </button>
-  <div class:bx--accordion__content={true}><slot /></div>
+  <div class:bx--accordion__content={true}>
+    {#if !lazy || hasOpened}
+      <slot />
+    {/if}
+  </div>
 </li>

--- a/tests/Accordion/Accordion.lazy.test.svelte
+++ b/tests/Accordion/Accordion.lazy.test.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  import Accordion from "carbon-components-svelte/Accordion/Accordion.svelte";
+  import AccordionItem from "carbon-components-svelte/Accordion/AccordionItem.svelte";
+
+  export let lazy = true;
+  export let open = false;
+
+  function logMount(_node: HTMLElement) {
+    console.log("lazy-content-mounted");
+  }
+</script>
+
+<Accordion>
+  <AccordionItem title="Natural Language Classifier" {lazy} {open}>
+    <p use:logMount>Lazy panel content</p>
+  </AccordionItem>
+</Accordion>

--- a/tests/Accordion/Accordion.test.ts
+++ b/tests/Accordion/Accordion.test.ts
@@ -2,6 +2,7 @@ import { render, screen } from "@testing-library/svelte";
 import { user } from "../utils/user";
 import AccordionBatchDisable from "./Accordion.batch-disable.test.svelte";
 import AccordionDisabled from "./Accordion.disabled.test.svelte";
+import AccordionLazy from "./Accordion.lazy.test.svelte";
 import AccordionProgrammatic from "./Accordion.programmatic.test.svelte";
 import AccordionSingle from "./Accordion.single.test.svelte";
 import AccordionSkeleton from "./Accordion.skeleton.test.svelte";
@@ -430,5 +431,44 @@ describe("Accordion", () => {
     // Clicking the open item again just collapses it.
     await user.click(lastItem);
     itemIsCollapsed(/Language Translator/);
+  });
+
+  it("should defer mounting panel content until first opened when lazy", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(AccordionLazy, { props: { lazy: true, open: false } });
+
+    expect(screen.queryByText("Lazy panel content")).not.toBeInTheDocument();
+    expect(consoleLog).not.toHaveBeenCalledWith("lazy-content-mounted");
+
+    await user.click(
+      screen.getByRole("button", { name: /Natural Language Classifier/ }),
+    );
+
+    expect(screen.getByText("Lazy panel content")).toBeInTheDocument();
+    expect(consoleLog).toHaveBeenCalledWith("lazy-content-mounted");
+    consoleLog.mockClear();
+
+    // Collapsing keeps the content mounted (no remount on re-expand).
+    await user.click(
+      screen.getByRole("button", { name: /Natural Language Classifier/ }),
+    );
+    await user.click(
+      screen.getByRole("button", { name: /Natural Language Classifier/ }),
+    );
+
+    expect(screen.getByText("Lazy panel content")).toBeInTheDocument();
+    expect(consoleLog).not.toHaveBeenCalledWith("lazy-content-mounted");
+  });
+
+  it("should mount panel content immediately when lazy is false", () => {
+    render(AccordionLazy, { props: { lazy: false, open: false } });
+
+    expect(screen.getByText("Lazy panel content")).toBeInTheDocument();
+  });
+
+  it("should mount panel content immediately when lazy item starts open", () => {
+    render(AccordionLazy, { props: { lazy: true, open: true } });
+
+    expect(screen.getByText("Lazy panel content")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Panels can now skip mounting their content until the item first
opens, then stay mounted across later collapses. Handy for panels
with heavy content like API-fetched data or charts.