### PR TITLE
fix(ui-shell): apply the current-page styling class on nav items

### DIFF
--- a/src/UIShell/HeaderNavItem.svelte
+++ b/src/UIShell/HeaderNavItem.svelte
@@ -74,6 +74,7 @@
     rel={$$restProps.target === "_blank" ? "noopener noreferrer" : undefined}
     class:bx--header__menu-item={true}
     class:bx--header__menu-item--icon={icon || $$slots.icon}
+    class:bx--header__menu-item--current={isSelected}
     aria-current={isSelected ? "page" : undefined}
     {...$$restProps}
     on:click

--- a/src/UIShell/SideNavMenuItem.svelte
+++ b/src/UIShell/SideNavMenuItem.svelte
@@ -27,6 +27,7 @@
     aria-current={isSelected ? "page" : undefined}
     {href}
     class:bx--side-nav__link={true}
+    class:bx--side-nav__link--current={isSelected}
     {...$$restProps}
     on:click
   >

--- a/tests/UIShell/HeaderNavItem.test.ts
+++ b/tests/UIShell/HeaderNavItem.test.ts
@@ -1,0 +1,24 @@
+import { render, screen } from "@testing-library/svelte";
+import HeaderNavItem from "carbon-components-svelte/UIShell/HeaderNavItem.svelte";
+
+describe("HeaderNavItem", () => {
+  it("applies the current-page styling class when isSelected", () => {
+    render(HeaderNavItem, {
+      props: { href: "/", text: "Overview", isSelected: true },
+    });
+
+    const item = screen.getByRole("menuitem", { name: "Overview" });
+    expect(item).toHaveClass("bx--header__menu-item--current");
+    expect(item).toHaveAttribute("aria-current", "page");
+  });
+
+  it("omits the current-page styling class when not selected", () => {
+    render(HeaderNavItem, {
+      props: { href: "/", text: "Overview", isSelected: false },
+    });
+
+    const item = screen.getByRole("menuitem", { name: "Overview" });
+    expect(item).not.toHaveClass("bx--header__menu-item--current");
+    expect(item).not.toHaveAttribute("aria-current");
+  });
+});

--- a/tests/UIShell/SideNavMenuItem.test.ts
+++ b/tests/UIShell/SideNavMenuItem.test.ts
@@ -1,0 +1,24 @@
+import { render, screen } from "@testing-library/svelte";
+import SideNavMenuItem from "carbon-components-svelte/UIShell/SideNavMenuItem.svelte";
+
+describe("SideNavMenuItem", () => {
+  it("applies the current-page styling class when isSelected", () => {
+    render(SideNavMenuItem, {
+      props: { href: "/", text: "Overview", isSelected: true },
+    });
+
+    const link = screen.getByRole("link", { name: "Overview" });
+    expect(link).toHaveClass("bx--side-nav__link--current");
+    expect(link).toHaveAttribute("aria-current", "page");
+  });
+
+  it("omits the current-page styling class when not selected", () => {
+    render(SideNavMenuItem, {
+      props: { href: "/", text: "Overview", isSelected: false },
+    });
+
+    const link = screen.getByRole("link", { name: "Overview" });
+    expect(link).not.toHaveClass("bx--side-nav__link--current");
+    expect(link).not.toHaveAttribute("aria-current");
+  });
+});


### PR DESCRIPTION
Found while auditing Carbon React's commit history for parity fixes
not yet ported here.

isSelected already set aria-current="page" on HeaderNavItem and
SideNavMenuItem, but never toggled the matching
bx--header__menu-item--current / bx--side-nav__link--current class,
so the visible current-page indicator (underline/background/color)
never showed up despite being announced correctly to assistive
tech. SideNavLink already wires both together; these two didn't.