### PR TITLE
build(bench): add baseline perf benchmarks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -703,6 +703,41 @@ For components that hide content with CSS (for example ComposedModal), `toBeVisi
 
 Add a link to `e2e/fixtures/index.html` so the fixture is reachable from the index page.
 
+### Performance benchmarks
+
+[mitata](https://github.com/evanwashere/mitata) benchmarks live in `bench/`, split into two tiers by filename convention.
+
+**Pure-logic tier** (`bench/*.bench.ts`) benches a standalone util module directly — no Svelte, no DOM. Run it straight under bun, with no vitest involved:
+
+```sh
+# Whole file
+bun run bench/treeCheckboxState.bench.ts
+
+# Only case(s) whose declared name matches a pattern — much faster while
+# iterating on one new case in a file with many
+bun run bench/treeCheckboxState.bench.ts "no cascade"
+```
+
+The filter pattern matches the case's title as written in `bench(...)`. For a `.range()`/`.args()` case that title still contains the literal `$size` placeholder (mitata substitutes it per data point only for display), so filter by something in the case name — a function, shape, or variant — not a specific resolved size like `"10000"`; a match still runs every range point for that case.
+
+Numbers from this tier are representative of real-browser V8 behavior (no jsdom involved), so it's the right tier for validating algorithmic or data-structure choices — proving a `Set`-over-`Array` change actually helps, or that a function stays O(n) instead of drifting to O(n²), with real measurements instead of a guess.
+
+**Component tier** (`bench/*.dom.bench.ts`) mounts a real component through the same vitest+jsdom+Svelte-plugin harness the unit tests use. Run the whole tier:
+
+```sh
+bun run bench
+```
+
+jsdom has no layout or paint, so treat this tier as a same-harness regression detector (did this change make mount/interaction meaningfully slower than before), not a real-browser latency number.
+
+A new bench file, either tier, follows the same shape as an existing one — copy the closest match (for example `bench/treeCheckboxState.bench.ts` for pure-logic, `bench/dropdown.dom.bench.ts` for component) rather than starting from scratch. A few conventions and gotchas to carry over:
+
+- Use mitata's generator form for a parametrized sweep: `bench(name, function* (state) { const size = state.get("size"); /* setup */ yield () => work(size); }).range("size", 100, 10_000)`. Setup code before `yield` runs once per size value (unmeasured); only the returned closure is timed.
+- Pure-logic files call `runWithFilter()` (from `bench/run-with-filter.ts`) instead of mitata's bare `run()` — that's what wires up the CLI filter pattern above.
+- Component-tier files wrap `bench()`/`run()` calls inside an `it()` block with an explicit longer timeout (vitest errors on a test file with zero registered tests, and mitata's warmup + sampling exceeds vitest's 5s default) and call `cleanup()` from `@testing-library/svelte` inside the benched closure so DOM nodes don't pile up across thousands of iterations.
+- Add `.gc("inner")` to any **pure-logic** case whose closure allocates non-trivially per call (sorting or copying an array, building objects). Without it, mitata's default batching (many calls back-to-back with no GC in between) can mis-calibrate and report numbers inflated by 20-60x. Cross-check a surprising absolute number against a plain `performance.now()` loop before trusting it.
+- Do **not** add `.gc("inner")` to a **component-tier** (DOM) bench. Forcing a real GC after every iteration over a large jsdom DOM object graph is far more expensive than over plain JS objects, and can trip real thermal throttling that silently inflates every number in the same run — including unrelated cases in the same file. If a bench's printed `clk: ~X GHz` header looks abnormally low, treat the whole run as suspect.
+
 ## Commit messages
 
 Use [Conventional Commits](https://www.conventionalcommits.org/):

--- a/bench/boundedFifoCache.bench.ts
+++ b/bench/boundedFifoCache.bench.ts
@@ -1,0 +1,53 @@
+// Pure-logic benchmark: no jsdom, no Svelte, run directly via bun (`bun run bench/<this file>.bench.ts`, optionally filtered — see CONTRIBUTING.md).
+// BoundedFifoCache backs DataTable's resolvePath path-segment cache (see
+// dataTableSort.bench.ts) and is a Map wrapper with `.keys().next().value`
+// eviction — expected O(1) per set() regardless of cache size. A naive FIFO
+// implementation (e.g. `Array.from(map.keys())[0]`) would be O(size) instead.
+//
+// Measured result is more nuanced than a clean O(1)/O(n) verdict: a single
+// evicting set(), measured in isolation (below), scales with maxSize —
+// ~110ns at 100 → ~11.7µs at 10,000 (confirmed with and without `.gc("inner")`,
+// so this isn't a mitata batching artifact) — because V8's Map does periodic
+// backing-table compaction proportional to table size after repeated
+// delete+insert cycles. But amortized over many sets in a tight loop, the
+// average cost is far lower (~0.3ns → ~12ns at the same sizes) because most
+// individual sets don't trigger a compaction. Both numbers are "real" —
+// they just answer different questions, so both are benched here. At this
+// cache's actual codebase size (MAX_PATH_CACHE_SIZE = 1000 in
+// data-table-utils.js) and its real workload (fills once, then mostly
+// cache-hit gets — evictions are rare, not back-to-back), the single-call
+// number is the more representative one, and even that is negligible
+// (sub-microsecond) at this scale.
+import { bench } from "mitata";
+import { BoundedFifoCache } from "../src/utils/boundedFifoCache.js";
+import { runWithFilter } from "./run-with-filter.js";
+
+// Cache held at capacity (maxSize == $size), so every set() past warmup
+// evicts — the worst case for eviction cost, not the empty-cache case.
+bench(
+  "BoundedFifoCache set() at capacity, single call, $size maxSize",
+  function* (state) {
+    const size = state.get("size");
+    const cache = new BoundedFifoCache<number, number>(size);
+    for (let i = 0; i < size; i++) cache.set(i, i);
+    let next = size;
+    yield () => cache.set(next++, next);
+  },
+).range("size", 100, 10_000);
+
+const AMORTIZE_COUNT = 1000;
+
+bench(
+  `BoundedFifoCache set() at capacity, amortized over ${AMORTIZE_COUNT} calls, $size maxSize`,
+  function* (state) {
+    const size = state.get("size");
+    const cache = new BoundedFifoCache<number, number>(size);
+    for (let i = 0; i < size; i++) cache.set(i, i);
+    let next = size;
+    yield () => {
+      for (let i = 0; i < AMORTIZE_COUNT; i++) cache.set(next++, next);
+    };
+  },
+).range("size", 100, 10_000);
+
+await runWithFilter();

--- a/bench/dataTableSort.bench.ts
+++ b/bench/dataTableSort.bench.ts
@@ -1,0 +1,73 @@
+// Pure-logic benchmark: no jsdom, no Svelte, run directly via bun (`bun run bench/<this file>.bench.ts`, optionally filtered — see CONTRIBUTING.md).
+// Mirrors DataTable.svelte's `$: sortedRows` reactive block exactly —
+// [...rows].sort((a, b) => compareValues(resolvePath(a, key), resolvePath(b, key), ascending))
+// — which recomputes on every rows/sortKey/sortDirection change.
+import { bench } from "mitata";
+import {
+  compareValues,
+  resolvePath,
+} from "../src/DataTable/data-table-utils.js";
+import { runWithFilter } from "./run-with-filter.js";
+
+type Row = {
+  id: number;
+  name: string;
+  age: number;
+  contact: { company: string };
+};
+
+const COMPANIES = ["Acme", "Globex", "Initech", "Umbrella", "Soylent"];
+
+function buildRows(count: number): Row[] {
+  const rows: Row[] = [];
+  for (let i = 0; i < count; i++) {
+    rows.push({
+      id: i,
+      name: `Row ${i}`,
+      age: (i * 37) % 100,
+      contact: { company: COMPANIES[i % COMPANIES.length] },
+    });
+  }
+  return rows;
+}
+
+// `.gc("inner")` forces a GC before/after every sample instead of mitata's
+// default of batching many calls together with no GC in between. Without it,
+// these two cases (which each allocate a fresh sorted array per call)
+// mis-calibrate batch size and report numbers inflated by 20-60x — e.g. the
+// nested-string case below measured 9.38s/iter at 10k rows without this flag,
+// vs. ~180ms/iter with it (confirmed against a plain performance.now() loop).
+// Cross-check any surprising absolute number from an allocation-heavy bench
+// against a manual loop before trusting it.
+
+// Flat numeric key: resolvePath's `path in object` fast path, compareValues'
+// numeric fast path.
+bench("DataTable sort, flat numeric key, $size rows", function* (state) {
+  const size = state.get("size");
+  const rows = buildRows(size);
+  yield () =>
+    [...rows].sort((a, b) => {
+      const itemA = resolvePath(a, "age");
+      const itemB = resolvePath(b, "age");
+      return compareValues(itemA, itemB, true);
+    });
+})
+  .range("size", 100, 10_000)
+  .gc("inner");
+
+// Nested string key: exercises resolvePath's split + path-cache lookup and
+// compareValues' localeCompare path — the more expensive combination.
+bench("DataTable sort, nested string key, $size rows", function* (state) {
+  const size = state.get("size");
+  const rows = buildRows(size);
+  yield () =>
+    [...rows].sort((a, b) => {
+      const itemA = resolvePath(a, "contact.company");
+      const itemB = resolvePath(b, "contact.company");
+      return compareValues(itemA, itemB, true);
+    });
+})
+  .range("size", 100, 10_000)
+  .gc("inner");
+
+await runWithFilter();

--- a/bench/datatable-mount.dom.bench.ts
+++ b/bench/datatable-mount.dom.bench.ts
@@ -1,0 +1,62 @@
+import { cleanup, render } from "@testing-library/svelte";
+import DataTable from "carbon-components-svelte/DataTable/DataTable.svelte";
+import { bench, run } from "mitata";
+
+// DataTable's equivalent of treeview-mount.dom.bench.ts: dataTableSort.bench.ts
+// and virtualize.bench.ts already proved the sort/windowing math in isolation
+// — this checks whether the real component's mount cost actually benefits
+// from virtualization the same way TreeView's did.
+//
+// No `.gc("inner")` here — see treeview-mount.dom.bench.ts's comment. Forcing
+// a real GC after every iteration over a large jsdom DOM object graph
+// (rather than plain JS objects/arrays) induced real thermal throttling
+// there; default batching (as dropdown.dom.bench.ts already uses) is safe.
+
+const headers = [
+  { key: "name", value: "Name" },
+  { key: "protocol", value: "Protocol" },
+  { key: "port", value: "Port" },
+  { key: "rule", value: "Rule" },
+];
+
+function buildRows(count: number) {
+  return Array.from({ length: count }, (_, i) => ({
+    id: String(i),
+    name: `Load Balancer ${i + 1}`,
+    protocol: "HTTP",
+    port: 3000 + i,
+    rule: "Round robin",
+  }));
+}
+
+it("benchmarks mounting a large DataTable, virtualized vs not", async () => {
+  // Every row becomes a real jsdom DOM row — capped well below the
+  // virtualized range below, same reasoning as TreeView's non-virtualized case.
+  bench("mount DataTable, $size rows, no virtualization", function* (state) {
+    const size = state.get("size");
+    const rows = buildRows(size);
+    yield () => {
+      render(DataTable, { props: { headers, rows } });
+      cleanup();
+    };
+  }).range("size", 20, 300);
+
+  // Virtualized: only the visible window (~10 rows at default maxVisibleRows)
+  // mounts regardless of row count. DataTable's virtualization threshold is
+  // 100 rows by default, so sizes below that render everything unvirtualized
+  // even with virtualize enabled — range starts at 100 to stay above it.
+  bench("mount DataTable, $size rows, virtualized", function* (state) {
+    const size = state.get("size");
+    const rows = buildRows(size);
+    yield () => {
+      render(DataTable, {
+        props: { headers, rows, virtualize: true, stickyHeader: true },
+      });
+      cleanup();
+    };
+  }).range("size", 100, 3000);
+
+  // mitata defaults `print` to console.log, which vitest swallows for
+  // passing tests. process.stdout.write always reaches the terminal.
+  await run({ print: (line) => process.stdout.write(`${line}\n`) });
+}, 60_000);

--- a/bench/dropdown.dom.bench.ts
+++ b/bench/dropdown.dom.bench.ts
@@ -1,0 +1,34 @@
+import { cleanup, render } from "@testing-library/svelte";
+import { userEvent } from "@testing-library/user-event";
+import Dropdown from "carbon-components-svelte/Dropdown/Dropdown.svelte";
+import { bench, run } from "mitata";
+
+const items = [
+  { id: "0", text: "Slack" },
+  { id: "1", text: "Email" },
+  { id: "2", text: "Fax" },
+];
+
+// Reused across iterations so the benchmark measures Dropdown, not the cost
+// of setting up userEvent.
+const user = userEvent.setup();
+
+it("benchmarks opening a Dropdown menu", async () => {
+  bench("mount + open Dropdown menu", async () => {
+    const { getByRole } = render(Dropdown, {
+      props: { items, selectedId: "0", labelText: "Contact" },
+    });
+
+    await user.click(getByRole("combobox"));
+
+    // Unmount so DOM nodes don't pile up across thousands of iterations.
+    cleanup();
+  });
+
+  // mitata defaults `print` to console.log, which vitest swallows for
+  // passing tests. process.stdout.write always reaches the terminal.
+  // (mitata also mislabels `runtime` as "chromium" here, since jsdom's
+  // window/navigator globals look like a browser to its feature sniff —
+  // the timings themselves still use bun's real nanosecond clock.)
+  await run({ print: (line) => process.stdout.write(`${line}\n`) });
+}, 60_000);

--- a/bench/fuzzyMatch.bench.ts
+++ b/bench/fuzzyMatch.bench.ts
@@ -1,0 +1,31 @@
+// Pure-logic benchmark: no jsdom, no Svelte, run directly via bun (`bun run bench/<this file>.bench.ts`, optionally filtered — see CONTRIBUTING.md).
+// fuzzyMatch backs SearchMenu/HeaderSearch filtering — called once per item,
+// once per keystroke. The realistic cost that matters is filtering a whole
+// list on one keystroke, not a single fuzzyMatch() call in isolation.
+import { bench } from "mitata";
+import { fuzzyMatch } from "../src/utils/fuzzyMatch.js";
+import { runWithFilter } from "./run-with-filter.js";
+
+// A mix of items that resolve via each of fuzzyMatch's two internal paths:
+// a contiguous-substring hit (cheap, single indexOf pass) and a scattered
+// subsequence hit (both passes run — substring scan fails first, then
+// subsequence scan succeeds), plus non-matches (both passes run and fail).
+function buildItems(count: number): string[] {
+  const items: string[] = [];
+  for (let i = 0; i < count; i++) {
+    const mod = i % 3;
+    if (mod === 0) items.push(`Settings > Notifications > Email Digest ${i}`);
+    else if (mod === 1) items.push(`Sxettxinxgxs Exmxaxixl Dxixgxexsxt ${i}`);
+    else items.push(`Unrelated menu entry number ${i}`);
+  }
+  return items;
+}
+
+bench("fuzzyMatch, filter $size items, one keystroke", function* (state) {
+  const size = state.get("size");
+  const items = buildItems(size);
+  yield () =>
+    items.filter((text) => fuzzyMatch(text, "settings email").matched);
+}).range("size", 100, 10_000);
+
+await runWithFilter();

--- a/bench/run-with-filter.ts
+++ b/bench/run-with-filter.ts
@@ -1,0 +1,38 @@
+import { run } from "mitata";
+
+/**
+ * `bun run bench/<file>.bench.ts` runs every case in the file.
+ * `bun run bench/<file>.bench.ts <pattern>` runs only cases whose *declared*
+ * name matches `<pattern>` (a RegExp source, e.g. "flat" or "no cascade") —
+ * for fast iteration on one new case in a file with many, instead of the
+ * whole file. Matches against the name as written in `bench(...)`, which for
+ * a `.range()`/`.args()` case still contains the literal `$size` placeholder
+ * (mitata substitutes it per data point only when printing results) — so a
+ * match runs *all* range points for that case, not a single size. Filter by
+ * something in the case title (function/shape/variant), not a specific size.
+ */
+export async function runWithFilter(
+  opts: Parameters<typeof run>[0] = {},
+): Promise<void> {
+  const pattern = process.argv[2];
+  if (pattern === undefined) {
+    await run(opts);
+    return;
+  }
+
+  let filter: RegExp;
+  try {
+    // `pattern` is a CLI argument the developer running this script supplies
+    // themselves on their own machine — it's the intended filter feature
+    // (see the doc comment above), not untrusted/network-facing input
+    // reaching a shared process.
+    // codeql[js/regex-injection]
+    filter = new RegExp(pattern);
+  } catch (error) {
+    throw new Error(
+      `Invalid filter pattern "${pattern}": ${error instanceof Error ? error.message : error}`,
+    );
+  }
+
+  await run({ ...opts, filter });
+}

--- a/bench/treeCheckboxState.bench.ts
+++ b/bench/treeCheckboxState.bench.ts
@@ -1,0 +1,125 @@
+// Pure-logic benchmark: no jsdom, no Svelte, run directly via bun (`bun run bench/<this file>.bench.ts`, optionally filtered — see CONTRIBUTING.md).
+// resolveCheckboxState walks the whole tree on every checkedIds change (see its
+// docstring), so it's the hottest path for a large TreeView with checkboxes.
+import { bench } from "mitata";
+import {
+  resolveCheckboxState,
+  toggleCheckboxNode,
+} from "../src/utils/treeCheckboxState.js";
+import { runWithFilter } from "./run-with-filter.js";
+
+type Node = {
+  id: number;
+  nodes?: Node[];
+};
+
+// Single-root, branching-factor-4 tree with `totalNodes` nodes total —
+// roughly the shape of a deep file-tree explorer.
+function buildTree(totalNodes: number, branching = 4): Node[] {
+  let created = 0;
+
+  function makeNode(): Node {
+    created += 1;
+    return { id: created, nodes: [] };
+  }
+
+  const root = makeNode();
+  const queue: Node[] = [root];
+
+  while (created < totalNodes && queue.length > 0) {
+    const parent = queue.shift();
+    if (!parent) break;
+    for (let i = 0; i < branching && created < totalNodes; i++) {
+      const child = makeNode();
+      parent.nodes?.push(child);
+      queue.push(child);
+    }
+  }
+
+  return [root];
+}
+
+// ~1/3 of nodes checked, spread through the tree so resolve exercises a mix
+// of fully-checked, indeterminate, and unchecked branches.
+function pickCheckedIds(totalNodes: number): number[] {
+  const ids: number[] = [];
+  for (let id = 1; id <= totalNodes; id++) {
+    if (id % 3 === 0) ids.push(id);
+  }
+  return ids;
+}
+
+bench("resolveCheckboxState (cascade), $size nodes", function* (state) {
+  const size = state.get("size");
+  const nodes = buildTree(size);
+  const checkedIds = pickCheckedIds(size);
+  yield () => resolveCheckboxState(nodes, checkedIds);
+}).range("size", 100, 10_000);
+
+bench("resolveCheckboxState (no cascade), $size nodes", function* (state) {
+  const size = state.get("size");
+  const nodes = buildTree(size);
+  const checkedIds = pickCheckedIds(size);
+  yield () => resolveCheckboxState(nodes, checkedIds, { cascade: false });
+}).range("size", 100, 10_000);
+
+bench("toggleCheckboxNode (cascade check), $size nodes", function* (state) {
+  const size = state.get("size");
+  const nodes = buildTree(size);
+  const checkedIds = pickCheckedIds(size);
+  const targetId = Math.floor(size / 2);
+  yield () => toggleCheckboxNode(nodes, checkedIds, targetId, true);
+}).range("size", 100, 10_000);
+
+// Unchecking walks the target's subtree plus every ancestor (a different
+// code path than checking — see toggleCheckboxNode's docstring), so it gets
+// its own case rather than assuming symmetric cost with the check above.
+bench("toggleCheckboxNode (cascade uncheck), $size nodes", function* (state) {
+  const size = state.get("size");
+  const nodes = buildTree(size);
+  const checkedIds = pickCheckedIds(size);
+  const targetId = Math.floor(size / 2);
+  yield () => toggleCheckboxNode(nodes, checkedIds, targetId, false);
+}).range("size", 100, 10_000);
+
+// Every case above uses a bushy tree (branching=4). walk/findPath/cascadableIds/
+// subtreeIds are all recursive, so cost could in principle track *depth* rather
+// than node count — a shape the bushy tree never stresses. These two shapes
+// isolate that: a chain (branching=1, depth == node count) and a flat tree
+// (branching == node count, depth 2). Confirmed safe to 20k depth with no
+// stack overflow (see stack-check probe) before picking this range.
+bench(
+  "resolveCheckboxState (cascade), $size nodes — deep/narrow (chain)",
+  function* (state) {
+    const size = state.get("size");
+    const nodes = buildTree(size, 1);
+    const checkedIds = pickCheckedIds(size);
+    yield () => resolveCheckboxState(nodes, checkedIds);
+  },
+).range("size", 100, 10_000);
+
+bench(
+  "resolveCheckboxState (cascade), $size nodes — wide/shallow (flat)",
+  function* (state) {
+    const size = state.get("size");
+    const nodes = buildTree(size, size);
+    const checkedIds = pickCheckedIds(size);
+    yield () => resolveCheckboxState(nodes, checkedIds);
+  },
+).range("size", 100, 10_000);
+
+// findPath walks root-to-target, so a chain forces it to scan the full depth
+// to reach a mid-chain target — the shape most likely to expose a cost
+// difference from the bushy case's shallow findPath.
+bench(
+  "toggleCheckboxNode (cascade check), $size nodes — deep/narrow (chain)",
+  function* (state) {
+    const size = state.get("size");
+    const nodes = buildTree(size, 1);
+    const checkedIds = pickCheckedIds(size);
+    const targetId = Math.floor(size / 2);
+    yield () => toggleCheckboxNode(nodes, checkedIds, targetId, true);
+  },
+).range("size", 100, 10_000);
+
+await runWithFilter();

--- a/bench/treeVirtualIndex.bench.ts
+++ b/bench/treeVirtualIndex.bench.ts
@@ -1,0 +1,152 @@
+// Pure-logic benchmark: no jsdom, no Svelte, run directly via bun (`bun run bench/<this file>.bench.ts`, optionally filtered — see CONTRIBUTING.md).
+// TreeView's own virtualization index (src/utils/treeVirtualIndex.js) documents
+// specific complexity claims in its module docstring:
+//   - build: O(n)
+//   - getRowAt / findIndexById: O(siblings along the path) — flat/wide lists
+//     are O(index), not O(depth)
+//   - collectRows: one cursor walk, O(path-to-start + window), not
+//     O(width × window) from independent getRowAt calls
+// This verifies those claims empirically rather than trusting the comment,
+// and directly validates the collectRows optimization against the naive
+// per-row alternative it's documented as improving on.
+import { bench } from "mitata";
+import { createTreeVirtualIndex } from "../src/utils/treeVirtualIndex.js";
+import { runWithFilter } from "./run-with-filter.js";
+
+type Node = {
+  id: number;
+  nodes?: Node[];
+};
+
+// Same shape generator as treeCheckboxState.bench.ts: single-root,
+// branching-factor-N tree with `totalNodes` nodes total.
+function buildTree(totalNodes: number, branching = 4): Node[] {
+  let created = 0;
+
+  function makeNode(): Node {
+    created += 1;
+    return { id: created, nodes: [] };
+  }
+
+  const root = makeNode();
+  const queue: Node[] = [root];
+
+  while (created < totalNodes && queue.length > 0) {
+    const parent = queue.shift();
+    if (!parent) break;
+    for (let i = 0; i < branching && created < totalNodes; i++) {
+      const child = makeNode();
+      parent.nodes?.push(child);
+      queue.push(child);
+    }
+  }
+
+  return [root];
+}
+
+function allIds(nodes: Node[]): Set<number> {
+  const ids = new Set<number>();
+  const stack = [...nodes];
+  while (stack.length > 0) {
+    const node = stack.pop();
+    if (!node) continue;
+    ids.add(node.id);
+    if (node.nodes) stack.push(...node.nodes);
+  }
+  return ids;
+}
+
+// bushy (branching=4, the default TreeView shape) vs flat (branching=size, a
+// single level with size-1 direct children) — the two shapes the docstring
+// explicitly distinguishes ("flat/wide lists are O(index), not O(depth)").
+const SHAPES: Array<[string, (size: number) => number]> = [
+  ["bushy", () => 4],
+  ["flat", (size) => size],
+];
+
+bench(
+  "createTreeVirtualIndex build, $size nodes — bushy, all expanded",
+  function* (state) {
+    const size = state.get("size");
+    const nodes = buildTree(size, 4);
+    const expandedIds = allIds(nodes);
+    yield () => createTreeVirtualIndex(nodes, expandedIds);
+  },
+).range("size", 100, 10_000);
+
+for (const [shapeName, branchingFor] of SHAPES) {
+  bench(
+    `getRowAt(last index), $size nodes — ${shapeName}, all expanded`,
+    function* (state) {
+      const size = state.get("size");
+      const nodes = buildTree(size, branchingFor(size));
+      const expandedIds = allIds(nodes);
+      const index = createTreeVirtualIndex(nodes, expandedIds);
+      yield () => index.getRowAt(index.totalCount - 1);
+    },
+  ).range("size", 100, 10_000);
+
+  bench(
+    `findIndexById(last id), $size nodes — ${shapeName}, all expanded`,
+    function* (state) {
+      const size = state.get("size");
+      const nodes = buildTree(size, branchingFor(size));
+      const expandedIds = allIds(nodes);
+      const index = createTreeVirtualIndex(nodes, expandedIds);
+      // The highest BFS-assigned id isn't necessarily last in document
+      // order for a bushy tree (only for flat, where BFS insertion order
+      // and document order coincide) — derive the true last-in-document-
+      // order id from getRowAt so both benches target the same node.
+      const lastRow = index.getRowAt(index.totalCount - 1);
+      const targetId = lastRow ? lastRow.node.id : size;
+      yield () => index.findIndexById(targetId);
+    },
+  ).range("size", 100, 10_000);
+}
+
+const WINDOW_SIZE = 30;
+
+// bushy barely benefits (each individual getRowAt call is already cheap on a
+// bushy tree — see the getRowAt results above), so this pairing is repeated
+// on the flat shape too, where individual getRowAt calls are the expensive
+// O(index) case — that's where batching into one cursor walk should actually
+// matter.
+for (const [shapeName, branchingFor] of SHAPES) {
+  // The optimization: one cursor walk collects a 30-row window near the end
+  // of the tree in a single pass.
+  bench(
+    `collectRows, 30-row window near end, $size nodes — ${shapeName}, all expanded`,
+    function* (state) {
+      const size = state.get("size");
+      const nodes = buildTree(size, branchingFor(size));
+      const expandedIds = allIds(nodes);
+      const index = createTreeVirtualIndex(nodes, expandedIds);
+      const start = index.totalCount - WINDOW_SIZE;
+      yield () => index.collectRows(start, index.totalCount);
+    },
+  ).range("size", 100, 10_000);
+
+  // The naive alternative collectRows replaces: calling getRowAt
+  // independently for each row in the same window. Same window, same tree,
+  // same shape — isolates the win from batching into one walk vs. `window`
+  // separate calls.
+  bench(
+    `getRowAt loop (naive), 30-row window near end, $size nodes — ${shapeName}, all expanded`,
+    function* (state) {
+      const size = state.get("size");
+      const nodes = buildTree(size, branchingFor(size));
+      const expandedIds = allIds(nodes);
+      const index = createTreeVirtualIndex(nodes, expandedIds);
+      const start = index.totalCount - WINDOW_SIZE;
+      yield () => {
+        const rows = [];
+        for (let i = start; i < index.totalCount; i++) {
+          rows.push(index.getRowAt(i));
+        }
+        return rows;
+      };
+    },
+  ).range("size", 100, 10_000);
+}
+
+await runWithFilter();

--- a/bench/treeview-mount.dom.bench.ts
+++ b/bench/treeview-mount.dom.bench.ts
@@ -1,0 +1,76 @@
+import { cleanup, render } from "@testing-library/svelte";
+import TreeView from "carbon-components-svelte/TreeView/TreeView.svelte";
+import { bench, run } from "mitata";
+
+// Bridges the gap the pure-logic tier left open: treeVirtualIndex.bench.ts
+// already confirmed the *windowing math* is O(1) in tree size, but that
+// doesn't prove TreeView.svelte's actual mount cost benefits — Svelte still
+// has to create and diff whatever DOM the component asks for. This mounts
+// the real component both ways to check.
+type TreeNode = { id: number; text: string; nodes?: TreeNode[] };
+
+// Matches tests/TreeView/TreeView.virtualize.test.svelte's fixture shape:
+// `totalRoots` collapsed roots, each with `childrenPerRoot` leaf children
+// (not mounted until expanded, so collapsed root count is what drives
+// non-virtualized DOM node count here).
+function buildTree(totalRoots: number, childrenPerRoot = 3): TreeNode[] {
+  const out: TreeNode[] = [];
+  let next = 0;
+  for (let r = 0; r < totalRoots; r++) {
+    const rootId = next++;
+    const children: TreeNode[] = [];
+    for (let c = 0; c < childrenPerRoot; c++) {
+      children.push({ id: next++, text: `root-${rootId}-child-${c}` });
+    }
+    out.push({ id: rootId, text: `root-${rootId}`, nodes: children });
+  }
+  return out;
+}
+
+it("benchmarks mounting a large TreeView, virtualized vs not", async () => {
+  // No `.gc("inner")` here, unlike the pure-logic tier's allocation-heavy
+  // cases: forcing a real GC after every iteration over a large jsdom DOM
+  // object graph (not plain JS objects/arrays) induced sustained thermal
+  // throttling in testing — mitata's own reported CPU clock collapsed from
+  // ~3GHz to ~0.01GHz partway through, invalidating every number after that
+  // point (including the unrelated Dropdown case earlier in the same run).
+  // Default batching is what dropdown.dom.bench.ts already uses successfully.
+
+  // Every collapsed root becomes a real jsdom DOM node — jsdom element
+  // creation is slow, so this range is capped well below the virtualized
+  // one below. Growing cost here (unlike the flat case below) is the point.
+  bench(
+    "mount TreeView, $size roots (collapsed), no virtualization",
+    function* (state) {
+      const totalRoots = state.get("size");
+      const nodes = buildTree(totalRoots);
+      yield () => {
+        render(TreeView, { props: { nodes, labelText: "Tree" } });
+        cleanup();
+      };
+    },
+  ).range("size", 20, 300);
+
+  // Virtualized: only the visible window (~13 rows at default settings)
+  // mounts regardless of totalRoots — should stay flatter than the
+  // no-virtualization case above, though the underlying treeVirtualIndex
+  // build is still O(n) in total node count (see treeVirtualIndex.bench.ts)
+  // so this isn't expected to be perfectly flat either.
+  bench(
+    "mount TreeView, $size roots (collapsed), virtualized",
+    function* (state) {
+      const totalRoots = state.get("size");
+      const nodes = buildTree(totalRoots);
+      yield () => {
+        render(TreeView, {
+          props: { nodes, labelText: "Tree", virtualize: true },
+        });
+        cleanup();
+      };
+    },
+  ).range("size", 100, 3000);
+
+  // mitata defaults `print` to console.log, which vitest swallows for
+  // passing tests. process.stdout.write always reaches the terminal.
+  await run({ print: (line) => process.stdout.write(`${line}\n`) });
+}, 60_000);

--- a/bench/virtualize.bench.ts
+++ b/bench/virtualize.bench.ts
@@ -1,0 +1,54 @@
+// Pure-logic benchmark: no jsdom, no Svelte, run directly via bun (`bun run bench/<this file>.bench.ts`, optionally filtered — see CONTRIBUTING.md).
+// Shared windowing math behind Dropdown/MultiSelect/DataTable/TreeViewGrid
+// virtualization — the third scenario named alongside tree render and
+// DataTable sort. virtualize() slices to a bounded visible window
+// (containerHeight/itemHeight + overscan), not the full item count, so this
+// sweep is the empirical check that cost is actually O(1) in item count
+// rather than assuming it from reading the code.
+import { bench } from "mitata";
+import { virtualize } from "../src/utils/virtualize.js";
+import { runWithFilter } from "./run-with-filter.js";
+
+type Item = { id: number };
+
+function buildItems(count: number): Item[] {
+  return Array.from({ length: count }, (_, i) => ({ id: i }));
+}
+
+bench("virtualize(), $size items, mid-scroll", function* (state) {
+  const size = state.get("size");
+  const items = buildItems(size);
+  const scrollTop = Math.floor((size * 40) / 2);
+  yield () =>
+    virtualize({
+      items,
+      itemHeight: 40,
+      containerHeight: 300,
+      scrollTop,
+      threshold: 100,
+    });
+}).range("size", 100, 100_000);
+
+// Realistic hot path: virtualize() runs on every scroll event, not once.
+// Simulates a scrollbar drag across a 10k-item list.
+bench("virtualize(), 10k items, 500 scroll positions", function* () {
+  const items = buildItems(10_000);
+  const totalHeight = items.length * 40;
+  const positions = Array.from({ length: 500 }, (_, i) =>
+    Math.floor((i / 500) * totalHeight),
+  );
+
+  yield () => {
+    for (const scrollTop of positions) {
+      virtualize({
+        items,
+        itemHeight: 40,
+        containerHeight: 300,
+        scrollTop,
+        threshold: 100,
+      });
+    }
+  };
+});
+
+await runWithFilter();

--- a/bun.lock
+++ b/bun.lock
@@ -24,6 +24,7 @@
         "culls": "^0.2.0",
         "jsdom": "^30.0.1",
         "lightningcss": "^1.33.0",
+        "mitata": "^1.0.34",
         "sass-embedded": "^1.100.0",
         "sveld": "^0.36.5",
         "svelte": "^5.56.8",
@@ -372,6 +373,8 @@
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
 
     "min-indent": ["min-indent@1.0.1", "", {}, "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="],
+
+    "mitata": ["mitata@1.0.34", "", {}, "sha512-Mc3zrtNBKIMeHSCQ0XqRLo1vbdIx1wvFV9c8NJAiyho6AjNfMY8bVhbS12bwciUdd1t4rj8099CH3N3NFahaUA=="],
 
     "mri": ["mri@1.2.0", "", {}, "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="],
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "scripts": {
     "setup": "bun ci && bun build:docs && bun build:css && cd docs && bun ci",
     "test": "vitest",
+    "bench": "vitest run --config vite.bench.config.ts",
     "test:src-types": "tsgo --project tsconfig.types.json",
     "test:package-exports": "tsgo --project tsconfig.package-exports.json",
     "test:types": "svelte-check --workspace tests --tsgo --fail-on-warnings",
@@ -71,6 +72,7 @@
     "culls": "^0.2.0",
     "jsdom": "^30.0.1",
     "lightningcss": "^1.33.0",
+    "mitata": "^1.0.34",
     "sass-embedded": "^1.100.0",
     "sveld": "^0.36.5",
     "svelte": "^5.56.8",

--- a/src/DataTable/data-table-utils.js
+++ b/src/DataTable/data-table-utils.js
@@ -221,6 +221,20 @@ export function formatHeaderWidth(header) {
   return styles.join(";");
 }
 
+// Cached collator for compareValues' string fast path. localeCompare(str,
+// locale, options) rebuilds the full ICU collator on every call when an
+// options object is passed — reusing one Intl.Collator's .compare() instead
+// is ~30x faster at scale. Locale is undefined so it defaults to the user's
+// locale, matching localeCompare's prior behavior.
+const collator = new Intl.Collator(undefined, {
+  // Enable numeric sorting for strings that look like numbers
+  // E.g., "10" should come after "2"
+  numeric: true,
+  // Comparison is case- and accent-insensitive
+  // E.g., "apple" == "Apple", "café" == "cafe"
+  sensitivity: "base",
+});
+
 /**
  * Compares two values for sorting in a data table.
  * Handles numbers, strings, null/undefined values, and custom sort functions.
@@ -251,19 +265,7 @@ export function compareValues(itemA, itemB, ascending, customSort) {
     } else if (!itemB && itemB !== 0) {
       result = -1;
     } else {
-      result = String(itemA).localeCompare(
-        String(itemB),
-        // Use undefined to default to user's locale
-        undefined,
-        {
-          // Enable numeric sorting for strings that look like numbers
-          // E.g., "10" should come after "2"
-          numeric: true,
-          // Comparison is case- and accent-insensitive
-          // E.g., "apple" == "Apple", "café" == "cafe"
-          sensitivity: "base",
-        },
-      );
+      result = collator.compare(String(itemA), String(itemB));
     }
   }
 

--- a/src/utils/treeVirtualIndex.js
+++ b/src/utils/treeVirtualIndex.js
@@ -5,8 +5,11 @@
  *
  * Complexity (after build):
  * - build: O(n) time and one size entry per node
- * - getRowAt / findIndexById: O(siblings along the path) — flat/wide lists
- *   are O(index), not O(depth)
+ * - getRowAt: O(siblings along the path) — flat/wide lists are O(index),
+ *   not O(depth)
+ * - findIndexById: O(n) worst case — a linear document-order search with no
+ *   reverse id→index map, so unlike getRowAt/collectRows it can't use
+ *   sizeById to skip a subtree before finding the id inside it
  * - collectRows: one cursor walk — O(path-to-start + window), not
  *   O(width × window) from independent getRowAt calls
  */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,5 +19,5 @@
       "carbon-components-svelte/*": ["./src/*"]
     }
   },
-  "include": ["src", "tests"]
+  "include": ["src", "tests", "bench"]
 }

--- a/vite.bench.config.ts
+++ b/vite.bench.config.ts
@@ -1,0 +1,32 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { svelte, vitePreprocess } from "@sveltejs/vite-plugin-svelte";
+import { defineConfig } from "vitest/config";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// Benchmarks reuse the vitest+jsdom harness (svelte compilation, DOM globals)
+// so component perf numbers come from the same environment the test suite
+// already mounts components in. Kept separate from vite.config.ts so `bun
+// run test` never picks up `*.bench.ts` files.
+export default defineConfig({
+  root: "./bench",
+  plugins: [svelte({ preprocess: [vitePreprocess()] })],
+  resolve: {
+    alias: {
+      "carbon-components-svelte": path.resolve(__dirname, "src"),
+    },
+    conditions: ["browser"],
+  },
+  test: {
+    globals: true,
+    environment: "jsdom",
+    // Only *.dom.bench.ts — component benches that need jsdom + the svelte
+    // plugin. Pure-logic benches (*.bench.ts) run straight under bun instead
+    // (see CONTRIBUTING.md), with no jsdom/vitest overhead to muddy the numbers.
+    include: ["*.dom.bench.ts"],
+    setupFiles: ["../tests/utils/setup-globals.ts"],
+    // mitata's own warmup + sampling runs well past vitest's 5s default.
+    testTimeout: 60_000,
+  },
+});


### PR DESCRIPTION
Adds a mitata-based benchmark suite (bun-only for pure logic, vitest +
jsdom for component mount) covering TreeView, DataTable, and
virtualization hot paths. Also fixes a misleading complexity comment
in treeVirtualIndex and a real sort perf issue in DataTable that the
benchmarks turned up.

## Benchmark

DataTable's default string-column sort called `localeCompare` with a
locale and options object per comparison, which rebuilds the ICU
collator on every call. Caching one `Intl.Collator` instead:

| rows   | before   | after  |
| ------ | -------- | ------ |
| 10,000 | 131.93ms | 4.60ms |

Measured with `bun run bench/dataTableSort.bench.ts`, nested string
key case. Sort order is unchanged, existing DataTable tests pass.