### PR TITLE
chore(css): drop decorative SCSS comments

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -130,7 +130,14 @@ jobs:
       # are baked into the image at PLAYWRIGHT_BROWSERS_PATH).
       - run: bun ci --ignore-scripts
 
+      - uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        id: css
+        with:
+          path: css/*.css
+          key: css-${{ runner.os }}-${{ hashFiles('css/**/*.scss', 'scripts/build-css.ts', 'package.json', 'bun.lock') }}
+
       - name: Build CSS
+        if: steps.css.outputs.cache-hit != 'true'
         run: bun run build:css
 
       - name: E2E tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
         run: bun run build:docs
 
       - name: Build CSS
-        run: bun run build:css
+        run: bun run build:css:themes
 
       - name: Prune package.json
         run: bunx culls --preserve=svelte

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -468,15 +468,17 @@ A `css/_*.scss` partial ships only after a theme entry file imports it. Add `@im
 
 #### Rebuild
 
-**After editing any `.scss` under `css/`, you must run `bun build:css` locally:**
+**After editing any `.scss` under `css/`, you must rebuild CSS locally:**
 
 ```sh
 bun build:css
+# or, while iterating:
+bun build:css:watch
 ```
 
 The compiled `css/*.css` are **not** committed (they are gitignored) — but they are still required at runtime, so without this step your local docs site and e2e tests will use stale (or missing) styles. `bun setup` runs `build:css` once on a fresh clone, and CI/release run it on demand; neither helps an in-progress local edit.
 
-This compiles every non-partial `*.scss` (sass, compressed) through Lightning CSS and writes `css/*.css` plus `css/css.d.ts`. Commit only the `.scss` source — never the generated `*.css`. The small `css/css.d.ts` (module declarations) **is** committed, so type-checks resolve the CSS imports without a build; commit it too if adding or removing a theme entry changes it.
+This compiles every non-partial `*.scss` (sass, compressed) and writes `css/*.css` plus `css/css.d.ts`. Local builds skip Lightning CSS minify/prefixing; CI and `BUILD_CSS_MINIFY=1` still run that pass. Commit only the `.scss` source — never the generated `*.css`. The small `css/css.d.ts` (module declarations) **is** committed, so type-checks resolve the CSS imports without a build; commit it too if adding or removing a theme entry changes it.
 
 The prebundled CSS targets the [Svelte 5 browser support](https://svelte.dev/docs/svelte/browser-support) baseline (Firefox 83/Safari 14), not older browsers. Matching that baseline lets Lightning CSS drop legacy fallbacks. Author SCSS to that baseline; see the `:has()` note in [Conventions](#conventions).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -476,9 +476,11 @@ bun build:css
 bun build:css:watch
 ```
 
+The default build compiles only `css/all.scss` (docs, e2e, and `Theme` switching). Static sheets (`white`, `g10`, `g80`, `g90`, `g100`) are produced by `bun build:css:themes`, which release uses so the npm package still ships every entry.
+
 The compiled `css/*.css` are **not** committed (they are gitignored) — but they are still required at runtime, so without this step your local docs site and e2e tests will use stale (or missing) styles. `bun setup` runs `build:css` once on a fresh clone, and CI/release run it on demand; neither helps an in-progress local edit.
 
-This compiles every non-partial `*.scss` (sass, compressed) and writes `css/*.css` plus `css/css.d.ts`. Local builds skip Lightning CSS minify/prefixing; CI and `BUILD_CSS_MINIFY=1` still run that pass. Commit only the `.scss` source — never the generated `*.css`. The small `css/css.d.ts` (module declarations) **is** committed, so type-checks resolve the CSS imports without a build; commit it too if adding or removing a theme entry changes it.
+This compiles Sass (compressed) and writes `css/*.css` plus `css/css.d.ts`. Local builds skip Lightning CSS minify/prefixing; CI and `BUILD_CSS_MINIFY=1` still run that pass. Commit only the `.scss` source — never the generated `*.css`. The small `css/css.d.ts` (module declarations) **is** committed, so type-checks resolve the CSS imports without a build; commit it too if adding or removing a theme entry changes it.
 
 The prebundled CSS targets the [Svelte 5 browser support](https://svelte.dev/docs/svelte/browser-support) baseline (Firefox 83/Safari 14), not older browsers. Matching that baseline lets Lightning CSS drop legacy fallbacks. Author SCSS to that baseline; see the `:has()` note in [Conventions](#conventions).
 

--- a/css/_contained-list.scss
+++ b/css/_contained-list.scss
@@ -125,7 +125,6 @@
     height: 4.5rem;
   }
 
-  // Disclosed variant
   .#{$prefix}--contained-list--disclosed .#{$prefix}--contained-list__header {
     @include type-style('label-01');
 

--- a/css/_copy-input.scss
+++ b/css/_copy-input.scss
@@ -35,7 +35,6 @@
     }
   }
 
-  // Transparent overlay pinned to the right edge of the field.
   .#{$prefix}--copy-input__field-wrapper .#{$prefix}--copy-btn {
     @include focus-outline("reset");
 
@@ -83,7 +82,6 @@
     }
   }
 
-  // Match the copy button width to the input height for each size.
   .#{$prefix}--copy-input__field-wrapper
     .#{$prefix}--text-input--sm
     ~ .#{$prefix}--copy-btn {

--- a/css/_datepicker.scss
+++ b/css/_datepicker.scss
@@ -12,7 +12,6 @@
 }
 
 // Readonly date picker (v11 backport).
-
 @mixin date-picker-readonly {
   .#{$prefix}--date-picker__input[readonly] {
     background: transparent;

--- a/css/_disclosure.scss
+++ b/css/_disclosure.scss
@@ -92,7 +92,6 @@
     display: none;
     padding-right: $carbon--spacing-05;
     padding-left: $carbon--spacing-05;
-    // Transition property for when the disclosure closes
     transition: padding motion(standard, productive) $duration--fast-02;
   }
 
@@ -115,7 +114,6 @@
       display: block;
       padding-top: $carbon--spacing-03;
       padding-bottom: $carbon--spacing-05;
-      // Transition property for when the disclosure opens
       transition: padding-top motion(entrance, productive) $duration--fast-02,
         padding-bottom motion(entrance, productive) $duration--fast-02;
     }

--- a/css/_fluid-date-picker.scss
+++ b/css/_fluid-date-picker.scss
@@ -106,7 +106,6 @@
     }
   }
 
-  // Simple: hide decorative calendar icon, draw bottom border.
   .#{$prefix}--date-picker--fluid
     .#{$prefix}--date-picker--simple
     .#{$prefix}--date-picker__icon {

--- a/css/_fluid-list-box.scss
+++ b/css/_fluid-list-box.scss
@@ -145,7 +145,7 @@
     inset-block-start: to-rem(20px);
   }
 
-  // Invalid / warning states. The wrapper-level ring replaces the field-level
+  // The wrapper-level ring replaces the field-level
   // outline that v10 renders for the non-fluid variants. A ::after overlay
   // paints above child backgrounds (including input-cell hover) so the ring
   // stays visible until focus moves to the field.
@@ -290,7 +290,7 @@
     inset-block-end: $spacing-10;
   }
 
-  // Focus styles. The outline renders on the field wrapper (not the fluid
+  // The outline renders on the field wrapper (not the fluid
   // wrapper) so the open menu, a sibling of the field, does not paint over
   // the bottom edge. `outline-offset: 0` on the outer wrapper is clipped by
   // adjacent fluid-form cells; the mixin's -2px inset offset stays visible

--- a/css/_fluid-text-area.scss
+++ b/css/_fluid-text-area.scss
@@ -181,8 +181,7 @@
     transition: none;
   }
 
-  // Focus styles. Declared after invalid styles so the focus outline
-  // wins while the textarea is focused.
+  // Declared after invalid styles so the focus outline wins while the textarea is focused.
   .#{$prefix}--text-area--fluid
     .#{$prefix}--text-area__wrapper[data-invalid]:focus-within,
   .#{$prefix}--text-area--fluid .#{$prefix}--text-area__wrapper:focus-within {

--- a/css/_fluid-time-picker.scss
+++ b/css/_fluid-time-picker.scss
@@ -59,7 +59,6 @@
     inline-size: 100%;
   }
 
-  // Time input cell uses fluid text input layout.
   .#{$prefix}--time-picker--fluid
     .#{$prefix}--time-picker__input
     .#{$prefix}--text-input-wrapper {

--- a/css/_popover.scss
+++ b/css/_popover.scss
@@ -18,8 +18,6 @@
     // stylelint-disable-next-line length-zero-no-unit
     --cds-popover-offset: 0rem;
 
-    // Specify the distance that the caret should be offset from the side of the
-    // popover when not centered
     --cds-popover-caret-offset: 1rem;
 
     position: absolute;

--- a/css/_profile-menu.scss
+++ b/css/_profile-menu.scss
@@ -12,18 +12,12 @@
 /// @access private
 /// @group ui-shell
 @mixin profile-menu {
-  //--------------------------------------------------------------------------
-  // Trigger
-  //--------------------------------------------------------------------------
   .#{$prefix}--profile-menu__trigger.#{$prefix}--profile-menu__trigger {
     display: flex;
     align-items: center;
     justify-content: center;
   }
 
-  //--------------------------------------------------------------------------
-  // Avatar (shared frame; sized per context)
-  //--------------------------------------------------------------------------
   .#{$prefix}--profile-menu__avatar {
     display: flex;
     flex-shrink: 0;
@@ -54,9 +48,6 @@
     height: 2.5rem;
   }
 
-  //--------------------------------------------------------------------------
-  // Card
-  //--------------------------------------------------------------------------
   .#{$prefix}--profile-menu.#{$prefix}--profile-menu {
     position: absolute;
     top: 3rem;
@@ -75,9 +66,6 @@
     box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.15);
   }
 
-  //--------------------------------------------------------------------------
-  // Header block ("View profile")
-  //--------------------------------------------------------------------------
   .#{$prefix}--profile-menu__header {
     display: flex;
     flex-direction: column;
@@ -128,18 +116,12 @@
     color: $text-primary;
   }
 
-  //--------------------------------------------------------------------------
-  // List (compact group of items with even top/bottom padding)
-  //--------------------------------------------------------------------------
   .#{$prefix}--profile-menu__list {
     display: flex;
     flex-direction: column;
     padding: $spacing-03 0;
   }
 
-  //--------------------------------------------------------------------------
-  // Item (link or button)
-  //--------------------------------------------------------------------------
   .#{$prefix}--profile-menu__item.#{$prefix}--profile-menu__item {
     display: flex;
     align-items: center;
@@ -173,9 +155,6 @@
     fill: $icon-primary;
   }
 
-  //--------------------------------------------------------------------------
-  // Detail row (label / value / trailing action)
-  //--------------------------------------------------------------------------
   .#{$prefix}--profile-menu__detail {
     display: flex;
     align-items: flex-end;
@@ -222,9 +201,6 @@
     outline-offset: -2px;
   }
 
-  //--------------------------------------------------------------------------
-  // Divider
-  //--------------------------------------------------------------------------
   .#{$prefix}--profile-menu__divider.#{$prefix}--profile-menu__divider {
     height: 1px;
     margin: 0;

--- a/css/_search-menu.scss
+++ b/css/_search-menu.scss
@@ -205,8 +205,6 @@
     @include type-style("body-short-01");
   }
 
-  // Flush-left alignment: result text and group headers share the search input
-  // text inset; leading icons sit in the magnifier gutter, centered per size.
   @each $size, $inset in $search-menu-insets {
     $text-inset: nth($inset, 1);
     $icon-left: nth($inset, 2);

--- a/css/_slider.scss
+++ b/css/_slider.scss
@@ -87,7 +87,6 @@
     display: none;
   }
 
-  // Thumb wrapper — positions each handle along the track.
   .#{$prefix}--slider__thumb-wrapper {
     position: absolute;
     z-index: 3;
@@ -198,7 +197,6 @@
     fill: $interactive-01;
   }
 
-  // When either handle is focused, recolor the filled track.
   .#{$prefix}--slider__thumb-wrapper:focus-within
     ~ .#{$prefix}--slider__filled-track {
     background-color: $interactive-04;

--- a/css/_tabs.scss
+++ b/css/_tabs.scss
@@ -153,7 +153,7 @@
 /// @access private
 /// @group components
 @mixin tabs-overflow {
-  // (1) The legacy nav is an absolutely-positioned dropdown overlay by default;
+  // The legacy nav is an absolutely-positioned dropdown overlay by default;
   // keep it in flow and horizontally scrollable at every breakpoint.
   .#{$prefix}--tabs .#{$prefix}--tabs__nav {
     position: static;
@@ -199,7 +199,7 @@
     inline-size: auto;
   }
 
-  // (2) Below `md`, render the inline desktop tab appearance instead of Carbon's
+  // Below `md`, render the inline desktop tab appearance instead of Carbon's
   // mobile-first dropdown rows. Values mirror Carbon's own `min-width: 42rem`
   // tab rules so the tabs look identical above and below the breakpoint.
   // Override partials emit before Carbon base, so every rule here carries a

--- a/css/_type.scss
+++ b/css/_type.scss
@@ -31,7 +31,6 @@
     }
   }
 
-  // Re-emitted after token rules so modifiers win when combined.
   @each $name, $value in $carbon--font-families {
     .#{$prefix}--type-#{$name} {
       font-family: $value;

--- a/css/_user-avatar-group.scss
+++ b/css/_user-avatar-group.scss
@@ -14,9 +14,6 @@
     display: none;
   }
 
-  //--------------------------------------------------------------------------
-  // Overlapping (stacked) layout
-  //--------------------------------------------------------------------------
   .#{$prefix}--user-avatar-group--overlap > * {
     // Stacking context so a hovered avatar can lift above its neighbors.
     position: relative;

--- a/css/_user-avatar.scss
+++ b/css/_user-avatar.scss
@@ -38,9 +38,6 @@
     object-fit: cover;
   }
 
-  //--------------------------------------------------------------------------
-  // Sizes
-  //--------------------------------------------------------------------------
   .#{$prefix}--user-avatar--sm {
     width: $carbon--spacing-06;
     height: $carbon--spacing-06;
@@ -77,9 +74,6 @@
     @include type-style("productive-heading-04");
   }
 
-  //--------------------------------------------------------------------------
-  // Color variants (static palette tokens; consistent across themes)
-  //--------------------------------------------------------------------------
   .#{$prefix}--user-avatar--red {
     background-color: $red-60;
   }
@@ -120,10 +114,8 @@
     background-color: $warm-gray-60;
   }
 
-  //--------------------------------------------------------------------------
   // Tooltip wrapper: strip the definition trigger's underline/padding so the
   // circle renders clean when `tooltipText` is set.
-  //--------------------------------------------------------------------------
   .#{$prefix}--user-avatar-tooltip .#{$prefix}--tooltip__trigger.#{$prefix}--tooltip__trigger--definition {
     margin: 0;
     border-bottom: none;

--- a/css/vendor/carbon-components/scss/components/accordion/_accordion.scss
+++ b/css/vendor/carbon-components/scss/components/accordion/_accordion.scss
@@ -72,7 +72,6 @@
     }
   }
 
-  // Size styles
   // TODO V11: Remove xl selector
   .#{$prefix}--accordion--xl .#{$prefix}--accordion__heading,
   .#{$prefix}--accordion--lg .#{$prefix}--accordion__heading {
@@ -84,7 +83,6 @@
     padding: to-rem(5px) 0;
   }
 
-  // Disabled styles
   .#{$prefix}--accordion__heading[disabled] {
     color: $disabled-02;
     cursor: not-allowed;
@@ -134,7 +132,6 @@
     display: none;
     padding-right: $carbon--spacing-05;
     padding-left: $carbon--spacing-05;
-    // Transition property for when the accordion closes
     transition: padding motion(standard, productive) $duration--fast-02;
 
     // Custom breakpoints based on issue #4993
@@ -152,12 +149,10 @@
   }
 
   .#{$prefix}--accordion--start .#{$prefix}--accordion__heading {
-    // Reverse `$accordion-flex-direction` token:
     flex-direction: row;
   }
 
   .#{$prefix}--accordion--start .#{$prefix}--accordion__arrow {
-    // Alters `$accordion-arrow-margin` token:
     margin: 2px 0 0 $carbon--spacing-05;
   }
 
@@ -190,7 +185,6 @@
       display: block;
       padding-top: $spacing-03;
       padding-bottom: $carbon--spacing-06;
-      // Transition property for when the accordion opens
       transition: padding-top motion(entrance, productive) $duration--fast-02,
         padding-bottom motion(entrance, productive) $duration--fast-02;
     }
@@ -201,7 +195,6 @@
     }
   }
 
-  // Skeleton state
   .#{$prefix}--accordion.#{$prefix}--skeleton .#{$prefix}--accordion__heading,
   .#{$prefix}--accordion.#{$prefix}--skeleton .#{$prefix}--accordion__button {
     cursor: default;
@@ -254,9 +247,7 @@
   @include accordion;
 }
 
-// ---------------------------------------------------------------------------
 // carbon-components-svelte patch (formerly css/_accordion.scss)
-// ---------------------------------------------------------------------------
 @import "carbon-components/scss/globals/scss/vars";
 @import "carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/import-once/import-once";
 
@@ -286,9 +277,7 @@
   @include accordion-nested;
 }
 
-// ---------------------------------------------------------------------------
 // carbon-components-svelte patch (formerly css/_accordion-flush.scss)
-// ---------------------------------------------------------------------------
 @import "carbon-components/scss/globals/scss/vars";
 @import "carbon-components/scss/globals/scss/helper-mixins";
 @import "carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/import-once/import-once";

--- a/css/vendor/carbon-components/scss/components/breadcrumb/_breadcrumb.scss
+++ b/css/vendor/carbon-components/scss/components/breadcrumb/_breadcrumb.scss
@@ -74,7 +74,6 @@
     }
   }
 
-  // Overflow Menu overrides
   .#{$prefix}--breadcrumb-item .#{$prefix}--overflow-menu {
     position: relative;
     width: to-rem(20px);
@@ -144,7 +143,6 @@
     background: transparent;
   }
 
-  // Skeleton State
   .#{$prefix}--breadcrumb.#{$prefix}--skeleton .#{$prefix}--link {
     @include skeleton;
 

--- a/css/vendor/carbon-components/scss/components/button/_button.scss
+++ b/css/vendor/carbon-components/scss/components/button/_button.scss
@@ -440,7 +440,6 @@
     padding: $button-padding-field;
   }
 
-  //expressive styles
   .#{$prefix}--btn--expressive {
     @include carbon--type-style('body-short-02');
 
@@ -449,7 +448,6 @@
 
   .#{$prefix}--btn--icon-only.#{$prefix}--btn--expressive {
     padding: 12px 13px;
-    //default size 48px
   }
 
   .#{$prefix}--btn.#{$prefix}--btn--expressive .#{$prefix}--btn__icon {
@@ -461,14 +459,12 @@
     max-width: to-rem(320px);
   }
 
-  // Skeleton State
   .#{$prefix}--btn.#{$prefix}--skeleton {
     @include skeleton;
 
     width: to-rem(150px);
   }
 
-  // button set styles
   .#{$prefix}--btn-set {
     display: flex;
   }

--- a/css/vendor/carbon-components/scss/components/checkbox/_checkbox.scss
+++ b/css/vendor/carbon-components/scss/components/checkbox/_checkbox.scss
@@ -16,13 +16,11 @@
 /// @access private
 /// @group checkbox
 @mixin checkbox {
-  // Spacing between checkboxes
   .#{$prefix}--form-item.#{$prefix}--checkbox-wrapper {
     position: relative;
     margin-bottom: $carbon--spacing-02;
   }
 
-  // Spacing above collection of checkboxes
   .#{$prefix}--form-item.#{$prefix}--checkbox-wrapper:first-of-type {
     margin-top: to-rem(3px);
   }
@@ -33,7 +31,6 @@
     margin-top: -#{$carbon--spacing-01};
   }
 
-  // Spacing below collection of checkboxes
   .#{$prefix}--form-item.#{$prefix}--checkbox-wrapper:last-of-type {
     margin-bottom: to-rem(3px);
   }
@@ -65,7 +62,6 @@
   }
 
   .#{$prefix}--checkbox-label-text {
-    // Add extra spacing when label is present
     padding-left: to-rem(6px);
   }
 
@@ -75,7 +71,6 @@
     box-sizing: border-box;
   }
 
-  // Spacing for presentational checkbox
   .#{$prefix}--checkbox-label::before {
     // We need to position the pseudo-element absolutely in the space that we've
     // created with the padding from the label itself. We position only with
@@ -116,11 +111,6 @@
     transform-origin: bottom right #{'/*rtl:center*/'};
   }
 
