### PR TITLE
feat(file-uploader): support per-file status

### DIFF
--- a/docs/src/pages/components/FileUploader.svx
+++ b/docs/src/pages/components/FileUploader.svx
@@ -80,6 +80,27 @@ This example accepts multiple JPEG files and displays them in a completed state.
 
 <FileUploader multiple labelTitle="Upload files" buttonLabel="Add files" labelDescription="Only JPEG files are accepted." accept="{['.jpg', '.jpeg']}" status="complete" />
 
+## Per-file status
+
+Use `fileStatus` when files upload independently and should not share one
+global `status`. The callback receives `(file, index)` and returns
+`"uploading"`, `"edit"`, or `"complete"`. When omitted, every row uses
+`status`.
+
+`FileUploader` re-resolves rows when `files` (or the `fileStatus` prop)
+changes. If the callback reads reactive state that updates without
+changing `files`, reassign the list afterward (for example
+`files = [...files]`) so each row picks up the new status.
+
+Optional `fileInvalid`, `fileErrorSubject`, and `fileErrorBody` callbacks
+mark individual rows as invalid with error copy—without switching to
+manual `FileUploaderItem` composition.
+
+This demo starts each new file as uploading, then marks it complete on a
+staggered delay.
+
+<FileSource src="/framed/FileUploader/FileUploaderPerFileStatus" />
+
 ## Per-file status icon labels
 
 Set `iconDescription` to a function for accessible labels that depend on each row. The callback receives `{ file, fileName, status, invalid }`.

--- a/docs/src/pages/framed/FileUploader/FileUploaderPerFileStatus.svelte
+++ b/docs/src/pages/framed/FileUploader/FileUploaderPerFileStatus.svelte
@@ -1,0 +1,58 @@
+<script>
+  import { FileUploader } from "carbon-components-svelte";
+
+  let files = [];
+  let statusByKey = {};
+  let timersByKey = {};
+
+  function fileKey(file) {
+    return `${file.name}-${file.size}-${file.lastModified}`;
+  }
+
+  function fileStatus(file) {
+    return statusByKey[fileKey(file)] ?? "uploading";
+  }
+
+  function handleAdd(e) {
+    e.detail.forEach((file, index) => {
+      const key = fileKey(file);
+      if (timersByKey[key]) clearTimeout(timersByKey[key]);
+      statusByKey = { ...statusByKey, [key]: "uploading" };
+      timersByKey[key] = setTimeout(
+        () => {
+          statusByKey = { ...statusByKey, [key]: "complete" };
+          // fileStatus closes over statusByKey; reassign files so rows
+          // re-resolve (callback identity alone does not invalidate).
+          files = [...files];
+          delete timersByKey[key];
+        },
+        700 + index * 500,
+      );
+    });
+  }
+
+  function handleRemove(e) {
+    const next = { ...statusByKey };
+    for (const file of e.detail) {
+      const key = fileKey(file);
+      if (timersByKey[key]) {
+        clearTimeout(timersByKey[key]);
+        delete timersByKey[key];
+      }
+      delete next[key];
+    }
+    statusByKey = next;
+  }
+</script>
+
+<FileUploader
+  multiple
+  labelTitle="Upload files"
+  buttonLabel="Add files"
+  labelDescription="Each file completes on its own schedule."
+  status="edit"
+  {fileStatus}
+  bind:files
+  on:add={handleAdd}
+  on:remove={handleRemove}
+/>

--- a/src/FileUploader/FileUploader.svelte
+++ b/src/FileUploader/FileUploader.svelte
@@ -9,9 +9,39 @@
 
   /**
    * Specify the file uploader status.
+   * Applied to every file row unless overridden by `fileStatus`.
    * @type {"uploading" | "edit" | "complete"}
    */
   export let status = "uploading";
+
+  /**
+   * Override the global `status` for an individual file.
+   * Receives `(file, index)` and returns `"uploading" | "edit" | "complete"`.
+   * When omitted, every row uses `status`.
+   * @type {undefined | ((file: File, index: number) => "uploading" | "edit" | "complete")}
+   */
+  export let fileStatus = undefined;
+
+  /**
+   * Mark an individual file as invalid.
+   * Receives `(file, index)` and returns a boolean.
+   * @type {undefined | ((file: File, index: number) => boolean)}
+   */
+  export let fileInvalid = undefined;
+
+  /**
+   * Per-file error subject when the row is invalid.
+   * Receives `(file, index)` and returns the subject text.
+   * @type {undefined | ((file: File, index: number) => string)}
+   */
+  export let fileErrorSubject = undefined;
+
+  /**
+   * Per-file error body when the row is invalid.
+   * Receives `(file, index)` and returns the body text.
+   * @type {undefined | ((file: File, index: number) => string)}
+   */
+  export let fileErrorBody = undefined;
 
   /** Set to `true` to disable the file uploader */
   export let disabled = false;
