### PR TITLE
feat(user-avatar): add clickable group overflow

### DIFF
--- a/css/_user-avatar.scss
+++ b/css/_user-avatar.scss
@@ -105,6 +105,27 @@
   }
 
   //--------------------------------------------------------------------------
+  // Interactive (button) avatars — shared by UserAvatar `interactive` and the
+  // group overflow chip. Reset native button chrome; keep a visible focus ring.
+  //--------------------------------------------------------------------------
+  button.#{$prefix}--user-avatar,
+  .#{$prefix}--user-avatar--interactive {
+    margin: 0;
+    padding: 0;
+    border: none;
+    cursor: pointer;
+    font: inherit;
+    appearance: none;
+    -webkit-appearance: none;
+  }
+
+  button.#{$prefix}--user-avatar:focus,
+  .#{$prefix}--user-avatar--interactive:focus {
+    outline: 2px solid $focus;
+    outline-offset: 1px;
+  }
+
+  //--------------------------------------------------------------------------
   // Tooltip wrapper: strip the definition trigger's underline/padding so the
   // circle renders clean when `tooltipText` is set.
   //--------------------------------------------------------------------------

--- a/docs/src/pages/components/UserAvatarGroup.svx
+++ b/docs/src/pages/components/UserAvatarGroup.svx
@@ -32,6 +32,12 @@ Set `max` to limit how many avatars show. Everyone else goes into a "+N" overflo
 
 Set `max` to `0` to show every avatar without an overflow.
 
+### See all members
+
+The "+N" chip is a button. Listen for `click:overflow` or provide an `overflow` slot to open a popover, modal, or other see-all surface. The event detail includes `hidden` (the slotted avatars past `max`). Hover still shows the name tooltip.
+
+<FileSource src="/framed/UserAvatarGroup/UserAvatarGroupOverflowClick" />
+
 ### Large groups
 
 Every slotted avatar still mounts; CSS hides the ones past `max`. For large lists, render only the faces you need and set `total` to the real headcount so the "+N" chip gets the right number without mounting hundreds of nodes. Set `overflowTooltipText` when the hidden people are not slotted, since the default tooltip only lists mounted `name` values.

