### PR TITLE
NumberInput: 2 Carbon React parity fixes

### DIFF
--- a/src/NumberInput/NumberInput.svelte
+++ b/src/NumberInput/NumberInput.svelte
@@ -484,6 +484,7 @@
         <input
           bind:this={ref}
           type="number"
+          inputmode="decimal"
           aria-describedby={hasErrorMessage
             ? errorId
             : showWarn

--- a/src/utils/numericFormat.js
+++ b/src/utils/numericFormat.js
@@ -7,13 +7,44 @@ const RE_DOT = /\./g;
 const RE_COMMA = /[,٫]/g;
 
 /**
+ * Non-Western decimal digit ranges that `Intl.NumberFormat` renders for some
+ * locales (e.g. "ar-EG" formats using Arabic-Indic ٠-٩), mapped to their
+ * Unicode codepoint offset from the localized "0".
+ */
+const DIGIT_RANGES = [
+  [0x0660, 0x0669], // Arabic-Indic
+  [0x06f0, 0x06f9], // Extended Arabic-Indic (Persian)
+  [0x0966, 0x096f], // Devanagari
+  [0x09e6, 0x09ef], // Bengali
+  [0xff10, 0xff19], // Fullwidth
+];
+
+/**
+ * Replace non-Western digit glyphs with ASCII `0`-`9` so `Number()` can parse them.
+ *
+ * @param {string} raw
+ * @returns {string}
+ */
+function normalizeDigits(raw) {
+  let result = "";
+  for (const char of raw) {
+    const code = char.codePointAt(0);
+    const range = DIGIT_RANGES.find(
+      ([start, end]) => code >= start && code <= end,
+    );
+    result += range ? String(code - range[0]) : char;
+  }
+  return result;
+}
+
+/**
  * Replace comma and ٫ with `.`. Use while the user is still typing, before blur.
  *
  * @param {string} raw
  * @returns {string}
  */
 function replaceDecimalSeparators(raw) {
-  return raw.replace(RE_COMMA, ".");
+  return normalizeDigits(raw).replace(RE_COMMA, ".");
 }
 
 /**
@@ -25,17 +56,21 @@ function replaceDecimalSeparators(raw) {
  * @returns {string}
  */
 function normalizeLocale(raw) {
-  const lastComma = Math.max(raw.lastIndexOf(","), raw.lastIndexOf("٫"));
-  const lastDot = raw.lastIndexOf(".");
+  const normalized = normalizeDigits(raw);
+  const lastComma = Math.max(
+    normalized.lastIndexOf(","),
+    normalized.lastIndexOf("٫"),
+  );
+  const lastDot = normalized.lastIndexOf(".");
 
   if (lastComma !== -1 && lastDot !== -1) {
     if (lastComma > lastDot) {
-      return raw.replace(RE_DOT, "").replace(RE_COMMA, ".");
+      return normalized.replace(RE_DOT, "").replace(RE_COMMA, ".");
     }
-    return raw.replace(RE_COMMA, "");
+    return normalized.replace(RE_COMMA, "");
   }
 
-  return replaceDecimalSeparators(raw);
+  return replaceDecimalSeparators(normalized);
 }
 
 /**
@@ -71,7 +106,7 @@ export function parseLocaleValue(raw, groupSeparator, decimalSeparator) {
   if (decimalSeparator !== ".") {
     normalized = normalized.replace(decimalSeparator, ".");
   }
-  const num = Number(normalized);
+  const num = Number(normalizeDigits(normalized));
   return Number.isNaN(num) ? null : num;
 }
 

--- a/tests/NumberInput/NumberInput.test.ts
+++ b/tests/NumberInput/NumberInput.test.ts
@@ -1736,6 +1736,21 @@ describe("NumberInput", () => {
       expect(screen.getByTestId("value").textContent).toBe("1234.5");
     });
 
+    it("should parse Arabic-Indic digits typed with an Arabic locale", async () => {
+      // Regression test: locales like "ar-EG" render/expect Arabic-Indic digit
+      // glyphs (١٢٣٤٥ etc), which JS's `Number()` can't parse directly.
+      render(NumberInput, {
+        props: { locale: "ar-EG", value: null, allowEmpty: true },
+      });
+
+      const input = screen.getByRole("textbox");
+      expect.assert(input instanceof HTMLInputElement);
+      await user.type(input, "١٢٣٤٫٥");
+      await user.tab();
+
+      expect(screen.getByTestId("value").textContent).toBe("1234.5");
+    });
+
     it("should fall back to standard parsing when locale is removed", async () => {
       const { rerender } = render(NumberInput, {
         props: { locale: "de-DE", value: 1234.5, allowEmpty: true },

--- a/tests/NumberInput/NumberInput.test.ts
+++ b/tests/NumberInput/NumberInput.test.ts
@@ -552,6 +552,13 @@ describe("NumberInput", () => {
     expect(input).not.toHaveAttribute("pattern");
   });
 
+  it("should default inputmode to decimal on type=number input", () => {
+    render(NumberInput);
+
+    const input = screen.getByRole("spinbutton");
+    expect(input).toHaveAttribute("inputmode", "decimal");
+  });
+
   it("should support aria-label override via restProps", () => {
     render(NumberInput, {
       props: {

--- a/tests/utils/numericFormat.test.ts
+++ b/tests/utils/numericFormat.test.ts
@@ -48,6 +48,26 @@ describe("parseLocaleValue", () => {
     expect(parseLocaleValue("", ".", ",")).toBe(null);
     expect(parseLocaleValue("-", ".", ",")).toBe(null);
   });
+
+  test("normalizes Arabic-Indic digits to ASCII before parsing", () => {
+    // new Intl.NumberFormat("ar-EG").formatToParts(12345.6) yields these separators,
+    // and format() renders digits using Arabic-Indic glyphs (١٢٣٤٥ etc).
+    expect(parseLocaleValue("١٬٢٣٤٫٥", "٬", "٫")).toBe(1234.5);
+  });
+
+  test("normalizes Extended Arabic-Indic (Persian) digits to ASCII before parsing", () => {
+    // new Intl.NumberFormat("fa-IR") renders digits using Extended Arabic-Indic glyphs (۱۲۳۴۵ etc).
+    expect(parseLocaleValue("۱٬۲۳۴٫۵", "٬", "٫")).toBe(1234.5);
+  });
+
+  test("normalizes Bengali digits to ASCII before parsing", () => {
+    // new Intl.NumberFormat("bn-BD") renders digits using Bengali glyphs (১২৩৪৫ etc).
+    expect(parseLocaleValue("১,২৩৪.৫", ",", ".")).toBe(1234.5);
+  });
+
+  test("normalizes fullwidth digits to ASCII before parsing", () => {
+    expect(parseLocaleValue("１，２３４．５", "，", "．")).toBe(1234.5);
+  });
 });
 
 describe("getDefaultValue", () => {


### PR DESCRIPTION
Found while auditing Carbon React's commit history for parity fixes
not yet ported here. Bundles two NumberInput fixes that touch the
same file:

- normalize non-Western digit glyphs before parsing.
  Intl.NumberFormat renders locales like ar-EG and fa-IR using
  Arabic-Indic or Devanagari/Bengali/fullwidth digit glyphs, which
  Number() can't parse, so typed or pasted localized digits were
  silently dropped instead of parsed
- default `inputmode` to `decimal` for `type="number"`, matching
  Carbon React's default (some mobile keyboards omit the decimal
  point unless inputmode is set explicitly, even for type="number")