### PR TITLE
perf(tooltip): reposition only when open or direction changes

### DIFF
--- a/src/Tooltip/Tooltip.svelte
+++ b/src/Tooltip/Tooltip.svelte
@@ -103,11 +103,11 @@
   export let portalTooltip = undefined;
 
   import {
-    afterUpdate,
     createEventDispatcher,
     getContext,
     onMount,
     setContext,
+    tick,
   } from "svelte";
   import { writable } from "svelte/store";
   import Information from "../icons/Information.svelte";
@@ -189,59 +189,74 @@
     };
   });
 
-  afterUpdate(() => {
-    if (open && !effectivePortalTooltip) {
-      const button = ref.getBoundingClientRect();
-      const tooltip = refTooltip.getBoundingClientRect();
+  function position() {
+    if (!(open && !effectivePortalTooltip && ref && refTooltip)) return;
 
-      let iconWidth = 16;
-      let iconHeight = 16;
+    const button = ref.getBoundingClientRect();
+    const tooltip = refTooltip.getBoundingClientRect();
 
-      if (refIcon) {
-        const icon = refIcon.getBoundingClientRect();
-        iconWidth = icon.width;
-        iconHeight = icon.height;
-      }
+    let iconWidth = 16;
+    let iconHeight = 16;
 
-      let offsetX = 0;
-      let offsetY = 0;
-
-      switch (direction) {
-        case "bottom":
-          if (hideIcon) {
-            offsetX = -1 * (tooltip.width / 2 - button.width / 2);
-          } else {
-            offsetX = -1 * (tooltip.width / 2 - button.width + iconWidth / 2);
-          }
-          offsetY = iconHeight / 2;
-          break;
-        case "right":
-          offsetX = button.width + 6;
-          offsetY = -1 * (tooltip.height / 2 + iconWidth / 2 - 3);
-          break;
-        case "left":
-          if (hideIcon) {
-            offsetX = -1 * (tooltip.width + 6 + 1);
-          } else {
-            offsetX = -1 * (tooltip.width - button.width + iconWidth + 8);
-          }
-          offsetY = -1 * (tooltip.height / 2 + button.height) - 2;
-          break;
-        case "top":
-          if (hideIcon) {
-            offsetX = -1 * (tooltip.width / 2 - button.width / 2);
-          } else {
-            offsetX =
-              -1 * (tooltip.width / 2 - button.width + iconWidth / 2 + 1);
-          }
-          offsetY = -1 * (tooltip.height + button.height + iconWidth / 2 - 1);
-          break;
-      }
-
-      refTooltip.style.left = `${offsetX}px`;
-      refTooltip.style.marginTop = `${offsetY}px`;
+    if (refIcon) {
+      const icon = refIcon.getBoundingClientRect();
+      iconWidth = icon.width;
+      iconHeight = icon.height;
     }
-  });
+
+    let offsetX = 0;
+    let offsetY = 0;
+
+    switch (direction) {
+      case "bottom":
+        if (hideIcon) {
+          offsetX = -1 * (tooltip.width / 2 - button.width / 2);
+        } else {
+          offsetX = -1 * (tooltip.width / 2 - button.width + iconWidth / 2);
+        }
+        offsetY = iconHeight / 2;
+        break;
+      case "right":
+        offsetX = button.width + 6;
+        offsetY = -1 * (tooltip.height / 2 + iconWidth / 2 - 3);
+        break;
+      case "left":
+        if (hideIcon) {
+          offsetX = -1 * (tooltip.width + 6 + 1);
+        } else {
+          offsetX = -1 * (tooltip.width - button.width + iconWidth + 8);
+        }
+        offsetY = -1 * (tooltip.height / 2 + button.height) - 2;
+        break;
+      case "top":
+        if (hideIcon) {
+          offsetX = -1 * (tooltip.width / 2 - button.width / 2);
+        } else {
+          offsetX = -1 * (tooltip.width / 2 - button.width + iconWidth / 2 + 1);
+        }
+        offsetY = -1 * (tooltip.height + button.height + iconWidth / 2 - 1);
+        break;
+    }
+
+    refTooltip.style.left = `${offsetX}px`;
+    refTooltip.style.marginTop = `${offsetY}px`;
+  }
+
+  // Reposition only when the tooltip opens or an input that affects its
+  // geometry changes—not on every unrelated re-render of this component
+  // (unlike `afterUpdate`, which would force a synchronous reflow each time).
+  // The DOM must be committed before measuring, so defer behind `tick()`.
+  //
+  // `ref`/`refTooltip`/`refIcon` are intentionally NOT read here: they're
+  // `bind:this` targets, and Svelte's compiled output re-invalidates a
+  // `bind:this` binding on every component update regardless of whether the
+  // element identity actually changed, which would make this block refire
+  // on every unrelated re-render. `position()` already null-checks them.
+  $: if (open && !effectivePortalTooltip) {
+    void direction;
+    void hideIcon;
+    tick().then(position);
+  }
 
   $: tooltipOpen.set(open);
   $: if (!open) openedByHover.set(false);

--- a/tests/Tooltip/Tooltip.test.ts
+++ b/tests/Tooltip/Tooltip.test.ts
@@ -1,6 +1,8 @@
 import { fireEvent, render, screen } from "@testing-library/svelte";
 import type TooltipComponent from "carbon-components-svelte/Tooltip/Tooltip.svelte";
+import Tooltip from "carbon-components-svelte/Tooltip/Tooltip.svelte";
 import type { ComponentProps } from "svelte";
+import { tick } from "svelte";
 import TooltipAlignments from "./TooltipAlignments.test.svelte";
 import TooltipCustomContent from "./TooltipCustomContent.test.svelte";
 import TooltipCustomIcon from "./TooltipCustomIcon.test.svelte";
@@ -295,6 +297,44 @@ describe("Tooltip", () => {
       .getAttribute("aria-labelledby");
     expect(labelledby).toBeTruthy();
     expect(document.getElementById(labelledby ?? "")).toBeInTheDocument();
+  });
+
+  describe("reposition performance", () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    test("should not remeasure geometry on unrelated re-renders while open", async () => {
+      const { rerender } = render(Tooltip, {
+        open: true,
+        iconDescription: "Information",
+      });
+
+      // Let the initial tick()-deferred position() run before observing.
+      // `tick()` resolves via microtasks, which fake timers don't control.
+      await tick();
+      await tick();
+
+      const spy = vi.spyOn(Element.prototype, "getBoundingClientRect");
+
+      // Re-render with a prop that doesn't affect tooltip geometry.
+      await rerender({ open: true, iconDescription: "Updated description" });
+      await tick();
+      await tick();
+
+      expect(spy).not.toHaveBeenCalled();
+
+      // A direction change still triggers a reposition.
+      await rerender({
+        open: true,
+        direction: "top",
+        iconDescription: "Updated description",
+      });
+      await tick();
+      await tick();
+
+      expect(spy).toHaveBeenCalled();
+    });
   });
 
   describe("Generics", () => {


### PR DESCRIPTION
afterUpdate re-measured tooltip geometry (2-3 getBoundingClientRect
calls plus 2 style writes) on every DOM update while a tooltip was
open, not just when it actually needed repositioning. Replaces it
with a guarded $: that only reacts to open, direction, and hideIcon,
deferring the actual measurement behind tick() since $: runs before
the DOM commits.

ref/refTooltip/refIcon are deliberately left out of the reactive
condition. They're bind:this targets, and Svelte's compiled output
re-invalidates a bind:this binding on every component update
regardless of whether the element identity changed, so referencing
them here made the block refire on every unrelated re-render,
defeating the fix. position() already null-checks them internally.