### PR TITLE
fix(multi-select): scope select-all to the currently filtered items

### DIFF
--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -431,13 +431,25 @@
   function syncSelectAllItem() {
     if (!hasSelectAll) return;
 
-    const newSelectableChecked = sortedItems.filter(
-      (sortedItem) =>
-        !sortedItem.disabled && !sortedItem.isSelectAll && sortedItem.checked,
+    // Recomputed fresh from `sortedItems`/`value` (plain reads) rather than
+    // the `$:`-derived `selectAllScope`/`selectableItems`, which haven't
+    // picked up the mutation callers make to `sortedItems` just before
+    // calling this (reactive statements only re-run on the next tick).
+    const scope =
+      filterable && open
+        ? sortedItems.filter(
+            (sortedItem) =>
+              sortedItem.isSelectAll || filterItem(sortedItem, value),
+          )
+        : sortedItems;
+    const selectable = scope.filter(
+      (sortedItem) => !sortedItem.disabled && !sortedItem.isSelectAll,
+    );
+    const newSelectableChecked = selectable.filter(
+      (sortedItem) => sortedItem.checked,
     ).length;
     const newAllSelected =
-      selectableItems.length > 0 &&
-      newSelectableChecked === selectableItems.length;
+      selectable.length > 0 && newSelectableChecked === selectable.length;
     const selectAllIndex = sortedItems.findIndex(
       (sortedItem) => sortedItem.isSelectAll,
     );
@@ -473,7 +485,9 @@
     if (item.isSelectAll) {
       const target = !allSelected;
       sortedItems = sortedItems.map((sortedItem) =>
-        sortedItem.disabled || sortedItem.checked === target
+        !selectAllScopeIds.has(sortedItem.id) ||
+        sortedItem.disabled ||
+        sortedItem.checked === target
           ? sortedItem
           : { ...sortedItem, checked: target },
       );
@@ -804,7 +818,11 @@
     (item) =>
       !item.isSelectAll && !item.disabled && selectedIdsSet.has(item.id),
   );
-  $: selectableItems = sortedItems.filter(
+  // Scope select-all to the currently visible (filtered) items, so it
+  // doesn't check/uncheck items hidden by an active filter.
+  $: selectAllScope = filterable && open ? filteredItems : sortedItems;
+  $: selectAllScopeIds = new Set(selectAllScope.map((item) => item.id));
+  $: selectableItems = selectAllScope.filter(
     (item) => !item.disabled && !item.isSelectAll,
   );
   $: selectableCheckedCount = selectableItems.filter(

--- a/tests/MultiSelect/MultiSelect.test.ts
+++ b/tests/MultiSelect/MultiSelect.test.ts
@@ -7,6 +7,7 @@ import {
 } from "@testing-library/svelte";
 import type MultiSelectComponent from "carbon-components-svelte/MultiSelect/MultiSelect.svelte";
 import type { MultiSelectItem } from "carbon-components-svelte/MultiSelect/MultiSelect.svelte";
+import MultiSelectReal from "carbon-components-svelte/MultiSelect/MultiSelect.svelte";
 import { fuzzyMatch } from "carbon-components-svelte/utils/fuzzyMatch";
 import type { ComponentEvents, ComponentProps } from "svelte";
 import { tick } from "svelte";
@@ -59,6 +60,14 @@ describe("MultiSelect", () => {
       "aria-expanded",
       "false",
     );
+  });
+
+  it("forwards a maxlength attribute to the filterable input via restProps", () => {
+    render(MultiSelectReal, {
+      props: { items: [], filterable: true, maxlength: 10 },
+    });
+
+    expect(screen.getByRole("combobox")).toHaveAttribute("maxlength", "10");
   });
 
   describe("field accessible name and description", () => {

--- a/tests/MultiSelect/MultiSelect.test.ts
+++ b/tests/MultiSelect/MultiSelect.test.ts
@@ -625,6 +625,54 @@ describe("MultiSelect", () => {
       expect(consoleLog.mock.calls[0][1].unselected).toHaveLength(4);
     });
 
+    it("scopes select-all to the currently filtered items, not the whole list", async () => {
+      const consoleLog = vi.spyOn(console, "log");
+      render(MultiSelect, {
+        props: {
+          items: itemsWithSelectAll,
+          labelText: "Roles",
+          filterable: true,
+          placeholder: "Filter...",
+        },
+      });
+
+      const input = screen.getByRole("combobox");
+      await user.click(input);
+      await user.type(input, "Ed");
+      await toggleOption("All roles");
+
+      expect(consoleLog).toHaveBeenCalledWith("select", {
+        selectedIds: ["editor"],
+        selected: [expect.objectContaining({ id: "editor", checked: true })],
+        unselected: expect.arrayContaining([
+          expect.objectContaining({ id: "owner", checked: false }),
+          expect.objectContaining({ id: "reader", checked: false }),
+          expect.objectContaining({ id: "uploader", checked: false }),
+        ]),
+      });
+      expect(consoleLog.mock.calls[0][1].unselected).toHaveLength(3);
+    });
+
+    it("does not indicate select-all as checked when unfiltered items remain unselected", async () => {
+      render(MultiSelect, {
+        props: {
+          items: itemsWithSelectAll,
+          labelText: "Roles",
+          filterable: true,
+          placeholder: "Filter...",
+        },
+      });
+
+      const input = screen.getByRole("combobox");
+      await user.click(input);
+      await user.type(input, "Ed");
+      await toggleOption("All roles");
+
+      await user.clear(input);
+      const selectAllOption = screen.getByRole("option", { name: "All roles" });
+      expect(selectAllOption).toHaveAttribute("aria-selected", "false");
+    });
+
     it("select event excludes isSelectAll item from selectedIds and selected/unselected", async () => {
       const consoleLog = vi.spyOn(console, "log");
       render(MultiSelect, {


### PR DESCRIPTION
Found while auditing Carbon React's commit history for parity fixes
not yet ported here.

Clicking select-all (or its checked/indeterminate display)
considered every item in the list, not just the ones visible under
an active filter, so it silently selected/deselected items the user
couldn't see. Scopes both the toggle and the checked/indeterminate
calculation to the filtered set when filterable and open. Also adds
a small regression test confirming restProps already forwards
maxlength to the filterable input, matching the same coverage added
for ComboBox.