### PR TITLE
fix(menu): close and return focus to the anchor on Tab, same as Escape

### DIFF
--- a/src/Menu/Menu.svelte
+++ b/src/Menu/Menu.svelte
@@ -172,8 +172,15 @@
     if (target instanceof Element && target.closest("[role='menu']")) return;
     if (isOutsideClick(event, [anchor, ref])) close("outside-click");
   }
+  
   function handleEscape(event) {
-    if (open && event.key === "Escape") close("escape-key");
+    if (!open) return;
+    // Tab is treated like Escape: without this, focus would leave the
+    // (possibly portaled) menu for whatever happens to be next in the DOM.
+    if (event.key === "Escape" || event.key === "Tab") {
+      event.preventDefault();
+      close("escape-key");
+    }
   }
 </script>
 

--- a/tests/Menu/Menu.test.ts
+++ b/tests/Menu/Menu.test.ts
@@ -242,6 +242,22 @@ describe("Menu", () => {
     });
   });
 
+  it("closes and returns focus to the anchor on Tab", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(MenuFixture);
+
+    const trigger = screen.getByRole("button", { name: "Trigger" });
+    await user.click(trigger);
+
+    await user.keyboard("{Tab}");
+
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    expect(trigger).toHaveFocus();
+    expect(consoleLog).toHaveBeenCalledWith("close", {
+      trigger: "escape-key",
+    });
+  });
+
   it("closes on outside click without returning focus", async () => {
     const consoleLog = vi.spyOn(console, "log");
     render(MenuFixture);


### PR DESCRIPTION
Found while auditing Carbon React's commit history for parity fixes
not yet ported here.

Tab wasn't handled at all, so pressing it inside an open (possibly
portaled) menu left focus on whatever happened to be next in the
DOM instead of the field the user actually tabbed from, especially
disorienting inside a Modal/Tearsheet. Applies to Menu, and by
extension MenuButton/OverflowMenu submenus and MenuItem submenus,
which all share this component.