### PR TITLE
fix(header-action): add aria-expanded and close on Escape

### DIFF
--- a/src/UIShell/HeaderAction.svelte
+++ b/src/UIShell/HeaderAction.svelte
@@ -6,7 +6,7 @@
    * @property {"toggle"} trigger
    * @event close
    * @type {object}
-   * @property {"outside-click" | "toggle"} trigger
+   * @property {"outside-click" | "toggle" | "escape-key"} trigger
    */
 
   /**
@@ -71,6 +71,9 @@
   /** Set to `true` to prevent the panel from closing when clicking outside */
   export let preventCloseOnClickOutside = false;
 
+  /** Set an id for the trigger button element. Also used to label the panel. */
+  export let id = `ccs-${Math.random().toString(36)}`;
+
   import { createEventDispatcher } from "svelte";
   import { slide } from "svelte/transition";
   import Close from "../icons/Close.svelte";
@@ -103,12 +106,29 @@
       dispatch("close", { trigger: "outside-click" });
     }
   }
+
+  function handleKeydown(event) {
+    if (isOpen && event.key === "Escape") {
+      isOpen = false;
+      dispatch("close", { trigger: "escape-key" });
+      ref?.focus();
+    }
+  }
 </script>
 
 <button
   bind:this={ref}
-  use:dismiss={{ enabled: isOpen, type: "click", handler: handleOutsideClick }}
+  use:dismiss={{
+    enabled: isOpen,
+    listeners: [
+      { type: "click", handler: handleOutsideClick },
+      { type: "keydown", handler: handleKeydown },
+    ],
+  }}
   type="button"
+  aria-haspopup="true"
+  aria-expanded={isOpen}
+  {id}
   class:bx--header__action={true}
   class:bx--header__action--active={isOpen}
   class:bx--header__action--text={text}
@@ -139,6 +159,8 @@
 {#if isOpen}
   <div
     bind:this={refPanel}
+    role="region"
+    aria-labelledby={id}
     class:bx--header-panel={true}
     class:bx--header-panel--expanded={true}
     transition:slide|local={{

--- a/tests/UIShell/HeaderAction.test.ts
+++ b/tests/UIShell/HeaderAction.test.ts
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/svelte";
+import { render, screen, waitFor } from "@testing-library/svelte";
 import type HeaderActionComponent from "carbon-components-svelte/UIShell/HeaderAction.svelte";
 import type { ComponentProps } from "svelte";
 import { user } from "../utils/user";
@@ -54,6 +54,37 @@ describe("HeaderAction", () => {
       await user.click(getActionButton());
       await user.click(document.body);
       expect(screen.getByTestId("panel-content")).toBeInTheDocument();
+    });
+  });
+
+  describe("accessibility", () => {
+    const getActionButton = () =>
+      screen.getByRole("button", { name: "Switcher" });
+
+    it("exposes aria-haspopup and toggles aria-expanded", async () => {
+      render(HeaderActionOutsideClick);
+
+      const button = getActionButton();
+      expect(button).toHaveAttribute("aria-haspopup", "true");
+      expect(button).toHaveAttribute("aria-expanded", "false");
+
+      await user.click(button);
+      expect(button).toHaveAttribute("aria-expanded", "true");
+    });
+
+    it("closes the panel and refocuses the trigger on Escape", async () => {
+      render(HeaderActionOutsideClick);
+
+      const button = getActionButton();
+      await user.click(button);
+      expect(screen.getByTestId("panel-content")).toBeInTheDocument();
+
+      await user.keyboard("{Escape}");
+
+      await waitFor(() =>
+        expect(screen.queryByTestId("panel-content")).not.toBeInTheDocument(),
+      );
+      expect(button).toHaveFocus();
     });
   });
 


### PR DESCRIPTION
The trigger toggled a panel but never exposed aria-expanded or
aria-haspopup, and Escape did nothing since the dismiss action only
listened for click. Brings HeaderAction in line with ProfileMenu in
the same folder: escape closes the panel and refocuses the trigger,
and the panel now has an accessible name via aria-labelledby.