### PR TITLE
feat(user-avatar): add status badge

### DIFF
--- a/css/_user-avatar.scss
+++ b/css/_user-avatar.scss
@@ -121,6 +121,74 @@
   }
 
   //--------------------------------------------------------------------------
+  // Status / badge overlay (bottom-right presence indicator)
+  //--------------------------------------------------------------------------
+  .#{$prefix}--user-avatar__badge-wrapper {
+    position: relative;
+    display: inline-flex;
+    flex-shrink: 0;
+  }
+
+  .#{$prefix}--user-avatar__badge {
+    position: absolute;
+    inset-block-end: 0;
+    inset-inline-end: 0;
+    display: flex;
+    border-radius: 50%;
+    // Ring separates the badge from the avatar using the surrounding surface.
+    box-shadow: 0 0 0 $carbon--spacing-01
+      var(--cds-ui-background, #{$ui-background});
+    transform: translate(25%, 25%);
+    pointer-events: none;
+  }
+
+  .#{$prefix}--user-avatar__status {
+    display: block;
+    width: $carbon--spacing-03;
+    height: $carbon--spacing-03;
+    border-radius: 50%;
+  }
+
+  .#{$prefix}--user-avatar--lg + .#{$prefix}--user-avatar__badge
+    .#{$prefix}--user-avatar__status,
+  .#{$prefix}--user-avatar--xl + .#{$prefix}--user-avatar__badge
+    .#{$prefix}--user-avatar__status {
+    width: $carbon--spacing-04;
+    height: $carbon--spacing-04;
+  }
+
+  .#{$prefix}--user-avatar__status--online {
+    background-color: $support-success;
+  }
+
+  .#{$prefix}--user-avatar__status--away {
+    background-color: $support-warning;
+  }
+
+  .#{$prefix}--user-avatar__status--busy {
+    position: relative;
+    background-color: $support-error;
+
+    // Horizontal bar distinguishes busy from online when color alone is unreliable.
+    &::after {
+      content: "";
+      position: absolute;
+      inset-block-start: 50%;
+      inset-inline-start: 20%;
+      width: 60%;
+      height: 2px;
+      background-color: $text-on-color;
+      transform: translateY(-50%);
+    }
+  }
+
+  .#{$prefix}--user-avatar__status--offline {
+    box-sizing: border-box;
+    border: 2px solid $icon-disabled;
+    background-color: var(--cds-ui-background, #{$ui-background});
+  }
+
+  //--------------------------------------------------------------------------
   // Tooltip wrapper: strip the definition trigger's underline/padding so the
   // circle renders clean when `tooltipText` is set.
   //--------------------------------------------------------------------------

--- a/docs/src/pages/components/UserAvatar.svx
+++ b/docs/src/pages/components/UserAvatar.svx
@@ -5,6 +5,7 @@ description: User avatars display a photo, a custom icon, or initials derived fr
 
 <script>
   import { UserAvatar } from "carbon-components-svelte";
+  import CheckmarkFilled from "carbon-icons-svelte/lib/CheckmarkFilled.svelte";
   import UserAvatarFilledAlt from "carbon-icons-svelte/lib/UserAvatarFilledAlt.svelte";
 </script>
 
