### PR TITLE
feat(list-box): add direction auto placement

### DIFF
--- a/docs/src/pages/components/ComboBox.svx
+++ b/docs/src/pages/components/ComboBox.svx
@@ -339,6 +339,8 @@ Set `portalMenu` to `true` to render the dropdown menu in a floating portal. Thi
 
 When inside a [Modal](/components/Modal#modal-with-dropdowns), `portalMenu` defaults to `true` unless explicitly set to `false`.
 
+Set `direction` to `"auto"` to prefer opening below the field and flip above when the menu would clip the viewport. With `"auto"`, `portalMenu` also defaults to `true` so placement uses FloatingPortal measurement. Explicit `"top"` and `"bottom"` keep a fixed preferred side.
+
 <FileSource src="/framed/ComboBox/ComboBoxPortalMenu" />
 
 ## Light

--- a/docs/src/pages/components/Dropdown.svx
+++ b/docs/src/pages/components/Dropdown.svx
@@ -361,6 +361,8 @@ Set `portalMenu` to `true` to render the dropdown menu in a floating portal. Thi
 
 When inside a [Modal](/components/Modal#modal-with-dropdowns), `portalMenu` defaults to `true` unless explicitly set to `false`.
 
+Set `direction` to `"auto"` to prefer opening below the field and flip above when the menu would clip the viewport. With `"auto"`, `portalMenu` also defaults to `true` so placement uses FloatingPortal measurement (same flip behavior as other portalled menus). Explicit `"top"` and `"bottom"` keep a fixed preferred side.
+
 <FileSource src="/framed/Dropdown/DropdownPortalMenu" />
 
 ## Skeleton

--- a/docs/src/pages/components/MultiSelect.svx
+++ b/docs/src/pages/components/MultiSelect.svx
@@ -397,6 +397,8 @@ Set `portalMenu` to `true` to render the dropdown menu in a floating portal. Thi
 
 When inside a [Modal](/components/Modal#modal-with-dropdowns), portalMenu defaults to true unless explicitly set to false.
 
+Set `direction` to `"auto"` to prefer opening below the field and flip above when the menu would clip the viewport. With `"auto"`, `portalMenu` also defaults to `true` so placement uses FloatingPortal measurement. Explicit `"top"` and `"bottom"` keep a fixed preferred side.
+
 <FileSource src="/framed/MultiSelect/MultiSelectPortalMenu" />
 
 ## States

--- a/src/ComboBox/ComboBox.svelte
+++ b/src/ComboBox/ComboBox.svelte
@@ -58,7 +58,10 @@
 
   /**
    * Specify the direction of the combobox dropdown menu.
-   * @type {"bottom" | "top"}
+   * `"auto"` prefers bottom and flips when the menu would clip the viewport.
+   * Pair with `portalMenu` (or leave `portalMenu` unset) so placement uses
+   * FloatingPortal measurement.
+   * @type {"bottom" | "top" | "auto"}
    */
   export let direction = "bottom";
 
@@ -228,7 +231,8 @@
   /**
    * Set to `true` to render the dropdown menu in a portal,
    * allowing it to escape containers with `overflow: hidden`.
-   * When inside a Modal, defaults to `true` unless explicitly set to `false`.
+   * When inside a Modal or when `direction` is `"auto"`, defaults to `true`
+   * unless explicitly set to `false`.
    * @type {boolean | undefined}
    */
   export let portalMenu = undefined;
@@ -250,6 +254,7 @@
   import { isOutsideClick } from "../utils/isOutsideClick.js";
   import { createScrollEndTracker } from "../utils/isScrollNearEnd.js";
   import { moveIndex } from "../utils/moveIndex.js";
+  import { resolveListBoxDirection } from "../utils/resolveListBoxDirection.js";
   import {
     resetVirtualScrollOnClose,
     scrollHighlightedIntoView,
@@ -263,7 +268,9 @@
   const formContext = getContext("carbon:Form");
 
   $: effectivePortalMenu =
-    portalMenu === undefined ? !!insideModal : portalMenu;
+    portalMenu === undefined
+      ? direction === "auto" || !!insideModal
+      : portalMenu;
 
   let fieldFocused = false;
   let selectedItem = undefined;
@@ -278,6 +285,52 @@
 
   /** @type {null | HTMLDivElement} */
   let fieldRef = null;
+
+  /** @type {"bottom" | "top"} */
+  let autoDirection = "bottom";
+  let autoDirectionLocked = false;
+
+  $: if (!open || direction !== "auto") {
+    const nextDirection = direction === "top" ? "top" : "bottom";
+    if (autoDirection !== nextDirection) {
+      autoDirection = nextDirection;
+    }
+    if (autoDirectionLocked) {
+      autoDirectionLocked = false;
+    }
+  }
+
+  $: menuDirection =
+    direction === "auto"
+      ? autoDirection
+      : direction === "top"
+        ? "top"
+        : "bottom";
+
+  $: if (
+    open &&
+    direction === "auto" &&
+    !effectivePortalMenu &&
+    fieldRef &&
+    listRef &&
+    !autoDirectionLocked
+  ) {
+    tick().then(() => {
+      if (!open || !fieldRef || !listRef || autoDirectionLocked) return;
+      const nextDirection = resolveListBoxDirection("auto", {
+        anchorRect: fieldRef.getBoundingClientRect(),
+        floatingRect: listRef.getBoundingClientRect(),
+        viewport: {
+          innerWidth: window.innerWidth,
+          innerHeight: window.innerHeight,
+        },
+      });
+      if (autoDirection !== nextDirection) {
+        autoDirection = nextDirection;
+      }
+      autoDirectionLocked = true;
+    });
+  }
 
   /**
    * @returns {boolean}
@@ -571,7 +624,7 @@
 
   $: comboBoxListBoxClass = [
     "bx--combo-box",
-    direction === "top" && "bx--list-box--up",
+    menuDirection === "top" && "bx--list-box--up",
     showWarn && "bx--combo-box--warning",
     readonly && "bx--combo-box--readonly",
   ]

--- a/src/Dropdown/Dropdown.svelte
+++ b/src/Dropdown/Dropdown.svelte
@@ -58,7 +58,10 @@
 
   /**
    * Specify the direction of the dropdown menu.
-   * @type {"bottom" | "top"}
+   * `"auto"` prefers bottom and flips when the menu would clip the viewport.
+   * Pair with `portalMenu` (or leave `portalMenu` unset) so placement uses
+   * FloatingPortal measurement.
+   * @type {"bottom" | "top" | "auto"}
    */
   export let direction = "bottom";
 
@@ -167,7 +170,8 @@
   /**
    * Set to `true` to render the dropdown menu in a portal,
    * allowing it to escape containers with `overflow: hidden`.
-   * When inside a Modal, defaults to `true` unless explicitly set to `false`.
+   * When inside a Modal or when `direction` is `"auto"`, defaults to `true`
+   * unless explicitly set to `false`.
    * @type {boolean | undefined}
    */
   export let portalMenu = undefined;
@@ -220,6 +224,7 @@
   import { isOutsideClick } from "../utils/isOutsideClick.js";
   import { createScrollEndTracker } from "../utils/isScrollNearEnd.js";
   import { moveIndex } from "../utils/moveIndex.js";
+  import { resolveListBoxDirection } from "../utils/resolveListBoxDirection.js";
   import { typeaheadIndex } from "../utils/typeahead.js";
   import {
     resetVirtualScrollOnClose,
@@ -234,7 +239,55 @@
   const formContext = getContext("carbon:Form");
 
   $: effectivePortalMenu =
-    portalMenu === undefined ? !!insideModal : portalMenu;
+    portalMenu === undefined
+      ? direction === "auto" || !!insideModal
+      : portalMenu;
+
+  /** @type {"bottom" | "top"} */
+  let autoDirection = "bottom";
+  let autoDirectionLocked = false;
+
+  $: if (!open || direction !== "auto") {
+    const nextDirection = direction === "top" ? "top" : "bottom";
+    if (autoDirection !== nextDirection) {
+      autoDirection = nextDirection;
+    }
+    if (autoDirectionLocked) {
+      autoDirectionLocked = false;
+    }
+  }
+
+  $: menuDirection =
+    direction === "auto"
+      ? autoDirection
+      : direction === "top"
+        ? "top"
+        : "bottom";
+
+  $: if (
+    open &&
+    direction === "auto" &&
+    !effectivePortalMenu &&
+    ref &&
+    listRef &&
+    !autoDirectionLocked
+  ) {
+    tick().then(() => {
+      if (!open || !ref || !listRef || autoDirectionLocked) return;
+      const nextDirection = resolveListBoxDirection("auto", {
+        anchorRect: ref.getBoundingClientRect(),
+        floatingRect: listRef.getBoundingClientRect(),
+        viewport: {
+          innerWidth: window.innerWidth,
+          innerHeight: window.innerHeight,
+        },
+      });
+      if (autoDirection !== nextDirection) {
+        autoDirection = nextDirection;
+      }
+      autoDirectionLocked = true;
+    });
+  }
 
   $: menuAriaLabel = $$props["aria-label"] ?? (labelText || "Choose an item");
 
@@ -505,7 +558,7 @@
 
   $: dropdownListBoxClass = [
     "bx--dropdown",
-    direction === "top" && "bx--list-box--up",
+    menuDirection === "top" && "bx--list-box--up",
     showInvalid && "bx--dropdown--invalid",
     showWarn && "bx--dropdown--warning",
     open && "bx--dropdown--open",

--- a/src/ListBox/ListBoxMenu.svelte
+++ b/src/ListBox/ListBoxMenu.svelte
@@ -31,8 +31,10 @@
 
   /**
    * Specify the direction of the menu.
+   * `"auto"` prefers bottom and flips when the menu would clip the viewport
+   * (via FloatingPortal when `portal` is `true`).
    * Only used when `portal` is `true`.
-   * @type {"bottom" | "top"}
+   * @type {"bottom" | "top" | "auto"}
    */
   export let direction = "bottom";
 
@@ -44,10 +46,18 @@
   export let portalHostClass = undefined;
 
   import FloatingPortal from "../Portal/FloatingPortal.svelte";
+
+  $: preferredDirection = direction === "auto" ? "bottom" : direction;
+  $: lockDirection = direction === "auto" ? "always" : "none";
 </script>
 
 {#if portal}
-  <FloatingPortal {anchor} {direction} {open}>
+  <FloatingPortal
+    {anchor}
+    direction={preferredDirection}
+    {lockDirection}
+    {open}
+  >
     <div class={portalHostClass}>
       <div
         bind:this={ref}

--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -67,7 +67,10 @@
 
   /**
    * Specify the direction of the multiselect dropdown menu.
-   * @type {"bottom" | "top"}
+   * `"auto"` prefers bottom and flips when the menu would clip the viewport.
+   * Pair with `portalMenu` (or leave `portalMenu` unset) so placement uses
+   * FloatingPortal measurement.
+   * @type {"bottom" | "top" | "auto"}
    */
   export let direction = "bottom";
 
@@ -266,7 +269,8 @@
   /**
    * Set to `true` to render the dropdown menu in a portal,
    * allowing it to escape containers with `overflow: hidden`.
-   * When inside a Modal, defaults to `true` unless explicitly set to `false`.
+   * When inside a Modal or when `direction` is `"auto"`, defaults to `true`
+   * unless explicitly set to `false`.
    * @type {boolean | undefined}
    */
   export let portalMenu = undefined;
@@ -304,6 +308,7 @@
   import { isOutsideClick } from "../utils/isOutsideClick.js";
   import { createScrollEndTracker } from "../utils/isScrollNearEnd.js";
   import { moveIndex } from "../utils/moveIndex.js";
+  import { resolveListBoxDirection } from "../utils/resolveListBoxDirection.js";
   import {
     resetVirtualScrollOnClose,
     scrollHighlightedIntoView,
@@ -317,7 +322,55 @@
   const insideModal = getContext("carbon:Modal");
 
   $: effectivePortalMenu =
-    portalMenu === undefined ? !!insideModal : portalMenu;
+    portalMenu === undefined
+      ? direction === "auto" || !!insideModal
+      : portalMenu;
+
+  /** @type {"bottom" | "top"} */
+  let autoDirection = "bottom";
+  let autoDirectionLocked = false;
+
+  $: if (!open || direction !== "auto") {
+    const nextDirection = direction === "top" ? "top" : "bottom";
+    if (autoDirection !== nextDirection) {
+      autoDirection = nextDirection;
+    }
+    if (autoDirectionLocked) {
+      autoDirectionLocked = false;
+    }
+  }
+
+  $: menuDirection =
+    direction === "auto"
+      ? autoDirection
+      : direction === "top"
+        ? "top"
+        : "bottom";
+
+  $: if (
+    open &&
+    direction === "auto" &&
+    !effectivePortalMenu &&
+    fieldRef &&
+    listRef &&
+    !autoDirectionLocked
+  ) {
+    tick().then(() => {
+      if (!open || !fieldRef || !listRef || autoDirectionLocked) return;
+      const nextDirection = resolveListBoxDirection("auto", {
+        anchorRect: fieldRef.getBoundingClientRect(),
+        floatingRect: listRef.getBoundingClientRect(),
+        viewport: {
+          innerWidth: window.innerWidth,
+          innerHeight: window.innerHeight,
+        },
+      });
+      if (autoDirection !== nextDirection) {
+        autoDirection = nextDirection;
+      }
+      autoDirectionLocked = true;
+    });
+  }
 
   let fieldFocused = false;
   let highlightedIndex = -1;
@@ -768,7 +821,7 @@
 
   $: multiSelectListBoxClass = [
     "bx--multi-select",
-    direction === "top" && "bx--list-box--up",
+    menuDirection === "top" && "bx--list-box--up",
     filterable && "bx--combo-box",
     filterable && "bx--multi-select--filterable",
     showInvalid && "bx--multi-select--invalid",

--- a/src/utils/resolveListBoxDirection.d.ts
+++ b/src/utils/resolveListBoxDirection.d.ts
@@ -1,0 +1,23 @@
+import type { RectLike } from "./floatingPosition.js";
+
+export type ListBoxDirection = "bottom" | "top" | "auto";
+
+export interface ResolveListBoxDirectionGeometry {
+  anchorRect: RectLike;
+  floatingRect: RectLike;
+  viewport: {
+    innerWidth: number;
+    innerHeight: number;
+    scrollX?: number;
+    scrollY?: number;
+  };
+}
+
+/**
+ * Resolve a list-box menu direction. `"auto"` prefers `"bottom"` and flips
+ * to `"top"` when the menu would clip the viewport.
+ */
+export function resolveListBoxDirection(
+  direction: ListBoxDirection,
+  geometry?: ResolveListBoxDirectionGeometry,
+): "bottom" | "top";

--- a/src/utils/resolveListBoxDirection.js
+++ b/src/utils/resolveListBoxDirection.js
@@ -1,0 +1,43 @@
+// @ts-check
+
+import { floatingPosition } from "./floatingPosition.js";
+
+/**
+ * @typedef {import("./floatingPosition.js").RectLike} RectLike
+ */
+
+/**
+ * Resolve a list-box menu direction. `"auto"` prefers `"bottom"` and flips
+ * to `"top"` when the menu would clip the viewport (same rules as
+ * {@link floatingPosition}).
+ *
+ * @param {"bottom" | "top" | "auto"} direction
+ * @param {Object} [geometry] - Required to evaluate `"auto"` against the viewport.
+ * @param {RectLike} geometry.anchorRect
+ * @param {RectLike} geometry.floatingRect
+ * @param {{ innerWidth: number, innerHeight: number, scrollX?: number, scrollY?: number }} geometry.viewport
+ * @returns {"bottom" | "top"}
+ */
+export function resolveListBoxDirection(direction, geometry) {
+  if (direction === "top" || direction === "bottom") {
+    return direction;
+  }
+
+  if (!geometry) {
+    return "bottom";
+  }
+
+  const { actualDirection } = floatingPosition({
+    anchorRect: geometry.anchorRect,
+    floatingRect: geometry.floatingRect,
+    viewport: {
+      innerWidth: geometry.viewport.innerWidth,
+      innerHeight: geometry.viewport.innerHeight,
+      scrollX: geometry.viewport.scrollX ?? 0,
+      scrollY: geometry.viewport.scrollY ?? 0,
+    },
+    direction: "bottom",
+  });
+
+  return actualDirection === "top" ? "top" : "bottom";
+}

--- a/tests/ComboBox/ComboBox.test.svelte
+++ b/tests/ComboBox/ComboBox.test.svelte
@@ -42,7 +42,7 @@
   export let typeahead = false;
   export let autoHighlight: ComponentProps<ComboBox>["autoHighlight"] = "none";
   export let virtualize: ComponentProps<ComboBox>["virtualize"] = undefined;
-  export let portalMenu: ComponentProps<ComboBox>["portalMenu"] = false;
+  export let portalMenu: ComponentProps<ComboBox>["portalMenu"] = undefined;
   export let ariaLabel: ComponentProps<ComboBox>["aria-label"] = undefined;
   export let fluid: ComponentProps<ComboBox>["fluid"] = false;
   export let condensed: ComponentProps<ComboBox>["condensed"] = false;

--- a/tests/Dropdown/Dropdown.test.svelte
+++ b/tests/Dropdown/Dropdown.test.svelte
@@ -31,7 +31,7 @@
   export let name: ComponentProps<Dropdown>["name"] = undefined;
   export let ref: ComponentProps<Dropdown>["ref"] = null;
   export let virtualize: ComponentProps<Dropdown>["virtualize"] = undefined;
-  export let portalMenu: ComponentProps<Dropdown>["portalMenu"] = false;
+  export let portalMenu: ComponentProps<Dropdown>["portalMenu"] = undefined;
   export let onselect: ((event: CustomEvent) => void) | undefined = undefined;
 </script>
 

--- a/tests/Dropdown/Dropdown.test.ts
+++ b/tests/Dropdown/Dropdown.test.ts
@@ -708,6 +708,94 @@ describe("Dropdown", () => {
     expect(dropdown).toHaveClass("bx--list-box--up");
   });
 
+  describe('direction="auto"', () => {
+    afterEach(() => {
+      const existingPortals = document.querySelectorAll(
+        "[data-floating-portal]",
+      );
+      for (const portal of existingPortals) {
+        portal.remove();
+      }
+    });
+
+    it("should portal the menu by default", () => {
+      render(Dropdown, {
+        props: {
+          items,
+          selectedId: "0",
+          direction: "auto",
+          open: true,
+        },
+      });
+
+      const menu = screen.getByRole("listbox");
+      const floatingPortal = menu.closest("[data-floating-portal]");
+      expect(floatingPortal).toBeInTheDocument();
+      expect(floatingPortal).toHaveAttribute(
+        "data-floating-direction",
+        "bottom",
+      );
+    });
+
+    it("should flip when the menu would clip the viewport", async () => {
+      const original = Element.prototype.getBoundingClientRect;
+      Element.prototype.getBoundingClientRect = function () {
+        if (this.hasAttribute?.("data-floating-portal")) {
+          return {
+            x: 0,
+            y: 0,
+            width: 150,
+            height: 200,
+            top: 0,
+            right: 150,
+            bottom: 200,
+            left: 0,
+            toJSON() {
+              return this;
+            },
+          } as DOMRect;
+        }
+        if (this.classList?.contains("bx--list-box__field")) {
+          return {
+            x: 100,
+            y: 750,
+            width: 150,
+            height: 40,
+            top: 750,
+            right: 250,
+            bottom: 790,
+            left: 100,
+            toJSON() {
+              return this;
+            },
+          } as DOMRect;
+        }
+        return original.call(this);
+      };
+
+      try {
+        render(Dropdown, {
+          props: {
+            items,
+            selectedId: "0",
+            direction: "auto",
+            open: true,
+          },
+        });
+
+        const menu = screen.getByRole("listbox");
+        await tick();
+        const floatingPortal = menu.closest("[data-floating-portal]");
+        expect(floatingPortal).toHaveAttribute(
+          "data-floating-direction",
+          "top",
+        );
+      } finally {
+        Element.prototype.getBoundingClientRect = original;
+      }
+    });
+  });
+
   it("should select nothing when all items are disabled", async () => {
     const allDisabledItems = [
       { id: "0", text: "Slack", disabled: true },

--- a/tests/ListBox/ListBoxMenu.test.ts
+++ b/tests/ListBox/ListBoxMenu.test.ts
@@ -155,6 +155,64 @@ describe("ListBoxMenu", () => {
       expect(floatingPortal).toHaveAttribute("data-floating-direction", "top");
     });
 
+    it('should prefer bottom and flip when direction is "auto"', async () => {
+      const original = Element.prototype.getBoundingClientRect;
+      Element.prototype.getBoundingClientRect = function () {
+        if (this.hasAttribute?.("data-floating-portal")) {
+          return {
+            x: 0,
+            y: 0,
+            width: 150,
+            height: 200,
+            top: 0,
+            right: 150,
+            bottom: 200,
+            left: 0,
+            toJSON() {
+              return this;
+            },
+          } as DOMRect;
+        }
+        if (this.getAttribute?.("data-testid") === "anchor") {
+          return {
+            x: 100,
+            y: 750,
+            width: 150,
+            height: 40,
+            top: 750,
+            right: 250,
+            bottom: 790,
+            left: 100,
+            toJSON() {
+              return this;
+            },
+          } as DOMRect;
+        }
+        return original.call(this);
+      };
+
+      try {
+        render(ListBoxMenu, {
+          props: {
+            slotContent: "Auto direction menu",
+            portal: true,
+            open: true,
+            direction: "auto",
+          },
+        });
+
+        const menu = await screen.findByText("Auto direction menu");
+        await tick();
+        const floatingPortal = menu.closest("[data-floating-portal]");
+        expect(floatingPortal).toHaveAttribute(
+          "data-floating-direction",
+          "top",
+        );
+      } finally {
+        Element.prototype.getBoundingClientRect = original;
+      }
+    });
+
     it("should expose ref when portal is true", async () => {
       const { component } = render(ListBoxMenu, {
         props: { slotContent: "Portal ref menu", portal: true, open: true },

--- a/tests/MultiSelect/MultiSelect.test.svelte
+++ b/tests/MultiSelect/MultiSelect.test.svelte
@@ -35,7 +35,7 @@
     undefined;
   export let helperText: ComponentProps<MultiSelect>["helperText"] = "";
   export let virtualize: ComponentProps<MultiSelect>["virtualize"] = undefined;
-  export let portalMenu: ComponentProps<MultiSelect>["portalMenu"] = false;
+  export let portalMenu: ComponentProps<MultiSelect>["portalMenu"] = undefined;
   export let sortItem: ComponentProps<MultiSelect>["sortItem"] = undefined;
   export let open: ComponentProps<MultiSelect>["open"] = undefined;
   export let ariaLabel: ComponentProps<MultiSelect>["aria-label"] = undefined;

--- a/tests/utils/resolveListBoxDirection.test.ts
+++ b/tests/utils/resolveListBoxDirection.test.ts
@@ -1,0 +1,50 @@
+import type { RectLike } from "../../src/utils/floatingPosition.js";
+import { resolveListBoxDirection } from "../../src/utils/resolveListBoxDirection.js";
+
+/** Build a RectLike from x/y/width/height (right/bottom derived). */
+function rect(x: number, y: number, width: number, height: number): RectLike {
+  return {
+    left: x,
+    top: y,
+    right: x + width,
+    bottom: y + height,
+    width,
+    height,
+  };
+}
+
+const viewport = {
+  innerWidth: 1000,
+  innerHeight: 800,
+};
+
+describe("resolveListBoxDirection", () => {
+  test("returns explicit bottom and top unchanged", () => {
+    expect(resolveListBoxDirection("bottom")).toBe("bottom");
+    expect(resolveListBoxDirection("top")).toBe("top");
+  });
+
+  test('defaults "auto" to bottom without geometry', () => {
+    expect(resolveListBoxDirection("auto")).toBe("bottom");
+  });
+
+  test('keeps "auto" as bottom when there is room below', () => {
+    expect(
+      resolveListBoxDirection("auto", {
+        anchorRect: rect(100, 200, 150, 40),
+        floatingRect: rect(0, 0, 150, 60),
+        viewport,
+      }),
+    ).toBe("bottom");
+  });
+
+  test('flips "auto" to top when the menu would clip below', () => {
+    expect(
+      resolveListBoxDirection("auto", {
+        anchorRect: rect(100, 750, 150, 40),
+        floatingRect: rect(0, 0, 150, 200),
+        viewport,
+      }),
+    ).toBe("top");
+  });
+});


### PR DESCRIPTION
direction="auto" on Dropdown, ComboBox, and MultiSelect prefers bottom
and flips via FloatingPortal when space is tight; unset portalMenu
enables the portal for auto.