### PR TITLE
feat(resizer): add Resizer component

### DIFF
--- a/css/_resizer.scss
+++ b/css/_resizer.scss
@@ -1,0 +1,60 @@
+@import "carbon-components/scss/globals/scss/vars";
+@import "carbon-components/scss/globals/scss/helper-mixins";
+@import "carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/import-once/import-once";
+@import "carbon-components/scss/globals/scss/motion";
+
+/// Resizer styles. Ported from Carbon React's own (not yet wired into its
+/// bundle) `packages/styles/scss/components/resizer`, mapped from v11
+/// tokens to this repo's v10 equivalents. Drops the `:focus-visible`/
+/// `:focus:not(:focus-visible)` split upstream uses to show the ring only
+/// on keyboard focus: like `:has()`, `:focus-visible` exceeds this
+/// library's Safari 14 baseline (shipped in Safari 15.4), so every focus
+/// shows the ring here.
+/// @access public
+/// @group resizer
+@mixin resizer {
+  .#{$prefix}--resizer {
+    position: relative;
+    flex: none;
+    background-color: $ui-03;
+  }
+
+  .#{$prefix}--resizer:hover {
+    @media (prefers-reduced-motion: no-preference) {
+      background-color: $interactive-01;
+      transition: background-color $duration--moderate-01;
+    }
+  }
+
+  .#{$prefix}--resizer:focus {
+    outline: 2px solid $focus;
+    outline-offset: -2px;
+    background-color: $interactive-01;
+  }
+
+  .#{$prefix}--resizer:active {
+    background-color: $interactive-01;
+  }
+
+  .#{$prefix}--resizer--horizontal {
+    cursor: ns-resize;
+  }
+
+  .#{$prefix}--resizer--vertical {
+    cursor: ew-resize;
+  }
+
+  // Optional utility: add to a Resizer's resizable siblings for a smooth
+  // size transition (for example on a programmatic or double-click reset).
+  // Not applied automatically, since a transition during an active drag
+  // would lag behind the pointer.
+  .#{$prefix}--smooth-resize {
+    @media (prefers-reduced-motion: no-preference) {
+      transition: all $duration--moderate-01 linear;
+    }
+  }
+}
+
+@include exports("resizer") {
+  @include resizer;
+}

--- a/css/all.scss
+++ b/css/all.scss
@@ -132,3 +132,4 @@ $css--plex: true;
 @import "./list-box-wrap-options";
 @import "./structured-list-sort";
 @import "./action-set";
+@import "./resizer";

--- a/css/g10.scss
+++ b/css/g10.scss
@@ -92,3 +92,4 @@ $css--plex: true;
 @import "./list-box-wrap-options";
 @import "./structured-list-sort";
 @import "./action-set";
+@import "./resizer";

--- a/css/g100.scss
+++ b/css/g100.scss
@@ -92,3 +92,4 @@ $css--plex: true;
 @import "./list-box-wrap-options";
 @import "./structured-list-sort";
 @import "./action-set";
+@import "./resizer";

--- a/css/g80.scss
+++ b/css/g80.scss
@@ -92,3 +92,4 @@ $css--plex: true;
 @import "./list-box-wrap-options";
 @import "./structured-list-sort";
 @import "./action-set";
+@import "./resizer";

--- a/css/g90.scss
+++ b/css/g90.scss
@@ -92,3 +92,4 @@ $css--plex: true;
 @import "./list-box-wrap-options";
 @import "./structured-list-sort";
 @import "./action-set";
+@import "./resizer";

--- a/css/white.scss
+++ b/css/white.scss
@@ -92,3 +92,4 @@ $css--plex: true;
 @import "./list-box-wrap-options";
 @import "./structured-list-sort";
 @import "./action-set";
+@import "./resizer";

