### PR TITLE
fix(menu): apply indented-content modifier to selectable/radio items

### DIFF
--- a/css/vendor/carbon-components/scss/components/menu/_menu.scss
+++ b/css/vendor/carbon-components/scss/components/menu/_menu.scss
@@ -176,3 +176,30 @@
 @include exports("menu-xs") {
   @include menu-xs;
 }
+
+// carbon-components-svelte patch (formerly css/_menu-selection-icon.scss)
+@import "carbon-components/scss/globals/scss/vars";
+@import "carbon-components/scss/globals/scss/helper-mixins";
+@import "carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/import-once/import-once";
+
+/// A selectable/radio item's checkmark, in its own column ahead of any
+/// custom icon, so a menu mixing icons with checkboxes (e.g. "Cut" next to
+/// "Bold" with its own icon and a checkmark) keeps both columns aligned
+/// instead of the checkmark displacing the icon. v10 only ever swapped the
+/// icon for a checkmark in a single `__icon` box; this mirrors the same
+/// dimensions in a class of its own.
+/// @access private
+/// @group components
+@mixin menu-selection-icon {
+  .#{$prefix}--menu-option__selection-icon {
+    display: flex;
+    width: 1rem;
+    height: 1rem;
+    align-items: center;
+    margin-right: $spacing-03;
+  }
+}
+
+@include exports("menu-selection-icon") {
+  @include menu-selection-icon;
+}

--- a/docs/src/pages/components/Menu.svx
+++ b/docs/src/pages/components/Menu.svx
@@ -72,6 +72,12 @@ Wrap items in `MenuItemRadioGroup` for a set where one choice is active at a tim
 
 <FileSource src="/framed/Menu/MenuItemRadioGroup" />
 
+### Indent alignment
+
+A selectable or radio item reserves space on the left for its checkmark, then adds extra spacing before the label so the checkmark doesn't crowd the text. This menu mixes plain icon items with a checkbox group to show the difference: "Cut", "Copy", and "Paste" sit close to their icons, while "Bold" and "Italic" get the wider gap.
+
+<FileSource src="/framed/Menu/MenuItemIndentAlignment" />
+
 ### Nested
 
 Set `labelText` on a `MenuItem` and nest child `MenuItem` rows to get a submenu. Use the `labelChildren` slot instead of plain text to customize the label's content; `labelText` is still used as the accessible name and title in that case. See [MenuButton menu items](/components/MenuButton#menu-items) for keyboard and hover behavior.

--- a/docs/src/pages/components/Menu.svx
+++ b/docs/src/pages/components/Menu.svx
@@ -74,7 +74,7 @@ Wrap items in `MenuItemRadioGroup` for a set where one choice is active at a tim
 
 ### Indent alignment
 
-A selectable or radio item reserves space on the left for its checkmark, then adds extra spacing before the label so the checkmark doesn't crowd the text. This menu mixes plain icon items with a checkbox group to show the difference: "Cut", "Copy", and "Paste" sit close to their icons, while "Bold" and "Italic" get the wider gap.
+A selectable or radio item's checkmark and a `MenuItem`'s own `icon` sit in separate columns: the checkmark column reserves space for every item once any item in the menu is selectable or radio, and the icon column reserves space for every item once any item sets `icon`. This keeps every label in one column, whether or not that particular row has a checkmark, an icon, both, or neither.
 
 <FileSource src="/framed/Menu/MenuItemIndentAlignment" />
 

