### PR TITLE
docs: fix broken cross-page anchor links

### DIFF
--- a/docs/src/pages/components/CopyInput.svx
+++ b/docs/src/pages/components/CopyInput.svx
@@ -11,7 +11,7 @@ description: Copy inputs display a read-only value in a text field with a built-
 
 ## Basic
 
-Set `value` to the string to show and copy. For install commands, see [CodeSnippet](/components/CodeSnippet); for display-only values, use [TextInput](/components/TextInput#readonly).
+Set `value` to the string to show and copy. For install commands, see [CodeSnippet](/components/CodeSnippet); for display-only values, use [TextInput](/components/TextInput#read-only).
 
 <CopyInput labelText="API endpoint" value="https://api.example.com/v1" />
 

--- a/docs/src/pages/components/Toolbar.svx
+++ b/docs/src/pages/components/Toolbar.svx
@@ -167,6 +167,6 @@ Stack multiple action buttons in the toolbar.
 
 Toolbar batch actions display batch actions when items are selected. 
 
-Although intended for use with [DataTable](/components/datatable), batch actions can be used standalone when selectedIds is provided. That prop is not required when used with a data table.
+Although intended for use with [DataTable](/components/DataTable), batch actions can be used standalone when `selectedIds` is provided. That prop is not required when used with a data table.
 
 <FileSource src="/framed/Toolbar/ToolbarBatchActionsStandalone" />

--- a/docs/src/pages/components/UserAvatar.svx
+++ b/docs/src/pages/components/UserAvatar.svx
@@ -99,7 +99,7 @@ Set `backgroundColor` to `"auto"` to pick a color from `name` (or `initials`). T
 
 Set `interactive` to render a `button` instead of a `span` when the avatar is a clickable control, such as a custom profile menu trigger. The button receives a focus ring. `name` is used as the accessible name when `aria-label` is not set.
 
-Do not set `interactive` when slotting the avatar into [ProfileMenu](/components/UIShell#profilemenu) — that component already wraps the avatar in a labelled trigger button.
+Do not set `interactive` when slotting the avatar into [ProfileMenu](/components/UIShell#profile-menu) — that component already wraps the avatar in a labelled trigger button.
 
 <UserAvatar interactive name="Richard Hendricks" backgroundColor="purple" />
 
@@ -131,6 +131,6 @@ The floating portal keeps the tooltip from being clipped by the modal's overflow
 
 ## Use within ProfileMenu
 
-Slot the avatar into [ProfileMenu](/components/UIShell#profilemenu) for the header trigger and the profile header. Use `size="md"` for the trigger and `size="lg"` for the header to match the menu frame. Leave `interactive`, `href`, and `tooltipText` unset on the slotted avatar so the menu owns focus and labelling.
+Slot the avatar into [ProfileMenu](/components/UIShell#profile-menu) for the header trigger and the profile header. Use `size="md"` for the trigger and `size="lg"` for the header to match the menu frame. Leave `interactive`, `href`, and `tooltipText` unset on the slotted avatar so the menu owns focus and labelling.
 
 <UserAvatar size="md" name="Richard Hendricks" />


### PR DESCRIPTION
Three links pointed at slugs that don't exist: UserAvatar's two
ProfileMenu links used #profilemenu instead of #profile-menu,
Toolbar's DataTable link used the lowercase route, and CopyInput's
TextInput link used #readonly instead of #read-only. Also backticks
selectedIds on the Toolbar line while touching it.