### PR TITLE
perf(css): prune selectors for classes the library never renders

### DIFF
--- a/css/_carbon-styles.scss
+++ b/css/_carbon-styles.scss
@@ -7,6 +7,13 @@
 //   - components/pagination/unstable_pagination: `bx--unstable-pagination`
 // Audit a partial's `bx--` class roots against `src/**/*.svelte` before
 // removing or re-adding an import here.
+//
+// Selector-level pruning has also been applied *within* several of the
+// imported partials below (and within the `css/_*.scss` override files),
+// removing individual rules/selectors for classes the library never renders
+// (v10.58 forward-compat `--lg` aliases, never-ported v10 features, and
+// markup this library structures differently). See `git log --grep
+// "prune selectors"` for the commit with the full class list.
 
 @import "carbon-components/scss/globals/scss/feature-flags";
 @import "carbon-components/scss/globals/scss/vars";

--- a/css/_number-input.scss
+++ b/css/_number-input.scss
@@ -58,10 +58,6 @@
     }
   }
 
-  .#{$prefix}--number--lg.#{$prefix}--number input[type='text'] {
-    padding-right: to-rem(144px);
-  }
-
   .#{$prefix}--number--sm.#{$prefix}--number input[type='text'] {
     padding-right: to-rem(112px);
   }
@@ -147,10 +143,6 @@
 
   .#{$prefix}--number--light input[type='text']:disabled {
     background-color: $field-02;
-  }
-
-  .#{$prefix}--number--lg input[type='text'] {
-    height: to-rem(48px);
   }
 
   .#{$prefix}--number--sm input[type='text'] {

--- a/css/_ui-shell.scss
+++ b/css/_ui-shell.scss
@@ -345,11 +345,6 @@
     background-color: $background-hover;
   }
 
-  .#{$prefix}--header-search-button--hidden {
-    opacity: 0;
-    display: none;
-  }
-
   .#{$prefix}--header-search-menu {
     position: absolute;
     z-index: 10000;
@@ -533,8 +528,6 @@
 
   .#{$prefix}--side-nav--ux.#{$prefix}--side-nav--ux
     .#{$prefix}--side-nav__items.#{$prefix}--side-nav__items,
-  .#{$prefix}--side-nav--fixed.#{$prefix}--side-nav--fixed
-    .#{$prefix}--side-nav__items.#{$prefix}--side-nav__items,
   .#{$prefix}--side-nav--expanded.#{$prefix}--side-nav--expanded
     .#{$prefix}--side-nav__items.#{$prefix}--side-nav__items,
   .#{$prefix}--side-nav.#{$prefix}--side-nav:hover
@@ -593,47 +586,6 @@
     .#{$prefix}--side-nav__submenu-chevron.#{$prefix}--side-nav__submenu-chevron
     > svg {
     transform: rotate(180deg);
-  }
-
-  .#{$prefix}--side-nav__item--large.#{$prefix}--side-nav__item--large
-    .#{$prefix}--side-nav__submenu.#{$prefix}--side-nav__submenu {
-    height: 3rem; // mini-units(6) = 3rem
-  }
-
-  .#{$prefix}--side-nav__item--active.#{$prefix}--side-nav__item--active
-    .#{$prefix}--side-nav__submenu.#{$prefix}--side-nav__submenu:hover {
-    background-color: $layer-selected;
-    color: $text-primary;
-  }
-
-  .#{$prefix}--side-nav__item--active.#{$prefix}--side-nav__item--active
-    .#{$prefix}--side-nav__submenu.#{$prefix}--side-nav__submenu[aria-expanded='false'] {
-    position: relative;
-    background-color: $layer-selected;
-    color: $text-primary;
-  }
-
-  .#{$prefix}--side-nav__item--active.#{$prefix}--side-nav__item--active
-    .#{$prefix}--side-nav__submenu.#{$prefix}--side-nav__submenu[aria-expanded='false']::before {
-    position: absolute;
-    background-color: $border-interactive;
-    content: '';
-    width: 3px;
-    top: 0;
-    bottom: 0;
-    left: 0;
-  }
-
-  .#{$prefix}--side-nav__item--active.#{$prefix}--side-nav__item--active
-    .#{$prefix}--side-nav__submenu-title.#{$prefix}--side-nav__submenu-title {
-    color: $text-primary;
-    font-weight: 600;
-  }
-
-  .#{$prefix}--side-nav__item--active.#{$prefix}--side-nav__item--active
-    .#{$prefix}--side-nav__icon.#{$prefix}--side-nav__icon
-    > svg {
-    fill: $icon-primary;
   }
 
   .#{$prefix}--side-nav__menu.#{$prefix}--side-nav__menu {
@@ -699,16 +651,8 @@
       outline 0.11s cubic-bezier(0.2, 0, 0.38, 0.9);
   }
 
-  .#{$prefix}--side-nav__item--large.#{$prefix}--side-nav__item--large
-    a.#{$prefix}--side-nav__link.#{$prefix}--side-nav__link {
-    height: 3rem; // mini-units(6) = 3rem
-  }
-
   a.#{$prefix}--side-nav__link.#{$prefix}--side-nav__link
-    > .#{$prefix}--side-nav__link-text.#{$prefix}--side-nav__link-text,
-  .#{$prefix}--side-nav.#{$prefix}--side-nav
-    a.#{$prefix}--header__menu-item.#{$prefix}--header__menu-item
-    .#{$prefix}--text-truncate-end.#{$prefix}--text-truncate-end {
+    > .#{$prefix}--side-nav__link-text.#{$prefix}--side-nav__link-text {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -764,37 +708,6 @@
     width: 1rem; // mini-units(2) = 1rem
     height: 1rem; // mini-units(2) = 1rem
     fill: $icon-secondary;
