### PR TITLE
feat(search-menu): add debounce and search event

### DIFF
--- a/docs/src/pages/components/SearchMenu.svx
+++ b/docs/src/pages/components/SearchMenu.svx
@@ -129,13 +129,13 @@ Provide a `noResults` slot to render an empty state when the search value matche
 
 ### Async results
 
-Combine an async data source with client-side highlighting. Bind to `value`, fetch on input (debounced here), and render the returned items. Because filtering happens on the server (`shouldFilter={false}`), the menu shows exactly what the server returns while the client-side matcher still highlights the query. Set `loading` to render a skeleton menu while fetching (customize the rows with `skeletonCount` or the `loading` slot), and use the `noResults` slot for the empty state.
+Combine an async data source with client-side highlighting. Set `debounce` (milliseconds) so the `search` event fires after typing pauses; `bind:value` stays immediate. Listen to `search` to fetch, set `loading` while the request is in flight, and render the returned items. Because filtering happens on the server (`shouldFilter={false}`), the menu shows exactly what the server returns while the client-side matcher still highlights the query. Customize skeleton rows with `skeletonCount` or the `loading` slot, and use the `noResults` slot for the empty state.
 
 <FileSource src="/framed/SearchMenu/AsyncResults" />
 
 ## Events
 
-The `select` event fires when an item is activated, carrying the `value`, the `item`, and the originating `event`. The `submit` event fires when pressing <DocKbd label="Enter" /> without an active item, carrying the current `value`. The `close` event fires when the menu closes, with a `trigger` of `"escape-key"`, `"outside-click"`, `"select"`, or `"blur"`.
+The `select` event fires when an item is activated, carrying the `value`, the `item`, and the originating `event`. The `submit` event fires when pressing <DocKbd label="Enter" /> without an active item, carrying the current `value`. The `search` event fires when `debounce` is set, carrying the current `value` after the delay (`0` means immediately on every value change; unset means no `search` event). The `close` event fires when the menu closes, with a `trigger` of `"escape-key"`, `"outside-click"`, `"select"`, or `"blur"`.
 
 ### Result links
 

--- a/docs/src/pages/framed/SearchMenu/AsyncResults.svelte
+++ b/docs/src/pages/framed/SearchMenu/AsyncResults.svelte
@@ -4,7 +4,6 @@
   let value = "";
   let results = [];
   let loading = false;
-  let timeout;
 
   const database = [
     "Databases for PostgreSQL",
@@ -28,32 +27,30 @@
     });
   }
 
