### PR TITLE
feat(menu): add maxHeight for scrollable menus

### DIFF
--- a/css/_menu.scss
+++ b/css/_menu.scss
@@ -1,0 +1,17 @@
+@import "carbon-components/scss/globals/scss/vars";
+@import "carbon-components/scss/globals/scss/helper-mixins";
+@import "carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/import-once/import-once";
+
+/// Scrollable menu, paired with the inline `max-height` the `maxHeight` prop
+/// sets on the menu list.
+/// @access private
+/// @group components
+@mixin menu-scrollable {
+  .#{$prefix}--menu--scrollable {
+    overflow-y: auto;
+  }
+}
+
+@include exports("menu-scrollable") {
+  @include menu-scrollable;
+}

--- a/css/all.scss
+++ b/css/all.scss
@@ -110,6 +110,7 @@ $css--plex: true;
 @import "./copy-button";
 @import "./copy-input";
 @import "./overflow-menu";
+@import "./menu";
 @import "./menu-xs";
 @import "./combo-button";
 @import "./list-box-menu-item";

--- a/css/g10.scss
+++ b/css/g10.scss
@@ -70,6 +70,7 @@ $css--plex: true;
 @import "./copy-button";
 @import "./copy-input";
 @import "./overflow-menu";
+@import "./menu";
 @import "./menu-xs";
 @import "./combo-button";
 @import "./list-box-menu-item";

--- a/css/g100.scss
+++ b/css/g100.scss
@@ -70,6 +70,7 @@ $css--plex: true;
 @import "./copy-button";
 @import "./copy-input";
 @import "./overflow-menu";
+@import "./menu";
 @import "./menu-xs";
 @import "./combo-button";
 @import "./list-box-menu-item";

--- a/css/g80.scss
+++ b/css/g80.scss
@@ -70,6 +70,7 @@ $css--plex: true;
 @import "./copy-button";
 @import "./copy-input";
 @import "./overflow-menu";
+@import "./menu";
 @import "./menu-xs";
 @import "./combo-button";
 @import "./list-box-menu-item";

--- a/css/g90.scss
+++ b/css/g90.scss
@@ -70,6 +70,7 @@ $css--plex: true;
 @import "./copy-button";
 @import "./copy-input";
 @import "./overflow-menu";
+@import "./menu";
 @import "./menu-xs";
 @import "./combo-button";
 @import "./list-box-menu-item";

--- a/css/white.scss
+++ b/css/white.scss
@@ -70,6 +70,7 @@ $css--plex: true;
 @import "./copy-button";
 @import "./copy-input";
 @import "./overflow-menu";
+@import "./menu";
 @import "./menu-xs";
 @import "./combo-button";
 @import "./list-box-menu-item";

--- a/docs/src/pages/components/Menu.svx
+++ b/docs/src/pages/components/Menu.svx
@@ -58,6 +58,12 @@ Set `labelText` on a `MenuItem` and nest child `MenuItem` rows to get a submenu.
 
 Once open, arrow keys move focus between items without wrapping past the first or last item. <DocKbd label="Home" /> and <DocKbd label="End" /> jump to the first and last enabled item, skipping disabled ones. The menu closes from an item selection, <DocKbd label="Escape" />, or an outside click; <DocKbd label="Escape" /> also returns focus to the anchor.
 
+## Scrollable
+
+Set `maxHeight` to cap the menu height and scroll the remaining items. A number is treated as pixels; a string is used as any CSS length, such as `"20rem"`. Keyboard navigation scrolls the focused item into view.
+
+<FileSource src="/framed/Menu/MenuScrollable" />
+
 ## Placement
 
 Menu forwards its placement props to [FloatingPortal](/components/FloatingPortal).

--- a/docs/src/pages/components/MenuButton.svx
+++ b/docs/src/pages/components/MenuButton.svx
@@ -101,6 +101,12 @@ Set `intrinsicAlign` to `"start"` (default), `"center"`, or `"end"` to align the
   <MenuItem on:click={() => console.log("Paste")}>Paste</MenuItem>
 </MenuButton>
 
