### PR TITLE
docs: backtick portalMenu and overflow tokens in portal sections

### DIFF
--- a/docs/src/pages/components/DatePicker.svx
+++ b/docs/src/pages/components/DatePicker.svx
@@ -126,7 +126,7 @@ Import the corresponding locale module from `flatpickr/dist/l10n/<key>` and pass
 
 ## Portal
 
-Set `portalMenu` to `true` to render the calendar in a floating portal. This prevents the calendar from being clipped by parent containers with overflow hidden or z-index stacking contexts. When inside a Modal, portalMenu defaults to true unless explicitly set to false.
+Set `portalMenu` to `true` to render the calendar in a floating portal. This prevents the calendar from being clipped by parent containers with `overflow: hidden` or z-index stacking contexts. Inside a [Modal](/components/Modal), `portalMenu` defaults to `true` unless explicitly set to `false`.
 
 <FileSource src="/framed/DatePicker/DatePickerModal" />
 

--- a/docs/src/pages/components/MultiSelect.svx
+++ b/docs/src/pages/components/MultiSelect.svx
@@ -392,7 +392,7 @@ Display a loading skeleton for the fluid multi-select variant.
 
 ## Portal menu
 
-Set `portalMenu` to `true` to render the dropdown menu in a floating portal. This prevents the menu from being clipped by parent containers with overflow hidden or z-index stacking contexts. Without portalMenu, the dropdown in the example below would be clipped by its container's hidden overflow.
+Set `portalMenu` to `true` to render the dropdown menu in a floating portal. This prevents the menu from being clipped by parent containers with `overflow: hidden` or z-index stacking contexts. Without `portalMenu`, the dropdown in the example below would be clipped by its container's hidden overflow.
 
 When inside a [Modal](/components/Modal#modal-with-dropdowns), portalMenu defaults to true unless explicitly set to false.
 


### PR DESCRIPTION
The same portalMenu paragraph appears on four pages; ComboBox and
Dropdown already backtick overflow: hidden and portalMenu, but
MultiSelect and DatePicker didn't. Match them, and give DatePicker's
copy a link to Modal plus consistent true/false backticking.