### PR TITLE
perf(pagination-nav): populate overflow options on demand

### DIFF
--- a/docs/src/pages/components/PaginationNav.svx
+++ b/docs/src/pages/components/PaginationNav.svx
@@ -30,6 +30,12 @@ Control the number of visible page numbers with `shown`.
 
 <PaginationNav total={100} shown={5} />
 
+## Overflow with many pages
+
+For large page counts, pages beyond `shown` collapse into an overflow menu. The overflow options recompute on every page change; once the hidden list grows past a threshold, options populate lazily on first interaction instead of mounting up front, avoiding needless DOM churn for a control the user may never open. Smaller overflow lists render immediately since the cost is negligible.
+
+<PaginationNav total={10000} shown={5} />
+
 ## Navigation buttons
 
 The forward and backward navigation buttons can be customized independently of the page numbers.

--- a/src/PaginationNav/PaginationOverflow.svelte
+++ b/src/PaginationNav/PaginationOverflow.svelte
@@ -15,7 +15,17 @@
 
   const dispatch = createEventDispatcher();
 
+  // Below this count, the option list is cheap enough to render up front;
+  // deferring it would only add interaction overhead for no real DOM savings.
+  // Matches the 1000-item default tolerance in Pagination's `pageWindow`.
+  const EAGER_RENDER_THRESHOLD = 1000;
+
   let value = "";
+  let interacted = false;
+
+  // Defer rendering large sets of hidden page options until the user
+  // actually interacts with the select, since it may never be opened.
+  $: populated = interacted || count <= EAGER_RENDER_THRESHOLD;
 </script>
 
 {#if count > 1}
@@ -27,20 +37,28 @@
         {value}
         class:bx--pagination-nav__page={true}
         class:bx--pagination-nav__page--select={true}
+        on:focus={() => {
+          interacted = true;
+        }}
+        on:mousedown={() => {
+          interacted = true;
+        }}
         on:change={(event) => {
           value = "";
           dispatch("select", { index: Number(event.target.value) });
         }}
       >
         <option value="" hidden></option>
-        {#each Array.from({ length: count }, (_, index) => index) as pageOffset (pageOffset)}
-          <option
-            value={fromIndex + pageOffset + 1}
-            data-page={fromIndex + pageOffset + 1}
-          >
-            {fromIndex + pageOffset + 1}
-          </option>
-        {/each}
+        {#if populated}
+          {#each Array.from({ length: count }, (_, index) => index) as pageOffset (pageOffset)}
+            <option
+              value={fromIndex + pageOffset + 1}
+              data-page={fromIndex + pageOffset + 1}
+            >
+              {fromIndex + pageOffset + 1}
+            </option>
+          {/each}
+        {/if}
       </select>
       <div class:bx--pagination-nav__select-icon-wrapper={true}>
         <OverflowMenuHorizontal class="bx--pagination-nav__select-icon" />

--- a/tests/PaginationNav/PaginationNav.test.ts
+++ b/tests/PaginationNav/PaginationNav.test.ts
@@ -1,4 +1,4 @@
-import { render, screen, within } from "@testing-library/svelte";
+import { fireEvent, render, screen, within } from "@testing-library/svelte";
 import { user } from "../utils/user";
 import PaginationNav from "./PaginationNav.test.svelte";
 
@@ -170,6 +170,8 @@ describe("PaginationNav", () => {
     const overflowIndicator = screen.getByLabelText("Select Page number");
     expect(overflowIndicator).toBeInTheDocument();
 
+    await user.click(overflowIndicator);
+
     await user.selectOptions(overflowIndicator, "4");
 
     expect(consoleLog).toHaveBeenCalledWith("change", { page: 4 });
@@ -178,5 +180,45 @@ describe("PaginationNav", () => {
     await user.selectOptions(overflowIndicator, "50");
     expect(consoleLog).toHaveBeenCalledWith("change", { page: 50 });
     expect(consoleLog).toHaveBeenCalledTimes(2);
+  });
+
+  it("should populate overflow options lazily on first interaction", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(PaginationNav, {
+      props: { total: 2000, shown: 5 },
+    });
+
+    const overflowIndicator = screen.getByLabelText("Select Page number");
+
+    // Before any interaction, only the hidden placeholder option should exist
+    // in the DOM -- the ~1990 hidden page options (above the eager-render
+    // threshold) must not be mounted yet.
+    // The placeholder itself is `hidden`, so it's excluded from the
+    // accessible role tree; query the raw <option> elements instead.
+    expect(overflowIndicator.querySelectorAll("option")).toHaveLength(1);
+
+    // A keyboard-originated interaction (focus) must populate the full list
+    // so the native picker isn't empty on first open.
+    await fireEvent.focus(overflowIndicator);
+
+    const options = overflowIndicator.querySelectorAll("option");
+    expect(options.length).toBeGreaterThan(1);
+
+    await user.selectOptions(overflowIndicator, "4");
+    expect(consoleLog).toHaveBeenCalledWith("change", { page: 4 });
+  });
+
+  it("should eagerly render overflow options below the lazy-populate threshold", () => {
+    render(PaginationNav, {
+      props: { total: 50, shown: 10 },
+    });
+
+    const overflowIndicator = screen.getByLabelText("Select Page number");
+
+    // A small overflow list (below the threshold) is cheap enough to render
+    // up front, without requiring focus/mousedown first.
+    expect(overflowIndicator.querySelectorAll("option").length).toBeGreaterThan(
+      1,
+    );
   });
 });


### PR DESCRIPTION
The overflow `<select>` mounted one keyed `<option>` per hidden page,
re-keyed on every page change, for a control the user may never
open. For a 10,000-page nav that's ~9,990 DOM nodes just sitting
there.

Options now populate lazily on first focus or mousedown (both
needed since keyboard and pointer can open the native picker via
different first events) once the hidden count exceeds a threshold,
gated behind a `populated` flag that only ever flips true so the
list doesn't thrash on blur/close.

Small overflow lists render eagerly instead of deferring, since
mounting a handful of options is negligible cost and deferring them
would only add interaction overhead for no real savings. The
threshold (1000) matches `Pagination`'s existing `pageWindow`
default, which documents 1000 as this codebase's tolerance for
eagerly rendering native `<select>` options.

Docs updated with an example illustrating a large total page count.