### PR TITLE
perf(tree-view): precompute sibling ids for auto-collapse

### DIFF
--- a/src/TreeView/TreeView.svelte
+++ b/src/TreeView/TreeView.svelte
@@ -107,46 +107,11 @@
   }
 
   /**
-   * Finds sibling node IDs for a given node ID within a tree structure.
-   * @template {{ id: string | number; nodes?: TNode[] }} TNode
-   * @returns {Array<string | number>} Array of sibling IDs (excluding the node itself)
+   * Sentinel "parent id" used in `cachedParentIdById`/`cachedChildIdsByParentId`
+   * to represent the implicit parent of top-level tree roots (the forest itself).
+   * A Symbol is used so it can never collide with a real `Node["id"]`.
    */
-  function findSiblingIds(nodes, id) {
-    for (const node of nodes) {
-      if (node.id === id) {
-        const siblings = [];
-        for (const n of nodes) {
-          if (n.id !== id) {
-            siblings.push(n.id);
-          }
-        }
-        return siblings;
-      }
-    }
-
-    for (const node of nodes) {
-      if (Array.isArray(node.nodes)) {
-        for (const child of node.nodes) {
-          if (child.id === id) {
-            const siblings = [];
-            for (const n of node.nodes) {
-              if (n.id !== id) {
-                siblings.push(n.id);
-              }
-            }
-            return siblings;
-          }
-        }
-
-        const result = findSiblingIds(node.nodes, id);
-        if (result.length > 0) {
-          return result;
-        }
-      }
-    }
-
-    return [];
-  }
+  const ROOT_PARENT_ID = Symbol("tree-view-root-parent");
 
   /**
    * Finds a node by id across top-level tree roots.
@@ -561,6 +526,24 @@
   let cachedNodeIds = null;
   /** @type {Map<Node["id"], Node> | null} */
   let cachedNodeMap = null;
+  /** @type {Map<Node["id"], Node["id"] | typeof ROOT_PARENT_ID> | null} */
+  let cachedParentIdById = null;
+  /** @type {Map<Node["id"] | typeof ROOT_PARENT_ID, Array<Node["id"]>> | null} */
+  let cachedChildIdsByParentId = null;
+
+  /**
+   * Finds sibling node IDs for a given node ID using the precomputed
+   * parent/child-id caches (rebuilt alongside `cachedNodeMap` whenever
+   * `nodes` changes identity). O(1) map lookups plus the sibling count,
+   * instead of a fresh full-tree traversal per call.
+   * @type {(id: Node["id"]) => Array<Node["id"]>}
+   */
+  function getCachedSiblingIds(id) {
+    const parentId = cachedParentIdById?.get(id);
+    const childIds = cachedChildIdsByParentId?.get(parentId);
+    if (!childIds) return [];
+    return childIds.filter((childId) => childId !== id);
+  }
 
   /** @type {Node["id"] | null} */
   let anchorId = null;
