### PR TITLE
fix(text-area): associate helper text and character count with the textarea

### DIFF
--- a/src/TextArea/TextArea.svelte
+++ b/src/TextArea/TextArea.svelte
@@ -84,11 +84,27 @@
 
   const formContext = getContext("carbon:Form");
 
+  $: helperId = `helper-${id}`;
+  $: counterId = `counter-${id}`;
   $: errorId = `error-${id}`;
   $: warnId = `warn-${id}`;
   $: showInvalid = invalid && !disabled && !readonly;
   $: showWarn = warn && !invalid && !disabled && !readonly;
   $: isFluid = fluid || !!formContext?.isFluid;
+  $: showCounter = !!maxCount && !!(labelText || $$slots.labelChildren);
+  $: describedBy =
+    [
+      showInvalid
+        ? errorId
+        : showWarn && !isFluid
+          ? warnId
+          : helperText && !isFluid
+            ? helperId
+            : null,
+      showCounter ? counterId : null,
+    ]
+      .filter(Boolean)
+      .join(" ") || undefined;
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
@@ -115,6 +131,7 @@
       </label>
       {#if maxCount}
         <div
+          id={counterId}
           class:bx--label={true}
           class:bx--label--disabled={disabled}
           class:bx--text-area__label-counter={true}
@@ -144,11 +161,7 @@
       bind:this={ref}
       bind:value
       aria-invalid={showInvalid || undefined}
-      aria-describedby={showInvalid
-        ? errorId
-        : showWarn && !isFluid
-          ? warnId
-          : undefined}
+      aria-describedby={describedBy}
       data-warn={showWarn || undefined}
       {disabled}
       {id}
@@ -193,6 +206,7 @@
   </div>
   {#if !isFluid && !showInvalid && !showWarn && helperText}
     <div
+      id={helperId}
       class:bx--form__helper-text={true}
       class:bx--form__helper-text--disabled={disabled}
     >

--- a/tests/TextArea/TextArea.test.ts
+++ b/tests/TextArea/TextArea.test.ts
@@ -73,6 +73,41 @@ describe("TextArea", () => {
     );
   });
 
+  it("should associate helper text with the textarea via aria-describedby", () => {
+    render(TextArea, { props: { helperText: "Helper text" } });
+
+    const textarea = screen.getByRole("textbox");
+    const describedById = textarea.getAttribute("aria-describedby");
+    assert(describedById);
+    expect(screen.getByText("Helper text")).toHaveAttribute(
+      "id",
+      describedById,
+    );
+  });
+
+  it("should include the counter id in aria-describedby alongside helper text", () => {
+    render(TextArea, {
+      props: { helperText: "Helper text", maxCount: 100, value: "hi" },
+    });
+
+    const textarea = screen.getByRole("textbox");
+    const describedBy = textarea.getAttribute("aria-describedby");
+    assert(describedBy);
+    const ids = describedBy.split(" ");
+
+    expect(screen.getByText("Helper text").id).toBe(ids[0]);
+    expect(screen.getByText("2/100").id).toBe(ids[1]);
+  });
+
+  it("should include the counter id in aria-describedby without helper text", () => {
+    render(TextArea, { props: { maxCount: 100, value: "hi" } });
+
+    const textarea = screen.getByRole("textbox");
+    expect(textarea.getAttribute("aria-describedby")).toBe(
+      screen.getByText("2/100").id,
+    );
+  });
+
   it("should handle invalid state", () => {
     render(TextArea, {
       props: { invalid: true, invalidText: "Invalid input" },


### PR DESCRIPTION
aria-describedby only covered the error/warning text, so the helper
div rendered with no id and was never referenced -- screen readers
skipped form hints that TextInput already surfaces correctly. The
character counter had the same gap.

Mirrors TextInput: helper text gets an id and joins aria-describedby
when not invalid/warn; the counter gets its own id and is always
included when present (not made live, since maxlength already caps
input and announcing every keystroke would be noise).