### PR TITLE
feat(side-panel): add SidePanel component

### DIFF
--- a/css/_side-panel.scss
+++ b/css/_side-panel.scss
@@ -1,0 +1,240 @@
+@import "carbon-components/scss/globals/scss/vars";
+@import "carbon-components/scss/globals/scss/helper-mixins";
+@import "carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/import-once/import-once";
+@import "carbon-components/scss/globals/scss/typography";
+@import "carbon-components/scss/globals/scss/motion";
+
+// Matches carbon-components' own $z-indexes map (globals/scss/_layout.scss),
+// not re-imported here since no other partial in this package pulls it in.
+$side-panel-z-index: 9000;
+$side-panel-overlay-z-index: 6000;
+
+$side-panel-sizes: (
+  xs: 16rem,
+  sm: 20rem,
+  md: 30rem,
+  lg: 40rem,
+  xl: 65rem,
+  2xl: 80rem,
+);
+
+/// SidePanel styles. Ported from Carbon React's own (not yet wired into its
+/// bundle) `packages/styles/scss/components/side-panel`, mapped from v11
+/// tokens to this repo's v10 equivalents, with the entrance/exit animation
+/// dropped entirely: `SidePanel.svelte` uses a Svelte `transition:`
+/// (fly/fade) instead of upstream's `@starting-style`/`animation`/
+/// `@property` CSS, which also removes the need to track an
+/// `--is-closing`-style class. The scroll-driven title-collapse system
+/// (`--scroll-animation-progress`, the collapsed title, the divider fade)
+/// is out of scope for this port and is not implemented, so its styles are
+/// dropped too. Every upstream `:has()` selector is replaced: the two
+/// resizer grid-column reservations become an explicit
+/// `--resizable`-gated grid (justified because `SidePanel.svelte` only
+/// ever applies `--resizable` when the `Resizer` child actually renders,
+/// so no introspection is needed), and the header's
+/// back-button/toolbar-presence selectors become the `--on-detail-step`/
+/// marker classes the component already computes in JS.
+/// @access public
+/// @group side-panel
+@mixin side-panel {
+  .#{$prefix}--side-panel {
+    position: fixed;
+    z-index: $side-panel-z-index;
+    display: grid;
+    box-sizing: border-box;
+    grid-template-rows: auto 1fr auto;
+    grid-template-columns: 1fr;
+    background-color: $ui-01;
+    block-size: calc(100% - #{$carbon--spacing-09});
+    color: $text-primary;
+    inset-block-start: $carbon--spacing-09;
+    max-inline-size: 100%;
+    min-inline-size: map-get($side-panel-sizes, xs);
+  }
+
+  @media (min-width: 672px) {
+    .#{$prefix}--side-panel {
+      max-inline-size: 75vw;
+    }
+  }
+
+  @each $size, $size-value in $side-panel-sizes {
+    .#{$prefix}--side-panel--#{$size} {
+      inline-size: $size-value;
+    }
+  }
+
+  .#{$prefix}--side-panel--right-placement {
+    border-inline-start: 1px solid $ui-03;
+    inset-inline-end: 0;
+  }
+
+  .#{$prefix}--side-panel--left-placement {
+    border-inline-end: 1px solid $ui-03;
+    inset-inline-start: 0;
+  }
+
+  .#{$prefix}--side-panel:not(.#{$prefix}--side-panel--has-overlay) {
+    box-shadow: 0 $carbon--spacing-01 $carbon--spacing-02 $overlay;
+  }
+
+  .#{$prefix}--side-panel--slide-in {
+    box-shadow: none;
+  }
+
+  .#{$prefix}--side-panel--has-decorator {
+    border: 1px solid $interactive-01;
+  }
+
+  // Reserve a column for the resizer handle, only applied when the
+  // `Resizer` child is actually rendered (see the mixin doc comment).
+  .#{$prefix}--side-panel--resizable.#{$prefix}--side-panel--right-placement {
+    grid-template-columns: auto 1fr;
+  }
+
+  .#{$prefix}--side-panel--resizable.#{$prefix}--side-panel--left-placement {
+    grid-template-columns: 1fr auto;
+  }
+
+  .#{$prefix}--side-panel--resizable.#{$prefix}--side-panel--right-placement
+    .#{$prefix}--side-panel__resizer {
+    grid-column: 1;
+    grid-row: 1 / -1;
+  }
+
+  .#{$prefix}--side-panel--resizable.#{$prefix}--side-panel--left-placement
+    .#{$prefix}--side-panel__resizer {
+    grid-column: 2;
+    grid-row: 1 / -1;
+  }
+
+  .#{$prefix}--side-panel--resizable.#{$prefix}--side-panel--right-placement
+    .#{$prefix}--side-panel__header,
+  .#{$prefix}--side-panel--resizable.#{$prefix}--side-panel--right-placement
+    .#{$prefix}--side-panel__inner-content,
+  .#{$prefix}--side-panel--resizable.#{$prefix}--side-panel--right-placement
+    .#{$prefix}--side-panel__actions-container {
+    grid-column: 2;
+  }
+
+  .#{$prefix}--side-panel--resizable.#{$prefix}--side-panel--left-placement
+    .#{$prefix}--side-panel__header,
+  .#{$prefix}--side-panel--resizable.#{$prefix}--side-panel--left-placement
+    .#{$prefix}--side-panel__inner-content,
+  .#{$prefix}--side-panel--resizable.#{$prefix}--side-panel--left-placement
+    .#{$prefix}--side-panel__actions-container {
+    grid-column: 1;
+  }
+
+  // ─── Header ────────────────────────────────────────────────────────────
+
+  .#{$prefix}--side-panel__header {
+    position: relative;
+    z-index: 1;
+    display: flex;
+    flex-direction: column;
+    gap: $carbon--spacing-03;
+    padding: $carbon--spacing-05;
+    border-block-end: 1px solid $ui-03;
+    background-color: $ui-01;
+  }
+
+  .#{$prefix}--side-panel__header--on-detail-step {
+    padding-block-start: $carbon--spacing-07;
+  }
+
+  .#{$prefix}--side-panel__label-text,
+  .#{$prefix}--side-panel__title-text,
+  .#{$prefix}--side-panel__subtitle-text {
+    padding-inline-end: $carbon--spacing-08;
+  }
+
+  .#{$prefix}--side-panel__label-text {
+    @include type-style("label-01");
+
+    color: $text-secondary;
+  }
+
+  .#{$prefix}--side-panel__title-text {
+    @include type-style("productive-heading-03");
+  }
+
+  .#{$prefix}--side-panel__subtitle-text {
+    @include type-style("body-short-01");
+
+    color: $text-secondary;
+  }
+
+  .#{$prefix}--side-panel__decorator-and-close {
+    position: absolute;
+    z-index: 1;
+    display: flex;
+    align-items: center;
+    gap: $carbon--spacing-02;
+    inset-block-start: $carbon--spacing-05;
+    inset-inline-end: $carbon--spacing-05;
+  }
+
+  .#{$prefix}--btn.#{$prefix}--side-panel__navigation-back-button,
+  .#{$prefix}--btn.#{$prefix}--side-panel__close-button {
+    &:hover {
+      background-color: $background-hover;
+    }
+  }
+
+  .#{$prefix}--side-panel__action-toolbar {
+    display: flex;
+    align-items: center;
+    gap: $carbon--spacing-03;
+  }
+
+  // ─── Body ──────────────────────────────────────────────────────────────
+
+  .#{$prefix}--side-panel__inner-content {
+    overflow: auto;
+    padding: $carbon--spacing-05;
+  }
+
+  // Form fields nested in the panel should pick up the elevated field
+  // background, matching how they render inside a Modal.
+  .#{$prefix}--side-panel .#{$prefix}--text-input,
+  .#{$prefix}--side-panel .#{$prefix}--text-area,
+  .#{$prefix}--side-panel .#{$prefix}--search-input,
+  .#{$prefix}--side-panel .#{$prefix}--select-input,
+  .#{$prefix}--side-panel .#{$prefix}--multi-select,
+  .#{$prefix}--side-panel .#{$prefix}--dropdown,
+  .#{$prefix}--side-panel .#{$prefix}--dropdown-list,
+  .#{$prefix}--side-panel .#{$prefix}--number input[type="number"],
+  .#{$prefix}--side-panel .#{$prefix}--date-picker__input {
+    background-color: $field-02;
+  }
+
+  // ─── Actions ───────────────────────────────────────────────────────────
+
+  .#{$prefix}--side-panel__actions-container {
+    position: sticky;
+    inset-block-end: 0;
+    padding: $carbon--spacing-05;
+    border-block-start: 1px solid $ui-03;
+    background-color: $ui-01;
+    min-block-size: $carbon--spacing-10;
+  }
+
+  .#{$prefix}--side-panel__actions-container--condensed {
+    padding: $carbon--spacing-03 $carbon--spacing-05;
+    min-block-size: $carbon--spacing-09;
+  }
+
+  // ─── Overlay ───────────────────────────────────────────────────────────
+
+  .#{$prefix}--side-panel__overlay {
+    position: fixed;
+    z-index: $side-panel-overlay-z-index;
+    inset: 0;
+    background-color: $overlay;
+  }
+}
+
+@include exports("side-panel") {
+  @include side-panel;
+}

