### PR TITLE
fix(modal): `hasScrollingContent` has bottom overflow gradient

### DIFF
--- a/css/vendor/carbon-components/scss/components/modal/_modal.scss
+++ b/css/vendor/carbon-components/scss/components/modal/_modal.scss
@@ -375,3 +375,25 @@
 @include exports("modal-full-width") {
   @include modal-full-width;
 }
+
+// carbon-components-svelte patch (modal overflow indicator)
+@import "carbon-components/scss/globals/scss/vars";
+@import "carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/import-once/import-once";
+
+/// Overflow fade uses `rgba($ui-01, 0)`, which compiles to invalid
+/// `rgba(var(--cds-ui-01), 0)` when CSS custom properties are enabled
+/// (`css/all.scss`). Fill with `$ui-01` and mask the alpha instead so the
+/// fade follows the active theme.
+/// @access private
+/// @group components
+@mixin modal-overflow-indicator {
+  .#{$prefix}--modal-content--overflow-indicator {
+    background-color: $ui-01;
+    background-image: none;
+    mask-image: linear-gradient(to bottom, transparent, $black-100);
+  }
+}
+
+@include exports("modal-overflow-indicator") {
+  @include modal-overflow-indicator;
+}

--- a/docs/src/pages/components/Modal.svx
+++ b/docs/src/pages/components/Modal.svx
@@ -79,6 +79,12 @@ Enable vertical scrolling for modals with lengthy content. This ensures all cont
 
 <FileSource src="/framed/Modal/ModalScrollingContent" />
 
+### Scrolling form
+
+When `hasScrollingContent` is set, a gradient overlays the bottom of the body while more content remains below. Tabbing to a field near that edge scrolls it into view so it isn't hidden under the gradient. Use <DocKbd label="Tab" /> to move through the fields; the fade recedes once you reach the last field.
+
+<FileSource src="/framed/Modal/ModalScrollingForm" />
+
 ### Full width
 
 Set `fullWidth` to remove the modal body padding so content spans edge to edge. Use it for content that supplies its own layout, such as a table or fluid form.

--- a/docs/src/pages/framed/Modal/ModalScrollingForm.svelte
+++ b/docs/src/pages/framed/Modal/ModalScrollingForm.svelte
@@ -1,0 +1,29 @@
+<script>
+  import { Button, Modal, Stack, TextInput } from "carbon-components-svelte";
+
+  let open = false;
+</script>
+
+<Button on:click={() => (open = true)}>Provision resource</Button>
+
+<Modal
+  bind:open
+  size="sm"
+  modalHeading="Provision resource"
+  primaryButtonText="Provision"
+  secondaryButtonText="Cancel"
+  hasForm
+  hasScrollingContent
+  on:click:button--secondary={() => (open = false)}
+>
+  <Stack gap={5}>
+    <TextInput labelText="Name" placeholder="Enter name" />
+    <TextInput labelText="Email" type="email" placeholder="Enter email" />
+    <TextInput labelText="Organization" placeholder="Enter organization" />
+    <TextInput labelText="Region" placeholder="Enter region" />
+    <TextInput labelText="Project" placeholder="Enter project" />
+    <TextInput labelText="Resource name" placeholder="Enter resource name" />
+    <TextInput labelText="Capacity" placeholder="Enter capacity" />
+    <TextInput labelText="Notes" placeholder="Enter notes" />
+  </Stack>
+</Modal>

--- a/src/ComposedModal/ModalBody.svelte
+++ b/src/ComposedModal/ModalBody.svelte
@@ -7,6 +7,7 @@
 
   import { getContext } from "svelte";
   import { writable } from "svelte/store";
+  import { scrollIntoViewWithinMenu } from "../utils/scrollIntoViewWithinMenu.js";
 
   const composedModalCtx = getContext("carbon:ComposedModal");
   const modalLabel = composedModalCtx?.label ?? writable(undefined);
@@ -32,6 +33,13 @@
   class:bx--modal-content={true}
   class:bx--modal-content--with-form={hasForm}
   class:bx--modal-scroll-content={hasScrollingContent}
+  on:focusin={(event) => {
+    // Keep a newly-focused element (e.g. via Tab) from being hidden under
+    // the scroll gradient at the bottom of the content area.
+    if (event.target instanceof HTMLElement) {
+      scrollIntoViewWithinMenu(event.target, ".bx--modal-content");
+    }
+  }}
   {...$$restProps}
 >
   <slot />

