### PR TITLE
feat(tabs): add lazy and unmountOnHide on TabContent

### DIFF
--- a/docs/src/pages/components/Tabs.svx
+++ b/docs/src/pages/components/Tabs.svx
@@ -4,7 +4,7 @@ description: Tabs organize content into separate views that can be switched betw
 ---
 
 <script>
-  import { Tabs, Tab, TabContent, TabsVertical, TabsSkeleton, TabsVerticalSkeleton } from "carbon-components-svelte";
+  import { Tabs, Tab, TabContent, TabsVertical, TabsSkeleton, TabsVerticalSkeleton, DataTable } from "carbon-components-svelte";
   import Calendar from "carbon-icons-svelte/lib/Calendar.svelte";
   import Information from "carbon-icons-svelte/lib/Information.svelte";
   import Settings from "carbon-icons-svelte/lib/Settings.svelte";
@@ -92,6 +92,51 @@ Tabs can be conditionally rendered using Svelte's `{#if}` blocks. The component 
 If the current selected tab is removed, the next tab is selected.
 
 <FileSource src="/framed/Tabs/TabsConditional" />
+
+## Lazy content
+
+By default, every `TabContent` panel stays mounted and toggles visibility with the `hidden` attribute. Set `lazy` on a panel to defer mounting its slot until that tab is first selected. Set `unmountOnHide` to remove the slot when the tab is deselected — useful for heavy panels such as a DataTable.
+
+<Tabs>
+  <Tab label="Overview" />
+  <Tab label="Load balancers" />
+  <svelte:fragment slot="content">
+    <TabContent>Lightweight overview content.</TabContent>
+    <TabContent lazy>
+      <DataTable
+        headers="{[
+          { key: "name", value: "Name" },
+          { key: "protocol", value: "Protocol" },
+          { key: "port", value: "Port" },
+          { key: "rule", value: "Rule" }
+        ]}"
+        rows="{[
+          {
+            id: "a",
+            name: "Load Balancer 3",
+            protocol: "HTTP",
+            port: 3000,
+            rule: "Round robin"
+          },
+          {
+            id: "b",
+            name: "Load Balancer 1",
+            protocol: "HTTP",
+            port: 443,
+            rule: "Round robin"
+          },
+          {
+            id: "c",
+            name: "Load Balancer 2",
+            protocol: "HTTP",
+            port: 80,
+            rule: "DNS delegation"
+          },
+        ]}"
+      />
+    </TabContent>
+  </svelte:fragment>
+</Tabs>
 
 ## Width
 

--- a/src/Tabs/TabContent.svelte
+++ b/src/Tabs/TabContent.svelte
@@ -2,6 +2,16 @@
   /** Set an id for the top-level element */
   export let id = `ccs-${Math.random().toString(36)}`;
 
+  /**
+   * Set to `true` to defer mounting panel content until this tab is first selected
+   */
+  export let lazy = false;
+
+  /**
+   * Set to `true` to unmount panel content when the tab is deselected
+   */
+  export let unmountOnHide = false;
+
   import { getContext, onMount } from "svelte";
 
   const { selectedContent, addContent, removeContent, tabs, contentById } =
@@ -15,9 +25,13 @@
     };
   });
 
+  let hasBeenSelected = false;
+
   $: selected = $selectedContent === id;
+  $: if (selected) hasBeenSelected = true;
   $: index = $contentById[id]?.index ?? 0;
   $: tabId = $tabs[index]?.id;
+  $: shouldMount = unmountOnHide ? selected : lazy ? hasBeenSelected : true;
 </script>
 
 <div
@@ -29,5 +43,7 @@
   class:bx--tab-content={true}
   {...$$restProps}
 >
