### PR TITLE
chore(utils): extract uniqueId, reuse across components

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -25,7 +25,7 @@
         "jsdom": "^30.0.1",
         "lightningcss": "^1.33.0",
         "sass-embedded": "^1.100.0",
-        "sveld": "^0.36.2",
+        "sveld": "^0.36.4",
         "svelte": "^5.56.8",
         "svelte-check": "^4.7.3",
         "typescript": "^6.0.3",
@@ -469,7 +469,7 @@
 
     "supports-color": ["supports-color@8.1.1", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q=="],
 
-    "sveld": ["sveld@0.36.2", "", { "bin": { "sveld": "cli.js" } }, "sha512-/0iQRfGTL/9hQyR7MVPr0lM5ZpETFVPUuHJo4eQKYsA3dVn94/tPzFUgwpBiPXIrnb1CI8Euewk9fOBi3cPPOA=="],
+    "sveld": ["sveld@0.36.4", "", { "bin": { "sveld": "cli.js" } }, "sha512-yVLcBJI4PcFu4acRrD8o7rEzGvJKNNZV9zNdnW4UdVtKsPS95vs0CDjdykZbFWo7w0HVak08tA8g2fjiz3xQ5g=="],
 
     "svelte": ["svelte@5.56.8", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "@jridgewell/sourcemap-codec": "^1.5.0", "@sveltejs/acorn-typescript": "^1.0.10", "@types/estree": "^1.0.5", "@types/trusted-types": "^2.0.7", "acorn": "^8.12.1", "aria-query": "5.3.1", "axobject-query": "^4.1.0", "clsx": "^2.1.1", "devalue": "^5.8.1", "esm-env": "^1.2.1", "esrap": "^2.2.12", "is-reference": "^3.0.3", "locate-character": "^3.0.0", "magic-string": "^0.30.11", "zimmerframe": "^1.1.2" } }, "sha512-PY8LOw7xP6c8IOiVqdo0sbbZVYhXRSfklOQLAUyGBKqjTX0wx/z4l/9J+PmBpmlLnxzEb1NqltxQ5/wZme/Cmg=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -25,7 +25,7 @@
         "jsdom": "^30.0.1",
         "lightningcss": "^1.33.0",
         "sass-embedded": "^1.100.0",
-        "sveld": "^0.36.4",
+        "sveld": "^0.36.5",
         "svelte": "^5.56.8",
         "svelte-check": "^4.7.3",
         "typescript": "^6.0.3",
@@ -469,7 +469,7 @@
 
     "supports-color": ["supports-color@8.1.1", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q=="],
 
-    "sveld": ["sveld@0.36.4", "", { "bin": { "sveld": "cli.js" } }, "sha512-yVLcBJI4PcFu4acRrD8o7rEzGvJKNNZV9zNdnW4UdVtKsPS95vs0CDjdykZbFWo7w0HVak08tA8g2fjiz3xQ5g=="],
+    "sveld": ["sveld@0.36.5", "", { "bin": { "sveld": "cli.js" } }, "sha512-Io/tksmCwZpzkMwjOxOwbIEKTwwD19Vj1ALrT2cT5EBVqM76O7HY2fkAb8N7X3TFgvmh++rRncLAjG2gcTZ/fA=="],
 
     "svelte": ["svelte@5.56.8", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "@jridgewell/sourcemap-codec": "^1.5.0", "@sveltejs/acorn-typescript": "^1.0.10", "@types/estree": "^1.0.5", "@types/trusted-types": "^2.0.7", "acorn": "^8.12.1", "aria-query": "5.3.1", "axobject-query": "^4.1.0", "clsx": "^2.1.1", "devalue": "^5.8.1", "esm-env": "^1.2.1", "esrap": "^2.2.12", "is-reference": "^3.0.3", "locate-character": "^3.0.0", "magic-string": "^0.30.11", "zimmerframe": "^1.1.2" } }, "sha512-PY8LOw7xP6c8IOiVqdo0sbbZVYhXRSfklOQLAUyGBKqjTX0wx/z4l/9J+PmBpmlLnxzEb1NqltxQ5/wZme/Cmg=="],
 

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "jsdom": "^30.0.1",
     "lightningcss": "^1.33.0",
     "sass-embedded": "^1.100.0",
-    "sveld": "^0.36.4",
+    "sveld": "^0.36.5",
     "svelte": "^5.56.8",
     "svelte-check": "^4.7.3",
     "typescript": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "jsdom": "^30.0.1",
     "lightningcss": "^1.33.0",
     "sass-embedded": "^1.100.0",
-    "sveld": "^0.36.2",
+    "sveld": "^0.36.4",
     "svelte": "^5.56.8",
     "svelte-check": "^4.7.3",
     "typescript": "^6.0.3",

--- a/src/Accordion/AccordionItem.svelte
+++ b/src/Accordion/AccordionItem.svelte
@@ -44,6 +44,7 @@
 
   import { getContext, onMount } from "svelte";
   import ChevronRight from "../icons/ChevronRight.svelte";
+  import { uniqueId } from "../utils/uniqueId.js";
 
   let initialDisabled = disabled;
 
@@ -54,7 +55,7 @@
   });
 
   const id = {};
