### PR TITLE
fix(data-table): label the table with its title and description

### DIFF
--- a/src/DataTable/DataTable.svelte
+++ b/src/DataTable/DataTable.svelte
@@ -414,6 +414,14 @@
   // since there may be multiple `DataTable` instances that have overlapping row ids.
   const id = `ccs-${Math.random().toString(36)}`;
 
+  // Label the table with its title/description. Only when the default
+  // heading markup renders (not overridden via the titleChildren /
+  // descriptionChildren slots, whose custom markup we don't control ids for).
+  const titleId = `${id}-title`;
+  const descriptionId = `${id}-description`;
+  $: hasTitle = !!title && !$$slots.titleChildren;
+  $: hasDescription = !!description && !$$slots.descriptionChildren;
+
   // A columnHidden header stays in `headers`, the column definition, and is
   // skipped everywhere the rendered column set is meant.
   $: visibleHeaders = headers.filter((header) => !header.columnHidden);
@@ -817,7 +825,9 @@
           name="titleChildren"
           props={{ class: "bx--data-table-header__title" }}
         >
-          <h4 class:bx--data-table-header__title={true}>{title}</h4>
+          <h4 id={titleId} class:bx--data-table-header__title={true}>
+            {title}
+          </h4>
         </slot>
       {/if}
       {#if description || $$slots.descriptionChildren}
@@ -825,7 +835,9 @@
           name="descriptionChildren"
           props={{ class: "bx--data-table-header__description" }}
         >
-          <p class:bx--data-table-header__description={true}>{description}</p>
+          <p id={descriptionId} class:bx--data-table-header__description={true}>
+            {description}
+          </p>
         </slot>
       {/if}
     </div>
@@ -848,6 +860,8 @@
       {stickyHeader}
       {sortable}
       {useStaticWidth}
+      labelledBy={hasTitle ? titleId : undefined}
+      describedBy={hasDescription ? descriptionId : undefined}
       tableStyle={[
         hasCustomHeaderWidth && "table-layout: fixed",
         stickyHeader &&

--- a/src/DataTable/Table.svelte
+++ b/src/DataTable/Table.svelte
@@ -29,6 +29,45 @@
    * @bindable readonly
    */
   export let ref = null;
+
+  /**
+   * Id of an element that labels the table (e.g. `DataTable`'s title heading).
+   * Internal: set directly by `DataTable`. Standalone compositions
+   * (`TableContainer` wrapping `Table`) get this from context instead.
+   * @type {string | undefined}
+   */
+  export let labelledBy = undefined;
+
+  /**
+   * Id of an element that describes the table (e.g. `DataTable`'s description text).
+   * Internal: set directly by `DataTable`. Standalone compositions
+   * (`TableContainer` wrapping `Table`) get this from context instead.
+   * @type {string | undefined}
+   */
+  export let describedBy = undefined;
+
+  import { getContext } from "svelte";
+  import { writable } from "svelte/store";
+
+  // Context is only consulted for the standalone `TableContainer` + `Table`
+  // composition: an explicit `labelledBy`/`describedBy` prop (set by
+  // `DataTable`, which renders its own title/description markup) always wins.
+  const tableContainerCtx = getContext("carbon:TableContainer");
+  const hasContextTitle = tableContainerCtx?.hasTitle ?? writable(false);
+  const hasContextDescription =
+    tableContainerCtx?.hasDescription ?? writable(false);
+
+  // A consumer-supplied aria-label/aria-labelledby/aria-describedby always
+  // wins over the id `TableContainer`/`DataTable` provide.
+  $: ariaLabelledby =
+    !$$restProps["aria-label"] && !$$restProps["aria-labelledby"]
+      ? (labelledBy ??
+        ($hasContextTitle ? tableContainerCtx.titleId : undefined))
+      : undefined;
+  $: ariaDescribedby = $$restProps["aria-describedby"]
+    ? undefined
+    : (describedBy ??
+      ($hasContextDescription ? tableContainerCtx.descriptionId : undefined));
 </script>
 
 {#if stickyHeader}
@@ -38,6 +77,8 @@
     {...$$restProps}
   >
     <table
+      aria-labelledby={ariaLabelledby}
+      aria-describedby={ariaDescribedby}
       class:bx--data-table={true}
       class:bx--data-table--compact={size === "compact"}
       class:bx--data-table--short={size === "short"}
@@ -54,6 +95,8 @@
   </section>
 {:else}
   <table
+    aria-labelledby={ariaLabelledby}
+    aria-describedby={ariaDescribedby}
     class:bx--data-table={true}
     class:bx--data-table--compact={size === "compact"}
     class:bx--data-table--short={size === "short"}

--- a/src/DataTable/TableContainer.svelte
+++ b/src/DataTable/TableContainer.svelte
@@ -10,6 +10,24 @@
 
   /** Set to `true` to use static width */
   export let useStaticWidth = false;
+
+  import { setContext } from "svelte";
+  import { writable } from "svelte/store";
+
+  const titleId = `ccs-${Math.random().toString(36)}`;
+  const descriptionId = `ccs-${Math.random().toString(36)}`;
+  const hasTitle = writable(!!title);
+  const hasDescription = writable(!!description);
+
+  $: hasTitle.set(!!title);
+  $: hasDescription.set(!!description);
+
+  setContext("carbon:TableContainer", {
+    titleId,
+    descriptionId,
+    hasTitle,
+    hasDescription,
+  });
 </script>
 
 <div
@@ -20,8 +38,10 @@
 >
   {#if title}
     <div class:bx--data-table-header={true}>
-      <h4 class:bx--data-table-header__title={true}>{title}</h4>
-      <p class:bx--data-table-header__description={true}>{description}</p>
+      <h4 id={titleId} class:bx--data-table-header__title={true}>{title}</h4>
+      <p id={descriptionId} class:bx--data-table-header__description={true}>
+        {description}
+      </p>
     </div>
   {/if}
   <slot />

--- a/tests/DataTable/DataTable.test.ts
+++ b/tests/DataTable/DataTable.test.ts
@@ -143,6 +143,39 @@ describe("DataTable", () => {
     expect(screen.getByText("Test Description")).toBeInTheDocument();
   });
 
+  it("labels the table with its title and description", () => {
+    render(DataTable, {
+      props: {
+        title: "Test Table",
+        description: "Test Description",
+        headers,
+        rows,
+      },
+    });
+
+    const table = screen.getByRole("table");
+
+    const labelledbyId = table.getAttribute("aria-labelledby");
+    assert(labelledbyId);
+    expect(document.getElementById(labelledbyId)).toHaveTextContent(
+      "Test Table",
+    );
+
+    const describedbyId = table.getAttribute("aria-describedby");
+    assert(describedbyId);
+    expect(document.getElementById(describedbyId)).toHaveTextContent(
+      "Test Description",
+    );
+  });
+
+  it("does not set aria-labelledby or aria-describedby without a title", () => {
+    render(DataTable, { props: { headers, rows } });
+
+    const table = screen.getByRole("table");
+    expect(table).not.toHaveAttribute("aria-labelledby");
+    expect(table).not.toHaveAttribute("aria-describedby");
+  });
+
   it("handles empty table state", () => {
     render(DataTable, {
       props: {

--- a/tests/DataTable/TableContainerWithTable.test.svelte
+++ b/tests/DataTable/TableContainerWithTable.test.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import Table from "carbon-components-svelte/DataTable/Table.svelte";
+  import TableBody from "carbon-components-svelte/DataTable/TableBody.svelte";
+  import TableCell from "carbon-components-svelte/DataTable/TableCell.svelte";
+  import TableContainer from "carbon-components-svelte/DataTable/TableContainer.svelte";
+  import TableRow from "carbon-components-svelte/DataTable/TableRow.svelte";
+  import type { ComponentProps } from "svelte";
+
+  export let title: ComponentProps<TableContainer>["title"] = "";
+  export let description: ComponentProps<TableContainer>["description"] = "";
+</script>
+
+<TableContainer {title} {description}>
+  <Table>
+    <TableBody>
+      <TableRow>
+        <TableCell>Cell</TableCell>
+      </TableRow>
+    </TableBody>
+  </Table>
+</TableContainer>

--- a/tests/DataTable/TableSubComponents.test.ts
+++ b/tests/DataTable/TableSubComponents.test.ts
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/svelte";
 import { user } from "../utils/user";
+import TableContainerWithTable from "./TableContainerWithTable.test.svelte";
 import TableSubComponents from "./TableSubComponents.test.svelte";
 
 describe("Table Sub-Components", () => {
@@ -12,6 +13,36 @@ describe("Table Sub-Components", () => {
       const table = container.querySelector("table");
       expect(table).toBeInTheDocument();
       expect(table).toHaveClass("bx--data-table");
+    });
+
+    it("should not set aria-labelledby without a TableContainer ancestor", () => {
+      render(TableSubComponents, {
+        props: { testComponent: "Table", slotContent: "Content" },
+      });
+
+      const table = screen.getByRole("table");
+      expect(table).not.toHaveAttribute("aria-labelledby");
+      expect(table).not.toHaveAttribute("aria-describedby");
+    });
+
+    it("labels a Table nested in a standalone TableContainer via context", () => {
+      render(TableContainerWithTable, {
+        props: { title: "Container Title", description: "Container Desc" },
+      });
+
+      const table = screen.getByRole("table");
+
+      const labelledbyId = table.getAttribute("aria-labelledby");
+      assert(labelledbyId);
+      expect(document.getElementById(labelledbyId)).toHaveTextContent(
+        "Container Title",
+      );
+
+      const describedbyId = table.getAttribute("aria-describedby");
+      assert(describedbyId);
+      expect(document.getElementById(describedbyId)).toHaveTextContent(
+        "Container Desc",
+      );
     });
 
     it("should handle size variants", () => {


### PR DESCRIPTION
The title/description render right next to the table but were never
programmatically associated with it, so a screen reader user entering
the table (or scanning a page's tables) heard no name.

Table.svelte gets two new internal props, labelledBy/describedBy,
that DataTable sets directly from its own title/description ids.
TableContainer sets the same ids through context for the standalone
TableContainer + Table composition, where there's no direct prop path
to an externally-supplied Table child. A consumer-supplied aria-label/
aria-labelledby/aria-describedby always wins, and standalone Table
(no container) behavior is unchanged.