### PR TITLE
test(header-action): flush deferred dismiss listener before Escape

### DIFF
--- a/tests/UIShell/HeaderAction.test.ts
+++ b/tests/UIShell/HeaderAction.test.ts
@@ -79,6 +79,11 @@ describe("HeaderAction", () => {
       await user.click(button);
       expect(screen.getByTestId("panel-content")).toBeInTheDocument();
 
+      // dismiss() defers window listener registration by a macrotask; flush
+      // it before Escape so the keydown isn't dispatched before the listener
+      // is attached.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
       await user.keyboard("{Escape}");
 
       await waitFor(() =>


### PR DESCRIPTION
Fixes an occasional CI flake on the HeaderAction Escape test: the
keydown could dispatch before use:dismiss's deferred window listener
attached, so it got dropped and the panel never closed.