### PR TITLE
test(docs): add baseline regression test for header search ranking

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -10,7 +10,8 @@
     "build:sitemap": "bun scripts/generate-sitemap.ts",
     "format-component-api": "bun scripts/format-component-api.ts",
     "build:vite": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "bun test scripts/__tests__"
   },
   "devDependencies": {
     "@roxi/routify": "^3.6.4",

--- a/docs/scripts/__fixtures__/search-index.json
+++ b/docs/scripts/__fixtures__/search-index.json
@@ -1,0 +1,2809 @@
+[
+  {
+    "id": "Button-page",
+    "text": "Button",
+    "description": "Button",
+    "href": "/components/Button",
+    "isComponent": true
+  },
+  {
+    "id": "Buttonkinds",
+    "text": "Button",
+    "description": "Kinds",
+    "href": "/components/Button#kinds",
+    "isComponent": false
+  },
+  {
+    "id": "Buttonicons",
+    "text": "Button",
+    "description": "Icons",
+    "href": "/components/Button#icons",
+    "isComponent": false
+  },
+  {
+    "id": "Buttonelement",
+    "text": "Button",
+    "description": "Element",
+    "href": "/components/Button#element",
+    "isComponent": false
+  },
+  {
+    "id": "Buttonsizes",
+    "text": "Button",
+    "description": "Sizes",
+    "href": "/components/Button#sizes",
+    "isComponent": false
+  },
+  {
+    "id": "Buttondisabled",
+    "text": "Button",
+    "description": "Disabled",
+    "href": "/components/Button#disabled",
+    "isComponent": false
+  },
+  {
+    "id": "Buttonexpressive-styles",
+    "text": "Button",
+    "description": "Expressive styles",
+    "href": "/components/Button#expressive-styles",
+    "isComponent": false
+  },
+  {
+    "id": "Buttonskeleton",
+    "text": "Button",
+    "description": "Skeleton",
+    "href": "/components/Button#skeleton",
+    "isComponent": false
+  },
+  {
+    "id": "Buttonprogrammatic-focus",
+    "text": "Button",
+    "description": "Programmatic focus",
+    "href": "/components/Button#programmatic-focus",
+    "isComponent": false
+  },
+  {
+    "id": "Toggle-page",
+    "text": "Toggle",
+    "description": "Toggle",
+    "href": "/components/Toggle",
+    "isComponent": true
+  },
+  {
+    "id": "Togglebasic",
+    "text": "Toggle",
+    "description": "Basic",
+    "href": "/components/Toggle#basic",
+    "isComponent": false
+  },
+  {
+    "id": "Toggletoggled",
+    "text": "Toggle",
+    "description": "Toggled",
+    "href": "/components/Toggle#toggled",
+    "isComponent": false
+  },
+  {
+    "id": "Togglelabels",
+    "text": "Toggle",
+    "description": "Labels",
+    "href": "/components/Toggle#labels",
+    "isComponent": false
+  },
+  {
+    "id": "Togglestates",
+    "text": "Toggle",
+    "description": "States",
+    "href": "/components/Toggle#states",
+    "isComponent": false
+  },
+  {
+    "id": "Togglesmall",
+    "text": "Toggle",
+    "description": "Small",
+    "href": "/components/Toggle#small",
+    "isComponent": false
+  },
+  {
+    "id": "Togglereactive",
+    "text": "Toggle",
+    "description": "Reactive",
+    "href": "/components/Toggle#reactive",
+    "isComponent": false
+  },
+  {
+    "id": "Toggleevents",
+    "text": "Toggle",
+    "description": "Events",
+    "href": "/components/Toggle#events",
+    "isComponent": false
+  },
+  {
+    "id": "Toggleskeleton",
+    "text": "Toggle",
+    "description": "Skeleton",
+    "href": "/components/Toggle#skeleton",
+    "isComponent": false
+  },
+  {
+    "id": "NumberInput-page",
+    "text": "NumberInput",
+    "description": "NumberInput",
+    "href": "/components/NumberInput",
+    "isComponent": true
+  },
+  {
+    "id": "NumberInputbasic",
+    "text": "NumberInput",
+    "description": "Basic",
+    "href": "/components/NumberInput#basic",
+    "isComponent": false
+  },
+  {
+    "id": "NumberInputno-value",
+    "text": "NumberInput",
+    "description": "No value",
+    "href": "/components/NumberInput#no-value",
+    "isComponent": false
+  },
+  {
+    "id": "NumberInputhelper-text",
+    "text": "NumberInput",
+    "description": "Helper text",
+    "href": "/components/NumberInput#helper-text",
+    "isComponent": false
+  },
+  {
+    "id": "NumberInputhidden-label",
+    "text": "NumberInput",
+    "description": "Hidden label",
+    "href": "/components/NumberInput#hidden-label",
+    "isComponent": false
+  },
+  {
+    "id": "NumberInputcustom-label",
+    "text": "NumberInput",
+    "description": "Custom label",
+    "href": "/components/NumberInput#custom-label",
+    "isComponent": false
+  },
+  {
+    "id": "NumberInputrange-and-steps",
+    "text": "NumberInput",
+    "description": "Range and steps",
+    "href": "/components/NumberInput#range-and-steps",
+    "isComponent": false
+  },
+  {
+    "id": "NumberInputformatting",
+    "text": "NumberInput",
+    "description": "Formatting",
+    "href": "/components/NumberInput#formatting",
+    "isComponent": false
+  },
+  {
+    "id": "NumberInputcustom-validation",
+    "text": "NumberInput",
+    "description": "Custom validation",
+    "href": "/components/NumberInput#custom-validation",
+    "isComponent": false
+  },
+  {
+    "id": "NumberInputstepper-controls",
+    "text": "NumberInput",
+    "description": "Stepper controls",
+    "href": "/components/NumberInput#stepper-controls",
+    "isComponent": false
+  },
+  {
+    "id": "NumberInputevents",
+    "text": "NumberInput",
+    "description": "Events",
+    "href": "/components/NumberInput#events",
+    "isComponent": false
+  },
+  {
+    "id": "NumberInputsizes",
+    "text": "NumberInput",
+    "description": "Sizes",
+    "href": "/components/NumberInput#sizes",
+    "isComponent": false
+  },
+  {
+    "id": "NumberInputlight",
+    "text": "NumberInput",
+    "description": "Light",
+    "href": "/components/NumberInput#light",
+    "isComponent": false
+  },
+  {
+    "id": "NumberInputfluid",
+    "text": "NumberInput",
+    "description": "Fluid",
+    "href": "/components/NumberInput#fluid",
+    "isComponent": false
+  },
+  {
+    "id": "NumberInputstates",
+    "text": "NumberInput",
+    "description": "States",
+    "href": "/components/NumberInput#states",
+    "isComponent": false
+  },
+  {
+    "id": "NumberInputskeleton",
+    "text": "NumberInput",
+    "description": "Skeleton",
+    "href": "/components/NumberInput#skeleton",
+    "isComponent": false
+  },
+  {
+    "id": "Text-page",
+    "text": "Text",
+    "description": "Text",
+    "href": "/components/Text",
+    "isComponent": true
+  },
+  {
+    "id": "Textbasic",
+    "text": "Text",
+    "description": "Basic",
+    "href": "/components/Text#basic",
+    "isComponent": false
+  },
+  {
+    "id": "Texttext-color",
+    "text": "Text",
+    "description": "Text color",
+    "href": "/components/Text#text-color",
+    "isComponent": false
+  },
+  {
+    "id": "Texttype-styles",
+    "text": "Text",
+    "description": "Type styles",
+    "href": "/components/Text#type-styles",
+    "isComponent": false
+  },
+  {
+    "id": "Textcustom-element",
+    "text": "Text",
+    "description": "Custom element",
+    "href": "/components/Text#custom-element",
+    "isComponent": false
+  },
+  {
+    "id": "Textmodifiers",
+    "text": "Text",
+    "description": "Modifiers",
+    "href": "/components/Text#modifiers",
+    "isComponent": false
+  },
+  {
+    "id": "Texttruncate",
+    "text": "Text",
+    "description": "Truncate",
+    "href": "/components/Text#truncate",
+    "isComponent": false
+  },
+  {
+    "id": "Texttypography-inspiration",
+    "text": "Text",
+    "description": "Typography inspiration",
+    "href": "/components/Text#typography-inspiration",
+    "isComponent": false
+  },
+  {
+    "id": "Textutility-classes",
+    "text": "Text",
+    "description": "Utility classes",
+    "href": "/components/Text#utility-classes",
+    "isComponent": false
+  },
+  {
+    "id": "Modal-page",
+    "text": "Modal",
+    "description": "Modal",
+    "href": "/components/Modal",
+    "isComponent": true
+  },
+  {
+    "id": "Modalmodal-vs-composedmodal",
+    "text": "Modal",
+    "description": "Modal vs ComposedModal",
+    "href": "/components/Modal#modal-vs-composedmodal",
+    "isComponent": false
+  },
+  {
+    "id": "Modalbasic",
+    "text": "Modal",
+    "description": "Basic",
+    "href": "/components/Modal#basic",
+    "isComponent": false
+  },
+  {
+    "id": "Modalfocus",
+    "text": "Modal",
+    "description": "Focus",
+    "href": "/components/Modal#focus",
+    "isComponent": false
+  },
+  {
+    "id": "Modalalert-mode",
+    "text": "Modal",
+    "description": "Alert mode",
+    "href": "/components/Modal#alert-mode",
+    "isComponent": false
+  },
+  {
+    "id": "Modalvariants",
+    "text": "Modal",
+    "description": "Variants",
+    "href": "/components/Modal#variants",
+    "isComponent": false
+  },
+  {
+    "id": "Modalcontent",
+    "text": "Modal",
+    "description": "Content",
+    "href": "/components/Modal#content",
+    "isComponent": false
+  },
+  {
+    "id": "Modalbuttons",
+    "text": "Modal",
+    "description": "Buttons",
+    "href": "/components/Modal#buttons",
+    "isComponent": false
+  },
+  {
+    "id": "Modalstacking-modals",
+    "text": "Modal",
+    "description": "Stacking modals",
+    "href": "/components/Modal#stacking-modals",
+    "isComponent": false
+  },
+  {
+    "id": "Modalportal-and-dropdowns",
+    "text": "Modal",
+    "description": "Portal and dropdowns",
+    "href": "/components/Modal#portal-and-dropdowns",
+    "isComponent": false
+  },
+  {
+    "id": "Modalsizes",
+    "text": "Modal",
+    "description": "Sizes",
+    "href": "/components/Modal#sizes",
+    "isComponent": false
+  },
+  {
+    "id": "Modalclosing",
+    "text": "Modal",
+    "description": "Closing",
+    "href": "/components/Modal#closing",
+    "isComponent": false
+  },
+  {
+    "id": "Modalevents",
+    "text": "Modal",
+    "description": "Events",
+    "href": "/components/Modal#events",
+    "isComponent": false
+  },
+  {
+    "id": "Box-page",
+    "text": "Box",
+    "description": "Box",
+    "href": "/components/Box",
+    "isComponent": true
+  },
+  {
+    "id": "Boxbasic",
+    "text": "Box",
+    "description": "Basic",
+    "href": "/components/Box#basic",
+    "isComponent": false
+  },
+  {
+    "id": "Boxtokens",
+    "text": "Box",
+    "description": "Tokens",
+    "href": "/components/Box#tokens",
+    "isComponent": false
+  },
+  {
+    "id": "Boxspacing",
+    "text": "Box",
+    "description": "Spacing",
+    "href": "/components/Box#spacing",
+    "isComponent": false
+  },
+  {
+    "id": "Boxwidth",
+    "text": "Box",
+    "description": "Width",
+    "href": "/components/Box#width",
+    "isComponent": false
+  },
+  {
+    "id": "Boxcustom-element",
+    "text": "Box",
+    "description": "Custom element",
+    "href": "/components/Box#custom-element",
+    "isComponent": false
+  },
+  {
+    "id": "Boxcomposition",
+    "text": "Box",
+    "description": "Composition",
+    "href": "/components/Box#composition",
+    "isComponent": false
+  },
+  {
+    "id": "Boxutility-classes",
+    "text": "Box",
+    "description": "Utility classes",
+    "href": "/components/Box#utility-classes",
+    "isComponent": false
+  },
+  {
+    "id": "ButtonSet-page",
+    "text": "ButtonSet",
+    "description": "ButtonSet",
+    "href": "/components/ButtonSet",
+    "isComponent": true
+  },
+  {
+    "id": "ButtonSetbasic",
+    "text": "ButtonSet",
+    "description": "Basic",
+    "href": "/components/ButtonSet#basic",
+    "isComponent": false
+  },
+  {
+    "id": "ButtonSetstacked",
+    "text": "ButtonSet",
+    "description": "Stacked",
+    "href": "/components/ButtonSet#stacked",
+    "isComponent": false
+  },
+  {
+    "id": "UnorderedList-page",
+    "text": "UnorderedList",
+    "description": "UnorderedList",
+    "href": "/components/UnorderedList",
+    "isComponent": true
+  },
+  {
+    "id": "UnorderedListbasic",
+    "text": "UnorderedList",
+    "description": "Basic",
+    "href": "/components/UnorderedList#basic",
+    "isComponent": false
+  },
+  {
+    "id": "UnorderedListwith-links",
+    "text": "UnorderedList",
+    "description": "With links",
+    "href": "/components/UnorderedList#with-links",
+    "isComponent": false
+  },
+  {
+    "id": "UnorderedListnested-lists",
+    "text": "UnorderedList",
+    "description": "Nested lists",
+    "href": "/components/UnorderedList#nested-lists",
+    "isComponent": false
+  },
+  {
+    "id": "UnorderedListexpressive-styles",
+    "text": "UnorderedList",
+    "description": "Expressive styles",
+    "href": "/components/UnorderedList#expressive-styles",
+    "isComponent": false
+  },
+  {
+    "id": "Form-page",
+    "text": "Form",
+    "description": "Form",
+    "href": "/components/Form",
+    "isComponent": true
+  },
+  {
+    "id": "Formbasic",
+    "text": "Form",
+    "description": "Basic",
+    "href": "/components/Form#basic",
+    "isComponent": false
+  },
+  {
+    "id": "Formform-group",
+    "text": "Form",
+    "description": "Form group",
+    "href": "/components/Form#form-group",
+    "isComponent": false
+  },
+  {
+    "id": "Formsubmission",
+    "text": "Form",
+    "description": "Submission",
+    "href": "/components/Form#submission",
+    "isComponent": false
+  },
+  {
+    "id": "MultiSelect-page",
+    "text": "MultiSelect",
+    "description": "MultiSelect",
+    "href": "/components/MultiSelect",
+    "isComponent": true
+  },
+  {
+    "id": "MultiSelectbasic",
+    "text": "MultiSelect",
+    "description": "Basic",
+    "href": "/components/MultiSelect#basic",
+    "isComponent": false
+  },
+  {
+    "id": "MultiSelectcontent",
+    "text": "MultiSelect",
+    "description": "Content",
+    "href": "/components/MultiSelect#content",
+    "isComponent": false
+  },
+  {
+    "id": "MultiSelectselection",
+    "text": "MultiSelect",
+    "description": "Selection",
+    "href": "/components/MultiSelect#selection",
+    "isComponent": false
+  },
+  {
+    "id": "MultiSelectfilterable",
+    "text": "MultiSelect",
+    "description": "Filterable",
+    "href": "/components/MultiSelect#filterable",
+    "isComponent": false
+  },
+  {
+    "id": "MultiSelectmultiple-multi-selects",
+    "text": "MultiSelect",
+    "description": "Multiple multi-selects",
+    "href": "/components/MultiSelect#multiple-multi-selects",
+    "isComponent": false
+  },
+  {
+    "id": "MultiSelectvirtualization",
+    "text": "MultiSelect",
+    "description": "Virtualization",
+    "href": "/components/MultiSelect#virtualization",
+    "isComponent": false
+  },
+  {
+    "id": "MultiSelectsizes",
+    "text": "MultiSelect",
+    "description": "Sizes",
+    "href": "/components/MultiSelect#sizes",
+    "isComponent": false
+  },
+  {
+    "id": "MultiSelectlight",
+    "text": "MultiSelect",
+    "description": "Light",
+    "href": "/components/MultiSelect#light",
+    "isComponent": false
+  },
+  {
+    "id": "MultiSelectinline",
+    "text": "MultiSelect",
+    "description": "Inline",
+    "href": "/components/MultiSelect#inline",
+    "isComponent": false
+  },
+  {
+    "id": "MultiSelecttop-direction",
+    "text": "MultiSelect",
+    "description": "Top direction",
+    "href": "/components/MultiSelect#top-direction",
+    "isComponent": false
+  },
+  {
+    "id": "MultiSelectfluid",
+    "text": "MultiSelect",
+    "description": "Fluid",
+    "href": "/components/MultiSelect#fluid",
+    "isComponent": false
+  },
+  {
+    "id": "MultiSelectportal-menu",
+    "text": "MultiSelect",
+    "description": "Portal menu",
+    "href": "/components/MultiSelect#portal-menu",
+    "isComponent": false
+  },
+  {
+    "id": "MultiSelectstates",
+    "text": "MultiSelect",
+    "description": "States",
+    "href": "/components/MultiSelect#states",
+    "isComponent": false
+  },
+  {
+    "id": "UserAvatar-page",
+    "text": "UserAvatar",
+    "description": "UserAvatar",
+    "href": "/components/UserAvatar",
+    "isComponent": true
+  },
+  {
+    "id": "UserAvatarcontent",
+    "text": "UserAvatar",
+    "description": "Content",
+    "href": "/components/UserAvatar#content",
+    "isComponent": false
+  },
+  {
+    "id": "UserAvatarimage",
+    "text": "UserAvatar",
+    "description": "Image",
+    "href": "/components/UserAvatar#image",
+    "isComponent": false
+  },
+  {
+    "id": "UserAvatarsizes",
+    "text": "UserAvatar",
+    "description": "Sizes",
+    "href": "/components/UserAvatar#sizes",
+    "isComponent": false
+  },
+  {
+    "id": "UserAvatarbackground-colors",
+    "text": "UserAvatar",
+    "description": "Background colors",
+    "href": "/components/UserAvatar#background-colors",
+    "isComponent": false
+  },
+  {
+    "id": "UserAvatarclickable-avatar",
+    "text": "UserAvatar",
+    "description": "Clickable avatar",
+    "href": "/components/UserAvatar#clickable-avatar",
+    "isComponent": false
+  },
+  {
+    "id": "UserAvatartooltip",
+    "text": "UserAvatar",
+    "description": "Tooltip",
+    "href": "/components/UserAvatar#tooltip",
+    "isComponent": false
+  },
+  {
+    "id": "UserAvataruse-within-profilemenu",
+    "text": "UserAvatar",
+    "description": "Use within ProfileMenu",
+    "href": "/components/UserAvatar#use-within-profilemenu",
+    "isComponent": false
+  },
+  {
+    "id": "TextArea-page",
+    "text": "TextArea",
+    "description": "TextArea",
+    "href": "/components/TextArea",
+    "isComponent": true
+  },
+  {
+    "id": "TextAreabasic",
+    "text": "TextArea",
+    "description": "Basic",
+    "href": "/components/TextArea#basic",
+    "isComponent": false
+  },
+  {
+    "id": "TextArearows-and-columns",
+    "text": "TextArea",
+    "description": "Rows and columns",
+    "href": "/components/TextArea#rows-and-columns",
+    "isComponent": false
+  },
+  {
+    "id": "TextAreamaximum-character-count",
+    "text": "TextArea",
+    "description": "Maximum character count",
+    "href": "/components/TextArea#maximum-character-count",
+    "isComponent": false
+  },
+  {
+    "id": "TextAreahelper-text",
+    "text": "TextArea",
+    "description": "Helper text",
+    "href": "/components/TextArea#helper-text",
+    "isComponent": false
+  },
+  {
+    "id": "TextAreahidden-label",
+    "text": "TextArea",
+    "description": "Hidden label",
+    "href": "/components/TextArea#hidden-label",
+    "isComponent": false
+  },
+  {
+    "id": "TextAreacustom-label",
+    "text": "TextArea",
+    "description": "Custom label",
+    "href": "/components/TextArea#custom-label",
+    "isComponent": false
+  },
+  {
+    "id": "TextArealight",
+    "text": "TextArea",
+    "description": "Light",
+    "href": "/components/TextArea#light",
+    "isComponent": false
+  },
+  {
+    "id": "TextAreafluid",
+    "text": "TextArea",
+    "description": "Fluid",
+    "href": "/components/TextArea#fluid",
+    "isComponent": false
+  },
+  {
+    "id": "TextAreastates",
+    "text": "TextArea",
+    "description": "States",
+    "href": "/components/TextArea#states",
+    "isComponent": false
+  },
+  {
+    "id": "TextAreaskeleton",
+    "text": "TextArea",
+    "description": "Skeleton",
+    "href": "/components/TextArea#skeleton",
+    "isComponent": false
+  },
+  {
+    "id": "OrderedList-page",
+    "text": "OrderedList",
+    "description": "OrderedList",
+    "href": "/components/OrderedList",
+    "isComponent": true
+  },
+  {
+    "id": "OrderedListbasic",
+    "text": "OrderedList",
+    "description": "Basic",
+    "href": "/components/OrderedList#basic",
+    "isComponent": false
+  },
+  {
+    "id": "OrderedListwith-links",
+    "text": "OrderedList",
+    "description": "With links",
+    "href": "/components/OrderedList#with-links",
+    "isComponent": false
+  },
+  {
+    "id": "OrderedListnested-lists",
+    "text": "OrderedList",
+    "description": "Nested lists",
+    "href": "/components/OrderedList#nested-lists",
+    "isComponent": false
+  },
+  {
+    "id": "OrderedListexpressive-styles",
+    "text": "OrderedList",
+    "description": "Expressive styles",
+    "href": "/components/OrderedList#expressive-styles",
+    "isComponent": false
+  },
+  {
+    "id": "Select-page",
+    "text": "Select",
+    "description": "Select",
+    "href": "/components/Select",
+    "isComponent": true
+  },
+  {
+    "id": "Selectbasic",
+    "text": "Select",
+    "description": "Basic",
+    "href": "/components/Select#basic",
+    "isComponent": false
+  },
+  {
+    "id": "Selectreactive",
+    "text": "Select",
+    "description": "Reactive",
+    "href": "/components/Select#reactive",
+    "isComponent": false
+  },
+  {
+    "id": "Selectcontent",
+    "text": "Select",
+    "description": "Content",
+    "href": "/components/Select#content",
+    "isComponent": false
+  },
+  {
+    "id": "Selectsizes",
+    "text": "Select",
+    "description": "Sizes",
+    "href": "/components/Select#sizes",
+    "isComponent": false
+  },
+  {
+    "id": "Selectvariants",
+    "text": "Select",
+    "description": "Variants",
+    "href": "/components/Select#variants",
+    "isComponent": false
+  },
+  {
+    "id": "Selectfluid",
+    "text": "Select",
+    "description": "Fluid",
+    "href": "/components/Select#fluid",
+    "isComponent": false
+  },
+  {
+    "id": "Selectstates",
+    "text": "Select",
+    "description": "States",
+    "href": "/components/Select#states",
+    "isComponent": false
+  },
+  {
+    "id": "Selectskeleton",
+    "text": "Select",
+    "description": "Skeleton",
+    "href": "/components/Select#skeleton",
+    "isComponent": false
+  },
+  {
+    "id": "InlineNotification-page",
+    "text": "InlineNotification",
+    "description": "InlineNotification",
+    "href": "/components/InlineNotification",
+    "isComponent": true
+  },
+  {
+    "id": "InlineNotificationbasic",
+    "text": "InlineNotification",
+    "description": "Basic",
+    "href": "/components/InlineNotification#basic",
+    "isComponent": false
+  },
+  {
+    "id": "InlineNotificationreusable",
+    "text": "InlineNotification",
+    "description": "Reusable",
+    "href": "/components/InlineNotification#reusable",
+    "isComponent": false
+  },
+  {
+    "id": "InlineNotificationautoclose",
+    "text": "InlineNotification",
+    "description": "Autoclose",
+    "href": "/components/InlineNotification#autoclose",
+    "isComponent": false
+  },
+  {
+    "id": "InlineNotificationtitle-and-subtitle",
+    "text": "InlineNotification",
+    "description": "Title and subtitle",
+    "href": "/components/InlineNotification#title-and-subtitle",
+    "isComponent": false
+  },
+  {
+    "id": "InlineNotificationactions",
+    "text": "InlineNotification",
+    "description": "Actions",
+    "href": "/components/InlineNotification#actions",
+    "isComponent": false
+  },
+  {
+    "id": "InlineNotificationclose-button",
+    "text": "InlineNotification",
+    "description": "Close button",
+    "href": "/components/InlineNotification#close-button",
+    "isComponent": false
+  },
+  {
+    "id": "InlineNotificationaria-role",
+    "text": "InlineNotification",
+    "description": "ARIA role",
+    "href": "/components/InlineNotification#aria-role",
+    "isComponent": false
+  },
+  {
+    "id": "InlineNotificationvariants",
+    "text": "InlineNotification",
+    "description": "Variants",
+    "href": "/components/InlineNotification#variants",
+    "isComponent": false
+  },
+  {
+    "id": "TooltipDefinition-page",
+    "text": "TooltipDefinition",
+    "description": "TooltipDefinition",
+    "href": "/components/TooltipDefinition",
+    "isComponent": true
+  },
+  {
+    "id": "TooltipDefinitionbasic",
+    "text": "TooltipDefinition",
+    "description": "Basic",
+    "href": "/components/TooltipDefinition#basic",
+    "isComponent": false
+  },
+  {
+    "id": "TooltipDefinitionplacement",
+    "text": "TooltipDefinition",
+    "description": "Placement",
+    "href": "/components/TooltipDefinition#placement",
+    "isComponent": false
+  },
+  {
+    "id": "TooltipDefinitionopen-behavior",
+    "text": "TooltipDefinition",
+    "description": "Open behavior",
+    "href": "/components/TooltipDefinition#open-behavior",
+    "isComponent": false
+  },
+  {
+    "id": "TooltipDefinitionreactive-example",
+    "text": "TooltipDefinition",
+    "description": "Reactive example",
+    "href": "/components/TooltipDefinition#reactive-example",
+    "isComponent": false
+  },
+  {
+    "id": "TooltipDefinitiondispatched-events",
+    "text": "TooltipDefinition",
+    "description": "Dispatched events",
+    "href": "/components/TooltipDefinition#dispatched-events",
+    "isComponent": false
+  },
+  {
+    "id": "TooltipDefinitioncustom-delay",
+    "text": "TooltipDefinition",
+    "description": "Custom delay",
+    "href": "/components/TooltipDefinition#custom-delay",
+    "isComponent": false
+  },
+  {
+    "id": "TooltipDefinitioncustom-tooltip-slot",
+    "text": "TooltipDefinition",
+    "description": "Custom tooltip slot",
+    "href": "/components/TooltipDefinition#custom-tooltip-slot",
+    "isComponent": false
+  },
+  {
+    "id": "TooltipDefinitionportal",
+    "text": "TooltipDefinition",
+    "description": "Portal",
+    "href": "/components/TooltipDefinition#portal",
+    "isComponent": false
+  },
+  {
+    "id": "TooltipDefinitioninside-a-modal",
+    "text": "TooltipDefinition",
+    "description": "Inside a modal",
+    "href": "/components/TooltipDefinition#inside-a-modal",
+    "isComponent": false
+  },
+  {
+    "id": "Dropdown-page",
+    "text": "Dropdown",
+    "description": "Dropdown",
+    "href": "/components/Dropdown",
+    "isComponent": true
+  },
+  {
+    "id": "Dropdownbasic",
+    "text": "Dropdown",
+    "description": "Basic",
+    "href": "/components/Dropdown#basic",
+    "isComponent": false
+  },
+  {
+    "id": "Dropdownselection",
+    "text": "Dropdown",
+    "description": "Selection",
+    "href": "/components/Dropdown#selection",
+    "isComponent": false
+  },
+  {
+    "id": "Dropdowncontent",
+    "text": "Dropdown",
+    "description": "Content",
+    "href": "/components/Dropdown#content",
+    "isComponent": false
+  },
+  {
+    "id": "Dropdownmenu",
+    "text": "Dropdown",
+    "description": "Menu",
+    "href": "/components/Dropdown#menu",
+    "isComponent": false
+  },
+  {
+    "id": "Dropdownvirtualization",
+    "text": "Dropdown",
+    "description": "Virtualization",
+    "href": "/components/Dropdown#virtualization",
+    "isComponent": false
+  },
+  {
+    "id": "Dropdownmultiple-dropdowns",
+    "text": "Dropdown",
+    "description": "Multiple dropdowns",
+    "href": "/components/Dropdown#multiple-dropdowns",
+    "isComponent": false
+  },
+  {
+    "id": "Dropdownevents",
+    "text": "Dropdown",
+    "description": "Events",
+    "href": "/components/Dropdown#events",
+    "isComponent": false
+  },
+  {
+    "id": "Dropdownsizes",
+    "text": "Dropdown",
+    "description": "Sizes",
+    "href": "/components/Dropdown#sizes",
+    "isComponent": false
+  },
+  {
+    "id": "Dropdownstates",
+    "text": "Dropdown",
+    "description": "States",
+    "href": "/components/Dropdown#states",
+    "isComponent": false
+  },
+  {
+    "id": "Dropdownlight",
+    "text": "Dropdown",
+    "description": "Light",
+    "href": "/components/Dropdown#light",
+    "isComponent": false
+  },
+  {
+    "id": "Dropdowninline",
+    "text": "Dropdown",
+    "description": "Inline",
+    "href": "/components/Dropdown#inline",
+    "isComponent": false
+  },
+  {
+    "id": "Dropdownfluid",
+    "text": "Dropdown",
+    "description": "Fluid",
+    "href": "/components/Dropdown#fluid",
+    "isComponent": false
+  },
+  {
+    "id": "Dropdownform-name",
+    "text": "Dropdown",
+    "description": "Form name",
+    "href": "/components/Dropdown#form-name",
+    "isComponent": false
+  },
+  {
+    "id": "Dropdownskeleton",
+    "text": "Dropdown",
+    "description": "Skeleton",
+    "href": "/components/Dropdown#skeleton",
+    "isComponent": false
+  },
+  {
+    "id": "SearchMenu-page",
+    "text": "SearchMenu",
+    "description": "SearchMenu",
+    "href": "/components/SearchMenu",
+    "isComponent": true
+  },
+  {
+    "id": "SearchMenubasic",
+    "text": "SearchMenu",
+    "description": "Basic",
+    "href": "/components/SearchMenu#basic",
+    "isComponent": false
+  },
+  {
+    "id": "SearchMenusizes",
+    "text": "SearchMenu",
+    "description": "Sizes",
+    "href": "/components/SearchMenu#sizes",
+    "isComponent": false
+  },
+  {
+    "id": "SearchMenulight",
+    "text": "SearchMenu",
+    "description": "Light",
+    "href": "/components/SearchMenu#light",
+    "isComponent": false
+  },
+  {
+    "id": "SearchMenucustom-icon",
+    "text": "SearchMenu",
+    "description": "Custom icon",
+    "href": "/components/SearchMenu#custom-icon",
+    "isComponent": false
+  },
+  {
+    "id": "SearchMenuclose-button-label",
+    "text": "SearchMenu",
+    "description": "Close button label",
+    "href": "/components/SearchMenu#close-button-label",
+    "isComponent": false
+  },
+  {
+    "id": "SearchMenugrouping",
+    "text": "SearchMenu",
+    "description": "Grouping",
+    "href": "/components/SearchMenu#grouping",
+    "isComponent": false
+  },
+  {
+    "id": "SearchMenulayout",
+    "text": "SearchMenu",
+    "description": "Layout",
+    "href": "/components/SearchMenu#layout",
+    "isComponent": false
+  },
+  {
+    "id": "SearchMenumenu-positioning",
+    "text": "SearchMenu",
+    "description": "Menu positioning",
+    "href": "/components/SearchMenu#menu-positioning",
+    "isComponent": false
+  },
+  {
+    "id": "SearchMenumatching",
+    "text": "SearchMenu",
+    "description": "Matching",
+    "href": "/components/SearchMenu#matching",
+    "isComponent": false
+  },
+  {
+    "id": "SearchMenufiltering",
+    "text": "SearchMenu",
+    "description": "Filtering",
+    "href": "/components/SearchMenu#filtering",
+    "isComponent": false
+  },
+  {
+    "id": "SearchMenuevents",
+    "text": "SearchMenu",
+    "description": "Events",
+    "href": "/components/SearchMenu#events",
+    "isComponent": false
+  },
+  {
+    "id": "SearchMenudisabled",
+    "text": "SearchMenu",
+    "description": "Disabled",
+    "href": "/components/SearchMenu#disabled",
+    "isComponent": false
+  },
+  {
+    "id": "SearchMenuskeleton",
+    "text": "SearchMenu",
+    "description": "Skeleton",
+    "href": "/components/SearchMenu#skeleton",
+    "isComponent": false
+  },
+  {
+    "id": "Stack-page",
+    "text": "Stack",
+    "description": "Stack",
+    "href": "/components/Stack",
+    "isComponent": true
+  },
+  {
+    "id": "Stackgap",
+    "text": "Stack",
+    "description": "Gap",
+    "href": "/components/Stack#gap",
+    "isComponent": false
+  },
+  {
+    "id": "Stackcustom-gap-value",
+    "text": "Stack",
+    "description": "Custom gap value",
+    "href": "/components/Stack#custom-gap-value",
+    "isComponent": false
+  },
+  {
+    "id": "Stackalignment",
+    "text": "Stack",
+    "description": "Alignment",
+    "href": "/components/Stack#alignment",
+    "isComponent": false
+  },
+  {
+    "id": "Stackjustify",
+    "text": "Stack",
+    "description": "Justify",
+    "href": "/components/Stack#justify",
+    "isComponent": false
+  },
+  {
+    "id": "Stackcombined-align-and-justify",
+    "text": "Stack",
+    "description": "Combined align and justify",
+    "href": "/components/Stack#combined-align-and-justify",
+    "isComponent": false
+  },
+  {
+    "id": "Stackwrap",
+    "text": "Stack",
+    "description": "Wrap",
+    "href": "/components/Stack#wrap",
+    "isComponent": false
+  },
+  {
+    "id": "Stackinline",
+    "text": "Stack",
+    "description": "Inline",
+    "href": "/components/Stack#inline",
+    "isComponent": false
+  },
+  {
+    "id": "Stackcustom-element",
+    "text": "Stack",
+    "description": "Custom element",
+    "href": "/components/Stack#custom-element",
+    "isComponent": false
+  },
+  {
+    "id": "TreeView-page",
+    "text": "TreeView",
+    "description": "TreeView",
+    "href": "/components/TreeView",
+    "isComponent": true
+  },
+  {
+    "id": "TreeViewbasic",
+    "text": "TreeView",
+    "description": "Basic",
+    "href": "/components/TreeView#basic",
+    "isComponent": false
+  },
+  {
+    "id": "TreeViewcompact",
+    "text": "TreeView",
+    "description": "Compact",
+    "href": "/components/TreeView#compact",
+    "isComponent": false
+  },
+  {
+    "id": "TreeViewhidden-label",
+    "text": "TreeView",
+    "description": "Hidden label",
+    "href": "/components/TreeView#hidden-label",
+    "isComponent": false
+  },
+  {
+    "id": "TreeViewcustom-label",
+    "text": "TreeView",
+    "description": "Custom label",
+    "href": "/components/TreeView#custom-label",
+    "isComponent": false
+  },
+  {
+    "id": "TreeViewinitial-state",
+    "text": "TreeView",
+    "description": "Initial state",
+    "href": "/components/TreeView#initial-state",
+    "isComponent": false
+  },
+  {
+    "id": "TreeViewnodes",
+    "text": "TreeView",
+    "description": "Nodes",
+    "href": "/components/TreeView#nodes",
+    "isComponent": false
+  },
+  {
+    "id": "TreeViewevents",
+    "text": "TreeView",
+    "description": "Events",
+    "href": "/components/TreeView#events",
+    "isComponent": false
+  },
+  {
+    "id": "TreeViewmulti-select",
+    "text": "TreeView",
+    "description": "Multi-select",
+    "href": "/components/TreeView#multi-select",
+    "isComponent": false
+  },
+  {
+    "id": "TreeViewexpand-and-collapse",
+    "text": "TreeView",
+    "description": "Expand and collapse",
+    "href": "/components/TreeView#expand-and-collapse",
+    "isComponent": false
+  },
+  {
+    "id": "TreeViewnode-access",
+    "text": "TreeView",
+    "description": "Node access",
+    "href": "/components/TreeView#node-access",
+    "isComponent": false
+  },
+  {
+    "id": "TreeViewperformance",
+    "text": "TreeView",
+    "description": "Performance",
+    "href": "/components/TreeView#performance",
+    "isComponent": false
+  },
+  {
+    "id": "TreeViewdata-utilities",
+    "text": "TreeView",
+    "description": "Data utilities",
+    "href": "/components/TreeView#data-utilities",
+    "isComponent": false
+  },
+  {
+    "id": "PaginationNav-page",
+    "text": "PaginationNav",
+    "description": "PaginationNav",
+    "href": "/components/PaginationNav",
+    "isComponent": true
+  },
+  {
+    "id": "PaginationNavbasic",
+    "text": "PaginationNav",
+    "description": "Basic",
+    "href": "/components/PaginationNav#basic",
+    "isComponent": false
+  },
+  {
+    "id": "PaginationNavreactive",
+    "text": "PaginationNav",
+    "description": "Reactive",
+    "href": "/components/PaginationNav#reactive",
+    "isComponent": false
+  },
+  {
+    "id": "PaginationNavpage-count",
+    "text": "PaginationNav",
+    "description": "Page count",
+    "href": "/components/PaginationNav#page-count",
+    "isComponent": false
+  },
+  {
+    "id": "PaginationNavnavigation-buttons",
+    "text": "PaginationNav",
+    "description": "Navigation buttons",
+    "href": "/components/PaginationNav#navigation-buttons",
+    "isComponent": false
+  },
+  {
+    "id": "PaginationNavevents",
+    "text": "PaginationNav",
+    "description": "Events",
+    "href": "/components/PaginationNav#events",
+    "isComponent": false
+  },
+  {
+    "id": "FileUploader-page",
+    "text": "FileUploader",
+    "description": "FileUploader",
+    "href": "/components/FileUploader",
+    "isComponent": true
+  },
+  {
+    "id": "FileUploaderbutton",
+    "text": "FileUploader",
+    "description": "Button",
+    "href": "/components/FileUploader#button",
+    "isComponent": false
+  },
+  {
+    "id": "FileUploaderfile-uploader",
+    "text": "FileUploader",
+    "description": "File uploader",
+    "href": "/components/FileUploader#file-uploader",
+    "isComponent": false
+  },
+  {
+    "id": "FileUploaderfile-ordering",
+    "text": "FileUploader",
+    "description": "File ordering",
+    "href": "/components/FileUploader#file-ordering",
+    "isComponent": false
+  },
+  {
+    "id": "FileUploaderitem",
+    "text": "FileUploader",
+    "description": "Item",
+    "href": "/components/FileUploader#item",
+    "isComponent": false
+  },
+  {
+    "id": "FileUploaderdrop-container",
+    "text": "FileUploader",
+    "description": "Drop container",
+    "href": "/components/FileUploader#drop-container",
+    "isComponent": false
+  },
+  {
+    "id": "FileUploaderskeleton",
+    "text": "FileUploader",
+    "description": "Skeleton",
+    "href": "/components/FileUploader#skeleton",
+    "isComponent": false
+  },
+  {
+    "id": "CopyButton-page",
+    "text": "CopyButton",
+    "description": "CopyButton",
+    "href": "/components/CopyButton",
+    "isComponent": true
+  },
+  {
+    "id": "CopyButtonbasic",
+    "text": "CopyButton",
+    "description": "Basic",
+    "href": "/components/CopyButton#basic",
+    "isComponent": false
+  },
+  {
+    "id": "CopyButtonasync-copy",
+    "text": "CopyButton",
+    "description": "Async copy",
+    "href": "/components/CopyButton#async-copy",
+    "isComponent": false
+  },
+  {
+    "id": "CopyButtonghost-kind",
+    "text": "CopyButton",
+    "description": "Ghost kind",
+    "href": "/components/CopyButton#ghost-kind",
+    "isComponent": false
+  },
+  {
+    "id": "CopyButtonsizes",
+    "text": "CopyButton",
+    "description": "Sizes",
+    "href": "/components/CopyButton#sizes",
+    "isComponent": false
+  },
+  {
+    "id": "CopyButtoncustom-feedback",
+    "text": "CopyButton",
+    "description": "Custom feedback",
+    "href": "/components/CopyButton#custom-feedback",
+    "isComponent": false
+  },
+  {
+    "id": "CopyButtoncopy-behavior",
+    "text": "CopyButton",
+    "description": "Copy behavior",
+    "href": "/components/CopyButton#copy-behavior",
+    "isComponent": false
+  },
+  {
+    "id": "CopyButtonhover-tooltip",
+    "text": "CopyButton",
+    "description": "Hover tooltip",
+    "href": "/components/CopyButton#hover-tooltip",
+    "isComponent": false
+  },
+  {
+    "id": "CopyButtonportal-tooltip",
+    "text": "CopyButton",
+    "description": "Portal tooltip",
+    "href": "/components/CopyButton#portal-tooltip",
+    "isComponent": false
+  },
+  {
+    "id": "CopyButtoninside-a-modal",
+    "text": "CopyButton",
+    "description": "Inside a modal",
+    "href": "/components/CopyButton#inside-a-modal",
+    "isComponent": false
+  },
+  {
+    "id": "ComposedModal-page",
+    "text": "ComposedModal",
+    "description": "ComposedModal",
+    "href": "/components/ComposedModal",
+    "isComponent": true
+  },
+  {
+    "id": "ComposedModalcomposedmodal-vs-modal",
+    "text": "ComposedModal",
+    "description": "ComposedModal vs Modal",
+    "href": "/components/ComposedModal#composedmodal-vs-modal",
+    "isComponent": false
+  },
+  {
+    "id": "ComposedModalbasic",
+    "text": "ComposedModal",
+    "description": "Basic",
+    "href": "/components/ComposedModal#basic",
+    "isComponent": false
+  },
+  {
+    "id": "ComposedModalfocus",
+    "text": "ComposedModal",
+    "description": "Focus",
+    "href": "/components/ComposedModal#focus",
+    "isComponent": false
+  },
+  {
+    "id": "ComposedModalvariants",
+    "text": "ComposedModal",
+    "description": "Variants",
+    "href": "/components/ComposedModal#variants",
+    "isComponent": false
+  },
+  {
+    "id": "ComposedModalcontent",
+    "text": "ComposedModal",
+    "description": "Content",
+    "href": "/components/ComposedModal#content",
+    "isComponent": false
+  },
+  {
+    "id": "ComposedModalbuttons",
+    "text": "ComposedModal",
+    "description": "Buttons",
+    "href": "/components/ComposedModal#buttons",
+    "isComponent": false
+  },
+  {
+    "id": "ComposedModalprogress",
+    "text": "ComposedModal",
+    "description": "Progress",
+    "href": "/components/ComposedModal#progress",
+    "isComponent": false
+  },
+  {
+    "id": "ComposedModalwith-portal",
+    "text": "ComposedModal",
+    "description": "With portal",
+    "href": "/components/ComposedModal#with-portal",
+    "isComponent": false
+  },
+  {
+    "id": "ComposedModalsizes",
+    "text": "ComposedModal",
+    "description": "Sizes",
+    "href": "/components/ComposedModal#sizes",
+    "isComponent": false
+  },
+  {
+    "id": "ComposedModalclosing",
+    "text": "ComposedModal",
+    "description": "Closing",
+    "href": "/components/ComposedModal#closing",
+    "isComponent": false
+  },
+  {
+    "id": "ComposedModalevents",
+    "text": "ComposedModal",
+    "description": "Events",
+    "href": "/components/ComposedModal#events",
+    "isComponent": false
+  },
+  {
+    "id": "RecursiveList-page",
+    "text": "RecursiveList",
+    "description": "RecursiveList",
+    "href": "/components/RecursiveList",
+    "isComponent": true
+  },
+  {
+    "id": "RecursiveListbasic",
+    "text": "RecursiveList",
+    "description": "Basic",
+    "href": "/components/RecursiveList#basic",
+    "isComponent": false
+  },
+  {
+    "id": "RecursiveListlink-attributes",
+    "text": "RecursiveList",
+    "description": "Link attributes",
+    "href": "/components/RecursiveList#link-attributes",
+    "isComponent": false
+  },
+  {
+    "id": "RecursiveListordered",
+    "text": "RecursiveList",
+    "description": "Ordered",
+    "href": "/components/RecursiveList#ordered",
+    "isComponent": false
+  },
+  {
+    "id": "RecursiveListexpressive-styles",
+    "text": "RecursiveList",
+    "description": "Expressive styles",
+    "href": "/components/RecursiveList#expressive-styles",
+    "isComponent": false
+  },
+  {
+    "id": "RecursiveListflat-data",
+    "text": "RecursiveList",
+    "description": "Flat data",
+    "href": "/components/RecursiveList#flat-data",
+    "isComponent": false
+  },
+  {
+    "id": "RecursiveListstable-keys",
+    "text": "RecursiveList",
+    "description": "Stable keys",
+    "href": "/components/RecursiveList#stable-keys",
+    "isComponent": false
+  },
+  {
+    "id": "Menu-page",
+    "text": "Menu",
+    "description": "Menu",
+    "href": "/components/Menu",
+    "isComponent": true
+  },
+  {
+    "id": "Menubasic",
+    "text": "Menu",
+    "description": "Basic",
+    "href": "/components/Menu#basic",
+    "isComponent": false
+  },
+  {
+    "id": "Menusize",
+    "text": "Menu",
+    "description": "Size",
+    "href": "/components/Menu#size",
+    "isComponent": false
+  },
+  {
+    "id": "Menumenu-items",
+    "text": "Menu",
+    "description": "Menu items",
+    "href": "/components/Menu#menu-items",
+    "isComponent": false
+  },
+  {
+    "id": "Menukeyboard-interactions",
+    "text": "Menu",
+    "description": "Keyboard interactions",
+    "href": "/components/Menu#keyboard-interactions",
+    "isComponent": false
+  },
+  {
+    "id": "Menuscrollable",
+    "text": "Menu",
+    "description": "Scrollable",
+    "href": "/components/Menu#scrollable",
+    "isComponent": false
+  },
+  {
+    "id": "Menuplacement",
+    "text": "Menu",
+    "description": "Placement",
+    "href": "/components/Menu#placement",
+    "isComponent": false
+  },
+  {
+    "id": "Menuevents",
+    "text": "Menu",
+    "description": "Events",
+    "href": "/components/Menu#events",
+    "isComponent": false
+  },
+  {
+    "id": "UserAvatarGroup-page",
+    "text": "UserAvatarGroup",
+    "description": "UserAvatarGroup",
+    "href": "/components/UserAvatarGroup",
+    "isComponent": true
+  },
+  {
+    "id": "UserAvatarGroupbasic",
+    "text": "UserAvatarGroup",
+    "description": "Basic",
+    "href": "/components/UserAvatarGroup#basic",
+    "isComponent": false
+  },
+  {
+    "id": "UserAvatarGroupoverflow",
+    "text": "UserAvatarGroup",
+    "description": "Overflow",
+    "href": "/components/UserAvatarGroup#overflow",
+    "isComponent": false
+  },
+  {
+    "id": "UserAvatarGroupspacing",
+    "text": "UserAvatarGroup",
+    "description": "Spacing",
+    "href": "/components/UserAvatarGroup#spacing",
+    "isComponent": false
+  },
+  {
+    "id": "UserAvatarGroupsizes",
+    "text": "UserAvatarGroup",
+    "description": "Sizes",
+    "href": "/components/UserAvatarGroup#sizes",
+    "isComponent": false
+  },
+  {
+    "id": "UserAvatarGroupimages",
+    "text": "UserAvatarGroup",
+    "description": "Images",
+    "href": "/components/UserAvatarGroup#images",
+    "isComponent": false
+  },
+  {
+    "id": "UserAvatarGroupicons",
+    "text": "UserAvatarGroup",
+    "description": "Icons",
+    "href": "/components/UserAvatarGroup#icons",
+    "isComponent": false
+  },
+  {
+    "id": "UserAvatarGroupbackground-colors",
+    "text": "UserAvatarGroup",
+    "description": "Background colors",
+    "href": "/components/UserAvatarGroup#background-colors",
+    "isComponent": false
+  },
+  {
+    "id": "UserAvatarGrouptooltips",
+    "text": "UserAvatarGroup",
+    "description": "Tooltips",
+    "href": "/components/UserAvatarGroup#tooltips",
+    "isComponent": false
+  },
+  {
+    "id": "ToastNotification-page",
+    "text": "ToastNotification",
+    "description": "ToastNotification",
+    "href": "/components/ToastNotification",
+    "isComponent": true
+  },
+  {
+    "id": "ToastNotificationbasic",
+    "text": "ToastNotification",
+    "description": "Basic",
+    "href": "/components/ToastNotification#basic",
+    "isComponent": false
+  },
+  {
+    "id": "ToastNotificationreusable",
+    "text": "ToastNotification",
+    "description": "Reusable",
+    "href": "/components/ToastNotification#reusable",
+    "isComponent": false
+  },
+  {
+    "id": "ToastNotificationautoclose",
+    "text": "ToastNotification",
+    "description": "Autoclose",
+    "href": "/components/ToastNotification#autoclose",
+    "isComponent": false
+  },
+  {
+    "id": "ToastNotificationfull-width",
+    "text": "ToastNotification",
+    "description": "Full width",
+    "href": "/components/ToastNotification#full-width",
+    "isComponent": false
+  },
+  {
+    "id": "ToastNotificationtitle-subtitle-caption",
+    "text": "ToastNotification",
+    "description": "Title, subtitle, caption",
+    "href": "/components/ToastNotification#title-subtitle-caption",
+    "isComponent": false
+  },
+  {
+    "id": "ToastNotificationclose-button",
+    "text": "ToastNotification",
+    "description": "Close button",
+    "href": "/components/ToastNotification#close-button",
+    "isComponent": false
+  },
+  {
+    "id": "ToastNotificationaria-role",
+    "text": "ToastNotification",
+    "description": "ARIA role",
+    "href": "/components/ToastNotification#aria-role",
+    "isComponent": false
+  },
+  {
+    "id": "ToastNotificationvariants",
+    "text": "ToastNotification",
+    "description": "Variants",
+    "href": "/components/ToastNotification#variants",
+    "isComponent": false
+  },
+  {
+    "id": "Search-page",
+    "text": "Search",
+    "description": "Search",
+    "href": "/components/Search",
+    "isComponent": true
+  },
+  {
+    "id": "Searchbasic",
+    "text": "Search",
+    "description": "Basic",
+    "href": "/components/Search#basic",
+    "isComponent": false
+  },
+  {
+    "id": "Searchinitial-value",
+    "text": "Search",
+    "description": "Initial value",
+    "href": "/components/Search#initial-value",
+    "isComponent": false
+  },
+  {
+    "id": "Searchreactive-example",
+    "text": "Search",
+    "description": "Reactive example",
+    "href": "/components/Search#reactive-example",
+    "isComponent": false
+  },
+  {
+    "id": "Searchclear-event",
+    "text": "Search",
+    "description": "Clear event",
+    "href": "/components/Search#clear-event",
+    "isComponent": false
+  },
+  {
+    "id": "Searchcustom-labels",
+    "text": "Search",
+    "description": "Custom labels",
+    "href": "/components/Search#custom-labels",
+    "isComponent": false
+  },
+  {
+    "id": "Searchexpandable",
+    "text": "Search",
+    "description": "Expandable",
+    "href": "/components/Search#expandable",
+    "isComponent": false
+  },
+  {
+    "id": "Searchlight",
+    "text": "Search",
+    "description": "Light",
+    "href": "/components/Search#light",
+    "isComponent": false
+  },
+  {
+    "id": "Searchfluid",
+    "text": "Search",
+    "description": "Fluid",
+    "href": "/components/Search#fluid",
+    "isComponent": false
+  },
+  {
+    "id": "Searchsizes",
+    "text": "Search",
+    "description": "Sizes",
+    "href": "/components/Search#sizes",
+    "isComponent": false
+  },
+  {
+    "id": "Searchdisabled",
+    "text": "Search",
+    "description": "Disabled",
+    "href": "/components/Search#disabled",
+    "isComponent": false
+  },
+  {
+    "id": "Searchcustom-icon",
+    "text": "Search",
+    "description": "Custom icon",
+    "href": "/components/Search#custom-icon",
+    "isComponent": false
+  },
+  {
+    "id": "Searchskeleton",
+    "text": "Search",
+    "description": "Skeleton",
+    "href": "/components/Search#skeleton",
+    "isComponent": false
+  },
+  {
+    "id": "SelectableTile-page",
+    "text": "SelectableTile",
+    "description": "SelectableTile",
+    "href": "/components/SelectableTile",
+    "isComponent": true
+  },
+  {
+    "id": "SelectableTilebasic",
+    "text": "SelectableTile",
+    "description": "Basic",
+    "href": "/components/SelectableTile#basic",
+    "isComponent": false
+  },
+  {
+    "id": "SelectableTilereactive",
+    "text": "SelectableTile",
+    "description": "Reactive",
+    "href": "/components/SelectableTile#reactive",
+    "isComponent": false
+  },
+  {
+    "id": "SelectableTilelegend",
+    "text": "SelectableTile",
+    "description": "Legend",
+    "href": "/components/SelectableTile#legend",
+    "isComponent": false
+  },
+  {
+    "id": "SelectableTilelight",
+    "text": "SelectableTile",
+    "description": "Light",
+    "href": "/components/SelectableTile#light",
+    "isComponent": false
+  },
+  {
+    "id": "SelectableTiledisabled",
+    "text": "SelectableTile",
+    "description": "Disabled",
+    "href": "/components/SelectableTile#disabled",
+    "isComponent": false
+  },
+  {
+    "id": "SelectableTilecheckmark-label",
+    "text": "SelectableTile",
+    "description": "Checkmark label",
+    "href": "/components/SelectableTile#checkmark-label",
+    "isComponent": false
+  },
+  {
+    "id": "Tooltip-page",
+    "text": "Tooltip",
+    "description": "Tooltip",
+    "href": "/components/Tooltip",
+    "isComponent": true
+  },
+  {
+    "id": "Tooltipbasic",
+    "text": "Tooltip",
+    "description": "Basic",
+    "href": "/components/Tooltip#basic",
+    "isComponent": false
+  },
+  {
+    "id": "Tooltipcustom-labels",
+    "text": "Tooltip",
+    "description": "Custom labels",
+    "href": "/components/Tooltip#custom-labels",
+    "isComponent": false
+  },
+  {
+    "id": "Tooltipreactive-example",
+    "text": "Tooltip",
+    "description": "Reactive example",
+    "href": "/components/Tooltip#reactive-example",
+    "isComponent": false
+  },
+  {
+    "id": "Tooltipdispatched-events",
+    "text": "Tooltip",
+    "description": "Dispatched events",
+    "href": "/components/Tooltip#dispatched-events",
+    "isComponent": false
+  },
+  {
+    "id": "Tooltipplacement",
+    "text": "Tooltip",
+    "description": "Placement",
+    "href": "/components/Tooltip#placement",
+    "isComponent": false
+  },
+  {
+    "id": "Tooltipinteractive",
+    "text": "Tooltip",
+    "description": "Interactive",
+    "href": "/components/Tooltip#interactive",
+    "isComponent": false
+  },
+  {
+    "id": "Tooltipcustom-icon",
+    "text": "Tooltip",
+    "description": "Custom icon",
+    "href": "/components/Tooltip#custom-icon",
+    "isComponent": false
+  },
+  {
+    "id": "Tooltipcustom-delay",
+    "text": "Tooltip",
+    "description": "Custom delay",
+    "href": "/components/Tooltip#custom-delay",
+    "isComponent": false
+  },
+  {
+    "id": "Tooltipportal",
+    "text": "Tooltip",
+    "description": "Portal",
+    "href": "/components/Tooltip#portal",
+    "isComponent": false
+  },
+  {
+    "id": "Tooltipinside-a-modal",
+    "text": "Tooltip",
+    "description": "Inside a modal",
+    "href": "/components/Tooltip#inside-a-modal",
+    "isComponent": false
+  },
+  {
+    "id": "TagSet-page",
+    "text": "TagSet",
+    "description": "TagSet",
+    "href": "/components/TagSet",
+    "isComponent": true
+  },
+  {
+    "id": "TagSetbasic",
+    "text": "TagSet",
+    "description": "Basic",
+    "href": "/components/TagSet#basic",
+    "isComponent": false
+  },
+  {
+    "id": "TagSetalignment",
+    "text": "TagSet",
+    "description": "Alignment",
+    "href": "/components/TagSet#alignment",
+    "isComponent": false
+  },
+  {
+    "id": "TagSetoverflow",
+    "text": "TagSet",
+    "description": "Overflow",
+    "href": "/components/TagSet#overflow",
+    "isComponent": false
+  },
+  {
+    "id": "TagSetoverflow-tooltip",
+    "text": "TagSet",
+    "description": "Overflow tooltip",
+    "href": "/components/TagSet#overflow-tooltip",
+    "isComponent": false
+  },
+  {
+    "id": "TagSetdismissible",
+    "text": "TagSet",
+    "description": "Dismissible",
+    "href": "/components/TagSet#dismissible",
+    "isComponent": false
+  },
+  {
+    "id": "TagSetevents",
+    "text": "TagSet",
+    "description": "Events",
+    "href": "/components/TagSet#events",
+    "isComponent": false
+  },
+  {
+    "id": "TagSetsizes",
+    "text": "TagSet",
+    "description": "Sizes",
+    "href": "/components/TagSet#sizes",
+    "isComponent": false
+  },
+  {
+    "id": "TagSetgap",
+    "text": "TagSet",
+    "description": "Gap",
+    "href": "/components/TagSet#gap",
+    "isComponent": false
+  },
+  {
+    "id": "Tag-page",
+    "text": "Tag",
+    "description": "Tag",
+    "href": "/components/Tag",
+    "isComponent": true
+  },
+  {
+    "id": "Tagbasic",
+    "text": "Tag",
+    "description": "Basic",
+    "href": "/components/Tag#basic",
+    "isComponent": false
+  },
+  {
+    "id": "Tagsizes",
+    "text": "Tag",
+    "description": "Sizes",
+    "href": "/components/Tag#sizes",
+    "isComponent": false
+  },
+  {
+    "id": "Tagtag-types",
+    "text": "Tag",
+    "description": "Tag types",
+    "href": "/components/Tag#tag-types",
+    "isComponent": false
+  },
+  {
+    "id": "Taginline",
+    "text": "Tag",
+    "description": "Inline",
+    "href": "/components/Tag#inline",
+    "isComponent": false
+  },
+  {
+    "id": "Tagfilterable",
+    "text": "Tag",
+    "description": "Filterable",
+    "href": "/components/Tag#filterable",
+    "isComponent": false
+  },
+  {
+    "id": "Tagcustom-icon",
+    "text": "Tag",
+    "description": "Custom icon",
+    "href": "/components/Tag#custom-icon",
+    "isComponent": false
+  },
+  {
+    "id": "Tagclickable-variants",
+    "text": "Tag",
+    "description": "Clickable variants",
+    "href": "/components/Tag#clickable-variants",
+    "isComponent": false
+  },
+  {
+    "id": "Tagdisabled",
+    "text": "Tag",
+    "description": "Disabled",
+    "href": "/components/Tag#disabled",
+    "isComponent": false
+  },
+  {
+    "id": "Tagtooltip",
+    "text": "Tag",
+    "description": "Tooltip",
+    "href": "/components/Tag#tooltip",
+    "isComponent": false
+  },
+  {
+    "id": "Tagselectable",
+    "text": "Tag",
+    "description": "Selectable",
+    "href": "/components/Tag#selectable",
+    "isComponent": false
+  },
+  {
+    "id": "Tagskeleton",
+    "text": "Tag",
+    "description": "Skeleton",
+    "href": "/components/Tag#skeleton",
+    "isComponent": false
+  },
+  {
+    "id": "Accordion-page",
+    "text": "Accordion",
+    "description": "Accordion",
+    "href": "/components/Accordion",
+    "isComponent": true
+  },
+  {
+    "id": "Accordionbasic",
+    "text": "Accordion",
+    "description": "Basic",
+    "href": "/components/Accordion#basic",
+    "isComponent": false
+  },
+  {
+    "id": "Accordionlayout",
+    "text": "Accordion",
+    "description": "Layout",
+    "href": "/components/Accordion#layout",
+    "isComponent": false
+  },
+  {
+    "id": "Accordiontitle",
+    "text": "Accordion",
+    "description": "Title",
+    "href": "/components/Accordion#title",
+    "isComponent": false
+  },
+  {
+    "id": "Accordionopen-state",
+    "text": "Accordion",
+    "description": "Open state",
+    "href": "/components/Accordion#open-state",
+    "isComponent": false
+  },
+  {
+    "id": "Accordionnested",
+    "text": "Accordion",
+    "description": "Nested",
+    "href": "/components/Accordion#nested",
+    "isComponent": false
+  },
+  {
+    "id": "Accordionlazy-loading",
+    "text": "Accordion",
+    "description": "Lazy loading",
+    "href": "/components/Accordion#lazy-loading",
+    "isComponent": false
+  },
+  {
+    "id": "Accordionsizes",
+    "text": "Accordion",
+    "description": "Sizes",
+    "href": "/components/Accordion#sizes",
+    "isComponent": false
+  },
+  {
+    "id": "Accordiondisabled",
+    "text": "Accordion",
+    "description": "Disabled",
+    "href": "/components/Accordion#disabled",
+    "isComponent": false
+  },
+  {
+    "id": "Accordionskeleton",
+    "text": "Accordion",
+    "description": "Skeleton",
+    "href": "/components/Accordion#skeleton",
+    "isComponent": false
+  },
+  {
+    "id": "SkeletonIcon-page",
+    "text": "SkeletonIcon",
+    "description": "SkeletonIcon",
+    "href": "/components/SkeletonIcon",
+    "isComponent": true
+  },
+  {
+    "id": "SkeletonIconsizes",
+    "text": "SkeletonIcon",
+    "description": "Sizes",
+    "href": "/components/SkeletonIcon#sizes",
+    "isComponent": false
+  },
+  {
+    "id": "SkeletonIconcustom-width-and-height",
+    "text": "SkeletonIcon",
+    "description": "Custom width and height",
+    "href": "/components/SkeletonIcon#custom-width-and-height",
+    "isComponent": false
+  },
+  {
+    "id": "Pagination-page",
+    "text": "Pagination",
+    "description": "Pagination",
+    "href": "/components/Pagination",
+    "isComponent": true
+  },
+  {
+    "id": "Paginationbasic",
+    "text": "Pagination",
+    "description": "Basic",
+    "href": "/components/Pagination#basic",
+    "isComponent": false
+  },
+  {
+    "id": "Paginationsizes",
+    "text": "Pagination",
+    "description": "Sizes",
+    "href": "/components/Pagination#sizes",
+    "isComponent": false
+  },
+  {
+    "id": "Paginationpage-and-page-size",
+    "text": "Pagination",
+    "description": "Page and page size",
+    "href": "/components/Pagination#page-and-page-size",
+    "isComponent": false
+  },
+  {
+    "id": "Paginationunknown-pages",
+    "text": "Pagination",
+    "description": "Unknown pages",
+    "href": "/components/Pagination#unknown-pages",
+    "isComponent": false
+  },
+  {
+    "id": "Paginationpage-window",
+    "text": "Pagination",
+    "description": "Page window",
+    "href": "/components/Pagination#page-window",
+    "isComponent": false
+  },
+  {
+    "id": "Paginationcustom-page-select",
+    "text": "Pagination",
+    "description": "Custom page select",
+    "href": "/components/Pagination#custom-page-select",
+    "isComponent": false
+  },
+  {
+    "id": "Paginationsimple",
+    "text": "Pagination",
+    "description": "Simple",
+    "href": "/components/Pagination#simple",
+    "isComponent": false
+  },
+  {
+    "id": "Paginationcustom-text",
+    "text": "Pagination",
+    "description": "Custom text",
+    "href": "/components/Pagination#custom-text",
+    "isComponent": false
+  },
+  {
+    "id": "Paginationhidden-controls",
+    "text": "Pagination",
+    "description": "Hidden controls",
+    "href": "/components/Pagination#hidden-controls",
+    "isComponent": false
+  },
+  {
+    "id": "Paginationdisabled",
+    "text": "Pagination",
+    "description": "Disabled",
+    "href": "/components/Pagination#disabled",
+    "isComponent": false
+  },
+  {
+    "id": "Paginationevents",
+    "text": "Pagination",
+    "description": "Events",
+    "href": "/components/Pagination#events",
+    "isComponent": false
+  },
+  {
+    "id": "Paginationskeleton",
+    "text": "Pagination",
+    "description": "Skeleton",
+    "href": "/components/Pagination#skeleton",
+    "isComponent": false
+  },
+  {
+    "id": "Link-page",
+    "text": "Link",
+    "description": "Link",
+    "href": "/components/Link",
+    "isComponent": true
+  },
+  {
+    "id": "Linkbasic",
+    "text": "Link",
+    "description": "Basic",
+    "href": "/components/Link#basic",
+    "isComponent": false
+  },
+  {
+    "id": "Linkinline",
+    "text": "Link",
+    "description": "Inline",
+    "href": "/components/Link#inline",
+    "isComponent": false
+  },
+  {
+    "id": "Linkmuted",
+    "text": "Link",
+    "description": "Muted",
+    "href": "/components/Link#muted",
+    "isComponent": false
+  },
+  {
+    "id": "Linkexternal-links",
+    "text": "Link",
+    "description": "External links",
+    "href": "/components/Link#external-links",
+    "isComponent": false
+  },
+  {
+    "id": "Linkdownload-link",
+    "text": "Link",
+    "description": "Download link",
+    "href": "/components/Link#download-link",
+    "isComponent": false
+  },
+  {
+    "id": "Linkicons",
+    "text": "Link",
+    "description": "Icons",
+    "href": "/components/Link#icons",
+    "isComponent": false
+  },
+  {
+    "id": "Linksizes",
+    "text": "Link",
+    "description": "Sizes",
+    "href": "/components/Link#sizes",
+    "isComponent": false
+  },
+  {
+    "id": "Linkstates",
+    "text": "Link",
+    "description": "States",
+    "href": "/components/Link#states",
+    "isComponent": false
+  },
+  {
+    "id": "MenuButton-page",
+    "text": "MenuButton",
+    "description": "MenuButton",
+    "href": "/components/MenuButton",
+    "isComponent": true
+  },
+  {
+    "id": "MenuButtonbasic",
+    "text": "MenuButton",
+    "description": "Basic",
+    "href": "/components/MenuButton#basic",
+    "isComponent": false
+  },
+  {
+    "id": "MenuButtonreactive-example",
+    "text": "MenuButton",
+    "description": "Reactive example",
+    "href": "/components/MenuButton#reactive-example",
+    "isComponent": false
+  },
+  {
+    "id": "MenuButtonkind",
+    "text": "MenuButton",
+    "description": "Kind",
+    "href": "/components/MenuButton#kind",
+    "isComponent": false
+  },
+  {
+    "id": "MenuButtonsize",
+    "text": "MenuButton",
+    "description": "Size",
+    "href": "/components/MenuButton#size",
+    "isComponent": false
+  },
+  {
+    "id": "MenuButtonicon-only",
+    "text": "MenuButton",
+    "description": "Icon-only",
+    "href": "/components/MenuButton#icon-only",
+    "isComponent": false
+  },
+  {
+    "id": "MenuButtondirection",
+    "text": "MenuButton",
+    "description": "Direction",
+    "href": "/components/MenuButton#direction",
+    "isComponent": false
+  },
+  {
+    "id": "MenuButtonscrollable",
+    "text": "MenuButton",
+    "description": "Scrollable",
+    "href": "/components/MenuButton#scrollable",
+    "isComponent": false
+  },
+  {
+    "id": "MenuButtondisabled",
+    "text": "MenuButton",
+    "description": "Disabled",
+    "href": "/components/MenuButton#disabled",
+    "isComponent": false
+  },
+  {
+    "id": "MenuButtonmenu-items",
+    "text": "MenuButton",
+    "description": "Menu items",
+    "href": "/components/MenuButton#menu-items",
+    "isComponent": false
+  },
+  {
+    "id": "MenuButtonevents",
+    "text": "MenuButton",
+    "description": "Events",
+    "href": "/components/MenuButton#events",
+    "isComponent": false
+  },
+  {
+    "id": "Tile-page",
+    "text": "Tile",
+    "description": "Tile",
+    "href": "/components/Tile",
+    "isComponent": true
+  },
+  {
+    "id": "Tilebasic",
+    "text": "Tile",
+    "description": "Basic",
+    "href": "/components/Tile#basic",
+    "isComponent": false
+  },
+  {
+    "id": "Tilelight",
+    "text": "Tile",
+    "description": "Light",
+    "href": "/components/Tile#light",
+    "isComponent": false
+  },
+  {
+    "id": "Tilecustom-interaction",
+    "text": "Tile",
+    "description": "Custom interaction",
+    "href": "/components/Tile#custom-interaction",
+    "isComponent": false
+  },
+  {
+    "id": "TextInput-page",
+    "text": "TextInput",
+    "description": "TextInput",
+    "href": "/components/TextInput",
+    "isComponent": true
+  },
+  {
+    "id": "TextInputbasic",
+    "text": "TextInput",
+    "description": "Basic",
+    "href": "/components/TextInput#basic",
+    "isComponent": false
+  },
+  {
+    "id": "TextInputhelper-text",
+    "text": "TextInput",
+    "description": "Helper text",
+    "href": "/components/TextInput#helper-text",
+    "isComponent": false
+  },
+  {
+    "id": "TextInputhidden-label",
+    "text": "TextInput",
+    "description": "Hidden label",
+    "href": "/components/TextInput#hidden-label",
+    "isComponent": false
+  },
+  {
+    "id": "TextInputcustom-label",
+    "text": "TextInput",
+    "description": "Custom label",
+    "href": "/components/TextInput#custom-label",
+    "isComponent": false
+  },
+  {
+    "id": "TextInputmaximum-character-count",
+    "text": "TextInput",
+    "description": "Maximum character count",
+    "href": "/components/TextInput#maximum-character-count",
+    "isComponent": false
+  },
+  {
+    "id": "TextInputevents",
+    "text": "TextInput",
+    "description": "Events",
+    "href": "/components/TextInput#events",
+    "isComponent": false
+  },
+  {
+    "id": "TextInputlight",
+    "text": "TextInput",
+    "description": "Light",
+    "href": "/components/TextInput#light",
+    "isComponent": false
+  },
+  {
+    "id": "TextInputfluid",
+    "text": "TextInput",
+    "description": "Fluid",
+    "href": "/components/TextInput#fluid",
+    "isComponent": false
+  },
+  {
+    "id": "TextInputinline",
+    "text": "TextInput",
+    "description": "Inline",
+    "href": "/components/TextInput#inline",
+    "isComponent": false
+  },
+  {
+    "id": "TextInputsizes",
+    "text": "TextInput",
+    "description": "Sizes",
+    "href": "/components/TextInput#sizes",
+    "isComponent": false
+  },
+  {
+    "id": "TextInputstates",
+    "text": "TextInput",
+    "description": "States",
+    "href": "/components/TextInput#states",
+    "isComponent": false
+  },
+  {
+    "id": "TextInputskeleton",
+    "text": "TextInput",
+    "description": "Skeleton",
+    "href": "/components/TextInput#skeleton",
+    "isComponent": false
+  },
+  {
+    "id": "TooltipIcon-page",
+    "text": "TooltipIcon",
+    "description": "TooltipIcon",
+    "href": "/components/TooltipIcon",
+    "isComponent": true
+  },
+  {
+    "id": "TooltipIconbasic",
+    "text": "TooltipIcon",
+    "description": "Basic",
+    "href": "/components/TooltipIcon#basic",
+    "isComponent": false
+  },
+  {
+    "id": "TooltipIconreactive-example",
+    "text": "TooltipIcon",
+    "description": "Reactive example",
+    "href": "/components/TooltipIcon#reactive-example",
+    "isComponent": false
+  },
+  {
+    "id": "TooltipIcondispatched-events",
+    "text": "TooltipIcon",
+    "description": "Dispatched events",
+    "href": "/components/TooltipIcon#dispatched-events",
+    "isComponent": false
+  },
+  {
+    "id": "TooltipIconsizes",
+    "text": "TooltipIcon",
+    "description": "Sizes",
+    "href": "/components/TooltipIcon#sizes",
+    "isComponent": false
+  },
+  {
+    "id": "TooltipIconplacement",
+    "text": "TooltipIcon",
+    "description": "Placement",
+    "href": "/components/TooltipIcon#placement",
+    "isComponent": false
+  },
+  {
+    "id": "TooltipIconcustom-tooltip-text",
+    "text": "TooltipIcon",
+    "description": "Custom tooltip text",
+    "href": "/components/TooltipIcon#custom-tooltip-text",
+    "isComponent": false
+  },
+  {
+    "id": "TooltipIconcustom-icon",
+    "text": "TooltipIcon",
+    "description": "Custom icon",
+    "href": "/components/TooltipIcon#custom-icon",
+    "isComponent": false
+  },
+  {
+    "id": "TooltipIconcustom-delay",
+    "text": "TooltipIcon",
+    "description": "Custom delay",
+    "href": "/components/TooltipIcon#custom-delay",
+    "isComponent": false
+  },
+  {
+    "id": "TooltipIcondisabled",
+    "text": "TooltipIcon",
+    "description": "Disabled",
+    "href": "/components/TooltipIcon#disabled",
+    "isComponent": false
+  },
+  {
+    "id": "TooltipIconportal",
+    "text": "TooltipIcon",
+    "description": "Portal",
+    "href": "/components/TooltipIcon#portal",
+    "isComponent": false
+  },
+  {
+    "id": "TooltipIconinside-a-modal",
+    "text": "TooltipIcon",
+    "description": "Inside a modal",
+    "href": "/components/TooltipIcon#inside-a-modal",
+    "isComponent": false
+  },
+  {
+    "id": "DatePicker-page",
+    "text": "DatePicker",
+    "description": "DatePicker",
+    "href": "/components/DatePicker",
+    "isComponent": true
+  },
+  {
+    "id": "DatePickercalendar-types",
+    "text": "DatePicker",
+    "description": "Calendar types",
+    "href": "/components/DatePicker#calendar-types",
+    "isComponent": false
+  },
+  {
+    "id": "DatePickercalendar-options",
+    "text": "DatePicker",
+    "description": "Calendar options",
+    "href": "/components/DatePicker#calendar-options",
+    "isComponent": false
+  },
+  {
+    "id": "DatePickerformatting",
+    "text": "DatePicker",
+    "description": "Formatting",
+    "href": "/components/DatePicker#formatting",
+    "isComponent": false
+  },
+  {
+    "id": "DatePickerportal",
+    "text": "DatePicker",
+    "description": "Portal",
+    "href": "/components/DatePicker#portal",
+    "isComponent": false
+  },
+  {
+    "id": "DatePickerevents",
+    "text": "DatePicker",
+    "description": "Events",
+    "href": "/components/DatePicker#events",
+    "isComponent": false
+  },
+  {
+    "id": "DatePickerhelper-text",
+    "text": "DatePicker",
+    "description": "Helper text",
+    "href": "/components/DatePicker#helper-text",
+    "isComponent": false
+  },
+  {
+    "id": "DatePickerhidden-label",
+    "text": "DatePicker",
+    "description": "Hidden label",
+    "href": "/components/DatePicker#hidden-label",
+    "isComponent": false
+  },
+  {
+    "id": "DatePickerlight",
+    "text": "DatePicker",
+    "description": "Light",
+    "href": "/components/DatePicker#light",
+    "isComponent": false
+  },
+  {
+    "id": "DatePickerfluid",
+    "text": "DatePicker",
+    "description": "Fluid",
+    "href": "/components/DatePicker#fluid",
+    "isComponent": false
+  },
+  {
+    "id": "DatePickersizes",
+    "text": "DatePicker",
+    "description": "Sizes",
+    "href": "/components/DatePicker#sizes",
+    "isComponent": false
+  },
+  {
+    "id": "DatePickerstates",
+    "text": "DatePicker",
+    "description": "States",
+    "href": "/components/DatePicker#states",
+    "isComponent": false
+  },
+  {
+    "id": "DatePickerskeleton",
+    "text": "DatePicker",
+    "description": "Skeleton",
+    "href": "/components/DatePicker#skeleton",
+    "isComponent": false
+  }
+]

--- a/docs/scripts/__tests__/search.test.ts
+++ b/docs/scripts/__tests__/search.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from "bun:test";
+import MiniSearch from "minisearch";
+import SEARCH_INDEX from "../__fixtures__/search-index.json";
+
+/**
+ * Baseline for the docs header search. `search-index.json` is a frozen
+ * subset of a real generated SEARCH_INDEX.json, kept small but including
+ * the components (Button/ButtonSet, Select/SelectableTile, Tag/TagSet, ...)
+ * whose overlapping names make ranking easy to get subtly wrong.
+ *
+ * This locks in the current (MiniSearch) engine's behavior. If the search
+ * engine or its config ever changes, re-run this suite against the new
+ * engine to see exactly which queries changed rank before merging.
+ */
+
+type SearchIndexDocument = {
+  id: string;
+  text: string;
+  description: string;
+  href: string;
+  isComponent: boolean;
+};
+
+function createIndex() {
+  const miniSearch = new MiniSearch<SearchIndexDocument>({
+    fields: ["text", "description"],
+    storeFields: ["text", "description", "href", "isComponent"],
+    searchOptions: {
+      prefix: true,
+      boost: { description: 2 },
+      fuzzy: 0.1,
+    },
+  });
+  miniSearch.addAll(SEARCH_INDEX as SearchIndexDocument[]);
+  return miniSearch;
+}
+
+function topHrefs(
+  miniSearch: MiniSearch<SearchIndexDocument>,
+  query: string,
+  n = 10,
+) {
+  return miniSearch
+    .search(query)
+    .slice(0, n)
+    .map((r) => String(r.href));
+}
+
+describe("docs search baseline", () => {
+  const miniSearch = createIndex();
+
+  test.each([
+    ["Button", "/components/Button"],
+    ["Text", "/components/Text"],
+    ["Select", "/components/Select"],
+    ["Tag", "/components/Tag"],
+    ["Pagination", "/components/Pagination"],
+    ["Menu", "/components/Menu"],
+    ["Search", "/components/Search"],
+    ["Tooltip", "/components/Tooltip"],
+    ["Toggle", "/components/Toggle"],
+    ["MultiSelect", "/components/MultiSelect"],
+  ])(
+    "exact component name %s ranks its own page first",
+    (query, expectedTop) => {
+      expect(topHrefs(miniSearch, query)[0]).toBe(expectedTop);
+    },
+  );
+
+  test("typo tolerance matches a close misspelling", () => {
+    expect(topHrefs(miniSearch, "buton")[0]).toBe("/components/Button");
+  });
+
+  test("short query does not fuzzy-match an unrelated word", () => {
+    // "tile" (4 chars) must not fuzzy-match "title"-shaped tokens.
+    expect(topHrefs(miniSearch, "tile")[0]).toBe("/components/Tile");
+  });
+
+  test("multi-term query matches across the text and description fields", () => {
+    // "multiselect" hits the `text` field, "bas" (prefix of "Basic") hits `description`.
+    expect(topHrefs(miniSearch, "multiselect bas")[0]).toBe(
+      "/components/MultiSelect",
+    );
+  });
+
+  test("a section heading query ranks the matching heading first", () => {
+    expect(topHrefs(miniSearch, "close button")[0]).toBe(
+      "/components/InlineNotification#close-button",
+    );
+  });
+
+  test("empty query returns no results", () => {
+    expect(topHrefs(miniSearch, "")).toEqual([]);
+  });
+});


### PR DESCRIPTION
The docs header search has overlapping component names (Button vs
ButtonSet, Select vs SelectableTile, Tag vs TagSet, ...). Nothing
pins the current ranking, so a config or engine change can silently
flip which page shows first.

Adds a frozen fixture (a subset of a real generated
SEARCH_INDEX.json) and a test that locks in today's MiniSearch
ranking for those overlaps, plus typo tolerance, multi-term
matching, and empty-query handling.

This is prep work for evaluating a different search engine. Run
this suite against a new engine's config before merging, to see
exactly which queries changed rank.