### PR TITLE
fix(accordion-item): link header button to its content region

### DIFF
--- a/src/Accordion/AccordionItem.svelte
+++ b/src/Accordion/AccordionItem.svelte
@@ -54,6 +54,7 @@
   });
 
   const id = {};
+  const contentId = `ccs-${Math.random().toString(36)}`;
 
   const unsubscribeOpenId = ctx.openId.subscribe((openItemId) => {
     if (openItemId !== null && openItemId !== id) {
@@ -97,6 +98,7 @@
     class:bx--accordion__heading={true}
     aria-label={ariaLabel}
     aria-expanded={open}
+    aria-controls={contentId}
     {disabled}
     on:click
     on:click={() => {
@@ -118,7 +120,7 @@
       <slot name="title">{title}</slot>
     </div>
   </button>
-  <div class:bx--accordion__content={true}>
+  <div id={contentId} class:bx--accordion__content={true}>
     {#if !lazy || hasOpened}
       <slot />
     {/if}

--- a/tests/Accordion/Accordion.test.ts
+++ b/tests/Accordion/Accordion.test.ts
@@ -27,6 +27,21 @@ describe("Accordion", () => {
     );
   };
 
+  it("links the header button to its content region via aria-controls", () => {
+    render(Accordion);
+
+    const button = screen.getByRole("button", {
+      name: /Natural Language Classifier/,
+    });
+    const contentId = button.getAttribute("aria-controls");
+    assert(contentId);
+
+    const content = document.getElementById(contentId);
+    assert(content);
+    expect(content).toHaveClass("bx--accordion__content");
+    expect(content).toHaveTextContent("1");
+  });
+
   it("renders and functions correctly", async () => {
     render(Accordion);
 


### PR DESCRIPTION
The header button had aria-expanded but no aria-controls, and the
content div had no id, so assistive tech couldn't expose the
button-to-region relationship. Carbon React sets it.