### PR TITLE
fix(modal): don't dismiss on a native select's orphaned mouseup

### DIFF
--- a/e2e/composed-modal.test.ts
+++ b/e2e/composed-modal.test.ts
@@ -100,11 +100,33 @@ test.describe("ComposedModal", () => {
     await expect(modal).not.toHaveClass(/is-visible/);
   });
 
+  test("does not close when clicking a native select inside the modal (#3710)", async ({
+    page,
+  }) => {
+    await page.getByTestId("open-modal").click();
+    const modal = page.locator(".bx--modal");
+    await expect(modal).toHaveClass(/is-visible/);
+
+    const select = page.getByTestId("modal-select");
+    await select.click();
+    // Chromium fires a second, unpaired `mouseup` on a native <select> when its
+    // (browser-native, not in the DOM) options popup closes — confirmed via
+    // direct event instrumentation: mousedown -> mouseup -> click -> mouseup.
+    // That extra mouseup is racy to trigger organically through a plain click
+    // in headless mode, so dispatch it directly for a deterministic test.
+    await select.evaluate((el) => {
+      el.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+    });
+
+    await expect(modal).toHaveClass(/is-visible/);
+  });
+
   test("traps focus with Tab", async ({ page }) => {
     await page.getByTestId("open-modal").click();
     await expect(page.locator(".bx--modal")).toHaveClass(/is-visible/);
 
     const primaryFocus = page.getByTestId("modal-primary-focus");
+    const select = page.getByTestId("modal-select");
     const footerClose = page.getByTestId("close-modal");
     const headerClose = page.locator(".bx--modal-close");
 
@@ -117,6 +139,9 @@ test.describe("ComposedModal", () => {
         { timeout: 10_000 },
       )
       .toBeTruthy();
+
+    await page.keyboard.press("Tab");
+    await expect(select).toBeFocused({ timeout: 10_000 });
 
     await page.keyboard.press("Tab");
     await expect(footerClose).toBeFocused({ timeout: 10_000 });

--- a/e2e/fixtures/ComposedModalFixture.svelte
+++ b/e2e/fixtures/ComposedModalFixture.svelte
@@ -5,6 +5,8 @@
     ModalBody,
     ModalFooter,
     ModalHeader,
+    Select,
+    SelectItem,
   } from "carbon-components-svelte";
 
   let open = false;
@@ -30,6 +32,10 @@
       data-testid="modal-primary-focus"
       aria-label="Primary focus input"
     >
+    <Select data-testid="modal-select" labelText="Contact method">
+      <SelectItem value="slack" text="Slack" />
+      <SelectItem value="email" text="Email" />
+    </Select>
   </ModalBody>
   <ModalFooter>
     <!-- The footer "Close" closes via app code (sets `open = false`), not a

--- a/e2e/fixtures/ModalFixture.svelte
+++ b/e2e/fixtures/ModalFixture.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { Modal } from "carbon-components-svelte";
+  import { Modal, Select, SelectItem } from "carbon-components-svelte";
 
   let open = false;
   let events = [];
@@ -24,6 +24,10 @@
   on:close={(e) => (closeEvents = [...closeEvents, e.detail?.trigger ?? "null"])}
 >
   <p data-testid="modal-body">Modal content</p>
+  <Select data-testid="modal-select" labelText="Contact method">
+    <SelectItem value="slack" text="Slack" />
+    <SelectItem value="email" text="Email" />
+  </Select>
   <!-- Custom in-modal control that closes via app code (sets `open = false`),
        not the built-in close affordance — exercises the "programmatic" trigger. -->
   <button

--- a/e2e/modal.test.ts
+++ b/e2e/modal.test.ts
@@ -68,6 +68,27 @@ test.describe("Modal", () => {
     await expect(modal).toHaveClass(/is-visible/);
   });
 
+  test("does not close when clicking a native select inside the modal (#3710)", async ({
+    page,
+  }) => {
+    await page.getByTestId("open-modal").click();
+    const modal = page.locator(".bx--modal");
+    await expect(modal).toHaveClass(/is-visible/);
+
+    const select = page.getByTestId("modal-select");
+    await select.click();
+    // Chromium fires a second, unpaired `mouseup` on a native <select> when its
+    // (browser-native, not in the DOM) options popup closes — confirmed via
+    // direct event instrumentation: mousedown -> mouseup -> click -> mouseup.
+    // That extra mouseup is racy to trigger organically through a plain click
+    // in headless mode, so dispatch it directly for a deterministic test.
+    await select.evaluate((el) => {
+      el.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+    });
+
+    await expect(modal).toHaveClass(/is-visible/);
+  });
+
   test("fires the secondary event when pressing Enter on the focused secondary button", async ({
     page,
   }) => {

--- a/src/ComposedModal/ComposedModal.svelte
+++ b/src/ComposedModal/ComposedModal.svelte
@@ -198,6 +198,9 @@
     }
   }}
   on:click
+  on:mousedown={(event) => {
+    if (event.target === event.currentTarget) outsideDismiss.pressOutside();
+  }}
   on:mouseup={outsideDismiss.release}
   on:mouseover
   on:mouseenter

--- a/src/Modal/Modal.svelte
+++ b/src/Modal/Modal.svelte
@@ -283,6 +283,9 @@
     }
   }}
   on:click
