### PR TITLE
fix(file-uploader): announce upload status changes

### DIFF
--- a/src/FileUploader/Filename.svelte
+++ b/src/FileUploader/Filename.svelte
@@ -53,11 +53,30 @@
     return null;
   })();
 
+  let prevStatus = status;
+  let prevInvalid = invalid;
+  let statusAnnouncement = "";
+
+  // Announce transitions only (not the initial render) so a screen reader
+  // user hears completion/invalid state without being told about every
+  // status a file starts in.
+  $: if (status !== prevStatus || invalid !== prevInvalid) {
+    if (invalid && !prevInvalid) {
+      statusAnnouncement = `${fileName} invalid`;
+    } else if (status === "complete" && prevStatus !== "complete") {
+      statusAnnouncement = `${fileName} upload complete`;
+    }
+    prevStatus = status;
+    prevInvalid = invalid;
+  }
+
   import CheckmarkFilled from "../icons/CheckmarkFilled.svelte";
   import Close from "../icons/Close.svelte";
   import WarningFilled from "../icons/WarningFilled.svelte";
   import Loading from "../Loading/Loading.svelte";
 </script>
+
+<span role="status" class:bx--visually-hidden={true}>{statusAnnouncement}</span>
 
 {#if status === "uploading"}
   <Loading

--- a/tests/FileUploader/Filename.test.ts
+++ b/tests/FileUploader/Filename.test.ts
@@ -202,6 +202,49 @@ describe("Filename", () => {
     expect(keydownHandler).toHaveBeenCalled();
   });
 
+  it("should render an empty status live region on initial render", () => {
+    const { container } = render(Filename, {
+      props: { status: "uploading", fileName: "report.csv" },
+    });
+
+    const status = container.querySelector('[role="status"]');
+    assert(status);
+    expect(status).toHaveTextContent("");
+  });
+
+  it("should announce upload complete when status transitions to complete", async () => {
+    const { container, rerender } = render(Filename, {
+      props: { status: "uploading", fileName: "report.csv" },
+    });
+
+    await rerender({ status: "complete", fileName: "report.csv" });
+
+    const status = container.querySelector('[role="status"]');
+    expect(status).toHaveTextContent("report.csv upload complete");
+  });
+
+  it("should announce invalid when a file becomes invalid", async () => {
+    const { container, rerender } = render(Filename, {
+      props: { status: "edit", fileName: "report.csv", invalid: false },
+    });
+
+    await rerender({ status: "edit", fileName: "report.csv", invalid: true });
+
+    const status = container.querySelector('[role="status"]');
+    expect(status).toHaveTextContent("report.csv invalid");
+  });
+
+  it("should not re-announce when status changes without a completion or invalid transition", async () => {
+    const { container, rerender } = render(Filename, {
+      props: { status: "uploading", fileName: "report.csv" },
+    });
+
+    await rerender({ status: "edit", fileName: "report.csv" });
+
+    const status = container.querySelector('[role="status"]');
+    expect(status).toHaveTextContent("");
+  });
+
   it("should be focusable when status is edit", () => {
     const { container } = render(Filename, {
       props: { status: "edit" },


### PR DESCRIPTION
Status is conveyed by swapping icons (spinner -> checkmark or warning),
which a screen reader user doesn't hear: the Loading live region
unmounts on transition, and a checkmark's aria-label on a static icon
isn't announced. A user who starts an upload gets no notification of
completion or failure.

Filename now renders a persistent visually-hidden role="status"
element that announces "<file> upload complete" or "<file> invalid"
on the transition into that state, guarded by a prev-value snapshot
so it doesn't chatter on every render.