### PR TITLE
feat(tag-set): disclose overflow tags in a popover

### DIFF
--- a/css/_tag-set.scss
+++ b/css/_tag-set.scss
@@ -2,7 +2,8 @@
 @import "carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/import-once/import-once";
 
 /// TagSet: a row of tags that collapses into a "+N" overflow indicator with
-/// a hover tooltip once they no longer fit the available width.
+/// a hover tooltip and a clickable disclosure popover once they no longer
+/// fit the available width.
 /// @access private
 /// @group components
 @mixin tag-set {
@@ -57,6 +58,25 @@
   .#{$prefix}--tag-set-overflow__popover-trigger {
     min-width: auto;
     padding: 0 $carbon--spacing-03;
+  }
+
+  .#{$prefix}--tag-set-overflow__tag-list {
+    display: flex;
+    flex-direction: column;
+    gap: $carbon--spacing-03;
+    margin: 0;
+    padding: $carbon--spacing-05;
+    list-style: none;
+    outline: none;
+  }
+
+  .#{$prefix}--tag-set-overflow__tagset-popover {
+    min-width: initial;
+    text-align: start;
+  }
+
+  .#{$prefix}--tag-set-overflow__tag-item .#{$prefix}--tag {
+    margin: 0;
   }
 }
 

--- a/docs/src/pages/components/TagSet.svx
+++ b/docs/src/pages/components/TagSet.svx
@@ -1,6 +1,6 @@
 ---
 components: ["TagSet"]
-description: Displays a row of tags that collapses to fit the available width, moving hidden tags into an overflow indicator with a tooltip.
+description: Displays a row of tags that collapses to fit the available width, with a tooltip preview and a clickable overflow popover for the hidden tags.
 ---
 
 <script>
@@ -39,7 +39,7 @@ Set `align` to change how the visible tags are positioned within the row when th
 
 ## Overflow
 
-Once the row runs out of space, the remaining tags collapse into a "+N" indicator. Hovering it shows the hidden labels in a tooltip.
+Once the row runs out of space, the remaining tags collapse into a "+N" indicator. Hovering it shows the hidden labels in a tooltip. Clicking it opens a popover that lists the overflow tags.
 
 There is no fixed number of tags that triggers this. `TagSet` measures the actual pixel width available and fits as many tags as space allows, so the count that overflows depends on the container's width and each tag's label length, not a set threshold.
 
@@ -106,6 +106,12 @@ Set `overflowDirection` to show the tooltip above the indicator instead of below
 Set `filter` on a `Tag` to render it as closable. `TagSet` dispatches `close:tag` with `{ tag, index }` instead of taking a per-tag handler: remove the tag from your own state in response.
 
 <FileSource src="/framed/TagSet/TagSetDismissible" />
+
+## Overflow disclosure
+
+In a constrained filter bar, click "+N" to open the overflow popover and dismiss hidden filter tags without resizing the row. Hover still shows the label preview tooltip.
+
+<FileSource src="/framed/TagSet/TagSetOverflowDisclosure" />
 
 ## Custom overflow tooltip
 