--- a/docs/src/pages/framed/UserAvatarGroup/UserAvatarGroupOverflowClick.svelte
+++ b/docs/src/pages/framed/UserAvatarGroup/UserAvatarGroupOverflowClick.svelte
@@ -1,0 +1,46 @@
+<script>
+  import {
+    Popover,
+    Stack,
+    UserAvatar,
+    UserAvatarGroup,
+  } from "carbon-components-svelte";
+
+  let open = false;
+  /** @type {{ id: string; name: string }[]} */
+  let hidden = [];
+
+  const members = [
+    "Monica",
+    "Richard Hendricks",
+    "Dinesh Chugtai",
+    "Bertram Gilfoyle",
+    "Jared Dunn",
+    "Erlich Bachman",
+  ];
+</script>
+
+<div style:position="relative" style:display="inline-block">
+  <UserAvatarGroup
+    max={3}
+    on:click:overflow={({ detail }) => {
+      hidden = detail.hidden;
+      open = !open;
+    }}
+  >
+    {#each members as name}
+      <UserAvatar backgroundColor="auto" {name} tooltipText={name} />
+    {/each}
+    <Popover slot="overflow" bind:open align="bottom" caret>
+      <Stack gap={3} style:padding="1rem" style:min-width="12rem">
+        <strong>All members</strong>
+        {#each hidden as member (member.id)}
+          <Stack orientation="horizontal" gap={3} align="center">
+            <UserAvatar backgroundColor="auto" name={member.name} size="sm" />
+            <span>{member.name}</span>
+          </Stack>
+        {/each}
+      </Stack>
+    </Popover>
+  </UserAvatarGroup>
+</div>

--- a/src/TooltipDefinition/TooltipDefinition.svelte
+++ b/src/TooltipDefinition/TooltipDefinition.svelte
@@ -61,6 +61,14 @@
    */
   export let portalTooltip = undefined;
 
+  /**
+   * Extra class names applied to the trigger button. Use when the trigger
+   * itself should carry visual component classes (for example an interactive
+   * avatar chip) instead of wrapping a nested interactive child.
+   * @type {string | undefined}
+   */
+  export let triggerClass = undefined;
+
   import { createEventDispatcher, getContext, onMount } from "svelte";
   import FloatingPortal from "../Portal/FloatingPortal.svelte";
   import { dismiss } from "../utils/dismiss.js";
@@ -132,6 +140,7 @@
     bind:this={ref}
     type="button"
     aria-describedby={id}
+    class={triggerClass}
     class:bx--tooltip--portal-active={effectivePortalTooltip}
     class:bx--tooltip--a11y={!effectivePortalTooltip}
     class:bx--tooltip__trigger={true}

--- a/src/UserAvatarGroup/UserAvatarGroup.svelte
+++ b/src/UserAvatarGroup/UserAvatarGroup.svelte
@@ -1,6 +1,18 @@
 <script>
   /**
+   * @typedef {Object} UserAvatarGroupHiddenItem
+   * @property {string} id
+   * @property {string} name
+   */
+
+  /**
    * Render a row of `UserAvatar` children. The group adds the "+N" overflow chip.
+   * The chip is a button: listen for `click:overflow` or provide an `overflow`
+   * slot to open a see-all members surface (popover, modal, etc.). Hover still
+   * shows the name tooltip.
+   *
+   * @event {{ hidden: UserAvatarGroupHiddenItem[] }} click:overflow - User clicks the "+N" overflow chip.
+   * @slot {{ hidden: UserAvatarGroupHiddenItem[] }} overflow - Optional see-all surface (popover, modal).
    * @restProps {div}
    */
 
@@ -52,10 +64,12 @@
    */
   export let overflowTooltipText = undefined;
 
-  import { setContext } from "svelte";
+  import { createEventDispatcher, setContext } from "svelte";
   import { writable } from "svelte/store";
   import Stack from "../Stack/Stack.svelte";
   import UserAvatarGroupOverflow from "./UserAvatarGroupOverflow.svelte";
+
+  const dispatch = createEventDispatcher();
 
   /** @type {import("svelte/store").Writable<Array<{ id: string; name: string; node?: HTMLElement }>>} */
   const items = writable([]);
@@ -138,11 +152,15 @@
   // Cap the label so it always fits the circle; counts above 99 read as "99+".
   $: overflowLabel = overflowCount > 99 ? "99+" : `+${overflowCount}`;
   // Names are known only for the slotted avatars past the visible ones.
-  $: hiddenNames = $items
+  $: hiddenItems = $items
     .slice(visibleCount)
-    .map((item) => item.name)
-    .filter(Boolean);
+    .map(({ id, name }) => ({ id, name }));
+  $: hiddenNames = hiddenItems.map((item) => item.name).filter(Boolean);
   $: overflowTooltip = overflowTooltipText ?? hiddenNames.join(", ");
+
+  function handleOverflowClick() {
+    dispatch("click:overflow", { hidden: hiddenItems });
+  }
 
   // Overlap (stacked) when no gap is set, or when a negative gap tightens the
   // stack; a positive gap switches to a spaced row.
@@ -195,6 +213,11 @@
 >
   <slot />
   {#if overflowCount > 0}
-    <UserAvatarGroupOverflow label={overflowLabel} names={overflowTooltip} />
+    <UserAvatarGroupOverflow
+      label={overflowLabel}
+      names={overflowTooltip}
+      on:trigger={handleOverflowClick}
+    />
   {/if}
+  <slot name="overflow" hidden={hiddenItems} />
 </Stack>

--- a/src/UserAvatarGroup/UserAvatarGroupOverflow.svelte
+++ b/src/UserAvatarGroup/UserAvatarGroupOverflow.svelte
@@ -1,7 +1,11 @@
 <script>
   /**
    * Internal "+N" overflow avatar for `UserAvatarGroup`. Shadows the group
-   * context so the inner `UserAvatar` does not register as a group item.
+   * context so the chip does not register as a group item. The chip is the
+   * tooltip trigger button (no nested button) and dispatches `trigger` on click
+   * so the group can open a see-all surface.
+   *
+   * @event {null} trigger - The overflow chip was clicked.
    */
 
   /** @type {string} */
@@ -10,11 +14,13 @@
   /** @type {string} */
   export let names = "";
 
-  import { getContext, setContext } from "svelte";
+  import { createEventDispatcher, getContext, setContext } from "svelte";
   import { readable } from "svelte/store";
-  import UserAvatar from "../UserAvatar/UserAvatar.svelte";
+  import TooltipDefinition from "../TooltipDefinition/TooltipDefinition.svelte";
 
+  const dispatch = createEventDispatcher();
   const parent = getContext("carbon:UserAvatarGroup");
+  const sizeStore = parent?.size ?? readable(undefined);
 
   // Opt out of registration and overflow (empty items/max, no-op register) so
   // the chip is never counted or hidden, but keep sharing the parent's
@@ -22,17 +28,45 @@
   setContext("carbon:UserAvatarGroup", {
     items: readable([]),
     max: readable(0),
-    size: parent?.size ?? readable(undefined),
+    size: sizeStore,
     activeTooltip: parent?.activeTooltip ?? readable(null),
     register: () => {},
     unregister: () => {},
     updateName: () => {},
   });
+
+  function handleClick() {
+    dispatch("trigger");
+  }
+
+  $: resolvedSize = $sizeStore ?? "md";
+  $: triggerClass = [
+    "bx--user-avatar",
+    "bx--user-avatar-group__overflow",
+    "bx--user-avatar--interactive",
+    `bx--user-avatar--${resolvedSize}`,
+    "bx--user-avatar--gray",
+  ].join(" ");
 </script>
 
-<UserAvatar
-  class="bx--user-avatar-group__overflow"
-  data-avatar-group-overflow="true"
-  initials={label}
-  tooltipText={names}
-/>
+{#if names}
+  <TooltipDefinition
+    class="bx--user-avatar-tooltip"
+    tooltipText={names}
+    {triggerClass}
+    portalTooltip={true}
+    data-avatar-group-overflow="true"
+    on:click={handleClick}
+  >
+    <span class:bx--user-avatar__text={true}>{label}</span>
+  </TooltipDefinition>
+{:else}
+  <button
+    type="button"
+    class={triggerClass}
+    data-avatar-group-overflow="true"
+    on:click={handleClick}
+  >
+    <span class:bx--user-avatar__text={true}>{label}</span>
+  </button>
+{/if}

--- a/tests/UserAvatarGroup/UserAvatarGroup.test.svelte
+++ b/tests/UserAvatarGroup/UserAvatarGroup.test.svelte
@@ -5,6 +5,10 @@
   // Toggles a leading avatar to exercise DOM-order resync: the avatar mounts
   // last but renders first.
   let showLead = false;
+
+  export let onOverflowClick: (event: CustomEvent) => void = () => {};
+  export let showOverflowSlot = false;
+  export let overflowOpen = false;
 </script>
 
 <div data-testid="under-max">
@@ -95,3 +99,32 @@
     <UserAvatar name="Cara" initials="C3" />
   </UserAvatarGroup>
 </div>
+
+<div data-testid="overflow-click">
+  <UserAvatarGroup max={2} on:click:overflow={onOverflowClick}>
+    <UserAvatar name="Monica" />
+    <UserAvatar name="Richard Hendricks" />
+    <UserAvatar name="Dinesh Chugtai" />
+    <UserAvatar name="Bertram Gilfoyle" />
+  </UserAvatarGroup>
+</div>
+
+{#if showOverflowSlot}
+  <div data-testid="overflow-slot">
+    <UserAvatarGroup max={2}>
+      <UserAvatar name="Monica" />
+      <UserAvatar name="Richard Hendricks" />
+      <UserAvatar name="Dinesh Chugtai" />
+      <UserAvatar name="Bertram Gilfoyle" />
+      <div slot="overflow" let:hidden>
+        {#if overflowOpen}
+          <ul data-testid="overflow-members">
+            {#each hidden as member (member.id)}
+              <li>{member.name}</li>
+            {/each}
+          </ul>
+        {/if}
+      </div>
+    </UserAvatarGroup>
+  </div>
+{/if}

--- a/tests/UserAvatarGroup/UserAvatarGroup.test.ts
+++ b/tests/UserAvatarGroup/UserAvatarGroup.test.ts
@@ -171,4 +171,37 @@ describe("UserAvatarGroup", () => {
     });
     expect(root).toHaveTextContent("+2");
   });
+
+  it("dispatches click:overflow with the hidden avatars when the chip is clicked", async () => {
+    const onOverflowClick = vi.fn();
+    render(UserAvatarGroup, { onOverflowClick });
+
+    const root = groupRoot("overflow-click");
+    const chip = root.querySelector(".bx--user-avatar-group__overflow");
+    assert(chip);
+    expect(chip.tagName).toBe("BUTTON");
+
+    await user.click(chip);
+
+    expect(onOverflowClick).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({
+        detail: {
+          hidden: [
+            expect.objectContaining({ name: "Dinesh Chugtai" }),
+            expect.objectContaining({ name: "Bertram Gilfoyle" }),
+          ],
+        },
+      }),
+    );
+  });
+
+  it("renders the overflow chip as a button when the overflow slot is present", () => {
+    render(UserAvatarGroup, { showOverflowSlot: true });
+
+    const root = groupRoot("overflow-slot");
+    const chip = root.querySelector(".bx--user-avatar-group__overflow");
+    assert(chip);
+    expect(chip.tagName).toBe("BUTTON");
+    expect(chip).toHaveClass("bx--user-avatar--interactive");
+  });
 });


### PR DESCRIPTION
UserAvatarGroup +N is a button that dispatches click:overflow with the
hidden members; hover tooltip remains, with a see-all Popover docs
example.