### PR TITLE
feat(tabs): add activation automatic or manual

### DIFF
--- a/docs/src/pages/components/Tabs.svx
+++ b/docs/src/pages/components/Tabs.svx
@@ -67,6 +67,24 @@ Below the medium breakpoint, vertical tabs collapse into the same horizontal, sc
 
 <FileSource src="/framed/Tabs/TabsVerticalOverflow" />
 
+## Manual activation
+
+By default, tabs use automatic activation: arrow keys move focus and select the
+tab. Set `activation` to `"manual"` so arrow keys only move focus; press
+<DocKbd label="Enter" /> or <DocKbd label="Space" /> to select. Use manual
+activation when switching panels is expensive.
+
+<Tabs activation="manual">
+  <Tab label="Tab label 1" />
+  <Tab label="Tab label 2" />
+  <Tab label="Tab label 3" />
+  <svelte:fragment slot="content">
+    <TabContent>Content 1</TabContent>
+    <TabContent>Content 2</TabContent>
+    <TabContent>Content 3</TabContent>
+  </svelte:fragment>
+</Tabs>
+
 ## Disabled tabs
 
 Set `disabled` on a tab to prevent interaction. Keyboard navigation skips disabled
@@ -452,6 +470,7 @@ Show a loading state for the container tab variant.
 Use TabsVertical for a tab list beside the panel. Compose it with the same Tab and
 TabContent components. From the medium breakpoint up, tabs stack in a vertical column.
 On narrower screens, the list becomes a horizontal row with overflow scrolling.
+`activation` works the same as on Tabs (see [Manual activation](#manual-activation)).
 
 <TabsVertical>
   <Tab label="Dashboard" />

--- a/src/Tabs/Tabs.svelte
+++ b/src/Tabs/Tabs.svelte
@@ -11,6 +11,14 @@
   export let selected = 0;
 
   /**
+   * Choose whether arrow keys change the selection on focus.
+   * Defaults to `"automatic"`. Set to `"manual"` so arrow keys only move
+   * focus; press Enter or Space to select.
+   * @type {"automatic" | "manual"}
+   */
+  export let activation = "automatic";
+
+  /**
    * Specify the type of tabs.
    * @type {"default" | "container"}
    */
@@ -180,6 +188,7 @@
    */
   function update(id) {
     currentIndex = $tabsById[id].index;
+    focusedIndex = -1;
   }
 
   /**
@@ -224,14 +233,34 @@
   }
 
   /**
+   * Focus a tab at an absolute index without changing selection.
+   * @type {(index: number) => Promise<void>}
+   */
+  async function focusTab(index) {
+    if (index < 0 || index >= $tabs.length) return;
+    focusedIndex = index;
+
+    await tick();
+    const activeTab = /** @type {HTMLElement | undefined} */ (
+      refTabList?.querySelectorAll("[role='tab']")[index]
+    );
+    activeTab?.focus({ preventScroll: true });
+    scrollTabIntoView(activeTab);
+  }
+
+  /**
    * Move selection/focus to a tab at an absolute index. Roving focus resolves
    * the index (skipping disabled, wrapping); selection follows focus.
    * @type {(index: number) => Promise<void>}
    */
   async function selectTab(index) {
-    if (index === currentIndex) return;
+    if (index === currentIndex) {
+      focusedIndex = -1;
+      return;
+    }
 
     currentIndex = index;
+    focusedIndex = -1;
 
     await tick();
     const activeTab = /** @type {HTMLElement | undefined} */ (
@@ -304,9 +333,13 @@
   });
 
   let currentIndex = selected;
+  let focusedIndex = -1;
   let prevIndex = -1;
 
-  $: currentIndex = selected;
+  $: {
+    currentIndex = selected;
+    focusedIndex = -1;
+  }
   $: currentTab = $tabs[currentIndex] || undefined;
   $: currentContent = $content[currentIndex] || undefined;
   $: {
@@ -367,8 +400,9 @@
       selector: "[role='tab']",
       orientation: "horizontal",
       skipDisabled: true,
-      getActiveIndex: () => currentIndex,
-      onMove: (index) => selectTab(index),
+      getActiveIndex: () => (focusedIndex >= 0 ? focusedIndex : currentIndex),
+      onMove: (index) =>
+        activation === "manual" ? focusTab(index) : selectTab(index),
     }}
     class:bx--tabs__nav={true}
     on:scroll={updateOverflow}

--- a/src/Tabs/TabsVertical.svelte
+++ b/src/Tabs/TabsVertical.svelte
@@ -10,6 +10,14 @@
   export let selected = 0;
 
   /**
+   * Choose whether arrow keys change the selection on focus.
+   * Defaults to `"automatic"`. Set to `"manual"` so arrow keys only move
+   * focus; press Enter or Space to select.
+   * @type {"automatic" | "manual"}
+   */
+  export let activation = "automatic";
+
+  /**
    * Specify the size of the vertical tabs.
    * `"xl"` matches the default height.
    * @type {"sm" | "md" | "lg" | "xl"}
@@ -171,10 +179,27 @@
    */
   function update(id) {
     currentIndex = $tabsById[id].index;
+    focusedIndex = -1;
   }
 
   // Vertical tabs are never dismissible; this no-op satisfies the `Tab` context.
   function dismiss() {}
+
+  /**
+   * Focus a tab at an absolute index without changing selection.
+   * @type {(index: number) => Promise<void>}
+   */
+  async function focusTab(index) {
+    if (index < 0 || index >= $tabs.length) return;
+    focusedIndex = index;
+
+    await tick();
+    const activeTab = /** @type {HTMLElement | undefined} */ (
+      refTabList?.querySelectorAll("[role='tab']")[index]
+    );
+    activeTab?.focus({ preventScroll: $belowMd });
+    if ($belowMd) scrollTabIntoView(activeTab);
+  }
 
   /**
    * Move selection/focus to a tab at an absolute index. Roving focus resolves
@@ -182,9 +207,13 @@
    * @type {(index: number) => Promise<void>}
    */
   async function selectTab(index) {
-    if (index === currentIndex) return;
+    if (index === currentIndex) {
+      focusedIndex = -1;
+      return;
+    }
 
     currentIndex = index;
+    focusedIndex = -1;
 
     await tick();
     const activeTab = /** @type {HTMLElement | undefined} */ (
@@ -260,9 +289,13 @@
   });
 
   let currentIndex = selected;
+  let focusedIndex = -1;
   let prevIndex = -1;
 
-  $: currentIndex = selected;
+  $: {
+    currentIndex = selected;
+    focusedIndex = -1;
+  }
   $: currentTab = $tabs[currentIndex] || undefined;
   $: currentContent = $content[currentIndex] || undefined;
   $: {
@@ -323,11 +356,15 @@
         selector: "[role='tab']",
         orientation,
         skipDisabled: true,
-        getActiveIndex: () => currentIndex,
+        getActiveIndex: () => (focusedIndex >= 0 ? focusedIndex : currentIndex),
         onMove: (index, event) => {
           // Prevent the arrow keys from also scrolling the page.
           event.preventDefault();
-          selectTab(index);
+          if (activation === "manual") {
+            focusTab(index);
+          } else {
+            selectTab(index);
+          }
         },
       }}
       class:bx--tabs__nav={true}

