### PR TITLE
fix(tooltip): stop tooltip stacking and off-center caret

### DIFF
--- a/e2e/fixtures/TooltipNarrowContainerFixture.svelte
+++ b/e2e/fixtures/TooltipNarrowContainerFixture.svelte
@@ -1,0 +1,22 @@
+<script>
+  import Link from "carbon-components-svelte/Link/Link.svelte";
+  import Tooltip from "carbon-components-svelte/Tooltip/Tooltip.svelte";
+</script>
+
+<!--
+  A narrow containing block reproduces a real bug: the tooltip's
+  `width: auto` shrink-to-fit sizing is bounded by its containing block
+  (this wrapper), which is much narrower than the tooltip's natural content
+  width. `position()` measures that too-narrow width before centering,
+  so the caret ends up off-center from the trigger icon.
+-->
+<div style="width: 230px;" data-testid="narrow-container">
+  <Tooltip triggerText="Round robin">
+    <p>
+      Distributes requests evenly across servers.
+      <Link href="https://en.wikipedia.org/wiki/Round-robin_DNS" target="_blank"
+        >Read more on Wikipedia</Link
+      >
+    </p>
+  </Tooltip>
+</div>

--- a/e2e/fixtures/tooltip-narrow-container.html
+++ b/e2e/fixtures/tooltip-narrow-container.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Tooltip Narrow Container Test</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="./tooltip-narrow-container.ts"></script>
+  </body>
+</html>

--- a/e2e/fixtures/tooltip-narrow-container.ts
+++ b/e2e/fixtures/tooltip-narrow-container.ts
@@ -1,0 +1,4 @@
+import { mount } from "./mount";
+import TooltipNarrowContainerFixture from "./TooltipNarrowContainerFixture.svelte";
+
+mount(TooltipNarrowContainerFixture);

--- a/e2e/tooltip-narrow-container.test.ts
+++ b/e2e/tooltip-narrow-container.test.ts
@@ -1,0 +1,21 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("Tooltip in a narrow containing block", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/tooltip-narrow-container.html");
+  });
+
+  test("centers the caret on the trigger icon", async ({ page }) => {
+    const trigger = page.locator(".bx--tooltip__trigger");
+    await trigger.focus();
+    await expect(page.getByRole("dialog")).toBeVisible();
+
+    const iconBox = await trigger.boundingBox();
+    const caretBox = await page.locator(".bx--tooltip__caret").boundingBox();
+
+    const iconCenterX = iconBox.x + iconBox.width / 2;
+    const caretCenterX = caretBox.x + caretBox.width / 2;
+
+    expect(caretCenterX).toBeCloseTo(iconCenterX, 0);
+  });
+});

--- a/src/Tooltip/Tooltip.svelte
+++ b/src/Tooltip/Tooltip.svelte
@@ -161,8 +161,16 @@
     }
   }
 
