### PR TITLE
fix(side-nav): close the overlay side nav on Escape

### DIFF
--- a/src/UIShell/HamburgerMenu.svelte
+++ b/src/UIShell/HamburgerMenu.svelte
@@ -27,8 +27,16 @@
   /** Obtain a reference to the HTML button element */
   export let ref = null;
 
+  import { onDestroy } from "svelte";
   import Close from "../icons/Close.svelte";
   import Menu from "../icons/Menu.svelte";
+  import { hamburgerMenuRef } from "./nav-store.js";
+
+  $: hamburgerMenuRef.set(ref);
+
+  onDestroy(() => {
+    hamburgerMenuRef.update((current) => (current === ref ? null : current));
+  });
 </script>
 
 <button

--- a/src/UIShell/SideNav.svelte
+++ b/src/UIShell/SideNav.svelte
@@ -47,12 +47,21 @@
     acquireBodyScrollLock,
     releaseBodyScrollLock,
   } from "../utils/bodyScrollLock.js";
+  import { dismiss } from "../utils/dismiss.js";
   import {
+    hamburgerMenuRef,
     isSideNavCollapsed,
     isSideNavMobile,
     isSideNavRail,
     shouldRenderHamburgerMenu,
   } from "./nav-store";
+
+  function handleEscape(event) {
+    if (isOpen && !fixed && $isSideNavMobile && event.key === "Escape") {
+      isOpen = false;
+      $hamburgerMenuRef?.focus();
+    }
+  }
 
   const dispatch = createEventDispatcher();
 
@@ -117,6 +126,11 @@
   ></div>
 {/if}
 <nav
+  use:dismiss={{
+    enabled: isOpen && !fixed && $isSideNavMobile,
+    type: "keydown",
+    handler: handleEscape,
+  }}
   aria-hidden={!isOpen}
   aria-label={ariaLabel}
   class:bx--side-nav__navigation={true}

--- a/src/UIShell/nav-store.js
+++ b/src/UIShell/nav-store.js
@@ -4,3 +4,10 @@ export const shouldRenderHamburgerMenu = writable(false);
 export const isSideNavCollapsed = writable(false);
 export const isSideNavRail = writable(false);
 export const isSideNavMobile = writable(false);
+
+/**
+ * The most recently mounted `HamburgerMenu` trigger button, so `SideNav` can
+ * return focus to it when the overlay closes via Escape.
+ * @type {import("svelte/store").Writable<HTMLButtonElement | null>}
+ */
+export const hamburgerMenuRef = writable(null);

--- a/tests/UIShell/UIShell.test.ts
+++ b/tests/UIShell/UIShell.test.ts
@@ -411,6 +411,63 @@ describe("UIShell", () => {
       );
     });
 
+    describe("Escape key (overlay mode)", () => {
+      const setViewportWidth = (width: number) => {
+        Object.defineProperty(window, "innerWidth", {
+          writable: true,
+          configurable: true,
+          value: width,
+        });
+        window.dispatchEvent(new Event("resize"));
+      };
+
+      afterEach(() => {
+        setViewportWidth(1024);
+      });
+
+      it("closes the overlay side nav and refocuses the hamburger trigger", async () => {
+        setViewportWidth(500); // Mobile viewport
+
+        const { component } = render(UiShell, {
+          props: { sideNavIsOpen: true },
+        });
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        const hamburgerButton = screen.getByRole("button", { name: /menu/i });
+
+        await user.keyboard("{Escape}");
+
+        expect(component.sideNavIsOpen).toBe(false);
+        expect(hamburgerButton).toHaveFocus();
+      });
+
+      it("does not close on Escape when fixed", async () => {
+        setViewportWidth(500); // Mobile viewport
+
+        const { component } = render(UiShell, {
+          props: { sideNavIsOpen: true, sideNavFixed: true },
+        });
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        await user.keyboard("{Escape}");
+
+        expect(component.sideNavIsOpen).toBe(true);
+      });
+
+      it("does not close on Escape on desktop viewport", async () => {
+        setViewportWidth(1200); // Desktop viewport
+
+        const { component } = render(UiShell, {
+          props: { sideNavIsOpen: true },
+        });
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        await user.keyboard("{Escape}");
+
+        expect(component.sideNavIsOpen).toBe(true);
+      });
+    });
+
     describe("body scroll lock", () => {
       const setViewportWidth = (width: number) => {
         Object.defineProperty(window, "innerWidth", {


### PR DESCRIPTION
In overlay mode (mobile, over a scrim), keyboard users could only
close the side nav by tabbing back to the hamburger button and
re-activating it — Escape did nothing. Adds a scoped window keydown
listener (same use:dismiss pattern as the rest of UIShell) that closes
the nav and returns focus to the hamburger trigger, tracked via a new
nav-store ref since HamburgerMenu and SideNav aren't otherwise linked.