### PR TITLE
fix(menu): keep menu open on selection via preventDefault

### DIFF
--- a/docs/src/pages/components/ContextMenu.svx
+++ b/docs/src/pages/components/ContextMenu.svx
@@ -43,7 +43,7 @@ Submenus can contain:
 | Selectable group | A nested `ContextMenuGroup` with an accessible label; options act as checkboxes and share `bind:selectedIds`. See [Selectable (nested)](#selectable-nested); the **Export as** branch in this example shows the same pattern alongside plain items.                                                                                                            |
 | Radio group      | A nested `ContextMenuRadioGroup` with `bind:selectedId` so only one choice is active. See [Radio group (nested)](#radio-group-nested).                                                                                                                                                                                                                           |
 
-Toggling a checkbox or radio item in a nested submenu leaves that flyout open so you can change several choices; the root menu still closes when you pick a plain action row or click outside.
+Selecting an option closes only that option's own menu level. At the root, that closes the whole menu. Inside a submenu, it closes just that flyout and leaves the rest open. Call `event.preventDefault()` to keep a flyout open across several picks; see [Prevent menu from closing](#prevent-menu-from-closing).
 
 <FileSource src="/framed/ContextMenu/ContextMenuNested" />
 
@@ -77,7 +77,7 @@ Use selectable for a single toggle item, or wrap options in ContextMenuGroup wit
 
 ### Selectable (nested)
 
-Put ContextMenuGroup inside a parent ContextMenuOption to show the checkbox-style group in a flyout submenu. Use `bind:selectedIds` for the chosen values. See also [Nested menu](#nested-menu) for a full submenu example that includes both plain options and grouped selection.
+Put ContextMenuGroup inside a parent ContextMenuOption to show the checkbox-style group in a flyout submenu. Use `bind:selectedIds` for the chosen values. See [Nested menu](#nested-menu) for a full submenu example, and [Prevent menu from closing](#prevent-menu-from-closing) to keep the flyout open while changing several checkboxes.
 
 <FileSource src="/framed/ContextMenu/ContextMenuSelectableNested" />
 
@@ -91,10 +91,12 @@ Use ContextMenuRadioGroup to organize related options as a radio set: only one o
 
 Put ContextMenuRadioGroup inside a parent ContextMenuOption to show the radio set in a flyout submenu, similar to the nested checkbox group in [Nested menu](#nested-menu). Use `bind:selectedId` for the active choice.
 
+Selecting an option closes that flyout. Call `event.preventDefault()` in the option's `on:click` handler to leave it open; `selectedId` still updates. See [Prevent menu from closing](#prevent-menu-from-closing).
+
 <FileSource src="/framed/ContextMenu/ContextMenuRadioGroupNested" />
 
 ## Prevent menu from closing
 
-Use `preventDefault()` on individual context menu option click events to prevent the menu from closing when that option is clicked. Use this to keep the menu open after performing an action.
+An option's `click` event is cancelable. Call `event.preventDefault()` in its `on:click` handler to keep the menu open. For a selectable or radio option, selection still updates; only the close is canceled. That is how you leave a nested submenu open while changing several choices. See [Radio group (nested)](#radio-group-nested).
 
 <FileSource src="/framed/ContextMenu/ContextMenuPreventDefault" />

--- a/docs/src/pages/components/Menu.svx
+++ b/docs/src/pages/components/Menu.svx
@@ -62,7 +62,7 @@ Set `labelText` on a `MenuItem` and nest child `MenuItem` rows to get a submenu.
 
 ## Keyboard interactions
 
-Once open, arrow keys move focus between items without wrapping past the first or last item. <DocKbd label="Home" /> and <DocKbd label="End" /> jump to the first and last enabled item, skipping disabled ones. The menu closes from an item selection, <DocKbd label="Escape" />, or an outside click; <DocKbd label="Escape" /> also returns focus to the anchor.
+Once open, arrow keys move focus between items without wrapping past the first or last item. <DocKbd label="Home" /> and <DocKbd label="End" /> jump to the first and last enabled item, skipping disabled ones. The menu closes from an item selection, <DocKbd label="Escape" />, or an outside click; <DocKbd label="Escape" /> also returns focus to the anchor. An item's `click` event is cancelable. Call `event.preventDefault()` in its handler to keep the menu open after selection. See [MenuButton keep open on selection](/components/MenuButton#keep-open-on-selection).
 
 ## Scrollable
 

--- a/docs/src/pages/components/MenuButton.svx
+++ b/docs/src/pages/components/MenuButton.svx
@@ -192,19 +192,19 @@ Put a `MenuDivider` between groups.
 
 Wrap items in `MenuItemGroup` to make them checkboxes that hold state, such as which table columns are visible. Give every item an id, then bind `selectedIds` for the chosen ones. Set `selected` on an item to check it when the menu first opens, or set `selectable` on a single item outside a group for a standalone toggle.
 
-Choosing an item closes the menu. Call `event.preventDefault()` in an item's `on:click` handler to keep it open for a multi-select flow, then update the bound value yourself.
+Choosing an item closes the menu by default. See [Keep open on selection](#keep-open-on-selection) to change that.
 
 <FileSource src="/framed/MenuButton/MenuButtonSelectable" />
 
 ### Radio group
 
-Wrap items in `MenuItemRadioGroup` for a set where one choice is active at a time, such as row density. Bind `selectedId` for the active id; picking another item clears the previous one.
+Wrap items in `MenuItemRadioGroup` for a set where one choice is active at a time, such as row density. Bind `selectedId` for the active id; picking another item clears the previous one. Choosing an item closes the menu by default; see [Keep open on selection](#keep-open-on-selection) to change that.
 
 <FileSource src="/framed/MenuButton/MenuButtonRadioGroup" />
 
 ### Nested
 
-Set `labelText` on a `MenuItem` and nest child `MenuItem` rows to get a submenu. Open it with <DocKbd label="→" />, click, or hover (short delay). <DocKbd label="←" /> closes it and refocuses the parent. Picking a nested item closes the whole menu.
+Set `labelText` on a `MenuItem` and nest child `MenuItem` rows to get a submenu. Open it with <DocKbd label="→" />, click, or hover (short delay). <DocKbd label="←" /> closes it and refocuses the parent. Picking a nested item closes the whole menu, including open submenus. See [Keep open on selection](#keep-open-on-selection) to change that.
 
 <MenuButton labelText="Actions">
   <MenuItem on:click={() => console.log("Cut")}>Cut</MenuItem>
@@ -215,3 +215,9 @@ Set `labelText` on a `MenuItem` and nest child `MenuItem` rows to get a submenu.
     <MenuItem on:click={() => console.log("PNG")}>PNG</MenuItem>
   </MenuItem>
 </MenuButton>
+
+### Keep open on selection
+
+Choosing an item closes the menu by default, including any open submenus. Call `event.preventDefault()` in the item's `on:click` handler to keep the menu open. A selectable or radio item still updates its own state; only the close is canceled. Use this for multi-select, or for a radio choice in a submenu that should stay open after a pick.
+
+<FileSource src="/framed/MenuButton/MenuButtonKeepOpen" />

--- a/docs/src/pages/framed/ContextMenu/ContextMenuRadioGroupNested.svelte
+++ b/docs/src/pages/framed/ContextMenu/ContextMenuRadioGroupNested.svelte
@@ -14,9 +14,21 @@
   <ContextMenuDivider />
   <ContextMenuOption labelText="View as">
     <ContextMenuRadioGroup bind:selectedId labelText="View mode">
-      <ContextMenuOption id="list" labelText="List" />
-      <ContextMenuOption id="grid" labelText="Grid" />
-      <ContextMenuOption id="compact" labelText="Compact" />
+      <ContextMenuOption
+        id="list"
+        labelText="List"
+        on:click={(e) => e.preventDefault()}
+      />
+      <ContextMenuOption
+        id="grid"
+        labelText="Grid"
+        on:click={(e) => e.preventDefault()}
+      />
+      <ContextMenuOption
+        id="compact"
+        labelText="Compact"
+        on:click={(e) => e.preventDefault()}
+      />
     </ContextMenuRadioGroup>
   </ContextMenuOption>
 </ContextMenu>

--- a/docs/src/pages/framed/MenuButton/MenuButtonKeepOpen.svelte
+++ b/docs/src/pages/framed/MenuButton/MenuButtonKeepOpen.svelte
@@ -1,0 +1,53 @@
+<script>
+  import {
+    MenuButton,
+    MenuDivider,
+    MenuItem,
+    MenuItemGroup,
+    MenuItemRadioGroup,
+    Stack,
+  } from "carbon-components-svelte";
+
+  let selectedIds = ["name"];
+  let theme = "light";
+</script>
+
+<Stack gap={5}>
+  <MenuButton labelText="View">
+    <MenuItemGroup labelText="Columns" bind:selectedIds>
+      <MenuItem
+        id="name"
+        labelText="Name"
+        on:click={(e) => e.preventDefault()}
+      />
+      <MenuItem
+        id="size"
+        labelText="Size"
+        on:click={(e) => e.preventDefault()}
+      />
+      <MenuItem
+        id="modified"
+        labelText="Last modified"
+        on:click={(e) => e.preventDefault()}
+      />
+    </MenuItemGroup>
+    <MenuDivider />
+    <MenuItem labelText="Theme">
+      <MenuItemRadioGroup bind:selectedId={theme}>
+        <MenuItem
+          id="light"
+          labelText="Light"
+          on:click={(e) => e.preventDefault()}
+        />
+        <MenuItem
+          id="dark"
+          labelText="Dark"
+          on:click={(e) => e.preventDefault()}
+        />
+      </MenuItemRadioGroup>
+    </MenuItem>
+  </MenuButton>
+
+  <p>Visible columns: {selectedIds.join(", ") || "None"}</p>
+  <p>Theme: {theme}</p>
+</Stack>

--- a/src/ContextMenu/ContextMenu.svelte
+++ b/src/ContextMenu/ContextMenu.svelte
@@ -234,13 +234,6 @@
   {...$$restProps}
   aria-label={menuAriaLabel}
   on:click
-  on:click={(event) => {
-    const closestOption = event.target.closest("[tabindex]");
-
-    if (closestOption && closestOption.getAttribute("role") !== "menuitem") {
-      close("select");
-    }
-  }}
   on:keydown
   on:keydown={(event) => {
     if (open) event.preventDefault();

--- a/src/ContextMenu/ContextMenuOption.svelte
+++ b/src/ContextMenu/ContextMenuOption.svelte
@@ -1,5 +1,8 @@
 <script>
   /**
+   * Dispatched on selection. Cancelable: call `preventDefault()` to keep
+   * this menu level open. A selectable or radio option's selection still
+   * updates.
    * @event {Event} click
    */
 
@@ -189,21 +192,22 @@
     if (disabled) return;
     if (subOptions) return;
 
-    const shouldContinue = dispatch("click", event, { cancelable: true });
-
-    if (shouldContinue) {
-      if (ctxGroup) {
-        ctxGroup.toggleOption({ id });
-      } else if (ctxRadioGroup) {
-        if (opts.fromKeyboard) {
-          ctxRadioGroup.setOption({ id: opts.id });
-        } else {
-          ctxRadioGroup.setOption({ id });
-        }
+    // Selection runs first so preventDefault only skips the close.
+    if (ctxGroup) {
+      ctxGroup.toggleOption({ id });
+    } else if (ctxRadioGroup) {
+      if (opts.fromKeyboard) {
+        ctxRadioGroup.setOption({ id: opts.id });
       } else {
-        selected = !selected;
+        ctxRadioGroup.setOption({ id });
       }
+    } else {
+      selected = !selected;
+    }
 
+    const shouldClose = dispatch("click", event, { cancelable: true });
+
+    if (shouldClose) {
       ctx.close("select");
     }
   }

--- a/src/Menu/MenuItem.svelte
+++ b/src/Menu/MenuItem.svelte
@@ -1,5 +1,7 @@
 <script>
   /**
+   * Dispatched on selection. Cancelable: call `preventDefault()` to keep
+   * the menu open. A selectable or radio item's selection still updates.
    * @event {MouseEvent} click
    */
 
@@ -112,17 +114,18 @@
   function handleClick(event) {
     if (disabled) return;
 
-    const shouldContinue = dispatch("click", event, { cancelable: true });
+    // Selection runs first so preventDefault only skips the close.
+    if (ctxGroup) {
+      ctxGroup.toggleOption({ id });
+    } else if (ctxRadioGroup) {
+      ctxRadioGroup.setOption({ id });
+    } else if (isSelectable) {
+      selected = !selected;
+    }
 
-    if (shouldContinue) {
-      if (ctxGroup) {
-        ctxGroup.toggleOption({ id });
-      } else if (ctxRadioGroup) {
-        ctxRadioGroup.setOption({ id });
-      } else if (isSelectable) {
-        selected = !selected;
-      }
+    const shouldClose = dispatch("click", event, { cancelable: true });
 
+    if (shouldClose) {
       ctx.close("select");
     }
   }

--- a/tests/ContextMenu/ContextMenuOption.keepOpen.test.svelte
+++ b/tests/ContextMenu/ContextMenuOption.keepOpen.test.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+  import ContextMenu from "carbon-components-svelte/ContextMenu/ContextMenu.svelte";
+  import ContextMenuGroup from "carbon-components-svelte/ContextMenu/ContextMenuGroup.svelte";
+  import ContextMenuOption from "carbon-components-svelte/ContextMenu/ContextMenuOption.svelte";
+  import ContextMenuRadioGroup from "carbon-components-svelte/ContextMenu/ContextMenuRadioGroup.svelte";
+  import type { ComponentProps } from "svelte";
+
+  export let selectedIds: ComponentProps<ContextMenuGroup>["selectedIds"] = [];
+  export let selectedId: ComponentProps<ContextMenuRadioGroup>["selectedId"] =
+    "list";
+
+  export let open = false;
+  export let x = 0;
+  export let y = 0;
+</script>
+
+<ContextMenu bind:open {x} {y}>
+  <ContextMenuGroup labelText="Columns" bind:selectedIds>
+    <ContextMenuOption id="name" labelText="Name" />
+    <ContextMenuOption
+      id="date"
+      labelText="Date"
+      on:click={(e) => e.preventDefault()}
+    />
+  </ContextMenuGroup>
+  <ContextMenuOption indented labelText="View as">
+    <ContextMenuRadioGroup bind:selectedId labelText="View mode">
+      <ContextMenuOption
+        id="list"
+        labelText="List"
+        on:click={(e) => e.preventDefault()}
+      />
+      <ContextMenuOption
+        id="grid"
+        labelText="Grid"
+        on:click={(e) => e.preventDefault()}
+      />
+    </ContextMenuRadioGroup>
+  </ContextMenuOption>
+</ContextMenu>
+
+<div data-testid="selected-ids">{JSON.stringify(selectedIds)}</div>
+<div data-testid="selected-id">{selectedId}</div>

--- a/tests/ContextMenu/ContextMenuOption.keepOpen.test.ts
+++ b/tests/ContextMenu/ContextMenuOption.keepOpen.test.ts
@@ -1,0 +1,39 @@
+import { render, screen } from "@testing-library/svelte";
+import { user } from "../utils/user";
+import ContextMenuOptionKeepOpenFixture from "./ContextMenuOption.keepOpen.test.svelte";
+
+describe("ContextMenuOption keep open on selection", () => {
+  const getSelectedIds = () =>
+    JSON.parse(screen.getByTestId("selected-ids").textContent || "[]");
+  const getSelectedId = () => screen.getByTestId("selected-id").textContent;
+
+  it("keeps the menu open when click is prevented and still toggles selection", async () => {
+    render(ContextMenuOptionKeepOpenFixture, {
+      props: { open: true, x: 100, y: 100 },
+    });
+
+    await user.click(screen.getByRole("menuitemcheckbox", { name: "Date" }));
+
+    expect(screen.getAllByRole("menu")[0]).toHaveClass("bx--menu--open");
+    expect(getSelectedIds()).toEqual(["date"]);
+  });
+
+  it("keeps nested and root menus open when a radio click is prevented", async () => {
+    render(ContextMenuOptionKeepOpenFixture, {
+      props: { open: true, x: 100, y: 100 },
+    });
+
+    await user.hover(screen.getByRole("menuitem", { name: "View as" }));
+    const gridOption = await screen.findByRole("menuitemradio", {
+      name: "Grid",
+    });
+    await user.click(gridOption);
+
+    expect(getSelectedId()).toBe("grid");
+
+    const menus = screen.getAllByRole("menu");
+    for (const menu of menus) {
+      expect(menu).toHaveClass("bx--menu--open");
+    }
+  });
+});

--- a/tests/Menu/MenuItem.radioGroup.test.svelte
+++ b/tests/Menu/MenuItem.radioGroup.test.svelte
@@ -20,6 +20,20 @@
     <MenuItem id="compact" labelText="Compact" />
     <MenuItem id="comfortable" labelText="Comfortable" selected />
   </MenuItemRadioGroup>
+  <MenuItem labelText="View">
+    <MenuItemRadioGroup labelText="Theme" selectedId="light">
+      <MenuItem
+        id="light"
+        labelText="Light"
+        on:click={(e) => e.preventDefault()}
+      />
+      <MenuItem
+        id="dark"
+        labelText="Dark"
+        on:click={(e) => e.preventDefault()}
+      />
+    </MenuItemRadioGroup>
+  </MenuItem>
 </Menu>
 
 <div data-testid="selected-id">{selectedId}</div>

--- a/tests/Menu/MenuItem.test.ts
+++ b/tests/Menu/MenuItem.test.ts
@@ -324,14 +324,14 @@ describe("MenuItem", () => {
       ).toHaveFocus();
     });
 
-    it("keeps the menu open when the click event is prevented", async () => {
+    it("keeps the menu open when click is prevented and still toggles selection", async () => {
       render(MenuItemSelectableFixture);
 
       await user.click(screen.getByRole("button", { name: "Trigger" }));
       await user.click(screen.getByRole("menuitemcheckbox", { name: "Date" }));
 
       expect(screen.getByRole("menu")).toBeInTheDocument();
-      expect(getSelectedIds()).toEqual(["size"]);
+      expect(getSelectedIds()).toEqual(["size", "date"]);
     });
   });
 
@@ -391,6 +391,24 @@ describe("MenuItem", () => {
       expect(
         screen.getByRole("menuitemradio", { name: "Compact" }),
       ).toHaveFocus();
+    });
+
+    it("keeps nested and root menus open when a radio click is prevented", async () => {
+      render(MenuItemRadioGroupFixture);
+
+      await user.click(screen.getByRole("button", { name: "Trigger" }));
+      await user.click(screen.getByRole("menuitem", { name: "View" }));
+      await user.click(screen.getByRole("menuitemradio", { name: "Dark" }));
+
+      expect(
+        screen.getByRole("menuitemradio", { name: "Dark" }),
+      ).toHaveAttribute("aria-checked", "true");
+      expect(
+        screen.getByRole("menuitemradio", { name: "Light" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("menuitem", { name: "Plain" }),
+      ).toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
Selection still applies when you call `preventDefault`; only the
close is canceled. ContextMenu had the same bug plus a root `<ul>`
click handler that closed checkbox/radio options regardless of
`preventDefault`. Docs cover keep-open for MenuButton and
ContextMenu.

---

https://github.com/user-attachments/assets/24a7dbe4-f9ab-4e61-bbd3-51ad7c860e20

