### PR TITLE
fix(pagination): add pageSelect slot for custom page-selection UI

### DIFF
--- a/docs/src/pages/components/Pagination.svx
+++ b/docs/src/pages/components/Pagination.svx
@@ -85,6 +85,12 @@ This example also overrides `itemRangeText` and `pageRangeText` to format the it
 
 <FileSource src="/framed/Pagination/PageWindow" />
 
+## Custom page select
+
+Use the `pageSelect` slot to replace the default page-number `Select` with your own control. The slot exposes `currentPage`, `totalPages`, `currentPageSize`, and `selectLabelText` for display; bind `page` on `Pagination` itself and set it from within the slot to navigate.
+
+<FileSource src="/framed/Pagination/PaginationPageSelect" />
+
 ## Simple
 
 Set `simple` for a compact previous/next control with page status text. Useful in toolbars and cards.

--- a/docs/src/pages/framed/Pagination/PaginationPageSelect.svelte
+++ b/docs/src/pages/framed/Pagination/PaginationPageSelect.svelte
@@ -1,0 +1,19 @@
+<script>
+  import { NumberInput, Pagination } from "carbon-components-svelte";
+
+  let page = 1;
+</script>
+
+<Pagination bind:page totalItems={102} pageSizes={[10, 15, 20]}>
+  <svelte:fragment slot="pageSelect" let:totalPages let:selectLabelText>
+    <NumberInput
+      size="sm"
+      hideLabel
+      hideSteppers
+      labelText={selectLabelText}
+      min={1}
+      max={totalPages}
+      bind:value={page}
+    />
+  </svelte:fragment>
+</Pagination>

--- a/src/Pagination/Pagination.svelte
+++ b/src/Pagination/Pagination.svelte
@@ -21,6 +21,13 @@
    */
 
   /**
+   * Override the page-selection control.
+   * Falls back to the default page number `Select` when unset.
+   * Use the bound `page` prop to navigate from within the slot.
+   * @slot {{ currentPage: number; totalPages: number; currentPageSize: number; selectLabelText: string; }} pageSelect
+   */
+
+  /**
    * Specify the current page index.
    * @bindable writable
    */
@@ -317,30 +324,38 @@
         {/if}
       </span>
     {:else if !pageInputDisabled}
-      <!-- Native <option>s instead of SelectItem: a SelectItem
-           registers a store subscriber per page (pageWindow, default
-           1000). Coerce on:update to Number — without SelectItem,
-           Select keeps option values as strings. -->
-      <Select
-        id="bx--pagination-select-{id}-pages"
-        class="bx--select__page-number"
-        labelText={pageSelectLabelText(totalPages)}
-        inline
-        hideLabel
-        disabled={pageInputDisabled || disabled}
-        selected={page}
-        on:update={(event) => {
-          const next = Number(event.detail);
-          page = next;
-          dispatch("change", { page: next });
-        }}
+      <slot
+        name="pageSelect"
+        currentPage={page}
+        {totalPages}
+        currentPageSize={pageSize}
+        selectLabelText={pageSelectLabelText(totalPages)}
       >
