### PR TITLE
fix: keyboard, overlay, and assistive-tech bugs

### DIFF
--- a/e2e/a11y-search.test.ts
+++ b/e2e/a11y-search.test.ts
@@ -21,7 +21,8 @@ test.describe("Search a11y", () => {
       .analyze();
     expect(withValueResults.violations).toEqual([]);
 
-    await page.getByTestId("search-expandable").focus();
+    const expandable = page.locator(".bx--search--expandable");
+    await expandable.locator(".bx--search-magnifier").click();
     await expect(page.getByTestId("search-expandable")).toBeFocused();
 
     const expandedResults = await new AxeBuilder({ page })

--- a/src/NumberInput/NumberInput.svelte
+++ b/src/NumberInput/NumberInput.svelte
@@ -378,7 +378,12 @@
   }
 
   function onKeyDown(event) {
-    if (useTextMode && (event.key === "ArrowUp" || event.key === "ArrowDown")) {
+    if (
+      useTextMode &&
+      !readonly &&
+      !disabled &&
+      (event.key === "ArrowUp" || event.key === "ArrowDown")
+    ) {
       event.preventDefault();
       updateValue(event.key === "ArrowUp");
     }

--- a/src/Pagination/Pagination.svelte
+++ b/src/Pagination/Pagination.svelte
@@ -151,6 +151,7 @@
 
   let prevPage = page;
   let prevPageSize = pageSize;
+  let prevPageSizesKey;
 
   /**
    * Returns a subset of page numbers centered around the current page to prevent
@@ -185,6 +186,25 @@
     return filtered.length ? filtered : sizes.slice(0, 1);
   }
 
+  $: effectivePageSizes = dynamicPageSizes
+    ? getFilteredPageSizes(pageSizes, totalItems)
+    : pageSizes;
+  // After the available sizes change, if the current size is gone, use the
+  // first remaining size and reset to page 1. Skip the initial run so a
+  // bound pageSize that isn't in the default `pageSizes` stays put.
+  $: {
+    const nextPageSizesKey = effectivePageSizes.join(",");
+    if (
+      prevPageSizesKey !== undefined &&
+      nextPageSizesKey !== prevPageSizesKey &&
+      effectivePageSizes.length &&
+      !effectivePageSizes.includes(pageSize)
+    ) {
+      pageSize = effectivePageSizes[0];
+      page = 1;
+    }
+    prevPageSizesKey = nextPageSizesKey;
+  }
   $: totalPages = Math.max(Math.ceil(totalItems / pageSize), 1);
   $: if (!pagesUnknown && page > totalPages) page = totalPages;
   $: if (prevPage !== page || prevPageSize !== pageSize) {
@@ -193,9 +213,6 @@
     prevPageSize = pageSize;
   }
   $: selectItems = getWindowedPages(page, totalPages, pageWindow);
-  $: effectivePageSizes = dynamicPageSizes
-    ? getFilteredPageSizes(pageSizes, totalItems)
-    : pageSizes;
   $: internalBackButtonDisabled =
     backButtonDisabled ?? (disabled || page === 1);
   $: internalForwardButtonDisabled =

--- a/src/ProgressIndicator/ProgressStep.svelte
+++ b/src/ProgressIndicator/ProgressStep.svelte
@@ -77,7 +77,7 @@
     {disabled}
     aria-disabled={disabled}
     aria-current={current ? "step" : undefined}
-    tabindex={!current && !disabled ? "0" : "-1"}
+    tabindex={disabled ? "-1" : "0"}
     class:bx--progress-step-button={true}
     class:bx--progress-step-button--unclickable={current ||
       $preventChangeOnClick}
@@ -106,10 +106,10 @@
     </slot>
     <div class:bx--progress-text={true}>
       <slot props={{ class: "bx--progress-label" }}>
-        <p class:bx--progress-label={true}>{label}</p>
+        <span class:bx--progress-label={true}>{label}</span>
       </slot>
       {#if secondaryLabel}
-        <p class:bx--progress-optional={true}>{secondaryLabel}</p>
+        <span class:bx--progress-optional={true}>{secondaryLabel}</span>
       {/if}
     </div>
     {#if stateSuffix}

--- a/src/Search/Search.svelte
+++ b/src/Search/Search.svelte
@@ -82,7 +82,7 @@
    */
   export let ref = null;
 
-  import { createEventDispatcher, getContext } from "svelte";
+  import { createEventDispatcher, getContext, tick } from "svelte";
   import Close from "../icons/Close.svelte";
   import IconSearch from "../icons/IconSearch.svelte";
   import { uniqueId } from "../utils/uniqueId.js";
@@ -95,7 +95,11 @@
   let prevExpanded = expanded;
 
   $: isFluid = !expandable && (fluid || !!formContext?.isFluid);
-  $: if (expanded && ref) ref.focus();
+  $: if (expanded && ref) {
+    tick().then(() => {
+      if (expanded) ref?.focus();
+    });
+  }
   $: if (expanded !== prevExpanded) {
     const nextExpanded = expanded;
     prevExpanded = expanded;
@@ -161,6 +165,8 @@
       {id}
       {placeholder}
       {...$$restProps}
+      tabindex={expandable && !expanded ? -1 : $$restProps.tabindex}
+      inert={expandable && !expanded ? true : $$restProps.inert}
       on:change
       on:input
       on:focus

--- a/src/Tabs/Tabs.svelte
+++ b/src/Tabs/Tabs.svelte
@@ -141,9 +141,10 @@
     if (!refTabList) return;
     const { scrollLeft, scrollWidth, clientWidth } = refTabList;
     canScrollBackward = scrollLeft > 0;
-    // Round up to absorb sub-pixel widths so the forward button hides cleanly
-    // when the list is scrolled to the end.
-    canScrollForward = Math.ceil(scrollLeft + clientWidth) < scrollWidth;
+    // Round up for sub-pixel widths. Firefox can report scrollWidth 1px
+    // larger than clientWidth with nowhere to scroll; ignore that gap so
+    // the forward button does not flicker in.
+    canScrollForward = Math.ceil(scrollLeft + clientWidth) + 1 < scrollWidth;
   }
 
   /**

--- a/src/Tile/ClickableTile.svelte
+++ b/src/Tile/ClickableTile.svelte
@@ -53,8 +53,13 @@
   on:keydown
   on:keydown={(event) => {
     if (disabled) return;
-    if (event.key === " " || event.key === "Enter") {
-      clicked = !clicked;
+    // A focused <a href> already fires a native click on Enter, and the
+    // on:click handler above picks that up. Space never does, and Enter
+    // does not without href. Dispatch click only in those cases so Enter
+    // with href does not toggle `clicked` twice.
+    if (event.key === " " || (event.key === "Enter" && !href)) {
+      event.preventDefault();
+      ref?.click();
     }
   }}
   on:keyup

--- a/src/UIShell/HeaderPanelDivider.svelte
+++ b/src/UIShell/HeaderPanelDivider.svelte
@@ -1,4 +1,4 @@
 {#if $$slots.default}
   <li class:bx--header-panel-divider={true}><slot /></li>
 {/if}
-<hr class:bx--switcher__item--divider={true}>
+<li><hr class:bx--switcher__item--divider={true}></li>

--- a/src/utils/isOutsideClick.js
+++ b/src/utils/isOutsideClick.js
@@ -5,16 +5,23 @@
  * Skips falsy entries. Pass `portalMenu && listRef` inline.
  * Returns false when `event.target` is not a Node.
  *
+ * Listeners outside a shadow root see `event.target` as the shadow host,
+ * not the clicked node. Also check `event.composedPath()` so a click
+ * inside a shadow descendant is not treated as outside.
+ *
  * @param {Event} event
  * @param {Element | null | undefined | false | Array<Element | null | undefined | false>} elements
  * @returns {boolean}
  */
 export function isOutsideClick(event, elements) {
   const { target } = event;
-  if (!(target instanceof Node)) return false;
+  const path =
+    typeof event.composedPath === "function" ? event.composedPath() : [];
+  if (!(target instanceof Node) && !path.length) return false;
   const list = Array.isArray(elements) ? elements : [elements];
   return list.every((el) => {
     if (!el) return true;
-    return !el.contains(target);
+    if (target instanceof Node && el.contains(target)) return false;
+    return !path.some((node) => node instanceof Node && el.contains(node));
   });
 }

--- a/tests/NumberInput/NumberInput.test.ts
+++ b/tests/NumberInput/NumberInput.test.ts
@@ -271,6 +271,22 @@ describe("NumberInput", () => {
     expect(input).toHaveAttribute("aria-readonly", "true");
   });
 
+  it("should not change value via arrow keys when readonly in text mode", async () => {
+    render(NumberInput, {
+      props: { readonly: true, allowDecimal: true, value: 50 },
+    });
+
+    const input = screen.getByRole("textbox");
+    expect(input).toHaveValue("50");
+
+    input.focus();
+    await user.keyboard("{ArrowUp}");
+    expect(input).toHaveValue("50");
+
+    await user.keyboard("{ArrowDown}");
+    expect(input).toHaveValue("50");
+  });
+
   it("should handle hidden steppers", () => {
     render(NumberInput, { props: { hideSteppers: true } });
 

--- a/tests/Pagination/Pagination.test.ts
+++ b/tests/Pagination/Pagination.test.ts
@@ -297,6 +297,59 @@ describe("Pagination", () => {
     });
   });
 
+  it("resets pageSize and page when an updated pageSizes array drops the current pageSize", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    const { rerender } = render(Pagination, {
+      props: {
+        page: 2,
+        totalItems: 6,
+        pageSize: 2,
+        pageSizes: [2, 4],
+      },
+    });
+
+    expect(screen.getByText("3–4 of 6 items")).toBeInTheDocument();
+    consoleLog.mockClear();
+
+    await rerender({ pageSizes: [3] });
+
+    const select = screen.getByRole("combobox", { name: "Items per page:" });
+    expect(select).toHaveValue("3");
+    expect(screen.getByText("1–3 of 6 items")).toBeInTheDocument();
+    expect(consoleLog).toHaveBeenCalledWith("update", { pageSize: 3, page: 1 });
+  });
+
+  it("keeps pageSize as-is when it remains valid in an updated pageSizes array", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    const { rerender } = render(Pagination, {
+      props: {
+        totalItems: 102,
+        pageSize: 15,
+        pageSizes: [10, 15, 20],
+      },
+    });
+
+    consoleLog.mockClear();
+
+    await rerender({ pageSizes: [10, 15] });
+
+    const select = screen.getByRole("combobox", { name: "Items per page:" });
+    expect(select).toHaveValue("15");
+    expect(consoleLog).not.toHaveBeenCalledWith("update", expect.anything());
+  });
+
+  it("keeps an initial pageSize that is not in pageSizes", () => {
+    render(Pagination, {
+      props: {
+        totalItems: 10,
+        pageSize: 5,
+        pageSizeInputDisabled: true,
+      },
+    });
+
+    expect(screen.getByText("1–5 of 10 items")).toBeInTheDocument();
+  });
+
   it("should handle edge cases", () => {
     render(Pagination, {
       props: {

--- a/tests/ProgressIndicator/ProgressIndicator.test.ts
+++ b/tests/ProgressIndicator/ProgressIndicator.test.ts
@@ -225,8 +225,8 @@ describe("ProgressIndicator", () => {
         "bx--progress-step-button--unclickable",
       );
 
-      // Current step button should be unclickable
-      expect(buttons[1]).toHaveAttribute("tabindex", "-1");
+      // Current step is unclickable but stays in tab order.
+      expect(buttons[1]).toHaveAttribute("tabindex", "0");
       expect(buttons[1]).toHaveAttribute("aria-disabled", "false");
       expect(buttons[1]).toHaveClass("bx--progress-step-button--unclickable");
 
@@ -255,6 +255,18 @@ describe("ProgressIndicator", () => {
       expect(disabledButton).toHaveAttribute("disabled");
       expect(disabledButton).toHaveAttribute("aria-disabled", "true");
       expect(disabledButton).toHaveAttribute("tabindex", "-1");
+    });
+
+    // <button> cannot contain block-level <p>.
+    it("renders the label and secondary label as spans, not paragraphs", () => {
+      const { container } = render(ProgressStepStandalone);
+
+      const label = container.querySelector(".bx--progress-label");
+      const secondary = container.querySelector(".bx--progress-optional");
+      assert(label);
+      assert(secondary);
+      expect(label.tagName).toBe("SPAN");
+      expect(secondary.tagName).toBe("SPAN");
     });
 
     it("should forward focus and blur events from step button", () => {

--- a/tests/Search/Search.test.ts
+++ b/tests/Search/Search.test.ts
@@ -53,6 +53,17 @@ describe("Search", () => {
     expect(consoleLog).toHaveBeenCalledTimes(1);
   });
 
+  it("gives the search landmark a unique accessible name per instance", () => {
+    render(Search);
+
+    expect(
+      screen.getByRole("search", { name: "Default search" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("search", { name: "Disabled search" }),
+    ).toBeInTheDocument();
+  });
+
   it("renders disabled state", () => {
     render(Search);
 

--- a/tests/Search/Search.test.ts
+++ b/tests/Search/Search.test.ts
@@ -96,6 +96,24 @@ describe("Search", () => {
     expect(searchWrapper).toHaveClass("bx--search--expanded");
   });
 
+  it("hides the collapsed expandable input from assistive tech", async () => {
+    render(SearchExpandable);
+
+    const search = getSearchInput("Expandable search");
+    expect(search).toHaveAttribute("inert");
+    expect(search).toHaveAttribute("tabindex", "-1");
+
+    const searchWrapper = search.closest(".bx--search");
+    assert(searchWrapper);
+    const magnifier = searchWrapper.querySelector(".bx--search-magnifier");
+    assert(magnifier);
+    await user.click(magnifier);
+
+    expect(search).not.toHaveAttribute("inert");
+    expect(search).not.toHaveAttribute("tabindex", "-1");
+    expect(search).toHaveFocus();
+  });
+
   it("renders skeleton states", () => {
     render(SearchSkeleton);
 

--- a/tests/Tabs/Tabs.test.ts
+++ b/tests/Tabs/Tabs.test.ts
@@ -342,6 +342,30 @@ describe("Tabs", () => {
     expect(next).toHaveClass("bx--tab--overflow-nav-button--hidden");
   });
 
+  it("does not show the overflow button for a 1px scrollWidth/clientWidth difference", async () => {
+    const { container } = render(Tabs);
+
+    const nav = screen.getByRole("tablist");
+    Object.defineProperty(nav, "scrollWidth", {
+      configurable: true,
+      value: 101,
+    });
+    Object.defineProperty(nav, "clientWidth", {
+      configurable: true,
+      value: 100,
+    });
+    Object.defineProperty(nav, "scrollLeft", {
+      configurable: true,
+      writable: true,
+      value: 0,
+    });
+    await fireEvent.scroll(nav);
+
+    expect(
+      container.querySelector(".bx--tab--overflow-nav-button"),
+    ).not.toBeInTheDocument();
+  });
+
   it("should apply custom class", () => {
     render(Tabs, {
       props: { customClass: "custom-tabs" },

--- a/tests/Tile/ClickableTile.test.ts
+++ b/tests/Tile/ClickableTile.test.ts
@@ -50,6 +50,28 @@ describe("ClickableTile", () => {
     expect(tile).not.toHaveClass("bx--tile--is-clicked");
   });
 
+  it("should fire the click handler on Space, not just toggle clicked state", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(ClickableTile);
+
+    const tile = screen.getByTestId("click-test");
+    tile.focus();
+    await user.keyboard(" ");
+
+    expect(consoleLog).toHaveBeenCalledWith("clicked");
+  });
+
+  it("should fire the click handler on Enter", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(ClickableTile);
+
+    const tile = screen.getByTestId("click-test");
+    tile.focus();
+    await user.keyboard("{Enter}");
+
+    expect(consoleLog).toHaveBeenCalledWith("clicked");
+  });
+
   it("should respect disabled state", () => {
     render(ClickableTile);
 

--- a/tests/UIShell/HeaderSwitcher.test.svelte
+++ b/tests/UIShell/HeaderSwitcher.test.svelte
@@ -27,6 +27,7 @@
       <HeaderPanelLinks>
         <HeaderPanelDivider>Switcher subject 1</HeaderPanelDivider>
         <HeaderPanelLink>Switcher item 1</HeaderPanelLink>
+        <HeaderPanelDivider />
         <HeaderPanelDivider>Switcher subject 2</HeaderPanelDivider>
         <HeaderPanelLink>Switcher item 1</HeaderPanelLink>
         <HeaderPanelLink>Switcher item 2</HeaderPanelLink>

--- a/tests/UIShell/UIShell.test.ts
+++ b/tests/UIShell/UIShell.test.ts
@@ -358,6 +358,21 @@ describe("UIShell", () => {
       ).toBeInTheDocument();
     });
 
+    // A bare <hr> cannot be a direct child of <ul>.
+    it("wraps a contentless HeaderPanelDivider's hr in an li", async () => {
+      const { container } = render(HeaderSwitcher);
+
+      const trigger = container.querySelector(
+        'button.bx--header__action[aria-haspopup="true"]',
+      );
+      assert(trigger);
+      await user.click(trigger);
+
+      const hr = container.querySelector("hr.bx--switcher__item--divider");
+      assert(hr);
+      expect(hr.parentElement?.tagName).toBe("LI");
+    });
+
     it("renders HeaderUtilities fixture", () => {
       const { container } = render(HeaderUtilities);
 

--- a/tests/utils/isOutsideClick.test.ts
+++ b/tests/utils/isOutsideClick.test.ts
@@ -67,4 +67,40 @@ describe("isOutsideClick", () => {
     const { outside } = setup();
     expect(isOutsideClick(clickOn(outside), [])).toBe(true);
   });
+
+  // event.target is the shadow host for listeners outside the shadow root.
+  // element.contains(host) is then false even when the click was inside.
+  // composedPath() still includes the real node.
+  test("false when the true target is inside via composedPath, even if event.target is retargeted to the shadow host", () => {
+    const shadowHost = document.createElement("div");
+    document.body.appendChild(shadowHost);
+    const shadowRoot = shadowHost.attachShadow({ mode: "open" });
+    const box = document.createElement("div");
+    const innerButton = document.createElement("button");
+    box.appendChild(innerButton);
+    shadowRoot.appendChild(box);
+
+    const event = {
+      target: shadowHost,
+      composedPath: () => [
+        innerButton,
+        box,
+        shadowRoot,
+        shadowHost,
+        document.body,
+      ],
+    } as unknown as Event;
+
+    expect(isOutsideClick(event, box)).toBe(false);
+  });
+
+  test("true via composedPath when the true target is genuinely outside", () => {
+    const { box, outside } = setup();
+    const event = {
+      target: outside,
+      composedPath: () => [outside, document.body],
+    } as unknown as Event;
+
+    expect(isOutsideClick(event, box)).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary

A collapsed expandable Search still showed up to screen readers. Firefox drew a Tabs forward-scroll button with nowhere to go, from a 1px rounding gap. Space on a ClickableTile flipped its own `clicked` state and never ran the consumer's `on:click`. A click inside a shadow root dismissed Toggletip and every other overlay that uses `isOutsideClick`.

The rest of this PR is the same class of miss: keyboard or markup that did not match the React library.

| Area | Before | After |
| --- | --- | --- |
| Search | Collapsed expandable field announced | Hidden with `inert` until expanded |
| Tabs | Forward overflow button with nowhere to scroll | Hidden unless more than 1px remains |
| ClickableTile | Space did not fire `on:click` | Space, and Enter without `href`, dispatch click |
| Overlays | Click inside shadow DOM dismissed the overlay | `composedPath()` keeps it open |
| Pagination | Stale page size after parent updated `pageSizes` | First remaining size, page 1 |
| ProgressIndicator | Current step skipped in tab order; `<p>` inside `<button>` | Tabbable; labels are spans |
| NumberInput | Arrow keys changed a readonly or disabled text-mode value | Ignored |
| Header panel | Bare `<hr>` inside `<ul>` | Wrapped in `<li>` |

## Test plan

- [ ] Expandable Search: collapsed input is not announced; expanding restores it
- [ ] Tabs: overflow buttons stay hidden when the list is only 1px over
- [ ] ClickableTile: Space fires the same `on:click` as a mouse click
- [ ] Toggletip or Popover inside shadow DOM: inside click does not dismiss
- [ ] Pagination: parent `pageSizes` that drops the current size snaps to the first remaining size and page 1
- [ ] ProgressIndicator: current step is in tab order; labels are not paragraphs
- [ ] NumberInput `allowDecimal` + `readonly`: ArrowUp/Down do not change value
- [ ] Header panel switcher: divider is an `li > hr`