-  }
-
-  .#{$prefix}--side-nav__icon.#{$prefix}--side-nav__icon
-    > svg.#{$prefix}--side-nav-collapse-icon.#{$prefix}--side-nav-collapse-icon {
-    display: none;
-  }
-
-  .#{$prefix}--side-nav--expanded.#{$prefix}--side-nav--expanded
-    .#{$prefix}--side-nav__icon.#{$prefix}--side-nav__icon
-    > svg.#{$prefix}--side-nav-expand-icon.#{$prefix}--side-nav-expand-icon {
-    display: none;
-  }
-
-  .#{$prefix}--side-nav--expanded.#{$prefix}--side-nav--expanded
-    .#{$prefix}--side-nav__icon.#{$prefix}--side-nav__icon
-    > svg.#{$prefix}--side-nav-collapse-icon.#{$prefix}--side-nav-collapse-icon {
-    display: block;
-  }
-
-  .#{$prefix}--side-nav--fixed.#{$prefix}--side-nav--fixed
-    a.#{$prefix}--side-nav__link.#{$prefix}--side-nav__link,
-  .#{$prefix}--side-nav--fixed.#{$prefix}--side-nav--fixed
-    .#{$prefix}--side-nav__submenu.#{$prefix}--side-nav__submenu {
-    padding-left: 1rem; // mini-units(2) = 1rem
-  }
-
-  .#{$prefix}--side-nav--fixed.#{$prefix}--side-nav--fixed
-    .#{$prefix}--side-nav__item.#{$prefix}--side-nav__item:not(.#{$prefix}--side-nav__item--icon.#{$prefix}--side-nav__item--icon)
-    .#{$prefix}--side-nav__menu.#{$prefix}--side-nav__menu
-    a.#{$prefix}--side-nav__link.#{$prefix}--side-nav__link {
-    padding-left: 2rem; // mini-units(4) = 2rem
   }
 
   .#{$prefix}--side-nav.#{$prefix}--side-nav

--- a/css/vendor/carbon-components/scss/components/accordion/_accordion.scss
+++ b/css/vendor/carbon-components/scss/components/accordion/_accordion.scss
@@ -73,8 +73,7 @@
   }
 
   // TODO V11: Remove xl selector
-  .#{$prefix}--accordion--xl .#{$prefix}--accordion__heading,
-  .#{$prefix}--accordion--lg .#{$prefix}--accordion__heading {
+  .#{$prefix}--accordion--xl .#{$prefix}--accordion__heading {
     min-height: to-rem(48px);
   }
 
@@ -195,8 +194,8 @@
     }
   }
 
-  .#{$prefix}--accordion.#{$prefix}--skeleton .#{$prefix}--accordion__heading,
-  .#{$prefix}--accordion.#{$prefix}--skeleton .#{$prefix}--accordion__button {
+  // Skeleton state
+  .#{$prefix}--accordion.#{$prefix}--skeleton .#{$prefix}--accordion__heading {
     cursor: default;
   }
 

--- a/css/vendor/carbon-components/scss/components/checkbox/_checkbox.scss
+++ b/css/vendor/carbon-components/scss/components/checkbox/_checkbox.scss
@@ -135,11 +135,8 @@
   }
 
   .#{$prefix}--checkbox:focus + .#{$prefix}--checkbox-label::before,
-  .#{$prefix}--checkbox-label__focus::before,
   .#{$prefix}--checkbox:checked:focus + .#{$prefix}--checkbox-label::before,
-  .#{$prefix}--checkbox-label[data-contained-checkbox-state='true'].#{$prefix}--checkbox-label__focus::before,
-  .#{$prefix}--checkbox:indeterminate:focus + .#{$prefix}--checkbox-label::before,
-  .#{$prefix}--checkbox-label[data-contained-checkbox-state='mixed'].#{$prefix}--checkbox-label__focus::before {
+  .#{$prefix}--checkbox:indeterminate:focus + .#{$prefix}--checkbox-label::before {
     outline: 2px solid $focus;
     outline-offset: 1px;
   }

--- a/css/vendor/carbon-components/scss/components/code-snippet/_code-snippet.scss
+++ b/css/vendor/carbon-components/scss/components/code-snippet/_code-snippet.scss
@@ -255,10 +255,6 @@
     top: to-rem(-1px);
   }
 
-  .#{$prefix}--snippet-btn--expand--hide.#{$prefix}--snippet-btn--expand {
-    display: none;
-  }
-
   .#{$prefix}--snippet-btn--expand .#{$prefix}--icon-chevron--down {
     margin-left: $spacing-03;
     fill: $icon-primary;

--- a/css/vendor/carbon-components/scss/components/content-switcher/_content-switcher.scss
+++ b/css/vendor/carbon-components/scss/components/content-switcher/_content-switcher.scss
@@ -27,8 +27,7 @@
   }
 
   // TODO V11: Remove xl selector
-  .#{$prefix}--content-switcher--xl,
-  .#{$prefix}--content-switcher--lg {
+  .#{$prefix}--content-switcher--xl {
     height: to-rem(48px);
   }
 
@@ -172,26 +171,12 @@
     background-color: transparent;
   }
 
-  .#{$prefix}--content-switcher__icon {
-    fill: $icon-secondary;
-    transition: fill $duration--fast-01 motion(standard, productive);
-  }
-
-  .#{$prefix}--content-switcher__icon + span {
-    margin-left: $carbon--spacing-03;
-  }
-
   .#{$prefix}--content-switcher__label {
     z-index: 1;
     overflow: hidden;
     max-width: 100%;
     text-overflow: ellipsis;
     white-space: nowrap;
-  }
-
-  .#{$prefix}--content-switcher-btn:hover .#{$prefix}--content-switcher__icon,
-  .#{$prefix}--content-switcher-btn:focus .#{$prefix}--content-switcher__icon {
-    fill: $icon-primary;
   }
 
   .#{$prefix}--content-switcher-btn.#{$prefix}--content-switcher--selected {
@@ -207,11 +192,6 @@
       background-color: $layer-selected-disabled;
       color: $text-disabled;
     }
-  }
-
-  .#{$prefix}--content-switcher-btn.#{$prefix}--content-switcher--selected
-    .#{$prefix}--content-switcher__icon {
-    fill: $icon-inverse;
   }
 
   // Windows HCM fix

--- a/css/vendor/carbon-components/scss/components/data-table/_data-table-action.scss
+++ b/css/vendor/carbon-components/scss/components/data-table/_data-table-action.scss
@@ -204,11 +204,6 @@
     cursor: not-allowed;
   }
 
-  .#{$prefix}--toolbar-action[disabled] .#{$prefix}--toolbar-action__icon {
-    cursor: not-allowed;
-    fill: $icon-disabled;
-  }
-
   .#{$prefix}--toolbar-action:focus:not([disabled]),
   .#{$prefix}--toolbar-action:active:not([disabled]) {
     @include focus-outline('outline');
