### PR TITLE
docs(link): fix disabled prop description

### DIFF
--- a/src/Link/Link.svelte
+++ b/src/Link/Link.svelte
@@ -25,7 +25,7 @@
    */
   export let icon = /** @type {Icon} */ (undefined);
 
-  /** Set to `true` to disable the checkbox */
+  /** Set to `true` to disable the link */
   export let disabled = false;
 
   /** Set to `true` to allow visited styles */


### PR DESCRIPTION
The JSDoc described \`disabled\` as controlling a checkbox, a
copy-paste leftover from a form input. This corrects it to describe
the link.