### PR TITLE
fix(progress-bar): apply label-text class for truncation

### DIFF
--- a/src/ProgressBar/ProgressBar.svelte
+++ b/src/ProgressBar/ProgressBar.svelte
@@ -78,7 +78,9 @@
     class:bx--progress-bar__label={true}
     class:bx--visually-hidden={hideLabel}
   >
-    <slot name="labelChildren"> {labelText} </slot>
+    <span class:bx--progress-bar__label-text={true}>
+      <slot name="labelChildren"> {labelText} </slot>
+    </span>
     {#if status === "error" || status === "finished"}
       <svelte:component
         this={statusIcons[status]}

--- a/tests/ProgressBar/ProgressBar.test.ts
+++ b/tests/ProgressBar/ProgressBar.test.ts
@@ -67,7 +67,9 @@ describe("ProgressBar", () => {
     render(ProgressBar);
 
     const label = screen.getByText("Hidden label");
-    expect(label).toHaveClass("bx--visually-hidden");
+    expect(label.closest(".bx--progress-bar__label")).toHaveClass(
+      "bx--visually-hidden",
+    );
   });
 
   it("should cap values appropriately", () => {
@@ -90,7 +92,10 @@ describe("ProgressBar", () => {
     const progressBar = within(screen.getByTestId("progress-40%")).getByRole(
       "progressbar",
     );
-    const label = screen.getByText("Progress 40%");
+    const label = screen
+      .getByText("Progress 40%")
+      .closest(".bx--progress-bar__label");
+    if (label === null) throw new Error("label not found");
     expect(progressBar).toHaveAttribute("aria-labelledby", label.id);
     expect(label).toHaveClass("bx--progress-bar__label");
     expect(progressBar).not.toHaveAttribute("for");


### PR DESCRIPTION
The label text was never wrapped in `bx--progress-bar__label-text`,
so long labels wrapped instead of ellipsis-truncating next to the
status icon.