### PR TITLE
feat(accordion): add `flush` alignment prop

### DIFF
--- a/css/_accordion-flush.scss
+++ b/css/_accordion-flush.scss
@@ -1,0 +1,89 @@
+@import "carbon-components/scss/globals/scss/vars";
+@import "carbon-components/scss/globals/scss/helper-mixins";
+@import "carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/import-once/import-once";
+
+/// Flush accordion variant (Carbon React `isFlush`, v11). v10 has no
+/// `bx--accordion--flush` class; the full-width item border is replaced with
+/// an inset line so the accordion can sit edge-to-edge with its container.
+///
+/// v10 paints hover fill and the focus ring on `.bx--accordion__heading::before`
+/// (`height: calc(100% + 2px)`). Do not restyle that pseudo for flush border
+/// blending the way v11 does — it collapses both states to a 1px line.
+/// @access private
+/// @group components
+@mixin accordion-flush {
+  .#{$prefix}--accordion--flush .#{$prefix}--accordion__item {
+    position: relative;
+    border-color: transparent;
+
+    &:last-child {
+      border-color: transparent;
+    }
+
+    &::before,
+    &::after {
+      position: absolute;
+      display: block;
+      inline-size: calc(100% - #{$carbon--spacing-05} - #{$carbon--spacing-05});
+      block-size: 1px;
+      margin-inline-start: $carbon--spacing-05;
+      content: "";
+      transition: background-color $duration--fast-02
+        motion(standard, productive);
+    }
+
+    &::before {
+      inset-block-start: -1px;
+      background-color: $ui-03;
+    }
+
+    &:last-child::after {
+      inset-block-end: -1px;
+      background-color: $ui-03;
+    }
+  }
+
+  @media (any-hover: hover) {
+    .#{$prefix}--accordion--flush .#{$prefix}--accordion__item:hover,
+    .#{$prefix}--accordion--flush
+      .#{$prefix}--accordion__item:last-child:hover,
+    .#{$prefix}--accordion--flush
+      .#{$prefix}--accordion__item:hover
+      + .#{$prefix}--accordion__item {
+      border-color: transparent;
+    }
+
+    // Blend inset dividers into the heading hover fill (v10 ::before).
+    .#{$prefix}--accordion--flush .#{$prefix}--accordion__item:hover::before,
+    .#{$prefix}--accordion--flush
+      .#{$prefix}--accordion__item:hover
+      + .#{$prefix}--accordion__item::before,
+    .#{$prefix}--accordion--flush
+      .#{$prefix}--accordion__item:last-child:hover::after {
+      background-color: $hover-ui;
+    }
+  }
+
+  // v10's focus ::before hangs 1px past the heading. Lift the focused item
+  // above the next sibling and the heading above expanding content so that
+  // hang is not painted over (reads as a brief white cutoff on click).
+  .#{$prefix}--accordion--flush .#{$prefix}--accordion__item:focus-within {
+    z-index: 1;
+
+    &::before,
+    & + .#{$prefix}--accordion__item::before,
+    &:last-child::after {
+      background-color: transparent;
+      // Instant — a fade under the ring looks like a bottom cutoff.
+      transition: none;
+    }
+  }
+
+  .#{$prefix}--accordion--flush .#{$prefix}--accordion__heading:focus {
+    z-index: 2;
+  }
+}
+
+@include exports("accordion-flush") {
+  @include accordion-flush;
+}

--- a/css/all.scss
+++ b/css/all.scss
@@ -144,3 +144,4 @@ $css--plex: true;
 @import "./user-avatar";
 @import "./user-avatar-group";
 @import "./disclosure";
+@import "./accordion-flush";

--- a/css/g10.scss
+++ b/css/g10.scss
@@ -104,3 +104,4 @@ $css--plex: true;
 @import "./user-avatar";
 @import "./user-avatar-group";
 @import "./disclosure";
+@import "./accordion-flush";

--- a/css/g100.scss
+++ b/css/g100.scss
@@ -104,3 +104,4 @@ $css--plex: true;
 @import "./user-avatar";
 @import "./user-avatar-group";
 @import "./disclosure";
+@import "./accordion-flush";

--- a/css/g80.scss
+++ b/css/g80.scss
@@ -104,3 +104,4 @@ $css--plex: true;
 @import "./user-avatar";
 @import "./user-avatar-group";
 @import "./disclosure";
+@import "./accordion-flush";

--- a/css/g90.scss
+++ b/css/g90.scss
@@ -104,3 +104,4 @@ $css--plex: true;
 @import "./user-avatar";
 @import "./user-avatar-group";
 @import "./disclosure";
+@import "./accordion-flush";

--- a/css/white.scss
+++ b/css/white.scss
@@ -104,3 +104,4 @@ $css--plex: true;
 @import "./user-avatar";
 @import "./user-avatar-group";
 @import "./disclosure";
+@import "./accordion-flush";

--- a/docs/src/pages/components/Accordion.svx
+++ b/docs/src/pages/components/Accordion.svx
@@ -47,6 +47,25 @@ Align the chevron icon to the left side of the accordion item by setting `align`
   </AccordionItem>
 </Accordion>
 
+## Flush
+
+Set `flush` to remove the accordion's gutter, aligning it flush with the
+edges of its container. This works well in full-bleed layouts and side
+panels. `flush` has no effect when `align` is `"start"`.
+
+<Accordion flush>
+  <AccordionItem title="Natural Language Classifier">
+   <p>Natural Language Classifier uses advanced natural language processing and machine learning techniques to create custom classification models. Users train their data and the service predicts the appropriate category for the inputted text.
+   </p>
+  </AccordionItem>
+  <AccordionItem title="Natural Language Understanding">
+    <p>Analyze text to extract meta-data from content such as concepts, entities, emotion, relations, sentiment and more.</p>
+  </AccordionItem>
+  <AccordionItem title="Language Translator">
+    <p>Translate text, documents, and websites from one language to another. Create industry or region-specific translations via the service's customization capability.</p>
+  </AccordionItem>
+</Accordion>
+
 ## Custom title slot
 
 Customize the title content with the title slot instead of the title prop for
