### PR TITLE
feat(ui-shell): add large prop to SideNavLink and SideNavMenu

### DIFF
--- a/css/_ui-shell.scss
+++ b/css/_ui-shell.scss
@@ -528,6 +528,21 @@
     overflow-y: auto;
   }
 
+  // At the rail's narrow (48px) width, an overflowing item list needs to
+  // scroll, but an OS scrollbar (particularly an overlay one, as on macOS)
+  // renders directly on top of the icon column with no room to spare.
+  // Keep scrolling but hide the scrollbar chrome, same technique the
+  // sticky-header data table uses for the same reason.
+  .#{$prefix}--side-nav--rail:not(:hover):not(.#{$prefix}--side-nav--expanded)
+    .#{$prefix}--side-nav__items.#{$prefix}--side-nav__items {
+    scrollbar-width: none;
+    -ms-overflow-style: none;
+
+    &::-webkit-scrollbar {
+      display: none;
+    }
+  }
+
   .#{$prefix}--side-nav__divider.#{$prefix}--side-nav__divider {
     margin: 0.5rem 1rem; // $spacing-03 $spacing-05
     background-color: $border-subtle;

--- a/css/_ui-shell.scss
+++ b/css/_ui-shell.scss
@@ -535,6 +535,21 @@
     overflow-y: auto;
   }
 
+  // At the rail's narrow (48px) width, an overflowing item list needs to
+  // scroll, but an OS scrollbar (particularly an overlay one, as on macOS)
+  // renders directly on top of the icon column with no room to spare.
+  // Keep scrolling but hide the scrollbar chrome, same technique the
+  // sticky-header data table uses for the same reason.
+  .#{$prefix}--side-nav--rail:not(:hover):not(.#{$prefix}--side-nav--expanded)
+    .#{$prefix}--side-nav__items.#{$prefix}--side-nav__items {
+    scrollbar-width: none;
+    -ms-overflow-style: none;
+
+    &::-webkit-scrollbar {
+      display: none;
+    }
+  }
+
   .#{$prefix}--side-nav__divider.#{$prefix}--side-nav__divider {
     margin: 0.5rem 1rem; // $spacing-03 $spacing-05
     background-color: $border-subtle;

--- a/css/vendor/carbon-components/scss/components/ui-shell/_side-nav.scss
+++ b/css/vendor/carbon-components/scss/components/ui-shell/_side-nav.scss
@@ -205,6 +205,10 @@
     color: $ibm-color__gray-100;
   }
 
+  .#{$prefix}--side-nav__item--large {
+    height: mini-units(6);
+  }
+
   .#{$prefix}--side-nav__divider {
     height: 1px;
     margin: $spacing-03 $spacing-05;
@@ -260,6 +264,10 @@
     transform: rotate(180deg);
   }
 
+  .#{$prefix}--side-nav__item--large .#{$prefix}--side-nav__submenu {
+    height: mini-units(6);
+  }
+
   .#{$prefix}--side-nav__menu {
     display: block;
     max-height: 0;
@@ -310,6 +318,10 @@
     text-decoration: none;
     transition: color $duration--fast-02, background-color $duration--fast-02,
       outline $duration--fast-02;
+  }
+
+  .#{$prefix}--side-nav__item--large a.#{$prefix}--side-nav__link {
+    height: mini-units(6);
   }
 
   a.#{$prefix}--side-nav__link > .#{$prefix}--side-nav__link-text {

