### PR TITLE
fix(dropdown,combobox): keep disabled options in keyboard navigation

### DIFF
--- a/src/ComboBox/ComboBox.svelte
+++ b/src/ComboBox/ComboBox.svelte
@@ -250,7 +250,7 @@
   import { dismiss } from "../utils/dismiss.js";
   import { isOutsideClick } from "../utils/isOutsideClick.js";
   import { createScrollEndTracker } from "../utils/isScrollNearEnd.js";
-  import { nextEnabledIndex } from "../utils/moveIndex.js";
+  import { moveIndex } from "../utils/moveIndex.js";
   import {
     resetVirtualScrollOnClose,
     scrollHighlightedIntoView,
@@ -318,12 +318,12 @@
   }
 
   function change(step) {
+    // Disabled options stay in the keyboard navigation sequence (APG:
+    // "Focusability of disabled controls") so assistive-tech users can
+    // discover them; the Enter handler and the option click handlers refuse
+    // the actual selection.
     const navigableItems = filteredItems?.length ? filteredItems : items;
-    highlightedIndex = nextEnabledIndex({
-      items: navigableItems,
-      index: highlightedIndex,
-      step,
-    });
+    highlightedIndex = moveIndex(highlightedIndex, step, navigableItems.length);
     highlightOrigin = "keyboard";
   }
 
