### PR TITLE
fix(slider): guard thumb position when min equals max

### DIFF
--- a/src/Slider/Slider.svelte
+++ b/src/Slider/Slider.svelte
@@ -183,7 +183,7 @@
   $: showInvalid = invalid && !disabled && !readonly;
   $: showWarn = warn && !invalid && !disabled && !readonly;
   $: range = max - min;
-  $: left = ((value - min) / range) * 100;
+  $: left = range === 0 ? 0 : ((value - min) / range) * 100;
   $: resolvedMarks = resolveSliderMarks(marks, min, max, step);
   $: hasMarkLabels = resolvedMarks.some(
     (mark) => mark.label != null && mark.label !== "",

--- a/tests/Slider/Slider.test.ts
+++ b/tests/Slider/Slider.test.ts
@@ -125,6 +125,19 @@ describe("Slider", () => {
     expect(screen.getByText("990 MB")).toBeInTheDocument();
   });
 
+  it("should pin the thumb at a defined position when min equals max", () => {
+    render(Slider, {
+      props: {
+        min: 10,
+        max: 10,
+        value: 10,
+      },
+    });
+
+    const slider = screen.getByRole("slider");
+    expect(slider.style.left).toBe("0%");
+  });
+
   it("should handle hidden text input", () => {
     render(Slider, {
       props: { hideTextInput: true },


### PR DESCRIPTION
## Summary
- `$: left = ((value - min) / range) * 100` divides by `range` (`max - min`) with no guard, so a degenerate `min === max` config (reachable whenever the range is data-driven) produces `NaN%`. Invalid CSS gets dropped by the browser, so the thumb's inline `left` ends up as an empty string and it falls back to the track origin instead of a defined position.
- `RangeSlider` and the marks calculation in this same file already guard the identical expression (`range === 0 ? 0 : ...`); this brings the thumb position calculation in line with both.

## Test plan
- [x] `bun run test Slider` — new boundary test added for `min === max`; verified it fails (`expected '' to be '0%'`) against the original code
- [x] `bun run lint:changed`