### PR TITLE
feat(content-switcher): add selectedId for stable selection

### DIFF
--- a/docs/src/pages/components/ContentSwitcher.svx
+++ b/docs/src/pages/components/ContentSwitcher.svx
@@ -31,6 +31,15 @@ Set `selectedIndex` to pre-select a switch when the content switcher loads.
   <Switch text="Recommended" />
 </ContentSwitcher>
 
+## Selected by id
+
+For dynamic switch sets, bind `selectedId` and give each `Switch` a stable
+`id`. Selection stays on the same logical switch when switches before it are
+added or removed. When set, `selectedId` takes precedence over
+`selectedIndex`.
+
+<FileSource src="/framed/ContentSwitcher/ContentSwitcherSelectedId" />
+
 ## Manual selection mode
 
 By default, the content switcher changes the selection when the user moves focus with the arrow keys.

--- a/docs/src/pages/framed/ContentSwitcher/ContentSwitcherSelectedId.svelte
+++ b/docs/src/pages/framed/ContentSwitcher/ContentSwitcherSelectedId.svelte
@@ -1,0 +1,46 @@
+<script>
+  import {
+    Button,
+    Checkbox,
+    ContentSwitcher,
+    Stack,
+    Switch,
+  } from "carbon-components-svelte";
+
+  let selectedId = "admin";
+  let showDashboard = true;
+  let showAdmin = true;
+  let showSettings = true;
+  let showProfile = true;
+
+  $: visibleSwitches = [
+    { id: "dashboard", text: "Dashboard", show: showDashboard },
+    { id: "admin", text: "Admin", show: showAdmin },
+    { id: "settings", text: "Settings", show: showSettings },
+    { id: "profile", text: "Profile", show: showProfile },
+  ].filter((s) => s.show);
+</script>
+
+<Stack gap={3}>
+  <div>
+    <Checkbox bind:checked={showDashboard} labelText="Show Dashboard" />
+    <Checkbox bind:checked={showAdmin} labelText="Show Admin" />
+    <Checkbox bind:checked={showSettings} labelText="Show Settings" />
+    <Checkbox bind:checked={showProfile} labelText="Show Profile" />
+  </div>
+  <Stack gap={4} orientation="horizontal" align="center">
+    <Button
+      kind="tertiary"
+      size="small"
+      on:click={() => (selectedId = "settings")}
+    >
+      Select Settings by id
+    </Button>
+    <div><strong>selectedId:</strong> {selectedId}</div>
+  </Stack>
+  <ContentSwitcher bind:selectedId>
+    {#each visibleSwitches as sw (sw.id)}
+      <Switch id={sw.id} text={sw.text} />
+    {/each}
+  </ContentSwitcher>
+</Stack>

--- a/src/ContentSwitcher/ContentSwitcher.svelte
+++ b/src/ContentSwitcher/ContentSwitcher.svelte
@@ -5,9 +5,20 @@
 
   /**
    * Set the selected index of the switch item.
+   * Ignored when `selectedId` is set.
    * @bindable writable
    */
   export let selectedIndex = 0;
+
+  /**
+   * Specify the selected switch by id.
+   * When set, takes precedence over `selectedIndex` and stays on the same
+   * logical switch as switches are added or removed. Pair with a stable `id`
+   * on each `Switch`.
+   * @bindable writable
+   * @type {string | undefined}
+   */
+  export let selectedId = undefined;
 
   /**
    * Specify the size of the content switcher.
@@ -56,6 +67,10 @@
   // Inferred when every registered switch provides an `icon`.
   $: iconOnly = switches.length > 0 && switches.every((s) => s.icon);
 
+  $: if (selectedId !== undefined && switches) {
+    syncSelection();
+  }
+
   // Flag to trigger DOM reordering only when switches change.
   // This is necessary to avoid infinite loops in Svelte 5.
   let needsDomSync = false;
@@ -75,7 +90,7 @@
       return;
     }
 
-    if (selected) {
+    if (selectedId === undefined && selected) {
       selectedIndex = switches.length;
     }
 
@@ -95,7 +110,32 @@
    * @type {(id: string) => void}
    */
   function update(id) {
+    if (selectedId !== undefined) {
+      selectedId = id;
+      return;
+    }
     selectedIndex = switches.map(({ id }) => id).indexOf(id);
+  }
+
+  /**
+   * Resolve `selectedIndex` from `selectedId` when set. If the selected id was
+   * removed, keep the same index (next switch) or clamp, and re-anchor
+   * `selectedId` to whatever switch that resolves to.
+   * @type {() => void}
+   */
+  function syncSelection() {
+    if (selectedId === undefined) return;
+
+    const index = switches.findIndex((s) => s.id === selectedId);
+    if (index > -1) {
+      selectedIndex = index;
+      return;
+    }
+
+    if (switches.length === 0) return;
+
+    selectedIndex = Math.min(Math.max(selectedIndex, 0), switches.length - 1);
+    selectedId = switches[selectedIndex]?.id;
   }
 
   /**
@@ -103,7 +143,14 @@
    */
   async function changeTo(index) {
     if (index < 0 || index >= switches.length) return;
-    selectedIndex = index;
+
+    if (selectedId === undefined) {
+      selectedIndex = index;
+    } else {
+      const target = switches[index];
+      if (!target) return;
+      selectedId = target.id;
+    }
 
     await tick();
     const tab = document.getElementById(switches[index].id);
@@ -146,15 +193,15 @@
     if (needsDomSync && ref) {
       needsDomSync = false;
 
-      const selectedId = switches[selectedIndex]?.id;
+      const preservedId = switches[selectedIndex]?.id;
       switches = syncDomOrder({
         root: ref,
         selector: "[role='tab']",
         items: switches,
       });
 
-      if (selectedId !== undefined) {
-        const nextIndex = switches.findIndex((s) => s.id === selectedId);
+      if (preservedId !== undefined) {
+        const nextIndex = switches.findIndex((s) => s.id === preservedId);
         if (nextIndex > -1) {
           selectedIndex = nextIndex;
         }

--- a/tests/ContentSwitcher/ContentSwitcher.selectedId.test.svelte
+++ b/tests/ContentSwitcher/ContentSwitcher.selectedId.test.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+  import ContentSwitcher from "carbon-components-svelte/ContentSwitcher/ContentSwitcher.svelte";
+  import Switch from "carbon-components-svelte/ContentSwitcher/Switch.svelte";
+
+  export let selectedIndex = 0;
+  export let selectedId: string | undefined = undefined;
+  export let showSwitchA = true;
+  export let showSwitchB = true;
+</script>
+
+<ContentSwitcher
+  bind:selectedIndex
+  bind:selectedId
+  on:change={({ detail }) => console.log("change event", detail)}
+>
+  {#if showSwitchA}
+    <Switch id="switch-a" text="Switch A" />
+  {/if}
+  {#if showSwitchB}
+    <Switch id="switch-b" text="Switch B" />
+  {/if}
+  <Switch id="switch-c" text="Switch C" />
+</ContentSwitcher>
+
+<button
+  type="button"
+  data-testid="toggle-switch-a"
+  on:click={() => (showSwitchA = !showSwitchA)}
+>
+  Toggle Switch A
+</button>
+<button
+  type="button"
+  data-testid="toggle-switch-b"
+  on:click={() => (showSwitchB = !showSwitchB)}
+>
+  Toggle Switch B
+</button>
+<div data-testid="selected-index">{selectedIndex}</div>
+<div data-testid="selected-id">{selectedId ?? ""}</div>

--- a/tests/ContentSwitcher/ContentSwitcher.test.ts
+++ b/tests/ContentSwitcher/ContentSwitcher.test.ts
@@ -7,6 +7,7 @@ import ContentSwitcherDynamic from "./ContentSwitcher.dynamic.test.svelte";
 import ContentSwitcherLowContrast from "./ContentSwitcher.lowContrast.test.svelte";
 import ContentSwitcherLowContrastIconOnly from "./ContentSwitcher.lowContrastIconOnly.test.svelte";
 import ContentSwitcherNested from "./ContentSwitcher.nested.test.svelte";
+import ContentSwitcherSelectedId from "./ContentSwitcher.selectedId.test.svelte";
 import ContentSwitcherSelectedIndex from "./ContentSwitcher.selectedIndex.test.svelte";
 import ContentSwitcherSelectionMode from "./ContentSwitcher.selectionMode.test.svelte";
 import ContentSwitcherSize from "./ContentSwitcher.size.test.svelte";
@@ -604,6 +605,85 @@ describe("ContentSwitcher", () => {
 
       await user.keyboard("{Enter}");
       expect(consoleLog).toHaveBeenCalledWith("change", 1);
+    });
+  });
+
+  describe("selectedId", () => {
+    it("keeps selectedId on the same logical switch when a prior switch is removed", async () => {
+      render(ContentSwitcherSelectedId, {
+        props: { selectedId: "switch-b", showSwitchA: true },
+      });
+
+      expect(screen.getByRole("tab", { name: "Switch B" })).toHaveAttribute(
+        "aria-selected",
+        "true",
+      );
+      expect(screen.getByTestId("selected-id")).toHaveTextContent("switch-b");
+      expect(screen.getByTestId("selected-index")).toHaveTextContent("1");
+
+      await user.click(screen.getByTestId("toggle-switch-a"));
+
+      expect(
+        screen.queryByRole("tab", { name: "Switch A" }),
+      ).not.toBeInTheDocument();
+      expect(screen.getByRole("tab", { name: "Switch B" })).toHaveAttribute(
+        "aria-selected",
+        "true",
+      );
+      expect(screen.getByTestId("selected-id")).toHaveTextContent("switch-b");
+      expect(screen.getByTestId("selected-index")).toHaveTextContent("0");
+    });
+
+    it("falls back when the selectedId switch itself is removed", async () => {
+      render(ContentSwitcherSelectedId, {
+        props: { selectedId: "switch-b", showSwitchA: true, showSwitchB: true },
+      });
+
+      await user.click(screen.getByTestId("toggle-switch-b"));
+
+      expect(
+        screen.queryByRole("tab", { name: "Switch B" }),
+      ).not.toBeInTheDocument();
+      expect(screen.getByTestId("selected-id")).toHaveTextContent("switch-c");
+      expect(screen.getByRole("tab", { name: "Switch C" })).toHaveAttribute(
+        "aria-selected",
+        "true",
+      );
+    });
+
+    it("uses the index API when selectedId is unset", async () => {
+      render(ContentSwitcherSelectedId, {
+        props: { selectedIndex: 2, selectedId: undefined },
+      });
+
+      expect(screen.getByRole("tab", { name: "Switch C" })).toHaveAttribute(
+        "aria-selected",
+        "true",
+      );
+      expect(screen.getByTestId("selected-index")).toHaveTextContent("2");
+      expect(screen.getByTestId("selected-id")).toHaveTextContent("");
+
+      await user.click(screen.getByRole("tab", { name: "Switch A" }));
+
+      expect(screen.getByRole("tab", { name: "Switch A" })).toHaveAttribute(
+        "aria-selected",
+        "true",
+      );
+      expect(screen.getByTestId("selected-index")).toHaveTextContent("0");
+      expect(screen.getByTestId("selected-id")).toHaveTextContent("");
+    });
+
+    it("lets selectedId win over selectedIndex", () => {
+      render(ContentSwitcherSelectedId, {
+        props: { selectedIndex: 0, selectedId: "switch-c" },
+      });
+
+      expect(screen.getByRole("tab", { name: "Switch C" })).toHaveAttribute(
+        "aria-selected",
+        "true",
+      );
+      expect(screen.getByTestId("selected-id")).toHaveTextContent("switch-c");
+      expect(screen.getByTestId("selected-index")).toHaveTextContent("2");
     });
   });
 });


### PR DESCRIPTION
Gives ContentSwitcher the same stable-selection API Tabs already has,
so a dynamic Switch set can be selected by id instead of by index.