### PR TITLE
fix(progress-indicator): expose step state to assistive tech

### DIFF
--- a/src/ProgressIndicator/ProgressStep.svelte
+++ b/src/ProgressIndicator/ProgressStep.svelte
@@ -35,6 +35,8 @@
 
   let step = {};
 
+  $: stateSuffix = invalid ? ", invalid" : complete ? ", complete" : "";
+
   const ctx = getContext("carbon:ProgressIndicator");
   const stepsById = ctx?.stepsById ?? writable({});
   const add = ctx?.add ?? (() => {});
@@ -73,6 +75,7 @@
     type="button"
     {disabled}
     aria-disabled={disabled}
+    aria-current={current ? "step" : undefined}
     tabindex={!current && !disabled ? "0" : "-1"}
     class:bx--progress-step-button={true}
     class:bx--progress-step-button--unclickable={current ||
@@ -108,6 +111,9 @@
         <p class:bx--progress-optional={true}>{secondaryLabel}</p>
       {/if}
     </div>
+    {#if stateSuffix}
+      <span class:bx--visually-hidden={true}>{stateSuffix}</span>
+    {/if}
     <span class:bx--progress-line={true}></span>
   </button>
 </li>

--- a/tests/ProgressIndicator/ProgressIndicator.test.ts
+++ b/tests/ProgressIndicator/ProgressIndicator.test.ts
@@ -43,6 +43,31 @@ describe("ProgressIndicator", () => {
       );
     });
 
+    it("should expose current, complete, and invalid state to assistive tech", () => {
+      render(ProgressIndicator, {
+        currentIndex: 1,
+        steps: [
+          { label: "Step 1", description: "First step", complete: true },
+          { label: "Step 2", description: "Second step", complete: false },
+          {
+            label: "Step 3",
+            description: "Third step",
+            complete: false,
+            invalid: true,
+          },
+        ],
+      });
+
+      const buttons = screen.getAllByRole("button");
+
+      expect(buttons[0]).not.toHaveAttribute("aria-current");
+      expect(buttons[1]).toHaveAttribute("aria-current", "step");
+      expect(buttons[2]).not.toHaveAttribute("aria-current");
+
+      expect(buttons[0]).toHaveAccessibleName(/, complete$/);
+      expect(buttons[2]).toHaveAccessibleName(/, invalid$/);
+    });
+
     it("should update currentIndex when clicking on completed steps", async () => {
       const consoleLog = vi.spyOn(console, "log");
       render(ProgressIndicator, {


### PR DESCRIPTION
Current/complete/invalid state lived only in CSS classes and which
icon got rendered, so a screen reader user tabbing across steps
couldn't tell which one was current, done, or invalid. The button now
gets aria-current="step" when current, and a visually-hidden suffix
appends ", complete" or ", invalid" to the accessible name for those
states.