### PR TITLE
fix(profile-menu): align aria-haspopup with the panel's actual semantics

### DIFF
--- a/src/UIShell/ProfileMenu.svelte
+++ b/src/UIShell/ProfileMenu.svelte
@@ -77,7 +77,7 @@
     ],
   }}
   type="button"
-  aria-haspopup="menu"
+  aria-haspopup="true"
   aria-expanded={isOpen}
   aria-label={iconDescription}
   class:bx--header__action={true}
@@ -97,6 +97,7 @@
 {#if isOpen}
   <div
     bind:this={refMenu}
+    aria-label={iconDescription}
     class:bx--profile-menu={true}
     transition:slide|local={{
       ...transition,

--- a/tests/UIShell/ProfileMenu.test.ts
+++ b/tests/UIShell/ProfileMenu.test.ts
@@ -12,6 +12,22 @@ describe("ProfileMenu", () => {
     expect(screen.queryByText("Settings")).not.toBeInTheDocument();
   });
 
+  it("promises a generic popup, not a menu", () => {
+    render(ProfileMenu);
+
+    expect(getTrigger()).toHaveAttribute("aria-haspopup", "true");
+  });
+
+  it("names the panel from the trigger's iconDescription", async () => {
+    render(ProfileMenu);
+
+    await user.click(getTrigger());
+
+    expect(
+      screen.getByText("Settings").closest(".bx--profile-menu"),
+    ).toHaveAttribute("aria-label", "Profile");
+  });
+
   it("renders a default UserAvatar when no avatar slot is provided", async () => {
     render(ProfileMenu);
 


### PR DESCRIPTION
aria-haspopup="menu" told screen readers to expect arrow-key menu
interaction, but the panel that opens is a disclosure of links, not
an ARIA menu -- adding role="menu"/menuitem would be the wrong fix
for navigation links. This corrects the promise instead: generic
aria-haspopup="true", plus an accessible name on the panel from the
trigger's iconDescription.