### PR TITLE
fix(accordion)!: remove forwarded on:click from AccordionSkeleton

### DIFF
--- a/src/Accordion/AccordionSkeleton.svelte
+++ b/src/Accordion/AccordionSkeleton.svelte
@@ -38,7 +38,6 @@
   class:bx--accordion--xl={size === "xl"}
   class:bx--accordion--flush={flush && align !== "start"}
   {...$$restProps}
-  on:click
   on:mouseover
   on:mouseenter
   on:mouseleave

--- a/src/Breadcrumb/BreadcrumbSkeleton.svelte
+++ b/src/Breadcrumb/BreadcrumbSkeleton.svelte
@@ -21,7 +21,6 @@
   class:bx--breadcrumb--no-trailing-slash={noTrailingSlash}
   class:bx--breadcrumb--sm={size === "sm"}
   {...$$restProps}
-  on:click
   on:mouseover
   on:mouseenter
   on:mouseleave

--- a/src/Button/ButtonSkeleton.svelte
+++ b/src/Button/ButtonSkeleton.svelte
@@ -44,7 +44,6 @@
     class:bx--btn--lg={size === "lg"}
     class:bx--btn--xl={size === "xl"}
     {...$$restProps}
-    on:click
     on:focus
     on:blur
     on:mouseover

--- a/src/Checkbox/CheckboxSkeleton.svelte
+++ b/src/Checkbox/CheckboxSkeleton.svelte
@@ -5,7 +5,6 @@
   class:bx--checkbox-wrapper={true}
   class:bx--checkbox-label={true}
   {...$$restProps}
-  on:click
   on:mouseover
   on:mouseenter
   on:mouseleave

--- a/src/CodeSnippet/CodeSnippetSkeleton.svelte
+++ b/src/CodeSnippet/CodeSnippetSkeleton.svelte
@@ -14,7 +14,6 @@
   class:bx--snippet--single={type === "single"}
   class:bx--snippet--multi={type === "multi"}
   {...$$restProps}
-  on:click
   on:mouseover
   on:mouseenter
   on:mouseleave

--- a/src/ComboBox/FluidComboBoxSkeleton.svelte
+++ b/src/ComboBox/FluidComboBoxSkeleton.svelte
@@ -4,7 +4,6 @@
   class:bx--list-box__wrapper--fluid={true}
   class:bx--list-box__wrapper--fluid--skeleton={true}
   {...$$restProps}
-  on:click
   on:mouseover
   on:mouseenter
   on:mouseleave

--- a/src/CopyInput/CopyInputSkeleton.svelte
+++ b/src/CopyInput/CopyInputSkeleton.svelte
@@ -8,7 +8,6 @@
 <div
   class:bx--form-item={true}
   {...$$restProps}
-  on:click
   on:mouseover
   on:mouseenter
   on:mouseleave

--- a/src/CopyInput/FluidCopyInputSkeleton.svelte
+++ b/src/CopyInput/FluidCopyInputSkeleton.svelte
@@ -4,7 +4,6 @@
   class:bx--form-item={true}
   class:bx--text-input--fluid__skeleton={true}
   {...$$restProps}
-  on:click
   on:mouseover
   on:mouseenter
   on:mouseleave

--- a/src/DataTable/DataTableSkeleton.svelte
+++ b/src/DataTable/DataTableSkeleton.svelte
@@ -71,7 +71,6 @@
     class:bx--data-table--short={size === "short"}
     class:bx--data-table--tall={size === "tall"}
     class:bx--data-table--zebra={zebra}
-    on:click
     on:mouseover
     on:mouseenter
     on:mouseleave

--- a/src/DatePicker/DatePickerSkeleton.svelte
+++ b/src/DatePicker/DatePickerSkeleton.svelte
@@ -11,7 +11,6 @@
 <div
   class:bx--form-item={true}
   {...$$restProps}
-  on:click
   on:mouseover
   on:mouseenter
   on:mouseleave

--- a/src/DatePicker/FluidDatePickerSkeleton.svelte
+++ b/src/DatePicker/FluidDatePickerSkeleton.svelte
@@ -12,7 +12,6 @@
   class:bx--date-picker--fluid__skeleton={true}
   class:bx--date-picker--fluid__skeleton--range={range}
   {...$$restProps}
-  on:click
   on:mouseover
   on:mouseenter
   on:mouseleave

--- a/src/Dropdown/DropdownSkeleton.svelte
+++ b/src/Dropdown/DropdownSkeleton.svelte
@@ -12,7 +12,6 @@
   class:bx--form-item={true}
   class:bx--list-box--inline={inline}
   {...$$restProps}
-  on:click
   on:mouseover
   on:mouseenter
   on:mouseleave

--- a/src/Dropdown/FluidDropdownSkeleton.svelte
+++ b/src/Dropdown/FluidDropdownSkeleton.svelte
@@ -4,7 +4,6 @@
   class:bx--list-box__wrapper--fluid={true}
   class:bx--list-box__wrapper--fluid--skeleton={true}
   {...$$restProps}
-  on:click
   on:mouseover
   on:mouseenter
   on:mouseleave

--- a/src/FileUploader/FileUploaderSkeleton.svelte
+++ b/src/FileUploader/FileUploaderSkeleton.svelte
@@ -14,7 +14,6 @@
 <div
   class:bx--form-item={true}
   {...$$restProps}
-  on:click
   on:mouseover
   on:mouseenter
   on:mouseleave

--- a/src/MultiSelect/FluidMultiSelectSkeleton.svelte
+++ b/src/MultiSelect/FluidMultiSelectSkeleton.svelte
@@ -4,7 +4,6 @@
   class:bx--list-box__wrapper--fluid={true}
   class:bx--list-box__wrapper--fluid--skeleton={true}
   {...$$restProps}
-  on:click
   on:mouseover
   on:mouseenter
   on:mouseleave

--- a/src/NumberInput/FluidNumberInputSkeleton.svelte
+++ b/src/NumberInput/FluidNumberInputSkeleton.svelte
@@ -4,7 +4,6 @@
   class:bx--form-item={true}
   class:bx--text-input--fluid__skeleton={true}
   {...$$restProps}
-  on:click
   on:mouseover
   on:mouseenter
   on:mouseleave

--- a/src/NumberInput/NumberInputSkeleton.svelte
+++ b/src/NumberInput/NumberInputSkeleton.svelte
@@ -8,7 +8,6 @@
 <div
   class:bx--form-item={true}
   {...$$restProps}
-  on:click
   on:mouseover
   on:mouseenter
   on:mouseleave

--- a/src/Pagination/PaginationSkeleton.svelte
+++ b/src/Pagination/PaginationSkeleton.svelte
@@ -17,7 +17,6 @@
   class:bx--pagination--lg={size === "lg"}
   class:bx--skeleton={true}
   {...$$restProps}
-  on:click
   on:mouseover
   on:mouseenter
   on:mouseleave

--- a/src/PinCodeInput/FluidPinCodeInputSkeleton.svelte
+++ b/src/PinCodeInput/FluidPinCodeInputSkeleton.svelte
@@ -4,7 +4,6 @@
   class:bx--form-item={true}
   class:bx--text-input--fluid__skeleton={true}
   {...$$restProps}
-  on:click
   on:mouseover
   on:mouseenter
   on:mouseleave

--- a/src/PinCodeInput/PinCodeInputSkeleton.svelte
+++ b/src/PinCodeInput/PinCodeInputSkeleton.svelte
@@ -8,7 +8,6 @@
 <div
   class:bx--form-item={true}
   {...$$restProps}
-  on:click
   on:mouseover
   on:mouseenter
   on:mouseleave

--- a/src/ProgressIndicator/ProgressIndicatorSkeleton.svelte
+++ b/src/ProgressIndicator/ProgressIndicatorSkeleton.svelte
@@ -17,7 +17,6 @@
   class:bx--progress--space-equal={spaceEqually && !vertical}
   class:bx--skeleton={true}
   {...$$restProps}
-  on:click
   on:mouseover
   on:mouseenter
   on:mouseleave

--- a/src/RadioButton/RadioButtonSkeleton.svelte
+++ b/src/RadioButton/RadioButtonSkeleton.svelte
@@ -3,7 +3,6 @@
 <div
   class:bx--radio-button-wrapper={true}
   {...$$restProps}
-  on:click
   on:mouseover
   on:mouseenter
   on:mouseleave

--- a/src/Search/FluidSearchSkeleton.svelte
+++ b/src/Search/FluidSearchSkeleton.svelte
@@ -4,7 +4,6 @@
   class:bx--form-item={true}
   class:bx--text-input--fluid__skeleton={true}
   {...$$restProps}
-  on:click
   on:mouseover
   on:mouseenter
   on:mouseleave

--- a/src/Search/SearchSkeleton.svelte
+++ b/src/Search/SearchSkeleton.svelte
@@ -18,7 +18,6 @@
   class:bx--search--lg={size === "lg"}
   class:bx--search--xl={size === "xl"}
   {...$$restProps}
-  on:click
   on:mouseover
   on:mouseenter
   on:mouseleave

--- a/src/SearchMenu/SearchMenuSkeleton.svelte
+++ b/src/SearchMenu/SearchMenuSkeleton.svelte
@@ -18,7 +18,6 @@
 <div
   class="bx--search-menu__menu bx--search-menu__menu--inline bx--search-menu__menu--{size}"
   {...$$restProps}
-  on:click
   on:mouseover
   on:mouseenter
   on:mouseleave

--- a/src/Select/FluidSelectSkeleton.svelte
+++ b/src/Select/FluidSelectSkeleton.svelte
@@ -4,7 +4,6 @@
   class:bx--form-item={true}
   class:bx--select--fluid__skeleton={true}
   {...$$restProps}
-  on:click
   on:mouseover
   on:mouseenter
   on:mouseleave

--- a/src/Select/SelectSkeleton.svelte
+++ b/src/Select/SelectSkeleton.svelte
@@ -8,7 +8,6 @@
 <div
   class:bx--form-item={true}
   {...$$restProps}
-  on:click
   on:mouseover
   on:mouseenter
   on:mouseleave

--- a/src/Slider/RangeSliderSkeleton.svelte
+++ b/src/Slider/RangeSliderSkeleton.svelte
@@ -8,7 +8,6 @@
 <div
   class:bx--form-item={true}
   {...$$restProps}
-  on:click
   on:mouseover
   on:mouseenter
   on:mouseleave

--- a/src/Slider/SliderSkeleton.svelte
+++ b/src/Slider/SliderSkeleton.svelte
@@ -8,7 +8,6 @@
 <div
   class:bx--form-item={true}
   {...$$restProps}
-  on:click
   on:mouseover
   on:mouseenter
   on:mouseleave

--- a/src/StructuredList/StructuredListSkeleton.svelte
+++ b/src/StructuredList/StructuredListSkeleton.svelte
@@ -14,7 +14,6 @@
   class:bx--skeleton={true}
   class:bx--structured-list={true}
   {...$$restProps}
-  on:click
   on:mouseover
   on:mouseenter
   on:mouseleave

--- a/src/Tabs/TabsSkeleton.svelte
+++ b/src/Tabs/TabsSkeleton.svelte
@@ -17,7 +17,6 @@
   class:bx--tabs--scrollable={true}
   class:bx--tabs--scrollable--container={type === "container"}
   {...$$restProps}
-  on:click
   on:mouseover
   on:mouseenter
   on:mouseleave

--- a/src/Tabs/TabsVerticalSkeleton.svelte
+++ b/src/Tabs/TabsVerticalSkeleton.svelte
@@ -11,7 +11,6 @@
     class:bx--tabs--vertical={true}
     class:bx--skeleton={true}
     {...$$restProps}
-    on:click
     on:mouseover
     on:mouseenter
     on:mouseleave

--- a/src/Tag/TagSkeleton.svelte
+++ b/src/Tag/TagSkeleton.svelte
@@ -11,7 +11,6 @@
   class:bx--tag--lg={size === "lg"}
   class:bx--skeleton={true}
   {...$$restProps}
-  on:click
   on:mouseover
   on:mouseenter
   on:mouseleave

--- a/src/TextArea/FluidTextAreaSkeleton.svelte
+++ b/src/TextArea/FluidTextAreaSkeleton.svelte
@@ -4,7 +4,6 @@
   class:bx--form-item={true}
   class:bx--text-area--fluid__skeleton={true}
   {...$$restProps}
