### PR TITLE
fix(multi-select): add keyboard clearing to the non-filterable variant, announce cleared selection

### DIFF
--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -198,6 +198,20 @@
   export let maxSelectedText = "Maximum items selected";
 
   /**
+   * Specify the assistive text advertising the keyboard shortcut that clears
+   * the selection. Appended to the field's visually-hidden description
+   * whenever there is a selection to clear.
+   */
+  export let clearSelectionText =
+    "To clear the selection, press Delete or Backspace";
+
+  /**
+   * Specify the assistive text announced through the status live region when
+   * the selection is cleared via the keyboard or the clear button.
+   */
+  export let selectionClearedText = "All items cleared";
+
+  /**
    * Specify a name attribute for the select.
    * @type {string}
    */
@@ -330,6 +344,8 @@
   let internalSelectedIdsRef = selectedIds;
   /** Anchor item id for shift+click range selection; cleared when selection is reset entirely. */
   let lastSelectedItemId = null;
+  /** Text content of the visually-hidden status live region. */
+  let statusText = "";
 
   /**
    * @type {(data: { key: "field" | "selection"; ref: HTMLDivElement | HTMLButtonElement }) => void}
@@ -477,6 +493,31 @@
     applyTopSelectionFeedback();
 
     return true;
+  }
+
+  /**
+   * Announce a message through the visually-hidden status region. The text is
+   * reset first so announcing the same message twice still mutates the DOM —
+   * live regions only fire on an actual text change.
+   * @param {string} text
+   */
+  async function announceStatus(text) {
+    statusText = "";
+    await tick();
+    statusText = text;
+  }
+
+  /**
+   * Clear every selected item and announce it. Shared by the clear button and
+   * the Delete/Backspace shortcuts in both field variants. No-op when nothing
+   * is selected so a bare Delete press does not announce a phantom clear.
+   */
+  function clearSelection() {
+    if (selectionCount === 0) return;
+    selectedIds = [];
+    lastSelectedItemId = null;
+    sortedItems = sortedItems.map((item) => ({ ...item, checked: false }));
+    announceStatus(selectionClearedText);
   }
 
   afterUpdate(() => {
@@ -871,14 +912,7 @@
             <ListBoxSelection
               {selectionCount}
               on:clear
-              on:clear={() => {
-              selectedIds = [];
-              lastSelectedItemId = null;
-              sortedItems = sortedItems.map((item) => ({
-                ...item,
-                checked: false,
-              }));
-            }}
+              on:clear={clearSelection}
               translateWithId={translateWithIdSelection}
               {disabled}
               {readonly}
@@ -944,24 +978,10 @@
               if (readonly) event.preventDefault();
               if (!open) open = true;
             } else if (event.key === "Backspace" && value === "") {
-              selectedIds = [];
-              lastSelectedItemId = null;
-              sortedItems = sortedItems.map((item) => ({
-                ...item,
-                checked: false,
-              }));
+              clearSelection();
             } else if (event.key === "Delete") {
-              if (open) {
-                value = "";
-              } else {
-                value = "";
-                selectedIds = [];
-                lastSelectedItemId = null;
-                sortedItems = sortedItems.map((item) => ({
-                  ...item,
-                  checked: false,
-                }));
-              }
+              value = "";
+              if (!open) clearSelection();
             }
           }}
             on:input
@@ -1091,6 +1111,13 @@
             highlightedIndex =
               event.key === "Home" ? 0 : navigableItems.length - 1;
             highlightOrigin = "keyboard";
