### PR TITLE
chore(deps): upgrade sveld to 0.36.2

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -26,7 +26,7 @@
         "jsdom": "^30.0.1",
         "lightningcss": "^1.33.0",
         "sass-embedded": "^1.100.0",
-        "sveld": "^0.36.1",
+        "sveld": "^0.36.2",
         "svelte": "^5.56.8",
         "svelte-check": "^4.7.3",
         "typescript": "^6.0.3",
@@ -478,7 +478,7 @@
 
     "supports-color": ["supports-color@8.1.1", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q=="],
 
-    "sveld": ["sveld@0.36.1", "", { "bin": { "sveld": "cli.js" } }, "sha512-XlbQuZza6oVkKGVEm1l/hit5BQLmZMeOb4WrsOB87bq7xaTSg7UywScgKB4aZlqF13izdwn2hN6vLFykbV6S4A=="],
+    "sveld": ["sveld@0.36.2", "", { "bin": { "sveld": "cli.js" } }, "sha512-/0iQRfGTL/9hQyR7MVPr0lM5ZpETFVPUuHJo4eQKYsA3dVn94/tPzFUgwpBiPXIrnb1CI8Euewk9fOBi3cPPOA=="],
 
     "svelte": ["svelte@5.56.8", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "@jridgewell/sourcemap-codec": "^1.5.0", "@sveltejs/acorn-typescript": "^1.0.10", "@types/estree": "^1.0.5", "@types/trusted-types": "^2.0.7", "acorn": "^8.12.1", "aria-query": "5.3.1", "axobject-query": "^4.1.0", "clsx": "^2.1.1", "devalue": "^5.8.1", "esm-env": "^1.2.1", "esrap": "^2.2.12", "is-reference": "^3.0.3", "locate-character": "^3.0.0", "magic-string": "^0.30.11", "zimmerframe": "^1.1.2" } }, "sha512-PY8LOw7xP6c8IOiVqdo0sbbZVYhXRSfklOQLAUyGBKqjTX0wx/z4l/9J+PmBpmlLnxzEb1NqltxQ5/wZme/Cmg=="],
 

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "jsdom": "^30.0.1",
     "lightningcss": "^1.33.0",
     "sass-embedded": "^1.100.0",
-    "sveld": "^0.36.1",
+    "sveld": "^0.36.2",
     "svelte": "^5.56.8",
     "svelte-check": "^4.7.3",
     "typescript": "^6.0.3",

--- a/src/ComboBox/ComboBox.svelte
+++ b/src/ComboBox/ComboBox.svelte
@@ -162,7 +162,6 @@
    * When `typeahead` is enabled and no custom function is provided,
    * the default case-insensitive prefix matching is used.
    * When a custom function is provided, it is used even with `typeahead`.
-   * @default () => true
    * @type {(item: Item, value: string) => boolean}
    */
   function defaultShouldFilter() {


### PR DESCRIPTION
Bumps the dev dependency from 0.36.1. Verified `bun run build:docs`
still generates TypeScript definitions and COMPONENT_API.json cleanly
with no output diffs.