### PR TITLE
fix(modal): close only the topmost stacked modal on Escape

### DIFF
--- a/src/ComposedModal/ComposedModal.svelte
+++ b/src/ComposedModal/ComposedModal.svelte
@@ -187,6 +187,10 @@
   on:keydown={(event) => {
     if (open) {
       if (event.key === "Escape") {
+        // Stop stacked (DOM-nested) modals from also closing: this
+        // handler is on each modal's own root and Escape bubbles from
+        // the focused (innermost, topmost) modal up through ancestors.
+        event.stopPropagation();
         close("escape-key");
       } else if (event.key === "Tab") {
         trapFocus({ container: ref, event });

--- a/src/Modal/Modal.svelte
+++ b/src/Modal/Modal.svelte
@@ -250,6 +250,10 @@
   on:keydown={(event) => {
     if (open) {
       if (event.key === "Escape") {
+        // Stop stacked (DOM-nested) modals from also closing: this
+        // handler is on each modal's own root and Escape bubbles from
+        // the focused (innermost, topmost) modal up through ancestors.
+        event.stopPropagation();
         close("escape-key");
       } else if (event.key === "Tab") {
         trapFocus({ container: ref, event });

--- a/tests/ComposedModal/ComposedModalOverflowMenu.test.svelte
+++ b/tests/ComposedModal/ComposedModalOverflowMenu.test.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import ComposedModal from "carbon-components-svelte/ComposedModal/ComposedModal.svelte";
+  import ModalBody from "carbon-components-svelte/ComposedModal/ModalBody.svelte";
+  import ModalHeader from "carbon-components-svelte/ComposedModal/ModalHeader.svelte";
+  import OverflowMenu from "carbon-components-svelte/OverflowMenu/OverflowMenu.svelte";
+  import OverflowMenuItem from "carbon-components-svelte/OverflowMenu/OverflowMenuItem.svelte";
+  import type { ComponentProps } from "svelte";
+
+  export let onclose: ((event: CustomEvent) => void) | undefined = undefined;
+  export let portalMenu: ComponentProps<OverflowMenu>["portalMenu"] = false;
+</script>
+
+<ComposedModal open on:close={(e) => onclose?.(e)}>
+  <ModalHeader title="Modal with overflow menu" />
+  <ModalBody>
+    <OverflowMenu iconDescription="More options" {portalMenu}>
+      <OverflowMenuItem text="Download" />
+      <OverflowMenuItem text="Share" />
+    </OverflowMenu>
+  </ModalBody>
+</ComposedModal>

--- a/tests/ComposedModal/ComposedModalOverflowMenu.test.ts
+++ b/tests/ComposedModal/ComposedModalOverflowMenu.test.ts
@@ -1,0 +1,24 @@
+import { render, screen } from "@testing-library/svelte";
+import { user } from "../utils/user";
+import ComposedModalOverflowMenu from "./ComposedModalOverflowMenu.test.svelte";
+
+describe.each([
+  ["non-portalled", false],
+  ["portalled", true],
+])("OverflowMenu (%s) inside a ComposedModal", (_label, portalMenu) => {
+  it("closes the menu on the first Escape and the modal on the second", async () => {
+    const onclose = vi.fn();
+    render(ComposedModalOverflowMenu, { props: { onclose, portalMenu } });
+
+    const menuButton = screen.getByRole("button", { name: "menu" });
+    await user.click(menuButton);
+    expect(menuButton).toHaveAttribute("aria-expanded", "true");
+
+    await user.keyboard("{Escape}");
+    expect(menuButton).toHaveAttribute("aria-expanded", "false");
+    expect(onclose).not.toHaveBeenCalled();
+
+    await user.keyboard("{Escape}");
+    expect(onclose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/ComposedModal/ComposedModalStacked.test.svelte
+++ b/tests/ComposedModal/ComposedModalStacked.test.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+  import ComposedModal from "carbon-components-svelte/ComposedModal/ComposedModal.svelte";
+  import ModalHeader from "carbon-components-svelte/ComposedModal/ModalHeader.svelte";
+
+  let siblingOpen = false;
+  let childOpen = false;
+</script>
+
+<ComposedModal open data-testid="modal">
+  <ModalHeader title="Modal" />
+  <button
+    type="button"
+    data-testid="launch-sibling-modal"
+    on:click={() => (siblingOpen = true)}
+  >
+    Launch sibling modal
+  </button>
+</ComposedModal>
+
+<ComposedModal bind:open={siblingOpen} data-testid="sibling-modal">
+  <ModalHeader title="Sibling modal" />
+  <button
+    type="button"
+    data-testid="launch-child-modal"
+    on:click={() => (childOpen = true)}
+  >
+    Launch child modal
+  </button>
+
+  <ComposedModal bind:open={childOpen} data-testid="child-modal">
+    <ModalHeader title="Child modal" />
+  </ComposedModal>
+</ComposedModal>

--- a/tests/ComposedModal/ComposedModalStacked.test.ts
+++ b/tests/ComposedModal/ComposedModalStacked.test.ts
@@ -1,0 +1,34 @@
+import { render, screen } from "@testing-library/svelte";
+import { tick } from "svelte";
+import { user } from "../utils/user";
+import ComposedModalStacked from "./ComposedModalStacked.test.svelte";
+
+function endTransition(element: Element) {
+  element.dispatchEvent(
+    new TransitionEvent("transitionend", { propertyName: "transform" }),
+  );
+}
+
+describe("Stacked ComposedModals", () => {
+  it("closes only the topmost modal when Escape is pressed", async () => {
+    render(ComposedModalStacked);
+
+    await user.click(screen.getByTestId("launch-sibling-modal"));
+    endTransition(screen.getByTestId("sibling-modal"));
+    await tick();
+
+    await user.click(screen.getByTestId("launch-child-modal"));
+    endTransition(screen.getByTestId("child-modal"));
+    await tick();
+
+    expect(screen.getByTestId("modal")).toHaveClass("is-visible");
+    expect(screen.getByTestId("sibling-modal")).toHaveClass("is-visible");
+    expect(screen.getByTestId("child-modal")).toHaveClass("is-visible");
+
+    await user.keyboard("{Escape}");
+
+    expect(screen.getByTestId("modal")).toHaveClass("is-visible");
+    expect(screen.getByTestId("sibling-modal")).toHaveClass("is-visible");
+    expect(screen.getByTestId("child-modal")).not.toHaveClass("is-visible");
+  });
+});

--- a/tests/Modal/ModalOverflowMenu.test.svelte
+++ b/tests/Modal/ModalOverflowMenu.test.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import Modal from "carbon-components-svelte/Modal/Modal.svelte";
+  import OverflowMenu from "carbon-components-svelte/OverflowMenu/OverflowMenu.svelte";
+  import OverflowMenuItem from "carbon-components-svelte/OverflowMenu/OverflowMenuItem.svelte";
+  import type { ComponentProps } from "svelte";
+
+  export let onclose: ((event: CustomEvent) => void) | undefined = undefined;
+  export let portalMenu: ComponentProps<OverflowMenu>["portalMenu"] = false;
+</script>
+
+<Modal
+  open
+  passiveModal
+  modalHeading="Modal with overflow menu"
+  on:close={(e) => onclose?.(e)}
+>
+  <OverflowMenu iconDescription="More options" {portalMenu}>
+    <OverflowMenuItem text="Download" />
+    <OverflowMenuItem text="Share" />
+  </OverflowMenu>
+</Modal>

--- a/tests/Modal/ModalOverflowMenu.test.ts
+++ b/tests/Modal/ModalOverflowMenu.test.ts
@@ -1,0 +1,24 @@
+import { render, screen } from "@testing-library/svelte";
+import { user } from "../utils/user";
+import ModalOverflowMenu from "./ModalOverflowMenu.test.svelte";
+
+describe.each([
+  ["non-portalled", false],
+  ["portalled", true],
+])("OverflowMenu (%s) inside a Modal", (_label, portalMenu) => {
+  it("closes the menu on the first Escape and the modal on the second", async () => {
+    const onclose = vi.fn();
+    render(ModalOverflowMenu, { props: { onclose, portalMenu } });
+
+    const menuButton = screen.getByRole("button", { name: "menu" });
+    await user.click(menuButton);
+    expect(menuButton).toHaveAttribute("aria-expanded", "true");
+
+    await user.keyboard("{Escape}");
+    expect(menuButton).toHaveAttribute("aria-expanded", "false");
+    expect(onclose).not.toHaveBeenCalled();
+
+    await user.keyboard("{Escape}");
+    expect(onclose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/Modal/ModalStacked.test.svelte
+++ b/tests/Modal/ModalStacked.test.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+  import Modal from "carbon-components-svelte/Modal/Modal.svelte";
+
+  let siblingOpen = false;
+  let childOpen = false;
+</script>
+
+<Modal open modalHeading="Modal" passiveModal data-testid="modal">
+  <button
+    type="button"
+    data-testid="launch-sibling-modal"
+    on:click={() => (siblingOpen = true)}
+  >
+    Launch sibling modal
+  </button>
+</Modal>
+
+<Modal
+  bind:open={siblingOpen}
+  modalHeading="Sibling modal"
+  passiveModal
+  data-testid="sibling-modal"
+>
+  <button
+    type="button"
+    data-testid="launch-child-modal"
+    on:click={() => (childOpen = true)}
+  >
+    Launch child modal
+  </button>
+
+  <Modal
+    bind:open={childOpen}
+    modalHeading="Child modal"
+    passiveModal
+    data-testid="child-modal"
+  />
+</Modal>

--- a/tests/Modal/ModalStacked.test.ts
+++ b/tests/Modal/ModalStacked.test.ts
@@ -1,0 +1,22 @@
+import { render, screen } from "@testing-library/svelte";
+import { user } from "../utils/user";
+import ModalStacked from "./ModalStacked.test.svelte";
+
+describe("Stacked modals", () => {
+  it("closes only the topmost modal when Escape is pressed", async () => {
+    render(ModalStacked);
+
+    await user.click(screen.getByTestId("launch-sibling-modal"));
+    await user.click(screen.getByTestId("launch-child-modal"));
+
+    expect(screen.getByTestId("modal")).toBeInTheDocument();
+    expect(screen.getByTestId("sibling-modal")).toHaveClass("is-visible");
+    expect(screen.getByTestId("child-modal")).toHaveClass("is-visible");
+
+    await user.keyboard("{Escape}");
+
+    expect(screen.getByTestId("modal")).toHaveClass("is-visible");
+    expect(screen.getByTestId("sibling-modal")).toHaveClass("is-visible");
+    expect(screen.getByTestId("child-modal")).not.toHaveClass("is-visible");
+  });
+});


### PR DESCRIPTION
Fixes Escape closing every nested modal at once, plus regression
coverage confirming an OverflowMenu inside a modal still eats the
first Escape before the modal eats the second.