### PR TITLE
feat(date-picker): order month/year in the calendar header per locale

### DIFF
--- a/docs/src/pages/components/DatePicker.svx
+++ b/docs/src/pages/components/DatePicker.svx
@@ -136,6 +136,12 @@ Import the corresponding locale module from `flatpickr/dist/l10n/<key>` and pass
 
 <FileSource src="/framed/DatePicker/DatePickerNonEnglishLocale" />
 
+### Locale with year-first order
+
+For locales where `Intl.DateTimeFormat` orders the year before the month (for example Japanese), the calendar header automatically reorders to match—"2000年1月" instead of "January 2000".
+
+<FileSource src="/framed/DatePicker/DatePickerYearFirstLocale" />
+
 ## Portal
 
 Set `portalMenu` to `true` to render the calendar in a floating portal. This prevents the calendar from being clipped by parent containers with `overflow: hidden` or z-index stacking contexts. Inside a [Modal](/components/Modal), `portalMenu` defaults to `true` unless explicitly set to `false`.

--- a/docs/src/pages/framed/DatePicker/DatePickerYearFirstLocale.svelte
+++ b/docs/src/pages/framed/DatePicker/DatePickerYearFirstLocale.svelte
@@ -1,0 +1,8 @@
+<script>
+  import { DatePicker, DatePickerInput } from "carbon-components-svelte";
+  import { Japanese } from "flatpickr/dist/l10n/ja";
+</script>
+
+<DatePicker datePickerType="single" locale={Japanese} on:change>
+  <DatePickerInput labelText="日付" placeholder="yyyy/mm/dd" />
+</DatePicker>

--- a/src/DatePicker/createCalendar.js
+++ b/src/DatePicker/createCalendar.js
@@ -132,20 +132,55 @@ function markTodayMonth(instance) {
 }
 
 /**
- * @param {FlatpickrInstance} instance
+ * Whether `locale` orders the month before the year (e.g. "January 2000"),
+ * as opposed to year before month (e.g. "2000年1月" in Japanese).
+ *
+ * @param {unknown} locale
+ * @returns {boolean}
  */
-function updateMonthNode(instance) {
-  const monthText = instance.l10n.months.longhand[instance.currentMonth];
-  const staticMonthNode = instance.monthNav.querySelector(".cur-month");
+function isMonthFirst(locale) {
+  if (typeof locale !== "string") return true;
+  try {
+    const parts = new Intl.DateTimeFormat(locale, {
+      year: "numeric",
+      month: "long",
+    }).formatToParts(new Date(2000, 0, 1));
+    const monthIndex = parts.findIndex((part) => part.type === "month");
+    const yearIndex = parts.findIndex((part) => part.type === "year");
+    return monthIndex < yearIndex;
+  } catch {
+    return true;
+  }
+}
 
-  if (staticMonthNode) {
-    staticMonthNode.textContent = monthText;
+/**
+ * @param {FlatpickrInstance} instance
+ * @param {unknown} locale
+ */
+function updateMonthNode(instance, locale) {
+  const monthText = instance.l10n.months.longhand[instance.currentMonth];
+  let monthNode = instance.monthNav.querySelector(".cur-month");
+
+  if (monthNode) {
+    monthNode.textContent = monthText;
   } else {
     const monthSelectNode = instance.monthsDropdownContainer;
     const span = document.createElement("span");
     span.setAttribute("class", "cur-month");
     span.textContent = monthText;
     monthSelectNode.parentNode?.replaceChild(span, monthSelectNode);
+    monthNode = span;
+  }
+
+  // Depending on the locale, toggle the order of the month and year.
+  const yearWrapper = monthNode.parentNode?.querySelector(".numInputWrapper");
+  if (!yearWrapper) return;
+  if (isMonthFirst(locale)) {
+    if (monthNode.nextSibling !== yearWrapper) {
+      yearWrapper.parentNode?.insertBefore(monthNode, yearWrapper);
+    }
+  } else if (yearWrapper.nextSibling !== monthNode) {
+    yearWrapper.insertAdjacentElement("afterend", monthNode);
   }
 }
 
@@ -230,7 +265,7 @@ export async function createCalendar({ options, base, input, dispatch }) {
       // The monthSelect / yearSelect plugins remove the month-label node, so
       // there is nothing for updateMonthNode to patch.
       if (options.mode !== "month" && options.mode !== "year") {
-        updateMonthNode(instance);
+        updateMonthNode(instance, options.locale);
       }
     },
     onYearChange: (
@@ -255,7 +290,7 @@ export async function createCalendar({ options, base, input, dispatch }) {
         isYear: options.mode === "year",
       });
       if (options.mode !== "month" && options.mode !== "year") {
-        updateMonthNode(instance);
+        updateMonthNode(instance, options.locale);
       }
       if (options.mode === "month") {
         markTodayMonth(instance);

--- a/tests/DatePicker/DatePicker.test.ts
+++ b/tests/DatePicker/DatePicker.test.ts
@@ -69,6 +69,44 @@ describe("DatePicker", () => {
     expect(weekdays).toEqual(["S", "M", "T", "W", "Th", "F", "S"]);
   });
 
+  it("renders month before year in the calendar header for locale='en'", async () => {
+    const { container } = render(DatePicker, {
+      datePickerType: "single",
+      locale: "en",
+    });
+
+    await user.click(screen.getByLabelText("Date"));
+    await screen.findByLabelText("calendar-container");
+
+    const header = container.querySelector(".flatpickr-current-month");
+    const month = header?.querySelector(".cur-month");
+    const year = header?.querySelector(".numInputWrapper");
+    expect(month).toBeTruthy();
+    expect(year).toBeTruthy();
+    expect(month?.compareDocumentPosition(year as Element)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+  });
+
+  it("renders year before month in the calendar header for locale='ja'", async () => {
+    const { container } = render(DatePicker, {
+      datePickerType: "single",
+      locale: "ja",
+    });
+
+    await user.click(screen.getByLabelText("Date"));
+    await screen.findByLabelText("calendar-container");
+
+    const header = container.querySelector(".flatpickr-current-month");
+    const month = header?.querySelector(".cur-month");
+    const year = header?.querySelector(".numInputWrapper");
+    expect(month).toBeTruthy();
+    expect(year).toBeTruthy();
+    expect(year?.compareDocumentPosition(month as Element)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+  });
+
   it("renders range mode", async () => {
     const { container } = render(DatePickerRange);
 


### PR DESCRIPTION
Found while auditing Carbon React's commit history for parity fixes
not yet ported here.

Carbon React reorders the flatpickr header's month/year text based
on Intl.DateTimeFormat part order (e.g. year-before-month in
Japanese); this port always rendered month-first regardless of
locale.