--- a/docs/src/pages/framed/Menu/MenuItemIndentAlignment.svelte
+++ b/docs/src/pages/framed/Menu/MenuItemIndentAlignment.svelte
@@ -1,0 +1,39 @@
+<script>
+  import {
+    Button,
+    Menu,
+    MenuDivider,
+    MenuItem,
+    MenuItemGroup,
+  } from "carbon-components-svelte";
+  import Copy from "carbon-icons-svelte/lib/Copy.svelte";
+  import Cut from "carbon-icons-svelte/lib/Cut.svelte";
+  import Paste from "carbon-icons-svelte/lib/Paste.svelte";
+
+  let anchor;
+  let open = false;
+  let selectedIds = ["bold"];
+</script>
+
+<Button bind:ref={anchor} on:click={() => (open = !open)}>Edit</Button>
+
+<Menu {anchor} bind:open labelText="Edit menu">
+  <MenuItem icon={Cut} shortcutText="⌘X" on:click={() => console.log("Cut")}>
+    Cut
+  </MenuItem>
+  <MenuItem icon={Copy} shortcutText="⌘C" on:click={() => console.log("Copy")}>
+    Copy
+  </MenuItem>
+  <MenuItem
+    icon={Paste}
+    shortcutText="⌘V"
+    on:click={() => console.log("Paste")}
+  >
+    Paste
+  </MenuItem>
+  <MenuDivider />
+  <MenuItemGroup labelText="Style" bind:selectedIds>
+    <MenuItem id="bold" shortcutText="⌘B">Bold</MenuItem>
+    <MenuItem id="italic" shortcutText="⌘I">Italic</MenuItem>
+  </MenuItemGroup>
+</Menu>

--- a/docs/src/pages/framed/Menu/MenuItemIndentAlignment.svelte
+++ b/docs/src/pages/framed/Menu/MenuItemIndentAlignment.svelte
@@ -9,6 +9,8 @@
   import Copy from "carbon-icons-svelte/lib/Copy.svelte";
   import Cut from "carbon-icons-svelte/lib/Cut.svelte";
   import Paste from "carbon-icons-svelte/lib/Paste.svelte";
+  import TextBold from "carbon-icons-svelte/lib/TextBold.svelte";
+  import TextItalic from "carbon-icons-svelte/lib/TextItalic.svelte";
 
   let anchor;
   let open = false;
@@ -33,7 +35,7 @@
   </MenuItem>
   <MenuDivider />
   <MenuItemGroup labelText="Style" bind:selectedIds>
-    <MenuItem id="bold" shortcutText="⌘B">Bold</MenuItem>
-    <MenuItem id="italic" shortcutText="⌘I">Italic</MenuItem>
+    <MenuItem id="bold" icon={TextBold} shortcutText="⌘B">Bold</MenuItem>
+    <MenuItem id="italic" icon={TextItalic} shortcutText="⌘I">Italic</MenuItem>
   </MenuItemGroup>
 </Menu>

--- a/src/Menu/Menu.svelte
+++ b/src/Menu/Menu.svelte
@@ -131,38 +131,48 @@
     dispatch("close", { trigger });
   }
 
