### PR TITLE
feat(tag-set): manage focus and announce on dismiss

### DIFF
--- a/docs/src/pages/components/TagSet.svx
+++ b/docs/src/pages/components/TagSet.svx
@@ -105,6 +105,8 @@ Set `overflowDirection` to show the tooltip above the indicator instead of below
 
 Set `filter` on a `Tag` to render it as closable. `TagSet` dispatches `close:tag` with `{ tag, index }` instead of taking a per-tag handler: remove the tag from your own state in response.
 
+After you remove the tag, `TagSet` moves focus to the next close button when dismiss came from that control (for example <DocKbd label="Enter" /> or <DocKbd label="Space" /> on the close icon, or a pointer click on it). If there is no next close button, focus moves to the previous one, or to the "+N" overflow trigger when present. A visually hidden polite live region announces "Filter X removed". Set `manageFocusOnClose` to `false` to keep focus management under your own control.
+
 <FileSource src="/framed/TagSet/TagSetDismissible" />
 
 ## Custom overflow tooltip

--- a/src/TagSet/TagSet.svelte
+++ b/src/TagSet/TagSet.svelte
@@ -70,6 +70,14 @@
    */
   export let gap = 3;
 
+  /**
+   * Move focus to a neighboring close button (or the "+N" overflow trigger)
+   * after a filter tag is dismissed via its close button. Set to `false` to
+   * opt out. Focus is only moved when the close button (or its tag) held
+   * focus at dismiss time — pointer activity elsewhere is left alone.
+   */
+  export let manageFocusOnClose = true;
+
   import { createEventDispatcher, onMount, setContext, tick } from "svelte";
   import { writable } from "svelte/store";
   import Stack from "../Stack/Stack.svelte";
@@ -86,6 +94,9 @@
   const sizeStore = writable(size);
   $: sizeStore.set(size);
 
+  /** Visually hidden polite live region text after a filter tag is dismissed. */
+  let liveAnnouncement = "";
+
   // Tags register in mount order, which differs from DOM order when they are
   // conditionally rendered. Sort by document position right at registration
   // time so the fit calculation and overflow tooltip track the rendered
@@ -100,8 +111,58 @@
     });
   }
 
