### PR TITLE
fix(data-table): add horizontal scroll wrapper for wide tables

### DIFF
--- a/docs/src/pages/components/DataTable.svx
+++ b/docs/src/pages/components/DataTable.svx
@@ -376,6 +376,28 @@ Set `columnAlign` in `headers` to align a column's header and cells. Values are 
   ]}
 />
 
+### Horizontal scroll
+
+When a table's columns need more space than its container, the table becomes horizontally scrollable.
+
+<DataTable
+  headers={[
+    { key: "id", value: "ID" },
+    { key: "name", value: "Name" },
+    { key: "email", value: "Email" },
+    { key: "department", value: "Department" },
+    { key: "role", value: "Role" },
+    { key: "location", value: "Location" },
+    { key: "status", value: "Status" },
+    { key: "lastActive", value: "Last active" },
+  ]}
+  rows={[
+    { id: "1", name: "Aiko Tanaka", email: "aiko.tanaka@example.com", department: "Engineering", role: "Senior Software Engineer", location: "Tokyo, Japan", status: "Active", lastActive: "2 minutes ago" },
+    { id: "2", name: "Marcus Johnson", email: "marcus.johnson@example.com", department: "Product Management", role: "Principal Product Manager", location: "Austin, Texas", status: "Active", lastActive: "1 hour ago" },
+    { id: "3", name: "Fatima Al-Sayed", email: "fatima.alsayed@example.com", department: "Customer Success", role: "Customer Success Lead", location: "Dubai, UAE", status: "Away", lastActive: "Yesterday" },
+  ]}
+/>
+
 ## Column visibility
 
 Control which columns render without editing the `headers` definition.

--- a/src/DataTable/Table.svelte
+++ b/src/DataTable/Table.svelte
@@ -94,21 +94,23 @@
     </table>
   </section>
 {:else}
-  <table
-    aria-labelledby={ariaLabelledby}
-    aria-describedby={ariaDescribedby}
-    class:bx--data-table={true}
-    class:bx--data-table--compact={size === "compact"}
-    class:bx--data-table--short={size === "short"}
-    class:bx--data-table--tall={size === "tall"}
-    class:bx--data-table--md={size === "medium"}
-    class:bx--data-table--sort={sortable}
-    class:bx--data-table--zebra={zebra}
-    class:bx--data-table--static={useStaticWidth}
-    class:bx--data-table--sticky-header={stickyHeader}
-    {...$$restProps}
-    style={tableStyle}
-  >
-    <slot />
-  </table>
+  <div class:bx--data-table-content={true}>
+    <table
+      aria-labelledby={ariaLabelledby}
+      aria-describedby={ariaDescribedby}
+      class:bx--data-table={true}
+      class:bx--data-table--compact={size === "compact"}
+      class:bx--data-table--short={size === "short"}
+      class:bx--data-table--tall={size === "tall"}
+      class:bx--data-table--md={size === "medium"}
+      class:bx--data-table--sort={sortable}
+      class:bx--data-table--zebra={zebra}
+      class:bx--data-table--static={useStaticWidth}
+      class:bx--data-table--sticky-header={stickyHeader}
+      {...$$restProps}
+      style={tableStyle}
+    >
+      <slot />
+    </table>
+  </div>
 {/if}

--- a/tests/DataTable/DataTable.test.ts
+++ b/tests/DataTable/DataTable.test.ts
@@ -1486,6 +1486,27 @@ describe("DataTable", () => {
     });
   });
 
+  describe("horizontal scroll wrapper", () => {
+    it("wraps the table in a bx--data-table-content element", () => {
+      render(DataTable, { props: { headers, rows } });
+
+      const table = screen.getByRole("table");
+      const wrapper = table.parentElement;
+      expect(wrapper).toHaveClass("bx--data-table-content");
+      expect(wrapper).not.toHaveAttribute("tabindex");
+    });
+
+    it("does not add the wrapper when stickyHeader is enabled", () => {
+      const { container } = render(DataTable, {
+        props: { headers, rows, stickyHeader: true },
+      });
+
+      expect(
+        container.querySelector(".bx--data-table-content"),
+      ).not.toBeInTheDocument();
+    });
+  });
+
   it("handles static width", () => {
     const { container } = render(DataTable, {
       props: {
@@ -2850,8 +2871,10 @@ describe("DataTable", () => {
       const tbody = container.querySelector("tbody");
       expect(tbody).toBeInTheDocument();
 
-      // When not using sticky header, the scroll container (table's parent) has max-height
-      const scrollContainer = table.parentElement;
+      // When not using sticky header, the scroll container (table's
+      // grandparent — the parent is Table's own `bx--data-table-content`
+      // horizontal-scroll wrapper) has max-height
+      const scrollContainer = table.parentElement?.parentElement;
       if (
         scrollContainer &&
         !container.querySelector(".bx--data-table_inner-container")
@@ -3195,7 +3218,9 @@ describe("DataTable", () => {
       await tick();
 
       const table = screen.getByRole("table");
-      const scrollContainer = table.parentElement;
+      // The table's direct parent is Table's own `bx--data-table-content`
+      // horizontal-scroll wrapper; the scroll container is one level up.
+      const scrollContainer = table.parentElement?.parentElement;
       expect(scrollContainer).toBeInstanceOf(HTMLElement);
       expect(scrollContainer?.style.overflowY).toBe("auto");
       expect(scrollContainer?.style.maxHeight).toBeDefined();
@@ -3231,7 +3256,7 @@ describe("DataTable", () => {
       expect(screen.getByText("Load Balancer 1")).toBeInTheDocument();
 
       const table = screen.getByRole("table");
-      const scrollContainer = table.parentElement;
+      const scrollContainer = table.parentElement?.parentElement;
       expect.assert(scrollContainer instanceof HTMLElement);
       scrollContainer.scrollTop = 48 * 40;
       scrollContainer.dispatchEvent(new Event("scroll"));


### PR DESCRIPTION
Non-sticky-header tables never rendered `bx--data-table-content`, so
the vendored `overflow-x: auto` and focus-outline rules were
unreachable and wide tables had no way to scroll. The new wrapper is
`tabindex="0"` so the scrollable region stays keyboard-reachable, per
the same `:focus` rule the CSS already shipped.

Sticky-header tables are unaffected; they already scroll via their
own flex layout. Adds a docs example wide enough to demonstrate the
scroll at normal viewport widths, since the existing fixtures all
comfortably fit within their containers.