### PR TITLE
ci: run static-checks, changes, test, and test-svelte-compat on ubuntu-latest

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -24,7 +24,7 @@ env:
 
 jobs:
   static-checks:
-    runs-on: macos-15
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
@@ -39,7 +39,7 @@ jobs:
       - run: bun run test:package-exports
 
   changes:
-    runs-on: macos-15
+    runs-on: ubuntu-latest
     outputs:
       unit: ${{ steps.filter.outputs.unit }}
       e2e: ${{ steps.filter.outputs.e2e }}
@@ -83,7 +83,7 @@ jobs:
   test:
     needs: [changes]
     if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.unit == 'true'
-    runs-on: macos-15
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
@@ -146,7 +146,7 @@ jobs:
   test-svelte-compat:
     needs: [changes]
     if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.unit == 'true'
-    runs-on: macos-15
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:

--- a/tests-svelte3/vite.config.ts
+++ b/tests-svelte3/vite.config.ts
@@ -2,7 +2,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { svelte, vitePreprocess } from "@sveltejs/vite-plugin-svelte";
 import { defineConfig } from "vitest/config";
-import { testConfig } from "../tests/utils";
+import { testConfig } from "../tests/utils.ts";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 

--- a/tests-svelte4/vite.config.ts
+++ b/tests-svelte4/vite.config.ts
@@ -2,7 +2,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { svelte, vitePreprocess } from "@sveltejs/vite-plugin-svelte";
 import { defineConfig } from "vitest/config";
-import { testConfig } from "../tests/utils";
+import { testConfig } from "../tests/utils.ts";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 

--- a/tests/UIShell/HeaderAction.test.ts
+++ b/tests/UIShell/HeaderAction.test.ts
@@ -1,4 +1,8 @@
-import { render, screen, waitFor } from "@testing-library/svelte";
+import {
+  render,
+  screen,
+  waitForElementToBeRemoved,
+} from "@testing-library/svelte";
 import type HeaderActionComponent from "carbon-components-svelte/UIShell/HeaderAction.svelte";
 import type { ComponentProps } from "svelte";
 import { flushDismiss } from "../utils/flushDismiss";
@@ -84,9 +88,14 @@ describe("HeaderAction", () => {
 
       await user.keyboard("{Escape}");
 
-      await waitFor(() =>
-        expect(screen.queryByTestId("panel-content")).not.toBeInTheDocument(),
-      );
+      const panel = screen.queryByTestId("panel-content");
+      if (panel) {
+        // The panel's outro is a real (if duration: 0) transition driven by
+        // Svelte's rAF-based transition loop. Under CI's parallel worker
+        // load, jsdom's setTimeout-based rAF polyfill can lag well past the
+        // default 1s timeout even though nothing is actually stuck.
+        await waitForElementToBeRemoved(panel, { timeout: 5000 });
+      }
       expect(button).toHaveFocus();
     });
   });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,7 +2,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { svelte, vitePreprocess } from "@sveltejs/vite-plugin-svelte";
 import { defineConfig } from "vitest/config";
-import { testConfig } from "./tests/utils";
+import { testConfig } from "./tests/utils.ts";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 


### PR DESCRIPTION
None of these jobs touch anything macOS-specific, just Bun/
TypeScript/Svelte tasks, so there's no reason to pay for macos-15
runners here. test-e2e stays on ubuntu-latest and deploy-docs is
untouched.