### PR TITLE
fix(checkbox): propagate CheckboxGroup invalid/warn to child checkboxes

### DIFF
--- a/docs/src/pages/components/Checkbox.svx
+++ b/docs/src/pages/components/Checkbox.svx
@@ -168,7 +168,7 @@ Set `readonly` to `true` on CheckboxGroup to display non-editable values. Unlike
 
 ### Invalid
 
-Set `invalid` to `true` and provide `invalidText` to show a validation error for the group. The group's state takes precedence over any invalid/warn state set on an individual checkbox.
+Set `invalid` to `true` and provide `invalidText` to show a validation error for the group. The group's invalid state propagates to every checkbox in the group, so each one is styled as invalid and marked with `aria-invalid` without setting the prop individually.
 
 <CheckboxGroup invalid invalidText="Select at least one notification preference" legendText="Notification preferences" name="prefs-invalid">
 <Checkbox value="email" labelText="Email" />
@@ -178,10 +178,22 @@ Set `invalid` to `true` and provide `invalidText` to show a validation error for
 
 ### Warning
 
-Set `warn` to `true` and provide `warnText` to show a warning message for the group.
+Set `warn` to `true` and provide `warnText` to show a warning message for the group. Like `invalid`, the group's warning state propagates to every checkbox in the group.
 
 <CheckboxGroup warn warnText="Push notifications may be delayed" legendText="Notification preferences" name="prefs-warn" selected={["email"]}>
 <Checkbox value="email" labelText="Email" />
 <Checkbox value="sms" labelText="SMS" />
 <Checkbox value="push" labelText="Push notifications" />
+</CheckboxGroup>
+
+### Validation within a group
+
+Set validation on the group rather than on individual checkboxes. Carbon hides a checkbox's own `invalidText` and `warnText` inside a group and resets its invalid styling unless the group itself is invalid, so the group owns the validation message for all of its checkboxes.
+
+Disabled and read-only checkboxes are exempt from the group's validation styling.
+
+<CheckboxGroup invalid invalidText="Select at least one notification preference" legendText="Notification preferences" name="prefs-invalid-suppressed" selected={["push"]}>
+<Checkbox value="email" labelText="Email (disabled)" disabled />
+<Checkbox value="sms" labelText="SMS" />
+<Checkbox value="push" labelText="Push notifications (read-only)" readonly />
 </CheckboxGroup>

--- a/src/Checkbox/Checkbox.svelte
+++ b/src/Checkbox/Checkbox.svelte
@@ -115,12 +115,16 @@
     groupName,
     groupRequired,
     readonly: groupReadonly,
+    invalid: groupInvalid,
+    warn: groupWarn,
     update: ctxUpdate,
   } = ctx ?? {
     selectedValues: readable([]),
     groupName: readable(undefined),
     groupRequired: readable(undefined),
     readonly: readable(false),
+    invalid: readable(false),
+    warn: readable(false),
   };
 
   $: useGroup = !ctx && Array.isArray(group);
@@ -130,8 +134,11 @@
   $: effectiveName = ctx ? ($groupName ?? name) : name;
   $: effectiveRequired = ctx ? ($groupRequired ?? required) : required;
   $: effectiveReadonly = $groupReadonly || readonly;
-  $: showInvalid = invalid && !disabled && !effectiveReadonly;
-  $: showWarn = warn && !invalid && !disabled && !effectiveReadonly;
+  $: effectiveInvalid = $groupInvalid || invalid;
+  $: effectiveWarn = $groupWarn || warn;
+  $: showInvalid = effectiveInvalid && !disabled && !effectiveReadonly;
+  $: showWarn =
+    effectiveWarn && !effectiveInvalid && !disabled && !effectiveReadonly;
 
   // Track previous checked value to avoid duplicate dispatches in Svelte 5
   // The reactive statement will only dispatch when checked changes externally (e.g., via bind:checked)

--- a/src/Checkbox/CheckboxGroup.svelte
+++ b/src/Checkbox/CheckboxGroup.svelte
@@ -80,6 +80,8 @@
   const groupName = writable(name);
   const groupRequired = writable(required);
   const groupReadonly = writable(readonly);
+  const groupInvalid = writable(invalid);
+  const groupWarn = writable(warn);
   let isInitialRender = true;
 
   /**
@@ -100,6 +102,8 @@
     groupName: readOnly(groupName),
     groupRequired: readOnly(groupRequired),
     readonly: readOnly(groupReadonly),
+    invalid: readOnly(groupInvalid),
+    warn: readOnly(groupWarn),
     update,
   });
 
@@ -123,6 +127,8 @@
   $: $groupName = name;
   $: $groupRequired = required;
   $: $groupReadonly = readonly;
+  $: $groupInvalid = invalid;
+  $: $groupWarn = warn;
   $: showInvalid = invalid && !disabled && !readonly;
   $: showWarn = warn && !invalid && !disabled && !readonly;
 

--- a/tests/Checkbox/CheckboxGroupComponent.test.ts
+++ b/tests/Checkbox/CheckboxGroupComponent.test.ts
@@ -296,6 +296,29 @@ describe("CheckboxGroup", () => {
     );
   });
 
+  it("propagates group invalid state to child checkboxes that don't set their own", () => {
+    render(CheckboxGroupComponent, {
+      props: { invalid: true, invalidText: "Select at least one option" },
+    });
+
+    const option1 = screen.getByRole("checkbox", { name: "Option 1" });
+    expect(option1.closest(".bx--checkbox-wrapper")).toHaveClass(
+      "bx--checkbox-wrapper--invalid",
+    );
+    expect(option1).toHaveAttribute("aria-invalid", "true");
+  });
+
+  it("propagates group warn state to child checkboxes that don't set their own", () => {
+    render(CheckboxGroupComponent, {
+      props: { warn: true, warnText: "Heads up" },
+    });
+
+    const option1 = screen.getByRole("checkbox", { name: "Option 1" });
+    expect(option1.closest(".bx--checkbox-wrapper")).toHaveClass(
+      "bx--checkbox-wrapper--warning",
+    );
+  });
+
   it("should support multiple selections", async () => {
     const consoleLog = vi.spyOn(console, "log");
     render(CheckboxGroupComponent);


### PR DESCRIPTION
Found while auditing Carbon React's commit history for parity fixes
not yet ported here.

readonly already flowed through context; invalid/warn didn't, so a
CheckboxGroup marked invalid or warn left its children showing no
per-checkbox validation styling unless each one set the prop
itself.