### PR TITLE
feat(slider): add `formatValue`

### DIFF
--- a/docs/src/pages/components/Slider.svx
+++ b/docs/src/pages/components/Slider.svx
@@ -47,6 +47,14 @@ Set `step` to control increment size.
 
 <Slider labelText="Runtime memory (MB)" min={10} max={990} maxLabel="990 MB" value={100} step={10} />
 
+### Formatted values
+
+Use `formatValue` to format range labels and `aria-valuetext` (for example currency or percent). The text input and bound `value` stay numeric.
+
+<Slider labelText="Budget" value={50} formatValue={(v) => new Intl.NumberFormat("en-US", { style: "currency", currency: "USD", maximumFractionDigits: 0 }).format(v)} />
+
+<Slider labelText="Opacity" value={75} formatValue={(v) => `${v}%`} />
+
 ## Light
 
 Use the light variant for light backgrounds.
@@ -104,6 +112,12 @@ Set `hideTextInput` to `true` to hide both numeric inputs while keeping the slid
 Set `min`, `max`, and `step` to customize the range.
 
 <RangeSlider labelText="Runtime memory (MB)" min={10} max={990} maxLabel="990 MB" step={10} value={100} valueUpper={500} />
+
+### Formatted values
+
+`formatValue` applies to both thumbs' `aria-valuetext` and the range labels. Bound `value` / `valueUpper` stay numeric.
+
+<RangeSlider labelText="Price range" value={20} valueUpper={80} formatValue={(v) => new Intl.NumberFormat("en-US", { style: "currency", currency: "USD", maximumFractionDigits: 0 }).format(v)} />
 
 ### Invalid
 

--- a/src/Slider/RangeSlider.svelte
+++ b/src/Slider/RangeSlider.svelte
@@ -28,6 +28,13 @@
   /** Specify the label for the min value */
   export let minLabel = "";
 
+  /**
+   * Format displayed values for range labels and `aria-valuetext`.
+   * Does not change the numeric model; the text inputs stay numeric.
+   * @type {undefined | ((value: number) => string)}
+   */
+  export let formatValue = undefined;
+
   /** Set the step value */
   export let step = 1;
 
@@ -130,6 +137,18 @@
   let holding = false;
   /** @type {PointerLikeEvent | null} */
   let currentEvent = null;
+
+  /** @type {(label: string, numericValue: number) => string | number} */
+  function formatRangeLabel(label, numericValue) {
+    if (label) return label;
+    if (formatValue) return formatValue(numericValue);
+    return label || numericValue;
+  }
+
+  /** @type {(numericValue: number) => string | undefined} */
+  function getValueText(numericValue) {
+    return formatValue ? formatValue(numericValue) : undefined;
+  }
 
   /** @type {(e: PointerLikeEvent) => number | null} */
   function getClientX(event) {
@@ -348,7 +367,9 @@
         />
       {/if}
     </div>
-    <span class:bx--slider__range-label={true}>{minLabel || min}</span>
+    <span class:bx--slider__range-label={true}
+      >{formatRangeLabel(minLabel, min)}</span
+    >
     <div
       bind:this={ref}
       class:bx--slider={true}
@@ -372,6 +393,7 @@
           aria-valuemax={valueUpper}
           aria-valuemin={min}
           aria-valuenow={value}
+          aria-valuetext={getValueText(value)}
           aria-label={ariaLabelInput}
           aria-describedby={invalid ? errorId : warn ? warnId : undefined}
           aria-invalid={invalid || undefined}
@@ -418,6 +440,7 @@
           aria-valuemax={max}
           aria-valuemin={value}
           aria-valuenow={valueUpper}
+          aria-valuetext={getValueText(valueUpper)}
           aria-label={ariaLabelInputUpper}
           aria-describedby={invalid ? errorId : warn ? warnId : undefined}
           aria-invalid={invalid || undefined}
@@ -456,7 +479,9 @@
           100})"
       ></div>
     </div>
-    <span class:bx--slider__range-label={true}>{maxLabel || max}</span>
+    <span class:bx--slider__range-label={true}
+      >{formatRangeLabel(maxLabel, max)}</span
+    >
     <div
       class:bx--slider-text-input-wrapper={true}
       class:bx--slider-text-input-wrapper--upper={true}

