### PR TITLE
fix(data-table-skeleton): add missing medium size class

### DIFF
--- a/src/DataTable/DataTableSkeleton.svelte
+++ b/src/DataTable/DataTableSkeleton.svelte
@@ -10,7 +10,7 @@
 
   /**
    * Set the size of the data table.
-   * @type {"compact" | "short" | "tall"}
+   * @type {"compact" | "short" | "medium" | "tall"}
    */
   export let size = undefined;
 
@@ -69,6 +69,7 @@
     class:bx--data-table={true}
     class:bx--data-table--compact={size === "compact"}
     class:bx--data-table--short={size === "short"}
+    class:bx--data-table--md={size === "medium"}
     class:bx--data-table--tall={size === "tall"}
     class:bx--data-table--zebra={zebra}
     on:click

--- a/tests/DataTable/DataTableSkeleton.test.ts
+++ b/tests/DataTable/DataTableSkeleton.test.ts
@@ -1,0 +1,28 @@
+import { render, screen } from "@testing-library/svelte";
+import DataTableSkeleton from "../../src/DataTable/DataTableSkeleton.svelte";
+
+describe("DataTableSkeleton", () => {
+  it("applies the medium size class", () => {
+    render(DataTableSkeleton, { props: { size: "medium" } });
+
+    expect(screen.getByRole("table")).toHaveClass("bx--data-table--md");
+  });
+
+  it("applies the compact size class", () => {
+    render(DataTableSkeleton, { props: { size: "compact" } });
+
+    expect(screen.getByRole("table")).toHaveClass("bx--data-table--compact");
+  });
+
+  it("applies the short size class", () => {
+    render(DataTableSkeleton, { props: { size: "short" } });
+
+    expect(screen.getByRole("table")).toHaveClass("bx--data-table--short");
+  });
+
+  it("applies the tall size class", () => {
+    render(DataTableSkeleton, { props: { size: "tall" } });
+
+    expect(screen.getByRole("table")).toHaveClass("bx--data-table--tall");
+  });
+});


### PR DESCRIPTION
Found while auditing Carbon React's commit history for parity fixes
not yet ported here.

size="medium" (the DataTable/Table default) rendered no size class
at all on the skeleton, unlike compact/short/tall. Also adds the
first real DataTableSkeleton.test.ts (previously only a type-check
fixture, no runtime assertions).