### PR TITLE
fix(multi-select): forward rest props to the non-filterable trigger

### DIFF
--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -20,6 +20,7 @@
    * @event {{ trigger: "escape-key" | "outside-click" }} close
    * @event {{ scrollTop: number; scrollHeight: number; clientHeight: number }} scrollend
    * @slot {{ item: Item; index: number; selected: boolean; highlighted: boolean; }}
+   * @restProps {input | button}
    */
 
   /**
@@ -1139,6 +1140,7 @@
           : showFieldFocus}
       >
         <ListBoxField
+          {...$$restProps}
           role="combobox"
           tabindex="0"
           aria-expanded={open}

--- a/tests/MultiSelect/MultiSelect.test.ts
+++ b/tests/MultiSelect/MultiSelect.test.ts
@@ -23,6 +23,7 @@ import MultiSelectGenerics from "./MultiSelectGenerics.test.svelte";
 import MultiSelectInModal from "./MultiSelectInModal.test.svelte";
 import MultiSelectItemSlot from "./MultiSelectItemSlot.test.svelte";
 import MultiSelectItemToStringId from "./MultiSelectItemToStringId.test.svelte";
+import MultiSelectRestProps from "./MultiSelectRestProps.test.svelte";
 import MultiSelectSlot from "./MultiSelectSlot.test.svelte";
 
 const items = [
@@ -68,6 +69,27 @@ describe("MultiSelect", () => {
     });
 
     expect(screen.getByRole("combobox")).toHaveAttribute("maxlength", "10");
+  });
+
+  describe("rest props", () => {
+    it.each([
+      { filterable: false, fieldClass: "bx--list-box__field" },
+      { filterable: true, fieldClass: "bx--text-input" },
+    ])(
+      "forwards rest props to the trigger when filterable is $filterable",
+      ({ filterable, fieldClass }) => {
+        render(MultiSelectRestProps, {
+          props: { items, labelText: "Contact methods", filterable },
+        });
+
+        const trigger = screen.getByRole("combobox");
+        expect(trigger).toHaveAttribute("aria-invalid", "true");
+        expect(trigger).toHaveAttribute("aria-required", "true");
+        expect(trigger).toHaveAttribute("data-custom", "passthrough");
+        expect(trigger).toHaveClass(fieldClass);
+        expect(trigger).toHaveClass("custom-class");
+      },
+    );
   });
 
   describe("field accessible name and description", () => {

--- a/tests/MultiSelect/MultiSelectRestProps.test.svelte
+++ b/tests/MultiSelect/MultiSelectRestProps.test.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  import MultiSelect from "carbon-components-svelte/MultiSelect/MultiSelect.svelte";
+  import type { ComponentProps } from "svelte";
+
+  export let items: ComponentProps<MultiSelect>["items"] = [];
+  export let labelText = "";
+  export let filterable = false;
+</script>
+
+<MultiSelect
+  {items}
+  {labelText}
+  {filterable}
+  aria-invalid="true"
+  aria-required="true"
+  data-custom="passthrough"
+  class="custom-class"
+/>


### PR DESCRIPTION
The filterable variant spreads `$$restProps` onto its `<input>`, but the non-filterable trigger dropped them entirely, so `aria-invalid`, `aria-required`, `data-*`, etc had nowhere to land on the default MultiSelect.