### PR TITLE
fix(multi-select): keep disabled options in keyboard navigation

### DIFF
--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -191,6 +191,13 @@
   export let readonlyText = "Read-only";
 
   /**
+   * Specify the assistive text describing options disabled by `maxSelectedItems`.
+   * Announced so screen reader users learn why an option refuses selection,
+   * not just that it is disabled.
+   */
+  export let maxSelectedText = "Maximum items selected";
+
+  /**
    * Specify a name attribute for the select.
    * @type {string}
    */
@@ -296,7 +303,7 @@
   import { dismiss } from "../utils/dismiss.js";
   import { isOutsideClick } from "../utils/isOutsideClick.js";
   import { createScrollEndTracker } from "../utils/isScrollNearEnd.js";
-  import { nextEnabledIndex } from "../utils/moveIndex.js";
+  import { moveIndex } from "../utils/moveIndex.js";
   import {
     resetVirtualScrollOnClose,
     scrollHighlightedIntoView,
@@ -355,13 +362,12 @@
   }
 
   function change(step) {
+    // Disabled options stay in the keyboard navigation sequence (APG:
+    // "Focusability of disabled controls") so assistive-tech users can
+    // discover them; selectItem and the option click handlers refuse the
+    // actual selection.
     const navigableItems = filterable ? filteredItems : sortedItems;
-    highlightedIndex = nextEnabledIndex({
-      items: navigableItems,
-      index: highlightedIndex,
-      step,
-      isDisabled: isItemDisabled,
-    });
+    highlightedIndex = moveIndex(highlightedIndex, step, navigableItems.length);
     highlightOrigin = "keyboard";
   }
 
@@ -713,6 +719,7 @@
     typeof maxSelectedItems === "number" && maxSelectedItems > 0;
   $: isAtSelectionCap =
     hasMaxSelectedItems && selectionCount >= maxSelectedItems;
+  $: maxSelectedId = `max-selected-${id}`;
   $: filteredItems = sortedItems.filter(
     (item) => item.isSelectAll || filterItem(item, value),
   );
@@ -1123,10 +1130,16 @@
                   item.disabled ||
                   (hasMaxSelectedItems && !!item.isSelectAll) ||
                   (isAtSelectionCap && !item.checked)}
+                {@const capDisabled =
+                  isAtSelectionCap &&
+                  !item.checked &&
+                  !item.disabled &&
+                  !item.isSelectAll}
                 <ListBoxMenuItem
                   id="{id}-{item.id}"
                   role="option"
                   aria-labelledby="checkbox-{id}-{item.id}"
+                  aria-describedby={capDisabled ? maxSelectedId : undefined}
                   aria-selected={item.isSelectAll ? allSelected : item.checked}
                   aria-checked={item.isSelectAll
                     ? selectAllIndeterminate
@@ -1199,10 +1212,16 @@
               item.disabled ||
               (hasMaxSelectedItems && !!item.isSelectAll) ||
               (isAtSelectionCap && !item.checked)}
+            {@const capDisabled =
+              isAtSelectionCap &&
+              !item.checked &&
+              !item.disabled &&
+              !item.isSelectAll}
             <ListBoxMenuItem
               id="{id}-{item.id}"
               role="option"
               aria-labelledby="checkbox-{id}-{item.id}"
