### PR TITLE
fix(pagination): add pageSelectLabelText prop

### DIFF
--- a/src/Pagination/Pagination.svelte
+++ b/src/Pagination/Pagination.svelte
@@ -130,6 +130,12 @@
   export let pageRangeText = (_current, total) =>
     `of ${total.toLocaleString()} page${total === 1 ? "" : "s"}`;
 
+  /**
+   * Override the accessible label for the page number select.
+   * @type {(total: number) => string}
+   */
+  export let pageSelectLabelText = (total) => `Page number, of ${total} pages`;
+
   /** Set an id for the top-level element */
   export let id = uniqueId();
 
@@ -304,7 +310,7 @@
       <Select
         id="bx--pagination-select-{id}-pages"
         class="bx--select__page-number"
-        labelText="Page number, of {totalPages} pages"
+        labelText={pageSelectLabelText(totalPages)}
         inline
         hideLabel
         disabled={pageInputDisabled || disabled}

--- a/tests/Pagination/Pagination.test.svelte
+++ b/tests/Pagination/Pagination.test.svelte
@@ -19,6 +19,8 @@
   export let pageText: ComponentProps<Pagination>["pageText"] = undefined;
   export let pageRangeText: ComponentProps<Pagination>["pageRangeText"] =
     undefined;
+  export let pageSelectLabelText: ComponentProps<Pagination>["pageSelectLabelText"] =
+    undefined;
   export let itemRangeText: ComponentProps<Pagination>["itemRangeText"] =
     undefined;
   export let id: ComponentProps<Pagination>["id"] = undefined;
@@ -47,6 +49,7 @@
   {pagesUnknown}
   {pageText}
   {pageRangeText}
+  {pageSelectLabelText}
   {itemRangeText}
   {id}
   {size}

--- a/tests/Pagination/Pagination.test.ts
+++ b/tests/Pagination/Pagination.test.ts
@@ -470,6 +470,21 @@ describe("Pagination", () => {
     expect(screen.getByText(/1 of 10000/)).toBeInTheDocument();
   });
 
+  it("handles custom page select label text", () => {
+    const props = {
+      totalItems: 40,
+      pageSizes: [10, 20],
+      pageSize: 10,
+      page: 2,
+      pageSelectLabelText: (total: number) =>
+        `Página de ${total} ${total === 1 ? "página" : "páginas"}`,
+    } satisfies ComponentProps<Pagination>;
+
+    render(Pagination, { props });
+
+    expect(screen.getByLabelText("Página de 4 páginas")).toBeInTheDocument();
+  });
+
   it("handles custom item range text", () => {
     const props = {
       totalItems: 100_000,


### PR DESCRIPTION
Found while auditing Carbon React's commit history for parity fixes not
yet ported here. Split out of #3691 as a standalone change.

The page-number select's accessible label was hardcoded, with no way
to translate or customize it, unlike every other Pagination text prop.
Matches Carbon React's `pageSelectLabelText` prop (default text
unchanged, so this is non-breaking).