### PR TITLE
feat(card): add Card component

### DIFF
--- a/css/_card.scss
+++ b/css/_card.scss
@@ -1,0 +1,411 @@
+@import "carbon-components/scss/globals/scss/vars";
+@import "carbon-components/scss/globals/scss/helper-mixins";
+@import "carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/import-once/import-once";
+@import "carbon-components/scss/globals/scss/typography";
+@import "carbon-components/scss/globals/scss/motion";
+
+/// Card lays out a composable Header/Body/Footer/Media container. Ported
+/// from Carbon React's `preview__Card`
+/// (`packages/styles/scss/components/card`), mapped from v11 tokens to this
+/// repo's v10 equivalents (`layer` -> `$ui-01`, `text-primary` -> `$text-01`,
+/// and so on). Every `:has()` in the upstream stylesheet is replaced with an
+/// explicit marker class set by a component prop
+/// (`bx--card__footer--action-set`, `bx--card__action--icon-only`) or, for
+/// the title/title-media pairing, a `+` adjacent-sibling selector, since
+/// `:has()` exceeds this library's browser support baseline.
+/// @access public
+/// @group card
+@mixin card {
+  // ─── Base ────────────────────────────────────────────────────────────
+  .#{$prefix}--card {
+    position: relative;
+    background-color: $ui-01;
+    color: $text-01;
+  }
+
+  // ─── Clickable ───────────────────────────────────────────────────────
+  .#{$prefix}--card--clickable {
+    display: block;
+    border: 1px solid $ui-03;
+    cursor: pointer;
+    text-decoration: none;
+    transition: background-color $duration--fast-02 motion(standard, productive);
+
+    &:hover {
+      background-color: $hover-ui;
+    }
+
+    &:focus {
+      outline: 2px solid $focus;
+      outline-offset: -2px;
+    }
+
+    &:active {
+      background-color: $active-ui;
+    }
+  }
+
+  // ─── Clickable footer affordance ─────────────────────────────────────
+  .#{$prefix}--card__clickable-footer {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    padding: $carbon--spacing-05;
+    color: $interactive-01;
+  }
+
+  .#{$prefix}--card--disabled .#{$prefix}--card__clickable-footer {
+    color: $disabled-02;
+  }
+
+  // ─── Disabled ────────────────────────────────────────────────────────
+  .#{$prefix}--card--disabled {
+    border-color: $disabled-02;
+    background-color: $ui-01;
+    color: $disabled-02;
+    cursor: not-allowed;
+    pointer-events: none;
+  }
+
+  // ─── Header ──────────────────────────────────────────────────────────
+  .#{$prefix}--card__header {
+    position: relative;
+    display: grid;
+    column-gap: $carbon--spacing-05;
+    grid-template-columns: auto 1fr;
+    row-gap: 0;
+  }
+
+  // ─── Body ────────────────────────────────────────────────────────────
+  .#{$prefix}--card__body {
+    @include type-style("body-short-01");
+
+    padding-block: $carbon--spacing-05;
+    padding-inline: $carbon--spacing-05;
+  }
+
+  .#{$prefix}--card__body--flush {
+    padding: 0;
+  }
+
+  // ─── Footer ──────────────────────────────────────────────────────────
+  // Default: padded, no border (raw-content slot)
+  .#{$prefix}--card__footer {
+    display: flex;
+    align-items: center;
+    padding: $carbon--spacing-05;
+  }
+
+  // Action-set layout: set via CardFooter's `actionSet` prop
+  .#{$prefix}--card__footer--action-set {
+    overflow: hidden;
+    padding: 0;
+    border-block-start: 1px solid $ui-03;
+    gap: 1px;
+  }
+
+  // Text/secondary actions stretch to fill width
+  .#{$prefix}--card__footer--action-set
+    > .#{$prefix}--card__action:not(.#{$prefix}--card__action--icon-only) {
+    flex: 1 0 0;
+    min-inline-size: 0;
+
+    > .#{$prefix}--btn,
+    > * > .#{$prefix}--btn {
+      inline-size: 100%;
+      max-inline-size: none;
+    }
+  }
+
+  // Icon-only actions are fixed-width, pushed to the right
+  .#{$prefix}--card__footer--action-set
+    > .#{$prefix}--card__action--icon-only {
+    flex: 0 0 auto;
+    margin-inline-start: auto;
+  }
+
+  // Consecutive icon-only actions: only the first gets the auto margin
+  .#{$prefix}--card__action--icon-only + .#{$prefix}--card__action--icon-only {
+    margin-inline-start: 0;
+  }
+
+  // ─── Action wrapper ───────────────────────────────────────────────────
+  .#{$prefix}--card__action {
+    display: inline-flex;
+  }
+
+  // ─── Header actions ───────────────────────────────────────────────────
+  .#{$prefix}--card__actions {
+    position: absolute;
+    display: inline-flex;
+    align-items: center;
+    justify-content: flex-end;
+    block-size: $carbon--spacing-07;
+    gap: $carbon--spacing-02;
+    inline-size: 50%;
+    inset-block-start: $carbon--spacing-03;
+    inset-inline-end: $carbon--spacing-03;
+    max-inline-size: 50%;
+  }
+
+  // ─── Header media (icon / avatar slot) ───────────────────────────────
+  // Spans both grid columns so it always sits above the title-media+title row.
+  .#{$prefix}--card__header-media {
+    display: flex;
+    align-items: flex-start;
+    justify-content: flex-start;
+    grid-column: 1 / -1;
+    margin-block: $carbon--spacing-05;
+    margin-inline: $carbon--spacing-05;
+    max-block-size: $carbon--spacing-10;
+  }
+
+  // ─── Media (AspectRatio slot) ────────────────────────────────────────
+  .#{$prefix}--card__media {
+    grid-column: 1 / -1;
+    inline-size: 100%;
+
+    // Disable this library's AspectRatio padding-top trick
+    &::before,
+    &::after {
+      display: none;
+    }
+  }
+
+  // Re-apply aspect ratio using the native CSS property
+  .#{$prefix}--card__media.#{$prefix}--aspect-ratio--16x9 {
+    aspect-ratio: 16 / 9;
+  }
+  .#{$prefix}--card__media.#{$prefix}--aspect-ratio--9x16 {
+    aspect-ratio: 9 / 16;
+  }
+  .#{$prefix}--card__media.#{$prefix}--aspect-ratio--2x1 {
+    aspect-ratio: 2 / 1;
+  }
+  .#{$prefix}--card__media.#{$prefix}--aspect-ratio--1x2 {
+    aspect-ratio: 1 / 2;
+  }
+  .#{$prefix}--card__media.#{$prefix}--aspect-ratio--4x3 {
+    aspect-ratio: 4 / 3;
+  }
+  .#{$prefix}--card__media.#{$prefix}--aspect-ratio--3x4 {
+    aspect-ratio: 3 / 4;
+  }
+  .#{$prefix}--card__media.#{$prefix}--aspect-ratio--3x2 {
+    aspect-ratio: 3 / 2;
+  }
+  .#{$prefix}--card__media.#{$prefix}--aspect-ratio--2x3 {
+    aspect-ratio: 2 / 3;
+  }
+  .#{$prefix}--card__media.#{$prefix}--aspect-ratio--1x1 {
+    aspect-ratio: 1 / 1;
+  }
+
+  // Children of the media slot (images, video) must fill the container.
+  // This library's AspectRatio nests content in an extra `--object` div.
+  .#{$prefix}--card__media .#{$prefix}--aspect-ratio--object,
+  .#{$prefix}--card__media .#{$prefix}--aspect-ratio--object > * {
+    block-size: 100%;
+    inline-size: 100%;
+  }
+
+  .#{$prefix}--card__media .#{$prefix}--aspect-ratio--object > * {
+    position: static;
+    object-fit: cover;
+  }
+
+  // ─── Horizontal layout ───────────────────────────────────────────────
+  .#{$prefix}--card--horizontal {
+    display: flex;
+    flex-direction: row;
+    align-items: stretch;
+  }
+
+  .#{$prefix}--card__media--horizontal {
+    overflow: hidden;
+    flex-basis: var(--#{$prefix}--card--media-width, 33.33%);
+    flex-shrink: 0;
+    align-self: stretch;
+  }
+
+  .#{$prefix}--card--horizontal > .#{$prefix}--card__content {
+    display: flex;
+    flex: 1 1 0;
+    flex-direction: column;
+    min-inline-size: 0;
+  }
+
+  .#{$prefix}--card--horizontal
+    > .#{$prefix}--card__content
+    > .#{$prefix}--card__body {
+    flex: 1 0 auto;
+  }
+
+  .#{$prefix}--card--horizontal
+    > .#{$prefix}--card__content
+    > .#{$prefix}--card__footer {
+    margin-block-start: auto;
+  }
+
+  // ─── Label ───────────────────────────────────────────────────────────
+  .#{$prefix}--card__title > .#{$prefix}--card__label {
+    @include type-style("label-01");
+
+    color: $text-02;
+  }
+
+  .#{$prefix}--card--disabled .#{$prefix}--card__label {
+    color: $disabled-02;
+  }
+
+  .#{$prefix}--card__label--truncate {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .#{$prefix}--card__label--truncate-multi {
+    display: -webkit-box;
+    overflow: hidden;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: var(--#{$prefix}--card--label-line-clamp);
+    text-overflow: ellipsis;
+  }
+
+  // ─── Title ───────────────────────────────────────────────────────────
+  .#{$prefix}--card__title {
+    display: flex;
+    overflow: hidden;
+    flex-direction: column;
+    gap: $carbon--spacing-01;
+    margin-inline: $carbon--spacing-05;
+    min-inline-size: 0;
+  }
+
+  .#{$prefix}--card__header > .#{$prefix}--card__title {
+    margin-block: $carbon--spacing-05;
+  }
+
+  .#{$prefix}--card--expressive .#{$prefix}--card__title-text-row {
+    @include type-style("productive-heading-03");
+  }
+
+  .#{$prefix}--card--productive .#{$prefix}--card__title-text-row {
+    @include type-style("productive-heading-02");
+  }
+
+  // ─── Title text row ──────────────────────────────────────────────────
+  .#{$prefix}--card__title-text-row {
+    display: block;
+  }
+
+  .#{$prefix}--card__title-text-row--truncate {
+    overflow: hidden;
+    max-inline-size: var(--#{$prefix}--card--title-max-width, 100%);
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .#{$prefix}--card__title-text-row--truncate-multi {
+    display: -webkit-box;
+    overflow: hidden;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: var(--#{$prefix}--card--title-line-clamp);
+    max-inline-size: var(--#{$prefix}--card--title-max-width, 100%);
+    text-overflow: ellipsis;
+  }
+
+  .#{$prefix}--card__title-text-row--with-start-icon {
+    display: flex;
+    align-items: flex-start;
+    gap: $carbon--spacing-03;
+  }
+
+  .#{$prefix}--card__title-start-icon {
+    display: flex;
+    flex-shrink: 0;
+    margin-block-start: $carbon--spacing-01;
+  }
+
+  .#{$prefix}--card__title-end-icon {
+    display: inline-flex;
+    align-items: center;
+    margin-inline-start: $carbon--spacing-03;
+    vertical-align: middle;
+  }
+
+  // ─── Description ───────────────────────────────────────────────────────
+  .#{$prefix}--card__title > .#{$prefix}--card__description {
+    @include type-style("label-01");
+
+    color: $text-02;
+  }
+
+  .#{$prefix}--card--disabled .#{$prefix}--card__description {
+    color: $disabled-02;
+  }
+
+  .#{$prefix}--card__description--truncate {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .#{$prefix}--card__description--truncate-multi {
+    display: -webkit-box;
+    overflow: hidden;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: var(--#{$prefix}--card--description-line-clamp);
+    text-overflow: ellipsis;
+  }
+
+  // ─── Title media ─────────────────────────────────────────────────────
+  .#{$prefix}--card__title-media {
+    display: flex;
+    flex-shrink: 0;
+    align-items: flex-start;
+    justify-content: center;
+    grid-column: 1;
+    margin-block-start: $carbon--spacing-05;
+    margin-inline-start: $carbon--spacing-05;
+    max-block-size: $carbon--spacing-10;
+  }
+
+  // CardTitleMedia always immediately precedes CardTitle in composition
+  // order, so an adjacent-sibling selector replaces upstream's `:has()`.
+  .#{$prefix}--card__title-media + .#{$prefix}--card__title {
+    grid-column: 2;
+    margin-inline-start: 0;
+  }
+
+  // ─── Decorator (AI-label or similar) ──────────────────────────────────
+  .#{$prefix}--card--has-decorator {
+    border: 1px solid $interactive-01;
+  }
+
+  .#{$prefix}--card__decorator {
+    position: absolute;
+    z-index: 1;
+    display: flex;
+    align-items: center;
+    block-size: $carbon--spacing-07;
+    inset-block-start: $carbon--spacing-03;
+    inset-inline-end: $carbon--spacing-03;
+  }
+
+  .#{$prefix}--card--has-decorator .#{$prefix}--card__title,
+  .#{$prefix}--card--has-decorator .#{$prefix}--card__label,
+  .#{$prefix}--card--has-decorator .#{$prefix}--card__description {
+    padding-inline-end: calc(#{$carbon--spacing-07} + #{$carbon--spacing-05});
+  }
+
+  .#{$prefix}--card--has-decorator .#{$prefix}--card__actions {
+    inset-inline-end: calc(
+      #{$carbon--spacing-03} + #{$carbon--spacing-06} + #{$carbon--spacing-03}
+    );
+  }
+}
+
+@include exports("card") {
+  @include card;
+}

