### PR TITLE
fix(link): make the visited prop force visited styling

### DIFF
--- a/css/_link.scss
+++ b/css/_link.scss
@@ -55,3 +55,24 @@
 @include exports("link-muted") {
   @include link-muted;
 }
+
+/// The `visited` prop lets a consumer force the visited color regardless of
+/// the browser's actual `:visited` state (e.g. to preview it, or because the
+/// consumer tracks visited state themselves). v10 only styles the real
+/// `:visited` pseudo-class, so the prop alone had no visual effect on an
+/// unvisited link.
+/// @access private
+/// @group components
+@mixin link-visited {
+  .#{$prefix}--link.#{$prefix}--link--visited {
+    color: $visited-link;
+  }
+
+  .#{$prefix}--link.#{$prefix}--link--visited:hover {
+    color: $hover-primary-text;
+  }
+}
+
+@include exports("link-visited") {
+  @include link-visited;
+}


### PR DESCRIPTION
Found while auditing Carbon React's commit history for parity fixes
not yet ported here.

v10 only styled the real browser :visited pseudo-class, so the
visited prop had no visual effect until the browser actually
considered the href visited. Adds plain-class rules alongside the
existing :visited-scoped ones (same token values, confirmed
identical after compiling) so the prop works standalone.