### PR TITLE
chore(utils): extract pooled window listener primitives from dismiss

### DIFF
--- a/src/Portal/FloatingPortal.svelte
+++ b/src/Portal/FloatingPortal.svelte
@@ -118,6 +118,7 @@
   import { floatingPosition } from "../utils/floatingPosition.js";
   import { getScrollableAncestors } from "../utils/getScrollableAncestors.js";
   import { rafThrottle } from "../utils/rafThrottle.js";
+  import { addPooledListener } from "../utils/windowListenerPool.js";
   import Portal from "./Portal.svelte";
 
   let mounted = true;
@@ -137,12 +138,43 @@
     }
   }
 
+  // Pooled `window` scroll/resize listeners: many `FloatingPortal` instances
+  // (every Tooltip, ListBoxMenu, Menu, ...) can be mounted at once while only
+  // a few are ever open, so each instance shares one real window listener
+  // per event type instead of registering its own for its whole mount
+  // lifetime.
+  /** @type {(() => void) | null} */
+  let unlistenWindowScroll = null;
+  /** @type {(() => void) | null} */
+  let unlistenWindowResize = null;
+
+  function addWindowListeners() {
+    if (!unlistenWindowScroll) {
+      unlistenWindowScroll = addPooledListener("scroll", scheduleUpdate, {
+        passive: true,
+      });
+    }
+    if (!unlistenWindowResize) {
+      unlistenWindowResize = addPooledListener("resize", scheduleUpdate, {
+        passive: true,
+      });
+    }
+  }
+
+  function removeWindowListeners() {
+    unlistenWindowScroll?.();
+    unlistenWindowScroll = null;
+    unlistenWindowResize?.();
+    unlistenWindowResize = null;
+  }
+
   onMount(() => {
     return () => {
       mounted = false;
       unobserveAnchor();
       unobserveFloating();
       removeScrollListeners();
+      removeWindowListeners();
       scheduleUpdate.cancel();
     };
   });
@@ -299,7 +331,10 @@
     .filter(Boolean)
     .join("; ");
 
-  $: if (!open) {
+  $: if (open) {
+    addWindowListeners();
+  } else {
+    removeWindowListeners();
     unobserveAnchor();
     unobserveFloating();
     removeScrollListeners();
@@ -335,11 +370,6 @@
     });
   }
 </script>
