### PR TITLE
feat(ui-shell): add `HeaderSwitcher` for account and workspace switching

### DIFF
--- a/css/_header-switcher.scss
+++ b/css/_header-switcher.scss
@@ -1,0 +1,105 @@
+// HeaderSwitcher: a header trigger (avatar + text + chevron) that opens an
+// anchored dropdown for switching between workspaces or accounts. The menu
+// anchors to the trigger itself, not the header edge, since the trigger can
+// sit anywhere in the header (unlike ProfileMenu, which assumes the
+// right-most position). Colors come from theme tokens; see _profile-menu.scss.
+
+@import "carbon-components/scss/globals/scss/vars";
+@import "carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/import-once/import-once";
+
+/// HeaderSwitcher component styles (trigger layout, chevron, anchored menu).
+/// @access private
+/// @group ui-shell
+@mixin header-switcher {
+  .#{$prefix}--header-switcher {
+    position: relative;
+    display: inline-flex;
+  }
+
+  // Sized to match `UserAvatar` `size="sm"` exactly (both `$spacing-06`) so a
+  // slotted `UserAvatar` fills the frame flush, with no halo of
+  // `$background-hover` showing around it. A plain icon in the `avatar` slot
+  // keeps its own (default 16px) size, centered by `align-items`/
+  // `justify-content` below — see the `svg` rule note.
+  .#{$prefix}--header-switcher__avatar {
+    display: flex;
+    flex-shrink: 0;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+    border-radius: 50%;
+    background-color: $background-hover;
+    color: $icon-primary;
+    width: $spacing-06;
+    height: $spacing-06;
+  }
+
+  // Only stretch a raw `img` (a photo slotted without `UserAvatar`) to fill
+  // the frame. A plain icon must NOT match this — stretching a 16px glyph to
+  // the full 24px frame renders oversized and blurry.
+  .#{$prefix}--header-switcher__avatar > img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+
+  // `min-width: 0` overrides the flex item's default `auto` minimum, which
+  // would otherwise let the text's intrinsic content width win over
+  // `max-width` (set via the `maxWidth` prop) and defeat truncation.
+  // `text-align: left` overrides the browser's default centered text-align
+  // on `<button>`, which otherwise centers a second line if the text ever
+  // wraps (for example `maxWidth="none"` inside a width-constrained header).
+  .#{$prefix}--header-switcher__text {
+    overflow: hidden;
+    min-width: 0;
+    text-align: left;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  // `.#{$prefix}--header__action-text`'s `margin-left` assumes a preceding
+  // icon/avatar. Without one (no `avatar` slot), that margin is a stray gap
+  // before the text — cancel it.
+  .#{$prefix}--header-switcher__text--flush.#{$prefix}--header-switcher__text--flush {
+    margin-left: 0;
+  }
+
+  .#{$prefix}--header-switcher__chevron {
+    display: flex;
+    flex-shrink: 0;
+    margin-left: $spacing-03;
+    transition: transform 110ms cubic-bezier(0.2, 0, 0.38, 0.9);
+  }
+
+  .#{$prefix}--header-switcher__chevron > svg {
+    fill: $icon-primary;
+  }
+
+  .#{$prefix}--header-switcher__chevron--open {
+    transform: rotate(180deg);
+  }
+
+  // Reserve the full focus border-width at rest (transparent) so `:focus`
+  // only swaps the border color instead of growing the border, which would
+  // otherwise shift this auto-width trigger's content by a couple of pixels.
+  .#{$prefix}--header-switcher__trigger.#{$prefix}--header-switcher__trigger {
+    border-width: $button-border-width;
+    border-color: transparent;
+    // Offset the reserved border so the avatar lands at the same inset as
+    // `.#{$prefix}--profile-menu__item`'s avatar (padding only, no border)
+    // in the menu below, keeping both flush with the same left edge.
+    padding-left: calc(#{$spacing-05} - #{$button-border-width});
+  }
+
+  .#{$prefix}--header-switcher__menu.#{$prefix}--header-switcher__menu {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: auto;
+    width: 16rem;
+  }
+}
+
+@include exports("header-switcher") {
+  @include header-switcher;
+}

--- a/css/_profile-menu.scss
+++ b/css/_profile-menu.scss
@@ -127,7 +127,8 @@
     align-items: center;
     justify-content: space-between;
     width: 100%;
-    min-height: 2rem;
+    // Tall enough to fit a leading `sm` (1.5rem) avatar with breathing room.
+    min-height: 2.5rem;
     margin: 0;
     padding: 0 $spacing-05;
     color: $text-secondary;
