### PR TITLE
feat(data-table): add header isSortable override

### DIFF
--- a/src/DataTable/DataTable.svelte
+++ b/src/DataTable/DataTable.svelte
@@ -1036,13 +1036,7 @@
                 on:click={(event) => {
                   dispatch("click", { header });
 
-                  if (!isHeaderSortable(header)) {
-                    dispatch("click:header", {
-                      header,
-                      target: event.target,
-                      currentTarget: event.currentTarget,
-                    });
-                  } else {
+                  if (isHeaderSortable(header)) {
                     const currentSortDirection =
                       sortKey === header.key ? sortDirection : "none";
                     const effectiveSortAlways =
@@ -1076,6 +1070,12 @@
                     dispatch("click:header", {
                       header,
                       sortDirection: nextSortDirection,
+                      target: event.target,
+                      currentTarget: event.currentTarget,
+                    });
+                  } else {
+                    dispatch("click:header", {
+                      header,
                       target: event.target,
                       currentTarget: event.currentTarget,
                     });

--- a/src/DataTable/DataTable.svelte
+++ b/src/DataTable/DataTable.svelte
@@ -21,6 +21,7 @@
    * @property {true} empty - Whether the header is empty
    * @property {(item: DataTableValue, row: Row) => DataTableValue} [display]
    * @property {false | ((a: DataTableSortValue<Row>, b: DataTableSortValue<Row>) => number)} [sort]
+   * @property {boolean} [isSortable] - Override the table-level `sortable` for this column (e.g. opt a column in while the table itself is not sortable). Ignored when `sort` is `false`.
    * @property {boolean} [sortAlways] - Override table-level sortAlways for this column
    * @property {boolean} [columnMenu] - Whether the column menu is enabled
    * @property {boolean} [columnHidden] - Whether the column is skipped in render while remaining in `headers`
@@ -32,6 +33,7 @@
    * @property {DataTableValue} value
    * @property {(item: DataTableValue, row: Row) => DataTableValue} [display]
    * @property {false | ((a: DataTableSortValue<Row>, b: DataTableSortValue<Row>) => number)} [sort]
+   * @property {boolean} [isSortable] - Override the table-level `sortable` for this column (e.g. opt a column in while the table itself is not sortable). Ignored when `sort` is `false`.
    * @property {boolean} [sortAlways] - Override table-level sortAlways for this column
    * @property {boolean} [columnMenu] - Whether the column menu is enabled
    * @property {boolean} [columnHidden] - Whether the column is skipped in render while remaining in `headers`
@@ -623,6 +625,18 @@
     return alignClasses[columnAlign];
   }
 
+  /**
+   * Resolve whether a header is sortable. `header.sort === false` always
+   * disables it; otherwise `header.isSortable` overrides the table-level
+   * `sortable` when set, letting a column opt in even when the table itself
+   * is not sortable (or opt out while the table is).
+   */
+  function isHeaderSortable(header) {
+    if (header.sort === false) return false;
+    if (header.isSortable !== undefined) return header.isSortable;
+    return sortable;
+  }
+
   /** Build cell objects for one row. Always new objects so `display` columns re-run. */
   function computeRowCells(row) {
     const cells = [];
@@ -728,8 +742,10 @@
   }
 
   $: ascending = sortDirection === "ascending";
-  $: sorting = sortable && sortKey != null;
   $: sortingHeader = headers.find((header) => header.key === sortKey);
+  $: sorting =
+    sortKey != null &&
+    (sortingHeader ? isHeaderSortable(sortingHeader) : sortable);
   $: sortedRows =
     sorting && sortDirection !== "none"
       ? [...$tableRows].sort((a, b) => {
@@ -1011,7 +1027,7 @@
                 id="{id}-{header.key}"
                 class={formatAlignClass(header.columnAlign)}
                 style={formatHeaderWidth(header)}
-                sortable={sortable && header.sort !== false}
+                sortable={isHeaderSortable(header)}
                 sortDirection={sortKey === header.key ? sortDirection : "none"}
                 active={sortKey === header.key}
                 {...(tableHeaderTranslateWithId
@@ -1020,7 +1036,7 @@
                 on:click={(event) => {
                   dispatch("click", { header });
 
-                  if (header.sort === false) {
+                  if (!isHeaderSortable(header)) {
                     dispatch("click:header", {
                       header,
                       target: event.target,

--- a/tests/DataTable/DataTable.test.ts
+++ b/tests/DataTable/DataTable.test.ts
@@ -520,6 +520,42 @@ describe("DataTable", () => {
     ).toHaveTextContent("Load Balancer 3");
   });
 
+  it("allows a header to opt into sorting when the table itself is not sortable", async () => {
+    const customHeaders = [
+      { key: "name", value: "Name", isSortable: true },
+      { key: "protocol", value: "Protocol" },
+    ];
+
+    render(DataTable, {
+      props: {
+        sortable: false,
+        headers: customHeaders,
+        rows,
+      },
+    });
+
+    // Protocol has no per-header override, so it stays non-interactive.
+    expect(screen.getByText("Protocol").closest("th")).not.toHaveAttribute(
+      "aria-sort",
+    );
+
+    // Name opted in via isSortable, so it renders as a sortable header and
+    // can be clicked even though the table-level `sortable` is false.
+    const nameHeader = screen.getByText("Name");
+    expect(nameHeader.closest("th")).toHaveAttribute("aria-sort", "none");
+
+    await user.click(nameHeader);
+
+    expect(nameHeader.closest("th")).toHaveAttribute("aria-sort", "ascending");
+
+    const tableRows = screen
+      .getAllByRole("row")
+      .filter((row) => row.closest("tbody") !== null);
+    expect(
+      within(tableRows[0]).getByRole("cell", { name: "Load Balancer 1" }),
+    ).toBeInTheDocument();
+  });
+
   it("handles table with numeric sorting", async () => {
     const numericRows = [
       { id: "a", value: 10 },


### PR DESCRIPTION
Found while auditing Carbon React's commit history for parity fixes
not yet ported here.

header.sort !== false could only disable sorting per column; there
was no way to opt a single column into sorting on an otherwise
non-sortable table. header.isSortable now overrides the table-level
sortable in either direction. Includes a small follow-up commit
inverting a negated branch the feature introduced, per lint.