--- a/src/Slider/Slider.svelte
+++ b/src/Slider/Slider.svelte
@@ -22,6 +22,13 @@
   /** Specify the label for the min value */
   export let minLabel = "";
 
+  /**
+   * Format displayed values for range labels and `aria-valuetext`.
+   * Does not change the numeric model; the text input stays numeric.
+   * @type {undefined | ((value: number) => string)}
+   */
+  export let formatValue = undefined;
+
   /** Set the step value */
   export let step = 1;
 
@@ -102,6 +109,18 @@
   let dragging = false;
   let holding = false;
   let currentEvent = null;
+
+  /** @type {(label: string, numericValue: number) => string | number} */
+  function formatRangeLabel(label, numericValue) {
+    if (label) return label;
+    if (formatValue) return formatValue(numericValue);
+    return label ?? numericValue;
+  }
+
+  /** @type {(numericValue: number) => string | undefined} */
+  function getValueText(numericValue) {
+    return formatValue ? formatValue(numericValue) : undefined;
+  }
 
   function startInteraction(event) {
     if (disabled || readonly) return;
@@ -203,7 +222,9 @@
     class:bx--slider-container--readonly={readonly}
     style:width={fullWidth && "100%"}
   >
-    <span class:bx--slider__range-label={true}>{minLabel ?? min}</span>
+    <span class:bx--slider__range-label={true}
+      >{formatRangeLabel(minLabel, min)}</span
+    >
     <div
       bind:this={ref}
       class:bx--slider={true}
@@ -221,6 +242,7 @@
         aria-valuemax={max}
         aria-valuemin={min}
         aria-valuenow={value}
+        aria-valuetext={getValueText(value)}
         aria-labelledby={labelId}
         aria-describedby={showInvalid
           ? errorId
@@ -257,7 +279,9 @@
         style:transform="translate(0, -50%) scaleX({left / 100})"
       ></div>
     </div>
-    <span class:bx--slider__range-label={true}>{maxLabel ?? max}</span>
+    <span class:bx--slider__range-label={true}
+      >{formatRangeLabel(maxLabel, max)}</span
+    >
     <div class:bx--slider-text-input-wrapper={true}>
       {#if showInvalid}
         <WarningFilled class="bx--slider__invalid-icon" />

--- a/tests/Slider/RangeSlider.test.svelte
+++ b/tests/Slider/RangeSlider.test.svelte
@@ -12,6 +12,7 @@
   export let labelText = "Range";
   export let name = "";
   export let nameUpper = "";
+  export let formatValue: ((value: number) => string) | undefined = undefined;
   export let ariaLabelInput: string | undefined = undefined;
   export let ariaLabelInputUpper: string | undefined = undefined;
 </script>
@@ -28,6 +29,7 @@
   {hideTextInput}
   {name}
   {nameUpper}
+  {formatValue}
   ariaLabelInput={ariaLabelInput ?? "Lower bound"}
   ariaLabelInputUpper={ariaLabelInputUpper ?? "Upper bound"}
   on:change={(e) => {

--- a/tests/Slider/RangeSlider.test.ts
+++ b/tests/Slider/RangeSlider.test.ts
@@ -161,6 +161,53 @@ describe("RangeSlider", () => {
     expect(inputs[1]).toHaveAttribute("name", "upper");
   });
 
+  it("should format aria-valuetext on both thumbs without changing numeric values", () => {
+    render(RangeSlider, {
+      props: {
+        value: 20,
+        valueUpper: 80,
+        formatValue: (v) => `$${v}`,
+      },
+    });
+
+    const [lowerThumb, upperThumb] = screen.getAllByRole("slider");
+    expect(lowerThumb).toHaveAttribute("aria-valuetext", "$20");
+    expect(upperThumb).toHaveAttribute("aria-valuetext", "$80");
+    expect(lowerThumb).toHaveAttribute("aria-valuenow", "20");
+    expect(upperThumb).toHaveAttribute("aria-valuenow", "80");
+    expect(screen.getByText("$0")).toBeInTheDocument();
+    expect(screen.getByText("$100")).toBeInTheDocument();
+
+    const inputs = screen.getAllByRole("spinbutton");
+    expect(inputs[0]).toHaveValue(20);
+    expect(inputs[1]).toHaveValue(80);
+  });
+
+  it("should keep value props numeric when formatValue is set", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(RangeSlider, {
+      props: {
+        value: 10,
+        valueUpper: 90,
+        formatValue: (v) => `${v}%`,
+      },
+    });
+
+    const [lowerThumb] = screen.getAllByRole("slider");
+    expect(lowerThumb).toHaveAttribute("aria-valuetext", "10%");
+
+    lowerThumb.focus();
+    await user.keyboard("{ArrowRight}");
+
+    expect(consoleLog).toHaveBeenCalledWith("change", {
+      value: 11,
+      valueUpper: 90,
+    });
+    expect(lowerThumb).toHaveAttribute("aria-valuenow", "11");
+    expect(lowerThumb).toHaveAttribute("aria-valuetext", "11%");
+    expect(screen.getAllByRole("spinbutton")[0]).toHaveValue(11);
+  });
+
   it("should not respond to keyboard when disabled", () => {
     render(RangeSlider, {
       props: { value: 10, valueUpper: 90, disabled: true },

--- a/tests/Slider/Slider.test.svelte
+++ b/tests/Slider/Slider.test.svelte
@@ -11,6 +11,7 @@
   export let required = false;
   export let minLabel = "";
   export let maxLabel = "";
+  export let formatValue: ((value: number) => string) | undefined = undefined;
   export let hideTextInput = false;
   export let fullWidth = false;
   export let min = 0;
@@ -46,6 +47,7 @@
     {required}
     {minLabel}
     {maxLabel}
+    {formatValue}
     {hideTextInput}
     {fullWidth}
     {light}
@@ -80,6 +82,7 @@
     {required}
     {minLabel}
     {maxLabel}
+    {formatValue}
     {hideTextInput}
     {fullWidth}
     {light}

--- a/tests/Slider/Slider.test.ts
+++ b/tests/Slider/Slider.test.ts
@@ -430,6 +430,44 @@ describe("Slider", () => {
     expect(screen.getByText("100 MB")).toBeInTheDocument();
   });
 
+  it("should format aria-valuetext and range labels without changing the numeric value", () => {
+    render(Slider, {
+      props: {
+        value: 50,
+        formatValue: (v) => `$${v}`,
+      },
+    });
+
+    const slider = screen.getByRole("slider");
+    expect(slider).toHaveAttribute("aria-valuetext", "$50");
+    expect(slider).toHaveAttribute("aria-valuenow", "50");
+    expect(screen.getByText("$0")).toBeInTheDocument();
+    expect(screen.getByText("$100")).toBeInTheDocument();
+    expect(screen.getByRole("spinbutton")).toHaveValue(50);
+  });
+
+  it("should keep value numeric when formatValue is set", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(Slider, {
+      props: {
+        value: 10,
+        formatValue: (v) => `${v}%`,
+      },
+    });
+
+    const slider = screen.getByRole("slider");
+    expect(slider).toHaveAttribute("aria-valuetext", "10%");
+
+    await user.tab();
+    expect(slider).toHaveFocus();
+    await user.keyboard("{ArrowRight}");
+
+    expect(consoleLog).toHaveBeenCalledWith("change", 11);
+    expect(slider).toHaveAttribute("aria-valuenow", "11");
+    expect(slider).toHaveAttribute("aria-valuetext", "11%");
+    expect(screen.getByRole("spinbutton")).toHaveValue(11);
+  });
+
   it("should handle required state", () => {
     render(Slider, {
       props: { required: true },


### PR DESCRIPTION
formatValue customizes visible labels and aria-valuetext on
Slider/RangeSlider; the bound numeric value is unchanged.

---

![slider formatValue example — currency and percent labels, aria-valuetext confirmed as "$50"/"75%", numeric text input unaffected](https://gist.githubusercontent.com/metonym/ab44a3e37e7fcc207efa49e06de617bd/raw/5dad4150325a81186fd618e5530344274a11691f/slider-format-value.png)