@@ -223,17 +218,6 @@
     max-width: none;
     margin: 0;
     white-space: nowrap;
-  }
-
-  .#{$prefix}--overflow-menu--data-table {
-    height: $spacing-09;
-  }
-
-  .#{$prefix}--toolbar-action__icon {
-    width: auto;
-    max-width: $spacing-05;
-    height: $spacing-05;
-    fill: $icon-primary;
   }
 
   .#{$prefix}--toolbar-search-container-persistent {
@@ -351,11 +335,6 @@
     fill: none;
   }
 
-  .#{$prefix}--batch-download {
-    //makes it smaller to match other icons
-    padding: to-rem(1px);
-  }
-
   .#{$prefix}--action-list .#{$prefix}--btn--primary:focus::before,
   .#{$prefix}--action-list .#{$prefix}--btn--primary::before,
   .#{$prefix}--action-list .#{$prefix}--btn--primary:focus::after,
@@ -408,10 +387,6 @@
     background-color: $background-brand;
 
     color: $text-on-color;
-  }
-
-  .#{$prefix}--batch-summary__scroll {
-    box-shadow: 0.5px 0 0.2px $hover-primary-text;
   }
 
   .#{$prefix}--batch-summary__para {

--- a/css/vendor/carbon-components/scss/components/data-table/_data-table-core.scss
+++ b/css/vendor/carbon-components/scss/components/data-table/_data-table-core.scss
@@ -202,25 +202,13 @@
     opacity: 1;
   }
 
-  .#{$prefix}--table-row--menu-option
-    .#{$prefix}--overflow-menu-options__btn
-    .#{$prefix}--overflow-menu-options__option-content
-    svg {
-    position: relative;
-    // Used to center svg without setting display flex //display block needed for overflow text truncation
-    top: to-rem(3px);
-    margin-right: $spacing-03;
-  }
-
-  .#{$prefix}--data-table .#{$prefix}--overflow-menu,
-  .#{$prefix}--data-table .#{$prefix}--overflow-menu__trigger {
+  .#{$prefix}--data-table .#{$prefix}--overflow-menu {
     &:hover {
       background-color: $layer-selected-hover;
     }
   }
 
-  .#{$prefix}--data-table--selected .#{$prefix}--overflow-menu,
-  .#{$prefix}--data-table--selected .#{$prefix}--overflow-menu__trigger {
+  .#{$prefix}--data-table--selected .#{$prefix}--overflow-menu {
     &:hover {
       background-color: $layer-hover;
     }
@@ -581,10 +569,9 @@
     vertical-align: top;
   }
 
-  .#{$prefix}--data-table--tall .#{$prefix}--data-table--cell-secondary-text {
-    @include type-style('label-01');
-  }
-
+  //----------------------------------------------------------------------------
+  // Static
+  //----------------------------------------------------------------------------
   .#{$prefix}--data-table--static {
     width: auto;
   }

--- a/css/vendor/carbon-components/scss/components/data-table/_data-table-expandable.scss
+++ b/css/vendor/carbon-components/scss/components/data-table/_data-table-expandable.scss
@@ -17,12 +17,6 @@
     border-top: 1px solid $border-subtle;
   }
 
-  .#{$prefix}--expandable-row--hidden td {
-    width: auto;
-    padding: $spacing-05;
-    border-top: 0;
-  }
-
   tr.#{$prefix}--parent-row:not(.#{$prefix}--expandable-row)
     + tr[data-child-row] {
     height: 0;

--- a/css/vendor/carbon-components/scss/components/data-table/_data-table-skeleton.scss
+++ b/css/vendor/carbon-components/scss/components/data-table/_data-table-skeleton.scss
@@ -39,10 +39,6 @@
     }
   }
 
-  .#{$prefix}--data-table.#{$prefix}--skeleton .#{$prefix}--table-sort-v2 {
-    pointer-events: none;
-  }
-
   .#{$prefix}--data-table.#{$prefix}--skeleton th span {
     background: $skeleton-element;
   }

--- a/css/vendor/carbon-components/scss/components/data-table/_data-table-sort.scss
+++ b/css/vendor/carbon-components/scss/components/data-table/_data-table-sort.scss
@@ -61,47 +61,6 @@
     padding-left: $spacing-05;
   }
 
-  th .#{$prefix}--table-sort__flex {
-    display: flex;
-    width: 100%;
-    height: 100%;
-    min-height: 3rem;
-    align-items: center;
-    justify-content: space-between;
-  }
-
-  // V11: remove compact
-  .#{$prefix}--data-table--compact.#{$prefix}--data-table--sort
-    th
-    .#{$prefix}--table-sort__flex {
-    min-height: 1.5rem;
-  }
-
-  // V11: remove short
-  .#{$prefix}--data-table--short.#{$prefix}--data-table--sort
-    th
-    .#{$prefix}--table-sort__flex {
-    min-height: 2rem;
-  }
-
-  .#{$prefix}--data-table--md.#{$prefix}--data-table--sort
-    th
-    .#{$prefix}--table-sort__flex {
-    min-height: 2.5rem;
-  }
-
-  // V11: remove tall
-  .#{$prefix}--data-table--tall.#{$prefix}--data-table--sort
-    th
-    .#{$prefix}--table-sort__flex {
-    min-height: 4rem;
-    align-items: flex-start;
-  }
-
-  .#{$prefix}--table-sort .#{$prefix}--table-sort__icon-inactive {
-    display: block;
-  }
-
   .#{$prefix}--table-sort .#{$prefix}--table-sort__icon {
     display: none;
   }

--- a/css/vendor/carbon-components/scss/components/date-picker/_date-picker.scss
+++ b/css/vendor/carbon-components/scss/components/date-picker/_date-picker.scss
@@ -118,8 +118,7 @@
   }
 
   // TODO V11: Remove xl selector
-  .#{$prefix}--date-picker__input--xl,
-  .#{$prefix}--date-picker__input--lg {
+  .#{$prefix}--date-picker__input--xl {
     height: to-rem(48px);
   }
 

--- a/css/vendor/carbon-components/scss/components/dropdown/_dropdown.scss
+++ b/css/vendor/carbon-components/scss/components/dropdown/_dropdown.scss
@@ -67,25 +67,14 @@
   }
 
   // TODO V11: Remove xl selector
