### PR TITLE
feat(tabs): add selectedId for stable selection

### DIFF
--- a/docs/src/pages/components/Tabs.svx
+++ b/docs/src/pages/components/Tabs.svx
@@ -37,6 +37,12 @@ Use `bind:selected` for a two-way binding with the selected tab index, so you ca
 
 <FileSource src="/framed/Tabs/TabsReactive" />
 
+## Selected by id
+
+For dynamic tab sets, bind `selectedId` and give each `Tab` a stable `id`. Selection stays on the same logical tab when tabs before it are added or removed. When set, `selectedId` takes precedence over `selected`.
+
+<FileSource src="/framed/Tabs/TabsSelectedId" />
+
 ## Overflow
 
 When the tabs exceed the available width, the list scrolls horizontally and backward/forward buttons appear at each end. Scroll by dragging, using the buttons, or moving focus with the arrow keys. Resize the viewport to see the buttons appear and hide.
@@ -315,10 +321,10 @@ Icon-only tabs also work with the container type.
 ## Dismissible
 
 Set `dismissible` on Tabs to render a close button on each tab. Handle the
-dismiss event to remove the tab from your data and update selected if needed. The
-event detail includes `{ id, label, disabled, index }`. Set an id on each Tab to
-match the event to your list. Press <DocKbd label="Delete" /> on the focused tab
-to dismiss it.
+dismiss event to remove the tab from your data. Bind `selectedId` with a stable
+`id` on each Tab so selection stays coherent without manual index math. The
+event detail includes `{ id, label, disabled, index }`. Press
+<DocKbd label="Delete" /> on the focused tab to dismiss it.
 
 ### Basic
 

--- a/docs/src/pages/components/Tabs.svx
+++ b/docs/src/pages/components/Tabs.svx
@@ -76,9 +76,8 @@ Below the medium breakpoint, vertical tabs collapse into the same horizontal, sc
 ## Manual activation
 
 By default, tabs use automatic activation: arrow keys move focus and select the
-tab. Set `activation` to `"manual"` so arrow keys only move focus; press
-<DocKbd label="Enter" /> or <DocKbd label="Space" /> to select. Use manual
-activation when switching panels is expensive.
+tab. Set `activation` to `"manual"` so arrow keys only move focus. Press <DocKbd label="Enter" /> or <DocKbd label="Space" /> to select.
+Use manual activation when switching panels is expensive.
 
 <Tabs activation="manual">
   <Tab label="Tab label 1" />

--- a/docs/src/pages/framed/Tabs/TabsDismissible.svelte
+++ b/docs/src/pages/framed/Tabs/TabsDismissible.svelte
@@ -1,7 +1,7 @@
 <script>
   import { Tab, TabContent, Tabs } from "carbon-components-svelte";
 
