### PR TITLE
fix(dropdown,combo-box): support Home and End keys in the open listbox

### DIFF
--- a/src/ComboBox/ComboBox.svelte
+++ b/src/ComboBox/ComboBox.svelte
@@ -790,6 +790,18 @@
             tick().then(() => {
               ref.setSelectionRange(value.length, value.length);
             });
+          } else if (open && (event.key === "Home" || event.key === "End")) {
+            // APG editable combobox: Home/End stay native caret keys while
+            // the menu is closed. Once open, they move the highlight to the
+            // first/last option instead, matching Carbon React's ComboBox
+            // (downshift's useCombobox gates the same jump on `isOpen`).
+            event.preventDefault();
+            const navigableItems = filteredItems?.length
+              ? filteredItems
+              : items;
+            highlightedIndex =
+              event.key === "Home" ? 0 : navigableItems.length - 1;
+            highlightOrigin = "keyboard";
           } else if (event.key === "ArrowDown" || event.key === "ArrowUp") {
             const step = event.key === "ArrowDown" ? 1 : -1;
             if (event.altKey) {

--- a/src/Dropdown/Dropdown.svelte
+++ b/src/Dropdown/Dropdown.svelte
@@ -646,6 +646,14 @@
               if (highlightedIndex === -1) change(step);
             });
           }
