### PR TITLE
feat(notification): pause timeout on hover

### DIFF
--- a/docs/src/pages/components/ToastNotification.svx
+++ b/docs/src/pages/components/ToastNotification.svx
@@ -21,7 +21,7 @@ Control notification visibility by binding to `open` to show, hide, and reuse th
 
 ## Autoclose
 
-Automatically close the notification after a specified duration (in milliseconds) with `timeout`.
+Automatically close the notification after a specified duration (in milliseconds) with `timeout`. Set `pauseOnHover` to pause the timeout while the pointer is over the toast so users can finish reading (opt-in).
 
 <FileSource src="/framed/ToastNotification/ToastNotificationTimeout" />
 

--- a/src/Notification/InlineNotification.svelte
+++ b/src/Notification/InlineNotification.svelte
@@ -16,6 +16,9 @@
   /** Set the timeout duration (ms) to hide the notification after opening it */
   export let timeout = 0;
 
+  /** Set to `true` to pause the auto-dismiss timeout while the pointer is over the notification. */
+  export let pauseOnHover = false;
+
   /**
    * Specify the ARIA `role` for the notification container.
    * @type {"alert" | "log" | "status"}
@@ -62,6 +65,14 @@
     }
   }
 
+  function onMouseEnter() {
+    if (pauseOnHover) dismiss.pause();
+  }
+
+  function onMouseLeave() {
+    if (pauseOnHover) dismiss.resume();
+  }
+
   $: dismiss.sync(open, timeout, () => close(true));
 
   onMount(() => () => dismiss.clear());
@@ -84,7 +95,9 @@
     on:click
     on:mouseover
     on:mouseenter
+    on:mouseenter={onMouseEnter}
     on:mouseleave
+    on:mouseleave={onMouseLeave}
   >
     <div class:bx--inline-notification__details={true}>
       <NotificationIcon notificationType="inline" {kind} />

--- a/src/Notification/ToastNotification.svelte
+++ b/src/Notification/ToastNotification.svelte
@@ -16,6 +16,9 @@
   /** Set the timeout duration (ms) to hide the notification after opening it */
   export let timeout = 0;
 
