### PR TITLE
feat(dialog): add close trigger detail and focus restore

### DIFF
--- a/docs/src/pages/components/Dialog.svx
+++ b/docs/src/pages/components/Dialog.svx
@@ -14,4 +14,18 @@ Set `modal` to `true` to open the dialog with the browser's `showModal()`, which
 
 `Dialog` renders only what you put in its default slot, with no built-in header, footer, or action buttons. Use it to build a custom overlay, or as the top-layer host for portalled content such as DatePicker or FloatingPortal. For a ready-made dialog with a heading, body, and action buttons, use [Modal](/components/Modal) instead.
 
+When the dialog opens, focus moves into it (native modal focus trap). When it closes, focus returns to the element that opened it.
+
 <FileSource src="/framed/Dialog/ModalDialog" />
+
+## Closing
+
+The `close` event includes a `trigger` property indicating what dismissed the dialog: `"escape-key"` (<DocKbd label="Escape" />), `"backdrop"`, `"close-button"` (for example a `<form method="dialog">` submit), or `"programmatic"` (when `open` is set to `false`).
+
+<FileSource src="/framed/Dialog/DialogCloseTriggers" />
+
+### Prevent on outside click
+
+Disable closing the modal dialog when clicking the backdrop with `preventCloseOnClickOutside`.
+
+<FileSource src="/framed/Dialog/DialogPreventOutsideClick" />