-  .#{$prefix}--dropdown--xl,
-  .#{$prefix}--dropdown--lg {
+  .#{$prefix}--dropdown--xl {
     height: to-rem(48px);
     max-height: to-rem(48px);
-  }
-
-  // TODO V11: Remove xl selector
-  .#{$prefix}--dropdown--xl .#{$prefix}--dropdown__arrow,
-  .#{$prefix}--dropdown--lg .#{$prefix}--dropdown__arrow {
-    top: to-rem(16px);
   }
 
   .#{$prefix}--dropdown--sm {
     height: to-rem(32px);
     max-height: to-rem(32px);
-  }
-
-  .#{$prefix}--dropdown--sm .#{$prefix}--dropdown__arrow {
-    top: to-rem(8px);
   }
 
   .#{$prefix}--dropdown--open {
@@ -100,14 +89,6 @@
       max-height: to-rem(200px);
       color: $text-error;
     }
-  }
-
-  .#{$prefix}--dropdown__invalid-icon {
-    position: absolute;
-    top: 50%;
-    right: $spacing-08;
-    fill: $support-error;
-    transform: translateY(-50%);
   }
 
   .#{$prefix}--dropdown--open:hover {
@@ -127,20 +108,6 @@
     }
   }
 
-  .#{$prefix}--dropdown__arrow {
-    position: absolute;
-    top: to-rem(13px);
-    right: 1rem;
-    fill: $icon-primary;
-    pointer-events: none;
-    transform-origin: 50% 45%;
-    transition: transform $duration--fast-02 motion(standard, productive);
-  }
-
-  .#{$prefix}--dropdown--open .#{$prefix}--dropdown__arrow {
-    transform: rotate(-180deg);
-  }
-
   .#{$prefix}--dropdown--disabled {
     border-bottom-color: transparent;
 
@@ -158,7 +125,6 @@
     }
 
     // TODO: remove in v11
-    .#{$prefix}--dropdown__arrow,
     .#{$prefix}--list-box__menu-icon svg {
       fill: $icon-disabled;
     }
@@ -172,11 +138,6 @@
   .#{$prefix}--dropdown--disabled .#{$prefix}--list-box__field,
   .#{$prefix}--dropdown--disabled .#{$prefix}--list-box__menu-icon {
     cursor: not-allowed;
-  }
-
-  .#{$prefix}--dropdown--auto-width {
-    width: auto;
-    max-width: to-rem(400px);
   }
 
   .#{$prefix}--dropdown--inline {
@@ -194,20 +155,10 @@
     &.#{$prefix}--dropdown--disabled {
       background-color: transparent;
     }
-
-    .#{$prefix}--dropdown__arrow {
-      top: to-rem(8px);
-      right: to-rem(8px);
-    }
   }
 
   .#{$prefix}--dropdown--inline.#{$prefix}--dropdown--open {
     background-color: transparent;
-  }
-
-  .#{$prefix}--dropdown--inline.#{$prefix}--dropdown--invalid
-    .#{$prefix}--dropdown__invalid-icon {
-    right: to-rem(32px);
   }
 
   .#{$prefix}--dropdown-v2.#{$prefix}--skeleton,

--- a/css/vendor/carbon-components/scss/components/file-uploader/_file-uploader.scss
+++ b/css/vendor/carbon-components/scss/components/file-uploader/_file-uploader.scss
@@ -22,11 +22,6 @@
     width: 100%;
   }
 
-  .#{$prefix}--file--invalid {
-    margin-right: $carbon--spacing-03;
-    fill: $support-01;
-  }
-
   // TODO: sync with type
   .#{$prefix}--file--label {
     @include reset;
@@ -36,21 +31,8 @@
     color: $text-01;
   }
 
-  .#{$prefix}--file--label--disabled {
-    color: $disabled-02;
-  }
-
   .#{$prefix}--file-input {
     @include hidden;
-  }
-
-  // This class is of old markup with "select file" button
-  // New code should use link-style "select file" UI (`.bx--file-browse-btn`)
-  // TODO: deprecate this block
-  .#{$prefix}--file-btn {
-    display: inline-flex;
-    padding-right: to-rem(64px);
-    margin: 0;
   }
 
   .#{$prefix}--file-browse-btn {
@@ -113,11 +95,6 @@
     color: $disabled-02;
   }
 
-  // For backwards compatibility
-  .#{$prefix}--file-btn ~ .#{$prefix}--file-container {
-    margin-top: $carbon--spacing-06;
-  }
-
   .#{$prefix}--btn ~ .#{$prefix}--file-container {
     margin-top: $carbon--spacing-05;
   }
@@ -166,7 +143,6 @@
   }
 
   // V11: Remove --field
-  .#{$prefix}--file__selected-file--field,
   .#{$prefix}--file__selected-file--md {
     min-height: to-rem(40px);
     gap: $carbon--spacing-03 $carbon--spacing-05;
@@ -175,16 +151,6 @@
   .#{$prefix}--file__selected-file--sm {
     min-height: to-rem(32px);
     gap: $carbon--spacing-02 $carbon--spacing-05;
-  }
-
-  // TODO: deprecate this block
-  .#{$prefix}--file__selected-file--invalid__wrapper {
-    @include focus-outline('invalid');
-
-    max-width: to-rem(320px);
-    margin-bottom: $carbon--spacing-03;
-    background-color: $field-01;
-    outline-width: 1px;
   }
 
   .#{$prefix}--file__selected-file--invalid {
@@ -198,7 +164,6 @@
   }
 
   // V11: Remove --field
-  .#{$prefix}--file__selected-file--invalid.#{$prefix}--file__selected-file--field,
   .#{$prefix}--file__selected-file--invalid.#{$prefix}--file__selected-file--md {
     padding: $carbon--spacing-03 0;
   }
@@ -214,8 +179,6 @@
   }
 
   // V11: Remove --field
-  .#{$prefix}--file__selected-file--invalid.#{$prefix}--file__selected-file--field
-    .#{$prefix}--form-requirement,
   .#{$prefix}--file__selected-file--invalid.#{$prefix}--file__selected-file--md
     .#{$prefix}--form-requirement {
     padding-top: to-rem(11px);

