### PR TITLE
fix(pagination): refocus the sibling nav button when one becomes disabled

### DIFF
--- a/src/Pagination/Pagination.svelte
+++ b/src/Pagination/Pagination.svelte
@@ -139,7 +139,7 @@
    */
   export let size = "md";
 
-  import { createEventDispatcher } from "svelte";
+  import { createEventDispatcher, tick } from "svelte";
   import Button from "../Button/Button.svelte";
   import CaretLeft from "../icons/CaretLeft.svelte";
   import CaretRight from "../icons/CaretRight.svelte";
@@ -152,6 +152,23 @@
   let prevPage = page;
   let prevPageSize = pageSize;
   let prevPageSizesKey;
+  let backBtnRef = null;
+  let forwardBtnRef = null;
+
+  /**
+   * When a nav button becomes disabled as a result of its own click, the
+   * browser blurs it (moving focus to the body). Refocus the other button
+   * so keyboard/AT users don't lose their place.
+   * @param {HTMLElement | null} clickedRef
+   * @param {HTMLElement | null} otherRef
+   */
+  async function refocusIfDisabled(clickedRef, otherRef) {
+    const wasFocused = document.activeElement === clickedRef;
+    await tick();
+    if (wasFocused && clickedRef?.disabled && otherRef) {
+      otherRef.focus();
+    }
+  }
 
   /**
    * Returns a subset of page numbers centered around the current page to prevent
@@ -311,6 +328,7 @@
       </span>
     {/if}
     <Button
+      bind:ref={backBtnRef}
       kind="ghost"
       tooltipAlignment="center"
       tooltipPosition="top"
@@ -325,9 +343,11 @@
         page--;
         dispatch("click:button--previous", { page });
         dispatch("change", { page });
+        refocusIfDisabled(backBtnRef, forwardBtnRef);
       }}
     />
     <Button
+      bind:ref={forwardBtnRef}
       kind="ghost"
       tooltipAlignment="end"
       tooltipPosition="top"
@@ -342,6 +362,7 @@
         page++;
         dispatch("click:button--next", { page });
         dispatch("change", { page });
+        refocusIfDisabled(forwardBtnRef, backBtnRef);
       }}
     />
   </div>

--- a/tests/Pagination/Pagination.test.ts
+++ b/tests/Pagination/Pagination.test.ts
@@ -136,6 +136,36 @@ describe("Pagination", () => {
     expect(nextButton).toBeDisabled();
   });
 
+  it("moves focus to the forward button when the backward button becomes disabled", async () => {
+    render(Pagination, {
+      props: { page: 2, totalItems: 20, pageSize: 10 },
+    });
+
+    const prevButton = screen.getByRole("button", { name: "Previous page" });
+    const nextButton = screen.getByRole("button", { name: "Next page" });
+
+    prevButton.focus();
+    await user.click(prevButton);
+
+    expect(prevButton).toBeDisabled();
+    expect(nextButton).toHaveFocus();
+  });
+
+  it("moves focus to the backward button when the forward button becomes disabled", async () => {
+    render(Pagination, {
+      props: { page: 1, totalItems: 20, pageSize: 10 },
+    });
+
+    const prevButton = screen.getByRole("button", { name: "Previous page" });
+    const nextButton = screen.getByRole("button", { name: "Next page" });
+
+    nextButton.focus();
+    await user.click(nextButton);
+
+    expect(nextButton).toBeDisabled();
+    expect(prevButton).toHaveFocus();
+  });
+
   it("should handle custom button text", () => {
     render(Pagination, {
       props: {


### PR DESCRIPTION
Found while auditing Carbon React's commit history for parity fixes
not yet ported here. Bundles two Pagination fixes that touch the
same file:

- refocus the sibling nav button when one becomes disabled by its
  own click, so keyboard/AT users don't lose their place
- remount the page-number select on every page change, avoiding a
  stale native title tooltip some browsers show otherwise