### PR TITLE
fix(structured-list): scope focus style to selected row

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Carbon Components Svelte is a [Svelte](https://github.com/sveltejs/svelte) component library that implements the [Carbon Design System](https://www.carbondesignsystem.com/), an open source design system by IBM. Ship accessible, consistent, production-ready interfaces.
 
-- **70+ components**: from inputs to data tables
+- **90+ components**: from inputs to data tables
 - **5 built-in themes**: two light, three dark
 - **Fully typed TypeScript API**: props, events, and slots
 - **WCAG 2.1 AA**: keyboard and screen-reader ready

--- a/css/_structured-list-input-focusable.scss
+++ b/css/_structured-list-input-focusable.scss
@@ -34,7 +34,11 @@
     @include hidden;
   }
 
-  .#{$prefix}--structured-list-row:focus-within {
+  // Scoped to `--selection`: `:focus-within` also fires for any focusable
+  // content a consumer places inside a plain row (e.g. a sort button in a
+  // header row), which isn't the row-level selection state this is for.
+  .#{$prefix}--structured-list--selection
+    .#{$prefix}--structured-list-row:focus-within {
     @include focus-outline("outline");
   }
 

--- a/docs/content/overview.md
+++ b/docs/content/overview.md
@@ -1,6 +1,6 @@
 A complete [Svelte](https://github.com/sveltejs/svelte) component library that implements the [IBM Carbon Design System](https://www.carbondesignsystem.com/). Ship accessible, consistent, production-ready interfaces.
 
-- **70+ components** — from inputs to data tables
+- **90+ components** — from inputs to data tables
 - **5 built-in themes** — two light, three dark
 - **Fully typed TypeScript API** — props, events, and slots
 - **WCAG 2.1 AA** — keyboard and screen-reader ready
@@ -277,7 +277,7 @@ Documentation is available in LLM-friendly plain text for use with coding assist
 
 The Carbon Svelte collection includes packages for icons, pictograms, and data visualization:
 
-- **Carbon Components Svelte** — 70+ components — [GitHub](https://github.com/carbon-design-system/carbon-components-svelte)
+- **Carbon Components Svelte** — 90+ components — [GitHub](https://github.com/carbon-design-system/carbon-components-svelte)
 - **Carbon Icons Svelte** — 2,700+ icons — [GitHub](https://github.com/carbon-design-system/carbon-icons-svelte)
 - **Carbon Pictograms Svelte** — 1,500+ pictograms — [GitHub](https://github.com/carbon-design-system/carbon-pictograms-svelte)
 - **Carbon Charts Svelte** — 25+ charts, powered by d3 — [GitHub](https://github.com/carbon-design-system/carbon-charts/tree/master/packages/svelte)

--- a/docs/src/components/DocHero.svelte
+++ b/docs/src/components/DocHero.svelte
@@ -22,7 +22,7 @@
 <Box tag="section" class="hero band" paddingY={8}>
   <Grid>
     <Row style="margin-top: 2rem">
-      <Column xlg={10} lg={12} md={8} sm={4}>
+      <Column>
         <Stack gap={3}>
           {#if eyebrow}
             <DocEyebrow {eyebrow} {icon} />

--- a/docs/src/pages/_module.svelte
+++ b/docs/src/pages/_module.svelte
@@ -91,7 +91,7 @@
     );
 
   // Split MiniSearch hits into two groups. MiniSearch already ranks and filters,
-  // so pass shouldFilter={false} and let the default matcher highlight labels.
+  // so pass shouldFilter={false} and let `matchQuery` highlight labels.
   $: componentHits = results.filter((r) => r.isComponent);
   $: sectionHits = results.filter((r) => !r.isComponent);
 
@@ -110,11 +110,33 @@
       .join("");
   }
 
+  /**
+   * Match `query` against `text` by OR-ing per-term fuzzy matches, mirroring how
+   * MiniSearch matched each term independently. A single whole-string match would
+   * fail whenever the query spans two displayed fields (e.g. "multiselect bas"
+   * matching text "MultiSelect" + description "Basic") or a query term isn't
+   * present in this particular field at all.
+   */
+  function matchQuery(text: string, query: string) {
+    const terms = query.trim().split(/\s+/).filter(Boolean);
+    if (terms.length === 0) return { matched: true, indices: [] as number[] };
+    const indices = new Set<number>();
+    let matched = false;
+    for (const term of terms) {
+      const result = fuzzyMatch(text, term);
+      if (result.matched) {
+        matched = true;
+        for (const i of result.indices) indices.add(i);
+      }
+    }
+    return { matched, indices: [...indices].sort((a, b) => a - b) };
+  }
+
   /** Highlight the current query in arbitrary text (e.g. a description). */
   function highlightHtml(text: string | undefined) {
     if (!text) return "";
-    const { matched, indices } = fuzzyMatch(text, value);
-    return toHtml(highlightSegments(text, matched ? (indices ?? []) : []));
+    const { matched, indices } = matchQuery(text, value);
+    return toHtml(highlightSegments(text, matched ? indices : []));
   }
 
   let isOpen = false;
@@ -226,6 +248,7 @@
         placeholder="Search"
         spellcheck="false"
         shouldFilter={false}
+        match={matchQuery}
         on:select={(e) => {
           // Selecting a link item would navigate natively; intercept it and
           // route through Routify for SPA navigation instead.
@@ -425,7 +448,7 @@
 
   :global(.docs-search-hit) {
     display: flex;
-    align-items: center;
+    align-items: baseline;
     gap: 0.5rem;
     min-width: 0;
   }

--- a/docs/src/pages/index.svelte
+++ b/docs/src/pages/index.svelte
@@ -120,7 +120,7 @@
         type="expressive-heading-06"
         color="primary"
         balance
-        maxWidth="32ch"
+        maxWidth="55rem"
       >
         The Carbon Design System,<br />built for Svelte
       </Text>
@@ -136,7 +136,7 @@
         <Column>
           <div class="metrics-grid">
             <DocMetric
-              value="70+"
+              value="90+"
               label="Components"
               caption="From inputs to data tables"
             />
@@ -226,7 +226,7 @@
                   borderRight
                   borderBottom
                   title="Carbon Components Svelte"
-                  subtitle="70+ components"
+                  subtitle="90+ components"
                   target="_blank"
                   href="https://github.com/carbon-design-system/carbon-components-svelte"
                 />

--- a/docs/src/pages/quick-start.svelte
+++ b/docs/src/pages/quick-start.svelte
@@ -330,8 +330,12 @@
                     bind:value={iconSizeIndex}
                     hideTextInput
                     fullWidth
-                    minLabel="16"
-                    maxLabel="32"
+                    marks={[
+                      { value: 0, label: "16" },
+                      { value: 1, label: "20" },
+                      { value: 2, label: "24" },
+                      { value: 3, label: "32" },
+                    ]}
                   />
                   <div class="glyph-grid glyph-grid--icons">
                     <div class="glyph-cell">
@@ -436,8 +440,13 @@
                     bind:value={pictogramSize}
                     hideTextInput
                     fullWidth
-                    minLabel="48"
-                    maxLabel="64"
+                    marks={[
+                      { value: 48, label: "48" },
+                      { value: 52, label: "52" },
+                      { value: 56, label: "56" },
+                      { value: 60, label: "60" },
+                      { value: 64, label: "64" },
+                    ]}
                   />
                   <div class="glyph-grid glyph-grid--pictograms">
                     <div class="glyph-cell">


### PR DESCRIPTION
Also fixes docs search highlighting for multi-word queries, keeps the
homepage hero's title and description from bouncing between line
counts across viewport widths, bumps the component count to 90+,
and adds tick marks to the quick start sliders.