-  //----------------------------------------------
-  // Checked
-  // ---------------------------------------------
-
-  // Update properties for checked checkbox
   .#{$prefix}--checkbox:checked + .#{$prefix}--checkbox-label::before,
   .#{$prefix}--checkbox:indeterminate + .#{$prefix}--checkbox-label::before,
   .#{$prefix}--checkbox-label[data-contained-checkbox-state='true']::before,
@@ -130,13 +120,11 @@
     background-color: $icon-01;
   }
 
-  // Display the check
   .#{$prefix}--checkbox:checked + .#{$prefix}--checkbox-label::after,
   .#{$prefix}--checkbox-label[data-contained-checkbox-state='true']::after {
     transform: scale(1) rotate(-45deg) #{'/*rtl:scale(1.2) rotate3d(.5, 1, 0, 158deg)*/'};
   }
 
-  // Indeterminate symbol
   .#{$prefix}--checkbox:indeterminate + .#{$prefix}--checkbox-label::after,
   .#{$prefix}--checkbox-label[data-contained-checkbox-state='mixed']::after {
     top: to-rem(11px);
@@ -146,26 +134,15 @@
     transform: scale(1) rotate(0deg);
   }
 
-  //----------------------------------------------
-  // Focus
-  // ---------------------------------------------
-
-  // Unchecked
   .#{$prefix}--checkbox:focus + .#{$prefix}--checkbox-label::before,
   .#{$prefix}--checkbox-label__focus::before,
-  // Checked
   .#{$prefix}--checkbox:checked:focus + .#{$prefix}--checkbox-label::before,
   .#{$prefix}--checkbox-label[data-contained-checkbox-state='true'].#{$prefix}--checkbox-label__focus::before,
-  // Indeterminate
   .#{$prefix}--checkbox:indeterminate:focus + .#{$prefix}--checkbox-label::before,
   .#{$prefix}--checkbox-label[data-contained-checkbox-state='mixed'].#{$prefix}--checkbox-label__focus::before {
     outline: 2px solid $focus;
     outline-offset: 1px;
   }
-
-  //----------------------------------------------
-  // Disabled
-  // ---------------------------------------------
 
   .#{$prefix}--checkbox:disabled + .#{$prefix}--checkbox-label,
   .#{$prefix}--checkbox-label[data-contained-checkbox-disabled='true'] {
@@ -186,9 +163,6 @@
     background-color: $disabled-02;
   }
 
-  //-----------------------------------------------
-  // Skeleton
-  //-----------------------------------------------
 
   .#{$prefix}--checkbox-label-text.#{$prefix}--skeleton {
     @include skeleton;
@@ -196,13 +170,9 @@
     width: to-rem(100px);
     height: $spacing-05;
 
-    // Add extra spacing when label is present
     margin: to-rem(1px) 0 0 to-rem(6px);
   }
 
-  //-----------------------------------------------
-  // InlineCheckbox
-  //-----------------------------------------------
   .#{$prefix}--checkbox--inline {
     position: relative;
   }

--- a/css/vendor/carbon-components/scss/components/code-snippet/_code-snippet.scss
+++ b/css/vendor/carbon-components/scss/components/code-snippet/_code-snippet.scss
@@ -48,7 +48,6 @@
     @include type-style('code-01');
   }
 
-  // Inline Code Snippet
   .#{$prefix}--snippet--inline {
     @include reset;
 
@@ -129,7 +128,6 @@
     cursor: auto;
   }
 
-  // Single Line Snippet
   .#{$prefix}--snippet--single {
     @include bx--snippet;
 
@@ -172,7 +170,6 @@
     white-space: pre;
   }
 
-  // Multi Line Snippet
   .#{$prefix}--snippet--multi {
     @include bx--snippet;
 
@@ -180,7 +177,6 @@
     padding: $carbon--spacing-05;
   }
 
-  //collapsed snippet container
   .#{$prefix}--snippet--multi .#{$prefix}--snippet-container {
     position: relative;
     min-height: 100%;
@@ -196,7 +192,6 @@
     }
   }
 
-  // expanded snippet container
   .#{$prefix}--snippet--multi.#{$prefix}--snippet--expand
     .#{$prefix}--snippet-container {
     padding-bottom: $spacing-05;
@@ -208,7 +203,6 @@
     word-wrap: break-word;
   }
 
-  // collapsed pre
   .#{$prefix}--snippet--multi .#{$prefix}--snippet-container pre {
     padding-right: $carbon--spacing-08;
     padding-bottom: to-rem(24px);
@@ -224,7 +218,6 @@
     overflow: hidden;
   }
 
-  //Copy Button
   .#{$prefix}--snippet__icon {
     width: to-rem(16px);
     height: to-rem(16px);
@@ -241,7 +234,6 @@
     @include carbon--font-family('sans');
   }
 
-  // Show more / less button
   .#{$prefix}--snippet-btn--expand {
     @include type-style('body-short-01');
     @include carbon--font-family('sans');
@@ -296,7 +288,6 @@
     transition: transform $transition--expansion;
   }
 
-  // Light version
   .#{$prefix}--snippet--light,
   .#{$prefix}--snippet--light .#{$prefix}--btn.#{$prefix}--snippet-btn--expand,
   .#{$prefix}--snippet--light .#{$prefix}--copy-btn {
@@ -325,7 +316,6 @@
     background-image: linear-gradient(to right, rgba($field-02, 0), $field-02);
   }
 
-  // Skeleton State
   .#{$prefix}--snippet.#{$prefix}--skeleton .#{$prefix}--snippet-container {
     width: 100%;
     height: 100%;
@@ -394,9 +384,7 @@
   @include snippet;
 }
 
-// ---------------------------------------------------------------------------
 // carbon-components-svelte patch (formerly css/_code-snippet.scss)
-// ---------------------------------------------------------------------------
 @import "carbon-components/scss/globals/scss/vars";
 
 /// Edge fade for code snippets (Carbon React v11 parity). v10 uses

--- a/css/vendor/carbon-components/scss/components/combo-box/_combo-box.scss
+++ b/css/vendor/carbon-components/scss/components/combo-box/_combo-box.scss
@@ -5,9 +5,6 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-//-----------------------------
-// ComboBox
-//-----------------------------
 
 @import '../../globals/scss/vars';
 @import '../../globals/scss/vendor/@carbon/elements/scss/import-once/import-once';

--- a/css/vendor/carbon-components/scss/components/content-switcher/_content-switcher.scss
+++ b/css/vendor/carbon-components/scss/components/content-switcher/_content-switcher.scss
@@ -225,9 +225,7 @@
   @include content-switcher;
 }
 
-// ---------------------------------------------------------------------------
 // carbon-components-svelte patch (formerly css/_content-switcher-low-contrast.scss)
-// ---------------------------------------------------------------------------
 @import "carbon-components/scss/globals/scss/vars";
 @import "carbon-components/scss/globals/scss/functions";
 @import "carbon-components/scss/globals/scss/typography";

--- a/css/vendor/carbon-components/scss/components/copy-button/_copy-button.scss
+++ b/css/vendor/carbon-components/scss/components/copy-button/_copy-button.scss
@@ -95,9 +95,7 @@
   }
 }
 
-// ---------------------------------------------------------------------------
 // carbon-components-svelte patch (formerly css/_copy-button-portal.scss)
-// ---------------------------------------------------------------------------
 // Hide Carbon's `::before` feedback caret when using a portalled tooltip.
 // `_tooltip.scss` loads before `carbon-components/.../styles`, so Carbon's
 // `.bx--copy-btn.bx--copy-btn--animating::before { display: block }` was
@@ -128,9 +126,7 @@
   @include copy-button-portal;
 }
 
-// ---------------------------------------------------------------------------
 // carbon-components-svelte patch (formerly css/_copy-button.scss)
-// ---------------------------------------------------------------------------
 // CopyButton variants: a `ghost` kind and a set of square sizes that mirror
 // `Button`. Carbon ships a single, fixed-size `bx--copy-btn` (a 2.5rem square
 // with a `$layer` fill), so these modifiers extend it to match the `Button`
@@ -149,9 +145,6 @@
 /// @access private
 /// @group copy-button
 @mixin copy-button {
-  //--------------------------------------------------------------------------
-  // Ghost kind (mirrors Button's ghost theme)
-  //--------------------------------------------------------------------------
   .#{$prefix}--copy-btn.#{$prefix}--copy-btn--ghost {
     background-color: transparent;
   }
@@ -168,10 +161,8 @@
     fill: $icon-01;
   }
 
-  //--------------------------------------------------------------------------
   // Sizes (square dimensions matching Button's small/lg/xl heights;
   // `default` keeps Carbon's native 2.5rem)
-  //--------------------------------------------------------------------------
   .#{$prefix}--copy-btn.#{$prefix}--copy-btn--sm {
     width: 2rem;
     height: 2rem;

--- a/css/vendor/carbon-components/scss/components/data-table/_data-table-action.scss
+++ b/css/vendor/carbon-components/scss/components/data-table/_data-table-action.scss
@@ -13,9 +13,6 @@
 /// @access private
 /// @group data-table
 @mixin data-table-v2-action {
-  //-------------------------------------------------
-  //TOOLBAR
-  //-------------------------------------------------
   .#{$prefix}--table-toolbar {
     // Need for batch actions
     position: relative;
@@ -44,9 +41,6 @@
     background-color: transparent;
   }
 
-  //-------------------------------------------------
-  //DEPRECATED v10/v9 search behavior
-  //-------------------------------------------------
   .#{$prefix}--batch-actions ~ .#{$prefix}--toolbar-search-container {
     display: flex;
     align-items: center;
@@ -54,9 +48,6 @@
     transition: opacity 110ms;
   }
 
-  //-------------------------------------------------
-  //HIDDEN SEARCH - DEFAULT TOOLBAR
-  //-------------------------------------------------
   .#{$prefix}--toolbar-content
     .#{$prefix}--toolbar-search-container-expandable {
     position: relative;
@@ -125,9 +116,6 @@
     background-color: $focus;
   }
 
-  //-------------------------------------------------
-  //ACTIVE SEARCH - DEFAULT TOOLBAR
-  //-------------------------------------------------
 
   .#{$prefix}--toolbar-search-container-active.#{$prefix}--search {
     width: 100%;
@@ -168,9 +156,6 @@
     outline: none;
   }
 
-  //-------------------------------------------------
-  //SEARCH CLOSE BUTTON
-  //-------------------------------------------------
   .#{$prefix}--toolbar-search-container-persistent .#{$prefix}--search-close,
   .#{$prefix}--toolbar-search-container-persistent
     .#{$prefix}--search-close:hover,
@@ -185,9 +170,6 @@
     display: none;
   }
 
-  //-------------------------------------------------
-  //TOOLBAR BUTTONS
-  //-------------------------------------------------
   .#{$prefix}--overflow-menu.#{$prefix}--toolbar-action {
     @include button-reset;
 
@@ -247,9 +229,6 @@
     height: $spacing-09;
   }
 
-  //-------------------------------------------------
-  //TOOLBAR BUTTON ICONS
-  //-------------------------------------------------
   .#{$prefix}--toolbar-action__icon {
     width: auto;
     max-width: $spacing-05;
@@ -257,9 +236,6 @@
     fill: $icon-primary;
   }
 
-  //-------------------------------------------------
-  //PERSISTENT SEARCH - OPTIONAL TOOLBAR
-  //-------------------------------------------------
   .#{$prefix}--toolbar-search-container-persistent {
     position: relative;
     width: 100%;
@@ -318,9 +294,6 @@
       clip-path $duration--fast-02 motion(standard, productive);
   }
 
-  //-------------------------------------------------
-  //BATCH ACTIONS
-  //-------------------------------------------------
   .#{$prefix}--batch-actions {
     position: absolute;
     right: 0;
@@ -350,7 +323,6 @@
     transform: translate3d(0, 0, 0);
   }
 
-  //btns container
   .#{$prefix}--action-list {
     display: flex;
     align-items: center;
@@ -384,7 +356,6 @@
     padding: to-rem(1px);
   }
 
-  // Override btn styles
   .#{$prefix}--action-list .#{$prefix}--btn--primary:focus::before,
   .#{$prefix}--action-list .#{$prefix}--btn--primary::before,
   .#{$prefix}--action-list .#{$prefix}--btn--primary:focus::after,
@@ -397,7 +368,6 @@
     outline-offset: to-rem(-2px);
   }
 
-  // cancel btn pseudo element
   .#{$prefix}--action-list
     .#{$prefix}--btn--primary:nth-child(3):hover
     + .#{$prefix}--btn--primary.#{$prefix}--batch-summary__cancel::before,
@@ -427,7 +397,6 @@
     transition: opacity $transition--base $carbon--standard-easing;
   }
 
-  // items selected text
   .#{$prefix}--batch-summary {
     position: sticky;
     z-index: 100000;
@@ -449,9 +418,6 @@
     @include type-style('body-short-01');
   }
 
-  //-------------------------------------------------
-  //SMALL TOOLBAR
-  //-------------------------------------------------
   // V11: remove --small
   .#{$prefix}--table-toolbar--small,
   .#{$prefix}--table-toolbar--sm {
@@ -495,7 +461,6 @@
       left: $spacing-03;
     }
 
-    //hidden
     .#{$prefix}--toolbar-search-container-expandable {
       width: to-rem(32px);
     }
