### PR TITLE
fix(data-table): align expanded row content with checkbox/radio columns

### DIFF
--- a/css/vendor/carbon-components/scss/components/data-table/_data-table-expandable.scss
+++ b/css/vendor/carbon-components/scss/components/data-table/_data-table-expandable.scss
@@ -63,11 +63,20 @@
   }
 
   tr.#{$prefix}--parent-row.#{$prefix}--expandable-row + tr[data-child-row] td {
-    padding-left: 4rem;
+    padding-left: 3.5rem;
     border-bottom: 1px solid $border-subtle;
     transition: padding-bottom $duration--fast-02 motion(standard, productive),
       transform $duration--fast-02 motion(standard, productive),
       background-color $duration--fast-02 motion(standard, productive);
+  }
+
+  // A checkbox or radio selection column pushes the parent row's own text
+  // past the 3.5rem baseline indent, so the child row needs to reach
+  // further to still land under it.
+  tr.#{$prefix}--parent-row.#{$prefix}--expandable-row.#{$prefix}--expandable-row--with-selection
+    + tr[data-child-row]
+    td {
+    padding-left: 5.5rem;
   }
 
   tr.#{$prefix}--parent-row.#{$prefix}--expandable-row
@@ -75,6 +84,8 @@
     td
     .#{$prefix}--child-row-inner-container {
     max-height: 100%;
+    padding-top: 1rem;
+    padding-bottom: 1.5rem;
   }
 
   // bottom border overrides

--- a/docs/src/pages/components/DataTable.svx
+++ b/docs/src/pages/components/DataTable.svx
@@ -1960,6 +1960,12 @@ Combine `batchExpansion` and `batchSelection` for expandable, selectable tables.
 
 <FileSource src="/framed/DataTable/DataTableExpandableSelectable" />
 
+### With radio selection
+
+Combine `batchExpansion` and `radio` for expandable tables with single-row selection.
+
+<FileSource src="/framed/DataTable/DataTableExpandableRadioSelectable" />
+
 ## Skeleton
 
 Show a loading state with `DataTableSkeleton`.

--- a/docs/src/pages/framed/DataTable/DataTableExpandableRadioSelectable.svelte
+++ b/docs/src/pages/framed/DataTable/DataTableExpandableRadioSelectable.svelte
@@ -1,0 +1,35 @@
+<script>
+  import { DataTable } from "carbon-components-svelte";
+
+  let expandedRowIds = [];
+  let selectedRowIds = [];
+
+  $: {
+    console.log("expandedRowIds", expandedRowIds);
+    console.log("selectedRowIds", selectedRowIds);
+  }
+</script>
+
+<DataTable
+  batchExpansion
+  radio
+  bind:expandedRowIds
+  bind:selectedRowIds
+  headers={[
+    { key: "name", value: "Name" },
+    { key: "protocol", value: "Protocol" },
+    { key: "port", value: "Port" },
+    { key: "rule", value: "Rule" },
+  ]}
+  rows={Array.from({ length: 6 }).map((_, i) => ({
+    id: i,
+    name: `Load Balancer ${i + 1}`,
+    protocol: "HTTP",
+    port: i % 3 ? (i % 2 ? 3000 : 80) : 443,
+    rule: i % 3 ? "Round robin" : "DNS delegation",
+  }))}
+>
+  <svelte:fragment slot="expandedRow" let:row>
+    <pre>{JSON.stringify(row, null, 2)}</pre>
+  </svelte:fragment>
+</DataTable>

--- a/e2e/data-table.test.ts
+++ b/e2e/data-table.test.ts
@@ -54,6 +54,43 @@ test.describe("DataTable", () => {
     );
   });
 
