### PR TITLE
feat(tag): add maxWidth truncation with tooltip

### DIFF
--- a/css/_tag.scss
+++ b/css/_tag.scss
@@ -1,4 +1,5 @@
 @import "carbon-components/scss/globals/scss/vars";
+@import "carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/import-once/import-once";
 
 @mixin tag-lg {
   .#{$prefix}--tag--lg {
@@ -20,10 +21,42 @@
   }
 }
 
+/// Truncation tooltip trigger inside a capped-width tag.
+/// `TooltipDefinition` draws a dotted underline by default; strip it and keep
+/// the trigger from expanding the label past the tag's max-width.
+/// @access private
+/// @group components
+@mixin tag-truncate {
+  .#{$prefix}--tag--truncate {
+    min-width: 0;
+  }
+
+  .#{$prefix}--tag__label-tooltip {
+    display: block;
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  .#{$prefix}--tag__label-tooltip
+    .#{$prefix}--tooltip__trigger.#{$prefix}--tooltip__trigger--definition {
+    display: block;
+    width: 100%;
+    max-width: 100%;
+    overflow: hidden;
+    border-bottom: none;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+}
+
 @include exports("tag-lg") {
   @include tag-lg;
 }
 
 @include exports("tag-inline") {
   @include tag-inline;
+}
+
+@include exports("tag-truncate") {
+  @include tag-truncate;
 }

--- a/css/_tooltip.scss
+++ b/css/_tooltip.scss
@@ -124,6 +124,16 @@
     text-align: center;
   }
 
+  // Unlike the `icon` variant, `definition` tooltips can open on hover and
+  // sit close enough to the trigger that the pointer travels over the
+  // tooltip itself (e.g. `Tag` `maxWidth` truncation). Keep this variant
+  // hoverable so entering the tooltip cancels the pending close instead of
+  // the portal being a dead zone the pointer falls through, which flickers
+  // the tooltip open/closed as it re-triggers the trigger's hover handlers.
+  .#{$prefix}--tooltip-portal[data-tooltip-type='definition'] {
+    pointer-events: auto;
+  }
+
   .#{$prefix}--tooltip-portal[data-tooltip-type='definition']
     .#{$prefix}--tooltip-portal__content {
     @include tooltip--content('definition');
@@ -133,7 +143,7 @@
     z-index: auto;
     transform: none;
     opacity: 1;
-    pointer-events: none;
+    pointer-events: auto;
     display: flex;
     align-items: center;
     min-height: unset;

--- a/docs/src/pages/components/Tag.svx
+++ b/docs/src/pages/components/Tag.svx
@@ -92,6 +92,39 @@ on:close={() => console.log("close")}
 carbon-components
 </Tag>
 
+### Max width
+
+Set `maxWidth` to a CSS length to ellipsis long labels. A tooltip with the full text appears only when the label is truncated. Accepts any valid CSS length, including `rem`, `px`, `ch`, and `%`.
+
+<Stack gap={5}>
+  <div>
+    <div>maxWidth="8rem"</div>
+    <Tag filter maxWidth="8rem" on:close>
+      status:active AND region:us-south AND service:cloud-object-storage
+    </Tag>
+  </div>
+  <div>
+    <div>maxWidth="140px"</div>
+    <Tag filter maxWidth="140px" on:close>
+      status:active AND region:us-south AND service:cloud-object-storage
+    </Tag>
+  </div>
+  <div>
+    <div>maxWidth="20ch"</div>
+    <Tag filter maxWidth="20ch" on:close>
+      status:active AND region:us-south AND service:cloud-object-storage
+    </Tag>
+  </div>
+  <div>
+    <div>maxWidth="60%" (relative to the containing block)</div>
+    <div style="width: 200px;">
+      <Tag filter maxWidth="60%" on:close>
+        status:active AND region:us-south AND service:cloud-object-storage
+      </Tag>
+    </div>
+  </div>
+</Stack>
+
 ## Custom icon
 
 Add a custom icon to the tag. Note: custom icons cannot be used with the filterable variant.

--- a/e2e/tooltip-definition.test.ts
+++ b/e2e/tooltip-definition.test.ts
@@ -83,4 +83,27 @@ test.describe("TooltipDefinition portaled inside Modal", () => {
       ),
     ).toBeVisible();
   });
