### PR TITLE
fix(pagination): show item count and nav buttons below md

### DIFF
--- a/src/Pagination/Pagination.svelte
+++ b/src/Pagination/Pagination.svelte
@@ -253,6 +253,13 @@
   $: internalForwardButtonDisabled =
     forwardButtonDisabled ??
     (disabled || (!pagesUnknown && page === totalPages));
+  $: itemsCountText = pagesUnknown
+    ? itemText(pageSize * (page - 1) + 1, page * pageSize)
+    : itemRangeText(
+        Math.min(pageSize * (page - 1) + 1, totalItems),
+        Math.min(page * pageSize, totalItems),
+        totalItems,
+      );
 </script>
 
 <div
@@ -292,16 +299,11 @@
           {/each}
         </Select>
       {/if}
-      <span class:bx--pagination__text={!pageSizeInputDisabled}>
-        {#if pagesUnknown}
-          {itemText(pageSize * (page - 1) + 1, page * pageSize)}
-        {:else}
-          {itemRangeText(
-            Math.min(pageSize * (page - 1) + 1, totalItems),
-            Math.min(page * pageSize, totalItems),
-            totalItems,
-          )}
-        {/if}
+      <span
+        class:bx--pagination__text={!pageSizeInputDisabled}
+        class:bx--pagination__items-count={true}
+      >
+        {itemsCountText}
       </span>
     </div>
   {/if}
@@ -347,43 +349,45 @@
         {/if}
       </span>
     {/if}
-    <Button
-      bind:ref={backBtnRef}
-      kind="ghost"
-      tooltipAlignment="center"
-      tooltipPosition={backwardTextTooltipPosition}
-      portalTooltip
-      icon={CaretLeft}
-      iconDescription={backwardText}
-      disabled={internalBackButtonDisabled}
-      class="bx--pagination__button bx--pagination__button--backward {internalBackButtonDisabled
-        ? 'bx--pagination__button--no-index'
-        : ''}"
-      on:click={() => {
-        page--;
-        dispatch("click:button--previous", { page });
-        dispatch("change", { page });
-        refocusIfDisabled(backBtnRef, forwardBtnRef);
-      }}
-    />
-    <Button
-      bind:ref={forwardBtnRef}
-      kind="ghost"
-      tooltipAlignment="end"
-      tooltipPosition={forwardTextTooltipPosition}
-      portalTooltip
-      icon={CaretRight}
-      iconDescription={forwardText}
-      disabled={internalForwardButtonDisabled}
-      class="bx--pagination__button bx--pagination__button--forward {internalForwardButtonDisabled
-        ? 'bx--pagination__button--no-index'
-        : ''}"
-      on:click={() => {
-        page++;
-        dispatch("click:button--next", { page });
-        dispatch("change", { page });
-        refocusIfDisabled(forwardBtnRef, backBtnRef);
-      }}
-    />
+    <div class:bx--pagination__control-buttons={true}>
+      <Button
+        bind:ref={backBtnRef}
+        kind="ghost"
+        tooltipAlignment="center"
+        tooltipPosition={backwardTextTooltipPosition}
+        portalTooltip
+        icon={CaretLeft}
+        iconDescription={backwardText}
+        disabled={internalBackButtonDisabled}
+        class="bx--pagination__button bx--pagination__button--backward {internalBackButtonDisabled
+          ? 'bx--pagination__button--no-index'
+          : ''}"
+        on:click={() => {
+          page--;
+          dispatch("click:button--previous", { page });
+          dispatch("change", { page });
+          refocusIfDisabled(backBtnRef, forwardBtnRef);
+        }}
+      />
+      <Button
+        bind:ref={forwardBtnRef}
+        kind="ghost"
+        tooltipAlignment="end"
+        tooltipPosition={forwardTextTooltipPosition}
+        portalTooltip
+        icon={CaretRight}
+        iconDescription={forwardText}
+        disabled={internalForwardButtonDisabled}
+        class="bx--pagination__button bx--pagination__button--forward {internalForwardButtonDisabled
+          ? 'bx--pagination__button--no-index'
+          : ''}"
+        on:click={() => {
+          page++;
+          dispatch("click:button--next", { page });
+          dispatch("change", { page });
+          refocusIfDisabled(forwardBtnRef, backBtnRef);
+        }}
+      />
+    </div>
   </div>
 </div>

--- a/tests/Pagination/Pagination.test.ts
+++ b/tests/Pagination/Pagination.test.ts
@@ -56,6 +56,28 @@ describe("Pagination", () => {
     expect(screen.getByText("1–10 of 102 items")).toBeInTheDocument();
   });
 
+  // The `bx--pagination__items-count` and `bx--pagination__control-buttons`
+  // classes are exempted from the CSS rule that hides every other control
+  // below the `md` breakpoint, so mobile pagination isn't left empty.
+  it("keeps an items-count element and a control-buttons group in the DOM for mobile", () => {
+    const { container } = render(Pagination, {
+      props: { totalItems: 102 },
+    });
+
+    const itemsCount = container.querySelector(".bx--pagination__items-count");
+    expect(itemsCount).toHaveTextContent("1–10 of 102 items");
+
+    const controlButtons = container.querySelector(
+      ".bx--pagination__control-buttons",
+    );
+    expect(controlButtons).toContainElement(
+      screen.getByRole("button", { name: "Previous page" }),
+    );
+    expect(controlButtons).toContainElement(
+      screen.getByRole("button", { name: "Next page" }),
+    );
+  });
+
   it("should handle custom page sizes", () => {
     render(Pagination, {
       props: {


### PR DESCRIPTION
Below the md breakpoint, the vendored CSS hides every control in
`__left`/`__right` except `bx--pagination__items-count` and
`bx--pagination__control-buttons`, but the markup never rendered
either class, so mobile pagination collapsed to an empty bar.

---

<img width="445" height="67" alt="Screenshot 2026-08-21 at 4 31 53 PM" src="https://github.com/user-attachments/assets/4fa5a13a-f022-4a53-a472-a0cd5789a419" />
