### PR TITLE
feat(truncated-text): add TruncatedText component

### DIFF
--- a/css/_truncated-text.scss
+++ b/css/_truncated-text.scss
@@ -1,0 +1,46 @@
+@import "carbon-components/scss/globals/scss/vars";
+@import "carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/import-once/import-once";
+
+/// TruncatedText styles. Ported from Carbon React's own (not yet part of its
+/// public API — its export is commented out upstream) `packages/styles/scss/
+/// components/truncated-text`. Drops the `:focus-visible` upstream uses for
+/// the expand toggle's focus ring: like elsewhere in this library,
+/// `:focus-visible` exceeds this library's Safari 14 baseline (shipped in
+/// Safari 15.4), so every focus shows the ring here. No `__tooltip-trigger`
+/// styles are ported: the tooltip variant reuses this repo's own
+/// `TooltipDefinition`, which already resets its own trigger button.
+/// @access public
+/// @group truncated-text
+@mixin truncated-text {
+  .#{$prefix}--truncated-text__text-content {
+    display: -webkit-box;
+    overflow: hidden;
+    -webkit-box-orient: vertical;
+    // The tooltip variant nests this inside TooltipDefinition's <button>
+    // trigger; buttons default to a centered text-align, which is
+    // inherited here since text-align isn't otherwise set. Reset
+    // explicitly so multi-line content stays left-aligned regardless of
+    // which variant (tooltip, expand, or plain) wraps it.
+    text-align: start;
+    line-height: initial;
+    text-overflow: clip;
+  }
+
+  .#{$prefix}--truncated-text__expand-toggle {
+    padding: 0;
+    border: 0;
+    background: none;
+    color: $link-primary;
+    cursor: pointer;
+    font: inherit;
+  }
+
+  .#{$prefix}--truncated-text__expand-toggle:focus {
+    outline: 2px solid $focus;
+    outline-offset: 2px;
+  }
+}
+
+@include exports("truncated-text") {
+  @include truncated-text;
+}

--- a/css/all.scss
+++ b/css/all.scss
@@ -117,6 +117,7 @@ $css--plex: true;
 @import "./menu-button";
 @import "./fluid-text-area";
 @import "./truncate-multiline";
+@import "./truncated-text";
 @import "./badge-indicator";
 @import "./icon-indicator";
 @import "./shape-indicator";

--- a/css/g10.scss
+++ b/css/g10.scss
@@ -77,6 +77,7 @@ $css--plex: true;
 @import "./menu-button";
 @import "./fluid-text-area";
 @import "./truncate-multiline";
+@import "./truncated-text";
 @import "./badge-indicator";
 @import "./icon-indicator";
 @import "./shape-indicator";

--- a/css/g100.scss
+++ b/css/g100.scss
@@ -77,6 +77,7 @@ $css--plex: true;
 @import "./menu-button";
 @import "./fluid-text-area";
 @import "./truncate-multiline";
+@import "./truncated-text";
 @import "./badge-indicator";
 @import "./icon-indicator";
 @import "./shape-indicator";

--- a/css/g80.scss
+++ b/css/g80.scss
@@ -77,6 +77,7 @@ $css--plex: true;
 @import "./menu-button";
 @import "./fluid-text-area";
 @import "./truncate-multiline";
+@import "./truncated-text";
 @import "./badge-indicator";
 @import "./icon-indicator";
 @import "./shape-indicator";

--- a/css/g90.scss
+++ b/css/g90.scss
@@ -77,6 +77,7 @@ $css--plex: true;
 @import "./menu-button";
 @import "./fluid-text-area";
 @import "./truncate-multiline";
+@import "./truncated-text";
 @import "./badge-indicator";
 @import "./icon-indicator";
 @import "./shape-indicator";

--- a/css/white.scss
+++ b/css/white.scss
@@ -77,6 +77,7 @@ $css--plex: true;
 @import "./menu-button";
 @import "./fluid-text-area";
 @import "./truncate-multiline";
+@import "./truncated-text";
 @import "./badge-indicator";
 @import "./icon-indicator";
 @import "./shape-indicator";

