### PR TITLE
test: extract flushDismiss util, fix flaky dismiss flushes

### DIFF
--- a/tests/ComboBox/ComboBoxWindowListeners.test.ts
+++ b/tests/ComboBox/ComboBoxWindowListeners.test.ts
@@ -1,9 +1,7 @@
 import { render } from "@testing-library/svelte";
+import { flushDismiss } from "../utils/flushDismiss";
 import { user } from "../utils/user";
 import ComboBox from "./ComboBox.test.svelte";
-
-/** dismiss() defers window listener registration by a macrotask; flush it before asserting. */
-const flush = () => new Promise((resolve) => setTimeout(resolve));
 
 const netClick = (
   add: ReturnType<typeof vi.spyOn>,
@@ -29,7 +27,7 @@ describe("ComboBox window listeners", () => {
     const remove = vi.spyOn(window, "removeEventListener");
 
     render(ComboBox, { props: { open: true } });
-    await flush();
+    await flushDismiss();
     expect(netClick(add, remove)).toBe(1);
 
     add.mockRestore();
@@ -41,7 +39,7 @@ describe("ComboBox window listeners", () => {
     const remove = vi.spyOn(window, "removeEventListener");
 
     render(ComboBox, { props: { open: true } });
-    await flush();
+    await flushDismiss();
     expect(netClick(add, remove)).toBe(1);
 
     // An outside click closes the menu, which must tear down the listener.

--- a/tests/ContextMenu/ContextMenuWindowListeners.test.ts
+++ b/tests/ContextMenu/ContextMenuWindowListeners.test.ts
@@ -1,8 +1,6 @@
 import { render } from "@testing-library/svelte";
+import { flushDismiss } from "../utils/flushDismiss";
 import ContextMenu from "./ContextMenu.test.svelte";
-
-/** dismiss() defers window listener registration by a macrotask; flush it before asserting. */
-const flush = () => new Promise((resolve) => setTimeout(resolve));
 
 const net = (
   add: ReturnType<typeof vi.spyOn>,
@@ -33,7 +31,7 @@ describe("ContextMenu window listeners", () => {
     const remove = vi.spyOn(window, "removeEventListener");
 
     render(ContextMenu, { props: { open: true } });
-    await flush();
+    await flushDismiss();
     expect(net(add, remove, "click")).toBe(1);
     expect(net(add, remove, "keydown")).toBe(1);
 

--- a/tests/DatePicker/DatePickerWindowListeners.test.ts
+++ b/tests/DatePicker/DatePickerWindowListeners.test.ts
@@ -1,12 +1,10 @@
 import { render, screen } from "@testing-library/svelte";
 import type { Instance } from "flatpickr/dist/types/instance";
 import { tick } from "svelte";
+import { flushDismiss } from "../utils/flushDismiss";
 import { user } from "../utils/user";
 import DatePicker from "./DatePicker.test.svelte";
 import DatePickerCalendar from "./DatePickerCalendar.test.svelte";
-
-/** dismiss() defers window listener registration by a macrotask; flush it before asserting. */
-const flush = () => new Promise((resolve) => setTimeout(resolve));
 
 const net = (
   add: ReturnType<typeof vi.spyOn>,
@@ -60,7 +58,7 @@ describe("DatePicker window listeners", () => {
     const remove = vi.spyOn(window, "removeEventListener");
 
     const instance = await openCalendar(() => {});
-    await flush();
+    await flushDismiss();
     expect(instance.isOpen).toBe(true);
     expect(net(add, remove, "click")).toBe(1);
 
@@ -73,7 +71,7 @@ describe("DatePicker window listeners", () => {
     const remove = vi.spyOn(window, "removeEventListener");
 
     const instance = await openCalendar(() => {});
-    await flush();
+    await flushDismiss();
     expect(net(add, remove, "click")).toBe(1);
 
     instance.close();

--- a/tests/Dropdown/DropdownWindowListeners.test.ts
+++ b/tests/Dropdown/DropdownWindowListeners.test.ts
@@ -1,8 +1,6 @@
 import { render } from "@testing-library/svelte";
+import { flushDismiss } from "../utils/flushDismiss";
 import Dropdown from "./Dropdown.test.svelte";
-
-/** dismiss() defers window listener registration by a macrotask; flush it before asserting. */
-const flush = () => new Promise((resolve) => setTimeout(resolve));
 
 const netClick = (
   add: ReturnType<typeof vi.spyOn>,
@@ -28,7 +26,7 @@ describe("Dropdown window listeners", () => {
     const remove = vi.spyOn(window, "removeEventListener");
 
     render(Dropdown, { props: { open: true } });
-    await flush();
+    await flushDismiss();
     expect(netClick(add, remove)).toBe(1);
 
     add.mockRestore();

--- a/tests/MultiSelect/MultiSelectWindowListeners.test.ts
+++ b/tests/MultiSelect/MultiSelectWindowListeners.test.ts
@@ -1,8 +1,6 @@
 import { render } from "@testing-library/svelte";
+import { flushDismiss } from "../utils/flushDismiss";
 import MultiSelect from "./MultiSelect.test.svelte";
-
-/** dismiss() defers window listener registration by a macrotask; flush it before asserting. */
-const flush = () => new Promise((resolve) => setTimeout(resolve));
 
 const net = (
   add: ReturnType<typeof vi.spyOn>,
@@ -33,7 +31,7 @@ describe("MultiSelect window listeners", () => {
     const remove = vi.spyOn(window, "removeEventListener");
 
     render(MultiSelect, { props: { open: true } });
-    await flush();
+    await flushDismiss();
     expect(net(add, remove, "click")).toBe(1);
     expect(net(add, remove, "focusin")).toBe(1);
 

--- a/tests/Popover/PopoverWindowListeners.test.ts
+++ b/tests/Popover/PopoverWindowListeners.test.ts
@@ -1,8 +1,6 @@
 import { render } from "@testing-library/svelte";
+import { flushDismiss } from "../utils/flushDismiss";
 import Popover from "./Popover.test.svelte";
-
-/** dismiss() defers window listener registration by a macrotask; flush it before asserting. */
-const flush = () => new Promise((resolve) => setTimeout(resolve));
 
 const netClick = (
   add: ReturnType<typeof vi.spyOn>,
@@ -28,7 +26,7 @@ describe("Popover window listeners", () => {
     const remove = vi.spyOn(window, "removeEventListener");
 
     render(Popover, { props: { open: true } });
-    await flush();
+    await flushDismiss();
     expect(netClick(add, remove)).toBe(1);
 
     add.mockRestore();

--- a/tests/Slider/RangeSliderWindowListeners.test.ts
+++ b/tests/Slider/RangeSliderWindowListeners.test.ts
@@ -1,9 +1,6 @@
 import { fireEvent, render } from "@testing-library/svelte";
-import { tick } from "svelte";
+import { flushDismiss } from "../utils/flushDismiss";
 import RangeSlider from "./RangeSlider.test.svelte";
-
-/** dismiss() defers window listener registration by a macrotask; flush it before asserting. */
-const flush = () => new Promise((resolve) => setTimeout(resolve));
 
 const net = (
   add: ReturnType<typeof vi.spyOn>,
@@ -38,16 +35,14 @@ describe("RangeSlider window listeners", () => {
     const slider = container.querySelector(".bx--slider");
     assert(slider instanceof HTMLElement);
     await fireEvent.mouseDown(slider);
-    await tick();
-    await flush();
+    await flushDismiss();
 
     expect(net(add, remove, "mousemove")).toBe(1);
     expect(net(add, remove, "touchmove")).toBe(1);
     expect(net(add, remove, "mouseup")).toBe(1);
 
     await fireEvent.mouseUp(window);
-    await tick();
-    await flush();
+    await flushDismiss();
     for (const type of ["mousemove", "touchmove", "mouseup", "touchend"]) {
       expect(net(add, remove, type)).toBe(0);
     }

--- a/tests/Slider/SliderWindowListeners.test.ts
+++ b/tests/Slider/SliderWindowListeners.test.ts
@@ -1,9 +1,6 @@
 import { fireEvent, render } from "@testing-library/svelte";
-import { tick } from "svelte";
+import { flushDismiss } from "../utils/flushDismiss";
 import Slider from "./Slider.test.svelte";
-
-/** dismiss() defers window listener registration by a macrotask; flush it before asserting. */
-const flush = () => new Promise((resolve) => setTimeout(resolve));
 
 const net = (
   add: ReturnType<typeof vi.spyOn>,
@@ -44,8 +41,7 @@ describe("Slider window listeners", () => {
     const sliderA = containers[0].querySelector(".bx--slider");
     assert(sliderA instanceof HTMLElement);
     await fireEvent.mouseDown(sliderA);
-    await tick();
-    await flush();
+    await flushDismiss();
 
     expect(net(add, remove, "mousemove")).toBe(1);
     expect(net(add, remove, "touchmove")).toBe(1);
@@ -55,14 +51,12 @@ describe("Slider window listeners", () => {
     const sliderB = containers[1].querySelector(".bx--slider");
     assert(sliderB instanceof HTMLElement);
     await fireEvent.mouseDown(sliderB);
-    await tick();
-    await flush();
+    await flushDismiss();
     expect(net(add, remove, "mousemove")).toBe(1);
 
     // Releasing both ends the drag and tears the shared listeners down.
     await fireEvent.mouseUp(window);
-    await tick();
-    await flush();
+    await flushDismiss();
     for (const type of ["mousemove", "touchmove", "mouseup", "touchend"]) {
       expect(net(add, remove, type)).toBe(0);
     }
@@ -78,8 +72,7 @@ describe("Slider window listeners", () => {
     const slider = container.querySelector(".bx--slider");
     assert(slider instanceof HTMLElement);
     await fireEvent.mouseDown(slider);
-    await tick();
-    await flush();
+    await flushDismiss();
 
     const moveCall = add.mock.calls.find(
       (c: unknown[]) => c[0] === "mousemove",

--- a/tests/Toggletip/Toggletip.test.ts
+++ b/tests/Toggletip/Toggletip.test.ts
@@ -1,19 +1,18 @@
 import { render, screen } from "@testing-library/svelte";
 import { tick } from "svelte";
+import { flushDismiss } from "../utils/flushDismiss";
 import { user } from "../utils/user";
 import Toggletip from "./ToggletipDispatchGuard.test.svelte";
 import ToggletipWithInteractiveContent from "./ToggletipWithInteractiveContent.test.svelte";
 
 /**
- * Listeners are enabled on the animation frame after opening; that state
- * change needs a Svelte `tick()` to reach the `dismiss` action's `update()`,
- * which itself defers the actual window listener registration by a further
- * macrotask. Flush all three before asserting.
+ * Listeners are enabled on the animation frame after opening, on top of the
+ * `dismiss` action's own deferred registration. Wait for that frame before
+ * flushing the `dismiss` action.
  */
 const flush = async () => {
   await new Promise((resolve) => requestAnimationFrame(resolve));
-  await tick();
-  await new Promise((resolve) => setTimeout(resolve));
+  await flushDismiss();
 };
 
 describe("Toggletip", () => {

--- a/tests/TooltipDefinition/TooltipDefinitionWindowListeners.test.ts
+++ b/tests/TooltipDefinition/TooltipDefinitionWindowListeners.test.ts
@@ -1,8 +1,6 @@
 import { render } from "@testing-library/svelte";
+import { flushDismiss } from "../utils/flushDismiss";
 import TooltipDefinition from "./TooltipDefinition.test.svelte";
-
-/** dismiss() defers window listener registration by a macrotask; flush it before asserting. */
-const flush = () => new Promise((resolve) => setTimeout(resolve));
 
 const net = (
   add: ReturnType<typeof vi.spyOn>,
@@ -30,7 +28,7 @@ describe("TooltipDefinition window listeners", () => {
     const remove = vi.spyOn(window, "removeEventListener");
 
     render(TooltipDefinition, { props: { open: true } });
-    await flush();
+    await flushDismiss();
     expect(net(add, remove, "keydown")).toBe(1);
 
     add.mockRestore();

--- a/tests/TooltipIcon/TooltipIconWindowListeners.test.ts
+++ b/tests/TooltipIcon/TooltipIconWindowListeners.test.ts
@@ -1,8 +1,6 @@
 import { render } from "@testing-library/svelte";
+import { flushDismiss } from "../utils/flushDismiss";
 import TooltipIcon from "./TooltipIcon.test.svelte";
-
-/** dismiss() defers window listener registration by a macrotask; flush it before asserting. */
-const flush = () => new Promise((resolve) => setTimeout(resolve));
 
 const net = (
   add: ReturnType<typeof vi.spyOn>,
@@ -29,7 +27,7 @@ describe("TooltipIcon window listeners", () => {
     const remove = vi.spyOn(window, "removeEventListener");
 
     render(TooltipIcon, { props: { open: true } });
-    await flush();
+    await flushDismiss();
     expect(net(add, remove, "keydown")).toBe(1);
 
     add.mockRestore();

--- a/tests/UIShell/HeaderAction.test.ts
+++ b/tests/UIShell/HeaderAction.test.ts
@@ -1,6 +1,7 @@
 import { render, screen, waitFor } from "@testing-library/svelte";
 import type HeaderActionComponent from "carbon-components-svelte/UIShell/HeaderAction.svelte";
 import type { ComponentProps } from "svelte";
+import { flushDismiss } from "../utils/flushDismiss";
 import { user } from "../utils/user";
 import HeaderActionOutsideClick from "./HeaderAction.outsideClick.test.svelte";
 import HeaderActionSlot from "./HeaderAction.slot.test.svelte";
@@ -79,10 +80,7 @@ describe("HeaderAction", () => {
       await user.click(button);
       expect(screen.getByTestId("panel-content")).toBeInTheDocument();
 
-      // dismiss() defers window listener registration by a macrotask; flush
-      // it before Escape so the keydown isn't dispatched before the listener
-      // is attached.
-      await new Promise((resolve) => setTimeout(resolve, 0));
+      await flushDismiss();
 
       await user.keyboard("{Escape}");
 

--- a/tests/UIShell/HeaderSearch.test.ts
+++ b/tests/UIShell/HeaderSearch.test.ts
@@ -2,6 +2,7 @@ import { fireEvent, render, screen } from "@testing-library/svelte";
 import type HeaderSearchComponent from "carbon-components-svelte/UIShell/HeaderSearch.svelte";
 import type { HeaderSearchResult } from "carbon-components-svelte/UIShell/HeaderSearch.svelte";
 import type { ComponentProps } from "svelte";
+import { flushDismiss } from "../utils/flushDismiss";
 import { user } from "../utils/user";
 import HeaderSearchTest from "./HeaderSearch.test.svelte";
 import HeaderSearchIconTest from "./HeaderSearchIcon.test.svelte";
@@ -551,9 +552,7 @@ describe("HeaderSearch", () => {
     it("should deactivate when clicking outside", async () => {
       render(HeaderSearchTest, { props: { active: true } });
 
-      // dismiss() defers window listener registration by a macrotask; flush
-      // it before the outside click so that click is not missed.
-      await new Promise((resolve) => setTimeout(resolve, 0));
+      await flushDismiss();
 
       // Click outside the search component
       const outsideElement = document.createElement("div");

--- a/tests/UIShell/HeaderSearchClose.test.ts
+++ b/tests/UIShell/HeaderSearchClose.test.ts
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen } from "@testing-library/svelte";
+import { flushDismiss } from "../utils/flushDismiss";
 import { user } from "../utils/user";
 import HeaderSearchClose from "./HeaderSearchClose.test.svelte";
 
@@ -21,9 +22,7 @@ describe("HeaderSearch close event", () => {
     const onClose = vi.fn();
     render(HeaderSearchClose, { props: { active: true, onClose } });
 
-    // dismiss() defers window listener registration by a macrotask; flush
-    // it before the outside click so that click is not missed.
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    await flushDismiss();
 
     const outside = document.createElement("div");
     document.body.appendChild(outside);
@@ -90,7 +89,7 @@ describe("HeaderSearch close event", () => {
     });
 
     component.active = false;
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    await flushDismiss();
 
     expect(onClose).not.toHaveBeenCalled();
   });

--- a/tests/utils/flushDismiss.ts
+++ b/tests/utils/flushDismiss.ts
@@ -1,0 +1,14 @@
+import { tick } from "svelte";
+
+/**
+ * `use:dismiss` defers its window listener registration by a macrotask, so
+ * that enabling it (e.g. via a click) doesn't register the listener in time
+ * to catch that same click as it bubbles. Wait a tick for the `enabled`
+ * change to reach the action's `update()`, then a macrotask for the
+ * deferred registration to run, before dispatching events the listener
+ * should catch.
+ */
+export const flushDismiss = async () => {
+  await tick();
+  await new Promise((resolve) => setTimeout(resolve));
+};


### PR DESCRIPTION
`use:dismiss` defers window listener registration by a
macrotask, so tests that open a panel and then dispatch a
dismiss event need to flush past that macrotask first.

`Toggletip.test.ts` already had this right: wait a tick for
the state change to reach the action's `update()`, then a
macrotask for the deferred registration. Other tests only
waited the macrotask, with no `tick()` first. That's a race:
if the state change hasn't flushed to `update()` yet, the
test's own `setTimeout` can run before the listener is even
scheduled.

Extract the pattern into `tests/utils/flushDismiss.ts` and use
it everywhere a test needs to wait for `use:dismiss` to attach.

Real fixes (missing `tick()` before the flush):
- `HeaderAction.test.ts` — Escape key after opening the panel.
  This one flaked in CI.
- `HeaderSearchClose.test.ts` — outside click, and setting
  `bind:active` to false externally.
- `Slider`/`RangeSlider` window listener tests already chained
  `tick()` + a local flush by hand at every call site; now they
  just call `flushDismiss()`.

Cleanup only (listener enabled from an initial prop, so no
reactivity gap to race): the various `*WindowListeners.test.ts`
files, plus two more spots in `HeaderSearch.test.ts` and
`HeaderSearchClose.test.ts`. Each had its own copy of the same
local `flush` helper.

Left `tests/utils/dismiss.test.ts` alone. It drives the raw
`dismiss()` action directly, not through a Svelte component, so
there's no reactivity tick to wait for.