--- a/css/all.scss
+++ b/css/all.scss
@@ -132,3 +132,4 @@ $css--plex: true;
 @import "./list-box-wrap-options";
 @import "./structured-list-sort";
 @import "./action-set";
+@import "./card";

--- a/css/g10.scss
+++ b/css/g10.scss
@@ -92,3 +92,4 @@ $css--plex: true;
 @import "./list-box-wrap-options";
 @import "./structured-list-sort";
 @import "./action-set";
+@import "./card";

--- a/css/g100.scss
+++ b/css/g100.scss
@@ -92,3 +92,4 @@ $css--plex: true;
 @import "./list-box-wrap-options";
 @import "./structured-list-sort";
 @import "./action-set";
+@import "./card";

--- a/css/g80.scss
+++ b/css/g80.scss
@@ -92,3 +92,4 @@ $css--plex: true;
 @import "./list-box-wrap-options";
 @import "./structured-list-sort";
 @import "./action-set";
+@import "./card";

--- a/css/g90.scss
+++ b/css/g90.scss
@@ -92,3 +92,4 @@ $css--plex: true;
 @import "./list-box-wrap-options";
 @import "./structured-list-sort";
 @import "./action-set";
+@import "./card";

--- a/css/white.scss
+++ b/css/white.scss
@@ -92,3 +92,4 @@ $css--plex: true;
 @import "./list-box-wrap-options";
 @import "./structured-list-sort";
 @import "./action-set";
