### PR TITLE
feat(dropdown): add empty menu slot

### DIFF
--- a/css/_list-box-menu-item.scss
+++ b/css/_list-box-menu-item.scss
@@ -39,3 +39,27 @@
 @include exports('list-box-menu-item-icon') {
   @include list-box-menu-item-icon;
 }
+
+/// Non-interactive empty / loading row for Dropdown, ComboBox, and MultiSelect menus.
+/// @access private
+/// @group components
+@mixin list-box-menu-item-empty {
+  .#{$prefix}--list-box__menu-item--empty {
+    color: $text-02;
+    cursor: default;
+    pointer-events: none;
+
+    &:hover {
+      background-color: transparent;
+    }
+
+    .#{$prefix}--list-box__menu-item__option {
+      color: inherit;
+      border-top-color: transparent;
+    }
+  }
+}
+
+@include exports("list-box-menu-item-empty") {
+  @include list-box-menu-item-empty;
+}

--- a/docs/src/pages/components/Dropdown.svx
+++ b/docs/src/pages/components/Dropdown.svx
@@ -149,6 +149,14 @@ By default, item height matches the menu row for each size: 24px (`xs`), 32px (`
 
 <FileSource src="/framed/Dropdown/VirtualizeItemHeight" />
 
+## Async options
+
+For async (for example, server-side) options, clear and replace `items` when the menu opens. Clear `items` while a request is in flight so the menu has no options.
+
+When the open menu has no options, the `empty` slot renders. Put loading UI, an error message, or a no-options string there. This example simulates a fetch on open with a short delay.
+
+<FileSource src="/framed/Dropdown/AsyncDropdown" />
+
 ## Multiple dropdowns
 
 Create multiple dropdowns that work together.

--- a/docs/src/pages/framed/Dropdown/AsyncDropdown.svelte
+++ b/docs/src/pages/framed/Dropdown/AsyncDropdown.svelte
@@ -1,0 +1,54 @@
+<script>
+  import { Dropdown, InlineLoading } from "carbon-components-svelte";
+
+  let items = [];
+  let open = false;
+  let status = "idle";
+  let selectedId;
+  let wasOpen = false;
+
+  const allItems = [
+    { id: "0", text: "Slack" },
+    { id: "1", text: "Email" },
+    { id: "2", text: "Fax" },
+    { id: "3", text: "Phone" },
+    { id: "4", text: "SMS" },
+  ];
+
+  async function fetchItems() {
+    status = "loading";
+    items = [];
+    try {
+      await new Promise((resolve) => setTimeout(resolve, 500));
+      items = allItems;
+      status = items.length ? "idle" : "empty";
+    } catch {
+      status = "error";
+    }
+  }
+
+  $: {
+    if (open && !wasOpen) {
+      fetchItems();
+    }
+    wasOpen = open;
+  }
+</script>
+
+<Dropdown
+  bind:open
+  bind:selectedId
+  labelText="Contact"
+  label="Choose a contact method"
+  {items}
+>
+  <svelte:fragment slot="empty">
+    {#if status === "loading"}
+      <InlineLoading status="active" description="Loading…" />
+    {:else if status === "error"}
+      Something went wrong
+    {:else}
+      No options
+    {/if}
+  </svelte:fragment>
+</Dropdown>

--- a/src/Dropdown/Dropdown.svelte
+++ b/src/Dropdown/Dropdown.svelte
@@ -16,6 +16,7 @@
    * @slot {{ item: Item; index: number; selected: boolean; highlighted: boolean; }}
    * @slot {{ item: Item; index: number; selected: boolean; highlighted: boolean; }} icon
    * @slot {{ item: Item; index: number; selected: boolean; highlighted: boolean; }} iconRight
+   * @slot {{}} empty
    */
 
   /**
@@ -658,7 +659,16 @@
             ? `max-height: ${virtualConfig.containerHeight}px; overflow-y: auto;`
             : undefined}
       >
-        {#if virtualData?.isVirtualized}
+        {#if itemsToRender.length === 0}
+          <div
+            class:bx--list-box__menu-item={true}
+            class:bx--list-box__menu-item--empty={true}
+          >
+            <div class:bx--list-box__menu-item__option={true}>
+              <slot name="empty">No options</slot>
+            </div>
+          </div>
+        {:else if virtualData?.isVirtualized}
           <div style="height: {virtualData.totalHeight}px; position: relative;">
             <div style="transform: translateY({virtualData.offsetY}px);">
               {#each itemsToRender as item, index (item.id)}

--- a/tests/Dropdown/Dropdown.empty.test.svelte
+++ b/tests/Dropdown/Dropdown.empty.test.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+  import Dropdown from "carbon-components-svelte/Dropdown/Dropdown.svelte";
+  import type { ComponentProps } from "svelte";
+
+  export let items: ComponentProps<Dropdown>["items"] = [];
+  export let open = false;
+  export let emptyContent: "custom" | "loading" | "error" = "custom";
+</script>
+
+<Dropdown {items} {open} labelText="Contact" label="Choose a contact method">
+  <svelte:fragment slot="empty">
+    {#if emptyContent === "loading"}
+      <span data-testid="empty-loading">Loading…</span>
+    {:else if emptyContent === "error"}
+      <span data-testid="empty-error">Something went wrong</span>
+    {:else}
+      <span data-testid="empty-custom">Custom empty</span>
+    {/if}
+  </svelte:fragment>
+</Dropdown>

--- a/tests/Dropdown/Dropdown.test.ts
+++ b/tests/Dropdown/Dropdown.test.ts
@@ -11,6 +11,7 @@ import type { ComponentEvents, ComponentProps } from "svelte";
 import { tick } from "svelte";
 import { isSvelte5 } from "../utils/svelte-version";
 import { user } from "../utils/user";
+import DropdownEmpty from "./Dropdown.empty.test.svelte";
 import DropdownFluidForm from "./Dropdown.fluidForm.test.svelte";
 import DropdownFluidSkeleton from "./Dropdown.fluidSkeleton.test.svelte";
 import DropdownFluidSlot from "./Dropdown.fluidSlot.test.svelte";
@@ -692,6 +693,84 @@ describe("Dropdown", () => {
     } else {
       expect(button).toHaveTextContent("undefined");
     }
+  });
+
+  describe("empty slot", () => {
+    it("shows default No options when the open menu has no items", async () => {
+      render(Dropdown, {
+        props: {
+          items: [],
+          labelText: "Contact",
+          label: "Choose a contact method",
+        },
+      });
+
+      await user.click(screen.getByLabelText("Contact"));
+
+      expect(screen.getByText("No options")).toBeInTheDocument();
+      expect(screen.queryByRole("option")).not.toBeInTheDocument();
+      expect(
+        document.querySelector(".bx--list-box__menu-item--empty"),
+      ).toBeInTheDocument();
+    });
+
+    it("does not show the empty slot when options are present", async () => {
+      render(Dropdown, {
+        props: { items, labelText: "Contact", selectedId: "0" },
+      });
+
+      await user.click(screen.getByLabelText("Contact"));
+
+      expect(screen.queryByText("No options")).not.toBeInTheDocument();
+      expect(screen.getAllByRole("option").length).toBeGreaterThan(0);
+      expect(
+        document.querySelector(".bx--list-box__menu-item--empty"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("renders a custom empty slot for loading and error states", () => {
+      const { unmount } = render(DropdownEmpty, {
+        props: { items: [], open: true, emptyContent: "loading" },
+      });
+
+      expect(screen.getByTestId("empty-loading")).toHaveTextContent("Loading…");
+      expect(screen.queryByText("No options")).not.toBeInTheDocument();
+      expect(screen.queryByRole("option")).not.toBeInTheDocument();
+
+      unmount();
+
+      render(DropdownEmpty, {
+        props: { items: [], open: true, emptyContent: "error" },
+      });
+
+      expect(screen.getByTestId("empty-error")).toHaveTextContent(
+        "Something went wrong",
+      );
+      expect(screen.queryByTestId("empty-loading")).not.toBeInTheDocument();
+    });
+
+    it("does not treat the empty row as a selectable option", async () => {
+      render(Dropdown, {
+        props: {
+          items: [],
+          labelText: "Contact",
+          label: "Choose a contact method",
+        },
+      });
+
+      const button = screen.getByLabelText("Contact");
+      await user.click(button);
+
+      expect(screen.getByText("No options")).toBeInTheDocument();
+      expect(screen.queryByRole("option")).not.toBeInTheDocument();
+      expect(button.getAttribute("aria-activedescendant")).toBe("");
+
+      await user.keyboard("{ArrowDown}");
+      expect(button.getAttribute("aria-activedescendant")).toBe("");
+
+      await user.keyboard("{Enter}");
+      expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    });
   });
 
   it("should handle translateWithId prop", () => {


### PR DESCRIPTION
When the open menu has no items, an empty slot renders (default “No
options”) so async or filtered Dropdowns can show loading or empty UI.