### PR TITLE
feat(pagination): add simple compact mode

### DIFF
--- a/css/_pagination.scss
+++ b/css/_pagination.scss
@@ -1,5 +1,6 @@
 // Extra-small (xs, 24px) pagination. v10 ships sm/lg only; upstream carbon#21695.
 // v11 sizes from layout.height; at xs that is 24px ($size-xs / 1.5rem in v10).
+// Simple mode: compact prev/next + status for toolbars and cards.
 
 @import "carbon-components/scss/globals/scss/vars";
 @import "carbon-components/scss/globals/scss/helper-mixins";
@@ -27,6 +28,47 @@
   }
 }
 
+/// Compact pagination for toolbars and cards
+/// @access private
+/// @group components
+@mixin pagination-simple {
+  .#{$prefix}--pagination--simple {
+    width: auto;
+    justify-content: flex-end;
+    border-top: 0;
+    background-color: transparent;
+  }
+
+  .#{$prefix}--pagination--simple .#{$prefix}--pagination__right {
+    margin-left: 0;
+  }
+
+  .#{$prefix}--pagination--simple
+    .#{$prefix}--pagination__right
+    > .#{$prefix}--pagination__text {
+    margin-left: $spacing-05;
+    margin-right: $spacing-05;
+  }
+
+  // Keep status text and buttons visible below the md breakpoint.
+  // Upstream mobile rules hide all `__right` children except control wrappers.
+  @include carbon--breakpoint-down(md) {
+    .#{$prefix}--pagination--simple .#{$prefix}--pagination__right > * {
+      display: flex;
+    }
+
+    .#{$prefix}--pagination--simple
+      .#{$prefix}--pagination__right
+      > .#{$prefix}--pagination__text {
+      display: inline-block;
+    }
+  }
+}
+
 @include exports("pagination-xs") {
   @include pagination-xs;
+}
+
+@include exports("pagination-simple") {
+  @include pagination-simple;
 }

--- a/docs/src/pages/components/Pagination.svx
+++ b/docs/src/pages/components/Pagination.svx
@@ -4,7 +4,7 @@ description: Pagination provides navigation controls for large data sets, showin
 ---
 
 <script>
-  import { Pagination, PaginationSkeleton } from "carbon-components-svelte";
+  import { Pagination, PaginationSkeleton, Toolbar, ToolbarContent } from "carbon-components-svelte";
 </script>
 
 ## Basic
