### PR TITLE
feat(structured-list): support `sortable` columns

### DIFF
--- a/css/_structured-list-sort.scss
+++ b/css/_structured-list-sort.scss
@@ -7,11 +7,18 @@
 // place of its plain header markup when `sortable` is set.
 //
 // The click/hover/focus target is the button, so it needs to fill the full
-// header cell -- not just wrap its text. Rather than stretch the button to
-// 100% width/height of a still-padded cell (percentage heights inside a
-// content-sized table-cell are unreliable), the cell's own padding is zeroed
-// and the same padding values move onto the button. The button's padding box
-// then *is* the cell's visual box, sized by ordinary content flow.
+// header cell -- not just wrap its text. The cell's own padding is zeroed
+// and the same values move onto the button, so the button's padding box
+// covers what used to be dead (unclickable) padding space around the text.
+//
+// That alone sizes the button correctly under normal conditions, since the
+// moved padding sums to the same total the cell used to reserve. It falls
+// short under `--condensed`: Carbon's `.bx--structured-list-th` carries an
+// unconditional `height: to-rem(40px)` that the condensed variant's shrunk
+// padding no longer reaches, so the cell renders taller than the button's
+// own content. `height: 100%` on the button closes that gap -- percentage
+// heights resolve reliably against a table-cell's final row height, fixed
+// or content-driven, so this works regardless of which one produced it.
 /// @access private
 /// @group components
 @mixin structured-list-sort {
@@ -22,6 +29,7 @@
   .#{$prefix}--structured-list-sort {
     display: flex;
     width: 100%;
+    height: 100%;
     align-items: center;
     gap: $carbon--spacing-03;
     padding: $carbon--spacing-05 $carbon--spacing-03 $carbon--spacing-03

--- a/css/_structured-list-sort.scss
+++ b/css/_structured-list-sort.scss
@@ -1,0 +1,131 @@
+@import "carbon-components/scss/globals/scss/vars";
+@import "carbon-components/scss/globals/scss/helper-mixins";
+@import "carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/import-once/import-once";
+
+// Carbon does not ship a sortable structured list upstream (sorting is a
+// DataTable-only feature there). `StructuredListCell` renders this button in
+// place of its plain header markup when `sortable` is set.
+//
+// The click/hover/focus target is the button, so it needs to fill the full
+// header cell -- not just wrap its text. Rather than stretch the button to
+// 100% width/height of a still-padded cell (percentage heights inside a
+// content-sized table-cell are unreliable), the cell's own padding is zeroed
+// and the same padding values move onto the button. The button's padding box
+// then *is* the cell's visual box, sized by ordinary content flow.
+/// @access private
+/// @group components
+@mixin structured-list-sort {
+  .#{$prefix}--structured-list-th--sortable {
+    padding: 0;
+  }
+
+  .#{$prefix}--structured-list-sort {
+    display: flex;
+    width: 100%;
+    align-items: center;
+    gap: $carbon--spacing-03;
+    padding: $carbon--spacing-05 $carbon--spacing-03 $carbon--spacing-03
+      $carbon--spacing-03;
+    border: none;
+    background: none;
+    color: inherit;
+    font: inherit;
+    text-align: left;
+    cursor: pointer;
+  }
+
+  // Matches the `:first-of-type` inset every other header/body cell gets
+  // (see `_structured-list.scss`), moved from the cell onto the button so
+  // the extra space stays part of the clickable target. That base rule is
+  // nested under `.bx--structured-list`, so the override needs the same
+  // ancestor to match its specificity -- a bare `.bx--structured-list-row
+  // .bx--structured-list-th--sortable:first-of-type` loses the tie and the
+  // cell keeps its own 1rem inset alongside the button's.
+  .#{$prefix}--structured-list
+    .#{$prefix}--structured-list-row
+    .#{$prefix}--structured-list-th--sortable:first-of-type {
+    padding-left: 0;
+  }
+
+  .#{$prefix}--structured-list-row
+    .#{$prefix}--structured-list-th--sortable:first-of-type
+    .#{$prefix}--structured-list-sort {
+    padding-left: 1rem;
+  }
+
+  // Same specificity concern for the condensed and flush variants: their
+  // cell padding rules are nested under `.bx--structured-list` too.
+  .#{$prefix}--structured-list.#{$prefix}--structured-list--condensed
+    .#{$prefix}--structured-list-th--sortable {
+    padding: 0;
+  }
+
+  .#{$prefix}--structured-list.#{$prefix}--structured-list--condensed
+    .#{$prefix}--structured-list-sort {
+    padding: $structured-list-padding * 0.25;
+  }
+
+  .#{$prefix}--structured-list.#{$prefix}--structured-list--flush
+    .#{$prefix}--structured-list-row
+    .#{$prefix}--structured-list-th--sortable,
+  .#{$prefix}--structured-list.#{$prefix}--structured-list--flush
+    .#{$prefix}--structured-list-row
+    .#{$prefix}--structured-list-th--sortable:first-of-type {
+    padding: 0;
+  }
+
+  .#{$prefix}--structured-list.#{$prefix}--structured-list--flush
+    .#{$prefix}--structured-list-row
+    .#{$prefix}--structured-list-sort {
+    padding-right: 1rem;
+    padding-left: 0;
+  }
+
+  .#{$prefix}--structured-list-sort:hover,
+  .#{$prefix}--structured-list-sort.#{$prefix}--structured-list-sort--active {
+    color: $text-01;
+  }
+
+  .#{$prefix}--structured-list-sort:focus {
+    @include focus-outline("outline");
+    outline-offset: -2px;
+  }
+
+  .#{$prefix}--structured-list-sort__icon-unsorted {
+    fill: $icon-01;
+    opacity: 0;
+  }
+
+  .#{$prefix}--structured-list-sort:hover
+    .#{$prefix}--structured-list-sort__icon-unsorted,
+  .#{$prefix}--structured-list-sort:focus
+    .#{$prefix}--structured-list-sort__icon-unsorted {
+    opacity: 0.6;
+  }
+
+  .#{$prefix}--structured-list-sort__icon {
+    display: none;
+    fill: $icon-01;
+    transform: rotate(0);
+    transition: transform $duration--fast-02 motion(standard, productive);
+  }
+
+  .#{$prefix}--structured-list-sort--active
+    .#{$prefix}--structured-list-sort__icon {
+    display: block;
+  }
+
+  .#{$prefix}--structured-list-sort--active
+    .#{$prefix}--structured-list-sort__icon-unsorted {
+    display: none;
+  }
+
+  .#{$prefix}--structured-list-sort--ascending
+    .#{$prefix}--structured-list-sort__icon {
+    transform: rotate(180deg);
+  }
+}
+
+@include exports("structured-list-sort") {
+  @include structured-list-sort;
+}

