### PR TITLE
feat(date-picker): add range presets

### DIFF
--- a/css/_datepicker.scss
+++ b/css/_datepicker.scss
@@ -1,4 +1,5 @@
 @import "carbon-components/scss/globals/scss/vars";
+@import "carbon-components/scss/globals/scss/helper-mixins";
 @import "carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/import-once/import-once";
 
 @mixin date-picker-input-wrapper {
@@ -207,4 +208,57 @@
 
 @include exports('datepicker-year-select-height') {
   @include date-picker-year-select-height;
+}
+
+// Range preset shortcuts (side rail) — not in Carbon v10 flatpickr styles.
+@mixin date-picker-presets {
+  .flatpickr-calendar.open.#{$prefix}--date-picker__calendar--with-presets {
+    flex-direction: row;
+    align-items: stretch;
+    justify-content: flex-start;
+    width: auto;
+    height: auto;
+    max-height: none;
+  }
+
+  .#{$prefix}--date-picker__calendar-main {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    width: to-rem(288px);
+  }
+
+  .#{$prefix}--date-picker__presets {
+    display: flex;
+    flex-direction: column;
+    gap: $spacing-01;
+    min-width: to-rem(120px);
+    padding: $spacing-03 $spacing-03 $spacing-03 $spacing-05;
+    border-right: 1px solid $ui-03;
+    text-align: left;
+  }
+
+  .#{$prefix}--date-picker__preset {
+    @include button-reset(true);
+
+    padding: $spacing-02 $spacing-03;
+    color: $link-01;
+    cursor: pointer;
+    text-align: left;
+    white-space: nowrap;
+
+    &:hover {
+      background-color: $hover-ui;
+      color: $link-01;
+    }
+
+    &:focus {
+      outline: 1px solid $focus;
+      outline-offset: -1px;
+    }
+  }
+}
+
+@include exports('datepicker-presets') {
+  @include date-picker-presets;
 }

--- a/docs/src/pages/components/DatePicker.svx
+++ b/docs/src/pages/components/DatePicker.svx
@@ -20,9 +20,15 @@ Set `datePickerType` to `"range"` for a start and end date. Provide two DatePick
 
 <FileSource src="/framed/DatePicker/DatePickerRange" />
 
+### Presets
+
+Pass `presets` for quick range shortcuts beside the calendar—useful for analytics filters such as Today or Last 7 days. Each item has a label and a `range` function that returns the start and end dates when clicked. Applying a preset updates `valueFrom` / `valueTo` and dispatches `change` like a normal selection. Presets are ignored when `datePickerType` is not `"range"`.
+
+<FileSource src="/framed/DatePicker/DatePickerPresets" />
+
 ### Programmatic
 
-Use `bind:valueFrom` and `bind:valueTo` to update the range from outside the component, such as preset buttons or filters.
+Use `bind:valueFrom` and `bind:valueTo` to update the range from outside the component, such as external filter controls.
 
 <FileSource src="/framed/DatePicker/DatePickerProgrammatic" />
 

--- a/docs/src/pages/framed/DatePicker/DatePickerPresets.svelte
+++ b/docs/src/pages/framed/DatePicker/DatePickerPresets.svelte
@@ -1,0 +1,55 @@
+<script>
+  import { DatePicker, DatePickerInput } from "carbon-components-svelte";
+
+  let valueFrom = "";
+  let valueTo = "";
+
+  function startOfDay(date) {
+    return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+  }
+
+  function daysAgo(n) {
+    const d = startOfDay(new Date());
+    d.setDate(d.getDate() - n);
+    return d;
+  }
+
+  const presets = [
+    {
+      label: "Today",
+      range: () => {
+        const d = startOfDay(new Date());
+        return [d, d];
+      },
+    },
+    {
+      label: "Last 7 days",
+      range: () => [daysAgo(6), startOfDay(new Date())],
+    },
+    {
+      label: "Last 30 days",
+      range: () => [daysAgo(29), startOfDay(new Date())],
+    },
+    {
+      label: "This month",
+      range: () => {
+        const now = new Date();
+        return [
+          new Date(now.getFullYear(), now.getMonth(), 1),
+          startOfDay(now),
+        ];
+      },
+    },
+  ];
+</script>
+
+<DatePicker
+  datePickerType="range"
+  bind:valueFrom
+  bind:valueTo
+  {presets}
+  on:change
+>
+  <DatePickerInput labelText="Start date" placeholder="mm/dd/yyyy" />
+  <DatePickerInput labelText="End date" placeholder="mm/dd/yyyy" />
+</DatePicker>