--- a/docs/src/pages/framed/TagSet/TagSetOverflowDisclosure.svelte
+++ b/docs/src/pages/framed/TagSet/TagSetOverflowDisclosure.svelte
@@ -1,0 +1,26 @@
+<script>
+  import { Tag, TagSet } from "carbon-components-svelte";
+
+  let tags = [
+    { label: "Angular", type: "red" },
+    { label: "React", type: "blue" },
+    { label: "Svelte", type: "purple" },
+    { label: "Vue", type: "green" },
+    { label: "Ember", type: "magenta" },
+    { label: "Preact", type: "cyan" },
+    { label: "Solid", type: "teal" },
+    { label: "Qwik", type: "cool-gray" },
+  ];
+
+  function handleTagClose({ detail }) {
+    tags = tags.filter((_, index) => index !== detail.index);
+  }
+</script>
+
+<div style="max-width: 16rem;">
+  <TagSet on:close:tag={handleTagClose}>
+    {#each tags as tag}
+      <Tag type={tag.type} filter>{tag.label}</Tag>
+    {/each}
+  </TagSet>
+</div>

--- a/src/TagSet/TagSet.svelte
+++ b/src/TagSet/TagSet.svelte
@@ -12,11 +12,13 @@
 
   /**
    * Render a row of `Tag` children. `TagSet` measures the available width and
-   * collapses whatever no longer fits into a "+N" overflow indicator, with a
-   * hover tooltip listing the hidden labels by default. Override the tooltip
-   * content with the `overflowTooltip` slot, for example to add a link.
+   * collapses whatever no longer fits into a "+N" overflow indicator. Hover
+   * shows a tooltip listing the hidden labels by default; click opens a
+   * popover of the overflow tags (including dismissible close controls).
+   * Override the tooltip content with the `overflowTooltip` slot, for example
+   * to add a link.
    *
-   * @event {{ tag: TagSetItem; index: number }} close:tag - User clicks the close icon on a dismissible (`filter`) tag.
+   * @event {{ tag: TagSetItem; index: number }} close:tag - User clicks the close icon on a dismissible (`filter`) tag, including tags listed in the overflow popover.
    * @event {{ count: number }} click:overflow - User clicks the "+N" indicator.
    * @event {{ count: number }} overflow:change - Dispatched when the number of overflowing tags changes, from a resize, a slotted-children change, or a `maxVisible` change.
    * @slot {{ tags: TagSetItem[]; count: number }} overflowTooltip - Override the "+N" indicator's tooltip content. Defaults to a comma-separated list of the hidden labels.
@@ -202,6 +204,11 @@
   function handleTriggerClick() {
     dispatch("click:overflow", { count: overflowCount });
   }
+
+  /** @param {CustomEvent<TagSetItem>} event */
+  function handleOverflowTagClose(event) {
+    handleTagClose(event.detail);
+  }
 </script>
 
 <div bind:this={wrapperRef} class:bx--tag-set={true} {...$$restProps}>
@@ -226,6 +233,7 @@
       {overflowDirection}
       {size}
       on:trigger={handleTriggerClick}
+      on:close:tag={handleOverflowTagClose}
     >
       <svelte:fragment slot="tooltip" let:tags let:count>
         <slot name="overflowTooltip" {tags} {count}>

--- a/src/TagSet/TagSetOverflow.svelte
+++ b/src/TagSet/TagSetOverflow.svelte
@@ -3,12 +3,15 @@
    * Internal: the "+N" overflow indicator. Not exported from the package;
    * only `TagSet` ships. Hovering shows a tooltip (a comma-separated list of
    * the hidden labels by default, or custom content via the forwarded
-   * `overflowTooltip` slot); clicking dispatches `trigger`.
+   * `overflowTooltip` slot). Clicking opens a popover listing the overflow
+   * tags and dispatches `trigger`.
    *
    * Always mounted (even when `count` is 0) so it stays measurable; visually
    * and functionally inert until there is something to show.
    *
    * @event {null} trigger - The indicator was clicked.
+   * @event {import("./TagSet.svelte").TagSetItem} close:tag - Close on a
+   * dismissible tag inside the overflow popover.
    * @slot {{ tags: import("./TagSet.svelte").TagSetItem[]; count: number }} tooltip - Override the tooltip content.
    */
 
@@ -35,35 +38,208 @@
   /** @type {"sm" | "default" | "lg" | undefined} */
   export let size = undefined;
 
-  import { createEventDispatcher, setContext } from "svelte";
+  import { createEventDispatcher, setContext, tick } from "svelte";
+  import Popover from "../Popover/Popover.svelte";
+  import FloatingPortal from "../Portal/FloatingPortal.svelte";
+  import Tag from "../Tag/Tag.svelte";
   import TooltipDefinition from "../TooltipDefinition/TooltipDefinition.svelte";
+  import { dismiss } from "../utils/dismiss.js";
+  import { isOutsideClick } from "../utils/isOutsideClick.js";
+  import { trapFocus } from "../utils/trapFocus.js";
 
   // The indicator is presentational, not a registered group item — shadow
-  // the context so it can't be mistaken for one.
+  // the context so it (and tags rendered in the disclosure popover) can't be
+  // mistaken for registered children.
   setContext("carbon:TagSet", undefined);
 
   const dispatch = createEventDispatcher();
