### PR TITLE
docs: backtick prop names instead of bolding them

### DIFF
--- a/docs/src/pages/components/Button.svx
+++ b/docs/src/pages/components/Button.svx
@@ -73,7 +73,7 @@ Add an icon to the button using the `icon` prop.
 
 ### Icon-only
 
-Omit the label and provide an **iconDescription** for accessibility. This text is used as the button's tooltip and screen reader label.
+Omit the label and provide an `iconDescription` for accessibility. This text is used as the button's tooltip and screen reader label.
 
 <Button iconDescription="Tooltip text" icon={Add} />
 
@@ -105,7 +105,7 @@ By default, the tooltip is portalled only when the button is inside a Modal. Set
 
 ### Hidden tooltip
 
-Set `hideTooltip` to `true` to visually hide the tooltip while maintaining accessibility for screen readers. Use this when tooltips cause layout issues, interfere with interactions, or when multiple icon buttons are densely packed, as in a toolbar. The **iconDescription** remains accessible to screen readers.
+Set `hideTooltip` to `true` to visually hide the tooltip while maintaining accessibility for screen readers. Use this when tooltips cause layout issues, interfere with interactions, or when multiple icon buttons are densely packed, as in a toolbar. The `iconDescription` remains accessible to screen readers.
 
 <Stack orientation="horizontal" gap={2}>
   <Button hideTooltip iconDescription="Add item" icon={Add} />

--- a/docs/src/pages/components/FileUploader.svx
+++ b/docs/src/pages/components/FileUploader.svx
@@ -50,7 +50,7 @@ Add an icon to the file uploader button with `icon`.
 
 ## Icon-only
 
-Set **labelText=""** to render an icon-only button. Provide an **iconDescription** for accessibility — it is used as the button's tooltip and screen reader label.
+Set `labelText` to an empty string to render an icon-only button. Provide an `iconDescription` for accessibility — it is used as the button's tooltip and screen reader label.
 
 <FileUploaderButton labelText="" iconDescription="Add file" icon={Add} />
 <FileUploaderButton labelText="" iconDescription="Upload document" icon={DocumentAdd} kind="secondary" />
@@ -63,7 +63,7 @@ Control the tooltip position and alignment with `tooltipPosition` and `tooltipAl
 
 ### Hidden tooltip
 
-Set `hideTooltip` to `true` to visually hide the tooltip while maintaining accessibility for screen readers. Use this when tooltips cause layout issues, interfere with interactions, or when multiple icon buttons are densely packed, as in a toolbar. The **iconDescription** remains accessible to screen readers.
+Set `hideTooltip` to `true` to visually hide the tooltip while maintaining accessibility for screen readers. Use this when tooltips cause layout issues, interfere with interactions, or when multiple icon buttons are densely packed, as in a toolbar. The `iconDescription` remains accessible to screen readers.
 
 <Stack orientation="horizontal" gap={2}>
   <FileUploaderButton labelText="" hideTooltip iconDescription="Add file" icon={Add} />

--- a/docs/src/pages/components/MultiSelect.svx
+++ b/docs/src/pages/components/MultiSelect.svx
@@ -130,7 +130,7 @@ Limit how many items a user can select by setting `maxSelectedItems`. Once the c
 
 Add a "select all" item by setting isSelectAll to true on an item. Clicking this item selects or deselects all non-disabled items. Disabled items are not affected by "select all".
 
-The select-all option is styled differently from regular options (with a separator border) so it is visually distinct as a group toggle. Its checkbox supports an **indeterminate** state when only a subset of non-disabled items are selected; it shows checked when all are selected and unchecked when none are selected.
+The select-all option is styled differently from regular options (with a separator border) so it is visually distinct as a group toggle. Its checkbox supports an `indeterminate` state when only a subset of non-disabled items are selected; it shows checked when all are selected and unchecked when none are selected.
 
 <FileSource src="/framed/MultiSelect/MultiSelectSelectAll" />
 


### PR DESCRIPTION
labelText, iconDescription (twice), and indeterminate were bolded in
prose on FileUploader, Button, and MultiSelect instead of backticked
like every other prop reference. InlineLoading's reference table and
TreeView's plain-English emphasis are untouched, those aren't
identifiers.