### PR TITLE
feat(file-uploader-button): parity for size and duplicate rejection

### DIFF
--- a/docs/src/pages/components/FileUploader.svx
+++ b/docs/src/pages/components/FileUploader.svx
@@ -24,12 +24,25 @@ Enable multiple file selection by setting `multiple` to `true`.
 
 ### Prevent duplicate
 
-Set `preventDuplicate` to `true` to skip re-selected files that match an
-already-selected file by name, size, and last modified. Only applies when
-`multiple` is `true`. For richer behavior with rejection events, see
-[Duplicate detection](#duplicate-detection).
+Set `preventDuplicate` to `true` to reject re-selected files that match an
+already-selected file by name, size, and last modified. Rejected duplicates are
+reported via `rejected` with `{ file, reason: "duplicate" }`.
 
-<FileUploaderButton multiple preventDuplicate labelText="Add files" />
+Only applies when `multiple` is `true`, since a single-file input replaces its
+selection rather than adding to it.
+
+<FileSource src="/framed/FileUploader/FileUploaderButtonPreventDuplicate" />
+
+### File size limit
+
+Limit selected file size with `maxFileSize`. Files exceeding the limit (in
+bytes) are automatically filtered out.
+
+This example accepts files up to 1 MB (1,048,576 bytes). Files over the limit
+are not added, and a `rejected` event fires with `{ file, reason: "size" }` for
+each rejected file.
+
+<FileSource src="/framed/FileUploader/FileUploaderButtonMaxFileSize" />
 
 ### Custom kind and size
 

--- a/docs/src/pages/framed/FileUploader/FileUploaderButtonMaxFileSize.svelte
+++ b/docs/src/pages/framed/FileUploader/FileUploaderButtonMaxFileSize.svelte
@@ -1,0 +1,48 @@
+<script>
+  import {
+    FileUploaderButton,
+    FileUploaderItem,
+    Stack,
+  } from "carbon-components-svelte";
+
+  let files = [];
+  let rejectedFiles = [];
+</script>
+
+<Stack gap={2}>
+  <FileUploaderButton
+    multiple
+    disableLabelChanges
+    maxFileSize={1024 * 1024}
+    labelText="Add files under 1 MB"
+    bind:files
+    on:rejected={(e) => {
+      rejectedFiles = [...rejectedFiles, ...e.detail];
+    }}
+  />
+
+  {#each files as file, i (`${file.name}-${file.lastModified}-${i}`)}
+    <FileUploaderItem
+      id={`accepted-${i}`}
+      name={file.name}
+      status="edit"
+      on:delete={() => {
+        files = files.filter((f) => f !== file);
+      }}
+    />
+  {/each}
+
+  {#each rejectedFiles as { file }, i (`${file.name}-${file.lastModified}-${i}`)}
+    <FileUploaderItem
+      invalid
+      id={`rejected-size-${i}`}
+      name={file.name}
+      errorSubject="File exceeds 1 MB limit"
+      errorBody="Please select a smaller file."
+      status="edit"
+      on:delete={() => {
+        rejectedFiles = rejectedFiles.filter((r) => r.file !== file);
+      }}
+    />
+  {/each}
+</Stack>

--- a/docs/src/pages/framed/FileUploader/FileUploaderButtonPreventDuplicate.svelte
+++ b/docs/src/pages/framed/FileUploader/FileUploaderButtonPreventDuplicate.svelte
@@ -1,0 +1,48 @@
+<script>
+  import {
+    FileUploaderButton,
+    FileUploaderItem,
+    Stack,
+  } from "carbon-components-svelte";
+
+  let files = [];
+  let rejectedFiles = [];
+</script>
+
+<Stack gap={2}>
+  <FileUploaderButton
+    multiple
+    preventDuplicate
+    disableLabelChanges
+    labelText="Add files"
+    bind:files
+    on:rejected={(e) => {
+      rejectedFiles = [...rejectedFiles, ...e.detail];
+    }}
+  />
+
+  {#each files as file, i (`${file.name}-${file.lastModified}-${i}`)}
+    <FileUploaderItem
+      id={`accepted-${i}`}
+      name={file.name}
+      status="edit"
+      on:delete={() => {
+        files = files.filter((f) => f !== file);
+      }}
+    />
+  {/each}
+
+  {#each rejectedFiles as { file }, i (`${file.name}-${file.lastModified}-${i}`)}
+    <FileUploaderItem
+      invalid
+      id={`rejected-duplicate-${i}`}
+      name={file.name}
+      errorSubject="Duplicate file"
+      errorBody="This file is already in the list."
+      status="edit"
+      on:delete={() => {
+        rejectedFiles = rejectedFiles.filter((r) => r.file !== file);
+      }}
+    />
+  {/each}
+</Stack>

--- a/src/FileUploader/FileUploaderButton.svelte
+++ b/src/FileUploader/FileUploaderButton.svelte
@@ -2,6 +2,8 @@
   /**
    * @template [Icon=any]
    * @event {ReadonlyArray<File>} change
+   * @event {Array<{ file: File; reason: "size" | "duplicate" }>} rejected
+   * @restProps {input}
    */
 
   /**
@@ -21,10 +23,14 @@
   export let multiple = false;
 
   /**
-   * Set to `true` to skip files that match an already-selected file
-   * (by name, size, and lastModified). Only applies when `multiple` is `true`.
-   * For richer behavior (rejection reporting via the `rejected` event),
-   * see `FileUploader`'s `preventDuplicate` prop.
+   * Specify the maximum file size in bytes.
+   * @type {number | undefined}
+   */
+  export let maxFileSize = undefined;
+
+  /**
+   * Set to `true` to reject files that match an already-selected file
+   * (by name, size, and lastModified).
    */
   export let preventDuplicate = false;
 
@@ -97,6 +103,7 @@
   export let hideTooltip = false;
 
   import { createEventDispatcher } from "svelte";
+  import { filterIncomingFiles } from "../utils/filterIncomingFiles.js";
   import { uniqueId } from "../utils/uniqueId.js";
 
   const dispatch = createEventDispatcher();
@@ -129,6 +136,24 @@
     } catch {
       // Fail open if DataTransfer API is not supported.
     }
+  }
+  /** @param {ReadonlyArray<File>} incoming */
+  function processIncoming(incoming) {
+    const { accepted, rejected } = filterIncomingFiles(incoming, {
+      maxFileSize,
+      preventDuplicate: preventDuplicate && multiple,
+      existingFiles: files,
+    });
+
+    if (rejected.length > 0) dispatch("rejected", rejected);
+
+    files = multiple ? [...files, ...accepted] : accepted;
+
+    if (files.length > 0 && !disableLabelChanges) {
+      labelText = files.length > 1 ? `${files.length} files` : files[0].name;
+    }
+
+    dispatch("change", files);
   }
 </script>
 
@@ -201,26 +226,7 @@
   class:bx--visually-hidden={true}
   {...$$restProps}
   on:change|stopPropagation={(event) => {
-    if (multiple) {
-      let incoming = [...event.target.files];
-      if (preventDuplicate) {
-        const existingKeys = new Set(
-          files.map((f) => `${f.name}\0${f.size}\0${f.lastModified}`),
-        );
-        incoming = incoming.filter(
-          (f) => !existingKeys.has(`${f.name}\0${f.size}\0${f.lastModified}`),
-        );
-      }
-      files = [...files, ...incoming];
-    } else {
-      files = [...event.target.files];
-    }
-
-    if (files && files.length > 0 && !disableLabelChanges) {
-      labelText = files.length > 1 ? `${files.length} files` : files[0].name;
-    }
-
-    dispatch("change", files);
+    processIncoming([...event.target.files]);
   }}
   on:click
   on:click={(event) => {

--- a/tests/FileUploader/FileUploaderButton.test.svelte
+++ b/tests/FileUploader/FileUploaderButton.test.svelte
@@ -1,3 +1,5 @@
+<svelte:options accessors />
+
 <script lang="ts">
   import FileUploaderButton from "carbon-components-svelte/FileUploader/FileUploaderButton.svelte";
   import type { ComponentProps } from "svelte";
@@ -6,10 +8,16 @@
   export let onchange:
     | ((e: CustomEvent<ReadonlyArray<File>>) => void)
     | undefined = undefined;
+  export let onrejected:
+    | ((
+        e: CustomEvent<Array<{ file: File; reason: "size" | "duplicate" }>>,
+      ) => void)
+    | undefined = undefined;
 </script>
 
 <FileUploaderButton
   bind:files
   on:change={(e) => onchange?.(e)}
+  on:rejected={(e) => onrejected?.(e)}
   {...$$restProps}
 />

--- a/tests/FileUploader/FileUploaderButton.test.ts
+++ b/tests/FileUploader/FileUploaderButton.test.ts
@@ -528,6 +528,252 @@ describe("FileUploaderButton", () => {
     expect(clickSpy).toHaveBeenCalled();
   });
 
+  describe("maxFileSize", () => {
+    it("should reject oversized files and report them", async () => {
+      const changeHandler = vi.fn();
+      const rejectedHandler = vi.fn();
+      const { container } = render(FileUploaderButton, {
+        props: {
+          multiple: true,
+          maxFileSize: 4,
+          onchange: changeHandler,
+          onrejected: rejectedHandler,
+        },
+      });
+
+      const input = container.querySelector('input[type="file"]');
+      assert(input instanceof HTMLInputElement);
+
+      const small = new File(["ab"], "small.txt", { type: "text/plain" });
+      const large = new File(["abcdefgh"], "large.txt", {
+        type: "text/plain",
+      });
+      simulateFileSelection(input, [small, large]);
+
+      await vi.waitFor(() => {
+        expect(changeHandler).toHaveBeenCalledTimes(1);
+      });
+
+      expect(changeHandler.mock.calls[0][0].detail).toEqual([small]);
+      expect(rejectedHandler).toHaveBeenCalledTimes(1);
+      expect(rejectedHandler.mock.calls[0][0].detail).toEqual([
+        { file: large, reason: "size" },
+      ]);
+    });
+
+    it("should not dispatch rejected when every file fits", async () => {
+      const changeHandler = vi.fn();
+      const rejectedHandler = vi.fn();
+      const { container } = render(FileUploaderButton, {
+        props: {
+          maxFileSize: 1024,
+          onchange: changeHandler,
+          onrejected: rejectedHandler,
+        },
+      });
+
+      const input = container.querySelector('input[type="file"]');
+      assert(input instanceof HTMLInputElement);
+
+      simulateFileSelection(input, [
+        new File(["ab"], "small.txt", { type: "text/plain" }),
+      ]);
+
+      await vi.waitFor(() => {
+        expect(changeHandler).toHaveBeenCalledTimes(1);
+      });
+      expect(rejectedHandler).not.toHaveBeenCalled();
+    });
+
+    it("should clear the selection and restore the label when the only file is rejected", async () => {
+      const rejectedHandler = vi.fn();
+      const { container } = render(FileUploaderButton, {
+        props: { maxFileSize: 4, onrejected: rejectedHandler },
+      });
+
+      const input = container.querySelector('input[type="file"]');
+      assert(input instanceof HTMLInputElement);
+
+      simulateFileSelection(input, [
+        new File(["abcdefgh"], "large.txt", { type: "text/plain" }),
+      ]);
+
+      await vi.waitFor(() => {
+        expect(rejectedHandler).toHaveBeenCalledTimes(1);
+      });
+      expect(screen.getByRole("button")).toHaveTextContent("Add file");
+    });
+
+    it("should not add rejected files to the bound files array", async () => {
+      const changeHandler = vi.fn();
+      const { component, container } = render(FileUploaderButton, {
+        props: { multiple: true, maxFileSize: 4, onchange: changeHandler },
+      });
+
+      const input = container.querySelector('input[type="file"]');
+      assert(input instanceof HTMLInputElement);
+
+      const small = new File(["ab"], "small.txt", { type: "text/plain" });
+      const large = new File(["abcdefgh"], "large.txt", {
+        type: "text/plain",
+      });
+      simulateFileSelection(input, [small, large]);
+
+      await vi.waitFor(() => {
+        expect(changeHandler).toHaveBeenCalledTimes(1);
+      });
+      expect(component.files).toEqual([small]);
+    });
+
+    it("should clear an existing selection when a later single-file pick is rejected", async () => {
+      const changeHandler = vi.fn();
+      const { component, container } = render(FileUploaderButton, {
+        props: { maxFileSize: 4, onchange: changeHandler },
+      });
+
+      const input = container.querySelector('input[type="file"]');
+      assert(input instanceof HTMLInputElement);
+
+      const small = new File(["ab"], "small.txt", { type: "text/plain" });
+      simulateFileSelection(input, [small]);
+
+      await vi.waitFor(() => {
+        expect(changeHandler).toHaveBeenCalledTimes(1);
+      });
+      expect(screen.getByRole("button")).toHaveTextContent("small.txt");
+
+      // A single-file input replaces its selection, so a rejected pick leaves
+      // nothing behind. This matches `FileUploaderDropContainer`.
+      simulateFileSelection(input, [
+        new File(["abcdefgh"], "large.txt", { type: "text/plain" }),
+      ]);
+
+      await vi.waitFor(() => {
+        expect(changeHandler).toHaveBeenCalledTimes(2);
+      });
+      expect(changeHandler.mock.calls[1][0].detail).toEqual([]);
+      expect(component.files).toEqual([]);
+      expect(screen.getByRole("button")).toHaveTextContent("Add file");
+    });
+  });
+
+  describe("maxFileSize with preventDuplicate", () => {
+    it("should report size and duplicate rejections in a single event", async () => {
+      const changeHandler = vi.fn();
+      const rejectedHandler = vi.fn();
+      const { component, container } = render(FileUploaderButton, {
+        props: {
+          multiple: true,
+          maxFileSize: 4,
+          preventDuplicate: true,
+          onchange: changeHandler,
+          onrejected: rejectedHandler,
+        },
+      });
+
+      const input = container.querySelector('input[type="file"]');
+      assert(input instanceof HTMLInputElement);
+
+      const lastModified = 1700000000000;
+      const props = { type: "text/plain", lastModified };
+      const fileA = new File(["a"], "a.txt", props);
+      simulateFileSelection(input, [fileA]);
+
+      await vi.waitFor(() => {
+        expect(changeHandler).toHaveBeenCalledTimes(1);
+      });
+      expect(rejectedHandler).not.toHaveBeenCalled();
+
+      const fileADup = new File(["a"], "a.txt", props);
+      const large = new File(["abcdefgh"], "large.txt", props);
+      const fileB = new File(["b"], "b.txt", props);
+      simulateFileSelection(input, [fileADup, large, fileB]);
+
+      await vi.waitFor(() => {
+        expect(rejectedHandler).toHaveBeenCalledTimes(1);
+      });
+      expect(rejectedHandler.mock.calls[0][0].detail).toEqual([
+        { file: large, reason: "size" },
+        { file: fileADup, reason: "duplicate" },
+      ]);
+      expect(component.files).toEqual([fileA, fileB]);
+    });
+  });
+
+  describe("rejected duplicates", () => {
+    it("should report deduped files when preventDuplicate and multiple are true", async () => {
+      const changeHandler = vi.fn();
+      const rejectedHandler = vi.fn();
+      const { container } = render(FileUploaderButton, {
+        props: {
+          multiple: true,
+          preventDuplicate: true,
+          onchange: changeHandler,
+          onrejected: rejectedHandler,
+        },
+      });
+
+      const input = container.querySelector('input[type="file"]');
+      assert(input instanceof HTMLInputElement);
+
+      const lastModified = 1700000000000;
+      const fileA = new File(["a"], "a.txt", {
+        type: "text/plain",
+        lastModified,
+      });
+      simulateFileSelection(input, [fileA]);
+
+      await vi.waitFor(() => {
+        expect(changeHandler).toHaveBeenCalledTimes(1);
+      });
+      expect(rejectedHandler).not.toHaveBeenCalled();
+
+      const fileADup = new File(["a"], "a.txt", {
+        type: "text/plain",
+        lastModified,
+      });
+      simulateFileSelection(input, [fileADup]);
+
+      await vi.waitFor(() => {
+        expect(rejectedHandler).toHaveBeenCalledTimes(1);
+      });
+      expect(rejectedHandler.mock.calls[0][0].detail).toEqual([
+        { file: fileADup, reason: "duplicate" },
+      ]);
+    });
+
+    it("should not dedupe in single-file mode", async () => {
+      const changeHandler = vi.fn();
+      const rejectedHandler = vi.fn();
+      const { container } = render(FileUploaderButton, {
+        props: {
+          preventDuplicate: true,
+          onchange: changeHandler,
+          onrejected: rejectedHandler,
+        },
+      });
+
+      const input = container.querySelector('input[type="file"]');
+      assert(input instanceof HTMLInputElement);
+
+      const lastModified = 1700000000000;
+      const props = { type: "text/plain", lastModified };
+      simulateFileSelection(input, [new File(["a"], "a.txt", props)]);
+      await vi.waitFor(() => {
+        expect(changeHandler).toHaveBeenCalledTimes(1);
+      });
+
+      const reselected = new File(["a"], "a.txt", props);
+      simulateFileSelection(input, [reselected]);
+
+      await vi.waitFor(() => {
+        expect(changeHandler).toHaveBeenCalledTimes(2);
+      });
+      expect(changeHandler.mock.calls[1][0].detail).toEqual([reselected]);
+      expect(rejectedHandler).not.toHaveBeenCalled();
+    });
+  });
+
   describe("Generics", () => {
     it("should support custom Icon types with generics", () => {
       type CustomIcon = new (...args: unknown[]) => unknown;

--- a/tests/utils/filterIncomingFiles.test.ts
+++ b/tests/utils/filterIncomingFiles.test.ts
@@ -44,6 +44,16 @@ describe("filterIncomingFiles", () => {
     expect(rejected).toEqual([]);
   });
 
+  test("honors a maxFileSize of 0", () => {
+    const empty = makeFile("empty.txt", 0);
+    const nonEmpty = makeFile("a.txt", 1);
+    const { accepted, rejected } = filterIncomingFiles([empty, nonEmpty], {
+      maxFileSize: 0,
+    });
+    expect(accepted).toEqual([empty]);
+    expect(rejected).toEqual([{ file: nonEmpty, reason: "size" }]);
+  });
+
   test("rejects duplicates against existing files", () => {
     const existing = makeFile("dup.txt", 10, 5);
     const duplicate = makeFile("dup.txt", 10, 5);


### PR DESCRIPTION
`FileUploaderButton` is the only file input that missed the 0.111.0 size and duplicate work. `maxFileSize` was not a prop at all, so setting it was silently accepted as an unknown attribute, and `preventDuplicate`'s skips were unreported since there was no rejected event.

Routes the change handler through the existing `filterIncomingFiles` util that FileUploader and `FileUploaderDropContainer` already use, so the button reports both reasons through the same rejected payload shape. 