### PR TITLE
chore: add delegated task prompts for cross-component gaps

### DIFF
--- a/agent-prompts/01-menu-max-height-combobutton-contextmenu.md
+++ b/agent-prompts/01-menu-max-height-combobutton-contextmenu.md
@@ -1,0 +1,113 @@
+# Add `maxHeight` to ComboButton and ContextMenu
+
+## Context
+
+This is `carbon-components-svelte`, a Svelte port of IBM's Carbon Design
+System. Read `CONTRIBUTING.md` at the repo root before starting — it defines
+the code style, JSDoc/typing, docs, and commit conventions this task must
+follow. This repo uses Bun (`bun <script>`, `bunx <bin>`), not npm/pnpm.
+
+Commit `046450f08` (`feat(menu): add maxHeight for scrollable menus`) added a
+`maxHeight` prop to `src/Menu/Menu.svelte`: a number is treated as pixels, a
+string as any CSS length; the menu caps its height and scrolls once items
+exceed it. `src/MenuButton/MenuButton.svelte` already forwards this prop to
+its internal `<Menu>` (see `export let maxHeight` around line 81 and `{maxHeight}`
+passed into `<Menu ...>` around line 216).
+
+Two sibling menu-trigger components do not yet offer this:
+
+- **`src/ComboButton/ComboButton.svelte`** wraps `<Menu>` directly (see the
+  `<Menu anchor={triggerRef} bind:open {direction} {intrinsicAlign}
+  intrinsicWidth={true} {size} {labelText} on:close><slot /></Menu>` block near
+  the end of the file). It has no `maxHeight` prop to forward.
+- **`src/ContextMenu/ContextMenu.svelte`** does **not** wrap `<Menu>` — it
+  implements its own independent `<ul role="menu">` with its own
+  `use:rovingFocus`, `use:dismiss`, and `class:bx--menu*` classes (see the
+  markup at the bottom of the file). It has no scroll-capping behavior at all.
+
+## What to implement
+
+### 1. ComboButton — forward `maxHeight` (mirror MenuButton exactly)
+
+- Add `export let maxHeight = undefined;` with the same JSDoc as
+  `MenuButton.svelte`'s `maxHeight` prop (copy the wording: "Specify the
+  maximum height of the menu. A number is treated as pixels; a string is used
+  as a CSS length. The menu scrolls once its items exceed the height." with
+  `@type {number | string}`). Place it in prop declaration order next to the
+  other menu-layout props (near `intrinsicAlign`/`size`), following the
+  existing prop order in the file.
+- Pass `{maxHeight}` into the `<Menu ...>` element, the same way MenuButton
+  does.
+
+### 2. ContextMenu — implement max-height + scroll directly
+
+ContextMenu doesn't compose `<Menu>`, so this isn't a one-line forward. Look
+at how `Menu.svelte` itself implements the behavior (search for `maxHeight` in
+`src/Menu/Menu.svelte`):
+
+- `$: maxHeightStyle = typeof maxHeight === "number" ? \`${maxHeight}px\` : maxHeight;`
+- `style:max-height={maxHeightStyle}` on the `<ul role="menu">`
+- `class:bx--menu--scrollable={!!maxHeight}` alongside the other `class:bx--menu*`
+  directives
+
+Add the same `maxHeight` prop (same JSDoc) and replicate this reactive
+statement plus the `style:max-height` / `class:bx--menu--scrollable` additions
+on ContextMenu's own `<ul>`. Use the `style:` directive per CONTRIBUTING's
+"Set dynamic styles with the `style:` directive, not inline `style` strings"
+rule — do not merge it into a template-literal `style` string. The
+`bx--menu--scrollable` class and its scroll CSS already exist in Carbon's v10
+styles (Menu.svelte relies on the same class with no extra SCSS partial), so
+no new `css/` partial should be needed — verify this by checking whether
+`bx--menu--scrollable` resolves visually once wired up (see Testing below).
+
+Follow CONTRIBUTING's prop-declaration ordering: component JSDoc first, then
+**all** `export let` props (each with its own JSDoc), then imports, then
+logic.
+
+## Docs
+
+Both `ComboButton.svx` and `ContextMenu.svx` live in
+`docs/src/pages/components/`. Model the new section on `Menu.svx`'s existing
+"Scrollable" section (`## Scrollable`, right after `## Menu items`):
+
+> Set `maxHeight` to cap the menu height and scroll the remaining items. A
+> number is treated as pixels; a string is used as any CSS length, such as
+> `"20rem"`. Keyboard navigation scrolls the focused item into view.
+
+- **ComboButton.svx**: add a `## Scrollable` section after `## Menu items`
+  (see the existing heading list in the file), with a short inline example
+  using several `MenuItem`s and `maxHeight="10rem"` (or similar). Follow
+  `docs/COMPONENT_DOCS_STYLE.md` prose rules (imperative, backticks only for
+  the prop/value being configured, no admonitions).
+- **ContextMenu.svx**: add a `## Scrollable` section after `## Context menu
+  options`. Use a framed example only if the demo needs script logic (it
+  likely doesn't for a static maxHeight demo — an inline example matching
+  Menu.svx's is enough).
+- Match the page's existing heading style: `## Basic` is never renamed, new
+  headings drop the redundant component-noun prefix, no `> [!NOTE]` blocks.
+
+## Commits
+
+Split into exactly two commits, per CONTRIBUTING's Conventional Commits rules
+(scope = lowercase-with-dashes component name):
+
+1. `feat(combo-button): forward maxHeight to menu` — code changes to
+   `ComboButton.svelte` and `ContextMenu.svelte` only (use two commits, one
+   per component, if that reads more cleanly — either is fine as long as docs
+   are separate).
+2. `docs(combo-button): document maxHeight` / `docs(context-menu): document
+   maxHeight` — the two `.svx` changes.
+
+## Validation (keep it minimal and scoped — do not run the full suite)
+
+```sh
+bunx biome check --write src/ComboButton src/ContextMenu docs/src/pages/components/ComboButton.svx docs/src/pages/components/ContextMenu.svx
+bun build:docs   # required after adding an exported prop (regenerates sveld types; the output is gitignored, don't commit it)
+bun run test ComboButton
+bun run test ContextMenu
+```
+
+Do not run `bun run lint`, `bun run test` (full suite), `bun test:e2e`, or the
+Svelte 3/4 compatibility workspaces — none of that is needed for this change.
+Do not hand-edit `src/**/*.svelte.d.ts` or `docs/src/COMPONENT_API.json`
+(generated, gitignored).

--- a/agent-prompts/02-listbox-menu-max-height.md
+++ b/agent-prompts/02-listbox-menu-max-height.md
@@ -1,0 +1,149 @@
+# Add a consumer-facing `maxHeight` override to Dropdown, ComboBox, and MultiSelect
+
+## Context
+
+This is `carbon-components-svelte`, a Svelte port of IBM's Carbon Design
+System. Read `CONTRIBUTING.md` at the repo root before starting — it defines
+the code style, JSDoc/typing, docs, and commit conventions this task must
+follow. This repo uses Bun (`bun <script>`, `bunx <bin>`), not npm/pnpm.
+
+CONTRIBUTING.md notes: "ComboBox, Dropdown, and MultiSelect share listbox
+behavior (virtualization, keyboard navigation, outside-click) through
+`src/utils/`. When you change shared menu behavior, apply and test the change
+in all three. The per-component wiring is parallel but not abstracted." This
+task changes shared menu-height behavior, so **all three components need the
+same change**, verified independently.
+
+Commit `046450f08` (`feat(menu): add maxHeight for scrollable menus`) gave
+`Menu` and `MenuButton` a `maxHeight` prop (number = px, string = any CSS
+length) that a consumer can set directly. `OverflowMenu` already had the same
+kind of prop (`src/OverflowMenu/OverflowMenu.svelte`, `export let maxHeight`
+around line 47, applied via `maxHeightStyle` and `class:bx--overflow-menu-options--scrollable={!!maxHeight}`).
+
+`src/ListBox/ListBoxMenu.svelte` (used internally by Dropdown, ComboBox, and
+MultiSelect) has **no `maxHeight` prop at all**. Today, Dropdown/ComboBox/MultiSelect
+each compute a *fixed, non-overridable* height cap from a shared util:
+
+```js
+// src/ListBox/list-box-utils.js
+export const MENU_MAX_HEIGHT = Object.freeze({ xs: "8.25rem", sm: "11rem", md: "13.75rem", lg: "16.5rem", xl: "16.5rem" });
+export function getMenuMaxHeight(size = "md") { return MENU_MAX_HEIGHT[size]; }
+```
+
+Each of the three components does:
+
+```js
+$: menuMaxHeight = getMenuMaxHeight(size);
+```
+
+and applies it only in specific cases — look at the identical block in all
+three (`src/Dropdown/Dropdown.svelte` ~line 711, `src/ComboBox/ComboBox.svelte`
+~line 881, `src/MultiSelect/MultiSelect.svelte` ~line 1057):
+
+```js
+style={effectivePortalMenu
+  ? `max-height: ${virtualConfig ? `${virtualConfig.containerHeight}px; overflow-y: auto` : menuMaxHeight};`
+  : virtualConfig
+    ? `max-height: ${virtualConfig.containerHeight}px; overflow-y: auto;`
+    : undefined}
+```
+
+Read this carefully before changing it: the size-based `menuMaxHeight` is
+**only** applied when the menu is portaled (`effectivePortalMenu`); a
+non-portaled, non-virtualized menu currently gets no `style` at all (`undefined`).
+When `virtualConfig` is set (virtualization active), the height comes from
+`virtualConfig.containerHeight` instead, regardless of portal state — virtualized
+lists compute their own scroll container height for row math and **must keep
+doing so**; do not let a consumer `maxHeight` override break virtualization's
+height/row-count calculations.
+
+## What to implement
+
+Goal: let a consumer pass an explicit `maxHeight` (number = px, string = any
+CSS length, same convention as `Menu`/`OverflowMenu`) to override the
+size-based default, without breaking virtualization or the existing
+portal/non-portal behavior.
+
+1. **`src/ListBox/ListBoxMenu.svelte`**: add a `maxHeight` prop
+   (`export let maxHeight = undefined;`) with the same JSDoc wording used in
+   `Menu.svelte`. Normalize it the same way Menu does
+   (`typeof maxHeight === "number" ? \`${maxHeight}px\` : maxHeight`) and apply
+   it via a `style:max-height` directive, merged sensibly with the existing
+   inline `style` used in the portal branch (`style="position: static; ..."`).
+   Decide whether ListBoxMenu should own the normalization or just accept an
+   already-normalized CSS-length string from its caller — either is
+   reasonable, but be consistent with how the three parent components already
+   compute `menuMaxHeight`.
+2. **Dropdown, ComboBox, MultiSelect**: add an `export let maxHeight = undefined;`
+   prop (same JSDoc as `Menu`'s), and use it to override `menuMaxHeight` when
+   set, e.g. `$: resolvedMenuMaxHeight = maxHeight ?? getMenuMaxHeight(size);`
+   — then use `resolvedMenuMaxHeight` everywhere `menuMaxHeight` was used.
+   Preserve the exact existing precedence: `virtualConfig`'s computed
+   `containerHeight` still wins over any height source when virtualization is
+   active (virtualization needs an accurate container height for its row math
+   — do not let a raw consumer `maxHeight` silently break that). If you think
+   a consumer-supplied `maxHeight` should apply *even under virtualization*,
+   that's a bigger design decision (feeding it into the virtualizer's height
+   calc) — do not attempt that; keep virtualization's own height authoritative
+   and treat `maxHeight` as only affecting the non-virtualized cap. Apply the
+   same change in **all three** components; do not let their implementations
+   drift from each other.
+3. Follow CONTRIBUTING's ordering rule: JSDoc tags first, then all
+   `export let` props (each with JSDoc), then imports, then logic. Use `$:`
+   reactive statements, not inline computation in markup.
+
+## Docs
+
+`Dropdown.svx`, `ComboBox.svx`, and `MultiSelect.svx` are in
+`docs/src/pages/components/`. Each already has a `## Virtualization` section
+with `### Custom threshold` / `### Custom overscan` subsections — that's the
+right neighborhood for a new `### Custom max height` (or similar) subsection,
+since it's the same "override the computed default" pattern. Alternatively, if
+`maxHeight` is meant to apply regardless of virtualization, place it as its
+own `## Max height` section modeled on `Menu.svx`'s `## Scrollable` section:
+
+> Set `maxHeight` to cap the menu height and scroll the remaining items. A
+> number is treated as pixels; a string is used as any CSS length, such as
+> `"20rem"`.
+
+Pick the placement that matches what you actually implemented. Update all
+three `.svx` files consistently — same heading, same wording, adapted sample
+data per page (each page already has its own item list in nearby examples;
+reuse those shapes per CONTRIBUTING's "Reuse the same sample data shapes as
+neighboring examples on that page").
+
+## Commits
+
+Split feature and docs, per CONTRIBUTING's Conventional Commits rules:
+
+1. `feat(list-box): add maxHeight override for dropdown, combo-box, and multi-select`
+   — the `ListBoxMenu.svelte` + Dropdown/ComboBox/MultiSelect code changes
+   together (they're one coherent shared-behavior change; CONTRIBUTING treats
+   the three as one unit for shared listbox behavior). If you'd rather split
+   per component for reviewability, use `feat(dropdown):`, `feat(combo-box):`,
+   `feat(multi-select):` as three commits — either is fine, just keep docs
+   separate.
+2. `docs(dropdown): document maxHeight override`, `docs(combo-box): document
+   maxHeight override`, `docs(multi-select): document maxHeight override` (or
+   one combined `docs: document listbox maxHeight override` if you documented
+   all three in one commit — CONTRIBUTING allows omitting scope "when the
+   change spans many areas").
+
+## Validation (keep it minimal and scoped — do not run the full suite)
+
+```sh
+bunx biome check --write src/ListBox src/Dropdown src/ComboBox src/MultiSelect docs/src/pages/components/Dropdown.svx docs/src/pages/components/ComboBox.svx docs/src/pages/components/MultiSelect.svx
+bun build:docs   # required after adding an exported prop; output is gitignored, don't commit it
+bun run test Dropdown
+bun run test ComboBox
+bun run test MultiSelect
+bun run test ListBox
+```
+
+Pay particular attention to any existing virtualization tests for these three
+components (search each `tests/<Component>/` folder for "virtual") — confirm
+they still pass unchanged, since that's the behavior most at risk here.
+
+Do not run `bun run lint`, `bun run test` (full suite), `bun test:e2e`, or the
+Svelte 3/4 compatibility workspaces. Do not hand-edit
+`src/**/*.svelte.d.ts` or `docs/src/COMPONENT_API.json` (generated, gitignored).

--- a/agent-prompts/03-dropdown-multiselect-form-name.md
+++ b/agent-prompts/03-dropdown-multiselect-form-name.md
@@ -1,0 +1,165 @@
+# Make Dropdown's and MultiSelect's `name` prop actually participate in form submission
+
+## Context
+
+This is `carbon-components-svelte`, a Svelte port of IBM's Carbon Design
+System. Read `CONTRIBUTING.md` at the repo root before starting — it defines
+the code style, JSDoc/typing, docs, and commit conventions this task must
+follow. This repo uses Bun (`bun <script>`, `bunx <bin>`), not npm/pnpm.
+
+Commit `9796644f8` (`feat(pin-code-input): add name with hidden form input`)
+gave `PinCodeInput` a pattern for custom (non-native-input) controls to
+participate in native HTML forms: when `name` is set, a real
+`<input type="hidden">` mirrors the component's assembled value, so the value
+shows up in `FormData`, plain `<form>` submission, and SvelteKit's
+`use:enhance`. From `src/PinCodeInput/PinCodeInput.svelte`:
+
+```svelte
+{#if name}
+  <input type="hidden" {name} {value} {required}>
+{/if}
+```
+
+(placed near the end of the template, after the visible segment inputs, and
+paired with `required={name ? undefined : required}` on the visible inputs so
+the browser doesn't validate individually-empty segments when a single hidden
+input already carries the real value).
+
+Two components already expose a `name` prop that looks like it should do the
+same thing, but currently doesn't work for form submission:
+
+### Dropdown (single selection)
+
+`src/Dropdown/Dropdown.svelte`: `export let name = undefined;` (~line 182,
+documented as "Specify a name attribute for the list box"). It's passed as
+`{name}` into `<ListBox ...>` (~line 551), but `ListBox` renders a plain
+`<div>` (`src/ListBox/ListBox.svelte`, `$$restProps` spread onto a `<div>`) —
+a `name` attribute on a `<div>` is inert; nothing is ever submitted.
+
+Dropdown's actual selection state is `selectedId` (`export let selectedId`,
+~line 51 — the id of the single selected item, resolved via
+`$: selectedItem = itemsById.get(selectedId);`).
+
+### MultiSelect (multi selection)
+
+`src/MultiSelect/MultiSelect.svelte`: `export let name = undefined;`
+(~line 197, "Specify a name attribute for the select"). It's only wired to a
+real `<input>` in the `filterable` branch of the template (~line 913, `{name}`
+on the filterable search `<input>`), and only when `filterable` is `true` —
+the library's default (`export let filterable = false;`, ~line 92). In the
+non-filterable default case, nothing carries `name` to any real form control
+at all. Even in the filterable case, the input's `value` binding holds the
+*filter text* the user typed, not the selected item IDs — so wiring `name`
+there was never form-submission-correct to begin with.
+
+MultiSelect's actual selection state is `selectedIds` (`export let
+selectedIds = [];`, ~line 48 — an array of selected item ids).
+
+## What to implement
+
+### Dropdown
+
+- Stop passing `{name}` to `<ListBox>` (it does nothing there today; leaving
+  it is misleading). Confirm nothing in `tests/Dropdown/` asserts a `name`
+  attribute on the ListBox wrapper element before removing it — if something
+  does, that test is asserting the current broken behavior and should be
+  updated as part of this change, not left in place.
+- Add a hidden input mirroring `selectedId`, gated the same way PinCodeInput
+  does it, placed after the closing `</ListBox>` tag (same section as the
+  fluid divider / validation / helper text blocks that already follow
+  `</ListBox>` around line 846):
+
+  ```svelte
+  {#if name}
+    <input type="hidden" {name} value={selectedId ?? ""}>
+  {/if}
+  ```
+
+  Match existing conventions: keep the `{#if name}` guard exactly like
+  PinCodeInput's, so the hidden input is absent entirely when no `name` is
+  set (a Dropdown used purely as a UI control, with no form, shouldn't grow a
+  stray `<input>`).
+
+### MultiSelect
+
+- The visible filterable `<input>`'s `{name}` binding (~line 913) is
+  semantically wrong (it would submit filter text, not selection) — remove it
+  from that input.
+- Add one hidden input per selected id, all sharing `name`, so the browser's
+  native multi-value submission semantics apply (this mirrors how a native
+  `<select multiple>` or a group of same-named checkboxes submits multiple
+  values under one key). Place it after the closing `</ListBox>` tag (same
+  section as the `{#if isFluid}` divider that already follows, around
+  line 1205):
+
+  ```svelte
+  {#if name}
+    {#each selectedIds as id (id)}
+      <input type="hidden" {name} value={id}>
+    {/each}
+  {/if}
+  ```
+
+  Follow CONTRIBUTING's keyed-`{#each}` rule (`(id)` as the key, since
+  `selectedIds` is already an array of unique ids).
+
+### Both
+
+- Update the `name` prop's JSDoc on both components to describe the actual
+  new behavior, modeled on PinCodeInput's wording: "Specify a name attribute
+  for native form participation. When set, a hidden input mirrors the
+  selected value(s)." Adjust singular/plural for Dropdown vs. MultiSelect.
+- Follow CONTRIBUTING's prop-ordering and JSDoc-first conventions; this is a
+  JSDoc *content* change on an existing prop (not adding a new prop), so it
+  still requires an API regeneration — see Validation below.
+
+## Docs
+
+Add a `## Form name` section to `Dropdown.svx` and `MultiSelect.svx` (in
+`docs/src/pages/components/`), modeled directly on `PinCodeInput.svx`'s
+existing section of the same name:
+
+> Set `name` so the assembled code participates in native form submission
+> (for example SvelteKit form actions and `FormData`). A hidden input mirrors
+> `value`.
+
+Adapt the wording to "the selected item" (Dropdown) / "the selected items"
+(MultiSelect) instead of "the assembled code," and show a short example using
+`<Form method="POST" action="?/submit">` + the component + a submit
+`<Button>`, matching PinCodeInput's example structure (inline is fine; use a
+framed example only if you need to demonstrate reading the submitted
+`FormData`). Place the new section near the other "Content"/"Selection"
+sections on each page — check each `.svx`'s existing heading list
+(`grep -n "^#" docs/src/pages/components/Dropdown.svx`) and slot it in
+logically rather than appending at the end, per CONTRIBUTING's section-order
+guidance.
+
+## Commits
+
+Split feature and docs, per CONTRIBUTING's Conventional Commits rules. Keep
+Dropdown and MultiSelect as separate commits since they're independent
+components with independent fixes:
+
+1. `feat(dropdown): make name participate in form submission`
+2. `feat(multi-select): make name participate in form submission`
+3. `docs(dropdown): document form name`
+4. `docs(multi-select): document form name`
+
+## Validation (keep it minimal and scoped — do not run the full suite)
+
+```sh
+bunx biome check --write src/Dropdown src/MultiSelect docs/src/pages/components/Dropdown.svx docs/src/pages/components/MultiSelect.svx
+bun build:docs   # required after retyping the `name` prop's JSDoc; output is gitignored, don't commit it
+bun run test Dropdown
+bun run test MultiSelect
+```
+
+Add a focused unit test per component asserting the hidden input's presence
+and `value` when `name` is set (and its absence when `name` is unset) — this
+is a real behavior fix, and CONTRIBUTING calls out "regressions for bugs you
+fix" as high-value coverage. Keep it to one or two cases per component, not
+an exhaustive matrix.
+
+Do not run `bun run lint`, `bun run test` (full suite), `bun test:e2e`, or the
+Svelte 3/4 compatibility workspaces. Do not hand-edit
+`src/**/*.svelte.d.ts` or `docs/src/COMPONENT_API.json` (generated, gitignored).

--- a/agent-prompts/04-structured-list-cell-max-width.md
+++ b/agent-prompts/04-structured-list-cell-max-width.md
@@ -1,0 +1,158 @@
+# Add `maxWidth` truncation + tooltip to StructuredListCell
+
+## Context
+
+This is `carbon-components-svelte`, a Svelte port of IBM's Carbon Design
+System. Read `CONTRIBUTING.md` at the repo root before starting — it defines
+the code style, JSDoc/typing, docs, custom-SCSS, and commit conventions this
+task must follow. This repo uses Bun (`bun <script>`, `bunx <bin>`), not
+npm/pnpm.
+
+Commit `e3d55fba5` (`feat(tag): add maxWidth truncation with tooltip`) gave
+`Tag` a `maxWidth` prop: CSS-truncates a long label with an ellipsis and
+shows the full text in a tooltip, but only when the text is actually
+overflowing (measured, not assumed). Read `src/Tag/Tag.svelte` in full before
+starting — the pattern is:
+
+- `export let maxWidth = undefined;` (number = px, string = any CSS length)
+- A `labelRef` bound to the text element, plus `isTruncated` /
+  `truncationLabel` state.
+- `measureTruncation()`: an `async` function that awaits `tick()`, then
+  compares `labelRef.scrollWidth > labelRef.clientWidth` to decide
+  `isTruncated`, and captures `labelRef.textContent?.trim()` as the tooltip
+  text. Guards a stale-measurement race with a `measureToken` counter (a
+  newer call invalidates an older in-flight one).
+- A reactive block re-runs `measureTruncation()` whenever `maxWidth` or the
+  values affecting rendered text/layout change (`void maxWidth; void filter; ...`
+  pattern to declare reactive dependencies explicitly, then call the function).
+- Markup: `style:max-width={maxWidth}` plus `class:bx--tag--truncate={maxWidth != null}`
+  on the truncatable element, and conditionally wraps the label in
+  `TooltipDefinition` (`portalTooltip`) when `isTruncated` — except for the
+  interactive-button variant, which uses the native `title` attribute instead
+  to avoid nesting a button inside a button.
+- SCSS: `css/_tag.scss` has a `tag-truncate` mixin (`.#{$prefix}--tag--truncate
+  { min-width: 0; }` plus overflow/ellipsis rules on the tooltip trigger),
+  registered via `@include exports("tag-truncate")`.
+
+`src/StructuredList/StructuredListCell.svelte` has an analogous but much
+weaker mechanism today — the entire file is short, read it before starting:
+
+```svelte
+<script>
+  export let head = false;
+  export let noWrap = false;
+  import { getContext } from "svelte";
+  const ctx = getContext("carbon:StructuredListWrapper");
+  const selection = ctx?.selection ?? false;
+</script>
+
+<div
+  role={selection ? undefined : head ? "columnheader" : "cell"}
+  class:bx--structured-list-th={head}
+  class:bx--structured-list-td={!head}
+  class:bx--structured-list-content--nowrap={noWrap}
+  {...$$restProps}
+  on:click on:mouseover on:mouseenter on:mouseleave
+>
+  <slot />
+</div>
+```
+
+`noWrap` only sets `white-space: nowrap` — no `overflow`, no `text-overflow`,
+and no tooltip escape hatch. Long cell content can currently bleed outside
+the cell with no way for a consumer to cap it and still let a user read the
+full value.
+
+## What to implement
+
+Add a `maxWidth` prop to `StructuredListCell`, following the Tag pattern:
+
+- `export let maxWidth = undefined;` (`@type {number | string}`, same
+  convention: number = px, string = any CSS length). JSDoc it the same way
+  Tag does: "Cap the cell width. When the content overflows, a tooltip shows
+  the full text." (adjust wording — Tag's is a label, this is generic cell
+  content behind a `<slot />`, so the tooltip text should be measured off the
+  cell's own rendered text, not a dedicated label prop).
+- Because content comes through a generic `<slot />` (not a fixed text prop
+  like Tag's `title`), measure the *outer element itself*
+  (`scrollWidth > clientWidth`) rather than a separate inner label element —
+  bind `ref` to the `<div>` and read `ref.textContent?.trim()` for the
+  tooltip text, same idea as Tag's `labelRef.textContent`.
+- Reuse Tag's `measureTruncation`-with-`tick()`-and-a-token-guard structure;
+  don't invent a different async pattern. Re-run the measurement reactively
+  when `maxWidth` changes (and, since slot content can change independently
+  of any prop on this component, also consider whether a `MutationObserver`
+  or a simpler re-measure-on-relevant-prop-change is sufficient — start with
+  the simpler `$:`-on-`maxWidth` approach Tag uses, and only reach for a
+  `MutationObserver` if slot content changing without any prop change turns
+  out to be a real gap worth covering; don't over-build this).
+- Setting `maxWidth` should imply `nowrap`-style layout (truncation requires
+  `white-space: nowrap` — reuse the existing `noWrap` prop's class internally
+  when `maxWidth` is set, or make `class:bx--structured-list-content--nowrap`
+  fire on `noWrap || maxWidth != null` — pick whichever reads more clearly in
+  context, but don't require callers to redundantly pass both `noWrap` and
+  `maxWidth`).
+- Add a new SCSS partial `css/_structured-list.scss` (this component doesn't
+  have one yet — check `ls css/` to confirm) modeled exactly on
+  `css/_tag.scss`'s `tag-truncate` mixin: token-only, `$prefix`-scoped,
+  wrapped in `@include exports("structured-list-truncate")`, with SassDoc
+  comments (`/// @access private`, `/// @group components`). It needs
+  `overflow: hidden; text-overflow: ellipsis; white-space: nowrap;` on the
+  truncated cell, plus whatever tooltip-trigger overflow rules are needed if
+  you reuse `TooltipDefinition` (see Tag's `.#{$prefix}--tag__label-tooltip`
+  rules for the trigger-sizing problem you'll likely hit — a tooltip trigger
+  wrapping arbitrary slot content needs `display: block; min-width: 0;
+  max-width: 100%;` the same way Tag's does). Do not use `:has()` (exceeds the
+  project's browser baseline). Register the new partial's `@import` in all
+  six theme entry files (`css/all.scss`, `white.scss`, `g10.scss`, `g80.scss`,
+  `g90.scss`, `g100.scss`), same import order in each, per CONTRIBUTING's
+  "Registering a partial" section.
+- Follow CONTRIBUTING's prop-ordering rule (JSDoc block, then all `export
+  let` props with JSDoc, then imports, then logic).
+
+## Docs
+
+`docs/src/pages/components/StructuredList.svx` currently has `## Basic`,
+`## Layout` (`### Condensed`, `### Flush`), `## Selection` (`### Single`,
+`### Custom selection icon`, `### Multiple`), `## Skeleton`. Add a new
+section for this feature — place it as its own `## Truncation` section (or as
+a `###` child under `## Layout` if you judge the content-overflow behavior
+fits better there as a layout concern; check CONTRIBUTING's "typical section
+order" — core variants/layout come before feature sections). Model the prose
+and example tightly on `Tag.svx`'s existing `### Max width` section:
+
+> Set `maxWidth` to a CSS length to ellipsis long content. A tooltip with the
+> full text appears only when the content is truncated. Accepts any valid CSS
+> length, including `rem`, `px`, `ch`, and `%`.
+
+Follow `docs/COMPONENT_DOCS_STYLE.md` and CONTRIBUTING's SVX gotchas (wrap
+object literals in backticks, no admonitions, `<DocKbd>` for keys if any come
+up — unlikely here).
+
+## Commits
+
+1. `feat(structured-list-cell): add maxWidth truncation with tooltip` — the
+   component change and the new `css/_structured-list.scss` partial +
+   6-file registration together (the SCSS is inseparable from the feature).
+2. `docs(structured-list-cell): document maxWidth`
+
+## Validation (keep it minimal and scoped — do not run the full suite)
+
+```sh
+bunx biome check --write src/StructuredList css/_structured-list.scss css/all.scss css/white.scss css/g10.scss css/g80.scss css/g90.scss css/g100.scss docs/src/pages/components/StructuredList.svx
+bun build:docs   # required after adding an exported prop; output is gitignored, don't commit it
+bun build:css    # required after editing any .scss under css/ — compiled CSS is gitignored but required at runtime
+bun run test StructuredList
+```
+
+Add a focused unit test asserting: no truncation markup/tooltip when
+`maxWidth` is unset (default behavior unchanged), and that setting a very
+small `maxWidth` against long text triggers the truncated state (you may need
+to mock or stub `scrollWidth`/`clientWidth` in jsdom, since jsdom doesn't lay
+out text — check how `Tag.test.ts` handles this exact measurement and mirror
+its approach rather than inventing a new one).
+
+Do not run `bun run lint`, `bun run test` (full suite), `bun test:e2e`, or the
+Svelte 3/4 compatibility workspaces. Do not hand-edit
+`src/**/*.svelte.d.ts` or `docs/src/COMPONENT_API.json` (generated, gitignored).
+Do not commit generated `css/*.css` (gitignored) — only the `.scss` source.

--- a/agent-prompts/05-multiselect-shift-click-selection.md
+++ b/agent-prompts/05-multiselect-shift-click-selection.md
@@ -1,0 +1,192 @@
+# Add shift+click range selection to MultiSelect
+
+## Context
+
+This is `carbon-components-svelte`, a Svelte port of IBM's Carbon Design
+System. Read `CONTRIBUTING.md` at the repo root before starting — it defines
+the code style, JSDoc/typing, docs, and commit conventions this task must
+follow. This repo uses Bun (`bun <script>`, `bunx <bin>`), not npm/pnpm.
+
+Commit `54aaa7d6d` (`feat(data-table): support shift+click selection`) added
+range multi-selection to `DataTable`: holding <kbd>Shift</kbd> while clicking
+a row checkbox selects (or deselects) every row between it and the last
+row clicked. `TreeView` already has an equivalent shift/ctrl-click range
+implementation in its checkbox selection mode. `MultiSelect` — the
+component most similar to DataTable's checkbox-list selection — has no
+`shiftKey` handling anywhere in `src/MultiSelect/MultiSelect.svelte`; its
+`selectItem` function only ever toggles one item at a time.
+
+### The DataTable pattern to mirror
+
+Read `src/DataTable/DataTable.svelte` around these three spots before
+starting:
+
+```js
+// state: the id of the last row explicitly clicked, used as the range anchor
+let lastSelectedRowId = null;
+
+// reset alongside the rest of selection state
+function resetSelectedRowIds() {
+  selectAll = false;
+  selectedRowIds = [];
+  lastSelectedRowId = null;
+}
+
+/**
+ * Apply `checked` to every selectable row between the anchor row and `targetIndex`
+ * (inclusive). Returns `false` if the anchor row is no longer present (for example,
+ * filtered out), so the caller can fall back to a single toggle.
+ */
+function selectRowRange(targetIndex, checked) {
+  const anchorIndex = rowsToVirtualize.findIndex((row) => row.id === lastSelectedRowId);
+  if (anchorIndex === -1) return false;
+
+  const start = Math.min(anchorIndex, targetIndex);
+  const end = Math.max(anchorIndex, targetIndex);
+  const next = new Set(selectedRowIds);
+  for (const row of rowsToVirtualize.slice(start, end + 1)) {
+    if (nonSelectableRowIdsSet.has(row.id)) continue;
+    if (checked) next.add(row.id); else next.delete(row.id);
+  }
+  selectedRowIds = [...next];
+  return true;
+}
+```
+
+And the click handler that uses it (`InlineCheckbox`'s `on:click`, in the
+selectable-column `<td>`):
+
+```js
+on:click={(event) => {
+  const checked = event.target.checked;
+  const usedRange = event.shiftKey && lastSelectedRowId !== null && selectRowRange(actualIndex, checked);
+  if (!usedRange) {
+    const next = new Set(selectedRowIds);
+    if (checked) next.add(row.id); else next.delete(row.id);
+    selectedRowIds = [...next];
+  }
+  lastSelectedRowId = row.id;
+  dispatch("click:row--select", { row, selected: checked });
+}}
+```
+
+The key ideas: track an anchor id (not index — indices shift as data
+reorders/filters), find the anchor's *current* position in whatever list is
+currently rendered, range-select between that position and the clicked
+item's position, skip non-selectable items in the range, and always update
+the anchor to the just-clicked item regardless of whether a range was applied.
+
+### Where this plugs into MultiSelect
+
+`src/MultiSelect/MultiSelect.svelte`:
+
+- `selectItem(item)` (~line 367) is the single-item toggle logic today. It
+  mutates `sortedItems` in place (`sortedItems[itemIndex] = { ...item, checked:
+  !item.checked }; sortedItems = [...sortedItems];`), handles the `isSelectAll`
+  pseudo-item specially, and recomputes `selectedIds` either immediately (when
+  `selectionFeedback === "top"`) or via a length-diff check in `afterUpdate`
+  further down. Read the whole function and the `afterUpdate` block below it
+  before changing anything — the `selectedIds`/`checked`-length-diff
+  bookkeeping is order-sensitive and easy to break.
+- The primary mouse click path is the `on:click` handler on `<ListBoxMenuItem>`
+  around line 1087:
+
+  ```js
+  on:click={(event) => {
+    if (itemDisabled) { event.stopPropagation(); return; }
+    event.preventDefault();
+    selectItem(item);
+    if (filterable) inputRef?.focus(); else fieldRef?.focus();
+  }}
+  ```
+
+  `event` (with `.shiftKey`) is available here. The item's position in the
+  currently-rendered list is `actualIndex` (`{@const actualIndex = virtualData.startIndex + index}`
+  a few lines above, inside the `{#each itemsToRender as item, index (item.id)}` block) —
+  this is the non-virtualized-list equivalent of DataTable's `actualIndex`/`rowsToVirtualize`.
+  Confirm whether `itemsToRender` or `sortedItems` is the correct list to
+  index range boundaries against (they may differ when filtering is active)
+  — use whichever one `actualIndex` is actually indexing into, the same way
+  DataTable ranges over `rowsToVirtualize` because that's what `actualIndex`
+  indexes into there.
+
+## What to implement
+
+1. Add anchor-tracking state analogous to `lastSelectedRowId`, for example
+   `let lastSelectedItemId = null;`, reset it wherever selection is reset
+   entirely (the places that already do `selectedIds = [];` — search for
+   that string in the file; there are several, including select-all-clear and
+   read-only guards).
+2. Add a `selectItemRange(targetIndex, checked)`-style helper mirroring
+   `selectRowRange`, adapted to MultiSelect's `sortedItems`-with-`.checked`
+   data model instead of DataTable's `selectedRowIds` Set. Skip disabled
+   items and the `isSelectAll` pseudo-item in the range the same way
+   DataTable skips `nonSelectableRowIdsSet` members.
+3. Wire `event.shiftKey` into the click handler at ~line 1087: when shift is
+   held and an anchor exists, apply the range instead of calling
+   `selectItem(item)`'s single-toggle path; otherwise fall back to the
+   existing single-toggle behavior. Update the anchor id to `item.id` after
+   every click, in or out of a range. Make sure the existing
+   `selectedIds`/`selectionFeedback` bookkeeping that currently lives inside
+   `selectItem` (and the `afterUpdate` diff below it) still fires correctly
+   for a range selection — don't let range-selected items silently fail to
+   propagate into `selectedIds` or skip the `on:select` dispatch.
+4. Only wire this into the primary mouse-click path (~line 1087). Do not
+   extend it to the keyboard-Enter path (~line 1001) or the "select highlighted
+   item" path (~line 853) — shift+click is a pointer-specific interaction
+   pattern, matching DataTable's scope.
+5. Follow CONTRIBUTING's conventions: `Set`/`Map` for membership checks where
+   it matters, keep the helper as a plain named `function` (not inline in
+   markup), and don't clobber the exported `selectedIds` prop directly from
+   inside the range helper if the existing code path routes through
+   `sortedItems` first — match whatever ordering the existing `selectItem`
+   function already uses so behavior stays consistent between a single click
+   and a range click.
+
+## Docs
+
+`docs/src/pages/components/MultiSelect.svx` has a `## Selection` section
+(`### Initial selection`, `### Selection feedback`, `### Maximum selection`,
+`### Select all`, `### Sorted items`, ...). DataTable documented its
+equivalent feature as a single added sentence inside its existing `###
+Checkbox` subsection, not a new heading:
+
+> Set `selectable` to `true` for multi-select. Bind selectedRowIds to track
+> selections. Use inputName to customize checkbox names. Hold
+> <DocKbd label="Shift" /> while clicking a checkbox to select every row
+> between it and the last row clicked.
+
+Follow the same approach here: add one sentence to the intro of
+MultiSelect.svx's `## Selection` section (or to whichever existing example is
+the natural checkbox-selection example) using
+`<DocKbd label="Shift" />` (mdsvex auto-imports it — no manual import), for
+example: "Hold <DocKbd label="Shift" /> while clicking an item to select
+every item between it and the last item clicked." Do not add a new heading
+or a new example file for this — it's a modifier on existing selection
+behavior, matching how DataTable documented it.
+
+## Commits
+
+1. `feat(multi-select): support shift+click range selection`
+2. `docs(multi-select): document shift+click range selection`
+
+## Validation (keep it minimal and scoped — do not run the full suite)
+
+```sh
+bunx biome check --write src/MultiSelect docs/src/pages/components/MultiSelect.svx
+bun run test MultiSelect
+```
+
+No `bun build:docs` needed here unless you also add/change a prop's JSDoc —
+this is pure interaction-handling logic with no new public API surface. Add a
+focused unit test: click one item, shift+click a later item, assert every
+item in between is now checked and reflected in `selectedIds`; and a second
+case confirming shift+click with no prior click (no anchor) falls back to a
+plain single-item toggle. Look at how DataTable's own shift+click tests are
+written (`tests/DataTable/`, search for "shift") and mirror the interaction
+style (the shared `user` helper from `tests/utils/user.ts`, `getByRole`
+queries) rather than reaching for `data-testid`.
+
+Do not run `bun run lint`, `bun run test` (full suite), `bun test:e2e`, or the
+Svelte 3/4 compatibility workspaces. Do not hand-edit
+`src/**/*.svelte.d.ts` or `docs/src/COMPONENT_API.json` (generated, gitignored).


### PR DESCRIPTION
Closed and emptied — the added files were internal planning prompts
that shouldn't have been opened as a PR against this repo. Removed
in the latest commit.