### PR TITLE
feat(pin-code-input): add name with hidden form input

### DIFF
--- a/docs/src/pages/components/PinCodeInput.svx
+++ b/docs/src/pages/components/PinCodeInput.svx
@@ -287,6 +287,29 @@ Use the `labelChildren` slot to render custom label content.
   </span>
 </PinCodeInput>
 
+## Form name
+
+Set `name` so the assembled code participates in native form submission
+(for example SvelteKit form actions and `FormData`). A hidden input mirrors
+`value`. When `name` is set, `required` is applied to the hidden input instead
+of each segment.
+
+```svelte
+<script>
+  import { Form, PinCodeInput, Button } from "carbon-components-svelte";
+</script>
+
+<Form method="POST" action="?/verify">
+  <PinCodeInput
+    name="code"
+    required
+    count={6}
+    labelText="Verification code"
+  />
+  <Button type="submit">Verify</Button>
+</Form>
+```
+
 ## Paste and autofill
 
 Paste a full code into any segment to fill all segments at once. A partial paste fills from the focused segment forward. Non-matching characters are ignored. The paste event fires with the clipboard value (whitespace stripped) before segments are updated.

--- a/src/PinCodeInput/PinCodeInput.svelte
+++ b/src/PinCodeInput/PinCodeInput.svelte
@@ -123,6 +123,16 @@
   /** Set to `true` to mark the field as required */
   export let required = false;
 
+  /**
+   * Specify a name attribute for native form participation.
+   *
+   * When set, a hidden input mirrors the assembled `value` so the code is
+   * included in FormData / form submissions. `required` is applied to the
+   * hidden input instead of each segment.
+   * @type {string | undefined}
+   */
+  export let name = undefined;
+
   /** Set to `true` to use the read-only variant */
   export let readonly = false;
 
@@ -466,6 +476,9 @@
         <slot name="labelChildren">{labelText}</slot>
       </legend>
     {/if}
+    {#if name}
+      <input type="hidden" {name} {value} {required}>
+    {/if}
     <div
       data-invalid={hasError || undefined}
       data-warn={hasWarn || undefined}
@@ -489,7 +502,7 @@
             id={index === 0 ? id : `${id}-${index}`}
             {disabled}
             {readonly}
-            {required}
+            required={name ? undefined : required}
             aria-readonly={readonly || undefined}
             aria-label={`${labelText || "Pin code"} digit ${index + 1} of ${count}`}
             aria-invalid={hasError || undefined}

--- a/tests/PinCodeInput/PinCodeInput.test.svelte
+++ b/tests/PinCodeInput/PinCodeInput.test.svelte
@@ -27,6 +27,8 @@
   export let selectTextOnFocus: ComponentProps<PinCodeInput>["selectTextOnFocus"] = false;
   export let size: ComponentProps<PinCodeInput>["size"] = "default";
   export let fluid: ComponentProps<PinCodeInput>["fluid"] = false;
+  export let name: ComponentProps<PinCodeInput>["name"] = undefined;
+  export let required: ComponentProps<PinCodeInput>["required"] = false;
 </script>
 
 <PinCodeInput
@@ -51,6 +53,8 @@
   {id}
   {selectTextOnFocus}
   {fluid}
+  {name}
+  {required}
   on:change={(e) => console.log("change", e.detail)}
   on:complete={(e) => console.log("complete", e.detail)}
   on:clear={() => console.log("clear")}

--- a/tests/PinCodeInput/PinCodeInput.test.ts
+++ b/tests/PinCodeInput/PinCodeInput.test.ts
@@ -156,6 +156,48 @@ describe("PinCodeInput", () => {
     expect(component.code).toEqual(["1", "2", "3", ""]);
   });
 
+  it("renders a hidden input for native form participation when name is set", async () => {
+    const { container } = render(PinCodeInput, {
+      props: { name: "otp", value: "12" },
+    });
+    const fieldset = getFieldset(container);
+    const hidden = fieldset?.querySelector(
+      'input[type="hidden"]',
+    ) as HTMLInputElement | null;
+
+    expect(hidden).not.toBeNull();
+    expect(hidden).toHaveAttribute("name", "otp");
+    expect(hidden?.value).toBe("12");
+
+    const inputs = getInputs();
+    inputs[2].focus();
+    await user.keyboard("34");
+    await tick();
+
+    expect(hidden?.value).toBe("1234");
+  });
+
+  it("does not render a hidden input when name is omitted", () => {
+    const { container } = render(PinCodeInput);
+    const fieldset = getFieldset(container);
+
+    expect(fieldset?.querySelector('input[type="hidden"]')).toBeNull();
+  });
+
+  it("applies required to the hidden input instead of segments when name is set", () => {
+    const { container } = render(PinCodeInput, {
+      props: { name: "otp", required: true },
+    });
+    const hidden = getFieldset(container)?.querySelector(
+      'input[type="hidden"]',
+    );
+
+    expect(hidden).toHaveAttribute("required");
+    for (const input of getInputs()) {
+      expect(input).not.toBeRequired();
+    }
+  });
+
   it("dispatches complete and change events", async () => {
     const consoleLog = vi.spyOn(console, "log");
     render(PinCodeInput);


### PR DESCRIPTION
Optional name syncs a hidden form input for native FormData / SvelteKit
submit; required moves onto that hidden input when name is set.

---

![pin-code-input form name example](https://gist.githubusercontent.com/metonym/7b004741bd3d0d8843267833187706ff/raw/56cb5bc664ddd7717a49488bc7856bb1f20d67dd/pin-code-input-form-name.png)