+  const contentId = `ccs-${Math.random().toString(36)}`;
+
+  // Space (px) reserved for the caret between the anchor and the content.
+  const PORTAL_GAP = 10;
+  const PORTAL_NEUTRALIZE_STYLE = "inset: auto; transform: none;";
+
+  /** @type {boolean} */
+  let open = false;
+  /** @type {boolean} */
+  let tooltipOpen = false;
+  /** @type {null | HTMLElement} */
+  let buttonRef = null;
+  /** @type {null | HTMLElement} */
+  let portalRef = null;
+  /** @type {null | HTMLElement} */
+  let rootRef = null;
+  /** @type {null | HTMLElement} */
+  let listRef = null;
+
+  let listenersEnabled = false;
+  /** @type {number | undefined} */
+  let enableFrame;
+
+  $: if (open && count === 0) {
+    open = false;
+  }
+
+  $: if (open) {
+    tooltipOpen = false;
+  }
+
+  /**
+   * @param {"top" | "bottom"} dir
+   * @param {"start" | "center" | "end"} intrinsic
+   */
+  function toPopoverAlign(dir, intrinsic) {
+    if (intrinsic === "center") return dir;
+    return `${dir}-${intrinsic === "start" ? "left" : "right"}`;
+  }
+
+  function close() {
+    open = false;
+  }
+
+  function handleTriggerClick() {
+    if (count === 0) return;
+    tooltipOpen = false;
+    open = !open;
+    dispatch("trigger");
+    if (open) {
+      tick().then(() => {
+        const focusable = listRef?.querySelector(
+          "button:not([disabled]), [href], [tabindex]:not([tabindex='-1'])",
+        );
+        if (focusable instanceof HTMLElement) {
+          focusable.focus();
+        } else {
+          listRef?.focus();
+        }
+      });
+    }
+  }
+
+  /**
+   * @param {import("./TagSet.svelte").TagSetItem} tag
+   */
+  function handlePopoverTagClose(tag) {
+    dispatch("close:tag", tag);
+  }
+
+  /** @param {KeyboardEvent} event */
+  function onKeydown(event) {
+    if (!open) return;
+    if (event.key === "Escape") {
+      event.stopPropagation();
+      close();
+      buttonRef?.focus();
+      return;
+    }
+    if (event.key === "Tab" && listRef) {
+      trapFocus({ container: listRef, event });
+    }
+  }
+
+  /** @param {Event} event */
+  function handleOutsideClick(event) {
+    if (open && isOutsideClick(event, [rootRef, portalRef])) {
+      close();
+    }
+  }
+
+  $: if (typeof requestAnimationFrame !== "undefined") {
+    if (open) {
+      cancelAnimationFrame(enableFrame);
+      enableFrame = requestAnimationFrame(() => {
+        if (open) listenersEnabled = true;
+      });
+    } else {
+      cancelAnimationFrame(enableFrame);
+      listenersEnabled = false;
+    }
+  }
 </script>
 
-<TooltipDefinition
-  align={overflowAlign}
-  direction={overflowDirection}
-  class="bx--tag-set-overflow{count === 0
-    ? ' bx--tag-set-overflow--empty'
-    : ''}"
-  on:click={() => dispatch("trigger")}
+<!-- svelte-ignore a11y-no-static-element-interactions -->
+<span
+  bind:this={rootRef}
+  class:bx--tag-set-overflow={true}
+  class:bx--tag-set-overflow--empty={count === 0}
+  use:dismiss={{
+    enabled: listenersEnabled,
+    type: "click",
+    handler: handleOutsideClick,
+  }}
+  on:keydown={onKeydown}
 >
-  <svelte:fragment slot="tooltip">
-    <slot name="tooltip" {tags} {count} />
-  </svelte:fragment>
-  <span
-    bind:this={triggerRef}
-    class:bx--tag={true}
-    class:bx--tag--interactive={true}
-    class:bx--tag-set-overflow__popover-trigger={true}
-    class:bx--tag--sm={size === "sm"}
-    class:bx--tag--lg={size === "lg"}
+  <TooltipDefinition
+    bind:open={tooltipOpen}
+    bind:ref={buttonRef}
+    align={overflowAlign}
+    direction={overflowDirection}
+    aria-expanded={open}
+    aria-controls={open ? contentId : undefined}
+    on:click={handleTriggerClick}
   >
