### PR TITLE
perf(multi-select): hoist regular items out of select-all map

### DIFF
--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -596,17 +596,14 @@
   function sort() {
     const selectedIdsSet = new Set(selectedIds);
 
+    const regularItems = items.filter((item) => !item.isSelectAll);
+    const enabledRegularItems = regularItems.filter((item) => !item.disabled);
+    const allChecked =
+      enabledRegularItems.length > 0 &&
+      enabledRegularItems.every((item) => selectedIdsSet.has(item.id));
     const selectAllEntries = items
       .filter((item) => item.isSelectAll)
-      .map((item) => {
-        const regularItems = items.filter((i) => !i.isSelectAll && !i.disabled);
-        const allChecked =
-          regularItems.length > 0 &&
-          regularItems.every((i) => selectedIdsSet.has(i.id));
-        return { ...item, checked: allChecked };
-      });
-
-    const regularItems = items.filter((item) => !item.isSelectAll);
+      .map((item) => ({ ...item, checked: allChecked }));
 
     if (
       selectionFeedback === "top" ||

--- a/tests/MultiSelect/MultiSelect.test.ts
+++ b/tests/MultiSelect/MultiSelect.test.ts
@@ -632,6 +632,23 @@ describe("MultiSelect", () => {
       expect(allRolesOption).toHaveAttribute("aria-checked", "false");
     });
 
+    it("select-all option shows checked when all enabled items are selected and disabled items are excluded", async () => {
+      render(MultiSelect, {
+        props: {
+          items: itemsWithSelectAll,
+          selectedIds: ["editor", "owner", "uploader"],
+          labelText: "Roles",
+        },
+      });
+
+      await openMenu();
+      const allRolesOption = screen.getByRole("option", { name: "All roles" });
+      expect(allRolesOption).toHaveAttribute("aria-checked", "true");
+      const readerOption = screen.getByRole("option", { name: "Reader" });
+      expect(readerOption).toHaveAttribute("aria-disabled", "true");
+      expect(readerOption).toHaveAttribute("aria-selected", "false");
+    });
+
     it("clear button deselects all including select-all state", async () => {
       render(MultiSelect, {
         props: {


### PR DESCRIPTION
The select-all "checked" computation ran items.filter() once inside
the .map() over select-all entries, then filtered again in the
outer scope under the same variable name. sort() runs on every
items/selectedIds change, so this was paying for the pass twice
(plus once per select-all entry) where one would do.

Hoists a single regularItems filter above the map and derives the
enabled subset once for the allChecked computation. The two
original filters differed in whether they excluded disabled items;
that distinction is preserved as regularItems (unfiltered) vs
enabledRegularItems (disabled excluded).