### PR TITLE
fix(dropdown): guard highlighted item lookup when items change while open

### DIFF
--- a/src/Dropdown/Dropdown.svelte
+++ b/src/Dropdown/Dropdown.svelte
@@ -241,6 +241,7 @@
   let highlightedIndex = -1;
   let highlightOrigin = /** @type {"keyboard" | "pointer" | null} */ (null);
   let prevHighlightedIndex = -1;
+  let prevItemsLength = items.length;
   let typeaheadBuffer = "";
   let listScrollTop = 0;
   let prevOpen = false;
@@ -290,6 +291,17 @@
     prevHighlightedIndex = -1;
     typeaheadBuffer = "";
     resetTypeaheadBuffer.cancel();
+  }
+
+  // Clamp a stale highlight when `items` shrinks while the menu is open, so a
+  // keyboard-driven Enter/Space cannot dereference an index past the end.
+  $: if (items.length !== prevItemsLength) {
+    prevItemsLength = items.length;
+    if (highlightedIndex >= items.length) {
+      highlightedIndex = -1;
+      highlightOrigin = null;
+      prevHighlightedIndex = -1;
+    }
   }
 
   $: shouldVirtualize =
@@ -480,20 +492,16 @@
       open = true;
       return;
     }
+    const highlighted =
+      highlightOrigin === "keyboard" && highlightedIndex > -1
+        ? items[highlightedIndex]
+        : undefined;
     // Enter/Space on a highlighted disabled option -> the menu stays open.
-    if (
-      highlightOrigin === "keyboard" &&
-      highlightedIndex > -1 &&
-      items[highlightedIndex]?.disabled
-    ) {
+    if (highlighted?.disabled) {
       return;
     }
-    if (
-      highlightOrigin === "keyboard" &&
-      highlightedIndex > -1 &&
-      items[highlightedIndex].id !== selectedId
-    ) {
-      selectedId = items[highlightedIndex].id;
+    if (highlighted && highlighted.id !== selectedId) {
+      selectedId = highlighted.id;
       dispatchSelect();
       close("select");
     } else {

--- a/tests/Dropdown/DropdownItemsChange.test.svelte
+++ b/tests/Dropdown/DropdownItemsChange.test.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  import Dropdown from "carbon-components-svelte/Dropdown/Dropdown.svelte";
+  import type { ComponentProps } from "svelte";
+
+  export let items: ComponentProps<Dropdown>["items"] = [];
+  export let open: ComponentProps<Dropdown>["open"] = false;
+  export let selectedId: ComponentProps<Dropdown>["selectedId"] = undefined;
+  export let onSelect: (e: CustomEvent) => void = () => {};
+</script>
+
+<Dropdown
+  {items}
+  bind:open
+  bind:selectedId
+  labelText="Contact"
+  portalMenu={false}
+  on:select={onSelect}
+/>

--- a/tests/Dropdown/DropdownItemsChange.test.ts
+++ b/tests/Dropdown/DropdownItemsChange.test.ts
@@ -1,0 +1,49 @@
+import { fireEvent, render, screen } from "@testing-library/svelte";
+import { tick } from "svelte";
+import DropdownItemsChange from "./DropdownItemsChange.test.svelte";
+
+function createItems(count: number) {
+  return Array.from({ length: count }, (_, i) => ({
+    id: String(i),
+    text: `Item ${i + 1}`,
+  }));
+}
+
+describe("Dropdown items change while open", () => {
+  it("does not throw and leaves selection unchanged when Enter is pressed after items shrink past the highlighted index", async () => {
+    const onSelect = vi.fn();
+    const onError = vi.fn();
+    window.addEventListener("error", onError);
+
+    const { rerender } = render(DropdownItemsChange, {
+      props: {
+        items: createItems(10),
+        open: false,
+        onSelect,
+      },
+    });
+
+    const trigger = screen.getByRole("combobox");
+    await fireEvent.click(trigger);
+
+    for (let i = 0; i < 6; i++) {
+      // biome-ignore lint/performance/noAwaitInLoops: sequential execution is intentional
+      await fireEvent.keyDown(trigger, { key: "ArrowDown" });
+    }
+    expect(trigger).toHaveAttribute(
+      "aria-activedescendant",
+      expect.stringContaining("-5"),
+    );
+
+    await rerender({ items: createItems(3), open: true, onSelect });
+    await tick();
+
+    await fireEvent.keyDown(trigger, { key: "Enter" });
+    await tick();
+
+    window.removeEventListener("error", onError);
+
+    expect(onError).not.toHaveBeenCalled();
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Enter/Space in `Dropdown` dereferenced `items[highlightedIndex]` without a bounds check. When a consumer replaces `items` with a shorter array while the menu is open and keyboard-highlighted past the new end, pressing Enter threw `TypeError: Cannot read properties of undefined (reading 'id')` and left the menu stuck open.
- Hoists the lookup into a single guarded `highlighted` value (matching the existing guarded pattern already used a few lines above for `highlightedId`), and adds a reactive clamp that resets `highlightedIndex`/`highlightOrigin` when `items.length` changes and the index no longer points at a valid item.
- `ComboBox` and `MultiSelect` were reviewed for the same class of bug; both already guard the dereference with optional chaining, so a stale index there safely no-ops rather than throwing — no change needed.

## Test plan
- [x] `bun run test DropdownItemsChange` — new regression test; verified it fails with the original `TypeError` when the fix is reverted
- [x] `bun run test Dropdown ComboBox MultiSelect` — 535 passed
- [x] `bun run lint:changed`