### PR TITLE
feat(action-set): add `ActionSet` component

### DIFF
--- a/css/_action-set.scss
+++ b/css/_action-set.scss
@@ -1,0 +1,180 @@
+@import "carbon-components/scss/globals/scss/vars";
+@import "carbon-components/scss/globals/scss/helper-mixins";
+@import "carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/import-once/import-once";
+@import "carbon-components/scss/globals/scss/typography";
+
+/// ActionSet renders real `Button` children over `ButtonSet`'s flex/divider
+/// base (`.bx--btn-set`), then overrides its fixed 196px button cap with
+/// per-count flex-basis percentages so 1-4 actions fill the row evenly.
+/// Ordering and ghost/expressive treatment key off `Button`'s own native
+/// `bx--btn--{kind}` classes directly, no extra marker class needed. Ported
+/// from Carbon React's `ActionSet`
+/// (`packages/styles/scss/components/action-set`), mapped from v11
+/// spacing/type tokens to this repo's v10 equivalents.
+/// @access private
+/// @group components
+@mixin action-set {
+  .#{$prefix}--action-set .#{$prefix}--btn {
+    @include type-style('body-short-01');
+
+    align-items: center;
+    margin: 0;
+    order: 3;
+  }
+
+  .#{$prefix}--action-set .#{$prefix}--btn.#{$prefix}--btn--expressive {
+    height: $carbon--spacing-10;
+    padding-top: $carbon--spacing-05;
+    padding-bottom: $carbon--spacing-07;
+  }
+
+  .#{$prefix}--action-set.#{$prefix}--btn-set .#{$prefix}--btn {
+    max-width: none;
+  }
+
+  .#{$prefix}--action-set:not(.#{$prefix}--action-set--stacking)
+    .#{$prefix}--btn--ghost,
+  .#{$prefix}--action-set:not(.#{$prefix}--action-set--stacking)
+    .#{$prefix}--btn--danger-ghost {
+    padding-left: $carbon--spacing-05;
+  }
+
+  // Order: ghost/danger-ghost first, tertiary next, danger then primary
+  // last. Reversed when stacking, so the primary action stays closest to
+  // the top (reading order) in both layouts.
+  .#{$prefix}--action-set .#{$prefix}--btn--ghost,
+  .#{$prefix}--action-set .#{$prefix}--btn--danger-ghost {
+    order: 1;
+  }
+
+  .#{$prefix}--action-set .#{$prefix}--btn--tertiary,
+  .#{$prefix}--action-set .#{$prefix}--btn--danger-tertiary {
+    order: 2;
+  }
+
+  .#{$prefix}--action-set .#{$prefix}--btn--danger {
+    order: 4;
+  }
+
+  .#{$prefix}--action-set .#{$prefix}--btn--primary {
+    order: 5;
+  }
+
+  .#{$prefix}--action-set--stacking .#{$prefix}--btn--ghost,
+  .#{$prefix}--action-set--stacking .#{$prefix}--btn--danger-ghost {
+    order: 5;
+  }
+
+  .#{$prefix}--action-set--stacking .#{$prefix}--btn--tertiary,
+  .#{$prefix}--action-set--stacking .#{$prefix}--btn--danger-tertiary {
+    order: 4;
+  }
+
+  .#{$prefix}--action-set--stacking .#{$prefix}--btn--danger {
+    order: 2;
+  }
+
+  .#{$prefix}--action-set--stacking .#{$prefix}--btn--primary {
+    order: 1;
+  }
+
+  // For row-single in medium,
+  // or for ghosts in row-single,
+  // buttons are 100% width
+  .#{$prefix}--action-set.#{$prefix}--action-set--row-single.#{$prefix}--action-set--md
+    .#{$prefix}--btn,
+  .#{$prefix}--action-set.#{$prefix}--action-set--row-single
+    .#{$prefix}--btn--ghost,
+  .#{$prefix}--action-set.#{$prefix}--action-set--row-single
+    .#{$prefix}--btn--danger-ghost {
+    flex: 0 0 100%;
+  }
+
+  // For ghosts in row-double,
+  // buttons are 75% width and expand to use any remaining space
+  .#{$prefix}--action-set.#{$prefix}--action-set--row-double
+    .#{$prefix}--btn--ghost,
+  .#{$prefix}--action-set.#{$prefix}--action-set--row-double
+    .#{$prefix}--btn--danger-ghost {
+    flex: 1 1 75%;
+  }
+
+  // For row-single in large (non-ghost),
+  // or row-double in medium or large,
+  // buttons are 50% width
+  .#{$prefix}--action-set.#{$prefix}--action-set--row-single.#{$prefix}--action-set--lg
+    .#{$prefix}--btn:not(.#{$prefix}--btn--ghost):not(.#{$prefix}--btn--danger-ghost),
+  .#{$prefix}--action-set.#{$prefix}--action-set--row-double.#{$prefix}--action-set--md
+    .#{$prefix}--btn,
+  .#{$prefix}--action-set.#{$prefix}--action-set--row-double.#{$prefix}--action-set--lg
+    .#{$prefix}--btn,
+  .#{$prefix}--action-set.#{$prefix}--action-set--row-triple
+    .#{$prefix}--btn--ghost,
+  .#{$prefix}--action-set.#{$prefix}--action-set--row-triple
+    .#{$prefix}--btn--danger-ghost {
+    flex: 0 1 50%;
+  }
+
+  // For ghosts in row-triple,
+  // buttons are 50% width and expand to use any remaining space
+  .#{$prefix}--action-set.#{$prefix}--action-set--row-triple
+    .#{$prefix}--btn--ghost,
+  .#{$prefix}--action-set.#{$prefix}--action-set--row-triple
+    .#{$prefix}--btn--danger-ghost {
+    flex: 1 1 50%;
+  }
+
+  // For row-triple in large (non-ghost),
+  // or any non-ghosts in extra large or 2xl,
+  // or row-quadruple (non-ghost),
+  // buttons are 25% width with a max of 232px
+  .#{$prefix}--action-set.#{$prefix}--btn-set.#{$prefix}--action-set--row-triple.#{$prefix}--action-set--lg
+    .#{$prefix}--btn:not(.#{$prefix}--btn--ghost):not(.#{$prefix}--btn--danger-ghost),
+  .#{$prefix}--action-set.#{$prefix}--btn-set.#{$prefix}--action-set--xl
+    .#{$prefix}--btn:not(.#{$prefix}--btn--ghost):not(.#{$prefix}--btn--danger-ghost),
+  .#{$prefix}--action-set.#{$prefix}--btn-set.#{$prefix}--action-set--2xl
+    .#{$prefix}--btn:not(.#{$prefix}--btn--ghost):not(.#{$prefix}--btn--danger-ghost),
+  .#{$prefix}--action-set.#{$prefix}--btn-set.#{$prefix}--action-set--row-quadruple
+    .#{$prefix}--btn:not(.#{$prefix}--btn--ghost):not(.#{$prefix}--btn--danger-ghost) {
+    flex: 0 1 25%;
+
+    max-width: to-rem(232px);
+  }
+
+  .#{$prefix}--action-set.#{$prefix}--btn-set.#{$prefix}--action-set--row-quadruple
+    .#{$prefix}--btn--ghost,
+  .#{$prefix}--action-set.#{$prefix}--btn-set.#{$prefix}--action-set--row-quadruple
+    .#{$prefix}--btn--danger-ghost {
+    flex: 1 1 25%;
+  }
+
+  // Nested in ModalFooter, ActionSet is the sole flex owner. Fill the
+  // 64px footer so the set isn't shrink-wrapped to the trailing edge.
+  .#{$prefix}--modal-footer > .#{$prefix}--action-set {
+    flex: 1 1 auto;
+    width: 100%;
+    max-width: none;
+    height: 100%;
+    min-width: 0;
+  }
+
+  .#{$prefix}--modal-footer > .#{$prefix}--action-set .#{$prefix}--btn {
+    height: 100%;
+    padding-top: $carbon--spacing-05;
+    padding-bottom: $carbon--spacing-07;
+  }
+
+  // Center the loading spinner vertically within the button; it is
+  // absolutely positioned so it doesn't shift button layout/width.
+  .#{$prefix}--action-set .#{$prefix}--btn .#{$prefix}--inline-loading {
+    position: absolute;
+    top: 50%;
+    right: 0;
+    width: $carbon--spacing-07;
+    transform: translateY(-50%);
+  }
+}
+
+@include exports("action-set") {
+  @include action-set;
+}

