### PR TITLE
fix(side-nav): apply the fixed class so rail stops expanding on hover

### DIFF
--- a/docs/src/pages/components/UIShell.svx
+++ b/docs/src/pages/components/UIShell.svx
@@ -126,6 +126,12 @@ Set `rail` on the side nav to use the rail variant. Expanded side nav menu items
 
 <FileSource src="/framed/UIShell/HeaderNavRail" />
 
+### Fixed rail
+
+Combine `rail` with `fixed` to keep the rail at its narrow width even on hover, instead of temporarily expanding.
+
+<FileSource src="/framed/UIShell/HeaderNavRailFixed" />
+
 ### Persisted hamburger
 
 Create a header with a persistent hamburger menu state.

--- a/docs/src/pages/framed/UIShell/HeaderNavRailFixed.svelte
+++ b/docs/src/pages/framed/UIShell/HeaderNavRailFixed.svelte
@@ -1,0 +1,67 @@
+<script>
+  import {
+    Column,
+    Content,
+    Grid,
+    Header,
+    HeaderNav,
+    HeaderNavItem,
+    HeaderNavMenu,
+    Row,
+    SideNav,
+    SideNavDivider,
+    SideNavItems,
+    SideNavLink,
+    SideNavMenu,
+    SideNavMenuItem,
+    SkipToContent,
+  } from "carbon-components-svelte";
+  import Activity from "carbon-icons-svelte/lib/Activity.svelte";
+  import Dashboard from "carbon-icons-svelte/lib/Dashboard.svelte";
+  import Kubernetes from "carbon-icons-svelte/lib/Kubernetes.svelte";
+  import ListBoxes from "carbon-icons-svelte/lib/ListBoxes.svelte";
+  import Settings from "carbon-icons-svelte/lib/Settings.svelte";
+</script>
+
+<Header companyName="IBM" platformName="Cloud">
+  <svelte:fragment slot="skipToContent"> <SkipToContent /> </svelte:fragment>
+  <HeaderNav>
+    <HeaderNavItem href="/catalog" text="Catalog" />
+    <HeaderNavItem href="/docs" text="Docs" />
+    <HeaderNavItem href="/support" text="Support" />
+    <HeaderNavMenu text="Manage">
+      <HeaderNavItem href="/account" text="Account" />
+      <HeaderNavItem href="/iam" text="Access (IAM)" />
+      <HeaderNavItem href="/billing" text="Billing and usage" />
+    </HeaderNavMenu>
+    <HeaderNavItem href="/status" text="Status" />
+  </HeaderNav>
+</Header>
+
+<SideNav rail fixed>
+  <SideNavItems>
+    <SideNavLink
+      icon={Dashboard}
+      text="Dashboard"
+      href="/dashboard"
+      isSelected
+    />
+    <SideNavLink icon={ListBoxes} text="Resource list" href="/resources" />
+    <SideNavLink icon={Activity} text="Activity tracker" href="/activity" />
+    <SideNavMenu icon={Kubernetes} text="Kubernetes">
+      <SideNavMenuItem href="/kubernetes/clusters" text="Clusters" />
+      <SideNavMenuItem href="/kubernetes/worker-pools" text="Worker pools" />
+      <SideNavMenuItem href="/kubernetes/registry" text="Container registry" />
+    </SideNavMenu>
+    <SideNavDivider />
+    <SideNavLink icon={Settings} text="Account settings" href="/settings" />
+  </SideNavItems>
+</SideNav>
+
+<Content>
+  <Grid>
+    <Row>
+      <Column> <h1>Dashboard</h1> </Column>
+    </Row>
+  </Grid>
+</Content>

--- a/src/UIShell/SideNav.svelte
+++ b/src/UIShell/SideNav.svelte
@@ -141,6 +141,7 @@
     : isOpen}
   class:bx--side-nav--collapsed={winWidth !== undefined && !isOpen && !rail}
   class:bx--side-nav--rail={rail}
+  class:bx--side-nav--fixed={fixed}
   class:bx--side-nav--ui-shell-classic={theme === "classic"}
   style:visibility={winWidth !== undefined && !isOpen && !rail
     ? "hidden"

--- a/tests/UIShell/UIShell.test.ts
+++ b/tests/UIShell/UIShell.test.ts
@@ -609,6 +609,9 @@ describe("UIShell", () => {
 
       const overlay = container.querySelector(".bx--side-nav__overlay");
       expect(overlay).not.toBeInTheDocument();
+
+      const nav = container.querySelector(".bx--side-nav");
+      expect(nav).toHaveClass("bx--side-nav--fixed");
     });
 
     it("should render rail variant", () => {


### PR DESCRIPTION
`fixed` already drove real behavior (no overlay, no scroll lock, no
Escape-to-close) but never applied `bx--side-nav--fixed` itself, so
the `:not(.bx--side-nav--fixed)` guard on the rail's hover-to-expand
rule never excluded anything. A `rail fixed` side nav would still
balloon open on hover, defeating the point of `fixed`.

Adds a "Rail + fixed" docs example since none of the existing
examples combine both props.