### PR TITLE
fix(multi-select): resolve dangling `aria-describedby` for invalid and warn text

### DIFF
--- a/src/ListBox/ListBox.svelte
+++ b/src/ListBox/ListBox.svelte
@@ -26,11 +26,23 @@
   /** Specify the invalid state text */
   export let invalidText = "";
 
+  /**
+   * Specify an id for the invalid state text
+   * @type {string}
+   */
+  export let invalidId = undefined;
+
   /** Set to `true` to indicate a warning state */
   export let warn = false;
 
   /** Specify the warning state text */
   export let warnText = "";
+
+  /**
+   * Specify an id for the warning state text
+   * @type {string}
+   */
+  export let warnId = undefined;
 </script>
 
 <div
@@ -58,8 +70,8 @@
   <slot />
 </div>
 {#if invalid && invalidText}
-  <div class:bx--form-requirement={true}>{invalidText}</div>
+  <div id={invalidId} class:bx--form-requirement={true}>{invalidText}</div>
 {/if}
 {#if !invalid && warn && warnText}
-  <div class:bx--form-requirement={true}>{warnText}</div>
+  <div id={warnId} class:bx--form-requirement={true}>{warnText}</div>
 {/if}

--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -839,11 +839,13 @@
     {disabled}
     invalid={showInvalid}
     invalidText={isFluid ? "" : invalidText}
+    invalidId={errorId}
     {open}
     {light}
     {size}
     warn={showWarn}
     warnText={isFluid ? "" : warnText}
+    {warnId}
     class={multiSelectListBoxClass}
   >
     {#if showInvalid}

--- a/tests/ListBox/ListBox.test.svelte
+++ b/tests/ListBox/ListBox.test.svelte
@@ -9,8 +9,10 @@
   export let disabled: ComponentProps<ListBox>["disabled"] = false;
   export let invalid: ComponentProps<ListBox>["invalid"] = false;
   export let invalidText: ComponentProps<ListBox>["invalidText"] = "";
+  export let invalidId: ComponentProps<ListBox>["invalidId"] = undefined;
   export let warn: ComponentProps<ListBox>["warn"] = false;
   export let warnText: ComponentProps<ListBox>["warnText"] = "";
+  export let warnId: ComponentProps<ListBox>["warnId"] = undefined;
   export let slotContent = "";
   export let onkeydown: ((event: KeyboardEvent) => void) | undefined =
     undefined;
@@ -25,8 +27,10 @@
   {disabled}
   {invalid}
   {invalidText}
+  {invalidId}
   {warn}
   {warnText}
+  {warnId}
   on:keydown={(e) => onkeydown?.(e)}
   on:click={(e) => onclick?.(e)}
   {...$$restProps}

--- a/tests/ListBox/ListBox.test.ts
+++ b/tests/ListBox/ListBox.test.ts
@@ -97,6 +97,47 @@ describe("ListBox", () => {
     );
   });
 
+  it("should render no id on the form-requirement text by default", () => {
+    render(ListBox, {
+      props: {
+        invalid: true,
+        invalidText: "Invalid selection",
+      },
+    });
+
+    expect(screen.getByText("Invalid selection")).not.toHaveAttribute("id");
+  });
+
+  it("should set invalidId on the invalid text", () => {
+    render(ListBox, {
+      props: {
+        invalid: true,
+        invalidText: "Invalid selection",
+        invalidId: "custom-error-id",
+      },
+    });
+
+    expect(screen.getByText("Invalid selection")).toHaveAttribute(
+      "id",
+      "custom-error-id",
+    );
+  });
+
+  it("should set warnId on the warning text", () => {
+    render(ListBox, {
+      props: {
+        warn: true,
+        warnText: "Warning message",
+        warnId: "custom-warn-id",
+      },
+    });
+
+    expect(screen.getByText("Warning message")).toHaveAttribute(
+      "id",
+      "custom-warn-id",
+    );
+  });
+
   it("should prioritize invalid over warning", () => {
     const { container } = render(ListBox, {
       props: {

--- a/tests/MultiSelect/MultiSelect.test.ts
+++ b/tests/MultiSelect/MultiSelect.test.ts
@@ -140,6 +140,52 @@ describe("MultiSelect", () => {
         "selection-test-multiselect helper-test-multiselect",
       );
     });
+
+    it.each([{ filterable: false }, { filterable: true }])(
+      "resolves aria-describedby to the non-fluid error text when %o",
+      ({ filterable }) => {
+        render(MultiSelect, {
+          props: {
+            id: "test-multiselect",
+            items,
+            labelText: "Contact methods",
+            filterable,
+            invalid: true,
+            invalidText: "Invalid selection",
+          },
+        });
+
+        expect(screen.getByRole("combobox")).toHaveAttribute(
+          "aria-describedby",
+          "error-test-multiselect",
+        );
+
+        const description = document.querySelector("#error-test-multiselect");
+        expect(description).toHaveTextContent("Invalid selection");
+        expect(description).toHaveClass("bx--form-requirement");
+      },
+    );
+
+    it("resolves aria-describedby to the non-fluid warning text", () => {
+      render(MultiSelect, {
+        props: {
+          id: "test-multiselect",
+          items,
+          labelText: "Contact methods",
+          warn: true,
+          warnText: "Warning message",
+        },
+      });
+
+      expect(screen.getByRole("combobox")).toHaveAttribute(
+        "aria-describedby",
+        "warn-test-multiselect",
+      );
+
+      const description = document.querySelector("#warn-test-multiselect");
+      expect(description).toHaveTextContent("Warning message");
+      expect(description).toHaveClass("bx--form-requirement");
+    });
   });
 
   it("renders default slot", () => {


### PR DESCRIPTION
A non-fluid MultiSelect with invalid/invalidText set points the field's aria-describedby at an id that is never rendered: the id'd error element only exists in the fluid branch, while non-fluid error text comes from ListBox with no id. Screen readers silently drop dangling describedby references, so the error message is never announced to the users who most need it. Same for warnText.

Give ListBox's form-requirement divs optional invalidId/warnId props and wire them up from MultiSelect so the existing describedby actually resolves. The props default to undefined, so Dropdown, ComboBox, and other ListBox consumers are unchanged and do not appear to need this.