### PR TITLE
fix(text-input): use aria-errormessage for invalid state

### DIFF
--- a/src/ComboBox/ComboBox.svelte
+++ b/src/ComboBox/ComboBox.svelte
@@ -728,11 +728,12 @@
           aria-disabled={disabled || readonly}
           aria-readonly={readonly || undefined}
           aria-controls={open ? menuId : undefined}
-          aria-describedby={showInvalid && invalidText
-          ? errorId
+          aria-errormessage={showInvalid && invalidText ? errorId : undefined}
+          aria-describedby={showInvalid
+          ? undefined
           : showWarn && warnText
             ? warnId
-            : !isFluid && !showInvalid && !showWarn && helperText
+            : !isFluid && !showWarn && helperText
               ? helperId
               : undefined}
           {disabled}

--- a/src/DatePicker/DatePickerInput.svelte
+++ b/src/DatePicker/DatePickerInput.svelte
@@ -132,7 +132,7 @@
   $: warnId = `warn-${id}`;
   $: helperId = `helper-${id}`;
   $: describedBy = showInvalid
-    ? errorId
+    ? undefined
     : showWarn
       ? warnId
       : helperText
@@ -169,6 +169,7 @@
       bind:this={ref}
       data-invalid={showInvalid || undefined}
       aria-invalid={showInvalid || undefined}
+      aria-errormessage={showInvalid ? errorId : undefined}
       aria-describedby={describedBy}
       {id}
       {name}

--- a/src/TextArea/TextArea.svelte
+++ b/src/TextArea/TextArea.svelte
@@ -94,10 +94,11 @@
   $: showWarn = warn && !invalid && !disabled && !readonly;
   $: isFluid = fluid || !!formContext?.isFluid;
   $: showCounter = !!maxCount && !!(labelText || $$slots.labelChildren);
+  $: errorMessageId = showInvalid ? errorId : undefined;
   $: describedBy =
     [
       showInvalid
-        ? errorId
+        ? null
         : showWarn && !isFluid
           ? warnId
           : helperText && !isFluid
@@ -163,6 +164,7 @@
       bind:this={ref}
       bind:value
       aria-invalid={showInvalid || undefined}
+      aria-errormessage={errorMessageId}
       aria-describedby={describedBy}
       data-warn={showWarn || undefined}
       {disabled}

--- a/src/TextInput/PasswordInput.svelte
+++ b/src/TextInput/PasswordInput.svelte
@@ -210,8 +210,9 @@
         data-invalid={showInvalid || undefined}
         aria-invalid={showInvalid || undefined}
         data-warn={showWarn || undefined}
+        aria-errormessage={showInvalid ? errorId : undefined}
         aria-describedby={showInvalid
-          ? errorId
+          ? undefined
           : showWarn
             ? warnId
             : helperText && !isFluid

--- a/src/TextInput/TextInput.svelte
+++ b/src/TextInput/TextInput.svelte
@@ -229,8 +229,9 @@
         data-invalid={showInvalid || undefined}
         aria-invalid={showInvalid || undefined}
         data-warn={showWarn || undefined}
+        aria-errormessage={showInvalid ? errorId : undefined}
         aria-describedby={showInvalid
-          ? errorId
+          ? undefined
           : showWarn
             ? warnId
             : helperText && !isFluid
@@ -264,7 +265,9 @@
         <hr class:bx--text-input__divider={true}>
       {/if}
       {#if isFluid && showInvalid}
-        <div class:bx--form-requirement={true} id={errorId}>{invalidText}</div>
+        <div class:bx--form-requirement={true} id={errorId} role="alert">
+          {invalidText}
+        </div>
       {/if}
       {#if isFluid && showWarn}
         <div class:bx--form-requirement={true} id={warnId}>{warnText}</div>
@@ -281,7 +284,9 @@
       </div>
     {/if}
     {#if !isFluid && showInvalid}
-      <div class:bx--form-requirement={true} id={errorId}>{invalidText}</div>
+      <div class:bx--form-requirement={true} id={errorId} role="alert">
+        {invalidText}
+      </div>
     {/if}
     {#if !isFluid && showWarn}
       <div class:bx--form-requirement={true} id={warnId}>{warnText}</div>

--- a/tests/ComboBox/ComboBox.test.ts
+++ b/tests/ComboBox/ComboBox.test.ts
@@ -1161,11 +1161,12 @@ describe("ComboBox", () => {
     expect(screen.getByText("Warn")).toHaveAttribute("id", "warn-cb");
   });
 
-  it("should describe the input by invalidText when invalid is true", () => {
+  it("should reference invalidText via aria-errormessage when invalid is true", () => {
     render(ComboBoxReal, {
       props: { id: "cb", invalid: true, invalidText: "Bad" },
     });
-    expect(getInput()).toHaveAttribute("aria-describedby", "error-cb");
+    expect(getInput()).toHaveAttribute("aria-errormessage", "error-cb");
+    expect(getInput()).not.toHaveAttribute("aria-describedby");
     expect(screen.getByText("Bad")).toHaveAttribute("id", "error-cb");
   });
 
@@ -3334,9 +3335,10 @@ describe("ComboBox", () => {
         "bx--list-box__wrapper--fluid--invalid",
       );
       expect(getInput()).toHaveAttribute(
-        "aria-describedby",
+        "aria-errormessage",
         "error-test-combobox",
       );
+      expect(getInput()).not.toHaveAttribute("aria-describedby");
     });
 
     it("renders the warning message inside the fluid wrapper", () => {

--- a/tests/DatePicker/DatePicker.test.ts
+++ b/tests/DatePicker/DatePicker.test.ts
@@ -233,11 +233,12 @@ describe("DatePicker", () => {
     expect(input).toHaveAttribute("aria-describedby", helperText.id);
   });
 
-  it("associates invalid text with the input and marks it aria-invalid", () => {
+  it("associates invalid text with the input via aria-errormessage and marks it aria-invalid", () => {
     render(DatePicker, { invalid: true, invalidText: "Invalid date" });
     const input = screen.getByLabelText("Date");
     const invalidText = screen.getByText("Invalid date");
-    expect(input).toHaveAttribute("aria-describedby", invalidText.id);
+    expect(input).toHaveAttribute("aria-errormessage", invalidText.id);
+    expect(input).not.toHaveAttribute("aria-describedby");
     expect(input).toHaveAttribute("aria-invalid", "true");
   });
 

--- a/tests/PasswordInput/PasswordInput.test.ts
+++ b/tests/PasswordInput/PasswordInput.test.ts
@@ -374,7 +374,7 @@ describe("PasswordInput", () => {
       expect(message).toHaveClass("bx--form-requirement");
       expect(message.closest(".bx--text-input__field-wrapper")).not.toBeNull();
       expect(screen.getByLabelText("Password")).toHaveAttribute(
-        "aria-describedby",
+        "aria-errormessage",
         "error-test-password",
       );
     });

--- a/tests/TextArea/TextArea.test.ts
+++ b/tests/TextArea/TextArea.test.ts
@@ -245,10 +245,9 @@ describe("TextArea", () => {
       const message = screen.getByText("Invalid input");
       expect(message).toHaveClass("bx--form-requirement");
       expect(message.closest(".bx--text-area__wrapper")).not.toBeNull();
-      expect(screen.getByLabelText("App description")).toHaveAttribute(
-        "aria-describedby",
-        "error-ccs-test",
-      );
+      const textarea = screen.getByLabelText("App description");
+      expect(textarea).toHaveAttribute("aria-errormessage", "error-ccs-test");
+      expect(textarea).not.toHaveAttribute("aria-describedby");
     });
 
     it("renders the warning message inside the input wrapper", () => {

--- a/tests/TextInput/TextInput.test.ts
+++ b/tests/TextInput/TextInput.test.ts
@@ -15,6 +15,15 @@ describe("TextInput", () => {
     expect(screen.getByLabelText("User name")).toBeInTheDocument();
   });
 
+  it("should not render a stray helper element or aria-describedby for an empty-string helperText", () => {
+    const { container } = render(TextInput, { props: { helperText: "" } });
+
+    expect(
+      container.querySelector(".bx--form__helper-text"),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole("textbox")).not.toHaveAttribute("aria-describedby");
+  });
+
   it("should handle placeholder text", () => {
     render(TextInput, {
       props: { placeholder: "Enter user name..." },
@@ -313,7 +322,7 @@ describe("TextInput", () => {
       expect(message).toHaveClass("bx--form-requirement");
       expect(message.closest(".bx--text-input__field-wrapper")).not.toBeNull();
       expect(screen.getByLabelText("User name")).toHaveAttribute(
-        "aria-describedby",
+        "aria-errormessage",
         "error-test-input",
       );
     });
@@ -380,7 +389,7 @@ describe("TextInput", () => {
     });
   });
 
-  it("should set aria-describedby to error id when invalid", () => {
+  it("should set aria-errormessage (not aria-describedby) to the error id when invalid", () => {
     render(TextInput, {
       props: {
         id: "test-input",
@@ -390,7 +399,8 @@ describe("TextInput", () => {
     });
 
     const input = screen.getByRole("textbox");
-    expect(input).toHaveAttribute("aria-describedby", "error-test-input");
+    expect(input).toHaveAttribute("aria-errormessage", "error-test-input");
+    expect(input).not.toHaveAttribute("aria-describedby");
   });
 
   it("should set aria-describedby to warning id when warn", () => {


### PR DESCRIPTION
Invalid-state inputs referenced their error message via
aria-describedby, which per the ARIA spec is meant for general
supplementary description, not error association. Switches
TextInput, PasswordInput, TextArea, DatePickerInput, and ComboBox
to aria-errormessage, paired with aria-invalid, one commit per
component.