### PR TITLE
fix(structured-list): suppress hover highlight on selected row

### DIFF
--- a/docs/src/pages/components/StructuredList.svx
+++ b/docs/src/pages/components/StructuredList.svx
@@ -122,6 +122,8 @@ Let users select one or more rows.
 
 Enable row selection with `selection` and structured list input components. The selection icon column is rendered automatically for each selectable row.
 
+Pass the same `value` to `StructuredListRow` as its nested `StructuredListInput` so the row can tell it's the current selection. This suppresses the hover highlight on an already-selected row.
+
 <StructuredList selection selected="postgresql-value">
   <StructuredListHead>
     <StructuredListRow head>
@@ -136,7 +138,7 @@ Enable row selection with `selection` and structured list input components. The 
       { id: "mongodb", name: "MongoDB", type: "Document", description: "Document-oriented NoSQL database designed for flexible schemas and horizontal scaling across distributed clusters." },
       { id: "redis", name: "Redis", type: "Key-value", description: "In-memory key-value store used as a cache, message broker, and real-time data platform with sub-millisecond latency." },
     ] as db}
-      <StructuredListRow label for={db.id}>
+      <StructuredListRow label for={db.id} value="{db.id}-value">
         <StructuredListCell>{db.name}</StructuredListCell>
         <StructuredListCell>{db.type}</StructuredListCell>
         <StructuredListCell>{db.description}</StructuredListCell>
@@ -168,7 +170,7 @@ Customize the selection icon with the `icon` prop on `StructuredList`.
       { id: "mongodb", name: "MongoDB", type: "Document" },
       { id: "redis", name: "Redis", type: "Key-value" },
     ] as db}
-      <StructuredListRow label for="icon-{db.id}">
+      <StructuredListRow label for="icon-{db.id}" value="{db.id}-value">
         <StructuredListCell>{db.name}</StructuredListCell>
         <StructuredListCell>{db.type}</StructuredListCell>
         <StructuredListInput
@@ -211,7 +213,7 @@ Allow selecting more than one row with `multiple`. Selected becomes an array of 
       { id: "mongodb", name: "MongoDB", type: "Document" },
       { id: "redis", name: "Redis", type: "Key-value" },
     ] as db}
-      <StructuredListRow label for="event-{db.id}">
+      <StructuredListRow label for="event-{db.id}" value="{db.id}-value">
         <StructuredListCell>{db.name}</StructuredListCell>
         <StructuredListCell>{db.type}</StructuredListCell>
         <StructuredListInput

--- a/docs/src/pages/framed/StructuredList/StructuredListMultiSelect.svelte
+++ b/docs/src/pages/framed/StructuredList/StructuredListMultiSelect.svelte
@@ -45,7 +45,7 @@
   </StructuredListHead>
   <StructuredListBody>
     {#each databases as db}
-      <StructuredListRow label for="multi-{db.id}">
+      <StructuredListRow label for="multi-{db.id}" value="{db.id}-value">
         <StructuredListCell>{db.name}</StructuredListCell>
         <StructuredListCell>{db.type}</StructuredListCell>
         <StructuredListCell>{db.description}</StructuredListCell>

--- a/src/StructuredList/StructuredListRow.svelte
+++ b/src/StructuredList/StructuredListRow.svelte
@@ -1,9 +1,22 @@
 <script>
+  /**
+   * @template {string} [Value=string]
+   */
+
   /** Set to `true` to use as a header */
   export let head = false;
 
   /** Set to `true` to render a label slot */
   export let label = false;
+
+  /**
+   * Specify the value of the nested `StructuredListInput`, so a selectable
+   * row can reflect its own selected state (e.g. suppressing the hover
+   * highlight when already selected). Only relevant when `selection` is
+   * `true` on the parent `StructuredList`.
+   * @type {Value}
+   */
+  export let value = undefined;
 
   /**
    * Specify the tabindex.
@@ -15,12 +28,22 @@
   export const tabindex = "0";
 
   import { getContext } from "svelte";
+  import { writable } from "svelte/store";
   import CheckmarkFilled from "../icons/CheckmarkFilled.svelte";
   import StructuredListCell from "./StructuredListCell.svelte";
 
   const ctx = getContext("carbon:StructuredListWrapper");
   const selection = ctx?.selection ?? false;
   const icon = ctx?.icon ?? CheckmarkFilled;
+  const multiple = ctx?.multiple ?? false;
+  // Standalone (no wrapper context) never matches, same as StructuredListInput.
+  const selectedValue = ctx?.selectedValue ?? writable(undefined);
+
+  $: isSelected =
+    value !== undefined &&
+    (multiple
+      ? Array.isArray($selectedValue) && $selectedValue.includes(value)
+      : $selectedValue === value);
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
@@ -30,6 +53,7 @@
   <label
     class:bx--structured-list-row={true}
     class:bx--structured-list-row--header-row={head}
+    class:bx--structured-list-row--selected={isSelected}
     {...$$restProps}
     on:click
     on:mouseover
@@ -49,6 +73,7 @@
     role={selection ? undefined : "row"}
     class:bx--structured-list-row={true}
     class:bx--structured-list-row--header-row={head}
+    class:bx--structured-list-row--selected={isSelected}
     {...$$restProps}
     on:click
     on:mouseover

--- a/tests/StructuredList/StructuredList.test.svelte
+++ b/tests/StructuredList/StructuredList.test.svelte
@@ -46,6 +46,7 @@
       <StructuredListRow
         label={selection}
         for={selection ? `row-${item}` : undefined}
+        value={selection ? `row-${item}-value` : undefined}
       >
         <StructuredListCell noWrap>Row {item}</StructuredListCell>
         <StructuredListCell>Row {item}</StructuredListCell>

--- a/tests/StructuredList/StructuredList.test.ts
+++ b/tests/StructuredList/StructuredList.test.ts
@@ -122,6 +122,23 @@ describe("StructuredList", () => {
     ).toHaveTextContent("Row 2");
   });
 
+  it("should apply the selected class only to the selected row", async () => {
+    const { container } = render(StructuredList, {
+      props: { selection: true, selected: "row-1-value" },
+    });
+
+    const rows = container.querySelectorAll(".bx--structured-list-row");
+    // rows[0] is the header row
+    expect(rows[1]).toHaveClass("bx--structured-list-row--selected");
+    expect(rows[2]).not.toHaveClass("bx--structured-list-row--selected");
+    expect(rows[3]).not.toHaveClass("bx--structured-list-row--selected");
+
+    await user.click(screen.getAllByRole("radio")[1]);
+
+    expect(rows[1]).not.toHaveClass("bx--structured-list-row--selected");
+    expect(rows[2]).toHaveClass("bx--structured-list-row--selected");
+  });
+
   it("should handle selection change", async () => {
     render(StructuredList, { props: { selection: true } });
 


### PR DESCRIPTION
bx--structured-list-row--selected exists purely as a :not() guard on
the hover rule (no standalone styling of its own), but
StructuredListRow never applied it, so hovering an already-selected
row still showed the same highlight as any other row.

Adds a value prop to StructuredListRow mirroring
StructuredListInput's existing value/context pattern, so the row can
tell whether it's the current selection.

---

<img width="861" height="241" alt="Screenshot 2026-08-21 at 4 21 08 PM" src="https://github.com/user-attachments/assets/4e4fb3ac-71c7-44b9-951d-154f6aacfacd" />