+@import "./card";

--- a/docs/src/component-categories.ts
+++ b/docs/src/component-categories.ts
@@ -122,6 +122,7 @@ export const COMPONENT_CATEGORIES: ComponentCategory[] = [
   {
     label: "Tiles",
     components: [
+      "Card",
       "Tile",
       "ClickableTile",
       "ExpandableTile",

--- a/docs/src/component-since-versions.ts
+++ b/docs/src/component-since-versions.ts
@@ -8,6 +8,7 @@ export const COMPONENT_SINCE_VERSIONS: Record<string, string> = {
   Breakpoint: "0.40.0",
   Button: "0.2.0",
   ButtonSet: "0.9.2",
+  Card: "0.112.0",
   Checkbox: "0.2.0",
   ClickableTile: "0.2.0",
   CodeSnippet: "0.2.0",

--- a/docs/src/pages/components/Card.svx
+++ b/docs/src/pages/components/Card.svx
@@ -1,0 +1,209 @@
+---
+components: ["Card", "CardHeader", "CardBody", "CardFooter", "CardTitle", "CardMedia", "CardHeaderMedia", "CardTitleMedia", "CardActions", "CardAction"]
+description: Cards group related content and actions into a single composable container, built from Header, Body, Footer, and Media regions.
+---
+
+<script>
+  import {
+    Card,
+    CardHeader,
+    CardBody,
+    CardFooter,
+    CardTitle,
+    CardMedia,
+    CardActions,
+    CardAction,
+    Button,
+    Tag,
+  } from "carbon-components-svelte";
+  import Star from "carbon-icons-svelte/lib/Star.svelte";
+  import OverflowMenuVertical from "carbon-icons-svelte/lib/OverflowMenuVertical.svelte";
+</script>
+
+## Basic
+
+Compose a card from `CardHeader`, `CardBody`, and `CardFooter`, the same way as [ComposedModal](/components/ComposedModal).
+
+<Card>
+  <CardHeader>
+    <CardTitle>Quarterly report</CardTitle>
+  </CardHeader>
+  <CardBody>
+    Review performance metrics and key highlights from the past quarter.
+  </CardBody>
+  <CardFooter>
+    <Button kind="ghost" size="sm">View report</Button>
+  </CardFooter>
+</Card>
+
+## Clickable
+
+Set `clickable` to `true` to make the entire card interactive, with hover, focus, and active styles. A clickable card needs an accessible name: pass `aria-label` or `aria-labelledby`.
+
+### Navigation
+
+Set `href` for a navigation card. It renders as an anchor with native keyboard handling, and shows a built-in footer arrow affordance.
+
+<Card clickable href="/components/Card" aria-label="View Card documentation">
+  <CardHeader>
+    <CardTitle>Card</CardTitle>
+  </CardHeader>
+  <CardBody>Composable card container with header, body, and footer regions.</CardBody>
+</Card>
+
+### Action
+
+Without `href`, a clickable card renders as a `role="button"` div. Enter and <DocKbd label="Space" /> both activate it.
+
+<Card
+  clickable
+  aria-label="Open project settings"
+  on:click={() => console.log("card clicked")}
+>
+  <CardHeader>
+    <CardTitle>Project settings</CardTitle>
+  </CardHeader>
+  <CardBody>Manage members, permissions, and integrations.</CardBody>
+</Card>
+
+## Density
+
+Set `density` to `"expressive"` for larger title typography. The default is `"productive"`.
+
+<Card density="expressive">
+  <CardHeader>
+    <CardTitle>Quarterly report</CardTitle>
+  </CardHeader>
+  <CardBody>
+    Review performance metrics and key highlights from the past quarter.
+  </CardBody>
+</Card>
+
+## Media
+
+Pass a `CardMedia` to the `media` slot. Outside `horizontal` layout it maintains an aspect ratio, set with `ratio`.
+
+<Card>
+  <CardMedia slot="media" ratio="16x9">
+    <img
+      src="https://upload.wikimedia.org/wikipedia/commons/5/51/IBM_logo.svg"
+      alt="IBM logo"
+    />
+  </CardMedia>
+  <CardHeader>
+    <CardTitle>Media card</CardTitle>
+  </CardHeader>
+  <CardBody>The media slot maintains its aspect ratio as the card resizes.</CardBody>
+</Card>
+
+### Horizontal
+
+Set `horizontal` to `true` to render the `media` slot beside the content instead of above it. Set `mediaPosition` to `"end"` to place it on the other side.
+
+<Card horizontal>
+  <CardMedia slot="media" mediaWidth="40%">
+    <img
+      src="https://upload.wikimedia.org/wikipedia/commons/5/51/IBM_logo.svg"
+      alt="IBM logo"
+    />
+  </CardMedia>
+  <CardHeader>
+    <CardTitle>Horizontal card</CardTitle>
+  </CardHeader>
+  <CardBody>Media stretches to the full card height instead of keeping an aspect ratio.</CardBody>
+</Card>
+
+## Title
+
+`CardTitle` takes optional `label` and `description` slots above and below the title text, and `titleStart`/`titleEnd` slots for icons.
+
+<Card>
+  <CardHeader>
+    <CardTitle>
+      <svelte:fragment slot="label">Project</svelte:fragment>
+      Quarterly report
+      <svelte:fragment slot="description">Updated 2 hours ago</svelte:fragment>
+    </CardTitle>
+  </CardHeader>
+</Card>
+
+### Truncate
+
+Set `titleTruncate` to `true` for single-line truncation, or a number for multi-line clamping. Pair with `maxWidth` to control where it truncates.
+
+<Card>
+  <CardHeader>
+    <CardTitle titleTruncate maxWidth="12rem">
+      A quarterly report title long enough to truncate
+    </CardTitle>
+  </CardHeader>
+</Card>
+
+## Actions
+
+Add `CardActions` with `CardAction` children to the header for quick actions.
+
+<Card>
+  <CardHeader>
+    <CardTitle>Quarterly report</CardTitle>
+    <CardActions>
+      <CardAction>
+        <Button kind="ghost" size="sm" icon={Star} iconDescription="Favorite" />
+      </CardAction>
+    </CardActions>
+  </CardHeader>
+  <CardBody>
+    Review performance metrics and key highlights from the past quarter.
+  </CardBody>
+</Card>
+
+### Footer action set
+
+Set `actionSet` on `CardFooter` when composing `CardAction` children: it removes footer padding, adds a top border, and stretches text actions to fill the row. Set `iconOnly` on a `CardAction` wrapping an icon-only button to keep it fixed-width instead.
+
+<Card>
+  <CardHeader>
+    <CardTitle>Delete this item?</CardTitle>
+  </CardHeader>
+  <CardBody>This action cannot be undone.</CardBody>
+  <CardFooter actionSet>
+    <CardAction>
+      <Button kind="secondary">Cancel</Button>
+    </CardAction>
+    <CardAction>
+      <Button kind="danger">Delete</Button>
+    </CardAction>
+    <CardAction iconOnly>
+      <Button
+        kind="ghost"
+        icon={OverflowMenuVertical}
+        iconDescription="More options"
+      />
+    </CardAction>
+  </CardFooter>
+</Card>
+
+## Decorator
+
+Use the `decorator` slot for supplementary content, typically an AI-label badge, rendered top-right of the card.
+
+<Card>
+  <svelte:fragment slot="decorator">
+    <Tag type="purple" size="sm">AI</Tag>
+  </svelte:fragment>
+  <CardHeader>
+    <CardTitle>Smart summary</CardTitle>
+  </CardHeader>
+  <CardBody>Generated automatically from your latest activity.</CardBody>
+</Card>
+
+## Disabled
+
+Set `disabled` to `true` to disable the card and all interactive content.
+
+<Card disabled clickable aria-label="Archived report">
+  <CardHeader>
+    <CardTitle>Quarterly report</CardTitle>
+  </CardHeader>
+  <CardBody>This report has been archived and can no longer be opened.</CardBody>
+</Card>

--- a/src/Card/Card.svelte
+++ b/src/Card/Card.svelte
@@ -1,0 +1,175 @@
+<script>
+  /**
+   * @template [Icon=any]
+   */
+
+  /**
+   * @restProps {div | a}
+   * @slot {{}}
+   * @slot {{}} media - A CardMedia, positioned per `mediaPosition` in horizontal layout, always first outside it.
+   * @slot {{}} decorator - Typically an AI-label badge, rendered top-right of the card.
+   */
+
+  /**
+   * Render as a navigation card. Only takes effect when `clickable` is `true`;
+   * renders an anchor instead of a div, with native keyboard handling.
+   * @type {string}
+   */
+  export let href = undefined;
+
+  /**
+   * Set to `true` to make the entire card interactive: hover/focus/active
+   * styles, keyboard activation, and a built-in footer arrow affordance.
+   */
+  export let clickable = false;
+
+  /** Set to `true` to disable the card and all interactive content. */
+  export let disabled = false;
+
+  /**
+   * Specify the title typography weight.
+   * @type {"productive" | "expressive"}
+   */
+  export let density = "productive";
+
+  /**
+   * Set to `true` to render the `media` slot beside the content instead of
+   * above it.
+   */
+  export let horizontal = false;
+
+  /**
+   * Position the `media` slot before or after the content in horizontal
+   * layout. Has no effect outside `horizontal`.
+   * @type {"start" | "end"}
+   */
+  export let mediaPosition = "start";
+
+  /**
+   * Icon rendered in the built-in footer affordance of a clickable card.
+   * Only takes effect when `clickable` is `true`.
+   * @type {Icon}
+   */
+  export let renderFooterIcon = ArrowRight;
+
+  /**
+   * Obtain a reference to the outer HTML element.
+   * @bindable readonly
+   */
+  export let ref = null;
+
+  import { setContext } from "svelte";
+  import { writable } from "svelte/store";
+  import ArrowRight from "../icons/ArrowRight.svelte";
+
+  const horizontalStore = writable(horizontal);
+  $: horizontalStore.set(horizontal);
+
+  const clickableStore = writable(clickable);
+  $: clickableStore.set(clickable);
+
+  // CardMedia reads `horizontal` to pick AspectRatio vs. a plain sized div;
+  // CardFooter reads `clickable` to warn when used inside a clickable card.
+  setContext("carbon:Card", {
+    horizontal: horizontalStore,
+    clickable: clickableStore,
+  });
+
+  $: hasHref = clickable && Boolean(href);
+  $: tag = hasHref ? "a" : "div";
+  $: cardProps = hasHref
+    ? disabled
+      ? { role: "link", "aria-disabled": "true" }
+      : {
+          href,
+          rel:
+            $$restProps.target === "_blank" ? "noopener noreferrer" : undefined,
+        }
+    : clickable
+      ? {
+          role: "button",
+          tabindex: disabled ? -1 : 0,
+          "aria-disabled": disabled ? "true" : undefined,
+        }
+      : {};
+
+  $: cardClass = [
+    "bx--card",
+    clickable && !disabled && "bx--card--clickable",
+    disabled && "bx--card--disabled",
+    `bx--card--${density}`,
+    horizontal && "bx--card--horizontal",
+    $$slots.decorator && "bx--card--has-decorator",
+    $$restProps.class,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  $: if (
+    clickable &&
+    !$$restProps["aria-label"] &&
+    !$$restProps["aria-labelledby"]
+  ) {
+    console.warn(
+      "[Card.svelte] a clickable card must have an accessible name. Pass `aria-label` or `aria-labelledby`.",
+    );
+  }
+
+  function handleKeyDown(event) {
+    if (
+      !hasHref &&
+      clickable &&
+      !disabled &&
+      (event.key === "Enter" || event.key === " ")
+    ) {
+      event.preventDefault();
+      event.currentTarget.click();
+    }
+  }
+</script>
+
+<!-- svelte-ignore a11y-no-static-element-interactions -->
+<!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
+<svelte:element
+  this={tag}
+  bind:this={ref}
+  {...$$restProps}
+  {...cardProps}
+  class={cardClass}
+  on:click
+  on:keydown
+  on:keydown={handleKeyDown}
+  on:focus
+  on:blur
+  on:mouseover
+  on:mouseenter
+  on:mouseleave
+>
+  {#if horizontal}
+    {#if mediaPosition === "end"}
+      <div class:bx--card__content={true}><slot /></div>
+      <slot name="media" />
+    {:else}
+      <slot name="media" />
+      <div class:bx--card__content={true}><slot /></div>
+    {/if}
+  {:else}
+    <slot name="media" />
+    <slot />
+  {/if}
+  {#if clickable}
+    <div class:bx--card__clickable-footer={true} aria-hidden="true">
+      <svelte:component this={renderFooterIcon} aria-hidden="true" />
+    </div>
+  {/if}
+  {#if $$slots.decorator}
+    <div
+      class:bx--card__decorator={true}
+      role="presentation"
+      on:click|stopPropagation
+      on:keydown|stopPropagation
+    >
+      <slot name="decorator" />
+    </div>
+  {/if}
+</svelte:element>

--- a/src/Card/CardAction.svelte
+++ b/src/Card/CardAction.svelte
@@ -1,0 +1,21 @@
+<script>
+  /**
+   * @restProps {div}
+   * @slot {{}}
+   */
+
+  /**
+   * Set to `true` when wrapping an icon-only button in a `CardFooter` with
+   * `actionSet`. Fixes the action's width instead of stretching it to fill
+   * the row.
+   */
+  export let iconOnly = false;
+</script>
+
+<div
+  class:bx--card__action={true}
+  class:bx--card__action--icon-only={iconOnly}
+  {...$$restProps}
+>
+  <slot />
+</div>

--- a/src/Card/CardActions.svelte
+++ b/src/Card/CardActions.svelte
@@ -1,0 +1,10 @@
+<script>
+  /**
+   * @restProps {div}
+   * @slot {{}}
+   */
+</script>
+
+<div class:bx--card__actions={true} {...$$restProps}>
+  <slot />
+</div>

--- a/src/Card/CardBody.svelte
+++ b/src/Card/CardBody.svelte
@@ -1,0 +1,20 @@
+<script>
+  /**
+   * @restProps {div}
+   * @slot {{}}
+   */
+
+  /**
+   * Set to `true` to remove body padding, for content that manages its own
+   * spacing (for example a table, chart, or image).
+   */
+  export let isFlush = false;
+</script>
+
+<div
+  class:bx--card__body={true}
+  class:bx--card__body--flush={isFlush}
+  {...$$restProps}
+>
+  <slot />
+</div>

--- a/src/Card/CardFooter.svelte
+++ b/src/Card/CardFooter.svelte
@@ -1,0 +1,34 @@
+<script>
+  /**
+   * @restProps {div}
+   * @slot {{}}
+   */
+
+  /**
+   * Set to `true` when composing `CardAction` children: removes footer
+   * padding, adds a top border, and stretches/fixes action widths.
+   */
+  export let actionSet = false;
+
+  import { getContext } from "svelte";
+
+  // Not supported inside a clickable Card — a clickable card renders its own
+  // footer affordance automatically.
+  const clickable = getContext("carbon:Card")?.clickable;
+
+  $: if ($clickable) {
+    console.warn(
+      "[CardFooter.svelte] cannot be used inside a clickable Card. A clickable card renders its own footer affordance automatically. Use `renderFooterIcon` on Card to customize the icon.",
+    );
+  }
+</script>
+
+{#if !$clickable}
+  <div
+    class:bx--card__footer={true}
+    class:bx--card__footer--action-set={actionSet}
+    {...$$restProps}
+  >
+    <slot />
+  </div>
+{/if}

--- a/src/Card/CardHeader.svelte
+++ b/src/Card/CardHeader.svelte
@@ -1,0 +1,10 @@
+<script>
+  /**
+   * @restProps {div}
+   * @slot {{}}
+   */
+</script>
+
+<div class:bx--card__header={true} {...$$restProps}>
+  <slot />
+</div>

--- a/src/Card/CardHeaderMedia.svelte
+++ b/src/Card/CardHeaderMedia.svelte
@@ -1,0 +1,10 @@
+<script>
+  /**
+   * @restProps {div}
+   * @slot {{}}
+   */
+</script>
+
+<div class:bx--card__header-media={true} {...$$restProps}>
+  <slot />
+</div>

--- a/src/Card/CardMedia.svelte
+++ b/src/Card/CardMedia.svelte
@@ -1,0 +1,43 @@
+<script>
+  /**
+   * @restProps {div}
+   * @slot {{}}
+   */
+
+  /**
+   * Specify the aspect ratio. Has no effect in horizontal layout, where the
+   * media column stretches to the full card height instead.
+   * @type {"2x1" | "2x3" | "16x9" | "4x3" | "1x1" | "3x4" | "3x2" | "9x16" | "1x2"}
+   */
+  export let ratio = undefined;
+
+  /**
+   * Width of the media column in horizontal layout. Accepts any CSS width
+   * value. Has no effect outside horizontal layout.
+   */
+  export let mediaWidth = "33.33%";
+
+  import { getContext } from "svelte";
+  import AspectRatio from "../AspectRatio/AspectRatio.svelte";
+
+  const horizontal = getContext("carbon:Card")?.horizontal;
+
+  $: mediaClass = ["bx--card__media", $$restProps.class]
+    .filter(Boolean)
+    .join(" ");
+</script>
+
+{#if $horizontal}
+  <div
+    {...$$restProps}
+    class={mediaClass}
+    class:bx--card__media--horizontal={true}
+    style:--bx--card--media-width={mediaWidth}
+  >
+    <slot />
+  </div>
+{:else}
+  <AspectRatio {ratio} {...$$restProps} class={mediaClass}>
+    <slot />
+  </AspectRatio>
+{/if}

--- a/src/Card/CardTitle.svelte
+++ b/src/Card/CardTitle.svelte
@@ -1,0 +1,91 @@
+<script>
+  /**
+   * @restProps {div}
+   * @slot {{}}
+   * @slot {{}} label - Rendered above the title text.
+   * @slot {{}} description - Rendered below the title text.
+   * @slot {{}} titleStart - Leading icon or content, before the title text.
+   * @slot {{}} titleEnd - Trailing icon or content, after the title text.
+   */
+
+  /**
+   * Enable truncation on the title text: `true` truncates to a single line
+   * with an ellipsis, a number clamps to that many lines.
+   * @type {boolean | number}
+   */
+  export let titleTruncate = false;
+
+  /**
+   * Maximum width applied to the title text row when `titleTruncate` is set.
+   */
+  export let maxWidth = "100%";
+
+  /**
+   * Enable truncation on the `label` slot, same values as `titleTruncate`.
+   * @type {boolean | number}
+   */
+  export let labelTruncate = false;
+
+  /**
+   * Enable truncation on the `description` slot, same values as
+   * `titleTruncate`.
+   * @type {boolean | number}
+   */
+  export let descriptionTruncate = false;
+
+  $: isTitleMulti = typeof titleTruncate === "number";
+  $: isLabelMulti = typeof labelTruncate === "number";
+  $: isDescriptionMulti = typeof descriptionTruncate === "number";
+</script>
+
+<div class:bx--card__title={true} {...$$restProps}>
+  {#if $$slots.label}
+    <div
+      class:bx--card__label={true}
+      class:bx--card__label--truncate={labelTruncate === true}
+      class:bx--card__label--truncate-multi={isLabelMulti}
+      style:--bx--card--label-line-clamp={isLabelMulti
+        ? labelTruncate
+        : undefined}
+    >
+      <slot name="label" />
+    </div>
+  {/if}
+  <span
+    class:bx--card__title-text-row={true}
+    class:bx--card__title-text-row--truncate={titleTruncate === true}
+    class:bx--card__title-text-row--truncate-multi={isTitleMulti}
+    class:bx--card__title-text-row--with-start-icon={$$slots.titleStart}
+    class:bx--card__title-text-row--with-end-icon={$$slots.titleEnd}
+    style:--bx--card--title-max-width={titleTruncate === false
+      ? undefined
+      : maxWidth}
+    style:--bx--card--title-line-clamp={isTitleMulti
+      ? titleTruncate
+      : undefined}
+  >
+    {#if $$slots.titleStart}
+      <span class:bx--card__title-start-icon={true}>
+        <slot name="titleStart" />
+      </span>
+    {/if}
+    <slot />
+    {#if $$slots.titleEnd}
+      <span class:bx--card__title-end-icon={true}>
+        <slot name="titleEnd" />
+      </span>
+    {/if}
+  </span>
+  {#if $$slots.description}
+    <div
+      class:bx--card__description={true}
+      class:bx--card__description--truncate={descriptionTruncate === true}
+      class:bx--card__description--truncate-multi={isDescriptionMulti}
+      style:--bx--card--description-line-clamp={isDescriptionMulti
+        ? descriptionTruncate
+        : undefined}
+    >
+      <slot name="description" />
+    </div>
+  {/if}
+</div>

--- a/src/Card/CardTitleMedia.svelte
+++ b/src/Card/CardTitleMedia.svelte
@@ -1,0 +1,10 @@
+<script>
+  /**
+   * @restProps {div}
+   * @slot {{}}
+   */
+</script>
+
+<div class:bx--card__title-media={true} {...$$restProps}>
+  <slot />
+</div>

--- a/src/Card/index.js
+++ b/src/Card/index.js
@@ -1,0 +1,10 @@
+export { default as Card } from "./Card.svelte";
+export { default as CardAction } from "./CardAction.svelte";
+export { default as CardActions } from "./CardActions.svelte";
+export { default as CardBody } from "./CardBody.svelte";
+export { default as CardFooter } from "./CardFooter.svelte";
+export { default as CardHeader } from "./CardHeader.svelte";
+export { default as CardHeaderMedia } from "./CardHeaderMedia.svelte";
+export { default as CardMedia } from "./CardMedia.svelte";
+export { default as CardTitle } from "./CardTitle.svelte";
+export { default as CardTitleMedia } from "./CardTitleMedia.svelte";

--- a/src/icons/ArrowRight.svelte
+++ b/src/icons/ArrowRight.svelte
@@ -1,0 +1,30 @@
+<script>
+  export let size = 16;
+
+  export let title = undefined;
+
+  $: labelled = $$props["aria-label"] || $$props["aria-labelledby"] || title;
+  $: attributes = {
+    "aria-hidden": labelled ? undefined : true,
+    role: labelled ? "img" : undefined,
+    focusable: Number($$props.tabindex) === 0 ? true : undefined,
+  };
+</script>
+
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 32 32"
+  fill="currentColor"
+  preserveAspectRatio="xMidYMid meet"
+  width={size}
+  height={size}
+  {...attributes}
+  {...$$restProps}
+>
+  {#if title}
+    <title>{title}</title>
+  {/if}
+  <path
+    d="M18 6 16.57 7.393 24.15 15 4 15 4 17 24.15 17 16.57 24.573 18 26 28 16 18 6z"
+  ></path>
+</svg>

--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,18 @@ export { hideAtBreakpoint } from "./Breakpoint/hideAtBreakpoint";
 export { default as Button } from "./Button/Button.svelte";
 export { default as ButtonSet } from "./Button/ButtonSet.svelte";
 export { default as ButtonSkeleton } from "./Button/ButtonSkeleton.svelte";
+export {
+  Card,
+  CardAction,
+  CardActions,
+  CardBody,
+  CardFooter,
+  CardHeader,
+  CardHeaderMedia,
+  CardMedia,
+  CardTitle,
+  CardTitleMedia,
+} from "./Card";
 export { default as Checkbox } from "./Checkbox/Checkbox.svelte";
 export { default as CheckboxGroup } from "./Checkbox/CheckboxGroup.svelte";
 export { default as CheckboxSkeleton } from "./Checkbox/CheckboxSkeleton.svelte";


### PR DESCRIPTION
Composable Header/Body/Footer/Media pieces, ported from Carbon React's
preview Card. Clickable, horizontal, and decorator behavior use a
carbon:Card context and named slots instead of child-type
introspection; upstream :has() becomes marker props or an adjacent
sibling selector. CardActions is a plain flex row for v1.
