### PR TITLE
feat(contained-list): add search header slot

### DIFF
--- a/css/_contained-list.scss
+++ b/css/_contained-list.scss
@@ -29,6 +29,10 @@
     width: 100%;
   }
 
+  .#{$prefix}--contained-list__search {
+    width: 100%;
+  }
+
   .#{$prefix}--contained-list .#{$prefix}--search {
     position: sticky;
     z-index: 1;

--- a/docs/src/pages/components/ContainedList.svx
+++ b/docs/src/pages/components/ContainedList.svx
@@ -103,14 +103,14 @@ Add icons using the `icon` prop. Icons appear to the left of each item.
 
 ## Search
 
-Add a search input to filter list items.
+Use the `search` slot to compose [Search](/components/Search) below the list header. ContainedList does not filter items; bind the search value and filter the list in your app. The `action` slot can still hold a separate header control alongside search.
 
 ### Expandable
 
-Use the `action` slot on the list to add an expandable search control in the header.
+Set `expandable` on Search in the `search` slot for a collapsible filter. You can also place expandable Search in the `action` slot when it should sit in the header row.
 
 <ContainedList labelText="List title">
-  <Search slot="action" expandable />
+  <Search slot="search" expandable placeholder="Filter" />
   <ContainedListItem>Item 1</ContainedListItem>
   <ContainedListItem>Item 2</ContainedListItem>
   <ContainedListItem>Item 3</ContainedListItem>
@@ -118,9 +118,15 @@ Use the `action` slot on the list to add an expandable search control in the hea
 
 ### Persistent
 
-Place the search as a direct child (not in the action slot) for a persistent filter below the title. The input is styled for list headers and works with sticky headers.
+Use a non-expandable Search in the `search` slot for a persistent filter below the title. The input uses list-search styling and works with sticky headers.
 
 <FileSource src="/framed/ContainedList/PersistentSearch" />
+
+### Filterable members
+
+Filter a member list by binding Search `value` and rendering only matching items.
+
+<FileSource src="/framed/ContainedList/FilterableMembers" />
 
 ## Interactive items
 

