### PR TITLE
fix(pagination): forward disabled to both selects

### DIFF
--- a/docs/src/pages/components/Pagination.svx
+++ b/docs/src/pages/components/Pagination.svx
@@ -99,6 +99,12 @@ Disable the page size selector with `pageSizeInputDisabled`.
 
 <Pagination totalItems={102} pageSizeInputDisabled />
 
+## Disabled
+
+Set `disabled` to disable the entire pagination, including the nav buttons and both selects.
+
+<Pagination disabled totalItems={102} pageSizes={[10, 15, 20]} />
+
 ## Skeleton
 
 Use the pagination skeleton to show a loading state.

--- a/src/Pagination/Pagination.svelte
+++ b/src/Pagination/Pagination.svelte
@@ -263,6 +263,7 @@
           hideLabel
           noLabel
           inline
+          disabled={pageSizeInputDisabled || disabled}
           on:update={(event) => {
             dispatch("change", { pageSize: event.detail });
           }}
@@ -306,6 +307,7 @@
         labelText="Page number, of {totalPages} pages"
         inline
         hideLabel
+        disabled={pageInputDisabled || disabled}
         selected={page}
         on:update={(event) => {
           const next = Number(event.detail);

--- a/tests/Pagination/Pagination.test.ts
+++ b/tests/Pagination/Pagination.test.ts
@@ -136,6 +136,24 @@ describe("Pagination", () => {
     expect(nextButton).toBeDisabled();
   });
 
+  it("should disable the items-per-page select when disabled", () => {
+    render(Pagination, {
+      props: { disabled: true, totalItems: 102, pageSizes: [10, 20] },
+    });
+
+    const select = screen.getByRole("combobox", { name: "Items per page:" });
+    expect(select).toBeDisabled();
+  });
+
+  it("should disable the page-number select when disabled", () => {
+    render(Pagination, {
+      props: { disabled: true, totalItems: 102 },
+    });
+
+    const select = screen.getByLabelText(/Page number, of \d+ pages/);
+    expect(select).toBeDisabled();
+  });
+
   it("moves focus to the forward button when the backward button becomes disabled", async () => {
     render(Pagination, {
       props: { page: 2, totalItems: 20, pageSize: 10 },


### PR DESCRIPTION
Only the nav buttons respected `disabled` before this; both
`<Select>` controls stayed interactive, so a disabled pagination
could still have its page or page size changed via the selects.
Matches Carbon React's `Select` disabled forwarding.