### PR TITLE
fix(data-table): unsubscribe toolbar search before resubscribing

### DIFF
--- a/src/DataTable/ToolbarSearch.svelte
+++ b/src/DataTable/ToolbarSearch.svelte
@@ -65,16 +65,20 @@
   let rows = null;
   let unsubscribe = null;
 
-  $: if (shouldFilterRows) {
-    unsubscribe = ctx?.tableRows.subscribe((tableRows) => {
-      // Only update if the rows have actually changed.
-      // This approach works in both Svelte 4 and Svelte 5.
-      if (!rowsEqual(tableRows, rows)) {
-        rows = tableRows;
-      }
-    });
-  } else {
-    rows = null;
+  $: {
+    unsubscribe?.();
+    unsubscribe = null;
+    if (shouldFilterRows) {
+      unsubscribe = ctx?.tableRows.subscribe((tableRows) => {
+        // Only update if the rows have actually changed.
+        // This approach works in both Svelte 4 and Svelte 5.
+        if (!rowsEqual(tableRows, rows)) {
+          rows = tableRows;
+        }
+      });
+    } else {
+      rows = null;
+    }
   }
 
   onMount(() => {

--- a/tests/DataTable/TableRowsSubscribeSpy.svelte
+++ b/tests/DataTable/TableRowsSubscribeSpy.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+  import { getContext, setContext } from "svelte";
+
+  type Ctx = {
+    tableRows: {
+      subscribe: (fn: (value: unknown) => void) => () => void;
+    };
+    [key: string]: unknown;
+  };
+
+  // Number of times any live subscriber callback has fired (including the
+  // immediate fire every new subscription receives from the store).
+  export let count = 0;
+
+  const ctx = getContext<Ctx>("carbon:DataTable");
+  const originalSubscribe = ctx.tableRows.subscribe.bind(ctx.tableRows);
+
+  setContext("carbon:DataTable", {
+    ...ctx,
+    tableRows: {
+      ...ctx.tableRows,
+      subscribe: (fn: (value: unknown) => void) => {
+        return originalSubscribe((value: unknown) => {
+          count += 1;
+          fn(value);
+        });
+      },
+    },
+  });
+</script>
+
+<slot />

--- a/tests/DataTable/ToolbarSearchUnsubscribe.test.svelte
+++ b/tests/DataTable/ToolbarSearchUnsubscribe.test.svelte
@@ -1,0 +1,37 @@
+<svelte:options accessors />
+
+<script lang="ts">
+  import Button from "carbon-components-svelte/Button/Button.svelte";
+  import DataTable from "carbon-components-svelte/DataTable/DataTable.svelte";
+  import Toolbar from "carbon-components-svelte/DataTable/Toolbar.svelte";
+  import ToolbarContent from "carbon-components-svelte/DataTable/ToolbarContent.svelte";
+  import ToolbarSearch from "carbon-components-svelte/DataTable/ToolbarSearch.svelte";
+  import TableRowsSubscribeSpy from "./TableRowsSubscribeSpy.svelte";
+
+  export let subscribeCount = 0;
+
+  let rows = Array.from({ length: 5 }).map((_, i) => ({
+    id: i,
+    name: `Row ${i + 1}`,
+  }));
+
+  // Starts `true` so mount creates the first live subscription.
+  let shouldFilterRows = true;
+</script>
+
+<Button on:click={() => (shouldFilterRows = !shouldFilterRows)}>
+  Toggle filter
+</Button>
+<Button on:click={() => (rows = rows.map((row) => ({ ...row })))}>
+  Change rows
+</Button>
+
+<DataTable headers={[{ key: "name", value: "Name" }]} {rows}>
+  <Toolbar>
+    <ToolbarContent>
+      <TableRowsSubscribeSpy bind:count={subscribeCount}>
+        <ToolbarSearch {shouldFilterRows} />
+      </TableRowsSubscribeSpy>
+    </ToolbarContent>
+  </Toolbar>
+</DataTable>

--- a/tests/DataTable/ToolbarSearchUnsubscribe.test.ts
+++ b/tests/DataTable/ToolbarSearchUnsubscribe.test.ts
@@ -1,0 +1,34 @@
+import { render, screen } from "@testing-library/svelte";
+import { user } from "../utils/user";
+import ToolbarSearchUnsubscribe from "./ToolbarSearchUnsubscribe.test.svelte";
+
+// Regression test: toggling `shouldFilterRows` used to overwrite the
+// component's `unsubscribe` handle without calling the previous one first,
+// leaking a live `tableRows` subscriber on every `false -> true` toggle.
+// Each leaked subscriber re-runs the row-equality check on every emission,
+// so the leak compounds with every toggle over a component's lifetime.
+describe("ToolbarSearch unsubscribes from tableRows before resubscribing", () => {
+  it("keeps exactly one live subscriber after toggling shouldFilterRows repeatedly", async () => {
+    const { component } = render(ToolbarSearchUnsubscribe);
+
+    const toggleButton = screen.getByRole("button", { name: "Toggle filter" });
+
+    // Mounts with `shouldFilterRows = true` (one live subscription), then
+    // toggles true -> false -> true -> false -> true.
+    for (let i = 0; i < 4; i++) {
+      await user.click(toggleButton);
+    }
+
+    // Baseline includes the immediate callback fire every new subscription
+    // receives from the store; reset the reference point before the single
+    // emission we actually care about.
+    const baseline = component.subscribeCount;
+
+    await user.click(screen.getByRole("button", { name: "Change rows" }));
+
+    // Exactly one live subscriber should receive the emission. Before the
+    // fix, each `false -> true` toggle leaked the previous subscription, so
+    // this would be 3 (three live subscribers left over from the toggles).
+    expect(component.subscribeCount - baseline).toBe(1);
+  });
+});

--- a/tests/DataTable/ToolbarSearchUnsubscribe.test.ts
+++ b/tests/DataTable/ToolbarSearchUnsubscribe.test.ts
@@ -16,6 +16,7 @@ describe("ToolbarSearch unsubscribes from tableRows before resubscribing", () =>
     // Mounts with `shouldFilterRows = true` (one live subscription), then
     // toggles true -> false -> true -> false -> true.
     for (let i = 0; i < 4; i++) {
+      // biome-ignore lint/performance/noAwaitInLoops: sequential execution is intentional
       await user.click(toggleButton);
     }
 


### PR DESCRIPTION
The reactive block that subscribes to tableRows overwrote the
unsubscribe handle without calling the previous one first, so every
false -> true toggle of shouldFilterRows leaked a live subscriber.
onMount's cleanup only ever releases the last handle, so toggling N
times leaves N callbacks running, each re-running rowsEqual (a
recursive deep-compare when rows aren't reference-identical) on
every tableRows emission.

Calls the previous unsubscribe before creating a new one, and
releases it on the else branch too, in the same reactive block that
reads and writes it.