--- a/src/DatePicker/DatePicker.svelte
+++ b/src/DatePicker/DatePicker.svelte
@@ -1,5 +1,11 @@
 <script>
   /**
+   * @typedef {object} DatePickerPreset
+   * @property {string} label Display label for the preset shortcut.
+   * @property {() => [Date, Date]} range Returns the start and end dates when applied.
+   */
+
+  /**
    * @event {string | { selectedDates: [dateFrom: Date, dateTo?: Date]; dateStr: string | { from: string; to: string; } }} change
    */
 
@@ -99,6 +105,13 @@
   export let flatpickrProps = { static: true };
 
   /**
+   * Specify quick-select range presets shown beside the calendar.
+   * Only used when `datePickerType` is `"range"`.
+   * @type {ReadonlyArray<DatePickerPreset>}
+   */
+  export let presets = [];
+
+  /**
    * Bind to the Flatpickr calendar instance for programmatic control.
    * Only available when `datePickerType` is `"single"`, `"range"`, `"month"`,
    * or `"year"`.
@@ -185,6 +198,10 @@
   let onCalendarReposition = null;
   /** @type {HTMLElement | null} */
   let topLayerAncestor = null;
+  /** @type {HTMLElement | null} */
+  let presetsRailEl = null;
+  /** @type {HTMLElement | null} */
+  let calendarMainEl = null;
   // Set from onOpen/onClose. Outside-click listener attaches only while open.
   let calendarOpen = false;
   // flatpickr onClose has no reason; explicit handlers set closeTrigger, else
@@ -392,6 +409,88 @@
     ).focus();
   }
 
