### PR TITLE
fix(file-uploader): set drop container input files when files are dropped

### DIFF
--- a/src/FileUploader/FileUploaderDropContainer.svelte
+++ b/src/FileUploader/FileUploaderDropContainer.svelte
@@ -136,6 +136,13 @@
     if (!disabled) {
       over = false;
       processIncoming([...event.dataTransfer.files]);
+      if (ref) {
+        const dataTransfer = new DataTransfer();
+        for (const file of files) {
+          dataTransfer.items.add(file);
+        }
+        ref.files = dataTransfer.files;
+      }
     }
   }}
 >

--- a/tests/FileUploader/FileUploaderDropContainer.test.ts
+++ b/tests/FileUploader/FileUploaderDropContainer.test.ts
@@ -235,6 +235,61 @@ describe("FileUploaderDropContainer", () => {
     expect(event.detail).toHaveLength(2);
   });
 
+  it("should sync dropped files to the native input's files property", async () => {
+    const changeHandler = vi.fn();
+    const { container } = render(FileUploaderDropContainer, {
+      props: { multiple: true, onchange: changeHandler },
+    });
+
+    const dropDiv = container.querySelector(".bx--file");
+    assert(dropDiv instanceof HTMLElement);
+
+    const input = container.querySelector('input[type="file"]');
+    assert(input instanceof HTMLInputElement);
+
+    const file1 = new File(["content1"], "file1.txt", { type: "text/plain" });
+    const file2 = new File(["content2"], "file2.txt", { type: "text/plain" });
+    dropDiv.dispatchEvent(createDragEvent("drop", [file1, file2]));
+
+    await vi.waitFor(() => {
+      expect(changeHandler).toHaveBeenCalled();
+    });
+
+    expect(input.files).toHaveLength(2);
+    expect(Array.from(input.files as FileList).map((f) => f.name)).toEqual([
+      "file1.txt",
+      "file2.txt",
+    ]);
+  });
+
+  it("should not include rejected files in the native input's files property", async () => {
+    const changeHandler = vi.fn();
+    const { container } = render(FileUploaderDropContainer, {
+      props: { multiple: true, maxFileSize: 1000, onchange: changeHandler },
+    });
+
+    const dropDiv = container.querySelector(".bx--file");
+    assert(dropDiv instanceof HTMLElement);
+
+    const input = container.querySelector('input[type="file"]');
+    assert(input instanceof HTMLInputElement);
+
+    const smallFile = new File(["x".repeat(500)], "small.txt", {
+      type: "text/plain",
+    });
+    const largeFile = new File(["x".repeat(2000)], "large.txt", {
+      type: "text/plain",
+    });
+    dropDiv.dispatchEvent(createDragEvent("drop", [smallFile, largeFile]));
+
+    await vi.waitFor(() => {
+      expect(changeHandler).toHaveBeenCalled();
+    });
+
+    expect(input.files).toHaveLength(1);
+    expect((input.files as FileList)[0].name).toBe("small.txt");
+  });
+
   it("should not handle drag events when disabled", () => {
     const { container } = render(FileUploaderDropContainer, {
       props: { disabled: true },

--- a/tests/utils/setup-globals.ts
+++ b/tests/utils/setup-globals.ts
@@ -99,6 +99,35 @@ if (typeof DataTransfer === "undefined") {
   globalThis.DataTransfer = DataTransferMock as unknown as typeof DataTransfer;
 }
 
+// jsdom's native `HTMLInputElement.files` setter enforces that the assigned
+// value is a genuine jsdom-internal FileList, which our DataTransfer mock's
+// `.files` (used to sync a drop container's input, e.g. FileUploaderDropContainer)
+// can never satisfy. Fall back to a plain property override, matching what
+// browsers actually let `input.files = dataTransfer.files` achieve.
+{
+  const nativeFilesDescriptor = Object.getOwnPropertyDescriptor(
+    HTMLInputElement.prototype,
+    "files",
+  );
+  if (nativeFilesDescriptor?.set && nativeFilesDescriptor?.get) {
+    Object.defineProperty(HTMLInputElement.prototype, "files", {
+      get: nativeFilesDescriptor.get,
+      configurable: true,
+      set(value: FileList) {
+        try {
+          nativeFilesDescriptor.set?.call(this, value);
+        } catch {
+          Object.defineProperty(this, "files", {
+            value,
+            writable: true,
+            configurable: true,
+          });
+        }
+      },
+    });
+  }
+}
+
 // jsdom reflects the `open` attribute but does not implement showModal()/show()/close().
 // https://github.com/jsdom/jsdom/issues/3294
 if (


### PR DESCRIPTION
Drag-and-drop into `FileUploaderDropContainer` only updated the
component's `files` state, leaving the native input's `.files` empty,
so a native form submit or `FormData` read would silently miss dropped
files. Port of carbon-react's fix:
https://github.com/carbon-design-system/carbon/pull/22712