### PR TITLE
fix(text-input): use aria-errormessage for invalid state

### DIFF
--- a/src/Menu/Menu.svelte
+++ b/src/Menu/Menu.svelte
@@ -172,7 +172,7 @@
     if (target instanceof Element && target.closest("[role='menu']")) return;
     if (isOutsideClick(event, [anchor, ref])) close("outside-click");
   }
-  
+
   function handleEscape(event) {
     if (!open) return;
     // Tab is treated like Escape: without this, focus would leave the

--- a/tests/PasswordInput/PasswordInput.test.ts
+++ b/tests/PasswordInput/PasswordInput.test.ts
@@ -73,7 +73,7 @@ describe("PasswordInput", () => {
 
       expect(
         screen.getByText("Password must be at least 8 characters"),
-      ).toBeInTheDocument();
+      ).toHaveAttribute("role", "alert");
       const wrapper = screen
         .getByLabelText("Password")
         .closest(".bx--text-input__field-wrapper");

--- a/tests/TextInput/TextInput.test.ts
+++ b/tests/TextInput/TextInput.test.ts
@@ -401,6 +401,7 @@ describe("TextInput", () => {
     const input = screen.getByRole("textbox");
     expect(input).toHaveAttribute("aria-errormessage", "error-test-input");
     expect(input).not.toHaveAttribute("aria-describedby");
+    expect(screen.getByText("Invalid input")).toHaveAttribute("role", "alert");
   });
 
   it("should set aria-describedby to warning id when warn", () => {

--- a/tests/TextInput/TextInput.test.ts
+++ b/tests/TextInput/TextInput.test.ts
@@ -320,6 +320,7 @@ describe("TextInput", () => {
 
       const message = screen.getByText("Invalid input");
       expect(message).toHaveClass("bx--form-requirement");
+      expect(message).toHaveAttribute("role", "alert");
       expect(message.closest(".bx--text-input__field-wrapper")).not.toBeNull();
       expect(screen.getByLabelText("User name")).toHaveAttribute(
         "aria-errormessage",


### PR DESCRIPTION
Found while auditing Carbon React's commit history for parity fixes
not yet ported here.

Invalid text inputs referenced their error message via
aria-describedby, which per the ARIA spec is for general
supplementary description, not error association. Switches to
aria-errormessage, the correct attribute when paired with
aria-invalid.