### PR TITLE
fix(data-table)!: stop clobbering the bound selectable prop

### DIFF
--- a/src/DataTable/DataTable.svelte
+++ b/src/DataTable/DataTable.svelte
@@ -220,18 +220,23 @@
    */
   export let nonExpandableRowIds = [];
 
-  /** Set to `true` for the radio selection variant */
+  /**
+   * Set to `true` for the radio selection variant.
+   * Row selection is enabled regardless of `selectable`.
+   */
   export let radio = false;
 
   /**
    * Set to `true` for the selectable variant.
-   * Automatically set to `true` if `radio` or `batchSelection` are `true`.
    * Shift-clicking a row checkbox extends selection to every row between it and the last row clicked (not supported with `radio`).
    * @bindable writable
    */
   export let selectable = false;
 
-  /** Set to `true` to enable batch selection */
+  /**
+   * Set to `true` to enable batch selection.
+   * Row selection is enabled regardless of `selectable`.
+   */
   export let batchSelection = false;
 
   /**
@@ -589,7 +594,7 @@
     expandable = true;
     expanded = expandedRowIds.length === expandableRowIds.length;
   }
-  $: if (radio || batchSelection) selectable = true;
+  $: isSelectionEnabled = selectable || radio || batchSelection;
 
   let tableCellsByRowId = {};
   let prevRows;
@@ -806,7 +811,7 @@
 
   // Calculate total columns for spacer rows and expanded row cells
   $: totalColumns =
-    (expandable ? 1 : 0) + (selectable ? 1 : 0) + visibleHeaders.length;
+    (expandable ? 1 : 0) + (isSelectionEnabled ? 1 : 0) + visibleHeaders.length;
 </script>
 
 <TableContainer {useStaticWidth} {...$$restProps}>
@@ -901,7 +906,7 @@
               {/if}
             </th>
           {/if}
-          {#if selectable && !batchSelection}
+          {#if isSelectionEnabled && !batchSelection}
             <th scope="col">
               <span class:bx--visually-hidden={true}>Select row</span>
             </th>
@@ -1105,7 +1110,7 @@
                   {/if}
                 </TableCell>
               {/if}
-              {#if selectable}
+              {#if isSelectionEnabled}
                 <td
                   class:bx--table-column-checkbox={true}
                   class:bx--table-column-radio={radio}
@@ -1336,7 +1341,7 @@
                   {/if}
                 </TableCell>
               {/if}
-              {#if selectable}
+              {#if isSelectionEnabled}
                 <td
                   class:bx--table-column-checkbox={true}
                   class:bx--table-column-radio={radio}
@@ -1468,7 +1473,7 @@
             {#if expandable}
               <td aria-hidden="true" class:bx--table-expand={true}></td>
             {/if}
-            {#if selectable}
+            {#if isSelectionEnabled}
               <td
                 aria-hidden="true"
                 class:bx--table-column-checkbox={true}

--- a/tests/DataTable/DataTableBatchSelectionSelectableBind.test.svelte
+++ b/tests/DataTable/DataTableBatchSelectionSelectableBind.test.svelte
@@ -1,0 +1,17 @@
+<svelte:options accessors />
+
+<script lang="ts">
+  import DataTable from "carbon-components-svelte/DataTable/DataTable.svelte";
+
+  export let selectable = false;
+  export let batchSelection = false;
+
+  const headers = [{ key: "name", value: "Name" }] as const;
+
+  const rows = [
+    { id: "a", name: "Load Balancer 1" },
+    { id: "b", name: "Load Balancer 2" },
+  ];
+</script>
+
+<DataTable {headers} {rows} bind:selectable {batchSelection} />

--- a/tests/DataTable/DataTableBatchSelectionSelectableBind.test.ts
+++ b/tests/DataTable/DataTableBatchSelectionSelectableBind.test.ts
@@ -1,0 +1,20 @@
+import { render, screen } from "@testing-library/svelte";
+import { tick } from "svelte";
+import DataTableBatchSelectionSelectableBind from "./DataTableBatchSelectionSelectableBind.test.svelte";
+
+// Regression test: `batchSelection` used to write `selectable = true` back
+// into the exported prop, clobbering a consumer's `bind:selectable`.
+describe("DataTable batchSelection does not clobber bound selectable", () => {
+  it("keeps a bound selectable false while still rendering selection checkboxes", async () => {
+    const { component } = render(DataTableBatchSelectionSelectableBind, {
+      props: { selectable: false, batchSelection: true },
+    });
+
+    await tick();
+
+    expect(component.selectable).toBe(false);
+    expect(
+      screen.getByRole("checkbox", { name: "Select all rows" }),
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
\`radio\` and \`batchSelection\` used to force-write \`selectable = true\`
back into the exported prop, so a consumer's \`bind:selectable\` got
silently overwritten. This derives an internal flag instead and
leaves \`selectable\` as a pure input the consumer controls.