-        {#each selectItems as pageNumber (pageNumber)}
-          <option class="bx--select-option" value={pageNumber}>
-            {pageNumber}
-          </option>
-        {/each}
-      </Select>
+        <!-- Native <option>s instead of SelectItem: a SelectItem
+             registers a store subscriber per page (pageWindow, default
+             1000). Coerce on:update to Number — without SelectItem,
+             Select keeps option values as strings. -->
+        <Select
+          id="bx--pagination-select-{id}-pages"
+          class="bx--select__page-number"
+          labelText={pageSelectLabelText(totalPages)}
+          inline
+          hideLabel
+          disabled={pageInputDisabled || disabled}
+          selected={page}
+          on:update={(event) => {
+            const next = Number(event.detail);
+            page = next;
+            dispatch("change", { page: next });
+          }}
+        >
+          {#each selectItems as pageNumber (pageNumber)}
+            <option class="bx--select-option" value={pageNumber}>
+              {pageNumber}
+            </option>
+          {/each}
+        </Select>
+      </slot>
       <span class:bx--pagination__text={true}>
         {#if pagesUnknown}
           {pageText(page)}

--- a/tests/Pagination/Pagination.test.ts
+++ b/tests/Pagination/Pagination.test.ts
@@ -2,6 +2,7 @@ import { fireEvent, render, screen, within } from "@testing-library/svelte";
 import type { ComponentProps } from "svelte";
 import { user } from "../utils/user";
 import Pagination from "./Pagination.test.svelte";
+import PaginationPageSelectSlot from "./PaginationPageSelectSlot.test.svelte";
 
 describe("Pagination", () => {
   beforeEach(() => {
@@ -776,5 +777,42 @@ describe("Pagination", () => {
         call[0] === "update" && call[1].pageSize === 15 && call[1].page === 3,
     );
     expect(updateCalls.length).toBe(1);
+  });
+
+  describe("pageSelect slot", () => {
+    it("replaces the default page select and exposes slot props", () => {
+      render(PaginationPageSelectSlot, {
+        props: { totalItems: 40, pageSizes: [10] },
+      });
+
+      expect(
+        screen.queryByRole("combobox", { name: /Page number/ }),
+      ).not.toBeInTheDocument();
+      expect(screen.getByTestId("page-select-label")).toHaveTextContent(
+        "Page number, of 4 pages",
+      );
+      expect(screen.getByTestId("current-page")).toHaveTextContent("1");
+      expect(screen.getByTestId("total-pages")).toHaveTextContent("4");
+      expect(screen.getByTestId("current-page-size")).toHaveTextContent("10");
+    });
+
+    it("navigates when the slot sets the bound page prop", async () => {
+      const consoleLog = vi.spyOn(console, "log");
+      render(PaginationPageSelectSlot, {
+        props: { totalItems: 40, pageSizes: [10] },
+      });
+
+      await user.click(screen.getByText("Go to 3"));
+
+      expect(screen.getByTestId("current-page")).toHaveTextContent("3");
+      expect(consoleLog).toHaveBeenCalledWith("update", {
+        pageSize: 10,
+        page: 3,
+      });
+      // The pageSelect slot owns its own control, so Pagination has no
+      // interaction handler to fire "change" from; only "update" reflects
+      // the bound page prop changing.
+      expect(consoleLog).not.toHaveBeenCalledWith("change", expect.anything());
+    });
   });
 });

--- a/tests/Pagination/PaginationPageSelectSlot.test.svelte
+++ b/tests/Pagination/PaginationPageSelectSlot.test.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+  import Pagination from "carbon-components-svelte/Pagination/Pagination.svelte";
+  import type { ComponentProps } from "svelte";
+
+  export let page: ComponentProps<Pagination>["page"] = 1;
+  export let totalItems: ComponentProps<Pagination>["totalItems"] = 0;
+  export let pageSizes: ComponentProps<Pagination>["pageSizes"] = [10];
+</script>
+
+<Pagination
+  bind:page
+  {totalItems}
+  {pageSizes}
+  on:change={(e) => {
+    console.log("change", e.detail);
+  }}
+  on:update={(e) => {
+    console.log("update", e.detail);
+  }}
+>
+  <svelte:fragment
+    slot="pageSelect"
+    let:currentPage
+    let:totalPages
+    let:currentPageSize
+    let:selectLabelText
+  >
+    <span data-testid="page-select-label">{selectLabelText}</span>
+    <span data-testid="current-page">{currentPage}</span>
+    <span data-testid="total-pages">{totalPages}</span>
+    <span data-testid="current-page-size">{currentPageSize}</span>
+    <button type="button" on:click={() => (page = 3)}>Go to 3</button>
+  </svelte:fragment>
+</Pagination>


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon-components-svelte/pull/3691

Carries forward the remaining piece of #3691. The other two prop
additions in that PR (pageSelectLabelText,
backward/forwardTextTooltipPosition) had already landed separately
as #3704 and #3705, so only the pageSelect slot commit applied here.
Includes a docs example showing a custom NumberInput swapped in for
the page-number select.

---

<img width="942" height="165" alt="Screenshot 2026-08-22 at 3 37 41 PM" src="https://github.com/user-attachments/assets/82bd77d5-b7e7-4c53-83ec-12e9d1911a95" />
