### PR TITLE
fix: remove hardcoded default title prop values

### DIFF
--- a/src/Accordion/AccordionItem.svelte
+++ b/src/Accordion/AccordionItem.svelte
@@ -2,6 +2,7 @@
   /**
    * Specify the title of the accordion item heading.
    * Alternatively, use the "title" slot.
+   * @type {string | undefined}
    * @example
    * ```svelte
    * <AccordionItem>
@@ -9,7 +10,7 @@
    * </AccordionItem>
    * ```
    */
-  export let title = "title";
+  export let title = undefined;
 
   /**
    * Set to `true` to open the first accordion item.

--- a/src/StructuredList/StructuredListInput.svelte
+++ b/src/StructuredList/StructuredListInput.svelte
@@ -9,8 +9,11 @@
    */
   export let checked = false;
 
-  /** Specify the title of the input */
-  export let title = "title";
+  /**
+   * Specify the title of the input.
+   * @type {string | undefined}
+   */
+  export let title = undefined;
 
   /**
    * Specify the value of the input.

--- a/src/Tile/SelectableTile.svelte
+++ b/src/Tile/SelectableTile.svelte
@@ -16,8 +16,11 @@
   /** Set to `true` to disable the tile */
   export let disabled = false;
 
-  /** Specify the title of the selectable tile */
-  export let title = "title";
+  /**
+   * Specify the title of the selectable tile.
+   * @type {string | undefined}
+   */
+  export let title = undefined;
 
   /** Specify the value of the selectable tile */
   export let value = "value";

--- a/tests/Accordion/Accordion.test.svelte
+++ b/tests/Accordion/Accordion.test.svelte
@@ -11,6 +11,7 @@
   export let customClass = "";
   export let itemClass = "";
   export let useSlot = false;
+  export let noTitle = false;
   export let ariaLabel: ComponentProps<AccordionItem>["ariaLabel"] = undefined;
   export let ref: ComponentProps<AccordionItem>["ref"] = null;
 </script>
@@ -38,6 +39,8 @@
       <div slot="title">Custom Title</div>
       Slot content
     </AccordionItem>
+  {:else if noTitle}
+    <AccordionItem>No title content</AccordionItem>
   {:else}
     <AccordionItem title="Natural Language Classifier" bind:ref
       >1</AccordionItem

--- a/tests/Accordion/Accordion.test.ts
+++ b/tests/Accordion/Accordion.test.ts
@@ -417,6 +417,13 @@ describe("Accordion", () => {
     expect(screen.getByText("Custom Title")).toBeInTheDocument();
   });
 
+  it("does not render a literal 'title' heading by default", () => {
+    const { container } = render(Accordion, { props: { noTitle: true } });
+
+    const heading = container.querySelector(".bx--accordion__title");
+    expect(heading?.textContent?.trim()).toBe("");
+  });
+
   it("should forward Escape keydown without closing the item", async () => {
     const consoleLog = vi.spyOn(console, "log");
     render(Accordion);

--- a/tests/StructuredList/StructuredList.test.ts
+++ b/tests/StructuredList/StructuredList.test.ts
@@ -286,6 +286,12 @@ describe("StructuredList", () => {
     expect(() => render(StructuredListInputStandalone)).not.toThrow();
   });
 
+  it("does not render a title attribute by default", () => {
+    const { container } = render(StructuredListInputStandalone);
+    const input = container.querySelector("input");
+    expect(input).not.toHaveAttribute("title");
+  });
+
   it("should emit change event on selection", async () => {
     const consoleLog = vi.spyOn(console, "log");
     render(StructuredList, { props: { selection: true } });

--- a/tests/Tile/SelectableTile.test.ts
+++ b/tests/Tile/SelectableTile.test.ts
@@ -53,6 +53,12 @@ describe("SelectableTile", () => {
     }
   });
 
+  it("does not render a title attribute by default", () => {
+    const { container } = render(SelectableTileStandalone);
+    const input = container.querySelector('input[type="checkbox"]');
+    expect(input).not.toHaveAttribute("title");
+  });
+
   it("renders with custom title and value", () => {
     const { container } = render(SelectableTileTest, {
       title: "Custom Title",


### PR DESCRIPTION
`SelectableTile`, `AccordionItem`, and `StructuredListInput` all
defaulted `title` to the literal string "title", which leaked to
users, either as a native tooltip or, for `AccordionItem`, as the
visible heading text when no title or title slot was given.
Defaulting to `undefined` fixes all three, matching the sibling
`ExpandableTile` component. Ports the upstream fix from
https://github.com/carbon-design-system/carbon/pull/22749.