@@ -506,7 +471,6 @@
       padding: 0 $spacing-09;
     }
 
-    //active
     .#{$prefix}--toolbar-search-container-active {
       flex: auto;
       transition: flex 175ms $carbon--standard-easing;
@@ -557,9 +521,6 @@
     background-color: transparent;
   }
 
-  //-------------------------------------------------
-  // SMALL BATCH ACTIONS
-  //-------------------------------------------------
   // V11: remove --small selector block
   .#{$prefix}--table-toolbar--small
     .#{$prefix}--batch-actions

--- a/css/vendor/carbon-components/scss/components/data-table/_data-table-core.scss
+++ b/css/vendor/carbon-components/scss/components/data-table/_data-table-core.scss
@@ -14,9 +14,6 @@
 /// @access private
 /// @group data-table
 @mixin data-table-core {
-  //----------------------------------------------------------------------------
-  // Container
-  //----------------------------------------------------------------------------
   .#{$prefix}--data-table-container {
     position: relative;
     // Allow space for focus styles
@@ -31,9 +28,6 @@
     @include focus-outline('outline');
   }
 
-  //----------------------------------------------------------------------------
-  // Table title text
-  //----------------------------------------------------------------------------
   .#{$prefix}--data-table-header {
     padding: $spacing-05 0 $spacing-06 $spacing-05;
     background: $layer;
@@ -51,9 +45,6 @@
     color: $text-secondary;
   }
 
-  //----------------------------------------------------------------------------
-  // Data table
-  //----------------------------------------------------------------------------
   .#{$prefix}--data-table {
     width: 100%;
     border-collapse: collapse;
@@ -155,8 +146,6 @@
     }
   }
 
-  // Form Control Overrides
-
   .#{$prefix}--data-table .#{$prefix}--list-box input[role='combobox'],
   .#{$prefix}--data-table .#{$prefix}--list-box input[type='text'],
   .#{$prefix}--data-table .#{$prefix}--dropdown,
@@ -169,7 +158,6 @@
     background-color: $field-02;
   }
 
-  // Overflow Menu Overrides
   .#{$prefix}--data-table
     td.#{$prefix}--table-column-menu
     .#{$prefix}--overflow-menu[aria-expanded='false']:focus {
@@ -265,9 +253,6 @@
     padding-top: $spacing-03;
   }
 
-  //----------------------------------------------------------------------------
-  //ZEBRA
-  //----------------------------------------------------------------------------
 
   .#{$prefix}--data-table--zebra
     tbody
@@ -294,9 +279,6 @@
     background-color: $layer-hover;
   }
 
-  //----------------------------------------------------------------------------
-  // Select
-  //----------------------------------------------------------------------------
   .#{$prefix}--table-column-checkbox .#{$prefix}--checkbox-label {
     padding-left: 0;
   }
@@ -410,9 +392,6 @@
     border-color: $disabled-03;
   }
 
-  //----------------------------------------------------------------------------
-  // Radio
-  //----------------------------------------------------------------------------
   .#{$prefix}--table-column-radio {
     width: 48px;
   }
@@ -421,7 +400,6 @@
     margin-right: to-rem(-2px);
   }
 
-  // default selected row + zebra select - even child
   .#{$prefix}--data-table--zebra
     tbody
     tr:nth-child(odd).#{$prefix}--data-table--selected
@@ -434,7 +412,6 @@
     color: $text-primary;
   }
 
-  // First row
   .#{$prefix}--data-table--zebra
     tbody
     tr:first-of-type:nth-child(odd).#{$prefix}--data-table--selected
@@ -444,7 +421,6 @@
     border-top: 1px solid $layer-active;
   }
 
-  // last row + zebra select last
   .#{$prefix}--data-table--zebra
     tbody
     tr:last-of-type:nth-child(odd).#{$prefix}--data-table--selected
@@ -459,7 +435,6 @@
     border-bottom: 1px solid $layer-selected;
   }
 
-  // zebra select - odd child
   .#{$prefix}--data-table--zebra
     tbody
     tr:nth-child(even).#{$prefix}--data-table--selected
@@ -474,7 +449,6 @@
     border-bottom: 1px solid $data-table-column-hover;
   }
 
-  // hover + zebra select - even child
   .#{$prefix}--data-table--zebra
     tbody
     tr:nth-child(odd).#{$prefix}--data-table--selected:hover
@@ -486,7 +460,6 @@
     color: $text-primary;
   }
 
-  // selected overflow menu
   .#{$prefix}--data-table--selected
     .#{$prefix}--overflow-menu
     .#{$prefix}--overflow-menu__icon {
@@ -494,9 +467,6 @@
   }
 
   // V11: Remove this compact block
-  //----------------------------------------------------------------------------
-  // Compact
-  //----------------------------------------------------------------------------
   .#{$prefix}--data-table--compact thead tr,
   .#{$prefix}--data-table--compact tbody tr,
   .#{$prefix}--data-table--compact tbody tr th {
@@ -534,9 +504,6 @@
   }
 
   // V11: Remove this short block
-  //----------------------------------------------------------------------------
-  // Short
-  //----------------------------------------------------------------------------
   .#{$prefix}--data-table--short thead tr,
   .#{$prefix}--data-table--short tbody tr,
   .#{$prefix}--data-table--short tbody tr th {
@@ -564,9 +531,6 @@
     height: 100%;
   }
 
-  //----------------------------------------------------------------------------
-  // Medium
-  //----------------------------------------------------------------------------
   .#{$prefix}--data-table--md thead tr,
   .#{$prefix}--data-table--md tbody tr,
   .#{$prefix}--data-table--md tbody tr th {
@@ -596,9 +560,6 @@
   }
 
   // V11: remove this tall block
-  //----------------------------------------------------------------------------
-  // Tall
-  //----------------------------------------------------------------------------
   .#{$prefix}--data-table--tall thead tr,
   .#{$prefix}--data-table--tall tbody tr,
   .#{$prefix}--data-table--tall tbody tr th {
@@ -624,9 +585,6 @@
     @include type-style('label-01');
   }
 
-  //----------------------------------------------------------------------------
-  // Static
-  //----------------------------------------------------------------------------
   .#{$prefix}--data-table--static {
     width: auto;
   }
@@ -635,9 +593,6 @@
     width: fit-content;
   }
 
-  // -------------
-  // Sticky header
-  // -------------
   .#{$prefix}--data-table_inner-container {
     background-color: $layer-accent;
     transform: translateZ(0);
@@ -721,7 +676,6 @@
       border-top: none;
     }
 
-    // Selectable fix
     thead th.#{$prefix}--table-column-checkbox,
     tbody tr td.#{$prefix}--table-column-checkbox {
       width: to-rem(36px);
@@ -735,7 +689,6 @@
       align-items: flex-start;
     }
 
-    // Overflow fix
     /* When using sticky header, with a selection element in the first column, we need to set the last item to a fixed width to match the table body. We only want this to happen when the last table header does not have any text */
     th.#{$prefix}--table-column-checkbox ~ th:last-of-type:empty {
       max-width: to-rem(64px);
@@ -782,25 +735,20 @@
       height: auto;
     }
 
-    // Compact
-    // V11: remove compact
     &.#{$prefix}--data-table--compact tr:not(.#{$prefix}--expandable-row) {
       min-height: to-rem(24px);
     }
 
-    // Short
     // V11: remove short
     &.#{$prefix}--data-table--short tr:not(.#{$prefix}--expandable-row) {
       min-height: to-rem(32px);
     }
 
-    // Tall
     // V11: remove tall
     &.#{$prefix}--data-table--tall tr:not(.#{$prefix}--expandable-row) {
       min-height: to-rem(64px);
     }
 
-    // Expansion overrides
     // V11: remove compact
     &.#{$prefix}--data-table--compact tr td.#{$prefix}--table-expand {
       padding-top: to-rem(4px);
@@ -844,7 +792,6 @@
       align-items: flex-start;
     }
 
-    // With dynamic content overrides
     // V11: remove compact, short
     &.#{$prefix}--data-table--compact
       tr.#{$prefix}--parent-row
@@ -858,9 +805,6 @@
 
   @include sticky-header($max-width: 100%);
 
-  // -------------------
-  // with boolean column
-  // -------------------
   .#{$prefix}--data-table
     .#{$prefix}--form-item.#{$prefix}--checkbox-wrapper:last-of-type {
     margin: 0;

--- a/css/vendor/carbon-components/scss/components/data-table/_data-table-expandable.scss
+++ b/css/vendor/carbon-components/scss/components/data-table/_data-table-expandable.scss
@@ -13,25 +13,16 @@
 /// @access private
 /// @group data-table
 @mixin data-table-expandable {
-  //----------------------------------------------------------------------------
-  // Parent row
-  //----------------------------------------------------------------------------
-  //first row top border
   .#{$prefix}--data-table tr.#{$prefix}--parent-row:first-of-type td {
     border-top: 1px solid $border-subtle;
   }
 
-  //----------------------------------------------------------------------------
-  // Child row
-  //----------------------------------------------------------------------------
-  // default styles
   .#{$prefix}--expandable-row--hidden td {
     width: auto;
     padding: $spacing-05;
     border-top: 0;
   }
 
-  //child row hidden
   tr.#{$prefix}--parent-row:not(.#{$prefix}--expandable-row)
     + tr[data-child-row] {
     height: 0;
@@ -57,7 +48,6 @@
     max-height: 0;
   }
 
-  //child row visible
   tr.#{$prefix}--parent-row.#{$prefix}--expandable-row + tr[data-child-row] {
     transition: height $duration--moderate-01 motion(standard, productive);
   }
@@ -88,7 +78,6 @@
     padding-bottom: 1.5rem;
   }
 
-  // bottom border overrides
   .#{$prefix}--parent-row.#{$prefix}--expandable-row > td,
   .#{$prefix}--parent-row.#{$prefix}--expandable-row + tr[data-child-row] > td {
     border-bottom: 1px solid $border-subtle;
@@ -106,9 +95,6 @@
     box-shadow: none;
   }
 
-  //----------------------------------------------------------------------------
-  // Hover styles
-  //----------------------------------------------------------------------------
   tr.#{$prefix}--parent-row:not(.#{$prefix}--expandable-row) td,
   tr.#{$prefix}--parent-row.#{$prefix}--expandable-row td,
   tr.#{$prefix}--parent-row.#{$prefix}--expandable-row {
@@ -116,14 +102,12 @@
       background-color $duration--fast-02 motion(standard, productive);
   }
 
-  // hovering on collapsed parent
   tr.#{$prefix}--parent-row:not(.#{$prefix}--expandable-row):first-of-type:hover
     td {
     border-top: 1px solid $border-subtle;
     border-bottom: 1px solid $border-subtle;
   }
 
-  // hovering on expanded parent
   tr.#{$prefix}--parent-row.#{$prefix}--expandable-row:hover td {
     border-top: 1px solid $border-subtle;
     border-bottom: 1px solid $border-subtle;
@@ -136,7 +120,6 @@
     border-bottom: 1px solid $layer-hover;
   }
 
-  // Child row when hovering on expanded parent
   tr.#{$prefix}--parent-row.#{$prefix}--expandable-row:hover
     + tr[data-child-row]
     td {
@@ -145,12 +128,10 @@
     color: $text-primary;
   }
 
-  //hovering on expanded child row
   tr.#{$prefix}--expandable-row--hover + tr[data-child-row] td {
     border-bottom: 1px solid $border-subtle;
   }
 
-  //hovering on expanded child row (class added to parent)
   tr.#{$prefix}--expandable-row--hover {
     background-color: $layer-hover;
   }
@@ -168,9 +149,6 @@
     border-bottom: 1px solid transparent;
   }
 
-  //----------------------------------------------------------------------------
-  // Expand icon column
-  //----------------------------------------------------------------------------
   .#{$prefix}--data-table td.#{$prefix}--table-expand {
     border-bottom: 1px solid $border-subtle;
   }
@@ -271,9 +249,6 @@
     display: none;
   }
 
-  //----------------------------------------------------------------------------
-  //ZEBRA
-  //----------------------------------------------------------------------------
   .#{$prefix}--data-table--zebra tbody tr[data-parent-row]:nth-child(4n + 3) td,
   .#{$prefix}--data-table--zebra tbody tr[data-child-row]:nth-child(4n + 4) td {
     border-bottom: 1px solid $layer;
@@ -316,10 +291,6 @@
     background: $layer-hover;
   }
 
-  //----------------------------------------------------------------------------
-  // Selected
-  //----------------------------------------------------------------------------
-  // Parent collapsed
   tr.#{$prefix}--parent-row.#{$prefix}--data-table--selected:first-of-type td {
     border-top: 1px solid $layer-active;
     border-bottom: 1px solid $border-subtle;
@@ -340,7 +311,6 @@
     box-shadow: 0 1px $border-subtle;
   }
 
-  // Parent collapsed hover
   tr.#{$prefix}--parent-row.#{$prefix}--data-table--selected:not(.#{$prefix}--expandable-row):hover
     td {
     border-top: 1px solid $layer-selected-hover;
@@ -349,7 +319,6 @@
     box-shadow: 0 1px $layer-selected-hover;
   }
 
-  // Parent expanded
   tr.#{$prefix}--parent-row.#{$prefix}--data-table--selected.#{$prefix}--expandable-row
     td,
   tr.#{$prefix}--parent-row.#{$prefix}--data-table--selected.#{$prefix}--expandable-row
@@ -359,7 +328,6 @@
     box-shadow: 0 1px $layer-selected;
   }
 
-  // Parent expanded hover
   tr.#{$prefix}--parent-row.#{$prefix}--data-table--selected.#{$prefix}--expandable-row:hover
     td,
   tr.#{$prefix}--parent-row.#{$prefix}--data-table--selected.#{$prefix}--expandable-row:hover
@@ -374,7 +342,6 @@
     box-shadow: 0 1px $layer-selected-hover;
   }
 
-  // Child row expanded
   tr.#{$prefix}--parent-row.#{$prefix}--data-table--selected.#{$prefix}--expandable-row
     + tr[data-child-row]
     td {
@@ -392,7 +359,6 @@
     box-shadow: inset 0 -1px $layer-active;
   }
 
-  // Child row expanded hover
   tr.#{$prefix}--parent-row.#{$prefix}--data-table--selected.#{$prefix}--expandable-row:hover
     + tr[data-child-row]
     td,

--- a/css/vendor/carbon-components/scss/components/data-table/_data-table-sort.scss
+++ b/css/vendor/carbon-components/scss/components/data-table/_data-table-sort.scss
@@ -13,9 +13,6 @@
 /// @access private
 /// @group data-table
 @mixin data-table-sort {
-  // -------------------------------------
-  // Sortable table
-  // -------------------------------------
   .#{$prefix}--data-table--sort th,
   .#{$prefix}--data-table th[aria-sort] {
     height: $spacing-09;
@@ -24,9 +21,6 @@
     border-bottom: none;
   }
 
-  // -------------------------------------
-  // Th > Button
-  // -------------------------------------
   .#{$prefix}--table-sort {
     @include button-reset(false);
 
@@ -67,9 +61,6 @@
     padding-left: $spacing-05;
   }
 
-  // -------------------------------------
-  // Th > Button > Span (span required for flex bugs in Safari)
-  // -------------------------------------
   th .#{$prefix}--table-sort__flex {
     display: flex;
     width: 100%;
@@ -107,10 +98,6 @@
     align-items: flex-start;
   }
 
-  // -------------------------------------
-  //Th > Button > Svg (Sort Icons)
-  // -------------------------------------
-  // inactive icons
   .#{$prefix}--table-sort .#{$prefix}--table-sort__icon-inactive {
     display: block;
   }
@@ -132,7 +119,6 @@
     background: $data-table-column-hover;
   }
 
-  // active icons
   .#{$prefix}--table-sort.#{$prefix}--table-sort--active
     .#{$prefix}--table-sort__icon-unsorted {
     display: none;
@@ -159,28 +145,21 @@
     transition: transform $transition--base $carbon--standard-easing;
   }
 
-  //----------------------------------------------------------------------------
-  // Compact, Short, Tall Sortable
-  //----------------------------------------------------------------------------
-  // Sortable compact
   // V11: remove compact
   .#{$prefix}--data-table--compact.#{$prefix}--data-table--sort th {
     height: to-rem(24px);
   }
 
-  // Sortable Short
   // V11: remove short
   .#{$prefix}--data-table--short.#{$prefix}--data-table--sort th {
     height: to-rem(32px);
   }
 
-  // Sortable Medium
   // V11: remove short
   .#{$prefix}--data-table--md.#{$prefix}--data-table--sort th {
     height: to-rem(40px);
   }
 
-  // Sortable Tall
   // V11: remove tall
   .#{$prefix}--data-table--tall.#{$prefix}--data-table--sort th {
     height: to-rem(64px);

--- a/css/vendor/carbon-components/scss/components/data-table/_data-table.scss
+++ b/css/vendor/carbon-components/scss/components/data-table/_data-table.scss
@@ -11,9 +11,7 @@
 @import 'data-table-sort';
 @import 'data-table-skeleton';
 
