### PR TITLE
docs: use DocKbd for keyboard keys in MenuButton and Toggletip

### DIFF
--- a/docs/src/pages/components/MenuButton.svx
+++ b/docs/src/pages/components/MenuButton.svx
@@ -204,7 +204,7 @@ Wrap items in `MenuItemRadioGroup` for a set where one choice is active at a tim
 
 ### Nested
 
-Set `labelText` on a `MenuItem` and nest child `MenuItem` rows to get a submenu. Open it with `ArrowRight`, click, or hover (short delay). `ArrowLeft` closes it and refocuses the parent. Picking a nested item closes the whole menu.
+Set `labelText` on a `MenuItem` and nest child `MenuItem` rows to get a submenu. Open it with <DocKbd label="→" />, click, or hover (short delay). <DocKbd label="←" /> closes it and refocuses the parent. Picking a nested item closes the whole menu.
 
 <MenuButton labelText="Actions">
   <MenuItem on:click={() => console.log("Cut")}>Cut</MenuItem>

--- a/docs/src/pages/components/Toggletip.svx
+++ b/docs/src/pages/components/Toggletip.svx
@@ -10,7 +10,7 @@ description: Toggletips display contextual content in a popover that is toggled 
 
 ## Basic
 
-Unlike a tooltip, a toggletip opens and closes on click. Click the button to toggle the content. Press `Escape` or click outside to close it.
+Unlike a tooltip, a toggletip opens and closes on click. Click the button to toggle the content. Press <DocKbd label="Escape" /> or click outside to close it.
 
 <Toggletip>
   Custom toggletip content with a longer description that wraps onto multiple lines.


### PR DESCRIPTION
Both pages backticked key names instead of using DocKbd. For the
arrow keys, matched the → / ← symbol form ComboBox and PinCodeInput
already use rather than ArrowRight/ArrowLeft.