### PR TITLE
fix(file-uploader): space the invalid icon from the close button

### DIFF
--- a/css/vendor/carbon-components/scss/components/file-uploader/_file-uploader.scss
+++ b/css/vendor/carbon-components/scss/components/file-uploader/_file-uploader.scss
@@ -288,6 +288,7 @@
   .#{$prefix}--file__state-container .#{$prefix}--file-invalid {
     width: $carbon--spacing-05;
     height: $carbon--spacing-05;
+    margin-right: $carbon--spacing-03;
     fill: $support-01;
   }
 


### PR DESCRIPTION
The CSS targeted `bx--file--invalid` (double dash) instead of the
rendered `bx--file-invalid` class, so it silently never matched.