-  // Debounce input, then fetch. `shouldFilter={false}` defers filtering to the
-  // server; the client still highlights the query within each returned result.
-  $: queryResults(value);
-
-  function queryResults(query) {
-    clearTimeout(timeout);
-    const trimmed = query.trim();
-    if (trimmed === "") {
+  // `debounce` delays the `search` event; `bind:value` stays immediate.
+  // `shouldFilter={false}` defers filtering to the server; the client still
+  // highlights the query within each returned result.
+  async function handleSearch(event) {
+    const query = event.detail.value.trim();
+    if (query === "") {
       results = [];
       loading = false;
       return;
     }
     loading = true;
-    timeout = setTimeout(async () => {
-      results = await fetchResults(trimmed);
-      loading = false;
-    }, 300);
+    results = await fetchResults(query);
+    loading = false;
   }
 </script>
 
 <SearchMenu
   bind:value
   {loading}
+  debounce={300}
   shouldFilter={false}
   labelText="Search"
   placeholder="Search..."
+  on:search={handleSearch}
 >
   {#each results as result (result)}
     <SearchMenuItem text={result} />

--- a/src/SearchMenu/SearchMenu.svelte
+++ b/src/SearchMenu/SearchMenu.svelte
@@ -6,6 +6,7 @@
   /**
    * @event {{ value: string; item: { text?: string; value?: string; href?: string }; event: Event }} select
    * @event {{ value: T }} submit
+   * @event {{ value: T }} search
    * @event {{ trigger: "escape-key" | "outside-click" | "select" | "blur" }} close
    * @restProps {input}
    * @slot {{}} before
@@ -69,6 +70,14 @@
   /** Specify the number of skeleton rows rendered while `loading` */
   export let skeletonCount = 4;
 
+  /**
+   * Debounce delay in milliseconds before dispatching the `search` event.
+   * `bind:value` updates immediately. When unset, no `search` event is
+   * dispatched. Set to `0` to dispatch on every value change without delay.
+   * @type {number | undefined}
+   */
+  export let debounce = undefined;
+
   /** Specify the placeholder text */
   export let placeholder = "Search...";
 
@@ -113,16 +122,51 @@
    */
   export let menuRef = null;
 
-  import { createEventDispatcher, setContext } from "svelte";
+  import { createEventDispatcher, onMount, setContext } from "svelte";
   import { writable } from "svelte/store";
   import FloatingPortal from "../Portal/FloatingPortal.svelte";
   import Search from "../Search/Search.svelte";
   import SkeletonText from "../SkeletonText/SkeletonText.svelte";
+  import { debounce as createDebounce } from "../utils/debounce.js";
   import { dismiss } from "../utils/dismiss.js";
   import { fuzzyMatch } from "../utils/fuzzyMatch.js";
   import { isOutsideClick } from "../utils/isOutsideClick.js";
 
   const dispatch = createEventDispatcher();
+
+  /** @type {(((next: T) => void) & { cancel?: () => void }) | null} */
+  let scheduleSearch = null;
+  /** @type {number | undefined | null} */
+  let activeDebounce = null;
+  // Svelte 3/4 drop events dispatched during the initial reactive flush
+  // (parent listeners are not attached yet). Wait until mount so `debounce={0}`
+  // still emits the initial value; debounced schedules only start after mount.
+  let searchReady = false;
+
+  function dispatchSearch(next) {
+    dispatch("search", { value: next });
+  }
+
+  // Gate on `activeDebounce` so this block does not re-enter when it assigns
+  // `scheduleSearch` (reading and writing that binding in one `$:` loops).
+  $: if (debounce !== activeDebounce) {
+    scheduleSearch?.cancel?.();
+    activeDebounce = debounce;
+    if (typeof debounce !== "number") {
+      scheduleSearch = null;
+    } else if (debounce <= 0) {
+      scheduleSearch = (next) => dispatchSearch(next);
+    } else {
+      scheduleSearch = createDebounce(dispatchSearch, debounce);
+    }
+  }
+
+  $: if (searchReady && scheduleSearch) scheduleSearch(value);
+
+  onMount(() => {
+    searchReady = true;
+    return () => scheduleSearch?.cancel?.();
+  });
 
   let anchorRef = null;
   let searchAnchorRef = null;

--- a/tests/SearchMenu/SearchMenu.test.svelte
+++ b/tests/SearchMenu/SearchMenu.test.svelte
@@ -8,6 +8,7 @@
   export let shouldFilter = true;
   export let disabled = false;
   export let loading = false;
+  export let debounce: ComponentProps<SearchMenu>["debounce"] = undefined;
   export let size: ComponentProps<SearchMenu>["size"] = undefined;
   export let menuSize: ComponentProps<SearchMenu>["menuSize"] = undefined;
   export let portal: ComponentProps<SearchMenu>["portal"] = true;
@@ -17,6 +18,7 @@
   };
   export let closeTrigger = "";
   export let events: string[] = [];
+  export let searches: string[] = [];
 
   const items = [
     "Databases for TestSQL",
@@ -32,6 +34,7 @@
   {shouldFilter}
   {disabled}
   {loading}
+  {debounce}
   {size}
   {menuSize}
   {portal}
@@ -39,6 +42,7 @@
   labelText="Search"
   on:select={(e) => (selected = { value: e.detail.value, submitted: false })}
   on:submit={(e) => (selected = { value: e.detail.value, submitted: true })}
+  on:search={(e) => (searches = [...searches, String(e.detail.value ?? "")])}
   on:close={(e) => (closeTrigger = e.detail.trigger)}
   on:keyup={() => (events = [...events, "keyup"])}
 >
@@ -52,3 +56,4 @@
 </div>
 <div data-testid="close">{closeTrigger}</div>
 <div data-testid="events">{events.join(",")}</div>
+<div data-testid="searches">{JSON.stringify(searches)}</div>

--- a/tests/SearchMenu/SearchMenu.test.ts
+++ b/tests/SearchMenu/SearchMenu.test.ts
@@ -250,6 +250,66 @@ describe("SearchMenu", () => {
   });
 });
 
+describe("SearchMenu debounce / search event", () => {
+  function getSearches() {
+    return JSON.parse(screen.getByTestId("searches").textContent ?? "[]");
+  }
+
+  function delay(ms: number) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  it("does not dispatch search when debounce is unset", async () => {
+    const { rerender } = render(SearchMenu);
+    await rerender({ value: "ab" });
+    await delay(50);
+    expect(getSearches()).toEqual([]);
+  });
+
+  it("dispatches search after the debounce delay", async () => {
+    const { rerender } = render(SearchMenu, { props: { debounce: 50 } });
+    // Drain the initial empty-value search scheduled on mount.
+    await vi.waitFor(() => {
+      expect(getSearches()).toEqual([""]);
+    });
+
+    await rerender({ debounce: 50, value: "ab", searches: [] });
+    expect(getSearches()).toEqual([]);
+    // bind:value stays immediate while search is still pending.
+    expect(screen.getByRole("combobox")).toHaveValue("ab");
+    await vi.waitFor(() => {
+      expect(getSearches()).toEqual(["ab"]);
+    });
+  });
+
+  it("collapses rapid value changes into one search", async () => {
+    const { rerender } = render(SearchMenu, { props: { debounce: 50 } });
+    await vi.waitFor(() => {
+      expect(getSearches()).toEqual([""]);
+    });
+
+    await rerender({ debounce: 50, value: "a", searches: [] });
+    await delay(15);
+    await rerender({ debounce: 50, value: "ab", searches: [] });
+    await delay(15);
+    await rerender({ debounce: 50, value: "abc", searches: [] });
+    expect(getSearches()).toEqual([]);
+    await vi.waitFor(() => {
+      expect(getSearches()).toEqual(["abc"]);
+    });
+  });
+
+  it("dispatches search immediately when debounce is 0", async () => {
+    const { rerender } = render(SearchMenu, { props: { debounce: 0 } });
+    expect(getSearches()).toEqual([""]);
+
+    await rerender({ debounce: 0, value: "a", searches: [] });
+    expect(getSearches()).toEqual(["a"]);
+    await rerender({ debounce: 0, value: "ab", searches: ["a"] });
+    expect(getSearches()).toEqual(["a", "ab"]);
+  });
+});
+
 describe("SearchMenu sizes", () => {
   it("defaults the input and menu to the xl size", async () => {
     render(SearchMenu);


### PR DESCRIPTION
Optional debounce on SearchMenu emits a search event (unset = none, 0 =
immediate, n = delayed) while bind:value stays live.

---

![search-menu debounced search example](https://gist.githubusercontent.com/metonym/6f38d491a89b195c4bd398d9015f68be/raw/5d402f4934f557665df15285f71a88ab1f7fd82d/search-menu-debounce.png)
