### PR TITLE
feat(pin-code-input): add segment groups

### DIFF
--- a/css/_fluid-pin-code-input.scss
+++ b/css/_fluid-pin-code-input.scss
@@ -87,6 +87,14 @@
   }
 
   .#{$prefix}--pin-code-input--fluid
+    .#{$prefix}--pin-code-input__group-separator {
+    align-self: flex-end;
+    margin-inline: $spacing-03;
+    margin-block-end: to-rem(10px);
+    color: $text-02;
+  }
+
+  .#{$prefix}--pin-code-input--fluid
     .#{$prefix}--pin-code-input__field
     + .#{$prefix}--pin-code-input__field {
     margin-inline-start: 0;

--- a/css/_pin-code-input.scss
+++ b/css/_pin-code-input.scss
@@ -25,6 +25,15 @@
     gap: $carbon--spacing-01;
   }
 
+  .#{$prefix}--pin-code-input__group-separator {
+    @include type-style('body-short-01');
+
+    flex-shrink: 0;
+    margin-inline: $carbon--spacing-02;
+    color: $text-02;
+    user-select: none;
+  }
+
   .#{$prefix}--pin-code-input__field.#{$prefix}--text-input {
     @include type-style('body-short-01');
 

--- a/docs/src/pages/components/PinCodeInput.svx
+++ b/docs/src/pages/components/PinCodeInput.svx
@@ -44,6 +44,20 @@ Use `count` to set the number of segments. For example, six is common for SMS, e
   on:paste
 />
 
+## Groups
+
+Use `groups` to visually partition segments with a decorative separator. Each entry is the number of segments in that group and the values must sum to `count`. Separators are decorative only and do not affect focus, paste, or the bound value.
+
+<PinCodeInput
+  count={6}
+  groups={[3, 3]}
+  labelText="Verification code"
+  on:complete
+  on:change
+  on:clear
+  on:paste
+/>
+
 ## Alphanumeric
 
 The default input mode is `"numeric"`. Set `type` to `"alphanumeric"` to allow letters and digits.

--- a/src/PinCodeInput/PinCodeInput.svelte
+++ b/src/PinCodeInput/PinCodeInput.svelte
@@ -150,6 +150,19 @@
    */
   export let selectTextOnFocus = false;
 
+  /**
+   * Visually partition segments into groups with a decorative separator
+   * between each group.
+   *
+   * Each entry is the number of segments in that group. Values must be
+   * positive integers that sum to `count`. Invalid values are ignored and
+   * segments render as a single contiguous row. Separators are decorative
+   * only (`aria-hidden`); focus, paste, and value indices ignore them.
+   * @type {number[] | undefined}
+   * @example [3, 3]
+   */
+  export let groups = undefined;
+
   /** Set an id for the input group */
   export let id = `ccs-${Math.random().toString(36)}`;
 
@@ -209,6 +222,8 @@
   $: isFluid = fluid || !!formContext?.isFluid;
   $: segmentPlaceholder =
     placeholder === undefined ? (isFluid ? "–" : "") : placeholder;
+  $: resolvedGroups = resolveGroups(groups, count);
+  $: segmentItems = buildSegmentItems(resolvedGroups, count);
 
   $: legendId = `legend-${id}`;
   $: helperId = `helper-${id}`;
@@ -234,6 +249,52 @@
     dispatch("clear");
   }
   $: if (anyValue) hadValue = true;
