### PR TITLE
fix(dropdown): serialize selectedId via a hidden input

### DIFF
--- a/docs/src/pages/components/ComboBox.svx
+++ b/docs/src/pages/components/ComboBox.svx
@@ -557,3 +557,30 @@ items={[
 Display a loading skeleton for the fluid combo box variant.
 
 <FluidComboBoxSkeleton />
+
+## Form name
+
+Set `name` so the combo box participates in native form submission (for
+example SvelteKit form actions and `FormData`). Unlike [Dropdown](/components/Dropdown#form-name),
+`name` lands directly on the always-mounted text input, so it submits
+the displayed text (`value`), not `selectedId`, empty string when
+nothing is selected.
+
+```svelte
+<script>
+  import { Form, ComboBox, Button } from "carbon-components-svelte";
+</script>
+
+<Form method="POST" action="?/contact">
+  <ComboBox
+    name="contactMethod"
+    labelText="Contact"
+    items={[
+      { id: "0", text: "Slack" },
+      { id: "1", text: "Email" },
+      { id: "2", text: "Fax" },
+    ]}
+  />
+  <Button type="submit">Submit</Button>
+</Form>
+```

--- a/docs/src/pages/components/Dropdown.svx
+++ b/docs/src/pages/components/Dropdown.svx
@@ -363,6 +363,32 @@ When inside a [Modal](/components/Modal#modal-with-dropdowns), `portalMenu` defa
 
 <FileSource src="/framed/Dropdown/DropdownPortalMenu" />
 
+## Form name
+
+Set `name` so the selection participates in native form submission (for
+example SvelteKit form actions and `FormData`). A hidden input mirrors
+`selectedId`, submitting an empty string when nothing is selected or when
+the selected item is disabled.
+
+```svelte
+<script>
+  import { Form, Dropdown, Button } from "carbon-components-svelte";
+</script>
+
+<Form method="POST" action="?/contact">
+  <Dropdown
+    name="contactMethod"
+    labelText="Contact"
+    items={[
+      { id: "0", text: "Slack" },
+      { id: "1", text: "Email" },
+      { id: "2", text: "Fax" },
+    ]}
+  />
+  <Button type="submit">Submit</Button>
+</Form>
+```
+
 ## Skeleton
 
 Display a loading state using the dropdown skeleton.

--- a/src/Dropdown/Dropdown.svelte
+++ b/src/Dropdown/Dropdown.svelte
@@ -192,7 +192,10 @@
   export let id = uniqueId();
 
   /**
-   * Specify a name attribute for the list box.
+   * Specify a name attribute for native form submission.
+   * Mounts a hidden input whose value mirrors `selectedId`
+   * (empty string when nothing is selected, or when the
+   * selected item is disabled).
    * @type {string}
    */
   export let name = undefined;
@@ -320,6 +323,10 @@
       ? `${id}-${items[highlightedIndex].id}`
       : undefined;
   $: selectedItem = itemsById.get(selectedId);
+  // Mirrors native `<select><option value>`: a disabled selection is not a
+  // successful control, so it serializes as empty like nothing being selected.
+  $: hiddenInputValue =
+    selectedId === undefined || selectedItem?.disabled ? "" : selectedId;
   $: if (!open) {
     highlightedIndex = -1;
     highlightOrigin = null;
@@ -609,10 +616,12 @@
       <slot name="labelChildren"> {labelText} </slot>
     </label>
   {/if}
+  {#if name}
+    <input type="hidden" {name} value={hiddenInputValue}>
+  {/if}
   <ListBox
     {type}
     {size}
-    {name}
     aria-label={$$props["aria-label"]}
     class={dropdownListBoxClass}
     on:click={(event) => {

--- a/tests/ComboBox/ComboBox.form.test.svelte
+++ b/tests/ComboBox/ComboBox.form.test.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+  import ComboBox from "carbon-components-svelte/ComboBox/ComboBox.svelte";
+  import type { ComponentProps } from "svelte";
+
+  export let items: ComponentProps<ComboBox>["items"] = [];
+  export let selectedId: ComponentProps<ComboBox>["selectedId"] = undefined;
+  export let value: ComponentProps<ComboBox>["value"] = "";
+  export let name: ComponentProps<ComboBox>["name"] = undefined;
+  export let virtualize: ComponentProps<ComboBox>["virtualize"] = undefined;
+  export let portalMenu: ComponentProps<ComboBox>["portalMenu"] = false;
+  export let open: ComponentProps<ComboBox>["open"] = false;
+</script>
+
+<form data-testid="form">
+  <ComboBox
+    id="test-combobox"
+    {items}
+    bind:selectedId
+    bind:value
+    {name}
+    {virtualize}
+    {portalMenu}
+    bind:open
+    labelText="Contact"
+  />
+</form>

--- a/tests/ComboBox/ComboBox.form.test.ts
+++ b/tests/ComboBox/ComboBox.form.test.ts
@@ -1,0 +1,105 @@
+import { render, screen } from "@testing-library/svelte";
+import { user } from "../utils/user";
+import ComboBox from "./ComboBox.form.test.svelte";
+
+const items = [
+  { id: "0", text: "Slack" },
+  { id: "1", text: "Email" },
+  { id: "2", text: "Fax" },
+] as const;
+
+const getInput = () => screen.getByRole("combobox") as HTMLInputElement;
+const getForm = () => screen.getByTestId("form") as HTMLFormElement;
+
+describe("ComboBox form participation", () => {
+  it("does not apply a name attribute to the input when name is omitted", () => {
+    render(ComboBox, {
+      props: { items, selectedId: "0", value: "Slack" },
+    });
+
+    expect(getInput()).not.toHaveAttribute("name");
+    expect(Array.from(new FormData(getForm()).keys())).toHaveLength(0);
+  });
+
+  it("serializes the initially selected value while the menu stays closed", () => {
+    render(ComboBox, {
+      props: { items, selectedId: "0", value: "Slack", name: "contact" },
+    });
+
+    expect(getInput()).toHaveAttribute("name", "contact");
+    expect(new FormData(getForm()).get("contact")).toBe("Slack");
+  });
+
+  it("serializes an empty string when nothing is selected", () => {
+    render(ComboBox, {
+      props: { items, name: "contact" },
+    });
+
+    expect(new FormData(getForm()).get("contact")).toBe("");
+  });
+
+  it("serializes the newly selected value after choosing an option from the menu", async () => {
+    render(ComboBox, {
+      props: { items, name: "contact" },
+    });
+
+    const input = getInput();
+    await user.click(input);
+    const option = screen.getByRole("option", { name: "Email" });
+    await user.click(option);
+
+    expect(input).toHaveAttribute("aria-expanded", "false");
+    const formData = new FormData(getForm());
+    expect(formData.getAll("contact")).toEqual(["Email"]);
+  });
+
+  it("serializes an empty string after the selection is cleared", async () => {
+    render(ComboBox, {
+      props: { items, selectedId: "0", value: "Slack", name: "contact" },
+    });
+
+    const clearButton = screen.getByRole("button", {
+      name: "Clear selected item",
+    });
+    await user.click(clearButton);
+
+    expect(new FormData(getForm()).get("contact")).toBe("");
+  });
+
+  it("keeps FormData in sync while typing, and reverts to the selected value on blur without a match", async () => {
+    render(ComboBox, {
+      props: { items, selectedId: "0", value: "Slack", name: "contact" },
+    });
+
+    const input = getInput();
+    await user.click(input);
+    await user.keyboard(" typing");
+
+    expect(new FormData(getForm()).get("contact")).toBe("Slack typing");
+
+    // No item matches "Slack typing" and allowCustomValue defaults to false,
+    // so losing focus without a selection restores the last selected value.
+    await user.click(document.body);
+
+    expect(new FormData(getForm()).get("contact")).toBe("Slack");
+  });
+
+  it("serializes the selected value while closed with virtualize enabled", () => {
+    const largeItems = Array.from({ length: 150 }, (_, i) => ({
+      id: String(i),
+      text: `Item ${i + 1}`,
+    }));
+
+    render(ComboBox, {
+      props: {
+        items: largeItems,
+        selectedId: "42",
+        value: "Item 43",
+        name: "contact",
+        virtualize: true,
+      },
+    });
+
+    expect(new FormData(getForm()).get("contact")).toBe("Item 43");
+  });
+});

--- a/tests/Dropdown/Dropdown.form.test.svelte
+++ b/tests/Dropdown/Dropdown.form.test.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+  import Dropdown from "carbon-components-svelte/Dropdown/Dropdown.svelte";
+  import type { ComponentProps } from "svelte";
+
+  export let items: ComponentProps<Dropdown>["items"] = [];
+  export let selectedId: ComponentProps<Dropdown>["selectedId"] = undefined;
+  export let name: ComponentProps<Dropdown>["name"] = undefined;
+  export let clearable: ComponentProps<Dropdown>["clearable"] = false;
+  export let virtualize: ComponentProps<Dropdown>["virtualize"] = undefined;
+  export let portalMenu: ComponentProps<Dropdown>["portalMenu"] = false;
+  export let open: ComponentProps<Dropdown>["open"] = false;
+</script>
+
+<form data-testid="form">
+  <Dropdown
+    id="test-dropdown"
+    {items}
+    bind:selectedId
+    {name}
+    {clearable}
+    {virtualize}
+    {portalMenu}
+    bind:open
+    labelText="Contact"
+  />
+</form>

--- a/tests/Dropdown/Dropdown.form.test.ts
+++ b/tests/Dropdown/Dropdown.form.test.ts
@@ -1,0 +1,108 @@
+import { render, screen } from "@testing-library/svelte";
+import { user } from "../utils/user";
+import Dropdown from "./Dropdown.form.test.svelte";
+
+const items = [
+  { id: "0", text: "Slack" },
+  { id: "1", text: "Email" },
+  { id: "2", text: "Fax" },
+] as const;
+
+const getForm = () => screen.getByTestId("form") as HTMLFormElement;
+
+describe("Dropdown form participation", () => {
+  it("does not render a hidden input when name is omitted", () => {
+    const { container } = render(Dropdown, {
+      props: { items, selectedId: "0" },
+    });
+
+    expect(container.querySelector('input[type="hidden"]')).toBeNull();
+  });
+
+  it("serializes the initially selected id while the menu stays closed", () => {
+    render(Dropdown, {
+      props: { items, selectedId: "1", name: "contact" },
+    });
+
+    expect(new FormData(getForm()).get("contact")).toBe("1");
+  });
+
+  it("serializes an empty string when nothing is selected", () => {
+    render(Dropdown, {
+      props: { items, name: "contact" },
+    });
+
+    expect(new FormData(getForm()).get("contact")).toBe("");
+  });
+
+  it("follows selectedId changes made without opening the menu", async () => {
+    const { rerender } = render(Dropdown, {
+      props: { items, name: "contact" },
+    });
+
+    expect(new FormData(getForm()).get("contact")).toBe("");
+
+    await rerender({ items, name: "contact", selectedId: "2" });
+
+    expect(new FormData(getForm()).get("contact")).toBe("2");
+  });
+
+  it("serializes the newly selected id after choosing an option from the menu", async () => {
+    render(Dropdown, {
+      props: { items, name: "contact" },
+    });
+
+    const combobox = screen.getByRole("combobox");
+    await user.click(combobox);
+    const option = screen.getByRole("option", { name: "Email" });
+    await user.click(option);
+
+    expect(combobox).toHaveAttribute("aria-expanded", "false");
+    const formData = new FormData(getForm());
+    expect(formData.getAll("contact")).toEqual(["1"]);
+  });
+
+  it("serializes an empty string after the selection is cleared", async () => {
+    render(Dropdown, {
+      props: { items, selectedId: "0", name: "contact", clearable: true },
+    });
+
+    const clearButton = screen.getByRole("button", {
+      name: "Clear selected item",
+    });
+    await user.click(clearButton);
+
+    expect(new FormData(getForm()).get("contact")).toBe("");
+  });
+
+  it("treats a disabled selected item as unselected", () => {
+    const itemsWithDisabled = [
+      { id: "0", text: "Slack", disabled: true },
+      { id: "1", text: "Email" },
+    ];
+
+    render(Dropdown, {
+      props: { items: itemsWithDisabled, selectedId: "0", name: "contact" },
+    });
+
+    expect(new FormData(getForm()).get("contact")).toBe("");
+  });
+
+  it("serializes the selected id while closed with virtualize enabled", () => {
+    const largeItems = Array.from({ length: 150 }, (_, i) => ({
+      id: String(i),
+      text: `Item ${i + 1}`,
+    }));
+
+    render(Dropdown, {
+      props: {
+        items: largeItems,
+        selectedId: "42",
+        name: "contact",
+        virtualize: true,
+      },
+    });
+
+    expect(new FormData(getForm()).get("contact")).toBe("42");
+  });
+});


### PR DESCRIPTION
`name` was forwarded into ListBox and landed on its wrapper div,
which is a no-op for FormData since divs aren't form-associated
elements. This mounts a hidden input driven by `selectedId`
instead, matching `PinCodeInput`'s pattern, so the value
serializes correctly whether the menu is open, closed,
virtualized, or portaled.