### PR TITLE
DatePicker: 2 Carbon React parity fixes

### DIFF
--- a/src/DatePicker/DatePicker.svelte
+++ b/src/DatePicker/DatePicker.svelte
@@ -583,6 +583,12 @@
     );
   }
 
+  // A scrollable modal can mask the pointerdown target so the matching
+  // `click` fires on an outside element (e.g. document.body) even though the
+  // interaction started inside the calendar. Track that origin so such a
+  // click doesn't get misread as an outside dismiss.
+  let pointerDownInside = false;
+
   /**
    * flatpickr closes on document `mousedown` before our `click` handler runs.
    * Set `closeTrigger` in capture phase so single-mode outside dismiss is not
@@ -591,13 +597,19 @@
    * @type {(event: Event) => void}
    */
   function handleOutsidePointerDown(event) {
-    if (isOutsideCalendarTarget(event)) closeTrigger = "outside-click";
+    const outside = isOutsideCalendarTarget(event);
+    pointerDownInside = !outside;
+    if (outside) closeTrigger = "outside-click";
   }
 
   /**
    * @type {(event: Event) => void}
    */
   function handleOutsideClick(event) {
+    if (pointerDownInside) {
+      pointerDownInside = false;
+      return;
+    }
     if (isOutsideCalendarTarget(event)) dismissCalendar("outside-click");
   }
 </script>

--- a/src/DatePicker/DatePicker.svelte
+++ b/src/DatePicker/DatePicker.svelte
@@ -528,12 +528,21 @@
   });
 
   $: dateFormatStore.set(dateFormat);
+  $: mode.set(datePickerType);
   $: inputValue.set(value);
   $: value = $inputValue;
   $: inputValueFrom.set(valueFrom);
   $: valueFrom = $inputValueFrom;
   $: inputValueTo.set(valueTo);
   $: valueTo = $inputValueTo;
+  $: if (!$hasCalendar && calendar) {
+    // datePickerType switched away from a calendar-having type; the
+    // flatpickr instance is otherwise only torn down on unmount.
+    detachFixedRepositionListeners();
+    calendar.destroy();
+    calendar = null;
+    lastAppliedOptions = {};
+  }
   $: if ($hasCalendar && inputRef) {
     initCalendar({
       dateFormat,

--- a/tests/DatePicker/DatePicker.test.ts
+++ b/tests/DatePicker/DatePicker.test.ts
@@ -418,6 +418,32 @@ describe("DatePicker", () => {
     expect(setDateSpy).not.toHaveBeenCalled();
   });
 
+  it("reinitializes the calendar when datePickerType changes after mount", async () => {
+    const { rerender } = render(DatePicker, {
+      props: { datePickerType: "simple" },
+    });
+
+    expect(screen.queryByLabelText("calendar-container")).toBeNull();
+
+    await rerender({ datePickerType: "single" });
+    await tick();
+
+    expect(await screen.findByLabelText("calendar-container")).toBeTruthy();
+  });
+
+  it("removes the calendar when datePickerType changes to simple after mount", async () => {
+    const { rerender } = render(DatePicker, {
+      props: { datePickerType: "single" },
+    });
+
+    await screen.findByLabelText("calendar-container");
+
+    await rerender({ datePickerType: "simple" });
+    await tick();
+
+    expect(screen.queryByLabelText("calendar-container")).toBeNull();
+  });
+
   it("supports custom label slot for DatePickerInput", () => {
     render(DatePickerInputSlot);
 

--- a/tests/DatePicker/DatePickerClose.test.ts
+++ b/tests/DatePicker/DatePickerClose.test.ts
@@ -1,4 +1,10 @@
-import { cleanup, render, screen, waitFor } from "@testing-library/svelte";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/svelte";
 import { tick } from "svelte";
 import { user } from "../utils/user";
 import DatePickerClose from "./DatePickerClose.test.svelte";
@@ -32,6 +38,54 @@ describe("DatePicker close event", () => {
     expect(calendar).not.toHaveClass("open");
     expect(onClose).toHaveBeenCalledTimes(1);
     expect(onClose.mock.calls[0][0].detail.trigger).toBe("select");
+  });
+
+  it("keeps the calendar open when a click bubbles from outside after a mousedown inside (e.g. modal scroll/blur)", async () => {
+    const onClose = vi.fn();
+    render(DatePickerClose, { props: { onClose } });
+
+    await user.click(screen.getByLabelText("Date"));
+    const calendar = await screen.findByLabelText("calendar-container");
+    expect(calendar).toHaveClass("open");
+
+    fireEvent.pointerDown(calendar);
+    document.body.dispatchEvent(
+      new MouseEvent("click", { bubbles: true, cancelable: true }),
+    );
+
+    expect(calendar).toHaveClass("open");
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("keeps the calendar open while tabbing between range inputs, closes on tabbing out", async () => {
+    const onClose = vi.fn();
+    const { container } = render(DatePickerClose, {
+      props: { onClose, datePickerType: "range" },
+    });
+    // A focusable element after the date picker so tabbing past the end
+    // input has a real next target (a null relatedTarget on blur means
+    // focus left the document entirely, which blurInput deliberately
+    // ignores to avoid replaying the open animation on tab-away/tab-back).
+    const nextButton = document.createElement("button");
+    nextButton.textContent = "next";
+    container.appendChild(nextButton);
+
+    const startInput = screen.getByLabelText("Start date");
+    const endInput = screen.getByLabelText("End date");
+
+    await user.click(startInput);
+    const calendar = await screen.findByLabelText("calendar-container");
+    expect(calendar).toHaveClass("open");
+
+    await user.tab();
+    expect(endInput).toHaveFocus();
+    expect(onClose).not.toHaveBeenCalled();
+    expect(calendar).toHaveClass("open");
+
+    await user.tab();
+    expect(nextButton).toHaveFocus();
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(calendar).not.toHaveClass("open");
   });
 
   it('dispatches close with trigger "escape-key" when Escape is pressed', async () => {


### PR DESCRIPTION
Found while auditing Carbon React's commit history for parity fixes
not yet ported here. Bundles two DatePicker fixes that touch the
same file:

- reinitialize the flatpickr instance when `datePickerType` changes
  after mount, instead of leaving the derived mode state stale
- keep the calendar open when a click bubbles in from outside a
  modal (a scrollable modal can mask the real pointerdown target so
  the click fires on document.body and gets misread as a dismiss)