@@ -245,6 +264,12 @@ Set `size` to `"sm"` for a small skeleton.
 
 <Accordion skeleton size="sm" />
 
+### Flush
+
+Set `flush` to remove the skeleton's gutter, matching the flush variant.
+
+<Accordion skeleton flush />
+
 ## Lazy loading
 
 Set `lazy` on an accordion item to defer mounting its panel content until the
@@ -264,4 +289,5 @@ after the item collapses.
     <p>Translate text, documents, and websites from one language to another. Create industry or region-specific translations via the service's customization capability.</p>
   </AccordionItem>
 </Accordion>
+
 

--- a/src/Accordion/Accordion.svelte
+++ b/src/Accordion/Accordion.svelte
@@ -13,6 +13,12 @@
    */
   export let size = undefined;
 
+  /**
+   * Set to `true` to remove the gutter around the accordion, aligning it flush with its container.
+   * Has no effect when `align` is `"start"`.
+   */
+  export let flush = false;
+
   /** Set to `true` to disable the accordion */
   export let disabled = false;
 
@@ -58,6 +64,7 @@
     {...$$restProps}
     {align}
     {size}
+    {flush}
     on:click
     on:mouseover
     on:mouseenter
@@ -71,6 +78,7 @@
     class:bx--accordion--end={align === "end"}
     class:bx--accordion--sm={size === "sm"}
     class:bx--accordion--xl={size === "xl"}
+    class:bx--accordion--flush={flush && align !== "start"}
     {...$$restProps}
     on:click
     on:mouseover

--- a/src/Accordion/AccordionSkeleton.svelte
+++ b/src/Accordion/AccordionSkeleton.svelte
@@ -14,6 +14,12 @@
    */
   export let size = undefined;
 
+  /**
+   * Set to `true` to remove the gutter around the accordion, aligning it flush with its container.
+   * Has no effect when `align` is `"start"`.
+   */
+  export let flush = false;
+
   /** Set to `false` to close the first accordion item */
   export let open = true;
 
@@ -30,6 +36,7 @@
   class:bx--accordion--end={align === "end"}
   class:bx--accordion--sm={size === "sm"}
   class:bx--accordion--xl={size === "xl"}
+  class:bx--accordion--flush={flush && align !== "start"}
   {...$$restProps}
   on:click
   on:mouseover

--- a/tests/Accordion/Accordion.skeleton.test.svelte
+++ b/tests/Accordion/Accordion.skeleton.test.svelte
@@ -1,5 +1,8 @@
 <script lang="ts">
   import Accordion from "carbon-components-svelte/Accordion/Accordion.svelte";
+  import type { ComponentProps } from "svelte";
+
+  export let flush: ComponentProps<Accordion>["flush"] = false;
 </script>
 
-<Accordion skeleton />
+<Accordion skeleton {flush} />

--- a/tests/Accordion/Accordion.test.svelte
+++ b/tests/Accordion/Accordion.test.svelte
@@ -7,6 +7,7 @@
 
   export let align: ComponentProps<Accordion>["align"] = "end";
   export let size: ComponentProps<Accordion>["size"] = undefined;
+  export let flush: ComponentProps<Accordion>["flush"] = false;
   export let customClass = "";
   export let itemClass = "";
   export let useSlot = false;
@@ -17,6 +18,7 @@
 <Accordion
   {align}
   {size}
+  {flush}
   class={customClass}
   on:click={() => {
     console.log("accordion-click");

--- a/tests/Accordion/Accordion.test.ts
+++ b/tests/Accordion/Accordion.test.ts
@@ -238,6 +238,13 @@ describe("Accordion", () => {
     itemIsCollapsed(/Language Translator/);
   });
 
+  it("applies flush class to skeleton", () => {
+    render(AccordionSkeleton, { props: { flush: true } });
+
+    const accordion = screen.getByRole("list");
+    expect(accordion).toHaveClass("bx--accordion--flush");
+  });
+
   it("renders skeleton", () => {
     render(AccordionSkeleton);
 
@@ -325,6 +332,20 @@ describe("Accordion", () => {
     const accordion = screen.getByRole("list");
     expect(accordion).not.toHaveClass("bx--accordion--sm");
     expect(accordion).not.toHaveClass("bx--accordion--xl");
+  });
+
+  it("applies flush class", () => {
+    render(Accordion, { props: { flush: true } });
+
+    const accordion = screen.getByRole("list");
+    expect(accordion).toHaveClass("bx--accordion--flush");
+  });
+
+  it("does not apply flush class when align is start", () => {
+    render(Accordion, { props: { flush: true, align: "start" } });
+
+    const accordion = screen.getByRole("list");
+    expect(accordion).not.toHaveClass("bx--accordion--flush");
   });
 
   it("should apply custom class to Accordion", () => {


### PR DESCRIPTION
Matches Carbon React `isFlush`: inset dividers so the accordion can
sit edge-to-edge in full-bleed layouts and side panels. Has no effect
when `align` is `"start"`.

Closes #1600

---

<img width="964" height="166" alt="Screenshot 2026-08-01 at 2 24 56 PM" src="https://github.com/user-attachments/assets/d6f2bce5-f2ef-4353-893e-d4ca9d9c1464" />

