### PR TITLE
feat(multi-select): announce filter result counts in the filterable variant

### DIFF
--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -212,6 +212,17 @@
   export let selectionClearedText = "All items cleared";
 
   /**
+   * Build the assistive message announced through the status live region when
+   * typing in the filterable variant changes how many options match.
+   * The count excludes any "select all" item.
+   * @type {(count: number) => string}
+   */
+  export let filterResultsText = (count) =>
+    count === 0
+      ? "No results"
+      : `${count} result${count === 1 ? "" : "s"} available`;
+
+  /**
    * Specify a name attribute for the select.
    * @type {string}
    */
@@ -296,6 +307,7 @@
     afterUpdate,
     createEventDispatcher,
     getContext,
+    onDestroy,
     setContext,
     tick,
   } from "svelte";
@@ -314,6 +326,7 @@
     getMenuItemHeight,
     getMenuMaxHeight,
   } from "../ListBox/list-box-utils.js";
+  import { debounce } from "../utils/debounce.js";
   import { dismiss } from "../utils/dismiss.js";
   import { isOutsideClick } from "../utils/isOutsideClick.js";
   import { createScrollEndTracker } from "../utils/isScrollNearEnd.js";
@@ -520,6 +533,17 @@
     sortedItems = sortedItems.map((item) => ({ ...item, checked: false }));
     announceStatus(selectionClearedText);
   }
+
+  /** Filter result count last announced; null when the menu is closed so reopening announces again. */
+  let announcedFilterCount = null;
+
+  const announceFilterResults = debounce((count) => {
+    if (count === announcedFilterCount) return;
+    announcedFilterCount = count;
+    announceStatus(filterResultsText(count));
+  }, 800);
+
+  onDestroy(() => announceFilterResults.cancel());
 
   afterUpdate(() => {
     // Compare by length, not by IDs. This is intentional: `on:select`
@@ -777,6 +801,18 @@
           (item) => item.isSelectAll || filterItem(item, value),
         )
       : [];
+  $: filterResultCount = filteredItems.filter(
+    (item) => !item.isSelectAll,
+  ).length;
+  $: if (filterable && open && value?.length > 0) {
+    announceFilterResults(filterResultCount);
+  } else {
+    announceFilterResults.cancel();
+  }
+  $: if (!open) {
+    announcedFilterCount = null;
+    statusText = "";
+  }
   $: highlightedId =
     highlightedIndex > -1
       ? ((filterable ? filteredItems : sortedItems)[highlightedIndex]?.id ??

--- a/tests/MultiSelect/MultiSelect.test.svelte
+++ b/tests/MultiSelect/MultiSelect.test.svelte
@@ -26,6 +26,8 @@
     undefined;
   export let selectionClearedText: ComponentProps<MultiSelect>["selectionClearedText"] =
     undefined;
+  export let filterResultsText: ComponentProps<MultiSelect>["filterResultsText"] =
+    undefined;
   export let selectionFeedback: ComponentProps<MultiSelect>["selectionFeedback"] =
     "top-after-reopen";
   export let maxSelectedItems: ComponentProps<MultiSelect>["maxSelectedItems"] =
@@ -71,6 +73,7 @@
   {readonlyText}
   {clearSelectionText}
   {selectionClearedText}
+  {filterResultsText}
   {selectionFeedback}
   {maxSelectedItems}
   {translateWithIdSelection}

--- a/tests/MultiSelect/MultiSelect.test.ts
+++ b/tests/MultiSelect/MultiSelect.test.ts
@@ -3566,6 +3566,142 @@ describe("MultiSelect", () => {
     });
   });
 
