### PR TITLE
feat(number-input): add validateNumberSeparators utility

### DIFF
--- a/src/NumberInput/NumberInput.svelte
+++ b/src/NumberInput/NumberInput.svelte
@@ -113,6 +113,11 @@
    * ```svelte
    * <NumberInput validate={(raw) => Number(raw) % 2 === 0} invalidText="Must be even" />
    * ```
+   * @example
+   * ```svelte
+   * <!-- import { validateNumberSeparators } from "carbon-components-svelte"; -->
+   * <NumberInput locale="de-DE" validate={validateNumberSeparators} />
+   * ```
    */
   export let validate = undefined;
 

--- a/src/index.js
+++ b/src/index.js
@@ -240,6 +240,7 @@ export {
   filterTreeNodes,
 } from "./utils/filterTreeNodes";
 export { fuzzyMatch, highlightSegments } from "./utils/fuzzyMatch";
+export { validateNumberSeparators } from "./utils/numericFormat";
 export { toHierarchy } from "./utils/toHierarchy";
 export {
   resolveCheckboxState,

--- a/src/utils/numericFormat.d.ts
+++ b/src/utils/numericFormat.d.ts
@@ -12,6 +12,12 @@ export function parseLocaleValue(
   decimalSeparator: string,
 ): number | null;
 
+/** Validate that `input`'s digits/separators are consistent with `locale`. */
+export function validateNumberSeparators(
+  input: string,
+  locale: string | undefined,
+): boolean;
+
 /** First step when empty: `stepStartValue`, else `min`, else 0. */
 export function getDefaultValue(
   stepStartValue: number | undefined,

--- a/src/utils/numericFormat.js
+++ b/src/utils/numericFormat.js
@@ -76,6 +76,26 @@ export function parseLocaleValue(raw, groupSeparator, decimalSeparator) {
 }
 
 /**
+ * Validate that `input` uses digits and separators consistent with `locale`
+ * (or plain ASCII digits/separators when `locale` is undefined). Intended for
+ * use as a `NumberInput` `validate` function.
+ *
+ * @param {string} input
+ * @param {string | undefined} locale
+ * @returns {boolean}
+ */
+export function validateNumberSeparators(input, locale) {
+  if (input === "" || input === "-") return true;
+  if (locale === undefined) return parse(input) !== null;
+
+  const parts = new Intl.NumberFormat(locale).formatToParts(12345.6);
+  const groupSeparator = parts.find((p) => p.type === "group")?.value ?? "";
+  const decimalSeparator =
+    parts.find((p) => p.type === "decimal")?.value ?? ".";
+  return parseLocaleValue(input, groupSeparator, decimalSeparator) !== null;
+}
+
+/**
  * First step value when the field is empty: `stepStartValue` if set, else `min`,
  * else 0.
  *

--- a/tests/utils/numericFormat.test.ts
+++ b/tests/utils/numericFormat.test.ts
@@ -4,6 +4,7 @@ import {
   parse,
   parseLocaleValue,
   roundToStep,
+  validateNumberSeparators,
 } from "../../src/utils/numericFormat.js";
 
 describe("parse", () => {
@@ -71,6 +72,28 @@ describe("clamp", () => {
 
   test("ignores undefined bounds", () => {
     expect(clamp(5, undefined, undefined)).toBe(5);
+  });
+});
+
+describe("validateNumberSeparators", () => {
+  test("allows an empty string", () => {
+    expect(validateNumberSeparators("", "de-DE")).toBe(true);
+  });
+
+  test("validates plain digits without a locale", () => {
+    expect(validateNumberSeparators("1234", undefined)).toBe(true);
+    expect(validateNumberSeparators("12a4", undefined)).toBe(false);
+  });
+
+  test("accepts correctly-separated input for the given locale", () => {
+    expect(validateNumberSeparators("1.234,5", "de-DE")).toBe(true);
+    expect(validateNumberSeparators("1,234.5", "en-US")).toBe(true);
+  });
+
+  test("rejects input using the wrong locale's separators", () => {
+    // "de-DE" expects "." as the group separator and "," as decimal;
+    // this string mixes both incorrectly (two decimal-style separators).
+    expect(validateNumberSeparators("1,234,5", "de-DE")).toBe(false);
   });
 });
 


### PR DESCRIPTION
Found while auditing Carbon React's commit history for parity fixes
not yet ported here.

Lets consumers opt into stricter locale-aware separator validation
via the existing `validate` prop, mirroring Carbon React's exported
helper.