-// ---------------------------------------------------------------------------
 // carbon-components-svelte patch (formerly css/_data-table-zebra-hidden.scss)
-// ---------------------------------------------------------------------------
 @import "carbon-components/scss/globals/scss/vars";
 @import "carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/import-once/import-once";
 
@@ -39,9 +37,7 @@
   @include data-table-zebra-hidden;
 }
 
-// ---------------------------------------------------------------------------
 // carbon-components-svelte patch (formerly css/_data-table-highlighted-row.scss)
-// ---------------------------------------------------------------------------
 @import "carbon-components/scss/globals/scss/vars";
 @import "carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/import-once/import-once";
 
@@ -98,9 +94,7 @@
   @include data-table-highlighted-row;
 }
 
-// ---------------------------------------------------------------------------
 // carbon-components-svelte patch (formerly css/_data-table-tooltip-link.scss)
-// ---------------------------------------------------------------------------
 @import "carbon-components/scss/globals/scss/vars";
 @import "carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/import-once/import-once";
 
@@ -128,9 +122,7 @@
   @include data-table-tooltip-link;
 }
 
-// ---------------------------------------------------------------------------
 // carbon-components-svelte patch (formerly css/_data-table-sticky-column-menu.scss)
-// ---------------------------------------------------------------------------
 @import "carbon-components/scss/globals/scss/vars";
 @import "carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/import-once/import-once";
 
@@ -160,9 +152,7 @@
   @include data-table-sticky-column-menu;
 }
 
-// ---------------------------------------------------------------------------
 // carbon-components-svelte patch (formerly css/_data-table-footer.scss)
-// ---------------------------------------------------------------------------
 @import "carbon-components/scss/globals/scss/vars";
 @import "carbon-components/scss/globals/scss/typography";
 @import "carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/import-once/import-once";
@@ -233,9 +223,7 @@
   @include data-table-footer;
 }
 
-// ---------------------------------------------------------------------------
 // carbon-components-svelte patch (formerly css/_data-table-align.scss)
-// ---------------------------------------------------------------------------
 @import "carbon-components/scss/globals/scss/vars";
 @import "carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/import-once/import-once";
 

--- a/css/vendor/carbon-components/scss/components/date-picker/_date-picker.scss
+++ b/css/vendor/carbon-components/scss/components/date-picker/_date-picker.scss
@@ -117,7 +117,6 @@
     }
   }
 
-  // Size variant styles
   // TODO V11: Remove xl selector
   .#{$prefix}--date-picker__input--xl,
   .#{$prefix}--date-picker__input--lg {
@@ -177,7 +176,6 @@
     width: to-rem(143.5px);
   }
 
-  // Skeleton State
   .#{$prefix}--date-picker.#{$prefix}--skeleton input,
   .#{$prefix}--date-picker__input.#{$prefix}--skeleton {
     @include skeleton;

--- a/css/vendor/carbon-components/scss/components/dropdown/_dropdown.scss
+++ b/css/vendor/carbon-components/scss/components/dropdown/_dropdown.scss
@@ -5,9 +5,6 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-//-----------------------------
-// Dropdown
-//-----------------------------
 
 @import '../../globals/scss/vars';
 @import '../../globals/scss/helper-mixins';
@@ -213,7 +210,6 @@
     right: to-rem(32px);
   }
 
-  // Skeleton State
   .#{$prefix}--dropdown-v2.#{$prefix}--skeleton,
   .#{$prefix}--dropdown.#{$prefix}--skeleton {
     @include skeleton;

--- a/css/vendor/carbon-components/scss/components/form/_form.scss
+++ b/css/vendor/carbon-components/scss/components/form/_form.scss
@@ -65,7 +65,6 @@
     @include type-style('label-01');
   }
 
-  // Skeleton State
   .#{$prefix}--label.#{$prefix}--skeleton {
     @include skeleton;
 
@@ -129,7 +128,6 @@
     }
   }
 
-  //Fluid Form
   .#{$prefix}--form--fluid .#{$prefix}--text-input__field-wrapper[data-invalid],
   .#{$prefix}--form--fluid .#{$prefix}--text-input__field-wrapper--warning {
     display: block;

--- a/css/vendor/carbon-components/scss/components/link/_link.scss
+++ b/css/vendor/carbon-components/scss/components/link/_link.scss
@@ -5,9 +5,6 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-//-----------------------------
-// Link
-//-----------------------------
 
 @import '../../globals/scss/colors';
 @import '../../globals/scss/vars';

--- a/css/vendor/carbon-components/scss/components/list-box/_list-box.scss
+++ b/css/vendor/carbon-components/scss/components/list-box/_list-box.scss
@@ -5,9 +5,6 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-//-----------------------------
-// List Box
-//-----------------------------
 
 @import '../../globals/scss/vars';
 @import '../../globals/scss/css--helpers';
@@ -41,8 +38,6 @@ $list-box-menu-width: to-rem(300px);
 /// @access private
 /// @group list-box
 @mixin listbox {
-  // The overall container element for a `list-box`. Has two variants,
-  // `disabled` and `inline`.
   .#{$prefix}--list-box__wrapper--inline {
     display: inline-grid;
     align-items: center;
@@ -116,7 +111,6 @@ $list-box-menu-width: to-rem(300px);
     height: 100%;
   }
 
-  // invalid states
   .#{$prefix}--list-box__invalid-icon {
     position: absolute;
     top: 50%;
@@ -146,7 +140,6 @@ $list-box-menu-width: to-rem(300px);
     padding-right: carbon--mini-units(7);
   }
 
-  // Light variation for 'list-box'
   .#{$prefix}--list-box--light {
     background-color: $field-02;
 
@@ -167,7 +160,6 @@ $list-box-menu-width: to-rem(300px);
     border-bottom-color: transparent;
   }
 
-  // Disabled state for `list-box`
   .#{$prefix}--list-box--disabled:hover {
     background-color: $field-01;
   }
@@ -212,7 +204,6 @@ $list-box-menu-width: to-rem(300px);
     cursor: not-allowed;
   }
 
-  // disabled && invalid
   .#{$prefix}--list-box--disabled.#{$prefix}--list-box[data-invalid]
     .#{$prefix}--list-box__field {
     padding-right: $carbon--spacing-09;
@@ -223,7 +214,6 @@ $list-box-menu-width: to-rem(300px);
     padding-right: carbon--mini-units(4);
   }
 
-  // Inline variant for a `list-box`
   .#{$prefix}--list-box.#{$prefix}--list-box--inline {
     border-width: 0;
     background-color: transparent;
@@ -282,7 +272,6 @@ $list-box-menu-width: to-rem(300px);
     max-width: to-rem(480px);
   }
 
-  // The field we use for input, showing selection, etc.
   .#{$prefix}--list-box__field {
     @include button-reset;
 
@@ -309,12 +298,10 @@ $list-box-menu-width: to-rem(300px);
     outline: none;
   }
 
-  // populated input field
   .#{$prefix}--list-box__field .#{$prefix}--text-input {
     padding-right: carbon--mini-units(9);
   }
 
-  // invalid && populated input field
   .#{$prefix}--list-box[data-invalid]
     .#{$prefix}--list-box__field
     .#{$prefix}--text-input,
@@ -337,12 +324,10 @@ $list-box-menu-width: to-rem(300px);
     right: to-rem(66px);
   }
 
-  // empty input field
   .#{$prefix}--list-box__field .#{$prefix}--text-input--empty {
     padding-right: $carbon--spacing-09;
   }
 
-  // invalid && empty input field
   .#{$prefix}--list-box[data-invalid]
     .#{$prefix}--list-box__field
     .#{$prefix}--text-input--empty,
@@ -364,7 +349,6 @@ $list-box-menu-width: to-rem(300px);
     right: to-rem(40px);
   }
 
-  // Label for a `list-box__field`
   .#{$prefix}--list-box__label {
     @include type-style('body-short-01');
 
@@ -375,7 +359,6 @@ $list-box-menu-width: to-rem(300px);
     white-space: nowrap;
   }
 
-  // Menu status inside of a `list-box__field`
   .#{$prefix}--list-box__menu-icon {
     @include button-reset($width: false);
 
@@ -401,7 +384,6 @@ $list-box-menu-width: to-rem(300px);
     transform: rotate(180deg);
   }
 
-  // Selection indicator for a `list-box__field`
   .#{$prefix}--list-box__selection {
     @include button-reset($width: false);
 
@@ -487,7 +469,6 @@ $list-box-menu-width: to-rem(300px);
     outline: none;
   }
 
-  // Descendant of a `list-box` that displays a list of options to select
   .#{$prefix}--list-box__menu {
     @include box-shadow();
 
@@ -532,7 +513,6 @@ $list-box-menu-width: to-rem(300px);
     max-height: to-rem(176px);
   }
 
-  // Descendant of a `list-box__menu` that represents a selection for a control
   .#{$prefix}--list-box__menu-item {
     @include type-style('body-short-01');
 
@@ -776,7 +756,6 @@ $list-box-menu-width: to-rem(300px);
     white-space: nowrap;
   }
 
-  // Dropdown top orientation modifiers
   .#{$prefix}--list-box--up .#{$prefix}--list-box__menu {
     bottom: 2.5rem;
   }
@@ -806,7 +785,6 @@ $list-box-menu-width: to-rem(300px);
     bottom: 3rem;
   }
 
-  // Tweaks for descendants
   // When handling input, we need to target nodes that specifically opt-in to
   // the type text in order to make sure the text input is styled
   // correctly.
@@ -842,9 +820,7 @@ $list-box-menu-width: to-rem(300px);
   @include listbox;
 }
 
-// ---------------------------------------------------------------------------
 // carbon-components-svelte patch (formerly css/_list-box-menu-item.scss)
-// ---------------------------------------------------------------------------
 @import "carbon-components/scss/globals/scss/vars";
 @import "carbon-components/scss/globals/scss/helper-mixins";
 @import "carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/import-once/import-once";
@@ -893,9 +869,7 @@ $list-box-menu-width: to-rem(300px);
   @include list-box-menu-item-icon;
 }
 
-// ---------------------------------------------------------------------------
 // carbon-components-svelte patch (formerly css/_list-box-xs.scss)
-// ---------------------------------------------------------------------------
 // xs (24px) list-box heights for Dropdown, ComboBox, and MultiSelect.
 // carbon-components v10 stops at sm; backported from
 // https://github.com/carbon-design-system/carbon/pull/22439

--- a/css/vendor/carbon-components/scss/components/list/_list.scss
+++ b/css/vendor/carbon-components/scss/components/list/_list.scss
@@ -5,9 +5,6 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-//-----------------------------
-// List
-//-----------------------------
 
 @import '../../globals/scss/vars';
 @import '../../globals/scss/css--reset';

--- a/css/vendor/carbon-components/scss/components/loading/_loading.scss
+++ b/css/vendor/carbon-components/scss/components/loading/_loading.scss
@@ -25,7 +25,6 @@
     height: $loading__size;
   }
 
-  // Animation (Spin by default)
   .#{$prefix}--loading__svg {
     fill: transparent;
   }

--- a/css/vendor/carbon-components/scss/components/loading/_mixins.scss
+++ b/css/vendor/carbon-components/scss/components/loading/_mixins.scss
@@ -5,22 +5,17 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-//-------------------------
-// Animations - Loading
-//-------------------------
 @import '../../globals/scss/vars';
 
 /// @access private
 /// @group loading
 @mixin animation__loading--spin {
-  // Animate the container
   animation-duration: 690ms;
   animation-fill-mode: forwards;
   animation-iteration-count: infinite;
   animation-name: rotate;
   animation-timing-function: linear;
 
-  // Animate the stroke
   svg circle {
     animation-duration: 10ms;
     animation-name: init-stroke;
@@ -35,11 +30,9 @@
 /// @access private
 /// @group loading
 @mixin animation__loading--stop {
-  // Animate the container
   animation: rotate-end-p1 700ms $carbon--ease-out forwards,
     rotate-end-p2 700ms $carbon--ease-out 700ms forwards;
 
-  // Animate the stroke
   svg circle {
     animation-delay: 700ms;
     animation-duration: 700ms;

--- a/css/vendor/carbon-components/scss/components/menu/_menu.scss
+++ b/css/vendor/carbon-components/scss/components/menu/_menu.scss
@@ -139,9 +139,7 @@
   @include menu;
 }
 
-// ---------------------------------------------------------------------------
 // carbon-components-svelte patch (formerly css/_menu.scss)
-// ---------------------------------------------------------------------------
 @import "carbon-components/scss/globals/scss/vars";
 @import "carbon-components/scss/globals/scss/helper-mixins";
 @import "carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/import-once/import-once";
@@ -160,9 +158,7 @@
   @include menu-scrollable;
 }
 
-// ---------------------------------------------------------------------------
 // carbon-components-svelte patch (formerly css/_menu-xs.scss)
-// ---------------------------------------------------------------------------
 @import "carbon-components/scss/globals/scss/vars";
 @import "carbon-components/scss/globals/scss/helper-mixins";
 @import "carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/import-once/import-once";

--- a/css/vendor/carbon-components/scss/components/modal/_modal.scss
+++ b/css/vendor/carbon-components/scss/components/modal/_modal.scss
@@ -5,9 +5,6 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-//-----------------------------
-// Modals
-//-----------------------------
 
 @import '../../globals/scss/vars';
 @import '../../globals/scss/helper-mixins';
@@ -75,9 +72,6 @@
     transition: transform $duration--moderate-02 motion(entrance, expressive);
   }
 
-  // -----------------------------
-  // Modal container
-  // -----------------------------
   .#{$prefix}--modal-container {
     position: fixed;
     top: 0;
@@ -117,9 +111,6 @@
     }
   }
 
-  // -----------------------------
-  // Modal content
-  // -----------------------------
   .#{$prefix}--modal-content {
     @include type-style('body-long-01');
 
@@ -156,9 +147,6 @@
     padding-right: $spacing-05;
   }
 
-  // -----------------------------
-  // Modal header
-  // -----------------------------
   .#{$prefix}--modal-header {
     padding-top: $spacing-05;
     padding-right: $spacing-09;
@@ -181,9 +169,6 @@
     color: $text-01;
   }
 
-  // -----------------------------
-  // XS Modal
-  // -----------------------------
   .#{$prefix}--modal-container--xs {
     //text always spans full width in xs modals
     .#{$prefix}--modal-content__regular-content {
@@ -209,9 +194,6 @@
     }
   }
 
-  // -----------------------------
-  // SM Modal
-  // -----------------------------
   .#{$prefix}--modal-container--sm {
     //text spans full width in sm modals below 1056
     .#{$prefix}--modal-content__regular-content {
@@ -242,9 +224,6 @@
     }
   }
 
-  // -----------------------------
-  // LG Modal
-  // -----------------------------
   .#{$prefix}--modal-container--lg {
     @include carbon--breakpoint(md) {
       width: 96%;
@@ -260,9 +239,6 @@
     }
   }
 
-  // -----------------------------
-  // Modal overflow
-  // -----------------------------
   // Required so overflow-indicator disappears at end of content
   .#{$prefix}--modal-scroll-content > *:last-child {
     padding-bottom: $spacing-07;
@@ -299,9 +275,6 @@
     margin: 0 2px 2px;
   }
 
-  // -----------------------------
-  // Modal footer
-  // -----------------------------
   .#{$prefix}--modal-footer {
     display: flex;
     height: to-rem(64px);
@@ -325,9 +298,6 @@
     align-items: flex-start;
   }
 
-  // -----------------------------
-  // Modal close btn
-  // -----------------------------
   .#{$prefix}--modal-close {
     position: absolute;
     z-index: 2;
@@ -387,9 +357,7 @@
   @include modal;
 }
 
-// ---------------------------------------------------------------------------
 // carbon-components-svelte patch (formerly css/_modal-full-width.scss)
-// ---------------------------------------------------------------------------
 @import "carbon-components/scss/globals/scss/vars";
 @import "carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/import-once/import-once";
 

--- a/css/vendor/carbon-components/scss/components/multi-select/_multi-select.scss
+++ b/css/vendor/carbon-components/scss/components/multi-select/_multi-select.scss
@@ -5,9 +5,6 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-//-----------------------------
-// List Box
-//-----------------------------
 
 @import '../../globals/scss/vendor/@carbon/elements/scss/import-once/import-once';
 @import '../../globals/scss/helper-mixins';
@@ -128,9 +125,7 @@
   @include multiselect;
 }
 
-// ---------------------------------------------------------------------------
 // carbon-components-svelte patch (formerly css/_multiselect.scss)
-// ---------------------------------------------------------------------------
 // Multi-select "select all" separator border.
 
 @import "carbon-components/scss/globals/scss/vars";

--- a/css/vendor/carbon-components/scss/components/notification/_inline-notification.scss
+++ b/css/vendor/carbon-components/scss/components/notification/_inline-notification.scss
@@ -5,9 +5,6 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-//-----------------------------
-// Notifications
-//-----------------------------
 
 @import '../../globals/scss/vars';
 @import '../../globals/scss/helper-mixins';

