### PR TITLE
feat(ui-shell): add openOnHover on HeaderNavMenu

### DIFF
--- a/docs/src/pages/components/UIShell.svx
+++ b/docs/src/pages/components/UIShell.svx
@@ -42,6 +42,12 @@ Duplicate those items in `HeaderSideNavItems` so the links stay in the side nav 
 
 <FileSource src="/framed/UIShell/HeaderNavExternalLinks" />
 
+### Hover menus
+
+Set `openOnHover` to `true` on `HeaderNavMenu` to open the submenu after a short delay when the pointer enters, and close it when the pointer leaves. Click and keyboard behavior are unchanged.
+
+<FileSource src="/framed/UIShell/HeaderNavHover" />
+
 ## Side navigation
 
 Pair the header with a `SideNav`. It collapses behind a hamburger menu by default and also supports responsive, fixed, and rail layouts.

--- a/docs/src/pages/framed/UIShell/HeaderNavHover.svelte
+++ b/docs/src/pages/framed/UIShell/HeaderNavHover.svelte
@@ -1,0 +1,39 @@
+<script>
+  import {
+    Column,
+    Content,
+    Grid,
+    Header,
+    HeaderNav,
+    HeaderNavItem,
+    HeaderNavMenu,
+    Row,
+    SkipToContent,
+  } from "carbon-components-svelte";
+</script>
+
+<Header companyName="IBM" platformName="Cloud">
+  <svelte:fragment slot="skipToContent"> <SkipToContent /> </svelte:fragment>
+  <HeaderNav>
+    <HeaderNavItem href="/catalog" text="Catalog" />
+    <HeaderNavItem href="/docs" text="Docs" />
+    <HeaderNavMenu text="Products" openOnHover>
+      <HeaderNavItem href="/products/a" text="Product A" />
+      <HeaderNavItem href="/products/b" text="Product B" />
+      <HeaderNavItem href="/products/c" text="Product C" />
+    </HeaderNavMenu>
+    <HeaderNavMenu text="Solutions" openOnHover>
+      <HeaderNavItem href="/solutions/industry" text="Industry" />
+      <HeaderNavItem href="/solutions/use-cases" text="Use cases" />
+    </HeaderNavMenu>
+    <HeaderNavItem href="/support" text="Support" />
+  </HeaderNav>
+</Header>
+
+<Content>
+  <Grid>
+    <Row>
+      <Column> <h1>Dashboard</h1> </Column>
+    </Row>
+  </Grid>
+</Content>

--- a/src/UIShell/HeaderNavMenu.svelte
+++ b/src/UIShell/HeaderNavMenu.svelte
@@ -27,13 +27,22 @@
    */
   export let ref = null;
 
-  import { createEventDispatcher, setContext, tick } from "svelte";
+  /**
+   * Set to `true` to open the menu on hover after a short delay.
+   * Click and keyboard behavior are unchanged.
+   */
+  export let openOnHover = false;
+
+  import { createEventDispatcher, onMount, setContext, tick } from "svelte";
   import { writable } from "svelte/store";
   import ChevronDown from "../icons/ChevronDown.svelte";
   import { dismiss } from "../utils/dismiss.js";
   import { isOutsideClick } from "../utils/isOutsideClick.js";
 
   const dispatch = createEventDispatcher();