--- a/docs/src/component-categories.ts
+++ b/docs/src/component-categories.ts
@@ -29,6 +29,7 @@ export const COMPONENT_CATEGORIES: ComponentCategory[] = [
       "AspectRatio",
       "Accordion",
       "Disclosure",
+      "Resizer",
     ],
   },
   {

--- a/docs/src/component-since-versions.ts
+++ b/docs/src/component-since-versions.ts
@@ -57,6 +57,7 @@ export const COMPONENT_SINCE_VERSIONS: Record<string, string> = {
   RadioButton: "0.2.0",
   RadioTile: "0.2.0",
   RecursiveList: "0.39.0",
+  Resizer: "0.112.0",
   Search: "0.2.0",
   SearchMenu: "0.110.0",
   Select: "0.2.0",

--- a/docs/src/pages/components/Resizer.svx
+++ b/docs/src/pages/components/Resizer.svx
@@ -1,0 +1,28 @@
+---
+components: ["Resizer"]
+description: A draggable, keyboard-operable handle placed between two elements that resizes them by dragging, arrow keys, or a double-click reset.
+---
+
+## Basic
+
+Place a `Resizer` between two sibling elements and set `orientation` to `"vertical"` (resize left/right) or `"horizontal"` (resize up/down). By default it resizes its DOM siblings directly: drag it, use arrow keys (hold <DocKbd label="Shift" /> for a larger step), press <DocKbd label="Home" /> or <DocKbd label="End" /> to collapse a side fully, or double-click to reset both sides to their size when the page loaded.
+
+<FileSource src="/framed/Resizer/ResizerBasic" />
+
+## Orientation
+
+Set `orientation` to `"horizontal"` to stack panels vertically and resize up/down instead.
+
+<FileSource src="/framed/Resizer/ResizerHorizontal" />
+
+## Controlled
+
+Call `event.preventDefault()` in `on:resize` to take over sizing yourself — the component then leaves its DOM siblings alone, and only reports the drag/key delta.
+
+<FileSource src="/framed/Resizer/ResizerControlled" />
+
+## Custom handle content
+
+Pass content to the default slot to render inside the handle, for example a drag-grip icon.
+
+<FileSource src="/framed/Resizer/ResizerCustomHandle" />

--- a/docs/src/pages/framed/Resizer/ResizerBasic.svelte
+++ b/docs/src/pages/framed/Resizer/ResizerBasic.svelte
@@ -1,0 +1,13 @@
+<script>
+  import { Resizer } from "carbon-components-svelte";
+</script>
+
+<div
+  style="display: flex; height: 200px; border: 1px solid var(--cds-border-subtle);"
+>
+  <div style="width: 200px; padding: 1rem; background: var(--cds-layer);">
+    Left panel
+  </div>
+  <Resizer orientation="vertical" />
+  <div style="flex: 1; padding: 1rem;">Right panel</div>
+</div>

--- a/docs/src/pages/framed/Resizer/ResizerControlled.svelte
+++ b/docs/src/pages/framed/Resizer/ResizerControlled.svelte
@@ -1,0 +1,32 @@
+<script>
+  import { Resizer } from "carbon-components-svelte";
+
+  let leftWidth = 200;
+  let baseline = leftWidth;
+</script>
+
+<div
+  style="display: flex; height: 200px; border: 1px solid var(--cds-border-subtle);"
+>
+  <div
+    style="width: {leftWidth}px; padding: 1rem; background: var(--cds-layer);"
+  >
+    {Math.round(leftWidth)}px
+  </div>
+  <Resizer
+    orientation="vertical"
+    on:resizestart={() => {
+      // delta on the resize events below is cumulative from this point,
+      // not incremental since the last event, so the baseline has to be
+      // captured once here rather than re-read from the latest width.
+      baseline = leftWidth;
+    }}
+    on:resize={(event) => {
+      // Fully controlled: prevent the default sibling-DOM resize and own
+      // the width ourselves.
+      event.preventDefault();
+      leftWidth = Math.max(80, baseline + event.detail.delta);
+    }}
+  />
+  <div style="flex: 1; padding: 1rem;">Right panel</div>
+</div>

--- a/docs/src/pages/framed/Resizer/ResizerCustomHandle.svelte
+++ b/docs/src/pages/framed/Resizer/ResizerCustomHandle.svelte
@@ -1,0 +1,19 @@
+<script>
+  import { Resizer } from "carbon-components-svelte";
+  import DragVertical from "carbon-icons-svelte/lib/DragVertical.svelte";
+</script>
+
+<div
+  style="display: flex; height: 200px; border: 1px solid var(--cds-border-subtle);"
+>
+  <div style="width: 200px; padding: 1rem; background: var(--cds-layer);">
+    Left panel
+  </div>
+  <Resizer
+    orientation="vertical"
+    style="display: flex; align-items: center; justify-content: center;"
+  >
+    <DragVertical size={16} />
+  </Resizer>
+  <div style="flex: 1; padding: 1rem;">Right panel</div>
+</div>

--- a/docs/src/pages/framed/Resizer/ResizerHorizontal.svelte
+++ b/docs/src/pages/framed/Resizer/ResizerHorizontal.svelte
@@ -1,0 +1,13 @@
+<script>
+  import { Resizer } from "carbon-components-svelte";
+</script>
+
+<div
+  style="display: flex; flex-direction: column; width: 300px; border: 1px solid var(--cds-border-subtle);"
+>
+  <div style="height: 120px; padding: 1rem; background: var(--cds-layer);">
+    Top panel
+  </div>
+  <Resizer orientation="horizontal" />
+  <div style="flex: 1; padding: 1rem;">Bottom panel</div>
+</div>

--- a/src/Resizer/Resizer.svelte
+++ b/src/Resizer/Resizer.svelte
@@ -1,0 +1,240 @@
+<script context="module">
+  /** Debounce window (ms) for the keyboard resizeend dispatch. */
+  export const DEBOUNCE_DELAY = 100;
+</script>
+
+<script>
+  /**
+   * @restProps {div}
+   * @slot {{}}
+   * @event {{ event: MouseEvent | KeyboardEvent }} resizestart - Fires once at the start of a resize interaction (mousedown, or each keydown, since a keyboard step is its own interaction). `delta` on the following `resize` events is cumulative from this point, not incremental since the last one. In controlled mode, capture your own baseline size here and add `delta` to that baseline, not to your latest state, or repeated `resize` events will compound.
+   * @event {{ event: MouseEvent | KeyboardEvent; delta: number }} resize - Fires on every resize movement. Call `event.preventDefault()` to take over sizing yourself; the component then leaves its DOM siblings alone.
+   * @event {{ event: MouseEvent | KeyboardEvent }} resizeend - Fires once when a resize interaction ends, debounced for keyboard.
+   * @event {MouseEvent} dblclick - Fires on double-click. Call `event.preventDefault()` to suppress the default reset-to-initial-size behavior.
+   */
+
+  /**
+   * Whether the handle resizes elements stacked above/below
+   * (`"horizontal"`) or side by side (`"vertical"`).
+   * @type {"horizontal" | "vertical"}
+   */
+  export let orientation;
+
+  /** Handle thickness in px. */
+  export let thickness = 4;
+
+  /**
+   * Obtain a reference to the outer HTML element.
+   * @bindable readonly
+   */
+  export let ref = null;
+
+  import { createEventDispatcher, onMount } from "svelte";
+  import { debounce } from "../utils/debounce.js";
+
+  const dispatch = createEventDispatcher();
+
+  const NAVIGATION_KEYS = [
+    "ArrowUp",
+    "ArrowDown",
+    "ArrowLeft",
+    "ArrowRight",
+    "Home",
+    "End",
+    "PageUp",
+    "PageDown",
+  ];
+
+  let startPos = { x: 0, y: 0 };
+  let sizes = {
+    prevSiblingSize: { width: 0, height: 0 },
+    nextSiblingSize: { width: 0, height: 0 },
+  };
+  let initialSizes = {
+    prevSiblingSize: { width: 0, height: 0 },
+    nextSiblingSize: { width: 0, height: 0 },
+  };
+
+  function getSize(el) {
+    const rect = el?.getBoundingClientRect();
+    return { width: rect?.width ?? 0, height: rect?.height ?? 0 };
+  }
+
+  // Set this handle's own thickness and capture the siblings' starting
+  // sizes for the double-click reset. Re-runs whenever orientation or
+  // thickness change, matching upstream's own effect dependency array.
+  $: if (ref) {
+    ref.style[orientation === "horizontal" ? "blockSize" : "inlineSize"] =
+      `${thickness / 16}rem`;
+    initialSizes = {
+      prevSiblingSize: getSize(ref.previousElementSibling),
+      nextSiblingSize: getSize(ref.nextElementSibling),
+    };
+  }
+
+  const debouncedResizeEnd = debounce((event) => {
+    dispatch("resizeend", { event });
+  }, DEBOUNCE_DELAY);
+
+  function updateSizes(event, delta) {
+    const shouldContinue = dispatch(
+      "resize",
+      { event, delta },
+      { cancelable: true },
+    );
+    if (!shouldContinue) return;
+
+    const prop = orientation === "horizontal" ? "height" : "width";
+    const prevSibling = ref?.previousElementSibling;
+    const nextSibling = ref?.nextElementSibling;
+
+    if (prevSibling instanceof HTMLElement) {
+      prevSibling.style[prop] = `${sizes.prevSiblingSize[prop] + delta}px`;
+    }
+    if (nextSibling instanceof HTMLElement) {
+      nextSibling.style[prop] = `${sizes.nextSiblingSize[prop] - delta}px`;
+    }
+  }
+
+  function handleMouseMove(event) {
+    event.preventDefault();
+    event.stopPropagation();
+    const delta =
+      orientation === "horizontal"
+        ? event.clientY - startPos.y
+        : event.clientX - startPos.x;
+    updateSizes(event, delta);
+  }
+
+  function handleMouseUp(event) {
+    window.removeEventListener("mousemove", handleMouseMove);
+    window.removeEventListener("mouseup", handleMouseUp);
+
+    dispatch("resizeend", { event });
+
+    const prevSibling = ref?.previousElementSibling;
+    const nextSibling = ref?.nextElementSibling;
+    if (prevSibling instanceof HTMLElement) prevSibling.style.transition = "";
+    if (nextSibling instanceof HTMLElement) nextSibling.style.transition = "";
+  }
+
+  function handleMouseDown(event) {
+    if (event.button !== 0) return;
+
+    const prevSibling = ref?.previousElementSibling;
+    const nextSibling = ref?.nextElementSibling;
+    if (prevSibling instanceof HTMLElement)
+      prevSibling.style.transition = "none";
+    if (nextSibling instanceof HTMLElement)
+      nextSibling.style.transition = "none";
+
+    startPos = { x: event.clientX, y: event.clientY };
+    sizes = {
+      prevSiblingSize: getSize(prevSibling),
+      nextSiblingSize: getSize(nextSibling),
+    };
+    dispatch("resizestart", { event });
+
+    window.addEventListener("mousemove", handleMouseMove);
+    window.addEventListener("mouseup", handleMouseUp);
+  }
+
+  function handleKeyDown(event) {
+    if (!NAVIGATION_KEYS.includes(event.key)) return;
+
+    event.preventDefault();
+    event.stopPropagation();
+
+    const isHorizontal = orientation === "horizontal";
+    sizes = {
+      prevSiblingSize: getSize(ref?.previousElementSibling),
+      nextSiblingSize: getSize(ref?.nextElementSibling),
+    };
+    dispatch("resizestart", { event });
+
+    const step = event.shiftKey ? 25 : 5;
+    let delta = 0;
+
+    switch (event.key) {
+      case "ArrowUp":
+        if (isHorizontal) delta = -step;
+        break;
+      case "ArrowDown":
+        if (isHorizontal) delta = step;
+        break;
+      case "ArrowLeft":
+        if (!isHorizontal) delta = -step;
+        break;
+      case "ArrowRight":
+        if (!isHorizontal) delta = step;
+        break;
+      case "Home":
+        delta = isHorizontal
+          ? -sizes.prevSiblingSize.height
+          : -sizes.prevSiblingSize.width;
+        break;
+      case "End":
+        delta = isHorizontal
+          ? sizes.nextSiblingSize.height
+          : sizes.nextSiblingSize.width;
+        break;
+    }
+
+    updateSizes(event, delta);
+    debouncedResizeEnd(event);
+  }
+
+  function handleDoubleClick(event) {
+    event.preventDefault();
+    const shouldContinue = dispatch("dblclick", event, { cancelable: true });
+    if (!shouldContinue) return;
+
+    const prop = orientation === "horizontal" ? "height" : "width";
+    const prevSibling = ref?.previousElementSibling;
+    const nextSibling = ref?.nextElementSibling;
+
+    if (prevSibling instanceof HTMLElement) {
+      prevSibling.style[prop] = `${initialSizes.prevSiblingSize[prop]}px`;
+    }
+    if (nextSibling instanceof HTMLElement) {
+      nextSibling.style[prop] = `${initialSizes.nextSiblingSize[prop]}px`;
+    }
+  }
+
+  onMount(() => {
+    return () => {
+      window.removeEventListener("mousemove", handleMouseMove);
+      window.removeEventListener("mouseup", handleMouseUp);
+    };
+  });
+
+  $: resizerClass = [
+    "bx--resizer",
+    `bx--resizer--${orientation}`,
+    $$restProps.class,
+  ]
+    .filter(Boolean)
+    .join(" ");
+</script>
+
+<!-- svelte-ignore a11y-no-noninteractive-tabindex -->
+<!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
+<div
+  bind:this={ref}
+  {...$$restProps}
+  class={resizerClass}
+  role="separator"
+  tabindex="0"
+  aria-orientation={orientation}
+  aria-live="assertive"
+  data-component-name="Resizer"
+  on:mousedown={handleMouseDown}
+  on:dblclick={handleDoubleClick}
+  on:keydown={handleKeyDown}
+>
+  <span class:bx--visually-hidden={true}>
+    Use arrow keys to resize, hold Shift for larger steps. Double-click to
+    reset.
+  </span>
+  <slot />
+</div>

--- a/src/Resizer/index.js
+++ b/src/Resizer/index.js
@@ -1,0 +1,1 @@
+export { default as Resizer } from "./Resizer.svelte";

--- a/src/index.js
+++ b/src/index.js
@@ -134,6 +134,7 @@ export { default as RadioButton } from "./RadioButton/RadioButton.svelte";
 export { default as RadioButtonSkeleton } from "./RadioButton/RadioButtonSkeleton.svelte";
 export { default as RadioButtonGroup } from "./RadioButtonGroup/RadioButtonGroup.svelte";
 export { default as RecursiveList } from "./RecursiveList/RecursiveList.svelte";
+export { default as Resizer } from "./Resizer/Resizer.svelte";
 export { default as FluidSearchSkeleton } from "./Search/FluidSearchSkeleton.svelte";
 export { default as Search } from "./Search/Search.svelte";
 export { default as SearchSkeleton } from "./Search/SearchSkeleton.svelte";

--- a/tests/Resizer/Resizer.test.svelte
+++ b/tests/Resizer/Resizer.test.svelte
@@ -1,0 +1,46 @@
+<svelte:options accessors />
+
+<script lang="ts">
+  import Resizer from "carbon-components-svelte/Resizer/Resizer.svelte";
+  import type { ComponentProps } from "svelte";
+
+  export let orientation: ComponentProps<Resizer>["orientation"] = "vertical";
+  export let thickness: ComponentProps<Resizer>["thickness"] = undefined;
+  export let controlled = false;
+  export let preventReset = false;
+  export let ref: ComponentProps<Resizer>["ref"] = null;
+
+  // Correct controlled-mode pattern: capture the baseline once per
+  // resizestart, then add delta to *that* baseline, not to the latest
+  // controlledWidth, since delta is cumulative from resizestart.
+  export let controlledWidth = 200;
+  let baseline = controlledWidth;
+</script>
+
+<div>
+  <div data-testid="prev"></div>
+  <Resizer
+    bind:ref
+    {orientation}
+    {thickness}
+    data-testid="resizer"
+    {...$$restProps}
+    on:resizestart={() => {
+      console.log("resizestart");
+      baseline = controlledWidth;
+    }}
+    on:resize={(event) => {
+      console.log("resize", event.detail.delta);
+      if (controlled) {
+        event.preventDefault();
+        controlledWidth = Math.max(80, baseline + event.detail.delta);
+      }
+    }}
+    on:resizeend={() => console.log("resizeend")}
+    on:dblclick={(event) => {
+      console.log("dblclick");
+      if (preventReset) event.preventDefault();
+    }}
+  />
+  <div data-testid="next"></div>
+</div>

--- a/tests/Resizer/Resizer.test.ts
+++ b/tests/Resizer/Resizer.test.ts
@@ -1,0 +1,235 @@
+import { fireEvent, render, screen } from "@testing-library/svelte";
+import { DEBOUNCE_DELAY } from "carbon-components-svelte/Resizer/Resizer.svelte";
+import Resizer from "./Resizer.test.svelte";
+
+/**
+ * jsdom has no real layout, so getBoundingClientRect() always reports 0.
+ * Stub it on the prototype (before mount, since Resizer reads sizes at
+ * mount time too) to report each stubbed element's *current* inline
+ * width/height, falling back to 100x100 — this mirrors a real browser,
+ * where a re-measurement after a style change reports the new size.
+ */
+function stubLayout() {
+  const original = Element.prototype.getBoundingClientRect;
+  const stubbed = new Set<string>(["prev", "next"]);
+
+  Element.prototype.getBoundingClientRect = function (this: HTMLElement) {
+    const testId = this.getAttribute("data-testid");
+    if (testId && stubbed.has(testId)) {
+      const width = this.style.width
+        ? Number.parseFloat(this.style.width)
+        : 100;
+      const height = this.style.height
+        ? Number.parseFloat(this.style.height)
+        : 100;
+      return {
+        width,
+        height,
+        x: 0,
+        y: 0,
+        top: 0,
+        left: 0,
+        right: width,
+        bottom: height,
+        toJSON() {
+          return this;
+        },
+      } as DOMRect;
+    }
+    return original.call(this);
+  };
+
+  return () => {
+    Element.prototype.getBoundingClientRect = original;
+  };
+}
+
+function setup(props: Record<string, unknown> = {}) {
+  const restore = stubLayout();
+  const utils = render(Resizer, props);
+  return {
+    ...utils,
+    prev: screen.getByTestId("prev"),
+    next: screen.getByTestId("next"),
+    resizer: screen.getByTestId("resizer"),
+    restore,
+  };
+}
+
+describe("Resizer", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders as a separator with the expected aria attributes", () => {
+    render(Resizer, { orientation: "horizontal" });
+    const el = screen.getByRole("separator");
+    expect(el).toHaveAttribute("aria-orientation", "horizontal");
+    expect(el).toHaveAttribute("aria-live", "assertive");
+    expect(el).toHaveAttribute("tabindex", "0");
+  });
+
+  it("applies a custom class and forwards a ref", () => {
+    const { component } = render(Resizer, {
+      class: "custom-class",
+    } as never);
+    expect(screen.getByRole("separator")).toHaveClass("custom-class");
+    expect(component.ref).toBeInstanceOf(HTMLElement);
+  });
+
+  it("resizes both siblings on mouse drag and dispatches resize/resizeend", async () => {
+    const consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+    const { prev, next, resizer, restore } = setup();
+
+    await fireEvent.mouseDown(resizer, { clientX: 50, button: 0 });
+    await fireEvent.mouseMove(window, { clientX: 70 });
+    await fireEvent.mouseUp(window, { clientX: 70 });
+
+    expect(consoleLog).toHaveBeenCalledWith("resizestart");
+    expect(consoleLog).toHaveBeenCalledWith("resize", 20);
+    expect(consoleLog).toHaveBeenCalledWith("resizeend");
+    expect(prev).toHaveStyle("width: 120px");
+    expect(next).toHaveStyle("width: 80px");
+    restore();
+  });
+
+  it("keeps delta cumulative from resizestart across multiple mousemove events in one drag", async () => {
+    const consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+    const { prev, next, resizer, restore } = setup();
+
+    await fireEvent.mouseDown(resizer, { clientX: 50, button: 0 });
+    await fireEvent.mouseMove(window, { clientX: 55 });
+    await fireEvent.mouseMove(window, { clientX: 60 });
+    await fireEvent.mouseMove(window, { clientX: 65 });
+    await fireEvent.mouseUp(window, { clientX: 65 });
+
+    // Each move reports total displacement from resizestart (5, 10, 15),
+    // not the 5px incremental step since the previous move.
+    expect(consoleLog).toHaveBeenCalledWith("resize", 5);
+    expect(consoleLog).toHaveBeenCalledWith("resize", 10);
+    expect(consoleLog).toHaveBeenCalledWith("resize", 15);
+    expect(prev).toHaveStyle("width: 115px");
+    expect(next).toHaveStyle("width: 85px");
+    restore();
+  });
+
+  it("resizes by 5px on ArrowRight and back on ArrowLeft for vertical orientation", async () => {
+    const { prev, next, resizer, restore } = setup();
+
+    await fireEvent.keyDown(resizer, { key: "ArrowRight" });
+    expect(prev).toHaveStyle("width: 105px");
+    expect(next).toHaveStyle("width: 95px");
+
+    await fireEvent.keyDown(resizer, { key: "ArrowLeft" });
+    expect(prev).toHaveStyle("width: 100px");
+    expect(next).toHaveStyle("width: 100px");
+    restore();
+  });
+
+  it("resizes by 25px with Shift", async () => {
+    const { prev, next, resizer, restore } = setup();
+
+    await fireEvent.keyDown(resizer, { key: "ArrowRight", shiftKey: true });
+    expect(prev).toHaveStyle("width: 125px");
+    expect(next).toHaveStyle("width: 75px");
+    restore();
+  });
+
+  it("ignores unrelated keys", async () => {
+    const { prev, next, resizer, restore } = setup();
+    await fireEvent.keyDown(resizer, { key: "a" });
+    expect(prev.style.width).toBe("");
+    expect(next.style.width).toBe("");
+    restore();
+  });
+
+  it("fully collapses the previous sibling on Home and the next on End", async () => {
+    const { prev, next, resizer, restore } = setup();
+
+    await fireEvent.keyDown(resizer, { key: "Home" });
+    expect(prev).toHaveStyle("width: 0px");
+    expect(next).toHaveStyle("width: 200px");
+
+    await fireEvent.keyDown(resizer, { key: "End" });
+    expect(prev).toHaveStyle("width: 200px");
+    expect(next).toHaveStyle("width: 0px");
+    restore();
+  });
+
+  it("debounces resizeend for keyboard interactions", async () => {
+    const consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+    const { resizer, restore } = setup();
+
+    await fireEvent.keyDown(resizer, { key: "ArrowRight" });
+    expect(consoleLog).not.toHaveBeenCalledWith("resizeend");
+
+    await new Promise((resolve) => setTimeout(resolve, DEBOUNCE_DELAY + 50));
+    expect(consoleLog).toHaveBeenCalledWith("resizeend");
+    restore();
+  });
+
+  it("resets both siblings to their initial size on double-click", async () => {
+    const { prev, next, resizer, restore } = setup();
+
+    await fireEvent.keyDown(resizer, { key: "ArrowRight", shiftKey: true });
+    expect(prev).toHaveStyle("width: 125px");
+
+    await fireEvent.dblClick(resizer);
+    expect(prev).toHaveStyle("width: 100px");
+    expect(next).toHaveStyle("width: 100px");
+    restore();
+  });
+
+  it("skips the default reset when on:dblclick calls preventDefault", async () => {
+    const { prev, resizer, restore } = setup({ preventReset: true });
+
+    await fireEvent.keyDown(resizer, { key: "ArrowRight", shiftKey: true });
+    await fireEvent.dblClick(resizer);
+
+    expect(prev).toHaveStyle("width: 125px");
+    restore();
+  });
+
+  it("does not touch sibling DOM when on:resize calls preventDefault (controlled mode)", async () => {
+    const consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+    const { prev, next, resizer, restore } = setup({ controlled: true });
+
+    await fireEvent.keyDown(resizer, { key: "ArrowRight" });
+
+    expect(consoleLog).toHaveBeenCalledWith("resize", 5);
+    expect(prev.style.width).toBe("");
+    expect(next.style.width).toBe("");
+    restore();
+  });
+
+  it("fires resizestart on every keydown, since each keyboard step is its own interaction", async () => {
+    const consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+    const { resizer, restore } = setup();
+
+    await fireEvent.keyDown(resizer, { key: "ArrowRight" });
+    await fireEvent.keyDown(resizer, { key: "ArrowRight" });
+
+    expect(
+      consoleLog.mock.calls.filter(([message]) => message === "resizestart"),
+    ).toHaveLength(2);
+    restore();
+  });
+
+  it("lets a controlled consumer avoid compounding by tracking its own baseline from resizestart", async () => {
+    const { component, resizer, restore } = setup({
+      controlled: true,
+      controlledWidth: 200,
+    });
+
+    await fireEvent.mouseDown(resizer, { clientX: 50, button: 0 });
+    await fireEvent.mouseMove(window, { clientX: 55 });
+    await fireEvent.mouseMove(window, { clientX: 60 });
+    await fireEvent.mouseMove(window, { clientX: 65 });
+    await fireEvent.mouseUp(window, { clientX: 65 });
+
+    // 15px of total mouse movement should produce 15px of total width
+    // change, not a compounded (5 + 10 + 15 = 30px) change.
+    expect(component.controlledWidth).toBe(215);
+    restore();
+  });
+});


### PR DESCRIPTION
Drag or keyboard-resize sibling elements, or call preventDefault on
on:resize to take over sizing. delta is cumulative from the start of
the interaction, so a controlled consumer can snapshot baseline size
once per drag.