--- a/css/all.scss
+++ b/css/all.scss
@@ -127,3 +127,4 @@ $css--plex: true;
 @import "./user-avatar";
 @import "./user-avatar-group";
 @import "./disclosure";
+@import "./structured-list-sort";

--- a/css/all.scss
+++ b/css/all.scss
@@ -129,3 +129,4 @@ $css--plex: true;
 @import "./user-avatar-group";
 @import "./disclosure";
 @import "./list-box-wrap-options";
+@import "./structured-list-sort";

--- a/css/g10.scss
+++ b/css/g10.scss
@@ -87,3 +87,4 @@ $css--plex: true;
 @import "./user-avatar";
 @import "./user-avatar-group";
 @import "./disclosure";
+@import "./structured-list-sort";

--- a/css/g10.scss
+++ b/css/g10.scss
@@ -89,3 +89,4 @@ $css--plex: true;
 @import "./user-avatar-group";
 @import "./disclosure";
 @import "./list-box-wrap-options";
+@import "./structured-list-sort";

--- a/css/g100.scss
+++ b/css/g100.scss
@@ -87,3 +87,4 @@ $css--plex: true;
 @import "./user-avatar";
 @import "./user-avatar-group";
 @import "./disclosure";
+@import "./structured-list-sort";

--- a/css/g100.scss
+++ b/css/g100.scss
@@ -89,3 +89,4 @@ $css--plex: true;
 @import "./user-avatar-group";
 @import "./disclosure";
 @import "./list-box-wrap-options";
+@import "./structured-list-sort";

--- a/css/g80.scss
+++ b/css/g80.scss
@@ -87,3 +87,4 @@ $css--plex: true;
 @import "./user-avatar";
 @import "./user-avatar-group";
 @import "./disclosure";
+@import "./structured-list-sort";

--- a/css/g80.scss
+++ b/css/g80.scss
@@ -89,3 +89,4 @@ $css--plex: true;
 @import "./user-avatar-group";
 @import "./disclosure";
 @import "./list-box-wrap-options";
+@import "./structured-list-sort";

--- a/css/g90.scss
+++ b/css/g90.scss
@@ -87,3 +87,4 @@ $css--plex: true;
 @import "./user-avatar";
 @import "./user-avatar-group";
 @import "./disclosure";