--- a/css/vendor/carbon-components/scss/components/inline-loading/_inline-loading.scss
+++ b/css/vendor/carbon-components/scss/components/inline-loading/_inline-loading.scss
@@ -40,13 +40,6 @@
   .#{$prefix}--inline-loading__checkmark-container {
     fill: $support-02;
 
-    // For deprecated older markup
-    &.#{$prefix}--inline-loading__svg {
-      position: absolute;
-      top: 0.75rem;
-      width: 0.75rem;
-    }
-
     &[hidden] {
       display: none;
     }
@@ -74,9 +67,6 @@
     }
   }
 
-  .#{$prefix}--loading--small .#{$prefix}--inline-loading__svg {
-    stroke: $interactive-04;
-  }
 }
 
 @include exports('inline-loading') {

--- a/css/vendor/carbon-components/scss/components/list-box/_list-box.scss
+++ b/css/vendor/carbon-components/scss/components/list-box/_list-box.scss
@@ -775,8 +775,6 @@ $list-box-menu-width: to-rem(300px);
     .#{$prefix}--list-box__menu,
   .#{$prefix}--list-box--up.#{$prefix}--list-box--xl
     .#{$prefix}--list-box__menu,
-  .#{$prefix}--list-box--up.#{$prefix}--dropdown--lg
-    .#{$prefix}--list-box__menu,
   .#{$prefix}--list-box--up.#{$prefix}--list-box--lg
     .#{$prefix}--list-box__menu,
   .#{$prefix}--list-box--up

--- a/css/vendor/carbon-components/scss/components/menu/_menu.scss
+++ b/css/vendor/carbon-components/scss/components/menu/_menu.scss
@@ -87,10 +87,6 @@
     color: $text-disabled;
   }
 
-  .#{$prefix}--menu-option__content--indented .#{$prefix}--menu-option__label {
-    margin-left: $spacing-05;
-  }
-
   .#{$prefix}--menu-option__label {
     @include type-style('body-short-01');
 

--- a/css/vendor/carbon-components/scss/components/modal/_modal.scss
+++ b/css/vendor/carbon-components/scss/components/modal/_modal.scss
@@ -105,10 +105,6 @@
     @include carbon--breakpoint(xlg) {
       width: 48%;
     }
-
-    .#{$prefix}--modal-container-body {
-      display: contents;
-    }
   }
 
   .#{$prefix}--modal-content {
@@ -133,10 +129,8 @@
     }
   }
 
-  //TO-DO: remove .#{$prefix}--modal-content__regular-content in v11 since hasForm has been deprecated
   // text/p gets 20% right padding
-  .#{$prefix}--modal-content > p,
-  .#{$prefix}--modal-content__regular-content {
+  .#{$prefix}--modal-content > p {
     padding-right: 20%;
     @include type-style('body-long-01');
   }
@@ -171,10 +165,6 @@
 
   .#{$prefix}--modal-container--xs {
     //text always spans full width in xs modals
-    .#{$prefix}--modal-content__regular-content {
-      padding-right: $spacing-05;
-    }
-
     .#{$prefix}--modal-content > p {
       //.#{$prefix}--modal-content already has 16px padding so this doesn't need any
       padding-right: 0;
@@ -196,10 +186,6 @@
 
   .#{$prefix}--modal-container--sm {
     //text spans full width in sm modals below 1056
-    .#{$prefix}--modal-content__regular-content {
-      padding-right: $spacing-05;
-    }
-
     .#{$prefix}--modal-content > p {
       //.#{$prefix}--modal-content already has 16px padding so this doesn't need any
       padding-right: 0;
@@ -213,8 +199,7 @@
       width: 42%;
       max-height: 72%;
 
-      .#{$prefix}--modal-content > p,
-      .#{$prefix}--modal-content__regular-content {
+      .#{$prefix}--modal-content > p {
         padding-right: 20%;
       }
     }

--- a/css/vendor/carbon-components/scss/components/multi-select/_multi-select.scss
+++ b/css/vendor/carbon-components/scss/components/multi-select/_multi-select.scss
@@ -85,7 +85,6 @@
     outline: none;
   }
 
-  .#{$prefix}--multi-select--filterable--input-focused,
   .#{$prefix}--multi-select
     .#{$prefix}--list-box__field--wrapper--input-focused {
     @include focus-outline('outline');

--- a/css/vendor/carbon-components/scss/components/notification/_mixins.scss
+++ b/css/vendor/carbon-components/scss/components/notification/_mixins.scss
@@ -29,8 +29,7 @@
   background: $background-color;
 
   .#{$prefix}--inline-notification__icon,
-  .#{$prefix}--toast-notification__icon,
-  .#{$prefix}--actionable-notification__icon {
+  .#{$prefix}--toast-notification__icon {
     fill: $color;
   }
 }

--- a/css/vendor/carbon-components/scss/components/number-input/_number-input.scss
+++ b/css/vendor/carbon-components/scss/components/number-input/_number-input.scss
@@ -75,8 +75,7 @@
   }
 
   // TODO V11: Remove xl selector
-  .#{$prefix}--number--xl.#{$prefix}--number input[type='number'],
-  .#{$prefix}--number--lg.#{$prefix}--number input[type='number'] {
+  .#{$prefix}--number--xl.#{$prefix}--number input[type='number'] {
     padding-right: to-rem(144px);
   }
 
@@ -301,8 +300,7 @@
   }
 
   // TODO V11: Remove xl selector
-  .#{$prefix}--number--xl .#{$prefix}--number__invalid,
-  .#{$prefix}--number--lg .#{$prefix}--number__invalid {
+  .#{$prefix}--number--xl .#{$prefix}--number__invalid {
     right: to-rem(112px);
   }
 
@@ -317,9 +315,6 @@
 
   // TODO V11: Remove xl selector
   .#{$prefix}--number--xl
-    .#{$prefix}--number__invalid
-    + .#{$prefix}--number__rule-divider,
-  .#{$prefix}--number--lg
     .#{$prefix}--number__invalid
     + .#{$prefix}--number__rule-divider {
     right: to-rem(96px);
@@ -382,20 +377,17 @@
   }
 
   // TODO V11: Remove xl selector
-  .#{$prefix}--number--xl input[type='number'],
-  .#{$prefix}--number--lg input[type='number'] {
+  .#{$prefix}--number--xl input[type='number'] {
     height: to-rem(48px);
   }
 
   // TODO V11: Remove xl selector
