### PR TITLE
feat(slider): add marks

### DIFF
--- a/css/_slider.scss
+++ b/css/_slider.scss
@@ -1,5 +1,6 @@
 @import "carbon-components/scss/globals/scss/vars";
 @import "carbon-components/scss/globals/scss/helper-mixins";
+@import "carbon-components/scss/globals/scss/typography";
 @import "carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/import-once/import-once";
 
 /// Slider validation message styles
@@ -220,7 +221,68 @@
   }
 }
 
-@include exports('slider-validation') {
+/// Slider tick marks / labeled stops
+/// @access private
+/// @group slider
+@mixin slider-marks {
+  // Suppress the Carbon default center tick (`.bx--slider__track:before`,
+  // fixed at 50% regardless of `step`/`min`/`max`) once custom marks render;
+  // otherwise it duplicates or misaligns with an actual mark.
+  .#{$prefix}--slider--with-marks .#{$prefix}--slider__track:before {
+    display: none;
+  }
+
+  // Percentage-based marks track the fluid/fullWidth slider width.
+  .#{$prefix}--slider__marks {
+    position: absolute;
+    top: 50%;
+    left: 0;
+    width: 100%;
+    height: 0;
+    pointer-events: none;
+  }
+
+  .#{$prefix}--slider__mark {
+    position: absolute;
+    top: 0;
+    width: to-rem(2px);
+    height: to-rem(8px);
+    background-color: $ui-03;
+    transform: translate(-50%, -50%);
+  }
+
+  .#{$prefix}--slider__mark-label {
+    @include type-style("label-01");
+
+    position: absolute;
+    top: to-rem(12px);
+    left: 50%;
+    color: $text-02;
+    white-space: nowrap;
+    transform: translateX(-50%);
+  }
+
+  .#{$prefix}--slider--with-mark-labels {
+    padding-bottom: $spacing-07;
+  }
+
+  .#{$prefix}--slider--disabled .#{$prefix}--slider__mark {
+    background-color: $disabled-02;
+  }
+
+  .#{$prefix}--slider--disabled .#{$prefix}--slider__mark-label {
+    color: $disabled-02;
+  }
+
+  .#{$prefix}--label--disabled
+    ~ .#{$prefix}--slider-container
+    .#{$prefix}--slider__mark-label {
+    color: $disabled-02;
+  }
+}
+
+@include exports("slider-validation") {
   @include slider-validation;
   @include slider-two-handle;
+  @include slider-marks;
 }

