### PR TITLE
perf(pagination-nav): compute page window without full-length array

### DIFF
--- a/src/PaginationNav/PaginationNav.svelte
+++ b/src/PaginationNav/PaginationNav.svelte
@@ -75,11 +75,24 @@
     }
   }
 
+  // Compute the visible page window directly instead of
+  // materializing a `total`-length array and slicing it down,
+  // since the rendered window is bounded by `shown`.
+  function computePageWindow(total, startOffset, front, back) {
+    const start = startOffset + front;
+    const end = total - back - 1;
+    const window = [];
+
+    for (let i = start; i < end; i++) {
+      window.push(i);
+    }
+
+    return window;
+  }
+
   // all enumerable items to render in between
   // overflow menus
-  $: items = Array.from({ length: total })
-    .map((_item, i) => i)
-    .slice(startOffset + front, (back + 1) * -1);
+  $: items = computePageWindow(total, startOffset, front, back);
 </script>
 
 <nav aria-label="pagination" class:bx--pagination-nav={true} {...$$restProps}>

--- a/tests/PaginationNav/PaginationNav.test.ts
+++ b/tests/PaginationNav/PaginationNav.test.ts
@@ -161,6 +161,21 @@ describe("PaginationNav", () => {
     expect(within(activeButton).getByText("Active, Page")).toBeInTheDocument();
   });
 
+  it("should render the correct page window when both front and back overflow", () => {
+    const { container } = render(PaginationNav, {
+      props: { total: 100, shown: 10, page: 50 },
+    });
+
+    const pageButtons = container.querySelectorAll("button[data-page]");
+    const pages = Array.from(pageButtons).map((button) =>
+      Number(button.getAttribute("data-page")),
+    );
+
+    // First page, the window around the current page (bounded by
+    // `shown`), and the last page — with overflow selects in between.
+    expect(pages).toEqual([1, 48, 49, 50, 51, 52, 53, 100]);
+  });
+
   it("should handle overflow selection", async () => {
     const consoleLog = vi.spyOn(console, "log");
     render(PaginationNav, {


### PR DESCRIPTION
The reactive block ran on every page change and allocated two
total-length arrays just to slice out the ~shown-sized visible
window, so a nav with thousands of pages did thousands of wasted
allocations per click. Builds the window directly with a bounded
loop instead.