### PR TITLE
ci: switch static-checks/test/test-svelte-compat to ubuntu-latest

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -24,7 +24,7 @@ env:
 
 jobs:
   static-checks:
-    runs-on: macos-15
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
@@ -83,7 +83,7 @@ jobs:
   test:
     needs: [changes]
     if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.unit == 'true'
-    runs-on: macos-15
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
@@ -139,7 +139,7 @@ jobs:
   test-svelte-compat:
     needs: [changes]
     if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.unit == 'true'
-    runs-on: macos-15
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:

--- a/bun.lock
+++ b/bun.lock
@@ -26,7 +26,7 @@
         "jsdom": "^30.0.1",
         "lightningcss": "^1.33.0",
         "sass-embedded": "^1.100.0",
-        "sveld": "^0.36.2",
+        "sveld": "^0.36.3",
         "svelte": "^5.56.8",
         "svelte-check": "^4.7.3",
         "typescript": "^6.0.3",
@@ -478,7 +478,7 @@
 
     "supports-color": ["supports-color@8.1.1", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q=="],
 
-    "sveld": ["sveld@0.36.2", "", { "bin": { "sveld": "cli.js" } }, "sha512-/0iQRfGTL/9hQyR7MVPr0lM5ZpETFVPUuHJo4eQKYsA3dVn94/tPzFUgwpBiPXIrnb1CI8Euewk9fOBi3cPPOA=="],
+    "sveld": ["sveld@0.36.3", "", { "bin": { "sveld": "cli.js" } }, "sha512-13pbDp1TAF+beb4sJoMq4nlvp58j3pBrfIc2RTrR8wnzTXqjwkfVT9LjQkGHf9y/QbdT2SOstQ0bRXpxyTtMmg=="],
 
     "svelte": ["svelte@5.56.8", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "@jridgewell/sourcemap-codec": "^1.5.0", "@sveltejs/acorn-typescript": "^1.0.10", "@types/estree": "^1.0.5", "@types/trusted-types": "^2.0.7", "acorn": "^8.12.1", "aria-query": "5.3.1", "axobject-query": "^4.1.0", "clsx": "^2.1.1", "devalue": "^5.8.1", "esm-env": "^1.2.1", "esrap": "^2.2.12", "is-reference": "^3.0.3", "locate-character": "^3.0.0", "magic-string": "^0.30.11", "zimmerframe": "^1.1.2" } }, "sha512-PY8LOw7xP6c8IOiVqdo0sbbZVYhXRSfklOQLAUyGBKqjTX0wx/z4l/9J+PmBpmlLnxzEb1NqltxQ5/wZme/Cmg=="],
 

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "jsdom": "^30.0.1",
     "lightningcss": "^1.33.0",
     "sass-embedded": "^1.100.0",
-    "sveld": "^0.36.2",
+    "sveld": "^0.36.3",
     "svelte": "^5.56.8",
     "svelte-check": "^4.7.3",
     "typescript": "^6.0.3",

--- a/tests/UIShell/HeaderAction.test.ts
+++ b/tests/UIShell/HeaderAction.test.ts
@@ -79,9 +79,13 @@ describe("HeaderAction", () => {
       await user.click(button);
       expect(screen.getByTestId("panel-content")).toBeInTheDocument();
 
-      // dismiss() defers window listener registration by a macrotask; flush
-      // it before Escape so the keydown isn't dispatched before the listener
-      // is attached.
+      // dismiss() registers window listeners on a macrotask after `enabled`
+      // flips true. On Svelte 3/4 that action update can itself land in a
+      // later macrotask than the click, so one `setTimeout(0)` can run
+      // before registration is even scheduled (and Escape is missed). Two
+      // flushes: (1) Svelte applies `enabled` and schedules add(), (2) add()
+      // attaches the listener.
+      await new Promise((resolve) => setTimeout(resolve, 0));
       await new Promise((resolve) => setTimeout(resolve, 0));
 
       await user.keyboard("{Escape}");


### PR DESCRIPTION
macOS GitHub-hosted runners provision slower and have much lower
concurrency limits than Linux ones. Nothing in static-checks, test,
or test-svelte-compat is macOS-specific (no platform checks, no
native deps), so this moves them to ubuntu-latest to cut queueing
and per-job startup time. test-e2e was already on ubuntu-latest.

changes stays on macos-15 for this PR to keep the diff scoped to the
jobs that actually run the test suites; can revisit separately.

Stacked on #3626.