--- a/docs/src/component-categories.ts
+++ b/docs/src/component-categories.ts
@@ -140,6 +140,7 @@ export const COMPONENT_CATEGORIES: ComponentCategory[] = [
       "SessionStorage",
       "ImageLoader",
       "Truncate",
+      "TruncatedText",
     ],
   },
   {

--- a/docs/src/component-since-versions.ts
+++ b/docs/src/component-since-versions.ts
@@ -88,6 +88,7 @@ export const COMPONENT_SINCE_VERSIONS: Record<string, string> = {
   TooltipIcon: "0.2.0",
   TreeView: "0.39.0",
   Truncate: "0.29.0",
+  TruncatedText: "0.112.0",
   UIShell: "0.3.0",
   UnorderedList: "0.2.0",
   UserAvatar: "0.110.0",

--- a/docs/src/pages/components/TruncatedText.svx
+++ b/docs/src/pages/components/TruncatedText.svx
@@ -1,0 +1,70 @@
+---
+components: ["TruncatedText"]
+description: Multi-line text that clamps to a maximum number of lines and offers a way to reveal the rest — a tooltip on hover, or an inline expand/collapse toggle — only when the text is actually truncated at the current width.
+---
+
+<script>
+  import { TruncatedText } from "carbon-components-svelte";
+</script>
+
+Unlike [Truncate](/components/Truncate), which just clamps text with CSS, `TruncatedText` measures the rendered content and only shows a reveal affordance (tooltip or expand toggle) when the text is actually overflowing at the current width — resize the examples below to see the affordance appear and disappear.
+
+## Basic
+
+By default (`type="tooltip"`), truncated text is wrapped in a tooltip trigger that reveals the full text on hover or focus.
+
+<div style="max-width: 20rem;">
+  <TruncatedText>
+    Carbon Components Svelte is a Svelte component library that implements the Carbon Design System, an open source design system by IBM.
+  </TruncatedText>
+</div>
+
+## Expand and collapse
+
+Set `type` to `"expand"` for a "Read more"/"Read less" toggle instead of a tooltip. Customize the labels with `expandLabel` and `collapseLabel`.
+
+<div style="max-width: 20rem;">
+  <TruncatedText type="expand" expandLabel="Read more" collapseLabel="Read less">
+    Carbon Components Svelte is a Svelte component library that implements the Carbon Design System, an open source design system by IBM.
+  </TruncatedText>
+</div>
+
+## Lines
+
+Set `lines` to control how many lines show before truncating. Defaults to `2`.
+
+<div style="max-width: 20rem;">
+  <TruncatedText lines={3} type="expand" expandLabel="Read more" collapseLabel="Read less">
+    Carbon Components Svelte is a Svelte component library that implements the Carbon Design System, an open source design system by IBM. It is maintained by the open source community and is available on npm.
+  </TruncatedText>
+</div>
+
+## No reveal
+
+Set `type` to `"none"` for plain ellipsis truncation with no tooltip or toggle.
+
+<div style="max-width: 20rem;">
+  <TruncatedText type="none">
+    Carbon Components Svelte is a Svelte component library that implements the Carbon Design System, an open source design system by IBM.
+  </TruncatedText>
+</div>
+
+## Tooltip placement
+
+Position the tooltip with `align` and `direction`, the same as [TooltipDefinition](/components/TooltipDefinition).
+
+<div style="max-width: 20rem;">
+  <TruncatedText direction="top" align="start">
+    Carbon Components Svelte is a Svelte component library that implements the Carbon Design System, an open source design system by IBM.
+  </TruncatedText>
+</div>
+
+## Not truncated
+
+When the content fits within `lines` at the current width, it renders as plain text with no reveal affordance, regardless of `type`.
+
+<div style="max-width: 20rem;">
+  <TruncatedText type="expand" expandLabel="Read more" collapseLabel="Read less">
+    Short text.
+  </TruncatedText>
+</div>

--- a/src/TruncatedText/TruncatedText.svelte
+++ b/src/TruncatedText/TruncatedText.svelte
@@ -1,0 +1,151 @@
+<script>
+  /**
+   * @restProps {div}
+   * @slot {{}}
+   */
+
+  /**
+   * Specify an id for the measured text content. Referenced by the expand
+   * toggle's `aria-controls` when `type` is `"expand"`.
+   * @type {string}
+   */
+  export let id = uniqueId();
+
+  /** Specify the maximum number of lines to display before truncating. */
+  export let lines = 2;
+
+  /**
+   * Specify how to reveal the full text once truncated. Set to `"none"` for
+   * plain ellipsis truncation with no reveal affordance.
+   * @type {"tooltip" | "expand" | "none"}
+   */
+  export let type = "tooltip";
+
+  /** Specify the expand toggle's label. Only used when `type` is `"expand"`. */
+  export let expandLabel = "Read more";
+
+  /** Specify the collapse toggle's label. Only used when `type` is `"expand"`. */
+  export let collapseLabel = "Read less";
+
+  /**
+   * Set the alignment of the tooltip relative to the content.
+   * Only applies when `type` is `"tooltip"`.
+   * @type {"start" | "center" | "end"}
+   */
+  export let align = "center";
+
+  /**
+   * Set the direction of the tooltip relative to the content.
+   * Only applies when `type` is `"tooltip"`.
+   * @type {"top" | "bottom"}
+   */
+  export let direction = "bottom";
+
+  /**
+   * Obtain a reference to the outer HTML element.
+   * @bindable readonly
+   */
+  export let ref = null;
+
+  import { onMount } from "svelte";
+  import TooltipDefinition from "../TooltipDefinition/TooltipDefinition.svelte";
+  import { uniqueId } from "../utils/uniqueId.js";
+
+  let contentRef = null;
+  let truncated = false;
+  let expanded = false;
+  let resolvedText = "";
+  let resizeObserver = null;
+
+  function checkTruncated() {
+    if (!contentRef || (type === "expand" && expanded)) return;
+    const isTruncated = contentRef.offsetHeight < contentRef.scrollHeight;
+    if (isTruncated !== truncated) truncated = isTruncated;
+  }
+
+  // Re-attach whenever the measured element changes identity, since the
+  // tooltip variant moves the content span in/out of a wrapping <button>
+  // (a different DOM subtree) as `truncated` toggles.
+  function attachObserver(el) {
+    resizeObserver?.disconnect();
+    if (!el) return;
+    resizeObserver = new ResizeObserver(checkTruncated);
+    resizeObserver.observe(el);
+  }
+
+  $: attachObserver(contentRef);
+
+  $: if (contentRef) {
+    resolvedText = contentRef.textContent ?? "";
+  }
+
+  // jsdom's ResizeObserver mock only fires once per `observe()` call, unlike
+  // a real one, which re-fires on the height change collapsing produces.
+  // Re-checking directly here keeps collapse-then-recheck correct under test
+  // without depending on that timing, and is harmless in a real browser
+  // since the observer already re-checks there too.
+  $: {
+    expanded;
+    lines;
+    if (!expanded) checkTruncated();
+  }
+
+  onMount(() => {
+    return () => resizeObserver?.disconnect();
+  });
+
+  function toggleExpand() {
+    expanded = !expanded;
+  }
+
+  $: clampValue = type === "expand" && expanded ? "none" : lines;
+</script>
+
+<div bind:this={ref} class:bx--truncated-text={true} {...$$restProps}>
+  {#if truncated && type === "tooltip"}
+    <!--
+      Force the portal: TooltipDefinition's default CSS-only positioning is
+      built for a compact, single-line trigger (a word or short phrase) and
+      uses fixed-percentage offsets that misplace the tooltip once the
+      trigger is a wide, multi-line block like a truncated paragraph. The
+      portal measures the real anchor rect via JS instead, so it stays
+      correct at any trigger size.
+    -->
+    <TooltipDefinition
+      tooltipText={resolvedText}
+      {align}
+      {direction}
+      portalTooltip
+    >
+      <span
+        bind:this={contentRef}
+        {id}
+        class:bx--truncated-text__text-content={true}
+        style:-webkit-line-clamp={clampValue}
+      >
+        <slot />
+      </span>
+    </TooltipDefinition>
+  {:else}
+    <span
+      bind:this={contentRef}
+      {id}
+      class:bx--truncated-text__text-content={true}
+      class:bx--truncated-text__text-content--expanded={expanded}
+      style:-webkit-line-clamp={clampValue}
+    >
+      <slot />
+    </span>
+  {/if}
+  {#if truncated && type === "expand"}
+    <button
+      type="button"
+      aria-controls={id}
+      aria-expanded={expanded}
+      class:bx--truncated-text__expand-toggle={true}
+      on:click={toggleExpand}
+    >
+      {expanded ? collapseLabel : expandLabel}
+    </button>
+  {/if}
+</div>

--- a/src/TruncatedText/index.js
+++ b/src/TruncatedText/index.js
@@ -1,0 +1,1 @@
+export { default as TruncatedText } from "./TruncatedText.svelte";

--- a/src/index.js
+++ b/src/index.js
@@ -204,6 +204,7 @@ export { default as TooltipIcon } from "./TooltipIcon/TooltipIcon.svelte";
 export { default as TreeView } from "./TreeView/TreeView.svelte";
 export { default as Truncate } from "./Truncate/Truncate.svelte";
 export { truncate } from "./Truncate/truncate";
+export { default as TruncatedText } from "./TruncatedText/TruncatedText.svelte";
 export { default as Content } from "./UIShell/Content.svelte";
 export { default as Header } from "./UIShell/Header.svelte";
 export { default as HeaderAction } from "./UIShell/HeaderAction.svelte";

--- a/tests/TruncatedText/TruncatedText.test.svelte
+++ b/tests/TruncatedText/TruncatedText.test.svelte
@@ -1,0 +1,26 @@
+<svelte:options accessors />
+
+<script lang="ts">
+  import TruncatedText from "carbon-components-svelte/TruncatedText/TruncatedText.svelte";
+  import type { ComponentProps } from "svelte";
+
+  export let id: ComponentProps<TruncatedText>["id"] = undefined;
+  export let lines: ComponentProps<TruncatedText>["lines"] = undefined;
+  export let type: ComponentProps<TruncatedText>["type"] = undefined;
+  export let expandLabel: ComponentProps<TruncatedText>["expandLabel"] =
+    undefined;
+  export let collapseLabel: ComponentProps<TruncatedText>["collapseLabel"] =
+    undefined;
+  export let text = "The quick brown fox jumps over the lazy dog.";
+</script>
+
+<TruncatedText
+  {id}
+  {lines}
+  {type}
+  {expandLabel}
+  {collapseLabel}
+  data-testid="truncated-text"
+>
+  {text}
+</TruncatedText>

--- a/tests/TruncatedText/TruncatedText.test.ts
+++ b/tests/TruncatedText/TruncatedText.test.ts
@@ -1,0 +1,229 @@
+import { render, screen, waitFor } from "@testing-library/svelte";
+import { user } from "../utils/user";
+import TruncatedText from "./TruncatedText.test.svelte";
+
+/**
+ * jsdom does no layout, so `offsetHeight`/`scrollHeight` both report 0 by
+ * default. Truncation detection compares the two, so both are stubbed on the
+ * prototype (global for the test, restored after) to simulate either a
+ * truncated (`scrollHeight` > `offsetHeight`) or non-truncated element.
+ */
+function stubHeights({
+  offsetHeight,
+  scrollHeight,
+}: {
+  offsetHeight: number;
+  scrollHeight: number;
+}) {
+  const offsetDescriptor = Object.getOwnPropertyDescriptor(
+    HTMLElement.prototype,
+    "offsetHeight",
+  );
+  const scrollDescriptor = Object.getOwnPropertyDescriptor(
+    Element.prototype,
+    "scrollHeight",
+  );
+
+  Object.defineProperty(HTMLElement.prototype, "offsetHeight", {
+    configurable: true,
+    get: () => offsetHeight,
+  });
+  Object.defineProperty(Element.prototype, "scrollHeight", {
+    configurable: true,
+    get: () => scrollHeight,
+  });
+
+  return () => {
+    if (offsetDescriptor) {
+      Object.defineProperty(
+        HTMLElement.prototype,
+        "offsetHeight",
+        offsetDescriptor,
+      );
+    }
+    if (scrollDescriptor) {
+      Object.defineProperty(
+        Element.prototype,
+        "scrollHeight",
+        scrollDescriptor,
+      );
+    }
+  };
+}
+
+describe("TruncatedText", () => {
+  it("renders the slot content", () => {
+    const restore = stubHeights({ offsetHeight: 100, scrollHeight: 100 });
+    render(TruncatedText, { text: "Hello world" });
+    restore();
+
+    expect(screen.getByText("Hello world")).toBeInTheDocument();
+  });
+
+  it("does not render a reveal affordance when the content is not truncated", async () => {
+    const restore = stubHeights({ offsetHeight: 100, scrollHeight: 100 });
+    render(TruncatedText);
+    await waitFor(() =>
+      expect(screen.queryByRole("button")).not.toBeInTheDocument(),
+    );
+    restore();
+  });
+
+  it("wraps the content in a tooltip trigger when truncated (default type)", async () => {
+    const restore = stubHeights({ offsetHeight: 40, scrollHeight: 100 });
+    render(TruncatedText, { text: "Full text shown in the tooltip" });
+    await waitFor(() => expect(screen.getByRole("button")).toBeInTheDocument());
+    restore();
+
+    // The tooltip is portalled (see the component's own comment on why),
+    // so its content only mounts once open — focus opens it without the
+    // hover-open delay.
+    const trigger = screen.getByRole("button");
+    trigger.focus();
+    const tooltipId = trigger.getAttribute("aria-describedby");
+    assert(tooltipId);
+    await waitFor(() =>
+      expect(document.getElementById(tooltipId)).toHaveTextContent(
+        "Full text shown in the tooltip",
+      ),
+    );
+  });
+
+  it("does not wrap the content in a tooltip when type is tooltip and not truncated", async () => {
+    const restore = stubHeights({ offsetHeight: 100, scrollHeight: 100 });
+    render(TruncatedText, { type: "tooltip" });
+    await waitFor(() =>
+      expect(screen.queryByRole("button")).not.toBeInTheDocument(),
+    );
+    restore();
+  });
+
+  it('never renders a reveal affordance when type is "none", even when truncated', async () => {
+    const restore = stubHeights({ offsetHeight: 40, scrollHeight: 100 });
+    render(TruncatedText, { type: "none" });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    restore();
+
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  it("renders an expand toggle when truncated and type is expand", async () => {
+    const restore = stubHeights({ offsetHeight: 40, scrollHeight: 100 });
+    render(TruncatedText, {
+      type: "expand",
+      expandLabel: "Read more",
+      collapseLabel: "Read less",
+    });
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: "Read more" }),
+      ).toBeInTheDocument(),
+    );
+    restore();
+
+    expect(screen.getByRole("button", { name: "Read more" })).toHaveAttribute(
+      "aria-expanded",
+      "false",
+    );
+  });
+
+  it("expands and collapses on click", async () => {
+    const restore = stubHeights({ offsetHeight: 40, scrollHeight: 100 });
+    render(TruncatedText, {
+      type: "expand",
+      expandLabel: "Read more",
+      collapseLabel: "Read less",
+    });
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: "Read more" }),
+      ).toBeInTheDocument(),
+    );
+
+    await user.click(screen.getByRole("button", { name: "Read more" }));
+    const collapseButton = screen.getByRole("button", { name: "Read less" });
+    expect(collapseButton).toHaveAttribute("aria-expanded", "true");
+
+    await user.click(collapseButton);
+    restore();
+    expect(screen.getByRole("button", { name: "Read more" })).toHaveAttribute(
+      "aria-expanded",
+      "false",
+    );
+  });
+
+  it("expands on keyboard activation", async () => {
+    const restore = stubHeights({ offsetHeight: 40, scrollHeight: 100 });
+    render(TruncatedText, {
+      type: "expand",
+      expandLabel: "Read more",
+      collapseLabel: "Read less",
+    });
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: "Read more" }),
+      ).toBeInTheDocument(),
+    );
+    restore();
+
+    screen.getByRole("button", { name: "Read more" }).focus();
+    await user.keyboard("{Enter}");
+
+    expect(screen.getByRole("button", { name: "Read less" })).toHaveAttribute(
+      "aria-expanded",
+      "true",
+    );
+  });
+
+  it("links the expand toggle to the content via aria-controls", async () => {
+    const restore = stubHeights({ offsetHeight: 40, scrollHeight: 100 });
+    render(TruncatedText, {
+      id: "my-truncated-text",
+      type: "expand",
+      expandLabel: "Read more",
+    });
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: "Read more" }),
+      ).toBeInTheDocument(),
+    );
+    restore();
+
+    expect(screen.getByRole("button", { name: "Read more" })).toHaveAttribute(
+      "aria-controls",
+      "my-truncated-text",
+    );
+  });
+
+  it("applies -webkit-line-clamp based on the lines prop", () => {
+    const restore = stubHeights({ offsetHeight: 40, scrollHeight: 100 });
+    const { container } = render(TruncatedText, { lines: 4 });
+    restore();
+
+    const content = container.querySelector(
+      ".bx--truncated-text__text-content",
+    ) as HTMLElement;
+    expect(content.style.webkitLineClamp).toBe("4");
+  });
+
+  it("removes the line clamp while expanded", async () => {
+    const restore = stubHeights({ offsetHeight: 40, scrollHeight: 100 });
+    const { container } = render(TruncatedText, {
+      type: "expand",
+      expandLabel: "Read more",
+    });
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: "Read more" }),
+      ).toBeInTheDocument(),
+    );
+    restore();
+
+    await user.click(screen.getByRole("button", { name: "Read more" }));
+
+    const content = container.querySelector(
+      ".bx--truncated-text__text-content",
+    ) as HTMLElement;
+    expect(content.style.webkitLineClamp).toBe("none");
+  });
+});


### PR DESCRIPTION
Clamps slot content to N lines and, only when actually truncated,
reveals the rest via a portalled TooltipDefinition or an
expand/collapse toggle.
