### PR TITLE
Pagination: 3 Carbon React parity prop additions

### DIFF
--- a/src/Pagination/Pagination.svelte
+++ b/src/Pagination/Pagination.svelte
@@ -21,6 +21,12 @@
    */
 
   /**
+   * Override the page-selection control.
+   * Falls back to the default page number `Select` when unset.
+   * @slot {{ currentPage: number; totalPages: number; currentPageSize: number; selectLabelText: string; onSetPage: (page: number | string) => void; }} pageSelect
+   */
+
+  /**
    * Specify the current page index.
    * @bindable writable
    */
@@ -204,6 +210,20 @@
     return filtered.length ? filtered : sizes.slice(0, 1);
   }
 
+  /**
+   * Sets the active page from the `pageSelect` slot.
+   * @param {number | string} nextPage
+   */
+  function setPageFromSlot(nextPage) {
+    if (disabled || pageInputDisabled) return;
+    const numericPage = Number(nextPage);
+    if (!Number.isInteger(numericPage)) return;
+    const clamped = Math.min(Math.max(numericPage, 1), totalPages);
+    if (clamped === page) return;
+    page = clamped;
+    dispatch("change", { page: clamped });
+  }
+
   $: effectivePageSizes = dynamicPageSizes
     ? getFilteredPageSizes(pageSizes, totalItems)
     : pageSizes;
@@ -297,29 +317,38 @@
         {/if}
       </span>
     {:else if !pageInputDisabled}
-      <!-- Native <option>s instead of SelectItem: a SelectItem
-           registers a store subscriber per page (pageWindow, default
-           1000). Coerce on:update to Number — without SelectItem,
-           Select keeps option values as strings. -->
-      <Select
-        id="bx--pagination-select-{id}-pages"
-        class="bx--select__page-number"
-        labelText={pageSelectLabelText(totalPages)}
-        inline
-        hideLabel
-        selected={page}
-        on:update={(event) => {
-          const next = Number(event.detail);
-          page = next;
-          dispatch("change", { page: next });
-        }}
+      <slot
+        name="pageSelect"
+        currentPage={page}
+        {totalPages}
+        currentPageSize={pageSize}
+        selectLabelText={pageSelectLabelText(totalPages)}
+        onSetPage={setPageFromSlot}
       >