+  function removePresetsRail() {
+    presetsRailEl?.remove();
+    presetsRailEl = null;
+    if (calendarMainEl && calendar?.calendarContainer) {
+      while (calendarMainEl.firstChild) {
+        calendar.calendarContainer.appendChild(calendarMainEl.firstChild);
+      }
+      calendarMainEl.remove();
+      calendarMainEl = null;
+    }
+    calendar?.calendarContainer?.classList.remove(
+      "bx--date-picker__calendar--with-presets",
+    );
+  }
+
+  /**
+   * @param {HTMLElement} container
+   */
+  function ensureCalendarMain(container) {
+    if (calendarMainEl?.parentNode === container) return calendarMainEl;
+
+    calendarMainEl = document.createElement("div");
+    calendarMainEl.className = "bx--date-picker__calendar-main";
+    while (container.firstChild) {
+      calendarMainEl.appendChild(container.firstChild);
+    }
+    container.appendChild(calendarMainEl);
+    return calendarMainEl;
+  }
+
+  /**
+   * @param {DatePickerPreset} preset
+   */
+  function applyPreset(preset) {
+    if (datePickerType !== "range" || !calendar) return;
+
+    const [from, to] = preset.range();
+    calendar.setDate([from, to], true);
+    if (calendar.config.closeOnSelect !== false) {
+      calendar.close();
+    }
+  }
+
+  function syncPresetsRail() {
+    if (!calendar?.calendarContainer) return;
+
+    const shouldShow = datePickerType === "range" && presets.length > 0;
+    if (!shouldShow) {
+      removePresetsRail();
+      return;
+    }
+
+    const container = calendar.calendarContainer;
+    const main = ensureCalendarMain(container);
+    container.classList.add("bx--date-picker__calendar--with-presets");
+
+    if (!presetsRailEl) {
+      presetsRailEl = document.createElement("div");
+      presetsRailEl.className = "bx--date-picker__presets";
+      presetsRailEl.setAttribute("role", "group");
+      presetsRailEl.setAttribute("aria-label", "Date range presets");
+    }
+
+    if (presetsRailEl.parentNode !== container) {
+      container.insertBefore(presetsRailEl, main);
+    }
+
+    presetsRailEl.replaceChildren();
+    for (const preset of presets) {
+      const button = document.createElement("button");
+      button.type = "button";
+      button.className = "bx--date-picker__preset";
+      button.textContent = preset.label;
+      button.addEventListener("click", (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        applyPreset(preset);
+      });
+      presetsRailEl.appendChild(button);
+    }
+  }
+
   setContext("carbon:DatePicker", {
     range,
     inputValue,
@@ -493,12 +592,19 @@
   onMount(() => {
     return () => {
       detachFixedRepositionListeners();
+      removePresetsRail();
       if (calendar) {
         calendar.destroy();
         calendar = null;
       }
     };
   });
+
+  $: if (calendar) {
+    presets;
+    datePickerType;
+    syncPresetsRail();
+  }
 
   afterUpdate(() => {
     if (calendar) {

--- a/tests/DatePicker/DatePicker.test.ts
+++ b/tests/DatePicker/DatePicker.test.ts
@@ -9,6 +9,7 @@ import DatePicker from "./DatePicker.test.svelte";
 import DatePickerCalendar from "./DatePickerCalendar.test.svelte";
 import DatePickerInModal from "./DatePickerInModal.test.svelte";
 import DatePickerInputSlot from "./DatePickerInput.slot.test.svelte";
+import DatePickerPresets from "./DatePickerPresets.test.svelte";
 import DatePickerRange from "./DatePickerRange.test.svelte";
 
 describe("DatePicker", () => {
@@ -88,6 +89,43 @@ describe("DatePicker", () => {
     expect(
       await screen.findByLabelText("calendar-container"),
     ).toBeInTheDocument();
+  });
+
+  describe("presets", () => {
+    it("applies a preset range and dispatches change", async () => {
+      const changeHandler = vi.fn();
+      render(DatePickerPresets, {
+        props: { onchange: changeHandler },
+      });
+
+      await user.click(screen.getByLabelText("Start date"));
+      await screen.findByLabelText("calendar-container");
+
+      await user.click(screen.getByRole("button", { name: "Last 7 days" }));
+
+      expect(screen.getByLabelText("Start date")).toHaveValue("01/09/2024");
+      expect(screen.getByLabelText("End date")).toHaveValue("01/15/2024");
+      expect(changeHandler).toHaveBeenCalled();
+      expect(changeHandler.mock.lastCall?.[0]?.detail).toMatchObject({
+        dateStr: { from: "01/09/2024", to: "01/15/2024" },
+      });
+    });
+
+    it("ignores presets when datePickerType is not range", async () => {
+      render(DatePickerPresets, {
+        props: { datePickerType: "single" },
+      });
+
+      await user.click(screen.getByLabelText("Date"));
+      await screen.findByLabelText("calendar-container");
+
+      expect(
+        screen.queryByRole("button", { name: "Today" }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByLabelText("Date range presets"),
+      ).not.toBeInTheDocument();
+    });
   });
 
   it("handles disabled state", () => {

--- a/tests/DatePicker/DatePickerPresets.test.svelte
+++ b/tests/DatePicker/DatePickerPresets.test.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+  import DatePicker from "carbon-components-svelte/DatePicker/DatePicker.svelte";
+  import DatePickerInput from "carbon-components-svelte/DatePicker/DatePickerInput.svelte";
+  import type { ComponentProps } from "svelte";
+
+  export let datePickerType: ComponentProps<DatePicker>["datePickerType"] =
+    "range";
+  export let valueFrom = "";
+  export let valueTo = "";
+  export let presets: ComponentProps<DatePicker>["presets"] = [
+    {
+      label: "Today",
+      range: () => {
+        const d = new Date(2024, 0, 15);
+        return [d, d];
+      },
+    },
+    {
+      label: "Last 7 days",
+      range: () => {
+        const to = new Date(2024, 0, 15);
+        const from = new Date(2024, 0, 9);
+        return [from, to];
+      },
+    },
+  ];
+  export let onchange: ((event: CustomEvent) => void) | undefined = undefined;
+</script>
+
+<DatePicker
+  {datePickerType}
+  {valueFrom}
+  {valueTo}
+  {presets}
+  on:change={(e) => onchange?.(e)}
+>
+  {#if datePickerType === "range"}
+    <DatePickerInput labelText="Start date" placeholder="mm/dd/yyyy" />
+    <DatePickerInput labelText="End date" placeholder="mm/dd/yyyy" />
+  {:else}
+    <DatePickerInput labelText="Date" placeholder="mm/dd/yyyy" />
+  {/if}
+</DatePicker>


### PR DESCRIPTION
Range DatePicker can show preset chips that set valueFrom/valueTo and
emit change. Non-range types ignore presets.