### PR TITLE
fix(combo-box): restore controlled selection label on non-matching blur

### DIFF
--- a/src/ComboBox/ComboBox.svelte
+++ b/src/ComboBox/ComboBox.svelte
@@ -607,6 +607,25 @@
   }
 
   /**
+   * Restore the selected item's label, or clear a non-matching custom value.
+   * The Tab handler calls this itself. Tab moves focus after `close()`
+   * flips `open`, so the `afterUpdate` open watcher can still see the
+   * input as focused and skip the restore.
+   */
+  function normalizeValue() {
+    // Read `selectedId` from `itemsById`, not the reactive `selectedItem`.
+    // A handler earlier in this same event may have just set `selectedId`,
+    // and the `$:` block that derives `selectedItem` has not re-run yet.
+    const currentSelectedItem =
+      selectedId === undefined ? undefined : itemsById.get(selectedId);
+    if (currentSelectedItem) {
+      value = itemToString(currentSelectedItem);
+    } else if (!allowCustomValue) {
+      value = "";
+    }
+  }
+
+  /**
    * Close the dropdown and surface the dismissal cause.
    * Guarded on `open` so redundant assignments don't double-fire the event.
    * @param {"escape-key" | "outside-click" | "select"} trigger
@@ -708,7 +727,10 @@
           }
 
           if (!value.length) {
-            clear();
+            // Skip `clear()`. It drops `selectedId`, so a later unmatched blur
+            // has nothing to restore.
+            highlightedIndex = -1;
+            highlightOrigin = null;
             open = true;
           }
         }}
@@ -767,9 +789,11 @@
             highlightedIndex = -1;
             highlightOrigin = null;
           } else if (event.key === "Tab") {
-            // Accept the inline suggestion before focus moves to the next
-            // control. Tab is not prevented, so focus still advances normally.
+            // Accept the inline typeahead suggestion before focus moves to
+            // the next control. Tab is not prevented, so focus still
+            // advances normally.
             const accepted = acceptTypeaheadSuggestion();
+            if (!accepted) normalizeValue();
             close(accepted ? "select" : "escape-key");
           } else if (
             typeahead &&

--- a/src/ComboBox/ComboBox.svelte
+++ b/src/ComboBox/ComboBox.svelte
@@ -607,6 +607,29 @@
   }
 
   /**
+   * Select the keyboard-highlighted item the same way Enter does.
+   * Without this, Tab discards the highlight instead of selecting it.
+   * @returns {boolean} Whether an item was committed.
+   */
+  function commitHighlightedItem() {
+    const item = filteredItems[highlightedIndex];
+    if (
+      open &&
+      highlightOrigin === "keyboard" &&
+      highlightedIndex > -1 &&
+      item &&
+      !item.disabled &&
+      item.id !== selectedId
+    ) {
+      value = itemToString(item);
+      selectedItem = item;
+      selectedId = item.id;
+      return true;
+    }
+    return false;
+  }
+
+  /**
    * Restore the selected item's label, or clear a non-matching custom value.
    * The Tab handler calls this itself. Tab moves focus after `close()`
    * flips `open`, so the `afterUpdate` open watcher can still see the
@@ -789,10 +812,10 @@
             highlightedIndex = -1;
             highlightOrigin = null;
           } else if (event.key === "Tab") {
-            // Accept the inline typeahead suggestion before focus moves to
-            // the next control. Tab is not prevented, so focus still
-            // advances normally.
-            const accepted = acceptTypeaheadSuggestion();
+            // Commit a keyboard highlight or typeahead suggestion first.
+            // Tab is not prevented, so focus still advances.
+            const committed = commitHighlightedItem();
+            const accepted = committed || acceptTypeaheadSuggestion();
             if (!accepted) normalizeValue();
             close(accepted ? "select" : "escape-key");
           } else if (

--- a/src/ComboBox/ComboBox.svelte
+++ b/src/ComboBox/ComboBox.svelte
@@ -519,7 +519,8 @@
   $: itemsToRender = virtualState.itemsToRender;
 
   $: if (typeahead) {
-    const topItemText = filteredItems[0] ? itemToString(filteredItems[0]) : "";
+    const topItem = filteredItems.find((item) => !item.disabled);
+    const topItemText = topItem ? itemToString(topItem) : "";
     // Inline completion only makes sense when the top match starts with the
     // typed text. A custom (fuzzy/contains) filter can surface items that do
     // not, where appending the untyped tail would produce a nonsense value

--- a/src/ListBox/ListBoxSelection.svelte
+++ b/src/ListBox/ListBoxSelection.svelte
@@ -51,9 +51,9 @@
     ctx.declareRef({ key: "selection", ref });
   }
   $: translationId =
-    selectionCount === undefined
-      ? translationIds.clearSelection
-      : translationIds.clearAll;
+    selectionCount !== undefined && selectionCount > 1
+      ? translationIds.clearAll
+      : translationIds.clearSelection;
   $: buttonLabel =
     translateWithId?.(translationId) ?? defaultTranslations[translationId];
   $: description =

--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -1055,6 +1055,15 @@
               on:clear={() => {
               value = "";
               open = false;
+              // `bind:value` writes the DOM value without firing "input",
+              // so the `on:input` below would miss this clear. Set the
+              // node first, then dispatch. Svelte's `bind:value` listener
+              // reads `event.target.value`, and the reactive assignment
+              // above has not flushed yet.
+              if (inputRef) {
+                inputRef.value = "";
+                inputRef.dispatchEvent(new Event("input", { bubbles: true }));
+              }
             }}
               translateWithId={translateWithIdSelection}
               {disabled}

--- a/tests/ComboBox/ComboBox.test.ts
+++ b/tests/ComboBox/ComboBox.test.ts
@@ -1193,6 +1193,36 @@ describe("ComboBox", () => {
     expect(input).toHaveValue("Custom Value");
   });
 
+  it("should not dispatch select with an empty selectedId on blur when allowCustomValue input is empty", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(ComboBox, { props: { allowCustomValue: true } });
+
+    const input = getInput();
+    await user.click(input);
+    await user.click(document.body);
+
+    expect(consoleLog).not.toHaveBeenCalledWith("select", expect.anything());
+  });
+
+  it("should not dispatch select with an empty selectedId after clearing a prior selection then blurring", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(ComboBox, { props: { allowCustomValue: true } });
+
+    const input = getInput();
+    await user.click(input);
+    await user.click(screen.getByText("Email"));
+    consoleLog.mockClear();
+
+    await user.click(input);
+    await user.clear(input);
+    await user.click(document.body);
+
+    const calls = consoleLog.mock.calls.filter(([type]) => type === "select");
+    for (const [, detail] of calls) {
+      expect(detail.selectedId).not.toBe("");
+    }
+  });
+
   it("should preserve custom value when allowCustomValue is true and menu closes", async () => {
     render(ComboBox, { props: { allowCustomValue: true } });
 
@@ -1211,6 +1241,23 @@ describe("ComboBox", () => {
     await user.type(input, "Custom Value");
     await user.click(document.body);
     expect(input).toHaveValue("");
+  });
+
+  it("should keep an externally-updated selection after the menu closes", async () => {
+    const { rerender } = render(ComboBox, { props: { selectedId: "0" } });
+
+    const input = getInput();
+    expect(input).toHaveValue("Slack");
+
+    // Simulate a parent updating selectedId from outside this ComboBox.
+    await rerender({ selectedId: "2" });
+    expect(input).toHaveValue("Fax");
+
+    // Open then dismiss the menu without making a new selection.
+    await user.click(input);
+    await user.click(document.body);
+
+    expect(input).toHaveValue("Fax");
   });
 
   it("should restore the initial controlled selection's label on blur with a non-matching value", async () => {
@@ -1438,6 +1485,28 @@ describe("ComboBox", () => {
       expect(input).toHaveValue("Apple");
       expect(input.selectionStart).toBe(2);
       expect(input.selectionEnd).toBe(5);
+    });
+
+    it("should not commit a typeahead selection on Tab after the menu is closed via Escape", async () => {
+      const consoleLog = vi.spyOn(console, "log");
+      render(ComboBox, {
+        props: {
+          typeahead: true,
+          items: [
+            { id: "1", text: "Apple", price: 100 },
+            { id: "2", text: "Apricot", price: 200 },
+          ],
+        },
+      });
+
+      const input = getInput();
+      await user.click(input);
+      await user.type(input, "Ap");
+      await user.keyboard("{Escape}");
+
+      await user.keyboard("{Tab}");
+
+      expect(consoleLog).not.toHaveBeenCalledWith("select", expect.anything());
     });
 
     it("should skip a disabled item when suggesting and completing a typeahead match on Tab", async () => {

--- a/tests/ComboBox/ComboBox.test.ts
+++ b/tests/ComboBox/ComboBox.test.ts
@@ -75,6 +75,22 @@ describe("ComboBox", () => {
     expect(input).toHaveValue("Slack");
   });
 
+  it("should commit a keyboard-highlighted item on Tab, same as Enter", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(ComboBox);
+
+    const input = getInput();
+    await user.click(input);
+    await user.keyboard("{ArrowDown}");
+    await user.keyboard("{Tab}");
+
+    expect(input).toHaveValue("Slack");
+    expect(consoleLog).toHaveBeenCalledWith("select", {
+      selectedId: "0",
+      selectedItem: { id: "0", text: "Slack", price: 100 },
+    });
+  });
+
   it("should open the menu on ArrowDown and highlight the first enabled item", async () => {
     render(ComboBox);
 

--- a/tests/ComboBox/ComboBox.test.ts
+++ b/tests/ComboBox/ComboBox.test.ts
@@ -1197,6 +1197,20 @@ describe("ComboBox", () => {
     expect(input).toHaveValue("");
   });
 
+  it("should restore the initial controlled selection's label on blur with a non-matching value", async () => {
+    render(ComboBox, { props: { selectedId: "1", allowCustomValue: false } });
+
+    const input = getInput();
+    expect(input).toHaveValue("Email");
+
+    await user.click(input);
+    await user.clear(input);
+    await user.type(input, "no-match");
+    await user.keyboard("{Tab}");
+
+    expect(input).toHaveValue("Email");
+  });
+
   it("should preserve custom value when allowCustomValue is true and Enter is pressed", async () => {
     render(ComboBox, { props: { allowCustomValue: true } });
 

--- a/tests/ComboBox/ComboBox.test.ts
+++ b/tests/ComboBox/ComboBox.test.ts
@@ -1440,6 +1440,29 @@ describe("ComboBox", () => {
       expect(input.selectionEnd).toBe(5);
     });
 
+    it("should skip a disabled item when suggesting and completing a typeahead match on Tab", async () => {
+      render(ComboBox, {
+        props: {
+          typeahead: true,
+          items: [
+            { id: "ibm-cloud", text: "IBM Cloud", price: 0, disabled: true },
+            { id: "ibm-quantum", text: "IBM Quantum", price: 0 },
+            { id: "ibm-z", text: "IBM Z", price: 0 },
+          ],
+        },
+      });
+
+      const input = getInput();
+      await user.click(input);
+      await user.type(input, "IBM ");
+
+      expect(input).toHaveValue("IBM Quantum");
+
+      await user.keyboard("{Tab}");
+
+      expect(input).toHaveValue("IBM Quantum");
+    });
+
     it("should filter items using prefix matching when typeahead is enabled", async () => {
       render(ComboBox, {
         props: {

--- a/tests/MultiSelect/MultiSelect.test.svelte
+++ b/tests/MultiSelect/MultiSelect.test.svelte
@@ -6,6 +6,7 @@
 
   export let items: ComponentProps<MultiSelect>["items"] = [];
   export let selectedIds: ComponentProps<MultiSelect>["selectedIds"] = [];
+  export let value: ComponentProps<MultiSelect>["value"] = "";
   export let filterable = false;
   export let filterItem: ComponentProps<MultiSelect>["filterItem"] = undefined;
   export let placeholder = "";
@@ -56,6 +57,7 @@
   aria-label={ariaLabel}
   {items}
   {selectedIds}
+  {value}
   {filterable}
   {filterItem}
   {placeholder}

--- a/tests/MultiSelect/MultiSelect.test.ts
+++ b/tests/MultiSelect/MultiSelect.test.ts
@@ -1638,6 +1638,26 @@ describe("MultiSelect", () => {
       expect(combobox).toHaveFocus();
     });
 
+    it("forwards a native input event when the filter text is cleared via the clear button", async () => {
+      render(MultiSelect, {
+        props: { items, filterable: true, placeholder: "Filter..." },
+      });
+
+      const input = screen.getByRole("combobox") as HTMLInputElement;
+      await user.click(input);
+      await user.type(input, "Em");
+      expect(input).toHaveValue("Em");
+
+      const inputSpy = vi.fn();
+      input.addEventListener("input", inputSpy);
+
+      const clearButton = screen.getByRole("button", { name: /clear/i });
+      await user.click(clearButton);
+
+      expect(input).toHaveValue("");
+      expect(inputSpy).toHaveBeenCalled();
+    });
+
     it("filterable variant has correct ARIA attributes", () => {
       render(MultiSelect, {
         props: {

--- a/tests/MultiSelect/MultiSelect.test.ts
+++ b/tests/MultiSelect/MultiSelect.test.ts
@@ -1658,6 +1658,29 @@ describe("MultiSelect", () => {
       expect(inputSpy).toHaveBeenCalled();
     });
 
+    it("uses the singular clear label when exactly one item is selected", () => {
+      render(MultiSelect, {
+        props: { items, selectedIds: ["0"] },
+      });
+
+      expect(
+        screen.getByRole("button", { name: "Clear selected item" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: "Clear all selected items" }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("uses the plural clear label when more than one item is selected", () => {
+      render(MultiSelect, {
+        props: { items, selectedIds: ["0", "1"] },
+      });
+
+      expect(
+        screen.getByRole("button", { name: "Clear all selected items" }),
+      ).toBeInTheDocument();
+    });
+
     it("filterable variant has correct ARIA attributes", () => {
       render(MultiSelect, {
         props: {

--- a/tests/MultiSelect/MultiSelect.test.ts
+++ b/tests/MultiSelect/MultiSelect.test.ts
@@ -1681,6 +1681,40 @@ describe("MultiSelect", () => {
       ).toBeInTheDocument();
     });
 
+    it("moves focus directly to the next control when tabbing away with the menu open", async () => {
+      render(MultiSelect, { props: { items } });
+      const nextInput = document.createElement("input");
+      nextInput.setAttribute("aria-label", "Next control");
+      document.body.appendChild(nextInput);
+
+      const combobox = screen.getByRole("combobox");
+      combobox.focus();
+      await user.keyboard(" ");
+      expect(combobox).toHaveAttribute("aria-expanded", "true");
+
+      await user.tab();
+
+      expect(document.activeElement).toBe(nextInput);
+      expect(combobox).toHaveAttribute("aria-expanded", "false");
+
+      document.body.removeChild(nextInput);
+    });
+
+    it("re-filters options when the filter value is updated externally, not just by typing", async () => {
+      const { rerender } = render(MultiSelect, {
+        props: { items, filterable: true, placeholder: "Filter..." },
+      });
+
+      await openMenu();
+      expect(screen.getAllByRole("option")).toHaveLength(3);
+
+      // Simulate a parent reassigning the `bind:value`d `value`.
+      await rerender({ items, filterable: true, value: "Email" });
+
+      expect(screen.getAllByRole("option")).toHaveLength(1);
+      expect(screen.getByRole("option", { name: "Email" })).toBeInTheDocument();
+    });
+
     it("filterable variant has correct ARIA attributes", () => {
       render(MultiSelect, {
         props: {


### PR DESCRIPTION
Batch of ComboBox/MultiSelect fixes: Tab now commits a
keyboard-highlighted item and restores a non-matching custom value
back to the controlled selection, typeahead skips disabled items,
and the shared clear-selection control uses the singular label for
exactly one selection. Includes regression coverage for a few
downshift-rooted React bugs that don't apply to this component's
reactive selection model.