+  describe("filterable: announces filter result counts", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    // Keep in sync with the `announceFilterResults` debounce delay in
+    // MultiSelect.svelte.
+    const DEBOUNCE_MS = 800;
+
+    // user-event stalls under fake timers, so these tests drive the input
+    // with fireEvent. An input event both sets `value` and opens the menu.
+    const renderFiltered = (
+      props: Partial<ComponentProps<MultiSelectComponent>> = {},
+    ) => {
+      render(MultiSelect, {
+        props: { items, filterable: true, placeholder: "Filter...", ...props },
+      });
+      return screen.getByPlaceholderText("Filter...");
+    };
+
+    it("announces the match count once typing pauses", async () => {
+      const input = renderFiltered();
+
+      await fireEvent.input(input, { target: { value: "sl" } });
+      expect(screen.getByRole("status")).toHaveTextContent("");
+
+      await vi.advanceTimersByTimeAsync(DEBOUNCE_MS);
+      expect(screen.getByRole("status")).toHaveTextContent(
+        "1 result available",
+      );
+    });
+
+    it("announces only the final count of a typing burst", async () => {
+      const input = renderFiltered();
+
+      await fireEvent.input(input, { target: { value: "a" } });
+      await vi.advanceTimersByTimeAsync(DEBOUNCE_MS - 100);
+      expect(screen.getByRole("status")).toHaveTextContent("");
+
+      await fireEvent.input(input, { target: { value: "ax" } });
+      await vi.advanceTimersByTimeAsync(DEBOUNCE_MS);
+      expect(screen.getByRole("status")).toHaveTextContent(
+        "1 result available",
+      );
+    });
+
+    it("announces no results and pluralizes counts", async () => {
+      const input = renderFiltered();
+
+      await fireEvent.input(input, { target: { value: "zzz" } });
+      await vi.advanceTimersByTimeAsync(DEBOUNCE_MS);
+      expect(screen.getByRole("status")).toHaveTextContent("No results");
+
+      await fireEvent.input(input, { target: { value: "a" } });
+      await vi.advanceTimersByTimeAsync(DEBOUNCE_MS);
+      expect(screen.getByRole("status")).toHaveTextContent(
+        "3 results available",
+      );
+    });
+
+    it("skips the announcement when the count has not changed, supports a custom message", async () => {
+      const filterResultsText = vi.fn((count: number) => `${count} matches`);
+      const input = renderFiltered({ filterResultsText });
+
+      await fireEvent.input(input, { target: { value: "sl" } });
+      await vi.advanceTimersByTimeAsync(DEBOUNCE_MS);
+      expect(screen.getByRole("status")).toHaveTextContent("1 matches");
+      expect(filterResultsText).toHaveBeenCalledTimes(1);
+
+      await fireEvent.input(input, { target: { value: "sla" } });
+      await vi.advanceTimersByTimeAsync(DEBOUNCE_MS);
+      expect(filterResultsText).toHaveBeenCalledTimes(1);
+    });
+
+    it("clears the region when the menu closes and announces again on reopen", async () => {
+      const input = renderFiltered();
+
+      await fireEvent.input(input, { target: { value: "sl" } });
+      await vi.advanceTimersByTimeAsync(DEBOUNCE_MS);
+      expect(screen.getByRole("status")).toHaveTextContent(
+        "1 result available",
+      );
+
+      await fireEvent.keyDown(input, { key: "Escape" });
+      await tick();
+      expect(screen.getByRole("status")).toHaveTextContent("");
+
+      // Reopening resets the "last announced" count: the same count announces
+      // again, since the region was cleared on close.
+      await fireEvent.input(input, { target: { value: "sl" } });
+      await vi.advanceTimersByTimeAsync(DEBOUNCE_MS);
+      expect(screen.getByRole("status")).toHaveTextContent(
+        "1 result available",
+      );
+    });
+
+    it("drops a pending announcement when the menu closes mid-debounce", async () => {
+      const input = renderFiltered();
+
+      await fireEvent.input(input, { target: { value: "sl" } });
+      await vi.advanceTimersByTimeAsync(DEBOUNCE_MS / 2);
+      await fireEvent.keyDown(input, { key: "Escape" });
+      await vi.advanceTimersByTimeAsync(DEBOUNCE_MS * 2);
+
+      expect(screen.getByRole("status")).toHaveTextContent("");
+    });
+
+    it("does not announce when the filter text is emptied", async () => {
+      const input = renderFiltered();
+
+      await fireEvent.input(input, { target: { value: "sl" } });
+      await vi.advanceTimersByTimeAsync(DEBOUNCE_MS / 2);
+      await fireEvent.input(input, { target: { value: "" } });
+      await vi.advanceTimersByTimeAsync(DEBOUNCE_MS * 2);
+
+      expect(screen.getByRole("status")).toHaveTextContent("");
+    });
+
+    it("excludes the select-all pseudo-item from the count", async () => {
+      const input = renderFiltered({
+        items: [{ id: "all", text: "Select all", isSelectAll: true }, ...items],
+      });
+
+      await fireEvent.input(input, { target: { value: "zzz" } });
+      await vi.advanceTimersByTimeAsync(DEBOUNCE_MS);
+
+      // The select-all item always survives filtering; it must not count as a
+      // result.
+      expect(screen.getByRole("status")).toHaveTextContent("No results");
+    });
+  });
+
   describe("readonly", () => {
     it("should apply readonly class on the listbox", () => {
       const { container } = render(MultiSelect, {


### PR DESCRIPTION
When typing in the filterable MultiSelect, the option list narrows silently — a screen reader user can't tell whether their query matched 40 items, 5, or none without arrowing into the list. Announce the count ("5 results available", "No results") through the status live region, debounced 800ms so it doesn't chatter on every keystroke, skipped when the count hasn't changed, and cleared when the menu closes. The message is customizable via the new `filterResultsText` prop for i18n.