### PR TITLE
feat(file-uploader): add maxFiles limit

### DIFF
--- a/docs/src/pages/components/FileUploader.svx
+++ b/docs/src/pages/components/FileUploader.svx
@@ -153,6 +153,17 @@ each rejected file.
 
 <FileSource src="/framed/FileUploader/FileUploaderMaxFileSize" />
 
+## Maximum number of files
+
+Limit how many files can be attached with `maxFiles`. Excess files are rejected
+after size and duplicate checks, in selection order. A `rejected` event fires
+with `{ file, reason: "count" }` for each excess file. When the list is at
+capacity, further picks are disabled until a file is removed.
+
+This example accepts up to 3 documents.
+
+<FileSource src="/framed/FileUploader/FileUploaderMaxFiles" />
+
 ## File ordering
 
 Control the order of files in the list.

--- a/docs/src/pages/framed/FileUploader/FileUploaderMaxFiles.svelte
+++ b/docs/src/pages/framed/FileUploader/FileUploaderMaxFiles.svelte
@@ -1,0 +1,37 @@
+<script>
+  import {
+    FileUploader,
+    FileUploaderItem,
+    Stack,
+  } from "carbon-components-svelte";
+
+  let rejectedFiles = [];
+</script>
+
+<Stack gap={2}>
+  <FileUploader
+    multiple
+    maxFiles={3}
+    labelTitle="Upload documents"
+    buttonLabel="Add files"
+    labelDescription="Up to 3 documents."
+    status="edit"
+    on:rejected={(e) => {
+      rejectedFiles = e.detail;
+    }}
+  />
+
+  {#each rejectedFiles as { file }, i (`${file.name}-${file.lastModified}-${i}`)}
+    <FileUploaderItem
+      invalid
+      id={`rejected-count-${i}`}
+      name={file.name}
+      errorSubject="Too many files"
+      errorBody="You can attach up to 3 documents."
+      status="edit"
+      on:delete={() => {
+        rejectedFiles = rejectedFiles.filter((r) => r.file !== file);
+      }}
+    />
+  {/each}
+</Stack>

--- a/src/FileUploader/FileUploader.svelte
+++ b/src/FileUploader/FileUploader.svelte
@@ -4,7 +4,7 @@
    * @event {ReadonlyArray<File>} remove
    * @event {ReadonlyArray<File>} change
    * @event {void} clear
-   * @event {Array<{ file: File; reason: "size" | "duplicate" }>} rejected
+   * @event {Array<{ file: File; reason: "size" | "duplicate" | "count" }>} rejected
    */
 
   /**
@@ -64,6 +64,19 @@
    * ```
    */
   export let maxFileSize = undefined;
+
+  /**
+   * Specify the maximum number of files that can be attached.
+   * Excess files are rejected after size and duplicate checks, in selection
+   * order, via the `rejected` event with `reason: "count"`.
+   * When the list is at capacity, further picks are disabled until a file is removed.
+   * @type {number | undefined}
+   * @example
+   * ```svelte
+   * <FileUploader multiple maxFiles={3} />
+   * ```
+   */
+  export let maxFiles = undefined;
 
   /**
    * Obtain a reference to the uploaded files.
@@ -238,6 +251,9 @@
       : "";
   }
 
+  $: atMaxFiles = maxFiles !== undefined && files.length >= maxFiles;
+  $: inputDisabled = disabled || atMaxFiles;
+
   $: {
     const prevSet = new Set(prevFiles);
     const currentSet = new Set(files);
@@ -290,7 +306,7 @@
     </p>
   {/if}
   <FileUploaderButton
-    {disabled}
+    disabled={inputDisabled}
     disableLabelChanges
     labelText={buttonLabel}
     {accept}
@@ -305,7 +321,7 @@
       // (same reference) plus newly selected ones. Only reject new
       // objects that match an existing file by content.
       const existingRefs = new Set(prevFiles);
-      const { accepted: newFiles, rejected: allRejected } = filterIncomingFiles(
+      let { accepted: newFiles, rejected: allRejected } = filterIncomingFiles(
         event.detail,
         {
           maxFileSize,
@@ -314,6 +330,21 @@
           carryRefs: existingRefs,
         },
       );
+
+      // Count check runs after size/duplicate. Keep carried files; trim
+      // newly added files that would exceed maxFiles (selection order).
+      if (maxFiles !== undefined) {
+        const carriedForCount = newFiles.filter((f) => existingRefs.has(f));
+        const addedForCount = newFiles.filter((f) => !existingRefs.has(f));
+        const slots = Math.max(0, maxFiles - carriedForCount.length);
+        if (addedForCount.length > slots) {
+          const excess = addedForCount.slice(slots);
+          allRejected.push(
+            ...excess.map((file) => ({ file, reason: "count" })),
+          );
+          newFiles = [...carriedForCount, ...addedForCount.slice(0, slots)];
+        }
+      }
 
       if (allRejected.length > 0) {
         dispatch("rejected", allRejected);

--- a/src/FileUploader/FileUploaderDropContainer.svelte
+++ b/src/FileUploader/FileUploaderDropContainer.svelte
@@ -2,7 +2,7 @@
   /**
    * @event {ReadonlyArray<File>} add
    * @event {ReadonlyArray<File>} change
-   * @event {Array<{ file: File; reason: "size" | "duplicate" | "invalid" }>} rejected
+   * @event {Array<{ file: File; reason: "size" | "duplicate" | "invalid" | "count" }>} rejected
    */
 
   /**
@@ -41,6 +41,19 @@
    * via the `rejected` event with `reason: 'duplicate'`.
    */
   export let preventDuplicate = false;
+
+  /**
+   * Specify the maximum number of files that can be attached.
+   * Excess files are rejected after `validateFiles`, in selection order, via
+   * the `rejected` event with `reason: "count"`.
+   * When the list is at capacity, further picks are disabled until a file is removed.
+   * @type {number | undefined}
+   * @example
+   * ```svelte
+   * <FileUploaderDropContainer multiple maxFiles={3} />
+   * ```
+   */
+  export let maxFiles = undefined;
 
   /**
    * Override the default behavior of validating uploaded files.
@@ -86,6 +99,9 @@
 
   let over = false;
 
+  $: atMaxFiles = maxFiles !== undefined && files.length >= maxFiles;
+  $: inputDisabled = disabled || atMaxFiles;
+
   /** @param {ReadonlyArray<File>} incoming */
   function processIncoming(incoming) {
     const { accepted, rejected: builtInRejected } = filterIncomingFiles(
@@ -96,15 +112,33 @@
         existingFiles: files,
       },
     );
-    const validated = validateFiles(accepted);
+    let validated = validateFiles(accepted);
     const acceptedSet = new Set(validated);
-    /** @type {Array<{ file: File; reason: "size" | "duplicate" | "invalid" }>} */
+    /** @type {Array<{ file: File; reason: "size" | "duplicate" | "invalid" | "count" }>} */
     const rejected = [
       ...builtInRejected,
       ...accepted
         .filter((file) => !acceptedSet.has(file))
         .map((file) => ({ file, reason: /** @type {const} */ ("invalid") })),
     ];
+
+    // Count check runs after validateFiles. In multiple mode, slots are
+    // relative to files already attached; in single mode, the selection replaces.
+    if (maxFiles !== undefined) {
+      const existingCount = multiple ? files.length : 0;
+      const slots = Math.max(0, maxFiles - existingCount);
+      if (validated.length > slots) {
+        const excess = validated.slice(slots);
+        rejected.push(
+          ...excess.map((file) => ({
+            file,
+            reason: /** @type {const} */ ("count"),
+          })),
+        );
+        validated = validated.slice(0, slots);
+      }
+    }
+
     if (rejected.length > 0) dispatch("rejected", rejected);
     files = multiple ? [...files, ...validated] : validated;
     dispatch("add", files);
@@ -118,21 +152,21 @@
   {...$$restProps}
   on:dragover
   on:dragover|preventDefault|stopPropagation={(event) => {
-    if (!disabled) {
+    if (!inputDisabled) {
       over = true;
       event.dataTransfer.dropEffect = "copy";
     }
   }}
   on:dragleave
   on:dragleave|preventDefault|stopPropagation={(event) => {
-    if (!disabled) {
+    if (!inputDisabled) {
       over = false;
       event.dataTransfer.dropEffect = "move";
     }
   }}
   on:drop
   on:drop|preventDefault|stopPropagation={(event) => {
-    if (!disabled) {
+    if (!inputDisabled) {
       over = false;
       processIncoming([...event.dataTransfer.files]);
     }
@@ -143,10 +177,10 @@
   <label
     for={id}
     {role}
-    tabindex={disabled ? -1 : tabindex}
-    aria-disabled={disabled || undefined}
+    tabindex={inputDisabled ? -1 : tabindex}
+    aria-disabled={inputDisabled || undefined}
     class:bx--file-browse-btn={true}
-    class:bx--file-browse-btn--disabled={disabled}
+    class:bx--file-browse-btn--disabled={inputDisabled}
     on:keydown
     on:keydown={(event) => {
       if (event.key === " " || event.key === "Enter") {
@@ -166,7 +200,7 @@
     type="file"
     tabindex="-1"
     {id}
-    {disabled}
+    disabled={inputDisabled}
     accept={typeof accept === "string" ? accept : accept.join(",")}
     {name}
     {multiple}

--- a/tests/FileUploader/FileUploader.test.svelte
+++ b/tests/FileUploader/FileUploader.test.svelte
@@ -34,6 +34,7 @@
   export let name: ComponentProps<FileUploader>["name"] = "";
   export let maxFileSize: ComponentProps<FileUploader>["maxFileSize"] =
     undefined;
+  export let maxFiles: ComponentProps<FileUploader>["maxFiles"] = undefined;
   export let preventDuplicate: ComponentProps<FileUploader>["preventDuplicate"] = false;
   export let orderFiles: ComponentProps<FileUploader>["orderFiles"] = "append";
   export let iconDescription: ComponentProps<FileUploader>["iconDescription"] =
@@ -59,6 +60,7 @@
     {labelDescription}
     {name}
     {maxFileSize}
+    {maxFiles}
     {preventDuplicate}
     {orderFiles}
     {iconDescription}

--- a/tests/FileUploader/FileUploader.test.ts
+++ b/tests/FileUploader/FileUploader.test.ts
@@ -1260,4 +1260,88 @@ describe("FileUploader", () => {
     expect(screen.getByText("Please try again.")).toBeInTheDocument();
     expect(rows[1].querySelector(".bx--file-invalid")).toBeInTheDocument();
   });
+
+  it("should accept files under maxFiles limit", async () => {
+    const rejectedHandler = vi.fn();
+    const { component } = render(FileUploader, {
+      props: { multiple: true, maxFiles: 3, onRejected: rejectedHandler },
+    });
+
+    const files = [
+      new File(["a"], "file1.txt", { type: "text/plain" }),
+      new File(["b"], "file2.txt", { type: "text/plain" }),
+      new File(["c"], "file3.txt", { type: "text/plain" }),
+    ];
+
+    assert(component.ref instanceof HTMLInputElement);
+    simulateFileSelection(component.ref, files);
+
+    await vi.waitFor(() => {
+      expect(screen.queryByText("file1.txt")).toBeInTheDocument();
+      expect(screen.queryByText("file2.txt")).toBeInTheDocument();
+      expect(screen.queryByText("file3.txt")).toBeInTheDocument();
+    });
+
+    expect(rejectedHandler).not.toHaveBeenCalled();
+  });
+
+  it("should reject excess files with reason count when exceeding maxFiles", async () => {
+    const rejectedHandler = vi.fn();
+    const changeHandler = vi.fn();
+    const { component } = render(FileUploader, {
+      props: {
+        multiple: true,
+        maxFiles: 3,
+        onRejected: rejectedHandler,
+        onChange: changeHandler,
+      },
+    });
+
+    const files = [
+      new File(["a"], "file1.txt", { type: "text/plain" }),
+      new File(["b"], "file2.txt", { type: "text/plain" }),
+      new File(["c"], "file3.txt", { type: "text/plain" }),
+      new File(["d"], "file4.txt", { type: "text/plain" }),
+    ];
+
+    assert(component.ref instanceof HTMLInputElement);
+    simulateFileSelection(component.ref, files);
+
+    await vi.waitFor(() => {
+      expect(rejectedHandler).toHaveBeenCalled();
+      expect(changeHandler).toHaveBeenCalled();
+    });
+
+    const rejected = rejectedHandler.mock.calls[0][0].detail;
+    expect(rejected).toHaveLength(1);
+    expect(rejected[0].file.name).toBe("file4.txt");
+    expect(rejected[0].reason).toBe("count");
+
+    expect(changeHandler.mock.calls[0][0].detail).toHaveLength(3);
+    expect(screen.queryByText("file4.txt")).not.toBeInTheDocument();
+  });
+
+  it("should reject additional picks when already at maxFiles", async () => {
+    const rejectedHandler = vi.fn();
+    const { component } = render(FileUploader, {
+      props: { multiple: true, maxFiles: 2, onRejected: rejectedHandler },
+    });
+
+    assert(component.ref instanceof HTMLInputElement);
+    const input = component.ref;
+    simulateFileSelection(input, [
+      new File(["a"], "file1.txt", { type: "text/plain" }),
+      new File(["b"], "file2.txt", { type: "text/plain" }),
+    ]);
+
+    await vi.waitFor(() => {
+      expect(screen.queryByText("file1.txt")).toBeInTheDocument();
+      expect(screen.queryByText("file2.txt")).toBeInTheDocument();
+    });
+
+    expect(input).toBeDisabled();
+    const button = document.querySelector("button");
+    assert(button);
+    expect(button).toHaveClass("bx--btn--disabled");
+  });
 });

--- a/tests/FileUploader/FileUploaderDropContainer.test.ts
+++ b/tests/FileUploader/FileUploaderDropContainer.test.ts
@@ -608,4 +608,87 @@ describe("FileUploaderDropContainer", () => {
     assert(label);
     expect(label).toHaveAttribute("for", "custom-drop");
   });
+
+  it("should accept files under maxFiles limit", async () => {
+    const rejectedHandler = vi.fn();
+    const changeHandler = vi.fn();
+    const { container } = render(FileUploaderDropContainer, {
+      props: {
+        multiple: true,
+        maxFiles: 3,
+        onrejected: rejectedHandler,
+        onchange: changeHandler,
+      },
+    });
+
+    const input = container.querySelector('input[type="file"]');
+    assert(input instanceof HTMLInputElement);
+    simulateFileSelection(input, [
+      new File(["a"], "file1.txt", { type: "text/plain" }),
+      new File(["b"], "file2.txt", { type: "text/plain" }),
+      new File(["c"], "file3.txt", { type: "text/plain" }),
+    ]);
+
+    await vi.waitFor(() => {
+      expect(changeHandler).toHaveBeenCalled();
+    });
+
+    expect(changeHandler.mock.calls[0][0].detail).toHaveLength(3);
+    expect(rejectedHandler).not.toHaveBeenCalled();
+  });
+
+  it("should reject excess files with reason count when exceeding maxFiles", async () => {
+    const rejectedHandler = vi.fn();
+    const changeHandler = vi.fn();
+    const { container } = render(FileUploaderDropContainer, {
+      props: {
+        multiple: true,
+        maxFiles: 3,
+        onrejected: rejectedHandler,
+        onchange: changeHandler,
+      },
+    });
+
+    const input = container.querySelector('input[type="file"]');
+    assert(input instanceof HTMLInputElement);
+    simulateFileSelection(input, [
+      new File(["a"], "file1.txt", { type: "text/plain" }),
+      new File(["b"], "file2.txt", { type: "text/plain" }),
+      new File(["c"], "file3.txt", { type: "text/plain" }),
+      new File(["d"], "file4.txt", { type: "text/plain" }),
+    ]);
+
+    await vi.waitFor(() => {
+      expect(rejectedHandler).toHaveBeenCalled();
+      expect(changeHandler).toHaveBeenCalled();
+    });
+
+    const rejected = rejectedHandler.mock.calls[0][0].detail;
+    expect(rejected).toHaveLength(1);
+    expect(rejected[0].file.name).toBe("file4.txt");
+    expect(rejected[0].reason).toBe("count");
+    expect(changeHandler.mock.calls[0][0].detail).toHaveLength(3);
+  });
+
+  it("should disable further picks when at maxFiles", async () => {
+    const { container } = render(FileUploaderDropContainer, {
+      props: { multiple: true, maxFiles: 2 },
+    });
+
+    const input = container.querySelector('input[type="file"]');
+    assert(input instanceof HTMLInputElement);
+    simulateFileSelection(input, [
+      new File(["a"], "file1.txt", { type: "text/plain" }),
+      new File(["b"], "file2.txt", { type: "text/plain" }),
+    ]);
+
+    await vi.waitFor(() => {
+      expect(input).toBeDisabled();
+    });
+
+    const label = container.querySelector("label");
+    assert(label instanceof HTMLElement);
+    expect(label).toHaveClass("bx--file-browse-btn--disabled");
+    expect(label).toHaveAttribute("aria-disabled", "true");
+  });
 });


### PR DESCRIPTION
maxFiles caps accepted picks on FileUploader and DropContainer; overflow
files emit rejected with reason "count" and the control disables at
capacity.