### PR TITLE
fix(tag)!: remove forwarded `on:click` event from non-interactive tags

### DIFF
--- a/src/Tag/Tag.svelte
+++ b/src/Tag/Tag.svelte
@@ -342,7 +342,6 @@
     class:bx--tag--outline={type === "outline"}
     {...$$restProps}
     style:max-width={maxWidth}
-
     on:mouseover
     on:mouseenter
     on:mouseleave

--- a/src/Tag/Tag.svelte
+++ b/src/Tag/Tag.svelte
@@ -342,7 +342,7 @@
     class:bx--tag--outline={type === "outline"}
     {...$$restProps}
     style:max-width={maxWidth}
-    on:click
+
     on:mouseover
     on:mouseenter
     on:mouseleave


### PR DESCRIPTION
Currently, screen readers like NVDA announces non-clickable tags as "Clickable" because of click event present in the else block. Removing the event listener should fix it for ADA compliance. 