--- a/docs/src/pages/framed/Dialog/DialogCloseTriggers.svelte
+++ b/docs/src/pages/framed/Dialog/DialogCloseTriggers.svelte
@@ -1,0 +1,34 @@
+<script>
+  import { Button, Dialog, Stack } from "carbon-components-svelte";
+
+  let open = false;
+  /** @type {string | null} */
+  let lastTrigger = null;
+</script>
+
+<Stack gap={5}>
+  <Button on:click={() => (open = true)}>Open modal dialog</Button>
+  {#if lastTrigger}
+    <p>Last close trigger: <code>{lastTrigger}</code></p>
+  {/if}
+</Stack>
+
+<Dialog
+  bind:open
+  modal
+  aria-label="Close trigger example"
+  on:close={(e) => {
+    lastTrigger = e.detail.trigger;
+    console.log("close", e.detail);
+  }}
+>
+  <Stack gap={5}>
+    <p>
+      Dismiss with <kbd>Escape</kbd>, the backdrop, the close button, or by
+      setting <code>open</code> to <code>false</code>.
+    </p>
+    <form method="dialog">
+      <Button type="submit">Close</Button>
+    </form>
+  </Stack>
+</Dialog>

--- a/docs/src/pages/framed/Dialog/DialogPreventOutsideClick.svelte
+++ b/docs/src/pages/framed/Dialog/DialogPreventOutsideClick.svelte
@@ -1,0 +1,25 @@
+<script>
+  import { Button, Dialog, Stack } from "carbon-components-svelte";
+
+  let open = false;
+</script>
+
+<Button on:click={() => (open = true)}>Open dialog</Button>
+
+<Dialog
+  preventCloseOnClickOutside
+  bind:open
+  modal
+  aria-label="Prevent outside click example"
+>
+  <Stack gap={5}>
+    <p>
+      Clicking the backdrop will not close this dialog. Use
+      <kbd>Escape</kbd>
+      or the close button.
+    </p>
+    <form method="dialog">
+      <Button type="submit">Close</Button>
+    </form>
+  </Stack>
+</Dialog>

--- a/docs/src/pages/framed/Dialog/ModalDialog.svelte
+++ b/docs/src/pages/framed/Dialog/ModalDialog.svelte
@@ -11,10 +11,12 @@
   modal
   aria-label="Example modal dialog"
   on:open={() => console.log("open")}
-  on:close={() => console.log("close")}
+  on:close={(e) => console.log("close", e.detail)}
 >
   <Stack gap={5}>
     <p>Dialog content.</p>
-    <Button on:click={() => (open = false)}>Close</Button>
+    <form method="dialog">
+      <Button type="submit">Close</Button>
+    </form>
   </Stack>
 </Dialog>

--- a/e2e/dialog.test.ts
+++ b/e2e/dialog.test.ts
@@ -17,16 +17,35 @@ test.describe("Dialog", () => {
     await expect(page.getByTestId("modal-open-count")).toHaveText("1");
   });
 
-  test("closes the modal on Escape and dispatches a close event", async ({
+  test("closes the modal on Escape with escape-key trigger and restores focus", async ({
     page,
   }) => {
-    await page.getByTestId("open-modal").click();
+    const opener = page.getByTestId("open-modal");
+    await opener.click();
     await expect(page.getByTestId("modal-dialog")).toBeVisible();
 
     await page.keyboard.press("Escape");
 
     await expect(page.getByTestId("modal-dialog")).toBeHidden();
     await expect(page.getByTestId("modal-close-count")).toHaveText("1");
+    await expect(page.getByTestId("modal-close-trigger")).toHaveText(
+      "escape-key",
+    );
+    await expect(opener).toBeFocused();
+  });
+
+  test("closes with close-button trigger via form method=dialog", async ({
+    page,
+  }) => {
+    await page.getByTestId("open-modal").click();
+    await expect(page.getByTestId("modal-dialog")).toBeVisible();
+
+    await page.getByTestId("modal-close-button").click();
+
+    await expect(page.getByTestId("modal-dialog")).toBeHidden();
+    await expect(page.getByTestId("modal-close-trigger")).toHaveText(
+      "close-button",
+    );
   });
 
   test("opens non-modally without a backdrop that blocks the rest of the page", async ({

--- a/e2e/fixtures/DialogFixture.svelte
+++ b/e2e/fixtures/DialogFixture.svelte
@@ -4,6 +4,8 @@
   let modalOpen = false;
   let modalOpenCount = 0;
   let modalCloseCount = 0;
+  /** @type {string | null} */
+  let modalCloseTrigger = null;
 
   let nonModalOpen = false;
 </script>
@@ -17,6 +19,7 @@
 </button>
 <div data-testid="modal-open-count">{modalOpenCount}</div>
 <div data-testid="modal-close-count">{modalCloseCount}</div>
+<div data-testid="modal-close-trigger">{modalCloseTrigger ?? ""}</div>
 
 <Dialog
   bind:open={modalOpen}
@@ -24,10 +27,16 @@
   aria-label="Modal dialog"
   data-testid="modal-dialog"
   on:open={() => (modalOpenCount += 1)}
-  on:close={() => (modalCloseCount += 1)}
+  on:close={(e) => {
+    modalCloseCount += 1;
+    modalCloseTrigger = e.detail.trigger;
+  }}
 >
   <p>Modal content</p>
   <button type="button" data-testid="modal-focus-target">Focus target</button>
+  <form method="dialog">
+    <button type="submit" data-testid="modal-close-button">Close</button>
+  </form>
 </Dialog>
 
 <button

--- a/src/Dialog/Dialog.svelte
+++ b/src/Dialog/Dialog.svelte
@@ -1,9 +1,10 @@
 <script>
   /**
+   * @typedef {"escape-key" | "backdrop" | "close-button" | "programmatic"} DialogCloseTrigger
    * @restProps {dialog}
    * @slot {{}}
    * @event {null} open
-   * @event {null} close
+   * @event {{ trigger: DialogCloseTrigger }} close
    */
 
   /**
@@ -19,9 +20,20 @@
    */
   export let modal = false;
 
+  /**
+   * Set to `true` to prevent the dialog from closing when clicking the backdrop.
+   * Only applies when `modal` is `true`.
+   */
+  export let preventCloseOnClickOutside = false;
+
   import { createEventDispatcher } from "svelte";
+  import { restoreFocus } from "../utils/focus.js";
 
   const dispatch = createEventDispatcher();
+  const focusReturn = restoreFocus();
+
+  /** @type {DialogCloseTrigger | null} */
+  let pendingTrigger = null;
 
   /**
    * Calls `showModal()`/`show()`/`close()` on the native `<dialog>` element
@@ -41,6 +53,7 @@
     function sync({ open: shouldOpen, modal: isModal }) {
       if (shouldOpen) {
         if (!node.open) {
+          focusReturn.save();
           if (isModal) {
             node.showModal();
           } else {
@@ -49,14 +62,37 @@
           dispatch("open");
         }
       } else if (node.open) {
+        pendingTrigger = pendingTrigger ?? "programmatic";
         node.close();
       }
     }
   }
 
+  function handleCancel() {
+    pendingTrigger = "escape-key";
+  }
+
+  /**
+   * Light-dismiss on backdrop: clicks on `::backdrop` are retargeted to the
+   * `<dialog>` element, so `event.target === event.currentTarget` means the
+   * click was outside the dialog's content children.
+   * @param {MouseEvent} event
+   */
+  function handleClick(event) {
+    if (!modal || preventCloseOnClickOutside) return;
+    if (event.target !== event.currentTarget) return;
+    /** @type {HTMLDialogElement} */
+    const node = event.currentTarget;
+    pendingTrigger = "backdrop";
+    node.close();
+  }
+
   function handleClose() {
+    const trigger = pendingTrigger ?? "close-button";
+    pendingTrigger = null;
     open = false;
-    dispatch("close");
+    dispatch("close", { trigger });
+    focusReturn.restore();
   }
 </script>
 
@@ -66,7 +102,9 @@
   class:bx--dialog--modal={modal}
   use:dialogAction={{ open, modal }}
   {...$$restProps}
+  on:cancel={handleCancel}
   on:close={handleClose}
+  on:click={handleClick}
   on:click
 >
   <slot />

--- a/tests/Dialog/Dialog.test.svelte
+++ b/tests/Dialog/Dialog.test.svelte
@@ -3,15 +3,31 @@
 
   export let open = false;
   export let modal = false;
+  export let preventCloseOnClickOutside = false;
   export let onopen: ((event: CustomEvent) => void) | undefined = undefined;
   export let onclose: ((event: CustomEvent) => void) | undefined = undefined;
 </script>
 
+<button type="button" data-testid="opener" on:click={() => (open = true)}>
+  Open
+</button>
+
 <Dialog
   bind:open
   {modal}
+  {preventCloseOnClickOutside}
   on:open={(e) => onopen?.(e)}
   on:close={(e) => onclose?.(e)}
 >
   <p>Dialog content</p>
+  <button
+    type="button"
+    data-testid="close-button"
+    on:click={(e) => {
+      const dialog = e.currentTarget.closest("dialog");
+      dialog?.close();
+    }}
+  >
+    Close
+  </button>
 </Dialog>

--- a/tests/Dialog/Dialog.test.ts
+++ b/tests/Dialog/Dialog.test.ts
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/svelte";
 import { tick } from "svelte";
+import { user } from "../utils/user";
 import Dialog from "./Dialog.test.svelte";
 
 describe("Dialog", () => {
@@ -56,6 +57,91 @@ describe("Dialog", () => {
     expect(closeSpy).toHaveBeenCalledTimes(1);
   });
 
+  it('dispatches close with trigger "programmatic" when open is set to false', async () => {
+    const onclose = vi.fn();
+    const { rerender } = render(Dialog, { props: { open: true, onclose } });
+    rerender({ open: false, onclose });
+    await tick();
+
+    expect(onclose).toHaveBeenCalledTimes(1);
+    expect(onclose.mock.calls[0][0].detail).toEqual({
+      trigger: "programmatic",
+    });
+  });
+
+  it('dispatches close with trigger "escape-key" when Escape closes the dialog', () => {
+    const onclose = vi.fn();
+    render(Dialog, { props: { open: true, modal: true, onclose } });
+
+    const dialogEl = screen.getByRole("dialog") as HTMLDialogElement;
+    dialogEl.dispatchEvent(new Event("cancel"));
+    dialogEl.close();
+
+    expect(onclose).toHaveBeenCalledTimes(1);
+    expect(onclose.mock.calls[0][0].detail).toEqual({
+      trigger: "escape-key",
+    });
+  });
+
+  it('dispatches close with trigger "backdrop" when clicking the backdrop', async () => {
+    const onclose = vi.fn();
+    render(Dialog, { props: { open: true, modal: true, onclose } });
+
+    const dialogEl = screen.getByRole("dialog");
+    await user.click(dialogEl);
+
+    expect(onclose).toHaveBeenCalledTimes(1);
+    expect(onclose.mock.calls[0][0].detail).toEqual({
+      trigger: "backdrop",
+    });
+  });
+
+  it("does not close on backdrop click when preventCloseOnClickOutside is set", async () => {
+    const onclose = vi.fn();
+    render(Dialog, {
+      props: {
+        open: true,
+        modal: true,
+        preventCloseOnClickOutside: true,
+        onclose,
+      },
+    });
+
+    const dialogEl = screen.getByRole("dialog");
+    await user.click(dialogEl);
+
+    expect(onclose).not.toHaveBeenCalled();
+    expect(dialogEl).toHaveAttribute("open");
+  });
+
+  it('dispatches close with trigger "close-button" when dialog.close() is called', async () => {
+    const onclose = vi.fn();
+    render(Dialog, { props: { open: true, modal: true, onclose } });
+
+    await user.click(screen.getByTestId("close-button"));
+
+    expect(onclose).toHaveBeenCalledTimes(1);
+    expect(onclose.mock.calls[0][0].detail).toEqual({
+      trigger: "close-button",
+    });
+  });
+
+  it("restores focus to the opener when the dialog closes", async () => {
+    render(Dialog, { props: { modal: true } });
+
+    const opener = screen.getByTestId("opener");
+    opener.focus();
+    await user.click(opener);
+    await tick();
+
+    expect(screen.getByRole("dialog")).toHaveAttribute("open");
+
+    await user.keyboard("{Escape}");
+    await tick();
+
+    expect(opener).toHaveFocus();
+  });
+
   it("dispatches a close event and syncs open to false when the browser closes the dialog", () => {
     const onclose = vi.fn();
     render(Dialog, { props: { open: true, onclose } });
@@ -64,6 +150,9 @@ describe("Dialog", () => {
     dialogEl.close();
 
     expect(onclose).toHaveBeenCalledTimes(1);
+    expect(onclose.mock.calls[0][0].detail).toEqual({
+      trigger: "close-button",
+    });
     expect(dialogEl).not.toHaveAttribute("open");
   });
 });


### PR DESCRIPTION
close detail reports which trigger dismissed the Dialog (escape,
backdrop, close-button, programmatic), optional
preventCloseOnClickOutside, and focus restore to the opener.