### PR TITLE
feat(table): add `Table` component

### DIFF
--- a/css/_table.scss
+++ b/css/_table.scss
@@ -1,0 +1,94 @@
+@import "carbon-components/scss/globals/scss/vars";
+@import "carbon-components/scss/globals/scss/helper-mixins";
+@import "carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/import-once/import-once";
+
+/// Table: a simple, non-interactive table. Deliberately does not reuse
+/// `bx--data-table` — that visual language (heavier borders, dense header
+/// shading) is for DataTable's sortable/selectable data grid. This mirrors
+/// the lighter table styling docs uses for its own prose content
+/// (`docs/src/global.css` `.prose > table`), scoped to `.bx--simple-table`.
+/// @access private
+/// @group components
+@mixin table {
+  .#{$prefix}--simple-table-container {
+    width: 100%;
+    overflow-x: auto;
+  }
+
+  .#{$prefix}--simple-table {
+    width: 100%;
+    border-collapse: collapse;
+  }
+
+  .#{$prefix}--simple-table th,
+  .#{$prefix}--simple-table td {
+    padding: $spacing-03 $spacing-04;
+    text-align: start;
+    vertical-align: top;
+    border: 1px solid $ui-03;
+  }
+
+  .#{$prefix}--simple-table th {
+    background-color: $field-01;
+  }
+
+  // Row heights match DataTable's size scale (see
+  // _data-table-core.scss): compact 24px, short 32px, medium 40px,
+  // tall 64px. Height is set on the row explicitly, same as DataTable,
+  // since padding alone does not reliably reproduce those pixel values
+  // across different type styles.
+  .#{$prefix}--simple-table tr {
+    height: to-rem(40px);
+  }
+
+  .#{$prefix}--simple-table--compact tr {
+    height: to-rem(24px);
+  }
+
+  .#{$prefix}--simple-table--compact th,
+  .#{$prefix}--simple-table--compact td {
+    padding-top: to-rem(2px);
+    padding-bottom: to-rem(2px);
+  }
+
+  .#{$prefix}--simple-table--short tr {
+    height: to-rem(32px);
+  }
+
+  .#{$prefix}--simple-table--short th,
+  .#{$prefix}--simple-table--short td {
+    padding-top: to-rem(7px);
+    padding-bottom: to-rem(6px);
+  }
+
+  .#{$prefix}--simple-table--tall tr {
+    height: to-rem(64px);
+  }
+
+  .#{$prefix}--simple-table--tall th,
+  .#{$prefix}--simple-table--tall td {
+    padding-top: $spacing-05;
+    padding-bottom: $spacing-05;
+  }
+
+  .#{$prefix}--simple-table td code,
+  .#{$prefix}--simple-table th code {
+    padding: 0 $spacing-02;
+    background-color: $field-01;
+    border-radius: 4px;
+  }
+
+  // bx--link uses body-short-01; inherit caption-01 / label-01 metrics from the cell.
+  .#{$prefix}--simple-table td .#{$prefix}--link,
+  .#{$prefix}--simple-table th .#{$prefix}--link {
+    font-size: inherit;
+    line-height: inherit;
+    letter-spacing: inherit;
+    font-weight: inherit;
+    text-decoration: underline;
+  }
+}
+
+@include exports("table") {
+  @include table;
+}

--- a/css/_table.scss
+++ b/css/_table.scss
@@ -87,6 +87,22 @@
     font-weight: inherit;
     text-decoration: underline;
   }