-  .#{$prefix}--number--xl .#{$prefix}--number__controls,
-  .#{$prefix}--number--lg .#{$prefix}--number__controls {
+  .#{$prefix}--number--xl .#{$prefix}--number__controls {
     width: to-rem(96px);
   }
 
   // TODO V11: Remove xl selector
-  .#{$prefix}--number--xl .#{$prefix}--number__control-btn,
-  .#{$prefix}--number--lg .#{$prefix}--number__control-btn {
+  .#{$prefix}--number--xl .#{$prefix}--number__control-btn {
     width: to-rem(48px);
 
     &::before,
@@ -443,11 +435,6 @@
 
   .#{$prefix}--number--readonly .#{$prefix}--number__controls {
     display: none;
-  }
-
-  .#{$prefix}--number__readonly-icon {
-    position: absolute;
-    right: to-rem(16px);
   }
 
   .#{$prefix}--number.#{$prefix}--skeleton {

--- a/css/vendor/carbon-components/scss/components/overflow-menu/_overflow-menu.scss
+++ b/css/vendor/carbon-components/scss/components/overflow-menu/_overflow-menu.scss
@@ -18,8 +18,7 @@
 /// @access private
 /// @group overflow-menu
 @mixin overflow-menu {
-  .#{$prefix}--overflow-menu,
-  .#{$prefix}--overflow-menu__trigger {
+  .#{$prefix}--overflow-menu {
     @include button-reset;
     @include reset;
     @include focus-outline('reset');
@@ -54,27 +53,14 @@
     height: to-rem(48px);
   }
 
-  // Overwrite Icon Tooltip focus styles
-  .#{$prefix}--overflow-menu__trigger.#{$prefix}--tooltip--a11y.#{$prefix}--tooltip__trigger:focus {
-    @include focus-outline('outline');
-
-    svg {
-      outline: none;
-    }
-  }
-
-  .#{$prefix}--overflow-menu.#{$prefix}--overflow-menu--open,
-  .#{$prefix}--overflow-menu.#{$prefix}--overflow-menu--open
-    .#{$prefix}--overflow-menu__trigger {
+  .#{$prefix}--overflow-menu.#{$prefix}--overflow-menu--open {
     @include box-shadow;
 
     background-color: $field-01;
     transition: none;
   }
 
-  .#{$prefix}--overflow-menu--light.#{$prefix}--overflow-menu--open,
-  .#{$prefix}--overflow-menu--light.#{$prefix}--overflow-menu--open
-    .#{$prefix}--overflow-menu__trigger {
+  .#{$prefix}--overflow-menu--light.#{$prefix}--overflow-menu--open {
     background-color: $field-02;
   }
 
@@ -170,8 +156,7 @@
   }
 
   // TODO V11: Remove xl selector
-  .#{$prefix}--overflow-menu-options--xl.#{$prefix}--overflow-menu-options,
-  .#{$prefix}--overflow-menu-options--lg.#{$prefix}--overflow-menu-options {
+  .#{$prefix}--overflow-menu-options--xl.#{$prefix}--overflow-menu-options {
     &[data-floating-menu-direction='bottom']::after,
     &[data-floating-menu-direction='top']::after {
       width: to-rem(48px);
@@ -222,8 +207,6 @@
 
   // TODO V11: Remove xl selector
   .#{$prefix}--overflow-menu-options--xl
-    .#{$prefix}--overflow-menu-options__option,
-  .#{$prefix}--overflow-menu-options--lg
     .#{$prefix}--overflow-menu-options__option {
     height: to-rem(48px);
   }
@@ -338,10 +321,6 @@
     &::before {
       left: 145px;
     }
-  }
-
-  .#{$prefix}--overflow-menu__container {
-    display: inline-block;
   }
 
   // Windows HCM fix

--- a/css/vendor/carbon-components/scss/components/pagination-nav/_pagination-nav.scss
+++ b/css/vendor/carbon-components/scss/components/pagination-nav/_pagination-nav.scss
@@ -125,8 +125,7 @@
       @include focus-outline('outline');
     }
 
-    &:disabled,
-    &.#{$prefix}--pagination-nav__page--disabled {
+    &:disabled {
       background: none;
       color: rgba($text-color, 0.5);
       outline: none;
@@ -141,10 +140,6 @@
       font-weight: 600;
     }
 
-    .#{$prefix}--pagination-nav__icon {
-      fill: currentColor;
-      pointer-events: none;
-    }
   }
 
   .#{$prefix}--pagination-nav__select {

--- a/css/vendor/carbon-components/scss/components/radio-button/_radio-button.scss
+++ b/css/vendor/carbon-components/scss/components/radio-button/_radio-button.scss
@@ -155,9 +155,7 @@
     margin-bottom: $carbon--spacing-03;
   }
 
-  .#{$prefix}--radio-button-group--label-right .#{$prefix}--radio-button__label,
-  .#{$prefix}--radio-button-wrapper.#{$prefix}--radio-button-wrapper--label-right
-    .#{$prefix}--radio-button__label {
+  .#{$prefix}--radio-button-group--label-right .#{$prefix}--radio-button__label {
     flex-direction: row;
   }
 

--- a/css/vendor/carbon-components/scss/components/select/_select.scss
+++ b/css/vendor/carbon-components/scss/components/select/_select.scss
@@ -97,8 +97,7 @@
   }
 
   // TODO V11: Remove xl selector
-  .#{$prefix}--select-input--xl,
-  .#{$prefix}--select-input--lg {
+  .#{$prefix}--select-input--xl {
     height: to-rem(48px);
     max-height: to-rem(48px);
   }

--- a/css/vendor/carbon-components/scss/components/slider/_slider.scss
+++ b/css/vendor/carbon-components/scss/components/slider/_slider.scss
@@ -107,12 +107,7 @@
     }
   }
 
-  .#{$prefix}--slider__input {
-    display: none;
-  }
-
-  .#{$prefix}--slider-text-input,
-  .#{$prefix}-slider-text-input {
+  .#{$prefix}--slider-text-input {
     width: to-rem(64px);
     height: to-rem(40px);
     -moz-appearance: textfield;

--- a/css/vendor/carbon-components/scss/components/tabs/_tabs.scss
+++ b/css/vendor/carbon-components/scss/components/tabs/_tabs.scss
@@ -60,20 +60,6 @@
     }
   }
 