+        } else if (event.key === "Home" || event.key === "End") {
+          // APG select-only combobox: Home/End open a closed listbox, then
+          // move the highlight to the first/last option, mirroring the
+          // open-and-move convention already used for the plain arrow keys.
+          event.preventDefault();
+          if (!open) open = true;
+          highlightedIndex = event.key === "Home" ? 0 : items.length - 1;
+          highlightOrigin = "keyboard";
         } else if (event.key === "Escape") {
           close("escape-key");
         } else if (

--- a/tests/ComboBox/ComboBox.test.ts
+++ b/tests/ComboBox/ComboBox.test.ts
@@ -250,6 +250,55 @@ describe("ComboBox", () => {
     expect(input.getAttribute("aria-activedescendant")).toMatch(/-0$/);
   });
 
+  it("should move the caret, not the highlight, on Home/End when the menu is closed", async () => {
+    render(ComboBox, {
+      props: { selectedId: "1", value: "Email" },
+    });
+
+    const input = getInput();
+    input.focus();
+    expect(input).toHaveAttribute("aria-expanded", "false");
+
+    await user.keyboard("{Home}");
+    expect(input.selectionStart).toBe(0);
+
+    await user.keyboard("{End}");
+    expect(input.selectionStart).toBe(5);
+    expect(input).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("should move the highlight to the last enabled item on End when the menu is open", async () => {
+    render(ComboBox);
+
+    const input = getInput();
+    input.focus();
+
+    await user.keyboard("{ArrowDown}");
+    await tick();
+    expect(input.getAttribute("aria-activedescendant")).toMatch(/-0$/);
+
+    await user.keyboard("{End}");
+    await tick();
+    // Fax (id="2") is the last enabled item.
+    expect(input.getAttribute("aria-activedescendant")).toMatch(/-2$/);
+  });
+
+  it("should move the highlight to the first enabled item on Home when the menu is open", async () => {
+    render(ComboBox);
+
+    const input = getInput();
+    input.focus();
+
+    await user.keyboard("{ArrowUp}");
+    await tick();
+    expect(input.getAttribute("aria-activedescendant")).toMatch(/-2$/);
+
+    await user.keyboard("{Home}");
+    await tick();
+    // Slack (id="0") is the first enabled item.
+    expect(input.getAttribute("aria-activedescendant")).toMatch(/-0$/);
+  });
+
   it("should set aria-activedescendant to the highlighted filtered item", async () => {
     render(ComboBox);
 
@@ -1733,6 +1782,29 @@ describe("ComboBox", () => {
       // A second ArrowRight has no ghost to accept; value is unchanged.
       await user.keyboard("{ArrowRight}");
       expect(input).toHaveValue("apple");
+    });
+
+    it("should move the highlight on End when there is no ghost to accept", async () => {
+      render(ComboBox, {
+        props: {
+          typeahead: true,
+          items: [
+            { id: "1", text: "Apple", price: 100 },
+            { id: "2", text: "Banana", price: 200 },
+          ],
+        },
+      });
+
+      const input = getInput();
+      await user.click(input);
+      await tick();
+      expect(input).toHaveAttribute("aria-expanded", "true");
+
+      // Nothing typed, so there is no ghost completion for End to accept;
+      // it falls through to the highlight-navigation behavior instead.
+      await user.keyboard("{End}");
+      await tick();
+      expect(input.getAttribute("aria-activedescendant")).toMatch(/-2$/);
     });
 
     it("should not inline-complete when the top match is not a prefix", async () => {

--- a/tests/Dropdown/Dropdown.test.ts
+++ b/tests/Dropdown/Dropdown.test.ts
@@ -480,6 +480,68 @@ describe("Dropdown", () => {
     expect(button.getAttribute("aria-activedescendant")).toMatch(/-2$/);
   });
 
+  it("should move the highlight to the last item with End", async () => {
+    render(Dropdown, { props: { items } });
+
+    const button = screen.getByRole("combobox");
+    button.focus();
+
+    await user.keyboard("{ArrowDown}");
+    await tick();
+    expect(button.getAttribute("aria-activedescendant")).toMatch(/-0$/);
+
+    await user.keyboard("{End}");
+    await tick();
+    // Fax (id="2") is the last item.
+    expect(button.getAttribute("aria-activedescendant")).toMatch(/-2$/);
+  });
+
+  it("should move the highlight to the first item with Home", async () => {
+    render(Dropdown, { props: { items } });
+
+    const button = screen.getByRole("combobox");
+    button.focus();
+
+    await user.keyboard("{ArrowUp}");
+    await tick();
+    expect(button.getAttribute("aria-activedescendant")).toMatch(/-2$/);
+
+    await user.keyboard("{Home}");
+    await tick();
+    // Slack (id="0") is the first item.
+    expect(button.getAttribute("aria-activedescendant")).toMatch(/-0$/);
+  });
+
+  it("should open a closed menu and highlight the last item with End", async () => {
+    render(Dropdown, { props: { items } });
+
+    const button = screen.getByRole("combobox");
+    button.focus();
+    expect(button).toHaveAttribute("aria-expanded", "false");
+
+    await user.keyboard("{End}");
+    await tick();
+
+    expect(button).toHaveAttribute("aria-expanded", "true");
+    // Fax (id="2") is the last item.
+    expect(button.getAttribute("aria-activedescendant")).toMatch(/-2$/);
+  });
+
+  it("should open a closed menu and highlight the first item with Home", async () => {
+    render(Dropdown, { props: { items } });
+
+    const button = screen.getByRole("combobox");
+    button.focus();
+    expect(button).toHaveAttribute("aria-expanded", "false");
+
+    await user.keyboard("{Home}");
+    await tick();
+
+    expect(button).toHaveAttribute("aria-expanded", "true");
+    // Slack (id="0") is the first item.
+    expect(button.getAttribute("aria-activedescendant")).toMatch(/-0$/);
+  });
+
   it("should open the menu on Alt+ArrowDown without moving the highlight", async () => {
     render(Dropdown, { props: { items } });
 
@@ -1739,6 +1801,24 @@ describe("Dropdown", () => {
       // ArrowDown twice: index 1 -> 2 (Item 3)
       // Enter selects Item 3
       expect(button).toHaveTextContent("Item 3");
+    });
+
+    it("should jump to the last item with End when virtualized", async () => {
+      const largeItems = createLargeItemList(500);
+      render(Dropdown, {
+        props: {
+          items: largeItems,
+          selectedId: "0",
+          virtualize: true,
+        },
+      });
+
+      const button = screen.getByRole("combobox");
+      await user.click(button);
+      await user.keyboard("{End}");
+      await user.keyboard("{Enter}");
+
+      expect(button).toHaveTextContent("Item 500");
     });
 
     it.each([


### PR DESCRIPTION
Follow-up to #3590

Only the arrow keys moved the highlight in the open listbox, so
reaching either end of a long list meant arrowing through every
option. SearchMenu already supports Home/End, and #3590 added it for
MultiSelect. This closes the gap for Dropdown and ComboBox.

Dropdown gets the same open-and-jump behavior #3590 shipped for
MultiSelect: Home/End open a closed menu and move the highlight to
the first/last option.

ComboBox is an editable combobox with a real text input, so Home/End
stay native caret keys while the menu is closed, or while a typeahead
ghost completion is showing (ComboBox already repurposes End to accept
that suggestion in place). Once the menu is open with nothing to
accept, Home/End move the highlight instead — matching Carbon React's
ComboBox, where downshift's `useCombobox` gates the same jump on
`isOpen`.

MultiSelect's filterable input keeps the caret-owns-Home/End rule from
#3590.