### PR TITLE
feat(pin-code-input): add custom pattern

### DIFF
--- a/docs/src/pages/components/PinCodeInput.svx
+++ b/docs/src/pages/components/PinCodeInput.svx
@@ -57,6 +57,23 @@ The default input mode is `"numeric"`. Set `type` to `"alphanumeric"` to allow l
   on:paste
 />
 
+## Custom pattern
+
+Use `pattern` to override the per-character test used for typing and paste. Pass a `RegExp` or a string compiled with `new RegExp(...)`. The pattern is matched against each individual character, not the full assembled value. When `pattern` is unset, `type` selects the numeric or alphanumeric preset.
+
+<PinCodeInput
+  count={6}
+  pattern={/^[0-9a-fA-F]$/}
+  type="alphanumeric"
+  uppercase
+  labelText="Serial number"
+  helperText="Enter the 6-character hex serial"
+  on:complete
+  on:change
+  on:clear
+  on:paste
+/>
+
 ## Uppercase display
 
 Set `uppercase` to `true` to display characters in uppercase. The bound value and code retain the original casing.

--- a/src/PinCodeInput/PinCodeInput.svelte
+++ b/src/PinCodeInput/PinCodeInput.svelte
@@ -16,9 +16,10 @@
    *
    * Derived from `code` (i.e. `code.join("")`); bind to read the assembled
    * value. When `complete` is `true`, its length equals `count`. Each
-   * character matches the active `type`: `0-9` for `"numeric"`, `a-zA-Z0-9`
-   * for `"alphanumeric"`. Original casing is preserved regardless of
-   * `uppercase`, which only affects the visual rendering.
+   * character matches `pattern` when set, otherwise the active `type`:
+   * `0-9` for `"numeric"`, `a-zA-Z0-9` for `"alphanumeric"`. Original casing
+   * is preserved regardless of `uppercase`, which only affects the visual
+   * rendering.
    * @bindable readonly
    */
   export let value = "";
@@ -28,8 +29,8 @@
    *
    * `code` is the source of truth; its length tracks `count`. Each element is
    * either an empty string (unfilled segment) or a single character matching
-   * the active `type`: `0-9` for `"numeric"`, `a-zA-Z0-9` for
-   * `"alphanumeric"`.
+   * `pattern` when set, otherwise the active `type`: `0-9` for `"numeric"`,
+   * `a-zA-Z0-9` for `"alphanumeric"`.
    * @type {string[]}
    * @bindable writable
    */
@@ -39,9 +40,21 @@
    * Specify the type of allowed characters.
    *
    * `"numeric"` allows `0-9`; `"alphanumeric"` allows `a-z`, `A-Z`, `0-9`.
+   * Ignored when `pattern` is set.
    * @type {"numeric" | "alphanumeric"}
    */
   export let type = "numeric";
