### PR TITLE
feat(checkbox): add invalid and warn states

### DIFF
--- a/css/_checkbox-validation.scss
+++ b/css/_checkbox-validation.scss
@@ -1,0 +1,119 @@
+// Checkbox/CheckboxGroup `invalid`/`warn` states. v10 ships none of this
+// (`grep` for `checkbox…--invalid` under carbon-components' checkbox SCSS
+// returns nothing) - ported from Carbon React's real @carbon/styles
+// `_checkbox.scss`, translated to this repo's `to-rem()`/`$carbon--spacing-*`
+// conventions. `$icon-primary`, `$support-error`, `$support-warning`, and
+// `$text-error` are v11 token names that the v10 theme mixin already
+// globally aliases to their v10 equivalents (`$icon-01`, `$support-01`,
+// `$support-03`, `$text-error`), so they resolve correctly under this
+// repo's v10 pin.
+//
+// Loaded after Carbon's base styles (see all.scss), so these selectors are
+// deliberately more specific than v10's own `.bx--checkbox-label::before`
+// and `.bx--form-requirement` rules and win regardless of load order.
+
+@import "carbon-components/scss/globals/scss/vars";
+@import "carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/import-once/import-once";
+
+/// Checkbox/CheckboxGroup invalid and warning states.
+/// @access private
+/// @group components
+@mixin checkbox-validation {
+  .#{$prefix}--checkbox-group[data-invalid] .#{$prefix}--checkbox-label::before,
+  .#{$prefix}--checkbox-wrapper--invalid .#{$prefix}--checkbox-label::before,
+  .#{$prefix}--checkbox-wrapper--invalid
+    .#{$prefix}--checkbox:checked
+    + .#{$prefix}--checkbox-label::before {
+    border: 1px solid $support-error;
+  }
+
+  // A checkbox individually marked invalid inside a group defers to the
+  // group's own state: its message is hidden, and its border resets to
+  // normal unless the group itself is also invalid.
+  .#{$prefix}--checkbox-group
+    .#{$prefix}--checkbox-wrapper--invalid
+    > .#{$prefix}--checkbox__validation-msg,
+  .#{$prefix}--checkbox-group
+    .#{$prefix}--checkbox-wrapper--warning
+    > .#{$prefix}--checkbox__validation-msg,
+  .#{$prefix}--checkbox-group
+    .#{$prefix}--checkbox-wrapper
+    > .#{$prefix}--form__helper-text {
+    display: none;
+  }
+
+  .#{$prefix}--checkbox-group:not(.#{$prefix}--checkbox-group[data-invalid])
+    .#{$prefix}--checkbox-wrapper--invalid
+    .#{$prefix}--checkbox-label::before,
+  .#{$prefix}--checkbox-group:not(.#{$prefix}--checkbox-group[data-invalid])
+    .#{$prefix}--checkbox-wrapper--invalid
+    .#{$prefix}--checkbox:checked
+    + .#{$prefix}--checkbox-label::before {
+    border: 1px solid $icon-primary;
+  }
+
+  .#{$prefix}--checkbox-group__validation-msg,
+  .#{$prefix}--checkbox__validation-msg {
+    display: none;
+    align-items: flex-start;
+    inline-size: 100%;
+    margin-block-start: $carbon--spacing-02;
+  }
+
+  .#{$prefix}--checkbox__invalid-icon {
+    margin: to-rem(1px) to-rem(1px) 0 to-rem(3px);
+    fill: $support-error;
+    min-inline-size: to-rem(16px);
+  }
+
+  .#{$prefix}--checkbox__invalid-icon--warning {
+    fill: $support-warning;
+  }
+
+  .#{$prefix}--checkbox__invalid-icon--warning path:first-of-type {
+    fill: #000000;
+  }
+
+  .#{$prefix}--checkbox-group--invalid
+    .#{$prefix}--checkbox-group__validation-msg,
+  .#{$prefix}--checkbox-group--warning
+    .#{$prefix}--checkbox-group__validation-msg,
+  .#{$prefix}--checkbox-wrapper--invalid
+    > .#{$prefix}--checkbox__validation-msg,
+  .#{$prefix}--checkbox-wrapper--warning
+    > .#{$prefix}--checkbox__validation-msg {
+    display: flex;
+  }
+
+  .#{$prefix}--checkbox-group--invalid
+    .#{$prefix}--checkbox-group__validation-msg
+    .#{$prefix}--form-requirement,
+  .#{$prefix}--checkbox-group--warning
+    .#{$prefix}--checkbox-group__validation-msg
+    .#{$prefix}--form-requirement,
+  .#{$prefix}--checkbox-wrapper--invalid
+    .#{$prefix}--checkbox__validation-msg
+    .#{$prefix}--form-requirement,
+  .#{$prefix}--checkbox-wrapper--warning
+    .#{$prefix}--checkbox__validation-msg
+    .#{$prefix}--form-requirement {
+    display: block;
+    overflow: visible;
+    margin-block-start: 0;
+    margin-inline-start: $carbon--spacing-03;
+    max-block-size: 100%;
+  }
+
+  .#{$prefix}--checkbox-group--invalid
+    .#{$prefix}--checkbox-group__validation-msg
+    .#{$prefix}--form-requirement,
+  .#{$prefix}--checkbox-wrapper--invalid
+    .#{$prefix}--checkbox__validation-msg
+    .#{$prefix}--form-requirement {
+    color: $text-error;
+  }
+}
+
+@include exports("checkbox-validation") {
+  @include checkbox-validation;
+}

