### PR TITLE
fix(multi-select): serialize selection via hidden inputs, not the menu

### DIFF
--- a/docs/src/pages/components/MultiSelect.svx
+++ b/docs/src/pages/components/MultiSelect.svx
@@ -63,23 +63,29 @@ Hide the label visually by setting `hideLabel` to `true`. The label remains avai
 
 ### Checkbox values
 
-Customize checkbox attributes using the `itemToInput` prop. This example sets a consistent name for all checkboxes.
+`MultiSelect` mounts a hidden `<input>` for every selected item, derived
+from the current selection -- not from what's rendered in the dropdown. This
+keeps native form submission (`FormData`) working while the menu is closed,
+while filtering, and with `virtualize`.
 
-Use itemToInput to customize the user-selectable checkbox values.
-This will also override the underlying hidden inputs used for form submission.
+By default, each hidden input uses `name={item.id}` and an empty `value`,
+matching the option checkbox's own defaults. Use `itemToInput` to override
+`name`/`value` per item, or set the `name` prop to give every hidden input a
+shared group name (unless `itemToInput` returns its own `name`). `name` is
+only used for the hidden inputs -- with `filterable`, the visible text input
+is a query box and is never included in `FormData`.
 
 ```js
 itemToInput={(item) => {
   return {
-    name: `Contact_${item.id}`,
+    name: 'contact',
     value: item.id
   }
 }}
 ```
 
-The above function sets the name attribute to
-Contact_0 (respective to each item's id) for every hidden input that
-renders, along with each respective item's id set to the value attribute.
+The above function sets every hidden input's name to `contact` and its value
+to the respective item's id, so a submission looks like `contact=0&contact=1`.
 
 <MultiSelect
   itemToInput={(item) => ({name: 'contact', value: item.id})}
@@ -91,6 +97,26 @@ renders, along with each respective item's id set to the value attribute.
     {id: "2", text: "Fax"}
   ]}"
 />
+
+```svelte
+<script>
+  import { Form, MultiSelect, Button } from "carbon-components-svelte";
+</script>
+
+<Form method="POST" action="?/subscribe">
+  <MultiSelect
+    name="contact"
+    labelText="Contact"
+    label="Select contact methods..."
+    items={[
+      {id: "0", text: "Slack"},
+      {id: "1", text: "Email"},
+      {id: "2", text: "Fax"}
+    ]}
+  />
+  <Button type="submit">Save</Button>
+</Form>
+```
 
 ## Selection
 

--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -35,7 +35,11 @@
   export let itemToString = (item) => item.text ?? item.id;
 
   /**
-   * Override the item name, title, labelText, or value passed to the user-selectable checkbox input as well as the hidden inputs.
+   * Override `name`/`value` for the hidden inputs that mirror the current
+   * selection for native form submission, and `title`/`labelText` for the
+   * visible option checkbox. `name`/`value` do not reach the option
+   * checkbox itself -- it is decorative and excluded from form
+   * participation, even while the menu is open.
    * @type {(item: Item) => { name?: string; labelText?: any; title?: string; value?: string }}
    */
   export let itemToInput = (_item) => {};
@@ -222,7 +226,10 @@
       : `${count} result${count === 1 ? "" : "s"} available`;
 
   /**
-   * Specify a name attribute for the select.
+   * Default group name for the hidden inputs that mirror the current
+   * selection for native form submission (`FormData`). Used per item
+   * unless `itemToInput` returns its own `name`. Not applied to the
+   * filterable text input, which is a query box, not the form value.
    * @type {string}
    */
   export let name = undefined;
@@ -786,6 +793,17 @@
   $: hasSelectAll = items.some((item) => item.isSelectAll);
   $: checked = sortedItems.filter((item) => item.checked);
   $: unchecked = sortedItems.filter((item) => !item.checked);
+  // Native form participation, decoupled from what's rendered: derived from
+  // `items` + `selectedIds` directly (in `items` order), never
+  // `sortedItems`/`checked` (whose order shifts with `selectionFeedback`),
+  // `filteredItems`, or the virtual window. Excludes the isSelectAll
+  // pseudo-item and disabled items (matching native disabled checkboxes,
+  // which never submit).
+  $: selectedIdsSet = new Set(selectedIds);
+  $: formItems = items.filter(
+    (item) =>
+      !item.isSelectAll && !item.disabled && selectedIdsSet.has(item.id),
+  );
   $: selectableItems = sortedItems.filter(
     (item) => !item.disabled && !item.isSelectAll,
   );
@@ -910,6 +928,14 @@
   class:bx--list-box__wrapper--fluid--condensed={isFluid && condensed}
   class:bx--multi-select--filterable__wrapper={isFluid && filterable}
 >
