### PR TITLE
feat(list-box): add wrapOptions for WCAG 1.4.10 Reflow (Dropdown, ComboBox, MultiSelect)

### DIFF
--- a/bench/virtualize.bench.ts
+++ b/bench/virtualize.bench.ts
@@ -51,4 +51,60 @@ bench("virtualize(), 10k items, 500 scroll positions", function* () {
   };
 });
 
+// The measured path, which `wrapOptions` turns on, replaces the fixed path's
+// offset arithmetic with a binary search over prefix sums. The sums are rebuilt
+// on every call: two walks over every option plus a Float64Array(n+1), however
+// few options are actually measured. Comparing this sweep against the fixed
+// sweep above shows what that costs.
+function buildHeights(count: number): number[] {
+  // Varied, so the binary search is not degenerate: a plain 40px list would
+  // make every prefix sum uniform and the search land in one step.
+  return Array.from({ length: count }, (_, i) => 32 + ((i * 17) % 96));
+}
+
+bench("virtualize() measured, $size items, mid-scroll", function* (state) {
+  const size = state.get("size");
+  const items = buildItems(size);
+  const heights = buildHeights(size);
+  const scrollTop = Math.floor(
+    heights.reduce((total, height) => total + height, 0) / 2,
+  );
+  yield () =>
+    virtualize({
+      items,
+      itemHeight: 40,
+      containerHeight: 300,
+      scrollTop,
+      threshold: 100,
+      measured: true,
+      heights,
+    });
+})
+  .range("size", 100, 100_000)
+  .gc("inner");
+
+// The measured counterpart of the scrollbar drag above.
+bench("virtualize() measured, 10k items, 500 scroll positions", function* () {
+  const items = buildItems(10_000);
+  const heights = buildHeights(10_000);
+  const totalHeight = heights.reduce((total, height) => total + height, 0);
+  const positions = Array.from({ length: 500 }, (_, i) =>
+    Math.floor((i / 500) * totalHeight),
+  );
+
+  yield () => {
+    for (const scrollTop of positions) {
+      virtualize({
+        items,
+        itemHeight: 40,
+        containerHeight: 300,
+        scrollTop,
+        threshold: 100,
+        measured: true,
+        heights,
+      });
+    }
+  };
+}).gc("inner");
+
 await runWithFilter();

--- a/css/_list-box-wrap-options.scss
+++ b/css/_list-box-wrap-options.scss
@@ -1,0 +1,91 @@
+@import "carbon-components/scss/globals/scss/vars";
+@import "carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/import-once/import-once";
+
+/// Option wrapping, reached by the `bx--list-box__menu--wrap-options` marker
+/// class that a listbox component's `wrapOptions` prop puts on its menu.
+/// `Dropdown`, `ComboBox`, and `MultiSelect` share the option markup, so they
+/// share this.
+///
+/// Carbon confines an option to one fixed-height line and truncates the
+/// overflow with an ellipsis. At the WCAG 1.4.10 Reflow test condition
+/// (320x256 CSS px) that loses text with no way to reach it, so this releases
+/// the height and lets the label take as many lines as it needs.
+///
+/// Unbounded on purpose: any line limit brings back the loss of information
+/// wrapping exists to remove. `overflow-wrap: break-word` reflows a single long
+/// unbroken token instead of forcing horizontal scroll, while ordinary words
+/// still break at their boundaries. `word-break: break-all`, which this rule
+/// carried first, breaks every word at the line edge, which reads badly and
+/// splits a highlighted match mid-word. `overflow-wrap: anywhere` would work
+/// too but needs Safari 15.4, past this library's Safari 14 baseline
+/// (`BROWSERSLIST` in `scripts/build-css.ts`).
+///
+/// The marker class sits on the menu rather than the component root, since the
+/// menu can be portaled out of that root's subtree.
+///
+/// Nothing here declares a color, so every shipped theme renders a wrapped
+/// option the way it renders an unwrapped one.
+/// @access private
+/// @group list-box
+@mixin list-box-wrap-options {
+  .#{$prefix}--list-box__menu--wrap-options .#{$prefix}--list-box__menu-item {
+    block-size: auto;
+  }
+
+  // Fluid (non-condensed) menu items are given a taller fixed height by a
+  // three-class selector in _fluid-list-box.scss, which outranks the rule
+  // above. Match its specificity so a fluid option grows too.
+  .#{$prefix}--list-box__wrapper--fluid
+    .#{$prefix}--list-box__menu--wrap-options
+    .#{$prefix}--list-box__menu-item {
+    block-size: auto;
+  }
+
+  .#{$prefix}--list-box__menu--wrap-options
+    .#{$prefix}--list-box__menu-item__option {
+    block-size: auto;
+    white-space: normal;
+    overflow-wrap: break-word;
+  }
+
+  // `MultiSelect` renders each option as a checkbox whose label carries the
+  // text, and that label is confined to one line twice over: on the label by
+  // `_multi-select.scss`, and on the text span inside it by `_list-box.scss`.
+  // The rule above reaches both only by inheritance, which loses to a
+  // declaration on the element, so each is released by name. The first matches
+  // the specificity of the rule it outranks and wins on order, this partial
+  // being imported last; the second outranks its two-class rule outright.
+  .#{$prefix}--list-box__menu--wrap-options
+    .#{$prefix}--list-box__menu-item__option
+    .#{$prefix}--checkbox-label,
+  .#{$prefix}--list-box__menu--wrap-options
+    .#{$prefix}--list-box__menu-item
+    .#{$prefix}--checkbox-label-text {
+    overflow: visible;
+    text-overflow: clip;
+    white-space: normal;
+  }
+
+  // The text span carries the gap between the checkbox and the words. Inline
+  // padding is drawn once at the start of the whole inline box rather than at
+  // the start of every line it breaks into, so on one line it reads as the gap
+  // and on three as a first-line indent with the rest hanging 6px to its left.
+  // A block box puts every line at the same left edge.
+  //
+  // `block` and not `inline-block`: an inline-block is sized shrink-to-fit,
+  // never narrower than the content's minimum, and `overflow-wrap: break-word`,
+  // unlike `anywhere`, does not lower that minimum for an unbreakable token. So
+  // an inline-block grows to the width of a long unbroken identifier, which
+  // stops it wrapping and pushes the option into overflow, bringing back both
+  // the reflow failure and the `title` tooltip. A block box takes the width it
+  // is given and lets the token break inside it.
+  .#{$prefix}--list-box__menu--wrap-options
+    .#{$prefix}--list-box__menu-item
+    .#{$prefix}--checkbox-label-text {
+    display: block;
+  }
+}
+
+@include exports("list-box-wrap-options") {
+  @include list-box-wrap-options;
+}

--- a/css/all.scss
+++ b/css/all.scss
@@ -128,3 +128,4 @@ $css--plex: true;
 @import "./user-avatar";
 @import "./user-avatar-group";
 @import "./disclosure";
+@import "./list-box-wrap-options";

--- a/css/g10.scss
+++ b/css/g10.scss
@@ -88,3 +88,4 @@ $css--plex: true;
 @import "./user-avatar";
 @import "./user-avatar-group";
 @import "./disclosure";
+@import "./list-box-wrap-options";

--- a/css/g100.scss
+++ b/css/g100.scss
@@ -88,3 +88,4 @@ $css--plex: true;
 @import "./user-avatar";
 @import "./user-avatar-group";
 @import "./disclosure";
+@import "./list-box-wrap-options";

--- a/css/g80.scss
+++ b/css/g80.scss
@@ -88,3 +88,4 @@ $css--plex: true;
 @import "./user-avatar";
 @import "./user-avatar-group";
 @import "./disclosure";
+@import "./list-box-wrap-options";

--- a/css/g90.scss
+++ b/css/g90.scss
@@ -88,3 +88,4 @@ $css--plex: true;
 @import "./user-avatar";
 @import "./user-avatar-group";
 @import "./disclosure";
+@import "./list-box-wrap-options";

--- a/css/white.scss
+++ b/css/white.scss
@@ -88,3 +88,4 @@ $css--plex: true;
 @import "./user-avatar";
 @import "./user-avatar-group";
 @import "./disclosure";
+@import "./list-box-wrap-options";

--- a/docs/src/pages/components/ComboBox.svx
+++ b/docs/src/pages/components/ComboBox.svx
@@ -400,6 +400,16 @@ When inside a [Modal](/components/Modal#modal-with-dropdowns), `portalMenu` defa
 
 <FileSource src="/framed/ComboBox/ComboBoxPortalMenu" />
 
+### Wrapped options
+
+Option labels are truncated to one line. At a 320px viewport, that hides text and can leave two options looking identical, a WCAG 1.4.10 Reflow failure.
+
+Set `wrapOptions` to let a label take as many lines as it needs. Lines break between words, and mid-word only when a word is too long to fit a line by itself. Default slot markup wraps with the label: a [highlighted match](#highlight-matches) stays marked across the break it is split by.
+
+It defaults to `false` because wrapping changes option heights.
+
+<FileSource src="/framed/ComboBox/WrapOptions" />
+
 ### Programmatic access
 
 Bind to `open` to control the dropdown menu programmatically, such as opening it from an external trigger.

--- a/docs/src/pages/components/Dropdown.svx
+++ b/docs/src/pages/components/Dropdown.svx
@@ -155,6 +155,16 @@ Set `open` to `true` to render the dropdown already expanded. The prop is bindab
   {id: "1", text: "Email"},
   {id: "2", text: "Fax"}]}" />
 
+### Wrapped options
+
+Option labels are truncated to one line. At a 320px viewport, that hides text and can leave two options looking identical, a WCAG 1.4.10 Reflow failure.
+
+Set `wrapOptions` to let a label take as many lines as it needs. Lines break between words, and mid-word only when a word is too long to fit a line by itself. A [custom slot](#custom-slot) wraps with the label.
+
+It defaults to `false` because wrapping changes option heights.
+
+<FileSource src="/framed/Dropdown/WrapOptions" />
+
 ## Virtualization
 
 Virtualization renders only the items currently visible in the viewport, improving performance for large lists.

--- a/docs/src/pages/components/MultiSelect.svx
+++ b/docs/src/pages/components/MultiSelect.svx
@@ -273,6 +273,16 @@ By default, item height matches the menu row for each size: 24px (xs), 32px (sm)
 
 <FileSource src="/framed/MultiSelect/VirtualizeItemHeight" />
 
+## Wrapped options
+
+Option labels are truncated to one line. At a 320px viewport, that hides text and can leave two options looking identical, a WCAG 1.4.10 Reflow failure.
+
+Set `wrapOptions` to let a label take as many lines as it needs. Lines break between words, and mid-word only when a word is too long to fit a line by itself. Default slot markup wraps with the label: a [highlighted match](#highlight-matches) stays marked across the break it is split by.
+
+It defaults to `false` because wrapping changes option heights.
+
+<FileSource src="/framed/MultiSelect/WrapOptions" />
+
 ## Sizes
 
 The `size` prop sets the field height. The default is medium.

--- a/docs/src/pages/framed/ComboBox/WrapOptions.svelte
+++ b/docs/src/pages/framed/ComboBox/WrapOptions.svelte
@@ -1,0 +1,83 @@
+<script>
+  import { ComboBox, highlightSegments, Stack } from "carbon-components-svelte";
+
+  const roles = [
+    "Chief Accessibility Officer for Regional Operations and Strategic Partnerships",
+    "Deputy Director of Interdepartmental Communications and Outreach",
+  ];
+
+  const items = [
+    { id: "0", text: roles[0] },
+    { id: "1", text: roles[1] },
+    { id: "2", text: "Analyst" },
+  ];
+
+  // Past the count at which a list is windowed, so only the options on screen
+  // are rendered. `wrapOptions` turns on measured row heights by itself, so
+  // offsets follow the heights the wrapped options actually take.
+  const manyItems = Array.from({ length: 300 }, (_, i) => ({
+    id: String(i),
+    text: `${i + 1}. ${roles[i % 2]}`,
+  }));
+
+  let truncatedValue = "";
+  let wrappedValue = "";
+  let windowedValue = "";
+
+  const shouldFilterItem = (item, value) =>
+    item.text.toLowerCase().includes(value.toLowerCase());
+
+  // Where the typed value occurs in the label, as the character indices
+  // `highlightSegments` splits on.
+  function matchIndices(text, value) {
+    const start = value ? text.toLowerCase().indexOf(value.toLowerCase()) : -1;
+    if (start === -1) return [];
+    return Array.from({ length: value.length }, (_, i) => start + i);
+  }
+</script>
+
+<Stack gap={6} style="max-width: 20rem;">
+  <ComboBox
+    labelText="Truncated (default)"
+    placeholder="Try typing 'operations'"
+    bind:value={truncatedValue}
+    {shouldFilterItem}
+    {items}
+    let:item
+  >
+    {#each highlightSegments(item.text, matchIndices(item.text, truncatedValue)) as segment}
+      {#if segment.match}
+        <mark>{segment.text}</mark>
+      {:else}
+        {segment.text}
+      {/if}
+    {/each}
+  </ComboBox>
+
+  <ComboBox
+    wrapOptions
+    labelText="Wrapped"
+    placeholder="Try typing 'operations'"
+    bind:value={wrappedValue}
+    {shouldFilterItem}
+    {items}
+    let:item
+  >
+    {#each highlightSegments(item.text, matchIndices(item.text, wrappedValue)) as segment}
+      {#if segment.match}
+        <mark>{segment.text}</mark>
+      {:else}
+        {segment.text}
+      {/if}
+    {/each}
+  </ComboBox>
+
+  <ComboBox
+    wrapOptions
+    labelText="Wrapped (windowed, 300 items)"
+    placeholder="Try typing 'operations'"
+    bind:value={windowedValue}
+    {shouldFilterItem}
+    items={manyItems}
+  />
+</Stack>

--- a/docs/src/pages/framed/Dropdown/WrapOptions.svelte
+++ b/docs/src/pages/framed/Dropdown/WrapOptions.svelte
@@ -1,0 +1,32 @@
+<script>
+  import { Dropdown, Stack } from "carbon-components-svelte";
+
+  const roles = [
+    "Chief Accessibility Officer for Regional Operations and Strategic Partnerships",
+    "Deputy Director of Interdepartmental Communications and Outreach",
+  ];
+
+  const items = [
+    { id: "0", text: roles[0] },
+    { id: "1", text: roles[1] },
+    { id: "2", text: "Analyst" },
+  ];
+
+  // Past the count at which a list is windowed, so only the options on screen
+  // are rendered. `wrapOptions` turns on measured row heights by itself, so
+  // offsets follow the heights the wrapped options actually take.
+  const manyItems = Array.from({ length: 300 }, (_, i) => ({
+    id: String(i),
+    text: `${i + 1}. ${roles[i % 2]}`,
+  }));
+</script>
+
+<Stack gap={6} style="max-width: 20rem;">
+  <Dropdown labelText="Truncated (default)" selectedId="2" {items} />
+  <Dropdown wrapOptions labelText="Wrapped" selectedId="2" {items} />
+  <Dropdown
+    wrapOptions
+    labelText="Wrapped (windowed, 300 items)"
+    items={manyItems}
+  />
+</Stack>

--- a/docs/src/pages/framed/MultiSelect/WrapOptions.svelte
+++ b/docs/src/pages/framed/MultiSelect/WrapOptions.svelte
@@ -1,0 +1,51 @@
+<script>
+  import { MultiSelect, Stack } from "carbon-components-svelte";
+
+  const roles = [
+    "Chief Accessibility Officer for Regional Operations and Strategic Partnerships",
+    "Deputy Director of Interdepartmental Communications and Outreach",
+  ];
+
+  const items = [
+    { id: "all", text: "Select every role listed below", isSelectAll: true },
+    { id: "0", text: roles[0] },
+    { id: "1", text: roles[1] },
+    { id: "2", text: "Analyst" },
+  ];
+
+  // Past the count at which a list is windowed, so only the options on screen
+  // are rendered. `wrapOptions` turns on measured row heights by itself, so
+  // offsets follow the heights the wrapped options actually take.
+  const manyItems = Array.from({ length: 300 }, (_, i) => ({
+    id: String(i),
+    text: `${i + 1}. ${roles[i % 2]}`,
+  }));
+
+  // Input order, so the "select all" row stays in front of the roles it
+  // toggles rather than sorting into the middle of them.
+  const sortItem = () => 0;
+</script>
+
+<Stack gap={6} style="max-width: 20rem;">
+  <MultiSelect
+    labelText="Truncated (default)"
+    selectedIds={["2"]}
+    {sortItem}
+    {items}
+  />
+  <MultiSelect
+    wrapOptions
+    labelText="Wrapped"
+    selectedIds={["2"]}
+    {sortItem}
+    {items}
+  />
+  <MultiSelect
+    wrapOptions
+    filterable
+    labelText="Wrapped (windowed, 300 items)"
+    placeholder="Filter…"
+    {sortItem}
+    items={manyItems}
+  />
+</Stack>

--- a/e2e/combobox-measured.test.ts
+++ b/e2e/combobox-measured.test.ts
@@ -1,0 +1,198 @@
+import { expect, type Page, test } from "@playwright/test";
+import {
+  expectMenuReadsContinuously,
+  filterBy,
+  isFullyInView,
+  readMenuMetrics,
+  readOptionBoxes,
+  SLACK,
+  scrollToEnd,
+  stepDown,
+} from "./measured-menu";
+
+const ITEM_COUNT = 300;
+/** Options matching either tag: half the list, still above the threshold. */
+const MATCH_COUNT = ITEM_COUNT / 2;
+
+function field(page: Page) {
+  return page.getByRole("combobox", { name: "Items" });
+}
+
+test.describe("ComboBox measured item heights", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/combobox-measured.html");
+    await field(page).click();
+    await expect(page.getByRole("listbox")).toBeVisible();
+  });
+
+  test("options render at unequal heights while filtered", async ({ page }) => {
+    await filterBy(page, field(page), "Even", MATCH_COUNT);
+
+    const boxes = await readOptionBoxes(page);
+    const heights = new Set(boxes?.options.map((option) => option.height));
+
+    // Without this the rest of the file would pass against a uniform list.
+    expect(heights.size).toBeGreaterThan(1);
+  });
+
+  test("the scrollbar spans the real length of the matching options", async ({
+    page,
+  }) => {
+    const unfiltered = await readMenuMetrics(page);
+
+    await filterBy(page, field(page), "Even", MATCH_COUNT);
+    const filtered = await readMenuMetrics(page);
+
+    expect(filtered.clientHeight).toBe(300);
+    // Taller than any single assumed row height would have produced, and
+    // shorter than the whole list: the scrollbar describes the matches alone.
+    expect(filtered.scrollHeight).toBeGreaterThan(MATCH_COUNT * 40);
+    expect(filtered.scrollHeight).toBeLessThan(unfiltered.scrollHeight);
+  });
+
+  test("scrolling a filtered list to the end reveals the last match in full", async ({
+    page,
+  }) => {
+    await filterBy(page, field(page), "Even", MATCH_COUNT);
+    await scrollToEnd(page);
+
+    // The end being the real end rather than the one a single assumed row
+    // height would have put there: the scrollbar has to account for the whole
+    // length of the matches before arriving at it means anything.
+    const metrics = await readMenuMetrics(page);
+    expect(metrics.scrollHeight).toBeGreaterThan(MATCH_COUNT * 40);
+
+    const boxes = await readOptionBoxes(page);
+    expect(boxes).not.toBeNull();
+    const last = boxes?.options.at(-1);
+
+    // The last *matching* option, one of the tallest, wholly inside the menu.
+    expect(last?.text).toContain(`Even item ${ITEM_COUNT}`);
+    expect(last?.top).toBeGreaterThanOrEqual((boxes?.menu.top ?? 0) - SLACK);
+    expect(last?.bottom).toBeLessThanOrEqual((boxes?.menu.bottom ?? 0) + SLACK);
+  });
+
+  test("a filtered list reads continuously, with no gaps or overlaps", async ({
+    page,
+  }) => {
+    await filterBy(page, field(page), "Even", MATCH_COUNT);
+    await scrollToEnd(page);
+
+    await expectMenuReadsContinuously(page);
+  });
+
+  test("no offsets survive a filter that changes which options match", async ({
+    page,
+  }) => {
+    // Measure one tag's options to the end of the list, then switch tags. Every
+    // height now held describes an option that is no longer at that position.
+    await filterBy(page, field(page), "Even", MATCH_COUNT);
+    await scrollToEnd(page);
+
+    await filterBy(page, field(page), "Odd", MATCH_COUNT);
+
+    await expectMenuReadsContinuously(page);
+    await scrollToEnd(page);
+    const boxes = await readOptionBoxes(page);
+    expect(boxes?.options.at(-1)?.text).toContain(`Odd item ${ITEM_COUNT - 1}`);
+  });
+
+  test("clearing the filter restores the offsets of the whole list", async ({
+    page,
+  }) => {
+    await filterBy(page, field(page), "Even", MATCH_COUNT);
+    const filtered = await readMenuMetrics(page);
+    await scrollToEnd(page);
+    await filterBy(page, field(page), "", ITEM_COUNT);
+
+    // Well clear of the half-list the filter had narrowed to. Comparing
+    // against the reading taken before the filter would prove less than it
+    // looks: both are dominated by the estimate for options nobody has
+    // scrolled to yet. Reaching the whole list's true last option below is
+    // what actually settles it.
+    expect((await readMenuMetrics(page)).scrollHeight).toBeGreaterThan(
+      filtered.scrollHeight * 1.5,
+    );
+    await expectMenuReadsContinuously(page);
+    await scrollToEnd(page);
+    const boxes = await readOptionBoxes(page);
+    expect(boxes?.options.at(-1)?.text).toContain(`Even item ${ITEM_COUNT}`);
+  });
+
+  // Stepping and jumping are scrolled by different things, and only one of
+  // them is this component's own arithmetic. A step lands on an option that is
+  // already rendered, so `ListBoxMenu`'s highlight cursor scrolls it exactly,
+  // from its real box. A jump lands on one that is not rendered yet, which the
+  // cursor has no node for, so the measured path has to carry it. Under a
+  // filter both run against heights measured moments earlier for a set of
+  // options that had only just come into being.
+  test("arrowing through a filtered list scrolls each option fully into view", async ({
+    page,
+  }) => {
+    await filterBy(page, field(page), "Even", MATCH_COUNT);
+
+    const highlighted = page.locator(".bx--list-box__menu-item--highlighted");
+
+    // Far enough to walk past the bottom edge several times over, one option at
+    // a time, through matches of all three heights.
+    const outOfView: number[] = [];
+    for (let step = 0; step < 14; step++) {
+      // biome-ignore lint/performance/noAwaitInLoops: a step has to land before the next is judged
+      const inView = await stepDown(page, field(page), highlighted);
+      if (inView !== true) outOfView.push(step);
+    }
+    expect(outOfView).toEqual([]);
+
+    await field(page).press("End");
+    await expect(highlighted).toContainText(`Even item ${ITEM_COUNT}`);
+    expect(await isFullyInView(highlighted)).toBe(true);
+  });
+
+  test("filtering down to a single match shows it whole", async ({ page }) => {
+    await filterBy(page, field(page), `item ${ITEM_COUNT}`, 1);
+
+    const options = page.getByRole("option");
+    await expect(options).toHaveCount(1);
+    await expect(options).toContainText(`Even item ${ITEM_COUNT}`);
+    expect(await isFullyInView(options)).toBe(true);
+  });
+
+  test("filtering down to no matches leaves an empty menu that recovers", async ({
+    page,
+  }) => {
+    await field(page).fill("no such option");
+
+    await expect(page.getByRole("option")).toHaveCount(0);
+    // Still mounted, though an empty menu has nothing to give it a height.
+    await expect(page.getByRole("listbox")).toBeAttached();
+
+    // The menu comes back correct rather than stuck at the empty list's
+    // offsets, which is the part an empty set could quietly break.
+    await filterBy(page, field(page), "Even", MATCH_COUNT);
+
+    await expectMenuReadsContinuously(page);
+    await scrollToEnd(page);
+    const boxes = await readOptionBoxes(page);
+    expect(boxes?.options.at(-1)?.text).toContain(`Even item ${ITEM_COUNT}`);
+  });
+
+  test("selecting a filtered option keeps the field and menu consistent", async ({
+    page,
+  }) => {
+    await filterBy(page, field(page), "Even", MATCH_COUNT);
+    await scrollToEnd(page);
+
+    await page
+      .getByRole("option", {
+        name: new RegExp(`Even item ${ITEM_COUNT}`),
+      })
+      .click();
+
+    await expect(page.getByRole("listbox")).toBeHidden();
+    // The field carries the whole label, filler words and all, so this is
+    // anchored on the part that names the option rather than repeating it.
+    await expect(field(page)).toHaveValue(
+      new RegExp(`^Even item ${ITEM_COUNT}\\b`),
+    );
+  });
+});

--- a/e2e/combobox-measured.test.ts
+++ b/e2e/combobox-measured.test.ts
@@ -2,8 +2,10 @@ import { expect, type Page, test } from "@playwright/test";
 import {
   expectMenuReadsContinuously,
   filterBy,
+  hoverBottomEdge,
   isFullyInView,
   readMenuMetrics,
+  readMenuScrollTop,
   readOptionBoxes,
   SLACK,
   scrollToEnd,
@@ -25,6 +27,18 @@ test.describe("ComboBox measured item heights", () => {
     await expect(page.getByRole("listbox")).toBeVisible();
   });
 
+  test("hovering the option the bottom edge cuts off leaves the menu alone", async ({
+    page,
+  }) => {
+    const held = await readMenuScrollTop(page);
+
+    await hoverBottomEdge(page);
+    await page.waitForTimeout(200);
+
+    // The pointer highlights whatever it lands on. Bringing a clipped option
+    // fully into view would scroll the list out from under the reader.
+    expect(await readMenuScrollTop(page)).toBe(held);
+  });
   test("options render at unequal heights while filtered", async ({ page }) => {
     await filterBy(page, field(page), "Even", MATCH_COUNT);
 

--- a/e2e/dropdown-measured.test.ts
+++ b/e2e/dropdown-measured.test.ts
@@ -1,0 +1,145 @@
+import { expect, test } from "@playwright/test";
+import {
+  expectMenuReadsContinuously,
+  isFullyInView,
+  readMenuMetrics,
+  readOptionBoxes,
+  SLACK,
+  scrollToEnd,
+  stepDown,
+} from "./measured-menu";
+
+const ITEM_COUNT = 300;
+
+test.describe("Dropdown measured item heights", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/dropdown-measured.html");
+    await page.getByRole("combobox", { name: "Items" }).click();
+    await expect(page.getByRole("listbox")).toBeVisible();
+  });
+
+  test("options render at unequal heights", async ({ page }) => {
+    const boxes = await readOptionBoxes(page);
+    const heights = new Set(boxes?.options.map((option) => option.height));
+
+    // Without this the rest of the file would pass against a uniform list.
+    expect(heights.size).toBeGreaterThan(1);
+  });
+
+  test("the scrollbar spans the real length of the list", async ({ page }) => {
+    const metrics = await readMenuMetrics(page);
+
+    expect(metrics.clientHeight).toBe(300);
+    // 300 wrapped options, most of them several lines tall: far taller than
+    // any single assumed row height would have produced.
+    expect(metrics.scrollHeight).toBeGreaterThan(ITEM_COUNT * 40);
+  });
+
+  test("scrolling to the end reveals the last option in full", async ({
+    page,
+  }) => {
+    await scrollToEnd(page);
+
+    const boxes = await readOptionBoxes(page);
+    expect(boxes).not.toBeNull();
+    const last = boxes?.options.at(-1);
+
+    expect(last?.text).toContain(`Item ${ITEM_COUNT}`);
+    expect(last?.top).toBeGreaterThanOrEqual((boxes?.menu.top ?? 0) - SLACK);
+    expect(last?.bottom).toBeLessThanOrEqual((boxes?.menu.bottom ?? 0) + SLACK);
+  });
+
+  test("the option list reads continuously, with no gaps or overlaps", async ({
+    page,
+  }) => {
+    await scrollToEnd(page);
+
+    await expectMenuReadsContinuously(page);
+  });
+
+  test("stays correctly laid out when option heights change with the menu open", async ({
+    page,
+  }) => {
+    await scrollToEnd(page);
+    // What changing browser zoom does to this list: every option grows, and no
+    // render pass says so. Zoom itself is browser chrome that no script can
+    // reach, and the root font size drives the same rem-sized text through the
+    // same shared observer. Doubling it more than doubles every option.
+    await page.evaluate(() => {
+      document.documentElement.style.fontSize = "200%";
+    });
+    // Let the resize observation land and any scroll correction settle.
+    await page.waitForTimeout(200);
+
+    // Every rendered option still abuts its neighbours, and between them they
+    // still fill the menu: no blank band, no options laid over one another, at
+    // heights nothing was measured at.
+    await expectMenuReadsContinuously(page);
+  });
+
+  // Stepping and jumping are scrolled by different things, and only one of
+  // them is this component's own arithmetic. A step lands on an option that is
+  // already rendered, so `ListBoxMenu`'s highlight cursor scrolls it exactly,
+  // from its real box. A jump lands on one that is not rendered yet, which the
+  // cursor has no node for, so the measured path has to carry it. Both cases
+  // need a test or the division of labour drifts unnoticed.
+  test("arrowing one option at a time keeps each highlight in view", async ({
+    page,
+  }) => {
+    const field = page.getByRole("combobox", { name: "Items" });
+    const highlighted = page.locator(".bx--list-box__menu-item--highlighted");
+    await page.waitForTimeout(200);
+
+    // Far enough to walk past the bottom edge several times over, through
+    // options of all three heights.
+    const outOfView: number[] = [];
+    for (let step = 0; step < 12; step++) {
+      // biome-ignore lint/performance/noAwaitInLoops: a step has to land before the next is judged
+      const inView = await stepDown(page, field, highlighted);
+      if (inView !== true) outOfView.push(step);
+    }
+
+    expect(outOfView).toEqual([]);
+  });
+
+  test("arrowing to the end of the list keeps the option in view", async ({
+    page,
+  }) => {
+    await page.getByRole("combobox", { name: "Items" }).press("End");
+
+    const highlighted = page.locator(".bx--list-box__menu-item--highlighted");
+    await expect(highlighted).toHaveCount(1);
+    await expect(highlighted).toContainText(`Item ${ITEM_COUNT}`);
+
+    // The settled position is what is being judged. A jump to the end places
+    // the option from the heights known at the time and again once the options
+    // it landed among have been measured, so the first frame is not yet the
+    // answer, and the option is a different element on either side of it.
+    await expect(async () => {
+      expect(await isFullyInView(highlighted)).toBe(true);
+    }).toPass({ timeout: 2000 });
+  });
+});
+
+test.describe("Dropdown measured item heights, reopened on a selection", () => {
+  test("places the selected option in view on open", async ({ page }) => {
+    await page.goto("/dropdown-measured.html");
+
+    const field = page.getByRole("combobox", { name: "Items" });
+    await field.click();
+    await scrollToEnd(page);
+    await page.getByRole("option", { name: /Item 300/ }).click();
+    await expect(page.getByRole("listbox")).toBeHidden();
+
+    await field.click();
+    await expect(page.getByRole("listbox")).toBeVisible();
+    // Reopening re-measures from nothing, so give the placement a chance to
+    // settle on the measured position rather than the estimated one.
+    await page.waitForTimeout(200);
+
+    const selected = page.locator('[role="option"][aria-selected="true"]');
+    await expect(selected).toHaveCount(1);
+
+    expect(await isFullyInView(selected)).toBe(true);
+  });
+});

--- a/e2e/dropdown-measured.test.ts
+++ b/e2e/dropdown-measured.test.ts
@@ -1,8 +1,11 @@
 import { expect, test } from "@playwright/test";
 import {
   expectMenuReadsContinuously,
+  hoverBottomEdge,
   isFullyInView,
+  readHighlightedOption,
   readMenuMetrics,
+  readMenuScrollTop,
   readOptionBoxes,
   SLACK,
   scrollToEnd,
@@ -57,6 +60,48 @@ test.describe("Dropdown measured item heights", () => {
     await expectMenuReadsContinuously(page);
   });
 
+  test("hovering the option the bottom edge cuts off leaves the menu alone", async ({
+    page,
+  }) => {
+    const held = await readMenuScrollTop(page);
+
+    await hoverBottomEdge(page);
+    await page.waitForTimeout(200);
+
+    // The pointer highlights whatever it lands on. Bringing a clipped option
+    // fully into view would scroll the list out from under the reader.
+    expect(await readMenuScrollTop(page)).toBe(held);
+  });
+
+  test("a hover ends the request the keyboard left behind", async ({
+    page,
+  }) => {
+    // `End` reaches the far end of the list in one jump, which the other two
+    // components' filterable fields read as a caret key. The menu window is
+    // shared, so proving it here proves it for the three.
+    await page.getByRole("combobox", { name: "Items" }).press("End");
+    await page.waitForTimeout(200);
+    const placed = await readHighlightedOption(page);
+
+    // The pointer takes the highlight off the option the keyboard placed. No
+    // scroll position moves, so nothing but this tells the menu that the
+    // request which placed it is spent.
+    await hoverBottomEdge(page);
+    await page.waitForTimeout(200);
+
+    // Every option grows, as a web font swapping in or the reader changing
+    // zoom would grow them, and no render pass says so. That carries the
+    // option the keyboard placed off the end of the menu, and a request still
+    // standing would fetch it back.
+    await page.evaluate(() => {
+      document.documentElement.style.fontSize = "200%";
+    });
+    await page.waitForTimeout(300);
+
+    await expect(
+      page.getByRole("option").filter({ hasText: placed }),
+    ).toHaveCount(0);
+  });
   test("stays correctly laid out when option heights change with the menu open", async ({
     page,
   }) => {

--- a/e2e/fixtures/ComboBoxMeasuredFixture.svelte
+++ b/e2e/fixtures/ComboBoxMeasuredFixture.svelte
@@ -1,0 +1,55 @@
+<script>
+  import { ComboBox } from "carbon-components-svelte";
+
+  // Filler words, appended to a label to push it onto more lines at the narrow
+  // field below. Three classes, so the list holds options of three visibly
+  // different heights: the case where no single `itemHeight` is right. The
+  // cycle is three long and the tags alternate, so a filtered set holds all
+  // three heights in a different order from the unfiltered list.
+  const FILLER = "wrapping";
+  const FILLER_WORDS = [0, 6, 14];
+
+  function label(prefix, index) {
+    const words = FILLER_WORDS[index % FILLER_WORDS.length];
+    return [prefix, ...Array.from({ length: words }, () => FILLER)].join(" ");
+  }
+
+  // Above the default virtualization threshold both unfiltered and filtered by
+  // either tag, so the menu is windowed on both sides of a keystroke and every
+  // offset has to come from somewhere.
+  const items = Array.from({ length: 300 }, (_, i) => ({
+    id: i,
+    // The tag is what the tests filter on; half the list matches each one.
+    text: label(`${(i + 1) % 2 === 0 ? "Even" : "Odd"} item ${i + 1}`, i),
+  }));
+
+  let selectedId = null;
+  let value = "";
+</script>
+
+<!-- `wrapOptions` is the whole of the opt-in: wrapping is what leaves the
+     options unequal in height, and what puts the windowed filtered list onto
+     measured offsets. There is no second switch, and the stylesheet it brings
+     releases the fixed option height without the fixture overriding anything. -->
+<div class="field">
+  <ComboBox
+    labelText="Items"
+    placeholder="Filter…"
+    {items}
+    bind:selectedId
+    bind:value
+    portalMenu={false}
+    shouldFilterItem={(item, value) =>
+      item.text.toLowerCase().includes(value.toLowerCase())}
+    wrapOptions
+    virtualize={{ containerHeight: 300 }}
+  />
+</div>
+
+<style>
+  /* Narrow enough that a label wraps at all, and fixed so the heights do not
+     move with the viewport the test happens to run at. */
+  .field {
+    inline-size: 320px;
+  }
+</style>

--- a/e2e/fixtures/DropdownMeasuredFixture.svelte
+++ b/e2e/fixtures/DropdownMeasuredFixture.svelte
@@ -1,0 +1,48 @@
+<script>
+  import { Dropdown } from "carbon-components-svelte";
+
+  // Filler words, appended to a label to push it onto more lines at the narrow
+  // field below. Three classes, so the list holds options of three visibly
+  // different heights: the case where no single `itemHeight` is right. The
+  // exact line count each produces is neither asserted nor relied on: only
+  // that the three differ.
+  const FILLER = "wrapping";
+  const FILLER_WORDS = [0, 6, 14];
+
+  function label(prefix, index) {
+    const words = FILLER_WORDS[index % FILLER_WORDS.length];
+    return [prefix, ...Array.from({ length: words }, () => FILLER)].join(" ");
+  }
+
+  // Above the default virtualization threshold, so the menu is windowed and
+  // every offset has to come from somewhere.
+  const items = Array.from({ length: 300 }, (_, i) => ({
+    id: i,
+    text: label(`Item ${i + 1}`, i),
+  }));
+
+  let selectedId = null;
+</script>
+
+<!-- `wrapOptions` is the whole of the opt-in: wrapping is what leaves the
+     options unequal in height, and what puts the windowed list onto measured
+     offsets. There is no second switch, and the stylesheet it brings releases
+     the fixed option height without the fixture overriding anything. -->
+<div class="field">
+  <Dropdown
+    labelText="Items"
+    {items}
+    bind:selectedId
+    portalMenu={false}
+    wrapOptions
+    virtualize={{ containerHeight: 300 }}
+  />
+</div>
+
+<style>
+  /* Narrow enough that a label wraps at all, and fixed so the heights do not
+     move with the viewport the test happens to run at. */
+  .field {
+    inline-size: 320px;
+  }
+</style>

--- a/e2e/fixtures/MultiSelectMeasuredFixture.svelte
+++ b/e2e/fixtures/MultiSelectMeasuredFixture.svelte
@@ -1,0 +1,63 @@
+<script>
+  import { MultiSelect } from "carbon-components-svelte";
+
+  // Filler words, appended to a label to push it onto more lines at the narrow
+  // field below. Three classes, so the list holds options of three visibly
+  // different heights: the case where no single `itemHeight` is right. The
+  // cycle is three long and the tags alternate, so a filtered set holds all
+  // three heights in a different order from the unfiltered list.
+  const FILLER = "wrapping";
+  const FILLER_WORDS = [0, 6, 14];
+
+  function label(prefix, index) {
+    const words = FILLER_WORDS[index % FILLER_WORDS.length];
+    return [prefix, ...Array.from({ length: words }, () => FILLER)].join(" ");
+  }
+
+  // Above the default virtualization threshold both unfiltered and filtered by
+  // either tag, so the menu is windowed on both sides of a keystroke and every
+  // offset has to come from somewhere.
+  const items = [
+    // Counted and measured with the rest, but not an item any filter has to
+    // match: it is always in the menu. Its label wraps too.
+    {
+      id: "all",
+      text: label("Select all", 1),
+      isSelectAll: true,
+    },
+    ...Array.from({ length: 300 }, (_, i) => ({
+      id: i,
+      // The tag is what the tests filter on; half the list matches each one.
+      text: label(`${(i + 1) % 2 === 0 ? "Even" : "Odd"} item ${i + 1}`, i),
+    })),
+  ];
+
+  let selectedIds = [];
+</script>
+
+<!-- `wrapOptions` is the whole of the opt-in: wrapping is what leaves the
+     options unequal in height, and what puts the windowed list onto measured
+     offsets. There is no second switch, and the stylesheet it brings releases
+     both the fixed option height and the one-line checkbox label without the
+     fixture overriding anything. -->
+<div class="field">
+  <MultiSelect
+    labelText="Items"
+    label="Items"
+    placeholder="Filter…"
+    {items}
+    bind:selectedIds
+    filterable
+    portalMenu={false}
+    wrapOptions
+    virtualize={{ containerHeight: 300 }}
+  />
+</div>
+
+<style>
+  /* Narrow enough that a label wraps at all, and fixed so the heights do not
+     move with the viewport the test happens to run at. */
+  .field {
+    inline-size: 320px;
+  }
+</style>

--- a/e2e/fixtures/ReflowFixture.svelte
+++ b/e2e/fixtures/ReflowFixture.svelte
@@ -1,0 +1,204 @@
+<script>
+  import {
+    ComboBox,
+    Dropdown,
+    highlightSegments,
+    MultiSelect,
+  } from "carbon-components-svelte";
+
+  // Longer than a 320px-wide field can show on one line, so a truncating
+  // option would lose the end of it.
+  const LONG_LABEL =
+    "Chief Accessibility Officer for Regional Operations and Strategic Partnerships";
+
+  // No space, no hyphen, nowhere a word-boundary break could land. Wrapping has
+  // to break inside it or the option forces the document to scroll sideways.
+  const UNBROKEN_LABEL =
+    "Verylongunbrokenidentifierwithnowhereatallforalinebreaktoland";
+
+  const shortItems = [
+    { id: "long", text: LONG_LABEL },
+    { id: "unbroken", text: UNBROKEN_LABEL },
+    { id: "brief", text: "Brief" },
+  ];
+
+  // Above the count at which a listbox windows a list by itself, so wrapping
+  // and measured offsets have to be right together.
+  const longItems = Array.from({ length: 300 }, (_, i) => ({
+    id: i,
+    text: `Item ${i + 1}: ${LONG_LABEL}`,
+  }));
+
+  // The same short list with a "select all" row in front of it. Its label is
+  // long too: the row carries its own padding and separator, and both have to
+  // survive it taking more than one line.
+  const selectAllItems = [
+    {
+      id: "all",
+      text: "Select every one of the roles listed below without exception",
+      isSelectAll: true,
+    },
+    ...shortItems,
+  ];
+
+  const contains = (item, value) =>
+    item.text.toLowerCase().includes(value.toLowerCase());
+
+  /**
+   * Where the typed value occurs in the label, as the character indices
+   * `highlightSegments` splits on. Contiguous on purpose: a run long enough to
+   * straddle a line break is the case that has to survive wrapping.
+   */
+  function matchIndices(text, value) {
+    if (!value) return [];
+    const start = text.toLowerCase().indexOf(value.toLowerCase());
+    if (start === -1) return [];
+    return Array.from({ length: value.length }, (_, i) => start + i);
+  }
+
+  let highlightValue = "";
+
+  // `MultiSelect` sorts its options by label unless told otherwise. These
+  // assertions read options by position, so the fields below keep the order
+  // the list was declared in — as `Dropdown` and `ComboBox` do — rather than
+  // stating the alphabetised order at one remove from the fixture.
+  const inInputOrder = () => 0;
+</script>
+
+<Dropdown
+  labelText="Dropdown short"
+  items={shortItems}
+  wrapOptions
+  portalMenu={false}
+/>
+
+<Dropdown
+  labelText="Dropdown windowed"
+  items={longItems}
+  wrapOptions
+  portalMenu={false}
+/>
+
+<Dropdown
+  labelText="Dropdown portaled"
+  items={shortItems}
+  wrapOptions
+  portalMenu
+/>
+
+<Dropdown
+  fluid
+  labelText="Dropdown fluid"
+  items={shortItems}
+  wrapOptions
+  portalMenu={false}
+/>
+
+<ComboBox
+  labelText="ComboBox short"
+  items={shortItems}
+  shouldFilterItem={contains}
+  wrapOptions
+  portalMenu={false}
+/>
+
+<ComboBox
+  labelText="ComboBox windowed"
+  items={longItems}
+  shouldFilterItem={contains}
+  wrapOptions
+  portalMenu={false}
+/>
+
+<ComboBox
+  labelText="ComboBox portaled"
+  items={shortItems}
+  shouldFilterItem={contains}
+  wrapOptions
+  portalMenu
+/>
+
+<ComboBox
+  fluid
+  labelText="ComboBox fluid"
+  items={shortItems}
+  shouldFilterItem={contains}
+  wrapOptions
+  portalMenu={false}
+/>
+
+<!-- The documented way to show why an option matched: the default slot splits
+     the label into matched and unmatched runs and marks the matched ones. A
+     wrapped label breaks inside that run, so the mark has to carry across. -->
+<ComboBox
+  labelText="ComboBox highlighted"
+  items={shortItems}
+  shouldFilterItem={contains}
+  bind:value={highlightValue}
+  wrapOptions
+  portalMenu={false}
+  let:item
+>
+  {#each highlightSegments(item.text, matchIndices(item.text, highlightValue)) as segment}
+    {#if segment.match}
+      <mark data-testid="match">{segment.text}</mark>
+    {:else}
+      {segment.text}
+    {/if}
+  {/each}
+</ComboBox>
+
+<MultiSelect
+  sortItem={inInputOrder}
+  labelText="MultiSelect short"
+  items={shortItems}
+  wrapOptions
+  portalMenu={false}
+/>
+
+<MultiSelect
+  filterable
+  sortItem={inInputOrder}
+  labelText="MultiSelect windowed"
+  placeholder="Filter…"
+  items={longItems}
+  wrapOptions
+  portalMenu={false}
+/>
+
+<MultiSelect
+  sortItem={inInputOrder}
+  labelText="MultiSelect portaled"
+  items={shortItems}
+  wrapOptions
+  portalMenu
+/>
+
+<MultiSelect
+  fluid
+  sortItem={inInputOrder}
+  labelText="MultiSelect fluid"
+  items={shortItems}
+  wrapOptions
+  portalMenu={false}
+/>
+
+<!-- Selection sorts checked options to the top, so checking one moves every
+     option to a different position. Wrapping has to survive that rearrangement,
+     and the heights held against the old positions have to be dropped. -->
+<MultiSelect
+  selectionFeedback="top"
+  sortItem={inInputOrder}
+  labelText="MultiSelect sorted"
+  items={shortItems}
+  wrapOptions
+  portalMenu={false}
+/>
+
+<MultiSelect
+  sortItem={inInputOrder}
+  labelText="MultiSelect select all"
+  items={selectAllItems}
+  wrapOptions
+  portalMenu={false}
+/>

--- a/e2e/fixtures/combobox-measured.html
+++ b/e2e/fixtures/combobox-measured.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ComboBox measured item heights</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="./combobox-measured.ts"></script>
+  </body>
+</html>

--- a/e2e/fixtures/combobox-measured.ts
+++ b/e2e/fixtures/combobox-measured.ts
@@ -1,0 +1,4 @@
+import ComboBoxMeasuredFixture from "./ComboBoxMeasuredFixture.svelte";
+import { mount } from "./mount";
+
+mount(ComboBoxMeasuredFixture);

--- a/e2e/fixtures/dropdown-measured.html
+++ b/e2e/fixtures/dropdown-measured.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Dropdown measured item heights</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="./dropdown-measured.ts"></script>
+  </body>
+</html>

--- a/e2e/fixtures/dropdown-measured.ts
+++ b/e2e/fixtures/dropdown-measured.ts
@@ -1,0 +1,4 @@
+import DropdownMeasuredFixture from "./DropdownMeasuredFixture.svelte";
+import { mount } from "./mount";
+
+mount(DropdownMeasuredFixture);

--- a/e2e/fixtures/index.html
+++ b/e2e/fixtures/index.html
@@ -9,8 +9,11 @@
     <nav>
       <a href="/breakpoint.html">Breakpoint</a>
       <a href="/combobox.html">ComboBox</a>
+      <a href="/combobox-measured.html">ComboBox (measured heights)</a>
       <a href="/search-menu.html">SearchMenu</a>
       <a href="/dropdown.html">Dropdown</a>
+      <a href="/dropdown-measured.html">Dropdown (measured heights)</a>
+      <a href="/reflow.html">Listbox option reflow (320x256)</a>
       <a href="/date-picker.html">DatePicker</a>
       <a href="/local-storage.html">LocalStorage</a>
       <a href="/session-storage.html">SessionStorage</a>
@@ -26,6 +29,7 @@
       <a href="/menu-button.html">MenuButton</a>
       <a href="/combo-button.html">ComboButton</a>
       <a href="/multiselect.html">MultiSelect</a>
+      <a href="/multiselect-measured.html">MultiSelect (measured heights)</a>
       <a href="/select.html">Select</a>
       <a href="/text-input.html">TextInput</a>
       <a href="/password-input.html">PasswordInput</a>

--- a/e2e/fixtures/multiselect-measured.html
+++ b/e2e/fixtures/multiselect-measured.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>MultiSelect measured item heights</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="./multiselect-measured.ts"></script>
+  </body>
+</html>

--- a/e2e/fixtures/multiselect-measured.ts
+++ b/e2e/fixtures/multiselect-measured.ts
@@ -1,0 +1,4 @@
+import MultiSelectMeasuredFixture from "./MultiSelectMeasuredFixture.svelte";
+import { mount } from "./mount";
+
+mount(MultiSelectMeasuredFixture);

--- a/e2e/fixtures/reflow.html
+++ b/e2e/fixtures/reflow.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Option reflow at 320x256</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="./reflow.ts"></script>
+  </body>
+</html>

--- a/e2e/fixtures/reflow.ts
+++ b/e2e/fixtures/reflow.ts
@@ -1,0 +1,4 @@
+import { mount } from "./mount";
+import ReflowFixture from "./ReflowFixture.svelte";
+
+mount(ReflowFixture);

--- a/e2e/measured-menu.ts
+++ b/e2e/measured-menu.ts
@@ -1,0 +1,152 @@
+import { expect, type Locator, type Page } from "@playwright/test";
+
+/**
+ * Reading a windowed, measured listbox menu in a real browser.
+ *
+ * Every listbox component that derives its offsets from measured option
+ * heights is asked the same questions. Does the scrollbar span the real list,
+ * do the options abut one another, is the option you arrowed onto actually on
+ * screen? Only a layout engine can answer any of them. These are shared so each
+ * component's test file states what it is checking rather than how to look.
+ */
+
+/** Rects are fractional; a pixel of slack keeps rounding out of the way. */
+export const SLACK = 1;
+
+/**
+ * Drive the menu to the true end of the list. One jump is not enough on its
+ * own: options measured on the way down change the total height, so the end
+ * moves while you are travelling towards it.
+ */
+export async function scrollToEnd(page: Page) {
+  let previous = -1;
+  for (let attempt = 0; attempt < 20; attempt++) {
+    // biome-ignore lint/performance/noAwaitInLoops: each jump must land before the next is judged
+    const scrollTop = await page.evaluate(() => {
+      const menu = document.querySelector('[role="listbox"]');
+      if (!(menu instanceof HTMLElement)) return -1;
+      menu.scrollTop = menu.scrollHeight;
+      return menu.scrollTop;
+    });
+    if (scrollTop === previous) return scrollTop;
+    previous = scrollTop;
+    await page.waitForTimeout(50);
+  }
+  return previous;
+}
+
+/**
+ * Type a filter into `field` and wait for the menu to settle on it.
+ *
+ * Settling is what the assertions rest on: the options a filter brings into
+ * the window are only measured once they render, so the offsets a keystroke
+ * produces sharpen over a frame or two before they are the real ones.
+ *
+ * `expectedCount` is the number of options the filter should leave, waited for
+ * through `aria-setsize`. Leave it out when the match set drops below the
+ * virtualization threshold, since an unwindowed list carries no `aria-setsize`.
+ */
+export async function filterBy(
+  page: Page,
+  field: Locator,
+  text: string,
+  expectedCount?: number,
+) {
+  await field.fill(text);
+  if (expectedCount !== undefined) {
+    await expect(page.getByRole("option").first()).toHaveAttribute(
+      "aria-setsize",
+      String(expectedCount),
+    );
+  }
+  await page.waitForTimeout(100);
+}
+
+/** The menu's own scroll geometry. */
+export function readMenuMetrics(page: Page) {
+  return page.getByRole("listbox").evaluate((el) => ({
+    clientHeight: el.clientHeight,
+    scrollHeight: el.scrollHeight,
+  }));
+}
+
+/** Every rendered option's box, in the order they are laid out. */
+export function readOptionBoxes(page: Page) {
+  return page.evaluate(() => {
+    const menu = document.querySelector('[role="listbox"]');
+    if (!(menu instanceof HTMLElement)) return null;
+    const menuBox = menu.getBoundingClientRect();
+    const options = Array.from(menu.querySelectorAll('[role="option"]')).map(
+      (option) => {
+        const box = option.getBoundingClientRect();
+        return {
+          text: option.textContent?.trim() ?? "",
+          top: box.top,
+          bottom: box.bottom,
+          height: box.height,
+        };
+      },
+    );
+    options.sort((a, b) => a.top - b.top);
+    return { menu: { top: menuBox.top, bottom: menuBox.bottom }, options };
+  });
+}
+
+export type OptionBoxes = NonNullable<
+  Awaited<ReturnType<typeof readOptionBoxes>>
+>;
+
+/** Whether the option is wholly inside its menu's scroll viewport. */
+export function isFullyInView(option: Locator) {
+  return option.evaluate((el, slack) => {
+    const menu = el.closest('[role="listbox"]');
+    if (!(menu instanceof HTMLElement)) return null;
+    const menuBox = menu.getBoundingClientRect();
+    const box = el.getBoundingClientRect();
+    return (
+      box.top >= menuBox.top - slack && box.bottom <= menuBox.bottom + slack
+    );
+  }, SLACK);
+}
+
+/**
+ * Arrow down one option and report whether the new highlight ends up fully in
+ * view. The pause matters: it is the settled position being judged, after any
+ * measurement batch has landed and had its chance to move the option.
+ */
+export async function stepDown(
+  page: Page,
+  field: Locator,
+  highlighted: Locator,
+) {
+  await field.press("ArrowDown");
+  await page.waitForTimeout(60);
+  return isFullyInView(highlighted);
+}
+
+/** Options must abut one another: no blank gap, no overlap. */
+export function expectContiguous(boxes: OptionBoxes) {
+  expect(boxes.options.length).toBeGreaterThan(1);
+  for (let index = 1; index < boxes.options.length; index++) {
+    const gap = boxes.options[index].top - boxes.options[index - 1].bottom;
+    expect(gap).toBeLessThan(SLACK);
+    expect(gap).toBeGreaterThan(-SLACK);
+  }
+}
+
+/** Rendered options must reach both edges of the viewport, leaving no blank. */
+export function expectViewportCovered(boxes: OptionBoxes) {
+  const first = boxes.options[0];
+  const last = boxes.options[boxes.options.length - 1];
+  expect(first.top).toBeLessThanOrEqual(boxes.menu.top + SLACK);
+  expect(last.bottom).toBeGreaterThanOrEqual(boxes.menu.bottom - SLACK);
+}
+
+/** Assert the option list reads continuously and fills the menu. */
+export async function expectMenuReadsContinuously(page: Page) {
+  const boxes = await readOptionBoxes(page);
+  expect(boxes).not.toBeNull();
+  if (!boxes) return;
+  expectContiguous(boxes);
+  expectViewportCovered(boxes);
+}

--- a/e2e/measured-menu.ts
+++ b/e2e/measured-menu.ts
@@ -67,7 +67,13 @@ export function readMenuMetrics(page: Page) {
   return page.getByRole("listbox").evaluate((el) => ({
     clientHeight: el.clientHeight,
     scrollHeight: el.scrollHeight,
+    scrollTop: el.scrollTop,
   }));
+}
+
+/** Where the menu is scrolled to, which is what "the menu moved" means. */
+export async function readMenuScrollTop(page: Page) {
+  return (await readMenuMetrics(page)).scrollTop;
 }
 
 /** Every rendered option's box, in the order they are laid out. */
@@ -122,6 +128,31 @@ export async function stepDown(
   await field.press("ArrowDown");
   await page.waitForTimeout(60);
   return isFullyInView(highlighted);
+}
+
+/** The option the highlight is on, by the text it renders. */
+export async function readHighlightedOption(page: Page) {
+  const text = await page
+    .locator(".bx--list-box__menu-item--highlighted")
+    .first()
+    .textContent();
+  return text?.trim() ?? "";
+}
+
+/**
+ * Put the pointer on whatever option the menu's bottom edge runs through,
+ * which is the option a hover would move the menu for: measured placement asks
+ * whether an option is fully visible rather than merely rendered, so a clipped
+ * one would be pulled out from under the pointer.
+ *
+ * A mouse move rather than a locator hover, because hovering a locator scrolls
+ * it into view first, which is the very thing being judged.
+ */
+export async function hoverBottomEdge(page: Page) {
+  const box = await page.getByRole("listbox").boundingBox();
+  expect(box).not.toBeNull();
+  if (!box) return;
+  await page.mouse.move(box.x + box.width / 2, box.y + box.height - 3);
 }
 
 /** Options must abut one another: no blank gap, no overlap. */

--- a/e2e/multiselect-measured.test.ts
+++ b/e2e/multiselect-measured.test.ts
@@ -2,8 +2,10 @@ import { expect, type Page, test } from "@playwright/test";
 import {
   expectMenuReadsContinuously,
   filterBy,
+  hoverBottomEdge,
   isFullyInView,
   readMenuMetrics,
+  readMenuScrollTop,
   readOptionBoxes,
   SLACK,
   scrollToEnd,
@@ -92,6 +94,18 @@ test.describe("MultiSelect measured item heights", () => {
     await expect(page.getByRole("listbox")).toBeVisible();
   });
 
+  test("hovering the option the bottom edge cuts off leaves the menu alone", async ({
+    page,
+  }) => {
+    const held = await readMenuScrollTop(page);
+
+    await hoverBottomEdge(page);
+    await page.waitForTimeout(200);
+
+    // The pointer highlights whatever it lands on. Bringing a clipped option
+    // fully into view would scroll the list out from under the reader.
+    expect(await readMenuScrollTop(page)).toBe(held);
+  });
   test("options render at unequal heights while filtered", async ({ page }) => {
     await filterBy(page, field(page), "Even", MATCH_COUNT);
 

--- a/e2e/multiselect-measured.test.ts
+++ b/e2e/multiselect-measured.test.ts
@@ -1,0 +1,330 @@
+import { expect, type Page, test } from "@playwright/test";
+import {
+  expectMenuReadsContinuously,
+  filterBy,
+  isFullyInView,
+  readMenuMetrics,
+  readOptionBoxes,
+  SLACK,
+  scrollToEnd,
+  stepDown,
+} from "./measured-menu";
+
+const ITEM_COUNT = 300;
+/** Options matching either tag, plus the select-all row that always does. */
+const MATCH_COUNT = ITEM_COUNT / 2 + 1;
+/** The whole list, select-all row included. */
+const TOTAL_COUNT = ITEM_COUNT + 1;
+
+function field(page: Page) {
+  return page.getByRole("combobox", { name: "Items" });
+}
+
+/** Send the menu to a scroll position and let the offsets settle there. */
+async function scrollTo(page: Page, scrollTop: number) {
+  await page.getByRole("listbox").evaluate((el, top) => {
+    el.scrollTop = top;
+  }, scrollTop);
+  await page.waitForTimeout(100);
+}
+
+/**
+ * Click an option that is already wholly inside the menu's viewport.
+ *
+ * Playwright scrolls a partly-hidden target into view before clicking it, so
+ * clicking one of the overscanned options above the fold would move the menu
+ * and there would be nothing left to say about whether checking it did.
+ */
+async function clickOptionInView(page: Page, nth = 0) {
+  const boxes = await readOptionBoxes(page);
+  expect(boxes).not.toBeNull();
+  const inView = (boxes?.options ?? [])
+    .map((option, index) => ({ ...option, index }))
+    .filter(
+      (option) =>
+        option.top >= (boxes?.menu.top ?? 0) - SLACK &&
+        option.bottom <= (boxes?.menu.bottom ?? 0) + SLACK,
+    );
+  expect(inView.length).toBeGreaterThan(nth);
+  // `readOptionBoxes` orders by position, which for a windowed menu is DOM
+  // order, so the index carries straight over.
+  await page.getByRole("option").nth(inView[nth].index).click();
+  await page.waitForTimeout(100);
+}
+
+/** The menu's scroll position and the options on screen at it. */
+async function readMenuState(page: Page) {
+  const boxes = await readOptionBoxes(page);
+  return {
+    scrollTop: await page
+      .getByRole("listbox")
+      .evaluate((el) => Math.round(el.scrollTop)),
+    texts: boxes?.options.map((option) => option.text) ?? [],
+    tops: boxes?.options.map((option) => Math.round(option.top)) ?? [],
+  };
+}
+
+type MenuState = Awaited<ReturnType<typeof readMenuState>>;
+
+/**
+ * The same options in the same places, give or take `tolerance` pixels.
+ *
+ * A checked option is a pixel taller than an unchecked one, Carbon giving it a
+ * border, so checking really does change the length of the list. Holding the
+ * reader's place is the promise, not that no measurement changed: the residual
+ * is bounded by that one pixel per option above the viewport, and it moves the
+ * whole list together rather than spreading the options apart.
+ */
+function expectMenuHeld(after: MenuState, before: MenuState, tolerance = 0) {
+  expect(after.texts).toEqual(before.texts);
+  expect(Math.abs(after.scrollTop - before.scrollTop)).toBeLessThanOrEqual(
+    tolerance,
+  );
+  for (const [index, top] of after.tops.entries()) {
+    expect(Math.abs(top - before.tops[index])).toBeLessThanOrEqual(tolerance);
+  }
+}
+
+test.describe("MultiSelect measured item heights", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/multiselect-measured.html");
+    await field(page).click();
+    await expect(page.getByRole("listbox")).toBeVisible();
+  });
+
+  test("options render at unequal heights while filtered", async ({ page }) => {
+    await filterBy(page, field(page), "Even", MATCH_COUNT);
+
+    const boxes = await readOptionBoxes(page);
+    const heights = new Set(boxes?.options.map((option) => option.height));
+
+    // Without this the rest of the file would pass against a uniform list.
+    expect(heights.size).toBeGreaterThan(1);
+  });
+
+  test("the select-all row is measured and sits above the first option", async ({
+    page,
+  }) => {
+    const boxes = await readOptionBoxes(page);
+    const selectAll = boxes?.options[0];
+
+    // It is an option like any other: it is in the window, it has a real
+    // rendered height, and the option after it starts where that height ends.
+    expect(selectAll?.text).toContain("Select all");
+    expect(selectAll?.height).toBeGreaterThan(0);
+    await expectMenuReadsContinuously(page);
+  });
+
+  test("the scrollbar spans the real length of the matching options", async ({
+    page,
+  }) => {
+    const unfiltered = await readMenuMetrics(page);
+
+    await filterBy(page, field(page), "Even", MATCH_COUNT);
+    const filtered = await readMenuMetrics(page);
+
+    expect(filtered.clientHeight).toBe(300);
+    // Taller than any single assumed row height would have produced, and
+    // shorter than the whole list: the scrollbar describes the matches alone.
+    expect(filtered.scrollHeight).toBeGreaterThan(MATCH_COUNT * 40);
+    expect(filtered.scrollHeight).toBeLessThan(unfiltered.scrollHeight);
+  });
+
+  test("scrolling a filtered list to the end reveals the last match in full", async ({
+    page,
+  }) => {
+    await filterBy(page, field(page), "Even", MATCH_COUNT);
+    await scrollToEnd(page);
+
+    // The end being the real end rather than the one a single assumed row
+    // height would have put there: the scrollbar has to account for the whole
+    // length of the matches before arriving at it means anything.
+    const metrics = await readMenuMetrics(page);
+    expect(metrics.scrollHeight).toBeGreaterThan(MATCH_COUNT * 40);
+
+    const boxes = await readOptionBoxes(page);
+    expect(boxes).not.toBeNull();
+    const last = boxes?.options.at(-1);
+
+    // The last *matching* option, one of the tallest, wholly inside the menu.
+    expect(last?.text).toContain(`Even item ${ITEM_COUNT}`);
+    expect(last?.top).toBeGreaterThanOrEqual((boxes?.menu.top ?? 0) - SLACK);
+    expect(last?.bottom).toBeLessThanOrEqual((boxes?.menu.bottom ?? 0) + SLACK);
+  });
+
+  test("a filtered list reads continuously, with no gaps or overlaps", async ({
+    page,
+  }) => {
+    await filterBy(page, field(page), "Even", MATCH_COUNT);
+    await scrollToEnd(page);
+
+    await expectMenuReadsContinuously(page);
+  });
+
+  test("no offsets survive a filter that changes which options match", async ({
+    page,
+  }) => {
+    // Measure one tag's options to the end of the list, then switch tags. Every
+    // height now held describes an option that is no longer at that position.
+    await filterBy(page, field(page), "Even", MATCH_COUNT);
+    await scrollToEnd(page);
+
+    await filterBy(page, field(page), "Odd", MATCH_COUNT);
+
+    await expectMenuReadsContinuously(page);
+    await scrollToEnd(page);
+    const boxes = await readOptionBoxes(page);
+    expect(boxes?.options.at(-1)?.text).toContain(`Odd item ${ITEM_COUNT - 1}`);
+  });
+
+  test("clearing the filter restores the offsets of the whole list", async ({
+    page,
+  }) => {
+    await filterBy(page, field(page), "Even", MATCH_COUNT);
+    const filtered = await readMenuMetrics(page);
+    await scrollToEnd(page);
+    await filterBy(page, field(page), "", TOTAL_COUNT);
+
+    // Well clear of the half-list the filter had narrowed to. Comparing
+    // against the reading taken before the filter would prove less than it
+    // looks: both are dominated by the estimate for options nobody has
+    // scrolled to yet. Reaching the whole list's true last option below is
+    // what actually settles it.
+    expect((await readMenuMetrics(page)).scrollHeight).toBeGreaterThan(
+      filtered.scrollHeight * 1.5,
+    );
+    await expectMenuReadsContinuously(page);
+    await scrollToEnd(page);
+    const boxes = await readOptionBoxes(page);
+    // Sorted by text, so the last option of the whole list is the highest-
+    // numbered odd one.
+    expect(boxes?.options.at(-1)?.text).toContain(`Odd item ${ITEM_COUNT - 1}`);
+  });
+
+  test("checking an option leaves the scroll position and the offsets alone", async ({
+    page,
+  }) => {
+    await filterBy(page, field(page), "Even", MATCH_COUNT);
+    await scrollTo(page, 1200);
+    const before = await readMenuState(page);
+    expect(before.texts.length).toBeGreaterThan(1);
+
+    // The default `selectionFeedback` leaves the order alone until the menu is
+    // reopened, so nothing has moved and nothing should shift under the reader.
+    await clickOptionInView(page);
+
+    expectMenuHeld(await readMenuState(page), before, 1);
+
+    // And again on the way back out.
+    await clickOptionInView(page);
+
+    expectMenuHeld(await readMenuState(page), before, 1);
+  });
+
+  test("checking the select-all row leaves the scroll position and the offsets alone", async ({
+    page,
+  }) => {
+    await filterBy(page, field(page), "Even", MATCH_COUNT);
+    // Measure the top of the list first, so returning to it later is not what
+    // moves the offsets.
+    await scrollTo(page, 0);
+    await scrollTo(page, 1200);
+    const before = await readMenuState(page);
+
+    // Select-all rebuilds every option in the list at once, which is the
+    // sharpest version of the same question: a re-check is not a re-order, no
+    // matter how much of the collection it replaces.
+    await scrollTo(page, 0);
+    await page.getByRole("option", { name: /Select all/ }).click();
+    await scrollTo(page, 1200);
+
+    expectMenuHeld(await readMenuState(page), before, 3);
+  });
+
+  test("selected options sorted to the top on reopen land at the right offsets", async ({
+    page,
+  }) => {
+    await filterBy(page, field(page), "Even", MATCH_COUNT);
+    await scrollToEnd(page);
+    const last = page.getByRole("option").last();
+    const lastText = (await last.textContent())?.trim();
+    await last.click();
+
+    // Close and reopen: `selectionFeedback: "top-after-reopen"` now puts the
+    // checked option directly under the select-all row, and opening scrolls it
+    // to the top of the viewport.
+    await field(page).press("Escape");
+    await expect(page.getByRole("listbox")).toBeHidden();
+    await field(page).click();
+    await expect(page.getByRole("listbox")).toBeVisible();
+    await page.waitForTimeout(150);
+
+    const boxes = await readOptionBoxes(page);
+    const selected = boxes?.options.find((option) => option.text === lastText);
+    expect(selected).toBeDefined();
+    // At the top of the viewport, whole, with the select-all row's real rather
+    // than guessed height deciding where that is.
+    expect(selected?.top).toBeGreaterThanOrEqual(
+      (boxes?.menu.top ?? 0) - SLACK,
+    );
+    expect(selected?.top).toBeLessThanOrEqual((boxes?.menu.top ?? 0) + SLACK);
+    await expectMenuReadsContinuously(page);
+  });
+
+  // Stepping and jumping are scrolled by different things, and only one of
+  // them is this component's own arithmetic. A step lands on an option that is
+  // already rendered, so `ListBoxMenu`'s highlight cursor scrolls it exactly,
+  // from its real box. A jump lands on one that is not rendered yet, which the
+  // cursor has no node for, so the measured path has to carry it. Under a
+  // filter both run against heights measured moments earlier for a set of
+  // options that had only just come into being.
+  test("arrowing through a filtered list scrolls each option fully into view", async ({
+    page,
+  }) => {
+    await filterBy(page, field(page), "Even", MATCH_COUNT);
+
+    const highlighted = page.locator(".bx--list-box__menu-item--highlighted");
+
+    // Far enough to walk past the bottom edge several times over, one option at
+    // a time, through matches of all three heights, starting on the select-all
+    // row, which is a different height again.
+    const outOfView: number[] = [];
+    for (let step = 0; step < 14; step++) {
+      // biome-ignore lint/performance/noAwaitInLoops: a step has to land before the next is judged
+      const inView = await stepDown(page, field(page), highlighted);
+      if (inView !== true) outOfView.push(step);
+    }
+    expect(outOfView).toEqual([]);
+  });
+
+  test("filtering down to a single match shows it whole", async ({ page }) => {
+    // Two options: the match and the select-all row that always accompanies it.
+    // Well below the threshold, so the list is unwindowed, which is why the
+    // count rather than `aria-setsize` says the filter has landed.
+    await field(page).fill(`item ${ITEM_COUNT}`);
+
+    const options = page.getByRole("option");
+    await expect(options).toHaveCount(2);
+    await expect(options.nth(1)).toContainText(`Even item ${ITEM_COUNT}`);
+    expect(await isFullyInView(options.nth(1))).toBe(true);
+  });
+
+  test("filtering down to no matches leaves the select-all row alone in the menu", async ({
+    page,
+  }) => {
+    await field(page).fill("no such option");
+
+    // The select-all row is not something a filter matches, so it stays.
+    await expect(page.getByRole("option")).toHaveCount(1);
+    await expect(page.getByRole("option")).toContainText("Select all");
+
+    // The menu comes back correct rather than stuck at the one-option list's
+    // offsets, which is the part an emptied set could quietly break.
+    await filterBy(page, field(page), "Even", MATCH_COUNT);
+
+    await expectMenuReadsContinuously(page);
+    await scrollToEnd(page);
+    const boxes = await readOptionBoxes(page);
+    expect(boxes?.options.at(-1)?.text).toContain(`Even item ${ITEM_COUNT}`);
+  });
+});

--- a/e2e/reflow.test.ts
+++ b/e2e/reflow.test.ts
@@ -1,0 +1,743 @@
+import { expect, type Locator, type Page, test } from "@playwright/test";
+import {
+  expectMenuReadsContinuously,
+  filterBy,
+  readOptionBoxes,
+  SLACK,
+  scrollToEnd,
+} from "./measured-menu";
+
+/**
+ * WCAG 1.4.10 Reflow, for the listbox family's options.
+ *
+ * Everything asserted here needs a layout engine: whether text wrapped,
+ * whether it is clipped, whether the document scrolls sideways. None of it is
+ * observable in the unit environment, where nothing has a size, which is why
+ * this file exists rather than a component test.
+ */
+
+// The criterion's test condition: 320x256 CSS px, i.e. 1280x1024 at 400% zoom.
+test.use({ viewport: { width: 320, height: 256 } });
+
+// Carbon's fixed option height at the default size. Wrapping releases it, so an
+// option taller than this is one that took more than the single line it used to
+// be confined to.
+const SINGLE_LINE_HEIGHT = 40;
+
+const LONG_LABEL =
+  "Chief Accessibility Officer for Regional Operations and Strategic Partnerships";
+const UNBROKEN_LABEL =
+  "Verylongunbrokenidentifierwithnowhereatallforalinebreaktoland";
+const ITEM_COUNT = 300;
+
+/** Whether reading the page requires scrolling in the second dimension. */
+function documentScrollsHorizontally(page: Page) {
+  return page.evaluate((slack) => {
+    const { scrollWidth, clientWidth } = document.documentElement;
+    return scrollWidth > clientWidth + slack;
+  }, SLACK);
+}
+
+/**
+ * How far an option's content escapes the box it is drawn in. Anything above
+ * zero is text the reader cannot see.
+ */
+function readOptionClipping(option: Locator) {
+  return option.evaluate((el, slack) => {
+    const inner = el.querySelector(".bx--list-box__menu-item__option") ?? el;
+    return {
+      horizontal: inner.scrollWidth - inner.clientWidth > slack,
+      vertical: inner.scrollHeight - inner.clientHeight > slack,
+      height: el.getBoundingClientRect().height,
+    };
+  }, SLACK);
+}
+
+/**
+ * Where each line of an option's text starts, for whichever element actually
+ * holds that text: the checkbox's label span on `MultiSelect`, the option's own
+ * box everywhere else.
+ */
+function readTextLineLefts(option: Locator) {
+  return option.evaluate((el) => {
+    const text =
+      el.querySelector(".bx--checkbox-label-text") ??
+      el.querySelector(".bx--list-box__menu-item__option") ??
+      el;
+    const range = document.createRange();
+    range.selectNodeContents(text);
+    const lines = Array.from(range.getClientRects()).filter(
+      (rect) => rect.height > 0 && rect.width > 0,
+    );
+    return lines.map((rect) => rect.left);
+  });
+}
+
+/**
+ * Every line of a wrapped label starts at the same left edge.
+ *
+ * Worth asserting because padding on an *inline* element is drawn once at the
+ * start of the whole inline box rather than at the start of each line it breaks
+ * into: any padded inline wrapping its text indents its first line and hangs
+ * the rest to the left of it.
+ */
+async function expectLinesShareLeftEdge(option: Locator) {
+  const lefts = await readTextLineLefts(option);
+
+  expect(lefts.length).toBeGreaterThan(1);
+  expect(Math.max(...lefts) - Math.min(...lefts)).toBeLessThanOrEqual(SLACK);
+}
+
+/**
+ * How far a `MultiSelect` option's label escapes its own box, and how many
+ * lines it took.
+ *
+ * `readOptionClipping` cannot see this component's failure: the label is
+ * `width: 100%` with `overflow: hidden`, so text lost inside it never overflows
+ * the option wrapper that function measures. The label is where Carbon confines
+ * the text, twice over: on the label and again on the span inside it. So the
+ * label is where the release has to be read.
+ */
+function readLabelClipping(option: Locator) {
+  return option.evaluate((el, slack) => {
+    const label = el.querySelector(".bx--checkbox-label");
+    const text = el.querySelector(".bx--checkbox-label-text");
+    if (!label || !text) return null;
+    // One rect per line box the label's text was laid out on.
+    const range = document.createRange();
+    range.selectNodeContents(text);
+    const lines = Array.from(range.getClientRects()).filter(
+      (rect) => rect.height > 0 && rect.width > 0,
+    );
+    // The label's content box: the width its text actually has to fit in,
+    // padding for the checkbox excluded. The text span is inline, so its own
+    // `clientWidth` is not a box any engine agrees on. The line rects above
+    // are, which is why the fit is judged from them.
+    const style = getComputedStyle(label);
+    const available =
+      label.clientWidth -
+      Number.parseFloat(style.paddingLeft) -
+      Number.parseFloat(style.paddingRight);
+    const lefts = lines.map((rect) => rect.left);
+    return {
+      labelClipped: label.scrollWidth - label.clientWidth > slack,
+      lineCount: lines.length,
+      widest: Math.max(0, ...lines.map((rect) => rect.width)),
+      available,
+      // How far the line starts spread apart. The gap between the checkbox and
+      // the words is padding on the text span, and inline padding is drawn
+      // once at the start of the whole inline rather than on every line, so an
+      // inline span indents its first line and hangs the rest to its left.
+      leftSpread: lines.length ? Math.max(...lefts) - Math.min(...lefts) : 0,
+    };
+  }, SLACK);
+}
+
+/**
+ * The label read every line of its text, over more than one line, inside the
+ * width it was given.
+ */
+async function expectLabelReadsWhole(option: Locator) {
+  const label = await readLabelClipping(option);
+  expect(label).not.toBeNull();
+  expect(label?.labelClipped).toBe(false);
+  expect(label?.lineCount).toBeGreaterThan(1);
+  expect(label?.widest).toBeLessThanOrEqual((label?.available ?? 0) + SLACK);
+  // Every line starts at the same place, so the wrapped label reads as one
+  // block of text beside its checkbox rather than as an indented first line.
+  expect(label?.leftSpread).toBeLessThanOrEqual(SLACK);
+}
+
+/** Open one of the fixture's fields by its accessible name. */
+async function openMenu(page: Page, name: string) {
+  await page.goto("/reflow.html");
+  const field = page.getByRole("combobox", { name });
+  await field.click();
+  await expect(page.getByRole("listbox")).toBeVisible();
+  return field;
+}
+
+/**
+ * The reflow assertions every wrapping listbox owes, against a list short
+ * enough that the component renders it whole. Shared rather than copied per
+ * component: the criterion is the same one, and what differs between them is
+ * only which field opens the menu.
+ */
+function describeListRenderedWhole(fieldName: string) {
+  test.describe("a list the component renders whole", () => {
+    test.beforeEach(async ({ page }) => {
+      await openMenu(page, fieldName);
+    });
+
+    test("the document does not scroll horizontally", async ({ page }) => {
+      expect(await documentScrollsHorizontally(page)).toBe(false);
+    });
+
+    test("a long label is rendered in full, unclipped, over several lines", async ({
+      page,
+    }) => {
+      const option = page.getByRole("option").first();
+
+      // The whole label, not the part that fit before an ellipsis.
+      await expect(option).toHaveText(LONG_LABEL);
+
+      const clipping = await readOptionClipping(option);
+      expect(clipping.horizontal).toBe(false);
+      expect(clipping.vertical).toBe(false);
+      expect(clipping.height).toBeGreaterThan(SINGLE_LINE_HEIGHT);
+      await expectLinesShareLeftEdge(option);
+    });
+
+    test("a single unbroken token reflows instead of forcing sideways scroll", async ({
+      page,
+    }) => {
+      const option = page.getByRole("option").nth(1);
+
+      await expect(option).toHaveText(UNBROKEN_LABEL);
+
+      const clipping = await readOptionClipping(option);
+      expect(clipping.horizontal).toBe(false);
+      expect(clipping.height).toBeGreaterThan(SINGLE_LINE_HEIGHT);
+      expect(await documentScrollsHorizontally(page)).toBe(false);
+    });
+
+    test("the overflow title removes itself once the text wraps", async ({
+      page,
+    }) => {
+      // The title exists only while text overflows horizontally, which wrapping
+      // ends. Verified rather than assumed: a hover-only tooltip is exactly the
+      // mitigation this work replaces.
+      const options = page.locator(".bx--list-box__menu-item__option");
+
+      await expect(options.first()).not.toHaveAttribute("title");
+      await expect(options.nth(1)).not.toHaveAttribute("title");
+    });
+  });
+}
+
+/**
+ * Wrapping is one stylesheet rule reaching one marker class, and a portal is
+ * where that reach is least obvious: the menu is rendered outside the
+ * component's own subtree, so nothing on the component root could style it.
+ * The same question of all three, so asked once here.
+ */
+function describePortaledMenu(fieldName: string) {
+  test.describe("a portaled menu", () => {
+    test.beforeEach(async ({ page }) => {
+      await openMenu(page, fieldName);
+    });
+
+    test("wraps options rendered outside the component's own subtree", async ({
+      page,
+    }) => {
+      const menu = page.getByRole("listbox");
+      // The marker class is on the menu rather than the component root for
+      // exactly this case: nothing on the root reaches here.
+      await expect(
+        menu.locator("xpath=ancestor::*[@data-floating-portal]"),
+      ).toHaveCount(1);
+
+      const option = page.getByRole("option").first();
+      await expect(option).toHaveText(LONG_LABEL);
+
+      const clipping = await readOptionClipping(option);
+      expect(clipping.horizontal).toBe(false);
+      expect(clipping.vertical).toBe(false);
+      expect(clipping.height).toBeGreaterThan(SINGLE_LINE_HEIGHT);
+      expect(await documentScrollsHorizontally(page)).toBe(false);
+    });
+  });
+}
+
+/**
+ * The other context where the reach is in doubt: fluid sets the option's fixed
+ * height through a stronger selector than the one that releases it. Also the
+ * same question of all three.
+ */
+function describeFluidField(fieldName: string) {
+  test.describe("a fluid field", () => {
+    test.beforeEach(async ({ page }) => {
+      await openMenu(page, fieldName);
+    });
+
+    test("wraps options, whose fixed height fluid sets through a stronger selector", async ({
+      page,
+    }) => {
+      const option = page.getByRole("option").first();
+      await expect(option).toHaveText(LONG_LABEL);
+
+      const clipping = await readOptionClipping(option);
+      expect(clipping.horizontal).toBe(false);
+      expect(clipping.vertical).toBe(false);
+      expect(await documentScrollsHorizontally(page)).toBe(false);
+
+      // What proves the fluid row height was released is the row hugging its
+      // wrapped content. A row taller than one line proves nothing, since it
+      // sits at fluid's own 64px either way.
+      const boxes = await option.evaluate((el) => {
+        const inner = el.querySelector(".bx--list-box__menu-item__option");
+        return {
+          item: el.getBoundingClientRect().height,
+          content: inner?.getBoundingClientRect().height ?? 0,
+        };
+      });
+      expect(boxes.content).toBeGreaterThan(0);
+      expect(Math.abs(boxes.item - boxes.content)).toBeLessThanOrEqual(SLACK);
+
+      await expectMenuReadsContinuously(page);
+    });
+  });
+}
+
+test.describe("Dropdown option reflow", () => {
+  describeListRenderedWhole("Dropdown short");
+
+  test.describe("a list the component windows", () => {
+    test.beforeEach(async ({ page }) => {
+      await openMenu(page, "Dropdown windowed");
+    });
+
+    test("options wrap while the list is windowed", async ({ page }) => {
+      const option = page.getByRole("option").first();
+
+      await expect(option).toHaveText(`Item 1: ${LONG_LABEL}`);
+
+      const clipping = await readOptionClipping(option);
+      expect(clipping.horizontal).toBe(false);
+      expect(clipping.vertical).toBe(false);
+      expect(clipping.height).toBeGreaterThan(SINGLE_LINE_HEIGHT);
+      expect(await documentScrollsHorizontally(page)).toBe(false);
+    });
+
+    test("scrolling to the end reveals the last option in full", async ({
+      page,
+    }) => {
+      await scrollToEnd(page);
+
+      const boxes = await readOptionBoxes(page);
+      expect(boxes).not.toBeNull();
+      const last = boxes?.options.at(-1);
+
+      expect(last?.text).toBe(`Item ${ITEM_COUNT}: ${LONG_LABEL}`);
+      expect(last?.top).toBeGreaterThanOrEqual((boxes?.menu.top ?? 0) - SLACK);
+      expect(last?.bottom).toBeLessThanOrEqual(
+        (boxes?.menu.bottom ?? 0) + SLACK,
+      );
+    });
+
+    test("the wrapped list reads continuously, with no gaps or overlaps", async ({
+      page,
+    }) => {
+      await scrollToEnd(page);
+
+      await expectMenuReadsContinuously(page);
+    });
+  });
+  describePortaledMenu("Dropdown portaled");
+  describeFluidField("Dropdown fluid");
+});
+
+test.describe("ComboBox option reflow", () => {
+  // Long enough to straddle a line break at 320px, and contiguous, so the
+  // highlight around it has to survive being split across two lines.
+  const TYPED_MATCH = "Accessibility Officer for Regional Operations";
+
+  // "Item 1", "Item 10".."Item 19", "Item 100".."Item 199": still above the
+  // count at which the list is windowed, so a filtered list has to wrap and
+  // place measured offsets at the same time.
+  const FILTER_MANY = "Item 1";
+  const FILTER_MANY_COUNT = 111;
+  const FILTER_SOLE = "Item 250:";
+
+  describeListRenderedWhole("ComboBox short");
+
+  test.describe("a filtered list the component windows", () => {
+    test("options wrap while a filtered list is still windowed", async ({
+      page,
+    }) => {
+      const field = await openMenu(page, "ComboBox windowed");
+      await filterBy(page, field, FILTER_MANY, FILTER_MANY_COUNT);
+
+      const option = page.getByRole("option").first();
+      await expect(option).toHaveText(`Item 1: ${LONG_LABEL}`);
+
+      const clipping = await readOptionClipping(option);
+      expect(clipping.horizontal).toBe(false);
+      expect(clipping.vertical).toBe(false);
+      expect(clipping.height).toBeGreaterThan(SINGLE_LINE_HEIGHT);
+      expect(await documentScrollsHorizontally(page)).toBe(false);
+    });
+
+    test("scrolling a filtered list to the end reveals the last match in full", async ({
+      page,
+    }) => {
+      const field = await openMenu(page, "ComboBox windowed");
+      await filterBy(page, field, FILTER_MANY, FILTER_MANY_COUNT);
+      await scrollToEnd(page);
+
+      const boxes = await readOptionBoxes(page);
+      expect(boxes).not.toBeNull();
+      const last = boxes?.options.at(-1);
+
+      expect(last?.text).toBe(`Item 199: ${LONG_LABEL}`);
+      expect(last?.top).toBeGreaterThanOrEqual((boxes?.menu.top ?? 0) - SLACK);
+      expect(last?.bottom).toBeLessThanOrEqual(
+        (boxes?.menu.bottom ?? 0) + SLACK,
+      );
+
+      await expectMenuReadsContinuously(page);
+    });
+
+    test("a filter that leaves a single match wraps it and reads it in full", async ({
+      page,
+    }) => {
+      const field = await openMenu(page, "ComboBox windowed");
+      // Below the threshold there is no window at all, so this is the browser
+      // laying one wrapped option out rather than the measured path placing it.
+      await filterBy(page, field, FILTER_SOLE);
+
+      const options = page.getByRole("option");
+      await expect(options).toHaveCount(1);
+      await expect(options.first()).toHaveText(`Item 250: ${LONG_LABEL}`);
+
+      const clipping = await readOptionClipping(options.first());
+      expect(clipping.horizontal).toBe(false);
+      expect(clipping.vertical).toBe(false);
+      expect(clipping.height).toBeGreaterThan(SINGLE_LINE_HEIGHT);
+      expect(await documentScrollsHorizontally(page)).toBe(false);
+    });
+  });
+
+  describePortaledMenu("ComboBox portaled");
+
+  describeFluidField("ComboBox fluid");
+
+  test.describe("a highlighted match", () => {
+    test("stays highlighted across the line break it is split by", async ({
+      page,
+    }) => {
+      const field = await openMenu(page, "ComboBox highlighted");
+      await filterBy(page, field, TYPED_MATCH);
+
+      const option = page.getByRole("option").first();
+      await expect(option).toHaveText(LONG_LABEL);
+      expect(await documentScrollsHorizontally(page)).toBe(false);
+
+      const mark = page.getByTestId("match");
+      await expect(mark).toHaveCount(1);
+      // The whole typed run is marked, not the part of it that fit on the
+      // first line. That is the visual connection to what was typed, and it is
+      // what a break inside the run must not cost.
+      await expect(mark).toHaveText(TYPED_MATCH);
+
+      // One inline element split into several line boxes: the highlight is one
+      // style over all of them, so what is left to check is that it really did
+      // break, that every piece of it is drawn, and that the reader's eye can
+      // carry from one to the next.
+      const fragments = await mark.evaluate((el) =>
+        Array.from(el.getClientRects(), (rect) => ({
+          top: rect.top,
+          bottom: rect.bottom,
+          width: rect.width,
+          height: rect.height,
+        })),
+      );
+
+      expect(fragments.length).toBeGreaterThan(1);
+      for (const fragment of fragments) {
+        expect(fragment.width).toBeGreaterThan(0);
+        expect(fragment.height).toBeGreaterThan(0);
+      }
+      // Consecutive line boxes, with no unhighlighted line stranded between
+      // them, which is the break the match survives rather than a scattering.
+      for (let i = 1; i < fragments.length; i++) {
+        expect(fragments[i].top).toBeGreaterThan(fragments[i - 1].top);
+        expect(fragments[i].top).toBeLessThan(
+          fragments[i - 1].bottom + fragments[i - 1].height,
+        );
+      }
+
+      // And it reads as a highlight at all, rather than as the text around it.
+      const contrast = await option.evaluate((el) => {
+        const marked = el.querySelector("mark");
+        if (!marked) return null;
+        return {
+          mark: getComputedStyle(marked).backgroundColor,
+          option: getComputedStyle(el).backgroundColor,
+        };
+      });
+      expect(contrast).not.toBeNull();
+      expect(contrast?.mark).not.toBe(contrast?.option);
+    });
+  });
+});
+
+test.describe("MultiSelect option reflow", () => {
+  // "Item 1", "Item 10".."Item 19", "Item 100".."Item 199": still above the
+  // count at which the list is windowed, so a filtered list has to wrap and
+  // place measured offsets at the same time.
+  const FILTER_MANY = "Item 1";
+  const FILTER_MANY_COUNT = 111;
+
+  describeListRenderedWhole("MultiSelect short");
+
+  test.describe("an option's label", () => {
+    // The shared block above measures the option wrapper, which on this
+    // component stays inside its own box whether the label wraps or not: the
+    // label is `width: 100%` with `overflow: hidden`, so the text it loses
+    // never reaches the wrapper. These read the label itself.
+    test("reads every line of its text inside the width it was given", async ({
+      page,
+    }) => {
+      await openMenu(page, "MultiSelect short");
+
+      const option = page.getByRole("option").first();
+      await expect(option).toHaveText(LONG_LABEL);
+
+      await expectLabelReadsWhole(option);
+    });
+
+    test("wraps a portaled option's label too", async ({ page }) => {
+      await openMenu(page, "MultiSelect portaled");
+
+      await expectLabelReadsWhole(page.getByRole("option").first());
+    });
+
+    test("wraps a fluid option's label too", async ({ page }) => {
+      await openMenu(page, "MultiSelect fluid");
+
+      await expectLabelReadsWhole(page.getByRole("option").first());
+    });
+  });
+
+  test.describe("an option's checkbox", () => {
+    test("stays with the first line of a label that wrapped", async ({
+      page,
+    }) => {
+      await openMenu(page, "MultiSelect short");
+
+      const option = page.getByRole("option").first();
+      await expect(option).toHaveText(LONG_LABEL);
+
+      const geometry = await option.evaluate((el) => {
+        const label = el.querySelector(".bx--checkbox-label");
+        if (!label) return null;
+        const labelBox = label.getBoundingClientRect();
+        // The checkbox is drawn as the label's ::before, positioned into the
+        // label's own padding, so its box has to be read off the style rather
+        // than off an element.
+        const box = getComputedStyle(label, "::before");
+        const top =
+          labelBox.top +
+          Number.parseFloat(box.top) +
+          Number.parseFloat(box.marginTop || "0");
+        const size = Number.parseFloat(box.height);
+        // The label's text as the browser laid it out: one rect per line box.
+        // Selected on the text span, not the label: the span is a block box, so
+        // selecting the label's contents also returns the one rect covering all
+        // of its lines, which is not a line box.
+        const range = document.createRange();
+        range.selectNodeContents(
+          label.querySelector(".bx--checkbox-label-text") ?? label,
+        );
+        const lines = Array.from(range.getClientRects())
+          .filter((rect) => rect.height > 0 && rect.width > 0)
+          .sort((a, b) => a.top - b.top);
+        const optionBox = el.getBoundingClientRect();
+        return {
+          checkbox: {
+            top,
+            bottom: top + size,
+            left: labelBox.left + Number.parseFloat(box.left),
+            right:
+              labelBox.left +
+              Number.parseFloat(box.left) +
+              Number.parseFloat(box.width),
+          },
+          firstLine: lines[0]
+            ? {
+                top: lines[0].top,
+                bottom: lines[0].bottom,
+                left: lines[0].left,
+              }
+            : null,
+          lineCount: lines.length,
+          option: { top: optionBox.top, bottom: optionBox.bottom },
+        };
+      });
+
+      expect(geometry).not.toBeNull();
+      if (!geometry?.firstLine) return;
+      // The premise: this label really did take more than one line.
+      expect(geometry.lineCount).toBeGreaterThan(1);
+
+      const checkboxCenter =
+        (geometry.checkbox.top + geometry.checkbox.bottom) / 2;
+      // Beside the first line, not floating above or below it.
+      expect(checkboxCenter).toBeGreaterThanOrEqual(
+        geometry.firstLine.top - SLACK,
+      );
+      expect(checkboxCenter).toBeLessThanOrEqual(
+        geometry.firstLine.bottom + SLACK,
+      );
+      // And not drifted to the middle of the grown option, which is what a
+      // vertically centred checkbox would do once the label wraps. The
+      // option's own centre lies below the first line, so a checkbox inside
+      // that line is demonstrably not centred on the option.
+      const optionCenter = (geometry.option.top + geometry.option.bottom) / 2;
+      expect(optionCenter).toBeGreaterThan(geometry.firstLine.bottom);
+      // Before the text it belongs to, and close enough to read as its box.
+      expect(geometry.checkbox.right).toBeLessThanOrEqual(
+        geometry.firstLine.left + SLACK,
+      );
+      expect(geometry.firstLine.left - geometry.checkbox.right).toBeLessThan(
+        32,
+      );
+    });
+
+    test("is toggled by a click on the part of the option wrapping added", async ({
+      page,
+    }) => {
+      await openMenu(page, "MultiSelect short");
+
+      const option = page.getByRole("option").first();
+      await expect(option).toHaveAttribute("aria-selected", "false");
+
+      // The last line of the label, well below the single line the option used
+      // to be: the grown option is one control only if this toggles it.
+      const box = await option.boundingBox();
+      expect(box?.height).toBeGreaterThan(SINGLE_LINE_HEIGHT);
+      await page.mouse.click(
+        (box?.x ?? 0) + (box?.width ?? 0) / 2,
+        (box?.y ?? 0) + (box?.height ?? 0) - 4,
+      );
+
+      await expect(option).toHaveAttribute("aria-selected", "true");
+    });
+  });
+
+  test.describe("a filtered list the component windows", () => {
+    test("options wrap while a filtered list is still windowed", async ({
+      page,
+    }) => {
+      const field = await openMenu(page, "MultiSelect windowed");
+      await filterBy(page, field, FILTER_MANY, FILTER_MANY_COUNT);
+
+      const option = page.getByRole("option").first();
+      await expect(option).toHaveText(`Item 1: ${LONG_LABEL}`);
+
+      const clipping = await readOptionClipping(option);
+      expect(clipping.horizontal).toBe(false);
+      expect(clipping.vertical).toBe(false);
+      expect(clipping.height).toBeGreaterThan(SINGLE_LINE_HEIGHT);
+      expect(await documentScrollsHorizontally(page)).toBe(false);
+    });
+
+    test("scrolling a filtered list to the end reveals the last match in full", async ({
+      page,
+    }) => {
+      const field = await openMenu(page, "MultiSelect windowed");
+      await filterBy(page, field, FILTER_MANY, FILTER_MANY_COUNT);
+      await scrollToEnd(page);
+
+      const boxes = await readOptionBoxes(page);
+      expect(boxes).not.toBeNull();
+      const last = boxes?.options.at(-1);
+
+      expect(last?.text).toBe(`Item 199: ${LONG_LABEL}`);
+      expect(last?.top).toBeGreaterThanOrEqual((boxes?.menu.top ?? 0) - SLACK);
+      expect(last?.bottom).toBeLessThanOrEqual(
+        (boxes?.menu.bottom ?? 0) + SLACK,
+      );
+
+      await expectMenuReadsContinuously(page);
+    });
+  });
+
+  describePortaledMenu("MultiSelect portaled");
+
+  describeFluidField("MultiSelect fluid");
+
+  test.describe("options that sort to the top when selected", () => {
+    test("stay wrapped through the rearrangement checking one causes", async ({
+      page,
+    }) => {
+      await openMenu(page, "MultiSelect sorted");
+
+      // The last option, so selecting it moves it past both of the others.
+      const brief = page.getByRole("option").nth(2);
+      await expect(brief).toHaveText("Brief");
+      await brief.click();
+
+      // It sorted to the top, and the long label that was above it moved down.
+      const options = page.getByRole("option");
+      await expect(options.first()).toHaveText("Brief");
+      await expect(options.nth(1)).toHaveText(LONG_LABEL);
+
+      const moved = options.nth(1);
+      const clipping = await readOptionClipping(moved);
+      expect(clipping.horizontal).toBe(false);
+      expect(clipping.vertical).toBe(false);
+      expect(clipping.height).toBeGreaterThan(SINGLE_LINE_HEIGHT);
+      await expectLabelReadsWhole(moved);
+      expect(await documentScrollsHorizontally(page)).toBe(false);
+
+      // And the options still abut one another at their new heights, rather
+      // than being placed against the heights they had before they moved.
+      await expectMenuReadsContinuously(page);
+    });
+  });
+
+  test.describe("a select-all row", () => {
+    test("wraps and keeps the separator that sets it apart from the options", async ({
+      page,
+    }) => {
+      await openMenu(page, "MultiSelect select all");
+
+      const selectAll = page.getByRole("option").first();
+      await expect(selectAll).toHaveText(
+        "Select every one of the roles listed below without exception",
+      );
+
+      const clipping = await readOptionClipping(selectAll);
+      expect(clipping.horizontal).toBe(false);
+      expect(clipping.vertical).toBe(false);
+      expect(clipping.height).toBeGreaterThan(SINGLE_LINE_HEIGHT);
+      expect(await documentScrollsHorizontally(page)).toBe(false);
+
+      // The separator and the padding either side of it are declared on the
+      // row's inner element by a selector wrapping does not touch, so what is
+      // checked is that they are still drawn under a row that grew.
+      const treatment = await selectAll.evaluate((el) => {
+        const inner = el.querySelector(".bx--list-box__menu-item__option");
+        if (!inner) return null;
+        const style = getComputedStyle(inner);
+        return {
+          borderBottomWidth: style.borderBottomWidth,
+          borderBottomStyle: style.borderBottomStyle,
+          paddingLeft: style.paddingLeft,
+          paddingRight: style.paddingRight,
+        };
+      });
+      expect(treatment?.borderBottomStyle).toBe("solid");
+      expect(Number.parseFloat(treatment?.borderBottomWidth ?? "0")).toBe(1);
+      expect(Number.parseFloat(treatment?.paddingLeft ?? "0")).toBeGreaterThan(
+        0,
+      );
+      expect(Number.parseFloat(treatment?.paddingRight ?? "0")).toBeGreaterThan(
+        0,
+      );
+
+      // The row below it draws no border of its own, so the two do not read as
+      // a double rule once both have grown.
+      const next = page.getByRole("option").nth(1);
+      const nextBorder = await next.evaluate((el) => {
+        const inner = el.querySelector(".bx--list-box__menu-item__option");
+        return inner ? getComputedStyle(inner).borderTopStyle : null;
+      });
+      expect(nextBorder).toBe("none");
+
+      await expectMenuReadsContinuously(page);
+    });
+  });
+});

--- a/src/ComboBox/ComboBox.svelte
+++ b/src/ComboBox/ComboBox.svelte
@@ -177,7 +177,10 @@
    * - `"hide"`: keep all options mounted and hide non-matching ones with the
    *   `hidden` attribute.
    *
-   * `"hide"` falls back to `"remove"` when virtualization is enabled.
+   * `"hide"` falls back to `"remove"` when virtualization is enabled, which
+   * also keeps `wrapOptions` correct on a windowed list: a hidden option has no
+   * rendered height, so measuring one would put a zero into offsets it does not
+   * occupy.
    * @type {"remove" | "hide"}
    */
   export let filterMode = "remove";
@@ -228,7 +231,7 @@
    * Set `virtualize={true}` to explicitly enable virtualization with default settings.
    *
    * Provide an object to customize virtualization behavior:
-   * - `itemHeight` (default: size-based, or 64px for fluid unless `condensed`): Height of each item in pixels. Override when custom slots change row height.
+   * - `itemHeight` (default: size-based, or 64px for fluid unless `condensed`): Height of each item in pixels. Override when custom slots change row height. Under `wrapOptions`, heights are measured from the rendered options and this serves as the starting estimate for ones not yet measured.
    * - `containerHeight` (default: 300): The maximum height in pixels of the dropdown container.
    * - `overscan` (default: 3): The number of extra items to render above and below the viewport for smoother scrolling. Higher values may cause more flickering during very fast scrolling.
    * - `threshold` (default: 100): The minimum number of items required before virtualization activates. Lists with fewer items will render all items normally without virtualization.
@@ -238,6 +241,13 @@
   export let virtualize = undefined;
 
   /**
+   * Set to `true` to let an option's label wrap onto as many lines as it needs
+   * instead of being truncated with an ellipsis.
+   * @type {boolean}
+   */
+  export let wrapOptions = false;
+
+  /**
    * Set to `true` to render the dropdown menu in a portal,
    * allowing it to escape containers with `overflow: hidden`.
    * When inside a Modal, defaults to `true` unless explicitly set to `false`.
@@ -245,7 +255,13 @@
    */
   export let portalMenu = undefined;
 
-  import { afterUpdate, createEventDispatcher, getContext, tick } from "svelte";
+  import {
+    afterUpdate,
+    createEventDispatcher,
+    getContext,
+    onMount,
+    tick,
+  } from "svelte";
   import Checkmark from "../icons/Checkmark.svelte";
   import WarningAltFilled from "../icons/WarningAltFilled.svelte";
   import WarningFilled from "../icons/WarningFilled.svelte";
@@ -255,21 +271,14 @@
   import ListBoxMenuIcon from "../ListBox/ListBoxMenuIcon.svelte";
   import ListBoxMenuItem from "../ListBox/ListBoxMenuItem.svelte";
   import ListBoxSelection from "../ListBox/ListBoxSelection.svelte";
-  import {
-    getMenuItemHeight,
-    getMenuMaxHeight,
-  } from "../ListBox/list-box-utils.js";
+  import { shouldVirtualizeMenu } from "../ListBox/list-box-utils.js";
+  import { createMenuWindow } from "../ListBox/menuWindow.js";
   import { dismiss } from "../utils/dismiss.js";
   import { isOutsideClick } from "../utils/isOutsideClick.js";
   import { createScrollEndTracker } from "../utils/isScrollNearEnd.js";
   import { moveIndex } from "../utils/moveIndex.js";
   import { uniqueId } from "../utils/uniqueId.js";
-  import {
-    resetVirtualScrollOnClose,
-    scrollHighlightedIntoView,
-    scrollSelectedIntoView,
-    virtualListState,
-  } from "../utils/virtualize.js";
+  import { resetVirtualScrollOnClose } from "../utils/virtualize.js";
 
   const dispatch = createEventDispatcher();
   const scrollEndTracker = createScrollEndTracker();
@@ -292,6 +301,25 @@
 
   /** @type {null | HTMLDivElement} */
   let fieldRef = null;
+
+  /** @type {import("../ListBox/menuWindow.js").MenuWindowState} */
+  let menuState;
+
+  const menuWindow = createMenuWindow({
+    getContainer: () => listRef,
+    onScrollTop: (scrollTop) => {
+      listScrollTop = scrollTop;
+    },
+    onState: (state) => {
+      menuState = state;
+    },
+  });
+
+  onMount(() => {
+    return () => {
+      menuWindow.destroy();
+    };
+  });
 
   /**
    * @returns {boolean}
@@ -319,6 +347,7 @@
   function handleMenuScroll(event) {
     const target = /** @type {HTMLElement} */ (event.target);
     listScrollTop = target.scrollTop;
+    menuWindow.noteScroll(target.scrollTop);
     const detail = scrollEndTracker.observe({
       scrollTop: target.scrollTop,
       scrollHeight: target.scrollHeight,
@@ -395,27 +424,14 @@
     if (
       open &&
       shouldVirtualize &&
-      virtualConfig &&
       highlightedIndex !== prevHighlightedIndex &&
       highlightedIndex >= 0 &&
       listRef
     ) {
       tick().then(() => {
-        if (listRef && virtualConfig && highlightedIndex >= 0) {
-          const nextScrollTop = scrollHighlightedIntoView({
-            highlightedIndex,
-            currentScrollTop: listRef.scrollTop ?? listScrollTop,
-            itemCount: filteredItems.length,
-            itemHeight: virtualConfig.itemHeight,
-            containerHeight: virtualConfig.containerHeight,
-            overscan: virtualConfig.overscan ?? 3,
-            maxItems: virtualConfig.maxItems,
-          });
-          if (nextScrollTop !== null) {
-            listScrollTop = nextScrollTop;
-            listRef.scrollTop = nextScrollTop;
-          }
-        }
+        if (!listRef || highlightedIndex < 0) return;
+        if (highlightOrigin === "pointer") return;
+        menuWindow.scrollIntoView(highlightedIndex, "nearest");
       });
       prevHighlightedIndex = highlightedIndex;
     }
@@ -436,23 +452,17 @@
     // Scroll to selected item when menu opens with virtualization
     if (wasJustOpened && shouldVirtualize && listRef) {
       tick().then(() => {
-        if (listRef && virtualConfig) {
-          const selectedIndex =
-            selectedId !== undefined && selectedItem
-              ? filteredItems.findIndex((item) => item.id === selectedId)
-              : -1;
-          const nextScrollTop = scrollSelectedIntoView({
-            selectedIndex,
-            itemCount: filteredItems.length,
-            itemHeight: virtualConfig.itemHeight,
-            containerHeight: virtualConfig.containerHeight,
-          });
-          listScrollTop = nextScrollTop;
-          listRef.scrollTop = nextScrollTop;
-        }
+        if (!listRef) return;
+        const selectedIndex =
+          selectedId !== undefined && selectedItem
+            ? filteredItems.findIndex((item) => item.id === selectedId)
+            : -1;
+        menuWindow.scrollIntoView(selectedIndex, "top");
       });
     }
     prevOpen = open;
+
+    menuWindow.sync();
 
     if (open) {
       ref.focus();
@@ -468,6 +478,7 @@
         listScrollTop = resetVirtualScrollOnClose();
       }
       scrollEndTracker.reset();
+      menuWindow.reset();
       highlightedIndex = -1;
       highlightOrigin = null;
       prevHighlightedIndex = -1;
@@ -525,10 +536,7 @@
   // Fluid (non-condensed) menu items are 64px tall (see css/_fluid-list-box.scss).
   // Portaled menus render outside the fluid wrapper, so they keep default heights.
   $: hasFluidMenuItems = isFluid && !condensed && !effectivePortalMenu;
-  $: shouldVirtualize =
-    virtualize === false
-      ? false
-      : virtualize !== undefined || items.length > 100;
+  $: shouldVirtualize = shouldVirtualizeMenu({ items, virtualize });
   $: hideMode = filterMode === "hide" && !shouldVirtualize;
   $: filteredItems = open ? items.filter((item) => filterFn(item, value)) : [];
   $: filteredIndexById = new Map(
@@ -541,20 +549,25 @@
       ? undefined
       : `${id}-${filteredItems[highlightedIndex].id}`;
 
-  $: menuMaxHeight = getMenuMaxHeight(size);
-
-  $: virtualState = virtualListState({
+  $: menuState = menuWindow.update({
     items: menuItems,
-    scrollTop: listScrollTop,
     shouldVirtualize,
     virtualize,
-    defaults: {
-      itemHeight: getMenuItemHeight(size, { fluid: hasFluidMenuItems }),
-    },
+    wrapOptions,
+    size,
+    fluid: hasFluidMenuItems,
+    scrollTop: listScrollTop,
   });
-  $: virtualConfig = virtualState.config;
-  $: virtualData = virtualState.data;
-  $: itemsToRender = virtualState.itemsToRender;
+  $: ({
+    itemsToRender,
+    isVirtualized,
+    startIndex,
+    offsetY,
+    totalHeight,
+    menuMaxHeight,
+    isWindowed,
+    isMeasured,
+  } = menuState);
 
   $: if (typeahead) {
     const topItem = filteredItems.find((item) => !item.disabled);
@@ -976,6 +989,7 @@
         anchor={fieldRef}
         {direction}
         {highlightedId}
+        {wrapOptions}
         highlightScroll={highlightOrigin !== "pointer"}
         on:scroll
         on:scroll={handleMenuScroll}
@@ -986,19 +1000,17 @@
           highlightOrigin = null;
         }}
         bind:ref={listRef}
-        style={effectivePortalMenu
-          ? `max-height: ${virtualConfig
-              ? `${virtualConfig.containerHeight}px; overflow-y: auto`
-              : menuMaxHeight};`
-          : virtualConfig
-            ? `max-height: ${virtualConfig.containerHeight}px; overflow-y: auto;`
+        style={isWindowed
+          ? `max-height: ${menuMaxHeight}; overflow-y: auto;`
+          : effectivePortalMenu
+            ? `max-height: ${menuMaxHeight};`
             : undefined}
       >
-        {#if virtualData?.isVirtualized}
-          <div style="height: {virtualData.totalHeight}px; position: relative;">
-            <div style="transform: translateY({virtualData.offsetY}px);">
+        {#if isVirtualized}
+          <div style:height="{totalHeight}px" style:position="relative">
+            <div style:transform="translateY({offsetY}px)">
               {#each itemsToRender as item, index (item.id)}
-                {@const actualIndex = virtualData.startIndex + index}
+                {@const actualIndex = startIndex + index}
                 {@const selected = selectedItem?.id === item.id}
                 {@const optionId = `${id}-${item.id}`}
                 <ListBoxMenuItem
@@ -1008,6 +1020,7 @@
                   hasLeftIcon={Boolean($$slots.icon || item.icon)}
                   aria-setsize={filteredItems.length}
                   aria-posinset={actualIndex + 1}
+                  data-virtual-index={isMeasured ? actualIndex : undefined}
                   on:click={(event) => {
                     if (item.disabled) {
                       event.stopPropagation();
@@ -1093,6 +1106,7 @@
               hidden={hideMode && matchIndex === undefined ? true : undefined}
               aria-setsize={filteredItems.length}
               aria-posinset={matchIndex === undefined ? undefined : matchIndex + 1}
+              data-virtual-index={isMeasured ? matchIndex : undefined}
               on:click={(event) => {
                 if (item.disabled) {
                   event.stopPropagation();

--- a/src/ComboBox/ComboBox.svelte
+++ b/src/ComboBox/ComboBox.svelte
@@ -558,6 +558,7 @@
 
   $: menuState = menuWindow.update({
     items: menuItems,
+    getKey: (item) => item.id,
     shouldVirtualize,
     virtualize,
     wrapOptions,

--- a/src/ComboBox/ComboBox.svelte
+++ b/src/ComboBox/ComboBox.svelte
@@ -430,7 +430,14 @@
     ) {
       tick().then(() => {
         if (!listRef || highlightedIndex < 0) return;
-        if (highlightOrigin === "pointer") return;
+        // Measured placement scrolls an option that is rendered but clipped
+        // fully into view, which would pull the list out from under the
+        // pointer. Cancel as well as return: the pointer has taken the
+        // highlight from the option an outstanding request was placing.
+        if (isMeasured && highlightOrigin === "pointer") {
+          menuWindow.cancelRequest();
+          return;
+        }
         menuWindow.scrollIntoView(highlightedIndex, "nearest");
       });
       prevHighlightedIndex = highlightedIndex;

--- a/src/Dropdown/Dropdown.svelte
+++ b/src/Dropdown/Dropdown.svelte
@@ -367,6 +367,7 @@
 
   $: menuState = menuWindow.update({
     items,
+    getKey: (item) => item.id,
     shouldVirtualize,
     virtualize,
     wrapOptions,

--- a/src/Dropdown/Dropdown.svelte
+++ b/src/Dropdown/Dropdown.svelte
@@ -398,7 +398,14 @@
     ) {
       tick().then(() => {
         if (!listRef || highlightedIndex < 0) return;
-        if (highlightOrigin === "pointer") return;
+        // Measured placement scrolls an option that is rendered but clipped
+        // fully into view, which would pull the list out from under the
+        // pointer. Cancel as well as return: the pointer has taken the
+        // highlight from the option an outstanding request was placing.
+        if (isMeasured && highlightOrigin === "pointer") {
+          menuWindow.cancelRequest();
+          return;
+        }
         menuWindow.scrollIntoView(highlightedIndex, "nearest");
       });
       prevHighlightedIndex = highlightedIndex;

--- a/src/Dropdown/Dropdown.svelte
+++ b/src/Dropdown/Dropdown.svelte
@@ -171,7 +171,7 @@
    * Set `virtualize={true}` to explicitly enable virtualization with default settings.
    *
    * Provide an object to customize virtualization behavior:
-   * - `itemHeight` (default: size-based, or 64px for fluid unless `condensed`): Height of each item in pixels. Override when custom slots change row height.
+   * - `itemHeight` (default: size-based, or 64px for fluid unless `condensed`): Height of each item in pixels. Override when custom slots change row height. Under `wrapOptions`, heights are measured from the rendered options and this serves as the starting estimate for ones not yet measured.
    * - `containerHeight` (default: 300): The maximum height in pixels of the dropdown container.
    * - `overscan` (default: 3): The number of extra items to render above and below the viewport for smoother scrolling. Higher values may cause more flickering during very fast scrolling.
    * - `threshold` (default: 100): The minimum number of items required before virtualization activates. Lists with fewer items will render all items normally without virtualization.
@@ -179,6 +179,13 @@
    * @type {undefined | boolean | { itemHeight?: number, containerHeight?: number, overscan?: number, threshold?: number, maxItems?: number }}
    */
   export let virtualize = undefined;
+
+  /**
+   * Set to `true` to let an option's label wrap onto as many lines as it needs
+   * instead of being truncated with an ellipsis.
+   * @type {boolean}
+   */
+  export let wrapOptions = false;
 
   /**
    * Set to `true` to render the dropdown menu in a portal,
@@ -231,10 +238,8 @@
     ListBoxSelection,
   } from "../ListBox";
   import HighlightSlot from "../ListBox/HighlightSlot.svelte";
-  import {
-    getMenuItemHeight,
-    getMenuMaxHeight,
-  } from "../ListBox/list-box-utils.js";
+  import { shouldVirtualizeMenu } from "../ListBox/list-box-utils.js";
+  import { createMenuWindow } from "../ListBox/menuWindow.js";
   import { debounce } from "../utils/debounce.js";
   import { dismiss } from "../utils/dismiss.js";
   import { isOutsideClick } from "../utils/isOutsideClick.js";
@@ -242,12 +247,7 @@
   import { moveIndex } from "../utils/moveIndex.js";
   import { typeaheadIndex } from "../utils/typeahead.js";
   import { uniqueId } from "../utils/uniqueId.js";
-  import {
-    resetVirtualScrollOnClose,
-    scrollHighlightedIntoView,
-    scrollSelectedIntoView,
-    virtualListState,
-  } from "../utils/virtualize.js";
+  import { resetVirtualScrollOnClose } from "../utils/virtualize.js";
 
   const dispatch = createEventDispatcher();
   const scrollEndTracker = createScrollEndTracker();
@@ -270,6 +270,18 @@
   let itemsById = new Map();
   /** Text content of the visually-hidden status live region. */
   let statusText = "";
+  /** @type {import("../ListBox/menuWindow.js").MenuWindowState} */
+  let menuState;
+
+  const menuWindow = createMenuWindow({
+    getContainer: () => listRef,
+    onScrollTop: (scrollTop) => {
+      listScrollTop = scrollTop;
+    },
+    onState: (state) => {
+      menuState = state;
+    },
+  });
 
   const TYPEAHEAD_DELAY = 500;
 
@@ -281,6 +293,7 @@
   onMount(() => {
     return () => {
       resetTypeaheadBuffer.cancel();
+      menuWindow.destroy();
     };
   });
 
@@ -346,29 +359,31 @@
     }
   }
 
-  $: shouldVirtualize =
-    virtualize === false
-      ? false
-      : virtualize !== undefined || items.length > 100;
-
-  $: menuMaxHeight = getMenuMaxHeight(size);
+  $: shouldVirtualize = shouldVirtualizeMenu({ items, virtualize });
 
   // Fluid (non-condensed) menu items are 64px tall (see css/_fluid-list-box.scss).
   // Portaled menus render outside the fluid wrapper, so they keep default heights.
   $: hasFluidMenuItems = isFluid && !condensed && !effectivePortalMenu;
 
-  $: virtualState = virtualListState({
+  $: menuState = menuWindow.update({
     items,
-    scrollTop: listScrollTop,
     shouldVirtualize,
     virtualize,
-    defaults: {
-      itemHeight: getMenuItemHeight(size, { fluid: hasFluidMenuItems }),
-    },
+    wrapOptions,
+    size,
+    fluid: hasFluidMenuItems,
+    scrollTop: listScrollTop,
   });
-  $: virtualConfig = virtualState.config;
-  $: virtualData = virtualState.data;
-  $: itemsToRender = virtualState.itemsToRender;
+  $: ({
+    itemsToRender,
+    isVirtualized,
+    startIndex,
+    offsetY,
+    totalHeight,
+    menuMaxHeight,
+    isWindowed,
+    isMeasured,
+  } = menuState);
   $: scrollEndTracker.noteItemCount(items.length);
 
   afterUpdate(() => {
@@ -377,27 +392,14 @@
     if (
       open &&
       shouldVirtualize &&
-      virtualConfig &&
       highlightedIndex !== prevHighlightedIndex &&
       highlightedIndex >= 0 &&
       listRef
     ) {
       tick().then(() => {
-        if (listRef && virtualConfig && highlightedIndex >= 0) {
-          const nextScrollTop = scrollHighlightedIntoView({
-            highlightedIndex,
-            currentScrollTop: listRef.scrollTop ?? listScrollTop,
-            itemCount: items.length,
-            itemHeight: virtualConfig.itemHeight,
-            containerHeight: virtualConfig.containerHeight,
-            overscan: virtualConfig.overscan ?? 3,
-            maxItems: virtualConfig.maxItems,
-          });
-          if (nextScrollTop !== null) {
-            listScrollTop = nextScrollTop;
-            listRef.scrollTop = nextScrollTop;
-          }
-        }
+        if (!listRef || highlightedIndex < 0) return;
+        if (highlightOrigin === "pointer") return;
+        menuWindow.scrollIntoView(highlightedIndex, "nearest");
       });
       prevHighlightedIndex = highlightedIndex;
     }
@@ -439,19 +441,13 @@
     // Scroll to selected item when menu opens with virtualization
     if (wasJustOpened && shouldVirtualize && listRef) {
       tick().then(() => {
-        if (listRef && virtualConfig) {
-          const nextScrollTop = scrollSelectedIntoView({
-            selectedIndex,
-            itemCount: items.length,
-            itemHeight: virtualConfig.itemHeight,
-            containerHeight: virtualConfig.containerHeight,
-          });
-          listScrollTop = nextScrollTop;
-          listRef.scrollTop = nextScrollTop;
-        }
+        if (!listRef) return;
+        menuWindow.scrollIntoView(selectedIndex, "top");
       });
     }
     prevOpen = open;
+
+    menuWindow.sync();
 
     // Reset scroll position when menu closes
     if (!open && shouldVirtualize) {
@@ -459,6 +455,7 @@
     }
     if (!open) {
       scrollEndTracker.reset();
+      menuWindow.reset();
     }
   });
 
@@ -468,6 +465,7 @@
   function handleMenuScroll(event) {
     const target = /** @type {HTMLElement} */ (event.target);
     listScrollTop = target.scrollTop;
+    menuWindow.noteScroll(target.scrollTop);
     const detail = scrollEndTracker.observe({
       scrollTop: target.scrollTop,
       scrollHeight: target.scrollHeight,
@@ -784,6 +782,7 @@
         anchor={ref}
         {direction}
         {highlightedId}
+        {wrapOptions}
         highlightScroll={highlightOrigin !== "pointer"}
         on:scroll
         on:scroll={handleMenuScroll}
@@ -794,19 +793,17 @@
           highlightOrigin = null;
         }}
         bind:ref={listRef}
-        style={effectivePortalMenu
-          ? `max-height: ${virtualConfig
-              ? `${virtualConfig.containerHeight}px; overflow-y: auto`
-              : menuMaxHeight};`
-          : virtualConfig
-            ? `max-height: ${virtualConfig.containerHeight}px; overflow-y: auto;`
+        style={isWindowed
+          ? `max-height: ${menuMaxHeight}; overflow-y: auto;`
+          : effectivePortalMenu
+            ? `max-height: ${menuMaxHeight};`
             : undefined}
       >
-        {#if virtualData?.isVirtualized}
-          <div style="height: {virtualData.totalHeight}px; position: relative;">
-            <div style="transform: translateY({virtualData.offsetY}px);">
+        {#if isVirtualized}
+          <div style:height="{totalHeight}px" style:position="relative">
+            <div style:transform="translateY({offsetY}px)">
               {#each itemsToRender as item, index (item.id)}
-                {@const actualIndex = virtualData.startIndex + index}
+                {@const actualIndex = startIndex + index}
                 {@const selected = selectedId === item.id}
                 {@const optionId = `${id}-${item.id}`}
                 <ListBoxMenuItem
@@ -816,6 +813,7 @@
                   hasLeftIcon={Boolean($$slots.icon || item.icon)}
                   aria-setsize={items.length}
                   aria-posinset={actualIndex + 1}
+                  data-virtual-index={isMeasured ? actualIndex : undefined}
                   on:click={(event) => {
                     if (item.disabled) {
                       event.stopPropagation();
@@ -902,6 +900,7 @@
               active={selectedId === item.id}
               disabled={item.disabled}
               hasLeftIcon={Boolean($$slots.icon || item.icon)}
+              data-virtual-index={isMeasured ? index : undefined}
               on:click={(event) => {
                 if (item.disabled) {
                   event.stopPropagation();

--- a/src/ListBox/ListBoxMenu.svelte
+++ b/src/ListBox/ListBoxMenu.svelte
@@ -44,6 +44,13 @@
   export let portalHostClass = undefined;
 
   /**
+   * Set to `true` to let an option's label wrap onto as many lines as it
+   * needs instead of being truncated with an ellipsis.
+   * @type {boolean}
+   */
+  export let wrapOptions = false;
+
+  /**
    * DOM id of the highlighted option (`{instanceId}-{item.id}`).
    * Applied as a two-node class change so `{#each}` does not re-run
    * every `ListBoxMenuItem` on ArrowDown.
@@ -80,6 +87,7 @@
         role="listbox"
         id="menu-{id}"
         class:bx--list-box__menu={true}
+        class:bx--list-box__menu--wrap-options={wrapOptions}
         style="position: static; {$$restProps.style || ''}"
         {...$$restProps}
         on:scroll
@@ -95,6 +103,7 @@
     role="listbox"
     id="menu-{id}"
     class:bx--list-box__menu={true}
+    class:bx--list-box__menu--wrap-options={wrapOptions}
     {...$$restProps}
     on:scroll
     on:mouseleave

--- a/src/ListBox/list-box-utils.d.ts
+++ b/src/ListBox/list-box-utils.d.ts
@@ -38,3 +38,12 @@ export declare function getMenuItemHeight(
   size?: "xs" | "sm" | "md" | "lg" | "xl",
   options?: { fluid?: boolean },
 ): number;
+
+/**
+ * Whether a listbox menu's options should be windowed.
+ */
+export declare function shouldVirtualizeMenu(options: {
+  /** The consumer's own items, not the filtered subset. */
+  items: ArrayLike<unknown>;
+  virtualize: boolean | object | undefined;
+}): boolean;

--- a/src/ListBox/list-box-utils.js
+++ b/src/ListBox/list-box-utils.js
@@ -49,3 +49,31 @@ export function getMenuItemHeight(size = "md", { fluid = false } = {}) {
   if (fluid) return FLUID_MENU_ITEM_HEIGHT;
   return MENU_ITEM_HEIGHT[size] ?? MENU_ITEM_HEIGHT.md;
 }
+
+/**
+ * Item count past which a menu windows itself without being asked. Matches
+ * `virtualize.js`'s own `threshold` default.
+ */
+const VIRTUALIZE_ITEM_COUNT_THRESHOLD = 100;
+
+/**
+ * Whether a listbox menu's options should be windowed. `virtualize={false}`
+ * refuses however long the list runs, supplying the prop at all asks for it,
+ * and with no prop a long enough list opts itself in.
+ *
+ * Separate from the windowing update because `ComboBox` needs the answer before
+ * it can work out which options that update receives.
+ *
+ * @param {Object} options
+ * @param {ArrayLike<unknown>} options.items The consumer's own items rather
+ * than the filtered subset, windowing being a property of the collection
+ * supplied and not of what a keystroke narrows it to.
+ * @param {boolean | object | undefined} options.virtualize
+ * @returns {boolean}
+ */
+export function shouldVirtualizeMenu({ items, virtualize }) {
+  if (virtualize === false) return false;
+  return (
+    virtualize !== undefined || items.length > VIRTUALIZE_ITEM_COUNT_THRESHOLD
+  );
+}

--- a/src/ListBox/list-box-utils.js
+++ b/src/ListBox/list-box-utils.js
@@ -1,3 +1,5 @@
+import { DEFAULT_VIRTUAL_LIST_CONFIG } from "../utils/virtualize.js";
+
 /**
  * Max height values for listbox/dropdown menus by size.
  * @type {Readonly<{ xs: string; sm: string; md: string; lg: string; xl: string }>}
@@ -51,12 +53,6 @@ export function getMenuItemHeight(size = "md", { fluid = false } = {}) {
 }
 
 /**
- * Item count past which a menu windows itself without being asked. Matches
- * `virtualize.js`'s own `threshold` default.
- */
-const VIRTUALIZE_ITEM_COUNT_THRESHOLD = 100;
-
-/**
  * Whether a listbox menu's options should be windowed. `virtualize={false}`
  * refuses however long the list runs, supplying the prop at all asks for it,
  * and with no prop a long enough list opts itself in.
@@ -74,6 +70,7 @@ const VIRTUALIZE_ITEM_COUNT_THRESHOLD = 100;
 export function shouldVirtualizeMenu({ items, virtualize }) {
   if (virtualize === false) return false;
   return (
-    virtualize !== undefined || items.length > VIRTUALIZE_ITEM_COUNT_THRESHOLD
+    virtualize !== undefined ||
+    items.length > DEFAULT_VIRTUAL_LIST_CONFIG.threshold
   );
 }

--- a/src/ListBox/menuWindow.d.ts
+++ b/src/ListBox/menuWindow.d.ts
@@ -58,6 +58,10 @@ export type MenuWindow<
   sync(): void | Promise<void>;
   /** Note a scroll event, so the reader supersedes an outstanding request. */
   noteScroll(scrollTop: number): void;
+  /**
+   * Drop the outstanding request, keeping what was measured for it.
+   */
+  cancelRequest(): void;
   /** Forget the measurements on close; the estimate they averaged to survives. */
   reset(): void;
   /** Stop observing for good. */

--- a/src/ListBox/menuWindow.d.ts
+++ b/src/ListBox/menuWindow.d.ts
@@ -1,0 +1,88 @@
+export type MenuWindowSize = "xs" | "sm" | "md" | "lg" | "xl";
+
+export type MenuWindowUpdateOptions<
+  Item extends Record<string, unknown> = Record<string, unknown>,
+> = {
+  /** The collection the menu renders, filtered where there is a filter. */
+  items: Item[];
+  /** What identifies an option across a rebuild of `items`. */
+  getKey?: (item: Item, index: number) => unknown;
+  /** The threshold gate, from `shouldVirtualizeMenu`. */
+  shouldVirtualize: boolean;
+  virtualize: boolean | object | undefined;
+  /**
+   * Wrapping makes options unequal in height, so it is what turns measuring on.
+   * Nothing else does: a `measured` key on `virtualize` is dropped.
+   */
+  wrapOptions?: boolean;
+  size?: MenuWindowSize;
+  /** Whether menu items render at the fluid height. */
+  fluid?: boolean;
+  scrollTop: number;
+};
+
+export type MenuWindowState<
+  Item extends Record<string, unknown> = Record<string, unknown>,
+> = {
+  itemsToRender: Item[];
+  isVirtualized: boolean;
+  startIndex: number;
+  offsetY: number;
+  totalHeight: number;
+  /** A CSS length: the windowed viewport, or the size-based maximum. */
+  menuMaxHeight: string;
+  /**
+   * Whether a windowing configuration was resolved, which differs from the list
+   * being windowed: one below the threshold resolves a config and still renders
+   * whole. `menuMaxHeight` came from the viewport when this is `true`, so an
+   * overflow rule gates on this.
+   */
+  isWindowed: boolean;
+  isMeasured: boolean;
+};
+
+export type MenuWindow<
+  Item extends Record<string, unknown> = Record<string, unknown>,
+> = {
+  /** Resolve the window for the options the menu is about to render. */
+  update(options: MenuWindowUpdateOptions<Item>): MenuWindowState<Item>;
+  /**
+   * Bring the option at `index` into view, on whichever of the measured and
+   * fixed-height paths the menu is on.
+   */
+  scrollIntoView(index: number, align: "top" | "nearest"): void;
+  /**
+   * Reconcile height observation against what the menu now renders and
+   * re-satisfy any outstanding scroll request. Call it after a render.
+   */
+  sync(): void | Promise<void>;
+  /** Note a scroll event, so the reader supersedes an outstanding request. */
+  noteScroll(scrollTop: number): void;
+  /** Forget the measurements on close; the estimate they averaged to survives. */
+  reset(): void;
+  /** Stop observing for good. */
+  destroy(): void;
+};
+
+export type CreateMenuWindowOptions<
+  Item extends Record<string, unknown> = Record<string, unknown>,
+> = {
+  /** The menu's scroll container, or nothing when the menu is not rendered. */
+  getContainer: () => HTMLElement | null | undefined;
+  /** The scroll position the container actually took. */
+  onScrollTop: (scrollTop: number) => void;
+  /** Called with a state resolved again because measurement moved it. */
+  onState?: (state: MenuWindowState<Item>) => void;
+};
+
+/**
+ * Which options a listbox menu renders and where they sit: the windowing
+ * configuration, the visible slice, the measured heights and the estimate that
+ * outlives them, scroll placement, and the menu's maximum height.
+ *
+ * Builds on the offset arithmetic in `src/utils/virtualize.js` and the DOM
+ * height observation in `src/utils/heightMeasurer.js`.
+ */
+export declare function createMenuWindow<
+  Item extends Record<string, unknown> = Record<string, unknown>,
+>(options: CreateMenuWindowOptions<Item>): MenuWindow<Item>;

--- a/src/ListBox/menuWindow.js
+++ b/src/ListBox/menuWindow.js
@@ -21,21 +21,6 @@ import { getMenuItemHeight, getMenuMaxHeight } from "./list-box-utils.js";
  */
 
 /**
- * Whether two collections hold the same entries in the same positions.
- *
- * @param {ArrayLike<unknown>} a
- * @param {ArrayLike<unknown>} b
- * @returns {boolean}
- */
-function isSameSequence(a, b) {
-  if (a.length !== b.length) return false;
-  for (let index = 0; index < a.length; index++) {
-    if (a[index] !== b[index]) return false;
-  }
-  return true;
-}
-
-/**
  * The consumer's `virtualize` prop with any `measured` key dropped.
  *
  * `wrapOptions` is the only thing that turns measuring on.
@@ -320,12 +305,30 @@ export function createMenuWindow({ getContainer, onScrollTop, onState }) {
    * @param {((item: any, index: number) => unknown) | undefined} getKey
    */
   function noteCollection(items, getKey) {
-    const keys = getKey ? Array.from(items, getKey) : items;
-    if (keys === knownKeys) return;
+    if (isSameCollection(items, getKey)) return;
+    knownKeys = getKey ? Array.from(items, getKey) : items;
+    reset();
+  }
 
-    const isChanged = !isSameSequence(knownKeys, keys);
-    knownKeys = keys;
-    if (isChanged) reset();
+  /**
+   * Whether the keys held still describe the options the menu renders, asked
+   * without materialising a key per option: `update` runs on every scroll
+   * event, and a long list would allocate an array per event to learn nothing.
+   *
+   * @param {ArrayLike<unknown>} items
+   * @param {((item: any, index: number) => unknown) | undefined} getKey
+   * @returns {boolean}
+   */
+  function isSameCollection(items, getKey) {
+    if (knownKeys === items) return true;
+    if (knownKeys.length !== items.length) return false;
+
+    for (let index = 0; index < items.length; index++) {
+      const key = getKey ? getKey(items[index], index) : items[index];
+      if (knownKeys[index] !== key) return false;
+    }
+
+    return true;
   }
 
   /**

--- a/src/ListBox/menuWindow.js
+++ b/src/ListBox/menuWindow.js
@@ -1,0 +1,507 @@
+// @ts-check
+import { tick } from "svelte";
+import {
+  createHeightMeasurer,
+  VIRTUAL_INDEX_ATTRIBUTE,
+} from "../utils/heightMeasurer.js";
+import { scrollIntoViewWithinMenu } from "../utils/scrollIntoViewWithinMenu.js";
+import {
+  getBoundedScrollTop,
+  getMeasuredAverage,
+  getMeasuredScrollCorrection,
+  scrollHighlightedIntoView,
+  scrollSelectedIntoView,
+  virtualListState,
+} from "../utils/virtualize.js";
+import { getMenuItemHeight, getMenuMaxHeight } from "./list-box-utils.js";
+
+/**
+ * The windowing configuration once one has been resolved.
+ * @typedef {import("../utils/virtualize.js").VirtualListConfig & Record<string, unknown>} ResolvedConfig
+ */
+
+/**
+ * Whether two collections hold the same entries in the same positions.
+ *
+ * @param {ArrayLike<unknown>} a
+ * @param {ArrayLike<unknown>} b
+ * @returns {boolean}
+ */
+function isSameSequence(a, b) {
+  if (a.length !== b.length) return false;
+  for (let index = 0; index < a.length; index++) {
+    if (a[index] !== b[index]) return false;
+  }
+  return true;
+}
+
+/**
+ * The consumer's `virtualize` prop with any `measured` key dropped.
+ *
+ * `wrapOptions` is the only thing that turns measuring on.
+ *
+ * @param {boolean | object | undefined} virtualizeProp
+ * @returns {boolean | object | undefined}
+ */
+function withoutMeasured(virtualizeProp) {
+  if (
+    typeof virtualizeProp !== "object" ||
+    virtualizeProp === null ||
+    !("measured" in virtualizeProp)
+  ) {
+    return virtualizeProp;
+  }
+
+  const { measured, ...rest } = /** @type {{ measured?: unknown }} */ (
+    virtualizeProp
+  );
+  return rest;
+}
+
+/**
+ * Which options a listbox menu renders and where they sit. Wraps the offset
+ * arithmetic in `virtualize.js` and the height observation in
+ * `heightMeasurer.js`
+ *
+ * @param {Object} options
+ * @param {() => HTMLElement | null | undefined} options.getContainer The menu's
+ * scroll container, or nothing when the menu is closed. Nothing here acts
+ * without one.
+ * @param {(scrollTop: number) => void} options.onScrollTop The position the
+ * container actually took, so the caller's mirror stays in step.
+ * @param {(state: MenuWindowState) => void} [options.onState] Called when
+ * measurement moves the state, resolved against the arguments `update` was last
+ * given.
+ */
+export function createMenuWindow({ getContainer, onScrollTop, onState }) {
+  /** @type {number[]} Per-option heights, by position, sparse. */
+  let heights = [];
+  /**
+   * Height to assume for an unmeasured option: the average of the heights last
+   * held.
+   * @type {number | undefined}
+   */
+  let estimate;
+  /**
+   * The keys the held heights are indexed against, or the collection itself
+   * when no key function was supplied.
+   * @type {ArrayLike<unknown>}
+   */
+  let knownKeys = [];
+  /** @type {ResolvedConfig | null} */
+  let config = null;
+  /** How many options the last `update` was given. */
+  let itemCount = 0;
+  /** Whether that update resolved to measured heights. */
+  let isMeasured = false;
+  /**
+   * Whether the list it resolved them for is also windowed. Every measured
+   * scroll path gates on this: a list under the threshold is laid out by the
+   * browser, so it has no place to hold and no request to satisfy.
+   */
+  let isMeasuredWindow = false;
+  /** Set while `resolve` runs, which the caller reads from the return value. */
+  let isUpdating = false;
+  /**
+   * The arguments `update` was last given, so measurement can resolve the state
+   * again without asking the caller to re-supply them.
+   * @type {Parameters<typeof update>[0] | null}
+   */
+  let lastOptions = null;
+  /**
+   * The outstanding request.
+   * @type {null | {
+   *   index: number,
+   *   align: "top" | "nearest",
+   *   scrollTop: number,
+   *   heights: number[]
+   * }}
+   */
+  let pending = null;
+  /**
+   * Position last written here, to tell a scroll the reader drove from one this
+   * caused.
+   */
+  let lastWrittenScrollTop = -1;
+
+  const measurer = createHeightMeasurer({ onMeasure: handleMeasured });
+
+  /** Hand the caller a state resolved again, unless it is about to be told. */
+  function notifyChange() {
+    if (isUpdating || !lastOptions) return;
+    onState?.(resolve(lastOptions));
+  }
+
+  /**
+   * Move the menu and read back what the container took.
+   * @param {number} next
+   */
+  function scrollTo(next) {
+    const container = getContainer();
+    if (!container) return;
+    container.scrollTop = next;
+    lastWrittenScrollTop = container.scrollTop;
+    onScrollTop(lastWrittenScrollTop);
+  }
+
+  /**
+   * Where the option at `index` has to sit for the requested alignment under
+   * measured heights, or `null` when it is already close enough to leave alone.
+   * @param {number} index
+   * @param {"top" | "nearest"} align
+   * @param {number} currentScrollTop
+   * @param {ResolvedConfig} resolved
+   * @returns {number | null}
+   */
+  function measuredPosition(index, align, currentScrollTop, resolved) {
+    if (align === "top") {
+      return getBoundedScrollTop({
+        index,
+        itemHeight: resolved.itemHeight,
+        containerHeight: resolved.containerHeight,
+        itemCount,
+        heights,
+      });
+    }
+
+    return scrollHighlightedIntoView({
+      highlightedIndex: index,
+      currentScrollTop,
+      itemCount,
+      itemHeight: resolved.itemHeight,
+      containerHeight: resolved.containerHeight,
+      overscan: resolved.overscan ?? 3,
+      maxItems: resolved.maxItems,
+      heights,
+    });
+  }
+
+  /**
+   * Place the option at `index` with the heights known so far.
+   * @param {number} index
+   * @param {"top" | "nearest"} align
+   */
+  function requestMeasured(index, align) {
+    const container = getContainer();
+    if (!isMeasuredWindow || !config || !container) return;
+
+    if (index < 0) {
+      pending = null;
+      scrollTo(0);
+      return;
+    }
+
+    const next = measuredPosition(index, align, container.scrollTop, config);
+    if (next !== null) scrollTo(next);
+    pending = {
+      index,
+      align,
+      scrollTop: next ?? container.scrollTop,
+      heights,
+    };
+  }
+
+  /**
+   * Place the option at `index` by reading the DOM: the measured path for a
+   * list that was never windowed.
+   * @param {number} index
+   * @param {"top" | "nearest"} align
+   */
+  function placeFromDom(index, align) {
+    const container = getContainer();
+    if (!container) return;
+
+    if (index < 0) {
+      scrollTo(0);
+      return;
+    }
+
+    const option = container.querySelector(
+      `[${VIRTUAL_INDEX_ATTRIBUTE}="${index}"]`,
+    );
+    if (!(option instanceof HTMLElement)) return;
+
+    if (align === "top") {
+      scrollTo(
+        container.scrollTop +
+          (option.getBoundingClientRect().top -
+            container.getBoundingClientRect().top),
+      );
+      return;
+    }
+
+    const before = container.scrollTop;
+    scrollIntoViewWithinMenu(option);
+    if (container.scrollTop !== before) scrollTo(container.scrollTop);
+  }
+
+  /**
+   * Take the heights just measured and hold the reader's place against them.
+   * @param {number[]} next
+   * @param {number[]} previous
+   */
+  function handleMeasured(next, previous) {
+    heights = next;
+    notifyChange();
+
+    if (next.length === 0) return;
+
+    const container = getContainer();
+    if (!isMeasuredWindow || !config || !container) return;
+
+    const correction = getMeasuredScrollCorrection({
+      scrollTop: container.scrollTop,
+      itemCount,
+      itemHeight: config.itemHeight,
+      containerHeight: config.containerHeight,
+      heights: next,
+      previousHeights: previous,
+    });
+
+    if (correction !== 0) {
+      scrollTo(Math.max(0, container.scrollTop + correction));
+    }
+
+    settle();
+  }
+
+  /**
+   * Re-satisfy the outstanding request. Runs on every pass while one stands,
+   * because measurement arrives in batches and each batch can move the option
+   * out from under the last answer.
+   */
+  function settle() {
+    const container = getContainer();
+    if (!pending || !isMeasuredWindow || !config || !container) return;
+
+    if (pending.heights !== heights) {
+      const previousScrollTop = pending.scrollTop;
+      const next = measuredPosition(
+        pending.index,
+        pending.align,
+        container.scrollTop,
+        config,
+      );
+      pending = { ...pending, scrollTop: next ?? previousScrollTop, heights };
+
+      if (next !== null && next !== previousScrollTop) {
+        scrollTo(next);
+        return;
+      }
+    }
+
+    const option = container.querySelector(
+      `[${VIRTUAL_INDEX_ATTRIBUTE}="${pending.index}"]`,
+    );
+    if (!(option instanceof HTMLElement)) return;
+
+    scrollIntoViewWithinMenu(option);
+    scrollTo(container.scrollTop);
+  }
+
+  /**
+   * Note the collection the menu renders, forgetting the measurements when it
+   * holds other options than the ones they describe. `getKey` is for a consumer
+   * whose option objects are rebuilt as well, such as a checkbox toggle
+   * replacing the toggled item, where what stays put is an id.
+   *
+   * @param {ArrayLike<unknown>} items
+   * @param {((item: any, index: number) => unknown) | undefined} getKey
+   */
+  function noteCollection(items, getKey) {
+    const keys = getKey ? Array.from(items, getKey) : items;
+    if (keys === knownKeys) return;
+
+    const isChanged = !isSameSequence(knownKeys, keys);
+    knownKeys = keys;
+    if (isChanged) reset();
+  }
+
+  /**
+   * Resolve the window for the options the menu is about to render.
+   *
+   * @param {Object} options
+   * @param {any[]} options.items The collection the menu renders, filtered
+   * where there is a filter, since its positions are what heights and offsets
+   * are indexed against.
+   * @param {(item: any, index: number) => unknown} [options.getKey] What
+   * identifies an option across a rebuild of `items`. Defaults to the option
+   * itself; only called while heights are being measured.
+   * @param {boolean} options.shouldVirtualize The threshold gate, from
+   * `shouldVirtualizeMenu`. The caller resolves it, needing the answer before
+   * it can work out `items`.
+   * @param {boolean | object | undefined} options.virtualize The consumer's
+   * `virtualize` prop.
+   * @param {boolean} [options.wrapOptions] The consumer's `wrapOptions` prop.
+   * Wrapping makes options unequal in height, so it is what turns measuring on.
+   * @param {"xs" | "sm" | "md" | "lg" | "xl"} [options.size]
+   * @param {boolean} [options.fluid] Whether menu items render at the fluid
+   * height.
+   * @param {number} options.scrollTop The menu's current scroll position.
+   * @returns {import("./menuWindow.js").MenuWindowState}
+   */
+  function update(options) {
+    lastOptions = options;
+    return resolve(options);
+  }
+
+  /**
+   * Resolve the state for one set of arguments. Split from `update` so
+   * measurement can re-run it against the arguments already held.
+   * @param {Parameters<typeof update>[0]} options
+   */
+  function resolve({
+    items,
+    getKey,
+    shouldVirtualize,
+    virtualize: virtualizeProp,
+    wrapOptions = false,
+    size = "md",
+    fluid = false,
+    scrollTop,
+  }) {
+    isUpdating = true;
+    try {
+      if (shouldVirtualize && wrapOptions) noteCollection(items, getKey);
+
+      const state = virtualListState({
+        items,
+        scrollTop,
+        shouldVirtualize,
+        virtualize: withoutMeasured(virtualizeProp),
+        defaults: {
+          itemHeight: getMenuItemHeight(size, { fluid }),
+          measured: wrapOptions,
+        },
+        heights,
+        estimate,
+      });
+
+      config = state.config;
+      itemCount = items.length;
+      isMeasured = Boolean(config?.measured);
+      isMeasuredWindow = isMeasured && Boolean(state.data?.isVirtualized);
+
+      return {
+        itemsToRender: state.itemsToRender,
+        isVirtualized: Boolean(state.data?.isVirtualized),
+        startIndex: state.data?.startIndex ?? 0,
+        offsetY: state.data?.offsetY ?? 0,
+        totalHeight: state.data?.totalHeight ?? 0,
+        menuMaxHeight: config
+          ? `${config.containerHeight}px`
+          : getMenuMaxHeight(size),
+        isWindowed: Boolean(config),
+        isMeasured,
+      };
+    } finally {
+      isUpdating = false;
+    }
+  }
+
+  /**
+   * Bring the option at `index` into view.
+   *
+   * @param {number} index
+   * @param {"top" | "nearest"} align
+   */
+  function scrollIntoView(index, align) {
+    if (!config) return;
+
+    if (isMeasured) {
+      if (isMeasuredWindow) {
+        requestMeasured(index, align);
+        return;
+      }
+
+      pending = null;
+      placeFromDom(index, align);
+      return;
+    }
+
+    const container = getContainer();
+    if (!container) return;
+
+    if (align === "top") {
+      scrollTo(
+        scrollSelectedIntoView({
+          selectedIndex: index,
+          itemCount,
+          itemHeight: config.itemHeight,
+          containerHeight: config.containerHeight,
+        }),
+      );
+      return;
+    }
+
+    if (index < 0) return;
+
+    const next = scrollHighlightedIntoView({
+      highlightedIndex: index,
+      currentScrollTop: container.scrollTop,
+      itemCount,
+      itemHeight: config.itemHeight,
+      containerHeight: config.containerHeight,
+      overscan: config.overscan ?? 3,
+      maxItems: config.maxItems,
+    });
+
+    if (next !== null) scrollTo(next);
+  }
+
+  /**
+   * Reconcile height observation against the options the menu now renders, and
+   * re-satisfy any outstanding scroll request..
+   *
+   * @returns {void | Promise<void>}
+   */
+  function sync() {
+    if (isMeasured) return tick().then(syncMeasurement);
+    syncMeasurement();
+  }
+
+  /**
+   * Reconcile measurement against the options now rendered, then re-satisfy any
+   * outstanding request.
+   */
+  function syncMeasurement() {
+    measurer.sync(isMeasuredWindow ? getContainer() : null);
+    settle();
+  }
+
+  /**
+   * Note a scroll event. A position other than the one last written came from
+   * the reader, whose intent is more recent, so it supersedes any request.
+   * @param {number} scrollTop
+   */
+  function noteScroll(scrollTop) {
+    if (Math.abs(scrollTop - lastWrittenScrollTop) > 1) {
+      pending = null;
+    }
+  }
+
+  /**
+   * Forget the measurements and any outstanding request, keeping the estimate
+   * they averaged to. Called on close, and by `noteCollection` when the
+   * collection comes to hold other options.
+   */
+  function reset() {
+    pending = null;
+
+    const average = getMeasuredAverage(heights);
+    if (average !== null && average !== estimate) {
+      estimate = average;
+      notifyChange();
+    }
+
+    measurer.clear();
+  }
+
+  /** Stop observing for good. */
+  function destroy() {
+    pending = null;
+    measurer.disconnect();
+  }
+
+  return { update, scrollIntoView, sync, noteScroll, reset, destroy };
+}

--- a/src/ListBox/menuWindow.js
+++ b/src/ListBox/menuWindow.js
@@ -119,8 +119,8 @@ export function createMenuWindow({ getContainer, onScrollTop, onState }) {
    */
   let pending = null;
   /**
-   * Position last written here, to tell a scroll the reader drove from one this
-   * caused.
+   * The position this last vouched for: written here, or read from a container
+   * this left where it was. Anything else is the reader's.
    */
   let lastWrittenScrollTop = -1;
 
@@ -192,7 +192,8 @@ export function createMenuWindow({ getContainer, onScrollTop, onState }) {
     }
 
     const next = measuredPosition(index, align, container.scrollTop, config);
-    if (next !== null) scrollTo(next);
+    if (next === null) lastWrittenScrollTop = container.scrollTop;
+    else scrollTo(next);
     pending = {
       index,
       align,
@@ -249,6 +250,11 @@ export function createMenuWindow({ getContainer, onScrollTop, onState }) {
     const container = getContainer();
     if (!isMeasuredWindow || !config || !container) return;
 
+    // Read where the reader left the menu before the correction below writes
+    // to it. After that write, the position on the container is one this made,
+    // and a scroll the reader had made would be indistinguishable from it.
+    noteScroll(container.scrollTop);
+
     const correction = getMeasuredScrollCorrection({
       scrollTop: container.scrollTop,
       itemCount,
@@ -273,6 +279,11 @@ export function createMenuWindow({ getContainer, onScrollTop, onState }) {
   function settle() {
     const container = getContainer();
     if (!pending || !isMeasuredWindow || !config || !container) return;
+
+    // Read rather than wait: a scroll event and the measurer's own frame are
+    // not ordered against each other.
+    noteScroll(container.scrollTop);
+    if (!pending) return;
 
     if (pending.heights !== heights) {
       const previousScrollTop = pending.scrollTop;
@@ -470,14 +481,29 @@ export function createMenuWindow({ getContainer, onScrollTop, onState }) {
   }
 
   /**
-   * Note a scroll event. A position other than the one last written came from
-   * the reader, whose intent is more recent, so it supersedes any request.
+   * Note where the menu is scrolled to. A position other than the one last
+   * written here is the reader's, and the reader's intent is more recent than
+   * an outstanding request, so it supersedes one.
+   *
+   * Called from the scroll handler, and called directly by the paths that read
+   * the container themselves, where waiting for the event would be too late.
+   *
    * @param {number} scrollTop
    */
   function noteScroll(scrollTop) {
     if (Math.abs(scrollTop - lastWrittenScrollTop) > 1) {
       pending = null;
     }
+  }
+
+  /**
+   * Drop the outstanding request, keeping everything measured for it. For a
+   * caller that knows the request is spent when no scroll position says so:
+   * a pointer landing on another option takes the highlight away from the one
+   * that asked, and moves nothing this could read.
+   */
+  function cancelRequest() {
+    pending = null;
   }
 
   /**
@@ -503,5 +529,13 @@ export function createMenuWindow({ getContainer, onScrollTop, onState }) {
     measurer.disconnect();
   }
 
-  return { update, scrollIntoView, sync, noteScroll, reset, destroy };
+  return {
+    update,
+    scrollIntoView,
+    sync,
+    noteScroll,
+    cancelRequest,
+    reset,
+    destroy,
+  };
 }

--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -876,7 +876,6 @@
 
   $: menuState = menuWindow.update({
     items: itemsToUse,
-
     getKey: (item) => item.id,
     shouldVirtualize,
     virtualize,

--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -636,7 +636,14 @@
     ) {
       tick().then(() => {
         if (!listRef || highlightedIndex < 0) return;
-        if (highlightOrigin === "pointer") return;
+        // Measured placement scrolls an option that is rendered but clipped
+        // fully into view, which would pull the list out from under the
+        // pointer. Cancel as well as return: the pointer has taken the
+        // highlight from the option an outstanding request was placing.
+        if (isMeasured && highlightOrigin === "pointer") {
+          menuWindow.cancelRequest();
+          return;
+        }
         menuWindow.scrollIntoView(highlightedIndex, "nearest");
       });
       prevHighlightedIndex = highlightedIndex;

--- a/src/MultiSelect/MultiSelect.svelte
+++ b/src/MultiSelect/MultiSelect.svelte
@@ -286,7 +286,7 @@
    * Set `virtualize={true}` to explicitly enable virtualization with default settings.
    *
    * Provide an object to customize virtualization behavior:
-   * - `itemHeight` (default: size-based, or 64px for fluid unless `condensed`): Height of each item in pixels. Override when custom slots change row height.
+   * - `itemHeight` (default: size-based, or 64px for fluid unless `condensed`): Height of each item in pixels. Override when custom slots change row height. Under `wrapOptions`, heights are measured from the rendered options and this serves as the starting estimate for ones not yet measured.
    * - `containerHeight` (default: 300): The maximum height in pixels of the dropdown container.
    * - `overscan` (default: 3): The number of extra items to render above and below the viewport for smoother scrolling. Higher values may cause more flickering during very fast scrolling.
    * - `threshold` (default: 100): The minimum number of items required before virtualization activates. Lists with fewer items will render all items normally without virtualization.
@@ -294,6 +294,13 @@
    * @type {undefined | boolean | { itemHeight?: number, containerHeight?: number, overscan?: number, threshold?: number, maxItems?: number }}
    */
   export let virtualize = undefined;
+
+  /**
+   * Set to `true` to let an option's label wrap onto as many lines as it needs
+   * instead of being truncated with an ellipsis.
+   * @type {boolean}
+   */
+  export let wrapOptions = false;
 
   /**
    * Set to `true` to render the dropdown menu in a portal,
@@ -330,22 +337,15 @@
     ListBoxSelection,
   } from "../ListBox";
   import HighlightSlot from "../ListBox/HighlightSlot.svelte";
-  import {
-    getMenuItemHeight,
-    getMenuMaxHeight,
-  } from "../ListBox/list-box-utils.js";
+  import { shouldVirtualizeMenu } from "../ListBox/list-box-utils.js";
+  import { createMenuWindow } from "../ListBox/menuWindow.js";
   import { debounce } from "../utils/debounce.js";
   import { dismiss } from "../utils/dismiss.js";
   import { isOutsideClick } from "../utils/isOutsideClick.js";
   import { createScrollEndTracker } from "../utils/isScrollNearEnd.js";
   import { moveIndex } from "../utils/moveIndex.js";
   import { uniqueId } from "../utils/uniqueId.js";
-  import {
-    resetVirtualScrollOnClose,
-    scrollHighlightedIntoView,
-    scrollSelectedIntoView,
-    virtualListState,
-  } from "../utils/virtualize.js";
+  import { resetVirtualScrollOnClose } from "../utils/virtualize.js";
 
   const dispatch = createEventDispatcher();
   const scrollEndTracker = createScrollEndTracker();
@@ -378,6 +378,18 @@
   let lastSelectedItemId = null;
   /** Text content of the visually-hidden status live region. */
   let statusText = "";
+  /** @type {import("../ListBox/menuWindow.js").MenuWindowState} */
+  let menuState;
+
+  const menuWindow = createMenuWindow({
+    getContainer: () => listRef,
+    onScrollTop: (scrollTop) => {
+      listScrollTop = scrollTop;
+    },
+    onState: (state) => {
+      menuState = state;
+    },
+  });
 
   /**
    * @type {(data: { key: "field" | "selection"; ref: HTMLDivElement | HTMLButtonElement }) => void}
@@ -575,7 +587,12 @@
     announceStatus(filterResultsText(count));
   }, 800);
 
-  onMount(() => announceFilterResults.cancel);
+  onMount(() => {
+    return () => {
+      announceFilterResults.cancel();
+      menuWindow.destroy();
+    };
+  });
 
   afterUpdate(() => {
     // Compare by length, not by IDs. This is intentional: `on:select`
@@ -613,27 +630,14 @@
     if (
       open &&
       shouldVirtualize &&
-      virtualConfig &&
       highlightedIndex !== prevHighlightedIndex &&
       highlightedIndex >= 0 &&
       listRef
     ) {
       tick().then(() => {
-        if (listRef && virtualConfig && highlightedIndex >= 0) {
-          const nextScrollTop = scrollHighlightedIntoView({
-            highlightedIndex,
-            currentScrollTop: listRef.scrollTop ?? listScrollTop,
-            itemCount: itemsToUse.length,
-            itemHeight: virtualConfig.itemHeight,
-            containerHeight: virtualConfig.containerHeight,
-            overscan: virtualConfig.overscan ?? 3,
-            maxItems: virtualConfig.maxItems,
-          });
-          if (nextScrollTop !== null) {
-            listScrollTop = nextScrollTop;
-            listRef.scrollTop = nextScrollTop;
-          }
-        }
+        if (!listRef || highlightedIndex < 0) return;
+        if (highlightOrigin === "pointer") return;
+        menuWindow.scrollIntoView(highlightedIndex, "nearest");
       });
       prevHighlightedIndex = highlightedIndex;
     }
@@ -642,31 +646,19 @@
     const wasJustOpened = open && !prevOpen;
     if (wasJustOpened && shouldVirtualize && listRef) {
       tick().then(() => {
-        if (listRef && virtualConfig) {
-          // Find the index of the first selected item in the itemsToUse array
-          // (the actual rendered list, which may be sorted/filtered).
-          const selectedIndex =
-            selectedIds && selectedIds.length > 0
-              ? itemsToUse.findIndex((item) => item.id === selectedIds[0])
-              : -1;
-          const nextScrollTop = scrollSelectedIntoView({
-            selectedIndex,
-            itemCount: itemsToUse.length,
-            itemHeight: virtualConfig.itemHeight,
-            containerHeight: virtualConfig.containerHeight,
-          });
-
-          listScrollTop = nextScrollTop;
-          // Use requestAnimationFrame to ensure DOM is ready
-          requestAnimationFrame(() => {
-            if (listRef) {
-              listRef.scrollTop = nextScrollTop;
-            }
-          });
-        }
+        if (!listRef) return;
+        // Against `itemsToUse`, the rendered list, which sorting and filtering
+        // can order differently from `items`.
+        const selectedIndex =
+          selectedIds && selectedIds.length > 0
+            ? itemsToUse.findIndex((item) => item.id === selectedIds[0])
+            : -1;
+        menuWindow.scrollIntoView(selectedIndex, "top");
       });
     }
     prevOpen = open;
+
+    menuWindow.sync();
 
     // Reset scroll position when menu closes
     if (!open && prevOpen && shouldVirtualize) {
@@ -677,6 +669,7 @@
     }
     if (!open) {
       scrollEndTracker.reset();
+      menuWindow.reset();
     }
   });
 
@@ -686,6 +679,7 @@
   function handleMenuScroll(event) {
     const target = /** @type {HTMLElement} */ (event.target);
     listScrollTop = target.scrollTop;
+    menuWindow.noteScroll(target.scrollTop);
     const detail = scrollEndTracker.observe({
       scrollTop: target.scrollTop,
       scrollHeight: target.scrollHeight,
@@ -868,28 +862,32 @@
   $: activeDescendantId =
     highlightedId == null ? null : `${id}-${highlightedId}`;
 
-  $: shouldVirtualize =
-    virtualize === false
-      ? false
-      : virtualize !== undefined || items.length > 100;
+  $: shouldVirtualize = shouldVirtualizeMenu({ items, virtualize });
 
   $: itemsToUse = filterable ? filteredItems : sortedItems;
   $: scrollEndTracker.noteItemCount(itemsToUse.length);
 
-  $: menuMaxHeight = getMenuMaxHeight(size);
-
-  $: virtualState = virtualListState({
+  $: menuState = menuWindow.update({
     items: itemsToUse,
-    scrollTop: listScrollTop,
+
+    getKey: (item) => item.id,
     shouldVirtualize,
     virtualize,
-    defaults: {
-      itemHeight: getMenuItemHeight(size, { fluid: hasFluidMenuItems }),
-    },
+    wrapOptions,
+    size,
+    fluid: hasFluidMenuItems,
+    scrollTop: listScrollTop,
   });
-  $: virtualConfig = virtualState.config;
-  $: virtualData = virtualState.data;
-  $: itemsToRender = virtualState.itemsToRender;
+  $: ({
+    itemsToRender,
+    isVirtualized,
+    startIndex,
+    offsetY,
+    totalHeight,
+    menuMaxHeight,
+    isWindowed,
+    isMeasured,
+  } = menuState);
 
   $: multiSelectListBoxClass = [
     "bx--multi-select",
@@ -1253,6 +1251,7 @@
         anchor={fieldRef}
         {direction}
         highlightedId={activeDescendantId}
+        {wrapOptions}
         highlightScroll={highlightOrigin !== "pointer"}
         aria-multiselectable="true"
         aria-readonly={readonly || undefined}
@@ -1265,19 +1264,17 @@
           highlightOrigin = null;
         }}
         bind:ref={listRef}
-        style={effectivePortalMenu
-          ? `max-height: ${virtualConfig
-              ? `${virtualConfig.containerHeight}px; overflow-y: auto`
-              : menuMaxHeight};`
-          : virtualConfig
-            ? `max-height: ${virtualConfig.containerHeight}px; overflow-y: auto;`
+        style={isWindowed
+          ? `max-height: ${menuMaxHeight}; overflow-y: auto;`
+          : effectivePortalMenu
+            ? `max-height: ${menuMaxHeight};`
             : undefined}
       >
-        {#if virtualData?.isVirtualized}
-          <div style="height: {virtualData.totalHeight}px; position: relative;">
-            <div style="transform: translateY({virtualData.offsetY}px);">
+        {#if isVirtualized}
+          <div style:height="{totalHeight}px" style:position="relative">
+            <div style:transform="translateY({offsetY}px)">
               {#each itemsToRender as item, index (item.id)}
-                {@const actualIndex = virtualData.startIndex + index}
+                {@const actualIndex = startIndex + index}
                 {@const optionId = `${id}-${item.id}`}
                 {@const itemDisabled =
                   item.disabled ||
@@ -1301,6 +1298,7 @@
                     : item.checked}
                   aria-setsize={itemsToUse.length}
                   aria-posinset={actualIndex + 1}
+                  data-virtual-index={isMeasured ? actualIndex : undefined}
                   active={item.isSelectAll ? false : item.checked}
                   disabled={itemDisabled}
                   on:click={(event) => {
@@ -1385,6 +1383,7 @@
                   ? "mixed"
                   : allSelected
                 : item.checked}
+              data-virtual-index={isMeasured ? index : undefined}
               active={item.isSelectAll ? false : item.checked}
               disabled={itemDisabled}
               on:click={(event) => {

--- a/src/utils/heightMeasurer.d.ts
+++ b/src/utils/heightMeasurer.d.ts
@@ -1,0 +1,41 @@
+/**
+ * Attribute a virtualized component stamps on every element in its rendered
+ * window, carrying the index of the item that element renders.
+ */
+export const VIRTUAL_INDEX_ATTRIBUTE: "data-virtual-index";
+
+export type HeightMeasurerOptions = {
+  /**
+   * Called with the heights indexed by item, sparse wherever an item has not
+   * been measured, and the heights they replace. Only called when a report
+   * differs from the heights already held.
+   */
+  onMeasure: (heights: number[], previousHeights: number[]) => void;
+};
+
+export type HeightMeasurer = {
+  /**
+   * Reconcile what is observed against what `container` currently renders.
+   * Call after the DOM has been committed; pass a falsy container when the
+   * window is gone.
+   */
+  sync: (container: Element | null | undefined) => void;
+  /**
+   * Forget every measurement, as when a menu closes or its item collection is
+   * replaced. Observation stops too, so the next `sync` measures the rendered
+   * elements again rather than waiting for one of them to resize.
+   */
+  clear: () => void;
+  /** Stop observing for good. */
+  disconnect: () => void;
+};
+
+/**
+ * Track the heights the elements of a virtualized window render at, so measured
+ * virtualization has real heights to place offsets from. A single shared
+ * `ResizeObserver` covers the window, falling back to a one-shot height read
+ * where there is no `ResizeObserver`.
+ */
+export function createHeightMeasurer(
+  options: HeightMeasurerOptions,
+): HeightMeasurer;

--- a/src/utils/heightMeasurer.js
+++ b/src/utils/heightMeasurer.js
@@ -1,0 +1,230 @@
+// @ts-check
+
+/**
+ * Attribute a virtualized component stamps on every element in its window,
+ * carrying the index of the item it renders. Measured heights are attributed
+ * back through it, so nothing here reasons about DOM order. The listbox
+ * components emit this name as a literal.
+ */
+export const VIRTUAL_INDEX_ATTRIBUTE = "data-virtual-index";
+
+/**
+ * The height a resize entry reports. Offsets need `borderBoxSize`, since an
+ * option's padding and border occupy scroll height too. `contentRect` is the
+ * fallback for environments that leave `borderBoxSize` empty.
+ *
+ * @param {ResizeObserverEntry} entry
+ * @returns {number}
+ */
+function readEntryHeight(entry) {
+  const borderBox = entry.borderBoxSize?.[0];
+  return borderBox ? borderBox.blockSize : entry.contentRect.height;
+}
+
+/**
+ * @param {Element} element
+ * @returns {number} The item index the element renders, or `-1` when it
+ * carries no usable one.
+ */
+function readIndex(element) {
+  const raw = element.getAttribute(VIRTUAL_INDEX_ATTRIBUTE);
+  if (raw === null || raw === "") return -1;
+  const index = Number(raw);
+  return Number.isInteger(index) && index >= 0 ? index : -1;
+}
+
+/**
+ * Track the heights the elements of a virtualized window render at, so
+ * measured virtualization has real heights to place offsets from.
+ *
+ * All height reading lives here, which keeps `virtualize.js` pure: this reports
+ * heights, that turns them into positions. Scroll position belongs to
+ * `menuWindow.js`, which owns the container element.
+ *
+ * Reports are an array indexed by item, sparse where unmeasured, matching the
+ * shape `virtualize.js` takes as `heights`. They carry the heights they replace
+ * so a caller can work out how far the options above the viewport moved.
+ *
+ * One observer covers the whole window rather than one per element. Besides
+ * being cheaper, it catches height changes no render pass would reveal: a web
+ * font swapping in, a container resize, or the reader changing browser zoom
+ * with the window still on screen.
+ *
+ * A batch is held until the next animation frame rather than reported from
+ * inside the observer's callback. Acting on heights moves the window, since the
+ * caller corrects the scroll position and re-resolves which options render.
+ * Doing that during a delivery both scrolls the container and observes the
+ * newly rendered options, leaving observations the browser cannot deliver in
+ * that pass. It then reports `ResizeObserver loop completed with undelivered
+ * notifications` as an uncatchable window error, on every scroll of a measured
+ * menu. Waiting for the frame also coalesces the batches one scroll arrives in,
+ * so offsets accumulate once for all of them.
+ *
+ * @param {Object} options
+ * @param {(heights: number[], previousHeights: number[]) => void} options.onMeasure
+ * Called on the animation frame after a report that differs from the heights
+ * already held.
+ * @returns {{
+ *   sync: (container: Element | null | undefined) => void,
+ *   clear: () => void,
+ *   disconnect: () => void
+ * }}
+ */
+export function createHeightMeasurer({ onMeasure }) {
+  /** @type {number[]} Indexed by item, sparse where unmeasured. */
+  let heights = [];
+  /** @type {Set<Element>} */
+  const observed = new Set();
+  /** @type {ResizeObserver | null} */
+  let observer = null;
+  /**
+   * Heights measured since the last frame, by item index. A Map so a second
+   * batch reporting the same option supersedes the first rather than queueing
+   * behind it.
+   * @type {Map<number, number> | null}
+   */
+  let batched = null;
+  /** Handle of the scheduled frame, or `0` when none is. */
+  let frame = 0;
+
+  /**
+   * @param {Iterable<[number, number]>} measurements Index/height pairs.
+   */
+  function record(measurements) {
+    /** @type {number[] | null} */
+    let next = null;
+
+    for (const [index, height] of measurements) {
+      if (index < 0 || heights[index] === height) continue;
+      if (next === null) next = heights.slice();
+      next[index] = height;
+    }
+
+    if (next === null) return;
+
+    const previousHeights = heights;
+    heights = next;
+    onMeasure(heights, previousHeights);
+  }
+
+  /** Report everything batched since the last frame, as one measurement. */
+  function flush() {
+    frame = 0;
+    const measurements = batched;
+    batched = null;
+    // A frame can still be pending when the caller tears the measurer down.
+    // Dropping those measurements beats writing into a destroyed component.
+    if (observer === null || measurements === null) return;
+    record(measurements);
+  }
+
+  /** @param {ResizeObserverEntry[]} entries */
+  function handleResize(entries) {
+    if (observer === null) return;
+
+    for (const entry of entries) {
+      // An element leaving the window is reported as a resize to nothing on
+      // its way out. Zero is a real height for one still in the document; for
+      // one that has left it only reports the removal.
+      if (!entry.target.isConnected || !observed.has(entry.target)) continue;
+      const index = readIndex(entry.target);
+      if (index < 0) continue;
+      batched ??= new Map();
+      batched.set(index, readEntryHeight(entry));
+    }
+
+    if (batched === null || frame !== 0) return;
+    frame = requestAnimationFrame(flush);
+  }
+
+  /**
+   * Drop a batch that has not been reported yet. Whatever stops the window
+   * being observed also leaves those heights describing options no longer
+   * rendered there.
+   */
+  function cancelBatch() {
+    if (frame !== 0) cancelAnimationFrame(frame);
+    frame = 0;
+    batched = null;
+  }
+
+  /** Stop observing every element, dropping any batch not yet reported. */
+  function unobserveAll() {
+    cancelBatch();
+    observer?.disconnect();
+    observed.clear();
+  }
+
+  /**
+   * Reconcile what is observed against what `container` currently renders.
+   * Call it after the DOM has been committed, since the elements have to exist
+   * to have a height. Pass a falsy container when the window is gone.
+   *
+   * @param {Element | null | undefined} container
+   */
+  function sync(container) {
+    if (!container) {
+      unobserveAll();
+      return;
+    }
+
+    const elements = container.querySelectorAll(`[${VIRTUAL_INDEX_ATTRIBUTE}]`);
+
+    // No ResizeObserver (the unit test environment; same gap TreeView guards
+    // for): read each height once and accept that later changes go unnoticed.
+    if (typeof ResizeObserver === "undefined") {
+      record(
+        Array.from(elements, (element) => [
+          readIndex(element),
+          element.getBoundingClientRect().height,
+        ]),
+      );
+      return;
+    }
+
+    if (observer === null) {
+      observer = new ResizeObserver(handleResize);
+    }
+
+    const rendered = new Set(elements);
+
+    for (const element of observed) {
+      if (rendered.has(element)) continue;
+      observer.unobserve(element);
+      observed.delete(element);
+    }
+
+    for (const element of rendered) {
+      if (observed.has(element)) continue;
+      observer.observe(element);
+      observed.add(element);
+    }
+  }
+
+  /**
+   * Forget every measurement, as when a menu closes or its collection is
+   * replaced. Heights are indexed by item, so a new collection leaves each of
+   * them describing the wrong element.
+   *
+   * Observation stops too, so the next `sync` starts it over. A keyed list
+   * keeps the elements of surviving entries in place, and an element that does
+   * not resize is never reported again, so observing it afresh asks once more.
+   */
+  function clear() {
+    unobserveAll();
+
+    if (heights.length === 0) return;
+
+    const previousHeights = heights;
+    heights = [];
+    onMeasure(heights, previousHeights);
+  }
+
+  /** Stop observing for good. Measurements are kept but never updated again. */
+  function disconnect() {
+    unobserveAll();
+    observer = null;
+  }
+
+  return { sync, clear, disconnect };
+}

--- a/src/utils/virtualize.d.ts
+++ b/src/utils/virtualize.d.ts
@@ -1,3 +1,10 @@
+/**
+ * Per-option heights indexed by item. An entry that is not a finite,
+ * non-negative number means the option has not been measured yet and takes an
+ * estimated height instead. Zero is a real height.
+ */
+export type ItemHeights = ArrayLike<number | undefined>;
+
 export type VirtualizeConfig<
   Item extends Record<string, unknown> = Record<string, unknown>,
 > = {
@@ -10,6 +17,13 @@ export type VirtualizeConfig<
   maxItems?: number;
   /** @default 100 */
   threshold?: number;
+  /**
+   * Derive offsets from `heights` instead of applying `itemHeight` to every
+   * option. Read only while the list is windowed.
+   * @default false
+   */
+  measured?: boolean;
+  heights?: ItemHeights;
 };
 
 export type VirtualizeResult<
@@ -31,7 +45,23 @@ export type GetVisibleRangeOptions = {
   /** @default 3 */
   overscan?: number;
   maxItems?: number;
+  /**
+   * Resolve the range by searching accumulated positions instead of dividing
+   * by `itemHeight`, which then serves only as the estimate for options with
+   * no entry.
+   */
+  heights?: ItemHeights;
 };
+
+/**
+ * The mean of the measured entries in `heights`, or `null` when none are.
+ * Outlives the heights it came from: a caller forgetting per-option heights can
+ * keep this and hand it back as `virtualListState`'s `estimate`.
+ */
+export function getMeasuredAverage(
+  heights: ItemHeights | undefined,
+  count?: number,
+): number | null;
 
 /** Compute the `[startIndex, endIndex)` slice of items to render. */
 export function getVisibleRange(options: GetVisibleRangeOptions): {
@@ -50,6 +80,7 @@ export type VirtualListConfig = {
   overscan: number;
   threshold: number;
   maxItems: number | undefined;
+  measured: boolean;
 };
 
 /** Default virtualization config for listbox-like components. */
@@ -63,6 +94,13 @@ export type VirtualListStateOptions<
   shouldVirtualize: boolean;
   virtualize: boolean | Partial<VirtualListConfig> | undefined;
   defaults?: Partial<VirtualListConfig>;
+  /** Read only when the config opts into measuring and the list is windowed. */
+  heights?: ItemHeights;
+  /**
+   * Height to assume for options nothing has measured yet, in place of the
+   * config's `itemHeight`. The returned config carries the seed actually used.
+   */
+  estimate?: number;
 };
 
 export type VirtualListStateResult<
@@ -83,6 +121,8 @@ export type GetBoundedScrollTopOptions = {
   itemHeight: number;
   containerHeight: number;
   itemCount: number;
+  /** Position by accumulated height instead of multiplying by `itemHeight`. */
+  heights?: ItemHeights;
 };
 
 /** `scrollTop` to place the item at `index` at the top of the viewport, clamped. */
@@ -99,6 +139,7 @@ export type ScrollHighlightedIntoViewOptions = {
   /** @default 3 */
   overscan?: number;
   maxItems?: number;
+  heights?: ItemHeights;
 };
 
 /**
@@ -114,11 +155,34 @@ export type ScrollSelectedIntoViewOptions = {
   itemCount: number;
   itemHeight: number;
   containerHeight: number;
+  heights?: ItemHeights;
 };
 
 /** `scrollTop` for the selected item on open, or `0` when `selectedIndex < 0`. */
 export function scrollSelectedIntoView(
   options: ScrollSelectedIntoViewOptions,
+): number;
+
+export type GetMeasuredScrollCorrectionOptions = {
+  /** Position the correction is relative to. */
+  scrollTop: number;
+  itemCount: number;
+  /** Seed estimate for unmeasured options. */
+  itemHeight: number;
+  containerHeight: number;
+  /** Per-option heights as they are now. */
+  heights: ItemHeights | undefined;
+  /** Per-option heights `scrollTop` was computed against. */
+  previousHeights: ItemHeights | undefined;
+};
+
+/**
+ * `getScrollCorrection` for a caller that knows its scroll position but not
+ * which option to anchor on: the anchor is the topmost option on screen at
+ * `scrollTop`. Returns the delta to add to `scrollTop`.
+ */
+export function getMeasuredScrollCorrection(
+  options: GetMeasuredScrollCorrectionOptions,
 ): number;
 
 /** Scroll position to reset when a virtualized menu closes. */

--- a/src/utils/virtualize.js
+++ b/src/utils/virtualize.js
@@ -1,4 +1,203 @@
 /**
+ * Per-option heights indexed by item.
+ * @typedef {ArrayLike<number | undefined>} ItemHeights
+ */
+
+/**
+ * A supplied height counts as measured when it is a finite, non-negative
+ * number. A hole in a sparse array, `undefined`, or a negative value means the
+ * option has not been measured yet and falls back to the estimate. Zero is a
+ * real height: an option can collapse to nothing.
+ *
+ * @param {unknown} height
+ * @returns {height is number}
+ */
+function isMeasuredHeight(height) {
+  return typeof height === "number" && height >= 0 && Number.isFinite(height);
+}
+
+/**
+ * The mean of the measured entries in `heights`, or `null` when none of them
+ * are measured.
+ *
+ * @param {ItemHeights | undefined} heights
+ * @param {number} [count] How many entries to read, defaulting to all of them.
+ * @returns {number | null}
+ */
+export function getMeasuredAverage(heights, count = heights?.length ?? 0) {
+  let measuredCount = 0;
+  let measuredTotal = 0;
+
+  for (let index = 0; index < count; index++) {
+    const height = heights?.[index];
+    if (isMeasuredHeight(height)) {
+      measuredCount += 1;
+      measuredTotal += height;
+    }
+  }
+
+  return measuredCount > 0 ? measuredTotal / measuredCount : null;
+}
+
+/**
+ * The height to assume for an option that has not been measured: the running
+ * average of the measured ones.
+ *
+ * @param {Object} options
+ * @param {number} options.itemCount
+ * @param {ItemHeights | undefined} options.heights
+ * @param {number} options.itemHeight Seed estimate.
+ * @returns {number}
+ */
+function getEstimatedHeight({ itemCount, heights, itemHeight }) {
+  return getMeasuredAverage(heights, itemCount) ?? itemHeight;
+}
+
+/**
+ * A seed estimate is usable when it is a positive, finite number. Zero and
+ * below are refused: `virtualize` reads a non-positive `itemHeight` as
+ * unwindowable and renders the list whole, which an average of nothing should
+ * not cause.
+ *
+ * @param {unknown} estimate
+ * @returns {estimate is number}
+ */
+function isUsableEstimate(estimate) {
+  return (
+    typeof estimate === "number" && estimate > 0 && Number.isFinite(estimate)
+  );
+}
+
+/**
+ * Accumulated positions for a list whose options each have their own height.
+ * `offsets[i]` is the distance from the top of the list to the top of option
+ * `i`, so `offsets[itemCount]` is the total scroll height.
+ *
+ * @param {Object} options
+ * @param {number} options.itemCount
+ * @param {ItemHeights | undefined} options.heights
+ * @param {number} options.itemHeight Seed estimate for unmeasured options.
+ * @returns {{ offsets: Float64Array, totalHeight: number }}
+ */
+function accumulateOffsets({ itemCount, heights, itemHeight }) {
+  const estimate = getEstimatedHeight({ itemCount, heights, itemHeight });
+  const offsets = new Float64Array(itemCount + 1);
+
+  for (let index = 0; index < itemCount; index++) {
+    const height = heights?.[index];
+    offsets[index + 1] =
+      offsets[index] + (isMeasuredHeight(height) ? height : estimate);
+  }
+
+  return { offsets, totalHeight: offsets[itemCount] };
+}
+
+/**
+ * Narrow `[startIndex, endIndex)` to at most `maxItems` entries.
+ *
+ * @param {number} startIndex
+ * @param {number} endIndex
+ * @param {number} [maxItems]
+ * @returns {number} The capped `endIndex`.
+ */
+function capToMaxItems(startIndex, endIndex, maxItems) {
+  if (maxItems && endIndex - startIndex > maxItems) {
+    return startIndex + maxItems;
+  }
+
+  return endIndex;
+}
+
+/**
+ * Index of the first entry in `offsets[0..size)` greater than `target`, or
+ * `size` when none is.
+ *
+ * @param {Float64Array} offsets
+ * @param {number} size
+ * @param {number} target
+ * @returns {number}
+ */
+function upperBound(offsets, size, target) {
+  let low = 0;
+  let high = size;
+
+  while (low < high) {
+    const mid = (low + high) >> 1;
+    if (offsets[mid] > target) high = mid;
+    else low = mid + 1;
+  }
+
+  return low;
+}
+
+/**
+ * Index of the first entry in `offsets[0..size)` at or above `target`, or
+ * `size` when none is.
+ *
+ * @param {Float64Array} offsets
+ * @param {number} size
+ * @param {number} target
+ * @returns {number}
+ */
+function lowerBound(offsets, size, target) {
+  let low = 0;
+  let high = size;
+
+  while (low < high) {
+    const mid = (low + high) >> 1;
+    if (offsets[mid] >= target) high = mid;
+    else low = mid + 1;
+  }
+
+  return low;
+}
+
+/**
+ * `getVisibleRange` against already-accumulated positions, so a caller that
+ * has built them once does not build them again.
+ *
+ * @param {Object} options
+ * @param {ReturnType<typeof accumulateOffsets>} options.accumulated
+ * @param {number} options.scrollTop
+ * @param {number} options.containerHeight
+ * @param {number} options.itemCount
+ * @param {number} options.overscan
+ * @param {number} [options.maxItems]
+ * @returns {{ startIndex: number, endIndex: number }}
+ */
+function measuredVisibleRange({
+  accumulated,
+  scrollTop,
+  containerHeight,
+  itemCount,
+  overscan,
+  maxItems,
+}) {
+  // Heights that accumulate to nothing can't be windowed: every option shares
+  // offset 0, so no search can separate them. Fall back to the full range, as
+  // the fixed path does for a non-positive item height.
+  if (!(accumulated.totalHeight > 0)) {
+    return { startIndex: 0, endIndex: itemCount };
+  }
+
+  const { offsets } = accumulated;
+  const size = itemCount + 1;
+  const firstVisible =
+    Math.min(itemCount, upperBound(offsets, size, scrollTop)) - 1;
+
+  const startIndex = Math.max(0, firstVisible - overscan);
+  const endIndex = Math.min(
+    itemCount,
+    lowerBound(offsets, size, scrollTop + containerHeight) + overscan,
+  );
+
+  return {
+    startIndex,
+    endIndex: capToMaxItems(startIndex, endIndex, maxItems),
+  };
+}
+
+/**
  * Compute the `[startIndex, endIndex)` slice of items to render for a given
  * scroll position, including `overscan` padding and an optional `maxItems` cap.
  *
@@ -9,6 +208,10 @@
  * @param {number} options.itemCount
  * @param {number} [options.overscan=3]
  * @param {number} [options.maxItems]
+ * @param {ItemHeights} [options.heights] Per-option heights,
+ * indexed by item. Supplying them resolves the range by searching accumulated
+ * positions instead of dividing by `itemHeight`, which then serves only as the
+ * estimate for options with no entry.
  * @returns {{ startIndex: number, endIndex: number }}
  */
 export function getVisibleRange({
@@ -18,7 +221,19 @@ export function getVisibleRange({
   itemCount,
   overscan = 3,
   maxItems = undefined,
+  heights = undefined,
 }) {
+  if (heights) {
+    return measuredVisibleRange({
+      accumulated: accumulateOffsets({ itemCount, heights, itemHeight }),
+      scrollTop,
+      containerHeight,
+      itemCount,
+      overscan,
+      maxItems,
+    });
+  }
+
   // A non-positive (or NaN) itemHeight can't be virtualized; the math below
   // divides by it and yields NaN indices, so fall back to the full range.
   if (!(itemHeight > 0)) {
@@ -26,20 +241,20 @@ export function getVisibleRange({
   }
 
   const startIndex = Math.max(0, Math.floor(scrollTop / itemHeight) - overscan);
-  let endIndex = Math.min(
+  const endIndex = Math.min(
     itemCount,
     Math.ceil((scrollTop + containerHeight) / itemHeight) + overscan,
   );
 
-  if (maxItems && endIndex - startIndex > maxItems) {
-    endIndex = startIndex + maxItems;
-  }
-
-  return { startIndex, endIndex };
+  return {
+    startIndex,
+    endIndex: capToMaxItems(startIndex, endIndex, maxItems),
+  };
 }
 
 /**
- * Render only the visible slice of a fixed-height list.
+ * Render only the visible slice of a list. Every option is `itemHeight` tall
+ * unless `measured` is set, in which case offsets come from `heights`.
  *
  * @template {Record<string, unknown>} Item
  * @param {Object} config
@@ -50,6 +265,15 @@ export function getVisibleRange({
  * @param {number} [config.overscan=3]
  * @param {number} [config.maxItems]
  * @param {number} [config.threshold=100]
+ * @param {boolean} [config.measured=false] Derive offsets from `heights`
+ * instead of applying `itemHeight` to every option. Read only while the list
+ * is windowed; below `threshold` the browser lays the options out itself.
+ * The config-level opt-in. The standalone helpers here (`getVisibleRange`,
+ * `getBoundedScrollTop`, `scrollSelectedIntoView`, `scrollHighlightedIntoView`)
+ * take no config and go measured whenever `heights` is supplied, so a caller
+ * that opts in must pass `heights` to all of them.
+ * @param {ItemHeights} [config.heights] Per-option heights,
+ * indexed by item. Options with no entry take an estimated height.
  * @returns {{
  *   visibleItems: Item[],
  *   startIndex: number,
@@ -67,9 +291,14 @@ export function virtualize({
   overscan = 3,
   maxItems = undefined,
   threshold = 100,
+  measured = false,
+  heights = undefined,
 }) {
   // A non-positive itemHeight can't be virtualized (the math divides by it and
-  // yields NaN indices), so render the full list unvirtualized.
+  // yields NaN indices), so render the full list unvirtualized. This holds
+  // under `measured` too: `itemHeight` is only the estimate there, but with no
+  // usable estimate and nothing measured yet there is no position to place an
+  // option at.
   if (items.length < threshold || itemHeight <= 0) {
     return {
       visibleItems: items,
@@ -81,7 +310,12 @@ export function virtualize({
     };
   }
 
-  const totalHeight = items.length * itemHeight;
+  const accumulated = measured
+    ? accumulateOffsets({ itemCount: items.length, heights, itemHeight })
+    : null;
+  const totalHeight = accumulated
+    ? accumulated.totalHeight
+    : items.length * itemHeight;
 
   // Clamp scrollTop to the scrollable range. A stale scrollTop (e.g. left over
   // from a longer list after the filter narrows it) would otherwise push
@@ -90,16 +324,27 @@ export function virtualize({
   const maxScroll = Math.max(0, totalHeight - containerHeight);
   const clampedScrollTop = Math.min(Math.max(0, scrollTop), maxScroll);
 
-  const { startIndex, endIndex } = getVisibleRange({
-    scrollTop: clampedScrollTop,
-    itemHeight,
-    containerHeight,
-    itemCount: items.length,
-    overscan,
-    maxItems,
-  });
+  const { startIndex, endIndex } = accumulated
+    ? measuredVisibleRange({
+        accumulated,
+        scrollTop: clampedScrollTop,
+        containerHeight,
+        itemCount: items.length,
+        overscan,
+        maxItems,
+      })
+    : getVisibleRange({
+        scrollTop: clampedScrollTop,
+        itemHeight,
+        containerHeight,
+        itemCount: items.length,
+        overscan,
+        maxItems,
+      });
 
-  const offsetY = startIndex * itemHeight;
+  const offsetY = accumulated
+    ? accumulated.offsets[startIndex]
+    : startIndex * itemHeight;
 
   return {
     visibleItems: items.slice(startIndex, endIndex),
@@ -118,6 +363,7 @@ export const DEFAULT_VIRTUAL_LIST_CONFIG = {
   overscan: 3,
   threshold: 100,
   maxItems: undefined,
+  measured: false,
 };
 
 /**
@@ -131,6 +377,14 @@ export const DEFAULT_VIRTUAL_LIST_CONFIG = {
  * @param {boolean} options.shouldVirtualize
  * @param {boolean | object | undefined} options.virtualize
  * @param {Partial<typeof DEFAULT_VIRTUAL_LIST_CONFIG>} [options.defaults]
+ * @param {ItemHeights} [options.heights] Per-option heights,
+ * indexed by item. Read only when the config opts into measuring and the list
+ * is windowed.
+ * @param {number} [options.estimate] Height to assume for options nothing has
+ * measured yet, in place of the config's `itemHeight`. Read only when the
+ * config opts into measuring, where `itemHeight` is only the seed. On the fixed
+ * path `itemHeight` is the height of every option and nothing may displace it.
+ * Supply the average of heights measured earlier.
  * @returns {{
  *   config: (typeof DEFAULT_VIRTUAL_LIST_CONFIG & Record<string, unknown>) | null,
  *   data: ReturnType<typeof virtualize<Item>> | null,
@@ -143,8 +397,10 @@ export function virtualListState({
   shouldVirtualize,
   virtualize: virtualizeProp,
   defaults = {},
+  heights = undefined,
+  estimate = undefined,
 }) {
-  const config = shouldVirtualize
+  const resolved = shouldVirtualize
     ? {
         ...DEFAULT_VIRTUAL_LIST_CONFIG,
         ...defaults,
@@ -152,7 +408,17 @@ export function virtualListState({
       }
     : null;
 
-  const data = config ? virtualize({ items, scrollTop, ...config }) : null;
+  // Everything downstream reads the seeded config, callers included: an offset
+  // placed against one seed and a scroll position computed against another
+  // describe different lists.
+  const config =
+    resolved?.measured && isUsableEstimate(estimate)
+      ? { ...resolved, itemHeight: estimate }
+      : resolved;
+
+  const data = config
+    ? virtualize({ items, scrollTop, heights, ...config })
+    : null;
 
   const itemsToRender = data?.isVirtualized ? data.visibleItems : items;
 
@@ -168,6 +434,9 @@ export function virtualListState({
  * @param {number} options.itemHeight
  * @param {number} options.containerHeight
  * @param {number} options.itemCount
+ * @param {ItemHeights} [options.heights] Per-option heights,
+ * indexed by item. Supplying them positions by accumulated height instead of
+ * multiplying by `itemHeight`.
  * @returns {number}
  */
 export function getBoundedScrollTop({
@@ -175,7 +444,19 @@ export function getBoundedScrollTop({
   itemHeight,
   containerHeight,
   itemCount,
+  heights = undefined,
 }) {
+  if (heights) {
+    const { offsets, totalHeight } = accumulateOffsets({
+      itemCount,
+      heights,
+      itemHeight,
+    });
+    const maxScroll = Math.max(0, totalHeight - containerHeight);
+    const position = offsets[Math.max(0, Math.min(index, itemCount))];
+    return Math.max(0, Math.min(position, maxScroll));
+  }
+
   const maxScroll = Math.max(0, itemCount * itemHeight - containerHeight);
   return Math.max(0, Math.min(index * itemHeight, maxScroll));
 }
@@ -192,6 +473,8 @@ export function getBoundedScrollTop({
  * @param {number} options.containerHeight
  * @param {number} [options.overscan=3]
  * @param {number} [options.maxItems]
+ * @param {ItemHeights} [options.heights] Per-option heights,
+ * indexed by item.
  * @returns {number | null}
  */
 export function scrollHighlightedIntoView({
@@ -202,6 +485,7 @@ export function scrollHighlightedIntoView({
   containerHeight,
   overscan = 3,
   maxItems = undefined,
+  heights = undefined,
 }) {
   const { startIndex: visibleStartIndex, endIndex: visibleEndIndex } =
     getVisibleRange({
@@ -211,6 +495,7 @@ export function scrollHighlightedIntoView({
       itemCount,
       overscan,
       maxItems,
+      heights,
     });
 
   if (
@@ -222,6 +507,7 @@ export function scrollHighlightedIntoView({
       itemHeight,
       containerHeight,
       itemCount,
+      heights,
     });
   }
 
@@ -236,6 +522,8 @@ export function scrollHighlightedIntoView({
  * @param {number} options.itemCount
  * @param {number} options.itemHeight
  * @param {number} options.containerHeight
+ * @param {ItemHeights} [options.heights] Per-option heights,
+ * indexed by item.
  * @returns {number}
  */
 export function scrollSelectedIntoView({
@@ -243,6 +531,7 @@ export function scrollSelectedIntoView({
   itemCount,
   itemHeight,
   containerHeight,
+  heights = undefined,
 }) {
   if (selectedIndex < 0) return 0;
 
@@ -251,6 +540,94 @@ export function scrollSelectedIntoView({
     itemHeight,
     containerHeight,
     itemCount,
+    heights,
+  });
+}
+
+/**
+ * The `scrollTop` delta that keeps the option at `index`, and everything below
+ * it, where the reader last saw it once the options above it measure to heights
+ * other than the ones assumed. Add the result to the current scroll position.
+ *
+ * Positive means the options above grew and the anchor moved down. Each height
+ * set is read with its own estimate for anything unmeasured, so a sharper
+ * estimate shifting unmeasured options is corrected too.
+ *
+ * @param {Object} options
+ * @param {number} options.index Index anchoring the viewport. Options before
+ * it are the ones whose height changes shift what is on screen.
+ * @param {number} options.itemCount
+ * @param {number} options.itemHeight Seed estimate for unmeasured options.
+ * @param {ItemHeights | undefined} options.heights
+ * Per-option heights as they are now.
+ * @param {ItemHeights | undefined} options.previousHeights
+ * Per-option heights the current scroll position was computed against.
+ * @returns {number}
+ */
+function getScrollCorrection({
+  index,
+  itemCount,
+  itemHeight,
+  heights,
+  previousHeights,
+}) {
+  const anchor = Math.max(0, Math.min(index, itemCount));
+  if (anchor === 0) return 0;
+
+  const after = accumulateOffsets({ itemCount, heights, itemHeight });
+  const before = accumulateOffsets({
+    itemCount,
+    heights: previousHeights,
+    itemHeight,
+  });
+
+  return after.offsets[anchor] - before.offsets[anchor];
+}
+
+/**
+ * `getScrollCorrection` for a caller that knows its scroll position but not
+ * which option to anchor on. The anchor is the topmost option on screen at
+ * `scrollTop` under the heights that position was computed against: the one
+ * the reader is looking at, and so the one that must not move.
+ *
+ * Every consumer of measured heights needs this pairing. Note that the
+ * rendered window starts `overscan` options earlier than the viewport does, so
+ * correcting against that index leaves the visible options shifting anyway.
+ *
+ * @param {Object} options
+ * @param {number} options.scrollTop Position the correction is relative to.
+ * @param {number} options.itemCount
+ * @param {number} options.itemHeight Seed estimate for unmeasured options.
+ * @param {number} options.containerHeight
+ * @param {ItemHeights | undefined} options.heights Per-option heights as they
+ * are now.
+ * @param {ItemHeights | undefined} options.previousHeights Per-option heights
+ * `scrollTop` was computed against.
+ * @returns {number} The delta to add to `scrollTop`.
+ */
+export function getMeasuredScrollCorrection({
+  scrollTop,
+  itemCount,
+  itemHeight,
+  containerHeight,
+  heights,
+  previousHeights,
+}) {
+  const { startIndex } = getVisibleRange({
+    scrollTop,
+    itemHeight,
+    containerHeight,
+    itemCount,
+    overscan: 0,
+    heights: previousHeights,
+  });
+
+  return getScrollCorrection({
+    index: startIndex,
+    itemCount,
+    itemHeight,
+    heights,
+    previousHeights,
   });
 }
 

--- a/tests/ComboBox/ComboBox.test.svelte
+++ b/tests/ComboBox/ComboBox.test.svelte
@@ -44,6 +44,7 @@
   export let virtualize: ComponentProps<ComboBox>["virtualize"] = undefined;
   export let filterMode: ComponentProps<ComboBox>["filterMode"] = undefined;
   export let portalMenu: ComponentProps<ComboBox>["portalMenu"] = false;
+  export let wrapOptions: ComponentProps<ComboBox>["wrapOptions"] = false;
   export let ariaLabel: ComponentProps<ComboBox>["aria-label"] = undefined;
   export let fluid: ComponentProps<ComboBox>["fluid"] = false;
   export let condensed: ComponentProps<ComboBox>["condensed"] = false;
@@ -82,6 +83,7 @@
   {virtualize}
   {filterMode}
   {portalMenu}
+  {wrapOptions}
   on:select={(e) => {
     console.log("select", e.detail);
   }}

--- a/tests/ComboBox/ComboBoxMeasured.test.svelte
+++ b/tests/ComboBox/ComboBoxMeasured.test.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+  import ComboBox from "carbon-components-svelte/ComboBox/ComboBox.svelte";
+  import type { ComponentProps } from "svelte";
+
+  type MeasuredItem = { id: string; text: string; height: number };
+
+  export let items: MeasuredItem[] = [];
+  export let selectedId: string | undefined = undefined;
+
+  let value = "";
+  export let virtualize: ComponentProps<ComboBox>["virtualize"] = undefined;
+  export let wrapOptions: ComponentProps<ComboBox>["wrapOptions"] = false;
+  export let filterMode: ComponentProps<ComboBox>["filterMode"] = undefined;
+  export let shouldFilterItem: (item: MeasuredItem, value: string) => boolean =
+    (item, value) => item.text.toLowerCase().includes(value.toLowerCase());
+</script>
+
+<!-- The height each option renders at travels on the option itself, so the
+     suite's stubbed ResizeObserver can report a different one per item — which
+     is the only way heights held against the wrong option are observable. -->
+<ComboBox
+  labelText="Items"
+  placeholder="Filter…"
+  portalMenu={false}
+  {items}
+  bind:value
+  bind:selectedId
+  {virtualize}
+  {wrapOptions}
+  {filterMode}
+  {shouldFilterItem}
+  let:item
+>
+  <span data-measured-height={item.height}>{item.text}</span>
+</ComboBox>

--- a/tests/ComboBox/ComboBoxMenuWindow.test.ts
+++ b/tests/ComboBox/ComboBoxMenuWindow.test.ts
@@ -1,0 +1,241 @@
+import { render, screen } from "@testing-library/svelte";
+import { stubPerOptionResizeObserver } from "../utils/stubPerOptionResizeObserver";
+import { user } from "../utils/user";
+import ComboBox from "./ComboBox.test.svelte";
+import MeasuredComboBox from "./ComboBoxMeasured.test.svelte";
+
+/**
+ * What is left of this component's measured-menu coverage once the behaviour
+ * lives in one place.
+ *
+ * Offsets across the windowing threshold, both scroll alignments, the identity
+ * of the options a height was measured on, wrapping being the only thing that
+ * turns measuring on, and what a close forgets are all asserted against
+ * `createMenuWindow` in tests/ListBox/menuWindow.test.ts. What is left
+ * here is that this component is connected to it: the wrapping prop reaches
+ * the menu, options are stamped for measurement only when heights are being
+ * measured, and this component's own filtered collection is one the menu
+ * window can still recognise. The wrapping itself, and the highlight markup
+ * surviving a line break, are asserted in e2e/reflow.test.ts.
+ */
+
+// The suite's ResizeObserver stub reports 100px for every element it observes,
+// so a measured list renders 100px rows against a 40px assumption. A scroll
+// height built from 100 rather than 40 is one built from measured heights.
+const MEASURED_HEIGHT = 100;
+const WINDOWED_COUNT = 120;
+const UNWINDOWED_COUNT = 10;
+
+const ITEM_HEIGHT = 40;
+const windowed = {
+  threshold: 1,
+  itemHeight: ITEM_HEIGHT,
+  containerHeight: 200,
+};
+
+function makeItems(count: number) {
+  return Array.from({ length: count }, (_, index) => ({
+    id: String(index),
+    text: `Item ${index + 1}`,
+    price: index,
+  }));
+}
+
+/**
+ * Ten options, half tagged `Alpha` and half `Beta`, each one of three heights.
+ *
+ * The tags and the heights are deliberately out of step: the `Alpha` options
+ * add up to 300 while the average of the whole list over five options is 280,
+ * so a filtered total taken from the estimate is a different number from one
+ * taken from the heights the surviving options were measured at.
+ */
+const unevenItems = Array.from({ length: 10 }, (_, index) => ({
+  id: String(index),
+  text: `${index % 2 === 0 ? "Alpha" : "Beta"} ${index + 1}`,
+  height: 40 + 20 * (index % 3),
+}));
+const ALPHA_HEIGHT = unevenItems
+  .filter((item) => item.text.startsWith("Alpha"))
+  .reduce((total, item) => total + item.height, 0);
+
+/**
+ * Options are only measured once they render, so an overscan wide enough to
+ * render the list whole is what lets a total be asserted exactly.
+ */
+const unevenWindowed = { ...windowed, overscan: unevenItems.length };
+
+function field() {
+  return screen.getByRole("combobox");
+}
+
+function menu() {
+  return screen.getByRole("listbox");
+}
+
+function menuScrollSpacer() {
+  return menu().querySelector<HTMLElement>(":scope > div");
+}
+
+/**
+ * Measurement arrives in batches, each one sharpening the offsets, so the
+ * length is polled rather than read.
+ */
+function expectScrollHeight(pixels: number) {
+  return expect
+    .poll(() => menuScrollSpacer()?.style.height)
+    .toBe(`${pixels}px`);
+}
+
+describe("ComboBox menu window wiring", () => {
+  it("marks the menu so the option wrap styles reach its options", async () => {
+    render(ComboBox, {
+      props: { items: makeItems(UNWINDOWED_COUNT), wrapOptions: true },
+    });
+
+    await user.click(field());
+
+    expect(menu()).toHaveClass("bx--list-box__menu--wrap-options");
+  });
+
+  it("marks a portaled menu, which a class on the component root could not reach", async () => {
+    render(ComboBox, {
+      props: {
+        items: makeItems(UNWINDOWED_COUNT),
+        wrapOptions: true,
+        portalMenu: true,
+      },
+    });
+
+    await user.click(field());
+
+    const portaled = menu();
+    expect(portaled.closest("[data-floating-portal]")).toBeInTheDocument();
+    expect(portaled).toHaveClass("bx--list-box__menu--wrap-options");
+  });
+
+  it("renders the menu as it does today when the prop is not set", async () => {
+    render(ComboBox, { props: { items: makeItems(UNWINDOWED_COUNT) } });
+
+    await user.click(field());
+
+    expect(menu()).not.toHaveClass("bx--list-box__menu--wrap-options");
+    expect(screen.getAllByRole("option")[0]).not.toHaveAttribute(
+      "data-virtual-index",
+    );
+  });
+
+  it("puts a list it windows itself on the measured path under the prop", async () => {
+    render(ComboBox, {
+      props: { items: makeItems(WINDOWED_COUNT), wrapOptions: true },
+    });
+
+    await user.click(field());
+
+    // The prop reaches the menu window, not just the stylesheet: the offsets
+    // are built from what the options measured rather than from the seed.
+    await expect
+      .poll(() => menuScrollSpacer()?.style.height)
+      .toBe(`${WINDOWED_COUNT * MEASURED_HEIGHT}px`);
+  });
+
+  it("marks options with their item index only when wrapping measures them", async () => {
+    const items = makeItems(UNWINDOWED_COUNT);
+    const { unmount } = render(ComboBox, {
+      props: { items, virtualize: windowed, wrapOptions: true },
+    });
+
+    await user.click(field());
+    const measuredOptions = screen.getAllByRole("option");
+    expect(measuredOptions[0]).toHaveAttribute("data-virtual-index", "0");
+    expect(measuredOptions[1]).toHaveAttribute("data-virtual-index", "1");
+    unmount();
+
+    render(ComboBox, {
+      props: { items, virtualize: windowed },
+    });
+    await user.click(field());
+
+    expect(screen.getAllByRole("option")[0]).not.toHaveAttribute(
+      "data-virtual-index",
+    );
+  });
+
+  // A `virtualize` object resolves a config below the threshold too, so the
+  // menu scrolls within `containerHeight` while rendering whole. Bringing an
+  // option into view there is the one path that reads the DOM back, by this
+  // attribute, so leaving those options unstamped strands the keyboard
+  // highlight off screen.
+  it("marks options of a measured list too short to window", async () => {
+    render(ComboBox, {
+      props: {
+        items: makeItems(UNWINDOWED_COUNT),
+        virtualize: { ...windowed, threshold: UNWINDOWED_COUNT + 1 },
+        wrapOptions: true,
+      },
+    });
+
+    await user.click(field());
+
+    const options = screen.getAllByRole("option");
+    expect(options).toHaveLength(UNWINDOWED_COUNT);
+    expect(options[0]).toHaveAttribute("data-virtual-index", "0");
+    expect(options.at(-1)).toHaveAttribute(
+      "data-virtual-index",
+      String(UNWINDOWED_COUNT - 1),
+    );
+  });
+
+  describe("the collection the menu window measures", () => {
+    beforeEach(() => {
+      stubPerOptionResizeObserver();
+    });
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    it("hands the menu window a filtered collection it still recognises", async () => {
+      render(MeasuredComboBox, {
+        props: {
+          items: unevenItems,
+          virtualize: unevenWindowed,
+          wrapOptions: true,
+        },
+      });
+
+      await user.click(field());
+      await user.type(field(), "Alpha");
+
+      // This component needs no identity key: filtering keeps the consumer's
+      // own option objects, so the heights measured before the keystroke still
+      // describe the options that survived it. The total is the matches'
+      // measured heights, not five options at the list's average.
+      await expectScrollHeight(ALPHA_HEIGHT);
+      expect(screen.getAllByRole("option")).toHaveLength(5);
+    });
+
+    it("never measures a hidden option, since the hide filter mode yields to windowing", async () => {
+      render(MeasuredComboBox, {
+        props: {
+          items: unevenItems,
+          virtualize: unevenWindowed,
+          wrapOptions: true,
+          filterMode: "hide" as const,
+        },
+      });
+
+      await user.click(field());
+      await user.type(field(), "Alpha");
+
+      // `filterMode="hide"` falls back to `"remove"` whenever virtualization is
+      // on, so a non-matching option is unmounted rather than left hidden at a
+      // height that is not the one it would render at.
+      await expectScrollHeight(ALPHA_HEIGHT);
+      const options = screen.getAllByRole("option");
+      expect(options).toHaveLength(5);
+      for (const option of options) {
+        expect(option).not.toHaveAttribute("hidden");
+      }
+    });
+  });
+});

--- a/tests/Dropdown/Dropdown.test.svelte
+++ b/tests/Dropdown/Dropdown.test.svelte
@@ -35,6 +35,7 @@
   export let name: ComponentProps<Dropdown>["name"] = undefined;
   export let ref: ComponentProps<Dropdown>["ref"] = null;
   export let virtualize: ComponentProps<Dropdown>["virtualize"] = undefined;
+  export let wrapOptions: ComponentProps<Dropdown>["wrapOptions"] = false;
   export let portalMenu: ComponentProps<Dropdown>["portalMenu"] = false;
   export let onselect: ((event: CustomEvent) => void) | undefined = undefined;
 </script>
@@ -69,6 +70,7 @@
   {name}
   bind:ref
   {virtualize}
+  {wrapOptions}
   {portalMenu}
   on:select={(e) => onselect?.(e)}
   on:clear={(e) => {

--- a/tests/Dropdown/DropdownMenuWindow.test.ts
+++ b/tests/Dropdown/DropdownMenuWindow.test.ts
@@ -1,0 +1,167 @@
+import { render, screen } from "@testing-library/svelte";
+import { user } from "../utils/user";
+import Dropdown from "./Dropdown.test.svelte";
+
+/**
+ * What is left of this component's measured-menu coverage once the behaviour
+ * lives in one place.
+ *
+ * Offsets across the windowing threshold, both scroll alignments, the identity
+ * of the options a height was measured on, wrapping being the only thing that
+ * turns measuring on, and what a close forgets are all asserted against
+ * `createMenuWindow` in tests/ListBox/menuWindow.test.ts. What is left
+ * here is that this component is connected to it: the wrapping prop reaches
+ * the menu, and options are stamped for measurement only when heights are
+ * being measured. The wrapping itself is unobservable in jsdom, which has no
+ * layout engine, so it is asserted in e2e/reflow.test.ts.
+ */
+
+// The suite's ResizeObserver stub reports 100px for every element it observes,
+// so a measured list renders 100px rows against a 40px assumption. A scroll
+// height built from 100 rather than 40 is one built from measured heights.
+const MEASURED_HEIGHT = 100;
+const WINDOWED_COUNT = 120;
+const UNWINDOWED_COUNT = 10;
+
+const ITEM_HEIGHT = 40;
+const windowed = {
+  threshold: 1,
+  itemHeight: ITEM_HEIGHT,
+  containerHeight: 200,
+};
+
+function makeItems(count: number) {
+  return Array.from({ length: count }, (_, index) => ({
+    id: String(index),
+    text: `Item ${index + 1}`,
+  }));
+}
+
+function menu() {
+  return screen.getByRole("listbox");
+}
+
+function menuScrollSpacer() {
+  return menu().querySelector<HTMLElement>(":scope > div");
+}
+
+describe("Dropdown menu window wiring", () => {
+  it("marks the menu so the option wrap styles reach its options", async () => {
+    render(Dropdown, {
+      props: {
+        items: makeItems(UNWINDOWED_COUNT),
+        labelText: "Items",
+        wrapOptions: true,
+      },
+    });
+
+    await user.click(screen.getByRole("combobox"));
+
+    expect(menu()).toHaveClass("bx--list-box__menu--wrap-options");
+  });
+
+  it("marks a portaled menu, which a class on the component root could not reach", async () => {
+    render(Dropdown, {
+      props: {
+        items: makeItems(UNWINDOWED_COUNT),
+        labelText: "Items",
+        wrapOptions: true,
+        portalMenu: true,
+      },
+    });
+
+    await user.click(screen.getByRole("combobox"));
+
+    const portaled = menu();
+    expect(portaled.closest("[data-floating-portal]")).toBeInTheDocument();
+    expect(portaled).toHaveClass("bx--list-box__menu--wrap-options");
+  });
+
+  it("renders the menu as it does today when the prop is not set", async () => {
+    render(Dropdown, {
+      props: { items: makeItems(UNWINDOWED_COUNT), labelText: "Items" },
+    });
+
+    await user.click(screen.getByRole("combobox"));
+
+    expect(menu()).not.toHaveClass("bx--list-box__menu--wrap-options");
+    expect(screen.getAllByRole("option")[0]).not.toHaveAttribute(
+      "data-virtual-index",
+    );
+  });
+
+  it("puts a list it windows itself on the measured path under the prop", async () => {
+    render(Dropdown, {
+      props: {
+        items: makeItems(WINDOWED_COUNT),
+        labelText: "Items",
+        wrapOptions: true,
+      },
+    });
+
+    await user.click(screen.getByRole("combobox"));
+
+    // The prop reaches the menu window, not just the stylesheet: the offsets
+    // are built from what the options measured rather than from the seed.
+    await expect
+      .poll(() => menuScrollSpacer()?.style.height)
+      .toBe(`${WINDOWED_COUNT * MEASURED_HEIGHT}px`);
+  });
+
+  it("marks options with their item index only when wrapping measures them", async () => {
+    const items = makeItems(UNWINDOWED_COUNT);
+    const { unmount } = render(Dropdown, {
+      props: {
+        items,
+        labelText: "Items",
+        virtualize: windowed,
+        wrapOptions: true,
+      },
+    });
+
+    await user.click(screen.getByRole("combobox"));
+    const measuredOptions = screen.getAllByRole("option");
+    expect(measuredOptions[0]).toHaveAttribute("data-virtual-index", "0");
+    expect(measuredOptions[1]).toHaveAttribute("data-virtual-index", "1");
+    unmount();
+
+    render(Dropdown, {
+      props: {
+        items,
+        labelText: "Items",
+        virtualize: windowed,
+      },
+    });
+    await user.click(screen.getByRole("combobox"));
+
+    expect(screen.getAllByRole("option")[0]).not.toHaveAttribute(
+      "data-virtual-index",
+    );
+  });
+
+  // A `virtualize` object resolves a config below the threshold too, so the
+  // menu scrolls within `containerHeight` while rendering whole. Bringing an
+  // option into view there is the one path that reads the DOM back, by this
+  // attribute, so leaving those options unstamped strands the keyboard
+  // highlight off screen.
+  it("marks options of a measured list too short to window", async () => {
+    render(Dropdown, {
+      props: {
+        items: makeItems(UNWINDOWED_COUNT),
+        labelText: "Items",
+        virtualize: { ...windowed, threshold: UNWINDOWED_COUNT + 1 },
+        wrapOptions: true,
+      },
+    });
+
+    await user.click(screen.getByRole("combobox"));
+
+    const options = screen.getAllByRole("option");
+    expect(options).toHaveLength(UNWINDOWED_COUNT);
+    expect(options[0]).toHaveAttribute("data-virtual-index", "0");
+    expect(options.at(-1)).toHaveAttribute(
+      "data-virtual-index",
+      String(UNWINDOWED_COUNT - 1),
+    );
+  });
+});

--- a/tests/ListBox/ListBoxMenu.test.svelte
+++ b/tests/ListBox/ListBoxMenu.test.svelte
@@ -12,6 +12,7 @@
   export let anchor: ComponentProps<ListBoxMenu>["anchor"] = null;
   export let direction: ComponentProps<ListBoxMenu>["direction"] = "bottom";
   export let open: ComponentProps<ListBoxMenu>["open"] = false;
+  export let wrapOptions: ComponentProps<ListBoxMenu>["wrapOptions"] = false;
 </script>
 
 <div data-testid="anchor" bind:this={anchor}>Anchor</div>
@@ -23,6 +24,7 @@
   {anchor}
   {direction}
   {open}
+  {wrapOptions}
   on:scroll={(e) => onscroll?.(e)}
   {...$$restProps}
 >

--- a/tests/ListBox/ListBoxMenu.test.ts
+++ b/tests/ListBox/ListBoxMenu.test.ts
@@ -183,4 +183,55 @@ describe("ListBoxMenu", () => {
       expect(wrapper?.parentElement).toHaveAttribute("data-floating-portal");
     });
   });
+  describe("wrapOptions", () => {
+    it("should not mark the menu by default", () => {
+      render(ListBoxMenu, { props: { slotContent: "Plain menu" } });
+
+      expect(
+        screen.getByText("Plain menu").closest(".bx--list-box__menu"),
+      ).not.toHaveClass("bx--list-box__menu--wrap-options");
+    });
+
+    it("should mark the menu so option wrap styles reach its options", () => {
+      render(ListBoxMenu, {
+        props: { slotContent: "Wrapping menu", wrapOptions: true },
+      });
+
+      expect(
+        screen.getByText("Wrapping menu").closest(".bx--list-box__menu"),
+      ).toHaveClass("bx--list-box__menu--wrap-options");
+    });
+
+    it("should mark the menu alongside a consumer class, not instead of it", () => {
+      render(ListBoxMenu, {
+        props: {
+          slotContent: "Both classes",
+          wrapOptions: true,
+          class: "consumer-class",
+        },
+      });
+
+      const menu = screen
+        .getByText("Both classes")
+        .closest(".bx--list-box__menu");
+      expect(menu).toHaveClass("bx--list-box__menu--wrap-options");
+      expect(menu).toHaveClass("consumer-class");
+    });
+
+    it("should mark a portaled menu, which a class on the component root could not reach", async () => {
+      render(ListBoxMenu, {
+        props: {
+          slotContent: "Portaled wrapping menu",
+          wrapOptions: true,
+          portal: true,
+          open: true,
+        },
+      });
+
+      const menu = await screen.findByText("Portaled wrapping menu");
+      expect(menu.closest(".bx--list-box__menu")).toHaveClass(
+        "bx--list-box__menu--wrap-options",
+      );
+    });
+  });
 });

--- a/tests/ListBox/list-box-utils.test.ts
+++ b/tests/ListBox/list-box-utils.test.ts
@@ -4,7 +4,9 @@ import {
   getMenuMaxHeight,
   MENU_ITEM_HEIGHT,
   MENU_MAX_HEIGHT,
+  shouldVirtualizeMenu,
 } from "../../src/ListBox/list-box-utils.js";
+import { DEFAULT_VIRTUAL_LIST_CONFIG } from "../../src/utils/virtualize.js";
 
 describe("getMenuMaxHeight", () => {
   it("returns default when size is undefined (optional size guard)", () => {
@@ -64,5 +66,42 @@ describe("getMenuItemHeight", () => {
   it("uses size-based heights when fluid is false", () => {
     expect(getMenuItemHeight("sm", { fluid: false })).toBe(32);
     expect(getMenuItemHeight("lg", { fluid: false })).toBe(48);
+  });
+});
+
+describe("shouldVirtualizeMenu", () => {
+  const items = (count: number) =>
+    Array.from({ length: count }, (_, id) => ({ id }));
+
+  it("refuses however long the list runs", () => {
+    expect(
+      shouldVirtualizeMenu({ items: items(5000), virtualize: false }),
+    ).toBe(false);
+  });
+
+  it("takes the prop as the ask, whatever the length", () => {
+    expect(shouldVirtualizeMenu({ items: items(3), virtualize: true })).toBe(
+      true,
+    );
+    expect(shouldVirtualizeMenu({ items: items(3), virtualize: {} })).toBe(
+      true,
+    );
+  });
+
+  it("windows a list of its own past the threshold, not at it", () => {
+    const { threshold } = DEFAULT_VIRTUAL_LIST_CONFIG;
+
+    // `virtualize.js` windows *at* its threshold where this gate windows
+    // *past* it. This gate decides first, so this is what a list with no prop
+    // gets, and it is what the components did before the gate was extracted.
+    expect(
+      shouldVirtualizeMenu({ items: items(threshold), virtualize: undefined }),
+    ).toBe(false);
+    expect(
+      shouldVirtualizeMenu({
+        items: items(threshold + 1),
+        virtualize: undefined,
+      }),
+    ).toBe(true);
   });
 });

--- a/tests/ListBox/menuWindow.test.ts
+++ b/tests/ListBox/menuWindow.test.ts
@@ -908,6 +908,19 @@ describe("createMenuWindow: closing and teardown", () => {
     expect(placeFifthOption(harness)).toBeCloseTo(PLACED_ON_ESTIMATE, 6);
   });
 
+  test("withdrawing a request keeps the heights it was placed against", async () => {
+    const observer = installManualResizeObserver();
+    const harness = setup();
+    const items = buildItems(300);
+
+    await measure(harness, observer, items);
+    harness.menu.cancelRequest();
+
+    // Withdrawing is not closing. The reader is still reading this menu, so
+    // the heights measured for it still describe what is on screen.
+    expect(placeFifthOption(harness)).toBe(PLACED_ON_MEASURED);
+  });
+
   test("has nothing to say about an unmeasured list on close", () => {
     const harness = setup();
     const items = buildItems(300);
@@ -1088,6 +1101,29 @@ describe("createMenuWindow: the measured scroll position", () => {
     expect(container.scrollTop).toBe(100);
   });
 
+  test("a reader's move supersedes a request, reported or not", async () => {
+    const observer = installManualResizeObserver();
+    const { container, menu, render } = setupPlaced({
+      optionHeights: { 2: 320 },
+    });
+    render();
+
+    menu.scrollIntoView(2, "nearest");
+    await menu.sync();
+    expect(container.scrollTop).toBe(100);
+
+    // A position the reader took that no scroll event has reported yet. A
+    // scroll event and the measurer's own frame are not ordered against each
+    // other, so waiting to be told leaves a batch free to arrive first and
+    // place the option against a position the reader has already left.
+    container.scrollTop = 4000;
+    render();
+    await menu.sync();
+    await observer.deliverAll();
+
+    expect(container.scrollTop).toBe(4000);
+  });
+
   test("keeps a request through the scroll event its own write produced", async () => {
     installManualResizeObserver();
     const { container, menu, render } = setupPlaced({
@@ -1100,6 +1136,22 @@ describe("createMenuWindow: the measured scroll position", () => {
     await menu.sync();
 
     expect(container.scrollTop).toBe(100);
+  });
+
+  test("a withdrawn request is not placed later", async () => {
+    installManualResizeObserver();
+    const { container, menu, render } = setupPlaced({
+      optionHeights: { 2: 320 },
+    });
+    render();
+
+    menu.scrollIntoView(2, "nearest");
+    // The caller has learned the reader moved on, which nothing here can see:
+    // a pointer landing on another option moves no scroll position.
+    menu.cancelRequest();
+    await menu.sync();
+
+    expect(container.scrollTop).toBe(0);
   });
 
   test("a close drops the request so nothing re-places the option", async () => {

--- a/tests/ListBox/menuWindow.test.ts
+++ b/tests/ListBox/menuWindow.test.ts
@@ -1,0 +1,1298 @@
+import { tick } from "svelte";
+import { createMenuWindow } from "../../src/ListBox/menuWindow.js";
+import { VIRTUAL_INDEX_ATTRIBUTE } from "../../src/utils/heightMeasurer.js";
+
+type Item = { id: number; text: string };
+
+const CONTAINER_HEIGHT = 300;
+const ITEM_HEIGHT = 40;
+/** The height every option reports once it is measured. */
+const MEASURED_HEIGHT = 100;
+
+function buildItems(count: number, prefix = "Item"): Item[] {
+  return Array.from({ length: count }, (_, index) => ({
+    id: index,
+    text: `${prefix} ${index}`,
+  }));
+}
+
+/**
+ * A menu whose geometry this test owns outright, since jsdom computes none:
+ * the container clamps a written scroll position to a scrollable range the
+ * test states, and every rendered option reports the height it was stamped
+ * with.
+ */
+function buildContainer(scrollHeight = 100_000) {
+  const container = document.createElement("div");
+  let scrollTop = 0;
+  const maxScroll = Math.max(0, scrollHeight - CONTAINER_HEIGHT);
+
+  Object.defineProperty(container, "scrollTop", {
+    get: () => scrollTop,
+    set: (next: number) => {
+      scrollTop = Math.max(0, Math.min(next, maxScroll));
+    },
+    configurable: true,
+  });
+  Object.defineProperty(container, "clientHeight", {
+    value: CONTAINER_HEIGHT,
+    configurable: true,
+  });
+  container.getBoundingClientRect = () =>
+    ({ top: 0, bottom: CONTAINER_HEIGHT }) as DOMRect;
+
+  document.body.appendChild(container);
+  return { container, maxScroll };
+}
+
+/** Render the options the window asked for, each carrying its height. */
+function renderOptions(
+  container: HTMLElement,
+  state: { itemsToRender: Item[]; startIndex: number; isMeasured: boolean },
+  heightAt: (index: number) => number = () => MEASURED_HEIGHT,
+) {
+  container.innerHTML = "";
+  state.itemsToRender.forEach((item, index) => {
+    const option = document.createElement("div");
+    const itemIndex = state.startIndex + index;
+    if (state.isMeasured) {
+      option.setAttribute(VIRTUAL_INDEX_ATTRIBUTE, String(itemIndex));
+    }
+    option.textContent = item.text;
+    const height = heightAt(itemIndex);
+    option.getBoundingClientRect = () =>
+      ({ top: 0, bottom: height, height }) as DOMRect;
+    container.appendChild(option);
+  });
+}
+
+/** The measurer holds a batch until the next frame; this is that frame. */
+function nextFrame() {
+  return new Promise<void>((resolve) => {
+    requestAnimationFrame(() => resolve());
+  });
+}
+
+/**
+ * Stub `ResizeObserver` so its batches are delivered by hand. jsdom lays
+ * nothing out, so a real one would never fire, and a test wants to arrive
+ * between an interaction and the measurement it triggers: the state in between
+ * is what it is looking at.
+ */
+function installManualResizeObserver() {
+  const instances: ManualResizeObserver[] = [];
+
+  class ManualResizeObserver {
+    callback: ResizeObserverCallback;
+    observed = new Set<Element>();
+
+    constructor(callback: ResizeObserverCallback) {
+      this.callback = callback;
+      instances.push(this);
+    }
+
+    observe(element: Element) {
+      this.observed.add(element);
+    }
+
+    unobserve(element: Element) {
+      this.observed.delete(element);
+    }
+
+    disconnect() {
+      this.observed.clear();
+    }
+  }
+
+  vi.stubGlobal("ResizeObserver", ManualResizeObserver);
+
+  return {
+    /**
+     * Report every observed option at the height `renderOptions` gave it, and
+     * resolve on the frame the measurer reports it: a batch is deliberately
+     * not acted on from inside the observer's own callback.
+     */
+    deliverAll() {
+      const instance = instances.at(-1);
+      if (!instance) throw new Error("no ResizeObserver was constructed");
+      const entries = Array.from(instance.observed, (target) => {
+        const { height } = target.getBoundingClientRect();
+        return {
+          target,
+          contentRect: { height } as DOMRectReadOnly,
+          borderBoxSize: [{ blockSize: height, inlineSize: 0 }],
+          contentBoxSize: [],
+          devicePixelContentBoxSize: [],
+        };
+      }) as unknown as ResizeObserverEntry[];
+      instance.callback(entries, instance as unknown as ResizeObserver);
+      return nextFrame();
+    },
+  };
+}
+
+function setup({ scrollHeight }: { scrollHeight?: number } = {}) {
+  const { container, maxScroll } = buildContainer(scrollHeight);
+  const scrollTops: number[] = [];
+  let changeCount = 0;
+  let lastState: ReturnType<(typeof menu)["update"]> | null = null;
+
+  const menu = createMenuWindow<Item>({
+    getContainer: () => container,
+    onScrollTop: (scrollTop) => scrollTops.push(scrollTop),
+    onState: (state) => {
+      changeCount += 1;
+      lastState = state;
+    },
+  });
+
+  return {
+    container,
+    maxScroll,
+    menu,
+    scrollTops,
+    get changeCount() {
+      return changeCount;
+    },
+    get lastState() {
+      return lastState;
+    },
+  };
+}
+
+/**
+ * One very tall option among short ones, so that where an option sits
+ * depends on *which* options are above it and not merely on how tall they
+ * run on average. Total scroll height cannot tell the two apart, since
+ * forgetting every height and laying the list out at their average comes to the
+ * same sum, but a placement can.
+ */
+const TALL_HEIGHT = 300;
+const SHORT_HEIGHT = 20;
+const unevenHeight = (index: number) =>
+  index === 0 ? TALL_HEIGHT : SHORT_HEIGHT;
+
+/** Where option 5 sits once the heights above it are known. */
+const PLACED_ON_MEASURED = TALL_HEIGHT + 4 * SHORT_HEIGHT;
+/** ...and where it sits when only their average survives. */
+const PLACED_ON_ESTIMATE = 5 * ((TALL_HEIGHT + 10 * SHORT_HEIGHT) / 11);
+
+function update(
+  harness: ReturnType<typeof setup>,
+  items: Item[],
+  getKey?: (item: Item) => unknown,
+) {
+  return harness.menu.update({
+    items,
+    getKey,
+    shouldVirtualize: true,
+    virtualize: true,
+    wrapOptions: true,
+    scrollTop: harness.container.scrollTop,
+  });
+}
+
+/** Render and measure the window, then hand back the settled state. */
+async function measure(
+  harness: ReturnType<typeof setup>,
+  observer: ReturnType<typeof installManualResizeObserver>,
+  items: Item[],
+  getKey?: (item: Item) => unknown,
+) {
+  const state = update(harness, items, getKey);
+  renderOptions(harness.container, state, unevenHeight);
+  await harness.menu.sync();
+  await observer.deliverAll();
+  return update(harness, items, getKey);
+}
+
+/** Place option 5 at the top of the menu and report where it landed. */
+function placeFifthOption(harness: ReturnType<typeof setup>) {
+  harness.menu.scrollIntoView(5, "top");
+  return harness.container.scrollTop;
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+  vi.unstubAllGlobals();
+});
+
+describe("createMenuWindow: the visible slice", () => {
+  test("renders every option, unwindowed, below the threshold", () => {
+    const { menu } = setup();
+    const items = buildItems(99);
+
+    const state = menu.update({
+      items,
+      shouldVirtualize: true,
+      virtualize: true,
+      scrollTop: 0,
+    });
+
+    expect(state.isVirtualized).toBe(false);
+    expect(state.itemsToRender).toHaveLength(99);
+    expect(state.startIndex).toBe(0);
+    expect(state.offsetY).toBe(0);
+    expect(state.totalHeight).toBe(99 * ITEM_HEIGHT);
+  });
+
+  test("renders only the visible slice above the threshold", () => {
+    const { menu } = setup();
+    const items = buildItems(300);
+
+    const state = menu.update({
+      items,
+      shouldVirtualize: true,
+      virtualize: true,
+      scrollTop: 0,
+    });
+
+    expect(state.isVirtualized).toBe(true);
+    expect(state.startIndex).toBe(0);
+    expect(state.offsetY).toBe(0);
+    expect(state.totalHeight).toBe(300 * ITEM_HEIGHT);
+    expect(state.itemsToRender[0]).toBe(items[0]);
+    // A 300px viewport of 40px options, plus three of overscan.
+    expect(state.itemsToRender).toHaveLength(
+      Math.ceil(CONTAINER_HEIGHT / ITEM_HEIGHT) + 3,
+    );
+  });
+
+  test("offsets the slice by the options scrolled past", () => {
+    const { menu } = setup();
+
+    const state = menu.update({
+      items: buildItems(300),
+      shouldVirtualize: true,
+      virtualize: true,
+      scrollTop: 400,
+    });
+
+    expect(state.startIndex).toBe(400 / ITEM_HEIGHT - 3);
+    expect(state.offsetY).toBe(state.startIndex * ITEM_HEIGHT);
+  });
+
+  test("sizes options by the menu size and fluidity", () => {
+    const { menu } = setup();
+    const items = buildItems(300);
+
+    const small = menu.update({
+      items,
+      shouldVirtualize: true,
+      virtualize: true,
+      size: "sm",
+      scrollTop: 0,
+    });
+    expect(small.totalHeight).toBe(300 * 32);
+
+    const fluid = menu.update({
+      items,
+      shouldVirtualize: true,
+      virtualize: true,
+      size: "sm",
+      fluid: true,
+      scrollTop: 0,
+    });
+    expect(fluid.totalHeight).toBe(300 * 64);
+  });
+});
+
+describe("createMenuWindow: the menu's maximum height", () => {
+  test("takes the size-based maximum when the list is not windowed", () => {
+    const { menu } = setup();
+
+    const state = menu.update({
+      items: buildItems(10),
+      shouldVirtualize: false,
+      virtualize: undefined,
+      size: "sm",
+      scrollTop: 0,
+    });
+
+    expect(state.menuMaxHeight).toBe("11rem");
+  });
+
+  test("takes the windowed viewport once windowing is configured", () => {
+    const { menu } = setup();
+
+    const state = menu.update({
+      items: buildItems(300),
+      shouldVirtualize: true,
+      virtualize: { containerHeight: 240 },
+      size: "sm",
+      scrollTop: 0,
+    });
+
+    expect(state.menuMaxHeight).toBe("240px");
+  });
+
+  test("reports a resolved configuration on a list too short to be windowed", () => {
+    const { menu } = setup();
+
+    const state = menu.update({
+      items: buildItems(10),
+      shouldVirtualize: true,
+      virtualize: { containerHeight: 240 },
+      size: "sm",
+      scrollTop: 0,
+    });
+
+    // The list renders whole, but its menu is still scrolled within the
+    // configured viewport, so the maximum height is the windowed one and the
+    // caller needs to tell that apart from `isVirtualized`.
+    expect(state.isVirtualized).toBe(false);
+    expect(state.isWindowed).toBe(true);
+    expect(state.menuMaxHeight).toBe("240px");
+  });
+
+  test("wrapping on its own resolves no windowing configuration", () => {
+    const { menu } = setup();
+
+    const state = menu.update({
+      items: buildItems(10),
+      shouldVirtualize: false,
+      virtualize: undefined,
+      wrapOptions: true,
+      size: "sm",
+      scrollTop: 0,
+    });
+
+    // Wrapping asks for measured heights, not for a window. A prop that
+    // synthesized a configuration here would swap the size-based maximum for
+    // the windowed viewport, making a short menu taller for turning on an
+    // accessibility prop.
+    expect(state.isWindowed).toBe(false);
+    expect(state.isVirtualized).toBe(false);
+    expect(state.menuMaxHeight).toBe("11rem");
+  });
+
+  test("reports no configuration when the list is not windowed at all", () => {
+    const { menu } = setup();
+
+    const state = menu.update({
+      items: buildItems(10),
+      shouldVirtualize: false,
+      virtualize: undefined,
+      size: "sm",
+      scrollTop: 0,
+    });
+
+    expect(state.isWindowed).toBe(false);
+  });
+});
+
+describe("createMenuWindow: measured heights", () => {
+  test("re-enters the heights it measured without the caller carrying them", async () => {
+    const observer = installManualResizeObserver();
+    const { container, menu } = setup();
+    const items = buildItems(300);
+
+    const update = () =>
+      menu.update({
+        items,
+        shouldVirtualize: true,
+        virtualize: true,
+        wrapOptions: true,
+        scrollTop: 0,
+      });
+
+    let state = update();
+    expect(state.isMeasured).toBe(true);
+    // Nothing measured yet, so every option is laid out at the seed.
+    expect(state.totalHeight).toBe(300 * ITEM_HEIGHT);
+
+    renderOptions(container, state);
+    await menu.sync();
+    await observer.deliverAll();
+
+    state = update();
+    // The measured options carry their real height; the rest take the average
+    // of what has been measured, which is that same height.
+    expect(state.totalHeight).toBe(300 * MEASURED_HEIGHT);
+  });
+
+  test("tells the caller when measurement moves what an update would return", async () => {
+    const observer = installManualResizeObserver();
+    const harness = setup();
+    const items = buildItems(300);
+
+    const state = harness.menu.update({
+      items,
+      shouldVirtualize: true,
+      virtualize: true,
+      wrapOptions: true,
+      scrollTop: 0,
+    });
+    renderOptions(harness.container, state);
+    await harness.menu.sync();
+
+    const before = harness.changeCount;
+    await observer.deliverAll();
+
+    expect(harness.changeCount).toBeGreaterThan(before);
+    // What arrives is the resolved state itself, laid out against the heights
+    // just measured rather than the seed the first pass used.
+    expect(harness.lastState?.totalHeight).toBe(300 * MEASURED_HEIGHT);
+    expect(state.totalHeight).toBe(300 * ITEM_HEIGHT);
+  });
+
+  test("leaves offsets on the seed while the list is under the threshold", async () => {
+    const observer = installManualResizeObserver();
+    const { container, menu } = setup();
+    const items = buildItems(50);
+
+    const state = menu.update({
+      items,
+      shouldVirtualize: true,
+      virtualize: true,
+      wrapOptions: true,
+      scrollTop: 0,
+    });
+    expect(state.isVirtualized).toBe(false);
+
+    renderOptions(container, state);
+    await menu.sync();
+
+    // Nothing is observed at all: below the threshold the browser lays every
+    // option out itself, so there is no offset for a height to sharpen.
+    expect(() => observer.deliverAll()).toThrow();
+
+    const next = menu.update({
+      items,
+      shouldVirtualize: true,
+      virtualize: true,
+      wrapOptions: true,
+      scrollTop: 0,
+    });
+    expect(next.totalHeight).toBe(50 * ITEM_HEIGHT);
+  });
+
+  test("renders the list whole when nothing can be measured", async () => {
+    // No `ResizeObserver` at all, and a layout engine that lays nothing out:
+    // the one-shot fallback read measures every option at zero. Nothing can be
+    // windowed against heights like those, and the list still renders.
+    vi.stubGlobal("ResizeObserver", undefined);
+    const { container, menu } = setup();
+    const items = buildItems(300);
+
+    const update = () =>
+      menu.update({
+        items,
+        shouldVirtualize: true,
+        virtualize: true,
+        wrapOptions: true,
+        scrollTop: 0,
+      });
+
+    renderOptions(container, update(), () => 0);
+    await menu.sync();
+
+    expect(update().itemsToRender).toHaveLength(300);
+  });
+});
+
+describe("createMenuWindow: wrapping is the only thing that measures", () => {
+  const base = {
+    shouldVirtualize: true,
+    scrollTop: 0,
+  } as const;
+
+  test("measures nothing when wrapping is off", () => {
+    const { menu } = setup();
+
+    const state = menu.update({
+      ...base,
+      items: buildItems(300),
+      virtualize: true,
+    });
+
+    expect(state.isMeasured).toBe(false);
+  });
+
+  test("measures when wrapping is on", () => {
+    const { menu } = setup();
+
+    const state = menu.update({
+      ...base,
+      items: buildItems(300),
+      virtualize: true,
+      wrapOptions: true,
+    });
+
+    expect(state.isMeasured).toBe(true);
+  });
+
+  // Measuring is not a consumer-facing choice, so `measured` is not part of
+  // the `virtualize` shape the components document. A key that reached the
+  // config anyway would be able to contradict the prop that is, in both
+  // directions; neither of these two does anything.
+  test("ignores a measured key asking for it without wrapping", () => {
+    const { menu } = setup();
+
+    const state = menu.update({
+      ...base,
+      items: buildItems(300),
+      virtualize: { measured: true },
+    });
+
+    expect(state.isMeasured).toBe(false);
+  });
+
+  test("ignores a measured key contradicting wrapping", () => {
+    const { menu } = setup();
+
+    const state = menu.update({
+      ...base,
+      items: buildItems(300),
+      virtualize: { measured: false },
+      wrapOptions: true,
+    });
+
+    expect(state.isMeasured).toBe(true);
+  });
+
+  test("a consumer who opted into neither pays for neither", () => {
+    const observer = installManualResizeObserver();
+    const getKey = vi.fn((item: Item) => item.id);
+    const { container, menu } = setup();
+
+    const state = menu.update({
+      ...base,
+      items: buildItems(300),
+      virtualize: true,
+      getKey,
+    });
+    renderOptions(container, state);
+
+    // No deferral: the reconciliation is over by the time `sync` returns.
+    expect(menu.sync()).toBeUndefined();
+    expect(getKey).not.toHaveBeenCalled();
+    expect(() => observer.deliverAll()).toThrow();
+  });
+});
+
+describe("createMenuWindow: bringing an option into view", () => {
+  test("puts a top-aligned option at the top of a fixed-height menu", () => {
+    const { container, menu, scrollTops } = setup();
+
+    menu.update({
+      items: buildItems(300),
+      shouldVirtualize: true,
+      virtualize: true,
+      scrollTop: 0,
+    });
+    menu.scrollIntoView(50, "top");
+
+    expect(container.scrollTop).toBe(50 * ITEM_HEIGHT);
+    expect(scrollTops).toEqual([50 * ITEM_HEIGHT]);
+  });
+
+  test("reports the position the container took, not the one asked for", () => {
+    const { container, menu, scrollTops, maxScroll } = setup({
+      scrollHeight: 1000,
+    });
+
+    menu.update({
+      items: buildItems(300),
+      shouldVirtualize: true,
+      virtualize: true,
+      wrapOptions: true,
+      scrollTop: 0,
+    });
+    menu.scrollIntoView(299, "top");
+
+    // Reporting the request instead would leave the caller's mirror, the value
+    // its windowing math reads, describing a position nothing is at.
+    expect(container.scrollTop).toBe(maxScroll);
+    expect(scrollTops).toEqual([maxScroll]);
+  });
+
+  test("bounds a top-aligned request by the end of the list", () => {
+    const { container, menu } = setup();
+
+    menu.update({
+      items: buildItems(300),
+      shouldVirtualize: true,
+      virtualize: true,
+      wrapOptions: true,
+      scrollTop: 0,
+    });
+    menu.scrollIntoView(299, "top");
+
+    // Putting the last option at the top of the viewport would scroll past the
+    // end of the list, so the request is bounded by it before the container has
+    // to clamp anything.
+    expect(container.scrollTop).toBe(300 * ITEM_HEIGHT - CONTAINER_HEIGHT);
+  });
+
+  test("sends a measured menu to the top when there is nothing to show", () => {
+    const { container, menu } = setup();
+
+    menu.update({
+      items: buildItems(300),
+      shouldVirtualize: true,
+      virtualize: true,
+      wrapOptions: true,
+      scrollTop: 0,
+    });
+    container.scrollTop = 1200;
+    menu.scrollIntoView(-1, "top");
+
+    expect(container.scrollTop).toBe(0);
+  });
+
+  test("sends a fixed-height menu to the top when there is nothing to show", () => {
+    const { container, menu } = setup();
+
+    menu.update({
+      items: buildItems(300),
+      shouldVirtualize: true,
+      virtualize: true,
+      scrollTop: 0,
+    });
+    container.scrollTop = 1200;
+    menu.scrollIntoView(-1, "top");
+
+    expect(container.scrollTop).toBe(0);
+  });
+
+  test("leaves a nearest option already on screen alone", () => {
+    const { container, menu, scrollTops } = setup();
+
+    menu.update({
+      items: buildItems(300),
+      shouldVirtualize: true,
+      virtualize: true,
+      scrollTop: 0,
+    });
+    menu.scrollIntoView(2, "nearest");
+
+    expect(container.scrollTop).toBe(0);
+    expect(scrollTops).toEqual([]);
+  });
+
+  test("brings a nearest option off the window into a fixed-height menu", () => {
+    const { container, menu } = setup();
+
+    menu.update({
+      items: buildItems(300),
+      shouldVirtualize: true,
+      virtualize: true,
+      scrollTop: 0,
+    });
+    menu.scrollIntoView(80, "nearest");
+
+    expect(container.scrollTop).toBe(80 * ITEM_HEIGHT);
+  });
+
+  test("places a top-aligned option against the heights measured so far", async () => {
+    const observer = installManualResizeObserver();
+    const { container, menu } = setup();
+    const items = buildItems(300);
+
+    const update = (scrollTop: number) =>
+      menu.update({
+        items,
+        shouldVirtualize: true,
+        virtualize: true,
+        wrapOptions: true,
+        scrollTop,
+      });
+
+    let state = update(0);
+    renderOptions(container, state);
+    await menu.sync();
+    await observer.deliverAll();
+
+    state = update(container.scrollTop);
+    menu.scrollIntoView(50, "top");
+
+    // The options above it are all measured at MEASURED_HEIGHT by now, so the
+    // placement rests on those and not on the seed.
+    expect(container.scrollTop).toBe(50 * MEASURED_HEIGHT);
+  });
+
+  test("re-places a measured request as the heights sharpen", async () => {
+    const observer = installManualResizeObserver();
+    const { container, menu } = setup();
+    const items = buildItems(300);
+
+    const update = (scrollTop: number) =>
+      menu.update({
+        items,
+        shouldVirtualize: true,
+        virtualize: true,
+        wrapOptions: true,
+        scrollTop,
+      });
+
+    let state = update(0);
+    renderOptions(container, state);
+
+    // Asked for before anything has been measured: the only placement
+    // available rests on the seed.
+    menu.scrollIntoView(50, "top");
+    expect(container.scrollTop).toBe(50 * ITEM_HEIGHT);
+
+    state = update(container.scrollTop);
+    renderOptions(container, state);
+    await menu.sync();
+    await observer.deliverAll();
+
+    state = update(container.scrollTop);
+    renderOptions(container, state);
+    await menu.sync();
+
+    // The request stood, so the option is placed again against what the
+    // options that rendered turned out to measure.
+    expect(container.scrollTop).toBe(50 * MEASURED_HEIGHT);
+  });
+
+  test("brings a nearest option into a measured menu, and only then", async () => {
+    const observer = installManualResizeObserver();
+    const harness = setup();
+    const items = buildItems(300);
+
+    await measure(harness, observer, items);
+
+    // Option 1 is inside the window the measured offsets put on screen, so a
+    // nearest request has nothing to do: the reader is already looking at it.
+    harness.menu.scrollIntoView(1, "nearest");
+    expect(harness.container.scrollTop).toBe(0);
+
+    // Option 50 is far below it, so this one has to move, and it lands on the
+    // offset the measured heights give it rather than the one the seed would.
+    harness.menu.scrollIntoView(50, "nearest");
+
+    const measuredRun = TALL_HEIGHT + 10 * SHORT_HEIGHT;
+    const unmeasured = 39 * (measuredRun / 11);
+    expect(harness.container.scrollTop).toBeCloseTo(
+      measuredRun + unmeasured,
+      6,
+    );
+    expect(harness.container.scrollTop).not.toBe(50 * ITEM_HEIGHT);
+  });
+
+  test("a reader's own scroll supersedes an outstanding request", async () => {
+    const observer = installManualResizeObserver();
+    const { container, menu } = setup();
+    const items = buildItems(300);
+
+    const update = (scrollTop: number) =>
+      menu.update({
+        items,
+        shouldVirtualize: true,
+        virtualize: true,
+        wrapOptions: true,
+        scrollTop,
+      });
+
+    let state = update(0);
+    renderOptions(container, state);
+    menu.scrollIntoView(50, "top");
+
+    container.scrollTop = 900;
+    menu.noteScroll(900);
+
+    state = update(900);
+    renderOptions(container, state);
+    await menu.sync();
+    await observer.deliverAll();
+    state = update(container.scrollTop);
+    renderOptions(container, state);
+    await menu.sync();
+
+    // Nothing pulled the reader back to the option they had been sent to.
+    expect(container.scrollTop).not.toBe(50 * MEASURED_HEIGHT);
+  });
+
+  test("does nothing at all while the menu is not windowed", () => {
+    const { container, menu, scrollTops } = setup();
+
+    menu.update({
+      items: buildItems(300),
+      shouldVirtualize: false,
+      virtualize: undefined,
+      scrollTop: 0,
+    });
+    menu.scrollIntoView(50, "top");
+
+    expect(container.scrollTop).toBe(0);
+    expect(scrollTops).toEqual([]);
+  });
+});
+
+describe("createMenuWindow: the collection the heights describe", () => {
+  test("keeps the measurements when a rebuild holds the same options", async () => {
+    const observer = installManualResizeObserver();
+    const harness = setup();
+    const items = buildItems(300);
+
+    await measure(harness, observer, items);
+    // A filtering menu rebuilds its collection on every keystroke, and most of
+    // those rebuilds arrive at the same options in the same order.
+    update(harness, [...items]);
+
+    expect(placeFifthOption(harness)).toBe(PLACED_ON_MEASURED);
+  });
+
+  test("forgets the measurements when the collection holds other options", async () => {
+    const observer = installManualResizeObserver();
+    const harness = setup();
+
+    await measure(harness, observer, buildItems(300));
+    const replaced = update(harness, buildItems(300, "Other"));
+
+    // Every height described an option that is no longer there. What survives
+    // is the one thing that was never about a particular option: how tall this
+    // consumer's options run.
+    expect(replaced.itemsToRender[0].text).toBe("Other 0");
+    expect(placeFifthOption(harness)).toBeCloseTo(PLACED_ON_ESTIMATE, 6);
+  });
+
+  test("identifies options by the supplied key across a rebuild", async () => {
+    const observer = installManualResizeObserver();
+    const harness = setup();
+    const getKey = (item: Item) => item.id;
+
+    await measure(harness, observer, buildItems(300), getKey);
+    // Every option object is replaced, as a checkbox toggle would replace the
+    // toggled one; the ids are what stayed put, so the heights still describe
+    // the options they were measured on.
+    update(harness, buildItems(300), getKey);
+
+    expect(placeFifthOption(harness)).toBe(PLACED_ON_MEASURED);
+  });
+
+  test("forgets when the keys themselves move", async () => {
+    const observer = installManualResizeObserver();
+    const harness = setup();
+    const getKey = (item: Item) => item.id;
+    const items = buildItems(300);
+
+    await measure(harness, observer, items, getKey);
+    const reordered = update(harness, [...items].reverse(), getKey);
+
+    expect(reordered.itemsToRender[0].id).toBe(299);
+    expect(placeFifthOption(harness)).toBeCloseTo(PLACED_ON_ESTIMATE, 6);
+  });
+
+  test("a rebuilt collection with no key is told apart by the options themselves", async () => {
+    const observer = installManualResizeObserver();
+    const harness = setup();
+
+    await measure(harness, observer, buildItems(300));
+    // No key function, and every option object is new: nothing says these are
+    // the options the heights were measured on.
+    update(harness, buildItems(300));
+
+    expect(placeFifthOption(harness)).toBeCloseTo(PLACED_ON_ESTIMATE, 6);
+  });
+});
+
+describe("createMenuWindow: closing and teardown", () => {
+  test("forgets the measurements on close but keeps the estimate", async () => {
+    const observer = installManualResizeObserver();
+    const harness = setup();
+    const items = buildItems(300);
+
+    await measure(harness, observer, items);
+    expect(placeFifthOption(harness)).toBe(PLACED_ON_MEASURED);
+
+    harness.container.scrollTop = 0;
+    harness.menu.reset();
+    update(harness, items);
+
+    // No option is measured any more, so every one of them takes the estimate,
+    // which is what the last opening averaged to rather than the seed.
+    expect(placeFifthOption(harness)).toBeCloseTo(PLACED_ON_ESTIMATE, 6);
+  });
+
+  test("has nothing to say about an unmeasured list on close", () => {
+    const harness = setup();
+    const items = buildItems(300);
+
+    update(harness, items);
+    const before = harness.changeCount;
+    harness.menu.reset();
+
+    // Not zero, and not the consumer's seed echoed back: no evidence at all,
+    // which leaves the seed in charge and gives the caller nothing to hear.
+    expect(harness.changeCount).toBe(before);
+    expect(update(harness, items).totalHeight).toBe(300 * ITEM_HEIGHT);
+  });
+
+  test("a close that learns nothing new is not news for the caller", async () => {
+    const observer = installManualResizeObserver();
+    const harness = setup();
+    const items = buildItems(300);
+
+    await measure(harness, observer, items);
+    harness.menu.reset();
+
+    const before = harness.changeCount;
+    harness.menu.reset();
+
+    // Nothing has been measured since, so there is nothing new to say.
+    expect(harness.changeCount).toBe(before);
+  });
+
+  test("stops observing once torn down", async () => {
+    const observer = installManualResizeObserver();
+    const harness = setup();
+    const items = buildItems(300);
+
+    const state = harness.menu.update({
+      items,
+      shouldVirtualize: true,
+      virtualize: true,
+      wrapOptions: true,
+      scrollTop: 0,
+    });
+    renderOptions(harness.container, state);
+    await harness.menu.sync();
+
+    harness.menu.destroy();
+    const before = harness.changeCount;
+    await observer.deliverAll();
+    await tick();
+
+    expect(harness.changeCount).toBe(before);
+    expect(
+      harness.menu.update({
+        items,
+        shouldVirtualize: true,
+        virtualize: true,
+        wrapOptions: true,
+        scrollTop: 0,
+      }).totalHeight,
+    ).toBe(300 * ITEM_HEIGHT);
+  });
+});
+
+/**
+ * Every case below arrived with `createMeasuredMenuScroll`, whose suite this
+ * absorbed when the module was. They ask the same questions of the menu
+ * window's own interface: the metrics that used to be handed across the seam
+ * are now the ones the last `update` resolved, and the requests are the ones
+ * `scrollIntoView` leaves outstanding.
+ */
+describe("createMenuWindow: the measured scroll position", () => {
+  /**
+   * A measured menu whose options sit where their own heights put them, so the
+   * fixture can disagree with the windowing arithmetic about how tall an
+   * option rendered. That disagreement is the subject: it is what the offsets
+   * cannot see and the rects can.
+   */
+  function setupPlaced({
+    optionHeights = {},
+    defaultHeight = ITEM_HEIGHT,
+    itemCount = 300,
+  }: {
+    /** Rendered height by item index; anything omitted is `defaultHeight`. */
+    optionHeights?: Record<number, number>;
+    defaultHeight?: number;
+    itemCount?: number;
+  } = {}) {
+    const items = buildItems(itemCount);
+    const heightOf = (index: number) => optionHeights[index] ?? defaultHeight;
+    const topOf = (index: number) => {
+      let top = 0;
+      for (let i = 0; i < index; i++) top += heightOf(i);
+      return top;
+    };
+    const scrollHeight = topOf(itemCount);
+    const maxScroll = Math.max(0, scrollHeight - CONTAINER_HEIGHT);
+
+    const container = document.createElement("div");
+    // The menu's own scroll container, which is what bounds the one adjustment
+    // only the DOM can work out.
+    container.setAttribute("role", "listbox");
+    Object.defineProperty(container, "clientHeight", {
+      value: CONTAINER_HEIGHT,
+      configurable: true,
+    });
+    Object.defineProperty(container, "scrollHeight", {
+      value: scrollHeight,
+      configurable: true,
+    });
+    let scrollTop = 0;
+    Object.defineProperty(container, "scrollTop", {
+      get: () => scrollTop,
+      set: (next: number) => {
+        scrollTop = Math.max(0, Math.min(next, maxScroll));
+      },
+      configurable: true,
+    });
+    container.getBoundingClientRect = () =>
+      ({ top: 0, bottom: CONTAINER_HEIGHT }) as DOMRect;
+    document.body.appendChild(container);
+
+    const scrollTops: number[] = [];
+    const menu = createMenuWindow<Item>({
+      getContainer: () => container,
+      onScrollTop: (next) => scrollTops.push(next),
+    });
+
+    /** Resolve the window at the menu's current position and render it. */
+    function render(collection: Item[] = items) {
+      const state = menu.update({
+        items: collection,
+        shouldVirtualize: true,
+        virtualize: true,
+        wrapOptions: true,
+        scrollTop: container.scrollTop,
+      });
+      container.innerHTML = "";
+      state.itemsToRender.forEach((item, index) => {
+        const itemIndex = state.startIndex + index;
+        const height = heightOf(itemIndex);
+        const option = document.createElement("div");
+        option.setAttribute(VIRTUAL_INDEX_ATTRIBUTE, String(itemIndex));
+        option.textContent = item.text;
+        option.getBoundingClientRect = () =>
+          ({
+            top: topOf(itemIndex) - container.scrollTop,
+            bottom: topOf(itemIndex) - container.scrollTop + height,
+            height,
+          }) as DOMRect;
+        const marker = document.createElement("span");
+        marker.setAttribute("data-measured-height", String(height));
+        option.appendChild(marker);
+        container.appendChild(option);
+      });
+      return state;
+    }
+
+    return { container, menu, scrollTops, maxScroll, render };
+  }
+
+  test("finishes a settled request by asking the DOM about the option itself", async () => {
+    // The option is mounted and the offsets agree with the arithmetic, but it
+    // is eight times the assumed height and hangs past the viewport. Nothing
+    // but its own rect can say so.
+    installManualResizeObserver();
+    const { container, menu, render } = setupPlaced({
+      optionHeights: { 2: 320 },
+    });
+    render();
+
+    menu.scrollIntoView(2, "nearest");
+    // Already inside the rendered window, so the arithmetic leaves it alone.
+    expect(container.scrollTop).toBe(0);
+
+    await menu.sync();
+
+    // Option 2 spans 80..400 of a 300-tall viewport, so 100 brings its bottom
+    // flush with the bottom of the menu.
+    expect(container.scrollTop).toBe(100);
+  });
+
+  test("keeps a request through the scroll event its own write produced", async () => {
+    installManualResizeObserver();
+    const { container, menu, render } = setupPlaced({
+      optionHeights: { 2: 320 },
+    });
+    render();
+
+    menu.scrollIntoView(2, "nearest");
+    menu.noteScroll(container.scrollTop);
+    await menu.sync();
+
+    expect(container.scrollTop).toBe(100);
+  });
+
+  test("a close drops the request so nothing re-places the option", async () => {
+    installManualResizeObserver();
+    const { container, menu, render } = setupPlaced({
+      optionHeights: { 2: 320 },
+    });
+    render();
+
+    menu.scrollIntoView(2, "nearest");
+    menu.reset();
+    await menu.sync();
+
+    expect(container.scrollTop).toBe(0);
+  });
+
+  test("tearing down drops the request too", async () => {
+    installManualResizeObserver();
+    const { container, menu, render } = setupPlaced({
+      optionHeights: { 2: 320 },
+    });
+    render();
+
+    menu.scrollIntoView(2, "nearest");
+    menu.destroy();
+    await menu.sync();
+
+    expect(container.scrollTop).toBe(0);
+  });
+
+  test("a changed collection drops the outstanding request", async () => {
+    installManualResizeObserver();
+    const { container, menu, render } = setupPlaced({
+      optionHeights: { 2: 320 },
+    });
+    render();
+
+    menu.scrollIntoView(2, "nearest");
+    // Index 2 named a different option before the collection changed, so the
+    // request cannot be carried over to whatever is at that position now.
+    render(buildItems(300, "Other"));
+    await menu.sync();
+
+    // Left alone, the request would have gone on to bring the option flush
+    // with the bottom of the menu.
+    expect(container.scrollTop).toBe(0);
+  });
+
+  test("holds the reader's place when the options above them measure taller", async () => {
+    const observer = installManualResizeObserver();
+    const { container, menu, render } = setupPlaced({
+      defaultHeight: MEASURED_HEIGHT,
+    });
+    container.scrollTop = 400;
+    render();
+
+    await menu.sync();
+    await observer.deliverAll();
+
+    // The options above the viewport rendered taller than the seed assumed, so
+    // everything below them moved; the position is corrected by the same
+    // amount so nothing shifts on screen.
+    expect(container.scrollTop).not.toBe(400);
+  });
+
+  test("leaves the scroll position alone when the measurements are forgotten", async () => {
+    const observer = installManualResizeObserver();
+    const { container, menu, render } = setupPlaced({
+      defaultHeight: MEASURED_HEIGHT,
+    });
+    container.scrollTop = 400;
+    render();
+
+    await menu.sync();
+    await observer.deliverAll();
+    const held = container.scrollTop;
+    expect(held).not.toBe(400);
+
+    menu.reset();
+
+    // Forgetting the heights is not news that anything on screen moved, so
+    // there is no place to hold; correcting against nothing would jerk the
+    // reader for no reason.
+    expect(container.scrollTop).toBe(held);
+  });
+});
+
+/**
+ * A list that resolved measured heights but was never windowed, which
+ * `shouldVirtualizeMenu` reaches for any list at all once the consumer supplies
+ * the `virtualize` prop: the threshold gate says yes on the count the *caller*
+ * holds, while `virtualize` reports `isVirtualized: false` under 100 options.
+ * So `isMeasured` is true and `isMeasuredWindow` is false, and the components
+ * still route their opening and keyboard placements here, their own
+ * DOM-placing fallback being gated on `!shouldVirtualize`.
+ *
+ * Nothing measured is on hand to place against, and none is coming: the
+ * measurer is not observing below the threshold. What is on hand is every
+ * option, rendered and laid out by the browser, so placement reads the DOM
+ * exactly, wrapping included.
+ */
+describe("createMenuWindow: measured, below the threshold", () => {
+  const UNWINDOWED_COUNT = 50;
+
+  /**
+   * A menu that scrolls and whose options sit where a browser would put them:
+   * stacked at `ITEM_HEIGHT`, moving under the container as it scrolls.
+   * `buildContainer` leaves both out, the cases above placing by arithmetic
+   * without ever asking the DOM. `scrollIntoViewWithinMenu` needs both, since
+   * it reads rects and gives up on a menu that cannot scroll.
+   */
+  function setupUnwindowed() {
+    const harness = setup();
+    const { container, menu } = harness;
+    const items = buildItems(UNWINDOWED_COUNT);
+
+    container.setAttribute("role", "listbox");
+    Object.defineProperty(container, "scrollHeight", {
+      value: UNWINDOWED_COUNT * ITEM_HEIGHT,
+      configurable: true,
+    });
+
+    const state = menu.update({
+      items,
+      shouldVirtualize: true,
+      virtualize: true,
+      wrapOptions: true,
+      scrollTop: container.scrollTop,
+    });
+
+    // The premise every case here rests on: measured heights resolved, no
+    // window to hold them.
+    expect(state.isMeasured).toBe(true);
+    expect(state.isVirtualized).toBe(false);
+    expect(state.itemsToRender).toHaveLength(UNWINDOWED_COUNT);
+
+    renderOptions(container, state);
+    Array.from(container.children).forEach((child, index) => {
+      const option = child as HTMLElement;
+      option.getBoundingClientRect = () => {
+        const top = index * ITEM_HEIGHT - container.scrollTop;
+        return {
+          top,
+          bottom: top + ITEM_HEIGHT,
+          height: ITEM_HEIGHT,
+        } as DOMRect;
+      };
+    });
+
+    return harness;
+  }
+
+  test("places a top-aligned option where the DOM has it", () => {
+    const { container, menu } = setupUnwindowed();
+
+    menu.scrollIntoView(5, "top");
+
+    expect(container.scrollTop).toBe(5 * ITEM_HEIGHT);
+  });
+
+  test("brings a nearest option off the window into view", () => {
+    const { container, menu } = setupUnwindowed();
+
+    menu.scrollIntoView(20, "nearest");
+
+    // Option 20 runs to 840 against a viewport 300 tall, so it comes up to sit
+    // against the bottom edge rather than the top.
+    expect(container.scrollTop).toBe(21 * ITEM_HEIGHT - CONTAINER_HEIGHT);
+  });
+
+  test("leaves a nearest option already on screen alone", () => {
+    const { container, menu, scrollTops } = setupUnwindowed();
+
+    menu.scrollIntoView(2, "nearest");
+
+    expect(container.scrollTop).toBe(0);
+    expect(scrollTops).toEqual([]);
+  });
+
+  test("sends the menu to the top when there is nothing to show", () => {
+    const { container, menu } = setupUnwindowed();
+    container.scrollTop = 400;
+
+    menu.scrollIntoView(-1, "top");
+
+    expect(container.scrollTop).toBe(0);
+  });
+
+  test("reports the position it took, so the caller's mirror keeps up", () => {
+    const { menu, scrollTops } = setupUnwindowed();
+
+    menu.scrollIntoView(5, "top");
+
+    expect(scrollTops.at(-1)).toBe(5 * ITEM_HEIGHT);
+  });
+});

--- a/tests/MultiSelect/MultiSelect.test.svelte
+++ b/tests/MultiSelect/MultiSelect.test.svelte
@@ -43,6 +43,7 @@
   export let helperText: ComponentProps<MultiSelect>["helperText"] = "";
   export let virtualize: ComponentProps<MultiSelect>["virtualize"] = undefined;
   export let portalMenu: ComponentProps<MultiSelect>["portalMenu"] = false;
+  export let wrapOptions: ComponentProps<MultiSelect>["wrapOptions"] = false;
   export let sortItem: ComponentProps<MultiSelect>["sortItem"] = undefined;
   export let open: ComponentProps<MultiSelect>["open"] = undefined;
   export let ariaLabel: ComponentProps<MultiSelect>["aria-label"] = undefined;
@@ -84,6 +85,7 @@
   {helperText}
   {virtualize}
   {portalMenu}
+  {wrapOptions}
   {sortItem}
   {open}
   {fluid}

--- a/tests/MultiSelect/MultiSelectMeasured.test.svelte
+++ b/tests/MultiSelect/MultiSelectMeasured.test.svelte
@@ -1,0 +1,48 @@
+<script lang="ts">
+  import MultiSelect from "carbon-components-svelte/MultiSelect/MultiSelect.svelte";
+  import type { ComponentProps } from "svelte";
+
+  type MeasuredItem = {
+    id: string;
+    text: string;
+    height: number;
+    isSelectAll?: boolean;
+  };
+
+  export let items: MeasuredItem[] = [];
+  export let selectedIds: string[] = [];
+  export let virtualize: ComponentProps<MultiSelect>["virtualize"] = undefined;
+  export let wrapOptions: ComponentProps<MultiSelect>["wrapOptions"] = false;
+  export let filterable = false;
+  export let selectionFeedback: ComponentProps<MultiSelect>["selectionFeedback"] =
+    "top-after-reopen";
+  /**
+   * Input order by default, so a test that says nothing about ordering reads
+   * the same list it declared. The default comparator sorts by text, which
+   * would put every assertion about a position at one remove from the fixture.
+   */
+  export let sortItem: (a: MeasuredItem, b: MeasuredItem) => number = () => 0;
+
+  let value = "";
+</script>
+
+<!-- The height each option renders at travels on the option itself, so the
+     suite's stubbed ResizeObserver can report a different one per item — which
+     is the only way heights held against the wrong option are observable. -->
+<MultiSelect
+  labelText="Items"
+  label="Items"
+  placeholder="Filter…"
+  portalMenu={false}
+  {items}
+  {filterable}
+  {selectionFeedback}
+  {sortItem}
+  {virtualize}
+  {wrapOptions}
+  bind:value
+  bind:selectedIds
+  let:item
+>
+  <span data-measured-height={item.height}>{item.text}</span>
+</MultiSelect>

--- a/tests/MultiSelect/MultiSelectMenuWindow.test.ts
+++ b/tests/MultiSelect/MultiSelectMenuWindow.test.ts
@@ -1,0 +1,290 @@
+import { render, screen, waitFor } from "@testing-library/svelte";
+import { stubPerOptionResizeObserver } from "../utils/stubPerOptionResizeObserver";
+import { user } from "../utils/user";
+import MultiSelect from "./MultiSelect.test.svelte";
+import MeasuredMultiSelect from "./MultiSelectMeasured.test.svelte";
+
+/**
+ * What is left of this component's measured-menu coverage once the behaviour
+ * lives in one place.
+ *
+ * Offsets across the windowing threshold, both scroll alignments, the identity
+ * of the options a height was measured on, wrapping being the only thing that
+ * turns measuring on, and what a close forgets are all asserted against
+ * `createMenuWindow` in tests/ListBox/menuWindow.test.ts. What is left
+ * here is that this component is connected to it: the wrapping prop reaches
+ * the menu, options are stamped for measurement only when heights are being
+ * measured, and the identity key it supplies is the one its collection needs,
+ * every check rebuilding those options. The wrapping itself, the checkbox
+ * staying with the first line of its label, and the select-all separator
+ * surviving are asserted in e2e/reflow.test.ts.
+ */
+
+// The suite's ResizeObserver stub reports 100px for every element it observes,
+// so a measured list renders 100px rows against a 40px assumption. A scroll
+// height built from 100 rather than 40 is one built from measured heights.
+const MEASURED_HEIGHT = 100;
+const WINDOWED_COUNT = 120;
+const UNWINDOWED_COUNT = 10;
+
+const ITEM_HEIGHT = 40;
+const CONTAINER_HEIGHT = 200;
+const windowed = {
+  threshold: 1,
+  itemHeight: ITEM_HEIGHT,
+  containerHeight: CONTAINER_HEIGHT,
+};
+
+function makeItems(count: number) {
+  return Array.from({ length: count }, (_, index) => ({
+    id: String(index),
+    text: `Item ${index + 1}`,
+  }));
+}
+
+/**
+ * A list whose select-all row is far taller than every other option, so a
+ * scroll position just past it lands somewhere no single assumed height would
+ * have put it. What is on screen there is evidence about the offsets
+ * themselves, which a total taken over the same heights would not be.
+ */
+const UNEVEN_TALL = 400;
+const UNEVEN_SHORT = 40;
+const unevenItems = [
+  { id: "all", text: "Select all", height: UNEVEN_TALL, isSelectAll: true },
+  ...Array.from({ length: 10 }, (_, index) => ({
+    id: String(index),
+    text: `Item ${index + 1}`,
+    height: UNEVEN_SHORT,
+  })),
+];
+
+/**
+ * Narrow enough that only the options on screen are ever measured, wide enough
+ * that the select-all row stays rendered from a scroll position below it.
+ */
+const partlyWindowed = { ...windowed, overscan: 1 };
+
+function field() {
+  return screen.getByRole("combobox");
+}
+
+function menu() {
+  return screen.getByRole("listbox");
+}
+
+function menuScrollSpacer() {
+  return menu().querySelector<HTMLElement>(":scope > div");
+}
+
+/** The spacer's height is the menu's whole scrollable length. */
+function menuScrollHeight() {
+  return menuScrollSpacer()?.style.height;
+}
+
+/**
+ * Wait until the menu's length stops moving. Measurement arrives in batches
+ * and each batch can sharpen the offsets, so a reading taken on the first one
+ * is not yet the settled one.
+ */
+async function waitForSettledOffsets() {
+  let previous: string | undefined;
+  await waitFor(() => {
+    const current = menuScrollHeight();
+    const settled = current !== undefined && current === previous;
+    previous = current;
+    expect(settled).toBe(true);
+  });
+}
+
+/** Option text in rendered order, trimmed of any surrounding whitespace. */
+function optionTexts() {
+  return screen
+    .queryAllByRole("option")
+    .map((option) => option.textContent?.trim() ?? "");
+}
+
+describe("MultiSelect menu window wiring", () => {
+  it("marks the menu so the option wrap styles reach its options", async () => {
+    render(MultiSelect, {
+      props: {
+        items: makeItems(UNWINDOWED_COUNT),
+        labelText: "Items",
+        wrapOptions: true,
+      },
+    });
+
+    await user.click(field());
+
+    expect(menu()).toHaveClass("bx--list-box__menu--wrap-options");
+  });
+
+  it("marks a portaled menu, which a class on the component root could not reach", async () => {
+    render(MultiSelect, {
+      props: {
+        items: makeItems(UNWINDOWED_COUNT),
+        labelText: "Items",
+        wrapOptions: true,
+        portalMenu: true,
+      },
+    });
+
+    await user.click(field());
+
+    const portaled = menu();
+    expect(portaled.closest("[data-floating-portal]")).toBeInTheDocument();
+    expect(portaled).toHaveClass("bx--list-box__menu--wrap-options");
+  });
+
+  it("renders the menu as it does today when the prop is not set", async () => {
+    render(MultiSelect, {
+      props: { items: makeItems(UNWINDOWED_COUNT), labelText: "Items" },
+    });
+
+    await user.click(field());
+
+    expect(menu()).not.toHaveClass("bx--list-box__menu--wrap-options");
+    expect(screen.getAllByRole("option")[0]).not.toHaveAttribute(
+      "data-virtual-index",
+    );
+  });
+
+  it("puts a list it windows itself on the measured path under the prop", async () => {
+    render(MultiSelect, {
+      props: {
+        items: makeItems(WINDOWED_COUNT),
+        labelText: "Items",
+        wrapOptions: true,
+      },
+    });
+
+    await user.click(field());
+
+    // The prop reaches the menu window, not just the stylesheet: the offsets
+    // are built from what the options measured rather than from the seed.
+    await expect
+      .poll(() => menuScrollSpacer()?.style.height)
+      .toBe(`${WINDOWED_COUNT * MEASURED_HEIGHT}px`);
+  });
+
+  it("marks options with their item index only when wrapping measures them", async () => {
+    const items = makeItems(UNWINDOWED_COUNT);
+    const { unmount } = render(MultiSelect, {
+      props: {
+        items,
+        labelText: "Items",
+        virtualize: windowed,
+        wrapOptions: true,
+      },
+    });
+
+    await user.click(field());
+    const measuredOptions = screen.getAllByRole("option");
+    expect(measuredOptions[0]).toHaveAttribute("data-virtual-index", "0");
+    expect(measuredOptions[1]).toHaveAttribute("data-virtual-index", "1");
+    unmount();
+
+    render(MultiSelect, {
+      props: {
+        items,
+        labelText: "Items",
+        virtualize: windowed,
+      },
+    });
+    await user.click(field());
+
+    expect(screen.getAllByRole("option")[0]).not.toHaveAttribute(
+      "data-virtual-index",
+    );
+  });
+
+  // A `virtualize` object resolves a config below the threshold too, so the
+  // menu scrolls within `containerHeight` while rendering whole. Bringing an
+  // option into view there is the one path that reads the DOM back, by this
+  // attribute, so leaving those options unstamped strands the keyboard
+  // highlight off screen.
+  it("marks options of a measured list too short to window", async () => {
+    render(MultiSelect, {
+      props: {
+        items: makeItems(UNWINDOWED_COUNT),
+        labelText: "Items",
+        virtualize: { ...windowed, threshold: UNWINDOWED_COUNT + 1 },
+        wrapOptions: true,
+      },
+    });
+
+    await user.click(field());
+
+    const options = screen.getAllByRole("option");
+    expect(options).toHaveLength(UNWINDOWED_COUNT);
+    expect(options[0]).toHaveAttribute("data-virtual-index", "0");
+    expect(options.at(-1)).toHaveAttribute(
+      "data-virtual-index",
+      String(UNWINDOWED_COUNT - 1),
+    );
+  });
+
+  describe("the collection the menu window measures", () => {
+    beforeEach(() => {
+      stubPerOptionResizeObserver();
+    });
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    it("supplies the identity key its rebuilt collection needs", async () => {
+      render(MeasuredMultiSelect, {
+        props: {
+          items: unevenItems,
+          virtualize: partlyWindowed,
+          wrapOptions: true,
+        },
+      });
+
+      await user.click(field());
+      await waitFor(() => {
+        expect(optionTexts().length).toBeGreaterThan(1);
+      });
+      // Before scrolling, not only before reading: a position is only "past
+      // the select-all row" once the row has been measured, and a batch is
+      // reported on the frame after the observer sees it. Scrolling against
+      // the seed instead would land somewhere else and be held there, the
+      // correction's job being to keep whatever is on screen on screen.
+      await waitForSettledOffsets();
+
+      // Just past the tall select-all row, which is an option of this
+      // collection like any other and was measured as one: a list that had
+      // assumed a height for it would be showing something else here.
+      const scroller = menu();
+      scroller.scrollTop = UNEVEN_TALL;
+      scroller.dispatchEvent(new Event("scroll"));
+      await waitFor(() => {
+        expect(optionTexts()[1]).toBe("Item 1");
+      });
+      await waitForSettledOffsets();
+      const settled = {
+        scrollHeight: menuScrollHeight(),
+        scrollTop: scroller.scrollTop,
+        texts: optionTexts(),
+      };
+      expect(settled.texts[0]).toBe("Select all");
+
+      // Select-all rebuilds every option in the list at once, which is the
+      // sharpest version of the question the key answers: a re-check is not a
+      // re-order, no matter how much of the collection it replaces. The ids
+      // stayed put, so the heights still describe the options they were
+      // measured on and the reader is left looking at the same options in the
+      // same places.
+      await user.click(screen.getByText("Select all"));
+
+      await waitFor(() => {
+        expect(screen.getByLabelText("Item 1")).toBeChecked();
+      });
+      await waitForSettledOffsets();
+      expect(optionTexts()).toEqual(settled.texts);
+      expect(menuScrollHeight()).toBe(settled.scrollHeight);
+      expect(scroller.scrollTop).toBe(settled.scrollTop);
+    });
+  });
+});

--- a/tests/utils/heightMeasurer.test.ts
+++ b/tests/utils/heightMeasurer.test.ts
@@ -1,0 +1,423 @@
+import {
+  createHeightMeasurer,
+  VIRTUAL_INDEX_ATTRIBUTE,
+} from "../../src/utils/heightMeasurer.js";
+
+/** A rendered window: one element per item index, inside a scroll container. */
+function buildWindow(indices: number[]) {
+  const container = document.createElement("div");
+  for (const index of indices) {
+    const element = document.createElement("div");
+    element.setAttribute(VIRTUAL_INDEX_ATTRIBUTE, String(index));
+    container.appendChild(element);
+  }
+  document.body.appendChild(container);
+  return container;
+}
+
+function optionAt(container: Element, index: number) {
+  const element = container.querySelector(
+    `[${VIRTUAL_INDEX_ATTRIBUTE}="${index}"]`,
+  );
+  if (!(element instanceof HTMLElement)) {
+    throw new Error(`no element for index ${index}`);
+  }
+  return element;
+}
+
+/** The measurer holds a batch until the next frame; this is that frame. */
+function nextFrame() {
+  return new Promise<void>((resolve) => {
+    requestAnimationFrame(() => resolve());
+  });
+}
+
+/**
+ * Replace the global `ResizeObserver` with one whose batches this test
+ * delivers by hand, so heights can differ per element and arrive on demand.
+ *
+ * `deliver` resolves on the frame after the batch, when the measurer reports
+ * it. `deliverWithoutFrame` stops short of that frame, for a test looking at
+ * the state in between.
+ */
+function installResizeObserver() {
+  const instances: FakeResizeObserver[] = [];
+
+  class FakeResizeObserver {
+    callback: ResizeObserverCallback;
+    observed = new Set<Element>();
+
+    constructor(callback: ResizeObserverCallback) {
+      this.callback = callback;
+      instances.push(this);
+    }
+
+    observe(element: Element) {
+      this.observed.add(element);
+    }
+
+    unobserve(element: Element) {
+      this.observed.delete(element);
+    }
+
+    disconnect() {
+      this.observed.clear();
+    }
+  }
+
+  vi.stubGlobal("ResizeObserver", FakeResizeObserver);
+
+  function current() {
+    const instance = instances.at(-1);
+    if (!instance) throw new Error("no ResizeObserver was constructed");
+    return instance;
+  }
+
+  return {
+    get observed() {
+      return instances.length === 0 ? new Set<Element>() : current().observed;
+    },
+    get instanceCount() {
+      return instances.length;
+    },
+    deliverWithoutFrame(
+      measurements: Array<{ target: Element; height: number }>,
+    ) {
+      const instance = current();
+      instance.callback(
+        measurements.map(({ target, height }) => ({
+          target,
+          contentRect: { height } as DOMRectReadOnly,
+          borderBoxSize: [{ blockSize: height, inlineSize: 0 }],
+          contentBoxSize: [],
+          devicePixelContentBoxSize: [],
+        })) as unknown as ResizeObserverEntry[],
+        instance as unknown as ResizeObserver,
+      );
+    },
+    deliver(measurements: Array<{ target: Element; height: number }>) {
+      this.deliverWithoutFrame(measurements);
+      return nextFrame();
+    },
+  };
+}
+
+describe("createHeightMeasurer", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    document.body.innerHTML = "";
+  });
+
+  test("reports each measured height against the item it renders", async () => {
+    const resize = installResizeObserver();
+    const onMeasure = vi.fn();
+    const measurer = createHeightMeasurer({ onMeasure });
+    const container = buildWindow([10, 11, 12]);
+
+    measurer.sync(container);
+    expect(onMeasure).not.toHaveBeenCalled();
+
+    await resize.deliver([
+      { target: optionAt(container, 10), height: 40 },
+      { target: optionAt(container, 11), height: 96 },
+      { target: optionAt(container, 12), height: 64 },
+    ]);
+
+    expect(onMeasure).toHaveBeenCalledTimes(1);
+    const [heights, previousHeights] = onMeasure.mock.calls[0];
+    expect(heights[10]).toBe(40);
+    expect(heights[11]).toBe(96);
+    expect(heights[12]).toBe(64);
+    expect(heights[9]).toBeUndefined();
+    expect(previousHeights).toHaveLength(0);
+  });
+
+  test("reports nothing from inside the observer's own callback", async () => {
+    const resize = installResizeObserver();
+    const onMeasure = vi.fn();
+    const measurer = createHeightMeasurer({ onMeasure });
+    const container = buildWindow([0]);
+
+    measurer.sync(container);
+    // Acting on a height moves the window, and doing that during a delivery
+    // leaves the browser with observations it cannot deliver in that pass,
+    // reported as an uncatchable window error on every scroll of a measured
+    // menu. So nothing is reported until the callback has returned.
+    resize.deliverWithoutFrame([
+      { target: optionAt(container, 0), height: 40 },
+    ]);
+    expect(onMeasure).not.toHaveBeenCalled();
+
+    await nextFrame();
+
+    expect(onMeasure).toHaveBeenCalledTimes(1);
+    expect(onMeasure.mock.calls[0][0][0]).toBe(40);
+  });
+
+  test("reports the batches of one frame as a single measurement", async () => {
+    const resize = installResizeObserver();
+    const onMeasure = vi.fn();
+    const measurer = createHeightMeasurer({ onMeasure });
+    const container = buildWindow([0, 1]);
+
+    measurer.sync(container);
+    // One scroll delivers its options in several batches. Accumulating the
+    // offsets once for all of them beats once per batch.
+    resize.deliverWithoutFrame([
+      { target: optionAt(container, 0), height: 40 },
+    ]);
+    resize.deliverWithoutFrame([
+      { target: optionAt(container, 1), height: 96 },
+    ]);
+    resize.deliverWithoutFrame([
+      { target: optionAt(container, 1), height: 88 },
+    ]);
+
+    await nextFrame();
+
+    expect(onMeasure).toHaveBeenCalledTimes(1);
+    const [heights] = onMeasure.mock.calls[0];
+    expect(heights[0]).toBe(40);
+    // The later report of an option supersedes the earlier one.
+    expect(heights[1]).toBe(88);
+  });
+
+  test("drops a batch the frame has not reported when heights are forgotten", async () => {
+    const resize = installResizeObserver();
+    const onMeasure = vi.fn();
+    const measurer = createHeightMeasurer({ onMeasure });
+    const container = buildWindow([0]);
+
+    measurer.sync(container);
+    resize.deliverWithoutFrame([
+      { target: optionAt(container, 0), height: 40 },
+    ]);
+    // A filter keystroke between the batch and its frame: heights are held by
+    // position, so this one now describes whichever option took position 0.
+    measurer.clear();
+
+    await nextFrame();
+
+    expect(onMeasure).not.toHaveBeenCalled();
+  });
+
+  test("treats a height of zero as measured", async () => {
+    const resize = installResizeObserver();
+    const onMeasure = vi.fn();
+    const measurer = createHeightMeasurer({ onMeasure });
+    const container = buildWindow([0]);
+
+    measurer.sync(container);
+    await resize.deliver([{ target: optionAt(container, 0), height: 0 }]);
+
+    expect(onMeasure).toHaveBeenCalledTimes(1);
+    expect(onMeasure.mock.calls[0][0][0]).toBe(0);
+  });
+
+  test("reports nothing when the delivered heights are unchanged", async () => {
+    const resize = installResizeObserver();
+    const onMeasure = vi.fn();
+    const measurer = createHeightMeasurer({ onMeasure });
+    const container = buildWindow([0, 1]);
+
+    measurer.sync(container);
+    await resize.deliver([
+      { target: optionAt(container, 0), height: 40 },
+      { target: optionAt(container, 1), height: 40 },
+    ]);
+    expect(onMeasure).toHaveBeenCalledTimes(1);
+
+    await resize.deliver([
+      { target: optionAt(container, 0), height: 40 },
+      { target: optionAt(container, 1), height: 40 },
+    ]);
+    expect(onMeasure).toHaveBeenCalledTimes(1);
+  });
+
+  test("keeps heights measured earlier when a later batch changes one", async () => {
+    const resize = installResizeObserver();
+    const onMeasure = vi.fn();
+    const measurer = createHeightMeasurer({ onMeasure });
+    const container = buildWindow([0, 1]);
+
+    measurer.sync(container);
+    await resize.deliver([
+      { target: optionAt(container, 0), height: 40 },
+      { target: optionAt(container, 1), height: 80 },
+    ]);
+    await resize.deliver([{ target: optionAt(container, 1), height: 120 }]);
+
+    expect(onMeasure).toHaveBeenCalledTimes(2);
+    const [heights, previousHeights] = onMeasure.mock.calls[1];
+    expect(heights[0]).toBe(40);
+    expect(heights[1]).toBe(120);
+    expect(previousHeights[1]).toBe(80);
+  });
+
+  test("ignores a height reported for an element that has left the DOM", async () => {
+    const resize = installResizeObserver();
+    const onMeasure = vi.fn();
+    const measurer = createHeightMeasurer({ onMeasure });
+    const container = buildWindow([0, 1]);
+
+    measurer.sync(container);
+    await resize.deliver([
+      { target: optionAt(container, 0), height: 40 },
+      { target: optionAt(container, 1), height: 40 },
+    ]);
+    expect(onMeasure).toHaveBeenCalledTimes(1);
+
+    // Scrolling an element out of the window is reported as a resize to
+    // nothing on its way out. That is news of the removal, not a height.
+    const leaving = optionAt(container, 1);
+    leaving.remove();
+    await resize.deliver([{ target: leaving, height: 0 }]);
+
+    expect(onMeasure).toHaveBeenCalledTimes(1);
+  });
+
+  test("ignores a height reported after the element stopped being observed", async () => {
+    const resize = installResizeObserver();
+    const onMeasure = vi.fn();
+    const measurer = createHeightMeasurer({ onMeasure });
+    const container = buildWindow([0]);
+    const option = optionAt(container, 0);
+
+    measurer.sync(container);
+    measurer.sync(null);
+    await resize.deliver([{ target: option, height: 40 }]);
+
+    expect(onMeasure).not.toHaveBeenCalled();
+  });
+
+  test("ignores elements carrying no usable index", async () => {
+    const resize = installResizeObserver();
+    const onMeasure = vi.fn();
+    const measurer = createHeightMeasurer({ onMeasure });
+    const container = buildWindow([0]);
+
+    const blank = document.createElement("div");
+    blank.setAttribute(VIRTUAL_INDEX_ATTRIBUTE, "");
+    const fractional = document.createElement("div");
+    fractional.setAttribute(VIRTUAL_INDEX_ATTRIBUTE, "1.5");
+    const negative = document.createElement("div");
+    negative.setAttribute(VIRTUAL_INDEX_ATTRIBUTE, "-1");
+    container.append(blank, fractional, negative);
+
+    measurer.sync(container);
+    await resize.deliver([
+      { target: blank, height: 40 },
+      { target: fractional, height: 40 },
+      { target: negative, height: 40 },
+    ]);
+
+    expect(onMeasure).not.toHaveBeenCalled();
+  });
+
+  test("observes only the options currently in the rendered window", () => {
+    const resize = installResizeObserver();
+    const measurer = createHeightMeasurer({ onMeasure: vi.fn() });
+    const container = buildWindow([0, 1, 2]);
+
+    measurer.sync(container);
+    expect(resize.observed.size).toBe(3);
+    const stillRendered = optionAt(container, 2);
+
+    optionAt(container, 0).remove();
+    optionAt(container, 1).remove();
+    const element = document.createElement("div");
+    element.setAttribute(VIRTUAL_INDEX_ATTRIBUTE, "3");
+    container.appendChild(element);
+
+    measurer.sync(container);
+
+    expect(resize.observed.size).toBe(2);
+    expect(resize.observed.has(stillRendered)).toBe(true);
+    expect(resize.observed.has(element)).toBe(true);
+    // The observer is shared across the window, not one per option.
+    expect(resize.instanceCount).toBe(1);
+  });
+
+  test("stops observing when the window goes away", () => {
+    const resize = installResizeObserver();
+    const measurer = createHeightMeasurer({ onMeasure: vi.fn() });
+    const container = buildWindow([0, 1]);
+
+    measurer.sync(container);
+    expect(resize.observed.size).toBe(2);
+
+    measurer.sync(null);
+
+    expect(resize.observed.size).toBe(0);
+  });
+
+  test("clear reports an empty set of heights exactly once", async () => {
+    const resize = installResizeObserver();
+    const onMeasure = vi.fn();
+    const measurer = createHeightMeasurer({ onMeasure });
+    const container = buildWindow([0]);
+
+    measurer.sync(container);
+    await resize.deliver([{ target: optionAt(container, 0), height: 40 }]);
+
+    measurer.clear();
+    expect(onMeasure).toHaveBeenCalledTimes(2);
+    expect(onMeasure.mock.calls[1][0]).toHaveLength(0);
+    expect(onMeasure.mock.calls[1][1][0]).toBe(40);
+
+    measurer.clear();
+    expect(onMeasure).toHaveBeenCalledTimes(2);
+  });
+
+  test("stops observing when cleared, so the next sync measures again", () => {
+    const resize = installResizeObserver();
+    const measurer = createHeightMeasurer({ onMeasure: vi.fn() });
+    const container = buildWindow([0, 1]);
+
+    measurer.sync(container);
+    expect(resize.observed.size).toBe(2);
+
+    // A filter narrowing a list forgets every height, but the options that
+    // survived it keep their elements. Nothing resizes, so observing them
+    // afresh is the only thing that reports their heights again.
+    measurer.clear();
+    expect(resize.observed.size).toBe(0);
+
+    measurer.sync(container);
+
+    expect(resize.observed.size).toBe(2);
+    // Still one observer covering the window, not one per option.
+    expect(resize.instanceCount).toBe(1);
+  });
+
+  test("disconnect stops further reports", async () => {
+    const resize = installResizeObserver();
+    const onMeasure = vi.fn();
+    const measurer = createHeightMeasurer({ onMeasure });
+    const container = buildWindow([0]);
+
+    measurer.sync(container);
+    measurer.disconnect();
+    await resize.deliver([{ target: optionAt(container, 0), height: 40 }]);
+
+    expect(onMeasure).not.toHaveBeenCalled();
+  });
+
+  test("falls back to a one-shot height read with no ResizeObserver", () => {
+    vi.stubGlobal("ResizeObserver", undefined);
+    const onMeasure = vi.fn();
+    const measurer = createHeightMeasurer({ onMeasure });
+    const container = buildWindow([0, 1]);
+    optionAt(container, 0).getBoundingClientRect = () =>
+      ({ height: 40 }) as DOMRect;
+    optionAt(container, 1).getBoundingClientRect = () =>
+      ({ height: 88 }) as DOMRect;
+
+    measurer.sync(container);
+
+    expect(onMeasure).toHaveBeenCalledTimes(1);
+    const [heights] = onMeasure.mock.calls[0];
+    expect(heights[0]).toBe(40);
+    expect(heights[1]).toBe(88);
+  });
+});

--- a/tests/utils/stubPerOptionResizeObserver.ts
+++ b/tests/utils/stubPerOptionResizeObserver.ts
@@ -1,0 +1,71 @@
+/// <reference types="vitest/globals" />
+
+/**
+ * Letting a rendered listbox option report a height in the unit environment.
+ *
+ * jsdom lays nothing out, so every real height is zero and no
+ * `ResizeObserver` ever fires. The height each option should report travels on
+ * the option itself, in a `data-measured-height` attribute the component's
+ * fixture puts there, and the stub below reads it back. That is the only way a
+ * height held against the wrong option is observable at all.
+ *
+ * Shared because `ComboBox` and `MultiSelect` both render real components
+ * through their measured fixtures. Anything a single suite drives belongs in
+ * that suite.
+ */
+
+/** The height the option's fixture says it renders at. */
+function readMarkedHeight(element: Element) {
+  const marker = element.querySelector("[data-measured-height]");
+  return Number(marker?.getAttribute("data-measured-height") ?? 0);
+}
+
+/** A resize entry reporting the height the option carries. */
+function entryFor(element: Element) {
+  const height = readMarkedHeight(element);
+  return {
+    target: element,
+    contentRect: { height } as DOMRectReadOnly,
+    borderBoxSize: [{ blockSize: height, inlineSize: 0 }],
+    contentBoxSize: [],
+    devicePixelContentBoxSize: [],
+  };
+}
+
+/**
+ * Stub `ResizeObserver` so each option reports the height it carries, rather
+ * than the suite-wide stub's one height for everything. Batches are delivered
+ * on their own, deferred like the real observer so the first paint still
+ * happens against unmeasured state.
+ */
+export function stubPerOptionResizeObserver() {
+  class PerOptionResizeObserver {
+    callback: ResizeObserverCallback;
+    elements = new Set<Element>();
+
+    constructor(callback: ResizeObserverCallback) {
+      this.callback = callback;
+    }
+
+    observe(element: Element) {
+      this.elements.add(element);
+      queueMicrotask(() => {
+        if (!this.elements.has(element)) return;
+        this.callback(
+          [entryFor(element)] as unknown as ResizeObserverEntry[],
+          this as unknown as ResizeObserver,
+        );
+      });
+    }
+
+    unobserve(element: Element) {
+      this.elements.delete(element);
+    }
+
+    disconnect() {
+      this.elements.clear();
+    }
+  }
+
+  vi.stubGlobal("ResizeObserver", PerOptionResizeObserver);
+}

--- a/tests/utils/virtualize.test.ts
+++ b/tests/utils/virtualize.test.ts
@@ -1,5 +1,7 @@
 import {
   getBoundedScrollTop,
+  getMeasuredAverage,
+  getMeasuredScrollCorrection,
   getVisibleRange,
   resetVirtualScrollOnClose,
   scrollHighlightedIntoView,
@@ -692,5 +694,764 @@ describe("scrollSelectedIntoView", () => {
 describe("resetVirtualScrollOnClose", () => {
   test("returns 0", () => {
     expect(resetVirtualScrollOnClose()).toBe(0);
+  });
+});
+
+describe("virtualize with measured heights", () => {
+  const makeItems = (length: number) =>
+    Array.from({ length }, (_, i) => ({ id: i, name: `Item ${i}` }));
+
+  test("derives total height from the supplied heights", () => {
+    // 100 options at 30px and 100 at 70px is 10000px, where a uniform 40px
+    // item height would report 8000px.
+    const items = makeItems(200);
+    const heights = items.map((_, index) => (index % 2 === 0 ? 30 : 70));
+
+    const result = virtualize({
+      items,
+      itemHeight: 40,
+      containerHeight: 300,
+      scrollTop: 0,
+      threshold: 100,
+      measured: true,
+      heights,
+    });
+
+    expect(result.isVirtualized).toBe(true);
+    expect(result.totalHeight).toBe(10_000);
+  });
+
+  // Alternating 30px/70px options: option 2k starts at 100k, option 2k+1 at
+  // 100k + 30. Every expectation below is read off that pattern by hand.
+  const alternating = {
+    items: makeItems(200),
+    heights: Array.from({ length: 200 }, (_, index) =>
+      index % 2 === 0 ? 30 : 70,
+    ),
+    itemHeight: 40,
+    containerHeight: 300,
+    threshold: 100,
+    measured: true,
+  };
+
+  test("resolves the visible range at the start of the list", () => {
+    const result = virtualize({ ...alternating, scrollTop: 0 });
+
+    // Option 6 starts at 300, the first past the viewport, plus 3 overscan.
+    expect(result.startIndex).toBe(0);
+    expect(result.endIndex).toBe(9);
+    expect(result.offsetY).toBe(0);
+  });
+
+  test("resolves the visible range mid-list", () => {
+    const result = virtualize({ ...alternating, scrollTop: 1000 });
+
+    // Option 20 starts at 1000, less 3 overscan; option 26 starts at 1300,
+    // the first past the viewport bottom, plus 3 overscan.
+    expect(result.startIndex).toBe(17);
+    expect(result.endIndex).toBe(29);
+    expect(result.offsetY).toBe(830);
+  });
+
+  test("resolves the visible range at the end of the list", () => {
+    // maxScroll is 10000 - 300; option 194 starts at 9700.
+    const result = virtualize({ ...alternating, scrollTop: 50_000 });
+
+    expect(result.startIndex).toBe(191);
+    expect(result.endIndex).toBe(200);
+    expect(result.offsetY).toBe(9530);
+    expect(result.visibleItems[result.visibleItems.length - 1].id).toBe(199);
+  });
+
+  test("falls back to the supplied item height while nothing is measured", () => {
+    const result = virtualize({
+      items: makeItems(200),
+      itemHeight: 40,
+      containerHeight: 300,
+      scrollTop: 1000,
+      threshold: 100,
+      measured: true,
+      heights: [],
+    });
+
+    // Identical to the fixed-height numbers for 200 options of 40px.
+    expect(result.totalHeight).toBe(8000);
+    expect(result.startIndex).toBe(22);
+    expect(result.endIndex).toBe(36);
+    expect(result.offsetY).toBe(880);
+  });
+
+  test("estimates unmeasured options from the measured ones", () => {
+    const heights = Array.from({ length: 200 }, (_, index) =>
+      index < 10 ? 100 : undefined,
+    );
+
+    const result = virtualize({
+      items: makeItems(200),
+      itemHeight: 40,
+      containerHeight: 300,
+      scrollTop: 0,
+      threshold: 100,
+      measured: true,
+      heights,
+    });
+
+    // Every option is assumed 100px tall, not the 40px seed, so the list is
+    // 20000px rather than the 8600px a seed-only estimate would report.
+    expect(result.totalHeight).toBe(20_000);
+  });
+
+  test("sharpens the estimate as more options are measured", () => {
+    const heights = Array.from({ length: 200 }, (_, index) => {
+      if (index < 10) return 100;
+      if (index < 20) return 20;
+      return undefined;
+    });
+
+    const result = virtualize({
+      items: makeItems(200),
+      itemHeight: 40,
+      containerHeight: 300,
+      scrollTop: 0,
+      threshold: 100,
+      measured: true,
+      heights,
+    });
+
+    // 20 measured options total 1200px and average 60px, so the 180
+    // unmeasured ones contribute 10800px.
+    expect(result.totalHeight).toBe(12_000);
+  });
+});
+
+describe("scroll positions with measured heights", () => {
+  // Alternating 30px/70px options: option 2k starts at 100k, option 2k+1 at
+  // 100k + 30, and the list totals 10000px.
+  const base = {
+    itemCount: 200,
+    itemHeight: 40,
+    containerHeight: 300,
+    heights: Array.from({ length: 200 }, (_, index) =>
+      index % 2 === 0 ? 30 : 70,
+    ),
+  };
+
+  describe("getBoundedScrollTop", () => {
+    test("returns the accumulated position of a mid-list option", () => {
+      expect(getBoundedScrollTop({ ...base, index: 20 })).toBe(1000);
+    });
+
+    test("clamps an option near the end to maxScroll", () => {
+      // Option 199 starts at 9930, past the 10000 - 300 maximum.
+      expect(getBoundedScrollTop({ ...base, index: 199 })).toBe(9700);
+    });
+
+    test("clamps to 0 for a negative index", () => {
+      expect(getBoundedScrollTop({ ...base, index: -5 })).toBe(0);
+    });
+
+    test("floors maxScroll at 0 when the list is shorter than the container", () => {
+      expect(
+        getBoundedScrollTop({
+          index: 2,
+          itemCount: 3,
+          itemHeight: 40,
+          containerHeight: 300,
+          heights: [30, 70, 30],
+        }),
+      ).toBe(0);
+    });
+  });
+
+  describe("scrollSelectedIntoView", () => {
+    test("returns 0 when there is no selection", () => {
+      expect(scrollSelectedIntoView({ ...base, selectedIndex: -1 })).toBe(0);
+    });
+
+    test("returns the accumulated position of the selected option", () => {
+      expect(scrollSelectedIntoView({ ...base, selectedIndex: 20 })).toBe(1000);
+    });
+
+    test("clamps a selection near the end to maxScroll", () => {
+      expect(scrollSelectedIntoView({ ...base, selectedIndex: 199 })).toBe(
+        9700,
+      );
+    });
+  });
+
+  describe("scrollHighlightedIntoView", () => {
+    test("returns null when the highlighted option is already visible", () => {
+      expect(
+        scrollHighlightedIntoView({
+          ...base,
+          highlightedIndex: 2,
+          currentScrollTop: 0,
+        }),
+      ).toBeNull();
+    });
+
+    test("returns a bounded position when the option is below the viewport", () => {
+      expect(
+        scrollHighlightedIntoView({
+          ...base,
+          highlightedIndex: 100,
+          currentScrollTop: 0,
+        }),
+      ).toBe(5000);
+    });
+
+    test("returns a bounded position when the option is above the viewport", () => {
+      expect(
+        scrollHighlightedIntoView({
+          ...base,
+          highlightedIndex: 10,
+          currentScrollTop: 5000,
+        }),
+      ).toBe(500);
+    });
+
+    test("respects overscan when deciding visibility", () => {
+      // At scrollTop 5000 the range starts at option 100 less 3 overscan.
+      expect(
+        scrollHighlightedIntoView({
+          ...base,
+          highlightedIndex: 96,
+          currentScrollTop: 5000,
+        }),
+      ).toBe(4800);
+      expect(
+        scrollHighlightedIntoView({
+          ...base,
+          highlightedIndex: 97,
+          currentScrollTop: 5000,
+        }),
+      ).toBeNull();
+    });
+  });
+});
+
+/**
+ * The anchor arithmetic, reached through `getMeasuredScrollCorrection` because
+ * that is the only way in: a caller knows the position it is holding, not which
+ * option that position anchors on. Each `scrollTop` below sits inside the option
+ * named as the anchor, under the heights the position was computed against.
+ */
+describe("getMeasuredScrollCorrection: the anchor arithmetic", () => {
+  const base = { itemCount: 200, itemHeight: 40, containerHeight: 300 };
+
+  const measureFirst = (count: number, height: number) =>
+    Array.from({ length: 200 }, (_, index) =>
+      index < count ? height : undefined,
+    );
+
+  test("returns 0 at the top of the list, where nothing sits above", () => {
+    expect(
+      getMeasuredScrollCorrection({
+        ...base,
+        scrollTop: 0,
+        previousHeights: [],
+        heights: measureFirst(20, 60),
+      }),
+    ).toBe(0);
+  });
+
+  test("returns 0 when the options above turn out to be the assumed height", () => {
+    expect(
+      getMeasuredScrollCorrection({
+        ...base,
+        // Inside option 20, which sits at 800 under the 40px seed.
+        scrollTop: 810,
+        previousHeights: [],
+        heights: measureFirst(20, 40),
+      }),
+    ).toBe(0);
+  });
+
+  test("pushes the anchor down when options above it are taller than assumed", () => {
+    // 20 options assumed at the 40px seed sat at 800; measured at 60px they
+    // sit at 1200.
+    expect(
+      getMeasuredScrollCorrection({
+        ...base,
+        scrollTop: 810,
+        previousHeights: [],
+        heights: measureFirst(20, 60),
+      }),
+    ).toBe(400);
+  });
+
+  test("pulls the anchor up when options above it are shorter than assumed", () => {
+    expect(
+      getMeasuredScrollCorrection({
+        ...base,
+        scrollTop: 810,
+        previousHeights: [],
+        heights: measureFirst(20, 20),
+      }),
+    ).toBe(-400);
+  });
+
+  test("corrects by the delta of the one option whose height changed", () => {
+    const previousHeights = measureFirst(20, 50);
+    const heights = measureFirst(20, 50);
+    heights[5] = 90;
+
+    expect(
+      // Inside option 20, which sits at 1000 once the options above it
+      // measure 50 apiece.
+      getMeasuredScrollCorrection({
+        ...base,
+        scrollTop: 1010,
+        previousHeights,
+        heights,
+      }),
+    ).toBe(40);
+  });
+
+  test("ignores an option measured below the anchor", () => {
+    const previousHeights = measureFirst(20, 50);
+    const heights = measureFirst(20, 50);
+    heights[100] = 90;
+
+    expect(
+      getMeasuredScrollCorrection({
+        ...base,
+        scrollTop: 1010,
+        previousHeights,
+        heights,
+      }),
+    ).toBe(0);
+  });
+});
+
+describe("getMeasuredScrollCorrection", () => {
+  const base = { itemCount: 200, itemHeight: 40, containerHeight: 300 };
+
+  const measureFirst = (count: number, height: number) =>
+    Array.from({ length: 200 }, (_, index) =>
+      index < count ? height : undefined,
+    );
+
+  test("returns 0 at the top of the list, where nothing sits above", () => {
+    expect(
+      getMeasuredScrollCorrection({
+        ...base,
+        scrollTop: 0,
+        previousHeights: [],
+        heights: measureFirst(20, 60),
+      }),
+    ).toBe(0);
+  });
+
+  test("returns 0 when the options above turn out to be the assumed height", () => {
+    expect(
+      getMeasuredScrollCorrection({
+        ...base,
+        scrollTop: 800,
+        previousHeights: [],
+        heights: measureFirst(20, 40),
+      }),
+    ).toBe(0);
+  });
+
+  test("anchors on the option at the top of the viewport, not the window", () => {
+    // scrollTop 800 puts option 20 at the top of the viewport under the 40px
+    // seed. Measured at 60px, the twenty options above it sit at 1200 instead
+    // of 800, so the anchor has to come down by 400 to stay where it was. An
+    // anchor taken from the rendered window would have been three options
+    // earlier and asked for 340.
+    expect(
+      getMeasuredScrollCorrection({
+        ...base,
+        scrollTop: 800,
+        previousHeights: [],
+        heights: measureFirst(20, 60),
+      }),
+    ).toBe(400);
+  });
+
+  test("pulls back when the options above turn out shorter than assumed", () => {
+    expect(
+      getMeasuredScrollCorrection({
+        ...base,
+        scrollTop: 800,
+        previousHeights: [],
+        heights: measureFirst(20, 20),
+      }),
+    ).toBe(-400);
+  });
+
+  test("corrects by the delta of the one option whose height changed", () => {
+    const previousHeights = measureFirst(20, 50);
+    const heights = measureFirst(20, 50);
+    heights[5] = 90;
+
+    expect(
+      getMeasuredScrollCorrection({
+        ...base,
+        scrollTop: 1000,
+        previousHeights,
+        heights,
+      }),
+    ).toBe(40);
+  });
+
+  test("ignores a height change below the anchor", () => {
+    const previousHeights = measureFirst(40, 50);
+    const heights = measureFirst(40, 50);
+    heights[30] = 200;
+
+    expect(
+      getMeasuredScrollCorrection({
+        ...base,
+        scrollTop: 500,
+        previousHeights,
+        heights,
+      }),
+    ).toBe(0);
+  });
+});
+
+describe("virtualListState with measured heights", () => {
+  const makeItems = (length: number) =>
+    Array.from({ length }, (_, i) => ({ id: i, name: `Item ${i}` }));
+
+  const tallHeights = (length: number) => Array.from({ length }, () => 100);
+
+  test("measures a windowed list from the supplied heights", () => {
+    const result = virtualListState({
+      items: makeItems(200),
+      scrollTop: 0,
+      shouldVirtualize: true,
+      virtualize: { measured: true },
+      heights: tallHeights(200),
+    });
+
+    expect(result.data?.isVirtualized).toBe(true);
+    expect(result.data?.totalHeight).toBe(20_000);
+  });
+
+  test("does not window a list below the threshold that opts into measuring", () => {
+    const items = makeItems(50);
+    const result = virtualListState({
+      items,
+      scrollTop: 0,
+      shouldVirtualize: true,
+      virtualize: { measured: true },
+      heights: tallHeights(50),
+    });
+
+    // Opting in resolves a full config, but the threshold still decides
+    // whether the list is windowed at all.
+    expect(result.config?.measured).toBe(true);
+    expect(result.data?.isVirtualized).toBe(false);
+    expect(result.itemsToRender).toBe(items);
+  });
+
+  test("ignores supplied heights unless the list opts into measuring", () => {
+    const result = virtualListState({
+      items: makeItems(200),
+      scrollTop: 0,
+      shouldVirtualize: true,
+      virtualize: true,
+      heights: tallHeights(200),
+    });
+
+    expect(result.config?.measured).toBe(false);
+    expect(result.data?.totalHeight).toBe(8000);
+  });
+
+  test("seeds the estimate from the size-based default when none is supplied", () => {
+    const result = virtualListState({
+      items: makeItems(200),
+      scrollTop: 0,
+      shouldVirtualize: true,
+      virtualize: { measured: true },
+      defaults: { itemHeight: 48 },
+    });
+
+    expect(result.data?.totalHeight).toBe(9600);
+  });
+
+  test("seeds the estimate from the supplied item height over the default", () => {
+    const result = virtualListState({
+      items: makeItems(200),
+      scrollTop: 0,
+      shouldVirtualize: true,
+      virtualize: { measured: true, itemHeight: 64 },
+      defaults: { itemHeight: 48 },
+    });
+
+    expect(result.data?.totalHeight).toBe(12_800);
+  });
+});
+
+describe("virtualize with degenerate measured heights", () => {
+  const makeItems = (length: number) =>
+    Array.from({ length }, (_, i) => ({ id: i, name: `Item ${i}` }));
+
+  const base = {
+    itemHeight: 40,
+    containerHeight: 300,
+    scrollTop: 0,
+    measured: true,
+  };
+
+  test("handles an empty list", () => {
+    const result = virtualize({
+      ...base,
+      items: [],
+      heights: [],
+      threshold: 0,
+    });
+
+    expect(result.visibleItems).toEqual([]);
+    expect(result.startIndex).toBe(0);
+    expect(result.endIndex).toBe(0);
+    expect(result.offsetY).toBe(0);
+    expect(result.totalHeight).toBe(0);
+  });
+
+  test("handles a single option", () => {
+    const items = makeItems(1);
+    const result = virtualize({
+      ...base,
+      items,
+      heights: [90],
+      threshold: 0,
+    });
+
+    expect(result.visibleItems).toEqual(items);
+    expect(result.startIndex).toBe(0);
+    expect(result.endIndex).toBe(1);
+    expect(result.offsetY).toBe(0);
+    expect(result.totalHeight).toBe(90);
+  });
+
+  test("handles every option measuring the same height", () => {
+    const result = virtualize({
+      ...base,
+      items: makeItems(200),
+      heights: Array.from({ length: 200 }, () => 55),
+      scrollTop: 1100,
+      threshold: 100,
+    });
+
+    // Option 20 starts at 1100, less 3 overscan; option 26 starts at 1430,
+    // the first past the 1400 viewport bottom, plus 3 overscan.
+    expect(result.totalHeight).toBe(11_000);
+    expect(result.startIndex).toBe(17);
+    expect(result.endIndex).toBe(29);
+    expect(result.offsetY).toBe(935);
+  });
+
+  test("handles a single option measuring zero", () => {
+    const heights = Array.from({ length: 200 }, () => 50);
+    heights[5] = 0;
+
+    const result = virtualize({
+      ...base,
+      items: makeItems(200),
+      heights,
+      scrollTop: 450,
+      threshold: 100,
+    });
+
+    // The collapsed option takes no space, so everything after it sits 50px
+    // higher than an all-50px list would put it.
+    expect(result.totalHeight).toBe(9950);
+    expect(result.startIndex).toBe(7);
+    expect(result.endIndex).toBe(19);
+    expect(result.offsetY).toBe(300);
+  });
+
+  test("renders every option when they all measure zero", () => {
+    const result = virtualize({
+      ...base,
+      items: makeItems(200),
+      heights: Array.from({ length: 200 }, () => 0),
+      threshold: 100,
+    });
+
+    // Nothing to search: every option shares offset 0, so window nothing out.
+    expect(result.totalHeight).toBe(0);
+    expect(result.startIndex).toBe(0);
+    expect(result.endIndex).toBe(200);
+    expect(result.offsetY).toBe(0);
+  });
+
+  test("treats a negative or non-finite height as unmeasured", () => {
+    const results = [-10, Number.NaN, Number.POSITIVE_INFINITY].map((bad) => {
+      const heights = Array.from({ length: 200 }, () => 50);
+      heights[5] = bad;
+
+      return virtualize({
+        ...base,
+        items: makeItems(200),
+        heights,
+        scrollTop: 500,
+        threshold: 100,
+      });
+    });
+
+    for (const result of results) {
+      // The rejected entry falls back to the estimate, which the other 199
+      // measured options put at 50, so the list reads as 200 options of 50px.
+      expect(result.totalHeight).toBe(10_000);
+      expect(result.startIndex).toBe(7);
+      expect(result.offsetY).toBe(350);
+    }
+  });
+
+  test("handles a list shorter than its container", () => {
+    const items = makeItems(200);
+    const result = virtualize({
+      ...base,
+      items,
+      heights: Array.from({ length: 200 }, () => 1),
+      scrollTop: 500,
+      threshold: 100,
+    });
+
+    expect(result.totalHeight).toBe(200);
+    expect(result.startIndex).toBe(0);
+    expect(result.endIndex).toBe(200);
+    expect(result.offsetY).toBe(0);
+    expect(result.visibleItems).toEqual(items);
+  });
+});
+
+describe("getVisibleRange with measured heights", () => {
+  // Alternating 30px/70px options: option 2k starts at 100k.
+  const base = {
+    itemHeight: 40,
+    containerHeight: 300,
+    itemCount: 200,
+    heights: Array.from({ length: 200 }, (_, index) =>
+      index % 2 === 0 ? 30 : 70,
+    ),
+  };
+
+  test("searches accumulated positions rather than dividing by itemHeight", () => {
+    expect(getVisibleRange({ ...base, scrollTop: 1000 })).toEqual({
+      startIndex: 17,
+      endIndex: 29,
+    });
+  });
+
+  test("clamps startIndex to 0 with overscan at the top", () => {
+    expect(getVisibleRange({ ...base, scrollTop: 0 })).toEqual({
+      startIndex: 0,
+      endIndex: 9,
+    });
+  });
+
+  test("clamps a negative scroll position to the top", () => {
+    // Option 4 starts at 200, the first past a viewport bottom pulled up to
+    // 200 by the negative offset, plus 3 overscan.
+    expect(getVisibleRange({ ...base, scrollTop: -100 })).toEqual({
+      startIndex: 0,
+      endIndex: 7,
+    });
+  });
+
+  test("clamps endIndex to itemCount past the end of the list", () => {
+    expect(getVisibleRange({ ...base, scrollTop: 10_000 })).toEqual({
+      startIndex: 196,
+      endIndex: 200,
+    });
+  });
+
+  test("caps the window to maxItems", () => {
+    expect(getVisibleRange({ ...base, scrollTop: 1000, maxItems: 5 })).toEqual({
+      startIndex: 17,
+      endIndex: 22,
+    });
+  });
+});
+
+describe("getMeasuredAverage", () => {
+  test("averages the measured heights, ignoring the unmeasured", () => {
+    // Sparse where nothing has been measured, which is every window that has
+    // not been scrolled through yet.
+    const heights = [40, undefined, 80, undefined, 120];
+
+    expect(getMeasuredAverage(heights)).toBe(80);
+  });
+
+  test("counts a height of zero, since an option can collapse", () => {
+    expect(getMeasuredAverage([0, 40])).toBe(20);
+  });
+
+  test("reads only as far as asked", () => {
+    expect(getMeasuredAverage([40, 40, 400], 2)).toBe(40);
+  });
+
+  test("reports nothing to average rather than a number", () => {
+    // The caller has to tell "no evidence" from "evidence that says zero",
+    // because only one of them is worth keeping as a seed.
+    expect(getMeasuredAverage([])).toBeNull();
+    expect(getMeasuredAverage([undefined, undefined])).toBeNull();
+    expect(getMeasuredAverage(undefined)).toBeNull();
+  });
+});
+
+describe("virtualListState estimate", () => {
+  const items = Array.from({ length: 10 }, (_, index) => ({ id: index }));
+  const base = {
+    items,
+    scrollTop: 0,
+    shouldVirtualize: true,
+  };
+
+  test("seeds unmeasured options from the estimate under measured heights", () => {
+    const { config, data } = virtualListState({
+      ...base,
+      virtualize: { measured: true, threshold: 1, itemHeight: 40 },
+      estimate: 90,
+    });
+
+    // Nothing measured, so every option takes the estimate rather than the
+    // consumer's seed, and the config reports the seed actually used. An offset
+    // and a scroll position computed against different seeds would describe
+    // different lists.
+    expect(data?.totalHeight).toBe(items.length * 90);
+    expect(config?.itemHeight).toBe(90);
+  });
+
+  test("leaves the fixed path's item height alone", () => {
+    const { config, data } = virtualListState({
+      ...base,
+      virtualize: { threshold: 1, itemHeight: 40 },
+      estimate: 90,
+    });
+
+    // There `itemHeight` is the height of every option, not a guess at one.
+    expect(data?.totalHeight).toBe(items.length * 40);
+    expect(config?.itemHeight).toBe(40);
+  });
+
+  test("yields to a real measurement", () => {
+    const heights = Array.from({ length: items.length }, () => 50);
+    const { data } = virtualListState({
+      ...base,
+      virtualize: { measured: true, threshold: 1, itemHeight: 40 },
+      heights,
+      estimate: 90,
+    });
+
+    expect(data?.totalHeight).toBe(items.length * 50);
+  });
+
+  test("ignores an estimate that could not be a height", () => {
+    for (const estimate of [0, -10, Number.NaN, Number.POSITIVE_INFINITY]) {
+      const { data } = virtualListState({
+        ...base,
+        virtualize: { measured: true, threshold: 1, itemHeight: 40 },
+        estimate,
+      });
+
+      expect(data?.totalHeight).toBe(items.length * 40);
+    }
   });
 });


### PR DESCRIPTION
Closes #3709

Option labels are one fixed-height line with `text-overflow: ellipsis`.  A stylesheet override doesn't work either: any list past the virtualization threshold derives every offset from a single `itemHeight`.

## The prop

```svelte
<Dropdown wrapOptions {items} />
```

On `Dropdown`, `ComboBox`, `MultiSelect`, and `ListBoxMenu`. Labels break between words. That's `overflow-wrap: break-word` rather than `anywhere`.

Nothing else moves: accessible names, `aria-setsize`/`aria-posinset`, the `scroll` payload, and `itemHeight`, which becomes the estimate for rows not yet measured.

## Measured virtualization

Wrapped rows aren't equal height, so offsets have to come from measurement: a per-option height cache. `wrapOptions` is the only thing that turns it on.

## Default

Off. Turning it on shifts rendered heights for every existing consumer and puts every long list on the measured path. The downside is real: people stay non-conformant until they find the prop, but perhaps CDS will revisit the design as a whole at some point. 

Broke it into four commits to try and make it a bit more digestible, but it's larger than I had hoped. Hopefully it's useful in some way or another. 