--- a/css/vendor/carbon-components/scss/components/notification/_mixins.scss
+++ b/css/vendor/carbon-components/scss/components/notification/_mixins.scss
@@ -5,10 +5,6 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-//----------------------------------------------
-// Inline Notification
-// ---------------------------------------------
-
 /// @access private
 /// @group notification
 @mixin inline-notification--color($color) {
@@ -19,10 +15,6 @@
     fill: $color;
   }
 }
-
-//----------------------------------------------
-// Toast Notification
-// ---------------------------------------------
 
 /// @access private
 /// @group notification

--- a/css/vendor/carbon-components/scss/components/notification/_toast-notification.scss
+++ b/css/vendor/carbon-components/scss/components/notification/_toast-notification.scss
@@ -5,9 +5,6 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-//-----------------------------
-// Notifications
-//-----------------------------
 
 @import '../../globals/scss/vars';
 @import '../../globals/scss/layout';

--- a/css/vendor/carbon-components/scss/components/number-input/_number-input.scss
+++ b/css/vendor/carbon-components/scss/components/number-input/_number-input.scss
@@ -256,7 +256,6 @@
     }
   }
 
-  // rule divider styles
   .#{$prefix}--number__controls
     .#{$prefix}--number__rule-divider:first-of-type {
     left: 0;
@@ -382,7 +381,6 @@
     background-color: $hover-light-ui;
   }
 
-  // Size Variant styles
   // TODO V11: Remove xl selector
   .#{$prefix}--number--xl input[type='number'],
   .#{$prefix}--number--lg input[type='number'] {
@@ -425,14 +423,12 @@
     }
   }
 
-  //No label positioning adjustment
   .#{$prefix}--number--nolabel
     .#{$prefix}--label
     + .#{$prefix}--form__helper-text {
     margin-top: 0;
   }
 
-  // No steppers
   .#{$prefix}--number--nosteppers input[type='number'] {
     padding-right: to-rem(48px);
   }
@@ -441,7 +437,6 @@
     right: to-rem(16px);
   }
 
-  // Readonly
   .#{$prefix}--number--readonly input[type='number'] {
     background: transparent;
   }
@@ -455,7 +450,6 @@
     right: to-rem(16px);
   }
 
-  // Skeleton State
   .#{$prefix}--number.#{$prefix}--skeleton {
     @include skeleton;
 

--- a/css/vendor/carbon-components/scss/components/overflow-menu/_overflow-menu.scss
+++ b/css/vendor/carbon-components/scss/components/overflow-menu/_overflow-menu.scss
@@ -5,9 +5,6 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-//-----------------------------
-// Overflow Menu
-//-----------------------------
 
 @import '../../globals/scss/vars';
 @import '../../globals/scss/helper-mixins';
@@ -343,7 +340,6 @@
     }
   }
 
-  // styles for "next" version
   .#{$prefix}--overflow-menu__container {
     display: inline-block;
   }

--- a/css/vendor/carbon-components/scss/components/pagination-nav/_pagination-nav.scss
+++ b/css/vendor/carbon-components/scss/components/pagination-nav/_pagination-nav.scss
@@ -5,9 +5,6 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-//-----------------------------
-// Pagination Nav
-//-----------------------------
 
 @import '../../globals/scss/colors';
 @import '../../globals/scss/vars';

--- a/css/vendor/carbon-components/scss/components/pagination/_pagination.scss
+++ b/css/vendor/carbon-components/scss/components/pagination/_pagination.scss
@@ -47,7 +47,6 @@ $css--helpers: true;
       }
     }
 
-    // mobile friendly pagination
     @include carbon--breakpoint-down('md') {
       .#{$prefix}--pagination__left > *,
       .#{$prefix}--pagination__right > * {
@@ -243,7 +242,6 @@ $css--helpers: true;
     fill: $disabled-02;
   }
 
-  // Skeleton state
   .#{$prefix}--pagination.#{$prefix}--skeleton .#{$prefix}--skeleton__text {
     margin-right: 1rem;
     margin-bottom: 0;
@@ -261,9 +259,7 @@ $css--helpers: true;
   @include pagination;
 }
 
-// ---------------------------------------------------------------------------
 // carbon-components-svelte patch (formerly css/_pagination.scss)
-// ---------------------------------------------------------------------------
 // Extra-small (xs, 24px) pagination. v10 ships sm/lg only; upstream carbon#21695.
 // v11 sizes from layout.height; at xs that is 24px ($size-xs / 1.5rem in v10).
 // Simple mode: compact prev/next + status for toolbars and cards.

--- a/css/vendor/carbon-components/scss/components/progress-indicator/_progress-indicator.scss
+++ b/css/vendor/carbon-components/scss/components/progress-indicator/_progress-indicator.scss
@@ -103,7 +103,6 @@
     color: $interactive;
   }
 
-  //OPTIONAL HELPER TEXT STYLING
   .#{$prefix}--progress-optional {
     @include type-style('label-01');
 
@@ -115,14 +114,12 @@
     text-align: start;
   }
 
-  //CURRENT STYLING
   .#{$prefix}--progress-step--current {
     .#{$prefix}--progress-line {
       background-color: $interactive-04;
     }
   }
 
-  //INCOMPLETE STYLING
   .#{$prefix}--progress-step--incomplete {
     svg {
       fill: $ui-05;
@@ -133,14 +130,12 @@
     }
   }
 
-  //COMPLETED STYLING
   .#{$prefix}--progress-step--complete {
     .#{$prefix}--progress-line {
       background-color: $interactive-04;
     }
   }
 
-  //interactive button
   .#{$prefix}--progress-step-button {
     @include button-reset();
 
@@ -148,7 +143,6 @@
     text-align: left;
   }
 
-  //unclickable button
   .#{$prefix}--progress-step-button--unclickable {
     cursor: default;
     outline: none;
@@ -161,7 +155,6 @@
     cursor: default;
   }
 
-  //DISABLED STYLING
   .#{$prefix}--progress-step--disabled {
     cursor: not-allowed;
     pointer-events: none;
@@ -189,12 +182,10 @@
     }
   }
 
-  // ERROR STYLING
   .#{$prefix}--progress__warning > * {
     fill: $support-01;
   }
 
-  // Skeleton State
   .#{$prefix}--progress.#{$prefix}--skeleton .#{$prefix}--progress-label {
     @include skeleton;
 
@@ -203,7 +194,6 @@
     margin-top: 0.625rem;
   }
 
-  // Vertical Variant
 
   .#{$prefix}--progress--vertical {
     display: flex;

--- a/css/vendor/carbon-components/scss/components/radio-button/_radio-button.scss
+++ b/css/vendor/carbon-components/scss/components/radio-button/_radio-button.scss
@@ -5,9 +5,6 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-//-----------------------------
-// Radio
-//-----------------------------
 
 @import '../../globals/scss/vars';
 @import '../../globals/scss/typography';
@@ -33,7 +30,6 @@
     margin-top: 0;
   }
 
-  // vertical radio button
   .#{$prefix}--radio-button-group--vertical {
     flex-direction: column;
     align-items: flex-start;
@@ -122,7 +118,6 @@
     }
   }
 
-  // Focus
 
   .#{$prefix}--radio-button:focus
     + .#{$prefix}--radio-button__label
@@ -131,7 +126,6 @@
     outline-offset: 1.5px;
   }
 
-  // Skeleton State
   .#{$prefix}--radio-button__label.#{$prefix}--skeleton {
     @include skeleton;
 

--- a/css/vendor/carbon-components/scss/components/search/_search.scss
+++ b/css/vendor/carbon-components/scss/components/search/_search.scss
@@ -5,9 +5,6 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-//-----------------------------
-// Search
-//-----------------------------
 
 @import '../../globals/scss/vars';
 @import '../../globals/scss/helper-mixins';
@@ -79,7 +76,6 @@
     background: $field-02;
   }
 
-  // Small styles
   .#{$prefix}--search--sm .#{$prefix}--search-input,
   .#{$prefix}--search--sm.#{$prefix}--search--expandable.#{$prefix}--search--expanded
     .#{$prefix}--search-input {
@@ -92,7 +88,6 @@
     left: to-rem(8px);
   }
 
-  // Large styles
   // V11: change lg to md
   .#{$prefix}--search--lg .#{$prefix}--search-input,
   .#{$prefix}--search--lg.#{$prefix}--search--expandable.#{$prefix}--search--expanded

--- a/css/vendor/carbon-components/scss/components/select/_select.scss
+++ b/css/vendor/carbon-components/scss/components/select/_select.scss
@@ -5,9 +5,6 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-//-----------------------------
-// Select
-//-----------------------------
 
 @import '../../globals/scss/vars';
 @import '../../globals/scss/css--reset';
@@ -251,7 +248,6 @@
     }
   }
 
-  //Skeleton State
   .#{$prefix}--select.#{$prefix}--skeleton {
     @include skeleton;
 
@@ -274,9 +270,7 @@
   @include select;
 }
 
-// ---------------------------------------------------------------------------
 // carbon-components-svelte patch (formerly css/_select.scss)
-// ---------------------------------------------------------------------------
 // Extends the v10 select with the extra-small (`xs`) size added in newer
 // Carbon (React `size="xs"`, 24px height). v10 only ships sm/md/lg.
 

--- a/css/vendor/carbon-components/scss/components/slider/_slider.scss
+++ b/css/vendor/carbon-components/scss/components/slider/_slider.scss
@@ -5,9 +5,6 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-//-----------------------------
-// Slider
-//-----------------------------
 
 @import '../../globals/scss/vars';
 @import '../../globals/scss/helper-mixins';
@@ -136,7 +133,6 @@
     background-color: $interactive-04;
   }
 
-  // Disabled state
   .#{$prefix}--label--disabled
     ~ .#{$prefix}--slider-container
     > .#{$prefix}--slider__range-label {
@@ -194,7 +190,6 @@
     }
   }
 
-  // Skeleton state
   .#{$prefix}--slider-container.#{$prefix}--skeleton
     .#{$prefix}--slider__range-label {
     @include skeleton;

--- a/css/vendor/carbon-components/scss/components/structured-list/_structured-list.scss
+++ b/css/vendor/carbon-components/scss/components/structured-list/_structured-list.scss
@@ -41,7 +41,6 @@
     border-spacing: 0;
     overflow-x: auto;
 
-    // Condensed list
     &.#{$prefix}--structured-list--condensed .#{$prefix}--structured-list-td,
     &.#{$prefix}--structured-list--condensed .#{$prefix}--structured-list-th {
       @include padding-td--condensed;
@@ -57,7 +56,6 @@
       // 8px side padding between col creates 16 px, with exception of 1st col, which needs an override to be 16px
     }
 
-    // Flush list
     &.#{$prefix}--structured-list--flush
       .#{$prefix}--structured-list-row
       .#{$prefix}--structured-list-td,
@@ -174,7 +172,6 @@
     fill: $icon-01;
   }
 
-  // Skeleton State
   .#{$prefix}--structured-list.#{$prefix}--skeleton {
     .#{$prefix}--structured-list-th {
       &:first-child {
@@ -221,9 +218,7 @@
   @include structured-list;
 }
 
-// ---------------------------------------------------------------------------
 // carbon-components-svelte patch (formerly css/_structured-list-input-focusable.scss)
-// ---------------------------------------------------------------------------
 @import "carbon-components/scss/globals/scss/vars";
 @import "carbon-components/scss/globals/scss/helper-mixins";
 @import "carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/import-once/import-once";

--- a/css/vendor/carbon-components/scss/components/tabs/_tabs.scss
+++ b/css/vendor/carbon-components/scss/components/tabs/_tabs.scss
@@ -5,9 +5,6 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-//-----------------------------
-// Tabs
-//-----------------------------
 
 @import '../../globals/scss/vars';
 @import '../../globals/scss/helper-mixins';
@@ -77,9 +74,6 @@
     }
   }
 
-  //-----------------------------
-  // Item
-  //-----------------------------
   .#{$prefix}--tabs__nav-item {
     @include reset;
 
@@ -124,9 +118,6 @@
       outline $duration--fast-01 motion(standard, productive);
   }
 
-  //-----------------------------
-  // Item Hover
-  //-----------------------------
   .#{$prefix}--tabs__nav-item:hover:not(.#{$prefix}--tabs__nav-item--selected) {
     @include carbon--breakpoint(md) {
       background: transparent;
@@ -153,9 +144,6 @@
     }
   }
 
-  //---------------------------------------------
-  // Item Disabled
-  //---------------------------------------------
   .#{$prefix}--tabs__nav-item--disabled,
   .#{$prefix}--tabs__nav-item--disabled:hover {
     cursor: not-allowed;
@@ -180,9 +168,6 @@
     }
   }
 
-  //-----------------------------
-  // Item Selected
-  //-----------------------------
   .#{$prefix}--tabs__nav-item--selected:not(.#{$prefix}--tabs__nav-item--disabled) {
     display: none;
     border: none;
@@ -224,9 +209,6 @@
     }
   }
 
-  //-----------------------------
-  // Link
-  //-----------------------------
   a.#{$prefix}--tabs__nav-link {
     @include focus-outline('reset');
 
@@ -280,9 +262,6 @@
     }
   }
 
-  //-----------------------------
-  //  Link Hover
-  //-----------------------------
   .#{$prefix}--tabs__nav-item:hover:not(.#{$prefix}--tabs__nav-item--selected):not(.#{$prefix}--tabs__nav-item--disabled)
     .#{$prefix}--tabs__nav-link {
     color: $text-01;
@@ -300,9 +279,6 @@
     }
   }
 
-  //-----------------------------
-  //  Link Disabled
-  //-----------------------------
   .#{$prefix}--tabs__nav-item--disabled .#{$prefix}--tabs__nav-link {
     border-bottom: $tab-underline-disabled;
     color: $tab-text-disabled;
@@ -320,9 +296,6 @@
     outline: none;
   }
 
-  //-----------------------------
-  //  Link Focus
-  //-----------------------------
   .#{$prefix}--tabs__nav-item:not(.#{$prefix}--tabs__nav-item--selected):not(.#{$prefix}--tabs__nav-item--disabled):not(.#{$prefix}--tabs__nav-item--selected)
     .#{$prefix}--tabs__nav-link:focus,
   .#{$prefix}--tabs__nav-item:not(.#{$prefix}--tabs__nav-item--selected):not(.#{$prefix}--tabs__nav-item--disabled):not(.#{$prefix}--tabs__nav-item--selected)
@@ -330,9 +303,6 @@
     color: $text-02;
   }
 
-  //-----------------------------
-  //  Tab Content Container
-  //-----------------------------
   .#{$prefix}--tab-content {
     padding: $carbon--spacing-05;
 
@@ -341,9 +311,6 @@
     }
   }
 
-  //-----------------------------
-  // Skeleton state
-  //-----------------------------
   .#{$prefix}--tabs.#{$prefix}--skeleton {
     cursor: default;
     pointer-events: none;
@@ -404,9 +371,6 @@
       }
     }
 
-    //-----------------------------
-    // Overflow Nav Buttons
-    //-----------------------------
     .#{$prefix}--tabs__overflow-indicator--left,
     .#{$prefix}--tabs__overflow-indicator--right {
       z-index: 1;
@@ -496,9 +460,6 @@
       fill: $icon-01;
     }
 
-    //-----------------------------
-    // Item
-    //-----------------------------
     .#{$prefix}--tabs--scrollable__nav-item {
       @include reset;
 
@@ -527,24 +488,15 @@
       box-shadow: to-rem(-1px) 0 0 0 $ui-04;
     }
 
-    //-----------------------------
-    // Item Hover
-    //-----------------------------
     &.#{$prefix}--tabs--scrollable--container
       .#{$prefix}--tabs--scrollable__nav-item:hover {
       background-color: $hover-selected-ui;
     }
 
-    //-----------------------------
-    //  Tab Content Container
-    //-----------------------------
     .#{$prefix}--tab-content {
       padding: $carbon--spacing-05;
     }
 
-    //-----------------------------
-    // Skeleton state
-    //-----------------------------
     .#{$prefix}--tabs.#{$prefix}--skeleton {
       cursor: default;
       pointer-events: none;

--- a/css/vendor/carbon-components/scss/components/tag/_tag.scss
+++ b/css/vendor/carbon-components/scss/components/tag/_tag.scss
@@ -162,7 +162,6 @@
     cursor: pointer;
   }
 
-  // tags used for filtering
   .#{$prefix}--tag--filter {
     padding-top: 0;
     padding-right: 0;
@@ -239,7 +238,6 @@
     fill: $disabled-02;
   }
 
-  // small tags
   .#{$prefix}--tag--sm {
     min-height: to-rem(18px);
     padding: 0 $carbon--spacing-03;
@@ -255,7 +253,6 @@
     margin-left: to-rem(5px);
   }
 
-  // Skeleton state
   .#{$prefix}--tag.#{$prefix}--skeleton {
     @include skeleton;
     @include tag-theme($bg-color: $skeleton-01, $text-color: $text-01);

