### PR TITLE
Modal/ComposedModal: 2 Carbon React parity fixes

### DIFF
--- a/src/ComposedModal/ComposedModal.svelte
+++ b/src/ComposedModal/ComposedModal.svelte
@@ -24,8 +24,15 @@
   /** Set to `true` to remove the modal body padding so content spans edge to edge */
   export let fullWidth = false;
 
-  /** Set to `true` to prevent the modal from closing when clicking outside */
-  export let preventCloseOnClickOutside = false;
+  /**
+   * Set to prevent (or force-allow) closing the modal on an outside click.
+   * A modal without a `ModalFooter` (passive) closes on an outside click
+   * unless this is explicitly `true`. A modal with a `ModalFooter`
+   * (non-passive) never closes on an outside click unless this is
+   * explicitly `false`.
+   * @type {boolean | undefined}
+   */
+  export let preventCloseOnClickOutside = undefined;
 
   /** Specify a class for the inner modal */
   export let containerClass = "";
@@ -64,6 +71,9 @@
   let buttonRef = null;
   let innerModal = null;
   let closeDispatched = false;
+  // Set by ModalFooter registering itself; a modal without a footer is
+  // considered passive, same distinction as Modal's `passiveModal` prop.
+  let hasFooter = false;
 
   function close(trigger) {
     closeDispatched = true;
@@ -76,7 +86,10 @@
   }
 
   const outsideDismiss = createOutsideDismiss(() => {
-    if (!preventCloseOnClickOutside) close("outside-click");
+    const shouldClose = hasFooter
+      ? preventCloseOnClickOutside === false
+      : preventCloseOnClickOutside !== true;
+    if (shouldClose) close("outside-click");
   });
 
   /**
@@ -115,6 +128,13 @@
     title.set(value);
   }
 
+  /**
+   * @type {() => void}
+   */
+  function registerFooter() {
+    hasFooter = true;
+  }
+
   setContext("carbon:Modal", {});
   setContext("carbon:ComposedModal", {
     closeModal,
@@ -126,6 +146,7 @@
     titleId,
     label,
     title,
+    registerFooter,
   });
 
   function focus(element) {

--- a/src/ComposedModal/ModalBody.svelte
+++ b/src/ComposedModal/ModalBody.svelte
@@ -7,6 +7,7 @@
 
   import { getContext } from "svelte";
   import { writable } from "svelte/store";
+  import { scrollIntoViewWithinMenu } from "../utils/scrollIntoViewWithinMenu.js";
 
   const composedModalCtx = getContext("carbon:ComposedModal");
   const modalLabel = composedModalCtx?.label ?? writable(undefined);
@@ -32,6 +33,13 @@
   class:bx--modal-content={true}
   class:bx--modal-content--with-form={hasForm}
   class:bx--modal-scroll-content={hasScrollingContent}
+  on:focusin={(event) => {
+    // Keep a newly-focused element (e.g. via Tab) from being hidden under
+    // the scroll gradient at the bottom of the content area.
+    if (event.target instanceof HTMLElement) {
+      scrollIntoViewWithinMenu(event.target, ".bx--modal-content");
+    }
+  }}
   {...$$restProps}
 >
   <slot />

--- a/src/ComposedModal/ModalFooter.svelte
+++ b/src/ComposedModal/ModalFooter.svelte
@@ -60,7 +60,10 @@
   import InlineLoading from "../InlineLoading/InlineLoading.svelte";
 
   const dispatch = createEventDispatcher();
-  const { closeModal, submit } = getContext("carbon:ComposedModal");
+  const { closeModal, submit, registerFooter } = getContext(
+    "carbon:ComposedModal",
+  );
+  registerFooter();
 
   function handlePrimaryClick() {
     if (primaryButtonLoading) return;

--- a/src/Modal/Modal.svelte
+++ b/src/Modal/Modal.svelte
@@ -146,6 +146,7 @@
   import Close from "../icons/Close.svelte";
   import { initialFocus, restoreFocus } from "../utils/focus.js";
   import { createOutsideDismiss } from "../utils/outsideDismiss.js";
+  import { scrollIntoViewWithinMenu } from "../utils/scrollIntoViewWithinMenu.js";
   import { trapFocus } from "../utils/trapFocus.js";
   import { uniqueId } from "../utils/uniqueId.js";
   import { trackModal } from "./modalStore";
@@ -363,6 +364,13 @@
       role={hasScrollingContent ? "region" : undefined}
       aria-label={hasScrollingContent ? ariaLabel : undefined}
       aria-labelledby={modalLabel ? modalLabelId : modalHeadingId}
+      on:focusin={(event) => {
+        // Keep a newly-focused element (e.g. via Tab) from being hidden
+        // under the scroll gradient at the bottom of the content area.
+        if (event.target instanceof HTMLElement) {
+          scrollIntoViewWithinMenu(event.target, ".bx--modal-content");
+        }
+      }}
     >
       <slot />
     </div>

--- a/src/Modal/Modal.svelte
+++ b/src/Modal/Modal.svelte
@@ -115,8 +115,14 @@
   /** Specify a selector to be focused when opening the modal */
   export let selectorPrimaryFocus = "[data-modal-primary-focus]";
 
-  /** Set to `true` to prevent the modal from closing when clicking outside */
-  export let preventCloseOnClickOutside = false;
+  /**
+   * Set to prevent (or force-allow) closing the modal on an outside click.
+   * Passive modals close on an outside click unless this is explicitly
+   * `true`. Non-passive modals never close on an outside click unless this
+   * is explicitly `false`.
+   * @type {boolean | undefined}
+   */
+  export let preventCloseOnClickOutside = undefined;
 
   /**
    * Set to `true` to hide the header close button.
@@ -179,7 +185,10 @@
   }
 
   const outsideDismiss = createOutsideDismiss(() => {
-    if (!preventCloseOnClickOutside) close("outside-click");
+    const shouldClose = passiveModal
+      ? preventCloseOnClickOutside !== true
+      : preventCloseOnClickOutside === false;
+    if (shouldClose) close("outside-click");
   });
 
   const openStore = writable(open);

--- a/tests/ComposedModal/ComposedModal.test.svelte
+++ b/tests/ComposedModal/ComposedModal.test.svelte
@@ -8,7 +8,8 @@
   export let open: ComponentProps<ComposedModal>["open"] = false;
   export let size: ComponentProps<ComposedModal>["size"] = undefined;
   export let danger: ComponentProps<ComposedModal>["danger"] = false;
-  export let preventCloseOnClickOutside: ComponentProps<ComposedModal>["preventCloseOnClickOutside"] = false;
+  export let preventCloseOnClickOutside: ComponentProps<ComposedModal>["preventCloseOnClickOutside"] =
+    undefined;
   export let containerClass: ComponentProps<ComposedModal>["containerClass"] =
     "";
   export let selectorPrimaryFocus: ComponentProps<ComposedModal>["selectorPrimaryFocus"] =

--- a/tests/ComposedModal/ComposedModal.test.ts
+++ b/tests/ComposedModal/ComposedModal.test.ts
@@ -192,6 +192,76 @@ describe("ComposedModal", () => {
     expect(consoleLog).not.toHaveBeenCalledWith("close");
   });
 
+  describe("outside click behavior", () => {
+    function backdropOf(container: HTMLElement) {
+      const backdrop = container.querySelector('[role="presentation"]');
+      assert(backdrop);
+      return backdrop;
+    }
+
+    it("does not close a modal with a ModalFooter on outside click by default", async () => {
+      const closeHandler = vi.fn();
+      const { container } = render(ComposedModalTest, {
+        props: {
+          open: true,
+          headerTitle: "Transactional",
+          footerPrimaryButtonText: "Save",
+          footerSecondaryButtonText: "Cancel",
+          onclose: closeHandler,
+        },
+      });
+
+      await user.click(backdropOf(container));
+      expect(closeHandler).not.toHaveBeenCalled();
+    });
+
+    it("closes a modal with a ModalFooter on outside click when preventCloseOnClickOutside is explicitly false", async () => {
+      const closeHandler = vi.fn();
+      const { container } = render(ComposedModalTest, {
+        props: {
+          open: true,
+          headerTitle: "Transactional",
+          footerPrimaryButtonText: "Save",
+          footerSecondaryButtonText: "Cancel",
+          preventCloseOnClickOutside: false,
+          onclose: closeHandler,
+        },
+      });
+
+      await user.click(backdropOf(container));
+      expect(closeHandler).toHaveBeenCalledTimes(1);
+    });
+
+    it("closes a modal without a ModalFooter on outside click by default", async () => {
+      const closeHandler = vi.fn();
+      const { container } = render(ComposedModalTest, {
+        props: {
+          open: true,
+          headerTitle: "Passive",
+          onclose: closeHandler,
+        },
+      });
+
+      await user.click(backdropOf(container));
+      expect(closeHandler).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not close a modal without a ModalFooter on outside click when preventCloseOnClickOutside is explicitly true", async () => {
+      const closeHandler = vi.fn();
+      const { container } = render(ComposedModalTest, {
+        props: {
+          open: true,
+          headerTitle: "Passive",
+          preventCloseOnClickOutside: true,
+          onclose: closeHandler,
+        },
+      });
+
+      await user.click(backdropOf(container));
+      expect(closeHandler).not.toHaveBeenCalled();
+    });
+  });
+
   it("should render header with title and label", () => {
     render(ComposedModalTest, {
       props: {

--- a/tests/ComposedModal/ComposedModal.test.ts
+++ b/tests/ComposedModal/ComposedModal.test.ts
@@ -332,6 +332,31 @@ describe("ComposedModal", () => {
     expect(modalBody).toHaveAttribute("tabindex", "0");
   });
 
+  it("scrolls a newly-focused element out from under the scroll gradient", () => {
+    render(ComposedModalTest, {
+      props: {
+        open: true,
+        headerTitle: "Test Modal",
+        bodyHasScrollingContent: true,
+      },
+    });
+
+    const modalContent = screen.getByRole("region");
+    Object.defineProperty(modalContent, "clientHeight", { value: 100 });
+    Object.defineProperty(modalContent, "scrollHeight", { value: 300 });
+    modalContent.scrollTop = 50;
+    modalContent.getBoundingClientRect = () =>
+      ({ top: 0, bottom: 100 }) as DOMRect;
+
+    const input = screen.getByTestId("test-focus");
+    input.getBoundingClientRect = () => ({ top: 110, bottom: 130 }) as DOMRect;
+
+    input.dispatchEvent(new FocusEvent("focusin", { bubbles: true }));
+
+    // scrollTop += itemBottom(130) - containerBottom(100) => 50 + 30 = 80
+    expect(modalContent.scrollTop).toBe(80);
+  });
+
   it("should handle form content", () => {
     render(ComposedModalTest, {
       props: {

--- a/tests/ComposedModal/ComposedModalFocusReturn.test.svelte
+++ b/tests/ComposedModal/ComposedModalFocusReturn.test.svelte
@@ -8,7 +8,7 @@
 </script>
 
 <button type="button" on:click={() => (open = true)}>Open Modal</button>
-<ComposedModal bind:open>
+<ComposedModal bind:open preventCloseOnClickOutside={false}>
   <ModalHeader title="Focus Return Test" />
   <ModalBody />
   <ModalFooter primaryButtonText="Save" secondaryButtonText="Cancel" />

--- a/tests/Modal/Modal.test.svelte
+++ b/tests/Modal/Modal.test.svelte
@@ -20,7 +20,8 @@
   export let secondaryButtons: ComponentProps<Modal>["secondaryButtons"] =
     undefined;
   export let selectorPrimaryFocus = "[data-modal-primary-focus]";
-  export let preventCloseOnClickOutside = false;
+  export let preventCloseOnClickOutside: ComponentProps<Modal>["preventCloseOnClickOutside"] =
+    undefined;
   export let hideCloseButton = false;
   export let size: ComponentProps<Modal>["size"] = undefined;
   export let danger = false;

--- a/tests/Modal/Modal.test.ts
+++ b/tests/Modal/Modal.test.ts
@@ -478,6 +478,78 @@ describe("Modal", () => {
     expect(screen.getByRole("button", { name: "Delete" })).toHaveFocus();
   });
 
+  describe("outside click behavior", () => {
+    function backdropOf(container: HTMLElement) {
+      const backdrop = container.querySelector('[role="presentation"]');
+      assert(backdrop);
+      return backdrop;
+    }
+
+    it("does not close a non-passive modal on outside click by default", async () => {
+      const closeHandler = vi.fn();
+      const { container } = render(ModalTest, {
+        props: {
+          open: true,
+          modalHeading: "Transactional",
+          primaryButtonText: "Save",
+          secondaryButtonText: "Cancel",
+          onclose: closeHandler,
+        },
+      });
+
+      await user.click(backdropOf(container));
+      expect(closeHandler).not.toHaveBeenCalled();
+    });
+
+    it("closes a non-passive modal on outside click when preventCloseOnClickOutside is explicitly false", async () => {
+      const closeHandler = vi.fn();
+      const { container } = render(ModalTest, {
+        props: {
+          open: true,
+          modalHeading: "Transactional",
+          primaryButtonText: "Save",
+          secondaryButtonText: "Cancel",
+          preventCloseOnClickOutside: false,
+          onclose: closeHandler,
+        },
+      });
+
+      await user.click(backdropOf(container));
+      expect(closeHandler).toHaveBeenCalledTimes(1);
+    });
+
+    it("closes a passive modal on outside click by default", async () => {
+      const closeHandler = vi.fn();
+      const { container } = render(ModalTest, {
+        props: {
+          open: true,
+          passiveModal: true,
+          modalHeading: "Passive",
+          onclose: closeHandler,
+        },
+      });
+
+      await user.click(backdropOf(container));
+      expect(closeHandler).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not close a passive modal on outside click when preventCloseOnClickOutside is explicitly true", async () => {
+      const closeHandler = vi.fn();
+      const { container } = render(ModalTest, {
+        props: {
+          open: true,
+          passiveModal: true,
+          modalHeading: "Passive",
+          preventCloseOnClickOutside: true,
+          onclose: closeHandler,
+        },
+      });
+
+      await user.click(backdropOf(container));
+      expect(closeHandler).not.toHaveBeenCalled();
+    });
+  });
+
   it("prevents closing when clicking outside if configured", async () => {
     render(ModalTest, {
       props: {
@@ -563,6 +635,7 @@ describe("Modal", () => {
     const { container } = render(ModalTest, {
       props: {
         open: true,
+        passiveModal: true,
         modalHeading: "Outside Click Test",
         onclose: closeHandler,
       },
@@ -721,6 +794,7 @@ describe("Modal", () => {
     const { container } = render(ModalTest, {
       props: {
         open: true,
+        passiveModal: true,
         modalHeading: "Prevent Close Test",
         onclose: closeHandler,
       },

--- a/tests/Modal/Modal.test.ts
+++ b/tests/Modal/Modal.test.ts
@@ -305,6 +305,31 @@ describe("Modal", () => {
     expect(modalBody).toHaveClass("bx--modal-scroll-content");
   });
 
+  it("scrolls a newly-focused element out from under the scroll gradient", () => {
+    render(ModalTest, {
+      props: {
+        open: true,
+        hasScrollingContent: true,
+        modalHeading: "Scrolling Modal",
+      },
+    });
+
+    const modalContent = screen.getByRole("region");
+    Object.defineProperty(modalContent, "clientHeight", { value: 100 });
+    Object.defineProperty(modalContent, "scrollHeight", { value: 300 });
+    modalContent.scrollTop = 50;
+    modalContent.getBoundingClientRect = () =>
+      ({ top: 0, bottom: 100 }) as DOMRect;
+
+    const input = screen.getByTestId("test-focus");
+    input.getBoundingClientRect = () => ({ top: 110, bottom: 130 }) as DOMRect;
+
+    input.dispatchEvent(new FocusEvent("focusin", { bubbles: true }));
+
+    // scrollTop += itemBottom(130) - containerBottom(100) => 50 + 30 = 80
+    expect(modalContent.scrollTop).toBe(80);
+  });
+
   // Regression test for https://github.com/carbon-design-system/carbon-components-svelte/issues/2671
   it("should focus primary button when open (not close button)", () => {
     render(ModalTest, {

--- a/tests/Modal/ModalFocusReturn.test.svelte
+++ b/tests/Modal/ModalFocusReturn.test.svelte
@@ -10,4 +10,5 @@
   modalHeading="Focus Return Test"
   primaryButtonText="Save"
   secondaryButtonText="Cancel"
+  preventCloseOnClickOutside={false}
 />


### PR DESCRIPTION
Found while auditing Carbon React's commit history for parity fixes
not yet ported here. Bundles two Modal-family fixes that touch the
same files:

- don't close non-passive modals (ones with footer actions) on
  outside click by default. `preventCloseOnClickOutside` was
  ignoring `passiveModal` entirely, so a transactional modal closed
  on outside click unless the consumer explicitly opted out, which
  is backwards from the Carbon design spec. Since ComposedModal has
  no `passiveModal` prop, `ModalFooter` now registers itself with
  its parent so the same passive/non-passive split can be derived
  from footer presence.
- scroll a newly-focused element out from under the scroll gradient.
  `hasScrollingContent` renders a bottom gradient overlay, but
  nothing kept a Tab-focused element from landing underneath it.