### PR TITLE
fix(ui-shell): add isSelected to HeaderPanelLink, fix panel theming

### DIFF
--- a/css/_ui-shell.scss
+++ b/css/_ui-shell.scss
@@ -468,12 +468,26 @@
     background: $border-subtle;
   }
 
+  // The vendored rule vertically centers text with fixed padding against
+  // the type style's line-height, which drifts a few px off-center in
+  // practice. Flexbox centers it exactly regardless of line-height.
   .#{$prefix}--switcher__item-link.#{$prefix}--switcher__item-link {
+    display: flex;
+    align-items: center;
     color: $text-secondary;
   }
 
   .#{$prefix}--switcher__item-link.#{$prefix}--switcher__item-link:hover:not(.#{$prefix}--switcher__item-link--selected.#{$prefix}--switcher__item-link--selected) {
     background: $background-hover;
+    color: $text-primary;
+  }
+
+  // Overrides the vendored rule's hardcoded dark background/text
+  // ($shell-panel-bg-04/$shell-panel-text-02, from _theme.scss), which
+  // never adapts to the page theme. $layer-selected matches the token
+  // SideNavLink's [aria-current='page'] state already uses.
+  .#{$prefix}--switcher__item-link--selected.#{$prefix}--switcher__item-link--selected {
+    background: $layer-selected;
     color: $text-primary;
   }
 

--- a/docs/src/pages/components/UIShell.svx
+++ b/docs/src/pages/components/UIShell.svx
@@ -169,6 +169,8 @@ Control tooltip alignment with `tooltipAlignment`. Providing button text overrid
 
 Compose the panel content from `HeaderPanelLinks`, `HeaderPanelDivider`, and `HeaderPanelLink`, as shown in both examples above. `HeaderPanelLinks` renders the list wrapper; `HeaderPanelDivider` renders a labelled separator (or a plain rule when it has no content) between groups of links; `HeaderPanelLink` renders each item. The same three components compose the notification and help panels in the multiple-switchers example — panel composition is not specific to the app switcher icon.
 
+Set `isSelected` on `HeaderPanelLink` to mark the current selection — see "Cloud console" in the app switcher example above. It adds `aria-current="page"` and a persistent highlight style, the same pattern used by `isSelected` on `HeaderNavItem`, `SideNavLink`, and `SideNavMenuItem`.
+
 ### Events
 
 `HeaderAction` dispatches `open` and `close` as the panel toggles, with `event.detail.trigger` set to `"toggle"`, `"outside-click"`, or `"escape-key"`. Set `preventCloseOnClickOutside` to keep the panel open when the user clicks elsewhere on the page — useful when the panel hosts its own dismiss controls.

--- a/docs/src/pages/framed/UIShell/HeaderSwitcher.svelte
+++ b/docs/src/pages/framed/UIShell/HeaderSwitcher.svelte
@@ -46,7 +46,9 @@
     <HeaderAction bind:isOpen transition={transitions[selected].value}>
       <HeaderPanelLinks>
         <HeaderPanelDivider>Switch product</HeaderPanelDivider>
-        <HeaderPanelLink href="/cloud">Cloud console</HeaderPanelLink>
+        <HeaderPanelLink href="/cloud" isSelected
+          >Cloud console</HeaderPanelLink
+        >
         <HeaderPanelLink href="/watson-studio">Watson Studio</HeaderPanelLink>
         <HeaderPanelLink href="/maximo"
           >Maximo Application Suite</HeaderPanelLink

--- a/src/UIShell/HeaderPanelLink.svelte
+++ b/src/UIShell/HeaderPanelLink.svelte
@@ -5,6 +5,9 @@
    */
   export let href = undefined;
 
+  /** Set to `true` to mark the link as the current selection */
+  export let isSelected = false;
+
   /**
    * Obtain a reference to the HTML anchor element.
    * @bindable readonly
@@ -17,7 +20,9 @@
     bind:this={ref}
     {href}
     rel={$$restProps.target === "_blank" ? "noopener noreferrer" : undefined}
+    aria-current={isSelected ? "page" : undefined}
     class:bx--switcher__item-link={true}
+    class:bx--switcher__item-link--selected={isSelected}
     {...$$restProps}
     on:click
   >

--- a/tests/UIShell/HeaderSwitcher.test.svelte
+++ b/tests/UIShell/HeaderSwitcher.test.svelte
@@ -29,7 +29,7 @@
         <HeaderPanelLink>Switcher item 1</HeaderPanelLink>
         <HeaderPanelDivider />
         <HeaderPanelDivider>Switcher subject 2</HeaderPanelDivider>
-        <HeaderPanelLink>Switcher item 1</HeaderPanelLink>
+        <HeaderPanelLink isSelected>Switcher item 1</HeaderPanelLink>
         <HeaderPanelLink>Switcher item 2</HeaderPanelLink>
         <HeaderPanelLink>Switcher item 3</HeaderPanelLink>
         <HeaderPanelLink>Switcher item 4</HeaderPanelLink>

--- a/tests/UIShell/UIShell.test.ts
+++ b/tests/UIShell/UIShell.test.ts
@@ -373,6 +373,29 @@ describe("UIShell", () => {
       expect(hr.parentElement?.tagName).toBe("LI");
     });
 
+    it("marks a HeaderPanelLink as selected", async () => {
+      const { container } = render(HeaderSwitcher);
+
+      const trigger = container.querySelector(
+        'button.bx--header__action[aria-haspopup="true"]',
+      );
+      assert(trigger);
+      await user.click(trigger);
+
+      const selected = container.querySelector(
+        ".bx--switcher__item-link--selected",
+      );
+      assert(selected);
+      expect(selected).toHaveAttribute("aria-current", "page");
+
+      const links = container.querySelectorAll(".bx--switcher__item-link");
+      for (const link of links) {
+        if (link !== selected) {
+          expect(link).not.toHaveAttribute("aria-current");
+        }
+      }
+    });
+
     it("renders HeaderUtilities fixture", () => {
       const { container } = render(HeaderUtilities);
 


### PR DESCRIPTION
HeaderPanelLink was the one component missing the isSelected/
aria-current convention already shared by HeaderNavItem, SideNavLink,
and SideNavMenuItem. Applying it surfaced two more bugs in the
vendored switcher CSS: the selected state's background/text came
from hardcoded literal hex values that never adapted to the page
theme (now uses the same $layer-selected/$text-primary tokens
SideNavLink's current-page state uses), and item link text was
vertically centered via fixed padding balanced against the type
style's line-height, which drifted off-center (switched to flexbox
centering).

---

<img width="437" height="246" alt="Screenshot 2026-08-21 at 4 24 03 PM" src="https://github.com/user-attachments/assets/e913357e-be96-4464-8724-55b2388e4b69" />