--- a/docs/src/pages/components/Slider.svx
+++ b/docs/src/pages/components/Slider.svx
@@ -55,6 +55,31 @@ Use `formatValue` to format range labels and `aria-valuetext` (for example curre
 
 <Slider labelText="Opacity" value={75} formatValue={(v) => `${v}%`} />
 
+## Marks
+
+Set `marks` to show tick marks along the track. Pass an array of stops with optional labels, or set `marks` to `true` to tick every `step`. Marks are visual only; snapping still follows `step`.
+
+<Slider
+  labelText="Intensity"
+  hideTextInput
+  min={0}
+  max={3}
+  step={1}
+  value={1}
+  marks={[
+    { value: 0, label: "Off" },
+    { value: 1, label: "Low" },
+    { value: 2, label: "Med" },
+    { value: 3, label: "High" },
+  ]}
+/>
+
+### Every step
+
+Set `marks` to `true` to place a tick at every `step`.
+
+<Slider labelText="Instances" hideTextInput min={0} max={10} step={2} value={4} marks />
+
 ## Light
 
 Use the light variant for light backgrounds.
@@ -118,6 +143,26 @@ Set `min`, `max`, and `step` to customize the range.
 `formatValue` applies to both thumbs' `aria-valuetext` and the range labels. Bound `value` / `valueUpper` stay numeric.
 
 <RangeSlider labelText="Price range" value={20} valueUpper={80} formatValue={(v) => new Intl.NumberFormat("en-US", { style: "currency", currency: "USD", maximumFractionDigits: 0 }).format(v)} />
+
+### Marks
+
+Set `marks` the same way as on `Slider` for tick marks and optional labels.
+
+<RangeSlider
+  labelText="Intensity"
+  hideTextInput
+  min={0}
+  max={3}
+  step={1}
+  value={0}
+  valueUpper={2}
+  marks={[
+    { value: 0, label: "Off" },
+    { value: 1, label: "Low" },
+    { value: 2, label: "Med" },
+    { value: 3, label: "High" },
+  ]}
+/>
 
 ### Invalid
 

--- a/src/Slider/RangeSlider.svelte
+++ b/src/Slider/RangeSlider.svelte
@@ -38,6 +38,15 @@
   /** Set the step value */
   export let step = 1;
 
+  /**
+   * Show tick marks along the track.
+   * Set to `true` to place a tick at every `step`, or pass an array of
+   * `{ value, label? }` for specific stops with optional labels below the track.
+   * Marks are visual only; snapping still follows `step`.
+   * @type {boolean | ReadonlyArray<{ value: number; label?: string }>}
+   */
+  export let marks = false;
+
   /** Set the step multiplier value */
   export let stepMultiplier = 4;
 
@@ -117,6 +126,7 @@
   import WarningAltFilled from "../icons/WarningAltFilled.svelte";
   import WarningFilled from "../icons/WarningFilled.svelte";
   import { dismiss } from "../utils/dismiss.js";
+  import { resolveSliderMarks } from "../utils/resolveSliderMarks.js";
 
   /** @typedef {{ value: number; valueUpper: number }} RangeSliderChangeDetail */
   /** @typedef {"lower" | "upper"} ActiveHandle */
@@ -271,6 +281,10 @@
   $: range = max - min;
   $: left = range === 0 ? 0 : ((value - min) / range) * 100;
   $: leftUpper = range === 0 ? 0 : ((valueUpper - min) / range) * 100;
+  $: resolvedMarks = resolveSliderMarks(marks, min, max, step);
+  $: hasMarkLabels = resolvedMarks.some(
+    (mark) => mark.label != null && mark.label !== "",
+  );
   $: {
     if (value < min) value = min;
     if (value > max) value = max;
@@ -375,6 +389,8 @@
       class:bx--slider={true}
       class:bx--slider--disabled={disabled}
       class:bx--slider--readonly={readonly}
+      class:bx--slider--with-marks={resolvedMarks.length > 0}
+      class:bx--slider--with-mark-labels={hasMarkLabels}
       style:max-width={fullWidth ? "none" : undefined}
       on:mousedown={startInteraction}
       on:touchstart={startInteraction}
@@ -478,6 +494,19 @@
         style:transform="translate({left}%, -50%) scaleX({(leftUpper - left) /
           100})"
       ></div>
