### PR TITLE
feat(modal): add primaryButtonLoading for async submit

### DIFF
--- a/docs/src/pages/components/ComposedModal.svx
+++ b/docs/src/pages/components/ComposedModal.svx
@@ -53,3 +53,8 @@ Combine the composed modal with a progress indicator to create a multi-step flow
 Set `secondaryButtons` in the modal footer to create a 3-button modal. This replaces secondaryButtonText and takes a tuple of two button configurations.
 
 <FileSource src="/framed/Modal/3ButtonComposedModal" />
+## Primary button loading
+
+Set `primaryButtonLoading` on `ModalFooter` while an async submit is in progress. The primary button shows an [InlineLoading](/components/InlineLoading) spinner, becomes non-interactive, and suppresses `submit` until loading finishes. The modal stays open.
+
+<FileSource src="/framed/Modal/ComposedModalPrimaryButtonLoading" />

--- a/docs/src/pages/components/Modal.svx
+++ b/docs/src/pages/components/Modal.svx
@@ -63,6 +63,12 @@ Connect the modal's primary button to a form with `formId`. This enables native 
 
 <FileSource src="/framed/Modal/ModalWithForm" />
 
+## Primary button loading
+
+Set `primaryButtonLoading` while an async submit is in progress. The primary button shows an [InlineLoading](/components/InlineLoading) spinner, becomes non-interactive, and suppresses `submit` until loading finishes. The modal stays open.
+
+<FileSource src="/framed/Modal/ModalPrimaryButtonLoading" />
+
 ## Has scrolling content
 
 Enable vertical scrolling for modals with lengthy content. This ensures all content remains accessible while maintaining a reasonable modal height.

--- a/docs/src/pages/framed/Modal/ComposedModalPrimaryButtonLoading.svelte
+++ b/docs/src/pages/framed/Modal/ComposedModalPrimaryButtonLoading.svelte
@@ -1,0 +1,35 @@
+<script>
+  import {
+    Button,
+    ComposedModal,
+    ModalBody,
+    ModalFooter,
+    ModalHeader,
+  } from "carbon-components-svelte";
+
+  let open = false;
+  let saving = false;
+
+  function onSave() {
+    saving = true;
+    setTimeout(() => {
+      saving = false;
+      open = false;
+    }, 2000);
+  }
+</script>
+
+<Button on:click={() => (open = true)}>Save changes</Button>
+
+<ComposedModal bind:open preventCloseOnClickOutside={saving} on:submit={onSave}>
+  <ModalHeader title="Save changes" />
+  <ModalBody>
+    <p>Save your changes to the Cloudant database configuration.</p>
+  </ModalBody>
+  <ModalFooter
+    primaryButtonText="Save"
+    secondaryButtonText="Cancel"
+    primaryButtonLoading={saving}
+    primaryButtonLoadingDescription="Saving..."
+  />
+</ComposedModal>

--- a/docs/src/pages/framed/Modal/ModalPrimaryButtonLoading.svelte
+++ b/docs/src/pages/framed/Modal/ModalPrimaryButtonLoading.svelte
@@ -1,0 +1,32 @@
+<script>
+  import { Button, Modal } from "carbon-components-svelte";
+
+  let open = false;
+  let saving = false;
+
+  function onSave() {
+    saving = true;
+    setTimeout(() => {
+      saving = false;
+      open = false;
+    }, 2000);
+  }
+</script>
+
+<Button on:click={() => (open = true)}>Save changes</Button>
+
+<Modal
+  bind:open
+  modalHeading="Save changes"
+  primaryButtonText="Save"
+  secondaryButtonText="Cancel"
+  primaryButtonLoading={saving}
+  primaryButtonLoadingDescription="Saving..."
+  preventCloseOnClickOutside={saving}
+  on:click:button--secondary={() => {
+    if (!saving) open = false;
+  }}
+  on:submit={onSave}
+>
+  <p>Save your changes to the Cloudant database configuration.</p>
+</Modal>

