### PR TITLE
chore(biome): restore dropped onDestroy ban, fix usages

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -240,6 +240,12 @@
             "noRestrictedImports": {
               "level": "error",
               "options": {
+                "paths": {
+                  "svelte": {
+                    "importNames": ["onDestroy"],
+                    "message": "Use the return function from onMount instead of onDestroy."
+                  }
+                },
                 "patterns": [
                   {
                     "group": ["carbon-icons-svelte", "carbon-icons-svelte/**"],

--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -307,7 +307,7 @@
     afterUpdate,
     createEventDispatcher,
     getContext,
-    onDestroy,
+    onMount,
     setContext,
     tick,
   } from "svelte";
@@ -543,7 +543,7 @@
     announceStatus(filterResultsText(count));
   }, 800);
 
-  onDestroy(() => announceFilterResults.cancel());
+  onMount(() => announceFilterResults.cancel);
 
   afterUpdate(() => {
     // Compare by length, not by IDs. This is intentional: `on:select`

--- a/src/UIShell/HamburgerMenu.svelte
+++ b/src/UIShell/HamburgerMenu.svelte
@@ -27,15 +27,17 @@
   /** Obtain a reference to the HTML button element */
   export let ref = null;
 
-  import { onDestroy } from "svelte";
+  import { onMount } from "svelte";
   import Close from "../icons/Close.svelte";
   import Menu from "../icons/Menu.svelte";
   import { hamburgerMenuRef } from "./nav-store.js";
 
   $: hamburgerMenuRef.set(ref);
 
-  onDestroy(() => {
-    hamburgerMenuRef.update((current) => (current === ref ? null : current));
+  onMount(() => {
+    return () => {
+      hamburgerMenuRef.update((current) => (current === ref ? null : current));
+    };
   });
 </script>
 


### PR DESCRIPTION
The src/** override for noRestrictedImports (banning
carbon-icons-svelte imports) replaced the whole rule's options
object instead of merging with it. Biome overrides don't deep-merge
nested rule options, so this silently dropped the earlier onDestroy
ban for every file under src/ — the one place it needs to apply.

Confirmed with an isolated repro: the rule fired outside src/ but
not inside, with the same biome.json.

Fixes:
- biome.json: added the svelte/onDestroy paths restriction to the
  same override, alongside the carbon-icons-svelte patterns
  restriction, so both survive.
- HamburgerMenu.svelte and MultiSelect.svelte: switched from
  onDestroy to onMount's return-cleanup form, which is what the
  banned-import message points people to.