### PR TITLE
docs: use large link size for sveld attribution

### DIFF
--- a/docs/src/layouts/ComponentLayout.svelte
+++ b/docs/src/layouts/ComponentLayout.svelte
@@ -207,6 +207,7 @@
           API documentation is
           <Link
             inline
+            size="lg"
             href="https://github.com/carbon-design-system/sveld"
             target="_blank"
           >


### PR DESCRIPTION
Bumps the "auto-generated by sveld." Link to size="lg" to match the
surrounding body-long-02 text under Component API.