### PR TITLE
fix(date-picker): use theme-aware today color, add aria-current

### DIFF
--- a/css/_datepicker.scss
+++ b/css/_datepicker.scss
@@ -104,6 +104,24 @@
       color: $text-04;
     }
 
+    &.today:not(.selected) {
+      position: relative;
+      color: $link-01;
+      font-weight: 600;
+
+      &::after {
+        content: "";
+        position: absolute;
+        bottom: 0.4375rem;
+        left: 50%;
+        display: block;
+        width: 0.25rem;
+        height: 0.25rem;
+        background-color: $link-01;
+        transform: translateX(-50%);
+      }
+    }
+
     &.disabled {
       color: $disabled-02;
       cursor: not-allowed;

--- a/css/_datepicker.scss
+++ b/css/_datepicker.scss
@@ -180,8 +180,21 @@
     }
 
     &.today:not(.selected) {
-      color: $interactive-01;
+      position: relative;
+      color: $link-01;
       font-weight: 600;
+
+      &::after {
+        content: "";
+        position: absolute;
+        bottom: 0.4375rem;
+        left: 50%;
+        display: block;
+        width: 0.25rem;
+        height: 0.25rem;
+        background-color: $link-01;
+        transform: translateX(-50%);
+      }
     }
 
     &.disabled {

--- a/src/DatePicker/createCalendar.js
+++ b/src/DatePicker/createCalendar.js
@@ -107,6 +107,31 @@ function markDisabledDayAriaState(_dObj, _dStr, _fp, dayElem) {
 }
 
 /**
+ * flatpickr's bundled monthSelect plugin has no concept of "today"; mark
+ * the current year's current month the same way flatpickr core marks the
+ * current day, since the month cells persist (and their `dateObj` year is
+ * mutated in place) across `onYearChange` instead of being rebuilt.
+ *
+ * @param {FlatpickrInstance} instance
+ */
+function markTodayMonth(instance) {
+  const now = new Date();
+  for (const node of instance.rContainer?.querySelectorAll(
+    ".flatpickr-monthSelect-month",
+  ) ?? []) {
+    const isToday =
+      node.dateObj.getFullYear() === now.getFullYear() &&
+      node.dateObj.getMonth() === now.getMonth();
+    node.classList.toggle("today", isToday);
+    if (isToday) {
+      node.setAttribute("aria-current", "date");
+    } else {
+      node.removeAttribute("aria-current");
+    }
+  }
+}
+
+/**
  * @param {FlatpickrInstance} instance
  */
 function updateMonthNode(instance) {
@@ -207,6 +232,17 @@ export async function createCalendar({ options, base, input, dispatch }) {
         updateMonthNode(instance);
       }
     },
+    onYearChange: (
+      /** @type {any} */ _s,
+      /** @type {any} */ _d,
+      /** @type {FlatpickrInstance} */ instance,
+    ) => {
+      // The monthSelect plugin mutates its month cells' `dateObj` in place
+      // on year change rather than rebuilding them, so re-mark "today" here.
+      if (options.mode === "month") {
+        markTodayMonth(instance);
+      }
+    },
     onOpen: (
       /** @type {any} */ _s,
       /** @type {any} */ _d,
@@ -219,6 +255,9 @@ export async function createCalendar({ options, base, input, dispatch }) {
       });
       if (options.mode !== "month" && options.mode !== "year") {
         updateMonthNode(instance);
+      }
+      if (options.mode === "month") {
+        markTodayMonth(instance);
       }
     },
     ...options,

--- a/src/DatePicker/yearSelectPlugin.js
+++ b/src/DatePicker/yearSelectPlugin.js
@@ -124,6 +124,7 @@ function yearSelectPlugin(pluginConfig) {
 
         if (year === new Date().getFullYear()) {
           yearEl.classList.add("today");
+          yearEl.setAttribute("aria-current", "date");
         }
 
         if (

--- a/tests/DatePicker/DatePicker.test.ts
+++ b/tests/DatePicker/DatePicker.test.ts
@@ -897,6 +897,19 @@ describe("DatePicker", () => {
       expect(calendar.querySelectorAll(".flatpickr-day")).toHaveLength(0);
     });
 
+    it("marks the current year with the today class and aria-current", async () => {
+      render(DatePicker, { datePickerType: "year", dateFormat: "Y" });
+
+      await user.click(screen.getByLabelText("Date"));
+      const calendar = await screen.findByLabelText("calendar-container");
+
+      const currentYear = calendar.querySelector(
+        `.flatpickr-yearSelect-year[data-year="${new Date().getFullYear()}"]`,
+      );
+      expect(currentYear).toHaveClass("today");
+      expect(currentYear).toHaveAttribute("aria-current", "date");
+    });
+
     it("labels the range to match the first and last rendered year", async () => {
       render(DatePicker, { datePickerType: "year", dateFormat: "Y" });
 

--- a/tests/DatePicker/DatePicker.test.ts
+++ b/tests/DatePicker/DatePicker.test.ts
@@ -818,6 +818,18 @@ describe("DatePicker", () => {
       expect(calendar.querySelectorAll(".flatpickr-day")).toHaveLength(0);
     });
 
+    it("marks the current month with the today class and aria-current", async () => {
+      render(DatePicker, { datePickerType: "month", dateFormat: "F Y" });
+
+      await user.click(screen.getByLabelText("Date"));
+      const calendar = await screen.findByLabelText("calendar-container");
+
+      const months = calendar.querySelectorAll(".flatpickr-monthSelect-month");
+      const currentMonth = months[new Date().getMonth()];
+      expect(currentMonth).toHaveClass("today");
+      expect(currentMonth).toHaveAttribute("aria-current", "date");
+    });
+
     // Regression test: SCSS scopes the shorter calendar height to month mode
     // via this marker class instead of `:has()` (unsupported at the Svelte 5
     // browser baseline).


### PR DESCRIPTION
The year and month grids were using $interactive-01 for the "today"
indicator, which stays blue-60 across all themes, so it never shifted
color in g90/g100 like the day view's $link-01 does. Both grids also
lacked the day cell's aria-current="date" marking and its ::after dot
indicator.

---

<img width="775" height="412" alt="Screenshot 2026-08-10 at 8 37 54 PM" src="https://github.com/user-attachments/assets/83536ca0-e428-4c47-b924-da3fc295e0a2" />
