### PR TITLE
perf(utils): avoid getComputedStyle per candidate in trapFocus

### DIFF
--- a/src/utils/trapFocus.js
+++ b/src/utils/trapFocus.js
@@ -21,12 +21,15 @@ export function trapFocus({ container, event }) {
   const tabbable = /** @type {HTMLElement[]} */ (
     Array.from(container.querySelectorAll(selectorTabbable))
   ).filter((el) => {
-    const style = getComputedStyle(el);
-    if (style.visibility === "hidden" || style.display === "none") {
-      return false;
-    }
-
-    // Zero dimensions after layout; offsetParent is null when not in the DOM.
+    // Cheap geometry check first, so the (layout/style-recalc-forcing)
+    // `getComputedStyle` call below is only reached for elements not
+    // already excluded by it. `offsetParent` is `null` both when the
+    // browser hasn't computed real layout for the element (not attached,
+    // inside a `display: none` ancestor) and for visible `position: fixed`
+    // elements — and, in test environments like jsdom that don't compute
+    // layout at all, for every element unconditionally. Requiring
+    // `offsetParent !== null` before trusting zero dimensions avoids
+    // treating "no layout information" as "hidden".
     if (
       el.offsetParent !== null &&
       el.offsetWidth === 0 &&
@@ -35,7 +38,10 @@ export function trapFocus({ container, event }) {
       return false;
     }
 
-    return true;
+    // `visibility: hidden` elements keep their layout box, so this can only
+    // be detected via computed style, not geometry.
+    const style = getComputedStyle(el);
+    return style.visibility !== "hidden" && style.display !== "none";
   });
 
   if (tabbable.length === 0) {

--- a/tests/utils/trapFocus.test.ts
+++ b/tests/utils/trapFocus.test.ts
@@ -1,16 +1,39 @@
 import { trapFocus } from "../../src/utils/trapFocus.js";
 
 /**
+ * jsdom has no layout engine, so `offsetParent`/`offsetWidth`/`offsetHeight`
+ * are `null`/`0`/`0` for every element by default. `trapFocus` treats a
+ * `null` offsetParent + zero height, or zero width + zero height, as "not
+ * tabbable" (a cheap stand-in for elements collapsed by `display: none`), so
+ * fixtures that should count as visible must stub these to look like a
+ * normal laid-out element.
+ */
+function stubVisibleGeometry(el: HTMLElement) {
+  Object.defineProperty(el, "offsetParent", {
+    value: document.body,
+    configurable: true,
+  });
+  Object.defineProperty(el, "offsetWidth", {
+    value: 42,
+    configurable: true,
+  });
+  Object.defineProperty(el, "offsetHeight", {
+    value: 20,
+    configurable: true,
+  });
+}
+
+/**
  * Build a container with `count` buttons, append it to the document, and
- * return the container plus its buttons. jsdom has no layout, so
- * `offsetParent` is null and the zero-dimension filter branch is skipped —
- * the buttons count as visible.
+ * return the container plus its buttons. Each button is stubbed to look
+ * like a normal, visible, laid-out element (see `stubVisibleGeometry`).
  */
 function setup(count: number) {
   const container = document.createElement("div");
   const buttons = Array.from({ length: count }, (_, i) => {
     const button = document.createElement("button");
     button.textContent = `Button ${i}`;
+    stubVisibleGeometry(button);
     container.appendChild(button);
     return button;
   });
@@ -118,5 +141,40 @@ describe("trapFocus", () => {
     trapFocus({ container, event });
 
     expect(document.activeElement).toBe(buttons[2]);
+  });
+
+  test("visibility:hidden and display:none elements are both excluded, only the visible one is focused", () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+
+    const visible = document.createElement("button");
+    visible.textContent = "Visible";
+    stubVisibleGeometry(visible);
+    container.appendChild(visible);
+
+    // display:none collapses the element's layout box, so it's excluded by
+    // the cheap geometry checks before getComputedStyle is ever called
+    // (jsdom's default offsetParent: null / offsetHeight: 0 is left as-is).
+    const displayNone = document.createElement("button");
+    displayNone.textContent = "Display none";
+    displayNone.style.display = "none";
+    container.appendChild(displayNone);
+
+    // visibility:hidden elements keep their layout box in real browsers, so
+    // this fixture is stubbed to look laid-out; it must be caught by the
+    // getComputedStyle check instead of the geometry checks.
+    const visibilityHidden = document.createElement("button");
+    visibilityHidden.textContent = "Visibility hidden";
+    visibilityHidden.style.visibility = "hidden";
+    stubVisibleGeometry(visibilityHidden);
+    container.appendChild(visibilityHidden);
+
+    visible.focus();
+    const { event } = tabEvent();
+
+    trapFocus({ container, event });
+
+    // Only one tabbable candidate (`visible`), so Tab wraps back to itself.
+    expect(document.activeElement).toBe(visible);
   });
 });


### PR DESCRIPTION
trapFocus called getComputedStyle, which forces a style recalc, for
every tabbable candidate matching the broad selectorTabbable list,
even ones a cheap geometry check would already exclude. Modal's
focus trap runs this on every Tab keydown, so a modal with a couple
hundred candidates pays that many recalcs per keypress.

Reorders the checks so the offsetWidth/offsetHeight geometry check
runs first and getComputedStyle is only reached for elements that
survive it. Keeps the offsetParent !== null guard from the original
code: without it, environments that don't compute real layout
(jsdom, and visible position: fixed elements in real browsers) get
misclassified as hidden, since offsetParent is null there by
default regardless of actual visibility.