### PR TITLE
fix(pagination): add backward/forwardTextTooltipPosition props

### DIFF
--- a/src/Pagination/Pagination.svelte
+++ b/src/Pagination/Pagination.svelte
@@ -45,8 +45,20 @@
   /** Specify the forward button text */
   export let forwardText = "Next page";
 
+  /**
+   * Specify the tooltip position for the forward button.
+   * @type {"top" | "right" | "bottom" | "left"}
+   */
+  export let forwardTextTooltipPosition = "top";
+
   /** Specify the backward button text */
   export let backwardText = "Previous page";
+
+  /**
+   * Specify the tooltip position for the backward button.
+   * @type {"top" | "right" | "bottom" | "left"}
+   */
+  export let backwardTextTooltipPosition = "top";
 
   /** Specify the items per page text */
   export let itemsPerPageText = "Items per page:";
@@ -333,7 +345,7 @@
       bind:ref={backBtnRef}
       kind="ghost"
       tooltipAlignment="center"
-      tooltipPosition="top"
+      tooltipPosition={backwardTextTooltipPosition}
       portalTooltip
       icon={CaretLeft}
       iconDescription={backwardText}
@@ -352,7 +364,7 @@
       bind:ref={forwardBtnRef}
       kind="ghost"
       tooltipAlignment="end"
-      tooltipPosition="top"
+      tooltipPosition={forwardTextTooltipPosition}
       portalTooltip
       icon={CaretRight}
       iconDescription={forwardText}

--- a/tests/Pagination/Pagination.test.svelte
+++ b/tests/Pagination/Pagination.test.svelte
@@ -7,6 +7,10 @@
   export let disabled = false;
   export let forwardText = "Next page";
   export let backwardText = "Previous page";
+  export let backwardTextTooltipPosition: ComponentProps<Pagination>["backwardTextTooltipPosition"] =
+    undefined;
+  export let forwardTextTooltipPosition: ComponentProps<Pagination>["forwardTextTooltipPosition"] =
+    undefined;
   export let itemsPerPageText = "Items per page:";
   export let pageInputDisabled = false;
   export let pageSizeInputDisabled = false;
@@ -36,6 +40,8 @@
   {disabled}
   {forwardText}
   {backwardText}
+  {backwardTextTooltipPosition}
+  {forwardTextTooltipPosition}
   {itemsPerPageText}
   {pageInputDisabled}
   {pageSizeInputDisabled}

--- a/tests/Pagination/Pagination.test.ts
+++ b/tests/Pagination/Pagination.test.ts
@@ -1,4 +1,4 @@
-import { render, screen, within } from "@testing-library/svelte";
+import { fireEvent, render, screen, within } from "@testing-library/svelte";
 import type { ComponentProps } from "svelte";
 import { user } from "../utils/user";
 import Pagination from "./Pagination.test.svelte";
@@ -480,6 +480,67 @@ describe("Pagination", () => {
     render(Pagination, { props });
 
     expect(screen.getByText(/1–10 of 100000/)).toBeInTheDocument();
+  });
+
+  describe("nav button tooltip position", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("defaults nav button tooltips to the top position", async () => {
+      render(Pagination, { props: { totalItems: 102, page: 2 } });
+
+      const prevButton = screen.getByRole("button", { name: "Previous page" });
+      await fireEvent.mouseEnter(prevButton);
+      await vi.advanceTimersByTimeAsync(100);
+      expect(document.querySelector("[data-direction]")).toHaveAttribute(
+        "data-direction",
+        "top",
+      );
+      await fireEvent.mouseLeave(prevButton);
+      await vi.advanceTimersByTimeAsync(300);
+
+      const nextButton = screen.getByRole("button", { name: "Next page" });
+      await fireEvent.mouseEnter(nextButton);
+      await vi.advanceTimersByTimeAsync(100);
+      expect(document.querySelector("[data-direction]")).toHaveAttribute(
+        "data-direction",
+        "top",
+      );
+    });
+
+    it("allows overriding the backward and forward tooltip positions independently", async () => {
+      render(Pagination, {
+        props: {
+          totalItems: 102,
+          page: 2,
+          backwardTextTooltipPosition: "bottom",
+          forwardTextTooltipPosition: "right",
+        },
+      });
+
+      const prevButton = screen.getByRole("button", { name: "Previous page" });
+      await fireEvent.mouseEnter(prevButton);
+      await vi.advanceTimersByTimeAsync(100);
+      expect(document.querySelector("[data-direction]")).toHaveAttribute(
+        "data-direction",
+        "bottom",
+      );
+      await fireEvent.mouseLeave(prevButton);
+      await vi.advanceTimersByTimeAsync(300);
+
+      const nextButton = screen.getByRole("button", { name: "Next page" });
+      await fireEvent.mouseEnter(nextButton);
+      await vi.advanceTimersByTimeAsync(100);
+      expect(document.querySelector("[data-direction]")).toHaveAttribute(
+        "data-direction",
+        "right",
+      );
+    });
   });
 
   it("should dispatch change event with new value, not previous value", async () => {


### PR DESCRIPTION
Found while auditing Carbon React's commit history for parity fixes not
yet ported here. Split out of #3691 as a standalone change.

The nav button tooltip position was hardcoded to `top`, with no way to
flip it for pagination controls anchored near a viewport edge. Matches
Carbon React's `backwardTextTooltipPosition`/`forwardTextTooltipPosition`
props (default unchanged, so this is non-breaking).