--- a/docs/src/pages/components/UIShell.svx
+++ b/docs/src/pages/components/UIShell.svx
@@ -94,6 +94,12 @@ In the [rail](#rail) variant, an expanded `SideNavMenu` automatically collapses 
 
 Set `isSelected` on `SideNavLink` or `SideNavMenuItem` to mark the current page — see "Dashboard" in the example above. It adds `aria-current="page"` and a persistent highlight style so the current location stays visible even while hovering other items.
 
+### Large
+
+Set `large` on `SideNavLink` or `SideNavMenu` to increase the item's height from 32px to 48px — useful for a top-level item that should stand out, or for larger touch targets. Not available on `SideNavMenuItem` (nested items). Composes with `icon` on both components.
+
+<FileSource src="/framed/UIShell/HeaderNavLarge" />
+
 ### Responsive
 
 On smaller screens, header links belong in the side nav, above the regular side nav items.
@@ -131,6 +137,12 @@ Set `rail` on the side nav to use the rail variant. Expanded side nav menu items
 Combine `rail` with `fixed` to keep the rail at its narrow width even on hover, instead of temporarily expanding.
 
 <FileSource src="/framed/UIShell/HeaderNavRailFixed" />
+
+### Rail + large
+
+`large` composes with `rail`, including its narrow, icon-only state.
+
+<FileSource src="/framed/UIShell/HeaderNavRailLarge" />
 
 ### Persisted hamburger
 

--- a/docs/src/pages/components/UIShell.svx
+++ b/docs/src/pages/components/UIShell.svx
@@ -94,6 +94,12 @@ In the [rail](#rail) variant, an expanded `SideNavMenu` automatically collapses 
 
 Set `isSelected` on `SideNavLink` or `SideNavMenuItem` to mark the current page — see "Dashboard" in the example above. It adds `aria-current="page"` and a persistent highlight style so the current location stays visible even while hovering other items.
 
+### Large
+
+Set `large` on `SideNavLink` or `SideNavMenu` to increase the item's height from 32px to 48px — useful for a top-level item that should stand out, or for larger touch targets. Not available on `SideNavMenuItem` (nested items). Composes with `icon` on both components.
+
+<FileSource src="/framed/UIShell/HeaderNavLarge" />
+
 ### Responsive
 
 On smaller screens, header links belong in the side nav, above the regular side nav items.
@@ -125,6 +131,12 @@ Set `fixed` on the side nav to keep it always visible, regardless of viewport wi
 Set `rail` on the side nav to use the rail variant. Expanded side nav menu items automatically collapse when the rail is in its narrow state.
 
 <FileSource src="/framed/UIShell/HeaderNavRail" />
+
+### Rail + large
+
+`large` composes with `rail`, including its narrow, icon-only state.
+
+<FileSource src="/framed/UIShell/HeaderNavRailLarge" />
 
 ### Persisted hamburger
 

--- a/docs/src/pages/framed/UIShell/HeaderNavLarge.svelte
+++ b/docs/src/pages/framed/UIShell/HeaderNavLarge.svelte
@@ -1,0 +1,85 @@
+<script>
+  import {
+    Column,
+    Content,
+    Grid,
+    Header,
+    HeaderNav,
+    HeaderNavItem,
+    HeaderNavMenu,
+    Row,
+    SideNav,
+    SideNavDivider,
+    SideNavItems,
+    SideNavLink,
+    SideNavMenu,
+    SideNavMenuItem,
+    SkipToContent,
+  } from "carbon-components-svelte";
+  import Activity from "carbon-icons-svelte/lib/Activity.svelte";
+  import Dashboard from "carbon-icons-svelte/lib/Dashboard.svelte";
+  import Kubernetes from "carbon-icons-svelte/lib/Kubernetes.svelte";
+  import ListBoxes from "carbon-icons-svelte/lib/ListBoxes.svelte";
+  import Settings from "carbon-icons-svelte/lib/Settings.svelte";
+
+  let isSideNavOpen = false;
+</script>
+
+<Header companyName="IBM" platformName="Cloud" bind:isSideNavOpen>
+  <svelte:fragment slot="skipToContent"> <SkipToContent /> </svelte:fragment>
+  <HeaderNav>
+    <HeaderNavItem href="/catalog" text="Catalog" />
+    <HeaderNavItem href="/docs" text="Docs" />
+    <HeaderNavItem href="/support" text="Support" />
+    <HeaderNavMenu text="Manage">
+      <HeaderNavItem href="/account" text="Account" />
+      <HeaderNavItem href="/iam" text="Access (IAM)" />
+      <HeaderNavItem href="/billing" text="Billing and usage" />
+    </HeaderNavMenu>
+    <HeaderNavItem href="/status" text="Status" />
+  </HeaderNav>
+</Header>
+
+<SideNav bind:isOpen={isSideNavOpen}>
+  <SideNavItems>
+    <SideNavLink
+      large
+      icon={Dashboard}
+      href="/dashboard"
+      text="Dashboard"
+      isSelected
+    />
+    <SideNavLink
+      large
+      icon={ListBoxes}
+      href="/resources"
+      text="Resource list"
+    />
+    <SideNavLink
+      large
+      icon={Activity}
+      href="/activity"
+      text="Activity tracker"
+    />
+    <SideNavMenu large icon={Kubernetes} text="Kubernetes">
+      <SideNavMenuItem href="/kubernetes/clusters" text="Clusters" />
+      <SideNavMenuItem href="/kubernetes/worker-pools" text="Worker pools" />
+      <SideNavMenuItem href="/kubernetes/registry" text="Container registry" />
+    </SideNavMenu>
+    <SideNavDivider />
+    <SideNavLink
+      large
+      icon={Settings}
+      href="/settings"
+      text="Account settings"
+    />
+  </SideNavItems>
+</SideNav>
+
+<Content>
+  <Grid>
+    <Row>
+      <Column> <h1>Dashboard</h1> </Column>
+    </Row>
+  </Grid>
+</Content>

--- a/docs/src/pages/framed/UIShell/HeaderNavRailLarge.svelte
+++ b/docs/src/pages/framed/UIShell/HeaderNavRailLarge.svelte
@@ -1,0 +1,85 @@
+<script>
+  import {
+    Column,
+    Content,
+    Grid,
+    Header,
+    HeaderNav,
+    HeaderNavItem,
+    HeaderNavMenu,
+    Row,
+    SideNav,
+    SideNavDivider,
+    SideNavItems,
+    SideNavLink,
+    SideNavMenu,
+    SideNavMenuItem,
+    SkipToContent,
+  } from "carbon-components-svelte";
+  import Activity from "carbon-icons-svelte/lib/Activity.svelte";
+  import Dashboard from "carbon-icons-svelte/lib/Dashboard.svelte";
+  import Kubernetes from "carbon-icons-svelte/lib/Kubernetes.svelte";
+  import ListBoxes from "carbon-icons-svelte/lib/ListBoxes.svelte";
+  import Settings from "carbon-icons-svelte/lib/Settings.svelte";
+
+  let isSideNavOpen = false;
+</script>
+
+<Header companyName="IBM" platformName="Cloud" bind:isSideNavOpen>
+  <svelte:fragment slot="skipToContent"> <SkipToContent /> </svelte:fragment>
+  <HeaderNav>
+    <HeaderNavItem href="/catalog" text="Catalog" />
+    <HeaderNavItem href="/docs" text="Docs" />
+    <HeaderNavItem href="/support" text="Support" />
+    <HeaderNavMenu text="Manage">
+      <HeaderNavItem href="/account" text="Account" />
+      <HeaderNavItem href="/iam" text="Access (IAM)" />
+      <HeaderNavItem href="/billing" text="Billing and usage" />
+    </HeaderNavMenu>
+    <HeaderNavItem href="/status" text="Status" />
+  </HeaderNav>
+</Header>
+
+<SideNav bind:isOpen={isSideNavOpen} rail>
+  <SideNavItems>
+    <SideNavLink
+      large
+      icon={Dashboard}
+      text="Dashboard"
+      href="/dashboard"
+      isSelected
+    />
+    <SideNavLink
+      large
+      icon={ListBoxes}
+      text="Resource list"
+      href="/resources"
+    />
+    <SideNavLink
+      large
+      icon={Activity}
+      text="Activity tracker"
+      href="/activity"
+    />
+    <SideNavMenu large expanded icon={Kubernetes} text="Kubernetes">
+      <SideNavMenuItem href="/kubernetes/clusters" text="Clusters" />
+      <SideNavMenuItem href="/kubernetes/worker-pools" text="Worker pools" />
+      <SideNavMenuItem href="/kubernetes/registry" text="Container registry" />
+    </SideNavMenu>
+    <SideNavDivider />
+    <SideNavLink
+      large
+      icon={Settings}
+      text="Account settings"
+      href="/settings"
+    />
+  </SideNavItems>
+</SideNav>
+
+<Content>
+  <Grid>
+    <Row>
+      <Column> <h1>Dashboard</h1> </Column>
+    </Row>
+  </Grid>
+</Content>

--- a/src/UIShell/SideNavLink.svelte
+++ b/src/UIShell/SideNavLink.svelte
@@ -6,6 +6,9 @@
   /** Set to `true` to select the current link */
   export let isSelected = false;
 
+  /** Set to `true` to use the large variant */
+  export let large = false;
+
   /**
    * Specify the `href` attribute.
    * @type {string}
@@ -31,7 +34,7 @@
   export let ref = null;
 </script>
 
-<li class:bx--side-nav__item={true}>
+<li class:bx--side-nav__item={true} class:bx--side-nav__item--large={large}>
   <a
     bind:this={ref}
     aria-current={isSelected ? "page" : undefined}

--- a/src/UIShell/SideNavMenu.svelte
+++ b/src/UIShell/SideNavMenu.svelte
@@ -9,6 +9,9 @@
    */
   export let expanded = false;
 
+  /** Set to `true` to use the large variant */
+  export let large = false;
+
   /**
    * Specify the text.
    * @type {string}
@@ -35,7 +38,11 @@
   }
 </script>
 
-<li class:bx--side-nav__item={true} class:bx--side-nav__item--icon={icon}>
+<li
+  class:bx--side-nav__item={true}
+  class:bx--side-nav__item--icon={icon}
+  class:bx--side-nav__item--large={large}
+>
   <button
     type="button"
     bind:this={ref}

--- a/tests/UIShell/UIShell.test.ts
+++ b/tests/UIShell/UIShell.test.ts
@@ -4,7 +4,9 @@ import type HeaderComponent from "carbon-components-svelte/UIShell/Header.svelte
 import type HeaderActionLinkComponent from "carbon-components-svelte/UIShell/HeaderActionLink.svelte";
 import type HeaderGlobalActionComponent from "carbon-components-svelte/UIShell/HeaderGlobalAction.svelte";
 import type SideNavLinkComponent from "carbon-components-svelte/UIShell/SideNavLink.svelte";
+import SideNavLink from "carbon-components-svelte/UIShell/SideNavLink.svelte";
 import type SideNavMenuComponent from "carbon-components-svelte/UIShell/SideNavMenu.svelte";
+import SideNavMenu from "carbon-components-svelte/UIShell/SideNavMenu.svelte";
 import type { ComponentProps } from "svelte";
 import { user } from "../utils/user";
 import HeaderSlot from "./Header.slot.test.svelte";
@@ -978,6 +980,26 @@ describe("UIShell", () => {
     });
 
     describe("SideNavLink", () => {
+      it("should apply the large class when large is true", () => {
+        const { container } = render(SideNavLink, {
+          props: { href: "#", text: "Link", large: true },
+        });
+
+        expect(container.querySelector(".bx--side-nav__item")).toHaveClass(
+          "bx--side-nav__item--large",
+        );
+      });
+
+      it("should not apply the large class by default", () => {
+        const { container } = render(SideNavLink, {
+          props: { href: "#", text: "Link" },
+        });
+
+        expect(container.querySelector(".bx--side-nav__item")).not.toHaveClass(
+          "bx--side-nav__item--large",
+        );
+      });
+
       it("should support custom Icon types with generics", () => {
         type CustomIcon = new (...args: unknown[]) => unknown;
 
@@ -997,6 +1019,26 @@ describe("UIShell", () => {
     });
 
     describe("SideNavMenu", () => {
+      it("should apply the large class when large is true", () => {
+        const { container } = render(SideNavMenu, {
+          props: { text: "Menu", large: true },
+        });
+
+        expect(container.querySelector(".bx--side-nav__item")).toHaveClass(
+          "bx--side-nav__item--large",
+        );
+      });
+
+      it("should not apply the large class by default", () => {
+        const { container } = render(SideNavMenu, {
+          props: { text: "Menu" },
+        });
+
+        expect(container.querySelector(".bx--side-nav__item")).not.toHaveClass(
+          "bx--side-nav__item--large",
+        );
+      });
+
       it("should support custom Icon types with generics", () => {
         type CustomIcon = new (...args: unknown[]) => unknown;
 

--- a/tests/UIShell/UIShell.test.ts
+++ b/tests/UIShell/UIShell.test.ts
@@ -4,7 +4,9 @@ import type HeaderComponent from "carbon-components-svelte/UIShell/Header.svelte
 import type HeaderActionLinkComponent from "carbon-components-svelte/UIShell/HeaderActionLink.svelte";
 import type HeaderGlobalActionComponent from "carbon-components-svelte/UIShell/HeaderGlobalAction.svelte";
 import type SideNavLinkComponent from "carbon-components-svelte/UIShell/SideNavLink.svelte";
+import SideNavLink from "carbon-components-svelte/UIShell/SideNavLink.svelte";
 import type SideNavMenuComponent from "carbon-components-svelte/UIShell/SideNavMenu.svelte";
+import SideNavMenu from "carbon-components-svelte/UIShell/SideNavMenu.svelte";
 import type { ComponentProps } from "svelte";
 import { user } from "../utils/user";
 import HeaderSlot from "./Header.slot.test.svelte";
@@ -1004,6 +1006,26 @@ describe("UIShell", () => {
     });
 
     describe("SideNavLink", () => {
+      it("should apply the large class when large is true", () => {
+        const { container } = render(SideNavLink, {
+          props: { href: "#", text: "Link", large: true },
+        });
+
+        expect(container.querySelector(".bx--side-nav__item")).toHaveClass(
+          "bx--side-nav__item--large",
+        );
+      });
+
+      it("should not apply the large class by default", () => {
+        const { container } = render(SideNavLink, {
+          props: { href: "#", text: "Link" },
+        });
+
+        expect(container.querySelector(".bx--side-nav__item")).not.toHaveClass(
+          "bx--side-nav__item--large",
+        );
+      });
+
       it("should support custom Icon types with generics", () => {
         type CustomIcon = new (...args: unknown[]) => unknown;
 
@@ -1023,6 +1045,26 @@ describe("UIShell", () => {
     });
 
     describe("SideNavMenu", () => {
+      it("should apply the large class when large is true", () => {
+        const { container } = render(SideNavMenu, {
+          props: { text: "Menu", large: true },
+        });
+
+        expect(container.querySelector(".bx--side-nav__item")).toHaveClass(
+          "bx--side-nav__item--large",
+        );
+      });
+
+      it("should not apply the large class by default", () => {
+        const { container } = render(SideNavMenu, {
+          props: { text: "Menu" },
+        });
+
+        expect(container.querySelector(".bx--side-nav__item")).not.toHaveClass(
+          "bx--side-nav__item--large",
+        );
+      });
+
       it("should support custom Icon types with generics", () => {
         type CustomIcon = new (...args: unknown[]) => unknown;
 


### PR DESCRIPTION
bx--side-nav__item--large already existed in the vendored CSS (32px
to 48px item height) but no component ever applied it. Adds a large
prop to SideNavLink and SideNavMenu, matching the class's only two
targets; SideNavMenuItem (nested items) has no corresponding rule so
it's intentionally left out.

Also hides the scrollbar on the rail's narrow (48px) item list: with
enough items to overflow, an OS scrollbar has no room to avoid
overlapping the icon column, same problem DataTable's sticky-header
already works around with the same technique.

---

<img width="827" height="472" alt="Screenshot 2026-08-30 at 1 12 00 PM" src="https://github.com/user-attachments/assets/df9317c7-8db5-493b-b075-af7d733734fb" />
<img width="756" height="506" alt="Screenshot 2026-08-30 at 1 11 54 PM" src="https://github.com/user-attachments/assets/db4bbedc-aa6d-4480-b79c-792a75bf2130" />
