### PR TITLE
perf(overflow-menu): avoid a second forced layout when positioning the menu

### DIFF
--- a/e2e/overflow-menu.test.ts
+++ b/e2e/overflow-menu.test.ts
@@ -77,4 +77,23 @@ test.describe("OverflowMenu", () => {
     await page.keyboard.press("Escape");
     await expect(trigger).toBeFocused();
   });
+
+  test("positions the menu below and flush with the trigger's left edge", async ({
+    page,
+  }) => {
+    const trigger = page.getByTestId("overflow-menu");
+    await trigger.click();
+
+    const menu = page.getByRole("menu");
+    await expect(menu).toBeVisible();
+
+    const triggerBox = await trigger.boundingBox();
+    const menuBox = await menu.boundingBox();
+    if (!triggerBox || !menuBox) throw new Error("missing bounding box");
+
+    // direction="bottom" (default), not flipped: menu top sits at the
+    // trigger's bottom edge, menu left aligns with the trigger's left edge.
+    expect(menuBox.y).toBeCloseTo(triggerBox.y + triggerBox.height, 0);
+    expect(menuBox.x).toBeCloseTo(triggerBox.x, 0);
+  });
 });

--- a/src/OverflowMenu/OverflowMenu.svelte
+++ b/src/OverflowMenu/OverflowMenu.svelte
@@ -220,15 +220,21 @@
       if (!effectivePortalMenu) {
         // Menu is a button sibling; position from offsetTop/offsetLeft.
         const { offsetTop, offsetLeft } = buttonRef;
+        // Read menu geometry up front, before any writes below: reading
+        // offsetHeight/offsetWidth after menuRef.style has already been
+        // written forces a second synchronous layout recalc on top of the
+        // one triggered by the reads above.
+        const menuHeight = menuRef.offsetHeight;
+        const menuWidth = menuRef.offsetWidth;
 
         if (direction === "top") {
-          menuRef.style.top = `${offsetTop - menuRef.offsetHeight}px`;
+          menuRef.style.top = `${offsetTop - menuHeight}px`;
         } else {
           menuRef.style.top = `${offsetTop + height}px`;
         }
 
         if (flipped) {
-          menuRef.style.left = `${offsetLeft + width - menuRef.offsetWidth}px`;
+          menuRef.style.left = `${offsetLeft + width - menuWidth}px`;
         } else {
           menuRef.style.left = `${offsetLeft}px`;
         }


### PR DESCRIPTION
The non-portal positioning path in afterUpdate read
menuRef.offsetHeight/offsetWidth after already writing
menuRef.style.top, forcing a second synchronous layout recalc on
top of the one triggered by the earlier reads. Same interleaved
read/write shape as #3561 (trapFocus); this hoists the menu
geometry reads above the style writes so there's one recalc
instead of two.