### PR TITLE
fix(file-uploader): manage focus after removing a file

### DIFF
--- a/src/FileUploader/FileUploader.svelte
+++ b/src/FileUploader/FileUploader.svelte
@@ -169,6 +169,39 @@
   const dispatch = createEventDispatcher();
 
   let prevFiles = [];
+  let triggerRef = null;
+
+  /** @param {HTMLElement} button */
+  function scheduleFocusAfterRemove(button) {
+    const row = button?.closest(".bx--file__selected-file") ?? null;
+    const nextRow = row?.nextElementSibling ?? null;
+    const prevRow = row?.previousElementSibling ?? null;
+
+    return () => {
+      const targetRow = nextRow?.isConnected
+        ? nextRow
+        : prevRow?.isConnected
+          ? prevRow
+          : null;
+      const targetButton = targetRow?.querySelector(".bx--file-close");
+
+      if (targetButton) {
+        targetButton.focus();
+      } else {
+        triggerRef?.focus();
+      }
+    };
+  }
+
+  /**
+   * @param {File} file
+   * @param {Event} event
+   */
+  function removeFile(file, event) {
+    const focusNext = scheduleFocusAfterRemove(event.currentTarget);
+    files = files.filter((f) => f !== file);
+    tick().then(focusNext);
+  }
 
   // Per-file stable id: assigned once on first sight and carried with the
   // File reference, so reorders and removals don't shift other files' ids.
@@ -299,6 +332,7 @@
     {kind}
     {size}
     bind:ref
+    bind:triggerRef
     bind:files
     on:change={(event) => {
       // In multiple mode, newFiles includes re-sent existing files
@@ -354,12 +388,12 @@
             on:keydown
             on:keydown={(event) => {
               if (event.key === " " || event.key === "Enter") {
-                files = files.filter((f) => f !== file);
+                removeFile(file, event);
               }
             }}
             on:click
-            on:click={() => {
-              files = files.filter((f) => f !== file);
+            on:click={(event) => {
+              removeFile(file, event);
             }}
           />
         </span>

--- a/src/FileUploader/FileUploaderButton.svelte
+++ b/src/FileUploader/FileUploaderButton.svelte
@@ -65,6 +65,12 @@
   export let ref = null;
 
   /**
+   * Obtain a reference to the button HTML element.
+   * @bindable readonly
+   */
+  export let triggerRef = null;
+
+  /**
    * Specify the icon to render.
    * @type {Icon}
    */
@@ -132,6 +138,7 @@
 </script>
 
 <button
+  bind:this={triggerRef}
   type="button"
   on:click={() => ref?.click()}
   {disabled}

--- a/tests/FileUploader/FileUploader.test.ts
+++ b/tests/FileUploader/FileUploader.test.ts
@@ -547,7 +547,9 @@ describe("FileUploader", () => {
 
     const closeButtons = () =>
       Array.from(
-        document.querySelectorAll(".bx--file__state-container .bx--file-close"),
+        document.querySelectorAll<HTMLElement>(
+          ".bx--file__state-container .bx--file-close",
+        ),
       );
 
     closeButtons()[0].focus();

--- a/tests/FileUploader/FileUploader.test.ts
+++ b/tests/FileUploader/FileUploader.test.ts
@@ -532,6 +532,45 @@ describe("FileUploader", () => {
     });
   });
 
+  it("should manage focus after removing a file with the keyboard", async () => {
+    const { component } = render(FileUploader);
+
+    const file1 = new File(["content1"], "file1.txt", { type: "text/plain" });
+    const file2 = new File(["content2"], "file2.txt", { type: "text/plain" });
+    assert(component.ref instanceof HTMLInputElement);
+    simulateFileSelection(component.ref, [file1, file2]);
+
+    await vi.waitFor(() => {
+      expect(screen.queryByText("file1.txt")).toBeInTheDocument();
+      expect(screen.queryByText("file2.txt")).toBeInTheDocument();
+    });
+
+    const closeButtons = () =>
+      Array.from(
+        document.querySelectorAll(".bx--file__state-container .bx--file-close"),
+      );
+
+    closeButtons()[0].focus();
+    await user.keyboard("{Enter}");
+
+    await vi.waitFor(() => {
+      expect(screen.queryByText("file1.txt")).not.toBeInTheDocument();
+    });
+
+    // Focus moves to the remaining file's remove button.
+    expect(closeButtons()).toHaveLength(1);
+    expect(closeButtons()[0]).toHaveFocus();
+
+    await user.keyboard("{Enter}");
+
+    await vi.waitFor(() => {
+      expect(screen.queryByText("file2.txt")).not.toBeInTheDocument();
+    });
+
+    // Focus moves to the upload trigger once the list is empty.
+    expect(screen.getByRole("button", { name: "Add files" })).toHaveFocus();
+  });
+
   it("should accept files under maxFileSize limit", async () => {
     const { component } = render(FileUploader, {
       props: { maxFileSize: 1000 },


### PR DESCRIPTION
Removing a file's row with the keyboard or mouse left focus nowhere
(it fell to document.body), so deleting several files meant tabbing
from the top of the page after every removal. Focus now moves to the
next file's remove button, falling back to the previous file's button
or the upload trigger once the list is empty.