-  function onBlur(event) {
-    if (refTooltip && !refTooltip.contains(event.relatedTarget)) {
+  // Bound to both the trigger and the tooltip content (which can hold
+  // interactive elements, e.g. a `Link` or `TooltipFooter` button). Using
+  // `focusout` instead of `blur` lets a single listener on the content
+  // wrapper catch focus leaving any of its descendants, since `blur` doesn't
+  // bubble. Without this, tabbing out of content past the trigger's own
+  // blur never closes the tooltip, leaving it open indefinitely.
+  function onFocusOut(event) {
+    const next = event.relatedTarget;
+    const stillInside = ref?.contains(next) || refTooltip?.contains(next);
+    if (!stillInside) {
       open = false;
     }
     focusByMouse = false;
@@ -296,7 +304,7 @@
         on:mouseenter={onMouseEnter}
         on:mousedown={onMouseDown}
         on:focus={onFocus}
-        on:blur={onBlur}
+        on:focusout={onFocusOut}
         on:keydown={onKeydown}
       >
         <slot name="icon">
@@ -313,7 +321,7 @@
       on:mouseenter={onMouseEnter}
       on:mousedown={onMouseDown}
       on:focus={onFocus}
-      on:blur={onBlur}
+      on:focusout={onFocusOut}
       on:keydown={onKeydown}
     >
       <slot name="triggerText">{triggerText}</slot>
@@ -334,7 +342,9 @@
       class:bx--tooltip--align-center={align === "center"}
       class:bx--tooltip--align-start={align === "start"}
       class:bx--tooltip--align-end={align === "end"}
+      style:width="max-content"
       on:mouseenter={onMouseEnter}
+      on:focusout={onFocusOut}
       on:keydown={onKeydown}
     >
       <span class:bx--tooltip__caret={true}></span>
@@ -384,6 +394,7 @@
         class:bx--tooltip--align-end={align === "end"}
         style="position: relative; transform: none; display: block; left: auto; margin-top: 0;"
         on:mouseenter={onMouseEnter}
+        on:focusout={onFocusOut}
         on:keydown={onKeydown}
       >
         <span class:bx--tooltip__caret={true}></span>

--- a/tests/Tooltip/Tooltip.test.ts
+++ b/tests/Tooltip/Tooltip.test.ts
@@ -15,6 +15,7 @@ import TooltipHideIcon from "./TooltipHideIcon.test.svelte";
 import TooltipNoLabel from "./TooltipNoLabel.test.svelte";
 import TooltipOpen from "./TooltipOpen.test.svelte";
 import TooltipPortalDirections from "./TooltipPortalDirections.test.svelte";
+import TooltipTwoInstancesFocus from "./TooltipTwoInstancesFocus.test.svelte";
 
 describe("Tooltip", () => {
   beforeEach(() => {
@@ -280,6 +281,32 @@ describe("Tooltip", () => {
 
     expect(screen.getByRole("dialog")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Learn more" })).not.toHaveFocus();
+  });
+
+  test("should close when focus tabs out of its content into another tooltip's trigger", async () => {
+    render(TooltipTwoInstancesFocus);
+
+    const trigger1 = screen.getByRole("button", { name: "First" });
+    await fireEvent.focus(trigger1);
+    expect(
+      screen.getByRole("link", { name: "Learn more" }),
+    ).toBeInTheDocument();
+
+    // Focus moves from the trigger into the link inside its own tooltip content.
+    const link = screen.getByRole("link", { name: "Learn more" });
+    await fireEvent.focusOut(trigger1, { relatedTarget: link });
+    await fireEvent.focus(link);
+    expect(
+      screen.getByRole("link", { name: "Learn more" }),
+    ).toBeInTheDocument();
+
+    // Focus then leaves the content for the second tooltip's trigger.
+    const trigger2 = screen.getByRole("button", { name: "Second" });
+    await fireEvent.focusOut(link, { relatedTarget: trigger2 });
+
+    expect(
+      screen.queryByRole("link", { name: "Learn more" }),
+    ).not.toBeInTheDocument();
   });
 
   test("should have a non-empty accessible name with no props set", () => {

--- a/tests/Tooltip/TooltipTwoInstancesFocus.test.svelte
+++ b/tests/Tooltip/TooltipTwoInstancesFocus.test.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+  import Tooltip from "carbon-components-svelte/Tooltip/Tooltip.svelte";
+</script>
+
+<Tooltip triggerText="First">
+  <p><a href="/first">Learn more</a></p>
+</Tooltip>
+<Tooltip triggerText="Second">
+  <p>Second tooltip content</p>
+</Tooltip>


### PR DESCRIPTION
Tabbing out of interactive tooltip content (a Link, or a
TooltipFooter button) never closed the tooltip, since blur was only
wired to the trigger icon. Fixes it by listening for focusout on
both the trigger and the content, so focus leaving either one closes
the tooltip while focus moving between them keeps it open.

Also fixes the caret sitting off-center from the trigger icon when
the tooltip's containing block is narrower than its natural content
width (e.g. a DataTable cell). The tooltip's width was computed with
`width: auto`, which shrink-fits against the containing block before
`position()` measures it, producing a stale width. Giving it
`width: max-content` decouples it from the containing block.

---

<img width="905" height="365" alt="Screenshot 2026-08-16 at 10 50 01 AM" src="https://github.com/user-attachments/assets/d5840704-e6a6-41fd-8360-55a8d1951c15" />
