### PR TITLE
fix(multi-select): stop the option-click focus bounce, drop aria-owns, set aria list attributes in virtual

### DIFF
--- a/src/ListBox/ListBoxField.svelte
+++ b/src/ListBox/ListBoxField.svelte
@@ -42,7 +42,6 @@
   {id}
   {role}
   aria-expanded={ariaExpanded}
-  aria-owns={(ariaExpanded && menuId) || undefined}
   aria-controls={(ariaExpanded && menuId) || undefined}
   aria-disabled={disabled}
   aria-readonly={readonly || undefined}

--- a/src/ListBox/ListBoxMenuItem.svelte
+++ b/src/ListBox/ListBoxMenuItem.svelte
@@ -35,6 +35,7 @@
   disabled={disabled ? true : undefined}
   {...$$restProps}
   on:click
+  on:mousedown
   on:mouseenter
   on:mouseleave
 >

--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -969,7 +969,6 @@
             aria-disabled={disabled || undefined}
             aria-readonly={readonly || undefined}
             aria-controls={open ? menuId : undefined}
-            aria-owns={open ? menuId : undefined}
             aria-describedby={fieldDescribedById}
             class:bx--text-input={true}
             class:bx--text-input--empty={value === ""}
@@ -1083,7 +1082,6 @@
           aria-expanded={open}
           aria-activedescendant={activeDescendantId}
           aria-controls={open ? menuId : undefined}
-          aria-owns={open ? menuId : undefined}
           aria-describedby={fieldDescribedById}
           on:focus={() => {
           fieldFocused = true;
@@ -1254,11 +1252,11 @@
                       selectItem(item);
                     }
                     lastSelectedItemId = item.id;
-                    if (filterable) {
-                      inputRef?.focus();
-                    } else {
-                      fieldRef?.focus();
-                    }
+                  }}
+                  on:mousedown={(event) => {
+                    // Keep focus on the field so screen readers don't
+                    // re-announce it on every option click.
+                    event.preventDefault();
                   }}
                   on:mouseenter={() => {
                     if (itemDisabled) return;
@@ -1336,11 +1334,11 @@
                   selectItem(item);
                 }
                 lastSelectedItemId = item.id;
-                if (filterable) {
-                  inputRef?.focus();
-                } else {
-                  fieldRef?.focus();
-                }
+              }}
+              on:mousedown={(event) => {
+                // Keep focus on the field so screen readers don't
+                // re-announce it on every option click.
+                event.preventDefault();
               }}
               on:mouseenter={() => {
                 if (itemDisabled) return;

--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -1232,6 +1232,8 @@
                       ? "mixed"
                       : allSelected
                     : item.checked}
+                  aria-setsize={itemsToUse.length}
+                  aria-posinset={actualIndex + 1}
                   active={item.isSelectAll ? false : item.checked}
                   highlighted={highlightedIndex === actualIndex}
                   disabled={itemDisabled}

--- a/tests/ListBox/ListBoxField.test.ts
+++ b/tests/ListBox/ListBoxField.test.ts
@@ -98,7 +98,7 @@ describe("ListBoxField", () => {
     });
 
     const field = screen.getByText("ID test").closest(".bx--list-box__field");
-    expect(field).toHaveAttribute("aria-owns", "menu-test-field");
+    expect(field).not.toHaveAttribute("aria-owns");
     expect(field).toHaveAttribute("aria-controls", "menu-test-field");
   });
 

--- a/tests/MultiSelect/MultiSelect.test.ts
+++ b/tests/MultiSelect/MultiSelect.test.ts
@@ -1533,6 +1533,9 @@ describe("MultiSelect", () => {
 
       expect(combobox).toHaveAttribute("aria-expanded", "true");
       expect(combobox).toHaveAttribute("aria-controls");
+      // ARIA 1.2 comboboxes reference the popup via aria-controls only;
+      // aria-owns restructures the accessibility tree and can double-read.
+      expect(combobox).not.toHaveAttribute("aria-owns");
       const menuId = combobox.getAttribute("aria-controls");
       expect(screen.getByRole("listbox")).toHaveAttribute("id", menuId);
     });
@@ -1551,6 +1554,70 @@ describe("MultiSelect", () => {
       await user.click(screen.getByText("Contact methods"));
 
       expect(combobox).toHaveAttribute("aria-expanded", "true");
+      expect(combobox).toHaveFocus();
+    });
+
+    it("keeps focus on the field while clicking options (non-filterable)", async () => {
+      render(MultiSelect, {
+        props: {
+          items,
+          labelText: "Contact methods",
+        },
+      });
+
+      const combobox = screen.getByRole("combobox");
+      await user.click(combobox);
+      expect(combobox).toHaveFocus();
+
+      // Focus must never move to the option — a focus bounce makes screen
+      // readers re-announce the entire field on every click.
+      const option = screen.getByRole("option", { name: "Email" });
+      await user.click(option);
+
+      expect(option).toHaveAttribute("aria-checked", "true");
+      expect(combobox).toHaveFocus();
+    });
+
+    it("keeps focus on the input while clicking options (filterable)", async () => {
+      render(MultiSelect, {
+        props: {
+          items,
+          filterable: true,
+          placeholder: "Filter...",
+        },
+      });
+
+      const combobox = screen.getByRole("combobox");
+      await user.click(combobox);
+      expect(combobox).toHaveFocus();
+
+      const option = screen.getByRole("option", { name: "Email" });
+      await user.click(option);
+
+      expect(option).toHaveAttribute("aria-checked", "true");
+      expect(combobox).toHaveFocus();
+    });
+
+    it("keeps focus on the field while clicking virtualized options", async () => {
+      const largeItems = Array.from({ length: 500 }, (_, i) => ({
+        id: String(i),
+        text: `Item ${i + 1}`,
+      }));
+      render(MultiSelect, {
+        props: {
+          items: largeItems,
+          virtualize: true,
+        },
+      });
+
+      const combobox = screen.getByRole("combobox");
+      await user.click(combobox);
+      expect(combobox).toHaveFocus();
+
+      const option = screen.getByRole("option", { name: "Item 1" });
+      await user.click(option);
+
+      expect(option).toHaveAttribute("aria-checked", "true");
       expect(combobox).toHaveFocus();
     });
 
@@ -1587,6 +1654,7 @@ describe("MultiSelect", () => {
 
       expect(combobox).toHaveAttribute("aria-expanded", "true");
       expect(combobox).toHaveAttribute("aria-controls");
+      expect(combobox).not.toHaveAttribute("aria-owns");
       const menuId = combobox.getAttribute("aria-controls");
       expect(screen.getByRole("listbox")).toHaveAttribute("id", menuId);
     });


### PR DESCRIPTION
These are the last of the fixes I identified in my accessibility review of the multi-select. Thanks for all the merges!

Clicking an option let focus land on the option and then bounced it back to the field with a programmatic focus() call, making many screen readers re-announce the entire field on every click. Prevent default on the option's mousedown instead so focus never leaves the trigger.

Also remove aria-owns from both field variants: ARIA 1.2 comboboxes reference the popup via aria-controls only, and aria-owns can cause double-reading.

Finally, set aria-posinset and aria-setsize in the virtualized menu to ensure correct counts for screen readers.