### PR TITLE
docs(text-area): add "Maximum character count" fluid example

### DIFF
--- a/docs/src/pages/components/TextArea.svx
+++ b/docs/src/pages/components/TextArea.svx
@@ -50,6 +50,13 @@ Set `fluid` to embed the label inside the field. Fluid text areas work
 standalone or inside [FluidForm](/components/FluidForm), which applies the
 variant automatically.
 
+<TextArea fluid labelText="App description" placeholder="Enter a description..." />
+
+### Maximum character count
+
+The character counter sits at the trailing edge of the field, opposite the
+embedded label.
+
 <TextArea fluid labelText="App description" placeholder="Enter a description..." maxCount={100} />
 
 ### Custom label


### PR DESCRIPTION
Splits the fluid example into its own base case and a dedicated
"Maximum character count" example, matching the docs structure added
for TextInput in #3699. TextArea's fluid CSS already positions the
counter opposite the label, so no CSS change is needed here.