### PR TITLE
perf(tree-view): expand only expandable nodes

### DIFF
--- a/src/TreeView/TreeView.svelte
+++ b/src/TreeView/TreeView.svelte
@@ -534,11 +534,11 @@
     tick,
   } from "svelte";
   import { writable } from "svelte/store";
+  import { isExpandableNode } from "../utils/isExpandableNode.js";
   import {
     resolveCheckboxState,
     toggleCheckboxNode,
   } from "../utils/treeCheckboxState.js";
-  import { isExpandableNode } from "../utils/isExpandableNode.js";
   import TreeViewNodeList from "./TreeViewNodeList.svelte";
 
   const dispatch = createEventDispatcher();
@@ -638,8 +638,6 @@
   let cachedNodes = null;
   /** @type {Array<Node> | null} */
   let cachedFlattenedNodes = null;
-  /** @type {Array<Node["id"]> | null} */
-  let cachedNodeIds = null;
   /** @type {Map<Node["id"], Node> | null} */
   let cachedNodeMap = null;
   /** @type {Map<Node["id"], Node["id"] | typeof ROOT_PARENT_ID> | null} */
@@ -662,13 +660,12 @@
   }
 
   /**
-   * Build `cachedFlattenedNodes` and `cachedNodeIds` when expand APIs
-   * need them. The `nodes` reactive path only builds maps.
+   * Build `cachedFlattenedNodes` when expand APIs need them. The `nodes`
+   * reactive path only builds maps.
    */
   function ensureFlatIndex() {
     if (cachedFlattenedNodes != null) return;
     cachedFlattenedNodes = traverse(nodes);
-    cachedNodeIds = cachedFlattenedNodes.map((node) => node.id);
   }
 
   /** @type {Node["id"] | null} */
@@ -1118,7 +1115,6 @@
     cachedChildIdsByParentId = maps.childIdsByParentId;
     // Flat list stays null until expandAll / expandNodes / collapseNodes / Ctrl+A.
     cachedFlattenedNodes = null;
-    cachedNodeIds = null;
   }
 
   $: multiselectStore.set(isMultiselect);

--- a/src/TreeView/TreeView.svelte
+++ b/src/TreeView/TreeView.svelte
@@ -353,7 +353,9 @@
   export let indeterminateIds = [];
 
   /**
-   * Programmatically expand all nodes
+   * Programmatically expand all expandable nodes (those with loaded children
+   * or `hasChildren: true`). Leaf ids are omitted — they do not affect
+   * expansion.
    * @type {() => void}
    * @example
    * ```svelte
@@ -363,8 +365,14 @@
    */
   export function expandAll() {
     ensureFlatIndex();
-    expandedIdsSet = new Set(cachedNodeIds);
-    expandedIds = Array.from(expandedIdsSet);
+    // Only expandable ids affect descent; leaf ids are no-ops and waste
+    // memory on large trees.
+    const expandableIds = [];
+    for (const node of cachedFlattenedNodes) {
+      if (isExpandableNode(node)) expandableIds.push(node.id);
+    }
+    expandedIdsSet = new Set(expandableIds);
+    expandedIds = expandableIds;
     lastExpandedIdsRef = expandedIds;
   }
 