+
+  // TableSkeleton: header cells stay plain text (or empty); body cells always
+  // render a shimmering placeholder bar, mirroring DataTableSkeleton.
+  .#{$prefix}--simple-table.#{$prefix}--skeleton th,
+  .#{$prefix}--simple-table.#{$prefix}--skeleton td {
+    vertical-align: middle;
+  }
+
+  .#{$prefix}--simple-table.#{$prefix}--skeleton th span,
+  .#{$prefix}--simple-table.#{$prefix}--skeleton td span {
+    @include skeleton;
+
+    display: block;
+    width: to-rem(64px);
+    height: to-rem(16px);
+  }
 }
 
 @include exports("table") {

--- a/css/all.scss
+++ b/css/all.scss
@@ -127,3 +127,4 @@ $css--plex: true;
 @import "./user-avatar";
 @import "./user-avatar-group";
 @import "./disclosure";
+@import "./table";

--- a/css/g10.scss
+++ b/css/g10.scss
@@ -87,3 +87,4 @@ $css--plex: true;
 @import "./user-avatar";
 @import "./user-avatar-group";
 @import "./disclosure";
+@import "./table";

--- a/css/g100.scss
+++ b/css/g100.scss
@@ -87,3 +87,4 @@ $css--plex: true;
 @import "./user-avatar";
 @import "./user-avatar-group";
 @import "./disclosure";
+@import "./table";

--- a/css/g80.scss
+++ b/css/g80.scss
@@ -87,3 +87,4 @@ $css--plex: true;
 @import "./user-avatar";
 @import "./user-avatar-group";
 @import "./disclosure";
+@import "./table";

--- a/css/g90.scss
+++ b/css/g90.scss
@@ -87,3 +87,4 @@ $css--plex: true;
 @import "./user-avatar";
 @import "./user-avatar-group";
 @import "./disclosure";
+@import "./table";

--- a/css/white.scss
+++ b/css/white.scss
@@ -87,3 +87,4 @@ $css--plex: true;
 @import "./user-avatar";
 @import "./user-avatar-group";
 @import "./disclosure";
+@import "./table";

--- a/docs/src/component-categories.ts
+++ b/docs/src/component-categories.ts
@@ -12,6 +12,7 @@ export const COMPONENT_CATEGORIES: ComponentCategory[] = [
     label: "Data & lists",
     components: [
       "DataTable",
+      "Table",
       "TreeView",
       "StructuredList",
       "ContainedList",

--- a/docs/src/component-since-versions.ts
+++ b/docs/src/component-since-versions.ts
@@ -68,6 +68,7 @@ export const COMPONENT_SINCE_VERSIONS: Record<string, string> = {
   Slider: "0.2.0",
   Stack: "0.93.0",
   StructuredList: "0.2.0",
+  Table: "0.112.0",
   Tabs: "0.2.0",
   TabsVertical: "0.110.0",
   Tag: "0.2.0",

--- a/docs/src/pages/components/Table.svx
+++ b/docs/src/pages/components/Table.svx
@@ -1,10 +1,10 @@
 ---
-components: ["Table"]
+components: ["Table", "TableSkeleton"]
 description: Tables display structured data in rows and columns, without sorting, selection, or virtualization.
 ---
 
 <script>
-  import { Table, CodeSnippet } from "carbon-components-svelte";
+  import { CodeSnippet, Table, TableSkeleton } from "carbon-components-svelte";
 </script>
 
 ## Basic
@@ -164,3 +164,37 @@ Use the `cell` and `cellHeader` slots to render content beyond plain text, such 
 Table always wraps its content in a horizontally scrollable container, so a table wider than its surrounding layout scrolls instead of overflowing the page.
 
 <FileSource src="/framed/Table/TableOverflow" />
+
+## Skeleton
+
+Show a loading state with `TableSkeleton`.
+
+### Loading state
+
+Use the table skeleton to show a loading state.
+
+<TableSkeleton />
+
+### Headers and rows
+
+Specify headers and row count for the skeleton.
+
+<TableSkeleton headers={["Name", "Protocol", "Port"]} rows={10} />
+
+### Object headers
+
+Pass header objects to customize the skeleton, matching the shape used by `Table`.
+
+<TableSkeleton headers={[{ value: "Name" }, { value: "Protocol" }, { value: "Port" }]} rows={10} />
+
+### Compact
+
+<TableSkeleton size="compact" headers={["Name", "Protocol"]} rows={5} />
+
+### Short
+
+<TableSkeleton size="short" headers={["Name", "Protocol"]} rows={5} />
+
+### Tall
+
+<TableSkeleton size="tall" headers={["Name", "Protocol"]} rows={5} />

--- a/docs/src/pages/components/Table.svx
+++ b/docs/src/pages/components/Table.svx
@@ -1,0 +1,166 @@
+---
+components: ["Table"]
+description: Tables display structured data in rows and columns, without sorting, selection, or virtualization.
+---
+
+<script>
+  import { Table, CodeSnippet } from "carbon-components-svelte";
+</script>
+
+## Basic
+
+Create a table using `headers` and `rows`. Match each header `key` with the corresponding row property. Every header needs a unique `key` and every row a unique `id`.
+
+Use [DataTable](/components/DataTable) instead for interactive use cases such as sorting, selection, or virtualization.
+
+<Table
+  headers={[
+    { key: "name", value: "Name" },
+    { key: "protocol", value: "Protocol" },
+    { key: "port", value: "Port" },
+  ]}
+  rows={[
+    { id: "a", name: "Load Balancer 1", protocol: "HTTP", port: "80" },
+    { id: "b", name: "Load Balancer 2", protocol: "HTTP", port: "80" },
+    { id: "c", name: "Load Balancer 3", protocol: "HTTP", port: "80" },
+  ]}
+/>
+
+## Row headers
+
+Set `rowHeader` on a header to render that column as `<th scope="row">` instead of `<td>` — useful for key/value tables where the first column names the row.
+
+<Table
+  headers={[
+    { key: "name", value: "Name", rowHeader: true },
+    { key: "protocol", value: "Protocol" },
+    { key: "port", value: "Port" },
+  ]}
+  rows={[
+    { id: "a", name: "Load Balancer 1", protocol: "HTTP", port: "80" },
+    { id: "b", name: "Load Balancer 2", protocol: "HTTP", port: "80" },
+    { id: "c", name: "Load Balancer 3", protocol: "HTTP", port: "80" },
+  ]}
+/>
+
+## Column alignment
+
+Set `columnAlign` on a header to `"start"`, `"center"`, or `"end"`. Values are logical, so `"end"` is the right edge in LTR and the left edge in RTL.
+
+<Table
+  headers={[
+    { key: "name", value: "Name", rowHeader: true },
+    { key: "cpu", value: "CPU %", columnAlign: "center" },
+    { key: "cost", value: "Cost", columnAlign: "end" },
+  ]}
+  rows={[
+    { id: "a", name: "Load Balancer 1", cpu: "42%", cost: "$12.40" },
+    { id: "b", name: "Load Balancer 2", cpu: "58%", cost: "$18.10" },
+    { id: "c", name: "Load Balancer 3", cpu: "31%", cost: "$9.75" },
+  ]}
+/>
+
+## Sizes
+
+Set `size` to `"compact"`, `"short"`, `"medium"`, or `"tall"` to control row density.
+
+### Compact
+
+<Table
+  size="compact"
+  headers={[
+    { key: "name", value: "Name", rowHeader: true },
+    { key: "protocol", value: "Protocol" },
+  ]}
+  rows={[
+    { id: "a", name: "Load Balancer 1", protocol: "HTTP" },
+    { id: "b", name: "Load Balancer 2", protocol: "HTTP" },
+  ]}
+/>
+
+### Short
+
+<Table
+  size="short"
+  headers={[
+    { key: "name", value: "Name", rowHeader: true },
+    { key: "protocol", value: "Protocol" },
+  ]}
+  rows={[
+    { id: "a", name: "Load Balancer 1", protocol: "HTTP" },
+    { id: "b", name: "Load Balancer 2", protocol: "HTTP" },
+  ]}
+/>
+
+### Medium (default)
+
+<Table
+  headers={[
+    { key: "name", value: "Name", rowHeader: true },
+    { key: "protocol", value: "Protocol" },
+  ]}
+  rows={[
+    { id: "a", name: "Load Balancer 1", protocol: "HTTP" },
+    { id: "b", name: "Load Balancer 2", protocol: "HTTP" },
+  ]}
+/>
+
+### Tall
+
+<Table
+  size="tall"
+  headers={[
+    { key: "name", value: "Name", rowHeader: true },
+    { key: "protocol", value: "Protocol" },
+  ]}
+  rows={[
+    { id: "a", name: "Load Balancer 1", protocol: "HTTP" },
+    { id: "b", name: "Load Balancer 2", protocol: "HTTP" },
+  ]}
+/>
+
+## Column widths
+
+Set `width` or `minWidth` on a header to size that column. Setting either on any header switches the table to `table-layout: fixed`; without them the table uses the browser default (`table-layout: auto`), sizing columns to their content.
+
+<Table
+  headers={[
+    { key: "name", value: "Name", rowHeader: true, width: "50%" },
+    { key: "protocol", value: "Protocol", minWidth: "8rem" },
+    { key: "port", value: "Port" },
+  ]}
+  rows={[
+    { id: "a", name: "Load Balancer 1", protocol: "HTTP", port: "80" },
+    { id: "b", name: "Load Balancer 2", protocol: "HTTP", port: "80" },
+    { id: "c", name: "Load Balancer 3", protocol: "HTTP", port: "80" },
+  ]}
+/>
+
+## Custom cell content
+
+Use the `cell` and `cellHeader` slots to render content beyond plain text, such as inline code or links. Both slots receive the `header` object; `cell` also receives `row`, `rowIndex`, and `cellIndex`.
+
+<Table
+  headers={[
+    { key: "name", value: "Name", rowHeader: true },
+    { key: "endpoint", value: "Endpoint" },
+  ]}
+  rows={[
+    { id: "a", name: "Load Balancer 1", endpoint: "10.0.0.1:80" },
+    { id: "b", name: "Load Balancer 2", endpoint: "10.0.0.2:80" },
+  ]}
+>
+  <svelte:fragment slot="cell" let:row let:header>
+    {#if header.key === "endpoint"}
+      <CodeSnippet type="inline" code={row.endpoint} />
+    {:else}
+      {row[header.key]}
+    {/if}
+  </svelte:fragment>
+</Table>
+
+## Wide tables
+
+Table always wraps its content in a horizontally scrollable container, so a table wider than its surrounding layout scrolls instead of overflowing the page.
+
+<FileSource src="/framed/Table/TableOverflow" />

--- a/docs/src/pages/framed/Table/TableOverflow.svelte
+++ b/docs/src/pages/framed/Table/TableOverflow.svelte
@@ -1,0 +1,19 @@
+<script>
+  import { Table } from "carbon-components-svelte";
+
+  const headers = Array.from({ length: 10 }).map((_, i) => ({
+    key: `col-${i}`,
+    value: `Column ${i + 1}`,
+    minWidth: "10rem",
+  }));
+
+  const rows = Array.from({ length: 4 }).map((_, rowIndex) => {
+    const row = { id: rowIndex };
+    headers.forEach((header, i) => {
+      row[header.key] = `Row ${rowIndex + 1}, Col ${i + 1}`;
+    });
+    return row;
+  });
+</script>
+
+<Table {headers} {rows} />

--- a/src/DataTable/DataTable.svelte
+++ b/src/DataTable/DataTable.svelte
@@ -334,6 +334,7 @@
   import RadioButton from "../RadioButton/RadioButton.svelte";
   import { uniqueId } from "../utils/uniqueId.js";
   import { virtualize as virtualizeUtil } from "../utils/virtualize.js";
+  import DataTableTable from "./DataTableTable.svelte";
   import {
     compareValues,
     formatHeaderWidth,
@@ -341,7 +342,6 @@
     resolvePath,
     shouldIgnoreRowClick,
   } from "./data-table-utils.js";
-  import Table from "./Table.svelte";
   import TableBody from "./TableBody.svelte";
   import TableCell from "./TableCell.svelte";
   import TableContainer from "./TableContainer.svelte";
@@ -895,7 +895,7 @@
       ? (event) => { tableBodyScrollTop = event.target.scrollTop || 0; }
       : undefined}
   >
-    <Table
+    <DataTableTable
       bind:ref={tableRef}
       zebra={zebra && !hideMode}
       {size}
@@ -1542,6 +1542,6 @@
           </TableRow>
         </TableFoot>
       {/if}
-    </Table>
+    </DataTableTable>
   </div>
 </TableContainer>

--- a/src/DataTable/DataTableTable.svelte
+++ b/src/DataTable/DataTableTable.svelte
@@ -33,7 +33,7 @@
   /**
    * Id of an element that labels the table (e.g. `DataTable`'s title heading).
    * Internal: set directly by `DataTable`. Standalone compositions
-   * (`TableContainer` wrapping `Table`) get this from context instead.
+   * (`TableContainer` wrapping `DataTableTable`) get this from context instead.
    * @type {string | undefined}
    */
   export let labelledBy = undefined;
@@ -41,7 +41,7 @@
   /**
    * Id of an element that describes the table (e.g. `DataTable`'s description text).
    * Internal: set directly by `DataTable`. Standalone compositions
-   * (`TableContainer` wrapping `Table`) get this from context instead.
+   * (`TableContainer` wrapping `DataTableTable`) get this from context instead.
    * @type {string | undefined}
    */
   export let describedBy = undefined;
@@ -49,7 +49,7 @@
   import { getContext } from "svelte";
   import { writable } from "svelte/store";
 
-  // Context is only consulted for the standalone `TableContainer` + `Table`
+  // Context is only consulted for the standalone `TableContainer` + `DataTableTable`
   // composition: an explicit `labelledBy`/`describedBy` prop (set by
   // `DataTable`, which renders its own title/description markup) always wins.
   const tableContainerCtx = getContext("carbon:TableContainer");

--- a/src/DataTable/index.js
+++ b/src/DataTable/index.js
@@ -1,6 +1,6 @@
 export { default as DataTable } from "./DataTable.svelte";
 export { default as DataTableSkeleton } from "./DataTableSkeleton.svelte";
-export { default as Table } from "./Table.svelte";
+export { default as DataTableTable } from "./DataTableTable.svelte";
 export { default as TableBody } from "./TableBody.svelte";
 export { default as TableCell } from "./TableCell.svelte";
 export { default as TableContainer } from "./TableContainer.svelte";

--- a/src/Table/Table.svelte
+++ b/src/Table/Table.svelte
@@ -1,0 +1,108 @@
+<script>
+  /**
+   * @typedef {any} TableValue
+   * @typedef {{ id: any; [key: string]: TableValue; }} TableRow
+   * @typedef {object} TableHeader
+   * @property {string} key
+   * @property {TableValue} value
+   * @property {boolean} [rowHeader] - Render this column as a row header (`<th scope="row">`) in the table body, both semantically and visually.
+   * @property {"start" | "center" | "end"} [columnAlign] - Horizontal alignment of the column header and cells. Logical, so `end` is the right edge in LTR and the left edge in RTL. Defaults to `"start"`.
+   * @property {string} [width] - Column width (e.g. `"20%"`, `"10rem"`). Setting `width` or `minWidth` on any header switches the table to `table-layout: fixed`.
+   * @property {string} [minWidth] - Column minimum width.
+   * @slot {{ header: TableHeader }} cellHeader
+   * @slot {{ row: TableRow; header: TableHeader; rowIndex: number; cellIndex: number; }} cell
+   * @restProps {table}
+   */
+
+  /**
+   * Specify the headers the table should render.
+   * @type {ReadonlyArray<TableHeader>}
+   */
+  export let headers = [];
+
+  /**
+   * Specify the rows the table should render.
+   * Values are read from each row using the `key` defined in `headers`.
+   * @type {ReadonlyArray<TableRow>}
+   */
+  export let rows = [];
+
+  /**
+   * Set the size of the table.
+   * @type {"compact" | "short" | "medium" | "tall"}
+   */
+  export let size = undefined;
+
+  import { formatHeaderWidth } from "../DataTable/data-table-utils.js";
+
+  const alignStyles = {
+    center: "text-align: center;",
+    end: "text-align: end;",
+  };
+
+  function formatAlignStyle(columnAlign) {
+    return alignStyles[columnAlign];
+  }
+
+  function formatHeaderStyle(header) {
+    return [formatHeaderWidth(header), formatAlignStyle(header.columnAlign)]
+      .filter(Boolean)
+      .join(";");
+  }
+
+  $: hasCustomHeaderWidth = headers.some(
+    (header) => header.width ?? header.minWidth,
+  );
+</script>
+
+<div class:bx--simple-table-container={true}>
+  <table
+    class:bx--simple-table={true}
+    class:bx--simple-table--compact={size === "compact"}
+    class:bx--simple-table--short={size === "short"}
+    class:bx--simple-table--tall={size === "tall"}
+    {...$$restProps}
+    style="{$$restProps.style ?? ''}{hasCustomHeaderWidth
+      ? ' table-layout: fixed;'
+      : ''}"
+  >
+    <thead>
+      <tr>
+        {#each headers as header (header.key)}
+          <th class:bx--type-label-01={true} style={formatHeaderStyle(header)}>
+            <slot name="cellHeader" {header}>{header.value}</slot>
+          </th>
+        {/each}
+      </tr>
+    </thead>
+    <tbody>
+      {#each rows as row, rowIndex (row.id)}
+        <tr>
+          {#each headers as header, cellIndex (header.key)}
+            {#if header.rowHeader}
+              <th
+                scope="row"
+                class:bx--type-label-01={true}
+                style={formatAlignStyle(header.columnAlign)}
+              >
+                <slot name="cell" {row} {header} {rowIndex} {cellIndex}>
+                  {row[header.key]}
+                </slot>
+              </th>
+            {:else}
+              <td
+                class:bx--type-caption-01={true}
+                class:bx--type-text-secondary={true}
+                style={formatAlignStyle(header.columnAlign)}
+              >
+                <slot name="cell" {row} {header} {rowIndex} {cellIndex}>
+                  {row[header.key]}
+                </slot>
+              </td>
+            {/if}
+          {/each}
+        </tr>
+      {/each}
+    </tbody>
+  </table>
+</div>

--- a/src/Table/TableSkeleton.svelte
+++ b/src/Table/TableSkeleton.svelte
@@ -1,0 +1,60 @@
+<script>
+  /**
+   * Specify the number of columns.
+   * Superseded by `headers` if `headers` is a non-empty array.
+   */
+  export let columns = 5;
+
+  /** Specify the number of rows */
+  export let rows = 5;
+
+  /**
+   * Set the size of the table.
+   * @type {"compact" | "short" | "tall"}
+   */
+  export let size = undefined;
+
+  /**
+   * Set the column headers.
+   * Supersedes `columns` if value is a non-empty array.
+   * @type {ReadonlyArray<string | Partial<import('./Table.svelte').TableHeader>>}
+   */
+  export let headers = [];
+
+  $: values = headers.map((header) =>
+    typeof header === "string" || header.value === undefined
+      ? header
+      : header.value,
+  );
+  $: cols = Array.from(
+    { length: headers.length > 0 ? headers.length : columns },
+    (_, i) => i,
+  );
+</script>
+
+<div class:bx--simple-table-container={true} {...$$restProps}>
+  <table
+    class:bx--skeleton={true}
+    class:bx--simple-table={true}
+    class:bx--simple-table--compact={size === "compact"}
+    class:bx--simple-table--short={size === "short"}
+    class:bx--simple-table--tall={size === "tall"}
+  >
+    <thead>
+      <tr>
+        {#each cols as col (col)}
+          <th class:bx--type-label-01={true}>{values[col] || ""}</th>
+        {/each}
+      </tr>
+    </thead>
+    <tbody>
+      {#each Array.from({ length: rows }, (_, i) => i) as row (row)}
+        <tr>
+          {#each cols as col (col)}
+            <td class:bx--type-caption-01={true}><span></span></td>
+          {/each}
+        </tr>
+      {/each}
+    </tbody>
+  </table>
+</div>

--- a/src/Table/index.js
+++ b/src/Table/index.js
@@ -1,0 +1,1 @@
+export { default as Table } from "./Table.svelte";

--- a/src/Table/index.js
+++ b/src/Table/index.js
@@ -1,1 +1,2 @@
 export { default as Table } from "./Table.svelte";
+export { default as TableSkeleton } from "./TableSkeleton.svelte";

--- a/src/index.js
+++ b/src/index.js
@@ -40,8 +40,8 @@ export { default as CopyInputSkeleton } from "./CopyInput/CopyInputSkeleton.svel
 export { default as FluidCopyInputSkeleton } from "./CopyInput/FluidCopyInputSkeleton.svelte";
 export { default as DataTable } from "./DataTable/DataTable.svelte";
 export { default as DataTableSkeleton } from "./DataTable/DataTableSkeleton.svelte";
+export { default as DataTableTable } from "./DataTable/DataTableTable.svelte";
 export { toCsv } from "./DataTable/data-table-utils";
-export { default as Table } from "./DataTable/Table.svelte";
 export { default as TableBody } from "./DataTable/TableBody.svelte";
 export { default as TableCell } from "./DataTable/TableCell.svelte";
 export { default as TableContainer } from "./DataTable/TableContainer.svelte";
@@ -162,6 +162,7 @@ export { default as StructuredListHead } from "./StructuredList/StructuredListHe
 export { default as StructuredListInput } from "./StructuredList/StructuredListInput.svelte";
 export { default as StructuredListRow } from "./StructuredList/StructuredListRow.svelte";
 export { default as StructuredListSkeleton } from "./StructuredList/StructuredListSkeleton.svelte";
+export { default as Table } from "./Table/Table.svelte";
 export { default as Tab } from "./Tabs/Tab.svelte";
 export { default as TabContent } from "./Tabs/TabContent.svelte";
 export { default as Tabs } from "./Tabs/Tabs.svelte";

--- a/src/index.js
+++ b/src/index.js
@@ -163,6 +163,7 @@ export { default as StructuredListInput } from "./StructuredList/StructuredListI
 export { default as StructuredListRow } from "./StructuredList/StructuredListRow.svelte";
 export { default as StructuredListSkeleton } from "./StructuredList/StructuredListSkeleton.svelte";
 export { default as Table } from "./Table/Table.svelte";
+export { default as TableSkeleton } from "./Table/TableSkeleton.svelte";
 export { default as Tab } from "./Tabs/Tab.svelte";
 export { default as TabContent } from "./Tabs/TabContent.svelte";
 export { default as Tabs } from "./Tabs/Tabs.svelte";

--- a/tests/DataTable/TableContainerWithTable.test.svelte
+++ b/tests/DataTable/TableContainerWithTable.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import Table from "carbon-components-svelte/DataTable/Table.svelte";
+  import DataTableTable from "carbon-components-svelte/DataTable/DataTableTable.svelte";
   import TableBody from "carbon-components-svelte/DataTable/TableBody.svelte";
   import TableCell from "carbon-components-svelte/DataTable/TableCell.svelte";
   import TableContainer from "carbon-components-svelte/DataTable/TableContainer.svelte";
@@ -11,11 +11,11 @@
 </script>
 
 <TableContainer {title} {description}>
-  <Table>
+  <DataTableTable>
     <TableBody>
       <TableRow>
         <TableCell>Cell</TableCell>
       </TableRow>
     </TableBody>
-  </Table>
+  </DataTableTable>
 </TableContainer>

--- a/tests/DataTable/TableSubComponents.test.svelte
+++ b/tests/DataTable/TableSubComponents.test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import Table from "carbon-components-svelte/DataTable/Table.svelte";
+  import DataTableTable from "carbon-components-svelte/DataTable/DataTableTable.svelte";
   import TableBody from "carbon-components-svelte/DataTable/TableBody.svelte";
   import TableCell from "carbon-components-svelte/DataTable/TableCell.svelte";
   import TableContainer from "carbon-components-svelte/DataTable/TableContainer.svelte";
@@ -9,21 +9,22 @@
   import type { ComponentProps } from "svelte";
 
   export let testComponent:
-    | "Table"
+    | "DataTableTable"
     | "TableBody"
     | "TableCell"
     | "TableRow"
     | "TableHead"
     | "TableFoot"
-    | "TableContainer" = "Table";
+    | "TableContainer" = "DataTableTable";
 
-  // Table props
-  export let size: ComponentProps<Table>["size"] = undefined;
-  export let zebra: ComponentProps<Table>["zebra"] = false;
-  export let useStaticWidth: ComponentProps<Table>["useStaticWidth"] = false;
-  export let sortable: ComponentProps<Table>["sortable"] = false;
-  export let stickyHeader: ComponentProps<Table>["stickyHeader"] = false;
-  export let tableStyle: ComponentProps<Table>["tableStyle"] = undefined;
+  // DataTableTable props
+  export let size: ComponentProps<DataTableTable>["size"] = undefined;
+  export let zebra: ComponentProps<DataTableTable>["zebra"] = false;
+  export let useStaticWidth: ComponentProps<DataTableTable>["useStaticWidth"] = false;
+  export let sortable: ComponentProps<DataTableTable>["sortable"] = false;
+  export let stickyHeader: ComponentProps<DataTableTable>["stickyHeader"] = false;
+  export let tableStyle: ComponentProps<DataTableTable>["tableStyle"] =
+    undefined;
 
   // TableContainer props
   export let title: ComponentProps<TableContainer>["title"] = "";
@@ -32,8 +33,8 @@
   export let slotContent = "";
 </script>
 
-{#if testComponent === "Table"}
-  <Table
+{#if testComponent === "DataTableTable"}
+  <DataTableTable
     {size}
     {zebra}
     {useStaticWidth}
@@ -46,7 +47,7 @@
       {slotContent}
     {/if}
     <slot />
-  </Table>
+  </DataTableTable>
 {:else if testComponent === "TableBody"}
   <TableBody {...$$restProps}>
     {#if slotContent}

--- a/tests/DataTable/TableSubComponents.test.ts
+++ b/tests/DataTable/TableSubComponents.test.ts
@@ -4,10 +4,10 @@ import TableContainerWithTable from "./TableContainerWithTable.test.svelte";
 import TableSubComponents from "./TableSubComponents.test.svelte";
 
 describe("Table Sub-Components", () => {
-  describe("Table", () => {
+  describe("DataTableTable", () => {
     it("should render with default props", () => {
       const { container } = render(TableSubComponents, {
-        props: { testComponent: "Table", slotContent: "Content" },
+        props: { testComponent: "DataTableTable", slotContent: "Content" },
       });
 
       const table = container.querySelector("table");
@@ -17,7 +17,7 @@ describe("Table Sub-Components", () => {
 
     it("should not set aria-labelledby without a TableContainer ancestor", () => {
       render(TableSubComponents, {
-        props: { testComponent: "Table", slotContent: "Content" },
+        props: { testComponent: "DataTableTable", slotContent: "Content" },
       });
 
       const table = screen.getByRole("table");
@@ -50,7 +50,7 @@ describe("Table Sub-Components", () => {
 
       for (const size of sizes) {
         const { container, unmount } = render(TableSubComponents, {
-          props: { testComponent: "Table", size },
+          props: { testComponent: "DataTableTable", size },
         });
 
         const table = container.querySelector("table");
@@ -63,7 +63,7 @@ describe("Table Sub-Components", () => {
 
     it("should handle zebra prop", () => {
       const { container } = render(TableSubComponents, {
-        props: { testComponent: "Table", zebra: true },
+        props: { testComponent: "DataTableTable", zebra: true },
       });
 
       const table = container.querySelector("table");
@@ -72,7 +72,7 @@ describe("Table Sub-Components", () => {
 
     it("should handle useStaticWidth prop", () => {
       const { container } = render(TableSubComponents, {
-        props: { testComponent: "Table", useStaticWidth: true },
+        props: { testComponent: "DataTableTable", useStaticWidth: true },
       });
 
       const table = container.querySelector("table");
@@ -81,7 +81,7 @@ describe("Table Sub-Components", () => {
 
     it("should handle sortable prop", () => {
       const { container } = render(TableSubComponents, {
-        props: { testComponent: "Table", sortable: true },
+        props: { testComponent: "DataTableTable", sortable: true },
       });
 
       const table = container.querySelector("table");
@@ -90,7 +90,7 @@ describe("Table Sub-Components", () => {
 
     it("should handle stickyHeader prop", () => {
       const { container } = render(TableSubComponents, {
-        props: { testComponent: "Table", stickyHeader: true },
+        props: { testComponent: "DataTableTable", stickyHeader: true },
       });
 
       const table = container.querySelector("table");
@@ -102,7 +102,7 @@ describe("Table Sub-Components", () => {
 
     it("should handle tableStyle prop", () => {
       const { container } = render(TableSubComponents, {
-        props: { testComponent: "Table", tableStyle: "width: 100%;" },
+        props: { testComponent: "DataTableTable", tableStyle: "width: 100%;" },
       });
 
       const table = container.querySelector("table");

--- a/tests/Table/Table.test.svelte
+++ b/tests/Table/Table.test.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+  import Table from "carbon-components-svelte/Table/Table.svelte";
+  import type { ComponentProps } from "svelte";
+
+  export let size: ComponentProps<Table>["size"] = undefined;
+  export let headers: ComponentProps<Table>["headers"] = [
+    { key: "name", value: "Name", rowHeader: true },
+    { key: "role", value: "Role" },
+    { key: "status", value: "Status", columnAlign: "center" },
+  ];
+
+  const rows: ComponentProps<Table>["rows"] = [
+    { id: "a", name: "Alice", role: "Engineer", status: "Active" },
+    { id: "b", name: "Bob", role: "Designer", status: "Inactive" },
+  ];
+</script>
+
+<Table {headers} {rows} {size}>
+  <svelte:fragment slot="cellHeader" let:header>
+    {#if header.key === "name"}
+      <span data-testid="custom-header-name">{header.value}</span>
+    {:else}
+      {header.value}
+    {/if}
+  </svelte:fragment>
+  <svelte:fragment slot="cell" let:row let:header>
+    {#if header.key === "status"}
+      <span data-testid="status-{row.id}">{row.status}</span>
+    {:else}
+      {row[header.key]}
+    {/if}
+  </svelte:fragment>
+</Table>

--- a/tests/Table/Table.test.ts
+++ b/tests/Table/Table.test.ts
@@ -1,0 +1,90 @@
+import { render, screen } from "@testing-library/svelte";
+import Table from "./Table.test.svelte";
+
+describe("Table", () => {
+  it("renders headers and rows from data", () => {
+    render(Table);
+
+    expect(screen.getByText("Role")).toBeInTheDocument();
+    expect(screen.getByText("Engineer")).toBeInTheDocument();
+    expect(screen.getByText("Designer")).toBeInTheDocument();
+  });
+
+  it("renders the row-header column as a scoped th with row-header styling", () => {
+    render(Table);
+
+    const aliceHeader = screen.getByRole("rowheader", { name: "Alice" });
+    expect(aliceHeader.tagName).toBe("TH");
+    expect(aliceHeader).toHaveAttribute("scope", "row");
+    expect(aliceHeader).toHaveClass("bx--type-label-01");
+  });
+
+  it("applies center alignment to the configured column", () => {
+    render(Table);
+
+    const statusHeader = screen.getByText("Status").closest("th");
+    expect(statusHeader).toHaveStyle({ textAlign: "center" });
+
+    const statusCell = screen.getByTestId("status-a");
+    expect(statusCell.closest("td")).toHaveStyle({ textAlign: "center" });
+  });
+
+  it("renders custom cellHeader and cell slot content", () => {
+    render(Table);
+
+    expect(screen.getByTestId("custom-header-name")).toBeInTheDocument();
+    expect(screen.getByTestId("status-a")).toHaveTextContent("Active");
+  });
+
+  it("applies the size variant", () => {
+    render(Table, { props: { size: "compact" } });
+
+    expect(document.querySelector(".bx--simple-table")).toHaveClass(
+      "bx--simple-table--compact",
+    );
+  });
+
+  it("wraps the table in a horizontally scrollable container", () => {
+    const { container } = render(Table);
+
+    const scrollContainer = container.querySelector(
+      ".bx--simple-table-container",
+    );
+    expect(scrollContainer).toBeInTheDocument();
+    expect(scrollContainer?.querySelector("table")).toBeInTheDocument();
+  });
+
+  it("uses table-layout: auto and no explicit column widths by default", () => {
+    const { container } = render(Table);
+
+    const table = container.querySelector("table");
+    expect(table).not.toHaveStyle({ tableLayout: "fixed" });
+
+    const roleHeader = screen.getByText("Role").closest("th");
+    expect(roleHeader).not.toHaveAttribute(
+      "style",
+      expect.stringContaining("width"),
+    );
+  });
+
+  it("switches to table-layout: fixed and applies column widths when a header sets width or minWidth", () => {
+    const { container } = render(Table, {
+      props: {
+        headers: [
+          { key: "name", value: "Name", rowHeader: true, width: "30%" },
+          { key: "role", value: "Role", minWidth: "8rem" },
+          { key: "status", value: "Status", columnAlign: "center" },
+        ],
+      },
+    });
+
+    const table = container.querySelector("table");
+    expect(table).toHaveStyle({ tableLayout: "fixed" });
+
+    const nameHeader = screen.getByText("Name").closest("th") as HTMLElement;
+    expect(nameHeader.style.width).toBe("30%");
+
+    const roleHeader = screen.getByText("Role").closest("th") as HTMLElement;
+    expect(roleHeader.style.minWidth).toBe("8rem");
+  });
+});

--- a/tests/Table/TableSkeleton.test.svelte
+++ b/tests/Table/TableSkeleton.test.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+  import TableSkeleton from "carbon-components-svelte/Table/TableSkeleton.svelte";
+  import type { ComponentProps } from "svelte";
+
+  export let columns: ComponentProps<TableSkeleton>["columns"] = undefined;
+  export let rows: ComponentProps<TableSkeleton>["rows"] = undefined;
+  export let size: ComponentProps<TableSkeleton>["size"] = undefined;
+  export let headers: ComponentProps<TableSkeleton>["headers"] = undefined;
+</script>
+
+<TableSkeleton {columns} {rows} {size} {headers} />

--- a/tests/Table/TableSkeleton.test.ts
+++ b/tests/Table/TableSkeleton.test.ts
@@ -1,0 +1,67 @@
+import { render, screen } from "@testing-library/svelte";
+import TableSkeleton from "./TableSkeleton.test.svelte";
+
+describe("TableSkeleton", () => {
+  it("renders the default 5x5 skeleton grid", () => {
+    const { container } = render(TableSkeleton);
+
+    expect(container.querySelectorAll("thead th")).toHaveLength(5);
+    expect(container.querySelectorAll("tbody tr")).toHaveLength(5);
+    expect(container.querySelectorAll("tbody td")).toHaveLength(25);
+  });
+
+  it("renders a placeholder span in every body cell", () => {
+    const { container } = render(TableSkeleton);
+
+    for (const td of container.querySelectorAll("tbody td")) {
+      expect(td.querySelector("span")).toBeInTheDocument();
+    }
+  });
+
+  it("uses columns and rows to size the grid", () => {
+    const { container } = render(TableSkeleton, {
+      props: { columns: 3, rows: 2 },
+    });
+
+    expect(container.querySelectorAll("thead th")).toHaveLength(3);
+    expect(container.querySelectorAll("tbody tr")).toHaveLength(2);
+  });
+
+  it("renders string headers as header text and overrides columns", () => {
+    render(TableSkeleton, {
+      props: { columns: 10, headers: ["Name", "Protocol", "Port"] },
+    });
+
+    expect(screen.getByText("Name")).toBeInTheDocument();
+    expect(screen.getByText("Protocol")).toBeInTheDocument();
+    expect(screen.getByText("Port")).toBeInTheDocument();
+    expect(document.querySelectorAll("thead th")).toHaveLength(3);
+  });
+
+  it("renders object headers using their value", () => {
+    render(TableSkeleton, {
+      props: { headers: [{ value: "Name" }, { value: "Protocol" }] },
+    });
+
+    expect(screen.getByText("Name")).toBeInTheDocument();
+    expect(screen.getByText("Protocol")).toBeInTheDocument();
+  });
+
+  it("applies the size variant", () => {
+    const { container } = render(TableSkeleton, {
+      props: { size: "compact" },
+    });
+
+    expect(container.querySelector(".bx--simple-table")).toHaveClass(
+      "bx--simple-table--compact",
+    );
+  });
+
+  it("applies skeleton and table classes", () => {
+    const { container } = render(TableSkeleton);
+
+    const table = container.querySelector("table");
+    expect(table).toHaveClass("bx--skeleton");
+    expect(table).toHaveClass("bx--simple-table");
+  });
+});


### PR DESCRIPTION
Adds a lightweight `Table` component for simple, non-interactive
tabular data: headers and rows, optional row headers, column
alignment, and column widths, without DataTable's sorting,
selection, or virtualization.

Breaking change: the internal `Table` sub-component used in
`TableContainer` compositions is renamed to `DataTableTable` to
free up the `Table` export name for the new component.

```svelte
<script>
  import { Table } from "carbon-components-svelte";
</script>

<Table
  headers={[
    { key: "name", value: "Name", rowHeader: true },
    { key: "protocol", value: "Protocol" },
    { key: "port", value: "Port", columnAlign: "end" },
  ]}
  rows={[
    { id: "a", name: "Load Balancer 1", protocol: "HTTP", port: "80" },
    { id: "b", name: "Load Balancer 2", protocol: "HTTP", port: "80" },
  ]}
/>
```