### PR TITLE
feat(notification): add NotificationQueue promise helper

### DIFF
--- a/docs/src/pages/components/NotificationQueue.svx
+++ b/docs/src/pages/components/NotificationQueue.svx
@@ -43,6 +43,14 @@ Use `update(id, patch)` to change an existing notification in place. The patch m
 
 <FileSource src="/framed/NotificationQueue/NotificationQueueUpdate" />
 
+## Promise
+
+Use `promise(p, msgs)` for async work that should show a loading toast, then morph to success or error when the promise settles. Pass string messages or `NotificationData` objects for `loading`, `success`, and `error`. `success` and `error` also accept a function of the resolved value or rejection reason.
+
+`promise` returns the original promise result so you can still `await` it. Settled toasts default to a 3000ms timeout; override `timeout` in a `NotificationData` object when needed.
+
+<FileSource src="/framed/NotificationQueue/NotificationQueuePromise" />
+
 ## Max notifications
 
 By default, the queue displays a maximum of 3 notifications. When the limit is exceeded, the oldest notification is removed automatically.

--- a/docs/src/pages/framed/NotificationQueue/NotificationQueuePromise.svelte
+++ b/docs/src/pages/framed/NotificationQueue/NotificationQueuePromise.svelte
@@ -1,0 +1,23 @@
+<script>
+  import { Button, NotificationQueue } from "carbon-components-svelte";
+
+  let queue;
+
+  async function save() {
+    await new Promise((resolve) => setTimeout(resolve, 1200));
+  }
+</script>
+
+<NotificationQueue bind:this={queue} />
+
+<Button
+  on:click={() => {
+    queue.promise(save(), {
+      loading: "Saving...",
+      success: "Changes saved",
+      error: "Failed to save",
+    });
+  }}
+>
+  Save
+</Button>

--- a/src/Notification/NotificationQueue.svelte
+++ b/src/Notification/NotificationQueue.svelte
@@ -118,6 +118,63 @@
   export function clear() {
     notifications = [];
   }
+
+  const DEFAULT_SETTLE_TIMEOUT = 3000;
+
+  /**
+   * @param {string | NotificationData} msg
+   * @param {NotificationData["kind"]} kind
+   * @param {Partial<NotificationData>} [defaults]
+   * @returns {NotificationData}
+   */
+  function toNotificationData(msg, kind, defaults = {}) {
+    if (typeof msg === "string") {
+      return { ...defaults, kind, title: msg, subtitle: "", caption: "" };
+    }
+    return { ...defaults, kind, ...msg };
+  }
+
+  /**
+   * Show a loading notification for a promise, then update it to success or
+   * error when the promise settles. Returns the original promise result.
+   * String messages become the notification title. Success and error toasts
+   * default to a 3000ms timeout unless overridden in a `NotificationData` object.
+   * @type {<T>(p: Promise<T>, msgs: { loading: string | NotificationData; success: string | ((value: T) => string | NotificationData); error: string | ((err: unknown) => string | NotificationData) }) => Promise<T>}
+   */
+  export function promise(p, msgs) {
+    const id = add(
+      toNotificationData(msgs.loading, "info", { hideCloseButton: true }),
+    );
+
+    return p.then(
+      (value) => {
+        const successMsg =
+          typeof msgs.success === "function"
+            ? msgs.success(value)
+            : msgs.success;
+        update(
+          id,
+          toNotificationData(successMsg, "success", {
+            hideCloseButton: false,
+            timeout: DEFAULT_SETTLE_TIMEOUT,
+          }),
+        );
+        return value;
+      },
+      (err) => {
+        const errorMsg =
+          typeof msgs.error === "function" ? msgs.error(err) : msgs.error;
+        update(
+          id,
+          toNotificationData(errorMsg, "error", {
+            hideCloseButton: false,
+            timeout: DEFAULT_SETTLE_TIMEOUT,
+          }),
+        );
+        throw err;
+      },
+    );
+  }
 </script>
 
 {#if notifications.length > 0}

--- a/tests/Notification/NotificationQueue.test.ts
+++ b/tests/Notification/NotificationQueue.test.ts
@@ -270,6 +270,73 @@ describe("NotificationQueue", () => {
     expect(updated).toBe(false);
   });
 
+  it("should update to success when promise resolves", async () => {
+    const { component } = render(NotificationQueueTest);
+    let resolvePromise!: (value: string) => void;
+    const p = new Promise<string>((resolve) => {
+      resolvePromise = resolve;
+    });
+
+    const resultPromise = getQueue(component).promise(p, {
+      loading: "Saving...",
+      success: "Saved",
+      error: "Failed",
+    });
+    await tick();
+
+    expect(screen.getByText("Saving...")).toBeInTheDocument();
+
+    resolvePromise("ok");
+    await expect(resultPromise).resolves.toBe("ok");
+    await tick();
+
+    expect(screen.queryByText("Saving...")).not.toBeInTheDocument();
+    expect(screen.getByText("Saved")).toBeInTheDocument();
+    expect(screen.getAllByRole("alert")).toHaveLength(1);
+  });
+
+  it("should update to error when promise rejects", async () => {
+    const { component } = render(NotificationQueueTest);
+    let rejectPromise!: (reason?: unknown) => void;
+    const p = new Promise<string>((_, reject) => {
+      rejectPromise = reject;
+    });
+
+    const resultPromise = getQueue(component).promise(p, {
+      loading: "Saving...",
+      success: "Saved",
+      error: (err: unknown) => (err instanceof Error ? err.message : "Failed"),
+    });
+    await tick();
+
+    expect(screen.getByText("Saving...")).toBeInTheDocument();
+
+    rejectPromise(new Error("Network error"));
+    await expect(resultPromise).rejects.toThrow("Network error");
+    await tick();
+
+    expect(screen.queryByText("Saving...")).not.toBeInTheDocument();
+    expect(screen.getByText("Network error")).toBeInTheDocument();
+    expect(screen.getAllByRole("alert")).toHaveLength(1);
+  });
+
+  it("should return the original promise result from promise()", async () => {
+    const { component } = render(NotificationQueueTest);
+
+    const value = await getQueue(component).promise(
+      Promise.resolve({ id: 42 }),
+      {
+        loading: "Loading...",
+        success: (data: { id: number }) => `Loaded ${data.id}`,
+        error: "Failed",
+      },
+    );
+    await tick();
+
+    expect(value).toEqual({ id: 42 });
+    expect(screen.getByText("Loaded 42")).toBeInTheDocument();
+  });
+
   it("should clear all notifications", async () => {
     const { component } = render(NotificationQueueTest);
 


### PR DESCRIPTION
NotificationQueue.promise() shows a loading toast then updates it to
success or error when the promise settles.

---

![notification queue promise loading toast example](https://gist.githubusercontent.com/metonym/30587d36685d8cef0b7443d299ce3998/raw/14c97936519a837fec360824aaa0e8c6c9505ffa/notification-queue-promise.png)
