### PR TITLE
feat(button)!: align size scale with Carbon React

### DIFF
--- a/css/_button-size.scss
+++ b/css/_button-size.scss
@@ -1,0 +1,39 @@
+// `Button`'s v10 size classes are offset one step from Carbon React's v11
+// scale (`xs | sm | md | lg | xl | 2xl`, 24/32/40/48/64/80px): v10's
+// unclassed base already lands on 48px (v11 `lg`), and v10's own `--lg`/
+// `--xl` classes are 64/80px (v11 `xl`/`2xl`). `sm`/`md` already have exact
+// v10 aliases (`--sm`, `--field`/`--md`). Only the 24px (`xs`) and 48px
+// (`lg`) steps have no v10 class of their own, so this partial adds them.
+//
+// Loaded after Carbon's base styles (see all.scss).
+
+@import "carbon-components/scss/globals/scss/vars";
+@import "carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/import-once/import-once";
+
+/// New v11 `xs`/`lg` Button size steps.
+/// @access private
+/// @group components
+@mixin button-size {
+  // Extra-small (Carbon React size="xs", 24px). No v10 class lands on 24px.
+  .#{$prefix}--btn--xs {
+    min-height: to-rem(24px);
+    padding-top: 0;
+    padding-bottom: 0;
+  }
+
+  .#{$prefix}--btn--xs.#{$prefix}--btn--icon-only {
+    padding-right: to-rem(4px);
+    padding-left: to-rem(4px);
+  }
+
+  // Large (Carbon React size="lg", 48px). Matches v10's unclassed base
+  // exactly; this class exists so `size="lg"` leaves an explicit, greppable
+  // marker instead of relying on the absence of any size class.
+  .#{$prefix}--btn--lg-48 {
+    min-height: to-rem(48px);
+  }
+}
+
+@include exports("button-size") {
+  @include button-size;
+}

--- a/css/_combo-button.scss
+++ b/css/_combo-button.scss
@@ -29,20 +29,6 @@
   .#{$prefix}--combo-button__trigger--open .#{$prefix}--btn__icon {
     transform: rotate(180deg);
   }
-
-  // Extra-small (Carbon React size="xs", 24px). Neither Button's "small"
-  // class (32px) nor any other Button size lands on 24px, so shrink further
-  // on top of the "small" size already passed to both buttons.
-  .#{$prefix}--combo-button--xs .#{$prefix}--btn {
-    min-height: to-rem(24px);
-    padding-top: 0;
-    padding-bottom: 0;
-  }
-
-  .#{$prefix}--combo-button--xs .#{$prefix}--btn--icon-only {
-    padding-right: to-rem(4px);
-    padding-left: to-rem(4px);
-  }
 }
 
 @include exports("combo-button") {

--- a/css/_menu-button.scss
+++ b/css/_menu-button.scss
@@ -15,15 +15,6 @@
     transform: rotate(180deg);
   }
 
-  // Extra-small (Carbon React size="xs", 24px). Neither Button's "small"
-  // class (32px) nor any other Button size lands on 24px, so shrink further
-  // on top of the "small" size already passed to the trigger.
-  .#{$prefix}--menu-button__trigger--xs {
-    min-height: to-rem(24px);
-    padding-top: 0;
-    padding-bottom: 0;
-  }
-
   /// Icon-only MenuButton uses Menu (box-shadow) with an overflow-style
   /// trigger. OverflowMenu hides the seam with a ::after bridge on the
   /// options list; Menu has no equivalent, so the menu shadow paints onto

--- a/css/all.scss
+++ b/css/all.scss
@@ -108,6 +108,7 @@ $css--plex: true;
 @import "./datepicker";
 @import "./fluid-date-picker";
 @import "./time-picker";
+@import "./button-size";
 @import "./copy-button-portal";
 @import "./copy-button";
 @import "./copy-input";

--- a/css/g10.scss
+++ b/css/g10.scss
@@ -68,6 +68,7 @@ $css--plex: true;
 @import "./datepicker";
 @import "./fluid-date-picker";
 @import "./time-picker";
+@import "./button-size";
 @import "./copy-button-portal";
 @import "./copy-button";
 @import "./copy-input";

--- a/css/g100.scss
+++ b/css/g100.scss
@@ -68,6 +68,7 @@ $css--plex: true;
 @import "./datepicker";
 @import "./fluid-date-picker";
 @import "./time-picker";
