### PR TITLE
refactor(context-menu): remove dead safe-triangle hover check

### DIFF
--- a/src/ContextMenu/ContextMenuOption.svelte
+++ b/src/ContextMenu/ContextMenuOption.svelte
@@ -86,8 +86,6 @@
   import CaretRight from "../icons/CaretRight.svelte";
   import Checkmark from "../icons/Checkmark.svelte";
   import { clampIndex } from "../utils/clampIndex.js";
-  import { dismiss } from "../utils/dismiss.js";
-  import { isInSafeTriangle as computeSafeTriangle } from "../utils/isInSafeTriangle.js";
   import ContextMenu from "./ContextMenu.svelte";
 
   const dispatch = createEventDispatcher();
@@ -110,7 +108,6 @@
   let submenuOpen = false;
   let submenuPosition = [0, 0];
   let menuOffsetX = 0;
-  let mousePosition = { x: 0, y: 0 };
   /** @type {HTMLUListElement | null} */
   let submenuRef = null;
 
@@ -121,18 +118,6 @@
   const unsubMenuOffsetX = ctx.menuOffsetX.subscribe((_menuOffsetX) => {
     menuOffsetX = _menuOffsetX;
   });
-
-  // True when the pointer is in the safe-transfer zone toward the submenu.
-  function isInSafeTriangle(mouseX, mouseY) {
-    if (!submenuOpen || !ref || !submenuRef) return false;
-
-    return computeSafeTriangle(
-      mouseX,
-      mouseY,
-      ref.getBoundingClientRect(),
-      submenuRef.getBoundingClientRect(),
-    );
-  }
 
   function handleClick(event, opts = {}) {
     if (disabled) return;
@@ -155,20 +140,6 @@
 
     if (shouldClose) {
       ctx.close("select");
-    }
-  }
-
-  function handleGlobalMouseMove(event) {
-    if (subOptions && submenuOpen) {
-      mousePosition = { x: event.clientX, y: event.clientY };
-
-      if (
-        isInSafeTriangle(event.clientX, event.clientY) &&
-        typeof timeoutClose === "number"
-      ) {
-        clearTimeout(timeoutClose);
-        timeoutClose = undefined;
-      }
     }
   }
 
@@ -244,12 +215,6 @@
 
 <li
   bind:this={ref}
-  use:dismiss={{
-    enabled: !!subOptions && submenuOpen,
-    type: "mousemove",
-    handler: handleGlobalMouseMove,
-    options: { passive: true },
-  }}
   {role}
   tabindex="-1"
   aria-disabled={disabled}
@@ -322,20 +287,13 @@
       }, moderate01);
     }
   }}
-  on:mousemove={(event) => {
-    if (subOptions && submenuOpen) {
-      mousePosition = { x: event.clientX, y: event.clientY };
-    }
-  }}
   on:mouseleave
   on:mouseleave={() => {
     if (subOptions) {
       if (typeof timeoutHover === "number") clearTimeout(timeoutHover);
 
       timeoutClose = setTimeout(() => {
-        if (!isInSafeTriangle(mousePosition.x, mousePosition.y)) {
-          submenuOpen = false;
-        }
+        submenuOpen = false;
       }, closeDelay);
     }
   }}

