### PR TITLE
docs: add missing components frontmatter for skeleton API tables

### DIFF
--- a/docs/src/pages/components/Breadcrumb.svx
+++ b/docs/src/pages/components/Breadcrumb.svx
@@ -1,5 +1,5 @@
 ---
-components: ["Breadcrumb", "BreadcrumbItem"]
+components: ["Breadcrumb", "BreadcrumbItem", "BreadcrumbSkeleton"]
 description: Breadcrumbs display a hierarchical navigation trail showing the user's location, with current-page indication and overflow handling.
 ---
 

--- a/docs/src/pages/components/Button.svx
+++ b/docs/src/pages/components/Button.svx
@@ -1,4 +1,5 @@
 ---
+components: ["Button", "ButtonSkeleton"]
 description: Buttons trigger actions like submitting a form or navigating, with multiple kinds and sizes to match each action's importance.
 ---
 

--- a/docs/src/pages/components/Checkbox.svx
+++ b/docs/src/pages/components/Checkbox.svx
@@ -1,4 +1,5 @@
 ---
+components: ["Checkbox", "CheckboxGroup", "CheckboxSkeleton"]
 description: Checkboxes let users select one or more options from a list, for multiple-choice questions, settings, or confirmations.
 ---
 

--- a/docs/src/pages/components/CodeSnippet.svx
+++ b/docs/src/pages/components/CodeSnippet.svx
@@ -1,4 +1,5 @@
 ---
+components: ["CodeSnippet", "CodeSnippetSkeleton"]
 description: Code snippets display and copy code examples, with single-line, multi-line, and inline formats and customizable copy and expand controls.
 ---
 

--- a/docs/src/pages/components/ComboBox.svx
+++ b/docs/src/pages/components/ComboBox.svx
@@ -1,4 +1,5 @@
 ---
+components: ["ComboBox", "FluidComboBoxSkeleton"]
 description: Combo boxes combine a text input with a dropdown menu to select from predefined options or enter custom values, with filtering and custom rendering.
 ---
 

--- a/docs/src/pages/components/DataTable.svx
+++ b/docs/src/pages/components/DataTable.svx
@@ -1,5 +1,5 @@
 ---
-components: ["DataTable", "Pagination","Toolbar", "ToolbarContent", "ToolbarSearch", "ToolbarMenu", "ToolbarMenuItem", "ToolbarBatchActions"]
+components: ["DataTable", "Pagination","Toolbar", "ToolbarContent", "ToolbarSearch", "ToolbarMenu", "ToolbarMenuItem", "ToolbarBatchActions", "DataTableSkeleton"]
 description: Data tables display structured data in rows and columns, with sorting, filtering, pagination, virtualization, and row selection and expansion.
 ---
 

--- a/docs/src/pages/components/MultiSelect.svx
+++ b/docs/src/pages/components/MultiSelect.svx
@@ -1,4 +1,5 @@
 ---
+components: ["MultiSelect", "FluidMultiSelectSkeleton"]
 description: Multi-selects provide a dropdown for selecting multiple options with checkboxes, with filtering, custom formatting, and multiple states.
 ---
 

--- a/docs/src/pages/components/Search.svx
+++ b/docs/src/pages/components/Search.svx
@@ -1,4 +1,5 @@
 ---
+components: ["Search", "SearchSkeleton", "FluidSearchSkeleton"]
 description: Search provides a flexible search input, with support for expandable and fluid variants, multiple sizes, and custom icons.
 ---
 


### PR DESCRIPTION
Eight pages render a skeleton or Fluid* variant in their examples, or
export one with no example at all, without listing it in
components:. ComponentLayout only builds an API table for what's
listed there, so these variants had no Props/Slots/Events table
anywhere on the site.