### PR TITLE
build(bench): add MultiSelect, toHierarchy, filterTreeNodes benchmarks

### DIFF
--- a/bench/dataTableFilter.bench.ts
+++ b/bench/dataTableFilter.bench.ts
@@ -1,0 +1,98 @@
+// Pure-logic benchmark: no jsdom, no Svelte, run directly via bun (`bun run bench/<this file>.bench.ts`, optionally filtered — see CONTRIBUTING.md).
+// Mirrors DataTable.svelte's `filterRows` default predicate exactly —
+// rows.filter((row) => searchableKeys.some((key) => { const v = resolvePath(row, key); return (typeof v === "string" || typeof v === "number") ? `${v}`.toLowerCase().includes(value) : false; }))
+// — which recomputes on every rows/searchValue change (default path when no customFilter is provided).
+// This is the hot path: ToolbarSearch invokes filterRows on every keystroke over all rows.
+import { bench } from "mitata";
+import { resolvePath } from "../src/DataTable/data-table-utils.js";
+import { runWithFilter } from "./run-with-filter.js";
+
+type Row = {
+  id: number;
+  name: string;
+  age: number;
+  contact: { company: string };
+};
+
+const COMPANIES = ["Acme", "Globex", "Initech", "Umbrella", "Soylent"];
+
+function buildRows(count: number): Row[] {
+  const rows: Row[] = [];
+  for (let i = 0; i < count; i++) {
+    rows.push({
+      id: i,
+      name: `Row ${i}`,
+      age: (i * 37) % 100,
+      contact: { company: COMPANIES[i % COMPANIES.length] },
+    });
+  }
+  return rows;
+}
+
+// `.gc("inner")` forces a GC before/after every sample instead of mitata's
+// default of batching many calls together with no GC in between. Without it,
+// these cases (which each allocate a fresh filtered array per call)
+// mis-calibrate batch size and report numbers inflated by 20-60x — e.g.
+// filtering at 10k rows without this flag could measure several hundred ms/iter,
+// vs. ~5-10ms/iter with it (allocation-heavy array.filter calls).
+// Cross-check any surprising absolute number from an allocation-heavy bench
+// against a manual loop before trusting it.
+
+// Few matches: only "Row 7" matches the search term "row 7" (one exact row ID match).
+bench("DataTable default filter, few matches, $size rows", function* (state) {
+  const size = state.get("size");
+  const rows = buildRows(size);
+  const keys = ["name", "age", "contact.company"];
+  const value = "row 7";
+  yield () =>
+    rows.filter((row) =>
+      keys.some((key) => {
+        const v = resolvePath(row, key);
+        return typeof v === "string" || typeof v === "number"
+          ? `${v}`.toLowerCase().includes(value)
+          : false;
+      }),
+    );
+})
+  .range("size", 100, 10_000)
+  .gc("inner");
+
+// Many matches: "acme" matches ~1/5 of rows via contact.company (COMPANIES[i % 5] cycles through "Acme" frequently).
+bench("DataTable default filter, many matches, $size rows", function* (state) {
+  const size = state.get("size");
+  const rows = buildRows(size);
+  const keys = ["name", "age", "contact.company"];
+  const value = "acme";
+  yield () =>
+    rows.filter((row) =>
+      keys.some((key) => {
+        const v = resolvePath(row, key);
+        return typeof v === "string" || typeof v === "number"
+          ? `${v}`.toLowerCase().includes(value)
+          : false;
+      }),
+    );
+})
+  .range("size", 100, 10_000)
+  .gc("inner");
+
+// No matches: "zzzz" does not match any row field.
+bench("DataTable default filter, no matches, $size rows", function* (state) {
+  const size = state.get("size");
+  const rows = buildRows(size);
+  const keys = ["name", "age", "contact.company"];
+  const value = "zzzz";
+  yield () =>
+    rows.filter((row) =>
+      keys.some((key) => {
+        const v = resolvePath(row, key);
+        return typeof v === "string" || typeof v === "number"
+          ? `${v}`.toLowerCase().includes(value)
+          : false;
+      }),
+    );
+})
+  .range("size", 100, 10_000)
+  .gc("inner");
+
+await runWithFilter();

--- a/bench/datatable-filter.dom.bench.ts
+++ b/bench/datatable-filter.dom.bench.ts
@@ -1,0 +1,84 @@
+import { cleanup, fireEvent, render } from "@testing-library/svelte";
+import { bench, run } from "mitata";
+import { tick } from "svelte";
+import DataTableFilterBench from "./fixtures/DataTableFilterBench.svelte";
+
+// DataTable filterMode benchmark: compare "hide" vs "remove" strategies per
+// search keystroke on a 1000-row table. Instances are rendered ONCE and
+// persist across iterations — the timed closure fires only the input event.
+// (Rendering inside the closure would bury the keystroke under ~1s of
+// mount/unmount cost and make the two modes indistinguishable.)
+// Alternating "row 7"/"row 8" swaps between two ~111-row disjoint match sets,
+// so every iteration does steady, genuine filter work.
+
+function buildRows(count: number) {
+  return Array.from({ length: count }, (_, i) => ({
+    id: String(i),
+    name: `row ${i} - Load Balancer`,
+    protocol: "HTTP",
+    port: 3000 + i,
+    rule: "Round robin",
+  }));
+}
+
+it("benchmarks DataTable filter keystroke, filterMode remove vs hide", async () => {
+  const removeInstance = render(DataTableFilterBench, {
+    props: { rows: buildRows(1000), filterMode: "remove" },
+  });
+  const hideInstance = render(DataTableFilterBench, {
+    props: { rows: buildRows(1000), filterMode: "hide" },
+  });
+
+  const getInput = (instance: typeof removeInstance) => {
+    const input = instance.container.querySelector("input");
+    if (!input) throw new Error("search input not found");
+    return input;
+  };
+
+  // Sanity check both modes actually filter before measuring.
+  const removeInput = getInput(removeInstance);
+  await fireEvent.input(removeInput, { target: { value: "row 7" } });
+  await tick();
+  const removeVisible =
+    removeInstance.container.querySelectorAll("tbody tr").length;
+  const hideInput = getInput(hideInstance);
+  await fireEvent.input(hideInput, { target: { value: "row 7" } });
+  await tick();
+  const hideMounted =
+    hideInstance.container.querySelectorAll("tbody tr").length;
+  const hideVisible = hideInstance.container.querySelectorAll(
+    "tbody tr:not([hidden])",
+  ).length;
+  process.stdout.write(
+    `sanity: remove mounted=${removeVisible} hide mounted=${hideMounted} hide visible=${hideVisible}\n`,
+  );
+
+  const registerKeystrokeCase = (
+    title: string,
+    input: HTMLInputElement,
+  ): void => {
+    bench(title, function* () {
+      let n = 0;
+      yield async () => {
+        const value = n++ % 2 === 0 ? "row 8" : "row 7";
+        await fireEvent.input(input, { target: { value } });
+        await tick();
+      };
+    });
+  };
+
+  registerKeystrokeCase(
+    "filter keystroke, DataTable 1000 rows, filterMode remove",
+    removeInput,
+  );
+  registerKeystrokeCase(
+    "filter keystroke, DataTable 1000 rows, filterMode hide",
+    hideInput,
+  );
+
+  await run({ print: (line) => process.stdout.write(`${line}\n`) });
+
+  // cleanup() once at the end, NOT inside the bench closures — the instances
+  // must persist across iterations (that is the whole point for "hide").
+  cleanup();
+}, 180_000);