+  /** Set to `true` to pause the auto-dismiss timeout while the pointer is over the notification. */
+  export let pauseOnHover = false;
+
   /**
    * Specify the ARIA `role` for the notification container.
    * @type {"alert" | "log" | "status"}
@@ -71,6 +74,14 @@
     }
   }
 
+  function onMouseEnter() {
+    if (pauseOnHover) dismiss.pause();
+  }
+
+  function onMouseLeave() {
+    if (pauseOnHover) dismiss.resume();
+  }
+
   $: dismiss.sync(open, timeout, () => close(true));
 
   onMount(() => () => dismiss.clear());
@@ -93,7 +104,9 @@
     on:click
     on:mouseover
     on:mouseenter
+    on:mouseenter={onMouseEnter}
     on:mouseleave
+    on:mouseleave={onMouseLeave}
   >
     <NotificationIcon {kind} />
     <div class:bx--toast-notification__details={true}>

--- a/src/utils/timeoutDismiss.d.ts
+++ b/src/utils/timeoutDismiss.d.ts
@@ -1,6 +1,8 @@
 export type TimeoutDismiss = {
   readonly timeoutId: ReturnType<typeof setTimeout> | undefined;
   sync: (open: boolean, timeout: number, onTimeout: () => void) => void;
+  pause: () => void;
+  resume: () => void;
   clear: () => void;
 };
 

--- a/src/utils/timeoutDismiss.js
+++ b/src/utils/timeoutDismiss.js
@@ -4,16 +4,39 @@
  * Auto-close timer for notifications with a `timeout` prop.
  * `sync()` clears any pending timer and calls `setTimeout` when `open` and `timeout` > 0.
  * Skips `setTimeout` when `window` is undefined (SSR).
+ * `pause()` / `resume()` track remaining time so hover can suspend auto-dismiss.
  *
  * @returns {{
  *   get timeoutId(): ReturnType<typeof setTimeout> | undefined,
  *   sync: (open: boolean, timeout: number, onTimeout: () => void) => void,
+ *   pause: () => void,
+ *   resume: () => void,
  *   clear: () => void,
  * }}
  */
 export function createTimeoutDismiss() {
   /** @type {ReturnType<typeof setTimeout> | undefined} */
   let timeoutId;
+  /** @type {() => void} */
+  let onTimeout = () => {};
+  let remaining = 0;
+  let startedAt = 0;
+  let active = false;
+  let paused = false;
+
+  function schedule(ms) {
+    clearTimeout(timeoutId);
+    timeoutId = undefined;
+    remaining = ms;
+    startedAt = Date.now();
+    timeoutId = setTimeout(() => {
+      timeoutId = undefined;
+      active = false;
+      remaining = 0;
+      paused = false;
+      onTimeout();
+    }, ms);
+  }
 
   return {
     get timeoutId() {
@@ -22,18 +45,45 @@ export function createTimeoutDismiss() {
     /**
      * @param {boolean} open
      * @param {number} timeout
-     * @param {() => void} onTimeout
+     * @param {() => void} onTimeoutCb
      */
-    sync(open, timeout, onTimeout) {
+    sync(open, timeout, onTimeoutCb) {
       clearTimeout(timeoutId);
       timeoutId = undefined;
-      if (typeof window !== "undefined" && open && timeout) {
-        timeoutId = setTimeout(onTimeout, timeout);
+      paused = false;
+      onTimeout = onTimeoutCb;
+      active = typeof window !== "undefined" && open && timeout > 0;
+      if (active) {
+        schedule(timeout);
+      } else {
+        remaining = 0;
       }
+    },
+    pause() {
+      if (!active || paused || timeoutId === undefined) return;
+      clearTimeout(timeoutId);
+      timeoutId = undefined;
+      remaining = Math.max(0, remaining - (Date.now() - startedAt));
+      paused = true;
+    },
+    resume() {
+      if (!paused || !active) return;
+      paused = false;
+      if (typeof window === "undefined") return;
+      if (remaining <= 0) {
+        active = false;
+        remaining = 0;
+        onTimeout();
+        return;
+      }
+      schedule(remaining);
     },
     clear() {
       clearTimeout(timeoutId);
       timeoutId = undefined;
+      remaining = 0;
+      active = false;
+      paused = false;
     },
   };
 }

--- a/tests/InlineNotification/InlineNotification.test.svelte
+++ b/tests/InlineNotification/InlineNotification.test.svelte
@@ -5,6 +5,7 @@
   export let kind: ComponentProps<InlineNotification>["kind"] = "error";
   export let lowContrast: ComponentProps<InlineNotification>["lowContrast"] = false;
   export let timeout: ComponentProps<InlineNotification>["timeout"] = 0;
+  export let pauseOnHover: ComponentProps<InlineNotification>["pauseOnHover"] = false;
   export let role: ComponentProps<InlineNotification>["role"] = "alert";
   export let title: ComponentProps<InlineNotification>["title"] = "";
   export let subtitle: ComponentProps<InlineNotification>["subtitle"] = "";
@@ -19,6 +20,7 @@
   {kind}
   {lowContrast}
   {timeout}
+  {pauseOnHover}
   {role}
   {title}
   {subtitle}

--- a/tests/InlineNotification/InlineNotification.test.ts
+++ b/tests/InlineNotification/InlineNotification.test.ts
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/svelte";
+import { fireEvent, render, screen } from "@testing-library/svelte";
 import { tick } from "svelte";
 import { user } from "../utils/user";
 import InlineNotificationTest from "./InlineNotification.test.svelte";
@@ -193,6 +193,52 @@ describe("InlineNotification", () => {
     expect(closeHandler).not.toHaveBeenCalled();
 
     vi.advanceTimersByTime(1000);
+    await tick();
+
+    expect(closeHandler).toHaveBeenCalledTimes(1);
+    expect(closeHandler.mock.calls[0][0].detail).toEqual({ timeout: true });
+  });
+
+  it("should pause timeout on hover when pauseOnHover is true", async () => {
+    const closeHandler = vi.fn();
+    render(InlineNotificationTest, {
+      props: { timeout: 1000, pauseOnHover: true, onclose: closeHandler },
+    });
+
+    const notification = document.querySelector(".bx--inline-notification");
+    assert(notification);
+
+    vi.advanceTimersByTime(400);
+    await fireEvent.mouseEnter(notification);
+
+    vi.advanceTimersByTime(1000);
+    await tick();
+    expect(closeHandler).not.toHaveBeenCalled();
+
+    await fireEvent.mouseLeave(notification);
+    vi.advanceTimersByTime(599);
+    await tick();
+    expect(closeHandler).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    await tick();
+    expect(closeHandler).toHaveBeenCalledTimes(1);
+    expect(closeHandler.mock.calls[0][0].detail).toEqual({ timeout: true });
+  });
+
+  it("should not pause timeout on hover when pauseOnHover is false", async () => {
+    const closeHandler = vi.fn();
+    render(InlineNotificationTest, {
+      props: { timeout: 1000, pauseOnHover: false, onclose: closeHandler },
+    });
+
+    const notification = document.querySelector(".bx--inline-notification");
+    assert(notification);
+
+    vi.advanceTimersByTime(400);
+    await fireEvent.mouseEnter(notification);
+
+    vi.advanceTimersByTime(600);
     await tick();
 
     expect(closeHandler).toHaveBeenCalledTimes(1);

--- a/tests/ToastNotification/ToastNotification.test.svelte
+++ b/tests/ToastNotification/ToastNotification.test.svelte
@@ -5,6 +5,7 @@
   export let kind: ComponentProps<ToastNotification>["kind"] = "error";
   export let lowContrast: ComponentProps<ToastNotification>["lowContrast"] = false;
   export let timeout: ComponentProps<ToastNotification>["timeout"] = 0;
+  export let pauseOnHover: ComponentProps<ToastNotification>["pauseOnHover"] = false;
   export let role: ComponentProps<ToastNotification>["role"] = "alert";
   export let title: ComponentProps<ToastNotification>["title"] = "";
   export let subtitle: ComponentProps<ToastNotification>["subtitle"] = "";
@@ -21,6 +22,7 @@
   {kind}
   {lowContrast}
   {timeout}
+  {pauseOnHover}
   {role}
   {title}
   {subtitle}

--- a/tests/ToastNotification/ToastNotification.test.ts
+++ b/tests/ToastNotification/ToastNotification.test.ts
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/svelte";
+import { fireEvent, render, screen } from "@testing-library/svelte";
 import { tick } from "svelte";
 import { user } from "../utils/user";
 import ToastNotificationTest from "./ToastNotification.test.svelte";
@@ -231,6 +231,52 @@ describe("ToastNotification", () => {
     expect(closeHandler).not.toHaveBeenCalled();
 
     vi.advanceTimersByTime(1000);
+    await tick();
+
+    expect(closeHandler).toHaveBeenCalledTimes(1);
+    expect(closeHandler.mock.calls[0][0].detail).toEqual({ timeout: true });
+  });
+
+  it("should pause timeout on hover when pauseOnHover is true", async () => {
+    const closeHandler = vi.fn();
+    render(ToastNotificationTest, {
+      props: { timeout: 1000, pauseOnHover: true, onclose: closeHandler },
+    });
+
+    const notification = document.querySelector(".bx--toast-notification");
+    assert(notification);
+
+    vi.advanceTimersByTime(400);
+    await fireEvent.mouseEnter(notification);
+
+    vi.advanceTimersByTime(1000);
+    await tick();
+    expect(closeHandler).not.toHaveBeenCalled();
+
+    await fireEvent.mouseLeave(notification);
+    vi.advanceTimersByTime(599);
+    await tick();
+    expect(closeHandler).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    await tick();
+    expect(closeHandler).toHaveBeenCalledTimes(1);
+    expect(closeHandler.mock.calls[0][0].detail).toEqual({ timeout: true });
+  });
+
+  it("should not pause timeout on hover when pauseOnHover is false", async () => {
+    const closeHandler = vi.fn();
+    render(ToastNotificationTest, {
+      props: { timeout: 1000, pauseOnHover: false, onclose: closeHandler },
+    });
+
+    const notification = document.querySelector(".bx--toast-notification");
+    assert(notification);
+
+    vi.advanceTimersByTime(400);
+    await fireEvent.mouseEnter(notification);
+
+    vi.advanceTimersByTime(600);
     await tick();
 
     expect(closeHandler).toHaveBeenCalledTimes(1);

--- a/tests/utils/timeoutDismiss.test.ts
+++ b/tests/utils/timeoutDismiss.test.ts
@@ -66,4 +66,49 @@ describe("createTimeoutDismiss", () => {
     vi.advanceTimersByTime(1000);
     expect(cb).not.toHaveBeenCalled();
   });
+
+  test("pause stops the timer and resume continues with remaining time", () => {
+    const dismiss = createTimeoutDismiss();
+    const cb = vi.fn();
+
+    dismiss.sync(true, 1000, cb);
+    vi.advanceTimersByTime(400);
+    dismiss.pause();
+
+    expect(dismiss.timeoutId).toBeUndefined();
+    vi.advanceTimersByTime(1000);
+    expect(cb).not.toHaveBeenCalled();
+
+    dismiss.resume();
+    vi.advanceTimersByTime(599);
+    expect(cb).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  test("pause is a no-op when no timer is active", () => {
+    const dismiss = createTimeoutDismiss();
+    const cb = vi.fn();
+
+    dismiss.sync(true, 0, cb);
+    dismiss.pause();
+    dismiss.resume();
+
+    vi.advanceTimersByTime(1000);
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  test("resume fires immediately when remaining time is already zero", () => {
+    const dismiss = createTimeoutDismiss();
+    const cb = vi.fn();
+
+    dismiss.sync(true, 1000, cb);
+    vi.setSystemTime(Date.now() + 1000);
+    dismiss.pause();
+    expect(dismiss.timeoutId).toBeUndefined();
+
+    dismiss.resume();
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
pauseOnHover (default false) pauses the auto-dismiss timer while the
pointer is over Toast or Inline notifications.