### PR TITLE
docs(action-set): add catalog thumbnail

### DIFF
--- a/carbon.yml
+++ b/carbon.yml
@@ -54,6 +54,19 @@ assets:
         name: Documentation
         action: link
         url: https://svelte.carbondesignsystem.com/components/Accordion
+  action-set:
+    name: Action set
+    description: A row of action buttons for a custom modal or panel footer that automatically stacks vertically at small sizes or with more than two actions.
+    status: stable
+    type: component
+    platform: web
+    framework: svelte
+    thumbnailPath: './thumbnails/action-set.svg'
+    demoLinks:
+      - type: other
+        name: Documentation
+        action: link
+        url: https://svelte.carbondesignsystem.com/components/ActionSet
   aspect-ratio:
     status: stable
     framework: svelte

--- a/thumbnails/action-set.svg
+++ b/thumbnails/action-set.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="320px" height="180px" viewBox="0 0 320 180" version="1.1" xmlns="http://www.w3.org/2000/svg">
+    <title>action-set</title>
+    <g id="action-set" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="ghost">
+            <rect id="ghost-label" fill="var(--cds-interactive-01, #0f62fe)" x="68" y="86" width="28" height="8"></rect>
+        </g>
+        <g id="secondary">
+            <rect id="secondary-button" fill="var(--cds-button-secondary, #393939)" x="124" y="74" width="71" height="32"></rect>
+            <rect id="secondary-label" fill="var(--cds-field-01, #f4f4f4)" x="140" y="86" width="28" height="8"></rect>
+        </g>
+        <g id="primary">
+            <rect id="primary-button" fill="var(--cds-interactive-01, #0f62fe)" x="196" y="74" width="71" height="32"></rect>
+            <rect id="primary-label" fill="var(--cds-ui-02, #ffffff)" x="212" y="86" width="28" height="8"></rect>
+        </g>
+    </g>
+</svg>


### PR DESCRIPTION
The Carbon platform catalog had no ActionSet tile. The thumbnail uses
the 320x180 token style of other Svelte-only components, with ghost,
secondary, and primary actions so it doesn't read as ButtonSet.

![action-set](https://raw.githubusercontent.com/carbon-design-system/carbon-components-svelte/metonym/new-components-tiles/thumbnails/action-set.svg)
