### PR TITLE
feat(file-uploader-drop-container): parity for size and duplicate reject

### DIFF
--- a/docs/src/pages/components/FileUploader.svx
+++ b/docs/src/pages/components/FileUploader.svx
@@ -225,22 +225,16 @@ Customize file uploader item size with `size`. The default is `"default"`.
 
 ## Drop container
 
-Use the file uploader drop container for drag-and-drop file uploads. It supports file
-validation and multiple file selection.
+Use the file uploader drop container for drag-and-drop file uploads. It supports
+multiple file selection, size and duplicate checks, and custom validation.
 
-This example accepts files smaller than 1 kB and logs the selected files to the
-console.
+Set `maxFileSize` and `preventDuplicate` for the same rejection reasons as
+`FileUploader` (`size`, `duplicate`). Use `validateFiles` for additional
+filtering; files it removes are reported with `reason: "invalid"`.
 
-<FileUploaderDropContainer
-  multiple
-  labelText="Drag and drop files here or click to upload" 
-  validateFiles={files => {
-    return files.filter(file => file.size < 1_024)
-  }}
-  on:change={e=> {
-    console.log("files", e.detail)
-  }}
-/>
+This example rejects files over 1 kB and duplicates of already-selected files.
+
+<FileSource src="/framed/FileUploader/FileUploaderDropContainerValidation" />
 
 ## Skeleton
 

