### PR TITLE
fix(tabs): link tabs to their panels with aria-controls

### DIFF
--- a/src/Tabs/Tab.svelte
+++ b/src/Tabs/Tab.svelte
@@ -91,6 +91,8 @@
     remove,
     update,
     dismiss,
+    tabsById,
+    contentByIndex,
   } = getContext("carbon:Tabs");
 
   // Icon-only tabs show `label` as a portalled tooltip on hover/focus.
@@ -159,6 +161,10 @@
   // Default href is the "#" placeholder, so tabs behave as selection controls.
   // Any other href is user-provided and should navigate like a link.
   $: isLink = !!href && href !== "#";
+  // Panels learn their tab's id by index (`TabContent`); mirror that pairing
+  // in the other direction so the tab can point `aria-controls` at its panel.
+  // `undefined` when no panel is rendered for this tab's position.
+  $: panelId = $contentByIndex[$tabsById[id]?.index];
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
@@ -200,6 +206,7 @@
     tabindex={disabled ? "-1" : tabindex}
     aria-selected={selected}
     aria-disabled={disabled}
+    aria-controls={panelId}
     aria-label={$iconOnly ? label : undefined}
     {id}
     {href}

--- a/src/Tabs/Tabs.svelte
+++ b/src/Tabs/Tabs.svelte
@@ -105,6 +105,16 @@
    */
   const contentById = derived(content, (_) => keyBy(_));
   /**
+   * Reverse lookup so each `Tab` can find its paired panel id by index.
+   * @type {import("svelte/store").Readable<Record<number, string>>}
+   */
+  const contentByIndex = derived(content, (_) => {
+    /** @type {Record<number, string>} */
+    const map = {};
+    for (const item of _) map[item.index] = item.id;
+    return map;
+  });
+  /**
    * @type {import("svelte/store").Writable<string | undefined>}
    */
   const selectedContent = writable(undefined);
@@ -315,7 +325,9 @@
 
   setContext("carbon:Tabs", {
     tabs,
+    tabsById,
     contentById,
+    contentByIndex,
     selectedTab,
     selectedContent,
     activeTooltip,

--- a/src/Tabs/TabsVertical.svelte
+++ b/src/Tabs/TabsVertical.svelte
@@ -69,6 +69,16 @@
    */
   const contentById = derived(content, (_) => keyBy(_));
   /**
+   * Reverse lookup so each `Tab` can find its paired panel id by index.
+   * @type {import("svelte/store").Readable<Record<number, string>>}
+   */
+  const contentByIndex = derived(content, (_) => {
+    /** @type {Record<number, string>} */
+    const map = {};
+    for (const item of _) map[item.index] = item.id;
+    return map;
+  });
+  /**
    * @type {import("svelte/store").Writable<string | undefined>}
    */
   const selectedContent = writable(undefined);
@@ -271,7 +281,9 @@
 
   setContext("carbon:Tabs", {
     tabs,
+    tabsById,
     contentById,
+    contentByIndex,
     selectedTab,
     selectedContent,
     activeTooltip,

--- a/tests/Tabs/Tabs.test.ts
+++ b/tests/Tabs/Tabs.test.ts
@@ -42,6 +42,24 @@ describe("Tabs", () => {
     expect(tabsContainer).not.toHaveClass("bx--tabs--full-width");
   });
 
+  it("should link each tab to its panel via aria-controls", () => {
+    render(Tabs);
+
+    const tabs = screen.getAllByRole("tab");
+    const panels = screen.getAllByRole("tabpanel", { hidden: true });
+
+    expect(tabs).toHaveLength(3);
+    expect(panels).toHaveLength(3);
+
+    tabs.forEach((tab, index) => {
+      const panelId = tab.getAttribute("aria-controls");
+      assert(panelId);
+      expect(panelId).toBe(panels[index].id);
+      // The pairing holds in both directions.
+      expect(panels[index]).toHaveAttribute("aria-labelledby", tab.id);
+    });
+  });
+
   it("should not put a tabindex on the presentational <li> wrapper", () => {
     const { container } = render(Tabs);
 

--- a/tests/Tabs/TabsVertical.test.ts
+++ b/tests/Tabs/TabsVertical.test.ts
@@ -29,6 +29,23 @@ describe("TabsVertical", () => {
     expect(screen.getByText("Content 2")).not.toBeVisible();
   });
 
+  it("should link each tab to its panel via aria-controls", () => {
+    render(TabsVertical);
+
+    const tabs = screen.getAllByRole("tab");
+    const panels = screen.getAllByRole("tabpanel", { hidden: true });
+
+    expect(tabs).toHaveLength(4);
+    expect(panels).toHaveLength(4);
+
+    tabs.forEach((tab, index) => {
+      const panelId = tab.getAttribute("aria-controls");
+      assert(panelId);
+      expect(panelId).toBe(panels[index].id);
+      expect(panels[index]).toHaveAttribute("aria-labelledby", tab.id);
+    });
+  });
+
   it("should default to the xl layout size", () => {
     render(TabsVertical);
 


### PR DESCRIPTION
TabContent points back to its tab with aria-labelledby, but the
forward link was missing, so assistive tech offering "jump to
controlled element" (or announcing the relationship) got nothing.
Carbon React sets it.

Panels already learn their tab's id by index; Tabs and TabsVertical
now expose the reverse lookup (tab index -> panel id) through context
so each Tab can point aria-controls at its panel. Omitted when no
panel is rendered for a tab's position.