+@import "./button-size";
 @import "./copy-button-portal";
 @import "./copy-button";
 @import "./copy-input";

--- a/css/g80.scss
+++ b/css/g80.scss
@@ -68,6 +68,7 @@ $css--plex: true;
 @import "./datepicker";
 @import "./fluid-date-picker";
 @import "./time-picker";
+@import "./button-size";
 @import "./copy-button-portal";
 @import "./copy-button";
 @import "./copy-input";

--- a/css/g90.scss
+++ b/css/g90.scss
@@ -68,6 +68,7 @@ $css--plex: true;
 @import "./datepicker";
 @import "./fluid-date-picker";
 @import "./time-picker";
+@import "./button-size";
 @import "./copy-button-portal";
 @import "./copy-button";
 @import "./copy-input";

--- a/css/white.scss
+++ b/css/white.scss
@@ -68,6 +68,7 @@ $css--plex: true;
 @import "./datepicker";
 @import "./fluid-date-picker";
 @import "./time-picker";
+@import "./button-size";
 @import "./copy-button-portal";
 @import "./copy-button";
 @import "./copy-input";

--- a/docs/src/pages/components/Button.svx
+++ b/docs/src/pages/components/Button.svx
@@ -149,31 +149,37 @@ To render a different element, set `as` to `true` and spread `let:props` to the 
 
 ## Sizes
 
-Set the `size` prop. The default is medium.
+Set the `size` prop to one of `"xs"`, `"sm"`, `"md"`, `"lg"`, `"xl"`, or `"2xl"`, matching
+Carbon React's size scale (24px, 32px, 40px, 48px, 64px, 80px). The default is `"lg"` (48px).
 
-### Field
+`"default"`, `"field"`, and `"small"` remain as deprecated aliases for `"lg"`, `"md"`, and
+`"sm"` for backward compatibility.
 
-Set `size="field"` for field-sized buttons that align with form input heights.
+### Extra-small
 
-<Button size="field">Primary</Button>
-<Button size="field" kind="secondary">Secondary</Button>
-<Button size="field" kind="tertiary">Tertiary</Button>
-<Button size="field" kind="ghost">Ghost</Button>
-<Button size="field" kind="danger">Danger</Button>
+<Button size="xs">Primary</Button>
+<Button size="xs" kind="secondary">Secondary</Button>
+<Button size="xs" kind="tertiary">Tertiary</Button>
+<Button size="xs" kind="ghost">Ghost</Button>
+<Button size="xs" kind="danger">Danger</Button>
 
 ### Small
 
-Set `size="small"` for small buttons.
+<Button size="sm">Primary</Button>
+<Button size="sm" kind="secondary">Secondary</Button>
+<Button size="sm" kind="tertiary">Tertiary</Button>
+<Button size="sm" kind="ghost">Ghost</Button>
+<Button size="sm" kind="danger">Danger</Button>
 
-<Button size="small">Primary</Button>
-<Button size="small" kind="secondary">Secondary</Button>
-<Button size="small" kind="tertiary">Tertiary</Button>
-<Button size="small" kind="ghost">Ghost</Button>
-<Button size="small" kind="danger">Danger</Button>
+### Medium
+
+<Button size="md">Primary</Button>
+<Button size="md" kind="secondary">Secondary</Button>
+<Button size="md" kind="tertiary">Tertiary</Button>
+<Button size="md" kind="ghost">Ghost</Button>
+<Button size="md" kind="danger">Danger</Button>
 
 ### Large
-
-Set `size="lg"` for large buttons.
 
 <Button size="lg">Primary</Button>
 <Button size="lg" kind="secondary">Secondary</Button>
@@ -183,13 +189,19 @@ Set `size="lg"` for large buttons.
 
 ### Extra-large
 
-Set `size="xl"` for extra-large buttons.
-
 <Button size="xl">Primary</Button>
 <Button size="xl" kind="secondary">Secondary</Button>
 <Button size="xl" kind="tertiary">Tertiary</Button>
 <Button size="xl" kind="ghost">Ghost</Button>
 <Button size="xl" kind="danger">Danger</Button>
