### PR TITLE
feat(data-table): support "shift+click" selection

### DIFF
--- a/docs/src/pages/components/DataTable.svx
+++ b/docs/src/pages/components/DataTable.svx
@@ -1517,7 +1517,7 @@ Enable row selection with checkboxes or radios, with optional batch actions.
 
 ### Checkbox
 
-Set `selectable` to `true` for multi-select. Bind selectedRowIds to track selections. Use inputName to customize checkbox names.
+Set `selectable` to `true` for multi-select. Bind selectedRowIds to track selections. Use inputName to customize checkbox names. Hold <DocKbd label="Shift" /> while clicking a checkbox to select every row between it and the last row clicked.
 
 <FileSource src="/framed/DataTable/SelectableDataTable" />
 

--- a/e2e/data-table.test.ts
+++ b/e2e/data-table.test.ts
@@ -79,4 +79,16 @@ test.describe("DataTable", () => {
     const selectedRows = batch.locator("tbody tr.bx--data-table--selected");
     await expect(selectedRows).toHaveCount(2);
   });
+
+  test("selectable: shift+click selects the row range", async ({ page }) => {
+    const table = page.getByTestId("data-table-select-range");
+    const checkboxes = table.getByRole("checkbox", { name: "Select row" });
+
+    await checkboxes.nth(0).click({ force: true });
+    await checkboxes.nth(2).click({ force: true, modifiers: ["Shift"] });
+
+    await expect(checkboxes.nth(0)).toBeChecked();
+    await expect(checkboxes.nth(1)).toBeChecked();
+    await expect(checkboxes.nth(2)).toBeChecked();
+  });
 });

--- a/e2e/fixtures/DataTableFixture.svelte
+++ b/e2e/fixtures/DataTableFixture.svelte
@@ -40,6 +40,14 @@
     { id: "b1", name: "Item A" },
     { id: "b2", name: "Item B" },
   ];
+
+  const selectRangeHeaders = [{ key: "name", value: "Product" }];
+
+  const selectRangeRows = [
+    { id: "r1", name: "Item A" },
+    { id: "r2", name: "Item B" },
+    { id: "r3", name: "Item C" },
+  ];
 </script>
 
 <div data-testid="data-table-basic">
@@ -68,4 +76,8 @@
 
 <div data-testid="data-table-batch">
   <DataTable batchSelection headers={batchHeaders} rows={batchRows} />
+</div>
+
+<div data-testid="data-table-select-range">
+  <DataTable selectable headers={selectRangeHeaders} rows={selectRangeRows} />
 </div>

--- a/src/Checkbox/InlineCheckbox.svelte
+++ b/src/Checkbox/InlineCheckbox.svelte
@@ -16,6 +16,25 @@
 
   /** Obtain a reference to the input HTML element */
   export let ref = null;
