### PR TITLE
fix(menu-item): prevent ArrowLeft from scrolling page on submenu close

### DIFF
--- a/src/ContentSwitcher/ContentSwitcher.svelte
+++ b/src/ContentSwitcher/ContentSwitcher.svelte
@@ -228,8 +228,15 @@
         .map((s) => document.getElementById(s.id))
         .filter((el) => el instanceof HTMLElement),
     getActiveIndex: () => (focusedIndex >= 0 ? focusedIndex : currentIndex),
-    onMove: (index) =>
-      selectionMode === "manual" ? focusTo(index) : changeTo(index),
+    onMove: (index, event) => {
+      // Prevent the arrow keys from also scrolling the page.
+      event.preventDefault();
+      if (selectionMode === "manual") {
+        focusTo(index);
+      } else {
+        changeTo(index);
+      }
+    },
   }}
   class:bx--content-switcher={true}
   class:bx--content-switcher--sm={size === "sm"}

--- a/src/Menu/MenuItem.svelte
+++ b/src/Menu/MenuItem.svelte
@@ -269,6 +269,7 @@
       {labelText}
       on:keydown={(event) => {
         if (event.key === "ArrowLeft") {
+          event.preventDefault();
           event.stopPropagation();
           submenuOpen = false;
           ref?.focus({ preventScroll: true });

--- a/src/Slider/RangeSlider.svelte
+++ b/src/Slider/RangeSlider.svelte
@@ -248,6 +248,8 @@
     if (disabled || readonly) return;
 
     if (event.key === "Home" || event.key === "End") {
+      // Prevent the browser from also scrolling to the top/bottom of the page.
+      event.preventDefault();
       if (activeHandle === "lower") {
         value = event.key === "Home" ? min : valueUpper;
       } else {
@@ -267,6 +269,8 @@
     };
     const dir = keys[event.key];
     if (!dir) return;
+    // Prevent the arrow keys from also scrolling the page.
+    event.preventDefault();
     const range = max - min;
     const delta =
       step * (event.shiftKey ? range / step / stepMultiplier : 1) * dir;

--- a/src/Slider/Slider.svelte
+++ b/src/Slider/Slider.svelte
@@ -271,6 +271,8 @@
           if (disabled || readonly) return;
 
           if (event.key === "Home" || event.key === "End") {
+            // Prevent the browser from also scrolling to the top/bottom of the page.
+            event.preventDefault();
             value = event.key === "Home" ? min : max;
             dispatch("input", value);
             dispatch("change", value);
@@ -284,6 +286,8 @@
             ArrowUp: 1,
           };
           if (keys[event.key]) {
+            // Prevent the arrow keys from also scrolling the page.
+            event.preventDefault();
             const delta =
               step *
               (event.shiftKey ? range / step / stepMultiplier : 1) *

--- a/src/Tabs/Tabs.svelte
+++ b/src/Tabs/Tabs.svelte
@@ -453,8 +453,15 @@
       orientation: "horizontal",
       skipDisabled: true,
       getActiveIndex: () => (focusedIndex >= 0 ? focusedIndex : currentIndex),
-      onMove: (index) =>
-        activation === "manual" ? focusTab(index) : selectTab(index),
+      onMove: (index, event) => {
+        // Prevent the arrow keys from also scrolling the page.
+        event.preventDefault();
+        if (activation === "manual") {
+          focusTab(index);
+        } else {
+          selectTab(index);
+        }
+      },
     }}
     class:bx--tabs__nav={true}
     on:scroll={updateOverflow}

--- a/tests/ContentSwitcher/ContentSwitcher.test.ts
+++ b/tests/ContentSwitcher/ContentSwitcher.test.ts
@@ -153,6 +153,22 @@ describe("ContentSwitcher", () => {
     expect(tabs[2]).toHaveClass("bx--content-switcher--selected");
   });
 
+  it("prevents ArrowRight's default action (page scroll) when moving focus", async () => {
+    render(ContentSwitcher);
+
+    const tabs = screen.getAllByRole("tab");
+    await user.tab();
+
+    const event = new KeyboardEvent("keydown", {
+      key: "ArrowRight",
+      bubbles: true,
+      cancelable: true,
+    });
+    tabs[0].dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(true);
+  });
+
   it("handles keyboard navigation", async () => {
     render(ContentSwitcher);
 

--- a/tests/Menu/MenuItem.test.ts
+++ b/tests/Menu/MenuItem.test.ts
@@ -153,6 +153,24 @@ describe("MenuItem", () => {
       expect(screen.getByRole("menuitem", { name: "Export as" })).toHaveFocus();
     });
 
+    it("prevents ArrowLeft's default action (page scroll) when closing the submenu", async () => {
+      render(MenuItemFixture);
+
+      await user.click(screen.getByRole("button", { name: "Trigger" }));
+      screen.getByRole("menuitem", { name: "Export as" }).focus();
+      await user.keyboard("{ArrowRight}");
+
+      const submenuItem = screen.getByRole("menuitem", { name: "PDF" });
+      const event = new KeyboardEvent("keydown", {
+        key: "ArrowLeft",
+        bubbles: true,
+        cancelable: true,
+      });
+      submenuItem.dispatchEvent(event);
+
+      expect(event.defaultPrevented).toBe(true);
+    });
+
     it("skips a disabled nested item during arrow key navigation", async () => {
       render(MenuItemFixture);
 

--- a/tests/Slider/RangeSlider.test.ts
+++ b/tests/Slider/RangeSlider.test.ts
@@ -92,6 +92,22 @@ describe("RangeSlider", () => {
     expect(upperThumb).toHaveAttribute("aria-valuenow", "50");
   });
 
+  it("prevents arrow/Home/End default actions (page scroll) while dragging a thumb", () => {
+    render(RangeSlider);
+
+    const [lowerThumb] = screen.getAllByRole("slider");
+
+    for (const key of ["ArrowRight", "Home", "End"]) {
+      const event = new KeyboardEvent("keydown", {
+        key,
+        bubbles: true,
+        cancelable: true,
+      });
+      lowerThumb.dispatchEvent(event);
+      expect(event.defaultPrevented).toBe(true);
+    }
+  });
+
   it("should jump the lower thumb to min/End clamped to upper via Home and End", async () => {
     render(RangeSlider, {
       props: { value: 40, valueUpper: 60, min: 0, max: 100 },

--- a/tests/Slider/Slider.test.ts
+++ b/tests/Slider/Slider.test.ts
@@ -79,6 +79,22 @@ describe("Slider", () => {
     expect(consoleLog).toHaveBeenCalledWith("change", 0);
   });
 
+  it("prevents arrow/Home/End default actions (page scroll) while dragging the thumb", () => {
+    render(Slider);
+
+    const slider = screen.getByRole("slider");
+
+    for (const key of ["ArrowRight", "Home", "End"]) {
+      const event = new KeyboardEvent("keydown", {
+        key,
+        bubbles: true,
+        cancelable: true,
+      });
+      slider.dispatchEvent(event);
+      expect(event.defaultPrevented).toBe(true);
+    }
+  });
+
   it("should jump to min and max with Home and End", async () => {
     render(Slider, { props: { value: 50, min: 0, max: 100 } });
 

--- a/tests/Tabs/Tabs.test.ts
+++ b/tests/Tabs/Tabs.test.ts
@@ -140,6 +140,22 @@ describe("Tabs", () => {
     expect(consoleLog).toHaveBeenCalledWith("change event", 0);
   });
 
+  it("prevents ArrowRight's default action (page scroll) when moving focus", async () => {
+    render(Tabs);
+
+    const tab1 = screen.getByRole("tab", { name: "Tab 1" });
+    await user.click(tab1);
+
+    const event = new KeyboardEvent("keydown", {
+      key: "ArrowRight",
+      bubbles: true,
+      cancelable: true,
+    });
+    tab1.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(true);
+  });
+
   it("supports Home/End keyboard navigation", async () => {
     render(Tabs);
 

--- a/tests/TreeView/TreeViewSelectionChange.test.ts
+++ b/tests/TreeView/TreeViewSelectionChange.test.ts
@@ -164,9 +164,7 @@ describe("TreeView select:change", () => {
     await vi.waitFor(() => expect(onSelectChange).toHaveBeenCalledTimes(1));
     const detail = lastDetail(onSelectChange);
     expect([...detail.selectedIds].sort()).toEqual([0, 1, 7, 9]);
-    expect(detail.selectedIds.length).toBe(
-      new Set(detail.selectedIds).size,
-    );
+    expect(detail.selectedIds.length).toBe(new Set(detail.selectedIds).size);
   });
 
   it("fires for Ctrl+Shift+End range-extend", async () => {


### PR DESCRIPTION
Same class of bug across five components: keyboard navigation moved
focus or value but never called preventDefault, so the browser's
native arrow/Home/End scroll ran alongside it. Tabs and ContentSwitcher
share a rovingFocus gap that TabsVertical already had a fix for; Slider
and RangeSlider had no preventDefault at all on their custom
role="slider" thumbs.