### PR TITLE
docs: scrub meta version/parity references from .svx pages

### DIFF
--- a/docs/src/pages/components/Box.svx
+++ b/docs/src/pages/components/Box.svx
@@ -18,7 +18,7 @@ Apply Carbon fill and border tokens.
 
 ### Fill
 
-Set `fill` to a Carbon background token. Tokens use v11 names and resolve through the active theme.
+Set `fill` to a Carbon background token. Tokens resolve through the active theme.
 
 | Token        | Description                          |
 | ------------ | ------------------------------------ |

--- a/docs/src/pages/components/ComboButton.svx
+++ b/docs/src/pages/components/ComboButton.svx
@@ -68,7 +68,7 @@ Set `iconDescription` to an empty string to render the trigger without Carbon's 
 
 ## Size
 
-Set `size` to scale both buttons and each menu item's row height together. The default is `"md"`. `ComboButton` only supports the `"primary"` kind, matching Carbon React.
+Set `size` to scale both buttons and each menu item's row height together. The default is `"md"`. `ComboButton` only supports the `"primary"` kind.
 
 ### Extra small
 

--- a/docs/src/pages/components/Menu.svx
+++ b/docs/src/pages/components/Menu.svx
@@ -20,7 +20,7 @@ Set `size` to control each item's row height. The default is `"sm"`.
 
 ### Extra small
 
-`"xs"` has no Carbon v10 equivalent; it's a compact row height hand-authored for this library.
+`"xs"` is a compact row height for dense layouts.
 
 <FileSource src="/framed/Menu/MenuSizeExtraSmall" />
 


### PR DESCRIPTION
Removes leftover Carbon-version and React-parity callouts from Box,
ComboButton, and Menu docs pages, since those are implementation
details rather than facts users need.