--- a/docs/src/pages/framed/ContainedList/FilterableMembers.svelte
+++ b/docs/src/pages/framed/ContainedList/FilterableMembers.svelte
@@ -1,0 +1,31 @@
+<script>
+  import {
+    ContainedList,
+    ContainedListItem,
+    Search,
+  } from "carbon-components-svelte";
+
+  const members = [
+    "Amelia Chen",
+    "Diego Morales",
+    "Harper Patel",
+    "Jordan Lee",
+    "Maya Okonkwo",
+    "Noah Bergman",
+    "Priya Shah",
+    "Samir Haddad",
+  ];
+
+  let searchTerm = "";
+
+  $: filteredMembers = members.filter((member) =>
+    member.toLowerCase().includes(searchTerm.toLowerCase()),
+  );
+</script>
+
+<ContainedList labelText="Team members">
+  <Search slot="search" placeholder="Filter members" bind:value={searchTerm} />
+  {#each filteredMembers as member (member)}
+    <ContainedListItem>{member}</ContainedListItem>
+  {/each}
+</ContainedList>

--- a/docs/src/pages/framed/ContainedList/PersistentSearch.svelte
+++ b/docs/src/pages/framed/ContainedList/PersistentSearch.svelte
@@ -19,7 +19,11 @@
 </script>
 
 <ContainedList kind="disclosed" labelText="List title">
-  <Search placeholder="Filterable search" bind:value={searchTerm} />
+  <Search
+    slot="search"
+    placeholder="Filterable search"
+    bind:value={searchTerm}
+  />
   {#each filteredResults as item}
     <ContainedListItem>{item}</ContainedListItem>
   {/each}

--- a/src/ContainedList/ContainedList.svelte
+++ b/src/ContainedList/ContainedList.svelte
@@ -1,5 +1,12 @@
 <script>
   /**
+   * @slot {{}} labelChildren - Custom label content. Overrides `labelText`.
+   * @slot {{}} action - Interactive control in the header (for example a button or expandable Search).
+   * @slot {{}} search - Search field below the header. Compose `Search` or expandable `Search`; filtering stays consumer-side.
+   * @slot {{}}
+   */
+
+  /**
    * Specify the kind of contained list.
    * @type {"on-page" | "disclosed"}
    */
@@ -24,6 +31,8 @@
   export let id = `ccs-${Math.random().toString(36)}`;
 
   $: labelId = `label-${id}`;
+  $: hasLabel = Boolean(labelText || $$slots.labelChildren);
+  $: hasHeader = Boolean(hasLabel || $$slots.action);
 </script>
 
 <div
@@ -40,7 +49,7 @@
   class:bx--contained-list--on-page="{kind === 'on-page'}"
   class:bx--contained-list--disclosed="{kind === 'disclosed'}"
 >
-  {#if labelText || $$slots.labelChildren || $$slots.action}
+  {#if hasHeader}
     <div
       class:bx--contained-list__header="{true}"
       class:bx--layout--size-sm={kind !== 'disclosed' && size === 'sm'}
@@ -48,7 +57,7 @@
       class:bx--layout--size-lg={kind !== 'disclosed' && size === 'lg'}
       class:bx--layout--size-xl={kind !== 'disclosed' && size === 'xl'}
     >
-      {#if labelText || $$slots.labelChildren}
+      {#if hasLabel}
         <div id="{labelId}" class:bx--contained-list__label="{true}">
           <slot name="labelChildren"> {labelText} </slot>
         </div>
@@ -60,9 +69,12 @@
       {/if}
     </div>
   {/if}
-  <ul
-    aria-labelledby={labelText || $$slots.labelChildren ? labelId : undefined}
-  >
+  {#if $$slots.search}
+    <div class:bx--contained-list__search="{true}">
+      <slot name="search" />
+    </div>
+  {/if}
+  <ul aria-labelledby={hasLabel ? labelId : undefined}>
     <slot />
   </ul>
 </div>

--- a/tests/ContainedList/ContainedList.search.test.svelte
+++ b/tests/ContainedList/ContainedList.search.test.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+  import ContainedList from "carbon-components-svelte/ContainedList/ContainedList.svelte";
+  import ContainedListItem from "carbon-components-svelte/ContainedList/ContainedListItem.svelte";
+  import Search from "carbon-components-svelte/Search/Search.svelte";
+
+  export let expandable = false;
+</script>
+
+<ContainedList labelText="List title">
+  <Search slot="search" {expandable} placeholder="Filter" />
+  <ContainedListItem>Item 1</ContainedListItem>
+  <ContainedListItem>Item 2</ContainedListItem>
+  <ContainedListItem>Item 3</ContainedListItem>
+</ContainedList>

--- a/tests/ContainedList/ContainedList.searchAction.test.svelte
+++ b/tests/ContainedList/ContainedList.searchAction.test.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  import Button from "carbon-components-svelte/Button/Button.svelte";
+  import ContainedList from "carbon-components-svelte/ContainedList/ContainedList.svelte";
+  import ContainedListItem from "carbon-components-svelte/ContainedList/ContainedListItem.svelte";
+  import Search from "carbon-components-svelte/Search/Search.svelte";
+  import Close from "carbon-icons-svelte/lib/Close.svelte";
+</script>
+
+<ContainedList labelText="List title">
+  <Button slot="action" kind="ghost" icon={Close} iconDescription="Action" />
+  <Search slot="search" placeholder="Filter" />
+  <ContainedListItem>Item 1</ContainedListItem>
+  <ContainedListItem>Item 2</ContainedListItem>
+  <ContainedListItem>Item 3</ContainedListItem>
+</ContainedList>

--- a/tests/ContainedList/ContainedList.test.ts
+++ b/tests/ContainedList/ContainedList.test.ts
@@ -3,6 +3,8 @@ import type ContainedListItemComponent from "carbon-components-svelte/ContainedL
 import type { ComponentProps } from "svelte";
 import { user } from "../utils/user";
 import ContainedListLabelChildren from "./ContainedList.labelChildren.test.svelte";
+import ContainedListSearch from "./ContainedList.search.test.svelte";
+import ContainedListSearchAction from "./ContainedList.searchAction.test.svelte";
 import ContainedList from "./ContainedList.test.svelte";
 import ContainedListItemAction from "./ContainedListItem.action.test.svelte";
 
@@ -124,6 +126,36 @@ describe("ContainedList", () => {
 
     const search = screen.getByRole("searchbox");
     expect(search).toBeInTheDocument();
+  });
+
+  it("should render search slot below the header", () => {
+    const { container } = render(ContainedListSearch);
+
+    const search = screen.getByRole("searchbox");
+    expect(search).toBeInTheDocument();
+
+    const searchRegion = container.querySelector(".bx--contained-list__search");
+    expect(searchRegion).toBeInTheDocument();
+    expect(searchRegion?.contains(search)).toBe(true);
+
+    const list = screen.getByRole("list");
+    expect(list.contains(search)).toBe(false);
+
+    const header = container.querySelector(".bx--contained-list__header");
+    expect(header?.nextElementSibling).toBe(searchRegion);
+  });
+
+  it("should render action and search slots together", () => {
+    const { container } = render(ContainedListSearchAction);
+
+    expect(screen.getByRole("button", { name: "Action" })).toBeInTheDocument();
+    expect(screen.getByRole("searchbox")).toBeInTheDocument();
+    expect(
+      container.querySelector(".bx--contained-list__action"),
+    ).toBeInTheDocument();
+    expect(
+      container.querySelector(".bx--contained-list__search"),
+    ).toBeInTheDocument();
   });
 
   it("should render list items", () => {


### PR DESCRIPTION
Named search slot under the ContainedList header for composing Search;
filtering stays consumer-side.

---

![contained-list search slot filter example](https://gist.githubusercontent.com/metonym/d9b29b3953114277a3456adb7ac550bc/raw/225210b6f94df1feeb2a15f3a4f4f06a2766a24c/contained-list-search.png)