--- a/tests/ContextMenu/ContextMenuOption.hoverTransfer.test.ts
+++ b/tests/ContextMenu/ContextMenuOption.hoverTransfer.test.ts
@@ -1,0 +1,102 @@
+import { render, screen } from "@testing-library/svelte";
+import { user } from "../utils/user";
+import ContextMenu from "./ContextMenu.test.svelte";
+
+/**
+ * Regression coverage for the safe-triangle hover-transfer check that used
+ * to run in ContextMenuOption. Its submenu is positioned flush against the
+ * parent option (zero horizontal gap) in real usage, which made the
+ * triangle math degenerate: anchor/floating edges coincide, the containment
+ * check's denominator is exactly 0, and every point (including ones inside
+ * the visual "gap") evaluated to NaN comparisons, i.e. always `false`. The
+ * check has been removed; hover transfer instead relies on `mouseenter` /
+ * `mouseleave` alone, which already covers the flush-adjacent case because
+ * the submenu <ul> is rendered as a DOM descendant of the parent <li> (not
+ * portaled) - moving the pointer onto it never fires `mouseleave` on the
+ * parent to begin with.
+ */
+describe("ContextMenuOption hover transfer to a flush submenu", () => {
+  const HOVER_DELAY = 150;
+  const wait = (ms: number) =>
+    new Promise((resolve) => setTimeout(resolve, ms));
+
+  it("positions the submenu with zero horizontal gap from the parent option", async () => {
+    render(ContextMenu, {
+      props: { open: true, withSubmenu: true, x: 100, y: 100 },
+    });
+
+    const triggerText = screen.getByText("Option with submenu");
+    const trigger = triggerText.closest("li");
+    assert(trigger);
+
+    // Mirrors what a real rendered `<li>` reports: it spans the full width
+    // of its containing `<ul>` (no horizontal padding on `.bx--menu`), so
+    // its right edge coincides with the parent menu's right edge.
+    vi.spyOn(trigger, "getBoundingClientRect").mockReturnValue({
+      left: 100,
+      right: 300,
+      top: 100,
+      bottom: 140,
+      width: 200,
+      height: 40,
+      x: 100,
+      y: 100,
+      toJSON() {},
+    });
+
+    await user.hover(triggerText);
+    await wait(HOVER_DELAY);
+
+    const submenu = screen
+      .getAllByRole("menu")
+      .find((menu) => menu.getAttribute("data-level") === "2");
+    assert(submenu);
+
+    // ContextMenuOption computes `x = rootMenuPosition[0] + width`, i.e. the
+    // parent option's own right edge - the same value plugged into
+    // `isInSafeTriangle` as both the anchor's and floating element's edge.
+    const submenuLeft = Number.parseInt(submenu.style.left, 10);
+    expect(submenuLeft).toBe(trigger.getBoundingClientRect().right);
+  });
+
+  it("keeps the submenu open when the pointer moves onto a submenu option", async () => {
+    render(ContextMenu, {
+      props: { open: true, withSubmenu: true, x: 100, y: 100 },
+    });
+
+    const triggerText = screen.getByText("Option with submenu");
+    const trigger = triggerText.closest("li");
+    assert(trigger);
+
+    await user.hover(triggerText);
+    await wait(HOVER_DELAY);
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+
+    // The submenu option is a DOM descendant of `trigger`, so moving the
+    // pointer onto it does not fire `mouseleave` on `trigger` - the same
+    // way it wouldn't in a real browser.
+    await user.hover(screen.getByText("Submenu option 1"));
+    await wait(HOVER_DELAY);
+
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("closes the submenu after the hover delay when the pointer leaves for good", async () => {
+    render(ContextMenu, {
+      props: { open: true, withSubmenu: true, x: 100, y: 100 },
+    });
+
+    const triggerText = screen.getByText("Option with submenu");
+    const trigger = triggerText.closest("li");
+    assert(trigger);
+
+    await user.hover(triggerText);
+    await wait(HOVER_DELAY);
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+
+    await user.hover(screen.getByText("Option 1"));
+    await wait(HOVER_DELAY);
+
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+  });
+});

--- a/tests/ContextMenu/ContextMenuWindowListeners.test.ts
+++ b/tests/ContextMenu/ContextMenuWindowListeners.test.ts
@@ -1,5 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/svelte";
-import { tick } from "svelte";
+import { render } from "@testing-library/svelte";
 import ContextMenu from "./ContextMenu.test.svelte";
 
 /** dismiss() defers window listener registration by a macrotask; flush it before asserting. */
@@ -37,24 +36,6 @@ describe("ContextMenu window listeners", () => {
     await flush();
     expect(net(add, remove, "click")).toBe(1);
     expect(net(add, remove, "keydown")).toBe(1);
-
-    add.mockRestore();
-    remove.mockRestore();
-  });
-
-  test("submenu options register the hover mousemove listener only while open", async () => {
-    const add = vi.spyOn(window, "addEventListener");
-    const remove = vi.spyOn(window, "removeEventListener");
-
-    render(ContextMenu, { props: { open: true, withSubmenu: true } });
-    await flush();
-    // The parent option's global mousemove handler is idle until its submenu opens.
-    expect(net(add, remove, "mousemove")).toBe(0);
-
-    await fireEvent.click(screen.getByText("Option with submenu"));
-    await tick();
-    await flush();
-    expect(net(add, remove, "mousemove")).toBe(1);
 
     add.mockRestore();
     remove.mockRestore();


### PR DESCRIPTION
ContextMenuOption's submenu always lands flush against the parent
option (zero gap), which made the safe-triangle containment check
degenerate to NaN and always false, same as the case found while
porting this behavior to MenuItem. Removes the dead triangle math and
its mousemove tracking; mouseenter/mouseleave already cover the
flush-adjacent transfer since the submenu is a DOM descendant of the
option, not portaled.