### PR TITLE
feat(tabs): add extra slot for tab bar actions

### DIFF
--- a/css/_tabs.scss
+++ b/css/_tabs.scss
@@ -362,6 +362,37 @@
   @include tabs-overflow;
 }
 
+/// Tab bar `extra` slot: right-aligned actions outside the scrollable nav so
+/// overflow chevron math still measures the tab list alone.
+/// @access private
+/// @group components
+@mixin tabs-extra {
+  .#{$prefix}--tabs--with-extra {
+    display: flex;
+    align-items: stretch;
+    width: 100%;
+  }
+
+  // Shrink the scrollport when actions take space; overflow still reads the
+  // nav's own scrollWidth / clientWidth (extra is a sibling, not a child).
+  .#{$prefix}--tabs--with-extra .#{$prefix}--tabs__nav {
+    flex: 1 1 auto;
+    min-inline-size: 0;
+  }
+
+  .#{$prefix}--tabs__extra {
+    display: flex;
+    flex-shrink: 0;
+    align-items: center;
+    margin-inline-start: auto;
+    padding-inline-start: $carbon--spacing-05;
+  }
+}
+
+@include exports('tabs-extra') {
+  @include tabs-extra;
+}
+
 /// Tab full-width styles
 /// @access private
 /// @group components

--- a/docs/src/pages/components/Tabs.svx
+++ b/docs/src/pages/components/Tabs.svx
@@ -4,7 +4,7 @@ description: Tabs organize content into separate views that can be switched betw
 ---
 
 <script>
-  import { Tabs, Tab, TabContent, TabsVertical, TabsSkeleton, TabsVerticalSkeleton, DataTable } from "carbon-components-svelte";
+  import { Tabs, Tab, TabContent, TabsVertical, TabsSkeleton, TabsVerticalSkeleton, DataTable, Button } from "carbon-components-svelte";
   import Calendar from "carbon-icons-svelte/lib/Calendar.svelte";
   import Information from "carbon-icons-svelte/lib/Information.svelte";
   import Settings from "carbon-icons-svelte/lib/Settings.svelte";
@@ -78,6 +78,24 @@ activation when switching panels is expensive.
   <Tab label="Tab label 1" />
   <Tab label="Tab label 2" />
   <Tab label="Tab label 3" />
+  <svelte:fragment slot="content">
+    <TabContent>Content 1</TabContent>
+    <TabContent>Content 2</TabContent>
+    <TabContent>Content 3</TabContent>
+  </svelte:fragment>
+</Tabs>
+
+## Tab bar actions
+
+Render right-aligned controls beside the tab list with the `extra` slot. The
+content sits outside the scrollable nav, so overflow buttons still measure the
+tabs alone.
+
+<Tabs>
+  <Tab label="Tab label 1" />
+  <Tab label="Tab label 2" />
+  <Tab label="Tab label 3" />
+  <Button slot="extra" kind="ghost" size="field">New tab</Button>
   <svelte:fragment slot="content">
     <TabContent>Content 1</TabContent>
     <TabContent>Content 2</TabContent>

