### PR TITLE
feat(form): add actions prop for use enhance

### DIFF
--- a/docs/src/pages/components/FluidForm.svx
+++ b/docs/src/pages/components/FluidForm.svx
@@ -176,6 +176,24 @@ intended.
   </TimePicker>
 </div>
 
+## SvelteKit enhance
+
+Set `actions` to apply SvelteKit's `enhance` (or any other action) to the
+underlying form element. See [Form](/components/Form#sveltekit-enhance) for
+usage details.
+
+```svelte
+<script>
+  import { enhance } from "$app/forms";
+  import { FluidForm, TextInput, Button } from "carbon-components-svelte";
+</script>
+
+<FluidForm method="POST" action="?/save" actions={[enhance]}>
+  <TextInput name="name" labelText="Name" />
+  <Button type="submit">Save</Button>
+</FluidForm>
+```
+
 ## Invalid
 
 Handle form validation and display error states with `invalid` and `invalidText` on form inputs.

--- a/docs/src/pages/components/Form.svx
+++ b/docs/src/pages/components/Form.svx
@@ -77,3 +77,33 @@ programmatically.
    <Checkbox id="checkbox-0" labelText="Checkbox Label" checked />
   <Button type="submit">Submit</Button>
 </Form>
+
+## SvelteKit enhance
+
+Svelte's `use:` directive cannot target components. Set `actions` to apply
+SvelteKit's `enhance` (or any other action) to the underlying form element.
+
+```svelte
+<script>
+  import { enhance } from "$app/forms";
+  import { Form, TextInput, Button } from "carbon-components-svelte";
+</script>
+
+<Form method="POST" action="?/save" actions={[enhance]}>
+  <TextInput name="name" labelText="Name" />
+  <Button type="submit">Save</Button>
+</Form>
+```
+
+Pass a submit callback as a `[action, parameter]` tuple:
+
+```svelte
+<Form
+  method="POST"
+  action="?/save"
+  actions={[[enhance, () => ({ reset: false })]]}
+>
+  <TextInput name="name" labelText="Name" />
+  <Button type="submit">Save</Button>
+</Form>
+```

--- a/src/FluidForm/FluidForm.svelte
+++ b/src/FluidForm/FluidForm.svelte
@@ -1,10 +1,9 @@
 <script>
   /**
    * @restProps {form}
+   * @typedef {import("svelte/action").Action<HTMLFormElement, any>} FormAction
+   * @typedef {FormAction | [FormAction, any]} FormActionEntry
    */
-
-  import { setContext } from "svelte";
-  import Form from "../Form/Form.svelte";
 
   /**
    * Obtain a reference to the form element.
@@ -12,6 +11,18 @@
    * @bindable readonly
    */
   export let ref = null;
+
+  /**
+   * Apply Svelte actions to the underlying form element.
+   * Each entry is an action or a `[action, parameter]` tuple.
+   * Use this for SvelteKit's `enhance` and other form actions that
+   * cannot target components with `use:`.
+   * @type {ReadonlyArray<FormActionEntry>}
+   */
+  export let actions = [];
+
+  import { setContext } from "svelte";
+  import Form from "../Form/Form.svelte";
 
   /**
    * Context published under the key `"carbon:Form"` for descendant inputs.
@@ -27,6 +38,7 @@
 
 <Form
   bind:ref
+  {actions}
   {...$$restProps}
   class={["bx--form--fluid", $$restProps.class].filter(Boolean).join(" ")}
   on:click

--- a/src/Form/Form.svelte
+++ b/src/Form/Form.svelte
@@ -1,9 +1,53 @@
 <script>
   /**
+   * @restProps {form}
+   * @typedef {import("svelte/action").Action<HTMLFormElement, any>} FormAction
+   * @typedef {FormAction | [FormAction, any]} FormActionEntry
+   */
+
+  /**
    * Obtain a reference to the form element.
+   * @type {null | HTMLFormElement}
    * @bindable readonly
    */
   export let ref = null;
+
+  /**
+   * Apply Svelte actions to the underlying form element.
+   * Each entry is an action or a `[action, parameter]` tuple.
+   * Use this for SvelteKit's `enhance` and other form actions that
+   * cannot target components with `use:`.
+   * @type {ReadonlyArray<FormActionEntry>}
+   */
+  export let actions = [];
+
+  import { onMount } from "svelte";
+
+  function applyActions(node, entries) {
+    /** @type {Array<() => void>} */
+    const destroyers = [];
+
+    for (const entry of entries) {
+      const isTuple = Array.isArray(entry);
+      const action = isTuple ? entry[0] : entry;
+      const result = isTuple ? action(node, entry[1]) : action(node);
+
+      if (result && typeof result.destroy === "function") {
+        destroyers.push(result.destroy);
+      }
+    }
+
+    return () => {
+      for (const destroy of destroyers) {
+        destroy();
+      }
+    };
+  }
+
+  onMount(() => {
+    if (!ref || actions.length === 0) return;
+    return applyActions(ref, actions);
+  });
 </script>
 
 <form

--- a/tests/FluidForm/FluidForm.actions.test.svelte
+++ b/tests/FluidForm/FluidForm.actions.test.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+  import FluidForm from "carbon-components-svelte/FluidForm/FluidForm.svelte";
+  import type { Action } from "svelte/action";
+
+  export let actions: Array<
+    | Action<HTMLFormElement, unknown>
+    | [Action<HTMLFormElement, unknown>, unknown]
+  > = [];
+  export let ref: null | HTMLFormElement = null;
+</script>
+
+<FluidForm bind:ref data-testid="fluid-form" {actions}>
+  <button type="submit">Submit</button>
+</FluidForm>

--- a/tests/FluidForm/FluidForm.test.ts
+++ b/tests/FluidForm/FluidForm.test.ts
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/svelte";
 import { user } from "../utils/user";
+import FluidFormActionsTest from "./FluidForm.actions.test.svelte";
 import FluidFormTest from "./FluidForm.test.svelte";
 
 describe("FluidForm", () => {
@@ -15,6 +16,37 @@ describe("FluidForm", () => {
     const form = screen.getByTestId("fluid-form");
     expect(component.ref).toBe(form);
     expect(component.ref?.tagName).toBe("FORM");
+  });
+
+  describe("actions", () => {
+    it("calls each action with the form element", () => {
+      const action = vi.fn(() => ({ destroy: vi.fn() }));
+      render(FluidFormActionsTest, { props: { actions: [action] } });
+      const form = screen.getByTestId("fluid-form");
+      expect(action).toHaveBeenCalledTimes(1);
+      expect(action).toHaveBeenCalledWith(form);
+    });
+
+    it("invokes destroy on unmount", () => {
+      const destroy = vi.fn();
+      const action = vi.fn(() => ({ destroy }));
+      const { unmount } = render(FluidFormActionsTest, {
+        props: { actions: [action] },
+      });
+      expect(destroy).not.toHaveBeenCalled();
+      unmount();
+      expect(destroy).toHaveBeenCalledTimes(1);
+    });
+
+    it("passes tuple parameters to actions", () => {
+      const action = vi.fn(() => ({ destroy: vi.fn() }));
+      const parameter = { submit: vi.fn() };
+      render(FluidFormActionsTest, {
+        props: { actions: [[action, parameter]] },
+      });
+      const form = screen.getByTestId("fluid-form");
+      expect(action).toHaveBeenCalledWith(form, parameter);
+    });
   });
 
   it("renders form elements correctly", () => {

--- a/tests/Form/Form.actions.test.svelte
+++ b/tests/Form/Form.actions.test.svelte
@@ -1,0 +1,16 @@
+<svelte:options accessors />
+
+<script lang="ts">
+  import Form from "carbon-components-svelte/Form/Form.svelte";
+  import type { Action } from "svelte/action";
+
+  export let actions: Array<
+    | Action<HTMLFormElement, unknown>
+    | [Action<HTMLFormElement, unknown>, unknown]
+  > = [];
+  export let ref: null | HTMLFormElement = null;
+</script>
+
+<Form bind:ref data-testid="form" {actions}>
+  <button type="submit">Submit</button>
+</Form>

--- a/tests/Form/Form.test.ts
+++ b/tests/Form/Form.test.ts
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/svelte";
 import { user } from "../utils/user";
+import FormActionsTest from "./Form.actions.test.svelte";
 import FormTest from "./Form.test.svelte";
 
 describe("Form", () => {
@@ -8,6 +9,46 @@ describe("Form", () => {
     const form = screen.getByTestId("form");
     expect(form).toBeInTheDocument();
     expect(form).toHaveClass("bx--form");
+  });
+
+  describe("actions", () => {
+    it("calls each action with the form element", () => {
+      const action = vi.fn(() => ({ destroy: vi.fn() }));
+      render(FormActionsTest, { props: { actions: [action] } });
+      const form = screen.getByTestId("form");
+      expect(action).toHaveBeenCalledTimes(1);
+      expect(action).toHaveBeenCalledWith(form);
+    });
+
+    it("invokes destroy on unmount", () => {
+      const destroy = vi.fn();
+      const action = vi.fn(() => ({ destroy }));
+      const { unmount } = render(FormActionsTest, {
+        props: { actions: [action] },
+      });
+      expect(destroy).not.toHaveBeenCalled();
+      unmount();
+      expect(destroy).toHaveBeenCalledTimes(1);
+    });
+
+    it("passes tuple parameters to actions", () => {
+      const action = vi.fn(() => ({ destroy: vi.fn() }));
+      const parameter = { submit: vi.fn() };
+      render(FormActionsTest, {
+        props: { actions: [[action, parameter]] },
+      });
+      const form = screen.getByTestId("form");
+      expect(action).toHaveBeenCalledWith(form, parameter);
+    });
+
+    it("preserves bind:ref alongside actions", () => {
+      const action = vi.fn(() => ({ destroy: vi.fn() }));
+      const { component } = render(FormActionsTest, {
+        props: { actions: [action] },
+      });
+      const form = screen.getByTestId("form");
+      expect(component.ref).toBe(form);
+    });
   });
 
   it("renders form elements correctly", () => {


### PR DESCRIPTION
actions on Form and FluidForm applies Svelte actions (e.g. SvelteKit
enhance) in onMount and destroys them on unmount.

---

![form actions enhance example](https://gist.githubusercontent.com/metonym/08972a71e40878f2b365a76cf53bb946/raw/ff856ef5df03029e5d6bdaed228cccdecfb7fd76/form-actions-enhance.png)