-  <slot />
+  {#if shouldMount}
+    <slot />
+  {/if}
 </div>

--- a/tests/Tabs/Tabs.test.ts
+++ b/tests/Tabs/Tabs.test.ts
@@ -13,6 +13,7 @@ import TabSlot from "./TabSlot.test.svelte";
 import Tabs from "./Tabs.test.svelte";
 import TabsAllDisabled from "./TabsAllDisabled.test.svelte";
 import TabsDynamic from "./TabsDynamic.test.svelte";
+import TabsLazy from "./TabsLazy.test.svelte";
 import TabsSkeleton from "./TabsSkeleton.test.svelte";
 
 describe("Tabs", () => {
@@ -885,6 +886,63 @@ describe("TabsSkeleton", () => {
 
       // biome-ignore lint/suspicious/noExplicitAny: Testing default any type
       expectTypeOf<Props["icon"]>().toEqualTypeOf<any>();
+    });
+  });
+
+  describe("TabContent lazy and unmountOnHide", () => {
+    it("keeps unselected content in the DOM with the hidden attribute by default", () => {
+      render(TabsLazy);
+
+      expect(screen.getByText("Content 1")).toBeVisible();
+      expect(screen.getByText("Content 2")).not.toBeVisible();
+      expect(screen.getByText("Content 3")).not.toBeVisible();
+
+      const panels = screen.getAllByRole("tabpanel", { hidden: true });
+      expect(panels[1]).toHaveAttribute("hidden");
+      expect(panels[2]).toHaveAttribute("hidden");
+    });
+
+    it("does not mount lazy content until the tab is first selected", async () => {
+      render(TabsLazy, { props: { lazy: true } });
+
+      expect(screen.getByText("Content 1")).toBeInTheDocument();
+      expect(screen.queryByText("Content 2")).not.toBeInTheDocument();
+      expect(screen.queryByText("Content 3")).not.toBeInTheDocument();
+
+      await user.click(screen.getByRole("tab", { name: "Tab 2" }));
+
+      expect(screen.getByText("Content 2")).toBeVisible();
+      expect(screen.queryByText("Content 3")).not.toBeInTheDocument();
+
+      await user.click(screen.getByRole("tab", { name: "Tab 1" }));
+
+      expect(screen.getByText("Content 2")).toBeInTheDocument();
+      expect(screen.getByText("Content 2")).not.toBeVisible();
+    });
+
+    it("unmounts content when deselected with unmountOnHide", async () => {
+      render(TabsLazy, { props: { unmountOnHide: true } });
+
+      expect(screen.getByText("Content 1")).toBeVisible();
+      expect(screen.queryByText("Content 2")).not.toBeInTheDocument();
+
+      await user.click(screen.getByRole("tab", { name: "Tab 2" }));
+
+      expect(screen.getByText("Content 2")).toBeVisible();
+      expect(screen.queryByText("Content 1")).not.toBeInTheDocument();
+
+      await user.click(screen.getByRole("tab", { name: "Tab 1" }));
+
+      expect(screen.getByText("Content 1")).toBeVisible();
+      expect(screen.queryByText("Content 2")).not.toBeInTheDocument();
+    });
+
+    it("mounts lazy content on the initially selected tab", () => {
+      render(TabsLazy, { props: { selected: 1, lazy: true } });
+
+      expect(screen.queryByText("Content 1")).not.toBeInTheDocument();
+      expect(screen.getByText("Content 2")).toBeVisible();
+      expect(screen.queryByText("Content 3")).not.toBeInTheDocument();
     });
   });
 });

--- a/tests/Tabs/TabsLazy.test.svelte
+++ b/tests/Tabs/TabsLazy.test.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+  import Tab from "carbon-components-svelte/Tabs/Tab.svelte";
+  import TabContent from "carbon-components-svelte/Tabs/TabContent.svelte";
+  import Tabs from "carbon-components-svelte/Tabs/Tabs.svelte";
+
+  export let selected = 0;
+  export let lazy = false;
+  export let unmountOnHide = false;
+</script>
+
+<Tabs {selected}>
+  <Tab label="Tab 1" />
+  <Tab label="Tab 2" />
+  <Tab label="Tab 3" />
+  <svelte:fragment slot="content">
+    <TabContent {lazy} {unmountOnHide}>Content 1</TabContent>
+    <TabContent {lazy} {unmountOnHide}>Content 2</TabContent>
+    <TabContent {lazy} {unmountOnHide}>Content 3</TabContent>
+  </svelte:fragment>
+</Tabs>


### PR DESCRIPTION
lazy and unmountOnHide on TabContent defer mounting inactive panes and
can tear them down when hidden to cut initial work.