### PR TITLE
feat(time-picker): add min and max constraints

### DIFF
--- a/docs/src/pages/components/TimePicker.svx
+++ b/docs/src/pages/components/TimePicker.svx
@@ -8,6 +8,7 @@ description: Time pickers provide a time input field with optional period (AM/PM
   import Information from "carbon-icons-svelte/lib/Information.svelte";
 
   let normalizedValue = "";
+  let bookingValue = "10:00";
 </script>
 
 ## Basic
@@ -68,6 +69,31 @@ optional `seconds`, and `valid`.
   normalize
   bind:value={normalizedValue}
   labelText="Departure"
+  on:change={(e) => {
+    console.log("change", e.detail);
+  }}
+/>
+
+## Min and max
+
+Constrain the field to a booking window with `min` and `max` (same format as
+`value`). Out-of-range times join the invalid state and set `reason` to
+`"min"` or `"max"` on the `change` detail. Omit either bound for an open end.
+
+Bounds compare minutes since midnight from the text field. Prefer
+`format="24"` for windows that cross noon. AM/PM `TimePickerSelect` values
+are independent of `min` / `max` — they do not shift the comparison.
+`normalize` still reformats on blur before the range check in `change`.
+
+<TimePicker
+  format="24"
+  normalize
+  min="09:00"
+  max="17:00"
+  bind:value={bookingValue}
+  invalidText="Choose a time between 09:00 and 17:00"
+  labelText="Appointment"
+  helperText="Business hours 09:00–17:00"
   on:change={(e) => {
     console.log("change", e.detail);
   }}

--- a/src/TimePicker/TimePicker.svelte
+++ b/src/TimePicker/TimePicker.svelte
@@ -1,7 +1,8 @@
 <script>
   /**
    * @typedef {import("../utils/timeFormat.js").TimeFormat} TimeFormat
-   * @typedef {{ value: string; hours: number | null; minutes: number | null; seconds?: number | null; valid: boolean }} TimePickerChangeDetail
+   * @typedef {import("../utils/timeFormat.js").TimeConstraintReason} TimeConstraintReason
+   * @typedef {{ value: string; hours: number | null; minutes: number | null; seconds?: number | null; valid: boolean; reason?: TimeConstraintReason }} TimePickerChangeDetail
    * @event {TimePickerChangeDetail} change
    */
 
@@ -36,6 +37,22 @@
    * (for example `930` → `09:30`).
    */
   export let normalize = false;
+
+  /**
+   * Specify the earliest allowed time (same format as `value`, e.g. `"09:00"`).
+   * Out-of-range values participate in the invalid state and set
+   * `reason: "min"` on the `change` detail. Unset means no lower bound.
+   * @type {string}
+   */
+  export let min = undefined;
+
+  /**
+   * Specify the latest allowed time (same format as `value`, e.g. `"17:00"`).
+   * Out-of-range values participate in the invalid state and set
+   * `reason: "max"` on the `change` detail. Unset means no upper bound.
+   * @type {string}
+   */
+  export let max = undefined;
 
   /**
    * Specify the input placeholder text.
@@ -115,7 +132,11 @@
   import WarningAltFilled from "../icons/WarningAltFilled.svelte";
   import WarningFilled from "../icons/WarningFilled.svelte";
   import Stack from "../Stack/Stack.svelte";
-  import { getTimeInputPreset, parseTime } from "../utils/timeFormat.js";
+  import {
+    checkTimeConstraints,
+    getTimeInputPreset,
+    parseTime,
+  } from "../utils/timeFormat.js";
 
   const formContext = getContext("carbon:Form");
   const selectCount = writable(0);
@@ -146,6 +167,18 @@
     if (seconds) {
       detail.seconds = parsed.seconds;
     }
+    if (parsed.valid && parsed.hours !== null) {
+      const range = checkTimeConstraints(parsed, {
+        format,
+        seconds,
+        min,
+        max,
+      });
+      if (!range.valid && range.reason) {
+        detail.valid = false;
+        detail.reason = range.reason;
+      }
+    }
     return detail;
   }
 
@@ -175,8 +208,19 @@
   $: helperId = `helper-${id}`;
   $: errorId = `error-${id}`;
   $: warnId = `warn-${id}`;
-  $: showInvalid = invalid && !disabled && !readonly;
-  $: showWarn = warn && !invalid && !disabled && !readonly;
+  $: rangeConstraint = checkTimeConstraints(value, {
+    format,
+    seconds,
+    min,
+    max,
+  });
+  $: autoInvalid =
+    ((min != null && min !== "") || (max != null && max !== "")) &&
+    value.trim() !== "" &&
+    (rangeConstraint.reason === "min" || rangeConstraint.reason === "max");
+  $: effectiveInvalid = invalid || autoInvalid;
+  $: showInvalid = effectiveInvalid && !disabled && !readonly;
+  $: showWarn = warn && !effectiveInvalid && !disabled && !readonly;
   $: isFluid = fluid || !!formContext?.isFluid;
   $: timePickerContext.isFluid = isFluid;
   $: equalWidth = $selectCount !== 2;
@@ -283,8 +327,8 @@
     <div
       class:bx--time-picker={true}
       class:bx--time-picker--light={light}
-      class:bx--time-picker--invalid={invalid}
-      class:bx--time-picker--warn={warn}
+      class:bx--time-picker--invalid={effectiveInvalid}
+      class:bx--time-picker--warn={warn && !effectiveInvalid}
       class:bx--time-picker--readonly={readonly}
       class:bx--time-picker--sm={size === "sm"}
       class:bx--time-picker--xl={size === "xl"}
@@ -304,13 +348,14 @@
         {/if}
         <Stack orientation="horizontal" gap={0}>
           <div
-            data-invalid={invalid || undefined}
-            data-warn={!invalid && warn ? true : undefined}
+            data-invalid={effectiveInvalid || undefined}
+            data-warn={!effectiveInvalid && warn ? true : undefined}
             class:bx--text-input__field-wrapper={true}
-            class:bx--text-input__field-wrapper--warning={!invalid && warn}
+            class:bx--text-input__field-wrapper--warning={!effectiveInvalid &&
+              warn}
             style:width="auto"
           >
-            {#if invalid}
+            {#if effectiveInvalid}
               <WarningFilled class="bx--text-input__invalid-icon" />
             {:else if warn}
               <WarningAltFilled
@@ -321,9 +366,9 @@
               bind:this={ref}
               bind:value
               type="text"
-              data-invalid={invalid || undefined}
-              aria-invalid={invalid || undefined}
-              aria-describedby={invalid
+              data-invalid={effectiveInvalid || undefined}
+              aria-invalid={effectiveInvalid || undefined}
+              aria-describedby={effectiveInvalid
                 ? errorId
                 : warn
                   ? warnId
@@ -341,8 +386,8 @@
               class:bx--time-picker__input-field={true}
               class:bx--text-input={true}
               class:bx--text-input--light={light}
-              class:bx--text-input--invalid={invalid}
-              class:bx--text-input--warning={!invalid && warn}
+              class:bx--text-input--invalid={effectiveInvalid}
+              class:bx--text-input--warning={!effectiveInvalid && warn}
               on:change={handleChange}
               on:input
               on:keydown
@@ -357,7 +402,7 @@
         </Stack>
       </div>
     </div>
-    {#if invalid}
+    {#if effectiveInvalid}
       <div id={errorId} class:bx--form-requirement={true}>{invalidText}</div>
     {:else if warn}
       <div id={warnId} class:bx--form-requirement={true}>{warnText}</div>

--- a/src/utils/timeFormat.d.ts
+++ b/src/utils/timeFormat.d.ts
@@ -46,3 +46,31 @@ export function isValidTime(
   raw: string,
   options?: { format?: TimeFormat; seconds?: boolean },
 ): boolean;
+
+/** Convert clock parts to minutes since midnight (seconds as a fraction). */
+export function toMinutesSinceMidnight(
+  hours: number,
+  minutes: number,
+  seconds?: number,
+): number;
+
+export type TimeConstraintReason = "min" | "max";
+
+export type TimeConstraintResult = {
+  valid: boolean;
+  reason?: TimeConstraintReason;
+};
+
+/**
+ * Check a parsed or raw time against optional `min` / `max` bounds.
+ * Unset or unparsable bounds are ignored. Empty input is valid. Inclusive.
+ */
+export function checkTimeConstraints(
+  rawOrParsed: string | ParsedTime,
+  options?: {
+    format?: TimeFormat;
+    seconds?: boolean;
+    min?: string;
+    max?: string;
+  },
+): TimeConstraintResult;

--- a/src/utils/timeFormat.js
+++ b/src/utils/timeFormat.js
@@ -294,3 +294,91 @@ export function formatTime(hours, minutes, options = {}) {
 export function isValidTime(raw, options = {}) {
   return parseTime(raw, options).valid;
 }
+
+/**
+ * Convert clock parts to minutes since midnight.
+ * Seconds contribute as a fraction of a minute.
+ *
+ * @param {number} hours
+ * @param {number} minutes
+ * @param {number} [seconds]
+ * @returns {number}
+ */
+export function toMinutesSinceMidnight(hours, minutes, seconds = 0) {
+  return hours * 60 + minutes + seconds / 60;
+}
+
+/**
+ * @typedef {"min" | "max"} TimeConstraintReason
+ */
+
+/**
+ * @typedef {object} TimeConstraintResult
+ * @property {boolean} valid
+ * @property {TimeConstraintReason} [reason]
+ */
+
+/**
+ * Check a parsed or raw time against optional `min` / `max` bounds.
+ *
+ * Bounds use the same format as `value`. Unset or unparsable bounds are
+ * ignored (unlimited on that side). Empty input is valid. Inclusive bounds.
+ *
+ * Compares minutes since midnight from the clock-face parts. With
+ * `format="12"`, hours are 1–12 and are not adjusted for AM/PM — period
+ * selects are independent of this check.
+ *
+ * @param {string | ParsedTime} rawOrParsed
+ * @param {{ format?: TimeFormat; seconds?: boolean; min?: string; max?: string }} [options]
+ * @returns {TimeConstraintResult}
+ */
+export function checkTimeConstraints(rawOrParsed, options = {}) {
+  const format = options.format ?? "12";
+  const includeSeconds = options.seconds === true;
+  const parsed =
+    typeof rawOrParsed === "string"
+      ? parseTime(rawOrParsed, { format, seconds: includeSeconds })
+      : rawOrParsed;
+
+  if (!parsed.valid || parsed.hours === null || parsed.minutes === null) {
+    return { valid: parsed.valid };
+  }
+
+  const valueMinutes = toMinutesSinceMidnight(
+    parsed.hours,
+    parsed.minutes,
+    parsed.seconds ?? 0,
+  );
+
+  const min = options.min;
+  if (min != null && min !== "") {
+    const bound = parseTime(min, { format, seconds: includeSeconds });
+    if (bound.valid && bound.hours !== null && bound.minutes !== null) {
+      const minMinutes = toMinutesSinceMidnight(
+        bound.hours,
+        bound.minutes,
+        bound.seconds ?? 0,
+      );
+      if (valueMinutes < minMinutes) {
+        return { valid: false, reason: "min" };
+      }
+    }
+  }
+
+  const max = options.max;
+  if (max != null && max !== "") {
+    const bound = parseTime(max, { format, seconds: includeSeconds });
+    if (bound.valid && bound.hours !== null && bound.minutes !== null) {
+      const maxMinutes = toMinutesSinceMidnight(
+        bound.hours,
+        bound.minutes,
+        bound.seconds ?? 0,
+      );
+      if (valueMinutes > maxMinutes) {
+        return { valid: false, reason: "max" };
+      }
+    }
+  }
+
+  return { valid: true };
+}

--- a/tests/TimePicker/TimePicker.test.svelte
+++ b/tests/TimePicker/TimePicker.test.svelte
@@ -9,6 +9,8 @@
   export let format: ComponentProps<TimePicker>["format"] = "12";
   export let seconds: ComponentProps<TimePicker>["seconds"] = false;
   export let normalize: ComponentProps<TimePicker>["normalize"] = false;
+  export let min: ComponentProps<TimePicker>["min"] = undefined;
+  export let max: ComponentProps<TimePicker>["max"] = undefined;
   export let placeholder: ComponentProps<TimePicker>["placeholder"] = undefined;
   export let pattern: ComponentProps<TimePicker>["pattern"] = undefined;
   export let maxlength: ComponentProps<TimePicker>["maxlength"] = undefined;
@@ -34,6 +36,8 @@
   {format}
   {seconds}
   {normalize}
+  {min}
+  {max}
   {placeholder}
   {pattern}
   {maxlength}

--- a/tests/TimePicker/TimePicker.test.ts
+++ b/tests/TimePicker/TimePicker.test.ts
@@ -292,6 +292,96 @@ describe("TimePicker", () => {
     });
   });
 
