### PR TITLE
feat(inline-edit): add InlineEdit component

### DIFF
--- a/css/_inline-edit.scss
+++ b/css/_inline-edit.scss
@@ -1,0 +1,188 @@
+@import "carbon-components/scss/globals/scss/vars";
+@import "carbon-components/scss/globals/scss/helper-mixins";
+@import "carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/import-once/import-once";
+@import "carbon-components/scss/globals/scss/typography";
+
+/// InlineEdit styles. Ported from Carbon React's EditInPlace
+/// (`packages/styles/scss/components/EditInPlace`), mapped from v11 tokens
+/// to this repo's v10 equivalents, with two deliberate departures from
+/// upstream: the one `:has()` in the upstream stylesheet (showing the focus
+/// outline only while the input itself has focus) is replaced with
+/// `:focus-within`, which this library's Safari 14 baseline supports
+/// natively; and the toolbar is a constant width (room for both the save
+/// and cancel buttons) instead of animating wider on focus, so this
+/// component doesn't resize its own column when used in a DataTable cell.
+/// @access public
+/// @group inline-edit
+@mixin inline-edit {
+  $block-class: #{$prefix}--edit-in-place;
+  $carbon-input: #{$prefix}--text-input;
+
+  .#{$block-class} {
+    --#{$block-class}--size: #{$carbon--spacing-07};
+
+    display: flex;
+    align-items: center;
+    // Always reserve the invalid-state border width, toggling only its
+    // color (below), so gaining/losing that state or the focus outline
+    // never resizes the box.
+    border: 2px solid transparent;
+    background: transparent;
+    cursor: pointer;
+  }
+
+  // Matches DataTable's compact row height, for use in a DataTable cell.
+  .#{$block-class}--xs {
+    --#{$block-class}--size: #{$carbon--spacing-06};
+  }
+
+  .#{$block-class}--sm {
+    --#{$block-class}--size: #{$carbon--spacing-08};
+  }
+
+  .#{$block-class}--md {
+    --#{$block-class}--size: #{$carbon--spacing-09};
+  }
+
+  .#{$block-class}--lg {
+    --#{$block-class}--size: #{$carbon--spacing-10};
+  }
+
+  // Readonly and disabled fields don't invite interaction the way an
+  // editable one does (there's no click-to-edit affordance), matching this
+  // library's other readonly/disabled inputs, which don't change on hover
+  // either.
+  .#{$block-class}:not(.#{$block-class}--readonly):not(.#{$block-class}--disabled):hover {
+    background: $field-01;
+  }
+
+  .#{$block-class}--disabled {
+    color: $text-disabled;
+    cursor: not-allowed;
+  }
+
+  .#{$block-class}:hover .#{$block-class}__btn-edit,
+  .#{$block-class}__btn-edit.#{$block-class}__btn-edit--always-visible {
+    visibility: visible;
+  }
+
+  .#{$block-class}__btn-edit {
+    visibility: hidden;
+  }
+
+  .#{$block-class}--invalid {
+    border-color: $support-01;
+  }
+
+  .#{$block-class}--focused {
+    background: $field-01;
+  }
+
+  // Show the outline on the whole component only while the input itself
+  // has focus.
+  .#{$block-class}--focused:focus-within {
+    outline: 2px solid $focus;
+  }
+
+  // Hide the red border ring while focused, so it doesn't clash with the
+  // outline. Toggling color (not width, as upstream does) keeps the box
+  // the same size in every state.
+  .#{$block-class}--invalid.#{$block-class}--focused {
+    border-color: transparent;
+  }
+
+  .#{$block-class}__text-input {
+    flex: 1;
+    block-size: var(--#{$block-class}--size);
+  }
+
+  .#{$block-class}--inherit-type .#{$block-class}__text-input {
+    font-size: inherit;
+    font-weight: inherit;
+    letter-spacing: inherit;
+    line-height: inherit;
+  }
+
+  .#{$block-class}__warning-icon {
+    margin: auto $carbon--spacing-03;
+    color: $support-01;
+    inline-size: $carbon--spacing-05;
+  }
+
+  .#{$block-class}__warning-text {
+    @include type-style("label-01");
+
+    color: $support-01;
+
+    margin-block-start: $carbon--spacing-03;
+  }
+
+  // Overrides: strip the text input's own chrome, this component draws it.
+  .#{$block-class}__text-input.#{$carbon-input} {
+    border: none;
+    background: transparent;
+    cursor: pointer;
+    outline: none;
+  }
+
+  // Remove the outline when not in edit mode.
+  .#{$block-class}:not(.#{$block-class}--focused)
+    .#{$block-class}__text-input.#{$carbon-input}:focus,
+  .#{$block-class}:not(.#{$block-class}--focused)
+    .#{$block-class}__text-input.#{$carbon-input}:active {
+    outline: none;
+  }
+
+  // Comes after the override above so it wins the tie (same specificity,
+  // later wins): a disabled field is never a pointer, editable or not.
+  .#{$block-class}--disabled .#{$block-class}__text-input.#{$carbon-input} {
+    cursor: not-allowed;
+  }
+
+  // Always room for two icon buttons (save + cancel), so entering or
+  // leaving edit mode never changes the toolbar's width. A table cell
+  // sizes its column to its widest rendered content, so a toolbar that
+  // grew on focus grew the whole column with it.
+  .#{$block-class}__toolbar {
+    display: inline-flex;
+    align-self: stretch;
+    justify-content: flex-end;
+    inline-size: calc(2 * var(--#{$block-class}--size));
+  }
+
+  // Width of the invalid icon is always spacing-07 (spacing-05 + 2 * spacing-03 margin).
+  .#{$block-class}--invalid .#{$block-class}__toolbar {
+    inline-size: calc(
+      2 * var(--#{$block-class}--size) + #{$carbon--spacing-07}
+    );
+  }
+
+  // Match button heights to input height for each size, and make them
+  // square. The buttons are wider than their icon at md/lg, so re-center
+  // it explicitly: Carbon's own tooltip-trigger mixin sets align-items but
+  // not justify-content, since it never expects a fixed-width button wider
+  // than its content.
+  .#{$block-class}__toolbar .#{$prefix}--btn.#{$prefix}--btn--icon-only {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    min-block-size: unset;
+    block-size: var(--#{$block-class}--size);
+    inline-size: var(--#{$block-class}--size);
+  }
+
+  // The readonly mode trigger is a Toggletip button, not a Button, so it
+  // needs its own matching size rule.
+  .#{$block-class}__toolbar .#{$prefix}--toggletip-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    block-size: var(--#{$block-class}--size);
+    inline-size: var(--#{$block-class}--size);
+  }
+}
+
+@include exports("inline-edit") {
+  @include inline-edit;
+}

--- a/css/all.scss
+++ b/css/all.scss
@@ -132,3 +132,4 @@ $css--plex: true;
 @import "./list-box-wrap-options";
 @import "./structured-list-sort";
 @import "./action-set";
+@import "./inline-edit";

--- a/css/g10.scss
+++ b/css/g10.scss
@@ -92,3 +92,4 @@ $css--plex: true;
 @import "./list-box-wrap-options";
 @import "./structured-list-sort";
 @import "./action-set";
+@import "./inline-edit";

--- a/css/g100.scss
+++ b/css/g100.scss
@@ -92,3 +92,4 @@ $css--plex: true;
 @import "./list-box-wrap-options";
 @import "./structured-list-sort";
 @import "./action-set";
+@import "./inline-edit";

--- a/css/g80.scss
+++ b/css/g80.scss
@@ -92,3 +92,4 @@ $css--plex: true;
 @import "./list-box-wrap-options";
 @import "./structured-list-sort";
 @import "./action-set";
+@import "./inline-edit";

--- a/css/g90.scss
+++ b/css/g90.scss
@@ -92,3 +92,4 @@ $css--plex: true;
 @import "./list-box-wrap-options";
 @import "./structured-list-sort";
 @import "./action-set";
+@import "./inline-edit";

--- a/css/white.scss
+++ b/css/white.scss
@@ -92,3 +92,4 @@ $css--plex: true;
 @import "./list-box-wrap-options";
 @import "./structured-list-sort";
 @import "./action-set";
+@import "./inline-edit";

--- a/docs/src/component-categories.ts
+++ b/docs/src/component-categories.ts
@@ -67,6 +67,7 @@ export const COMPONENT_CATEGORIES: ComponentCategory[] = [
       "CopyInput",
       "DatePicker",
       "FileUploader",
+      "InlineEdit",
       "NumberInput",
       "PasswordInput",
       "PinCodeInput",

--- a/docs/src/component-since-versions.ts
+++ b/docs/src/component-since-versions.ts
@@ -33,6 +33,7 @@ export const COMPONENT_SINCE_VERSIONS: Record<string, string> = {
   Heading: "0.98.0",
   IconIndicator: "0.110.0",
   ImageLoader: "0.30.0",
+  InlineEdit: "0.112.0",
   InlineLoading: "0.2.0",
   InlineNotification: "0.2.0",
   Link: "0.2.0",

--- a/docs/src/pages/components/InlineEdit.svx
+++ b/docs/src/pages/components/InlineEdit.svx
@@ -1,0 +1,148 @@
+---
+components: ["InlineEdit"]
+description: Inline text editing with save and cancel affordances. Click or focus to enter edit mode; blur saves a real change or cancels an unchanged one.
+---
+
+<script>
+  import { InlineEdit } from "carbon-components-svelte";
+</script>
+
+## Basic
+
+Click the text, or the edit button that appears on hover, to start editing. <DocKbd label="Enter" /> saves and keeps editing, <DocKbd label="Escape" /> reverts and exits, and moving focus away saves a real change or cancels an unchanged one.
+
+<InlineEdit
+  labelText="Project name"
+  editLabel="Edit project name"
+  saveLabel="Save"
+  cancelLabel="Cancel"
+  value="Q3 roadmap"
+/>
+
+## Always visible
+
+By default the edit button only appears on hover. Set `editAlwaysVisible` to `true` to keep it visible.
+
+<InlineEdit
+  editAlwaysVisible
+  labelText="Project name"
+  editLabel="Edit project name"
+  saveLabel="Save"
+  cancelLabel="Cancel"
+  value="Q3 roadmap"
+/>
+
+## Select text on focus
+
+Set `selectTextOnFocus` to `true` to select the input's text when entering edit mode, so typing immediately replaces it.
+
+<InlineEdit
+  selectTextOnFocus
+  labelText="Project name"
+  editLabel="Edit project name"
+  saveLabel="Save"
+  cancelLabel="Cancel"
+  value="Q3 roadmap"
+/>
+
+## Sizes
+
+Set `size` to control the vertical size of the control. The default is `"sm"`.
+
+### Extra small
+
+`"xs"` matches the row height of a `compact` [DataTable](/components/DataTable), for use in a table cell.
+
+<InlineEdit
+  size="xs"
+  labelText="Project name"
+  editLabel="Edit project name"
+  saveLabel="Save"
+  cancelLabel="Cancel"
+  value="Q3 roadmap"
+/>
+
+### Medium
+
+<InlineEdit
+  size="md"
+  labelText="Project name"
+  editLabel="Edit project name"
+  saveLabel="Save"
+  cancelLabel="Cancel"
+  value="Q3 roadmap"
+/>
+
+### Large
+
+<InlineEdit
+  size="lg"
+  labelText="Project name"
+  editLabel="Edit project name"
+  saveLabel="Save"
+  cancelLabel="Cancel"
+  value="Q3 roadmap"
+/>
+
+## Inherit typography
+
+Set `inheritTypography` to `true` for the input to inherit the surrounding container's font settings, useful when editing a heading in place. `size` still clamps the input's vertical size.
+
+<h3 style="margin: 0;">
+  <InlineEdit
+    inheritTypography
+    labelText="Page title"
+    editLabel="Edit page title"
+    saveLabel="Save"
+    cancelLabel="Cancel"
+    value="Quarterly planning"
+  />
+</h3>
+
+## Invalid
+
+Set `invalid` to `true` and provide `invalidText` to show a validation message. Save stays disabled while invalid, even with a change.
+
+<InlineEdit
+  invalid
+  invalidText="Project name is required"
+  labelText="Project name"
+  editLabel="Edit project name"
+  saveLabel="Save"
+  cancelLabel="Cancel"
+  value=""
+/>
+
+## Readonly
+
+Set `readonly` to `true` to disable editing while keeping the field focusable. The edit button is replaced with a toggletip explaining why, set through `readonlyLabel` and `readonlyToggletipText`.
+
+<InlineEdit
+  readonly
+  readonlyLabel="Edit off"
+  readonlyToggletipText="You don't have permission to edit this field"
+  labelText="Project name"
+  editLabel="Edit project name"
+  saveLabel="Save"
+  cancelLabel="Cancel"
+  value="Q3 roadmap"
+/>
+
+## Disabled
+
+Set `disabled` to `true` to turn off the field entirely: no edit affordance, and the input itself isn't focusable. Use `readonly` instead when the field should stay visible and focusable with an explanation.
+
+<InlineEdit
+  disabled
+  labelText="Project name"
+  editLabel="Edit project name"
+  saveLabel="Save"
+  cancelLabel="Cancel"
+  value="Q3 roadmap"
+/>
+
+## DataTable cells
+
+Use the `cell` slot to render `InlineEdit` for inline editing of a row field, the same way as other form inputs. Bind to the row field, then call `refreshRow(id)` from `on:save` so columns that derive from other fields on the same row (like `Total` below) stay in sync — `on:save` only fires on a real commit, unlike an input's `on:input`.
+
+<FileSource src="/framed/InlineEdit/InlineEditDataTableCell" />

--- a/docs/src/pages/framed/InlineEdit/InlineEditDataTableCell.svelte
+++ b/docs/src/pages/framed/InlineEdit/InlineEditDataTableCell.svelte
@@ -1,0 +1,47 @@
+<script>
+  import { DataTable, InlineEdit } from "carbon-components-svelte";
+
+  let dataTable;
+
+  let rows = [
+    { id: "a", item: "Widget", unitPrice: 10, qty: 3 },
+    { id: "b", item: "Gadget", unitPrice: 25, qty: 1 },
+    { id: "c", item: "Gizmo", unitPrice: 8, qty: 5 },
+  ];
+</script>
+
+<DataTable
+  bind:this={dataTable}
+  size="compact"
+  headers={[
+    { key: "item", value: "Item" },
+    { key: "unitPrice", value: "Unit price" },
+    { key: "qty", value: "Quantity" },
+    {
+      key: "total",
+      value: "Total",
+      display: (_value, row) => `$${row.unitPrice * row.qty}`,
+    },
+  ]}
+  {rows}
+>
+  <svelte:fragment slot="cell" let:row let:cell>
+    {#if cell.key === "item"}
+      <InlineEdit
+        size="xs"
+        id="item-{row.id}"
+        labelText="Item name"
+        editLabel="Edit item name"
+        saveLabel="Save"
+        cancelLabel="Cancel"
+        bind:value={row.item}
+        on:save={() => {
+          // Rebuild cells so the Total column stays paired with the right row.
+          dataTable.refreshRow(row.id);
+        }}
+      />
+    {:else}
+      {cell.display ? cell.display(cell.value, row) : cell.value}
+    {/if}
+  </svelte:fragment>
+</DataTable>

--- a/src/InlineEdit/InlineEdit.svelte
+++ b/src/InlineEdit/InlineEdit.svelte
@@ -1,0 +1,335 @@
+<script>
+  /**
+   * @restProps {div}
+   * @event {null} save - Fires on the save button, or on blur/Enter with a changed value.
+   * @event {null} cancel - Fires on the cancel button, or on blur/Escape with no real change.
+   * @event {FocusEvent} blur - Forwarded after the auto-save/auto-cancel decision runs.
+   */
+
+  /**
+   * Current value of the input.
+   * @bindable writable
+   */
+  export let value = "";
+
+  /**
+   * Specify a custom id for the input.
+   * @type {string}
+   */
+  export let id = uniqueId();
+
+  /**
+   * Screen-reader label for the input.
+   * @type {string}
+   */
+  export let labelText;
+
+  /**
+   * Label for the edit button.
+   * @type {string}
+   */
+  export let editLabel;
+
+  /**
+   * Label for the save button.
+   * @type {string}
+   */
+  export let saveLabel;
+
+  /**
+   * Label for the cancel button.
+   * @type {string}
+   */
+  export let cancelLabel;
+
+  /** By default the edit button is shown on hover only. */
+  export let editAlwaysVisible = false;
+
+  /**
+   * Set to `true` to have the input inherit the container's font settings.
+   * `size` still clamps the input's vertical size.
+   */
+  export let inheritTypography = false;
+
+  /** Set to `true` to indicate an invalid state. */
+  export let invalid = false;
+
+  /** Specify the invalid state text. */
+  export let invalidText = "";
+
+  /**
+   * Specify the input placeholder text.
+   * @type {string}
+   */
+  export let placeholder = undefined;
+
+  /** Set to `true` to select the input's text when entering edit mode. */
+  export let selectTextOnFocus = false;
+
+  /**
+   * Set to `true` to disable the field entirely: no edit affordance, not
+   * focusable. Use `readonly` instead to keep the field visible and
+   * focusable while explaining why it can't be edited.
+   */
+  export let disabled = false;
+
+  /** Set to `true` to disable editing. */
+  export let readonly = false;
+
+  /**
+   * Label for the "edit off" icon shown in readonly mode. Defaults to
+   * `"Edit off"`.
+   * @type {string}
+   */
+  export let readonlyLabel = undefined;
+
+  /**
+   * Toggletip text shown in readonly mode, explaining why the field can't
+   * be edited. Defaults to `"This field is read-only and cannot be edited"`.
+   * @type {string}
+   */
+  export let readonlyToggletipText = undefined;
+
+  /**
+   * Vertical size of the control. `"xs"` matches DataTable's `compact` row
+   * size.
+   * @type {"xs" | "sm" | "md" | "lg"}
+   */
+  export let size = "sm";
+
+  /**
+   * Obtain a reference to the outer HTML element.
+   * @bindable readonly
+   */
+  export let ref = null;
+
+  import { createEventDispatcher } from "svelte";
+  import Button from "../Button/Button.svelte";
+  import Checkmark from "../icons/Checkmark.svelte";
+  import Close from "../icons/Close.svelte";
+  import Edit from "../icons/Edit.svelte";
+  import EditOff from "../icons/EditOff.svelte";
+  import WarningFilled from "../icons/WarningFilled.svelte";
+  import Toggletip from "../Toggletip/Toggletip.svelte";
+  import { uniqueId } from "../utils/uniqueId.js";
+
+  const dispatch = createEventDispatcher();
+  const errorId = `error-${id}`;
+
+  let initialValue = value;
+  let focused = false;
+  let containerRef = null;
+  let inputRef = null;
+
+  // Guards ported from Carbon React's EditInPlace: `escaping` suppresses the
+  // blur handler's own auto-save/cancel when Escape/Enter already triggered
+  // it explicitly (calling `.blur()` fires a synchronous, bubbling
+  // `focusout`); `clickingWithin` tells the blur handler a toolbar button
+  // was pressed, so it can tell "moved to an enabled button" (stay in edit
+  // mode, let the button's own click handler act) apart from "moved to a
+  // disabled button, then away" (exit edit mode).
+  let escaping = false;
+  let clickingWithin = false;
+
+  // Matches TextInput's own showInvalid convention: disabled/readonly take
+  // precedence over validation styling.
+  $: showInvalid = invalid && !disabled && !readonly;
+  $: hasValueChanged = value.trim() !== initialValue.trim();
+  $: canSave = hasValueChanged && !showInvalid;
+  $: canCancel = hasValueChanged;
+
+  $: containerClass = [
+    "bx--edit-in-place",
+    `bx--edit-in-place--${size}`,
+    focused && "bx--edit-in-place--focused",
+    showInvalid && "bx--edit-in-place--invalid",
+    inheritTypography && "bx--edit-in-place--inherit-type",
+    readonly && "bx--edit-in-place--readonly",
+    disabled && "bx--edit-in-place--disabled",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  function isTargetingChild(relatedTarget) {
+    return (
+      relatedTarget instanceof Node && containerRef?.contains(relatedTarget)
+    );
+  }
+
+  function handleFocus(event) {
+    if (!isTargetingChild(event?.relatedTarget)) {
+      inputRef?.focus();
+      if (selectTextOnFocus) inputRef?.select();
+    }
+    focused = true;
+  }
+
+  function handleSave(exitEditMode) {
+    initialValue = value;
+    dispatch("save");
+    if (exitEditMode) {
+      focused = false;
+    } else {
+      requestAnimationFrame(() => {
+        inputRef?.focus();
+      });
+    }
+  }
+
+  function handleCancel(exitEditMode) {
+    value = initialValue;
+    dispatch("cancel");
+    if (exitEditMode) {
+      focused = false;
+    } else {
+      requestAnimationFrame(() => {
+        inputRef?.focus();
+        const length = inputRef?.value.length ?? 0;
+        inputRef?.setSelectionRange(length, length);
+      });
+    }
+  }
+
+  function handleBlur(event) {
+    const clickedWithin = clickingWithin;
+    const targetingChild = isTargetingChild(event.relatedTarget);
+
+    // Clicked an enabled toolbar button: let its own click handler act.
+    if (clickedWithin && targetingChild) {
+      clickingWithin = false;
+      return;
+    }
+    // Clicked a disabled toolbar button, then focus left: fall through and exit.
+    if (clickedWithin && !targetingChild) {
+      clickingWithin = false;
+    }
+    // Tabbing to a toolbar button: allow it, don't exit edit mode.
+    if (!clickedWithin && targetingChild) {
+      return;
+    }
+    if (escaping) return;
+
+    dispatch("blur", event);
+    if (canSave) {
+      handleSave(true);
+    } else {
+      handleCancel(true);
+    }
+  }
+
+  function removeFocus() {
+    inputRef?.blur();
+    focused = false;
+  }
+
+  function handleKeyDown(event) {
+    escaping = true;
+    if (event.key === "Escape") {
+      removeFocus();
+      handleCancel(true);
+    } else if (event.key === "Enter") {
+      removeFocus();
+      if (canSave) handleSave(false);
+    }
+    escaping = false;
+  }
+
+  function handleToolbarMouseDown(event) {
+    const button = /** @type {HTMLElement} */ (event.target).closest("button");
+    if (!button) return;
+
+    clickingWithin = true;
+    const isDisabled =
+      button.hasAttribute("disabled") ||
+      button.getAttribute("aria-disabled") === "true";
+    if (isDisabled) {
+      event.preventDefault();
+    }
+  }
+</script>
+
+<div bind:this={ref} data-component-name="InlineEdit" {...$$restProps}>
+  <div
+    bind:this={containerRef}
+    class={containerClass}
+    on:focusin={handleFocus}
+    on:focusout={handleBlur}
+  >
+    <input
+      bind:this={inputRef}
+      {id}
+      type="text"
+      class="bx--edit-in-place__text-input bx--text-input"
+      {placeholder}
+      bind:value
+      readonly={readonly || undefined}
+      disabled={disabled || undefined}
+      on:keydown={handleKeyDown}
+      aria-label={labelText}
+      aria-invalid={showInvalid || undefined}
+      aria-describedby={showInvalid ? errorId : undefined}
+    >
+    <!-- svelte-ignore a11y-no-static-element-interactions -->
+    <div
+      class="bx--edit-in-place__toolbar"
+      on:mousedown={handleToolbarMouseDown}
+    >
+      {#if showInvalid}
+        <WarningFilled size={16} class="bx--edit-in-place__warning-icon" />
+      {/if}
+      {#if disabled}
+      <!-- No edit affordance: the field is fully inert. -->
+      {:else if readonly}
+        <Toggletip
+          icon={EditOff}
+          iconDescription={readonlyLabel ?? "Edit off"}
+          align="center"
+          direction="top"
+        >
+          <p>
+            {readonlyToggletipText ??
+              "This field is read-only and cannot be edited"}
+          </p>
+        </Toggletip>
+      {:else if focused}
+        <Button
+          kind="ghost"
+          size="small"
+          icon={Close}
+          iconDescription={cancelLabel}
+          tooltipPosition="top"
+          disabled={!canCancel}
+          class="bx--edit-in-place__btn bx--edit-in-place__btn-cancel"
+          on:click={() => handleCancel(false)}
+        />
+        <Button
+          kind="ghost"
+          size="small"
+          icon={Checkmark}
+          iconDescription={saveLabel}
+          tooltipPosition="top"
+          disabled={!canSave}
+          class="bx--edit-in-place__btn bx--edit-in-place__btn-save"
+          on:click={() => handleSave(false)}
+        />
+      {:else}
+        <Button
+          kind="ghost"
+          size="small"
+          icon={Edit}
+          iconDescription={editLabel}
+          tooltipPosition="top"
+          class="bx--edit-in-place__btn bx--edit-in-place__btn-edit {editAlwaysVisible
+            ? 'bx--edit-in-place__btn-edit--always-visible'
+            : ''}"
+          on:click={handleFocus}
+        />
+      {/if}
+    </div>
+  </div>
+  {#if showInvalid}
+    <p class:bx--edit-in-place__warning-text={true} id={errorId}>
+      {invalidText}
+    </p>
+  {/if}
+</div>

--- a/src/InlineEdit/index.js
+++ b/src/InlineEdit/index.js
@@ -1,0 +1,1 @@
+export { default as InlineEdit } from "./InlineEdit.svelte";

--- a/src/icons/Edit.svelte
+++ b/src/icons/Edit.svelte
@@ -1,0 +1,31 @@
+<script>
+  export let size = 16;
+
+  export let title = undefined;
+
+  $: labelled = $$props["aria-label"] || $$props["aria-labelledby"] || title;
+  $: attributes = {
+    "aria-hidden": labelled ? undefined : true,
+    role: labelled ? "img" : undefined,
+    focusable: Number($$props.tabindex) === 0 ? true : undefined,
+  };
+</script>
+
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 32 32"
+  fill="currentColor"
+  preserveAspectRatio="xMidYMid meet"
+  width={size}
+  height={size}
+  {...attributes}
+  {...$$restProps}
+>
+  {#if title}
+    <title>{title}</title>
+  {/if}
+  <path d="M2 26H30V28H2z"></path>
+  <path
+    d="M25.4,9c0.8-0.8,0.8-2,0-2.8c0,0,0,0,0,0l-3.6-3.6c-0.8-0.8-2-0.8-2.8,0c0,0,0,0,0,0l-15,15V24h6.4L25.4,9z M20.4,4L24,7.6	l-3,3L17.4,7L20.4,4z M6,22v-3.6l10-10l3.6,3.6l-10,10H6z"
+  ></path>
+</svg>

--- a/src/index.js
+++ b/src/index.js
@@ -83,6 +83,7 @@ export { default as Heading } from "./Heading/Heading.svelte";
 export { default as Section } from "./Heading/Section.svelte";
 export { default as IconIndicator } from "./IconIndicator/IconIndicator.svelte";
 export { default as ImageLoader } from "./ImageLoader/ImageLoader.svelte";
+export { default as InlineEdit } from "./InlineEdit/InlineEdit.svelte";
 export { default as InlineLoading } from "./InlineLoading/InlineLoading.svelte";
 export { default as Link } from "./Link/Link.svelte";
 export { default as LinkDownload } from "./Link/LinkDownload.svelte";

--- a/tests/InlineEdit/InlineEdit.test.svelte
+++ b/tests/InlineEdit/InlineEdit.test.svelte
@@ -1,0 +1,48 @@
+<svelte:options accessors />
+
+<script lang="ts">
+  import InlineEdit from "carbon-components-svelte/InlineEdit/InlineEdit.svelte";
+  import type { ComponentProps } from "svelte";
+
+  export let value = "default";
+  export let id: ComponentProps<InlineEdit>["id"] = "test-id";
+  export let labelText = "test label";
+  export let editLabel = "Edit";
+  export let saveLabel = "Save";
+  export let cancelLabel = "Cancel";
+  export let invalid = false;
+  export let invalidText = "This field is required";
+  export let disabled = false;
+  export let readonly = false;
+  export let readonlyLabel: ComponentProps<InlineEdit>["readonlyLabel"] =
+    undefined;
+  export let readonlyToggletipText: ComponentProps<InlineEdit>["readonlyToggletipText"] =
+    undefined;
+  export let editAlwaysVisible = false;
+  export let selectTextOnFocus = false;
+  export let size: ComponentProps<InlineEdit>["size"] = undefined;
+  export let ref: ComponentProps<InlineEdit>["ref"] = null;
+</script>
+
+<InlineEdit
+  bind:value
+  bind:ref
+  {id}
+  {labelText}
+  {editLabel}
+  {saveLabel}
+  {cancelLabel}
+  {invalid}
+  {invalidText}
+  {disabled}
+  {readonly}
+  {readonlyLabel}
+  {readonlyToggletipText}
+  {editAlwaysVisible}
+  {selectTextOnFocus}
+  {size}
+  data-testid="inline-edit"
+  on:save={() => console.log("save")}
+  on:cancel={() => console.log("cancel")}
+  on:blur={() => console.log("blur")}
+/>

--- a/tests/InlineEdit/InlineEdit.test.ts
+++ b/tests/InlineEdit/InlineEdit.test.ts
@@ -1,0 +1,200 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/svelte";
+import { user } from "../utils/user";
+import InlineEdit from "./InlineEdit.test.svelte";
+
+const editButton = () => screen.getByRole("button", { name: "Edit" });
+const saveButton = () => screen.getByRole("button", { name: "Save" });
+const cancelButton = () => screen.getByRole("button", { name: "Cancel" });
+
+describe("InlineEdit", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the current value in a text input", () => {
+    render(InlineEdit, { value: "default" });
+    expect(screen.getByDisplayValue("default")).toBeInTheDocument();
+  });
+
+  it("enters edit mode when the edit button is clicked", async () => {
+    render(InlineEdit);
+    await user.click(editButton());
+    expect(saveButton()).toBeInTheDocument();
+    expect(cancelButton()).toBeInTheDocument();
+  });
+
+  it("enters edit mode when the input is clicked", async () => {
+    render(InlineEdit);
+    await user.click(screen.getByDisplayValue("default"));
+    expect(saveButton()).toBeInTheDocument();
+  });
+
+  it("selects the input's text on entering edit mode when selectTextOnFocus is set", async () => {
+    render(InlineEdit, { value: "default", selectTextOnFocus: true });
+    await user.click(editButton());
+
+    const input = screen.getByDisplayValue<HTMLInputElement>("default");
+    expect(input.selectionStart).toBe(0);
+    expect(input.selectionEnd).toBe("default".length);
+  });
+
+  it("disables save and cancel until the value actually changes", async () => {
+    render(InlineEdit);
+    await user.click(editButton());
+    expect(saveButton()).toBeDisabled();
+    expect(cancelButton()).toBeDisabled();
+
+    const input = screen.getByDisplayValue("default");
+    await user.type(input, " updated");
+
+    expect(saveButton()).toBeEnabled();
+    expect(cancelButton()).toBeEnabled();
+  });
+
+  it("treats a whitespace-only change as unchanged", async () => {
+    render(InlineEdit, { value: "test" });
+    await user.click(editButton());
+
+    const input = screen.getByDisplayValue("test");
+    await user.type(input, "   ");
+
+    expect(saveButton()).toBeDisabled();
+    expect(cancelButton()).toBeDisabled();
+  });
+
+  it("saves and stays in edit mode when the save button is clicked", async () => {
+    const consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+    render(InlineEdit);
+    await user.click(editButton());
+    await user.type(screen.getByDisplayValue("default"), " updated");
+    await user.click(saveButton());
+
+    expect(consoleLog).toHaveBeenCalledWith("save");
+    expect(saveButton()).toBeInTheDocument();
+    expect(cancelButton()).toBeInTheDocument();
+  });
+
+  it("cancels, reverts the value, and stays in edit mode when the cancel button is clicked", async () => {
+    const consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+    render(InlineEdit, { value: "default" });
+    await user.click(editButton());
+    await user.type(screen.getByDisplayValue("default"), " updated");
+    await user.click(cancelButton());
+
+    expect(consoleLog).toHaveBeenCalledWith("cancel");
+    expect(screen.getByDisplayValue("default")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Edit" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("auto-saves and exits edit mode on blur when the value changed", async () => {
+    const consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+    render(InlineEdit);
+    await user.click(editButton());
+    const input = screen.getByDisplayValue("default");
+    await user.type(input, " updated");
+    await fireEvent.focusOut(input);
+
+    expect(consoleLog).toHaveBeenCalledWith("save");
+    expect(editButton()).toBeInTheDocument();
+  });
+
+  it("auto-cancels and exits edit mode on blur when the value is unchanged", async () => {
+    const consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+    render(InlineEdit);
+    await user.click(editButton());
+    const input = screen.getByDisplayValue("default");
+    await fireEvent.focusOut(input);
+
+    expect(consoleLog).toHaveBeenCalledWith("cancel");
+    expect(editButton()).toBeInTheDocument();
+  });
+
+  it("cancels, reverts the value, and exits edit mode on Escape", async () => {
+    const consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+    render(InlineEdit, { value: "default" });
+    await user.click(editButton());
+    const input = screen.getByDisplayValue("default");
+    await user.type(input, " updated");
+    await user.keyboard("{Escape}");
+
+    expect(consoleLog).toHaveBeenCalledWith("cancel");
+    expect(screen.getByDisplayValue("default")).toBeInTheDocument();
+    expect(editButton()).toBeInTheDocument();
+  });
+
+  it("does not save on Enter when the value is unchanged", async () => {
+    const consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+    render(InlineEdit);
+    await user.click(editButton());
+    await user.keyboard("{Enter}");
+    expect(consoleLog).not.toHaveBeenCalledWith("save");
+  });
+
+  it("saves on Enter when the value changed, and stays in edit mode", async () => {
+    const consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+    render(InlineEdit);
+    await user.click(editButton());
+    await user.type(screen.getByDisplayValue("default"), " updated");
+    await user.keyboard("{Enter}");
+
+    expect(consoleLog).toHaveBeenCalledWith("save");
+    await waitFor(() => expect(saveButton()).toBeInTheDocument());
+  });
+
+  it("shows invalidText and disables save while invalid, even with a change", async () => {
+    render(InlineEdit, {
+      invalid: true,
+      invalidText: "This field is required",
+    });
+    await user.click(editButton());
+    await user.type(screen.getByDisplayValue("default"), " updated");
+
+    expect(screen.getByText("This field is required")).toBeInTheDocument();
+    expect(saveButton()).toBeDisabled();
+    expect(cancelButton()).toBeEnabled();
+  });
+
+  it("disables the input and shows no edit affordance when disabled", () => {
+    render(InlineEdit, { disabled: true });
+
+    const input = screen.getByDisplayValue("default");
+    expect(input).toBeDisabled();
+    expect(
+      screen.queryByRole("button", { name: "Edit" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Edit off" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("suppresses invalid styling while disabled, matching TextInput", () => {
+    render(InlineEdit, {
+      disabled: true,
+      invalid: true,
+      invalidText: "This field is required",
+    });
+
+    expect(
+      screen.queryByText("This field is required"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders a readonly input with a toggletip trigger in readonly mode", async () => {
+    render(InlineEdit, {
+      readonly: true,
+      readonlyLabel: "Edit off",
+      readonlyToggletipText: "This field is read-only",
+    });
+
+    const input = screen.getByDisplayValue("default");
+    expect(input).toHaveAttribute("readonly");
+    expect(
+      screen.queryByRole("button", { name: "Edit" }),
+    ).not.toBeInTheDocument();
+
+    await user.click(screen.getByLabelText("Edit off"));
+    expect(screen.getByText("This field is read-only")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Click or focus to edit; blur saves a real change or cancels an
unchanged one. bind:value instead of a controlled pair, with
payload-less on:save/on:cancel. The toolbar stays a constant width so
it doesn't resize a DataTable column on focus.