--- a/docs/src/pages/framed/FileUploader/FileUploaderDropContainerValidation.svelte
+++ b/docs/src/pages/framed/FileUploader/FileUploaderDropContainerValidation.svelte
@@ -1,0 +1,56 @@
+<script>
+  import {
+    FileUploaderDropContainer,
+    FileUploaderItem,
+    Stack,
+  } from "carbon-components-svelte";
+
+  let files = [];
+  let rejectedFiles = [];
+</script>
+
+<Stack gap={2}>
+  <FileUploaderDropContainer
+    multiple
+    maxFileSize={1024}
+    preventDuplicate
+    labelText="Drag and drop files here or click to upload"
+    bind:files
+    on:rejected={(e) => {
+      rejectedFiles = [...rejectedFiles, ...e.detail];
+    }}
+  />
+
+  {#each files as file, i (`${file.name}-${file.lastModified}-${i}`)}
+    <FileUploaderItem
+      id={`accepted-${i}`}
+      name={file.name}
+      status="edit"
+      on:delete={() => {
+        files = files.filter((f) => f !== file);
+      }}
+    />
+  {/each}
+
+  {#each rejectedFiles as { file, reason }, i (`${file.name}-${reason}-${i}`)}
+    <FileUploaderItem
+      invalid
+      id={`rejected-${i}`}
+      name={file.name}
+      errorSubject={reason === "size"
+        ? "File exceeds 1 kB limit"
+        : reason === "duplicate"
+          ? "Duplicate file"
+          : "File rejected"}
+      errorBody={reason === "size"
+        ? "Please select a smaller file."
+        : reason === "duplicate"
+          ? "This file is already in the list."
+          : "The file did not pass validation."}
+      status="edit"
+      on:delete={() => {
+        rejectedFiles = rejectedFiles.filter((r) => r.file !== file);
+      }}
+    />
+  {/each}
+</Stack>

--- a/src/FileUploader/FileUploader.svelte
+++ b/src/FileUploader/FileUploader.svelte
@@ -132,6 +132,7 @@
   export let ref = null;
 
   import { createEventDispatcher, tick } from "svelte";
+  import { filterIncomingFiles } from "../utils/filterIncomingFiles.js";
   import Filename from "./Filename.svelte";
   import FileUploaderButton from "./FileUploaderButton.svelte";
 
@@ -233,43 +234,19 @@
     bind:ref
     bind:files
     on:change={(event) => {
-      let newFiles = event.detail;
-      const allRejected = [];
+      // In multiple mode, newFiles includes re-sent existing files
+      // (same reference) plus newly selected ones. Only reject new
+      // objects that match an existing file by content.
       const existingRefs = new Set(prevFiles);
-
-      if (maxFileSize !== undefined) {
-        const rejected = newFiles.filter((file) => file.size > maxFileSize);
-        newFiles = newFiles.filter((file) => file.size <= maxFileSize);
-
-        if (rejected.length > 0) {
-          allRejected.push(
-            ...rejected.map((file) => ({ file, reason: "size" })),
-          );
-        }
-      }
-
-      if (preventDuplicate) {
-        // In multiple mode, newFiles includes re-sent existing files
-        // (same reference) plus newly selected ones. Only reject new
-        // objects that match an existing file by content.
-        const existingKeys = new Set(
-          prevFiles.map((f) => `${f.name}\0${f.size}\0${f.lastModified}`),
-        );
-        function isDuplicate(f) {
-          return (
-            !existingRefs.has(f) &&
-            existingKeys.has(`${f.name}\0${f.size}\0${f.lastModified}`)
-          );
-        }
-        const duplicates = newFiles.filter(isDuplicate);
-        newFiles = newFiles.filter((f) => !isDuplicate(f));
-
-        if (duplicates.length > 0) {
-          allRejected.push(
-            ...duplicates.map((file) => ({ file, reason: "duplicate" })),
-          );
-        }
-      }
+      const { accepted: newFiles, rejected: allRejected } = filterIncomingFiles(
+        event.detail,
+        {
+          maxFileSize,
+          preventDuplicate,
+          existingFiles: prevFiles,
+          carryRefs: existingRefs,
+        },
+      );
 
       if (allRejected.length > 0) {
         dispatch("rejected", allRejected);

--- a/src/FileUploader/FileUploaderDropContainer.svelte
+++ b/src/FileUploader/FileUploaderDropContainer.svelte
@@ -2,7 +2,7 @@
   /**
    * @event {ReadonlyArray<File>} add
    * @event {ReadonlyArray<File>} change
-   * @event {Array<{ file: File; reason: string }>} rejected
+   * @event {Array<{ file: File; reason: "size" | "duplicate" | "invalid" }>} rejected
    */
 
   /**
@@ -22,7 +22,31 @@
   export let multiple = false;
 
   /**
+   * Specify the maximum file size in bytes.
+   * Files exceeding this limit are filtered out and reported via the
+   * `rejected` event with `reason: 'size'`.
+   * File sizes use binary (base 2) units: 1024 bytes = 1 KiB, not 1000 bytes.
+   * @type {number | undefined}
+   * @example
+   * ```svelte
+   * <!-- 5 MB = 5 × 1024 × 1024 = 5,242,880 bytes -->
+   * <FileUploaderDropContainer maxFileSize={5 * 1024 * 1024} />
+   * ```
+   */
+  export let maxFileSize = undefined;
+
+  /**
+   * Set to `true` to reject files that match an already-selected file
+   * (by name, size, and lastModified). Rejected duplicates are reported
+   * via the `rejected` event with `reason: 'duplicate'`.
+   */
+  export let preventDuplicate = false;
+
+  /**
    * Override the default behavior of validating uploaded files.
+   * Runs after `maxFileSize` and `preventDuplicate` checks.
+   * Files removed by this function are reported via `rejected` with
+   * `reason: 'invalid'`.
    * By default, files are not validated.
    * @type {(files: ReadonlyArray<File>) => ReadonlyArray<File>}
    */
@@ -56,10 +80,36 @@
   export let ref = null;
 
   import { createEventDispatcher } from "svelte";
+  import { filterIncomingFiles } from "../utils/filterIncomingFiles.js";
 
   const dispatch = createEventDispatcher();
 
   let over = false;
+
+  /** @param {ReadonlyArray<File>} incoming */
+  function processIncoming(incoming) {
+    const { accepted, rejected: builtInRejected } = filterIncomingFiles(
+      incoming,
+      {
+        maxFileSize,
+        preventDuplicate,
+        existingFiles: files,
+      },
+    );
+    const validated = validateFiles(accepted);
+    const acceptedSet = new Set(validated);
+    /** @type {Array<{ file: File; reason: "size" | "duplicate" | "invalid" }>} */
+    const rejected = [
+      ...builtInRejected,
+      ...accepted
+        .filter((file) => !acceptedSet.has(file))
+        .map((file) => ({ file, reason: /** @type {const} */ ("invalid") })),
+    ];
+    if (rejected.length > 0) dispatch("rejected", rejected);
+    files = multiple ? [...files, ...validated] : validated;
+    dispatch("add", files);
+    dispatch("change", files);
+  }
 </script>
 
 <!-- svelte-ignore a11y-no-static-element-interactions -->
@@ -84,16 +134,7 @@
   on:drop|preventDefault|stopPropagation={(event) => {
     if (!disabled) {
       over = false;
-      const incoming = [...event.dataTransfer.files];
-      const newFiles = validateFiles(incoming);
-      const accepted = new Set(newFiles);
-      const rejected = incoming
-        .filter((file) => !accepted.has(file))
-        .map((file) => ({ file, reason: "invalid" }));
-      if (rejected.length > 0) dispatch("rejected", rejected);
-      files = multiple ? [...files, ...newFiles] : newFiles;
-      dispatch("add", files);
-      dispatch("change", files);
+      processIncoming([...event.dataTransfer.files]);
     }
   }}
 >
@@ -131,16 +172,7 @@
     {multiple}
     class:bx--file-input={true}
     on:change={({ target }) => {
-      const incoming = [...target.files];
-      const newFiles = validateFiles(incoming);
-      const accepted = new Set(newFiles);
-      const rejected = incoming
-        .filter((file) => !accepted.has(file))
-        .map((file) => ({ file, reason: "invalid" }));
-      if (rejected.length > 0) dispatch("rejected", rejected);
-      files = multiple ? [...files, ...newFiles] : newFiles;
-      dispatch("add", files);
-      dispatch("change", files);
+      processIncoming([...target.files]);
     }}
     on:click
     on:click={(event) => {

--- a/src/utils/filterIncomingFiles.d.ts
+++ b/src/utils/filterIncomingFiles.d.ts
@@ -1,0 +1,28 @@
+export type FileRejectionReason = "size" | "duplicate";
+
+export type FileRejection = {
+  file: File;
+  reason: FileRejectionReason;
+};
+
+/** Stable identity key for duplicate detection (name, size, lastModified). */
+export function fileIdentityKey(file: File): string;
+
+/**
+ * Filter incoming files by max size and duplicate rules.
+ *
+ * `carryRefs` marks same-reference files from `existingFiles` that should not
+ * be treated as duplicates (FileUploader button re-sends existing File objects).
+ */
+export function filterIncomingFiles(
+  incoming: ReadonlyArray<File>,
+  options?: {
+    maxFileSize?: number;
+    preventDuplicate?: boolean;
+    existingFiles?: ReadonlyArray<File>;
+    carryRefs?: ReadonlySet<File>;
+  },
+): {
+  accepted: File[];
+  rejected: FileRejection[];
+};

--- a/src/utils/filterIncomingFiles.js
+++ b/src/utils/filterIncomingFiles.js
@@ -1,0 +1,64 @@
+// @ts-check
+
+/**
+ * Stable identity key for duplicate detection (name, size, lastModified).
+ * @param {File} file
+ * @returns {string}
+ */
+export function fileIdentityKey(file) {
+  return `${file.name}\0${file.size}\0${file.lastModified}`;
+}
+
+/**
+ * Filter incoming files by max size and duplicate rules.
+ *
+ * @param {ReadonlyArray<File>} incoming
+ * @param {{
+ *   maxFileSize?: number;
+ *   preventDuplicate?: boolean;
+ *   existingFiles?: ReadonlyArray<File>;
+ *   carryRefs?: ReadonlySet<File>;
+ * }} [options]
+ * @returns {{
+ *   accepted: File[];
+ *   rejected: Array<{ file: File; reason: "size" | "duplicate" }>;
+ * }}
+ */
+export function filterIncomingFiles(incoming, options = {}) {
+  const {
+    maxFileSize,
+    preventDuplicate = false,
+    existingFiles = [],
+    carryRefs,
+  } = options;
+
+  /** @type {File[]} */
+  let accepted = [...incoming];
+  /** @type {Array<{ file: File; reason: "size" | "duplicate" }>} */
+  const rejected = [];
+
+  if (maxFileSize !== undefined) {
+    const oversized = accepted.filter((file) => file.size > maxFileSize);
+    accepted = accepted.filter((file) => file.size <= maxFileSize);
+    for (const file of oversized) {
+      rejected.push({ file, reason: "size" });
+    }
+  }
+
+  if (preventDuplicate) {
+    const existingKeys = new Set(existingFiles.map(fileIdentityKey));
+    function isDuplicate(file) {
+      return (
+        !(carryRefs?.has(file) ?? false) &&
+        existingKeys.has(fileIdentityKey(file))
+      );
+    }
+    const duplicates = accepted.filter(isDuplicate);
+    accepted = accepted.filter((file) => !isDuplicate(file));
+    for (const file of duplicates) {
+      rejected.push({ file, reason: "duplicate" });
+    }
+  }
+
+  return { accepted, rejected };
+}

--- a/tests/FileUploader/FileUploaderDropContainer.test.svelte
+++ b/tests/FileUploader/FileUploaderDropContainer.test.svelte
@@ -10,7 +10,11 @@
     | ((e: CustomEvent<ReadonlyArray<File>>) => void)
     | undefined = undefined;
   export let onrejected:
-    | ((e: CustomEvent<Array<{ file: File; reason: string }>>) => void)
+    | ((
+        e: CustomEvent<
+          Array<{ file: File; reason: "size" | "duplicate" | "invalid" }>
+        >,
+      ) => void)
     | undefined = undefined;
 </script>
 

--- a/tests/FileUploader/FileUploaderDropContainer.test.ts
+++ b/tests/FileUploader/FileUploaderDropContainer.test.ts
@@ -384,6 +384,133 @@ describe("FileUploaderDropContainer", () => {
     expect(event.detail[0].reason).toBe("invalid");
   });
 
+  it("should reject oversized files with reason size", async () => {
+    const rejectedHandler = vi.fn();
+    const changeHandler = vi.fn();
+    const { container } = render(FileUploaderDropContainer, {
+      props: {
+        multiple: true,
+        maxFileSize: 1000,
+        onrejected: rejectedHandler,
+        onchange: changeHandler,
+      },
+    });
+
+    const dropDiv = container.querySelector(".bx--file");
+    assert(dropDiv instanceof HTMLElement);
+
+    const smallFile = new File(["x".repeat(500)], "small.txt", {
+      type: "text/plain",
+    });
+    const largeFile = new File(["x".repeat(2000)], "large.txt", {
+      type: "text/plain",
+    });
+    dropDiv.dispatchEvent(createDragEvent("drop", [smallFile, largeFile]));
+
+    await vi.waitFor(() => {
+      expect(rejectedHandler).toHaveBeenCalled();
+      expect(changeHandler).toHaveBeenCalled();
+    });
+
+    expect(rejectedHandler.mock.calls[0][0].detail).toEqual([
+      { file: largeFile, reason: "size" },
+    ]);
+    expect(changeHandler.mock.calls[0][0].detail).toHaveLength(1);
+    expect(changeHandler.mock.calls[0][0].detail[0].name).toBe("small.txt");
+  });
+
+  it("should reject duplicate files with reason duplicate", async () => {
+    const existing = new File(["content"], "dup.txt", { type: "text/plain" });
+    Object.defineProperty(existing, "lastModified", { value: 100 });
+    const rejectedHandler = vi.fn();
+    const changeHandler = vi.fn();
+    const { container } = render(FileUploaderDropContainer, {
+      props: {
+        multiple: true,
+        preventDuplicate: true,
+        files: [existing],
+        onrejected: rejectedHandler,
+        onchange: changeHandler,
+      },
+    });
+
+    const dropDiv = container.querySelector(".bx--file");
+    assert(dropDiv instanceof HTMLElement);
+
+    const duplicate = new File(["content"], "dup.txt", { type: "text/plain" });
+    Object.defineProperty(duplicate, "lastModified", { value: 100 });
+    const unique = new File(["other"], "new.txt", { type: "text/plain" });
+    dropDiv.dispatchEvent(createDragEvent("drop", [duplicate, unique]));
+
+    await vi.waitFor(() => {
+      expect(rejectedHandler).toHaveBeenCalled();
+      expect(changeHandler).toHaveBeenCalled();
+    });
+
+    expect(rejectedHandler.mock.calls[0][0].detail).toEqual([
+      { file: duplicate, reason: "duplicate" },
+    ]);
+    const files = changeHandler.mock.calls[0][0].detail;
+    expect(files).toHaveLength(2);
+    expect(files.map((f: File) => f.name)).toEqual(["dup.txt", "new.txt"]);
+  });
+
+  it("should apply validateFiles after size and duplicate checks", async () => {
+    const existing = new File(["ok"], "kept.txt", { type: "text/plain" });
+    Object.defineProperty(existing, "lastModified", { value: 1 });
+    const validateFiles = vi.fn((files: File[]) =>
+      files.filter((f: File) => !f.name.startsWith("skip")),
+    );
+    const rejectedHandler = vi.fn();
+    const changeHandler = vi.fn();
+    const { container } = render(FileUploaderDropContainer, {
+      props: {
+        multiple: true,
+        maxFileSize: 1000,
+        preventDuplicate: true,
+        files: [existing],
+        validateFiles,
+        onrejected: rejectedHandler,
+        onchange: changeHandler,
+      },
+    });
+
+    const dropDiv = container.querySelector(".bx--file");
+    assert(dropDiv instanceof HTMLElement);
+
+    const oversized = new File(["x".repeat(2000)], "big.txt", {
+      type: "text/plain",
+    });
+    const duplicate = new File(["ok"], "kept.txt", { type: "text/plain" });
+    Object.defineProperty(duplicate, "lastModified", { value: 1 });
+    const skipped = new File(["x".repeat(10)], "skip-me.txt", {
+      type: "text/plain",
+    });
+    const ok = new File(["x".repeat(10)], "ok.txt", { type: "text/plain" });
+
+    dropDiv.dispatchEvent(
+      createDragEvent("drop", [oversized, duplicate, skipped, ok]),
+    );
+
+    await vi.waitFor(() => {
+      expect(rejectedHandler).toHaveBeenCalled();
+      expect(changeHandler).toHaveBeenCalled();
+    });
+
+    // validateFiles should only see files that passed size/duplicate
+    expect(validateFiles).toHaveBeenCalledWith([skipped, ok]);
+
+    const rejected = rejectedHandler.mock.calls[0][0].detail;
+    expect(rejected).toEqual([
+      { file: oversized, reason: "size" },
+      { file: duplicate, reason: "duplicate" },
+      { file: skipped, reason: "invalid" },
+    ]);
+    expect(
+      changeHandler.mock.calls[0][0].detail.map((f: File) => f.name),
+    ).toEqual(["kept.txt", "ok.txt"]);
+  });
+
   it("should handle file input change event", async () => {
     const changeHandler = vi.fn();
     const { container } = render(FileUploaderDropContainer, {

--- a/tests/utils/filterIncomingFiles.test.ts
+++ b/tests/utils/filterIncomingFiles.test.ts
@@ -1,0 +1,82 @@
+import {
+  fileIdentityKey,
+  filterIncomingFiles,
+} from "../../src/utils/filterIncomingFiles.js";
+
+function makeFile(name: string, size: number, lastModified = 1) {
+  const file = new File(["x".repeat(size)], name, { type: "text/plain" });
+  Object.defineProperty(file, "lastModified", { value: lastModified });
+  return file;
+}
+
+describe("fileIdentityKey", () => {
+  test("joins name, size, and lastModified", () => {
+    const file = makeFile("a.txt", 3, 42);
+    expect(fileIdentityKey(file)).toBe("a.txt\u00003\u000042");
+  });
+});
+
+describe("filterIncomingFiles", () => {
+  test("accepts all files when no options are set", () => {
+    const a = makeFile("a.txt", 10);
+    const b = makeFile("b.txt", 20);
+    const { accepted, rejected } = filterIncomingFiles([a, b]);
+    expect(accepted).toEqual([a, b]);
+    expect(rejected).toEqual([]);
+  });
+
+  test("rejects oversized files with reason size", () => {
+    const small = makeFile("small.txt", 500);
+    const large = makeFile("large.txt", 2000);
+    const { accepted, rejected } = filterIncomingFiles([small, large], {
+      maxFileSize: 1000,
+    });
+    expect(accepted).toEqual([small]);
+    expect(rejected).toEqual([{ file: large, reason: "size" }]);
+  });
+
+  test("accepts files at exactly maxFileSize", () => {
+    const exact = makeFile("exact.txt", 1000);
+    const { accepted, rejected } = filterIncomingFiles([exact], {
+      maxFileSize: 1000,
+    });
+    expect(accepted).toEqual([exact]);
+    expect(rejected).toEqual([]);
+  });
+
+  test("rejects duplicates against existing files", () => {
+    const existing = makeFile("dup.txt", 10, 5);
+    const duplicate = makeFile("dup.txt", 10, 5);
+    const unique = makeFile("new.txt", 10, 5);
+    const { accepted, rejected } = filterIncomingFiles([duplicate, unique], {
+      preventDuplicate: true,
+      existingFiles: [existing],
+    });
+    expect(accepted).toEqual([unique]);
+    expect(rejected).toEqual([{ file: duplicate, reason: "duplicate" }]);
+  });
+
+  test("does not reject same-reference files in carryRefs", () => {
+    const existing = makeFile("kept.txt", 10, 5);
+    const fresh = makeFile("kept.txt", 10, 5);
+    const { accepted, rejected } = filterIncomingFiles([existing, fresh], {
+      preventDuplicate: true,
+      existingFiles: [existing],
+      carryRefs: new Set([existing]),
+    });
+    expect(accepted).toEqual([existing]);
+    expect(rejected).toEqual([{ file: fresh, reason: "duplicate" }]);
+  });
+
+  test("applies size before duplicate", () => {
+    const existing = makeFile("big.txt", 2000, 1);
+    const oversizedDup = makeFile("big.txt", 2000, 1);
+    const { accepted, rejected } = filterIncomingFiles([oversizedDup], {
+      maxFileSize: 1000,
+      preventDuplicate: true,
+      existingFiles: [existing],
+    });
+    expect(accepted).toEqual([]);
+    expect(rejected).toEqual([{ file: oversizedDup, reason: "size" }]);
+  });
+});


### PR DESCRIPTION
DropContainer now rejects oversize and duplicate files the same way
FileUploader does, through a shared validation util.