### PR TITLE
docs: move page intros out of the body into frontmatter descriptions

### DIFF
--- a/docs/src/pages/components/Search.svx
+++ b/docs/src/pages/components/Search.svx
@@ -8,13 +8,11 @@ description: Search provides a flexible search input, with support for expandabl
   import { Search, SearchSkeleton, FluidSearchSkeleton, TooltipIcon } from "carbon-components-svelte";
 </script>
 
-`Search` is a standalone search input supporting expandable variants, sizes, and custom icons. It clears on <DocKbd label="Escape" /> or the clear button.
-
-To build a search typeahead with a results menu—suggestions, grouped results, and recent searches—use [SearchMenu](/components/SearchMenu), which composes `Search`.
-
 ## Basic
 
-The search input is extra-large by default. Set `size` to choose another variant — see [large](#large), [small](#small), and [extra-small](#extra-small).
+The search input is extra-large by default. Set `size` to choose another variant — see [large](#large), [small](#small), and [extra-small](#extra-small). The input clears on <DocKbd label="Escape" /> or the clear button.
+
+To build a search typeahead with a results menu — suggestions, grouped results, and recent searches — use [SearchMenu](/components/SearchMenu), which composes `Search`.
 
 <Search />
 

--- a/docs/src/pages/components/UserAvatar.svx
+++ b/docs/src/pages/components/UserAvatar.svx
@@ -1,5 +1,6 @@
 ---
 components: ["UserAvatar"]
+description: User avatars display a photo, a custom icon, or initials derived from a name, for identifying a person in a header, list, or profile menu.
 ---
 
 <script>
@@ -7,13 +8,9 @@ components: ["UserAvatar"]
   import UserAvatarFilledAlt from "carbon-icons-svelte/lib/UserAvatarFilledAlt.svelte";
 </script>
 
-The `UserAvatar` renders a circular avatar for a user. It displays a photo, a custom icon, or initials derived from a name, falling back to a default user icon.
-
-It is designed to be used with the UI Shell [profile menu](/components/UIShell#profile-menu).
-
 ## Content
 
-The avatar renders the first available of an image, a custom icon, initials, or the default user icon.
+The avatar renders the first available of an image, a custom icon, initials, or the default user icon. It is designed for the UI Shell [profile menu](/components/UIShell#profile-menu).
 
 ### Default
 


### PR DESCRIPTION
Search and UserAvatar were the only two pages whose body opened with
a paragraph instead of a heading. The heroIntro remark plugin extracts
that leading paragraph and silently overrides the frontmatter
description, and drops inline HTML while doing it, so Search's
<DocKbd> chip vanished from the rendered hero and left a double space.
Fold both intros into their first section and let the frontmatter
description render as-is. Confirmed with a Playwright check that the
hero text and the DocKbd chip both render correctly on each page.