+
+### 2x Extra-large
+
+<Button size="2xl">Primary</Button>
+<Button size="2xl" kind="secondary">Secondary</Button>
+<Button size="2xl" kind="tertiary">Tertiary</Button>
+<Button size="2xl" kind="ghost">Ghost</Button>
+<Button size="2xl" kind="danger">Danger</Button>
 
 ## Disabled
 
@@ -200,19 +212,19 @@ Set `disabled` to disable the button.
 
 ## Expressive styles
 
-Set `expressive` to `true` to use Carbon's expressive typesetting. Use expressive styles with the default, "lg", or "xl" button sizes.
+Set `expressive` to `true` to use Carbon's expressive typesetting. Use expressive styles with the default, "xl", or "2xl" button sizes.
 
+<Button expressive size="2xl">Primary</Button>
+<Button expressive size="2xl" kind="secondary">Secondary</Button>
+<Button expressive size="2xl" kind="tertiary">Tertiary</Button>
+<Button expressive size="2xl" kind="ghost">Ghost</Button>
+<Button expressive size="2xl" kind="danger">Danger</Button>
+<br /><br />
 <Button expressive size="xl">Primary</Button>
 <Button expressive size="xl" kind="secondary">Secondary</Button>
 <Button expressive size="xl" kind="tertiary">Tertiary</Button>
 <Button expressive size="xl" kind="ghost">Ghost</Button>
 <Button expressive size="xl" kind="danger">Danger</Button>
-<br /><br />
-<Button expressive size="lg">Primary</Button>
-<Button expressive size="lg" kind="secondary">Secondary</Button>
-<Button expressive size="lg" kind="tertiary">Tertiary</Button>
-<Button expressive size="lg" kind="ghost">Ghost</Button>
-<Button expressive size="lg" kind="danger">Danger</Button>
 <br /><br />
 <Button expressive>Primary</Button>
 <Button expressive kind="secondary">Secondary</Button>
@@ -224,11 +236,12 @@ Set `expressive` to `true` to use Carbon's expressive typesetting. Use expressiv
 
 Set `skeleton` to show a loading state.
 
+<Button size="2xl" skeleton />
 <Button size="xl" skeleton />
-<Button size="lg" skeleton />
 <Button skeleton />
-<Button skeleton size="field" />
-<Button skeleton size="small" />
+<Button skeleton size="md" />
+<Button skeleton size="sm" />
+<Button skeleton size="xs" />
 
 ## Programmatic focus
 

--- a/src/Button/Button.svelte
+++ b/src/Button/Button.svelte
@@ -20,7 +20,9 @@
   /**
    * Specify the size of button.
    * When the `badge` slot is used, size is set to `lg` per Carbon design guidelines.
-   * @type {"default" | "field" | "small" | "lg" | "xl"}
+   * `"default"`, `"field"`, and `"small"` are deprecated aliases for `"lg"`, `"md"`, and `"sm"`
+   * kept for backward compatibility.
+   * @type {"xs" | "sm" | "md" | "lg" | "xl" | "2xl" | "default" | "field" | "small"}
    */
   export let size = "default";
 
