### PR TITLE
feat(tabs): add size prop for line and container tabs

### DIFF
--- a/css/vendor/carbon-components/scss/components/tabs/_tabs.scss
+++ b/css/vendor/carbon-components/scss/components/tabs/_tabs.scss
@@ -493,3 +493,126 @@
 @include exports('tabs') {
   @include tabs;
 }
+
+// carbon-components-svelte patch (formerly the `tabs-size` portion of css/_tabs.scss)
+@import "carbon-components/scss/globals/scss/vars";
+@import "carbon-components/scss/globals/scss/helper-mixins";
+@import "carbon-components/scss/globals/scss/vendor/@carbon/layout/scss/generated/size";
+@import "carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/import-once/import-once";
+
+$tabs-sizes: (
+  sm: $size-sm,
+  md: $size-md,
+  lg: $size-lg,
+  xl: $size-xl,
+);
+
+/// Line and container tabs size variants (Carbon React `size` on `TabList`).
+/// Unlike vertical tabs, line/container tabs stay a horizontal row at every
+/// breakpoint (see `tabs-overflow` in `css/_tabs.scss`), so a single set of
+/// rules covers both. `Tabs.svelte` clamps the requested size to each type's
+/// own range (line: sm-lg, container: sm-xl) before applying the class, so
+/// the CSS itself does not need to gate by `bx--tabs--container`.
+///
+/// The base link's height comes from fixed padding + line-height, not the
+/// nav item's own block-size, so just resizing the nav item leaves the link
+/// (and the selected/focus indicators drawn on it) at its original height —
+/// clipped by the now-shorter item and misaligned with its bottom edge. The
+/// link is flexed to fill and center within the sized item instead, the
+/// same technique `tabs-vertical-size` (`css/_tabs.scss`) already uses,
+/// rather than hand-tuning padding/line-height per size and per state
+/// (selected, hover, focus, container).
+///
+/// Separately, the root element itself carries its own `min-height` from
+/// Carbon's base styles above (40px for line, 48px for container) — a floor
+/// meant for the unsized default, not aware of a smaller requested size. At
+/// `sm` (32px) or `md` (40px, container only) that floor is taller than the
+/// now-sized nav items, leaving slack space below the row. Reset per size so
+/// the root never reserves more height than its items need.
+///
+/// This patch lives here, appended after the upstream rules above, rather
+/// than in `css/_tabs.scss` with the other Tabs overrides: those override
+/// partials load before this file and need extra `:not()`/element-selector
+/// padding just to out-specify equal-shaped upstream rules; appended here,
+/// each selector only needs to add the `bx--layout--size-*` class actually
+/// carrying new meaning.
+/// @access private
+/// @group components
+@mixin tabs-size {
+  @each $size, $size-value in $tabs-sizes {
+    .#{$prefix}--tabs.#{$prefix}--layout--size-#{$size} {
+      min-block-size: $size-value;
+
+      .#{$prefix}--tabs__nav-item {
+        block-size: $size-value;
+      }
+
+      .#{$prefix}--tabs__nav-link,
+      .#{$prefix}--tabs__nav-link:focus,
+      .#{$prefix}--tabs__nav-link:active {
+        display: flex;
+        align-items: center;
+        block-size: 100%;
+        padding-block: 0;
+      }
+
+      // Line (non-container, non-vertical) tabs only: every underline/
+      // indicator state (default, hover, selected, disabled) is drawn with
+      // a real `border-bottom`, which is a box-model side that only eats
+      // space from the bottom of the link. That biases the label — now
+      // flex-centered above — above the item's true vertical center, most
+      // visible once a focus outline frames the tab. Container and vertical
+      // tabs already dodge this by painting their indicator as an inset
+      // `box-shadow` instead (not part of the box model); give sized line
+      // tabs the same treatment so centering holds regardless of which
+      // indicator is showing.
+      &:not(.#{$prefix}--tabs--container):not(.#{$prefix}--tabs--vertical) {
+        .#{$prefix}--tabs__nav-link,
+        .#{$prefix}--tabs__nav-link:focus,
+        .#{$prefix}--tabs__nav-link:active {
+          border-bottom: none;
+          // `box-shadow` isn't in the base link's `transition: border,
+          // outline` list, so without this the indicator swap on mousedown
+          // (:active, which fires before the click/selection commits) snaps
+          // instantly instead of easing like the border-based indicator did
+          // on unsized tabs, reading as the highlight jumping ahead of the
+          // actual click.
+          transition: box-shadow $duration--fast-01
+            motion(standard, productive);
+          box-shadow: inset 0 -2px 0 0 $ui-03;
+        }
+
+        .#{$prefix}--tabs__nav-item:hover:not(.#{$prefix}--tabs__nav-item--selected):not(.#{$prefix}--tabs__nav-item--disabled)
+          .#{$prefix}--tabs__nav-link {
+          box-shadow: inset 0 -2px 0 0 $ui-04;
+        }
+
+        .#{$prefix}--tabs__nav-item--selected:not(.#{$prefix}--tabs__nav-item--disabled) {
+          .#{$prefix}--tabs__nav-link,
+          .#{$prefix}--tabs__nav-link:focus,
+          .#{$prefix}--tabs__nav-link:active {
+            box-shadow: inset 0 -2px 0 0 $interactive-04;
+          }
+        }
+
+        .#{$prefix}--tabs__nav-item--disabled .#{$prefix}--tabs__nav-link {
+          box-shadow: inset 0 -2px 0 0 $disabled-01;
+        }
+
+        // Focused/active (not selected, not disabled): Carbon shows the
+        // focus outline instead of the underline here, so drop the
+        // indicator entirely rather than repaint it.
+        .#{$prefix}--tabs__nav-item:not(.#{$prefix}--tabs__nav-item--selected):not(.#{$prefix}--tabs__nav-item--disabled) {
+          .#{$prefix}--tabs__nav-link:focus,
+          .#{$prefix}--tabs__nav-link:active {
+            box-shadow: none;
+          }
+        }
+      }
+    }
+  }
+}
+
+@include exports('tabs-size') {
+  @include tabs-size;
+}

