### PR TITLE
fix(context-menu-option)!: stop clobbering the icon and indented props

### DIFF
--- a/src/ContextMenu/ContextMenuOption.svelte
+++ b/src/ContextMenu/ContextMenuOption.svelte
@@ -18,6 +18,7 @@
 
   /**
    * Set to `true` to indent the label.
+   * Rendered indented regardless when `icon` is set, or when the option is selectable or part of a radio group.
    * @bindable writable
    */
   export let indented = false;
@@ -25,6 +26,7 @@
   /**
    * Specify the icon to render.
    * Icon is rendered to the left of the label text.
+   * Overridden with a checkmark icon when the option is selectable or part of a radio group.
    * @type {Icon}
    * @bindable writable
    */
@@ -268,36 +270,25 @@
 
     submenuPosition = [x, y];
   }
-  $: {
-    if (icon) {
-      indented = true;
-    }
+  $: resolvedIcon =
+    isSelectable || isRadio ? (selected ? Checkmark : undefined) : icon;
+  $: isIndented = indented || icon !== undefined || isSelectable || isRadio;
 
+  $: {
     let nextRole = "menuitem";
     if (isSelectable) nextRole = "menuitemcheckbox";
     if (isRadio) nextRole = "menuitemradio";
     role = nextRole;
 
-    if (isSelectable) {
-      indented = true;
-
-      if (selected) {
-        if (ctxGroup) ctxGroup.addOption({ id });
-        icon = Checkmark;
-      } else {
-        icon = undefined;
-      }
+    if (isSelectable && selected && ctxGroup) {
+      ctxGroup.addOption({ id });
     }
 
     if (isRadio) {
-      indented = true;
       ctxRadioGroup.addOption({ id });
 
-      if (selected) {
-        if (ctxRadioGroup) ctxRadioGroup.setOption({ id });
-        icon = Checkmark;
-      } else {
-        icon = undefined;
+      if (selected && ctxRadioGroup) {
+        ctxRadioGroup.setOption({ id });
       }
     }
   }
@@ -320,7 +311,7 @@
   class:bx--menu-option--disabled={disabled}
   class:bx--menu-option--active={subOptions && submenuOpen}
   class:bx--menu-option--danger={!subOptions && kind === "danger"}
-  {indented}
+  indented={isIndented}
   aria-checked={isSelectable || isRadio ? selected : undefined}
   data-nested={ref &&
     ref.closest(".bx--menu").getAttribute("data-level") === "2"}
@@ -413,9 +404,9 @@
       class:bx--menu-option__content={true}
       class:bx--menu-option__content--disabled={disabled}
     >
-      {#if indented}
+      {#if isIndented}
         <div class:bx--menu-option__icon={true}>
-          <slot name="icon"> <svelte:component this={icon} /> </slot>
+          <slot name="icon"> <svelte:component this={resolvedIcon} /> </slot>
         </div>
       {/if}
       <span class:bx--menu-option__label={true} title={labelText}>
@@ -437,9 +428,9 @@
       class:bx--menu-option__content={true}
       class:bx--menu-option__content--disabled={disabled}
     >
-      {#if indented}
+      {#if isIndented}
         <div class:bx--menu-option__icon={true}>
-          <slot name="icon"> <svelte:component this={icon} /> </slot>
+          <slot name="icon"> <svelte:component this={resolvedIcon} /> </slot>
         </div>
       {/if}
       <span class:bx--menu-option__label={true} title={labelText}>

--- a/src/ContextMenu/ContextMenuOption.svelte
+++ b/src/ContextMenu/ContextMenuOption.svelte
@@ -19,7 +19,6 @@
   /**
    * Set to `true` to indent the label.
    * Rendered indented regardless when `icon` is set, or when the option is selectable or part of a radio group.
-   * @bindable writable
    */
   export let indented = false;
 
@@ -28,7 +27,6 @@
    * Icon is rendered to the left of the label text.
    * Overridden with a checkmark icon when the option is selectable or part of a radio group.
    * @type {Icon}
-   * @bindable writable
    */
   export let icon = /** @type {Icon} */ (undefined);
 

--- a/tests/ContextMenu/ContextMenuOptionSelectableIconBind.test.svelte
+++ b/tests/ContextMenu/ContextMenuOptionSelectableIconBind.test.svelte
@@ -1,0 +1,22 @@
+<svelte:options accessors />
+
+<script lang="ts">
+  import ContextMenu from "carbon-components-svelte/ContextMenu/ContextMenu.svelte";
+  import ContextMenuGroup from "carbon-components-svelte/ContextMenu/ContextMenuGroup.svelte";
+  import ContextMenuOption from "carbon-components-svelte/ContextMenu/ContextMenuOption.svelte";
+  import CopyFile from "carbon-icons-svelte/lib/CopyFile.svelte";
+
+  export let icon = CopyFile;
+  export let indented = false;
+</script>
+
+<ContextMenu open={true} x={100} y={100}>
+  <ContextMenuGroup labelText="Test group">
+    <ContextMenuOption
+      id="option1"
+      labelText="Option 1"
+      bind:icon
+      bind:indented
+    />
+  </ContextMenuGroup>
+</ContextMenu>

--- a/tests/ContextMenu/ContextMenuOptionSelectableIconBind.test.ts
+++ b/tests/ContextMenu/ContextMenuOptionSelectableIconBind.test.ts
@@ -1,0 +1,23 @@
+import { render, screen } from "@testing-library/svelte";
+import CopyFile from "carbon-icons-svelte/lib/CopyFile.svelte";
+import { tick } from "svelte";
+import ContextMenuOptionSelectableIconBind from "./ContextMenuOptionSelectableIconBind.test.svelte";
+
+// Regression test: a selectable/radio ContextMenuOption used to write
+// `icon = Checkmark` / `indented = true` back into the exported props,
+// clobbering a consumer's `bind:icon` / `bind:indented`.
+describe("ContextMenuOption does not clobber bound icon and indented props in a selectable group", () => {
+  it("keeps the consumer's bound icon and indented unchanged while rendering the checkmark", async () => {
+    const { component } = render(ContextMenuOptionSelectableIconBind, {
+      props: { indented: false },
+    });
+
+    await tick();
+
+    expect(component.icon).toBe(CopyFile);
+    expect(component.indented).toBe(false);
+
+    const option = screen.getByRole("menuitemcheckbox", { name: "Option 1" });
+    expect(option.querySelector(".bx--menu-option__icon")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Selectable and radio-group options used to force-write \`icon = Checkmark\`
and \`indented = true\` back into their exported props, so a consumer's
\`bind:icon\` / \`bind:indented\` got silently overwritten. This derives
the checkmark and indentation internally instead and leaves both props
as pure inputs the consumer controls.