### PR TITLE
fix(accordion-item): remove Escape key handler causing controlled desync

### DIFF
--- a/src/Accordion/AccordionItem.svelte
+++ b/src/Accordion/AccordionItem.svelte
@@ -110,11 +110,6 @@
     on:mouseenter
     on:mouseleave
     on:keydown
-    on:keydown={(event) => {
-      if (open && event.key === "Escape") {
-        open = false;
-      }
-    }}
   >
     <ChevronRight class="bx--accordion__arrow" />
     <div class:bx--accordion__title={true}>

--- a/tests/Accordion/Accordion.test.ts
+++ b/tests/Accordion/Accordion.test.ts
@@ -417,7 +417,7 @@ describe("Accordion", () => {
     expect(screen.getByText("Custom Title")).toBeInTheDocument();
   });
 
-  it("should handle Escape key to close item", async () => {
+  it("should forward Escape keydown without closing the item", async () => {
     const consoleLog = vi.spyOn(console, "log");
     render(Accordion);
 
@@ -429,7 +429,7 @@ describe("Accordion", () => {
     await user.keyboard("{Escape}");
     expect(consoleLog).toHaveBeenCalledWith("item-keydown", "Escape");
 
-    itemIsCollapsed(/Language Translator/);
+    itemIsExpanded(/Language Translator/);
   });
 
   it("should expose ref to the heading button", () => {


### PR DESCRIPTION
The internal Escape handler closed the item by mutating `open`
directly, which could desync it from a parent controlling `open` via
bind or notifyOpen. Removes the handler and forwards Escape to
consumers instead.

Port reference:
https://github.com/carbon-design-system/carbon/pull/22667