+
+  // "moderate-01" duration (ms) from Carbon motion — matches MenuItem submenu hover.
+  const HOVER_DELAY_MS = 150;
 
   /**
    * @type {import("svelte/store").Writable<Record<string, boolean>>}
@@ -45,6 +54,10 @@
   const menuItems = writable([]);
 
   let menuRef = null;
+  /** @type {ReturnType<typeof setTimeout> | undefined} */
+  let hoverTimeout;
+  /** @type {ReturnType<typeof setTimeout> | undefined} */
+  let closeTimeout;
 
   /**
    * @type {(item: { id: string; isSelected: boolean }) => void}
@@ -100,6 +113,35 @@
       dispatch("close", { trigger: "outside-click" });
     }
   }
+
+  function clearHoverTimers() {
+    clearTimeout(hoverTimeout);
+    clearTimeout(closeTimeout);
+  }
+
+  function scheduleOpenOnHover() {
+    if (!openOnHover) return;
+    clearTimeout(closeTimeout);
+    clearTimeout(hoverTimeout);
+    hoverTimeout = setTimeout(() => {
+      expanded = true;
+    }, HOVER_DELAY_MS);
+  }
+
+  function scheduleCloseOnHover() {
+    if (!openOnHover) return;
+    clearTimeout(hoverTimeout);
+    clearTimeout(closeTimeout);
+    closeTimeout = setTimeout(() => {
+      expanded = false;
+    }, HOVER_DELAY_MS);
+  }
+
+  onMount(() => {
+    return () => {
+      clearHoverTimers();
+    };
+  });
 </script>
 
 <li
@@ -119,6 +161,8 @@
       expanded = !expanded;
     }
   }}
+  on:mouseenter={scheduleOpenOnHover}
+  on:mouseleave={scheduleCloseOnHover}
 >
   <a
     bind:this={ref}

--- a/tests/UIShell/HeaderNavMenuHover.test.svelte
+++ b/tests/UIShell/HeaderNavMenuHover.test.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  import Header from "carbon-components-svelte/UIShell/Header.svelte";
+  import HeaderNav from "carbon-components-svelte/UIShell/HeaderNav.svelte";
+  import HeaderNavItem from "carbon-components-svelte/UIShell/HeaderNavItem.svelte";
+  import HeaderNavMenu from "carbon-components-svelte/UIShell/HeaderNavMenu.svelte";
+
+  export let openOnHover = true;
+</script>
+
+<Header companyName="Test" platformName="Test">
+  <HeaderNav>
+    <HeaderNavItem href="/" text="Link 1" />
+    <HeaderNavMenu text="Menu" {openOnHover}>
+      <HeaderNavItem href="/item1" text="Menu Item 1" />
+      <HeaderNavItem href="/item2" text="Menu Item 2" />
+      <HeaderNavItem href="/item3" text="Menu Item 3" />
+    </HeaderNavMenu>
+  </HeaderNav>
+</Header>

--- a/tests/UIShell/HeaderNavMenuHover.test.ts
+++ b/tests/UIShell/HeaderNavMenuHover.test.ts
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import { fireEvent, render, screen } from "@testing-library/svelte";
+import { user } from "../utils/user";
+import HeaderNavMenuHover from "./HeaderNavMenuHover.test.svelte";
+
+/** HeaderNavMenu's hover-open/close delay. */
+const HOVER_DELAY_MS = 150;
+
+describe("HeaderNavMenu openOnHover", () => {
+  it("opens the menu on hover after a delay", async () => {
+    vi.useFakeTimers();
+    try {
+      render(HeaderNavMenuHover);
+
+      const submenu = screen
+        .getByRole("menuitem", { name: "Menu" })
+        .closest(".bx--header__submenu");
+      assert(submenu);
+
+      await fireEvent.mouseEnter(submenu);
+      expect(screen.getByRole("menuitem", { name: "Menu" })).toHaveAttribute(
+        "aria-expanded",
+        "false",
+      );
+
+      await vi.advanceTimersByTimeAsync(HOVER_DELAY_MS);
+      expect(screen.getByRole("menuitem", { name: "Menu" })).toHaveAttribute(
+        "aria-expanded",
+        "true",
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("closes the menu after the pointer leaves and the delay elapses", async () => {
+    vi.useFakeTimers();
+    try {
+      render(HeaderNavMenuHover);
+
+      const menuTrigger = screen.getByRole("menuitem", { name: "Menu" });
+      const submenu = menuTrigger.closest(".bx--header__submenu");
+      assert(submenu);
+
+      await fireEvent.mouseEnter(submenu);
+      await vi.advanceTimersByTimeAsync(HOVER_DELAY_MS);
+      expect(menuTrigger).toHaveAttribute("aria-expanded", "true");
+
+      await fireEvent.mouseLeave(submenu);
+      expect(menuTrigger).toHaveAttribute("aria-expanded", "true");
+
+      await vi.advanceTimersByTimeAsync(HOVER_DELAY_MS);
+      expect(menuTrigger).toHaveAttribute("aria-expanded", "false");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not open on hover when openOnHover is false", async () => {
+    vi.useFakeTimers();
+    try {
+      render(HeaderNavMenuHover, { props: { openOnHover: false } });
+
+      const menuTrigger = screen.getByRole("menuitem", { name: "Menu" });
+      const submenu = menuTrigger.closest(".bx--header__submenu");
+      assert(submenu);
+
+      await fireEvent.mouseEnter(submenu);
+      await vi.advanceTimersByTimeAsync(HOVER_DELAY_MS);
+      expect(menuTrigger).toHaveAttribute("aria-expanded", "false");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("still toggles with keyboard when openOnHover is enabled", async () => {
+    render(HeaderNavMenuHover);
+
+    const menuTrigger = screen.getByRole("menuitem", { name: "Menu" });
+    menuTrigger.focus();
+
+    await user.keyboard("{Enter}");
+    expect(menuTrigger).toHaveAttribute("aria-expanded", "true");
+
+    await user.keyboard("{Escape}");
+    expect(menuTrigger).toHaveAttribute("aria-expanded", "false");
+    expect(menuTrigger).toHaveFocus();
+  });
+});


### PR DESCRIPTION
openOnHover on HeaderNavMenu opens on pointer enter/leave with short
delays; keyboard open/close is unchanged.

---

![ui-shell hover nav example — rapid traversal and repeated back-and-forth hovering between adjacent menus settles cleanly with exactly one menu open, no stuck state](https://gist.githubusercontent.com/metonym/6de3e66820e293f13aa95cf8b28c2527/raw/b9871517a349edba24cb12976678737ac8d779a6/uishell-hover-nav.png)
