### PR TITLE
feat(contained-list): support href on ContainedListItem

### DIFF
--- a/docs/src/pages/components/ContainedList.svx
+++ b/docs/src/pages/components/ContainedList.svx
@@ -1,6 +1,6 @@
 ---
 components: ["ContainedList", "ContainedListItem"]
-description: Contained lists display items within a labeled container, with support for multiple sizes, icons, actions, interactive items, and search.
+description: Contained lists display items within a labeled container, with support for multiple sizes, icons, actions, interactive items, links, and search.
 ---
 
 <script>
@@ -152,5 +152,22 @@ Use the `action` slot on an item for trailing controls such as buttons or icons.
   <ContainedListItem interactive disabled>Item 2</ContainedListItem>
   <ContainedListItem interactive>
     Item 3
+  </ContainedListItem>
+</ContainedList>
+
+## Link items
+
+Set `href` to render a list item as an anchor with clickable styles. Prefer this for navigation so links support middle-click and SEO. `href` takes precedence over `interactive`. Pass `target` and `rel` through rest props on the item.
+
+<ContainedList labelText="Related resources">
+  <ContainedListItem href="https://carbondesignsystem.com/">
+    Carbon Design System
+  </ContainedListItem>
+  <ContainedListItem href="https://svelte.dev/">Svelte</ContainedListItem>
+  <ContainedListItem
+    href="https://github.com/carbon-design-system/carbon-components-svelte"
+    target="_blank"
+  >
+    carbon-components-svelte
   </ContainedListItem>
 </ContainedList>

--- a/src/ContainedList/ContainedListItem.svelte
+++ b/src/ContainedList/ContainedListItem.svelte
@@ -1,6 +1,7 @@
 <script>
   /**
    * @template [Icon=any]
+   * @restProps {a | button | div}
    */
 
   /** Set to `true` to render a `button` element instead of a `div` */
@@ -10,22 +11,36 @@
   export let disabled = false;
 
   /**
+   * Specify the `href` attribute.
+   * Renders an anchor with clickable styles. Takes precedence over `interactive`.
+   * @type {string}
+   */
+  export let href = undefined;
+
+  /**
    * Specify the icon to render.
    * Icon is rendered to the left of the item content.
    * @type {Icon}
    */
   export let icon = /** @type {Icon} */ (undefined);
 
-  $: tag = interactive ? "button" : "div";
+  $: isLink = Boolean(href);
+  $: isClickable = isLink || interactive;
+  $: tag = isLink ? "a" : interactive ? "button" : "div";
   $: props = {
-    type: interactive ? "button" : undefined,
-    disabled: interactive ? disabled : undefined,
+    type: tag === "button" ? "button" : undefined,
+    disabled: tag === "button" ? disabled : undefined,
+    href: isLink ? href : undefined,
+    rel:
+      isLink && $$restProps.target === "_blank"
+        ? "noopener noreferrer"
+        : undefined,
   };
 </script>
 
 <li
   class:bx--contained-list-item="{true}"
-  class:bx--contained-list-item--clickable="{interactive}"
+  class:bx--contained-list-item--clickable="{isClickable}"
   class:bx--contained-list-item--with-icon="{icon}"
   class:bx--contained-list-item--with-action="{$$slots.action}"
 >
@@ -33,6 +48,7 @@
   <svelte:element
     this="{tag}"
     {...props}
+    {...$$restProps}
     on:click
     class:bx--contained-list-item__content="{true}"
   >

--- a/tests/ContainedList/ContainedList.test.ts
+++ b/tests/ContainedList/ContainedList.test.ts
@@ -5,6 +5,7 @@ import { user } from "../utils/user";
 import ContainedListLabelChildren from "./ContainedList.labelChildren.test.svelte";
 import ContainedList from "./ContainedList.test.svelte";
 import ContainedListItemAction from "./ContainedListItem.action.test.svelte";
+import ContainedListItemHref from "./ContainedListItem.href.test.svelte";
 
 describe("ContainedList", () => {
   beforeEach(() => {
@@ -214,6 +215,49 @@ describe("ContainedList", () => {
 
     await user.click(dismissButton);
     expect(consoleLog).toHaveBeenCalledWith("action click");
+  });
+
+  it("should render href items as anchors with clickable styles", () => {
+    render(ContainedListItemHref);
+
+    const link = screen.getByRole("link", { name: "Documentation" });
+    expect(link).toHaveAttribute("href", "/docs");
+    expect(link).toHaveClass("bx--contained-list-item__content");
+    expect(link.closest("li")).toHaveClass(
+      "bx--contained-list-item--clickable",
+    );
+  });
+
+  it("should prefer href over interactive and forward click", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(ContainedListItemHref);
+
+    const link = screen.getByRole("link", { name: "Prefer href" });
+    expect(link.tagName).toBe("A");
+    expect(
+      screen.getByText("Prefer href").closest("li")?.querySelector("button"),
+    ).toBeNull();
+
+    await user.click(link);
+    expect(consoleLog).toHaveBeenCalledWith("click");
+  });
+
+  it("should keep button and div when href is unset", () => {
+    render(ContainedListItemHref);
+
+    const interactiveItem = screen.getByText("Interactive").closest("li");
+    assert(interactiveItem);
+    expect(interactiveItem.querySelector("button")).toBeInTheDocument();
+    expect(interactiveItem.querySelector("a")).toBeNull();
+
+    const staticItem = screen.getByText("Static").closest("li");
+    assert(staticItem);
+    expect(
+      staticItem.querySelector("div.bx--contained-list-item__content"),
+    ).toBeInTheDocument();
+    expect(staticItem.querySelector("button")).toBeNull();
+    expect(staticItem.querySelector("a")).toBeNull();
+    expect(staticItem).not.toHaveClass("bx--contained-list-item--clickable");
   });
 
   describe("ContainedListItem Generics", () => {

--- a/tests/ContainedList/ContainedListItem.href.test.svelte
+++ b/tests/ContainedList/ContainedListItem.href.test.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+  import ContainedList from "carbon-components-svelte/ContainedList/ContainedList.svelte";
+  import ContainedListItem from "carbon-components-svelte/ContainedList/ContainedListItem.svelte";
+
+  function handleClick(event: MouseEvent) {
+    event.preventDefault();
+    console.log("click");
+  }
+</script>
+
+<ContainedList labelText="Related resources">
+  <ContainedListItem href="/docs" on:click={handleClick}>
+    Documentation
+  </ContainedListItem>
+  <ContainedListItem href="/docs" interactive on:click={handleClick}>
+    Prefer href
+  </ContainedListItem>
+  <ContainedListItem interactive on:click={() => console.log("click")}>
+    Interactive
+  </ContainedListItem>
+  <ContainedListItem>Static</ContainedListItem>
+</ContainedList>


### PR DESCRIPTION
ContainedListItem href prefers an anchor over a button so list rows can
be real links.

---

![contained-list item href example](https://gist.githubusercontent.com/metonym/14a3601bebd94d3178885c1c2e26ebc9/raw/474bd3a15640409fa06024f0f7b9ad340fdc184c/contained-list-item-href.png)
