### PR TITLE
fix(dropdown): add keyboard clearing, announce cleared selection

### DIFF
--- a/src/Dropdown/Dropdown.svelte
+++ b/src/Dropdown/Dropdown.svelte
@@ -104,8 +104,24 @@
   /**
    * Set to `true` to show a clear button when an item is selected.
    * Clears `selectedId` and dispatches a `clear` event.
+   * Also enables clearing the selection with Delete/Backspace.
    */
   export let clearable = false;
+
+  /**
+   * Specify the assistive text advertising the keyboard shortcut that clears
+   * the selection. Appended to the field's description whenever there is a
+   * selection to clear. Only used when `clearable` is `true`.
+   */
+  export let clearSelectionText =
+    "To clear the selection, press Delete or Backspace";
+
+  /**
+   * Specify the assistive text announced through the status live region when
+   * the selection is cleared via the keyboard or the clear button. Only used
+   * when `clearable` is `true`.
+   */
+  export let selectionClearedText = "Selection cleared";
 
   /**
    * Set to `true` to use the fluid variant.
@@ -247,6 +263,8 @@
   let prevOpen = false;
   let fieldFocused = false;
   let itemsById = new Map();
+  /** Text content of the visually-hidden status live region. */
+  let statusText = "";
 
   const TYPEAHEAD_DELAY = 500;
 
@@ -272,9 +290,24 @@
   $: helperId = `helper-${id}`;
   $: errorId = `error-${id}`;
   $: warnId = `warn-${id}`;
+  $: selectionId = `selection-${id}`;
   // Invalid/warn states are suppressed when the dropdown is disabled or read-only.
   $: showInvalid = invalid && !disabled && !readonly;
   $: showWarn = warn && !invalid && !disabled && !readonly;
+  $: hasSelectionDescription =
+    clearable && !readonly && selectedId !== undefined;
+  $: statusDescribedById =
+    showInvalid && invalidText
+      ? errorId
+      : showWarn && warnText
+        ? warnId
+        : !inline && !isFluid && !showInvalid && !showWarn && helperText
+          ? helperId
+          : undefined;
+  $: fieldDescribedById =
+    [hasSelectionDescription ? selectionId : null, statusDescribedById]
+      .filter(Boolean)
+      .join(" ") || undefined;
   $: isFluid = !inline && (fluid || !!formContext?.isFluid);
   $: showFieldFocus = isFluid && (fieldFocused || open);
   // Scope the option id with the instance `id` so multiple Dropdowns on a
@@ -468,10 +501,23 @@
     });
   }
 
