### PR TITLE
feat(composed-modal): make secondary button close cancelable

### DIFF
--- a/docs/src/pages/components/ComposedModal.svx
+++ b/docs/src/pages/components/ComposedModal.svx
@@ -40,6 +40,12 @@ Set `hideCloseButton` on `ModalHeader` to remove the header close button. Use th
 
 <FileSource src="/framed/Modal/ComposedModalHideCloseButton" />
 
+## Prevent secondary button close
+
+`secondaryButtonText` closes the modal by default. The footer dispatches a cancelable `click:button--secondary` event first. Call `e.preventDefault()` to keep the modal open — for example when Cancel should stay put for a dirty form.
+
+<FileSource src="/framed/Modal/ComposedModalPreventSecondaryClose" />
+
 ## Danger
 
 Display critical or destructive actions with the danger variant. Set `danger` on both ComposedModal and ModalFooter for the red danger styling.

--- a/docs/src/pages/framed/Modal/ComposedModalPreventSecondaryClose.svelte
+++ b/docs/src/pages/framed/Modal/ComposedModalPreventSecondaryClose.svelte
@@ -1,0 +1,59 @@
+<script>
+  import {
+    Button,
+    ComposedModal,
+    InlineNotification,
+    ModalBody,
+    ModalFooter,
+    ModalHeader,
+    TextInput,
+  } from "carbon-components-svelte";
+
+  let open = false;
+  let name = "Ada Lovelace";
+  let draft = name;
+  let showWarning = false;
+
+  $: isDirty = draft !== name;
+</script>
+
+<Button
+  on:click={() => {
+    open = true;
+    draft = name;
+    showWarning = false;
+  }}
+>
+  Edit name
+</Button>
+
+<ComposedModal
+  bind:open
+  on:submit={() => {
+    name = draft;
+    open = false;
+  }}
+>
+  <ModalHeader title="Edit name" />
+  <ModalBody hasForm>
+    {#if showWarning}
+      <InlineNotification
+        kind="warning"
+        title="Unsaved changes"
+        subtitle="Save your changes, or keep editing. Cancel stays open while the form is dirty."
+        hideCloseButton
+      />
+    {/if}
+    <TextInput labelText="Name" bind:value={draft} />
+  </ModalBody>
+  <ModalFooter
+    primaryButtonText="Save"
+    secondaryButtonText="Cancel"
+    on:click:button--secondary={(e) => {
+      if (isDirty) {
+        e.preventDefault();
+        showWarning = true;
+      }
+    }}
+  />
+</ComposedModal>

--- a/src/ComposedModal/ModalFooter.svelte
+++ b/src/ComposedModal/ModalFooter.svelte
@@ -1,8 +1,7 @@
 <script>
   /**
    * @template [Icon=any]
-   * @event click:button--secondary
-   * @property {string} text
+   * @event {{ text: string }} click:button--secondary - Dispatched when a secondary button is clicked. For `secondaryButtonText`, the event is cancelable: call `preventDefault()` to keep the modal open. If not cancelled, the modal closes. Array `secondaryButtons` never auto-close.
    */
 
   /** Specify the primary button text */
@@ -67,6 +66,17 @@
     if (primaryButtonLoading) return;
     submit();
   }
+
+  function handleSecondaryClick() {
+    const shouldContinue = dispatch(
+      "click:button--secondary",
+      { text: secondaryButtonText },
+      { cancelable: true },
+    );
+    if (shouldContinue) {
+      closeModal();
+    }
+  }
 </script>
 
 <div
@@ -90,10 +100,7 @@
     <Button
       kind="secondary"
       class={secondaryClass}
-      on:click={() => {
-        closeModal();
-        dispatch("click:button--secondary", { text: secondaryButtonText });
-      }}
+      on:click={handleSecondaryClick}
     >
       {secondaryButtonText}
     </Button>

--- a/tests/ComposedModal/ModalFooter.test.svelte
+++ b/tests/ComposedModal/ModalFooter.test.svelte
@@ -24,6 +24,8 @@
     undefined;
   export let danger: ComponentProps<ModalFooter>["danger"] = false;
   export let slotContent = "";
+  /** When true, `on:click:button--secondary` calls preventDefault() so the modal stays open. */
+  export let preventSecondaryDefault = false;
 </script>
 
 <ComposedModal
@@ -45,8 +47,10 @@
     {secondaryButtons}
     {secondaryClass}
     {danger}
-    on:click:button--secondary={(e) =>
-      console.log("click:button--secondary", e.detail)}
+    on:click:button--secondary={(e) => {
+      console.log("click:button--secondary", e.detail);
+      if (preventSecondaryDefault) e.preventDefault();
+    }}
     {...$$restProps}
   >
     {#if slotContent}

--- a/tests/ComposedModal/ModalFooter.test.ts
+++ b/tests/ComposedModal/ModalFooter.test.ts
@@ -64,7 +64,7 @@ describe("ModalFooter", () => {
 
   it("should handle secondary button click", async () => {
     const consoleLog = vi.spyOn(console, "log");
-    render(ModalFooterTest, {
+    const { container } = render(ModalFooterTest, {
       props: {
         secondaryButtonText: "Cancel",
       },
@@ -76,6 +76,25 @@ describe("ModalFooter", () => {
       text: "Cancel",
     });
     expect(consoleLog).toHaveBeenCalledWith("close");
+    expect(container.querySelector(".bx--modal")).not.toHaveClass("is-visible");
+  });
+
+  it("keeps modal open when preventDefault is called on secondary click", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    const { container } = render(ModalFooterTest, {
+      props: {
+        secondaryButtonText: "Cancel",
+        preventSecondaryDefault: true,
+      },
+    });
+
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(consoleLog).toHaveBeenCalledWith("click:button--secondary", {
+      text: "Cancel",
+    });
+    expect(consoleLog).not.toHaveBeenCalledWith("close");
+    expect(container.querySelector(".bx--modal")).toHaveClass("is-visible");
   });
 
   it("should disable primary button when configured", () => {


### PR DESCRIPTION
ModalFooter’s secondaryButtonText path now fires a cancelable
click:button--secondary and only closes when the listener does not
preventDefault—same escape hatch as dirty-form Cancel flows.