--- a/css/all.scss
+++ b/css/all.scss
@@ -22,6 +22,7 @@ $css--plex: true;
 @import "carbon-components/src/components/notification/toast-notification";
 @import "./popover";
 @import "./checkbox-readonly";
+@import "./checkbox-validation";
 @import "./combobox-readonly";
 @import "./dropdown-readonly";
 @import "./multiselect-readonly";

--- a/css/g10.scss
+++ b/css/g10.scss
@@ -23,6 +23,7 @@ $css--plex: true;
 @import "carbon-components/src/components/notification/toast-notification";
 @import "./popover";
 @import "./checkbox-readonly";
+@import "./checkbox-validation";
 @import "./combobox-readonly";
 @import "./dropdown-readonly";
 @import "./multiselect-readonly";

--- a/css/g100.scss
+++ b/css/g100.scss
@@ -23,6 +23,7 @@ $css--plex: true;
 @import "carbon-components/src/components/notification/toast-notification";
 @import "./popover";
 @import "./checkbox-readonly";
+@import "./checkbox-validation";
 @import "./combobox-readonly";
 @import "./dropdown-readonly";
 @import "./multiselect-readonly";

--- a/css/g80.scss
+++ b/css/g80.scss
@@ -23,6 +23,7 @@ $css--plex: true;
 @import "carbon-components/src/components/notification/toast-notification";
 @import "./popover";
 @import "./checkbox-readonly";
+@import "./checkbox-validation";
 @import "./combobox-readonly";
 @import "./dropdown-readonly";
 @import "./multiselect-readonly";

--- a/css/g90.scss
+++ b/css/g90.scss
@@ -23,6 +23,7 @@ $css--plex: true;
 @import "carbon-components/src/components/notification/toast-notification";
 @import "./popover";
 @import "./checkbox-readonly";
+@import "./checkbox-validation";
 @import "./combobox-readonly";
 @import "./dropdown-readonly";
 @import "./multiselect-readonly";

--- a/css/white.scss
+++ b/css/white.scss
@@ -23,6 +23,7 @@ $css--plex: true;
 @import "carbon-components/src/components/notification/toast-notification";
 @import "./popover";
 @import "./checkbox-readonly";
+@import "./checkbox-validation";
 @import "./combobox-readonly";
 @import "./dropdown-readonly";
 @import "./multiselect-readonly";