@@ -105,6 +106,23 @@ Do not set `interactive` when slotting the avatar into [ProfileMenu](/components
 Set `href` to render an anchor, for example a profile page link. `href` takes priority over `interactive`.
 
 <UserAvatar href="/profile" name="Richard Hendricks" backgroundColor="blue" />
+
+## Status
+
+Set `status` to show a presence indicator at the bottom-right of the avatar. Use `"online"`, `"away"`, `"busy"`, or `"offline"`.
+
+<UserAvatar name="Monica" status="online" />
+<UserAvatar name="Richard Hendricks" status="away" />
+<UserAvatar name="Dinesh Chugtai" status="busy" />
+<UserAvatar name="Bertram Gilfoyle" status="offline" />
+
+### Custom badge
+
+Use the `badge` slot to replace the status indicator with custom overlay content. The slot sits at the bottom-right with a ring in the surrounding background color.
+
+<UserAvatar name="Jared Dunn" status="online">
+  <CheckmarkFilled slot="badge" size={8} />
+</UserAvatar>
 
 ## Tooltip
 

--- a/src/UserAvatar/UserAvatar.svelte
+++ b/src/UserAvatar/UserAvatar.svelte
@@ -3,8 +3,10 @@
 
   /**
    * Custom avatar content via the default slot overrides the computed image, icon, and initials.
+   * Compose a presence indicator or other overlay via the `badge` slot.
    * @event {null} image:error - Dispatched when the `image` URL fails to load. The avatar then falls back to the icon or initials.
    * @restProps {span | button | a}
+   * @slot {{}} badge - Overlay content at the bottom-right of the avatar (for example a status dot or `BadgeIndicator`).
    */
 
   /**
@@ -61,6 +63,13 @@
    * @type {Icon}
    */
   export let icon = /** @type {Icon} */ (undefined);
+
+  /**
+   * Specify a presence status. Renders a status indicator as the default
+   * `badge` slot content. A custom `badge` slot overrides this.
+   * @type {"online" | "away" | "busy" | "offline"}
+   */
+  export let status = undefined;
 
   /**
    * Specify the tooltip text. When set, the avatar is wrapped in a tooltip.
@@ -248,6 +257,11 @@
     failedImage = image;
     dispatch("image:error");
   }
+
+  $: hasBadge = $$slots.badge || Boolean(status);
+  $: overflowAttrs = {
+    "data-overflow": groupOverflow ? "true" : undefined,
+  };
 </script>
 
 {#if useTooltipWrapper}
@@ -262,6 +276,79 @@
     data-overflow={groupOverflow ? "true" : undefined}
     data-avatar-group-overflow={$$restProps["data-avatar-group-overflow"]}
   >
+    {#if hasBadge}
+      <div class:bx--user-avatar__badge-wrapper={true}>
+        <span
+          bind:this={ref}
+          {...$$restProps}
+          class={avatarClass}
+          on:click
+          on:mouseover
+          on:mouseenter
+          on:mouseenter={claimTooltip}
+          on:mouseleave
+          on:mouseleave={scheduleRelease}
+        >
+          {#if $$slots.default}
+            <slot />
+          {:else if image}
+            <img src={image} alt={imageDescription}>
+          {:else if icon}
+            <svelte:component this={icon} size={glyphSize[resolvedSize]} />
+          {:else if avatarInitials}
+            <span class:bx--user-avatar__text={true}>{avatarInitials}</span>
+          {:else}
+            <User size={glyphSize[resolvedSize]} />
+          {/if}
+        </span>
+        <span class:bx--user-avatar__badge={true}>
+          <slot name="badge">
+            {#if status}
+              <span
+                class:bx--user-avatar__status={true}
+                class:bx--user-avatar__status--online={status === "online"}
+                class:bx--user-avatar__status--away={status === "away"}
+                class:bx--user-avatar__status--busy={status === "busy"}
+                class:bx--user-avatar__status--offline={status === "offline"}
+                aria-hidden="true"
+              ></span>
+            {/if}
+          </slot>
+        </span>
+      </div>
+    {:else}
+      <span
+        bind:this={ref}
+        {...$$restProps}
+        class={avatarClass}
+        on:click
+        on:mouseover
+        on:mouseenter
+        on:mouseenter={claimTooltip}
+        on:mouseleave
+        on:mouseleave={scheduleRelease}
+      >
+        {#if $$slots.default}
+          <slot />
+        {:else if image}
+          <img src={image} alt={imageDescription}>
+        {:else if icon}
+          <svelte:component this={icon} size={glyphSize[resolvedSize]} />
+        {:else if avatarInitials}
+          <span class:bx--user-avatar__text={true}>{avatarInitials}</span>
+        {:else}
+          <User size={glyphSize[resolvedSize]} />
+        {/if}
+      </span>
+    {/if}
+  </TooltipDefinition>
+{:else if hasBadge}
+  <!-- svelte-ignore a11y-no-static-element-interactions -->
+  <div
+    class:bx--user-avatar__badge-wrapper={true}
+    {...overflowAttrs}
+    data-avatar-group-overflow={$$restProps["data-avatar-group-overflow"]}
+  >
     <span
       bind:this={ref}
       {...$$restProps}
@@ -269,9 +356,7 @@
       on:click
       on:mouseover
       on:mouseenter
-      on:mouseenter={claimTooltip}
       on:mouseleave
-      on:mouseleave={scheduleRelease}
     >
       {#if $$slots.default}
         <slot />
@@ -290,7 +375,21 @@
         <User size={glyphSize[resolvedSize]} />
       {/if}
     </span>
-  </TooltipDefinition>
+    <span class:bx--user-avatar__badge={true}>
+      <slot name="badge">
+        {#if status}
+          <span
+            class:bx--user-avatar__status={true}
+            class:bx--user-avatar__status--online={status === "online"}
+            class:bx--user-avatar__status--away={status === "away"}
+            class:bx--user-avatar__status--busy={status === "busy"}
+            class:bx--user-avatar__status--offline={status === "offline"}
+            aria-hidden="true"
+          ></span>
+        {/if}
+      </slot>
+    </span>
+  </div>
 {:else}
   <!-- svelte-ignore a11y-no-static-element-interactions -->
   <!-- svelte-ignore a11y-missing-attribute -->

--- a/tests/UserAvatar/UserAvatar.test.svelte
+++ b/tests/UserAvatar/UserAvatar.test.svelte
@@ -86,3 +86,15 @@
   interactive
   name="John Doe"
 />
+
+<UserAvatar data-testid="status-online" name="Jane Roe" status="online" />
+
+<UserAvatar data-testid="status-away" name="Jane Roe" status="away" />
+
+<UserAvatar data-testid="status-busy" name="Jane Roe" status="busy" />
+
+<UserAvatar data-testid="status-offline" name="Jane Roe" status="offline" />
+
+<UserAvatar data-testid="badge-slot" name="Jane Roe" status="online">
+  <span slot="badge" data-testid="custom-badge">99</span>
+</UserAvatar>

--- a/tests/UserAvatar/UserAvatar.test.ts
+++ b/tests/UserAvatar/UserAvatar.test.ts
@@ -240,6 +240,31 @@ describe("UserAvatar", () => {
     expect(avatar).not.toHaveAttribute("type");
   });
 
+  it("renders a status badge for each presence status", () => {
+    render(UserAvatar);
+
+    for (const status of ["online", "away", "busy", "offline"] as const) {
+      const avatar = screen.getByTestId(`status-${status}`);
+      const badge = avatar.parentElement?.querySelector(
+        ".bx--user-avatar__badge",
+      );
+      assert(badge);
+      expect(
+        badge.querySelector(`.bx--user-avatar__status--${status}`),
+      ).toBeInTheDocument();
+    }
+  });
+
+  it("lets a custom badge slot override the status indicator", () => {
+    render(UserAvatar);
+
+    const avatar = screen.getByTestId("badge-slot");
+    const wrapper = avatar.parentElement;
+    assert(wrapper);
+    expect(wrapper.querySelector(".bx--user-avatar__status")).toBeNull();
+    expect(screen.getByTestId("custom-badge")).toHaveTextContent("99");
+  });
+
   describe("Generics", () => {
     it("should support custom Icon types with generics", () => {
       type CustomIcon = new (...args: unknown[]) => unknown;


### PR DESCRIPTION
status prop and badge slot add presence dots (online/away/busy/offline)
at the avatar’s bottom-right with a UI-background ring.