+
+  // Firefox treats shift+click on a `<label for="...">` as a text-selection gesture and
+  // never forwards a click to the associated checkbox (no click, no change, no toggle):
+  // https://bugzilla.mozilla.org/show_bug.cgi?id=559506. Detect that case on the label and
+  // redispatch a click on the input directly so `on:click` sees consistent behavior,
+  // including `shiftKey`, across browsers. Dispatching "click" on a checkbox runs its native
+  // pre-click activation (toggle + a follow-up "change"), so do not also toggle `checked`
+  // here or the browser's activation will immediately undo it (a double-toggle).
+  function handleLabelClick(event) {
+    if (!event.shiftKey || !ref || ref.disabled) return;
+    event.preventDefault();
+    ref.dispatchEvent(
+      new MouseEvent("click", {
+        shiftKey: true,
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
+  }
 </script>
 
 <div class:bx--checkbox--inline={true}>
@@ -28,14 +47,18 @@
     {id}
     {...$$restProps}
     aria-checked={indeterminate ? undefined : checked}
+    on:click
     on:change
     on:focus
     on:blur
   >
+  <!-- svelte-ignore a11y-click-events-have-key-events -->
+  <!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
   <label
     for={id}
     {title}
     aria-label={$$props["aria-label"]}
     class:bx--checkbox-label={true}
+    on:click={handleLabelClick}
   ></label>
 </div>

--- a/src/DataTable/DataTable.svelte
+++ b/src/DataTable/DataTable.svelte
@@ -223,6 +223,7 @@
   /**
    * Set to `true` for the selectable variant.
    * Automatically set to `true` if `radio` or `batchSelection` are `true`.
+   * Shift-clicking a row checkbox extends selection to every row between it and the last row clicked (not supported with `radio`).
    * @bindable writable
    */
   export let selectable = false;
@@ -498,6 +499,37 @@
   function resetSelectedRowIds() {
     selectAll = false;
     selectedRowIds = [];
+    lastSelectedRowId = null;
+  }
+
+  /** Anchor row id for shift+click range selection; cleared when the anchor no longer exists in the current row order. */
+  let lastSelectedRowId = null;
+
+  /**
+   * Apply `checked` to every selectable row between the anchor row and `targetIndex` (inclusive),
+   * where `targetIndex` is a position in `rowsToVirtualize`. Returns `false` if the anchor row
+   * is no longer present (for example, filtered out), so the caller can fall back to a single toggle.
+   * @type {(targetIndex: number, checked: boolean) => boolean}
+   */
+  function selectRowRange(targetIndex, checked) {
+    const anchorIndex = rowsToVirtualize.findIndex(
+      (row) => row.id === lastSelectedRowId,
+    );
+    if (anchorIndex === -1) return false;
+
+    const start = Math.min(anchorIndex, targetIndex);
+    const end = Math.max(anchorIndex, targetIndex);
+    const next = new Set(selectedRowIds);
+    for (const row of rowsToVirtualize.slice(start, end + 1)) {
+      if (nonSelectableRowIdsSet.has(row.id)) continue;
+      if (checked) {
+        next.add(row.id);
+      } else {
+        next.delete(row.id);
+      }
+    }
+    selectedRowIds = [...next];
+    return true;
   }
 
   setContext("carbon:DataTable", {
@@ -1067,22 +1099,25 @@
                         aria-label="Select row"
                         checked={selectedRowIdsSet.has(row.id)}
                         value={row.id}
-                        on:change={() => {
-                          if (selectedRowIdsSet.has(row.id)) {
-                            selectedRowIds = selectedRowIds.filter(
-                              (id) => id !== row.id,
-                            );
-                            dispatch("click:row--select", {
-                              row,
-                              selected: false,
-                            });
-                          } else {
-                            selectedRowIds = [...selectedRowIds, row.id];
-                            dispatch("click:row--select", {
-                              row,
-                              selected: true,
-                            });
+                        on:click={(event) => {
+                          const checked = event.target.checked;
+                          const usedRange =
+                            event.shiftKey &&
+                            lastSelectedRowId !== null &&
+                            selectRowRange(actualIndex, checked);
+
+                          if (!usedRange) {
+                            const next = new Set(selectedRowIds);
+                            if (checked) {
+                              next.add(row.id);
+                            } else {
+                              next.delete(row.id);
+                            }
+                            selectedRowIds = [...next];
                           }
+
+                          lastSelectedRowId = row.id;
+                          dispatch("click:row--select", { row, selected: checked });
                         }}
                       />
                     {/if}
@@ -1292,17 +1327,25 @@
                         aria-label="Select row"
                         checked={isSelected}
                         value={row.id}
-                        on:change={() => {
-                          const next = new Set(selectedRowIds);
-                          if (isSelected) {
-                            next.delete(row.id);
+                        on:click={(event) => {
+                          const checked = event.target.checked;
+                          const usedRange =
+                            event.shiftKey &&
+                            lastSelectedRowId !== null &&
+                            selectRowRange(index, checked);
+
+                          if (!usedRange) {
+                            const next = new Set(selectedRowIds);
+                            if (checked) {
+                              next.add(row.id);
+                            } else {
+                              next.delete(row.id);
+                            }
                             selectedRowIds = [...next];
-                            dispatch("click:row--select", { row, selected: false });
-                          } else {
-                            next.add(row.id);
-                            selectedRowIds = [...next];
-                            dispatch("click:row--select", { row, selected: true });
                           }
+
+                          lastSelectedRowId = row.id;
+                          dispatch("click:row--select", { row, selected: checked });
                         }}
                       />
                     {/if}

--- a/src/DataTable/DataTable.svelte
+++ b/src/DataTable/DataTable.svelte
@@ -871,7 +871,9 @@
             </th>
           {/if}
           {#if selectable && !batchSelection}
-            <th scope="col"></th>
+            <th scope="col">
+              <span class:bx--visually-hidden={true}>Select row</span>
+            </th>
           {/if}
           {#if batchSelection && !radio}
             <th scope="col" class:bx--table-column-checkbox={true}>

--- a/tests/DataTable/DataTable.test.ts
+++ b/tests/DataTable/DataTable.test.ts
@@ -942,6 +942,61 @@ describe("DataTable", () => {
     expect(selectedRow).toBeInTheDocument();
   });
 
+  it("handles shift+click range selection", async () => {
+    render(DataTable, {
+      props: {
+        selectable: true,
+        headers,
+        rows,
+      },
+    });
+
+    const checkboxes = screen.getAllByRole("checkbox");
+
+    await user.click(checkboxes[0]);
+
+    await user.keyboard("{Shift>}");
+    await user.click(checkboxes[2]);
+    await user.keyboard("{/Shift}");
+
+    // Every row between the anchor and the shift-clicked row is selected.
+    expect(checkboxes[0]).toBeChecked();
+    expect(checkboxes[1]).toBeChecked();
+    expect(checkboxes[2]).toBeChecked();
+
+    // Shift+click again to deselect the range back to the anchor.
+    await user.keyboard("{Shift>}");
+    await user.click(checkboxes[1]);
+    await user.keyboard("{/Shift}");
+
+    expect(checkboxes[0]).toBeChecked();
+    expect(checkboxes[1]).not.toBeChecked();
+    expect(checkboxes[2]).not.toBeChecked();
+  });
+
+  it("does not range-select non-selectable rows on shift+click", async () => {
+    render(DataTable, {
+      props: {
+        selectable: true,
+        nonSelectableRowIds: ["b"],
+        headers,
+        rows,
+      },
+    });
+
+    const checkboxes = screen.getAllByRole("checkbox");
+    expect(checkboxes).toHaveLength(2);
+
+    await user.click(checkboxes[0]);
+
+    await user.keyboard("{Shift>}");
+    await user.click(checkboxes[1]);
+    await user.keyboard("{/Shift}");
+
+    expect(checkboxes[0]).toBeChecked();
+    expect(checkboxes[1]).toBeChecked();
+  });
+
   it("handles batch selection", async () => {
     const { container } = render(DataTable, {
       props: {


### PR DESCRIPTION
Shift-clicking a row checkbox now selects every row between it and
the last row you clicked, skipping non-selectable rows. Includes a
fix for a long-standing Firefox bug where shift-clicking a
checkbox's label never toggles the checkbox at all, plus an e2e
test that catches it.

---


https://github.com/user-attachments/assets/f12e6cd1-0442-42e9-9ba6-27d1ac893d4a