+  /** Visible (non-overflow) filter-tag close buttons, in DOM order. */
+  function getVisibleCloseButtons() {
+    if (!wrapperRef) return [];
+    return Array.from(
+      wrapperRef.querySelectorAll(
+        '.bx--tag-set__space > .bx--tag:not([data-overflow="true"]) .bx--tag__close-icon:not([disabled])',
+      ),
+    );
+  }
+
+  function focusNeighborAfterClose(index) {
+    const closeButtons = getVisibleCloseButtons();
+    const next = closeButtons[index] ?? closeButtons[index - 1];
+    if (next instanceof HTMLElement) {
+      next.focus();
+      return;
+    }
+
+    const overflowTrigger = wrapperRef?.querySelector(
+      ".bx--tag-set-overflow:not(.bx--tag-set-overflow--empty) .bx--tooltip__trigger",
+    );
+    if (overflowTrigger instanceof HTMLElement) {
+      overflowTrigger.focus();
+    }
+  }
+
   function handleTagClose(item) {
-    dispatch("close:tag", { tag: item, index: $items.indexOf(item) });
+    const index = $items.indexOf(item);
+    const label = item.label;
+    const active =
+      typeof document === "undefined" ? null : document.activeElement;
+    // Only move focus when dismiss came from the close button / its tag
+    // (keyboard or pointer on that control). Do not steal focus if something
+    // else was focused when close fired.
+    const shouldManageFocus =
+      manageFocusOnClose &&
+      item.node != null &&
+      active instanceof Node &&
+      item.node.contains(active);
+
+    liveAnnouncement = label ? `Filter ${label} removed` : "Filter removed";
+    dispatch("close:tag", { tag: item, index });
+
+    if (!shouldManageFocus) return;
+
+    const closedId = item.id;
+    tick().then(() => {
+      // Consumer must remove the tag for focus to move; if it is still
+      // registered, leave focus alone.
+      if ($items.some((tag) => tag.id === closedId)) return;
+      focusNeighborAfterClose(index);
+    });
   }
 
   setContext("carbon:TagSet", {
@@ -234,4 +295,7 @@
       </svelte:fragment>
     </TagSetOverflow>
   </Stack>
+  <div aria-live="polite" aria-atomic="true" class:bx--visually-hidden={true}>
+    {liveAnnouncement}
+  </div>
 </div>

--- a/tests/TagSet/TagSet.test.svelte
+++ b/tests/TagSet/TagSet.test.svelte
@@ -5,6 +5,7 @@
 
   export let labels: string[] = ["Tag 1", "Tag 2", "Tag 3", "Tag 4"];
   export let dismissible = false;
+  export let manageFocusOnClose = true;
   export let maxVisible: ComponentProps<TagSet>["maxVisible"] = undefined;
   export let size: ComponentProps<TagSet>["size"] = undefined;
   export let gap: ComponentProps<TagSet>["gap"] = undefined;
@@ -13,17 +14,25 @@
     () => {};
   export let onOverflowClick: (event: CustomEvent) => void = () => {};
   export let onOverflowChange: (detail: { count: number }) => void = () => {};
+
+  function handleTagClose(detail: { tag: unknown; index: number }) {
+    onTagClose(detail);
+    if (dismissible) {
+      labels = labels.filter((_, index) => index !== detail.index);
+    }
+  }
 </script>
 
 <TagSet
   {maxVisible}
   {size}
   {gap}
-  on:close:tag={({ detail }) => onTagClose(detail)}
+  {manageFocusOnClose}
+  on:close:tag={({ detail }) => handleTagClose(detail)}
   on:click:overflow={onOverflowClick}
   on:overflow:change={({ detail }) => onOverflowChange(detail)}
 >
-  {#each labels as label}
+  {#each labels as label (label)}
     <Tag filter={dismissible}>{label}</Tag>
   {/each}
 </TagSet>

--- a/tests/TagSet/TagSet.test.ts
+++ b/tests/TagSet/TagSet.test.ts
@@ -173,4 +173,66 @@ describe("TagSet", () => {
     const row = container.querySelector(".bx--tag-set__space");
     expect(row).toHaveStyle({ gap: "2rem" });
   });
+
+  it("moves focus to the next close button after keyboard dismiss", async () => {
+    const { container } = render(TagSetFixture, { dismissible: true });
+
+    const closeButtons = within(container).getAllByTitle("Clear filter");
+    closeButtons[1].focus();
+    expect(closeButtons[1]).toHaveFocus();
+
+    await user.keyboard("{Enter}");
+    await tick();
+
+    const remaining = within(container).getAllByTitle("Clear filter");
+    expect(remaining).toHaveLength(3);
+    // Former index 2 ("Tag 3") is now at index 1.
+    expect(remaining[1]).toHaveFocus();
+    expect(remaining[1].closest(".bx--tag")?.textContent?.trim()).toBe("Tag 3");
+  });
+
+  it("moves focus to the previous close button when dismissing the last tag", async () => {
+    const { container } = render(TagSetFixture, { dismissible: true });
+
+    const closeButtons = within(container).getAllByTitle("Clear filter");
+    closeButtons[3].focus();
+    await user.keyboard("{Enter}");
+    await tick();
+
+    const remaining = within(container).getAllByTitle("Clear filter");
+    expect(remaining).toHaveLength(3);
+    expect(remaining[2]).toHaveFocus();
+    expect(remaining[2].closest(".bx--tag")?.textContent?.trim()).toBe("Tag 3");
+  });
+
+  it("announces the removed filter in a polite live region", async () => {
+    const { container } = render(TagSetFixture, { dismissible: true });
+
+    const liveRegion = container.querySelector("[aria-live='polite']");
+    expect.assert(liveRegion instanceof HTMLElement);
+    expect(liveRegion).toHaveClass("bx--visually-hidden");
+    expect(liveRegion).toHaveTextContent("");
+
+    const closeButtons = within(container).getAllByTitle("Clear filter");
+    closeButtons[0].focus();
+    await user.keyboard("{Enter}");
+    await tick();
+
+    expect(liveRegion).toHaveTextContent("Filter Tag 1 removed");
+  });
+
+  it("does not move focus when manageFocusOnClose is false", async () => {
+    const { container } = render(TagSetFixture, {
+      dismissible: true,
+      manageFocusOnClose: false,
+    });
+
+    const closeButtons = within(container).getAllByTitle("Clear filter");
+    closeButtons[1].focus();
+    await user.keyboard("{Enter}");
+    await tick();
+
+    expect(within(container).getAllByTitle("Clear filter")).toHaveLength(3);
+    expect(document.activeElement).not.toHaveAttribute("title", "Clear filter");
+  });
 });


### PR DESCRIPTION
After a TagSet dismiss from the close control, focus moves to the next
(or previous / +N) close button and a polite live region announces the
removal.