### PR TITLE
feat(search): add optional submit button and submit event

### DIFF
--- a/css/_search.scss
+++ b/css/_search.scss
@@ -1,6 +1,7 @@
 // Extends the v10 search with the extra-small (`xs`) size added in newer
 // Carbon (React `size="xs"`, 24px height). v10 only ships sm/lg/xl.
 // Mirrors the v10 `--sm` block scaled to 24px: 4px gap + 16px icon + 4px.
+// Also lays out an optional trailing submit button (`--with-submit`).
 
 @import "carbon-components/scss/globals/scss/vars";
 @import "carbon-components/scss/globals/scss/helper-mixins";
@@ -24,6 +25,7 @@
 
   .#{$prefix}--search--xs {
     .#{$prefix}--search-close,
+    .#{$prefix}--search-button,
     &.#{$prefix}--search--expandable,
     &.#{$prefix}--search--expandable .#{$prefix}--search-magnifier {
       width: to-rem(24px);
@@ -36,6 +38,120 @@
   }
 }
 
+/// Optional trailing submit button layout
+/// @access private
+/// @group components
+@mixin search-submit-button {
+  // v10 sizes the submit button via a sibling selector outside `.bx--search`.
+  // When the button is inside the field, mirror close-button sizing here.
+  .#{$prefix}--search--sm .#{$prefix}--search-button {
+    width: to-rem(32px);
+    height: to-rem(32px);
+  }
+
+  .#{$prefix}--search--lg .#{$prefix}--search-button {
+    width: to-rem(40px);
+    height: to-rem(40px);
+  }
+
+  .#{$prefix}--search--xl .#{$prefix}--search-button {
+    width: to-rem(48px);
+    height: to-rem(48px);
+  }
+
+  .#{$prefix}--search--with-submit .#{$prefix}--search-button {
+    @include button-reset(false);
+    @include focus-outline("reset");
+
+    position: absolute;
+    top: 0;
+    right: 0;
+    margin-left: 0;
+  }
+
+  .#{$prefix}--search--with-submit.#{$prefix}--search--light
+    .#{$prefix}--search-button {
+    background-color: $field-02;
+  }
+
+  .#{$prefix}--search--with-submit.#{$prefix}--search--xs .#{$prefix}--search-input {
+    padding-right: to-rem(48px);
+  }
+
+  .#{$prefix}--search--with-submit.#{$prefix}--search--sm .#{$prefix}--search-input {
+    padding-right: to-rem(64px);
+  }
+
+  .#{$prefix}--search--with-submit.#{$prefix}--search--lg .#{$prefix}--search-input {
+    padding-right: to-rem(80px);
+  }
+
+  .#{$prefix}--search--with-submit.#{$prefix}--search--xl .#{$prefix}--search-input {
+    padding-right: to-rem(96px);
+  }
+
+  .#{$prefix}--search--with-submit.#{$prefix}--search--xs .#{$prefix}--search-close {
+    right: to-rem(24px);
+  }
+
+  .#{$prefix}--search--with-submit.#{$prefix}--search--sm .#{$prefix}--search-close {
+    right: to-rem(32px);
+  }
+
+  .#{$prefix}--search--with-submit.#{$prefix}--search--lg .#{$prefix}--search-close {
+    right: to-rem(40px);
+  }
+
+  .#{$prefix}--search--with-submit.#{$prefix}--search--xl .#{$prefix}--search-close {
+    right: to-rem(48px);
+  }
+
+  // Fluid already reserves the right edge for the decorative magnifier; place
+  // the submit button there and shift the clear control one button width left.
+  .#{$prefix}--search--with-submit.#{$prefix}--search--fluid
+    .#{$prefix}--search-input {
+    padding-right: to-rem(128px);
+  }
+
+  .#{$prefix}--search--with-submit.#{$prefix}--search--fluid
+    .#{$prefix}--search-close {
+    right: to-rem(48px);
+    inset: auto to-rem(48px) 0 auto;
+  }
+
+  .#{$prefix}--search--with-submit.#{$prefix}--search--fluid
+    .#{$prefix}--search-button {
+    border: none;
+    block-size: to-rem(40px);
+    inline-size: to-rem(40px);
+    inset: auto 0 0 auto;
+  }
+
+  .#{$prefix}--search--with-submit.#{$prefix}--search--fluid
+    .#{$prefix}--search-magnifier-icon {
+    display: none;
+  }
+
+  .#{$prefix}--search--with-submit
+    .#{$prefix}--search-input:focus
+    ~ .#{$prefix}--search-button:hover {
+    @include focus-outline("outline");
+  }
+
+  .#{$prefix}--search--disabled .#{$prefix}--search-button {
+    cursor: not-allowed;
+    outline: none;
+
+    &:hover {
+      background-color: transparent;
+    }
+  }
+}
+
 @include exports("search-xs") {
   @include search-xs;
+}
+
+@include exports("search-submit-button") {
+  @include search-submit-button;
 }