@@ -170,6 +200,43 @@
   /** Stable keys for `{#each}` (and Biome-safe: no commas in the each header). */
   $: filesWithKeys = keyFiles(files);
 
+  /**
+   * @param {File} file
+   * @param {number} index
+   * @returns {"uploading" | "edit" | "complete"}
+   */
+  function resolveFileStatus(file, index) {
+    return typeof fileStatus === "function" ? fileStatus(file, index) : status;
+  }
+
+  /**
+   * @param {File} file
+   * @param {number} index
+   */
+  function resolveFileInvalid(file, index) {
+    return typeof fileInvalid === "function" ? fileInvalid(file, index) : false;
+  }
+
+  /**
+   * @param {File} file
+   * @param {number} index
+   */
+  function resolveFileErrorSubject(file, index) {
+    return typeof fileErrorSubject === "function"
+      ? fileErrorSubject(file, index)
+      : "";
+  }
+
+  /**
+   * @param {File} file
+   * @param {number} index
+   */
+  function resolveFileErrorBody(file, index) {
+    return typeof fileErrorBody === "function"
+      ? fileErrorBody(file, index)
+      : "";
+  }
+
   $: {
     const prevSet = new Set(prevFiles);
     const currentSet = new Set(files);
@@ -290,15 +357,23 @@
     }}
   />
   <div class:bx--file-container={true}>
