### PR TITLE
fix(search): use native type=search input

### DIFF
--- a/css/_search.scss
+++ b/css/_search.scss
@@ -39,3 +39,23 @@
 @include exports("search-xs") {
   @include search-xs;
 }
+
+/// Suppress native browser chrome for the `type="search"` input
+/// (magnifier/clear icons, results dropdown) in favor of Carbon's own.
+/// @access private
+/// @group components
+@mixin search-native-decoration {
+  .#{$prefix}--search-input {
+    &::-webkit-search-decoration,
+    &::-webkit-search-cancel-button,
+    &::-webkit-search-results-button,
+    &::-webkit-search-results-decoration {
+      display: none;
+      appearance: none;
+    }
+  }
+}
+
+@include exports("search-native-decoration") {
+  @include search-native-decoration;
+}

--- a/src/Search/Search.svelte
+++ b/src/Search/Search.svelte
@@ -156,8 +156,7 @@
     <input
       bind:this={ref}
       bind:value
-      type="text"
-      role="searchbox"
+      type="search"
       class:bx--search-input={true}
       autofocus={autofocus === true ? true : undefined}
       {autocomplete}

--- a/src/SearchMenu/SearchMenu.svelte
+++ b/src/SearchMenu/SearchMenu.svelte
@@ -289,7 +289,9 @@
       }
       case "Escape":
         if (open) {
-          // Close the menu without letting Search clear the value.
+          // Close the menu without letting Search (or the native
+          // type="search" clear-on-Escape affordance) clear the value.
+          event.preventDefault();
           event.stopImmediatePropagation();
           close("escape-key");
           dismissed = true;

--- a/tests/Search/Search.test.ts
+++ b/tests/Search/Search.test.ts
@@ -53,6 +53,12 @@ describe("Search", () => {
     expect(consoleLog).toHaveBeenCalledTimes(1);
   });
 
+  it("uses a native type=search input", () => {
+    render(Search);
+
+    expect(getSearchInput("Default search")).toHaveAttribute("type", "search");
+  });
+
   it("gives the search landmark a unique accessible name per instance", () => {
     render(Search);
 


### PR DESCRIPTION
Found while auditing Carbon React's commit history for parity fixes
not yet ported here.

Enables browser search-input semantics (Escape-to-clear affordance,
form autofill heuristics). Suppresses webkit's own decoration/cancel
button in favor of Carbon's, and drops the now-redundant
role="searchbox" since type="search" already implies it.