### PR TITLE
feat(pin-code-input): distribute multi-char autofill input

### DIFF
--- a/docs/src/pages/components/PinCodeInput.svx
+++ b/docs/src/pages/components/PinCodeInput.svx
@@ -1,6 +1,6 @@
 ---
 components: ["PinCodeInput", "PinCodeInputSkeleton", "FluidPinCodeInputSkeleton"]
-description: Pin code inputs collect a short verification code across a row of single-character segments, with shared validation, keyboard navigation, and paste support.
+description: Pin code inputs collect a short verification code across a row of single-character segments, with shared validation, keyboard navigation, paste, and autofill support.
 ---
 
 <script>
@@ -270,9 +270,11 @@ Use the `labelChildren` slot to render custom label content.
   </span>
 </PinCodeInput>
 
-## Paste support
+## Paste and autofill
 
 Paste a full code into any segment to fill all segments at once. A partial paste fills from the focused segment forward. Non-matching characters are ignored. The paste event fires with the clipboard value (whitespace stripped) before segments are updated.
+
+OS and password-manager autofill that inserts the whole code into one segment is distributed the same way.
 
 <PinCodeInput
   labelText="Verification code"

--- a/src/PinCodeInput/PinCodeInput.svelte
+++ b/src/PinCodeInput/PinCodeInput.svelte
@@ -227,6 +227,29 @@
     }
   }
 
+  /**
+   * Distribute valid characters across segments, matching paste behavior:
+   * a full-length code replaces every segment; otherwise fill from `index`.
+   * @type {(index: number, chars: string[]) => void}
+   */
+  function fillFromChars(index, chars) {
+    const next = code.slice();
+    if (chars.length === count) {
+      for (let i = 0; i < count; i++) next[i] = chars[i];
+    } else {
+      let cursor = index;
+      for (const char of chars) {
+        if (cursor >= count) break;
+        next[cursor++] = char;
+      }
+    }
+    code = next;
+    dispatch("change", { value: code.join(""), code });
+
+    const firstEmpty = code.findIndex((char) => !char);
+    focusInput(firstEmpty === -1 ? count - 1 : firstEmpty);
+  }
+
   /** @type {(index: number, event: Event) => void} */
   function handleInput(index, event) {
     const input = /** @type {HTMLInputElement} */ (event.target);
@@ -234,9 +257,20 @@
       input.value = code[index] ?? "";
       return;
     }
-    let char = input.value;
-    if (char.length > 1) char = char.slice(-1);
 
+    const raw = input.value;
+    // OS/password-manager autofill may insert the whole code into one field.
+    if (raw.length > 1) {
+      const chars = raw.split("").filter(isValidChar);
+      if (chars.length === 0) {
+        input.value = code[index] ?? "";
+        return;
+      }
+      fillFromChars(index, chars);
+      return;
+    }
+
+    const char = raw;
     if (char && !isValidChar(char)) {
       input.value = code[index] ?? "";
       return;
@@ -288,22 +322,7 @@
     if (chars.length === 0) return;
 
     dispatch("paste", { value: text });
-
-    const next = code.slice();
-    if (chars.length === count) {
-      for (let i = 0; i < count; i++) next[i] = chars[i];
-    } else {
-      let cursor = index;
-      for (const char of chars) {
-        if (cursor >= count) break;
-        next[cursor++] = char;
-      }
-    }
-    code = next;
-    dispatch("change", { value: code.join(""), code });
-
-    const firstEmpty = code.findIndex((char) => !char);
-    focusInput(firstEmpty === -1 ? count - 1 : firstEmpty);
+    fillFromChars(index, chars);
   }
 
   /** @type {(event: KeyboardEvent) => void} */

--- a/tests/PinCodeInput/PinCodeInput.test.ts
+++ b/tests/PinCodeInput/PinCodeInput.test.ts
@@ -149,6 +149,43 @@ describe("PinCodeInput", () => {
     ).toBe(true);
   });
 
+  it("distributes multi-char autofill input across all segments", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    const { component } = render(PinCodeInput);
+    const inputs = getInputs();
+
+    inputs[0].focus();
+    await fireEvent.input(inputs[0], { target: { value: "1234" } });
+    await tick();
+
+    expect(component.value).toBe("1234");
+    expect(component.code).toEqual(["1", "2", "3", "4"]);
+    expect(inputs[3]).toHaveFocus();
+    expect(consoleLog.mock.calls.some(([event]) => event === "paste")).toBe(
+      false,
+    );
+    expect(
+      consoleLog.mock.calls.some(
+        ([event, detail]) =>
+          event === "complete" &&
+          (detail as { value: string }).value === "1234",
+      ),
+    ).toBe(true);
+  });
+
+  it("keeps single-character input behavior unchanged", async () => {
+    const { component } = render(PinCodeInput);
+    const inputs = getInputs();
+
+    inputs[0].focus();
+    await user.keyboard("9");
+    await tick();
+
+    expect(component.value).toBe("9");
+    expect(component.code).toEqual(["9", "", "", ""]);
+    expect(inputs[1]).toHaveFocus();
+  });
+
   it("does not dispatch paste when the clipboard has no valid characters", async () => {
     const consoleLog = vi.spyOn(console, "log");
     render(PinCodeInput);


### PR DESCRIPTION
Distributes multi-character autofill across PinCodeInput segments via
the same fill helper used for paste; single-char typing is unchanged.