+## Scrollable
+
+Set `maxHeight` to cap the menu height and scroll the remaining items. A number is treated as pixels; a string is used as any CSS length, such as `"20rem"`. Keyboard navigation scrolls the focused item into view.
+
+<FileSource src="/framed/MenuButton/MenuButtonScrollable" />
+
 ## Disabled
 
 Set `disabled` to `true` to disable the trigger button.

--- a/docs/src/pages/framed/Menu/MenuScrollable.svelte
+++ b/docs/src/pages/framed/Menu/MenuScrollable.svelte
@@ -1,0 +1,19 @@
+<script>
+  import { Button, Menu, MenuItem } from "carbon-components-svelte";
+
+  let anchor;
+  let open = false;
+
+  const actions = Array.from(
+    { length: 20 },
+    (_, index) => `Action ${index + 1}`,
+  );
+</script>
+
+<Button bind:ref={anchor} on:click={() => (open = !open)}>Actions</Button>
+
+<Menu {anchor} bind:open labelText="Actions menu" maxHeight={240}>
+  {#each actions as action (action)}
+    <MenuItem on:click={() => console.log(action)}>{action}</MenuItem>
+  {/each}
+</Menu>

--- a/docs/src/pages/framed/MenuButton/MenuButtonScrollable.svelte
+++ b/docs/src/pages/framed/MenuButton/MenuButtonScrollable.svelte
@@ -1,0 +1,14 @@
+<script>
+  import { MenuButton, MenuItem } from "carbon-components-svelte";
+
+  const actions = Array.from(
+    { length: 20 },
+    (_, index) => `Action ${index + 1}`,
+  );
+</script>
+
+<MenuButton labelText="Actions" maxHeight={240}>
+  {#each actions as action (action)}
+    <MenuItem on:click={() => console.log(action)}>{action}</MenuItem>
+  {/each}
+</MenuButton>

--- a/src/Menu/Menu.svelte
+++ b/src/Menu/Menu.svelte
@@ -83,6 +83,14 @@
   export let intrinsicAlign = "center";
 
   /**
+   * Specify the maximum height of the menu.
+   * A number is treated as pixels; a string is used as a CSS length.
+   * The menu scrolls once its items exceed the height.
+   * @type {number | string}
+   */
+  export let maxHeight = undefined;
+
+  /**
    * DOM node to mount the menu into.
    * When unset, uses the anchor's nearest `<dialog>` or `[popover]`, else `document.body`.
    * @type {HTMLElement | null}
@@ -94,6 +102,7 @@
   import { dismiss } from "../utils/dismiss.js";
   import { isOutsideClick } from "../utils/isOutsideClick.js";
   import { rovingFocus } from "../utils/rovingFocus.js";
+  import { scrollIntoViewWithinMenu } from "../utils/scrollIntoViewWithinMenu.js";
 
   const NON_DISABLED_MENUITEM_SELECTOR =
     "[role='menuitem']:not([aria-disabled='true'])";
@@ -123,7 +132,7 @@
         const firstItem = ref?.querySelector(NON_DISABLED_MENUITEM_SELECTOR);
         if (firstItem instanceof HTMLElement) {
           focusIndex = 0;
-          firstItem.focus({ preventScroll: true });
+          focusMenuItem(firstItem);
         } else {
           ref?.focus({ preventScroll: true });
         }
@@ -134,6 +143,18 @@
   }
 
   $: menuAriaLabel = ($$props["aria-label"] ?? labelText) || undefined;
+  $: maxHeightStyle =
+    typeof maxHeight === "number" ? `${maxHeight}px` : maxHeight;
+
+  /**
+   * @param {HTMLElement} item
+   */
+  function focusMenuItem(item) {
+    // `preventScroll` keeps a portaled menu from scrolling the document;
+    // scroll the item into view within the menu's own scroll container.
+    item.focus({ preventScroll: true });
+    scrollIntoViewWithinMenu(item, '[role="menu"]');
+  }
 
   function handleOutsideClick(event) {
     if (!open) return;
@@ -173,10 +194,15 @@
       selector: NON_DISABLED_MENUITEM_SELECTOR,
       orientation: "vertical",
       wrap: false,
-      focusOnMove: true,
+      focusOnMove: false,
       getActiveIndex: () => focusIndex,
       onMove: (index) => {
         focusIndex = index;
+        const items = /** @type {HTMLElement[]} */ (
+          Array.from(ref?.querySelectorAll(NON_DISABLED_MENUITEM_SELECTOR) ?? [])
+        );
+        const item = items[index];
+        if (item) focusMenuItem(item);
       },
     }}
     use:dismiss={{
@@ -192,11 +218,13 @@
     style:position="relative"
     style:top="auto"
     style:left="auto"
+    style:max-height={maxHeightStyle}
     class:bx--menu={true}
     class:bx--menu--open={open}
     class:bx--menu--xs={size === "xs"}
     class:bx--menu--md={size === "md"}
     class:bx--menu--lg={size === "lg"}
+    class:bx--menu--scrollable={!!maxHeight}
     {...$$restProps}
     aria-label={menuAriaLabel}
     on:keydown

--- a/src/MenuButton/MenuButton.svelte
+++ b/src/MenuButton/MenuButton.svelte
@@ -49,6 +49,14 @@
   export let intrinsicAlign = "start";
 
   /**
+   * Specify the maximum height of the menu.
+   * A number is treated as pixels; a string is used as a CSS length.
+   * The menu scrolls once its items exceed the height.
+   * @type {number | string}
+   */
+  export let maxHeight = undefined;
+
+  /**
    * Set to `true` to open the menu.
    * @bindable writable
    */
@@ -133,6 +141,7 @@
   {direction}
   {intrinsicAlign}
   {size}
+  {maxHeight}
   intrinsicWidth
   bind:open
   {labelText}

--- a/src/utils/scrollIntoViewWithinMenu.d.ts
+++ b/src/utils/scrollIntoViewWithinMenu.d.ts
@@ -9,7 +9,11 @@
  * not scrollable.
  */
 /**
- * Scroll `el` into view within its nearest `role="listbox"` scroll container
- * using `block: "nearest"` semantics. Never scrolls the document.
+ * Scroll `el` into view within its nearest scroll container matching
+ * `containerSelector` using `block: "nearest"` semantics. Never scrolls the
+ * document.
  */
-export function scrollIntoViewWithinMenu(el: HTMLElement): void;
+export function scrollIntoViewWithinMenu(
+  el: HTMLElement,
+  containerSelector?: string,
+): void;

--- a/src/utils/scrollIntoViewWithinMenu.js
+++ b/src/utils/scrollIntoViewWithinMenu.js
@@ -9,14 +9,19 @@
 // not scrollable.
 
 /**
- * Scroll `el` into view within its nearest `role="listbox"` scroll container
- * using `block: "nearest"` semantics. Never scrolls the document.
+ * Scroll `el` into view within its nearest scroll container matching
+ * `containerSelector` using `block: "nearest"` semantics. Never scrolls the
+ * document.
  *
  * @param {HTMLElement} el
+ * @param {string} [containerSelector] defaults to `[role="listbox"]`
  * @returns {void}
  */
-export function scrollIntoViewWithinMenu(el) {
-  const container = el.closest('[role="listbox"]');
+export function scrollIntoViewWithinMenu(
+  el,
+  containerSelector = '[role="listbox"]',
+) {
+  const container = el.closest(containerSelector);
   if (!(container instanceof HTMLElement)) return;
   if (container.scrollHeight <= container.clientHeight) return;
 

--- a/tests/Menu/Menu.test.svelte
+++ b/tests/Menu/Menu.test.svelte
@@ -5,6 +5,7 @@
 
   export let direction: ComponentProps<Menu>["direction"] = "bottom";
   export let size: ComponentProps<Menu>["size"] = "sm";
+  export let maxHeight: ComponentProps<Menu>["maxHeight"] = undefined;
   export let disabledIndex: number | undefined = undefined;
 
   let anchor: HTMLButtonElement;
@@ -21,6 +22,7 @@
   {anchor}
   {direction}
   {size}
+  {maxHeight}
   bind:open
   labelText="Example menu"
   on:open={(e) => console.log("open", e.detail)}

--- a/tests/Menu/Menu.test.ts
+++ b/tests/Menu/Menu.test.ts
@@ -220,4 +220,36 @@ describe("Menu", () => {
       trigger: "outside-click",
     });
   });
+
+  describe("maxHeight", () => {
+    it("caps the menu height in pixels when given a number", async () => {
+      render(MenuFixture, { props: { maxHeight: 240 } });
+
+      await user.click(screen.getByRole("button", { name: "Trigger" }));
+
+      const menu = screen.getByRole("menu");
+      expect(menu).toHaveClass("bx--menu--scrollable");
+      expect(menu).toHaveStyle("max-height: 240px");
+    });
+
+    it("passes a string maxHeight through verbatim", async () => {
+      render(MenuFixture, { props: { maxHeight: "20rem" } });
+
+      await user.click(screen.getByRole("button", { name: "Trigger" }));
+
+      const menu = screen.getByRole("menu");
+      expect(menu).toHaveClass("bx--menu--scrollable");
+      expect(menu.style.maxHeight).toBe("20rem");
+    });
+
+    it("renders neither the class nor the style when maxHeight is unset", async () => {
+      render(MenuFixture);
+
+      await user.click(screen.getByRole("button", { name: "Trigger" }));
+
+      const menu = screen.getByRole("menu");
+      expect(menu).not.toHaveClass("bx--menu--scrollable");
+      expect(menu.style.maxHeight).toBe("");
+    });
+  });
 });

--- a/tests/utils/scrollIntoViewWithinMenu.test.ts
+++ b/tests/utils/scrollIntoViewWithinMenu.test.ts
@@ -1,9 +1,8 @@
 import { scrollIntoViewWithinMenu } from "../../src/utils/scrollIntoViewWithinMenu.js";
 
 /**
- * Build a `role="listbox"` container with a single item, stubbing the layout
- * jsdom does not compute: the container's scrollability and both elements'
- * bounding rects.
+ * Build a container with a single item, stubbing the layout jsdom does not
+ * compute: the container's scrollability and both elements' bounding rects.
  */
 function buildMenu(options: {
   scrollable: boolean;
@@ -11,9 +10,10 @@ function buildMenu(options: {
   containerBottom: number;
   itemTop: number;
   itemBottom: number;
+  role?: string;
 }) {
   const container = document.createElement("div");
-  container.setAttribute("role", "listbox");
+  container.setAttribute("role", options.role ?? "listbox");
   Object.defineProperty(container, "clientHeight", { value: 100 });
   Object.defineProperty(container, "scrollHeight", {
     value: options.scrollable ? 300 : 100,
@@ -100,5 +100,66 @@ describe("scrollIntoViewWithinMenu", () => {
     scrollIntoViewWithinMenu(item);
 
     expect(container.scrollTop).toBe(50);
+  });
+
+  describe("container selector", () => {
+    test("resolves a listbox container by default", () => {
+      const { container, item } = buildMenu({
+        scrollable: true,
+        containerTop: 0,
+        containerBottom: 100,
+        itemTop: 110,
+        itemBottom: 130,
+      });
+
+      scrollIntoViewWithinMenu(item);
+
+      expect(container.scrollTop).toBe(80);
+    });
+
+    test("ignores a menu container under the default selector", () => {
+      const { container, item } = buildMenu({
+        scrollable: true,
+        containerTop: 0,
+        containerBottom: 100,
+        itemTop: 110,
+        itemBottom: 130,
+        role: "menu",
+      });
+
+      scrollIntoViewWithinMenu(item);
+
+      expect(container.scrollTop).toBe(50);
+    });
+
+    test("resolves a menu container when the selector is passed", () => {
+      const { container, item } = buildMenu({
+        scrollable: true,
+        containerTop: 0,
+        containerBottom: 100,
+        itemTop: 110,
+        itemBottom: 130,
+        role: "menu",
+      });
+
+      scrollIntoViewWithinMenu(item, '[role="menu"]');
+
+      expect(container.scrollTop).toBe(80);
+    });
+
+    test("does not scroll a non-scrollable menu container", () => {
+      const { container, item } = buildMenu({
+        scrollable: false,
+        containerTop: 0,
+        containerBottom: 100,
+        itemTop: 110,
+        itemBottom: 130,
+        role: "menu",
+      });
+
+      scrollIntoViewWithinMenu(item, '[role="menu"]');
+
+      expect(container.scrollTop).toBe(50);
+    });
   });
 });


### PR DESCRIPTION
maxHeight on Menu (forwarded from MenuButton) caps long menus and keeps
keyboard focus scrolled inside the list.