### PR TITLE
feat(user-avatar): fall back when image fails to load

### DIFF
--- a/docs/src/pages/components/UserAvatar.svx
+++ b/docs/src/pages/components/UserAvatar.svx
@@ -42,6 +42,8 @@ Set `icon` to render a custom icon instead of the default user icon.
 
 Set `image` to render a photo. Provide `imageDescription` for the alternative text. The image fills the circle (`object-fit: cover`) and takes priority over the icon and initials.
 
+If the image fails to load, the avatar falls back to the icon or initials and dispatches `image:error`.
+
 <UserAvatar
   size="xl"
   image="https://i.pravatar.cc/300?img=12"

--- a/src/UserAvatar/UserAvatar.svelte
+++ b/src/UserAvatar/UserAvatar.svelte
@@ -3,6 +3,7 @@
 
   /**
    * Custom avatar content via the default slot overrides the computed image, icon, and initials.
+   * @event {null} image:error - Dispatched when the `image` URL fails to load. The avatar then falls back to the icon or initials.
    * @restProps {span | button | a}
    */
 
@@ -35,6 +36,8 @@
   /**
    * Specify an image source to render a photo.
    * Takes priority over the icon and initials.
+   * If the image fails to load, the avatar falls back to the icon or initials
+   * and dispatches `image:error`.
    * @type {string}
    */
   export let image = undefined;
@@ -109,11 +112,13 @@
    */
   export let ref = null;
 
-  import { getContext, onMount } from "svelte";
+  import { createEventDispatcher, getContext, onMount } from "svelte";
   import { get, readable } from "svelte/store";
   import User from "../icons/User.svelte";
   import TooltipDefinition from "../TooltipDefinition/TooltipDefinition.svelte";
   import { getAvatarBackgroundColor } from "../utils/avatarColor.js";
+
+  const dispatch = createEventDispatcher();
 
   // When rendered inside a `UserAvatarGroup`, register with the group so it can
   // count avatars and hide those beyond its `max`. The group context is absent
@@ -233,6 +238,16 @@
   ]
     .filter(Boolean)
     .join(" ");
+
+  // Fall back to icon/initials when the photo URL fails. Comparing against the
+  // failed URL means a new `image` value automatically retries without a
+  // reactive reset that would fight the error handler.
+  let failedImage = undefined;
+
+  function handleImageError() {
+    failedImage = image;
+    dispatch("image:error");
+  }
 </script>
 
 {#if useTooltipWrapper}
@@ -260,8 +275,13 @@
     >
       {#if $$slots.default}
         <slot />
-      {:else if image}
-        <img {...imageAttributes} src={image} alt={imageDescription}>
+      {:else if image && image !== failedImage}
+        <img
+          {...imageAttributes}
+          src={image}
+          alt={imageDescription}
+          on:error={handleImageError}
+        >
       {:else if icon}
         <svelte:component this={icon} size={glyphSize[resolvedSize]} />
       {:else if avatarInitials}
@@ -291,8 +311,13 @@
   >
     {#if $$slots.default}
       <slot />
-    {:else if image}
-      <img {...imageAttributes} src={image} alt={imageDescription}>
+    {:else if image && image !== failedImage}
+      <img
+        {...imageAttributes}
+        src={image}
+        alt={imageDescription}
+        on:error={handleImageError}
+      >
     {:else if icon}
       <svelte:component this={icon} size={glyphSize[resolvedSize]} />
     {:else if avatarInitials}

--- a/tests/UserAvatar/UserAvatar.test.ts
+++ b/tests/UserAvatar/UserAvatar.test.ts
@@ -1,9 +1,10 @@
-import { render, screen } from "@testing-library/svelte";
+import { render, screen, waitFor } from "@testing-library/svelte";
 import type UserAvatarComponent from "carbon-components-svelte/UserAvatar/UserAvatar.svelte";
 import type { ComponentProps } from "svelte";
 import { getAvatarBackgroundColor } from "../../src/utils/avatarColor.js";
 import { user } from "../utils/user";
 import UserAvatar from "./UserAvatar.test.svelte";
+import UserAvatarImageError from "./UserAvatarImageError.test.svelte";
 
 describe("UserAvatar", () => {
   afterEach(() => {
@@ -69,6 +70,44 @@ describe("UserAvatar", () => {
     expect(img).toHaveAttribute("referrerpolicy", "no-referrer");
     expect(img).not.toHaveAttribute("data-testid");
     expect(img).not.toHaveAttribute("data-avatar-host");
+  });
+
+  it("falls back to initials when the image fails to load and dispatches image:error", async () => {
+    const onImageError = vi.fn();
+    render(UserAvatarImageError, { props: { onImageError } });
+
+    const avatar = screen.getByTestId("image-error");
+    const img = avatar.querySelector("img");
+    assert(img);
+
+    img.dispatchEvent(new Event("error"));
+
+    expect(onImageError).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(avatar.querySelector("img")).toBeNull();
+      expect(avatar).toHaveTextContent("JD");
+    });
+  });
+
+  it("retries the image when the src changes after a failed load", async () => {
+    const { rerender } = render(UserAvatarImageError, {
+      props: { image: "https://example.com/broken.jpg" },
+    });
+
+    const avatar = screen.getByTestId("image-error");
+    const img = avatar.querySelector("img");
+    assert(img);
+    img.dispatchEvent(new Event("error"));
+    await waitFor(() => {
+      expect(avatar).toHaveTextContent("JD");
+    });
+
+    await rerender({ image: "https://example.com/photo.jpg" });
+
+    const nextImg = avatar.querySelector("img");
+    assert(nextImg);
+    expect(nextImg).toHaveAttribute("src", "https://example.com/photo.jpg");
+    expect(avatar).not.toHaveTextContent("JD");
   });
 
   it("renders a custom icon, taking priority over the name", () => {

--- a/tests/UserAvatar/UserAvatarImageError.test.svelte
+++ b/tests/UserAvatar/UserAvatarImageError.test.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  import UserAvatar from "carbon-components-svelte/UserAvatar/UserAvatar.svelte";
+
+  export let image = "https://example.com/broken.jpg";
+  export let name = "Jane Doe";
+  export let onImageError = () => {};
+</script>
+
+<UserAvatar
+  data-testid="image-error"
+  {image}
+  {name}
+  imageDescription="User photo"
+  on:image:error={onImageError}
+/>


### PR DESCRIPTION
Broken photos fall back to initials/icon and dispatch image:error; a new
image URL retries automatically.