### PR TITLE
chore(deps-dev): upgrade sveld to 0.36.10

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -26,7 +26,7 @@
         "lightningcss": "^1.33.0",
         "mitata": "^1.0.34",
         "sass-embedded": "^1.100.0",
-        "sveld": "^0.36.9",
+        "sveld": "^0.36.10",
         "svelte": "^5.56.8",
         "svelte-check": "^4.7.3",
         "typescript": "^6.0.3",
@@ -472,7 +472,7 @@
 
     "supports-color": ["supports-color@8.1.1", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q=="],
 
-    "sveld": ["sveld@0.36.9", "", { "bin": { "sveld": "cli.js" } }, "sha512-WuJ4q5KWBoDY7Arwbyyh5eOs+4DdTPi+NdRfsQG3fgc38ffwy/MunS+0SVtkvjRjjHEmTfOOdXOcPLHCP2nO/Q=="],
+    "sveld": ["sveld@0.36.10", "", { "bin": { "sveld": "cli.js" } }, "sha512-zBdtKTv0aMNf0kJmTlej1YOTTWH09BD1CrY13U53AbVfocM8fGm+48IN0iQEToQAW7sDYz8Tuz288fkelHDtUg=="],
 
     "svelte": ["svelte@5.56.8", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "@jridgewell/sourcemap-codec": "^1.5.0", "@sveltejs/acorn-typescript": "^1.0.10", "@types/estree": "^1.0.5", "@types/trusted-types": "^2.0.7", "acorn": "^8.12.1", "aria-query": "5.3.1", "axobject-query": "^4.1.0", "clsx": "^2.1.1", "devalue": "^5.8.1", "esm-env": "^1.2.1", "esrap": "^2.2.12", "is-reference": "^3.0.3", "locate-character": "^3.0.0", "magic-string": "^0.30.11", "zimmerframe": "^1.1.2" } }, "sha512-PY8LOw7xP6c8IOiVqdo0sbbZVYhXRSfklOQLAUyGBKqjTX0wx/z4l/9J+PmBpmlLnxzEb1NqltxQ5/wZme/Cmg=="],
 

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "lightningcss": "^1.33.0",
     "mitata": "^1.0.34",
     "sass-embedded": "^1.100.0",
-    "sveld": "^0.36.9",
+    "sveld": "^0.36.10",
     "svelte": "^5.56.8",
     "svelte-check": "^4.7.3",
     "typescript": "^6.0.3",


### PR DESCRIPTION
Bumps the sveld dev dependency from 0.36.9 to the latest release
(0.36.10). Verified TypeScript definitions still generate cleanly via
build:docs.