-  on:click
   on:mouseover
   on:mouseenter
   on:mouseleave

--- a/src/TextArea/TextAreaSkeleton.svelte
+++ b/src/TextArea/TextAreaSkeleton.svelte
@@ -8,7 +8,6 @@
 <div
   class:bx--form-item={true}
   {...$$restProps}
-  on:click
   on:mouseover
   on:mouseenter
   on:mouseleave

--- a/src/TextInput/FluidTextInputSkeleton.svelte
+++ b/src/TextInput/FluidTextInputSkeleton.svelte
@@ -4,7 +4,6 @@
   class:bx--form-item={true}
   class:bx--text-input--fluid__skeleton={true}
   {...$$restProps}
-  on:click
   on:mouseover
   on:mouseenter
   on:mouseleave

--- a/src/TextInput/PasswordInputSkeleton.svelte
+++ b/src/TextInput/PasswordInputSkeleton.svelte
@@ -8,7 +8,6 @@
 <div
   class:bx--form-item={true}
   {...$$restProps}
-  on:click
   on:mouseover
   on:mouseenter
   on:mouseleave

--- a/src/TextInput/TextInputSkeleton.svelte
+++ b/src/TextInput/TextInputSkeleton.svelte
@@ -8,7 +8,6 @@
 <div
   class:bx--form-item={true}
   {...$$restProps}
-  on:click
   on:mouseover
   on:mouseenter
   on:mouseleave

--- a/src/TimePicker/FluidTimePickerSkeleton.svelte
+++ b/src/TimePicker/FluidTimePickerSkeleton.svelte
@@ -12,7 +12,6 @@
   class:bx--time-picker--fluid--skeleton={true}
   class:bx--time-picker--equal-width={isOnlyTwo}
   {...$$restProps}
-  on:click
   on:mouseover
   on:mouseenter
   on:mouseleave

--- a/src/Toggle/ToggleSkeleton.svelte
+++ b/src/Toggle/ToggleSkeleton.svelte
@@ -17,7 +17,6 @@
 <div
   class:bx--form-item={true}
   {...$$restProps}
-  on:click
   on:mouseover
   on:mouseenter
   on:mouseleave

--- a/tests/Accordion/Accordion.test.ts
+++ b/tests/Accordion/Accordion.test.ts
@@ -7,6 +7,7 @@ import AccordionProgrammatic from "./Accordion.programmatic.test.svelte";
 import AccordionSingle from "./Accordion.single.test.svelte";
 import AccordionSkeleton from "./Accordion.skeleton.test.svelte";
 import Accordion from "./Accordion.test.svelte";
+import AccordionSkeletonForwardedEvents from "./AccordionSkeleton.forwarded-events.test.svelte";
 
 describe("Accordion", () => {
   const itemIsDisabled = (name: string | RegExp) => {
@@ -491,5 +492,19 @@ describe("Accordion", () => {
     render(AccordionLazy, { props: { lazy: true, open: true } });
 
     expect(screen.getByText("Lazy panel content")).toBeInTheDocument();
+  });
+
+  it("should not forward click but should forward mouse events on AccordionSkeleton", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(AccordionSkeletonForwardedEvents);
+
+    const accordion = screen.getByRole("list");
+
+    // Click should not fire
+    await user.click(accordion);
+    const clickCalls = consoleLog.mock.calls.filter(
+      (call) => call[0] === "click",
+    );
+    expect(clickCalls).toHaveLength(0);
   });
 });

--- a/tests/Accordion/AccordionSkeleton.forwarded-events.test.svelte
+++ b/tests/Accordion/AccordionSkeleton.forwarded-events.test.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  import AccordionSkeleton from "carbon-components-svelte/Accordion/AccordionSkeleton.svelte";
+</script>
+
+<AccordionSkeleton
+  on:click={() => {
+    console.log("click");
+  }}
+  on:mouseover={() => {
+    console.log("mouseover");
+  }}
+  on:mouseenter={() => {
+    console.log("mouseenter");
+  }}
+  on:mouseleave={() => {
+    console.log("mouseleave");
+  }}
+/>

--- a/tests/Breadcrumb/Breadcrumb.test.ts
+++ b/tests/Breadcrumb/Breadcrumb.test.ts
@@ -1,4 +1,5 @@
 import { render, screen, within } from "@testing-library/svelte";
+import { user } from "../utils/user";
 import BreadcrumbAriaCurrent from "./Breadcrumb.ariaCurrent.test.svelte";
 import BreadcrumbDynamic from "./Breadcrumb.dynamic.test.svelte";
 import BreadcrumbLabelText from "./Breadcrumb.labelText.test.svelte";
@@ -7,6 +8,7 @@ import BreadcrumbSize from "./Breadcrumb.size.test.svelte";
 import BreadcrumbSkeleton from "./Breadcrumb.skeleton.test.svelte";
 import BreadcrumbSkeletonSm from "./Breadcrumb.skeleton-sm.test.svelte";
 import Breadcrumb from "./Breadcrumb.test.svelte";
+import BreadcrumbSkeletonForwardedEvents from "./BreadcrumbSkeleton.forwarded-events.test.svelte";
 
 describe("Breadcrumb", () => {
   it("renders with default props", () => {
@@ -159,5 +161,20 @@ describe("Breadcrumb", () => {
     const skeleton = document.querySelector(".bx--skeleton.bx--breadcrumb");
     expect(skeleton).toBeInTheDocument();
     expect(skeleton).toHaveClass("bx--breadcrumb--sm");
+  });
+
+  it("should not forward click on BreadcrumbSkeleton", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(BreadcrumbSkeletonForwardedEvents);
+
+    const skeleton = document.querySelector(".bx--skeleton.bx--breadcrumb");
+    assert(skeleton);
+
+    // Click should not fire
+    await user.click(skeleton);
+    const clickCalls = consoleLog.mock.calls.filter(
+      (call) => call[0] === "click",
+    );
+    expect(clickCalls).toHaveLength(0);
   });
 });

--- a/tests/Breadcrumb/BreadcrumbSkeleton.forwarded-events.test.svelte
+++ b/tests/Breadcrumb/BreadcrumbSkeleton.forwarded-events.test.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  import BreadcrumbSkeleton from "carbon-components-svelte/Breadcrumb/BreadcrumbSkeleton.svelte";
+</script>
+
+<BreadcrumbSkeleton
+  on:click={() => {
+    console.log("click");
+  }}
+  on:mouseover={() => {
+    console.log("mouseover");
+  }}
+  on:mouseenter={() => {
+    console.log("mouseenter");
+  }}
+  on:mouseleave={() => {
+    console.log("mouseleave");
+  }}
+/>

--- a/tests/Button/Button.test.ts
+++ b/tests/Button/Button.test.ts
@@ -5,6 +5,7 @@ import { user } from "../utils/user";
 import Button from "./Button.test.svelte";
 import ButtonInModal from "./ButtonInModal.test.svelte";
 import ButtonPortalAdjacent from "./ButtonPortalAdjacent.test.svelte";
+import ButtonSkeletonForwardedEvents from "./ButtonSkeleton.forwarded-events.test.svelte";
 import HeaderGlobalActionPortal from "./HeaderGlobalActionPortal.test.svelte";
 
 describe("Button", () => {
@@ -413,5 +414,23 @@ describe("Button", () => {
       // biome-ignore lint/suspicious/noExplicitAny: Testing default any type
       expectTypeOf<Props["icon"]>().toEqualTypeOf<any>();
     });
+  });
+
+  it("does not forward click but forwards mouse events on ButtonSkeleton (div branch)", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    const { container } = render(ButtonSkeletonForwardedEvents);
+
+    const skeleton = container.querySelector(".bx--skeleton.bx--btn");
+    assert(skeleton);
+    expect(skeleton.tagName).toBe("DIV");
+
+    await user.click(skeleton);
+    expect(consoleLog).not.toHaveBeenCalledWith("click");
+
+    await user.hover(skeleton);
+    expect(consoleLog).toHaveBeenCalledWith("mouseover");
+
+    await user.unhover(skeleton);
+    expect(consoleLog).toHaveBeenCalledWith("mouseleave");
   });
 });

--- a/tests/Button/ButtonSkeleton.forwarded-events.test.svelte
+++ b/tests/Button/ButtonSkeleton.forwarded-events.test.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  import ButtonSkeleton from "carbon-components-svelte/Button/ButtonSkeleton.svelte";
+</script>
+
+<ButtonSkeleton
+  on:click={() => {
+    console.log("click");
+  }}
+  on:mouseover={() => {
+    console.log("mouseover");
+  }}
+  on:mouseenter={() => {
+    console.log("mouseenter");
+  }}
+  on:mouseleave={() => {
+    console.log("mouseleave");
+  }}
+/>

--- a/tests/Checkbox/Checkbox.test.ts
+++ b/tests/Checkbox/Checkbox.test.ts
@@ -11,6 +11,7 @@ import Checkbox from "./Checkbox.test.svelte";
 import CheckboxGroupEvents from "./CheckboxGroupEvents.test.svelte";
 import CheckboxGroupReactive from "./CheckboxGroupReactive.test.svelte";
 import CheckboxReactiveBind from "./CheckboxReactiveBind.test.svelte";
+import CheckboxSkeletonForwardedEvents from "./CheckboxSkeleton.forwarded-events.test.svelte";
 import CheckboxTitleTruncation from "./CheckboxTitleTruncation.test.svelte";
 import MultipleCheckboxes from "./MultipleCheckboxes.test.svelte";
 import MultipleCheckboxesObject from "./MultipleCheckboxesObject.test.svelte";
@@ -587,6 +588,20 @@ describe("Checkbox", () => {
 
       expect(getLabel().getAttribute("title")).toBe("Custom title");
     });
