### PR TITLE
docs(inline-loading,clickable-tile): fix stale prop descriptions

### DIFF
--- a/src/InlineLoading/InlineLoading.svelte
+++ b/src/InlineLoading/InlineLoading.svelte
@@ -18,7 +18,7 @@
    */
   export let iconDescription = undefined;
 
-  /** Specify the timeout delay (ms) after `status` is set to "success" */
+  /** Specify the timeout delay (ms) before the `success` event fires after `status` is set to "finished" */
   export let successDelay = 1500;
 
   import { createEventDispatcher, onMount } from "svelte";

--- a/src/Tile/ClickableTile.svelte
+++ b/src/Tile/ClickableTile.svelte
@@ -2,7 +2,8 @@
   /** @restProps {a | p} */
 
   /**
-   * Set to `true` to click the tile.
+   * Whether the tile has been clicked.
+   * Toggles on click and on Space/Enter.
    * @bindable readonly
    */
   export let clicked = false;


### PR DESCRIPTION
\`InlineLoading.successDelay\` referenced a "success" status that
doesn't exist; the real trigger is \`status\` set to "finished", after
which the \`success\` event fires. \`ClickableTile.clicked\` told
consumers to set it to click the tile, contradicting its
\`@bindable readonly\` tag since the component actually owns and
toggles the value.