-
-<svelte:window
-  on:scroll|passive={open ? scheduleUpdate : undefined}
-  on:resize|passive={open ? scheduleUpdate : undefined}
-/>
 
 {#if open}
   <Portal

--- a/src/utils/dismiss.js
+++ b/src/utils/dismiss.js
@@ -1,82 +1,15 @@
 // @ts-check
 
+import {
+  poolKey,
+  registerConsumer,
+  unregisterConsumer,
+} from "./windowListenerPool.js";
+
 /**
- * One `window` listener per `(type, options)`. Handlers register as consumers;
- * the first consumer calls `addEventListener`, the last calls `removeEventListener`.
- *
  * @typedef {{ handler: (event: Event) => void }} Consumer
- * @typedef {{
- *   type: string,
- *   options: boolean | AddEventListenerOptions | undefined,
- *   listener: (event: Event) => void,
- *   consumers: Set<Consumer>,
- * }} Pool
- *
- * @type {Map<string, Pool>}
+ * @typedef {import("./windowListenerPool.js").Pool} Pool
  */
-const pools = new Map();
-
-/**
- * Pool key from type plus `capture`, `passive`, and `once`. Those are the only
- * options that change how the listener runs.
- *
- * @param {string} type
- * @param {boolean | AddEventListenerOptions | undefined} options
- * @returns {string}
- */
-function poolKey(type, options) {
-  let capture = false;
-  let passive = false;
-  let once = false;
-  if (typeof options === "boolean") {
-    capture = options;
-  } else if (options) {
-    capture = !!options.capture;
-    passive = !!options.passive;
-    once = !!options.once;
-  }
-  return `${type} ${capture ? 1 : 0}${passive ? 1 : 0}${once ? 1 : 0}`;
-}
-
-/**
- * Add a consumer to the pool for `(type, options)`. Creates the pool on first use.
- *
- * @param {{ type: string, handler: (event: Event) => void, options: boolean | AddEventListenerOptions | undefined }} spec
- * @returns {{ key: string, pool: Pool, consumer: Consumer }}
- */
-function registerConsumer(spec) {
-  const key = poolKey(spec.type, spec.options);
-  let pool = pools.get(key);
-  if (!pool) {
-    const consumers = /** @type {Set<Consumer>} */ (new Set());
-    const listener = (/** @type {Event} */ event) => {
-      // Copy before iterating. Handlers may add or remove consumers mid-dispatch;
-      // removed consumers should not run, same as native listeners.
-      for (const consumer of [...consumers]) {
-        if (consumers.has(consumer)) consumer.handler(event);
-      }
-    };
-    pool = { type: spec.type, options: spec.options, listener, consumers };
-    pools.set(key, pool);
-    window.addEventListener(spec.type, listener, spec.options);
-  }
-  const consumer = { handler: spec.handler };
-  pool.consumers.add(consumer);
-  return { key, pool, consumer };
-}
-
-/**
- * Remove a consumer. Drops the window listener when the pool is empty.
- *
- * @param {{ key: string, pool: Pool, consumer: Consumer }} entry
- */
-function unregisterConsumer({ key, pool, consumer }) {
-  pool.consumers.delete(consumer);
-  if (pool.consumers.size === 0) {
-    window.removeEventListener(pool.type, pool.listener, pool.options);
-    pools.delete(key);
-  }
-}
 
 /**
  * Svelte action: `window` listeners while `enabled` is true.

--- a/src/utils/windowListenerPool.d.ts
+++ b/src/utils/windowListenerPool.d.ts
@@ -1,0 +1,44 @@
+/** A single consumer of a pooled `window` listener. */
+export interface Consumer {
+  handler: (event: Event) => void;
+}
+
+/** A pooled `window` listener shared by one or more consumers. */
+export interface Pool {
+  type: string;
+  options: boolean | AddEventListenerOptions | undefined;
+  listener: (event: Event) => void;
+  consumers: Set<Consumer>;
+}
+
+/** Pool key from `type` plus the `capture`/`passive`/`once` options. */
+export function poolKey(
+  type: string,
+  options: boolean | AddEventListenerOptions | undefined,
+): string;
+
+/** Add a consumer to the pool for `(type, options)`. Creates the pool on first use. */
+export function registerConsumer(spec: {
+  type: string;
+  handler: (event: Event) => void;
+  options: boolean | AddEventListenerOptions | undefined;
+}): { key: string; pool: Pool; consumer: Consumer };
+
+/** Remove a consumer. Drops the window listener when the pool is empty. */
+export function unregisterConsumer(entry: {
+  key: string;
+  pool: Pool;
+  consumer: Consumer;
+}): void;
+
+/**
+ * Add a pooled `window` listener, registered immediately (no deferral).
+ * Consumers sharing the same `(type, options)` share one real
+ * `addEventListener` call; the underlying listener is removed once the last
+ * consumer unregisters.
+ */
+export function addPooledListener(
+  type: string,
+  handler: (event: Event) => void,
+  options?: boolean | AddEventListenerOptions,
+): () => void;

--- a/src/utils/windowListenerPool.js
+++ b/src/utils/windowListenerPool.js
@@ -1,0 +1,98 @@
+// @ts-check
+
+/**
+ * One `window` listener per `(type, options)`. Callers register as consumers;
+ * the first consumer calls `addEventListener`, the last calls
+ * `removeEventListener`. Shared by the `dismiss` action (outside-click/escape)
+ * and any other code that wants a `window` listener without adding one per
+ * component instance (e.g. `FloatingPortal`'s scroll/resize reposition).
+ *
+ * @typedef {{ handler: (event: Event) => void }} Consumer
+ * @typedef {{
+ *   type: string,
+ *   options: boolean | AddEventListenerOptions | undefined,
+ *   listener: (event: Event) => void,
+ *   consumers: Set<Consumer>,
+ * }} Pool
+ *
+ * @type {Map<string, Pool>}
+ */
+const pools = new Map();
+
+/**
+ * Pool key from type plus `capture`, `passive`, and `once`. Those are the only
+ * options that change how the listener runs.
+ *
+ * @param {string} type
+ * @param {boolean | AddEventListenerOptions | undefined} options
+ * @returns {string}
+ */
+export function poolKey(type, options) {
+  let capture = false;
+  let passive = false;
+  let once = false;
+  if (typeof options === "boolean") {
+    capture = options;
+  } else if (options) {
+    capture = !!options.capture;
+    passive = !!options.passive;
+    once = !!options.once;
+  }
+  return `${type} ${capture ? 1 : 0}${passive ? 1 : 0}${once ? 1 : 0}`;
+}
+
+/**
+ * Add a consumer to the pool for `(type, options)`. Creates the pool on first use.
+ *
+ * @param {{ type: string, handler: (event: Event) => void, options: boolean | AddEventListenerOptions | undefined }} spec
+ * @returns {{ key: string, pool: Pool, consumer: Consumer }}
+ */
+export function registerConsumer(spec) {
+  const key = poolKey(spec.type, spec.options);
+  let pool = pools.get(key);
+  if (!pool) {
+    const consumers = /** @type {Set<Consumer>} */ (new Set());
+    const listener = (/** @type {Event} */ event) => {
+      // Copy before iterating. Handlers may add or remove consumers mid-dispatch;
+      // removed consumers should not run, same as native listeners.
+      for (const consumer of [...consumers]) {
+        if (consumers.has(consumer)) consumer.handler(event);
+      }
+    };
+    pool = { type: spec.type, options: spec.options, listener, consumers };
+    pools.set(key, pool);
+    window.addEventListener(spec.type, listener, spec.options);
+  }
+  const consumer = { handler: spec.handler };
+  pool.consumers.add(consumer);
+  return { key, pool, consumer };
+}
+
+/**
+ * Remove a consumer. Drops the window listener when the pool is empty.
+ *
+ * @param {{ key: string, pool: Pool, consumer: Consumer }} entry
+ */
+export function unregisterConsumer({ key, pool, consumer }) {
+  pool.consumers.delete(consumer);
+  if (pool.consumers.size === 0) {
+    window.removeEventListener(pool.type, pool.listener, pool.options);
+    pools.delete(key);
+  }
+}
+
+/**
+ * Add a pooled `window` listener, registered immediately (no deferral).
+ * Consumers sharing the same `(type, options)` share one real
+ * `addEventListener` call; the underlying listener is removed once the last
+ * consumer unregisters. SSR-unsafe: call only where `window` exists.
+ *
+ * @param {string} type
+ * @param {(event: Event) => void} handler
+ * @param {boolean | AddEventListenerOptions} [options]
+ * @returns {() => void} Call to unregister.
+ */
+export function addPooledListener(type, handler, options) {
+  const entry = registerConsumer({ type, handler, options });
+  return () => unregisterConsumer(entry);
+}

--- a/tests/Portal/FloatingPortal.test.ts
+++ b/tests/Portal/FloatingPortal.test.ts
@@ -491,6 +491,66 @@ describe("FloatingPortal", () => {
     });
   });
 
