### PR TITLE
fix(pagination-nav): emit 1-based page index from single overflow item

### DIFF
--- a/src/PaginationNav/PaginationOverflow.svelte
+++ b/src/PaginationNav/PaginationOverflow.svelte
@@ -51,7 +51,7 @@
   <PaginationItem
     page={fromIndex + 1}
     on:click={() => {
-      dispatch("select", { index: fromIndex });
+      dispatch("select", { index: fromIndex + 1 });
     }}
   >
     Page

--- a/tests/PaginationNav/PaginationOverflow.test.svelte
+++ b/tests/PaginationNav/PaginationOverflow.test.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+  import PaginationOverflow from "carbon-components-svelte/PaginationNav/PaginationOverflow.svelte";
+  import type { ComponentProps } from "svelte";
+
+  export let fromIndex: ComponentProps<PaginationOverflow>["fromIndex"] = 0;
+  export let count: ComponentProps<PaginationOverflow>["count"] = 0;
+  export let onSelect: (e: CustomEvent<{ index: number }>) => void = () => {};
+</script>
+
+<ul>
+  <PaginationOverflow {fromIndex} {count} on:select={onSelect} />
+</ul>

--- a/tests/PaginationNav/PaginationOverflow.test.ts
+++ b/tests/PaginationNav/PaginationOverflow.test.ts
@@ -1,0 +1,33 @@
+import { render, screen } from "@testing-library/svelte";
+import { user } from "../utils/user";
+import PaginationOverflow from "./PaginationOverflow.test.svelte";
+
+describe("PaginationOverflow", () => {
+  test("single-item branch dispatches a 1-based index matching the rendered page", async () => {
+    const onSelect = vi.fn();
+    render(PaginationOverflow, {
+      props: { fromIndex: 4, count: 1, onSelect },
+    });
+
+    const item = screen.getByRole("button");
+    expect(item).toHaveTextContent("5");
+
+    await user.click(item);
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect.mock.calls[0][0].detail).toEqual({ index: 5 });
+  });
+
+  test("multi-item branch already dispatches a 1-based index for comparison", async () => {
+    const onSelect = vi.fn();
+    render(PaginationOverflow, {
+      props: { fromIndex: 4, count: 2, onSelect },
+    });
+
+    const select = screen.getByRole("combobox");
+    await user.selectOptions(select, "5");
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect.mock.calls[0][0].detail).toEqual({ index: 5 });
+  });
+});


### PR DESCRIPTION
## Summary
- `PaginationOverflow`'s `count === 1` branch dispatched `{ index: fromIndex }` (0-based), while the `count > 1` branch's `<option value={fromIndex + pageOffset + 1}>` feeds a 1-based index, and the parent `PaginationNav` treats the payload as 1-based throughout (`page = event.detail.index`, `export let page = 1`). The single-item branch would navigate to page N−1 while displaying `page={fromIndex + 1}` ("Page N") — disagreeing with its own label.
- Currently unreachable from `PaginationNav`: its `front`/`back` math (both guards zero the value before it can land on exactly `1`) never produces `count === 1`. `PaginationOverflow` isn't exported from `src/index.js` either. This is consistency hardening for a component that's one 1-based/0-based mismatch away from a real bug if that math ever changes, or if `PaginationOverflow` is used directly.
- Left the `count === 1` branch in place rather than deleting it — that's a separate, behavior-preserving simplification call not part of this fix.

## Test plan
- [x] `bun run test PaginationOverflow` — new direct test for `PaginationOverflow` with `count={1}`, asserting the dispatched index matches the displayed page number; verified it fails (`index: 4` vs expected `5`) against the original code. `PaginationNav` itself cannot exercise this branch, so this needed a direct component test.
- [x] `bun run test PaginationNav` — 21 passed
- [x] `bun run lint:changed`