### PR TITLE
feat(modal): add hideCloseButton

### DIFF
--- a/docs/src/pages/components/ComposedModal.svx
+++ b/docs/src/pages/components/ComposedModal.svx
@@ -34,6 +34,12 @@ The modal dispatches a cancelable `close` event. Call e.preventDefault() to keep
 
 <FileSource src="/framed/Modal/ComposedModalPreventClose" />
 
+## Hide close button
+
+Set `hideCloseButton` on `ModalHeader` to remove the header close button. Use this for forced-choice dialogs such as auth walls or terms acceptance. Always provide an alternative dismiss path — typically footer actions — and pair with `preventCloseOnClickOutside` when outside clicks should not dismiss the dialog. <DocKbd label="Escape" /> still closes the modal unless you cancel the `close` event.
+
+<FileSource src="/framed/Modal/ComposedModalHideCloseButton" />
+
 ## Danger
 
 Display critical or destructive actions with the danger variant. Set `danger` on both ComposedModal and ModalFooter for the red danger styling.

--- a/docs/src/pages/components/Modal.svx
+++ b/docs/src/pages/components/Modal.svx
@@ -131,6 +131,12 @@ Disable closing the modal when clicking outside with `preventCloseOnClickOutside
 
 <FileSource src="/framed/Modal/ModalPreventOutsideClick" />
 
+### Hide close button
+
+Set `hideCloseButton` to `true` to remove the header close button. Use this for forced-choice dialogs such as auth walls or terms acceptance. Always provide an alternative dismiss path — typically footer actions — and pair with `preventCloseOnClickOutside` when outside clicks should not dismiss the dialog. <DocKbd label="Escape" /> still closes the modal unless you cancel the `close` event.
+
+<FileSource src="/framed/Modal/ModalHideCloseButton" />
+
 ## Button with icon
 
 Enhance modal buttons with icons for better visual context and clarity.

--- a/docs/src/pages/framed/Modal/ComposedModalHideCloseButton.svelte
+++ b/docs/src/pages/framed/Modal/ComposedModalHideCloseButton.svelte
@@ -1,0 +1,32 @@
+<script>
+  import {
+    Button,
+    ComposedModal,
+    ModalBody,
+    ModalFooter,
+    ModalHeader,
+  } from "carbon-components-svelte";
+
+  let open = false;
+</script>
+
+<Button on:click={() => (open = true)}>Review terms</Button>
+
+<ComposedModal
+  bind:open
+  preventCloseOnClickOutside
+  on:submit={() => (open = false)}
+>
+  <ModalHeader title="Accept terms of use" hideCloseButton />
+  <ModalBody>
+    <p>
+      You must accept or decline the terms. The header close button is hidden,
+      so use the footer actions to leave this dialog.
+    </p>
+  </ModalBody>
+  <ModalFooter
+    primaryButtonText="Accept"
+    secondaryButtonText="Decline"
+    on:click:button--secondary={() => (open = false)}
+  />
+</ComposedModal>

--- a/docs/src/pages/framed/Modal/ModalHideCloseButton.svelte
+++ b/docs/src/pages/framed/Modal/ModalHideCloseButton.svelte
@@ -1,0 +1,23 @@
+<script>
+  import { Button, Modal } from "carbon-components-svelte";
+
+  let open = false;
+</script>
+
+<Button on:click={() => (open = true)}>Review terms</Button>
+
+<Modal
+  bind:open
+  hideCloseButton
+  preventCloseOnClickOutside
+  modalHeading="Accept terms of use"
+  primaryButtonText="Accept"
+  secondaryButtonText="Decline"
+  on:click:button--secondary={() => (open = false)}
+  on:submit={() => (open = false)}
+>
+  <p>
+    You must accept or decline the terms. The header close button is hidden, so
+    use the footer actions to leave this dialog.
+  </p>
+</Modal>

--- a/src/ComposedModal/ModalHeader.svelte
+++ b/src/ComposedModal/ModalHeader.svelte
@@ -20,6 +20,12 @@
   /** Specify the ARIA label for the close icon */
   export let iconDescription = "Close";
 
+  /**
+   * Set to `true` to hide the header close button.
+   * Provide an alternative dismiss path (footer actions or Escape).
+   */
+  export let hideCloseButton = false;
+
   import { getContext } from "svelte";
   import Close from "../icons/Close.svelte";
 
@@ -51,18 +57,20 @@
     </h3>
   {/if}
   <slot />
-  <button
-    type="button"
-    aria-label={iconDescription}
-    class:bx--modal-close={true}
-    class={closeClass}
-    on:click
-    on:click={closeModal}
-  >
-    <Close
-      size={20}
-      class="bx--modal-close__icon {closeIconClass}"
-      aria-hidden="true"
-    />
-  </button>
+  {#if !hideCloseButton}
+    <button
+      type="button"
+      aria-label={iconDescription}
+      class:bx--modal-close={true}
+      class={closeClass}
+      on:click
+      on:click={closeModal}
+    >
+      <Close
+        size={20}
+        class="bx--modal-close__icon {closeIconClass}"
+        aria-hidden="true"
+      />
+    </button>
+  {/if}
 </div>

--- a/src/Modal/Modal.svelte
+++ b/src/Modal/Modal.svelte
@@ -118,6 +118,12 @@
   /** Set to `true` to prevent the modal from closing when clicking outside */
   export let preventCloseOnClickOutside = false;
 
+  /**
+   * Set to `true` to hide the header close button.
+   * Provide an alternative dismiss path (footer actions or Escape).
+   */
+  export let hideCloseButton = false;
+
   /** Set an id for the top-level element */
   export let id = `ccs-${Math.random().toString(36)}`;
 
@@ -276,7 +282,7 @@
     on:mousedown={outsideDismiss.pressInside}
   >
     <div class:bx--modal-header={true}>
-      {#if passiveModal}
+      {#if passiveModal && !hideCloseButton}
         <button
           bind:this={buttonRef}
           type="button"
@@ -297,7 +303,7 @@
       <h3 id={modalHeadingId} class:bx--modal-header__heading={true}>
         <slot name="heading">{modalHeading}</slot>
       </h3>
-      {#if !passiveModal}
+      {#if !passiveModal && !hideCloseButton}
         <button
           bind:this={buttonRef}
           type="button"

--- a/tests/ComposedModal/ModalHeader.test.svelte
+++ b/tests/ComposedModal/ModalHeader.test.svelte
@@ -13,6 +13,7 @@
   export let closeIconClass: ComponentProps<ModalHeader>["closeIconClass"] = "";
   export let iconDescription: ComponentProps<ModalHeader>["iconDescription"] =
     "Close";
+  export let hideCloseButton = false;
   export let slotContent = "";
 </script>
 
@@ -25,6 +26,7 @@
     {closeClass}
     {closeIconClass}
     {iconDescription}
+    {hideCloseButton}
     on:click={() => console.log("click")}
     {...$$restProps}
   >

--- a/tests/ComposedModal/ModalHeader.test.ts
+++ b/tests/ComposedModal/ModalHeader.test.ts
@@ -57,6 +57,20 @@ describe("ModalHeader", () => {
     expect(closeButton).toHaveClass("bx--modal-close");
   });
 
+  it("should hide close button when hideCloseButton is true", () => {
+    render(ModalHeaderTest, {
+      props: {
+        title: "Forced choice",
+        hideCloseButton: true,
+      },
+    });
+
+    expect(
+      screen.queryByRole("button", { name: "Close" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("Forced choice")).toBeInTheDocument();
+  });
+
   it("should handle custom icon description", () => {
     render(ModalHeaderTest, {
       props: {

--- a/tests/Modal/Modal.test.svelte
+++ b/tests/Modal/Modal.test.svelte
@@ -21,6 +21,7 @@
     undefined;
   export let selectorPrimaryFocus = "[data-modal-primary-focus]";
   export let preventCloseOnClickOutside = false;
+  export let hideCloseButton = false;
   export let size: ComponentProps<Modal>["size"] = undefined;
   export let danger = false;
   export let alert = false;
@@ -30,6 +31,10 @@
   export let onsubmit: ((event: CustomEvent) => void) | undefined = undefined;
   export let onclickbuttonprimary: ((event: CustomEvent) => void) | undefined =
     undefined;
+  export let onclickbuttonsecondary:
+    | ((event: CustomEvent) => void)
+    | undefined = undefined;
+  export let closeOnSecondary = false;
   export let includeInput = true;
 </script>
 
@@ -51,6 +56,7 @@
   {secondaryButtons}
   {selectorPrimaryFocus}
   {preventCloseOnClickOutside}
+  {hideCloseButton}
   {size}
   {danger}
   {alert}
@@ -59,8 +65,14 @@
   on:close={(e) => onclose?.(e)}
   on:submit={onsubmit || (() => console.log("submit"))}
   on:click:button--primary={onclickbuttonprimary || (() => console.log("click:button--primary"))}
-  on:click:button--secondary={(e) =>
-    console.log("click:button--secondary", e.detail)}
+  on:click:button--secondary={(e) => {
+    if (closeOnSecondary) open = false;
+    if (onclickbuttonsecondary) {
+      onclickbuttonsecondary(e);
+    } else {
+      console.log("click:button--secondary", e.detail);
+    }
+  }}
   on:transitionend={(e) => console.log("transitionend", e.detail)}
 >
   <slot />

--- a/tests/Modal/Modal.test.ts
+++ b/tests/Modal/Modal.test.ts
@@ -568,6 +568,53 @@ describe("Modal", () => {
     });
   });
 
+  it("hides the close button when hideCloseButton is true", () => {
+    render(ModalTest, {
+      props: {
+        open: true,
+        modalHeading: "Forced choice",
+        primaryButtonText: "Accept",
+        secondaryButtonText: "Decline",
+        hideCloseButton: true,
+      },
+    });
+
+    expect(screen.queryByLabelText("Close the modal")).not.toBeInTheDocument();
+    expect(screen.getByText("Accept")).toBeInTheDocument();
+    expect(screen.getByText("Decline")).toBeInTheDocument();
+  });
+
+  it("still closes via footer secondary button when hideCloseButton is true", async () => {
+    render(ModalTest, {
+      props: {
+        open: true,
+        modalHeading: "Forced choice",
+        primaryButtonText: "Accept",
+        secondaryButtonText: "Decline",
+        hideCloseButton: true,
+        closeOnSecondary: true,
+      },
+    });
+
+    expect(screen.queryByLabelText("Close the modal")).not.toBeInTheDocument();
+
+    await user.click(screen.getByText("Decline"));
+    await tick();
+
+    expect(document.querySelector(".bx--modal")).not.toHaveClass("is-visible");
+  });
+
+  it("renders the close button by default", () => {
+    render(ModalTest, {
+      props: {
+        open: true,
+        modalHeading: "Default close",
+      },
+    });
+
+    expect(screen.getByLabelText("Close the modal")).toBeInTheDocument();
+  });
+
   it("does not leave the modal open when a programmatic on:close handler throws", async () => {
     const error = new Error("consumer error");
     const trap = absorbUnhandledRejection((reason) => reason === error);


### PR DESCRIPTION
Opt-in hideCloseButton removes the header X on Modal and ModalHeader for
forced-choice flows. Escape and footer actions stay available.