### PR TITLE
test(ui-shell): cover HeaderNavMenu collapse on link-item click

### DIFF
--- a/tests/UIShell/HeaderNavMenuClose.test.ts
+++ b/tests/UIShell/HeaderNavMenuClose.test.ts
@@ -50,6 +50,19 @@ describe("HeaderNavMenu close event", () => {
     });
   });
 
+  it("collapses when clicking a link menu item", async () => {
+    const onClose = vi.fn();
+    render(HeaderNavMenuClose, { props: { onClose } });
+
+    const menuTrigger = screen.getByRole("menuitem", { name: "Menu" });
+    menuTrigger.focus();
+    await user.keyboard(" ");
+    expect(menuTrigger).toHaveAttribute("aria-expanded", "true");
+
+    await user.click(screen.getByRole("menuitem", { name: "Menu Item 1" }));
+    expect(menuTrigger).toHaveAttribute("aria-expanded", "false");
+  });
+
   it("does not dispatch close on outside clicks while collapsed", async () => {
     const onClose = vi.fn();
     render(HeaderNavMenuClose, { props: { onClose } });


### PR DESCRIPTION
Found while auditing Carbon React's commit history for parity fixes
not yet ported here.

Adds regression coverage confirming clicking a link menu item
collapses its parent HeaderNavMenu. Already worked correctly here:
the click listener sits on the li wrapping the whole submenu, so it
catches bubbled clicks from any item regardless of type, unlike
upstream React's bug (a handler wired only to specific child
types).