### PR TITLE
docs(clickable-tile): add reactive clicked example

### DIFF
--- a/docs/src/pages/components/ClickableTile.svx
+++ b/docs/src/pages/components/ClickableTile.svx
@@ -14,6 +14,12 @@ Create a clickable tile with an href to link to another page.
 Carbon Design System
 </ClickableTile>
 
+## Reactive example
+
+Bind to `clicked` to read whether the tile has been activated.
+
+<FileSource src="/framed/ClickableTile/ReactiveClickableTile" />
+
 ## Prevent default
 
 Handle the click event to override default link behavior. Use e.preventDefault() to stop navigation.

--- a/docs/src/pages/framed/ClickableTile/ReactiveClickableTile.svelte
+++ b/docs/src/pages/framed/ClickableTile/ReactiveClickableTile.svelte
@@ -1,0 +1,10 @@
+<script>
+  import { ClickableTile, Stack } from "carbon-components-svelte";
+
+  let clicked = false;
+</script>
+
+<Stack gap={5}>
+  <div>Clicked: <strong>{clicked}</strong></div>
+  <ClickableTile bind:clicked>Click this tile</ClickableTile>
+</Stack>


### PR DESCRIPTION
clicked is a bindable, readonly prop that already shows up in the API
table, but nothing on the page demonstrated it. Add a framed example
that binds it and prints the value. Verified with a scripted click
that it flips from false to true.