### PR TITLE
feat(text-input): accept md and lg size aliases

### DIFF
--- a/docs/src/pages/components/ComboBox.svx
+++ b/docs/src/pages/components/ComboBox.svx
@@ -379,6 +379,18 @@ items={[
   {id: "2", text: "Fax"}
   ]}  />
 
+### Large
+
+Set `size` to `"lg"` (Carbon React's name for this step) or `"xl"` for a large combobox - both render identically.
+
+<ComboBox labelText="Contact" placeholder="Select contact method"
+size="lg"
+items={[
+  {id: "0", text: "Slack"},
+  {id: "1", text: "Email"},
+  {id: "2", text: "Fax"}
+  ]}  />
+
 ### Extra-large
 
 Set `size` to `"xl"` for an extra-large combobox.

--- a/docs/src/pages/components/Dropdown.svx
+++ b/docs/src/pages/components/Dropdown.svx
@@ -186,6 +186,14 @@ Set `direction` to `"top"` to open the menu above the input. Useful when space b
 
 Set `size` to adjust the height of the dropdown. The default is medium.
 
+### Large
+
+Set `size` to `"lg"` (Carbon React's name for this step) or `"xl"` for a large dropdown - both render identically.
+
+<Dropdown size="lg" labelText="Contact" selectedId="0" items="{[{id: "0", text: "Slack"},
+  {id: "1", text: "Email"},
+  {id: "2", text: "Fax"}]}" />
+
 ### Extra-large
 
 Set `size` to `"xl"` for an extra-large dropdown.

--- a/docs/src/pages/components/MultiSelect.svx
+++ b/docs/src/pages/components/MultiSelect.svx
@@ -250,6 +250,16 @@ Use the small size for compact layouts by setting `size` to `"sm"`. This is idea
     {id: "2", text: "Fax"}]}"
   />
 
+### Large
+
+Use the large size for prominent selections by setting `size` to `"lg"` (Carbon React's name for this step) or `"xl"` - both render identically.
+
+<MultiSelect size="lg" labelText="Contact" label="Select contact methods..."
+    items="{[{id: "0", text: "Slack"},
+    {id: "1", text: "Email"},
+    {id: "2", text: "Fax"}]}"
+  />
+
 ### Extra-large
 
 Use the extra-large size for prominent selections by setting `size` to `"xl"`.

--- a/docs/src/pages/components/NumberInput.svx
+++ b/docs/src/pages/components/NumberInput.svx
@@ -150,6 +150,12 @@ detail includes the current value, direction, and original FocusEvent.
 
 `size` sets the input height. The default is `"md"`.
 