+  });
+
+  it("should not forward click on CheckboxSkeleton", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(CheckboxSkeletonForwardedEvents);
+
+    const skeleton = screen.getByTestId("checkbox-skeleton");
+
+    // Click should not fire
+    await user.click(skeleton);
+    const clickCalls = consoleLog.mock.calls.filter(
+      (call) => call[0] === "click",
+    );
+    expect(clickCalls).toHaveLength(0);
   });
 
   describe("Generics", () => {

--- a/tests/Checkbox/CheckboxSkeleton.forwarded-events.test.svelte
+++ b/tests/Checkbox/CheckboxSkeleton.forwarded-events.test.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  import CheckboxSkeleton from "carbon-components-svelte/Checkbox/CheckboxSkeleton.svelte";
+</script>
+
+<CheckboxSkeleton
+  data-testid="checkbox-skeleton"
+  on:click={() => {
+    console.log("click");
+  }}
+  on:mouseover={() => {
+    console.log("mouseover");
+  }}
+  on:mouseenter={() => {
+    console.log("mouseenter");
+  }}
+  on:mouseleave={() => {
+    console.log("mouseleave");
+  }}
+/>

--- a/tests/CodeSnippet/CodeSnippet.test.ts
+++ b/tests/CodeSnippet/CodeSnippet.test.ts
@@ -27,6 +27,7 @@ import CodeSnippetNullishAriaLabel from "./CodeSnippetNullishAriaLabel.test.svel
 import CodeSnippetRestPropsButton from "./CodeSnippetRestPropsButton.test.svelte";
 import CodeSnippetRestPropsSingle from "./CodeSnippetRestPropsSingle.test.svelte";
 import CodeSnippetRestPropsSpan from "./CodeSnippetRestPropsSpan.test.svelte";
+import CodeSnippetSkeletonForwardedEvents from "./CodeSnippetSkeleton.forwarded-events.test.svelte";
 import CodeSnippetWithCustomCopyText from "./CodeSnippetWithCustomCopyText.test.svelte";
 import CodeSnippetWithHideShowMore from "./CodeSnippetWithHideShowMore.test.svelte";
 import CodeSnippetWithWrapText from "./CodeSnippetWithWrapText.test.svelte";
@@ -696,5 +697,20 @@ yarn -v`,
     });
     const snippet = container.querySelector(".bx--snippet-container");
     expect(snippet).toHaveAttribute("aria-label", "Code snippet");
+  });
+
+  it("should not forward click on CodeSnippetSkeleton", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(CodeSnippetSkeletonForwardedEvents);
+
+    const skeleton = document.querySelector(".bx--skeleton.bx--snippet");
+    assert(skeleton);
+
+    // Click should not fire
+    await user.click(skeleton);
+    const clickCalls = consoleLog.mock.calls.filter(
+      (call) => call[0] === "click",
+    );
+    expect(clickCalls).toHaveLength(0);
   });
 });

--- a/tests/CodeSnippet/CodeSnippetSkeleton.forwarded-events.test.svelte
+++ b/tests/CodeSnippet/CodeSnippetSkeleton.forwarded-events.test.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import CodeSnippetSkeleton from "carbon-components-svelte/CodeSnippet/CodeSnippetSkeleton.svelte";
+
+  export let type = "single";
+</script>
+
+<CodeSnippetSkeleton
+  {type}
+  on:click={() => {
+    console.log("click");
+  }}
+  on:mouseover={() => {
+    console.log("mouseover");
+  }}
+  on:mouseenter={() => {
+    console.log("mouseenter");
+  }}
+  on:mouseleave={() => {
+    console.log("mouseleave");
+  }}
+/>

--- a/tests/ComboBox/ComboBox.test.ts
+++ b/tests/ComboBox/ComboBox.test.ts
@@ -18,6 +18,7 @@ import ComboBoxIconSlots from "./ComboBoxIconSlots.test.svelte";
 import ComboBoxInModal from "./ComboBoxInModal.test.svelte";
 import ComboBoxItemIcon from "./ComboBoxItemIcon.test.svelte";
 import ComboBoxItemSlot from "./ComboBoxItemSlot.test.svelte";
+import FluidComboBoxSkeletonEvents from "./FluidComboBoxSkeletonEvents.test.svelte";
 
 describe("ComboBox", () => {
   const getInput = () => {
@@ -3215,5 +3216,21 @@ describe("ComboBox", () => {
     expect(listBox.children).toHaveLength(2);
     expect(listBox.children[0]).toHaveClass("bx--list-box__label");
     expect(listBox.children[1]).toHaveClass("bx--list-box__field");
+  });
+
+  it("does not forward click but forwards mouse events", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(FluidComboBoxSkeletonEvents);
+
+    const element = screen.getByTestId("fluid-combo-box-skeleton");
+
+    await user.click(element);
+    expect(consoleLog).not.toHaveBeenCalledWith("click");
+
+    await user.hover(element);
+    expect(consoleLog).toHaveBeenCalledWith("mouseover");
+
+    await user.unhover(element);
+    expect(consoleLog).toHaveBeenCalledWith("mouseleave");
   });
 });

--- a/tests/ComboBox/FluidComboBoxSkeletonEvents.test.svelte
+++ b/tests/ComboBox/FluidComboBoxSkeletonEvents.test.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  import FluidComboBoxSkeleton from "carbon-components-svelte/ComboBox/FluidComboBoxSkeleton.svelte";
+</script>
+
+<FluidComboBoxSkeleton
+  data-testid="fluid-combo-box-skeleton"
+  on:click={() => {
+    console.log("click");
+  }}
+  on:mouseover={() => {
+    console.log("mouseover");
+  }}
+  on:mouseenter={() => {
+    console.log("mouseenter");
+  }}
+  on:mouseleave={() => {
+    console.log("mouseleave");
+  }}
+/>

--- a/tests/CopyInput/CopyInput.test.ts
+++ b/tests/CopyInput/CopyInput.test.ts
@@ -8,6 +8,7 @@ import CopyInput from "./CopyInput.test.svelte";
 import CopyInputAsync from "./CopyInputAsync.test.svelte";
 import CopyInputAsyncDoubleClick from "./CopyInputAsyncDoubleClick.test.svelte";
 import CopyInputMouseEnter from "./CopyInputMouseEnter.test.svelte";
+import CopyInputSkeletonEvents from "./CopyInputSkeletonEvents.test.svelte";
 
 describe("CopyInput", () => {
   beforeEach(() => {
@@ -332,6 +333,22 @@ describe("CopyInput", () => {
         "bx--skeleton",
         "bx--text-input",
       );
+    });
+
+    it("does not forward click but forwards mouse events on skeleton", async () => {
+      const consoleLog = vi.spyOn(console, "log");
+      render(CopyInputSkeletonEvents);
+
+      const element = screen.getByTestId("copy-input-skeleton");
+
+      await user.click(element);
+      expect(consoleLog).not.toHaveBeenCalledWith("click");
+
+      await user.hover(element);
+      expect(consoleLog).toHaveBeenCalledWith("mouseover");
+
+      await user.unhover(element);
+      expect(consoleLog).toHaveBeenCalledWith("mouseleave");
     });
   });
 });

--- a/tests/CopyInput/CopyInput.test.ts
+++ b/tests/CopyInput/CopyInput.test.ts
@@ -9,6 +9,7 @@ import CopyInputAsync from "./CopyInputAsync.test.svelte";
 import CopyInputAsyncDoubleClick from "./CopyInputAsyncDoubleClick.test.svelte";
 import CopyInputMouseEnter from "./CopyInputMouseEnter.test.svelte";
 import CopyInputSkeletonEvents from "./CopyInputSkeletonEvents.test.svelte";
+import FluidCopyInputSkeletonEvents from "./FluidCopyInputSkeletonEvents.test.svelte";
 
 describe("CopyInput", () => {
   beforeEach(() => {
@@ -340,6 +341,22 @@ describe("CopyInput", () => {
       render(CopyInputSkeletonEvents);
 
       const element = screen.getByTestId("copy-input-skeleton");
+
+      await user.click(element);
+      expect(consoleLog).not.toHaveBeenCalledWith("click");
+
+      await user.hover(element);
+      expect(consoleLog).toHaveBeenCalledWith("mouseover");
+
+      await user.unhover(element);
+      expect(consoleLog).toHaveBeenCalledWith("mouseleave");
+    });
+
+    it("does not forward click but forwards mouse events on fluid skeleton", async () => {
+      const consoleLog = vi.spyOn(console, "log");
+      render(FluidCopyInputSkeletonEvents);
+
+      const element = screen.getByTestId("fluid-copy-input-skeleton");
 
       await user.click(element);
       expect(consoleLog).not.toHaveBeenCalledWith("click");

--- a/tests/CopyInput/CopyInputSkeletonEvents.test.svelte
+++ b/tests/CopyInput/CopyInputSkeletonEvents.test.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+  import CopyInputSkeleton from "carbon-components-svelte/CopyInput/CopyInputSkeleton.svelte";
+
+  export let hideLabel = false;
+</script>
+
+<CopyInputSkeleton
+  data-testid="copy-input-skeleton"
+  {hideLabel}
+  on:click={() => {
+    console.log("click");
+  }}
+  on:mouseover={() => {
+    console.log("mouseover");
+  }}
+  on:mouseenter={() => {
+    console.log("mouseenter");
+  }}
+  on:mouseleave={() => {
+    console.log("mouseleave");
+  }}
+/>

--- a/tests/CopyInput/FluidCopyInputSkeletonEvents.test.svelte
+++ b/tests/CopyInput/FluidCopyInputSkeletonEvents.test.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  import FluidCopyInputSkeleton from "carbon-components-svelte/CopyInput/FluidCopyInputSkeleton.svelte";
+</script>
+
+<FluidCopyInputSkeleton
+  data-testid="fluid-copy-input-skeleton"
+  on:click={() => {
+    console.log("click");
+  }}
+  on:mouseover={() => {
+    console.log("mouseover");
+  }}
+  on:mouseenter={() => {
+    console.log("mouseenter");
+  }}
+  on:mouseleave={() => {
+    console.log("mouseleave");
+  }}
+/>

--- a/tests/DataTable/DataTableSkeleton.test.ts
+++ b/tests/DataTable/DataTableSkeleton.test.ts
@@ -1,0 +1,49 @@
+import { render } from "@testing-library/svelte";
+import { user } from "../utils/user";
+import DataTableSkeleton from "./DataTableSkeleton.test.svelte";
+import DataTableSkeletonEvents from "./DataTableSkeletonEvents.test.svelte";
+
+describe("DataTableSkeleton", () => {
+  it("renders skeleton state", () => {
+    const { container } = render(DataTableSkeleton);
+
+    const table = container.querySelector("table");
+    expect(table).toBeInTheDocument();
+    expect(table).toHaveClass("bx--skeleton", "bx--data-table");
+  });
+
+  it("renders with container wrapper", () => {
+    const { container } = render(DataTableSkeleton);
+    const wrapper = container.querySelector(".bx--data-table-container");
+    expect(wrapper).toBeInTheDocument();
+  });
+
+  it("does not forward click but forwards mouse events on the table", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    const { container } = render(DataTableSkeletonEvents);
+
+    const table = container.querySelector("table");
+    assert(table);
+
+    await user.click(table);
+    expect(consoleLog).not.toHaveBeenCalledWith("click");
+
+    await user.hover(table);
+    expect(consoleLog).toHaveBeenCalledWith("mouseover");
+
+    await user.unhover(table);
+    expect(consoleLog).toHaveBeenCalledWith("mouseleave");
+  });
+
+  it("renders header section by default", () => {
+    const { container } = render(DataTableSkeleton);
+    const header = container.querySelector(".bx--data-table-header");
+    expect(header).toBeInTheDocument();
+  });
+
+  it("renders toolbar section by default", () => {
+    const { container } = render(DataTableSkeleton);
+    const toolbar = container.querySelector(".bx--table-toolbar");
+    expect(toolbar).toBeInTheDocument();
+  });
+});

--- a/tests/DataTable/DataTableSkeletonEvents.test.svelte
+++ b/tests/DataTable/DataTableSkeletonEvents.test.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  import DataTableSkeleton from "carbon-components-svelte/DataTable/DataTableSkeleton.svelte";
+</script>
+
+<DataTableSkeleton
+  on:click={() => {
+    console.log("click");
+  }}
+  on:mouseover={() => {
+    console.log("mouseover");
+  }}
+  on:mouseenter={() => {
+    console.log("mouseenter");
+  }}
+  on:mouseleave={() => {
+    console.log("mouseleave");
+  }}
+/>

--- a/tests/DatePicker/DatePicker.fluidSkeleton.test.svelte
+++ b/tests/DatePicker/DatePicker.fluidSkeleton.test.svelte
@@ -5,4 +5,16 @@
 <FluidDatePickerSkeleton
   data-testid="fluid-date-picker-skeleton"
   {...$$props}
+  on:click={() => {
+    console.log("click");
+  }}
+  on:mouseover={() => {
+    console.log("mouseover");
+  }}
+  on:mouseenter={() => {
+    console.log("mouseenter");
+  }}
+  on:mouseleave={() => {
+    console.log("mouseleave");
+  }}
 />

--- a/tests/DatePicker/DatePickerSkeleton.test.ts
+++ b/tests/DatePicker/DatePickerSkeleton.test.ts
@@ -70,7 +70,7 @@ describe("DatePickerSkeleton", () => {
     const element = screen.getByTestId("date-picker-skeleton");
 
     await user.click(element);
-    expect(consoleLog).toHaveBeenCalledWith("click");
+    expect(consoleLog).not.toHaveBeenCalledWith("click");
 
     await user.hover(element);
     expect(consoleLog).toHaveBeenCalledWith("mouseover");

--- a/tests/DatePicker/DatePickerSkeleton.test.ts
+++ b/tests/DatePicker/DatePickerSkeleton.test.ts
@@ -123,4 +123,20 @@ describe("FluidDatePickerSkeleton", () => {
       skeleton.querySelectorAll(".bx--date-picker--fluid__skeleton--container"),
     ).toHaveLength(2);
   });
+
+  it("does not forward click but forwards mouse events", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(FluidDatePickerSkeleton);
+
+    const element = screen.getByTestId("fluid-date-picker-skeleton");
+
+    await user.click(element);
+    expect(consoleLog).not.toHaveBeenCalledWith("click");
+
+    await user.hover(element);
+    expect(consoleLog).toHaveBeenCalledWith("mouseover");
+
+    await user.unhover(element);
+    expect(consoleLog).toHaveBeenCalledWith("mouseleave");
+  });
 });

--- a/tests/Dropdown/Dropdown.fluidSkeleton.test.svelte
+++ b/tests/Dropdown/Dropdown.fluidSkeleton.test.svelte
@@ -2,4 +2,18 @@
   import FluidDropdownSkeleton from "carbon-components-svelte/Dropdown/FluidDropdownSkeleton.svelte";
 </script>
 
-<FluidDropdownSkeleton data-testid="fluid-dropdown-skeleton" />
+<FluidDropdownSkeleton
+  data-testid="fluid-dropdown-skeleton"
+  on:click={() => {
+    console.log("click");
+  }}
+  on:mouseover={() => {
+    console.log("mouseover");
+  }}
+  on:mouseenter={() => {
+    console.log("mouseenter");
+  }}
+  on:mouseleave={() => {
+    console.log("mouseleave");
+  }}
+/>

--- a/tests/Dropdown/Dropdown.test.ts
+++ b/tests/Dropdown/Dropdown.test.ts
@@ -2612,4 +2612,22 @@ describe("Dropdown", () => {
       expect(consoleLog).toHaveBeenCalledWith("mouseleave");
     });
   });
+
+  describe("FluidDropdownSkeleton", () => {
+    it("does not forward click but forwards mouse events", async () => {
+      const consoleLog = vi.spyOn(console, "log");
+      render(DropdownFluidSkeleton);
+
+      const element = screen.getByTestId("fluid-dropdown-skeleton");
+
+      await user.click(element);
+      expect(consoleLog).not.toHaveBeenCalledWith("click");
+
+      await user.hover(element);
+      expect(consoleLog).toHaveBeenCalledWith("mouseover");
+
+      await user.unhover(element);
+      expect(consoleLog).toHaveBeenCalledWith("mouseleave");
+    });
+  });
 });

--- a/tests/Dropdown/Dropdown.test.ts
+++ b/tests/Dropdown/Dropdown.test.ts
@@ -21,6 +21,7 @@ import DropdownGenerics from "./DropdownGenerics.test.svelte";
 import DropdownIconSlots from "./DropdownIconSlots.test.svelte";
 import DropdownInModal from "./DropdownInModal.test.svelte";
 import DropdownItemIcon from "./DropdownItemIcon.test.svelte";
+import DropdownSkeleton from "./DropdownSkeleton.test.svelte";
 import DropdownSlot from "./DropdownSlot.test.svelte";
 
 const items = [
@@ -2592,5 +2593,23 @@ describe("Dropdown", () => {
     expect(listBox.children).toHaveLength(2);
     expect(listBox.children[0]).toHaveClass("bx--list-box__label");
     expect(listBox.children[1]).toHaveClass("bx--list-box__field");
+  });
+
+  describe("DropdownSkeleton", () => {
+    it("does not forward click but forwards mouse events", async () => {
+      const consoleLog = vi.spyOn(console, "log");
+      render(DropdownSkeleton);
+
+      const element = screen.getByTestId("dropdown-skeleton");
+
+      await user.click(element);
+      expect(consoleLog).not.toHaveBeenCalledWith("click");
+
+      await user.hover(element);
+      expect(consoleLog).toHaveBeenCalledWith("mouseover");
+
+      await user.unhover(element);
+      expect(consoleLog).toHaveBeenCalledWith("mouseleave");
+    });
   });
 });

--- a/tests/Dropdown/DropdownSkeleton.test.svelte
+++ b/tests/Dropdown/DropdownSkeleton.test.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+  import DropdownSkeleton from "carbon-components-svelte/Dropdown/DropdownSkeleton.svelte";
+</script>
+
+<DropdownSkeleton
+  data-testid="dropdown-skeleton"
+  {...$$props}
+  on:click={() => {
+    console.log("click");
+  }}
+  on:mouseover={() => {
+    console.log("mouseover");
+  }}
+  on:mouseenter={() => {
+    console.log("mouseenter");
+  }}
+  on:mouseleave={() => {
+    console.log("mouseleave");
+  }}
+/>

--- a/tests/FileUploader/FileUploaderSkeleton.test.svelte
+++ b/tests/FileUploader/FileUploaderSkeleton.test.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+  import FileUploaderSkeleton from "carbon-components-svelte/FileUploader/FileUploaderSkeleton.svelte";
+</script>
+
+<FileUploaderSkeleton
+  data-testid="file-uploader-skeleton"
+  {...$$props}
+  on:click={() => {
+    console.log("click");
+  }}
+  on:mouseover={() => {
+    console.log("mouseover");
+  }}
+  on:mouseenter={() => {
+    console.log("mouseenter");
+  }}
+  on:mouseleave={() => {
+    console.log("mouseleave");
+  }}
+/>

--- a/tests/FileUploader/FileUploaderSkeleton.test.ts
+++ b/tests/FileUploader/FileUploaderSkeleton.test.ts
@@ -1,0 +1,21 @@
+import { render, screen } from "@testing-library/svelte";
+import { user } from "../utils/user";
+import FileUploaderSkeleton from "./FileUploaderSkeleton.test.svelte";
+
+describe("FileUploaderSkeleton", () => {
+  it("does not forward click but forwards mouse events", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(FileUploaderSkeleton);
+
+    const element = screen.getByTestId("file-uploader-skeleton");
+
+    await user.click(element);
+    expect(consoleLog).not.toHaveBeenCalledWith("click");
+
+    await user.hover(element);
+    expect(consoleLog).toHaveBeenCalledWith("mouseover");
+
+    await user.unhover(element);
+    expect(consoleLog).toHaveBeenCalledWith("mouseleave");
+  });
+});

--- a/tests/MultiSelect/MultiSelect.fluidSkeleton.test.svelte
+++ b/tests/MultiSelect/MultiSelect.fluidSkeleton.test.svelte
@@ -2,4 +2,18 @@
   import FluidMultiSelectSkeleton from "carbon-components-svelte/MultiSelect/FluidMultiSelectSkeleton.svelte";
 </script>
 
-<FluidMultiSelectSkeleton data-testid="fluid-multi-select-skeleton" />
+<FluidMultiSelectSkeleton
+  data-testid="fluid-multi-select-skeleton"
+  on:click={() => {
+    console.log("click");
+  }}
+  on:mouseover={() => {
+    console.log("mouseover");
+  }}
+  on:mouseenter={() => {
+    console.log("mouseenter");
+  }}
+  on:mouseleave={() => {
+    console.log("mouseleave");
+  }}
+/>

--- a/tests/MultiSelect/MultiSelect.test.ts
+++ b/tests/MultiSelect/MultiSelect.test.ts
@@ -3614,4 +3614,22 @@ describe("MultiSelect", () => {
     expect(listBox.children[0]).toHaveClass("bx--list-box__label");
     expect(listBox.children[1]).toHaveClass("bx--list-box__field");
   });
+
+  describe("FluidMultiSelectSkeleton", () => {
+    it("does not forward click but forwards mouse events", async () => {
+      const consoleLog = vi.spyOn(console, "log");
+      render(MultiSelectFluidSkeleton);
+
+      const element = screen.getByTestId("fluid-multi-select-skeleton");
+
+      await user.click(element);
+      expect(consoleLog).not.toHaveBeenCalledWith("click");
+
+      await user.hover(element);
+      expect(consoleLog).toHaveBeenCalledWith("mouseover");
+
+      await user.unhover(element);
+      expect(consoleLog).toHaveBeenCalledWith("mouseleave");
+    });
+  });
 });

--- a/tests/NumberInput/NumberInput.fluidSkeleton.test.svelte
+++ b/tests/NumberInput/NumberInput.fluidSkeleton.test.svelte
@@ -2,4 +2,18 @@
   import FluidNumberInputSkeleton from "carbon-components-svelte/NumberInput/FluidNumberInputSkeleton.svelte";
 </script>
 
-<FluidNumberInputSkeleton data-testid="fluid-number-input-skeleton" />
+<FluidNumberInputSkeleton
+  data-testid="fluid-number-input-skeleton"
+  on:click={() => {
+    console.log("click");
+  }}
+  on:mouseover={() => {
+    console.log("mouseover");
+  }}
+  on:mouseenter={() => {
+    console.log("mouseenter");
+  }}
+  on:mouseleave={() => {
+    console.log("mouseleave");
+  }}
+/>

--- a/tests/NumberInput/NumberInput.skeleton.test.svelte
+++ b/tests/NumberInput/NumberInput.skeleton.test.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+  import NumberInputSkeleton from "carbon-components-svelte/NumberInput/NumberInputSkeleton.svelte";
+
+  export let hideLabel = false;
+</script>
+
+<NumberInputSkeleton
+  data-testid="number-input-skeleton"
+  {hideLabel}
+  on:click={() => {
+    console.log("click");
+  }}
+  on:mouseover={() => {
+    console.log("mouseover");
+  }}
+  on:mouseenter={() => {
+    console.log("mouseenter");
+  }}
+  on:mouseleave={() => {
+    console.log("mouseleave");
+  }}
+/>

--- a/tests/NumberInput/NumberInput.test.ts
+++ b/tests/NumberInput/NumberInput.test.ts
@@ -1944,4 +1944,21 @@ describe("NumberInput", () => {
     expect(skeleton.children[0]).toHaveClass("bx--label", "bx--skeleton");
     expect(skeleton.children[1]).toHaveClass("bx--skeleton", "bx--text-input");
   });
+
+  it("does not forward click but forwards mouse events on fluid skeleton", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(NumberInputFluidSkeleton);
+
+    const skeleton = screen.getByTestId("fluid-number-input-skeleton");
+
+    await user.click(skeleton);
+    expect(consoleLog).not.toHaveBeenCalledWith("click");
+
+    await user.hover(skeleton);
+    expect(consoleLog).toHaveBeenCalledWith("mouseover");
+    expect(consoleLog).toHaveBeenCalledWith("mouseenter");
+
+    await user.unhover(skeleton);
+    expect(consoleLog).toHaveBeenCalledWith("mouseleave");
+  });
 });

--- a/tests/NumberInput/NumberInput.test.ts
+++ b/tests/NumberInput/NumberInput.test.ts
@@ -6,6 +6,7 @@ import { user } from "../utils/user";
 import NumberInputFluidForm from "./NumberInput.fluidForm.test.svelte";
 import NumberInputFluidSkeleton from "./NumberInput.fluidSkeleton.test.svelte";
 import NumberInputFluidSlot from "./NumberInput.fluidSlot.test.svelte";
+import NumberInputSkeleton from "./NumberInput.skeleton.test.svelte";
 import NumberInput from "./NumberInput.test.svelte";
 import NumberInputCustom from "./NumberInputCustom.test.svelte";
 
@@ -1950,6 +1951,23 @@ describe("NumberInput", () => {
     render(NumberInputFluidSkeleton);
 
     const skeleton = screen.getByTestId("fluid-number-input-skeleton");
+
+    await user.click(skeleton);
+    expect(consoleLog).not.toHaveBeenCalledWith("click");
+
+    await user.hover(skeleton);
+    expect(consoleLog).toHaveBeenCalledWith("mouseover");
+    expect(consoleLog).toHaveBeenCalledWith("mouseenter");
+
+    await user.unhover(skeleton);
+    expect(consoleLog).toHaveBeenCalledWith("mouseleave");
+  });
+
+  it("does not forward click but forwards mouse events on skeleton", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(NumberInputSkeleton);
+
+    const skeleton = screen.getByTestId("number-input-skeleton");
 
     await user.click(skeleton);
     expect(consoleLog).not.toHaveBeenCalledWith("click");

--- a/tests/Pagination/PaginationSkeleton.test.svelte
+++ b/tests/Pagination/PaginationSkeleton.test.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  import PaginationSkeleton from "carbon-components-svelte/Pagination/PaginationSkeleton.svelte";
+</script>
+
+<PaginationSkeleton
+  on:click={() => {
+    console.log("click");
+  }}
+  on:mouseover={() => {
+    console.log("mouseover");
+  }}
+  on:mouseenter={() => {
+    console.log("mouseenter");
+  }}
+  on:mouseleave={() => {
+    console.log("mouseleave");
+  }}
+/>

--- a/tests/Pagination/PaginationSkeleton.test.ts
+++ b/tests/Pagination/PaginationSkeleton.test.ts
@@ -1,5 +1,7 @@
 import { render } from "@testing-library/svelte";
 import PaginationSkeleton from "carbon-components-svelte/Pagination/PaginationSkeleton.svelte";
+import { user } from "../utils/user";
+import PaginationSkeletonFixture from "./PaginationSkeleton.test.svelte";
 
 describe("PaginationSkeleton", () => {
   function getRoot(container: HTMLElement) {
@@ -32,5 +34,24 @@ describe("PaginationSkeleton", () => {
     const { container } = render(PaginationSkeleton, { props: { size: "lg" } });
 
     expect(getRoot(container)).toHaveClass("bx--pagination--lg");
+  });
+
+  describe("event forwarding", () => {
+    it("does not forward click but forwards mouse events", async () => {
+      const consoleLog = vi.spyOn(console, "log");
+      const { container } = render(PaginationSkeletonFixture);
+
+      const skeleton = getRoot(container);
+
+      await user.click(skeleton);
+      expect(consoleLog).not.toHaveBeenCalledWith("click");
+
+      await user.hover(skeleton);
+      expect(consoleLog).toHaveBeenCalledWith("mouseover");
+      expect(consoleLog).toHaveBeenCalledWith("mouseenter");
+
+      await user.unhover(skeleton);
+      expect(consoleLog).toHaveBeenCalledWith("mouseleave");
+    });
   });
 });

--- a/tests/PasswordInput/PasswordInput.test.ts
+++ b/tests/PasswordInput/PasswordInput.test.ts
@@ -6,6 +6,7 @@ import PasswordInputSkeleton from "./PasswordInput.skeleton.test.svelte";
 import PasswordInputSlot from "./PasswordInput.slot.test.svelte";
 import PasswordInput from "./PasswordInput.test.svelte";
 import PasswordInputInModal from "./PasswordInputInModal.test.svelte";
+import PasswordInputSkeletonEvents from "./PasswordInputSkeletonEvents.test.svelte";
 
 describe("PasswordInput", () => {
   describe("Default", () => {
@@ -484,6 +485,26 @@ describe("PasswordInput", () => {
         "bx--skeleton",
         "bx--text-input",
       );
+    });
+
+    it("does not forward click but forwards mouse events", async () => {
+      const consoleLog = vi.spyOn(console, "log");
+      render(PasswordInputSkeletonEvents);
+
+      const skeleton = screen.getByTestId("skeleton");
+      expect(consoleLog).not.toHaveBeenCalledWith("click");
+
+      await user.click(skeleton);
+      expect(consoleLog).not.toHaveBeenCalledWith("click");
+
+      await user.hover(skeleton);
+      expect(consoleLog).toHaveBeenCalledWith("mouseover");
+      expect(consoleLog).toHaveBeenCalledWith("mouseenter");
+
+      await user.unhover(skeleton);
+      expect(consoleLog).toHaveBeenCalledWith("mouseleave");
+
+      consoleLog.mockRestore();
     });
   });
 });

--- a/tests/PasswordInput/PasswordInputSkeletonEvents.test.svelte
+++ b/tests/PasswordInput/PasswordInputSkeletonEvents.test.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+  import PasswordInputSkeleton from "carbon-components-svelte/TextInput/PasswordInputSkeleton.svelte";
+
+  export let hideLabel = false;
+</script>
+
+<PasswordInputSkeleton
+  data-testid="skeleton"
+  {hideLabel}
+  on:click={() => {
+    console.log("click");
+  }}
+  on:mouseover={() => {
+    console.log("mouseover");
+  }}
+  on:mouseenter={() => {
+    console.log("mouseenter");
+  }}
+  on:mouseleave={() => {
+    console.log("mouseleave");
+  }}
+/>

--- a/tests/PinCodeInput/PinCodeInput.fluidSkeleton.test.svelte
+++ b/tests/PinCodeInput/PinCodeInput.fluidSkeleton.test.svelte
@@ -2,4 +2,18 @@
   import FluidPinCodeInputSkeleton from "carbon-components-svelte/PinCodeInput/FluidPinCodeInputSkeleton.svelte";
 </script>
 
-<FluidPinCodeInputSkeleton data-testid="fluid-pin-code-input-skeleton" />
+<FluidPinCodeInputSkeleton
+  data-testid="fluid-pin-code-input-skeleton"
+  on:click={() => {
+    console.log("click");
+  }}
+  on:mouseover={() => {
+    console.log("mouseover");
+  }}
+  on:mouseenter={() => {
+    console.log("mouseenter");
+  }}
+  on:mouseleave={() => {
+    console.log("mouseleave");
+  }}
+/>

--- a/tests/PinCodeInput/PinCodeInput.skeleton.test.svelte
+++ b/tests/PinCodeInput/PinCodeInput.skeleton.test.svelte
@@ -4,4 +4,19 @@
   export let hideLabel = false;
 </script>
 
-<PinCodeInputSkeleton data-testid="pin-code-input-skeleton" {hideLabel} />
+<PinCodeInputSkeleton
+  data-testid="pin-code-input-skeleton"
+  {hideLabel}
+  on:click={() => {
+    console.log("click");
+  }}
+  on:mouseover={() => {
+    console.log("mouseover");
+  }}
+  on:mouseenter={() => {
+    console.log("mouseenter");
+  }}
+  on:mouseleave={() => {
+    console.log("mouseleave");
+  }}
+/>

--- a/tests/PinCodeInput/PinCodeInput.test.ts
+++ b/tests/PinCodeInput/PinCodeInput.test.ts
@@ -816,4 +816,21 @@ describe("PinCodeInput", () => {
     await user.unhover(skeleton);
     expect(consoleLog).toHaveBeenCalledWith("mouseleave");
   });
+
+  it("does not forward click but forwards mouse events on skeleton", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(PinCodeInputSkeleton);
+
+    const skeleton = screen.getByTestId("pin-code-input-skeleton");
+
+    await user.click(skeleton);
+    expect(consoleLog).not.toHaveBeenCalledWith("click");
+
+    await user.hover(skeleton);
+    expect(consoleLog).toHaveBeenCalledWith("mouseover");
+    expect(consoleLog).toHaveBeenCalledWith("mouseenter");
+
+    await user.unhover(skeleton);
+    expect(consoleLog).toHaveBeenCalledWith("mouseleave");
+  });
 });

--- a/tests/PinCodeInput/PinCodeInput.test.ts
+++ b/tests/PinCodeInput/PinCodeInput.test.ts
@@ -799,4 +799,21 @@ describe("PinCodeInput", () => {
     expect(skeleton.children).toHaveLength(1);
     expect(skeleton.children[0]).toHaveClass("bx--skeleton", "bx--text-input");
   });
+
+  it("does not forward click but forwards mouse events on fluid skeleton", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(PinCodeInputFluidSkeleton);
+
+    const skeleton = screen.getByTestId("fluid-pin-code-input-skeleton");
+
+    await user.click(skeleton);
+    expect(consoleLog).not.toHaveBeenCalledWith("click");
+
+    await user.hover(skeleton);
+    expect(consoleLog).toHaveBeenCalledWith("mouseover");
+    expect(consoleLog).toHaveBeenCalledWith("mouseenter");
+
+    await user.unhover(skeleton);
+    expect(consoleLog).toHaveBeenCalledWith("mouseleave");
+  });
 });

--- a/tests/ProgressIndicator/ProgressIndicatorSkeleton.events.test.svelte
+++ b/tests/ProgressIndicator/ProgressIndicatorSkeleton.events.test.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  import ProgressIndicatorSkeleton from "carbon-components-svelte/ProgressIndicator/ProgressIndicatorSkeleton.svelte";
+</script>
+
+<ProgressIndicatorSkeleton
+  on:click={() => {
+    console.log("click");
+  }}
+  on:mouseover={() => {
+    console.log("mouseover");
+  }}
+  on:mouseenter={() => {
+    console.log("mouseenter");
+  }}
+  on:mouseleave={() => {
+    console.log("mouseleave");
+  }}
+/>

--- a/tests/ProgressIndicator/ProgressIndicatorSkeleton.test.ts
+++ b/tests/ProgressIndicator/ProgressIndicatorSkeleton.test.ts
@@ -1,5 +1,7 @@
 import { render, screen } from "@testing-library/svelte";
 import ProgressIndicatorSkeleton from "carbon-components-svelte/ProgressIndicator/ProgressIndicatorSkeleton.svelte";
+import { user } from "../utils/user";
+import ProgressIndicatorSkeletonEvents from "./ProgressIndicatorSkeleton.events.test.svelte";
 
 describe("ProgressIndicatorSkeleton", () => {
   it("applies space-equal class when spaceEqually is true", () => {
@@ -24,5 +26,21 @@ describe("ProgressIndicatorSkeleton", () => {
 
     const list = screen.getByRole("list");
     expect(list).not.toHaveClass("bx--progress--space-equal");
+  });
+
+  it("does not forward click but forwards mouse events", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(ProgressIndicatorSkeletonEvents);
+
+    const list = screen.getByRole("list");
+
+    await user.click(list);
+    expect(consoleLog).not.toHaveBeenCalledWith("click");
+
+    await user.hover(list);
+    expect(consoleLog).toHaveBeenCalledWith("mouseover");
+
+    await user.unhover(list);
+    expect(consoleLog).toHaveBeenCalledWith("mouseleave");
   });
 });

--- a/tests/RadioButton/RadioButtonSkeleton.events.test.svelte
+++ b/tests/RadioButton/RadioButtonSkeleton.events.test.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  import RadioButtonSkeleton from "carbon-components-svelte/RadioButton/RadioButtonSkeleton.svelte";
+</script>
+
+<RadioButtonSkeleton
+  on:click={() => {
+    console.log("click");
+  }}
+  on:mouseover={() => {
+    console.log("mouseover");
+  }}
+  on:mouseenter={() => {
+    console.log("mouseenter");
+  }}
+  on:mouseleave={() => {
+    console.log("mouseleave");
+  }}
+/>

--- a/tests/RadioButton/RadioButtonSkeleton.test.ts
+++ b/tests/RadioButton/RadioButtonSkeleton.test.ts
@@ -1,0 +1,22 @@
+import { render } from "@testing-library/svelte";
+import { user } from "../utils/user";
+import RadioButtonSkeletonEvents from "./RadioButtonSkeleton.events.test.svelte";
+
+describe("RadioButtonSkeleton", () => {
+  it("does not forward click but forwards mouse events", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    const { container } = render(RadioButtonSkeletonEvents);
+
+    const wrapper = container.querySelector(".bx--radio-button-wrapper");
+    expect.assert(wrapper instanceof HTMLElement);
+
+    await user.click(wrapper);
+    expect(consoleLog).not.toHaveBeenCalledWith("click");
+
+    await user.hover(wrapper);
+    expect(consoleLog).toHaveBeenCalledWith("mouseover");
+
+    await user.unhover(wrapper);
+    expect(consoleLog).toHaveBeenCalledWith("mouseleave");
+  });
+});

--- a/tests/Search/FluidSearchSkeleton.events.test.svelte
+++ b/tests/Search/FluidSearchSkeleton.events.test.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  import FluidSearchSkeleton from "carbon-components-svelte/Search/FluidSearchSkeleton.svelte";
+</script>
+
+<FluidSearchSkeleton
+  data-testid="fluid-search-skeleton"
+  on:click={() => {
+    console.log("click");
+  }}
+  on:mouseover={() => {
+    console.log("mouseover");
+  }}
+  on:mouseenter={() => {
+    console.log("mouseenter");
+  }}
+  on:mouseleave={() => {
+    console.log("mouseleave");
+  }}
+/>

--- a/tests/Search/Search.test.ts
+++ b/tests/Search/Search.test.ts
@@ -2,6 +2,7 @@ import { render, screen } from "@testing-library/svelte";
 import type SearchComponent from "carbon-components-svelte/Search/Search.svelte";
 import type { ComponentProps } from "svelte";
 import { user } from "../utils/user";
+import FluidSearchSkeletonEvents from "./FluidSearchSkeleton.events.test.svelte";
 import SearchFluidForm from "./Search.fluidForm.test.svelte";
 import SearchFluidSkeleton from "./Search.fluidSkeleton.test.svelte";
 import SearchFluidSlot from "./Search.fluidSlot.test.svelte";
@@ -244,5 +245,21 @@ describe("Search", () => {
     expect(skeleton.children).toHaveLength(2);
     expect(skeleton.children[0]).toHaveClass("bx--label", "bx--skeleton");
     expect(skeleton.children[1]).toHaveClass("bx--skeleton", "bx--text-input");
+  });
+
+  it("FluidSearchSkeleton does not forward click but forwards mouse events", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(FluidSearchSkeletonEvents);
+
+    const skeleton = screen.getByTestId("fluid-search-skeleton");
+
+    await user.click(skeleton);
+    expect(consoleLog).not.toHaveBeenCalledWith("click");
+
+    await user.hover(skeleton);
+    expect(consoleLog).toHaveBeenCalledWith("mouseover");
+
+    await user.unhover(skeleton);
+    expect(consoleLog).toHaveBeenCalledWith("mouseleave");
   });
 });

--- a/tests/Search/Search.test.ts
+++ b/tests/Search/Search.test.ts
@@ -10,6 +10,7 @@ import SearchSlot from "./Search.slot.test.svelte";
 import Search from "./Search.test.svelte";
 import SearchExpandable from "./SearchExpandable.test.svelte";
 import SearchInitialEvent from "./SearchInitialEvent.test.svelte";
+import SearchSkeletonEvents from "./SearchSkeleton.events.test.svelte";
 import SearchSkeleton from "./SearchSkeleton.test.svelte";
 
 describe("Search", () => {
@@ -252,6 +253,24 @@ describe("Search", () => {
     render(FluidSearchSkeletonEvents);
 
     const skeleton = screen.getByTestId("fluid-search-skeleton");
+
+    await user.click(skeleton);
+    expect(consoleLog).not.toHaveBeenCalledWith("click");
+
+    await user.hover(skeleton);
+    expect(consoleLog).toHaveBeenCalledWith("mouseover");
+
+    await user.unhover(skeleton);
+    expect(consoleLog).toHaveBeenCalledWith("mouseleave");
+  });
+
+  it("SearchSkeleton does not forward click but forwards mouse events", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(SearchSkeletonEvents);
+
+    const skeleton = document.querySelector(".bx--skeleton");
+    expect(skeleton).not.toBeNull();
+    assert(skeleton instanceof HTMLElement);
 
     await user.click(skeleton);
     expect(consoleLog).not.toHaveBeenCalledWith("click");

--- a/tests/Search/SearchSkeleton.events.test.svelte
+++ b/tests/Search/SearchSkeleton.events.test.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  import SearchSkeleton from "carbon-components-svelte/Search/SearchSkeleton.svelte";
+</script>
+
+<SearchSkeleton
+  on:click={() => {
+    console.log("click");
+  }}
+  on:mouseover={() => {
+    console.log("mouseover");
+  }}
+  on:mouseenter={() => {
+    console.log("mouseenter");
+  }}
+  on:mouseleave={() => {
+    console.log("mouseleave");
+  }}
+/>

--- a/tests/SearchMenu/SearchMenu.test.ts
+++ b/tests/SearchMenu/SearchMenu.test.ts
@@ -6,6 +6,7 @@ import SearchMenuFooterDivider from "./SearchMenuFooterDivider.test.svelte";
 import SearchMenuGroups from "./SearchMenuGroups.test.svelte";
 import SearchMenuHighlight from "./SearchMenuHighlight.test.svelte";
 import SearchMenuMatch from "./SearchMenuMatch.test.svelte";
+import SearchMenuSkeletonEvents from "./SearchMenuSkeleton.events.test.svelte";
 import SearchMenuSkeleton from "./SearchMenuSkeleton.test.svelte";
 
 describe("SearchMenu", () => {
@@ -324,6 +325,24 @@ describe("SearchMenu groups", () => {
       ),
     ).toHaveLength(3);
     expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
+  });
+
+  it("SearchMenuSkeleton does not forward click but forwards mouse events", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(SearchMenuSkeletonEvents);
+
+    const skeleton = document.querySelector(".bx--search-menu__menu");
+    expect(skeleton).not.toBeNull();
+    assert(skeleton instanceof HTMLElement);
+
+    await user.click(skeleton);
+    expect(consoleLog).not.toHaveBeenCalledWith("click");
+
+    await user.hover(skeleton);
+    expect(consoleLog).toHaveBeenCalledWith("mouseover");
+
+    await user.unhover(skeleton);
+    expect(consoleLog).toHaveBeenCalledWith("mouseleave");
   });
 
   it("keeps a filter:false group unfiltered and hides empty group headers", async () => {

--- a/tests/SearchMenu/SearchMenuSkeleton.events.test.svelte
+++ b/tests/SearchMenu/SearchMenuSkeleton.events.test.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  import SearchMenuSkeleton from "carbon-components-svelte/SearchMenu/SearchMenuSkeleton.svelte";
+</script>
+
+<SearchMenuSkeleton
+  on:click={() => {
+    console.log("click");
+  }}
+  on:mouseover={() => {
+    console.log("mouseover");
+  }}
+  on:mouseenter={() => {
+    console.log("mouseenter");
+  }}
+  on:mouseleave={() => {
+    console.log("mouseleave");
+  }}
+/>

--- a/tests/Select/Select.fluidSkeleton.test.svelte
+++ b/tests/Select/Select.fluidSkeleton.test.svelte
@@ -2,4 +2,18 @@
   import FluidSelectSkeleton from "carbon-components-svelte/Select/FluidSelectSkeleton.svelte";
 </script>
 
-<FluidSelectSkeleton data-testid="fluid-select-skeleton" />
+<FluidSelectSkeleton
+  data-testid="fluid-select-skeleton"
+  on:click={() => {
+    console.log("click");
+  }}
+  on:mouseover={() => {
+    console.log("mouseover");
+  }}
+  on:mouseenter={() => {
+    console.log("mouseenter");
+  }}
+  on:mouseleave={() => {
+    console.log("mouseleave");
+  }}
+/>

--- a/tests/Select/Select.skeleton.test.svelte
+++ b/tests/Select/Select.skeleton.test.svelte
@@ -2,4 +2,18 @@
   import SelectSkeleton from "carbon-components-svelte/Select/SelectSkeleton.svelte";
 </script>
 
-<SelectSkeleton data-testid="select-skeleton" />
+<SelectSkeleton
+  data-testid="select-skeleton"
+  on:click={() => {
+    console.log("click");
+  }}
+  on:mouseover={() => {
+    console.log("mouseover");
+  }}
+  on:mouseenter={() => {
+    console.log("mouseenter");
+  }}
+  on:mouseleave={() => {
+    console.log("mouseleave");
+  }}
+/>

--- a/tests/Select/Select.test.ts
+++ b/tests/Select/Select.test.ts
@@ -753,3 +753,25 @@ describe("Select Generics", () => {
     expectTypeOf<Props["value"]>().toEqualTypeOf<string | number | undefined>();
   });
 });
+
+describe("SelectSkeleton", () => {
+  it("does not forward click but forwards mouse events", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(SelectSkeleton);
+
+    const skeleton = screen.getByTestId("select-skeleton");
+    expect(skeleton).toBeInTheDocument();
+
+    // Click should not trigger console.log
+    await user.click(skeleton);
+    expect(consoleLog).not.toHaveBeenCalledWith("click");
+
+    // But mouse events should still fire
+    await user.hover(skeleton);
+    expect(consoleLog).toHaveBeenCalledWith("mouseenter");
+    expect(consoleLog).toHaveBeenCalledWith("mouseover");
+
+    await user.unhover(skeleton);
+    expect(consoleLog).toHaveBeenCalledWith("mouseleave");
+  });
+});

--- a/tests/Select/Select.test.ts
+++ b/tests/Select/Select.test.ts
@@ -775,3 +775,25 @@ describe("SelectSkeleton", () => {
     expect(consoleLog).toHaveBeenCalledWith("mouseleave");
   });
 });
+
+describe("FluidSelectSkeleton", () => {
+  it("does not forward click but forwards mouse events", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(SelectFluidSkeleton);
+
+    const skeleton = screen.getByTestId("fluid-select-skeleton");
+    expect(skeleton).toBeInTheDocument();
+
+    // Click should not trigger console.log
+    await user.click(skeleton);
+    expect(consoleLog).not.toHaveBeenCalledWith("click");
+
+    // But mouse events should still fire
+    await user.hover(skeleton);
+    expect(consoleLog).toHaveBeenCalledWith("mouseenter");
+    expect(consoleLog).toHaveBeenCalledWith("mouseover");
+
+    await user.unhover(skeleton);
+    expect(consoleLog).toHaveBeenCalledWith("mouseleave");
+  });
+});

--- a/tests/Slider/RangeSlider.skeleton.test.ts
+++ b/tests/Slider/RangeSlider.skeleton.test.ts
@@ -1,0 +1,29 @@
+import { render, screen } from "@testing-library/svelte";
+import { user } from "../utils/user";
+import RangeSliderSkeleton from "./RangeSliderSkeleton.test.svelte";
+
+describe("RangeSliderSkeleton", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not forward click but forwards mouse events", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(RangeSliderSkeleton);
+
+    const skeleton = screen.getByTestId("range-slider-skeleton");
+    expect(skeleton).toBeInTheDocument();
+
+    // Click should not trigger console.log
+    await user.click(skeleton);
+    expect(consoleLog).not.toHaveBeenCalledWith("click");
+
+    // But mouse events should still fire
+    await user.hover(skeleton);
+    expect(consoleLog).toHaveBeenCalledWith("mouseenter");
+    expect(consoleLog).toHaveBeenCalledWith("mouseover");
+
+    await user.unhover(skeleton);
+    expect(consoleLog).toHaveBeenCalledWith("mouseleave");
+  });
+});

--- a/tests/Slider/RangeSliderSkeleton.test.svelte
+++ b/tests/Slider/RangeSliderSkeleton.test.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  import RangeSliderSkeleton from "carbon-components-svelte/Slider/RangeSliderSkeleton.svelte";
+</script>
+
+<RangeSliderSkeleton
+  data-testid="range-slider-skeleton"
+  on:click={() => {
+    console.log("click");
+  }}
+  on:mouseover={() => {
+    console.log("mouseover");
+  }}
+  on:mouseenter={() => {
+    console.log("mouseenter");
+  }}
+  on:mouseleave={() => {
+    console.log("mouseleave");
+  }}
+/>

--- a/tests/Slider/Slider.skeleton.test.ts
+++ b/tests/Slider/Slider.skeleton.test.ts
@@ -1,0 +1,29 @@
+import { render, screen } from "@testing-library/svelte";
+import { user } from "../utils/user";
+import SliderSkeleton from "./SliderSkeleton.test.svelte";
+
+describe("SliderSkeleton", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not forward click but forwards mouse events", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(SliderSkeleton);
+
+    const skeleton = screen.getByTestId("slider-skeleton");
+    expect(skeleton).toBeInTheDocument();
+
+    // Click should not trigger console.log
+    await user.click(skeleton);
+    expect(consoleLog).not.toHaveBeenCalledWith("click");
+
+    // But mouse events should still fire
+    await user.hover(skeleton);
+    expect(consoleLog).toHaveBeenCalledWith("mouseenter");
+    expect(consoleLog).toHaveBeenCalledWith("mouseover");
+
+    await user.unhover(skeleton);
+    expect(consoleLog).toHaveBeenCalledWith("mouseleave");
+  });
+});

--- a/tests/Slider/SliderSkeleton.test.svelte
+++ b/tests/Slider/SliderSkeleton.test.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  import SliderSkeleton from "carbon-components-svelte/Slider/SliderSkeleton.svelte";
+</script>
+
+<SliderSkeleton
+  data-testid="slider-skeleton"
+  on:click={() => {
+    console.log("click");
+  }}
+  on:mouseover={() => {
+    console.log("mouseover");
+  }}
+  on:mouseenter={() => {
+    console.log("mouseenter");
+  }}
+  on:mouseleave={() => {
+    console.log("mouseleave");
+  }}
+/>

--- a/tests/StructuredList/StructuredListSkeleton.test.svelte
+++ b/tests/StructuredList/StructuredListSkeleton.test.svelte
@@ -2,4 +2,19 @@
   import StructuredListSkeleton from "carbon-components-svelte/StructuredList/StructuredListSkeleton.svelte";
 </script>
 
-<StructuredListSkeleton {...$$props} />
+<StructuredListSkeleton
+  data-testid="structured-list-skeleton"
+  on:click={() => {
+    console.log("click");
+  }}
+  on:mouseover={() => {
+    console.log("mouseover");
+  }}
+  on:mouseenter={() => {
+    console.log("mouseenter");
+  }}
+  on:mouseleave={() => {
+    console.log("mouseleave");
+  }}
+  {...$$props}
+/>

--- a/tests/StructuredList/StructuredListSkeleton.test.ts
+++ b/tests/StructuredList/StructuredListSkeleton.test.ts
@@ -1,7 +1,12 @@
-import { render } from "@testing-library/svelte";
+import { render, screen } from "@testing-library/svelte";
+import { user } from "../utils/user";
 import StructuredListSkeleton from "./StructuredListSkeleton.test.svelte";
 
 describe("StructuredListSkeleton", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("renders 3 columns by default", () => {
     const { container } = render(StructuredListSkeleton);
 
@@ -25,5 +30,25 @@ describe("StructuredListSkeleton", () => {
     expect(container.querySelectorAll(".bx--structured-list-td")).toHaveLength(
       24,
     );
+  });
+
+  it("does not forward click but forwards mouse events", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(StructuredListSkeleton);
+
+    const skeleton = screen.getByTestId("structured-list-skeleton");
+    expect(skeleton).toBeInTheDocument();
+
+    // Click should not trigger console.log
+    await user.click(skeleton);
+    expect(consoleLog).not.toHaveBeenCalledWith("click");
+
+    // But mouse events should still fire
+    await user.hover(skeleton);
+    expect(consoleLog).toHaveBeenCalledWith("mouseenter");
+    expect(consoleLog).toHaveBeenCalledWith("mouseover");
+
+    await user.unhover(skeleton);
+    expect(consoleLog).toHaveBeenCalledWith("mouseleave");
   });
 });

--- a/tests/Tabs/Tabs.test.ts
+++ b/tests/Tabs/Tabs.test.ts
@@ -1004,6 +1004,25 @@ describe("TabsSkeleton", () => {
     expect(navItems).toHaveLength(20);
   });
 
+  it("does not forward click but forwards mouse events", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    const { container } = render(TabsSkeleton);
+
+    const skeleton = container.querySelector(".bx--tabs");
+    if (!skeleton) {
+      throw new Error("Skeleton not found");
+    }
+
+    await user.click(skeleton);
+    expect(consoleLog).not.toHaveBeenCalledWith("click");
+
+    await user.hover(skeleton);
+    expect(consoleLog).toHaveBeenCalledWith("mouseover");
+
+    await user.unhover(skeleton);
+    expect(consoleLog).toHaveBeenCalledWith("mouseleave");
+  });
+
   describe("Tab Generics", () => {
     it("should support custom Icon types with generics", () => {
       type CustomIcon = new (...args: unknown[]) => unknown;

--- a/tests/Tabs/TabsSkeleton.test.svelte
+++ b/tests/Tabs/TabsSkeleton.test.svelte
@@ -6,4 +6,19 @@
   export let type: ComponentProps<TabsSkeleton>["type"] = "default";
 </script>
 
-<TabsSkeleton {count} {type} />
+<TabsSkeleton
+  {count}
+  {type}
+  on:click={() => {
+    console.log("click");
+  }}
+  on:mouseover={() => {
+    console.log("mouseover");
+  }}
+  on:mouseenter={() => {
+    console.log("mouseenter");
+  }}
+  on:mouseleave={() => {
+    console.log("mouseleave");
+  }}
+/>

--- a/tests/Tabs/TabsVertical.test.ts
+++ b/tests/Tabs/TabsVertical.test.ts
@@ -179,6 +179,16 @@ describe("TabsVertical", () => {
 });
 
 describe("TabsVerticalSkeleton", () => {
+  let consoleLog: Console["log"];
+
+  beforeEach(() => {
+    consoleLog = vi.spyOn(console, "log");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("should render the vertical skeleton with the default count", () => {
     const { container } = render(TabsVerticalSkeleton);
 
@@ -198,5 +208,23 @@ describe("TabsVerticalSkeleton", () => {
     const { container } = render(TabsVerticalSkeleton, { props: { count: 0 } });
 
     expect(container.querySelectorAll(".bx--tabs__nav-item")).toHaveLength(0);
+  });
+
+  it("does not forward click but forwards mouse events", async () => {
+    const { container } = render(TabsVerticalSkeleton);
+
+    const skeleton = container.querySelector(".bx--tabs--vertical");
+    if (!skeleton) {
+      throw new Error("Skeleton not found");
+    }
+
+    await user.click(skeleton);
+    expect(consoleLog).not.toHaveBeenCalledWith("click");
+
+    await user.hover(skeleton);
+    expect(consoleLog).toHaveBeenCalledWith("mouseover");
+
+    await user.unhover(skeleton);
+    expect(consoleLog).toHaveBeenCalledWith("mouseleave");
   });
 });

--- a/tests/Tabs/TabsVerticalSkeleton.test.svelte
+++ b/tests/Tabs/TabsVerticalSkeleton.test.svelte
@@ -4,4 +4,18 @@
   export let count = 4;
 </script>
 
-<TabsVerticalSkeleton {count} />
+<TabsVerticalSkeleton
+  {count}
+  on:click={() => {
+    console.log("click");
+  }}
+  on:mouseover={() => {
+    console.log("mouseover");
+  }}
+  on:mouseenter={() => {
+    console.log("mouseenter");
+  }}
+  on:mouseleave={() => {
+    console.log("mouseleave");
+  }}
+/>

--- a/tests/Tag/Tag.test.ts
+++ b/tests/Tag/Tag.test.ts
@@ -6,6 +6,7 @@ import { expectInlineStyle } from "../utils/inline-style";
 import { user } from "../utils/user";
 import Tag from "./Tag.test.svelte";
 import TagMaxWidth from "./TagMaxWidth.test.svelte";
+import TagSkeleton from "./TagSkeleton.test.svelte";
 
 describe("Tag", () => {
   afterEach(() => {
@@ -339,6 +340,59 @@ describe("Tag", () => {
 
       // biome-ignore lint/suspicious/noExplicitAny: Testing default any type
       expectTypeOf<Props["icon"]>().toEqualTypeOf<any>();
+    });
+  });
+
+  describe("TagSkeleton", () => {
+    let consoleLog: Console["log"];
+
+    beforeEach(() => {
+      consoleLog = vi.spyOn(console, "log");
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it("should render with default props", () => {
+      const { container } = render(TagSkeleton);
+
+      const skeleton = container.querySelector(".bx--tag");
+      expect(skeleton).toBeInTheDocument();
+      expect(skeleton).toHaveClass("bx--skeleton");
+      expect(skeleton).toHaveClass("bx--tag");
+    });
+
+    it("should render with sm size", () => {
+      const { container } = render(TagSkeleton, { props: { size: "sm" } });
+
+      const skeleton = container.querySelector(".bx--tag");
+      expect(skeleton).toHaveClass("bx--tag--sm");
+    });
+
+    it("should render with lg size", () => {
+      const { container } = render(TagSkeleton, { props: { size: "lg" } });
+
+      const skeleton = container.querySelector(".bx--tag");
+      expect(skeleton).toHaveClass("bx--tag--lg");
+    });
+
+    it("does not forward click but forwards mouse events", async () => {
+      const { container } = render(TagSkeleton);
+
+      const skeleton = container.querySelector(".bx--tag");
+      if (!skeleton) {
+        throw new Error("Skeleton not found");
+      }
+
+      await user.click(skeleton);
+      expect(consoleLog).not.toHaveBeenCalledWith("click");
+
+      await user.hover(skeleton);
+      expect(consoleLog).toHaveBeenCalledWith("mouseover");
+
+      await user.unhover(skeleton);
+      expect(consoleLog).toHaveBeenCalledWith("mouseleave");
     });
   });
 });

--- a/tests/Tag/TagSkeleton.test.svelte
+++ b/tests/Tag/TagSkeleton.test.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+  import TagSkeleton from "carbon-components-svelte/Tag/TagSkeleton.svelte";
+  import type { ComponentProps } from "svelte";
+
+  export let size: ComponentProps<TagSkeleton>["size"] = "default";
+</script>
+
+<TagSkeleton
+  {size}
+  on:click={() => {
+    console.log("click");
+  }}
+  on:mouseover={() => {
+    console.log("mouseover");
+  }}
+  on:mouseenter={() => {
+    console.log("mouseenter");
+  }}
+  on:mouseleave={() => {
+    console.log("mouseleave");
+  }}
+/>

--- a/tests/TextArea/TextArea.fluidSkeleton.test.svelte
+++ b/tests/TextArea/TextArea.fluidSkeleton.test.svelte
@@ -2,4 +2,18 @@
   import FluidTextAreaSkeleton from "carbon-components-svelte/TextArea/FluidTextAreaSkeleton.svelte";
 </script>
 
-<FluidTextAreaSkeleton data-testid="fluid-text-area-skeleton" />
+<FluidTextAreaSkeleton
+  data-testid="fluid-text-area-skeleton"
+  on:click={() => {
+    console.log("click");
+  }}
+  on:mouseover={() => {
+    console.log("mouseover");
+  }}
+  on:mouseenter={() => {
+    console.log("mouseenter");
+  }}
+  on:mouseleave={() => {
+    console.log("mouseleave");
+  }}
+/>

--- a/tests/TextArea/TextArea.test.ts
+++ b/tests/TextArea/TextArea.test.ts
@@ -285,4 +285,23 @@ describe("TextArea", () => {
     expect(skeleton.children[0]).toHaveClass("bx--label", "bx--skeleton");
     expect(skeleton.children[1]).toHaveClass("bx--skeleton", "bx--text-area");
   });
+
+  it("FluidTextAreaSkeleton does not forward click but forwards mouse events", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+
+    render(TextAreaFluidSkeleton);
+
+    const skeleton = screen.getByTestId("fluid-text-area-skeleton");
+
+    await user.click(skeleton);
+    expect(consoleLog).not.toHaveBeenCalledWith("click");
+
+    await user.hover(skeleton);
+    expect(consoleLog).toHaveBeenCalledWith("mouseover");
+
+    await user.unhover(skeleton);
+    expect(consoleLog).toHaveBeenCalledWith("mouseleave");
+
+    vi.restoreAllMocks();
+  });
 });

--- a/tests/TextArea/TextArea.test.ts
+++ b/tests/TextArea/TextArea.test.ts
@@ -5,6 +5,7 @@ import TextAreaFluidSkeleton from "./TextArea.fluidSkeleton.test.svelte";
 import TextAreaFluidSlot from "./TextArea.fluidSlot.test.svelte";
 import TextArea from "./TextArea.test.svelte";
 import TextAreaCustom from "./TextAreaCustom.test.svelte";
+import TextAreaSkeleton from "./TextAreaSkeleton.test.svelte";
 
 describe("TextArea", () => {
   it("should render with default props", () => {
@@ -303,5 +304,67 @@ describe("TextArea", () => {
     expect(consoleLog).toHaveBeenCalledWith("mouseleave");
 
     vi.restoreAllMocks();
+  });
+
+  describe("TextAreaSkeleton", () => {
+    let consoleLog: Console["log"];
+
+    beforeEach(() => {
+      consoleLog = vi.spyOn(console, "log");
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it("should render with default props", () => {
+      const { container } = render(TextAreaSkeleton);
+
+      const formItem = container.querySelector(".bx--form-item");
+      expect(formItem).toBeInTheDocument();
+
+      const textAreaSkeleton = container.querySelector(".bx--text-area");
+      expect(textAreaSkeleton).toBeInTheDocument();
+      expect(textAreaSkeleton).toHaveClass("bx--skeleton");
+    });
+
+    it("should render with hidden label", () => {
+      const { container } = render(TextAreaSkeleton, {
+        props: { hideLabel: true },
+      });
+
+      const label = container.querySelector(".bx--label");
+      expect(label).not.toBeInTheDocument();
+
+      const textAreaSkeleton = container.querySelector(".bx--text-area");
+      expect(textAreaSkeleton).toBeInTheDocument();
+      expect(textAreaSkeleton).toHaveClass("bx--skeleton");
+    });
+
+    it("should render label by default", () => {
+      const { container } = render(TextAreaSkeleton);
+
+      const label = container.querySelector(".bx--label");
+      expect(label).toBeInTheDocument();
+      expect(label).toHaveClass("bx--skeleton");
+    });
+
+    it("does not forward click but forwards mouse events", async () => {
+      const { container } = render(TextAreaSkeleton);
+
+      const skeleton = container.querySelector(".bx--form-item");
+      if (!skeleton) {
+        throw new Error("Skeleton not found");
+      }
+
+      await user.click(skeleton);
+      expect(consoleLog).not.toHaveBeenCalledWith("click");
+
+      await user.hover(skeleton);
+      expect(consoleLog).toHaveBeenCalledWith("mouseover");
+
+      await user.unhover(skeleton);
+      expect(consoleLog).toHaveBeenCalledWith("mouseleave");
+    });
   });
 });

--- a/tests/TextArea/TextAreaSkeleton.test.svelte
+++ b/tests/TextArea/TextAreaSkeleton.test.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+  import TextAreaSkeleton from "carbon-components-svelte/TextArea/TextAreaSkeleton.svelte";
+  import type { ComponentProps } from "svelte";
+
+  export let hideLabel: ComponentProps<TextAreaSkeleton>["hideLabel"] = false;
+</script>
+
+<TextAreaSkeleton
+  {hideLabel}
+  on:click={() => {
+    console.log("click");
+  }}
+  on:mouseover={() => {
+    console.log("mouseover");
+  }}
+  on:mouseenter={() => {
+    console.log("mouseenter");
+  }}
+  on:mouseleave={() => {
+    console.log("mouseleave");
+  }}
+/>

--- a/tests/TextInput/TextInput.skeleton.test.svelte
+++ b/tests/TextInput/TextInput.skeleton.test.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  import TextInputSkeleton from "carbon-components-svelte/TextInput/TextInputSkeleton.svelte";
+
+  export let hideLabel = false;
+</script>
+
+<TextInputSkeleton data-testid="text-input-skeleton" {hideLabel} />

--- a/tests/TextInput/TextInput.test.ts
+++ b/tests/TextInput/TextInput.test.ts
@@ -4,6 +4,7 @@ import { user } from "../utils/user";
 import TextInputFluidForm from "./TextInput.fluidForm.test.svelte";
 import TextInputFluidSkeleton from "./TextInput.fluidSkeleton.test.svelte";
 import TextInputFluidSlot from "./TextInput.fluidSlot.test.svelte";
+import TextInputSkeleton from "./TextInput.skeleton.test.svelte";
 import TextInput from "./TextInput.test.svelte";
 import TextInputCustom from "./TextInputCustom.test.svelte";
 import TextInputInlineLabelChildren from "./TextInputInlineLabelChildren.test.svelte";
@@ -661,9 +662,48 @@ describe("TextInput", () => {
     expect(skeleton.children[1]).toHaveClass("bx--skeleton", "bx--text-input");
   });
 
+  it("renders text input skeleton state", () => {
+    render(TextInputSkeleton);
+
+    const skeleton = screen.getByTestId("text-input-skeleton");
+    expect(skeleton).toBeInTheDocument();
+    expect(skeleton).toHaveClass("bx--form-item");
+    expect(skeleton.children).toHaveLength(2);
+    expect(skeleton.children[0]).toHaveClass("bx--label", "bx--skeleton");
+    expect(skeleton.children[1]).toHaveClass("bx--skeleton", "bx--text-input");
+  });
+
+  it("hides the text input skeleton label when hideLabel is true", () => {
+    render(TextInputSkeleton, { props: { hideLabel: true } });
+
+    const skeleton = screen.getByTestId("text-input-skeleton");
+    expect(skeleton.children).toHaveLength(1);
+    expect(skeleton.children[0]).toHaveClass("bx--skeleton", "bx--text-input");
+  });
+
   it("FluidTextInputSkeleton does not forward click but forwards mouse events", async () => {
     const consoleLog = vi.spyOn(console, "log");
     render(TextInputSkeletonEvents, { props: { component: "fluid" } });
+
+    const skeleton = screen.getByTestId("skeleton");
+    expect(consoleLog).not.toHaveBeenCalledWith("click");
+
+    await user.click(skeleton);
+    expect(consoleLog).not.toHaveBeenCalledWith("click");
+
+    await user.hover(skeleton);
+    expect(consoleLog).toHaveBeenCalledWith("mouseover");
+    expect(consoleLog).toHaveBeenCalledWith("mouseenter");
+
+    await user.unhover(skeleton);
+    expect(consoleLog).toHaveBeenCalledWith("mouseleave");
+
+    consoleLog.mockRestore();
+  });
+
+  it("TextInputSkeleton does not forward click but forwards mouse events", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(TextInputSkeletonEvents, { props: { component: "text" } });
 
     const skeleton = screen.getByTestId("skeleton");
     expect(consoleLog).not.toHaveBeenCalledWith("click");

--- a/tests/TextInput/TextInput.test.ts
+++ b/tests/TextInput/TextInput.test.ts
@@ -7,6 +7,7 @@ import TextInputFluidSlot from "./TextInput.fluidSlot.test.svelte";
 import TextInput from "./TextInput.test.svelte";
 import TextInputCustom from "./TextInputCustom.test.svelte";
 import TextInputInlineLabelChildren from "./TextInputInlineLabelChildren.test.svelte";
+import TextInputSkeletonEvents from "./TextInputSkeletonEvents.test.svelte";
 
 describe("TextInput", () => {
   it("should render with default props", () => {
@@ -658,5 +659,25 @@ describe("TextInput", () => {
     expect(skeleton.children).toHaveLength(2);
     expect(skeleton.children[0]).toHaveClass("bx--label", "bx--skeleton");
     expect(skeleton.children[1]).toHaveClass("bx--skeleton", "bx--text-input");
+  });
+
+  it("FluidTextInputSkeleton does not forward click but forwards mouse events", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(TextInputSkeletonEvents, { props: { component: "fluid" } });
+
+    const skeleton = screen.getByTestId("skeleton");
+    expect(consoleLog).not.toHaveBeenCalledWith("click");
+
+    await user.click(skeleton);
+    expect(consoleLog).not.toHaveBeenCalledWith("click");
+
+    await user.hover(skeleton);
+    expect(consoleLog).toHaveBeenCalledWith("mouseover");
+    expect(consoleLog).toHaveBeenCalledWith("mouseenter");
+
+    await user.unhover(skeleton);
+    expect(consoleLog).toHaveBeenCalledWith("mouseleave");
+
+    consoleLog.mockRestore();
   });
 });

--- a/tests/TextInput/TextInputSkeletonEvents.test.svelte
+++ b/tests/TextInput/TextInputSkeletonEvents.test.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+  import FluidTextInputSkeleton from "carbon-components-svelte/TextInput/FluidTextInputSkeleton.svelte";
+  import TextInputSkeleton from "carbon-components-svelte/TextInput/TextInputSkeleton.svelte";
+
+  export let component = "fluid";
+</script>
+
+{#if component === "fluid"}
+  <FluidTextInputSkeleton
+    data-testid="skeleton"
+    on:click={() => {
+      console.log("click");
+    }}
+    on:mouseover={() => {
+      console.log("mouseover");
+    }}
+    on:mouseenter={() => {
+      console.log("mouseenter");
+    }}
+    on:mouseleave={() => {
+      console.log("mouseleave");
+    }}
+  />
+{:else}
+  <TextInputSkeleton
+    data-testid="skeleton"
+    on:click={() => {
+      console.log("click");
+    }}
+    on:mouseover={() => {
+      console.log("mouseover");
+    }}
+    on:mouseenter={() => {
+      console.log("mouseenter");
+    }}
+    on:mouseleave={() => {
+      console.log("mouseleave");
+    }}
+  />
+{/if}

--- a/tests/TimePicker/FluidTimePickerSkeletonEvents.test.svelte
+++ b/tests/TimePicker/FluidTimePickerSkeletonEvents.test.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+  import FluidTimePickerSkeleton from "carbon-components-svelte/TimePicker/FluidTimePickerSkeleton.svelte";
+
+  export let isOnlyTwo = false;
+</script>
+
+<FluidTimePickerSkeleton
+  data-testid="skeleton"
+  {isOnlyTwo}
+  on:click={() => {
+    console.log("click");
+  }}
+  on:mouseover={() => {
+    console.log("mouseover");
+  }}
+  on:mouseenter={() => {
+    console.log("mouseenter");
+  }}
+  on:mouseleave={() => {
+    console.log("mouseleave");
+  }}
+/>

--- a/tests/TimePicker/TimePicker.test.ts
+++ b/tests/TimePicker/TimePicker.test.ts
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/svelte";
 import { user } from "../utils/user";
+import FluidTimePickerSkeletonEvents from "./FluidTimePickerSkeletonEvents.test.svelte";
 import TimePickerFluidForm from "./TimePicker.fluidForm.test.svelte";
 import TimePickerFluidSkeleton from "./TimePicker.fluidSkeleton.test.svelte";
 import TimePickerFluidSlot from "./TimePicker.fluidSlot.test.svelte";
@@ -501,5 +502,25 @@ describe("TimePicker", () => {
     expect(skeleton.children).toHaveLength(2);
     expect(skeleton.children[0]).toHaveClass("bx--text-input--fluid__skeleton");
     expect(skeleton.children[1]).toHaveClass("bx--select--fluid__skeleton");
+  });
+
+  it("does not forward click but forwards mouse events", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(FluidTimePickerSkeletonEvents);
+
+    const skeleton = screen.getByTestId("skeleton");
+    expect(consoleLog).not.toHaveBeenCalledWith("click");
+
+    await user.click(skeleton);
+    expect(consoleLog).not.toHaveBeenCalledWith("click");
+
+    await user.hover(skeleton);
+    expect(consoleLog).toHaveBeenCalledWith("mouseover");
+    expect(consoleLog).toHaveBeenCalledWith("mouseenter");
+
+    await user.unhover(skeleton);
+    expect(consoleLog).toHaveBeenCalledWith("mouseleave");
+
+    consoleLog.mockRestore();
   });
 });

--- a/tests/Toggle/Toggle.test.ts
+++ b/tests/Toggle/Toggle.test.ts
@@ -4,6 +4,7 @@ import ToggleReadonly from "./Toggle.readonly.test.svelte";
 import Toggle from "./Toggle.test.svelte";
 import ToggleNullishAriaLabel from "./ToggleNullishAriaLabel.test.svelte";
 import ToggleSkeletonSlot from "./ToggleSkeleton.slot.test.svelte";
+import ToggleSkeletonEvents from "./ToggleSkeletonEvents.test.svelte";
 import ToggleSkeletonNullishAriaLabel from "./ToggleSkeletonNullishAriaLabel.test.svelte";
 
 describe("Toggle", () => {
@@ -375,5 +376,25 @@ describe("Toggle", () => {
     render(ToggleSkeletonNullishAriaLabel, { props: { ariaLabel: "" } });
     const label = document.querySelector("label[aria-label]");
     expect(label).toHaveAttribute("aria-label", "");
+  });
+
+  it("ToggleSkeleton does not forward click but forwards mouse events", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(ToggleSkeletonEvents);
+
+    const skeleton = screen.getByTestId("skeleton");
+    expect(consoleLog).not.toHaveBeenCalledWith("click");
+
+    await user.click(skeleton);
+    expect(consoleLog).not.toHaveBeenCalledWith("click");
+
+    await user.hover(skeleton);
+    expect(consoleLog).toHaveBeenCalledWith("mouseover");
+    expect(consoleLog).toHaveBeenCalledWith("mouseenter");
+
+    await user.unhover(skeleton);
+    expect(consoleLog).toHaveBeenCalledWith("mouseleave");
+
+    consoleLog.mockRestore();
   });
 });

--- a/tests/Toggle/ToggleSkeletonEvents.test.svelte
+++ b/tests/Toggle/ToggleSkeletonEvents.test.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+  import ToggleSkeleton from "carbon-components-svelte/Toggle/ToggleSkeleton.svelte";
+
+  export let size = "default";
+  export let labelText = "Toggle";
+</script>
+
+<ToggleSkeleton
+  data-testid="skeleton"
+  {size}
+  {labelText}
+  on:click={() => {
+    console.log("click");
+  }}
+  on:mouseover={() => {
+    console.log("mouseover");
+  }}
+  on:mouseenter={() => {
+    console.log("mouseenter");
+  }}
+  on:mouseleave={() => {
+    console.log("mouseleave");
+  }}
+/>


### PR DESCRIPTION
Same breaking change lands on the other skeleton components, one
commit apiece. Non-interactive loading placeholders no longer
forward click events from their root.