--- a/src/Tabs/Tabs.svelte
+++ b/src/Tabs/Tabs.svelte
@@ -2,6 +2,7 @@
   /**
    * @event {number} change
    * @event {{ id: string; label: string; disabled: boolean; hasSecondaryLabel: boolean; index: number }} dismiss
+   * @slot {{}} extra - Right-aligned tab bar actions outside the scrollable list.
    */
 
   /**
@@ -359,6 +360,7 @@
   $: useFullWidth.set(fullWidth);
   $: useDismissible.set(dismissible);
   $: useIconOnly.set(iconOnly);
+  $: hasExtra = $$slots.extra;
 </script>
 
 <div
@@ -373,6 +375,7 @@
   class:bx--tabs__icon--lg={iconOnly && iconSize === "lg"}
   class:bx--tabs--scrollable={isOverflow}
   class:bx--tabs--scrollable--container={isOverflow && type === "container"}
+  class:bx--tabs--with-extra={hasExtra}
   {...$$restProps}
 >
   {#if isOverflow}
@@ -425,6 +428,11 @@
     >
       <ChevronRight />
     </button>
+  {/if}
+  {#if hasExtra}
+    <div class:bx--tabs__extra={true}>
+      <slot name="extra" />
+    </div>
   {/if}
 </div>
 <slot name="content" />

--- a/tests/Tabs/Tabs.test.ts
+++ b/tests/Tabs/Tabs.test.ts
@@ -13,6 +13,7 @@ import TabSlot from "./TabSlot.test.svelte";
 import Tabs from "./Tabs.test.svelte";
 import TabsAllDisabled from "./TabsAllDisabled.test.svelte";
 import TabsDynamic from "./TabsDynamic.test.svelte";
+import TabsExtra from "./TabsExtra.test.svelte";
 import TabsLazy from "./TabsLazy.test.svelte";
 import TabsSkeleton from "./TabsSkeleton.test.svelte";
 
@@ -300,6 +301,70 @@ describe("Tabs", () => {
     await fireEvent.scroll(nav);
     expect(prev).not.toHaveClass("bx--tab--overflow-nav-button--hidden");
     expect(next).toHaveClass("bx--tab--overflow-nav-button--hidden");
+  });
+
+  describe("extra slot", () => {
+    it("renders extra content outside the tab list", () => {
+      const { container } = render(TabsExtra);
+
+      const tablist = screen.getByRole("tablist");
+      const extra = screen.getByRole("button", { name: "New tab" });
+
+      expect(extra).toBeInTheDocument();
+      expect(tablist).not.toContainElement(extra);
+      expect(extra.closest(".bx--tabs__extra")).toBeInTheDocument();
+      expect(
+        container.querySelector(".bx--tabs--with-extra"),
+      ).toBeInTheDocument();
+    });
+
+    it("does not render the extra wrapper without the slot", () => {
+      const { container } = render(TabsExtra, {
+        props: { withExtra: false },
+      });
+
+      expect(
+        container.querySelector(".bx--tabs__extra"),
+      ).not.toBeInTheDocument();
+      expect(
+        container.querySelector(".bx--tabs--with-extra"),
+      ).not.toBeInTheDocument();
+    });
+
+    // Extra is a sibling of the nav, so overflow still reads only the tablist
+    // scroll metrics — extra width does not inflate scrollWidth.
+    it("computes overflow from the tablist without including extra width", async () => {
+      const { container } = render(TabsExtra);
+
+      const nav = screen.getByRole("tablist");
+      const extra = screen.getByRole("button", { name: "New tab" });
+
+      Object.defineProperty(extra, "offsetWidth", {
+        configurable: true,
+        value: 120,
+      });
+      Object.defineProperty(nav, "scrollWidth", {
+        configurable: true,
+        value: 600,
+      });
+      Object.defineProperty(nav, "clientWidth", {
+        configurable: true,
+        value: 200,
+      });
+      Object.defineProperty(nav, "scrollLeft", {
+        configurable: true,
+        writable: true,
+        value: 0,
+      });
+      await fireEvent.scroll(nav);
+
+      const next = container.querySelector(
+        ".bx--tab--overflow-nav-button--next",
+      );
+      expect(next).toBeInTheDocument();
+      expect(next).not.toHaveClass("bx--tab--overflow-nav-button--hidden");
+      expect(nav).not.toContainElement(extra);
+    });
   });
 
   it("should apply custom class", () => {

--- a/tests/Tabs/TabsExtra.test.svelte
+++ b/tests/Tabs/TabsExtra.test.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+  import Tab from "carbon-components-svelte/Tabs/Tab.svelte";
+  import TabContent from "carbon-components-svelte/Tabs/TabContent.svelte";
+  import Tabs from "carbon-components-svelte/Tabs/Tabs.svelte";
+
+  export let withExtra = true;
+</script>
+
+{#if withExtra}
+  <Tabs>
+    <Tab label="Tab 1" />
+    <Tab label="Tab 2" />
+    <Tab label="Tab 3" />
+    <button type="button" slot="extra">New tab</button>
+    <svelte:fragment slot="content">
+      <TabContent>Content 1</TabContent>
+      <TabContent>Content 2</TabContent>
+      <TabContent>Content 3</TabContent>
+    </svelte:fragment>
+  </Tabs>
+{:else}
+  <Tabs>
+    <Tab label="Tab 1" />
+    <Tab label="Tab 2" />
+    <Tab label="Tab 3" />
+    <svelte:fragment slot="content">
+      <TabContent>Content 1</TabContent>
+      <TabContent>Content 2</TabContent>
+      <TabContent>Content 3</TabContent>
+    </svelte:fragment>
+  </Tabs>
+{/if}


### PR DESCRIPTION
extra slot on Tabs places actions beside the tab list without breaking
keyboard navigation of the tabs themselves.