### PR TITLE
fix(utils): add graphemeCount for user-perceived character counts

### DIFF
--- a/src/TextArea/TextArea.svelte
+++ b/src/TextArea/TextArea.svelte
@@ -81,6 +81,7 @@
   import { getContext } from "svelte";
   import WarningAltFilled from "../icons/WarningAltFilled.svelte";
   import WarningFilled from "../icons/WarningFilled.svelte";
+  import { graphemeCount } from "../utils/graphemeCount.js";
 
   const formContext = getContext("carbon:Form");
 
@@ -136,7 +137,7 @@
           class:bx--label--disabled={disabled}
           class:bx--text-area__label-counter={true}
         >
-          {(value ?? "").length}/{maxCount}
+          {graphemeCount(value ?? "")}/{maxCount}
         </div>
       {/if}
     </div>

--- a/src/TextInput/TextInput.svelte
+++ b/src/TextInput/TextInput.svelte
@@ -92,6 +92,7 @@
   import EditOff from "../icons/EditOff.svelte";
   import WarningAltFilled from "../icons/WarningAltFilled.svelte";
   import WarningFilled from "../icons/WarningFilled.svelte";
+  import { graphemeCount } from "../utils/graphemeCount.js";
 
   const ctx = getContext("carbon:Form");
   const dispatch = createEventDispatcher();
@@ -158,7 +159,7 @@
               class:bx--label--disabled={disabled}
               class:bx--text-input__label-counter={true}
             >
-              {(value ?? "").toString().length}/{maxCount}
+              {graphemeCount((value ?? "").toString())}/{maxCount}
             </div>
           {/if}
         </div>
@@ -194,7 +195,7 @@
           class:bx--label--disabled={disabled}
           class:bx--text-input__label-counter={true}
         >
-          {(value ?? "").toString().length}/{maxCount}
+          {graphemeCount((value ?? "").toString())}/{maxCount}
         </div>
       {/if}
     </div>

--- a/src/utils/graphemeCount.d.ts
+++ b/src/utils/graphemeCount.d.ts
@@ -1,0 +1,4 @@
+/**
+ * Count user-perceived characters (grapheme clusters) in `value`.
+ */
+export function graphemeCount(value: string): number;

--- a/src/utils/graphemeCount.js
+++ b/src/utils/graphemeCount.js
@@ -1,0 +1,23 @@
+// @ts-check
+// Firefox < 125 has no Intl.Segmenter; code-point iteration is still closer to
+// user-perceived length than value.length (UTF-16 code units).
+
+const segmenter =
+  typeof Intl !== "undefined" && typeof Intl.Segmenter === "function"
+    ? new Intl.Segmenter()
+    : null;
+
+/**
+ * Count user-perceived characters (grapheme clusters) in `value`.
+ *
+ * @param {string} value
+ * @returns {number}
+ */
+export function graphemeCount(value) {
+  if (segmenter) {
+    let count = 0;
+    for (const _ of segmenter.segment(value)) count++;
+    return count;
+  }
+  return [...value].length;
+}

--- a/tests/utils/graphemeCount.test.ts
+++ b/tests/utils/graphemeCount.test.ts
@@ -1,0 +1,16 @@
+import { graphemeCount } from "../../src/utils/graphemeCount.js";
+
+describe("graphemeCount", () => {
+  test("counts plain ASCII characters", () => {
+    expect(graphemeCount("hello")).toBe(5);
+    expect(graphemeCount("")).toBe(0);
+  });
+
+  test("counts a family emoji (ZWJ sequence) as one character", () => {
+    expect(graphemeCount("👨‍👩‍👧")).toBe(1);
+  });
+
+  test("counts a single-codepoint emoji as one character", () => {
+    expect(graphemeCount("😀")).toBe(1);
+  });
+});


### PR DESCRIPTION
Wires the same fix into TextInput and TextArea, whose maxCount
counters had the identical UTF-16 code unit bug.

graphemeCount checks for Intl.Segmenter support at module load.
Where it's available (Chrome/Edge 87+, Safari 14.1+, Firefox
125+), it segments by grapheme cluster. Otherwise it falls back
to code-point iteration (`[...value]`), which still fixes basic
astral-plane characters but not multi-codepoint sequences like
ZWJ emoji or flags.

| Input | Before (`.length`) | After (`graphemeCount`) |
| ----- | ------------------- | ------------------------ |
| `hello` | 5 ✅ | 5 ✅ |
| `😀` | 2 ❌ | 1 ✅ |
| `👨‍👩‍👧` | 8 ❌ | 1 ✅ |
| `🇯🇵` | 4 ❌ | 1 ✅ |