### PR TITLE
docs(multi-select): drop filler tail from disabled section

### DIFF
--- a/docs/src/pages/components/MultiSelect.svx
+++ b/docs/src/pages/components/MultiSelect.svx
@@ -444,7 +444,7 @@ Combine `filterable` and `warn` to show warnings on a filterable multi-select.
 
 ### Disabled
 
-Disable the entire dropdown by setting `disabled` to `true`. This prevents all user interaction.
+Disable the entire dropdown by setting `disabled` to `true`.
 
 <MultiSelect disabled labelText="Contact" label="Select contact methods..."
     items="{[{id: "0", text: "Slack"},


### PR DESCRIPTION
"This prevents all user interaction" just restates what disabled
already says, unlike the sibling "This prevents..." sentences
elsewhere that carry real when-to-use guidance and stay as-is.