### PR TITLE
fix(radio-button): apply label-text class in readonly mode

### DIFF
--- a/src/RadioButton/RadioButton.svelte
+++ b/src/RadioButton/RadioButton.svelte
@@ -196,7 +196,10 @@
   <label class:bx--radio-button__label={true} for={id}>
     <span class:bx--radio-button__appearance={true}></span>
     {#if labelText || $$slots.labelChildren}
-      <span class:bx--visually-hidden={hideLabel}>
+      <span
+        class:bx--radio-button__label-text={true}
+        class:bx--visually-hidden={hideLabel}
+      >
         <slot name="labelChildren"> {labelText} </slot>
       </span>
     {/if}


### PR DESCRIPTION
The label text span never carried `bx--radio-button__label-text`, so
the readonly rule keeping it selectable (`cursor: text`) was
unreachable while the rest of the label showed `cursor: default`.