+  it("marks values below min as invalid with reason min", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(TimePicker, {
+      props: {
+        format: "24",
+        min: "09:00",
+        max: "17:00",
+        invalidText: "Outside booking hours",
+      },
+    });
+
+    const input = screen.getByRole("textbox");
+    await user.type(input, "08:00");
+    await user.tab();
+    expect(input).toHaveClass("bx--text-input--invalid");
+    expect(input).toHaveAttribute("aria-invalid", "true");
+    expect(screen.getByText("Outside booking hours")).toBeInTheDocument();
+    expect(consoleLog).toHaveBeenCalledWith("change", {
+      value: "08:00",
+      hours: 8,
+      minutes: 0,
+      valid: false,
+      reason: "min",
+    });
+  });
+
+  it("marks values above max as invalid with reason max", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(TimePicker, {
+      props: {
+        format: "24",
+        min: "09:00",
+        max: "17:00",
+        invalidText: "Outside booking hours",
+      },
+    });
+
+    const input = screen.getByRole("textbox");
+    await user.type(input, "18:00");
+    await user.tab();
+    expect(input).toHaveClass("bx--text-input--invalid");
+    expect(consoleLog).toHaveBeenCalledWith("change", {
+      value: "18:00",
+      hours: 18,
+      minutes: 0,
+      valid: false,
+      reason: "max",
+    });
+  });
+
+  it("accepts in-range values when min and max are set", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(TimePicker, {
+      props: {
+        format: "24",
+        min: "09:00",
+        max: "17:00",
+        invalidText: "Outside booking hours",
+      },
+    });
+
+    const input = screen.getByRole("textbox");
+    await user.type(input, "10:30");
+    await user.tab();
+    expect(input).not.toHaveClass("bx--text-input--invalid");
+    expect(screen.queryByText("Outside booking hours")).not.toBeInTheDocument();
+    expect(consoleLog).toHaveBeenCalledWith("change", {
+      value: "10:30",
+      hours: 10,
+      minutes: 30,
+      valid: true,
+    });
+  });
+
+  it("does not constrain when min and max are unset", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(TimePicker, { props: { format: "24" } });
+
+    const input = screen.getByRole("textbox");
+    await user.type(input, "03:00");
+    await user.tab();
+    expect(input).not.toHaveClass("bx--text-input--invalid");
+    expect(consoleLog).toHaveBeenCalledWith("change", {
+      value: "03:00",
+      hours: 3,
+      minutes: 0,
+      valid: true,
+    });
+  });
+
   it("should handle focus and blur events", async () => {
     const consoleLog = vi.spyOn(console, "log");
     render(TimePicker);

--- a/tests/utils/timeFormat.test.ts
+++ b/tests/utils/timeFormat.test.ts
@@ -1,8 +1,10 @@
 import {
+  checkTimeConstraints,
   formatTime,
   getTimeInputPreset,
   isValidTime,
   parseTime,
+  toMinutesSinceMidnight,
 } from "../../src/utils/timeFormat.js";
 
 describe("getTimeInputPreset", () => {
@@ -151,5 +153,101 @@ describe("isValidTime", () => {
     expect(isValidTime("14:30", { format: "24" })).toBe(true);
     expect(isValidTime("14:30", { format: "12" })).toBe(false);
     expect(isValidTime("")).toBe(true);
+  });
+});
+
+describe("toMinutesSinceMidnight", () => {
+  test("converts clock parts", () => {
+    expect(toMinutesSinceMidnight(9, 30)).toBe(570);
+    expect(toMinutesSinceMidnight(0, 0)).toBe(0);
+    expect(toMinutesSinceMidnight(14, 30, 30)).toBe(870.5);
+  });
+});
+
+describe("checkTimeConstraints", () => {
+  test("treats unset bounds as unlimited", () => {
+    expect(checkTimeConstraints("03:00", { format: "24" })).toEqual({
+      valid: true,
+    });
+    expect(
+      checkTimeConstraints("23:00", { format: "24", min: "", max: "" }),
+    ).toEqual({ valid: true });
+  });
+
+  test("rejects times below min", () => {
+    expect(
+      checkTimeConstraints("08:00", {
+        format: "24",
+        min: "09:00",
+        max: "17:00",
+      }),
+    ).toEqual({ valid: false, reason: "min" });
+  });
+
+  test("rejects times above max", () => {
+    expect(
+      checkTimeConstraints("18:00", {
+        format: "24",
+        min: "09:00",
+        max: "17:00",
+      }),
+    ).toEqual({ valid: false, reason: "max" });
+  });
+
+  test("accepts times in range inclusive of bounds", () => {
+    expect(
+      checkTimeConstraints("09:00", {
+        format: "24",
+        min: "09:00",
+        max: "17:00",
+      }),
+    ).toEqual({ valid: true });
+    expect(
+      checkTimeConstraints("17:00", {
+        format: "24",
+        min: "09:00",
+        max: "17:00",
+      }),
+    ).toEqual({ valid: true });
+    expect(
+      checkTimeConstraints("12:30", {
+        format: "24",
+        min: "09:00",
+        max: "17:00",
+      }),
+    ).toEqual({ valid: true });
+  });
+
+  test("treats empty input as valid", () => {
+    expect(
+      checkTimeConstraints("", { format: "24", min: "09:00", max: "17:00" }),
+    ).toEqual({ valid: true });
+  });
+
+  test("ignores unparsable bounds", () => {
+    expect(
+      checkTimeConstraints("10:00", {
+        format: "24",
+        min: "nope",
+        max: "also-bad",
+      }),
+    ).toEqual({ valid: true });
+  });
+
+  test("compares seconds when enabled", () => {
+    expect(
+      checkTimeConstraints("09:00:00", {
+        format: "24",
+        seconds: true,
+        min: "09:00:01",
+      }),
+    ).toEqual({ valid: false, reason: "min" });
+    expect(
+      checkTimeConstraints("09:00:01", {
+        format: "24",
+        seconds: true,
+        min: "09:00:01",
+      }),
+    ).toEqual({ valid: true });
   });
 });


### PR DESCRIPTION
Adds min/max time constraints on TimePicker (minutes-since-midnight),
auto-invalid when out of range, and change detail reason min|max. Stacks
on format-normalize.