--- a/css/all.scss
+++ b/css/all.scss
@@ -133,3 +133,4 @@ $css--plex: true;
 @import "./structured-list-sort";
 @import "./action-set";
 @import "./resizer";
+@import "./side-panel";

--- a/css/g10.scss
+++ b/css/g10.scss
@@ -93,3 +93,4 @@ $css--plex: true;
 @import "./structured-list-sort";
 @import "./action-set";
 @import "./resizer";
+@import "./side-panel";

--- a/css/g100.scss
+++ b/css/g100.scss
@@ -93,3 +93,4 @@ $css--plex: true;
 @import "./structured-list-sort";
 @import "./action-set";
 @import "./resizer";
+@import "./side-panel";

--- a/css/g80.scss
+++ b/css/g80.scss
@@ -93,3 +93,4 @@ $css--plex: true;
 @import "./structured-list-sort";
 @import "./action-set";
 @import "./resizer";
+@import "./side-panel";

--- a/css/g90.scss
+++ b/css/g90.scss
@@ -93,3 +93,4 @@ $css--plex: true;
 @import "./structured-list-sort";
 @import "./action-set";
 @import "./resizer";
+@import "./side-panel";

--- a/css/white.scss
+++ b/css/white.scss
@@ -93,3 +93,4 @@ $css--plex: true;
 @import "./structured-list-sort";
 @import "./action-set";
 @import "./resizer";
+@import "./side-panel";