--- a/docs/src/pages/components/Tabs.svx
+++ b/docs/src/pages/components/Tabs.svx
@@ -31,6 +31,49 @@ Create a basic tab interface with labels and content.
   </svelte:fragment>
 </Tabs>
 
+## Sizes
+
+Set `size` to change the tab height. Line tabs support `"sm"`, `"md"`, and `"lg"`; `size` is unset by default, which preserves the original unsized height. An out-of-range value (for example `"xl"` on line tabs) clamps to the type's max — see [Container sizes](#sizes-1) for the full range on container tabs.
+
+### Small
+
+<Tabs size="sm">
+  <Tab label="Tab label 1" />
+  <Tab label="Tab label 2" />
+  <Tab label="Tab label 3" />
+  <svelte:fragment slot="content">
+    <TabContent>Content 1</TabContent>
+    <TabContent>Content 2</TabContent>
+    <TabContent>Content 3</TabContent>
+  </svelte:fragment>
+</Tabs>
+
+### Medium
+
+<Tabs size="md">
+  <Tab label="Tab label 1" />
+  <Tab label="Tab label 2" />
+  <Tab label="Tab label 3" />
+  <svelte:fragment slot="content">
+    <TabContent>Content 1</TabContent>
+    <TabContent>Content 2</TabContent>
+    <TabContent>Content 3</TabContent>
+  </svelte:fragment>
+</Tabs>
+
+### Large
+
+<Tabs size="lg">
+  <Tab label="Tab label 1" />
+  <Tab label="Tab label 2" />
+  <Tab label="Tab label 3" />
+  <svelte:fragment slot="content">
+    <TabContent>Content 1</TabContent>
+    <TabContent>Content 2</TabContent>
+    <TabContent>Content 3</TabContent>
+  </svelte:fragment>
+</Tabs>
+
 ## Selection
 
 Control which tab is active by index, by a stable id, or by changing how arrow keys move the selection.