@@ -724,6 +724,15 @@
             event.preventDefault();
           }
           if (event.key === "Enter") {
+            // Enter on a highlighted disabled option -> the menu stays open.
+            if (
+              open &&
+              highlightOrigin === "keyboard" &&
+              highlightedIndex > -1 &&
+              filteredItems[highlightedIndex]?.disabled
+            ) {
+              return;
+            }
             const wasOpen = open;
             open = !open;
             if (

--- a/src/Dropdown/Dropdown.svelte
+++ b/src/Dropdown/Dropdown.svelte
@@ -219,7 +219,7 @@
   import { dismiss } from "../utils/dismiss.js";
   import { isOutsideClick } from "../utils/isOutsideClick.js";
   import { createScrollEndTracker } from "../utils/isScrollNearEnd.js";
-  import { nextEnabledIndex } from "../utils/moveIndex.js";
+  import { moveIndex } from "../utils/moveIndex.js";
   import { typeaheadIndex } from "../utils/typeahead.js";
   import {
     resetVirtualScrollOnClose,
@@ -426,11 +426,11 @@
   }
 
   function change(step) {
-    highlightedIndex = nextEnabledIndex({
-      items,
-      index: highlightedIndex,
-      step,
-    });
+    // Disabled options stay in the keyboard navigation sequence (APG:
+    // "Focusability of disabled controls") so assistive-tech users can
+    // discover them; selectHighlighted and the option click handlers refuse
+    // the actual selection.
+    highlightedIndex = moveIndex(highlightedIndex, step, items.length);
     highlightOrigin = "keyboard";
   }
 
@@ -478,6 +478,14 @@
   function selectHighlighted() {
     if (!open) {
       open = true;
+      return;
+    }
+    // Enter/Space on a highlighted disabled option -> the menu stays open.
+    if (
+      highlightOrigin === "keyboard" &&
+      highlightedIndex > -1 &&
+      items[highlightedIndex]?.disabled
+    ) {
       return;
     }
     if (

--- a/tests/ComboBox/ComboBox.test.ts
+++ b/tests/ComboBox/ComboBox.test.ts
@@ -111,7 +111,7 @@ describe("ComboBox", () => {
     expect(input).toHaveValue("Fax");
   });
 
-  it("should skip disabled items when opening the menu on ArrowDown", async () => {
+  it("should highlight a disabled first item when opening the menu on ArrowDown", async () => {
     render(ComboBox, {
       props: {
         items: [
@@ -128,8 +128,15 @@ describe("ComboBox", () => {
     await user.keyboard("{ArrowDown}");
     await tick();
 
-    // Slack (id="0") is disabled, so Email (id="1") is highlighted.
-    expect(input.getAttribute("aria-activedescendant")).toMatch(/-1$/);
+    // Slack (id="0") is disabled but stays in the navigation sequence so
+    // assistive-tech users can discover it.
+    expect(input.getAttribute("aria-activedescendant")).toMatch(/-0$/);
+
+    // Enter on the highlighted disabled item selects nothing and leaves the
+    // menu open
+    await user.keyboard("{Enter}");
+    expect(input).toHaveValue("");
+    expect(input).toHaveAttribute("aria-expanded", "true");
   });
 
   it("should respect an existing typed filter when opening the menu on ArrowDown", async () => {
@@ -935,7 +942,7 @@ describe("ComboBox", () => {
     expect(dropdown).toBeVisible();
   });
 
-  it("should not infinite loop when all items are disabled", async () => {
+  it("should select nothing when all items are disabled", async () => {
     render(ComboBoxCustom, {
       props: {
         items: [
@@ -948,13 +955,18 @@ describe("ComboBox", () => {
     const input = getInput();
     await user.click(input);
 
-    // If the while loop has no guard, this would hang forever.
+    // Disabled items stay in the keyboard navigation sequence so
+    // assistive-tech users can discover them.
     await user.keyboard("{ArrowDown}");
+    expect(input.getAttribute("aria-activedescendant")).toMatch(/-1$/);
     await user.keyboard("{ArrowUp}");
+    expect(input.getAttribute("aria-activedescendant")).toMatch(/-3$/);
 
-    // No item should be selectable since all are disabled.
+    // Enter on a highlighted disabled item selects nothing and leaves the
+    // menu open
     await user.keyboard("{Enter}");
     expect(input).toHaveValue("");
+    expect(input).toHaveAttribute("aria-expanded", "true");
   });
 
   it("should not auto-select an unrelated item when Enter is pressed with a partial match", async () => {
@@ -971,17 +983,13 @@ describe("ComboBox", () => {
     expect(input).toHaveValue("a");
   });
 
-  it("should skip disabled items in filtered list, not unfiltered list", async () => {
-    // Regression: `change()` previously checked `items[index].disabled`
-    // instead of `_items[index].disabled`, indexing into the wrong array
-    // when filtering was active.
+  it("should navigate the filtered list, not the unfiltered list", async () => {
+    // Regression guard: `change()` previously indexed into the wrong array
+    // when filtering was active. Navigation must step through the filtered
+    // items, including disabled ones.
     //
     // Unfiltered: [Ax, Bx, Ay(disabled), Az]
     // Filtered by "a": [Ax, Ay(disabled), Az]
-    //
-    // Old bug: at filtered index 1 (Ay), it checked items[1] (Bx, not
-    // disabled) and stopped — highlighting a disabled item. Fixed code
-    // checks _items[1] (Ay, disabled) and correctly skips to Az.
     render(ComboBoxCustom, {
       props: {
         items: [
@@ -998,15 +1006,22 @@ describe("ComboBox", () => {
     // Typing "a" filters to: Ax, Ay (disabled), Az
     await user.type(input, "a");
 
-    // ArrowDown highlights Ax (index 0)
+    // ArrowDown highlights Ax (filtered index 0)
     await user.keyboard("{ArrowDown}");
-    // ArrowDown should skip disabled Ay, highlight Az
+    // ArrowDown highlights disabled Ay (id "3"), not Bx (id "2") — the
+    // highlight steps through the filtered list and includes disabled items.
+    await user.keyboard("{ArrowDown}");
+    expect(input.getAttribute("aria-activedescendant")).toMatch(/-3$/);
+    // Enter on the highlighted disabled item is a no-op.
+    await user.keyboard("{Enter}");
+    expect(input).toHaveValue("a");
+    // ArrowDown reaches Az, which selects normally.
     await user.keyboard("{ArrowDown}");
     await user.keyboard("{Enter}");
     expect(input).toHaveValue("Az");
   });
 
-  it("should skip disabled items during keyboard navigation", async () => {
+  it("should highlight but not select disabled items during keyboard navigation", async () => {
     render(ComboBoxCustom, {
       props: {
         items: [
@@ -1018,8 +1033,14 @@ describe("ComboBox", () => {
     });
     const input = getInput();
     await user.click(input);
-    await user.keyboard("{ArrowDown}"); // should highlight A
-    await user.keyboard("{ArrowDown}"); // should skip B and highlight C
+    await user.keyboard("{ArrowDown}"); // highlights A
+    await user.keyboard("{ArrowDown}"); // highlights disabled B
+    // Enter on the highlighted disabled item selects nothing and leaves the
+    // menu open, matching click.
+    await user.keyboard("{Enter}");
+    expect(input).toHaveValue("");
+    expect(input).toHaveAttribute("aria-expanded", "true");
+    await user.keyboard("{ArrowDown}"); // highlights C
     await user.keyboard("{Enter}");
     expect(input).toHaveValue("C");
   });

--- a/tests/Dropdown/Dropdown.test.ts
+++ b/tests/Dropdown/Dropdown.test.ts
@@ -646,7 +646,7 @@ describe("Dropdown", () => {
     expect(dropdown).toHaveClass("bx--list-box--up");
   });
 
-  it("should not infinite loop when all items are disabled", async () => {
+  it("should select nothing when all items are disabled", async () => {
     const allDisabledItems = [
       { id: "0", text: "Slack", disabled: true },
       { id: "1", text: "Email", disabled: true },
@@ -663,18 +663,24 @@ describe("Dropdown", () => {
     const button = screen.getByRole("combobox");
     await user.click(button);
 
-    // If the while loop has no guard, this would hang forever.
+    // Disabled items stay in the keyboard navigation sequence so
+    // assistive-tech users can discover them.
     await user.keyboard("{ArrowDown}");
+    expect(button.getAttribute("aria-activedescendant")).toMatch(/-0$/);
     await user.keyboard("{ArrowUp}");
+    expect(button.getAttribute("aria-activedescendant")).toMatch(/-2$/);
 
-    // No item should be selected since all are disabled.
+    // Enter on a highlighted disabled item selects nothing and leaves the
+    // menu open, matching click.
+    await user.keyboard("{Enter}");
+    expect(button).toHaveAttribute("aria-expanded", "true");
     const options = screen.getAllByRole("option");
     for (const option of options) {
       expect(option).not.toHaveAttribute("aria-selected", "true");
     }
   });
 
-  it("should handle keyboard navigation with disabled items", async () => {
+  it("should highlight but not select disabled items during keyboard navigation", async () => {
     const itemsWithDisabled = [
       { id: "0", text: "Slack" },
       { id: "1", text: "Email", disabled: true },
@@ -691,8 +697,19 @@ describe("Dropdown", () => {
     const button = screen.getByRole("combobox");
     await user.click(button);
 
-    // Keyboard nav starts at selected item (index 0, Slack)
-    // ArrowDown once: skips disabled Email (index 1), goes to Fax (index 2)
+    // Keyboard nav starts at selected item (index 0, Slack). ArrowDown lands
+    // on disabled Email (index 1) — disabled items stay in the navigation
+    // sequence so assistive-tech users can discover them.
+    await user.keyboard("{ArrowDown}");
+    expect(button.getAttribute("aria-activedescendant")).toMatch(/-1$/);
+
+    // Enter on the highlighted disabled item selects nothing and leaves the
+    // menu open, matching click.
+    await user.keyboard("{Enter}");
+    expect(button).toHaveAttribute("aria-expanded", "true");
+    expect(button).toHaveTextContent("Slack");
+
+    // ArrowDown again reaches Fax (index 2), which selects normally.
     await user.keyboard("{ArrowDown}");
     await user.keyboard("{Enter}");
 


### PR DESCRIPTION
Arrow keys now step through disabled options instead of skipping them, so screen reader users driving the menu via aria-activedescendant can discover they exist (APG "Focusability of disabled controls"). Enter on a highlighted disabled option matches click: no selection, and the menu stays open. Typeahead, first-match auto-highlight, and hover highlighting still target enabled items only.