-  const contentId = `ccs-${Math.random().toString(36)}`;
+  const contentId = uniqueId();
 
   const unsubscribeOpenId = ctx.openId.subscribe((openItemId) => {
     if (openItemId !== null && openItemId !== id) {

--- a/src/Checkbox/Checkbox.svelte
+++ b/src/Checkbox/Checkbox.svelte
@@ -74,7 +74,7 @@
   export let title = undefined;
 
   /** Set an id for the input label */
-  export let id = `ccs-${Math.random().toString(36)}`;
+  export let id = uniqueId();
 
   /**
    * Set the tabindex for the input element.
@@ -103,6 +103,7 @@
   import WarningAltFilled from "../icons/WarningAltFilled.svelte";
   import WarningFilled from "../icons/WarningFilled.svelte";
   import { overflowTitle } from "../utils/overflowTitle.js";
+  import { uniqueId } from "../utils/uniqueId.js";
   import CheckboxSkeleton from "./CheckboxSkeleton.svelte";
 
   const dispatch = createEventDispatcher();

--- a/src/Checkbox/CheckboxGroup.svelte
+++ b/src/Checkbox/CheckboxGroup.svelte
@@ -70,6 +70,7 @@
   import { readonly as readOnly, writable } from "svelte/store";
   import WarningAltFilled from "../icons/WarningAltFilled.svelte";
   import WarningFilled from "../icons/WarningFilled.svelte";
+  import { uniqueId } from "../utils/uniqueId.js";
 
   const dispatch = createEventDispatcher();
   /**
@@ -125,9 +126,9 @@
   $: showInvalid = invalid && !disabled && !readonly;
   $: showWarn = warn && !invalid && !disabled && !readonly;
 
-  const fallbackHelperId = `ccs-${Math.random().toString(36)}`;
-  const fallbackErrorId = `ccs-${Math.random().toString(36)}`;
-  const fallbackWarnId = `ccs-${Math.random().toString(36)}`;
+  const fallbackHelperId = uniqueId();
+  const fallbackErrorId = uniqueId();
+  const fallbackWarnId = uniqueId();
   $: helperId = id ? `helper-${id}` : fallbackHelperId;
   $: errorId = id ? `error-${id}` : fallbackErrorId;
   $: warnId = id ? `warn-${id}` : fallbackWarnId;

--- a/src/Checkbox/InlineCheckbox.svelte
+++ b/src/Checkbox/InlineCheckbox.svelte
@@ -1,4 +1,6 @@
 <script>
+  import { uniqueId } from "../utils/uniqueId.js";
+
   /** Specify whether the checkbox is checked */
   export let checked = false;
 
@@ -12,7 +14,7 @@
   export let title = undefined;
 
   /** Set an id for the input label */
-  export let id = `ccs-${Math.random().toString(36)}`;
+  export let id = uniqueId();
 
   /** Obtain a reference to the input HTML element */
   export let ref = null;

--- a/src/CodeSnippet/CodeSnippet.svelte
+++ b/src/CodeSnippet/CodeSnippet.svelte
@@ -173,7 +173,7 @@
   export let minExpandedNumberOfRows = 16;
 
   /** Set an id for the code element */
-  export let id = `ccs-${Math.random().toString(36)}`;
+  export let id = uniqueId();
 
   /**
    * Obtain a reference to the pre HTML element.
@@ -213,6 +213,7 @@
   import PortalTooltip from "../Portal/PortalTooltip.svelte";
   import { observeModalClose } from "../Portal/portal-utils.js";
   import { createCopyFeedbackState } from "../utils/copyFeedback.js";
+  import { uniqueId } from "../utils/uniqueId.js";
   import CodeSnippetSkeleton from "./CodeSnippetSkeleton.svelte";
 
   const dispatch = createEventDispatcher();

--- a/src/ComboBox/ComboBox.svelte
+++ b/src/ComboBox/ComboBox.svelte
@@ -185,7 +185,7 @@
   export let translateWithIdSelection = undefined;
 
   /** Set an id for the list box component */
-  export let id = `ccs-${Math.random().toString(36)}`;
+  export let id = uniqueId();
 
   /**
    * Specify a name attribute for the input.
@@ -250,6 +250,7 @@
   import { isOutsideClick } from "../utils/isOutsideClick.js";
   import { createScrollEndTracker } from "../utils/isScrollNearEnd.js";
   import { moveIndex } from "../utils/moveIndex.js";
+  import { uniqueId } from "../utils/uniqueId.js";
   import {
     resetVirtualScrollOnClose,
     scrollHighlightedIntoView,

--- a/src/ComposedModal/ComposedModal.svelte
+++ b/src/ComposedModal/ComposedModal.svelte
@@ -48,6 +48,7 @@
   import { initialFocus, restoreFocus } from "../utils/focus.js";
   import { createOutsideDismiss } from "../utils/outsideDismiss.js";
   import { trapFocus } from "../utils/trapFocus.js";
+  import { uniqueId } from "../utils/uniqueId.js";
 
   const dispatch = createEventDispatcher();
   const label = writable(undefined);
@@ -56,7 +57,7 @@
 
   // Ids for ModalHeader's label/title headings, so ModalBody (when
   // `hasScrollingContent`) can name its region via `aria-labelledby`.
-  const modalId = `ccs-${Math.random().toString(36)}`;
+  const modalId = uniqueId();
   const labelId = `${modalId}-label`;
   const titleId = `${modalId}-title`;
 

--- a/src/ContainedList/ContainedList.svelte
+++ b/src/ContainedList/ContainedList.svelte
@@ -1,4 +1,6 @@
 <script>
+  import { uniqueId } from "../utils/uniqueId.js";
+
   /**
    * Specify the kind of contained list.
    * @type {"on-page" | "disclosed"}
@@ -21,7 +23,7 @@
   export let inset = false;
 
   /** Set an id for the list element */
-  export let id = `ccs-${Math.random().toString(36)}`;
+  export let id = uniqueId();
 
   $: labelId = `label-${id}`;
 </script>

--- a/src/ContentSwitcher/ContentSwitcher.svelte
+++ b/src/ContentSwitcher/ContentSwitcher.svelte
@@ -45,6 +45,7 @@
 
   import { afterUpdate, createEventDispatcher, setContext, tick } from "svelte";
   import { writable } from "svelte/store";
+  import { clampIndex } from "../utils/clampIndex.js";
   import { rovingFocus } from "../utils/rovingFocus.js";
   import { syncDomOrder } from "../utils/syncDomOrder.js";
 
@@ -134,7 +135,7 @@
 
     if (switches.length === 0) return;
 
-    selectedIndex = Math.min(Math.max(selectedIndex, 0), switches.length - 1);
+    selectedIndex = clampIndex(selectedIndex, 0, switches.length);
     selectedId = switches[selectedIndex]?.id;
   }
 

--- a/src/ContentSwitcher/Switch.svelte
+++ b/src/ContentSwitcher/Switch.svelte
@@ -39,7 +39,7 @@
   export let tooltipAlignment = "center";
 
   /** Set an id for the button element */
-  export let id = `ccs-${Math.random().toString(36)}`;
+  export let id = uniqueId();
 
   /**
    * Obtain a reference to the button HTML element.
@@ -50,6 +50,7 @@
   import { getContext, onMount } from "svelte";
   import { get } from "svelte/store";
   import PortalTooltip from "../Portal/PortalTooltip.svelte";
+  import { uniqueId } from "../utils/uniqueId.js";
 
   const ctx = getContext("carbon:ContentSwitcher");
   const activeTooltip = ctx.activeTooltip;

--- a/src/ContextMenu/ContextMenuOption.svelte
+++ b/src/ContextMenu/ContextMenuOption.svelte
@@ -74,7 +74,7 @@
    * Specify the id.
    * It's recommended to provide an id as a value to bind to within a selectable/radio menu group.
    */
-  export let id = `ccs-${Math.random().toString(36)}`;
+  export let id = uniqueId();
 
   /**
    * Obtain a reference to the list item HTML element.
@@ -86,6 +86,7 @@
   import CaretRight from "../icons/CaretRight.svelte";
   import Checkmark from "../icons/Checkmark.svelte";
   import { clampIndex } from "../utils/clampIndex.js";
+  import { uniqueId } from "../utils/uniqueId.js";
   import ContextMenu from "./ContextMenu.svelte";
 
   const dispatch = createEventDispatcher();

--- a/src/ContextMenu/ContextMenuOption.svelte
+++ b/src/ContextMenu/ContextMenuOption.svelte
@@ -86,6 +86,7 @@
   import CaretRight from "../icons/CaretRight.svelte";
   import Checkmark from "../icons/Checkmark.svelte";
   import { clampIndex } from "../utils/clampIndex.js";
+  import { createSubmenuHoverIntent } from "../utils/submenuHoverIntent.js";
   import { uniqueId } from "../utils/uniqueId.js";
   import ContextMenu from "./ContextMenu.svelte";
 
@@ -100,8 +101,6 @@
 
   let unsubCurrentIds = undefined;
   let unsubCurrentId = undefined;
-  let timeoutHover = undefined;
-  let timeoutClose = undefined;
   let rootMenuPosition = [0, 0];
   let focusIndex = 0;
   let options = [];
@@ -111,6 +110,13 @@
   let menuOffsetX = 0;
   /** @type {HTMLUListElement | null} */
   let submenuRef = null;
+
+  const hoverIntent = createSubmenuHoverIntent(
+    (value) => {
+      submenuOpen = value;
+    },
+    { openDelay: moderate01, closeDelay },
+  );
 
   const unsubPosition = ctx.position.subscribe((position) => {
     rootMenuPosition = position;
@@ -164,8 +170,7 @@
       unsubMenuOffsetX();
       if (unsubCurrentIds) unsubCurrentIds();
       if (unsubCurrentId) unsubCurrentId();
-      if (typeof timeoutHover === "number") clearTimeout(timeoutHover);
-      if (typeof timeoutClose === "number") clearTimeout(timeoutClose);
+      hoverIntent.cancel();
     };
   });
 
@@ -278,24 +283,13 @@
   on:mouseenter
   on:mouseenter={() => {
     if (subOptions && !disabled) {
-      if (typeof timeoutClose === "number") {
-        clearTimeout(timeoutClose);
-        timeoutClose = undefined;
-      }
-
-      timeoutHover = setTimeout(() => {
-        submenuOpen = true;
-      }, moderate01);
+      hoverIntent.scheduleOpen();
     }
   }}
   on:mouseleave
   on:mouseleave={() => {
     if (subOptions) {
-      if (typeof timeoutHover === "number") clearTimeout(timeoutHover);
-
-      timeoutClose = setTimeout(() => {
-        submenuOpen = false;
-      }, closeDelay);
+      hoverIntent.scheduleClose();
     }
   }}
   on:click={(event) => {

--- a/src/CopyInput/CopyInput.svelte
+++ b/src/CopyInput/CopyInput.svelte
@@ -71,7 +71,7 @@
   export let helperText = "";
 
   /** Set an id for the input element */
-  export let id = `ccs-${Math.random().toString(36)}`;
+  export let id = uniqueId();
 
   /**
    * Specify a name attribute for the input.
@@ -134,6 +134,7 @@
 
   import { createEventDispatcher, getContext } from "svelte";
   import CopyButton from "../CopyButton/CopyButton.svelte";
+  import { uniqueId } from "../utils/uniqueId.js";
 
   const dispatch = createEventDispatcher();
   const ctx = getContext("carbon:Form");

--- a/src/DataTable/DataTable.svelte
+++ b/src/DataTable/DataTable.svelte
@@ -142,7 +142,7 @@
    * When the table is inside a form, this name will
    * be included in the form data on submit.
    */
-  export let inputName = `ccs-${Math.random().toString(36)}`;
+  export let inputName = uniqueId();
 
   /** Set to `true` to use zebra styles */
   export let zebra = false;
@@ -328,6 +328,7 @@
   import InlineCheckbox from "../Checkbox/InlineCheckbox.svelte";
   import ChevronRight from "../icons/ChevronRight.svelte";
   import RadioButton from "../RadioButton/RadioButton.svelte";
+  import { uniqueId } from "../utils/uniqueId.js";
   import { virtualize as virtualizeUtil } from "../utils/virtualize.js";
   import {
     compareValues,
@@ -417,7 +418,7 @@
 
   // Internal ID prefix for radio buttons, checkboxes, etc.
   // since there may be multiple `DataTable` instances that have overlapping row ids.
-  const id = `ccs-${Math.random().toString(36)}`;
+  const id = uniqueId();
 
   // Label the table with its title/description. Only when the default
   // heading markup renders (not overridden via the titleChildren /

--- a/src/DataTable/TableContainer.svelte
+++ b/src/DataTable/TableContainer.svelte
@@ -13,9 +13,10 @@
 
   import { setContext } from "svelte";
   import { writable } from "svelte/store";
+  import { uniqueId } from "../utils/uniqueId.js";
 
-  const titleId = `ccs-${Math.random().toString(36)}`;
-  const descriptionId = `ccs-${Math.random().toString(36)}`;
+  const titleId = uniqueId();
+  const descriptionId = uniqueId();
   const hasTitle = writable(!!title);
   const hasDescription = writable(!!description);
 

--- a/src/DataTable/TableHeader.svelte
+++ b/src/DataTable/TableHeader.svelte
@@ -31,10 +31,11 @@
   export let translateWithId = (id) => defaultTranslations[id];
 
   /** Set an id for the top-level element */
-  export let id = `ccs-${Math.random().toString(36)}`;
+  export let id = uniqueId();
 
   import ArrowsVertical from "../icons/ArrowsVertical.svelte";
   import ArrowUp from "../icons/ArrowUp.svelte";
+  import { uniqueId } from "../utils/uniqueId.js";
 
   const defaultTranslations = {
     [translationIds.columnSortAscending]:

--- a/src/DataTable/data-table-utils.js
+++ b/src/DataTable/data-table-utils.js
@@ -1,4 +1,6 @@
 // @ts-check
+import { BoundedFifoCache } from "../utils/boundedFifoCache.js";
+
 /**
  * Deep equality check for values (nested objects and arrays).
  * @param {*} a - First value to compare
@@ -152,8 +154,8 @@ export function shouldIgnoreRowClick(target) {
 
 const PATH_SPLIT_REGEX = /[.[\]'"]/;
 const MAX_PATH_CACHE_SIZE = 1000;
-/** @type {Map<string, string[]>} */
-const pathCache = new Map();
+/** @type {BoundedFifoCache<string, string[]>} */
+const pathCache = new BoundedFifoCache(MAX_PATH_CACHE_SIZE);
 
 /**
  * Resolves a nested property path in an object.
@@ -170,12 +172,6 @@ export function resolvePath(object, path) {
   if (!segments) {
     segments = path.split(PATH_SPLIT_REGEX).filter((p) => p);
     if (segments.length > 1) {
-      if (pathCache.size >= MAX_PATH_CACHE_SIZE) {
-        const firstKey = pathCache.keys().next().value;
-        if (firstKey !== undefined) {
-          pathCache.delete(firstKey);
-        }
-      }
       pathCache.set(path, segments);
     }
   }

--- a/src/DatePicker/DatePicker.svelte
+++ b/src/DatePicker/DatePicker.svelte
@@ -89,7 +89,7 @@
   export let portalMenu = undefined;
 
   /** Set an id for the date picker element */
-  export let id = `ccs-${Math.random().toString(36)}`;
+  export let id = uniqueId();
 
   /**
    * Override the options passed to the Flatpickr instance.
@@ -117,6 +117,7 @@
   } from "svelte";
   import { derived, writable } from "svelte/store";
   import { dismiss } from "../utils/dismiss.js";
+  import { uniqueId } from "../utils/uniqueId.js";
   import { createCalendar, resolveLocale } from "./createCalendar";
   import {
     getTopLayerAncestor,

--- a/src/DatePicker/DatePickerInput.svelte
+++ b/src/DatePicker/DatePickerInput.svelte
@@ -32,7 +32,7 @@
   export let iconDescription = "";
 
   /** Set an id for the input element */
-  export let id = `ccs-${Math.random().toString(36)}`;
+  export let id = uniqueId();
 
   /** Specify the label text */
   export let labelText = "";
@@ -68,6 +68,7 @@
   import Calendar from "../icons/Calendar.svelte";
   import WarningAltFilled from "../icons/WarningAltFilled.svelte";
   import WarningFilled from "../icons/WarningFilled.svelte";
+  import { uniqueId } from "../utils/uniqueId.js";
 
   const REGEX_SPECIAL_CHARS = /[/\\^$*+?.()|[\]{}]/g;
 

--- a/src/Disclosure/Disclosure.svelte
+++ b/src/Disclosure/Disclosure.svelte
@@ -32,10 +32,11 @@
 
   import { createEventDispatcher } from "svelte";
   import ChevronRight from "../icons/ChevronRight.svelte";
+  import { uniqueId } from "../utils/uniqueId.js";
 
   const dispatch = createEventDispatcher();
 
-  const contentId = `ccs-${Math.random().toString(36)}`;
+  const contentId = uniqueId();
 
   let animation = undefined;
 

--- a/src/Dropdown/Dropdown.svelte
+++ b/src/Dropdown/Dropdown.svelte
@@ -189,7 +189,7 @@
   export let portalMenu = undefined;
 
   /** Set an id for the list box component */
-  export let id = `ccs-${Math.random().toString(36)}`;
+  export let id = uniqueId();
 
   /**
    * Specify a name attribute for the list box.
@@ -237,6 +237,7 @@
   import { createScrollEndTracker } from "../utils/isScrollNearEnd.js";
   import { moveIndex } from "../utils/moveIndex.js";
   import { typeaheadIndex } from "../utils/typeahead.js";
+  import { uniqueId } from "../utils/uniqueId.js";
   import {
     resetVirtualScrollOnClose,
     scrollHighlightedIntoView,

--- a/src/FileUploader/FileUploaderButton.svelte
+++ b/src/FileUploader/FileUploaderButton.svelte
@@ -53,7 +53,7 @@
   export let labelText = "Add file";
 
   /** Set an id for the input element */
-  export let id = `ccs-${Math.random().toString(36)}`;
+  export let id = uniqueId();
 
   /** Specify a name attribute for the input */
   export let name = "";
@@ -97,6 +97,7 @@
   export let hideTooltip = false;
 
   import { createEventDispatcher } from "svelte";
+  import { uniqueId } from "../utils/uniqueId.js";
 
   const dispatch = createEventDispatcher();
 

--- a/src/FileUploader/FileUploaderDropContainer.svelte
+++ b/src/FileUploader/FileUploaderDropContainer.svelte
@@ -68,7 +68,7 @@
   export let tabindex = "0";
 
   /** Set an id for the input element */
-  export let id = `ccs-${Math.random().toString(36)}`;
+  export let id = uniqueId();
 
   /** Specify a name attribute for the input */
   export let name = "";
@@ -81,6 +81,7 @@
 
   import { createEventDispatcher } from "svelte";
   import { filterIncomingFiles } from "../utils/filterIncomingFiles.js";
+  import { uniqueId } from "../utils/uniqueId.js";
 
   const dispatch = createEventDispatcher();
 

--- a/src/FileUploader/FileUploaderItem.svelte
+++ b/src/FileUploader/FileUploaderItem.svelte
@@ -33,12 +33,13 @@
   export let errorBody = "";
 
   /** Set an id for the top-level element */
-  export let id = `ccs-${Math.random().toString(36)}`;
+  export let id = uniqueId();
 
   /** Specify the file uploader name */
   export let name = "";
 
   import { createEventDispatcher } from "svelte";
+  import { uniqueId } from "../utils/uniqueId.js";
   import Filename from "./Filename.svelte";
 
   const dispatch = createEventDispatcher();

--- a/src/FormLabel/FormLabel.svelte
+++ b/src/FormLabel/FormLabel.svelte
@@ -1,6 +1,8 @@
 <script>
+  import { uniqueId } from "../utils/uniqueId.js";
+
   /** Set an id to be used by the label element */
-  export let id = `ccs-${Math.random().toString(36)}`;
+  export let id = uniqueId();
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->

--- a/src/ListBox/ListBoxField.svelte
+++ b/src/ListBox/ListBoxField.svelte
@@ -15,7 +15,7 @@
   export let tabindex = "-1";
 
   /** Set an id for the top-level element */
-  export let id = `ccs-${Math.random().toString(36)}`;
+  export let id = uniqueId();
 
   /**
    * Obtain a reference to the top-level HTML element.
@@ -24,6 +24,7 @@
   export let ref = null;
 
   import { getContext } from "svelte";
+  import { uniqueId } from "../utils/uniqueId.js";
 
   const ctx = getContext("carbon:MultiSelect");
 

--- a/src/ListBox/ListBoxMenu.svelte
+++ b/src/ListBox/ListBoxMenu.svelte
@@ -1,6 +1,6 @@
 <script>
   /** Set an id for the top-level element */
-  export let id = `ccs-${Math.random().toString(36)}`;
+  export let id = uniqueId();
 
   /**
    * Obtain a reference to the HTML element.
@@ -44,6 +44,7 @@
   export let portalHostClass = undefined;
 
   import FloatingPortal from "../Portal/FloatingPortal.svelte";
+  import { uniqueId } from "../utils/uniqueId.js";
 </script>
 
 {#if portal}

--- a/src/Menu/MenuItem.svelte
+++ b/src/Menu/MenuItem.svelte
@@ -80,6 +80,7 @@
   import { createEventDispatcher, getContext, onMount } from "svelte";
   import CaretRight from "../icons/CaretRight.svelte";
   import Checkmark from "../icons/Checkmark.svelte";
+  import { createSubmenuHoverIntent } from "../utils/submenuHoverIntent.js";
   import { uniqueId } from "../utils/uniqueId.js";
   import Menu from "./Menu.svelte";
 
@@ -94,8 +95,12 @@
   const ctxRadioGroup = getContext("carbon:MenuItemRadioGroup");
 
   let submenuOpen = false;
-  let hoverTimeout;
-  let closeTimeout;
+  const hoverIntent = createSubmenuHoverIntent(
+    (value) => {
+      submenuOpen = value;
+    },
+    { openDelay: HOVER_DELAY_MS, closeDelay: HOVER_DELAY_MS },
+  );
   // `selected` implies the checkbox variant. Latch it instead of writing back
   // to `selectable` so deselecting the item keeps its role and indentation.
   let hasBeenSelected = false;
@@ -133,28 +138,20 @@
 
   function openSubmenu() {
     if (disabled) return;
-    clearTimeout(hoverTimeout);
-    clearTimeout(closeTimeout);
-    submenuOpen = true;
+    hoverIntent.open();
   }
 
   function scheduleOpenSubmenu() {
     if (disabled) return;
-    clearTimeout(closeTimeout);
-    clearTimeout(hoverTimeout);
-    hoverTimeout = setTimeout(openSubmenu, HOVER_DELAY_MS);
+    hoverIntent.scheduleOpen();
   }
 
   function scheduleCloseSubmenu() {
-    clearTimeout(hoverTimeout);
-    clearTimeout(closeTimeout);
-    closeTimeout = setTimeout(() => {
-      submenuOpen = false;
-    }, HOVER_DELAY_MS);
+    hoverIntent.scheduleClose();
   }
 
   function cancelCloseSubmenu() {
-    clearTimeout(closeTimeout);
+    hoverIntent.cancelClose();
   }
 
   onMount(() => {
@@ -173,8 +170,7 @@
     }
 
     return () => {
-      clearTimeout(hoverTimeout);
-      clearTimeout(closeTimeout);
+      hoverIntent.cancel();
       unsubscribe?.();
     };
   });

--- a/src/Menu/MenuItem.svelte
+++ b/src/Menu/MenuItem.svelte
@@ -69,7 +69,7 @@
    * It's recommended to provide an id as a value to bind to
    * within a selectable or radio menu group.
    */
-  export let id = `ccs-${Math.random().toString(36)}`;
+  export let id = uniqueId();
 
   /**
    * Obtain a reference to the list item HTML element.
@@ -80,6 +80,7 @@
   import { createEventDispatcher, getContext, onMount } from "svelte";
   import CaretRight from "../icons/CaretRight.svelte";
   import Checkmark from "../icons/Checkmark.svelte";
+  import { uniqueId } from "../utils/uniqueId.js";
   import Menu from "./Menu.svelte";
 
   // "moderate-01" duration (ms) from Carbon motion recommended for small

--- a/src/Modal/Modal.svelte
+++ b/src/Modal/Modal.svelte
@@ -125,7 +125,7 @@
   export let hideCloseButton = false;
 
   /** Set an id for the top-level element */
-  export let id = `ccs-${Math.random().toString(36)}`;
+  export let id = uniqueId();
 
   /**
    * Obtain a reference to the top-level HTML element.
@@ -141,6 +141,7 @@
   import { initialFocus, restoreFocus } from "../utils/focus.js";
   import { createOutsideDismiss } from "../utils/outsideDismiss.js";
   import { trapFocus } from "../utils/trapFocus.js";
+  import { uniqueId } from "../utils/uniqueId.js";
   import { trackModal } from "./modalStore";
 
   const dispatch = createEventDispatcher();

--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -179,7 +179,7 @@
   export let hideLabel = false;
 
   /** Set an id for the list box component */
-  export let id = `ccs-${Math.random().toString(36)}`;
+  export let id = uniqueId();
 
   /** Set to `true` to use the read-only variant */
   export let readonly = false;
@@ -318,6 +318,7 @@
   import { isOutsideClick } from "../utils/isOutsideClick.js";
   import { createScrollEndTracker } from "../utils/isScrollNearEnd.js";
   import { moveIndex } from "../utils/moveIndex.js";
+  import { uniqueId } from "../utils/uniqueId.js";
   import {
     resetVirtualScrollOnClose,
     scrollHighlightedIntoView,

--- a/src/NumberInput/NumberInput.svelte
+++ b/src/NumberInput/NumberInput.svelte
@@ -153,7 +153,7 @@
   };
 
   /** Set an id for the input element */
-  export let id = `ccs-${Math.random().toString(36)}`;
+  export let id = uniqueId();
 
   /**
    * Specify a name attribute for the input.
@@ -180,6 +180,7 @@
     parseLocaleValue,
     roundToStep,
   } from "../utils/numericFormat.js";
+  import { uniqueId } from "../utils/uniqueId.js";
 
   const defaultTranslations = {
     [translationIds.increment]: "Increment number",

--- a/src/OverflowMenu/OverflowMenu.svelte
+++ b/src/OverflowMenu/OverflowMenu.svelte
@@ -69,7 +69,7 @@
   export let iconDescription = "Open and close list of options";
 
   /** Set an id for the button element */
-  export let id = `ccs-${Math.random().toString(36)}`;
+  export let id = uniqueId();
 
   /**
    * Obtain a reference to the trigger button element.
@@ -105,6 +105,7 @@
   import { isOutsideClick } from "../utils/isOutsideClick.js";
   import { keyBy } from "../utils/keyBy.js";
   import { rovingFocus } from "../utils/rovingFocus.js";
+  import { uniqueId } from "../utils/uniqueId.js";
 
   const ctxBreadcrumbItem = getContext("carbon:BreadcrumbItem");
   const insideModal = getContext("carbon:Modal");

--- a/src/OverflowMenu/OverflowMenuItem.svelte
+++ b/src/OverflowMenu/OverflowMenuItem.svelte
@@ -80,7 +80,7 @@
   export let requireTitle = true;
 
   /** Set an id for the top-level element */
-  export let id = `ccs-${Math.random().toString(36)}`;
+  export let id = uniqueId();
 
   /**
    * Obtain a reference to the HTML element.
@@ -95,6 +95,7 @@
     onMount,
   } from "svelte";
   import { scrollIntoViewWithinMenu } from "../utils/scrollIntoViewWithinMenu.js";
+  import { uniqueId } from "../utils/uniqueId.js";
 
   const dispatch = createEventDispatcher();
   const { focusedId, add, remove, update, itemsById } = getContext(

--- a/src/Pagination/Pagination.svelte
+++ b/src/Pagination/Pagination.svelte
@@ -131,7 +131,7 @@
     `of ${total.toLocaleString()} page${total === 1 ? "" : "s"}`;
 
   /** Set an id for the top-level element */
-  export let id = `ccs-${Math.random().toString(36)}`;
+  export let id = uniqueId();
 
   /**
    * Specify the size of the pagination.
@@ -145,6 +145,7 @@
   import CaretRight from "../icons/CaretRight.svelte";
   import Select from "../Select/Select.svelte";
   import SelectItem from "../Select/SelectItem.svelte";
+  import { uniqueId } from "../utils/uniqueId.js";
 
   const dispatch = createEventDispatcher();
 

--- a/src/PinCodeInput/PinCodeInput.svelte
+++ b/src/PinCodeInput/PinCodeInput.svelte
@@ -151,7 +151,7 @@
   export let selectTextOnFocus = false;
 
   /** Set an id for the input group */
-  export let id = `ccs-${Math.random().toString(36)}`;
+  export let id = uniqueId();
 
   /**
    * Obtain a reference to the outer element.
@@ -163,6 +163,7 @@
   import { createEventDispatcher, getContext, onMount } from "svelte";
   import WarningAltFilled from "../icons/WarningAltFilled.svelte";
   import WarningFilled from "../icons/WarningFilled.svelte";
+  import { uniqueId } from "../utils/uniqueId.js";
 
   const dispatch = createEventDispatcher();
   const formContext = getContext("carbon:Form");

--- a/src/ProgressBar/ProgressBar.svelte
+++ b/src/ProgressBar/ProgressBar.svelte
@@ -36,17 +36,18 @@
   export let helperText = "";
 
   /** Set an id for the progress bar element */
-  export let id = `ccs-${Math.random().toString(36)}`;
+  export let id = uniqueId();
 
   import CheckmarkFilled from "../icons/CheckmarkFilled.svelte";
   import ErrorFilled from "../icons/ErrorFilled.svelte";
+  import { uniqueId } from "../utils/uniqueId.js";
 
   const statusIcons = {
     error: ErrorFilled,
     finished: CheckmarkFilled,
   };
 
-  let helperId = `ccs-${Math.random().toString(36)}`;
+  let helperId = uniqueId();
 
   $: indeterminate = value === undefined && status === "active";
   let capped;

--- a/src/ProgressIndicator/ProgressIndicator.svelte
+++ b/src/ProgressIndicator/ProgressIndicator.svelte
@@ -27,6 +27,7 @@
 
   import { createEventDispatcher, setContext } from "svelte";
   import { derived, writable } from "svelte/store";
+  import { clampIndex } from "../utils/clampIndex.js";
   import { keyBy } from "../utils/keyBy.js";
 
   const dispatch = createEventDispatcher();
@@ -118,7 +119,7 @@
 
     if ($steps.length === 0) return;
 
-    currentIndex = Math.min(Math.max(currentIndex, 0), $steps.length - 1);
+    currentIndex = clampIndex(currentIndex, 0, $steps.length);
     selectedId = $steps[currentIndex]?.id;
   }
 

--- a/src/ProgressIndicator/ProgressStep.svelte
+++ b/src/ProgressIndicator/ProgressStep.svelte
@@ -24,7 +24,7 @@
   export let secondaryLabel = "";
 
   /** Set an id for the top-level element */
-  export let id = `ccs-${Math.random().toString(36)}`;
+  export let id = uniqueId();
 
   import { getContext, onMount } from "svelte";
   import { writable } from "svelte/store";
@@ -32,6 +32,7 @@
   import CircleDash from "../icons/CircleDash.svelte";
   import Incomplete from "../icons/Incomplete.svelte";
   import Warning from "../icons/Warning.svelte";
+  import { uniqueId } from "../utils/uniqueId.js";
 
   let step = {};
 

--- a/src/RadioButton/RadioButton.svelte
+++ b/src/RadioButton/RadioButton.svelte
@@ -34,7 +34,7 @@
   export let hideLabel = false;
 
   /** Set an id for the input element */
-  export let id = `ccs-${Math.random().toString(36)}`;
+  export let id = uniqueId();
 
   /**
    * Specify a name attribute for the radio button input.
@@ -52,6 +52,7 @@
 
   import { getContext, onMount } from "svelte";
   import { readable } from "svelte/store";
+  import { uniqueId } from "../utils/uniqueId.js";
   import {
     registerRadioButton,
     updateGroupSelection,

--- a/src/RadioButtonGroup/RadioButtonGroup.svelte
+++ b/src/RadioButtonGroup/RadioButtonGroup.svelte
@@ -70,6 +70,7 @@
 
   import { createEventDispatcher, onMount, setContext } from "svelte";
   import { readonly as readOnly, writable } from "svelte/store";
+  import { uniqueId } from "../utils/uniqueId.js";
 
   const dispatch = createEventDispatcher();
   /**
@@ -79,7 +80,7 @@
   const groupName = writable(name);
   const groupRequired = writable(required);
   const groupReadonly = writable(readonly);
-  const fallbackHelperId = `ccs-${Math.random().toString(36)}`;
+  const fallbackHelperId = uniqueId();
   /** @type {import("svelte/store").Writable<string | undefined>} */
   const helperId = writable(undefined);
   let isInitialRender = true;

--- a/src/Search/Search.svelte
+++ b/src/Search/Search.svelte
@@ -74,7 +74,7 @@
   export let icon = /** @type {Icon} */ (IconSearch);
 
   /** Set an id for the input element */
-  export let id = `ccs-${Math.random().toString(36)}`;
+  export let id = uniqueId();
 
   /**
    * Obtain a reference to the input HTML element.
@@ -85,6 +85,7 @@
   import { createEventDispatcher, getContext } from "svelte";
   import Close from "../icons/Close.svelte";
   import IconSearch from "../icons/IconSearch.svelte";
+  import { uniqueId } from "../utils/uniqueId.js";
   import SearchSkeleton from "./SearchSkeleton.svelte";
 
   const dispatch = createEventDispatcher();

--- a/src/SearchMenu/SearchMenu.svelte
+++ b/src/SearchMenu/SearchMenu.svelte
@@ -97,7 +97,7 @@
   export let searchClass = "";
 
   /** Set an id for the search input */
-  export let id = `ccs-${Math.random().toString(36)}`;
+  export let id = uniqueId();
 
   /**
    * Obtain a reference to the input HTML element.
@@ -121,6 +121,7 @@
   import { dismiss } from "../utils/dismiss.js";
   import { fuzzyMatch } from "../utils/fuzzyMatch.js";
   import { isOutsideClick } from "../utils/isOutsideClick.js";
+  import { uniqueId } from "../utils/uniqueId.js";
 
   const dispatch = createEventDispatcher();
 

--- a/src/SearchMenu/SearchMenuItem.svelte
+++ b/src/SearchMenu/SearchMenuItem.svelte
@@ -52,11 +52,12 @@
   export let filter = undefined;
 
   /** Set an id for the item element */
-  export let id = `ccs-${Math.random().toString(36)}`;
+  export let id = uniqueId();
 
   import { createEventDispatcher, getContext, onMount } from "svelte";
   import { readable } from "svelte/store";
   import { highlightSegments } from "../utils/fuzzyMatch.js";
+  import { uniqueId } from "../utils/uniqueId.js";
 
   const dispatch = createEventDispatcher();
   const menu = getContext("carbon:SearchMenu");

--- a/src/Select/Select.svelte
+++ b/src/Select/Select.svelte
@@ -27,7 +27,7 @@
   export let disabled = false;
 
   /** Set an id for the select element */
-  export let id = `ccs-${Math.random().toString(36)}`;
+  export let id = uniqueId();
 
   /**
    * Specify a name attribute for the select element.
@@ -90,6 +90,7 @@
   import ChevronDown from "../icons/ChevronDown.svelte";
   import WarningAltFilled from "../icons/WarningAltFilled.svelte";
   import WarningFilled from "../icons/WarningFilled.svelte";
+  import { uniqueId } from "../utils/uniqueId.js";
 
   const dispatch = createEventDispatcher();
   const formContext = getContext("carbon:Form");

--- a/src/Select/SelectItem.svelte
+++ b/src/Select/SelectItem.svelte
@@ -37,8 +37,9 @@
   export let style = undefined;
 
   import { getContext, onMount } from "svelte";
+  import { uniqueId } from "../utils/uniqueId.js";
 
-  const id = `ccs-${Math.random().toString(36)}`;
+  const id = uniqueId();
   const ctx =
     getContext("carbon:Select") || getContext("carbon:TimePickerSelect");
 

--- a/src/Slider/RangeSlider.svelte
+++ b/src/Slider/RangeSlider.svelte
@@ -75,7 +75,7 @@
   export let fullWidth = false;
 
   /** Set an id for the slider div element */
-  export let id = `ccs-${Math.random().toString(36)}`;
+  export let id = uniqueId();
 
   /** Set to `true` to indicate an invalid state */
   export let invalid = false;
@@ -127,6 +127,7 @@
   import WarningFilled from "../icons/WarningFilled.svelte";
   import { dismiss } from "../utils/dismiss.js";
   import { resolveSliderMarks } from "../utils/resolveSliderMarks.js";
+  import { uniqueId } from "../utils/uniqueId.js";
 
   /** @typedef {{ value: number; valueUpper: number }} RangeSliderChangeDetail */
   /** @typedef {"lower" | "upper"} ActiveHandle */

--- a/src/Slider/Slider.svelte
+++ b/src/Slider/Slider.svelte
@@ -69,7 +69,7 @@
   export let fullWidth = false;
 
   /** Set an id for the slider div element */
-  export let id = `ccs-${Math.random().toString(36)}`;
+  export let id = uniqueId();
 
   /** Set to `true` to indicate an invalid state */
   export let invalid = false;
@@ -112,6 +112,7 @@
   import WarningFilled from "../icons/WarningFilled.svelte";
   import { dismiss } from "../utils/dismiss.js";
   import { resolveSliderMarks } from "../utils/resolveSliderMarks.js";
+  import { uniqueId } from "../utils/uniqueId.js";
 
   const dispatch = createEventDispatcher();
 

--- a/src/StructuredList/StructuredListInput.svelte
+++ b/src/StructuredList/StructuredListInput.svelte
@@ -19,7 +19,7 @@
   export let value = "value";
 
   /** Set an id for the input element */
-  export let id = `ccs-${Math.random().toString(36)}`;
+  export let id = uniqueId();
 
   /** Specify a name attribute for the input */
   export let name = "";
@@ -38,6 +38,7 @@
 
   import { getContext } from "svelte";
   import { writable } from "svelte/store";
+  import { uniqueId } from "../utils/uniqueId.js";
 
   const initialChecked = checked;
   const ctx = getContext("carbon:StructuredListWrapper");

--- a/src/Tabs/Tab.svelte
+++ b/src/Tabs/Tab.svelte
@@ -35,7 +35,7 @@
    * Set an id for the top-level element.
    * Use a stable value with `Tabs` `selectedId` when tabs are added or removed dynamically.
    */
-  export let id = `ccs-${Math.random().toString(36)}`;
+  export let id = uniqueId();
 
   /**
    * Specify an optional secondary label.
@@ -78,6 +78,7 @@
   import { get } from "svelte/store";
   import Close from "../icons/Close.svelte";
   import PortalTooltip from "../Portal/PortalTooltip.svelte";
+  import { uniqueId } from "../utils/uniqueId.js";
 
   const {
     selectedTab,

--- a/src/Tabs/TabContent.svelte
+++ b/src/Tabs/TabContent.svelte
@@ -3,7 +3,7 @@
    * Set an id for the top-level element.
    * Prefer a stable value when pairing panels with dynamic tabs.
    */
-  export let id = `ccs-${Math.random().toString(36)}`;
+  export let id = uniqueId();
 
   /**
    * Set to `true` to defer mounting panel content until this tab is first selected
@@ -16,6 +16,7 @@
   export let unmountOnHide = false;
 
   import { getContext, onMount } from "svelte";
+  import { uniqueId } from "../utils/uniqueId.js";
 
   const { selectedContent, addContent, removeContent, tabs, contentById } =
     getContext("carbon:Tabs");

--- a/src/Tabs/Tabs.svelte
+++ b/src/Tabs/Tabs.svelte
@@ -69,6 +69,7 @@
   import { derived, get, writable } from "svelte/store";
   import ChevronLeft from "../icons/ChevronLeft.svelte";
   import ChevronRight from "../icons/ChevronRight.svelte";
+  import { clampIndex } from "../utils/clampIndex.js";
   import { keyBy } from "../utils/keyBy.js";
   import { rovingFocus } from "../utils/rovingFocus.js";
   import { syncDomOrder } from "../utils/syncDomOrder.js";
@@ -234,7 +235,7 @@
 
     if ($tabs.length === 0) return;
 
-    currentIndex = Math.min(Math.max(currentIndex, 0), $tabs.length - 1);
+    currentIndex = clampIndex(currentIndex, 0, $tabs.length);
     selectedId = $tabs[currentIndex].id;
   }
 

--- a/src/Tabs/TabsVertical.svelte
+++ b/src/Tabs/TabsVertical.svelte
@@ -45,6 +45,7 @@
   import { breakpointObserver } from "../Breakpoint/breakpointObserver.js";
   import ChevronLeft from "../icons/ChevronLeft.svelte";
   import ChevronRight from "../icons/ChevronRight.svelte";
+  import { clampIndex } from "../utils/clampIndex.js";
   import { keyBy } from "../utils/keyBy.js";
   import { rovingFocus } from "../utils/rovingFocus.js";
   import { syncDomOrder } from "../utils/syncDomOrder.js";
@@ -225,7 +226,7 @@
 
     if ($tabs.length === 0) return;
 
-    currentIndex = Math.min(Math.max(currentIndex, 0), $tabs.length - 1);
+    currentIndex = clampIndex(currentIndex, 0, $tabs.length);
     selectedId = $tabs[currentIndex].id;
   }
 

--- a/src/Tag/SelectableTag.svelte
+++ b/src/Tag/SelectableTag.svelte
@@ -30,9 +30,10 @@
   export let icon = /** @type {Icon} */ (undefined);
 
   /** Set an id for the tag */
-  export let id = `ccs-${Math.random().toString(36)}`;
+  export let id = uniqueId();
 
   import { createEventDispatcher } from "svelte";
+  import { uniqueId } from "../utils/uniqueId.js";
 
   const dispatch = createEventDispatcher();
 

--- a/src/Tag/Tag.svelte
+++ b/src/Tag/Tag.svelte
@@ -56,7 +56,7 @@
   export let icon = /** @type {Icon} */ (undefined);
 
   /** Set an id for the filterable tag */
-  export let id = `ccs-${Math.random().toString(36)}`;
+  export let id = uniqueId();
 
   /**
    * Obtain a reference to the outer HTML element.
@@ -69,6 +69,7 @@
   import { readable } from "svelte/store";
   import Close from "../icons/Close.svelte";
   import TooltipDefinition from "../TooltipDefinition/TooltipDefinition.svelte";
+  import { uniqueId } from "../utils/uniqueId.js";
   import TagSkeleton from "./TagSkeleton.svelte";
 
   const dispatch = createEventDispatcher();
@@ -78,9 +79,7 @@
   // group context is absent for a standalone tag, in which case none of this
   // applies.
   const tagSet = getContext("carbon:TagSet");
-  const groupItemId = tagSet
-    ? `ctag-${Math.random().toString(36).slice(2)}`
-    : undefined;
+  const groupItemId = tagSet ? uniqueId("ctag") : undefined;
   const groupOverflowIds = tagSet?.overflowIds ?? readable(new Set());
   const groupSize = tagSet?.size ?? readable(undefined);
 

--- a/src/TextArea/TextArea.svelte
+++ b/src/TextArea/TextArea.svelte
@@ -64,7 +64,7 @@
   export let fluid = false;
 
   /** Set an id for the textarea element */
-  export let id = `ccs-${Math.random().toString(36)}`;
+  export let id = uniqueId();
 
   /**
    * Specify a name attribute for the input.
@@ -82,6 +82,7 @@
   import WarningAltFilled from "../icons/WarningAltFilled.svelte";
   import WarningFilled from "../icons/WarningFilled.svelte";
   import { graphemeCount } from "../utils/graphemeCount.js";
+  import { uniqueId } from "../utils/uniqueId.js";
 
   const formContext = getContext("carbon:Form");
 

--- a/src/TextInput/PasswordInput.svelte
+++ b/src/TextInput/PasswordInput.svelte
@@ -82,7 +82,7 @@
   export let fluid = false;
 
   /** Set an id for the input element */
-  export let id = `ccs-${Math.random().toString(36)}`;
+  export let id = uniqueId();
 
   /**
    * Specify a name attribute for the input.
@@ -110,6 +110,7 @@
   import WarningAltFilled from "../icons/WarningAltFilled.svelte";
   import WarningFilled from "../icons/WarningFilled.svelte";
   import PortalTooltip from "../Portal/PortalTooltip.svelte";
+  import { uniqueId } from "../utils/uniqueId.js";
 
   const ctx = getContext("carbon:Form");
   const insideModal = getContext("carbon:Modal");

--- a/src/TextInput/TextInput.svelte
+++ b/src/TextInput/TextInput.svelte
@@ -32,7 +32,7 @@
   export let helperText = "";
 
   /** Set an id for the input element */
-  export let id = `ccs-${Math.random().toString(36)}`;
+  export let id = uniqueId();
 
   /**
    * Specify a name attribute for the input.
@@ -93,6 +93,7 @@
   import WarningAltFilled from "../icons/WarningAltFilled.svelte";
   import WarningFilled from "../icons/WarningFilled.svelte";
   import { graphemeCount } from "../utils/graphemeCount.js";
+  import { uniqueId } from "../utils/uniqueId.js";
 
   const ctx = getContext("carbon:Form");
   const dispatch = createEventDispatcher();

--- a/src/Tile/ExpandableTile.svelte
+++ b/src/Tile/ExpandableTile.svelte
@@ -39,7 +39,7 @@
   export let tabindex = "0";
 
   /** Set an id for the top-level div element */
-  export let id = `ccs-${Math.random().toString(36)}`;
+  export let id = uniqueId();
 
   /**
    * Set to `true` if the tile contains interactive content
@@ -57,6 +57,7 @@
 
   import { afterUpdate, onMount } from "svelte";
   import ChevronDown from "../icons/ChevronDown.svelte";
+  import { uniqueId } from "../utils/uniqueId.js";
 
   let refAbove = null;
   let resizeObserver;

--- a/src/Tile/RadioTile.svelte
+++ b/src/Tile/RadioTile.svelte
@@ -35,7 +35,7 @@
   export let iconDescription = "Tile checkmark";
 
   /** Set an id for the input element */
-  export let id = `ccs-${Math.random().toString(36)}`;
+  export let id = uniqueId();
 
   /**
    * Specify a name attribute for the radio tile input.
@@ -46,6 +46,7 @@
   import { getContext } from "svelte";
   import { readable } from "svelte/store";
   import CheckmarkFilled from "../icons/CheckmarkFilled.svelte";
+  import { uniqueId } from "../utils/uniqueId.js";
 
   // aria attributes should go to the input element, not the label.
   $: ariaDescribedBy = $$restProps["aria-describedby"];

--- a/src/Tile/SelectableTile.svelte
+++ b/src/Tile/SelectableTile.svelte
@@ -32,7 +32,7 @@
   export let iconDescription = "Tile checkmark";
 
   /** Set an id for the input element */
-  export let id = `ccs-${Math.random().toString(36)}`;
+  export let id = uniqueId();
 
   /**
    * Specify a name attribute for the input.
@@ -49,6 +49,7 @@
   import { createEventDispatcher, getContext } from "svelte";
   import { readable } from "svelte/store";
   import CheckmarkFilled from "../icons/CheckmarkFilled.svelte";
+  import { uniqueId } from "../utils/uniqueId.js";
 
   const dispatch = createEventDispatcher();
 

--- a/src/TimePicker/TimePicker.svelte
+++ b/src/TimePicker/TimePicker.svelte
@@ -52,7 +52,7 @@
   export let helperText = "";
 
   /** Set an id for the input element */
-  export let id = `ccs-${Math.random().toString(36)}`;
+  export let id = uniqueId();
 
   /**
    * Specify a name attribute for the input.
@@ -78,6 +78,7 @@
   import WarningAltFilled from "../icons/WarningAltFilled.svelte";
   import WarningFilled from "../icons/WarningFilled.svelte";
   import Stack from "../Stack/Stack.svelte";
+  import { uniqueId } from "../utils/uniqueId.js";
 
   const formContext = getContext("carbon:Form");
   const selectCount = writable(0);

--- a/src/TimePicker/TimePickerSelect.svelte
+++ b/src/TimePicker/TimePickerSelect.svelte
@@ -19,7 +19,7 @@
   export let labelText = "";
 
   /** Set an id for the select element */
-  export let id = `ccs-${Math.random().toString(36)}`;
+  export let id = uniqueId();
 
   /**
    * Specify a name attribute for the select element.
@@ -36,6 +36,7 @@
   import { getContext, onMount, setContext } from "svelte";
   import { writable } from "svelte/store";
   import ChevronDown from "../icons/ChevronDown.svelte";
+  import { uniqueId } from "../utils/uniqueId.js";
 
   const formContext = getContext("carbon:Form");
   const timePickerContext = getContext("carbon:TimePicker");

--- a/src/Toggle/Toggle.svelte
+++ b/src/Toggle/Toggle.svelte
@@ -31,7 +31,7 @@
   export let hideLabel = false;
 
   /** Set an id for the input element */
-  export let id = `ccs-${Math.random().toString(36)}`;
+  export let id = uniqueId();
 
   /** Set to `true` to use the read-only variant */
   export let readonly = false;
@@ -49,6 +49,7 @@
   export let ref = null;
 
   import { createEventDispatcher } from "svelte";
+  import { uniqueId } from "../utils/uniqueId.js";
 
   const dispatch = createEventDispatcher();
 </script>

--- a/src/Toggle/ToggleSkeleton.svelte
+++ b/src/Toggle/ToggleSkeleton.svelte
@@ -1,4 +1,6 @@
 <script>
+  import { uniqueId } from "../utils/uniqueId.js";
+
   /**
    * Specify the toggle size.
    * @type {"default" | "sm"}
@@ -9,7 +11,7 @@
   export let labelText = "";
 
   /** Set an id for the input element */
-  export let id = `ccs-${Math.random().toString(36)}`;
+  export let id = uniqueId();
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->

--- a/src/Toggletip/Toggletip.svelte
+++ b/src/Toggletip/Toggletip.svelte
@@ -68,9 +68,10 @@
   import { observeModalClose } from "../Portal/portal-utils.js";
   import { dismiss } from "../utils/dismiss.js";
   import { isOutsideClick } from "../utils/isOutsideClick.js";
+  import { uniqueId } from "../utils/uniqueId.js";
 
   const dispatch = createEventDispatcher();
-  const contentId = `ccs-${Math.random().toString(36)}`;
+  const contentId = uniqueId();
   const insideModal = getContext("carbon:Modal");
 
   // Space (px) reserved for the caret between the anchor and the content.

--- a/src/Tooltip/Tooltip.svelte
+++ b/src/Tooltip/Tooltip.svelte
@@ -53,13 +53,13 @@
    * Set an id for the tooltip.
    * @type {string}
    */
-  export let tooltipId = `ccs-${Math.random().toString(36)}`;
+  export let tooltipId = uniqueId();
 
   /**
    * Set an id for the tooltip button.
    * @type {string}
    */
-  export let triggerId = `ccs-${Math.random().toString(36)}`;
+  export let triggerId = uniqueId();
 
   /** Set the tooltip button text */
   export let triggerText = "";
@@ -112,6 +112,7 @@
   import { writable } from "svelte/store";
   import Information from "../icons/Information.svelte";
   import FloatingPortal from "../Portal/FloatingPortal.svelte";
+  import { uniqueId } from "../utils/uniqueId.js";
 
   const insideModal = getContext("carbon:Modal");
 

--- a/src/Tooltip/Tooltip.svelte
+++ b/src/Tooltip/Tooltip.svelte
@@ -112,6 +112,7 @@
   import { writable } from "svelte/store";
   import Information from "../icons/Information.svelte";
   import FloatingPortal from "../Portal/FloatingPortal.svelte";
+  import { createDelayedSetter } from "../utils/delayedSetter.js";
   import { uniqueId } from "../utils/uniqueId.js";
 
   const insideModal = getContext("carbon:Modal");
@@ -130,7 +131,6 @@
   const openedByHover = writable(false);
 
   let prevOpen = undefined;
-  let openTimeout;
   let focusByMouse = false;
 
   $: effectivePortalTooltip =
@@ -138,24 +138,19 @@
 
   setContext("carbon:Tooltip", { tooltipOpen, openedByHover });
 
-  function setOpenDelayed(value, delay = 0) {
-    clearTimeout(openTimeout);
-    if (delay > 0) {
-      openTimeout = setTimeout(() => {
-        open = value;
-      }, delay);
-    } else {
-      open = value;
-    }
-  }
+  const scheduleOpen = createDelayedSetter();
 
   function onMouseEnter() {
     openedByHover.set(true);
-    setOpenDelayed(true, enterDelayMs);
+    scheduleOpen(enterDelayMs, () => {
+      open = true;
+    });
   }
 
   function onMouseLeave() {
-    setOpenDelayed(false, leaveDelayMs);
+    scheduleOpen(leaveDelayMs, () => {
+      open = false;
+    });
   }
 
   function onKeydown(event) {
@@ -186,7 +181,7 @@
 
   onMount(() => {
     return () => {
-      clearTimeout(openTimeout);
+      scheduleOpen.cancel();
     };
   });
 

--- a/src/TooltipDefinition/TooltipDefinition.svelte
+++ b/src/TooltipDefinition/TooltipDefinition.svelte
@@ -63,6 +63,7 @@
 
   import { createEventDispatcher, getContext, onMount } from "svelte";
   import FloatingPortal from "../Portal/FloatingPortal.svelte";
+  import { createDelayedSetter } from "../utils/delayedSetter.js";
   import { dismiss } from "../utils/dismiss.js";
   import { uniqueId } from "../utils/uniqueId.js";
 
@@ -76,17 +77,12 @@
 
   const dispatch = createEventDispatcher();
 
-  let openTimeout;
+  const scheduleOpen = createDelayedSetter();
 
   function setOpenDelayed(value, delay = 0) {
-    clearTimeout(openTimeout);
-    if (delay > 0) {
-      openTimeout = setTimeout(() => {
-        open = value;
-      }, delay);
-    } else {
+    scheduleOpen(delay, () => {
       open = value;
-    }
+    });
   }
 
   function hide() {
@@ -114,7 +110,7 @@
 
   onMount(() => {
     return () => {
-      clearTimeout(openTimeout);
+      scheduleOpen.cancel();
     };
   });
   function handleEscape(event) {

--- a/src/TooltipDefinition/TooltipDefinition.svelte
+++ b/src/TooltipDefinition/TooltipDefinition.svelte
@@ -26,7 +26,7 @@
   export let direction = "bottom";
 
   /** Set an id for the tooltip div element */
-  export let id = `ccs-${Math.random().toString(36)}`;
+  export let id = uniqueId();
 
   /**
    * By default, the tooltip is opened on hover or focus.
@@ -64,6 +64,7 @@
   import { createEventDispatcher, getContext, onMount } from "svelte";
   import FloatingPortal from "../Portal/FloatingPortal.svelte";
   import { dismiss } from "../utils/dismiss.js";
+  import { uniqueId } from "../utils/uniqueId.js";
 
   const insideModal = getContext("carbon:Modal");
 

--- a/src/TooltipIcon/TooltipIcon.svelte
+++ b/src/TooltipIcon/TooltipIcon.svelte
@@ -9,6 +9,7 @@
   import { get } from "svelte/store";
   import PortalTooltip from "../Portal/PortalTooltip.svelte";
   import { dismiss } from "../utils/dismiss.js";
+  import { uniqueId } from "../utils/uniqueId.js";
   import { activeTooltipIcon } from "./tooltip-icon-store.js";
 
   /**
@@ -52,7 +53,7 @@
   export let direction = "bottom";
 
   /** Set an id for the span element */
-  export let id = `ccs-${Math.random().toString(36)}`;
+  export let id = uniqueId();
 
   /**
    * Specify the duration in milliseconds to delay before displaying the tooltip.

--- a/src/TooltipIcon/TooltipIcon.svelte
+++ b/src/TooltipIcon/TooltipIcon.svelte
@@ -8,6 +8,7 @@
   import { createEventDispatcher, getContext, onMount } from "svelte";
   import { get } from "svelte/store";
   import PortalTooltip from "../Portal/PortalTooltip.svelte";
+  import { createDelayedSetter } from "../utils/delayedSetter.js";
   import { dismiss } from "../utils/dismiss.js";
   import { uniqueId } from "../utils/uniqueId.js";
   import { activeTooltipIcon } from "./tooltip-icon-store.js";
@@ -86,19 +87,14 @@
 
   let isInitialRender = true;
   let clicked = false;
-  let openTimeout;
+
+  const scheduleOpen = createDelayedSetter();
 
   function setOpenDelayed(value, delay = 0) {
-    clearTimeout(openTimeout);
-    if (delay > 0) {
-      openTimeout = setTimeout(() => {
-        if (value) show();
-        else hide();
-      }, delay);
-    } else {
+    scheduleOpen(delay, () => {
       if (value) show();
       else hide();
-    }
+    });
   }
 
   const insideModal = getContext("carbon:Modal");
@@ -188,7 +184,7 @@
 
   onMount(() => {
     return () => {
-      clearTimeout(openTimeout);
+      scheduleOpen.cancel();
       if (get(activeTooltipIcon) === tooltipId) {
         activeTooltipIcon.set(null);
       }
@@ -244,31 +240,22 @@
     hidden = false;
     // If immediately hovering over another tooltip icon, skip the delay.
     const warmHandoff = $activeTooltipIcon !== null;
+    const delay = warmHandoff ? 0 : enterDelayMs;
     if (effectivePortalTooltip) {
-      clearTimeout(openTimeout);
-      if (!warmHandoff && enterDelayMs > 0) {
-        openTimeout = setTimeout(() => {
-          hovered = true;
-        }, enterDelayMs);
-      } else {
+      scheduleOpen(delay, () => {
         hovered = true;
-      }
+      });
     } else {
-      setOpenDelayed(true, warmHandoff ? 0 : enterDelayMs);
+      setOpenDelayed(true, delay);
     }
   }}
   on:mouseleave
   on:mouseleave={() => {
     if (clicked) return;
     if (effectivePortalTooltip) {
-      clearTimeout(openTimeout);
-      if (leaveDelayMs > 0) {
-        openTimeout = setTimeout(() => {
-          hovered = false;
-        }, leaveDelayMs);
-      } else {
+      scheduleOpen(leaveDelayMs, () => {
         hovered = false;
-      }
+      });
     } else {
       setOpenDelayed(false, leaveDelayMs);
     }

--- a/src/TreeView/TreeView.svelte
+++ b/src/TreeView/TreeView.svelte
@@ -577,6 +577,7 @@
     createTreeVirtualIndex,
     isExpandableNode,
   } from "../utils/treeVirtualIndex.js";
+  import { uniqueId } from "../utils/uniqueId.js";
   import {
     getVisibleRange,
     scrollHighlightedIntoView,
@@ -585,8 +586,8 @@
   import TreeViewNodeVirtual from "./TreeViewNodeVirtual.svelte";
 
   const dispatch = createEventDispatcher();
-  const labelId = `label-${Math.random().toString(36)}`;
-  const treeId = `tree-${Math.random().toString(36)}`;
+  const labelId = uniqueId("label");
+  const treeId = uniqueId("tree");
 
   /** @type {import("svelte/store").Writable<boolean>} */
   const multiselectStore = writable(multiselect);

--- a/src/UIShell/HeaderAction.svelte
+++ b/src/UIShell/HeaderAction.svelte
@@ -72,7 +72,7 @@
   export let preventCloseOnClickOutside = false;
 
   /** Set an id for the trigger button element. Also used to label the panel. */
-  export let id = `ccs-${Math.random().toString(36)}`;
+  export let id = uniqueId();
 
   import { createEventDispatcher } from "svelte";
   import { slide } from "svelte/transition";
@@ -80,6 +80,7 @@
   import Switcher from "../icons/Switcher.svelte";
   import { dismiss } from "../utils/dismiss.js";
   import { isOutsideClick } from "../utils/isOutsideClick.js";
+  import { uniqueId } from "../utils/uniqueId.js";
 
   const dispatch = createEventDispatcher();
 

--- a/src/UIShell/HeaderNavItem.svelte
+++ b/src/UIShell/HeaderNavItem.svelte
@@ -33,8 +33,9 @@
 
   import { getContext, onMount } from "svelte";
   import { moveIndex } from "../utils/moveIndex.js";
+  import { uniqueId } from "../utils/uniqueId.js";
 
-  const id = `ccs-${Math.random().toString(36)}`;
+  const id = uniqueId();
   const ctx = getContext("carbon:HeaderNavMenu");
 
   let selectedItemIds = [];

--- a/src/UIShell/HeaderSearch.svelte
+++ b/src/UIShell/HeaderSearch.svelte
@@ -117,10 +117,11 @@
   import { dismiss } from "../utils/dismiss.js";
   import { fuzzyMatch } from "../utils/fuzzyMatch.js";
   import { isOutsideClick } from "../utils/isOutsideClick.js";
+  import { uniqueId } from "../utils/uniqueId.js";
 
   const dispatch = createEventDispatcher();
 
-  const id = `ccs-${Math.random().toString(36)}`;
+  const id = uniqueId();
   const inputId = `${id}-input`;
   const labelId = `${id}-label`;
   const menuId = `${id}-menu`;

--- a/src/UIShell/ProfileMenuDetail.svelte
+++ b/src/UIShell/ProfileMenuDetail.svelte
@@ -1,11 +1,13 @@
 <script>
+  import { uniqueId } from "../utils/uniqueId.js";
+
   /**
    * Specify the label describing the value (for example, "Plan" or "Location").
    * @type {string}
    */
   export let label = undefined;
 
-  const id = `ccs-${Math.random().toString(36)}`;
+  const id = uniqueId();
 </script>
 
 <div class:bx--profile-menu__detail={true}>

--- a/src/UserAvatar/UserAvatar.svelte
+++ b/src/UserAvatar/UserAvatar.svelte
@@ -117,6 +117,7 @@
   import User from "../icons/User.svelte";
   import TooltipDefinition from "../TooltipDefinition/TooltipDefinition.svelte";
   import { getAvatarBackgroundColor } from "../utils/avatarColor.js";
+  import { uniqueId } from "../utils/uniqueId.js";
 
   const dispatch = createEventDispatcher();
 
@@ -124,9 +125,7 @@
   // count avatars and hide those beyond its `max`. The group context is absent
   // for a standalone avatar, in which case none of this applies.
   const userAvatarGroup = getContext("carbon:UserAvatarGroup");
-  const groupItemId = userAvatarGroup
-    ? `cua-${Math.random().toString(36).slice(2)}`
-    : undefined;
+  const groupItemId = userAvatarGroup ? uniqueId("cua") : undefined;
   const groupItems = userAvatarGroup?.items ?? readable([]);
   const groupMax = userAvatarGroup?.max ?? readable(0);
   const groupSize = userAvatarGroup?.size ?? readable(undefined);

--- a/src/utils/boundedFifoCache.d.ts
+++ b/src/utils/boundedFifoCache.d.ts
@@ -1,0 +1,15 @@
+/**
+ * A Map-like cache that evicts the oldest-inserted entry once `maxSize` is
+ * reached. Eviction order is insertion order (FIFO) — a cache hit does not
+ * bump an entry's recency, unlike an LRU cache.
+ */
+export class BoundedFifoCache<K, V> {
+  constructor(maxSize: number);
+  maxSize: number;
+  map: Map<K, V>;
+  get(key: K): V | undefined;
+  set(key: K, value: V): void;
+  get size(): number;
+}
+
+export default BoundedFifoCache;

--- a/src/utils/boundedFifoCache.d.ts
+++ b/src/utils/boundedFifoCache.d.ts
@@ -11,5 +11,3 @@ export class BoundedFifoCache<K, V> {
   set(key: K, value: V): void;
   get size(): number;
 }
-
-export default BoundedFifoCache;

--- a/src/utils/boundedFifoCache.js
+++ b/src/utils/boundedFifoCache.js
@@ -41,5 +41,3 @@ export class BoundedFifoCache {
     return this.map.size;
   }
 }
-
-export default BoundedFifoCache;

--- a/src/utils/boundedFifoCache.js
+++ b/src/utils/boundedFifoCache.js
@@ -1,0 +1,45 @@
+// @ts-check
+
+/**
+ * A Map-like cache that evicts the oldest-inserted entry once `maxSize` is
+ * reached. Eviction order is insertion order (FIFO) — a cache hit does not
+ * bump an entry's recency, unlike an LRU cache.
+ * @template K
+ * @template V
+ */
+export class BoundedFifoCache {
+  /** @param {number} maxSize */
+  constructor(maxSize) {
+    this.maxSize = maxSize;
+    /** @type {Map<K, V>} */
+    this.map = new Map();
+  }
+
+  /**
+   * @param {K} key
+   * @returns {V | undefined}
+   */
+  get(key) {
+    return this.map.get(key);
+  }
+
+  /**
+   * @param {K} key
+   * @param {V} value
+   */
+  set(key, value) {
+    if (this.map.size >= this.maxSize && !this.map.has(key)) {
+      const oldestKey = this.map.keys().next().value;
+      if (oldestKey !== undefined) {
+        this.map.delete(oldestKey);
+      }
+    }
+    this.map.set(key, value);
+  }
+
+  get size() {
+    return this.map.size;
+  }
+}
+
+export default BoundedFifoCache;

--- a/src/utils/delayedSetter.d.ts
+++ b/src/utils/delayedSetter.d.ts
@@ -1,0 +1,8 @@
+export type DelayedSetter = ((delay: number, fn: () => void) => void) & {
+  cancel: () => void;
+};
+
+/** Create a canceling delayed-call scheduler for hover-intent style UI. */
+export function createDelayedSetter(): DelayedSetter;
+
+export default createDelayedSetter;

--- a/src/utils/delayedSetter.d.ts
+++ b/src/utils/delayedSetter.d.ts
@@ -4,5 +4,3 @@ export type DelayedSetter = ((delay: number, fn: () => void) => void) & {
 
 /** Create a canceling delayed-call scheduler for hover-intent style UI. */
 export function createDelayedSetter(): DelayedSetter;
-
-export default createDelayedSetter;

--- a/src/utils/delayedSetter.js
+++ b/src/utils/delayedSetter.js
@@ -1,0 +1,34 @@
+// @ts-check
+
+/**
+ * Create a canceling delayed-call scheduler for hover-intent style UI (e.g.
+ * opening/closing a tooltip after a delay). Each call clears any pending
+ * invocation before scheduling the next one; a non-positive `delay` runs
+ * `fn` synchronously instead of queuing a timer.
+ * @returns {((delay: number, fn: () => void) => void) & { cancel: () => void }}
+ */
+export function createDelayedSetter() {
+  /** @type {ReturnType<typeof setTimeout> | undefined} */
+  let timeoutId;
+
+  /**
+   * @param {number} delay
+   * @param {() => void} fn
+   */
+  function schedule(delay, fn) {
+    clearTimeout(timeoutId);
+    if (delay > 0) {
+      timeoutId = setTimeout(fn, delay);
+    } else {
+      fn();
+    }
+  }
+
+  schedule.cancel = () => {
+    clearTimeout(timeoutId);
+  };
+
+  return schedule;
+}
+
+export default createDelayedSetter;

--- a/src/utils/delayedSetter.js
+++ b/src/utils/delayedSetter.js
@@ -30,5 +30,3 @@ export function createDelayedSetter() {
 
   return schedule;
 }
-
-export default createDelayedSetter;

--- a/src/utils/submenuHoverIntent.d.ts
+++ b/src/utils/submenuHoverIntent.d.ts
@@ -11,5 +11,3 @@ export function createSubmenuHoverIntent(
   setOpen: (open: boolean) => void,
   delays: { openDelay: number; closeDelay: number },
 ): SubmenuHoverIntent;
-
-export default createSubmenuHoverIntent;

--- a/src/utils/submenuHoverIntent.d.ts
+++ b/src/utils/submenuHoverIntent.d.ts
@@ -1,0 +1,15 @@
+export interface SubmenuHoverIntent {
+  open: () => void;
+  scheduleOpen: () => void;
+  scheduleClose: () => void;
+  cancelClose: () => void;
+  cancel: () => void;
+}
+
+/** Create an open/close scheduler for hover-intent submenus. */
+export function createSubmenuHoverIntent(
+  setOpen: (open: boolean) => void,
+  delays: { openDelay: number; closeDelay: number },
+): SubmenuHoverIntent;
+
+export default createSubmenuHoverIntent;

--- a/src/utils/submenuHoverIntent.js
+++ b/src/utils/submenuHoverIntent.js
@@ -40,5 +40,3 @@ export function createSubmenuHoverIntent(setOpen, delays) {
 
   return { open, scheduleOpen, scheduleClose, cancelClose, cancel };
 }
-
-export default createSubmenuHoverIntent;

--- a/src/utils/submenuHoverIntent.js
+++ b/src/utils/submenuHoverIntent.js
@@ -1,0 +1,44 @@
+// @ts-check
+
+/**
+ * Create an open/close scheduler for hover-intent submenus (Menu/ContextMenu
+ * items with a nested submenu): entering schedules an open after
+ * `openDelay`, leaving schedules a close after `closeDelay`, and each
+ * cancels the other's pending timer.
+ * @param {(open: boolean) => void} setOpen - Applies the resolved open state.
+ * @param {{ openDelay: number; closeDelay: number }} delays
+ */
+export function createSubmenuHoverIntent(setOpen, delays) {
+  /** @type {ReturnType<typeof setTimeout> | undefined} */
+  let openTimeout;
+  /** @type {ReturnType<typeof setTimeout> | undefined} */
+  let closeTimeout;
+
+  function cancel() {
+    clearTimeout(openTimeout);
+    clearTimeout(closeTimeout);
+  }
+
+  function open() {
+    cancel();
+    setOpen(true);
+  }
+
+  function scheduleOpen() {
+    cancel();
+    openTimeout = setTimeout(open, delays.openDelay);
+  }
+
+  function scheduleClose() {
+    cancel();
+    closeTimeout = setTimeout(() => setOpen(false), delays.closeDelay);
+  }
+
+  function cancelClose() {
+    clearTimeout(closeTimeout);
+  }
+
+  return { open, scheduleOpen, scheduleClose, cancelClose, cancel };
+}
+
+export default createSubmenuHoverIntent;

--- a/src/utils/uniqueId.d.ts
+++ b/src/utils/uniqueId.d.ts
@@ -1,4 +1,2 @@
 /** Generate a random id string, e.g. `ccs-4f2k9x1z`. */
 export function uniqueId(prefix?: string): string;
-
-export default uniqueId;

--- a/src/utils/uniqueId.d.ts
+++ b/src/utils/uniqueId.d.ts
@@ -1,0 +1,4 @@
+/** Generate a random id string, e.g. `ccs-4f2k9x1z`. */
+export function uniqueId(prefix?: string): string;
+
+export default uniqueId;

--- a/src/utils/uniqueId.js
+++ b/src/utils/uniqueId.js
@@ -1,0 +1,13 @@
+// @ts-check
+
+/**
+ * Generate a random id string, e.g. `ccs-4f2k9x1z`.
+ * Not cryptographically secure; intended for DOM ids (aria-* pairing, label `for`, etc.).
+ * @param {string} [prefix]
+ * @returns {string}
+ */
+export function uniqueId(prefix = "ccs") {
+  return `${prefix}-${Math.random().toString(36).slice(2)}`;
+}
+
+export default uniqueId;

--- a/src/utils/uniqueId.js
+++ b/src/utils/uniqueId.js
@@ -9,5 +9,3 @@
 export function uniqueId(prefix = "ccs") {
   return `${prefix}-${Math.random().toString(36).slice(2)}`;
 }
-
-export default uniqueId;

--- a/sveld-cross-file-type-inference-prompt.md
+++ b/sveld-cross-file-type-inference-prompt.md
@@ -1,0 +1,185 @@
+# Prompt: cross-file type inference for prop defaults in sveld
+
+Use this as an implementation brief for [carbon-design-system/sveld](https://github.com/carbon-design-system/sveld).
+
+## Problem
+
+sveld is AST-local. When a prop default is a **call to an imported function**, it does not follow the import to read the callee's return type (JSDoc `@returns`, `.d.ts`, or TS signature). The emitted prop type collapses incorrectly.
+
+In carbon-components-svelte we extracted a shared helper:
+
+```js
+// src/utils/uniqueId.js
+/**
+ * @param {string} [prefix]
+ * @returns {string}
+ */
+export function uniqueId(prefix = "ccs") {
+  return `${prefix}-${Math.random().toString(36).slice(2)}`;
+}
+```
+
+```ts
+// src/utils/uniqueId.d.ts
+export function uniqueId(prefix?: string): string;
+```
+
+Then replaced ~55 in-component defaults:
+
+```js
+// before (inferred as string)
+export let id = `ccs-${Math.random().toString(36)}`;
+
+// after (emitted as undefined)
+export let id = uniqueId();
+```
+
+Generated output (sveld 0.36.2):
+
+```ts
+/**
+ * Set an id for the list box component
+ * @default uniqueId()
+ */
+id?: undefined;
+```
+
+That is worse than falling back to `any`. Consumers and `svelte-check` then reject every `id="..."` pass:
+
+`Type 'string' is not assignable to type 'undefined'.`
+
+Workaround we had to ship: add explicit `@type {string}` on every such prop and regenerate. That works, but it duplicates information the helper already declares.
+
+## Why this matters
+
+JS-first Svelte libraries (carbon-components-svelte's model) push shared runtime helpers into modules. Prop defaults like `uniqueId()`, `createId()`, `getDefaultItems()` are normal. Today each call site needs a redundant `@type`, or types silently go wrong.
+
+Related work already in sveld (build on this, don't reinvent):
+
+- inherit JSDoc from **same-file** identifier / function-declaration defaults
+- infer return type for **same-file** un-annotated function defaults
+- opt-in `resolveTypes` for expanding imported **type** aliases on `$props()` (different problem: docs expansion, not value-call return types)
+
+Gap: **CallExpression** whose callee is an **imported value**.
+
+## Desired behavior
+
+Given:
+
+```svelte
+<script>
+  import { uniqueId } from "../utils/uniqueId.js";
+
+  /** Set an id for the input element */
+  export let id = uniqueId();
+</script>
+```
+
+Emit:
+
+```ts
+/**
+ * Set an id for the input element
+ * @default uniqueId()
+ */
+id?: string;
+```
+
+Resolution order for the prop type should stay:
+
+1. explicit TypeScript annotation
+2. explicit JSDoc `@type` on the prop
+3. **initializer inference, including cross-file call returns** (new)
+4. `any` (never invent `undefined` for a failed call inference)
+
+`@default` can keep printing `uniqueId()` (or the source text). Do not require inlining the helper body into `@default`.
+
+## Proposed approach
+
+Keep the default path AST-only and cheap. Add a narrow resolver for call defaults:
+
+1. Prop initializer is `CallExpression`.
+2. Callee is an `Identifier` (start with named imports; default import / member calls can be follow-ups).
+3. Find the matching `ImportDeclaration` in the component.
+4. Resolve the module relative to the `.svelte` file (`./x.js`, `../utils/x.js`).
+5. Read return type from, in order:
+   - sibling `x.d.ts` / package types for that specifier
+   - `x.js` / `x.ts` with `@returns` / `@return` on the exported function
+   - TS `export function …: T` / `export const … = (): T => …`
+6. Cache by resolved file + export name for the run.
+7. If unresolved, fall back to `any` (or leave unset so the existing `any` path runs). **Do not emit `undefined`.**
+
+Optional later:
+
+- `Foo.bar()` member calls when `Foo` is a namespace import
+- re-exports (`export { uniqueId } from "./id.js"`)
+- `resolveTypes`-style TypeScript program reuse if you already spin up a `TypeResolver` for other features
+
+Non-goals for the first cut:
+
+- full project-wide semantic checking of every expression
+- evaluating the function
+- replacing explicit `@type` when authors want a narrower override
+
+## Acceptance tests
+
+Add fixtures roughly like:
+
+**A. Local `.js` + `@returns`**
+
+```
+utils/uniqueId.js   // @returns {string}
+Button.svelte       // export let id = uniqueId()
+```
+
+Expect `id?: string`.
+
+**B. Local `.d.ts` beside `.js`**
+
+Same as A, types only in `uniqueId.d.ts`. Expect `id?: string`.
+
+**C. Explicit `@type` wins**
+
+```js
+/** @type {"a" | "b"} */
+export let id = uniqueId();
+```
+
+Expect `id?: "a" | "b"`.
+
+**D. Unresolvable import**
+
+Unknown specifier or missing export. Expect `any` (or today's non-`undefined` fallback), never `id?: undefined`.
+
+**E. Same-file function still works**
+
+```js
+function uniqueId() { return "x"; }
+export let id = uniqueId();
+```
+
+Keep existing same-file inference behavior.
+
+**F. Regression: template literal defaults**
+
+```js
+export let id = `ccs-${Math.random().toString(36)}`;
+```
+
+Still `id?: string`.
+
+## Concrete failure to fix (carbon-components-svelte)
+
+Repo: https://github.com/carbon-design-system/carbon-components-svelte  
+Branch context: extracting `src/utils/uniqueId.js` and replacing `` `ccs-${Math.random().toString(36)}` `` defaults.
+
+Without `@type {string}` on each prop, `bun build:docs` (sveld) wrote `id?: undefined` / `inputName?: undefined` / etc., and `bun test:types` (`svelte-check --tsgo`) reported ~120 errors of the form `Type 'string' is not assignable to type 'undefined'`.
+
+Success criterion: remove those redundant `@type {string}` annotations on `uniqueId()` defaults, regenerate, and `test:types` stays green with `id?: string`.
+
+## Implementation notes for the agent
+
+- Start from how same-file "inherit JSDoc from identifier / function defaults" works; extend that path across import boundaries instead of adding a parallel system.
+- Prefer reading `.d.ts` / `@returns` text over running `tsc`, unless `resolveTypes` already gives you a cheap program you can query.
+- Emit diagnostics under the existing type-inference / `--strict` machinery when a call default could not be resolved (optional but useful).
+- Document the new capability next to initializer inference and `resolveTypes`, and stress that failed cross-file inference must not emit `undefined`.

--- a/tests/utils/boundedFifoCache.test.ts
+++ b/tests/utils/boundedFifoCache.test.ts
@@ -1,0 +1,48 @@
+import { BoundedFifoCache } from "../../src/utils/boundedFifoCache.js";
+
+describe("BoundedFifoCache", () => {
+  test("stores and retrieves values", () => {
+    const cache = new BoundedFifoCache<string, number>(2);
+    cache.set("a", 1);
+    expect(cache.get("a")).toBe(1);
+    expect(cache.get("missing")).toBeUndefined();
+  });
+
+  test("evicts the oldest-inserted entry once maxSize is reached", () => {
+    const cache = new BoundedFifoCache<string, number>(2);
+    cache.set("a", 1);
+    cache.set("b", 2);
+    cache.set("c", 3);
+
+    expect(cache.get("a")).toBeUndefined();
+    expect(cache.get("b")).toBe(2);
+    expect(cache.get("c")).toBe(3);
+    expect(cache.size).toBe(2);
+  });
+
+  test("a cache hit does not bump recency (FIFO, not LRU)", () => {
+    const cache = new BoundedFifoCache<string, number>(2);
+    cache.set("a", 1);
+    cache.set("b", 2);
+
+    // Reading "a" would refresh it in an LRU cache; it should not here.
+    expect(cache.get("a")).toBe(1);
+
+    cache.set("c", 3);
+
+    expect(cache.get("a")).toBeUndefined();
+    expect(cache.get("b")).toBe(2);
+    expect(cache.get("c")).toBe(3);
+  });
+
+  test("re-setting an existing key updates its value without evicting", () => {
+    const cache = new BoundedFifoCache<string, number>(2);
+    cache.set("a", 1);
+    cache.set("b", 2);
+    cache.set("a", 10);
+
+    expect(cache.get("a")).toBe(10);
+    expect(cache.get("b")).toBe(2);
+    expect(cache.size).toBe(2);
+  });
+});

--- a/tests/utils/delayedSetter.test.ts
+++ b/tests/utils/delayedSetter.test.ts
@@ -1,0 +1,56 @@
+import { createDelayedSetter } from "../../src/utils/delayedSetter.js";
+
+describe("createDelayedSetter", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("runs fn synchronously when delay is 0", () => {
+    const schedule = createDelayedSetter();
+    const fn = vi.fn();
+    schedule(0, fn);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  test("runs fn synchronously when delay is negative", () => {
+    const schedule = createDelayedSetter();
+    const fn = vi.fn();
+    schedule(-1, fn);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  test("delays fn until the given delay elapses", () => {
+    const schedule = createDelayedSetter();
+    const fn = vi.fn();
+    schedule(100, fn);
+    expect(fn).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(99);
+    expect(fn).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  test("a later call cancels an earlier pending call", () => {
+    const schedule = createDelayedSetter();
+    const first = vi.fn();
+    const second = vi.fn();
+    schedule(100, first);
+    schedule(100, second);
+    vi.advanceTimersByTime(100);
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+
+  test("cancel() prevents a pending call from running", () => {
+    const schedule = createDelayedSetter();
+    const fn = vi.fn();
+    schedule(100, fn);
+    schedule.cancel();
+    vi.advanceTimersByTime(100);
+    expect(fn).not.toHaveBeenCalled();
+  });
+});

--- a/tests/utils/submenuHoverIntent.test.ts
+++ b/tests/utils/submenuHoverIntent.test.ts
@@ -1,0 +1,95 @@
+import { createSubmenuHoverIntent } from "../../src/utils/submenuHoverIntent.js";
+
+describe("createSubmenuHoverIntent", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("open() applies true immediately", () => {
+    const setOpen = vi.fn();
+    const intent = createSubmenuHoverIntent(setOpen, {
+      openDelay: 150,
+      closeDelay: 150,
+    });
+    intent.open();
+    expect(setOpen).toHaveBeenCalledWith(true);
+  });
+
+  test("scheduleOpen() applies true after openDelay", () => {
+    const setOpen = vi.fn();
+    const intent = createSubmenuHoverIntent(setOpen, {
+      openDelay: 150,
+      closeDelay: 150,
+    });
+    intent.scheduleOpen();
+    expect(setOpen).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(150);
+    expect(setOpen).toHaveBeenCalledWith(true);
+  });
+
+  test("scheduleClose() applies false after closeDelay", () => {
+    const setOpen = vi.fn();
+    const intent = createSubmenuHoverIntent(setOpen, {
+      openDelay: 150,
+      closeDelay: 150,
+    });
+    intent.scheduleClose();
+    expect(setOpen).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(150);
+    expect(setOpen).toHaveBeenCalledWith(false);
+  });
+
+  test("scheduleClose() cancels a pending scheduleOpen()", () => {
+    const setOpen = vi.fn();
+    const intent = createSubmenuHoverIntent(setOpen, {
+      openDelay: 150,
+      closeDelay: 150,
+    });
+    intent.scheduleOpen();
+    intent.scheduleClose();
+    vi.advanceTimersByTime(150);
+    expect(setOpen).toHaveBeenCalledTimes(1);
+    expect(setOpen).toHaveBeenCalledWith(false);
+  });
+
+  test("scheduleOpen() cancels a pending scheduleClose()", () => {
+    const setOpen = vi.fn();
+    const intent = createSubmenuHoverIntent(setOpen, {
+      openDelay: 150,
+      closeDelay: 150,
+    });
+    intent.scheduleClose();
+    intent.scheduleOpen();
+    vi.advanceTimersByTime(150);
+    expect(setOpen).toHaveBeenCalledTimes(1);
+    expect(setOpen).toHaveBeenCalledWith(true);
+  });
+
+  test("cancelClose() discards a pending close without affecting open", () => {
+    const setOpen = vi.fn();
+    const intent = createSubmenuHoverIntent(setOpen, {
+      openDelay: 150,
+      closeDelay: 150,
+    });
+    intent.scheduleClose();
+    intent.cancelClose();
+    vi.advanceTimersByTime(150);
+    expect(setOpen).not.toHaveBeenCalled();
+  });
+
+  test("cancel() discards any pending open or close", () => {
+    const setOpen = vi.fn();
+    const intent = createSubmenuHoverIntent(setOpen, {
+      openDelay: 150,
+      closeDelay: 150,
+    });
+    intent.scheduleOpen();
+    intent.cancel();
+    vi.advanceTimersByTime(150);
+    expect(setOpen).not.toHaveBeenCalled();
+  });
+});

--- a/tests/utils/uniqueId.test.ts
+++ b/tests/utils/uniqueId.test.ts
@@ -1,0 +1,16 @@
+import { uniqueId } from "../../src/utils/uniqueId.js";
+
+describe("uniqueId", () => {
+  test("defaults to a 'ccs-' prefix", () => {
+    expect(uniqueId()).toMatch(/^ccs-[a-z0-9]+$/);
+  });
+
+  test("supports a custom prefix", () => {
+    expect(uniqueId("cua")).toMatch(/^cua-[a-z0-9]+$/);
+  });
+
+  test("generates distinct ids across calls", () => {
+    const ids = Array.from({ length: 100 }, () => uniqueId());
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});


### PR DESCRIPTION
Also reuses clampIndex for index reclamping, pulls the tooltip hover-
delay timer and the Menu/ContextMenu submenu hover-intent logic into
shared utils, and extracts the FIFO cache backing DataTable's
resolvePath. The new uniqueId() also drops the leading "0." that
Math.random().toString(36) left in most generated ids, matching what
UserAvatar and Tag already did.