### PR TITLE
docs(ui-shell): use DocKbd for the Enter key

### DIFF
--- a/docs/src/pages/components/UIShell.svx
+++ b/docs/src/pages/components/UIShell.svx
@@ -134,7 +134,7 @@ Set `icon` to render a different trigger icon. Use `placeholder`, `labelText`, a
 
 Use the `menu` slot to render [SearchMenu](/components/SearchMenu) items in the header. Compose `SearchMenuGroup` and `SearchMenuItem` for grouped, fuzzy-highlighted results with icons, persistent footer actions, and a `loading` skeleton state.
 
-When the `menu` slot is present, it replaces the `results` prop. Keyboard navigation uses `role="option"`. Press Enter with no selection to dispatch `submit`. Use the `noResults` slot when nothing matches. The `results` prop still works if you do not use `menu`.
+When the `menu` slot is present, it replaces the `results` prop. Keyboard navigation uses `role="option"`. Press <DocKbd label="Enter" /> with no selection to dispatch `submit`. Use the `noResults` slot when nothing matches. The `results` prop still works if you do not use `menu`.
 
 Set `size` to `"sm"` (default), `"lg"`, or `"xl"` to control row density. Result text stays flush with the header input at every size. Pass `icon` or `iconRight` to each `SearchMenuItem`, or use the default slot with `let:segments` to highlight the query in secondary text like a description.
 


### PR DESCRIPTION
"Enter" was written as plain prose text while the rest of the page
uses DocKbd chips for keyboard keys. mdsvex auto-imports DocKbd, so
no import is needed.