@@ -313,10 +315,12 @@
     class: [
       "bx--btn",
       expressive && "bx--btn--expressive",
-      effectiveSize === "small" && "bx--btn--sm",
-      effectiveSize === "field" && "bx--btn--field",
-      effectiveSize === "lg" && "bx--btn--lg",
-      effectiveSize === "xl" && "bx--btn--xl",
+      effectiveSize === "xs" && "bx--btn--xs",
+      (effectiveSize === "small" || effectiveSize === "sm") && "bx--btn--sm",
+      (effectiveSize === "field" || effectiveSize === "md") && "bx--btn--field",
+      effectiveSize === "lg" && "bx--btn--lg-48",
+      effectiveSize === "xl" && "bx--btn--lg",
+      effectiveSize === "2xl" && "bx--btn--xl",
       kind && `bx--btn--${kind}`,
       isDisabled && "bx--btn--disabled",
       hasIconOnly && "bx--btn--icon-only",

--- a/src/Button/ButtonSkeleton.svelte
+++ b/src/Button/ButtonSkeleton.svelte
@@ -7,9 +7,18 @@
 
   /**
    * Specify the size of button skeleton.
-   * @type {"default" | "field" | "small" | "lg" | "xl"}
+   * `"default"`, `"field"`, and `"small"` are deprecated aliases for `"lg"`, `"md"`, and `"sm"`
+   * kept for backward compatibility.
+   * @type {"xs" | "sm" | "md" | "lg" | "xl" | "2xl" | "default" | "field" | "small"}
    */
   export let size = "default";
+
+  $: isXs = size === "xs";
+  $: isSm = size === "small" || size === "sm";
+  $: isMd = size === "field" || size === "md";
+  $: isLg = size === "lg";
+  $: isXl = size === "xl";
+  $: is2xl = size === "2xl";
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
@@ -20,10 +29,12 @@
     role="button"
     class:bx--skeleton={true}
     class:bx--btn={true}
-    class:bx--btn--field={size === "field"}
-    class:bx--btn--sm={size === "small"}
-    class:bx--btn--lg={size === "lg"}
-    class:bx--btn--xl={size === "xl"}
+    class:bx--btn--xs={isXs}
+    class:bx--btn--sm={isSm}
+    class:bx--btn--field={isMd}
+    class:bx--btn--lg-48={isLg}
+    class:bx--btn--lg={isXl}
+    class:bx--btn--xl={is2xl}
     {...$$restProps}
     on:click
     on:focus
@@ -39,10 +50,12 @@
   <div
     class:bx--skeleton={true}
     class:bx--btn={true}
-    class:bx--btn--field={size === "field"}
-    class:bx--btn--sm={size === "small"}
-    class:bx--btn--lg={size === "lg"}
-    class:bx--btn--xl={size === "xl"}
+    class:bx--btn--xs={isXs}
+    class:bx--btn--sm={isSm}
+    class:bx--btn--field={isMd}
+    class:bx--btn--lg-48={isLg}
+    class:bx--btn--lg={isXl}
+    class:bx--btn--xl={is2xl}
     {...$$restProps}
     on:click
     on:focus

--- a/src/ComboButton/ComboButton.svelte
+++ b/src/ComboButton/ComboButton.svelte
@@ -90,20 +90,6 @@
 
   const dispatch = createEventDispatcher();
 
-  /**
-   * Button's own "default"/"lg" naming is offset from the v11 size scale:
-   * unclassed "default" renders at 48px (v11 "lg"), while Button's "lg"
-   * class renders at 64px with baseline-aligned text (v11's "xl"/"2xl"
-   * tier). Remap so ComboButton never touches Button's "lg"/"xl" classes.
-   * "xs" has no Button equivalent; combo-button.scss shrinks it further.
-   */
-  const TRIGGER_BUTTON_SIZES = {
-    xs: "small",
-    sm: "small",
-    md: "field",
-    lg: "default",
-  };
-
   let triggerRef = null;
 
   /**
@@ -130,15 +116,10 @@
   }
 </script>
 
-<div
-  bind:this={ref}
-  class:bx--combo-button={true}
-  class:bx--combo-button--xs={size === "xs"}
-  {...$$restProps}
->
+<div bind:this={ref} class:bx--combo-button={true} {...$$restProps}>
   <Button
     kind="primary"
-    size={TRIGGER_BUTTON_SIZES[size]}
+    {size}
     {disabled}
     class="bx--combo-button__primary-action"
     aria-label={$$restProps["aria-label"] ?? labelText}
@@ -157,7 +138,7 @@
     icon={ChevronDown}
     {iconDescription}
     kind="primary"
-    size={TRIGGER_BUTTON_SIZES[size]}
+    {size}
     {disabled}
     hideTooltip={open}
     {tooltipPosition}

--- a/src/FileUploader/FileUploaderButton.svelte
+++ b/src/FileUploader/FileUploaderButton.svelte
@@ -144,10 +144,12 @@
   class:bx--btn--danger={kind === "danger"}
   class:bx--btn--danger-tertiary={kind === "danger-tertiary"}
   class:bx--btn--danger-ghost={kind === "danger-ghost"}
-  class:bx--btn--sm={size === "small"}
-  class:bx--btn--field={size === "field"}
-  class:bx--btn--lg={size === "lg"}
-  class:bx--btn--xl={size === "xl"}
+  class:bx--btn--xs={size === "xs"}
+  class:bx--btn--sm={size === "small" || size === "sm"}
+  class:bx--btn--field={size === "field" || size === "md"}
+  class:bx--btn--lg-48={size === "lg"}
+  class:bx--btn--lg={size === "xl"}
+  class:bx--btn--xl={size === "2xl"}
   class:bx--btn--icon-only={hasIconOnly}
   class:bx--tooltip__trigger={hasIconOnly && !hideTooltip}
   class:bx--tooltip--a11y={hasIconOnly && !hideTooltip}

--- a/src/MenuButton/MenuButton.svelte
+++ b/src/MenuButton/MenuButton.svelte
@@ -99,20 +99,6 @@
   import Menu from "../Menu/Menu.svelte";
 
   /**
-   * Button's own "default"/"lg" naming is offset from the v11 size scale:
-   * unclassed "default" renders at 48px (v11 "lg"), while Button's "lg"
-   * class renders at 64px with baseline-aligned text (v11's "xl"/"2xl"
-   * tier). Remap so MenuButton never touches Button's "lg"/"xl" classes.
-   * "xs" has no Button equivalent; menu-button.scss shrinks it further.
-   */
-  const TRIGGER_BUTTON_SIZES = {
-    xs: "small",
-    sm: "small",
-    md: "field",
-    lg: "default",
-  };
-
-  /**
    * The overflow menu scale is offset from MenuButton's: its unclassed
    * default is 40px ("md" here) and its largest, "xl", is 48px ("lg" here).
    */
@@ -125,7 +111,6 @@
 
   $: triggerClass = [
     "bx--menu-button__trigger",
-    size === "xs" && "bx--menu-button__trigger--xs",
     open && "bx--menu-button__trigger--open",
     $$restProps.class,
   ]
@@ -186,7 +171,7 @@
   <Button
     bind:ref
     {kind}
-    size={TRIGGER_BUTTON_SIZES[size]}
+    {size}
     {disabled}
     icon={ChevronDown}
     {...$$restProps}

--- a/tests/Button/Button.test.svelte
+++ b/tests/Button/Button.test.svelte
@@ -12,8 +12,16 @@
 <Button kind="danger-tertiary">danger-tertiary</Button>
 <Button kind="danger-ghost">danger-ghost</Button>
 
+<!-- Deprecated size aliases, kept for backward compatibility -->
 <Button size="field">field size</Button>
 <Button size="small">small size</Button>
+
+<Button size="xs">xs size</Button>
+<Button size="sm">sm size</Button>
+<Button size="md">md size</Button>
+<Button size="lg">lg size</Button>
+<Button size="xl">xl size</Button>
+<Button size="2xl">2xl size</Button>
 
 <Button
   icon={Add}

--- a/tests/Button/Button.test.ts
+++ b/tests/Button/Button.test.ts
@@ -47,6 +47,23 @@ describe("Button", () => {
     }
   });
 
