### PR TITLE
chore(utils): add `downloadFile` utility

### DIFF
--- a/docs/src/pages/components/Link.svx
+++ b/docs/src/pages/components/Link.svx
@@ -1,10 +1,10 @@
 ---
-components: ["Link", "OutboundLink"]
-description: Links provide styled hyperlinks with multiple sizes, states, and icons, including an outbound variant for external links.
+components: ["Link", "OutboundLink", "LinkDownload"]
+description: Links provide styled hyperlinks with multiple sizes, states, and icons, including outbound and download variants.
 ---
 
 <script>
-  import { Link, OutboundLink, Text } from "carbon-components-svelte";
+  import { Link, LinkDownload, OutboundLink, Text } from "carbon-components-svelte";
   import Carbon from "carbon-icons-svelte/lib/Carbon.svelte";
 </script>
 
@@ -69,6 +69,24 @@ External links open in a new tab and append assistive text automatically for scr
 >
   Carbon Design System
 </OutboundLink>
+
+## Download link
+
+Use `LinkDownload` to trigger a client-side file download instead of navigating to a URL. Set `data` to the content to download, a string or `Blob`, and `filename` for the downloaded file name.
+
+<LinkDownload
+  data="id,name{'\n'}1,Alpha{'\n'}2,Bravo"
+  filename="items.csv"
+  type="text/csv;charset=utf-8"
+>
+  Download CSV
+</LinkDownload>
+
+### Dynamic content
+
+`data` is read at the moment the link is clicked, so downloaded content reflects filtering, sorting, or other state changes made before the click.
+
+<FileSource src="/framed/Link/LinkDownloadCsv" />
 
 ## Icons
 