+
+  /**
+   * @param {number[] | undefined} groupSizes
+   * @param {number} segmentCount
+   * @returns {number[] | undefined}
+   */
+  function resolveGroups(groupSizes, segmentCount) {
+    if (!groupSizes || groupSizes.length === 0) return undefined;
+    if (!groupSizes.every((size) => Number.isInteger(size) && size > 0)) {
+      return undefined;
+    }
+    const sum = groupSizes.reduce((total, size) => total + size, 0);
+    if (sum !== segmentCount) return undefined;
+    return groupSizes;
+  }
+
+  /**
+   * @typedef {{ kind: "segment"; index: number } | { kind: "separator"; key: string }} SegmentItem
+   */
+
+  /**
+   * @param {number[] | undefined} groupSizes
+   * @param {number} segmentCount
+   * @returns {SegmentItem[]}
+   */
+  function buildSegmentItems(groupSizes, segmentCount) {
+    /** @type {SegmentItem[]} */
+    const items = [];
+    if (!groupSizes) {
+      for (let index = 0; index < segmentCount; index++) {
+        items.push({ kind: "segment", index });
+      }
+      return items;
+    }
+
+    let index = 0;
+    for (let groupIndex = 0; groupIndex < groupSizes.length; groupIndex++) {
+      for (let offset = 0; offset < groupSizes[groupIndex]; offset++) {
+        items.push({ kind: "segment", index: index++ });
+      }
+      if (groupIndex < groupSizes.length - 1) {
+        items.push({ kind: "separator", key: `sep-${groupIndex}` });
+      }
+    }
+    return items;
+  }
 
   /** @type {(char: string) => boolean} */
   function isValidChar(char) {
@@ -487,42 +548,52 @@
       class:bx--pin-code-input__fields--warning={hasWarn}
     >
       <div class:bx--pin-code-input__segments={true}>
-        {#each code as char, index (index)}
-          <input
-            bind:this={inputs[index]}
-            type="text"
-            inputmode={type === "numeric" ? "numeric" : "text"}
-            autocomplete={index === 0 ? "one-time-code" : "off"}
-            autocorrect="off"
-            autocapitalize="off"
-            spellcheck="false"
-            maxlength="1"
-            value={char}
-            placeholder={segmentPlaceholder || undefined}
-            id={index === 0 ? id : `${id}-${index}`}
-            {disabled}
-            {readonly}
-            required={name ? undefined : required}
-            aria-readonly={readonly || undefined}
-            aria-label={`${labelText || "Pin code"} digit ${index + 1} of ${count}`}
-            aria-invalid={hasError || undefined}
-            data-invalid={hasError || undefined}
-            data-warn={hasWarn || undefined}
-            class:bx--text-input={true}
-            class:bx--pin-code-input__field={true}
-            class:bx--pin-code-input__field--masked={mask}
-            class:bx--pin-code-input__field--uppercase={uppercase}
-            class:bx--text-input--light={light}
-            class:bx--text-input--invalid={hasError}
-            class:bx--text-input--warning={hasWarn}
-            class:bx--text-input--xs={size === "xs"}
-            class:bx--text-input--sm={size === "sm"}
-            class:bx--text-input--xl={size === "xl"}
-            on:input={(event) => handleInput(index, event)}
-            on:keydown={(event) => handleKeydown(index, event)}
-            on:paste={(event) => handlePaste(index, event)}
-            on:focus={handleFocus}
-          >
+        {#each segmentItems as item (item.kind === "segment" ? item.index : item.key)}
+          {#if item.kind === "separator"}
+            <span
+              class:bx--pin-code-input__group-separator={true}
+              aria-hidden="true"
+              >–</span
+            >
+          {:else}
+            {@const index = item.index}
+            {@const char = code[index]}
+            <input
+              bind:this={inputs[index]}
+              type="text"
+              inputmode={type === "numeric" ? "numeric" : "text"}
+              autocomplete={index === 0 ? "one-time-code" : "off"}
+              autocorrect="off"
+              autocapitalize="off"
+              spellcheck="false"
+              maxlength="1"
+              value={char}
+              placeholder={segmentPlaceholder || undefined}
+              id={index === 0 ? id : `${id}-${index}`}
+              {disabled}
+              {readonly}
+              required={name ? undefined : required}
+              aria-readonly={readonly || undefined}
+              aria-label={`${labelText || "Pin code"} digit ${index + 1} of ${count}`}
+              aria-invalid={hasError || undefined}
+              data-invalid={hasError || undefined}
+              data-warn={hasWarn || undefined}
+              class:bx--text-input={true}
+              class:bx--pin-code-input__field={true}
+              class:bx--pin-code-input__field--masked={mask}
+              class:bx--pin-code-input__field--uppercase={uppercase}
+              class:bx--text-input--light={light}
+              class:bx--text-input--invalid={hasError}
+              class:bx--text-input--warning={hasWarn}
+              class:bx--text-input--xs={size === "xs"}
+              class:bx--text-input--sm={size === "sm"}
+              class:bx--text-input--xl={size === "xl"}
+              on:input={(event) => handleInput(index, event)}
+              on:keydown={(event) => handleKeydown(index, event)}
+              on:paste={(event) => handlePaste(index, event)}
+              on:focus={handleFocus}
+            >
+          {/if}
         {/each}
         {#if !isFluid}
           {#if hasError}

--- a/tests/PinCodeInput/PinCodeInput.test.svelte
+++ b/tests/PinCodeInput/PinCodeInput.test.svelte
@@ -29,6 +29,7 @@
   export let fluid: ComponentProps<PinCodeInput>["fluid"] = false;
   export let name: ComponentProps<PinCodeInput>["name"] = undefined;
   export let required: ComponentProps<PinCodeInput>["required"] = false;
+  export let groups: ComponentProps<PinCodeInput>["groups"] = undefined;
 </script>
 
 <PinCodeInput
@@ -55,6 +56,7 @@
   {fluid}
   {name}
   {required}
+  {groups}
   on:change={(e) => console.log("change", e.detail)}
   on:complete={(e) => console.log("complete", e.detail)}
   on:clear={() => console.log("clear")}

--- a/tests/PinCodeInput/PinCodeInput.test.ts
+++ b/tests/PinCodeInput/PinCodeInput.test.ts
@@ -32,6 +32,120 @@ describe("PinCodeInput", () => {
     expect(getInputs()).toHaveLength(6);
   });
 
+  describe("groups", () => {
+    const getSeparators = (container: HTMLElement) =>
+      container.querySelectorAll(".bx--pin-code-input__group-separator");
+
+    it("renders decorative separators between valid groups", () => {
+      const { container } = render(PinCodeInput, {
+        props: { count: 6, groups: [3, 3] },
+      });
+
+      expect(getInputs()).toHaveLength(6);
+      expect(getSeparators(container)).toHaveLength(1);
+      expect(getSeparators(container)[0]).toHaveAttribute(
+        "aria-hidden",
+        "true",
+      );
+      expect(getSeparators(container)[0]).toHaveTextContent("–");
+    });
+
+    it("renders a separator between each adjacent group", () => {
+      const { container } = render(PinCodeInput, {
+        props: { count: 6, groups: [2, 2, 2] },
+      });
+
+      expect(getSeparators(container)).toHaveLength(2);
+    });
+
+    it("ignores groups that do not sum to count", () => {
+      const { container } = render(PinCodeInput, {
+        props: { count: 6, groups: [2, 2] },
+      });
+
+      expect(getInputs()).toHaveLength(6);
+      expect(getSeparators(container)).toHaveLength(0);
+    });
+
+    it("ignores groups with non-positive sizes", () => {
+      const { container } = render(PinCodeInput, {
+        props: { count: 4, groups: [0, 4] },
+      });
+
+      expect(getSeparators(container)).toHaveLength(0);
+    });
+
+    it("keeps arrow navigation contiguous across separators", async () => {
+      render(PinCodeInput, { props: { count: 6, groups: [3, 3] } });
+      const inputs = getInputs();
+
+      inputs[2].focus();
+      await user.keyboard("{ArrowRight}");
+      expect(inputs[3]).toHaveFocus();
+
+      await user.keyboard("{ArrowLeft}");
+      expect(inputs[2]).toHaveFocus();
+    });
+
+    it("auto-advances focus across a group boundary", async () => {
+      render(PinCodeInput, { props: { count: 6, groups: [3, 3] } });
+      const inputs = getInputs();
+
+      inputs[2].focus();
+      await user.keyboard("1");
+      expect(inputs[3]).toHaveFocus();
+    });
+
+    it("distributes a pasted code across grouped segments", async () => {
+      const { component } = render(PinCodeInput, {
+        props: { count: 6, groups: [3, 3] },
+      });
+      const inputs = getInputs();
+
+      inputs[0].focus();
+      await fireEvent.paste(inputs[0], {
+        clipboardData: { getData: () => "123456" },
+      });
+      await tick();
+
+      expect(component.value).toBe("123456");
+      expect(inputs.map((input) => input.value)).toEqual([
+        "1",
+        "2",
+        "3",
+        "4",
+        "5",
+        "6",
+      ]);
+      expect(inputs[5]).toHaveFocus();
+    });
+
+    it("fills a partial paste from the focused segment across groups", async () => {
+      const { component } = render(PinCodeInput, {
+        props: { count: 6, groups: [3, 3] },
+      });
+      const inputs = getInputs();
+
+      inputs[2].focus();
+      await fireEvent.paste(inputs[2], {
+        clipboardData: { getData: () => "789" },
+      });
+      await tick();
+
+      expect(inputs.map((input) => input.value)).toEqual([
+        "",
+        "",
+        "7",
+        "8",
+        "9",
+        "",
+      ]);
+      expect(component.value).toBe("789");
+      // First empty segment receives focus after paste.
+      expect(inputs[0]).toHaveFocus();
+    });
+  });
+
   it("applies the extra-small size to each field", () => {
     render(PinCodeInput, { props: { size: "xs" } });
     for (const input of getInputs()) {


### PR DESCRIPTION
groups partitions PinCodeInput segments with decorative separators (e.g.
[3, 3]) without changing focus, paste, or value indices.

<img width="694" height="348" alt="Screenshot 2026-08-02 at 9 22 30 AM" src="https://github.com/user-attachments/assets/86e2e55d-5acf-4490-8f19-e151c99928e5" />
