### PR TITLE
fix(toggletip): stop closing on browser window blur

### DIFF
--- a/src/Toggletip/Toggletip.svelte
+++ b/src/Toggletip/Toggletip.svelte
@@ -170,10 +170,6 @@
     if (open && isOutsideClick(event, insideElements)) close();
   }
 
-  function handleWindowBlur() {
-    if (open) close();
-  }
-
   // Close when an ancestor modal closes so the portalled content does not linger.
   $: {
     disconnectModalObserver();
@@ -223,10 +219,7 @@ whitespace gap; the label's `margin-right` is then the only spacing. -->
     class:bx--toggletip--open={open}
     use:dismiss={{
       enabled: listenersEnabled,
-      listeners: [
-        { type: "click", handler: handleOutsideClick },
-        { type: "blur", handler: handleWindowBlur },
-      ],
+      listeners: [{ type: "click", handler: handleOutsideClick }],
     }}
     on:keydown={onKeydown}
     on:focusout={onFocusOut}

--- a/tests/Toggletip/Toggletip.test.ts
+++ b/tests/Toggletip/Toggletip.test.ts
@@ -2,6 +2,7 @@ import { render, screen } from "@testing-library/svelte";
 import { tick } from "svelte";
 import { user } from "../utils/user";
 import Toggletip from "./ToggletipDispatchGuard.test.svelte";
+import ToggletipWithInteractiveContent from "./ToggletipWithInteractiveContent.test.svelte";
 
 /**
  * Listeners are enabled on the animation frame after opening; that state
@@ -27,6 +28,21 @@ describe("Toggletip", () => {
     window.dispatchEvent(new Event("blur"));
     await tick();
     await tick();
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("should not close when clicking an interactive element inside the content", async () => {
+    const onClose = vi.fn();
+    render(ToggletipWithInteractiveContent, {
+      props: { open: false, onClose },
+    });
+
+    const trigger = screen.getByRole("button", { name: "Information" });
+    await user.click(trigger);
+    await flush();
+
+    await user.click(screen.getByTestId("inside-button"));
 
     expect(onClose).not.toHaveBeenCalled();
   });

--- a/tests/Toggletip/Toggletip.test.ts
+++ b/tests/Toggletip/Toggletip.test.ts
@@ -46,4 +46,14 @@ describe("Toggletip", () => {
 
     expect(onClose).not.toHaveBeenCalled();
   });
+
+  it("should set aria-describedby on the trigger so content is announced the first time it opens", async () => {
+    render(Toggletip, { props: { open: false } });
+
+    const trigger = screen.getByRole("button", { name: "Information" });
+    expect(trigger).not.toHaveAttribute("aria-describedby");
+
+    await user.click(trigger);
+    expect(trigger).toHaveAttribute("aria-describedby");
+  });
 });

--- a/tests/Toggletip/Toggletip.test.ts
+++ b/tests/Toggletip/Toggletip.test.ts
@@ -1,0 +1,33 @@
+import { render, screen } from "@testing-library/svelte";
+import { tick } from "svelte";
+import { user } from "../utils/user";
+import Toggletip from "./ToggletipDispatchGuard.test.svelte";
+
+/**
+ * Listeners are enabled on the animation frame after opening; that state
+ * change needs a Svelte `tick()` to reach the `dismiss` action's `update()`,
+ * which itself defers the actual window listener registration by a further
+ * macrotask. Flush all three before asserting.
+ */
+const flush = async () => {
+  await new Promise((resolve) => requestAnimationFrame(resolve));
+  await tick();
+  await new Promise((resolve) => setTimeout(resolve));
+};
+
+describe("Toggletip", () => {
+  it("should not close when the browser window loses focus (e.g. switching tabs)", async () => {
+    const onClose = vi.fn();
+    render(Toggletip, { props: { open: false, onClose } });
+
+    const trigger = screen.getByRole("button", { name: "Information" });
+    await user.click(trigger);
+    await flush();
+
+    window.dispatchEvent(new Event("blur"));
+    await tick();
+    await tick();
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/tests/Toggletip/ToggletipWithInteractiveContent.test.svelte
+++ b/tests/Toggletip/ToggletipWithInteractiveContent.test.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+  import Toggletip from "carbon-components-svelte/Toggletip/Toggletip.svelte";
+  import type { ComponentProps } from "svelte";
+
+  export let open: ComponentProps<Toggletip>["open"] = false;
+  export let onClose: () => void = () => {};
+</script>
+
+<Toggletip bind:open iconDescription="Information" on:close={onClose}>
+  <button type="button" data-testid="inside-button">Inside button</button>
+</Toggletip>


### PR DESCRIPTION
Found while auditing Carbon React's commit history for parity fixes
not yet ported here. Bundles a real fix with two regression tests
added during the same investigation, all touching
tests/Toggletip/Toggletip.test.ts:

- stop closing on browser window blur. Listening for window blur
  closed the toggletip on any tab/app switch, not just focus
  actually leaving it. The existing focusout handler already closes
  correctly when focus moves outside, so this drops the redundant,
  overly-broad window blur listener.
- confirms clicking/focusing an interactive child inside the
  content is already treated as inside, without needing React's
  later relatedTarget/mousedown tracking workarounds
- confirms the trigger already gets aria-describedby (and content
  has no aria-live) so screen readers announce content the first
  time it opens, without React's separate two-part fix