### PR TITLE
fix(link): use span for icon wrapper, block disabled clicks

### DIFF
--- a/docs/src/pages/components/Link.svx
+++ b/docs/src/pages/components/Link.svx
@@ -151,6 +151,14 @@ Disabled links render as plain text while remaining accessible.
   Disabled link
 </Link>
 
+### Disabled with icon
+
+The icon still renders when the link is disabled.
+
+<Link disabled href="https://www.carbondesignsystem.com/" icon={Carbon}>
+  Disabled link
+</Link>
+
 ### Visited
 
 Show visited state styling with `visited`.

--- a/src/Link/Link.svelte
+++ b/src/Link/Link.svelte
@@ -60,7 +60,10 @@
     class:bx--link--visited={visited}
     class:bx--link--muted={muted}
     {...$$restProps}
-    on:click
+    on:click={(event) => {
+      event.preventDefault();
+      event.stopPropagation();
+    }}
     on:mouseover
     on:mouseenter
     on:mouseleave
@@ -71,9 +74,9 @@
   >
     <slot />
     {#if !inline && ($$slots.icon || icon)}
-      <div class:bx--link__icon={true}>
+      <span class:bx--link__icon={true}>
         <slot name="icon"> <svelte:component this={icon} /> </slot>
-      </div>
+      </span>
     {/if}
   </a>
 {:else}
@@ -100,9 +103,9 @@
   >
     <slot />
     {#if !inline && ($$slots.icon || icon)}
-      <div class:bx--link__icon={true}>
+      <span class:bx--link__icon={true}>
         <slot name="icon"> <svelte:component this={icon} /> </slot>
-      </div>
+      </span>
     {/if}
   </a>
 {/if}

--- a/tests/Link/Link.test.svelte
+++ b/tests/Link/Link.test.svelte
@@ -86,7 +86,11 @@
 
 <!-- Disabled link -->
 <div data-testid="link-disabled">
-  <Link disabled href="https://www.carbondesignsystem.com/">
+  <Link
+    disabled
+    href="https://www.carbondesignsystem.com/"
+    on:click={() => console.log("disabled-click")}
+  >
     Carbon Design System
   </Link>
 </div>

--- a/tests/Link/Link.test.ts
+++ b/tests/Link/Link.test.ts
@@ -57,6 +57,7 @@ describe("Link", () => {
     const iconWrapper = link.querySelector(".bx--link__icon");
     assert(iconWrapper);
     expect(iconWrapper.querySelector("svg")).toBeInTheDocument();
+    expect(iconWrapper.tagName).toBe("SPAN");
   });
 
   it("supports icon slot", () => {
@@ -122,6 +123,18 @@ describe("Link", () => {
     expect(link).toHaveClass("bx--link--disabled");
     expect(link).toHaveAttribute("aria-disabled", "true");
     expect(link).toHaveAttribute("role", "link");
+  });
+
+  it("does not call onClick when disabled", async () => {
+    const consoleLog = vi.spyOn(console, "log");
+    render(Link);
+    const links = screen.getAllByRole("link", { name: "Carbon Design System" });
+    const link = links.find((l) => l.getAttribute("aria-disabled") === "true");
+    assert(link);
+
+    await user.click(link);
+
+    expect(consoleLog).not.toHaveBeenCalledWith("disabled-click");
   });
 
   it("supports muted variant", () => {


### PR DESCRIPTION
Found while auditing Carbon React's commit history for parity fixes
not yet ported here.

Icon wrapper was a div, invalid inside an inline a in some
browsers' accessibility trees. Disabled links only omitted href but
still forwarded click events to consumers and let them bubble to
ancestor listeners.