+          } else if (event.key === "Delete" || event.key === "Backspace") {
+            // Clear the whole selection from the keyboard, menu open or
+            // closed, matching the filterable variant. Read-only reviews the
+            // menu but never changes the selection.
+            if (readonly) return;
+            event.preventDefault();
+            clearSelection();
           }
         }}
           on:blur={(event) => {
@@ -1105,14 +1132,7 @@
             <ListBoxSelection
               {selectionCount}
               on:clear
-              on:clear={() => {
-              selectedIds = [];
-              lastSelectedItemId = null;
-              sortedItems = sortedItems.map((item) => ({
-                ...item,
-                checked: false,
-              }));
-            }}
+              on:clear={clearSelection}
               translateWithId={translateWithIdSelection}
               {disabled}
               {readonly}
@@ -1351,7 +1371,12 @@
   {#if hasSelectionDescription}
     <span id={selectionId} class:bx--visually-hidden={true}
       >{selectionCount}
-      selected</span
+      selected. {clearSelectionText}</span
     >
   {/if}
+  <!-- Live region for selection announcements. Always rendered (even while
+       empty) so assistive tech registers the region before its text changes. -->
+  <span role="status" aria-live="polite" class:bx--visually-hidden={true}
+    >{statusText}</span
+  >
 </div>

--- a/tests/MultiSelect/MultiSelect.test.svelte
+++ b/tests/MultiSelect/MultiSelect.test.svelte
@@ -22,6 +22,10 @@
   export let readonly = false;
   export let readonlyText: ComponentProps<MultiSelect>["readonlyText"] =
     undefined;
+  export let clearSelectionText: ComponentProps<MultiSelect>["clearSelectionText"] =
+    undefined;
+  export let selectionClearedText: ComponentProps<MultiSelect>["selectionClearedText"] =
+    undefined;
   export let selectionFeedback: ComponentProps<MultiSelect>["selectionFeedback"] =
     "top-after-reopen";
   export let maxSelectedItems: ComponentProps<MultiSelect>["maxSelectedItems"] =
@@ -65,6 +69,8 @@
   {disabled}
   {readonly}
   {readonlyText}
+  {clearSelectionText}
+  {selectionClearedText}
   {selectionFeedback}
   {maxSelectedItems}
   {translateWithIdSelection}

--- a/tests/MultiSelect/MultiSelect.test.ts
+++ b/tests/MultiSelect/MultiSelect.test.ts
@@ -3378,6 +3378,192 @@ describe("MultiSelect", () => {
       expect(options[1]).toHaveAttribute("aria-selected", "false");
       expect(options[2]).toHaveAttribute("aria-selected", "false");
     });
+
+    it("announces the cleared selection through the status region", async () => {
+      render(MultiSelect, {
+        props: {
+          items,
+          filterable: true,
+          placeholder: "Filter...",
+          selectedIds: ["0", "1"],
+        },
+      });
+
+      expect(screen.getByRole("status")).toHaveTextContent("");
+
+      await user.click(screen.getByPlaceholderText("Filter..."));
+      await user.keyboard("{Backspace}");
+
+      await waitFor(() =>
+        expect(screen.getByRole("status")).toHaveTextContent(
+          "All items cleared",
+        ),
+      );
+    });
+  });
+
+  describe("non-filterable: Delete/Backspace clears selection (with announcement)", () => {
+    it("Delete clears the selection while the menu is closed and announces it", async () => {
+      render(MultiSelect, {
+        props: {
+          items,
+          labelText: "Contact methods",
+          selectedIds: ["0", "1"],
+        },
+      });
+
+      const combobox = screen.getByRole("combobox");
+      combobox.focus();
+      expect(combobox).toHaveAttribute("aria-expanded", "false");
+      expect(screen.getByRole("status")).toHaveTextContent("");
+
+      await user.keyboard("{Delete}");
+
+      await waitFor(() =>
+        expect(screen.getByRole("status")).toHaveTextContent(
+          "All items cleared",
+        ),
+      );
+
+      // Open the menu to verify every option was unchecked.
+      await user.click(combobox);
+      for (const option of screen.getAllByRole("option")) {
+        expect(option).toHaveAttribute("aria-selected", "false");
+      }
+    });
+
+    it("Backspace clears the selection while the menu is open and keeps it open", async () => {
+      render(MultiSelect, {
+        props: {
+          items,
+          labelText: "Contact methods",
+          selectedIds: ["0"],
+        },
+      });
+
+      const combobox = screen.getByRole("combobox");
+      combobox.focus();
+      await user.keyboard("{ArrowDown}");
+      await tick();
+      expect(combobox).toHaveAttribute("aria-expanded", "true");
+
+      await user.keyboard("{Backspace}");
+
+      expect(combobox).toHaveAttribute("aria-expanded", "true");
+      for (const option of screen.getAllByRole("option")) {
+        expect(option).toHaveAttribute("aria-selected", "false");
+      }
+      await waitFor(() =>
+        expect(screen.getByRole("status")).toHaveTextContent(
+          "All items cleared",
+        ),
+      );
+    });
+
+    it("Delete with nothing selected announces nothing", async () => {
+      render(MultiSelect, {
+        props: { items, labelText: "Contact methods" },
+      });
+
+      const combobox = screen.getByRole("combobox");
+      combobox.focus();
+      await user.keyboard("{Delete}");
+      await tick();
+
+      expect(screen.getByRole("status")).toHaveTextContent("");
+    });
+
+    it("does not clear the selection when read-only", async () => {
+      render(MultiSelect, {
+        props: {
+          items,
+          labelText: "Contact methods",
+          readonly: true,
+          selectedIds: ["0", "1"],
+        },
+      });
+
+      const combobox = screen.getByRole("combobox");
+      await user.click(combobox);
+      await user.keyboard("{Delete}");
+      await user.keyboard("{Backspace}");
+      await tick();
+
+      const options = screen.getAllByRole("option");
+      expect(options[0]).toHaveAttribute("aria-selected", "true");
+      expect(options[1]).toHaveAttribute("aria-selected", "true");
+      expect(screen.getByRole("status")).toHaveTextContent("");
+    });
+
+    it("announces when the selection is cleared with the clear button", async () => {
+      const { container } = render(MultiSelect, {
+        props: {
+          items,
+          labelText: "Contact methods",
+          selectedIds: ["0"],
+        },
+      });
+
+      const closeIcon = container.querySelector(".bx--tag__close-icon");
+      assert(closeIcon);
+      await user.click(closeIcon);
+
+      await waitFor(() =>
+        expect(screen.getByRole("status")).toHaveTextContent(
+          "All items cleared",
+        ),
+      );
+    });
+
+    it("advertises the clear shortcut in the field description only while there is a selection", async () => {
+      render(MultiSelect, {
+        props: {
+          id: "test-multiselect",
+          items,
+          labelText: "Contact methods",
+          selectedIds: ["0"],
+        },
+      });
+
+      const description = document.querySelector("#selection-test-multiselect");
+      expect(description).toHaveTextContent(
+        "1 selected. To clear the selection, press Delete or Backspace",
+      );
+
+      screen.getByRole("combobox").focus();
+      await user.keyboard("{Delete}");
+      await tick();
+
+      // The existing "omits the selection count description when nothing is
+      // selected" behavior removes the shortcut hint along with the count.
+      expect(
+        document.querySelector("#selection-test-multiselect"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("supports overriding the shortcut hint and cleared announcement", async () => {
+      render(MultiSelect, {
+        props: {
+          id: "test-multiselect",
+          items,
+          labelText: "Contact methods",
+          selectedIds: ["0"],
+          clearSelectionText: "Press Delete to reset",
+          selectionClearedText: "Selection reset",
+        },
+      });
+
+      expect(
+        document.querySelector("#selection-test-multiselect"),
+      ).toHaveTextContent("1 selected. Press Delete to reset");
+
+      screen.getByRole("combobox").focus();
+      await user.keyboard("{Delete}");
+
+      await waitFor(() =>
+        expect(screen.getByRole("status")).toHaveTextContent("Selection reset"),
+      );
+    });
   });
 
   describe("readonly", () => {


### PR DESCRIPTION
Delete/Backspace now clear the selection in the non-filterable field (matching the filterable variant and Carbon React), the shortcut is advertised in the field's visually-hidden description, and clearing by keyboard or the clear button announces "All items cleared" through a role="status" live region. Adds `clearSelectionText` and `selectionClearedText` props for i18n.