### PR TITLE
perf(tree-view): look up range-selected nodes via cached map

### DIFF
--- a/src/TreeView/TreeView.svelte
+++ b/src/TreeView/TreeView.svelte
@@ -149,19 +149,6 @@
   }
 
   /**
-   * Finds a node by id across top-level tree roots.
-   * @template {{ id: string | number; disabled?: boolean; nodes?: TNode[] }} TNode
-   * @returns {TNode | null}
-   */
-  function findForestNodeById(roots, id) {
-    for (const child of roots) {
-      const path = findNodeById(child, id);
-      if (path) return path[path.length - 1];
-    }
-    return null;
-  }
-
-  /**
    * IDs to select for multiselect expansion from `node` (non-disabled only).
    * Disabled nodes are omitted; subtrees under a disabled node are not traversed.
    * @template {{ id: string | number; disabled?: boolean; nodes?: TNode[] }} TNode
@@ -643,7 +630,7 @@
             const ordered = [];
             const seen = new Set();
             for (const id of sliceIds) {
-              const n = findForestNodeById(nodes, id);
+              const n = cachedNodeMap?.get(id);
               if (!n) continue;
               for (const eid of multiselectExpansionIds(n, mode)) {
                 if (!seen.has(eid)) {

--- a/tests/TreeView/TreeView.test.ts
+++ b/tests/TreeView/TreeView.test.ts
@@ -981,6 +981,35 @@ describe("TreeView Props", () => {
     expect(disabledNode).not.toHaveAttribute("aria-selected", "true");
   });
 
+  it("shift+click range selection in shallow mode expands each ranged node to its direct children", async () => {
+    render(TreeViewMultiselect, {
+      multiselect: true,
+      multiselectMode: "shallow",
+      selectedIds: [],
+      expandedIds: [],
+    });
+
+    const aiItem = treeItemById(0);
+    const blockchainItem = treeItemById(7);
+
+    await user.click(aiItem);
+
+    await user.keyboard("{Shift>}");
+    await user.click(blockchainItem);
+    await user.keyboard("{/Shift}");
+
+    // Range covers AI (0), Analytics (1), Blockchain (7); each expands to
+    // itself plus its direct (non-disabled) children.
+    for (const id of [0, 1, 2, 5, 6, 7, 8]) {
+      expect(treeItemById(id)).toHaveAttribute("aria-selected", "true");
+    }
+
+    // Nodes outside the range are not selected, and shallow mode does not
+    // recurse past direct children (id 3 is a grandchild of Analytics).
+    expect(treeItemById(9)).toHaveAttribute("aria-selected", "false");
+    expect(treeItemById(3)).toHaveAttribute("aria-selected", "false");
+  });
+
   it("multiselect tree has bx--tree--multiselect class", () => {
     render(TreeViewMultiselect, {
       multiselect: true,


### PR DESCRIPTION
Shift+click range selection called findForestNodeById per id in the
selected range, each a fresh depth-first search of the whole tree.
Swaps in cachedNodeMap, which the component already rebuilds on
nodes changes for getNode()/getNodes(), for an O(1) lookup instead.
findForestNodeById had no other callers, so it's removed.