### PR TITLE
docs: replace raw <kbd> with DocKbd in Toolbar.svx

### DIFF
--- a/docs/src/pages/components/Checkbox.svx
+++ b/docs/src/pages/components/Checkbox.svx
@@ -86,7 +86,7 @@ Set `warn` to `true` and provide `warnText` to show a warning message. `invalid`
 
 Set `decorative` to `true` to hide the checkbox from the accessibility tree using CSS, rather than just `tabindex`/`aria-hidden` (which axe-core's nested-interactive check doesn't treat as sufficient). Use this when the checkbox is nested inside another interactive, widget-role element that already owns the checked-state semantics, such as a custom listbox option.
 
-<div role="option" aria-checked="true">
+<div role="option" aria-selected="true" aria-checked="true">
   <Checkbox decorative checked labelText="Option A" hideLabel />
   Option A
 </div>

--- a/docs/src/pages/components/Toolbar.svx
+++ b/docs/src/pages/components/Toolbar.svx
@@ -100,7 +100,7 @@ Use `bind:this` to obtain a ToolbarSearch reference and call `clear()` to reset 
 
 ### Clear event
 
-Listen for `on:clear` to know when the user clears the field—by clicking the built-in clear icon or pressing <kbd>Escape</kbd> while focused. This is distinct from calling the exported `clear()` method yourself, which updates `value` and `expanded` directly without dispatching the event.
+Listen for `on:clear` to know when the user clears the field—by clicking the built-in clear icon or pressing <DocKbd label="Escape" /> while focused. This is distinct from calling the exported `clear()` method yourself, which updates `value` and `expanded` directly without dispatching the event.
 
 <Toolbar>
   <ToolbarContent>


### PR DESCRIPTION
The raw `kbd` tag in Toolbar.svx broke the docs build: mdsvex splits
standalone inline HTML into separate open/close nodes, and the opening
node isn't excluded from the Preview-wrapping step (which only skips `DocKbd`),
leaving it unclosed. Swapped in the DocKbd component already used everywhere
else in the docs for inline key references.