+  {#each formItems as item (item.id)}
+    {@const itemInput = itemToInput(item) ?? {}}
+    <input
+      type="hidden"
+      name={itemInput.name ?? name ?? item.id}
+      value={itemInput.value ?? ""}
+    >
+  {/each}
   {#if labelText || $$slots.labelChildren}
     <label
       for={id}
@@ -1049,7 +1075,6 @@
             {readonly}
             {placeholder}
             {id}
-            {name}
           >
           {#if value}
             <ListBoxSelection
@@ -1280,9 +1305,9 @@
                 >
                   <HighlightSlot {optionId} let:highlighted>
                     <Checkbox
-                      name={item.id}
                       title={useTitleInItem ? itemToString(item) : undefined}
                       {...itemToInput(item)}
+                      name={undefined}
                       tabindex="-1"
                       decorative
                       id="checkbox-{id}-{item.id}"
@@ -1364,9 +1389,9 @@
             >
               <HighlightSlot {optionId} let:highlighted>
                 <Checkbox
-                  name={item.id}
                   title={useTitleInItem ? itemToString(item) : undefined}
                   {...itemToInput(item)}
+                  name={undefined}
                   tabindex="-1"
                   decorative
                   id="checkbox-{id}-{item.id}"

--- a/tests/MultiSelect/MultiSelect.form.test.svelte
+++ b/tests/MultiSelect/MultiSelect.form.test.svelte
@@ -1,0 +1,35 @@
+<svelte:options accessors />
+
+<script lang="ts">
+  import MultiSelect from "carbon-components-svelte/MultiSelect/MultiSelect.svelte";
+  import type { ComponentProps } from "svelte";
+
+  export let items: ComponentProps<MultiSelect>["items"] = [];
+  export let selectedIds: ComponentProps<MultiSelect>["selectedIds"] = [];
+  export let itemToInput: ComponentProps<MultiSelect>["itemToInput"] =
+    undefined;
+  export let name: ComponentProps<MultiSelect>["name"] = undefined;
+  export let filterable = false;
+  export let filterItem: ComponentProps<MultiSelect>["filterItem"] = undefined;
+  export let open: ComponentProps<MultiSelect>["open"] = undefined;
+  export let virtualize: ComponentProps<MultiSelect>["virtualize"] = undefined;
+  export let portalMenu: ComponentProps<MultiSelect>["portalMenu"] = false;
+  export let value: ComponentProps<MultiSelect>["value"] = "";
+</script>
+
+<form data-testid="form">
+  <MultiSelect
+    labelText="Contact"
+    label="Select contact methods..."
+    {items}
+    {selectedIds}
+    {itemToInput}
+    {name}
+    {filterable}
+    {filterItem}
+    {open}
+    {virtualize}
+    {portalMenu}
+    bind:value
+  />
+</form>

--- a/tests/MultiSelect/MultiSelect.form.test.ts
+++ b/tests/MultiSelect/MultiSelect.form.test.ts
@@ -1,0 +1,172 @@
+import { render, screen } from "@testing-library/svelte";
+import type { MultiSelectItem } from "carbon-components-svelte/MultiSelect/MultiSelect.svelte";
+import { user } from "../utils/user";
+import MultiSelectForm from "./MultiSelect.form.test.svelte";
+
+const items = [
+  { id: "0", text: "Slack" },
+  { id: "1", text: "Email" },
+  { id: "2", text: "Fax" },
+] as const;
+
+describe("MultiSelect native form serialization", () => {
+  const getForm = () => screen.getByTestId("form") as HTMLFormElement;
+
+  const openMenu = async () =>
+    await user.click(await screen.findByRole("combobox", { expanded: false }));
+
+  it("submits selected items while the menu is closed, keyed by item id by default", () => {
+    render(MultiSelectForm, {
+      props: { items, selectedIds: ["0", "1"] },
+    });
+
+    const formData = new FormData(getForm());
+    expect(formData.has("0")).toBe(true);
+    expect(formData.has("1")).toBe(true);
+    expect(formData.has("2")).toBe(false);
+  });
+
+  it("uses a shared name and per-item value from itemToInput", () => {
+    render(MultiSelectForm, {
+      props: {
+        items,
+        selectedIds: ["0", "1"],
+        itemToInput: (item: MultiSelectItem) => ({
+          name: "contact",
+          value: item.id,
+        }),
+      },
+    });
+
+    const formData = new FormData(getForm());
+    expect(formData.getAll("contact")).toEqual(["0", "1"]);
+  });
+
+  it("uses the `name` prop as the default group name when itemToInput does not override it", () => {
+    render(MultiSelectForm, {
+      props: { items, selectedIds: ["0", "1"], name: "items" },
+    });
+
+    const formData = new FormData(getForm());
+    expect(formData.getAll("items")).toHaveLength(2);
+    expect(formData.has("0")).toBe(false);
+    expect(formData.has("1")).toBe(false);
+  });
+
+  it("does not duplicate entries when the menu is open", async () => {
+    render(MultiSelectForm, {
+      props: {
+        items,
+        selectedIds: ["0", "1"],
+        itemToInput: (item: MultiSelectItem) => ({
+          name: "contact",
+          value: item.id,
+        }),
+      },
+    });
+
+    await openMenu();
+
+    const formData = new FormData(getForm());
+    expect(formData.getAll("contact")).toEqual(["0", "1"]);
+  });
+
+  it("omits the isSelectAll item", () => {
+    const itemsWithSelectAll = [
+      { id: "select-all", text: "All roles", isSelectAll: true },
+      { id: "editor", text: "Editor" },
+      { id: "owner", text: "Owner" },
+    ];
+
+    render(MultiSelectForm, {
+      props: {
+        items: itemsWithSelectAll,
+        selectedIds: ["select-all", "editor", "owner"],
+      },
+    });
+
+    const formData = new FormData(getForm());
+    expect(formData.has("select-all")).toBe(false);
+    expect(formData.has("editor")).toBe(true);
+    expect(formData.has("owner")).toBe(true);
+  });
+
+  it("omits disabled items even when selected", () => {
+    const itemsWithDisabled = [
+      { id: "0", text: "Slack" },
+      { id: "1", text: "Email", disabled: true },
+    ];
+
+    render(MultiSelectForm, {
+      props: {
+        items: itemsWithDisabled,
+        selectedIds: ["0", "1"],
+      },
+    });
+
+    const formData = new FormData(getForm());
+    expect(formData.has("0")).toBe(true);
+    expect(formData.has("1")).toBe(false);
+  });
+
+  it("contributes nothing to FormData when nothing is selected", () => {
+    render(MultiSelectForm, { props: { items, selectedIds: [] } });
+
+    const formData = new FormData(getForm());
+    expect([...formData.keys()]).toEqual([]);
+  });
+
+  it("filterable: submits the selection while closed and never the filter query, even when `name` is set", async () => {
+    render(MultiSelectForm, {
+      props: {
+        items,
+        filterable: true,
+        selectedIds: ["0"],
+        name: "items",
+      },
+    });
+
+    const input = screen.getByRole("combobox") as HTMLInputElement;
+    await user.type(input, "no-match-xyz");
+
+    const formData = new FormData(getForm());
+    expect(formData.getAll("items")).toHaveLength(1);
+    expect([...formData.values()]).not.toContain("no-match-xyz");
+  });
+
+  it("filterable: honors itemToInput while closed", () => {
+    render(MultiSelectForm, {
+      props: {
+        items,
+        filterable: true,
+        selectedIds: ["0", "1"],
+        itemToInput: (item: MultiSelectItem) => ({
+          name: "contact",
+          value: item.id,
+        }),
+      },
+    });
+
+    const formData = new FormData(getForm());
+    expect(formData.getAll("contact")).toEqual(["0", "1"]);
+  });
+
+  it("virtualize: serializes the full selection while closed, beyond the viewport window", () => {
+    const manyItems = Array.from({ length: 150 }, (_, index) => ({
+      id: String(index),
+      text: `Item ${index}`,
+    }));
+
+    render(MultiSelectForm, {
+      props: {
+        items: manyItems,
+        virtualize: true,
+        selectedIds: ["0", "149"],
+      },
+    });
+
+    const formData = new FormData(getForm());
+    expect(formData.has("0")).toBe(true);
+    expect(formData.has("149")).toBe(true);
+  });
+});

--- a/tests/MultiSelect/MultiSelect.test.ts
+++ b/tests/MultiSelect/MultiSelect.test.ts
@@ -1751,7 +1751,10 @@ describe("MultiSelect", () => {
       await openMenu();
       const option = screen.getByRole("option", { name: "Slack" });
       const checkbox = option.querySelector('input[type="checkbox"]');
-      expect(checkbox).toHaveAttribute("name", "contact_0");
+      // The option checkbox is decorative and excluded from native form
+      // participation; itemToInput's `name` targets the always-mounted
+      // hidden inputs instead (see MultiSelect.form.test.ts).
+      expect(checkbox).not.toHaveAttribute("name", "contact_0");
       expect(checkbox).toHaveAttribute("value", "slack");
     });
   });


### PR DESCRIPTION
PR #1835 fixed #1742 by keeping closed-menu checkboxes in the DOM via
`display: none`. #6ff5823ab swapped that for `{#if open}` to cut mount
cost on large lists, which quietly broke #1835 again (filterable,
virtualize, and portalMenu never honored it either). Hidden inputs now
mirror `selectedIds` directly, so submission doesn't depend on what's
mounted, and the perf win stays intact.