### PR TITLE
feat(progress-indicator): add selectedId for stable selection

### DIFF
--- a/docs/src/pages/components/ProgressIndicator.svx
+++ b/docs/src/pages/components/ProgressIndicator.svx
@@ -33,6 +33,12 @@ Create a horizontal progress indicator with four steps.
   />
 </ProgressIndicator>
 
+## Selected by id
+
+For dynamic step sets, bind `selectedId` and give each `ProgressStep` a stable `id`. Selection stays on the same logical step when steps before it are added or removed. When set, `selectedId` takes precedence over `currentIndex`.
+
+<FileSource src="/framed/ProgressIndicator/ProgressIndicatorSelectedId" />
+
 ## Prevent change on click
 
 Disable automatic step selection when clicking completed steps.

--- a/docs/src/pages/framed/ProgressIndicator/ProgressIndicatorSelectedId.svelte
+++ b/docs/src/pages/framed/ProgressIndicator/ProgressIndicatorSelectedId.svelte
@@ -1,0 +1,46 @@
+<script>
+  import {
+    Button,
+    Checkbox,
+    ProgressIndicator,
+    ProgressStep,
+    Stack,
+  } from "carbon-components-svelte";
+
+  let selectedId = "step-b";
+  let showStepA = true;
+  let showStepB = true;
+  let showStepC = true;
+  let showStepD = true;
+
+  $: visibleSteps = [
+    { id: "step-a", label: "Step 1", show: showStepA },
+    { id: "step-b", label: "Step 2", show: showStepB },
+    { id: "step-c", label: "Step 3", show: showStepC },
+    { id: "step-d", label: "Step 4", show: showStepD },
+  ].filter((s) => s.show);
+</script>
+
+<Stack gap={3}>
+  <div>
+    <Checkbox bind:checked={showStepA} labelText="Show Step 1" />
+    <Checkbox bind:checked={showStepB} labelText="Show Step 2" />
+    <Checkbox bind:checked={showStepC} labelText="Show Step 3" />
+    <Checkbox bind:checked={showStepD} labelText="Show Step 4" />
+  </div>
+  <Stack gap={4} orientation="horizontal" align="center">
+    <Button
+      kind="tertiary"
+      size="small"
+      on:click={() => (selectedId = "step-c")}
+    >
+      Select Step 3 by id
+    </Button>
+    <div><strong>selectedId:</strong> {selectedId}</div>
+  </Stack>
+  <ProgressIndicator bind:selectedId>
+    {#each visibleSteps as step (step.id)}
+      <ProgressStep id={step.id} label={step.label} complete />
+    {/each}
+  </ProgressIndicator>
+</Stack>

--- a/src/ProgressIndicator/ProgressIndicator.svelte
+++ b/src/ProgressIndicator/ProgressIndicator.svelte
@@ -1,9 +1,20 @@
 <script>
   /**
    * Specify the current step index.
+   * Ignored when `selectedId` is set.
    * @bindable writable
    */
   export let currentIndex = 0;
+
+  /**
+   * Specify the current step by id.
+   * When set, takes precedence over `currentIndex` and stays on the same
+   * logical step as steps are added or removed. Pair with a stable `id` on
+   * each `ProgressStep`.
+   * @bindable writable
+   * @type {string | undefined}
+   */
+  export let selectedId = undefined;
 
   /** Set to `true` to use the vertical variant */
   export let vertical = false;
@@ -77,10 +88,38 @@
    */
   function change(index) {
     if (preventChangeOnClick) return;
-    currentIndex = index;
+
+    if (selectedId === undefined) {
+      currentIndex = index;
+    } else {
+      const step = $steps[index];
+      if (!step) return;
+      selectedId = step.id;
+    }
 
     /** @event {number} change */
     dispatch("change", index);
+  }
+
+  /**
+   * Resolve `currentIndex` from `selectedId` when set. If the selected id was
+   * removed, keep the same index (next step) or clamp, and re-anchor
+   * `selectedId` to whatever step that resolves to.
+   * @type {() => void}
+   */
+  function syncSelection() {
+    if (selectedId === undefined) return;
+
+    const step = $stepsById[selectedId];
+    if (step) {
+      currentIndex = step.index;
+      return;
+    }
+
+    if ($steps.length === 0) return;
+
+    currentIndex = Math.min(Math.max(currentIndex, 0), $steps.length - 1);
+    selectedId = $steps[currentIndex]?.id;
   }
 
   setContext("carbon:ProgressIndicator", {
@@ -92,12 +131,25 @@
     change,
   });
 
-  $: steps.update((_) =>
-    _.map((step, i) => ({
-      ...step,
-      current: i === currentIndex,
-    })),
-  );
+  // Combined into one statement (rather than a separate syncSelection()
+  // block feeding this one) so the flag recompute always runs in the same
+  // pass right after syncSelection(), using the just-resolved currentIndex.
+  // Svelte skips re-invalidating `currentIndex` when syncSelection() (called
+  // from a different reactive statement) reassigns it to the same numeric
+  // value, which would otherwise leave stale `current` flags on removal.
+  // This also makes the recompute run on every steps add/remove (via
+  // `$stepsById`), not just when currentIndex itself changes.
+  $: {
+    if (selectedId !== undefined && $stepsById) {
+      syncSelection();
+    }
+    steps.update((_) =>
+      _.map((step, i) => ({
+        ...step,
+        current: i === currentIndex,
+      })),
+    );
+  }
   $: preventChangeOnClickStore.set(preventChangeOnClick);
 </script>
 

--- a/tests/ProgressIndicator/ProgressIndicator.test.ts
+++ b/tests/ProgressIndicator/ProgressIndicator.test.ts
@@ -4,6 +4,7 @@ import ProgressIndicator from "./ProgressIndicator.test.svelte";
 import ProgressIndicatorConditional from "./ProgressIndicatorConditional.test.svelte";
 import ProgressIndicatorIssue1249 from "./ProgressIndicatorIssue1249.test.svelte";
 import ProgressIndicatorReactive from "./ProgressIndicatorReactive.test.svelte";
+import ProgressIndicatorSelectedId from "./ProgressIndicatorSelectedId.test.svelte";
 import ProgressStepIconSlot from "./ProgressStepIconSlot.test.svelte";
 import ProgressStepStandalone from "./ProgressStepStandalone.test.svelte";
 
@@ -388,6 +389,32 @@ describe("ProgressIndicator", () => {
       await waitFor(() => {
         expect(listItems[2]).toHaveClass("bx--progress-step--complete");
       });
+    });
+  });
+
+  describe("selectedId", () => {
+    it("keeps selectedId on the same logical step when a prior step is removed", async () => {
+      render(ProgressIndicatorSelectedId, {
+        props: { selectedId: "step-b", showStepA: true },
+      });
+
+      let listItems = screen.getAllByRole("listitem");
+      expect(listItems[1]).toHaveTextContent("Step B");
+      expect(listItems[1]).toHaveClass("bx--progress-step--current");
+      expect(screen.getByTestId("selected-id")).toHaveTextContent("step-b");
+      expect(screen.getByTestId("current-index")).toHaveTextContent("1");
+
+      await user.click(screen.getByTestId("toggle-step-a"));
+
+      await waitFor(() => {
+        expect(screen.getAllByRole("listitem")).toHaveLength(2);
+      });
+
+      listItems = screen.getAllByRole("listitem");
+      expect(listItems[0]).toHaveTextContent("Step B");
+      expect(listItems[0]).toHaveClass("bx--progress-step--current");
+      expect(screen.getByTestId("selected-id")).toHaveTextContent("step-b");
+      expect(screen.getByTestId("current-index")).toHaveTextContent("0");
     });
   });
 });

