### PR TITLE
fix(accordion): keep nested accordion items independently collapsible

### DIFF
--- a/css/_accordion.scss
+++ b/css/_accordion.scss
@@ -1,0 +1,28 @@
+@import "carbon-components/scss/globals/scss/vars";
+@import "carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/import-once/import-once";
+
+/// Carbon v10 toggles accordion content and arrow visibility from an
+/// ancestor `bx--accordion__item--active` selector. A closed item nested
+/// inside an open one still looks open. This higher-specificity `:not()`
+/// rule restores the closed state. v11 fixed the upstream selectors with
+/// `>` in https://github.com/carbon-design-system/carbon/pull/7329. v10 is
+/// pinned, so the patch lives here. Skip `--collapsing` so the close
+/// animation still plays.
+/// @access private
+/// @group components
+@mixin accordion-nested {
+  .#{$prefix}--accordion__item:not(.#{$prefix}--accordion__item--active):not(.#{$prefix}--accordion__item--collapsing)
+    > .#{$prefix}--accordion__content {
+    display: none;
+  }
+
+  .#{$prefix}--accordion__item:not(.#{$prefix}--accordion__item--active)
+    > .#{$prefix}--accordion__heading
+    .#{$prefix}--accordion__arrow {
+    transform: rotate(-270deg) #{"/*rtl:ignore*/"};
+  }
+}
+
+@include exports("accordion-nested") {
+  @include accordion-nested;
+}

--- a/css/all.scss
+++ b/css/all.scss
@@ -149,4 +149,5 @@ $css--plex: true;
 @import "./user-avatar";
 @import "./user-avatar-group";
 @import "./disclosure";
+@import "./accordion";
 @import "./accordion-flush";

--- a/css/g10.scss
+++ b/css/g10.scss
@@ -109,4 +109,5 @@ $css--plex: true;
 @import "./user-avatar";
 @import "./user-avatar-group";
 @import "./disclosure";
+@import "./accordion";
 @import "./accordion-flush";

--- a/css/g100.scss
+++ b/css/g100.scss
@@ -109,4 +109,5 @@ $css--plex: true;
 @import "./user-avatar";
 @import "./user-avatar-group";
 @import "./disclosure";
+@import "./accordion";
 @import "./accordion-flush";

--- a/css/g80.scss
+++ b/css/g80.scss
@@ -109,4 +109,5 @@ $css--plex: true;
 @import "./user-avatar";
 @import "./user-avatar-group";
 @import "./disclosure";
+@import "./accordion";
 @import "./accordion-flush";

--- a/css/g90.scss
+++ b/css/g90.scss
@@ -109,4 +109,5 @@ $css--plex: true;
 @import "./user-avatar";
 @import "./user-avatar-group";
 @import "./disclosure";
+@import "./accordion";
 @import "./accordion-flush";

--- a/css/white.scss
+++ b/css/white.scss
@@ -109,4 +109,5 @@ $css--plex: true;
 @import "./user-avatar";
 @import "./user-avatar-group";
 @import "./disclosure";
+@import "./accordion";
 @import "./accordion-flush";

--- a/docs/src/pages/components/Accordion.svx
+++ b/docs/src/pages/components/Accordion.svx
@@ -134,6 +134,21 @@ panels where only one section should be expanded at a time. The default is
   </AccordionItem>
 </Accordion>
 
+## Nested
+
+Put an `Accordion` inside an `AccordionItem`. Nested items keep their own
+open state. Opening the outer item leaves the inner one closed.
+
+<Accordion>
+  <AccordionItem title="Outer item">
+    <Accordion>
+      <AccordionItem title="Inner item">
+        <p>Nested content.</p>
+      </AccordionItem>
+    </Accordion>
+  </AccordionItem>
+</Accordion>
+
 ## Programmatic example
 
 Programmatically control the accordion items with the `bind:open` directive,

--- a/e2e/accordion-nested.test.ts
+++ b/e2e/accordion-nested.test.ts
@@ -1,0 +1,29 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("Accordion nested", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/accordion-nested.html");
+  });
+
+  test("keeps a closed inner item closed when the outer item opens", async ({
+    page,
+  }) => {
+    await page.getByRole("button", { name: "Outer" }).click();
+
+    const innerButton = page.getByRole("button", { name: "Inner" });
+    await expect(innerButton).toHaveAttribute("aria-expanded", "false");
+    await expect(page.getByText("Nested content")).not.toBeVisible();
+  });
+
+  test("inner item still opens independently once the outer item is open", async ({
+    page,
+  }) => {
+    await page.getByRole("button", { name: "Outer" }).click();
+
+    const innerButton = page.getByRole("button", { name: "Inner" });
+    await innerButton.click();
+
+    await expect(innerButton).toHaveAttribute("aria-expanded", "true");
+    await expect(page.getByText("Nested content")).toBeVisible();
+  });
+});

--- a/e2e/fixtures/AccordionNestedFixture.svelte
+++ b/e2e/fixtures/AccordionNestedFixture.svelte
@@ -1,0 +1,13 @@
+<script>
+  import { Accordion, AccordionItem } from "carbon-components-svelte";
+</script>
+
+<Accordion data-testid="accordion-outer">
+  <AccordionItem title="Outer" data-testid="accordion-item-outer">
+    <Accordion data-testid="accordion-inner">
+      <AccordionItem title="Inner" data-testid="accordion-item-inner">
+        <p>Nested content</p>
+      </AccordionItem>
+    </Accordion>
+  </AccordionItem>
+</Accordion>

--- a/e2e/fixtures/accordion-nested.html
+++ b/e2e/fixtures/accordion-nested.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Accordion Nested Test</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="./accordion-nested.ts"></script>
+  </body>
+</html>

--- a/e2e/fixtures/accordion-nested.ts
+++ b/e2e/fixtures/accordion-nested.ts
@@ -1,0 +1,4 @@
+import AccordionNestedFixture from "./AccordionNestedFixture.svelte";
+import { mount } from "./mount";
+
+mount(AccordionNestedFixture);

--- a/e2e/fixtures/index.html
+++ b/e2e/fixtures/index.html
@@ -54,6 +54,7 @@
       <a href="/search.html">Search</a>
       <a href="/button.html">Button</a>
       <a href="/accordion.html">Accordion</a>
+      <a href="/accordion-nested.html">Accordion (nested)</a>
       <a href="/composed-modal.html">ComposedModal</a>
       <a href="/modal.html">Modal</a>
       <a href="/popover.html">Popover</a>


### PR DESCRIPTION
Fixes https://github.com/carbon-design-system/carbon-components-svelte/issues/1676

Carbon v10's accordion CSS toggles open state off an ancestor
selector, so a closed nested AccordionItem inherited its parent's
active state and rendered open. This scopes the override the way
Carbon fixed it for v11 and adds a docs example for the pattern.

---
<img width="1110" height="202" alt="Screenshot 2026-08-09 at 9 12 56 AM" src="https://github.com/user-attachments/assets/1b193024-8647-4783-9230-08cfeb1a4c2c" />

