### PR TITLE
feat(list-box): add maxHeight override for dropdown, combo-box, and multi-select

### DIFF
--- a/docs/src/pages/components/ComboBox.svx
+++ b/docs/src/pages/components/ComboBox.svx
@@ -340,6 +340,12 @@ When inside a [Modal](/components/Modal#modal-with-dropdowns), `portalMenu` defa
 
 <FileSource src="/framed/ComboBox/ComboBoxPortalMenu" />
 
+### Custom max height
+
+Set `maxHeight` to override the size-based default height of a portaled menu. A number is treated as pixels; a string is used as any CSS length, such as `"20rem"`. The menu scrolls once its items exceed the height.
+
+<FileSource src="/framed/ComboBox/ComboBoxMaxHeight" />
+
 ## Light
 
 Set `light` to `true` to use the light color scheme.

--- a/docs/src/pages/components/Dropdown.svx
+++ b/docs/src/pages/components/Dropdown.svx
@@ -363,6 +363,12 @@ When inside a [Modal](/components/Modal#modal-with-dropdowns), `portalMenu` defa
 
 <FileSource src="/framed/Dropdown/DropdownPortalMenu" />
 
+### Custom max height
+
+Set `maxHeight` to override the size-based default height of a portaled menu. A number is treated as pixels; a string is used as any CSS length, such as `"20rem"`. The menu scrolls once its items exceed the height.
+
+<FileSource src="/framed/Dropdown/DropdownMaxHeight" />
+
 ## Skeleton
 
 Display a loading state using the dropdown skeleton.

--- a/docs/src/pages/components/MultiSelect.svx
+++ b/docs/src/pages/components/MultiSelect.svx
@@ -398,6 +398,12 @@ When inside a [Modal](/components/Modal#modal-with-dropdowns), portalMenu defaul
 
 <FileSource src="/framed/MultiSelect/MultiSelectPortalMenu" />
 
+### Custom max height
+
+Set `maxHeight` to override the size-based default height of a portaled menu. A number is treated as pixels; a string is used as any CSS length, such as `"20rem"`. The menu scrolls once its items exceed the height.
+
+<FileSource src="/framed/MultiSelect/MultiSelectMaxHeight" />
+
 ## States
 
 Surface validation and interaction states. Invalid and warning states each have a filterable counterpart.

--- a/docs/src/pages/framed/ComboBox/ComboBoxMaxHeight.svelte
+++ b/docs/src/pages/framed/ComboBox/ComboBoxMaxHeight.svelte
@@ -1,0 +1,21 @@
+<script>
+  import { ComboBox } from "carbon-components-svelte";
+
+  const items = Array.from({ length: 20 }, (_, i) => ({
+    id: i,
+    text: `Item ${i + 1}`,
+  }));
+
+  let value = "";
+  let selectedId = undefined;
+</script>
+
+<ComboBox
+  portalMenu
+  maxHeight={150}
+  labelText="Contact method"
+  placeholder="Select contact method"
+  {items}
+  bind:selectedId
+  bind:value
+/>

--- a/docs/src/pages/framed/Dropdown/DropdownMaxHeight.svelte
+++ b/docs/src/pages/framed/Dropdown/DropdownMaxHeight.svelte
@@ -1,0 +1,16 @@
+<script>
+  import { Dropdown } from "carbon-components-svelte";
+
+  const items = Array.from({ length: 20 }, (_, i) => ({
+    id: i,
+    text: `Item ${i + 1}`,
+  }));
+</script>
+
+<Dropdown
+  portalMenu
+  maxHeight={150}
+  labelText="Preferred channel"
+  {items}
+  selectedId={0}
+/>

--- a/docs/src/pages/framed/MultiSelect/MultiSelectMaxHeight.svelte
+++ b/docs/src/pages/framed/MultiSelect/MultiSelectMaxHeight.svelte
@@ -1,0 +1,18 @@
+<script>
+  import { MultiSelect } from "carbon-components-svelte";
+
+  const items = Array.from({ length: 20 }, (_, i) => ({
+    id: i,
+    text: `Item ${i + 1}`,
+  }));
+
+  let selectedIds = [];
+</script>
+
+<MultiSelect
+  portalMenu
+  maxHeight={150}
+  labelText="Contact methods"
+  {items}
+  bind:selectedIds
+/>

--- a/src/ComboBox/ComboBox.svelte
+++ b/src/ComboBox/ComboBox.svelte
@@ -234,6 +234,14 @@
    */
   export let portalMenu = undefined;
 
+  /**
+   * Specify the maximum height of the menu.
+   * A number is treated as pixels; a string is used as a CSS length.
+   * The menu scrolls once its items exceed the height.
+   * @type {number | string}
+   */
+  export let maxHeight = undefined;
+
   import { afterUpdate, createEventDispatcher, getContext, tick } from "svelte";
   import Checkmark from "../icons/Checkmark.svelte";
   import WarningAltFilled from "../icons/WarningAltFilled.svelte";
@@ -503,7 +511,7 @@
       ? false
       : virtualize !== undefined || items.length > 100;
 
-  $: menuMaxHeight = getMenuMaxHeight(size);
+  $: resolvedMenuMaxHeight = maxHeight ?? getMenuMaxHeight(size);
 
   $: virtualState = virtualListState({
     items: filteredItems,
@@ -877,13 +885,12 @@
           highlightOrigin = null;
         }}
         bind:ref={listRef}
-        style={effectivePortalMenu
-          ? `max-height: ${virtualConfig
-              ? `${virtualConfig.containerHeight}px; overflow-y: auto`
-              : menuMaxHeight};`
-          : virtualConfig
-            ? `max-height: ${virtualConfig.containerHeight}px; overflow-y: auto;`
-            : undefined}
+        style={virtualConfig
+          ? `max-height: ${virtualConfig.containerHeight}px; overflow-y: auto;`
+          : undefined}
+        maxHeight={!virtualConfig && effectivePortalMenu
+          ? resolvedMenuMaxHeight
+          : undefined}
       >
         {#if virtualData?.isVirtualized}
           <div style="height: {virtualData.totalHeight}px; position: relative;">

--- a/src/Dropdown/Dropdown.svelte
+++ b/src/Dropdown/Dropdown.svelte
@@ -172,6 +172,14 @@
    */
   export let portalMenu = undefined;
 
+  /**
+   * Specify the maximum height of the menu.
+   * A number is treated as pixels; a string is used as a CSS length.
+   * The menu scrolls once its items exceed the height.
+   * @type {number | string}
+   */
+  export let maxHeight = undefined;
+
   /** Set an id for the list box component */
   export let id = `ccs-${Math.random().toString(36)}`;
 
@@ -297,7 +305,7 @@
       ? false
       : virtualize !== undefined || items.length > 100;
 
-  $: menuMaxHeight = getMenuMaxHeight(size);
+  $: resolvedMenuMaxHeight = maxHeight ?? getMenuMaxHeight(size);
 
   // Fluid (non-condensed) menu items are 64px tall (see css/_fluid-list-box.scss).
   // Portaled menus render outside the fluid wrapper, so they keep default heights.
@@ -707,13 +715,12 @@
           highlightOrigin = null;
         }}
         bind:ref={listRef}
-        style={effectivePortalMenu
-          ? `max-height: ${virtualConfig
-              ? `${virtualConfig.containerHeight}px; overflow-y: auto`
-              : menuMaxHeight};`
-          : virtualConfig
-            ? `max-height: ${virtualConfig.containerHeight}px; overflow-y: auto;`
-            : undefined}
+        style={virtualConfig
+          ? `max-height: ${virtualConfig.containerHeight}px; overflow-y: auto;`
+          : undefined}
+        maxHeight={!virtualConfig && effectivePortalMenu
+          ? resolvedMenuMaxHeight
+          : undefined}
       >
         {#if virtualData?.isVirtualized}
           <div style="height: {virtualData.totalHeight}px; position: relative;">

--- a/src/ListBox/ListBoxMenu.svelte
+++ b/src/ListBox/ListBoxMenu.svelte
@@ -43,7 +43,19 @@
    */
   export let portalHostClass = undefined;
 
+  /**
+   * Specify the maximum height of the menu.
+   * A number is treated as pixels; a string is used as a CSS length.
+   * The menu scrolls once its items exceed the height.
+   * @type {number | string}
+   */
+  export let maxHeight = undefined;
+
   import FloatingPortal from "../Portal/FloatingPortal.svelte";
+
+  $: maxHeightStyle =
+    typeof maxHeight === "number" ? `${maxHeight}px` : maxHeight;
+  $: maxHeightCss = maxHeightStyle ? `max-height: ${maxHeightStyle};` : "";
 </script>
 
 {#if portal}
@@ -51,11 +63,11 @@
     <div class={portalHostClass}>
       <div
         bind:this={ref}
+        {...$$restProps}
         role="listbox"
         id="menu-{id}"
         class:bx--list-box__menu={true}
-        style="position: static; {$$restProps.style || ''}"
-        {...$$restProps}
+        style="position: static; {maxHeightCss} {$$restProps.style || ''}"
         on:scroll
         on:mouseleave
       >
@@ -66,10 +78,11 @@
 {:else}
   <div
     bind:this={ref}
+    {...$$restProps}
     role="listbox"
     id="menu-{id}"
     class:bx--list-box__menu={true}
-    {...$$restProps}
+    style="{maxHeightCss} {$$restProps.style || ''}"
     on:scroll
     on:mouseleave
   >

--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -265,6 +265,14 @@
   export let portalMenu = undefined;
 
   /**
+   * Specify the maximum height of the menu.
+   * A number is treated as pixels; a string is used as a CSS length.
+   * The menu scrolls once its items exceed the height.
+   * @type {number | string}
+   */
+  export let maxHeight = undefined;
+
+  /**
    * Obtain a reference to the list HTML element.
    * @type {null | HTMLDivElement}
    * @bindable readonly
@@ -732,7 +740,7 @@
   $: itemsToUse = filterable ? filteredItems : sortedItems;
   $: scrollEndTracker.noteItemCount(itemsToUse.length);
 
-  $: menuMaxHeight = getMenuMaxHeight(size);
+  $: resolvedMenuMaxHeight = maxHeight ?? getMenuMaxHeight(size);
 
   $: virtualState = virtualListState({
     items: itemsToUse,
@@ -1106,13 +1114,12 @@
           highlightOrigin = null;
         }}
         bind:ref={listRef}
-        style={effectivePortalMenu
-          ? `max-height: ${virtualConfig
-              ? `${virtualConfig.containerHeight}px; overflow-y: auto`
-              : menuMaxHeight};`
-          : virtualConfig
-            ? `max-height: ${virtualConfig.containerHeight}px; overflow-y: auto;`
-            : undefined}
+        style={virtualConfig
+          ? `max-height: ${virtualConfig.containerHeight}px; overflow-y: auto;`
+          : undefined}
+        maxHeight={!virtualConfig && effectivePortalMenu
+          ? resolvedMenuMaxHeight
+          : undefined}
       >
         {#if virtualData?.isVirtualized}
           <div style="height: {virtualData.totalHeight}px; position: relative;">

--- a/tests/ComboBox/ComboBox.test.svelte
+++ b/tests/ComboBox/ComboBox.test.svelte
@@ -43,6 +43,7 @@
   export let autoHighlight: ComponentProps<ComboBox>["autoHighlight"] = "none";
   export let virtualize: ComponentProps<ComboBox>["virtualize"] = undefined;
   export let portalMenu: ComponentProps<ComboBox>["portalMenu"] = false;
+  export let maxHeight: ComponentProps<ComboBox>["maxHeight"] = undefined;
   export let ariaLabel: ComponentProps<ComboBox>["aria-label"] = undefined;
   export let fluid: ComponentProps<ComboBox>["fluid"] = false;
   export let condensed: ComponentProps<ComboBox>["condensed"] = false;
@@ -80,6 +81,7 @@
   {autoHighlight}
   {virtualize}
   {portalMenu}
+  {maxHeight}
   on:select={(e) => {
     console.log("select", e.detail);
   }}

--- a/tests/ComboBox/ComboBox.test.ts
+++ b/tests/ComboBox/ComboBox.test.ts
@@ -2612,6 +2612,19 @@ describe("ComboBox", () => {
     });
   });
 
+  describe("maxHeight", () => {
+    it("should override the size-based default on a portaled menu", async () => {
+      render(ComboBox, {
+        props: { portalMenu: true, maxHeight: 200 },
+      });
+
+      await user.click(getInput());
+
+      const menu = screen.getByRole("listbox");
+      expect(menu.style.maxHeight).toBe("200px");
+    });
+  });
+
   describe("portalMenu", () => {
     afterEach(() => {
       const existingPortals = document.querySelectorAll(

--- a/tests/Dropdown/Dropdown.test.ts
+++ b/tests/Dropdown/Dropdown.test.ts
@@ -1969,6 +1969,24 @@ describe("Dropdown", () => {
     });
   });
 
+  describe("maxHeight", () => {
+    it("should override the size-based default on a portaled menu", async () => {
+      render(Dropdown, {
+        props: {
+          items,
+          portalMenu: true,
+          maxHeight: 200,
+        },
+      });
+
+      const button = screen.getByRole("combobox");
+      await user.click(button);
+
+      const menu = screen.getByRole("listbox");
+      expect(menu.style.maxHeight).toBe("200px");
+    });
+  });
+
   describe("portalMenu", () => {
     afterEach(() => {
       const existingPortals = document.querySelectorAll(

--- a/tests/ListBox/ListBoxMenu.test.ts
+++ b/tests/ListBox/ListBoxMenu.test.ts
@@ -63,6 +63,31 @@ describe("ListBoxMenu", () => {
     expect(component.ref).toBeInstanceOf(HTMLDivElement);
   });
 
+  it("should apply maxHeight as pixels when a number", () => {
+    render(ListBoxMenu, {
+      props: { slotContent: "Capped menu", maxHeight: 200 },
+    });
+
+    const menu = screen.getByText("Capped menu").closest(".bx--list-box__menu");
+    expect(menu).toHaveStyle("max-height: 200px");
+  });
+
+  it("should apply maxHeight as a CSS length when a string", async () => {
+    render(ListBoxMenu, {
+      props: {
+        slotContent: "Portal capped menu",
+        maxHeight: "20rem",
+        portal: true,
+        open: true,
+      },
+    });
+
+    const menu = await screen.findByText("Portal capped menu");
+    expect(
+      menu.closest(".bx--list-box__menu")?.getAttribute("style"),
+    ).toContain("max-height: 20rem");
+  });
+
   it("should apply custom attributes", () => {
     render(ListBoxMenu, {
       props: {

--- a/tests/MultiSelect/MultiSelect.test.svelte
+++ b/tests/MultiSelect/MultiSelect.test.svelte
@@ -36,6 +36,7 @@
   export let helperText: ComponentProps<MultiSelect>["helperText"] = "";
   export let virtualize: ComponentProps<MultiSelect>["virtualize"] = undefined;
   export let portalMenu: ComponentProps<MultiSelect>["portalMenu"] = false;
+  export let maxHeight: ComponentProps<MultiSelect>["maxHeight"] = undefined;
   export let sortItem: ComponentProps<MultiSelect>["sortItem"] = undefined;
   export let open: ComponentProps<MultiSelect>["open"] = undefined;
   export let ariaLabel: ComponentProps<MultiSelect>["aria-label"] = undefined;
@@ -73,6 +74,7 @@
   {helperText}
   {virtualize}
   {portalMenu}
+  {maxHeight}
   {sortItem}
   {open}
   {fluid}

--- a/tests/MultiSelect/MultiSelect.test.ts
+++ b/tests/MultiSelect/MultiSelect.test.ts
@@ -2773,6 +2773,19 @@ describe("MultiSelect", () => {
     });
   });
 
+  describe("maxHeight", () => {
+    it("should override the size-based default on a portaled menu", async () => {
+      render(MultiSelect, {
+        props: { items, portalMenu: true, maxHeight: 200 },
+      });
+
+      await openMenu();
+
+      const menu = screen.getByRole("listbox");
+      expect(menu.style.maxHeight).toBe("200px");
+    });
+  });
+
   describe("portalMenu", () => {
     afterEach(() => {
       const existingPortals = document.querySelectorAll(


### PR DESCRIPTION
Lets Dropdown, ComboBox, and MultiSelect accept a maxHeight prop
(number = px, string = any CSS length), same convention as
Menu/OverflowMenu, to override the size-based default menu height.
Only applies to the non-virtualized, portaled case; virtualization
keeps computing its own container height.