### PR TITLE
feat(menu): add shortcutText on MenuItem

### DIFF
--- a/docs/src/pages/components/Menu.svx
+++ b/docs/src/pages/components/Menu.svx
@@ -36,6 +36,12 @@ Pass a Carbon icon to `icon`.
 
 <FileSource src="/framed/Menu/MenuItemIcons" />
 
+### Shortcuts
+
+Set `shortcutText` to show a keyboard hint on the right of the row. Use the `shortcutText` slot for custom content. The hint is display-only; it does not register a keybinding.
+
+<FileSource src="/framed/Menu/MenuItemShortcuts" />
+
 ### Danger
 
 Set `kind="danger"` on `MenuItem` for a destructive action.

--- a/docs/src/pages/components/MenuButton.svx
+++ b/docs/src/pages/components/MenuButton.svx
@@ -131,6 +131,16 @@ Pass a Carbon icon to `icon`.
   <MenuItem icon={Copy} on:click={() => console.log("Copy")}>Copy</MenuItem>
 </MenuButton>
 
+### Shortcuts
+
+Set `shortcutText` to show a keyboard hint on the right of the row. Use the `shortcutText` slot for custom content. The hint is display-only; it does not register a keybinding.
+
+<MenuButton labelText="Actions">
+  <MenuItem icon={Cut} shortcutText="⌘X" on:click={() => console.log("Cut")}>Cut</MenuItem>
+  <MenuItem icon={Copy} shortcutText="⌘C" on:click={() => console.log("Copy")}>Copy</MenuItem>
+  <MenuItem shortcutText="⌘V" on:click={() => console.log("Paste")}>Paste</MenuItem>
+</MenuButton>
+
 ### Danger
 
 Set `kind="danger"` on `MenuItem` for a destructive action.

--- a/docs/src/pages/framed/Menu/MenuItemShortcuts.svelte
+++ b/docs/src/pages/framed/Menu/MenuItemShortcuts.svelte
@@ -1,0 +1,27 @@
+<script>
+  import { Button, Menu, MenuItem } from "carbon-components-svelte";
+  import Copy from "carbon-icons-svelte/lib/Copy.svelte";
+  import Cut from "carbon-icons-svelte/lib/Cut.svelte";
+  import Paste from "carbon-icons-svelte/lib/Paste.svelte";
+
+  let anchor;
+  let open = false;
+</script>
+
+<Button bind:ref={anchor} on:click={() => (open = !open)}>Actions</Button>
+
+<Menu {anchor} bind:open labelText="Actions menu">
+  <MenuItem icon={Cut} shortcutText="⌘X" on:click={() => console.log("Cut")}>
+    Cut
+  </MenuItem>
+  <MenuItem icon={Copy} shortcutText="⌘C" on:click={() => console.log("Copy")}>
+    Copy
+  </MenuItem>
+  <MenuItem
+    icon={Paste}
+    shortcutText="⌘V"
+    on:click={() => console.log("Paste")}
+  >
+    Paste
+  </MenuItem>
+</Menu>

--- a/src/Menu/MenuItem.svelte
+++ b/src/Menu/MenuItem.svelte
@@ -34,6 +34,19 @@
   export let labelText = undefined;
 
   /**
+   * Specify the shortcut text.
+   * Alternatively, use the "shortcutText" slot.
+   * Display only; does not register a keybinding.
+   * @example
+   * ```svelte
+   * <MenuItem>
+   *   <span slot="shortcutText">⌘S</span>
+   * </MenuItem>
+   * ```
+   */
+  export let shortcutText = "";
+
+  /**
    * Obtain a reference to the list item HTML element.
    * @bindable readonly
    */
@@ -175,6 +188,10 @@
     {#if hasSubmenu}
       <div class:bx--menu-option__info={true}>
         <CaretRight />
+      </div>
+    {:else if shortcutText || $$slots.shortcutText}
+      <div class:bx--menu-option__info={true}>
+        <slot name="shortcutText">{shortcutText}</slot>
       </div>
     {/if}
   </div>

--- a/tests/Menu/MenuItem.slot.test.svelte
+++ b/tests/Menu/MenuItem.slot.test.svelte
@@ -11,6 +11,12 @@
 </button>
 
 <Menu {anchor} bind:open labelText="Example menu">
+  <MenuItem>
+    Save
+    <svelte:fragment slot="shortcutText">
+      <kbd>⌘S</kbd>
+    </svelte:fragment>
+  </MenuItem>
   <MenuItem labelText="Export as">
     <svelte:fragment slot="labelChildren">
       <strong>Custom label content</strong>

--- a/tests/Menu/MenuItem.test.svelte
+++ b/tests/Menu/MenuItem.test.svelte
@@ -15,6 +15,7 @@
 <Menu {anchor} bind:open labelText="Example menu">
   <MenuItem icon={Add}>Add item</MenuItem>
   <MenuItem>Plain</MenuItem>
+  <MenuItem shortcutText="⌘S">Save</MenuItem>
   <MenuItem labelText="Export as">
     <MenuItem on:click={() => console.log("select", "PDF")}>PDF</MenuItem>
     <MenuItem on:click={() => console.log("select", "JPG")}>JPG</MenuItem>

--- a/tests/Menu/MenuItem.test.ts
+++ b/tests/Menu/MenuItem.test.ts
@@ -28,6 +28,39 @@ describe("MenuItem", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("renders shortcutText in the info region", async () => {
+    render(MenuItemFixture);
+
+    await user.click(screen.getByRole("button", { name: "Trigger" }));
+
+    const item = screen.getByRole("menuitem", { name: "Save ⌘S" });
+    expect(item.querySelector(".bx--menu-option__info")).toHaveTextContent(
+      "⌘S",
+    );
+  });
+
+  it("does not render an info region when shortcutText is unset", async () => {
+    render(MenuItemFixture);
+
+    await user.click(screen.getByRole("button", { name: "Trigger" }));
+
+    const item = screen.getByRole("menuitem", { name: "Plain" });
+    expect(
+      item.querySelector(".bx--menu-option__info"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders the shortcutText slot", async () => {
+    render(MenuItemSlot);
+
+    await user.click(screen.getByRole("button", { name: "Trigger" }));
+
+    const item = screen.getByRole("menuitem", { name: "Save ⌘S" });
+    expect(item.querySelector(".bx--menu-option__info kbd")).toHaveTextContent(
+      "⌘S",
+    );
+  });
+
   it("applies the danger class for kind danger", async () => {
     render(MenuItemFixture);
 


### PR DESCRIPTION
MenuItem shortcutText (prop or slot) shows a display-only keyboard hint;
it does not register shortcuts.