### PR TITLE
fix(data-table): fix tooltip link color in tables

### DIFF
--- a/css/_data-table-tooltip-link.scss
+++ b/css/_data-table-tooltip-link.scss
@@ -1,0 +1,26 @@
+@import "carbon-components/scss/globals/scss/vars";
+@import "carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/import-once/import-once";
+
+/// `Tooltip` uses the inverse (dark) link color since it sits on a dark
+/// popover surface. `DataTable` row hover overrides `.bx--link` color at
+/// equal or higher specificity, so a `Tooltip` inside a hovered row loses its
+/// inverse link color and becomes unreadable. Re-assert the inverse color at
+/// higher specificity for links inside a tooltip.
+/// @access private
+/// @group components
+@mixin data-table-tooltip-link {
+  .#{$prefix}--data-table tr:hover .#{$prefix}--tooltip .#{$prefix}--link,
+  .#{$prefix}--data-table tr:hover .#{$prefix}--tooltip .#{$prefix}--link:visited {
+    color: $inverse-link;
+  }
+
+  .#{$prefix}--data-table tr:hover .#{$prefix}--tooltip .#{$prefix}--link:active,
+  .#{$prefix}--data-table tr:hover .#{$prefix}--tooltip .#{$prefix}--link:active:visited,
+  .#{$prefix}--data-table tr:hover .#{$prefix}--tooltip .#{$prefix}--link:active:visited:hover {
+    color: $inverse-01;
+  }
+}
+
+@include exports("data-table-tooltip-link") {
+  @include data-table-tooltip-link;
+}

--- a/css/all.scss
+++ b/css/all.scss
@@ -96,6 +96,7 @@ $css--plex: true;
 @import "./data-table-toolbar";
 @import "./data-table-zebra-hidden";
 @import "./data-table-highlighted-row";
+@import "./data-table-tooltip-link";
 @import "./data-table-sticky-column-menu";
 @import "./data-table-footer";
 @import "./data-table-align";

--- a/css/g10.scss
+++ b/css/g10.scss
@@ -56,6 +56,7 @@ $css--plex: true;
 @import "./data-table-toolbar";
 @import "./data-table-zebra-hidden";
 @import "./data-table-highlighted-row";
+@import "./data-table-tooltip-link";
 @import "./data-table-sticky-column-menu";
 @import "./data-table-footer";
 @import "./data-table-align";

--- a/css/g100.scss
+++ b/css/g100.scss
@@ -56,6 +56,7 @@ $css--plex: true;
 @import "./data-table-toolbar";
 @import "./data-table-zebra-hidden";
 @import "./data-table-highlighted-row";
+@import "./data-table-tooltip-link";
 @import "./data-table-sticky-column-menu";
 @import "./data-table-footer";
 @import "./data-table-align";

--- a/css/g80.scss
+++ b/css/g80.scss
@@ -56,6 +56,7 @@ $css--plex: true;
 @import "./data-table-toolbar";
 @import "./data-table-zebra-hidden";
 @import "./data-table-highlighted-row";
+@import "./data-table-tooltip-link";
 @import "./data-table-sticky-column-menu";
 @import "./data-table-footer";
 @import "./data-table-align";

--- a/css/g90.scss
+++ b/css/g90.scss
@@ -56,6 +56,7 @@ $css--plex: true;
 @import "./data-table-toolbar";
 @import "./data-table-zebra-hidden";
 @import "./data-table-highlighted-row";
+@import "./data-table-tooltip-link";
 @import "./data-table-sticky-column-menu";
 @import "./data-table-footer";
 @import "./data-table-align";

--- a/css/white.scss
+++ b/css/white.scss
@@ -56,6 +56,7 @@ $css--plex: true;
 @import "./data-table-toolbar";
 @import "./data-table-zebra-hidden";
 @import "./data-table-highlighted-row";
+@import "./data-table-tooltip-link";
 @import "./data-table-sticky-column-menu";
 @import "./data-table-footer";
 @import "./data-table-align";

--- a/docs/src/pages/components/DataTable.svx
+++ b/docs/src/pages/components/DataTable.svx
@@ -4,7 +4,7 @@ description: Data tables display structured data in rows and columns, with sorti
 ---
 
 <script>
-  import { DataTable, DataTableSkeleton, Pagination, Toolbar, ToolbarContent, ToolbarSearch, ToolbarMenu, ToolbarMenuItem, Button, Link, OverflowMenu, OverflowMenuItem } from "carbon-components-svelte";
+  import { DataTable, DataTableSkeleton, Pagination, Toolbar, ToolbarContent, ToolbarSearch, ToolbarMenu, ToolbarMenuItem, Button, Link, Tooltip, OverflowMenu, OverflowMenuItem } from "carbon-components-svelte";
   import Launch from "carbon-icons-svelte/lib/Launch.svelte";
 </script>
 
@@ -134,7 +134,12 @@ Use the `cell` slot to customize cell content. Access row and cell data through 
   </svelte:fragment>
   <svelte:fragment slot="cell" let:row let:cell>
     {#if cell.key === 'rule' && cell.value === 'Round robin'}
-      <Link icon={Launch} href="https://en.wikipedia.org/wiki/Round-robin_DNS" target="_blank">{cell.value}</Link>
+      <Tooltip triggerText={cell.value}>
+        <p>
+          Distributes requests evenly across servers.
+          <Link icon={Launch} href="https://en.wikipedia.org/wiki/Round-robin_DNS" target="_blank">Read more on Wikipedia</Link>
+        </p>
+      </Tooltip>
     {:else}
       {cell.value}
     {/if}


### PR DESCRIPTION
`Tooltip` sets `.bx--link` to the inverse link color, since its
content sits on a dark popover surface. `DataTable`'s row-hover
rule for `.bx--link` has higher CSS specificity, so it wins and
flips the link back to the light-theme color whenever the row
under a tooltip is hovered.

Adds `css/_data-table-tooltip-link.scss`. It re-asserts the
inverse link color for `.bx--link` nested inside `.bx--tooltip`
within a hovered row, at higher specificity than the DataTable
hover rule. Registered in all six theme entry files.

Updates the "Slottable" cell example in `DataTable.svx` to nest a
`Link` inside a `Tooltip`, so the fix is easy to check by hand:
hover a row while its tooltip is open and the link stays legible.

See carbon-design-system/carbon#10182 for the original report
against carbon-components v10.

---

<img width="1378" height="380" alt="Screenshot 2026-08-10 at 2 29 31 PM" src="https://github.com/user-attachments/assets/1727eea9-47e5-4d8c-b646-cdae96732ee7" />