--- a/bench/datatable-mount.dom.bench.ts
+++ b/bench/datatable-mount.dom.bench.ts
@@ -59,4 +59,4 @@ it("benchmarks mounting a large DataTable, virtualized vs not", async () => {
   // mitata defaults `print` to console.log, which vitest swallows for
   // passing tests. process.stdout.write always reaches the terminal.
   await run({ print: (line) => process.stdout.write(`${line}\n`) });
-}, 60_000);
+}, 180_000);

--- a/bench/dropdown.dom.bench.ts
+++ b/bench/dropdown.dom.bench.ts
@@ -31,4 +31,4 @@ it("benchmarks opening a Dropdown menu", async () => {
   // window/navigator globals look like a browser to its feature sniff —
   // the timings themselves still use bun's real nanosecond clock.)
   await run({ print: (line) => process.stdout.write(`${line}\n`) });
-}, 60_000);
+}, 180_000);

--- a/bench/filterTreeNodes.bench.ts
+++ b/bench/filterTreeNodes.bench.ts
@@ -112,6 +112,24 @@ bench(
   .range("size", 100, 10_000)
   .gc("inner");
 
+// Bushy tree, match root only, with includeChildren and includeAncestors.
+// Matching the root with includeChildren deep-clones the entire subtree via cloneNode,
+// so a single match near the root approaches match-all cost — this is the worst-case allocation path.
+bench(
+  "filterTreeNodes bushy, match root only, includeChildren, $size nodes",
+  function* (state) {
+    const size = state.get("size");
+    const tree = buildBushyTree(size);
+    yield () =>
+      filterTreeNodes(tree, (n: TreeNode) => n.id === 0, {
+        includeChildren: true,
+        includeAncestors: true,
+      });
+  },
+)
+  .range("size", 100, 10_000)
+  .gc("inner");
+
 // Chain tree, match-few predicate, default options.
 // Tests filterTreeNodes on deep/narrow structure (opposite of bushy).
 bench("filterTreeNodes chain, match few, $size nodes", function* (state) {

--- a/bench/filterTreeNodes.bench.ts
+++ b/bench/filterTreeNodes.bench.ts
@@ -1,0 +1,125 @@
+// Pure-logic benchmark: no jsdom, no Svelte, run directly via bun (`bun run bench/<this file>.bench.ts`, optionally filtered — see CONTRIBUTING.md).
+// filterTreeNodes filters a hierarchical tree by a predicate function, with options
+// to include/exclude children and ancestors of matching nodes.
+import { bench } from "mitata";
+import { filterTreeNodes } from "../src/utils/filterTreeNodes.js";
+import { runWithFilter } from "./run-with-filter.js";
+
+type TreeNode = {
+  id: number;
+  text: string;
+  nodes?: TreeNode[];
+};
+
+/**
+ * Build a bushy hierarchical tree with ~branching children per node, filled
+ * level by level using BFS until totalNodes is reached.
+ * @param totalNodes Total number of nodes to create
+ * @param branching Number of children per node (default 10)
+ */
+function buildBushyTree(totalNodes: number, branching = 10): TreeNode[] {
+  if (totalNodes <= 0) return [];
+
+  let nextId = 0;
+  const root: TreeNode = { id: nextId++, text: `Node ${nextId - 1}` };
+  const queue: TreeNode[] = [root];
+
+  while (nextId < totalNodes && queue.length > 0) {
+    const parent = queue.shift();
+    if (!parent) break;
+
+    parent.nodes = [];
+    for (let i = 0; i < branching && nextId < totalNodes; i++) {
+      const child: TreeNode = { id: nextId, text: `Node ${nextId}` };
+      parent.nodes.push(child);
+      queue.push(child);
+      nextId++;
+    }
+  }
+
+  return [root];
+}
+
+/**
+ * Build a chain (single-path) tree: node 0 -> node 1 -> node 2 -> ... -> node N-1.
+ * @param totalNodes Number of nodes in the chain
+ */
+function buildChainTree(totalNodes: number): TreeNode[] {
+  if (totalNodes <= 0) return [];
+
+  let current: TreeNode = { id: 0, text: "Node 0" };
+  const root = current;
+
+  for (let i = 1; i < totalNodes; i++) {
+    const child: TreeNode = { id: i, text: `Node ${i}` };
+    current.nodes = [child];
+    current = child;
+  }
+
+  return [root];
+}
+
+// Predicates (deterministic, used across multiple cases)
+const predicateMatchNone = (n: TreeNode) => n.text.includes("zzz");
+const predicateMatchFew = (n: TreeNode) => n.id % 100 === 0;
+const predicateMatchAll = (_n: TreeNode) => true;
+
+// `.gc("inner")` forces GC before/after every sample instead of batching calls
+// with no GC in between. filterTreeNodes does recursive cloning and filtering,
+// which is allocation-heavy, so without .gc("inner") numbers inflate by 20-60x.
+// See CONTRIBUTING.md and dataTableSort.bench.ts for details.
+
+// Bushy tree, match-none predicate, default options (includeAncestors: true)
+bench("filterTreeNodes bushy, match none, $size nodes", function* (state) {
+  const size = state.get("size");
+  const tree = buildBushyTree(size);
+  yield () => filterTreeNodes(tree, predicateMatchNone);
+})
+  .range("size", 100, 10_000)
+  .gc("inner");
+
+// Bushy tree, match-few predicate, default options
+bench("filterTreeNodes bushy, match few, $size nodes", function* (state) {
+  const size = state.get("size");
+  const tree = buildBushyTree(size);
+  yield () => filterTreeNodes(tree, predicateMatchFew);
+})
+  .range("size", 100, 10_000)
+  .gc("inner");
+
+// Bushy tree, match-all predicate, default options
+bench("filterTreeNodes bushy, match all, $size nodes", function* (state) {
+  const size = state.get("size");
+  const tree = buildBushyTree(size);
+  yield () => filterTreeNodes(tree, predicateMatchAll);
+})
+  .range("size", 100, 10_000)
+  .gc("inner");
+
+// Bushy tree, match-few predicate, with includeChildren and includeAncestors
+bench(
+  "filterTreeNodes bushy, match few, includeChildren, $size nodes",
+  function* (state) {
+    const size = state.get("size");
+    const tree = buildBushyTree(size);
+    yield () =>
+      filterTreeNodes(tree, predicateMatchFew, {
+        includeChildren: true,
+        includeAncestors: true,
+      });
+  },
+)
+  .range("size", 100, 10_000)
+  .gc("inner");
+
+// Chain tree, match-few predicate, default options.
+// Tests filterTreeNodes on deep/narrow structure (opposite of bushy).
+bench("filterTreeNodes chain, match few, $size nodes", function* (state) {
+  const size = state.get("size");
+  const tree = buildChainTree(size);
+  yield () => filterTreeNodes(tree, predicateMatchFew);
+})
+  .range("size", 100, 10_000)
+  .gc("inner");
+
+await runWithFilter();

--- a/bench/fixtures/DataTableFilterBench.svelte
+++ b/bench/fixtures/DataTableFilterBench.svelte
@@ -1,0 +1,26 @@
+<svelte:options accessors />
+
+<script lang="ts">
+  import DataTable from "carbon-components-svelte/DataTable/DataTable.svelte";
+  import Toolbar from "carbon-components-svelte/DataTable/Toolbar.svelte";
+  import ToolbarContent from "carbon-components-svelte/DataTable/ToolbarContent.svelte";
+  import ToolbarSearch from "carbon-components-svelte/DataTable/ToolbarSearch.svelte";
+
+  export let rows = [];
+  export let filterMode = "remove";
+
+  const headers = [
+    { key: "name", value: "Name" },
+    { key: "protocol", value: "Protocol" },
+    { key: "port", value: "Port" },
+    { key: "rule", value: "Rule" },
+  ];
+</script>
+
+<DataTable size="short" {headers} {rows} {filterMode}>
+  <Toolbar>
+    <ToolbarContent>
+      <ToolbarSearch persistent shouldFilterRows />
+    </ToolbarContent>
+  </Toolbar>
+</DataTable>

--- a/bench/multiSelectSort.bench.ts
+++ b/bench/multiSelectSort.bench.ts
@@ -1,0 +1,62 @@
+// Pure-logic benchmark: no jsdom, no Svelte, run directly via bun (`bun run bench/<this file>.bench.ts`, optionally filtered — see CONTRIBUTING.md).
+// Mirrors MultiSelect.svelte's default `sortItem`, which runs inside sort()
+// on every items/selectedIds change, against the cached-Intl.Collator form
+// the default was switched to (same change DataTable's compareValues got).
+import { bench } from "mitata";
+import { runWithFilter } from "./run-with-filter.js";
+
+type Item = {
+  id: number;
+  text: string;
+};
+
+function buildItems(count: number): Item[] {
+  const items: Item[] = [];
+  for (let i = 0; i < count; i++) {
+    items.push({
+      id: i,
+      text: `Option ${(i * 37) % count} rev ${i % 10}`,
+    });
+  }
+  return items;
+}
+
+// `.gc("inner")` forces a GC before/after every sample instead of mitata's
+// default of batching many calls together with no GC in between. Without it,
+// these two cases (which each allocate a fresh sorted array per call)
+// mis-calibrate batch size and report numbers inflated by 20-60x.
+// Cross-check any surprising absolute number from an allocation-heavy bench
+// against a manual loop before trusting it (the 10k ratio below was confirmed
+// at ~10x with a plain performance.now() loop: 140ms vs 14ms per sort).
+
+// Per-call localeCompare: MultiSelect's former default sortItem. Passing an
+// options object makes each comparison rebuild the full ICU collator.
+bench(
+  "MultiSelect default sortItem (per-call localeCompare), $size items",
+  function* (state) {
+    const size = state.get("size");
+    const items = buildItems(size);
+    yield () =>
+      [...items].sort((a, b) =>
+        a.text.localeCompare(b.text, "en", { numeric: true }),
+      );
+  },
+)
+  .range("size", 100, 10_000)
+  .gc("inner");
+
+// Cached Intl.Collator: the current default. The collator is created once in
+// setup (unmeasured), then its .compare() is reused across all comparisons.
+bench(
+  "MultiSelect cached Intl.Collator sortItem, $size items",
+  function* (state) {
+    const size = state.get("size");
+    const items = buildItems(size);
+    const collator = new Intl.Collator("en", { numeric: true });
+    yield () => [...items].sort((a, b) => collator.compare(a.text, b.text));
+  },
+)
+  .range("size", 100, 10_000)
+  .gc("inner");
+
+await runWithFilter();

--- a/bench/multiselect-mount.dom.bench.ts
+++ b/bench/multiselect-mount.dom.bench.ts
@@ -1,0 +1,69 @@
+import { cleanup, render } from "@testing-library/svelte";
+import { userEvent } from "@testing-library/user-event";
+import MultiSelect from "carbon-components-svelte/MultiSelect/MultiSelect.svelte";
+import { bench, run } from "mitata";
+
+function buildItems(count: number) {
+  const items = [];
+  for (let i = 0; i < count; i++) {
+    // Scrambled, not sequential: `Item ${i}` would already be sorted under the
+    // default sortItem (numeric-aware), letting TimSort skip most comparisons
+    // and hiding the mount-time sort cost this bench should include.
+    items.push({ id: String(i), text: `Item ${(i * 37) % count}` });
+  }
+  return items;
+}
+
+// Fixtures built once — MultiSelect copies items internally (sort() maps to
+// new objects), so sharing them across iterations is safe.
+const items100 = buildItems(100);
+const items1000 = buildItems(1000);
+
+// Reused across iterations so the benchmark measures MultiSelect, not the cost
+// of setting up userEvent.
+const user = userEvent.setup();
+
+it("benchmarks mounting MultiSelect with various item counts and virtualization modes", async () => {
+  // 100 items is at the auto-virtualization cutoff (virtualize kicks in above
+  // 100), so this mounts every menu item — the closed menu is display:none
+  // gated but still rendered.
+  bench("mount MultiSelect, 100 items", () => {
+    render(MultiSelect, {
+      props: { items: items100, label: "Options", labelText: "Options" },
+    });
+    cleanup();
+  });
+
+  bench("mount MultiSelect, 1000 items (virtualized default)", () => {
+    render(MultiSelect, {
+      props: { items: items1000, label: "Options", labelText: "Options" },
+    });
+    cleanup();
+  });
+
+  bench("mount MultiSelect, 1000 items, virtualize disabled", () => {
+    render(MultiSelect, {
+      props: {
+        items: items1000,
+        label: "Options",
+        labelText: "Options",
+        virtualize: false,
+      },
+    });
+    cleanup();
+  });
+
+  bench("mount + open MultiSelect, 1000 items", async () => {
+    const { getByRole } = render(MultiSelect, {
+      props: { items: items1000, label: "Options", labelText: "Options" },
+    });
+
+    await user.click(getByRole("combobox"));
+
+    cleanup();
+  });
+
+  // mitata defaults `print` to console.log, which vitest swallows for
+  // passing tests. process.stdout.write always reaches the terminal.
+  await run({ print: (line) => process.stdout.write(`${line}\n`) });
+}, 120_000);

--- a/bench/multiselect-toggle.dom.bench.ts
+++ b/bench/multiselect-toggle.dom.bench.ts
@@ -1,0 +1,95 @@
+import { cleanup, fireEvent, render, within } from "@testing-library/svelte";
+import { userEvent } from "@testing-library/user-event";
+import MultiSelect from "carbon-components-svelte/MultiSelect/MultiSelect.svelte";
+import { bench, run } from "mitata";
+
+function buildItems(count: number) {
+  const items = [];
+  for (let i = 0; i < count; i++) {
+    // Scrambled, not sequential: `Item ${i}` would already be sorted under the
+    // default sortItem (numeric-aware), letting TimSort skip most comparisons.
+    items.push({ id: String(i), text: `Item ${(i * 37) % count}` });
+  }
+  return items;
+}
+
+// Fixture built once — MultiSelect copies items internally, safe to share.
+const items1000 = buildItems(1000);
+
+// Reused across iterations so the benchmark measures MultiSelect, not the cost
+// of setting up userEvent.
+const user = userEvent.setup();
+
+it("benchmarks toggling a selection in an open MultiSelect menu", async () => {
+  // Three instances coexist in jsdom; every query is scoped to the owning
+  // instance's container. Only one menu can be open at a time — opening one
+  // instance is an outside click for the others (use:dismiss closes them) —
+  // so each case's generator setup (re)opens its own menu just before
+  // sampling instead of opening all three up front.
+  const instance1 = render(MultiSelect, {
+    props: { items: items1000, label: "Options", labelText: "Options" },
+  });
+
+  const instance2 = render(MultiSelect, {
+    props: {
+      items: items1000,
+      label: "Options",
+      labelText: "Options",
+      selectionFeedback: "top",
+    },
+  });
+
+  const instance3 = render(MultiSelect, {
+    props: {
+      items: items1000,
+      label: "Options",
+      labelText: "Options",
+      virtualize: false,
+    },
+  });
+
+  const registerToggleCase = (
+    title: string,
+    instance: typeof instance1,
+  ): void => {
+    bench(title, function* () {
+      const scope = within(instance.container);
+      // Guarded open: the field click handler toggles, and mitata may invoke
+      // this setup more than once — only click when the menu is closed.
+      const combobox = scope.getByRole("combobox", { hidden: true });
+      if (combobox.getAttribute("aria-expanded") === "false") {
+        fireEvent.click(combobox);
+      }
+      const listbox = scope.getByRole("listbox", { hidden: true });
+      yield async () => {
+        // Re-query each iteration: with selectionFeedback "top" the sorted
+        // order changes per click, so "first option" is a moving target.
+        const option = within(listbox).queryAllByRole("option", {
+          hidden: true,
+        })[0];
+        await user.click(option);
+      };
+    });
+  };
+
+  registerToggleCase(
+    "toggle option, open MultiSelect, 1000 items (virtualized)",
+    instance1,
+  );
+  registerToggleCase(
+    "toggle option, open MultiSelect, 1000 items, selectionFeedback top",
+    instance2,
+  );
+  registerToggleCase(
+    "toggle option, open MultiSelect, 1000 items, virtualize disabled",
+    instance3,
+  );
+
+  // mitata defaults `print` to console.log, which vitest swallows for
+  // passing tests. process.stdout.write always reaches the terminal.
+  await run({ print: (line) => process.stdout.write(`${line}\n`) });
+
+  // cleanup() once at the end, NOT inside the bench closures — the instances
+  // must persist across all iterations.
+  cleanup();
+}, 180_000);

--- a/bench/toHierarchy.bench.ts
+++ b/bench/toHierarchy.bench.ts
@@ -1,0 +1,103 @@
+// Pure-logic benchmark: no jsdom, no Svelte, run directly via bun (`bun run bench/<this file>.bench.ts`, optionally filtered — see CONTRIBUTING.md).
+// toHierarchy converts a flat array into a hierarchical tree by assigning item.nodes.
+// IMPORTANT: toHierarchy mutates its input by assigning `item.nodes`. Each benchmark
+// closure must operate on a fresh shallow clone to avoid cross-iteration state pollution.
+// The "clone only" baseline lets us subtract clone overhead from the real measurements.
+import { bench } from "mitata";
+import { toHierarchy } from "../src/utils/toHierarchy.js";
+import { runWithFilter } from "./run-with-filter.js";
+
+type Node = {
+  id: number;
+  pid: number | null;
+  text: string;
+  nodes?: Node[];
+};
+
+/**
+ * Build a flat array of nodes with a given parent structure.
+ * Each node is { id, pid, text }.
+ * @param totalNodes Total number of nodes to create
+ * @param parentFn Function that maps node index i to its parent id (or null for roots)
+ */
+function buildFlatNodes(
+  totalNodes: number,
+  parentFn: (i: number) => number | null,
+): Node[] {
+  const nodes: Node[] = [];
+  for (let i = 0; i < totalNodes; i++) {
+    nodes.push({
+      id: i,
+      pid: parentFn(i),
+      text: `Node ${i}`,
+    });
+  }
+  return nodes;
+}
+
+// Flat shape: every node is a root (pid null)
+const flatParent = () => null;
+
+// Bushy shape: each node's parent is Math.floor((i - 1) / 10), node 0 is root
+const bushyParent = (i: number) => (i === 0 ? null : Math.floor((i - 1) / 10));
+
+// Chain shape: node i's parent is i - 1, node 0 is root
+const chainParent = (i: number) => (i === 0 ? null : i - 1);
+
+// Baseline: clone overhead only (no toHierarchy call).
+// `.gc("inner")` forces GC before/after every sample instead of batching calls
+// with no GC in between. Without it, the clone + toHierarchy allocation-heavy
+// operations mis-calibrate and report numbers inflated by 20-60x. See
+// CONTRIBUTING.md and dataTableSort.bench.ts for details.
+bench("clone only, $size nodes", function* (state) {
+  const size = state.get("size");
+  const flat = buildFlatNodes(size, flatParent);
+  yield () => flat.map((n) => ({ ...n }));
+})
+  .range("size", 100, 10_000)
+  .gc("inner");
+
+// Flat tree: every node a root. Tree has height 1, width = size.
+// Exercises the root-only path in toHierarchy.
+bench("toHierarchy flat, $size nodes", function* (state) {
+  const size = state.get("size");
+  const flat = buildFlatNodes(size, flatParent);
+  yield () =>
+    toHierarchy(
+      flat.map((n) => ({ ...n })),
+      (n) => n.pid,
+    );
+})
+  .range("size", 100, 10_000)
+  .gc("inner");
+
+// Bushy tree: 10 children per node, roughly breadth-first fill.
+// Exercises parent-child linking in the typical case.
+bench("toHierarchy bushy, $size nodes", function* (state) {
+  const size = state.get("size");
+  const flat = buildFlatNodes(size, bushyParent);
+  yield () =>
+    toHierarchy(
+      flat.map((n) => ({ ...n })),
+      (n) => n.pid,
+    );
+})
+  .range("size", 100, 10_000)
+  .gc("inner");
+
+// Chain tree: node i's parent is i - 1, so every node has exactly one child.
+// Tree has height = size, width 1. Exercises deep recursion-like behavior
+// in data structure with linear parent-child chains.
+bench("toHierarchy chain, $size nodes", function* (state) {
+  const size = state.get("size");
+  const flat = buildFlatNodes(size, chainParent);
+  yield () =>
+    toHierarchy(
+      flat.map((n) => ({ ...n })),
+      (n) => n.pid,
+    );
+})
+  .range("size", 100, 10_000)
+  .gc("inner");
+
+await runWithFilter();

--- a/bench/treeview-filter.dom.bench.ts
+++ b/bench/treeview-filter.dom.bench.ts
@@ -38,6 +38,7 @@ function buildBushyTree(totalNodes: number, branching = 10): TreeNode[] {
 // Module-level fixtures: build trees once, reuse across iterations
 const tree10k = buildBushyTree(10_000);
 const tree1k = buildBushyTree(1_000);
+const checkedIds50 = Array.from({ length: 50 }, (_, i) => i * 200);
 
 it("benchmarks TreeView filtering during search keystroke", async () => {
   // No `.gc("inner")` on DOM benches: forcing GC after every iteration over
@@ -95,6 +96,46 @@ it("benchmarks TreeView filtering during search keystroke", async () => {
       yield async () => {
         const filtered = predicateCount++ % 2 === 0 ? filteredA : filteredB;
         result.rerender({ nodes: filtered, labelText: "Tree" });
+        await tick();
+      };
+
+      cleanup();
+    },
+  );
+
+  bench(
+    "filter keystroke, TreeView 10000 nodes (virtualized, checkbox mode)",
+    function* () {
+      const fullTree = tree10k;
+      const predicateA = (node: TreeNode) => node.text.includes("1");
+      const predicateB = (node: TreeNode) => node.text.includes("2");
+
+      const filteredA = filterTreeNodes(fullTree, predicateA);
+      const filteredB = filterTreeNodes(fullTree, predicateB);
+
+      let predicateCount = 0;
+
+      // Checkbox mode runs resolveCheckboxState on every nodes change,
+      // this case measures that delta vs the plain virtualized case.
+      const result = render(TreeView, {
+        props: {
+          nodes: filteredA,
+          labelText: "Tree",
+          virtualize: true,
+          selectionMode: "checkbox",
+          checkedIds: checkedIds50,
+        },
+      });
+
+      yield async () => {
+        const filtered = predicateCount++ % 2 === 0 ? filteredA : filteredB;
+        result.rerender({
+          nodes: filtered,
+          labelText: "Tree",
+          virtualize: true,
+          selectionMode: "checkbox",
+          checkedIds: checkedIds50,
+        });
         await tick();
       };
 

--- a/bench/treeview-filter.dom.bench.ts
+++ b/bench/treeview-filter.dom.bench.ts
@@ -1,0 +1,106 @@
+import { cleanup, render } from "@testing-library/svelte";
+import TreeView from "carbon-components-svelte/TreeView/TreeView.svelte";
+import { bench, run } from "mitata";
+import { tick } from "svelte";
+import { filterTreeNodes } from "../src/utils/filterTreeNodes.js";
+
+type TreeNode = { id: number; text: string; nodes?: TreeNode[] };
+
+/**
+ * Build a bushy hierarchical tree with ~branching children per node, filled
+ * level by level using BFS until totalNodes is reached.
+ * @param totalNodes Total number of nodes to create
+ * @param branching Number of children per node (default 10)
+ */
+function buildBushyTree(totalNodes: number, branching = 10): TreeNode[] {
+  if (totalNodes <= 0) return [];
+
+  let nextId = 0;
+  const root: TreeNode = { id: nextId++, text: `Node ${nextId - 1}` };
+  const queue: TreeNode[] = [root];
+
+  while (nextId < totalNodes && queue.length > 0) {
+    const parent = queue.shift();
+    if (!parent) break;
+
+    parent.nodes = [];
+    for (let i = 0; i < branching && nextId < totalNodes; i++) {
+      const child: TreeNode = { id: nextId, text: `Node ${nextId}` };
+      parent.nodes.push(child);
+      queue.push(child);
+      nextId++;
+    }
+  }
+
+  return [root];
+}
+
+// Module-level fixtures: build trees once, reuse across iterations
+const tree10k = buildBushyTree(10_000);
+const tree1k = buildBushyTree(1_000);
+
+it("benchmarks TreeView filtering during search keystroke", async () => {
+  // No `.gc("inner")` on DOM benches: forcing GC after every iteration over
+  // a large jsdom DOM object graph can induce thermal throttling that
+  // invalidates all numbers (including unrelated cases in the same run).
+  // See CONTRIBUTING.md for details.
+
+  bench("filter keystroke, TreeView 10000 nodes (virtualized)", function* () {
+    const fullTree = tree10k;
+    const predicateA = (node: TreeNode) => node.text.includes("1");
+    const predicateB = (node: TreeNode) => node.text.includes("2");
+
+    // Pre-compute both filtered variants to measure only component update cost,
+    // not filterTreeNodes cost
+    const filteredA = filterTreeNodes(fullTree, predicateA);
+    const filteredB = filterTreeNodes(fullTree, predicateB);
+
+    // Alternating predicates guarantee the prop genuinely changes every
+    // iteration — without this, the framework might short-circuit updates.
+    let predicateCount = 0;
+
+    const result = render(TreeView, {
+      props: { nodes: filteredA, labelText: "Tree", virtualize: true },
+    });
+
+    yield async () => {
+      const filtered = predicateCount++ % 2 === 0 ? filteredA : filteredB;
+      result.rerender({
+        nodes: filtered,
+        labelText: "Tree",
+        virtualize: true,
+      });
+      await tick();
+    };
+
+    cleanup();
+  });
+
+  bench(
+    "filter keystroke, TreeView 1000 nodes (not virtualized)",
+    function* () {
+      const fullTree = tree1k;
+      const predicateA = (node: TreeNode) => node.text.includes("1");
+      const predicateB = (node: TreeNode) => node.text.includes("2");
+
+      const filteredA = filterTreeNodes(fullTree, predicateA);
+      const filteredB = filterTreeNodes(fullTree, predicateB);
+
+      let predicateCount = 0;
+
+      const result = render(TreeView, {
+        props: { nodes: filteredA, labelText: "Tree" },
+      });
+
+      yield async () => {
+        const filtered = predicateCount++ % 2 === 0 ? filteredA : filteredB;
+        result.rerender({ nodes: filtered, labelText: "Tree" });
+        await tick();
+      };
+
+      cleanup();
+    },
+  );
+
+  await run({ print: (line) => process.stdout.write(`${line}\n`) });
+}, 180_000);

--- a/bench/treeview-mount.dom.bench.ts
+++ b/bench/treeview-mount.dom.bench.ts
@@ -73,4 +73,4 @@ it("benchmarks mounting a large TreeView, virtualized vs not", async () => {
   // mitata defaults `print` to console.log, which vitest swallows for
   // passing tests. process.stdout.write always reaches the terminal.
   await run({ print: (line) => process.stdout.write(`${line}\n`) });
-}, 60_000);
+}, 180_000);

--- a/bench/treeview-toggle.dom.bench.ts
+++ b/bench/treeview-toggle.dom.bench.ts
@@ -1,0 +1,89 @@
+import { cleanup, fireEvent, render } from "@testing-library/svelte";
+import TreeView from "carbon-components-svelte/TreeView/TreeView.svelte";
+import { bench, run } from "mitata";
+import { tick } from "svelte";
+
+type TreeNode = { id: number; text: string; nodes?: TreeNode[] };
+
+/**
+ * Build a bushy hierarchical tree with ~branching children per node, filled
+ * level by level using BFS until totalNodes is reached.
+ * @param totalNodes Total number of nodes to create
+ * @param branching Number of children per node (default 10)
+ */
+function buildBushyTree(totalNodes: number, branching = 10): TreeNode[] {
+  if (totalNodes <= 0) return [];
+
+  let nextId = 0;
+  const root: TreeNode = { id: nextId++, text: `Node ${nextId - 1}` };
+  const queue: TreeNode[] = [root];
+
+  while (nextId < totalNodes && queue.length > 0) {
+    const parent = queue.shift();
+    if (!parent) break;
+
+    parent.nodes = [];
+    for (let i = 0; i < branching && nextId < totalNodes; i++) {
+      const child: TreeNode = { id: nextId, text: `Node ${nextId}` };
+      parent.nodes.push(child);
+      queue.push(child);
+      nextId++;
+    }
+  }
+
+  return [root];
+}
+
+// Module-level fixtures: build trees once, reuse across iterations
+// Two separate 1000-node trees, one per TreeView instance
+const treeA = buildBushyTree(1_000);
+const treeB = buildBushyTree(1_000);
+
+it("benchmarks TreeView toggle expand/collapse cost", async () => {
+  // No `.gc("inner")` on DOM benches: forcing GC after every iteration over
+  // a large jsdom DOM object graph can induce thermal throttling that
+  // invalidates all numbers (including unrelated cases in the same run).
+  // See CONTRIBUTING.md for details.
+
+  bench(
+    "toggle root expand/collapse, TreeView 1000 nodes (not virtualized)",
+    function* () {
+      const result = render(TreeView, {
+        props: { nodes: treeA, labelText: "Tree" },
+      });
+
+      yield async () => {
+        // Each iteration alternates expand/collapse by clicking the toggle
+        const toggle = result.container.querySelector(
+          ".bx--tree-parent-node__toggle",
+        );
+        await fireEvent.click(toggle);
+        await tick();
+      };
+
+      cleanup();
+    },
+  );
+
+  bench(
+    "toggle root expand/collapse, TreeView 1000 nodes (virtualized)",
+    function* () {
+      const result = render(TreeView, {
+        props: { nodes: treeB, labelText: "Tree", virtualize: true },
+      });
+
+      yield async () => {
+        // Each iteration alternates expand/collapse by clicking the toggle
+        const toggle = result.container.querySelector(
+          ".bx--tree-parent-node__toggle",
+        );
+        await fireEvent.click(toggle);
+        await tick();
+      };
+
+      cleanup();
+    },
+  );
+
+  await run({ print: (line) => process.stdout.write(`${line}\n`) });
+}, 180_000);

--- a/src/DataTable/DataTable.svelte
+++ b/src/DataTable/DataTable.svelte
@@ -282,6 +282,10 @@
    *   attribute, preserving focus, inputs, and open menus.
    *
    * `"hide"` falls back to `"remove"` when `pageSize` is set or `virtualize` is enabled.
+   *
+   * Because `"hide"` keeps every row mounted, each keystroke re-renders all
+   * rows, not just matching ones. For large row counts (hundreds or more),
+   * prefer `"remove"`, pagination, or virtualization.
    * @type {"remove" | "hide"}
    */
   export let filterMode = "remove";

--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -134,8 +134,7 @@
    * The default sorting compare the item text value.
    * @type {((a: Item, b: Item) => number) | (() => void)}
    */
-  export let sortItem = (a, b) =>
-    a.text.localeCompare(b.text, locale, { numeric: true });
+  export let sortItem = (a, b) => getSortCollator().compare(a.text, b.text);
 
   /**
    * Override the chevron icon label based on the open state.
@@ -346,6 +345,16 @@
 
   $: effectivePortalMenu =
     portalMenu === undefined ? !!insideModal : portalMenu;
+
+  let sortCollatorLocale;
+  let sortCollator;
+  function getSortCollator() {
+    if (!sortCollator || sortCollatorLocale !== locale) {
+      sortCollatorLocale = locale;
+      sortCollator = new Intl.Collator(locale, { numeric: true });
+    }
+    return sortCollator;
+  }
 
   let fieldFocused = false;
   let highlightedIndex = -1;

--- a/src/TreeView/TreeView.svelte
+++ b/src/TreeView/TreeView.svelte
@@ -495,8 +495,8 @@
     const targetNode = cachedNodeMap?.get(id);
     if (!targetNode) return;
 
+    const ancestorIds = expand ? getAncestorIds(id, cachedParentIdById) : [];
     if (expand) {
-      const ancestorIds = getAncestorIds(id, cachedParentIdById);
       for (const ancestorId of ancestorIds) {
         expandedIdsSet.add(ancestorId);
       }
@@ -520,12 +520,19 @@
     }
 
     if (focus) {
-      tick().then(() => {
+      tick().then(async () => {
         if (virtualConfig && scrollContainerRef) {
           focusVirtualRowById(id);
           return;
         }
-        ref?.querySelector(`[id="${CSS.escape(String(id))}"]`)?.focus();
+        const selector = `[id="${CSS.escape(String(id))}"]`;
+        let el = ref?.querySelector(selector);
+        for (let i = 0; !el && i < ancestorIds.length * 2 + 2; i++) {
+          // biome-ignore lint/performance/noAwaitInLoops: each tick waits for the next reveal flush
+          await tick();
+          el = ref?.querySelector(selector);
+        }
+        el?.focus();
       });
     }
   }
@@ -947,6 +954,8 @@
     dispatch("toggle", withLiveState(node));
   }
 
+  let initialRenderComplete = false;
+
   setContext("carbon:TreeView", {
     treeId,
     activeNodeId,
@@ -963,6 +972,7 @@
     expandNode,
     focusNode,
     toggleNode,
+    isInitialRender: () => !initialRenderComplete,
   });
 
   /** @param {HTMLElement | null} root */
@@ -1162,6 +1172,8 @@
   });
 
   onMount(() => {
+    initialRenderComplete = true;
+
     if (ref && !treeWalker) {
       treeWalker = createTreeWalkerInstance(ref);
     }

--- a/src/TreeView/TreeViewNodeList.svelte
+++ b/src/TreeView/TreeViewNodeList.svelte
@@ -31,7 +31,7 @@
    */
   export let icon = /** @type {Icon} */ (undefined);
 
-  import { getContext } from "svelte";
+  import { getContext, tick } from "svelte";
   import Checkbox from "../Checkbox/Checkbox.svelte";
   import CaretDown from "../icons/CaretDown.svelte";
   import TreeViewNode, {
@@ -73,7 +73,10 @@
     expandNode,
     focusNode,
     toggleNode,
+    isInitialRender,
   } = getContext("carbon:TreeView");
+
+  let subtreeRendered = isInitialRender() && $expandedIdsSetStore.has(id);
 
   /**
    * Tri-state value for `aria-checked` on the row.
@@ -98,6 +101,16 @@
 
   $: parent = Array.isArray(nodes);
   $: expanded = $expandedIdsSetStore.has(id);
+  const SYNC_REVEAL_LEVELS = 16;
+  $: if (expanded && !subtreeRendered) {
+    if (level % SYNC_REVEAL_LEVELS === 0) {
+      tick().then(() => {
+        if (expanded) subtreeRendered = true;
+      });
+    } else {
+      subtreeRendered = true;
+    }
+  }
   $: selected = $selectedIdsSetStore.has(id);
   $: checked = $checkedIdsSetStore.has(id);
   $: isCheckboxMode = $selectionModeStore === "checkbox";
@@ -305,36 +318,38 @@
       class:bx--tree-node__children={true}
       class:bx--tree-node--hidden={!expanded}
     >
-      {#if hasChildren && nodes.length === 0}
-        <slot name="childNodes" {node} />
-      {:else}
-        {#each nodes as child, index (child.id)}
-          {#if Array.isArray(child.nodes) || child.hasChildren}
-            <Self
-              {...child}
-              level={level + 1}
-              posinset={index + 1}
-              setsize={nodes.length}
-              let:node
-            >
-              <slot {node} />
-              <svelte:fragment slot="childNodes" let:node>
-                <slot name="childNodes" {node} />
-              </svelte:fragment>
-            </Self>
-          {:else}
-            <TreeViewNode
-              leaf
-              {...child}
-              level={level + 1}
-              posinset={index + 1}
-              setsize={nodes.length}
-              let:node
-            >
-              <slot {node}>{node.text}</slot>
-            </TreeViewNode>
-          {/if}
-        {/each}
+      {#if subtreeRendered}
+        {#if hasChildren && nodes.length === 0}
+          <slot name="childNodes" {node} />
+        {:else}
+          {#each nodes as child, index (child.id)}
+            {#if Array.isArray(child.nodes) || child.hasChildren}
+              <Self
+                {...child}
+                level={level + 1}
+                posinset={index + 1}
+                setsize={nodes.length}
+                let:node
+              >
+                <slot {node} />
+                <svelte:fragment slot="childNodes" let:node>
+                  <slot name="childNodes" {node} />
+                </svelte:fragment>
+              </Self>
+            {:else}
+              <TreeViewNode
+                leaf
+                {...child}
+                level={level + 1}
+                posinset={index + 1}
+                setsize={nodes.length}
+                let:node
+              >
+                <slot {node}>{node.text}</slot>
+              </TreeViewNode>
+            {/if}
+          {/each}
+        {/if}
       {/if}
     </ul>
   </li>

--- a/tests/MultiSelect/MultiSelect.test.ts
+++ b/tests/MultiSelect/MultiSelect.test.ts
@@ -1243,6 +1243,23 @@ describe("MultiSelect", () => {
       expect(nthRenderedOptionText(0)).toBe("Alpha");
     });
 
+    it("sorts numeric-aware by default (Item 2 before Item 10)", async () => {
+      render(MultiSelect, {
+        props: {
+          items: [
+            { id: "0", text: "Item 10" },
+            { id: "1", text: "Item 2" },
+            { id: "2", text: "Item 1" },
+          ],
+        },
+      });
+
+      await openMenu();
+      expect(nthRenderedOptionText(0)).toBe("Item 1");
+      expect(nthRenderedOptionText(1)).toBe("Item 2");
+      expect(nthRenderedOptionText(2)).toBe("Item 10");
+    });
+
     it("exposes sortedItems via bind", async () => {
       const { component } = render(MultiSelect, {
         props: {

--- a/tests/TreeView/TreeView.deepReveal.test.svelte
+++ b/tests/TreeView/TreeView.deepReveal.test.svelte
@@ -1,0 +1,62 @@
+<svelte:options accessors />
+
+<script lang="ts">
+  import TreeView from "carbon-components-svelte/TreeView/TreeView.svelte";
+
+  export let depth = 500;
+
+  export let shape: "chain" | "bushy" = "chain";
+
+  type ChainNode = { id: number; text: string; nodes?: ChainNode[] };
+
+  function buildChain(totalDepth: number): ChainNode[] {
+    let node: ChainNode = {
+      id: totalDepth - 1,
+      text: `Level ${totalDepth - 1}`,
+    };
+    for (let i = totalDepth - 2; i >= 0; i--) {
+      node = { id: i, text: `Level ${i}`, nodes: [node] };
+    }
+    return [node];
+  }
+
+  function buildBushy(): ChainNode[] {
+    let id = 0;
+    return Array.from({ length: 10 }, () => ({
+      id: id++,
+      text: "Root",
+      nodes: Array.from({ length: 10 }, () => ({
+        id: id++,
+        text: "Branch",
+        nodes: Array.from({ length: 10 }, () => ({
+          id: id++,
+          text: "Leaf",
+        })),
+      })),
+    }));
+  }
+
+  let treeview: TreeView;
+  let expandedIds: number[] = [];
+
+  $: nodes = shape === "chain" ? buildChain(depth) : buildBushy();
+
+  export function showDeepest() {
+    treeview.showNode(depth - 1);
+  }
+
+  export function expandAll() {
+    treeview.expandAll();
+  }
+
+  export function expandAllViaProp() {
+    expandedIds = Array.from({ length: depth - 1 }, (_, i) => i);
+  }
+</script>
+
+<TreeView
+  labelText="Deep chain"
+  {nodes}
+  bind:this={treeview}
+  bind:expandedIds
+/>

--- a/tests/TreeView/TreeView.deepReveal.test.ts
+++ b/tests/TreeView/TreeView.deepReveal.test.ts
@@ -1,0 +1,63 @@
+import { render, waitFor } from "@testing-library/svelte";
+import { tick } from "svelte";
+import TreeViewShowNode from "./TreeView.deepReveal.test.svelte";
+
+describe("TreeView deep reveal", () => {
+  const DEPTH = 200;
+
+  it("showNode reveals and focuses a node 200 levels deep without overflowing the stack", async () => {
+    const { component } = render(TreeViewShowNode, { props: { depth: DEPTH } });
+
+    component.showDeepest();
+
+    await waitFor(
+      () => {
+        const el = document.getElementById(String(DEPTH - 1));
+        expect(el).toBeInstanceOf(HTMLElement);
+        expect(el).toHaveFocus();
+      },
+      { timeout: 15_000 },
+    );
+  }, 30_000);
+
+  it("expandAll mounts a 200-level chain without overflowing the stack", async () => {
+    const { component } = render(TreeViewShowNode, { props: { depth: DEPTH } });
+
+    component.expandAll();
+
+    await waitFor(
+      () => {
+        expect(document.getElementById(String(DEPTH - 1))).toBeInstanceOf(
+          HTMLElement,
+        );
+      },
+      { timeout: 15_000 },
+    );
+  }, 30_000);
+
+  it("expandAll on a wide shallow tree completes in a single flush (no staggering)", async () => {
+    const { component } = render(TreeViewShowNode, {
+      props: { shape: "bushy" },
+    });
+
+    component.expandAll();
+    await tick();
+
+    expect(document.querySelectorAll("li").length).toBe(1110);
+  });
+
+  it("setting expandedIds directly reveals a deep chain without overflowing the stack", async () => {
+    const { component } = render(TreeViewShowNode, { props: { depth: DEPTH } });
+
+    component.expandAllViaProp();
+
+    await waitFor(
+      () => {
+        expect(document.getElementById(String(DEPTH - 1))).toBeInstanceOf(
+          HTMLElement,
+        );
+      },
+      { timeout: 15_000 },
+    );
+  }, 30_000);
+});

--- a/tests/TreeView/TreeView.multiselect.test.svelte
+++ b/tests/TreeView/TreeView.multiselect.test.svelte
@@ -1,3 +1,5 @@
+<svelte:options accessors />
+
 <script lang="ts">
   import TreeView from "carbon-components-svelte/TreeView/TreeView.svelte";
   import type { ComponentProps } from "svelte";

--- a/tests/TreeView/TreeView.showNode.test.ts
+++ b/tests/TreeView/TreeView.showNode.test.ts
@@ -48,9 +48,8 @@ describe("TreeView.showNode with options", () => {
 
     await user.click(getButton("select-only"));
     expect(getExpandedCount()).toBe(0);
-    const selected = screen.getByRole("treeitem", { selected: true });
-    expect(selected).toHaveAttribute("id", "3");
-    expect(selected.closest("ul.bx--tree-node--hidden")).not.toBeNull();
+    expect(document.getElementById("3")).toBeNull();
+    expect(screen.queryByRole("treeitem", { selected: true })).toBeNull();
     expect(consoleLog).toHaveBeenCalledWith("activeId", "");
     expect(consoleLog).toHaveBeenCalledWith("selectedIds", [3]);
   });

--- a/tests/TreeView/TreeView.test.ts
+++ b/tests/TreeView/TreeView.test.ts
@@ -350,19 +350,14 @@ describe.each(testCases)("$name", ({ component }) => {
 
     const firstItem = treeItemById(0);
     const analytics = treeItemById(1);
-    const ibmEngine = treeItemById(2); // descendant of collapsed Analytics
-    const apacheSpark = treeItemById(3); // leaf, descendant of collapsed IBM Engine
 
-    // Both descendants stay in the DOM but inside `ul.bx--tree-node--hidden`.
-    expect(ibmEngine.closest("ul.bx--tree-node--hidden")).not.toBeNull();
-    expect(apacheSpark.closest("ul.bx--tree-node--hidden")).not.toBeNull();
+    expect(document.getElementById("2")).toBeNull();
+    expect(document.getElementById("3")).toBeNull();
 
     firstItem.focus();
     await user.keyboard("{ArrowDown}");
 
     expect(analytics).toHaveFocus();
-    expect(ibmEngine).not.toHaveFocus();
-    expect(apacheSpark).not.toHaveFocus();
   });
 
   it("End key moves focus to the last non-disabled treeitem", async () => {
@@ -733,7 +728,7 @@ describe("TreeView Props", () => {
   });
 
   it("multiselectMode shallow selects parent and direct children only", async () => {
-    render(TreeViewMultiselect, {
+    const { component } = render(TreeViewMultiselect, {
       multiselect: true,
       multiselectMode: "shallow",
       selectedIds: [],
@@ -756,7 +751,8 @@ describe("TreeView Props", () => {
     expect(sqlItem).toHaveAttribute("aria-selected", "true");
     expect(db2Item).toHaveAttribute("aria-selected", "true");
 
-    expect(treeItemById(3)).toHaveAttribute("aria-selected", "false");
+    expect(document.getElementById("3")).toBeNull();
+    expect(component.selectedIds).not.toContain(3);
   });
 
   it("multiselectMode deep selects all descendants", async () => {
@@ -839,7 +835,7 @@ describe("TreeView Props", () => {
   });
 
   it("shift+click range only includes visible (expanded) nodes", async () => {
-    render(TreeViewMultiselect, {
+    const { component } = render(TreeViewMultiselect, {
       multiselect: true,
       multiselectMode: "node",
       selectedIds: [],
@@ -861,7 +857,8 @@ describe("TreeView Props", () => {
 
     // Children of collapsed parents should NOT be selected
     // (e.g., id=2 "IBM Analytics Engine" is a child of collapsed Analytics)
-    expect(treeItemById(2)).toHaveAttribute("aria-selected", "false");
+    expect(document.getElementById("2")).toBeNull();
+    expect(component.selectedIds).not.toContain(2);
   });
 
   it("shift+click range includes children when parent is expanded", async () => {
@@ -1014,7 +1011,7 @@ describe("TreeView Props", () => {
   });
 
   it("shift+click range selection in shallow mode expands each ranged node to its direct children", async () => {
-    render(TreeViewMultiselect, {
+    const { component } = render(TreeViewMultiselect, {
       multiselect: true,
       multiselectMode: "shallow",
       selectedIds: [],
@@ -1032,14 +1029,18 @@ describe("TreeView Props", () => {
 
     // Range covers AI (0), Analytics (1), Blockchain (7); each expands to
     // itself plus its direct (non-disabled) children.
-    for (const id of [0, 1, 2, 5, 6, 7, 8]) {
+    for (const id of [0, 1, 7]) {
       expect(treeItemById(id)).toHaveAttribute("aria-selected", "true");
     }
+    expect(component.selectedIds).toEqual(
+      expect.arrayContaining([0, 1, 2, 5, 6, 7, 8]),
+    );
 
     // Nodes outside the range are not selected, and shallow mode does not
     // recurse past direct children (id 3 is a grandchild of Analytics).
     expect(treeItemById(9)).toHaveAttribute("aria-selected", "false");
-    expect(treeItemById(3)).toHaveAttribute("aria-selected", "false");
+    expect(component.selectedIds).not.toContain(9);
+    expect(component.selectedIds).not.toContain(3);
   });
 
   it("multiselect tree has bx--tree--multiselect class", () => {
@@ -1333,6 +1334,13 @@ describe("TreeView Generics", () => {
       render(TreeViewGenerics, { props: { onselect } });
 
       await user.click(treeItemById("electronics"));
+
+      const toggle = treeItemById("electronics").querySelector(
+        ".bx--tree-parent-node__toggle",
+      );
+      expect.assert(toggle instanceof HTMLElement);
+      await user.click(toggle);
+
       await user.click(treeItemById("laptop"));
 
       expect(onselect).toHaveBeenLastCalledWith(


### PR DESCRIPTION
Collapsed TreeView branches mount on first expansion and stay mounted,
so collapsed mount and `nodes` updates scale with visible nodes instead
of the whole tree. MultiSelect's default `sortItem` reuses one
`Intl.Collator` keyed on `locale`. `filterMode: "hide"` still
rerenders every row per keystroke; that's documented on the prop, not
fixed.

## Benchmark

`perf(multi-select): cache Intl.Collator for default item sorting`

| Scenario | Before | After |
| --- | --- | --- |
| Sort 10k items | 1x | ~10x faster |
| Mount 1000 virtualized items | 1x | ~3x faster |

`perf(tree-view): mount collapsed subtrees lazily on first expansion`

| Scenario | Before | After |
| --- | --- | --- |
| Collapsed mount | 1x | ~3.5x faster |
| Non-virtualized `nodes` update at 1k | 1x | ~120x faster |