+@import "./structured-list-sort";

--- a/css/g90.scss
+++ b/css/g90.scss
@@ -89,3 +89,4 @@ $css--plex: true;
 @import "./user-avatar-group";
 @import "./disclosure";
 @import "./list-box-wrap-options";
+@import "./structured-list-sort";

--- a/css/white.scss
+++ b/css/white.scss
@@ -87,3 +87,4 @@ $css--plex: true;
 @import "./user-avatar";
 @import "./user-avatar-group";
 @import "./disclosure";
+@import "./structured-list-sort";

--- a/css/white.scss
+++ b/css/white.scss
@@ -89,3 +89,4 @@ $css--plex: true;
 @import "./user-avatar-group";
 @import "./disclosure";
 @import "./list-box-wrap-options";
+@import "./structured-list-sort";

--- a/docs/src/pages/component-index.svelte
+++ b/docs/src/pages/component-index.svelte
@@ -18,9 +18,6 @@
     Tag,
     Text,
   } from "carbon-components-svelte";
-  import ArrowDown from "carbon-icons-svelte/lib/ArrowDown.svelte";
-  import ArrowsVertical from "carbon-icons-svelte/lib/ArrowsVertical.svelte";
-  import ArrowUp from "carbon-icons-svelte/lib/ArrowUp.svelte";
   import Catalog from "carbon-icons-svelte/lib/Catalog.svelte";
   import { onMount } from "svelte";
   import { COMPONENT_CATEGORIES } from "../component-categories";
@@ -153,9 +150,9 @@
     since: "desc",
   };
 
