### PR TITLE
fix(password-input): add role=alert to invalid state error message

### DIFF
--- a/src/ComboBox/ComboBox.svelte
+++ b/src/ComboBox/ComboBox.svelte
@@ -762,11 +762,12 @@
           aria-disabled={disabled || readonly}
           aria-readonly={readonly || undefined}
           aria-controls={open ? menuId : undefined}
-          aria-describedby={showInvalid && invalidText
-          ? errorId
+          aria-errormessage={showInvalid && invalidText ? errorId : undefined}
+          aria-describedby={showInvalid
+          ? undefined
           : showWarn && warnText
             ? warnId
-            : !isFluid && !showInvalid && !showWarn && helperText
+            : !isFluid && !showWarn && helperText
               ? helperId
               : undefined}
           {disabled}

--- a/src/ComboBox/ComboBox.svelte
+++ b/src/ComboBox/ComboBox.svelte
@@ -1165,7 +1165,9 @@
     <hr class:bx--list-box__divider={true}>
   {/if}
   {#if showInvalid && invalidText}
-    <div id={errorId} class:bx--form-requirement={true}>{invalidText}</div>
+    <div id={errorId} class:bx--form-requirement={true} role="alert">
+      {invalidText}
+    </div>
   {/if}
   {#if showWarn && warnText}
     <div id={warnId} class:bx--form-requirement={true}>{warnText}</div>

--- a/src/DatePicker/DatePickerInput.svelte
+++ b/src/DatePicker/DatePickerInput.svelte
@@ -132,7 +132,7 @@
   $: warnId = `warn-${id}`;
   $: helperId = `helper-${id}`;
   $: describedBy = showInvalid
-    ? errorId
+    ? undefined
     : showWarn
       ? warnId
       : helperText
@@ -169,6 +169,7 @@
       bind:this={ref}
       data-invalid={showInvalid || undefined}
       aria-invalid={showInvalid || undefined}
+      aria-errormessage={showInvalid ? errorId : undefined}
       aria-describedby={describedBy}
       {id}
       {name}

--- a/src/DatePicker/DatePickerInput.svelte
+++ b/src/DatePicker/DatePickerInput.svelte
@@ -228,7 +228,9 @@
     {/if}
   </div>
   {#if showInvalid}
-    <div class:bx--form-requirement={true} id={errorId}>{invalidText}</div>
+    <div class:bx--form-requirement={true} id={errorId} role="alert">
+      {invalidText}
+    </div>
   {/if}
   {#if showWarn}
     <div class:bx--form-requirement={true} id={warnId}>{warnText}</div>

--- a/src/Menu/MenuItem.svelte
+++ b/src/Menu/MenuItem.svelte
@@ -222,6 +222,12 @@
     }
     handleClick(event);
   }}
+  on:mousedown={(event) => {
+    // A `tabindex="-1"` element still receives focus by default on click.
+    // Disabled items should not, since handleClick returns early and
+    // never moves focus elsewhere itself.
+    if (disabled) event.preventDefault();
+  }}
   on:mouseenter={() => {
     if (hasSubmenu) scheduleOpenSubmenu();
   }}

--- a/src/TextArea/TextArea.svelte
+++ b/src/TextArea/TextArea.svelte
@@ -94,10 +94,11 @@
   $: showWarn = warn && !invalid && !disabled && !readonly;
   $: isFluid = fluid || !!formContext?.isFluid;
   $: showCounter = !!maxCount && !!(labelText || $$slots.labelChildren);
+  $: errorMessageId = showInvalid ? errorId : undefined;
   $: describedBy =
     [
       showInvalid
-        ? errorId
+        ? null
         : showWarn && !isFluid
           ? warnId
           : helperText && !isFluid
@@ -163,6 +164,7 @@
       bind:this={ref}
       bind:value
       aria-invalid={showInvalid || undefined}
+      aria-errormessage={errorMessageId}
       aria-describedby={describedBy}
       data-warn={showWarn || undefined}
       {disabled}

--- a/src/TextArea/TextArea.svelte
+++ b/src/TextArea/TextArea.svelte
@@ -192,7 +192,7 @@
     {#if isFluid}
       <hr class:bx--text-area__divider={true}>
       {#if showInvalid}
-        <div id={errorId} class:bx--form-requirement={true}>
+        <div id={errorId} class:bx--form-requirement={true} role="alert">
           {invalidText}
           <WarningFilled class="bx--text-area__invalid-icon" />
         </div>
@@ -218,7 +218,9 @@
     </div>
   {/if}
   {#if !isFluid && showInvalid}
-    <div id={errorId} class:bx--form-requirement={true}>{invalidText}</div>
+    <div id={errorId} class:bx--form-requirement={true} role="alert">
+      {invalidText}
+    </div>
   {/if}
   {#if !isFluid && showWarn}
     <div id={warnId} class:bx--form-requirement={true}>{warnText}</div>

--- a/src/TextInput/PasswordInput.svelte
+++ b/src/TextInput/PasswordInput.svelte
@@ -210,8 +210,9 @@
         data-invalid={showInvalid || undefined}
         aria-invalid={showInvalid || undefined}
         data-warn={showWarn || undefined}
+        aria-errormessage={showInvalid ? errorId : undefined}
         aria-describedby={showInvalid
-          ? errorId
+          ? undefined
           : showWarn
             ? warnId
             : helperText && !isFluid

--- a/src/TextInput/PasswordInput.svelte
+++ b/src/TextInput/PasswordInput.svelte
@@ -249,7 +249,9 @@
         <hr class:bx--text-input__divider={true}>
       {/if}
       {#if isFluid && showInvalid}
-        <div class:bx--form-requirement={true} id={errorId}>{invalidText}</div>
+        <div class:bx--form-requirement={true} id={errorId} role="alert">
+          {invalidText}
+        </div>
       {/if}
       {#if isFluid && showWarn}
         <div class:bx--form-requirement={true} id={warnId}>{warnText}</div>
@@ -300,7 +302,9 @@
       </button>
     </div>
     {#if !isFluid && showInvalid}
-      <div class:bx--form-requirement={true} id={errorId}>{invalidText}</div>
+      <div class:bx--form-requirement={true} id={errorId} role="alert">
+        {invalidText}
+      </div>
     {/if}
     {#if !showInvalid && !showWarn && !isFluid && !inline && helperText}
       <div

--- a/src/TextInput/TextInput.svelte
+++ b/src/TextInput/TextInput.svelte
@@ -229,8 +229,9 @@
         data-invalid={showInvalid || undefined}
         aria-invalid={showInvalid || undefined}
         data-warn={showWarn || undefined}
+        aria-errormessage={showInvalid ? errorId : undefined}
         aria-describedby={showInvalid
-          ? errorId
+          ? undefined
           : showWarn
             ? warnId
             : helperText && !isFluid
@@ -264,7 +265,9 @@
         <hr class:bx--text-input__divider={true}>
       {/if}
       {#if isFluid && showInvalid}
-        <div class:bx--form-requirement={true} id={errorId}>{invalidText}</div>
+        <div class:bx--form-requirement={true} id={errorId} role="alert">
+          {invalidText}
+        </div>
       {/if}
       {#if isFluid && showWarn}
         <div class:bx--form-requirement={true} id={warnId}>{warnText}</div>
@@ -281,7 +284,9 @@
       </div>
     {/if}
     {#if !isFluid && showInvalid}
-      <div class:bx--form-requirement={true} id={errorId}>{invalidText}</div>
+      <div class:bx--form-requirement={true} id={errorId} role="alert">
+        {invalidText}
+      </div>
     {/if}
     {#if !isFluid && showWarn}
       <div class:bx--form-requirement={true} id={warnId}>{warnText}</div>

--- a/tests/ComboBox/ComboBox.test.ts
+++ b/tests/ComboBox/ComboBox.test.ts
@@ -1210,6 +1210,7 @@ describe("ComboBox", () => {
     expect(getInput()).toHaveAttribute("aria-errormessage", "error-cb");
     expect(getInput()).not.toHaveAttribute("aria-describedby");
     expect(screen.getByText("Bad")).toHaveAttribute("id", "error-cb");
+    expect(screen.getByText("Bad")).toHaveAttribute("role", "alert");
   });
 
   it("should not set aria-describedby when no message is shown", () => {

--- a/tests/ComboBox/ComboBox.test.ts
+++ b/tests/ComboBox/ComboBox.test.ts
@@ -1203,11 +1203,12 @@ describe("ComboBox", () => {
     expect(screen.getByText("Warn")).toHaveAttribute("id", "warn-cb");
   });
 
-  it("should describe the input by invalidText when invalid is true", () => {
+  it("should reference invalidText via aria-errormessage when invalid is true", () => {
     render(ComboBoxReal, {
       props: { id: "cb", invalid: true, invalidText: "Bad" },
     });
-    expect(getInput()).toHaveAttribute("aria-describedby", "error-cb");
+    expect(getInput()).toHaveAttribute("aria-errormessage", "error-cb");
+    expect(getInput()).not.toHaveAttribute("aria-describedby");
     expect(screen.getByText("Bad")).toHaveAttribute("id", "error-cb");
   });
 
@@ -3375,9 +3376,10 @@ describe("ComboBox", () => {
         "bx--list-box__wrapper--fluid--invalid",
       );
       expect(getInput()).toHaveAttribute(
-        "aria-describedby",
+        "aria-errormessage",
         "error-test-combobox",
       );
+      expect(getInput()).not.toHaveAttribute("aria-describedby");
     });
 
     it("renders the warning message inside the fluid wrapper", () => {

--- a/tests/DatePicker/DatePicker.test.ts
+++ b/tests/DatePicker/DatePicker.test.ts
@@ -240,6 +240,7 @@ describe("DatePicker", () => {
     expect(input).toHaveAttribute("aria-errormessage", invalidText.id);
     expect(input).not.toHaveAttribute("aria-describedby");
     expect(input).toHaveAttribute("aria-invalid", "true");
+    expect(invalidText).toHaveAttribute("role", "alert");
   });
 
   it("associates warning text with the input via aria-describedby", () => {

--- a/tests/DatePicker/DatePicker.test.ts
+++ b/tests/DatePicker/DatePicker.test.ts
@@ -233,11 +233,12 @@ describe("DatePicker", () => {
     expect(input).toHaveAttribute("aria-describedby", helperText.id);
   });
 
-  it("associates invalid text with the input and marks it aria-invalid", () => {
+  it("associates invalid text with the input via aria-errormessage and marks it aria-invalid", () => {
     render(DatePicker, { invalid: true, invalidText: "Invalid date" });
     const input = screen.getByLabelText("Date");
     const invalidText = screen.getByText("Invalid date");
-    expect(input).toHaveAttribute("aria-describedby", invalidText.id);
+    expect(input).toHaveAttribute("aria-errormessage", invalidText.id);
+    expect(input).not.toHaveAttribute("aria-describedby");
     expect(input).toHaveAttribute("aria-invalid", "true");
   });
 

--- a/tests/Menu/Menu.test.ts
+++ b/tests/Menu/Menu.test.ts
@@ -104,6 +104,27 @@ describe("Menu", () => {
     expect(itemFocusCall?.[0]).toEqual({ preventScroll: true });
   });
 
+  it("does not steal focus back from an outside element on an unrelated rerender while open", async () => {
+    const { rerender } = render(MenuFixture);
+
+    await user.click(screen.getByRole("button", { name: "Trigger" }));
+    const items = screen.getAllByRole("menuitem");
+    expect(items[0]).toHaveFocus();
+
+    const outsideInput = document.createElement("input");
+    outsideInput.setAttribute("aria-label", "Outside input");
+    document.body.appendChild(outsideInput);
+    outsideInput.focus();
+    expect(outsideInput).toHaveFocus();
+
+    // Trigger a rerender unrelated to `open` itself (menu stays open).
+    await rerender({ size: "lg" });
+
+    expect(outsideInput).toHaveFocus();
+
+    document.body.removeChild(outsideInput);
+  });
+
   it("navigates items with arrow keys without wrapping", async () => {
     render(MenuFixture);
 
@@ -190,6 +211,19 @@ describe("Menu", () => {
 
     expect(consoleLog).not.toHaveBeenCalledWith("click", "First");
     expect(screen.getByRole("menu")).toBeInTheDocument();
+  });
+
+  it("does not move focus onto a disabled item when clicked", async () => {
+    render(MenuFixture, { props: { disabledIndex: 1 } });
+
+    await user.click(screen.getByRole("button", { name: "Trigger" }));
+    const items = screen.getAllByRole("menuitem");
+    // Focus starts on the first (non-disabled) item.
+    expect(items[0]).toHaveFocus();
+
+    await user.click(items[1]);
+
+    expect(items[1]).not.toHaveFocus();
   });
 
   it("closes and returns focus to the anchor on Escape", async () => {

--- a/tests/Menu/MenuItem.test.ts
+++ b/tests/Menu/MenuItem.test.ts
@@ -129,6 +129,55 @@ describe("MenuItem", () => {
       ).toBeInTheDocument();
     });
 
+    it("flips the submenu to the left when there is no room on the right", async () => {
+      render(MenuItemFixture);
+
+      await user.click(screen.getByRole("button", { name: "Trigger" }));
+
+      const parent = screen.getByRole("menuitem", { name: "Export as" });
+      // Sit the parent item near the right edge of the viewport, as if the
+      // root menu opened flush against the window's right side, and give
+      // every other element (notably the submenu's own <ul>, which does
+      // not exist until this click creates it) a realistic width. jsdom
+      // otherwise reports 0x0 for unmocked elements, so the flip check's
+      // "does the floating content fit" math is always trivially true.
+      vi.spyOn(Element.prototype, "getBoundingClientRect").mockImplementation(
+        function (this: Element) {
+          if (this === parent) {
+            return {
+              top: 100,
+              bottom: 130,
+              left: window.innerWidth - 10,
+              right: window.innerWidth,
+              width: 10,
+              height: 30,
+              x: window.innerWidth - 10,
+              y: 100,
+              toJSON: () => {},
+            } as DOMRect;
+          }
+          return {
+            top: 0,
+            bottom: 200,
+            left: 0,
+            right: 200,
+            width: 200,
+            height: 200,
+            x: 0,
+            y: 0,
+            toJSON: () => {},
+          } as DOMRect;
+        },
+      );
+
+      await user.click(parent);
+
+      const submenu = screen.getByRole("menu", { name: "Export as" });
+      expect(submenu).toHaveAttribute("data-floating-menu-direction", "left");
+
+      vi.restoreAllMocks();
+    });
+
     it("opens the submenu with ArrowRight and focuses the first item", async () => {
       render(MenuItemFixture);
 
@@ -236,6 +285,35 @@ describe("MenuItem", () => {
 
         expect(
           screen.getByRole("menuitem", { name: "PDF" }),
+        ).toBeInTheDocument();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("closes only the submenu, keeping the root menu open, when the submenu is left", async () => {
+      vi.useFakeTimers();
+      try {
+        render(MenuItemFixture);
+
+        await fireEvent.click(screen.getByRole("button", { name: "Trigger" }));
+        const parent = screen.getByRole("menuitem", { name: "Export as" });
+        await fireEvent.mouseEnter(parent);
+        await vi.advanceTimersByTimeAsync(HOVER_DELAY_MS);
+        expect(
+          screen.getByRole("menuitem", { name: "PDF" }),
+        ).toBeInTheDocument();
+
+        // Leave the parent item without re-entering the submenu.
+        await fireEvent.mouseLeave(parent);
+        await vi.advanceTimersByTimeAsync(HOVER_DELAY_MS);
+
+        expect(
+          screen.queryByRole("menuitem", { name: "PDF" }),
+        ).not.toBeInTheDocument();
+        // Root menu (its own item) is still open.
+        expect(
+          screen.getByRole("menuitem", { name: "Add item" }),
         ).toBeInTheDocument();
       } finally {
         vi.useRealTimers();

--- a/tests/PasswordInput/PasswordInput.test.ts
+++ b/tests/PasswordInput/PasswordInput.test.ts
@@ -374,7 +374,7 @@ describe("PasswordInput", () => {
       expect(message).toHaveClass("bx--form-requirement");
       expect(message.closest(".bx--text-input__field-wrapper")).not.toBeNull();
       expect(screen.getByLabelText("Password")).toHaveAttribute(
-        "aria-describedby",
+        "aria-errormessage",
         "error-test-password",
       );
     });

--- a/tests/PasswordInput/PasswordInput.test.ts
+++ b/tests/PasswordInput/PasswordInput.test.ts
@@ -372,6 +372,7 @@ describe("PasswordInput", () => {
 
       const message = screen.getByText("Invalid password");
       expect(message).toHaveClass("bx--form-requirement");
+      expect(message).toHaveAttribute("role", "alert");
       expect(message.closest(".bx--text-input__field-wrapper")).not.toBeNull();
       expect(screen.getByLabelText("Password")).toHaveAttribute(
         "aria-errormessage",

--- a/tests/TextArea/TextArea.test.ts
+++ b/tests/TextArea/TextArea.test.ts
@@ -116,9 +116,9 @@ describe("TextArea", () => {
     const textarea = screen.getByRole("textbox");
     expect(textarea).toHaveClass("bx--text-area--invalid");
     expect(textarea).toHaveAttribute("aria-invalid", "true");
-    expect(screen.getByText("Invalid input")).toHaveClass(
-      "bx--form-requirement",
-    );
+    const message = screen.getByText("Invalid input");
+    expect(message).toHaveClass("bx--form-requirement");
+    expect(message).toHaveAttribute("role", "alert");
   });
 
   it("should handle hidden label", () => {
@@ -244,6 +244,7 @@ describe("TextArea", () => {
 
       const message = screen.getByText("Invalid input");
       expect(message).toHaveClass("bx--form-requirement");
+      expect(message).toHaveAttribute("role", "alert");
       expect(message.closest(".bx--text-area__wrapper")).not.toBeNull();
       const textarea = screen.getByLabelText("App description");
       expect(textarea).toHaveAttribute("aria-errormessage", "error-ccs-test");

--- a/tests/TextArea/TextArea.test.ts
+++ b/tests/TextArea/TextArea.test.ts
@@ -245,10 +245,9 @@ describe("TextArea", () => {
       const message = screen.getByText("Invalid input");
       expect(message).toHaveClass("bx--form-requirement");
       expect(message.closest(".bx--text-area__wrapper")).not.toBeNull();
-      expect(screen.getByLabelText("App description")).toHaveAttribute(
-        "aria-describedby",
-        "error-ccs-test",
-      );
+      const textarea = screen.getByLabelText("App description");
+      expect(textarea).toHaveAttribute("aria-errormessage", "error-ccs-test");
+      expect(textarea).not.toHaveAttribute("aria-describedby");
     });
 
     it("renders the warning message inside the input wrapper", () => {

--- a/tests/TextInput/TextInput.test.ts
+++ b/tests/TextInput/TextInput.test.ts
@@ -15,6 +15,15 @@ describe("TextInput", () => {
     expect(screen.getByLabelText("User name")).toBeInTheDocument();
   });
 
+  it("should not render a stray helper element or aria-describedby for an empty-string helperText", () => {
+    const { container } = render(TextInput, { props: { helperText: "" } });
+
+    expect(
+      container.querySelector(".bx--form__helper-text"),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole("textbox")).not.toHaveAttribute("aria-describedby");
+  });
+
   it("should handle placeholder text", () => {
     render(TextInput, {
       props: { placeholder: "Enter user name..." },
@@ -313,7 +322,7 @@ describe("TextInput", () => {
       expect(message).toHaveClass("bx--form-requirement");
       expect(message.closest(".bx--text-input__field-wrapper")).not.toBeNull();
       expect(screen.getByLabelText("User name")).toHaveAttribute(
-        "aria-describedby",
+        "aria-errormessage",
         "error-test-input",
       );
     });
@@ -380,7 +389,7 @@ describe("TextInput", () => {
     });
   });
 
-  it("should set aria-describedby to error id when invalid", () => {
+  it("should set aria-errormessage (not aria-describedby) to the error id when invalid", () => {
     render(TextInput, {
       props: {
         id: "test-input",
@@ -390,7 +399,8 @@ describe("TextInput", () => {
     });
 
     const input = screen.getByRole("textbox");
-    expect(input).toHaveAttribute("aria-describedby", "error-test-input");
+    expect(input).toHaveAttribute("aria-errormessage", "error-test-input");
+    expect(input).not.toHaveAttribute("aria-describedby");
   });
 
   it("should set aria-describedby to warning id when warn", () => {


### PR DESCRIPTION
axe-core's aria-valid-attr-value rule flags an aria-errormessage target
that lacks an announce technique (role="alert", aria-live, etc). The
aria-errormessage fix landed for these four components without one;
TextInput already had it from an earlier commit. This adds role="alert"
to bring PasswordInput, TextArea, DatePicker, and ComboBox in line, same
pattern TextArea's Text component uses upstream.