@@ -154,6 +155,32 @@
     flex-shrink: 0;
     fill: $icon-primary;
   }
+
+  // `min-width: 0` lets this flex child shrink below its content size, which
+  // `.#{$prefix}--profile-menu__item-text` needs in order to truncate instead
+  // of forcing the row (and the menu) wider.
+  .#{$prefix}--profile-menu__item-label {
+    display: flex;
+    flex: 1;
+    align-items: center;
+    min-width: 0;
+    gap: $spacing-03;
+  }
+
+  .#{$prefix}--profile-menu__item-avatar {
+    display: flex;
+    flex-shrink: 0;
+  }
+
+  .#{$prefix}--profile-menu__item-text {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  //--------------------------------------------------------------------------
+  // Detail row (label / value / trailing action)
+  //--------------------------------------------------------------------------
 
   .#{$prefix}--profile-menu__detail {
     display: flex;

--- a/css/all.scss
+++ b/css/all.scss
@@ -125,6 +125,7 @@ $css--plex: true;
 @import "./dialog";
 @import "./link";
 @import "./profile-menu";
+@import "./header-switcher";
 @import "./user-avatar";
 @import "./user-avatar-group";
 @import "./disclosure";

--- a/css/g10.scss
+++ b/css/g10.scss
@@ -85,6 +85,7 @@ $css--plex: true;
 @import "./dialog";
 @import "./link";
 @import "./profile-menu";
+@import "./header-switcher";
 @import "./user-avatar";
 @import "./user-avatar-group";
 @import "./disclosure";

--- a/css/g100.scss
+++ b/css/g100.scss
@@ -85,6 +85,7 @@ $css--plex: true;
 @import "./dialog";
 @import "./link";
 @import "./profile-menu";
+@import "./header-switcher";
 @import "./user-avatar";
 @import "./user-avatar-group";
 @import "./disclosure";

--- a/css/g80.scss
+++ b/css/g80.scss
@@ -85,6 +85,7 @@ $css--plex: true;
 @import "./dialog";
 @import "./link";
 @import "./profile-menu";
+@import "./header-switcher";
 @import "./user-avatar";
 @import "./user-avatar-group";
 @import "./disclosure";

--- a/css/g90.scss
+++ b/css/g90.scss
@@ -85,6 +85,7 @@ $css--plex: true;
 @import "./dialog";
 @import "./link";
 @import "./profile-menu";
+@import "./header-switcher";
 @import "./user-avatar";
 @import "./user-avatar-group";
 @import "./disclosure";

--- a/css/white.scss
+++ b/css/white.scss
@@ -85,6 +85,7 @@ $css--plex: true;
 @import "./dialog";
 @import "./link";
 @import "./profile-menu";
+@import "./header-switcher";
 @import "./user-avatar";
 @import "./user-avatar-group";
 @import "./disclosure";