+              aria-describedby={capDisabled ? maxSelectedId : undefined}
               aria-selected={item.isSelectAll ? allSelected : item.checked}
               aria-checked={item.isSelectAll
                 ? selectAllIndeterminate
@@ -1288,6 +1307,11 @@
     >
       {helperText}
     </div>
+  {/if}
+  {#if hasMaxSelectedItems}
+    <span id={maxSelectedId} class:bx--visually-hidden={true}
+      >{maxSelectedText}</span
+    >
   {/if}
   {#if readonly}
     <span id={readonlyId} class:bx--visually-hidden={true}

--- a/tests/MultiSelect/MultiSelect.test.ts
+++ b/tests/MultiSelect/MultiSelect.test.ts
@@ -670,7 +670,7 @@ describe("MultiSelect", () => {
       );
     });
 
-    it("skips unchecked items at the cap during keyboard navigation", async () => {
+    it("keeps cap-disabled items navigable but refuses selection", async () => {
       render(MultiSelect, {
         props: {
           items: preferenceItems,
@@ -691,14 +691,41 @@ describe("MultiSelect", () => {
       expect(emailOption).toHaveClass("bx--list-box__menu-item--highlighted");
 
       await user.keyboard("{ArrowDown}");
-      expect(emailOption).toHaveClass("bx--list-box__menu-item--highlighted");
-      expect(slackOption).not.toHaveClass(
-        "bx--list-box__menu-item--highlighted",
-      );
+      expect(slackOption).toHaveClass("bx--list-box__menu-item--highlighted");
 
       await user.keyboard("{Enter}");
-      expect(emailOption).toHaveAttribute("aria-selected", "false");
-      expect(slackOption).not.toHaveAttribute("aria-disabled");
+      expect(slackOption).toHaveAttribute("aria-selected", "false");
+      expect(slackOption).toHaveAttribute("aria-disabled", "true");
+      expect(emailOption).toHaveAttribute("aria-selected", "true");
+    });
+
+    it("describes why cap-disabled options refuse selection", async () => {
+      render(MultiSelect, {
+        props: {
+          items: preferenceItems,
+          maxSelectedItems: 1,
+          selectedIds: ["0"],
+          sortItem: () => 0,
+          labelText: "Preferences",
+        },
+      });
+
+      await openMenu();
+
+      const slackOption = screen.getByRole("option", { name: "Slack" });
+      const describedById = slackOption.getAttribute("aria-describedby");
+      expect(describedById).toBeTruthy();
+      expect(document.getElementById(describedById ?? "")).toHaveTextContent(
+        "Maximum items selected",
+      );
+
+      // Checked items stay selectable at the cap and need no explanation.
+      const emailOption = screen.getByRole("option", { name: "Email" });
+      expect(emailOption).not.toHaveAttribute("aria-describedby");
+
+      // Below the cap, no option carries the description.
+      await toggleOption("Email");
+      expect(slackOption).not.toHaveAttribute("aria-describedby");
     });
 
     it("disables select-all when a cap is set", async () => {
@@ -1522,7 +1549,6 @@ describe("MultiSelect", () => {
     const input = screen.getByPlaceholderText("Filter...");
     await user.click(input);
 
-    // If the while loop has no guard, this would hang forever.
     await user.keyboard("{ArrowDown}");
     await user.keyboard("{ArrowUp}");
 
@@ -1533,7 +1559,7 @@ describe("MultiSelect", () => {
     }
   });
 
-  it("skips disabled items during keyboard navigation", async () => {
+  it("highlights disabled items during keyboard navigation without selecting them", async () => {
     render(MultiSelect, {
       props: {
         items: [
@@ -1550,9 +1576,15 @@ describe("MultiSelect", () => {
     await user.type(input, "a");
     await user.keyboard("{ArrowDown}");
     await user.keyboard("{ArrowDown}");
-    await user.keyboard("{Enter}");
 
+    // The disabled item is reachable (APG), but Enter on it is a no-op.
     const options = screen.getAllByRole("option");
+    expect(options[1]).toHaveClass("bx--list-box__menu-item--highlighted");
+    await user.keyboard("{Enter}");
+    expect(options[1]).toHaveAttribute("aria-selected", "false");
+
+    await user.keyboard("{ArrowDown}");
+    await user.keyboard("{Enter}");
     expect(options[2]).toHaveAttribute("aria-selected", "true");
   });
 


### PR DESCRIPTION
Arrow keys no longer skip disabled options. Disabled items stay in the navigation sequence with aria-disabled="true" and refuse selection, per APG guidance for composite widgets — otherwise a screen reader user driving the listbox through aria-activedescendant cannot discover that a disabled option exists. Hover highlighting of disabled options remains off.

Options disabled by maxSelectedItems now reference a visually-hidden "Maximum items selected" description via aria-describedby, so the reason an option refuses selection is announced, not just the dimmed state. The text is exposed as a new maxSelectedText prop for i18n.

Note that this is a departure from the React project. They skip disabled items. But that behavior is not correct according to https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#focusabilityofdisabledcontrols.