### PR TITLE
fix(multi-select)!: name the non-filterable trigger by its field label

### DIFF
--- a/e2e/modal-with-dropdowns.test.ts
+++ b/e2e/modal-with-dropdowns.test.ts
@@ -38,7 +38,9 @@ test.describe("Modal with Dropdowns", () => {
   });
 
   test("MultiSelect opens and selects items", async ({ page }) => {
-    const trigger = page.getByRole("combobox", { name: "Open menu" });
+    const trigger = page.getByRole("combobox", {
+      name: "Notification methods",
+    });
     await trigger.click();
 
     const menu = page.getByRole("listbox", { name: "Choose an item" });
@@ -65,7 +67,9 @@ test.describe("Modal with Dropdowns", () => {
   test("MultiSelect keeps sequential label clicks selected and syncs bind:selectedIds", async ({
     page,
   }) => {
-    const trigger = page.getByRole("combobox", { name: "Open menu" });
+    const trigger = page.getByRole("combobox", {
+      name: "Notification methods",
+    });
     await trigger.click();
 
     const menu = page.getByRole("listbox", { name: "Choose an item" });

--- a/src/ListBox/ListBoxField.svelte
+++ b/src/ListBox/ListBoxField.svelte
@@ -1,8 +1,4 @@
 <script>
-  /**
-   * @typedef {"close" | "open"} ListBoxFieldTranslationId
-   */
-
   /** Set to `true` to disable the list box field */
   export let disabled = false;
 
@@ -18,15 +14,6 @@
    */
   export let tabindex = "-1";
 
-  /** Default translation ids */
-  export const translationIds = { close: "close", open: "open" };
-
-  /**
-   * Override the default translation ids.
-   * @type {(id: ListBoxFieldTranslationId) => string}
-   */
-  export let translateWithId = (id) => defaultTranslations[id];
-
   /** Set an id for the top-level element */
   export let id = `ccs-${Math.random().toString(36)}`;
 
@@ -38,10 +25,6 @@
 
   import { getContext } from "svelte";
 
-  const defaultTranslations = {
-    [translationIds.close]: "Close menu",
-    [translationIds.open]: "Open menu",
-  };
   const ctx = getContext("carbon:MultiSelect");
 
   $: if (ctx && ref) {
@@ -62,7 +45,6 @@
   aria-controls={(ariaExpanded && menuId) || undefined}
   aria-disabled={disabled}
   aria-readonly={readonly || undefined}
-  aria-label={ariaExpanded ? translateWithId("close") : translateWithId("open")}
   tabindex={disabled ? "-1" : tabindex}
   class:bx--list-box__field={true}
   {...$$restProps}

--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -648,6 +648,7 @@
   $: errorId = `error-${id}`;
   $: warnId = `warn-${id}`;
   $: readonlyId = `readonly-${id}`;
+  $: selectionId = `selection-${id}`;
   // `aria-readonly` on a combobox/listbox does not reliably surface read-only state,
   // so the read-only state is also exposed as a visually-hidden description. The
   // single status/help id is combined with the read-only id (a describedby
@@ -660,8 +661,13 @@
         : !isFluid && !showInvalid && !showWarn && helperText
           ? helperId
           : undefined;
+  $: hasSelectionDescription = !readonly && selectionCount > 0;
   $: fieldDescribedById =
-    [readonly ? readonlyId : null, statusDescribedById]
+    [
+      readonly ? readonlyId : null,
+      hasSelectionDescription ? selectionId : null,
+      statusDescribedById,
+    ]
       .filter(Boolean)
       .join(" ") || undefined;
   // The selection count badge is hidden from assistive tech in read-only.
@@ -1069,7 +1075,6 @@
           {id}
           {disabled}
           {readonly}
-          {translateWithId}
         >
           {#if selectionCount > 0}
             <ListBoxSelection
@@ -1316,6 +1321,12 @@
   {#if readonly}
     <span id={readonlyId} class:bx--visually-hidden={true}
       >{readonlyDescription}</span
+    >
+  {/if}
+  {#if hasSelectionDescription}
+    <span id={selectionId} class:bx--visually-hidden={true}
+      >{selectionCount}
+      selected</span
     >
   {/if}
 </div>

--- a/tests/ListBox/ListBoxField.test.svelte
+++ b/tests/ListBox/ListBoxField.test.svelte
@@ -8,8 +8,6 @@
   export let readonly: ComponentProps<ListBoxField>["readonly"] = false;
   export let role: ComponentProps<ListBoxField>["role"] = "combobox";
   export let tabindex: ComponentProps<ListBoxField>["tabindex"] = "-1";
-  export let translateWithId: ComponentProps<ListBoxField>["translateWithId"] =
-    undefined;
   export let id: ComponentProps<ListBoxField>["id"] = undefined;
   export let ref: ComponentProps<ListBoxField>["ref"] = null;
   export let slotContent = "";
@@ -30,7 +28,6 @@
   {readonly}
   {role}
   {tabindex}
-  {translateWithId}
   {id}
   bind:ref
   on:click={(e) => onclick?.(e)}

--- a/tests/ListBox/ListBoxField.test.ts
+++ b/tests/ListBox/ListBoxField.test.ts
@@ -1,5 +1,4 @@
 import { render, screen } from "@testing-library/svelte";
-import type { ComponentProps } from "svelte";
 import { user } from "../utils/user";
 import ListBoxField from "./ListBoxField.test.svelte";
 
@@ -72,75 +71,22 @@ describe("ListBoxField", () => {
     expect(field).toHaveAttribute("aria-expanded", "true");
   });
 
-  it("should show 'Open menu' label when collapsed", () => {
-    render(ListBoxField, {
-      props: {
-        "aria-expanded": false,
-        slotContent: "Test field",
-      },
-    });
+  it.each([{ "aria-expanded": true }, { "aria-expanded": false }])(
+    "should not set an aria-label when %o as that would override the <label for>",
+    (props) => {
+      render(ListBoxField, {
+        props: {
+          ...props,
+          slotContent: "Test field",
+        },
+      });
 
-    const field = screen
-      .getByText("Test field")
-      .closest(".bx--list-box__field");
-    expect(field).toHaveAttribute("aria-label", "Open menu");
-  });
-
-  it("should show 'Close menu' label when expanded", () => {
-    render(ListBoxField, {
-      props: {
-        "aria-expanded": true,
-        slotContent: "Test field",
-      },
-    });
-
-    const field = screen
-      .getByText("Test field")
-      .closest(".bx--list-box__field");
-    expect(field).toHaveAttribute("aria-label", "Close menu");
-  });
-
-  it("should use custom translation for open", () => {
-    const customTranslations = {
-      open: "Custom open",
-      close: "Custom close",
-    } as const;
-
-    const props = {
-      "aria-expanded": false,
-      translateWithId: (id: keyof typeof customTranslations) =>
-        customTranslations[id],
-      slotContent: "Custom field",
-    } satisfies ComponentProps<ListBoxField>;
-
-    render(ListBoxField, { props });
-
-    const field = screen
-      .getByText("Custom field")
-      .closest(".bx--list-box__field");
-    expect(field).toHaveAttribute("aria-label", "Custom open");
-  });
-
-  it("should use custom translation for close", () => {
-    const customTranslations = {
-      open: "Custom open",
-      close: "Custom close",
-    } as const;
-
-    const props = {
-      "aria-expanded": true,
-      translateWithId: (id: keyof typeof customTranslations) =>
-        customTranslations[id],
-      slotContent: "Custom field",
-    } satisfies ComponentProps<ListBoxField>;
-
-    render(ListBoxField, { props });
-
-    const field = screen
-      .getByText("Custom field")
-      .closest(".bx--list-box__field");
-    expect(field).toHaveAttribute("aria-label", "Custom close");
-  });
+      const field = screen
+        .getByText("Test field")
+        .closest(".bx--list-box__field");
+      expect(field).not.toHaveAttribute("aria-label");
+    },
+  );
 
   it("should generate menu id based on field id", () => {
     render(ListBoxField, {

--- a/tests/MultiSelect/MultiSelect.test.ts
+++ b/tests/MultiSelect/MultiSelect.test.ts
@@ -32,18 +32,10 @@ const items = [
 
 describe("MultiSelect", () => {
   const openMenu = async () =>
-    await user.click(
-      await screen.findByLabelText("Open menu", {
-        selector: `[role="combobox"]`,
-      }),
-    );
+    await user.click(await screen.findByRole("combobox", { expanded: false }));
 
   const closeMenu = async () =>
-    await user.click(
-      await screen.findByLabelText("Close menu", {
-        selector: `[role="combobox"]`,
-      }),
-    );
+    await user.click(await screen.findByRole("combobox", { expanded: true }));
 
   const toggleOption = async (optionText: string) =>
     await user.click(
@@ -67,6 +59,87 @@ describe("MultiSelect", () => {
       "aria-expanded",
       "false",
     );
+  });
+
+  describe("field accessible name and description", () => {
+    it("names the non-filterable trigger with the field label", async () => {
+      render(MultiSelect, {
+        props: {
+          items,
+          labelText: "Contact methods",
+        },
+      });
+
+      // aria-label would beat the <label for> association in accessible-name
+      // precedence, so the trigger must not carry one.
+      const trigger = screen.getByRole("combobox", {
+        name: "Contact methods",
+      });
+      expect(trigger).not.toHaveAttribute("aria-label");
+
+      // The name must not flip to "Close menu" while the menu is open.
+      await user.click(trigger);
+      expect(
+        screen.getByRole("combobox", { name: "Contact methods" }),
+      ).toHaveAttribute("aria-expanded", "true");
+    });
+
+    it.each([{ filterable: false }, { filterable: true }])(
+      "describes the field with the selection count when %o",
+      ({ filterable }) => {
+        render(MultiSelect, {
+          props: {
+            id: "test-multiselect",
+            items,
+            labelText: "Contact methods",
+            filterable,
+            selectedIds: ["0", "1"],
+          },
+        });
+
+        const combobox = screen.getByRole("combobox");
+        expect(combobox).toHaveAttribute(
+          "aria-describedby",
+          "selection-test-multiselect",
+        );
+
+        const description = document.querySelector(
+          "#selection-test-multiselect",
+        );
+        expect(description).toHaveTextContent("2 selected");
+        expect(description).toHaveClass("bx--visually-hidden");
+      },
+    );
+
+    it("omits the selection count description when nothing is selected", () => {
+      render(MultiSelect, {
+        props: {
+          items,
+          labelText: "Contact methods",
+        },
+      });
+
+      expect(screen.getByRole("combobox")).not.toHaveAttribute(
+        "aria-describedby",
+      );
+    });
+
+    it("appends the selection count description to existing helper text", () => {
+      render(MultiSelect, {
+        props: {
+          id: "test-multiselect",
+          items,
+          labelText: "Contact methods",
+          helperText: "Helper text",
+          selectedIds: ["0"],
+        },
+      });
+
+      expect(screen.getByRole("combobox")).toHaveAttribute(
+        "aria-describedby",
+        "selection-test-multiselect helper-test-multiselect",
+      );
+    });
   });
 
   it("renders default slot", () => {


### PR DESCRIPTION
The trigger's aria-label ("Open menu"/"Close menu") overrode the `<label for>` association, so screen readers never heard the field's label or selection count. The open/close text stays on the chevron icon, the selection count is now a visually-hidden description, and ListBoxField's unused translateWithId prop is removed.