+  on:mousedown={(event) => {
+    if (event.target === event.currentTarget) outsideDismiss.pressOutside();
+  }}
   on:mouseup={outsideDismiss.release}
   on:mouseover
   on:mouseenter

--- a/src/utils/outsideDismiss.d.ts
+++ b/src/utils/outsideDismiss.d.ts
@@ -1,5 +1,6 @@
 export type OutsideDismiss = {
   pressInside: () => void;
+  pressOutside: () => void;
   release: () => void;
 };
 

--- a/src/utils/outsideDismiss.js
+++ b/src/utils/outsideDismiss.js
@@ -8,8 +8,14 @@
  * track whether the pointer was pressed inside the dialog on `mousedown` and only
  * dismiss on `mouseup` when it was not.
  *
+ * A native `<select>` inside the dialog fires an unpaired `mouseup` on its host
+ * element when its (browser-native, not in the DOM) options popup is dismissed,
+ * with no corresponding `mousedown`. `pressedInside` is therefore only cleared by
+ * an explicit outside `mousedown` (`pressOutside`), not by every `release`, so
+ * that orphaned `mouseup` doesn't read as an outside click.
+ *
  * @param {() => void} onDismiss Called on a press-and-release that began outside the dialog.
- * @returns {{ pressInside: () => void, release: () => void }}
+ * @returns {{ pressInside: () => void, pressOutside: () => void, release: () => void }}
  */
 export function createOutsideDismiss(onDismiss) {
   let pressedInside = false;
@@ -19,10 +25,13 @@ export function createOutsideDismiss(onDismiss) {
     pressInside() {
       pressedInside = true;
     },
+    /** Wire to the backdrop's `on:mousedown`, guarded to `event.target === event.currentTarget`. */
+    pressOutside() {
+      pressedInside = false;
+    },
     /** Wire to the surface's `on:mouseup`; dismisses only if the press began outside. */
     release() {
       if (!pressedInside) onDismiss();
-      pressedInside = false;
     },
   };
 }

--- a/tests/utils/outsideDismiss.test.ts
+++ b/tests/utils/outsideDismiss.test.ts
@@ -20,16 +20,18 @@ describe("createOutsideDismiss", () => {
     expect(onDismiss).toHaveBeenCalledTimes(1);
   });
 
-  test("resets the flag after release", () => {
+  test("does not dismiss on an orphaned release with no matching mousedown", () => {
+    // A native <select> fires an unpaired `mouseup` on its host element when its
+    // (browser-native) options popup closes, with no preceding `mousedown`. That
+    // orphaned release must not read as an outside click.
     const onDismiss = vi.fn();
     const dismiss = createOutsideDismiss(onDismiss);
 
     dismiss.pressInside();
     dismiss.release();
-    expect(onDismiss).not.toHaveBeenCalled();
-
     dismiss.release();
-    expect(onDismiss).toHaveBeenCalledTimes(1);
+
+    expect(onDismiss).not.toHaveBeenCalled();
   });
 
   test("suppresses dismissal for each independent inside interaction", () => {
@@ -42,5 +44,18 @@ describe("createOutsideDismiss", () => {
     dismiss.release();
 
     expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  test("pressOutside clears a prior inside press so the next release dismisses", () => {
+    const onDismiss = vi.fn();
+    const dismiss = createOutsideDismiss(onDismiss);
+
+    dismiss.pressInside();
+    dismiss.release();
+    expect(onDismiss).not.toHaveBeenCalled();
+
+    dismiss.pressOutside();
+    dismiss.release();
+    expect(onDismiss).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
Closes #3710

Selecting an option from a native `<select>` inside a `Modal` or
`ComposedModal` could immediately close the dialog, since the popup's
closing `mouseup` has no matching `mousedown` and outsideDismiss read
it as an outside click.