--- a/tests/ProgressIndicator/ProgressIndicator.test.ts
+++ b/tests/ProgressIndicator/ProgressIndicator.test.ts
@@ -312,6 +312,36 @@ describe("ProgressIndicator", () => {
       await user.click(screen.getByText("Step 3"));
       expect(consoleLog).toHaveBeenLastCalledWith("change", 1);
     });
+
+    it("does not track the logical step across removal when selectedId is unset (documents existing index-based behavior)", async () => {
+      const { rerender } = render(ProgressIndicatorConditional, {
+        showOptional: true,
+        currentIndex: 2,
+      });
+
+      let listItems = screen.getAllByRole("listitem");
+      expect(listItems[2]).toHaveTextContent("Step 3");
+      expect(listItems[2]).toHaveClass("bx--progress-step--current");
+
+      rerender({ showOptional: false, currentIndex: 2 });
+
+      await waitFor(() => {
+        expect(screen.getAllByRole("listitem")).toHaveLength(2);
+      });
+
+      listItems = screen.getAllByRole("listitem");
+      // Step 3 shifted from index 2 to index 1, but currentIndex is still 2
+      // (no selectedId to re-anchor it) — by design, no step is marked
+      // "current" anymore. This is the pre-existing, unchanged behavior;
+      // selectedId is the opt-in fix for it.
+      expect(listItems[1]).toHaveTextContent("Step 3");
+      expect(listItems[1]).not.toHaveClass("bx--progress-step--current");
+      expect(
+        listItems.some((item) =>
+          item.classList.contains("bx--progress-step--current"),
+        ),
+      ).toBe(false);
+    });
   });
 
   it("should not throw when ProgressStep is rendered outside a ProgressIndicator", () => {
@@ -415,6 +445,46 @@ describe("ProgressIndicator", () => {
       expect(listItems[0]).toHaveClass("bx--progress-step--current");
       expect(screen.getByTestId("selected-id")).toHaveTextContent("step-b");
       expect(screen.getByTestId("current-index")).toHaveTextContent("0");
+    });
+
+    it("falls back when the selectedId step itself is removed", async () => {
+      render(ProgressIndicatorSelectedId, {
+        props: { selectedId: "step-a", showStepA: true },
+      });
+
+      await user.click(screen.getByTestId("toggle-step-a"));
+
+      await waitFor(() => {
+        expect(screen.getAllByRole("listitem")).toHaveLength(2);
+      });
+
+      const listItems = screen.getAllByRole("listitem");
+      expect(listItems[0]).toHaveTextContent("Step B");
+      expect(listItems[0]).toHaveClass("bx--progress-step--current");
+      expect(screen.getByTestId("selected-id")).toHaveTextContent("step-b");
+      expect(screen.getByTestId("current-index")).toHaveTextContent("0");
+    });
+
+    it("uses the index API when selectedId is unset", () => {
+      render(ProgressIndicatorSelectedId, {
+        props: { currentIndex: 2, selectedId: undefined },
+      });
+
+      const listItems = screen.getAllByRole("listitem");
+      expect(listItems[2]).toHaveClass("bx--progress-step--current");
+      expect(screen.getByTestId("current-index")).toHaveTextContent("2");
+      expect(screen.getByTestId("selected-id")).toHaveTextContent("");
+    });
+
+    it("lets selectedId win over currentIndex", () => {
+      render(ProgressIndicatorSelectedId, {
+        props: { currentIndex: 0, selectedId: "step-c" },
+      });
+
+      const listItems = screen.getAllByRole("listitem");
+      expect(listItems[2]).toHaveClass("bx--progress-step--current");
+      expect(screen.getByTestId("selected-id")).toHaveTextContent("step-c");
+      expect(screen.getByTestId("current-index")).toHaveTextContent("2");
     });
   });
 });