-    {#each filesWithKeys as { file, key } (key)}
-      <span class:bx--file__selected-file={true}>
+    {#each filesWithKeys as { file, key }, index (key)}
+      {@const rowStatus = resolveFileStatus(file, index)}
+      {@const rowInvalid = resolveFileInvalid(file, index)}
+      {@const rowErrorSubject = resolveFileErrorSubject(file, index)}
+      {@const rowErrorBody = resolveFileErrorBody(file, index)}
+      <span
+        class:bx--file__selected-file={true}
+        class:bx--file__selected-file--invalid={rowInvalid}
+      >
         <p class:bx--file-filename={true}>{file.name}</p>
         <span class:bx--file__state-container={true}>
           <Filename
             {file}
             fileName={file.name}
             {iconDescription}
-            {status}
+            status={rowStatus}
+            invalid={rowInvalid}
             on:keydown
             on:keydown={(event) => {
               if (event.key === " " || event.key === "Enter") {
@@ -311,6 +386,18 @@
             }}
           />
         </span>
+        {#if rowInvalid && rowErrorSubject}
+          <div class:bx--form-requirement={true}>
+            <div class:bx--form-requirement__title={true}>
+              {rowErrorSubject}
+            </div>
+            {#if rowErrorBody}
+              <p class:bx--form-requirement__supplement={true}>
+                {rowErrorBody}
+              </p>
+            {/if}
+          </div>
+        {/if}
       </span>
     {/each}
   </div>

--- a/tests/FileUploader/FileUploader.perFileStatus.test.svelte
+++ b/tests/FileUploader/FileUploader.perFileStatus.test.svelte
@@ -1,0 +1,57 @@
+<script>
+  import FileUploader from "carbon-components-svelte/FileUploader/FileUploader.svelte";
+
+  export let delay = 50;
+
+  let files = [];
+  let statusByKey = {};
+  let timersByKey = {};
+
+  function fileKey(file) {
+    return `${file.name}-${file.size}-${file.lastModified}`;
+  }
+
+  function fileStatus(file) {
+    return statusByKey[fileKey(file)] ?? "uploading";
+  }
+
+  function handleAdd(e) {
+    e.detail.forEach((file, index) => {
+      const key = fileKey(file);
+      if (timersByKey[key]) clearTimeout(timersByKey[key]);
+      statusByKey = { ...statusByKey, [key]: "uploading" };
+      timersByKey[key] = setTimeout(
+        () => {
+          statusByKey = { ...statusByKey, [key]: "complete" };
+          files = [...files];
+          delete timersByKey[key];
+        },
+        delay + index * delay,
+      );
+    });
+  }
+
+  function handleRemove(e) {
+    const next = { ...statusByKey };
+    for (const file of e.detail) {
+      const key = fileKey(file);
+      if (timersByKey[key]) {
+        clearTimeout(timersByKey[key]);
+        delete timersByKey[key];
+      }
+      delete next[key];
+    }
+    statusByKey = next;
+  }
+</script>
+
+<FileUploader
+  multiple
+  labelTitle="Upload files"
+  buttonLabel="Add files"
+  status="edit"
+  {fileStatus}
+  bind:files
+  on:add={handleAdd}
+  on:remove={handleRemove}
+/>

--- a/tests/FileUploader/FileUploader.test.svelte
+++ b/tests/FileUploader/FileUploader.test.svelte
@@ -38,6 +38,13 @@
   export let orderFiles: ComponentProps<FileUploader>["orderFiles"] = "append";
   export let iconDescription: ComponentProps<FileUploader>["iconDescription"] =
     undefined;
+  export let fileStatus: ComponentProps<FileUploader>["fileStatus"] = undefined;
+  export let fileInvalid: ComponentProps<FileUploader>["fileInvalid"] =
+    undefined;
+  export let fileErrorSubject: ComponentProps<FileUploader>["fileErrorSubject"] =
+    undefined;
+  export let fileErrorBody: ComponentProps<FileUploader>["fileErrorBody"] =
+    undefined;
 </script>
 
 <form data-testid="file-form">
@@ -55,6 +62,10 @@
     {preventDuplicate}
     {orderFiles}
     {iconDescription}
+    {fileStatus}
+    {fileInvalid}
+    {fileErrorSubject}
+    {fileErrorBody}
     bind:ref
     bind:files
     on:add={(e) => onAdd?.(e)}

--- a/tests/FileUploader/FileUploader.test.ts
+++ b/tests/FileUploader/FileUploader.test.ts
@@ -1,5 +1,7 @@
 import { render, screen } from "@testing-library/svelte";
+import { tick } from "svelte";
 import { user } from "../utils/user";
+import FileUploaderPerFileStatusDemo from "./FileUploader.perFileStatus.test.svelte";
 import FileUploader from "./FileUploader.test.svelte";
 import FileUploaderButtonSlot from "./FileUploaderButton.slot.test.svelte";
 import FileUploaderDropContainerSlot from "./FileUploaderDropContainer.slot.test.svelte";
@@ -1106,5 +1108,156 @@ describe("FileUploader", () => {
       assert(ctx.file instanceof File);
       expect(ctx.file.name).toBe(ctx.fileName);
     }
+  });
+
+  it("should apply per-file status via fileStatus, overriding global status", () => {
+    const file1 = new File(["a"], "file1.txt", { type: "text/plain" });
+    const file2 = new File(["b"], "file2.txt", { type: "text/plain" });
+    const file3 = new File(["c"], "file3.txt", { type: "text/plain" });
+
+    const { container } = render(FileUploader, {
+      props: {
+        multiple: true,
+        status: "edit",
+        files: [file1, file2, file3],
+        fileStatus: (_file: File, index: number) =>
+          (["uploading", "edit", "complete"] as const)[index],
+      },
+    });
+
+    const rows = container.querySelectorAll(".bx--file__selected-file");
+    expect(rows).toHaveLength(3);
+
+    expect(rows[0].querySelector(".bx--loading")).toBeInTheDocument();
+    expect(rows[0].querySelector(".bx--file-close")).not.toBeInTheDocument();
+    expect(rows[0].querySelector(".bx--file-complete")).not.toBeInTheDocument();
+
+    expect(rows[1].querySelector(".bx--file-close")).toBeInTheDocument();
+    expect(rows[1].querySelector(".bx--loading")).not.toBeInTheDocument();
+    expect(rows[1].querySelector(".bx--file-complete")).not.toBeInTheDocument();
+
+    expect(rows[2].querySelector(".bx--file-complete")).toBeInTheDocument();
+    expect(rows[2].querySelector(".bx--loading")).not.toBeInTheDocument();
+    expect(rows[2].querySelector(".bx--file-close")).not.toBeInTheDocument();
+  });
+
+  it("should fall back to global status when fileStatus is unset", () => {
+    const file1 = new File(["a"], "file1.txt", { type: "text/plain" });
+    const file2 = new File(["b"], "file2.txt", { type: "text/plain" });
+
+    const { container } = render(FileUploader, {
+      props: {
+        multiple: true,
+        status: "complete",
+        files: [file1, file2],
+      },
+    });
+
+    const rows = container.querySelectorAll(".bx--file__selected-file");
+    expect(rows).toHaveLength(2);
+    expect(rows[0].querySelector(".bx--file-complete")).toBeInTheDocument();
+    expect(rows[1].querySelector(".bx--file-complete")).toBeInTheDocument();
+    expect(container.querySelector(".bx--loading")).not.toBeInTheDocument();
+    expect(container.querySelector(".bx--file-close")).not.toBeInTheDocument();
+  });
+
+  it("demo-style fileStatus transitions uploading to complete", async () => {
+    const { container } = render(FileUploaderPerFileStatusDemo, {
+      props: { delay: 50 },
+    });
+
+    const input = container.querySelector(
+      "input[type=file]",
+    ) as HTMLInputElement;
+    const file = new File(["a"], "a.txt", { type: "text/plain" });
+    simulateFileSelection(input, [file]);
+
+    await vi.waitFor(() => {
+      expect(container.querySelector(".bx--loading")).toBeInTheDocument();
+    });
+
+    await vi.waitFor(
+      () => {
+        expect(
+          container.querySelector(".bx--file-complete"),
+        ).toBeInTheDocument();
+      },
+      { timeout: 1000 },
+    );
+    expect(container.querySelector(".bx--loading")).not.toBeInTheDocument();
+  });
+
+  it("should update row status when fileStatus callback identity changes", async () => {
+    const file = new File(["a"], "file1.txt", { type: "text/plain" });
+    let current: "uploading" | "complete" = "uploading";
+
+    const { rerender, container } = render(FileUploader, {
+      props: {
+        files: [file],
+        status: "edit",
+        fileStatus: () => current,
+      },
+    });
+
+    expect(container.querySelector(".bx--loading")).toBeInTheDocument();
+
+    current = "complete";
+    await rerender({
+      files: [file],
+      status: "edit",
+      fileStatus: () => current,
+    });
+    await tick();
+
+    expect(container.querySelector(".bx--loading")).not.toBeInTheDocument();
+    expect(container.querySelector(".bx--file-complete")).toBeInTheDocument();
+  });
+
+  it("should NOT update when fileStatus reference is stable but closure data changes", async () => {
+    const file = new File(["a"], "file1.txt", { type: "text/plain" });
+    const state = { status: "uploading" as "uploading" | "complete" };
+    const fileStatus = () => state.status;
+
+    const { container } = render(FileUploader, {
+      props: {
+        files: [file],
+        status: "edit",
+        fileStatus,
+      },
+    });
+
+    expect(container.querySelector(".bx--loading")).toBeInTheDocument();
+
+    state.status = "complete";
+    await tick();
+
+    // Stable callback: child has no signal to re-resolve.
+    expect(container.querySelector(".bx--loading")).toBeInTheDocument();
+  });
+
+  it("should render per-file invalid state and error copy", () => {
+    const file1 = new File(["a"], "ok.txt", { type: "text/plain" });
+    const file2 = new File(["b"], "bad.txt", { type: "text/plain" });
+
+    const { container } = render(FileUploader, {
+      props: {
+        multiple: true,
+        status: "edit",
+        files: [file1, file2],
+        fileInvalid: (file: File) => file.name === "bad.txt",
+        fileErrorSubject: (file: File) =>
+          file.name === "bad.txt" ? "Upload failed" : "",
+        fileErrorBody: (file: File) =>
+          file.name === "bad.txt" ? "Please try again." : "",
+      },
+    });
+
+    const rows = container.querySelectorAll(".bx--file__selected-file");
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).not.toHaveClass("bx--file__selected-file--invalid");
+    expect(rows[1]).toHaveClass("bx--file__selected-file--invalid");
+    expect(screen.getByText("Upload failed")).toBeInTheDocument();
+    expect(screen.getByText("Please try again.")).toBeInTheDocument();
+    expect(rows[1].querySelector(".bx--file-invalid")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Per-file status, invalid, and error copy via function props, with the
global status prop as the fallback when a file has no override.