### PR TITLE
docs: rename Default headings to descriptive labels

### DIFF
--- a/docs/src/pages/components/Search.svx
+++ b/docs/src/pages/components/Search.svx
@@ -18,7 +18,7 @@ The search input is extra-large by default. Set `size` to choose another variant
 
 <Search />
 
-## Default value
+## Initial value
 
 Set an initial value with `value`.
 

--- a/docs/src/pages/components/SearchMenu.svx
+++ b/docs/src/pages/components/SearchMenu.svx
@@ -76,7 +76,7 @@ Use the `before` slot to render content to the left of the input within a joined
 
 As the user types, each `SearchMenuItem` is matched against the search value to decide whether it is shown and which characters of its `text` are highlighted. The `match` prop controls this. It receives the item `text` and the current search value and returns `{ matched, indices }`: `matched` filters the item out when `false`, and `indices` are the character positions highlighted in the text. The default is fuzzy matching.
 
-### Default fuzzy matching
+### Built-in fuzzy matching
 
 Fuzzy matching prefers a contiguous substring, ranking a prefix above a word boundary above a mid-word occurrence, and falls back to a subsequence match so that "dsm" matches "**D**ata **S**tore for **M**emcache". Matching is case-insensitive. No configuration is required.
 

--- a/docs/src/pages/components/UIShell.svx
+++ b/docs/src/pages/components/UIShell.svx
@@ -146,7 +146,7 @@ Add utilities to the header with header utilities. Compose [BadgeIndicator](/com
 
 <FileSource src="/framed/UIShell/HeaderUtilities" />
 
-### Default avatar
+### Fallback avatar
 
 Use `ProfileMenu` for an account menu in the header. When the `avatar` slot is empty, a default [UserAvatar](/components/UserAvatar) renders. The menu closes on outside click and <DocKbd label="Escape" />.
 

--- a/docs/src/pages/components/UserAvatar.svx
+++ b/docs/src/pages/components/UserAvatar.svx
@@ -15,7 +15,7 @@ It is designed to be used with the UI Shell [profile menu](/components/UIShell#p
 
 The avatar renders the first available of an image, a custom icon, initials, or the default user icon.
 
-### Default
+### Fallback icon
 
 Render the avatar without any content to show the default user icon.
 


### PR DESCRIPTION
Search, UserAvatar, SearchMenu, and UIShell each had a section titled
(or ending in) "Default" instead of a label describing what it shows.
Verified none of the four old anchors have inbound links, in-page or
cross-page.