### PR TITLE
fix(ui-shell): add bottom padding to side-nav items list

### DIFF
--- a/css/_ui-shell.scss
+++ b/css/_ui-shell.scss
@@ -523,7 +523,7 @@
   .#{$prefix}--side-nav__items.#{$prefix}--side-nav__items {
     overflow: hidden;
     flex: 1 1 0%;
-    padding: 1rem 0 0;
+    padding: 1rem 0;
   }
 
   .#{$prefix}--side-nav--ux.#{$prefix}--side-nav--ux


### PR DESCRIPTION
The side nav items list already had 1rem of top padding but no
bottom padding, so content could butt right up against the bottom
edge. Mirrors the existing top padding for a consistent buffer.