+
+  // Regression test: the portal used to be `pointer-events: none`, so moving
+  // the pointer from the trigger onto the portalled tooltip fell through to
+  // whatever was underneath. That left the trigger's hover state stuck
+  // "left" with no counterpart on the portal to cancel the pending close,
+  // so the tooltip closed after leaveDelayMs, the trigger reappeared under
+  // the pointer, and the tooltip reopened — flickering open/closed.
+  test("stays open when the pointer moves from the trigger onto the portalled tooltip", async ({
+    page,
+  }) => {
+    await page.getByTestId("open-modal").click();
+    await page.getByRole("button", { name: "Definition in modal" }).hover();
+
+    const tooltip = page.getByRole("tooltip");
+    await expect(tooltip).toBeVisible();
+
+    await tooltip.hover();
+    // Longer than the default 300ms leaveDelayMs, so a stale close timer
+    // would have fired and hidden the tooltip by now.
+    await page.waitForTimeout(500);
+
+    await expect(tooltip).toBeVisible();
+  });
 });

--- a/src/Tag/Tag.svelte
+++ b/src/Tag/Tag.svelte
@@ -43,6 +43,13 @@
   export let title = "Clear filter";
 
   /**
+   * Cap the tag width. When the label overflows, a tooltip shows the full text.
+   * Accepts any CSS length (for example `"8rem"`, `"120px"`).
+   * @type {string | undefined}
+   */
+  export let maxWidth = undefined;
+
+  /**
    * Specify the icon to render.
    * @type {Icon}
    */
@@ -58,9 +65,10 @@
    */
   export let ref = null;
 
-  import { createEventDispatcher, getContext, onMount } from "svelte";
+  import { createEventDispatcher, getContext, onMount, tick } from "svelte";
   import { readable } from "svelte/store";
   import Close from "../icons/Close.svelte";
+  import TooltipDefinition from "../TooltipDefinition/TooltipDefinition.svelte";
   import TagSkeleton from "./TagSkeleton.svelte";
 
   const dispatch = createEventDispatcher();
@@ -77,9 +85,47 @@
   const groupSize = tagSet?.size ?? readable(undefined);
 
   let labelRef = null;
+  let isTruncated = false;
+  let truncationLabel = "";
+  let measureToken = 0;
 
   // Fall back to the group's size, then to "default".
   $: resolvedSize = size ?? $groupSize ?? "default";
