### PR TITLE
docs: replace Latin abbreviations in prose

### DIFF
--- a/docs/src/pages/components/Button.svx
+++ b/docs/src/pages/components/Button.svx
@@ -105,7 +105,7 @@ By default, the tooltip is portalled only when the button is inside a Modal. Set
 
 ### Hidden tooltip
 
-Set `hideTooltip` to `true` to visually hide the tooltip while maintaining accessibility for screen readers. Use this when tooltips cause layout issues, interfere with interactions, or when multiple icon buttons are densely packed (e.g., toolbars). The **iconDescription** remains accessible to screen readers.
+Set `hideTooltip` to `true` to visually hide the tooltip while maintaining accessibility for screen readers. Use this when tooltips cause layout issues, interfere with interactions, or when multiple icon buttons are densely packed, as in a toolbar. The **iconDescription** remains accessible to screen readers.
 
 <Stack orientation="horizontal" gap={2}>
   <Button hideTooltip iconDescription="Add item" icon={Add} />

--- a/docs/src/pages/components/FileUploader.svx
+++ b/docs/src/pages/components/FileUploader.svx
@@ -63,7 +63,7 @@ Control the tooltip position and alignment with `tooltipPosition` and `tooltipAl
 
 ### Hidden tooltip
 
-Set `hideTooltip` to `true` to visually hide the tooltip while maintaining accessibility for screen readers. Use this when tooltips cause layout issues, interfere with interactions, or when multiple icon buttons are densely packed (e.g., toolbars). The **iconDescription** remains accessible to screen readers.
+Set `hideTooltip` to `true` to visually hide the tooltip while maintaining accessibility for screen readers. Use this when tooltips cause layout issues, interfere with interactions, or when multiple icon buttons are densely packed, as in a toolbar. The **iconDescription** remains accessible to screen readers.
 
 <Stack orientation="horizontal" gap={2}>
   <FileUploaderButton labelText="" hideTooltip iconDescription="Add file" icon={Add} />

--- a/docs/src/pages/components/UIShell.svx
+++ b/docs/src/pages/components/UIShell.svx
@@ -96,7 +96,7 @@ A `HeaderAction` reveals a panel from the right edge.
 
 ### App switcher
 
-The panel does not animate by default. Enable a slide transition by passing [transition:slide params](https://svelte.dev/docs#slide) to `transition` (e.g., `{ duration: 200 }`) to customize duration, delay, and easing.
+The panel does not animate by default. Enable a slide transition by passing [transition:slide params](https://svelte.dev/docs#slide) to `transition`, for example `{ duration: 200 }`, to customize duration, delay, and easing.
 
 <FileSource src="/framed/UIShell/HeaderSwitcher" />
 


### PR DESCRIPTION
Button, FileUploader, and UIShell each had one "e.g." in prose text.
Swap them for plain English per the style guide, leaving the code
comments and helper-text prop values on other pages alone since
those are out of scope for prose passes.