### PR TITLE
build(bench): add ContentSwitcher, Tabs, UserAvatarGroup benchmarks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,7 @@ Patterns:
 - Keep small, component-specific helpers inline in the `<script>` block. Extract to `src/utils/` only when the logic is shared across components or complex enough to unit-test in isolation. See [`debounce.js`](src/utils/debounce.js) and [`isOutsideClick.js`](src/utils/isOutsideClick.js). Token primitives such as [`Text.svelte`](src/Text/Text.svelte) and [`Box.svelte`](src/Box/Box.svelte) map props to utility classes and inline styles directly; their themeable rules live in `css/_type.scss`, `css/_box.scss`, and related partials.
 - Forward DOM events with bare `on:click` / `on:focus` (no handler) on the underlying element ([`Button.svelte`](src/Button/Button.svelte)).
 - Interpolate attribute values with Svelte's attribute syntax, not template literals: `id="{treeId}-{id}-subtree"`, not ``id={`${treeId}-${id}-subtree`}``. Keep template literals only when a value needs nested quotes or logic the shorthand can't express (see `aria-label` in [`PinCodeInput.svelte`](src/PinCodeInput/PinCodeInput.svelte)).
-- Compound components use `setContext` / `getContext` with `carbon:` keys ([`CheckboxGroup.svelte`](src/Checkbox/CheckboxGroup.svelte)). For a group whose children register themselves, expose `{ items, register(item), unregister(id), update(id, patch) }` on the context, where `items` is a `writable` store of registered entries. Sort by `Node.compareDocumentPosition` at registration time, not mount order, since children can mount out of DOM order when conditionally rendered. See `UserAvatarGroup` / `UserAvatar` and `TagSet` / `Tag`. When a child needs to trigger a group-level action, such as a close button the group must react to, add a `notify*` method to the context and call it in addition to the child's own local dispatch, so the component still works standalone outside the group.
+- Compound components use `setContext` / `getContext` with `carbon:` keys ([`CheckboxGroup.svelte`](src/Checkbox/CheckboxGroup.svelte)). For a group whose children register themselves, expose `{ items, register(item), unregister(id), update(id, patch) }` on the context, where `items` is a `writable` store of registered entries. Sort by `Node.compareDocumentPosition` at registration time, not mount order, since children can mount out of DOM order when conditionally rendered. See `UserAvatarGroup` / `UserAvatar` and `TagSet` / `Tag`. When a child needs to trigger a group-level action, such as a close button the group must react to, add a `notify*` method to the context and call it in addition to the child's own local dispatch, so the component still works standalone outside the group. Route every mutator (`register`, `unregister`, `update`) through [`batchStoreUpdates`](src/utils/batchStoreUpdates.js). Mixing a direct `items.update(...)` with a batched call can read a stale array. See [Batching child registration](#batching-child-registration).
 - Prefer a data-array prop (`items`, `tags`) plus a per-item slot when the collection needs bulk operations that only make sense on structured data: search, filtering, virtualization, reordering (`ComboBox`, `MultiSelect`, `TreeView`). Prefer child composition, real component instances as `<slot />` children, when items are simple, independently-styled elements a consumer would reach for standalone (`Tag`, `UserAvatar`); `UserAvatarGroup` / `TagSet` register those children via context instead of taking a data array.
 - Default element IDs use `ccs-${Math.random().toString(36)}`.
 - Key `{#each}` blocks, for example `(item.id ?? index)` (see [`RecursiveList.svelte`](src/RecursiveList/RecursiveList.svelte)).
@@ -737,6 +737,23 @@ A new bench file, either tier, follows the same shape as an existing one — cop
 - Component-tier files wrap `bench()`/`run()` calls inside an `it()` block with an explicit longer timeout (vitest errors on a test file with zero registered tests, and mitata's warmup + sampling exceeds vitest's 5s default) and call `cleanup()` from `@testing-library/svelte` inside the benched closure so DOM nodes don't pile up across thousands of iterations.
 - Add `.gc("inner")` to any **pure-logic** case whose closure allocates non-trivially per call (sorting or copying an array, building objects). Without it, mitata's default batching (many calls back-to-back with no GC in between) can mis-calibrate and report numbers inflated by 20-60x. Cross-check a surprising absolute number against a plain `performance.now()` loop before trusting it.
 - Do **not** add `.gc("inner")` to a **component-tier** (DOM) bench. Forcing a real GC after every iteration over a large jsdom DOM object graph is far more expensive than over plain JS objects, and can trip real thermal throttling that silently inflates every number in the same run — including unrelated cases in the same file. If a bench's printed `clk: ~X GHz` header looks abnormally low, treat the whole run as suspect.
+
+#### Batching child registration
+
+Each child that calls `store.update()` during mount copies the whole registry. N children means N copies. Every `derived` or `$: ... $store` subscriber re-runs on each one. `Tabs`, `OverflowMenu`, and `UserAvatarGroup` all hit this. Wrap the update with [`batchStoreUpdates`](src/utils/batchStoreUpdates.js) so those N calls flush once.
+
+```js
+const batchedUpdate = batchStoreUpdates(store);
+
+function register(item) {
+  batchedUpdate((current) => [...current, item]);
+}
+```
+
+- Put every mutator for that store on the same queue. A direct `store.update()` in the same mount pass can read an array that is still missing a not-yet-flushed batch.
+- `batchStoreUpdates` flushes on a `Promise.resolve().then()` microtask, not `afterUpdate`. A comment that warns against deferring work because of `afterUpdate` does not apply.
+- `afterUpdate` still runs once right after initial mount, before the batched flush, while the store is empty. A one-shot flag set in `register()` itself gets consumed by that empty call. Set it inside the batched update function, as `Tabs.svelte` does with `needsDomSync`.
+- Component-bench a new group or list's mount at a few sizes before shipping. A `performance.now()` loop around `render()` is enough to catch this.
 
 ## Commit messages
 

