### PR TITLE
perf(multi-select): gate filtered items on open and filterable

### DIFF
--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -366,7 +366,13 @@
     // "Focusability of disabled controls") so assistive-tech users can
     // discover them; selectItem and the option click handlers refuse the
     // actual selection.
-    const navigableItems = filterable ? filteredItems : sortedItems;
+    //
+    // `filteredItems` is gated on `open` and recomputes reactively, so it can
+    // still be stale/empty here immediately after synchronously flipping
+    // `open` to `true` in the same keydown handler (before the reactive
+    // statement re-runs). Fall back to `sortedItems` in that case, matching
+    // ComboBox's `filteredItems?.length ? filteredItems : items` guard.
+    const navigableItems = filteredItems.length ? filteredItems : sortedItems;
     highlightedIndex = moveIndex(highlightedIndex, step, navigableItems.length);
     highlightOrigin = "keyboard";
   }
@@ -723,9 +729,12 @@
   $: isAtSelectionCap =
     hasMaxSelectedItems && selectionCount >= maxSelectedItems;
   $: maxSelectedId = `max-selected-${id}`;
-  $: filteredItems = sortedItems.filter(
-    (item) => item.isSelectAll || filterItem(item, value),
-  );
+  $: filteredItems =
+    filterable && open
+      ? sortedItems.filter(
+          (item) => item.isSelectAll || filterItem(item, value),
+        )
+      : [];
   $: highlightedId =
     highlightedIndex > -1
       ? ((filterable ? filteredItems : sortedItems)[highlightedIndex]?.id ??

--- a/tests/MultiSelect/MultiSelect.test.ts
+++ b/tests/MultiSelect/MultiSelect.test.ts
@@ -955,6 +955,61 @@ describe("MultiSelect", () => {
 
       expect(screen.getByTestId("bound-value")).toHaveTextContent("hello");
     });
+
+    // Perf regression: `filteredItems` must be gated on `filterable && open`
+    // so a closed, non-filterable MultiSelect never runs the (potentially
+    // expensive, consumer-supplied) filterItem over the full item list.
+    it("does not invoke filterItem while closed and not filterable", async () => {
+      const filterItem = vi.fn((item: MultiSelectItem, value: string) =>
+        item.text.toLowerCase().includes(value.trim().toLowerCase()),
+      );
+
+      const { component } = render(MultiSelect, {
+        props: {
+          items,
+          filterable: false,
+          filterItem,
+        },
+      });
+
+      filterItem.mockClear();
+
+      // Programmatic selectedIds updates reassign `sortedItems`, which is
+      // what used to always re-run the always-on filter.
+      component.selectedIds = ["0"];
+      await tick();
+
+      expect(filterItem).not.toHaveBeenCalled();
+    });
+
+    it("invokes filterItem once filterable and open", async () => {
+      const filterItem = vi.fn((item: MultiSelectItem, value: string) =>
+        item.text.toLowerCase().includes(value.trim().toLowerCase()),
+      );
+
+      render(MultiSelect, {
+        props: {
+          items,
+          filterable: true,
+          filterItem,
+          placeholder: "Filter items...",
+        },
+      });
+
+      // Not yet open: still gated.
+      expect(filterItem).not.toHaveBeenCalled();
+
+      const input = screen.getByPlaceholderText("Filter items...");
+      await user.click(input);
+      filterItem.mockClear();
+
+      await user.type(input, "em");
+
+      expect(filterItem).toHaveBeenCalled();
+      expect(screen.queryByText("Slack")).not.toBeInTheDocument();
+      expect(screen.getByText("Email")).toBeInTheDocument();
+      expect(screen.queryByText("Fax")).not.toBeInTheDocument();
+    });
   });
 
   describe("sorting behavior", () => {


### PR DESCRIPTION
filteredItems ran sortedItems.filter(...) unconditionally, even
when the menu was closed or filterable was false, calling the
consumer-supplied filterItem over the full list for no reason.
Gates it on filterable && open, mirroring ComboBox's reference
implementation. change(step) now falls back to sortedItems when
filteredItems is momentarily empty right after open flips
synchronously within the same keydown handler, before the
reactive statement re-runs.