### PR TITLE
feat(code-snippet): surface clipboard copy failures

### DIFF
--- a/docs/src/pages/components/CodeSnippet.svx
+++ b/docs/src/pages/components/CodeSnippet.svx
@@ -10,7 +10,7 @@ description: Code snippets display and copy code examples, with single-line, mul
 
 ## Basic
 
-Display a single-line code snippet by default. By default, the copy button uses the native [Clipboard API](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard/writeText) to copy text. Pass a function to `copy` to replace it. See [Override](#override).
+Display a single-line code snippet by default. By default, the copy button uses the native [Clipboard API](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard/writeText) to copy text, with a `document.execCommand("copy")` fallback when that API is unavailable or rejects (for example in an insecure context). Pass a function to `copy` to replace it. See [Override](#override).
 
 <CodeSnippet code="npm i carbon-components-svelte" />
 
@@ -18,7 +18,7 @@ Display a single-line code snippet by default. By default, the copy button uses 
 
 Pass an async function to `copy` when clipboard text is not ready at render time, such as a longer install command fetched on click. The copy feedback text appears after `copy()` resolves.
 
-During the request, the copy control sets `aria-busy="true"` and ignores further clicks. A rejected copy skips the success message and emits `copy:error`.
+During the request, the copy control sets `aria-busy="true"` and ignores further clicks. A rejected copy shows `errorFeedback` (default `"Failed to copy"`) in the same tooltip slot as the success message and emits `copy:error`.
 
 Prefetch on hover with `on:mouseenter:copy-button` on the copy control. The example below shows async copy for each variant (`single`, `inline`, `multi`).
 
@@ -86,7 +86,7 @@ Customize the message and icon shown after copying.
 
 ### Text
 
-Set `feedback` to customize the copy button feedback text.
+Set `feedback` to customize the copy button feedback text. Set `errorFeedback` to customize the message shown when copying fails (default `"Failed to copy"`).
 
 <FileSource src="/framed/CodeSnippet/CodeSnippetFeedback" />
 

--- a/docs/src/pages/components/CopyButton.svx
+++ b/docs/src/pages/components/CopyButton.svx
@@ -9,7 +9,7 @@ description: Copy buttons copy text to the clipboard as a standalone control, fo
 
 ## Basic
 
-Set `text` to the string to copy. By default, the copy button uses the native [Clipboard API](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard/writeText); pass a function to `copy` to replace it (see [Override](#override)). For code examples, use [CodeSnippet](/components/CodeSnippet); for content not ready at render time, see [Async copy](#async-copy).
+Set `text` to the string to copy. By default, the copy button uses the native [Clipboard API](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard/writeText), with a `document.execCommand("copy")` fallback when that API is unavailable or rejects (for example in an insecure context); pass a function to `copy` to replace it (see [Override](#override)). For code examples, use [CodeSnippet](/components/CodeSnippet); for content not ready at render time, see [Async copy](#async-copy).
 
 <CopyButton text="Carbon svelte" />
 
@@ -17,7 +17,7 @@ Set `text` to the string to copy. By default, the copy button uses the native [C
 
 Pass an async `copy` function when the text is not available at render time, for example markdown fetched on click. Feedback appears after `copy()` resolves.
 
-While `copy()` is pending, the button sets `aria-busy` and ignores clicks. On failure, skip feedback and listen for `copy:error`.
+While `copy()` is pending, the button sets `aria-busy` and ignores clicks. On failure, the button shows `errorFeedback` (default `"Failed to copy"`) and emits `copy:error`.
 
 Prefetch on hover with `on:mouseenter`.
 
@@ -57,7 +57,7 @@ Customize the message and icon shown after copying.
 
 ### Text
 
-Set `feedback` to customize the message shown after copying.
+Set `feedback` to customize the message shown after copying. Set `errorFeedback` to customize the message shown when copying fails (default `"Failed to copy"`).
 
 <CopyButton text="Carbon svelte" feedback="Copied to clipboard" />
 

--- a/docs/src/pages/components/CopyInput.svx
+++ b/docs/src/pages/components/CopyInput.svx
@@ -25,7 +25,7 @@ Set `selectOnFocus` to select the full value when the field receives focus.
 
 Pass an async `copy` function when the text is not available at render time, for example a token fetched on click. Feedback appears after `copy()` resolves.
 
-While `copy()` is pending, the copy button shows a busy state and ignores clicks. On failure, skip feedback and listen for `copy:error`.
+While `copy()` is pending, the copy button shows a busy state and ignores clicks. On failure, the button shows `errorFeedback` (default `"Failed to copy"`) and emits `copy:error`.
 
 Prefetch on hover with `on:mouseenter:copy-button`.
 
@@ -84,7 +84,7 @@ Customize the message and icon shown after copying.
 
 ### Text
 
-Set `feedback` to customize the message shown after copying.
+Set `feedback` to customize the message shown after copying. Set `errorFeedback` to customize the message shown when copying fails (default `"Failed to copy"`).
 
 <CopyInput labelText="Repository" value="git@github.com:carbon-design-system/carbon-components-svelte.git" feedback="Copied to clipboard" />
 

--- a/src/CodeSnippet/CodeSnippet.svelte
+++ b/src/CodeSnippet/CodeSnippet.svelte
@@ -1,4 +1,6 @@
 <script>
+  import { copyText } from "../utils/copyText.js";
+
   /**
    * @template [Icon=any]
    */
@@ -33,18 +35,14 @@
   export let code = undefined;
 
   /**
-   * By default, this component uses `navigator.clipboard.writeText` API to copy text to the user's clipboard.
+   * By default, this component uses `navigator.clipboard.writeText` API to copy text to the user's clipboard,
+   * with a `document.execCommand("copy")` fallback. Failures reject so the component can show
+   * `errorFeedback` and dispatch `copy:error`.
    *
    * Provide a custom function to override this behavior.
    * @type {(code: string) => void | Promise<void>}
    */
-  export let copy = async (code) => {
-    try {
-      await navigator.clipboard.writeText(code);
-    } catch (error) {
-      console.log(error);
-    }
-  };
+  export let copy = copyText;
 
   /**
    * Set to `true` to expand a multi-line code snippet (type="multi").
@@ -93,6 +91,9 @@
 
   /** Specify the feedback text displayed when clicking the snippet */
   export let feedback = "Copied!";
+
+  /** Specify the feedback text displayed when copying fails */
+  export let errorFeedback = "Failed to copy";
 
   /** Set the timeout duration (ms) to display feedback text */
   export let feedbackTimeout = 2000;
@@ -232,6 +233,7 @@
   let animation = undefined;
   let feedbackOpen = false;
   let copyPending = false;
+  let isCopyError = false;
   let prevExpanded = expanded;
   let exceedsThreshold = false;
   let resizeObserver;
@@ -250,7 +252,10 @@
     animation = copyFeedback.animation;
     feedbackOpen = copyFeedback.feedbackOpen;
     copyPending = copyFeedback.copyPending;
+    isCopyError = copyFeedback.isError;
   }
+
+  $: feedbackText = isCopyError ? errorFeedback : feedback;
 
   function dismissFeedback() {
     copyFeedback.dismiss();
@@ -436,7 +441,7 @@
           class:bx--assistive-text={true}
           class:bx--copy-btn__feedback={true}
         >
-          {feedback}
+          {feedbackText}
         </span>
       {/if}
     </button>
@@ -445,7 +450,7 @@
       <PortalTooltip
         anchor={copyRef}
         open={feedbackOpen}
-        text={feedback}
+        text={feedbackText}
         direction={tooltipPosition}
         intrinsicAlign={tooltipAlignment}
         horizontalGapLeft={portalGaps.horizontalGapLeft}
@@ -497,6 +502,7 @@
         {copy}
         {disabled}
         {feedback}
+        {errorFeedback}
         {feedbackTimeout}
         {feedbackIcon}
         iconDescription={copyButtonDescription}

--- a/src/CopyButton/CopyButton.svelte
+++ b/src/CopyButton/CopyButton.svelte
@@ -1,10 +1,17 @@
 <script>
+  import { copyText } from "../utils/copyText.js";
+
   /**
    * @template [Icon=any]
+   * @event {null} copy
+   * @event {{ error: unknown }} copy:error
    */
 
   /** Set the feedback text shown after clicking the button */
   export let feedback = "Copied!";
+
+  /** Set the feedback text shown when copying fails */
+  export let errorFeedback = "Failed to copy";
 
   /** Set the timeout duration (ms) to display feedback text */
   export let feedbackTimeout = 2000;
@@ -40,14 +47,12 @@
   export let text = undefined;
 
   /**
-   * Override the default copy behavior (navigator.clipboard.writeText).
+   * Override the default copy behavior (`navigator.clipboard.writeText` with
+   * a `document.execCommand("copy")` fallback). Failures reject so the button
+   * can show `errorFeedback` and dispatch `copy:error`.
    * @type {(text: string) => void | Promise<void>}
    */
-  async function defaultCopy(text) {
-    await navigator.clipboard.writeText(text);
-  }
-
-  export let copy = defaultCopy;
+  export let copy = copyText;
 
   /**
    * Set how the "Copied!" feedback tooltip is rendered.
@@ -97,12 +102,16 @@
   let animation = undefined;
   let feedbackOpen = false;
   let copyPending = false;
+  let isCopyError = false;
 
   function syncCopyFeedback() {
     animation = copyFeedback.animation;
     feedbackOpen = copyFeedback.feedbackOpen;
     copyPending = copyFeedback.copyPending;
+    isCopyError = copyFeedback.isError;
   }
+
+  $: feedbackText = isCopyError ? errorFeedback : feedback;
 
   // Proactive hover/focus tooltip. Reuses the floating-portal `PortalTooltip`
   // and the shared `activeButtonTooltip` store, so a CopyButton coordinates
@@ -132,7 +141,7 @@
     $activeButtonTooltip === tooltipId;
   $: feedbackInPortal = feedbackPortalled && feedbackOpen;
   $: tooltipOpen = tooltipHoverActive || feedbackInPortal;
-  $: tooltipText = feedbackOpen ? feedback : iconDescription;
+  $: tooltipText = feedbackOpen ? feedbackText : iconDescription;
 
   function claimTooltip() {
     activeButtonTooltip.set(tooltipId);
@@ -233,7 +242,7 @@
   on:click={async () => {
     try {
       await copyFeedback.onClick(async () => {
-        if (copy === defaultCopy ? text !== undefined : true) {
+        if (copy === copyText ? text !== undefined : true) {
           await copy(text ?? "");
           dispatch("copy");
         }
@@ -266,7 +275,7 @@
       class:bx--assistive-text={true}
       class:bx--copy-btn__feedback={true}
     >
-      {feedback}
+      {feedbackText}
     </span>
   {/if}
 </button>

--- a/src/CopyInput/CopyInput.svelte
+++ b/src/CopyInput/CopyInput.svelte
@@ -1,4 +1,6 @@
 <script>
+  import { copyText } from "../utils/copyText.js";
+
   /**
    * @template [Icon=any]
    * @event {null} copy
@@ -86,6 +88,9 @@
   /** Set the feedback text shown after clicking the copy button */
   export let feedback = "Copied!";
 
+  /** Set the feedback text shown when copying fails */
+  export let errorFeedback = "Failed to copy";
+
   /**
    * Specify an icon to render during the feedback window (for example, after copying).
    * When unset, the copy icon is always shown.
@@ -100,10 +105,12 @@
   export let iconDescription = "Copy to clipboard";
 
   /**
-   * Override the default copy behavior of using the navigator.clipboard.writeText API to copy text.
+   * Override the default copy behavior (`navigator.clipboard.writeText` with
+   * a `document.execCommand("copy")` fallback). Failures reject so the control
+   * can show `errorFeedback` and dispatch `copy:error`.
    * @type {(text: string) => void | Promise<void>}
    */
-  export let copy = undefined;
+  export let copy = copyText;
 
   /**
    * Set to `true` to render the feedback tooltip in a portal,
@@ -243,6 +250,7 @@
       <CopyButton
         text={value}
         {feedback}
+        {errorFeedback}
         {feedbackIcon}
         {feedbackTimeout}
         {iconDescription}

--- a/src/utils/copyFeedback.d.ts
+++ b/src/utils/copyFeedback.d.ts
@@ -4,6 +4,7 @@ export type CopyFeedbackState = {
   readonly animation: CopyFeedbackAnimation;
   readonly feedbackOpen: boolean;
   readonly copyPending: boolean;
+  readonly isError: boolean;
   dismiss: () => void;
   onClick: (
     performCopy: () => void | Promise<void>,

--- a/src/utils/copyFeedback.js
+++ b/src/utils/copyFeedback.js
@@ -3,14 +3,17 @@
 /** @typedef {'fade-in' | 'fade-out' | undefined} CopyFeedbackAnimation */
 
 /**
- * Copy-button "Copied!" feedback (fade-in/out, portal tooltip).
+ * Copy-button feedback (fade-in/out, portal tooltip).
  * `copyActive` blocks a second click before Svelte assigns `animation`.
+ * On copy failure, still opens feedback (`isError`) so callers can show
+ * error text in the same tooltip slot, then rethrows.
  *
  * @param {() => void} [onSync] - Run after internal state changes (sync component `let`s).
  * @returns {{
  *   get animation(): CopyFeedbackAnimation,
  *   get feedbackOpen(): boolean,
  *   get copyPending(): boolean,
+ *   get isError(): boolean,
  *   dismiss: () => void,
  *   onClick: (performCopy: () => void | Promise<void>, feedbackTimeout: number, portalled?: boolean) => Promise<void>,
  *   onAnimationEnd: (event: { animationName: string }) => void,
@@ -25,9 +28,35 @@ export function createCopyFeedbackState(onSync) {
   let timeout;
   let copyActive = false;
   let copyPending = false;
+  let isError = false;
 
   function notify() {
     onSync?.();
+  }
+
+  /**
+   * @param {number} feedbackTimeout
+   * @param {boolean} portalled
+   * @param {boolean} error
+   */
+  function openFeedback(feedbackTimeout, portalled, error) {
+    copyPending = false;
+    isError = error;
+    animation = "fade-in";
+    feedbackOpen = true;
+    clearTimeout(timeout);
+    timeout = setTimeout(() => {
+      if (portalled) {
+        feedbackOpen = false;
+        animation = undefined;
+        copyActive = false;
+        isError = false;
+      } else {
+        animation = "fade-out";
+      }
+      notify();
+    }, feedbackTimeout);
+    notify();
   }
 
   function dismiss() {
@@ -35,6 +64,7 @@ export function createCopyFeedbackState(onSync) {
     animation = undefined;
     copyActive = false;
     copyPending = false;
+    isError = false;
     clearTimeout(timeout);
     timeout = undefined;
     notify();
@@ -45,6 +75,7 @@ export function createCopyFeedbackState(onSync) {
     animation = undefined;
     copyActive = false;
     copyPending = false;
+    isError = false;
     clearTimeout(timeout);
     timeout = undefined;
   }
@@ -63,32 +94,17 @@ export function createCopyFeedbackState(onSync) {
 
     copyActive = true;
     copyPending = true;
+    isError = false;
     notify();
 
     try {
       await performCopy();
     } catch (error) {
-      copyActive = false;
-      copyPending = false;
-      notify();
+      openFeedback(feedbackTimeout, portalled, true);
       throw error;
     }
 
-    copyPending = false;
-    animation = "fade-in";
-    feedbackOpen = true;
-    clearTimeout(timeout);
-    timeout = setTimeout(() => {
-      if (portalled) {
-        feedbackOpen = false;
-        animation = undefined;
-        copyActive = false;
-      } else {
-        animation = "fade-out";
-      }
-      notify();
-    }, feedbackTimeout);
-    notify();
+    openFeedback(feedbackTimeout, portalled, false);
   }
 
   /** @param {{ animationName: string }} event */
@@ -97,6 +113,7 @@ export function createCopyFeedbackState(onSync) {
       animation = undefined;
       feedbackOpen = false;
       copyActive = false;
+      isError = false;
       notify();
     }
   }
@@ -110,6 +127,9 @@ export function createCopyFeedbackState(onSync) {
     },
     get copyPending() {
       return copyPending;
+    },
+    get isError() {
+      return isError;
     },
     dismiss,
     onClick,

--- a/src/utils/copyText.d.ts
+++ b/src/utils/copyText.d.ts
@@ -1,0 +1,7 @@
+/**
+ * Copy text to the clipboard.
+ *
+ * Tries `navigator.clipboard.writeText` first, then falls back to a
+ * textarea + `document.execCommand("copy")` path. Rejects if both fail.
+ */
+export function copyText(text: string): Promise<void>;

--- a/src/utils/copyText.js
+++ b/src/utils/copyText.js
@@ -1,0 +1,56 @@
+// @ts-check
+
+/**
+ * Copy `text` via a hidden textarea and `document.execCommand("copy")`.
+ * Used when `navigator.clipboard.writeText` is unavailable or rejects
+ * (for example in an insecure context).
+ * @param {string} text
+ * @returns {void}
+ */
+function copyTextWithExecCommand(text) {
+  if (typeof document.execCommand !== "function") {
+    throw new Error("Failed to copy");
+  }
+
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.setAttribute("readonly", "");
+  textarea.style.position = "fixed";
+  textarea.style.top = "0";
+  textarea.style.left = "0";
+  textarea.style.opacity = "0";
+  document.body.appendChild(textarea);
+  textarea.focus();
+  textarea.select();
+
+  try {
+    const ok = document.execCommand("copy");
+    if (!ok) {
+      throw new Error("Failed to copy");
+    }
+  } finally {
+    document.body.removeChild(textarea);
+  }
+}
+
+/**
+ * Copy text to the clipboard.
+ *
+ * Tries `navigator.clipboard.writeText` first, then falls back to a
+ * textarea + `document.execCommand("copy")` path. Rejects if both fail.
+ *
+ * @param {string} text
+ * @returns {Promise<void>}
+ */
+export async function copyText(text) {
+  if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return;
+    } catch {
+      // Fall through to execCommand (insecure contexts, permission denied, etc.).
+    }
+  }
+
+  copyTextWithExecCommand(text);
+}

--- a/tests/CodeSnippet/CodeSnippet.test.ts
+++ b/tests/CodeSnippet/CodeSnippet.test.ts
@@ -15,6 +15,7 @@ import CodeSnippetCopyButtonMouseLeave from "./CodeSnippetCopyButtonMouseLeave.t
 import CodeSnippetCopyError from "./CodeSnippetCopyError.test.svelte";
 import CodeSnippetCopyRef from "./CodeSnippetCopyRef.test.svelte";
 import CodeSnippetCustomEvents from "./CodeSnippetCustomEvents.test.svelte";
+import CodeSnippetDefaultCopyError from "./CodeSnippetDefaultCopyError.test.svelte";
 import CodeSnippetDisabled from "./CodeSnippetDisabled.test.svelte";
 import CodeSnippetDoubleClick from "./CodeSnippetDoubleClick.test.svelte";
 import CodeSnippetExpandable from "./CodeSnippetExpandable.test.svelte";
@@ -166,7 +167,7 @@ yarn -v`,
   );
 
   it.each(snippetVariants)(
-    "async copy failure does not show feedback ($type)",
+    "async copy failure shows error feedback ($type)",
     async ({ type, label }) => {
       const error = new Error("copy failed");
       const copy = vi.fn().mockRejectedValue(error);
@@ -180,7 +181,13 @@ yarn -v`,
       await user.click(button);
 
       expect(onCopyError).toHaveBeenCalledWith({ error });
-      expect(button).not.toHaveClass("bx--copy-btn--fade-in");
+      expect(button).toHaveClass("bx--copy-btn--fade-in");
+
+      const portal = document.querySelector("[data-floating-portal]");
+      expect(
+        portal?.querySelector(".bx--tooltip-portal__content"),
+      ).toHaveTextContent("Failed to copy");
+      expect(screen.queryByText("Copied!")).toBeNull();
     },
   );
 
@@ -492,6 +499,45 @@ yarn -v`,
       await user.click(screen.getByLabelText(label));
 
       expect(onCopyError).toHaveBeenCalledWith({ error });
+      expect(screen.getByText("Failed to copy")).toBeInTheDocument();
+      expect(screen.queryByText("Copied!")).toBeNull();
+    },
+  );
+
+  it.each(snippetVariants)(
+    "default copy failure shows error feedback ($type)",
+    async ({ type, label }) => {
+      const onCopyError = vi.fn();
+      const originalClipboard = navigator.clipboard;
+      Object.defineProperty(navigator, "clipboard", {
+        configurable: true,
+        value: {
+          writeText: vi.fn().mockRejectedValue(new Error("denied")),
+        },
+      });
+      Object.defineProperty(document, "execCommand", {
+        configurable: true,
+        writable: true,
+        value: vi.fn().mockReturnValue(false),
+      });
+
+      render(CodeSnippetDefaultCopyError, {
+        props: { type, onCopyError },
+      });
+
+      await user.click(screen.getByLabelText(label));
+
+      expect(onCopyError).toHaveBeenCalledWith({
+        error: expect.any(Error),
+      });
+      expect(onCopyError.mock.calls[0][0].error.message).toBe("Failed to copy");
+      expect(screen.getByText("Failed to copy")).toBeInTheDocument();
+      expect(screen.queryByText("Copied!")).toBeNull();
+
+      Object.defineProperty(navigator, "clipboard", {
+        configurable: true,
+        value: originalClipboard,
+      });
     },
   );
 
@@ -576,6 +622,11 @@ yarn -v`,
   });
 
   test("should display custom copy text", async () => {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+    });
+
     render(CodeSnippetWithCustomCopyText);
 
     const copyButton = screen.getByLabelText("Copy to clipboard");

--- a/tests/CodeSnippet/CodeSnippetDefaultCopyError.test.svelte
+++ b/tests/CodeSnippet/CodeSnippetDefaultCopyError.test.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+  import CodeSnippet from "carbon-components-svelte/CodeSnippet/CodeSnippet.svelte";
+  import type { ComponentProps } from "svelte";
+
+  export let type: ComponentProps<CodeSnippet>["type"];
+  export let onCopyError = (_detail: { error: unknown }) => {};
+</script>
+
+<CodeSnippet
+  {type}
+  code="npm install --save @carbon/icons"
+  on:copy:error={(event) => onCopyError(event.detail)}
+/>

--- a/tests/CopyButton/CopyButton.test.ts
+++ b/tests/CopyButton/CopyButton.test.ts
@@ -76,16 +76,26 @@ describe("CopyButton", () => {
       value: { writeText: () => Promise.reject("Clipboard error") },
       writable: true,
     });
+    Object.defineProperty(document, "execCommand", {
+      configurable: true,
+      writable: true,
+      value: vi.fn().mockReturnValue(false),
+    });
 
     render(CopyButton, { props: { onCopyError } });
 
     const button = getCopyButton("Basic");
     await user.click(button);
-    expect(onCopyError).toHaveBeenCalledWith({ error: "Clipboard error" });
-    expect(button).not.toHaveClass("bx--copy-btn--fade-in");
-    // No "Copied!" feedback on error. (A hover/focus description tooltip may
-    // still portal because clicking focuses the button — that is not feedback.)
-    expect(button.querySelector(".bx--copy-btn__feedback")).toBeNull();
+    expect(onCopyError).toHaveBeenCalledWith({
+      error: expect.any(Error),
+    });
+    expect(onCopyError.mock.calls[0][0].error.message).toBe("Failed to copy");
+    expect(button).toHaveClass("bx--copy-btn--fade-in");
+
+    const portal = document.querySelector("[data-floating-portal]");
+    expect(
+      portal?.querySelector(".bx--tooltip-portal__content"),
+    ).toHaveTextContent("Failed to copy");
     expect(screen.queryByText("Copied!")).toBeNull();
   });
 
