### PR TITLE
ci: run test/test-svelte3/test-svelte4 concurrently with static-checks

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -81,7 +81,7 @@ jobs:
               - '.github/**'
 
   test:
-    needs: [static-checks, changes]
+    needs: [changes]
     if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.unit == 'true'
     runs-on: macos-15
     steps:
@@ -137,7 +137,7 @@ jobs:
         run: bunx playwright test --project=chromium
 
   test-svelte-compat:
-    needs: [static-checks, changes]
+    needs: [changes]
     if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.unit == 'true'
     runs-on: macos-15
     strategy:


### PR DESCRIPTION
test, test-svelte3, and test-svelte4 don't consume anything
static-checks produces, so needs: [static-checks, changes] just
serialized them behind lint/typecheck/docs-build for no reason.
Dropping static-checks from their needs lets them start as soon as
changes finishes, running alongside static-checks instead of after
it.

test-e2e and deploy-docs still explicitly depend on static-checks
(and on test), so fast-fail behavior there is unchanged.

Independent of #3626/#3627/#3628, based on master directly.