+      {#if resolvedMarks.length > 0}
+        <div class:bx--slider__marks={true} aria-hidden="true">
+          {#each resolvedMarks as mark (mark.value)}
+            {@const percent =
+              range === 0 ? 0 : ((mark.value - min) / range) * 100}
+            <span class:bx--slider__mark={true} style:left="{percent}%">
+              {#if mark.label != null && mark.label !== ""}
+                <span class:bx--slider__mark-label={true}>{mark.label}</span>
+              {/if}
+            </span>
+          {/each}
+        </div>
+      {/if}
     </div>
     <span class:bx--slider__range-label={true}
       >{formatRangeLabel(maxLabel, max)}</span

--- a/src/Slider/Slider.svelte
+++ b/src/Slider/Slider.svelte
@@ -32,6 +32,15 @@
   /** Set the step value */
   export let step = 1;
 
+  /**
+   * Show tick marks along the track.
+   * Set to `true` to place a tick at every `step`, or pass an array of
+   * `{ value, label? }` for specific stops with optional labels below the track.
+   * Marks are visual only; snapping still follows `step`.
+   * @type {boolean | ReadonlyArray<{ value: number; label?: string }>}
+   */
+  export let marks = false;
+
   /** Set the step multiplier value */
   export let stepMultiplier = 4;
 
@@ -102,6 +111,7 @@
   import WarningAltFilled from "../icons/WarningAltFilled.svelte";
   import WarningFilled from "../icons/WarningFilled.svelte";
   import { dismiss } from "../utils/dismiss.js";
+  import { resolveSliderMarks } from "../utils/resolveSliderMarks.js";
 
   const dispatch = createEventDispatcher();
 
@@ -174,6 +184,10 @@
   $: showWarn = warn && !invalid && !disabled && !readonly;
   $: range = max - min;
   $: left = ((value - min) / range) * 100;
+  $: resolvedMarks = resolveSliderMarks(marks, min, max, step);
+  $: hasMarkLabels = resolvedMarks.some(
+    (mark) => mark.label != null && mark.label !== "",
+  );
   $: {
     if (value <= min) {
       value = min;
@@ -230,6 +244,8 @@
       class:bx--slider={true}
       class:bx--slider--disabled={disabled}
       class:bx--slider--readonly={readonly}
+      class:bx--slider--with-marks={resolvedMarks.length > 0}
+      class:bx--slider--with-mark-labels={hasMarkLabels}
       style:max-width={fullWidth ? "none" : undefined}
       on:mousedown={startInteraction}
       on:touchstart={startInteraction}
@@ -278,6 +294,19 @@
         class:bx--slider__filled-track={true}
         style:transform="translate(0, -50%) scaleX({left / 100})"
       ></div>
+      {#if resolvedMarks.length > 0}
+        <div class:bx--slider__marks={true} aria-hidden="true">
+          {#each resolvedMarks as mark (mark.value)}
+            {@const percent =
+              range === 0 ? 0 : ((mark.value - min) / range) * 100}
+            <span class:bx--slider__mark={true} style:left="{percent}%">
+              {#if mark.label != null && mark.label !== ""}
+                <span class:bx--slider__mark-label={true}>{mark.label}</span>
+              {/if}
+            </span>
+          {/each}
+        </div>
+      {/if}
     </div>
     <span class:bx--slider__range-label={true}
       >{formatRangeLabel(maxLabel, max)}</span

--- a/src/utils/resolveSliderMarks.d.ts
+++ b/src/utils/resolveSliderMarks.d.ts
@@ -1,0 +1,17 @@
+/**
+ * Resolve Slider / RangeSlider `marks` into a list of tick positions.
+ */
+
+export type SliderMark = { value: number; label?: string };
+
+/**
+ * Resolve `marks` into tick entries within `[min, max]`.
+ * `true` generates a tick at every `step` from `min` through `max`.
+ * An array is filtered to values in range. Falsy values yield no marks.
+ */
+export function resolveSliderMarks(
+  marks: boolean | ReadonlyArray<SliderMark> | null | undefined,
+  min: number,
+  max: number,
+  step: number,
+): SliderMark[];

--- a/src/utils/resolveSliderMarks.js
+++ b/src/utils/resolveSliderMarks.js
@@ -1,0 +1,43 @@
+// @ts-check
+// Resolve Slider / RangeSlider `marks` into a list of tick positions.
+
+/**
+ * @typedef {{ value: number; label?: string }} SliderMark
+ */
+
+/**
+ * Resolve `marks` into tick entries within `[min, max]`.
+ * `true` generates a tick at every `step` from `min` through `max`.
+ * An array is filtered to values in range. Falsy values yield no marks.
+ *
+ * @param {boolean | ReadonlyArray<SliderMark> | null | undefined} marks
+ * @param {number} min
+ * @param {number} max
+ * @param {number} step
+ * @returns {SliderMark[]}
+ */
+export function resolveSliderMarks(marks, min, max, step) {
+  if (!marks) return [];
+
+  if (Array.isArray(marks)) {
+    return marks.filter(
+      (mark) =>
+        typeof mark?.value === "number" &&
+        !Number.isNaN(mark.value) &&
+        mark.value >= min &&
+        mark.value <= max,
+    );
+  }
+
+  if (marks !== true || !(step > 0) || max < min) return [];
+
+  const range = max - min;
+  const steps = Math.round(range / step);
+  /** @type {SliderMark[]} */
+  const resolved = [];
+  for (let i = 0; i <= steps; i++) {
+    const value = i === steps ? max : min + i * step;
+    resolved.push({ value });
+  }
+  return resolved;
+}

--- a/tests/Slider/RangeSlider.test.svelte
+++ b/tests/Slider/RangeSlider.test.svelte
@@ -6,6 +6,10 @@
   export let min = 0;
   export let max = 100;
   export let step = 1;
+  export let marks:
+    | boolean
+    | ReadonlyArray<{ value: number; label?: string }>
+    | undefined = false;
   export let disabled = false;
   export let readonly = false;
   export let hideTextInput = false;
@@ -24,6 +28,7 @@
   {min}
   {max}
   {step}
+  {marks}
   {disabled}
   {readonly}
   {hideTextInput}

--- a/tests/Slider/RangeSlider.test.ts
+++ b/tests/Slider/RangeSlider.test.ts
@@ -251,4 +251,39 @@ describe("RangeSlider", () => {
       valueUpper: 89,
     });
   });
+
+  it("should render labeled marks at the given values", () => {
+    const { container } = render(RangeSlider, {
+      props: {
+        min: 0,
+        max: 3,
+        step: 1,
+        value: 0,
+        valueUpper: 2,
+        marks: [
+          { value: 0, label: "Off" },
+          { value: 1, label: "Low" },
+          { value: 2, label: "Med" },
+          { value: 3, label: "High" },
+        ],
+      },
+    });
+
+    const markEls = container.querySelectorAll(".bx--slider__mark");
+    expect(markEls).toHaveLength(4);
+    expect(screen.getByText("Off")).toBeInTheDocument();
+    expect(screen.getByText("High")).toBeInTheDocument();
+    expect(markEls[0]).toHaveStyle({ left: "0%" });
+    expect(markEls[3]).toHaveStyle({ left: "100%" });
+  });
+
+  it("should place a tick at every step when marks is true", () => {
+    const { container } = render(RangeSlider, {
+      props: { min: 0, max: 10, step: 5, marks: true },
+    });
+
+    const markEls = container.querySelectorAll(".bx--slider__mark");
+    expect(markEls).toHaveLength(3);
+    expect(markEls[1]).toHaveStyle({ left: "50%" });
+  });
 });

--- a/tests/Slider/Slider.test.svelte
+++ b/tests/Slider/Slider.test.svelte
@@ -17,6 +17,10 @@
   export let min = 0;
   export let max = 100;
   export let step = 1;
+  export let marks:
+    | boolean
+    | ReadonlyArray<{ value: number; label?: string }>
+    | undefined = false;
   export let light = false;
   export let hideLabel = false;
   export let labelText = "Test Slider";
@@ -38,6 +42,7 @@
     {min}
     {max}
     {step}
+    {marks}
     {disabled}
     {readonly}
     {invalid}
@@ -73,6 +78,7 @@
     {min}
     {max}
     {step}
+    {marks}
     {disabled}
     {readonly}
     {invalid}

--- a/tests/Slider/Slider.test.ts
+++ b/tests/Slider/Slider.test.ts
@@ -808,4 +808,58 @@ describe("Slider", () => {
     expect(Number.isInteger(secondValue)).toBe(true);
     expect(secondValue % 1).toBe(0);
   });
+
+  it("should render labeled marks at the given values", () => {
+    const { container } = render(Slider, {
+      props: {
+        min: 0,
+        max: 3,
+        step: 1,
+        value: 1,
+        marks: [
+          { value: 0, label: "Off" },
+          { value: 1, label: "Low" },
+          { value: 2, label: "Med" },
+          { value: 3, label: "High" },
+        ],
+      },
+    });
+
+    const marksEl = container.querySelector(".bx--slider__marks");
+    const markEls = container.querySelectorAll(".bx--slider__mark");
+    expect(marksEl).toBeInTheDocument();
+    expect(markEls).toHaveLength(4);
+    expect(screen.getByText("Off")).toBeInTheDocument();
+    expect(screen.getByText("Low")).toBeInTheDocument();
+    expect(screen.getByText("Med")).toBeInTheDocument();
+    expect(screen.getByText("High")).toBeInTheDocument();
+    expect(markEls[0]).toHaveStyle({ left: "0%" });
+    expect(markEls[1]).toHaveStyle({ left: `${(1 / 3) * 100}%` });
+    expect(markEls[3]).toHaveStyle({ left: "100%" });
+    expect(container.querySelector(".bx--slider")).toHaveClass(
+      "bx--slider--with-marks",
+      "bx--slider--with-mark-labels",
+    );
+  });
+
+  it("should place a tick at every step when marks is true", () => {
+    const { container } = render(Slider, {
+      props: { min: 0, max: 10, step: 5, marks: true },
+    });
+
+    const markEls = container.querySelectorAll(".bx--slider__mark");
+    expect(markEls).toHaveLength(3);
+    expect(markEls[0]).toHaveStyle({ left: "0%" });
+    expect(markEls[1]).toHaveStyle({ left: "50%" });
+    expect(markEls[2]).toHaveStyle({ left: "100%" });
+    expect(container.querySelector(".bx--slider__mark-label")).toBeNull();
+  });
+
+  it("should not render marks when marks is false", () => {
+    const { container } = render(Slider, {
+      props: { marks: false },
+    });
+
+    expect(container.querySelector(".bx--slider__marks")).toBeNull();
+  });
 });

--- a/tests/utils/resolveSliderMarks.test.ts
+++ b/tests/utils/resolveSliderMarks.test.ts
@@ -1,0 +1,41 @@
+import { resolveSliderMarks } from "../../src/utils/resolveSliderMarks.js";
+
+describe("resolveSliderMarks", () => {
+  test("returns empty array for falsy marks", () => {
+    expect(resolveSliderMarks(false, 0, 100, 1)).toEqual([]);
+    expect(resolveSliderMarks(undefined, 0, 100, 1)).toEqual([]);
+    expect(resolveSliderMarks(null, 0, 100, 1)).toEqual([]);
+  });
+
+  test("generates a tick at every step when marks is true", () => {
+    expect(resolveSliderMarks(true, 0, 10, 5)).toEqual([
+      { value: 0 },
+      { value: 5 },
+      { value: 10 },
+    ]);
+  });
+
+  test("filters array marks to the min/max range", () => {
+    expect(
+      resolveSliderMarks(
+        [
+          { value: -1, label: "below" },
+          { value: 0, label: "Off" },
+          { value: 2, label: "Med" },
+          { value: 99, label: "above" },
+        ],
+        0,
+        3,
+        1,
+      ),
+    ).toEqual([
+      { value: 0, label: "Off" },
+      { value: 2, label: "Med" },
+    ]);
+  });
+
+  test("returns empty array when step is not positive in boolean mode", () => {
+    expect(resolveSliderMarks(true, 0, 10, 0)).toEqual([]);
+    expect(resolveSliderMarks(true, 0, 10, -1)).toEqual([]);
+  });
+});


### PR DESCRIPTION
marks on Slider and RangeSlider draw tick stops (boolean step ticks or a
labeled array) without changing the numeric model.

---


<img width="650" height="335" alt="Screenshot 2026-08-02 at 12 57 55 PM" src="https://github.com/user-attachments/assets/da659507-b368-45a5-894e-29f6aab263c9" />
<img width="704" height="316" alt="Screenshot 2026-08-02 at 12 58 07 PM" src="https://github.com/user-attachments/assets/c7158e0c-7020-4679-9300-05d213b879fa" />