--- a/tests/Tabs/Tabs.test.svelte
+++ b/tests/Tabs/Tabs.test.svelte
@@ -5,6 +5,7 @@
   import type { ComponentProps } from "svelte";
 
   export let selected = 0;
+  export let activation: ComponentProps<Tabs>["activation"] = "automatic";
   export let type: ComponentProps<Tabs>["type"] = "default";
   export let autoWidth = false;
   export let fullWidth = false;
@@ -14,6 +15,7 @@
 
 <Tabs
   {selected}
+  {activation}
   {type}
   {autoWidth}
   {fullWidth}

--- a/tests/Tabs/Tabs.test.ts
+++ b/tests/Tabs/Tabs.test.ts
@@ -156,6 +156,57 @@ describe("Tabs", () => {
     expect(consoleLog).toHaveBeenCalledWith("change event", 0);
   });
 
+  describe('activation="manual"', () => {
+    it("ArrowRight moves focus without changing selection", async () => {
+      render(Tabs, { props: { activation: "manual" } });
+
+      const tab1 = screen.getByRole("tab", { name: "Tab 1" });
+      const tab3 = screen.getByRole("tab", { name: "Tab 3" });
+      await user.click(tab1);
+
+      await user.keyboard("{ArrowRight}");
+      expect(tab3).toHaveFocus();
+      expect(tab1).toHaveAttribute("aria-selected", "true");
+      expect(tab3).toHaveAttribute("aria-selected", "false");
+      expect(screen.getByText("Content 1")).toBeVisible();
+      expect(consoleLog).not.toHaveBeenCalledWith("change event", 2);
+    });
+
+    it("Enter selects the focused tab", async () => {
+      render(Tabs, { props: { activation: "manual" } });
+
+      const tab1 = screen.getByRole("tab", { name: "Tab 1" });
+      const tab3 = screen.getByRole("tab", { name: "Tab 3" });
+      await user.click(tab1);
+
+      await user.keyboard("{ArrowRight}");
+      expect(tab3).toHaveFocus();
+      expect(tab1).toHaveAttribute("aria-selected", "true");
+
+      await user.keyboard("{Enter}");
+      expect(tab3).toHaveAttribute("aria-selected", "true");
+      expect(tab1).toHaveAttribute("aria-selected", "false");
+      expect(screen.getByText("Content 3")).toBeVisible();
+      expect(consoleLog).toHaveBeenCalledWith("change event", 2);
+    });
+
+    it("Space selects the focused tab", async () => {
+      render(Tabs, { props: { activation: "manual" } });
+
+      const tab1 = screen.getByRole("tab", { name: "Tab 1" });
+      const tab3 = screen.getByRole("tab", { name: "Tab 3" });
+      await user.click(tab1);
+
+      await user.keyboard("{ArrowRight}");
+      expect(tab3).toHaveFocus();
+
+      await user.keyboard(" ");
+      expect(tab3).toHaveAttribute("aria-selected", "true");
+      expect(tab1).toHaveAttribute("aria-selected", "false");
+      expect(consoleLog).toHaveBeenCalledWith("change event", 2);
+    });
+  });
+
   it("uses an empty aria-label when passed an empty string", () => {
     render(Tabs, { props: { ariaLabel: "" } });
     const nav = screen.getByRole("navigation");

--- a/tests/Tabs/TabsVertical.test.svelte
+++ b/tests/Tabs/TabsVertical.test.svelte
@@ -5,12 +5,15 @@
   import type { ComponentProps } from "svelte";
 
   export let selected = 0;
+  export let activation: ComponentProps<TabsVertical>["activation"] =
+    "automatic";
   export let icon: ComponentProps<Tab>["icon"] = undefined;
   export let size: ComponentProps<TabsVertical>["size"] = undefined;
 </script>
 
 <TabsVertical
   {selected}
+  {activation}
   {size}
   on:change={({ detail }) => {
     console.log("change event", detail);

--- a/tests/Tabs/TabsVertical.test.ts
+++ b/tests/Tabs/TabsVertical.test.ts
@@ -99,6 +99,40 @@ describe("TabsVertical", () => {
     expect(consoleLog).toHaveBeenCalledWith("change event", 0);
   });
 
+  describe('activation="manual"', () => {
+    it("ArrowDown moves focus without changing selection", async () => {
+      render(TabsVertical, { props: { activation: "manual" } });
+
+      const tab1 = screen.getByRole("tab", { name: "Tab 1" });
+      const tab3 = screen.getByRole("tab", { name: "Tab 3" });
+      await user.click(tab1);
+
+      await user.keyboard("{ArrowDown}");
+      expect(tab3).toHaveFocus();
+      expect(tab1).toHaveAttribute("aria-selected", "true");
+      expect(tab3).toHaveAttribute("aria-selected", "false");
+      expect(screen.getByText("Content 1")).toBeVisible();
+      expect(consoleLog).not.toHaveBeenCalledWith("change event", 2);
+    });
+
+    it("Enter selects the focused tab", async () => {
+      render(TabsVertical, { props: { activation: "manual" } });
+
+      const tab1 = screen.getByRole("tab", { name: "Tab 1" });
+      const tab3 = screen.getByRole("tab", { name: "Tab 3" });
+      await user.click(tab1);
+
+      await user.keyboard("{ArrowDown}");
+      expect(tab3).toHaveFocus();
+
+      await user.keyboard("{Enter}");
+      expect(tab3).toHaveAttribute("aria-selected", "true");
+      expect(tab1).toHaveAttribute("aria-selected", "false");
+      expect(screen.getByText("Content 3")).toBeVisible();
+      expect(consoleLog).toHaveBeenCalledWith("change event", 2);
+    });
+  });
+
   it("should prevent the default scroll on arrow navigation", async () => {
     render(TabsVertical);
 


### PR DESCRIPTION
activation="manual" moves focus with arrows but selects only on
Enter/Space (automatic remains the default), matching ContentSwitcher
selectionMode.