+  test("expandable: expanded content has block padding, not flush against row edges", async ({
+    page,
+  }) => {
+    const expand = page.getByTestId("data-table-expand");
+    await expand
+      .getByRole("button", { name: "Expand current row" })
+      .first()
+      .click();
+
+    const container = expand.locator(".bx--child-row-inner-container").first();
+    await expect(container).toHaveCSS("padding-top", "16px");
+    await expect(container).toHaveCSS("padding-bottom", "24px");
+  });
+
+  test("expandable: with a checkbox column, expanded content aligns under the row's own text", async ({
+    page,
+  }) => {
+    const table = page.getByTestId("data-table-expand-selectable");
+    await table
+      .getByRole("button", { name: "Expand current row" })
+      .first()
+      .click();
+
+    const nameCell = table.locator("tr.bx--parent-row td").nth(2);
+    const detail = table.getByTestId("expand-selectable-detail");
+
+    const [nameBox, detailBox] = await Promise.all([
+      nameCell.boundingBox(),
+      detail.boundingBox(),
+    ]);
+    const namePaddingLeft = await nameCell.evaluate((el) =>
+      Number.parseFloat(getComputedStyle(el).paddingLeft),
+    );
+
+    expect(detailBox.x).toBeCloseTo(nameBox.x + namePaddingLeft, 0);
+  });
+
   test("expandable: supports row ids matching object prototype properties", async ({
     page,
   }) => {

--- a/e2e/fixtures/DataTableFixture.svelte
+++ b/e2e/fixtures/DataTableFixture.svelte
@@ -74,6 +74,19 @@
   </DataTable>
 </div>
 
+<div data-testid="data-table-expand-selectable">
+  <DataTable
+    expandable
+    batchSelection
+    headers={expandHeaders}
+    rows={expandRows}
+  >
+    <svelte:fragment slot="expandedRow" let:row>
+      <p data-testid="expand-selectable-detail">Extra row: {row.name}</p>
+    </svelte:fragment>
+  </DataTable>
+</div>
+
 <div data-testid="data-table-batch">
   <DataTable batchSelection headers={batchHeaders} rows={batchRows} />
 </div>

--- a/src/DataTable/DataTable.svelte
+++ b/src/DataTable/DataTable.svelte
@@ -1099,7 +1099,10 @@
                 : ''} {isExpanded ? 'bx--expandable-row' : ''} {expandable ? 'bx--parent-row' : ''} {expandable &&
               parentRowId === row.id
                 ? 'bx--expandable-row--hover'
-                : ''} {isHighlighted ? 'bx--data-table--highlighted-row' : ''} {rowClassValue ?? ''}"
+                : ''} {isHighlighted ? 'bx--data-table--highlighted-row' : ''} {expandable &&
+              isSelectionEnabled
+                ? 'bx--expandable-row--with-selection'
+                : ''} {rowClassValue ?? ''}"
               on:click={(event) => {
                 // forgo "click", "click:row" events if target
                 // resembles an overflow menu, a checkbox, or radio button
@@ -1333,7 +1336,10 @@
                 ? 'bx--parent-row'
                 : ''} {expandable && parentRowId === row.id
                 ? 'bx--expandable-row--hover'
-                : ''} {isHighlighted ? 'bx--data-table--highlighted-row' : ''} {rowClassValue ?? ''}"
+                : ''} {isHighlighted ? 'bx--data-table--highlighted-row' : ''} {expandable &&
+              isSelectionEnabled
+                ? 'bx--expandable-row--with-selection'
+                : ''} {rowClassValue ?? ''}"
               on:click={(event) => {
                 // forgo "click", "click:row" events if target
                 // resembles an overflow menu, a checkbox, or radio button


### PR DESCRIPTION
Expanded content used a flat left inset that ignored selection
columns, so with `selectable`/`radio`/`batchSelection` enabled it
landed left of the parent row's own text instead of under it. Also
restores vertical padding on the expanded content wrapper, which had
none and sat flush against the row edges.

---

<img width="965" height="351" alt="Screenshot 2026-08-19 at 5 43 30 AM" src="https://github.com/user-attachments/assets/6da46c01-75f9-4357-ad4b-a9d7911a0426" />
<img width="950" height="305" alt="Screenshot 2026-08-19 at 5 43 21 AM" src="https://github.com/user-attachments/assets/ce66cbe0-369a-47a0-b746-f64f0f32932b" />
<img width="950" height="306" alt="Screenshot 2026-08-19 at 5 43 12 AM" src="https://github.com/user-attachments/assets/b86d632b-d2cc-419e-8b52-3aa0713d278c" />
