### PR TITLE
chore(utils): add isInSafeTriangle for submenu hover transfer

### DIFF
--- a/src/ContextMenu/ContextMenuOption.svelte
+++ b/src/ContextMenu/ContextMenuOption.svelte
@@ -87,6 +87,7 @@
   import Checkmark from "../icons/Checkmark.svelte";
   import { clampIndex } from "../utils/clampIndex.js";
   import { dismiss } from "../utils/dismiss.js";
+  import { isInSafeTriangle as computeSafeTriangle } from "../utils/isInSafeTriangle.js";
   import ContextMenu from "./ContextMenu.svelte";
 
   const dispatch = createEventDispatcher();
@@ -121,71 +122,16 @@
     menuOffsetX = _menuOffsetX;
   });
 
-  function isPointInTriangle(px, py, x1, y1, x2, y2, x3, y3) {
-    const denominator = (y2 - y3) * (x1 - x3) + (x3 - x2) * (y1 - y3);
-    const a = ((y2 - y3) * (px - x3) + (x3 - x2) * (py - y3)) / denominator;
-    const b = ((y3 - y1) * (px - x3) + (x1 - x3) * (py - y3)) / denominator;
-    const c = 1 - a - b;
-
-    return a >= 0 && a <= 1 && b >= 0 && b <= 1 && c >= 0 && c <= 1;
-  }
-
-  // Utility function to check if mouse is in the
-  // safe triangle when transferring to the submenu.
+  // True when the pointer is in the safe-transfer zone toward the submenu.
   function isInSafeTriangle(mouseX, mouseY) {
     if (!submenuOpen || !ref || !submenuRef) return false;
 
-    const parentRect = ref.getBoundingClientRect();
-    const submenuRect = submenuRef.getBoundingClientRect();
-
-    // Magic number to make the triangle slightly larger
-    const buffer = 12;
-    const isSubmenuOnRight = submenuRect.left >= parentRect.right;
-
-    let trianglePoints;
-    if (isSubmenuOnRight) {
-      trianglePoints = {
-        x1: parentRect.right,
-        y1: parentRect.top - buffer,
-        x2: parentRect.right,
-        y2: parentRect.bottom + buffer,
-        x3: submenuRect.left,
-        y3: submenuRect.top + submenuRect.height / 2,
-      };
-    } else {
-      trianglePoints = {
-        x1: parentRect.left,
-        y1: parentRect.top - buffer,
-        x2: parentRect.left,
-        y2: parentRect.bottom + buffer,
-        x3: submenuRect.right,
-        y3: submenuRect.top + submenuRect.height / 2,
-      };
-    }
-
-    const inTopTriangle = isPointInTriangle(
+    return computeSafeTriangle(
       mouseX,
       mouseY,
-      trianglePoints.x1,
-      trianglePoints.y1,
-      isSubmenuOnRight ? trianglePoints.x3 : trianglePoints.x2,
-      submenuRect.top,
-      trianglePoints.x3,
-      trianglePoints.y3,
+      ref.getBoundingClientRect(),
+      submenuRef.getBoundingClientRect(),
     );
-
-    const inBottomTriangle = isPointInTriangle(
-      mouseX,
-      mouseY,
-      trianglePoints.x2,
-      trianglePoints.y2,
-      trianglePoints.x3,
-      trianglePoints.y3,
-      isSubmenuOnRight ? trianglePoints.x3 : trianglePoints.x1,
-      submenuRect.bottom,
-    );
-
-    return inTopTriangle || inBottomTriangle;
   }
 
   function handleClick(event, opts = {}) {

--- a/src/utils/isInSafeTriangle.d.ts
+++ b/src/utils/isInSafeTriangle.d.ts
@@ -1,0 +1,19 @@
+/**
+ * True when `(mouseX, mouseY)` falls within the buffered triangle connecting
+ * `anchorRect`'s facing edge to `floatingRect`'s facing edge. Lets the
+ * pointer travel diagonally from a trigger toward its submenu/popover
+ * without it closing mid-crossing.
+ */
+export function isInSafeTriangle(
+  mouseX: number,
+  mouseY: number,
+  anchorRect: { top: number; right: number; bottom: number; left: number },
+  floatingRect: {
+    top: number;
+    right: number;
+    bottom: number;
+    left: number;
+    height: number;
+  },
+  buffer?: number,
+): boolean;

--- a/src/utils/isInSafeTriangle.js
+++ b/src/utils/isInSafeTriangle.js
@@ -1,0 +1,86 @@
+// @ts-check
+
+/**
+ * True when `(mouseX, mouseY)` falls within the buffered triangle connecting
+ * `anchorRect`'s facing edge to `floatingRect`'s facing edge. Lets the
+ * pointer travel diagonally from a trigger toward its submenu/popover
+ * without it closing mid-crossing.
+ *
+ * @param {number} mouseX
+ * @param {number} mouseY
+ * @param {{ top: number, right: number, bottom: number, left: number }} anchorRect
+ * @param {{ top: number, right: number, bottom: number, left: number, height: number }} floatingRect
+ * @param {number} [buffer] Extra px added above/below the anchor's near edge to widen the triangle.
+ * @returns {boolean}
+ */
+export function isInSafeTriangle(
+  mouseX,
+  mouseY,
+  anchorRect,
+  floatingRect,
+  buffer = 12,
+) {
+  const isFloatingOnRight = floatingRect.left >= anchorRect.right;
+
+  const trianglePoints = isFloatingOnRight
+    ? {
+        x1: anchorRect.right,
+        y1: anchorRect.top - buffer,
+        x2: anchorRect.right,
+        y2: anchorRect.bottom + buffer,
+        x3: floatingRect.left,
+        y3: floatingRect.top + floatingRect.height / 2,
+      }
+    : {
+        x1: anchorRect.left,
+        y1: anchorRect.top - buffer,
+        x2: anchorRect.left,
+        y2: anchorRect.bottom + buffer,
+        x3: floatingRect.right,
+        y3: floatingRect.top + floatingRect.height / 2,
+      };
+
+  const inTopTriangle = isPointInTriangle(
+    mouseX,
+    mouseY,
+    trianglePoints.x1,
+    trianglePoints.y1,
+    isFloatingOnRight ? trianglePoints.x3 : trianglePoints.x2,
+    floatingRect.top,
+    trianglePoints.x3,
+    trianglePoints.y3,
+  );
+
+  const inBottomTriangle = isPointInTriangle(
+    mouseX,
+    mouseY,
+    trianglePoints.x2,
+    trianglePoints.y2,
+    trianglePoints.x3,
+    trianglePoints.y3,
+    isFloatingOnRight ? trianglePoints.x3 : trianglePoints.x1,
+    floatingRect.bottom,
+  );
+
+  return inTopTriangle || inBottomTriangle;
+}
+
+/**
+ * @param {number} px
+ * @param {number} py
+ * @param {number} x1
+ * @param {number} y1
+ * @param {number} x2
+ * @param {number} y2
+ * @param {number} x3
+ * @param {number} y3
+ * @returns {boolean}
+ */
+function isPointInTriangle(px, py, x1, y1, x2, y2, x3, y3) {
+  const denominator = (y2 - y3) * (x1 - x3) + (x3 - x2) * (y1 - y3);
+  const a = ((y2 - y3) * (px - x3) + (x3 - x2) * (py - y3)) / denominator;
+  const b = ((y3 - y1) * (px - x3) + (x1 - x3) * (py - y3)) / denominator;
+  const c = 1 - a - b;
+
+  return a >= 0 && a <= 1 && b >= 0 && b <= 1 && c >= 0 && c <= 1;
+}

--- a/tests/utils/isInSafeTriangle.test.ts
+++ b/tests/utils/isInSafeTriangle.test.ts
@@ -1,0 +1,55 @@
+import { isInSafeTriangle } from "../../src/utils/isInSafeTriangle.js";
+
+describe("isInSafeTriangle", () => {
+  test("true for a point crossing diagonally toward a floating element on the right", () => {
+    const anchorRect = { left: 0, right: 100, top: 0, bottom: 40 };
+    const floatingRect = {
+      left: 120,
+      right: 220,
+      top: 0,
+      bottom: 200,
+      height: 200,
+    };
+
+    expect(isInSafeTriangle(113, 117, anchorRect, floatingRect)).toBe(true);
+  });
+
+  test("false for a point far from the gap between anchor and floating element", () => {
+    const anchorRect = { left: 0, right: 100, top: 0, bottom: 40 };
+    const floatingRect = {
+      left: 120,
+      right: 220,
+      top: 0,
+      bottom: 200,
+      height: 200,
+    };
+
+    expect(isInSafeTriangle(50, 500, anchorRect, floatingRect)).toBe(false);
+  });
+
+  test("true for a point crossing diagonally toward a floating element on the left", () => {
+    const anchorRect = { left: 100, right: 200, top: 0, bottom: 40 };
+    const floatingRect = {
+      left: -20,
+      right: 80,
+      top: 0,
+      bottom: 200,
+      height: 200,
+    };
+
+    expect(isInSafeTriangle(95, 100, anchorRect, floatingRect)).toBe(true);
+  });
+
+  test("false for a point on the wrong side of the anchor", () => {
+    const anchorRect = { left: 100, right: 200, top: 0, bottom: 40 };
+    const floatingRect = {
+      left: -20,
+      right: 80,
+      top: 0,
+      bottom: 200,
+      height: 200,
+    };
+
+    expect(isInSafeTriangle(300, 300, anchorRect, floatingRect)).toBe(false);
+  });
+});


### PR DESCRIPTION
ContextMenuOption already had this geometry inline for its submenu
hover close; it now imports the shared version instead of keeping its
own copy. No behavior change.
