### PR TITLE
feat(data-table): allow `header.sort` to opt a column into sorting

### DIFF
--- a/docs/src/pages/components/DataTable.svx
+++ b/docs/src/pages/components/DataTable.svx
@@ -1253,6 +1253,27 @@ When a sortable header is clicked, the table dispatches a cancelable `sort` even
   on:sort={(e) => console.log(e.detail.key, e.detail.direction)}
 />
 
+### Per-column opt-in
+
+`sort` also works the other way: set `sort: true` on individual headers to opt them into sorting when the table itself is not `sortable`, rather than setting table-level `sortable` and disabling every other column with `sort: false`.
+
+In this incident table, row order reflects severity and should not be disturbed by sorting most columns, but "Last updated" still benefits from a sortable column to find the most (or least) recently touched incident.
+
+<DataTable
+  headers="{[
+    { key: 'id', value: 'Incident' },
+    { key: 'severity', value: 'Severity' },
+    { key: 'owner', value: 'Owner' },
+    { key: 'updated', value: 'Last updated', sort: true }
+  ]}"
+  rows="{[
+    { id: 'INC-142', severity: 'Critical', owner: 'Priya', updated: '2025-03-05' },
+    { id: 'INC-139', severity: 'High', owner: 'Marcus', updated: '2025-03-04' },
+    { id: 'INC-137', severity: 'High', owner: 'Priya', updated: '2025-03-02' },
+    { id: 'INC-128', severity: 'Medium', owner: 'Jae', updated: '2025-02-28' }
+  ]}"
+/>
+
 ### Server-side
 
 When rows and sort order come from an API, the canonical order is usually defined on the server (collation, nullable fields, joined columns, security filters).

--- a/src/DataTable/DataTable.svelte
+++ b/src/DataTable/DataTable.svelte
@@ -20,7 +20,7 @@
    * @property {DataTableKey<Row> | (string & {})} key
    * @property {true} empty - Whether the header is empty
    * @property {(item: DataTableValue, row: Row) => DataTableValue} [display]
-   * @property {false | ((a: DataTableSortValue<Row>, b: DataTableSortValue<Row>) => number)} [sort]
+   * @property {boolean | ((a: DataTableSortValue<Row>, b: DataTableSortValue<Row>) => number)} [sort] - `false` disables sorting for this column even when the table is sortable; `true` enables it even when the table is not; a comparator both enables sorting and provides it. Unset inherits the table-level `sortable`.
    * @property {boolean} [sortAlways] - Override table-level sortAlways for this column
    * @property {boolean} [columnMenu] - Whether the column menu is enabled
    * @property {boolean} [columnHidden] - Whether the column is skipped in render while remaining in `headers`
@@ -31,7 +31,7 @@
    * @property {false} [empty]
    * @property {DataTableValue} value
    * @property {(item: DataTableValue, row: Row) => DataTableValue} [display]
-   * @property {false | ((a: DataTableSortValue<Row>, b: DataTableSortValue<Row>) => number)} [sort]
+   * @property {boolean | ((a: DataTableSortValue<Row>, b: DataTableSortValue<Row>) => number)} [sort] - `false` disables sorting for this column even when the table is sortable; `true` enables it even when the table is not; a comparator both enables sorting and provides it. Unset inherits the table-level `sortable`.
    * @property {boolean} [sortAlways] - Override table-level sortAlways for this column
    * @property {boolean} [columnMenu] - Whether the column menu is enabled
    * @property {boolean} [columnHidden] - Whether the column is skipped in render while remaining in `headers`
@@ -147,7 +147,7 @@
   /** Set to `true` to use zebra styles */
   export let zebra = false;
 
-  /** Set to `true` for the sortable variant */
+  /** Set to `true` for the sortable variant. Individual columns can opt out (or, if this is `false`, opt in) via `header.sort`. */
   export let sortable = false;
 
   /**
@@ -623,6 +623,19 @@
     return alignClasses[columnAlign];
   }
 
+  /**
+   * Resolve whether a header is sortable. `header.sort` overrides the
+   * table-level `sortable` in either direction (`false` opts out, `true` or
+   * a comparator opts in); unset inherits `sortable`.
+   */
+  function isHeaderSortable(header) {
+    if (header.sort === false) return false;
+    if (header.sort === true || typeof header.sort === "function") {
+      return true;
+    }
+    return sortable;
+  }
+
   /** Build cell objects for one row. Always new objects so `display` columns re-run. */
   function computeRowCells(row) {
     const cells = [];
@@ -728,8 +741,10 @@
   }
 
   $: ascending = sortDirection === "ascending";
