### PR TITLE
fix(dropdown,combobox): stop option-click focus bounce, drop aria-owns

### DIFF
--- a/src/ComboBox/ComboBox.svelte
+++ b/src/ComboBox/ComboBox.svelte
@@ -681,7 +681,6 @@
           aria-disabled={disabled || readonly}
           aria-readonly={readonly || undefined}
           aria-controls={open ? menuId : undefined}
-          aria-owns={open ? menuId : undefined}
           aria-describedby={showInvalid && invalidText
           ? errorId
           : showWarn && warnText
@@ -919,6 +918,8 @@
                   {highlighted}
                   disabled={item.disabled}
                   hasLeftIcon={Boolean($$slots.icon || item.icon)}
+                  aria-setsize={filteredItems.length}
+                  aria-posinset={actualIndex + 1}
                   on:click={(event) => {
                     if (item.disabled) {
                       event.stopPropagation();
@@ -931,6 +932,11 @@
                     if (filteredItems[actualIndex]) {
                       value = itemToString(filteredItems[actualIndex]);
                     }
+                  }}
+                  on:mousedown={(event) => {
+                    // Keep focus on the field so screen readers don't
+                    // re-announce it on every option click.
+                    event.preventDefault();
                   }}
                   on:mouseenter={() => {
                     if (item.disabled) return;
@@ -999,6 +1005,11 @@
                 if (filteredItems[index]) {
                   value = itemToString(filteredItems[index]);
                 }
+              }}
+              on:mousedown={(event) => {
+                // Keep focus on the field so screen readers don't
+                // re-announce it on every option click.
+                event.preventDefault();
               }}
               on:mouseenter={() => {
                 if (item.disabled) return;

--- a/src/Dropdown/Dropdown.svelte
+++ b/src/Dropdown/Dropdown.svelte
@@ -803,6 +803,8 @@
                   {highlighted}
                   disabled={item.disabled}
                   hasLeftIcon={Boolean($$slots.icon || item.icon)}
+                  aria-setsize={items.length}
+                  aria-posinset={actualIndex + 1}
                   on:click={(event) => {
                     if (item.disabled) {
                       event.stopPropagation();
@@ -811,7 +813,11 @@
                     selectedId = item.id;
                     dispatchSelect();
                     close("select");
-                    ref.focus();
+                  }}
+                  on:mousedown={(event) => {
+                    // Keep focus on the field so screen readers don't
+                    // re-announce it on every option click.
+                    event.preventDefault();
                   }}
                   on:mouseenter={() => {
                     if (item.disabled) return;
@@ -876,7 +882,11 @@
                 selectedId = item.id;
                 dispatchSelect();
                 close("select");
-                ref.focus();
+              }}
+              on:mousedown={(event) => {
+                // Keep focus on the field so screen readers don't
+                // re-announce it on every option click.
+                event.preventDefault();
               }}
               on:mouseenter={() => {
                 if (item.disabled) return;

--- a/tests/ComboBox/ComboBox.test.ts
+++ b/tests/ComboBox/ComboBox.test.ts
@@ -348,6 +348,33 @@ describe("ComboBox", () => {
     expect(input).toHaveValue("");
   });
 
+  it("should not set aria-owns on the combobox", async () => {
+    render(ComboBox);
+
+    const input = getInput();
+    await user.click(input);
+    expect(input).toHaveAttribute("aria-controls");
+    // ARIA 1.2 comboboxes reference the popup via aria-controls only;
+    // aria-owns restructures the accessibility tree and can double-read.
+    expect(input).not.toHaveAttribute("aria-owns");
+  });
+
+  it("keeps focus on the field while clicking an option", async () => {
+    render(ComboBox);
+
+    const input = getInput();
+    await user.click(input);
+    expect(input).toHaveFocus();
+
+    // Focus must never move to the option — a focus bounce makes screen
+    // readers re-announce the entire field on every click.
+    const emailOption = screen.getByRole("option", { name: "Email" });
+    await user.click(emailOption);
+
+    expect(input).toHaveValue("Email");
+    expect(input).toHaveFocus();
+  });
+
   it("should set aria-activedescendant only when an item is highlighted", async () => {
     render(ComboBox, { props: { shouldFilterItem: () => true } });
 
@@ -2449,6 +2476,26 @@ describe("ComboBox", () => {
       // Selected item should be visible and marked as active
       const selectedOption = screen.getByRole("option", { name: "Item 251" });
       expect(selectedOption).toHaveAttribute("aria-selected", "true");
+    });
+
+    it("keeps focus on the field while clicking virtualized options", async () => {
+      const largeItems = createLargeItemList(500);
+      render(ComboBox, {
+        props: {
+          items: largeItems,
+          virtualize: true,
+        },
+      });
+
+      const input = getInput();
+      await user.click(input);
+      expect(input).toHaveFocus();
+
+      const option = screen.getByRole("option", { name: "Item 1" });
+      await user.click(option);
+
+      expect(input).toHaveValue("Item 1");
+      expect(input).toHaveFocus();
     });
 
     it("should handle keyboard navigation with virtualization", async () => {

--- a/tests/Dropdown/Dropdown.test.ts
+++ b/tests/Dropdown/Dropdown.test.ts
@@ -623,6 +623,40 @@ describe("Dropdown", () => {
     expect(screen.getByRole("listbox")).toBeVisible();
   });
 
+  it("keeps focus on the field while clicking an option", async () => {
+    render(Dropdown, { props: { items } });
+
+    const button = screen.getByRole("combobox");
+    await user.click(button);
+    expect(button).toHaveFocus();
+
+    // Focus must never move to the option — a focus bounce makes screen
+    // readers re-announce the entire field on every click.
+    const option = screen.getByRole("option", { name: "Email" });
+    await user.click(option);
+
+    expect(button).toHaveTextContent("Email");
+    expect(button).toHaveFocus();
+  });
+
+  it("keeps focus on the field while clicking virtualized options", async () => {
+    const largeItems = Array.from({ length: 500 }, (_, i) => ({
+      id: String(i),
+      text: `Item ${i + 1}`,
+    }));
+    render(Dropdown, { props: { items: largeItems, virtualize: true } });
+
+    const button = screen.getByRole("combobox");
+    await user.click(button);
+    expect(button).toHaveFocus();
+
+    const option = screen.getByRole("option", { name: "Item 1" });
+    await user.click(option);
+
+    expect(button).toHaveTextContent("Item 1");
+    expect(button).toHaveFocus();
+  });
+
   it("should open the menu on ArrowDown and highlight the first enabled item", async () => {
     render(Dropdown, { props: { items } });
 
@@ -2489,6 +2523,9 @@ describe("Dropdown", () => {
     await user.click(button);
     const menu = screen.getByRole("listbox");
     expect(button).toHaveAttribute("aria-controls", menu.id);
+    // ARIA 1.2 comboboxes reference the popup via aria-controls only;
+    // aria-owns restructures the accessibility tree and can double-read.
+    expect(button).not.toHaveAttribute("aria-owns");
 
     await user.click(button);
     expect(screen.queryByRole("listbox")).not.toBeInTheDocument();


### PR DESCRIPTION
Builds on #3647. That PR fixed the same focus-bounce and
aria-owns issues in MultiSelect. This applies the same pattern to
Dropdown and ComboBox, which share the option-click and combobox
markup.

Clicking an option focused the option, then a `.focus()` call (or,
in ComboBox, a blur handler) bounced focus back to the trigger.
Screen readers re-announced the whole field on every click.

Prevent default on the option's mousedown so focus never leaves
the trigger. The redundant `.focus()` calls in Dropdown go away;
ComboBox's blur-triggered refocus simply stops firing, since focus
never leaves the input.

Also:
- Drop `aria-owns` from ComboBox's input. ARIA 1.2 comboboxes
  reference their popup via `aria-controls` alone; `aria-owns` can
  cause double-reading. Dropdown already loses this via the shared
  `ListBoxField` fix in #3647.
- Set `aria-posinset`/`aria-setsize` on virtualized menu items in
  both components, since virtualization removes most items from
  the DOM and screen readers can't infer position or count on
  their own.