@@ -686,7 +669,7 @@
   function expandNode(node, expanded) {
     if (expanded) {
       if (autoCollapse) {
-        const siblingIds = findSiblingIds(nodes, node.id);
+        const siblingIds = getCachedSiblingIds(node.id);
         for (const siblingId of siblingIds) {
           expandedIdsSet.delete(siblingId);
         }
@@ -936,6 +919,33 @@
     cachedNodeMap = new Map(
       cachedFlattenedNodes.map((node) => [node.id, node]),
     );
+
+    const parentIdById = new Map();
+    const childIdsByParentId = new Map();
+
+    // Top-level roots' implicit parent is the forest itself.
+    childIdsByParentId.set(
+      ROOT_PARENT_ID,
+      nodes.map((node) => node.id),
+    );
+    for (const node of nodes) {
+      parentIdById.set(node.id, ROOT_PARENT_ID);
+    }
+
+    for (const node of cachedFlattenedNodes) {
+      if (Array.isArray(node.nodes) && node.nodes.length > 0) {
+        childIdsByParentId.set(
+          node.id,
+          node.nodes.map((child) => child.id),
+        );
+        for (const child of node.nodes) {
+          parentIdById.set(child.id, node.id);
+        }
+      }
+    }
+
+    cachedParentIdById = parentIdById;
+    cachedChildIdsByParentId = childIdsByParentId;
   }
 
   $: multiselectStore.set(multiselect);
@@ -961,7 +971,7 @@
 
           // For each ancestor, collapse its siblings.
           for (const ancestorId of ancestorIds) {
-            const siblingIds = findSiblingIds(nodes, ancestorId);
+            const siblingIds = getCachedSiblingIds(ancestorId);
             for (const siblingId of siblingIds) {
               expandedIdsSet.delete(siblingId);
             }

--- a/tests/TreeView/TreeView.autoCollapse.test.svelte
+++ b/tests/TreeView/TreeView.autoCollapse.test.svelte
@@ -32,12 +32,24 @@
         {
           id: "subfolder1",
           text: "Subfolder 1",
-          nodes: [{ id: "subitem1", text: "Subitem 1" }],
+          nodes: [
+            {
+              id: "subitem1",
+              text: "Subitem 1",
+              nodes: [{ id: "subsubitem1", text: "Subsubitem 1" }],
+            },
+          ],
         },
         {
           id: "subfolder2",
           text: "Subfolder 2",
-          nodes: [{ id: "subitem2", text: "Subitem 2" }],
+          nodes: [
+            {
+              id: "subitem2",
+              text: "Subitem 2",
+              nodes: [{ id: "subsubitem2", text: "Subsubitem 2" }],
+            },
+          ],
         },
       ],
     },

--- a/tests/TreeView/TreeView.test.ts
+++ b/tests/TreeView/TreeView.test.ts
@@ -1828,6 +1828,43 @@ describe("TreeView autoCollapse", () => {
     expect(folder1).toHaveAttribute("aria-expanded", "false");
   });
 
+  it("applies autoCollapse across 4 levels of nesting and top-level root siblings when activeId changes", async () => {
+    // Exercises the precomputed sibling cache (perf/tree-view-autocollapse-sibling-cache):
+    // a chain of ancestors 4 levels deep, a sibling collapse at a *nested* level,
+    // and a sibling collapse at the *top-level root* (whose "parent" is the
+    // implicit forest root, not a real node).
+    const { rerender } = render(TreeViewAutoCollapse, { autoCollapse: true });
+
+    const folder1 = treeItemById("folder1");
+    const folder2 = treeItemById("folder2");
+    const folder3 = treeItemById("folder3");
+
+    // Activate a leaf 4 levels deep: folder3 > subfolder1 > subitem1 > subsubitem1.
+    await rerender({ activeId: "subsubitem1" });
+
+    expect(folder3).toHaveAttribute("aria-expanded", "true");
+    const subfolder1 = treeItemById("subfolder1");
+    const subfolder2 = treeItemById("subfolder2");
+    expect(subfolder1).toHaveAttribute("aria-expanded", "true");
+    expect(subfolder2).toHaveAttribute("aria-expanded", "false");
+    const subitem1 = treeItemById("subitem1");
+    expect(subitem1).toHaveAttribute("aria-expanded", "true");
+
+    // Move to the sibling deep branch: subfolder1 (and its expanded child
+    // subitem1) must collapse, while the shared ancestor folder3 stays expanded.
+    await rerender({ activeId: "subsubitem2" });
+    expect(folder3).toHaveAttribute("aria-expanded", "true");
+    expect(subfolder2).toHaveAttribute("aria-expanded", "true");
+    expect(subfolder1).toHaveAttribute("aria-expanded", "false");
+
+    // Jump to a leaf under a different top-level root (folder1): its root-level
+    // siblings folder2 and folder3 must collapse (root-parent edge case).
+    await rerender({ activeId: "item1" });
+    expect(folder1).toHaveAttribute("aria-expanded", "true");
+    expect(folder2).toHaveAttribute("aria-expanded", "false");
+    expect(folder3).toHaveAttribute("aria-expanded", "false");
+  });
+
   describe("TreeViewNode Generics", () => {
     it("should support custom Icon types with generics", () => {
       type CustomIcon = new (...args: unknown[]) => unknown;


### PR DESCRIPTION
autoCollapse called findSiblingIds, a fresh full-tree traversal,
once per ancestor on every activeId change (also used by
expandNode). Builds cachedParentIdById/cachedChildIdsByParentId
alongside cachedNodeMap so sibling lookup is O(1) plus sibling
count. Top-level roots use a sentinel parent id since their
"parent" is the forest itself, not a real node.