### PR TITLE
fix(slider): support Home and End keys

### DIFF
--- a/src/Slider/RangeSlider.svelte
+++ b/src/Slider/RangeSlider.svelte
@@ -246,6 +246,18 @@
   /** @type {(e: KeyboardEvent) => void} */
   function onKeyDown(event) {
     if (disabled || readonly) return;
+
+    if (event.key === "Home" || event.key === "End") {
+      if (activeHandle === "lower") {
+        value = event.key === "Home" ? min : valueUpper;
+      } else {
+        valueUpper = event.key === "Home" ? value : max;
+      }
+      dispatch("input", { value, valueUpper });
+      dispatch("change", { value, valueUpper });
+      return;
+    }
+
     /** @type {Record<string, number>} */
     const keys = {
       ArrowDown: -1,

--- a/src/Slider/Slider.svelte
+++ b/src/Slider/Slider.svelte
@@ -269,6 +269,14 @@
         {id}
         on:keydown={(event) => {
           if (disabled || readonly) return;
+
+          if (event.key === "Home" || event.key === "End") {
+            value = event.key === "Home" ? min : max;
+            dispatch("input", value);
+            dispatch("change", value);
+            return;
+          }
+
           const keys = {
             ArrowDown: -1,
             ArrowLeft: -1,

--- a/tests/Slider/RangeSlider.test.ts
+++ b/tests/Slider/RangeSlider.test.ts
@@ -92,6 +92,36 @@ describe("RangeSlider", () => {
     expect(upperThumb).toHaveAttribute("aria-valuenow", "50");
   });
 
+  it("should jump the lower thumb to min/End clamped to upper via Home and End", async () => {
+    render(RangeSlider, {
+      props: { value: 40, valueUpper: 60, min: 0, max: 100 },
+    });
+
+    const [lowerThumb] = screen.getAllByRole("slider");
+    lowerThumb.focus();
+
+    await user.keyboard("{End}");
+    expect(lowerThumb).toHaveAttribute("aria-valuenow", "60");
+
+    await user.keyboard("{Home}");
+    expect(lowerThumb).toHaveAttribute("aria-valuenow", "0");
+  });
+
+  it("should jump the upper thumb to max/Home clamped to lower via Home and End", async () => {
+    render(RangeSlider, {
+      props: { value: 40, valueUpper: 60, min: 0, max: 100 },
+    });
+
+    const [, upperThumb] = screen.getAllByRole("slider");
+    upperThumb.focus();
+
+    await user.keyboard("{Home}");
+    expect(upperThumb).toHaveAttribute("aria-valuenow", "40");
+
+    await user.keyboard("{End}");
+    expect(upperThumb).toHaveAttribute("aria-valuenow", "100");
+  });
+
   it("should dispatch change event with { value, valueUpper } detail", async () => {
     const consoleLog = vi.spyOn(console, "log");
     render(RangeSlider, { props: { value: 0, valueUpper: 100 } });

--- a/tests/Slider/Slider.test.ts
+++ b/tests/Slider/Slider.test.ts
@@ -79,6 +79,19 @@ describe("Slider", () => {
     expect(consoleLog).toHaveBeenCalledWith("change", 0);
   });
 
+  it("should jump to min and max with Home and End", async () => {
+    render(Slider, { props: { value: 50, min: 0, max: 100 } });
+
+    const slider = screen.getByRole("slider");
+    slider.focus();
+
+    await user.keyboard("{End}");
+    expect(slider).toHaveAttribute("aria-valuenow", "100");
+
+    await user.keyboard("{Home}");
+    expect(slider).toHaveAttribute("aria-valuenow", "0");
+  });
+
   it("should handle custom range and step", () => {
     render(Slider, {
       props: {


### PR DESCRIPTION
Only the arrow keys moved the thumb, so reaching min or max on a wide
range meant holding an arrow key or repeatedly pressing it. Home and
End are required keys for the slider pattern; RangeSlider clamps each
thumb against the other, same as the arrow keys already do.