### PR TITLE
fix(code-snippet): set aria-expanded on the show-more button

### DIFF
--- a/src/CodeSnippet/CodeSnippet.svelte
+++ b/src/CodeSnippet/CodeSnippet.svelte
@@ -476,6 +476,7 @@
   >
     <!-- svelte-ignore a11y-no-noninteractive-tabindex -->
     <div
+      {id}
       role="textbox"
       tabindex={disabled ? undefined : "0"}
       aria-readonly="true"
@@ -515,6 +516,8 @@
         kind="ghost"
         size="small"
         class="bx--snippet-btn--expand"
+        aria-expanded={expanded}
+        aria-controls={id}
         {disabled}
         on:click={() => {
           expanded = !expanded;

--- a/tests/CodeSnippet/CodeSnippet.test.ts
+++ b/tests/CodeSnippet/CodeSnippet.test.ts
@@ -298,6 +298,27 @@ yarn -v`,
     expect(screen.getByText("Show more")).toBeInTheDocument();
   });
 
+  test("should set aria-expanded and aria-controls on the show-more button", async () => {
+    mockSnippetOverflowHeight();
+    render(CodeSnippetExpandable);
+    await waitForSnippetMeasurement();
+
+    const showMoreButton = await screen.findByText("Show more");
+    const button = showMoreButton.closest("button");
+    assert(button);
+    expect(button).toHaveAttribute("aria-expanded", "false");
+
+    const controlsId = button.getAttribute("aria-controls");
+    assert(controlsId);
+    const codeContainer = document.getElementById(controlsId);
+    assert(codeContainer);
+    expect(codeContainer).toHaveClass("bx--snippet-container");
+
+    await user.click(button);
+
+    expect(button).toHaveAttribute("aria-expanded", "true");
+  });
+
   // Regression: chevron should not duplicate the button's accessible name
   test("should not set aria-label on the expand chevron", async () => {
     mockSnippetOverflowHeight();


### PR DESCRIPTION
The multiline expand button toggled visible text ("Show more" /
"Show less") but exposed no aria-expanded or aria-controls, so the
state and target weren't programmatic. Wires both through Button's
restProps, pointing at the snippet's code container.