-  function toggleSort(key: SortKey) {
+  function handleSort(key: SortKey, direction: "ascending" | "descending") {
     if (sortKey === key) {
-      sortDirection = sortDirection === "asc" ? "desc" : "asc";
+      sortDirection = direction === "ascending" ? "asc" : "desc";
     } else {
       sortKey = key;
       sortDirection = defaultDirection[key];
@@ -227,35 +224,17 @@
                   {#each columns as column (column.key)}
                     <StructuredListCell
                       head
-                      aria-sort={sortKey === column.key
-                      ? sortDirection === "asc"
-                        ? "ascending"
-                        : "descending"
-                      : "none"}
+                      sortable
+                      sortAlways
+                      active={sortKey === column.key}
+                      sortDirection={sortDirection === "asc"
+                      ? "ascending"
+                      : "descending"}
+                      on:sort={(e) => handleSort(column.key, e.detail.direction)}
                     >
-                      <button
-                        type="button"
-                        class="sort-header"
-                        class:is-active={sortKey === column.key}
-                        on:click={() => toggleSort(column.key)}
-                      >
-                        <span class="sort-header__title">
-                          {column.key === "name"
-                          ? `Component (${visible.length})`
-                          : column.label}
-                          {#if sortKey === column.key}
-                            <svelte:component
-                              this={sortDirection === "asc" ? ArrowUp : ArrowDown}
-                              size={16}
-                            />
-                          {:else}
-                            <ArrowsVertical
-                              size={16}
-                              class="sort-header__idle-icon"
-                            />
-                          {/if}
-                        </span>
-                      </button>
+                      {column.key === "name"
+                      ? `Component (${visible.length})`
+                      : column.label}
                     </StructuredListCell>
                   {/each}
                   <StructuredListCell head class="links-cell" />
@@ -418,45 +397,6 @@
 
   :global(.links-cell) {
     text-align: right;
-  }
-
-  .sort-header {
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-    width: 100%;
-    padding: 0;
-    border: none;
-    background: none;
-    cursor: pointer;
-    color: var(--cds-text-02, #525252);
-    font: inherit;
-    text-align: left;
-  }
-
-  .sort-header__title {
-    display: inline-flex;
-    align-items: center;
-    gap: var(--cds-spacing-03);
-  }
-
-  .sort-header:hover,
-  .sort-header.is-active {
-    color: var(--cds-text-01, #161616);
-  }
-
-  .sort-header:focus-visible {
-    outline: 2px solid var(--cds-focus, #0f62fe);
-    outline-offset: -2px;
-  }
-
-  .sort-header :global(.sort-header__idle-icon) {
-    opacity: 0;
-    transition: opacity 70ms;
-  }
-
-  .sort-header:hover :global(.sort-header__idle-icon) {
-    opacity: 0.6;
   }
 
   :global(.component-name-cell) {

--- a/docs/src/pages/components/StructuredList.svx
+++ b/docs/src/pages/components/StructuredList.svx
@@ -190,6 +190,46 @@ Allow selecting more than one row with `multiple`. Selected becomes an array of 
 
 <FileSource src="/framed/StructuredList/StructuredListMultiSelect" />
 
+## Sorting
+
+Let users sort rows by a column.
+
+### Basic
+
+Set `sortable` on a header `StructuredListCell` and listen for `sort` to update the active column and direction. Set `active` and `sortDirection` to reflect the current state; the header renders `aria-sort` from these props.
+
+<FileSource src="/framed/StructuredList/StructuredListSortable" />
+
+### Initial sort
+
+Set `active` and `sortDirection` to their sorted values up front to start the table pre-sorted, without waiting for a click.
+
+<FileSource src="/framed/StructuredList/StructuredListSortableInitial" />
+
+### Always sorted
+
+Set `sortAlways` to skip the unsorted state and toggle only between ascending and descending.
+
+<FileSource src="/framed/StructuredList/StructuredListSortableAlways" />
+
+### One sortable column
+
+Omit `sortable` on any header cell to exclude that column from sorting.
+
+<FileSource src="/framed/StructuredList/StructuredListSortableSingleColumn" />
+
+### Condensed
+
+Combine `sortable` with `condensed` for compact sortable headers.
+
+<FileSource src="/framed/StructuredList/StructuredListSortableCondensed" />
+
+### With selection
+
+Combine `sortable` header cells with `selection` to let users sort and select rows in the same list.
+
+<FileSource src="/framed/StructuredList/StructuredListSortableSelection" />
+
 ## Events
 
 ### Selection change

--- a/docs/src/pages/components/StructuredList.svx
+++ b/docs/src/pages/components/StructuredList.svx
@@ -188,6 +188,46 @@ Allow selecting more than one row with `multiple`. Selected becomes an array of 
 
 <FileSource src="/framed/StructuredList/StructuredListMultiSelect" />
 
+## Sorting
+
+Let users sort rows by a column.
+
+### Basic
+
+Set `sortable` on a header `StructuredListCell` and listen for `sort` to update the active column and direction. Set `active` and `sortDirection` to reflect the current state; the header renders `aria-sort` from these props.
+
+<FileSource src="/framed/StructuredList/StructuredListSortable" />
+
+### Initial sort
+
+Set `active` and `sortDirection` to their sorted values up front to start the table pre-sorted, without waiting for a click.
+
+<FileSource src="/framed/StructuredList/StructuredListSortableInitial" />
+
+### Always sorted
+
+Set `sortAlways` to skip the unsorted state and toggle only between ascending and descending.
+
+<FileSource src="/framed/StructuredList/StructuredListSortableAlways" />
+
+### One sortable column
+
+Omit `sortable` on any header cell to exclude that column from sorting.
+
+<FileSource src="/framed/StructuredList/StructuredListSortableSingleColumn" />
+
+### Condensed
+
+Combine `sortable` with `condensed` for compact sortable headers.
+
+<FileSource src="/framed/StructuredList/StructuredListSortableCondensed" />
+
+### With selection
+
+Combine `sortable` header cells with `selection` to let users sort and select rows in the same list.
+
+<FileSource src="/framed/StructuredList/StructuredListSortableSelection" />
+
 ## Skeleton
 
 Show a loading state with the skeleton variant.

--- a/docs/src/pages/framed/StructuredList/StructuredListSortable.svelte
+++ b/docs/src/pages/framed/StructuredList/StructuredListSortable.svelte
@@ -1,0 +1,76 @@
+<script>
+  import {
+    StructuredList,
+    StructuredListBody,
+    StructuredListCell,
+    StructuredListHead,
+    StructuredListRow,
+  } from "carbon-components-svelte";
+
+  const databases = [
+    {
+      name: "PostgreSQL",
+      type: "Relational",
+      version: "16.2",
+    },
+    {
+      name: "MongoDB",
+      type: "Document",
+      version: "7.0",
+    },
+    {
+      name: "Redis",
+      type: "Key-value",
+      version: "7.2",
+    },
+  ];
+
+  const columns = [
+    { key: "name", label: "Name" },
+    { key: "type", label: "Type" },
+    { key: "version", label: "Latest version" },
+  ];
+
+  let sortKey = null;
+  let sortDirection = "none";
+
+  function handleSort(key, direction) {
+    sortDirection = direction;
+    sortKey = direction === "none" ? null : key;
+  }
+
+  $: sorted =
+    sortKey === null
+      ? databases
+      : [...databases].sort((a, b) => {
+          const result = a[sortKey].localeCompare(b[sortKey]);
+          return sortDirection === "ascending" ? result : -result;
+        });
+</script>
+
+<StructuredList>
+  <StructuredListHead>
+    <StructuredListRow head>
+      {#each columns as column}
+        <StructuredListCell
+          head
+          sortable
+          active={sortKey === column.key}
+          sortDirection={sortKey === column.key ? sortDirection : "none"}
+          on:sort={(e) => handleSort(column.key, e.detail.direction)}
+        >
+          {column.label}
+        </StructuredListCell>
+      {/each}
+    </StructuredListRow>
+  </StructuredListHead>
+  <StructuredListBody>
+    {#each sorted as db (db.name)}
+      <StructuredListRow>
+        <StructuredListCell>{db.name}</StructuredListCell>
+        <StructuredListCell>{db.type}</StructuredListCell>
+        <StructuredListCell>{db.version}</StructuredListCell>
+      </StructuredListRow>
+    {/each}
+  </StructuredListBody>
+</StructuredList>

--- a/docs/src/pages/framed/StructuredList/StructuredListSortableAlways.svelte
+++ b/docs/src/pages/framed/StructuredList/StructuredListSortableAlways.svelte
@@ -1,0 +1,74 @@
+<script>
+  import {
+    StructuredList,
+    StructuredListBody,
+    StructuredListCell,
+    StructuredListHead,
+    StructuredListRow,
+  } from "carbon-components-svelte";
+
+  const databases = [
+    {
+      name: "PostgreSQL",
+      type: "Relational",
+      version: "16.2",
+    },
+    {
+      name: "MongoDB",
+      type: "Document",
+      version: "7.0",
+    },
+    {
+      name: "Redis",
+      type: "Key-value",
+      version: "7.2",
+    },
+  ];
+
+  const columns = [
+    { key: "name", label: "Name" },
+    { key: "type", label: "Type" },
+    { key: "version", label: "Latest version" },
+  ];
+
+  let sortKey = "name";
+  let sortDirection = "ascending";
+
+  function handleSort(key, direction) {
+    sortDirection = direction;
+    sortKey = key;
+  }
+
+  $: sorted = [...databases].sort((a, b) => {
+    const result = a[sortKey].localeCompare(b[sortKey]);
+    return sortDirection === "ascending" ? result : -result;
+  });
+</script>
+
+<StructuredList>
+  <StructuredListHead>
+    <StructuredListRow head>
+      {#each columns as column}
+        <StructuredListCell
+          head
+          sortable
+          sortAlways
+          active={sortKey === column.key}
+          sortDirection={sortKey === column.key ? sortDirection : "none"}
+          on:sort={(e) => handleSort(column.key, e.detail.direction)}
+        >
+          {column.label}
+        </StructuredListCell>
+      {/each}
+    </StructuredListRow>
+  </StructuredListHead>
+  <StructuredListBody>
+    {#each sorted as db (db.name)}
+      <StructuredListRow>
+        <StructuredListCell>{db.name}</StructuredListCell>
+        <StructuredListCell>{db.type}</StructuredListCell>
+        <StructuredListCell>{db.version}</StructuredListCell>
+      </StructuredListRow>
+    {/each}
+  </StructuredListBody>
+</StructuredList>

--- a/docs/src/pages/framed/StructuredList/StructuredListSortableCondensed.svelte
+++ b/docs/src/pages/framed/StructuredList/StructuredListSortableCondensed.svelte
@@ -1,0 +1,76 @@
+<script>
+  import {
+    StructuredList,
+    StructuredListBody,
+    StructuredListCell,
+    StructuredListHead,
+    StructuredListRow,
+  } from "carbon-components-svelte";
+
+  const databases = [
+    {
+      name: "PostgreSQL",
+      type: "Relational",
+      version: "16.2",
+    },
+    {
+      name: "MongoDB",
+      type: "Document",
+      version: "7.0",
+    },
+    {
+      name: "Redis",
+      type: "Key-value",
+      version: "7.2",
+    },
+  ];
+
+  const columns = [
+    { key: "name", label: "Name" },
+    { key: "type", label: "Type" },
+    { key: "version", label: "Latest version" },
+  ];
+
+  let sortKey = null;
+  let sortDirection = "none";
+
+  function handleSort(key, direction) {
+    sortDirection = direction;
+    sortKey = direction === "none" ? null : key;
+  }
+
+  $: sorted =
+    sortKey === null
+      ? databases
+      : [...databases].sort((a, b) => {
+          const result = a[sortKey].localeCompare(b[sortKey]);
+          return sortDirection === "ascending" ? result : -result;
+        });
+</script>
+
+<StructuredList condensed>
+  <StructuredListHead>
+    <StructuredListRow head>
+      {#each columns as column}
+        <StructuredListCell
+          head
+          sortable
+          active={sortKey === column.key}
+          sortDirection={sortKey === column.key ? sortDirection : "none"}
+          on:sort={(e) => handleSort(column.key, e.detail.direction)}
+        >
+          {column.label}
+        </StructuredListCell>
+      {/each}
+    </StructuredListRow>
+  </StructuredListHead>
+  <StructuredListBody>
+    {#each sorted as db (db.name)}
+      <StructuredListRow>
+        <StructuredListCell>{db.name}</StructuredListCell>
+        <StructuredListCell>{db.type}</StructuredListCell>
+        <StructuredListCell>{db.version}</StructuredListCell>
+      </StructuredListRow>
+    {/each}
+  </StructuredListBody>
+</StructuredList>

--- a/docs/src/pages/framed/StructuredList/StructuredListSortableInitial.svelte
+++ b/docs/src/pages/framed/StructuredList/StructuredListSortableInitial.svelte
@@ -1,0 +1,76 @@
+<script>
+  import {
+    StructuredList,
+    StructuredListBody,
+    StructuredListCell,
+    StructuredListHead,
+    StructuredListRow,
+  } from "carbon-components-svelte";
+
+  const databases = [
+    {
+      name: "PostgreSQL",
+      type: "Relational",
+      version: "16.2",
+    },
+    {
+      name: "MongoDB",
+      type: "Document",
+      version: "7.0",
+    },
+    {
+      name: "Redis",
+      type: "Key-value",
+      version: "7.2",
+    },
+  ];
+
+  const columns = [
+    { key: "name", label: "Name" },
+    { key: "type", label: "Type" },
+    { key: "version", label: "Latest version" },
+  ];
+
+  let sortKey = "version";
+  let sortDirection = "descending";
+
+  function handleSort(key, direction) {
+    sortDirection = direction;
+    sortKey = direction === "none" ? null : key;
+  }
+
+  $: sorted =
+    sortKey === null
+      ? databases
+      : [...databases].sort((a, b) => {
+          const result = a[sortKey].localeCompare(b[sortKey]);
+          return sortDirection === "ascending" ? result : -result;
+        });
+</script>
+
+<StructuredList>
+  <StructuredListHead>
+    <StructuredListRow head>
+      {#each columns as column}
+        <StructuredListCell
+          head
+          sortable
+          active={sortKey === column.key}
+          sortDirection={sortKey === column.key ? sortDirection : "none"}
+          on:sort={(e) => handleSort(column.key, e.detail.direction)}
+        >
+          {column.label}
+        </StructuredListCell>
+      {/each}
+    </StructuredListRow>
+  </StructuredListHead>
+  <StructuredListBody>
+    {#each sorted as db (db.name)}
+      <StructuredListRow>
+        <StructuredListCell>{db.name}</StructuredListCell>
+        <StructuredListCell>{db.type}</StructuredListCell>
+        <StructuredListCell>{db.version}</StructuredListCell>
+      </StructuredListRow>
+    {/each}
+  </StructuredListBody>
+</StructuredList>

--- a/docs/src/pages/framed/StructuredList/StructuredListSortableSelection.svelte
+++ b/docs/src/pages/framed/StructuredList/StructuredListSortableSelection.svelte
@@ -1,0 +1,87 @@
+<script>
+  import {
+    StructuredList,
+    StructuredListBody,
+    StructuredListCell,
+    StructuredListHead,
+    StructuredListInput,
+    StructuredListRow,
+  } from "carbon-components-svelte";
+
+  const databases = [
+    {
+      id: "postgresql",
+      name: "PostgreSQL",
+      type: "Relational",
+      version: "16.2",
+    },
+    {
+      id: "mongodb",
+      name: "MongoDB",
+      type: "Document",
+      version: "7.0",
+    },
+    {
+      id: "redis",
+      name: "Redis",
+      type: "Key-value",
+      version: "7.2",
+    },
+  ];
+
+  const columns = [
+    { key: "name", label: "Name" },
+    { key: "type", label: "Type" },
+    { key: "version", label: "Latest version" },
+  ];
+
+  let sortKey = null;
+  let sortDirection = "none";
+  let selected = "postgresql-value";
+
+  function handleSort(key, direction) {
+    sortDirection = direction;
+    sortKey = direction === "none" ? null : key;
+  }
+
+  $: sorted =
+    sortKey === null
+      ? databases
+      : [...databases].sort((a, b) => {
+          const result = a[sortKey].localeCompare(b[sortKey]);
+          return sortDirection === "ascending" ? result : -result;
+        });
+</script>
+
+<StructuredList selection bind:selected>
+  <StructuredListHead>
+    <StructuredListRow head>
+      {#each columns as column}
+        <StructuredListCell
+          head
+          sortable
+          active={sortKey === column.key}
+          sortDirection={sortKey === column.key ? sortDirection : "none"}
+          on:sort={(e) => handleSort(column.key, e.detail.direction)}
+        >
+          {column.label}
+        </StructuredListCell>
+      {/each}
+    </StructuredListRow>
+  </StructuredListHead>
+  <StructuredListBody>
+    {#each sorted as db (db.name)}
+      <StructuredListRow label for={db.id}>
+        <StructuredListCell>{db.name}</StructuredListCell>
+        <StructuredListCell>{db.type}</StructuredListCell>
+        <StructuredListCell>{db.version}</StructuredListCell>
+        <StructuredListInput
+          id={db.id}
+          value="{db.id}-value"
+          title="{db.name} option"
+          name="database"
+        />
+      </StructuredListRow>
+    {/each}
+  </StructuredListBody>
+</StructuredList>

--- a/docs/src/pages/framed/StructuredList/StructuredListSortableSingleColumn.svelte
+++ b/docs/src/pages/framed/StructuredList/StructuredListSortableSingleColumn.svelte
@@ -1,0 +1,68 @@
+<script>
+  import {
+    StructuredList,
+    StructuredListBody,
+    StructuredListCell,
+    StructuredListHead,
+    StructuredListRow,
+  } from "carbon-components-svelte";
+
+  const databases = [
+    {
+      name: "PostgreSQL",
+      type: "Relational",
+      version: "16.2",
+    },
+    {
+      name: "MongoDB",
+      type: "Document",
+      version: "7.0",
+    },
+    {
+      name: "Redis",
+      type: "Key-value",
+      version: "7.2",
+    },
+  ];
+
+  let sortDirection = "none";
+
+  function handleSort(direction) {
+    sortDirection = direction;
+  }
+
+  $: sorted =
+    sortDirection === "none"
+      ? databases
+      : [...databases].sort((a, b) => {
+          const result = a.name.localeCompare(b.name);
+          return sortDirection === "ascending" ? result : -result;
+        });
+</script>
+
+<StructuredList>
+  <StructuredListHead>
+    <StructuredListRow head>
+      <StructuredListCell
+        head
+        sortable
+        active={sortDirection !== "none"}
+        {sortDirection}
+        on:sort={(e) => handleSort(e.detail.direction)}
+      >
+        Name
+      </StructuredListCell>
+      <StructuredListCell head>Type</StructuredListCell>
+      <StructuredListCell head>Latest version</StructuredListCell>
+    </StructuredListRow>
+  </StructuredListHead>
+  <StructuredListBody>
+    {#each sorted as db (db.name)}
+      <StructuredListRow>
+        <StructuredListCell>{db.name}</StructuredListCell>
+        <StructuredListCell>{db.type}</StructuredListCell>
+        <StructuredListCell>{db.version}</StructuredListCell>
+      </StructuredListRow>
+    {/each}
+  </StructuredListBody>
+</StructuredList>

--- a/src/StructuredList/StructuredListCell.svelte
+++ b/src/StructuredList/StructuredListCell.svelte
@@ -1,27 +1,139 @@
 <script>
+  /**
+   * @typedef {"columnSortAscending" | "columnSortDescending"} StructuredListCellTranslationId
+   */
+
+  /**
+   * @event {{ direction: "none" | "ascending" | "descending" }} sort - Dispatched when the sortable header button is clicked, with the next direction in the sort cycle.
+   */
+
   /** Set to `true` to use as a header */
   export let head = false;
 
   /** Set to `true` to prevent wrapping */
   export let noWrap = false;
 
-  import { getContext } from "svelte";
+  /**
+   * Set to `true` to render the header cell as a sortable column button.
+   * Only applies when `head` is `true`.
+   */
+  export let sortable = false;
+
+  /**
+   * Specify the sort direction.
+   * Only used when `sortable` is `true`.
+   * @type {"none" | "ascending" | "descending"}
+   */
+  export let sortDirection = "none";
+
+  /** Set to `true` when this column is the active sort key */
+  export let active = false;
+
+  /**
+   * Set to `true` to only toggle between "ascending" and "descending"
+   * sort directions, skipping "none", when computing the `sort` event.
+   * Only used when `sortable` is `true`.
+   */
+  export let sortAlways = false;
+
+  /** Default translation ids */
+  export const translationIds = {
+    columnSortAscending: "columnSortAscending",
+    columnSortDescending: "columnSortDescending",
+  };
+
+  /**
+   * Override the default translation ids.
+   * Only used when `sortable` is `true`.
+   * @type {(id: StructuredListCellTranslationId) => string}
+   */
+  export let translateWithId = (id) => defaultTranslations[id];
+
+  import { createEventDispatcher, getContext } from "svelte";
+  import ArrowsVertical from "../icons/ArrowsVertical.svelte";
+  import ArrowUp from "../icons/ArrowUp.svelte";
 
   const ctx = getContext("carbon:StructuredListWrapper");
   const selection = ctx?.selection ?? false;
+
+  const dispatch = createEventDispatcher();
+
+  const defaultTranslations = {
+    [translationIds.columnSortAscending]:
+      "Sort rows by this header in ascending order",
+    [translationIds.columnSortDescending]:
+      "Sort rows by this header in descending order",
+  };
+
+  $: translationId = active
+    ? sortDirection === "descending"
+      ? translationIds.columnSortAscending
+      : translationIds.columnSortDescending
+    : translationIds.columnSortAscending;
+  $: ariaLabel =
+    translateWithId?.(translationId) ?? defaultTranslations[translationId];
+
+  function handleSortClick() {
+    const currentDirection = active ? sortDirection : "none";
+    const nextDirection =
+      currentDirection === "none"
+        ? "ascending"
+        : currentDirection === "ascending"
+          ? "descending"
+          : sortAlways
+            ? "ascending"
+            : "none";
+    dispatch("sort", { direction: nextDirection });
+  }
 </script>
 
-<!-- svelte-ignore a11y-mouse-events-have-key-events -->
-<div
-  role={selection ? undefined : head ? "columnheader" : "cell"}
-  class:bx--structured-list-th={head}
-  class:bx--structured-list-td={!head}
-  class:bx--structured-list-content--nowrap={noWrap}
-  {...$$restProps}
-  on:click
-  on:mouseover
-  on:mouseenter
-  on:mouseleave
->
-  <slot />
-</div>
+{#if head && sortable}
+  <!-- svelte-ignore a11y-mouse-events-have-key-events -->
+  <div
+    role={selection ? undefined : "columnheader"}
+    aria-sort={active ? sortDirection : "none"}
+    class:bx--structured-list-th={true}
+    class:bx--structured-list-th--sortable={true}
+    {...$$restProps}
+    on:mouseover
+    on:mouseenter
+    on:mouseleave
+  >
+    <button
+      type="button"
+      class:bx--structured-list-sort={true}
+      class:bx--structured-list-sort--active={active}
+      class:bx--structured-list-sort--ascending={active &&
+        sortDirection === "descending"}
+      on:click
+      on:click={handleSortClick}
+    >
+      <slot />
+      <ArrowUp
+        size={16}
+        aria-label={ariaLabel}
+        class="bx--structured-list-sort__icon"
+      />
+      <ArrowsVertical
+        size={16}
+        aria-label={ariaLabel}
+        class="bx--structured-list-sort__icon-unsorted"
+      />
+    </button>
+  </div>
+{:else}
+  <!-- svelte-ignore a11y-mouse-events-have-key-events -->
+  <div
+    role={selection ? undefined : head ? "columnheader" : "cell"}
+    class:bx--structured-list-th={head}
+    class:bx--structured-list-td={!head}
+    class:bx--structured-list-content--nowrap={noWrap}
+    {...$$restProps}
+    on:click
+    on:mouseover
+    on:mouseenter
+    on:mouseleave
+  >
+    <slot />
+  </div>
+{/if}


### PR DESCRIPTION
Mirrors DataTable's TableHeader API (`sort` event, `sortAlways`,
`active`, `sortDirection`) so the two components stay consistent. Also
fixes a condensed-header height bug and refactors the component index
page to use the new feature instead of its hand-rolled sort button.

---


https://github.com/user-attachments/assets/c6c9d741-f900-43a8-8c5a-303e3021fd1f