--- a/css/vendor/carbon-components/scss/components/tag/_tokens.scss
+++ b/css/vendor/carbon-components/scss/components/tag/_tokens.scss
@@ -11,7 +11,6 @@
 
 // prettier-ignore
 $tag-colors: (
-  // red
   'tag-background-red': (
     fallback: $carbon__red-20,
     values: (
@@ -88,7 +87,6 @@ $tag-colors: (
     ),
   ),
 
-  // magenta
   'tag-background-magenta': (
     fallback: $carbon__magenta-20,
     values: (
@@ -165,7 +163,6 @@ $tag-colors: (
     ),
   ),
 
-  // purple
   'tag-background-purple': (
     fallback: $carbon__purple-20,
     values: (
@@ -242,7 +239,6 @@ $tag-colors: (
     ),
   ),
 
-  // blue
   'tag-background-blue': (
     fallback: $carbon__blue-20,
     values: (
@@ -319,7 +315,6 @@ $tag-colors: (
     ),
   ),
 
-  // cyan
   'tag-background-cyan': (
     fallback: $carbon__cyan-20,
     values: (
@@ -396,7 +391,6 @@ $tag-colors: (
     ),
   ),
 
-  // teal
   'tag-background-teal': (
     fallback: $carbon__teal-20,
     values: (
@@ -473,7 +467,6 @@ $tag-colors: (
     ),
   ),
 
-  // green
   'tag-background-green': (
     fallback: $carbon__green-20,
     values: (
@@ -550,7 +543,6 @@ $tag-colors: (
     ),
   ),
 
-  // gray
   'tag-background-gray': (
     fallback: $carbon__gray-20,
     values: (
@@ -627,7 +619,6 @@ $tag-colors: (
     ),
   ),
 
-  // cool-gray
   'tag-background-cool-gray': (
     fallback: $carbon__cool-gray-20,
     values: (
@@ -704,7 +695,6 @@ $tag-colors: (
     ),
   ),
 
-  // warm-gray
   'tag-background-warm-gray': (
     fallback: $carbon__warm-gray-20,
     values: (

--- a/css/vendor/carbon-components/scss/components/text-area/_text-area.scss
+++ b/css/vendor/carbon-components/scss/components/text-area/_text-area.scss
@@ -5,9 +5,6 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-//-----------------------------
-// Text area
-//-----------------------------
 
 @import '../../globals/scss/vars';
 @import '../../globals/scss/typography';
@@ -70,9 +67,6 @@
     fill: $support-01;
   }
 
-  //-----------------------------
-  // Disabled
-  //-----------------------------
   .#{$prefix}--text-area:disabled {
     border-bottom: 1px solid transparent;
     background-color: $disabled-01;
@@ -89,7 +83,6 @@
     background-color: $field-02;
   }
 
-  // Skeleton State
   .#{$prefix}--text-area.#{$prefix}--skeleton {
     @include skeleton;
 

--- a/css/vendor/carbon-components/scss/components/text-input/_text-input.scss
+++ b/css/vendor/carbon-components/scss/components/text-input/_text-input.scss
@@ -5,9 +5,6 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-//-----------------------------
-// Text
-//-----------------------------
 @import '../../globals/scss/vars';
 @import '../../globals/scss/css--reset';
 @import '../../globals/scss/helper-mixins';
@@ -75,9 +72,6 @@
     background-color: $field-02;
   }
 
-  //-----------------------------
-  // Disabled & Error icon spacing
-  //-----------------------------
   .#{$prefix}--text-input__field-wrapper {
     position: relative;
     display: flex;
@@ -201,9 +195,6 @@
     }
   }
 
-  //-----------------------------
-  // Disabled
-  //-----------------------------
   .#{$prefix}--text-input:disabled {
     @include focus-outline('reset');
 
@@ -225,9 +216,6 @@
     opacity: 1;
   }
 
-  //-----------------------------
-  // Error
-  //-----------------------------
   .#{$prefix}--text-input--invalid {
     @include focus-outline('invalid');
 
@@ -240,16 +228,10 @@
     }
   }
 
-  //-----------------------------
-  // Skeleton
-  //-----------------------------
   .#{$prefix}--skeleton.#{$prefix}--text-input {
     @include skeleton;
   }
 
-  //-----------------------------
-  // Fluid Text Input
-  //-----------------------------
   .#{$prefix}--form--fluid .#{$prefix}--text-input-wrapper {
     position: relative;
     background: $field-01;
@@ -322,9 +304,6 @@
     @include focus-outline('outline');
   }
 
-  //-----------------------------
-  // Inline Text Input
-  //-----------------------------
 
   .#{$prefix}--text-input-wrapper.#{$prefix}--text-input-wrapper--inline {
     flex-flow: row wrap;
@@ -372,9 +351,6 @@
     flex-direction: column;
   }
 
-  //-----------------------------
-  // Readonly
-  //-----------------------------
 
   .#{$prefix}--form--fluid .#{$prefix}--text-input-wrapper--readonly,
   .#{$prefix}--text-input-wrapper--readonly .#{$prefix}--text-input {
@@ -395,9 +371,7 @@
   @include text-input;
 }
 
-// ---------------------------------------------------------------------------
 // carbon-components-svelte patch (formerly css/_text-input.scss)
-// ---------------------------------------------------------------------------
 // Extends the v10 text input with the extra-small (`xs`) size added in
 // newer Carbon (React `size="xs"`, 24px height). v10 only ships sm/md/lg.
 

--- a/css/vendor/carbon-components/scss/components/tile/_tile.scss
+++ b/css/vendor/carbon-components/scss/components/tile/_tile.scss
@@ -5,9 +5,6 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-//-----------------------------
-// Tiles
-//-----------------------------
 
 @import '../../globals/scss/vars';
 @import '../../globals/scss/helper-mixins';
@@ -89,7 +86,6 @@
     text-decoration: none;
   }
 
-  // Disabled ClickableTile
   .#{$prefix}--tile--clickable.#{$prefix}--link--disabled {
     color: $disabled-02;
   }

--- a/css/vendor/carbon-components/scss/components/time-picker/_time-picker.scss
+++ b/css/vendor/carbon-components/scss/components/time-picker/_time-picker.scss
@@ -5,9 +5,6 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-//-----------------------------
-// Time Picker
-//-----------------------------
 
 @import '../../globals/scss/vars';
 @import '../../globals/scss/helper-mixins';
@@ -96,9 +93,7 @@
   @include time-picker;
 }
 
-// ---------------------------------------------------------------------------
 // carbon-components-svelte patch (formerly css/_time-picker.scss)
-// ---------------------------------------------------------------------------
 @import "carbon-components/scss/globals/scss/vars";
 @import "carbon-components/scss/globals/scss/helper-mixins";
 @import "carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/import-once/import-once";

--- a/css/vendor/carbon-components/scss/components/toggle/_toggle.scss
+++ b/css/vendor/carbon-components/scss/components/toggle/_toggle.scss
@@ -5,9 +5,6 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-//-----------------------------
-// Toggle
-//-----------------------------
 
 @import '../../globals/scss/vars';
 @import '../../globals/scss/helper-mixins';
@@ -140,7 +137,6 @@
       fill: $button-disabled;
     }
 
-    // HCM
 
     .#{$prefix}--toggle__switch,
     .#{$prefix}--toggle__switch::before {
@@ -184,7 +180,6 @@
       width: to-rem(48px);
       height: to-rem(24px);
 
-      // Toggle background oval
       &::before {
         position: absolute;
         top: 0;
@@ -207,7 +202,6 @@
         }
       }
 
-      // Toggle circle
       &::after {
         position: absolute;
         top: to-rem(3px);
@@ -280,9 +274,6 @@
       }
     }
 
-    //----------------------------------------------
-    // Focus
-    // ---------------------------------------------
     .#{$prefix}--toggle
       + .#{$prefix}--toggle__label
       .#{$prefix}--toggle__appearance::before {
@@ -297,9 +288,6 @@
       box-shadow: 0 0 0 1px $ui-03, 0 0 0 3px $focus;
     }
 
-    //----------------------------------------------
-    // Disabled
-    // ---------------------------------------------
     .#{$prefix}--toggle:disabled + .#{$prefix}--toggle__label {
       cursor: not-allowed;
     }
@@ -347,9 +335,6 @@
       fill: $disabled-02;
     }
 
-    //----------------------------------------------
-    // Small toggle
-    // ---------------------------------------------
 
     .#{$prefix}--toggle--small
       + .#{$prefix}--toggle__label
@@ -395,10 +380,7 @@
       }
     }
 
-    // -----------------------------------------------------
-    // new accessible toggle
     // TODO: deprecate styles above this line
-    // -----------------------------------------------------
 
     .#{$prefix}--toggle-input {
       @include hidden;
@@ -426,7 +408,6 @@
       align-items: center;
       cursor: pointer;
 
-      // Toggle background oval
       &::before {
         position: absolute;
         top: 0;
@@ -448,7 +429,6 @@
         }
       }
 
-      // Toggle circle
       &::after {
         position: absolute;
         top: to-rem(3px);
@@ -481,9 +461,6 @@
       white-space: nowrap;
     }
 
-    //----------------------------------------------
-    // Checked
-    // ---------------------------------------------
     .#{$prefix}--toggle-input:checked
       + .#{$prefix}--toggle-input__label
       > .#{$prefix}--toggle__switch
@@ -508,9 +485,6 @@
       }
     }
 
-    //----------------------------------------------
-    // Focus and active
-    // ---------------------------------------------
     .#{$prefix}--toggle-input:focus
       + .#{$prefix}--toggle-input__label
       > .#{$prefix}--toggle__switch::before,
@@ -520,9 +494,6 @@
       box-shadow: 0 0 0 1px $ui-02, 0 0 0 3px $focus;
     }
 
-    //----------------------------------------------
-    // Disabled
-    // ---------------------------------------------
     .#{$prefix}--toggle-input:disabled + .#{$prefix}--toggle-input__label {
       color: $disabled;
       cursor: not-allowed;
@@ -558,9 +529,6 @@
       box-shadow: none;
     }
 
-    //----------------------------------------------
-    // Small toggle
-    // ---------------------------------------------
     .#{$prefix}--toggle-input--small + .#{$prefix}--toggle-input__label {
       > .#{$prefix}--toggle__switch {
         width: to-rem(32px);
@@ -602,10 +570,6 @@
       fill: $disabled-01;
     }
 
-    //----------------------------------------------
-    // Skeleton
-    // ---------------------------------------------
-    //md toggle input
     .#{$prefix}--toggle.#{$prefix}--skeleton
       + .#{$prefix}--toggle-input__label
       .#{$prefix}--toggle__switch {
@@ -615,7 +579,6 @@
       margin-top: 0.5rem;
     }
 
-    //md skeleton label text
     .#{$prefix}--toggle.#{$prefix}--skeleton
       + .#{$prefix}--toggle-input__label
       > div {
@@ -629,7 +592,6 @@
       @include skeleton;
     }
 
-    //small toggle input
     .#{$prefix}--toggle-input--small.#{$prefix}--skeleton
       + .#{$prefix}--toggle-input__label
       .#{$prefix}--toggle__switch {
@@ -639,7 +601,6 @@
       margin-top: 0.5rem;
     }
 
-    //sm skeleton label text
     .#{$prefix}--toggle-input--small.#{$prefix}--skeleton
       + .#{$prefix}--toggle-input__label
       > div {
@@ -653,7 +614,6 @@
       @include skeleton;
     }
 
-    // on/off text skeleton
     .#{$prefix}--toggle.#{$prefix}--skeleton
       + .#{$prefix}--toggle-input__label
       .#{$prefix}--toggle__switch
@@ -672,7 +632,6 @@
       left: 2rem;
     }
 
-    //pseudo "toggle" button
     .#{$prefix}--toggle.#{$prefix}--skeleton
       + .#{$prefix}--toggle-input__label
       .#{$prefix}--toggle__switch::after,
@@ -685,7 +644,6 @@
       display: none;
     }
 
-    //make it square
     .#{$prefix}--toggle.#{$prefix}--skeleton
       + .#{$prefix}--toggle-input__label
       .#{$prefix}--toggle__switch::before {

--- a/css/vendor/carbon-components/scss/components/tooltip/_tooltip.scss
+++ b/css/vendor/carbon-components/scss/components/tooltip/_tooltip.scss
@@ -49,7 +49,6 @@
     }
   }
 
-  // Disabled styles
   .#{$prefix}--tooltip__trigger:not(.#{$prefix}--btn--icon-only)[disabled] svg {
     fill: $icon-disabled;
   }
@@ -249,7 +248,6 @@
     margin-top: 0;
   }
 
-  // Tooltip Definition
   .#{$prefix}--tooltip--definition.#{$prefix}--tooltip--a11y {
     // Wrapping element set to inline since the tooltip isn't contained within the trigger (affects center and end alignments)
     // Also allows for Definition Tooltip to be used within a paragraph of text as defined in the usage guidelines
@@ -261,7 +259,6 @@
     margin: 0;
   }
 
-  // Definition CSS only tooltip
   .#{$prefix}--tooltip__trigger.#{$prefix}--tooltip__trigger--definition {
     @include type-style('label-01');
 
@@ -308,8 +305,6 @@
     }
   }
 
-  // Tooltip Icon
-  // Icon CSS only tooltip
   .#{$prefix}--tooltip__trigger {
     &:hover,
     &:focus {

--- a/css/vendor/carbon-components/scss/components/treeview/_treeview.scss
+++ b/css/vendor/carbon-components/scss/components/treeview/_treeview.scss
@@ -5,9 +5,6 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-//-----------------------------
-// Treeview
-//-----------------------------
 
 @import '../../globals/scss/vars';
 @import '../../globals/scss/vendor/@carbon/elements/scss/import-once/import-once';
@@ -177,9 +174,7 @@
   @include treeview;
 }
 
-// ---------------------------------------------------------------------------
 // carbon-components-svelte patch (formerly css/_treeview.scss)
-// ---------------------------------------------------------------------------
 @import "carbon-components/scss/globals/scss/vars";
 @import "carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/import-once/import-once";
 
@@ -231,9 +226,7 @@
   @include treeview-multiselect-overrides;
 }
 
-// ---------------------------------------------------------------------------
 // carbon-components-svelte patch (formerly css/_treeview-checkbox.scss)
-// ---------------------------------------------------------------------------
 @import "carbon-components/scss/globals/scss/vars";
 @import "carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/import-once/import-once";
 

--- a/css/vendor/carbon-components/scss/components/ui-shell/_header-panel.scss
+++ b/css/vendor/carbon-components/scss/components/ui-shell/_header-panel.scss
@@ -17,9 +17,6 @@
 /// @access private
 /// @group ui-shell
 @mixin carbon-header-panel {
-  //----------------------------------------------------------------------------
-  // Header Panel
-  //----------------------------------------------------------------------------
   .#{$prefix}--header-panel {
     @include carbon--motion(exit, productive);
 

--- a/css/vendor/carbon-components/scss/components/ui-shell/_header.scss
+++ b/css/vendor/carbon-components/scss/components/ui-shell/_header.scss
@@ -88,9 +88,6 @@
     }
   }
 
-  //--------------------------------------------------------------------------
-  // Header - Name
-  //--------------------------------------------------------------------------
   a.#{$prefix}--header__name {
     @include type-style('body-short-01');
 
@@ -126,9 +123,6 @@
     padding-left: to-rem(8px);
   }
 
-  //--------------------------------------------------------------------------
-  // Header - Navigation
-  //--------------------------------------------------------------------------
   .#{$prefix}--header__nav {
     position: relative;
     display: none;
@@ -163,19 +157,15 @@
   a.#{$prefix}--header__menu-item {
     position: relative;
     display: flex;
-    // Used for links that are directly in the menubar to span the full height
     height: 100%;
     align-items: center;
     padding: 0 mini-units(2);
-    // Used for focus styles
     border: 2px solid transparent;
     color: $shell-header-text-02;
-    // Text styles
     font-size: to-rem(14px);
     font-weight: 400;
     letter-spacing: 0;
     line-height: 1.125rem;
-    // Reset link styles and make sure the text isn't selectable
     text-decoration: none;
     transition: background-color $duration--fast-02,
       border-color $duration--fast-02, color $duration--fast-02;
@@ -205,7 +195,6 @@
     fill: $shell-header-icon-01;
   }
 
-  // Styles for selected state
 
   a.#{$prefix}--header__menu-item[aria-current='page']::after,
   .#{$prefix}--header__menu-item--current::after {
@@ -317,9 +306,6 @@
     transition: transform $duration--fast-02, fill $duration--fast-02;
   }
 
-  //--------------------------------------------------------------------------
-  // Header - Global
-  //--------------------------------------------------------------------------
   .#{$prefix}--header__global {
     display: flex;
     height: 100%;
@@ -327,9 +313,6 @@
     justify-content: flex-end;
   }
 
-  //--------------------------------------------------------------------------
-  // Header - Skip to content
-  //--------------------------------------------------------------------------
   .#{$prefix}--skip-to-content {
     position: absolute;
     overflow: hidden;

