### PR TITLE
docs(code-snippet): add syntax highlighting composition example

### DIFF
--- a/docs/src/pages/components/CodeSnippet.svx
+++ b/docs/src/pages/components/CodeSnippet.svx
@@ -132,6 +132,12 @@ Set `wrapText` to `true` to wrap long lines in multi-line snippets.
 
 <FileSource src="/framed/CodeSnippet/CodeSnippetWrapText" />
 
+## Syntax highlighting
+
+CodeSnippet does not ship a syntax highlighter. Pass the plain source to `code` so copy uses unstyled text, and render highlighted HTML from Prism, Shiki, or another highlighter in the default slot with `{@html}`. Load language grammars and token theme CSS in your app.
+
+<FileSource src="/framed/CodeSnippet/CodeSnippetSyntaxHighlight" />
+
 ## Dynamic multi-line code
 
 Use `code` instead of the default slot for dynamically updated code.

--- a/docs/src/pages/framed/CodeSnippet/CodeSnippetSyntaxHighlight.svelte
+++ b/docs/src/pages/framed/CodeSnippet/CodeSnippetSyntaxHighlight.svelte
@@ -1,0 +1,21 @@
+<script>
+  import { CodeSnippet } from "carbon-components-svelte";
+  import Prism from "prismjs";
+  import "prismjs/components/prism-typescript";
+
+  const code = `export function add(a: number, b: number) {
+  return a + b;
+}
+
+export function subtract(a: number, b: number) {
+  return a - b;
+}`;
+
+  const highlighted = Prism.highlight(
+    code,
+    Prism.languages.typescript,
+    "typescript",
+  );
+</script>
+
+<CodeSnippet type="multi" {code}> {@html highlighted} </CodeSnippet>


### PR DESCRIPTION
Docs-only recipe: keep plain code for clipboard copy and put highlighted
HTML in the CodeSnippet slot—no highlighter dependency in the library.

---

![code-snippet with Prism TypeScript syntax highlighting example](https://gist.githubusercontent.com/metonym/1fd5d931d3174aa0922f2c2523c345ef/raw/63468f1e93c0baaf353af93f498393d9cb688de5/code-snippet-syntax-highlight.png)
