### PR TITLE
docs(number-input): omit unnecessary props

### DIFF
--- a/docs/src/pages/components/Accordion.svx
+++ b/docs/src/pages/components/Accordion.svx
@@ -10,6 +10,7 @@ description: Accordions stack expandable sections vertically to show or hide con
     Stack,
     Text,
   } from "carbon-components-svelte";
+  import Notification from "carbon-icons-svelte/lib/Notification.svelte";
 </script>
 
 ## Basic
@@ -32,7 +33,12 @@ By default, the chevron icon is on the right side of the accordion item.
   </AccordionItem>
 </Accordion>
 
-## Left-aligned chevron
+## Layout
+
+Adjust chevron alignment and container spacing. The two interact: flush has
+no effect when the chevron is left-aligned.
+
+### Left-aligned chevron
 
 Align the chevron icon to the left side of the accordion item by setting `align` to `"start"`.
 
@@ -49,7 +55,7 @@ Align the chevron icon to the left side of the accordion item by setting `align`
   </AccordionItem>
 </Accordion>
 
-## Flush
+### Flush
 
 Set `flush` to remove the accordion's gutter, aligning it flush with the
 edges of its container. This works well in full-bleed layouts and side
@@ -68,7 +74,11 @@ panels. `flush` has no effect when `align` is `"start"`.
   </AccordionItem>
 </Accordion>
 
-## Custom title slot
+## Title
+
+Customize the item heading content and its accessible name.
+
+### Custom title slot
 
 Customize the title content with the title slot instead of the title prop for
 more complex layouts with multiple elements.
@@ -98,7 +108,27 @@ more complex layouts with multiple elements.
   </AccordionItem>
 </Accordion>
 
-## First item open
+### Accessible label
+
+Set `ariaLabel` to give the item's heading button an accessible name that's
+independent of its visible content. This matters when the title slot doesn't
+render readable text, such as an icon-only title, since screen readers would
+otherwise have nothing to announce for the control.
+
+<Accordion>
+  <AccordionItem ariaLabel="Notifications">
+    <svelte:fragment slot="title">
+      <Notification />
+    </svelte:fragment>
+    <p>You have no new notifications.</p>
+  </AccordionItem>
+</Accordion>
+
+## Open state
+
+Control which items are open by default, exclusively, or programmatically.
+
+### First item open
 
 Set `open` on an item to have it expanded by default when the
 accordion is first rendered.
@@ -116,7 +146,7 @@ accordion is first rendered.
   </AccordionItem>
 </Accordion>
 
-## Single-open
+### Single-open
 
 Set `type` to `"single"` so that opening an item automatically closes any
 other open item. This is useful for FAQs, step-by-step wizards, or settings
@@ -135,6 +165,13 @@ panels where only one section should be expanded at a time. The default is
     <p>Translate text, documents, and websites from one language to another. Create industry or region-specific translations via the service's customization capability.</p>
   </AccordionItem>
 </Accordion>
+
+### Programmatic example
+
+Programmatically control the accordion items with the `bind:open` directive,
+expanding and collapsing items based on user interactions or application state.
+
+<FileSource src="/framed/Accordion/ExpandableAccordion" />
 
 ## Nested
 
@@ -177,12 +214,25 @@ Nested items keep their own open state, independent of the parent.
   </AccordionItem>
 </Accordion>
 
-## Programmatic example
+## Lazy loading
 
-Programmatically control the accordion items with the `bind:open` directive,
-expanding and collapsing items based on user interactions or application state.
+Set `lazy` on an accordion item to defer mounting its panel content until the
+item first opens. Use it for panels with heavy content, such as API-fetched
+data or charts, so they mount only when needed. The content stays mounted
+after the item collapses.
 
-<FileSource src="/framed/Accordion/ExpandableAccordion" />
+<Accordion>
+  <AccordionItem lazy title="Natural Language Classifier">
+   <p>Natural Language Classifier uses advanced natural language processing and machine learning techniques to create custom classification models. Users train their data and the service predicts the appropriate category for the inputted text.
+   </p>
+  </AccordionItem>
+  <AccordionItem lazy title="Natural Language Understanding">
+    <p>Analyze text to extract meta-data from content such as concepts, entities, emotion, relations, sentiment and more.</p>
+  </AccordionItem>
+  <AccordionItem lazy title="Language Translator">
+    <p>Translate text, documents, and websites from one language to another. Create industry or region-specific translations via the service's customization capability.</p>
+  </AccordionItem>
+</Accordion>
 
 ## Sizes
 
@@ -312,25 +362,3 @@ Set `size` to `"sm"` for a small skeleton.
 Set `flush` to remove the skeleton's gutter, matching the flush variant.
 
 <Accordion skeleton flush />
-
-## Lazy loading
-
-Set `lazy` on an accordion item to defer mounting its panel content until the
-item first opens. Use it for panels with heavy content, such as API-fetched
-data or charts, so they mount only when needed. The content stays mounted
-after the item collapses.
-
-<Accordion>
-  <AccordionItem lazy title="Natural Language Classifier">
-   <p>Natural Language Classifier uses advanced natural language processing and machine learning techniques to create custom classification models. Users train their data and the service predicts the appropriate category for the inputted text.
-   </p>
-  </AccordionItem>
-  <AccordionItem lazy title="Natural Language Understanding">
-    <p>Analyze text to extract meta-data from content such as concepts, entities, emotion, relations, sentiment and more.</p>
-  </AccordionItem>
-  <AccordionItem lazy title="Language Translator">
-    <p>Translate text, documents, and websites from one language to another. Create industry or region-specific translations via the service's customization capability.</p>
-  </AccordionItem>
-</Accordion>
-
-

--- a/docs/src/pages/components/AspectRatio.svx
+++ b/docs/src/pages/components/AspectRatio.svx
@@ -8,7 +8,7 @@ description: Aspect ratios maintain consistent proportions for content like imag
 
 ## Basic
 
-Display a 2:1 aspect ratio container by default.
+Display a 2:1 aspect ratio container by default. The container fills the width of its parent, and its height is derived from the ratio.
 
 <AspectRatio>
   2x1
@@ -16,7 +16,7 @@ Display a 2:1 aspect ratio container by default.
 
 ## Ratios
 
-Supported aspect ratios include `2x1`, `2x3`, `16x9`, `4x3`, `1x1`, `3x4`, `3x2`, `9x16`, and `1x2`.
+Set `ratio` to change the aspect ratio. Supported values include `2x1`, `2x3`, `16x9`, `4x3`, `1x1`, `3x4`, `3x2`, `9x16`, and `1x2`.
 
 ### 2x3
 
@@ -82,10 +82,18 @@ Display content with a 1:2 aspect ratio.
   1x2
 </AspectRatio>
 
-## Tile (16x9)
+## Usage
 
-Wrap a tile or other content in an aspect ratio container to maintain proportions.
+Wrap content like tiles, images, or videos in an aspect ratio container to maintain consistent proportions across screen sizes.
+
+### Tile
+
+Wrap a tile or other content in an aspect ratio container to maintain proportions. Content that should fill the container, like a `Tile`, needs `height: 100%` since the container's own height is derived from padding rather than a fixed size.
 
 <AspectRatio ratio="16x9">
   <Tile style="height: 100%">Content</Tile>
 </AspectRatio>
+
+### Grid columns
+
+To keep column heights consistent within a `Grid`, use the `aspectRatio` prop on `Column` instead—see [Grid: Aspect ratio](/components/Grid#aspect-ratio) for aligning columns of differing content across a row.

--- a/docs/src/pages/components/BadgeIndicator.svx
+++ b/docs/src/pages/components/BadgeIndicator.svx
@@ -10,7 +10,7 @@ description: Badge indicators draw attention to unread counts and new activity o
 
 ## Basic
 
-Omit count to render an empty dot that signals presence without a number.
+Compose a `BadgeIndicator` in the `badge` slot of an icon-only [Button](/components/Button) to overlay a badge on it. Omit `count`, or set it to `0`, to render an empty dot that signals presence without a number.
 
 <Button
   kind="ghost"
@@ -22,7 +22,11 @@ Omit count to render an empty dot that signals presence without a number.
 
 ## Count
 
-Set count to a number. Values greater than 999 display as 999+.
+Control the badge content with `count`.
+
+### Numeric
+
+Set `count` to a number. Values greater than `999` display as `999+`.
 
 <Stack orientation="horizontal" gap={7}>
   <Button
@@ -48,9 +52,9 @@ Set count to a number. Values greater than 999 display as 999+.
   </Button>
 </Stack>
 
-## Formatted count
+### Formatted
 
-Pass a string to count to override the built-in numeric display. String values bypass the 999+ cap.
+Pass a string to `count` to override the built-in numeric display. String values bypass the `999+` cap.
 
 <FileSource src="/framed/BadgeIndicator/FormattedCount" />
 

--- a/docs/src/pages/components/Box.svx
+++ b/docs/src/pages/components/Box.svx
@@ -14,7 +14,7 @@ The default component renders a `<div>` with no modifiers.
 
 ## Tokens
 
-Apply Carbon fill, inset, and border tokens.
+Apply Carbon fill and border tokens.
 
 ### Fill
 
@@ -44,12 +44,29 @@ Nested fills stack Carbon layer surfaces. Contrast depends on the active theme: 
   </Box>
 </Box>
 
-### Inset
+### Border
 
-Set inset and margin props using the shared layout scale 1–13 (same values as [Stack](/components/Stack) gap). Pass a string for any CSS length.
+Set `border` to a Carbon border token. Each utility applies `1px solid`.
 
-| Scale | Size   |
-| ----- | ------ |
+| Token         | Description                |
+| ------------- | --------------------------- |
+| `subtle`      | Subtle divider border      |
+| `strong`      | Strong divider border      |
+| `interactive` | Interactive element border |
+| `disabled`    | Disabled element border    |
+
+<Stack gap={3}>
+  <Box fill="layer-01" padding={5} border="subtle">subtle</Box>
+  <Box fill="layer-01" padding={5} border="strong">strong</Box>
+  <Box fill="layer-01" padding={5} border="interactive">interactive</Box>
+</Stack>
+
+## Spacing
+
+Set padding and margin using the shared layout scale 1–13 (same values as [Stack](/components/Stack) gap). Pass a string for any CSS length.
+
+| Scale | Size          |
+| ----- | ------------- |
 | 1     | 0.125rem (2px)  |
 | 2     | 0.25rem (4px)   |
 | 3     | 0.5rem (8px)    |
@@ -64,33 +81,37 @@ Set inset and margin props using the shared layout scale 1–13 (same values as 
 | 12    | 6rem (96px)     |
 | 13    | 10rem (160px)   |
 
+### Padding
+
+Use `padding` for all sides, or `paddingX`/`paddingY` to target an axis.
+
 <Stack gap={5}>
   <Box fill="layer-01" padding={5}>Scale padding (5)</Box>
   <Box fill="layer-01" padding="2rem">Custom padding (`2rem`)</Box>
   <Box fill="layer-01" paddingX={6} paddingY={3}>Axis padding</Box>
-  <Box fill="layer-01" padding={5} marginY={5}>Vertical margin</Box>
 </Stack>
 
-### Border
+### Margin
 
-Set `border` to a Carbon border token. Each utility applies `1px solid`.
+Use `margin` for all sides, or `marginX`/`marginY` to target an axis.
 
-| Token         | Description                |
-| ------------- | -------------------------- |
-| `subtle`      | Subtle divider border      |
-| `strong`      | Strong divider border      |
-| `interactive` | Interactive element border |
-| `disabled`    | Disabled element border    |
-
-<Stack gap={3}>
-  <Box fill="layer-01" padding={5} border="subtle">subtle</Box>
-  <Box fill="layer-01" padding={5} border="strong">strong</Box>
-  <Box fill="layer-01" padding={5} border="interactive">interactive</Box>
+<Stack gap={5}>
+  <Box fill="layer-01" padding={5} margin={5}>All-side margin</Box>
+  <Box fill="layer-01" padding={5} marginX={6}>Horizontal margin</Box>
+  <Box fill="layer-01" padding={5} marginY={5}>Vertical margin</Box>
 </Stack>
 
 ## Width
 
-Set width, maxWidth, or minWidth to any CSS length. Numbers are treated as pixels. Use `fullWidth` to span the container (`width: 100%`).
+Set `width`, `maxWidth`, or `minWidth` to any CSS length. Numbers are treated as pixels. Use `fullWidth` to span the container (`width: 100%`).
+
+### Fixed width
+
+<Box fill="layer-01" padding={5} width="16rem">
+  Fixed width (`16rem`).
+</Box>
+
+### Max width
 
 <Stack gap={5}>
   <Box fill="layer-01" padding={5} maxWidth="20rem">
@@ -101,11 +122,29 @@ Set width, maxWidth, or minWidth to any CSS length. Numbers are treated as pixel
   </Box>
 </Stack>
 
+### Min width
+
+<div style="width: 100%; overflow-x: auto;">
+  <Box fill="layer-01" padding={5} minWidth="30rem">
+    Min width in rem (`30rem`); scroll if the container is narrower.
+  </Box>
+</div>
+
+### Full width
+
 <div style="width: 100%;">
   <Box fill="layer-01" padding={5} fullWidth maxWidth="24rem">
     Full width up to a custom max width.
   </Box>
 </div>
+
+## Custom element
+
+The box renders a `<div>` by default. Set `tag` to use a different element.
+
+<Box tag="section" fill="layer-01" padding={5} border="subtle">
+  Rendered as a `section`.
+</Box>
 
 ## Composition
 

--- a/docs/src/pages/components/Breadcrumb.svx
+++ b/docs/src/pages/components/Breadcrumb.svx
@@ -31,7 +31,11 @@ Remove the trailing slash from the last item with `noTrailingSlash`.
   <BreadcrumbItem href="/profile" isCurrentPage>Profile</BreadcrumbItem>
 </Breadcrumb>
 
-## Overflow menu
+## Overflow and sizing
+
+Handle long breadcrumb trails with an overflow menu, a compact size, or both together.
+
+### Overflow menu
 
 Add an overflow menu to handle long breadcrumb trails. Use overflow menu item components for menu options.
 
@@ -49,7 +53,7 @@ Add an overflow menu to handle long breadcrumb trails. Use overflow menu item co
   </BreadcrumbItem>
 </Breadcrumb>
 
-## Small
+### Small
 
 Use `size="sm"` for a compact breadcrumb. This pairs with an overflow menu when space is tight.
 
@@ -73,7 +77,11 @@ Build a full breadcrumb trail with multiple items and a current page indicator.
 
 <FileSource src="/framed/Breadcrumbs/Breadcrumbs" />
 
-## Custom link element
+## Accessibility
+
+Preserve ARIA semantics when rendering custom link elements or renaming the nav's accessible label.
+
+### Custom link element
 
 Omit href and use `let:props` to render a custom link element (for example, a router link). Spread props onto the element to apply the Carbon link class and forward aria-current when isCurrentPage is set.
 
@@ -87,6 +95,15 @@ Omit href and use `let:props` to render a custom link element (for example, a ro
   <BreadcrumbItem isCurrentPage let:props>
     <a {...props} href="/reports/2019">2019</a>
   </BreadcrumbItem>
+</Breadcrumb>
+
+### Accessible label
+
+Set `labelText` to change the nav's accessible name from the default `"Breadcrumb"`. This is useful when a page has more than one breadcrumb trail and each needs a distinguishable landmark label for assistive technology.
+
+<Breadcrumb labelText="Secondary breadcrumb">
+  <BreadcrumbItem href="/">Home</BreadcrumbItem>
+  <BreadcrumbItem href="/settings" isCurrentPage>Settings</BreadcrumbItem>
 </Breadcrumb>
 
 ## Skeleton

--- a/docs/src/pages/components/Breakpoint.svx
+++ b/docs/src/pages/components/Breakpoint.svx
@@ -3,7 +3,7 @@ description: Breakpoint declaratively reports the current Carbon responsive brea
 ---
 
 <script>
-  import { hideAtBreakpoint } from "carbon-components-svelte";
+  import { Breakpoint, hideAtBreakpoint } from "carbon-components-svelte";
 </script>
 
 ## Breakpoints
@@ -22,9 +22,18 @@ The Carbon Design System [grid implementation](https://carbondesignsystem.com/gu
 
 Bind to `size` to determine the current breakpoint. Possible values include `"sm"`, `"md"`, `"lg"`, `"xlg"`, and `"max"`.
 
-The on:change event fires when the size is initially determined and when a breakpoint change occurs (for example, when the browser is resized).
+The on:change event fires when the size is initially determined and when a breakpoint change occurs (for example, when the browser is resized). `event.detail` includes `size` and the matching `breakpointValue` in pixels.
 
 <FileSource src="/framed/Breakpoint/Breakpoint" />
+
+### Slot props
+
+Use the default slot to access `size` and `sizes` without binding a variable. `sizes` is also available as a bindable prop; it provides the same information as `size` but as an object of booleans keyed by breakpoint (`sm`, `md`, `lg`, `xlg`, `max`), which is convenient for `{#if sizes.lg}`-style checks.
+
+<Breakpoint let:size let:sizes>
+  <p>Current size: {size}</p>
+  <p>Large or up: {sizes.lg || sizes.xlg || sizes.max}</p>
+</Breakpoint>
 
 ## Store and breakpoint values
 

--- a/docs/src/pages/components/Button.svx
+++ b/docs/src/pages/components/Button.svx
@@ -4,10 +4,11 @@ description: Buttons trigger actions like submitting a form or navigating, with 
 ---
 
 <script>
-  import { Button, Stack } from "carbon-components-svelte";
+  import { BadgeIndicator, Button, Stack } from "carbon-components-svelte";
   import Add from "carbon-icons-svelte/lib/Add.svelte";
   import TrashCan from "carbon-icons-svelte/lib/TrashCan.svelte";
   import Login from "carbon-icons-svelte/lib/Login.svelte";
+  import Notification from "carbon-icons-svelte/lib/Notification.svelte";
 </script>
 
 ## Kinds
@@ -72,6 +73,15 @@ Add an icon to the button using the `icon` prop.
 
 <Button icon={Add}>With icon</Button>
 
+### Custom icon
+
+Use the `icon` named slot to render custom icon markup instead of, or with different props than, the `icon` prop.
+
+<Button>
+  <Add slot="icon" size={20} />
+  Custom icon
+</Button>
+
 ### Icon-only
 
 Omit the label and provide an `iconDescription` for accessibility. This text is used as the button's tooltip and screen reader label.
@@ -126,23 +136,31 @@ When multiple icon-only buttons are placed next to each other, only one tooltip 
 
 <FileSource src="/framed/Button/AdjacentIconOnlyButtons" />
 
-## Link
+### Badge
+
+Compose a `BadgeIndicator` in the `badge` slot to overlay a badge on an icon-only button. Size is set to `lg` automatically. See [BadgeIndicator](/components/BadgeIndicator) for the full set of examples.
+
+<Button kind="ghost" icon={Notification} iconDescription="Notifications">
+  <BadgeIndicator slot="badge" />
+</Button>
+
+## Element
+
+By default, the button renders a `button` or `a` element. Set `href` to render an anchor, or `as` to render a fully custom element.
+
+### Link
 
 Set `href` to render an [anchor element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a) instead of a button element.
 
 <Button href="#">Link button</Button>
 
-### With icon
-
-Similarly, link buttons can have icons.
+Link buttons can also have icons.
 
 <Button href="#" icon={Add}>Link button with icon</Button>
 
-## Custom element
+### Custom element
 
-By default, the button renders either a button or anchor element.
-
-To render a different element, set `as` to `true` and spread `let:props` to the element.
+Set `as` to `true` and spread `let:props` to the element.
 
 <Button as let:props>
   <p {...props}>Custom element</p>
@@ -150,7 +168,7 @@ To render a different element, set `as` to `true` and spread `let:props` to the 
 
 ## Sizes
 
-Set the `size` prop. The default is medium.
+Set the `size` prop. The default is `"default"`.
 
 ### Field
 

--- a/docs/src/pages/components/ButtonSet.svx
+++ b/docs/src/pages/components/ButtonSet.svx
@@ -18,7 +18,7 @@ Place buttons side by side in a horizontal layout.
 
 ## Stacked
 
-Stack buttons vertically with `stacked`.
+Set `stacked` to `true` to stack the buttons vertically instead of side by side.
 
 <ButtonSet stacked>
   <Button icon={Login}>Log in</Button>

--- a/docs/src/pages/components/Checkbox.svx
+++ b/docs/src/pages/components/Checkbox.svx
@@ -27,11 +27,25 @@ Set `indeterminate` to `true` to show a mixed state, typically used in parent ch
 
 <Checkbox labelText="Label text" indeterminate />
 
-## Hidden label
+## Labels
+
+Control the visibility and content of the checkbox label.
+
+### Hidden label
 
 Hide the label visually by setting `hideLabel` to `true`. The label remains available to screen readers.
 
 <Checkbox labelText="Label text" hideLabel />
+
+### Custom label
+
+Use the `labelChildren` slot to provide custom label content instead of `labelText`.
+
+<Checkbox labelText="Fallback label">
+  <span slot="labelChildren">
+    I agree to the <strong>terms and conditions</strong>
+  </span>
+</Checkbox>
 
 ## Helper text
 
@@ -68,6 +82,15 @@ Set `warn` to `true` and provide `warnText` to show a warning message. `invalid`
 
 <Checkbox labelText="Subscribe to promotional emails" warn warnText="You may receive fewer updates about your account" />
 
+## Decorative
+
+Set `decorative` to `true` to hide the checkbox from the accessibility tree using CSS, rather than just `tabindex`/`aria-hidden` (which axe-core's nested-interactive check doesn't treat as sufficient). Use this when the checkbox is nested inside another interactive, widget-role element that already owns the checked-state semantics, such as a custom listbox option.
+
+<div role="option" aria-checked="true">
+  <Checkbox decorative checked labelText="Option A" hideLabel />
+  Option A
+</div>
+
 ## Reactive
 
 Bind to track and update the checkbox state.
@@ -85,6 +108,15 @@ Bind an array to `group` so each checkbox adds or removes its value when toggled
 When using `bind:group`, the checked state is derived from the group array: use `bind:group` (not `bind:checked`) to control selection, since updating checked directly will be overwritten.
 
 <FileSource src="/framed/Checkbox/MultipleCheckboxes" />
+
+## Events
+
+Use `on:check` to listen for changes to a standalone checkbox. The event dispatches the new checked state as `event.detail`.
+
+<Checkbox
+  labelText="Label text"
+  on:check={(e) => console.log(e.detail)} // boolean
+/>
 
 ## Skeleton
 
@@ -120,7 +152,7 @@ Hide the legend visually by setting `hideLegend` to `true`. The legend remains a
 
 ### Custom label
 
-Use the `legendChildren` slot to provide custom label content instead of `legendText`.
+Use the `legendChildren` slot to provide custom legend content instead of `legendText`.
 
 <CheckboxGroup name="prefs-legend-slot" selected={["email"]}>
   <Stack slot="legendChildren" orientation="horizontal">
@@ -196,4 +228,19 @@ Disabled and read-only checkboxes are exempt from the group's validation styling
 <Checkbox value="email" labelText="Email (disabled)" disabled />
 <Checkbox value="sms" labelText="SMS" />
 <Checkbox value="push" labelText="Push notifications (read-only)" readonly />
+</CheckboxGroup>
+
+### Events
+
+Use `on:change` to listen for changes to the group's selected values. The event dispatches the updated array as `event.detail`.
+
+<CheckboxGroup
+  legendText="Notification preferences"
+  name="prefs-events"
+  selected={["email"]}
+  on:change={(e) => console.log(e.detail)} // Array<string | number>
+>
+<Checkbox value="email" labelText="Email" />
+<Checkbox value="sms" labelText="SMS" />
+<Checkbox value="push" labelText="Push notifications" />
 </CheckboxGroup>

--- a/docs/src/pages/components/ClickableTile.svx
+++ b/docs/src/pages/components/ClickableTile.svx
@@ -14,6 +14,10 @@ Create a clickable tile with an href to link to another page.
 Carbon Design System
 </ClickableTile>
 
+## Keyboard interaction
+
+Focus the tile and press <DocKbd label="Enter" /> or <DocKbd label="Space" /> to activate it. Both keys fire the same `on:click` handler as a mouse click and toggle `clicked`, whether or not `href` is set.
+
 ## Reactive example
 
 Bind to `clicked` to read whether the tile has been activated.

--- a/docs/src/pages/components/CodeSnippet.svx
+++ b/docs/src/pages/components/CodeSnippet.svx
@@ -14,33 +14,11 @@ Display a single-line code snippet by default. By default, the copy button uses 
 
 <CodeSnippet code="npm i carbon-components-svelte" />
 
-## Async copy
+## Light
 
-Pass an async function to `copy` when clipboard text is not ready at render time, such as a longer install command fetched on click. The copy feedback text appears after `copy()` resolves.
+Set `light` to `true` for the light variant, for use on white or light-gray backgrounds.
 
-During the request, the copy control sets `aria-busy="true"` and ignores further clicks. A rejected copy shows `errorFeedback` (default `"Failed to copy"`) in the same tooltip slot as the success message and emits `copy:error`.
-
-Prefetch on hover with `on:mouseenter:copy-button` on the copy control. The example below shows async copy for each variant (`single`, `inline`, `multi`).
-
-<FileSource src="/framed/CodeSnippet/CodeSnippetAsync" />
-
-## Copy behavior
-
-Replace or disable the default clipboard behavior.
-
-### Override
-
-Pass a custom function to `copy` to override the default copy behavior.
-
-This example uses [clipboard-copy](https://github.com/feross/clipboard-copy) to copy the text instead of the default Clipboard API.
-
-<FileSource src="/framed/CodeSnippet/CodeSnippetOverride" />
-
-### Prevent
-
-Pass a no-op function to `copy` to disable copying.
-
-<CodeSnippet code="npm i carbon-components-svelte" copy={() => {}} />
+<CodeSnippet light code="npm i carbon-components-svelte" />
 
 ## Inline
 
@@ -68,21 +46,75 @@ Set `maxCollapsedNumberOfRows` to shorten the collapsed preview. Each row is 16p
 
 <FileSource src="/framed/CodeSnippet/CodeSnippetRowCounts" />
 
-## Expanded by default
+### Custom show more/less text
+
+Set `showMoreText` and `showLessText` to customize the expand/collapse button text.
+
+<FileSource src="/framed/CodeSnippet/CodeSnippetCustomText" />
+
+### Wrapped text
+
+By default, the code snippet preserves text formatting and does not wrap text. Set `wrapText` to `true` to wrap long lines instead of scrolling horizontally.
+
+<FileSource src="/framed/CodeSnippet/CodeSnippetWrapText" />
+
+### Expanded by default
 
 Set `expanded` to `true` to show the full multi-line code snippet.
 
 <FileSource src="/framed/CodeSnippet/CodeSnippetExpanded" />
 
-## Reactive example
+### Events
 
-The multi-line code snippet dispatches "expand" and "collapse" events.
+Dispatches `expand` and `collapse` events when the snippet is toggled open and closed.
 
 <FileSource src="/framed/CodeSnippet/CodeSnippetReactive" />
 
+### Dynamic code
+
+Use `code` instead of the default slot for dynamically updated code.
+
+<FileSource src="/framed/CodeSnippet/DynamicCodeSnippet" />
+
+### Hidden content
+
+The "Show more" button relies on the element's computed height. For hidden content, the button won't appear because the height is `0`.
+
+Re-render the component to fix this issue.
+
+<FileSource src="/framed/CodeSnippet/HiddenCodeSnippet" />
+
+## Copy behavior
+
+Customize, replace, or disable the default clipboard behavior.
+
+### Async
+
+Pass an async function to `copy` when clipboard text is not ready at render time, such as a longer install command fetched on click. The copy feedback text appears after `copy()` resolves.
+
+During the request, the copy control sets `aria-busy="true"` and ignores further clicks. A rejected copy shows `errorFeedback` (default `"Failed to copy"`) in the same tooltip slot as the success message and emits `copy:error`.
+
+Prefetch on hover with `on:mouseenter:copy-button` on the copy control. The example below shows async copy for each variant (`single`, `inline`, `multi`).
+
+<FileSource src="/framed/CodeSnippet/CodeSnippetAsync" />
+
+### Override
+
+Pass a custom function to `copy` to override the default copy behavior.
+
+This example uses [clipboard-copy](https://github.com/feross/clipboard-copy) to copy the text instead of the default Clipboard API.
+
+<FileSource src="/framed/CodeSnippet/CodeSnippetOverride" />
+
+### Prevent
+
+Pass a no-op function to `copy` to disable copying.
+
+<CodeSnippet code="npm i carbon-components-svelte" copy={() => {}} />
+
 ## Custom feedback
 
-Customize the message and icon shown after copying.
+Customize the message, icon, and duration shown after copying.
 
 ### Text
 
@@ -96,6 +128,34 @@ Set `feedbackIcon` to swap the copy button icon during the feedback window. Appl
 to `"single"` and `"multi"` types; has no effect on `"inline"`.
 
 <CodeSnippet code="npm i carbon-components-svelte" feedbackIcon={Checkmark} />
+
+### Duration
+
+Set `feedbackTimeout` to change how long the feedback stays visible, in milliseconds. Defaults to `2000`.
+
+<CodeSnippet code="npm i carbon-components-svelte" feedbackTimeout={5000} />
+
+## Custom labels
+
+Customize the ARIA labels used for accessibility. Which prop applies depends on `type`.
+
+### Copy label
+
+Set `copyLabel` to customize the ARIA label of the copy control. Applies to `"inline"` only; single and multi-line snippets use `codeLabel` and `copyButtonDescription` instead.
+
+<CodeSnippet type="inline" code="rm -rf node_modules/" copyLabel="Delete node_modules" />
+
+### Code label
+
+Set `codeLabel` to customize the ARIA label of the code container (default `"Code snippet"`). Applies to `"single"` and `"multi"` only; inline snippets have no separate container.
+
+<CodeSnippet code="npm i carbon-components-svelte" codeLabel="npm install command" />
+
+### Copy button description
+
+Set `copyButtonDescription` to customize the ARIA label of the copy button. It also shows as a proactive tooltip on hover or focus, before the button is clicked. Applies to `"single"` and `"multi"` only.
+
+<CodeSnippet code="npm i carbon-components-svelte" copyButtonDescription="Copy install command" />
 
 ## Hidden buttons
 
@@ -119,12 +179,6 @@ Hide both the copy and expand/collapse buttons.
 
 <FileSource src="/framed/CodeSnippet/CodeSnippetHideButtons" />
 
-## Custom show more/less text
-
-Set `showMoreText` and `showLessText` to customize the expand/collapse button text.
-
-<FileSource src="/framed/CodeSnippet/CodeSnippetCustomText" />
-
 ## Disabled
 
 Set `disabled` to `true` to disable interaction.
@@ -141,44 +195,25 @@ Set `disabled` to `true` to disable interaction.
 
 <CodeSnippet disabled type="inline" code="rm -rf node_modules/" />
 
-## Wrapped text
-
-By default, the code snippet preserves text formatting and does not wrap text.
-
-Set `wrapText` to `true` to wrap long lines in multi-line snippets.
-
-<FileSource src="/framed/CodeSnippet/CodeSnippetWrapText" />
-
 ## Syntax highlighting
 
 CodeSnippet does not ship a syntax highlighter. Pass the plain source to `code` so copy uses unstyled text, and render highlighted HTML from Prism, Shiki, or another highlighter in the default slot with `{@html}`. Load language grammars and token theme CSS in your app.
 
 <FileSource src="/framed/CodeSnippet/CodeSnippetSyntaxHighlight" />
 
-## Dynamic multi-line code
+## Tooltip
 
-Use `code` instead of the default slot for dynamically updated code.
+The copy button shows a tooltip: a proactive hint on hover or focus for single and multi-line snippets (see [Copy button description](#copy-button-description)), and copy feedback for every variant, including inline. Both render in the same floating portal.
 
-<FileSource src="/framed/CodeSnippet/DynamicCodeSnippet" />
+### Position
 
-## Hidden multi-line code
-
-The "Show more" button relies on the element's computed height. For hidden content, the button won't appear because the height is `0`.
-
-Re-render the component to fix this issue.
-
-<FileSource src="/framed/CodeSnippet/HiddenCodeSnippet" />
-
-## Tooltip position
-
-Set `tooltipPosition` to place the feedback tooltip relative to the copy button.
-It applies to every variant, including the inline snippet.
+Set `tooltipPosition` to place the tooltip relative to the copy button. Applies to every variant, including the inline snippet.
 
 <FileSource src="/framed/CodeSnippet/CodeSnippetTooltipPosition" />
 
-## Tooltip alignment
+### Alignment
 
-Set `tooltipAlignment` to align the feedback tooltip relative to the copy button.
+Set `tooltipAlignment` to align the tooltip relative to the copy button.
 
 <FileSource src="/framed/CodeSnippet/CodeSnippetTooltipAlignment" />
 

--- a/docs/src/pages/components/ComboBox.svx
+++ b/docs/src/pages/components/ComboBox.svx
@@ -24,12 +24,6 @@ items={[
   {id: "2", text: "Fax"}
   ]}  />
 
-## Reactive
-
-See how the combobox responds to user input and selection changes.
-
-<FileSource src="/framed/ComboBox/ReactiveComboBox" />
-
 ## Content
 
 Customize how items render and how the label and helper text appear.
@@ -87,7 +81,13 @@ items={[
 
 ## Selection
 
-Pre-select items, clear the current selection, and coordinate multiple combo boxes.
+Bind to the selection, pre-select items, clear the current selection, and coordinate multiple combo boxes.
+
+### Reactive
+
+See how the combobox responds to user input and selection changes.
+
+<FileSource src="/framed/ComboBox/ReactiveComboBox" />
 
 ### Initial selection
 
@@ -128,11 +128,11 @@ See how to manage multiple comboboxes in a form.
 
 <FileSource src="/framed/ComboBox/MultipleComboBox" />
 
-## Auto-highlight
+## Typeahead and auto-highlight
 
-By default, no item is automatically highlighted when typing. Set `autoHighlight` to `"first-match"` to highlight the first matching item as you type.
+Auto-highlight and typeahead both assist users while typing. Auto-highlight highlights a matching item as you type so it can be selected with <DocKbd label="Enter" /> alone. Typeahead completes the input inline with the untyped portion of a match. They work independently or together.
 
-### First match
+### Auto-highlight
 
 Set `autoHighlight` to `"first-match"` to automatically highlight the first matching item as you type. Select it by pressing <DocKbd label="Enter" /> without using arrow keys.
 
@@ -177,7 +177,21 @@ items={[
   {id: "9", text: "Pineapple"},
   ]}  />
 
-### With typeahead
+### Typeahead
+
+Set `typeahead` to `true` to enable autocomplete. As users type, the input suggests and completes matching items.
+
+By default, typeahead uses case-insensitive prefix matching. When a match is found, the suggestion shows the untyped portion highlighted so users can accept it or keep typing.
+
+Pressing <DocKbd label="Enter" /> or <DocKbd label="Tab" /> accepts the suggestion: it selects the matching item, normalizes the value to the item's casing, and closes the dropdown. <DocKbd label="Tab" /> still moves focus to the next control. Clicking away accepts the suggestion the same way. When the typed text matches no item, the suggestion is not committed.
+
+Pressing <DocKbd label="→" /> or <DocKbd label="End" /> accepts the inline suggestion in place: it commits the completed text into the value (keeping your casing) and collapses the cursor to the end, but keeps focus in the input and leaves the dropdown open so you can continue editing. Unlike <DocKbd label="Enter" /> and <DocKbd label="Tab" />, it does not select an item or close the menu.
+
+You can provide a custom `shouldFilterItem` to change the filtering logic. See the [fuzzy filter](#fuzzy-filter) example below.
+
+<FileSource src="/framed/ComboBox/TypeaheadComboBox" />
+
+### Combined with auto-highlight
 
 Combine `typeahead` and `autoHighlight="first-match"` for the full autocomplete experience: the input text is completed and the matching item is visually highlighted.
 
@@ -194,20 +208,6 @@ items={[
   {id: "8", text: "Mango"},
   {id: "9", text: "Pineapple"},
   ]}  />
-
-## Typeahead
-
-Set `typeahead` to `true` to enable autocomplete. As users type, the input suggests and completes matching items.
-
-By default, typeahead uses case-insensitive prefix matching. When a match is found, the suggestion shows the untyped portion highlighted so users can accept it or keep typing.
-
-Pressing <DocKbd label="Enter" /> or <DocKbd label="Tab" /> accepts the suggestion: it selects the matching item, normalizes the value to the item's casing, and closes the dropdown. <DocKbd label="Tab" /> still moves focus to the next control. Clicking away accepts the suggestion the same way. When the typed text matches no item, the suggestion is not committed.
-
-Pressing <DocKbd label="→" /> or <DocKbd label="End" /> accepts the inline suggestion in place: it commits the completed text into the value (keeping your casing) and collapses the cursor to the end, but keeps focus in the input and leaves the dropdown open so you can continue editing. Unlike <DocKbd label="Enter" /> and <DocKbd label="Tab" />, it does not select an item or close the menu.
-
-You can provide a custom `shouldFilterItem` to change the filtering logic. See the [fuzzy filter](#fuzzy-filter) example below.
-
-<FileSource src="/framed/ComboBox/TypeaheadComboBox" />
 
 ### Fuzzy filter
 
@@ -238,6 +238,13 @@ Enable filtering to let users search through the options.
 By default (`filterMode="remove"`), filtering unmounts non-matching options and recreates them when they match again.
 
 Set `filterMode` to `"hide"` to keep every option mounted and hide non-matching ones with the `hidden` attribute. Keyboard navigation, `aria-setsize`, and `aria-posinset` still follow the matching items only. `"hide"` falls back to `"remove"` when virtualization is enabled. For typical ComboBox lists, `"remove"` is faster per keystroke because it only updates matching option nodes.
+
+<ComboBox filterMode="hide" labelText="Contact" placeholder="Select contact method"
+items={[
+  {id: "0", text: "Slack"},
+  {id: "1", text: "Email"},
+  {id: "2", text: "Fax"}
+  ]}  />
 
 ### Custom label
 
@@ -296,6 +303,8 @@ items={[
 
 Virtualization renders only the items currently visible in the viewport, improving performance for large lists. By default, the combo box virtualizes lists with more than 100 items.
 
+Besides the options shown below, `virtualize` also accepts `containerHeight` (the maximum height in pixels of the dropdown container, default 300) and `maxItems` (a cap on the number of items rendered, default unlimited) for further tuning.
+
 ### Large lists
 
 In the example below, 10,000 items are provided to the combobox but only 11 items (8 visible items + 3 overscan items) are rendered in the DOM.
@@ -328,7 +337,51 @@ By default, item height matches the menu row for each size: 24px (`xs`), 32px (`
 
 <FileSource src="/framed/ComboBox/VirtualizeItemHeight" />
 
-## Top direction
+## Events
+
+Listen for selection, dismissal, and clear interactions. The `scrollend` load-more event is documented separately; see [Load more](#load-more).
+
+### Select
+
+Listen for `on:select` to know when an item is selected. `event.detail` includes `selectedId` and `selectedItem`.
+
+<ComboBox labelText="Contact" placeholder="Select contact method"
+on:select={(e) => console.log(e.detail.selectedId, e.detail.selectedItem)}
+items={[
+  {id: "0", text: "Slack"},
+  {id: "1", text: "Email"},
+  {id: "2", text: "Fax"}
+  ]}  />
+
+### Close
+
+Listen for `on:close` to know when the dropdown menu closes and why. `event.detail.trigger` is `"escape-key"`, `"outside-click"`, or `"select"`.
+
+<ComboBox labelText="Contact" placeholder="Select contact method"
+on:close={(e) => console.log(e.detail.trigger)}
+items={[
+  {id: "0", text: "Slack"},
+  {id: "1", text: "Email"},
+  {id: "2", text: "Fax"}
+  ]}  />
+
+### Clear
+
+Listen for `on:clear` to know when the user activates the clear ("x") button that appears once there is a selection, whether by click or by keyboard. `event.detail` is the originating `KeyboardEvent` or `MouseEvent`. This is distinct from calling the [imperative `clear()` method](#clear-selection) directly, which does not dispatch `clear`.
+
+<ComboBox selectedId="1" labelText="Contact" placeholder="Select contact method"
+on:clear={(e) => console.log(e.type)}
+items={[
+  {id: "0", text: "Slack"},
+  {id: "1", text: "Email"},
+  {id: "2", text: "Fax"}
+  ]}  />
+
+## Menu placement
+
+Control where and how the dropdown menu renders relative to the input.
+
+### Direction
 
 Set `direction` to `"top"` to make the dropdown menu appear above the input.
 
@@ -339,13 +392,19 @@ items={[
   {id: "2", text: "Fax"}
   ]}  />
 
-## Portal menu
+### Portal menu
 
 Set `portalMenu` to `true` to render the dropdown menu in a floating portal. This prevents the menu from being clipped by parent containers with `overflow: hidden` or z-index stacking contexts. Without `portalMenu`, the dropdown in the example below would be clipped by its container's hidden overflow.
 
 When inside a [Modal](/components/Modal#modal-with-dropdowns), `portalMenu` defaults to `true` unless explicitly set to `false`.
 
 <FileSource src="/framed/ComboBox/ComboBoxPortalMenu" />
+
+### Programmatic access
+
+Bind to `open` to control the dropdown menu programmatically, such as opening it from an external trigger.
+
+<FileSource src="/framed/ComboBox/ComboBoxOpenBinding" />
 
 ## Light
 

--- a/docs/src/pages/components/ComboButton.svx
+++ b/docs/src/pages/components/ComboButton.svx
@@ -11,7 +11,7 @@ description: ComboButton pairs a primary action with a menu of related secondary
 
 ## Basic
 
-Wrap `MenuItem` components in `ComboButton` and set `labelText` for the primary action button. Use the `labelChildren` slot for custom button content. Clicking the label fires `on:click`; clicking the chevron trigger opens the menu and fires the separate `on:click:trigger` event. The trigger's other native events (`mousedown`, `focus`, `blur`, `mouseover`, `mouseenter`, `mouseleave`) dispatch the same way, each with a `:trigger`-suffixed counterpart alongside the shared, unscoped event.
+Wrap `MenuItem` components in `ComboButton` and set `labelText` for the primary action button. Clicking the label fires `on:click`; clicking the chevron trigger opens the menu. See [Events](#events) for the trigger's other events and the menu's `close` event.
 
 <ComboButton labelText="Save">
   <MenuItem on:click={() => console.log("Save as")}>Save as</MenuItem>
@@ -19,7 +19,27 @@ Wrap `MenuItem` components in `ComboButton` and set `labelText` for the primary 
   <MenuItem on:click={() => console.log("Save and close")}>Save and close</MenuItem>
 </ComboButton>
 
-## Icon description
+## Reactive example
+
+Control the menu state programmatically by binding to `open`.
+
+<FileSource src="/framed/ComboButton/ComboButtonReactive" />
+
+## Label children
+
+Use the `labelChildren` slot for custom content in the primary action button. `labelText` is still used as the accessible name in that case.
+
+<ComboButton labelText="Save document">
+  <strong slot="labelChildren">Save</strong>
+  <MenuItem on:click={() => console.log("Save as")}>Save as</MenuItem>
+  <MenuItem on:click={() => console.log("Save a copy")}>Save a copy</MenuItem>
+</ComboButton>
+
+## Trigger
+
+Customize the icon-only chevron button that opens the menu.
+
+### Icon description
 
 The icon-only trigger needs its own accessible label, since it has no visible text. Override `iconDescription` to change it; the default is `"Additional actions"`.
 
@@ -145,4 +165,27 @@ Set `labelText` on a `MenuItem` and nest child `MenuItem` rows to get a submenu.
     <MenuItem on:click={() => console.log("JPG")}>JPG</MenuItem>
     <MenuItem on:click={() => console.log("PNG")}>PNG</MenuItem>
   </MenuItem>
+</ComboButton>
+
+## Events
+
+### Trigger events
+
+Clicking the chevron trigger fires `on:click:trigger`, separate from the primary action's `on:click`. The trigger's other native events (`mousedown`, `focus`, `blur`, `mouseover`, `mouseenter`, `mouseleave`) dispatch the same way, each with a `:trigger`-suffixed counterpart alongside the shared, unscoped event.
+
+<ComboButton labelText="Save" on:click:trigger={() => console.log("Trigger clicked")}>
+  <MenuItem on:click={() => console.log("Save as")}>Save as</MenuItem>
+  <MenuItem on:click={() => console.log("Save a copy")}>Save a copy</MenuItem>
+</ComboButton>
+
+### Close event
+
+Use `on:close` to respond to every close attempt, regardless of cause. The event detail's `trigger` is `"escape-key"`, `"outside-click"`, or `"select"`.
+
+<ComboButton
+  labelText="Save"
+  on:close={(e) => console.log(e.detail.trigger)}
+>
+  <MenuItem on:click={() => console.log("Save as")}>Save as</MenuItem>
+  <MenuItem on:click={() => console.log("Save a copy")}>Save a copy</MenuItem>
 </ComboButton>

--- a/docs/src/pages/components/ComposedModal.svx
+++ b/docs/src/pages/components/ComposedModal.svx
@@ -16,37 +16,21 @@ Create a modal with a header, body, and footer. Each section can be customized i
 
 <FileSource src="/framed/Modal/ComposedModal" />
 
-## Full width
+## Focus
 
-Remove modal body padding so content spans edge to edge with `fullWidth`. Use it for content that supplies its own layout, such as a table or fluid form.
+Control how focus moves when the composed modal opens, and override the default target when needed. Focus follows the same priority order as Modal — see [focus behavior](/components/Modal#focus-behavior).
 
-<FileSource src="/framed/Modal/FullWidthComposedModal" />
+### Custom focus
 
-## With portal
+Use `selectorPrimaryFocus` on `ComposedModal` to override the default and target a specific element when the automatic first-input focus is not desired.
 
-Wrap the composed modal in a portal to ensure it renders above all z-index stacking contexts and parent overflow constraints, preventing visual clipping and layering issues.
+<FileSource src="/framed/Modal/ComposedModalCustomFocus" />
 
-<FileSource src="/framed/Portal/ComposedModalPortal" />
+## Variants
 
-## Prevent default close behavior
+Change the composed modal's tone and purpose.
 
-The modal dispatches a cancelable `close` event. Call `e.preventDefault()` to keep the modal open. The event includes a trigger property indicating what triggered the close attempt: `"escape-key"` (<DocKbd label="Escape" />), `"outside-click"`, or `"close-button"`.
-
-<FileSource src="/framed/Modal/ComposedModalPreventClose" />
-
-## Hide close button
-
-Set `hideCloseButton` on `ModalHeader` to remove the header close button. Use this for forced-choice dialogs such as auth walls or terms acceptance. Always provide an alternative dismiss path — typically footer actions — and pair with `preventCloseOnClickOutside` when outside clicks should not dismiss the dialog. <DocKbd label="Escape" /> still closes the modal unless you cancel the `close` event.
-
-<FileSource src="/framed/Modal/ComposedModalHideCloseButton" />
-
-## Prevent secondary button close
-
-`secondaryButtonText` closes the modal by default. The footer dispatches a cancelable `click:button--secondary` event first. Call `e.preventDefault()` to keep the modal open — for example when Cancel should stay put for a dirty form.
-
-<FileSource src="/framed/Modal/ComposedModalPreventSecondaryClose" />
-
-## Danger
+### Danger
 
 Display critical or destructive actions with the danger variant. Set `danger` on both ComposedModal and ModalFooter for the red danger styling.
 
@@ -54,19 +38,134 @@ By default, the cancel button receives focus instead of the critical button to p
 
 <FileSource src="/framed/Modal/DangerComposedModal" />
 
+## Content
+
+Customize the header content and body layout. Set `hasForm` on `ModalBody` when it directly contains form elements (see the [Basic](#basic) example above) — it adjusts the body padding to match Carbon's form spacing.
+
+### Custom heading
+
+Use `ModalHeader`'s default slot to add extra content — such as a status tag — below the title. This is in addition to (or instead of) the plain-text `title` and `label` props.
+
+<FileSource src="/framed/Modal/ComposedModalCustomHeading" />
+
+### Full width
+
+Remove modal body padding so content spans edge to edge with `fullWidth`. Use it for content that supplies its own layout, such as a table or fluid form.
+
+<FileSource src="/framed/Modal/FullWidthComposedModal" />
+
+### Has scrolling content
+
+Set `hasScrollingContent` on `ModalBody` to enable vertical scrolling for lengthy content, matching Modal's [Has scrolling content](/components/Modal#has-scrolling-content). Omitting `ModalFooter` — as in this example — creates a passive, information-only modal, the composed equivalent of Modal's `passiveModal`.
+
+<FileSource src="/framed/Modal/ComposedModalScrollingContent" />
+
+## Buttons
+
+Configure the footer actions.
+
+### Multiple secondary buttons
+
+Set `secondaryButtons` in the modal footer to create a 3-button modal. This replaces secondaryButtonText and takes a tuple of two button configurations.
+
+<FileSource src="/framed/Modal/3ButtonComposedModal" />
+
+### Button with icon
+
+Enhance the primary button with an icon using `primaryButtonIcon` on `ModalFooter`.
+
+<FileSource src="/framed/Modal/ComposedModalButtonWithIcon" />
+
+### Primary button loading
+
+Set `primaryButtonLoading` on `ModalFooter` while an async submit is in progress. The primary button shows an [InlineLoading](/components/InlineLoading) spinner, becomes non-interactive, and suppresses `submit` until loading finishes. The modal stays open.
+
+<FileSource src="/framed/Modal/ComposedModalPrimaryButtonLoading" />
+
 ## Progress
 
 Combine the composed modal with a progress indicator to create a multi-step flow within a modal. Use the modal footer's default slot to render Cancel (ghost), Previous (secondary), and Next (primary) buttons. Track the current step to control which content is displayed and update the button label on the final step.
 
 <FileSource src="/framed/Modal/ProgressModal" />
 
-## Multiple secondary buttons
+## With portal
 
-Set `secondaryButtons` in the modal footer to create a 3-button modal. This replaces secondaryButtonText and takes a tuple of two button configurations.
+Wrap the composed modal in a portal to ensure it renders above all z-index stacking contexts and parent overflow constraints, preventing visual clipping and layering issues.
 
-<FileSource src="/framed/Modal/3ButtonComposedModal" />
-## Primary button loading
+Components with menus (combo box, dropdown, date picker, and so on) placed inside a composed modal also auto-portal their menus the same way as in Modal — see [Modal with dropdowns](/components/Modal#modal-with-dropdowns).
 
-Set `primaryButtonLoading` on `ModalFooter` while an async submit is in progress. The primary button shows an [InlineLoading](/components/InlineLoading) spinner, becomes non-interactive, and suppresses `submit` until loading finishes. The modal stays open.
+<FileSource src="/framed/Portal/ComposedModalPortal" />
 
-<FileSource src="/framed/Modal/ComposedModalPrimaryButtonLoading" />
+## Sizes
+
+Set `size` on `ComposedModal` to control modal width: `"xs"`, `"sm"`, or `"lg"`. The default (no `size`) matches Modal's `"md"`.
+
+<FileSource src="/framed/Modal/ComposedModalSmall" />
+
+## Closing
+
+Control how the composed modal can be dismissed.
+
+### Prevent default
+
+The modal dispatches a cancelable `close` event. Call `e.preventDefault()` to keep the modal open. The event includes a `trigger` property indicating what triggered the close attempt: `"escape-key"` (<DocKbd label="Escape" />), `"outside-click"`, `"close-button"`, or `"programmatic"` (the `open` prop was set to `false` from outside the component, for example through `bind:open`, rather than through one of the modal's own dismiss controls).
+
+<FileSource src="/framed/Modal/ComposedModalPreventClose" />
+
+### Prevent on outside click
+
+Disable closing the modal when clicking outside with `preventCloseOnClickOutside`. This is useful for transactional modals where explicit user action is required.
+
+<FileSource src="/framed/Modal/ComposedModalPreventOutsideClick" />
+
+### Hide close button
+
+Set `hideCloseButton` on `ModalHeader` to remove the header close button. Use this for forced-choice dialogs such as auth walls or terms acceptance. Always provide an alternative dismiss path — typically footer actions — and pair with `preventCloseOnClickOutside` when outside clicks should not dismiss the dialog. <DocKbd label="Escape" /> still closes the modal unless you cancel the `close` event.
+
+<FileSource src="/framed/Modal/ComposedModalHideCloseButton" />
+
+### Secondary button
+
+`secondaryButtonText` closes the modal by default. The footer dispatches a cancelable `click:button--secondary` event first. Call `e.preventDefault()` to keep the modal open — for example when Cancel should stay put for a dirty form.
+
+<FileSource src="/framed/Modal/ComposedModalPreventSecondaryClose" />
+
+## Events
+
+ComposedModal and ModalFooter dispatch events for the modal's lifecycle and button interactions. Only the close button, <DocKbd label="Escape" />, and (by default) an outside click close the modal automatically — see [Closing](#closing) above. Every other action leaves `open` untouched; handle the event and set `open` to `false` yourself when the action should dismiss the dialog.
+
+### Open
+
+Listen for `on:open` to know when the modal has become visible and focus has moved into it.
+
+```svelte
+<ComposedModal bind:open on:open={() => console.log("opened")}>
+```
+
+### Submit and button clicks
+
+The primary button in `ModalFooter` dispatches both `submit` and `click:button--primary` when clicked. Secondary buttons dispatch `click:button--secondary` with the button's `text`.
+
+```svelte
+<ComposedModal bind:open>
+  <ModalHeader title="Confirm changes" />
+  <ModalBody>...</ModalBody>
+  <ModalFooter
+    primaryButtonText="Confirm"
+    secondaryButtonText="Cancel"
+    on:click:button--secondary={() => (open = false)}
+    on:submit={() => (open = false)}
+  />
+</ComposedModal>
+```
+
+### Transition end
+
+Listen for `on:transitionend` to know when the modal's open or close animation finishes. `event.detail.open` reflects the modal's state at the end of the transition.
+
+```svelte
+<ComposedModal
+  bind:open
+  on:transitionend={(e) => console.log("open:", e.detail.open)}
+>
+```

--- a/docs/src/pages/components/ContainedList.svx
+++ b/docs/src/pages/components/ContainedList.svx
@@ -122,7 +122,11 @@ Place the search as a direct child (not in the action slot) for a persistent fil
 
 <FileSource src="/framed/ContainedList/PersistentSearch" />
 
-## Interactive items
+## Clickable items
+
+Make items respond to interaction with `interactive` for in-page actions or `href` for navigation. Both produce a clickable item; add trailing controls to either with the `action` slot.
+
+### Interactive
 
 Set `interactive` on a list item to render it as a clickable button with keyboard support. Combine with `disabled` to prevent interaction.
 
@@ -155,7 +159,7 @@ Use the `action` slot on an item for trailing controls such as buttons or icons.
   </ContainedListItem>
 </ContainedList>
 
-## Link items
+### Link items
 
 Set `href` to render a list item as an anchor with clickable styles. Prefer this for navigation so links support middle-click and SEO. `href` takes precedence over `interactive`. Pass `target` and `rel` through rest props on the item.
 

--- a/docs/src/pages/components/ContentSwitcher.svx
+++ b/docs/src/pages/components/ContentSwitcher.svx
@@ -21,7 +21,11 @@ Create a content switcher with switch components. Each switch needs a text label
   <Switch text="Trending" />
 </ContentSwitcher>
 
-## Initial selected index
+## Selection
+
+Control which switch is selected by index, by a stable id, or by changing how arrow keys move the selection.
+
+### Initial selected index
 
 Set `selectedIndex` to pre-select a switch when the content switcher loads.
 
@@ -31,7 +35,7 @@ Set `selectedIndex` to pre-select a switch when the content switcher loads.
   <Switch text="Recommended" />
 </ContentSwitcher>
 
-## Selected by id
+### Selected by id
 
 For dynamic switch sets, bind `selectedId` and give each `Switch` a stable
 `id`. Selection stays on the same logical switch when switches before it are
@@ -40,7 +44,7 @@ added or removed. When set, `selectedId` takes precedence over
 
 <FileSource src="/framed/ContentSwitcher/ContentSwitcherSelectedId" />
 
-## Manual selection mode
+### Manual selection mode
 
 By default, the content switcher changes the selection when the user moves focus with the arrow keys.
 
@@ -52,13 +56,27 @@ Set `selectionMode` to `"manual"` so that arrow keys only move focus without cha
   <Switch text="Recommended" />
 </ContentSwitcher>
 
-## Reactive example
+### Reactive
 
 Programmatically control the content switcher with the `bind:selectedIndex`
 directive, updating the selected index based on user interactions or application
 state.
 
 <FileSource src="/framed/ContentSwitcher/ContentSwitcherReactive" />
+
+## Events
+
+Listen for content switcher selection changes.
+
+### Change
+
+Listen for `on:change` to know when the selected switch index changes, whether from a click, keyboard navigation, or a `selectedIndex`/`selectedId` update. `event.detail` is the new selected index.
+
+<ContentSwitcher on:change={(e) => console.log(e.detail)}>
+  <Switch text="Latest news" />
+  <Switch text="Trending" />
+  <Switch text="Recommended" />
+</ContentSwitcher>
 
 ## Conditional switches
 
@@ -93,7 +111,7 @@ Set `icon` on every switch for compact, icon-only controls. The switcher becomes
   <Switch icon={List} text="List" />
 </ContentSwitcher>
 
-### Custom tooltip alignment
+### Tooltip alignment
 
 Pass `tooltipAlignment` to individual icon-only switches to adjust tooltip alignment.
 
@@ -102,6 +120,12 @@ Pass `tooltipAlignment` to individual icon-only switches to adjust tooltip align
   <Switch icon={Dashboard} text="Dashboard" />
   <Switch icon={List} text="List" tooltipAlignment="end" />
 </ContentSwitcher>
+
+### Tooltip behavior
+
+Within a content switcher, only one switch's tooltip stays open at a time — hovering or focusing a new switch closes the previous one immediately.
+
+Moving the pointer directly from one icon-only switch to a neighbor whose tooltip is already open skips the usual enter delay, so the tooltip swaps in immediately instead of waiting again. Hover across the icon-only switches in the examples above to feel this.
 
 ## Low contrast
 
@@ -155,7 +179,7 @@ Combine low contrast with icon-only switches.
   <Switch icon={List} text="List" />
 </ContentSwitcher>
 
-### Icon-only (custom tooltip alignment)
+### Icon-only (tooltip alignment)
 
 Pass `tooltipAlignment` to individual icon-only switches to adjust tooltip alignment.
 

--- a/docs/src/pages/components/ContextMenu.svx
+++ b/docs/src/pages/components/ContextMenu.svx
@@ -11,18 +11,20 @@ description: Context menus display contextual actions on right-click, with neste
 In the examples, right click anywhere within the iframe. The context menu appears when right-clicking anywhere in the window. Use ContextMenuOption for menu items and ContextMenuDivider for visual separation.
 
 The root element has `role="menu"`. Set `labelText` or `aria-label` on ContextMenu so assistive technologies get a meaningful name. This matters most for the default window-wide behavior (target unset), where there is no visible trigger to label the menu with `aria-labelledby`.
-  
+
+`open`, `x`, and `y` are also bindable, letting you trigger the menu from something other than a right-click; see [Programmatic position](#programmatic-position).
+
 <FileSource src="/framed/ContextMenu/ContextMenu" />
 
-## Context menu options
+## Menu items
 
 `ContextMenuOption` supports the following props:
 
 | Prop            | Description                                                                                                                                                                                                                                                                                    |
 | --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `labelText`     | Primary label (or use the `labelChildren` slot; see the API reference).                                                                                                                                                                                                                        |
-| `shortcutText`  | Keyboard hint shown on the right, with or without an icon. Pass the shortcut as a string, for example `"⌘C"`.                                                                                                                                                                                  |
-| `icon`          | Carbon icon component to the left of the label. When an icon is set, the option is indented automatically so rows align; you do not need to pass `indented` for icon rows.                                                                                                                     |
+| `shortcutText`  | Keyboard hint shown on the right, with or without an icon. Pass the shortcut as a string, for example `"⌘C"`, or use the `shortcutText` slot for custom content. The hint is display-only; it does not register a keybinding.                                                                |
+| `icon`          | Carbon icon component to the left of the label, or use the `icon` slot for custom content in its place. When an icon is set, the option is indented automatically so rows align; you do not need to pass `indented` for icon rows.                                                            |
 | `indented`      | Indent the label without an icon, for example to align with submenu parents or nested items (see [Nested menu](#nested-menu), [Custom target](#custom-target), and [Multiple targets](#multiple-targets)).                                                                                     |
 | `disabled`      | Non-interactive, dimmed row.                                                                                                                                                                                                                                                                   |
 | `kind`          | `"default"` or `"danger"` for destructive actions.                                                                                                                                                                                                                                               |
@@ -31,7 +33,7 @@ For options inside `ContextMenuGroup`, see [Selectable](#selectable), [Selectabl
 
 <FileSource src="/framed/ContextMenu/ContextMenuOptionProps" />
 
-## Nested menu
+### Nested menu
 
 Put children inside a parent `ContextMenuOption` to open a flyout submenu. Use `indented` on the parent when it has no icon so the label aligns with other rows.
 
@@ -46,28 +48,6 @@ Submenus can contain:
 Selecting an option closes only that option's own menu level. At the root, that closes the whole menu. Inside a submenu, it closes just that flyout and leaves the rest open. Call `event.preventDefault()` to keep a flyout open across several picks; see [Prevent menu from closing](#prevent-menu-from-closing).
 
 <FileSource src="/framed/ContextMenu/ContextMenuNested" />
-
-## Targets
-
-Control which element triggers the menu.
-
-### Custom target
-
-By default, the context menu triggers when you right-click anywhere in the window.
-
-Set `target` to specify which element triggers the context menu.
-
-<FileSource src="/framed/ContextMenu/ContextMenuTarget" />
-
-### Multiple targets
-
-Set `target` to an array of elements to trigger the context menu from multiple sources.
-
-<FileSource src="/framed/ContextMenu/ContextMenuTargets" />
-
-## Selection
-
-Let options act as checkboxes or radios, standalone or grouped.
 
 ### Selectable
 
@@ -95,7 +75,47 @@ Selecting an option closes that flyout. Call `event.preventDefault()` in the opt
 
 <FileSource src="/framed/ContextMenu/ContextMenuRadioGroupNested" />
 
-## Prevent menu from closing
+## Triggering
+
+Control which element triggers the menu, or open it programmatically without a right-click at all.
+
+### Custom target
+
+By default, the context menu triggers when you right-click anywhere in the window.
+
+Set `target` to specify which element triggers the context menu.
+
+<FileSource src="/framed/ContextMenu/ContextMenuTarget" />
+
+### Multiple targets
+
+Set `target` to an array of elements to trigger the context menu from multiple sources.
+
+<FileSource src="/framed/ContextMenu/ContextMenuTargets" />
+
+### Programmatic position
+
+`open`, `x`, and `y` are bindable, so you can open the menu from something other than a right-click, such as a "..." overflow button. Compute a position (for example, from the trigger element's bounding rectangle) and set `x` and `y` before setting `open` to `true`.
+
+This does not replace the right-click behavior described above; if `target` is left unset, the window-wide right-click trigger from [Basic](#basic) still applies alongside the button. Set `target` if you want the button to be the only way to open the menu.
+
+<FileSource src="/framed/ContextMenu/ContextMenuProgrammatic" />
+
+## Events
+
+ContextMenu dispatches `open` once it finishes opening, and `close` on every close attempt.
+
+<FileSource src="/framed/ContextMenu/ContextMenuEvents" />
+
+### Open event
+
+`open`'s detail is the DOM element that was right-clicked. When the menu is opened programmatically instead (see [Programmatic position](#programmatic-position)), the detail is `null` unless a prior right-click already populated it.
+
+### Close event
+
+`close`'s detail contains `trigger`, one of `"escape-key"`, `"outside-click"`, or `"select"`, describing why the menu closed.
+
+### Prevent menu from closing
 
 An option's `click` event is cancelable. Call `event.preventDefault()` in its `on:click` handler to keep the menu open. For a selectable or radio option, selection still updates; only the close is canceled. That is how you leave a nested submenu open while changing several choices. See [Radio group (nested)](#radio-group-nested).
 

--- a/docs/src/pages/components/CopyButton.svx
+++ b/docs/src/pages/components/CopyButton.svx
@@ -17,7 +17,7 @@ Set `text` to the string to copy. By default, the copy button uses the native [C
 
 Pass an async `copy` function when the text is not available at render time, for example markdown fetched on click. Feedback appears after `copy()` resolves.
 
-While `copy()` is pending, the button sets `aria-busy` and ignores clicks. On failure, the button shows `errorFeedback` (default `"Failed to copy"`) and emits `copy:error`.
+While `copy()` is pending, the button sets `aria-busy` and ignores clicks. On success, the button dispatches `copy`. On failure, it shows `errorFeedback` (default `"Failed to copy"`) and dispatches `copy:error`.
 
 Prefetch on hover with `on:mouseenter`.
 

--- a/docs/src/pages/components/CopyInput.svx
+++ b/docs/src/pages/components/CopyInput.svx
@@ -15,6 +15,18 @@ Set `value` to the string to show and copy. For install commands, see [CodeSnipp
 
 <CopyInput labelText="API endpoint" value="https://api.example.com/v1" />
 
+## Custom label
+
+Use the `labelChildren` slot to render custom label content, such as a
+tooltip icon.
+
+<CopyInput labelText="API token" value="sk-1234567890abcdef">
+  <svelte:fragment slot="labelChildren">
+    API token
+    <TooltipIcon tooltipText="Use this token to authenticate API requests." icon={Information} />
+  </svelte:fragment>
+</CopyInput>
+
 ## Select on focus
 
 Set `selectOnFocus` to select the full value when the field receives focus.
@@ -27,7 +39,7 @@ Pass an async `copy` function when the text is not available at render time, for
 
 While `copy()` is pending, the copy button shows a busy state and ignores clicks. On failure, the button shows `errorFeedback` (default `"Failed to copy"`) and emits `copy:error`.
 
-Prefetch on hover with `on:mouseenter:copy-button`.
+Prefetch on hover with `on:mouseenter:copy-button`; `on:mouseleave:copy-button` fires when the pointer leaves the button.
 
 <FileSource src="/framed/CopyInput/CopyInputAsync" />
 
@@ -64,6 +76,12 @@ Long values truncate with an ellipsis when the field is narrower than the text. 
   helperText="Use this ID when contacting support."
 />
 
+## Hidden label
+
+Set `hideLabel` to visually hide the label text. The label remains available to screen readers.
+
+<CopyInput hideLabel labelText="API token" value="sk-1234567890abcdef" />
+
 ## Sizes
 
 Set `size` to `"sm"` or `"xl"`.
@@ -77,6 +95,16 @@ Set `size` to `"sm"` or `"xl"`.
 ## Inline label
 
 <CopyInput inline labelText="Token" value="sk-1234567890abcdef" />
+
+## Disabled
+
+Set `disabled` to disable the input and copy button.
+
+<CopyInput disabled labelText="API token" value="sk-1234567890abcdef" />
+
+## Light
+
+<CopyInput light labelText="API endpoint" value="https://api.example.com/v1" />
 
 ## Custom feedback
 
@@ -94,9 +122,29 @@ Set `feedbackIcon` to show a different icon while feedback is visible. The copy 
 
 <CopyInput labelText="API endpoint" value="https://api.example.com/v1" feedbackIcon={Checkmark} />
 
-## Light
+### Duration
 
-<CopyInput light labelText="API endpoint" value="https://api.example.com/v1" />
+Set `feedbackTimeout` to change how long the feedback stays visible, in milliseconds. Defaults to `2000`.
+
+<CopyInput labelText="API endpoint" value="https://api.example.com/v1" feedbackTimeout={5000} />
+
+## Copy behavior
+
+Replace or disable the default clipboard behavior.
+
+### Override
+
+Pass a function to `copy` to replace the default Clipboard API behavior.
+
+This example uses the [clipboard-copy](https://github.com/feross/clipboard-copy) package instead of the Clipboard API.
+
+<FileSource src="/framed/CopyInput/CopyInputOverride" />
+
+### Prevent
+
+Set `copy` to a no-op function to disable copying.
+
+<CopyInput labelText="Read-only value" value="This value should not be copied" copy={() => {}} />
 
 ## Tooltip
 

--- a/docs/src/pages/components/DataTable.svx
+++ b/docs/src/pages/components/DataTable.svx
@@ -499,6 +499,10 @@ The example below shows 10,000 rows with a filterable toolbar; only visible rows
 
 <FileSource src="/framed/DataTable/VirtualizedDataTable" />
 
+Pass an object instead of `true` to customize behavior further. Besides the options below, `threshold` (default 100) sets the minimum row count before virtualization activates—smaller tables render normally—and `maxItems` caps how many rows are ever rendered, regardless of dataset size.
+
+When `stickyHeader` is `false`, bind `scrollContainerRef` to obtain the scrolling element and control its position programmatically, for example resetting scroll to the top after the row data changes.
+
 ### Custom overscan
 
 Overscanning renders extra rows above and below the viewport for smoother scrolling. The default overscan is 3. Set `overscan` to control how many extra rows are rendered.
@@ -1605,7 +1609,7 @@ Use `selectedRowIds` to specify initially selected rows.
 
 ### Actions toolbar
 
-Add a toolbar for batch actions when rows are selected.
+Add a toolbar for batch actions when rows are selected. Override the "N items selected" label with `formatTotalSelected` on `ToolbarBatchActions`.
 
 <FileSource src="/framed/DataTable/DataTableBatchSelectionToolbar" />
 
@@ -1966,6 +1970,49 @@ Combine `batchExpansion` and `radio` for expandable tables with single-row selec
 
 <FileSource src="/framed/DataTable/DataTableExpandableRadioSelectable" />
 
+## Events
+
+Listen for clicks and hovers on headers, rows, and cells—for example, to open a detail view when a row is clicked. For the sortable header's cancelable `sort` event, see [Sorting](#sortable-columns).
+
+### Row and cell clicks
+
+`click:row` fires when a row is clicked and `click:cell` fires for the specific cell, with `event.detail.target`/`currentTarget` identifying what was clicked. `click:header` fires for header cells. A generic `click` event also fires alongside each of these, with whichever of `header`, `row`, or `cell` applies to that click.
+
+<DataTable
+  headers={[
+    { key: "name", value: "Name" },
+    { key: "protocol", value: "Protocol" },
+    { key: "port", value: "Port" },
+  ]}
+  rows={[
+    { id: "a", name: "Load Balancer 3", protocol: "HTTP", port: 3000 },
+    { id: "b", name: "Load Balancer 1", protocol: "HTTP", port: 443 },
+    { id: "c", name: "Load Balancer 2", protocol: "HTTP", port: 80 },
+  ]}
+  on:click:row={(e) => console.log("click:row", e.detail.row)}
+  on:click:cell={(e) => console.log("click:cell", e.detail.cell)}
+  on:click:header={(e) => console.log("click:header", e.detail.header)}
+/>
+
+### Row hover
+
+`mouseenter:row` and `mouseleave:row` fire when the pointer enters or leaves a row, with the row data as `event.detail`.
+
+<DataTable
+  headers={[
+    { key: "name", value: "Name" },
+    { key: "protocol", value: "Protocol" },
+    { key: "port", value: "Port" },
+  ]}
+  rows={[
+    { id: "a", name: "Load Balancer 3", protocol: "HTTP", port: 3000 },
+    { id: "b", name: "Load Balancer 1", protocol: "HTTP", port: 443 },
+    { id: "c", name: "Load Balancer 2", protocol: "HTTP", port: 80 },
+  ]}
+  on:mouseenter:row={(e) => console.log("mouseenter:row", e.detail)}
+  on:mouseleave:row={(e) => console.log("mouseleave:row", e.detail)}
+/>
+
 ## Skeleton
 
 Show a loading state with `DataTableSkeleton`.
@@ -1999,6 +2046,12 @@ Add an empty header column with `empty: true`.
 Hide the header and toolbar in the skeleton.
 
 <DataTableSkeleton showHeader={false} showToolbar={false} />
+
+### Medium
+
+Set `size="medium"` to explicitly match the default `DataTable` row height.
+
+<DataTableSkeleton showHeader={false} showToolbar={false} size="medium" />
 
 ### Tall
 

--- a/docs/src/pages/components/DataTable.svx
+++ b/docs/src/pages/components/DataTable.svx
@@ -1577,7 +1577,7 @@ Set `empty: true` in a header to create an empty column—for overflow menus wit
 
 ## Highlighted row
 
-Pass row ids in `highlightedRowIds` to keep a row visually highlighted. Bind each overflow menu open state to track which row is open. Highlighted rows use the bx--data-table--highlighted-row class, styled with the same theme tokens as row hover.
+Pass row ids in `highlightedRowIds` to keep a row visually highlighted. Bind each overflow menu open state to track which row is open. Highlighted rows use the `bx--data-table--highlighted-row` class, styled with the same theme tokens as row hover. This is purely cosmetic — no `aria-*` attribute is added, so it isn't announced to screen readers. For a selection state that's also exposed to assistive technology, see [Selectable rows](#selectable-rows).
 
 <FileSource src="/framed/DataTable/DataTableHighlightedRow" />
 

--- a/docs/src/pages/components/DatePicker.svx
+++ b/docs/src/pages/components/DatePicker.svx
@@ -8,49 +8,61 @@ description: Date pickers collect dates through simple typed fields, single cale
   import Information from "carbon-icons-svelte/lib/Information.svelte";
 </script>
 
-## Single calendar
+## Calendar types
+
+DatePicker supports five `datePickerType` values: `"simple"` (default, no calendar), `"single"`, `"range"`, `"month"`, and `"year"`.
+
+### Simple
+
+The default `datePickerType` renders a text field without a dropdown calendar.
+
+<DatePicker>
+  <DatePickerInput labelText="Date of birth" placeholder="mm/dd/yyyy" />
+</DatePicker>
+
+### Single
 
 Set `datePickerType` to `"single"` for one date with a dropdown calendar. Use a single DatePickerInput; clicking the field or calendar icon opens the calendar to pick one day. Bind `value` to read or set the formatted date string.
 
 <FileSource src="/framed/DatePicker/DatePickerSingle" />
 
-## Range calendar
+### Range
 
 Set `datePickerType` to `"range"` for a start and end date. Provide two DatePickerInput components in order—start, then end—and bind `valueFrom` and `valueTo`. Both fields share one calendar: the user selects a span, and the start and end inputs update together.
 
 <FileSource src="/framed/DatePicker/DatePickerRange" />
 
-### Programmatic
+#### Programmatic
 
 Use `bind:valueFrom` and `bind:valueTo` to update the range from outside the component, such as preset buttons or filters.
 
 <FileSource src="/framed/DatePicker/DatePickerProgrammatic" />
 
-## Month calendar
+### Month
 
 Set `datePickerType` to `"month"` to select a month instead of a day. The calendar shows a 12-month grid for the current year; use the year stepper to change years. Pair it with a `dateFormat` that omits the day, such as `"F Y"` (for example, "January 2026").
 
 <FileSource src="/framed/DatePicker/DatePickerMonth" />
 
-### Custom format
+#### Custom format
 
 Pass a numeric `dateFormat`, such as `"Y-m"`, along with a matching `placeholder` for a compact "yyyy-mm" input.
 
 <FileSource src="/framed/DatePicker/DatePickerMonthCustomFormat" />
 
-### Programmatic
+#### Programmatic
 
 Use `bind:value` to update the selected month from outside the component, such as a "previous month" button.
 
 <FileSource src="/framed/DatePicker/DatePickerMonthProgrammatic" />
 
-## Year calendar
+### Year
 
 Set `datePickerType` to `"year"` to select a year instead of a day. The calendar shows a decade grid; use the prev/next controls to move between decades. Pair it with a year-only `dateFormat` such as `"Y"` (for example, "2026").
 
 <FileSource src="/framed/DatePicker/DatePickerYear" />
 
-### Programmatic
+#### Programmatic
 
 Use `bind:value` to select a year from outside the component, or `bind:calendar` to move the displayed decade—such as jumping to the current year or paging forward—without changing the selection.
 
@@ -142,11 +154,23 @@ When the date picker is inside an open element with a [popover](https://develope
 
 <FileSource src="/framed/DatePicker/DatePickerPopover" />
 
-## Simple
+## Events
 
-Create a simple date picker without a dropdown calendar.
+Listen for calendar interactions.
 
-<DatePicker>
+### Change
+
+Listen for `on:change` to respond to value updates. For the `"simple"` date picker type (no calendar), `event.detail` is the input's string value. For calendar types (`"single"`, `"range"`, `"month"`, `"year"`), `event.detail` is an object with `selectedDates` (an array of `Date`) and `dateStr` (a string, or `{ from, to }` for `"range"`).
+
+<DatePicker datePickerType="single" on:change={(e) => console.log(e.detail)}>
+  <DatePickerInput labelText="Date of birth" placeholder="mm/dd/yyyy" />
+</DatePicker>
+
+### Close
+
+Listen for `on:close` to know when the calendar closes and why. This event is only dispatched for calendar types (not `"simple"`). `event.detail.trigger` is `"escape-key"`, `"outside-click"`, or `"select"`; the detail also includes `selectedDates` and `dateStr`.
+
+<DatePicker datePickerType="single" on:close={(e) => console.log(e.detail.trigger)}>
   <DatePickerInput labelText="Date of birth" placeholder="mm/dd/yyyy" />
 </DatePicker>
 
@@ -281,6 +305,14 @@ Display a loading skeleton for the fluid date picker variant. Set `range` to `tr
 ## Sizes
 
 Set `size` on DatePickerInput. The default is `md`.
+
+### Short
+
+Set `short` to `true` on DatePicker for a narrower field. It only changes the field width for the default `"simple"` date picker type.
+
+<DatePicker short>
+  <DatePickerInput labelText="Date of birth" placeholder="mm/dd/yyyy" />
+</DatePicker>
 
 ### Extra-large
 

--- a/docs/src/pages/components/Dialog.svx
+++ b/docs/src/pages/components/Dialog.svx
@@ -18,6 +18,18 @@ When the dialog opens, focus moves into it (native modal focus trap). When it cl
 
 <FileSource src="/framed/Dialog/ModalDialog" />
 
+## Events
+
+`Dialog` dispatches `open` once the dialog becomes visible (after `show()`/`showModal()` runs and focus moves in). Pair it with `close` — see [Closing](#closing) below — to track the dialog's full lifecycle.
+
+```svelte
+<Dialog
+  bind:open
+  on:open={() => console.log("open")}
+  on:close={(e) => console.log("close", e.detail)}
+>
+```
+
 ## Closing
 
 The `close` event includes a `trigger` property indicating what dismissed the dialog: `"escape-key"` (<DocKbd label="Escape" />), `"backdrop"`, `"close-button"` (for example a `<form method="dialog">` submit), or `"programmatic"` (when `open` is set to `false`).

--- a/docs/src/pages/components/Disclosure.svx
+++ b/docs/src/pages/components/Disclosure.svx
@@ -37,7 +37,12 @@ for more complex layouts with multiple elements.
   <p>Orders ship within 2 business days and arrive in 3-5 business days.</p>
 </Disclosure>
 
-## Open by default
+## Open state
+
+Control whether the disclosure starts open, and read or drive its state
+programmatically.
+
+### Open by default
 
 Set `open` to `true` to render the disclosure expanded.
 
@@ -45,7 +50,7 @@ Set `open` to `true` to render the disclosure expanded.
   <p>Orders ship within 2 business days and arrive in 3-5 business days.</p>
 </Disclosure>
 
-## Reactive (two-way binding)
+### Reactive (two-way binding)
 
 Bind to `open` to control and read the disclosure state outside the component.
 Listen for `toggle` to react to state changes, such as when the trigger is

--- a/docs/src/pages/components/Dropdown.svx
+++ b/docs/src/pages/components/Dropdown.svx
@@ -41,6 +41,14 @@ Set `clearable` to `true` to show a clear button when an item is selected. Clear
   {id: "1", text: "Email"},
   {id: "2", text: "Fax"}]}" />
 
+### Clear button text
+
+Override the assistive text for the clear interaction with `clearSelectionText` (appended to the field's description whenever there is a selection to clear) and `selectionClearedText` (announced through the status live region after clearing). Both only apply when `clearable` is `true`.
+
+<Dropdown clearable clearSelectionText="Press Escape twice to clear" selectionClearedText="Contact method cleared" labelText="Contact" selectedId="0" items="{[{id: "0", text: "Slack"},
+  {id: "1", text: "Email"},
+  {id: "2", text: "Fax"}]}" />
+
 ### Initial selection
 
 Set `selectedId` to pre-select an item when the dropdown first renders. The trigger shows that item's label in the closed state.
@@ -119,6 +127,34 @@ available to screen readers.
   {id: "1", text: "Email"},
   {id: "2", text: "Fax"}]}" />
 
+## Menu
+
+Control the menu's position, portalling, and open state.
+
+### Top direction
+
+Set `direction` to `"top"` to open the menu above the input. Useful when space below is limited.
+
+<Dropdown direction="top" labelText="Contact" selectedId="0" items="{[{id: "0", text: "Slack"},
+  {id: "1", text: "Email"},
+  {id: "2", text: "Fax"}]}" />
+
+### Portal menu
+
+Set `portalMenu` to `true` to render the dropdown menu in a floating portal. This prevents the menu from being clipped by parent containers with `overflow: hidden` or z-index stacking contexts. Without `portalMenu`, the dropdown in the example below would be clipped by its container's hidden overflow.
+
+When inside a [Modal](/components/Modal#modal-with-dropdowns), `portalMenu` defaults to `true` unless explicitly set to `false`.
+
+<FileSource src="/framed/Dropdown/DropdownPortalMenu" />
+
+### Open by default
+
+Set `open` to `true` to render the dropdown already expanded. The prop is bindable (`bind:open`), so you can also drive it externally, such as from a trigger elsewhere on the page.
+
+<Dropdown open labelText="Contact" selectedId="0" items="{[{id: "0", text: "Slack"},
+  {id: "1", text: "Email"},
+  {id: "2", text: "Fax"}]}" />
+
 ## Virtualization
 
 Virtualization renders only the items currently visible in the viewport, improving performance for large lists.
@@ -168,19 +204,81 @@ By default, item height matches the menu row for each size: 24px (`xs`), 32px (`
 
 <FileSource src="/framed/Dropdown/VirtualizeItemHeight" />
 
+### Custom container height
+
+The virtualized menu's scrollable container defaults to a maximum height of 300px. Set `containerHeight` within the `virtualize` object to change it. Providing any `virtualize` object (even with a short list, as below) activates the sizing behavior, though items only get windowed once the list reaches `threshold`.
+
+<Dropdown virtualize={{ containerHeight: 150 }} labelText="Contact" items={[
+  { id: "0", text: "Slack" },
+  { id: "1", text: "Email" },
+  { id: "2", text: "Fax" },
+  { id: "3", text: "Phone" },
+  { id: "4", text: "Mail" },
+  { id: "5", text: "SMS" },
+  { id: "6", text: "WhatsApp" },
+  { id: "7", text: "Teams" },
+  { id: "8", text: "Zoom" },
+  { id: "9", text: "In person" },
+]} />
+
+Set `maxItems` within the same object to cap the number of items rendered in the DOM window at once, independent of `overscan`. This only takes effect once the list is windowed (at or above `threshold`), and is rarely needed outside of extreme item counts or very expensive item templates—set it too low and items can appear to go blank near the scroll edges.
+
 ## Multiple dropdowns
 
 Create multiple dropdowns that work together.
 
 <FileSource src="/framed/Dropdown/MultipleDropdown" />
 
-## Top direction
+## Events
 
-Set `direction` to `"top"` to open the menu above the input. Useful when space below is limited.
+Respond to selection, clearing, and menu-close interactions.
 
-<Dropdown direction="top" labelText="Contact" selectedId="0" items="{[{id: "0", text: "Slack"},
-  {id: "1", text: "Email"},
-  {id: "2", text: "Fax"}]}" />
+### Select
+
+Use `on:select` to listen for a new selection. The event detail includes the selected item's id and the full item.
+
+<Dropdown
+  labelText="Contact"
+  items={[
+    { id: "0", text: "Slack" },
+    { id: "1", text: "Email" },
+    { id: "2", text: "Fax" },
+  ]}
+  on:select={(e) => {
+    console.log(e.detail.selectedId);
+    console.log(e.detail.selectedItem);
+  }}
+/>
+
+### Clear
+
+Use `on:clear` to listen for the selection being cleared, either via the clear button or the Delete/Backspace shortcut. Only fires when `clearable` is `true`. The event detail is the original `KeyboardEvent` or `MouseEvent`.
+
+<Dropdown
+  clearable
+  selectedId="0"
+  labelText="Contact"
+  items={[
+    { id: "0", text: "Slack" },
+    { id: "1", text: "Email" },
+    { id: "2", text: "Fax" },
+  ]}
+  on:clear={(e) => console.log(e)}
+/>
+
+### Close
+
+Use `on:close` to know when the menu closes and why. `event.detail.trigger` is `"escape-key"`, `"outside-click"`, or `"select"`.
+
+<Dropdown
+  labelText="Contact"
+  items={[
+    { id: "0", text: "Slack" },
+    { id: "1", text: "Email" },
+    { id: "2", text: "Fax" },
+  ]}
+  on:close={(e) => console.log(e.detail.trigger)}
+/>
 
 ## Sizes
 
@@ -354,14 +452,6 @@ Invalid and warning states are not displayed while the dropdown is read-only.
 Display a loading skeleton for the fluid dropdown variant.
 
 <FluidDropdownSkeleton />
-
-## Portal menu
-
-Set `portalMenu` to `true` to render the dropdown menu in a floating portal. This prevents the menu from being clipped by parent containers with `overflow: hidden` or z-index stacking contexts. Without `portalMenu`, the dropdown in the example below would be clipped by its container's hidden overflow.
-
-When inside a [Modal](/components/Modal#modal-with-dropdowns), `portalMenu` defaults to `true` unless explicitly set to `false`.
-
-<FileSource src="/framed/Dropdown/DropdownPortalMenu" />
 
 ## Form name
 

--- a/docs/src/pages/components/ExpandableTile.svx
+++ b/docs/src/pages/components/ExpandableTile.svx
@@ -28,7 +28,11 @@ By default, the tile is collapsed. Use the above and below slots to define conte
   <div slot="below">Below the fold content here</div>
 </ExpandableTile>
 
-## Reactive (two-way binding)
+## Expanded state
+
+Control whether the tile is expanded, either reactively or by default.
+
+### Reactive (two-way binding)
 
 Bind to `expanded` to control and read the tile state outside the component.
 Grow the above-the-fold content while collapsed to see the resize observer remeasure
@@ -36,7 +40,7 @@ and update the tile height.
 
 <FileSource src="/framed/ExpandableTile/ExpandableTileReactive" />
 
-## Expanded
+### Expanded by default
 
 Display the tile expanded by default with `expanded`.
 
@@ -54,9 +58,11 @@ Use the light variant on dark backgrounds with `light`.
   <div slot="below">Below the fold content here</div>
 </ExpandableTile>
 
-## Customization
+## Content height
 
-### Heights
+Control how the tile measures and displays its collapsed height.
+
+### CSS dimensions
 
 Set custom heights for the tile content using CSS to control the exact dimensions
 of the visible and hidden content.
@@ -66,11 +72,42 @@ of the visible and hidden content.
   <div slot="below" style="height: 10rem">Below the fold content here</div>
 </ExpandableTile>
 
-### Labels
+### Manual height override
+
+By default, the tile measures the above-the-fold content's height and its own
+padding automatically with a resize observer. Set `tileMaxHeight` and
+`tilePadding` (in pixels) to override the measured values—for example, to fix
+the collapsed height ahead of time instead of relying on the observer.
+
+<ExpandableTile tileMaxHeight={64} tilePadding={32}>
+  <div slot="above">Above the fold content here</div>
+  <div slot="below">Below the fold content here</div>
+</ExpandableTile>
+
+## Labels
+
+Customize the chevron's visible label text and the tile's accessible tooltip text.
+
+### Chevron label
 
 Customize expand/collapse button labels with `tileExpandedLabel` and `tileCollapsedLabel`.
 
 <ExpandableTile tileExpandedLabel="View less" tileCollapsedLabel="View more">
+  <div slot="above">Above the fold content here</div>
+  <div slot="below">Below the fold content here</div>
+</ExpandableTile>
+
+### Accessible text
+
+Customize the accessible name announced for the expand/collapse control with
+`tileCollapsedIconText` and `tileExpandedIconText`. These render as the
+`title` attribute on the tile, or as the `aria-label`/`title` on the chevron
+button when `hasInteractiveContent` is set.
+
+<ExpandableTile
+  tileCollapsedIconText="Show more details"
+  tileExpandedIconText="Show fewer details"
+>
   <div slot="above">Above the fold content here</div>
   <div slot="below">Below the fold content here</div>
 </ExpandableTile>

--- a/docs/src/pages/components/FileUploader.svx
+++ b/docs/src/pages/components/FileUploader.svx
@@ -48,7 +48,23 @@ Add an icon to the file uploader button with `icon`.
 <FileUploaderButton icon={Add} labelText="Add file" />
 <FileUploaderButton icon={DocumentAdd} labelText="Upload document" kind="secondary" />
 
-## Icon-only
+### Custom label
+
+Use the `labelChildren` slot to provide custom label content instead of `labelText`.
+
+<FileUploaderButton labelText="">
+  <strong slot="labelChildren">Add file</strong>
+</FileUploaderButton>
+
+### Disable label changes
+
+By default, the button label updates to show the selected file name (or file
+count, when `multiple`) after a file is chosen. Set `disableLabelChanges` to
+`true` to keep the original `labelText` instead.
+
+<FileUploaderButton disableLabelChanges labelText="Add file" />
+
+### Icon-only
 
 Set `labelText` to an empty string to render an icon-only button. Provide an `iconDescription` for accessibility — it is used as the button's tooltip and screen reader label.
 
@@ -80,7 +96,16 @@ This example accepts multiple JPEG files and displays them in a completed state.
 
 <FileUploader multiple labelTitle="Upload files" buttonLabel="Add files" labelDescription="Only JPEG files are accepted." accept="{['.jpg', '.jpeg']}" status="complete" />
 
-## Per-file status
+### Custom label
+
+Use the `labelTitle` and `labelDescription` slots to provide custom label content instead of the `labelTitle` and `labelDescription` props.
+
+<FileUploader multiple buttonLabel="Add files">
+  <strong slot="labelTitle">Upload files</strong>
+  <span slot="labelDescription">Only JPEG files are accepted.</span>
+</FileUploader>
+
+### Per-file status
 
 Use `fileStatus` when files upload independently and should not share one
 global `status`. The callback receives `(file, index)` and returns
@@ -101,7 +126,7 @@ staggered delay.
 
 <FileSource src="/framed/FileUploader/FileUploaderPerFileStatus" />
 
-## Per-file status icon labels
+### Per-file status icon labels
 
 Set `iconDescription` to a function for accessible labels that depend on each row. The callback receives `{ file, fileName, status, invalid }`.
 
@@ -120,7 +145,7 @@ always undefined and fileName matches name.
   on:delete
 />
 
-## Clear files
+### Clear files
 
 Remove uploaded files from the file uploader in two ways:
 
@@ -131,14 +156,14 @@ Calling `clearFiles` or setting `files` to `[]` dispatches `change` (with an emp
 
 <FileSource src="/framed/FileUploader/FileUploaderClearFiles" />
 
-## Programmatic input access
+### Programmatic input access
 
 Use `bind:ref` to capture the underlying `<input type="file">` and trigger it
 programmatically.
 
 <FileSource src="/framed/FileUploader/FileUploaderProgrammaticInputAccess" />
 
-## Maximum file size
+### Maximum file size
 
 Limit uploaded file size with `maxFileSize`. Files exceeding the limit (in bytes)
 are automatically filtered out.
@@ -152,6 +177,37 @@ are not added, and a `rejected` event fires with `{ file, reason: "size" }` for
 each rejected file.
 
 <FileSource src="/framed/FileUploader/FileUploaderMaxFileSize" />
+
+### Duplicate detection
+
+Set `preventDuplicate` to `true` to reject files that match an already-selected
+file by name, size, and last modified. Rejected duplicates are reported via
+`rejected` with `{ file, reason: "duplicate" }`.
+
+<FileSource src="/framed/FileUploader/FileUploaderPreventDuplicate" />
+
+### Disabled
+
+Disable the file uploader by setting `disabled` to `true`.
+
+<FileUploader disabled multiple labelTitle="Upload files" buttonLabel="Add files" labelDescription="Only JPEG files are accepted." accept="{['.jpg', '.jpeg']}" status="complete" />
+
+### Events
+
+Respond to file list changes. `add` and `remove` fire whenever `files` gains or
+loses entries (including via two-way binding), `change` fires with the full
+list, `clear` fires when the list becomes empty (see [Clear
+files](#clear-files)), and `rejected` fires per file that fails validation
+(see [Maximum file size](#maximum-file-size) and [Duplicate
+detection](#duplicate-detection)).
+
+<FileUploader
+  on:add={(e) => console.log(e.detail)} // File[]
+  on:remove={(e) => console.log(e.detail)} // File[]
+  on:change={(e) => console.log(e.detail)} // File[]
+  on:clear={() => console.log("cleared")}
+  on:rejected={(e) => console.log(e.detail)} // Array<{ file: File; reason: "size" | "duplicate" }>
+/>
 
 ## File ordering
 
@@ -172,20 +228,6 @@ Pass a custom function to `orderFiles` for full control over the file list order
 This example sorts all files by `lastModified`, newest first.
 
 <FileSource src="/framed/FileUploader/FileUploaderOrderFilesCustom" />
-
-## Duplicate detection
-
-Set `preventDuplicate` to `true` to reject files that match an already-selected
-file by name, size, and last modified. Rejected duplicates are reported via
-`rejected` with `{ file, reason: "duplicate" }`.
-
-<FileSource src="/framed/FileUploader/FileUploaderPreventDuplicate" />
-
-## Disabled
-
-Disable the file uploader by setting `disabled` to `true`.
-
-<FileUploader disabled multiple labelTitle="Upload files" buttonLabel="Add files" labelDescription="Only JPEG files are accepted." accept="{['.jpg', '.jpeg']}" status="complete" />
 
 ## Item
 
@@ -251,11 +293,28 @@ multiple file selection, size and duplicate checks, and custom validation.
 
 Set `maxFileSize` and `preventDuplicate` for the same rejection reasons as
 `FileUploader` (`size`, `duplicate`). Use `validateFiles` for additional
-filtering; files it removes are reported with `reason: "invalid"`.
+filtering; files it removes are reported with `reason: "invalid"`. Dispatches
+the same `add`, `change`, and `rejected` events described in
+[Events](#events).
 
 This example rejects files over 1 kB and duplicates of already-selected files.
 
 <FileSource src="/framed/FileUploader/FileUploaderDropContainerValidation" />
+
+### Custom label
+
+Use the `labelChildren` slot to provide custom label content instead of `labelText`.
+
+<FileUploaderDropContainer>
+  <strong slot="labelChildren">Drag and drop files here or click to upload</strong>
+</FileUploaderDropContainer>
+
+### Programmatic input access
+
+Use `bind:ref` to capture the underlying `<input type="file">` and trigger it
+programmatically.
+
+<FileSource src="/framed/FileUploader/FileUploaderDropContainerProgrammaticInputAccess" />
 
 ## Skeleton
 

--- a/docs/src/pages/components/FloatingPortal.svx
+++ b/docs/src/pages/components/FloatingPortal.svx
@@ -19,7 +19,8 @@ toggle the floating content and drag the tile to move the anchor.
 
 ## Placement
 
-Control how floating content is positioned.
+Control how floating content is positioned, how flips are resolved, and how
+that content is sized and stacked.
 
 ### Direction
 
@@ -30,6 +31,40 @@ space (for example, top flips to bottom, right flips to left).
 The default direction is `"bottom"`.
 
 <FileSource src="/framed/FloatingPortal/FloatingPortalDirection" />
+
+### Locking the resolved direction
+
+By default (`lockDirection="none"`), the flip check re-runs on every position
+update, so the resolved direction can change as the anchor scrolls, the
+viewport resizes, or the floating content's own size changes.
+
+Set `lockDirection` to change this:
+
+- `"after-flip"`: once the content flips away from the preferred `direction`,
+  that side stays locked for the rest of the open session. This keeps a
+  flipped tooltip stable when its content resizes (for example, text that
+  changes to something narrower) instead of snapping back to the preferred
+  side mid-session. [Tooltip](/components/Tooltip) and other portalled
+  tooltips use this mode.
+- `"always"`: whichever side the initial open settles on—flipped or
+  not—stays locked for the rest of the session, so later scroll or resize
+  updates only reposition along that side instead of re-running the flip
+  check. [Menu](/components/Menu) uses this mode so an open menu does not
+  jump sides while scrolling.
+
+```svelte
+<FloatingPortal {anchor} {open} lockDirection="after-flip">
+  <div>Content</div>
+</FloatingPortal>
+```
+
+### Reading the resolved direction
+
+Use the `direction` slot prop to read the actual rendered direction—after
+auto-flipping and after any `lockDirection` lock takes effect—for conditional
+logic, like styles.
+
+<FileSource src="/framed/FloatingPortal/FloatingPortalSlotDirection" />
 
 ### Intrinsic width
 
@@ -76,35 +111,37 @@ uses them when portalTooltip is true;
 [TooltipDefinition](/components/TooltipDefinition) apply small built-in gaps when
 portalled so spacing matches the non-portal Carbon tooltips.
 
-## Escaping overflow
+### Z-index
+
+Set `zIndex` to change the floating content's stacking order. The default is
+`9200`, which supersedes the z-index used by [Modal](/components/Modal)
+(`9000`) and list box menus (`9100`).
+
+```svelte
+<FloatingPortal {anchor} {open} zIndex={2000}>
+  <div>Content</div>
+</FloatingPortal>
+```
+
+## Portal target
+
+Control which DOM node the floating content is mounted into. Positioning is
+always driven by `anchor`; the target only changes which DOM subtree the
+floating content lives in.
+
+### Escaping overflow
 
 Because the floating content is rendered into document.body, it escapes parent
 containers with overflow hidden.
 
 <FileSource src="/framed/FloatingPortal/FloatingPortalOverflow" />
 
-## Slot direction
-
-By default, the floating content is rendered below the anchor element. However,
-if there is not enough space below the anchor element, the component automatically
-flips to the opposite direction.
-
-Use the direction slot prop to read the actual rendered direction after
-auto-flipping for conditional logic, like styles.
-
-<FileSource src="/framed/FloatingPortal/FloatingPortalSlotDirection" />
-
-## Custom target
+### Custom target
 
 Use `target` to mount the floating content into a specific DOM element instead of
-document.body. Positioning is always driven by anchor, so target only changes
-which DOM subtree the floating content lives in. See the
+document.body. See the
 [Portal custom target example](/components/Portal#custom-target) for typical use
 cases.
-
-## Inside
-
-Use floating portals inside native top-layer elements.
 
 ### Native dialog
 

--- a/docs/src/pages/components/FluidForm.svx
+++ b/docs/src/pages/components/FluidForm.svx
@@ -15,8 +15,10 @@ description: Fluid forms provide a full-width form layout that adapts to their c
     FluidTextInputSkeleton,
     MultiSelect,
     NumberInput,
+    PinCodeInput,
     TextInput,
     PasswordInput,
+    Search,
     TextArea,
     Select,
     SelectItem,
@@ -28,7 +30,7 @@ description: Fluid forms provide a full-width form layout that adapts to their c
 ## Basic
 
 Create a fluid-width form layout using the fluid form component. This example
-shows an application registration form with required fields. Supported inputs include text inputs, copy inputs, text areas, number inputs, selects, dropdowns, combo boxes, multi-selects, date pickers, and time pickers. Note that inline input variants cannot be used within a fluid form.
+shows an application registration form with required fields. Supported inputs include text inputs, copy inputs, text areas, number inputs, search inputs, pin code inputs, selects, dropdowns, combo boxes, multi-selects, date pickers, and time pickers. Note that inline input variants cannot be used within a fluid form.
 
 <FluidForm>
   <TextInput
@@ -100,7 +102,13 @@ shows an application registration form with required fields. Supported inputs in
   </TimePicker>
 </FluidForm>
 
-## Standalone fluid inputs
+## Supported inputs
+
+Fluid inputs can be used standalone outside a fluid form, custom inputs can
+opt into the same fluid behavior, and each supported input ships a dedicated
+skeleton for loading states.
+
+### Standalone
 
 Fluid inputs do not require a fluid form. Set `fluid` on a supported component to use the fluid variant standalone.
 
@@ -148,6 +156,8 @@ Fluid inputs do not require a fluid form. Set `fluid` on a supported component t
   ]}"
 />
 
+<Search fluid labelText="Search catalog" placeholder="Search services..." />
+
 <TextArea
   fluid
   labelText="Description"
@@ -158,6 +168,8 @@ Fluid inputs do not require a fluid form. Set `fluid` on a supported component t
 <CopyInput fluid labelText="API key" value="a1b2c3d4-e5f6-7890-abcd-ef1234567890" />
 
 <NumberInput fluid labelText="Clusters" value={0} />
+
+<PinCodeInput fluid labelText="Verification code" />
 
 Fluid time pickers use percentage-based columns (25% / 25% / 50% with two
 selects, 50% / 50% with one). Set a parent width so those ratios resolve as
@@ -176,6 +188,49 @@ intended.
   </TimePicker>
 </div>
 
+### Custom fluid-aware inputs
+
+FluidForm publishes context under the key `"carbon:Form"` so custom inputs
+can opt into the fluid variant automatically, the same way built-in inputs
+like `TextInput` and `NumberInput` do. Read `isFluid` from the context to
+adapt a custom component's rendering when it is placed inside a fluid form.
+
+```svelte
+<script>
+  import { getContext } from "svelte";
+
+  const formContext = getContext("carbon:Form");
+
+  $: isFluid = !!formContext?.isFluid;
+</script>
+```
+
+### Loading skeletons
+
+Each fluid input ships a dedicated skeleton component for loading states:
+`FluidTextInputSkeleton`, `FluidNumberInputSkeleton`, `FluidSearchSkeleton`,
+`FluidTextAreaSkeleton`, `FluidSelectSkeleton`, `FluidDropdownSkeleton`,
+`FluidComboBoxSkeleton`, `FluidMultiSelectSkeleton`, `FluidDatePickerSkeleton`,
+`FluidTimePickerSkeleton`, `FluidCopyInputSkeleton`, and
+`FluidPinCodeInputSkeleton`. Compose them to mirror a fluid form while data
+loads.
+
+<FluidTextInputSkeleton />
+<FluidSelectSkeleton />
+<FluidDatePickerSkeleton />
+
+## Invalid
+
+Handle form validation and display error states with `invalid` and `invalidText` on form inputs.
+
+<FileSource src="/framed/FluidForm/FluidFormInvalid" />
+
+## Inside a modal
+
+Place a fluid form inside a [modal](/components/Modal#full-width) to keep inputs flush with the modal edges. Set `fullWidth` on the modal to remove body padding so the form spans edge to edge.
+
+<FileSource src="/framed/FluidForm/FluidFormModal" />
+
 ## SvelteKit enhance
 
 Set `actions` to apply SvelteKit's `enhance` (or any other action) to the
@@ -193,28 +248,3 @@ usage details.
   <Button type="submit">Save</Button>
 </FluidForm>
 ```
-
-## Invalid
-
-Handle form validation and display error states with `invalid` and `invalidText` on form inputs.
-
-<FileSource src="/framed/FluidForm/FluidFormInvalid" />
-
-## Inside a modal
-
-Place a fluid form inside a [modal](/components/Modal#full-width) to keep inputs flush with the modal edges. Set `fullWidth` on the modal to remove body padding so the form spans edge to edge.
-
-<FileSource src="/framed/FluidForm/FluidFormModal" />
-
-## Loading skeletons
-
-Each fluid input ships a dedicated skeleton component for loading states:
-`FluidTextInputSkeleton`, `FluidNumberInputSkeleton`, `FluidSearchSkeleton`,
-`FluidTextAreaSkeleton`, `FluidSelectSkeleton`, `FluidDropdownSkeleton`,
-`FluidComboBoxSkeleton`, `FluidMultiSelectSkeleton`, `FluidDatePickerSkeleton`,
-and `FluidTimePickerSkeleton`. Compose them to mirror a fluid form while data
-loads.
-
-<FluidTextInputSkeleton />
-<FluidSelectSkeleton />
-<FluidDatePickerSkeleton />

--- a/docs/src/pages/components/Form.svx
+++ b/docs/src/pages/components/Form.svx
@@ -64,7 +64,12 @@ shows a form with checkboxes, radio buttons, and a select menu.
   <Button type="submit">Submit</Button>
 </Form>
 
-## Disabled
+## Form group
+
+Use `FormGroup` to wrap related controls in a `fieldset`, with an optional
+`legend` rendered from `legendText`.
+
+### Disabled
 
 Set `disabled` on FormGroup to disable the fieldset and nested native form
 controls. Labels are visually muted via Carbon's `fieldset[disabled]` styles.
@@ -84,7 +89,45 @@ of those components directly.
   <Button type="submit">Submit</Button>
 </Form>
 
-## Prevent default behavior
+### No margin
+
+Set `noMargin` to `true` to remove the default bottom margin below a fieldset,
+useful when stacking form groups without extra spacing between them.
+
+<Form>
+  <FormGroup legendText="Default spacing">
+    <Checkbox id="checkbox-margin-0" labelText="Checkbox Label" />
+  </FormGroup>
+  <FormGroup legendText="No margin" noMargin>
+    <Checkbox id="checkbox-margin-1" labelText="Checkbox Label" />
+  </FormGroup>
+</Form>
+
+### Validation
+
+Set `invalid` to `true` to mark the fieldset invalid via the `data-invalid`
+attribute. Set `message` to `true` with `messageText` to render a requirement
+below the fieldset's controls.
+
+<Form>
+  <FormGroup
+    legendText="Contact preferences"
+    invalid
+    message
+    messageText="Select at least one contact method"
+  >
+    <Checkbox id="checkbox-contact-0" labelText="Email" />
+    <Checkbox id="checkbox-contact-1" labelText="SMS" />
+  </FormGroup>
+  <Button type="submit">Submit</Button>
+</Form>
+
+## Submission
+
+Handle form submission, including preventing the default browser behavior and
+integrating with SvelteKit's form actions.
+
+### Prevent default behavior
 
 Handle form submission by preventing the default browser behavior. Use
 `e.preventDefault()` to stop the native form submission and handle the event
@@ -98,7 +141,7 @@ programmatically.
   <Button type="submit">Submit</Button>
 </Form>
 
-## SvelteKit enhance
+### SvelteKit enhance
 
 Svelte's `use:` directive cannot target components. Set `actions` to apply
 SvelteKit's `enhance` (or any other action) to the underlying form element.

--- a/docs/src/pages/components/Grid.svx
+++ b/docs/src/pages/components/Grid.svx
@@ -44,7 +44,26 @@ for dense data displays.
 
 <FileSource src="/framed/Grid/CondensedGrid" />
 
-## Responsive
+### Per-row
+
+`condensed`, `narrow`, `noGutter`, and `padding` are also available directly on
+`Row`, so you can mix densities within a single grid instead of applying a
+variant to every row.
+
+```svelte
+<Grid>
+  <Row condensed>
+    <Column>Condensed row</Column>
+    <Column>Condensed row</Column>
+  </Row>
+  <Row>
+    <Column>Default row</Column>
+    <Column>Default row</Column>
+  </Row>
+</Grid>
+```
+
+## Columns
 
 Build responsive layouts by setting a different column width per breakpoint.
 Each breakpoint has a different total column count, so scale spans
@@ -70,28 +89,73 @@ proportionally.
 <Column sm={4} md={2} lg={5} />
 ```
 
+### Extra-large and max breakpoints
+
+`lg`, `xlg`, and `max` all share the same 16-column grid, but the viewport
+keeps growing past `lg`. Set `xlg` and `max` independently when a layout needs
+a different span on very wide screens instead of stretching the `lg` value.
+
+```svelte
+<Column sm={4} md={8} lg={8} xlg={6} max={4} />
+```
+
 <FileSource src="/framed/Grid/ResponsiveGrid" />
 
-## Offset columns
+### Offset
 
 Create space between columns using the offset feature for more flexible layouts
 without empty columns.
 
 <FileSource src="/framed/Grid/OffsetColumns" />
 
-## Aspect ratio columns
+### Aspect ratio
 
 Maintain consistent column heights using aspect ratio columns. This ensures
 content alignment across different column widths.
 
 <FileSource src="/framed/Grid/AspectRatioColumns" />
 
-## Padding
+## Spacing
+
+Control vertical rhythm and horizontal gutters at the grid, row, or column
+level.
+
+### Padding
 
 Add vertical padding (top/bottom) with `padding`. Apply it at the grid, row, or column level to control spacing between rows
 of content. This is useful for creating vertical rhythm without manually adding margins.
 
 <FileSource src="/framed/Grid/PaddedGrid" />
+
+### Gutter
+
+Remove the horizontal gutter with `noGutter`, or remove just one side with
+`noGutterLeft` / `noGutterRight`. These props are available on `Grid`, `Row`,
+and `Column`, so you can drop the gutter globally or flush a single column
+against an edge or divider.
+
+<FileSource src="/framed/Grid/NoGutterColumns" />
+
+## Custom element
+
+Set `as` to `true` on `Grid`, `Row`, or `Column` to render a semantic element
+instead of the default `<div>`. Props are destructured as `props` in the
+default slot and must be spread onto the custom element to keep the Carbon
+grid classes.
+
+```svelte
+<Grid as let:props>
+  <main {...props}>
+    <Row as let:props>
+      <section {...props}>
+        <Column as let:props>
+          <article {...props}>Content</article>
+        </Column>
+      </section>
+    </Row>
+  </main>
+</Grid>
+```
 
 ## Breakpoints reference
 

--- a/docs/src/pages/components/Heading.svx
+++ b/docs/src/pages/components/Heading.svx
@@ -15,7 +15,17 @@ A top-level heading inside a section renders as an h1 element, a semantic starti
   <Heading>Heading 1</Heading>
 </Section>
 
-## Nested sections
+## Standalone heading
+
+A `Heading` used without a `Section` ancestor also defaults to h1. Wrap headings in `Section` when you need automatic level management as content nests.
+
+<Heading>Standalone Heading</Heading>
+
+## Heading levels
+
+`Heading` reads its semantic level (h1–h6) from the nearest `Section` context. Levels advance automatically as sections nest, and can be given a custom starting point.
+
+### Nested sections
 
 As you nest sections, heading levels automatically increment to maintain proper hierarchy. Each nested section increases the heading level by one (h1 → h2 → h3, and so on). Heading levels cap at h6 to ensure valid HTML structure, even when nested deeper than six levels.
 
@@ -41,7 +51,7 @@ As you nest sections, heading levels automatically increment to maintain proper 
   </Section>
 </Section>
 
-## Custom level
+### Custom starting level
 
 Set a custom starting heading level with `level` on the section. Child sections continue to increment from this level.
 

--- a/docs/src/pages/components/ImageLoader.svx
+++ b/docs/src/pages/components/ImageLoader.svx
@@ -6,6 +6,10 @@ description: Image loaders load images with built-in loading and error states, a
     import { ImageLoader, Button, InlineLoading } from "carbon-components-svelte";
 
     let key = 0;
+
+    let loading = false;
+    let loaded = false;
+    let imageError = false;
 </script>
 
 ## Basic
@@ -15,7 +19,35 @@ process automatically.
 
 <ImageLoader src="https://upload.wikimedia.org/wikipedia/commons/5/51/IBM_logo.svg" />
 
-## Slots
+## Alt text
+
+Set `alt` to provide alternative text for the image.
+
+<ImageLoader alt="IBM logo" src="https://upload.wikimedia.org/wikipedia/commons/5/51/IBM_logo.svg" />
+
+## Aspect ratio
+
+Maintain consistent image dimensions using aspect ratios. The component uses
+[AspectRatio](/components/AspectRatio) to constrain the image.
+
+Supported aspect ratios include `"2x1"`, `"2x3"`, `"16x9"`, `"4x3"`, `"1x1"`,
+`"3x4"`, `"3x2"`, `"9x16"` and `"1x2"`.
+
+<ImageLoader ratio="16x9" src="https://upload.wikimedia.org/wikipedia/commons/5/51/IBM_logo.svg" />
+
+## Fade in
+
+Enable a smooth fade-in animation when the image loads successfully.
+
+<Button kind="ghost" on:click="{() => { key++;}}">Reload image</Button>
+{#key key}<ImageLoader fadeIn ratio="16x9" src="https://upload.wikimedia.org/wikipedia/commons/5/51/IBM_logo.svg" />{/key}
+
+## Loading and error states
+
+ImageLoader tracks its own loading, loaded, and error state internally. Customize
+the UI shown at each stage, read the state directly, or listen for events.
+
+### Slots
 
 Customize the loading and error states using named slots.
 
@@ -28,30 +60,38 @@ Customize the loading and error states using named slots.
     </svelte:fragment>
 </ImageLoader>
 
-## With aspect ratio
+### Bindable state
 
-Maintain consistent image dimensions using aspect ratios. The component uses
-[AspectRatio](/components/AspectRatio) to constrain the image.
+Bind to `loading`, `loaded`, and `error` to read the image's state. All three
+props are readonly outside the component and are set automatically as the
+image loads.
 
-Supported aspect ratios include `"2x1"`, `"2x3"`, `"16x9"`, `"4x3"`, `"1x1"`,
-`"3x4"`, `"3x2"`, `"9x16"` and `"1x2"`.
-  
-<ImageLoader ratio="16x9" src="https://upload.wikimedia.org/wikipedia/commons/5/51/IBM_logo.svg" />
+<ImageLoader bind:loading bind:loaded bind:error={imageError} src="https://upload.wikimedia.org/wikipedia/commons/5/51/IBM_logo.svg" />
+<p>loading: {loading} · loaded: {loaded} · error: {imageError}</p>
 
-## Fade in
+### Events
 
-Enable a smooth fade-in animation when the image loads successfully.
+Dispatches `load` when the image loads successfully, and `error` when it
+fails to load.
 
-<Button kind="ghost" on:click="{() => { key++;}}">Reload image</Button>
-{#key key}<ImageLoader fadeIn ratio="16x9" src="https://upload.wikimedia.org/wikipedia/commons/5/51/IBM_logo.svg" />{/key}
+<ImageLoader
+  on:load={() => console.log("loaded")}
+  on:error={() => console.log("error")}
+  src="https://upload.wikimedia.org/wikipedia/commons/5/51/IBM_logo.svg"
+/>
 
-## Programmatic usage
+## Updating the image source
+
+Change the image displayed by the same ImageLoader instance, either
+imperatively or by reacting to a changing `src` value.
+
+### Programmatic
 
 Control image loading programmatically using component references.
 
 <FileSource src="/framed/ImageLoader/ProgrammaticImageLoader" />
 
-## Dynamic image source
+### Dynamic
 
 Update the image source dynamically using the same image loader instance for
 smooth transitions between images.

--- a/docs/src/pages/components/InlineLoading.svx
+++ b/docs/src/pages/components/InlineLoading.svx
@@ -35,6 +35,23 @@ The component supports different status states to indicate progress:
 <InlineLoading status="finished" description="Success" />
 <InlineLoading status="error" description="An error occurred" />
 
+### Icon description
+
+Set `iconDescription` to override the accessible label announced for the status icon. For the `"finished"` and `"error"` states, it defaults to the `status` value if not set.
+
+<InlineLoading status="error" iconDescription="Upload failed" description="An error occurred" />
+
+## Events
+
+Listen for `on:success`, dispatched `successDelay` milliseconds (default `1500`) after `status` is set to `"finished"`.
+
+<InlineLoading
+  status="finished"
+  description="Success"
+  successDelay={1000}
+  on:success={() => console.log("success")}
+/>
+
 ## UX example
 
 See how to integrate the loading indicator in a real-world scenario.

--- a/docs/src/pages/components/InlineNotification.svx
+++ b/docs/src/pages/components/InlineNotification.svx
@@ -19,6 +19,12 @@ Control notification visibility by binding to `open` to show, hide, and reuse th
 
 <FileSource src="/framed/InlineNotification/InlineNotificationReusable" />
 
+## Autoclose
+
+Automatically close the notification after a specified duration (in milliseconds) with `timeout`. Set `pauseOnHover` to pause the timeout while the pointer is over the notification so users can finish reading (opt-in).
+
+<FileSource src="/framed/InlineNotification/InlineNotificationTimeout" />
+
 ## Title and subtitle
 
 Both the title and subtitle are optional and can be customized with slots.
@@ -89,6 +95,12 @@ The component is controlled, so you can prevent the default close behavior with 
   e.preventDefault();
   // custom close logic (e.g., transitions)
 }} />
+
+## ARIA role
+
+Specify the ARIA `role` for the notification container to control how screen readers announce it. Defaults to `"alert"` for interruptive announcements. Use `"status"` for polite live-region updates, or `"log"` for a running log of messages.
+
+<InlineNotification role="status" kind="success" title="Success:" subtitle="Your settings have been saved." />
 
 ## Variants
 

--- a/docs/src/pages/components/Link.svx
+++ b/docs/src/pages/components/Link.svx
@@ -88,6 +88,32 @@ Use `LinkDownload` to trigger a client-side file download instead of navigating 
 
 <FileSource src="/framed/Link/LinkDownloadCsv" />
 
+### Events
+
+Listen for `download`, dispatched after the file downloads successfully, and `download:error`, dispatched if the download throws, with the error at `event.detail.error`.
+
+<LinkDownload
+  data="id,name{'\n'}1,Alpha{'\n'}2,Bravo"
+  filename="items.csv"
+  type="text/csv;charset=utf-8"
+  on:download={() => console.log("downloaded")}
+  on:download:error={(e) => console.log(e.detail.error)}
+>
+  Download CSV
+</LinkDownload>
+
+### Custom download behavior
+
+Override the default download behavior by passing a function to `download`. It receives `(data, filename, type)` and can return a promise; use it to upload the payload, show a confirmation step, or otherwise replace the built-in Blob download.
+
+<LinkDownload
+  data="id,name{'\n'}1,Alpha{'\n'}2,Bravo"
+  filename="items.csv"
+  download={(data, filename, type) => console.log(data, filename, type)}
+>
+  Download CSV
+</LinkDownload>
+
 ## Icons
 
 Add an icon with the `icon` prop. Inline must be false when using icons.
@@ -98,6 +124,18 @@ Add an icon with the `icon` prop. Inline must be false when using icons.
   Visit the
   <Link href="https://www.carbondesignsystem.com/" icon={Carbon}>
     Carbon Design System
+  </Link>.
+</div>
+
+### Custom icon
+
+Use the `icon` named slot to render custom icon markup instead of, or with different props than, the `icon` prop.
+
+<div>
+  Visit the
+  <Link href="https://www.carbondesignsystem.com/">
+    Carbon Design System
+    <Carbon slot="icon" size={24} />
   </Link>.
 </div>
 
@@ -123,17 +161,15 @@ Set `size` to control link size. The default is medium (`"md"`).
   Small link
 </Link>
 
-## Size with icon
+### Large with icon
 
 Combine `size` and `icon`. The icon scales to match the link size. Inline must be false.
-
-### Large
 
 <Link size="lg" href="https://www.carbondesignsystem.com/" icon={Carbon}>
   Large link
 </Link>
 
-### Small
+### Small with icon
 
 <Link size="sm" href="https://www.carbondesignsystem.com/" icon={Carbon}>
   Small link
@@ -145,7 +181,7 @@ Reflect interaction and navigation history.
 
 ### Disabled
 
-Disabled links render as plain text while remaining accessible.
+Set `disabled` to `true` to disable the link. Native `<a>` elements have no `disabled` attribute, so the link instead renders with `role="link"` and `aria-disabled="true"`, and drops its `href`, remaining focusable and readable by assistive technology while looking and behaving like plain text. Clicks are also blocked outright—`event.preventDefault()` and `event.stopPropagation()` run before any forwarded `on:click` listener, so neither the link nor an ancestor element receives the click.
 
 <Link disabled href="https://www.carbondesignsystem.com/">
   Disabled link

--- a/docs/src/pages/components/Loading.svx
+++ b/docs/src/pages/components/Loading.svx
@@ -24,3 +24,15 @@ Show a loading indicator without the overlay, allowing interaction with the unde
 Display a more compact loading indicator.
 
 <Loading withOverlay={false} small />
+
+## Description
+
+Customize the text announced to screen readers by setting `description`. Defaults to `"loading"`.
+
+<Loading description="Loading metrics..." withOverlay={false} />
+
+## Stop state
+
+Set `active` to `false` to play the spinner's end-of-loading animation and mark it inactive for screen readers (`aria-live="off"`). Useful when transitioning out of a loading state before removing the component.
+
+<Loading active={false} withOverlay={false} />

--- a/docs/src/pages/components/LocalStorage.svx
+++ b/docs/src/pages/components/LocalStorage.svx
@@ -12,6 +12,8 @@ See how the component maintains state across page reloads. Toggle the switch and
 
 The component listens for the [storage event](https://developer.mozilla.org/en-US/docs/Web/API/Window/storage_event), so changes made in one browser tab are automatically synchronized to other tabs with the same key. Cross-tab updates dispatch `on:update` with a payload shaped like `{ prevValue, value }`. When another tab removes the key, the bound value resets to undefined so the next local write does not re-persist stale data.
 
+The example below logs both `on:save` and `on:update` as they fire; see [Events](#events) for what each one means.
+
 <FileSource src="/framed/LocalStorage/LocalStorage" />
 
 ## Persisting objects and arrays
@@ -54,8 +56,40 @@ The component provides methods to manage stored data:
 | `clearItem`  | Remove a specific key-value pair.   |
 | `clearAll`   | Remove all stored data.             |
 
-Use `bind:this` to access these methods. They only clear browser storage in the current tab; they do not reset the bound value. Other tabs with the same key will reset their bound value when they receive the storage event. To clear both storage and the bound value in the current tab, reset the value yourself after calling clearItem or clearAll.
+Use `bind:this` to access these methods. They only clear browser storage in the current tab; they do not reset the bound value. Other tabs with the same key will reset their bound value when they receive the storage event. To clear both storage and the bound value in the current tab, reset the value yourself after calling clearItem or clearAll — if you don't, the next mutation to `value` persists as normal and silently rewrites the key you just cleared, since clearing storage doesn't change the component's own record of what `value` currently is.
 
 In this example, try toggling the switch, refreshing the page, then clearing the storage.
 
 <FileSource src="/framed/LocalStorage/LocalStorageClear" />
+
+## Events
+
+The component dispatches three events: `save`, `update`, and `error`.
+
+### Update
+
+Fires whenever the persisted value changes — after your own `bind:value` write, or when another tab or window writes the same key while `sync` is `"on"` (the default). The payload is `{ prevValue, value }`.
+
+```svelte
+<LocalStorage
+  key="dark-mode"
+  bind:value
+  on:update={({ detail }) => console.log(detail)} // { prevValue, value }
+/>
+```
+
+### Save
+
+Fires once, when the component mounts, if the key does not already exist in storage — this is the component's own first write to initialize that key. Switching to a different key afterward (see [Reactive key](#reactive-key)) does not dispatch `save`, even if the new key has no stored value yet.
+
+### Error
+
+Fires when a write to storage fails, for example when the storage quota is exceeded or storage access is denied (such as private browsing modes that disable storage). The payload is `{ error }`.
+
+```svelte
+<LocalStorage
+  key="my-key"
+  bind:value
+  on:error={({ detail }) => console.error(detail.error)}
+/>
+```

--- a/docs/src/pages/components/Menu.svx
+++ b/docs/src/pages/components/Menu.svx
@@ -1,5 +1,5 @@
 ---
-components: ["Menu", "MenuItem", "MenuDivider"]
+components: ["Menu", "MenuItem", "MenuDivider", "MenuItemGroup", "MenuItemRadioGroup"]
 description: Menu positions a list of actions next to an anchor element you control. Keyboard navigation and outside-click dismissal are built in.
 ---
 
@@ -18,6 +18,12 @@ The root element has `role="menu"`. Set `labelText` or `aria-label` on Menu so a
 
 Set `size` to control each item's row height. The default is `"sm"`.
 
+### Extra small
+
+`"xs"` has no Carbon v10 equivalent; it's a compact row height hand-authored for this library.
+
+<FileSource src="/framed/Menu/MenuSizeExtraSmall" />
+
 ### Medium
 
 <FileSource src="/framed/Menu/MenuSizeMedium" />
@@ -28,7 +34,7 @@ Set `size` to control each item's row height. The default is `"sm"`.
 
 ## Menu items
 
-`MenuItem` takes an `icon`, `kind="danger"` for destructive rows, and nested children for submenus. Use `MenuDivider` between groups. Items can also hold checkbox or radio state; see [MenuButton selectable](/components/MenuButton#selectable).
+`MenuItem` takes an `icon`, `kind="danger"` for destructive rows, and nested children for submenus. Use `MenuDivider` between groups.
 
 ### Icons
 
@@ -54,15 +60,27 @@ Put a `MenuDivider` between groups.
 
 <FileSource src="/framed/Menu/MenuItemDividers" />
 
+### Selectable
+
+Wrap items in `MenuItemGroup` to make them checkboxes that hold state, such as which table columns are visible. Set `labelText` on `MenuItemGroup` for the group's accessible name. Give every item an `id`, then bind `selectedIds` for the chosen ones. Set `selected` on an item to check it when the menu first opens, or set `selectable` on a single item outside a group for a standalone toggle. See [MenuButton selectable](/components/MenuButton#selectable) for how this interacts with keeping the menu open on selection.
+
+<FileSource src="/framed/Menu/MenuItemSelectable" />
+
+### Radio group
+
+Wrap items in `MenuItemRadioGroup` for a set where one choice is active at a time, such as row density. Set `labelText` on `MenuItemRadioGroup` for the group's accessible name. Bind `selectedId` for the active id; picking another item clears the previous one.
+
+<FileSource src="/framed/Menu/MenuItemRadioGroup" />
+
 ### Nested
 
-Set `labelText` on a `MenuItem` and nest child `MenuItem` rows to get a submenu. See [MenuButton menu items](/components/MenuButton#menu-items) for keyboard and hover behavior.
+Set `labelText` on a `MenuItem` and nest child `MenuItem` rows to get a submenu. Use the `labelChildren` slot instead of plain text to customize the label's content; `labelText` is still used as the accessible name and title in that case. See [MenuButton menu items](/components/MenuButton#menu-items) for keyboard and hover behavior.
 
 <FileSource src="/framed/Menu/MenuItemNested" />
 
 ## Keyboard interactions
 
-Once open, arrow keys move focus between items without wrapping past the first or last item. <DocKbd label="Home" /> and <DocKbd label="End" /> jump to the first and last enabled item, skipping disabled ones. The menu closes from an item selection, <DocKbd label="Escape" />, or an outside click; <DocKbd label="Escape" /> also returns focus to the anchor. An item's `click` event is cancelable. Call `event.preventDefault()` in its handler to keep the menu open after selection. See [MenuButton keep open on selection](/components/MenuButton#keep-open-on-selection).
+Once open, arrow keys move focus between items without wrapping past the first or last item. <DocKbd label="Home" /> and <DocKbd label="End" /> jump to the first and last enabled item, skipping disabled ones. <DocKbd label="Escape" /> closes the menu and returns focus to the anchor. See [Events](#events) for the full set of ways the menu can close, and how to keep it open after selection.
 
 ## Scrollable
 
@@ -103,3 +121,17 @@ By default, the menu mounts into the anchor's nearest `<dialog>` or `[popover]` 
 ### Z-index
 
 Set `zIndex` to change the menu's stacking order. The default is `9200`.
+
+## Events
+
+Menu dispatches `open` once it finishes opening and focus moves to the first item, and `close` on every close attempt.
+
+<FileSource src="/framed/Menu/MenuEvents" />
+
+### Open event
+
+`open`'s detail is the `anchor` element.
+
+### Close event
+
+Use `on:close` to respond to every close attempt, regardless of cause. The event detail's `trigger` is `"escape-key"`, `"outside-click"`, or `"select"`. An item's `click` event is separately cancelable: call `event.preventDefault()` in a `MenuItem`'s `on:click` handler to keep the menu open after that particular selection. See [MenuButton keep open on selection](/components/MenuButton#keep-open-on-selection).

--- a/docs/src/pages/components/MenuButton.svx
+++ b/docs/src/pages/components/MenuButton.svx
@@ -12,7 +12,7 @@ description: MenuButton is a labeled button that opens a dropdown of actions, in
 
 ## Basic
 
-Wrap `MenuItem` components in `MenuButton` and set `labelText` for the trigger label. Use the `labelChildren` slot for custom trigger content. Unlike [Menu](/components/Menu), `MenuButton` includes the trigger; you don't pass an anchor. 
+Wrap `MenuItem` components in `MenuButton` and set `labelText` for the trigger label. Use the `labelChildren` slot for custom trigger content. Unlike [Menu](/components/Menu), `MenuButton` includes the trigger; you don't pass an anchor. See [Events](#events) for the menu's `close` event.
 
 <MenuButton labelText="Actions">
   <MenuItem on:click={() => console.log("Cut")}>Cut</MenuItem>
@@ -20,6 +20,12 @@ Wrap `MenuItem` components in `MenuButton` and set `labelText` for the trigger l
   <MenuItem on:click={() => console.log("Paste")}>Paste</MenuItem>
   <MenuItem disabled>Delete</MenuItem>
 </MenuButton>
+
+## Reactive example
+
+Control the menu state programmatically by binding to `open`.
+
+<FileSource src="/framed/MenuButton/MenuButtonReactive" />
 
 ## Kind
 
@@ -81,7 +87,7 @@ Set `size` to scale the trigger button and each menu item's row height together.
 
 ## Icon-only
 
-Set `iconOnly` for an icon-only trigger. `labelText` is no longer rendered, but it remains the trigger's accessible name. Pass `icon` to swap the glyph. Use this trigger for overflow menus that need submenus, which [OverflowMenu](/components/OverflowMenu) does not support.
+Set `iconOnly` for an icon-only trigger. `labelText` is no longer rendered, but it remains the trigger's accessible name. Use this trigger for overflow menus that need submenus, which [OverflowMenu](/components/OverflowMenu) does not support.
 
 <MenuButton iconOnly labelText="Row actions">
   <MenuItem on:click={() => console.log("Rename")}>Rename</MenuItem>
@@ -90,6 +96,26 @@ Set `iconOnly` for an icon-only trigger. `labelText` is no longer rendered, but 
     <MenuItem on:click={() => console.log("CSV")}>CSV</MenuItem>
   </MenuItem>
   <MenuDivider />
+  <MenuItem icon={TrashCan} kind="danger" on:click={() => console.log("Delete")}>
+    Delete
+  </MenuItem>
+</MenuButton>
+
+### Custom icon
+
+Pass `icon` to swap the glyph. The default is the overflow (kebab) icon.
+
+<MenuButton iconOnly labelText="Copy options" icon={Copy}>
+  <MenuItem on:click={() => console.log("Copy")}>Copy</MenuItem>
+  <MenuItem on:click={() => console.log("Copy as reference")}>Copy as reference</MenuItem>
+</MenuButton>
+
+### Icon description
+
+The icon-only trigger needs its own accessible label, since it has no visible text. Override `iconDescription` to change it; the default is `labelText`.
+
+<MenuButton iconOnly labelText="Row actions" iconDescription="More row actions">
+  <MenuItem on:click={() => console.log("Rename")}>Rename</MenuItem>
   <MenuItem icon={TrashCan} kind="danger" on:click={() => console.log("Delete")}>
     Delete
   </MenuItem>
@@ -221,3 +247,14 @@ Set `labelText` on a `MenuItem` and nest child `MenuItem` rows to get a submenu.
 Choosing an item closes the menu by default, including any open submenus. Call `event.preventDefault()` in the item's `on:click` handler to keep the menu open. A selectable or radio item still updates its own state; only the close is canceled. Use this for multi-select, or for a radio choice in a submenu that should stay open after a pick.
 
 <FileSource src="/framed/MenuButton/MenuButtonKeepOpen" />
+
+## Events
+
+### Close event
+
+Use `on:close` to respond to every close attempt, regardless of cause. The event detail's `trigger` is `"escape-key"`, `"outside-click"`, or `"select"`.
+
+<MenuButton labelText="Actions" on:close={(e) => console.log(e.detail.trigger)}>
+  <MenuItem on:click={() => console.log("Cut")}>Cut</MenuItem>
+  <MenuItem on:click={() => console.log("Copy")}>Copy</MenuItem>
+</MenuButton>

--- a/docs/src/pages/components/Modal.svx
+++ b/docs/src/pages/components/Modal.svx
@@ -6,7 +6,17 @@ description: Modals provide a focused dialog for user interactions, confirmation
 
 The modal is an all-in-one component configured through props, making it ideal for standard modal dialogs. For more complex layouts or fine-grained control, use [ComposedModal](/components/ComposedModal) instead.
 
-## Focus behavior
+## Basic
+
+Display a modal dialog with a header, content area, and footer. Use primary and secondary actions for confirmations or input. Neither button closes the modal automatically — wire up `on:submit` and `on:click:button--secondary` to set `open` to `false` yourself; see [Events](#events).
+
+<FileSource src="/framed/Modal/Modal" />
+
+## Focus
+
+Control how focus moves when the modal opens, and override the default target when needed.
+
+### Focus behavior
 
 When the modal opens, focus is set using the following priority:
 
@@ -17,33 +27,23 @@ When the modal opens, focus is set using the following priority:
 
 After closing the modal, focus is returned to the element that triggered the modal.
 
-## Basic
-
-Display a modal dialog with a header, content area, and footer. Use primary and secondary actions for confirmations or input.
-
-<FileSource src="/framed/Modal/Modal" />
-
-## With portal
-
-Wrap the modal in a portal to escape parent containers with `overflow: hidden` or z-index stacking contexts. This ensures the modal appears above all content and isn't clipped by parent boundaries.
-
-<FileSource src="/framed/Portal/ModalPortal" />
-
-## Modal with dropdowns
-
-Components with menus — such as a combo box, dropdown, multi-select, date picker, or overflow menu — automatically render their menus in a floating portal when used inside a modal. The menus are positioned relative to their trigger and are not clipped by the modal's overflow or z-index stacking.
-
-Set `portalMenu={false}` on these components to opt out. In this example, the modal itself is wrapped in a portal.
-
-<FileSource src="/framed/Modal/ModalWithDropdowns" />
-
-## Custom focus
+### Custom focus
 
 Use `selectorPrimaryFocus` to override the default and target a specific element when the automatic first-input focus is not desired.
 
 <FileSource src="/framed/Modal/ModalCustomFocus" />
 
-## Danger
+## Alert mode
+
+Set `alert` to `true` to mark the modal as time-sensitive or requiring immediate attention. This changes the ARIA `role` from `"dialog"` to `"alertdialog"` (or `"alert"` when combined with `passiveModal`), which prompts assistive technology to announce the modal as soon as it opens. When not `passiveModal`, the body content is also linked with `aria-describedby` so screen readers include it in the announcement.
+
+<FileSource src="/framed/Modal/ModalAlert" />
+
+## Variants
+
+Change the modal's tone and purpose.
+
+### Danger
 
 Display critical actions or destructive operations with the danger variant. This style emphasizes the severity of the action.
 
@@ -51,37 +51,73 @@ By default, the cancel button receives focus instead of the critical button to p
 
 <FileSource src="/framed/Modal/DangerModal" />
 
-## Passive
+### Passive
 
 Create a non-interactive modal for displaying information. This variant lacks action buttons and focuses on content presentation. Since there is no primary button, the close button will receive focus when the modal opens.
 
 <FileSource src="/framed/Modal/PassiveModal" />
 
-## With form submission
+## Content
+
+Customize the modal's heading, label, and body content.
+
+### Custom heading and label
+
+Override the plain-text `modalHeading` and `modalLabel` with the `heading` and `label` slots when you need richer markup, such as a status tag next to the title.
+
+<FileSource src="/framed/Modal/ModalCustomHeading" />
+
+### With form submission
 
 Connect the modal's primary button to a form with `formId`. This enables native form submission even though the button is outside the form element. Clicking the primary button or pressing <DocKbd label="Enter" /> will trigger the form's submit event.
 
 <FileSource src="/framed/Modal/ModalWithForm" />
 
-## Primary button loading
-
-Set `primaryButtonLoading` while an async submit is in progress. The primary button shows an [InlineLoading](/components/InlineLoading) spinner, becomes non-interactive, and suppresses `submit` until loading finishes. The modal stays open.
-
-<FileSource src="/framed/Modal/ModalPrimaryButtonLoading" />
-
-## Has scrolling content
+### Has scrolling content
 
 Enable vertical scrolling for modals with lengthy content. This ensures all content remains accessible while maintaining a reasonable modal height.
 
 <FileSource src="/framed/Modal/ModalScrollingContent" />
 
-## Multiple modals
+### Full width
+
+Set `fullWidth` to remove the modal body padding so content spans edge to edge. Use it for content that supplies its own layout, such as a table or fluid form.
+
+<FileSource src="/framed/Modal/FullWidthModal" />
+
+## Buttons
+
+Configure the footer actions.
+
+### Multiple secondary buttons
+
+Add up to two secondary actions with `secondaryButtons`, which replaces the single secondary button text option. Each entry needs display text; set `kind` and `disabled` per button when actions should differ in weight or availability.
+
+<FileSource src="/framed/Modal/3ButtonModal" />
+
+### Button with icon
+
+Enhance modal buttons with icons for better visual context and clarity.
+
+<FileSource src="/framed/Modal/ModalButtonWithIcon" />
+
+### Primary button loading
+
+Set `primaryButtonLoading` while an async submit is in progress. The primary button shows an [InlineLoading](/components/InlineLoading) spinner, becomes non-interactive, and suppresses `submit` until loading finishes. The modal stays open.
+
+<FileSource src="/framed/Modal/ModalPrimaryButtonLoading" />
+
+## Stacking modals
+
+Show more than one modal at a time.
+
+### Multiple modals
 
 Stack multiple modals for complex workflows. Each modal maintains its own state and focus management.
 
 <FileSource src="/framed/Modal/ModalMultiple" />
 
-## Nested
+### Nested
 
 Nest a modal inside another modal's content to stack a confirmation dialog on top of it. Each modal tracks its own `open` state, and <DocKbd label="Escape" /> only closes the topmost (innermost) modal.
 
@@ -89,11 +125,23 @@ Wrap the nested modal in [Portal](/components/Portal) so it renders outside the 
 
 <FileSource src="/framed/Modal/ModalNested" />
 
-## Multiple secondary buttons
+## Portal and dropdowns
 
-Add up to two secondary actions with `secondaryButtons`, which replaces the single secondary button text option. Each entry needs display text; set `kind` and `disabled` per button when actions should differ in weight or availability.
+Render the modal — or components inside it — outside normal DOM boundaries.
 
-<FileSource src="/framed/Modal/3ButtonModal" />
+### With portal
+
+Wrap the modal in a portal to escape parent containers with `overflow: hidden` or z-index stacking contexts. This ensures the modal appears above all content and isn't clipped by parent boundaries.
+
+<FileSource src="/framed/Portal/ModalPortal" />
+
+### Modal with dropdowns
+
+Components with menus — such as a combo box, dropdown, multi-select, date picker, or overflow menu — automatically render their menus in a floating portal when used inside a modal. The menus are positioned relative to their trigger and are not clipped by the modal's overflow or z-index stacking.
+
+Set `portalMenu={false}` on these components to opt out. In this example, the modal itself is wrapped in a portal.
+
+<FileSource src="/framed/Modal/ModalWithDropdowns" />
 
 ## Sizes
 
@@ -117,19 +165,13 @@ Use the large size for complex content by setting `size` to `"lg"`.
 
 <FileSource src="/framed/Modal/ModalLarge" />
 
-## Full width
-
-Set `fullWidth` to remove the modal body padding so content spans edge to edge. Use it for content that supplies its own layout, such as a table or fluid form.
-
-<FileSource src="/framed/Modal/FullWidthModal" />
-
 ## Closing
 
 Control how the modal can be dismissed.
 
 ### Prevent default
 
-The modal dispatches a cancelable `close` event. Call `e.preventDefault()` to keep the modal open. The event includes a `trigger` property indicating what triggered the close attempt: `"escape-key"` (<DocKbd label="Escape" />), `"outside-click"`, or `"close-button"`.
+The modal dispatches a cancelable `close` event. Call `e.preventDefault()` to keep the modal open. The event includes a `trigger` property indicating what triggered the close attempt: `"escape-key"` (<DocKbd label="Escape" />), `"outside-click"`, `"close-button"`, or `"programmatic"` (the `open` prop was set to `false` from outside the component, for example through `bind:open`, rather than through one of the modal's own dismiss controls).
 
 <FileSource src="/framed/Modal/ModalPreventClose" />
 
@@ -145,8 +187,41 @@ Set `hideCloseButton` to `true` to remove the header close button. Use this for 
 
 <FileSource src="/framed/Modal/ModalHideCloseButton" />
 
-## Button with icon
+## Events
 
-Enhance modal buttons with icons for better visual context and clarity.
+Modal dispatches events for its lifecycle and button interactions. Only the close button, <DocKbd label="Escape" />, and (by default) an outside click close the modal automatically — see [Closing](#closing) above. Every other action leaves `open` untouched; handle the event and set `open` to `false` yourself when the action should dismiss the dialog.
 
-<FileSource src="/framed/Modal/ModalButtonWithIcon" />
+### Open
+
+Listen for `on:open` to know when the modal has become visible and focus has moved into it.
+
+```svelte
+<Modal bind:open on:open={() => console.log("opened")}>
+```
+
+### Submit and button clicks
+
+The primary button dispatches both `submit` and `click:button--primary` when clicked. Secondary buttons dispatch `click:button--secondary` with the button's `text`.
+
+```svelte
+<Modal
+  bind:open
+  primaryButtonText="Confirm"
+  secondaryButtonText="Cancel"
+  on:click:button--secondary={() => (open = false)}
+  on:submit={() => (open = false)}
+>
+```
+
+When `shouldSubmitOnEnter` is `true` (the default), pressing <DocKbd label="Enter" /> also dispatches `submit` and `click:button--primary`, unless focus is on a button, textarea, select, or contenteditable element. Set `shouldSubmitOnEnter` to `false` to disable this.
+
+### Transition end
+
+Listen for `on:transitionend` to know when the modal's open or close animation finishes. `event.detail.open` reflects the modal's state at the end of the transition.
+
+```svelte
+<Modal
+  bind:open
+  on:transitionend={(e) => console.log("open:", e.detail.open)}
+>
+```

--- a/docs/src/pages/components/Modal.svx
+++ b/docs/src/pages/components/Modal.svx
@@ -81,6 +81,14 @@ Stack multiple modals for complex workflows. Each modal maintains its own state 
 
 <FileSource src="/framed/Modal/ModalMultiple" />
 
+## Nested
+
+Nest a modal inside another modal's content to stack a confirmation dialog on top of it. Each modal tracks its own `open` state, and <DocKbd label="Escape" /> only closes the topmost (innermost) modal.
+
+Wrap the nested modal in [Portal](/components/Portal) so it renders outside the outer modal's DOM. The outer modal's container has its own transform and `overflow: hidden`, so an unportaled nested modal would be sized and clipped to that container instead of covering the full screen.
+
+<FileSource src="/framed/Modal/ModalNested" />
+
 ## Multiple secondary buttons
 
 Add up to two secondary actions with `secondaryButtons`, which replaces the single secondary button text option. Each entry needs display text; set `kind` and `disabled` per button when actions should differ in weight or availability.

--- a/docs/src/pages/components/MultiSelect.svx
+++ b/docs/src/pages/components/MultiSelect.svx
@@ -61,6 +61,16 @@ Hide the label visually by setting `hideLabel` to `true`. The label remains avai
     {id: "2", text: "Fax"}]}"
   />
 
+### Title attribute
+
+Set `useTitleInItem` to `true` to add a native `title` attribute to each option, using the resolved `itemToString` text. This surfaces a browser tooltip when an item's label is truncated by the field width.
+
+<MultiSelect useTitleInItem labelText="Contact" label="Select contact methods..."
+    items="{[{id: "0", text: "Slack"},
+    {id: "1", text: "Email"},
+    {id: "2", text: "Fax"}]}"
+  />
+
 ### Checkbox values
 
 `MultiSelect` mounts a hidden `<input>` for every selected item, derived
@@ -166,6 +176,16 @@ The select-all option is styled differently from regular options (with a separat
 Bind to `sortedItems` to read the resolved list after sorting and selection feedback is applied. This avoids recomputing the order from items, selectedIds, and sortItem in consumer code.
 
 <FileSource src="/framed/MultiSelect/MultiSelectSortedItems" />
+
+### Locale
+
+Set `locale` to a BCP 47 language tag to control how the default `sortItem` orders items. The default sort uses `Intl.Collator` with numeric-aware comparison, so locale affects the ordering of accented characters and numbers embedded in text. Only used when `sortItem` is left at its default -- a custom `sortItem` ignores `locale`.
+
+<MultiSelect locale="de-DE" labelText="Contact" label="Select contact methods..."
+    items="{[{id: "0", text: "Öl"},
+    {id: "1", text: "Apfel"},
+    {id: "2", text: "Zebra"}]}"
+  />
 
 ### No alphabetical ordering
 
@@ -287,11 +307,7 @@ Use the extra-large size for prominent selections by setting `size` to `"xl"`.
     {id: "2", text: "Fax"}]}"
   />
 
-## Variants
-
-Alternate presentations for different surfaces and layouts.
-
-### Light
+## Light
 
 Use the light variant for dark backgrounds by setting `light` to `true`.
 
@@ -301,7 +317,7 @@ Use the light variant for dark backgrounds by setting `light` to `true`.
     {id: "2", text: "Fax"}]}"
   />
 
-### Inline
+## Inline
 
 Display the dropdown inline with other content by setting `type` to `"inline"`. This removes the background and border.
 

--- a/docs/src/pages/components/NotificationQueue.svx
+++ b/docs/src/pages/components/NotificationQueue.svx
@@ -15,6 +15,10 @@ Use `bind:this` to get a queue reference, then call `add()` to show notification
 
 ## Positioning
 
+Configure where the queue and its notifications render on screen.
+
+### Screen position
+
 Configure queue position with the `position` prop. Supported values are `top-left`, `top-center`, `top-right` (default), `bottom-left`, `bottom-center`, and `bottom-right`.
 
 The top-right position assumes usage of the [UIShell](/components/UIShell) component. Use left or center placements when a side panel would otherwise cover toasts. Customize placement with [offset props](#custom-offsets).
@@ -27,7 +31,21 @@ Customize queue placement with `offsetTop`, `offsetBottom`, `offsetLeft`, and `o
 
 <FileSource src="/framed/NotificationQueue/NotificationQueueOffsets" />
 
-## Deduplication
+### Z-index
+
+Specify the stacking order of the queue with `zIndex`. Defaults to `9000`, matching the z-index used by [Modal](/components/Modal), so notifications render above dialog content by default.
+
+```svelte
+<NotificationQueue zIndex={2000} />
+```
+
+Lower the value if the queue should render behind other fixed UI instead.
+
+## Managing notifications
+
+The queue tracks notifications by id, so `add`, `update`, `remove`, and the `maxNotifications` limit all key off the same identifier.
+
+### Deduplication
 
 By default, id is optional; a unique id is generated for each notification. The queue [keys](https://svelte.dev/docs/svelte/each#Keyed-each-blocks) notifications by id for performance.
 
@@ -35,7 +53,7 @@ Notifications are deduplicated by id. Adding a notification with an id that alre
 
 <FileSource src="/framed/NotificationQueue/NotificationQueueDeduplication" />
 
-## Update
+### Update
 
 Use `update(id, patch)` to change an existing notification in place. The patch merges into the matching notification, useful for reflecting progress (for example, transitioning a loading toast to success without removing and re-adding it).
 
@@ -43,7 +61,7 @@ Use `update(id, patch)` to change an existing notification in place. The patch m
 
 <FileSource src="/framed/NotificationQueue/NotificationQueueUpdate" />
 
-## Max notifications
+### Max notifications
 
 By default, the queue displays a maximum of 3 notifications. When the limit is exceeded, the oldest notification is removed automatically.
 
@@ -51,7 +69,7 @@ Customize the limit with `maxNotifications`.
 
 <FileSource src="/framed/NotificationQueue/NotificationQueueMax" />
 
-## Remove and clear
+### Remove and clear
 
 Use `remove(id)` to programmatically remove a specific notification, or `clear()` to remove all notifications at once.
 

--- a/docs/src/pages/components/NumberInput.svx
+++ b/docs/src/pages/components/NumberInput.svx
@@ -33,6 +33,14 @@ Hide the label visually by setting `hideLabel` to `true`. The label remains avai
 
 <NumberInput hideLabel labelText="Clusters" value={0} />
 
+## Custom label
+
+Use the `labelChildren` slot to provide custom label content.
+
+<NumberInput labelText="" value={0}>
+  <strong slot="labelChildren">Clusters</strong>
+</NumberInput>
+
 ## Range and steps
 
 Control the allowed values and increment.
@@ -100,9 +108,36 @@ string and optional locale. Return `false` to mark invalid, `true` to force vali
 
 <NumberInput validate={(raw) => { const num = Number(raw); return Number.isNaN(num) ? undefined : num % 2 === 0; }} invalidText="Must be an even number" labelText="Even number" value={0} />
 
+## Stepper controls
+
+Control the stepper buttons and scroll-wheel interaction.
+
+### Hidden steppers
+
+Hide the increment and decrement controls by setting `hideSteppers` to `true`.
+
+<NumberInput hideSteppers labelText="Clusters" value={0} />
+
+### Disable wheel
+
+Prevent the scroll wheel from changing the input value by setting `disableWheel` to `true`. This is useful in forms where accidental scroll changes are undesirable.
+
+<NumberInput disableWheel labelText="Clusters" value={0} />
+
 ## Events
 
 Respond to value changes and stepper interactions.
+
+### Value change
+
+Use `on:input` to listen for every keystroke, and `on:change` to listen for
+committed changes—on blur, or immediately after a stepper click or arrow key
+press. Both events dispatch the parsed value directly as `event.detail`.
+
+<NumberInput
+  on:input={(e) => console.log(e.detail)} // number | null
+  on:change={(e) => console.log(e.detail)} // number | null
+/>
 
 ### Blur
 
@@ -246,18 +281,6 @@ Disable the input by setting `disabled` to `true`.
 Make the input read-only by setting `readonly` to `true`. This allows viewing but prevents editing.
 
 <NumberInput readonly labelText="Clusters" value={0} />
-
-## Hidden steppers
-
-Hide the increment and decrement controls by setting `hideSteppers` to `true`.
-
-<NumberInput hideSteppers labelText="Clusters" value={0} />
-
-## Disable wheel
-
-Prevent the scroll wheel from changing the input value by setting `disableWheel` to `true`. This is useful in forms where accidental scroll changes are undesirable.
-
-<NumberInput disableWheel labelText="Clusters" value={0} />
 
 ## Skeleton
 

--- a/docs/src/pages/components/NumberInput.svx
+++ b/docs/src/pages/components/NumberInput.svx
@@ -211,7 +211,7 @@ Invalid and warning states are not displayed while the input is disabled.
 
 Invalid and warning states are not displayed while the input is read-only.
 
-<NumberInput fluid readonly warn warnText="The number of clusters is read-only." labelText="Clusters" value={0} />
+<NumberInput fluid readonly labelText="Clusters" value={0} />
 
 ### Skeleton
 

--- a/docs/src/pages/components/OrderedList.svx
+++ b/docs/src/pages/components/OrderedList.svx
@@ -33,9 +33,13 @@ Add interactive elements like link components within list items.
   </ListItem>
 </OrderedList>
 
-## Nested
+## Nested lists
 
-Create nested lists with `nested` for proper indentation and numbering.
+Create hierarchical lists with support for the browser's native numbering style.
+
+### Standard
+
+Set `nested` on a child ordered list for proper indentation and numbering.
 
 <OrderedList>
   <ListItem>
@@ -55,13 +59,9 @@ Create nested lists with `nested` for proper indentation and numbering.
   <ListItem>Ordered list level 1</ListItem>
 </OrderedList>
 
-## Styles
+### Native styles
 
-Alternate rendering styles for the list.
-
-### Native
-
-Enable native browser list styles with `native`. Useful for large lists where the list number may overlap with the list item text.
+Set `native` to `true` to use the browser's native list styles. Useful for large lists where the list number may overlap with the list item text.
 
 <OrderedList native>
   <ListItem>
@@ -81,7 +81,7 @@ Enable native browser list styles with `native`. Useful for large lists where th
   <ListItem>Ordered list level 1</ListItem>
 </OrderedList>
 
-### Expressive
+## Expressive styles
 
 Use Carbon's expressive typesetting with `expressive`.
 

--- a/docs/src/pages/components/OverflowMenu.svx
+++ b/docs/src/pages/components/OverflowMenu.svx
@@ -22,6 +22,12 @@ Create a basic overflow menu by wrapping overflow menu item components within th
   <OverflowMenuItem danger text="Delete service" />
 </OverflowMenu>
 
+## Reactive example
+
+Control the menu state programmatically by binding to `open`.
+
+<FileSource src="/framed/OverflowMenu/OverflowMenuReactive" />
+
 ## Positioning
 
 Control where and how the menu opens.
@@ -104,32 +110,6 @@ Set `maxHeight` to cap the menu height and scroll the remaining items. A number 
 
 <FileSource src="/framed/OverflowMenu/OverflowMenuScrollable" />
 
-## Custom primary focus
-
-Set `primaryFocus` to `true` on a menu item to focus it when opening the dropdown.
-
-<OverflowMenu>
-  <OverflowMenuItem text="Manage credentials" />
-  <OverflowMenuItem href="https://cloud.ibm.com/docs/api-gateway/" target="_blank" text="API documentation" />
-  <OverflowMenuItem primaryFocus danger text="Delete service" />
-</OverflowMenu>
-
-## Item icons
-
-Set `icon` for a left icon or `iconRight` for a right icon; the label fills the space between them. Use the matching slots for custom markup. Item icons are not intended for `sm` or `xs` sizes.
-
-<OverflowMenu>
-  <OverflowMenuItem icon={Edit} text="Rename" />
-  <OverflowMenuItem
-    icon={Document}
-    iconRight={Launch}
-    text="Open docs"
-    href="https://www.ibm.com/docs"
-    target="_blank"
-  />
-  <OverflowMenuItem hasDivider danger icon={TrashCan} text="Delete" />
-</OverflowMenu>
-
 ## Trigger
 
 Customize the menu trigger button.
@@ -155,11 +135,25 @@ Use the `menu` slot to customize the trigger button content.
   <OverflowMenuItem danger text="Delete service" />
 </OverflowMenu>
 
-## Disabled
+### Accessible label
 
-Disable the whole menu or individual items.
+The trigger button's accessible name defaults to `"menu"`. Set `aria-label` for a more descriptive name.
 
-### Button
+<OverflowMenu aria-label="Actions for API Gateway service">
+  <OverflowMenuItem text="Manage credentials" />
+  <OverflowMenuItem href="https://cloud.ibm.com/docs/api-gateway/" target="_blank" text="API documentation" />
+  <OverflowMenuItem danger text="Delete service" />
+</OverflowMenu>
+
+Set `iconDescription` to change the icon's label and native tooltip. It defaults to `"Open and close list of options"`.
+
+<OverflowMenu iconDescription="Actions">
+  <OverflowMenuItem text="Manage credentials" />
+  <OverflowMenuItem href="https://cloud.ibm.com/docs/api-gateway/" target="_blank" text="API documentation" />
+  <OverflowMenuItem danger text="Delete service" />
+</OverflowMenu>
+
+### Disabled
 
 Set `disabled` to `true` to disable the trigger button.
 
@@ -169,7 +163,37 @@ Set `disabled` to `true` to disable the trigger button.
   <OverflowMenuItem danger text="Delete service" />
 </OverflowMenu>
 
-### Items
+## Items
+
+Customize individual menu items.
+
+### Icons
+
+Set `icon` for a left icon or `iconRight` for a right icon; the label fills the space between them. Use the matching slots for custom markup. Item icons are not intended for `sm` or `xs` sizes.
+
+<OverflowMenu>
+  <OverflowMenuItem icon={Edit} text="Rename" />
+  <OverflowMenuItem
+    icon={Document}
+    iconRight={Launch}
+    text="Open docs"
+    href="https://www.ibm.com/docs"
+    target="_blank"
+  />
+  <OverflowMenuItem hasDivider danger icon={TrashCan} text="Delete" />
+</OverflowMenu>
+
+### Primary focus
+
+Set `primaryFocus` to `true` on a menu item to focus it when opening the dropdown.
+
+<OverflowMenu>
+  <OverflowMenuItem text="Manage credentials" />
+  <OverflowMenuItem href="https://cloud.ibm.com/docs/api-gateway/" target="_blank" text="API documentation" />
+  <OverflowMenuItem primaryFocus danger text="Delete service" />
+</OverflowMenu>
+
+### Disabled
 
 Disable individual menu items with `disabled`. Use a divider to add visual separation between items.
 
@@ -187,9 +211,35 @@ Disable individual menu items with `disabled`. Use a divider to add visual separ
   <OverflowMenuItem hasDivider danger text="Delete service" />
 </OverflowMenu>
 
-## Closing
+### Danger
 
-Control whether selecting an item closes the menu.
+Set `danger` on an item to indicate a critical or destructive action, such as deleting a resource. The item renders in red with a matching focus outline.
+
+<OverflowMenu>
+  <OverflowMenuItem text="Manage credentials" />
+  <OverflowMenuItem href="https://cloud.ibm.com/docs/api-gateway/" target="_blank" text="API documentation" />
+  <OverflowMenuItem hasDivider danger text="Delete service" />
+</OverflowMenu>
+
+## Events
+
+Respond to menu close attempts and individual item clicks.
+
+### Close event
+
+Use `on:close` to respond to every close attempt, regardless of cause. The event detail includes `trigger` (`"toggle"`, `"escape-key"`, `"outside-click"`, or `"item-select"`); when triggered by a selection, `index` and `text` identify the selected item.
+
+<OverflowMenu
+  on:close={(e) => {
+    console.log(e.detail.trigger); // "toggle" | "escape-key" | "outside-click" | "item-select"
+    console.log(e.detail.index); // number | undefined
+    console.log(e.detail.text); // string | undefined
+  }}
+>
+  <OverflowMenuItem text="Manage credentials" />
+  <OverflowMenuItem href="https://cloud.ibm.com/docs/api-gateway/" target="_blank" text="API documentation" />
+  <OverflowMenuItem danger text="Delete service" />
+</OverflowMenu>
 
 ### Prevent item close
 

--- a/docs/src/pages/components/Pagination.svx
+++ b/docs/src/pages/components/Pagination.svx
@@ -35,23 +35,23 @@ Set `size` to `"lg"` for a large pagination.
 
 <Pagination size="lg" totalItems={102} pageSizes={[10, 15, 20]} />
 
-## Current page
+## Page and page size
+
+Configure the current page, and the available and default page sizes.
+
+### Current page
 
 Set the current page with `page`.
 
 <Pagination totalItems={102} page={4} />
 
-## Page sizes
-
-Configure the selectable page-size options.
-
-### Custom
+### Custom sizes
 
 Specify custom page sizes and set a default page size.
 
 <Pagination totalItems={102} pageSizes={[16, 36, 99]} pageSize={36} />
 
-### Dynamic
+### Dynamic sizes
 
 Set `dynamicPageSizes` to hide page sizes larger than needed to display all items on one page.
 
@@ -63,13 +63,25 @@ For example, with 9 total items and page sizes of `[5, 10, 15]`, only 5 and 10 a
 
 Set `pagesUnknown` when the total page count is unknown, such as with cursor-based APIs. The item range renders without a total, and the forward button is not constrained by totalItems.
 
-Because the component cannot detect the last page, bind to `page` and toggle `forwardButtonDisabled` when there is no more data to load.
+Because the component cannot detect the last page, bind to `page` and toggle `forwardButtonDisabled` when there is no more data to load. The back button is disabled automatically once `page` reaches `1`; override `backButtonDisabled` the same way if the consumer needs equivalent manual control over the back button.
 
 <FileSource src="/framed/Pagination/PaginationUnknown" />
+
+### Custom item and page text
+
+Because the total is unknown, this mode falls back to `itemText` and `pageText` instead of `itemRangeText` and `pageRangeText`, since there's no total to describe. Override either to change the wording.
+
+<Pagination
+  pagesUnknown
+  itemText={(min, max) => `Showing ${min}–${max}`}
+  pageText={(page) => `Page ${page}`}
+/>
 
 ## Page window
 
 The page-number dropdown uses native `<option>` elements, derived from `totalItems`. For large datasets, use `pageWindow` to cap how many options are rendered (default 1000).
+
+This example also overrides `itemRangeText` and `pageRangeText` to format the item and page counts compactly (for example, `100k` instead of `100,000`).
 
 <FileSource src="/framed/Pagination/PageWindow" />
 
@@ -77,11 +89,25 @@ The page-number dropdown uses native `<option>` elements, derived from `totalIte
 
 Set `simple` for a compact previous/next control with page status text. Useful in toolbars and cards.
 
+The example below also overrides `pageText` to show only the page number, omitting the default `"page "` prefix.
+
 <Toolbar size="sm">
   <ToolbarContent>
     <Pagination simple size="sm" totalItems={102} pageText={(page) => `${page.toLocaleString()}`} />
   </ToolbarContent>
 </Toolbar>
+
+## Custom text
+
+Override the button tooltips and items-per-page label independently of the total and item text overrides above.
+
+<Pagination
+  totalItems={102}
+  pageSizes={[10, 15, 20]}
+  forwardText="Next"
+  backwardText="Previous"
+  itemsPerPageText="Rows per page:"
+/>
 
 ## Hidden controls
 
@@ -101,9 +127,42 @@ Disable the page size selector with `pageSizeInputDisabled`.
 
 ## Disabled
 
-Set `disabled` to disable the entire pagination, including the nav buttons and both selects.
+Set `disabled` to `true` to disable the entire pagination, including the nav buttons and both selects.
 
 <Pagination disabled totalItems={102} pageSizes={[10, 15, 20]} />
+
+## Events
+
+### Change
+
+Use `on:change` to listen for direct user interaction—the previous/next buttons, or the page and page-size selects. The event detail includes whichever value changed.
+
+<Pagination
+  totalItems={102}
+  pageSizes={[10, 15, 20]}
+  on:change={(e) => console.log(e.detail)} // { page: number } | { pageSize: number }
+/>
+
+### Update
+
+Use `on:update` to listen for every change to `page` or `pageSize`, including programmatic updates from outside the component (for example, through `bind:page`). Unlike `change`, this fires regardless of whether the update came from user interaction, and the detail always includes both values.
+
+<Pagination
+  totalItems={102}
+  pageSizes={[10, 15, 20]}
+  on:update={(e) => console.log(e.detail)} // { page: number, pageSize: number }
+/>
+
+### Button clicks
+
+Use `on:click:button--previous` and `on:click:button--next` to listen specifically for previous and next button clicks, separate from the page and page-size selects. Both dispatch the resulting page number.
+
+<Pagination
+  totalItems={102}
+  pageSizes={[10, 15, 20]}
+  on:click:button--previous={(e) => console.log(e.detail)} // { page: number }
+  on:click:button--next={(e) => console.log(e.detail)} // { page: number }
+/>
 
 ## Skeleton
 

--- a/docs/src/pages/components/PaginationNav.svx
+++ b/docs/src/pages/components/PaginationNav.svx
@@ -18,15 +18,17 @@ Bind to `page` for the current page number.
 
 <FileSource src="/framed/PaginationNav/PaginationNavReactive" />
 
-## Total pages
+## Page count
+
+### Total pages
 
 Specify the total number of pages with `total`.
 
 <PaginationNav total={3} />
 
-## Visible pages
+### Visible pages
 
-Control the number of visible page numbers with `shown`.
+Control the number of visible page numbers with `shown`. Pages that don't fit collapse into an overflow menu.
 
 <PaginationNav total={100} shown={5} />
 
@@ -36,7 +38,7 @@ The forward and backward navigation buttons can be customized independently of t
 
 ### Loop
 
-Enable circular navigation between pages with `loop`.
+Enable circular navigation between pages with `loop`. When enabled, clicking "Next" from the last page wraps to the first page, and clicking "Previous" from the first page wraps to the last page.
 
 <PaginationNav total={3} loop />
 
@@ -54,3 +56,24 @@ Customize navigation button text with `forwardText` and `backwardText`.
 Set tooltip position relative to the navigation buttons with `tooltipPosition`.
 
 <PaginationNav tooltipPosition="outside" total={3} loop />
+
+## Events
+
+### Change
+
+Use `on:change` to listen for every user interaction—clicking a page number, an overflow menu item, or the previous/next buttons. The event detail includes the resulting page.
+
+<PaginationNav
+  total={5}
+  on:change={(e) => console.log(e.detail)} // { page: number }
+/>
+
+### Button clicks
+
+Use `on:click:button--previous` and `on:click:button--next` to listen specifically for previous and next button clicks, separate from the page numbers and overflow menu. Both dispatch the resulting page number.
+
+<PaginationNav
+  total={5}
+  on:click:button--previous={(e) => console.log(e.detail)} // { page: number }
+  on:click:button--next={(e) => console.log(e.detail)} // { page: number }
+/>

--- a/docs/src/pages/components/PasswordInput.svx
+++ b/docs/src/pages/components/PasswordInput.svx
@@ -22,7 +22,7 @@ Control the show/hide password toggle button and its tooltip.
 
 Set `type` to `"text"` to show the password in plain text.
 
-<PasswordInput labelText="Password" type="text" placeholder="Enter password..." value="as_lta0890sdfpo__!9901" />
+<PasswordInput labelText="Password" type="text" placeholder="Enter password..." value="correct horse battery staple" />
 
 ### Custom tooltip alignment
 

--- a/docs/src/pages/components/PasswordInput.svx
+++ b/docs/src/pages/components/PasswordInput.svx
@@ -14,23 +14,41 @@ Create a basic password input with a label and placeholder.
 
 <PasswordInput labelText="Password" placeholder="Enter password..." />
 
-## Custom tooltip alignment
+## Visibility toggle
+
+Control the show/hide password toggle button and its tooltip.
+
+### Value shown as text
+
+Set `type` to `"text"` to show the password in plain text.
+
+<PasswordInput labelText="Password" type="text" placeholder="Enter password..." value="as_lta0890sdfpo__!9901" />
+
+### Custom tooltip alignment
 
 Customize visibility toggle placement with `tooltipAlignment` and `tooltipPosition`.
 
 <PasswordInput tooltipAlignment="start" tooltipPosition="left" labelText="Password" placeholder="Enter password..." />
 
-## Password is visible
+### Toggle labels
 
-Set `type` to `"text"` to show the password in plain text.
+Customize the toggle button's tooltip and ARIA label text with `showPasswordLabel` and `hidePasswordLabel`.
 
-<PasswordInput labelText="Password" type="text" placeholder="Enter password..." value="as_lta0890sdfpo__!9901" />
+<PasswordInput labelText="Password" placeholder="Enter password..." showPasswordLabel="Reveal password" hidePasswordLabel="Conceal password" />
 
 ## Hidden label
 
 Hide the label visually by setting `hideLabel` to `true`. The label remains available to screen readers.
 
 <PasswordInput hideLabel labelText="Password" placeholder="Enter password..." />
+
+## Custom label
+
+Use the `labelChildren` slot to provide custom label content.
+
+<PasswordInput labelText="" placeholder="Enter password...">
+  <strong slot="labelChildren">Password</strong>
+</PasswordInput>
 
 ## Helper text
 
@@ -92,6 +110,14 @@ Invalid and warning states are not displayed while the input is read-only.
 Display the input with an inline label layout.
 
 <PasswordInput inline labelText="Password" placeholder="Enter password..." />
+
+### Custom label
+
+Use the `labelChildren` slot to provide custom inline label content.
+
+<PasswordInput inline labelText="" placeholder="Enter password...">
+  <strong slot="labelChildren">Password</strong>
+</PasswordInput>
 
 ## Sizes
 

--- a/docs/src/pages/components/PinCodeInput.svx
+++ b/docs/src/pages/components/PinCodeInput.svx
@@ -12,52 +12,50 @@ description: Pin code inputs collect a short verification code across a row of s
 
 By default, four numeric segments are rendered. Typing a digit advances focus to the next segment; <DocKbd label="Backspace" /> moves to the previous segment, <DocKbd label="Delete" /> clears the focused segment, and <DocKbd label="←" /> / <DocKbd label="→" /> move between segments.
 
+<PinCodeInput labelText="Verification code" />
 
+## Helper text
+
+Add helper text below the input to provide additional context or instructions.
 
 <PinCodeInput
   labelText="Verification code"
-  on:complete={(e) => console.log("complete", e.detail)}
-  on:change={(e) => console.log("change", e.detail)}
-  on:clear={() => console.log("clear")}
-  on:paste={(e) => console.log("paste", e.detail)}
+  helperText="Enter the 4-digit code sent to your device"
 />
 
-The component emits the following events:
+## Hidden label
 
-| Event | When |
-| --- | --- |
-| `on:change` | Any edit (type, paste, delete). |
-| `on:complete` | All segments become filled. This does not fire on mount with a prefilled value, but fires after user interaction fills every segment. |
-| `on:clear` | All segments are emptied. |
-| `on:paste` | A paste inserts one or more characters. Whitespace is stripped. |
+Hide the label visually by setting `hideLabel` to `true`. The label remains available to screen readers.
 
-## Custom length
+<PinCodeInput hideLabel labelText="Verification code" />
+
+## Custom label
+
+Use the `labelChildren` slot to render custom label content.
+
+<PinCodeInput labelText="Verification code">
+  <span slot="labelChildren">
+    Verification code (<Link href="/">resend</Link>)
+  </span>
+</PinCodeInput>
+
+## Input rules
+
+Control how many segments render and which characters are accepted.
+
+### Custom length
 
 Use `count` to set the number of segments. For example, six is common for SMS, email, and authenticator OTP flows.
 
-<PinCodeInput
-  count={6}
-  labelText="Verification code"
-  on:complete
-  on:change
-  on:clear
-  on:paste
-/>
+<PinCodeInput count={6} labelText="Verification code" />
 
-## Alphanumeric
+### Alphanumeric
 
 The default input mode is `"numeric"`. Set `type` to `"alphanumeric"` to allow letters and digits.
 
-<PinCodeInput
-  type="alphanumeric"
-  labelText="Invite code"
-  on:complete
-  on:change
-  on:clear
-  on:paste
-/>
+<PinCodeInput type="alphanumeric" labelText="Invite code" />
 
-## Custom pattern
+### Custom pattern
 
 Use `pattern` to override the per-character test used for typing and paste. Pass a `RegExp` or a string compiled with `new RegExp(...)`. The pattern is matched against each individual character, not the full assembled value. When `pattern` is unset, `type` selects the numeric or alphanumeric preset.
 
@@ -68,51 +66,25 @@ Use `pattern` to override the per-character test used for typing and paste. Pass
   uppercase
   labelText="Serial number"
   helperText="Enter the 6-character hex serial"
-  on:complete
-  on:change
-  on:clear
-  on:paste
 />
 
-## Uppercase display
+### Uppercase display
 
 Set `uppercase` to `true` to display characters in uppercase. The bound value and code retain the original casing.
 
-<PinCodeInput
-  type="alphanumeric"
-  uppercase
-  labelText="Invite code"
-  on:complete
-  on:change
-  on:clear
-  on:paste
-/>
+<PinCodeInput type="alphanumeric" uppercase labelText="Invite code" />
 
 ## Masked
 
 Set `mask` to `true` to obscure the entered characters. Each segment is masked while it is not focused and reveals its character when focused.
 
-<PinCodeInput
-  mask
-  labelText="Security code"
-  on:complete
-  on:change
-  on:clear
-  on:paste
-/>
+<PinCodeInput mask labelText="Security code" />
 
 ## Placeholder
 
 Non-fluid pin code inputs do not show a placeholder by default. Set `placeholder` to hint at empty segments and indicate expected length.
 
-<PinCodeInput
-  placeholder="0"
-  labelText="Verification code"
-  on:complete
-  on:change
-  on:clear
-  on:paste
-/>
+<PinCodeInput placeholder="0" labelText="Verification code" />
 
 ## Sizes
 
@@ -122,53 +94,114 @@ The `size` prop sets the segment height. The default is `md`.
 
 Set `size` to `"xs"` to render extra-small segments.
 
-<PinCodeInput
-  size="xs"
-  labelText="Verification code"
-  on:complete
-  on:change
-  on:clear
-  on:paste
-/>
+<PinCodeInput size="xs" labelText="Verification code" />
 
 ### Small
 
 Set `size` to `"sm"` to render small segments.
 
-<PinCodeInput
-  size="sm"
-  labelText="Verification code"
-  on:complete
-  on:change
-  on:clear
-  on:paste
-/>
+<PinCodeInput size="sm" labelText="Verification code" />
 
 ### Extra-large
 
 Set `size` to `"xl"` to render extra-large segments.
 
-<PinCodeInput
-  size="xl"
-  labelText="Verification code"
-  on:complete
-  on:change
-  on:clear
-  on:paste
-/>
+<PinCodeInput size="xl" labelText="Verification code" />
 
 ## Light
 
 Use the light variant for light-themed backgrounds by setting `light` to `true`.
 
+<PinCodeInput light labelText="Verification code" />
+
+## Select on focus
+
+Set `selectTextOnFocus` to `true` to select a segment's value when it receives focus. Without this prop, browsers typically select the value only when the segment receives keyboard focus (for example, via <DocKbd label="Tab" />), not on click.
+
+<PinCodeInput selectTextOnFocus labelText="Verification code" />
+
+## Events
+
+Respond to edits, completion, clearing, and paste or autofill.
+
+### Edits, completion, and clearing
+
+The component emits the following events:
+
+| Event | When |
+| --- | --- |
+| `on:change` | Any edit (type, paste, delete). |
+| `on:complete` | All segments become filled. This does not fire on mount with a prefilled value, but fires after user interaction fills every segment. |
+| `on:clear` | All segments are emptied. |
+
 <PinCodeInput
-  light
   labelText="Verification code"
-  on:complete
-  on:change
-  on:clear
-  on:paste
+  on:complete={(e) => console.log("complete", e.detail)}
+  on:change={(e) => console.log("change", e.detail)}
+  on:clear={() => console.log("clear")}
 />
+
+### Paste and autofill
+
+Paste a full code into any segment to fill all segments at once. A partial paste fills from the focused segment forward. Non-matching characters are ignored. The `on:paste` event fires with the clipboard value (whitespace stripped) before segments are updated.
+
+OS and password-manager autofill that inserts the whole code into one segment is distributed the same way. The first segment also sets `autocomplete="one-time-code"`, which lets browsers and mobile OSes offer a one-time-code autofill suggestion (for example, from an incoming SMS) for it.
+
+<PinCodeInput
+  labelText="Verification code"
+  on:paste={(e) => console.log("paste", e.detail)}
+/>
+
+## Form name
+
+Set `name` so the assembled code participates in native form submission
+(for example SvelteKit form actions and `FormData`). A hidden input mirrors
+`value`. When `name` is set, `required` is applied to the hidden input instead
+of each segment.
+
+```svelte
+<script>
+  import { Form, PinCodeInput, Button } from "carbon-components-svelte";
+</script>
+
+<Form method="POST" action="?/verify">
+  <PinCodeInput
+    name="code"
+    required
+    count={6}
+    labelText="Verification code"
+  />
+  <Button type="submit">Verify</Button>
+</Form>
+```
+
+## States
+
+Reflect validation and interaction states.
+
+### Invalid
+
+Set `invalid` to `true` and provide `invalidText` to describe the error. Invalid takes precedence over the [warning state](#warning) when both are set.
+
+<PinCodeInput invalid value="018" invalidText="The code you entered is incorrect" labelText="Verification code" />
+
+### Warning
+
+Set `warn` to `true` and provide `warnText` to surface a non-blocking warning.
+
+<PinCodeInput warn value="018" warnText="This code is about to expire" labelText="Verification code" />
+
+### Disabled
+
+Set `disabled` to `true` to disable every segment.
+
+<PinCodeInput disabled value="0182" labelText="Verification code" />
+
+### Read-only
+
+Set `readonly` to `true` to display a code that cannot be edited.
+
+<PinCodeInput readonly value="0182" labelText="Verification code" />
 
 ## Skeleton
 
@@ -192,14 +225,7 @@ boxed fields, empty segments show a placeholder by default so the expected
 length remains visible. Set `placeholder=""` to remove it, or pass any other
 string to override the default in either variant.
 
-<PinCodeInput
-  fluid
-  labelText="Verification code"
-  on:complete
-  on:change
-  on:clear
-  on:paste
-/>
+<PinCodeInput fluid labelText="Verification code" />
 
 ### Custom label
 
@@ -216,7 +242,7 @@ tooltip icon.
 ### Invalid
 
 Fluid pin code inputs display the error message inside the field boundary. Long
-messages wrap to multiple lines.
+messages wrap to multiple lines. Invalid takes precedence over the [warning state](#warning) when both are set.
 
 <PinCodeInput fluid invalid value="018" invalidText="The code you entered is incorrect. Please check the message we sent to your device and try again, or request a new code if it has expired." labelText="Verification code" />
 
@@ -244,123 +270,6 @@ Invalid and warning states are not displayed while the pin code input is read-on
 Display a loading skeleton for the fluid pin code input variant.
 
 <FluidPinCodeInputSkeleton />
-
-## Helper text
-
-Add helper text below the input to provide additional context or instructions.
-
-<PinCodeInput
-  labelText="Verification code"
-  helperText="Enter the 4-digit code sent to your device"
-  on:complete
-  on:change
-  on:clear
-  on:paste
-/>
-
-## Hidden label
-
-Hide the label visually by setting `hideLabel` to `true`. The label remains available to screen readers.
-
-<PinCodeInput
-  hideLabel
-  labelText="Verification code"
-  on:complete
-  on:change
-  on:clear
-  on:paste
-/>
-
-## Custom label
-
-Use the `labelChildren` slot to render custom label content.
-
-<PinCodeInput
-  labelText="Verification code"
-  on:complete
-  on:change
-  on:clear
-  on:paste
->
-  <span slot="labelChildren">
-    Verification code (<Link href="/">resend</Link>)
-  </span>
-</PinCodeInput>
-
-## Form name
-
-Set `name` so the assembled code participates in native form submission
-(for example SvelteKit form actions and `FormData`). A hidden input mirrors
-`value`. When `name` is set, `required` is applied to the hidden input instead
-of each segment.
-
-```svelte
-<script>
-  import { Form, PinCodeInput, Button } from "carbon-components-svelte";
-</script>
-
-<Form method="POST" action="?/verify">
-  <PinCodeInput
-    name="code"
-    required
-    count={6}
-    labelText="Verification code"
-  />
-  <Button type="submit">Verify</Button>
-</Form>
-```
-
-## Paste and autofill
-
-Paste a full code into any segment to fill all segments at once. A partial paste fills from the focused segment forward. Non-matching characters are ignored. The paste event fires with the clipboard value (whitespace stripped) before segments are updated.
-
-OS and password-manager autofill that inserts the whole code into one segment is distributed the same way.
-
-<PinCodeInput
-  labelText="Verification code"
-  on:paste={(e) => console.log("paste", e.detail)}
-/>
-
-## Select on focus
-
-Set `selectTextOnFocus` to `true` to select a segment's value when it receives focus. Without this prop, browsers typically select the value only when the segment receives keyboard focus (for example, via <DocKbd label="Tab" />), not on click.
-
-<PinCodeInput
-  selectTextOnFocus
-  labelText="Verification code"
-  on:complete
-  on:change
-  on:clear
-  on:paste
-/>
-
-## States
-
-Reflect validation and interaction states.
-
-### Invalid
-
-Set `invalid` to `true` and provide `invalidText` to describe the error.
-
-<PinCodeInput invalid value="018" invalidText="The code you entered is incorrect" labelText="Verification code" />
-
-### Warning
-
-Set `warn` to `true` and provide `warnText` to surface a non-blocking warning.
-
-<PinCodeInput warn value="018" warnText="This code is about to expire" labelText="Verification code" />
-
-### Disabled
-
-Set `disabled` to `true` to disable every segment.
-
-<PinCodeInput disabled value="0182" labelText="Verification code" />
-
-### Read-only
-
-Set `readonly` to `true` to display a code that cannot be edited.
-
-<PinCodeInput readonly value="0182" labelText="Verification code" />
 
 ## Bindable value
 

--- a/docs/src/pages/components/Popover.svx
+++ b/docs/src/pages/components/Popover.svx
@@ -17,7 +17,11 @@ Create a basic popover with absolute positioning.
     </Popover>
 </div>
 
-## Relative position
+## Placement
+
+Position the popover relative to its trigger.
+
+### Relative position
 
 Position the popover relative to its parent with `relative`.
 
@@ -28,18 +32,7 @@ Position the popover relative to its parent with `relative`.
     </Popover>
 </div>
 
-## Close on outside click
-
-Close the popover when clicking outside with `closeOnOutsideClick`.
-
-<div>
-    Parent
-    <Popover open closeOnOutsideClick on:click:outside={() => {console.log('on:click:outside')}}>
-        Content
-    </Popover>
-</div>
-
-## Alignment
+### Alignment
 
 Customize popover alignment with `align`. Valid values include `"top"`, `"top-left"`, `"top-right"`, `"bottom"`, `"bottom-left"`, `"bottom-right"`, `"left"`, `"left-bottom"`, `"left-top"`, `"right"`, `"right-bottom"`, and `"right-top"`.
 
@@ -127,7 +120,7 @@ Add a caret indicator with `caret`.
 
 ### Custom alignment
 
-By default, the caret aligns to top. See the alignment section above for all valid values.
+By default, the caret aligns to top. See [Alignment](#alignment) for all valid values.
 
 <div>
     Parent
@@ -158,6 +151,37 @@ Enable the high contrast variant for improved visibility.
 <div>
     Parent
     <Popover highContrast open>
+        Content
+    </Popover>
+</div>
+
+## Dismissal
+
+Close the popover automatically, and listen for outside-click interactions.
+
+### Close on outside click
+
+Close the popover when clicking outside with `closeOnOutsideClick`.
+
+<div>
+    Parent
+    <Popover open closeOnOutsideClick on:click:outside={() => {console.log('on:click:outside')}}>
+        Content
+    </Popover>
+</div>
+
+### Events
+
+`on:click:outside` fires whenever a click lands outside the popover, with `event.detail.target` set to the clicked element—regardless of whether `closeOnOutsideClick` is set. `on:close` fires only when the popover closes itself in response to `closeOnOutsideClick`, with `event.detail.trigger` set to `"outside-click"`.
+
+<div>
+    Parent
+    <Popover
+      open
+      closeOnOutsideClick
+      on:click:outside={(e) => console.log('on:click:outside', e.detail)}
+      on:close={(e) => console.log('on:close', e.detail)}
+    >
         Content
     </Popover>
 </div>

--- a/docs/src/pages/components/Portal.svx
+++ b/docs/src/pages/components/Portal.svx
@@ -14,7 +14,7 @@ Render content in a portal — useful for modals, tooltips, and menus that need 
 
 ## Multiple portals
 
-Each portal instance is independent and creates its own element in document.body. Each portal is automatically cleaned up when removed.
+Each portal instance is independent, creating its own element in document.body, and is automatically cleaned up when removed.
 
 <FileSource src="/framed/Portal/MultiplePortals" />
 

--- a/docs/src/pages/components/ProgressBar.svx
+++ b/docs/src/pages/components/ProgressBar.svx
@@ -3,38 +3,54 @@ description: Progress bars visually indicate the progress of operations like fil
 ---
 
 <script>
-  import { ProgressBar } from "carbon-components-svelte";
+  import { ProgressBar, TooltipIcon } from "carbon-components-svelte";
+  import Information from "carbon-icons-svelte/lib/Information.svelte";
 </script>
 
 ## Basic
 
-Create an indeterminate progress bar that continuously animates.
+Create an indeterminate progress bar that continuously animates. A progress bar is indeterminate when `value` is left `undefined` while `status` is `"active"`.
 
 <ProgressBar helperText="Loading..." />
 
-## Percentage
+## Value
+
+### Percentage
 
 Display progress as a percentage with `value`.
 
 <ProgressBar value={40} labelText="Upload status" helperText="40 MB of 100 MB" />
 
-## Custom max value
+### Custom max value
 
 Set a custom maximum value for the progress bar.
 
 <ProgressBar value={40} max={200} labelText="Upload status" helperText="40 MB of 200 MB" />
 
-## Small
+## Label
 
-Use the small size variant for compact layouts.
-
-<ProgressBar size="sm" helperText="Loading..." />
-
-## Hidden label
+### Hidden label
 
 Hide the label visually by setting `hideLabel` to `true`. The label remains available to screen readers.
 
 <ProgressBar hideLabel value={40} labelText="Upload status" helperText="40 MB of 100 MB" />
+
+### Custom label content
+
+Use the `labelChildren` slot to render custom label content, such as a tooltip icon.
+
+<ProgressBar value={40} helperText="40 MB of 100 MB">
+  <svelte:fragment slot="labelChildren">
+    Upload status
+    <TooltipIcon tooltipText="Files are scanned before upload completes." icon={Information} />
+  </svelte:fragment>
+</ProgressBar>
+
+## Size
+
+Use the small size variant for compact layouts.
+
+<ProgressBar size="sm" helperText="Loading..." />
 
 ## Status
 

--- a/docs/src/pages/components/ProgressIndicator.svx
+++ b/docs/src/pages/components/ProgressIndicator.svx
@@ -33,13 +33,23 @@ Create a horizontal progress indicator with four steps.
   />
 </ProgressIndicator>
 
-## Selected by id
+## Step selection
+
+Control which step is active, and how clicking a step affects that selection.
+
+### Selected by id
 
 For dynamic step sets, bind `selectedId` and give each `ProgressStep` a stable `id`. Selection stays on the same logical step when steps before it are added or removed. When set, `selectedId` takes precedence over `currentIndex`.
 
 <FileSource src="/framed/ProgressIndicator/ProgressIndicatorSelectedId" />
 
-## Prevent change on click
+### Programmatic usage
+
+Update the current step programmatically while maintaining step completion rules. Bind to a step's `current` prop to read whether it's the active step.
+
+<FileSource src="/framed/ProgressIndicator/ProgrammaticProgressIndicator" />
+
+### Prevent change on click
 
 Disable automatic step selection when clicking completed steps.
 
@@ -62,13 +72,9 @@ Disable automatic step selection when clicking completed steps.
   />
 </ProgressIndicator>
 
-## Programmatic usage
+## Step states
 
-Update the current step programmatically while maintaining step completion rules.
-
-<FileSource src="/framed/ProgressIndicator/ProgrammaticProgressIndicator" />
-
-## Invalid step
+### Invalid step
 
 Mark a step as invalid to indicate an error state.
 
@@ -87,7 +93,7 @@ Mark a step as invalid to indicate an error state.
   />
 </ProgressIndicator>
 
-## Disabled steps
+### Disabled steps
 
 Disable specific steps to prevent user interaction.
 
@@ -106,9 +112,13 @@ Disable specific steps to prevent user interaction.
   />
 </ProgressIndicator>
 
-## Custom step icon (slot)
+## Step content
 
-Override the default step icon using the icon named slot. The slot exposes complete, current, invalid, and description so the override can mirror the step state.
+Customize what renders inside a step, beyond the default label and icon.
+
+### Icon (slot)
+
+Override the default step icon using the `icon` named slot. The slot exposes complete, current, invalid, and description so the override can mirror the step state.
 
 <ProgressIndicator currentIndex={1}>
   <ProgressStep complete label="Step 1" description="Completed step">
@@ -120,6 +130,36 @@ Override the default step icon using the icon named slot. The slot exposes compl
   <ProgressStep label="Step 3" description="Upcoming step">
     <Circle slot="icon" />
   </ProgressStep>
+</ProgressIndicator>
+
+### Label (slot)
+
+Override the default label using the default slot instead of `label`. The slot exposes `props`, which includes the `class` needed to keep the label styled correctly.
+
+<ProgressIndicator currentIndex={1}>
+  <ProgressStep complete let:props description="Completed step">
+    <strong class={props.class}>Step 1</strong>
+  </ProgressStep>
+  <ProgressStep let:props description="Current step">
+    <strong class={props.class}>Step 2</strong>
+  </ProgressStep>
+  <ProgressStep let:props description="Upcoming step">
+    <strong class={props.class}>Step 3</strong>
+  </ProgressStep>
+</ProgressIndicator>
+
+### Secondary label
+
+Set `secondaryLabel` to display supplementary text after the label, such as marking a step as optional.
+
+<ProgressIndicator currentIndex={1}>
+  <ProgressStep complete label="Step 1" description="Completed step" />
+  <ProgressStep
+    label="Step 2"
+    description="Current step"
+    secondaryLabel="Optional"
+  />
+  <ProgressStep label="Step 3" description="Upcoming step" />
 </ProgressIndicator>
 
 ## Layout
@@ -164,6 +204,30 @@ Display steps in a vertical layout.
   />
 </ProgressIndicator>
 
+## Events
+
+Respond to step selection changes.
+
+Use `on:change` to listen for the step becoming active, either from a completed step being clicked or from `currentIndex`/`selectedId` being updated. The event dispatches the new step index as `event.detail`.
+
+<ProgressIndicator
+  currentIndex={0}
+  on:change={(e) => console.log(e.detail)} // number
+>
+  <ProgressStep complete
+    label="Step 1"
+    description="The progress indicator will listen for clicks on the steps"
+  />
+  <ProgressStep complete
+    label="Step 2"
+    description="The progress indicator will listen for clicks on the steps"
+  />
+  <ProgressStep
+    label="Step 3"
+    description="The progress indicator will listen for clicks on the steps"
+  />
+</ProgressIndicator>
+
 ## Skeleton
 
 Show a loading state with the specified number of steps.
@@ -181,3 +245,9 @@ Show a vertical loading state with the specified number of steps.
 Show a loading state with steps distributed evenly across the available space.
 
 <ProgressIndicatorSkeleton spaceEqually />
+
+### Step count
+
+Set `count` to change the number of skeleton steps rendered. Defaults to `4`.
+
+<ProgressIndicatorSkeleton count={6} />

--- a/docs/src/pages/components/RadioButton.svx
+++ b/docs/src/pages/components/RadioButton.svx
@@ -31,7 +31,17 @@ Multiple standalone radio buttons sharing the same name automatically form a gro
 
 <FileSource src="/framed/RadioButton/RadioButtonImplicitGroup" />
 
-## Hidden legend
+## Reactive
+
+Bind and update the selected value programmatically.
+
+<FileSource src="/framed/RadioButton/RadioButtonReactive" />
+
+## Labels and legend
+
+Control the visibility and content of individual radio button labels and the group legend.
+
+### Hidden legend
 
 Hide the legend visually by setting `hideLegend` to `true`. The legend remains available to screen readers.
 
@@ -41,9 +51,15 @@ Hide the legend visually by setting `hideLegend` to `true`. The legend remains a
   <RadioButton labelText="Pro (128 GB)" value="pro" />
 </RadioButtonGroup>
 
-## Custom label
+### Hidden label
 
-Use the `labelChildren` slot for custom label content instead of plain label text.
+Hide an individual radio button's label text by setting `hideLabel` to `true` on `RadioButton`. The label remains available to screen readers.
+
+<RadioButton labelText="Label text" hideLabel />
+
+### Custom label
+
+Use the `legendChildren` slot to provide custom legend content instead of `legendText`.
 
 <RadioButtonGroup name="plan-legend-slot" selected="standard">
   <Stack slot="legendChildren" orientation="horizontal">
@@ -59,13 +75,11 @@ Use the `labelChildren` slot for custom label content instead of plain label tex
   <RadioButton labelText="Pro (128 GB)" value="pro" />
 </RadioButtonGroup>
 
-## Reactive example
+## Layout
 
-Bind and update the selected value programmatically.
+Control the position and orientation of radio buttons within a group.
 
-<FileSource src="/framed/RadioButton/RadioButtonReactive" />
-
-## Left-aligned label
+### Left-aligned label
 
 Position labels to the left of the radio buttons.
 
@@ -73,6 +87,26 @@ Position labels to the left of the radio buttons.
   <RadioButton labelText="Free (1 GB)" value="free" />
   <RadioButton labelText="Standard (10 GB)" value="standard" />
   <RadioButton labelText="Pro (128 GB)" value="pro" />
+</RadioButtonGroup>
+
+### Vertical
+
+Display radio buttons in a vertical layout.
+
+<RadioButtonGroup orientation="vertical" legendText="Storage tier (disk)" name="plan-vertical" selected="standard">
+  <RadioButton labelText="Free (1 GB)" value="free" />
+  <RadioButton labelText="Standard (10 GB)" value="standard" />
+  <RadioButton labelText="Pro (128 GB)" value="pro" />
+</RadioButtonGroup>
+
+## Helper text
+
+Use `helperText` to provide additional context below the radio button group.
+
+<RadioButtonGroup legendText="Notification preferences" name="plan-helper" selected="email" helperText="You can change this setting at any time">
+  <RadioButton labelText="Email" value="email" />
+  <RadioButton labelText="SMS" value="sms" />
+  <RadioButton labelText="Push notifications" value="push" />
 </RadioButtonGroup>
 
 ## States
@@ -104,26 +138,6 @@ Disable all radio buttons in the group with `disabled` on RadioButtonGroup. Thei
 Display non-editable values with `readonly` on RadioButtonGroup.
 
 <RadioButtonGroup readonly labelPosition="left" legendText="Storage tier (disk)" name="plan-readonly" selected="standard">
-  <RadioButton labelText="Free (1 GB)" value="free" />
-  <RadioButton labelText="Standard (10 GB)" value="standard" />
-  <RadioButton labelText="Pro (128 GB)" value="pro" />
-</RadioButtonGroup>
-
-## Helper text
-
-Use `helperText` to provide additional context below the radio button group.
-
-<RadioButtonGroup legendText="Notification preferences" name="plan-helper" selected="email" helperText="You can change this setting at any time">
-  <RadioButton labelText="Email" value="email" />
-  <RadioButton labelText="SMS" value="sms" />
-  <RadioButton labelText="Push notifications" value="push" />
-</RadioButtonGroup>
-
-## Vertical
-
-Display radio buttons in a vertical layout.
-
-<RadioButtonGroup orientation="vertical" legendText="Storage tier (disk)" name="plan-vertical" selected="standard">
   <RadioButton labelText="Free (1 GB)" value="free" />
   <RadioButton labelText="Standard (10 GB)" value="standard" />
   <RadioButton labelText="Pro (128 GB)" value="pro" />

--- a/docs/src/pages/components/RadioTile.svx
+++ b/docs/src/pages/components/RadioTile.svx
@@ -37,6 +37,23 @@ Bind to `selected` for simpler state management.
 
 <FileSource src="/framed/RadioTile/RadioTileReactive" />
 
+## Legend
+
+Use the `legendChildren` slot on `TileGroup` to provide custom legend content instead of `legendText`.
+
+<TileGroup name="plan-legend-slot" selected="standard">
+  <strong slot="legendChildren">Service pricing tiers</strong>
+  <RadioTile value="lite">
+    Lite plan
+  </RadioTile>
+  <RadioTile value="standard">
+    Standard plan
+  </RadioTile>
+  <RadioTile value="plus">
+    Plus plan
+  </RadioTile>
+</TileGroup>
+
 ## Light
 
 Use the light variant for light backgrounds.
@@ -55,6 +72,10 @@ Use the light variant for light backgrounds.
 
 ## Disabled
 
+Disable specific tiles, or the entire group, to prevent selection.
+
+### Individual tiles
+
 Disable specific tiles to prevent selection.
 
 <TileGroup legendText="Service pricing tiers" name="plan-disabled" selected="standard">
@@ -65,6 +86,38 @@ Disable specific tiles to prevent selection.
     Standard plan
   </RadioTile>
   <RadioTile value="plus" disabled>
+    Plus plan
+  </RadioTile>
+</TileGroup>
+
+### Entire group
+
+Disable every tile at once by setting `disabled` on `TileGroup`. This prevents selection natively through the underlying `fieldset`, but doesn't apply the muted disabled tile styling shown above—set `disabled` on each `RadioTile` too for the visual state.
+
+<TileGroup legendText="Service pricing tiers" name="plan-disabled-group" selected="standard" disabled>
+  <RadioTile value="lite">
+    Lite plan
+  </RadioTile>
+  <RadioTile value="standard">
+    Standard plan
+  </RadioTile>
+  <RadioTile value="plus">
+    Plus plan
+  </RadioTile>
+</TileGroup>
+
+## Checkmark label
+
+Customize the ARIA label announced for a tile's checkmark icon with `iconDescription`. Defaults to `"Tile checkmark"`.
+
+<TileGroup legendText="Service pricing tiers" name="plan-checkmark-label" selected="standard">
+  <RadioTile value="lite">
+    Lite plan
+  </RadioTile>
+  <RadioTile value="standard" iconDescription="Standard plan selected">
+    Standard plan
+  </RadioTile>
+  <RadioTile value="plus">
     Plus plan
   </RadioTile>
 </TileGroup>

--- a/docs/src/pages/components/RecursiveList.svx
+++ b/docs/src/pages/components/RecursiveList.svx
@@ -12,6 +12,12 @@ Create a hierarchical list using the `nodes` prop. Each node can contain text, l
 
 <FileSource src="/framed/RecursiveList/RecursiveList" />
 
+## Link attributes
+
+Set `target` on a node to control where a link opens. When `target` is `"_blank"`, `rel` defaults to `"noopener noreferrer"`; supply `rel` explicitly to override it.
+
+<FileSource src="/framed/RecursiveList/RecursiveListLinkAttributes" />
+
 ## Ordered
 
 Set `type` to `"ordered"` for numbered lists with proper indentation.

--- a/docs/src/pages/components/Search.svx
+++ b/docs/src/pages/components/Search.svx
@@ -35,9 +35,25 @@ The `clear` event fires when clicking the clear button or pressing <DocKbd label
 
 <Search value="Cloud functions" on:clear={() => console.log('clear')}/>
 
+## Custom labels
+
+Customize the ARIA labels used for accessibility.
+
+### Landmark label
+
+The outer element has `role="search"`, and its accessible name comes from `labelText` via `aria-labelledby`, not a static `aria-label`. The label is visually hidden by default — see [Fluid](#fluid) for the variant with a visible label. Always set a descriptive `labelText`, especially when a page has more than one search region, so screen reader users can distinguish each landmark by name.
+
+<Search labelText="Search catalog" />
+
+### Close button label
+
+Set `closeButtonLabelText` to customize the accessible label of the clear button (default `"Clear search input"`).
+
+<Search value="Cloud functions" closeButtonLabelText="Clear catalog search" />
+
 ## Expandable
 
-Enable the expandable variant to show a compact search icon that expands on focus.
+Enable the expandable variant to show a compact search icon that expands on focus. While collapsed, the input is marked `inert` and removed from the tab order, hiding it from assistive technology until it expands — only the search icon button is reachable.
 
 <FileSource src="/framed/Search/SearchExpandableReactive" />
 

--- a/docs/src/pages/components/SearchMenu.svx
+++ b/docs/src/pages/components/SearchMenu.svx
@@ -4,8 +4,9 @@ description: Search menus filter and highlight typeahead suggestions as users ty
 ---
 
 <script>
-  import { SearchMenu, SearchMenuItem } from "carbon-components-svelte";
+  import { SearchMenu, SearchMenuItem, SearchMenuGroup } from "carbon-components-svelte";
   import ArrowRight from "carbon-icons-svelte/lib/ArrowRight.svelte";
+  import Query from "carbon-icons-svelte/lib/Query.svelte";
 </script>
 
 ## Basic
@@ -48,6 +49,32 @@ Set `menuSize` to size the results menu independently of the input. By default t
 
 <FileSource src="/framed/SearchMenu/SizeDecoupled" />
 
+## Light
+
+Set `light` to `true` for search menus on dark backgrounds.
+
+<SearchMenu light labelText="Search" placeholder="Search...">
+  <SearchMenuItem text="Databases for TestSQL" />
+  <SearchMenuItem text="Data Store for Memcache" />
+</SearchMenu>
+
+## Custom icon
+
+Replace the default search icon with a custom one.
+
+<SearchMenu icon={Query} labelText="Search" placeholder="Search...">
+  <SearchMenuItem text="Databases for TestSQL" />
+  <SearchMenuItem text="Data Store for Memcache" />
+</SearchMenu>
+
+## Close button label
+
+Set `closeButtonLabelText` to customize the accessible label of the clear button (default `"Clear search input"`).
+
+<SearchMenu closeButtonLabelText="Clear catalog search" labelText="Search" placeholder="Search..." value="Cloud functions">
+  <SearchMenuItem text="Cloud functions" />
+</SearchMenu>
+
 ## Grouping
 
 Compose `SearchMenuGroup` and `SearchMenuItem` for grouped results, recent searches, and footer actions.
@@ -64,6 +91,18 @@ Set `filter` to `false` on a group to show its items regardless of the search va
 
 <FileSource src="/framed/SearchMenu/RecentSearches" />
 
+### Item filter override
+
+Set `filter` on a `SearchMenuItem` to override the group's `filter` (or the menu's `shouldFilter`) for that one item, for example to pin a suggestion inside an otherwise-filtered group.
+
+<SearchMenu labelText="Search" placeholder="Search..." value="test">
+  <SearchMenuGroup label="Results">
+    <SearchMenuItem text="Databases for TestSQL" />
+    <SearchMenuItem text="Data Store for Memcache" />
+    <SearchMenuItem text="Pinned: Getting started guide" filter={false} />
+  </SearchMenuGroup>
+</SearchMenu>
+
 ## Layout
 
 ### Leading dropdown
@@ -71,6 +110,28 @@ Set `filter` to `false` on a group to show its items regardless of the search va
 Use the `before` slot to render content to the left of the input within a joined bar, for example a [Dropdown](/components/Dropdown) that scopes the search. Bind to the dropdown selection to update the placeholder and filter results. Compose a [Stack](/components/Stack) with a 1px separator between the dropdown and the search input. The results menu matches the search input width, and opening the dropdown closes the search menu.
 
 <FileSource src="/framed/SearchMenu/LeadingDropdown" />
+
+## Menu positioning
+
+Control where and how the results menu renders relative to the input.
+
+### Top direction
+
+Set `direction` to `"top"` to open the results menu above the input. Useful when space below is limited.
+
+<SearchMenu direction="top" labelText="Search" placeholder="Search...">
+  <SearchMenuItem text="Databases for TestSQL" />
+  <SearchMenuItem text="Data Store for Memcache" />
+</SearchMenu>
+
+### Portal menu
+
+By default, the results menu renders in a floating portal so it can escape parent containers with `overflow: hidden` or z-index stacking contexts. Set it to `false` for the menu to render within the parent container.
+
+<SearchMenu portal={false} labelText="Search" placeholder="Search...">
+  <SearchMenuItem text="Databases for TestSQL" />
+  <SearchMenuItem text="Data Store for Memcache" />
+</SearchMenu>
 
 ## Matching
 

--- a/docs/src/pages/components/Select.svx
+++ b/docs/src/pages/components/Select.svx
@@ -22,7 +22,9 @@ Create a basic select menu with select item components. The first item's value i
 
 ## Reactive
 
-Bind to `selected` for reactive updates.
+Bind to `selected` for reactive updates, or listen for the `update` event
+directly—Select dispatches it whenever the selected value changes, which is
+what powers the two-way binding.
 
 <FileSource src="/framed/Select/SelectReactive" />
 
@@ -78,9 +80,41 @@ Hide the label visually by setting `hideLabel` to `true`. The label remains avai
   <SelectItem value="g100" text="Gray 100" />
 </Select>
 
+### Custom label
+
+Use the `labelChildren` slot to provide custom label content.
+
+<Select labelText="">
+  <strong slot="labelChildren">Carbon theme</strong>
+  <SelectItem value="white" text="White" />
+  <SelectItem value="g10" text="Gray 10" />
+  <SelectItem value="g80" text="Gray 80" />
+  <SelectItem value="g90" text="Gray 90" />
+  <SelectItem value="g100" text="Gray 100" />
+</Select>
+
+### Remove label
+
+Set `noLabel` to `true` to omit the label element entirely. Unlike
+`hideLabel`, which keeps the label available to screen readers, `noLabel`
+removes it from the DOM. Provide an accessible name some other way, such
+as `aria-label` (forwarded through to the select element), when using
+`noLabel`.
+
+<Select noLabel labelText="Carbon theme" selected="g10" aria-label="Carbon theme">
+  <SelectItem value="white" text="White" />
+  <SelectItem value="g10" text="Gray 10" />
+  <SelectItem value="g80" text="Gray 80" />
+  <SelectItem value="g90" text="Gray 90" />
+  <SelectItem value="g100" text="Gray 100" />
+</Select>
+
 ### Item groups
 
-Group related options using select item group components.
+Group related options using select item group components. The example below
+also combines `disabled` and `hidden` on the first `SelectItem` to create a
+non-selectable placeholder that appears as the initial value but is absent
+from the open option list.
 
 <Select labelText="Carbon theme" selected="0">
   <SelectItem value="0" text="Select a theme" disabled hidden />
@@ -89,6 +123,22 @@ Group related options using select item group components.
     <SelectItem value="g10" text="Gray 10" />
   </SelectItemGroup>
   <SelectItemGroup label="Dark theme">
+    <SelectItem value="g80" text="Gray 80" />
+    <SelectItem value="g90" text="Gray 90" />
+    <SelectItem value="g100" text="Gray 100" />
+  </SelectItemGroup>
+</Select>
+
+### Disabled group
+
+Set `disabled` on `SelectItemGroup` to disable every item within a group.
+
+<Select labelText="Carbon theme" selected="white">
+  <SelectItemGroup label="Light theme">
+    <SelectItem value="white" text="White" />
+    <SelectItem value="g10" text="Gray 10" />
+  </SelectItemGroup>
+  <SelectItemGroup label="Dark theme" disabled>
     <SelectItem value="g80" text="Gray 80" />
     <SelectItem value="g90" text="Gray 90" />
     <SelectItem value="g100" text="Gray 100" />
@@ -281,6 +331,18 @@ Disable the select menu to prevent interaction.
 
 <Select disabled labelText="Carbon theme" selected="g10" >
   <SelectItem value="white" text="White" />
+  <SelectItem value="g10" text="Gray 10" />
+  <SelectItem value="g80" text="Gray 80" />
+  <SelectItem value="g90" text="Gray 90" />
+  <SelectItem value="g100" text="Gray 100" />
+</Select>
+
+### Disabled option
+
+Mark individual items with `disabled` on `SelectItem` for finer control over available selections.
+
+<Select labelText="Carbon theme" selected="g10">
+  <SelectItem value="white" text="White" disabled />
   <SelectItem value="g10" text="Gray 10" />
   <SelectItem value="g80" text="Gray 80" />
   <SelectItem value="g90" text="Gray 90" />

--- a/docs/src/pages/components/SelectableTile.svx
+++ b/docs/src/pages/components/SelectableTile.svx
@@ -37,7 +37,26 @@ Bind to `selected` for simpler state management.
 
 <FileSource src="/framed/SelectableTile/SelectableTileReactive" />
 
-## Hidden legend
+## Legend
+
+### Custom content
+
+Use the `legendChildren` slot on `SelectableTileGroup` to provide custom legend content instead of `legendText`.
+
+<SelectableTileGroup name="options-legend-slot" selected={["option1", "option2"]}>
+  <strong slot="legendChildren">Select options</strong>
+  <SelectableTile value="option1">
+    Multi-select Tile
+  </SelectableTile>
+  <SelectableTile value="option2">
+    Multi-select Tile
+  </SelectableTile>
+  <SelectableTile value="option3">
+    Multi-select Tile
+  </SelectableTile>
+</SelectableTileGroup>
+
+### Hidden
 
 Hide the legend visually by setting `hideLegend` to `true`. The legend remains available to screen readers.
 
@@ -71,6 +90,10 @@ Use the light variant for light backgrounds.
 
 ## Disabled
 
+Disable specific tiles, or the entire group, to prevent selection.
+
+### Individual tiles
+
 Disable specific tiles to prevent interaction.
 
 <SelectableTileGroup legendText="Select options" name="options-disabled" selected={["option1"]}>
@@ -81,6 +104,38 @@ Disable specific tiles to prevent interaction.
     Multi-select Tile
   </SelectableTile>
   <SelectableTile disabled value="option3">
+    Multi-select Tile
+  </SelectableTile>
+</SelectableTileGroup>
+
+### Entire group
+
+Disable every tile at once by setting `disabled` on `SelectableTileGroup`. This prevents selection natively through the underlying `fieldset`, but doesn't apply the muted disabled tile styling shown above—set `disabled` on each `SelectableTile` too for the visual state.
+
+<SelectableTileGroup legendText="Select options" name="options-disabled-group" selected={["option1", "option2"]} disabled>
+  <SelectableTile value="option1">
+    Multi-select Tile
+  </SelectableTile>
+  <SelectableTile value="option2">
+    Multi-select Tile
+  </SelectableTile>
+  <SelectableTile value="option3">
+    Multi-select Tile
+  </SelectableTile>
+</SelectableTileGroup>
+
+## Checkmark label
+
+Customize the ARIA label announced for a tile's checkmark icon with `iconDescription`. Defaults to `"Tile checkmark"`.
+
+<SelectableTileGroup legendText="Select options" name="options-checkmark-label" selected={["option1"]}>
+  <SelectableTile iconDescription="Option 1 selected" value="option1">
+    Multi-select Tile
+  </SelectableTile>
+  <SelectableTile value="option2">
+    Multi-select Tile
+  </SelectableTile>
+  <SelectableTile value="option3">
     Multi-select Tile
   </SelectableTile>
 </SelectableTileGroup>

--- a/docs/src/pages/components/SessionStorage.svx
+++ b/docs/src/pages/components/SessionStorage.svx
@@ -7,7 +7,9 @@ description: Session storage provides a reactive wrapper around the sessionStora
 
 See how the component maintains state within a session. Toggle the switch and refresh the page to see the persisted state. State is cleared when the tab is closed. Unlike [LocalStorage](/components/LocalStorage), data is isolated per tab.
 
-The component listens for the [storage event](https://developer.mozilla.org/en-US/docs/Web/API/Window/storage_event) so updates from another same-origin document in the same tab (for example, an iframe) stay in sync. Session storage is isolated per tab, so this event does not propagate across tabs or windows. Cross-document updates dispatch `on:update` with a payload shaped like `{ prevValue, value }`. When the key is removed from a shared session context, the bound value resets to undefined so the next local write does not re-persist stale data.
+The component listens for the [storage event](https://developer.mozilla.org/en-US/docs/Web/API/Window/storage_event) so updates from another same-origin document in the same tab (for example, an iframe) stay in sync. Session storage is isolated per tab, so this event does not propagate across tabs or windows. When the key is removed from a shared session context, the bound value resets to undefined so the next local write does not re-persist stale data.
+
+This example logs the `save` and `update` events as they fire — see [Events](#events) for what each one means and its payload shape.
 
 <FileSource src="/framed/SessionStorage/SessionStorage" />
 
@@ -28,7 +30,7 @@ The storage key is also reactive — set `key` to switch between contexts, usefu
 
 In this example, each user has their own theme preference stored under a separate key. When you switch users, the component automatically loads that user's saved preference.
 
-Switching keys only hydrates the bound value from storage; it does not dispatch `on:update`. The event log below should stay empty when you change users and only record entries when you change the theme.
+Switching keys only hydrates the bound value from storage; it does not dispatch [`update`](#update). The event log below should stay empty when you change users and only record entries when you change the theme.
 
 <FileSource src="/framed/SessionStorage/SessionStorageReactiveKey" />
 
@@ -46,13 +48,43 @@ Session storage is already per tab, so this matters mainly when an iframe shares
 
 The component provides methods to manage stored data:
 
-| Method       | Description                         |
-| ------------ | ----------------------------------- |
-| `clearItem`  | Remove a specific key-value pair.   |
-| `clearAll`   | Remove all stored data.             |
+| Method      | Description                       |
+| ----------- | ---------------------------------- |
+| `clearItem` | Remove a specific key-value pair. |
+| `clearAll`  | Remove all stored data.           |
 
 Use `bind:this` to access these methods. They only clear browser storage in the current tab; they do not reset the bound value. To clear both storage and the bound value, reset the value yourself after calling clearItem or clearAll.
 
-In this example, try toggling the switch, refreshing the page, then clearing the storage.
+In this example, toggle the switch and refresh the page to confirm the value persists, then try either button to clear storage.
 
 <FileSource src="/framed/SessionStorage/SessionStorageClear" />
+
+## Events
+
+Respond to storage writes, cross-document updates, and write failures.
+
+### Save
+
+Dispatched once on mount, when `key` is not already present in storage — right after the component seeds storage with the current `value`. The payload is always `null`.
+
+This fires the first time a key is used in the current session, and again after storage is cleared and the page is refreshed (see [Clear item, clear all](#clear-item-clear-all)). The [Basic](#basic) example above logs this event.
+
+### Update
+
+Dispatched whenever the stored value changes: after a local bound-value write, or after `sync` picks up a matching write from another same-origin document in this tab (see [Disabling sync](#disabling-sync)). The payload is `{ prevValue, value }`; `prevValue` is a snapshot taken before the change, not a live reference to the current value.
+
+Switching `key` hydrates the bound value from storage but does not dispatch this event (see [Reactive key](#reactive-key)).
+
+The [Basic](#basic), [Persisting objects and arrays](#persisting-objects-and-arrays), and [Reactive key](#reactive-key) examples above all log this event.
+
+### Error
+
+Dispatched when a write to session storage fails — for example, when storage quota is exceeded, or access is denied such as in a private browsing mode that blocks Web Storage. The payload is `{ error }`, where `error` is the value thrown by the underlying `sessionStorage.setItem` call.
+
+```svelte
+<SessionStorage
+  key="draft"
+  bind:value
+  on:error={({ detail }) => console.error("Failed to persist:", detail.error)}
+/>
+```

--- a/docs/src/pages/components/ShapeIndicator.svx
+++ b/docs/src/pages/components/ShapeIndicator.svx
@@ -9,7 +9,7 @@ description: Shape indicator pairs a status shape with a label to communicate th
 
 ## Basic
 
-Create a shape indicator with `kind` and `label`.
+Create a shape indicator with `kind` and `label`. For a version that pairs a status icon with more visual weight instead of a shape, see [IconIndicator](/components/IconIndicator).
 
 <ShapeIndicator kind="stable" label="Stable" />
 

--- a/docs/src/pages/components/SkeletonIcon.svx
+++ b/docs/src/pages/components/SkeletonIcon.svx
@@ -25,3 +25,9 @@ SkeletonIcon wraps [SkeletonPlaceholder](/components/SkeletonPlaceholder) for ic
 ### 32px
 
 <SkeletonIcon size={32} />
+
+## Custom width and height
+
+SkeletonIcon also accepts `width` and `height`, forwarded to the underlying [SkeletonPlaceholder](/components/SkeletonPlaceholder), for a non-square placeholder instead of `size`.
+
+<SkeletonIcon width="2rem" height="1rem" />

--- a/docs/src/pages/components/SkeletonPlaceholder.svx
+++ b/docs/src/pages/components/SkeletonPlaceholder.svx
@@ -35,3 +35,9 @@ Use `width` and `height` for different dimensions.
 Number values default to pixels.
 
 <SkeletonPlaceholder width={320} height={160} />
+
+### Override a single dimension
+
+`width` and `height` each take precedence over `size` independently, so you can set `size` as a base and override just one dimension.
+
+<SkeletonPlaceholder size="4rem" height="10rem" />

--- a/docs/src/pages/components/SkeletonText.svx
+++ b/docs/src/pages/components/SkeletonText.svx
@@ -30,8 +30,14 @@ Specify the number of lines with `lines`.
 
 <SkeletonText paragraph lines={8} />
 
-### Max width
+## Width
 
-Set a custom width with `width`.
+Set a custom width with `width`, as a percentage or pixel value. This works with any variant, not just paragraph.
+
+<SkeletonText width="50%" />
+
+### Paragraph
+
+In paragraph mode, each line's width varies around the `width` value instead of using it uniformly, for a more natural look.
 
 <SkeletonText paragraph width="50%" />

--- a/docs/src/pages/components/Slider.svx
+++ b/docs/src/pages/components/Slider.svx
@@ -29,11 +29,29 @@ Hide the label visually by setting `hideLabel` to `true`. The label remains avai
 
 <Slider labelText="Instances" hideLabel value={0} />
 
+### Custom label
+
+Use the `labelChildren` slot to provide custom label content.
+
+<Slider labelText="" value={0}>
+  <strong slot="labelChildren">Instances</strong>
+</Slider>
+
 ### Hidden text input
 
 Set `hideTextInput` to `true` to hide the numeric input while keeping the slider.
 
 <Slider labelText="Instances" hideTextInput value={0} />
+
+### Input type
+
+Set `inputType` to change the native `type` attribute of the text input—for example, `"text"` to avoid the browser's built-in number spinner controls. The bound `value` stays numeric regardless of `inputType`.
+
+<Slider inputType="text" labelText="Instances" value={0} />
+
+## Range and steps
+
+Control the allowed values and increment.
 
 ### Custom range
 
@@ -46,6 +64,16 @@ Set `min`, `max`, `minLabel`, and `maxLabel` to customize the range.
 Set `step` to control increment size.
 
 <Slider labelText="Runtime memory (MB)" min={10} max={990} maxLabel="990 MB" value={100} step={10} />
+
+### Step multiplier
+
+Set `stepMultiplier` to control how far Shift + Arrow key presses move the value. Holding Shift while pressing an arrow key moves the value by `(max - min) / stepMultiplier`, rounded to the nearest `step`, instead of a single step. Defaults to `4`.
+
+<Slider labelText="Runtime memory (MB)" min={10} max={990} maxLabel="990 MB" value={100} step={10} stepMultiplier={2} />
+
+## Formatting
+
+Control how range labels and `aria-valuetext` are displayed.
 
 ### Formatted values
 
@@ -85,6 +113,19 @@ Set `marks` to `true` to place a tick at every `step`.
 Use the light variant for light backgrounds.
 
 <Slider light labelText="Runtime memory (MB)" min={10} max={990} maxLabel="990 MB" value={100} step={10} />
+
+## Events
+
+Respond to value changes as the user drags the handle, uses the keyboard, or edits the text input.
+
+Use `on:input` to listen for every value while dragging or pressing an arrow key, and `on:change` to listen for committed changes—when the drag ends, an arrow key is pressed, or the text input is committed. Both events dispatch the numeric value directly as `event.detail`.
+
+<Slider
+  on:input={(e) => console.log(e.detail)} // number
+  on:change={(e) => console.log(e.detail)} // number
+  labelText="Instances"
+  value={0}
+/>
 
 ## States
 
@@ -162,6 +203,24 @@ Set `marks` the same way as on `Slider` for tick marks and optional labels.
     { value: 2, label: "Med" },
     { value: 3, label: "High" },
   ]}
+/>
+
+### Handle labels
+
+Set `ariaLabelInput` and `ariaLabelInputUpper` to distinguish the lower and upper bound handles for screen reader users. Defaults to `"Lower bound"` and `"Upper bound"`.
+
+<RangeSlider ariaLabelInput="Minimum price" ariaLabelInputUpper="Maximum price" labelText="Price range" value={20} valueUpper={80} />
+
+### Events
+
+Use `on:input` and `on:change` the same way as `Slider`. Both events dispatch `{ value, valueUpper }` as `event.detail`.
+
+<RangeSlider
+  on:input={(e) => console.log(e.detail)} // { value: number; valueUpper: number }
+  on:change={(e) => console.log(e.detail)} // { value: number; valueUpper: number }
+  labelText="Range"
+  value={10}
+  valueUpper={90}
 />
 
 ### Invalid

--- a/docs/src/pages/components/Stack.svx
+++ b/docs/src/pages/components/Stack.svx
@@ -10,22 +10,22 @@ description: Stacks arrange elements vertically or horizontally with a consisten
 
 Stacks are vertical by default. Set `orientation` to `"horizontal"` for a row. Use `gap` to pick a spacing step from 0–13, or pass a custom value such as `"22px"`. A gap of 0 omits spacing entirely; the default is step 1 (2px). Drag the slider below to preview each step.
 
-| Gap   | Size              |
-| ----- | ----------------- |
-| **0** | 0 (no gap)        |
-| **1** | 0.125rem (2px)    |
-| **2** | 0.25rem (4px)     |
-| **3** | 0.5rem (8px)      |
-| **4** | 0.75rem (12px)    |
-| **5** | 1rem (16px)       |
-| **6** | 1.5rem (24px)     |
-| **7** | 2rem (32px)       |
-| **8** | 2.5rem (40px)     |
-| **9** | 3rem (48px)       |
-| **10** | 4rem (64px)       |
-| **11** | 5rem (80px)       |
-| **12** | 6rem (96px)       |
-| **13** | 10rem (160px)     |
+| Gap    | Size           |
+| ------ | -------------- |
+| **0**  | 0 (no gap)     |
+| **1**  | 0.125rem (2px) |
+| **2**  | 0.25rem (4px)  |
+| **3**  | 0.5rem (8px)   |
+| **4**  | 0.75rem (12px) |
+| **5**  | 1rem (16px)    |
+| **6**  | 1.5rem (24px)  |
+| **7**  | 2rem (32px)    |
+| **8**  | 2.5rem (40px)  |
+| **9**  | 3rem (48px)    |
+| **10** | 4rem (64px)    |
+| **11** | 5rem (80px)    |
+| **12** | 6rem (96px)    |
+| **13** | 10rem (160px)  |
 
 ### Vertical
 
@@ -35,17 +35,7 @@ Stacks are vertical by default. Set `orientation` to `"horizontal"` for a row. U
 
 <FileSource src="/framed/Stack/StackHorizontalGap" />
 
-## Inline
-
-Set `inline` to use inline-flex so the stack shrinks to its content width instead of spanning the full container.
-
-<Stack inline gap={3}>
-  <div>Item 1</div>
-  <div>Item 2</div>
-  <div>Item 3</div>
-</Stack>
-
-## Custom value
+## Custom gap value
 
 Use an arbitrary `gap` value (for example, `"22px"`) instead of the scale.
 
@@ -65,102 +55,78 @@ Use an arbitrary `gap` value (for example, `"22px"`) instead of the scale.
   <div>Item 3</div>
 </Stack>
 
-## Custom element
+## Alignment
 
-The stack renders a div by default. Set `tag` to use a different element.
+Set `align` to position items along the cross-axis. For horizontal stacks, the cross-axis is vertical; for vertical stacks, it's horizontal. The default is stretch, which fills the container along that axis.
 
-### Vertical
-
-<Stack tag="ul" gap={3}>
-  <li>Item 1</li>
-  <li>Item 2</li>
-  <li>Item 3</li>
-</Stack>
-
-### Horizontal
-
-<Stack orientation="horizontal" tag="ul" gap={3}>
-  <li>Item 1</li>
-  <li>Item 2</li>
-  <li>Item 3</li>
-</Stack>
-
-## Align (horizontal)
-
-Set `align` to position items along the cross-axis. For horizontal stacks, this is the vertical axis. The default is stretch, which fills the container height.
-
-### Start
+### Start (horizontal)
 
 Aligns items to the top.
 
 <Stack orientation="horizontal" align="start" gap={2} style="height: 120px">
-  <div  style="height: 40px">Short</div>
-  <div  style="height: 80px">Taller item</div>
-  <div  style="height: 50px">Short</div>
+  <div style="height: 40px">Short</div>
+  <div style="height: 80px">Taller item</div>
+  <div style="height: 50px">Short</div>
 </Stack>
 
-### Center
+### Center (horizontal)
 
 Centers items vertically.
 
 <Stack orientation="horizontal" align="center" gap={2} style="height: 120px">
-  <div  style="height: 40px; min-width: 60px">Short</div>
-  <div  style="height: 80px; min-width: 80px">Taller item</div>
-  <div  style="height: 50px; min-width: 60px">Short</div>
+  <div style="height: 40px; min-width: 60px">Short</div>
+  <div style="height: 80px; min-width: 80px">Taller item</div>
+  <div style="height: 50px; min-width: 60px">Short</div>
 </Stack>
 
-### End
+### End (horizontal)
 
 Aligns items to the bottom.
 
 <Stack orientation="horizontal" align="end" gap={2} style="height: 120px">
-  <div  style="height: 40px">Short</div>
-  <div  style="height: 80px">Taller item</div>
-  <div  style="height: 50px">Short</div>
+  <div style="height: 40px">Short</div>
+  <div style="height: 80px">Taller item</div>
+  <div style="height: 50px">Short</div>
 </Stack>
 
-### Baseline
+### Baseline (horizontal)
 
 Aligns items along their text baseline.
 
 <Stack orientation="horizontal" align="baseline" gap={2}>
-  <div  style="font-size: 2rem; line-height: 1">Large</div>
-  <div  style="font-size: 1rem; line-height: 1">Medium</div>
-  <div  style="font-size: 0.75rem; line-height: 1">Small</div>
+  <div style="font-size: 2rem; line-height: 1">Large</div>
+  <div style="font-size: 1rem; line-height: 1">Medium</div>
+  <div style="font-size: 0.75rem; line-height: 1">Small</div>
 </Stack>
 
-## Align (vertical)
-
-For vertical stacks, `align` positions items along the horizontal cross-axis.
-
-### Start
+### Start (vertical)
 
 Aligns items to the left.
 
 <Stack orientation="vertical" align="start" gap={2}>
-  <div  style="width: 80px">Narrow</div>
-  <div  style="width: 150px">Wider item</div>
-  <div  style="width: 100px">Medium</div>
+  <div style="width: 80px">Narrow</div>
+  <div style="width: 150px">Wider item</div>
+  <div style="width: 100px">Medium</div>
 </Stack>
 
-### Center
+### Center (vertical)
 
 Centers items horizontally.
 
 <Stack orientation="vertical" align="center" gap={2}>
-  <div  style="width: 80px">Narrow</div>
-  <div  style="width: 150px">Wider item</div>
-  <div  style="width: 100px">Medium</div>
+  <div style="width: 80px">Narrow</div>
+  <div style="width: 150px">Wider item</div>
+  <div style="width: 100px">Medium</div>
 </Stack>
 
-### End
+### End (vertical)
 
 Aligns items to the right.
 
 <Stack orientation="vertical" align="end" gap={2}>
-  <div  style="width: 80px">Narrow</div>
-  <div  style="width: 150px">Wider item</div>
-  <div  style="width: 100px">Medium</div>
+  <div style="width: 80px">Narrow</div>
+  <div style="width: 150px">Wider item</div>
+  <div style="width: 100px">Medium</div>
 </Stack>
 
 ## Justify
@@ -172,9 +138,9 @@ Set `justify` to distribute items along the main axis. The default is start.
 Aligns items to the center of the main axis.
 
 <Stack orientation="horizontal" justify="center" gap={2}>
-  <div >Item 1</div>
-  <div >Item 2</div>
-  <div >Item 3</div>
+  <div>Item 1</div>
+  <div>Item 2</div>
+  <div>Item 3</div>
 </Stack>
 
 ### End
@@ -182,9 +148,9 @@ Aligns items to the center of the main axis.
 Aligns items to the end of the main axis.
 
 <Stack orientation="horizontal" justify="end" gap={2}>
-  <div >Item 1</div>
-  <div >Item 2</div>
-  <div >Item 3</div>
+  <div>Item 1</div>
+  <div>Item 2</div>
+  <div>Item 3</div>
 </Stack>
 
 ### Space between
@@ -192,9 +158,9 @@ Aligns items to the end of the main axis.
 Distributes items evenly with the first item at the start and the last item at the end.
 
 <Stack orientation="horizontal" justify="space-between">
-  <div >Item 1</div>
-  <div >Item 2</div>
-  <div >Item 3</div>
+  <div>Item 1</div>
+  <div>Item 2</div>
+  <div>Item 3</div>
 </Stack>
 
 ### Space around
@@ -202,9 +168,9 @@ Distributes items evenly with the first item at the start and the last item at t
 Distributes items evenly with equal space around each item.
 
 <Stack orientation="horizontal" justify="space-around">
-  <div >Item 1</div>
-  <div >Item 2</div>
-  <div >Item 3</div>
+  <div>Item 1</div>
+  <div>Item 2</div>
+  <div>Item 3</div>
 </Stack>
 
 ### Space evenly
@@ -215,6 +181,15 @@ Distributes items evenly with equal space between each item.
   <div>Item 1</div>
   <div>Item 2</div>
   <div>Item 3</div>
+</Stack>
+
+## Combined align and justify
+
+Use both `align` and `justify` to center content on both axes.
+
+<Stack align="center" justify="center" gap={4}>
+  <div>Centered</div>
+  <div>Content</div>
 </Stack>
 
 ## Wrap
@@ -247,11 +222,32 @@ Set `wrap` to `"wrap-reverse"` to wrap items in the reverse cross-axis direction
   <div>Item 6</div>
 </Stack>
 
-## Combined align and justify
+## Inline
 
-Use both `align` and `justify` to center content on both axes.
+Set `inline` to use inline-flex so the stack shrinks to its content width instead of spanning the full container.
 
-<Stack align="center" justify="center" gap={4}>
-  <div >Centered</div>
-  <div >Content</div>
+<Stack inline gap={3}>
+  <div>Item 1</div>
+  <div>Item 2</div>
+  <div>Item 3</div>
+</Stack>
+
+## Custom element
+
+The stack renders a div by default. Set `tag` to use a different element.
+
+### Vertical
+
+<Stack tag="ul" gap={3}>
+  <li>Item 1</li>
+  <li>Item 2</li>
+  <li>Item 3</li>
+</Stack>
+
+### Horizontal
+
+<Stack orientation="horizontal" tag="ul" gap={3}>
+  <li>Item 1</li>
+  <li>Item 2</li>
+  <li>Item 3</li>
 </Stack>

--- a/docs/src/pages/components/StructuredList.svx
+++ b/docs/src/pages/components/StructuredList.svx
@@ -188,6 +188,43 @@ Allow selecting more than one row with `multiple`. Selected becomes an array of 
 
 <FileSource src="/framed/StructuredList/StructuredListMultiSelect" />
 
+## Events
+
+### Selection change
+
+`StructuredList` dispatches a `change` event whenever the selected row changes. The event detail is the selected value—or an array of values when `multiple` is `true`.
+
+<StructuredList
+  selection
+  selected="postgresql-value"
+  on:change={(e) => console.log(e.detail)}
+>
+  <StructuredListHead>
+    <StructuredListRow head>
+      <StructuredListCell head>Name</StructuredListCell>
+      <StructuredListCell head>Type</StructuredListCell>
+    </StructuredListRow>
+  </StructuredListHead>
+  <StructuredListBody>
+    {#each [
+      { id: "postgresql", name: "PostgreSQL", type: "Relational" },
+      { id: "mongodb", name: "MongoDB", type: "Document" },
+      { id: "redis", name: "Redis", type: "Key-value" },
+    ] as db}
+      <StructuredListRow label for="event-{db.id}">
+        <StructuredListCell>{db.name}</StructuredListCell>
+        <StructuredListCell>{db.type}</StructuredListCell>
+        <StructuredListInput
+          id="event-{db.id}"
+          value="{db.id}-value"
+          title="{db.name} option"
+          name="database-event"
+        />
+      </StructuredListRow>
+    {/each}
+  </StructuredListBody>
+</StructuredList>
+
 ## Skeleton
 
 Show a loading state with the skeleton variant.

--- a/docs/src/pages/components/Tabs.svx
+++ b/docs/src/pages/components/Tabs.svx
@@ -31,17 +31,57 @@ Create a basic tab interface with labels and content.
   </svelte:fragment>
 </Tabs>
 
-## Reactive
+## Selection
+
+Control which tab is active by index, by a stable id, or by changing how arrow keys move the selection.
+
+### Reactive
 
 Use `bind:selected` for a two-way binding with the selected tab index, so you can programmatically control the selected tab and react to tab changes.
 
 <FileSource src="/framed/Tabs/TabsReactive" />
 
-## Selected by id
+### Selected by id
 
 For dynamic tab sets, bind `selectedId` and give each `Tab` a stable `id`. Selection stays on the same logical tab when tabs before it are added or removed. When set, `selectedId` takes precedence over `selected`.
 
 <FileSource src="/framed/Tabs/TabsSelectedId" />
+
+### Manual activation
+
+By default, tabs use automatic activation: arrow keys move focus and select the
+tab. Set `activation` to `"manual"` so arrow keys only move focus. Press <DocKbd label="Enter" /> or <DocKbd label="Space" /> to select.
+Use manual activation when switching panels is expensive.
+
+<Tabs activation="manual">
+  <Tab label="Tab label 1" />
+  <Tab label="Tab label 2" />
+  <Tab label="Tab label 3" />
+  <svelte:fragment slot="content">
+    <TabContent>Content 1</TabContent>
+    <TabContent>Content 2</TabContent>
+    <TabContent>Content 3</TabContent>
+  </svelte:fragment>
+</Tabs>
+
+## Events
+
+Listen for tab selection changes.
+
+### Change
+
+Listen for `on:change` to know when the selected tab index changes, whether from a click, keyboard navigation, or a `selected`/`selectedId` update. `event.detail` is the new selected index. For the dismiss event, see [Dismissible](#dismissible).
+
+<Tabs on:change={(e) => console.log(e.detail)}>
+  <Tab label="Tab label 1" />
+  <Tab label="Tab label 2" />
+  <Tab label="Tab label 3" />
+  <svelte:fragment slot="content">
+    <TabContent>Content 1</TabContent>
+    <TabContent>Content 2</TabContent>
+    <TabContent>Content 3</TabContent>
+  </svelte:fragment>
+</Tabs>
 
 ## Overflow
 
@@ -72,23 +112,6 @@ When the tabs exceed the available width, the list scrolls horizontally and back
 Below the medium breakpoint, vertical tabs collapse into the same horizontal, scrollable row with overflow buttons. Resize the viewport to see them.
 
 <FileSource src="/framed/Tabs/TabsVerticalOverflow" />
-
-## Manual activation
-
-By default, tabs use automatic activation: arrow keys move focus and select the
-tab. Set `activation` to `"manual"` so arrow keys only move focus. Press <DocKbd label="Enter" /> or <DocKbd label="Space" /> to select.
-Use manual activation when switching panels is expensive.
-
-<Tabs activation="manual">
-  <Tab label="Tab label 1" />
-  <Tab label="Tab label 2" />
-  <Tab label="Tab label 3" />
-  <svelte:fragment slot="content">
-    <TabContent>Content 1</TabContent>
-    <TabContent>Content 2</TabContent>
-    <TabContent>Content 3</TabContent>
-  </svelte:fragment>
-</Tabs>
 
 ## Disabled tabs
 
@@ -229,6 +252,10 @@ the route to the console instead of navigating.
 
 ## Icons
 
+Add an icon next to the tab label, or render compact tabs that show only an icon.
+
+### With label
+
 Add an icon next to the tab label with `icon`. The icon renders to the right of
 the label by default and shifts left when dismissible is enabled.
 
@@ -243,13 +270,13 @@ the label by default and shifts left when dismissible is enabled.
   </svelte:fragment>
 </Tabs>
 
-## Icon-only
+### Icon-only
 
 Set `iconOnly` on Tabs to render compact, square tabs that display only an icon.
 Set icon and label on each Tab; the label is the accessible name and the tooltip
 shown on hover and focus.
 
-### Basic
+#### Basic
 
 <Tabs iconOnly>
   <Tab label="Search" icon={Search} />
@@ -264,7 +291,7 @@ shown on hover and focus.
   </svelte:fragment>
 </Tabs>
 
-### Large
+#### Large
 
 Set `iconSize` to `"lg"` for large icon-only tabs. The tabs and their icons are enlarged to the large scale.
 
@@ -281,7 +308,7 @@ Set `iconSize` to `"lg"` for large icon-only tabs. The tabs and their icons are 
   </svelte:fragment>
 </Tabs>
 
-### Tooltip placement
+#### Tooltip placement
 
 The tooltip renders below the tab by default. Use `tooltipDirection` and
 `tooltipAlignment` to control placement. The tooltip automatically flips to the
@@ -300,7 +327,7 @@ opposite side if there is not enough space.
   </svelte:fragment>
 </Tabs>
 
-### Container
+#### Container
 
 Icon-only tabs also work with the container type.
 
@@ -322,7 +349,7 @@ Icon-only tabs also work with the container type.
 Set `dismissible` on Tabs to render a close button on each tab. Handle the
 dismiss event to remove the tab from your data. Bind `selectedId` with a stable
 `id` on each Tab so selection stays coherent without manual index math. The
-event detail includes `{ id, label, disabled, index }`. Press
+event detail includes `{ id, label, disabled, hasSecondaryLabel, index }`. Press
 <DocKbd label="Delete" /> on the focused tab to dismiss it.
 
 ### Basic
@@ -520,7 +547,7 @@ Show a loading state for the container tab variant.
 Use TabsVertical for a tab list beside the panel. Compose it with the same Tab and
 TabContent components. From the medium breakpoint up, tabs stack in a vertical column.
 On narrower screens, the list becomes a horizontal row with overflow scrolling.
-`activation` works the same as on Tabs (see [Manual activation](#manual-activation)).
+`selected`, `selectedId`, and `activation` all work the same as on Tabs (see [Selection](#selection)).
 
 <TabsVertical>
   <Tab label="Dashboard" />
@@ -583,8 +610,8 @@ height.
 
 ### Selected
 
-Set selected to control the active tab index. Bind to selected to update the
-index as users switch tabs.
+Set `selected` to control the active tab index on mount. As with `Tabs`, bind
+`selected` or `selectedId` for two-way updates (see [Selection](#selection)).
 
 <TabsVertical selected={1}>
   <Tab label="Dashboard" />

--- a/docs/src/pages/components/Tag.svx
+++ b/docs/src/pages/components/Tag.svx
@@ -125,19 +125,29 @@ Set `maxWidth` to a CSS length to ellipsis long labels. A tooltip with the full 
   </div>
 </Stack>
 
+### Close button label
+
+Set `title` to customize the accessible name and hover tooltip of the close button. Defaults to `"Clear filter"`.
+
+<Tag filter title="Remove filter" on:close>carbon-components</Tag>
+
 ## Custom icon
 
 Add a custom icon to the tag. Note: custom icons cannot be used with the filterable variant.
 
 <Tag icon={IbmCloud}>IBM Cloud</Tag>
 
-## Interactive
+## Clickable variants
+
+Render the tag as a native interactive element instead of a `div`.
+
+### Interactive
 
 Set `interactive` to render a button element instead of a div for clickable tags.
 
 <Tag interactive>Machine learning</Tag>
 
-## Link
+### Link
 
 Set `href` to render the tag as an anchor. Link tags reuse interactive styles. Do not wrap a `Tag` in an `<a>`; pass `href` on the tag itself. `href` is mutually exclusive with `filter`; when both are set, `filter` takes precedence.
 
@@ -174,7 +184,7 @@ Embed a tooltip within a tag to provide additional context.
 
 ## Selectable
 
-Use `SelectableTag` to create a tag that toggles between selected and unselected states.
+Use `SelectableTag` to create a tag that toggles between selected and unselected states. Toggling dispatches `change` with `{ selected }`.
 
 <FileSource src="/framed/Tag/SelectableTagReactive" />
 
@@ -183,6 +193,12 @@ Use `SelectableTag` to create a tag that toggles between selected and unselected
 Combine `SelectableTag` with a custom icon.
 
 <FileSource src="/framed/Tag/SelectableTagIconReactive" />
+
+### Type
+
+Combine `SelectableTag` with a color `type`, matching the color types available on `Tag`.
+
+<SelectableTag type="blue">Machine learning</SelectableTag>
 
 ### Disabled
 

--- a/docs/src/pages/components/TagSet.svx
+++ b/docs/src/pages/components/TagSet.svx
@@ -4,7 +4,7 @@ description: Displays a row of tags that collapses to fit the available width, m
 ---
 
 <script>
-  import { Tag, TagSet } from "carbon-components-svelte";
+  import { Stack, Tag, TagSet } from "carbon-components-svelte";
 </script>
 
 ## Basic
@@ -57,39 +57,81 @@ Set `multiline` to wrap every tag onto multiple lines instead of collapsing into
 
 <FileSource src="/framed/TagSet/TagSetMultiline" />
 
-## Tooltip alignment
+### Measurement offset
+
+Set `measurementOffset` to subtract a fixed amount from the measured available width before fitting tags — useful when other content shares the same row and should be reserved space.
+
+<Stack gap={5}>
+  <div>
+    <div>measurementOffset={0} (default)</div>
+    <div style="max-width: 14rem;">
+      <TagSet>
+        <Tag type="red">Angular</Tag>
+        <Tag type="blue">React</Tag>
+        <Tag type="purple">Svelte</Tag>
+        <Tag type="green">Vue</Tag>
+        <Tag type="magenta">Ember</Tag>
+      </TagSet>
+    </div>
+  </div>
+  <div>
+    <div>measurementOffset={80}</div>
+    <div style="max-width: 14rem;">
+      <TagSet measurementOffset={80}>
+        <Tag type="red">Angular</Tag>
+        <Tag type="blue">React</Tag>
+        <Tag type="purple">Svelte</Tag>
+        <Tag type="green">Vue</Tag>
+        <Tag type="magenta">Ember</Tag>
+      </TagSet>
+    </div>
+  </div>
+</Stack>
+
+### Custom measurement target
+
+Set `containingElement` to measure a different element instead of `TagSet`'s own wrapper — useful when the width `TagSet` should fit within isn't its own box, for example when matching the width of another element on the page.
+
+<FileSource src="/framed/TagSet/TagSetContainingElement" />
+
+## Overflow tooltip
+
+Control the content and positioning of the tooltip shown by the "+N" indicator.
+
+### Alignment
 
 Set `overflowAlign` to align the tooltip relative to the "+N" indicator.
 
-### Align start
+<Stack gap={5}>
+  <div>
+    <div>overflowAlign="start"</div>
+    <div style="max-width: 12rem;">
+      <TagSet overflowAlign="start">
+        <Tag type="red">Angular</Tag>
+        <Tag type="blue">React</Tag>
+        <Tag type="purple">Svelte</Tag>
+        <Tag type="green">Vue</Tag>
+        <Tag type="magenta">Ember</Tag>
+      </TagSet>
+    </div>
+  </div>
+  <div>
+    <div>overflowAlign="end"</div>
+    <div style="max-width: 12rem;">
+      <TagSet overflowAlign="end">
+        <Tag type="red">Angular</Tag>
+        <Tag type="blue">React</Tag>
+        <Tag type="purple">Svelte</Tag>
+        <Tag type="green">Vue</Tag>
+        <Tag type="magenta">Ember</Tag>
+      </TagSet>
+    </div>
+  </div>
+</Stack>
 
-<div style="max-width: 12rem;">
-  <TagSet overflowAlign="start">
-    <Tag type="red">Angular</Tag>
-    <Tag type="blue">React</Tag>
-    <Tag type="purple">Svelte</Tag>
-    <Tag type="green">Vue</Tag>
-    <Tag type="magenta">Ember</Tag>
-  </TagSet>
-</div>
+### Direction
 
-### Align end
-
-<div style="max-width: 12rem;">
-  <TagSet overflowAlign="end">
-    <Tag type="red">Angular</Tag>
-    <Tag type="blue">React</Tag>
-    <Tag type="purple">Svelte</Tag>
-    <Tag type="green">Vue</Tag>
-    <Tag type="magenta">Ember</Tag>
-  </TagSet>
-</div>
-
-## Tooltip direction
-
-Set `overflowDirection` to show the tooltip above the indicator instead of below.
-
-### Direction top
+Set `overflowDirection` to `"top"` to show the tooltip above the indicator instead of below.
 
 <div style="max-width: 12rem;">
   <TagSet overflowDirection="top">
@@ -101,17 +143,49 @@ Set `overflowDirection` to show the tooltip above the indicator instead of below
   </TagSet>
 </div>
 
+### Custom content
+
+Override the `overflowTooltip` slot to replace the default plain-text tooltip with custom content.
+
+<FileSource src="/framed/TagSet/TagSetCustomOverflowTooltip" />
+
 ## Dismissible
 
 Set `filter` on a `Tag` to render it as closable. `TagSet` dispatches `close:tag` with `{ tag, index }` instead of taking a per-tag handler: remove the tag from your own state in response.
 
 <FileSource src="/framed/TagSet/TagSetDismissible" />
 
-## Custom overflow tooltip
+## Events
 
-Override the `overflowTooltip` slot to replace the default plain-text tooltip with custom content.
+Respond to interactions with the "+N" overflow indicator.
 
-<FileSource src="/framed/TagSet/TagSetCustomOverflowTooltip" />
+### Overflow click
+
+Use `on:click:overflow` to listen for clicks on the "+N" indicator. The event detail includes the current overflow count.
+
+<div style="max-width: 12rem;">
+  <TagSet on:click:overflow={(e) => console.log(e.detail.count)}>
+    <Tag type="red">Angular</Tag>
+    <Tag type="blue">React</Tag>
+    <Tag type="purple">Svelte</Tag>
+    <Tag type="green">Vue</Tag>
+    <Tag type="magenta">Ember</Tag>
+  </TagSet>
+</div>
+
+### Overflow count change
+
+Use `on:overflow:change` to listen for changes to the overflow count, whether from a resize, a slotted-children change, or a `maxVisible` change. The event detail includes the new count.
+
+<div style="max-width: 12rem;">
+  <TagSet on:overflow:change={(e) => console.log(e.detail.count)}>
+    <Tag type="red">Angular</Tag>
+    <Tag type="blue">React</Tag>
+    <Tag type="purple">Svelte</Tag>
+    <Tag type="green">Vue</Tag>
+    <Tag type="magenta">Ember</Tag>
+  </TagSet>
+</div>
 
 ## Sizes
 

--- a/docs/src/pages/components/Text.svx
+++ b/docs/src/pages/components/Text.svx
@@ -142,6 +142,8 @@ Set modifier props alongside a type style.
   <Text type="body-long-01" italic>Italic body text</Text>
   <Text type="body-long-01" family="mono">IBM Plex Mono</Text>
   <Text type="body-long-01" family="serif">IBM Plex Serif</Text>
+  <Text type="body-long-01" family="sans-condensed">IBM Plex Sans Condensed</Text>
+  <Text type="body-long-01" family="sans-hebrew">IBM Plex Sans Hebrew</Text>
   <Text tag="h2" type="productive-heading-04" balance maxWidth="20rem">Balanced heading across multiple lines</Text>
 </Stack>
 
@@ -185,9 +187,27 @@ Set `fullWidth` when the row should span its container (`width: 100%`). A block 
   </Text>
 </Box>
 
-## Truncate (multiline)
+## Truncate
 
-Set `lines` to truncate overflow while keeping the Carbon type style. Values above 1 use multiline mode (end clamp only). See also [Truncate](/components/Truncate) for wrapping inline text, or the truncate action on native elements.
+Set `lines` to truncate overflow while keeping the Carbon type style. See also [Truncate](/components/Truncate) for wrapping inline text, or the truncate action on native elements.
+
+### Single line
+
+Set `lines` to `1` to truncate a single line with an ellipsis. Pair with `maxWidth` (or a constrained container) so there is a boundary to truncate against.
+
+<Text type="body-short-01" maxWidth="16rem" lines={1}>
+  Carbon Components Svelte is a Svelte component library that implements the Carbon Design System.
+</Text>
+
+Set `clamp` to `"front"` to truncate from the start instead of the end. `clamp` only takes effect when `lines` is `1`; multiline mode always clamps at the end.
+
+<Text type="body-short-01" maxWidth="16rem" lines={1} clamp="front">
+  Carbon Components Svelte is a Svelte component library that implements the Carbon Design System.
+</Text>
+
+### Multiline
+
+Values of `lines` above `1` use multiline mode (end clamp only).
 
 <Text type="body-long-01" maxWidth="20rem" lines={3}>
   Carbon Components Svelte is a Svelte component library that implements the Carbon Design System, an open source design system by IBM. It is maintained by the open source community and is available on npm.

--- a/docs/src/pages/components/TextArea.svx
+++ b/docs/src/pages/components/TextArea.svx
@@ -14,17 +14,27 @@ Create a basic textarea with a label and placeholder text.
 
 <TextArea labelText="App description" placeholder="Enter a description..." />
 
+## Rows and columns
+
+Control the visible size of the textarea.
+
+### Rows
+
+Adjust visible rows with `rows`. The default is `4`.
+
+<TextArea rows={10} labelText="App description" placeholder="Enter a description..." />
+
+### Columns
+
+Adjust visible columns with `cols`. Setting `cols` disables the default resize handle; override this with the `resize` style property.
+
+<TextArea cols={40} labelText="App description" placeholder="Enter a description..." />
+
 ## Maximum character count
 
 Specify the max character count with `maxCount`. A character counter appears to the right of the label. Use the native maxlength attribute instead if you prefer not to show a counter.
 
 <TextArea labelText="App description" placeholder="Enter a description..." maxCount={100} />
-
-## Custom rows
-
-Adjust visible rows with `rows`. The default is 4.
-
-<TextArea rows={10} labelText="App description" placeholder="Enter a description..." />
 
 ## Helper text
 
@@ -37,6 +47,14 @@ Add helper text below the textarea to provide additional context or instructions
 Hide the label visually by setting `hideLabel` to `true`. The label remains available to screen readers.
 
 <TextArea hideLabel labelText="App description" placeholder="Enter a description..." />
+
+## Custom label
+
+Use the `labelChildren` slot to provide custom label content.
+
+<TextArea labelText="" placeholder="Enter a description...">
+  <strong slot="labelChildren">App description</strong>
+</TextArea>
 
 ## Light
 

--- a/docs/src/pages/components/TextInput.svx
+++ b/docs/src/pages/components/TextInput.svx
@@ -40,6 +40,31 @@ Specify the max character count with `maxCount`. A character counter appears to 
 
 <TextInput labelText="User name" placeholder="Enter user name..." maxCount={10} />
 
+## Events
+
+Respond to value changes.
+
+### Value change
+
+Use `on:input` to listen for every keystroke, and `on:change` to listen for
+committed changes on blur. Both events dispatch the current value directly as
+`event.detail`.
+
+<TextInput
+  labelText="User name"
+  placeholder="Enter user name..."
+  on:input={(e) => console.log(e.detail)} // string | null
+  on:change={(e) => console.log(e.detail)} // string | null
+/>
+
+### Numeric values
+
+Set the native `type` attribute to `"number"` to parse `value` as a number.
+The bound value—and the event detail dispatched by `on:input` and `on:change`—is
+`null` when the input is empty, otherwise a `number`.
+
+<TextInput type="number" labelText="Age" placeholder="Enter age..." />
+
 ## Light
 
 Use the light variant for light-themed backgrounds with `light`.

--- a/docs/src/pages/components/Theme.svx
+++ b/docs/src/pages/components/Theme.svx
@@ -38,41 +38,63 @@ For example, primary buttons use `interactive-01` for background, with separate 
 
 <FileSource src="/framed/Theme/ThemeTokens" />
 
-## Toggle
+## Controls
+
+Render a built-in control instead of managing `theme` yourself. Set `render` to `"toggle"`, `"select"`, or `"dropdown"`.
+
+### Toggle
 
 Set `render` to `"toggle"` to display a toggle switch for switching between two themes. By default, it toggles between "white" and "g100" themes.
 
 <FileSource src="/framed/Theme/ThemeToggle" />
 
-### Custom
+#### Custom
 
 Customize themes, labels, and other toggle options with `toggle`.
 
 <FileSource src="/framed/Theme/ThemeToggleCustom" />
 
-## Select
+### Select
 
 Set `render` to `"select"` to display a dropdown menu for selecting from all available themes.
 
 <FileSource src="/framed/Theme/ThemeSelect" />
 
-### Custom
+#### Custom
 
 Choose which themes to include, customize labels, and adjust other select options with `select`.
 
 <FileSource src="/framed/Theme/ThemeSelectCustom" />
 
-## Dropdown
+### Dropdown
 
 Set `render` to `"dropdown"` to display a Dropdown component for selecting from all available themes.
 
 <FileSource src="/framed/Theme/ThemeDropdown" />
 
-### Custom
+#### Custom
 
 Choose which themes to include, customize labels, and adjust other dropdown options with `dropdown`.
 
 <FileSource src="/framed/Theme/ThemeDropdownCustom" />
+
+## Events
+
+Theme dispatches an `update` event whenever `theme` changes, whether from a built-in control or a bound value updated elsewhere in your app. The initial theme on mount does not dispatch `update`.
+
+```svelte
+<Theme render="toggle" on:update={(e) => console.log(e.detail.theme)} />
+```
+
+## Slot
+
+Use the default slot to access the current `theme` value with `let:theme`, without duplicating local state.
+
+```svelte
+<Theme render="select" let:theme>
+  <p>Current theme: {theme}</p>
+</Theme>
+```
 
 ## Exported themes constant
 

--- a/docs/src/pages/components/Tile.svx
+++ b/docs/src/pages/components/Tile.svx
@@ -17,3 +17,9 @@ Create a basic tile container for your content.
 Use the light variant for light-themed backgrounds by setting `light` to `true`.
 
 <Tile light>Content</Tile>
+
+## Custom interaction
+
+The tile forwards `on:click`, `on:mouseover`, `on:mouseenter`, and `on:mouseleave` for custom interactions. Unlike `ClickableTile`, a plain tile has no `tabindex` and doesn't respond to <DocKbd label="Enter" /> or <DocKbd label="Space" />—use `ClickableTile` if you need built-in keyboard accessibility.
+
+<Tile on:click={() => console.log("clicked")}>Content</Tile>

--- a/docs/src/pages/components/TimePicker.svx
+++ b/docs/src/pages/components/TimePicker.svx
@@ -23,6 +23,106 @@ Create a time picker with period (AM/PM) and timezone selectors.
   </TimePickerSelect>
 </TimePicker>
 
+## Formatting
+
+Customize input validation to match a different time notation.
+
+### 24-hour clock
+
+The default `pattern` validates a 12-hour `h:mm` or `hh:mm` value. Override
+`pattern` (and update `helperText` or `placeholder` to match) to accept a
+24-hour clock instead. A 24-hour field typically drops the AM/PM select.
+
+<TimePicker pattern="([01][0-9]|2[0-3]):[0-5][0-9]" labelText="Cron job" placeholder="hh:mm" helperText="24-hour clock, e.g. 14:30" value="14:30">
+  <TimePickerSelect value="pdt">
+    <SelectItem value="pdt" text="PDT" />
+    <SelectItem value="gmt" text="GMT" />
+  </TimePickerSelect>
+</TimePicker>
+
+### Seconds
+
+Update `pattern` and increase `maxlength` together to accept a `hh:mm:ss`
+value. The default `maxlength` (5) only fits `hh:mm`.
+
+<TimePicker pattern="(1[012]|[1-9]):[0-5][0-9]:[0-5][0-9]" maxlength={8} labelText="Cron job" placeholder="hh:mm:ss" value="2:15:30">
+  <TimePickerSelect value="pm">
+    <SelectItem value="am" text="AM" />
+    <SelectItem value="pm" text="PM" />
+  </TimePickerSelect>
+</TimePicker>
+
+## Events
+
+Respond to edits on the time field and to period/timezone selection.
+
+### Change
+
+`on:change` and `on:input` forward the native input events from the time
+field. Read the current value from `event.target.value`, or use `bind:value`
+for two-way binding.
+
+<TimePicker labelText="Cron job" placeholder="hh:mm" on:change={(e) => console.log(e.target.value)}>
+  <TimePickerSelect value="pm">
+    <SelectItem value="am" text="AM" />
+    <SelectItem value="pm" text="PM" />
+  </TimePickerSelect>
+</TimePicker>
+
+### Period and timezone change
+
+`TimePickerSelect` forwards `on:change` from its native select element the
+same way.
+
+<TimePicker labelText="Cron job" placeholder="hh:mm">
+  <TimePickerSelect value="pm" on:change={(e) => console.log(e.target.value)}>
+    <SelectItem value="am" text="AM" />
+    <SelectItem value="pm" text="PM" />
+  </TimePickerSelect>
+</TimePicker>
+
+## Select icon label
+
+Set `iconDescription` on `TimePickerSelect` to change the chevron icon's ARIA
+label and native tooltip. It defaults to `"Open list of options"`.
+
+<TimePicker labelText="Cron job" placeholder="hh:mm">
+  <TimePickerSelect iconDescription="Choose AM or PM" value="pm">
+    <SelectItem value="am" text="AM" />
+    <SelectItem value="pm" text="PM" />
+  </TimePickerSelect>
+  <TimePickerSelect iconDescription="Choose timezone" value="pdt">
+    <SelectItem value="pdt" text="PDT" />
+    <SelectItem value="gmt" text="GMT" />
+  </TimePickerSelect>
+</TimePicker>
+
+## Helper text
+
+Add helper text to provide additional context or formatting instructions.
+
+<TimePicker labelText="Cron job" placeholder="hh:mm" helperText="24-hour, e.g. 14:30">
+  <TimePickerSelect value="pm">
+    <SelectItem value="am" text="AM" />
+    <SelectItem value="pm" text="PM" />
+  </TimePickerSelect>
+  <TimePickerSelect value="pdt">
+    <SelectItem value="pdt" text="PDT" />
+    <SelectItem value="gmt" text="GMT" />
+  </TimePickerSelect>
+</TimePicker>
+
+## Hidden label
+
+Hide the label visually by setting `hideLabel` to `true`. The label remains available to screen readers.
+
+<TimePicker hideLabel labelText="Cron job" placeholder="hh:mm">
+  <TimePickerSelect value="pm">
+    <SelectItem value="am" text="AM" />
+    <SelectItem value="pm" text="PM" />
+  </TimePickerSelect>
+</TimePicker>
+
 ## Light
 
 Enable the light variant with `light`.
@@ -202,32 +302,6 @@ Use the small size for more compact time pickers by setting `size` to `"sm"`.
   <TimePickerSelect value="pdt">
     <SelectItem value="pdt" text="PDT" />
     <SelectItem value="gmt" text="GMT" />
-  </TimePickerSelect>
-</TimePicker>
-
-## Helper text
-
-Add helper text to provide additional context or formatting instructions.
-
-<TimePicker labelText="Cron job" placeholder="hh:mm" helperText="24-hour, e.g. 14:30">
-  <TimePickerSelect value="pm">
-    <SelectItem value="am" text="AM" />
-    <SelectItem value="pm" text="PM" />
-  </TimePickerSelect>
-  <TimePickerSelect value="pdt">
-    <SelectItem value="pdt" text="PDT" />
-    <SelectItem value="gmt" text="GMT" />
-  </TimePickerSelect>
-</TimePicker>
-
-## Hidden label
-
-Hide the label visually by setting `hideLabel` to `true`. The label remains available to screen readers.
-
-<TimePicker hideLabel labelText="Cron job" placeholder="hh:mm">
-  <TimePickerSelect value="pm">
-    <SelectItem value="am" text="AM" />
-    <SelectItem value="pm" text="PM" />
   </TimePickerSelect>
 </TimePicker>
 

--- a/docs/src/pages/components/ToastNotification.svx
+++ b/docs/src/pages/components/ToastNotification.svx
@@ -83,6 +83,12 @@ Prevent the default close behavior using `e.preventDefault()` in the `on:close` 
   // custom close logic (e.g., transitions)
 }} />
 
+## ARIA role
+
+Specify the ARIA `role` for the notification container to control how screen readers announce it. Defaults to `"alert"` for interruptive announcements. Use `"status"` for polite live-region updates, or `"log"` for a running log of messages.
+
+<ToastNotification role="status" kind="success" title="Success" subtitle="Your settings have been saved." caption="{new Date().toLocaleString()}" />
+
 ## Variants
 
 The component supports different notification types.

--- a/docs/src/pages/components/Toggle.svx
+++ b/docs/src/pages/components/Toggle.svx
@@ -19,18 +19,6 @@ Display the toggle in its on state with `toggled`.
 
 <Toggle labelText="Push notifications" toggled />
 
-## Reactive example
-
-Use two-way binding to control the toggle state programmatically.
-
-<FileSource src="/framed/Toggle/ToggleReactive" />
-
-## on:toggle event
-
-Listen for state changes with `on:toggle`.
-
-<Toggle labelText="Push notifications" on:toggle={e => console.log(e.detail)} />
-
 ## Labels
 
 Customize or hide the toggle labels.
@@ -56,6 +44,16 @@ Use slots to customize the toggle labels with additional styling or content.
   <span slot="labelB" style="color: green">Yes</span>
 </Toggle>
 
+### Custom label
+
+Use the `labelChildren` slot to provide custom label content instead of `labelText`.
+
+<Toggle labelText="Fallback label">
+  <span slot="labelChildren">
+    Push notifications <strong>(recommended)</strong>
+  </span>
+</Toggle>
+
 ## States
 
 Reflect interaction states.
@@ -77,6 +75,18 @@ Display a non-editable value with `readonly`.
 Use the small size variant by setting `size` to `"sm"`.
 
 <Toggle size="sm" labelText="Push notifications" />
+
+## Reactive
+
+Use two-way binding with `bind:toggled` to track and update the toggle state programmatically.
+
+<FileSource src="/framed/Toggle/ToggleReactive" />
+
+## Events
+
+Use `on:toggle` to listen for state changes. The event dispatches `{ toggled: boolean }` as `event.detail`.
+
+<Toggle labelText="Push notifications" on:toggle={e => console.log(e.detail)} />
 
 ## Skeleton
 

--- a/docs/src/pages/components/Toggletip.svx
+++ b/docs/src/pages/components/Toggletip.svx
@@ -22,25 +22,33 @@ Control the toggletip state programmatically by binding to `open`.
 
 <FileSource src="/framed/Toggletip/ToggletipReactive" />
 
-## Label
+## Custom labels
 
-Render an inline label beside the button.
+Customize the toggletip's visible label and the button's accessible name.
 
-### Prop
+### Label prop
 
-Use the `labelText` prop.
+Render an inline label beside the button using the `labelText` prop.
 
 <Toggletip labelText="Setting">
   This setting controls how items are displayed.
 </Toggletip>
 
-### Slot
+### Label slot
 
 Alternatively, use the `"labelText"` slot for custom markup.
 
 <Toggletip>
   <span slot="labelText"><strong>Setting</strong></span>
   This setting controls how items are displayed.
+</Toggletip>
+
+### Accessible label
+
+Set the button's ARIA label with `iconDescription`. It defaults to `"Show information"`.
+
+<Toggletip iconDescription="Additional information">
+  The button has a custom ARIA label.
 </Toggletip>
 
 ## Actions
@@ -72,14 +80,6 @@ Alternatively, use the `"icon"` slot.
 <Toggletip iconDescription="Add">
   <Add slot="icon" />
   The button renders a custom icon.
-</Toggletip>
-
-## Accessible label
-
-Set the button's ARIA label with `iconDescription`. It defaults to `"Show information"`.
-
-<Toggletip iconDescription="Additional information">
-  The button has a custom ARIA label.
 </Toggletip>
 
 ## Placement

--- a/docs/src/pages/components/Toolbar.svx
+++ b/docs/src/pages/components/Toolbar.svx
@@ -5,15 +5,27 @@ description: Toolbars provide a flexible container for actions, search, and menu
 
 <script>
   import { Toolbar, ToolbarContent, ToolbarSearch, ToolbarMenu, ToolbarMenuItem, ToolbarBatchActions, Button } from "carbon-components-svelte";
+  import Filter from "carbon-icons-svelte/lib/Filter.svelte";
+  import TrashCan from "carbon-icons-svelte/lib/TrashCan.svelte";
 </script>
 
 ## Basic
 
-Create a basic toolbar with content inside toolbar content.
+Create a basic toolbar with content inside toolbar content. **Toolbar** can be used independently of DataTable—it provides its own context for child components like **ToolbarMenu**, **ToolbarSearch**, and **ToolbarBatchActions**, so every example on this page works standalone. To use a toolbar with a data table instead, see [DataTable's Toolbar section](/components/DataTable#toolbar).
 
 <Toolbar>
   <ToolbarContent>
     <Button>Primary action</Button>
+  </ToolbarContent>
+</Toolbar>
+
+## Accessible label
+
+Set `ariaLabel` to override the toolbar's accessible name. The default, `"data table toolbar"`, is inherited from Toolbar's original use inside DataTable—override it for standalone toolbars so assistive technology announces something more meaningful.
+
+<Toolbar ariaLabel="Product actions">
+  <ToolbarContent>
+    <Button>Create</Button>
   </ToolbarContent>
 </Toolbar>
 
@@ -63,9 +75,20 @@ Set `persistent` on toolbar search to keep it always expanded.
   </ToolbarContent>
 </Toolbar>
 
+### Disabled
+
+Set `disabled` to `true` to disable the search field.
+
+<Toolbar>
+  <ToolbarContent>
+    <ToolbarSearch disabled placeholder="Search..." />
+    <Button>Create</Button>
+  </ToolbarContent>
+</Toolbar>
+
 ### Reactive
 
-Bind to `value` for reactive updates.
+Bind to `value` for reactive updates. `expanded` is also bindable, so you can read or programmatically set whether the search field is open.
 
 <FileSource src="/framed/Toolbar/ToolbarSearchReactive" />
 
@@ -74,6 +97,17 @@ Bind to `value` for reactive updates.
 Use `bind:this` to obtain a ToolbarSearch reference and call `clear()` to reset the value.
 
 <FileSource src="/framed/Toolbar/ToolbarSearchClear" />
+
+### Clear event
+
+Listen for `on:clear` to know when the user clears the field—by clicking the built-in clear icon or pressing <kbd>Escape</kbd> while focused. This is distinct from calling the exported `clear()` method yourself, which updates `value` and `expanded` directly without dispatching the event.
+
+<Toolbar>
+  <ToolbarContent>
+    <ToolbarSearch persistent placeholder="Search..." on:clear={() => console.log("cleared")} />
+    <Button>Create</Button>
+  </ToolbarContent>
+</Toolbar>
 
 ## Menu
 
@@ -118,7 +152,98 @@ Set `primaryFocus` on a menu item to focus it when opening the dropdown.
   </ToolbarContent>
 </Toolbar>
 
-## Complete toolbar
+### Disabled item
+
+Set `disabled` on a menu item to prevent it from being selected.
+
+<Toolbar>
+  <ToolbarContent>
+    <ToolbarMenu>
+      <ToolbarMenuItem>Restart all</ToolbarMenuItem>
+      <ToolbarMenuItem disabled>Restart selected</ToolbarMenuItem>
+    </ToolbarMenu>
+  </ToolbarContent>
+</Toolbar>
+
+### Custom icon
+
+**ToolbarMenu** extends [OverflowMenu](/components/OverflowMenu), inheriting props such as `icon`. The default icon is a settings gear—pass a different icon component to change it.
+
+<Toolbar>
+  <ToolbarContent>
+    <ToolbarMenu icon={Filter}>
+      <ToolbarMenuItem>Filter by category</ToolbarMenuItem>
+      <ToolbarMenuItem>Filter by price</ToolbarMenuItem>
+    </ToolbarMenu>
+  </ToolbarContent>
+</Toolbar>
+
+## Batch actions
+
+Toolbar batch actions display batch actions when items are selected.
+
+Although intended for use with [DataTable](/components/DataTable), batch actions can be used standalone when `selectedIds` is provided. That prop is not required when used with a data table.
+
+### Basic usage
+
+<Toolbar>
+  <ToolbarBatchActions selectedIds={[1, 2, 3]}>
+    <Button icon={TrashCan}>Delete</Button>
+  </ToolbarBatchActions>
+  <ToolbarContent>
+    <Button size="small">Create</Button>
+  </ToolbarContent>
+</Toolbar>
+
+### Manually controlling visibility
+
+Set `active` to `true` or `false` to override the automatic visibility based on `selectedIds`. This is useful when the batch action bar should be driven by application state instead of a selection count. Here, the bar is forced open even though no items are selected.
+
+<Toolbar>
+  <ToolbarBatchActions active>
+    <Button icon={TrashCan}>Delete</Button>
+  </ToolbarBatchActions>
+  <ToolbarContent>
+    <Button size="small">Create</Button>
+  </ToolbarContent>
+</Toolbar>
+
+### Custom cancel label
+
+Override the Cancel button's text using the `cancel` slot.
+
+<Toolbar>
+  <ToolbarBatchActions selectedIds={[1, 2, 3]}>
+    <Button icon={TrashCan}>Delete</Button>
+    <svelte:fragment slot="cancel">Discard</svelte:fragment>
+  </ToolbarBatchActions>
+  <ToolbarContent>
+    <Button size="small">Create</Button>
+  </ToolbarContent>
+</Toolbar>
+
+### Total selected label
+
+Override the "N items selected" text with `formatTotalSelected`.
+
+<Toolbar>
+  <ToolbarBatchActions selectedIds={[1, 2, 3]} formatTotalSelected={(total) => `${total} item${total === 1 ? "" : "s"} chosen`}>
+    <Button icon={TrashCan}>Delete</Button>
+  </ToolbarBatchActions>
+  <ToolbarContent>
+    <Button size="small">Create</Button>
+  </ToolbarContent>
+</Toolbar>
+
+### Standalone with dynamic selection
+
+In standalone usage there's no `DataTable` context to reset the selection automatically, so listen for `on:cancel` and clear your own selection state in the handler.
+
+<FileSource src="/framed/Toolbar/ToolbarBatchActionsStandalone" />
+
+## Composition
+
+### Complete toolbar
 
 Combine search, menu, and buttons for a full-featured toolbar.
 
@@ -136,7 +261,7 @@ Combine search, menu, and buttons for a full-featured toolbar.
   </ToolbarContent>
 </Toolbar>
 
-## With multiple actions
+### With multiple actions
 
 Stack multiple action buttons in the toolbar.
 
@@ -147,26 +272,3 @@ Stack multiple action buttons in the toolbar.
     <Button size="small">Create</Button>
   </ToolbarContent>
 </Toolbar>
-
-## Standalone usage
-
-**Toolbar** can be used independently of DataTable. It provides its own context for child components like **ToolbarMenu** and **ToolbarSearch**. The toolbar components work standalone for general-purpose layouts:
-
-<Toolbar>
-  <ToolbarContent>
-    <ToolbarSearch placeholder="Search products..." />
-    <ToolbarMenu>
-      <ToolbarMenuItem>Filter by category</ToolbarMenuItem>
-      <ToolbarMenuItem>Sort by price</ToolbarMenuItem>
-    </ToolbarMenu>
-    <Button>Add product</Button>
-  </ToolbarContent>
-</Toolbar>
-
-## Batch actions
-
-Toolbar batch actions display batch actions when items are selected. 
-
-Although intended for use with [DataTable](/components/DataTable), batch actions can be used standalone when `selectedIds` is provided. That prop is not required when used with a data table.
-
-<FileSource src="/framed/Toolbar/ToolbarBatchActionsStandalone" />

--- a/docs/src/pages/components/Tooltip.svx
+++ b/docs/src/pages/components/Tooltip.svx
@@ -18,13 +18,38 @@ Display a tooltip triggered by the default information icon.
   </p>
 </Tooltip>
 
-## With trigger text
+## Custom labels
 
-Use custom trigger text instead of the default icon.
+Customize the tooltip's visible trigger text and the icon button's accessible name.
+
+### Trigger text
+
+Use custom trigger text instead of the default icon with `triggerText`.
 
 <Tooltip triggerText="Resource list">
   <p>
     Resources are provisioned based on your account's organization.
+  </p>
+</Tooltip>
+
+### Trigger text slot
+
+Alternatively, use the `"triggerText"` slot for custom markup.
+
+<Tooltip>
+  <span slot="triggerText"><strong>Resource list</strong></span>
+  <p>
+    Resources are provisioned based on your account's organization.
+  </p>
+</Tooltip>
+
+### Accessible label
+
+Set the button's ARIA label with `iconDescription`. It defaults to `"Show information"`.
+
+<Tooltip iconDescription="Additional information">
+  <p>
+    The button has a custom ARIA label.
   </p>
 </Tooltip>
 
@@ -33,6 +58,12 @@ Use custom trigger text instead of the default icon.
 Control the tooltip state programmatically.
 
 <FileSource src="/framed/Tooltip/TooltipReactive" />
+
+## Dispatched events
+
+The component dispatches `open` and `close` events.
+
+<FileSource src="/framed/Tooltip/TooltipEvents" />
 
 ## Placement
 
@@ -71,7 +102,7 @@ Add interactive elements like links and buttons using the tooltip footer.
 
 ## Custom icon
 
-Replace the default icon via prop or slot.
+Customize or hide the default trigger icon.
 
 ### Component
 
@@ -94,6 +125,16 @@ Customize the icon using the `icon` slot for more flexibility.
   </p>
 </Tooltip>
 
+### Hidden icon
+
+Hide the trigger icon while keeping tooltip behavior with `hideIcon`.
+
+<Tooltip hideIcon triggerText="Resource list">
+  <p>
+    Resources are provisioned based on your account's organization.
+  </p>
+</Tooltip>
+
 ## Custom delay
 
 Customize the enter and leave delay with `enterDelayMs` and `leaveDelayMs`. Defaults are 100ms and 300ms.
@@ -101,16 +142,6 @@ Customize the enter and leave delay with `enterDelayMs` and `leaveDelayMs`. Defa
 <Tooltip triggerText="Slow open" enterDelayMs={500} leaveDelayMs={200}>
   <p>
     This tooltip has a 500ms enter delay and a 200ms leave delay.
-  </p>
-</Tooltip>
-
-## Hidden icon
-
-Hide the trigger icon while keeping tooltip behavior with `hideIcon`.
-
-<Tooltip hideIcon triggerText="Resource list">
-  <p>
-    Resources are provisioned based on your account's organization.
   </p>
 </Tooltip>
 

--- a/docs/src/pages/components/TooltipDefinition.svx
+++ b/docs/src/pages/components/TooltipDefinition.svx
@@ -18,7 +18,7 @@ Display a basic definition tooltip with the default bottom-center alignment.
 
 Position the tooltip with direction and alignment.
 
-### Direction
+### Directions
 
 By default, the tooltip is positioned to the bottom.
 
@@ -47,7 +47,11 @@ Center
 End
 </TooltipDefinition>
 
-## Click to open
+## Open behavior
+
+Control how and when the tooltip opens.
+
+### Click to open
 
 Open the tooltip on click instead of hover with `clickToOpen`.
 
@@ -55,7 +59,7 @@ Open the tooltip on click instead of hover with `clickToOpen`.
   Armonk
 </TooltipDefinition>
 
-## Open by default
+### Open by default
 
 Open the tooltip by default with `open`.
 
@@ -63,7 +67,7 @@ Open the tooltip by default with `open`.
   Armonk
 </TooltipDefinition>
 
-## Programmatic usage
+## Reactive example
 
 Control tooltip state programmatically with `bind:open`.
 
@@ -102,7 +106,7 @@ Set `portalTooltip` to render the tooltip in a portal so it is not clipped by ov
   Armonk
 </TooltipDefinition>
 
-### Direction
+### Directions
 
 Definition tooltips support top and bottom directions only. With portalling, direction behaves the same as the default CSS path.
 

--- a/docs/src/pages/components/TooltipIcon.svx
+++ b/docs/src/pages/components/TooltipIcon.svx
@@ -20,6 +20,12 @@ Control tooltip state programmatically with `bind:open`.
 
 <FileSource src="/framed/TooltipIcon/TooltipIconReactive" />
 
+## Dispatched events
+
+The component dispatches `open` and `close` events.
+
+<FileSource src="/framed/TooltipIcon/TooltipIconEvents" />
+
 ## Sizes
 
 Set icon size with `size`. Carbon icons use a 16/20/24/32 scale, but any pixel value works.
@@ -29,14 +35,30 @@ Set icon size with `size`. Carbon icons use a 16/20/24/32 scale, but any pixel v
 <TooltipIcon tooltipText="24px" icon={Carbon} size={24} />
 <TooltipIcon tooltipText="32px" icon={Carbon} size={32} />
 
-## Directions
+## Placement
 
-Position the tooltip with `direction` and `align`.
+Position the tooltip with direction and alignment.
 
-<TooltipIcon tooltipText="Top start" direction="top" align="start" icon={Filter} />
-<TooltipIcon tooltipText="Right end" direction="right" align="end" icon={Filter} />
-<TooltipIcon tooltipText="Bottom start" direction="bottom" align="start" icon={Filter} />
-<TooltipIcon tooltipText="Left start" direction="left" align="start" icon={Filter} />
+### Directions
+
+By default, the tooltip is positioned to the bottom.
+
+Position the tooltip with `direction`.
+
+<TooltipIcon tooltipText="Top" direction="top" icon={Filter} />
+<TooltipIcon tooltipText="Right" direction="right" icon={Filter} />
+<TooltipIcon tooltipText="Bottom" direction="bottom" icon={Filter} />
+<TooltipIcon tooltipText="Left" direction="left" icon={Filter} />
+
+### Alignment
+
+By default, the tooltip is aligned to the center.
+
+Align the tooltip content with `align`.
+
+<TooltipIcon tooltipText="Start" align="start" icon={Filter} />
+<TooltipIcon tooltipText="Center" align="center" icon={Filter} />
+<TooltipIcon tooltipText="End" align="end" icon={Filter} />
 
 ## Custom tooltip text
 
@@ -44,6 +66,14 @@ Use the `tooltipText` slot to customize the tooltip content with additional styl
 
 <TooltipIcon icon={Carbon}>
   <span slot="tooltipText" style="color: red">Carbon is an open source design system by IBM.</span>
+</TooltipIcon>
+
+## Custom icon
+
+Use the default slot to fully customize the trigger content, replacing what the `icon` prop would otherwise render.
+
+<TooltipIcon tooltipText="Custom icon content">
+  <div style="width: 1rem; height: 1rem; outline: 1px solid red;"></div>
 </TooltipIcon>
 
 ## Custom delay
@@ -64,7 +94,7 @@ Set `portalTooltip` to render the tooltip in a portal so it is not clipped by ov
 
 <TooltipIcon portalTooltip tooltipText="Carbon is an open source design system by IBM." icon={Carbon} />
 
-### Direction
+### Directions
 
 Icon tooltips support top, right, bottom, and left. With portalling, direction behaves the same as the default CSS path.
 

--- a/docs/src/pages/components/TreeView.svx
+++ b/docs/src/pages/components/TreeView.svx
@@ -2,6 +2,10 @@
 description: A tree view displays hierarchical data in a collapsible tree structure. It supports node selection, expansion, icons, programmatic control of the tree state, and virtualization for large trees.
 ---
 
+<script>
+  import { TreeView } from "carbon-components-svelte";
+</script>
+
 ## Basic
 
 Create a basic tree view using the `nodes` prop. Each node needs a unique id and display text; icons, disabled state, and nested children are optional.
@@ -15,6 +19,35 @@ By default, only one node is selected at a time. For multiple selection, see Mul
 Use the compact variant by setting `size` to `"compact"`.
 
 <FileSource src="/framed/TreeView/TreeViewCompact" />
+
+## Hidden label
+
+Hide the label visually by setting `hideLabel` to `true`. The label remains available to screen readers.
+
+<TreeView
+  hideLabel
+  labelText="Cloud Products"
+  nodes={[
+    { id: 0, text: "AI / Machine learning" },
+    { id: 1, text: "Analytics" },
+    { id: 2, text: "Databases" },
+  ]}
+/>
+
+## Custom label
+
+Use the `labelChildren` slot to provide custom label content instead of `labelText`.
+
+<TreeView
+  labelText=""
+  nodes={[
+    { id: 0, text: "AI / Machine learning" },
+    { id: 1, text: "Analytics" },
+    { id: 2, text: "Databases" },
+  ]}
+>
+  <strong slot="labelChildren">Cloud Products</strong>
+</TreeView>
 
 ## Initial state
 
@@ -175,19 +208,23 @@ Use `TreeView.collapseNodes` to collapse specific nodes based on a condition. Ca
 
 <FileSource src="/framed/TreeView/TreeViewCollapseNodes" />
 
-## Show a node
+## Node access
+
+Programmatically reveal or query specific nodes by id.
+
+### Show a node
 
 Use `TreeView.showNode` to expand, select, and focus a specific node.
 
 <FileSource src="/framed/TreeView/TreeViewShowNode" />
 
-### With options
+#### With options
 
 Configure `TreeView.showNode` behavior using optional parameters. By default, all three actions occur (`expand`, `select`, `focus`), but you can disable any combination. This is useful for expanding nodes without selecting them, or selecting without expanding.
 
 <FileSource src="/framed/TreeView/TreeViewShowNodeOptions" />
 
-## Node lookup
+### Node lookup
 
 Use `TreeView.getNode` to resolve a node's text or metadata from its id, useful for a breadcrumb or detail pane driven by `activeId`. Unmatched ids return `null`.
 
@@ -195,7 +232,11 @@ Use `TreeView.getNodes` to resolve multiple ids at once, such as `selectedIds`. 
 
 <FileSource src="/framed/TreeView/TreeViewGetNode" />
 
-## Lazy loading
+## Performance
+
+Scale to large trees by loading, rendering, and measuring only what's needed.
+
+### Lazy loading
 
 Set `hasChildren` on a node to render it as an expandable branch before its `nodes` are known. Expanding it fires `toggle` as usual; the handler can fetch and assign `nodes` asynchronously.
 
@@ -203,14 +244,14 @@ While `hasChildren` is `true` and `nodes` is empty, the `childNodes` slot render
 
 <FileSource src="/framed/TreeView/TreeViewLazyLoad" />
 
-## Virtualization
+### Virtualization
 
 Virtualization renders only the rows currently visible in the scroll viewport, improving performance for large trees (for example, file trees and log explorers). Set `virtualize` to enable it. The tree still tracks the full `nodes` dataset; only the on-screen slice is mounted in the DOM.
 
 Row height is fixed and comes from `size` (32px default, 24px compact). Rows do not grow to fit their content, so keep slot content to a single line. Pass `true` for defaults, or an object to customize:
 
 | Field             | Default                       | Description                                                                 |
-| ----------------- | ----------------------------- | --------------------------------------------------------------------------- |
+| ----------------- | ------------------------------ | --------------------------------------------------------------------------- |
 | `containerHeight` | `maxVisibleRows * itemHeight` | Scroll viewport height. Pass a number (pixels) or a CSS string (`"80%"`, `"100%"`, `"calc(...)"`) when the parent sets height. |
 | `maxVisibleRows`  | `10`                          | Rows visible at once when `containerHeight` is not set.                     |
 | `overscan`        | `3`                           | Extra rows rendered above and below the viewport during scroll.             |
@@ -219,42 +260,46 @@ Row height is fixed and comes from `size` (32px default, 24px compact). Rows do 
 
 <FileSource src="/framed/TreeView/TreeViewVirtualize" />
 
-### With lazy loading
+#### With lazy loading
 
 Combine `virtualize` with `hasChildren` to fetch children on expand. This example starts with the same project-folder roots as [Virtualization](#virtualization), but each subtree loads on demand (including nested folders). The virtualized path does not render the `childNodes` slot, so the demo inserts a temporary disabled "Loading…" child while the request is in flight, then replaces it with the fetched nodes.
 
 <FileSource src="/framed/TreeView/TreeViewVirtualizeLazy" />
 
-## Flat data
+### Large and deep trees
+
+The tree view is optimized to handle large datasets efficiently, as shown here with a large tree (1000+ nodes) and a deeply nested tree (100 levels deep).
+
+<FileSource src="/framed/TreeView/TreeViewPerformance" />
+
+## Data utilities
+
+Transform and filter node data using standalone utility functions.
+
+### Flat data
 
 Convert flat data to a hierarchical structure using the `toHierarchy` utility.
 
 <FileSource src="/framed/TreeView/TreeViewFlatArray" />
 
-## Filtering
+### Filtering
 
 Filter nodes with the built-in helpers.
 
-### By text
+#### By text
 
 Combine a search input with `filterTreeByText` to create an interactive searchable tree. Type to filter nodes by name (case-insensitive substring matching). By default, matching nodes and their ancestors are included to maintain valid tree structure.
 
 <FileSource src="/framed/TreeView/TreeViewFilter" />
 
-### By ID
+#### By ID
 
 Use `filterTreeById` to filter nodes by their ID. Accepts either a single ID or an array of IDs. Click the buttons to filter by a single ID or multiple IDs. Matching nodes and their ancestors are included by default.
 
 <FileSource src="/framed/TreeView/TreeViewFilterById" />
 
-### Custom predicate
+#### Custom predicate
 
 Use `filterTreeNodes` with a predicate function to implement custom filtering logic. The example demonstrates filtering by file extension, filtering leaf nodes only, and using the `includeChildren` option to include all descendants of matching nodes. By default, matching nodes and their ancestors are included.
 
 <FileSource src="/framed/TreeView/TreeViewFilterNodes" />
-
-## Large and deep trees
-
-The tree view is optimized to handle large datasets efficiently, as shown here with a large tree (1000+ nodes) and a deeply nested tree (100 levels deep).
-
-<FileSource src="/framed/TreeView/TreeViewPerformance" />

--- a/docs/src/pages/components/Truncate.svx
+++ b/docs/src/pages/components/Truncate.svx
@@ -6,7 +6,11 @@ description: Truncate handles single-line and multiline text overflow, as a comp
   import { Truncate, truncate } from "carbon-components-svelte";
 </script>
 
-## Basic
+Truncate offers two ways to clip overflowing text: the `Truncate` component, which wraps content in a `<p>`, and the `truncate` action, which applies the same clipping to any element. For truncating text that also needs a specific Carbon type style, see [Text](/components/Text#truncate).
+
+## Component
+
+### Basic
 
 The default component wraps text in a paragraph and truncates at the end of the line.
 
@@ -14,36 +18,43 @@ The default component wraps text in a paragraph and truncates at the end of the 
   Carbon Components Svelte is a Svelte component library that implements the Carbon Design System, an open source design system by IBM.
 </Truncate>
 
-## Clamp front
+### Clamp front
 
-Set `clamp` to `"front"` to keep the end of the text visible.
+Set `clamp` to `"front"` to keep the end of the text visible. `clamp` only takes effect when `lines` is `1`.
 
 <Truncate clamp="front" style="max-width: 20rem">
   Carbon Components Svelte is a Svelte component library that implements the Carbon Design System, an open source design system by IBM.
 </Truncate>
 
-## Multiline
+### Multiline
 
-Set lines above 1 to limit how many lines show. Multiline mode only clamps from the end.
+Set `lines` above 1 to limit how many lines show. Multiline mode always clamps from the end, regardless of `clamp`.
 
 <Truncate lines={3} style="max-width: 20rem">
   Carbon Components Svelte is a Svelte component library that implements the Carbon Design System, an open source design system by IBM. It is maintained by the open source community and is available on npm.
 </Truncate>
 
-## use:truncate
+## Action
 
-Use the `truncate` action on any element.
+Use the `truncate` action on any element for the same behavior without the `Truncate` component's wrapping `<p>`.
+
+### Basic
 
 <h4 use:truncate style="max-width: 20rem">
   Carbon Components Svelte is a Svelte component library that implements the Carbon Design System, an open source design system by IBM.
 </h4>
+
+### Clamp front
+
+Pass `clamp: "front"` to keep the end of the text visible.
+
 <h4 use:truncate={{ clamp: "front" }} style="max-width: 20rem">
   Carbon Components Svelte is a Svelte component library that implements the Carbon Design System, an open source design system by IBM.
 </h4>
 
 ### Multiline
 
-Pass lines for multiline truncation.
+Pass `lines` for multiline truncation.
 
 <p use:truncate={{ lines: 3 }} style="max-width: 20rem">
   Carbon Components Svelte is a Svelte component library that implements the Carbon Design System, an open source design system by IBM. It is maintained by the open source community and is available on npm.

--- a/docs/src/pages/components/UIShell.svx
+++ b/docs/src/pages/components/UIShell.svx
@@ -22,8 +22,10 @@ components: ["Header",
 "SideNavLink",
 "SideNavMenu",
 "SideNavMenuItem",
+"SideNavDivider",
 "Content",
 "SkipToContent",
+"HamburgerMenu",
 "HeaderGlobalAction"]
 description: The UI shell provides components for building application shells and navigation — header, side navigation, and content areas.
 ---
@@ -32,7 +34,34 @@ description: The UI shell provides components for building application shells an
 
 Create a basic header with the header component. Open these examples in a new tab to experience them in full.
 
+### Basic header
+
 <FileSource src="/framed/UIShell/Header" />
+
+### Navigation menus
+
+Group related links behind a dropdown with `HeaderNavMenu` inside `HeaderNav`, as shown in the "Manage" menu in the example above. Clicking the trigger toggles the dropdown; clicking a `HeaderNavItem` link inside it also collapses the dropdown, since the click bubbles up to the trigger.
+
+Keyboard support follows the WAI-ARIA menu pattern: <DocKbd label="Enter" />, <DocKbd label="Space" />, <DocKbd label="ArrowDown" />, or <DocKbd label="ArrowUp" /> open the menu and move focus to the first or last item, <DocKbd label="ArrowDown" />/<DocKbd label="ArrowUp" /> move between items once open, and <DocKbd label="Escape" /> closes the menu and returns focus to the trigger.
+
+`HeaderNavMenu` dispatches `close` with `event.detail.trigger` set to `"escape-key"`, `"outside-click"`, or `"blur"`:
+
+```svelte
+<HeaderNavMenu
+  text="Manage"
+  on:close={(event) => console.log(event.detail.trigger)}
+>
+  <HeaderNavItem href="/account" text="Account" />
+</HeaderNavMenu>
+```
+
+### Current page
+
+Set `isSelected` on `HeaderNavItem` to mark the current page. It adds `aria-current="page"` and a persistent underline style. The same prop is available on `SideNavLink` and `SideNavMenuItem` in the side navigation section below.
+
+```svelte
+<HeaderNavItem href="/catalog" text="Catalog" isSelected />
+```
 
 ### External links
 
@@ -41,6 +70,10 @@ Set the `icon` prop on `HeaderNavItem` to add a trailing icon after the text. Fo
 Duplicate those items in `HeaderSideNavItems` so the links stay in the side nav below the large breakpoint.
 
 <FileSource src="/framed/UIShell/HeaderNavExternalLinks" />
+
+### Skip to content
+
+Pair `SkipToContent` with `Content` so keyboard users can jump past the header and navigation straight to the main content. By default `SkipToContent` links to `href="#main-content"` and `Content` renders with `id="main-content"`, so the two work together without extra configuration. Override both `href` and `id` together if you render more than one `Content` region, or need a different anchor.
 
 ## Side navigation
 
@@ -52,11 +85,21 @@ The hamburger menu is automatically rendered when the side nav component is used
 
 <FileSource src="/framed/UIShell/HeaderNav" />
 
+### Side nav menus
+
+Group related links behind a dropdown with `SideNavMenu`, wrapping `SideNavMenuItem` children, as shown in the "Kubernetes" menu in the example above. Set `expanded` to open the dropdown by default, and `icon` to render a leading icon on the trigger. Separate groups of items with `SideNavDivider`.
+
+In the [rail](#rail) variant, an expanded `SideNavMenu` automatically collapses when the rail returns to its narrow state.
+
+### Current page
+
+Set `isSelected` on `SideNavLink` or `SideNavMenuItem` to mark the current page — see "Dashboard" in the example above. It adds `aria-current="page"` and a persistent highlight style so the current location stays visible even while hovering other items.
+
 ### Responsive
 
 On smaller screens, header links belong in the side nav, above the regular side nav items.
 
-Carbon hides the header nav below the large breakpoint (66rem). Duplicate those links with `HeaderSideNavItems`; its children only appear below that breakpoint. Use a divider to separate them from the regular side nav items.
+Carbon hides the header nav below the large breakpoint (66rem). Duplicate those links with `HeaderSideNavItems`; its children only appear below that breakpoint. Set `hasDivider` to separate them from the regular side nav items below.
 
 Resize the viewport to see the switch.
 
@@ -90,6 +133,21 @@ Create a header with a persistent hamburger menu state.
 
 <FileSource src="/framed/UIShell/PersistedHamburgerMenu" />
 
+### Events
+
+`SideNav` dispatches `open` and `close` when `isOpen` changes, and `click:overlay` when the mobile overlay behind the panel is clicked (just before it closes):
+
+```svelte
+<SideNav
+  bind:isOpen
+  on:open={() => console.log("opened")}
+  on:close={() => console.log("closed")}
+  on:click:overlay={() => console.log("overlay clicked")}
+>
+  <SideNavItems>...</SideNavItems>
+</SideNav>
+```
+
 ## Switcher
 
 A `HeaderAction` reveals a panel from the right edge.
@@ -107,6 +165,25 @@ You can mount multiple switchers and customize each button. For example, add a t
 Control tooltip alignment with `tooltipAlignment`. Providing button text overrides the tooltip.
 
 <FileSource src="/framed/UIShell/HeaderMultipleSwitcher" />
+
+### Panel composition
+
+Compose the panel content from `HeaderPanelLinks`, `HeaderPanelDivider`, and `HeaderPanelLink`, as shown in both examples above. `HeaderPanelLinks` renders the list wrapper; `HeaderPanelDivider` renders a labelled separator (or a plain rule when it has no content) between groups of links; `HeaderPanelLink` renders each item. The same three components compose the notification and help panels in the multiple-switchers example — panel composition is not specific to the app switcher icon.
+
+### Events
+
+`HeaderAction` dispatches `open` and `close` as the panel toggles, with `event.detail.trigger` set to `"toggle"`, `"outside-click"`, or `"escape-key"`. Set `preventCloseOnClickOutside` to keep the panel open when the user clicks elsewhere on the page — useful when the panel hosts its own dismiss controls.
+
+```svelte
+<HeaderAction
+  bind:isOpen
+  preventCloseOnClickOutside
+  on:open={(event) => console.log(event.detail.trigger)}
+  on:close={(event) => console.log(event.detail.trigger)}
+>
+  <HeaderPanelLinks>...</HeaderPanelLinks>
+</HeaderAction>
+```
 
 ## Search
 
@@ -140,29 +217,73 @@ Set `size` to `"sm"` (default), `"lg"`, or `"xl"` to control row density. Result
 
 <FileSource src="/framed/UIShell/HeaderSearchMenu" />
 
+### Events
+
+`HeaderSearch` dispatches `active` and `inactive` as the search bar opens and closes, `clear` when the clear ("x") button is clicked, `select` when a result is chosen (from `results` or the `menu` slot), and `submit` when <DocKbd label="Enter" /> is pressed with no result selected (`menu` slot only).
+
+It also dispatches `close` — with `event.detail.trigger` set to `"escape-key"`, `"outside-click"`, or `"select"` — whenever the search bar deactivates, whether the user dismissed it or selected a result:
+
+```svelte
+<HeaderSearch
+  bind:value
+  on:active={() => console.log("active")}
+  on:inactive={() => console.log("inactive")}
+  on:clear={() => console.log("cleared")}
+  on:select={(event) => console.log(event.detail)}
+  on:close={(event) => console.log(event.detail.trigger)}
+/>
+```
+
 ## Utilities
 
 Add utilities to the header with header utilities. Compose [BadgeIndicator](/components/BadgeIndicator) in the badge slot on `HeaderGlobalAction`. Set `iconDescription` for screen readers.
 
+### Icon actions
+
 <FileSource src="/framed/UIShell/HeaderUtilities" />
+
+### Action links
+
+Use `HeaderActionLink` instead of `HeaderGlobalAction` when the utility is a plain link rather than a button that toggles a panel — for example, a link out to a GitHub repository. Set `icon`, `href`, and `target="_blank"` as needed; set `linkIsActive` to style it as active.
+
+<FileSource src="/framed/UIShell/HeaderActionLink" />
+
+## Profile menu
+
+Use `ProfileMenu` for an account menu in the header.
 
 ### Fallback avatar
 
-Use `ProfileMenu` for an account menu in the header. When the `avatar` slot is empty, a default [UserAvatar](/components/UserAvatar) renders. The menu closes on outside click and <DocKbd label="Escape" />.
+When the `avatar` slot is empty, a default [UserAvatar](/components/UserAvatar) renders. The menu closes on outside click and <DocKbd label="Escape" />.
 
 <FileSource src="/framed/UIShell/ProfileMenuDefaultAvatar" />
 
-### Profile menu
+### Composed menu
 
 Render the avatar with [UserAvatar](/components/UserAvatar) in the `avatar` slot, and compose the card from `ProfileMenuHeader`, `ProfileMenuList`, `ProfileMenuItem`, and `ProfileMenuDivider`.
 
 <FileSource src="/framed/UIShell/ProfileMenuSimple" />
 
-### Profile menu with details
+### With details
 
 Add `ProfileMenuDetail` for labelled values with a trailing action, and pass an image to the avatar.
 
 <FileSource src="/framed/UIShell/ProfileMenu" />
+
+### Events
+
+`ProfileMenu` dispatches `open` and `close` as the menu toggles. Set `preventCloseOnClickOutside` to keep the menu open when the user clicks elsewhere on the page, and `transition` (for example `{ duration: 200 }`) to animate the menu open and closed — by default it does not animate.
+
+```svelte
+<ProfileMenu
+  bind:isOpen
+  preventCloseOnClickOutside
+  on:open={() => console.log("opened")}
+  on:close={() => console.log("closed")}
+>
+  <ProfileMenuList>...</ProfileMenuList>
+</ProfileMenu>
+```
 
 ## Integrations
 

--- a/docs/src/pages/components/UnorderedList.svx
+++ b/docs/src/pages/components/UnorderedList.svx
@@ -33,9 +33,9 @@ Add links to list items by wrapping them in link components.
   </ListItem>
 </UnorderedList>
 
-## Nested
+## Nested lists
 
-Create nested lists by setting `nested` on child unordered list components.
+Create hierarchical lists by setting `nested` on a child unordered list component.
 
 <UnorderedList>
   <ListItem>

--- a/docs/src/pages/components/UserAvatar.svx
+++ b/docs/src/pages/components/UserAvatar.svx
@@ -10,7 +10,7 @@ description: User avatars display a photo, a custom icon, or initials derived fr
 
 ## Content
 
-The avatar renders the first available of an image, a custom icon, initials, or the default user icon. It is designed for the UI Shell [profile menu](/components/UIShell#profile-menu).
+The avatar renders the first available of custom slotted content, an image, a custom icon, initials, or the default user icon. It is designed for the UI Shell [profile menu](/components/UIShell#profile-menu).
 
 ### Fallback icon
 
@@ -35,6 +35,12 @@ Set `icon` to render a custom icon instead of the default user icon.
 
 <UserAvatar icon={UserAvatarFilledAlt} />
 
+### Custom content
+
+Use the default slot to render arbitrary content, such as a status badge, instead of the computed image, icon, or initials. Slotted content takes priority over `image`, `icon`, and `initials`.
+
+<UserAvatar backgroundColor="cyan">99+</UserAvatar>
+
 ## Image
 
 Set `image` to render a photo. Provide `imageDescription` for the alternative text. The image fills the circle (`object-fit: cover`) and takes priority over the icon and initials.
@@ -58,7 +64,7 @@ Pass HTML attributes to the image with `imageAttributes`. Use this for values su
   imageAttributes={{ loading: "lazy" }}
 />
 
-### Sizes
+## Sizes
 
 Set `size` to one of `"sm"`, `"md"` (default), `"lg"`, or `"xl"`. The size applies to any content; the image fills the frame at every size.
 
@@ -92,7 +98,11 @@ Set `backgroundColor` to `"auto"` to pick a color from `name` (or `initials`). T
 <UserAvatar backgroundColor="auto" name="Bertram Gilfoyle" />
 <UserAvatar backgroundColor="auto" name="Jared Dunn" />
 
-## Interactive
+## Clickable avatar
+
+Render the avatar as an interactive element instead of a static `span` — a `button` for a custom control, or an anchor for a link.
+
+### Interactive
 
 Set `interactive` to render a `button` instead of a `span` when the avatar is a clickable control, such as a custom profile menu trigger. The button receives a focus ring. `name` is used as the accessible name when `aria-label` is not set.
 
@@ -100,7 +110,7 @@ Do not set `interactive` when slotting the avatar into [ProfileMenu](/components
 
 <UserAvatar interactive name="Richard Hendricks" backgroundColor="purple" />
 
-## Link
+### Link
 
 Set `href` to render an anchor, for example a profile page link. `href` takes priority over `interactive`.
 
@@ -108,11 +118,26 @@ Set `href` to render an anchor, for example a profile page link. `href` takes pr
 
 ## Tooltip
 
-Set `tooltipText` to show the display name on hover or focus. Use `align` and `direction` to position the tooltip. The tooltip closes on <DocKbd label="Escape" />.
+Set `tooltipText` to show the display name on hover or focus. The tooltip closes on <DocKbd label="Escape" />.
 
 Setting `tooltipText` wraps the avatar in a focusable button. Do not combine it with `interactive` or `href`, and do not set it when slotting the avatar into the `ProfileMenu` trigger.
 
 <UserAvatar name="Richard Hendricks" tooltipText="Richard Hendricks" />
+
+### Position
+
+Set `direction` to `"top"` or `"bottom"` to position the tooltip relative to the avatar.
+
+<UserAvatar name="Richard Hendricks" tooltipText="Richard Hendricks" direction="top" />
+<UserAvatar name="Richard Hendricks" tooltipText="Richard Hendricks" direction="bottom" />
+
+### Alignment
+
+Set `align` to `"start"`, `"center"`, or `"end"` to align the tooltip relative to the avatar.
+
+<UserAvatar name="Richard Hendricks" tooltipText="Richard Hendricks" align="start" />
+<UserAvatar name="Richard Hendricks" tooltipText="Richard Hendricks" align="center" />
+<UserAvatar name="Richard Hendricks" tooltipText="Richard Hendricks" align="end" />
 
 ### Inline tooltip
 

--- a/docs/src/pages/components/UserAvatarGroup.svx
+++ b/docs/src/pages/components/UserAvatarGroup.svx
@@ -179,3 +179,25 @@ Photos, icons, and initials work the same as on a lone `UserAvatar`.
   <UserAvatar backgroundColor="auto" name="Bertram Gilfoyle" tooltipText="Bertram Gilfoyle" />
   <UserAvatar backgroundColor="auto" name="Jared Dunn" tooltipText="Jared Dunn" />
 </UserAvatarGroup>
+
+## Background colors
+
+Every example on this page sets `backgroundColor="auto"` on each `UserAvatar`, which hashes a stable color from `name` (or `initials`) — the same name always gets the same color. See [UserAvatar's background colors section](/components/UserAvatar#background-colors) for the full palette and the other `backgroundColor` values.
+
+### Exported `getAvatarBackgroundColor` utility
+
+Import `getAvatarBackgroundColor` to compute the same color outside a `UserAvatar`, for example to match a name's avatar color in a legend or a custom rendering.
+
+```html
+<script context="module">
+  import { getAvatarBackgroundColor } from "carbon-components-svelte/src/utils/avatarColor.js";
+
+  getAvatarBackgroundColor("Richard Hendricks"); // "teal"
+</script>
+```
+
+## Tooltips
+
+Set `tooltipText` on each avatar to show its name on hover or focus, the same as a standalone [UserAvatar](/components/UserAvatar#tooltip). Within a group, only one avatar's tooltip stays open at a time — hovering a new avatar closes the previous one immediately, whether it's a slotted avatar or the "+N" overflow chip.
+
+Moving the pointer directly from one avatar to a neighbor whose tooltip is already open skips the usual enter delay, so the tooltip swaps in immediately instead of waiting again. Hover across the avatars in the examples above to feel this.

--- a/docs/src/pages/framed/ComboBox/ComboBoxOpenBinding.svelte
+++ b/docs/src/pages/framed/ComboBox/ComboBoxOpenBinding.svelte
@@ -1,0 +1,18 @@
+<script>
+  import { Button, ComboBox } from "carbon-components-svelte";
+
+  let open = false;
+</script>
+
+<ComboBox
+  bind:open
+  labelText="Contact"
+  placeholder="Select contact method"
+  items={[
+    { id: "0", text: "Slack" },
+    { id: "1", text: "Email" },
+    { id: "2", text: "Fax" },
+  ]}
+/>
+<br>
+<Button on:click={() => (open = !open)}>Toggle menu</Button>

--- a/docs/src/pages/framed/ComboButton/ComboButtonReactive.svelte
+++ b/docs/src/pages/framed/ComboButton/ComboButtonReactive.svelte
@@ -1,0 +1,20 @@
+<script>
+  import {
+    Button,
+    ComboButton,
+    MenuItem,
+    Stack,
+  } from "carbon-components-svelte";
+
+  let open = false;
+</script>
+
+<Stack gap={6} align="start">
+  <ComboButton labelText="Save" bind:open>
+    <MenuItem on:click={() => console.log("Save as")}>Save as</MenuItem>
+    <MenuItem on:click={() => console.log("Save a copy")}>Save a copy</MenuItem>
+  </ComboButton>
+  <Button kind="tertiary" size="small" on:click={() => (open = !open)}>
+    {open ? "Close menu" : "Open menu"}
+  </Button>
+</Stack>

--- a/docs/src/pages/framed/ContextMenu/ContextMenuEvents.svelte
+++ b/docs/src/pages/framed/ContextMenu/ContextMenuEvents.svelte
@@ -1,0 +1,25 @@
+<script>
+  import {
+    ContextMenu,
+    ContextMenuDivider,
+    ContextMenuOption,
+  } from "carbon-components-svelte";
+  import CopyFile from "carbon-icons-svelte/lib/CopyFile.svelte";
+  import Cut from "carbon-icons-svelte/lib/Cut.svelte";
+  import TrashCan from "carbon-icons-svelte/lib/TrashCan.svelte";
+</script>
+
+<ContextMenu
+  labelText="Menu actions"
+  on:open={(e) => console.log("open", e.detail)}
+  on:close={(e) => console.log("close", e.detail.trigger)}
+>
+  <ContextMenuOption labelText="Copy" shortcutText="⌘C" icon={CopyFile} />
+  <ContextMenuOption labelText="Cut" shortcutText="⌘X" icon={Cut} />
+  <ContextMenuDivider />
+  <ContextMenuOption kind="danger" labelText="Delete" icon={TrashCan} />
+</ContextMenu>
+
+<div data-centered>
+  <p>Right click anywhere on this page, then check the console.</p>
+</div>

--- a/docs/src/pages/framed/ContextMenu/ContextMenuProgrammatic.svelte
+++ b/docs/src/pages/framed/ContextMenu/ContextMenuProgrammatic.svelte
@@ -1,0 +1,39 @@
+<script>
+  import {
+    Button,
+    ContextMenu,
+    ContextMenuDivider,
+    ContextMenuOption,
+  } from "carbon-components-svelte";
+  import CopyFile from "carbon-icons-svelte/lib/CopyFile.svelte";
+  import Cut from "carbon-icons-svelte/lib/Cut.svelte";
+  import OverflowMenuVertical from "carbon-icons-svelte/lib/OverflowMenuVertical.svelte";
+  import TrashCan from "carbon-icons-svelte/lib/TrashCan.svelte";
+
+  let trigger;
+  let open = false;
+  let x = 0;
+  let y = 0;
+
+  function handleClick() {
+    const { left, bottom } = trigger.getBoundingClientRect();
+    x = left;
+    y = bottom;
+    open = true;
+  }
+</script>
+
+<Button
+  kind="ghost"
+  icon={OverflowMenuVertical}
+  iconDescription="Open row actions"
+  bind:ref={trigger}
+  on:click={handleClick}
+/>
+
+<ContextMenu bind:open bind:x bind:y labelText="Row actions">
+  <ContextMenuOption labelText="Copy" icon={CopyFile} />
+  <ContextMenuOption labelText="Cut" icon={Cut} />
+  <ContextMenuDivider />
+  <ContextMenuOption kind="danger" labelText="Delete" icon={TrashCan} />
+</ContextMenu>

--- a/docs/src/pages/framed/CopyInput/CopyInputOverride.svelte
+++ b/docs/src/pages/framed/CopyInput/CopyInputOverride.svelte
@@ -1,0 +1,10 @@
+<script>
+  import { CopyInput } from "carbon-components-svelte";
+  import copy from "clipboard-copy";
+</script>
+
+<CopyInput
+  labelText="API endpoint"
+  value="https://api.example.com/v1"
+  copy={(text) => copy(text)}
+/>

--- a/docs/src/pages/framed/FileUploader/FileUploaderDropContainerProgrammaticInputAccess.svelte
+++ b/docs/src/pages/framed/FileUploader/FileUploaderDropContainerProgrammaticInputAccess.svelte
@@ -1,0 +1,20 @@
+<script>
+  import {
+    Button,
+    FileUploaderDropContainer,
+    Stack,
+  } from "carbon-components-svelte";
+
+  let inputRef = null;
+</script>
+
+<Stack gap={6}>
+  <Button kind="secondary" on:click={() => inputRef?.click()}>
+    Open file picker
+  </Button>
+  <FileUploaderDropContainer
+    bind:ref={inputRef}
+    multiple
+    labelText="Drag and drop files here or click to upload"
+  />
+</Stack>

--- a/docs/src/pages/framed/Grid/NoGutterColumns.svelte
+++ b/docs/src/pages/framed/Grid/NoGutterColumns.svelte
@@ -1,0 +1,32 @@
+<script>
+  import { Column, Grid, Row, Stack } from "carbon-components-svelte";
+</script>
+
+<Stack gap={5}>
+  <div style="padding: var(--cds-spacing-05)">
+    Adding noGutter to Grid removes the gutter from every column:
+  </div>
+
+  <Grid noGutter>
+    <Row>
+      <Column>Column</Column>
+      <Column>Column</Column>
+      <Column>Column</Column>
+      <Column>Column</Column>
+    </Row>
+  </Grid>
+
+  <div style="padding: var(--cds-spacing-05)">
+    Adding noGutterLeft or noGutterRight to individual columns removes only that
+    side's gutter—useful for flushing a column against a page edge or divider:
+  </div>
+
+  <Grid>
+    <Row>
+      <Column noGutterLeft>No left gutter</Column>
+      <Column>Column</Column>
+      <Column>Column</Column>
+      <Column noGutterRight>No right gutter</Column>
+    </Row>
+  </Grid>
+</Stack>

--- a/docs/src/pages/framed/InlineNotification/InlineNotificationTimeout.svelte
+++ b/docs/src/pages/framed/InlineNotification/InlineNotificationTimeout.svelte
@@ -1,0 +1,32 @@
+<script>
+  import { Button, InlineNotification } from "carbon-components-svelte";
+  import { fade } from "svelte/transition";
+
+  let timeout = undefined;
+  $: showNotification = timeout !== undefined;
+</script>
+
+<Button
+  disabled={showNotification}
+  on:click={() => {
+    timeout = 3_000; // 3 seconds
+  }}
+>
+  Show notification
+</Button>
+
+{#if showNotification}
+  <div transition:fade>
+    <InlineNotification
+      {timeout}
+      pauseOnHover
+      kind="success"
+      title="Success:"
+      subtitle="This notification will autoclose in {timeout.toLocaleString()} ms. Hover to pause the countdown."
+      on:close={(e) => {
+        timeout = undefined;
+        console.log(e.detail.timeout); // true if closed via timeout
+      }}
+    />
+  </div>
+{/if}

--- a/docs/src/pages/framed/Menu/MenuEvents.svelte
+++ b/docs/src/pages/framed/Menu/MenuEvents.svelte
@@ -1,0 +1,20 @@
+<script>
+  import { Button, Menu, MenuItem } from "carbon-components-svelte";
+
+  let anchor;
+  let open = false;
+</script>
+
+<Button bind:ref={anchor} on:click={() => (open = !open)}>Actions</Button>
+
+<Menu
+  {anchor}
+  bind:open
+  labelText="Actions menu"
+  on:open={(e) => console.log("open", e.detail)}
+  on:close={(e) => console.log("close", e.detail.trigger)}
+>
+  <MenuItem on:click={() => console.log("Cut")}>Cut</MenuItem>
+  <MenuItem on:click={() => console.log("Copy")}>Copy</MenuItem>
+  <MenuItem on:click={() => console.log("Paste")}>Paste</MenuItem>
+</Menu>

--- a/docs/src/pages/framed/Menu/MenuItemRadioGroup.svelte
+++ b/docs/src/pages/framed/Menu/MenuItemRadioGroup.svelte
@@ -1,0 +1,30 @@
+<script>
+  import {
+    Button,
+    Menu,
+    MenuDivider,
+    MenuItem,
+    MenuItemRadioGroup,
+    Stack,
+  } from "carbon-components-svelte";
+
+  let anchor;
+  let open = false;
+  let selectedId = "comfortable";
+</script>
+
+<Stack gap={5}>
+  <Button bind:ref={anchor} on:click={() => (open = !open)}>View</Button>
+
+  <Menu {anchor} bind:open labelText="View menu">
+    <MenuItem on:click={() => console.log("Reset")}>Reset</MenuItem>
+    <MenuDivider />
+    <MenuItemRadioGroup labelText="Density" bind:selectedId>
+      <MenuItem id="compact" labelText="Compact" />
+      <MenuItem id="comfortable" labelText="Comfortable" />
+      <MenuItem id="spacious" labelText="Spacious" />
+    </MenuItemRadioGroup>
+  </Menu>
+
+  <p>Density: {selectedId}</p>
+</Stack>

--- a/docs/src/pages/framed/Menu/MenuItemSelectable.svelte
+++ b/docs/src/pages/framed/Menu/MenuItemSelectable.svelte
@@ -1,0 +1,29 @@
+<script>
+  import {
+    Button,
+    Menu,
+    MenuItem,
+    MenuItemGroup,
+    Stack,
+  } from "carbon-components-svelte";
+
+  let anchor;
+  let open = false;
+  let selectedIds = ["name"];
+
+  $: visibleColumns = selectedIds.join(", ") || "None";
+</script>
+
+<Stack gap={5}>
+  <Button bind:ref={anchor} on:click={() => (open = !open)}>View</Button>
+
+  <Menu {anchor} bind:open labelText="View menu">
+    <MenuItemGroup labelText="Columns" bind:selectedIds>
+      <MenuItem id="name" labelText="Name" />
+      <MenuItem id="size" labelText="Size" />
+      <MenuItem id="modified" labelText="Last modified" />
+    </MenuItemGroup>
+  </Menu>
+
+  <p>Visible columns: {visibleColumns}</p>
+</Stack>

--- a/docs/src/pages/framed/Menu/MenuSizeExtraSmall.svelte
+++ b/docs/src/pages/framed/Menu/MenuSizeExtraSmall.svelte
@@ -1,0 +1,14 @@
+<script>
+  import { Button, Menu, MenuItem } from "carbon-components-svelte";
+
+  let anchor;
+  let open = false;
+</script>
+
+<Button bind:ref={anchor} on:click={() => (open = !open)}>Actions</Button>
+
+<Menu {anchor} size="xs" bind:open labelText="Actions menu">
+  <MenuItem on:click={() => console.log("Cut")}>Cut</MenuItem>
+  <MenuItem on:click={() => console.log("Copy")}>Copy</MenuItem>
+  <MenuItem on:click={() => console.log("Paste")}>Paste</MenuItem>
+</Menu>

--- a/docs/src/pages/framed/MenuButton/MenuButtonReactive.svelte
+++ b/docs/src/pages/framed/MenuButton/MenuButtonReactive.svelte
@@ -1,0 +1,21 @@
+<script>
+  import {
+    Button,
+    MenuButton,
+    MenuItem,
+    Stack,
+  } from "carbon-components-svelte";
+
+  let open = false;
+</script>
+
+<Stack gap={6} align="start">
+  <MenuButton labelText="Actions" bind:open>
+    <MenuItem on:click={() => console.log("Cut")}>Cut</MenuItem>
+    <MenuItem on:click={() => console.log("Copy")}>Copy</MenuItem>
+    <MenuItem on:click={() => console.log("Paste")}>Paste</MenuItem>
+  </MenuButton>
+  <Button kind="tertiary" size="small" on:click={() => (open = !open)}>
+    {open ? "Close menu" : "Open menu"}
+  </Button>
+</Stack>

--- a/docs/src/pages/framed/Modal/ComposedModalButtonWithIcon.svelte
+++ b/docs/src/pages/framed/Modal/ComposedModalButtonWithIcon.svelte
@@ -1,0 +1,27 @@
+<script>
+  import {
+    Button,
+    ComposedModal,
+    ModalBody,
+    ModalFooter,
+    ModalHeader,
+  } from "carbon-components-svelte";
+  import Send from "carbon-icons-svelte/lib/Send.svelte";
+
+  let open = false;
+</script>
+
+<Button on:click={() => (open = true)}>Invite someone</Button>
+
+<ComposedModal bind:open on:submit={() => (open = false)}>
+  <ModalHeader title="Invite someone" />
+  <ModalBody>
+    <p>Do you really want to invite someone?</p>
+  </ModalBody>
+  <ModalFooter
+    primaryButtonText="Send invitation"
+    primaryButtonIcon={Send}
+    secondaryButtonText="Cancel"
+    on:click:button--secondary={() => (open = false)}
+  />
+</ComposedModal>

--- a/docs/src/pages/framed/Modal/ComposedModalCustomFocus.svelte
+++ b/docs/src/pages/framed/Modal/ComposedModalCustomFocus.svelte
@@ -1,0 +1,41 @@
+<script>
+  import {
+    Button,
+    ComposedModal,
+    ModalBody,
+    ModalFooter,
+    ModalHeader,
+    Stack,
+    TextInput,
+  } from "carbon-components-svelte";
+
+  let open = false;
+</script>
+
+<Button on:click={() => (open = true)}>Create database</Button>
+
+<ComposedModal
+  bind:open
+  selectorPrimaryFocus="#advanced-options"
+  on:submit={() => (open = false)}
+>
+  <ModalHeader title="Create database" />
+  <ModalBody>
+    <Stack gap={3}>
+      <p>Create a new Cloudant database in the US South region.</p>
+      <TextInput
+        id="db-name"
+        labelText="Database name"
+        placeholder="Enter database name..."
+      />
+      <Button id="advanced-options" kind="ghost" size="small">
+        Advanced options
+      </Button>
+    </Stack>
+  </ModalBody>
+  <ModalFooter
+    primaryButtonText="Confirm"
+    secondaryButtonText="Cancel"
+    on:click:button--secondary={() => (open = false)}
+  />
+</ComposedModal>

--- a/docs/src/pages/framed/Modal/ComposedModalCustomHeading.svelte
+++ b/docs/src/pages/framed/Modal/ComposedModalCustomHeading.svelte
@@ -1,0 +1,28 @@
+<script>
+  import {
+    Button,
+    ComposedModal,
+    ModalBody,
+    ModalFooter,
+    ModalHeader,
+    Tag,
+  } from "carbon-components-svelte";
+
+  let open = false;
+</script>
+
+<Button on:click={() => (open = true)}>Create database</Button>
+
+<ComposedModal bind:open on:submit={() => (open = false)}>
+  <ModalHeader title="Create database">
+    <Tag type="green" size="sm">Beta</Tag>
+  </ModalHeader>
+  <ModalBody>
+    <p>Create a new Cloudant database in the US South region.</p>
+  </ModalBody>
+  <ModalFooter
+    primaryButtonText="Confirm"
+    secondaryButtonText="Cancel"
+    on:click:button--secondary={() => (open = false)}
+  />
+</ComposedModal>

--- a/docs/src/pages/framed/Modal/ComposedModalPreventOutsideClick.svelte
+++ b/docs/src/pages/framed/Modal/ComposedModalPreventOutsideClick.svelte
@@ -1,0 +1,29 @@
+<script>
+  import {
+    Button,
+    ComposedModal,
+    ModalBody,
+    ModalFooter,
+    ModalHeader,
+  } from "carbon-components-svelte";
+
+  let open = false;
+</script>
+
+<Button on:click={() => (open = true)}>Create database</Button>
+
+<ComposedModal
+  preventCloseOnClickOutside
+  bind:open
+  on:submit={() => (open = false)}
+>
+  <ModalHeader title="Create database" />
+  <ModalBody>
+    <p>Create a new Cloudant database in the US South region.</p>
+  </ModalBody>
+  <ModalFooter
+    primaryButtonText="Confirm"
+    secondaryButtonText="Cancel"
+    on:click:button--secondary={() => (open = false)}
+  />
+</ComposedModal>

--- a/docs/src/pages/framed/Modal/ComposedModalScrollingContent.svelte
+++ b/docs/src/pages/framed/Modal/ComposedModalScrollingContent.svelte
@@ -1,0 +1,29 @@
+<script>
+  import {
+    Button,
+    ComposedModal,
+    ModalBody,
+    ModalHeader,
+  } from "carbon-components-svelte";
+
+  let open = false;
+</script>
+
+<Button on:click={() => (open = true)}>About Cloudant</Button>
+
+<ComposedModal bind:open>
+  <ModalHeader title="About Cloudant" />
+  <ModalBody hasScrollingContent>
+    <p>
+      Cloudant is a fully managed, distributed database optimized for heavy
+      workloads and fast-growing web and mobile apps, IBM Cloudant is available
+      as an IBM Cloud® service with a 99.99% SLA.
+    </p>
+    <br>
+    <p>
+      The database elastically scales throughput and storage, and its API and
+      replication protocols are compatible with Apache CouchDB for hybrid or
+      multicloud architectures.
+    </p>
+  </ModalBody>
+</ComposedModal>

--- a/docs/src/pages/framed/Modal/ComposedModalSmall.svelte
+++ b/docs/src/pages/framed/Modal/ComposedModalSmall.svelte
@@ -1,0 +1,25 @@
+<script>
+  import {
+    Button,
+    ComposedModal,
+    ModalBody,
+    ModalFooter,
+    ModalHeader,
+  } from "carbon-components-svelte";
+
+  let open = false;
+</script>
+
+<Button on:click={() => (open = true)}>Create database</Button>
+
+<ComposedModal size="sm" bind:open on:submit={() => (open = false)}>
+  <ModalHeader title="Create database" />
+  <ModalBody>
+    <p>Create a new Cloudant database in the US South region.</p>
+  </ModalBody>
+  <ModalFooter
+    primaryButtonText="Confirm"
+    secondaryButtonText="Cancel"
+    on:click:button--secondary={() => (open = false)}
+  />
+</ComposedModal>

--- a/docs/src/pages/framed/Modal/ModalAlert.svelte
+++ b/docs/src/pages/framed/Modal/ModalAlert.svelte
@@ -1,0 +1,19 @@
+<script>
+  import { Button, Modal } from "carbon-components-svelte";
+
+  let open = false;
+</script>
+
+<Button kind="danger" on:click={() => (open = true)}>Delete all</Button>
+
+<Modal
+  alert
+  danger
+  bind:open
+  modalHeading="Delete all instances"
+  primaryButtonText="Delete"
+  secondaryButtonText="Cancel"
+  on:click:button--secondary={() => (open = false)}
+>
+  <p>This is a permanent action and cannot be undone.</p>
+</Modal>

--- a/docs/src/pages/framed/Modal/ModalCustomHeading.svelte
+++ b/docs/src/pages/framed/Modal/ModalCustomHeading.svelte
@@ -1,0 +1,20 @@
+<script>
+  import { Button, Modal, Tag } from "carbon-components-svelte";
+
+  let open = false;
+</script>
+
+<Button on:click={() => (open = true)}>Create database</Button>
+
+<Modal
+  bind:open
+  primaryButtonText="Confirm"
+  secondaryButtonText="Cancel"
+  on:click:button--secondary={() => (open = false)}
+>
+  <svelte:fragment slot="label">
+    Cloudant <Tag type="green" size="sm">Beta</Tag>
+  </svelte:fragment>
+  <svelte:fragment slot="heading">Create database</svelte:fragment>
+  <p>Create a new Cloudant database in the US South region.</p>
+</Modal>

--- a/docs/src/pages/framed/Modal/ModalNested.svelte
+++ b/docs/src/pages/framed/Modal/ModalNested.svelte
@@ -1,0 +1,40 @@
+<script>
+  import { Button, Modal, Portal } from "carbon-components-svelte";
+
+  let open = false;
+  let openConfirm = false;
+</script>
+
+<Button kind="danger-tertiary" on:click={() => (open = true)}>
+  Delete database
+</Button>
+
+<Modal
+  danger
+  bind:open
+  modalHeading="Delete database"
+  primaryButtonText="Delete"
+  secondaryButtonText="Cancel"
+  on:click:button--secondary={() => (open = false)}
+  on:submit={() => (openConfirm = true)}
+>
+  <p>This will permanently delete the database and all of its data.</p>
+
+  <Portal>
+    <Modal
+      danger
+      size="xs"
+      bind:open={openConfirm}
+      modalHeading="Are you absolutely sure?"
+      primaryButtonText="Delete forever"
+      secondaryButtonText="Cancel"
+      on:click:button--secondary={() => (openConfirm = false)}
+      on:submit={() => {
+        openConfirm = false;
+        open = false;
+      }}
+    >
+      <p>This action cannot be undone.</p>
+    </Modal>
+  </Portal>
+</Modal>

--- a/docs/src/pages/framed/OverflowMenu/OverflowMenuReactive.svelte
+++ b/docs/src/pages/framed/OverflowMenu/OverflowMenuReactive.svelte
@@ -1,0 +1,25 @@
+<script>
+  import {
+    Button,
+    OverflowMenu,
+    OverflowMenuItem,
+    Stack,
+  } from "carbon-components-svelte";
+
+  let open = false;
+</script>
+
+<Stack gap={6} align="start">
+  <OverflowMenu bind:open>
+    <OverflowMenuItem text="Manage credentials" />
+    <OverflowMenuItem
+      href="https://cloud.ibm.com/docs/api-gateway/"
+      target="_blank"
+      text="API documentation"
+    />
+    <OverflowMenuItem danger text="Delete service" />
+  </OverflowMenu>
+  <Button kind="tertiary" size="small" on:click={() => (open = !open)}>
+    {open ? "Close menu" : "Open menu"}
+  </Button>
+</Stack>

--- a/docs/src/pages/framed/RecursiveList/RecursiveListLinkAttributes.svelte
+++ b/docs/src/pages/framed/RecursiveList/RecursiveListLinkAttributes.svelte
@@ -1,0 +1,18 @@
+<script>
+  import { RecursiveList } from "carbon-components-svelte";
+
+  const nodes = [
+    {
+      text: "Opens in a new tab",
+      href: "https://svelte.dev/",
+      target: "_blank",
+    },
+    {
+      text: "Custom rel",
+      href: "https://svelte.dev/",
+      rel: "nofollow",
+    },
+  ];
+</script>
+
+<RecursiveList {nodes} />

--- a/docs/src/pages/framed/SessionStorage/SessionStorageClear.svelte
+++ b/docs/src/pages/framed/SessionStorage/SessionStorageClear.svelte
@@ -1,5 +1,10 @@
 <script>
-  import { Button, SessionStorage, Toggle } from "carbon-components-svelte";
+  import {
+    Button,
+    SessionStorage,
+    Stack,
+    Toggle,
+  } from "carbon-components-svelte";
 
   let storage;
   let toggled = false;
@@ -7,11 +12,24 @@
   $: document.documentElement.setAttribute("theme", toggled ? "g100" : "white");
 </script>
 
-<SessionStorage bind:this={storage} bind:value={toggled} />
+<Stack gap={6}>
+  <SessionStorage bind:this={storage} bind:value={toggled} />
 
-<Toggle size="sm" labelText="Dark mode" bind:toggled />
+  <Toggle size="sm" labelText="Dark mode" bind:toggled />
 
-<br>
-<br>
+  <div>
+    Toggle the switch, then refresh the page to confirm the value persists.
+    <code>clearItem</code>
+    removes just this key; <code>clearAll</code> removes every key in session
+    storage. Either way, the toggle itself is left untouched until you refresh.
+  </div>
 
-<Button size="small" on:click={storage.clearAll}>Clear storage</Button>
+  <Stack gap={3} orientation="horizontal">
+    <Button size="small" on:click={() => storage.clearItem()}>
+      Clear item
+    </Button>
+    <Button size="small" kind="danger" on:click={() => storage.clearAll()}>
+      Clear all
+    </Button>
+  </Stack>
+</Stack>

--- a/docs/src/pages/framed/TagSet/TagSetContainingElement.svelte
+++ b/docs/src/pages/framed/TagSet/TagSetContainingElement.svelte
@@ -1,0 +1,19 @@
+<script>
+  import { Tag, TagSet } from "carbon-components-svelte";
+
+  // An empty reference element whose width TagSet should fit within,
+  // instead of its own (wider) wrapper — for example, to match the width
+  // of an unrelated column elsewhere on the page.
+  let target;
+</script>
+
+<div style="max-width: 20rem;">
+  <div bind:this={target} style="max-width: 8rem;"></div>
+  <TagSet containingElement={target}>
+    <Tag type="red">Angular</Tag>
+    <Tag type="blue">React</Tag>
+    <Tag type="purple">Svelte</Tag>
+    <Tag type="green">Vue</Tag>
+    <Tag type="magenta">Ember</Tag>
+  </TagSet>
+</div>

--- a/docs/src/pages/framed/Tooltip/TooltipEvents.svelte
+++ b/docs/src/pages/framed/Tooltip/TooltipEvents.svelte
@@ -1,0 +1,16 @@
+<script>
+  import { Stack, Tooltip } from "carbon-components-svelte";
+
+  let events = [];
+</script>
+
+<Stack gap={4}>
+  <Tooltip
+    triggerText="Resource list"
+    on:open={() => (events = [...events, "open"])}
+    on:close={() => (events = [...events, "close"])}
+  >
+    <p>Resources are provisioned based on your account's organization.</p>
+  </Tooltip>
+  <p>Dispatched events: {events.join(", ")}</p>
+</Stack>

--- a/docs/src/pages/framed/TooltipIcon/TooltipIconEvents.svelte
+++ b/docs/src/pages/framed/TooltipIcon/TooltipIconEvents.svelte
@@ -1,0 +1,16 @@
+<script>
+  import { Stack, TooltipIcon } from "carbon-components-svelte";
+  import Carbon from "carbon-icons-svelte/lib/Carbon.svelte";
+
+  let events = [];
+</script>
+
+<Stack gap={4}>
+  <TooltipIcon
+    tooltipText="Carbon is an open source design system by IBM."
+    icon={Carbon}
+    on:open={() => (events = [...events, "open"])}
+    on:close={() => (events = [...events, "close"])}
+  />
+  <p>Dispatched events: {events.join(", ")}</p>
+</Stack>

--- a/docs/src/pages/framed/TreeView/TreeViewPerformance.svelte
+++ b/docs/src/pages/framed/TreeView/TreeViewPerformance.svelte
@@ -175,8 +175,8 @@
     <Stack gap={2}>
       {#if performanceInfo.generate > 0}
         <div>
-          Tree Generation: {performanceInfo.generate.toFixed(4)}ms
-          ({nodeCount.toLocaleString()} nodes)
+          Tree Generation: {performanceInfo.generate.toFixed(4)}ms ({nodeCount.toLocaleString()}
+          nodes)
         </div>
       {/if}
       {#if performanceInfo.expandAll > 0}

--- a/docs/src/pages/framed/TreeView/TreeViewPerformance.svelte
+++ b/docs/src/pages/framed/TreeView/TreeViewPerformance.svelte
@@ -7,10 +7,15 @@
     Switch,
     TreeView,
   } from "carbon-components-svelte";
-  import { tick } from "svelte";
+  import { onMount, tick } from "svelte";
 
   let treeview = null;
-  let performanceInfo = { expandAll: 0, collapseAll: 0, showNode: 0 };
+  let performanceInfo = {
+    generate: 0,
+    expandAll: 0,
+    collapseAll: 0,
+    showNode: 0,
+  };
 
   function generateLargeTree() {
     const nodes = [];
@@ -43,7 +48,7 @@
       });
     }
 
-    return nodes;
+    return { nodes, count: idCounter };
   }
 
   function generateDeepTree() {
@@ -65,42 +70,60 @@
     }
 
     const rootNode = createNestedNode(0, 100);
-    return { nodes: [rootNode], lastId };
+    return { nodes: [rootNode], count: idCounter, lastId };
   }
 
-  let nodes = generateLargeTree();
+  let genStart = performance.now();
+  let initialTree = generateLargeTree();
+  let nodes = initialTree.nodes;
+  let nodeCount = initialTree.count;
   let treeType = "large";
   let lastDeepNodeId = null;
   let selectedIndex = 0;
+
+  $: hasTiming =
+    performanceInfo.generate > 0 ||
+    performanceInfo.expandAll > 0 ||
+    performanceInfo.collapseAll > 0 ||
+    performanceInfo.showNode > 0;
+
+  onMount(async () => {
+    await tick();
+    const end = performance.now();
+    performanceInfo.generate = end - genStart;
+    performanceInfo = performanceInfo;
+  });
 
   async function handleTreeSwitch(event) {
     const index = event.detail;
     selectedIndex = index;
 
-    performanceInfo = { expandAll: 0, collapseAll: 0, showNode: 0 };
+    performanceInfo = {
+      generate: 0,
+      expandAll: 0,
+      collapseAll: 0,
+      showNode: 0,
+    };
 
     const start = performance.now();
     if (index === 0) {
-      nodes = generateLargeTree();
+      const result = generateLargeTree();
+      nodes = result.nodes;
+      nodeCount = result.count;
       treeType = "large";
       lastDeepNodeId = null;
     } else {
-      const { nodes: deepNodes, lastId } = generateDeepTree();
-      nodes = deepNodes;
-      lastDeepNodeId = lastId;
+      const result = generateDeepTree();
+      nodes = result.nodes;
+      nodeCount = result.count;
+      lastDeepNodeId = result.lastId;
       treeType = "deep";
     }
 
     await tick();
-    setTimeout(() => {
-      const end = performance.now();
-      console.log(
-        (index === 0 ? "Large" : "Deep") +
-          " tree generation: " +
-          (end - start).toFixed(2) +
-          "ms",
-      );
-    }, 0);
+    const end = performance.now();
+    performanceInfo.generate = end - start;
+    performanceInfo = performanceInfo;
   }
 
   function handleExpandAll() {
@@ -148,11 +171,23 @@
     <Button on:click={handleShowNode}>Show Deep Node</Button>
   </ButtonSet>
 
-  {#if performanceInfo.expandAll > 0 || performanceInfo.collapseAll > 0 || performanceInfo.showNode > 0}
+  {#if hasTiming}
     <Stack gap={2}>
-      <div>Expand All: {performanceInfo.expandAll.toFixed(2)}ms</div>
-      <div>Collapse All: {performanceInfo.collapseAll.toFixed(2)}ms</div>
-      <div>Show Node: {performanceInfo.showNode.toFixed(2)}ms</div>
+      {#if performanceInfo.generate > 0}
+        <div>
+          Tree Generation: {performanceInfo.generate.toFixed(4)}ms
+          ({nodeCount.toLocaleString()} nodes)
+        </div>
+      {/if}
+      {#if performanceInfo.expandAll > 0}
+        <div>Expand All: {performanceInfo.expandAll.toFixed(4)}ms</div>
+      {/if}
+      {#if performanceInfo.collapseAll > 0}
+        <div>Collapse All: {performanceInfo.collapseAll.toFixed(4)}ms</div>
+      {/if}
+      {#if performanceInfo.showNode > 0}
+        <div>Show Node: {performanceInfo.showNode.toFixed(4)}ms</div>
+      {/if}
     </Stack>
   {/if}
   <div>

--- a/docs/src/pages/framed/UIShell/HeaderActionLink.svelte
+++ b/docs/src/pages/framed/UIShell/HeaderActionLink.svelte
@@ -1,0 +1,38 @@
+<script>
+  import {
+    Column,
+    Content,
+    Grid,
+    Header,
+    HeaderActionLink,
+    HeaderGlobalAction,
+    HeaderUtilities,
+    Row,
+    SkipToContent,
+  } from "carbon-components-svelte";
+  import LogoGithub from "carbon-icons-svelte/lib/LogoGithub.svelte";
+  import Notification from "carbon-icons-svelte/lib/Notification.svelte";
+
+  let isSideNavOpen = false;
+</script>
+
+<Header companyName="IBM" platformName="Cloud" bind:isSideNavOpen>
+  <svelte:fragment slot="skipToContent"> <SkipToContent /> </svelte:fragment>
+  <HeaderUtilities>
+    <HeaderActionLink
+      href="https://github.com/carbon-design-system/carbon-components-svelte"
+      target="_blank"
+      icon={LogoGithub}
+      aria-label="GitHub repository"
+    />
+    <HeaderGlobalAction iconDescription="Notifications" icon={Notification} />
+  </HeaderUtilities>
+</Header>
+
+<Content>
+  <Grid>
+    <Row>
+      <Column> <h1>Dashboard</h1> </Column>
+    </Row>
+  </Grid>
+</Content>

--- a/docs/src/toc-scroll-spy.ts
+++ b/docs/src/toc-scroll-spy.ts
@@ -26,6 +26,27 @@ export function setupTocScrollSpy(page: ParentNode): () => void {
 
   let currentActiveId = "";
 
+  // Mirrors the side nav's `scrollIntoView({ block: "center" })` on the
+  // current page item: keep the active TOC entry visible in its own scroll
+  // container (`.table__scroll`) as the page scrolls through many headings,
+  // without disturbing an entry that's already in view.
+  function scrollTocLinkIntoViewIfNeeded(link: HTMLAnchorElement) {
+    // Skip the hidden mobile/desktop clone; only the rendered copy has a box.
+    if (link.offsetParent === null) return;
+
+    const container = link.closest<HTMLElement>(".table__scroll");
+    if (!container) return;
+
+    const containerRect = container.getBoundingClientRect();
+    const linkRect = link.getBoundingClientRect();
+
+    const inView =
+      linkRect.top >= containerRect.top &&
+      linkRect.bottom <= containerRect.bottom;
+
+    if (!inView) link.scrollIntoView({ block: "center" });
+  }
+
   function setActive(activeId: string) {
     if (activeId === currentActiveId) return;
     currentActiveId = activeId;
@@ -35,8 +56,12 @@ export function setupTocScrollSpy(page: ParentNode): () => void {
 
       for (const link of links) {
         link.classList.toggle("is-active", active);
-        if (active) link.setAttribute("aria-current", "location");
-        else link.removeAttribute("aria-current");
+        if (active) {
+          link.setAttribute("aria-current", "location");
+          scrollTocLinkIntoViewIfNeeded(link);
+        } else {
+          link.removeAttribute("aria-current");
+        }
       }
     }
   }


### PR DESCRIPTION
Audits every component doc page against its component source,
filling gaps in undocumented props, events, and slots, and
reorganizing flat sections into grouped ones where the structure
earns it.