### PR TITLE
docs(ui-shell): drop unexported HamburgerMenu from components list

### DIFF
--- a/docs/src/pages/components/UIShell.svx
+++ b/docs/src/pages/components/UIShell.svx
@@ -25,7 +25,6 @@ components: ["Header",
 "SideNavDivider",
 "Content",
 "SkipToContent",
-"HamburgerMenu",
 "HeaderGlobalAction"]
 description: The UI shell provides components for building application shells and navigation — header, side navigation, and content areas.
 ---


### PR DESCRIPTION
HamburgerMenu isn't exported from src/index.js. The docs build
generates API data only for exported components, so it had
nothing for HamburgerMenu and threw:

    error: API data not found for component: HamburgerMenu

Dropped it from the components list in UIShell.svx.