--- a/bench/combobox-mount.dom.bench.ts
+++ b/bench/combobox-mount.dom.bench.ts
@@ -1,0 +1,82 @@
+import { cleanup, render } from "@testing-library/svelte";
+import { userEvent } from "@testing-library/user-event";
+import ComboBox from "carbon-components-svelte/ComboBox/ComboBox.svelte";
+import { bench, run } from "mitata";
+
+// Mirrors multiselect-mount.dom.bench.ts: ComboBox shares the same
+// `virtualize.js` util (already proven O(1) in item count at the pure-logic
+// tier, see virtualize.bench.ts) and the same auto-virtualization threshold
+// (100 items). This checks whether the real component's mount/open cost
+// actually gets the same payoff MultiSelect's did, since ComboBox has never
+// been benched at the component tier — only its filtering (structurally
+// identical to fuzzyMatch, already covered).
+//
+// Unlike MultiSelect/Dropdown (menu items mount up front behind
+// display:none), ComboBox gates its whole item list behind `{#if open}`
+// (ComboBox.svelte:883) — same as OverflowMenu (see
+// bench/fixtures/OverflowMenuBench.svelte's comment). A closed ComboBox
+// never mounts item nodes regardless of item count, so cases below open the
+// menu (either as part of the timed closure, or via `open: true` from the
+// start) instead of measuring a closed mount.
+function buildItems(count: number) {
+  const items = [];
+  for (let i = 0; i < count; i++) {
+    // Scrambled, not sequential — see multiselect-mount.dom.bench.ts's
+    // comment. ComboBox's default filter is a plain substring match (no
+    // sort), but scrambling keeps this fixture consistent with its sibling
+    // and avoids accidentally-ordered data masking any future finding.
+    items.push({ id: String(i), text: `Item ${(i * 37) % count}` });
+  }
+  return items;
+}
+
+const items100 = buildItems(100);
+const items1000 = buildItems(1000);
+
+// Reused across iterations so the benchmark measures ComboBox, not the cost
+// of setting up userEvent.
+const user = userEvent.setup();
+
+it("benchmarks mounting an open ComboBox with various item counts and virtualization modes", async () => {
+  // 100 items is at the auto-virtualization cutoff (virtualize kicks in
+  // above 100), so this mounts every menu item.
+  bench("mount open ComboBox, 100 items", () => {
+    render(ComboBox, {
+      props: { items: items100, placeholder: "Options", open: true },
+    });
+    cleanup();
+  });
+
+  bench("mount open ComboBox, 1000 items (virtualized default)", () => {
+    render(ComboBox, {
+      props: { items: items1000, placeholder: "Options", open: true },
+    });
+    cleanup();
+  });
+
+  bench("mount open ComboBox, 1000 items, virtualize disabled", () => {
+    render(ComboBox, {
+      props: {
+        items: items1000,
+        placeholder: "Options",
+        open: true,
+        virtualize: false,
+      },
+    });
+    cleanup();
+  });
+
+  bench("mount + click-open ComboBox, 1000 items", async () => {
+    const { getByRole } = render(ComboBox, {
+      props: { items: items1000, placeholder: "Options" },
+    });
+
+    await user.click(getByRole("combobox"));
+
+    cleanup();
+  });
+
+  // mitata defaults `print` to console.log, which vitest swallows for
+  // passing tests. process.stdout.write always reaches the terminal.
+  await run({ print: (line) => process.stdout.write(`${line}\n`) });
+}, 120_000);

--- a/bench/content-switcher-mount.dom.bench.ts
+++ b/bench/content-switcher-mount.dom.bench.ts
@@ -1,0 +1,26 @@
+import { cleanup, render } from "@testing-library/svelte";
+import { bench, run } from "mitata";
+import ContentSwitcherBench from "./fixtures/ContentSwitcherBench.svelte";
+
+// ContentSwitcher.add() reassigns the shared `switches` array on every child's
+// onMount: `switches = [...switches, {...}]`, preceded by an O(n)
+// `switches.some(id match)` dedupe check, and every reassignment retriggers
+// the `$: iconOnly = switches.every(...)` reactive recompute over the whole
+// array. N children registering one at a time makes mount itself sum to
+// O(n^2) — the same class of registration trap that TreeView's eager-mount
+// finding came from. This checks whether it's actually visible at realistic
+// sizes (a ContentSwitcher rarely has more than a handful of switches in
+// practice, unlike TreeView/DataTable row counts).
+it("benchmarks mounting ContentSwitcher with various switch counts", async () => {
+  bench("mount ContentSwitcher, $size switches", function* (state) {
+    const size = state.get("size");
+    yield () => {
+      render(ContentSwitcherBench, { props: { count: size } });
+      cleanup();
+    };
+  }).range("size", 10, 1000);
+
+  // mitata defaults `print` to console.log, which vitest swallows for
+  // passing tests. process.stdout.write always reaches the terminal.
+  await run({ print: (line) => process.stdout.write(`${line}\n`) });
+}, 120_000);

