### PR TITLE
feat(form): add disabled on FormGroup

### DIFF
--- a/docs/src/pages/components/Form.svx
+++ b/docs/src/pages/components/Form.svx
@@ -64,6 +64,26 @@ shows a form with checkboxes, radio buttons, and a select menu.
   <Button type="submit">Submit</Button>
 </Form>
 
+## Disabled
+
+Set `disabled` on FormGroup to disable the fieldset and nested native form
+controls. Labels are visually muted via Carbon's `fieldset[disabled]` styles.
+Div-based controls such as Dropdown, ComboBox, and MultiSelect are not fully
+styled by the native attribute alone—pass `disabled` on those components until
+form-level context propagation lands.
+
+<Form>
+  <FormGroup legendText="Account details" disabled>
+    <Checkbox id="checkbox-disabled-0" labelText="Email notifications" checked />
+    <Checkbox id="checkbox-disabled-1" labelText="SMS notifications" />
+    <Select id="select-disabled" labelText="Preferred language">
+      <SelectItem value="en" text="English" />
+      <SelectItem value="es" text="Spanish" />
+    </Select>
+  </FormGroup>
+  <Button type="submit">Submit</Button>
+</Form>
+
 ## Prevent default behavior
 
 Handle form submission by preventing the default browser behavior. Use

--- a/src/FormGroup/FormGroup.svelte
+++ b/src/FormGroup/FormGroup.svelte
@@ -1,9 +1,21 @@
 <script>
+  /**
+   * @restProps {fieldset}
+   * @slot {{}}
+   */
+
   /** Set to `true` for to remove the bottom margin */
   export let noMargin = false;
 
   /** Set to `true` to indicate an invalid state */
   export let invalid = false;
+
+  /**
+   * Set to `true` to disable the fieldset and nested native form controls.
+   * Div-based controls such as Dropdown may still need an explicit
+   * `disabled` prop for full visual disable.
+   */
+  export let disabled = false;
 
   /** Set to `true` to render a form requirement */
   export let message = false;
@@ -21,6 +33,7 @@
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
 <fieldset
+  {disabled}
   data-invalid={invalid || undefined}
   class:bx--fieldset={true}
   class:bx--fieldset--no-margin={noMargin}

--- a/tests/FormGroup/FormGroup.test.svelte
+++ b/tests/FormGroup/FormGroup.test.svelte
@@ -4,16 +4,19 @@
 
   export let noMargin: ComponentProps<FormGroup>["noMargin"] = false;
   export let invalid: ComponentProps<FormGroup>["invalid"] = false;
+  export let disabled: ComponentProps<FormGroup>["disabled"] = false;
   export let message: ComponentProps<FormGroup>["message"] = false;
   export let messageText: ComponentProps<FormGroup>["messageText"] = "";
   export let legendText: ComponentProps<FormGroup>["legendText"] = "";
   export let legendId: ComponentProps<FormGroup>["legendId"] = "";
   export let slotContent = "";
+  export let withNativeInput = false;
 </script>
 
 <FormGroup
   {noMargin}
   {invalid}
+  {disabled}
   {message}
   {messageText}
   {legendText}
@@ -26,6 +29,9 @@
 >
   {#if slotContent}
     {slotContent}
+  {/if}
+  {#if withNativeInput}
+    <input type="text" aria-label="Nested input">
   {/if}
   <slot />
 </FormGroup>

--- a/tests/FormGroup/FormGroup.test.ts
+++ b/tests/FormGroup/FormGroup.test.ts
@@ -76,6 +76,37 @@ describe("FormGroup", () => {
     expect(fieldset).toHaveAttribute("data-invalid", "true");
   });
 
+  it("should set disabled on the fieldset", () => {
+    render(FormGroupTest, {
+      props: {
+        disabled: true,
+        withNativeInput: true,
+      },
+    });
+
+    const fieldset = screen.getByRole("group");
+    expect(fieldset).toBeDisabled();
+
+    // Native `<fieldset disabled>` propagates to nested inputs; the input
+    // should not carry its own `disabled` attribute.
+    const input = screen.getByRole("textbox", { name: "Nested input" });
+    expect(input).toBeDisabled();
+    expect(input).not.toHaveAttribute("disabled");
+  });
+
+  it("should not disable the fieldset by default", () => {
+    render(FormGroupTest, {
+      props: {
+        withNativeInput: true,
+      },
+    });
+
+    expect(screen.getByRole("group")).not.toBeDisabled();
+    expect(
+      screen.getByRole("textbox", { name: "Nested input" }),
+    ).not.toBeDisabled();
+  });
+
   it("should not have data-invalid when invalid is false", () => {
     render(FormGroupTest, {
       props: {


### PR DESCRIPTION
FormGroup disabled sets native fieldset disabled (stage 1). List-box
controls still need an explicit disabled until stage 2 context.

## Preview

![FormGroup disabled example](https://gist.githubusercontent.com/metonym/78cb26d5e9cfdcfa605090b00d62a0ae/raw/337592fd6d336e0b4e76d176f28d55000fbbf554/form-group-disabled.png)

Verified locally against the docs "Disabled" example on the Form page: the fieldset, legend, checkboxes, and native `<select>` all render in the disabled state.