@@ -398,15 +406,14 @@
    */
   export function expandNodes(filterNode = () => true) {
     ensureFlatIndex();
-    const nodesToExpand = cachedFlattenedNodes
-      .filter(
-        (node) =>
-          filterNode(node) ||
-          node.nodes?.some((child) => filterNode(child) && child.nodes),
-      )
-      .map((node) => node.id);
-    for (const id of nodesToExpand) {
-      expandedIdsSet.add(id);
+    const nodesToExpand = cachedFlattenedNodes.filter(
+      (node) =>
+        isExpandableNode(node) &&
+        (filterNode(node) ||
+          node.nodes?.some((child) => filterNode(child) && child.nodes)),
+    );
+    for (const node of nodesToExpand) {
+      expandedIdsSet.add(node.id);
     }
     expandedIds = Array.from(expandedIdsSet);
     lastExpandedIdsRef = expandedIds;
@@ -531,6 +538,7 @@
     resolveCheckboxState,
     toggleCheckboxNode,
   } from "../utils/treeCheckboxState.js";
+  import { isExpandableNode } from "../utils/isExpandableNode.js";
   import TreeViewNodeList from "./TreeViewNodeList.svelte";
 
   const dispatch = createEventDispatcher();
@@ -845,17 +853,25 @@
   /** @type {(node: Node, expanded: boolean) => void} */
   function expandNode(node, expanded) {
     if (expanded) {
+      let removedSibling = false;
       if (autoCollapse) {
         const siblingIds = getCachedSiblingIds(node.id);
         for (const siblingId of siblingIds) {
-          expandedIdsSet.delete(siblingId);
+          if (expandedIdsSet.delete(siblingId)) removedSibling = true;
         }
       }
-      expandedIdsSet.add(node.id);
+      const added = !expandedIdsSet.has(node.id);
+      if (added) expandedIdsSet.add(node.id);
+      if (!added && !removedSibling) return;
+      // Bulk sibling collapse needs a full copy; single-id toggles append.
+      expandedIds = removedSibling
+        ? Array.from(expandedIdsSet)
+        : [...expandedIds, node.id];
     } else {
+      if (!expandedIdsSet.has(node.id)) return;
       expandedIdsSet.delete(node.id);
+      expandedIds = expandedIds.filter((id) => id !== node.id);
     }
-    expandedIds = Array.from(expandedIdsSet);
     lastExpandedIdsRef = expandedIds;
   }
 

--- a/src/utils/isExpandableNode.d.ts
+++ b/src/utils/isExpandableNode.d.ts
@@ -1,0 +1,7 @@
+type ExpandableNodeLike = {
+  nodes?: unknown[];
+  hasChildren?: boolean;
+};
+
+/** True when the node can expand (loaded children or lazy `hasChildren`). */
+export function isExpandableNode<T extends ExpandableNodeLike>(node: T): boolean;

--- a/src/utils/isExpandableNode.d.ts
+++ b/src/utils/isExpandableNode.d.ts
@@ -4,4 +4,6 @@ type ExpandableNodeLike = {
 };
 
 /** True when the node can expand (loaded children or lazy `hasChildren`). */
-export function isExpandableNode<T extends ExpandableNodeLike>(node: T): boolean;
+export function isExpandableNode<T extends ExpandableNodeLike>(
+  node: T,
+): boolean;

--- a/src/utils/isExpandableNode.js
+++ b/src/utils/isExpandableNode.js
@@ -7,7 +7,6 @@
  * @returns {boolean}
  */
 export function isExpandableNode(node) {
-  const hasLoadedChildren =
-    Array.isArray(node.nodes) && node.nodes.length > 0;
+  const hasLoadedChildren = Array.isArray(node.nodes) && node.nodes.length > 0;
   return hasLoadedChildren || node.hasChildren === true;
 }

--- a/src/utils/isExpandableNode.js
+++ b/src/utils/isExpandableNode.js
@@ -1,0 +1,13 @@
+/**
+ * True when a tree node can expand: it has loaded children, or it is a lazy
+ * parent marked with `hasChildren` before `nodes` are loaded.
+ *
+ * @template {{ nodes?: unknown[]; hasChildren?: boolean }} T
+ * @param {T} node
+ * @returns {boolean}
+ */
+export function isExpandableNode(node) {
+  const hasLoadedChildren =
+    Array.isArray(node.nodes) && node.nodes.length > 0;
+  return hasLoadedChildren || node.hasChildren === true;
+}

--- a/tests/TreeView/TreeView.expandedChange.test.ts
+++ b/tests/TreeView/TreeView.expandedChange.test.ts
@@ -50,7 +50,7 @@ describe("TreeView toggle:change", () => {
     expect(onToggle).toHaveBeenCalledTimes(2);
   });
 
-  it("expandAll() emits exactly once with every id added", async () => {
+  it("expandAll() emits exactly once with expandable ids added", async () => {
     const onToggleChange = vi.fn();
     render(TreeViewExpandedChange, { onToggleChange });
 
@@ -58,13 +58,14 @@ describe("TreeView toggle:change", () => {
     await waitFor(() => expect(onToggleChange).toHaveBeenCalledTimes(1));
 
     const detail = lastDetail(onToggleChange);
-    // `expandAll` marks every node id (parents and leaves) as expanded.
-    const allIds = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
+    // Only expandable nodes (loaded children or hasChildren) — leaves are
+    // no-ops for descent and are omitted to keep large trees cheap.
+    const expandableIds = [1, 2, 7, 9];
     expect(
       [...detail.expandedIds].sort((a, b) => Number(a) - Number(b)),
-    ).toEqual(allIds);
+    ).toEqual(expandableIds);
     expect([...detail.added].sort((a, b) => Number(a) - Number(b))).toEqual(
-      allIds,
+      expandableIds,
     );
     expect(detail.removed).toEqual([]);
   });

--- a/tests/TreeView/TreeView.lazyIndex.test.svelte
+++ b/tests/TreeView/TreeView.lazyIndex.test.svelte
@@ -70,4 +70,5 @@
 </button>
 
 <span data-testid="expanded-count">{expandedIds.length}</span>
+<span data-testid="expandable-count">{totalRoots}</span>
 <span data-testid="total-count">{totalRoots * (childrenPerRoot + 1)}</span>

--- a/tests/TreeView/TreeView.lazyIndex.test.ts
+++ b/tests/TreeView/TreeView.lazyIndex.test.ts
@@ -28,7 +28,11 @@ describe("TreeView lazy flat index", () => {
     );
 
     await user.click(screen.getByTestId("expand-all"));
+    // expandAll only includes expandable (parent) ids, not leaves.
     expect(screen.getByTestId("expanded-count").textContent).toBe(
+      screen.getByTestId("expandable-count").textContent,
+    );
+    expect(screen.getByTestId("expanded-count").textContent).not.toBe(
       screen.getByTestId("total-count").textContent,
     );
   });


### PR DESCRIPTION
`expandAll` / `expandNodes` used to put every node id into
`expandedIds`, including leaves that never affect descent. That
balloons memory on large trees and makes every caret toggle pay
`Array.from` over a huge set.

This keeps only expandable ids (loaded children or `hasChildren`),
and updates `expandedIds` incrementally on single-node toggles.

## Complexity

Let **N** = total nodes, **P** = expandable (parents / `hasChildren`), **L** = leaves (`N = P + L`). File trees are typically `L ≫ P`.

| Operation | Before | After |
| --- | --- | --- |
| `expandAll()` — `expandedIds` size | **O(N)** | **O(P)** |
| `expandAll()` — build cost | **O(N)** (`Set` + `Array.from` over all ids) | **O(N)** scan + **O(P)** allocate (still walks the flat index; output is smaller) |
| `expandNodes(filter)` — ids added | parents **and** matching leaves | **expandable only** (filter ∩ expandable) |
| `expandNode` expand (no `autoCollapse`) | **O(\|expandedIds\|)** via `Array.from(Set)` | **O(\|expandedIds\|)** append copy; early-return **O(1)** if already expanded |
| `expandNode` collapse | **O(\|expandedIds\|)** via `Array.from(Set)` | **O(\|expandedIds\|)** `filter`; early-return **O(1)** if already collapsed |
| Carets after `expandAll` | each toggle copies **O(N)** | each toggle copies **O(P)** |

Dominant win: peak `expandedIds` memory and per-toggle copy cost drop from **O(N)** to **O(P)** once the tree is fully expanded.

## Risk

Callers that assumed `expandAll()` made `expandedIds.length` equal
the total node count will see a smaller array. Expansion behavior
is unchanged.