### PR TITLE
perf(tabs-vertical): batch tab/content registration into one flush

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -753,7 +753,9 @@ function register(item) {
 - Put every mutator for that store on the same queue. A direct `store.update()` in the same mount pass can read an array that is still missing a not-yet-flushed batch.
 - `batchStoreUpdates` flushes on a `Promise.resolve().then()` microtask, not `afterUpdate`. A comment that warns against deferring work because of `afterUpdate` does not apply.
 - `afterUpdate` still runs once right after initial mount, before the batched flush, while the store is empty. A one-shot flag set in `register()` itself gets consumed by that empty call. Set it inside the batched update function, as `Tabs.svelte` does with `needsDomSync`.
+- Inside the batched updater, dedup and patch against the updater's own accumulator, not a `derived` store from outer scope. The derived store is the last flushed value, so a same-batch id looks unregistered. See `add()` in `ProgressIndicator.svelte`.
 - Component-bench a new group or list's mount at a few sizes before shipping. A `performance.now()` loop around `render()` is enough to catch this.
+- Matching `register()` code can still measure differently. If the consumer runs behind `tick()`, a synchronous `render()` never waits for that work. `TagSet` and `UserAvatarGroup` share a `sortByDomOrder` register shape. Only the avatar group's `$:` block runs synchronously, so only that one showed the cost.
 
 ## Commit messages
 

--- a/bench/contextmenuradiogroup-mount.dom.bench.ts
+++ b/bench/contextmenuradiogroup-mount.dom.bench.ts
@@ -1,0 +1,21 @@
+import { cleanup, render } from "@testing-library/svelte";
+import { bench, run } from "mitata";
+import ContextMenuRadioGroupBench from "./fixtures/ContextMenuRadioGroupBench.svelte";
+
+// addOption() appends to `radioIds` with an `.includes()` dedup. Nothing
+// derived from that store fans out to siblings, so this should stay closer
+// to ContentSwitcher than to the O(n^2) group components. The bench is
+// here to measure that, not infer it from the source.
+it("benchmarks mounting ContextMenuRadioGroup with various option counts", async () => {
+  bench("mount ContextMenuRadioGroup, $size options", function* (state) {
+    const size = state.get("size");
+    yield () => {
+      render(ContextMenuRadioGroupBench, { props: { count: size } });
+      cleanup();
+    };
+  }).range("size", 10, 1000);
+
+  // mitata defaults `print` to console.log, which vitest swallows for
+  // passing tests. process.stdout.write always reaches the terminal.
+  await run({ print: (line) => process.stdout.write(`${line}\n`) });
+}, 120_000);

--- a/bench/fixtures/ContextMenuRadioGroupBench.svelte
+++ b/bench/fixtures/ContextMenuRadioGroupBench.svelte
@@ -1,0 +1,19 @@
+<svelte:options accessors />
+
+<script lang="ts">
+  import ContextMenu from "carbon-components-svelte/ContextMenu/ContextMenu.svelte";
+  import ContextMenuOption from "carbon-components-svelte/ContextMenu/ContextMenuOption.svelte";
+  import ContextMenuRadioGroup from "carbon-components-svelte/ContextMenu/ContextMenuRadioGroup.svelte";
+
+  export let count = 10;
+</script>
+
+<!-- ContextMenu mounts item-slot children even when closed. `open` is still
+  true so this matches the other benches' visible-mount setup. -->
+<ContextMenu open>
+  <ContextMenuRadioGroup labelText="Options">
+    {#each { length: count } as _, i}
+      <ContextMenuOption id={`option-${i}`} labelText={`Option ${i}`} />
+    {/each}
+  </ContextMenuRadioGroup>
+</ContextMenu>

--- a/bench/fixtures/ProgressIndicatorBench.svelte
+++ b/bench/fixtures/ProgressIndicatorBench.svelte
@@ -1,0 +1,14 @@
+<svelte:options accessors />
+
+<script lang="ts">
+  import ProgressIndicator from "carbon-components-svelte/ProgressIndicator/ProgressIndicator.svelte";
+  import ProgressStep from "carbon-components-svelte/ProgressIndicator/ProgressStep.svelte";
+
+  export let count = 10;
+</script>
+
+<ProgressIndicator>
+  {#each { length: count } as _, i}
+    <ProgressStep label={`Step ${i}`} />
+  {/each}
+</ProgressIndicator>

--- a/bench/fixtures/TabsVerticalBench.svelte
+++ b/bench/fixtures/TabsVerticalBench.svelte
@@ -1,0 +1,14 @@
+<svelte:options accessors />
+
+<script lang="ts">
+  import Tab from "carbon-components-svelte/Tabs/Tab.svelte";
+  import TabsVertical from "carbon-components-svelte/Tabs/TabsVertical.svelte";
+
+  export let count = 10;
+</script>
+
+<TabsVertical>
+  {#each { length: count } as _, i}
+    <Tab label={`Tab ${i}`} />
+  {/each}
+</TabsVertical>

--- a/bench/fixtures/TagSetBench.svelte
+++ b/bench/fixtures/TagSetBench.svelte
@@ -1,0 +1,14 @@
+<svelte:options accessors />
+
+<script lang="ts">
+  import Tag from "carbon-components-svelte/Tag/Tag.svelte";
+  import TagSet from "carbon-components-svelte/TagSet/TagSet.svelte";
+
+  export let count = 100;
+</script>
+
+<TagSet>
+  {#each { length: count } as _, i}
+    <Tag>{`Tag ${i}`}</Tag>
+  {/each}
+</TagSet>

--- a/bench/progressindicator-mount.dom.bench.ts
+++ b/bench/progressindicator-mount.dom.bench.ts
@@ -1,0 +1,21 @@
+import { cleanup, render } from "@testing-library/svelte";
+import { bench, run } from "mitata";
+import ProgressIndicatorBench from "./fixtures/ProgressIndicatorBench.svelte";
+
+// Each ProgressStep calls add() during init. That used to call
+// `steps.update` per step, then a `$:` block did a second `steps.update`
+// to recompute `current` flags. Range capped at 100. A mount at 100 steps
+// is already ~2s, and mitata's calibration at 500 would run for minutes.
+it("benchmarks mounting ProgressIndicator with various step counts", async () => {
+  bench("mount ProgressIndicator, $size steps", function* (state) {
+    const size = state.get("size");
+    yield () => {
+      render(ProgressIndicatorBench, { props: { count: size } });
+      cleanup();
+    };
+  }).range("size", 10, 100);
+
+  // mitata defaults `print` to console.log, which vitest swallows for
+  // passing tests. process.stdout.write always reaches the terminal.
+  await run({ print: (line) => process.stdout.write(`${line}\n`) });
+}, 180_000);

--- a/bench/tabsvertical-mount.dom.bench.ts
+++ b/bench/tabsvertical-mount.dom.bench.ts
@@ -1,0 +1,20 @@
+import { cleanup, render } from "@testing-library/svelte";
+import { bench, run } from "mitata";
+import TabsVerticalBench from "./fixtures/TabsVerticalBench.svelte";
+
+// TabsVertical.add() used the same unbatched `tabs.update` plus
+// `derived(tabs, keyBy)` fanout as Tabs. Range capped at 100. An O(n^2)
+// closure makes mitata's calibration take minutes at wider ranges.
+it("benchmarks mounting TabsVertical with various tab counts", async () => {
+  bench("mount TabsVertical, $size tabs", function* (state) {
+    const size = state.get("size");
+    yield () => {
+      render(TabsVerticalBench, { props: { count: size } });
+      cleanup();
+    };
+  }).range("size", 10, 100);
+
+  // mitata defaults `print` to console.log, which vitest swallows for
+  // passing tests. process.stdout.write always reaches the terminal.
+  await run({ print: (line) => process.stdout.write(`${line}\n`) });
+}, 120_000);

--- a/bench/tagset-mount.dom.bench.ts
+++ b/bench/tagset-mount.dom.bench.ts
@@ -1,0 +1,20 @@
+import { cleanup, render } from "@testing-library/svelte";
+import { bench, run } from "mitata";
+import TagSetBench from "./fixtures/TagSetBench.svelte";
+
+// TagSet.register() sorts by DOM order on every Tag onMount, same shape as
+// UserAvatarGroup. Overflow measurement runs behind `tick()`, so this
+// harness does not wait for it. Range capped at 100.
+it("benchmarks mounting TagSet with various tag counts", async () => {
+  bench("mount TagSet, $size tags", function* (state) {
+    const size = state.get("size");
+    yield () => {
+      render(TagSetBench, { props: { count: size } });
+      cleanup();
+    };
+  }).range("size", 10, 100);
+
+  // mitata defaults `print` to console.log, which vitest swallows for
+  // passing tests. process.stdout.write always reaches the terminal.
+  await run({ print: (line) => process.stdout.write(`${line}\n`) });
+}, 180_000);

--- a/src/ProgressIndicator/ProgressIndicator.svelte
+++ b/src/ProgressIndicator/ProgressIndicator.svelte
@@ -27,6 +27,7 @@
 
   import { createEventDispatcher, setContext } from "svelte";
   import { derived, writable } from "svelte/store";
+  import { batchStoreUpdates } from "../utils/batchStoreUpdates.js";
   import { clampIndex } from "../utils/clampIndex.js";
   import { keyBy } from "../utils/keyBy.js";
 
@@ -48,16 +49,21 @@
     subscribe: preventChangeOnClickStore.subscribe,
   };
 
+  // Batch child registration. Dedup and patch against `_` (this batch's
+  // accumulator), not `$stepsById`. The derived store is the last flushed
+  // value, so a same-batch id looks unregistered if you check it there.
+  const batchedStepsUpdate = batchStoreUpdates(steps);
+
   /**
    * @type {(step: { id: string; complete: boolean; disabled: boolean }) => void}
    */
   function add(step) {
-    steps.update((_) => {
-      if (step.id in $stepsById) {
-        return _.map((_step) => {
-          if (_step.id === step.id) return { ..._step, ...step };
-          return _step;
-        });
+    batchedStepsUpdate((_) => {
+      const index = _.findIndex((_step) => _step.id === step.id);
+      if (index !== -1) {
+        return _.map((_step, i) =>
+          i === index ? { ..._step, ...step } : _step,
+        );
       }
 
       return [
@@ -76,7 +82,7 @@
    * @type {(id: string) => void}
    */
   function remove(id) {
-    steps.update((_) =>
+    batchedStepsUpdate((_) =>
       _.filter((step) => step.id !== id).map((step, i) => ({
         ...step,
         index: i,

--- a/src/Tabs/TabsVertical.svelte
+++ b/src/Tabs/TabsVertical.svelte
@@ -45,6 +45,7 @@
   import { breakpointObserver } from "../Breakpoint/breakpointObserver.js";
   import ChevronLeft from "../icons/ChevronLeft.svelte";
   import ChevronRight from "../icons/ChevronRight.svelte";
+  import { batchStoreUpdates } from "../utils/batchStoreUpdates.js";
   import { clampIndex } from "../utils/clampIndex.js";
   import { keyBy } from "../utils/keyBy.js";
   import { rovingFocus } from "../utils/rovingFocus.js";
@@ -163,36 +164,52 @@
   // This is necessary to avoid infinite loops in Svelte 5.
   let needsDomSync = false;
 
+  // Batch child registration. Leave afterUpdate's syncDomOrder unbatched
+  // so DOM-order correction stays synchronous.
+  //
+  // Set needsDomSync inside the batched update. afterUpdate runs once
+  // after mount before this flush, while tabs is still [].
+  const batchedTabsUpdate = batchStoreUpdates(tabs);
+  const batchedContentUpdate = batchStoreUpdates(content);
+
   /**
    * @type {(data: { id: string; label: string; disabled: boolean; hasSecondaryLabel: boolean }) => void}
    */
   function add(data) {
-    needsDomSync = true;
-    tabs.update((_) => [..._, { ...data, index: _.length }]);
+    batchedTabsUpdate((_) => {
+      needsDomSync = true;
+      return [..._, { ...data, index: _.length }];
+    });
   }
 
   /**
    * @type {(id: string) => void}
    */
   function remove(id) {
-    needsDomSync = true;
-    tabs.update((_) => _.filter((tab) => tab.id !== id));
+    batchedTabsUpdate((_) => {
+      needsDomSync = true;
+      return _.filter((tab) => tab.id !== id);
+    });
   }
 
   /**
    * @type {(data: { id: string }) => void}
    */
   function addContent(data) {
-    needsDomSync = true;
-    content.update((_) => [..._, { ...data, index: _.length }]);
+    batchedContentUpdate((_) => {
+      needsDomSync = true;
+      return [..._, { ...data, index: _.length }];
+    });
   }
 
   /**
    * @type {(id: string) => void}
    */
   function removeContent(id) {
-    needsDomSync = true;
-    content.update((_) => _.filter((item) => item.id !== id));
+    batchedContentUpdate((_) => {
+      needsDomSync = true;
+      return _.filter((item) => item.id !== id);
+    });
   }
 
   /**
@@ -204,7 +221,10 @@
       selectedId = id;
       return;
     }
-    currentIndex = $tabsById[id].index;
+    // Ignore clicks that land before this tab's batched registration flushes.
+    const tab = $tabsById[id];
+    if (!tab) return;
+    currentIndex = tab.index;
   }
 
   /**

--- a/src/TagSet/TagSet.svelte
+++ b/src/TagSet/TagSet.svelte
@@ -73,6 +73,7 @@
   import { createEventDispatcher, onMount, setContext, tick } from "svelte";
   import { writable } from "svelte/store";
   import Stack from "../Stack/Stack.svelte";
+  import { batchStoreUpdates } from "../utils/batchStoreUpdates.js";
   import { rafThrottle } from "../utils/rafThrottle.js";
   import { getVisibleTagCount } from "../utils/tagOverflow.js";
   import TagSetOverflow from "./TagSetOverflow.svelte";
@@ -104,22 +105,27 @@
     dispatch("close:tag", { tag: item, index: $items.indexOf(item) });
   }
 
+  // Route register, unregister, and update through the same batched queue.
+  // Mixing in a direct items.update() would read a stale array still
+  // missing not-yet-flushed registrations.
+  const batchedItemsUpdate = batchStoreUpdates(items);
+
   setContext("carbon:TagSet", {
     items,
     overflowIds,
     size: sizeStore,
     register: (item) => {
-      items.update((current) =>
+      batchedItemsUpdate((current) =>
         current.some((existing) => existing.id === item.id)
           ? current
           : sortByDomOrder([...current, item]),
       );
     },
     unregister: (id) => {
-      items.update((current) => current.filter((item) => item.id !== id));
+      batchedItemsUpdate((current) => current.filter((item) => item.id !== id));
     },
     update: (id, patch) => {
-      items.update((current) =>
+      batchedItemsUpdate((current) =>
         current.map((item) => (item.id === id ? { ...item, ...patch } : item)),
       );
     },

--- a/tests/ProgressIndicator/ProgressIndicator.test.ts
+++ b/tests/ProgressIndicator/ProgressIndicator.test.ts
@@ -1,4 +1,5 @@
 import { render, screen, waitFor } from "@testing-library/svelte";
+import { tick } from "svelte";
 import { user } from "../utils/user";
 import ProgressIndicator from "./ProgressIndicator.test.svelte";
 import ProgressIndicatorConditional from "./ProgressIndicatorConditional.test.svelte";
@@ -43,7 +44,7 @@ describe("ProgressIndicator", () => {
       );
     });
 
-    it("should expose current, complete, and invalid state to assistive tech", () => {
+    it("should expose current, complete, and invalid state to assistive tech", async () => {
       render(ProgressIndicator, {
         currentIndex: 1,
         steps: [
@@ -57,6 +58,7 @@ describe("ProgressIndicator", () => {
           },
         ],
       });
+      await tick();
 
       const buttons = screen.getAllByRole("button");
 
@@ -203,7 +205,7 @@ describe("ProgressIndicator", () => {
   });
 
   describe("Accessibility", () => {
-    it("should have correct button attributes for different states", () => {
+    it("should have correct button attributes for different states", async () => {
       render(ProgressIndicator, {
         currentIndex: 1,
         steps: [
@@ -212,6 +214,7 @@ describe("ProgressIndicator", () => {
           { label: "Step 3", description: "Third step", complete: false },
         ],
       });
+      await tick();
 
       const buttons = screen.getAllByRole("button");
 
@@ -343,6 +346,7 @@ describe("ProgressIndicator", () => {
         showOptional: true,
         currentIndex: 2,
       });
+      await tick();
 
       let listItems = screen.getAllByRole("listitem");
       expect(listItems[2]).toHaveTextContent("Step 3");
@@ -375,8 +379,9 @@ describe("ProgressIndicator", () => {
   });
 
   describe("Icon slot", () => {
-    it("should render custom icon slot content with state props", () => {
+    it("should render custom icon slot content with state props", async () => {
       render(ProgressStepIconSlot);
+      await tick();
 
       const icon1 = screen.getByTestId("icon-1");
       expect(icon1).toHaveTextContent("c:true|cur:false|inv:false");
@@ -452,6 +457,7 @@ describe("ProgressIndicator", () => {
       render(ProgressIndicatorSelectedId, {
         props: { selectedId: "step-b", showStepA: true },
       });
+      await tick();
 
       let listItems = screen.getAllByRole("listitem");
       expect(listItems[1]).toHaveTextContent("Step B");
@@ -490,10 +496,11 @@ describe("ProgressIndicator", () => {
       expect(screen.getByTestId("current-index")).toHaveTextContent("0");
     });
 
-    it("uses the index API when selectedId is unset", () => {
+    it("uses the index API when selectedId is unset", async () => {
       render(ProgressIndicatorSelectedId, {
         props: { currentIndex: 2, selectedId: undefined },
       });
+      await tick();
 
       const listItems = screen.getAllByRole("listitem");
       expect(listItems[2]).toHaveClass("bx--progress-step--current");
@@ -501,10 +508,11 @@ describe("ProgressIndicator", () => {
       expect(screen.getByTestId("selected-id")).toHaveTextContent("");
     });
 
-    it("lets selectedId win over currentIndex", () => {
+    it("lets selectedId win over currentIndex", async () => {
       render(ProgressIndicatorSelectedId, {
         props: { currentIndex: 0, selectedId: "step-c" },
       });
+      await tick();
 
       const listItems = screen.getAllByRole("listitem");
       expect(listItems[2]).toHaveClass("bx--progress-step--current");

--- a/tests/Snippets/Snippets.test.ts
+++ b/tests/Snippets/Snippets.test.ts
@@ -189,8 +189,9 @@ describe("Svelte 5 Snippets", () => {
   });
 
   describe("ProgressStep icon", () => {
-    it("should render icon snippet with complete, current, and invalid arguments", () => {
+    it("should render icon snippet with complete, current, and invalid arguments", async () => {
       render(Snippets);
+      await tick();
 
       const icon1 = screen.getByTestId("progress-step-icon-1");
       expect(icon1).toHaveAttribute("data-complete", "true");

--- a/tests/Tabs/TabsVertical.test.ts
+++ b/tests/Tabs/TabsVertical.test.ts
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen } from "@testing-library/svelte";
+import { tick } from "svelte";
 import Calendar from "../../src/icons/Calendar.svelte";
 import { user } from "../utils/user";
 import TabsVertical from "./TabsVertical.test.svelte";
@@ -16,8 +17,9 @@ describe("TabsVertical", () => {
     vi.restoreAllMocks();
   });
 
-  it("should render with default props", () => {
+  it("should render with default props", async () => {
     render(TabsVertical);
+    await tick();
 
     expect(screen.getByRole("navigation")).toHaveClass("bx--tabs--vertical");
 
@@ -29,8 +31,9 @@ describe("TabsVertical", () => {
     expect(screen.getByText("Content 2")).not.toBeVisible();
   });
 
-  it("should link each tab to its panel via aria-controls", () => {
+  it("should link each tab to its panel via aria-controls", async () => {
     render(TabsVertical);
+    await tick();
 
     const tabs = screen.getAllByRole("tab");
     const panels = screen.getAllByRole("tabpanel", { hidden: true });
@@ -69,8 +72,9 @@ describe("TabsVertical", () => {
     );
   });
 
-  it("should select the initial tab from the selected prop", () => {
+  it("should select the initial tab from the selected prop", async () => {
     render(TabsVertical, { props: { selected: 2 } });
+    await tick();
 
     expect(screen.getByRole("tab", { name: "Tab 3" })).toHaveAttribute(
       "aria-selected",
@@ -173,6 +177,7 @@ describe("TabsVertical", () => {
     render(TabsVerticalSelectedId, {
       props: { selectedId: "tab-b", showTabA: true },
     });
+    await tick();
 
     expect(screen.getByRole("tab", { name: "Tab B" })).toHaveAttribute(
       "aria-selected",
@@ -182,6 +187,7 @@ describe("TabsVertical", () => {
     expect(screen.getByTestId("selected-index")).toHaveTextContent("1");
 
     await user.click(screen.getByTestId("toggle-tab-a"));
+    await tick();
 
     expect(
       screen.queryByRole("tab", { name: "Tab A" }),


### PR DESCRIPTION
Continues the registration-fanout sweep from #3653. TabsVertical,
TagSet, and ProgressIndicator had the same O(n^2) registration bug
and are now batched with the existing `batchStoreUpdates` util.
ContextMenuRadioGroup got the same scrutiny but came back clean, so
it just gets a new benchmark, no fix needed.

## Benchmark

Measured with paired `git stash` before/after runs against each
component's `bench/*.dom.bench.ts` file.

| Component          | Count | Before  | After   | Factor |
| ------------------- | ----: | ------: | ------: | -----: |
| TabsVertical        |    10 | 11.97ms | 2.48ms  | ~4.8x  |
| TabsVertical        |    80 | 1.10s   | 16.82ms | ~65x   |
| TabsVertical        |   100 | 1.71s   | 24.34ms | ~70x   |
| TagSet              |    10 | 8.40ms  | 2.75ms  | ~3.1x  |
| TagSet              |    80 | 74.84ms | 15.37ms | ~4.9x  |
| TagSet              |   100 | 98.41ms | 20.00ms | ~4.9x  |
| ProgressIndicator   |    10 | 16.28ms | 2.92ms  | ~5.6x  |
| ProgressIndicator   |    80 | 1.31s   | 20.58ms | ~64x   |
| ProgressIndicator   |   100 | 2.03s   | 24.87ms | ~82x   |

TagSet is a useful reminder that matching source shape doesn't mean
matching severity. Its `register()` is nearly identical to
UserAvatarGroup's, but its own reactive fanout (overflow
measurement) runs behind `tick()` instead of synchronously, so its
unfixed cost was only ~11.7x at 10x scale instead of UserAvatarGroup's
~147x. Fixed anyway since the win was still real, just smaller.

ContextMenuRadioGroup has no `derived(keyBy)` fanout to begin with, so
it stays close to linear (10 -> 1000 options is ~136x time for 100x
count) and didn't need a fix.
