### PR TITLE
docs(copy-button): document feedbackTimeout

### DIFF
--- a/docs/src/pages/components/CopyButton.svx
+++ b/docs/src/pages/components/CopyButton.svx
@@ -67,6 +67,12 @@ Set `feedbackIcon` to show a different icon while feedback is visible. The copy 
 
 <CopyButton text="Carbon svelte" feedbackIcon={Checkmark} />
 
+### Duration
+
+Set `feedbackTimeout` to change how long the feedback stays visible, in milliseconds. Defaults to `2000`.
+
+<CopyButton text="Carbon svelte" feedbackTimeout={5000} />
+
 ## Copy behavior
 
 Replace or disable the default clipboard behavior.


### PR DESCRIPTION
feedback and feedbackIcon each got a sentence and demo in the Custom
feedback section, but feedbackTimeout, which controls how long that
feedback stays visible, wasn't mentioned anywhere. Verified with a
scripted click that the feedback text shows immediately, is still
visible past the default 2000ms, and clears at the custom 5000ms.

CopyInput and CodeSnippet expose the same prop with the same
documentation gap — leaving that as a follow-up rather than
expanding this PR's scope.