--- a/docs/src/pages/components/Checkbox.svx
+++ b/docs/src/pages/components/Checkbox.svx
@@ -55,6 +55,18 @@ Set `readonly` to `true` to make the checkbox non-interactive while keeping the 
 <Checkbox labelText="Label text (unchecked)" readonly />
 <Checkbox labelText="Label text (checked)" checked readonly />
 
+### Invalid
+
+Set `invalid` to `true` and provide `invalidText` to show a validation error.
+
+<Checkbox labelText="I agree to the terms and conditions" invalid invalidText="You must agree to the terms and conditions to continue" />
+
+### Warning
+
+Set `warn` to `true` and provide `warnText` to show a warning message. `invalid` takes precedence over `warn` when both are set.
+
+<Checkbox labelText="Subscribe to promotional emails" warn warnText="You may receive fewer updates about your account" />
+
 ## Reactive
 
 Bind to track and update the checkbox state.
@@ -148,6 +160,26 @@ Disable all checkboxes in the group.
 Set `readonly` to `true` on CheckboxGroup to display non-editable values. Unlike disabled, the readonly state keeps labels readable. You can also set readonly on individual checkboxes when needed.
 
 <CheckboxGroup readonly legendText="Notification preferences" name="prefs-readonly" selected={["email", "push"]}>
+<Checkbox value="email" labelText="Email" />
+<Checkbox value="sms" labelText="SMS" />
+<Checkbox value="push" labelText="Push notifications" />
+</CheckboxGroup>
+
+### Invalid
+
+Set `invalid` to `true` and provide `invalidText` to show a validation error for the group. The group's state takes precedence over any invalid/warn state set on an individual checkbox.
+
+<CheckboxGroup invalid invalidText="Select at least one notification preference" legendText="Notification preferences" name="prefs-invalid">
+<Checkbox value="email" labelText="Email" />
+<Checkbox value="sms" labelText="SMS" />
+<Checkbox value="push" labelText="Push notifications" />
+</CheckboxGroup>
+
+### Warning
+
+Set `warn` to `true` and provide `warnText` to show a warning message for the group.
+
+<CheckboxGroup warn warnText="Push notifications may be delayed" legendText="Notification preferences" name="prefs-warn" selected={["email"]}>
 <Checkbox value="email" labelText="Email" />
 <Checkbox value="sms" labelText="SMS" />
 <Checkbox value="push" labelText="Push notifications" />

--- a/src/Checkbox/Checkbox.svelte
+++ b/src/Checkbox/Checkbox.svelte
@@ -51,6 +51,18 @@
   /** Specify the helper text */
   export let helperText = "";
 
+  /** Set to `true` to indicate an invalid state */
+  export let invalid = false;
+
+  /** Specify the invalid state text */
+  export let invalidText = "";
+
+  /** Set to `true` to indicate a warning state */
+  export let warn = false;
+
+  /** Specify the warning state text */
+  export let warnText = "";
+
   /** Set a name for the input element */
   export let name = "";
 
@@ -88,6 +100,8 @@
 
   import { createEventDispatcher, getContext } from "svelte";
   import { readable } from "svelte/store";
+  import WarningAltFilled from "../icons/WarningAltFilled.svelte";
+  import WarningFilled from "../icons/WarningFilled.svelte";
   import { overflowTitle } from "../utils/overflowTitle.js";
   import CheckboxSkeleton from "./CheckboxSkeleton.svelte";
 
@@ -115,6 +129,8 @@
   $: effectiveName = ctx ? ($groupName ?? name) : name;
   $: effectiveRequired = ctx ? ($groupRequired ?? required) : required;
   $: effectiveReadonly = $groupReadonly || readonly;
+  $: showInvalid = invalid && !disabled && !effectiveReadonly;
+  $: showWarn = warn && !invalid && !disabled && !effectiveReadonly;
 
   // Track previous checked value to avoid duplicate dispatches in Svelte 5
   // The reactive statement will only dispatch when checked changes externally (e.g., via bind:checked)