--- a/docs/src/pages/components/UIShell.svx
+++ b/docs/src/pages/components/UIShell.svx
@@ -17,6 +17,7 @@ components: ["Header",
 "ProfileMenuItem",
 "ProfileMenuDetail",
 "ProfileMenuDivider",
+"HeaderSwitcher",
 "SideNav",
 "SideNavItems",
 "SideNavLink",
@@ -304,6 +305,52 @@ Add `ProfileMenuDetail` for labelled values with a trailing action, and pass an 
 >
   <ProfileMenuList>...</ProfileMenuList>
 </ProfileMenu>
+```
+
+## Account switcher
+
+Use `HeaderSwitcher` in place of the header logo to let users switch between accounts or workspaces. The trigger shows the active account name; the chevron rotates to indicate the open state.
+
+_Prototype — pending review._
+
+<FileSource src="/framed/UIShell/HeaderSwitcherWorkspace" />
+
+Compose the dropdown from [`ProfileMenuList`](#profile-menu) and `ProfileMenuItem`, as shown above. Pass an `icon` to `ProfileMenuItem` to mark the active account, and use its `avatar` slot for a leading avatar. The label truncates with an ellipsis when the name overflows the menu width, as shown by the last item.
+
+The trigger's `text` truncates with an ellipsis past `maxWidth`, defaulting to `"10rem"`, so a long account name does not push the header wider. Set `maxWidth` to a different CSS length, or to `"none"` to let the trigger grow with the text instead.
+
+<DocKbd label="ArrowDown" /> and <DocKbd label="ArrowUp" /> from the trigger open the menu and move focus to the first or last item. Once inside, <DocKbd label="ArrowDown" />/<DocKbd label="ArrowUp" /> move between items (wrapping at either end), <DocKbd label="Home" />/<DocKbd label="End" /> jump to the first or last item, and <DocKbd label="Escape" /> closes the menu and returns focus to the trigger.
+
+### No avatar
+
+Neither `HeaderSwitcher` nor `ProfileMenuItem` renders a default avatar — the `avatar` slot is empty unless you provide one. Omit it on both for a text-only trigger and menu.
+
+<FileSource src="/framed/UIShell/HeaderSwitcherNoAvatar" />
+
+### Without a logo
+
+Omit `companyName` and `platformName` on `Header` to make `HeaderSwitcher` the only brand element.
+
+<FileSource src="/framed/UIShell/HeaderSwitcherNoLogo" />
+
+### Icon avatar
+
+Use the `avatar` slot to render a plain icon instead of a `UserAvatar`, for example a fixed brand icon rather than a per-account photo.
+
+<FileSource src="/framed/UIShell/HeaderSwitcherIconAvatar" />
+
+### Events
+
+`HeaderSwitcher` dispatches `open` and `close` as the menu toggles, with `event.detail.trigger` set to `"toggle"`, `"outside-click"`, or `"escape-key"` (`close` only):
+
+```svelte
+<HeaderSwitcher
+  bind:isOpen
+  on:open={(event) => console.log(event.detail.trigger)}
+  on:close={(event) => console.log(event.detail.trigger)}
+>
+  <ProfileMenuList>...</ProfileMenuList>
+</HeaderSwitcher>
 ```
 
 ## Integrations

--- a/docs/src/pages/components/UIShell.svx
+++ b/docs/src/pages/components/UIShell.svx
@@ -277,6 +277,8 @@ When the `avatar` slot is empty, a default [UserAvatar](/components/UserAvatar) 
 
 <FileSource src="/framed/UIShell/ProfileMenuDefaultAvatar" />
 
+From the trigger, <DocKbd label="ArrowDown" />/<DocKbd label="ArrowUp" /> open the menu and move focus to the first or last `ProfileMenuItem`. Once inside, <DocKbd label="ArrowDown" />/<DocKbd label="ArrowUp" /> move between items (wrapping at either end), and <DocKbd label="Home" />/<DocKbd label="End" /> jump to the first or last item.
+
 ### Composed menu
 
 Render the avatar with [UserAvatar](/components/UserAvatar) in the `avatar` slot, and compose the card from `ProfileMenuHeader`, `ProfileMenuList`, `ProfileMenuItem`, and `ProfileMenuDivider`.

--- a/docs/src/pages/framed/UIShell/HeaderSwitcherIconAvatar.svelte
+++ b/docs/src/pages/framed/UIShell/HeaderSwitcherIconAvatar.svelte
@@ -1,0 +1,65 @@
+<script>
+  import {
+    Column,
+    Content,
+    Grid,
+    Header,
+    HeaderSwitcher,
+    ProfileMenuItem,
+    ProfileMenuList,
+    Row,
+    SkipToContent,
+    UserAvatar,
+  } from "carbon-components-svelte";
+  import Checkmark from "carbon-icons-svelte/lib/Checkmark.svelte";
+  import Enterprise from "carbon-icons-svelte/lib/Enterprise.svelte";
+
+  const workspaces = [
+    { id: "acme", name: "Acme Corp" },
+    { id: "globex", name: "Globex Industries" },
+  ];
+
+  let activeId = "acme";
+
+  $: active = workspaces.find((workspace) => workspace.id === activeId);
+</script>
+
+<Header>
+  <svelte:fragment slot="skipToContent"> <SkipToContent /> </svelte:fragment>
+  <HeaderSwitcher text={active.name}>
+    <svelte:fragment slot="avatar">
+      <Enterprise size={16} />
+    </svelte:fragment>
+    <ProfileMenuList>
+      {#each workspaces as workspace (workspace.id)}
+        <ProfileMenuItem
+          icon={workspace.id === activeId ? Checkmark : undefined}
+          on:click={() => (activeId = workspace.id)}
+        >
+          <svelte:fragment slot="avatar">
+            <UserAvatar
+              name={workspace.name}
+              backgroundColor="auto"
+              size="sm"
+            />
+          </svelte:fragment>
+          {workspace.name}
+        </ProfileMenuItem>
+      {/each}
+    </ProfileMenuList>
+  </HeaderSwitcher>
+</Header>
+
+<Content>
+  <Grid>
+    <Row>
+      <Column>
+        <h1>{active.name}</h1>
+        <p>
+          A plain icon in the <code>avatar</code> slot replaces the
+          per-workspace photo with a fixed brand icon.
+        </p>
+      </Column>
+    </Row>
+  </Grid>
+</Content>

--- a/docs/src/pages/framed/UIShell/HeaderSwitcherNoAvatar.svelte
+++ b/docs/src/pages/framed/UIShell/HeaderSwitcherNoAvatar.svelte
@@ -1,0 +1,57 @@
+<script>
+  import {
+    Column,
+    Content,
+    Grid,
+    Header,
+    HeaderSwitcher,
+    ProfileMenuItem,
+    ProfileMenuList,
+    Row,
+    SkipToContent,
+  } from "carbon-components-svelte";
+  import Checkmark from "carbon-icons-svelte/lib/Checkmark.svelte";
+
+  const accounts = [
+    { id: "acme", name: "Acme Corp" },
+    { id: "globex", name: "Globex Industries" },
+    { id: "initech", name: "Initech" },
+  ];
+
+  let activeId = "acme";
+  let isOpen = false;
+
+  $: active = accounts.find((account) => account.id === activeId);
+</script>
+
+<Header companyName="IBM" platformName="Cloud">
+  <svelte:fragment slot="skipToContent"> <SkipToContent /> </svelte:fragment>
+  <HeaderSwitcher text={active.name} bind:isOpen>
+    <ProfileMenuList>
+      {#each accounts as account (account.id)}
+        <ProfileMenuItem
+          icon={account.id === activeId ? Checkmark : undefined}
+          on:click={() => {
+            activeId = account.id;
+            isOpen = false;
+          }}
+        >
+          {account.name}
+        </ProfileMenuItem>
+      {/each}
+    </ProfileMenuList>
+  </HeaderSwitcher>
+</Header>
+
+<Content>
+  <Grid>
+    <Row>
+      <Column>
+        <h1>{active.name}</h1>
+        <p>
+          No avatar slot on the trigger or the items — a text-only switcher.
+        </p>
+      </Column>
+    </Row>
+  </Grid>
+</Content>

--- a/docs/src/pages/framed/UIShell/HeaderSwitcherNoLogo.svelte
+++ b/docs/src/pages/framed/UIShell/HeaderSwitcherNoLogo.svelte
@@ -1,0 +1,58 @@
+<script>
+  import {
+    Column,
+    Content,
+    Grid,
+    Header,
+    HeaderSwitcher,
+    ProfileMenuItem,
+    ProfileMenuList,
+    Row,
+    SkipToContent,
+    UserAvatar,
+  } from "carbon-components-svelte";
+  import Checkmark from "carbon-icons-svelte/lib/Checkmark.svelte";
+
+  const workspaces = [
+    { id: "acme", name: "Acme Corp" },
+    { id: "globex", name: "Globex Industries" },
+  ];
+
+  let activeId = "acme";
+
+  $: active = workspaces.find((workspace) => workspace.id === activeId);
+</script>
+
+<Header>
+  <svelte:fragment slot="skipToContent"> <SkipToContent /> </svelte:fragment>
+  <HeaderSwitcher text={active.name}>
+    <svelte:fragment slot="avatar">
+      <UserAvatar name={active.name} backgroundColor="auto" size="sm" />
+    </svelte:fragment>
+    <ProfileMenuList>
+      {#each workspaces as workspace (workspace.id)}
+        <ProfileMenuItem
+          icon={workspace.id === activeId ? Checkmark : undefined}
+          on:click={() => (activeId = workspace.id)}
+        >
+          {workspace.name}
+        </ProfileMenuItem>
+      {/each}
+    </ProfileMenuList>
+  </HeaderSwitcher>
+</Header>
+
+<Content>
+  <Grid>
+    <Row>
+      <Column>
+        <h1>{active.name}</h1>
+        <p>
+          No <code>companyName</code> or <code>platformName</code> is set, so
+          the header renders without a name link. <code>HeaderSwitcher</code> is
+          the only brand element.
+        </p>
+      </Column>
+    </Row>
+  </Grid>
+</Content>

--- a/docs/src/pages/framed/UIShell/HeaderSwitcherWorkspace.svelte
+++ b/docs/src/pages/framed/UIShell/HeaderSwitcherWorkspace.svelte
@@ -1,0 +1,76 @@
+<script>
+  import {
+    Column,
+    Content,
+    Grid,
+    Header,
+    HeaderSwitcher,
+    ProfileMenuDivider,
+    ProfileMenuItem,
+    ProfileMenuList,
+    Row,
+    SkipToContent,
+    UserAvatar,
+  } from "carbon-components-svelte";
+  import Add from "carbon-icons-svelte/lib/Add.svelte";
+  import Checkmark from "carbon-icons-svelte/lib/Checkmark.svelte";
+
+  const workspaces = [
+    { id: "acme", name: "Acme Corp" },
+    { id: "globex", name: "Globex Industries" },
+    { id: "initech", name: "Initech" },
+    {
+      id: "umbrella",
+      name: "Umbrella Regional Distribution & Logistics Cooperative",
+    },
+  ];
+
+  let activeId = "acme";
+  let isOpen = false;
+
+  $: active = workspaces.find((workspace) => workspace.id === activeId);
+</script>
+
+<Header companyName="IBM" platformName="Cloud">
+  <svelte:fragment slot="skipToContent"> <SkipToContent /> </svelte:fragment>
+  <HeaderSwitcher text={active.name} bind:isOpen>
+    <svelte:fragment slot="avatar">
+      <UserAvatar name={active.name} backgroundColor="auto" size="sm" />
+    </svelte:fragment>
+    <ProfileMenuList>
+      {#each workspaces as workspace (workspace.id)}
+        <ProfileMenuItem
+          icon={workspace.id === activeId ? Checkmark : undefined}
+          on:click={() => {
+            activeId = workspace.id;
+            isOpen = false;
+          }}
+        >
+          <svelte:fragment slot="avatar">
+            <UserAvatar
+              name={workspace.name}
+              backgroundColor="auto"
+              size="sm"
+            />
+          </svelte:fragment>
+          {workspace.name}
+        </ProfileMenuItem>
+      {/each}
+    </ProfileMenuList>
+    <ProfileMenuDivider />
+    <ProfileMenuList>
+      <ProfileMenuItem icon={Add}>Create workspace</ProfileMenuItem>
+    </ProfileMenuList>
+  </HeaderSwitcher>
+</Header>
+
+<Content>
+  <Grid>
+    <Row>
+      <Column>
+        <h1>{active.name}</h1>
+        <p>Switch workspaces from the trigger in the header above.</p>
+      </Column>
+    </Row>
+  </Grid>
+</Content>

--- a/src/UIShell/Header.svelte
+++ b/src/UIShell/Header.svelte
@@ -163,19 +163,21 @@
       ariaLabel={hamburgerAriaLabel}
     />
   {/if}
-  <a
-    {href}
-    class:bx--header__name={true}
-    bind:this={ref}
-    {...$$restProps}
-    on:click
-  >
-    {#if companyName || $$slots.company}
-      <span class:bx--header__name--prefix={true}
-        ><slot name="company">{companyName}&nbsp;</slot></span
-      >
-    {/if}
-    <slot name="platform">{platformName}</slot>
-  </a>
+  {#if companyName || platformName || $$slots.company || $$slots.platform}
+    <a
+      {href}
+      class:bx--header__name={true}
+      bind:this={ref}
+      {...$$restProps}
+      on:click
+    >
+      {#if companyName || $$slots.company}
+        <span class:bx--header__name--prefix={true}
+          ><slot name="company">{companyName}&nbsp;</slot></span
+        >
+      {/if}
+      <slot name="platform">{platformName}</slot>
+    </a>
+  {/if}
   <slot />
 </header>

--- a/src/UIShell/HeaderSwitcher.svelte
+++ b/src/UIShell/HeaderSwitcher.svelte
@@ -1,0 +1,192 @@
+<script>
+  /**
+   * @event open
+   * @type {object}
+   * @property {"toggle"} trigger
+   * @event close
+   * @type {object}
+   * @property {"outside-click" | "toggle" | "escape-key"} trigger
+   * @slot {{}} avatar - Optional leading avatar. Renders nothing by default.
+   */
+
+  /**
+   * Set to `true` to open the menu.
+   * @bindable writable
+   */
+  export let isOpen = false;
+
+  /**
+   * Specify the workspace or account name shown next to the avatar.
+   * @type {string}
+   */
+  export let text = undefined;
+
+  /**
+   * Specify the maximum width of `text` before it truncates with an ellipsis.
+   * A number is treated as pixels; a string is used as a CSS length.
+   * Set to `"none"` to let the trigger grow with the text.
+   * @type {number | string}
+   */
+  export let maxWidth = "10rem";
+
+  /**
+   * Specify the accessible label for the trigger button.
+   * Only used when `text` is not set.
+   * @type {string}
+   */
+  export let iconDescription = "Switch account";
+
+  /**
+   * Obtain a reference to the trigger button HTML element.
+   * @bindable readonly
+   * @type {null | HTMLButtonElement}
+   */
+  export let ref = null;
+
+  /**
+   * Customize the menu slide transition (for example, `{ duration: 200 }`).
+   * By default, the menu does not animate.
+   * @type {false | import("svelte/transition").SlideParams}
+   */
+  export let transition = false;
+
+  /** Set to `true` to prevent the menu from closing when clicking outside */
+  export let preventCloseOnClickOutside = false;
+
+  import { createEventDispatcher, setContext, tick } from "svelte";
+  import { get, writable } from "svelte/store";
+  import { slide } from "svelte/transition";
+  import ChevronDown from "../icons/ChevronDown.svelte";
+  import { dismiss } from "../utils/dismiss.js";
+  import { isOutsideClick } from "../utils/isOutsideClick.js";
+
+  const dispatch = createEventDispatcher();
+
+  let refMenu = null;
+
+  /** @type {import("svelte/store").Writable<ReadonlyArray<HTMLElement>>} */
+  const menuItems = writable([]);
+
+  function registerMenuItem(element) {
+    menuItems.update((items) => [...items, element]);
+  }
+
+  function unregisterMenuItem(element) {
+    menuItems.update((items) => items.filter((item) => item !== element));
+  }
+
+  setContext("carbon:ProfileMenu", {
+    menuItems,
+    registerMenuItem,
+    unregisterMenuItem,
+  });
+
+  $: maxWidthStyle = typeof maxWidth === "number" ? `${maxWidth}px` : maxWidth;
+
+  function close(trigger) {
+    isOpen = false;
+    dispatch("close", { trigger });
+  }
+
+  function handleOutsideClick(event) {
+    if (
+      isOpen &&
+      !preventCloseOnClickOutside &&
+      isOutsideClick(event, [ref, refMenu])
+    ) {
+      close("outside-click");
+    }
+  }
+
+  function handleKeydown(event) {
+    if (isOpen && event.key === "Escape") {
+      close("escape-key");
+      ref?.focus();
+    }
+  }
+
+  async function handleTriggerKeydown(event) {
+    if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+      event.preventDefault();
+      if (!isOpen) {
+        isOpen = true;
+        dispatch("open", { trigger: "toggle" });
+      }
+      await tick();
+      const items = get(menuItems);
+      if (event.key === "ArrowDown") {
+        items[0]?.focus();
+      } else {
+        items[items.length - 1]?.focus();
+      }
+    }
+  }
+</script>
+
+<span class:bx--header-switcher={true}>
+  <button
+    bind:this={ref}
+    use:dismiss={{
+      enabled: isOpen,
+      listeners: [
+        { type: "click", handler: handleOutsideClick },
+        { type: "keydown", handler: handleKeydown },
+      ],
+    }}
+    type="button"
+    aria-haspopup="true"
+    aria-expanded={isOpen}
+    aria-label={text ? undefined : iconDescription}
+    class:bx--header__action={true}
+    class:bx--header__action--active={isOpen}
+    class:bx--header__action--text={true}
+    class:bx--header-switcher__trigger={true}
+    {...$$restProps}
+    on:click
+    on:click|stopPropagation={async (event) => {
+      const wasOpen = isOpen;
+      isOpen = !isOpen;
+      dispatch(isOpen ? "open" : "close", { trigger: "toggle" });
+      if (!wasOpen && isOpen && event.detail === 0) {
+        await tick();
+        get(menuItems)[0]?.focus();
+      }
+    }}
+    on:keydown={handleTriggerKeydown}
+  >
+    {#if $$slots.avatar}
+      <span class:bx--header-switcher__avatar={true}>
+        <slot name="avatar" />
+      </span>
+    {/if}
+    {#if text}
+      <span
+        class:bx--header__action-text={true}
+        class:bx--header-switcher__text={true}
+        class:bx--header-switcher__text--flush={!$$slots.avatar}
+        style:max-width={maxWidthStyle}
+        >{text}</span
+      >
+    {/if}
+    <span
+      class:bx--header-switcher__chevron={true}
+      class:bx--header-switcher__chevron--open={isOpen}
+    >
+      <ChevronDown size={16} />
+    </span>
+  </button>
+  {#if isOpen}
+    <div
+      bind:this={refMenu}
+      aria-label={iconDescription}
+      class:bx--profile-menu={true}
+      class:bx--header-switcher__menu={true}
+      transition:slide|local={{
+        ...transition,
+        duration: transition === false ? 0 : transition.duration,
+      }}
+    >
+      <slot />
+    </div>
+  {/if}
+</span>

--- a/src/UIShell/ProfileMenu.svelte
+++ b/src/UIShell/ProfileMenu.svelte
@@ -34,7 +34,8 @@
   /** Set to `true` to prevent the menu from closing when clicking outside */
   export let preventCloseOnClickOutside = false;
 
-  import { createEventDispatcher } from "svelte";
+  import { createEventDispatcher, setContext, tick } from "svelte";
+  import { get, writable } from "svelte/store";
   import { slide } from "svelte/transition";
   import UserAvatar from "../UserAvatar/UserAvatar.svelte";
   import { dismiss } from "../utils/dismiss.js";
@@ -43,6 +44,23 @@
   const dispatch = createEventDispatcher();
 
   let refMenu = null;
+
+  /** @type {import("svelte/store").Writable<ReadonlyArray<HTMLElement>>} */
+  const menuItems = writable([]);
+
+  function registerMenuItem(element) {
+    menuItems.update((items) => [...items, element]);
+  }
+
+  function unregisterMenuItem(element) {
+    menuItems.update((items) => items.filter((item) => item !== element));
+  }
+
+  setContext("carbon:ProfileMenu", {
+    menuItems,
+    registerMenuItem,
+    unregisterMenuItem,
+  });
 
   function close() {
     isOpen = false;
@@ -65,6 +83,23 @@
       ref?.focus();
     }
   }
+
+  async function handleTriggerKeydown(event) {
+    if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+      event.preventDefault();
+      if (!isOpen) {
+        isOpen = true;
+        dispatch("open");
+      }
+      await tick();
+      const items = get(menuItems);
+      if (event.key === "ArrowDown") {
+        items[0]?.focus();
+      } else {
+        items[items.length - 1]?.focus();
+      }
+    }
+  }
 </script>
 
 <button
@@ -85,10 +120,16 @@
   class:bx--profile-menu__trigger={true}
   {...$$restProps}
   on:click
-  on:click|stopPropagation={() => {
+  on:click|stopPropagation={async (event) => {
+    const wasOpen = isOpen;
     isOpen = !isOpen;
     dispatch(isOpen ? "open" : "close");
+    if (!wasOpen && isOpen && event.detail === 0) {
+      await tick();
+      get(menuItems)[0]?.focus();
+    }
   }}
+  on:keydown={handleTriggerKeydown}
 >
   <span class:bx--profile-menu__avatar={true}>
     <slot name="avatar"><UserAvatar size="md" /></slot>

--- a/src/UIShell/ProfileMenuItem.svelte
+++ b/src/UIShell/ProfileMenuItem.svelte
@@ -1,5 +1,8 @@
 <script>
-  /** @template [Icon=any] */
+  /**
+   * @template [Icon=any]
+   * @slot {{}} avatar - Leading avatar rendered before the label. The label truncates to make room for it.
+   */
 
   /**
    * Specify the `href` attribute to render an anchor.
@@ -21,6 +24,45 @@
    * @type {null | HTMLAnchorElement | HTMLButtonElement}
    */
   export let ref = null;
+
+  import { getContext, onMount } from "svelte";
+  import { moveIndex } from "../utils/moveIndex.js";
+
+  const ctx = getContext("carbon:ProfileMenu");
+
+  let menuItems = [];
+  const unsubMenuItems = ctx?.menuItems.subscribe((_menuItems) => {
+    menuItems = _menuItems;
+  });
+
+  onMount(() => {
+    if (ctx && ref) ctx.registerMenuItem(ref);
+    return () => {
+      unsubMenuItems?.();
+      if (ctx && ref) ctx.unregisterMenuItem(ref);
+    };
+  });
+
+  function handleKeydown(event) {
+    if (!ctx) return;
+
+    const currentIndex = menuItems.indexOf(ref);
+    if (currentIndex === -1) return;
+
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      menuItems[moveIndex(currentIndex, 1, menuItems.length)]?.focus();
+    } else if (event.key === "ArrowUp") {
+      event.preventDefault();
+      menuItems[moveIndex(currentIndex, -1, menuItems.length)]?.focus();
+    } else if (event.key === "Home") {
+      event.preventDefault();
+      menuItems[0]?.focus();
+    } else if (event.key === "End") {
+      event.preventDefault();
+      menuItems[menuItems.length - 1]?.focus();
+    }
+  }
 </script>
 
 {#if href}
@@ -31,8 +73,17 @@
     class:bx--profile-menu__item={true}
     {...$$restProps}
     on:click
+    on:keydown
+    on:keydown={handleKeydown}
   >
-    <span class:bx--profile-menu__item-label={true}><slot /></span>
+    <span class:bx--profile-menu__item-label={true}>
+      {#if $$slots.avatar}
+        <span class:bx--profile-menu__item-avatar={true}
+          ><slot name="avatar" /></span
+        >
+      {/if}
+      <span class:bx--profile-menu__item-text={true}><slot /></span>
+    </span>
     {#if $$slots.icon || icon}
       <slot name="icon"><svelte:component this={icon} size={16} /></slot>
     {/if}
@@ -44,8 +95,17 @@
     class:bx--profile-menu__item={true}
     {...$$restProps}
     on:click
+    on:keydown
+    on:keydown={handleKeydown}
   >
-    <span class:bx--profile-menu__item-label={true}><slot /></span>
+    <span class:bx--profile-menu__item-label={true}>
+      {#if $$slots.avatar}
+        <span class:bx--profile-menu__item-avatar={true}
+          ><slot name="avatar" /></span
+        >
+      {/if}
+      <span class:bx--profile-menu__item-text={true}><slot /></span>
+    </span>
     {#if $$slots.icon || icon}
       <slot name="icon"><svelte:component this={icon} size={16} /></slot>
     {/if}

--- a/src/UIShell/index.js
+++ b/src/UIShell/index.js
@@ -11,6 +11,7 @@ export { default as HeaderPanelLink } from "./HeaderPanelLink.svelte";
 export { default as HeaderPanelLinks } from "./HeaderPanelLinks.svelte";
 export { default as HeaderSearch } from "./HeaderSearch.svelte";
 export { default as HeaderSideNavItems } from "./HeaderSideNavItems.svelte";
+export { default as HeaderSwitcher } from "./HeaderSwitcher.svelte";
 export { default as HeaderUtilities } from "./HeaderUtilities.svelte";
 export { default as ProfileMenu } from "./ProfileMenu.svelte";
 export { default as ProfileMenuDetail } from "./ProfileMenuDetail.svelte";

--- a/src/index.js
+++ b/src/index.js
@@ -217,6 +217,7 @@ export { default as HeaderPanelLink } from "./UIShell/HeaderPanelLink.svelte";
 export { default as HeaderPanelLinks } from "./UIShell/HeaderPanelLinks.svelte";
 export { default as HeaderSearch } from "./UIShell/HeaderSearch.svelte";
 export { default as HeaderSideNavItems } from "./UIShell/HeaderSideNavItems.svelte";
+export { default as HeaderSwitcher } from "./UIShell/HeaderSwitcher.svelte";
 export { default as HeaderUtilities } from "./UIShell/HeaderUtilities.svelte";
 export { default as ProfileMenu } from "./UIShell/ProfileMenu.svelte";
 export { default as ProfileMenuDetail } from "./UIShell/ProfileMenuDetail.svelte";


### PR DESCRIPTION
Adds `HeaderSwitcher`, a prototype header trigger for switching
accounts or workspaces. The dropdown reuses `ProfileMenuList` and
`ProfileMenuItem`.

- `HeaderSwitcher`: avatar, truncated label, chevron, and an
  anchored menu that opens from the trigger
- `Header`: skip the brand name link when company and platform
  are unset, so the switcher can sit alone
- `ProfileMenuItem`: leading avatar slot; overflowing labels
  truncate with an ellipsis
- `ProfileMenu`: ArrowDown/ArrowUp from the trigger, then
  ArrowDown/ArrowUp/Home/End between items
- docs for `ProfileMenu` keyboard navigation
- docs for `HeaderSwitcher` (workspace, no avatar, no logo,
  icon avatar)

---

<img width="496" height="242" alt="Screenshot 2026-08-30 at 5 55 51 PM" src="https://github.com/user-attachments/assets/810c488c-3c79-47ca-9e74-5dcf0d37c04c" />
<img width="645" height="234" alt="Screenshot 2026-08-30 at 5 55 46 PM" src="https://github.com/user-attachments/assets/ed7e8cea-5bf2-471e-9b1c-76a6e04dca92" />
<img width="672" height="320" alt="Screenshot 2026-08-30 at 5 55 39 PM" src="https://github.com/user-attachments/assets/9fbb965a-fb97-4681-961e-1909328c26b9" />
