### PR TITLE
docs(data-table): shorten the frontmatter description

### DIFF
--- a/docs/src/pages/components/DataTable.svx
+++ b/docs/src/pages/components/DataTable.svx
@@ -1,6 +1,6 @@
 ---
 components: ["DataTable", "Pagination","Toolbar", "ToolbarContent", "ToolbarSearch", "ToolbarMenu", "ToolbarMenuItem", "ToolbarBatchActions"]
-description: Data tables display structured data in a tabular format. Use them to present large datasets with built-in support for sorting, filtering, pagination, virtualization, and row selection and expansion.
+description: Data tables display structured data in rows and columns, with sorting, filtering, pagination, virtualization, and row selection and expansion.
 ---
 
 <script>


### PR DESCRIPTION
At 198 characters, DataTable was the only page over the ~180
character budget. Trimmed to 142 while keeping it focused on what
the component is for rather than how it works.