--- a/css/vendor/carbon-components/scss/components/ui-shell/_side-nav.scss
+++ b/css/vendor/carbon-components/scss/components/ui-shell/_side-nav.scss
@@ -62,9 +62,6 @@
 /// @access private
 /// @group ui-shell
 @mixin carbon-side-nav {
-  //----------------------------------------------------------------------------
-  // Side-nav > Panel
-  //----------------------------------------------------------------------------.
   .#{$prefix}--side-nav {
     position: fixed;
     z-index: z('header');
@@ -91,13 +88,6 @@
     }
   }
 
-  //----------------------------------------------------------------------------
-  // Rail
-  //---------------------------------------------------------------------------
-  // Used for rendering the actual side rail. There are two states that we have
-  // to style for, namely for when the rail is collapsed and expanded. When
-  // collapsed, the rail is intended to expand on mouse over. When expanded, it
-  // should have the same dimensions as when expanded on mouse over
 
   .#{$prefix}--side-nav--rail {
     width: mini-units(6);
@@ -147,18 +137,12 @@
     transform: translateX(mini-units(-32));
   }
 
-  //----------------------------------------------------------------------------
-  // Side-nav > Navigation
-  //----------------------------------------------------------------------------
   .#{$prefix}--side-nav__navigation {
     display: flex;
     height: 100%;
     flex-direction: column;
   }
 
-  //----------------------------------------------------------------------------
-  // Side-nav > Navigation > Header
-  //----------------------------------------------------------------------------
   .#{$prefix}--side-nav__header {
     display: flex;
     width: 100%;
@@ -175,9 +159,6 @@
     height: auto;
   }
 
-  //----------------------------------------------------------------------------
-  // Side-nav > Navigation > Header > Details
-  //----------------------------------------------------------------------------
   .#{$prefix}--side-nav__details {
     display: flex;
     min-width: 0;
@@ -195,9 +176,6 @@
     visibility: inherit;
   }
 
-  //----------------------------------------------------------------------------
-  // Side-nav > Navigation > Footer
-  //----------------------------------------------------------------------------
   .#{$prefix}--side-nav__footer {
     width: 100%;
     flex: 0 0 to-rem(48px);
@@ -218,9 +196,6 @@
     @include focus-outline('outline');
   }
 
-  //----------------------------------------------------------------------------
-  // Side-nav > Navigation > Item(s)
-  //----------------------------------------------------------------------------
   .#{$prefix}--side-nav__items {
     overflow: hidden;
     flex: 1 1 0%;
@@ -275,18 +250,12 @@
     height: mini-units(6);
   }
 
-  //----------------------------------------------------------------------------
-  // Side-nav > Navigation > Divider
-  //----------------------------------------------------------------------------
   .#{$prefix}--side-nav__divider {
     height: 1px;
     margin: $spacing-03 $spacing-05;
     background-color: $ibm-color__gray-20;
   }
 
-  //----------------------------------------------------------------------------
-  // Side-nav > Navigation > {Menu,Submenu}
-  //----------------------------------------------------------------------------
   .#{$prefix}--side-nav__submenu {
     @include button-reset($width: true);
     @include type-style('productive-heading-01');
@@ -374,9 +343,6 @@
     }
   }
 
-  //----------------------------------------------------------------------------
-  // Side-nav > Link
-  //----------------------------------------------------------------------------
   a.#{$prefix}--side-nav__link,
   .#{$prefix}--side-nav a.#{$prefix}--header__menu-item,
   .#{$prefix}--side-nav
@@ -440,9 +406,6 @@
     content: '';
   }
 
-  //----------------------------------------------------------------------------
-  // Side-nav > Icons
-  //----------------------------------------------------------------------------
   .#{$prefix}--side-nav__icon {
     display: flex;
     // Helpful in flex containers so the icon does not have less than the
@@ -462,9 +425,6 @@
     fill: $shell-side-nav-icon-01;
   }
 
-  //----------------------------------------------------------------------------
-  // Variants - Header Nav Links in Side Nav
-  //----------------------------------------------------------------------------
   .#{$prefix}--side-nav .#{$prefix}--header__nav {
     @include carbon--breakpoint-down('lg') {
       display: block;
@@ -491,7 +451,6 @@
     content: '';
   }
 
-  //header menu items overrides
   .#{$prefix}--side-nav a.#{$prefix}--header__menu-item {
     justify-content: space-between;
     color: $shell-side-nav-text-01;

--- a/css/vendor/carbon-components/scss/components/ui-shell/_switcher.scss
+++ b/css/vendor/carbon-components/scss/components/ui-shell/_switcher.scss
@@ -17,9 +17,6 @@
 /// @access private
 /// @group ui-shell
 @mixin carbon-switcher {
-  //----------------------------------------------------------------------------
-  // Header Switcher
-  //----------------------------------------------------------------------------
   .#{$prefix}--switcher {
     display: flex;
     flex-direction: column;

--- a/css/vendor/carbon-components/scss/components/ui-shell/_theme.scss
+++ b/css/vendor/carbon-components/scss/components/ui-shell/_theme.scss
@@ -7,9 +7,6 @@
 
 @import '../../globals/scss/colors';
 
-//----------------------------------------------------------------------------
-// Header tokens
-//----------------------------------------------------------------------------
 /// Header bar background
 /// @type Color
 /// @access private
@@ -96,9 +93,6 @@ $shell-header-icon-03: $carbon--gray-30;
 /// @group ui-shell
 $shell-header-link: $carbon--blue-60;
 
-//----------------------------------------------------------------------------
-// Header Panel tokens
-//----------------------------------------------------------------------------
 
 /// Header-panel background
 /// @type Color
@@ -149,9 +143,6 @@ $shell-panel-text-02: $carbon--gray-10;
 /// @group ui-shell
 $shell-panel-focus: $carbon--white-0;
 
-//----------------------------------------------------------------------------
-// Side nav tokens
-//----------------------------------------------------------------------------
 /// Side-nav panel background
 /// @type Color
 /// @access private

--- a/css/vendor/carbon-components/scss/globals/scss/_colors.scss
+++ b/css/vendor/carbon-components/scss/globals/scss/_colors.scss
@@ -5,7 +5,4 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-//-----------
-// v10 COLORS
-//-----------
 @import './vendor/@carbon/elements/scss/colors/colors';

--- a/css/vendor/carbon-components/scss/globals/scss/_feature-flags.scss
+++ b/css/vendor/carbon-components/scss/globals/scss/_feature-flags.scss
@@ -5,10 +5,6 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-//-------------------------
-// 🎌 Feature Flags
-//-------------------------
-
 /// Initialize the feature flag map with default values.
 /// @access public
 /// @type Map

--- a/css/vendor/carbon-components/scss/globals/scss/_helper-mixins.scss
+++ b/css/vendor/carbon-components/scss/globals/scss/_helper-mixins.scss
@@ -5,20 +5,6 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-//----------------------------------------------
-// Mixins
-// ---------------------------------------------
-//
-//   Category             ||  Description
-//   ===========================================
-//   Misc                 ||  General helper @mixins
-//   Deprecated           ||  Not used anymore
-//   ===========================================
-
-//----------------------------------------------
-// Misc
-// ---------------------------------------------
-
 @import 'vars';
 @import 'css--reset';
 @import 'typography';
@@ -35,7 +21,6 @@
   text-overflow: ellipsis;
   white-space: nowrap;
 
-  // apply a width if width parameter exists
   @if ($width) {
     width: $width;
   }

--- a/css/vendor/carbon-components/scss/globals/scss/_layer.scss
+++ b/css/vendor/carbon-components/scss/globals/scss/_layer.scss
@@ -5,24 +5,6 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-//-------------------------------------------
-// 📑 Layer
-// ------------------------------------------
-//
-//   Layer                 ||  Elevation
-//   ==========================================
-//   0 - Base              ||  0
-//   1 - Flat              ||  1
-//   2 - Raised            ||  2
-//   3 - Overlay           ||  8
-//   4 - Pop-out           ||  24
-//   ==========================================
-//   Custom: Left Nav      ||  16
-//   Custom: Global Header ||  12
-//
-
-// Box shadow variables
-
 /// Box shadow color
 /// @access private
 /// @type Value
@@ -59,8 +41,6 @@ $box-shadow--temporary-nav: 0 2px 6px 0 $box-shadow;
 /// @type Value
 /// @group global-layer
 $box-shadow--pop-out: 0 2px 6px 0 $box-shadow;
-
-// Layer box-shadow map
 
 /// Map of box shadows used in the `layer()` mixin
 /// @access private

--- a/css/vendor/carbon-components/scss/globals/scss/_spacing.scss
+++ b/css/vendor/carbon-components/scss/globals/scss/_spacing.scss
@@ -8,37 +8,6 @@
 @import './vendor/@carbon/elements/scss/layout/mini-unit';
 @import './vendor/@carbon/elements/scss/layout/spacing';
 
-//-------------------------------------------
-// 🌌 Spacing
-// ------------------------------------------
-//
-//   Size in px based on 16px base
-//
-//   Spacing Scale
-//   ==========================================
-//   4xs  ||  1px
-//   3xs  ||  2px
-//   2xs  ||  4px
-//   xs   ||  8px
-//   sm   ||  12px
-//   md   ||  16px
-//   lg   ||  24px
-//   xl   ||  32px
-//   2xl  ||  40px
-//   3xl  ||  48px
-//   ==========================================
-//
-//   Layout Scale
-//   ==========================================
-//   2xs  ||  16px
-//   xs   ||  24px
-//   sm   ||  32px
-//   md   ||  48px
-//   lg   ||  64px
-//   xl   ||  96px
-//   2xl  ||  160px
-//   ==========================================
-
 /// 1rem baseline spacing
 /// @access public
 /// @type Number

--- a/css/vendor/carbon-components/scss/globals/scss/_theme-tokens.scss
+++ b/css/vendor/carbon-components/scss/globals/scss/_theme-tokens.scss
@@ -48,8 +48,6 @@ $focus: $ibm-color__blue-60 !default;
 /// @group global-themes
 $inverse-focus-ui: $ibm-color__white-0 !default;
 
-// Link
-
 /// @type Color
 /// @access public
 /// @group link
@@ -62,14 +60,10 @@ $link-visited: $visited-link !default;
 /// @group link
 $link-inverse-color: #6ea6ff !default;
 
-// Tooltip
-
 /// @type Color
 /// @access public
 /// @group tooltip
 $tooltip-background-color: $inverse-02 !default;
-
-// Button
 
 /// @type Number
 /// @access public
@@ -151,8 +145,6 @@ $button-outline-offset: -5px !default;
 /// @deprecated
 $button-outline: 1px solid $ibm-color__white-0 !default;
 
-// Accordion
-
 /// @type Value
 /// @access public
 /// @group accordion
@@ -178,14 +170,10 @@ $accordion-title-margin: 0 0 0 $carbon--spacing-05 !default;
 /// @group accordion
 $accordion-content-padding: 0 0 0 $carbon--spacing-05 !default;
 
-// Checkbox
-
 /// @type Number
 /// @access public
 /// @group checkbox
 $checkbox-border-width: 2px !default;
-
-// Code Snippet
 
 /// @type Color
 /// @access public
@@ -198,8 +186,6 @@ $snippet-background-color: $field-01 !default;
 /// @group code-snippet
 /// TODO: Define for experimental
 $snippet-border-color: $ui-03 !default;
-
-// Content Switcher
 
 /// @type Number
 /// @access public
@@ -215,8 +201,6 @@ $content-switcher-option-border: 1px solid $brand-01 !default;
 /// @access public
 /// @group content-switcher
 $content-switcher-divider: $ui-03 !default;
-
-// Data Table
 
 /// @type Value
 /// @access public
@@ -243,15 +227,11 @@ $data-table-zebra-color: $ui-02 !default;
 /// @group data-table
 $data-table-column-hover: $hover-selected-ui !default;
 
-// Date Picker
-
 /// @type Color
 /// @access public
 /// @group date-picker
 /// @deprecated
 $date-picker-in-range-background-color: $ibm-color__blue-20 !default;
-
-// Modal
 
 /// @type Color
 /// @access public
@@ -263,8 +243,6 @@ $modal-border-top: $brand-01 4px solid !default;
 /// @group modal
 /// @deprecated
 $modal-footer-background-color: $ui-03 !default;
-
-// Notification
 
 /// @type Color
 /// @access public
@@ -294,8 +272,6 @@ $notification-warning-background-color: mix(
 /// @deprecated
 $notification-success-background-color: $ibm-color__green-10 !default;
 
-// Progress Indicator
-
 /// @type Value
 /// @access public
 /// @group progress-indicator
@@ -311,8 +287,6 @@ $progress-indicator-stroke-width: 5 !default;
 /// @group progress-indicator
 $progress-indicator-line-offset: 0.625rem !default;
 
-// Copy Button
-
 /// @type Color
 /// @access public
 /// @group copy-button
@@ -323,14 +297,10 @@ $copy-active: $active-ui !default;
 /// @group copy-button
 $copy-btn-feedback: $inverse-02 !default;
 
-// Radio Button
-
 /// @type Number
 /// @access public
 /// @group radio-button
 $radio-border-width: 1px !default;
-
-// Structured List
 
 /// @type Number
 /// @access public
@@ -341,8 +311,6 @@ $structured-list-padding: 2rem !default;
 /// @access public
 /// @group structured-list
 $structured-list-text-transform: none !default;
-
-// Tabs
 
 /// @type Value
 /// @access public
@@ -364,15 +332,11 @@ $tab-text-disabled: $disabled-02 !default;
 /// @group tabs
 $tab-underline-disabled: 2px solid $disabled-01 !default;
 
-// Skeleton Loading
-
 /// @type Color
 /// @access public
 /// @group skeleton
 /// TODO: Remove this in next major release
 $skeleton: $skeleton-01 !default;
-
-// Light UI
 
 // Determine the "light" color for a given token.
 /// @param {String} $token The theme token.

--- a/css/vendor/carbon-components/scss/globals/scss/_tooltip.scss
+++ b/css/vendor/carbon-components/scss/globals/scss/_tooltip.scss
@@ -10,8 +10,6 @@
 @import 'layout';
 @import 'typography';
 
-// Tooltip
-// Tooltip caret visual styles
 /// @access public
 /// @group tooltip
 @mixin tooltip--caret {
@@ -23,8 +21,6 @@
   content: '';
 }
 
-// Tooltip
-// Tooltip content box visual styles
 /// @param {String} $tooltip-type ['icon'] - The type, from: `icon`, `definition`
 /// @access public
 /// @group tooltip
@@ -55,8 +51,6 @@
   }
 }
 
-// Tooltip
-// Definition and Icon CSS only tooltip
 /// @param {String} $tooltip-type ['icon'] - The type, from: `icon`, `definition`
 /// @param {String} $position ['bottom'] - The position, from: `top`, `right`, `bottom`, `left`
 /// @access public
@@ -117,7 +111,6 @@
     transition: none;
   }
 
-  // caret
   &::before {
     width: 0;
     height: 0;
@@ -137,7 +130,6 @@
     word-break: break-word;
   }
 
-  // content box
   // @todo Simplify CSS selectors on next major release
   &::after,
   .#{$prefix}--assistive-text,
@@ -198,8 +190,6 @@
   }
 }
 
-// Tooltip
-// Definition and Icon CSS only tooltip
 /// @param {String} $tooltip-type ['icon'] - The type, from: `icon`, `definition`
 /// @param {String} $position ['bottom'] - The position, from: `top`, `right`, `bottom`, `left`
 /// @param {String} $align ['center'] - The alignment, from: `start`, `center`, `end`
@@ -210,7 +200,6 @@
   $position: 'bottom',
   $align: 'center'
 ) {
-  // position and alignment
   $caret-spacing: if($tooltip-type == 'definition', to-rem(4px), to-rem(8px));
 
   // space between caret and trigger button

--- a/css/vendor/carbon-components/scss/globals/scss/_typography.import.scss
+++ b/css/vendor/carbon-components/scss/globals/scss/_typography.import.scss
@@ -4,9 +4,7 @@
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
 //
-//-------------------------------------------
 // Compatibility notes (*.import.scss)
-// ------------------------------------------
 //
 // This file is intended to be consumed and processed with dart-sass.
 // It is incompatible with node-sass/libsass as it contains sass language features
@@ -91,7 +89,6 @@ $base-font-size: 16px !default;
   }
 }
 
-// 🔬 Experimental
 // stylelint-disable-next-line no-invalid-position-at-import-rule
 @import '../../globals/scss/vendor/@carbon/elements/scss/type/font-family';
 // stylelint-disable-next-line no-invalid-position-at-import-rule

--- a/css/vendor/carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/grid/_mixins.import.scss
+++ b/css/vendor/carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/grid/_mixins.import.scss
@@ -4,9 +4,7 @@
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
 //
-//-------------------------------------------
 // Compatibility notes (*.import.scss)
-// ------------------------------------------
 //
 // This file is intended to be consumed and processed with dart-sass.
 // It is incompatible with node-sass/libsass as it contains sass language features