-  .#{$prefix}--tabs__nav--hidden {
-    overflow: hidden;
-    max-height: 0;
-    transition: max-height $duration--fast-01 motion(standard, productive);
-
-    @include carbon--breakpoint(md) {
-      display: flex;
-      max-width: 100%;
-      max-height: none;
-      overflow-x: auto;
-      transition: inherit;
-    }
-  }
-
   .#{$prefix}--tabs__nav-item {
     @include reset;
 

--- a/css/vendor/carbon-components/scss/components/text-input/_text-input.scss
+++ b/css/vendor/carbon-components/scss/components/text-input/_text-input.scss
@@ -43,8 +43,7 @@
   }
 
   // TODO V11: Remove xl selector
-  .#{$prefix}--text-input--xl,
-  .#{$prefix}--text-input--lg {
+  .#{$prefix}--text-input--xl {
     height: to-rem(48px);
   }
 
@@ -58,10 +57,6 @@
 
   .#{$prefix}--text-input--sm.#{$prefix}--password-input {
     padding-right: $carbon--spacing-07;
-  }
-
-  .#{$prefix}--text-input--lg.#{$prefix}--password-input {
-    padding-right: $carbon--spacing-09;
   }
 
   .#{$prefix}--text-input::placeholder {
@@ -129,11 +124,6 @@
   .#{$prefix}--text-input--sm
     + .#{$prefix}--btn.#{$prefix}--text-input--password__visibility__toggle.#{$prefix}--tooltip__trigger {
     width: to-rem(32px);
-  }
-
-  .#{$prefix}--text-input--lg
-    + .#{$prefix}--btn.#{$prefix}--text-input--password__visibility__toggle.#{$prefix}--tooltip__trigger {
-    width: to-rem(48px);
   }
 
   .#{$prefix}--btn.#{$prefix}--text-input--password__visibility__toggle.#{$prefix}--tooltip__trigger
@@ -321,8 +311,7 @@
   }
 
   // TODO V11: Remove xl selector
-  .#{$prefix}--text-input-wrapper .#{$prefix}--label--inline--xl,
-  .#{$prefix}--text-input-wrapper .#{$prefix}--label--inline--lg {
+  .#{$prefix}--text-input-wrapper .#{$prefix}--label--inline--xl {
     margin-top: to-rem(17px);
   }
 

--- a/css/vendor/carbon-components/scss/components/tile/_tile.scss
+++ b/css/vendor/carbon-components/scss/components/tile/_tile.scss
@@ -126,10 +126,6 @@
     }
   }
 
-  .#{$prefix}--tile__checkmark--persistent {
-    opacity: 1;
-  }
-
   .#{$prefix}--tile__chevron {
     position: absolute;
     right: $carbon--spacing-05;

--- a/css/vendor/carbon-components/scss/components/time-picker/_time-picker.scss
+++ b/css/vendor/carbon-components/scss/components/time-picker/_time-picker.scss
@@ -81,9 +81,7 @@
 
   // TODO V11: Remove xl selector
   .#{$prefix}--time-picker--xl .#{$prefix}--select-input,
-  .#{$prefix}--time-picker--xl .#{$prefix}--time-picker__input-field,
-  .#{$prefix}--time-picker--lg .#{$prefix}--select-input,
-  .#{$prefix}--time-picker--lg .#{$prefix}--time-picker__input-field {
+  .#{$prefix}--time-picker--xl .#{$prefix}--time-picker__input-field {
     height: to-rem(48px);
     max-height: to-rem(48px);
   }

--- a/css/vendor/carbon-components/scss/components/toggle/_toggle.scss
+++ b/css/vendor/carbon-components/scss/components/toggle/_toggle.scss
@@ -104,18 +104,6 @@
       transform: translateX(to-rem(16px));
     }
 
-    .#{$prefix}--toggle__check {
-      position: absolute;
-      top: to-rem(6px);
-      right: to-rem(5px);
-      fill: $support-success;
-      visibility: hidden;
-    }
-
-    .#{$prefix}--toggle__switch--checked .#{$prefix}--toggle__check {
-      visibility: visible;
-    }
-
     .#{$prefix}--toggle--disabled .#{$prefix}--toggle__appearance {
       cursor: not-allowed;
     }
@@ -132,11 +120,6 @@
         background-color: $icon-on-color-disabled;
       }
     }
-
-    .#{$prefix}--toggle--disabled .#{$prefix}--toggle__check {
-      fill: $button-disabled;
-    }
-
 
     .#{$prefix}--toggle__switch,
     .#{$prefix}--toggle__switch::before {
@@ -216,18 +199,6 @@
         cursor: pointer;
         transition: transform $duration--fast-01 motion(exit, productive);
       }
-    }
-
-    .#{$prefix}--toggle__check {
-      position: absolute;
-      z-index: 1;
-      top: to-rem(6px);
-      left: to-rem(6px);
-      width: to-rem(6px);
-      height: to-rem(5px);
-      fill: $icon-03;
-      transform: scale(0.2);
-      transition: $duration--fast-01 motion(exit, productive);
     }
 
     .#{$prefix}--toggle__text--left,
@@ -329,12 +300,6 @@
       box-shadow: none;
     }
 
-    .#{$prefix}--toggle:disabled
-      + .#{$prefix}--toggle__label
-      .#{$prefix}--toggle__check {
-      fill: $disabled-02;
-    }
-
 
     .#{$prefix}--toggle--small
       + .#{$prefix}--toggle__label
@@ -356,13 +321,6 @@
         width: to-rem(10px);
         height: to-rem(10px);
       }
-    }
-
-    .#{$prefix}--toggle--small:checked
-      + .#{$prefix}--toggle__label
-      .#{$prefix}--toggle__check {
-      fill: $support-02;
-      transform: scale(1) translateX(to-rem(16px));
     }
 
     .#{$prefix}--toggle--small
@@ -557,17 +515,6 @@
       > .#{$prefix}--toggle__switch::after {
         transform: translateX(to-rem(17px));
       }
