### PR TITLE
feat(user-avatar): support interactive button and href

### DIFF
--- a/css/_user-avatar.scss
+++ b/css/_user-avatar.scss
@@ -15,6 +15,22 @@
     color: $text-on-color;
   }
 
+  // Reset native button/link chrome so `interactive` / `href` keep the circle.
+  // Offset the focus ring outside the disc so `overflow: hidden` does not hide it.
+  .#{$prefix}--user-avatar--interactive {
+    padding: 0;
+    border: none;
+    cursor: pointer;
+    text-decoration: none;
+    font: inherit;
+    appearance: none;
+
+    &:focus {
+      outline: 2px solid $focus;
+      outline-offset: 2px;
+    }
+  }
+
   // Images fill the circle; the icon glyph keeps its intrinsic size.
   .#{$prefix}--user-avatar img {
     width: 100%;

--- a/docs/src/pages/components/UserAvatar.svx
+++ b/docs/src/pages/components/UserAvatar.svx
@@ -82,11 +82,25 @@ Set `backgroundColor` to `"auto"` to pick a color from `name` (or `initials`). T
 <UserAvatar backgroundColor="auto" name="Bertram Gilfoyle" />
 <UserAvatar backgroundColor="auto" name="Jared Dunn" />
 
+## Interactive
+
+Set `interactive` to render a `button` instead of a `span` when the avatar is a clickable control, such as a custom profile menu trigger. The button receives a focus ring. `name` is used as the accessible name when `aria-label` is not set.
+
+Do not set `interactive` when slotting the avatar into [ProfileMenu](/components/UIShell#profilemenu) — that component already wraps the avatar in a labelled trigger button.
+
+<UserAvatar interactive name="Richard Hendricks" backgroundColor="purple" />
+
+## Link
+
+Set `href` to render an anchor, for example a profile page link. `href` takes priority over `interactive`.
+
+<UserAvatar href="/profile" name="Richard Hendricks" backgroundColor="blue" />
+
 ## Tooltip
 
 Set `tooltipText` to show the display name on hover or focus. Use `align` and `direction` to position the tooltip. The tooltip closes on <DocKbd label="Escape" />.
 
-Setting `tooltipText` wraps the avatar in a focusable button. Do not set it when slotting the avatar into the `ProfileMenu` trigger, which is already a labelled button.
+Setting `tooltipText` wraps the avatar in a focusable button. Do not combine it with `interactive` or `href`, and do not set it when slotting the avatar into the `ProfileMenu` trigger.
 
 <UserAvatar name="Richard Hendricks" tooltipText="Richard Hendricks" />
 
@@ -104,6 +118,6 @@ The floating portal keeps the tooltip from being clipped by the modal's overflow
 
 ## Use within ProfileMenu
 
-Slot the avatar into [ProfileMenu](/components/UIShell#profilemenu) for the header trigger and the profile header. Use `size="md"` for the trigger and `size="lg"` for the header to match the menu frame.
+Slot the avatar into [ProfileMenu](/components/UIShell#profilemenu) for the header trigger and the profile header. Use `size="md"` for the trigger and `size="lg"` for the header to match the menu frame. Leave `interactive`, `href`, and `tooltipText` unset on the slotted avatar so the menu owns focus and labelling.
 
 <UserAvatar size="md" name="Richard Hendricks" />

--- a/src/UserAvatar/UserAvatar.svelte
+++ b/src/UserAvatar/UserAvatar.svelte
@@ -3,7 +3,7 @@
 
   /**
    * Custom avatar content via the default slot overrides the computed image, icon, and initials.
-   * @restProps {div}
+   * @restProps {span | button | a}
    */
 
   /**
@@ -53,6 +53,8 @@
 
   /**
    * Specify the tooltip text. When set, the avatar is wrapped in a tooltip.
+   * Do not combine with `interactive` or `href` — the tooltip trigger is already
+   * focusable, and nesting an interactive avatar inside it is invalid.
    * @type {string}
    */
   export let tooltipText = undefined;
@@ -76,6 +78,21 @@
    * @type {boolean}
    */
   export let portalTooltip = true;
+
+  /**
+   * Set to `true` to render a `button` element instead of a `span`.
+   * Use when the avatar is a clickable control (for example, a custom profile menu
+   * trigger). Prefer this over attaching `on:click` to a non-interactive `span`.
+   * Ignored when `href` is set.
+   */
+  export let interactive = false;
+
+  /**
+   * Set an `href` to render an anchor element instead of a `span`.
+   * Takes priority over `interactive`.
+   * @type {string}
+   */
+  export let href = undefined;
 
   /**
    * Obtain a reference to the avatar HTML element.
@@ -169,6 +186,16 @@
   // Fall back to the group's size, then to "md".
   $: resolvedSize = size ?? $groupSize ?? "md";
 
+  // `href` wins over `interactive`. When either is set, the avatar itself is the
+  // focus target — do not nest it inside TooltipDefinition's button.
+  $: isLink = typeof href === "string";
+  $: isButton = !isLink && interactive;
+  $: isInteractive = isLink || isButton;
+  $: avatarTag = isLink ? "a" : isButton ? "button" : "span";
+  // TooltipDefinition always renders a focusable button trigger. Use it only
+  // when the avatar stays a non-interactive span.
+  $: useTooltipWrapper = !!tooltipText && !isInteractive;
+
   const glyphSize = { sm: 16, md: 20, lg: 24, xl: 32 };
   const WHITESPACE = /\s+/;
 
@@ -193,13 +220,14 @@
     "bx--user-avatar",
     `bx--user-avatar--${resolvedSize}`,
     `bx--user-avatar--${resolvedBackgroundColor}`,
+    isInteractive && "bx--user-avatar--interactive",
     $$restProps.class,
   ]
     .filter(Boolean)
     .join(" ");
 </script>
 
-{#if tooltipText}
+{#if useTooltipWrapper}
   <TooltipDefinition
     class="bx--user-avatar-tooltip"
     {tooltipText}
@@ -237,10 +265,16 @@
   </TooltipDefinition>
 {:else}
   <!-- svelte-ignore a11y-no-static-element-interactions -->
-  <span
+  <!-- svelte-ignore a11y-missing-attribute -->
+  <svelte:element
+    this={avatarTag}
     bind:this={ref}
     {...$$restProps}
     class={avatarClass}
+    href={isLink ? href : undefined}
+    type={isButton ? "button" : undefined}
+    aria-label={$$restProps["aria-label"] ??
+      (isInteractive && name ? name : undefined)}
     data-overflow={groupOverflow ? "true" : undefined}
     on:click
     on:mouseover
@@ -258,5 +292,5 @@
     {:else}
       <User size={glyphSize[resolvedSize]} />
     {/if}
-  </span>
+  </svelte:element>
 {/if}

--- a/tests/UserAvatar/UserAvatar.test.svelte
+++ b/tests/UserAvatar/UserAvatar.test.svelte
@@ -62,3 +62,14 @@
   name="Jane Roe"
   tooltipText="Jane Roe"
 />
+
+<UserAvatar data-testid="interactive" interactive name="John Doe" />
+
+<UserAvatar data-testid="href" href="/profile" name="John Doe" />
+
+<UserAvatar
+  data-testid="href-over-interactive"
+  href="/profile"
+  interactive
+  name="John Doe"
+/>

--- a/tests/UserAvatar/UserAvatar.test.ts
+++ b/tests/UserAvatar/UserAvatar.test.ts
@@ -145,6 +145,42 @@ describe("UserAvatar", () => {
     expect(consoleLog).toHaveBeenCalledWith("mouseenter");
   });
 
+  it("renders a span by default", () => {
+    render(UserAvatar);
+
+    const avatar = screen.getByTestId("default");
+    expect(avatar.tagName).toBe("SPAN");
+    expect(avatar).not.toHaveClass("bx--user-avatar--interactive");
+  });
+
+  it("renders a button when interactive is set", () => {
+    render(UserAvatar);
+
+    const avatar = screen.getByTestId("interactive");
+    expect(avatar.tagName).toBe("BUTTON");
+    expect(avatar).toHaveAttribute("type", "button");
+    expect(avatar).toHaveClass("bx--user-avatar--interactive");
+    expect(avatar).toHaveAttribute("aria-label", "John Doe");
+  });
+
+  it("renders an anchor when href is set", () => {
+    render(UserAvatar);
+
+    const avatar = screen.getByTestId("href");
+    expect(avatar.tagName).toBe("A");
+    expect(avatar).toHaveAttribute("href", "/profile");
+    expect(avatar).toHaveClass("bx--user-avatar--interactive");
+  });
+
+  it("prefers href over interactive", () => {
+    render(UserAvatar);
+
+    const avatar = screen.getByTestId("href-over-interactive");
+    expect(avatar.tagName).toBe("A");
+    expect(avatar).toHaveAttribute("href", "/profile");
+    expect(avatar).not.toHaveAttribute("type");
+  });
+
   describe("Generics", () => {
     it("should support custom Icon types with generics", () => {
       type CustomIcon = new (...args: unknown[]) => unknown;


### PR DESCRIPTION
href renders UserAvatar as an anchor; interactive as a button; default
stays a span, with focus-ring styles for the interactive cases.