-        {#each selectItems as pageNumber (pageNumber)}
-          <option class="bx--select-option" value={pageNumber}>
-            {pageNumber}
-          </option>
-        {/each}
-      </Select>
+        <!-- Native <option>s instead of SelectItem: a SelectItem
+             registers a store subscriber per page (pageWindow, default
+             1000). Coerce on:update to Number — without SelectItem,
+             Select keeps option values as strings. -->
+        <Select
+          id="bx--pagination-select-{id}-pages"
+          class="bx--select__page-number"
+          labelText={pageSelectLabelText(totalPages)}
+          inline
+          hideLabel
+          selected={page}
+          on:update={(event) => {
+            const next = Number(event.detail);
+            page = next;
+            dispatch("change", { page: next });
+          }}
+        >
+          {#each selectItems as pageNumber (pageNumber)}
+            <option class="bx--select-option" value={pageNumber}>
+              {pageNumber}
+            </option>
+          {/each}
+        </Select>
+      </slot>
       <span class:bx--pagination__text={true}>
         {#if pagesUnknown}
           {pageText(page)}

--- a/src/Pagination/Pagination.svelte
+++ b/src/Pagination/Pagination.svelte
@@ -130,6 +130,12 @@
   export let pageRangeText = (_current, total) =>
     `of ${total.toLocaleString()} page${total === 1 ? "" : "s"}`;
 
+  /**
+   * Override the accessible label for the page number select.
+   * @type {(total: number) => string}
+   */
+  export let pageSelectLabelText = (total) => `Page number, of ${total} pages`;
+
   /** Set an id for the top-level element */
   export let id = uniqueId();
 
@@ -286,7 +292,7 @@
       <Select
         id="bx--pagination-select-{id}-pages"
         class="bx--select__page-number"
-        labelText="Page number, of {totalPages} pages"
+        labelText={pageSelectLabelText(totalPages)}
         inline
         hideLabel
         selected={page}

--- a/src/Pagination/Pagination.svelte
+++ b/src/Pagination/Pagination.svelte
@@ -45,8 +45,20 @@
   /** Specify the forward button text */
   export let forwardText = "Next page";
 
+  /**
+   * Specify the tooltip position for the forward button.
+   * @type {"top" | "right" | "bottom" | "left"}
+   */
+  export let forwardTextTooltipPosition = "top";
+
   /** Specify the backward button text */
   export let backwardText = "Previous page";
+
+  /**
+   * Specify the tooltip position for the backward button.
+   * @type {"top" | "right" | "bottom" | "left"}
+   */
+  export let backwardTextTooltipPosition = "top";
 
   /** Specify the items per page text */
   export let itemsPerPageText = "Items per page:";
@@ -319,7 +331,7 @@
     <Button
       kind="ghost"
       tooltipAlignment="center"
-      tooltipPosition="top"
+      tooltipPosition={backwardTextTooltipPosition}
       portalTooltip
       icon={CaretLeft}
       iconDescription={backwardText}
@@ -336,7 +348,7 @@
     <Button
       kind="ghost"
       tooltipAlignment="end"
-      tooltipPosition="top"
+      tooltipPosition={forwardTextTooltipPosition}
       portalTooltip
       icon={CaretRight}
       iconDescription={forwardText}

--- a/tests/Pagination/Pagination.test.svelte
+++ b/tests/Pagination/Pagination.test.svelte
@@ -19,6 +19,8 @@
   export let pageText: ComponentProps<Pagination>["pageText"] = undefined;
   export let pageRangeText: ComponentProps<Pagination>["pageRangeText"] =
     undefined;
+  export let pageSelectLabelText: ComponentProps<Pagination>["pageSelectLabelText"] =
+    undefined;
   export let itemRangeText: ComponentProps<Pagination>["itemRangeText"] =
     undefined;
   export let id: ComponentProps<Pagination>["id"] = undefined;
@@ -47,6 +49,7 @@
   {pagesUnknown}
   {pageText}
   {pageRangeText}
+  {pageSelectLabelText}
   {itemRangeText}
   {id}
   {size}

--- a/tests/Pagination/Pagination.test.svelte
+++ b/tests/Pagination/Pagination.test.svelte
@@ -7,6 +7,10 @@
   export let disabled = false;
   export let forwardText = "Next page";
   export let backwardText = "Previous page";
+  export let backwardTextTooltipPosition: ComponentProps<Pagination>["backwardTextTooltipPosition"] =
+    undefined;
+  export let forwardTextTooltipPosition: ComponentProps<Pagination>["forwardTextTooltipPosition"] =
+    undefined;
   export let itemsPerPageText = "Items per page:";
   export let pageInputDisabled = false;
   export let pageSizeInputDisabled = false;
@@ -38,6 +42,8 @@
   {disabled}
   {forwardText}
   {backwardText}
+  {backwardTextTooltipPosition}
+  {forwardTextTooltipPosition}
   {itemsPerPageText}
   {pageInputDisabled}
   {pageSizeInputDisabled}

--- a/tests/Pagination/Pagination.test.ts
+++ b/tests/Pagination/Pagination.test.ts
@@ -1,4 +1,4 @@
-import { render, screen, within } from "@testing-library/svelte";
+import { fireEvent, render, screen, within } from "@testing-library/svelte";
 import type { ComponentProps } from "svelte";
 import { user } from "../utils/user";
 import Pagination from "./Pagination.test.svelte";
@@ -447,6 +447,67 @@ describe("Pagination", () => {
     render(Pagination, { props });
 
     expect(screen.getByText(/1–10 of 100000/)).toBeInTheDocument();
+  });
+
+  describe("nav button tooltip position", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("defaults nav button tooltips to the top position", async () => {
+      render(Pagination, { props: { totalItems: 102, page: 2 } });
+
+      const prevButton = screen.getByRole("button", { name: "Previous page" });
+      await fireEvent.mouseEnter(prevButton);
+      await vi.advanceTimersByTimeAsync(100);
+      expect(document.querySelector("[data-direction]")).toHaveAttribute(
+        "data-direction",
+        "top",
+      );
+      await fireEvent.mouseLeave(prevButton);
+      await vi.advanceTimersByTimeAsync(300);
+
+      const nextButton = screen.getByRole("button", { name: "Next page" });
+      await fireEvent.mouseEnter(nextButton);
+      await vi.advanceTimersByTimeAsync(100);
+      expect(document.querySelector("[data-direction]")).toHaveAttribute(
+        "data-direction",
+        "top",
+      );
+    });
+
+    it("allows overriding the backward and forward tooltip positions independently", async () => {
+      render(Pagination, {
+        props: {
+          totalItems: 102,
+          page: 2,
+          backwardTextTooltipPosition: "bottom",
+          forwardTextTooltipPosition: "right",
+        },
+      });
+
+      const prevButton = screen.getByRole("button", { name: "Previous page" });
+      await fireEvent.mouseEnter(prevButton);
+      await vi.advanceTimersByTimeAsync(100);
+      expect(document.querySelector("[data-direction]")).toHaveAttribute(
+        "data-direction",
+        "bottom",
+      );
+      await fireEvent.mouseLeave(prevButton);
+      await vi.advanceTimersByTimeAsync(300);
+
+      const nextButton = screen.getByRole("button", { name: "Next page" });
+      await fireEvent.mouseEnter(nextButton);
+      await vi.advanceTimersByTimeAsync(100);
+      expect(document.querySelector("[data-direction]")).toHaveAttribute(
+        "data-direction",
+        "right",
+      );
+    });
   });
 
   it("should dispatch change event with new value, not previous value", async () => {

--- a/tests/Pagination/Pagination.test.ts
+++ b/tests/Pagination/Pagination.test.ts
@@ -422,6 +422,21 @@ describe("Pagination", () => {
     expect(screen.getByText(/1 of 10000/)).toBeInTheDocument();
   });
 
+  it("handles custom page select label text", () => {
+    const props = {
+      totalItems: 40,
+      pageSizes: [10, 20],
+      pageSize: 10,
+      page: 2,
+      pageSelectLabelText: (total: number) =>
+        `Página de ${total} ${total === 1 ? "página" : "páginas"}`,
+    } satisfies ComponentProps<Pagination>;
+
+    render(Pagination, { props });
+
+    expect(screen.getByLabelText("Página de 4 páginas")).toBeInTheDocument();
+  });
+
   it("handles custom item range text", () => {
     const props = {
       totalItems: 100_000,

--- a/tests/Pagination/Pagination.test.ts
+++ b/tests/Pagination/Pagination.test.ts
@@ -2,6 +2,7 @@ import { fireEvent, render, screen, within } from "@testing-library/svelte";
 import type { ComponentProps } from "svelte";
 import { user } from "../utils/user";
 import Pagination from "./Pagination.test.svelte";
+import PaginationPageSelectSlot from "./PaginationPageSelectSlot.test.svelte";
 
 describe("Pagination", () => {
   beforeEach(() => {
@@ -706,5 +707,71 @@ describe("Pagination", () => {
         call[0] === "update" && call[1].pageSize === 15 && call[1].page === 3,
     );
     expect(updateCalls.length).toBe(1);
+  });
+
+  describe("pageSelect slot", () => {
+    it("replaces the default page select and exposes slot props", () => {
+      render(PaginationPageSelectSlot, {
+        props: { totalItems: 40, pageSizes: [10] },
+      });
+
+      expect(
+        screen.queryByRole("combobox", { name: /Page number/ }),
+      ).not.toBeInTheDocument();
+      expect(screen.getByTestId("page-select-label")).toHaveTextContent(
+        "Page number, of 4 pages",
+      );
+      expect(screen.getByTestId("current-page")).toHaveTextContent("1");
+      expect(screen.getByTestId("total-pages")).toHaveTextContent("4");
+      expect(screen.getByTestId("current-page-size")).toHaveTextContent("10");
+    });
+
+    it("calls onSetPage to navigate and dispatches change", async () => {
+      const consoleLog = vi.spyOn(console, "log");
+      render(PaginationPageSelectSlot, {
+        props: { totalItems: 40, pageSizes: [10] },
+      });
+
+      await user.click(screen.getByText("Go to 3"));
+
+      expect(screen.getByTestId("current-page")).toHaveTextContent("3");
+      expect(consoleLog).toHaveBeenCalledWith("change", { page: 3 });
+    });
+
+    it("ignores onSetPage when disabled", async () => {
+      const consoleLog = vi.spyOn(console, "log");
+      render(PaginationPageSelectSlot, {
+        props: { totalItems: 40, pageSizes: [10], disabled: true },
+      });
+
+      await user.click(screen.getByText("Go to 3"));
+
+      expect(screen.getByTestId("current-page")).toHaveTextContent("1");
+      expect(consoleLog).not.toHaveBeenCalledWith("change", expect.anything());
+    });
+
+    it("ignores onSetPage with a non-numeric page", async () => {
+      const consoleLog = vi.spyOn(console, "log");
+      render(PaginationPageSelectSlot, {
+        props: { totalItems: 40, pageSizes: [10] },
+      });
+
+      await user.click(screen.getByText("Go to invalid"));
+
+      expect(screen.getByTestId("current-page")).toHaveTextContent("1");
+      expect(consoleLog).not.toHaveBeenCalledWith("change", expect.anything());
+    });
+
+    it("clamps onSetPage to the last page when it exceeds totalPages", async () => {
+      const consoleLog = vi.spyOn(console, "log");
+      render(PaginationPageSelectSlot, {
+        props: { totalItems: 15, pageSizes: [10] },
+      });
+
+      await user.click(screen.getByText("Go to 3"));
+
+      expect(screen.getByTestId("current-page")).toHaveTextContent("2");
+      expect(consoleLog).toHaveBeenCalledWith("change", { page: 2 });
+    });
   });
 });

--- a/tests/Pagination/PaginationPageSelectSlot.test.svelte
+++ b/tests/Pagination/PaginationPageSelectSlot.test.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+  import Pagination from "carbon-components-svelte/Pagination/Pagination.svelte";
+  import type { ComponentProps } from "svelte";
+
+  export let page: ComponentProps<Pagination>["page"] = 1;
+  export let totalItems: ComponentProps<Pagination>["totalItems"] = 0;
+  export let pageSizes: ComponentProps<Pagination>["pageSizes"] = [10];
+  export let disabled: ComponentProps<Pagination>["disabled"] = false;
+  export let pageInputDisabled: ComponentProps<Pagination>["pageInputDisabled"] = false;
+</script>
+
+<Pagination
+  bind:page
+  {totalItems}
+  {pageSizes}
+  {disabled}
+  {pageInputDisabled}
+  on:change={(e) => {
+    console.log("change", e.detail);
+  }}
+>
+  <svelte:fragment
+    slot="pageSelect"
+    let:currentPage
+    let:totalPages
+    let:currentPageSize
+    let:selectLabelText
+    let:onSetPage
+  >
+    <span data-testid="page-select-label">{selectLabelText}</span>
+    <span data-testid="current-page">{currentPage}</span>
+    <span data-testid="total-pages">{totalPages}</span>
+    <span data-testid="current-page-size">{currentPageSize}</span>
+    <button type="button" on:click={() => onSetPage(3)}>Go to 3</button>
+    <button type="button" on:click={() => onSetPage("not-a-number")}>
+      Go to invalid
+    </button>
+  </svelte:fragment>
+</Pagination>


### PR DESCRIPTION
Found while auditing Carbon React's commit history for parity fixes
not yet ported here. Bundles three feature additions that touch the
same file sequentially:

- `pageSelectLabelText` prop for the page-number select's
  accessible label (was hardcoded, no way to translate it)
- `backwardTextTooltipPosition`/`forwardTextTooltipPosition` props
  for the nav button tooltips (was hardcoded to `top`)
- `pageSelect` slot, the Svelte equivalent of Carbon React's
  `renderPageSelect` render prop