-
-      .#{$prefix}--toggle__check {
-        fill: $support-02;
-        transform: scale(1) translateX(to-rem(16px));
-      }
-    }
-
-    .#{$prefix}--toggle-input--small:disabled:checked
-      + .#{$prefix}--toggle-input__label
-      .#{$prefix}--toggle__check {
-      fill: $disabled-01;
     }
 
     .#{$prefix}--toggle.#{$prefix}--skeleton

--- a/css/vendor/carbon-components/scss/components/tooltip/_tooltip.scss
+++ b/css/vendor/carbon-components/scss/components/tooltip/_tooltip.scss
@@ -58,10 +58,6 @@
     margin-left: $carbon--spacing-03;
   }
 
-  .#{$prefix}--tooltip__label--bold {
-    font-weight: 600;
-  }
-
   .#{$prefix}--tooltip {
     @include box-shadow;
     @include reset;
@@ -235,12 +231,6 @@
     &[data-floating-menu-direction='bottom'] {
       margin-top: $spacing-03;
     }
-  }
-
-  .#{$prefix}--tooltip__heading {
-    @include carbon--type-style('productive-heading-01');
-
-    margin-bottom: $spacing-03;
   }
 
   .#{$prefix}--tooltip--shown {

--- a/css/vendor/carbon-components/scss/components/ui-shell/_header.scss
+++ b/css/vendor/carbon-components/scss/components/ui-shell/_header.scss
@@ -82,12 +82,6 @@
     justify-content: center;
   }
 
-  .#{$prefix}--header__menu-toggle__hidden {
-    @include carbon--breakpoint('lg') {
-      display: none;
-    }
-  }
-
   a.#{$prefix}--header__name {
     @include type-style('body-short-01');
 

--- a/css/vendor/carbon-components/scss/components/ui-shell/_side-nav.scss
+++ b/css/vendor/carbon-components/scss/components/ui-shell/_side-nav.scss
@@ -93,10 +93,6 @@
     width: mini-units(6);
   }
 
-  .#{$prefix}--side-nav--hidden {
-    width: 0;
-  }
-
   .#{$prefix}--side-nav.#{$prefix}--side-nav--rail:not(.#{$prefix}--side-nav--fixed):hover,
   .#{$prefix}--side-nav--expanded {
     width: mini-units(32);
@@ -159,43 +155,6 @@
     height: auto;
   }
 
-  .#{$prefix}--side-nav__details {
-    display: flex;
-    min-width: 0;
-    // Necessary for text truncation in title
-    // https://css-tricks.com/flexbox-truncated-text/#article-header-id-3
-    flex: 1;
-    flex-direction: column;
-    padding-right: mini-units(2);
-
-    @include expanded($opacity: true, $visibility: true);
-  }
-
-  .#{$prefix}--side-nav--ux .#{$prefix}--side-nav__details {
-    opacity: 1;
-    visibility: inherit;
-  }
-
-  .#{$prefix}--side-nav__footer {
-    width: 100%;
-    flex: 0 0 to-rem(48px);
-    background-color: $shell-side-nav-bg-01;
-  }
-
-  .#{$prefix}--side-nav__toggle {
-    @include focus-outline('reset');
-    @include button-reset($width: true);
-
-    height: 100%;
-    padding-left: mini-units(2);
-    text-align: left;
-    transition: outline $duration--fast-02;
-  }
-
-  .#{$prefix}--side-nav__toggle:focus {
-    @include focus-outline('outline');
-  }
-
   .#{$prefix}--side-nav__items {
     overflow: hidden;
     flex: 1 1 0%;
@@ -244,10 +203,6 @@
     > .#{$prefix}--side-nav__link:hover
     > span {
     color: $ibm-color__gray-100;
-  }
-
-  .#{$prefix}--side-nav__item--large {
-    height: mini-units(6);
   }
 
   .#{$prefix}--side-nav__divider {
@@ -305,10 +260,6 @@
     transform: rotate(180deg);
   }
 
-  .#{$prefix}--side-nav__item--large .#{$prefix}--side-nav__submenu {
-    height: mini-units(6);
-  }
-
   .#{$prefix}--side-nav__menu {
     display: block;
     max-height: 0;
@@ -361,14 +312,7 @@
       outline $duration--fast-02;
   }
 
-  .#{$prefix}--side-nav__item--large a.#{$prefix}--side-nav__link {
-    height: mini-units(6);
-  }
-
-  a.#{$prefix}--side-nav__link > .#{$prefix}--side-nav__link-text,
-  .#{$prefix}--side-nav
-    a.#{$prefix}--header__menu-item
-    .#{$prefix}--text-truncate-end {
+  a.#{$prefix}--side-nav__link > .#{$prefix}--side-nav__link-text {
     @include text-overflow();
 
     color: $shell-side-nav-text-01;

--- a/css/vendor/carbon-components/scss/components/ui-shell/_switcher.scss
+++ b/css/vendor/carbon-components/scss/components/ui-shell/_switcher.scss
@@ -69,10 +69,6 @@
     }
   }
 
-  .#{$prefix}--switcher__item-link--selected {
-    background: $shell-panel-bg-04;
-    color: $shell-panel-text-02;
-  }
 }
 
 @include exports('carbon-header-switcher') {


### PR DESCRIPTION
Removes rule-level selectors for dead `bx--` classes from the
vendored Carbon SCSS and the matching `css/_*.scss` overrides,
verified with a css-tree AST diff of `css/all.css` so no live
selector could slip through. Selectors inside `:not(...)` guards on
otherwise-live rules were left alone, since rewriting a guard
changes behavior even when the guarded class is itself dead.

Rebased onto latest `master` and rechecked every flagged class
against it, since a few companion `class:`-binding fixes landed in
the meantime (#3717, #3718, #3719, #3720, #3721, #3722). Two of
those classes are kept genuinely dead-in-effect even though the
class itself is now applied: `bx--side-nav--fixed`'s rules are
no-ops next to an unconditional base rule, and
`bx--switcher__item-link--selected` is fully superseded by a newer,
higher-specificity override. Both were independently confirmed
against the current CSS, not just taken on faith.

## Benchmark

Measured `css/all.css` with `BUILD_CSS_MINIFY=1 bun build:css`
(matches what CI/release ship), gzip via `gzip -c css/all.css | wc -c`.

| | Before | After | Delta |
|---|---|---|---|
| Raw | 912,825 B | 898,320 B | -14.2 KB |
| Gzip | 85,164 B | 83,306 B | -1.8 KB |