### PR TITLE
feat(user-avatar): add imageAttributes passthrough

### DIFF
--- a/docs/src/pages/components/UserAvatar.svx
+++ b/docs/src/pages/components/UserAvatar.svx
@@ -48,6 +48,17 @@ Set `image` to render a photo. Provide `imageDescription` for the alternative te
   imageDescription="Richard Hendricks"
 />
 
+### Image attributes
+
+Pass HTML attributes to the image with `imageAttributes`. Use this for values such as `loading`, `srcset`, or `referrerPolicy`. Rest props stay on the host element; `image` and `imageDescription` still set `src` and `alt`.
+
+<UserAvatar
+  size="xl"
+  image="https://i.pravatar.cc/300?img=12"
+  imageDescription="Richard Hendricks"
+  imageAttributes={{ loading: "lazy" }}
+/>
+
 ### Sizes
 
 Set `size` to one of `"sm"`, `"md"` (default), `"lg"`, or `"xl"`. The size applies to any content; the image fills the frame at every size.

--- a/src/UserAvatar/UserAvatar.svelte
+++ b/src/UserAvatar/UserAvatar.svelte
@@ -46,6 +46,14 @@
   export let imageDescription = undefined;
 
   /**
+   * Pass additional attributes through to the image element
+   * (for example `loading`, `srcset`, or `referrerPolicy`).
+   * Does not replace `image` or `imageDescription`. Rest props stay on the host.
+   * @type {Record<string, string>}
+   */
+  export let imageAttributes = undefined;
+
+  /**
    * Specify the icon to render. Falls back to a default user icon.
    * @type {Icon}
    */
@@ -225,7 +233,7 @@
       {#if $$slots.default}
         <slot />
       {:else if image}
-        <img src={image} alt={imageDescription}>
+        <img {...imageAttributes} src={image} alt={imageDescription}>
       {:else if icon}
         <svelte:component this={icon} size={glyphSize[resolvedSize]} />
       {:else if avatarInitials}
@@ -250,7 +258,7 @@
     {#if $$slots.default}
       <slot />
     {:else if image}
-      <img src={image} alt={imageDescription}>
+      <img {...imageAttributes} src={image} alt={imageDescription}>
     {:else if icon}
       <svelte:component this={icon} size={glyphSize[resolvedSize]} />
     {:else if avatarInitials}

--- a/tests/UserAvatar/UserAvatar.test.svelte
+++ b/tests/UserAvatar/UserAvatar.test.svelte
@@ -18,6 +18,19 @@
   imageDescription="A user photo"
 />
 
+<UserAvatar
+  data-testid="image-attributes"
+  data-avatar-host="true"
+  name="Should Not Show"
+  image="https://example.com/photo.jpg"
+  imageDescription="A user photo"
+  imageAttributes={{
+    loading: "lazy",
+    srcset: "https://example.com/photo.jpg 1x",
+    referrerPolicy: "no-referrer",
+  }}
+/>
+
 <UserAvatar data-testid="icon" name="Should Not Show" icon={Add} />
 
 <UserAvatar data-testid="size-lg" size="lg" name="John Doe" />

--- a/tests/UserAvatar/UserAvatar.test.ts
+++ b/tests/UserAvatar/UserAvatar.test.ts
@@ -51,6 +51,26 @@ describe("UserAvatar", () => {
     expect(avatar).not.toHaveTextContent("SS");
   });
 
+  it("spreads imageAttributes onto the img and keeps rest props on the host", () => {
+    render(UserAvatar);
+
+    const avatar = screen.getByTestId("image-attributes");
+    expect(avatar).toHaveAttribute("data-avatar-host", "true");
+    expect(avatar).not.toHaveAttribute("loading");
+    expect(avatar).not.toHaveAttribute("srcset");
+    expect(avatar).not.toHaveAttribute("referrerpolicy");
+
+    const img = avatar.querySelector("img");
+    assert(img);
+    expect(img).toHaveAttribute("src", "https://example.com/photo.jpg");
+    expect(img).toHaveAttribute("alt", "A user photo");
+    expect(img).toHaveAttribute("loading", "lazy");
+    expect(img).toHaveAttribute("srcset", "https://example.com/photo.jpg 1x");
+    expect(img).toHaveAttribute("referrerpolicy", "no-referrer");
+    expect(img).not.toHaveAttribute("data-testid");
+    expect(img).not.toHaveAttribute("data-avatar-host");
+  });
+
   it("renders a custom icon, taking priority over the name", () => {
     render(UserAvatar);
 


### PR DESCRIPTION
imageAttributes spreads onto the UserAvatar img while rest props stay on
the host element.