### PR TITLE
fix(context-menu): restore focus to parent option when submenu closes

### DIFF
--- a/src/ContextMenu/ContextMenuOption.svelte
+++ b/src/ContextMenu/ContextMenuOption.svelte
@@ -343,8 +343,10 @@
 
     if (submenuOpen) {
       if (event.key === "ArrowLeft") {
+        event.stopPropagation();
         submenuOpen = false;
         focusIndex = 0;
+        ref?.focus({ preventScroll: true });
         return;
       }
 

--- a/tests/ContextMenu/ContextMenu.test.ts
+++ b/tests/ContextMenu/ContextMenu.test.ts
@@ -236,6 +236,32 @@ describe("ContextMenu", () => {
     expect(submenu).toHaveAttribute("data-level", "2");
   });
 
+  it("should restore focus to the parent option when the submenu closes with ArrowLeft", async () => {
+    render(ContextMenu, {
+      props: {
+        open: true,
+        withSubmenu: true,
+        x: 100,
+        y: 100,
+      },
+    });
+
+    const submenuTrigger = screen.getByRole("menuitem", {
+      name: "Option with submenu",
+    });
+    submenuTrigger.focus();
+    await user.keyboard("{ArrowRight}");
+
+    const submenuOption = screen.getByRole("menuitem", {
+      name: "Submenu option 1",
+    });
+    expect(submenuOption).toHaveFocus();
+
+    await user.keyboard("{ArrowLeft}");
+
+    expect(submenuTrigger).toHaveFocus();
+  });
+
   // Regression test for https://github.com/carbon-design-system/carbon-components-svelte/issues/1848
   it("should not close parent menu when clicking submenu trigger", async () => {
     const consoleLog = vi.spyOn(console, "log");


### PR DESCRIPTION
Pressing ArrowLeft in a submenu closed it but never moved focus
anywhere, so it fell to document.body and keyboard users had to
rebuild focus from the top of the page. Mirrors the same handling
already used in Menu/MenuItem.svelte.