### PR TITLE
feat(text-input): add maxCount character counter

### DIFF
--- a/css/_text-input.scss
+++ b/css/_text-input.scss
@@ -24,3 +24,23 @@
 @include exports("text-input-xs") {
   @include text-input-xs;
 }
+
+/// Character counter (Carbon React `enableCounter`/`maxCount`). v10 ships no
+/// `.bx--text-input__label-wrapper` at all (unlike `.bx--text-area__label-wrapper`,
+/// which v10 already flexes label/counter apart) - add it here so the label
+/// and counter split across the row the same way TextArea's already does.
+/// The counter itself reuses `.bx--label`'s own `label-01` type style; no
+/// dedicated counter rule is needed.
+/// @access private
+/// @group components
+@mixin text-input-counter {
+  .#{$prefix}--text-input__label-wrapper {
+    display: flex;
+    width: 100%;
+    justify-content: space-between;
+  }
+}
+
+@include exports("text-input-counter") {
+  @include text-input-counter;
+}

--- a/docs/src/pages/components/TextInput.svx
+++ b/docs/src/pages/components/TextInput.svx
@@ -34,6 +34,12 @@ Use the `labelChildren` slot to provide custom label content.
   <strong slot="labelChildren">User name</strong>
 </TextInput>
 
+## Maximum character count
+
+Specify the max character count with `maxCount`. A character counter appears to the right of the label. Use the native maxlength attribute instead if you prefer not to show a counter.
+
+<TextInput labelText="User name" placeholder="Enter user name..." maxCount={10} />
+
 ## Light
 
 Use the light variant for light-themed backgrounds with `light`.

--- a/src/TextInput/TextInput.svelte
+++ b/src/TextInput/TextInput.svelte
@@ -46,6 +46,13 @@
   /** Set to `true` to visually hide the label text */
   export let hideLabel = false;
 
+  /**
+   * Specify the max character count allowed for the input.
+   * Displays a character counter to the right of the label.
+   * @type {number}
+   */
+  export let maxCount = undefined;
+
   /** Set to `true` to indicate an invalid state */
   export let invalid = false;
 
@@ -131,19 +138,30 @@
   {#if inline}
     <div class:bx--text-input__label-helper-wrapper={true}>
       {#if labelText || $$slots.labelChildren}
-        <label
-          for={id}
-          class:bx--label={true}
-          class:bx--visually-hidden={hideLabel}
-          class:bx--label--disabled={disabled}
-          class:bx--label--inline={inline}
-          class:bx--label--inline--xs={size === "xs"}
-          class:bx--label--inline--sm={size === "sm"}
-          class:bx--label--inline--xl={size === "xl"}
-          class:bx--label--slotted={isFluid && $$slots.labelChildren}
-        >
-          <slot name="labelChildren"> {labelText} </slot>
-        </label>
+        <div class:bx--text-input__label-wrapper={true}>
+          <label
+            for={id}
+            class:bx--label={true}
+            class:bx--visually-hidden={hideLabel}
+            class:bx--label--disabled={disabled}
+            class:bx--label--inline={inline}
+            class:bx--label--inline--xs={size === "xs"}
+            class:bx--label--inline--sm={size === "sm"}
+            class:bx--label--inline--xl={size === "xl"}
+            class:bx--label--slotted={isFluid && $$slots.labelChildren}
+          >
+            <slot name="labelChildren"> {labelText} </slot>
+          </label>
+          {#if maxCount != null}
+            <div
+              class:bx--label={true}
+              class:bx--label--disabled={disabled}
+              class:bx--text-input__label-counter={true}
+            >
+              {(value ?? "").toString().length}/{maxCount}
+            </div>
+          {/if}
+        </div>
       {/if}
       {#if !isFluid && helperText}
         <div
@@ -157,18 +175,29 @@
     </div>
   {/if}
   {#if !inline && (labelText || $$slots.labelChildren)}
-    <label
-      for={id}
-      class:bx--label={true}
-      class:bx--visually-hidden={hideLabel}
-      class:bx--label--disabled={disabled}
-      class:bx--label--inline={inline}
-      class:bx--label--inline-sm={inline && size === "sm"}
-      class:bx--label--inline-xl={inline && size === "xl"}
-      class:bx--label--slotted={isFluid && $$slots.labelChildren}
-    >
-      <slot name="labelChildren"> {labelText} </slot>
-    </label>
+    <div class:bx--text-input__label-wrapper={true}>
+      <label
+        for={id}
+        class:bx--label={true}
+        class:bx--visually-hidden={hideLabel}
+        class:bx--label--disabled={disabled}
+        class:bx--label--inline={inline}
+        class:bx--label--inline-sm={inline && size === "sm"}
+        class:bx--label--inline-xl={inline && size === "xl"}
+        class:bx--label--slotted={isFluid && $$slots.labelChildren}
+      >
+        <slot name="labelChildren"> {labelText} </slot>
+      </label>
+      {#if maxCount != null}
+        <div
+          class:bx--label={true}
+          class:bx--label--disabled={disabled}
+          class:bx--text-input__label-counter={true}
+        >
+          {(value ?? "").toString().length}/{maxCount}
+        </div>
+      {/if}
+    </div>
   {/if}
   <div
     class:bx--text-input__field-outer-wrapper={true}
@@ -219,6 +248,7 @@
         class:bx--text-input--xs={size === "xs"}
         class:bx--text-input--sm={size === "sm"}
         class:bx--text-input--xl={size === "xl"}
+        maxlength={maxCount ?? undefined}
         {...$$restProps}
         on:change={onChange}
         on:input={onInput}

--- a/tests/TextInput/TextInput.test.svelte
+++ b/tests/TextInput/TextInput.test.svelte
@@ -10,6 +10,7 @@
   export let helperText = "";
   export let labelText = "User name";
   export let hideLabel = false;
+  export let maxCount: ComponentProps<TextInput>["maxCount"] = undefined;
   export let invalid = false;
   export let invalidText = "";
   export let warn = false;
@@ -41,6 +42,7 @@
   {helperText}
   {labelText}
   {hideLabel}
+  {maxCount}
   {invalid}
   {invalidText}
   {warn}

--- a/tests/TextInput/TextInput.test.ts
+++ b/tests/TextInput/TextInput.test.ts
@@ -60,6 +60,26 @@ describe("TextInput", () => {
     );
   });
 
+  it("should show the character counter when maxCount is set", () => {
+    render(TextInput, {
+      props: { maxCount: 100, value: "Test text" },
+    });
+
+    expect(screen.getByText("9/100")).toBeInTheDocument();
+  });
+
+  it("should not show the character counter when maxCount is unset", () => {
+    render(TextInput, { props: { value: "Test text" } });
+
+    expect(screen.queryByText(/^9\//)).not.toBeInTheDocument();
+  });
+
+  it("should set maxlength when maxCount is set", () => {
+    render(TextInput, { props: { maxCount: 100 } });
+
+    expect(screen.getByRole("textbox")).toHaveAttribute("maxlength", "100");
+  });
+
   it("should handle invalid state", () => {
     render(TextInput, {
       props: { invalid: true, invalidText: "Invalid input" },


### PR DESCRIPTION
TextArea already has a character counter; TextInput doesn't, so a
character-limited single-line field has to be built by hand. Mirrors
TextArea's implementation: setting `maxCount` alone shows the counter
and applies the native `maxlength` attribute, no separate enable flag
required.