### PR TITLE
feat(tag): support href

### DIFF
--- a/docs/src/pages/components/Tag.svx
+++ b/docs/src/pages/components/Tag.svx
@@ -104,12 +104,30 @@ Set `interactive` to render a button element instead of a div for clickable tags
 
 <Tag interactive>Machine learning</Tag>
 
+## Link
+
+Set `href` to render the tag as an anchor. Link tags reuse interactive styles. Do not wrap a `Tag` in an `<a>`; pass `href` on the tag itself. `href` is mutually exclusive with `filter`; when both are set, `filter` takes precedence.
+
+<Tag href="/components/Tag" type="red">red</Tag>
+<Tag href="/components/Tag" type="magenta">magenta</Tag>
+<Tag href="/components/Tag" type="purple">purple</Tag>
+<Tag href="/components/Tag" type="blue">blue</Tag>
+<Tag href="/components/Tag" type="cyan">cyan</Tag>
+<Tag href="/components/Tag" type="teal">teal</Tag>
+<Tag href="/components/Tag" type="green">green</Tag>
+<Tag href="/components/Tag" type="gray">gray</Tag>
+<Tag href="/components/Tag" type="cool-gray">cool-gray</Tag>
+<Tag href="/components/Tag" type="warm-gray">warm-gray</Tag>
+<Tag href="/components/Tag" type="high-contrast">high-contrast</Tag>
+<Tag href="/components/Tag" type="outline">outline</Tag>
+
 ## Disabled
 
-Both filterable and interactive tag variants support a disabled state.
+Filterable, interactive, and link tag variants support a disabled state.
 
 <Tag filter disabled>Machine learning</Tag>
 <Tag interactive disabled>Machine learning</Tag>
+<Tag href="/components/Tag" disabled>Machine learning</Tag>
 
 ## Tooltip
 

--- a/src/Tag/Tag.svelte
+++ b/src/Tag/Tag.svelte
@@ -1,7 +1,7 @@
 <script>
   /**
    * @template [Icon=any]
-   * @restProps {div | span}
+   * @restProps {div | button | a}
    */
 
   /**
@@ -25,6 +25,13 @@
 
   /** Set to `true` to render a `button` element instead of a `div` */
   export let interactive = false;
+
+  /**
+   * Specify the `href` attribute to render the tag as an anchor.
+   * Mutually exclusive with `filter`; when both are set, `filter` takes precedence.
+   * @type {string}
+   */
+  export let href = undefined;
 
   /** Set to `true` to display the skeleton state */
   export let skeleton = false;
@@ -162,6 +169,48 @@
       <Close />
     </button>
   </div>
+{:else if href}
+  <!-- svelte-ignore a11y-missing-attribute -->
+  <!-- svelte-ignore a11y-no-redundant-roles -->
+  <a
+    bind:this={ref}
+    href={disabled ? undefined : href}
+    role={disabled ? "link" : undefined}
+    {id}
+    aria-disabled={disabled || undefined}
+    rel={$$restProps.target === "_blank" ? "noopener noreferrer" : undefined}
+    data-overflow={groupOverflow ? "true" : undefined}
+    class:bx--tag={true}
+    class:bx--tag--inline={inline}
+    class:bx--tag--interactive={true}
+    class:bx--tag--disabled={disabled}
+    class:bx--tag--sm={resolvedSize === "sm"}
+    class:bx--tag--lg={resolvedSize === "lg"}
+    class:bx--tag--red={type === "red"}
+    class:bx--tag--magenta={type === "magenta"}
+    class:bx--tag--purple={type === "purple"}
+    class:bx--tag--blue={type === "blue"}
+    class:bx--tag--cyan={type === "cyan"}
+    class:bx--tag--teal={type === "teal"}
+    class:bx--tag--green={type === "green"}
+    class:bx--tag--gray={type === "gray"}
+    class:bx--tag--cool-gray={type === "cool-gray"}
+    class:bx--tag--warm-gray={type === "warm-gray"}
+    class:bx--tag--high-contrast={type === "high-contrast"}
+    class:bx--tag--outline={type === "outline"}
+    {...$$restProps}
+    on:click
+    on:mouseover
+    on:mouseenter
+    on:mouseleave
+  >
+    {#if $$slots.icon || icon}
+      <div class:bx--tag__custom-icon={true}>
+        <slot name="icon"> <svelte:component this={icon} /> </slot>
+      </div>
+    {/if}
+    <span bind:this={labelRef} class:bx--tag__label={true}> <slot /> </span>
+  </a>
 {:else if interactive}
   <button
     bind:this={ref}

--- a/tests/Tag/Tag.test.svelte
+++ b/tests/Tag/Tag.test.svelte
@@ -100,3 +100,11 @@
 >
   Filter click and close
 </Tag>
+
+<Tag href="/filtered?tag=ml" type="blue">Linked tag</Tag>
+
+<Tag href="/filtered?tag=ml" target="_blank">External linked tag</Tag>
+
+<Tag href="/filtered?tag=ml" disabled>Disabled linked tag</Tag>
+
+<Tag filter href="/should-not-link" on:close>Filter wins over href</Tag>

--- a/tests/Tag/Tag.test.ts
+++ b/tests/Tag/Tag.test.ts
@@ -98,6 +98,54 @@ describe("Tag", () => {
     expect(interactiveTag).toHaveClass("bx--tag--interactive");
   });
 
+  it("renders href tag as an anchor with interactive styles", () => {
+    render(Tag);
+
+    const linkedTag = screen.getByRole("link", { name: "Linked tag" });
+    expect(linkedTag).toHaveAttribute("href", "/filtered?tag=ml");
+    expect(linkedTag).toHaveClass("bx--tag");
+    expect(linkedTag).toHaveClass("bx--tag--interactive");
+    expect(linkedTag).toHaveClass("bx--tag--blue");
+  });
+
+  it("forwards target and sets rel for blank targets", () => {
+    render(Tag);
+
+    const linkedTag = screen.getByRole("link", { name: "External linked tag" });
+    expect(linkedTag).toHaveAttribute("target", "_blank");
+    expect(linkedTag).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
+  it("disables href navigation when disabled", () => {
+    render(Tag);
+
+    const linkedTag = screen
+      .getByText("Disabled linked tag")
+      .closest(".bx--tag");
+    assert(linkedTag);
+    expect(linkedTag.tagName).toBe("A");
+    expect(linkedTag).not.toHaveAttribute("href");
+    expect(linkedTag).toHaveAttribute("role", "link");
+    expect(linkedTag).toHaveAttribute("aria-disabled", "true");
+    expect(linkedTag).not.toHaveAttribute("tabindex");
+    expect(linkedTag).toHaveClass("bx--tag--disabled");
+  });
+
+  it("prefers filter over href when both are set", () => {
+    render(Tag);
+
+    const filterTag = screen
+      .getByText("Filter wins over href")
+      .closest(".bx--tag");
+    assert(filterTag);
+    expect(filterTag.tagName).toBe("DIV");
+    expect(filterTag).toHaveClass("bx--tag--filter");
+    expect(filterTag).not.toHaveAttribute("href");
+    expect(
+      screen.queryByRole("link", { name: "Filter wins over href" }),
+    ).not.toBeInTheDocument();
+  });
+
   it("renders skeleton state", () => {
     render(Tag);
 


### PR DESCRIPTION
href renders Tag as an interactive anchor; filter wins when both are
set; target/rel are forwarded with noopener for blank.