### PR TITLE
chore(deps): upgrade sveld to 0.36.9

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -26,7 +26,7 @@
         "lightningcss": "^1.33.0",
         "mitata": "^1.0.34",
         "sass-embedded": "^1.100.0",
-        "sveld": "^0.36.8",
+        "sveld": "^0.36.9",
         "svelte": "^5.56.8",
         "svelte-check": "^4.7.3",
         "typescript": "^6.0.3",
@@ -472,7 +472,7 @@
 
     "supports-color": ["supports-color@8.1.1", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q=="],
 
-    "sveld": ["sveld@0.36.8", "", { "bin": { "sveld": "cli.js" } }, "sha512-/BK9AhFl9+HU683ETF8Z1F1kNg0msQ2gzM2i7bkYNzzmbsYmQddh0+BhCiA98MQL2zBtJ5YPPrU5Hl6bvxVYFA=="],
+    "sveld": ["sveld@0.36.9", "", { "bin": { "sveld": "cli.js" } }, "sha512-WuJ4q5KWBoDY7Arwbyyh5eOs+4DdTPi+NdRfsQG3fgc38ffwy/MunS+0SVtkvjRjjHEmTfOOdXOcPLHCP2nO/Q=="],
 
     "svelte": ["svelte@5.56.8", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "@jridgewell/sourcemap-codec": "^1.5.0", "@sveltejs/acorn-typescript": "^1.0.10", "@types/estree": "^1.0.5", "@types/trusted-types": "^2.0.7", "acorn": "^8.12.1", "aria-query": "5.3.1", "axobject-query": "^4.1.0", "clsx": "^2.1.1", "devalue": "^5.8.1", "esm-env": "^1.2.1", "esrap": "^2.2.12", "is-reference": "^3.0.3", "locate-character": "^3.0.0", "magic-string": "^0.30.11", "zimmerframe": "^1.1.2" } }, "sha512-PY8LOw7xP6c8IOiVqdo0sbbZVYhXRSfklOQLAUyGBKqjTX0wx/z4l/9J+PmBpmlLnxzEb1NqltxQ5/wZme/Cmg=="],
 

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "lightningcss": "^1.33.0",
     "mitata": "^1.0.34",
     "sass-embedded": "^1.100.0",
-    "sveld": "^0.36.8",
+    "sveld": "^0.36.9",
     "svelte": "^5.56.8",
     "svelte-check": "^4.7.3",
     "typescript": "^6.0.3",


### PR DESCRIPTION
This clears a false-positive "Could not resolve setContext key"
warning from build:docs, caused by ListBoxMenu's context key being
imported from a sibling module instead of declared locally.