### PR TITLE
fix(tooltip): update previous-state guard before dispatching

### DIFF
--- a/src/CodeSnippet/CodeSnippet.svelte
+++ b/src/CodeSnippet/CodeSnippet.svelte
@@ -335,8 +335,9 @@
   $: showExpandButton = showMoreLess && type === "multi" && exceedsThreshold;
 
   $: if (type === "multi" && prevExpanded !== expanded) {
-    dispatch(expanded ? "expand" : "collapse");
+    const nextExpanded = expanded;
     prevExpanded = expanded;
+    dispatch(nextExpanded ? "expand" : "collapse");
   }
 
   let disconnectModalObserver = () => {};

--- a/src/Search/Search.svelte
+++ b/src/Search/Search.svelte
@@ -96,8 +96,9 @@
   $: isFluid = !expandable && (fluid || !!formContext?.isFluid);
   $: if (expanded && ref) ref.focus();
   $: if (expanded !== prevExpanded) {
-    dispatch(expanded ? "expand" : "collapse");
+    const nextExpanded = expanded;
     prevExpanded = expanded;
+    dispatch(nextExpanded ? "expand" : "collapse");
   }
 </script>
 

--- a/src/Toggletip/Toggletip.svelte
+++ b/src/Toggletip/Toggletip.svelte
@@ -192,8 +192,10 @@
     }
   }
   $: {
-    if (prevOpen !== undefined) dispatch(open ? "open" : "close");
+    const shouldDispatch = prevOpen !== undefined;
+    const nextOpen = open;
     prevOpen = open;
+    if (shouldDispatch) dispatch(nextOpen ? "open" : "close");
   }
 
   onMount(() => {

--- a/src/Tooltip/Tooltip.svelte
+++ b/src/Tooltip/Tooltip.svelte
@@ -261,10 +261,12 @@
   $: tooltipOpen.set(open);
   $: if (!open) openedByHover.set(false);
   $: {
-    if (prevOpen !== undefined) {
-      dispatch(open ? "open" : "close");
-    }
+    const shouldDispatch = prevOpen !== undefined;
+    const nextOpen = open;
     prevOpen = open;
+    if (shouldDispatch) {
+      dispatch(nextOpen ? "open" : "close");
+    }
   }
   $: buttonProps = {
     role: "button",

--- a/src/TooltipDefinition/TooltipDefinition.svelte
+++ b/src/TooltipDefinition/TooltipDefinition.svelte
@@ -103,10 +103,12 @@
   let isInitialRender = true;
 
   $: {
-    if (!isInitialRender) {
-      dispatch(open ? "open" : "close");
-    }
+    const shouldDispatch = !isInitialRender;
+    const nextOpen = open;
     isInitialRender = false;
+    if (shouldDispatch) {
+      dispatch(nextOpen ? "open" : "close");
+    }
   }
 
   onMount(() => {

--- a/src/TooltipIcon/TooltipIcon.svelte
+++ b/src/TooltipIcon/TooltipIcon.svelte
@@ -137,10 +137,12 @@
   }
 
   $: {
-    if (!isInitialRender) {
-      dispatch(open ? "open" : "close");
-    }
+    const shouldDispatch = !isInitialRender;
+    const nextOpen = open;
     isInitialRender = false;
+    if (shouldDispatch) {
+      dispatch(nextOpen ? "open" : "close");
+    }
   }
 
   $: portalOpen =

--- a/tests/CodeSnippet/CodeSnippetDispatchGuard.test.svelte
+++ b/tests/CodeSnippet/CodeSnippetDispatchGuard.test.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  import CodeSnippet from "carbon-components-svelte/CodeSnippet/CodeSnippet.svelte";
+  import type { ComponentProps } from "svelte";
+
+  export let expanded: ComponentProps<CodeSnippet>["expanded"] = false;
+  export let onExpand: () => void = () => {};
+  export let onCollapse: () => void = () => {};
+</script>
+
+<CodeSnippet
+  type="multi"
+  bind:expanded
+  code={`node -v
+npm -v`}
+  on:expand={onExpand}
+  on:collapse={onCollapse}
+/>

--- a/tests/CodeSnippet/CodeSnippetDispatchGuard.test.ts
+++ b/tests/CodeSnippet/CodeSnippetDispatchGuard.test.ts
@@ -1,0 +1,61 @@
+import { render, screen } from "@testing-library/svelte";
+import {
+  absorbUnhandledRejection,
+  flushRejectionQueue,
+  isConsumerBoom,
+} from "../utils/absorb-unhandled-rejection";
+import {
+  mockSnippetOverflowHeight,
+  waitForSnippetMeasurement,
+} from "../utils/mockSnippetOverflowHeight";
+import { user } from "../utils/user";
+import CodeSnippetDispatchGuard from "./CodeSnippetDispatchGuard.test.svelte";
+
+describe("CodeSnippet dispatch guard", () => {
+  it("updates the previous-expanded guard before dispatching, so a throwing on:expand handler does not prevent the dispatch itself from firing exactly once", async () => {
+    mockSnippetOverflowHeight();
+    const onExpand = vi.fn(() => {
+      throw new Error("consumer boom");
+    });
+    const onCollapse = vi.fn();
+    const trap = absorbUnhandledRejection(isConsumerBoom);
+
+    render(CodeSnippetDispatchGuard, {
+      props: { expanded: false, onExpand, onCollapse },
+    });
+    await waitForSnippetMeasurement();
+
+    const showMoreButton = await screen.findByText("Show more");
+
+    try {
+      await user.click(showMoreButton);
+    } catch {
+      // Framework-version-dependent: some Svelte versions surface this
+      // synchronously here, others only via absorbUnhandledRejection below.
+    }
+    await Promise.race([trap.wait, flushRejectionQueue()]);
+    trap.dispose();
+
+    expect(onExpand).toHaveBeenCalledTimes(1);
+  });
+
+  it("dispatches expand then collapse in order across a full cycle", async () => {
+    mockSnippetOverflowHeight();
+    const onExpand = vi.fn();
+    const onCollapse = vi.fn();
+
+    render(CodeSnippetDispatchGuard, {
+      props: { expanded: false, onExpand, onCollapse },
+    });
+    await waitForSnippetMeasurement();
+
+    const showMoreButton = await screen.findByText("Show more");
+    await user.click(showMoreButton);
+    expect(onExpand).toHaveBeenCalledTimes(1);
+    expect(onCollapse).not.toHaveBeenCalled();
+
+    const showLessButton = screen.getByText("Show less");
+    await user.click(showLessButton);
+    expect(onCollapse).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/Search/SearchDispatchGuard.test.svelte
+++ b/tests/Search/SearchDispatchGuard.test.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  import Search from "carbon-components-svelte/Search/Search.svelte";
+  import type { ComponentProps } from "svelte";
+
+  export let expanded: ComponentProps<Search>["expanded"] = false;
+  export let onExpand: () => void = () => {};
+  export let onCollapse: () => void = () => {};
+</script>
+
+<Search
+  expandable
+  bind:expanded
+  labelText="Search"
+  placeholder="Search"
+  closeButtonLabelText="Clear"
+  on:expand={onExpand}
+  on:collapse={onCollapse}
+/>

--- a/tests/Search/SearchDispatchGuard.test.ts
+++ b/tests/Search/SearchDispatchGuard.test.ts
@@ -1,0 +1,52 @@
+import { fireEvent, render, screen } from "@testing-library/svelte";
+import {
+  absorbUnhandledRejection,
+  flushRejectionQueue,
+  isConsumerBoom,
+} from "../utils/absorb-unhandled-rejection";
+import SearchDispatchGuard from "./SearchDispatchGuard.test.svelte";
+
+describe("Search dispatch guard", () => {
+  it("updates the previous-expanded guard before dispatching, so a throwing on:expand handler does not prevent the dispatch itself from firing exactly once", async () => {
+    const onExpand = vi.fn(() => {
+      throw new Error("consumer boom");
+    });
+    const onCollapse = vi.fn();
+    const trap = absorbUnhandledRejection(isConsumerBoom);
+
+    render(SearchDispatchGuard, {
+      props: { expanded: false, onExpand, onCollapse },
+    });
+
+    const input = screen.getByRole("searchbox");
+
+    try {
+      await fireEvent.focus(input);
+    } catch {
+      // Framework-version-dependent: some Svelte versions surface this
+      // synchronously here, others only via absorbUnhandledRejection below.
+    }
+    await Promise.race([trap.wait, flushRejectionQueue()]);
+    trap.dispose();
+
+    expect(onExpand).toHaveBeenCalledTimes(1);
+  });
+
+  it("dispatches expand then collapse in order across a full cycle", async () => {
+    const onExpand = vi.fn();
+    const onCollapse = vi.fn();
+
+    render(SearchDispatchGuard, {
+      props: { expanded: false, onExpand, onCollapse },
+    });
+
+    const input = screen.getByRole("searchbox");
+
+    await fireEvent.focus(input);
+    expect(onExpand).toHaveBeenCalledTimes(1);
+    expect(onCollapse).not.toHaveBeenCalled();
+
+    await fireEvent.blur(input);
+    expect(onCollapse).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/Toggletip/ToggletipDispatchGuard.test.svelte
+++ b/tests/Toggletip/ToggletipDispatchGuard.test.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  import Toggletip from "carbon-components-svelte/Toggletip/Toggletip.svelte";
+  import type { ComponentProps } from "svelte";
+
+  export let open: ComponentProps<Toggletip>["open"] = false;
+  export let onOpen: () => void = () => {};
+  export let onClose: () => void = () => {};
+</script>
+
+<Toggletip
+  bind:open
+  iconDescription="Information"
+  on:open={onOpen}
+  on:close={onClose}
+>
+  <p>Content</p>
+</Toggletip>

--- a/tests/Toggletip/ToggletipDispatchGuard.test.ts
+++ b/tests/Toggletip/ToggletipDispatchGuard.test.ts
@@ -1,0 +1,53 @@
+import { render, screen } from "@testing-library/svelte";
+import {
+  absorbUnhandledRejection,
+  flushRejectionQueue,
+  isConsumerBoom,
+} from "../utils/absorb-unhandled-rejection";
+import { user } from "../utils/user";
+import ToggletipDispatchGuard from "./ToggletipDispatchGuard.test.svelte";
+
+describe("Toggletip dispatch guard", () => {
+  it("updates the previous-open guard before dispatching, so a throwing on:open handler does not prevent the dispatch itself from firing exactly once", async () => {
+    const onOpen = vi.fn(() => {
+      throw new Error("consumer boom");
+    });
+    const onClose = vi.fn();
+    const trap = absorbUnhandledRejection(isConsumerBoom);
+
+    render(ToggletipDispatchGuard, {
+      props: { open: false, onOpen, onClose },
+    });
+
+    const trigger = screen.getByRole("button", { name: "Information" });
+
+    try {
+      await user.click(trigger);
+    } catch {
+      // Framework-version-dependent: some Svelte versions surface this
+      // synchronously here, others only via absorbUnhandledRejection below.
+    }
+    await Promise.race([trap.wait, flushRejectionQueue()]);
+    trap.dispose();
+
+    expect(onOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it("dispatches open then close in order across a full cycle", async () => {
+    const onOpen = vi.fn();
+    const onClose = vi.fn();
+
+    render(ToggletipDispatchGuard, {
+      props: { open: false, onOpen, onClose },
+    });
+
+    const trigger = screen.getByRole("button", { name: "Information" });
+
+    await user.click(trigger);
+    expect(onOpen).toHaveBeenCalledTimes(1);
+    expect(onClose).not.toHaveBeenCalled();
+
+    await user.click(trigger);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/Tooltip/TooltipDispatchGuard.test.svelte
+++ b/tests/Tooltip/TooltipDispatchGuard.test.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  import Tooltip from "carbon-components-svelte/Tooltip/Tooltip.svelte";
+  import type { ComponentProps } from "svelte";
+
+  export let open: ComponentProps<Tooltip>["open"] = false;
+  export let onOpen: () => void = () => {};
+  export let onClose: () => void = () => {};
+</script>
+
+<Tooltip
+  bind:open
+  iconDescription="Information"
+  on:open={onOpen}
+  on:close={onClose}
+>
+  Content
+</Tooltip>

--- a/tests/Tooltip/TooltipDispatchGuard.test.ts
+++ b/tests/Tooltip/TooltipDispatchGuard.test.ts
@@ -1,0 +1,61 @@
+import { fireEvent, render, screen } from "@testing-library/svelte";
+import {
+  absorbUnhandledRejection,
+  flushRejectionQueue,
+  isConsumerBoom,
+} from "../utils/absorb-unhandled-rejection";
+import TooltipDispatchGuard from "./TooltipDispatchGuard.test.svelte";
+
+describe("Tooltip dispatch guard", () => {
+  it("updates the previous-open guard before dispatching, so a throwing on:open handler does not prevent the dispatch itself from firing exactly once", async () => {
+    const onOpen = vi.fn(() => {
+      throw new Error("consumer boom");
+    });
+    const onClose = vi.fn();
+    const trap = absorbUnhandledRejection(isConsumerBoom);
+
+    vi.useFakeTimers();
+    render(TooltipDispatchGuard, {
+      props: { open: false, onOpen, onClose },
+    });
+
+    const trigger = screen.getByRole("button");
+
+    try {
+      await fireEvent.mouseEnter(trigger);
+      await vi.advanceTimersByTimeAsync(100);
+    } catch {
+      // Framework-version-dependent: some Svelte versions surface this
+      // synchronously here, others only via absorbUnhandledRejection below.
+    }
+    // Real timers so `flushRejectionQueue`'s setImmediate can actually fire;
+    // fake timers leave it (and thus this whole race) hanging.
+    vi.useRealTimers();
+    await Promise.race([trap.wait, flushRejectionQueue()]);
+    trap.dispose();
+
+    expect(onOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it("dispatches open then close in order across a full cycle", async () => {
+    vi.useFakeTimers();
+    const onOpen = vi.fn();
+    const onClose = vi.fn();
+
+    render(TooltipDispatchGuard, {
+      props: { open: false, onOpen, onClose },
+    });
+
+    const trigger = screen.getByRole("button");
+    await fireEvent.mouseEnter(trigger);
+    await vi.advanceTimersByTimeAsync(100);
+    expect(onOpen).toHaveBeenCalledTimes(1);
+    expect(onClose).not.toHaveBeenCalled();
+
+    const tooltip = screen.getByRole("dialog");
+    await fireEvent.keyDown(tooltip, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    vi.useRealTimers();
+  });
+});

--- a/tests/TooltipDefinition/TooltipDefinitionDispatchGuard.test.svelte
+++ b/tests/TooltipDefinition/TooltipDefinitionDispatchGuard.test.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  import TooltipDefinition from "carbon-components-svelte/TooltipDefinition/TooltipDefinition.svelte";
+  import type { ComponentProps } from "svelte";
+
+  export let open: ComponentProps<TooltipDefinition>["open"] = false;
+  export let onOpen: () => void = () => {};
+  export let onClose: () => void = () => {};
+</script>
+
+<TooltipDefinition
+  tooltipText="Test tooltip text"
+  bind:open
+  enterDelayMs={0}
+  leaveDelayMs={0}
+  on:open={onOpen}
+  on:close={onClose}
+>
+  Tooltip trigger
+</TooltipDefinition>

--- a/tests/TooltipDefinition/TooltipDefinitionDispatchGuard.test.ts
+++ b/tests/TooltipDefinition/TooltipDefinitionDispatchGuard.test.ts
@@ -1,0 +1,53 @@
+import { render, screen } from "@testing-library/svelte";
+import {
+  absorbUnhandledRejection,
+  flushRejectionQueue,
+  isConsumerBoom,
+} from "../utils/absorb-unhandled-rejection";
+import { user } from "../utils/user";
+import TooltipDefinitionDispatchGuard from "./TooltipDefinitionDispatchGuard.test.svelte";
+
+describe("TooltipDefinition dispatch guard", () => {
+  it("does not prevent the dispatch itself from firing exactly once when on:open throws", async () => {
+    const onOpen = vi.fn(() => {
+      throw new Error("consumer boom");
+    });
+    const onClose = vi.fn();
+    const trap = absorbUnhandledRejection(isConsumerBoom);
+
+    render(TooltipDefinitionDispatchGuard, {
+      props: { open: false, onOpen, onClose },
+    });
+
+    const trigger = screen.getByText("Tooltip trigger");
+
+    try {
+      await user.hover(trigger);
+    } catch {
+      // Framework-version-dependent: some Svelte versions surface this
+      // synchronously here, others only via absorbUnhandledRejection below.
+    }
+    await Promise.race([trap.wait, flushRejectionQueue()]);
+    trap.dispose();
+
+    expect(onOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it("dispatches open then close in order across a full cycle", async () => {
+    const onOpen = vi.fn();
+    const onClose = vi.fn();
+
+    render(TooltipDefinitionDispatchGuard, {
+      props: { open: false, onOpen, onClose },
+    });
+
+    const trigger = screen.getByText("Tooltip trigger");
+
+    await user.hover(trigger);
+    expect(onOpen).toHaveBeenCalledTimes(1);
+    expect(onClose).not.toHaveBeenCalled();
+
+    await user.unhover(trigger);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/TooltipIcon/TooltipIconDispatchGuard.test.svelte
+++ b/tests/TooltipIcon/TooltipIconDispatchGuard.test.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  import TooltipIcon from "carbon-components-svelte/TooltipIcon/TooltipIcon.svelte";
+  import Carbon from "carbon-icons-svelte/lib/Carbon.svelte";
+  import type { ComponentProps } from "svelte";
+
+  export let open: ComponentProps<TooltipIcon>["open"] = false;
+  export let onOpen: () => void = () => {};
+  export let onClose: () => void = () => {};
+</script>
+
+<TooltipIcon
+  tooltipText="Test tooltip text"
+  bind:open
+  icon={Carbon}
+  enterDelayMs={0}
+  leaveDelayMs={0}
+  on:open={onOpen}
+  on:close={onClose}
+/>

--- a/tests/TooltipIcon/TooltipIconDispatchGuard.test.ts
+++ b/tests/TooltipIcon/TooltipIconDispatchGuard.test.ts
@@ -1,0 +1,53 @@
+import { render, screen } from "@testing-library/svelte";
+import {
+  absorbUnhandledRejection,
+  flushRejectionQueue,
+  isConsumerBoom,
+} from "../utils/absorb-unhandled-rejection";
+import { user } from "../utils/user";
+import TooltipIconDispatchGuard from "./TooltipIconDispatchGuard.test.svelte";
+
+describe("TooltipIcon dispatch guard", () => {
+  it("does not prevent the dispatch itself from firing exactly once when on:open throws", async () => {
+    const onOpen = vi.fn(() => {
+      throw new Error("consumer boom");
+    });
+    const onClose = vi.fn();
+    const trap = absorbUnhandledRejection(isConsumerBoom);
+
+    render(TooltipIconDispatchGuard, {
+      props: { open: false, onOpen, onClose },
+    });
+
+    const trigger = screen.getByRole("button");
+
+    try {
+      await user.hover(trigger);
+    } catch {
+      // Framework-version-dependent: some Svelte versions surface this
+      // synchronously here, others only via absorbUnhandledRejection below.
+    }
+    await Promise.race([trap.wait, flushRejectionQueue()]);
+    trap.dispose();
+
+    expect(onOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it("dispatches open then close in order across a full cycle", async () => {
+    const onOpen = vi.fn();
+    const onClose = vi.fn();
+
+    render(TooltipIconDispatchGuard, {
+      props: { open: false, onOpen, onClose },
+    });
+
+    const trigger = screen.getByRole("button");
+
+    await user.hover(trigger);
+    expect(onOpen).toHaveBeenCalledTimes(1);
+    expect(onClose).not.toHaveBeenCalled();
+
+    await user.unhover(trigger);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/utils/absorb-unhandled-rejection.ts
+++ b/tests/utils/absorb-unhandled-rejection.ts
@@ -5,8 +5,12 @@ export function isConsumerBoom(reason: unknown): reason is Error {
 }
 
 /**
- * `tick().then(dispatch)` leaves consumer throws as unhandled rejections in
- * Vitest even when assertions pass. Prepend a listener before the update.
+ * A throw out of a consumer's dispatch handler can escape as either an
+ * `unhandledRejection` (e.g. `tick().then(dispatch)`, or Svelte 3/4's own
+ * internal `resolved_promise.then(flush)` scheduler, which is fire-and-forget)
+ * or a synchronous `uncaughtException` (observed for Svelte 5's scheduler),
+ * depending on framework version and call path. Prepend a listener for both
+ * before the update.
  */
 export function absorbUnhandledRejection(
   predicate: (reason: unknown) => boolean,
@@ -28,11 +32,24 @@ export function absorbUnhandledRejection(
   };
 
   process.prependListener("unhandledRejection", handler);
+  process.prependListener("uncaughtException", handler);
 
   return {
     wait,
     dispose() {
       process.off("unhandledRejection", handler);
+      process.off("uncaughtException", handler);
     },
   };
+}
+
+/**
+ * Yields to a real macrotask so Node's rejection-tracking check (which runs
+ * after the current tick) has a chance to fire before a listener is torn
+ * down. Framework versions that resolve the throw synchronously never emit
+ * anything for this to catch, so callers should race this against `wait`
+ * rather than awaiting `wait` unconditionally.
+ */
+export function flushRejectionQueue(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
 }


### PR DESCRIPTION
## Summary
- Six components dispatched `open`/`close` (or `expand`/`collapse`) *before* updating their internal `prev` guard: `CodeSnippet`, `Tooltip`, `TooltipDefinition`, `TooltipIcon`, `Toggletip`, `Search`. If a consumer's event handler throws, the guard assignment is skipped, permanently desyncing the component's event stream — a missed close, followed by a duplicate open on the next real toggle.
- Swaps the order in all six so the guard is committed before the dispatch is attempted, matching `Checkbox.svelte`'s existing correct reference pattern (`previousChecked = checked` before `dispatch`). Dispatches stay synchronous per `CONTRIBUTING.md` — no `tick().then()` deferral was introduced.
- `TooltipDefinition`/`TooltipIcon` use an `isInitialRender` latch rather than a `prevOpen` comparison. That pattern only needs to flip once (mount) and isn't actually exploitable the same way, but the swap was applied for consistency with the other four.

## Test plan
- [x] One new regression test per component (`*DispatchGuard.test.ts`), verifying (a) a throwing `on:open`/`on:expand` handler doesn't prevent the dispatch from firing exactly once, and (b) a full non-throwing open→close (or expand→collapse) cycle still dispatches correctly after the refactor.
  - Note: I could not reliably reproduce a live "open, close, open" *recovery* sequence through an actual thrown exception in this Svelte 5 + jsdom + vitest harness — once an uncaught exception escapes any effect during a flush, that component instance appears to stop processing further reactive updates entirely (confirmed this is pre-existing and equally present in `Checkbox.svelte`'s already-accepted reference implementation, not something introduced or worsened by this change). The tests above are the most reliable, honest coverage achievable here; this is documented for anyone digging into it in the future.
- [x] `bun run test Search Tooltip TooltipDefinition TooltipIcon Toggletip CodeSnippet` — 351 passed
- [x] `bun run lint:changed`