--- a/tests/ProgressIndicator/ProgressIndicatorSelectedId.test.svelte
+++ b/tests/ProgressIndicator/ProgressIndicatorSelectedId.test.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+  import ProgressIndicator from "carbon-components-svelte/ProgressIndicator/ProgressIndicator.svelte";
+  import ProgressStep from "carbon-components-svelte/ProgressIndicator/ProgressStep.svelte";
+
+  export let currentIndex = 0;
+  export let selectedId: string | undefined = undefined;
+  export let showStepA = true;
+</script>
+
+<ProgressIndicator
+  bind:currentIndex
+  bind:selectedId
+  on:change={({ detail }) => console.log("change", detail)}
+>
+  {#if showStepA}
+    <ProgressStep id="step-a" label="Step A" complete />
+  {/if}
+  <ProgressStep id="step-b" label="Step B" complete />
+  <ProgressStep id="step-c" label="Step C" />
+</ProgressIndicator>
+
+<button
+  type="button"
+  data-testid="toggle-step-a"
+  on:click={() => (showStepA = !showStepA)}
+>
+  Toggle Step A
+</button>
+<div data-testid="current-index">{currentIndex}</div>
+<div data-testid="selected-id">{selectedId ?? ""}</div>


### PR DESCRIPTION
Mirrors the Tabs/TabsVertical selectedId API so ProgressIndicator can
select by a stable step id instead of a numeric index, which
previously desynced from the intended step once steps were added or
removed at runtime.