+
+  /**
+   * Override the per-character validation used for typing and paste.
+   *
+   * Accepts a `RegExp` or a string compiled with `new RegExp(...)`. The
+   * pattern is tested against each individual character, not the full
+   * assembled value. When unset, `type` selects the preset (`"numeric"` or
+   * `"alphanumeric"`).
+   * @type {RegExp | string | undefined}
+   */
+  export let pattern = undefined;
 
   /**
    * Set to `true` to visually display the characters in uppercase
@@ -162,7 +175,16 @@
   wasComplete = count > 0 && code.length === count && code.every(Boolean);
   hadValue = code.some(Boolean);
 
-  $: pattern = type === "numeric" ? /^[0-9]$/ : /^[a-zA-Z0-9]$/;
+  /** @type {RegExp} */
+  let charPattern;
+  $: charPattern =
+    pattern == null
+      ? type === "numeric"
+        ? /^[0-9]$/
+        : /^[a-zA-Z0-9]$/
+      : typeof pattern === "string"
+        ? new RegExp(pattern)
+        : pattern;
 
   $: if (code.length !== count) {
     code = Array.from({ length: count }, (_, index) => code[index] ?? "");
@@ -204,7 +226,9 @@
   $: if (anyValue) hadValue = true;
 
   /** @type {(char: string) => boolean} */
-  const isValidChar = (char) => pattern.test(char);
+  function isValidChar(char) {
+    return charPattern.test(char);
+  }
 
   /** @type {(index: number, char: string) => void} */
   function setChar(index, char) {

--- a/tests/PinCodeInput/PinCodeInput.test.svelte
+++ b/tests/PinCodeInput/PinCodeInput.test.svelte
@@ -8,6 +8,7 @@
   export let value: ComponentProps<PinCodeInput>["value"] = "";
   export let code: ComponentProps<PinCodeInput>["code"] = [];
   export let type: ComponentProps<PinCodeInput>["type"] = "numeric";
+  export let pattern: ComponentProps<PinCodeInput>["pattern"] = undefined;
   export let mask: ComponentProps<PinCodeInput>["mask"] = false;
   export let uppercase: ComponentProps<PinCodeInput>["uppercase"] = false;
   export let complete: ComponentProps<PinCodeInput>["complete"] = false;
@@ -35,6 +36,7 @@
   bind:complete
   {size}
   {type}
+  {pattern}
   {mask}
   {uppercase}
   {disabled}

--- a/tests/PinCodeInput/PinCodeInput.test.ts
+++ b/tests/PinCodeInput/PinCodeInput.test.ts
@@ -72,6 +72,64 @@ describe("PinCodeInput", () => {
     expect(inputs[0].value).toBe("a");
   });
 
+  it("accepts and rejects characters against a custom pattern", async () => {
+    render(PinCodeInput, { props: { pattern: /^[0-9a-fA-F]$/ } });
+    const inputs = getInputs();
+
+    inputs[0].focus();
+    await user.keyboard("g");
+    expect(inputs[0].value).toBe("");
+
+    await user.keyboard("a");
+    expect(inputs[0].value).toBe("a");
+
+    await user.keyboard("F");
+    expect(inputs[1].value).toBe("F");
+
+    await user.keyboard("9");
+    expect(inputs[2].value).toBe("9");
+  });
+
+  it("compiles a string pattern for per-character validation", async () => {
+    render(PinCodeInput, { props: { pattern: "^[a-zA-Z]$" } });
+    const inputs = getInputs();
+
+    inputs[0].focus();
+    await user.keyboard("1");
+    expect(inputs[0].value).toBe("");
+
+    await user.keyboard("b");
+    expect(inputs[0].value).toBe("b");
+  });
+
+  it("uses type presets when pattern is omitted", async () => {
+    render(PinCodeInput, { props: { type: "numeric" } });
+    const inputs = getInputs();
+
+    inputs[0].focus();
+    await user.keyboard("a");
+    expect(inputs[0].value).toBe("");
+
+    await user.keyboard("3");
+    expect(inputs[0].value).toBe("3");
+  });
+
+  it("filters pasted characters with a custom pattern", async () => {
+    const { component } = render(PinCodeInput, {
+      props: { pattern: /^[0-9a-fA-F]$/ },
+    });
+    const inputs = getInputs();
+
+    inputs[0].focus();
+    await fireEvent.paste(inputs[0], {
+      clipboardData: { getData: () => "A1gB2z" },
+    });
+    await tick();
+
+    expect(component.value).toBe("A1B2");
+    expect(inputs.map((input) => input.value)).toEqual(["A", "1", "B", "2"]);
+  });
+
   it("moves focus back and clears on backspace when empty", async () => {
     render(PinCodeInput);
     const inputs = getInputs();


### PR DESCRIPTION
pattern (RegExp or string) overrides per-character validation for typing
and paste; unset keeps the existing type presets.

---

![pin-code-input custom hex pattern example — invalid "g" rejected, valid hex chars accepted and uppercased](https://gist.githubusercontent.com/metonym/a3c7bee576da1db769618044397fae4a/raw/047cefeb191caa42c9efc6d7dde47013654bbab2/pin-code-input-pattern.png)