@@ -120,7 +130,7 @@ describe("CopyButton", () => {
     ).toHaveTextContent("Copied!");
   });
 
-  it("async copy failure does not show feedback and dispatches copy:error", async () => {
+  it("async copy failure shows error feedback and dispatches copy:error", async () => {
     const error = new Error("copy failed");
     const copy = vi.fn().mockRejectedValue(error);
     const onCopyError = vi.fn();
@@ -133,10 +143,16 @@ describe("CopyButton", () => {
     await user.click(button);
 
     expect(onCopyError).toHaveBeenCalledWith({ error });
-    expect(button).not.toHaveClass("bx--copy-btn--fade-in");
+    expect(button).toHaveClass("bx--copy-btn--fade-in");
 
+    const portal = document.querySelector("[data-floating-portal]");
+    expect(
+      portal?.querySelector(".bx--tooltip-portal__content"),
+    ).toHaveTextContent("Failed to copy");
+
+    // Error feedback holds the button until timeout/dismiss; a second click is ignored.
     await user.click(button);
-    expect(copy).toHaveBeenCalledTimes(2);
+    expect(copy).toHaveBeenCalledTimes(1);
   });
 
   it("dispatches copy event after async copy resolves", async () => {

--- a/tests/CopyInput/CopyInput.test.ts
+++ b/tests/CopyInput/CopyInput.test.ts
@@ -160,7 +160,7 @@ describe("CopyInput", () => {
     ).toHaveTextContent("Copied!");
   });
 
-  it("async copy failure does not show feedback and dispatches copy:error", async () => {
+  it("async copy failure shows error feedback and dispatches copy:error", async () => {
     const error = new Error("copy failed");
     const copy = vi.fn().mockRejectedValue(error);
     const onCopyError = vi.fn();
@@ -173,10 +173,15 @@ describe("CopyInput", () => {
     await user.click(button);
 
     expect(onCopyError).toHaveBeenCalledWith({ error });
-    expect(button).not.toHaveClass("bx--copy-btn--fade-in");
+    expect(button).toHaveClass("bx--copy-btn--fade-in");
+
+    const portal = document.querySelector("[data-floating-portal]");
+    expect(
+      portal?.querySelector(".bx--tooltip-portal__content"),
+    ).toHaveTextContent("Failed to copy");
 
     await user.click(button);
-    expect(copy).toHaveBeenCalledTimes(2);
+    expect(copy).toHaveBeenCalledTimes(1);
   });
 
   it("dispatches mouseenter:copy-button from the copy button", () => {

--- a/tests/utils/copyFeedback.test.ts
+++ b/tests/utils/copyFeedback.test.ts
@@ -128,7 +128,7 @@ describe("createCopyFeedbackState", () => {
     expect(state.feedbackOpen).toBe(true);
   });
 
-  test("rejected performCopy resets state and allows retry", async () => {
+  test("rejected performCopy shows error feedback then allows retry after dismiss", async () => {
     const state = createCopyFeedbackState();
     const performCopy = vi
       .fn()
@@ -139,13 +139,22 @@ describe("createCopyFeedbackState", () => {
       "copy failed",
     );
 
-    expect(state.animation).toBeUndefined();
-    expect(state.feedbackOpen).toBe(false);
+    expect(state.animation).toBe("fade-in");
+    expect(state.feedbackOpen).toBe(true);
+    expect(state.isError).toBe(true);
     expect(state.copyPending).toBe(false);
+
+    // Error feedback still holds copyActive, so a retry is blocked until dismiss.
+    await state.onClick(performCopy, 2000);
+    expect(performCopy).toHaveBeenCalledTimes(1);
+
+    state.dismiss();
+    expect(state.isError).toBe(false);
 
     await state.onClick(performCopy, 2000);
 
     expect(performCopy).toHaveBeenCalledTimes(2);
     expect(state.animation).toBe("fade-in");
+    expect(state.isError).toBe(false);
   });
 });

--- a/tests/utils/copyText.test.ts
+++ b/tests/utils/copyText.test.ts
@@ -1,0 +1,56 @@
+import { copyText } from "../../src/utils/copyText.js";
+
+describe("copyText", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    // jsdom may not define execCommand; clear any stub we installed.
+    // @ts-expect-error -- optional cleanup of test stub
+    document.execCommand = undefined;
+  });
+
+  function stubExecCommand(result: boolean) {
+    const execCommand = vi.fn().mockReturnValue(result);
+    Object.defineProperty(document, "execCommand", {
+      configurable: true,
+      writable: true,
+      value: execCommand,
+    });
+    return execCommand;
+  }
+
+  it("resolves via navigator.clipboard.writeText when available", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+    const execCommand = stubExecCommand(true);
+
+    await copyText("hello");
+
+    expect(writeText).toHaveBeenCalledWith("hello");
+    expect(execCommand).not.toHaveBeenCalled();
+  });
+
+  it("falls back to execCommand when clipboard write rejects", async () => {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText: vi.fn().mockRejectedValue(new Error("denied")) },
+    });
+    const execCommand = stubExecCommand(true);
+
+    await expect(copyText("fallback")).resolves.toBeUndefined();
+
+    expect(execCommand).toHaveBeenCalledWith("copy");
+  });
+
+  it("rejects when clipboard and execCommand both fail", async () => {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText: vi.fn().mockRejectedValue(new Error("denied")) },
+    });
+    stubExecCommand(false);
+
+    await expect(copyText("nope")).rejects.toThrow("Failed to copy");
+  });
+});


### PR DESCRIPTION
Clipboard failures now reject (with execCommand fallback), show
errorFeedback, and dispatch copy:error on CodeSnippet, CopyButton, and
CopyInput.