### PR TITLE
perf(modal): track open state reactively instead of afterUpdate

### DIFF
--- a/src/Modal/Modal.svelte
+++ b/src/Modal/Modal.svelte
@@ -133,7 +133,7 @@
    */
   export let ref = null;
 
-  import { afterUpdate, createEventDispatcher, setContext, tick } from "svelte";
+  import { createEventDispatcher, onMount, setContext, tick } from "svelte";
   import { writable } from "svelte/store";
   import Button from "../Button/Button.svelte";
   import InlineLoading from "../InlineLoading/InlineLoading.svelte";
@@ -151,6 +151,7 @@
   let innerModal = null;
   let opened = false;
   let closeDispatched = false;
+  let mounted = false;
 
   function focus(element) {
     const container = element || innerModal;
@@ -186,7 +187,19 @@
 
   setContext("carbon:Modal", {});
 
-  afterUpdate(() => {
+  // Initial mount already runs the reactive block below, which handles
+  // dispatching "open" and the `opened`/`focusReturn.save()` bookkeeping.
+  // What it can't do is focus the modal: reactive statements run *before*
+  // the DOM is committed, so `innerModal` isn't attached yet. `onMount`
+  // runs after mount, so the DOM is already in place — no `tick()` needed.
+  onMount(() => {
+    mounted = true;
+    if (open) {
+      focus();
+    }
+  });
+
+  $: {
     if (opened) {
       if (!open) {
         opened = false;
@@ -199,11 +212,20 @@
       }
     } else if (open) {
       opened = true;
+      // Reading `document.activeElement` doesn't depend on this modal's own
+      // DOM, so it's safe (and race-free) to capture it synchronously here.
       focusReturn.save();
-      focus();
       dispatch("open");
+      // Skip on the initial-mount run: `onMount` above already handles
+      // focusing an already-open modal. This only covers later open
+      // transitions, where `focus()` needs the committed DOM (`tick()`).
+      if (mounted) {
+        tick().then(() => {
+          if (open) focus();
+        });
+      }
     }
-  });
+  }
 
   $: modalLabelId = `bx--modal-header__label--modal-${id}`;
   $: modalHeadingId = `bx--modal-header__heading--modal-${id}`;

--- a/tests/Modal/Modal.test.ts
+++ b/tests/Modal/Modal.test.ts
@@ -110,6 +110,38 @@ describe("Modal", () => {
     expect(closeHandler).toHaveBeenCalledTimes(1);
   });
 
+  // perf/modal-reactive-open-state: focusing on a post-mount open transition
+  // now happens via `tick().then(focus)` (the `$:` block that dispatches
+  // "open" runs before the DOM commits, unlike the old `afterUpdate`), so
+  // this pins down that focus still lands correctly once the tick resolves,
+  // and that an unrelated re-render doesn't cause a duplicate "open" dispatch.
+  it("moves focus into the modal on a post-mount open transition, without duplicating on:open", async () => {
+    const openHandler = vi.fn();
+    const { rerender } = render(ModalTest, {
+      props: {
+        open: false,
+        modalHeading: "Post-mount Focus Test",
+        primaryButtonText: "Save",
+        includeInput: false,
+        onopen: openHandler,
+      },
+    });
+
+    rerender({ open: true });
+    await tick();
+    await tick();
+
+    expect(screen.getByRole("button", { name: "Save" })).toHaveFocus();
+    expect(openHandler).toHaveBeenCalledTimes(1);
+
+    // An unrelated re-render (open stays true) must not re-fire "open".
+    rerender({ open: true, modalHeading: "Post-mount Focus Test Updated" });
+    await tick();
+    await tick();
+
+    expect(openHandler).toHaveBeenCalledTimes(1);
+  });
+
   it("handles form submission", async () => {
     const consoleLog = vi.spyOn(console, "log");
     render(ModalTest, {


### PR DESCRIPTION
Modal ran its open/close transition bookkeeping (focusReturn.save(),
focus(), on:open dispatch) inside afterUpdate, so the guard chain
was re-evaluated after every DOM update for the modal's whole
lifetime. ComposedModal already implements the same state machine
correctly as a $: block; this ports that pattern to Modal, keeping
Modal's two extra calls.

$: runs before the DOM commits, unlike afterUpdate, so focus()
can't stay inline. focusReturn.save() only reads document
.activeElement (not this modal's own DOM) so it's still safe
synchronously. focus() itself is split: onMount handles the
initial-open case (DOM is already committed by then), and
tick().then() handles later open transitions.