### PR TITLE
docs: standardize hidden label and legend boilerplate

### DIFF
--- a/docs/src/pages/components/PasswordInput.svx
+++ b/docs/src/pages/components/PasswordInput.svx
@@ -28,7 +28,7 @@ Set `type` to `"text"` to show the password in plain text.
 
 ## Hidden label
 
-Hide the visible label with `hideLabel`. Screen readers still receive the label text.
+Hide the label visually by setting `hideLabel` to `true`. The label remains available to screen readers.
 
 <PasswordInput hideLabel labelText="Password" placeholder="Enter password..." />
 
@@ -151,7 +151,7 @@ Show a loading state with the default skeleton variant.
 
 ### Without label
 
-Show a loading state without a label using `hideLabel`.
+Show a loading state without a label by setting `hideLabel` to `true`.
 
 <PasswordInputSkeleton hideLabel />
 

--- a/docs/src/pages/components/ProgressBar.svx
+++ b/docs/src/pages/components/ProgressBar.svx
@@ -32,7 +32,7 @@ Use the small size variant for compact layouts.
 
 ## Hidden label
 
-Hide the visible label with `hideLabel`. Screen readers still receive the label text.
+Hide the label visually by setting `hideLabel` to `true`. The label remains available to screen readers.
 
 <ProgressBar hideLabel value={40} labelText="Upload status" helperText="40 MB of 100 MB" />
 

--- a/docs/src/pages/components/RadioButton.svx
+++ b/docs/src/pages/components/RadioButton.svx
@@ -33,7 +33,7 @@ Multiple standalone radio buttons sharing the same name automatically form a gro
 
 ## Hidden legend
 
-Hide the visible legend with `hideLegend`. Screen readers still receive the legend text.
+Hide the legend visually by setting `hideLegend` to `true`. The legend remains available to screen readers.
 
 <RadioButtonGroup hideLegend legendText="Storage tier (disk)" name="plan-legend" selected="standard">
   <RadioButton labelText="Free (1 GB)" value="free" />

--- a/docs/src/pages/components/Search.svx
+++ b/docs/src/pages/components/Search.svx
@@ -139,6 +139,6 @@ Display a loading state for the extra-small search variant.
 
 ### Without label
 
-Show a loading state without a label using `hideLabel`.
+Show a loading state without a label by setting `hideLabel` to `true`.
 
 <SearchSkeleton hideLabel />

--- a/docs/src/pages/components/Select.svx
+++ b/docs/src/pages/components/Select.svx
@@ -68,7 +68,7 @@ Add descriptive text below the select menu.
 
 ### Hidden label
 
-Hide the visible label with `hideLabel`. Screen readers still receive the label text.
+Hide the label visually by setting `hideLabel` to `true`. The label remains available to screen readers.
 
 <Select hideLabel labelText="Carbon theme" selected="g10" >
   <SelectItem value="white" text="White" />
@@ -309,6 +309,6 @@ Display a loading state using the skeleton variant.
 
 ### No label
 
-Show a loading state without a visible label using `hideLabel`.
+Show a loading state without a label by setting `hideLabel` to `true`.
 
 <SelectSkeleton hideLabel />

--- a/docs/src/pages/components/SelectableTile.svx
+++ b/docs/src/pages/components/SelectableTile.svx
@@ -39,7 +39,7 @@ Bind to `selected` for simpler state management.
 
 ## Hidden legend
 
-Hide the visible legend with `hideLegend`. Screen readers still receive the legend text.
+Hide the legend visually by setting `hideLegend` to `true`. The legend remains available to screen readers.
 
 <SelectableTileGroup hideLegend legendText="Select options" name="options-hidden-legend" selected={["option1"]}>
   <SelectableTile value="option1">

--- a/docs/src/pages/components/TextArea.svx
+++ b/docs/src/pages/components/TextArea.svx
@@ -34,7 +34,7 @@ Add helper text below the textarea to provide additional context or instructions
 
 ## Hidden label
 
-Hide the visible label with `hideLabel`. Screen readers still receive the label text.
+Hide the label visually by setting `hideLabel` to `true`. The label remains available to screen readers.
 
 <TextArea hideLabel labelText="App description" placeholder="Enter a description..." />
 
@@ -129,6 +129,6 @@ Show a loading state with the default skeleton variant.
 
 ### Without label
 
-Show a loading state without a label using `hideLabel`.
+Show a loading state without a label by setting `hideLabel` to `true`.
 
 <TextAreaSkeleton hideLabel />

--- a/docs/src/pages/components/TextInput.svx
+++ b/docs/src/pages/components/TextInput.svx
@@ -22,7 +22,7 @@ Add helper text below the input to provide additional context or instructions.
 
 ## Hidden label
 
-Hide the label visually with `hideLabel`. The label remains available to screen readers.
+Hide the label visually by setting `hideLabel` to `true`. The label remains available to screen readers.
 
 <TextInput hideLabel labelText="User name" placeholder="Enter user name..." />
 
@@ -162,6 +162,6 @@ Show a loading state with the default skeleton variant.
 
 ### Without label
 
-Show a loading state without a label with `hideLabel`.
+Show a loading state without a label by setting `hideLabel` to `true`.
 
 <TextInputSkeleton hideLabel />

--- a/docs/src/pages/components/TimePicker.svx
+++ b/docs/src/pages/components/TimePicker.svx
@@ -222,7 +222,7 @@ Add helper text to provide additional context or formatting instructions.
 
 ## Hidden label
 
-Hide the visible label with `hideLabel`. Screen readers still receive the label text.
+Hide the label visually by setting `hideLabel` to `true`. The label remains available to screen readers.
 
 <TimePicker hideLabel labelText="Cron job" placeholder="hh:mm">
   <TimePickerSelect value="pm">

--- a/docs/src/pages/components/Toggle.svx
+++ b/docs/src/pages/components/Toggle.svx
@@ -37,7 +37,7 @@ Customize or hide the toggle labels.
 
 ### Hidden
 
-Hide the visible label with `hideLabel`. Screen readers still receive the label text.
+Hide the label visually by setting `hideLabel` to `true`. The label remains available to screen readers.
 
 <Toggle labelText="Push notifications" hideLabel />
 


### PR DESCRIPTION
Nine pages phrased the hide-label/hide-legend sentence differently,
and seven more varied the skeleton-loading version of it. This lines
every instance up with the boilerplate CONTRIBUTING.md already
specifies.