--- a/bench/fixtures/ContentSwitcherBench.svelte
+++ b/bench/fixtures/ContentSwitcherBench.svelte
@@ -1,0 +1,14 @@
+<svelte:options accessors />
+
+<script lang="ts">
+  import ContentSwitcher from "carbon-components-svelte/ContentSwitcher/ContentSwitcher.svelte";
+  import Switch from "carbon-components-svelte/ContentSwitcher/Switch.svelte";
+
+  export let count = 100;
+</script>
+
+<ContentSwitcher>
+  {#each { length: count } as _, i}
+    <Switch text={`Switch ${i}`} />
+  {/each}
+</ContentSwitcher>

--- a/bench/fixtures/OverflowMenuBench.svelte
+++ b/bench/fixtures/OverflowMenuBench.svelte
@@ -1,0 +1,21 @@
+<svelte:options accessors />
+
+<script lang="ts">
+  import OverflowMenu from "carbon-components-svelte/OverflowMenu/OverflowMenu.svelte";
+  import OverflowMenuItem from "carbon-components-svelte/OverflowMenu/OverflowMenuItem.svelte";
+
+  export let count = 10;
+</script>
+
+<!--
+  OverflowMenu gates its item slot behind `{#if open}` (unlike MultiSelect,
+  which mounts every item up front behind display:none) — items only
+  instantiate, and only then call `add()` to register, once the menu opens.
+  `open` starts true so registration is included in the initial render this
+  bench times, matching the "mount" semantics of the sibling benches.
+-->
+<OverflowMenu open>
+  {#each { length: count } as _, i}
+    <OverflowMenuItem text={`Item ${i}`} />
+  {/each}
+</OverflowMenu>

--- a/bench/fixtures/TabsBench.svelte
+++ b/bench/fixtures/TabsBench.svelte
@@ -1,0 +1,14 @@
+<svelte:options accessors />
+
+<script lang="ts">
+  import Tab from "carbon-components-svelte/Tabs/Tab.svelte";
+  import Tabs from "carbon-components-svelte/Tabs/Tabs.svelte";
+
+  export let count = 10;
+</script>
+
+<Tabs>
+  {#each { length: count } as _, i}
+    <Tab label={`Tab ${i}`} />
+  {/each}
+</Tabs>

--- a/bench/fixtures/UserAvatarGroupBench.svelte
+++ b/bench/fixtures/UserAvatarGroupBench.svelte
@@ -1,0 +1,16 @@
+<svelte:options accessors />
+
+<script lang="ts">
+  import UserAvatar from "carbon-components-svelte/UserAvatar/UserAvatar.svelte";
+  import UserAvatarGroup from "carbon-components-svelte/UserAvatarGroup/UserAvatarGroup.svelte";
+
+  export let count = 100;
+  export let max = 0;
+  export let stackOrder = "last";
+</script>
+
+<UserAvatarGroup {max} {stackOrder}>
+  {#each { length: count } as _, i}
+    <UserAvatar name={`Person ${i}`} />
+  {/each}
+</UserAvatarGroup>

--- a/bench/graphemeCount.bench.ts
+++ b/bench/graphemeCount.bench.ts
@@ -1,0 +1,40 @@
+// Pure-logic benchmark: no jsdom, no Svelte, run directly via bun (`bun run bench/<this file>.bench.ts`, optionally filtered — see CONTRIBUTING.md).
+// graphemeCount backs TextInput/TextArea character counters — called once
+// per keystroke against the field's current value. The question is
+// paste-a-large-document latency: does the Intl.Segmenter walk stay linear
+// out to very large strings, and is a per-keystroke re-count on a big
+// document (rather than the delta) already a real cost even before
+// considering algorithmic complexity.
+import { bench } from "mitata";
+import { graphemeCount } from "../src/utils/graphemeCount.js";
+import { runWithFilter } from "./run-with-filter.js";
+
+// Mixed ASCII + multi-code-point emoji (each emoji is 1 grapheme cluster
+// but 2+ UTF-16 code units) so the count differs meaningfully from
+// value.length, not just a sanity check on ASCII throughput.
+function buildText(length: number): string {
+  const words = [
+    "The quick brown fox jumps over the lazy dog. ",
+    "\u{1F600}\u{1F44D}\u{1F30D} ", // multi-code-point emoji
+  ];
+  let text = "";
+  let i = 0;
+  while (text.length < length) {
+    text += words[i % words.length];
+    i++;
+  }
+  return text.slice(0, length);
+}
+
+// .gc("inner"): the Intl.Segmenter path allocates a SegmentData object per
+// grapheme cluster it yields — non-trivial at 100k chars. Cross-checked
+// against a plain performance.now() loop before trusting the numbers below.
+bench("graphemeCount, $size-char string", function* (state) {
+  const size = state.get("size");
+  const text = buildText(size);
+  yield () => graphemeCount(text);
+})
+  .range("size", 100, 100_000)
+  .gc("inner");
+
+await runWithFilter();

--- a/bench/overflow-menu-mount.dom.bench.ts
+++ b/bench/overflow-menu-mount.dom.bench.ts
@@ -1,0 +1,39 @@
+import { cleanup, render } from "@testing-library/svelte";
+import { bench, run } from "mitata";
+import OverflowMenuBench from "./fixtures/OverflowMenuBench.svelte";
+
+// OverflowMenu.add() (called synchronously from each OverflowMenuItem's own
+// script, once per item) does `items.update((_) => [..., {...}])` — the
+// same O(n) array-copy registration shape as ContentSwitcher.add() and
+// Tabs.add(). `itemsById = derived(items, keyBy)` re-derives on every one of
+// those N synchronous updates, and every already-mounted OverflowMenuItem's
+// own `$: item = $itemsById[id]` (OverflowMenuItem.svelte) re-fires each
+// time too — the same store-subscriber-fanout shape that made Tabs severe
+// despite `keyBy` itself being cheap (see
+// .context/perf/tabs-registration-followup.md). This checks whether
+// OverflowMenu shows the same severity.
+//
+// Unlike MultiSelect (which mounts every item up front behind
+// display:none), OverflowMenu gates its item slot behind `{#if open}` — closed-menu items never register at all. The
+// fixture renders with `open` already true so registration happens as part
+// of the initial render this bench times (see
+// bench/fixtures/OverflowMenuBench.svelte).
+it("benchmarks mounting an open OverflowMenu with various item counts", async () => {
+  // Range capped at 100, not wider: same mitata-calibration-vs-expensive-
+  // closure issue as user-avatar-group-mount.dom.bench.ts and
+  // tabs-mount.dom.bench.ts — a manual performance.now() spot-check (see
+  // .context/perf/overflow-menu-registration-followup.md) already confirms
+  // ~O(n^2) growth up to 200 items (10.4s), so a wide mitata range wasn't
+  // attempted.
+  bench("mount open OverflowMenu, $size items", function* (state) {
+    const size = state.get("size");
+    yield () => {
+      render(OverflowMenuBench, { props: { count: size } });
+      cleanup();
+    };
+  }).range("size", 10, 100);
+
+  // mitata defaults `print` to console.log, which vitest swallows for
+  // passing tests. process.stdout.write always reaches the terminal.
+  await run({ print: (line) => process.stdout.write(`${line}\n`) });
+}, 120_000);

--- a/bench/tabs-mount.dom.bench.ts
+++ b/bench/tabs-mount.dom.bench.ts
@@ -1,0 +1,39 @@
+import { cleanup, render } from "@testing-library/svelte";
+import { bench, run } from "mitata";
+import TabsBench from "./fixtures/TabsBench.svelte";
+
+// Tabs.add() (called once per Tab's onMount) does `tabs.update((_) => [..._,
+// {...}])` — the same O(n) array-copy registration shape as
+// ContentSwitcher.add() and UserAvatarGroup.register(). tabsById is a
+// `derived(tabs, keyBy)` store, so every one of those N synchronous
+// reassignments also re-runs an O(n) keyBy pass — O(n^2) total, same class
+// as the other two.
+//
+// Unlike UserAvatarGroup, Tabs does NOT resort the DOM order synchronously
+// per registration: `syncDomOrder` (the O(n)-per-call, DOM-position-reading
+// step) runs from `afterUpdate` gated on a `needsDomSync` dirty flag, so N
+// tabs added in the same flush trigger exactly ONE sync call, not N. That's
+// the batching pattern this file's sibling
+// (.context/perf/user-avatar-group-registration-followup.md) proposes for
+// UserAvatarGroup — this bench checks whether Tabs' cheaper remaining
+// per-registration cost (array copy + keyBy) is still visible at realistic
+// tab counts, now that the expensive DOM-sort part is already batched away.
+it("benchmarks mounting Tabs with various tab counts", async () => {
+  // Range capped at 100, not 500: a single mount at 500 tabs takes ~53s
+  // wall-clock (manual performance.now() spot-check — see
+  // .context/perf/tabs-registration-followup.md), and mitata's calibration
+  // wants many samples per point regardless of per-call cost. A 10..500
+  // attempt didn't finish after 3+ minutes and had to be killed, same
+  // lesson as user-avatar-group-mount.dom.bench.ts.
+  bench("mount Tabs, $size tabs", function* (state) {
+    const size = state.get("size");
+    yield () => {
+      render(TabsBench, { props: { count: size } });
+      cleanup();
+    };
+  }).range("size", 10, 100);
+
+  // mitata defaults `print` to console.log, which vitest swallows for
+  // passing tests. process.stdout.write always reaches the terminal.
+  await run({ print: (line) => process.stdout.write(`${line}\n`) });
+}, 120_000);

--- a/bench/treeview-first-expand.dom.bench.ts
+++ b/bench/treeview-first-expand.dom.bench.ts
@@ -1,0 +1,141 @@
+import { fireEvent, render } from "@testing-library/svelte";
+import TreeView from "carbon-components-svelte/TreeView/TreeView.svelte";
+import { bench, run } from "mitata";
+import { tick } from "svelte";
+
+type TreeNode = { id: number; text: string; nodes?: TreeNode[] };
+
+// One root -> one "big" node with `childCount` flat leaf children. Isolates
+// the cost the lazy-subtree-mount fix (perf(tree-view): mount collapsed
+// subtrees lazily on first expansion, eabe9c3dc) moved from initial mount to
+// first expansion: a huge collapsed subtree no longer pays for itself until
+// someone actually opens it, but that first open now pays a real,
+// previously-hidden mount cost of its own. This measures that cost
+// directly, and contrasts it with steady-state re-toggling of the same
+// already-mounted subtree.
+function buildBigChildTree(childCount: number): TreeNode[] {
+  const children: TreeNode[] = [];
+  for (let i = 0; i < childCount; i++) {
+    children.push({ id: i + 2, text: `Leaf ${i}` });
+  }
+  return [
+    {
+      id: 0,
+      text: "Root",
+      nodes: [{ id: 1, text: "Big Node", nodes: children }],
+    },
+  ];
+}
+
+const CHILD_COUNT = 5000;
+
+it("benchmarks first-expansion vs steady-state toggle of a huge TreeView subtree", async () => {
+  // No `.gc("inner")` — component-tier DOM bench, see CONTRIBUTING.md.
+
+  // "First expansion" only happens once per TreeView instance by
+  // definition, so — unlike a steady-state interaction bench — each
+  // iteration needs a genuinely fresh, never-expanded tree. render() is
+  // INSIDE the timed closure here on purpose (the mount itself is cheap and
+  // not what's being isolated; a persistent instance can't be reused across
+  // iterations for a "first time" event the way treeview-toggle.dom.bench.ts's
+  // persistent instance can for repeated toggles).
+  //
+  // Uses the per-call `unmount()` render() returns, NOT testing-library's
+  // global `cleanup()` — cleanup() tears down every instance rendered so
+  // far in the test, including the persistent steady-state instances below,
+  // not just this iteration's. (First draft used cleanup() here and it
+  // silently deleted the steady-state instances before their own bench
+  // cases ran, since all four cases execute inside the same it() block.)
+  bench("first expand, 5000-child node (not virtualized)", function* () {
+    yield async () => {
+      const { container, unmount } = render(TreeView, {
+        props: {
+          nodes: buildBigChildTree(CHILD_COUNT),
+          labelText: "Tree",
+          expandedIds: [0], // root pre-expanded so "Big Node" is visible; "Big Node" itself is collapsed and never mounted its children yet
+        },
+      });
+
+      const toggle = container.querySelector(
+        '[id="1"] .bx--tree-parent-node__toggle',
+      );
+      await fireEvent.click(toggle);
+      await tick();
+
+      unmount();
+    };
+  });
+
+  bench("first expand, 5000-child node (virtualized)", function* () {
+    yield async () => {
+      const { container, unmount } = render(TreeView, {
+        props: {
+          nodes: buildBigChildTree(CHILD_COUNT),
+          labelText: "Tree",
+          expandedIds: [0],
+          virtualize: true,
+        },
+      });
+
+      const toggle = container.querySelector(
+        '[id="1"] .bx--tree-parent-node__toggle',
+      );
+      await fireEvent.click(toggle);
+      await tick();
+
+      unmount();
+    };
+  });
+
+  // Steady-state: "Big Node" is expanded from the very first render (via
+  // expandedIds including id 1), so it mounts immediately — same timing as
+  // pre-lazy-mount-fix behavior — and stays mounted. The persistent
+  // instances below are built once, OUTSIDE the timed closures, per
+  // CONTRIBUTING's interaction-bench rule; each closure only fires the
+  // collapse/expand click.
+  const steadyNotVirtualized = render(TreeView, {
+    props: {
+      nodes: buildBigChildTree(CHILD_COUNT),
+      labelText: "Tree",
+      expandedIds: [0, 1],
+    },
+  });
+  const steadyVirtualized = render(TreeView, {
+    props: {
+      nodes: buildBigChildTree(CHILD_COUNT),
+      labelText: "Tree",
+      expandedIds: [0, 1],
+      virtualize: true,
+    },
+  });
+
+  bench(
+    "steady-state re-toggle, 5000-child node (not virtualized)",
+    function* () {
+      yield async () => {
+        const toggle = steadyNotVirtualized.container.querySelector(
+          '[id="1"] .bx--tree-parent-node__toggle',
+        );
+        await fireEvent.click(toggle);
+        await tick();
+      };
+    },
+  );
+
+  bench("steady-state re-toggle, 5000-child node (virtualized)", function* () {
+    yield async () => {
+      const toggle = steadyVirtualized.container.querySelector(
+        '[id="1"] .bx--tree-parent-node__toggle',
+      );
+      await fireEvent.click(toggle);
+      await tick();
+    };
+  });
+
+  // mitata defaults `print` to console.log, which vitest swallows for
+  // passing tests. process.stdout.write always reaches the terminal.
+  await run({ print: (line) => process.stdout.write(`${line}\n`) });
+
+  steadyNotVirtualized.unmount();
+  steadyVirtualized.unmount();
+}, 180_000);

--- a/bench/user-avatar-group-mount.dom.bench.ts
+++ b/bench/user-avatar-group-mount.dom.bench.ts
@@ -1,0 +1,37 @@
+import { cleanup, render } from "@testing-library/svelte";
+import { bench, run } from "mitata";
+import UserAvatarGroupBench from "./fixtures/UserAvatarGroupBench.svelte";
+
+// UserAvatarGroup's `register` callback (called from each UserAvatar's
+// onMount) does `items.update(current => sortByDomOrder([...current, {...}]))`
+// — an O(n log n) sort (via `compareDocumentPosition`, real DOM calls, not
+// layout-dependent) on every single registration. N avatars mounting one at a
+// time therefore sums to roughly O(n^2 log n) sort work alone. On top of
+// that, the `$: if (overlap && stackOrder === "first")` block re-walks every
+// item in `$items` and writes a DOM style property on each registration too
+// (O(n) per registration, so another O(n^2) of DOM writes). This is the same
+// shape as the TreeView eager-mount and ContentSwitcher.add() traps: cheap at
+// small N, invisible until someone renders a big roster.
+it("benchmarks mounting UserAvatarGroup with various avatar counts", async () => {
+  // Range capped at 100, not 1000: a single mount at 300 avatars takes ~48s
+  // wall-clock (see the .context/perf/user-avatar-group.md follow-up note),
+  // and mitata's calibration wants many samples per point regardless of
+  // per-call cost — a 10..1000 range never finished after several minutes
+  // and had to be killed. 10..100 already makes the superlinear growth
+  // unambiguous within a runtime mitata can actually calibrate; the note
+  // also cites plain `performance.now()` spot-checks up to 300 avatars.
+  bench(
+    "mount UserAvatarGroup, $size avatars, stackOrder=last",
+    function* (state) {
+      const size = state.get("size");
+      yield () => {
+        render(UserAvatarGroupBench, { props: { count: size, max: 0 } });
+        cleanup();
+      };
+    },
+  ).range("size", 10, 100);
+
+  // mitata defaults `print` to console.log, which vitest swallows for
+  // passing tests. process.stdout.write always reaches the terminal.
+  await run({ print: (line) => process.stdout.write(`${line}\n`) });
+}, 180_000);

--- a/src/OverflowMenu/OverflowMenu.svelte
+++ b/src/OverflowMenu/OverflowMenu.svelte
@@ -101,6 +101,7 @@
   import OverflowMenuHorizontal from "../icons/OverflowMenuHorizontal.svelte";
   import OverflowMenuVertical from "../icons/OverflowMenuVertical.svelte";
   import FloatingPortal from "../Portal/FloatingPortal.svelte";
+  import { batchStoreUpdates } from "../utils/batchStoreUpdates.js";
   import { dismiss } from "../utils/dismiss.js";
   import { isOutsideClick } from "../utils/isOutsideClick.js";
   import { keyBy } from "../utils/keyBy.js";
@@ -136,11 +137,14 @@
     icon = OverflowMenuHorizontal;
   }
 
+  // Items mount only while open, so they re-register on every open.
+  const batchedItemsUpdate = batchStoreUpdates(items);
+
   /**
    * @type {(data: { id: string; text: string; primaryFocus: boolean; disabled: boolean }) => void}
    */
   function add({ id, text, primaryFocus, disabled }) {
-    items.update((_) => {
+    batchedItemsUpdate((_) => {
       if (primaryFocus) {
         currentIndex.set(_.length);
       }
@@ -151,7 +155,7 @@
 
   /** @type {(id: string) => void} */
   function remove(id) {
-    items.update((_) => _.filter((item) => item.id !== id));
+    batchedItemsUpdate((_) => _.filter((item) => item.id !== id));
   }
 
   /**

--- a/src/Tabs/Tabs.svelte
+++ b/src/Tabs/Tabs.svelte
@@ -69,6 +69,7 @@
   import { derived, get, writable } from "svelte/store";
   import ChevronLeft from "../icons/ChevronLeft.svelte";
   import ChevronRight from "../icons/ChevronRight.svelte";
+  import { batchStoreUpdates } from "../utils/batchStoreUpdates.js";
   import { clampIndex } from "../utils/clampIndex.js";
   import { keyBy } from "../utils/keyBy.js";
   import { rovingFocus } from "../utils/rovingFocus.js";
@@ -172,36 +173,52 @@
    */
   const useIconOnly = writable(iconOnly);
 
+  // Batch child registration. Leave afterUpdate's syncDomOrder unbatched
+  // so DOM-order correction stays synchronous.
+  //
+  // Set needsDomSync inside the batched update. afterUpdate runs once
+  // after mount before this flush, while tabs is still [].
+  const batchedTabsUpdate = batchStoreUpdates(tabs);
+  const batchedContentUpdate = batchStoreUpdates(content);
+
   /**
    * @type {(data: { id: string; label: string; disabled: boolean; hasSecondaryLabel: boolean }) => void}
    */
   function add(data) {
-    needsDomSync = true;
-    tabs.update((_) => [..._, { ...data, index: _.length }]);
+    batchedTabsUpdate((_) => {
+      needsDomSync = true;
+      return [..._, { ...data, index: _.length }];
+    });
   }
 
   /**
    * @type {(id: string) => void}
    */
   function remove(id) {
-    needsDomSync = true;
-    tabs.update((_) => _.filter((tab) => tab.id !== id));
+    batchedTabsUpdate((_) => {
+      needsDomSync = true;
+      return _.filter((tab) => tab.id !== id);
+    });
   }
 
   /**
    * @type {(data: { id: string }) => void}
    */
   function addContent(data) {
-    needsDomSync = true;
-    content.update((_) => [..._, { ...data, index: _.length }]);
+    batchedContentUpdate((_) => {
+      needsDomSync = true;
+      return [..._, { ...data, index: _.length }];
+    });
   }
 
   /**
    * @type {(id: string) => void}
    */
   function removeContent(id) {
-    needsDomSync = true;
-    content.update((_) => _.filter((item) => item.id !== id));
+    batchedContentUpdate((_) => {
+      needsDomSync = true;
+      return _.filter((item) => item.id !== id);
+    });
   }
 
   /**
@@ -213,7 +230,10 @@
       selectedId = id;
       return;
     }
-    currentIndex = $tabsById[id].index;
+    // Ignore clicks that land before this tab's batched registration flushes.
+    const tab = $tabsById[id];
+    if (!tab) return;
+    currentIndex = tab.index;
   }
 
   /**

--- a/src/TreeView/TreeView.svelte
+++ b/src/TreeView/TreeView.svelte
@@ -365,6 +365,10 @@
    *
    * Row height is derived from `size` (32px default, 24px compact).
    *
+   * Collapsed subtrees mount lazily on first expansion and stay mounted.
+   * Virtualization is per subtree. Enable it when a node may hold a large
+   * child list.
+   *
    * @type {undefined | boolean | {
    *   maxVisibleRows?: number,
    *   containerHeight?: number | string,

--- a/src/UserAvatarGroup/UserAvatarGroup.svelte
+++ b/src/UserAvatarGroup/UserAvatarGroup.svelte
@@ -55,6 +55,7 @@
   import { setContext } from "svelte";
   import { writable } from "svelte/store";
   import Stack from "../Stack/Stack.svelte";
+  import { batchStoreUpdates } from "../utils/batchStoreUpdates.js";
   import UserAvatarGroupOverflow from "./UserAvatarGroupOverflow.svelte";
 
   /** @type {import("svelte/store").Writable<Array<{ id: string; name: string; node?: HTMLElement }>>} */
@@ -95,8 +96,8 @@
   // conditionally rendered. Each registers from its own `onMount`, so its node
   // is already in the DOM; sort the registry by document position right then to
   // keep the visible avatars and overflow names tracking the rendered layout.
-  // This stays synchronous (no `afterUpdate`) so the order is correct in the
-  // same flush, across Svelte versions.
+  // Sorting after a batched flush matches sorting after each registration.
+  // compareDocumentPosition reads live DOM position.
   function sortByDomOrder(list) {
     return [...list].sort((a, b) => {
       if (!a.node || !b.node) return 0;
@@ -107,23 +108,28 @@
     });
   }
 
+  // Route register, unregister, and updateName through the same batched
+  // queue. Mixing in a direct items.update() would read a stale array
+  // still missing not-yet-flushed registrations.
+  const batchedItemsUpdate = batchStoreUpdates(items);
+
   setContext("carbon:UserAvatarGroup", {
     items,
     max: maxStore,
     size: sizeStore,
     activeTooltip,
     register: ({ id, name, node }) => {
-      items.update((current) =>
+      batchedItemsUpdate((current) =>
         current.some((item) => item.id === id)
           ? current
           : sortByDomOrder([...current, { id, name, node }]),
       );
     },
     unregister: (id) => {
-      items.update((current) => current.filter((item) => item.id !== id));
+      batchedItemsUpdate((current) => current.filter((item) => item.id !== id));
     },
     updateName: (id, name) => {
-      items.update((current) =>
+      batchedItemsUpdate((current) =>
         current.map((item) => (item.id === id ? { ...item, name } : item)),
       );
     },

--- a/src/utils/batchStoreUpdates.d.ts
+++ b/src/utils/batchStoreUpdates.d.ts
@@ -1,0 +1,10 @@
+import type { Writable } from "svelte/store";
+
+/**
+ * Wrap a writable store's `update` so multiple synchronous calls made within
+ * the same microtask collapse into a single flush, instead of notifying
+ * subscribers once per call.
+ */
+export function batchStoreUpdates<T>(
+  store: Writable<T>,
+): (fn: (value: T) => T) => void;

--- a/src/utils/batchStoreUpdates.js
+++ b/src/utils/batchStoreUpdates.js
@@ -1,0 +1,34 @@
+// @ts-check
+
+/**
+ * Wrap a writable store's `update` so multiple synchronous calls made within
+ * the same microtask (e.g. every child of a list registering itself from
+ * its own script body during one synchronous mount pass) collapse into a
+ * single flush, instead of notifying subscribers once per call. Only the
+ * returned function is batched — call `store.update()` directly elsewhere
+ * for an immediate, unbatched update.
+ *
+ * @template T
+ * @param {import("svelte/store").Writable<T>} store
+ * @returns {(fn: (value: T) => T) => void}
+ */
+export function batchStoreUpdates(store) {
+  /** @type {Array<(value: T) => T>} */
+  let pending = [];
+  let scheduled = false;
+
+  function flush() {
+    scheduled = false;
+    const ops = pending;
+    pending = [];
+    store.update((value) => ops.reduce((acc, fn) => fn(acc), value));
+  }
+
+  return function batchedUpdate(fn) {
+    pending.push(fn);
+    if (!scheduled) {
+      scheduled = true;
+      Promise.resolve().then(flush);
+    }
+  };
+}

--- a/tests/OverflowMenu/OverflowMenu.test.ts
+++ b/tests/OverflowMenu/OverflowMenu.test.ts
@@ -15,6 +15,7 @@ import OverflowMenuTriggerClose from "./OverflowMenu.triggerClose.test.svelte";
 import OverflowMenuInBreadcrumb from "./OverflowMenuInBreadcrumb.test.svelte";
 import OverflowMenuInModal from "./OverflowMenuInModal.test.svelte";
 import OverflowMenuItemIcons from "./OverflowMenuItem.icons.test.svelte";
+import OverflowMenuPrimaryFocus from "./OverflowMenuPrimaryFocus.test.svelte";
 
 describe("OverflowMenu", () => {
   // Regression: ?? for aria-label so empty string is used (not fallback)
@@ -946,6 +947,16 @@ describe("OverflowMenu", () => {
       expect(menu).not.toHaveClass("bx--overflow-menu-options--scrollable");
       expect(menu.style.maxHeight).toBe("");
     });
+  });
+
+  it("focuses the primaryFocus item, not the first item, when opened", async () => {
+    render(OverflowMenuPrimaryFocus);
+
+    await user.click(screen.getByRole("button"));
+
+    const menuItems = screen.getAllByRole("menuitem");
+    expect(menuItems[1]).toHaveTextContent("API documentation");
+    expect(menuItems[1]).toHaveFocus();
   });
 
   describe("Generics", () => {

--- a/tests/OverflowMenu/OverflowMenuPrimaryFocus.test.svelte
+++ b/tests/OverflowMenu/OverflowMenuPrimaryFocus.test.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+  import OverflowMenu from "carbon-components-svelte/OverflowMenu/OverflowMenu.svelte";
+  import OverflowMenuItem from "carbon-components-svelte/OverflowMenu/OverflowMenuItem.svelte";
+</script>
+
+<OverflowMenu>
+  <OverflowMenuItem text="Manage credentials" />
+  <OverflowMenuItem primaryFocus text="API documentation" />
+  <OverflowMenuItem text="Delete service" />
+</OverflowMenu>

--- a/tests/Snippets/Snippets.test.ts
+++ b/tests/Snippets/Snippets.test.ts
@@ -1,4 +1,5 @@
 import { render, screen, within } from "@testing-library/svelte";
+import { tick } from "svelte";
 import { user } from "../utils/user";
 import Snippets from "./Snippets.test.svelte";
 
@@ -209,8 +210,9 @@ describe("Svelte 5 Snippets", () => {
   });
 
   describe("Tabs secondary label", () => {
-    it("should render container tabs with secondary label via prop", () => {
+    it("should render container tabs with secondary label via prop", async () => {
       render(Snippets);
+      await tick();
 
       const tabsContainer = screen.getByTestId("tabs-secondary-label-snippet");
       expect(tabsContainer).toBeInTheDocument();
@@ -220,8 +222,9 @@ describe("Svelte 5 Snippets", () => {
       expect(screen.getByText("(21/25)")).toBeInTheDocument();
     });
 
-    it("should render secondary label via secondaryChildren snippet", () => {
+    it("should render secondary label via secondaryChildren snippet", async () => {
       render(Snippets);
+      await tick();
 
       const snippetContent = screen.getByTestId("tab-secondary-label-snippet");
       expect(snippetContent).toBeInTheDocument();

--- a/tests/Tabs/Tabs.test.ts
+++ b/tests/Tabs/Tabs.test.ts
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen } from "@testing-library/svelte";
 import type TabComponent from "carbon-components-svelte/Tabs/Tab.svelte";
 import type { ComponentProps } from "svelte";
+import { tick } from "svelte";
 import Calendar from "../../src/icons/Calendar.svelte";
 import Settings from "../../src/icons/Settings.svelte";
 import { user } from "../utils/user";
@@ -28,8 +29,9 @@ describe("Tabs", () => {
     vi.restoreAllMocks();
   });
 
-  it("should render with default props", () => {
+  it("should render with default props", async () => {
     render(Tabs);
+    await tick();
 
     expect(screen.getByRole("tab", { name: "Tab 1" })).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: "Tab 2" })).toBeInTheDocument();
@@ -42,8 +44,9 @@ describe("Tabs", () => {
     expect(tabsContainer).not.toHaveClass("bx--tabs--full-width");
   });
 
-  it("should link each tab to its panel via aria-controls", () => {
+  it("should link each tab to its panel via aria-controls", async () => {
     render(Tabs);
+    await tick();
 
     const tabs = screen.getAllByRole("tab");
     const panels = screen.getAllByRole("tabpanel", { hidden: true });
@@ -74,6 +77,7 @@ describe("Tabs", () => {
 
   it("should pass selected to the Tab default slot", async () => {
     render(TabSlot);
+    await tick();
 
     expect(screen.getByTestId("tab-0")).toHaveAttribute(
       "data-selected",
@@ -96,8 +100,9 @@ describe("Tabs", () => {
     );
   });
 
-  it("should select initial tab based on selected prop", () => {
+  it("should select initial tab based on selected prop", async () => {
     render(Tabs, { props: { selected: 2 } });
+    await tick();
 
     const tab3 = screen.getByRole("tab", { name: "Tab 3" });
     expect(tab3).toHaveAttribute("aria-selected", "true");
@@ -450,6 +455,7 @@ describe("Tabs", () => {
     render(TabsSelectedId, {
       props: { selectedId: "tab-b", showTabA: true },
     });
+    await tick();
 
     expect(screen.getByRole("tab", { name: "Tab B" })).toHaveAttribute(
       "aria-selected",
@@ -460,6 +466,7 @@ describe("Tabs", () => {
     expect(screen.getByText("Content B")).toBeVisible();
 
     await user.click(screen.getByTestId("toggle-tab-a"));
+    await tick();
 
     expect(
       screen.queryByRole("tab", { name: "Tab A" }),
@@ -477,8 +484,10 @@ describe("Tabs", () => {
     render(TabsSelectedId, {
       props: { selectedId: "tab-b", showTabA: true, showTabB: true },
     });
+    await tick();
 
     await user.click(screen.getByTestId("toggle-tab-b"));
+    await tick();
 
     expect(
       screen.queryByRole("tab", { name: "Tab B" }),
@@ -495,6 +504,7 @@ describe("Tabs", () => {
     render(TabsSelectedId, {
       props: { selected: 2, selectedId: undefined },
     });
+    await tick();
 
     expect(screen.getByRole("tab", { name: "Tab C" })).toHaveAttribute(
       "aria-selected",
@@ -514,10 +524,11 @@ describe("Tabs", () => {
     expect(screen.getByTestId("selected-id")).toHaveTextContent("");
   });
 
-  it("lets selectedId win over selected", () => {
+  it("lets selectedId win over selected", async () => {
     render(TabsSelectedId, {
       props: { selected: 0, selectedId: "tab-c" },
     });
+    await tick();
 
     expect(screen.getByRole("tab", { name: "Tab C" })).toHaveAttribute(
       "aria-selected",
@@ -805,8 +816,9 @@ describe("Container tabs with icon", () => {
 });
 
 describe("Container tabs with icons and secondary label", () => {
-  it("should render container type with icon and secondary label on each tab", () => {
+  it("should render container type with icon and secondary label on each tab", async () => {
     const { container } = render(TabIconSecondaryLabel);
+    await tick();
 
     const tabsContainer = screen.getByRole("navigation");
     expect(tabsContainer).toHaveClass("bx--tabs--container");
@@ -828,8 +840,9 @@ describe("Container tabs with icons and secondary label", () => {
     expect(iconWrappers).toHaveLength(3);
   });
 
-  it("should have label wrapper and secondary label when tab has icon and secondaryLabel", () => {
+  it("should have label wrapper and secondary label when tab has icon and secondaryLabel", async () => {
     const { container } = render(TabIconSecondaryLabel);
+    await tick();
 
     const navItems = container.querySelectorAll(".bx--tabs__nav-item");
     const calendarTab = navItems[0];
@@ -869,30 +882,34 @@ describe("Container tabs with icons and secondary label", () => {
 });
 
 describe("Container tabs with secondary label", () => {
-  it("should render container with tall class when any tab has secondary label", () => {
+  it("should render container with tall class when any tab has secondary label", async () => {
     render(TabSecondaryLabel);
+    await tick();
 
     const tabsContainer = screen.getByRole("navigation");
     expect(tabsContainer).toHaveClass("bx--tabs--container");
     expect(tabsContainer).toHaveClass("bx--tabs--tall");
   });
 
-  it("should render secondary label via prop", () => {
+  it("should render secondary label via prop", async () => {
     render(TabSecondaryLabel);
+    await tick();
 
     expect(screen.getByRole("tab", { name: /Engage/ })).toBeInTheDocument();
     expect(screen.getByText("(21/25)")).toBeInTheDocument();
   });
 
-  it("should render secondary label via slot", () => {
+  it("should render secondary label via slot", async () => {
     render(TabSecondaryLabel);
+    await tick();
 
     expect(screen.getByRole("tab", { name: /Analyze/ })).toBeInTheDocument();
     expect(screen.getByText("(12/16)")).toBeInTheDocument();
   });
 
-  it("should have label wrapper and secondary label element for tab with prop", () => {
+  it("should have label wrapper and secondary label element for tab with prop", async () => {
     const { container } = render(TabSecondaryLabel);
+    await tick();
 
     const navItems = container.querySelectorAll(".bx--tabs__nav-item");
     const engageTab = navItems[0];
@@ -908,8 +925,9 @@ describe("Container tabs with secondary label", () => {
     expect(secondaryLabel).toHaveTextContent("(21/25)");
   });
 
-  it("should have label wrapper and secondary label element for tab with slot", () => {
+  it("should have label wrapper and secondary label element for tab with slot", async () => {
     const { container } = render(TabSecondaryLabel);
+    await tick();
 
     const navItems = container.querySelectorAll(".bx--tabs__nav-item");
     const analyzeTab = navItems[1];
@@ -925,8 +943,9 @@ describe("Container tabs with secondary label", () => {
     expect(secondaryLabel).toHaveTextContent("(12/16)");
   });
 
-  it("should render label wrapper and empty spacer for tab without secondary label (for alignment)", () => {
+  it("should render label wrapper and empty spacer for tab without secondary label (for alignment)", async () => {
     const { container } = render(TabSecondaryLabel);
+    await tick();
 
     const navItems = container.querySelectorAll(".bx--tabs__nav-item");
     const plainTab = navItems[2];
@@ -1058,8 +1077,9 @@ describe("TabsSkeleton", () => {
   });
 
   describe("TabContent lazy and unmountOnHide", () => {
-    it("keeps unselected content in the DOM with the hidden attribute by default", () => {
+    it("keeps unselected content in the DOM with the hidden attribute by default", async () => {
       render(TabsLazy);
+      await tick();
 
       expect(screen.getByText("Content 1")).toBeVisible();
       expect(screen.getByText("Content 2")).not.toBeVisible();
@@ -1072,6 +1092,7 @@ describe("TabsSkeleton", () => {
 
     it("does not mount lazy content until the tab is first selected", async () => {
       render(TabsLazy, { props: { lazy: true } });
+      await tick();
 
       expect(screen.getByText("Content 1")).toBeInTheDocument();
       expect(screen.queryByText("Content 2")).not.toBeInTheDocument();
@@ -1090,6 +1111,7 @@ describe("TabsSkeleton", () => {
 
     it("unmounts content when deselected with unmountOnHide", async () => {
       render(TabsLazy, { props: { unmountOnHide: true } });
+      await tick();
 
       expect(screen.getByText("Content 1")).toBeVisible();
       expect(screen.queryByText("Content 2")).not.toBeInTheDocument();
@@ -1105,8 +1127,9 @@ describe("TabsSkeleton", () => {
       expect(screen.queryByText("Content 2")).not.toBeInTheDocument();
     });
 
-    it("mounts lazy content on the initially selected tab", () => {
+    it("mounts lazy content on the initially selected tab", async () => {
       render(TabsLazy, { props: { selected: 1, lazy: true } });
+      await tick();
 
       expect(screen.queryByText("Content 1")).not.toBeInTheDocument();
       expect(screen.getByText("Content 2")).toBeVisible();

--- a/tests/UserAvatarGroup/UserAvatarGroup.test.ts
+++ b/tests/UserAvatarGroup/UserAvatarGroup.test.ts
@@ -1,4 +1,5 @@
 import { render, screen, waitFor } from "@testing-library/svelte";
+import { tick } from "svelte";
 import { user } from "../utils/user";
 import UserAvatarGroup from "./UserAvatarGroup.test.svelte";
 
@@ -20,8 +21,9 @@ function visibleAvatar(root: HTMLElement): HTMLElement {
 }
 
 describe("UserAvatarGroup", () => {
-  it("renders every avatar and no overflow when under max", () => {
+  it("renders every avatar and no overflow when under max", async () => {
     render(UserAvatarGroup);
+    await tick();
 
     const root = groupRoot("under-max");
     expect(root.querySelectorAll(".bx--user-avatar")).toHaveLength(3);
@@ -29,16 +31,18 @@ describe("UserAvatarGroup", () => {
     expect(root).not.toHaveTextContent("+");
   });
 
-  it("applies the overlap modifier by default", () => {
+  it("applies the overlap modifier by default", async () => {
     render(UserAvatarGroup);
+    await tick();
 
     expect(groupRoot("under-max")).toHaveClass(
       "bx--user-avatar-group--overlap",
     );
   });
 
-  it("hides avatars past max and renders a +N overflow avatar", () => {
+  it("hides avatars past max and renders a +N overflow avatar", async () => {
     render(UserAvatarGroup);
+    await tick();
 
     const root = groupRoot("overflow");
     // Two of the four slotted avatars are hidden as overflow.
@@ -50,24 +54,27 @@ describe("UserAvatarGroup", () => {
     ).toBeInTheDocument();
   });
 
-  it("treats max of 0 as no limit", () => {
+  it("treats max of 0 as no limit", async () => {
     render(UserAvatarGroup);
+    await tick();
 
     const root = groupRoot("no-limit");
     expect(root.querySelectorAll('[data-overflow="true"]')).toHaveLength(0);
     expect(root).not.toHaveTextContent("+");
   });
 
-  it("spaces avatars apart when a gap is set", () => {
+  it("spaces avatars apart when a gap is set", async () => {
     render(UserAvatarGroup);
+    await tick();
 
     const root = groupRoot("spaced");
     expect(root).not.toHaveClass("bx--user-avatar-group--overlap");
     expect(root).toHaveClass("bx--stack-scale-3");
   });
 
-  it("tightens the overlap with a negative gap", () => {
+  it("tightens the overlap with a negative gap", async () => {
     render(UserAvatarGroup);
+    await tick();
 
     const root = groupRoot("tighter");
     expect(root).toHaveClass("bx--user-avatar-group--overlap");
@@ -76,8 +83,9 @@ describe("UserAvatarGroup", () => {
     );
   });
 
-  it("uses total for the overflow without rendering the hidden avatars", () => {
+  it("uses total for the overflow without rendering the hidden avatars", async () => {
     render(UserAvatarGroup);
+    await tick();
 
     const root = groupRoot("total");
     // Only the three slotted avatars render (plus the overflow avatar); the
@@ -90,8 +98,9 @@ describe("UserAvatarGroup", () => {
     ).toHaveTextContent("99+");
   });
 
-  it("cascades its size to avatars that do not set their own", () => {
+  it("cascades its size to avatars that do not set their own", async () => {
     render(UserAvatarGroup);
+    await tick();
 
     const root = groupRoot("cascade");
     // First avatar inherits the group size; the second keeps its own.
@@ -107,6 +116,7 @@ describe("UserAvatarGroup", () => {
 
   it("uses overflowTooltipText for the overflow chip tooltip", async () => {
     render(UserAvatarGroup);
+    await tick();
 
     const overflow = groupRoot("overflow-tooltip").querySelector(
       ".bx--user-avatar-group__overflow",
@@ -122,8 +132,9 @@ describe("UserAvatarGroup", () => {
     });
   });
 
-  it("reverses the stacking order so the first avatar paints on top, even when tooltipText wraps it", () => {
+  it("reverses the stacking order so the first avatar paints on top, even when tooltipText wraps it", async () => {
     render(UserAvatarGroup);
+    await tick();
 
     const root = groupRoot("stack-first");
     expect(root).toHaveClass("bx--user-avatar-group--stack-first");
@@ -156,6 +167,7 @@ describe("UserAvatarGroup", () => {
 
   it("re-sorts to DOM order when an avatar is inserted ahead of others", async () => {
     render(UserAvatarGroup);
+    await tick();
 
     const root = groupRoot("resync");
     // Only Bob and Cara are mounted; Bob is the single visible avatar.

--- a/tests/utils/batchStoreUpdates.test.ts
+++ b/tests/utils/batchStoreUpdates.test.ts
@@ -1,0 +1,67 @@
+import { writable } from "svelte/store";
+import { batchStoreUpdates } from "../../src/utils/batchStoreUpdates.js";
+
+describe("batchStoreUpdates", () => {
+  test("collapses synchronous calls into a single store update", async () => {
+    const store = writable<number[]>([]);
+    let notifications = 0;
+    store.subscribe(() => {
+      notifications++;
+    });
+    // The initial subscribe call itself counts as one notification.
+    notifications = 0;
+
+    const batchedUpdate = batchStoreUpdates(store);
+    batchedUpdate((value) => [...value, 1]);
+    batchedUpdate((value) => [...value, 2]);
+    batchedUpdate((value) => [...value, 3]);
+
+    expect(notifications).toBe(0);
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(notifications).toBe(1);
+    let current: number[] = [];
+    store.subscribe((value) => {
+      current = value;
+    })();
+    expect(current).toEqual([1, 2, 3]);
+  });
+
+  test("applies queued operations in call order", async () => {
+    const store = writable<string[]>(["a"]);
+    const batchedUpdate = batchStoreUpdates(store);
+
+    batchedUpdate((value) => [...value, "b"]);
+    batchedUpdate((value) => value.filter((item) => item !== "a"));
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    let current: string[] = [];
+    store.subscribe((value) => {
+      current = value;
+    })();
+    expect(current).toEqual(["b"]);
+  });
+
+  test("a later batch flushes independently of an earlier one", async () => {
+    const store = writable<number[]>([]);
+    const batchedUpdate = batchStoreUpdates(store);
+
+    batchedUpdate((value) => [...value, 1]);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    batchedUpdate((value) => [...value, 2]);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    let current: number[] = [];
+    store.subscribe((value) => {
+      current = value;
+    })();
+    expect(current).toEqual([1, 2]);
+  });
+});


### PR DESCRIPTION
Adds component-tier mount benchmarks for previously-uncovered areas
(context-registration groups, ComboBox mount/open, TreeView first
expansion, graphemeCount), then fixes three O(n^2) registration bugs
the sweep turned up. Tabs, OverflowMenu, and UserAvatarGroup all ran a
per-child `store.update()` during mount that re-derived a keyed store
and re-triggered every already-mounted sibling's own subscription, so
N children registering at once cost O(n^2). A new `batchStoreUpdates`
util collapses those into a single flush per mount.

## Benchmarks

Measured with paired `git stash` before/after runs against each
component's `bench/*.dom.bench.ts` file.

| Component        | Count | Before  | After   | Factor |
| ----------------- | ----: | ------: | ------: | -----: |
| Tabs              |    10 | 12.11ms | 2.66ms  | ~4.6x  |
| Tabs              |    80 | 1.09s   | 15.76ms | ~69x   |
| Tabs              |   100 | 1.72s   | 20.33ms | ~85x   |
| OverflowMenu      |    10 | 11.65ms | 2.44ms  | ~4.8x  |
| OverflowMenu      |    80 | 1.34s   | 14.27ms | ~94x   |
| OverflowMenu      |   100 | 2.12s   | 16.88ms | ~126x  |
| UserAvatarGroup   |    10 | 31.01ms | 2.55ms  | ~12.2x |
| UserAvatarGroup   |    80 | 2.70s   | 16.39ms | ~165x  |
| UserAvatarGroup   |   100 | 4.56s   | 22.83ms | ~200x  |

Along the way, the Tabs fix caught a real bug. `afterUpdate` fires
once for free right after mount, before the batched flush lands, and
it was consuming a `needsDomSync` flag meant for the real correction,
silently breaking `selectedId`-based initial selection. Fixed by
setting the flag inside the batched update itself instead of eagerly,
caught by 3 existing tests.

OverflowMenu's `primaryFocus` had no test coverage before this and
turned out to have a transient focus race from the batching (the
container briefly gets focus before the flagged item claims it). Added
a regression test pinning that the item still ends up with real DOM
focus; the race itself resolves before paint so it's not user-visible.