-  $: sorting = sortable && sortKey != null;
   $: sortingHeader = headers.find((header) => header.key === sortKey);
+  $: sorting =
+    sortKey != null &&
+    (sortingHeader ? isHeaderSortable(sortingHeader) : sortable);
   $: sortedRows =
     sorting && sortDirection !== "none"
       ? [...$tableRows].sort((a, b) => {
@@ -737,7 +752,7 @@
           const itemB = resolvePath(b, sortKey);
           const headerSort = sortingHeader?.sort;
 
-          if (headerSort) {
+          if (typeof headerSort === "function") {
             return compareValues(itemA, itemB, ascending, headerSort);
           }
 
@@ -1011,7 +1026,7 @@
                 id="{id}-{header.key}"
                 class={formatAlignClass(header.columnAlign)}
                 style={formatHeaderWidth(header)}
-                sortable={sortable && header.sort !== false}
+                sortable={isHeaderSortable(header)}
                 sortDirection={sortKey === header.key ? sortDirection : "none"}
                 active={sortKey === header.key}
                 {...(tableHeaderTranslateWithId
@@ -1020,13 +1035,7 @@
                 on:click={(event) => {
                   dispatch("click", { header });
 
-                  if (header.sort === false) {
-                    dispatch("click:header", {
-                      header,
-                      target: event.target,
-                      currentTarget: event.currentTarget,
-                    });
-                  } else {
+                  if (isHeaderSortable(header)) {
                     const currentSortDirection =
                       sortKey === header.key ? sortDirection : "none";
                     const effectiveSortAlways =
@@ -1060,6 +1069,12 @@
                     dispatch("click:header", {
                       header,
                       sortDirection: nextSortDirection,
+                      target: event.target,
+                      currentTarget: event.currentTarget,
+                    });
+                  } else {
+                    dispatch("click:header", {
+                      header,
                       target: event.target,
                       currentTarget: event.currentTarget,
                     });

--- a/tests/DataTable/DataTable.test.svelte
+++ b/tests/DataTable/DataTable.test.svelte
@@ -17,7 +17,7 @@
     columnAlign?: "start" | "end";
     display?: (value: string | number | boolean) => string;
     sort?:
-      | false
+      | boolean
       | ((
           a: DataTableSortValue<BaseRow>,
           b: DataTableSortValue<BaseRow>,

--- a/tests/DataTable/DataTable.test.ts
+++ b/tests/DataTable/DataTable.test.ts
@@ -520,6 +520,42 @@ describe("DataTable", () => {
     ).toHaveTextContent("Load Balancer 3");
   });
 
+  it("allows a header to opt into sorting when the table itself is not sortable", async () => {
+    const customHeaders = [
+      { key: "name", value: "Name", sort: true as const },
+      { key: "protocol", value: "Protocol" },
+    ];
+
+    render(DataTable, {
+      props: {
+        sortable: false,
+        headers: customHeaders,
+        rows,
+      },
+    });
+
+    // Protocol has no per-header override, so it stays non-interactive.
+    expect(screen.getByText("Protocol").closest("th")).not.toHaveAttribute(
+      "aria-sort",
+    );
+
+    // Name opted in via sort: true, so it renders as a sortable header and
+    // can be clicked even though the table-level `sortable` is false.
+    const nameHeader = screen.getByText("Name");
+    expect(nameHeader.closest("th")).toHaveAttribute("aria-sort", "none");
+
+    await user.click(nameHeader);
+
+    expect(nameHeader.closest("th")).toHaveAttribute("aria-sort", "ascending");
+
+    const tableRows = screen
+      .getAllByRole("row")
+      .filter((row) => row.closest("tbody") !== null);
+    expect(
+      within(tableRows[0]).getByRole("cell", { name: "Load Balancer 1" }),
+    ).toBeInTheDocument();
+  });
+
   it("handles table with numeric sorting", async () => {
     const numericRows = [
       { id: "a", value: 10 },


### PR DESCRIPTION
Closes #3683

Supersedes #3683, which added a separate `header.isSortable`
override. Folding the opt-in into `header.sort` instead avoids two
props that can disagree, the old one needed a note saying it's
ignored when `sort` is `false`.

## Example

```svelte
<DataTable
  headers={[
    { key: "id", value: "Incident" },
    { key: "severity", value: "Severity" },
    { key: "owner", value: "Owner" },
    { key: "updated", value: "Last updated", sort: true }
  ]}
  rows={rows}
/>
```

The table itself isn't `sortable`, but `sort: true` opts "Last
updated" in on its own. `sort: false` still opts a column out the
other way, same as before.