--- a/docs/src/component-categories.ts
+++ b/docs/src/component-categories.ts
@@ -89,6 +89,7 @@ export const COMPONENT_CATEGORIES: ComponentCategory[] = [
       "Modal",
       "ComposedModal",
       "Popover",
+      "SidePanel",
       "Toggletip",
       "Tooltip",
       "TooltipDefinition",

--- a/docs/src/component-since-versions.ts
+++ b/docs/src/component-since-versions.ts
@@ -64,6 +64,7 @@ export const COMPONENT_SINCE_VERSIONS: Record<string, string> = {
   SelectableTile: "0.2.0",
   SessionStorage: "0.102.0",
   ShapeIndicator: "0.110.0",
+  SidePanel: "0.112.0",
   SkeletonIcon: "0.104.0",
   SkeletonPlaceholder: "0.2.0",
   SkeletonText: "0.2.0",

--- a/docs/src/pages/components/SidePanel.svx
+++ b/docs/src/pages/components/SidePanel.svx
@@ -1,0 +1,70 @@
+---
+components: ["SidePanel"]
+description: A docked panel that slides in from the left or right edge of the screen for supplementary content, forms, or multi-step flows.
+---
+
+SidePanel pairs well with the [UI Shell](/components/UIShell#sidepanel) for inspecting or editing a record without navigating away from the page underneath the header. The examples below wrap each panel in a minimal header for that context.
+
+## Focus behavior
+
+When the panel opens, focus is set using the following priority:
+
+1. The element matching `selectorPrimaryFocus`
+2. The first input, textarea, or select
+3. The close button
+
+After closing the panel, focus is returned to the element that triggered it.
+
+## Basic
+
+Set `bind:open` to control visibility. Use the `actions` slot for footer buttons, typically an [ActionSet](/components/ActionSet).
+
+<FileSource src="/framed/SidePanel/SidePanelBasic" />
+
+## Placement
+
+Set `placement` to `"left"` or `"right"` (default) to control which screen edge the panel docks to.
+
+<FileSource src="/framed/SidePanel/SidePanelPlacement" />
+
+## Sizes
+
+Set `size` to `"xs"`, `"sm"`, `"lg"`, `"xl"`, or `"2xl"`. The default is `"md"`.
+
+<FileSource src="/framed/SidePanel/SidePanelSizes" />
+
+## Slide-in
+
+Set `slideIn` to `true` and `selectorPageContent` to a CSS selector for the page's main content element. Instead of overlaying the page, the panel shrinks that element to make room for itself. Escape-to-close and `resizable` are disabled in this mode.
+
+<FileSource src="/framed/SidePanel/SidePanelSlideIn" />
+
+## Resizable
+
+Set `resizable` to `true` to let the panel be resized by dragging its edge, using arrow keys, or double-clicking the handle to reset. Has no effect when `slideIn` is `true`, or on narrow (768px and under) viewports.
+
+<FileSource src="/framed/SidePanel/SidePanelResizable" />
+
+## Multi-step
+
+Set `currentStep` to a value greater than `0` to show a back button in the header. Listen for `on:back` to navigate to the previous step.
+
+<FileSource src="/framed/SidePanel/SidePanelMultiStep" />
+
+## Decorator
+
+Use the `decorator` slot for supplementary content, typically an AI-label badge, rendered top-right of the header.
+
+<FileSource src="/framed/SidePanel/SidePanelDecorator" />
+
+## Toolbar
+
+Use the `toolbar` slot for secondary header-row actions, typically icon-only buttons.
+
+<FileSource src="/framed/SidePanel/SidePanelToolbar" />
+
+## Transition
+
+The panel does not animate by default. Set `transition` to a [fly](https://svelte.dev/docs/svelte/svelte-transition#fly) params object (e.g. `{ duration: 240 }`) to enable the slide-in/out transition.
+
+<FileSource src="/framed/SidePanel/SidePanelTransition" />

--- a/docs/src/pages/components/UIShell.svx
+++ b/docs/src/pages/components/UIShell.svx
@@ -369,6 +369,12 @@ Integrate toasts with the UI Shell. This example triggers a toast, which appears
 
 <FileSource src="/framed/UIShell/HeaderWithToast" />
 
+### SidePanel
+
+[SidePanel](/components/SidePanel) pairs well with the UI Shell for inspecting or editing a record without navigating away from the page underneath the header.
+
+<FileSource src="/framed/UIShell/HeaderWithSidePanel" />
+
 ## Classic theme
 
 Before version 0.105.0, the UI Shell defaulted to a mixed theme: **Gray 100** header and **White** side navigation. Now it follows the active theme (`white`, `g10`, `g80`, `g90`, `g100`).

--- a/docs/src/pages/framed/SidePanel/SidePanelBasic.svelte
+++ b/docs/src/pages/framed/SidePanel/SidePanelBasic.svelte
@@ -1,0 +1,45 @@
+<script>
+  import {
+    ActionSet,
+    Button,
+    Column,
+    Content,
+    Grid,
+    Header,
+    Row,
+    SidePanel,
+    SkipToContent,
+  } from "carbon-components-svelte";
+
+  let open = false;
+</script>
+
+<Header companyName="IBM" platformName="Cloud">
+  <svelte:fragment slot="skipToContent"> <SkipToContent /> </svelte:fragment>
+</Header>
+
+<SidePanel
+  bind:open
+  title="Panel title"
+  subtitle="Optional subtitle describing the panel's purpose."
+  includeOverlay
+>
+  <p>Panel body content goes here.</p>
+
+  <svelte:fragment slot="actions">
+    <ActionSet>
+      <Button kind="secondary" on:click={() => (open = false)}>Cancel</Button>
+      <Button on:click={() => (open = false)}>Save</Button>
+    </ActionSet>
+  </svelte:fragment>
+</SidePanel>
+
+<Content>
+  <Grid>
+    <Row>
+      <Column>
+        <Button on:click={() => (open = true)}>Open panel</Button>
+      </Column>
+    </Row>
+  </Grid>
+</Content>

--- a/docs/src/pages/framed/SidePanel/SidePanelDecorator.svelte
+++ b/docs/src/pages/framed/SidePanel/SidePanelDecorator.svelte
@@ -1,0 +1,36 @@
+<script>
+  import {
+    Button,
+    Column,
+    Content,
+    Grid,
+    Header,
+    Row,
+    SidePanel,
+    SkipToContent,
+    Tag,
+  } from "carbon-components-svelte";
+
+  let open = false;
+</script>
+
+<Header companyName="IBM" platformName="Cloud">
+  <svelte:fragment slot="skipToContent"> <SkipToContent /> </svelte:fragment>
+</Header>
+
+<SidePanel bind:open title="Smart summary" includeOverlay>
+  <svelte:fragment slot="decorator">
+    <Tag type="purple" size="sm">AI</Tag>
+  </svelte:fragment>
+  <p>Generated automatically from your latest activity.</p>
+</SidePanel>
+
+<Content>
+  <Grid>
+    <Row>
+      <Column>
+        <Button on:click={() => (open = true)}>Open panel</Button>
+      </Column>
+    </Row>
+  </Grid>
+</Content>

--- a/docs/src/pages/framed/SidePanel/SidePanelMultiStep.svelte
+++ b/docs/src/pages/framed/SidePanel/SidePanelMultiStep.svelte
@@ -1,0 +1,69 @@
+<script>
+  import {
+    ActionSet,
+    Button,
+    Column,
+    Content,
+    Grid,
+    Header,
+    Row,
+    SidePanel,
+    SkipToContent,
+  } from "carbon-components-svelte";
+
+  let open = false;
+  let currentStep = 0;
+
+  const steps = [
+    {
+      title: "Select a template",
+      body: "Choose a starting point for your project.",
+    },
+    {
+      title: "Configure options",
+      body: "Fine-tune the template to fit your needs.",
+    },
+  ];
+</script>
+
+<Header companyName="IBM" platformName="Cloud">
+  <svelte:fragment slot="skipToContent"> <SkipToContent /> </svelte:fragment>
+</Header>
+
+<SidePanel
+  bind:open
+  {currentStep}
+  title={steps[currentStep].title}
+  includeOverlay
+  on:back={() => (currentStep = 0)}
+>
+  <p>{steps[currentStep].body}</p>
+
+  <svelte:fragment slot="actions">
+    <ActionSet>
+      <Button kind="secondary" on:click={() => (open = false)}>Cancel</Button>
+      {#if currentStep === 0}
+        <Button on:click={() => (currentStep = 1)}>Next</Button>
+      {:else}
+        <Button on:click={() => (open = false)}>Finish</Button>
+      {/if}
+    </ActionSet>
+  </svelte:fragment>
+</SidePanel>
+
+<Content>
+  <Grid>
+    <Row>
+      <Column>
+        <Button
+          on:click={() => {
+            currentStep = 0;
+            open = true;
+          }}
+        >
+          Open panel
+        </Button>
+      </Column>
+    </Row>
+  </Grid>
+</Content>

--- a/docs/src/pages/framed/SidePanel/SidePanelPlacement.svelte
+++ b/docs/src/pages/framed/SidePanel/SidePanelPlacement.svelte
@@ -1,0 +1,32 @@
+<script>
+  import {
+    Button,
+    Column,
+    Content,
+    Grid,
+    Header,
+    Row,
+    SidePanel,
+    SkipToContent,
+  } from "carbon-components-svelte";
+
+  let open = false;
+</script>
+
+<Header companyName="IBM" platformName="Cloud">
+  <svelte:fragment slot="skipToContent"> <SkipToContent /> </svelte:fragment>
+</Header>
+
+<SidePanel bind:open placement="left" title="Panel title" includeOverlay>
+  <p>Docked to the left edge of the screen.</p>
+</SidePanel>
+
+<Content>
+  <Grid>
+    <Row>
+      <Column>
+        <Button on:click={() => (open = true)}>Open panel</Button>
+      </Column>
+    </Row>
+  </Grid>
+</Content>

--- a/docs/src/pages/framed/SidePanel/SidePanelResizable.svelte
+++ b/docs/src/pages/framed/SidePanel/SidePanelResizable.svelte
@@ -1,0 +1,35 @@
+<script>
+  import {
+    Button,
+    Column,
+    Content,
+    Grid,
+    Header,
+    Row,
+    SidePanel,
+    SkipToContent,
+  } from "carbon-components-svelte";
+
+  let open = false;
+</script>
+
+<Header companyName="IBM" platformName="Cloud">
+  <svelte:fragment slot="skipToContent"> <SkipToContent /> </svelte:fragment>
+</Header>
+
+<SidePanel bind:open resizable title="Panel title" includeOverlay>
+  <p>
+    Drag the handle on the panel's inner edge to resize it, or double-click the
+    handle to reset.
+  </p>
+</SidePanel>
+
+<Content>
+  <Grid>
+    <Row>
+      <Column>
+        <Button on:click={() => (open = true)}>Open panel</Button>
+      </Column>
+    </Row>
+  </Grid>
+</Content>

--- a/docs/src/pages/framed/SidePanel/SidePanelSizes.svelte
+++ b/docs/src/pages/framed/SidePanel/SidePanelSizes.svelte
@@ -1,0 +1,43 @@
+<script>
+  import {
+    Button,
+    Column,
+    Content,
+    Grid,
+    Header,
+    Row,
+    SidePanel,
+    SkipToContent,
+  } from "carbon-components-svelte";
+
+  const sizes = ["xs", "sm", "md", "lg", "xl", "2xl"];
+  let open = false;
+  let size = "md";
+
+  function openWithSize(value) {
+    size = value;
+    open = true;
+  }
+</script>
+
+<Header companyName="IBM" platformName="Cloud">
+  <svelte:fragment slot="skipToContent"> <SkipToContent /> </svelte:fragment>
+</Header>
+
+<SidePanel bind:open {size} title="Panel title" includeOverlay>
+  <p>Size: <strong>{size}</strong></p>
+</SidePanel>
+
+<Content>
+  <Grid>
+    <Row>
+      <Column>
+        {#each sizes as value}
+          <Button kind="secondary" on:click={() => openWithSize(value)}>
+            {value}
+          </Button>
+        {/each}
+      </Column>
+    </Row>
+  </Grid>
+</Content>

--- a/docs/src/pages/framed/SidePanel/SidePanelSlideIn.svelte
+++ b/docs/src/pages/framed/SidePanel/SidePanelSlideIn.svelte
@@ -1,0 +1,41 @@
+<script>
+  import {
+    Button,
+    Column,
+    Content,
+    Grid,
+    Header,
+    Row,
+    SidePanel,
+    SkipToContent,
+  } from "carbon-components-svelte";
+
+  let open = false;
+</script>
+
+<Header companyName="IBM" platformName="Cloud">
+  <svelte:fragment slot="skipToContent"> <SkipToContent /> </svelte:fragment>
+</Header>
+
+<SidePanel
+  bind:open
+  slideIn
+  selectorPageContent="#side-panel-slide-in-content"
+  title="Panel title"
+>
+  <p>Panel body content goes here.</p>
+</SidePanel>
+
+<Content id="side-panel-slide-in-content">
+  <Grid>
+    <Row>
+      <Column>
+        <Button on:click={() => (open = true)}>Open panel</Button>
+        <p>
+          This content shrinks to make room for the panel instead of being
+          covered by it.
+        </p>
+      </Column>
+    </Row>
+  </Grid>
+</Content>

--- a/docs/src/pages/framed/SidePanel/SidePanelToolbar.svelte
+++ b/docs/src/pages/framed/SidePanel/SidePanelToolbar.svelte
@@ -1,0 +1,50 @@
+<script>
+  import {
+    Button,
+    Column,
+    Content,
+    Grid,
+    Header,
+    Row,
+    SidePanel,
+    SkipToContent,
+  } from "carbon-components-svelte";
+  import Filter from "carbon-icons-svelte/lib/Filter.svelte";
+  import Settings from "carbon-icons-svelte/lib/Settings.svelte";
+
+  let open = false;
+</script>
+
+<Header companyName="IBM" platformName="Cloud">
+  <svelte:fragment slot="skipToContent"> <SkipToContent /> </svelte:fragment>
+</Header>
+
+<SidePanel bind:open title="Panel title" includeOverlay>
+  <svelte:fragment slot="toolbar">
+    <Button
+      kind="ghost"
+      size="small"
+      icon={Filter}
+      iconDescription="Filter"
+      tooltipPosition="bottom"
+    />
+    <Button
+      kind="ghost"
+      size="small"
+      icon={Settings}
+      iconDescription="Settings"
+      tooltipPosition="bottom"
+    />
+  </svelte:fragment>
+  <p>Panel body content goes here.</p>
+</SidePanel>
+
+<Content>
+  <Grid>
+    <Row>
+      <Column>
+        <Button on:click={() => (open = true)}>Open panel</Button>
+      </Column>
+    </Row>
+  </Grid>
+</Content>

--- a/docs/src/pages/framed/SidePanel/SidePanelTransition.svelte
+++ b/docs/src/pages/framed/SidePanel/SidePanelTransition.svelte
@@ -1,0 +1,37 @@
+<script>
+  import {
+    Button,
+    Column,
+    Content,
+    Grid,
+    Header,
+    Row,
+    SidePanel,
+    SkipToContent,
+  } from "carbon-components-svelte";
+
+  let open = false;
+</script>
+
+<Header companyName="IBM" platformName="Cloud">
+  <svelte:fragment slot="skipToContent"> <SkipToContent /> </svelte:fragment>
+</Header>
+
+<SidePanel
+  bind:open
+  title="Panel title"
+  includeOverlay
+  transition={{ duration: 240 }}
+>
+  <p>This panel slides in and out. Close it to see the exit transition.</p>
+</SidePanel>
+
+<Content>
+  <Grid>
+    <Row>
+      <Column>
+        <Button on:click={() => (open = true)}>Open panel</Button>
+      </Column>
+    </Row>
+  </Grid>
+</Content>

--- a/docs/src/pages/framed/UIShell/HeaderWithSidePanel.svelte
+++ b/docs/src/pages/framed/UIShell/HeaderWithSidePanel.svelte
@@ -1,0 +1,58 @@
+<script>
+  import {
+    ActionSet,
+    Button,
+    Column,
+    Content,
+    Grid,
+    Header,
+    HeaderNav,
+    HeaderNavItem,
+    Row,
+    SidePanel,
+    SkipToContent,
+    Stack,
+  } from "carbon-components-svelte";
+
+  let open = false;
+</script>
+
+<Header companyName="IBM" platformName="Cloud">
+  <svelte:fragment slot="skipToContent"> <SkipToContent /> </svelte:fragment>
+  <HeaderNav>
+    <HeaderNavItem href="/catalog" text="Catalog" />
+    <HeaderNavItem href="/docs" text="Docs" />
+  </HeaderNav>
+</Header>
+
+<SidePanel
+  bind:open
+  title="Cluster details"
+  subtitle="mycluster-prod"
+  includeOverlay
+>
+  <p>
+    Docked alongside the header, a side panel works well for inspecting or
+    editing a record without navigating away from the page underneath.
+  </p>
+
+  <svelte:fragment slot="actions">
+    <ActionSet>
+      <Button kind="secondary" on:click={() => (open = false)}>Cancel</Button>
+      <Button on:click={() => (open = false)}>Save</Button>
+    </ActionSet>
+  </svelte:fragment>
+</SidePanel>
+
+<Content>
+  <Grid>
+    <Row>
+      <Column>
+        <Stack gap={6}>
+          <h1>Clusters</h1>
+          <Button on:click={() => (open = true)}>View details</Button>
+        </Stack>
+      </Column>
+    </Row>
+  </Grid>
+</Content>

--- a/src/SidePanel/SidePanel.svelte
+++ b/src/SidePanel/SidePanel.svelte
@@ -1,0 +1,417 @@
+<script>
+  /**
+   * @restProps {div}
+   * @slot {{}}
+   * @slot {{}} actions - Footer actions, typically an ActionSet.
+   * @slot {{}} toolbar - Secondary header-row actions, real Button children.
+   * @slot {{}} decorator - Typically an AI-label badge, rendered top-right of the header.
+   * @event {{ trigger: "close-button" | "escape-key" | "overlay-click" | "programmatic" }} close - Fires on a request to close (close button, Escape, overlay click). Call `event.preventDefault()` to stop `open` from being set to `false`.
+   * @event {null} back - Fires when the back button (shown when `currentStep` is greater than 0) is clicked.
+   */
+
+  /**
+   * Whether the panel is open.
+   * @bindable writable
+   */
+  export let open = false;
+
+  /**
+   * Specify a custom id.
+   * @type {string}
+   */
+  export let id = uniqueId();
+
+  /**
+   * Specify the title text.
+   * @type {string}
+   */
+  export let title = undefined;
+
+  /**
+   * Specify the subtitle text.
+   * @type {string}
+   */
+  export let subtitle = undefined;
+
+  /**
+   * Specify a small label shown above the title. Only takes effect when
+   * `title` is also set.
+   * @type {string}
+   */
+  export let labelText = undefined;
+
+  /**
+   * Which screen edge the panel is docked to.
+   * @type {"left" | "right"}
+   */
+  export let placement = "right";
+
+  /**
+   * Specify the panel width.
+   * @type {"xs" | "sm" | "md" | "lg" | "xl" | "2xl"}
+   */
+  export let size = "md";
+
+  /**
+   * Set to `true` for the slide-in variant, which shrinks
+   * `selectorPageContent` instead of overlaying it. Disables Escape-to-close
+   * and `resizable`.
+   */
+  export let slideIn = false;
+
+  /**
+   * CSS selector for the page content element to shrink. Required when
+   * `slideIn` is `true`.
+   * @type {string}
+   */
+  export let selectorPageContent = undefined;
+
+  /**
+   * Set to `true` to render a dim overlay behind the panel. Clicking it
+   * closes the panel unless `preventCloseOnClickOutside` is set.
+   */
+  export let includeOverlay = false;
+
+  /** Set to `true` to prevent the overlay click from closing the panel. */
+  export let preventCloseOnClickOutside = false;
+
+  /** Set to `true` to hide the close button. */
+  export let hideCloseButton = false;
+
+  /** Specify the close button's accessible label. */
+  export let closeIconDescription = "Close";
+
+  /**
+   * Set to `true` to let the panel be resized by dragging its edge. Has no
+   * effect when `slideIn` is `true`, or on narrow (768px and under) viewports.
+   */
+  export let resizable = false;
+
+  /**
+   * Specify the current step for multi-step content. Greater than `0` shows
+   * a back button in the header.
+   */
+  export let currentStep = 0;
+
+  /** Specify the back button's accessible label. */
+  export let navigationBackIconDescription = "Back";
+
+  /**
+   * CSS selector for the element to focus when the panel opens. Falls back
+   * to the first form input, then the close button.
+   * @type {string}
+   */
+  export let selectorPrimaryFocus = undefined;
+
+  /** Set to `true` for a condensed footer action layout. */
+  export let condensedActions = false;
+
+  /**
+   * Customize the panel's enter/exit transition (e.g., `transition={{ duration: 240 }}`).
+   * The panel does not animate by default; provide fly params to enable the
+   * transition.
+   * @type {false | import("svelte/transition").FlyParams}
+   */
+  export let transition = false;
+
+  /**
+   * Obtain a reference to the outer HTML element.
+   * @bindable readonly
+   */
+  export let ref = null;
+
+  import { createEventDispatcher, onMount, tick } from "svelte";
+  import { fade, fly } from "svelte/transition";
+  import Button from "../Button/Button.svelte";
+  import Heading from "../Heading/Heading.svelte";
+  import ArrowLeft from "../icons/ArrowLeft.svelte";
+  import Close from "../icons/Close.svelte";
+  import Resizer from "../Resizer/Resizer.svelte";
+  import { initialFocus, restoreFocus } from "../utils/focus.js";
+  import { trapFocus } from "../utils/trapFocus.js";
+  import { uniqueId } from "../utils/uniqueId.js";
+
+  const dispatch = createEventDispatcher();
+  const focusReturn = restoreFocus();
+
+  const SIZE_WIDTH_REM = { xs: 16, sm: 20, md: 30, lg: 40, xl: 65, "2xl": 80 };
+  const MOTION_DURATION = 240;
+  const MOTION_DISTANCE = 320;
+
+  const prefersReducedMotion =
+    typeof window !== "undefined" &&
+    Boolean(window.matchMedia?.("(prefers-reduced-motion: reduce)").matches);
+
+  let closeButtonRef = null;
+  let opened = false;
+  let widthOverridePx = undefined;
+  let resizeBaseline = 0;
+
+  function close(trigger) {
+    const shouldContinue = dispatch("close", { trigger }, { cancelable: true });
+    if (shouldContinue) {
+      open = false;
+    }
+  }
+
+  function focusPanel() {
+    const node = initialFocus({
+      container: ref,
+      selectorPrimaryFocus,
+      fallbacks: [closeButtonRef],
+    });
+    node?.focus();
+  }
+
+  onMount(() => {
+    if (open) {
+      focusReturn.save();
+      tick().then(() => {
+        if (open) focusPanel();
+      });
+    }
+
+    return () => {
+      if (slideIn && selectorPageContent && typeof document !== "undefined") {
+        const pageContentElement = document.querySelector(selectorPageContent);
+        if (pageContentElement instanceof HTMLElement) {
+          pageContentElement.style.marginInlineEnd = "0";
+          pageContentElement.style.marginInlineStart = "0";
+        }
+      }
+    };
+  });
+
+  // Mirrors Modal's own open/close bookkeeping: track a local `opened` flag
+  // to detect the open -> close and close -> open transitions from a single
+  // reactive block, since reactive statements run before the DOM (and thus
+  // `ref`, bound inside the `{#if open}` block below) commits.
+  $: {
+    if (opened) {
+      if (!open) {
+        opened = false;
+      }
+    } else if (open) {
+      opened = true;
+      focusReturn.save();
+      tick().then(() => {
+        if (open) focusPanel();
+      });
+    }
+  }
+
+  function handleOutroEnd() {
+    focusReturn.restore();
+    widthOverridePx = undefined;
+  }
+
+  function panelTransition(node) {
+    if (transition === false) {
+      return fly(node, { duration: 0 });
+    }
+    if (prefersReducedMotion) {
+      return fade(node, { duration: transition.duration ?? MOTION_DURATION });
+    }
+    return fly(node, {
+      x: placement === "right" ? MOTION_DISTANCE : -MOTION_DISTANCE,
+      duration: MOTION_DURATION,
+      ...transition,
+    });
+  }
+
+  $: transitionDuration =
+    transition === false ? 0 : (transition.duration ?? MOTION_DURATION);
+
+  function handleKeyDown(event) {
+    if (slideIn) return;
+    if (event.key === "Escape") {
+      event.stopPropagation();
+      close("escape-key");
+    } else if (event.key === "Tab") {
+      trapFocus({ container: ref, event });
+    }
+  }
+
+  function handleOverlayClick() {
+    if (!preventCloseOnClickOutside) close("overlay-click");
+  }
+
+  function handleResizeStart() {
+    resizeBaseline = ref?.clientWidth ?? SIZE_WIDTH_REM[size] * 16;
+  }
+
+  function handleResize(event) {
+    event.preventDefault();
+    const delta = event.detail.delta;
+    const next = resizeBaseline - (placement === "right" ? delta : -delta);
+    const min = SIZE_WIDTH_REM.xs * 16;
+    const max = window.innerWidth * 0.75;
+    widthOverridePx = Math.max(min, Math.min(next, max));
+  }
+
+  function handleResizeDoubleClick(event) {
+    event.preventDefault();
+    widthOverridePx = undefined;
+  }
+
+  $: canResize =
+    resizable &&
+    !slideIn &&
+    typeof window !== "undefined" &&
+    window.innerWidth > 768;
+
+  $: panelWidthPercent =
+    typeof window !== "undefined" && ref
+      ? Math.round((ref.clientWidth / window.innerWidth) * 100)
+      : 0;
+
+  // Shrink (or reset) the page content element for the slideIn variant.
+  $: if (typeof document !== "undefined" && slideIn && selectorPageContent) {
+    const pageContentElement = document.querySelector(selectorPageContent);
+    const marginProp =
+      placement === "right" ? "marginInlineEnd" : "marginInlineStart";
+
+    if (pageContentElement instanceof HTMLElement) {
+      if (open) {
+        pageContentElement.style.inlineSize = "auto";
+        pageContentElement.style.transition =
+          prefersReducedMotion || transitionDuration === 0
+            ? ""
+            : `margin ${transitionDuration}ms`;
+        pageContentElement.style[marginProp] = `${SIZE_WIDTH_REM[size]}rem`;
+      } else {
+        pageContentElement.style[marginProp] = "0";
+      }
+    } else {
+      console.warn(
+        `[SidePanel.svelte] \`selectorPageContent\` ("${selectorPageContent}") did not match any element. The panel will render as a slide over.`,
+      );
+    }
+  }
+
+  $: if (!title && labelText) {
+    console.warn(
+      "[SidePanel.svelte] `labelText` was provided without `title`. `labelText` only renders when `title` is also set.",
+    );
+  }
+
+  $: panelClass = [
+    "bx--side-panel",
+    `bx--side-panel--${size}`,
+    placement === "right"
+      ? "bx--side-panel--right-placement"
+      : "bx--side-panel--left-placement",
+    slideIn && "bx--side-panel--slide-in",
+    canResize && "bx--side-panel--resizable",
+    $$slots.decorator && "bx--side-panel--has-decorator",
+    includeOverlay && "bx--side-panel--has-overlay",
+    condensedActions && "bx--side-panel--condensed-actions",
+    $$restProps.class,
+  ]
+    .filter(Boolean)
+    .join(" ");
+</script>
+
+{#if open}
+  {#if includeOverlay}
+    <!-- svelte-ignore a11y-click-events-have-key-events -->
+    <!-- svelte-ignore a11y-no-static-element-interactions -->
+    <div
+      class:bx--side-panel__overlay={true}
+      transition:fade={{ duration: transitionDuration }}
+      on:click={handleOverlayClick}
+    ></div>
+  {/if}
+  <!-- svelte-ignore a11y-no-noninteractive-tabindex -->
+  <aside
+    bind:this={ref}
+    {...$$restProps}
+    {id}
+    class={panelClass}
+    aria-label={title || $$restProps["aria-label"]}
+    tabindex="-1"
+    transition:panelTransition|local
+    on:outroend={handleOutroEnd}
+    on:keydown={handleKeyDown}
+    style:inline-size={widthOverridePx ? `${widthOverridePx}px` : undefined}
+  >
+    {#if canResize}
+      <Resizer
+        orientation="vertical"
+        class="bx--side-panel__resizer"
+        aria-label={`side panel is covering ${panelWidthPercent}% of screen`}
+        aria-valuemin={Math.round((SIZE_WIDTH_REM.xs * 16 * 100) / window.innerWidth)}
+        aria-valuemax={75}
+        aria-valuenow={panelWidthPercent}
+        on:resizestart={handleResizeStart}
+        on:resize={handleResize}
+        on:dblclick={handleResizeDoubleClick}
+      />
+    {/if}
+
+    <div
+      class:bx--side-panel__header={true}
+      class:bx--side-panel__header--on-detail-step={currentStep > 0}
+    >
+      {#if currentStep > 0}
+        <Button
+          kind="ghost"
+          size="small"
+          icon={ArrowLeft}
+          iconDescription={navigationBackIconDescription}
+          tooltipPosition="bottom"
+          tooltipAlignment={placement === "left" ? "start" : "center"}
+          class="bx--side-panel__navigation-back-button"
+          on:click={() => dispatch("back")}
+        />
+      {/if}
+      {#if title && labelText}
+        <p class:bx--side-panel__label-text={true}>{labelText}</p>
+      {/if}
+      {#if title}
+        <div class:bx--side-panel__title={true}>
+          <Heading class="bx--side-panel__title-text">{title}</Heading>
+        </div>
+      {/if}
+      {#if $$slots.decorator || !hideCloseButton}
+        <div class:bx--side-panel__decorator-and-close={true}>
+          <slot name="decorator" />
+          {#if !hideCloseButton}
+            <Button
+              bind:ref={closeButtonRef}
+              kind="ghost"
+              size="small"
+              icon={Close}
+              iconDescription={closeIconDescription}
+              tooltipPosition="bottom"
+              tooltipAlignment={placement === "right" ? "end" : "center"}
+              class="bx--side-panel__close-button"
+              on:click={() => close("close-button")}
+            />
+          {/if}
+        </div>
+      {/if}
+      {#if subtitle}
+        <p class:bx--side-panel__subtitle-text={true}>{subtitle}</p>
+      {/if}
+      {#if $$slots.toolbar}
+        <div class:bx--side-panel__action-toolbar={true}>
+          <slot name="toolbar" />
+        </div>
+      {/if}
+    </div>
+
+    <div class:bx--side-panel__inner-content={true}>
+      <slot />
+    </div>
+
+    {#if $$slots.actions}
+      <div
+        class:bx--side-panel__actions-container={true}
+        class:bx--side-panel__actions-container--condensed={condensedActions}
+      >
+        <slot name="actions" />
+      </div>
+    {/if}
+  </aside>
+{/if}

--- a/src/SidePanel/index.js
+++ b/src/SidePanel/index.js
@@ -1,0 +1,1 @@
+export { default as SidePanel } from "./SidePanel.svelte";

--- a/src/icons/ArrowLeft.svelte
+++ b/src/icons/ArrowLeft.svelte
@@ -1,0 +1,30 @@
+<script>
+  export let size = 16;
+
+  export let title = undefined;
+
+  $: labelled = $$props["aria-label"] || $$props["aria-labelledby"] || title;
+  $: attributes = {
+    "aria-hidden": labelled ? undefined : true,
+    role: labelled ? "img" : undefined,
+    focusable: Number($$props.tabindex) === 0 ? true : undefined,
+  };
+</script>
+
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 32 32"
+  fill="currentColor"
+  preserveAspectRatio="xMidYMid meet"
+  width={size}
+  height={size}
+  {...attributes}
+  {...$$restProps}
+>
+  {#if title}
+    <title>{title}</title>
+  {/if}
+  <path
+    d="M14 26 15.41 24.59 7.83 17 28 17 28 15 7.83 15 15.41 7.41 14 6 4 16 14 26z"
+  ></path>
+</svg>

--- a/src/index.js
+++ b/src/index.js
@@ -149,6 +149,7 @@ export { default as SelectItemGroup } from "./Select/SelectItemGroup.svelte";
 export { default as SelectSkeleton } from "./Select/SelectSkeleton.svelte";
 export { default as SessionStorage } from "./SessionStorage/SessionStorage.svelte";
 export { default as ShapeIndicator } from "./ShapeIndicator/ShapeIndicator.svelte";
+export { default as SidePanel } from "./SidePanel/SidePanel.svelte";
 export { default as SkeletonIcon } from "./SkeletonIcon/SkeletonIcon.svelte";
 export { default as SkeletonPlaceholder } from "./SkeletonPlaceholder/SkeletonPlaceholder.svelte";
 export { default as SkeletonText } from "./SkeletonText/SkeletonText.svelte";

--- a/tests/SidePanel/SidePanel.actions.test.svelte
+++ b/tests/SidePanel/SidePanel.actions.test.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  import ActionSet from "carbon-components-svelte/ActionSet/ActionSet.svelte";
+  import Button from "carbon-components-svelte/Button/Button.svelte";
+  import SidePanel from "carbon-components-svelte/SidePanel/SidePanel.svelte";
+
+  export let open = true;
+</script>
+
+<SidePanel {open} title="Panel title" data-testid="side-panel">
+  Body content
+  <svelte:fragment slot="actions">
+    <ActionSet>
+      <Button kind="secondary">Cancel</Button>
+      <Button>Save</Button>
+    </ActionSet>
+  </svelte:fragment>
+</SidePanel>

--- a/tests/SidePanel/SidePanel.test.svelte
+++ b/tests/SidePanel/SidePanel.test.svelte
@@ -1,0 +1,53 @@
+<svelte:options accessors />
+
+<script lang="ts">
+  import SidePanel from "carbon-components-svelte/SidePanel/SidePanel.svelte";
+  import type { ComponentProps } from "svelte";
+
+  export let open = false;
+  export let title: ComponentProps<SidePanel>["title"] = "Panel title";
+  export let subtitle: ComponentProps<SidePanel>["subtitle"] = undefined;
+  export let labelText: ComponentProps<SidePanel>["labelText"] = undefined;
+  export let placement: ComponentProps<SidePanel>["placement"] = undefined;
+  export let size: ComponentProps<SidePanel>["size"] = undefined;
+  export let slideIn = false;
+  export let selectorPageContent: ComponentProps<SidePanel>["selectorPageContent"] =
+    undefined;
+  export let includeOverlay = false;
+  export let preventCloseOnClickOutside = false;
+  export let hideCloseButton = false;
+  export let resizable = false;
+  export let currentStep = 0;
+  export let condensedActions = false;
+  export let transition: ComponentProps<SidePanel>["transition"] = undefined;
+  export let ref: ComponentProps<SidePanel>["ref"] = null;
+</script>
+
+<button type="button">Launcher</button>
+
+<SidePanel
+  bind:open
+  bind:ref
+  {title}
+  {subtitle}
+  {labelText}
+  {placement}
+  {size}
+  {slideIn}
+  {selectorPageContent}
+  {includeOverlay}
+  {preventCloseOnClickOutside}
+  {hideCloseButton}
+  {resizable}
+  {currentStep}
+  {condensedActions}
+  {transition}
+  data-testid="side-panel"
+  on:close={(event) => console.log("close", event.detail.trigger)}
+  on:back={() => console.log("back")}
+>
+  Body content
+  <svelte:fragment slot="decorator">
+    <span data-testid="decorator">Decorator</span>
+  </svelte:fragment>
+</SidePanel>

--- a/tests/SidePanel/SidePanel.test.ts
+++ b/tests/SidePanel/SidePanel.test.ts
@@ -1,0 +1,199 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/svelte";
+import { user } from "../utils/user";
+import SidePanelActions from "./SidePanel.actions.test.svelte";
+import SidePanel from "./SidePanel.test.svelte";
+
+describe("SidePanel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not render when closed", () => {
+    render(SidePanel, { open: false });
+    expect(screen.queryByTestId("side-panel")).not.toBeInTheDocument();
+  });
+
+  it("renders title, subtitle, and labelText when open", () => {
+    render(SidePanel, {
+      open: true,
+      title: "Settings",
+      subtitle: "Manage your preferences",
+      labelText: "Configuration",
+    });
+
+    expect(
+      screen.getByRole("heading", { name: "Settings" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Manage your preferences")).toBeInTheDocument();
+    expect(screen.getByText("Configuration")).toBeInTheDocument();
+  });
+
+  it("renders the decorator slot", () => {
+    render(SidePanel, { open: true });
+    expect(screen.getByTestId("decorator")).toBeInTheDocument();
+  });
+
+  it("closes and dispatches close with trigger on close button click", async () => {
+    const consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+    const { component } = render(SidePanel, { open: true });
+
+    await user.click(screen.getByRole("button", { name: "Close" }));
+
+    expect(consoleLog).toHaveBeenCalledWith("close", "close-button");
+    expect(component.open).toBe(false);
+  });
+
+  it("closes and dispatches close with trigger on Escape", async () => {
+    const consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+    const { component } = render(SidePanel, { open: true });
+
+    await user.keyboard("{Escape}");
+
+    expect(consoleLog).toHaveBeenCalledWith("close", "escape-key");
+    expect(component.open).toBe(false);
+  });
+
+  it("does not close on Escape when slideIn is true", async () => {
+    const consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+    const { component } = render(SidePanel, { open: true, slideIn: true });
+
+    await user.keyboard("{Escape}");
+
+    expect(consoleLog).not.toHaveBeenCalledWith("close", expect.anything());
+    expect(component.open).toBe(true);
+  });
+
+  it("closes on overlay click when includeOverlay is set", async () => {
+    const consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+    const { container } = render(SidePanel, {
+      open: true,
+      includeOverlay: true,
+    });
+
+    const overlay = container.querySelector(".bx--side-panel__overlay");
+    expect(overlay).toBeInTheDocument();
+    await fireEvent.click(overlay as Element);
+
+    expect(consoleLog).toHaveBeenCalledWith("close", "overlay-click");
+  });
+
+  it("does not close on overlay click when preventCloseOnClickOutside is set", async () => {
+    const consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+    const { container } = render(SidePanel, {
+      open: true,
+      includeOverlay: true,
+      preventCloseOnClickOutside: true,
+    });
+
+    const overlay = container.querySelector(".bx--side-panel__overlay");
+    await fireEvent.click(overlay as Element);
+
+    expect(consoleLog).not.toHaveBeenCalledWith("close", expect.anything());
+  });
+
+  it("shows a back button and dispatches back when currentStep is greater than 0", async () => {
+    const consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+    render(SidePanel, { open: true, currentStep: 1 });
+
+    const backButton = screen.getByRole("button", { name: "Back" });
+    await user.click(backButton);
+
+    expect(consoleLog).toHaveBeenCalledWith("back");
+  });
+
+  it("hides the back button when currentStep is 0", () => {
+    render(SidePanel, { open: true, currentStep: 0 });
+    expect(
+      screen.queryByRole("button", { name: "Back" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders slotted actions in the footer", () => {
+    render(SidePanelActions);
+    expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+  });
+
+  it("returns focus to the launcher when closed", async () => {
+    const { component } = render(SidePanel, { open: false });
+    const launcher = screen.getByRole("button", { name: "Launcher" });
+    launcher.focus();
+    expect(launcher).toHaveFocus();
+
+    component.open = true;
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Close" })).toBeInTheDocument(),
+    );
+    await user.click(screen.getByRole("button", { name: "Close" }));
+    await waitFor(() => expect(launcher).toHaveFocus());
+  });
+
+  it("shrinks the page content element in slideIn mode and resets it on close", async () => {
+    document.body.innerHTML = '<main id="page-content"></main>';
+    const pageContent = document.querySelector("#page-content") as HTMLElement;
+
+    const { component } = render(SidePanel, {
+      open: true,
+      slideIn: true,
+      selectorPageContent: "#page-content",
+      size: "md",
+    });
+
+    await waitFor(() => expect(pageContent.style.marginInlineEnd).not.toBe(""));
+    expect(pageContent.style.marginInlineEnd).not.toBe("0px");
+
+    component.open = false;
+    await waitFor(() => expect(pageContent.style.marginInlineEnd).toBe("0px"));
+  });
+
+  it("applies size and placement classes", () => {
+    const { container } = render(SidePanel, {
+      open: true,
+      size: "lg",
+      placement: "left",
+    });
+
+    const panel = container.querySelector(".bx--side-panel");
+    expect(panel).toHaveClass("bx--side-panel--lg");
+    expect(panel).toHaveClass("bx--side-panel--left-placement");
+  });
+
+  it("does not animate by default", async () => {
+    const animateSpy = vi.spyOn(Element.prototype, "animate");
+    const { component } = render(SidePanel, { open: false });
+
+    component.open = true;
+    await waitFor(() =>
+      expect(screen.getByTestId("side-panel")).toBeInTheDocument(),
+    );
+
+    expect(animateSpy).not.toHaveBeenCalled();
+  });
+
+  it("animates when transition params are provided", async () => {
+    const animateSpy = vi.spyOn(Element.prototype, "animate");
+    const { component } = render(SidePanel, {
+      open: false,
+      transition: { duration: 240 },
+    });
+
+    component.open = true;
+    await waitFor(() =>
+      expect(screen.getByTestId("side-panel")).toBeInTheDocument(),
+    );
+    // Svelte schedules the WAAPI `animate()` call via a later animation
+    // frame, not synchronously with the DOM update above; under a heavily
+    // parallel full-suite run that can take longer than the default
+    // `waitFor` timeout, so it's raised here.
+    await waitFor(
+      () =>
+        expect(
+          animateSpy.mock.calls.some(
+            ([, options]) =>
+              typeof options === "object" && options?.duration === 240,
+          ),
+        ).toBe(true),
+      { timeout: 3000 },
+    );
+  });
+});

--- a/tests/utils/setup-globals.ts
+++ b/tests/utils/setup-globals.ts
@@ -99,6 +99,61 @@ if (typeof DataTransfer === "undefined") {
   globalThis.DataTransfer = DataTransferMock as unknown as typeof DataTransfer;
 }
 
+// jsdom has no Web Animations API, but Svelte's built-in transitions
+// (fly, fade, slide, ...) call `element.animate()` directly. Without a stub,
+// mounting any component that uses `transition:`/`in:`/`out:` throws
+// "element.animate is not a function".
+if (typeof Element !== "undefined" && !Element.prototype.animate) {
+  class AnimationMock extends EventTarget {
+    onfinish: (() => void) | null = null;
+    oncancel: (() => void) | null = null;
+    playbackRate = 1;
+    currentTime = 0;
+    finished: Promise<AnimationMock>;
+    private resolveFinished!: (animation: AnimationMock) => void;
+    private timeoutId: ReturnType<typeof setTimeout>;
+
+    constructor(duration: number) {
+      super();
+      this.finished = new Promise((resolve) => {
+        this.resolveFinished = resolve;
+      });
+      this.timeoutId = setTimeout(() => this.finish(), duration);
+    }
+
+    finish() {
+      clearTimeout(this.timeoutId);
+      this.onfinish?.();
+      this.dispatchEvent(new Event("finish"));
+      this.resolveFinished(this);
+    }
+
+    cancel() {
+      clearTimeout(this.timeoutId);
+      this.oncancel?.();
+      this.dispatchEvent(new Event("cancel"));
+    }
+
+    play() {}
+    pause() {}
+  }
+
+  Element.prototype.animate = (
+    _keyframes: unknown,
+    options?: number | KeyframeAnimationOptions,
+  ) => {
+    const duration =
+      typeof options === "number" ? options : (options?.duration ?? 0);
+    return new AnimationMock(
+      typeof duration === "number" ? duration : 0,
+    ) as unknown as Animation;
+  };
+}
+
+if (typeof Element !== "undefined" && !Element.prototype.getAnimations) {
+  Element.prototype.getAnimations = () => [];
+}
+
 // jsdom reflects the `open` attribute but does not implement showModal()/show()/close().
 // https://github.com/jsdom/jsdom/issues/3294
 if (


### PR DESCRIPTION
Docked slide-in for supplementary content or multi-step flows. Reuses
Modal's focus-trap and outside-dismiss, with Resizer on the optional
resizable edge. The enter/exit motion is opt-in via a transition prop.