+  it("aligns the size scale with Carbon React's v11 xs/sm/md/lg/xl/2xl steps", () => {
+    render(Button);
+
+    const sizes = {
+      "xs size": "bx--btn--xs",
+      "sm size": "bx--btn--sm",
+      "md size": "bx--btn--field",
+      "lg size": "bx--btn--lg-48",
+      "xl size": "bx--btn--lg",
+      "2xl size": "bx--btn--xl",
+    };
+
+    for (const [text, className] of Object.entries(sizes)) {
+      expect(screen.getByText(text).closest("button")).toHaveClass(className);
+    }
+  });
+
   it("should render icon-only button with tooltip", () => {
     render(Button);
 
@@ -361,7 +378,7 @@ describe("Button", () => {
     expect(
       container.querySelector(".bx--btn__badge-wrapper"),
     ).toBeInTheDocument();
-    expect(button).toHaveClass("bx--btn--lg");
+    expect(button).toHaveClass("bx--btn--lg-48");
     expect(badge).not.toHaveClass("bx--badge-indicator--count");
     expect(badge?.textContent?.trim()).toBe("");
   });
@@ -392,7 +409,7 @@ describe("Button", () => {
     const container = screen.getByTestId("badge-size-override");
     const button = container.querySelector("button");
 
-    expect(button).toHaveClass("bx--btn--lg");
+    expect(button).toHaveClass("bx--btn--lg-48");
     expect(button).not.toHaveClass("bx--btn--sm");
   });
 

--- a/tests/Button/ButtonSkeleton.test.svelte
+++ b/tests/Button/ButtonSkeleton.test.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+  import ButtonSkeleton from "carbon-components-svelte/Button/ButtonSkeleton.svelte";
+</script>
+
+<ButtonSkeleton data-testid="default" />
+<ButtonSkeleton data-testid="xs" size="xs" />
+<ButtonSkeleton data-testid="sm" size="sm" />
+<ButtonSkeleton data-testid="md" size="md" />
+<ButtonSkeleton data-testid="lg" size="lg" />
+<ButtonSkeleton data-testid="xl" size="xl" />
+<ButtonSkeleton data-testid="2xl" size="2xl" />
+<ButtonSkeleton data-testid="href-lg" href="#" size="lg" />

--- a/tests/Button/ButtonSkeleton.test.ts
+++ b/tests/Button/ButtonSkeleton.test.ts
@@ -1,0 +1,45 @@
+import { render, screen } from "@testing-library/svelte";
+import ButtonSkeleton from "./ButtonSkeleton.test.svelte";
+
+describe("ButtonSkeleton", () => {
+  it("aligns the size scale with Carbon React's v11 xs/sm/md/lg/xl/2xl steps", () => {
+    render(ButtonSkeleton);
+
+    const sizes = {
+      xs: "bx--btn--xs",
+      sm: "bx--btn--sm",
+      md: "bx--btn--field",
+      lg: "bx--btn--lg-48",
+      xl: "bx--btn--lg",
+      "2xl": "bx--btn--xl",
+    };
+
+    for (const [testId, className] of Object.entries(sizes)) {
+      expect(screen.getByTestId(testId)).toHaveClass(className);
+    }
+  });
+
+  it("renders the default size with no size modifier class", () => {
+    render(ButtonSkeleton);
+
+    const button = screen.getByTestId("default");
+    for (const className of [
+      "bx--btn--xs",
+      "bx--btn--sm",
+      "bx--btn--field",
+      "bx--btn--lg-48",
+      "bx--btn--lg",
+      "bx--btn--xl",
+    ]) {
+      expect(button).not.toHaveClass(className);
+    }
+  });
+
+  it("renders an anchor when href is set", () => {
+    render(ButtonSkeleton);
+
+    const link = screen.getByTestId("href-lg");
+    expect(link.tagName).toBe("A");
+    expect(link).toHaveClass("bx--btn--lg-48");
+  });
+});

--- a/tests/ComboButton/ComboButton.test.ts
+++ b/tests/ComboButton/ComboButton.test.ts
@@ -108,10 +108,10 @@ describe("ComboButton", () => {
   });
 
   it.each([
-    { size: "xs", buttonClass: "bx--btn--sm", menuClass: "bx--menu--xs" },
+    { size: "xs", buttonClass: "bx--btn--xs", menuClass: "bx--menu--xs" },
     { size: "sm", buttonClass: "bx--btn--sm", menuClass: undefined },
     { size: "md", buttonClass: "bx--btn--field", menuClass: "bx--menu--md" },
-    { size: "lg", buttonClass: undefined, menuClass: "bx--menu--lg" },
+    { size: "lg", buttonClass: "bx--btn--lg-48", menuClass: "bx--menu--lg" },
   ] as const)(
     "propagates size $size to both buttons and the menu row height",
     async ({ size, buttonClass, menuClass }) => {
@@ -123,8 +123,10 @@ describe("ComboButton", () => {
       });
 
       for (const unwanted of [
+        "bx--btn--xs",
         "bx--btn--sm",
         "bx--btn--field",
+        "bx--btn--lg-48",
         "bx--btn--lg",
         "bx--btn--xl",
       ]) {
@@ -148,15 +150,18 @@ describe("ComboButton", () => {
     },
   );
 
-  it("keeps both buttons the same height at every size (no Button `lg`/`xl` baseline misalignment)", () => {
+  it("keeps both buttons at the 48px `lg` step, never Button's old 64px `lg` class", () => {
     render(ComboButtonFixture, { props: { size: "lg" } });
 
     const primaryAction = screen.getByRole("button", { name: "Save" });
     const trigger = screen.getByRole("button", { name: "Additional actions" });
 
-    // Button's own "lg"/"xl" classes render at 64px/80px for labeled buttons
-    // but are ignored for icon-only buttons, and apply baseline (not center)
-    // alignment - ComboButton must never reach for them.
+    // Button's size scale aligns with Carbon React's v11 scale: "lg" is the
+    // 48px step (`bx--btn--lg-48`), not the v10-named `bx--btn--lg` (64px,
+    // Carbon React's "xl"), which also applies baseline (not center)
+    // alignment - ComboButton must never reach for it.
+    expect(primaryAction).toHaveClass("bx--btn--lg-48");
+    expect(trigger).toHaveClass("bx--btn--lg-48");
     expect(primaryAction).not.toHaveClass("bx--btn--lg");
     expect(trigger).not.toHaveClass("bx--btn--lg");
   });

--- a/tests/FileUploader/FileUploaderButton.test.ts
+++ b/tests/FileUploader/FileUploaderButton.test.ts
@@ -324,8 +324,11 @@ describe("FileUploaderButton", () => {
     expect(button2).toHaveClass("bx--btn--field");
     expect(button3).not.toHaveClass("bx--btn--sm");
     expect(button3).not.toHaveClass("bx--btn--field");
-    expect(button4).toHaveClass("bx--btn--lg");
-    expect(button5).toHaveClass("bx--btn--xl");
+    // Button's size scale aligns with Carbon React's v11 scale: "lg" is the
+    // 48px step, and Button's old 64px `bx--btn--lg` class is now reached
+    // via "xl".
+    expect(button4).toHaveClass("bx--btn--lg-48");
+    expect(button5).toHaveClass("bx--btn--lg");
   });
 
   it("should handle name attribute", () => {

--- a/tests/MenuButton/MenuButton.test.ts
+++ b/tests/MenuButton/MenuButton.test.ts
@@ -44,10 +44,10 @@ describe("MenuButton", () => {
   });
 
   it.each([
-    { size: "xs", buttonClass: "bx--btn--sm", menuClass: "bx--menu--xs" },
+    { size: "xs", buttonClass: "bx--btn--xs", menuClass: "bx--menu--xs" },
     { size: "sm", buttonClass: "bx--btn--sm", menuClass: undefined },
     { size: "md", buttonClass: "bx--btn--field", menuClass: "bx--menu--md" },
-    { size: "lg", buttonClass: undefined, menuClass: "bx--menu--lg" },
+    { size: "lg", buttonClass: "bx--btn--lg-48", menuClass: "bx--menu--lg" },
   ] as const)(
     "propagates size $size to the trigger and the menu row height",
     async ({ size, buttonClass, menuClass }) => {
@@ -56,8 +56,10 @@ describe("MenuButton", () => {
       const trigger = screen.getByRole("button", { name: "Actions" });
 
       for (const unwanted of [
+        "bx--btn--xs",
         "bx--btn--sm",
         "bx--btn--field",
+        "bx--btn--lg-48",
         "bx--btn--lg",
         "bx--btn--xl",
       ]) {
@@ -75,12 +77,12 @@ describe("MenuButton", () => {
     },
   );
 
-  it("keeps the trigger off Button's baseline-aligned `lg`/`xl` classes", () => {
+  it("keeps the trigger off Button's old, baseline-aligned 64px `lg` class", () => {
     render(MenuButtonFixture, { props: { size: "lg" } });
 
-    expect(screen.getByRole("button", { name: "Actions" })).not.toHaveClass(
-      "bx--btn--lg",
-    );
+    const trigger = screen.getByRole("button", { name: "Actions" });
+    expect(trigger).toHaveClass("bx--btn--lg-48");
+    expect(trigger).not.toHaveClass("bx--btn--lg");
   });
 
   it("rotates the trigger's chevron by toggling the open modifier class", async () => {

--- a/tests/UIShell/HeaderGlobalAction.test.ts
+++ b/tests/UIShell/HeaderGlobalAction.test.ts
@@ -23,7 +23,7 @@ describe("HeaderGlobalAction", () => {
     expect(
       container.querySelector(".bx--btn__badge-wrapper"),
     ).toBeInTheDocument();
-    expect(button).toHaveClass("bx--btn--lg");
+    expect(button).toHaveClass("bx--btn--lg-48");
     expect(badge).not.toHaveClass("bx--badge-indicator--count");
     expect(badge?.textContent?.trim()).toBe("");
   });


### PR DESCRIPTION
Button's `lg`/`xl` sizes rendered one step larger than Carbon React's;
v10's own SCSS marks the mismatch as a v11 rename. `size` now takes
the full `xs | sm | md | lg | xl | 2xl` scale (24/32/40/48/64/80px),
with `default`/`field`/`small` kept as deprecated aliases.