@@ -72,6 +72,16 @@ Because the component cannot detect the last page, bind to `page` and toggle `fo
 The number of native select items is derived from totalItems. For large datasets, this can impact performance. Use `pageWindow` to limit rendered items.
 
 <FileSource src="/framed/Pagination/PageWindow" />
+
+## Simple
+
+Set `simple` for a compact previous/next control with page status text. Useful in toolbars and cards.
+
+<Toolbar size="sm">
+  <ToolbarContent>
+    <Pagination simple size="sm" totalItems={102} pageText={(page) => `${page.toLocaleString()}`} />
+  </ToolbarContent>
+</Toolbar>
 
 ## Hidden controls
 

--- a/src/Pagination/Pagination.svelte
+++ b/src/Pagination/Pagination.svelte
@@ -72,6 +72,12 @@
   export let pageSizeInputDisabled = false;
 
   /**
+   * Set to `true` for a compact prev/next control with page status text.
+   * Hides the page size and page selects. Suited to toolbars and cards.
+   */
+  export let simple = false;
+
+  /**
    * Specify the number of items to display in a page.
    * @bindable writable
    */
@@ -199,51 +205,62 @@
 <div
   {id}
   class:bx--pagination={true}
+  class:bx--pagination--simple={simple}
   class:bx--pagination--xs={size === "xs"}
   class:bx--pagination--sm={size === "sm"}
   class:bx--pagination--md={size === "md"}
   class:bx--pagination--lg={size === "lg"}
   {...$$restProps}
 >
-  <div class:bx--pagination__left={true}>
-    {#if !pageSizeInputDisabled}
-      <label
-        id="bx--pagination-select-{id}-sizes-label"
-        for="bx--pagination-select-{id}-sizes"
-        class:bx--pagination__text={true}
-      >
-        {itemsPerPageText}
-      </label>
-      <Select
-        id="bx--pagination-select-{id}-sizes"
-        class="bx--select__item-count"
-        hideLabel
-        noLabel
-        inline
-        on:update={(event) => {
-          dispatch("change", { pageSize: event.detail });
-        }}
-        bind:selected={pageSize}
-      >
-        {#each effectivePageSizes as size, index (size)}
-          <SelectItem value={size} text={size.toString()} />
-        {/each}
-      </Select>
-    {/if}
-    <span class:bx--pagination__text={!pageSizeInputDisabled}>
-      {#if pagesUnknown}
-        {itemText(pageSize * (page - 1) + 1, page * pageSize)}
-      {:else}
-        {itemRangeText(
-          Math.min(pageSize * (page - 1) + 1, totalItems),
-          Math.min(page * pageSize, totalItems),
-          totalItems,
-        )}
+  {#if !simple}
+    <div class:bx--pagination__left={true}>
+      {#if !pageSizeInputDisabled}
+        <label
+          id="bx--pagination-select-{id}-sizes-label"
+          for="bx--pagination-select-{id}-sizes"
+          class:bx--pagination__text={true}
+        >
+          {itemsPerPageText}
+        </label>
+        <Select
+          id="bx--pagination-select-{id}-sizes"
+          class="bx--select__item-count"
+          hideLabel
+          noLabel
+          inline
+          on:update={(event) => {
+            dispatch("change", { pageSize: event.detail });
+          }}
+          bind:selected={pageSize}
+        >
+          {#each effectivePageSizes as size, index (size)}
+            <SelectItem value={size} text={size.toString()} />
+          {/each}
+        </Select>
       {/if}
-    </span>
-  </div>
+      <span class:bx--pagination__text={!pageSizeInputDisabled}>
+        {#if pagesUnknown}
+          {itemText(pageSize * (page - 1) + 1, page * pageSize)}
+        {:else}
+          {itemRangeText(
+            Math.min(pageSize * (page - 1) + 1, totalItems),
+            Math.min(page * pageSize, totalItems),
+            totalItems,
+          )}
+        {/if}
+      </span>
+    </div>
+  {/if}
   <div class:bx--pagination__right={true}>
-    {#if !pageInputDisabled}
+    {#if simple}
+      <span class:bx--pagination__text={true}>
+        {#if pagesUnknown}
+          {pageText(page)}
+        {:else}
+          {pageText(page)} {pageRangeText(page, totalPages)}
+        {/if}
+      </span>
+    {:else if !pageInputDisabled}
       <Select
         id="bx--pagination-select-{id}-pages"
         class="bx--select__page-number"

--- a/tests/Pagination/Pagination.test.svelte
+++ b/tests/Pagination/Pagination.test.svelte
@@ -10,6 +10,7 @@
   export let itemsPerPageText = "Items per page:";
   export let pageInputDisabled = false;
   export let pageSizeInputDisabled = false;
+  export let simple = false;
   export let pageSize = 10;
   export let pageSizes: ComponentProps<Pagination>["pageSizes"] = [10];
   export let dynamicPageSizes = false;
@@ -38,6 +39,7 @@
   {itemsPerPageText}
   {pageInputDisabled}
   {pageSizeInputDisabled}
+  {simple}
   {pageWindow}
   bind:pageSize
   {pageSizes}

--- a/tests/Pagination/Pagination.test.ts
+++ b/tests/Pagination/Pagination.test.ts
@@ -180,6 +180,36 @@ describe("Pagination", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("hides selects in simple mode and shows page status text", () => {
+    const { container } = render(Pagination, {
+      props: { simple: true, totalItems: 102 },
+    });
+
+    const pagination = container.querySelector(".bx--pagination");
+    expect(pagination).toHaveClass("bx--pagination--simple");
+    expect(screen.queryAllByRole("combobox")).toHaveLength(0);
+    expect(screen.getByText("page 1 of 11 pages")).toBeInTheDocument();
+    expect(screen.queryByText("1–10 of 102 items")).not.toBeInTheDocument();
+  });
+
+  it("navigates pages in simple mode", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(Pagination, {
+      props: { simple: true, totalItems: 102, page: 1 },
+    });
+
+    await user.click(screen.getByRole("button", { name: "Next page" }));
+
+    expect(consoleLog).toHaveBeenCalledWith("next", { page: 2 });
+    expect(consoleLog).toHaveBeenCalledWith("change", { page: 2 });
+    expect(screen.getByText("page 2 of 11 pages")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Previous page" }));
+
+    expect(consoleLog).toHaveBeenCalledWith("previous", { page: 1 });
+    expect(screen.getByText("page 1 of 11 pages")).toBeInTheDocument();
+  });
+
   it("should handle unknown pages", () => {
     render(Pagination, {
       props: { pagesUnknown: true },


### PR DESCRIPTION
simple mode hides page-size/page selects and shows compact prev/next
with “page X of Y” for toolbars.