### PR TITLE
feat(combo-button): forward maxHeight to menu

### DIFF
--- a/docs/src/pages/components/ComboButton.svx
+++ b/docs/src/pages/components/ComboButton.svx
@@ -99,6 +99,18 @@ Set `disabled` to `true` to disable both the primary action and trigger buttons.
   <MenuItem on:click={() => console.log("Save as")}>Save as</MenuItem>
 </ComboButton>
 
+## Scrollable
+
+Set `maxHeight` to cap the menu height and scroll the remaining items. A number is treated as pixels; a string is used as any CSS length, such as `"10rem"`. Keyboard navigation scrolls the focused item into view.
+
+<ComboButton labelText="Save" maxHeight="10rem">
+  <MenuItem on:click={() => console.log("Save as")}>Save as</MenuItem>
+  <MenuItem on:click={() => console.log("Save a copy")}>Save a copy</MenuItem>
+  <MenuItem on:click={() => console.log("Save and close")}>Save and close</MenuItem>
+  <MenuItem on:click={() => console.log("Save as template")}>Save as template</MenuItem>
+  <MenuItem on:click={() => console.log("Save to drive")}>Save to drive</MenuItem>
+</ComboButton>
+
 ## Menu items
 
 `MenuItem` takes `disabled`, an `icon`, `kind="danger"` for destructive rows, and nested children for submenus. Use `MenuDivider` between groups. See [MenuButton](/components/MenuButton#menu-items) for the full set of examples and keyboard/hover behavior for submenus.

--- a/docs/src/pages/components/ContextMenu.svx
+++ b/docs/src/pages/components/ContextMenu.svx
@@ -31,6 +31,14 @@ For options inside `ContextMenuGroup`, see [Selectable](#selectable), [Selectabl
 
 <FileSource src="/framed/ContextMenu/ContextMenuOptionProps" />
 
+## Scrollable
+
+Set `maxHeight` to cap the menu height and scroll the remaining items. A number is treated as pixels; a string is used as any CSS length, such as `"10rem"`. Keyboard navigation scrolls the focused item into view.
+
+ContextMenu flips above the cursor when the menu doesn't otherwise fit below it, but always renders at `maxHeight` regardless of which side has room - a fixed value can still overflow the viewport edge on the side it lands on. This example computes `maxHeight` from the click position so the menu always fills, but never exceeds, whichever side has more space.
+
+<FileSource src="/framed/ContextMenu/ContextMenuScrollable" />
+
 ## Nested menu
 
 Put children inside a parent `ContextMenuOption` to open a flyout submenu. Use `indented` on the parent when it has no icon so the label aligns with other rows.

--- a/docs/src/pages/framed/ContextMenu/ContextMenuScrollable.svelte
+++ b/docs/src/pages/framed/ContextMenu/ContextMenuScrollable.svelte
@@ -1,0 +1,34 @@
+<script>
+  import { ContextMenu, ContextMenuOption } from "carbon-components-svelte";
+
+  const actions = Array.from(
+    { length: 30 },
+    (_, index) => `Action ${index + 1}`,
+  );
+
+  // ContextMenu flips above the cursor when the menu doesn't fit below, but
+  // otherwise renders at `maxHeight` regardless of which side has room. Cap
+  // the height to whichever side (above or below the cursor) has more space,
+  // computed before ContextMenu's own contextmenu handler runs, so the menu
+  // always fits without being clipped by the viewport edge.
+  function setMaxHeight(event) {
+    const spaceAbove = event.clientY;
+    const spaceBelow = window.innerHeight - event.clientY;
+    document.documentElement.style.setProperty(
+      "--docs-context-menu-max-height",
+      `${Math.max(spaceAbove, spaceBelow)}px`,
+    );
+  }
+</script>
+
+<svelte:window on:contextmenu={setMaxHeight} />
+
+<ContextMenu maxHeight="var(--docs-context-menu-max-height)">
+  {#each actions as action (action)}
+    <ContextMenuOption labelText={action} />
+  {/each}
+</ContextMenu>
+
+<div data-centered>
+  <p>Right click anywhere on this page</p>
+</div>

--- a/src/ComboButton/ComboButton.svelte
+++ b/src/ComboButton/ComboButton.svelte
@@ -56,6 +56,14 @@
   export let intrinsicAlign = "end";
 
   /**
+   * Specify the maximum height of the menu.
+   * A number is treated as pixels; a string is used as a CSS length.
+   * The menu scrolls once its items exceed the height.
+   * @type {number | string}
+   */
+  export let maxHeight = undefined;
+
+  /**
    * Set to `true` to open the menu.
    * @bindable writable
    */
@@ -188,6 +196,7 @@
     {intrinsicAlign}
     intrinsicWidth={true}
     {size}
+    {maxHeight}
     {labelText}
     on:close
   >

--- a/src/ContextMenu/ContextMenu.svelte
+++ b/src/ContextMenu/ContextMenu.svelte
@@ -49,6 +49,14 @@
    */
   export let labelText = undefined;
 
+  /**
+   * Specify the maximum height of the menu.
+   * A number is treated as pixels; a string is used as a CSS length.
+   * The menu scrolls once its items exceed the height.
+   * @type {number | string}
+   */
+  export let maxHeight = undefined;
+
   import {
     afterUpdate,
     createEventDispatcher,
@@ -183,6 +191,8 @@
   $: level = ctx ? 2 : 1;
   $: currentIndex.set(focusIndex);
   $: menuAriaLabel = ($$props["aria-label"] ?? labelText) || undefined;
+  $: maxHeightStyle =
+    typeof maxHeight === "number" ? `${maxHeight}px` : maxHeight;
 
   function handleOutsideClick(event) {
     if (open && isOutsideClick(event, ref)) close("outside-click");
@@ -229,8 +239,10 @@
   class:bx--menu--open={open}
   class:bx--menu--invisible={open && x === 0 && y === 0}
   class:bx--menu--root={level === 1}
+  class:bx--menu--scrollable={!!maxHeight}
   style:left="{x}px"
   style:top="{y}px"
+  style:max-height={maxHeightStyle}
   {...$$restProps}
   aria-label={menuAriaLabel}
   on:click

--- a/tests/ComboButton/ComboButton.test.svelte
+++ b/tests/ComboButton/ComboButton.test.svelte
@@ -10,6 +10,7 @@
     undefined;
   export let iconDescription: ComponentProps<ComboButton>["iconDescription"] =
     undefined;
+  export let maxHeight: ComponentProps<ComboButton>["maxHeight"] = undefined;
 
   export let open = false;
 
@@ -23,6 +24,7 @@
   {direction}
   {tooltipPosition}
   {iconDescription}
+  {maxHeight}
   bind:open
   on:click={() => console.log("click")}
   on:click:trigger={() => console.log("click:trigger")}

--- a/tests/ComboButton/ComboButton.test.ts
+++ b/tests/ComboButton/ComboButton.test.ts
@@ -253,4 +253,30 @@ describe("ComboButton", () => {
     await fireEvent.click(trigger, { detail: 0 });
     expect(trigger).toHaveFocus();
   });
+
+  describe("maxHeight", () => {
+    it("caps the menu height and marks it scrollable", async () => {
+      render(ComboButtonFixture, { props: { maxHeight: 240 } });
+
+      await user.click(
+        screen.getByRole("button", { name: "Additional actions" }),
+      );
+
+      const menu = screen.getByRole("menu");
+      expect(menu).toHaveClass("bx--menu--scrollable");
+      expect(menu).toHaveStyle("max-height: 240px");
+    });
+
+    it("renders neither the class nor the style when maxHeight is unset", async () => {
+      render(ComboButtonFixture);
+
+      await user.click(
+        screen.getByRole("button", { name: "Additional actions" }),
+      );
+
+      const menu = screen.getByRole("menu");
+      expect(menu).not.toHaveClass("bx--menu--scrollable");
+      expect(menu.style.maxHeight).toBe("");
+    });
+  });
 });

--- a/tests/ContextMenu/ContextMenu.test.svelte
+++ b/tests/ContextMenu/ContextMenu.test.svelte
@@ -14,6 +14,7 @@
   export let optionDisabled = false;
   export let labelText: ComponentProps<ContextMenu>["labelText"] = undefined;
   export let ariaLabel: string | undefined = undefined;
+  export let maxHeight: ComponentProps<ContextMenu>["maxHeight"] = undefined;
 </script>
 
 <div data-testid="target">Right click me</div>
@@ -25,6 +26,7 @@
   {y}
   {labelText}
   aria-label={ariaLabel}
+  {maxHeight}
   bind:ref
   on:open={(e) => {
     console.log("open", e.detail);

--- a/tests/ContextMenu/ContextMenu.test.ts
+++ b/tests/ContextMenu/ContextMenu.test.ts
@@ -664,4 +664,22 @@ describe("ContextMenu", () => {
       expectTypeOf<Props["icon"]>().toEqualTypeOf<any>();
     });
   });
+
+  describe("maxHeight", () => {
+    it("caps the menu height and marks it scrollable", () => {
+      render(ContextMenu, { props: { open: true, maxHeight: 240 } });
+
+      const menu = screen.getAllByRole("menu")[0];
+      expect(menu).toHaveClass("bx--menu--scrollable");
+      expect(menu).toHaveStyle("max-height: 240px");
+    });
+
+    it("renders neither the class nor the style when maxHeight is unset", () => {
+      render(ContextMenu, { props: { open: true } });
+
+      const menu = screen.getAllByRole("menu")[0];
+      expect(menu).not.toHaveClass("bx--menu--scrollable");
+      expect(menu.style.maxHeight).toBe("");
+    });
+  });
 });


### PR DESCRIPTION
Also adds the same maxHeight support to ContextMenu, which
implements its own menu markup instead of composing Menu, and
documents both on the docs site.