### PR TITLE
fix(toolbar-batch-actions): announce selection count and manage focus on dismiss

### DIFF
--- a/src/DataTable/Toolbar.svelte
+++ b/src/DataTable/Toolbar.svelte
@@ -57,11 +57,13 @@
     overflowVisible,
     setOverflowVisible,
     batchActionsActive,
+    getRef: () => ref,
   });
 </script>
 
 <section
   bind:this={ref}
+  tabindex="-1"
   aria-label={ariaLabel}
   class:bx--table-toolbar={true}
   class:bx--table-toolbar--xs={effectiveSize === "xs"}

--- a/src/DataTable/ToolbarBatchActions.svelte
+++ b/src/DataTable/ToolbarBatchActions.svelte
@@ -24,11 +24,13 @@
    */
   export let selectedIds = [];
 
-  import { createEventDispatcher, getContext, onMount } from "svelte";
+  import { createEventDispatcher, getContext, onMount, tick } from "svelte";
 
   import Button from "../Button/Button.svelte";
 
   let batchSelectedIds = [];
+  let wrapperRef = null;
+  let prevShowActions = false;
 
   const dispatch = createEventDispatcher();
 
@@ -74,6 +76,22 @@
     ctxToolbar.batchActionsActive.set(showActions);
   }
 
+  $: {
+    if (
+      prevShowActions &&
+      !showActions &&
+      wrapperRef?.contains(document.activeElement)
+    ) {
+      // The bar is about to go inert while it still contains focus (e.g.
+      // Cancel was just activated). Move focus to a stable element before
+      // the browser drops it to `document.body`.
+      tick().then(() => {
+        ctxToolbar?.getRef?.()?.focus();
+      });
+    }
+    prevShowActions = showActions;
+  }
+
   onMount(() => {
     return () => {
       unsubscribe?.();
@@ -84,13 +102,18 @@
 
 {#if !overflowVisible}
   <div
+    bind:this={wrapperRef}
     class:bx--batch-actions={true}
     class:bx--batch-actions--active={showActions}
     {...inertProps}
     {...$$restProps}
   >
     <div class:bx--batch-summary={true}>
-      <p class:bx--batch-summary__para={true}>
+      <p
+        class:bx--batch-summary__para={true}
+        aria-live="polite"
+        aria-atomic="true"
+      >
         <span> {formatTotalSelected(batchSelectedIds.length)} </span>
       </p>
     </div>

--- a/tests/DataTable/DataTableBatchSelectionToolbar.test.ts
+++ b/tests/DataTable/DataTableBatchSelectionToolbar.test.ts
@@ -202,6 +202,36 @@ describe("DataTableBatchSelectionToolbar", () => {
     ).toHaveFocus();
   });
 
+  it("announces the selection count via a live region", () => {
+    const { container } = render(DataTableBatchSelectionToolbar, {
+      props: {
+        selectedRowIds: ["a", "b"],
+      },
+    });
+
+    const summary = container.querySelector(".bx--batch-summary__para");
+    expect(summary).toHaveAttribute("aria-live", "polite");
+    expect(summary).toHaveAttribute("aria-atomic", "true");
+  });
+
+  it("moves focus off the bar when Cancel closes it via the keyboard", async () => {
+    const { container } = render(DataTableBatchSelectionToolbar, {
+      props: {
+        selectedRowIds: ["a", "b"],
+      },
+    });
+
+    const cancelButton = screen.getByText("Cancel");
+    cancelButton.focus();
+    await user.keyboard("{Enter}");
+    await tick();
+
+    expect(document.activeElement).not.toBe(document.body);
+    expect(document.activeElement).toBe(
+      container.querySelector(".bx--table-toolbar"),
+    );
+  });
+
   it("applies inert to batch actions when no rows are selected", () => {
     const { container } = render(DataTableBatchSelectionToolbar, {
       props: {


### PR DESCRIPTION
Two gaps here: the "N items selected" summary updated visually with
no live region, so screen reader users never heard the count change
as they selected rows. And when the bar closes (Cancel, or the last
row gets deselected) while it still holds focus, the browser drops
focus to the body once the bar goes inert.

The summary paragraph is now aria-live="polite", and Toolbar exposes
its section ref through context so ToolbarBatchActions can refocus it
right before the bar goes inert.