--- a/docs/src/pages/components/Search.svx
+++ b/docs/src/pages/components/Search.svx
@@ -36,6 +36,16 @@ The `clear` event fires when clicking the clear button or pressing <DocKbd label
 
 <Search value="Cloud functions" on:clear={() => console.log('clear')}/>
 
+## Submit button
+
+Set `showSubmitButton` to `true` to show a trailing search button for form-style search. Clicking the button or pressing <DocKbd label="Enter" /> dispatches `submit` with the current value. Use `submitButtonLabelText` to localize the button label.
+
+<Search
+  showSubmitButton
+  value="Cloud functions"
+  on:submit={(e) => console.log("submit", e.detail.value)}
+/>
+
 ## Expandable
 
 Enable the expandable variant to show a compact search icon that expands on focus.

--- a/src/Search/Search.svelte
+++ b/src/Search/Search.svelte
@@ -4,6 +4,7 @@
    * @template [Icon=any]
    * @event {null} expand
    * @event {null} collapse
+   * @event {{ value: T }} submit
    * @restProps {input}
    */
 
@@ -64,6 +65,16 @@
   /** Specify the close button label text */
   export let closeButtonLabelText = "Clear search input";
 
+  /**
+   * Set to `true` to show a trailing submit button.
+   * Clicking the button dispatches `submit`. Pressing Enter also
+   * dispatches `submit`, with or without the button.
+   */
+  export let showSubmitButton = false;
+
+  /** Specify the submit button label text */
+  export let submitButtonLabelText = "Search";
+
   /** Specify the label text */
   export let labelText = "";
 
@@ -92,6 +103,11 @@
 
   let searchRef = null;
   let prevExpanded = expanded;
+
+  function submit() {
+    if (disabled) return;
+    dispatch("submit", { value });
+  }
 
   $: isFluid = !expandable && (fluid || !!formContext?.isFluid);
   $: if (expanded && ref) ref.focus();
@@ -125,6 +141,7 @@
     class:bx--search--expandable={expandable}
     class:bx--search--expanded={expanded}
     class:bx--search--fluid={isFluid}
+    class:bx--search--with-submit={showSubmitButton}
     class={searchClass}
   >
     <!-- svelte-ignore a11y-click-events-have-key-events -->
@@ -176,6 +193,8 @@
         if (event.key === "Escape") {
           value = "";
           dispatch("clear");
+        } else if (event.key === "Enter") {
+          submit();
         }
       }}
       on:keyup
@@ -196,5 +215,17 @@
     >
       <svelte:component this={Close} size={size === "xl" ? 20 : 16} />
     </button>