-  let selected = 0;
+  let selectedId = "dashboard";
   let tabs = [
     { id: "dashboard", label: "Dashboard" },
     { id: "monitoring", label: "Monitoring" },
@@ -11,16 +11,10 @@
 
   function handleDismiss({ detail }) {
     tabs = tabs.filter((tab) => tab.id !== detail.id);
-
-    if (selected > detail.index) {
-      selected -= 1;
-    } else if (selected >= tabs.length) {
-      selected = Math.max(tabs.length - 1, 0);
-    }
   }
 </script>
 
-<Tabs bind:selected dismissible on:dismiss={handleDismiss}>
+<Tabs bind:selectedId dismissible on:dismiss={handleDismiss}>
   {#each tabs as tab (tab.id)}
     <Tab id={tab.id} label={tab.label} disabled={tab.disabled} />
   {/each}

--- a/docs/src/pages/framed/Tabs/TabsDismissibleContainer.svelte
+++ b/docs/src/pages/framed/Tabs/TabsDismissibleContainer.svelte
@@ -1,7 +1,7 @@
 <script>
   import { Tab, TabContent, Tabs } from "carbon-components-svelte";
 
-  let selected = 0;
+  let selectedId = "dashboard";
   let tabs = [
     { id: "dashboard", label: "Dashboard" },
     { id: "monitoring", label: "Monitoring" },
@@ -11,16 +11,10 @@
 
   function handleDismiss({ detail }) {
     tabs = tabs.filter((tab) => tab.id !== detail.id);
-
-    if (selected > detail.index) {
-      selected -= 1;
-    } else if (selected >= tabs.length) {
-      selected = Math.max(tabs.length - 1, 0);
-    }
   }
 </script>
 
-<Tabs type="container" bind:selected dismissible on:dismiss={handleDismiss}>
+<Tabs type="container" bind:selectedId dismissible on:dismiss={handleDismiss}>
   {#each tabs as tab (tab.id)}
     <Tab id={tab.id} label={tab.label} disabled={tab.disabled} />
   {/each}

--- a/docs/src/pages/framed/Tabs/TabsDismissibleIcons.svelte
+++ b/docs/src/pages/framed/Tabs/TabsDismissibleIcons.svelte
@@ -4,7 +4,7 @@
   import Dashboard from "carbon-icons-svelte/lib/Dashboard.svelte";
   import Settings from "carbon-icons-svelte/lib/Settings.svelte";
 
-  let selected = 0;
+  let selectedId = "dashboard";
   let tabs = [
     { id: "dashboard", label: "Dashboard", icon: Dashboard },
     { id: "schedule", label: "Schedule", icon: Calendar },
@@ -13,16 +13,10 @@
 
   function handleDismiss({ detail }) {
     tabs = tabs.filter((tab) => tab.id !== detail.id);
-
-    if (selected > detail.index) {
-      selected -= 1;
-    } else if (selected >= tabs.length) {
-      selected = Math.max(tabs.length - 1, 0);
-    }
   }
 </script>
 
-<Tabs bind:selected dismissible on:dismiss={handleDismiss}>
+<Tabs bind:selectedId dismissible on:dismiss={handleDismiss}>
   {#each tabs as tab (tab.id)}
     <Tab
       id={tab.id}

--- a/docs/src/pages/framed/Tabs/TabsOverflowDismissible.svelte
+++ b/docs/src/pages/framed/Tabs/TabsOverflowDismissible.svelte
@@ -1,7 +1,7 @@
 <script>
   import { Tab, TabContent, Tabs } from "carbon-components-svelte";
 
-  let selected = 0;
+  let selectedId = "tab-1";
   let tabs = Array.from({ length: 12 }, (_, i) => ({
     id: `tab-${i + 1}`,
     label: `Tab label ${i + 1}`,
@@ -9,16 +9,10 @@
 
   function handleDismiss({ detail }) {
     tabs = tabs.filter((tab) => tab.id !== detail.id);
-
-    if (selected > detail.index) {
-      selected -= 1;
-    } else if (selected >= tabs.length) {
-      selected = Math.max(tabs.length - 1, 0);
-    }
   }
 </script>
 
-<Tabs bind:selected dismissible on:dismiss={handleDismiss}>
+<Tabs bind:selectedId dismissible on:dismiss={handleDismiss}>
   {#each tabs as tab (tab.id)}
     <Tab id={tab.id} label={tab.label} />
   {/each}

--- a/docs/src/pages/framed/Tabs/TabsSelectedId.svelte
+++ b/docs/src/pages/framed/Tabs/TabsSelectedId.svelte
@@ -1,0 +1,57 @@
+<script>
+  import {
+    Button,
+    Checkbox,
+    Stack,
+    Tab,
+    TabContent,
+    Tabs,
+  } from "carbon-components-svelte";
+
+  let selectedId = "admin";
+  let showDashboard = true;
+  let showAdmin = true;
+  let showSettings = true;
+  let showProfile = true;
+
+  $: visibleTabs = [
+    { id: "dashboard", label: "Dashboard", show: showDashboard },
+    { id: "admin", label: "Admin", show: showAdmin },
+    { id: "settings", label: "Settings", show: showSettings },
+    { id: "profile", label: "Profile", show: showProfile },
+  ].filter((tab) => tab.show);
+</script>
+
+<Stack gap={3}>
+  <div>
+    <Checkbox bind:checked={showDashboard} labelText="Show Dashboard" />
+    <Checkbox bind:checked={showAdmin} labelText="Show Admin" />
+    <Checkbox bind:checked={showSettings} labelText="Show Settings" />
+    <Checkbox bind:checked={showProfile} labelText="Show Profile" />
+  </div>
+  <Stack gap={4} orientation="horizontal" align="center">
+    <Button
+      kind="tertiary"
+      size="small"
+      on:click={() => (selectedId = "settings")}
+    >
+      Select Settings by id
+    </Button>
+    <div>
+      <strong>selectedId:</strong>
+      {selectedId}
+    </div>
+  </Stack>
+  <Tabs bind:selectedId>
+    {#each visibleTabs as tab (tab.id)}
+      <Tab id={tab.id} label={tab.label} />
+    {/each}
+    <svelte:fragment slot="content">
+      {#each visibleTabs as tab (tab.id)}
+        <TabContent>
+          <p>{tab.label} content</p>
+        </TabContent>
+      {/each}
+    </svelte:fragment>
+  </Tabs>
+</Stack>

--- a/src/Tabs/Tab.svelte
+++ b/src/Tabs/Tab.svelte
@@ -31,7 +31,10 @@
    */
   export let tabindex = "0";
 
-  /** Set an id for the top-level element */
+  /**
+   * Set an id for the top-level element.
+   * Use a stable value with `Tabs` `selectedId` when tabs are added or removed dynamically.
+   */
   export let id = `ccs-${Math.random().toString(36)}`;
 
   /**

--- a/src/Tabs/TabContent.svelte
+++ b/src/Tabs/TabContent.svelte
@@ -1,5 +1,8 @@
 <script>
-  /** Set an id for the top-level element */
+  /**
+   * Set an id for the top-level element.
+   * Prefer a stable value when pairing panels with dynamic tabs.
+   */
   export let id = `ccs-${Math.random().toString(36)}`;
 
   /**

--- a/src/Tabs/Tabs.svelte
+++ b/src/Tabs/Tabs.svelte
@@ -6,9 +6,19 @@
 
   /**
    * Specify the selected tab index.
+   * Ignored when `selectedId` is set.
    * @bindable writable
    */
   export let selected = 0;
+
+  /**
+   * Specify the selected tab by id.
+   * When set, takes precedence over `selected` and stays on the same logical
+   * tab as tabs are added or removed. Pair with a stable `id` on each `Tab`.
+   * @bindable writable
+   * @type {string | undefined}
+   */
+  export let selectedId = undefined;
 
   /**
    * Choose whether arrow keys change the selection on focus.
@@ -187,8 +197,35 @@
    * @type {(id: string) => void}
    */
   function update(id) {
-    currentIndex = $tabsById[id].index;
     focusedIndex = -1;
+    if (selectedId !== undefined) {
+      selectedId = id;
+      return;
+    }
+    currentIndex = $tabsById[id].index;
+  }
+
+  /**
+   * Resolve selection from `selectedId` when set; otherwise use `selected`.
+   * If the selected id was removed, keep the same index (next tab) or clamp.
+   * @type {() => void}
+   */
+  function syncSelection() {
+    if (selectedId === undefined) {
+      currentIndex = selected;
+      return;
+    }
+
+    const tab = $tabsById[selectedId];
+    if (tab) {
+      currentIndex = tab.index;
+      return;
+    }
+
+    if ($tabs.length === 0) return;
+
+    currentIndex = Math.min(Math.max(currentIndex, 0), $tabs.length - 1);
+    selectedId = $tabs[currentIndex].id;
   }
 
   /**
@@ -259,8 +296,14 @@
       return;
     }
 
-    currentIndex = index;
     focusedIndex = -1;
+    if (selectedId === undefined) {
+      currentIndex = index;
+    } else {
+      const tab = $tabs[index];
+      if (!tab) return;
+      selectedId = tab.id;
+    }
 
     await tick();
     const activeTab = /** @type {HTMLElement | undefined} */ (
@@ -312,6 +355,11 @@
           }),
         );
       }
+
+      // Re-resolve after reorder so `selectedId` keeps the same logical tab.
+      if (selectedId !== undefined) {
+        syncSelection();
+      }
     }
 
     if (selected !== currentIndex) {
@@ -337,7 +385,11 @@
   let prevIndex = -1;
 
   $: {
-    currentIndex = selected;
+    if (selectedId === undefined) {
+      currentIndex = selected;
+    } else {
+      syncSelection();
+    }
     focusedIndex = -1;
   }
   $: currentTab = $tabs[currentIndex] || undefined;

--- a/src/Tabs/TabsVertical.svelte
+++ b/src/Tabs/TabsVertical.svelte
@@ -5,9 +5,19 @@
 
   /**
    * Specify the selected tab index.
+   * Ignored when `selectedId` is set.
    * @bindable writable
    */
   export let selected = 0;
+
+  /**
+   * Specify the selected tab by id.
+   * When set, takes precedence over `selected` and stays on the same logical
+   * tab as tabs are added or removed. Pair with a stable `id` on each `Tab`.
+   * @bindable writable
+   * @type {string | undefined}
+   */
+  export let selectedId = undefined;
 
   /**
    * Choose whether arrow keys change the selection on focus.
@@ -178,8 +188,35 @@
    * @type {(id: string) => void}
    */
   function update(id) {
-    currentIndex = $tabsById[id].index;
     focusedIndex = -1;
+    if (selectedId !== undefined) {
+      selectedId = id;
+      return;
+    }
+    currentIndex = $tabsById[id].index;
+  }
+
+  /**
+   * Resolve selection from `selectedId` when set; otherwise use `selected`.
+   * If the selected id was removed, keep the same index (next tab) or clamp.
+   * @type {() => void}
+   */
+  function syncSelection() {
+    if (selectedId === undefined) {
+      currentIndex = selected;
+      return;
+    }
+
+    const tab = $tabsById[selectedId];
+    if (tab) {
+      currentIndex = tab.index;
+      return;
+    }
+
+    if ($tabs.length === 0) return;
+
+    currentIndex = Math.min(Math.max(currentIndex, 0), $tabs.length - 1);
+    selectedId = $tabs[currentIndex].id;
   }
 
   // Vertical tabs are never dismissible; this no-op satisfies the `Tab` context.
@@ -212,8 +249,14 @@
       return;
     }
 
-    currentIndex = index;
     focusedIndex = -1;
+    if (selectedId === undefined) {
+      currentIndex = index;
+    } else {
+      const tab = $tabs[index];
+      if (!tab) return;
+      selectedId = tab.id;
+    }
 
     await tick();
     const activeTab = /** @type {HTMLElement | undefined} */ (
@@ -268,6 +311,11 @@
           }),
         );
       }
+
+      // Re-resolve after reorder so `selectedId` keeps the same logical tab.
+      if (selectedId !== undefined) {
+        syncSelection();
+      }
     }
 
     if (selected !== currentIndex) {
@@ -293,7 +341,11 @@
   let prevIndex = -1;
 
   $: {
-    currentIndex = selected;
+    if (selectedId === undefined) {
+      currentIndex = selected;
+    } else {
+      syncSelection();
+    }
     focusedIndex = -1;
   }
   $: currentTab = $tabs[currentIndex] || undefined;

--- a/tests/Tabs/Tabs.test.ts
+++ b/tests/Tabs/Tabs.test.ts
@@ -14,6 +14,7 @@ import Tabs from "./Tabs.test.svelte";
 import TabsAllDisabled from "./TabsAllDisabled.test.svelte";
 import TabsDynamic from "./TabsDynamic.test.svelte";
 import TabsLazy from "./TabsLazy.test.svelte";
+import TabsSelectedId from "./TabsSelectedId.test.svelte";
 import TabsSkeleton from "./TabsSkeleton.test.svelte";
 
 describe("Tabs", () => {
@@ -409,6 +410,88 @@ describe("Tabs", () => {
     const tab1 = screen.getByRole("tab", { name: "Tab 1" });
     await user.click(tab1);
     expect(selectedIndex).toHaveTextContent("0");
+  });
+
+  it("keeps selectedId on the same logical tab when a prior tab is removed", async () => {
+    render(TabsSelectedId, {
+      props: { selectedId: "tab-b", showTabA: true },
+    });
+
+    expect(screen.getByRole("tab", { name: "Tab B" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(screen.getByTestId("selected-id")).toHaveTextContent("tab-b");
+    expect(screen.getByTestId("selected-index")).toHaveTextContent("1");
+    expect(screen.getByText("Content B")).toBeVisible();
+
+    await user.click(screen.getByTestId("toggle-tab-a"));
+
+    expect(
+      screen.queryByRole("tab", { name: "Tab A" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Tab B" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(screen.getByTestId("selected-id")).toHaveTextContent("tab-b");
+    expect(screen.getByTestId("selected-index")).toHaveTextContent("0");
+    expect(screen.getByText("Content B")).toBeVisible();
+  });
+
+  it("falls back when the selectedId tab is removed", async () => {
+    render(TabsSelectedId, {
+      props: { selectedId: "tab-b", showTabA: true, showTabB: true },
+    });
+
+    await user.click(screen.getByTestId("toggle-tab-b"));
+
+    expect(
+      screen.queryByRole("tab", { name: "Tab B" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByTestId("selected-id")).toHaveTextContent("tab-c");
+    expect(screen.getByRole("tab", { name: "Tab C" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(screen.getByText("Content C")).toBeVisible();
+  });
+
+  it("uses the index API when selectedId is unset", async () => {
+    render(TabsSelectedId, {
+      props: { selected: 2, selectedId: undefined },
+    });
+
+    expect(screen.getByRole("tab", { name: "Tab C" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(screen.getByText("Content C")).toBeVisible();
+    expect(screen.getByTestId("selected-index")).toHaveTextContent("2");
+    expect(screen.getByTestId("selected-id")).toHaveTextContent("");
+
+    await user.click(screen.getByRole("tab", { name: "Tab A" }));
+
+    expect(screen.getByRole("tab", { name: "Tab A" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(screen.getByTestId("selected-index")).toHaveTextContent("0");
+    expect(screen.getByTestId("selected-id")).toHaveTextContent("");
+  });
+
+  it("lets selectedId win over selected", () => {
+    render(TabsSelectedId, {
+      props: { selected: 0, selectedId: "tab-c" },
+    });
+
+    expect(screen.getByRole("tab", { name: "Tab C" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(screen.getByText("Content C")).toBeVisible();
+    expect(screen.getByTestId("selected-id")).toHaveTextContent("tab-c");
+    expect(screen.getByTestId("selected-index")).toHaveTextContent("2");
   });
 });
 

--- a/tests/Tabs/TabsSelectedId.test.svelte
+++ b/tests/Tabs/TabsSelectedId.test.svelte
@@ -1,0 +1,65 @@
+<script lang="ts">
+  import Tab from "carbon-components-svelte/Tabs/Tab.svelte";
+  import TabContent from "carbon-components-svelte/Tabs/TabContent.svelte";
+  import Tabs from "carbon-components-svelte/Tabs/Tabs.svelte";
+
+  export let selected = 0;
+  /** `undefined` keeps the index API; set a string to exercise `selectedId`. */
+  export let selectedId: string | undefined = undefined;
+  export let showTabA = true;
+  export let showTabB = true;
+  export let showTabC = true;
+</script>
+
+<Tabs
+  bind:selected
+  bind:selectedId
+  on:change={({ detail }) => {
+    console.log("change event", detail);
+  }}
+>
+  {#if showTabA}
+    <Tab id="tab-a" label="Tab A" />
+  {/if}
+  {#if showTabB}
+    <Tab id="tab-b" label="Tab B" />
+  {/if}
+  {#if showTabC}
+    <Tab id="tab-c" label="Tab C" />
+  {/if}
+  <svelte:fragment slot="content">
+    {#if showTabA}
+      <TabContent id="panel-a">Content A</TabContent>
+    {/if}
+    {#if showTabB}
+      <TabContent id="panel-b">Content B</TabContent>
+    {/if}
+    {#if showTabC}
+      <TabContent id="panel-c">Content C</TabContent>
+    {/if}
+  </svelte:fragment>
+</Tabs>
+
+<button
+  type="button"
+  data-testid="toggle-tab-a"
+  on:click={() => (showTabA = !showTabA)}
+>
+  Toggle Tab A
+</button>
+<button
+  type="button"
+  data-testid="toggle-tab-b"
+  on:click={() => (showTabB = !showTabB)}
+>
+  Toggle Tab B
+</button>
+<button
+  type="button"
+  data-testid="toggle-tab-c"
+  on:click={() => (showTabC = !showTabC)}
+>
+  Toggle Tab C
+</button>
+<div data-testid="selected-index">{selected}</div>
+<div data-testid="selected-id">{selectedId ?? ""}</div>

--- a/tests/Tabs/TabsVertical.test.ts
+++ b/tests/Tabs/TabsVertical.test.ts
@@ -2,6 +2,7 @@ import { fireEvent, render, screen } from "@testing-library/svelte";
 import Calendar from "../../src/icons/Calendar.svelte";
 import { user } from "../utils/user";
 import TabsVertical from "./TabsVertical.test.svelte";
+import TabsVerticalSelectedId from "./TabsVerticalSelectedId.test.svelte";
 import TabsVerticalSkeleton from "./TabsVerticalSkeleton.test.svelte";
 
 describe("TabsVertical", () => {
@@ -149,6 +150,31 @@ describe("TabsVertical", () => {
     expect(
       navLink?.querySelector(".bx--tabs__nav-item--icon svg"),
     ).toBeInTheDocument();
+  });
+
+  it("keeps selectedId on the same logical tab when a prior tab is removed", async () => {
+    render(TabsVerticalSelectedId, {
+      props: { selectedId: "tab-b", showTabA: true },
+    });
+
+    expect(screen.getByRole("tab", { name: "Tab B" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(screen.getByTestId("selected-id")).toHaveTextContent("tab-b");
+    expect(screen.getByTestId("selected-index")).toHaveTextContent("1");
+
+    await user.click(screen.getByTestId("toggle-tab-a"));
+
+    expect(
+      screen.queryByRole("tab", { name: "Tab A" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Tab B" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(screen.getByTestId("selected-id")).toHaveTextContent("tab-b");
+    expect(screen.getByTestId("selected-index")).toHaveTextContent("0");
   });
 });
 

--- a/tests/Tabs/TabsVerticalSelectedId.test.svelte
+++ b/tests/Tabs/TabsVerticalSelectedId.test.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+  import Tab from "carbon-components-svelte/Tabs/Tab.svelte";
+  import TabContent from "carbon-components-svelte/Tabs/TabContent.svelte";
+  import TabsVertical from "carbon-components-svelte/Tabs/TabsVertical.svelte";
+
+  export let selected = 0;
+  /** `undefined` keeps the index API; set a string to exercise `selectedId`. */
+  export let selectedId: string | undefined = undefined;
+  export let showTabA = true;
+</script>
+
+<TabsVertical
+  bind:selected
+  bind:selectedId
+  on:change={({ detail }) => {
+    console.log("change event", detail);
+  }}
+>
+  {#if showTabA}
+    <Tab id="tab-a" label="Tab A" />
+  {/if}
+  <Tab id="tab-b" label="Tab B" />
+  <Tab id="tab-c" label="Tab C" />
+  <svelte:fragment slot="content">
+    {#if showTabA}
+      <TabContent id="panel-a">Content A</TabContent>
+    {/if}
+    <TabContent id="panel-b">Content B</TabContent>
+    <TabContent id="panel-c">Content C</TabContent>
+  </svelte:fragment>
+</TabsVertical>
+
+<button
+  type="button"
+  data-testid="toggle-tab-a"
+  on:click={() => (showTabA = !showTabA)}
+>
+  Toggle Tab A
+</button>
+<div data-testid="selected-index">{selected}</div>
+<div data-testid="selected-id">{selectedId ?? ""}</div>


### PR DESCRIPTION
Bindable selectedId picks tabs by id instead of index so selection stays
on the same logical tab across add/remove; when set it wins over selected.