### PR TITLE
fix(skeleton): hide skeleton placeholders from assistive tech

### DIFF
--- a/src/SkeletonPlaceholder/SkeletonPlaceholder.svelte
+++ b/src/SkeletonPlaceholder/SkeletonPlaceholder.svelte
@@ -35,6 +35,7 @@
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <!-- svelte-ignore a11y-no-static-element-interactions -->
 <div
+  aria-hidden="true"
   class:bx--skeleton__placeholder={true}
   style:width={resolvedWidth}
   style:height={resolvedHeight}

--- a/src/SkeletonText/SkeletonText.svelte
+++ b/src/SkeletonText/SkeletonText.svelte
@@ -20,7 +20,14 @@
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
 {#if paragraph}
   <!-- svelte-ignore a11y-no-static-element-interactions -->
-  <div {...$$restProps} on:click on:mouseover on:mouseenter on:mouseleave>
+  <div
+    aria-hidden="true"
+    {...$$restProps}
+    on:click
+    on:mouseover
+    on:mouseenter
+    on:mouseleave
+  >
     {#each Array.from({ length: lines }).map((_, i) => {
       const min = widthPx ? widthNum - 75 : 0;
       const max = widthPx ? widthNum : 75;
@@ -38,6 +45,7 @@
 {:else}
   <!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
   <p
+    aria-hidden="true"
     class:bx--skeleton__text={true}
     class:bx--skeleton__heading={heading}
     style:width

--- a/tests/SkeletonPlaceholder/SkeletonPlaceholder.test.ts
+++ b/tests/SkeletonPlaceholder/SkeletonPlaceholder.test.ts
@@ -47,6 +47,13 @@ describe("SkeletonPlaceholder", () => {
     expectInlineStyle(element, { width: "10rem", height: "8rem" });
   });
 
+  it("should hide the placeholder from assistive technology", () => {
+    render(SkeletonPlaceholder);
+
+    const element = screen.getByTestId("skeleton-placeholder");
+    expect(element).toHaveAttribute("aria-hidden", "true");
+  });
+
   it("should handle mouse events", async () => {
     const consoleLog = vi.spyOn(console, "log");
     render(SkeletonPlaceholder);

--- a/tests/SkeletonText/SkeletonText.test.ts
+++ b/tests/SkeletonText/SkeletonText.test.ts
@@ -5,21 +5,21 @@ import SkeletonText from "./SkeletonText.test.svelte";
 describe("SkeletonText", () => {
   it("should render with default props", () => {
     render(SkeletonText);
-    const element = screen.getByRole("paragraph");
+    const element = screen.getByRole("paragraph", { hidden: true });
     expect(element).toHaveClass("bx--skeleton__text");
     expect(element).toHaveStyle({ width: "100%" });
   });
 
   it("should render heading variant", () => {
     render(SkeletonText, { props: { heading: true } });
-    const element = screen.getByRole("paragraph");
+    const element = screen.getByRole("paragraph", { hidden: true });
     expect(element).toHaveClass("bx--skeleton__text", "bx--skeleton__heading");
   });
 
   it("should render paragraph variant with default lines", () => {
     render(SkeletonText, { props: { paragraph: true } });
 
-    const elements = screen.getAllByRole("paragraph");
+    const elements = screen.getAllByRole("paragraph", { hidden: true });
     expect(elements).toHaveLength(3); // default lines is 3
     for (const element of elements) {
       expect(element).toHaveClass("bx--skeleton__text");
@@ -29,21 +29,21 @@ describe("SkeletonText", () => {
   it("should render paragraph with custom line count", () => {
     render(SkeletonText, { props: { paragraph: true, lines: 8 } });
 
-    const elements = screen.getAllByRole("paragraph");
+    const elements = screen.getAllByRole("paragraph", { hidden: true });
     expect(elements).toHaveLength(8);
   });
 
   it("should render with custom width", () => {
     render(SkeletonText, { props: { width: "50%" } });
 
-    const element = screen.getByRole("paragraph");
+    const element = screen.getByRole("paragraph", { hidden: true });
     expect(element).toHaveStyle({ width: "50%" });
   });
 
   it("should render paragraph with pixel width", () => {
     render(SkeletonText, { props: { paragraph: true, width: "200px" } });
 
-    const elements = screen.getAllByRole("paragraph");
+    const elements = screen.getAllByRole("paragraph", { hidden: true });
     for (const element of elements) {
       const width = element.style.width;
       expect(width).toMatch(/^\d+px$/);
@@ -53,11 +53,26 @@ describe("SkeletonText", () => {
     }
   });
 
+  it("should hide text lines from assistive technology", () => {
+    render(SkeletonText);
+
+    const element = screen.getByRole("paragraph", { hidden: true });
+    expect(element).toHaveAttribute("aria-hidden", "true");
+  });
+
+  it("should hide the paragraph variant container from assistive technology", () => {
+    render(SkeletonText, { props: { paragraph: true } });
+
+    const container = screen.getAllByRole("paragraph", { hidden: true })[0]
+      .parentElement;
+    expect(container).toHaveAttribute("aria-hidden", "true");
+  });
+
   it("should handle mouse events", async () => {
     const consoleLog = vi.spyOn(console, "log");
     render(SkeletonText);
 
-    const element = screen.getByRole("paragraph");
+    const element = screen.getByRole("paragraph", { hidden: true });
 
     await user.click(element);
     expect(consoleLog).toHaveBeenCalledWith("click");
@@ -73,7 +88,8 @@ describe("SkeletonText", () => {
     const consoleLog = vi.spyOn(console, "log");
     render(SkeletonText, { props: { paragraph: true } });
 
-    const container = screen.getAllByRole("paragraph")[0].parentElement;
+    const container = screen.getAllByRole("paragraph", { hidden: true })[0]
+      .parentElement;
     assert(container);
     await user.click(container);
     expect(consoleLog).toHaveBeenCalledWith("click");


### PR DESCRIPTION
Skeleton divs/paragraphs sat in the accessibility tree, so a screen
reader user could land on meaningless loading placeholders. Adds
aria-hidden="true" to SkeletonPlaceholder and SkeletonText's roots
(before restProps so a consumer can still override it). SkeletonIcon
gets this for free since it composes SkeletonPlaceholder.

Scoped to these two shared primitives per the audit; other
`*Skeleton.svelte` files with their own markup are a follow-up.