@@ -28,9 +26,6 @@
 @import '../layout/breakpoint';
 @import 'prefix';
 
-// -----------------------------------------------------------------------------
-// Columns
-// -----------------------------------------------------------------------------
 
 /// Used to initialize the default properties for a column class, most notably
 /// for setting width and default gutters when a column's breakpoint has not been
@@ -140,7 +135,6 @@
     }
 
     @include carbon--breakpoint($breakpoint, $breakpoints) {
-      // Provide basic `.col-{bp}` classes for equal-width flexbox columns
       .#{$prefix}--col,
       .#{$prefix}--col#{$infix} {
         max-width: 100%;
@@ -173,9 +167,6 @@
   }
 }
 
-// -----------------------------------------------------------------------------
-// Rows
-// -----------------------------------------------------------------------------
 
 /// Define the properties for a selector assigned to a row in the grid system.
 /// @param {Number} $gutter [$carbon--grid-gutter] - The gutter in the grid system
@@ -188,9 +179,6 @@
   margin-left: -1 * $gutter * 0.5;
 }
 
-// -----------------------------------------------------------------------------
-// No gutter
-// -----------------------------------------------------------------------------
 
 /// Add `no-gutter` and `no-gutter--{start,end}` classes to the output CSS. These
 /// classes are useful for dropping the gutter in fluid situations.
@@ -225,9 +213,6 @@
   }
 }
 
-// -----------------------------------------------------------------------------
-// Hang
-// -----------------------------------------------------------------------------
 
 /// Add `hang--start` and `hang--end` classes for a given gutter. These classes are
 /// used alongside `no-gutter--start` and `no-gutter--end` to "hang" type.
@@ -253,9 +238,6 @@
   }
 }
 
-// -----------------------------------------------------------------------------
-// Aspect ratio
-// -----------------------------------------------------------------------------
 
 /// The aspect ratios that are used to generate corresponding aspect ratio
 /// classes in code
@@ -328,9 +310,6 @@ $carbon--aspect-ratios: (
   }
 }
 
-// -----------------------------------------------------------------------------
-// Grid
-// -----------------------------------------------------------------------------
 
 /// Create the container for a grid. Will cause full-bleed for the grid unless
 /// max-width properties are added with `make-container-max-widths`

--- a/css/vendor/carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/layout/_breakpoint.scss
+++ b/css/vendor/carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/layout/_breakpoint.scss
@@ -21,7 +21,6 @@ $carbon--grid-gutter: to-rem(32px);
 /// @group @carbon/layout
 $carbon--grid-gutter--condensed: to-rem(1px);
 
-// Initial map of our breakpoints and their values
 /// @type Map
 /// @access public
 /// @group @carbon/layout

--- a/css/vendor/carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/layout/_convert.import.scss
+++ b/css/vendor/carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/layout/_convert.import.scss
@@ -4,9 +4,7 @@
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
 //
-//-------------------------------------------
 // Compatibility notes (*.import.scss)
-// ------------------------------------------
 //
 // This file is intended to be consumed and processed with dart-sass.
 // It is incompatible with node-sass/libsass as it contains sass language features

--- a/css/vendor/carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/layout/_key-height.import.scss
+++ b/css/vendor/carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/layout/_key-height.import.scss
@@ -4,9 +4,7 @@
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
 //
-//-------------------------------------------
 // Compatibility notes (*.import.scss)
-// ------------------------------------------
 //
 // This file is intended to be consumed and processed with dart-sass.
 // It is incompatible with node-sass/libsass as it contains sass language features

--- a/css/vendor/carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/type/_classes.scss
+++ b/css/vendor/carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/type/_classes.scss
@@ -13,26 +13,22 @@
 /// @access public
 /// @group @carbon/type
 @mixin carbon--type-classes {
-  // Font families
   @each $name, $value in $carbon--font-families {
     .#{$prefix}--type-#{$name} {
       font-family: $value;
     }
   }
 
-  // Font weights
   @each $name, $value in $carbon--font-weights {
     .#{$prefix}--type-#{$name} {
       font-weight: $value;
     }
   }
 
-  // Font styles
   .#{$prefix}--type-italic {
     font-style: italic;
   }
 
-  // Type styles
   @each $name, $value in $tokens {
     .#{$prefix}--type-#{$name} {
       @include carbon--type-style($name, map-has-key($value, breakpoints));

--- a/css/vendor/carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/type/_styles.import.scss
+++ b/css/vendor/carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/type/_styles.import.scss
@@ -4,9 +4,7 @@
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
 //
-//-------------------------------------------
 // Compatibility notes (*.import.scss)
-// ------------------------------------------
 //
 // This file is intended to be consumed and processed with dart-sass.
 // It is incompatible with node-sass/libsass as it contains sass language features

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "lint": "biome check --write .",
     "lint:changed": "biome check --write --changed --since=master --no-errors-on-unmatched .",
     "build:css": "bun scripts/build-css",
+    "build:css:watch": "bun scripts/build-css --watch",
     "build:docs": "bun scripts/build-docs",
     "postinstall": "ibmtelemetry --config=telemetry.yml",
     "release": "bun scripts/release-changelog",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "lint:changed": "biome check --write --changed --since=master --no-errors-on-unmatched .",
     "build:css": "bun scripts/build-css",
     "build:css:watch": "bun scripts/build-css --watch",
+    "build:css:themes": "bun scripts/build-css --themes",
     "build:docs": "bun scripts/build-docs",
     "postinstall": "ibmtelemetry --config=telemetry.yml",
     "release": "bun scripts/release-changelog",

--- a/scripts/build-css.ts
+++ b/scripts/build-css.ts
@@ -10,6 +10,7 @@ import { initAsyncCompiler } from "sass-embedded";
 const PARTIAL_FILE_REGEX = /^_/;
 const CACHE_DIR = ".cache/build-css";
 const WATCH = process.argv.includes("--watch");
+const FULL_THEMES = process.argv.includes("--themes");
 // Svelte 5 minimum browsers — https://svelte.dev/docs/svelte/browser-support
 const BROWSERSLIST = [
   "Chrome >= 87",
@@ -57,6 +58,16 @@ function themeEntries() {
     .filter((file) => !PARTIAL_FILE_REGEX.test(file))
     .sort()
     .map((file) => path.parse(file));
+}
+
+function compileEntries() {
+  const entries = themeEntries();
+  if (FULL_THEMES) return entries;
+  const all = entries.find((entry) => entry.name === "all");
+  if (!all) {
+    throw new Error("css/all.scss is required for the default CSS build");
+  }
+  return [all];
 }
 
 async function hashPathStats(files: string[], cwd: string): Promise<string> {
@@ -131,7 +142,7 @@ async function build(compiler: Compiler): Promise<void> {
 
   const keyStarted = performance.now();
   const shared = await sharedInputs();
-  const scss = themeEntries();
+  const scss = compileEntries();
   const entryStats = await Promise.all(
     scss.map(async ({ base }) => ({
       base,
@@ -169,7 +180,7 @@ async function build(compiler: Compiler): Promise<void> {
     }),
   );
 
-  const cssTypes = `${scss
+  const cssTypes = `${themeEntries()
     .map(
       ({ name }) =>
         `declare module "carbon-components-svelte/css/${name}.css";`,
@@ -185,6 +196,7 @@ async function build(compiler: Compiler): Promise<void> {
       "[build-css]",
       `${compiled} compiled`,
       `${cached} cached`,
+      FULL_THEMES ? "all themes" : "all.css only",
       MINIFY ? "minify on" : "minify off",
       compiled ? `compile ${ms(workStarted)}` : "",
       `total ${ms(started)}`,

--- a/scripts/build-css.ts
+++ b/scripts/build-css.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
-import { access, mkdir, readFile, writeFile } from "node:fs/promises";
+import { watch } from "node:fs";
+import { access, mkdir, readFile, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
 import browserslist from "browserslist";
 import { Glob } from "bun";
@@ -8,6 +9,7 @@ import { initAsyncCompiler } from "sass-embedded";
 
 const PARTIAL_FILE_REGEX = /^_/;
 const CACHE_DIR = ".cache/build-css";
+const WATCH = process.argv.includes("--watch");
 // Svelte 5 minimum browsers — https://svelte.dev/docs/svelte/browser-support
 const BROWSERSLIST = [
   "Chrome >= 87",
@@ -16,6 +18,14 @@ const BROWSERSLIST = [
   "Edge >= 87",
 ] as const;
 const targets = browserslistToTargets(browserslist([...BROWSERSLIST]));
+
+function minifyEnabled(): boolean {
+  if (process.env.BUILD_CSS_MINIFY === "0") return false;
+  if (process.env.BUILD_CSS_MINIFY === "1") return true;
+  return process.env.CI === "true";
+}
+
+const MINIFY = minifyEnabled();
 
 function postprocessCss(css: string, outFile: string): Uint8Array {
   const { code } = transform({
@@ -42,32 +52,32 @@ const SASS_OPTIONS = {
   ],
 };
 
-const glob = new Glob("*.scss");
-const scss = Array.from(glob.scanSync({ cwd: "css" }))
-  .filter((file) => !PARTIAL_FILE_REGEX.test(file))
-  .sort()
-  .map((file) => path.parse(file));
-
-async function readPartialContents(): Promise<string> {
-  const partialGlob = new Glob("_*.scss");
-  const partials = Array.from(partialGlob.scanSync({ cwd: "css" })).sort();
-  return (
-    await Promise.all(partials.map((file) => readFile(`css/${file}`, "utf8")))
-  ).join("\0");
+function themeEntries() {
+  return Array.from(new Glob("*.scss").scanSync({ cwd: "css" }))
+    .filter((file) => !PARTIAL_FILE_REGEX.test(file))
+    .sort()
+    .map((file) => path.parse(file));
 }
 
-async function vendorHash(): Promise<string> {
-  const vendorGlob = new Glob("vendor/**/*.scss");
-  const files = Array.from(vendorGlob.scanSync({ cwd: "css" })).sort();
-  const contents = await Promise.all(
-    files.map((file) => readFile(`css/${file}`)),
-  );
+async function hashPathStats(files: string[], cwd: string): Promise<string> {
   const hash = createHash("sha256");
+  const stats = await Promise.all(
+    files.map((file) => stat(path.join(cwd, file))),
+  );
   files.forEach((file, i) => {
     hash.update(file);
-    hash.update(contents[i]);
+    hash.update("\0");
+    hash.update(String(stats[i].mtimeMs));
+    hash.update("\0");
+    hash.update(String(stats[i].size));
+    hash.update("\0");
   });
   return hash.digest("hex");
+}
+
+async function hashGlob(pattern: string, cwd: string): Promise<string> {
+  const files = Array.from(new Glob(pattern).scanSync({ cwd })).sort();
+  return await hashPathStats(files, cwd);
 }
 
 async function sharedInputs(): Promise<string> {
@@ -79,18 +89,19 @@ async function sharedInputs(): Promise<string> {
   };
 
   return [
-    await readPartialContents(),
-    await vendorHash(),
+    await hashGlob("_*.scss", "css"),
+    await hashGlob("vendor/**/*.scss", "css"),
     packageJson.devDependencies?.lightningcss ?? "",
     packageJson.devDependencies?.browserslist ?? "",
     BROWSERSLIST.join(","),
-    "lightningcss-single-pass",
+    MINIFY ? "lightningcss-single-pass" : "sass-compressed",
+    "stat-cache-v1",
   ].join("\0");
 }
 
-function inputHash(entryContents: string, shared: string): string {
+function inputHash(entryMtimeSize: string, shared: string): string {
   const hash = createHash("sha256");
-  hash.update(entryContents);
+  hash.update(entryMtimeSize);
   hash.update(shared);
   return hash.digest("hex");
 }
@@ -108,56 +119,134 @@ async function isCached(name: string, hash: string): Promise<boolean> {
   }
 }
 
-console.time("[build-css]");
+function ms(started: number): string {
+  return `${Math.round(performance.now() - started)}ms`;
+}
 
-await mkdir(CACHE_DIR, { recursive: true });
+type Compiler = Awaited<ReturnType<typeof initAsyncCompiler>>;
 
-const shared = await sharedInputs();
-const entryContents = await Promise.all(
-  scss.map(async ({ base }) => ({
-    base,
-    contents: await readFile(`css/${base}`, "utf8"),
-  })),
-);
+async function build(compiler: Compiler): Promise<void> {
+  const started = performance.now();
+  await mkdir(CACHE_DIR, { recursive: true });
 
-const compiler = await initAsyncCompiler();
+  const keyStarted = performance.now();
+  const shared = await sharedInputs();
+  const scss = themeEntries();
+  const entryStats = await Promise.all(
+    scss.map(async ({ base }) => ({
+      base,
+      stamp: await hashPathStats([base], "css"),
+    })),
+  );
+  console.log("[build-css] cache keys", ms(keyStarted));
 
-try {
+  let compiled = 0;
+  let cached = 0;
+  const workStarted = performance.now();
+
   await Promise.all(
     scss.map(async ({ name, base }) => {
       const file = `css/${base}`;
       const outFile = `css/${name}.css`;
-      const contents =
-        entryContents.find((entry) => entry.base === base)?.contents ?? "";
-      const hash = inputHash(contents, shared);
+      const stamp =
+        entryStats.find((entry) => entry.base === base)?.stamp ?? "";
+      const hash = inputHash(stamp, shared);
 
       if (await isCached(name, hash)) {
+        cached += 1;
         console.log("[build-css]", file, "-->", outFile, "(cached)");
         return;
       }
 
       console.log("[build-css]", file, "-->", outFile);
+      compiled += 1;
 
       const { css } = await compiler.compileAsync(file, SASS_OPTIONS);
-
-      console.time("[build-css] prefix");
-      const code = postprocessCss(css, outFile);
-      console.timeEnd("[build-css] prefix");
+      const code = MINIFY ? postprocessCss(css, outFile) : css;
 
       await Bun.write(outFile, code);
       await writeFile(`${CACHE_DIR}/${name}.hash`, `${hash}\n`);
     }),
   );
-} finally {
-  await compiler.dispose();
+
+  const cssTypes = `${scss
+    .map(
+      ({ name }) =>
+        `declare module "carbon-components-svelte/css/${name}.css";`,
+    )
+    .join("\n")}\n`;
+  const previousTypes = await readFile("css/css.d.ts", "utf8").catch(() => "");
+  if (previousTypes !== cssTypes) {
+    await Bun.write("css/css.d.ts", cssTypes);
+  }
+
+  console.log(
+    [
+      "[build-css]",
+      `${compiled} compiled`,
+      `${cached} cached`,
+      MINIFY ? "minify on" : "minify off",
+      compiled ? `compile ${ms(workStarted)}` : "",
+      `total ${ms(started)}`,
+    ]
+      .filter(Boolean)
+      .join(" "),
+  );
 }
 
-const cssTypes = scss
-  .map(
-    ({ name }) => `declare module "carbon-components-svelte/css/${name}.css";`,
-  )
-  .join("\n");
+function isScssChange(filename: string | null): boolean {
+  if (!filename) return true;
+  return filename.endsWith(".scss");
+}
 
-await Bun.write("css/css.d.ts", `${cssTypes}\n`);
+const compiler = await initAsyncCompiler();
+let keepAlive = false;
 
-console.timeEnd("[build-css]");
+try {
+  await build(compiler);
+
+  if (WATCH) {
+    keepAlive = true;
+    console.log("[build-css] watching css/**/*.scss");
+    let pending: ReturnType<typeof setTimeout> | undefined;
+    let running = false;
+    let rerun = false;
+
+    const kick = () => {
+      if (running) {
+        rerun = true;
+        return;
+      }
+      running = true;
+      build(compiler)
+        .catch((error: unknown) => {
+          console.error(error);
+        })
+        .finally(() => {
+          running = false;
+          if (rerun) {
+            rerun = false;
+            kick();
+          }
+        });
+    };
+
+    watch("css", { recursive: true }, (_event, filename) => {
+      if (!isScssChange(filename)) return;
+      clearTimeout(pending);
+      pending = setTimeout(kick, 150);
+    });
+
+    await new Promise<void>((resolve) => {
+      const stop = () => {
+        compiler.dispose().finally(() => resolve());
+      };
+      process.once("SIGINT", stop);
+      process.once("SIGTERM", stop);
+    });
+  }
+} finally {
+  if (!keepAlive) {
+    await compiler.dispose();
+  }
+}


### PR DESCRIPTION
Also speeds up `bun build:css` for the loop we actually run: docs,
e2e, and `Theme` only need `all.css`. Static theme sheets still
ship from `bun build:css:themes` on release. IBM TODOs in vendor
SCSS are frozen v10 notes, not follow-ups.

## Benchmark

Wall clock on this machine, minify off (`bun scripts/build-css`).
The "before" six-theme number is after skipping Lightning CSS
locally; the remaining drop is compiling one entry instead of six.

| Path | Before | After |
|---|---|---|
| Cold default build | ~15.7 s (six themes) | ~4.5 s (`all.css` only) |
| Unchanged rebuild | full compile | ~15 ms (stat cache) |