### PR TITLE
feat(notification): add actions to ToastNotification

### DIFF
--- a/docs/src/pages/components/NotificationQueue.svx
+++ b/docs/src/pages/components/NotificationQueue.svx
@@ -64,3 +64,9 @@ Create persistent notifications that do not auto-dismiss by omitting timeout and
 These notifications remain visible until programmatically removed.
 
 <FileSource src="/framed/NotificationQueue/NotificationQueuePersistent" />
+
+## Actions
+
+Pass `actionText` and `onAction` to `add()` to render a [NotificationActionButton](ToastNotification#actions) in the toast. Useful for undo or retry flows without mounting a toast template yourself.
+
+<FileSource src="/framed/NotificationQueue/NotificationQueueActions" />

--- a/docs/src/pages/components/ToastNotification.svx
+++ b/docs/src/pages/components/ToastNotification.svx
@@ -1,6 +1,6 @@
 ---
-components: ["ToastNotification"]
-description: Toast notifications are non-modal, time-based messages that appear briefly and dismiss automatically. They support multiple types and custom content.
+components: ["ToastNotification", "NotificationActionButton"]
+description: Toast notifications are non-modal, time-based messages that appear briefly and dismiss automatically. They support multiple types, custom content, and actions.
 ---
 
 <script>
@@ -53,6 +53,12 @@ Customize the notification content using slots for more flexibility.
   <strong slot="subtitleChildren">An internal server error occurred.</strong>
   <strong slot="captionChildren">{new Date().toLocaleString()}</strong>
 </ToastNotification>
+
+## Actions
+
+Add interactive elements with the actions slot. Use [NotificationActionButton](InlineNotification#actions) for undo or retry after a destructive action.
+
+<FileSource src="/framed/ToastNotification/ToastNotificationUndo" />
 
 ## Close button
 

--- a/docs/src/pages/framed/NotificationQueue/NotificationQueueActions.svelte
+++ b/docs/src/pages/framed/NotificationQueue/NotificationQueueActions.svelte
@@ -1,0 +1,31 @@
+<script>
+  import { Button, NotificationQueue, Stack } from "carbon-components-svelte";
+
+  let queue;
+  let lastAction = "";
+
+  function showUndo() {
+    lastAction = "";
+    queue.add({
+      kind: "success",
+      title: "Item deleted",
+      subtitle: "You can undo this action.",
+      timeout: 5000,
+      actionText: "Undo",
+      onAction: () => {
+        lastAction = "undone";
+        queue.clear();
+      },
+    });
+  }
+</script>
+
+<NotificationQueue bind:this={queue} />
+
+<Stack gap={5}>
+  <Button on:click={showUndo}>Delete item</Button>
+
+  {#if lastAction === "undone"}
+    <p>Item restored.</p>
+  {/if}
+</Stack>

--- a/docs/src/pages/framed/ToastNotification/ToastNotificationUndo.svelte
+++ b/docs/src/pages/framed/ToastNotification/ToastNotificationUndo.svelte
@@ -1,0 +1,35 @@
+<script>
+  import {
+    NotificationActionButton,
+    Stack,
+    ToastNotification,
+  } from "carbon-components-svelte";
+
+  let open = true;
+  let restored = false;
+
+  function undo() {
+    restored = true;
+    open = false;
+  }
+</script>
+
+<Stack gap={5}>
+  {#if open}
+    <ToastNotification
+      kind="success"
+      title="Item deleted"
+      subtitle="You can undo this action."
+      caption={new Date().toLocaleString()}
+      bind:open
+    >
+      <svelte:fragment slot="actions">
+        <NotificationActionButton on:click={undo}
+          >Undo</NotificationActionButton
+        >
+      </svelte:fragment>
+    </ToastNotification>
+  {:else if restored}
+    <p>Item restored.</p>
+  {/if}
+</Stack>

--- a/src/Notification/NotificationQueue.svelte
+++ b/src/Notification/NotificationQueue.svelte
@@ -10,6 +10,8 @@
    * @property {boolean} [lowContrast]
    * @property {string} [closeButtonDescription]
    * @property {boolean} [hideCloseButton]
+   * @property {string} [actionText] - Label for an action button rendered in the toast actions slot
+   * @property {() => void} [onAction] - Click handler for the action button
    */
 
   /**
@@ -42,6 +44,7 @@
    */
   export let maxNotifications = 3;
 
+  import NotificationActionButton from "./NotificationActionButton.svelte";
   import ToastNotification from "./ToastNotification.svelte";
 
   /** @type {Array<NotificationData & { id: string }>} */
@@ -163,10 +166,19 @@
     style:z-index={zIndex}
   >
     {#each notifications as notification (notification.id)}
+      {@const { actionText, onAction, ...toastProps } = notification}
       <ToastNotification
-        {...notification}
+        {...toastProps}
         on:close={() => remove(notification.id)}
-      />
+      >
+        <svelte:fragment slot="actions">
+          {#if actionText}
+            <NotificationActionButton on:click={onAction}>
+              {actionText}
+            </NotificationActionButton>
+          {/if}
+        </svelte:fragment>
+      </ToastNotification>
     {/each}
   </div>
 {/if}

--- a/src/Notification/ToastNotification.svelte
+++ b/src/Notification/ToastNotification.svelte
@@ -125,6 +125,7 @@
       {/if}
       <slot />
     </div>
+    <slot name="actions" />
     {#if !hideCloseButton}
       <NotificationButton
         iconDescription={closeButtonDescription}

--- a/tests/Notification/NotificationQueue.test.ts
+++ b/tests/Notification/NotificationQueue.test.ts
@@ -576,6 +576,42 @@ describe("NotificationQueue", () => {
     },
   );
 
+  it("should render action button from actionText and invoke onAction", async () => {
+    vi.useRealTimers();
+    const onAction = vi.fn();
+    const { component } = render(NotificationQueueTest);
+
+    getQueue(component).add({
+      kind: "success",
+      title: "Item deleted",
+      subtitle: "You can undo this action.",
+      actionText: "Undo",
+      onAction,
+    });
+    await tick();
+
+    const actionButton = screen.getByRole("button", { name: "Undo" });
+    expect(actionButton).toBeInTheDocument();
+
+    await user.click(actionButton);
+    expect(onAction).toHaveBeenCalledTimes(1);
+  });
+
+  it("should not render action button when actionText is omitted", async () => {
+    const { component } = render(NotificationQueueTest);
+
+    getQueue(component).add({
+      kind: "success",
+      title: "No action",
+    });
+    await tick();
+
+    expect(
+      screen.queryByRole("button", { name: "Undo" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Close notification")).toBeInTheDocument();
+  });
+
   it.each(["bottom-right", "bottom-left", "bottom-center"] as const)(
     "should append notifications for %s position",
     async (position) => {

--- a/tests/ToastNotification/ToastNotification.test.ts
+++ b/tests/ToastNotification/ToastNotification.test.ts
@@ -2,6 +2,7 @@ import { fireEvent, render, screen } from "@testing-library/svelte";
 import { tick } from "svelte";
 import { user } from "../utils/user";
 import ToastNotificationTest from "./ToastNotification.test.svelte";
+import ToastNotificationActionsTest from "./ToastNotificationActions.test.svelte";
 import ToastNotificationCaptionSlotTest from "./ToastNotificationCaptionSlot.test.svelte";
 import ToastNotificationCustomTest from "./ToastNotificationCustom.test.svelte";
 import ToastNotificationReusableTest from "./ToastNotificationReusable.test.svelte";
@@ -351,6 +352,22 @@ describe("ToastNotification", () => {
     expect(screen.getByText("Custom Title:")).toBeInTheDocument();
     expect(screen.getByText("Custom subtitle content.")).toBeInTheDocument();
     expect(screen.getByText("Custom caption content.")).toBeInTheDocument();
+  });
+
+  it("should render actions slot", () => {
+    render(ToastNotificationActionsTest);
+
+    expect(screen.getByRole("button", { name: "Undo" })).toBeInTheDocument();
+  });
+
+  it("should invoke action button click handler", async () => {
+    vi.useRealTimers();
+    const onAction = vi.fn();
+    render(ToastNotificationActionsTest, { props: { onAction } });
+
+    await user.click(screen.getByRole("button", { name: "Undo" }));
+
+    expect(onAction).toHaveBeenCalledTimes(1);
   });
 
   it("should support bind:open", async () => {

--- a/tests/ToastNotification/ToastNotificationActions.test.svelte
+++ b/tests/ToastNotification/ToastNotificationActions.test.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  import NotificationActionButton from "carbon-components-svelte/Notification/NotificationActionButton.svelte";
+  import ToastNotification from "carbon-components-svelte/Notification/ToastNotification.svelte";
+
+  export let onAction: () => void = () => {};
+</script>
+
+<ToastNotification
+  kind="success"
+  title="Item deleted"
+  subtitle="You can undo this action."
+>
+  <svelte:fragment slot="actions">
+    <NotificationActionButton on:click={onAction}
+      >Undo</NotificationActionButton
+    >
+  </svelte:fragment>
+</ToastNotification>


### PR DESCRIPTION
ToastNotification gains an actions slot (InlineNotification parity), and
NotificationQueue.add accepts actionText / onAction.

---

![toast notification undo action example](https://gist.githubusercontent.com/metonym/ae60d55fbff69a53b1ba2467ba491732/raw/1ff4126b78d34a0a71128416dd98efd5c48817c3/notification-actions.png)