@@ -404,6 +447,62 @@ Use the container type for a more prominent tab interface. By default, container
 ### Basic
 
 <Tabs type="container">
+  <Tab label="Tab label 1" />
+  <Tab label="Tab label 2" />
+  <Tab label="Tab label 3" />
+  <svelte:fragment slot="content">
+    <TabContent>Content 1</TabContent>
+    <TabContent>Content 2</TabContent>
+    <TabContent>Content 3</TabContent>
+  </svelte:fragment>
+</Tabs>
+
+### Sizes
+
+Container tabs support the full size range: `"sm"`, `"md"`, `"lg"`, and `"xl"`. `size` is unset by default, which preserves the original unsized height (48px, matching `"lg"`).
+
+#### Small
+
+<Tabs type="container" size="sm">
+  <Tab label="Tab label 1" />
+  <Tab label="Tab label 2" />
+  <Tab label="Tab label 3" />
+  <svelte:fragment slot="content">
+    <TabContent>Content 1</TabContent>
+    <TabContent>Content 2</TabContent>
+    <TabContent>Content 3</TabContent>
+  </svelte:fragment>
+</Tabs>
+
+#### Medium
+
+<Tabs type="container" size="md">
+  <Tab label="Tab label 1" />
+  <Tab label="Tab label 2" />
+  <Tab label="Tab label 3" />
+  <svelte:fragment slot="content">
+    <TabContent>Content 1</TabContent>
+    <TabContent>Content 2</TabContent>
+    <TabContent>Content 3</TabContent>
+  </svelte:fragment>
+</Tabs>
+
+#### Large
+
+<Tabs type="container" size="lg">
+  <Tab label="Tab label 1" />
+  <Tab label="Tab label 2" />
+  <Tab label="Tab label 3" />
+  <svelte:fragment slot="content">
+    <TabContent>Content 1</TabContent>
+    <TabContent>Content 2</TabContent>
+    <TabContent>Content 3</TabContent>
+  </svelte:fragment>
+</Tabs>
+
+#### Extra large
+
+<Tabs type="container" size="xl">
   <Tab label="Tab label 1" />
   <Tab label="Tab label 2" />
   <Tab label="Tab label 3" />

--- a/src/Tabs/Tabs.svelte
+++ b/src/Tabs/Tabs.svelte
@@ -59,6 +59,15 @@
    */
   export let iconSize = "default";
 