+    {#if showSubmitButton}
+      <button
+        type="button"
+        aria-label={submitButtonLabelText}
+        {disabled}
+        class:bx--search-button={true}
+        on:click
+        on:click={submit}
+      >
+        <svelte:component this={IconSearch} size={size === "xl" ? 20 : 16} />
+      </button>
+    {/if}
   </div>
 {/if}

--- a/tests/Search/Search.test.ts
+++ b/tests/Search/Search.test.ts
@@ -10,6 +10,7 @@ import Search from "./Search.test.svelte";
 import SearchExpandable from "./SearchExpandable.test.svelte";
 import SearchInitialEvent from "./SearchInitialEvent.test.svelte";
 import SearchSkeleton from "./SearchSkeleton.test.svelte";
+import SearchSubmit from "./SearchSubmit.test.svelte";
 
 describe("Search", () => {
   const getSearchInput = (label?: string | RegExp) =>
@@ -244,5 +245,63 @@ describe("Search", () => {
     expect(skeleton.children).toHaveLength(2);
     expect(skeleton.children[0]).toHaveClass("bx--label", "bx--skeleton");
     expect(skeleton.children[1]).toHaveClass("bx--skeleton", "bx--text-input");
+  });
+
+  describe("submit button", () => {
+    const getSubmitButton = (label = "Search") =>
+      screen.getByRole("button", { name: label });
+
+    it("does not render the submit button by default", () => {
+      render(Search);
+
+      expect(
+        screen.queryByRole("button", { name: "Search" }),
+      ).not.toBeInTheDocument();
+      expect(document.querySelector(".bx--search--with-submit")).toBeNull();
+    });
+
+    it("renders the submit button when showSubmitButton is true", () => {
+      render(SearchSubmit);
+
+      const submitButton = getSubmitButton();
+      expect(submitButton).toBeInTheDocument();
+      expect(submitButton).toHaveClass("bx--search-button");
+      expect(
+        getSearchInput("Submit search").closest(".bx--search"),
+      ).toHaveClass("bx--search--with-submit");
+    });
+
+    it("dispatches submit with the current value on button click", async () => {
+      const consoleLog = vi.spyOn(console, "log");
+      render(SearchSubmit);
+
+      await user.click(getSubmitButton());
+      expect(consoleLog).toHaveBeenCalledWith("submit", "Cloud functions");
+      expect(screen.getByTestId("submitted")).toHaveTextContent(
+        "Cloud functions",
+      );
+    });
+
+    it("dispatches submit with the current value on Enter", async () => {
+      const consoleLog = vi.spyOn(console, "log");
+      render(SearchSubmit);
+
+      const search = getSearchInput("Submit search");
+      search.focus();
+      await user.keyboard("{Enter}");
+      expect(consoleLog).toHaveBeenCalledWith("submit", "Cloud functions");
+      expect(screen.getByTestId("submitted")).toHaveTextContent(
+        "Cloud functions",
+      );
+    });
+
+    it("does not dispatch submit when disabled", async () => {
+      const consoleLog = vi.spyOn(console, "log");
+      render(SearchSubmit, { props: { disabled: true } });
+
+      await user.click(getSubmitButton());
+      expect(consoleLog).not.toHaveBeenCalled();
+      expect(screen.getByTestId("submitted")).toHaveTextContent("");
+    });
   });
 });

--- a/tests/Search/SearchSubmit.test.svelte
+++ b/tests/Search/SearchSubmit.test.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  import Search from "carbon-components-svelte/Search/Search.svelte";
+
+  export let showSubmitButton = true;
+  export let value = "Cloud functions";
+  export let disabled = false;
+
+  let submitted: string | null = null;
+</script>
+
+<Search
+  bind:value
+  {showSubmitButton}
+  {disabled}
+  labelText="Submit search"
+  placeholder="Search"
+  on:submit={(e) => {
+    submitted = String(e.detail.value);
+    console.log("submit", e.detail.value);
+  }}
+/>
+
+<div data-testid="submitted">{submitted ?? ""}</div>


### PR DESCRIPTION
Optional showSubmitButton adds a trailing search button and a submit
event on click or Enter with the current value.

---

![search submit button example](https://gist.githubusercontent.com/metonym/d18ea53d597ba34d9dfc70686dd350b4/raw/029f9a2499bc03383442a9434a141448584a2358/search-submit-button.png)
