### PR TITLE
docs(code-snippet): rename Disabled state heading to Disabled

### DIFF
--- a/docs/src/pages/components/CodeSnippet.svx
+++ b/docs/src/pages/components/CodeSnippet.svx
@@ -124,7 +124,7 @@ Set `showMoreText` and `showLessText` to customize the expand/collapse button te
 
 <FileSource src="/framed/CodeSnippet/CodeSnippetCustomText" />
 
-## Disabled state
+## Disabled
 
 Set `disabled` to `true` to disable interaction. This only applies to `"single"` and `"multi"` types.
 


### PR DESCRIPTION
32 other component pages use "## Disabled" exactly; CodeSnippet was
the only one with a redundant trailing "state". Confirmed no inbound
links target the old #disabled-state anchor.