### PR TITLE
test(slider): cover uneven-step reachability and decimal-step rounding

### DIFF
--- a/tests/Slider/RangeSlider.test.ts
+++ b/tests/Slider/RangeSlider.test.ts
@@ -186,6 +186,18 @@ describe("RangeSlider", () => {
     });
   });
 
+  it("should allow the upper handle to reach max via keyboard when step doesn't evenly divide the range", async () => {
+    render(RangeSlider, {
+      props: { value: 0, valueUpper: 400, min: 0, max: 435, step: 50 },
+    });
+
+    const [, upperThumb] = screen.getAllByRole("slider");
+    upperThumb.focus();
+    await user.keyboard("{ArrowRight}");
+
+    expect(upperThumb).toHaveAttribute("aria-valuenow", "435");
+  });
+
   it("should not dispatch change on programmatic value updates", async () => {
     const consoleLog = vi.spyOn(console, "log");
     const { rerender } = render(RangeSlider, {

--- a/tests/Slider/Slider.test.ts
+++ b/tests/Slider/Slider.test.ts
@@ -807,6 +807,21 @@ describe("Slider", () => {
     expect(consoleLog).toHaveBeenCalledWith("input", 1);
   });
 
+  it("should not accumulate floating-point drift with decimal steps", async () => {
+    render(Slider, { props: { min: 0, max: 1, step: 0.1, value: 0 } });
+
+    const slider = screen.getByRole("slider");
+    await user.tab();
+    expect(slider).toHaveFocus();
+
+    for (let i = 0; i < 4; i++) {
+      // biome-ignore lint/performance/noAwaitInLoops: sequential execution is intentional
+      await user.keyboard("{ArrowRight}");
+    }
+
+    expect(slider).toHaveAttribute("aria-valuenow", "0.4");
+  });
+
   // Regression test for https://github.com/carbon-design-system/carbon-components-svelte/issues/1219
   it("should round shift+arrow values to valid steps", async () => {
     const consoleLog = vi.spyOn(console, "log");


### PR DESCRIPTION
Found while auditing Carbon React's commit history for parity fixes
not yet ported here.

Carbon React had bugs in both areas (index-based step calculation
losing the max endpoint; floor-based delta causing fp drift). This
port's round-and-clamp stepping formula already avoids both, so
this adds regression coverage instead of a behavior change.