### PR TITLE
feat(file-uploader): support paste-to-upload

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -219,6 +219,10 @@
               "level": "error",
               "options": {
                 "paths": {
+                  "svelte": {
+                    "importNames": ["onDestroy"],
+                    "message": "Use the return function from onMount instead of onDestroy."
+                  },
                   "carbon-components-svelte": {
                     "message": "Avoid the barrel import in tests; import directly (e.g. \"carbon-components-svelte/Button/Button.svelte\") to keep Vitest transforms fast."
                   },
@@ -240,6 +244,12 @@
             "noRestrictedImports": {
               "level": "error",
               "options": {
+                "paths": {
+                  "svelte": {
+                    "importNames": ["onDestroy"],
+                    "message": "Use the return function from onMount instead of onDestroy."
+                  }
+                },
                 "patterns": [
                   {
                     "group": ["carbon-icons-svelte", "carbon-icons-svelte/**"],

--- a/docs/src/pages/components/FileUploader.svx
+++ b/docs/src/pages/components/FileUploader.svx
@@ -181,6 +181,24 @@ file by name, size, and last modified. Rejected duplicates are reported via
 
 <FileSource src="/framed/FileUploader/FileUploaderPreventDuplicate" />
 
+## Paste uploads
+
+Set `pasteTarget` to `true` to accept screenshots and other clipboard files
+pasted anywhere on the page.
+
+Pasted files use the same size limit, duplicate detection, ordering, and
+`add` / `change` / `rejected` events as button selection. Paste is ignored when
+`disabled` is `true`.
+
+<FileSource src="/framed/FileUploader/FileUploaderPaste" />
+
+### Focused target
+
+Pass an `HTMLElement` to listen only when paste happens on that element (for
+example a bug-report form). Focus inside the form and paste a screenshot.
+
+<FileSource src="/framed/FileUploader/FileUploaderPasteFocusedTarget" />
+
 ## Disabled
 
 Disable the file uploader by setting `disabled` to `true`.

--- a/docs/src/pages/framed/FileUploader/FileUploaderPaste.svelte
+++ b/docs/src/pages/framed/FileUploader/FileUploaderPaste.svelte
@@ -1,0 +1,43 @@
+<script>
+  import {
+    FileUploader,
+    FileUploaderItem,
+    Stack,
+  } from "carbon-components-svelte";
+
+  let rejectedFiles = [];
+</script>
+
+<Stack gap={2}>
+  <FileUploader
+    multiple
+    pasteTarget
+    maxFileSize={5 * 1024 * 1024}
+    preventDuplicate
+    labelTitle="Bug report attachments"
+    buttonLabel="Add files"
+    labelDescription="Paste a screenshot or file anywhere on the page, or click Add files."
+    status="edit"
+    on:rejected={(e) => {
+      rejectedFiles = e.detail;
+    }}
+  />
+
+  {#each rejectedFiles as { file, reason }, i (`${file.name}-${file.lastModified}-${i}`)}
+    <FileUploaderItem
+      invalid
+      id={`rejected-paste-${i}`}
+      name={file.name}
+      errorSubject={reason === "size"
+        ? "File exceeds 5 MB limit"
+        : "Duplicate file"}
+      errorBody={reason === "size"
+        ? "Please select a smaller file."
+        : "This file is already in the list."}
+      status="edit"
+      on:delete={() => {
+        rejectedFiles = rejectedFiles.filter((r) => r.file !== file);
+      }}
+    />
+  {/each}
+</Stack>

--- a/docs/src/pages/framed/FileUploader/FileUploaderPasteFocusedTarget.svelte
+++ b/docs/src/pages/framed/FileUploader/FileUploaderPasteFocusedTarget.svelte
@@ -1,0 +1,56 @@
+<script>
+  import {
+    FileUploader,
+    FileUploaderItem,
+    Stack,
+    TextArea,
+    TextInput,
+  } from "carbon-components-svelte";
+
+  /** @type {HTMLFormElement | undefined} */
+  let form;
+
+  let rejectedFiles = [];
+</script>
+
+<form bind:this={form}>
+  <Stack gap={5}>
+    <TextInput labelText="Title" placeholder="Brief summary" />
+    <TextArea
+      labelText="Description"
+      placeholder="Describe the issue. Focus here and paste a screenshot to attach it."
+      rows={4}
+    />
+    <FileUploader
+      multiple
+      pasteTarget={form}
+      maxFileSize={5 * 1024 * 1024}
+      preventDuplicate
+      labelTitle="Attachments"
+      buttonLabel="Add files"
+      labelDescription="Paste a screenshot while focused in this form, or click Add files."
+      status="edit"
+      on:rejected={(e) => {
+        rejectedFiles = e.detail;
+      }}
+    />
+
+    {#each rejectedFiles as { file, reason }, i (`${file.name}-${file.lastModified}-${i}`)}
+      <FileUploaderItem
+        invalid
+        id={`rejected-paste-target-${i}`}
+        name={file.name}
+        errorSubject={reason === "size"
+          ? "File exceeds 5 MB limit"
+          : "Duplicate file"}
+        errorBody={reason === "size"
+          ? "Please select a smaller file."
+          : "This file is already in the list."}
+        status="edit"
+        on:delete={() => {
+          rejectedFiles = rejectedFiles.filter((r) => r.file !== file);
+        }}
+      />
+    {/each}
+  </Stack>
+</form>

--- a/src/FileUploader/FileUploader.svelte
+++ b/src/FileUploader/FileUploader.svelte
@@ -156,12 +156,22 @@
   export let name = "";
 
   /**
+   * Enable paste-to-upload for screenshots and clipboard files.
+   * When `true`, listens for `paste` on `document`. Pass an `HTMLElement`
+   * (for example a form) to listen on that element instead.
+   * Clipboard files use the same size, duplicate, ordering, `add`, `change`,
+   * and `rejected` path as button selection. No-op when `disabled`.
+   * @type {boolean | HTMLElement}
+   */
+  export let pasteTarget = false;
+
+  /**
    * Obtain a reference to the input HTML element.
    * @type {null | HTMLInputElement}
    */
   export let ref = null;
 
-  import { createEventDispatcher, tick } from "svelte";
+  import { createEventDispatcher, onMount, tick } from "svelte";
   import { filterIncomingFiles } from "../utils/filterIncomingFiles.js";
   import Filename from "./Filename.svelte";
   import FileUploaderButton from "./FileUploaderButton.svelte";
@@ -169,6 +179,85 @@
   const dispatch = createEventDispatcher();
 
   let prevFiles = [];
+
+  /** @type {EventTarget | null} */
+  let pasteListenNode = null;
+
+  /**
+   * Shared path for files from button selection and paste: filters by size
+   * and duplicates, orders, and dispatches `change`/`rejected`.
+   * @param {ReadonlyArray<File>} newFiles
+   */
+  function processIncomingFiles(newFiles) {
+    const existingRefs = new Set(prevFiles);
+    const { accepted, rejected: allRejected } = filterIncomingFiles(newFiles, {
+      maxFileSize,
+      preventDuplicate,
+      existingFiles: prevFiles,
+      carryRefs: existingRefs,
+    });
+
+    if (allRejected.length > 0) {
+      dispatch("rejected", allRejected);
+    }
+
+    const carried = accepted.filter((f) => existingRefs.has(f));
+    const added = accepted.filter((f) => !existingRefs.has(f));
+
+    if (typeof orderFiles === "function") {
+      files = orderFiles(carried, added);
+    } else if (orderFiles === "prepend") {
+      files = [...added, ...carried];
+    } else {
+      files = [...carried, ...added];
+    }
+
+    dispatch("change", files);
+  }
+
+  /** @param {ClipboardEvent} event */
+  function handlePaste(event) {
+    if (disabled) return;
+    const clipboardFiles = event.clipboardData?.files;
+    if (!clipboardFiles?.length) return;
+
+    event.preventDefault();
+    const incoming = [...clipboardFiles];
+    processIncomingFiles(multiple ? [...files, ...incoming] : incoming);
+  }
+
+  /** @param {boolean | HTMLElement} target */
+  function setPasteListener(target) {
+    /** @type {EventTarget | null} */
+    const next =
+      target === true
+        ? typeof document === "undefined"
+          ? null
+          : document
+        : typeof HTMLElement !== "undefined" && target instanceof HTMLElement
+          ? target
+          : null;
+
+    if (pasteListenNode === next) return;
+
+    if (pasteListenNode !== null) {
+      pasteListenNode.removeEventListener("paste", handlePaste);
+    }
+
+    pasteListenNode = next;
+
+    if (pasteListenNode !== null) {
+      pasteListenNode.addEventListener("paste", handlePaste);
+    }
+  }
+
+  $: setPasteListener(pasteTarget);
+
+  onMount(() => {
+    return () => {
+      setPasteListener(false);
+    };
+  });
 
   // Per-file stable id: assigned once on first sight and carried with the
   // File reference, so reorders and removals don't shift other files' ids.
@@ -301,36 +390,7 @@
     bind:ref
     bind:files
     on:change={(event) => {
-      // In multiple mode, newFiles includes re-sent existing files
-      // (same reference) plus newly selected ones. Only reject new
-      // objects that match an existing file by content.
-      const existingRefs = new Set(prevFiles);
-      const { accepted: newFiles, rejected: allRejected } = filterIncomingFiles(
-        event.detail,
-        {
-          maxFileSize,
-          preventDuplicate,
-          existingFiles: prevFiles,
-          carryRefs: existingRefs,
-        },
-      );
-
-      if (allRejected.length > 0) {
-        dispatch("rejected", allRejected);
-      }
-
-      const carried = newFiles.filter((f) => existingRefs.has(f));
-      const added = newFiles.filter((f) => !existingRefs.has(f));
-
-      if (typeof orderFiles === "function") {
-        files = orderFiles(carried, added);
-      } else if (orderFiles === "prepend") {
-        files = [...added, ...carried];
-      } else {
-        files = [...carried, ...added];
-      }
-
-      dispatch("change", files);
+      processIncomingFiles(event.detail);
     }}
   />
   <div class:bx--file-container={true}>

--- a/tests/FileUploader/FileUploader.test.svelte
+++ b/tests/FileUploader/FileUploader.test.svelte
@@ -45,6 +45,7 @@
     undefined;
   export let fileErrorBody: ComponentProps<FileUploader>["fileErrorBody"] =
     undefined;
+  export let pasteTarget: ComponentProps<FileUploader>["pasteTarget"] = false;
 </script>
 
 <form data-testid="file-form">
@@ -66,6 +67,7 @@
     {fileInvalid}
     {fileErrorSubject}
     {fileErrorBody}
+    {pasteTarget}
     bind:ref
     bind:files
     on:add={(e) => onAdd?.(e)}

--- a/tests/FileUploader/FileUploader.test.ts
+++ b/tests/FileUploader/FileUploader.test.ts
@@ -26,6 +26,20 @@ describe("FileUploader", () => {
     input.dispatchEvent(new Event("change", { bubbles: true }));
   }
 
+  function simulatePaste(target: EventTarget, files: File[]) {
+    const dataTransfer = new DataTransfer();
+    for (const file of files) {
+      dataTransfer.items.add(file);
+    }
+
+    const event = new Event("paste", { bubbles: true, cancelable: true });
+    Object.defineProperty(event, "clipboardData", {
+      value: dataTransfer,
+      configurable: true,
+    });
+    target.dispatchEvent(event);
+  }
+
   // Regression test for https://github.com/carbon-design-system/carbon-components-svelte/issues/1785
   it("should synchronize input.files when files are removed programmatically", async () => {
     const { component } = render(FileUploader);
@@ -1259,5 +1273,126 @@ describe("FileUploader", () => {
     expect(screen.getByText("Upload failed")).toBeInTheDocument();
     expect(screen.getByText("Please try again.")).toBeInTheDocument();
     expect(rows[1].querySelector(".bx--file-invalid")).toBeInTheDocument();
+  });
+
+  it("should add pasted files when pasteTarget is true", async () => {
+    const addHandler = vi.fn();
+    render(FileUploader, {
+      props: { pasteTarget: true, multiple: true, onAdd: addHandler },
+    });
+
+    const pasted = new File(["screenshot"], "paste.png", { type: "image/png" });
+    simulatePaste(document, [pasted]);
+
+    await vi.waitFor(() => {
+      expect(screen.queryByText("paste.png")).toBeInTheDocument();
+      expect(addHandler).toHaveBeenCalled();
+    });
+
+    expect(addHandler.mock.calls[0][0].detail[0].name).toBe("paste.png");
+  });
+
+  it("should reject oversized pasted files", async () => {
+    const rejectedHandler = vi.fn();
+    render(FileUploader, {
+      props: {
+        pasteTarget: true,
+        maxFileSize: 1000,
+        onRejected: rejectedHandler,
+      },
+    });
+
+    const largeFile = new File(["x".repeat(2000)], "large-paste.txt", {
+      type: "text/plain",
+    });
+    simulatePaste(document, [largeFile]);
+
+    await vi.waitFor(() => {
+      expect(rejectedHandler).toHaveBeenCalled();
+    });
+
+    expect(screen.queryByText("large-paste.txt")).not.toBeInTheDocument();
+    expect(rejectedHandler.mock.calls[0][0].detail[0].reason).toBe("size");
+  });
+
+  it("should reject duplicate pasted files when preventDuplicate is true", async () => {
+    const rejectedHandler = vi.fn();
+    const { component } = render(FileUploader, {
+      props: {
+        pasteTarget: true,
+        preventDuplicate: true,
+        multiple: true,
+        onRejected: rejectedHandler,
+      },
+    });
+
+    const file1 = new File(["content1"], "file1.txt", {
+      type: "text/plain",
+      lastModified: 1000,
+    });
+    assert(component.ref instanceof HTMLInputElement);
+    simulateFileSelection(component.ref, [file1]);
+
+    await vi.waitFor(() => {
+      expect(screen.queryByText("file1.txt")).toBeInTheDocument();
+    });
+
+    const duplicate = new File(["content1"], "file1.txt", {
+      type: "text/plain",
+      lastModified: 1000,
+    });
+    simulatePaste(document, [duplicate]);
+
+    await vi.waitFor(() => {
+      expect(rejectedHandler).toHaveBeenCalled();
+    });
+
+    expect(rejectedHandler.mock.calls[0][0].detail[0].reason).toBe("duplicate");
+    expect(screen.queryAllByText("file1.txt")).toHaveLength(1);
+  });
+
+  it("should ignore paste when disabled", async () => {
+    const addHandler = vi.fn();
+    render(FileUploader, {
+      props: {
+        pasteTarget: true,
+        disabled: true,
+        onAdd: addHandler,
+      },
+    });
+
+    const pasted = new File(["screenshot"], "paste.png", { type: "image/png" });
+    simulatePaste(document, [pasted]);
+
+    await vi.waitFor(() => {
+      expect(screen.queryByText("paste.png")).not.toBeInTheDocument();
+    });
+
+    expect(addHandler).not.toHaveBeenCalled();
+  });
+
+  it("should listen for paste on a custom pasteTarget element", async () => {
+    const form = document.createElement("form");
+    document.body.appendChild(form);
+
+    try {
+      render(FileUploader, {
+        props: { pasteTarget: form, multiple: true },
+      });
+
+      const pasted = new File(["shot"], "custom-target.png", {
+        type: "image/png",
+      });
+      simulatePaste(document, [pasted]);
+      expect(screen.queryByText("custom-target.png")).not.toBeInTheDocument();
+
+      simulatePaste(form, [pasted]);
+
+      await vi.waitFor(() => {
+        expect(screen.queryByText("custom-target.png")).toBeInTheDocument();
+      });
+    } finally {
+      form.remove();
+    }
   });
 });


### PR DESCRIPTION
Optional pasteTarget (document or an element) feeds clipboard files
through the same validation and add/rejected path as button selection.