### PR TITLE
feat(grid): add bindable ref to Column

### DIFF
--- a/src/Grid/Column.svelte
+++ b/src/Grid/Column.svelte
@@ -73,6 +73,13 @@
    */
   export let max = undefined;
 
+  /**
+   * Obtain a reference to the top-level HTML element.
+   * `null` when `as` is `true`, since the element is then rendered by the consumer.
+   * @bindable readonly
+   */
+  export let ref = null;
+
   const breakpoints = ["sm", "md", "lg", "xlg", "max"];
 
   $: columnClass = [sm, md, lg, xlg, max]
@@ -123,5 +130,5 @@
 {#if as}
   <slot {props} />
 {:else}
-  <div {...props}><slot /></div>
+  <div bind:this={ref} {...props}><slot /></div>
 {/if}

--- a/tests/Column/Column.test.svelte
+++ b/tests/Column/Column.test.svelte
@@ -1,3 +1,5 @@
+<svelte:options accessors />
+
 <script lang="ts">
   import Column from "carbon-components-svelte/Grid/Column.svelte";
   import type { ComponentProps } from "svelte";
@@ -13,6 +15,7 @@
   export let lg: ComponentProps<Column>["lg"] = undefined;
   export let xlg: ComponentProps<Column>["xlg"] = undefined;
   export let max: ComponentProps<Column>["max"] = undefined;
+  export let ref: ComponentProps<Column>["ref"] = null;
 </script>
 
 <Column
@@ -27,6 +30,7 @@
   {lg}
   {xlg}
   {max}
+  bind:ref
 >
   <div data-testid="content">Column Content</div>
 </Column>

--- a/tests/Column/Column.test.ts
+++ b/tests/Column/Column.test.ts
@@ -9,6 +9,13 @@ describe("Column", () => {
     expect(column).toHaveClass("bx--col");
   });
 
+  it("should expose ref to the rendered element", () => {
+    const { component } = render(Column);
+
+    expect(component.ref).toBeInstanceOf(HTMLDivElement);
+    expect(component.ref).toHaveClass("bx--col");
+  });
+
   it("should render with custom element when as is true", () => {
     render(Column, { props: { as: true } });
     const column = screen.getByTestId("content").parentElement;


### PR DESCRIPTION
Found while auditing Carbon React's commit history for parity fixes
not yet ported here.

Every other component in this codebase exposes a bindable ref to
its top-level element; Column was a gap.