--- a/docs/src/pages/framed/Link/LinkDownloadCsv.svelte
+++ b/docs/src/pages/framed/Link/LinkDownloadCsv.svelte
@@ -1,0 +1,40 @@
+<script>
+  import { LinkDownload, Search, Stack } from "carbon-components-svelte";
+
+  const loadBalancers = [
+    { id: "1", name: "lb-east", region: "us-east-1" },
+    { id: "2", name: "lb-west", region: "us-west-2" },
+    { id: "3", name: "lb-central", region: "us-central-1" },
+  ];
+
+  let value = "";
+
+  $: filteredRows = loadBalancers.filter((row) =>
+    row.name.toLowerCase().includes(value.toLowerCase()),
+  );
+
+  $: csv = [
+    "id,name,region",
+    ...filteredRows.map((row) => `${row.id},${row.name},${row.region}`),
+  ].join("\n");
+</script>
+
+<Stack gap={5}>
+  <Search
+    bind:value
+    labelText="Filter load balancers"
+    placeholder="Filter by name..."
+  />
+  <ul>
+    {#each filteredRows as row (row.id)}
+      <li>{row.name} ({row.region})</li>
+    {/each}
+  </ul>
+  <LinkDownload
+    data={csv}
+    filename="load-balancers.csv"
+    type="text/csv;charset=utf-8"
+  >
+    Download CSV
+  </LinkDownload>
+</Stack>

--- a/src/Link/LinkDownload.svelte
+++ b/src/Link/LinkDownload.svelte
@@ -1,0 +1,72 @@
+<script>
+  /** @extends {"./Link.svelte"} LinkProps */
+
+  /**
+   * @event download
+   * @event download:error
+   * @type {object}
+   * @property {unknown} error
+   */
+
+  /**
+   * Specify the content to download.
+   * @type {string | Blob}
+   */
+  export let data = undefined;
+
+  /** Specify the downloaded file name. */
+  export let filename = "download";
+
+  /**
+   * Specify the MIME type used to build the `Blob` when `data` is a string.
+   * @type {string}
+   */
+  export let type = undefined;
+
+  /** Set to `true` to disable the link. */
+  export let disabled = false;
+
+  /**
+   * Override the default download behavior (creates an object URL for
+   * `data` and clicks a temporary anchor).
+   * @type {(data: string | Blob, filename: string, type: string) => void | Promise<void>}
+   */
+  export let download = downloadFile;
+
+  import { createEventDispatcher } from "svelte";
+  import { downloadFile } from "../utils/downloadFile.js";
+  import Link from "./Link.svelte";
+
+  const dispatch = createEventDispatcher();
+
+  async function handleClick(event) {
+    event.preventDefault();
+    if (disabled) return;
+
+    try {
+      if (download === downloadFile ? data !== undefined : true) {
+        await download(data, filename, type);
+        dispatch("download");
+      }
+    } catch (error) {
+      dispatch("download:error", { error });
+    }
+  }
+</script>
+
+<Link
+  href="#"
+  {disabled}
+  {...$$restProps}
+  on:click
+  on:click={handleClick}
+  on:mouseover
+  on:mouseenter
+  on:mouseleave
+  on:focus
+  on:blur
+  on:keydown
+  on:keyup
+>
+  <slot />
+</Link>

--- a/src/Link/index.js
+++ b/src/Link/index.js
@@ -1,2 +1,3 @@
 export { default as Link } from "./Link.svelte";
+export { default as LinkDownload } from "./LinkDownload.svelte";
 export { default as OutboundLink } from "./OutboundLink.svelte";

--- a/src/index.js
+++ b/src/index.js
@@ -82,6 +82,7 @@ export { default as IconIndicator } from "./IconIndicator/IconIndicator.svelte";
 export { default as ImageLoader } from "./ImageLoader/ImageLoader.svelte";
 export { default as InlineLoading } from "./InlineLoading/InlineLoading.svelte";
 export { default as Link } from "./Link/Link.svelte";
+export { default as LinkDownload } from "./Link/LinkDownload.svelte";
 export { default as OutboundLink } from "./Link/OutboundLink.svelte";
 export { default as ListBox } from "./ListBox/ListBox.svelte";
 export { default as ListBoxField } from "./ListBox/ListBoxField.svelte";

--- a/src/index.js
+++ b/src/index.js
@@ -228,6 +228,7 @@ export { default as SkipToContent } from "./UIShell/SkipToContent.svelte";
 export { default as UnorderedList } from "./UnorderedList/UnorderedList.svelte";
 export { default as UserAvatar } from "./UserAvatar/UserAvatar.svelte";
 export { default as UserAvatarGroup } from "./UserAvatarGroup/UserAvatarGroup.svelte";
+export { downloadFile } from "./utils/downloadFile";
 export {
   filterTreeById,
   filterTreeByText,

--- a/src/utils/downloadFile.d.ts
+++ b/src/utils/downloadFile.d.ts
@@ -1,0 +1,9 @@
+/**
+ * Downloads `data` as a file. Wraps `data` in a `Blob` when it is a string,
+ * then triggers the download through a temporary object URL and anchor click.
+ */
+export function downloadFile(
+  data: string | Blob,
+  filename: string,
+  type?: string,
+): void;

--- a/src/utils/downloadFile.js
+++ b/src/utils/downloadFile.js
@@ -1,0 +1,20 @@
+// @ts-check
+
+/**
+ * Downloads `data` as a file. Wraps `data` in a `Blob` when it is a string,
+ * then triggers the download through a temporary object URL and anchor click.
+ *
+ * @param {string | Blob} data - The file content
+ * @param {string} filename - The downloaded file name
+ * @param {string} [type] - The MIME type used to build the `Blob` when `data` is a string
+ */
+export function downloadFile(data, filename, type) {
+  const blob = data instanceof Blob ? data : new Blob([data], { type });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+
+  anchor.href = url;
+  anchor.download = filename;
+  anchor.click();
+  URL.revokeObjectURL(url);
+}

--- a/tests/Link/LinkDownload.test.svelte
+++ b/tests/Link/LinkDownload.test.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+  import LinkDownload from "carbon-components-svelte/Link/LinkDownload.svelte";
+  import type { ComponentProps } from "svelte";
+
+  export let data: ComponentProps<LinkDownload>["data"] = "id,name\n1,Alpha";
+  export let filename = "load-balancers.csv";
+  export let type = "text/csv;charset=utf-8";
+  export let disabled = false;
+  export let download: ComponentProps<LinkDownload>["download"] = undefined;
+  export let onDownload = () => {};
+  export let onDownloadError = (_detail: { error: unknown }) => {};
+</script>
+
+<LinkDownload
+  {data}
+  {filename}
+  {type}
+  {disabled}
+  {download}
+  on:download={onDownload}
+  on:download:error={(event) => onDownloadError(event.detail)}
+>
+  Download CSV
+</LinkDownload>

--- a/tests/Link/LinkDownload.test.ts
+++ b/tests/Link/LinkDownload.test.ts
@@ -1,0 +1,104 @@
+import { render, screen } from "@testing-library/svelte";
+import { user } from "../utils/user";
+import LinkDownload from "./LinkDownload.test.svelte";
+
+describe("LinkDownload", () => {
+  let createObjectURL: ReturnType<typeof vi.fn>;
+  let revokeObjectURL: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    createObjectURL = vi.fn(() => "blob:mock-url");
+    revokeObjectURL = vi.fn();
+    URL.createObjectURL = createObjectURL as typeof URL.createObjectURL;
+    URL.revokeObjectURL = revokeObjectURL as typeof URL.revokeObjectURL;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const getLink = () => screen.getByRole("link", { name: "Download CSV" });
+
+  it("builds a Blob from string data and clicks a temporary anchor", async () => {
+    const clickSpy = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(() => {});
+
+    render(LinkDownload);
+    await user.click(getLink());
+
+    expect(createObjectURL).toHaveBeenCalledTimes(1);
+    const blob = createObjectURL.mock.calls[0][0] as Blob;
+    expect(blob.type).toBe("text/csv;charset=utf-8");
+
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+    expect(revokeObjectURL).toHaveBeenCalledWith("blob:mock-url");
+  });
+
+  it("does not navigate the underlying link", async () => {
+    vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
+
+    render(LinkDownload);
+    const link = getLink();
+    expect(link).toHaveAttribute("href", "#");
+
+    const { pathname } = window.location;
+    await user.click(link);
+
+    expect(window.location.pathname).toBe(pathname);
+  });
+
+  it("passes a Blob straight through without rewrapping it", async () => {
+    vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
+    const blob = new Blob(["custom"], { type: "application/json" });
+
+    render(LinkDownload, { props: { data: blob } });
+    await user.click(getLink());
+
+    expect(createObjectURL).toHaveBeenCalledWith(blob);
+  });
+
+  it("supports a custom download function", async () => {
+    const download = vi.fn();
+
+    render(LinkDownload, { props: { download } });
+    await user.click(getLink());
+
+    expect(download).toHaveBeenCalledWith(
+      "id,name\n1,Alpha",
+      "load-balancers.csv",
+      "text/csv;charset=utf-8",
+    );
+    expect(createObjectURL).not.toHaveBeenCalled();
+  });
+
+  it("dispatches download after a successful download", async () => {
+    vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
+    const onDownload = vi.fn();
+
+    render(LinkDownload, { props: { onDownload } });
+    await user.click(getLink());
+
+    expect(onDownload).toHaveBeenCalledTimes(1);
+  });
+
+  it("dispatches download:error when the download function throws", async () => {
+    const error = new Error("download failed");
+    const download = vi.fn().mockRejectedValue(error);
+    const onDownloadError = vi.fn();
+
+    render(LinkDownload, { props: { download, onDownloadError } });
+    await user.click(getLink());
+
+    expect(onDownloadError).toHaveBeenCalledWith({ error });
+  });
+
+  it("does not download when disabled", async () => {
+    const download = vi.fn();
+
+    render(LinkDownload, { props: { disabled: true, download } });
+    await user.click(getLink());
+
+    expect(download).not.toHaveBeenCalled();
+  });
+});

--- a/tests/utils/downloadFile.test.ts
+++ b/tests/utils/downloadFile.test.ts
@@ -1,0 +1,47 @@
+import { downloadFile } from "../../src/utils/downloadFile.js";
+
+describe("downloadFile", () => {
+  let createObjectURL: ReturnType<typeof vi.fn>;
+  let revokeObjectURL: ReturnType<typeof vi.fn>;
+  let clickSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    createObjectURL = vi.fn(() => "blob:mock-url");
+    revokeObjectURL = vi.fn();
+    URL.createObjectURL = createObjectURL as typeof URL.createObjectURL;
+    URL.revokeObjectURL = revokeObjectURL as typeof URL.revokeObjectURL;
+    clickSpy = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("wraps string data in a Blob with the given type", () => {
+    downloadFile("id,name\n1,Alpha", "items.csv", "text/csv;charset=utf-8");
+
+    expect(createObjectURL).toHaveBeenCalledTimes(1);
+    const blob = createObjectURL.mock.calls[0][0] as Blob;
+    expect(blob).toBeInstanceOf(Blob);
+    expect(blob.type).toBe("text/csv;charset=utf-8");
+  });
+
+  test("passes a Blob straight through without rewrapping it", () => {
+    const blob = new Blob(["custom"], { type: "application/json" });
+    downloadFile(blob, "data.json");
+
+    expect(createObjectURL).toHaveBeenCalledWith(blob);
+  });
+
+  test("clicks a temporary anchor with the object URL and filename, then revokes it", () => {
+    downloadFile("content", "report.txt");
+
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+    const anchor = clickSpy.mock.instances[0] as HTMLAnchorElement;
+    expect(anchor.download).toBe("report.txt");
+    expect(anchor.href).toBe("blob:mock-url");
+    expect(revokeObjectURL).toHaveBeenCalledWith("blob:mock-url");
+  });
+});


### PR DESCRIPTION
Also adds a `LinkDownload` component built on top of it, wrapping Link
to trigger a file download instead of navigating, and a Link docs
section covering a basic example plus a live-filtered CSV export.

---

```svelte
<script>
  import { LinkDownload } from "carbon-components-svelte";
</script>

<LinkDownload
  data="id,name{'\n'}1,Alpha{'\n'}2,Bravo"
  filename="items.csv"
  type="text/csv;charset=utf-8"
>
  Download CSV
</LinkDownload>
```