+  describe("window listener pooling", () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it("shares one window scroll/resize listener across multiple open instances", async () => {
+      const addSpy = vi.spyOn(window, "addEventListener");
+
+      render(FloatingPortalTest, { props: { open: true } });
+      await screen.findByText("Floating content");
+      render(FloatingPortalTest, { props: { open: true } });
+      await screen.findAllByText("Floating content");
+
+      const scrollAdds = addSpy.mock.calls.filter(
+        ([event]) => event === "scroll",
+      ).length;
+      const resizeAdds = addSpy.mock.calls.filter(
+        ([event]) => event === "resize",
+      ).length;
+      expect(scrollAdds).toBe(1);
+      expect(resizeAdds).toBe(1);
+    });
+
+    it("does not hold a window scroll/resize listener while closed", async () => {
+      const addSpy = vi.spyOn(window, "addEventListener");
+
+      render(FloatingPortalTest, { props: { open: false } });
+      await tick();
+
+      const scrollAdds = addSpy.mock.calls.filter(
+        ([event]) => event === "scroll",
+      ).length;
+      const resizeAdds = addSpy.mock.calls.filter(
+        ([event]) => event === "resize",
+      ).length;
+      expect(scrollAdds).toBe(0);
+      expect(resizeAdds).toBe(0);
+    });
+
+    it("removes the pooled window listener once the last open instance unmounts", async () => {
+      const removeSpy = vi.spyOn(window, "removeEventListener");
+
+      const { unmount } = render(FloatingPortalTest, {
+        props: { open: true },
+      });
+      await screen.findByText("Floating content");
+
+      unmount();
+
+      const scrollRemoves = removeSpy.mock.calls.filter(
+        ([event]) => event === "scroll",
+      ).length;
+      const resizeRemoves = removeSpy.mock.calls.filter(
+        ([event]) => event === "resize",
+      ).length;
+      expect(scrollRemoves).toBe(1);
+      expect(resizeRemoves).toBe(1);
+    });
+  });
+
   describe("scrollable ancestor tracking", () => {
     afterEach(() => {
       vi.restoreAllMocks();

--- a/tests/utils/windowListenerPool.test.ts
+++ b/tests/utils/windowListenerPool.test.ts
@@ -1,0 +1,59 @@
+import { addPooledListener } from "../../src/utils/windowListenerPool.js";
+
+describe("addPooledListener", () => {
+  test("registers immediately and shares one listener across consumers", () => {
+    const addSpy = vi.spyOn(window, "addEventListener");
+    const a = vi.fn();
+    const b = vi.fn();
+
+    const unlistenA = addPooledListener("scroll", a, { passive: true });
+    const unlistenB = addPooledListener("scroll", b, { passive: true });
+
+    expect(addSpy.mock.calls.filter((c) => c[0] === "scroll").length).toBe(1);
+
+    window.dispatchEvent(new Event("scroll"));
+    expect(a).toHaveBeenCalledTimes(1);
+    expect(b).toHaveBeenCalledTimes(1);
+
+    unlistenA();
+    unlistenB();
+    addSpy.mockRestore();
+  });
+
+  test("removes the real listener only after the last consumer unregisters", () => {
+    const removeSpy = vi.spyOn(window, "removeEventListener");
+    const handler = vi.fn();
+
+    const unlistenA = addPooledListener("resize", handler);
+    const unlistenB = addPooledListener("resize", handler);
+
+    unlistenA();
+    expect(removeSpy.mock.calls.filter((c) => c[0] === "resize").length).toBe(
+      0,
+    );
+
+    unlistenB();
+    expect(removeSpy.mock.calls.filter((c) => c[0] === "resize").length).toBe(
+      1,
+    );
+
+    removeSpy.mockRestore();
+  });
+
+  test("keeps distinct options in separate pools", () => {
+    const addSpy = vi.spyOn(window, "addEventListener");
+    const bubble = vi.fn();
+    const capture = vi.fn();
+
+    const unlistenBubble = addPooledListener("click", bubble);
+    const unlistenCapture = addPooledListener("click", capture, {
+      capture: true,
+    });
+
+    expect(addSpy.mock.calls.filter((c) => c[0] === "click").length).toBe(2);
+
+    unlistenBubble();
+    unlistenCapture();
+    addSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
dismiss.js already pooled window listeners for outside-click and
escape handling; this pulls that primitive into its own module so
FloatingPortal can reuse it for scroll/resize too. FloatingPortal
mounts for the whole life of its parent (OverflowMenu, Tooltip,
Toggletip, Menu, ListBoxMenu, PortalTooltip), not just while open,
since only SearchMenu unmounts it on close. A table with an overflow
menu or tooltip per row was carrying one permanent scroll and one
permanent resize listener per row even when nothing was ever
expanded.

## Benchmark

Mounted 10 FloatingPortal instances (3 open, 7 closed) and spied on
`window.addEventListener`. Before: 20 real listeners (2 per
instance), present regardless of open state. After: at most 2 total,
shared across every open instance, and 0 when none are open. The
gain scales with mounted count, not concurrently-open count, so it
matters most on a table with an overflow menu or tooltip per row
rather than a handful of components on one screen.
