### PR TITLE
fix(utils): handle empty palette in getAvatarBackgroundColor

### DIFF
--- a/src/utils/avatarColor.js
+++ b/src/utils/avatarColor.js
@@ -34,7 +34,8 @@ export function hashString(value) {
 
 /**
  * Pick a stable avatar background color from a string. Empty or falsy input
- * returns the first palette entry.
+ * returns the first palette entry. An empty `palette` falls back to the
+ * default palette so a `T` is always returned.
  *
  * @template {string} [T=AVATAR_BACKGROUND_COLORS[number]]
  * @param {string | null | undefined} value
@@ -45,6 +46,10 @@ export function getAvatarBackgroundColor(
   value,
   palette = /** @type {ReadonlyArray<T>} */ (AVATAR_BACKGROUND_COLORS),
 ) {
-  if (!value || palette.length === 0) return palette[0];
-  return palette[hashString(value) % palette.length];
+  const effectivePalette =
+    palette.length === 0
+      ? /** @type {ReadonlyArray<T>} */ (AVATAR_BACKGROUND_COLORS)
+      : palette;
+  if (!value) return effectivePalette[0];
+  return effectivePalette[hashString(value) % effectivePalette.length];
 }

--- a/tests/utils/avatarColor.test.ts
+++ b/tests/utils/avatarColor.test.ts
@@ -63,4 +63,11 @@ describe("getAvatarBackgroundColor", () => {
     const color = getAvatarBackgroundColor("anything", palette);
     expect(palette).toContain(color);
   });
+
+  test("falls back to the default palette for an empty palette", () => {
+    expect(AVATAR_BACKGROUND_COLORS).toContain(
+      getAvatarBackgroundColor("anything", []),
+    );
+    expect(getAvatarBackgroundColor("", [])).toBe(AVATAR_BACKGROUND_COLORS[0]);
+  });
 });


### PR DESCRIPTION
## Summary
- `if (!value || palette.length === 0) return palette[0];` returns `palette[0]` even when the caller explicitly passed an empty `palette`, which is `undefined` — contradicting the function's own `@returns {T}` contract. Downstream, `UserAvatar`'s `backgroundColor="auto"` would resolve to `undefined` and render with no background.
- Falls back to the default `AVATAR_BACKGROUND_COLORS` palette when the caller's palette is empty, so a `T` is always returned. A falsy `value` still returns the first entry of whichever palette is in effect.

## Test plan
- [x] `bun run test avatarColor` — new empty-palette case; verified it fails (`expected [...] to include undefined`) against the original code
- [x] `bun run test UserAvatar` — 35 passed
- [x] `bun run test:src-types`
- [x] `bun run lint:changed`