--- a/src/Modal/Modal.svelte
+++ b/src/Modal/Modal.svelte
@@ -140,6 +140,7 @@
   import Close from "../icons/Close.svelte";
   import { initialFocus, restoreFocus } from "../utils/focus.js";
   import { createOutsideDismiss } from "../utils/outsideDismiss.js";
+  import { scrollIntoViewWithinMenu } from "../utils/scrollIntoViewWithinMenu.js";
   import { trapFocus } from "../utils/trapFocus.js";
   import { uniqueId } from "../utils/uniqueId.js";
   import { trackModal } from "./modalStore";
@@ -357,6 +358,13 @@
       role={hasScrollingContent ? "region" : undefined}
       aria-label={hasScrollingContent ? ariaLabel : undefined}
       aria-labelledby={modalLabel ? modalLabelId : modalHeadingId}
+      on:focusin={(event) => {
+        // Keep a newly-focused element (e.g. via Tab) from being hidden
+        // under the scroll gradient at the bottom of the content area.
+        if (event.target instanceof HTMLElement) {
+          scrollIntoViewWithinMenu(event.target, ".bx--modal-content");
+        }
+      }}
     >
       <slot />
     </div>

--- a/tests/ComposedModal/ComposedModal.test.ts
+++ b/tests/ComposedModal/ComposedModal.test.ts
@@ -262,6 +262,31 @@ describe("ComposedModal", () => {
     expect(modalBody).toHaveAttribute("tabindex", "0");
   });
 
+  it("scrolls a newly-focused element out from under the scroll gradient", () => {
+    render(ComposedModalTest, {
+      props: {
+        open: true,
+        headerTitle: "Test Modal",
+        bodyHasScrollingContent: true,
+      },
+    });
+
+    const modalContent = screen.getByRole("region");
+    Object.defineProperty(modalContent, "clientHeight", { value: 100 });
+    Object.defineProperty(modalContent, "scrollHeight", { value: 300 });
+    modalContent.scrollTop = 50;
+    modalContent.getBoundingClientRect = () =>
+      ({ top: 0, bottom: 100 }) as DOMRect;
+
+    const input = screen.getByTestId("test-focus");
+    input.getBoundingClientRect = () => ({ top: 110, bottom: 130 }) as DOMRect;
+
+    input.dispatchEvent(new FocusEvent("focusin", { bubbles: true }));
+
+    // scrollTop += itemBottom(130) - containerBottom(100) => 50 + 30 = 80
+    expect(modalContent.scrollTop).toBe(80);
+  });
+
   it("should handle form content", () => {
     render(ComposedModalTest, {
       props: {

--- a/tests/Modal/Modal.test.ts
+++ b/tests/Modal/Modal.test.ts
@@ -305,6 +305,31 @@ describe("Modal", () => {
     expect(modalBody).toHaveClass("bx--modal-scroll-content");
   });
 
+  it("scrolls a newly-focused element out from under the scroll gradient", () => {
+    render(ModalTest, {
+      props: {
+        open: true,
+        hasScrollingContent: true,
+        modalHeading: "Scrolling Modal",
+      },
+    });
+
+    const modalContent = screen.getByRole("region");
+    Object.defineProperty(modalContent, "clientHeight", { value: 100 });
+    Object.defineProperty(modalContent, "scrollHeight", { value: 300 });
+    modalContent.scrollTop = 50;
+    modalContent.getBoundingClientRect = () =>
+      ({ top: 0, bottom: 100 }) as DOMRect;
+
+    const input = screen.getByTestId("test-focus");
+    input.getBoundingClientRect = () => ({ top: 110, bottom: 130 }) as DOMRect;
+
+    input.dispatchEvent(new FocusEvent("focusin", { bubbles: true }));
+
+    // scrollTop += itemBottom(130) - containerBottom(100) => 50 + 30 = 80
+    expect(modalContent.scrollTop).toBe(80);
+  });
+
   // Regression test for https://github.com/carbon-design-system/carbon-components-svelte/issues/2671
   it("should focus primary button when open (not close button)", () => {
     render(ModalTest, {


### PR DESCRIPTION
The fade was compiling to invalid `rgba(var(--cds-ui-01), 0)` with CSS
custom properties, so the browser dropped it. Tabbing into a field near
that edge now scrolls it into view in Modal and ComposedModal, and
there's a Scrolling form example on the Modal docs page to try it.

---

<img width="854" height="634" alt="Screenshot 2026-08-22 at 3 13 39 PM" src="https://github.com/user-attachments/assets/bbd14072-ad7f-4b87-9085-543d485a0f97" />
