### PR TITLE
fix(tree-view): dedupe selectedIds on Ctrl+A / range-select

### DIFF
--- a/src/TreeView/TreeView.svelte
+++ b/src/TreeView/TreeView.svelte
@@ -880,7 +880,7 @@
         }
       }
 
-      setSelectedIds(selectedIds.concat(nodeIds));
+      setSelectedIds([...new Set(selectedIds.concat(nodeIds))]);
     }
 
     if (nextFocusNode && nextFocusNode !== treeItem) {

--- a/tests/TreeView/TreeViewSelectionChange.test.ts
+++ b/tests/TreeView/TreeViewSelectionChange.test.ts
@@ -150,6 +150,25 @@ describe("TreeView select:change", () => {
     expect(detail.removed).toEqual([]);
   });
 
+  it("does not duplicate an already-selected id on Ctrl+A select-all", async () => {
+    const onSelectChange = vi.fn();
+    render(TreeViewSelectionChange, {
+      multiselect: true,
+      selectedIds: [0],
+      onSelectChange,
+    });
+
+    treeItemById(0).focus();
+    await user.keyboard("{Control>}a{/Control}");
+
+    await vi.waitFor(() => expect(onSelectChange).toHaveBeenCalledTimes(1));
+    const detail = lastDetail(onSelectChange);
+    expect([...detail.selectedIds].sort()).toEqual([0, 1, 7, 9]);
+    expect(detail.selectedIds.length).toBe(
+      new Set(detail.selectedIds).size,
+    );
+  });
+
   it("fires for Ctrl+Shift+End range-extend", async () => {
     const onSelectChange = vi.fn();
     render(TreeViewSelectionChange, {


### PR DESCRIPTION
Ctrl+A select-all and Ctrl+Shift+Home/End range-extend concat new
node ids onto the existing selectedIds without deduping, so an
already-selected id ends up twice in the bound array.