--- a/css/all.scss
+++ b/css/all.scss
@@ -130,3 +130,4 @@ $css--plex: true;
 @import "./disclosure";
 @import "./list-box-wrap-options";
 @import "./structured-list-sort";
+@import "./action-set";

--- a/css/g10.scss
+++ b/css/g10.scss
@@ -90,3 +90,4 @@ $css--plex: true;
 @import "./disclosure";
 @import "./list-box-wrap-options";
 @import "./structured-list-sort";
+@import "./action-set";

--- a/css/g100.scss
+++ b/css/g100.scss
@@ -90,3 +90,4 @@ $css--plex: true;
 @import "./disclosure";
 @import "./list-box-wrap-options";
 @import "./structured-list-sort";
+@import "./action-set";

--- a/css/g80.scss
+++ b/css/g80.scss
@@ -90,3 +90,4 @@ $css--plex: true;
 @import "./disclosure";
 @import "./list-box-wrap-options";
 @import "./structured-list-sort";
+@import "./action-set";

--- a/css/g90.scss
+++ b/css/g90.scss
@@ -90,3 +90,4 @@ $css--plex: true;
 @import "./disclosure";
 @import "./list-box-wrap-options";
 @import "./structured-list-sort";
+@import "./action-set";

--- a/css/vendor/carbon-components/scss/components/modal/_modal.scss
+++ b/css/vendor/carbon-components/scss/components/modal/_modal.scss
@@ -269,7 +269,7 @@
     grid-row: -1/-1;
   }
 
-  .#{$prefix}--modal-footer .#{$prefix}--btn {
+  .#{$prefix}--modal-footer > .#{$prefix}--btn {
     max-width: none;
     height: to-rem(64px);
     flex: 0 1 50%;
@@ -278,7 +278,7 @@
     margin: 0;
   }
 
-  .#{$prefix}--modal-footer--three-button .#{$prefix}--btn {
+  .#{$prefix}--modal-footer--three-button > .#{$prefix}--btn {
     flex: 0 1 25%;
     align-items: flex-start;
   }

