### PR TITLE
docs: promote bold pseudo-headings to real headings

### DIFF
--- a/docs/src/pages/components/Grid.svx
+++ b/docs/src/pages/components/Grid.svx
@@ -46,26 +46,24 @@ for dense data displays.
 
 ## Responsive
 
-Build responsive layouts by specifying different column widths for different
-breakpoints. The grid automatically adjusts based on screen size.
+Build responsive layouts by setting a different column width per breakpoint.
+Each breakpoint has a different total column count, so scale spans
+proportionally.
 
-**Key concept:** Since each breakpoint has a different total number of columns,
-you need to scale your column spans proportionally. Here are common patterns:
-
-**Full width column:**
+### Full width column
 
 ```svelte
 <Column sm={4} md={8} lg={16} />
 ```
 
-**Half width (50/50 split):**
+### Half width (50/50 split)
 
 ```svelte
 <Column sm={2} md={4} lg={8} />
 <Column sm={2} md={4} lg={8} />
 ```
 
-**Two-thirds / One-third split:**
+### Two-thirds / one-third split
 
 ```svelte
 <Column sm={4} md={6} lg={11} />

--- a/docs/src/pages/components/Theme.svx
+++ b/docs/src/pages/components/Theme.svx
@@ -32,7 +32,7 @@ When persistence is enabled, theme changes sync across browser tabs that share t
 
 Override default Carbon theme tokens using the `tokens` prop.
 
-**Understanding token usage:** The Theme component sets CSS custom properties as `--cds-{token}`. Not every token name maps directly to component styles. Components often use semantic tokens (like `interactive-01`) rather than component-specific ones.
+`Theme` sets CSS custom properties as `--cds-{token}`. Not every token name maps directly to component styles. Components often use semantic tokens (like `interactive-01`) rather than component-specific ones.
 
 For example, primary buttons use `interactive-01` for background, with separate hover and active tokens. Check component CSS or Carbon docs to see which tokens affect a given component.
 


### PR DESCRIPTION
Bold text doing a heading's job is invisible to the page TOC and
search index, which both key off ## / ### headings.

Grid's Responsive section had three bold labels; promoted them to
### headings, naming them to avoid duplicating the existing "Full
width" heading under Variants. Also tightened the surrounding prose:
direct imperative instead of "you need to", and dropped the "Here are
common patterns" filler tail.

Theme had one bold label ("Understanding token usage:") folded into
plain prose instead, since it wasn't really introducing a subsection.

Verified both pages in the dev server: Grid's three new headings show
up as real h3s alongside the existing ones with no text collision,
and Theme's paragraph reads cleanly with the bold gone.