### PR TITLE
fix(code-snippet): respect disabled on the inline variant

### DIFF
--- a/css/_code-snippet.scss
+++ b/css/_code-snippet.scss
@@ -1,0 +1,30 @@
+@import "carbon-components/scss/globals/scss/vars";
+@import "carbon-components/scss/globals/scss/helper-mixins";
+@import "carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/import-once/import-once";
+
+/// Disabled treatment for the inline code snippet variant. Carbon's vendored
+/// v10.58 CSS only styles `.bx--snippet--disabled` on the single/multi
+/// container; the inline variant renders as a bare button with no disabled
+/// styling at all, so a disabled inline snippet kept its pointer cursor and
+/// hover/active backgrounds even though clicks are natively suppressed.
+/// @access private
+/// @group components
+@mixin code-snippet-inline-disabled {
+  .#{$prefix}--snippet--inline:disabled {
+    background-color: $disabled-01;
+    color: $disabled-02;
+    cursor: not-allowed;
+
+    &:hover,
+    &:active,
+    &:focus {
+      background-color: $disabled-01;
+      border-color: transparent;
+      cursor: not-allowed;
+    }
+  }
+}
+
+@include exports("code-snippet-inline-disabled") {
+  @include code-snippet-inline-disabled;
+}

--- a/css/all.scss
+++ b/css/all.scss
@@ -100,6 +100,7 @@ $css--plex: true;
 @import "./datepicker";
 @import "./fluid-date-picker";
 @import "./copy-input";
+@import "./code-snippet";
 @import "./overflow-menu";
 @import "./combo-button";
 @import "./fluid-list-box";

--- a/css/g10.scss
+++ b/css/g10.scss
@@ -60,6 +60,7 @@ $css--plex: true;
 @import "./datepicker";
 @import "./fluid-date-picker";
 @import "./copy-input";
+@import "./code-snippet";
 @import "./overflow-menu";
 @import "./combo-button";
 @import "./fluid-list-box";

--- a/css/g100.scss
+++ b/css/g100.scss
@@ -60,6 +60,7 @@ $css--plex: true;
 @import "./datepicker";
 @import "./fluid-date-picker";
 @import "./copy-input";
+@import "./code-snippet";
 @import "./overflow-menu";
 @import "./combo-button";
 @import "./fluid-list-box";

--- a/css/g80.scss
+++ b/css/g80.scss
@@ -60,6 +60,7 @@ $css--plex: true;
 @import "./datepicker";
 @import "./fluid-date-picker";
 @import "./copy-input";
+@import "./code-snippet";
 @import "./overflow-menu";
 @import "./combo-button";
 @import "./fluid-list-box";

--- a/css/g90.scss
+++ b/css/g90.scss
@@ -60,6 +60,7 @@ $css--plex: true;
 @import "./datepicker";
 @import "./fluid-date-picker";
 @import "./copy-input";
+@import "./code-snippet";
 @import "./overflow-menu";
 @import "./combo-button";
 @import "./fluid-list-box";

--- a/css/white.scss
+++ b/css/white.scss
@@ -60,6 +60,7 @@ $css--plex: true;
 @import "./datepicker";
 @import "./fluid-date-picker";
 @import "./copy-input";
+@import "./code-snippet";
 @import "./overflow-menu";
 @import "./combo-button";
 @import "./fluid-list-box";

--- a/docs/src/pages/components/CodeSnippet.svx
+++ b/docs/src/pages/components/CodeSnippet.svx
@@ -127,9 +127,19 @@ Set `showMoreText` and `showLessText` to customize the expand/collapse button te
 
 ## Disabled
 
-Set `disabled` to `true` to disable interaction. This only applies to `"single"` and `"multi"` types.
+Set `disabled` to `true` to disable interaction.
+
+### Single line
+
+<CodeSnippet disabled code="npm i carbon-components-svelte" />
+
+### Multi-line
 
 <FileSource src="/framed/CodeSnippet/CodeSnippetDisabledMulti" />
+
+### Inline
+
+<CodeSnippet disabled type="inline" code="rm -rf node_modules/" />
 
 ## Wrapped text
 

--- a/docs/src/pages/framed/CodeSnippet/CodeSnippetDisabledMulti.svelte
+++ b/docs/src/pages/framed/CodeSnippet/CodeSnippetDisabledMulti.svelte
@@ -1,11 +1,8 @@
 <script>
-  import { CodeSnippet, Stack } from "carbon-components-svelte";
+  import { CodeSnippet } from "carbon-components-svelte";
 
   let comment =
     "> carbon-components-svelte is a Svelte component library that implements the [Carbon Design System](https://github.com/carbon-design-system), an open source design system by IBM.\n\n> A design system can facilitate frontend development and prototyping because it is encourages reuse, consistency, and extensibility.\n";
 </script>
 
-<Stack gap={2}>
-  <CodeSnippet disabled code="npm i carbon-components-svelte" />
-  <CodeSnippet disabled type="multi" code={comment} />
-</Stack>
+<CodeSnippet disabled type="multi" code={comment} />

--- a/src/CodeSnippet/CodeSnippet.svelte
+++ b/src/CodeSnippet/CodeSnippet.svelte
@@ -53,10 +53,7 @@
   /** Set to `true` to hide the copy button */
   export let hideCopyButton = false;
 
-  /**
-   * Set to `true` for the disabled variant.
-   * Only applies to the "single", "multi" types.
-   */
+  /** Set to `true` for the disabled variant. */
   export let disabled = false;
 
   /**
@@ -397,6 +394,7 @@
     <button
       bind:this={copyRef}
       type="button"
+      {disabled}
       aria-live="polite"
       aria-busy={copyPending || undefined}
       class:bx--copy={true}

--- a/tests/CodeSnippet/CodeSnippet.test.ts
+++ b/tests/CodeSnippet/CodeSnippet.test.ts
@@ -702,6 +702,14 @@ yarn -v`,
     expect(snippet).not.toHaveAttribute("tabindex");
   });
 
+  test("respects disabled on the inline variant's copy button", () => {
+    const { container } = render(CodeSnippetDisabled, {
+      props: { type: "inline" },
+    });
+    const button = container.querySelector("button");
+    expect(button).toBeDisabled();
+  });
+
   test.each([
     { type: "inline" as const, expectedClass: "bx--snippet--inline" },
     { type: "single" as const, expectedClass: "bx--copy-btn" },


### PR DESCRIPTION
Found while auditing Carbon React's commit history for parity fixes
not yet ported here.

The disabled prop was declared but only ever forwarded to the
single/multi CopyButton; the inline variant's own button never read
it, leaving it clickable.