--- a/src/ComposedModal/ModalFooter.svelte
+++ b/src/ComposedModal/ModalFooter.svelte
@@ -18,6 +18,18 @@
   export let primaryButtonDisabled = false;
 
   /**
+   * Set to `true` to show a loading state on the primary button.
+   * While loading, the button is non-interactive and submit is suppressed.
+   */
+  export let primaryButtonLoading = false;
+
+  /**
+   * Specify the description for the primary button loading state.
+   * Passed to `InlineLoading` as `description`.
+   */
+  export let primaryButtonLoadingDescription = "Loading";
+
+  /**
    * Specify a class for the primary button.
    * @type {string}
    */
@@ -44,9 +56,15 @@
 
   import { createEventDispatcher, getContext } from "svelte";
   import Button from "../Button/Button.svelte";
+  import InlineLoading from "../InlineLoading/InlineLoading.svelte";
 
   const dispatch = createEventDispatcher();
   const { closeModal, submit } = getContext("carbon:ComposedModal");
+
+  function handlePrimaryClick() {
+    if (primaryButtonLoading) return;
+    submit();
+  }
 </script>
 
 <div
@@ -80,12 +98,19 @@
   {#if primaryButtonText}
     <Button
       kind={danger ? "danger" : "primary"}
-      disabled={primaryButtonDisabled}
+      disabled={primaryButtonDisabled || primaryButtonLoading}
       class={primaryClass}
-      icon={primaryButtonIcon}
-      on:click={submit}
+      icon={primaryButtonLoading ? undefined : primaryButtonIcon}
+      on:click={handlePrimaryClick}
     >
-      {primaryButtonText}
+      {#if primaryButtonLoading}
+        <InlineLoading
+          status="active"
+          description={primaryButtonLoadingDescription}
+        />
+      {:else}
+        {primaryButtonText}
+      {/if}
     </Button>
   {/if}
   <slot />

--- a/src/Modal/Modal.svelte
+++ b/src/Modal/Modal.svelte
@@ -77,6 +77,18 @@
   export let primaryButtonDisabled = false;
 
   /**
+   * Set to `true` to show a loading state on the primary button.
+   * While loading, the button is non-interactive and submit is suppressed.
+   */
+  export let primaryButtonLoading = false;
+
+  /**
+   * Specify the description for the primary button loading state.
+   * Passed to `InlineLoading` as `description`.
+   */
+  export let primaryButtonLoadingDescription = "Loading";
+
+  /**
    * Specify the primary button icon.
    * @type {Icon}
    */
@@ -116,6 +128,7 @@
   import { afterUpdate, createEventDispatcher, setContext, tick } from "svelte";
   import { writable } from "svelte/store";
   import Button from "../Button/Button.svelte";
+  import InlineLoading from "../InlineLoading/InlineLoading.svelte";
   import Close from "../icons/Close.svelte";
   import { initialFocus, restoreFocus } from "../utils/focus.js";
   import { createOutsideDismiss } from "../utils/outsideDismiss.js";
@@ -212,7 +225,8 @@
       } else if (
         shouldSubmitOnEnter &&
         event.key === "Enter" &&
-        !primaryButtonDisabled
+        !primaryButtonDisabled &&
+        !primaryButtonLoading
       ) {
         const target = event.target;
         const tag = target?.tagName;
@@ -342,16 +356,24 @@
         <Button
           bind:ref={primaryButtonRef}
           kind={danger ? "danger" : "primary"}
-          disabled={primaryButtonDisabled}
-          icon={primaryButtonIcon}
+          disabled={primaryButtonDisabled || primaryButtonLoading}
+          icon={primaryButtonLoading ? undefined : primaryButtonIcon}
           type={formId ? "submit" : "button"}
           form={formId}
           on:click={() => {
+            if (primaryButtonLoading) return;
             dispatch("submit");
             dispatch("click:button--primary");
           }}
         >
-          {primaryButtonText}
+          {#if primaryButtonLoading}
+            <InlineLoading
+              status="active"
+              description={primaryButtonLoadingDescription}
+            />
+          {:else}
+            {primaryButtonText}
+          {/if}
         </Button>
       </div>
     {/if}

--- a/tests/ComposedModal/ModalFooter.test.svelte
+++ b/tests/ComposedModal/ModalFooter.test.svelte
@@ -11,6 +11,9 @@
   export let primaryButtonIcon: ComponentProps<ModalFooter>["primaryButtonIcon"] =
     undefined;
   export let primaryButtonDisabled: ComponentProps<ModalFooter>["primaryButtonDisabled"] = false;
+  export let primaryButtonLoading: ComponentProps<ModalFooter>["primaryButtonLoading"] = false;
+  export let primaryButtonLoadingDescription: ComponentProps<ModalFooter>["primaryButtonLoadingDescription"] =
+    "Loading";
   export let primaryClass: ComponentProps<ModalFooter>["primaryClass"] =
     undefined;
   export let secondaryButtonText: ComponentProps<ModalFooter>["secondaryButtonText"] =
@@ -35,6 +38,8 @@
     {primaryButtonText}
     {primaryButtonIcon}
     {primaryButtonDisabled}
+    {primaryButtonLoading}
+    {primaryButtonLoadingDescription}
     {primaryClass}
     {secondaryButtonText}
     {secondaryButtons}

--- a/tests/ComposedModal/ModalFooter.test.ts
+++ b/tests/ComposedModal/ModalFooter.test.ts
@@ -90,6 +90,59 @@ describe("ModalFooter", () => {
     expect(primaryButton).toBeDisabled();
   });
 
+  describe("primaryButtonLoading", () => {
+    it("shows InlineLoading and does not dispatch submit on click", async () => {
+      const consoleLog = vi.spyOn(console, "log");
+      render(ModalFooterTest, {
+        props: {
+          primaryButtonText: "Save",
+          primaryButtonLoading: true,
+        },
+      });
+
+      expect(screen.getByText("Loading")).toBeInTheDocument();
+      expect(document.querySelector(".bx--inline-loading")).toBeInTheDocument();
+
+      const primaryButton = screen.getByRole("button", { name: /Loading/i });
+      expect(primaryButton).toBeDisabled();
+      await user.click(primaryButton);
+
+      expect(consoleLog).not.toHaveBeenCalledWith("submit");
+      expect(consoleLog).not.toHaveBeenCalledWith("click:button--primary");
+    });
+
+    it("keeps the idle primary button path unchanged", async () => {
+      const consoleLog = vi.spyOn(console, "log");
+      render(ModalFooterTest, {
+        props: {
+          primaryButtonText: "Save",
+          primaryButtonLoading: false,
+        },
+      });
+
+      expect(screen.getByText("Save")).toBeInTheDocument();
+      expect(
+        document.querySelector(".bx--inline-loading"),
+      ).not.toBeInTheDocument();
+
+      await user.click(screen.getByRole("button", { name: "Save" }));
+      expect(consoleLog).toHaveBeenCalledWith("submit");
+      expect(consoleLog).toHaveBeenCalledWith("click:button--primary");
+    });
+
+    it("uses a custom loading description", () => {
+      render(ModalFooterTest, {
+        props: {
+          primaryButtonText: "Save",
+          primaryButtonLoading: true,
+          primaryButtonLoadingDescription: "Saving...",
+        },
+      });
+
+      expect(screen.getByText("Saving...")).toBeInTheDocument();
+    });
+  });
+
   it("should render danger variant", () => {
     render(ModalFooterTest, {
       props: {

--- a/tests/Modal/Modal.test.svelte
+++ b/tests/Modal/Modal.test.svelte
@@ -12,6 +12,8 @@
   export let hasScrollingContent = false;
   export let primaryButtonText = "";
   export let primaryButtonDisabled = false;
+  export let primaryButtonLoading = false;
+  export let primaryButtonLoadingDescription = "Loading";
   export let primaryButtonIcon = undefined;
   export let shouldSubmitOnEnter = true;
   export let secondaryButtonText = "";
@@ -41,6 +43,8 @@
   {hasScrollingContent}
   {primaryButtonText}
   {primaryButtonDisabled}
+  {primaryButtonLoading}
+  {primaryButtonLoadingDescription}
   {primaryButtonIcon}
   {shouldSubmitOnEnter}
   {secondaryButtonText}

--- a/tests/Modal/Modal.test.ts
+++ b/tests/Modal/Modal.test.ts
@@ -845,6 +845,87 @@ describe("Modal", () => {
     expect(clickPrimaryHandler).not.toHaveBeenCalled();
   });
 
+  describe("primaryButtonLoading", () => {
+    it("shows InlineLoading and does not dispatch submit on click", async () => {
+      const submitHandler = vi.fn();
+      const clickPrimaryHandler = vi.fn();
+      render(ModalTest, {
+        props: {
+          open: true,
+          primaryButtonText: "Save",
+          primaryButtonLoading: true,
+          onsubmit: submitHandler,
+          onclickbuttonprimary: clickPrimaryHandler,
+        },
+      });
+
+      expect(screen.getByText("Loading")).toBeInTheDocument();
+      expect(document.querySelector(".bx--inline-loading")).toBeInTheDocument();
+
+      const primaryButton = screen.getByRole("button", { name: /Loading/i });
+      expect(primaryButton).toBeDisabled();
+      await user.click(primaryButton);
+
+      expect(submitHandler).not.toHaveBeenCalled();
+      expect(clickPrimaryHandler).not.toHaveBeenCalled();
+    });
+
+    it("does not dispatch submit when pressing Enter while loading", async () => {
+      const submitHandler = vi.fn();
+      const clickPrimaryHandler = vi.fn();
+      render(ModalTest, {
+        props: {
+          open: true,
+          primaryButtonText: "Save",
+          primaryButtonLoading: true,
+          shouldSubmitOnEnter: true,
+          onsubmit: submitHandler,
+          onclickbuttonprimary: clickPrimaryHandler,
+        },
+      });
+
+      screen.getByTestId("test-focus").focus();
+      await user.keyboard("{Enter}");
+      await tick();
+
+      expect(submitHandler).not.toHaveBeenCalled();
+      expect(clickPrimaryHandler).not.toHaveBeenCalled();
+    });
+
+    it("keeps the idle primary button path unchanged", async () => {
+      const consoleLog = vi.spyOn(console, "log");
+      render(ModalTest, {
+        props: {
+          open: true,
+          primaryButtonText: "Save",
+          primaryButtonLoading: false,
+        },
+      });
+
+      expect(screen.getByText("Save")).toBeInTheDocument();
+      expect(
+        document.querySelector(".bx--inline-loading"),
+      ).not.toBeInTheDocument();
+
+      await user.click(screen.getByRole("button", { name: "Save" }));
+      expect(consoleLog).toHaveBeenCalledWith("submit");
+      expect(consoleLog).toHaveBeenCalledWith("click:button--primary");
+    });
+
+    it("uses a custom loading description", () => {
+      render(ModalTest, {
+        props: {
+          open: true,
+          primaryButtonText: "Save",
+          primaryButtonLoading: true,
+          primaryButtonLoadingDescription: "Saving...",
+        },
+      });
+
+      expect(screen.getByText("Saving...")).toBeInTheDocument();
+    });
+  });
+
   describe("Generics", () => {
     it("should support custom Icon types with generics", () => {
       type CustomIcon = new (...args: unknown[]) => unknown;


### PR DESCRIPTION
Shows InlineLoading in the primary button while an async submit runs,
and blocks Enter/click submit until it clears. Works on Modal and
ModalFooter via primaryButtonLoading / primaryButtonLoadingDescription.