@@ -130,6 +146,8 @@
   let refLabel = null;
 
   $: helperId = `helper-${id}`;
+  $: errorId = `error-${id}`;
+  $: warnId = `warn-${id}`;
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
@@ -147,6 +165,8 @@
     class:bx--form-item={true}
     class:bx--checkbox-wrapper={true}
     class:bx--checkbox-wrapper--readonly={effectiveReadonly}
+    class:bx--checkbox-wrapper--invalid={showInvalid}
+    class:bx--checkbox-wrapper--warning={showWarn}
     {...$$restProps}
     on:click
     on:mouseover
@@ -166,7 +186,15 @@
       name={effectiveName}
       required={effectiveRequired}
       aria-readonly={effectiveReadonly || undefined}
-      aria-describedby={helperText ? helperId : undefined}
+      aria-invalid={showInvalid || undefined}
+      data-invalid={showInvalid || undefined}
+      aria-describedby={showInvalid
+        ? errorId
+        : showWarn
+          ? warnId
+          : helperText
+            ? helperId
+            : undefined}
       class:bx--checkbox={true}
       on:click={(event) => {
         if (effectiveReadonly) {
@@ -209,7 +237,18 @@
         <slot name="labelChildren"> {labelText} </slot>
       </span>
     </label>
-    {#if helperText}
+    <div class:bx--checkbox__validation-msg={true}>
+      {#if showInvalid}
+        <WarningFilled class="bx--checkbox__invalid-icon" />
+        <div id={errorId} class:bx--form-requirement={true}>{invalidText}</div>
+      {:else if showWarn}
+        <WarningAltFilled
+          class="bx--checkbox__invalid-icon bx--checkbox__invalid-icon--warning"
+        />
+        <div id={warnId} class:bx--form-requirement={true}>{warnText}</div>
+      {/if}
+    </div>
+    {#if helperText && !showInvalid && !showWarn}
       <div
         id={helperId}
         class:bx--form__helper-text={true}

--- a/src/Checkbox/CheckboxGroup.svelte
+++ b/src/Checkbox/CheckboxGroup.svelte
@@ -45,6 +45,18 @@
   /** Specify the helper text */
   export let helperText = "";
 
+  /** Set to `true` to indicate an invalid state */
+  export let invalid = false;
+
+  /** Specify the invalid state text */
+  export let invalidText = "";
+
+  /** Set to `true` to indicate a warning state */
+  export let warn = false;
+
+  /** Specify the warning state text */
+  export let warnText = "";
+
   /** Set to `true` to use the read-only variant */
   export let readonly = false;
 
@@ -56,6 +68,8 @@
 
   import { createEventDispatcher, onMount, setContext, tick } from "svelte";
   import { readonly as readOnly, writable } from "svelte/store";
+  import WarningAltFilled from "../icons/WarningAltFilled.svelte";
+  import WarningFilled from "../icons/WarningFilled.svelte";
 
   const dispatch = createEventDispatcher();
   /**
@@ -108,9 +122,15 @@
   $: $groupName = name;
   $: $groupRequired = required;
   $: $groupReadonly = readonly;
+  $: showInvalid = invalid && !disabled && !readonly;
+  $: showWarn = warn && !invalid && !disabled && !readonly;
 
   const fallbackHelperId = `ccs-${Math.random().toString(36)}`;
+  const fallbackErrorId = `ccs-${Math.random().toString(36)}`;
+  const fallbackWarnId = `ccs-${Math.random().toString(36)}`;
   $: helperId = id ? `helper-${id}` : fallbackHelperId;
+  $: errorId = id ? `error-${id}` : fallbackErrorId;
+  $: warnId = id ? `warn-${id}` : fallbackWarnId;
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
@@ -127,8 +147,17 @@
   <fieldset
     class:bx--checkbox-group={true}
     class:bx--checkbox-group--readonly={readonly}
+    class:bx--checkbox-group--invalid={showInvalid}
+    class:bx--checkbox-group--warning={showWarn}
     {disabled}
-    aria-describedby={helperText ? helperId : undefined}
+    data-invalid={showInvalid || undefined}
+    aria-describedby={showInvalid
+      ? errorId
+      : showWarn
+        ? warnId
+        : helperText
+          ? helperId
+          : undefined}
   >
     {#if legendText || $$slots.legendChildren}
       <legend class:bx--label={true} class:bx--visually-hidden={hideLegend}>
@@ -136,8 +165,19 @@
       </legend>
     {/if}
     <slot />
+    <div class:bx--checkbox-group__validation-msg={true}>
+      {#if showInvalid}
+        <WarningFilled class="bx--checkbox__invalid-icon" />
+        <div id={errorId} class:bx--form-requirement={true}>{invalidText}</div>
+      {:else if showWarn}
+        <WarningAltFilled
+          class="bx--checkbox__invalid-icon bx--checkbox__invalid-icon--warning"
+        />
+        <div id={warnId} class:bx--form-requirement={true}>{warnText}</div>
+      {/if}
+    </div>
   </fieldset>
-  {#if helperText}
+  {#if helperText && !showInvalid && !showWarn}
     <div
       id={helperId}
       class:bx--form__helper-text={true}

--- a/tests/Checkbox/Checkbox.test.ts
+++ b/tests/Checkbox/Checkbox.test.ts
@@ -8,6 +8,7 @@ import CheckboxReadonly from "./Checkbox.readonly.test.svelte";
 import CheckboxSkeleton from "./Checkbox.skeleton.test.svelte";
 import CheckboxSlot from "./Checkbox.slot.test.svelte";
 import Checkbox from "./Checkbox.test.svelte";
+import CheckboxValidation from "./Checkbox.validation.test.svelte";
 import CheckboxGroupEvents from "./CheckboxGroupEvents.test.svelte";
 import CheckboxGroupReactive from "./CheckboxGroupReactive.test.svelte";
 import CheckboxReactiveBind from "./CheckboxReactiveBind.test.svelte";
@@ -507,6 +508,82 @@ describe("Checkbox", () => {
 
     await user.click(input);
     expect(input).toBeChecked();
+  });
+
+  it("renders the invalid state with an error message and aria wiring", () => {
+    render(CheckboxValidation, { invalid: true, invalidText: "Required" });
+
+    const wrapper = screen.getByTestId("checkbox");
+    expect(wrapper).toHaveClass("bx--checkbox-wrapper--invalid");
+
+    const input = screen.getByRole("checkbox");
+    expect(input).toHaveAttribute("aria-invalid", "true");
+    expect(input).toHaveAttribute("data-invalid", "true");
+
+    const message = screen.getByText("Required");
+    expect(message).toHaveClass("bx--form-requirement");
+    expect(input).toHaveAttribute("aria-describedby", message.id);
+  });
+
+  it("renders the warning state with a warning message", () => {
+    render(CheckboxValidation, { warn: true, warnText: "Heads up" });
+
+    const wrapper = screen.getByTestId("checkbox");
+    expect(wrapper).toHaveClass("bx--checkbox-wrapper--warning");
+    expect(wrapper).not.toHaveClass("bx--checkbox-wrapper--invalid");
+
+    const input = screen.getByRole("checkbox");
+    expect(input).not.toHaveAttribute("aria-invalid");
+
+    const message = screen.getByText("Heads up");
+    expect(message).toHaveClass("bx--form-requirement");
+    expect(input).toHaveAttribute("aria-describedby", message.id);
+  });
+
+  it("prioritizes invalid over warn when both are set", () => {
+    render(CheckboxValidation, {
+      invalid: true,
+      invalidText: "Required",
+      warn: true,
+      warnText: "Heads up",
+    });
+
+    expect(screen.getByText("Required")).toBeInTheDocument();
+    expect(screen.queryByText("Heads up")).not.toBeInTheDocument();
+  });
+
+  it("suppresses invalid/warn styling when disabled or readonly", () => {
+    const { rerender } = render(CheckboxValidation, {
+      invalid: true,
+      invalidText: "Required",
+      disabled: true,
+    });
+    expect(screen.getByTestId("checkbox")).not.toHaveClass(
+      "bx--checkbox-wrapper--invalid",
+    );
+    expect(screen.queryByText("Required")).not.toBeInTheDocument();
+
+    rerender({
+      invalid: true,
+      invalidText: "Required",
+      disabled: false,
+      readonly: true,
+    });
+    expect(screen.getByTestId("checkbox")).not.toHaveClass(
+      "bx--checkbox-wrapper--invalid",
+    );
+    expect(screen.queryByText("Required")).not.toBeInTheDocument();
+  });
+
+  it("hides helper text while invalid or warn text is shown", () => {
+    render(CheckboxValidation, {
+      invalid: true,
+      invalidText: "Required",
+      helperText: "Helper text",
+    });
+
+    expect(screen.getByText("Required")).toBeInTheDocument();
+    expect(screen.queryByText("Helper text")).not.toBeInTheDocument();
   });
 
   it("should render helper text when provided", () => {

--- a/tests/Checkbox/Checkbox.validation.test.svelte
+++ b/tests/Checkbox/Checkbox.validation.test.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  import Checkbox from "carbon-components-svelte/Checkbox/Checkbox.svelte";
+
+  export let invalid = false;
+  export let invalidText = "Invalid checkbox";
+  export let warn = false;
+  export let warnText = "Warning checkbox";
+  export let disabled = false;
+  export let readonly = false;
+  export let helperText = "";
+</script>
+
+<Checkbox
+  {invalid}
+  {invalidText}
+  {warn}
+  {warnText}
+  {disabled}
+  {readonly}
+  {helperText}
+  labelText="Validation checkbox"
+  data-testid="checkbox"
+/>

--- a/tests/Checkbox/CheckboxGroupComponent.test.svelte
+++ b/tests/Checkbox/CheckboxGroupComponent.test.svelte
@@ -12,10 +12,15 @@
   export let legendText: ComponentProps<CheckboxGroup>["legendText"] = "";
   export let hideLegend: ComponentProps<CheckboxGroup>["hideLegend"] = false;
   export let helperText: ComponentProps<CheckboxGroup>["helperText"] = "";
+  export let invalid: ComponentProps<CheckboxGroup>["invalid"] = false;
+  export let invalidText: ComponentProps<CheckboxGroup>["invalidText"] = "";
+  export let warn: ComponentProps<CheckboxGroup>["warn"] = false;
+  export let warnText: ComponentProps<CheckboxGroup>["warnText"] = "";
   export let id: ComponentProps<CheckboxGroup>["id"] = undefined;
   export let readonly: ComponentProps<CheckboxGroup>["readonly"] = false;
   export let customClass = "";
   export let useSlot = false;
+  export let checkboxInvalid = false;
 </script>
 
 {#if useSlot}
@@ -27,6 +32,10 @@
     {hideLegend}
     {id}
     {helperText}
+    {invalid}
+    {invalidText}
+    {warn}
+    {warnText}
     {readonly}
     class={customClass}
     on:change={(e) => {
@@ -48,6 +57,10 @@
     {hideLegend}
     {id}
     {helperText}
+    {invalid}
+    {invalidText}
+    {warn}
+    {warnText}
     {readonly}
     class={customClass}
     on:change={(e) => {
@@ -55,7 +68,12 @@
     }}
   >
     <Checkbox value="1" labelText="Option 1" />
-    <Checkbox value="2" labelText="Option 2" />
+    <Checkbox
+      value="2"
+      labelText="Option 2"
+      invalid={checkboxInvalid}
+      invalidText="Individual error"
+    />
     <Checkbox value="3" labelText="Option 3" />
   </CheckboxGroup>
 {/if}

--- a/tests/Checkbox/CheckboxGroupComponent.test.ts
+++ b/tests/Checkbox/CheckboxGroupComponent.test.ts
@@ -229,6 +229,73 @@ describe("CheckboxGroup", () => {
     expect(fieldset).not.toHaveAttribute("aria-describedby");
   });
 
+  it("renders the invalid state on the fieldset with an error message", () => {
+    render(CheckboxGroupComponent, {
+      props: { invalid: true, invalidText: "Select at least one option" },
+    });
+
+    const fieldset = screen.getByRole("group");
+    expect(fieldset).toHaveClass("bx--checkbox-group--invalid");
+    expect(fieldset).toHaveAttribute("data-invalid", "true");
+
+    const message = screen.getByText("Select at least one option");
+    expect(message).toHaveClass("bx--form-requirement");
+    expect(fieldset).toHaveAttribute("aria-describedby", message.id);
+  });
+
+  it("renders the warning state on the fieldset with a warning message", () => {
+    render(CheckboxGroupComponent, {
+      props: { warn: true, warnText: "Heads up" },
+    });
+
+    const fieldset = screen.getByRole("group");
+    expect(fieldset).toHaveClass("bx--checkbox-group--warning");
+    expect(fieldset).not.toHaveAttribute("data-invalid");
+
+    const message = screen.getByText("Heads up");
+    expect(message).toHaveClass("bx--form-requirement");
+  });
+
+  it("prioritizes invalid over warn on the group when both are set", () => {
+    render(CheckboxGroupComponent, {
+      props: {
+        invalid: true,
+        invalidText: "Select at least one option",
+        warn: true,
+        warnText: "Heads up",
+      },
+    });
+
+    expect(screen.getByText("Select at least one option")).toBeInTheDocument();
+    expect(screen.queryByText("Heads up")).not.toBeInTheDocument();
+  });
+
+  it("hides group helper text while invalid or warn text is shown", () => {
+    render(CheckboxGroupComponent, {
+      props: {
+        invalid: true,
+        invalidText: "Select at least one option",
+        helperText: "Helper text message",
+      },
+    });
+
+    expect(screen.getByText("Select at least one option")).toBeInTheDocument();
+    expect(screen.queryByText("Helper text message")).not.toBeInTheDocument();
+  });
+
+  it("defers a checkbox's own invalid message to the group when nested", () => {
+    render(CheckboxGroupComponent, { props: { checkboxInvalid: true } });
+
+    // The individual Checkbox's own invalid text is suppressed by CSS
+    // (`display: none`) when nested in a CheckboxGroup, in favor of the
+    // group's own validation message - assert the wrapper still carries the
+    // marker class CSS keys off of, without asserting computed styles.
+    const option2 = screen.getByRole("checkbox", { name: "Option 2" });
+    expect(option2.closest(".bx--checkbox-wrapper")).toHaveClass(
+      "bx--checkbox-wrapper--invalid",
+    );
+  });
+
   it("should support multiple selections", async () => {
     const consoleLog = vi.spyOn(console, "log");
     render(CheckboxGroupComponent);


### PR DESCRIPTION
Checkbox and CheckboxGroup were the only form controls here without
`invalid`/`warn` support, and v10 ships no checkbox validation
styles at all. The new `invalid`/`invalidText`/`warn`/`warnText`
props follow Carbon React's real behavior: a checkbox's own
validation message defers to its parent CheckboxGroup's when both
carry state.

---

<img width="662" height="245" alt="Screenshot 2026-08-07 at 11 24 00 PM" src="https://github.com/user-attachments/assets/dfd88e1a-9822-40a7-aeca-cd9d5cb830e0" />
<img width="672" height="253" alt="Screenshot 2026-08-07 at 11 24 03 PM" src="https://github.com/user-attachments/assets/f5e42532-4e50-431e-9c27-6ade81a8d0d4" />
