### PR TITLE
fix(menu): move item title tooltip to the interactive element

### DIFF
--- a/src/Menu/MenuItem.svelte
+++ b/src/Menu/MenuItem.svelte
@@ -184,6 +184,7 @@
   aria-checked={isIndented ? selected : undefined}
   aria-haspopup={hasSubmenu ? true : undefined}
   aria-expanded={hasSubmenu ? submenuOpen : undefined}
+  title={labelText}
   class:bx--menu-option={true}
   class:bx--menu-option--disabled={disabled}
   class:bx--menu-option--active={hasSubmenu && submenuOpen}
@@ -244,10 +245,7 @@
         <svelte:component this={displayIcon} />
       </div>
     {/if}
-    <span
-      class:bx--menu-option__label={true}
-      title={hasSubmenu ? labelText : undefined}
-    >
+    <span class:bx--menu-option__label={true}>
       {#if labelText !== undefined}
         <slot name="labelChildren">{labelText}</slot>
       {:else}

--- a/tests/Menu/MenuItem.test.svelte
+++ b/tests/Menu/MenuItem.test.svelte
@@ -15,6 +15,7 @@
 <Menu {anchor} bind:open labelText="Example menu">
   <MenuItem icon={Add}>Add item</MenuItem>
   <MenuItem>Plain</MenuItem>
+  <MenuItem labelText="Standalone label" />
   <MenuItem shortcutText="⌘S">Save</MenuItem>
   <MenuItem labelText="Export as">
     <MenuItem on:click={() => console.log("select", "PDF")}>PDF</MenuItem>

--- a/tests/Menu/MenuItem.test.ts
+++ b/tests/Menu/MenuItem.test.ts
@@ -329,10 +329,20 @@ describe("MenuItem", () => {
       const parent = screen.getByRole("menuitem", {
         name: "Custom label content",
       });
-      expect(parent.querySelector(".bx--menu-option__label")).toHaveAttribute(
-        "title",
-        "Export as",
-      );
+      // On the interactive element (the <li>), not the label span: the label
+      // truncates with an ellipsis, so the title needs to be reachable by
+      // hovering anywhere in the row, not just the label text itself.
+      expect(parent).toHaveAttribute("title", "Export as");
+    });
+
+    it("sets the title on a non-submenu item that uses labelText, since its label can also truncate", async () => {
+      render(MenuItemFixture);
+
+      await user.click(screen.getByRole("button", { name: "Trigger" }));
+
+      expect(
+        screen.getByRole("menuitem", { name: "Standalone label" }),
+      ).toHaveAttribute("title", "Standalone label");
     });
   });
 


### PR DESCRIPTION
Found while auditing Carbon React's commit history for parity fixes
not yet ported here.

title was only set for submenu items, and on the label span rather
than the li: a non-submenu item's label truncates with an ellipsis
the same way (bx--menu-option__label's text-overflow: ellipsis) but
had no tooltip, and hovering anywhere in a submenu item's row
besides the label text itself didn't trigger one either.