+  /**
+   * Announce a message through the visually-hidden status region. The text is
+   * reset first so announcing the same message twice still mutates the DOM —
+   * live regions only fire on an actual text change.
+   * @param {string} text
+   */
+  async function announceStatus(text) {
+    statusText = "";
+    await tick();
+    statusText = text;
+  }
+
   function clearSelection() {
-    if (readonly) return;
+    if (readonly || selectedId === undefined) return;
     selectedId = undefined;
     open = false;
+    announceStatus(selectionClearedText);
   }
 
   /**
@@ -602,13 +648,7 @@
         aria-haspopup="listbox"
         aria-activedescendant={highlightedId ?? ""}
         aria-controls={open ? menuId : undefined}
-        aria-describedby={showInvalid && invalidText
-          ? errorId
-          : showWarn && warnText
-            ? warnId
-            : !inline && !isFluid && !showInvalid && !showWarn && helperText
-              ? helperId
-              : undefined}
+        aria-describedby={fieldDescribedById}
         on:focus={() => {
           if (isFluid) fieldFocused = true;
         }}
@@ -664,6 +704,16 @@
           highlightOrigin = "keyboard";
         } else if (event.key === "Escape") {
           close("escape-key");
+        } else if (
+          clearable &&
+          selectedId !== undefined &&
+          (event.key === "Delete" || event.key === "Backspace")
+        ) {
+          // Clear the selection from the keyboard, menu open or closed,
+          // matching the click-to-clear button. Only wired when `clearable`
+          // is set, since that is what makes clearing possible at all.
+          event.preventDefault();
+          clearSelection();
         } else if (
           open &&
           event.key.length === 1 &&
@@ -886,4 +936,14 @@
       {helperText}
     </div>
   {/if}
+  {#if hasSelectionDescription}
+    <span id={selectionId} class:bx--visually-hidden={true}
+      >{clearSelectionText}</span
+    >
+  {/if}
+  <!-- Live region for selection announcements. Always rendered (even while
+       empty) so assistive tech registers the region before its text changes. -->
+  <span role="status" aria-live="polite" class:bx--visually-hidden={true}
+    >{statusText}</span
+  >
 </div>

--- a/tests/Dropdown/Dropdown.test.svelte
+++ b/tests/Dropdown/Dropdown.test.svelte
@@ -27,6 +27,10 @@
   export let translateWithIdSelection: ComponentProps<Dropdown>["translateWithIdSelection"] =
     undefined;
   export let clearable: ComponentProps<Dropdown>["clearable"] = false;
+  export let clearSelectionText: ComponentProps<Dropdown>["clearSelectionText"] =
+    undefined;
+  export let selectionClearedText: ComponentProps<Dropdown>["selectionClearedText"] =
+    undefined;
   export let id: ComponentProps<Dropdown>["id"] = "test-dropdown";
   export let name: ComponentProps<Dropdown>["name"] = undefined;
   export let ref: ComponentProps<Dropdown>["ref"] = null;
@@ -59,6 +63,8 @@
   {translateWithId}
   {translateWithIdSelection}
   {clearable}
+  {clearSelectionText}
+  {selectionClearedText}
   {id}
   {name}
   bind:ref

--- a/tests/Dropdown/Dropdown.test.ts
+++ b/tests/Dropdown/Dropdown.test.ts
@@ -300,6 +300,179 @@ describe("Dropdown", () => {
     ).toBeInTheDocument();
   });
 
+  describe("clearable: Delete/Backspace clears selection (with announcement)", () => {
+    it("Delete clears the selection while the menu is closed and announces it", async () => {
+      render(Dropdown, {
+        props: {
+          items,
+          selectedId: "0",
+          labelText: "Contact",
+          clearable: true,
+        },
+      });
+
+      const combobox = screen.getByRole("combobox");
+      combobox.focus();
+      expect(combobox).toHaveAttribute("aria-expanded", "false");
+      expect(screen.getByRole("status")).toHaveTextContent("");
+
+      await user.keyboard("{Delete}");
+
+      await waitFor(() =>
+        expect(screen.getByRole("status")).toHaveTextContent(
+          "Selection cleared",
+        ),
+      );
+      expect(within(combobox).queryByText("Slack")).not.toBeInTheDocument();
+    });
+
+    it("Backspace clears the selection while the menu is open", async () => {
+      render(Dropdown, {
+        props: {
+          items,
+          selectedId: "0",
+          labelText: "Contact",
+          clearable: true,
+        },
+      });
+
+      const combobox = screen.getByRole("combobox");
+      await user.click(combobox);
+      expect(combobox).toHaveAttribute("aria-expanded", "true");
+
+      await user.keyboard("{Backspace}");
+
+      expect(within(combobox).queryByText("Slack")).not.toBeInTheDocument();
+      await waitFor(() =>
+        expect(screen.getByRole("status")).toHaveTextContent(
+          "Selection cleared",
+        ),
+      );
+    });
+
+    it("does not clear the selection when clearable is false", async () => {
+      render(Dropdown, {
+        props: {
+          items,
+          selectedId: "0",
+          labelText: "Contact",
+          clearable: false,
+        },
+      });
+
+      const combobox = screen.getByRole("combobox");
+      combobox.focus();
+      await user.keyboard("{Delete}");
+      await user.keyboard("{Backspace}");
+
+      expect(within(combobox).getByText("Slack")).toBeInTheDocument();
+      expect(screen.getByRole("status")).toHaveTextContent("");
+    });
+
+    it("does not clear the selection when read-only", async () => {
+      render(Dropdown, {
+        props: {
+          items,
+          selectedId: "0",
+          labelText: "Contact",
+          clearable: true,
+          readonly: true,
+        },
+      });
+
+      const combobox = screen.getByRole("combobox");
+      combobox.focus();
+      await user.keyboard("{Delete}");
+      await user.keyboard("{Backspace}");
+
+      expect(within(combobox).getByText("Slack")).toBeInTheDocument();
+      expect(screen.getByRole("status")).toHaveTextContent("");
+    });
+
+    it("Delete with nothing selected announces nothing", async () => {
+      render(Dropdown, {
+        props: { items, labelText: "Contact", clearable: true },
+      });
+
+      const combobox = screen.getByRole("combobox");
+      combobox.focus();
+      await user.keyboard("{Delete}");
+
+      expect(screen.getByRole("status")).toHaveTextContent("");
+    });
+
+    it("announces when the selection is cleared with the clear button", async () => {
+      render(Dropdown, {
+        props: {
+          items,
+          selectedId: "0",
+          labelText: "Contact",
+          clearable: true,
+        },
+      });
+
+      const clearButton = screen.getByRole("button", {
+        name: "Clear selected item",
+      });
+      await user.click(clearButton);
+
+      await waitFor(() =>
+        expect(screen.getByRole("status")).toHaveTextContent(
+          "Selection cleared",
+        ),
+      );
+    });
+
+    it("advertises the clear shortcut in the field description only while there is a selection", async () => {
+      render(Dropdown, {
+        props: {
+          id: "test-dropdown",
+          items,
+          selectedId: "0",
+          labelText: "Contact",
+          clearable: true,
+        },
+      });
+
+      const description = document.querySelector("#selection-test-dropdown");
+      expect(description).toHaveTextContent(
+        "To clear the selection, press Delete or Backspace",
+      );
+
+      screen.getByRole("combobox").focus();
+      await user.keyboard("{Delete}");
+
+      expect(
+        document.querySelector("#selection-test-dropdown"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("supports overriding the shortcut hint and cleared announcement", async () => {
+      render(Dropdown, {
+        props: {
+          id: "test-dropdown",
+          items,
+          selectedId: "0",
+          labelText: "Contact",
+          clearable: true,
+          clearSelectionText: "Press Delete to reset",
+          selectionClearedText: "Selection reset",
+        },
+      });
+
+      expect(
+        document.querySelector("#selection-test-dropdown"),
+      ).toHaveTextContent("Press Delete to reset");
+
+      screen.getByRole("combobox").focus();
+      await user.keyboard("{Delete}");
+
+      await waitFor(() =>
+        expect(screen.getByRole("status")).toHaveTextContent("Selection reset"),
+      );
+    });
+  });
+
   it("should handle helper text", () => {
     render(Dropdown, {
       props: {


### PR DESCRIPTION
Delete/Backspace now clear the selection when `clearable` is set,
menu open or closed, and the clear (keyboard or button) is announced
through a role="status" live region. The shortcut is advertised in
the field's visually-hidden description. Adds `clearSelectionText`
and `selectionClearedText` props for i18n.

Same gap and same fix shape as #3642 for MultiSelect's non-filterable
field; Dropdown's clearable field had the identical hole since it's
also a button-triggered combobox with no text to backspace over.