### PR TITLE
docs(user-avatar): add carbon-icons-svelte examples

### DIFF
--- a/docs/src/pages/components/UserAvatar.svx
+++ b/docs/src/pages/components/UserAvatar.svx
@@ -6,6 +6,9 @@ description: User avatars display a photo, a custom icon, or initials derived fr
 <script>
   import { UserAvatar } from "carbon-components-svelte";
   import UserAvatarFilledAlt from "carbon-icons-svelte/lib/UserAvatarFilledAlt.svelte";
+  import Bot from "carbon-icons-svelte/lib/Bot.svelte";
+  import Password from "carbon-icons-svelte/lib/Password.svelte";
+  import Group from "carbon-icons-svelte/lib/Group.svelte";
 </script>
 
 ## Content
@@ -31,9 +34,17 @@ Set `initials` to override the derived initials while keeping `name` for display
 
 ### Custom icon
 
-Set `icon` to render a custom icon instead of the default user icon.
+Set `icon` to render a custom icon instead of the default user icon, such as an icon from [carbon-icons-svelte](https://github.com/carbon-design-system/carbon-icons-svelte).
 
 <UserAvatar icon={UserAvatarFilledAlt} />
+<UserAvatar icon={Bot} backgroundColor="purple" />
+<UserAvatar icon={Password} backgroundColor="teal" />
+<UserAvatar icon={Group} backgroundColor="cool-gray" />
+
+<UserAvatar size="sm" icon={Bot} backgroundColor="purple" />
+<UserAvatar size="md" icon={Bot} backgroundColor="purple" />
+<UserAvatar size="lg" icon={Bot} backgroundColor="purple" />
+<UserAvatar size="xl" icon={Bot} backgroundColor="purple" />
 
 ### Custom content
 

--- a/docs/src/pages/components/UserAvatarGroup.svx
+++ b/docs/src/pages/components/UserAvatarGroup.svx
@@ -5,6 +5,9 @@ description: A row of overlapping or spaced user avatars. Extras fold into a "+N
 
 <script>
   import { UserAvatar, UserAvatarGroup } from "carbon-components-svelte";
+  import Bot from "carbon-icons-svelte/lib/Bot.svelte";
+  import Password from "carbon-icons-svelte/lib/Password.svelte";
+  import Group from "carbon-icons-svelte/lib/Group.svelte";
 </script>
 
 ## Basic
@@ -178,6 +181,16 @@ Photos, icons, and initials work the same as on a lone `UserAvatar`.
   <UserAvatar image="https://i.pravatar.cc/150?img=33" imageDescription="Dinesh Chugtai" tooltipText="Dinesh Chugtai" />
   <UserAvatar backgroundColor="auto" name="Bertram Gilfoyle" tooltipText="Bertram Gilfoyle" />
   <UserAvatar backgroundColor="auto" name="Jared Dunn" tooltipText="Jared Dunn" />
+</UserAvatarGroup>
+
+## Icons
+
+Set `icon` on each avatar to render a custom icon, such as one from [carbon-icons-svelte](https://github.com/carbon-design-system/carbon-icons-svelte), instead of a photo or initials.
+
+<UserAvatarGroup>
+  <UserAvatar icon={Bot} backgroundColor="purple" tooltipText="Bot" />
+  <UserAvatar icon={Password} backgroundColor="teal" tooltipText="Password" />
+  <UserAvatar icon={Group} backgroundColor="cool-gray" tooltipText="Group" />
 </UserAvatarGroup>
 
 ## Background colors


### PR DESCRIPTION
Adds carbon-icons-svelte examples to UserAvatar's custom icon section
and a new size row, plus a matching icons example on
UserAvatarGroup.