### PR TITLE
fix(hamburger-menu): set aria-expanded on the menu toggle

### DIFF
--- a/src/UIShell/HamburgerMenu.svelte
+++ b/src/UIShell/HamburgerMenu.svelte
@@ -36,6 +36,7 @@
   type="button"
   title={ariaLabel}
   aria-label={ariaLabel}
+  aria-expanded={isOpen}
   class:bx--header__action={true}
   class:bx--header__menu-trigger={true}
   class:bx--header__menu-toggle={true}

--- a/tests/UIShell/UIShell.test.ts
+++ b/tests/UIShell/UIShell.test.ts
@@ -155,6 +155,27 @@ describe("UIShell", () => {
       expect(hamburgerButton).toHaveAttribute("title", "Close menu");
     });
 
+    it("should toggle aria-expanded on the hamburger menu button", async () => {
+      const { container } = render(UiShell, {
+        props: {
+          persistentHamburgerMenu: true,
+          isSideNavOpen: false,
+        },
+      });
+
+      const hamburgerButton = container.querySelector(
+        ".bx--header__menu-trigger",
+      );
+      assert(hamburgerButton);
+      expect(hamburgerButton).toHaveAttribute("aria-expanded", "false");
+
+      await user.click(hamburgerButton);
+      expect(hamburgerButton).toHaveAttribute("aria-expanded", "true");
+
+      await user.click(hamburgerButton);
+      expect(hamburgerButton).toHaveAttribute("aria-expanded", "false");
+    });
+
     describe("user interaction preservation", () => {
       const setViewportWidth = (width: number) => {
         Object.defineProperty(window, "innerWidth", {


### PR DESCRIPTION
The button toggles the side nav but exposed no state; the aria-label
text swap ("Open menu" / "Close menu") isn't announced as a state
change the way aria-expanded is.