### PR TITLE
docs: backtick method calls and ARIA attributes in prose

### DIFF
--- a/docs/src/pages/components/ClickableTile.svx
+++ b/docs/src/pages/components/ClickableTile.svx
@@ -16,7 +16,7 @@ Carbon Design System
 
 ## Prevent default
 
-Handle the click event to override default link behavior. Use e.preventDefault() to stop navigation.
+Handle the `click` event to override default link behavior. Call `e.preventDefault()` to stop navigation.
 
 <ClickableTile
   href="/"

--- a/docs/src/pages/components/ComposedModal.svx
+++ b/docs/src/pages/components/ComposedModal.svx
@@ -30,7 +30,7 @@ Wrap the composed modal in a portal to ensure it renders above all z-index stack
 
 ## Prevent default close behavior
 
-The modal dispatches a cancelable `close` event. Call e.preventDefault() to keep the modal open. The event includes a trigger property indicating what triggered the close attempt: `"escape-key"` (<DocKbd label="Escape" />), `"outside-click"`, or `"close-button"`.
+The modal dispatches a cancelable `close` event. Call `e.preventDefault()` to keep the modal open. The event includes a trigger property indicating what triggered the close attempt: `"escape-key"` (<DocKbd label="Escape" />), `"outside-click"`, or `"close-button"`.
 
 <FileSource src="/framed/Modal/ComposedModalPreventClose" />
 

--- a/docs/src/pages/components/CopyButton.svx
+++ b/docs/src/pages/components/CopyButton.svx
@@ -17,7 +17,7 @@ Set `text` to the string to copy. By default, the copy button uses the native [C
 
 Pass an async `copy` function when the text is not available at render time, for example markdown fetched on click. Feedback appears after `copy()` resolves.
 
-While copy() is pending, the button sets aria-busy and ignores clicks. On failure, skip feedback and listen for `copy:error`.
+While `copy()` is pending, the button sets `aria-busy` and ignores clicks. On failure, skip feedback and listen for `copy:error`.
 
 Prefetch on hover with `on:mouseenter`.
 


### PR DESCRIPTION
ComposedModal, ClickableTile, and CopyButton left e.preventDefault(),
copy(), and aria-busy as plain text in prose, unlike Modal,
InlineNotification, and ToastNotification's near-identical sentences.