+  /**
+   * Specify the size of the tabs. Unset by default, which preserves the
+   * original unsized height. Line tabs (`type="default"`) support up to
+   * `"lg"`; container tabs support the full range up to `"xl"` — an
+   * out-of-range value clamps to the type's max.
+   * @type {"sm" | "md" | "lg" | "xl"}
+   */
+  export let size = undefined;
+
   import {
     afterUpdate,
     createEventDispatcher,
@@ -76,6 +85,8 @@
   import { syncDomOrder } from "../utils/syncDomOrder.js";
 
   const dispatch = createEventDispatcher();
+
+  const SIZE_SCALE = ["sm", "md", "lg", "xl"];
 
   /**
    * @type {import("svelte/store").Writable<ReadonlyArray<{ id: string; label: string; disabled: boolean; hasSecondaryLabel: boolean; index: number }>>}
@@ -445,6 +456,18 @@
   $: useFullWidth.set(fullWidth);
   $: useDismissible.set(dismissible);
   $: useIconOnly.set(iconOnly);
+
+  // Line tabs support up to `lg`; container tabs support the full range up
+  // to `xl`. An out-of-range value clamps to the type's max, mirroring
+  // Carbon's own `layout.use($min, $max)` clamping. An unrecognized value is
+  // ignored (no class), same as leaving `size` unset.
+  $: maxSizeIndex = type === "container" ? 3 : 2;
+  $: resolvedSize = (() => {
+    if (!size) return undefined;
+    const index = SIZE_SCALE.indexOf(size);
+    if (index === -1) return undefined;
+    return SIZE_SCALE[Math.min(index, maxSizeIndex)];
+  })();
 </script>
 
 <div
@@ -459,6 +482,10 @@
   class:bx--tabs__icon--lg={iconOnly && iconSize === "lg"}
   class:bx--tabs--scrollable={isOverflow}
   class:bx--tabs--scrollable--container={isOverflow && type === "container"}
+  class:bx--layout--size-sm={resolvedSize === "sm"}
+  class:bx--layout--size-md={resolvedSize === "md"}
+  class:bx--layout--size-lg={resolvedSize === "lg"}
+  class:bx--layout--size-xl={resolvedSize === "xl"}
   {...$$restProps}
 >
   {#if isOverflow}

--- a/tests/Tabs/Tabs.test.svelte
+++ b/tests/Tabs/Tabs.test.svelte
@@ -9,6 +9,7 @@
   export let type: ComponentProps<Tabs>["type"] = "default";
   export let autoWidth = false;
   export let fullWidth = false;
+  export let size: ComponentProps<Tabs>["size"] = undefined;
   export let customClass = "";
   export let ariaLabel = "";
 </script>
@@ -19,6 +20,7 @@
   {type}
   {autoWidth}
   {fullWidth}
+  {size}
   class={customClass}
   aria-label={ariaLabel === undefined ? undefined : ariaLabel}
   on:change={({ detail }) => {

--- a/tests/Tabs/Tabs.test.ts
+++ b/tests/Tabs/Tabs.test.ts
@@ -263,6 +263,47 @@ describe("Tabs", () => {
     expect(tabsContainer).toHaveClass("bx--tabs--container");
   });
 
+  it("should not apply a layout size class by default", () => {
+    render(Tabs);
+
+    const nav = screen.getByRole("navigation");
+    for (const size of ["sm", "md", "lg", "xl"]) {
+      expect(nav).not.toHaveClass(`bx--layout--size-${size}`);
+    }
+  });
+
+  it("should apply the layout size class for the size prop", () => {
+    render(Tabs, { props: { size: "sm" } });
+
+    const nav = screen.getByRole("navigation");
+    expect(nav).toHaveClass("bx--layout--size-sm");
+  });
+
+  it("should clamp an out-of-range size to the max for line tabs", () => {
+    render(Tabs, { props: { type: "default", size: "xl" } });
+
+    const nav = screen.getByRole("navigation");
+    expect(nav).toHaveClass("bx--layout--size-lg");
+    expect(nav).not.toHaveClass("bx--layout--size-xl");
+  });
+
+  it("should allow the full size range for container tabs", () => {
+    render(Tabs, { props: { type: "container", size: "xl" } });
+
+    const nav = screen.getByRole("navigation");
+    expect(nav).toHaveClass("bx--layout--size-xl");
+  });
+
+  it("should ignore an invalid size value", () => {
+    // @ts-expect-error - exercising the runtime fallback for an invalid value
+    render(Tabs, { props: { size: "invalid" } });
+
+    const nav = screen.getByRole("navigation");
+    for (const size of ["sm", "md", "lg", "xl"]) {
+      expect(nav).not.toHaveClass(`bx--layout--size-${size}`);
+    }
+  });
+
   it("should support auto width", () => {
     render(Tabs, {
       props: { autoWidth: true },


### PR DESCRIPTION
Line and container tabs get the same size scale as TabsVertical,
clamped per type (line sm-lg, container sm-xl). Unset by default so
existing unsized heights stay put.

---


<img width="479" height="160" alt="Screenshot 2026-09-05 at 7 22 48 AM" src="https://github.com/user-attachments/assets/33d0b542-7189-4e8f-a81f-e222b6cdca57" />
<img width="942" height="210" alt="Screenshot 2026-09-05 at 7 19 49 AM" src="https://github.com/user-attachments/assets/1da512f8-5842-410e-b1eb-5e62c4e4fa44" />