--- a/css/white.scss
+++ b/css/white.scss
@@ -90,3 +90,4 @@ $css--plex: true;
 @import "./disclosure";
 @import "./list-box-wrap-options";
 @import "./structured-list-sort";
+@import "./action-set";

--- a/docs/src/component-categories.ts
+++ b/docs/src/component-categories.ts
@@ -34,6 +34,7 @@ export const COMPONENT_CATEGORIES: ComponentCategory[] = [
   {
     label: "Actions",
     components: [
+      "ActionSet",
       "Button",
       "ButtonSet",
       "Toolbar",

--- a/docs/src/component-since-versions.ts
+++ b/docs/src/component-since-versions.ts
@@ -1,5 +1,6 @@
 export const COMPONENT_SINCE_VERSIONS: Record<string, string> = {
   Accordion: "0.2.0",
+  ActionSet: "0.112.0",
   AspectRatio: "0.17.0",
   BadgeIndicator: "0.109.0",
   Box: "0.109.0",

--- a/docs/src/pages/components/ActionSet.svx
+++ b/docs/src/pages/components/ActionSet.svx
@@ -1,0 +1,67 @@
+---
+components: ["ActionSet"]
+description: A row of action buttons for a custom modal or panel footer that automatically stacks vertically at small sizes or with more than two actions.
+---
+
+<script>
+  import { ActionSet, Button } from "carbon-components-svelte";
+</script>
+
+Use `ActionSet` for custom footers you compose yourself, typically [ComposedModal](/components/ComposedModal#custom-footer-with-actionset)'s `ModalFooter` slot. [Modal](/components/Modal) builds its footer from props and has no footer slot.
+
+## Basic
+
+Compose `ActionSet` from ordinary `Button` children, the same way as [ButtonSet](/components/ButtonSet). `size` cascades to every child button that doesn't set its own `size`.
+
+<ActionSet>
+  <Button kind="secondary">Cancel</Button>
+  <Button>Save</Button>
+</ActionSet>
+
+## Kinds
+
+Buttons are ordered automatically by `kind`: ghost and `"danger-ghost"` first, primary and danger last. Reversed when the set stacks, so the primary action stays closest to the reading direction's end in both layouts. DOM order does not matter.
+
+<ActionSet>
+  <Button kind="secondary">Cancel</Button>
+  <Button kind="danger">Delete</Button>
+  <Button kind="ghost">Learn more</Button>
+</ActionSet>
+
+## Sizes
+
+Set `size` to control the layout. `"sm"` always stacks; `"md"` stacks once there are more than two actions; `"lg"`, `"xl"`, and `"2xl"` never stack and give actions progressively more room.
+
+### Small
+
+<ActionSet size="sm">
+  <Button kind="secondary">Cancel</Button>
+  <Button>Save</Button>
+</ActionSet>
+
+### Large
+
+<ActionSet size="lg">
+  <Button kind="secondary">Cancel</Button>
+  <Button kind="danger">Delete</Button>
+  <Button>Save</Button>
+</ActionSet>
+
+### Extra large
+
+<ActionSet size="2xl">
+  <Button kind="ghost">Learn more</Button>
+  <Button kind="secondary">Cancel</Button>
+  <Button kind="danger">Delete</Button>
+  <Button>Save</Button>
+</ActionSet>
+
+## Disable stacking
+
+Set `disableStacking` to `true` to force a horizontal layout even at a size that would normally stack.
+
+<ActionSet size="sm" disableStacking>
+  <Button kind="secondary">Cancel</Button>
+  <Button kind="danger">Delete</Button>
+  <Button>Save</Button>
+</ActionSet>

--- a/docs/src/pages/components/ButtonSet.svx
+++ b/docs/src/pages/components/ButtonSet.svx
@@ -7,6 +7,8 @@ description: Group related buttons together with consistent spacing and alignmen
   import Login from "carbon-icons-svelte/lib/Login.svelte";
 </script>
 
+For a custom modal or panel footer that needs size-aware stacking (one to four actions, ordered automatically by `kind`), use [ActionSet](/components/ActionSet) instead, which wraps `ButtonSet` with that behavior built in. [Modal](/components/Modal) builds its footer from props.
+
 ## Basic
 
 Place buttons side by side in a horizontal layout.

--- a/docs/src/pages/components/ComposedModal.svx
+++ b/docs/src/pages/components/ComposedModal.svx
@@ -18,7 +18,7 @@ Create a modal with a header, body, and footer. Each section can be customized i
 
 ## Focus
 
-Control how focus moves when the composed modal opens, and override the default target when needed. Focus follows the same priority order as Modal — see [focus behavior](/components/Modal#focus-behavior).
+Control how focus moves when the composed modal opens, and override the default target when needed. Focus follows the same priority order as Modal. See [focus behavior](/components/Modal#focus-behavior).
 
 ### Custom focus
 
@@ -40,11 +40,11 @@ By default, the cancel button receives focus instead of the critical button to p
 
 ## Content
 
-Customize the header content and body layout. Set `hasForm` on `ModalBody` when it directly contains form elements (see the [Basic](#basic) example above) — it adjusts the body padding to match Carbon's form spacing.
+Customize the header content and body layout. Set `hasForm` on `ModalBody` when it directly contains form elements (see the [Basic](#basic) example above). It adjusts the body padding to match Carbon's form spacing.
 
 ### Custom heading
 
-Use `ModalHeader`'s default slot to add extra content — such as a status tag — below the title. This is in addition to (or instead of) the plain-text `title` and `label` props.
+Use `ModalHeader`'s default slot to add extra content, such as a status tag, below the title. This is in addition to (or instead of) the plain-text `title` and `label` props.
 
 <FileSource src="/framed/Modal/ComposedModalCustomHeading" />
 
@@ -56,7 +56,7 @@ Remove modal body padding so content spans edge to edge with `fullWidth`. Use it
 
 ### Has scrolling content
 
-Set `hasScrollingContent` on `ModalBody` to enable vertical scrolling for lengthy content, matching Modal's [Has scrolling content](/components/Modal#has-scrolling-content). Omitting `ModalFooter` — as in this example — creates a passive, information-only modal, the composed equivalent of Modal's `passiveModal`.
+Set `hasScrollingContent` on `ModalBody` to enable vertical scrolling for lengthy content, matching Modal's [Has scrolling content](/components/Modal#has-scrolling-content). Omitting `ModalFooter`, as in this example, creates a passive, information-only modal, the composed equivalent of Modal's `passiveModal`.
 
 <FileSource src="/framed/Modal/ComposedModalScrollingContent" />
 
@@ -69,6 +69,12 @@ Configure the footer actions.
 Set `secondaryButtons` in the modal footer to create a 3-button modal. This replaces secondaryButtonText and takes a tuple of two button configurations.
 
 <FileSource src="/framed/Modal/3ButtonComposedModal" />
+
+### Custom footer with ActionSet
+
+Slot [ActionSet](/components/ActionSet) into `ModalFooter` for a custom action row composed from `Button`s. Set `disableStacking` so the set stays horizontal inside the 64px footer, and `size="lg"` so child buttons stay `"default"` instead of shrinking to `"field"`.
+
+<FileSource src="/framed/Modal/ComposedModalActionSet" />
 
 ### Button with icon
 
@@ -92,7 +98,7 @@ Combine the composed modal with a progress indicator to create a multi-step flow
 
 Wrap the composed modal in a portal to ensure it renders above all z-index stacking contexts and parent overflow constraints, preventing visual clipping and layering issues.
 
-Components with menus (combo box, dropdown, date picker, and so on) placed inside a composed modal also auto-portal their menus the same way as in Modal — see [Modal with dropdowns](/components/Modal#modal-with-dropdowns).
+Components with menus (combo box, dropdown, date picker, and so on) placed inside a composed modal also auto-portal their menus the same way as in Modal. See [Modal with dropdowns](/components/Modal#modal-with-dropdowns).
 
 <FileSource src="/framed/Portal/ComposedModalPortal" />
 
@@ -120,19 +126,19 @@ Disable closing the modal when clicking outside with `preventCloseOnClickOutside
 
 ### Hide close button
 
-Set `hideCloseButton` on `ModalHeader` to remove the header close button. Use this for forced-choice dialogs such as auth walls or terms acceptance. Always provide an alternative dismiss path — typically footer actions — and pair with `preventCloseOnClickOutside` when outside clicks should not dismiss the dialog. <DocKbd label="Escape" /> still closes the modal unless you cancel the `close` event.
+Set `hideCloseButton` on `ModalHeader` to remove the header close button. Use this for forced-choice dialogs such as auth walls or terms acceptance. Always provide an alternative dismiss path, typically footer actions, and pair with `preventCloseOnClickOutside` when outside clicks should not dismiss the dialog. <DocKbd label="Escape" /> still closes the modal unless you cancel the `close` event.
 
 <FileSource src="/framed/Modal/ComposedModalHideCloseButton" />
 
 ### Secondary button
 
-`secondaryButtonText` closes the modal by default. The footer dispatches a cancelable `click:button--secondary` event first. Call `e.preventDefault()` to keep the modal open — for example when Cancel should stay put for a dirty form.
+`secondaryButtonText` closes the modal by default. The footer dispatches a cancelable `click:button--secondary` event first. Call `e.preventDefault()` to keep the modal open, for example when Cancel should stay put for a dirty form.
 
 <FileSource src="/framed/Modal/ComposedModalPreventSecondaryClose" />
 
 ## Events
 
-ComposedModal and ModalFooter dispatch events for the modal's lifecycle and button interactions. Only the close button, <DocKbd label="Escape" />, and (by default) an outside click close the modal automatically — see [Closing](#closing) above. Every other action leaves `open` untouched; handle the event and set `open` to `false` yourself when the action should dismiss the dialog.
+ComposedModal and ModalFooter dispatch events for the modal's lifecycle and button interactions. Only the close button, <DocKbd label="Escape" />, and (by default) an outside click close the modal automatically. See [Closing](#closing) above. Every other action leaves `open` untouched; handle the event and set `open` to `false` yourself when the action should dismiss the dialog.
 
 ### Open
 

--- a/docs/src/pages/components/Modal.svx
+++ b/docs/src/pages/components/Modal.svx
@@ -8,7 +8,7 @@ The modal is an all-in-one component configured through props, making it ideal f
 
 ## Basic
 
-Display a modal dialog with a header, content area, and footer. Use primary and secondary actions for confirmations or input. Neither button closes the modal automatically — wire up `on:submit` and `on:click:button--secondary` to set `open` to `false` yourself; see [Events](#events).
+Display a modal dialog with a header, content area, and footer. Use primary and secondary actions for confirmations or input. Neither button closes the modal automatically. Wire up `on:submit` and `on:click:button--secondary` to set `open` to `false` yourself; see [Events](#events).
 
 <FileSource src="/framed/Modal/Modal" />
 
@@ -101,6 +101,10 @@ Add up to two secondary actions with `secondaryButtons`, which replaces the sing
 
 <FileSource src="/framed/Modal/3ButtonModal" />
 
+### Custom footer with ActionSet
+
+Modal builds its footer from `primaryButtonText` and `secondaryButtons` and has no footer slot. For a custom footer composed from `Button`s, use [ActionSet](/components/ActionSet) in [ComposedModal](/components/ComposedModal#custom-footer-with-actionset)'s `ModalFooter`.
+
 ### Button with icon
 
 Enhance modal buttons with icons for better visual context and clarity.
@@ -133,7 +137,7 @@ Wrap the nested modal in [Portal](/components/Portal) so it renders outside the 
 
 ## Portal and dropdowns
 
-Render the modal — or components inside it — outside normal DOM boundaries.
+Render the modal, or components inside it, outside normal DOM boundaries.
 
 ### With portal
 
@@ -143,7 +147,7 @@ Wrap the modal in a portal to escape parent containers with `overflow: hidden` o
 
 ### Modal with dropdowns
 
-Components with menus — such as a combo box, dropdown, multi-select, date picker, or overflow menu — automatically render their menus in a floating portal when used inside a modal. The menus are positioned relative to their trigger and are not clipped by the modal's overflow or z-index stacking.
+Components with menus, such as a combo box, dropdown, multi-select, date picker, or overflow menu, automatically render their menus in a floating portal when used inside a modal. The menus are positioned relative to their trigger and are not clipped by the modal's overflow or z-index stacking.
 
 Set `portalMenu={false}` on these components to opt out. In this example, the modal itself is wrapped in a portal.
 
@@ -189,13 +193,13 @@ Disable closing the modal when clicking outside with `preventCloseOnClickOutside
 
 ### Hide close button
 
-Set `hideCloseButton` to `true` to remove the header close button. Use this for forced-choice dialogs such as auth walls or terms acceptance. Always provide an alternative dismiss path — typically footer actions — and pair with `preventCloseOnClickOutside` when outside clicks should not dismiss the dialog. <DocKbd label="Escape" /> still closes the modal unless you cancel the `close` event.
+Set `hideCloseButton` to `true` to remove the header close button. Use this for forced-choice dialogs such as auth walls or terms acceptance. Always provide an alternative dismiss path, typically footer actions, and pair with `preventCloseOnClickOutside` when outside clicks should not dismiss the dialog. <DocKbd label="Escape" /> still closes the modal unless you cancel the `close` event.
 
 <FileSource src="/framed/Modal/ModalHideCloseButton" />
 
 ## Events
 
-Modal dispatches events for its lifecycle and button interactions. Only the close button, <DocKbd label="Escape" />, and (by default) an outside click close the modal automatically — see [Closing](#closing) above. Every other action leaves `open` untouched; handle the event and set `open` to `false` yourself when the action should dismiss the dialog.
+Modal dispatches events for its lifecycle and button interactions. Only the close button, <DocKbd label="Escape" />, and (by default) an outside click close the modal automatically. See [Closing](#closing) above. Every other action leaves `open` untouched; handle the event and set `open` to `false` yourself when the action should dismiss the dialog.
 
 ### Open
 

--- a/docs/src/pages/framed/Modal/ComposedModalActionSet.svelte
+++ b/docs/src/pages/framed/Modal/ComposedModalActionSet.svelte
@@ -1,0 +1,28 @@
+<script>
+  import {
+    ActionSet,
+    Button,
+    ComposedModal,
+    ModalBody,
+    ModalFooter,
+    ModalHeader,
+  } from "carbon-components-svelte";
+
+  let open = true;
+</script>
+
+<Button on:click={() => (open = true)}>Continue setup</Button>
+
+<ComposedModal bind:open>
+  <ModalHeader title="Continue setup" />
+  <ModalBody>
+    <p>Review this step, go back, or continue to the next one.</p>
+  </ModalBody>
+  <ModalFooter>
+    <ActionSet size="lg" disableStacking>
+      <Button kind="ghost" on:click={() => (open = false)}>Cancel</Button>
+      <Button kind="secondary">Previous</Button>
+      <Button on:click={() => (open = false)}>Next</Button>
+    </ActionSet>
+  </ModalFooter>
+</ComposedModal>

--- a/src/ActionSet/ActionSet.svelte
+++ b/src/ActionSet/ActionSet.svelte
@@ -1,0 +1,88 @@
+<script>
+  /**
+   * @restProps {div}
+   * @slot {{}}
+   */
+
+  /**
+   * Specify the size of the action set. Different button arrangements are
+   * used at different sizes to make the best use of available space. Also
+   * sets the default size for child `Button`s that don't set their own
+   * `size`.
+   * @type {"sm" | "md" | "lg" | "xl" | "2xl"}
+   */
+  export let size = "md";
+
+  /**
+   * Set to `true` to prevent automatic stacking, even when `size` would
+   * normally trigger it (`"sm"`, or `"md"` with more than two actions).
+   */
+  export let disableStacking = false;
+
+  import { onMount, setContext } from "svelte";
+  import { writable } from "svelte/store";
+  import ButtonSet from "../Button/ButtonSet.svelte";
+
+  /**
+   * Button's own size scale ("default"/"field"/"small"/"lg"/"xl") is offset
+   * from ActionSet's v11-derived scale. Same idea as the size table in
+   * ComboButton.svelte.
+   */
+  const BUTTON_SIZES = {
+    sm: "small",
+    md: "field",
+    lg: "default",
+    xl: "lg",
+    "2xl": "xl",
+  };
+
+  const buttonSize = writable(BUTTON_SIZES[size]);
+  $: buttonSize.set(BUTTON_SIZES[size]);
+
+  // Button reads this to fall back to ActionSet's size when it has none of
+  // its own set, the same way it reads carbon:Modal for portalTooltip.
+  setContext("carbon:ActionSet", { size: buttonSize });
+
+  let ref = null;
+  let actionCount = 0;
+
+  function syncActionCount() {
+    actionCount = ref?.children.length ?? 0;
+  }
+
+  // Children are real, consumer-placed <Button>s, not a data array, so
+  // stacking's action count has to be measured from the DOM rather than
+  // read off a prop. Observe childList in case actions are added/removed
+  // after mount.
+  onMount(() => {
+    syncActionCount();
+    const observer = new MutationObserver(syncActionCount);
+    observer.observe(ref, { childList: true });
+    return () => observer.disconnect();
+  });
+
+  $: stacking =
+    !disableStacking && (size === "sm" || (size === "md" && actionCount > 2));
+  $: wrapperClass = [
+    "bx--action-set",
+    `bx--action-set--${size}`,
+    stacking && "bx--action-set--stacking",
+    !stacking && actionCount === 1 && "bx--action-set--row-single",
+    !stacking && actionCount === 2 && "bx--action-set--row-double",
+    !stacking && actionCount === 3 && "bx--action-set--row-triple",
+    !stacking && actionCount >= 4 && "bx--action-set--row-quadruple",
+    $$restProps.class,
+  ]
+    .filter(Boolean)
+    .join(" ");
+</script>
+
+<ButtonSet
+  {...$$restProps}
+  bind:ref
+  class={wrapperClass}
+  stacked={stacking}
+  role="presentation"
+>
+  <slot />
+</ButtonSet>

--- a/src/ActionSet/index.js
+++ b/src/ActionSet/index.js
@@ -1,0 +1,1 @@
+export { default as ActionSet } from "./ActionSet.svelte";

--- a/src/Button/Button.svelte
+++ b/src/Button/Button.svelte
@@ -20,9 +20,11 @@
   /**
    * Specify the size of button.
    * When the `badge` slot is used, size is set to `lg` per Carbon design guidelines.
+   * Falls back to the size set by an ancestor `ActionSet` when unset.
    * @type {"default" | "field" | "small" | "lg" | "xl"}
+   * @default "default"
    */
-  export let size = "default";
+  export let size = undefined;
 
   /** Set to `true` to use Carbon's expressive typesetting */
   export let expressive = false;
@@ -132,6 +134,7 @@
 
   const ctx = getContext("carbon:ComposedModal");
   const insideModal = getContext("carbon:Modal");
+  const actionSetSize = getContext("carbon:ActionSet")?.size;
 
   $: if (ctx && ref) {
     ctx.declareRef(ref);
@@ -293,7 +296,9 @@
   });
 
   $: isDisabled = Boolean(disabled);
-  $: effectiveSize = $$slots.badge ? "lg" : size;
+  $: effectiveSize = $$slots.badge
+    ? "lg"
+    : (size ?? $actionSetSize ?? "default");
   $: iconProps = {
     "aria-hidden": "true",
     class: "bx--btn__icon",

--- a/src/Button/ButtonSet.svelte
+++ b/src/Button/ButtonSet.svelte
@@ -1,9 +1,20 @@
 <script>
+  /**
+   * @restProps {div}
+   */
+
   /** Set to `true` to stack the buttons vertically */
   export let stacked = false;
+
+  /**
+   * Obtain a reference to the HTML element.
+   * @bindable readonly
+   */
+  export let ref = null;
 </script>
 
 <div
+  bind:this={ref}
   class:bx--btn-set={true}
   class:bx--btn-set--stacked={stacked}
   {...$$restProps}

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 export { default as Accordion } from "./Accordion/Accordion.svelte";
 export { default as AccordionItem } from "./Accordion/AccordionItem.svelte";
 export { default as AccordionSkeleton } from "./Accordion/AccordionSkeleton.svelte";
+export { default as ActionSet } from "./ActionSet/ActionSet.svelte";
 export { default as AspectRatio } from "./AspectRatio/AspectRatio.svelte";
 export { default as BadgeIndicator } from "./BadgeIndicator/BadgeIndicator.svelte";
 export { default as Box } from "./Box/Box.svelte";

--- a/tests/ActionSet/ActionSet.sizeOverride.test.svelte
+++ b/tests/ActionSet/ActionSet.sizeOverride.test.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+  import ActionSet from "carbon-components-svelte/ActionSet/ActionSet.svelte";
+  import Button from "carbon-components-svelte/Button/Button.svelte";
+</script>
+
+<ActionSet data-testid="action-set" size="sm">
+  <Button kind="secondary">Cancel</Button>
+  <Button size="field">Save</Button>
+</ActionSet>

--- a/tests/ActionSet/ActionSet.test.svelte
+++ b/tests/ActionSet/ActionSet.test.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  import ActionSet from "carbon-components-svelte/ActionSet/ActionSet.svelte";
+  import Button from "carbon-components-svelte/Button/Button.svelte";
+
+  export let size: "sm" | "md" | "lg" | "xl" | "2xl" = "md";
+  export let disableStacking = false;
+  export let count = 2;
+</script>
+
+<ActionSet data-testid="action-set" {size} {disableStacking}>
+  <Button kind="secondary">Cancel</Button>
+  {#if count >= 2}
+    <Button kind="danger">Delete</Button>
+  {/if}
+  {#if count >= 3}
+    <Button>Save</Button>
+  {/if}
+</ActionSet>

--- a/tests/ActionSet/ActionSet.test.ts
+++ b/tests/ActionSet/ActionSet.test.ts
@@ -1,0 +1,85 @@
+import { render, screen, waitFor } from "@testing-library/svelte";
+import ActionSetSizeOverride from "./ActionSet.sizeOverride.test.svelte";
+import ActionSet from "./ActionSet.test.svelte";
+
+describe("ActionSet", () => {
+  it("renders slotted Button children inside a presentation wrapper", () => {
+    render(ActionSet, { count: 2 });
+
+    const actionSet = screen.getByTestId("action-set");
+    expect(actionSet).toHaveClass("bx--action-set");
+    expect(actionSet).toHaveClass("bx--btn-set");
+    expect(actionSet).toHaveAttribute("role", "presentation");
+
+    const buttons = screen.getAllByRole("button");
+    expect(buttons).toHaveLength(2);
+    expect(buttons[0]).toHaveTextContent("Cancel");
+    expect(buttons[1]).toHaveTextContent("Delete");
+  });
+
+  it("sets the size layout class from the `size` prop", () => {
+    render(ActionSet, { size: "lg", count: 2 });
+
+    expect(screen.getByTestId("action-set")).toHaveClass("bx--action-set--lg");
+  });
+
+  it("always stacks at the sm size, regardless of action count", async () => {
+    render(ActionSet, { size: "sm", count: 2 });
+
+    const actionSet = screen.getByTestId("action-set");
+    await waitFor(() =>
+      expect(actionSet).toHaveClass("bx--action-set--stacking"),
+    );
+    expect(actionSet).toHaveClass("bx--btn-set--stacked");
+  });
+
+  it("stacks at the md size once there are more than two actions", async () => {
+    render(ActionSet, { size: "md", count: 3 });
+
+    const actionSet = screen.getByTestId("action-set");
+    await waitFor(() =>
+      expect(actionSet).toHaveClass("bx--action-set--stacking"),
+    );
+  });
+
+  it("does not stack at the md size with two or fewer actions", async () => {
+    render(ActionSet, { size: "md", count: 2 });
+
+    const actionSet = screen.getByTestId("action-set");
+    await waitFor(() =>
+      expect(actionSet).toHaveClass("bx--action-set--row-double"),
+    );
+    expect(actionSet).not.toHaveClass("bx--action-set--stacking");
+  });
+
+  it("never stacks at the lg size, even with three actions", async () => {
+    render(ActionSet, { size: "lg", count: 3 });
+
+    const actionSet = screen.getByTestId("action-set");
+    await waitFor(() =>
+      expect(actionSet).toHaveClass("bx--action-set--row-triple"),
+    );
+    expect(actionSet).not.toHaveClass("bx--action-set--stacking");
+  });
+
+  it("does not stack at the sm size when disableStacking is true", async () => {
+    render(ActionSet, { size: "sm", count: 2, disableStacking: true });
+
+    const actionSet = screen.getByTestId("action-set");
+    await waitFor(() =>
+      expect(actionSet).toHaveClass("bx--action-set--row-double"),
+    );
+    expect(actionSet).not.toHaveClass("bx--action-set--stacking");
+  });
+
+  it("cascades its size to child buttons that don't set their own, without overriding one that does", () => {
+    render(ActionSetSizeOverride);
+
+    const buttons = screen.getAllByRole("button");
+    expect(buttons[0]).toHaveTextContent("Cancel");
+    expect(buttons[0]).toHaveClass("bx--btn--sm");
+    expect(buttons[1]).toHaveTextContent("Save");
+    expect(buttons[1]).toHaveClass("bx--btn--field");
+    expect(buttons[1]).not.toHaveClass("bx--btn--sm");
+  });
+});

--- a/tests/Button/Button.test.ts
+++ b/tests/Button/Button.test.ts
@@ -3,6 +3,7 @@ import type ButtonComponent from "carbon-components-svelte/Button/Button.svelte"
 import type { ComponentProps } from "svelte";
 import { user } from "../utils/user";
 import Button from "./Button.test.svelte";
+import ButtonInActionSetContext from "./ButtonInActionSetContext.test.svelte";
 import ButtonInModal from "./ButtonInModal.test.svelte";
 import ButtonPortalAdjacent from "./ButtonPortalAdjacent.test.svelte";
 import HeaderGlobalActionPortal from "./HeaderGlobalActionPortal.test.svelte";
@@ -392,6 +393,20 @@ describe("Button", () => {
     const container = screen.getByTestId("badge-size-override");
     const button = container.querySelector("button");
 
+    expect(button).toHaveClass("bx--btn--lg");
+    expect(button).not.toHaveClass("bx--btn--sm");
+  });
+
+  it("falls back to the size from an ancestor `carbon:ActionSet` context", () => {
+    render(ButtonInActionSetContext);
+
+    expect(screen.getByRole("button")).toHaveClass("bx--btn--sm");
+  });
+
+  it("does not override a Button's own size with the ActionSet context", () => {
+    render(ButtonInActionSetContext, { size: "lg" });
+
+    const button = screen.getByRole("button");
     expect(button).toHaveClass("bx--btn--lg");
     expect(button).not.toHaveClass("bx--btn--sm");
   });

--- a/tests/Button/ButtonInActionSetContext.test.svelte
+++ b/tests/Button/ButtonInActionSetContext.test.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+  import Button from "carbon-components-svelte/Button/Button.svelte";
+  import type { ComponentProps } from "svelte";
+  import { setContext } from "svelte";
+  import { writable } from "svelte/store";
+
+  export let size: ComponentProps<Button>["size"] = undefined;
+
+  setContext("carbon:ActionSet", { size: writable("small") });
+</script>
+
+<Button {size}>Save</Button>

--- a/tests/ButtonSet/ButtonSet.test.svelte
+++ b/tests/ButtonSet/ButtonSet.test.svelte
@@ -1,11 +1,15 @@
+<svelte:options accessors />
+
 <script lang="ts">
   import Button from "carbon-components-svelte/Button/Button.svelte";
   import ButtonSet from "carbon-components-svelte/Button/ButtonSet.svelte";
+  import type { ComponentProps } from "svelte";
 
   export let stacked = false;
+  export let ref: ComponentProps<ButtonSet>["ref"] = null;
 </script>
 
-<ButtonSet data-testid="button-set" {stacked}>
+<ButtonSet data-testid="button-set" {stacked} bind:ref>
   <Button kind="secondary">Cancel</Button>
   <Button>Submit</Button>
 </ButtonSet>

--- a/tests/ButtonSet/ButtonSet.test.ts
+++ b/tests/ButtonSet/ButtonSet.test.ts
@@ -23,4 +23,11 @@ describe("ButtonSet", () => {
     expect(buttons[0]).toHaveTextContent("Cancel");
     expect(buttons[1]).toHaveTextContent("Submit");
   });
+
+  it("binds a reference to the outer element", () => {
+    const { component } = render(ButtonSet);
+
+    expect(component.ref).toBeInstanceOf(HTMLDivElement);
+    expect(component.ref).toBe(screen.getByTestId("button-set"));
+  });
 });


### PR DESCRIPTION
ActionSet lays out a row of action buttons for a modal or panel
footer, stacking vertically at small sizes or once there are more
than two actions. It's recently implemented in Carbon React but
is not yet released.

## Why compose over a config array

Carbon React's ActionSet takes an `actions` array of button-config
objects. That shape doesn't sit well here: event handlers on a plain
object are awkward, and every other multi-button component in this
library (`ComboButton`, `MenuButton`, `ButtonSet` itself) takes real
child components instead. ActionSet follows the same pattern: it's a
thin wrapper around `ButtonSet`, and you place ordinary `Button`
children inside it, exactly like `ButtonSet` today.

```svelte
<ActionSet size="lg">
  <Button kind="secondary">Cancel</Button>
  <Button kind="danger">Delete</Button>
  <Button>Save</Button>
</ActionSet>
```

Ordering and sizing still come for free. Buttons order themselves by
`kind` (ghost first, primary/danger last, reversed when stacked)
through plain CSS `order`, keyed off `Button`'s own
`bx--btn--{kind}` classes, so there's no JS sort to maintain. `size`
cascades down too: `Button` now reads a `carbon:ActionSet` context
to fall back to the set's size when it has none of its own, the same
pattern it already uses for `carbon:Modal`. A child that sets its
own `size` still wins.

```svelte
<ActionSet size="sm">
  <Button kind="secondary">Cancel</Button>
  <Button>Save</Button>
</ActionSet>
```

With no array to read a length off, stacking (and the
row-single/double/triple/quadruple width classes) gets measured from
the DOM through `onMount` and a `MutationObserver`, so it still
reacts if actions are added or removed after mount.

## Use cases

Modal and dialog footers are the main one, mirroring how Carbon
React itself uses ActionSet. It also fits a side panel, or any other
bounded footer that needs one to four actions with size-aware
stacking, without hand-rolling that layout math every time.

---

<img width="932" height="152" alt="Screenshot 2026-08-30 at 1 38 18 PM" src="https://github.com/user-attachments/assets/6cddf9e8-8726-4762-bfec-a6bcfee8bde0" />
<img width="461" height="203" alt="Screenshot 2026-08-30 at 1 38 14 PM" src="https://github.com/user-attachments/assets/651d2262-57bd-4592-8261-7acbe316640e" />
<img width="612" height="125" alt="Screenshot 2026-08-30 at 1 38 11 PM" src="https://github.com/user-attachments/assets/baf2ddce-6825-4ca5-b0fb-9f251f9a75ab" />

<img width="831" height="286" alt="Screenshot 2026-08-30 at 3 00 56 PM" src="https://github.com/user-attachments/assets/5ac6eb88-5dc4-4348-9ed3-28508ed6ebb8" />