+
+  // Interactive tags are already buttons — wrapping the label in
+  // `TooltipDefinition` would nest buttons. Use the native `title` instead.
+  $: showTruncationTooltip = isTruncated && !interactive;
+  $: interactiveTitle =
+    isTruncated && interactive ? truncationLabel : undefined;
+
+  async function measureTruncation() {
+    const token = ++measureToken;
+    await tick();
+    if (token !== measureToken) return;
+
+    if (!maxWidth || !labelRef) {
+      isTruncated = false;
+      truncationLabel = "";
+      return;
+    }
+
+    const text = labelRef.textContent?.trim() ?? "";
+    const truncated = labelRef.scrollWidth > labelRef.clientWidth;
+    isTruncated = truncated;
+    truncationLabel = truncated ? text : "";
+  }
+
+  $: if (maxWidth != null && !skeleton) {
+    void maxWidth;
+    void filter;
+    void interactive;
+    void type;
+    void resolvedSize;
+    measureTruncation();
+  } else if (maxWidth == null) {
+    isTruncated = false;
+    truncationLabel = "";
+  }
 
   if (tagSet) {
     onMount(() => {
@@ -133,6 +179,7 @@
     class:bx--tag--inline={inline}
     class:bx--tag--disabled={disabled}
     class:bx--tag--filter={filter}
+    class:bx--tag--truncate={maxWidth != null}
     class:bx--tag--sm={resolvedSize === "sm"}
     class:bx--tag--lg={resolvedSize === "lg"}
     class:bx--tag--red={type === "red"}
@@ -148,16 +195,31 @@
     class:bx--tag--high-contrast={type === "high-contrast"}
     class:bx--tag--outline={type === "outline"}
     {...$$restProps}
+    style:max-width={maxWidth}
     on:click
     on:mouseover
     on:mouseenter
     on:mouseleave
   >
-    <span bind:this={labelRef} class:bx--tag__label={true}>
-      <slot props={{ class: "bx--tag__label" }}>
-        {type}
-      </slot>
-    </span>
+    {#if showTruncationTooltip}
+      <TooltipDefinition
+        class="bx--tag__label-tooltip"
+        tooltipText={truncationLabel}
+        portalTooltip
+      >
+        <span bind:this={labelRef} class:bx--tag__label={true}>
+          <slot props={{ class: "bx--tag__label" }}>
+            {type}
+          </slot>
+        </span>
+      </TooltipDefinition>
+    {:else}
+      <span bind:this={labelRef} class:bx--tag__label={true}>
+        <slot props={{ class: "bx--tag__label" }}>
+          {type}
+        </slot>
+      </span>
+    {/if}
     <button
       type="button"
       aria-labelledby={id}
@@ -219,11 +281,13 @@
     {disabled}
     aria-disabled={disabled}
     tabindex={disabled ? "-1" : undefined}
+    title={interactiveTitle}
     data-overflow={groupOverflow ? "true" : undefined}
     class:bx--tag={true}
     class:bx--tag--inline={inline}
     class:bx--tag--interactive={true}
     class:bx--tag--disabled={disabled}
+    class:bx--tag--truncate={maxWidth != null}
     class:bx--tag--sm={resolvedSize === "sm"}
     class:bx--tag--lg={resolvedSize === "lg"}
     class:bx--tag--red={type === "red"}
@@ -239,6 +303,7 @@
     class:bx--tag--high-contrast={type === "high-contrast"}
     class:bx--tag--outline={type === "outline"}
     {...$$restProps}
+    style:max-width={maxWidth}
     on:click
     on:mouseover
     on:mouseenter
@@ -260,6 +325,7 @@
     class:bx--tag={true}
     class:bx--tag--inline={inline}
     class:bx--tag--disabled={disabled}
+    class:bx--tag--truncate={maxWidth != null}
     class:bx--tag--sm={resolvedSize === "sm"}
     class:bx--tag--lg={resolvedSize === "lg"}
     class:bx--tag--red={type === "red"}
@@ -275,6 +341,7 @@
     class:bx--tag--high-contrast={type === "high-contrast"}
     class:bx--tag--outline={type === "outline"}
     {...$$restProps}
+    style:max-width={maxWidth}
     on:click
     on:mouseover
     on:mouseenter
@@ -285,6 +352,16 @@
         <slot name="icon"> <svelte:component this={icon} /> </slot>
       </div>
     {/if}
-    <span bind:this={labelRef} class:bx--tag__label={true}> <slot /> </span>
+    {#if showTruncationTooltip}
+      <TooltipDefinition
+        class="bx--tag__label-tooltip"
+        tooltipText={truncationLabel}
+        portalTooltip
+      >
+        <span bind:this={labelRef} class:bx--tag__label={true}> <slot /> </span>
+      </TooltipDefinition>
+    {:else}
+      <span bind:this={labelRef} class:bx--tag__label={true}> <slot /> </span>
+    {/if}
   </div>
 {/if}

--- a/src/TooltipDefinition/TooltipDefinition.svelte
+++ b/src/TooltipDefinition/TooltipDefinition.svelte
@@ -175,10 +175,15 @@
     intrinsicWidth={true}
     let:direction={actualDirection}
   >
+    <!-- svelte-ignore a11y-no-static-element-interactions -->
     <div
       class:bx--tooltip-portal={true}
       data-direction={actualDirection ?? direction}
       data-tooltip-type="definition"
+      on:mouseenter={clickToOpen ? undefined : () => setOpenDelayed(true, 0)}
+      on:mouseleave={clickToOpen
+        ? undefined
+        : () => setOpenDelayed(false, leaveDelayMs)}
     >
       <span class:bx--tooltip-portal__caret={true}></span>
       <span

--- a/tests/Tag/Tag.test.ts
+++ b/tests/Tag/Tag.test.ts
@@ -1,9 +1,11 @@
 import { render, screen } from "@testing-library/svelte";
 import type TagComponent from "carbon-components-svelte/Tag/Tag.svelte";
 import type { ComponentProps } from "svelte";
+import { tick } from "svelte";
 import { expectInlineStyle } from "../utils/inline-style";
 import { user } from "../utils/user";
 import Tag from "./Tag.test.svelte";
+import TagMaxWidth from "./TagMaxWidth.test.svelte";
 
 describe("Tag", () => {
   afterEach(() => {
@@ -258,6 +260,67 @@ describe("Tag", () => {
     assert(tagElement);
     const iconContainer = tagElement.querySelector(".bx--tag__custom-icon");
     expect(iconContainer).toBeInTheDocument();
+  });
+
+  describe("maxWidth truncation", () => {
+    let clientWidthSpy: ReturnType<typeof vi.spyOn>;
+    let scrollWidthSpy: ReturnType<typeof vi.spyOn>;
+
+    function mockOverflow(truncated: boolean) {
+      clientWidthSpy = vi
+        .spyOn(HTMLElement.prototype, "clientWidth", "get")
+        .mockReturnValue(truncated ? 40 : 200);
+      scrollWidthSpy = vi
+        .spyOn(HTMLElement.prototype, "scrollWidth", "get")
+        .mockReturnValue(truncated ? 200 : 40);
+    }
+
+    afterEach(() => {
+      clientWidthSpy?.mockRestore();
+      scrollWidthSpy?.mockRestore();
+    });
+
+    it("applies the truncate class and max-width style", async () => {
+      mockOverflow(false);
+      render(TagMaxWidth, {
+        props: { maxWidth: "8rem", label: "Short", filter: true },
+      });
+      await tick();
+
+      const tag = screen.getByText("Short").closest(".bx--tag");
+      expect(tag).toHaveClass("bx--tag--truncate");
+      expectInlineStyle(tag, { maxWidth: "8rem" });
+    });
+
+    it("does not render a tooltip when the label is not truncated", async () => {
+      mockOverflow(false);
+      render(TagMaxWidth, {
+        props: { maxWidth: "8rem", label: "Short", filter: true },
+      });
+      await tick();
+
+      expect(
+        document.querySelector(".bx--tooltip--definition"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("renders a tooltip when the filter label overflows", async () => {
+      mockOverflow(true);
+      const label =
+        "status:active AND region:us-south AND service:cloud-object-storage";
+      render(TagMaxWidth, {
+        props: { maxWidth: "8rem", label, filter: true },
+      });
+      await tick();
+      // Wrapping the label remounts it; wait for the post-measure update.
+      await tick();
+
+      const tooltip = document.querySelector(".bx--tooltip--definition");
+      expect(tooltip).toBeInTheDocument();
+      expect(
+        tooltip?.querySelector(".bx--tooltip__trigger")?.textContent?.trim(),
+      ).toBe(label);
+    });
   });
 
   describe("Generics", () => {

--- a/tests/Tag/TagMaxWidth.test.svelte
+++ b/tests/Tag/TagMaxWidth.test.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+  import Tag from "carbon-components-svelte/Tag/Tag.svelte";
+
+  export let maxWidth: string | undefined = "8rem";
+  export let filter = false;
+  export let interactive = false;
+  export let label =
+    "status:active AND region:us-south AND service:cloud-object-storage";
+</script>
+
+<Tag {maxWidth} {filter} {interactive} on:close>{label}</Tag>

--- a/tests/TooltipDefinition/TooltipDefinition.test.ts
+++ b/tests/TooltipDefinition/TooltipDefinition.test.ts
@@ -300,5 +300,62 @@ describe("TooltipDefinition", () => {
         "bx--tooltip--portal-active",
       );
     });
+
+    // Regression test: the portalled tooltip sits right against (and
+    // slightly overlaps) the trigger, so the pointer can leave the trigger
+    // and land on the portal before the close timer fires. Without a
+    // mouseenter handler on the portal to cancel that timer, the tooltip
+    // would close and immediately reopen in a loop.
+    it("should stay open when the pointer moves from the trigger onto the portal", async () => {
+      vi.useFakeTimers();
+
+      render(TooltipDefinition, {
+        props: { portalTooltip: true, enterDelayMs: 0, leaveDelayMs: 200 },
+      });
+
+      const trigger = screen.getByText("Tooltip trigger");
+      const definition = trigger.closest(".bx--tooltip--definition");
+      expect.assert(definition instanceof HTMLElement);
+
+      await fireEvent.mouseEnter(definition);
+      expect(screen.getByText("Test tooltip text")).toBeInTheDocument();
+
+      await fireEvent.mouseLeave(definition);
+
+      const portalContent = document.querySelector(".bx--tooltip-portal");
+      expect.assert(portalContent instanceof HTMLElement);
+      await fireEvent.mouseEnter(portalContent);
+
+      await vi.advanceTimersByTimeAsync(200);
+
+      expect(screen.getByText("Test tooltip text")).toBeInTheDocument();
+
+      vi.useRealTimers();
+    });
+
+    it("should close after leaveDelayMs when the pointer leaves the portal", async () => {
+      vi.useFakeTimers();
+
+      render(TooltipDefinition, {
+        props: { portalTooltip: true, enterDelayMs: 0, leaveDelayMs: 200 },
+      });
+
+      const trigger = screen.getByText("Tooltip trigger");
+      const definition = trigger.closest(".bx--tooltip--definition");
+      expect.assert(definition instanceof HTMLElement);
+
+      await fireEvent.mouseEnter(definition);
+
+      const portalContent = document.querySelector(".bx--tooltip-portal");
+      expect.assert(portalContent instanceof HTMLElement);
+      await fireEvent.mouseEnter(portalContent);
+      await fireEvent.mouseLeave(portalContent);
+
+      await vi.advanceTimersByTimeAsync(200);
+
+      expect(screen.queryByText("Test tooltip text")).not.toBeInTheDocument();
+
+      vi.useRealTimers();
+    });
   });
 });


### PR DESCRIPTION
maxWidth truncates long Tag labels with ellipsis and shows a portalled
tooltip only when the text actually overflows.

<img width="777" height="531" alt="Screenshot 2026-08-02 at 2 19 22 PM" src="https://github.com/user-attachments/assets/c98b3ca7-9071-4bac-bb37-a322d28738db" />