-    +{count}
-  </span>
-</TooltipDefinition>
+    <svelte:fragment slot="tooltip">
+      <slot name="tooltip" {tags} {count} />
+    </svelte:fragment>
+    <span
+      bind:this={triggerRef}
+      class:bx--tag={true}
+      class:bx--tag--interactive={true}
+      class:bx--tag-set-overflow__popover-trigger={true}
+      class:bx--tag--sm={size === "sm"}
+      class:bx--tag--lg={size === "lg"}
+    >
+      +{count}
+    </span>
+  </TooltipDefinition>
+
+  {#if open}
+    <FloatingPortal
+      anchor={buttonRef}
+      direction={overflowDirection}
+      {open}
+      intrinsicWidth={true}
+      intrinsicAlign={overflowAlign}
+      gapTop={PORTAL_GAP}
+      gapBottom={PORTAL_GAP}
+      bind:ref={portalRef}
+      let:direction={actualDirection}
+    >
+      <Popover
+        open
+        relative
+        caret
+        id={contentId}
+        align={toPopoverAlign(
+          actualDirection ?? overflowDirection,
+          overflowAlign,
+        )}
+        style={PORTAL_NEUTRALIZE_STYLE}
+      >
+        <!-- svelte-ignore a11y-no-noninteractive-tabindex -->
+        <!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
+        <ul
+          bind:this={listRef}
+          class:bx--tag-set-overflow__tagset-popover={true}
+          class:bx--tag-set-overflow__tag-list={true}
+          tabindex="-1"
+          on:keydown={onKeydown}
+        >
+          {#each tags as tag (tag.id)}
+            <li class:bx--tag-set-overflow__tag-item={true}>
+              <Tag
+                type={/** @type {any} */ (tag.type)}
+                size={/** @type {any} */ (tag.size)}
+                filter={tag.filter}
+                disabled={tag.disabled}
+                on:close={() => handlePopoverTagClose(tag)}
+              >
+                {tag.label}
+              </Tag>
+            </li>
+          {/each}
+        </ul>
+      </Popover>
+    </FloatingPortal>
+  {/if}
+</span>

--- a/tests/TagSet/TagSet.test.ts
+++ b/tests/TagSet/TagSet.test.ts
@@ -94,6 +94,60 @@ describe("TagSet", () => {
     ).toHaveLength(0);
   });
 
+  it("opens a disclosure popover listing overflow tags when +N is clicked", async () => {
+    const { container } = render(TagSetFixture);
+
+    stubMeasurements(container, 110, 50);
+    const trigger = await screen.findByText("+3");
+    await user.click(trigger);
+
+    await waitFor(() => {
+      expect(
+        document.querySelector(".bx--tag-set-overflow__tag-list"),
+      ).not.toBeNull();
+    });
+
+    const list = document.querySelector(".bx--tag-set-overflow__tag-list");
+    expect.assert(list instanceof HTMLElement);
+    expect(
+      within(list)
+        .getAllByText(/^Tag \d$/)
+        .map((el) => el.textContent?.trim()),
+    ).toEqual(["Tag 2", "Tag 3", "Tag 4"]);
+    // Hover tooltip preview is separate from the disclosure list.
+    expect(
+      container.querySelectorAll('[role="tooltip"] .bx--tag'),
+    ).toHaveLength(0);
+  });
+
+  it("dispatches close:tag from a dismissible tag inside the overflow popover", async () => {
+    const onTagClose = vi.fn();
+    const { container } = render(TagSetFixture, {
+      dismissible: true,
+      onTagClose,
+    });
+
+    stubMeasurements(container, 110, 50);
+    const trigger = await screen.findByText("+3");
+    await user.click(trigger);
+
+    const list = await waitFor(() => {
+      const node = document.querySelector(".bx--tag-set-overflow__tag-list");
+      expect.assert(node instanceof HTMLElement);
+      return node;
+    });
+
+    const closeButtons = within(list).getAllByTitle("Clear filter");
+    await user.click(closeButtons[0]);
+
+    expect(onTagClose).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({
+        tag: expect.objectContaining({ label: "Tag 2" }),
+        index: 1,
+      }),
+    );
+  });
+
   it("dispatches close:tag with the tag and its index", async () => {
     const onTagClose = vi.fn();
     const { container } = render(TagSetFixture, {


### PR DESCRIPTION
Clicking TagSet +N opens a Popover of overflow tags (close still fires
close:tag). Hover tooltip and click:overflow are unchanged.