+### Large
+
+Use the large size for prominent inputs by setting `size` to `"lg"` (Carbon React's name for this step) or `"xl"` - both render identically.
+
+<NumberInput size="lg" labelText="Clusters" value={0} />
+
 ### Extra-large
 
 Use the extra-large size for prominent inputs by setting `size` to `"xl"`.

--- a/docs/src/pages/components/PasswordInput.svx
+++ b/docs/src/pages/components/PasswordInput.svx
@@ -97,6 +97,12 @@ Display the input with an inline label layout.
 
 The default input height is medium. Set `size` to choose another variant.
 
+### Large
+
+Use the large size variant for increased visibility, setting `size` to `"lg"` (Carbon React's name for this step) or `"xl"` - both render identically.
+
+<PasswordInput size="lg" labelText="Password" placeholder="Enter password..." />
+
 ### Extra-large
 
 Use the extra-large size variant for increased visibility.

--- a/docs/src/pages/components/Select.svx
+++ b/docs/src/pages/components/Select.svx
@@ -123,6 +123,18 @@ Use the small size variant for compact layouts.
   <SelectItem value="g100" text="Gray 100" />
 </Select>
 
+### Large
+
+Use the large size variant for prominent selections, setting `size` to `"lg"` (Carbon React's name for this step) or `"xl"` - both render identically.
+
+<Select size="lg" labelText="Carbon theme" selected="g10" >
+  <SelectItem value="white" text="White" />
+  <SelectItem value="g10" text="Gray 10" />
+  <SelectItem value="g80" text="Gray 80" />
+  <SelectItem value="g90" text="Gray 90" />
+  <SelectItem value="g100" text="Gray 100" />
+</Select>
+
 ### Extra-large
 
 Use the extra-large size variant for prominent selections.

--- a/docs/src/pages/components/TextInput.svx
+++ b/docs/src/pages/components/TextInput.svx
@@ -108,6 +108,12 @@ Use the `labelChildren` slot to provide custom inline label content.
 
 Set `size` to control input height. The default is `md`.
 
+### Large
+
+Use the large size for more prominent inputs by setting `size` to `"lg"` (Carbon React's name for this step) or `"xl"` - both render identically.
+
+<TextInput size="lg" labelText="User name" placeholder="Enter user name..." />
+
 ### Extra-large
 
 Use the extra-large size for more prominent inputs by setting `size` to `"xl"`.

--- a/docs/src/pages/components/TimePicker.svx
+++ b/docs/src/pages/components/TimePicker.svx
@@ -175,6 +175,21 @@ Set `isOnlyTwo` to render only two elements.
 
 The default input height is medium. Set `size` to choose another variant.
 
+### Large
+
+Use the large size for more prominent time pickers by setting `size` to `"lg"` (Carbon React's name for this step) or `"xl"` - both render identically.
+
+<TimePicker size="lg" labelText="Cron job" placeholder="hh:mm">
+  <TimePickerSelect value="pm">
+    <SelectItem value="am" text="AM" />
+    <SelectItem value="pm" text="PM" />
+  </TimePickerSelect>
+  <TimePickerSelect value="pdt">
+    <SelectItem value="pdt" text="PDT" />
+    <SelectItem value="gmt" text="GMT" />
+  </TimePickerSelect>
+</TimePicker>
+
 ### Extra-large
 
 Use the extra-large size for more prominent time pickers by setting `size` to `"xl"`.

--- a/src/ComboBox/ComboBox.svelte
+++ b/src/ComboBox/ComboBox.svelte
@@ -63,8 +63,8 @@
   export let direction = "bottom";
 
   /**
-   * Set the size of the combobox.
-   * @type {"xs" | "sm" | "lg" | "xl"}
+   * Set the size of the combobox. `"md"` is the default, unclassed size.
+   * @type {"xs" | "sm" | "md" | "lg" | "xl"}
    */
   export let size = undefined;
 

--- a/src/Dropdown/Dropdown.svelte
+++ b/src/Dropdown/Dropdown.svelte
@@ -63,8 +63,10 @@
   export let direction = "bottom";
 
   /**
-   * Specify the size of the dropdown field.
-   * @type {"xs" | "sm" | "lg" | "xl"}
+   * Specify the size of the dropdown field. `"md"` (the default, unclassed
+   * size) and `"lg"` are Carbon React's v11 names for the same steps `"xl"`
+   * already renders (48px); `"xl"` remains supported.
+   * @type {"xs" | "sm" | "md" | "lg" | "xl"}
    */
   export let size = undefined;
 
@@ -511,6 +513,7 @@
     open && "bx--dropdown--open",
     size === "xs" && "bx--dropdown--xs",
     size === "sm" && "bx--dropdown--sm",
+    size === "lg" && "bx--dropdown--lg",
     size === "xl" && "bx--dropdown--xl",
     inline && "bx--dropdown--inline",
     disabled && "bx--dropdown--disabled",

--- a/src/ListBox/ListBox.svelte
+++ b/src/ListBox/ListBox.svelte
@@ -1,7 +1,7 @@
 <script>
   /**
-   * Set the size of the list box.
-   * @type {"xs" | "sm" | "lg" | "xl"}
+   * Set the size of the list box. `"md"` is the default, unclassed size.
+   * @type {"xs" | "sm" | "md" | "lg" | "xl"}
    */
   export let size = undefined;
 

--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -54,8 +54,8 @@
   export let value = "";
 
   /**
-   * Set the size of the multiselect.
-   * @type {"xs" | "sm" | "lg" | "xl"}
+   * Set the size of the multiselect. `"md"` is the default, unclassed size.
+   * @type {"xs" | "sm" | "md" | "lg" | "xl"}
    */
   export let size = undefined;
 

--- a/src/NumberInput/NumberInput.svelte
+++ b/src/NumberInput/NumberInput.svelte
@@ -9,8 +9,10 @@
    */
 
   /**
-   * Set the size of the input.
-   * @type {"sm" | "xl"}
+   * Set the size of the input. `"md"` (the default, unclassed size) and
+   * `"lg"` are Carbon React's v11 names for the same steps `"xl"` already
+   * renders (48px); `"xl"` remains supported.
+   * @type {"sm" | "md" | "lg" | "xl"}
    */
   export let size = undefined;
 
@@ -418,6 +420,7 @@
     class:bx--number--nolabel={hideLabel}
     class:bx--number--nosteppers={hideSteppers}
     class:bx--number--sm={size === "sm"}
+    class:bx--number--lg={size === "lg"}
     class:bx--number--xl={size === "xl"}
   >
     {#if $$slots.labelChildren || labelText}

--- a/src/Select/Select.svelte
+++ b/src/Select/Select.svelte
@@ -12,8 +12,10 @@
   export let selected = undefined;
 
   /**
-   * Set the size of the select input.
-   * @type {"xs" | "sm" | "xl"}
+   * Set the size of the select input. `"md"` (the default, unclassed size)
+   * and `"lg"` are Carbon React's v11 names for the same steps `"xl"`
+   * already renders (48px); `"xl"` remains supported.
+   * @type {"xs" | "sm" | "md" | "lg" | "xl"}
    */
   export let size = undefined;
 
@@ -240,6 +242,7 @@
             class:bx--select-input={true}
             class:bx--select-input--xs={size === "xs"}
             class:bx--select-input--sm={size === "sm"}
+            class:bx--select-input--lg={size === "lg"}
             class:bx--select-input--xl={size === "xl"}
             {...$$restProps}
             on:change={handleChange}
@@ -306,6 +309,7 @@
           class:bx--select-input={true}
           class:bx--select-input--xs={size === "xs"}
           class:bx--select-input--sm={size === "sm"}
+          class:bx--select-input--lg={size === "lg"}
           class:bx--select-input--xl={size === "xl"}
           {...$$restProps}
           on:change={handleChange}

--- a/src/TextInput/PasswordInput.svelte
+++ b/src/TextInput/PasswordInput.svelte
@@ -1,7 +1,9 @@
 <script>
   /**
-   * Set the size of the input.
-   * @type {"xs" | "sm" | "xl"}
+   * Set the size of the input. `"md"` (the default, unclassed size) and
+   * `"lg"` are Carbon React's v11 names for the same steps `"xl"` already
+   * renders (48px); `"xl"` remains supported.
+   * @type {"xs" | "sm" | "md" | "lg" | "xl"}
    */
   export let size = undefined;
 
@@ -154,6 +156,7 @@
       class:bx--label--inline={inline}
       class:bx--label--inline--xs={inline && size === "xs"}
       class:bx--label--inline--sm={inline && size === "sm"}
+      class:bx--label--inline--lg={inline && size === "lg"}
       class:bx--label--inline--xl={inline && size === "xl"}
       class:bx--label--slotted={isFluid && $$slots.labelChildren}
     >
@@ -179,6 +182,7 @@
       class:bx--label--inline={inline}
       class:bx--label--inline--xs={inline && size === "xs"}
       class:bx--label--inline--sm={inline && size === "sm"}
+      class:bx--label--inline--lg={inline && size === "lg"}
       class:bx--label--inline--xl={inline && size === "xl"}
       class:bx--label--slotted={isFluid && $$slots.labelChildren}
     >
@@ -230,6 +234,7 @@
         class:bx--text-input--warning={showWarn}
         class:bx--text-input--xs={size === "xs"}
         class:bx--text-input--sm={size === "sm"}
+        class:bx--text-input--lg={size === "lg"}
         class:bx--text-input--xl={size === "xl"}
         {...$$restProps}
         on:change

--- a/src/TextInput/TextInput.svelte
+++ b/src/TextInput/TextInput.svelte
@@ -5,8 +5,10 @@
    */
 
   /**
-   * Set the size of the input.
-   * @type {"xs" | "sm" | "xl"}
+   * Set the size of the input. `"md"` (the default, unclassed size) and
+   * `"lg"` are Carbon React's v11 names for the same steps `"xl"` already
+   * renders (48px); `"xl"` remains supported.
+   * @type {"xs" | "sm" | "md" | "lg" | "xl"}
    */
   export let size = undefined;
 
@@ -139,6 +141,7 @@
           class:bx--label--inline={inline}
           class:bx--label--inline--xs={size === "xs"}
           class:bx--label--inline--sm={size === "sm"}
+          class:bx--label--inline--lg={size === "lg"}
           class:bx--label--inline--xl={size === "xl"}
           class:bx--label--slotted={isFluid && $$slots.labelChildren}
         >
@@ -218,6 +221,7 @@
         class:bx--text-input--warning={showWarn}
         class:bx--text-input--xs={size === "xs"}
         class:bx--text-input--sm={size === "sm"}
+        class:bx--text-input--lg={size === "lg"}
         class:bx--text-input--xl={size === "xl"}
         {...$$restProps}
         on:change={onChange}

--- a/src/TimePicker/TimePicker.svelte
+++ b/src/TimePicker/TimePicker.svelte
@@ -1,7 +1,9 @@
 <script>
   /**
-   * Specify the size of the input.
-   * @type {"sm" | "xl"}
+   * Specify the size of the input. `"md"` (the default, unclassed size) and
+   * `"lg"` are Carbon React's v11 names for the same steps `"xl"` already
+   * renders (48px); `"xl"` remains supported.
+   * @type {"sm" | "md" | "lg" | "xl"}
    */
   export let size = undefined;
 
@@ -208,6 +210,7 @@
       class:bx--time-picker--warn={warn}
       class:bx--time-picker--readonly={readonly}
       class:bx--time-picker--sm={size === "sm"}
+      class:bx--time-picker--lg={size === "lg"}
       class:bx--time-picker--xl={size === "xl"}
       class:bx--select--light={light}
     >

--- a/tests/ComboBox/ComboBox.test.ts
+++ b/tests/ComboBox/ComboBox.test.ts
@@ -537,6 +537,7 @@ describe("ComboBox", () => {
 
   test.each([
     ["sm", "bx--list-box--sm"],
+    ["lg", "bx--list-box--lg"],
     ["xl", "bx--list-box--xl"],
   ] as const)("should handle size variants", (size, className) => {
     const { container } = render(ComboBox, { props: { size } });

--- a/tests/Dropdown/Dropdown.test.ts
+++ b/tests/Dropdown/Dropdown.test.ts
@@ -147,6 +147,20 @@ describe("Dropdown", () => {
 
     await rerender({ items, selectedId: "0", size: "xl" });
     expect(button.closest(".bx--dropdown")).toHaveClass("bx--dropdown--xl");
+
+    // Carbon React's v11 name for the same 48px step as "xl".
+    await rerender({ items, selectedId: "0", size: "lg" });
+    expect(button.closest(".bx--dropdown")).toHaveClass("bx--dropdown--lg");
+    expect(button.closest(".bx--dropdown")).not.toHaveClass("bx--dropdown--xl");
+
+    await rerender({ items, selectedId: "0", size: "md" });
+    for (const className of [
+      "bx--dropdown--sm",
+      "bx--dropdown--lg",
+      "bx--dropdown--xl",
+    ]) {
+      expect(button.closest(".bx--dropdown")).not.toHaveClass(className);
+    }
   });
 
   it("should handle invalid state", () => {

--- a/tests/ListBox/ListBox.test.ts
+++ b/tests/ListBox/ListBox.test.ts
@@ -59,10 +59,24 @@ describe("ListBox", () => {
 
   test.each([
     ["sm", "bx--list-box--sm"],
+    ["lg", "bx--list-box--lg"],
     ["xl", "bx--list-box--xl"],
   ] as const)("should handle size variants", (size, className) => {
     const { container } = render(ListBox, { props: { size } });
     expect(getRoot(container)).toHaveClass(className);
+  });
+
+  it("should render md size the same as the default, unclassed size", () => {
+    const { container } = render(ListBox, { props: { size: "md" } });
+
+    for (const className of [
+      "bx--list-box--xs",
+      "bx--list-box--sm",
+      "bx--list-box--lg",
+      "bx--list-box--xl",
+    ]) {
+      expect(getRoot(container)).not.toHaveClass(className);
+    }
   });
 
   it("should handle invalid state", () => {

--- a/tests/MultiSelect/MultiSelect.test.ts
+++ b/tests/MultiSelect/MultiSelect.test.ts
@@ -1174,6 +1174,17 @@ describe("MultiSelect", () => {
       expect(listBox).toHaveClass("bx--list-box--light");
     });
 
+    it.each([
+      ["sm", "bx--list-box--sm"],
+      ["lg", "bx--list-box--lg"],
+      ["xl", "bx--list-box--xl"],
+    ] as const)("should handle size variants", (size, className) => {
+      const { container } = render(MultiSelect, { props: { items, size } });
+      expect(container.querySelector(".bx--multi-select")).toHaveClass(
+        className,
+      );
+    });
+
     it("renders in inline variant", () => {
       render(MultiSelect, {
         props: {

--- a/tests/NumberInput/NumberInput.test.ts
+++ b/tests/NumberInput/NumberInput.test.ts
@@ -32,7 +32,7 @@ describe("NumberInput", () => {
   });
 
   it("should handle different sizes", () => {
-    const sizes = ["sm", "xl"] as const;
+    const sizes = ["sm", "lg", "xl"] as const;
     for (const size of sizes) {
       const { unmount } = render(NumberInput, {
         props: { size },
@@ -41,6 +41,20 @@ describe("NumberInput", () => {
       const input = screen.getByLabelText("Clusters");
       expect(input.closest(".bx--number")).toHaveClass(`bx--number--${size}`);
       unmount();
+    }
+  });
+
+  it("should render md size the same as the default, unclassed size", () => {
+    render(NumberInput, { props: { size: "md" } });
+
+    const input = screen.getByLabelText("Clusters");
+    const wrapper = input.closest(".bx--number");
+    for (const className of [
+      "bx--number--sm",
+      "bx--number--lg",
+      "bx--number--xl",
+    ]) {
+      expect(wrapper).not.toHaveClass(className);
     }
   });
 

--- a/tests/PasswordInput/PasswordInput.test.ts
+++ b/tests/PasswordInput/PasswordInput.test.ts
@@ -188,6 +188,28 @@ describe("PasswordInput", () => {
       const input = screen.getByLabelText("Password");
       expect(input).toHaveClass("bx--text-input--xl");
     });
+
+    it("should render in large size (Carbon React's v11 alias for xl)", () => {
+      render(PasswordInput, { labelText: "Password", size: "lg" });
+
+      const input = screen.getByLabelText("Password");
+      expect(input).toHaveClass("bx--text-input--lg");
+      expect(input).not.toHaveClass("bx--text-input--xl");
+    });
+
+    it("should render md size the same as the default, unclassed size", () => {
+      render(PasswordInput, { labelText: "Password", size: "md" });
+
+      const input = screen.getByLabelText("Password");
+      for (const className of [
+        "bx--text-input--xs",
+        "bx--text-input--sm",
+        "bx--text-input--lg",
+        "bx--text-input--xl",
+      ]) {
+        expect(input).not.toHaveClass(className);
+      }
+    });
   });
 
   describe("Label handling", () => {

--- a/tests/Select/Select.test.ts
+++ b/tests/Select/Select.test.ts
@@ -102,6 +102,26 @@ describe("Select", () => {
     expect(selectElement).toHaveClass("bx--select-input--xl");
   });
 
+  it("renders large size variant (Carbon React's v11 alias for xl)", () => {
+    render(Select, { size: "lg" });
+    const selectElement = screen.getByLabelText("Select label");
+    expect(selectElement).toHaveClass("bx--select-input--lg");
+    expect(selectElement).not.toHaveClass("bx--select-input--xl");
+  });
+
+  it("renders md size the same as the default, unclassed size", () => {
+    render(Select, { size: "md" });
+    const selectElement = screen.getByLabelText("Select label");
+    for (const className of [
+      "bx--select-input--xs",
+      "bx--select-input--sm",
+      "bx--select-input--lg",
+      "bx--select-input--xl",
+    ]) {
+      expect(selectElement).not.toHaveClass(className);
+    }
+  });
+
   it("renders default variant", () => {
     render(Select);
     const selectElement = screen.getByLabelText("Select label");

--- a/tests/TextInput/TextInput.test.ts
+++ b/tests/TextInput/TextInput.test.ts
@@ -26,7 +26,7 @@ describe("TextInput", () => {
   });
 
   it("should handle different sizes", () => {
-    const sizes = ["xs", "sm", "xl"] as const;
+    const sizes = ["xs", "sm", "lg", "xl"] as const;
     for (const size of sizes) {
       const { unmount } = render(TextInput, {
         props: { size },
@@ -35,6 +35,20 @@ describe("TextInput", () => {
       const input = screen.getByLabelText("User name");
       expect(input).toHaveClass(`bx--text-input--${size}`);
       unmount();
+    }
+  });
+
+  it("should render md size the same as the default, unclassed size", () => {
+    render(TextInput, { props: { size: "md" } });
+
+    const input = screen.getByLabelText("User name");
+    for (const className of [
+      "bx--text-input--xs",
+      "bx--text-input--sm",
+      "bx--text-input--lg",
+      "bx--text-input--xl",
+    ]) {
+      expect(input).not.toHaveClass(className);
     }
   });
 

--- a/tests/TimePicker/TimePicker.test.ts
+++ b/tests/TimePicker/TimePicker.test.ts
@@ -26,7 +26,7 @@ describe("TimePicker", () => {
   });
 
   it("should handle different sizes", () => {
-    const sizes = ["sm", "xl"] as const;
+    const sizes = ["sm", "lg", "xl"] as const;
     for (const size of sizes) {
       const { container } = render(TimePicker, {
         props: { size },
@@ -36,6 +36,19 @@ describe("TimePicker", () => {
         `bx--time-picker--${size}`,
       );
       container.remove();
+    }
+  });
+
+  it("should render md size the same as the default, unclassed size", () => {
+    const { container } = render(TimePicker, { props: { size: "md" } });
+
+    const timePicker = container.querySelector(".bx--time-picker");
+    for (const className of [
+      "bx--time-picker--sm",
+      "bx--time-picker--lg",
+      "bx--time-picker--xl",
+    ]) {
+      expect(timePicker).not.toHaveClass(className);
     }
   });
 


### PR DESCRIPTION
TextInput and TimePicker's `size` unions only had v10 names
(xs/sm/xl); porting `size="lg"` from Carbon React silently fell back
to the 40px default. v10 already ships `--lg` as an exact alias of
`--xl`, so this is a pure rename with no geometry mismatch - widens
both, plus every sibling input whose v10 classes alias `--lg`/`--xl`
identically (Select, NumberInput, Dropdown, PasswordInput, and the
shared ListBox that backs ComboBox/MultiSelect).

Also fixes a real bug found along the way: Dropdown's own JSDoc
already promised `"lg"` but the class-list builder never matched it,
silently falling through to the default size.