-  // Carbon indents every item's label when the menu has any
-  // selectable/radio sibling, so the whole column stays aligned instead of
-  // just the indented rows shifting right on their own. Items register by
-  // an internal id (not the consumer-facing `id` prop) since a plain item
-  // never registers and multiple items may share no `id` at all.
-  const indentedIds = writable(/** @type {Set<string>} */ (new Set()));
-  const hasIndentedItems = derived(indentedIds, (_) => _.size > 0);
-  const batchedIndentedUpdate = batchStoreUpdates(indentedIds);
+  /**
+   * A menu-wide "does any item need this column" registry: a selectable/
+   * radio sibling reserves the checkmark column for every item, and an
+   * icon-bearing sibling reserves the icon column for every item, so the
+   * whole menu keeps both columns aligned instead of just the row that
+   * needs them shifting its own label over. Items register by an internal
+   * id (not the consumer-facing `id` prop), since a plain item never
+   * registers and multiple items may share no `id` at all.
+   * @returns {{ hasAny: import("svelte/store").Readable<boolean>, register: (id: string) => void, unregister: (id: string) => void }}
+   */
+  function createColumnRegistry() {
+    const ids = writable(/** @type {Set<string>} */ (new Set()));
+    const hasAny = derived(ids, (_) => _.size > 0);
+    const batchedUpdate = batchStoreUpdates(ids);
 
-  /** @type {(id: string) => void} */
-  function registerIndented(id) {
-    batchedIndentedUpdate((_) => {
-      if (_.has(id)) return _;
-      return new Set(_).add(id);
-    });
+    return {
+      hasAny,
+      register(id) {
+        batchedUpdate((_) => (_.has(id) ? _ : new Set(_).add(id)));
+      },
+      unregister(id) {
+        batchedUpdate((_) => {
+          if (!_.has(id)) return _;
+          const next = new Set(_);
+          next.delete(id);
+          return next;
+        });
+      },
+    };
   }
 
-  /** @type {(id: string) => void} */
-  function unregisterIndented(id) {
-    batchedIndentedUpdate((_) => {
-      if (!_.has(id)) return _;
-      const next = new Set(_);
-      next.delete(id);
-      return next;
-    });
-  }
+  const indentedColumn = createColumnRegistry();
+  const iconColumn = createColumnRegistry();
 
   setContext("carbon:Menu", {
     close,
-    registerIndented,
-    unregisterIndented,
-    hasIndentedItems,
+    registerIndented: indentedColumn.register,
+    unregisterIndented: indentedColumn.unregister,
+    hasIndentedItems: indentedColumn.hasAny,
+    registerIcon: iconColumn.register,
+    unregisterIcon: iconColumn.unregister,
+    hasIconItems: iconColumn.hasAny,
   });
 
   $: {

--- a/src/Menu/Menu.svelte
+++ b/src/Menu/Menu.svelte
@@ -98,7 +98,9 @@
   export let target = null;
 
   import { createEventDispatcher, setContext, tick } from "svelte";
+  import { derived, writable } from "svelte/store";
   import FloatingPortal from "../Portal/FloatingPortal.svelte";
+  import { batchStoreUpdates } from "../utils/batchStoreUpdates.js";
   import { dismiss } from "../utils/dismiss.js";
   import { isOutsideClick } from "../utils/isOutsideClick.js";
   import { rovingFocus } from "../utils/rovingFocus.js";
@@ -129,7 +131,39 @@
     dispatch("close", { trigger });
   }
 
-  setContext("carbon:Menu", { close });
+  // Carbon indents every item's label when the menu has any
+  // selectable/radio sibling, so the whole column stays aligned instead of
+  // just the indented rows shifting right on their own. Items register by
+  // an internal id (not the consumer-facing `id` prop) since a plain item
+  // never registers and multiple items may share no `id` at all.
+  const indentedIds = writable(/** @type {Set<string>} */ (new Set()));
+  const hasIndentedItems = derived(indentedIds, (_) => _.size > 0);
+  const batchedIndentedUpdate = batchStoreUpdates(indentedIds);
+
+  /** @type {(id: string) => void} */
+  function registerIndented(id) {
+    batchedIndentedUpdate((_) => {
+      if (_.has(id)) return _;
+      return new Set(_).add(id);
+    });
+  }
+
+  /** @type {(id: string) => void} */
+  function unregisterIndented(id) {
+    batchedIndentedUpdate((_) => {
+      if (!_.has(id)) return _;
+      const next = new Set(_);
+      next.delete(id);
+      return next;
+    });
+  }
+
+  setContext("carbon:Menu", {
+    close,
+    registerIndented,
+    unregisterIndented,
+    hasIndentedItems,
+  });
 
   $: {
     if (open && !prevOpen) {

--- a/src/Menu/MenuItem.svelte
+++ b/src/Menu/MenuItem.svelte
@@ -239,6 +239,7 @@
   <div
     class:bx--menu-option__content={true}
     class:bx--menu-option__content--disabled={disabled}
+    class:bx--menu-option__content--indented={isIndented}
   >
     {#if isIndented || icon}
       <div class:bx--menu-option__icon={true}>

--- a/src/Menu/MenuItem.svelte
+++ b/src/Menu/MenuItem.svelte
@@ -117,6 +117,16 @@
       : "menuitem";
   $: displayIcon = isIndented ? (selected ? Checkmark : undefined) : icon;
 
+  // A selectable/radio sibling widens every row's label gap so the whole
+  // column of labels stays aligned, not just this item's own.
+  const indentRegId = uniqueId();
+  const hasIndentedSiblings = ctx.hasIndentedItems;
+  $: if (isIndented) {
+    ctx.registerIndented(indentRegId);
+  } else {
+    ctx.unregisterIndented(indentRegId);
+  }
+
   function handleClick(event) {
     if (disabled) return;
 
@@ -172,6 +182,7 @@
     return () => {
       hoverIntent.cancel();
       unsubscribe?.();
+      ctx.unregisterIndented(indentRegId);
     };
   });
 </script>
@@ -239,9 +250,9 @@
   <div
     class:bx--menu-option__content={true}
     class:bx--menu-option__content--disabled={disabled}
-    class:bx--menu-option__content--indented={isIndented}
+    class:bx--menu-option__content--indented={$hasIndentedSiblings}
   >
-    {#if isIndented || icon}
+    {#if isIndented || icon || $hasIndentedSiblings}
       <div class:bx--menu-option__icon={true}>
         <svelte:component this={displayIcon} />
       </div>

--- a/src/Menu/MenuItem.svelte
+++ b/src/Menu/MenuItem.svelte
@@ -115,16 +115,23 @@
     : isSelectable
       ? "menuitemcheckbox"
       : "menuitem";
-  $: displayIcon = isIndented ? (selected ? Checkmark : undefined) : icon;
-
-  // A selectable/radio sibling widens every row's label gap so the whole
-  // column of labels stays aligned, not just this item's own.
+  // A selectable/radio sibling reserves the checkmark column for every
+  // item, and an icon-bearing sibling reserves the icon column for every
+  // item, so both stay aligned across the whole menu instead of just the
+  // row that needs them shifting its own label over.
   const indentRegId = uniqueId();
+  const iconRegId = uniqueId();
   const hasIndentedSiblings = ctx.hasIndentedItems;
+  const hasIconSiblings = ctx.hasIconItems;
   $: if (isIndented) {
     ctx.registerIndented(indentRegId);
   } else {
     ctx.unregisterIndented(indentRegId);
+  }
+  $: if (icon) {
+    ctx.registerIcon(iconRegId);
+  } else {
+    ctx.unregisterIcon(iconRegId);
   }
 
   function handleClick(event) {
@@ -183,6 +190,7 @@
       hoverIntent.cancel();
       unsubscribe?.();
       ctx.unregisterIndented(indentRegId);
+      ctx.unregisterIcon(iconRegId);
     };
   });
 </script>
@@ -250,11 +258,17 @@
   <div
     class:bx--menu-option__content={true}
     class:bx--menu-option__content--disabled={disabled}
-    class:bx--menu-option__content--indented={$hasIndentedSiblings}
   >
-    {#if isIndented || icon || $hasIndentedSiblings}
+    {#if isIndented || $hasIndentedSiblings}
+      <div class:bx--menu-option__selection-icon={true}>
+        {#if isIndented && selected}
+          <Checkmark />
+        {/if}
+      </div>
+    {/if}
+    {#if icon || $hasIconSiblings}
       <div class:bx--menu-option__icon={true}>
-        <svelte:component this={displayIcon} />
+        <svelte:component this={icon} />
       </div>
     {/if}
     <span class:bx--menu-option__label={true}>

--- a/tests/Menu/MenuItem.selectable.test.svelte
+++ b/tests/Menu/MenuItem.selectable.test.svelte
@@ -2,6 +2,7 @@
   import Menu from "carbon-components-svelte/Menu/Menu.svelte";
   import MenuItem from "carbon-components-svelte/Menu/MenuItem.svelte";
   import MenuItemGroup from "carbon-components-svelte/Menu/MenuItemGroup.svelte";
+  import Add from "carbon-icons-svelte/lib/Add.svelte";
   import type { ComponentProps } from "svelte";
 
   export let selectedIds: ComponentProps<MenuItemGroup>["selectedIds"] = [];
@@ -18,7 +19,7 @@
   <MenuItem>Plain</MenuItem>
   <MenuItemGroup labelText="Columns" bind:selectedIds>
     <MenuItem id="name" labelText="Name" />
-    <MenuItem id="size" labelText="Size" selected />
+    <MenuItem id="size" labelText="Size" icon={Add} selected />
     <MenuItem id="date" labelText="Date" on:click={(e) => e.preventDefault()} />
   </MenuItemGroup>
 </Menu>

--- a/tests/Menu/MenuItem.test.ts
+++ b/tests/Menu/MenuItem.test.ts
@@ -19,6 +19,17 @@ describe("MenuItem", () => {
     expect(icon).toBeInTheDocument();
   });
 
+  it("does not apply the indented content modifier to a plain icon item", async () => {
+    render(MenuItemFixture);
+
+    await user.click(screen.getByRole("button", { name: "Trigger" }));
+
+    const item = screen.getByRole("menuitem", { name: "Add item" });
+    expect(item.querySelector(".bx--menu-option__content")).not.toHaveClass(
+      "bx--menu-option__content--indented",
+    );
+  });
+
   it("does not render an icon wrapper when icon is unset", async () => {
     render(MenuItemFixture);
 
@@ -367,6 +378,17 @@ describe("MenuItem", () => {
       expect(getSelectedIds()).toEqual(["size"]);
     });
 
+    it("applies the indented content modifier to checkbox items", async () => {
+      render(MenuItemSelectableFixture);
+
+      await user.click(screen.getByRole("button", { name: "Trigger" }));
+
+      const item = screen.getByRole("menuitemcheckbox", { name: "Name" });
+      expect(item.querySelector(".bx--menu-option__content")).toHaveClass(
+        "bx--menu-option__content--indented",
+      );
+    });
+
     it("toggles aria-checked and the bound selectedIds on click", async () => {
       render(MenuItemSelectableFixture);
 
@@ -441,6 +463,17 @@ describe("MenuItem", () => {
         screen.getByRole("menuitemradio", { name: "Comfortable" }),
       ).toHaveAttribute("aria-checked", "true");
       expect(getSelectedId()).toBe("comfortable");
+    });
+
+    it("applies the indented content modifier to radio items", async () => {
+      render(MenuItemRadioGroupFixture);
+
+      await user.click(screen.getByRole("button", { name: "Trigger" }));
+
+      const item = screen.getByRole("menuitemradio", { name: "Compact" });
+      expect(item.querySelector(".bx--menu-option__content")).toHaveClass(
+        "bx--menu-option__content--indented",
+      );
     });
 
     it("unchecks the previous item when another one is selected", async () => {

--- a/tests/Menu/MenuItem.test.ts
+++ b/tests/Menu/MenuItem.test.ts
@@ -19,26 +19,24 @@ describe("MenuItem", () => {
     expect(icon).toBeInTheDocument();
   });
 
-  it("does not apply the indented content modifier to a plain icon item", async () => {
+  it("does not reserve a checkmark column when no item in the menu is selectable or radio", async () => {
     render(MenuItemFixture);
 
     await user.click(screen.getByRole("button", { name: "Trigger" }));
 
     const item = screen.getByRole("menuitem", { name: "Add item" });
-    expect(item.querySelector(".bx--menu-option__content")).not.toHaveClass(
-      "bx--menu-option__content--indented",
-    );
+    expect(
+      item.querySelector(".bx--menu-option__selection-icon"),
+    ).not.toBeInTheDocument();
   });
 
-  it("does not render an icon wrapper when icon is unset", async () => {
+  it("reserves an icon column for a sibling without its own icon, so its label lines up with icon items", async () => {
     render(MenuItemFixture);
 
     await user.click(screen.getByRole("button", { name: "Trigger" }));
 
     const item = screen.getByRole("menuitem", { name: "Plain" });
-    expect(
-      item.querySelector(".bx--menu-option__icon"),
-    ).not.toBeInTheDocument();
+    expect(item.querySelector(".bx--menu-option__icon")).toBeInTheDocument();
   });
 
   it("renders shortcutText in the info region", async () => {
@@ -378,26 +376,40 @@ describe("MenuItem", () => {
       expect(getSelectedIds()).toEqual(["size"]);
     });
 
-    it("applies the indented content modifier to checkbox items", async () => {
+    it("reserves a checkmark column for checkbox items", async () => {
       render(MenuItemSelectableFixture);
 
       await user.click(screen.getByRole("button", { name: "Trigger" }));
 
       const item = screen.getByRole("menuitemcheckbox", { name: "Name" });
-      expect(item.querySelector(".bx--menu-option__content")).toHaveClass(
-        "bx--menu-option__content--indented",
-      );
+      expect(
+        item.querySelector(".bx--menu-option__selection-icon"),
+      ).toBeInTheDocument();
     });
 
-    it("indents a plain sibling's content so its label stays aligned with checkbox items", async () => {
+    it("renders a checked item's own icon alongside its checkmark, in separate columns", async () => {
+      render(MenuItemSelectableFixture);
+
+      await user.click(screen.getByRole("button", { name: "Trigger" }));
+
+      const item = screen.getByRole("menuitemcheckbox", { name: "Size" });
+      const selectionIcon = item.querySelector(
+        ".bx--menu-option__selection-icon svg",
+      );
+      const icon = item.querySelector(".bx--menu-option__icon svg");
+      expect(selectionIcon).toBeInTheDocument();
+      expect(icon).toBeInTheDocument();
+    });
+
+    it("reserves a checkmark column for a plain sibling so its label stays aligned with checkbox items", async () => {
       render(MenuItemSelectableFixture);
 
       await user.click(screen.getByRole("button", { name: "Trigger" }));
 
       const plainItem = screen.getByRole("menuitem", { name: "Plain" });
-      expect(plainItem.querySelector(".bx--menu-option__content")).toHaveClass(
-        "bx--menu-option__content--indented",
-      );
+      expect(
+        plainItem.querySelector(".bx--menu-option__selection-icon"),
+      ).toBeInTheDocument();
     });
 
     it("toggles aria-checked and the bound selectedIds on click", async () => {
@@ -476,15 +488,15 @@ describe("MenuItem", () => {
       expect(getSelectedId()).toBe("comfortable");
     });
 
-    it("applies the indented content modifier to radio items", async () => {
+    it("reserves a checkmark column for radio items", async () => {
       render(MenuItemRadioGroupFixture);
 
       await user.click(screen.getByRole("button", { name: "Trigger" }));
 
       const item = screen.getByRole("menuitemradio", { name: "Compact" });
-      expect(item.querySelector(".bx--menu-option__content")).toHaveClass(
-        "bx--menu-option__content--indented",
-      );
+      expect(
+        item.querySelector(".bx--menu-option__selection-icon"),
+      ).toBeInTheDocument();
     });
 
     it("unchecks the previous item when another one is selected", async () => {

--- a/tests/Menu/MenuItem.test.ts
+++ b/tests/Menu/MenuItem.test.ts
@@ -389,6 +389,17 @@ describe("MenuItem", () => {
       );
     });
 
+    it("indents a plain sibling's content so its label stays aligned with checkbox items", async () => {
+      render(MenuItemSelectableFixture);
+
+      await user.click(screen.getByRole("button", { name: "Trigger" }));
+
+      const plainItem = screen.getByRole("menuitem", { name: "Plain" });
+      expect(plainItem.querySelector(".bx--menu-option__content")).toHaveClass(
+        "bx--menu-option__content--indented",
+      );
+    });
+
     it("toggles aria-checked and the bound selectedIds on click", async () => {
       render(MenuItemSelectableFixture);
 


### PR DESCRIPTION
Found while auditing #3715 (the CSS selector-pruning PR), which
flagged bx--menu-option__content--indented as a possible unwired
feature: MenuItem.svelte computed isIndented for selectable/radio
items but never applied that class, so Carbon's checkmark indentation
never took effect.

That single-box, "checkmark replaces icon" model turned out not to
match Carbon's real behavior. In Carbon's own menu, a selectable/radio
item's checkmark sits in its own column ahead of any custom icon, not
in place of it, and that alignment holds across every item in the
menu, not just the ones that are themselves checkable. A menu mixing
icon items with a checkbox group (e.g. "Cut" with a scissors icon next
to "Bold" with a bold-glyph icon and a checkmark) needs all of: a
shared checkmark column, a shared icon column, and both reserved for
every row so labels land in one column regardless of what that
particular row itself has.

Menu now tracks two independent menu-wide flags via context: whether
any item is selectable/radio (reserves the checkmark column for every
item) and whether any item sets `icon` (reserves the icon column for
every item). MenuItem renders both columns from those shared flags,
filling each with its own state. This also lifts an existing
limitation where a selectable/radio item's `icon` prop was silently
dropped in favor of the checkmark; icon and checkmark can now render
together.

Adds a MenuItemIndentAlignment docs example mixing icon items with an
icon-plus-checkbox group to make the two-column alignment visible.

---

<img width="534" height="282" alt="Screenshot 2026-08-22 at 4 42 06 PM" src="https://github.com/user-attachments/assets/6e571ba6-88cc-439b-966a-521fff5760b4" />

