### PR TITLE
fix(utils): guard getVisibleRange against non-positive itemHeight

### DIFF
--- a/src/utils/virtualize.js
+++ b/src/utils/virtualize.js
@@ -19,6 +19,12 @@ export function getVisibleRange({
   overscan = 3,
   maxItems = undefined,
 }) {
+  // A non-positive (or NaN) itemHeight can't be virtualized; the math below
+  // divides by it and yields NaN indices, so fall back to the full range.
+  if (!(itemHeight > 0)) {
+    return { startIndex: 0, endIndex: itemCount };
+  }
+
   const startIndex = Math.max(0, Math.floor(scrollTop / itemHeight) - overscan);
   let endIndex = Math.min(
     itemCount,

--- a/tests/utils/virtualize.test.ts
+++ b/tests/utils/virtualize.test.ts
@@ -514,6 +514,15 @@ describe("getVisibleRange", () => {
       endIndex: 5,
     });
   });
+
+  test("falls back to the full range for a non-positive or NaN itemHeight", () => {
+    for (const itemHeight of [0, -1, Number.NaN]) {
+      expect(getVisibleRange({ ...base, itemHeight, scrollTop: 100 })).toEqual({
+        startIndex: 0,
+        endIndex: base.itemCount,
+      });
+    }
+  });
 });
 
 describe("getBoundedScrollTop", () => {


### PR DESCRIPTION
## Summary
- `getVisibleRange` divides `scrollTop`/`containerHeight` by `itemHeight` with no guard, producing `Infinity`/`NaN` indices when `itemHeight` is `0`, negative, or `NaN`.
- Not currently reachable from any component: the public `virtualize()` wrapper already guards this exact case (`itemHeight <= 0` → unvirtualized full list), and the only other internal caller always passes a positive `getMenuItemHeight(size)`. Still, `getVisibleRange` is separately exported and directly unit-tested, so it should carry its own defensive fallback rather than relying on callers to avoid the hazard.
- Mirrors the wrapper's existing fallback shape (`{ startIndex: 0, endIndex: itemCount }`).

## Test plan
- [x] `bun run test virtualize` — new boundary cases for `itemHeight` of `0`, `-1`, and `NaN`; verified they fail (`Infinity` startIndex) against the original code
- [x] `bun run test utils` — 438 passed
- [x] `bun run lint:changed`