### PR TITLE
fix(composed-modal): name the scrolling content region

### DIFF
--- a/src/ComposedModal/ComposedModal.svelte
+++ b/src/ComposedModal/ComposedModal.svelte
@@ -54,6 +54,12 @@
   const title = writable(undefined);
   const focusReturn = restoreFocus();
 
+  // Ids for ModalHeader's label/title headings, so ModalBody (when
+  // `hasScrollingContent`) can name its region via `aria-labelledby`.
+  const modalId = `ccs-${Math.random().toString(36)}`;
+  const labelId = `${modalId}-label`;
+  const titleId = `${modalId}-title`;
+
   let buttonRef = null;
   let innerModal = null;
   let closeDispatched = false;
@@ -115,6 +121,10 @@
     declareRef,
     updateLabel,
     updateTitle,
+    labelId,
+    titleId,
+    label,
+    title,
   });
 
   function focus(element) {

--- a/src/ComposedModal/ModalBody.svelte
+++ b/src/ComposedModal/ModalBody.svelte
@@ -4,12 +4,31 @@
 
   /** Set to `true` if the modal contains scrolling content */
   export let hasScrollingContent = false;
+
+  import { getContext } from "svelte";
+  import { writable } from "svelte/store";
+
+  const composedModalCtx = getContext("carbon:ComposedModal");
+  const modalLabel = composedModalCtx?.label ?? writable(undefined);
+  const modalTitle = composedModalCtx?.title ?? writable(undefined);
+
+  // Name the region with ModalHeader's label/title heading when the
+  // consumer hasn't already supplied their own aria-label/aria-labelledby.
+  $: regionLabelledby =
+    !$$restProps["aria-label"] && !$$restProps["aria-labelledby"]
+      ? $modalLabel
+        ? composedModalCtx.labelId
+        : $modalTitle
+          ? composedModalCtx.titleId
+          : undefined
+      : undefined;
 </script>
 
 <!-- svelte-ignore a11y-no-noninteractive-tabindex -->
 <div
   tabindex={hasScrollingContent ? "0" : undefined}
   role={hasScrollingContent ? "region" : undefined}
+  aria-labelledby={hasScrollingContent ? regionLabelledby : undefined}
   class:bx--modal-content={true}
   class:bx--modal-content--with-form={hasForm}
   class:bx--modal-scroll-content={hasScrollingContent}

--- a/src/ComposedModal/ModalHeader.svelte
+++ b/src/ComposedModal/ModalHeader.svelte
@@ -29,7 +29,7 @@
   import { getContext } from "svelte";
   import Close from "../icons/Close.svelte";
 
-  const { closeModal, updateLabel, updateTitle } = getContext(
+  const { closeModal, updateLabel, updateTitle, labelId, titleId } = getContext(
     "carbon:ComposedModal",
   );
 
@@ -40,6 +40,7 @@
 <div class:bx--modal-header={true} {...$$restProps}>
   {#if label}
     <h2
+      id={labelId}
       class:bx--modal-header__label={true}
       class:bx--type-delta={true}
       class={labelClass}
@@ -49,6 +50,7 @@
   {/if}
   {#if title}
     <h3
+      id={titleId}
       class:bx--modal-header__heading={true}
       class:bx--type-beta={true}
       class={titleClass}

--- a/tests/ComposedModal/ModalBody.test.ts
+++ b/tests/ComposedModal/ModalBody.test.ts
@@ -41,6 +41,50 @@ describe("ModalBody", () => {
     expect(modalBody).toHaveAttribute("tabindex", "0");
   });
 
+  it("should name the region with the modal heading", () => {
+    render(ModalBodyTest, {
+      props: {
+        hasScrollingContent: true,
+        slotContent: "Scrolling content",
+      },
+    });
+
+    const modalBody = screen.getByRole("region");
+    const labelledbyId = modalBody.getAttribute("aria-labelledby");
+    assert(labelledbyId);
+    expect(document.getElementById(labelledbyId)).toHaveTextContent(
+      "Test Modal",
+    );
+  });
+
+  it("should not set aria-labelledby when a consumer supplies aria-label", () => {
+    render(ModalBodyTest, {
+      props: {
+        hasScrollingContent: true,
+        slotContent: "Scrolling content",
+        "aria-label": "Custom region name",
+      },
+    });
+
+    const modalBody = screen.getByRole("region", {
+      name: "Custom region name",
+    });
+    expect(modalBody).not.toHaveAttribute("aria-labelledby");
+  });
+
+  it("should not set aria-labelledby when hasScrollingContent is false", () => {
+    render(ModalBodyTest, {
+      props: {
+        hasScrollingContent: false,
+        slotContent: "Content",
+      },
+    });
+
+    const content = screen.getByText("Content");
+    const modalBody = content.closest(".bx--modal-content");
+    expect(modalBody).not.toHaveAttribute("aria-labelledby");
+  });
+
   it("should render overflow indicator when hasScrollingContent is true", () => {
     render(ModalBodyTest, {
       props: {


### PR DESCRIPTION
With hasScrollingContent, ModalBody gets role="region" and
tabindex="0" -- a focusable, nameless landmark. Screen readers
announce an anonymous "region" and axe flags it.

ComposedModal now generates ids for ModalHeader's label/title
headings and shares them through context; ModalBody wires
aria-labelledby to whichever one is present (label wins over title,
matching the same precedence the dialog's own aria-label already
uses). A consumer-supplied aria-label/aria-labelledby always wins.