### PR TITLE
feat(modal): widen secondaryButtons with kind and disabled

### DIFF
--- a/docs/src/pages/components/Modal.svx
+++ b/docs/src/pages/components/Modal.svx
@@ -83,7 +83,7 @@ Stack multiple modals for complex workflows. Each modal maintains its own state 
 
 ## Multiple secondary buttons
 
-Add up to two secondary actions with `secondaryButtons`, which replaces the single secondary button text option.
+Add up to two secondary actions with `secondaryButtons`, which replaces the single secondary button text option. Each entry needs display text; set `kind` and `disabled` per button when actions should differ in weight or availability.
 
 <FileSource src="/framed/Modal/3ButtonModal" />
 

--- a/docs/src/pages/framed/Modal/3ButtonModal.svelte
+++ b/docs/src/pages/framed/Modal/3ButtonModal.svelte
@@ -10,10 +10,13 @@
   bind:open
   modalHeading="Create database"
   primaryButtonText="Confirm"
-  secondaryButtons={[{ text: "Cancel" }, { text: "Edit" }]}
+  secondaryButtons={[
+    { text: "Cancel", kind: "ghost" },
+    { text: "Save draft", kind: "secondary" },
+  ]}
   on:click:button--secondary={({ detail }) => {
     if (detail.text === "Cancel") open = false;
-    if (detail.text === "Edit") console.log("Edit");
+    if (detail.text === "Save draft") console.log("Save draft");
   }}
   on:open
   on:close

--- a/src/ComposedModal/ModalFooter.svelte
+++ b/src/ComposedModal/ModalFooter.svelte
@@ -39,9 +39,11 @@
   export let secondaryButtonText = "";
 
   /**
-   * 2-tuple prop to render two secondary buttons for a 3 button modal.
-   * Supersedes `secondaryButtonText`.
-   * @type {[] | [{ text: string; }, { text: string; }]}
+   * One or two secondary buttons for the modal footer.
+   * Supersedes `secondaryButtonText`. Each entry needs `text`; optional
+   * `kind` (defaults to `"secondary"`) and `disabled` pass through to Button.
+   * With two entries plus a primary button, the footer uses the three-button layout.
+   * @type {ReadonlyArray<{ text: string; kind?: string; disabled?: boolean }>}
    */
   export let secondaryButtons = [];
 
@@ -75,7 +77,8 @@
   {#if secondaryButtons.length > 0}
     {#each secondaryButtons as button (button.text)}
       <Button
-        kind="secondary"
+        kind={button.kind ?? "secondary"}
+        disabled={button.disabled}
         on:click={() => {
           dispatch("click:button--secondary", { text: button.text });
         }}

--- a/src/Modal/Modal.svelte
+++ b/src/Modal/Modal.svelte
@@ -104,9 +104,11 @@
   export let secondaryButtonText = "";
 
   /**
-   * 2-tuple prop to render two secondary buttons for a 3 button modal.
-   * Supersedes `secondaryButtonText`.
-   * @type {[{ text: string; }, { text: string; }]}
+   * One or two secondary buttons for the modal footer.
+   * Supersedes `secondaryButtonText`. Each entry needs `text`; optional
+   * `kind` (defaults to `"secondary"`) and `disabled` pass through to Button.
+   * With two entries plus a primary button, the footer uses the three-button layout.
+   * @type {ReadonlyArray<{ text: string; kind?: string; disabled?: boolean }>}
    */
   export let secondaryButtons = [];
 
@@ -333,7 +335,8 @@
         {#if secondaryButtons.length > 0}
           {#each secondaryButtons as button (button.text)}
             <Button
-              kind="secondary"
+              kind={button.kind ?? "secondary"}
+              disabled={button.disabled}
               on:click={() => {
                 dispatch("click:button--secondary", { text: button.text });
               }}

--- a/tests/ComposedModal/ModalFooter.test.ts
+++ b/tests/ComposedModal/ModalFooter.test.ts
@@ -168,6 +168,37 @@ describe("ModalFooter", () => {
     expect(screen.getByRole("button", { name: "Reset" })).toBeInTheDocument();
   });
 
+  it("should render one secondaryButtons entry with legacy { text }", () => {
+    render(ModalFooterTest, {
+      props: {
+        primaryButtonText: "Save",
+        secondaryButtons: [{ text: "Cancel" }],
+      },
+    });
+
+    const cancel = screen.getByRole("button", { name: "Cancel" });
+    expect(cancel).toHaveClass("bx--btn--secondary");
+    expect(cancel).not.toBeDisabled();
+  });
+
+  it("should apply kind and disabled from secondaryButtons", () => {
+    render(ModalFooterTest, {
+      props: {
+        primaryButtonText: "Save",
+        secondaryButtons: [
+          { text: "Save draft", kind: "secondary" },
+          { text: "Cancel", kind: "ghost", disabled: true },
+        ],
+      },
+    });
+
+    const draft = screen.getByRole("button", { name: "Save draft" });
+    const cancel = screen.getByRole("button", { name: "Cancel" });
+    expect(draft).toHaveClass("bx--btn--secondary");
+    expect(cancel).toHaveClass("bx--btn--ghost");
+    expect(cancel).toBeDisabled();
+  });
+
   it("should handle three-button layout", () => {
     render(ModalFooterTest, {
       props: {

--- a/tests/Modal/Modal.test.ts
+++ b/tests/Modal/Modal.test.ts
@@ -146,6 +146,63 @@ describe("Modal", () => {
     });
   });
 
+  it("renders one secondaryButtons entry with legacy { text }", () => {
+    render(ModalTest, {
+      props: {
+        open: true,
+        primaryButtonText: "Save",
+        secondaryButtons: [{ text: "Cancel" }],
+      },
+    });
+
+    const cancel = screen.getByRole("button", { name: "Cancel" });
+    expect(cancel).toHaveClass("bx--btn--secondary");
+    expect(cancel).not.toBeDisabled();
+  });
+
+  it("renders two secondaryButtons with kind and disabled", () => {
+    render(ModalTest, {
+      props: {
+        open: true,
+        primaryButtonText: "Save",
+        secondaryButtons: [
+          { text: "Save draft", kind: "secondary" },
+          { text: "Cancel", kind: "ghost", disabled: true },
+        ],
+      },
+    });
+
+    const draft = screen.getByRole("button", { name: "Save draft" });
+    const cancel = screen.getByRole("button", { name: "Cancel" });
+    expect(draft).toHaveClass("bx--btn--secondary");
+    expect(cancel).toHaveClass("bx--btn--ghost");
+    expect(cancel).toBeDisabled();
+
+    const footer = draft.closest(".bx--modal-footer");
+    expect(footer).toHaveClass("bx--modal-footer--three-button");
+  });
+
+  it("dispatches click:button--secondary for secondaryButtons entries", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(ModalTest, {
+      props: {
+        open: true,
+        primaryButtonText: "Save",
+        secondaryButtons: [{ text: "Cancel" }, { text: "Reset" }],
+      },
+    });
+
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(consoleLog).toHaveBeenCalledWith("click:button--secondary", {
+      text: "Cancel",
+    });
+
+    await user.click(screen.getByRole("button", { name: "Reset" }));
+    expect(consoleLog).toHaveBeenCalledWith("click:button--secondary", {
+      text: "Reset",
+    });
+  });
+
   it("supports different modal sizes", () => {
     type Size = "xs" | "sm" | "lg";
     const sizeMappings = {


### PR DESCRIPTION
secondaryButtons entries can set kind and disabled so multi-action
footers match Carbon’s richer secondary patterns without dropping back
to a custom slot.