### PR TITLE
docs(form): drop roadmap language from the disabled section

### DIFF
--- a/docs/src/pages/components/Form.svx
+++ b/docs/src/pages/components/Form.svx
@@ -68,9 +68,9 @@ shows a form with checkboxes, radio buttons, and a select menu.
 
 Set `disabled` on FormGroup to disable the fieldset and nested native form
 controls. Labels are visually muted via Carbon's `fieldset[disabled]` styles.
-Div-based controls such as Dropdown, ComboBox, and MultiSelect are not fully
-styled by the native attribute alone—pass `disabled` on those components until
-form-level context propagation lands.
+`Dropdown`, `ComboBox`, and `MultiSelect` render as divs rather than native form
+controls, so the fieldset attribute does not reach them. Set `disabled` on each
+of those components directly.
 
 <Form>
   <FormGroup legendText="Account details" disabled>


### PR DESCRIPTION
"until form-level context propagation lands" is roadmap copy that
will read as stale the moment it ships or is abandoned. Confirmed
src/Form/ still publishes no context (only FluidForm does), so the
underlying fact is unchanged, only the phrasing needed to go.